### PR TITLE
deprecation warning for old parametric method syntax. fixes #11310

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ New language features
 Language changes
 ----------------
 
+  * The syntax for parametric methods, `function f{T}(x::T)`, has been
+    changed to `function f(x::T) where {T}` ([#11310]).
+
   * The syntax `1.+2` is deprecated, since it is ambiguous: it could mean either
     `1 .+ 2` (the current meaning) or `1. + 2` ([#19089]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1591,6 +1591,9 @@ end
 @deprecate readstring(filename::AbstractString) read(filename, String)
 @deprecate readstring(cmd::AbstractCmd) read(cmd, String)
 
+# issue #11310
+# remove "parametric method syntax" deprecation in julia-syntax.scm
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -96,6 +96,7 @@
                  (deparse-block (string (car e) " " (deparse (cadr e)))
                                 (block-stmts (caddr e))))
                 ((copyast) (deparse (cadr e)))
+                ((kw) (string (deparse (cadr e)) " = " (deparse (caddr e))))
                 (else
                  (string e))))))
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -810,13 +810,15 @@
                   (sig    (car temp))
                   (params (cdr temp)))
              (if (pair? params)
-                 (let* ((lnos (filter (lambda (e) (and (pair? e) (eq? (car e) 'line)))
-                                      body))
-                        (lno (if (null? lnos) '() (car lnos))))
-                   (syntax-deprecation #f
-                                       (string "inner constructor " name "(...)" (linenode-string lno))
-                                       (deparse `(where (call (curly ,name ,@params) ...) ,@params)))))
+                 (syntax-deprecation #f
+                                     (string "inner constructor " name "(...)" (linenode-string (function-body-lineno body)))
+                                     (deparse `(where (call (curly ,name ,@params) ...) ,@params))))
              `(,keyword ,sig ,(ctor-body body params)))))))
+
+(define (function-body-lineno body)
+  (let ((lnos (filter (lambda (e) (and (pair? e) (eq? (car e) 'line)))
+                      body)))
+    (if (null? lnos) '() (car lnos))))
 
 ;; rewrite calls to `new( ... )` to `new` expressions on the appropriate
 ;; type, determined by the containing constructor definition.
@@ -1062,6 +1064,11 @@
                                                                    (eq? (caar argl) 'parameters))))))
                   (name    (if (or (decl? name) (and (pair? name) (eq? (car name) 'curly)))
                                #f name)))
+             (if has-sp
+                 (syntax-deprecation #f
+                                     (string "parametric method syntax " (deparse (cadr e))
+                                             (linenode-string (function-body-lineno body)))
+                                     (deparse `(where (call ,name ,@(cdr argl)) ,@(map car sparams)))))
              (expand-forms
               (method-def-expr name sparams argl body isstaged rett))))
           (else


### PR DESCRIPTION
OK folks, it's time to rip the band-aid off.