### PR TITLE
RFC: deprecate reading functions that accept both a cmd and stdin

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -164,6 +164,9 @@ Deprecated or removed
     and `is_windows`, have been deprecated in favor of `Sys.islinux`, `Sys.isbsd`, `Sys.isapple`,
     `Sys.isunix`, and `Sys.iswindows`, respectively ([#22182]).
 
+  * The forms of `read`, `readstring`, and `eachline` that accepted both a `Cmd` object and an
+    input stream are deprecated. Use e.g. `read(pipeline(stdin, cmd))` instead ([#22762]).
+
 
 Julia v0.6.0 Release Notes
 ==========================

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1577,6 +1577,10 @@ end
 @deprecate is_unix    Sys.isunix
 @deprecate is_windows Sys.iswindows
 
+@deprecate read(cmd::AbstractCmd, stdin::Redirectable) read(pipeline(stdin, cmd))
+@deprecate readstring(cmd::AbstractCmd, stdin::Redirectable) readstring(pipeline(stdin, cmd))
+@deprecate eachline(cmd::AbstractCmd, stdin; chomp::Bool=true) eachline(pipeline(stdin, cmd), chomp=chomp)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/process.jl
+++ b/base/process.jl
@@ -553,16 +553,15 @@ spawn_opts_inherit(in::Redirectable=RawFD(0), out::Redirectable=RawFD(1), err::R
 spawn(cmds::AbstractCmd, args...; chain::Nullable{ProcessChain}=Nullable{ProcessChain}()) =
     spawn(cmds, spawn_opts_swallow(args...)...; chain=chain)
 
-function eachline(cmd::AbstractCmd, stdin; chomp::Bool=true)
+function eachline(cmd::AbstractCmd; chomp::Bool=true)
     stdout = Pipe()
-    processes = spawn(cmd, (stdin,stdout,STDERR))
+    processes = spawn(cmd, (DevNull,stdout,STDERR))
     close(stdout.in)
     out = stdout.out
     # implicitly close after reading lines, since we opened
     return EachLine(out, chomp=chomp,
         ondone=()->(close(out); success(processes) || pipeline_error(processes)))::EachLine
 end
-eachline(cmd::AbstractCmd; chomp::Bool=true) = eachline(cmd, DevNull, chomp=chomp)
 
 # return a Process object to read-to/write-from the pipeline
 """
@@ -642,22 +641,14 @@ function readandwrite(cmds::AbstractCmd)
     return (processes.out, processes.in, processes)
 end
 
-function read(cmd::AbstractCmd, stdin::Redirectable=DevNull)
-    procs = open(cmd, "r", stdin)
+function read(cmd::AbstractCmd)
+    procs = open(cmd, "r", DevNull)
     bytes = read(procs.out)
     success(procs) || pipeline_error(procs)
     return bytes
 end
 
-function readstring(cmd::AbstractCmd, stdin::Redirectable=DevNull)
-    return String(read(cmd, stdin))
-end
-
-function writeall(cmd::AbstractCmd, stdin::AbstractString, stdout::Redirectable=DevNull)
-    open(cmd, "w", stdout) do io
-        write(io, stdin)
-    end
-end
+readstring(cmd::AbstractCmd) = String(read(cmd))
 
 """
     run(command, args...)

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -313,7 +313,7 @@ will attempt to store the data in the kernel's buffers while waiting for a reade
 Another common solution is to separate the reader and writer of the pipeline into separate Tasks:
 
 ```julia
-writer = @async writeall(process, "data")
+writer = @async write(process, "data")
 reader = @async do_compute(readstring(process))
 wait(process)
 fetch(reader)


### PR DESCRIPTION
These are strange methods because (1) they violate orthogonality, and (2) they conflict with other uses of the second argument (normally we have `read(io, type)`, but here we have `read(cmd, stdin)`). I don't think these are widely used.

Also removed the mystery function `writeall` that doesn't seem to be referenced anywhere.