### PR TITLE
Set `PROGRAM_FILE` once

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -259,8 +259,10 @@ function process_options(opts::JLOptions)
     global is_interactive = (opts.isinteractive != 0)
 
     # remove filename from ARGS
-    arg_is_program = opts.eval == C_NULL && opts.print == C_NULL && !isempty(ARGS)
-    global const PROGRAM_FILE = arg_is_program ? shift!(ARGS) : ""
+    if !isdefined(Base, :PROGRAM_FILE)
+        arg_is_program = opts.eval == C_NULL && opts.print == C_NULL && !isempty(ARGS)
+        global const PROGRAM_FILE = arg_is_program ? shift!(ARGS) : ""
+    end
 
     while true
         # startup worker.

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -332,7 +332,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
             end
             """)
 
-        withenv((is_windows() ? "USERPROFILE" : "HOME") => dir) do
+        withenv((Sys.is_windows() ? "USERPROFILE" : "HOME") => dir) do
             @test readchomp(`$exename $file foo`) == file
         end
     end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -318,6 +318,25 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
         end
     end
 
+    # Running `Base.process_options` more than once should not update PROGRAM_FILE
+    @test isconst(Base, :PROGRAM_FILE)
+
+    mktempdir() do dir
+        file = joinpath(dir, "file.jl")
+
+        write(file, """
+            if !isdefined(Main, :processed)
+                processed = true
+                Base.process_options(Base.JLOptions())
+                println(PROGRAM_FILE)
+            end
+            """)
+
+        withenv((is_windows() ? "USERPROFILE" : "HOME") => dir) do
+            @test readchomp(`$exename $file foo`) == file
+        end
+    end
+
     # issue #10562
     @test readchomp(`$exename -e 'println(ARGS);' ''`) == "String[\"\"]"
 


### PR DESCRIPTION
Previous code would allow `PROGRAM_FILE` to be modified on subsequent runs of the `process_options` function. ~Although this never actually occurs in practice it appears that the compiler understood that `PROGRAM_FILE` could be modified and made it a `global` rather than a `global const`.~