### PR TITLE
use in-place inv, since lufact already made a copy

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -653,7 +653,7 @@ function inv(A::StridedMatrix{T}) where T
         Ai = inv(LowerTriangular(AA))
         Ai = convert(typeof(parent(Ai)), Ai)
     else
-        Ai = inv(lufact(AA))
+        Ai = inv!(lufact(AA))
         Ai = convert(typeof(parent(Ai)), Ai)
     end
     return Ai

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -202,6 +202,7 @@ convert(::Type{LU{T,S}}, F::LU) where {T,S} = LU{T,S}(convert(S, F.factors), F.i
 convert(::Type{Factorization{T}}, F::LU{T}) where {T} = F
 convert(::Type{Factorization{T}}, F::LU) where {T} = convert(LU{T}, F)
 
+copy(A::LU{T,S}) where {T,S} = LU{T,S}(copy(A.factors), copy(A.ipiv), A.info)
 
 size(A::LU) = size(A.factors)
 size(A::LU,n) = size(A.factors,n)
@@ -313,8 +314,9 @@ end
 
 inv!(A::LU{<:BlasFloat,<:StridedMatrix}) =
     @assertnonsingular LAPACK.getri!(A.factors, A.ipiv) A.info
-inv(A::LU{<:BlasFloat,<:StridedMatrix}) =
-    inv!(LU(copy(A.factors), copy(A.ipiv), copy(A.info)))
+inv!(A::LU{T,<:StridedMatrix}) where {T} =
+    @assertnonsingular A_ldiv_B!(A.factors, copy(A), eye(T, size(A, 1))) A.info
+inv(A::LU{<:BlasFloat,<:StridedMatrix}) = inv!(copy(A))
 
 function _cond1Inf(A::LU{<:BlasFloat,<:StridedMatrix}, p::Number, normA::Real)
     if p != 1 && p != Inf

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -64,6 +64,7 @@ debug && println("(Automatic) Square LU decomposition. eltya: $eltya, eltyb: $el
         @test l*u ≈ a[p,:]
         @test (l*u)[invperm(p),:] ≈ a
         @test a * inv(lua) ≈ eye(n)
+        @test copy(lua) == lua
 
         lstring = sprint(show,l)
         ustring = sprint(show,u)


### PR DESCRIPTION
Basically cuts allocated memory in half for generic `inv` calls.

| Matrix size | master                                  | PR                                     |
|:----------- |:--------------------------------------- |:-------------------------------------- |
| 10          | 1.750 μs (9 allocations: 7.28 KiB)      | 1.688 μs (7 allocations: 6.25 KiB)     |
| 100         | 165.047 μs (11 allocations: 208.38 KiB) | 156.498 μs (8 allocations: 129.30 KiB) |
| 500         | 4.250 ms (11 allocations: 4.07 MiB)     | 3.976 ms (8 allocations: 2.16 MiB)     |
| 1000        | 27.447 ms (11 allocations: 15.76 MiB)   | 26.299 ms (8 allocations: 8.13 MiB)    |
| 2000        | 210.670 ms (11 allocations: 62.04 MiB)  | 204.308 ms (8 allocations: 31.51 MiB)  |
| 4000        | 1.539 s (13 allocations: 246.16 MiB)    | 1.482 s (9 allocations: 124.05 MiB)    |