### PR TITLE
Define `isone` for base types

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -5,20 +5,6 @@
 isreal(x::AbstractArray) = all(isreal,x)
 iszero(x::AbstractArray) = all(iszero,x)
 isone(x::AbstractMatrix) = x == one(x)
-function isone(x::StridedMatrix)
-    m, n = size(x)
-    m != n && return false # only square matrices can satisfy x == one(x)
-    for i in 1:m
-        for j in 1:m
-            if i == j
-                @inbounds !isone(x[i,i]) && return false
-            else
-                @inbounds !iszero(x[i,j]) && return false
-            end
-        end
-    end
-    return true
-end
 isreal(x::AbstractArray{<:Real}) = true
 all(::typeof(isinteger), ::AbstractArray{<:Integer}) = true
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -4,14 +4,20 @@
 
 isreal(x::AbstractArray) = all(isreal,x)
 iszero(x::AbstractArray) = all(iszero,x)
-isone(x::AbstractVector) = false # vectors are not multiplicative identities
-function isone(x::AbstractMatrix)
+isone(x::AbstractMatrix) = x == one(x)
+function isone(x::StridedMatrix)
     m, n = size(x)
     m != n && return false # only square matrices can satisfy x == one(x)
-    @inbounds for i in 1:m
-        !isone(x[i,i]) && return false
+    for i in 1:m
+        for j in 1:m
+            if i == j
+                @inbounds !isone(x[i,i]) && return false
+            else
+                @inbounds !iszero(x[i,j]) && return false
+            end
+        end
     end
-    return x == one(x)
+    return true
 end
 isreal(x::AbstractArray{<:Real}) = true
 all(::typeof(isinteger), ::AbstractArray{<:Integer}) = true

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -4,6 +4,15 @@
 
 isreal(x::AbstractArray) = all(isreal,x)
 iszero(x::AbstractArray) = all(iszero,x)
+isone(x::AbstractVector) = false # vectors are not multiplicative identities
+function isone(x::AbstractMatrix)
+    m, n = size(x)
+    m != n && return false # only square matrices can satisfy x == one(x)
+    @inbounds for i in 1:m
+        !isone(x[i,i]) && return false
+    end
+    return x == one(x)
+end
 isreal(x::AbstractArray{<:Real}) = true
 all(::typeof(isinteger), ::AbstractArray{<:Integer}) = true
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -4,7 +4,6 @@
 
 isreal(x::AbstractArray) = all(isreal,x)
 iszero(x::AbstractArray) = all(iszero,x)
-isone(x::AbstractMatrix) = x == one(x)
 isreal(x::AbstractArray{<:Real}) = true
 all(::typeof(isinteger), ::AbstractArray{<:Integer}) = true
 

--- a/base/bool.jl
+++ b/base/bool.jl
@@ -77,6 +77,7 @@ sign(x::Bool) = x
 abs(x::Bool) = x
 abs2(x::Bool) = x
 iszero(x::Bool) = !x
+isone(x::Bool) = x
 
 <(x::Bool, y::Bool) = y&!x
 <=(x::Bool, y::Bool) = y|!x

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -131,6 +131,7 @@ isfinite(z::Complex) = isfinite(real(z)) & isfinite(imag(z))
 isnan(z::Complex) = isnan(real(z)) | isnan(imag(z))
 isinf(z::Complex) = isinf(real(z)) | isinf(imag(z))
 iszero(z::Complex) = iszero(real(z)) & iszero(imag(z))
+isone(z::Complex) = isone(real(z)) & isone(imag(z))
 
 """
     complex(r, [i])

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -131,7 +131,7 @@ isfinite(z::Complex) = isfinite(real(z)) & isfinite(imag(z))
 isnan(z::Complex) = isnan(real(z)) | isnan(imag(z))
 isinf(z::Complex) = isinf(real(z)) | isinf(imag(z))
 iszero(z::Complex) = iszero(real(z)) & iszero(imag(z))
-isone(z::Complex) = isone(real(z)) & isone(imag(z))
+isone(z::Complex) = isone(real(z)) & iszero(imag(z))
 
 """
     complex(r, [i])

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -355,6 +355,7 @@ export
     isreal,
     issubnormal,
     iszero,
+    isone,
     lcm,
     ldexp,
     leading_ones,

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -9,7 +9,8 @@ import Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              ndigits, promote_rule, rem, show, isqrt, string, powermod,
              sum, trailing_zeros, trailing_ones, count_ones, base, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, prevpow2, nextpow2, ndigits0zpb,
-             widen, signed, unsafe_trunc, trunc, iszero, big, flipsign, signbit, hastypemax
+             widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
+             hastypemax
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -553,6 +554,7 @@ binomial(n::BigInt, k::Integer) = k < 0 ? BigInt(0) : binomial(n, UInt(k))
 ==(x::BigInt, f::CdoubleMax) = isnan(f) ? false : cmp(x,f) == 0
 ==(f::CdoubleMax, x::BigInt) = isnan(f) ? false : cmp(x,f) == 0
 iszero(x::BigInt) = x.size == 0
