### PR TITLE
fix #22840, regression in parsing `[:a :b]`

### DIFF
--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1244,3 +1244,6 @@ end === (3, String)
 @test_throws ParseError parse("[x.2]")
 @test_throws ParseError parse("x.2")
 @test parse("[x;.2]") == Expr(:vcat, :x, 0.2)
+
+# issue #22840
+@test parse("[:a :b]") == Expr(:hcat, QuoteNode(:a), QuoteNode(:b))


### PR DESCRIPTION
Also fixes other space-handling bugs in the parser. Surprising we never ran into this before; I guess before we didn't look at spaces often enough for it to matter.