### PR TITLE
RFC: deprecate `showall`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -197,6 +197,9 @@ Deprecated or removed
 
   * The method `String(io::IOBuffer)` is deprecated to `String(take!(copy(io)))` ([#21438]).
 
+  * The function `showall` is deprecated. Showing entire values is the default, unless an
+    `IOContext` specifying `:limit=>true` is in use ([#22847]).
+
 
 Julia v0.6.0 Release Notes
 ==========================

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1565,6 +1565,9 @@ end
 @deprecate readstring(cmd::AbstractCmd, stdin::Redirectable) readstring(pipeline(stdin, cmd))
 @deprecate eachline(cmd::AbstractCmd, stdin; chomp::Bool=true) eachline(pipeline(stdin, cmd), chomp=chomp)
 
+@deprecate showall(x)     show(x)
+@deprecate showall(io, x) show(IOContext(io, :limit => false), x)
+
 @deprecate_binding AbstractIOBuffer GenericIOBuffer false
 
 @deprecate String(io::GenericIOBuffer) String(take!(copy(io)))

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1867,13 +1867,6 @@ it for new types as appropriate.
 promote_rule
 
 """
-    showall(x)
-
-Similar to [`show`](@ref), except shows all elements of arrays.
-"""
-showall
-
-"""
     match(r::Regex, s::AbstractString[, idx::Integer[, addopts]])
 
 Search for the first match of the regular expression `r` in `s` and return a `RegexMatch`

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -809,7 +809,6 @@ export
     search,
     searchindex,
     show,
-    showall,
     showcompact,
     showerror,
     split,

--- a/base/show.jl
+++ b/base/show.jl
@@ -1758,15 +1758,6 @@ function showarray(io::IO, X::AbstractArray, repr::Bool = true; header = true)
     end
 end
 
-showall(x) = showall(STDOUT, x)
-function showall(io::IO, x)
-    if !get(io, :limit, false)
-        show(io, x)
-    else
-        show(IOContext(io, :limit => false), x)
-    end
-end
-
 showcompact(x) = showcompact(STDOUT, x)
 function showcompact(io::IO, x)
     if get(io, :compact, false)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -139,11 +139,11 @@ end
 """
     repr(x)
 
-Create a string from any value using the [`showall`](@ref) function.
+Create a string from any value using the [`show`](@ref) function.
 """
 function repr(x)
     s = IOBuffer()
-    showall(s, x)
+    show(s, x)
     String(take!(s))
 end
 

--- a/doc/src/stdlib/io-network.md
+++ b/doc/src/stdlib/io-network.md
@@ -59,7 +59,6 @@ Base.IOContext(::IO, ::IOContext)
 ```@docs
 Base.show(::Any)
 Base.showcompact
-Base.showall
 Base.summary
 Base.print
 Base.println


### PR DESCRIPTION
This function has become pretty useless, since showing everything is basically the default.