### PR TITLE
emit warning when importing a deprecated binding

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1902,7 +1902,7 @@ extern "C" void jl_binding_deprecation_warning(jl_binding_t *b);
 static void cg_bdw(jl_codectx_t &ctx, jl_binding_t *b)
 {
     jl_binding_deprecation_warning(b);
-    if (jl_options.depwarn) {
+    if (b->deprecated == 1 && jl_options.depwarn) {
         show_source_loc(ctx, JL_STDERR);
         jl_printf(JL_STDERR, "\n");
     }

--- a/src/module.c
+++ b/src/module.c
@@ -281,6 +281,16 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                   jl_symbol_name(to->name));
     }
     else {
+        if (b->deprecated && to != jl_main_module && to != jl_base_module) {
+            /* with #22763, external packages wanting to replace
+               deprecated Base bindings should simply export the new
+               binding */
+            jl_printf(JL_STDERR,
+                      "WARNING: importing deprecated binding %s.%s into %s.\n",
+                      jl_symbol_name(from->name), jl_symbol_name(s),
+                      jl_symbol_name(to->name));
+        }
+
         jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&to->bindings, s);
         jl_binding_t *bto = *bp;
         if (bto != HT_NOTFOUND) {

--- a/src/module.c
+++ b/src/module.c
@@ -281,7 +281,8 @@ static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                   jl_symbol_name(to->name));
     }
     else {
-        if (b->deprecated && to != jl_main_module && to != jl_base_module) {
+        if (b->deprecated && to != jl_main_module && to != jl_base_module &&
+            jl_options.depwarn != JL_OPTIONS_DEPWARN_OFF) {
             /* with #22763, external packages wanting to replace
                deprecated Base bindings should simply export the new
                binding */

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -39,6 +39,12 @@ end
     @test foo1234(3) == 4
     @test_throws ErrorException DeprecationTests.bar(3)
 
+    # 22845
+    ex = :(module M22845; import ..DeprecationTests: bar;
+                          bar(x::Number) = x + 3; end)
+    @test_warn "importing deprecated binding" eval(ex)
+    @test @test_nowarn(DeprecationTests.bar(4)) == 7
+
     # enable when issue #22043 is fixed
     # @test @test_warn "f1 is deprecated, use f instead." f1()
     # @test @test_nowarn f1()


### PR DESCRIPTION
After #22763, we need to give a more comprehensible warning for this; see https://github.com/JuliaLang/julia/pull/22763#issuecomment-315653315