### PR TITLE
remove misleading bidiag constructor, make Bidiagonal immutable

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Bidiagonal matrices
-mutable struct Bidiagonal{T} <: AbstractMatrix{T}
+struct Bidiagonal{T} <: AbstractMatrix{T}
     dv::Vector{T} # diagonal
     ev::Vector{T} # sub/super diagonal
     uplo::Char    # upper bidiagonal ('U') or lower ('L')
@@ -58,7 +58,6 @@ julia> Bl = Bidiagonal(dv, ev, :L) # ev is on the first subdiagonal
 function Bidiagonal(dv::AbstractVector{T}, ev::AbstractVector{T}, uplo::Symbol) where T
     Bidiagonal{T}(collect(dv), collect(ev), char_uplo(uplo))
 end
-Bidiagonal(dv::AbstractVector, ev::AbstractVector) = throw(ArgumentError("did you want an upper or lower Bidiagonal? Try again with an additional true (upper) or false (lower) argument."))
 
 function Bidiagonal(dv::AbstractVector{Td}, ev::AbstractVector{Te}, uplo::Symbol) where {Td,Te}
     T = promote_type(Td,Te)

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -27,7 +27,7 @@ srand(1)
         @test Bidiagonal(dv,ev,:U) != Bidiagonal(dv,ev,:L)
         @test_throws ArgumentError Bidiagonal(dv,ev,:R)
         @test_throws DimensionMismatch Bidiagonal(dv,ones(elty,n),:U)
-        @test_throws ArgumentError Bidiagonal(dv,ev)
+        @test_throws MethodError Bidiagonal(dv,ev)
     end
 
     @testset "getindex, setindex!, size, and similar" begin


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/22703#discussion_r126565276

Also changed `Bidiagonal` to an immutable, like `Diagonal` and `[Sym]Tridiagonal`