### PR TITLE
allow a function instead of a string as Prompt.prompt

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -186,7 +186,7 @@ end
 prompt_string(s::PromptState) = prompt_string(s.p)
 prompt_string(p::Prompt) = prompt_string(p.prompt)
 prompt_string(s::AbstractString) = s
-prompt_string(f::Function) = eval(Expr(:call, f))
+prompt_string(f::Function) = Base.invokelatest(f)
 
 refresh_multi_line(s::ModeState) = refresh_multi_line(terminal(s), s)
 refresh_multi_line(termbuf::TerminalBuffer, s::ModeState) = refresh_multi_line(termbuf, terminal(s), s)
@@ -626,8 +626,8 @@ default_enter_cb(_) = true
 
 write_prompt(terminal, s::PromptState) = write_prompt(terminal, s.p)
 function write_prompt(terminal, p::Prompt)
-    prefix = isa(p.prompt_prefix,Function) ? eval(Expr(:call, p.prompt_prefix)) : p.prompt_prefix
-    suffix = isa(p.prompt_suffix,Function) ? eval(Expr(:call, p.prompt_suffix)) : p.prompt_suffix
+    prefix = prompt_string(p.prompt_prefix)
+    suffix = prompt_string(p.prompt_suffix)
     write(terminal, prefix)
     write(terminal, Base.text_colors[:bold])
     write(terminal, prompt_string(p.prompt))

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -19,7 +19,8 @@ struct ModalInterface <: TextInterface
 end
 
 mutable struct Prompt <: TextInterface
-    prompt::String
+    # A string or function to be printed as the prompt.
+    prompt::Union{String,Function}
     # A string or function to be printed before the prompt. May not change the length of the prompt.
     # This may be used for changing the color, issuing other terminal escape codes, etc.
     prompt_prefix::Union{String,Function}
@@ -34,7 +35,7 @@ mutable struct Prompt <: TextInterface
     sticky::Bool
 end
 
-show(io::IO, x::Prompt) = show(io, string("Prompt(\"", x.prompt, "\",...)"))
+show(io::IO, x::Prompt) = show(io, string("Prompt(\"", prompt_string(x.prompt), "\",...)"))
 
 mutable struct MIState
     interface::ModalInterface
@@ -182,8 +183,10 @@ function _clear_input_area(terminal, state::InputAreaState)
     clear_line(terminal)
 end
 
-prompt_string(s::PromptState) = s.p.prompt
+prompt_string(s::PromptState) = prompt_string(s.p)
+prompt_string(p::Prompt) = prompt_string(p.prompt)
 prompt_string(s::AbstractString) = s
+prompt_string(f::Function) = eval(Expr(:call, f))
 
 refresh_multi_line(s::ModeState) = refresh_multi_line(terminal(s), s)
 refresh_multi_line(termbuf::TerminalBuffer, s::ModeState) = refresh_multi_line(termbuf, terminal(s), s)
@@ -454,7 +457,7 @@ function edit_insert(s::PromptState, c)
     end
     str = string(c)
     edit_insert(buf, str)
-    offset = s.ias.curs_row == 1 ? sizeof(s.p.prompt) : s.indent
+    offset = s.ias.curs_row == 1 ? sizeof(prompt_string(s.p.prompt)) : s.indent
     if !('\n' in str) && eof(buf) &&
         ((line_size() + offset + sizeof(str) - 1) < width(terminal(s)))
         # Avoid full update when appending characters to the end
@@ -627,11 +630,11 @@ function write_prompt(terminal, p::Prompt)
     suffix = isa(p.prompt_suffix,Function) ? eval(Expr(:call, p.prompt_suffix)) : p.prompt_suffix
     write(terminal, prefix)
     write(terminal, Base.text_colors[:bold])
-    write(terminal, p.prompt)
+    write(terminal, prompt_string(p.prompt))
     write(terminal, Base.text_colors[:normal])
     write(terminal, suffix)
 end