+isone(x::BigInt) = x == ONE
 
 <=(x::BigInt, y::BigInt) = cmp(x,y) <= 0
 <=(x::BigInt, i::Integer) = cmp(x,i) <= 0

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -554,7 +554,7 @@ binomial(n::BigInt, k::Integer) = k < 0 ? BigInt(0) : binomial(n, UInt(k))
 ==(x::BigInt, f::CdoubleMax) = isnan(f) ? false : cmp(x,f) == 0
 ==(f::CdoubleMax, x::BigInt) = isnan(f) ? false : cmp(x,f) == 0
 iszero(x::BigInt) = x.size == 0
-isone(x::BigInt) = x == ONE
+isone(x::BigInt) = x == Culong(1)
 
 <=(x::BigInt, y::BigInt) = cmp(x,y) <= 0
 <=(x::BigInt, i::Integer) = cmp(x,i) <= 0

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -104,6 +104,7 @@ end
 isfinite(::Irrational) = true
 isinteger(::Irrational) = false
 iszero(::Irrational) = false
+isone(::Irrational) = false
 
 hash(x::Irrational, h::UInt) = 3*object_id(x) - h
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -33,11 +33,11 @@ function isone(x::StridedMatrix)
     m, n = size(x)
     m != n && return false # only square matrices can satisfy x == one(x)
     for i in 1:m
-        for j in 1:m
+        for j in i:m
             if i == j
                 @inbounds !isone(x[i,i]) && return false
             else
-                @inbounds !iszero(x[i,j]) && return false
+                @inbounds (!iszero(x[i,j]) || !iszero(x[j,i])) && return false
             end
         end
     end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -29,6 +29,21 @@ function scale!(X::Array{T}, s::Real) where T<:BlasComplex
     X
 end
 
+function isone(x::StridedMatrix)
+    m, n = size(x)
+    m != n && return false # only square matrices can satisfy x == one(x)
+    for i in 1:m
+        for j in 1:m
+            if i == j
+                @inbounds !isone(x[i,i]) && return false
+            else
+                @inbounds !iszero(x[i,j]) && return false
+            end
+        end
+    end
+    return true
+end
+
 """
     isposdef!(A) -> Bool
 

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -7,11 +7,11 @@ import Base: A_mul_Bt, At_ldiv_Bt, A_rdiv_Bc, At_ldiv_B, Ac_mul_Bc, A_mul_Bc, Ac
     Ac_ldiv_B, Ac_ldiv_Bc, At_mul_Bt, A_rdiv_Bt, At_mul_B
 import Base: USE_BLAS64, abs, big, broadcast, ceil, conj, convert, copy, copy!,
     ctranspose, eltype, eye, findmax, findmin, fill!, floor, full, getindex,
-    hcat, imag, indices, inv, isapprox, kron, length, IndexStyle, map,
+    hcat, imag, indices, inv, isapprox, isone, IndexStyle, kron, length, map,
     ndims, oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round,
     setindex!, show, similar, size, transpose, trunc, typed_hcat
-using Base: promote_op, _length, iszero, @pure, @propagate_inbounds, IndexLinear,
-    reduce, hvcat_fill, typed_vcat, promote_typeof
+using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
+    @propagate_inbounds, @pure, reduce, typed_vcat
 # We use `_length` because of non-1 indices; releases after julia 0.5
 # can go back to `length`. `_length(A)` is equivalent to `length(linearindices(A))`.
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -16,7 +16,8 @@ import
         eps, signbit, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
         cbrt, typemax, typemin, unsafe_trunc, realmin, realmax, rounding,
-        setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero, big
+        setrounding, maxintfloat, widen, significand, frexp, tryparse, iszero,
+        isone, big
 
 import Base.Rounding: rounding_raw, setrounding_raw
 
@@ -850,6 +851,7 @@ end
 isfinite(x::BigFloat) = !isinf(x) && !isnan(x)
 
 iszero(x::BigFloat) = x == Clong(0)
+isone(x::BigFloat) = x == Clong(1)
 
 @eval typemax(::Type{BigFloat}) = $(BigFloat( Inf))
 @eval typemin(::Type{BigFloat}) = $(BigFloat(-Inf))

--- a/base/number.jl
+++ b/base/number.jl
@@ -18,8 +18,26 @@ isinteger(x::Integer) = true
 
 Return `true` if `x == zero(x)`; if `x` is an array, this checks whether
 all of the elements of `x` are zero.
+
+```jldoctest
+julia> iszero(0.0)
+true
+```
 """
 iszero(x) = x == zero(x) # fallback method
+
+"""
+    isone(x)
+
+Return `true` if `x == one(x)`; if `x` is an array, this checks whether
+all of the elements of `x` are one.
+
+```jldoctest
+julia> isone(1.0)
+true
+```
+"""
+isone(x) = x == one(x) # fallback method
 
 size(x::Number) = ()
 size(x::Number,d) = convert(Int,d)<1 ? throw(BoundsError()) : 1

