### PR TITLE
Base.Test: add GenericArray type and use it in test/random.jl

### DIFF
--- a/base/test.jl
+++ b/base/test.jl
@@ -20,7 +20,7 @@ export @testset
 # Legacy approximate testing functions, yet to be included
 export @inferred
 export detect_ambiguities
-export GenericString, GenericSet, GenericDict
+export GenericString, GenericSet, GenericDict, GenericArray
 
 #-----------------------------------------------------------------------
 
@@ -1302,5 +1302,24 @@ for (G, A) in ((GenericSet, AbstractSet),
 end
 
 Base.get(s::GenericDict, x, y) = get(s.s, x, y)
+
+"""
+The `GenericArray` can be used to test generic array APIs that program to
+the `AbstractArray` interface, in order to ensure that functions can work
+with array types besides the standard `Array` type.
+"""
+struct GenericArray{T,N} <: AbstractArray{T,N}
+    a::Array{T,N}
+end
+
+GenericArray{T}(args...) where {T} = GenericArray(Array{T}(args...))
+GenericArray{T,N}(args...) where {T,N} = GenericArray(Array{T,N}(args...))
+
+Base.eachindex(a::GenericArray) = eachindex(a.a)
+Base.indices(a::GenericArray) = indices(a.a)
+Base.length(a::GenericArray) = length(a.a)
+Base.size(a::GenericArray) = size(a.a)
+Base.getindex(a::GenericArray, i...) = a.a[i...]
+Base.setindex!(a::GenericArray, x, i...) = a.a[i...] = x
 
 end # module

--- a/test/random.jl
+++ b/test/random.jl
@@ -372,7 +372,7 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
     for f! in [rand!, randn!, randexp!]
         for T in (f! === rand! ? types : f! === randn! ? cftypes : ftypes)
             X = T == Bool ? T[0,1] : T[0,1,2]
-            for A in [Array{T}(5), Array{T}(2, 3), GenericArray{T}(5), GenericArray{T}(2, 3)]
+            for A in (Array{T}(5), Array{T}(2, 3), GenericArray{T}(5), GenericArray{T}(2, 3))
                 f!(rng..., A)                    ::typeof(A)
                 if f! === rand!
                     f!(rng..., A, X)             ::typeof(A)

--- a/test/random.jl
+++ b/test/random.jl
@@ -344,16 +344,18 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
         end
     end
     for (C, T) in collections
-        a0 = rand(rng..., C)                  ::T
-        a1 = rand(rng..., C, 5)               ::Vector{T}
-        a2 = rand(rng..., C, 2, 3)            ::Array{T, 2}
-        a3 = rand(rng..., C, (2, 3))          ::Array{T, 2}
-        a4 = rand(rng..., C, b2, u3)          ::Array{T, 2}
-        a5 = rand!(rng..., Array{T}(5), C)    ::Vector{T}
-        a6 = rand!(rng..., Array{T}(2, 3), C) ::Array{T, 2}
+        a0 = rand(rng..., C)                         ::T
+        a1 = rand(rng..., C, 5)                      ::Vector{T}
+        a2 = rand(rng..., C, 2, 3)                   ::Array{T, 2}
+        a3 = rand(rng..., C, (2, 3))                 ::Array{T, 2}
+        a4 = rand(rng..., C, b2, u3)                 ::Array{T, 2}
+        a5 = rand!(rng..., Array{T}(5), C)           ::Vector{T}
+        a6 = rand!(rng..., Array{T}(2, 3), C)        ::Array{T, 2}
+        a7 = rand!(rng..., GenericArray{T}(5), C)    ::GenericArray{T, 1}
+        a8 = rand!(rng..., GenericArray{T}(2, 3), C) ::GenericArray{T, 2}
         @test size(a1) == (5,)
         @test size(a2) == size(a3) == (2, 3)
-        for a in [a0, a1..., a2..., a3..., a4..., a5..., a6...]
+        for a in [a0, a1..., a2..., a3..., a4..., a5..., a6..., a7..., a8...]
             if C isa Type
                 @test a isa C
             else
@@ -370,11 +372,11 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
     for f! in [rand!, randn!, randexp!]
         for T in (f! === rand! ? types : f! === randn! ? cftypes : ftypes)
             X = T == Bool ? T[0,1] : T[0,1,2]
-            for A in (Array{T}(5), Array{T}(2, 3))
+            for A in [Array{T}(5), Array{T}(2, 3), GenericArray{T}(5), GenericArray{T}(2, 3)]
                 f!(rng..., A)                    ::typeof(A)
                 if f! === rand!
                     f!(rng..., A, X)             ::typeof(A)
-                    if T !== Char # Char/Integer comparison
+                    if A isa Array && T !== Char # Char/Integer comparison
                         f!(rng..., sparse(A))    ::typeof(sparse(A))
                         f!(rng..., sparse(A), X) ::typeof(sparse(A))
                     end


### PR DESCRIPTION
`GenericArray`, similarly to `GenericString`, `GenericDict` and `GenericSet`, can be used to test APIs using `AbstractArray`. 