### PR TITLE
fix #14182: OS X linker target mismatch warning

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1070,6 +1070,7 @@ void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char
     TheTriple.setObjectFormat(Triple::COFF);
 #elif defined(_OS_DARWIN_)
     TheTriple.setObjectFormat(Triple::MachO);
+    TheTriple.setOS(llvm::Triple::MacOSX);
 #endif
     std::unique_ptr<TargetMachine>
     TM(jl_TargetMachine->getTarget().createTargetMachine(


### PR DESCRIPTION
fix #14182. ref: https://github.com/ldc-developers/ldc/pull/1209