### PR TITLE
RFC: slightly refactor representation of generated methods

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -289,7 +289,7 @@ function InferenceState(linfo::MethodInstance,
     # prepare an InferenceState object for inferring lambda
     # create copies of the CodeInfo definition, and any fields that type-inference might modify
     m = linfo.def::Method
-    if m.isstaged
+    if isdefined(m, :generator)
         try
             # user code might throw errors – ignore them
             src = get_staged(linfo)
@@ -1994,7 +1994,7 @@ function pure_eval_call(f::ANY, argtypes::ANY, atype::ANY, sv::InferenceState)
     meth = meth[1]::SimpleVector
     method = meth[3]::Method
     # TODO: check pure on the inferred thunk
-    if method.isstaged || !method.pure
+    if isdefined(method, :generator) || !method.pure
         return false
     end
 
@@ -2788,7 +2788,7 @@ function code_for_method(method::Method, atypes::ANY, sparams::SimpleVector, wor
     if world < min_world(method)
         return nothing
     end
-    if method.isstaged && !isleaftype(atypes)
+    if isdefined(method, :generator) && !isleaftype(atypes)
         # don't call staged functions on abstract types.
         # (see issues #8504, #10230)
         # we can't guarantee that their type behavior is monotonic.
@@ -4206,7 +4206,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     end
 
     # check whether call can be inlined to just a quoted constant value
-    if isa(f, widenconst(ft)) && !method.isstaged
+    if isa(f, widenconst(ft)) && !isdefined(method, :generator)
         if f === return_type
             if isconstType(e.typ)
                 return inline_as_constant(e.typ.parameters[1], argexprs, sv, invoke_data)
@@ -4248,7 +4248,7 @@ function inlineable(f::ANY, ft::ANY, e::Expr, atypes::Vector{Any}, sv::Inference
     # some gf have special tfunc, meaning they wouldn't have been inferred yet
     # check the same conditions from abstract_call to detect this case
     force_infer = false
-    if !method.isstaged
+    if !isdefined(method, :generator)
         if method.module == _topmod(method.module) || (isdefined(Main, :Base) && method.module == Main.Base)
             la = length(atypes)
             if (la==3 && (method.name == :getindex || method.name == :next)) ||

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -663,7 +663,7 @@ function length(mt::MethodTable)
 end
 isempty(mt::MethodTable) = (mt.defs === nothing)
 
-uncompressed_ast(m::Method) = uncompressed_ast(m, m.source)
+uncompressed_ast(m::Method) = uncompressed_ast(m, isdefined(m,:source) ? m.source : m.generator.inferred)
 uncompressed_ast(m::Method, s::CodeInfo) = s
 uncompressed_ast(m::Method, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Any), m, s)::CodeInfo
 
@@ -780,7 +780,7 @@ code_native(::IO, ::ANY, ::Symbol) = error("illegal code_native call") # resolve
 
 # give a decent error message if we try to instantiate a staged function on non-leaf types
 function func_for_method_checked(m::Method, types::ANY)
-    if m.isstaged && !isleaftype(types)
+    if isdefined(m,:generator) && !isdefined(m,:source) && !isleaftype(types)
         error("cannot call @generated function `", m, "` ",
               "with abstract argument types: ", types)
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -320,7 +320,7 @@ end
 function show(io::IO, l::Core.MethodInstance)
     def = l.def
     if isa(def, Method)
-        if def.isstaged && l === def.generator
+        if isdefined(def, :generator) && l === def.generator
             print(io, "MethodInstance generator for ")
             show(io, def)
         else

--- a/src/dump.c
+++ b/src/dump.c
@@ -627,7 +627,6 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         union jl_typemap_t *tf = &m->specializations;
         jl_serialize_value(s, tf->unknown);
         jl_serialize_value(s, (jl_value_t*)m->name);
-        write_int8(s->s, m->isstaged);
         jl_serialize_value(s, (jl_value_t*)m->file);
         write_int32(s->s, m->line);
         if (external_mt)
@@ -1396,7 +1395,6 @@ static jl_value_t *jl_deserialize_value_method(jl_serializer_state *s, jl_value_
     jl_gc_wb(m, m->specializations.unknown);
     m->name = (jl_sym_t*)jl_deserialize_value(s, NULL);
     jl_gc_wb(m, m->name);
-    m->isstaged = read_int8(s->s);
     m->file = (jl_sym_t*)jl_deserialize_value(s, NULL);
     m->line = read_int32(s->s);
     m->min_world = jl_world_counter;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -644,13 +644,14 @@ jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint
         return lam->inferred_const;
     jl_code_info_t *src = (jl_code_info_t*)lam->inferred;
     if (!src || (jl_value_t*)src == jl_nothing) {
-        if (lam->def.method->isstaged) {
+        if (lam->def.method->source) {
+            src = (jl_code_info_t*)lam->def.method->source;
+        }
+        else {
+            assert(lam->def.method->generator);
             src = jl_code_for_staged(lam);
             lam->inferred = (jl_value_t*)src;
             jl_gc_wb(lam, src);
-        }
-        else {
-            src = (jl_code_info_t*)lam->def.method->source;
         }
     }
     if (src && (jl_value_t*)src != jl_nothing) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1938,7 +1938,7 @@ void jl_init_types(void)
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(19,
+                        jl_perm_symsvec(18,
                             "name",
                             "module",
                             "file",
@@ -1956,9 +1956,8 @@ void jl_init_types(void)
                             "nargs",
                             "called",
                             "isva",
-                            "isstaged",
                             "pure"),
-                        jl_svec(19,
+                        jl_svec(18,
                             jl_sym_type,
                             jl_module_type,
                             jl_sym_type,
@@ -1975,7 +1974,6 @@ void jl_init_types(void)
                             jl_any_type,
                             jl_int32_type,
                             jl_int32_type,
-                            jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
                         0, 1, 9);

--- a/src/julia.h
+++ b/src/julia.h
@@ -245,7 +245,7 @@ typedef struct _jl_method_t {
     jl_svec_t *sparam_syms;  // symbols giving static parameter names
     jl_value_t *source;  // original code template (jl_code_info_t, but may be compressed), null for builtins
     struct _jl_method_instance_t *unspecialized;  // unspecialized executable method instance, or null
-    struct _jl_method_instance_t *generator;  // executable code-generating function if isstaged
+    struct _jl_method_instance_t *generator;  // executable code-generating function if available
     jl_array_t *roots;  // pointers in generated code (shared to reduce memory), or null
 
     // cache of specializations of this method for invoke(), i.e.
@@ -256,7 +256,6 @@ typedef struct _jl_method_t {
     int32_t nargs;
     int32_t called;  // bit flags: whether each of the first 8 arguments is called
     uint8_t isva;
-    uint8_t isstaged;
     uint8_t pure;
 
 // hidden fields:

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -342,7 +342,7 @@ STATIC_INLINE jl_value_t *jl_compile_method_internal(jl_generic_fptr_t *fptr,
             fptr->fptr = meth->unspecialized_ducttape;
             fptr->jlcall_api = 1;
             if (!fptr->fptr) {
-                if (jl_is_method(meth->def.method) && !meth->def.method->isstaged && meth->def.method->unspecialized) {
+                if (jl_is_method(meth->def.method) && meth->def.method->unspecialized) {
                     fptr->fptr = meth->def.method->unspecialized->fptr;
                     fptr->jlcall_api = meth->def.method->unspecialized->jlcall_api;
                     if (fptr->jlcall_api == 2) {

--- a/src/method.c
+++ b/src/method.c
@@ -267,8 +267,8 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
     jl_value_t *linenum = NULL;
     jl_svec_t *sparam_vals = env;
     jl_method_instance_t *generator = linfo->def.method->generator;
+    assert(generator != NULL);
     assert(linfo != generator);
-    assert(linfo->def.method->isstaged);
     jl_code_info_t *func = NULL;
     JL_GC_PUSH4(&ex, &linenum, &sparam_vals, &func);
     jl_ptls_t ptls = jl_get_ptls_states();
@@ -289,7 +289,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
 
         jl_array_t *argnames = jl_alloc_vec_any(linfo->def.method->nargs);
         jl_array_ptr_set(ex->args, 0, argnames);
-        jl_fill_argnames((jl_array_t*)linfo->def.method->source, argnames);
+        jl_fill_argnames((jl_array_t*)generator->inferred, argnames);
 
         // build the rest of the body to pass to expand
         jl_expr_t *scopeblock = jl_exprn(jl_symbol("scope-block"), 1);
@@ -466,7 +466,6 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     m->line = 0;
     m->called = 0xff;
     m->invokes.unknown = NULL;
-    m->isstaged = 0;
     m->isva = 0;
     m->nargs = 0;
     m->traced = 0;
@@ -499,7 +498,6 @@ static jl_method_t *jl_new_method(
     m->sparam_syms = sparam_syms;
     root = (jl_value_t*)m;
     m->min_world = ++jl_world_counter;
-    m->isstaged = isstaged;
     m->name = name;
     m->sig = (jl_value_t*)sig;
     m->isva = isva;
@@ -510,6 +508,7 @@ static jl_method_t *jl_new_method(
         m->generator = jl_get_specialized(m, (jl_value_t*)jl_anytuple_type, jl_emptysvec);
         jl_gc_wb(m, m->generator);
         m->generator->inferred = (jl_value_t*)m->source;
+        m->source = NULL;
     }
 
 #ifdef RECORD_METHOD_ORDER

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -239,7 +239,7 @@ static void _compile_all_deq(jl_array_t *found)
             jl_printf(JL_STDERR, " %d / %d\r", found_i + 1, found_l);
         jl_typemap_entry_t *ml = (jl_typemap_entry_t*)jl_array_ptr_ref(found, found_i);
         jl_method_t *m = ml->func.method;
-        if (m->isstaged)  // TODO: generic implementations of generated functions
+        if (m->source == NULL)  // TODO: generic implementations of generated functions
             continue;
         linfo = m->unspecialized;
         if (!linfo) {
@@ -274,7 +274,7 @@ static int compile_all_enq__(jl_typemap_entry_t *ml, void *env)
     jl_array_t *found = (jl_array_t*)env;
     // method definition -- compile template field
     jl_method_t *m = ml->func.method;
-    if (!m->isstaged &&
+    if (m->source &&
         (!m->unspecialized ||
          (m->unspecialized->functionObjectsDecls.functionObject == NULL &&
           m->unspecialized->jlcall_api != 2 &&


### PR DESCRIPTION
This is a small step in the direction of having fallbacks for `@generated` functions --- or, put differently, treating `@generated` methods as just optimizations of normal methods.

- Remove `isstaged` field. In the future, a method will not be inherently staged but rather have a generator available or not.
- Always use meth.generator.inferred to access generator code.
- Make meth.source always refer to normal code, set to NULL for generated methods. This allows us to have both in the future.