### PR TITLE
prevent wait() from gc-rooting the next task

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -330,10 +330,10 @@ function take_unbuffered(c::Channel{T}) where T
     push!(c.takers, current_task())
     try
         if length(c.putters) > 0
-            let putter = shift!(c.putters)
-                return Base.try_yieldto(putter) do
+            let refputter = Ref(shift!(c.putters))
+                return Base.try_yieldto(refputter) do putter
                     # if we fail to start putter, put it back in the queue
-                    unshift!(c.putters, putter)
+                    putter === current_task || unshift!(c.putters, putter)
                 end::T
             end
         else

--- a/src/julia.h
+++ b/src/julia.h
@@ -1520,7 +1520,7 @@ typedef struct _jl_task_t {
 } jl_task_t;
 
 JL_DLLEXPORT jl_task_t *jl_new_task(jl_function_t *start, size_t ssize);
-JL_DLLEXPORT void jl_switchto(jl_task_t *t);
+JL_DLLEXPORT void jl_switchto(jl_task_t **pt);
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e);


### PR DESCRIPTION
Using an extra indirection through a Ref allows jl_switch_task to ensure that a task-switch
in wait() won't hold onto the Task in a gc-root after switching to it,
since popping a Task from the Workqueue shouldn't cause it to get a gc-root in
the current Task.

fix #6597