### PR TITLE
Remove unused variable in GC root placement

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1247,7 +1247,6 @@ void LateLowerGCFrame::PlaceGCFrameStores(Function &F, State &S, unsigned MinCol
 }
 
 void LateLowerGCFrame::PlaceRootsAndUpdateCalls(Function &F, std::vector<int> &Colors, State &S, std::map<Value *, std::pair<int, int>>) {
-    auto &DT = getAnalysis<DominatorTreeWrapperPass>().getDomTree();
     int MaxColor = -1;
     for (auto C : Colors)
         if (C > MaxColor)


### PR DESCRIPTION
This was causing an unused variable warning when building with Clang.