### PR TITLE
parse error for missing spaces before `for` and between hcat args

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1228,3 +1228,11 @@ end
 @test parse("local x, y = 1, 2") == Expr(:local, Expr(:(=),
                                                       Expr(:tuple, :x, :y),
                                                       Expr(:tuple, 1, 2)))
+
+@test_throws ParseError parse("[2for i=1:10]")
+@test_throws ParseError parse("[1 for i in 1:2for j in 2]")
+@test_throws ParseError parse("(1 for i in 1:2for j in 2)")
+# issue #20441
+@test_throws ParseError parse("[x.2]")
+@test_throws ParseError parse("x.2")
+@test parse("[x;.2]") == Expr(:vcat, :x, 0.2)


### PR DESCRIPTION
This makes e.g. `[2for i in x]` and `[x.2]` parse errors. In both of these cases, the parser is able to identify separate tokens (`x` and `.2`), but there is no visible separator in the source, making the parsing surprising.

fixes #20441 --- I believe we now give a syntax error for all occurrences of `x.1`.