### PR TITLE
Add repeat for Char to fix performance of pow

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -438,3 +438,25 @@ function repeat(s::String, r::Integer)
     end
     return out
 end
+
+"""
+    repeat(c::Char, r::Integer) -> String
+
+Repeat a character `r` times.
+
+# Examples
+```jldoctest
+julia> repeat('A', 3)
+"AAA"
+```
+"""
+function repeat(c::Char, r::Integer)
+    if isascii(c)
+        r < 0 && throw(ArgumentError("can't repeat a character $r times"))
+        out = _string_n(r)
+        ccall(:memset, Ptr{Void}, (Ptr{UInt8}, Cint, Csize_t), out, c, r)
+        return out
+    else
+        return repeat(string(c), r)
+    end
+end

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -442,7 +442,7 @@ end
 """
     repeat(c::Char, r::Integer) -> String
 
-Repeat a character `r` times.
+Repeat a character `r` times. This can equivalently be accomplished by calling [`^`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -442,7 +442,7 @@ end
 """
     repeat(c::Char, r::Integer) -> String
 
-Repeat a character `r` times. This can equivalently be accomplished by calling [`^`](@ref).
+Repeat a character `r` times. This can equivalently be accomplished by calling [`c^r`](@ref ^).
 
 # Examples
 ```jldoctest

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -155,7 +155,7 @@ reverseind(s::SubString{String}, i::Integer) =
 """
     repeat(s::AbstractString, r::Integer)
 
-Repeat a string `r` times.
+Repeat a string `r` times. This can equivalently be accomplished by calling [`^`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -155,7 +155,7 @@ reverseind(s::SubString{String}, i::Integer) =
 """
     repeat(s::AbstractString, r::Integer)
 
-Repeat a string `r` times. This can equivalently be accomplished by calling [`^`](@ref).
+Repeat a string `r` times. This can equivalently be accomplished by calling [`s^r`](@ref ^).
 
 # Examples
 ```jldoctest

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -152,6 +152,17 @@ reverseind(s::RevString, i::Integer) = endof(s) - i + 1
 reverseind(s::SubString{String}, i::Integer) =
     reverseind(s.string, nextind(s.string, endof(s.string))-s.offset-s.endof+i-1) - s.offset
 
+"""
+    repeat(s::AbstractString, r::Integer)
+
+Repeat a string `r` times.
+
+# Examples
+```jldoctest
+julia> repeat("ha", 3)
+"hahaha"
+```
+"""
 function repeat(s::AbstractString, r::Integer)
     r <  0 ? throw(ArgumentError("can't repeat a string $r times")) :
     r == 0 ? "" :
@@ -160,9 +171,9 @@ function repeat(s::AbstractString, r::Integer)
 end
 
 """
-    ^(s::AbstractString, n::Integer)
+    ^(s::Union{AbstractString,Char}, n::Integer)
 
-Repeat `n` times the string `s`.
+Repeat a string or character `n` times.
 The [`repeat`](@ref) function is an alias to this operator.
 
 # Examples
@@ -171,7 +182,7 @@ julia> "Test "^3
 "Test Test Test "
 ```
 """
-(^)(s::AbstractString, r::Integer) = repeat(s,r)
+(^)(s::Union{AbstractString,Char}, r::Integer) = repeat(s,r)
 
 pointer(x::SubString{String}) = pointer(x.string) + x.offset
 pointer(x::SubString{String}, i::Integer) = pointer(x.string) + x.offset + (i-1)

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -143,6 +143,7 @@ Base.cumsum_kbn
 Base.crc32c
 Base.LinAlg.diff
 Base.LinAlg.gradient
+Base.repeat(::AbstractArray)
 Base.rot180
 Base.rotl90
 Base.rotr90

--- a/doc/src/stdlib/linalg.md
+++ b/doc/src/stdlib/linalg.md
@@ -89,7 +89,7 @@ Base.inv(::AbstractMatrix)
 Base.LinAlg.pinv
 Base.LinAlg.nullspace
 Base.repmat
-Base.repeat
+Base.repeat(::AbstractArray)
 Base.kron
 Base.SparseArrays.blkdiag
 Base.LinAlg.linreg

--- a/doc/src/stdlib/linalg.md
+++ b/doc/src/stdlib/linalg.md
@@ -89,7 +89,6 @@ Base.inv(::AbstractMatrix)
 Base.LinAlg.pinv
 Base.LinAlg.nullspace
 Base.repmat
-Base.repeat(::AbstractArray)
 Base.kron
 Base.SparseArrays.blkdiag
 Base.LinAlg.linreg

--- a/doc/src/stdlib/strings.md
+++ b/doc/src/stdlib/strings.md
@@ -6,6 +6,8 @@ Base.sizeof(::AbstractString)
 Base.:*(::AbstractString, ::Any...)
 Base.:^(::AbstractString, ::Integer)
 Base.string
+Base.repeat(::AbstractString, ::Integer)
+Base.repeat(::Char, ::Integer)
 Base.repr
 Core.String(::AbstractString)
 Base.transcode

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -478,8 +478,10 @@ Base.endof(x::CharStr) = endof(x.chars)
 @test cmp(CharStr("\U1f596"), "\U1f596\U1f596") == -1
 
 # repeat function
-@test repeat("xx",3) == repeat("x",6) == "xxxxxx"
-@test repeat("αα",3) == repeat("α",6) == "αααααα"
+@test repeat("xx",3) == repeat("x",6) == repeat('x',6) == repeat(GenericString("x"), 6) == "xxxxxx"
+@test repeat("αα",3) == repeat("α",6) == repeat('α',6) == repeat(GenericString("α"), 6) == "αααααα"
+@test repeat("x",1) == repeat('x',1) == "x"^1 == 'x'^1 == GenericString("x")^1 == "x"
+@test repeat("x",0) == repeat('x',0) == "x"^0 == 'x'^0 == GenericString("x")^0 == ""
 
 # issue #12495: check that logical indexing attempt raises ArgumentError
 @test_throws ArgumentError "abc"[[true, false, true]]


### PR DESCRIPTION
close https://github.com/JuliaLang/julia/issues/22785

But more importantly fix the bug for  `::Char ^ 0` and `::Char^1`

As a future optimization someone may want to improve the nonascii case to remove the allocation for the string conversion. 


```julia
# benchmark using 0.6

julia> using BenchmarkTools; import Base.repeat, Base._string_n

julia> function repeat(c::Char, r::Integer)
           r < 0 && throw(ArgumentError("can't repeat a character $r times"))
           if isascii(c)
               out = _string_n(r)
               ccall(:memset, Ptr{Void}, (Ptr{UInt8}, Cint, Csize_t), out, c, r)
               return out
           else
               return repeat(string(c), r)
           end
       end
repeat (generic function with 4 methods)

julia> @btime repeat($('x'), $(100));
  28.140 ns (1 allocation: 128 bytes)

julia> @btime repeat($("x"), $(100));
  280.596 ns (1 allocation: 128 bytes)

julia> @btime repeat($('x'), $(10));
  18.158 ns (1 allocation: 32 bytes)

julia> @btime repeat($("x"), $(10));
  42.239 ns (1 allocation: 32 bytes)

julia> @btime repeat($('x'), $(2));
  18.158 ns (1 allocation: 32 bytes)

julia> @btime repeat($("x"), $(2));
  21.711 ns (1 allocation: 32 bytes)
```