### PR TITLE
[GC Lowering] Improve calculation of rooting location

### DIFF
--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -50,6 +50,32 @@ define void @heap_refinement2(i64 %a) {
     ret void
 }
 
+declare %jl_value_t addrspace(10)* @allocate_some_value()
+
+; Check that the way we compute rooting is compatible with refinements
+define void @issue22770() {
+; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %y = call %jl_value_t addrspace(10)* @allocate_some_value()
+    %casted1 = bitcast %jl_value_t addrspace(10)* %y to %jl_value_t addrspace(10)* addrspace(10)*
+    %x = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
+; CHECK: store %jl_value_t addrspace(10)* %y,
+    %a = call %jl_value_t addrspace(10)* @allocate_some_value()
+; CHECK: store %jl_value_t addrspace(10)* %a
+; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(10)* %x)
+; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(10)* %a)
+; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(10)* %y)
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %x)
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %a)
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %y)
+; CHECK: store %jl_value_t addrspace(10)* %x
+    %c = call %jl_value_t addrspace(10)* @allocate_some_value()
+; CHECK: store %jl_value_t addrspace(10)* %c
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %x)
+    call void @one_arg_boxed(%jl_value_t addrspace(10)* %c)
+    ret void
+}
+
 !0 = !{!"jtbaa"}
 !1 = !{!2, !2, i64 0}
 !2 = !{!"jtbaa_immut", !0, i64 0}


### PR DESCRIPTION
The old way to do it interacted badly with load refinements, causing
roots to get clobbered, because the compiler would attemt to root values
while their slot was still in use by a different value. Instead,
look at live sets and insert a rooting, whenever there's a non-live->live
transition.

Fixes #22770