### PR TITLE
define deg2rad and rad2deg for any Number

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -165,6 +165,8 @@ julia> deg2rad(90)
 deg2rad(z::AbstractFloat) = z * (oftype(z, pi) / 180)
 rad2deg(z::Real) = rad2deg(float(z))
 deg2rad(z::Real) = deg2rad(float(z))
+rad2deg(z::Number) = (z/pi)*180
+deg2rad(z::Number) = (z*pi)/180
 
 log(b::T, x::T) where {T<:Number} = log(x)/log(b)
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -331,6 +331,8 @@ end
         @test rad2deg(T(1)) ≈ rad2deg(true)
         @test deg2rad(T(1)) ≈ deg2rad(true)
     end
+    @test deg2rad(180 + 60im) ≈ pi + (pi/3)*im
+    @test rad2deg(pi + (pi/3)*im) ≈ 180 + 60im
 end
 
 @testset "degree-based trig functions" begin


### PR DESCRIPTION
`deg2rad` and `rad2deg` were previously defined only for `Real`, but there is no reason not to define them for any `Number` type for completeness, and this could occasionally be useful [as I commented on discourse](https://discourse.julialang.org/t/angle-package/4832/28?u=stevengj).

The fallback definitions added by this PR are somewhat suboptimal for `Complex`, but I don't see this as a real problem (no pun intended).  I can't imagine a performance-sensitive case where this would be applied to complex numbers without being combined with some much more expensive function like `sin`.  And of course, optimized methods could be added later if there is a need.