### PR TITLE
Bugfix for zero matrix in A_ldiv_B! for QRPivoted

### DIFF
--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -706,7 +706,7 @@ function A_ldiv_B!(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real) where T<:B
     nrhs = size(B, 2)
     if nr == 0 return zeros(T, 0, nrhs), 0 end
     ar = abs(A.factors[1])
-    if ar == 0 return zeros(T, nr, nrhs), 0 end
+    if ar == 0 return zeros(T, nA, nrhs), 0 end
     rnk = 1
     xmin = ones(T, 1)
     xmax = ones(T, 1)

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -704,9 +704,13 @@ function A_ldiv_B!(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real) where T<:B
     mA, nA = size(A.factors)
     nr = min(mA,nA)
     nrhs = size(B, 2)
-    if nr == 0 return zeros(T, 0, nrhs), 0 end
+    if nr == 0
+        return zeros(T, 0, nrhs), 0
+    end
     ar = abs(A.factors[1])
-    if ar == 0 return zeros(T, nA, nrhs), 0 end
+    if ar == 0
+        return zeros(T, nA, nrhs), 0
+    end
     rnk = 1
     xmin = ones(T, 1)
     xmax = ones(T, 1)

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -183,3 +183,11 @@ B = rand(7,2)
 
 # Issue 16520
 @test_throws DimensionMismatch ones(3,2)\(1:5)
+
+# Issue 22810
+let
+    A = zeros(1, 2)
+    B = zeros(1, 1)
+    @test A \ B == zeros(2, 1)
+    @test qrfact(A, Val{true}) \ B == zeros(2, 1)
+end

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -189,5 +189,5 @@ let
     A = zeros(1, 2)
     B = zeros(1, 1)
     @test A \ B == zeros(2, 1)
-    @test qrfact(A, Val{true}) \ B == zeros(2, 1)
+    @test qrfact(A, Val(true)) \ B == zeros(2, 1)
 end


### PR DESCRIPTION
I believe this fixes JuliaLang/LinearAlgebra.jl#448 but needs review by someone who is familiar with this code.
