### PR TITLE
Printing of negated first arguments in exponentiated expressions

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -803,9 +803,10 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
                     all(!isa(a, Expr) || a.head !== :... for a in func_args)
                 sep = " $func "
                 # parenthesize (-x) ^ y for negative x
-                if func == :^ && ((func_args[1] isa Expr && func_args[1].head === :call &&
-                                   func_args[1].args[1] === :-) ||
-                                  (func_args[1] isa Real && func_args[1] < 0))
+                if (operator_precedence(func) == operator_precedence(:^) &&
+                    ((func_args[1] isa Expr && func_args[1].head === :call &&
+                      func_args[1].args[1] in uni_ops) ||
+                     (func_args[1] isa Real && func_args[1] < 0)))
                     encl_inds = [1]
                 else
                     encl_inds = []

--- a/test/show.jl
+++ b/test/show.jl
@@ -94,10 +94,13 @@ end
 @test_repr "(a / b) / (c / d / e)"
 @test_repr "(a == b == c) != (c == d < e)"
 
-# Exponentiation of negative numbers or negated symbols
-@test_repr "(-1)^-1"
+# Exponentiation (operator_precedence(:^)) and unary operators
+@test_repr "(-1)^a"
 @test_repr "(-2.1)^-1"
+@test_repr "(-x)^a"
 @test_repr "(-a)^-1"
+@test_repr "(!x)↑!a"
+
 
 # control structures (shamelessly stolen from base/bitarray.jl)
 @test_repr """mutable struct BitArray{N} <: AbstractArray{Bool, N}

--- a/test/show.jl
+++ b/test/show.jl
@@ -94,6 +94,11 @@ end
 @test_repr "(a / b) / (c / d / e)"
 @test_repr "(a == b == c) != (c == d < e)"
 
+# Exponentiation of negative numbers or negated symbols
+@test_repr "(-1)^-1"
+@test_repr "(-2.1)^-1"
+@test_repr "(-a)^-1"
+
 # control structures (shamelessly stolen from base/bitarray.jl)
 @test_repr """mutable struct BitArray{N} <: AbstractArray{Bool, N}
     # line meta


### PR DESCRIPTION
`:((-a) ^ b)` prints as `:(-a ^ b)` which parses as `:(-(a ^ b))`. Which is wrong. I think it should be fixed by this commit. I also added some tests to make sure it won't happen again. :blush: