### PR TITLE
RFC: Make `PROGRAM_FILE` into a proper constant

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -260,7 +260,7 @@ function process_options(opts::JLOptions)
 
     # remove filename from ARGS
     arg_is_program = opts.eval == C_NULL && opts.print == C_NULL && !isempty(ARGS)
-    global const PROGRAM_FILE = arg_is_program ? shift!(ARGS) : ""
+    PROGRAM_FILE[] = arg_is_program ? shift!(ARGS) : ""
 
     while true
         # startup worker.

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -9,7 +9,7 @@ A string containing the script name passed to Julia from the command line. Note 
 script name remains unchanged from within included files. Alternatively see
 [`@__FILE__`](@ref).
 """
-:PROGRAM_FILE
+const PROGRAM_FILE = RefString("")
 
 """
     ARGS

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -175,3 +175,16 @@ julia> "Test "^3
 
 pointer(x::SubString{String}) = pointer(x.string) + x.offset
 pointer(x::SubString{String}, i::Integer) = pointer(x.string) + x.offset + (i-1)
+
+## reference string ##
+
+struct RefString{T<:AbstractString} <: AbstractString
+    string::Ref{T}
+end
+
+RefString(s::T) where {T<:AbstractString} = RefString{T}(Ref{T}(s))
+
+endof(ref::RefString) = endof(ref.string[])
+next(ref::RefString, state::Int) = next(ref.string[], state)
+
+setindex!(ref::RefString{T}, s::T) where {T<:AbstractString} = (ref.string[] = s)

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -188,6 +188,14 @@ for T in (String, GenericString)
     end
 end
 
+## Reference strings ##
+
+ref = RefString("")
+@test length(ref) == 0
+
+ref[] = "foobar"
+@test length(ref) == 6
+
 ## Cstring tests ##
 
 # issue #13974: comparison against pointers


### PR DESCRIPTION
As mentioned in https://github.com/JuliaLang/julia/pull/22753#issuecomment-314633607 using `global const` from inside a function is wrong and should be avoided. This PR attempts to correct this by making `PROGRAM_FILE` a reference.

The PR also introduces a new type `RefString` which works like a `Ref{String}` and a `AbstractString`. This was done to make user interaction with `PROGRAM_FILE` behave like a normal string.