-write_prompt(terminal, s::String) = write(terminal, s)
+write_prompt(terminal, s::Union{AbstractString,Function}) = write(terminal, prompt_string(s))
 
 ### Keymap Support
 
@@ -1062,7 +1065,7 @@ PrefixHistoryPrompt(hp::T, parent_prompt) where T<:HistoryProvider = PrefixHisto
 init_state(terminal, p::PrefixHistoryPrompt) = PrefixSearchState(terminal, p, "", IOBuffer())
 
 write_prompt(terminal, s::PrefixSearchState) = write_prompt(terminal, s.histprompt.parent_prompt)
-prompt_string(s::PrefixSearchState) = s.histprompt.parent_prompt.prompt
+prompt_string(s::PrefixSearchState) = prompt_string(s.histprompt.parent_prompt.prompt)
 
 terminal(s::PrefixSearchState) = s.terminal
 
@@ -1559,7 +1562,9 @@ end
 
 run_interface(::Prompt) = nothing
 
-init_state(terminal, prompt::Prompt) = PromptState(terminal, prompt, IOBuffer(), InputAreaState(1, 1), #=indent(spaces)=#strwidth(prompt.prompt))
+init_state(terminal, prompt::Prompt) =
+    PromptState(terminal, prompt, IOBuffer(), InputAreaState(1, 1),
+    #=indent(spaces)=# strwidth(prompt_string(prompt.prompt)))
 
 function init_state(terminal, m::ModalInterface)
     s = MIState(m, m.modes[1], false, Dict{Any,Any}())

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -274,7 +274,7 @@ end
 
 
 # Edit functionality
-is_non_word_char(c) = c in " \t\n\"\\'`@\$><=:;|&{}()[].,+-*/?%^~"
+is_non_word_char(c) = c in """ \t\n\"\\'`@\$><=:;|&{}()[].,+-*/?%^~"""
 
 function reset_key_repeats(f::Function, s::MIState)
     key_repeats_sav = s.key_repeats
@@ -1564,7 +1564,7 @@ run_interface(::Prompt) = nothing
 
 init_state(terminal, prompt::Prompt) =
     PromptState(terminal, prompt, IOBuffer(), InputAreaState(1, 1),
-    #=indent(spaces)=# strwidth(prompt_string(prompt.prompt)))
+    #=indent(spaces)=# strwidth(prompt_string(prompt)))
 
 function init_state(terminal, m::ModalInterface)
     s = MIState(m, m.modes[1], false, Dict{Any,Any}())


### PR DESCRIPTION
I had this as an old branch, but since I know now of a [way](https://discourse.julialang.org/t/ann-higher-productivity-fewer-julia-restarts-with-revise-jl/4564/6) to change the repl from ".juliarc.jl", I'm more motivated to merge it. This allows to have a dynamic string for the prompt. On a daily basis, I would have for example this function called from ".juliarc.jl":
```
function histprompt()
    for i = 1:3
        hist = Base.active_repl.interface.modes[i].hist
        prompt = ["julia", "shell", "help?"][i]
        Base.active_repl.interface.modes[i].prompt = () -> begin
            if hist.cur_idx != length(hist.history)+1
                string(prompt, " [", hist.cur_idx-hist.start_idx, "/",
                       length(hist.history) + 1 - hist.start_idx, "]> ")
            else
                "$prompt [$(hist.cur_idx - hist.start_idx)]> "
            end
        end
    end
end
```
Then a sample julia session:
```
julia [1]> f(x) = 1
f (generic function with 1 method)

julia [1/2]> f(x::Int) = 2 # here I came backward in history to edit the previous definition, hence "1/2"
f (generic function with 2 methods)

julia [3]> @which f(0) # I can now make sense of the "REPL[2]" reference!
f(x::Int64) in Main at REPL[2]:1

julia [3/4]> @which f(0.0)
f(x) in Main at REPL[1]:1
```

PS: I'm really not very familiar with REPL code, so I may have got something wrong.