--- a/base/number.jl
+++ b/base/number.jl
@@ -30,7 +30,7 @@ iszero(x) = x == zero(x) # fallback method
     isone(x)
 
 Return `true` if `x == one(x)`; if `x` is an array, this checks whether
-all of the elements of `x` are one.
+`x` is an identity matrix.
 
 ```jldoctest
 julia> isone(1.0)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -435,6 +435,7 @@ function ^(z::Complex{<:Rational}, n::Integer)
 end
 
 iszero(x::Rational) = iszero(numerator(x))
+isone(x::Rational) = isone(numerator(x)) & isone(denominator(x))
 
 function lerpi(j::Integer, d::Integer, a::Rational, b::Rational)
     ((d-j)*a)/d + (j*b)/d

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -87,6 +87,7 @@ Base.isfinite
 Base.isinf
 Base.isnan
 Base.iszero
+Base.isone
 Base.nextfloat
 Base.prevfloat
 Base.isinteger

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2974,6 +2974,7 @@ end
     @test !isone(triu(ones(Int, 5, 5)))
     @test !isone(zeros(Int, 5, 5))
     @test isone(eye(Int, 5, 5))
+    @test isone(eye(Int, 1000, 1000)) # sizeof(X) > 2M == ISONE_CUTOFF
 end
 
 f20065(B, i) = UInt8(B[i])

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2969,8 +2969,8 @@ end
 
     # Array reduction
     @test !iszero([0, 1, 2, 3])
-    @test !isone([0, 1, 2, 3])
     @test iszero(zeros(Int, 5))
+    @test !isone(reshape([0, 1, 2, 3], 2, 2))
     @test !isone(zeros(Int, 5, 5))
     @test isone(eye(Int, 5, 5))
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2971,8 +2971,8 @@ end
     @test !iszero([0, 1, 2, 3])
     @test !isone([0, 1, 2, 3])
     @test iszero(zeros(Int, 5))
-    @test !isone(zeros(Int, 5))
-    @test isone(eye(Int, 5))
+    @test !isone(zeros(Int, 5, 5))
+    @test isone(eye(Int, 5, 5))
 end
 
 f20065(B, i) = UInt8(B[i])

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2970,7 +2970,8 @@ end
     # Array reduction
     @test !iszero([0, 1, 2, 3])
     @test iszero(zeros(Int, 5))
-    @test !isone(reshape([0, 1, 2, 3], 2, 2))
+    @test !isone(tril(ones(Int, 5, 5)))
+    @test !isone(triu(ones(Int, 5, 5)))
     @test !isone(zeros(Int, 5, 5))
     @test isone(eye(Int, 5, 5))
 end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -53,6 +53,7 @@ const ≣ = isequal # convenient for comparing NaNs
 @test_throws InexactError Bool(1//2)
 
 @test iszero(false) && !iszero(true)
+@test isone(true) && !isone(false)
 
 # basic arithmetic
 @test 2 + 3 == 5
@@ -2942,28 +2943,36 @@ module M20889 # do we get the expected behavior without importing Base.^?
     Base.Test.@test PR20889(2)^3 == 5
 end
 
-@testset "iszero" begin
+@testset "iszero & isone" begin
     # Numeric scalars
     for T in [Float16, Float32, Float64, BigFloat,
               Int8, Int16, Int32, Int64, Int128, BigInt,
               UInt8, UInt16, UInt32, UInt64, UInt128]
         @test iszero(T(0))
+        @test isone(T(1))
         @test iszero(Complex{T}(0))
+        @test isone(Complex{T}(1))
         if T <: Integer
             @test iszero(Rational{T}(0))
+            @test isone(Rational{T}(1))
         elseif T <: AbstractFloat
             @test iszero(T(-0.0))
             @test iszero(Complex{T}(-0.0))
         end
     end
     @test !iszero(nextfloat(BigFloat(0)))
+    @test !isone(nextfloat(BigFloat(1)))
     for x in (π, e, γ, catalan, φ)
         @test !iszero(x)
+        @test !isone(x)
     end
 
     # Array reduction
     @test !iszero([0, 1, 2, 3])
+    @test !isone([0, 1, 2, 3])
     @test iszero(zeros(Int, 5))
+    @test !isone(zeros(Int, 5))
+    @test isone(eye(Int, 5))
 end
 
 f20065(B, i) = UInt8(B[i])


### PR DESCRIPTION
I was surprised that Base provides and exports `zero` and the associated `iszero` but there is no matching `isone` for `one`. When you multiply or exponentiate by the multiplicative identity, you don't actually need to do the multiplication, and so `isone` can actually be useful in these cases to short-circuit around a consuming algorithm.

This PR defines `isone` for the base types where `iszero` has methods (except `BigInt` where it falls back to the default). I am not sure if there are routines in Base which would actually benefit from short-circuiting on `isone`, since there is a slight overhead in all the cases where it isn't true, but I tried to minimise it as best as possible.