### PR TITLE
pager: split the argument for handling options

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -92,13 +92,13 @@ edit(file, line::Integer) = error("could not find source file for function")
 
 if Sys.iswindows()
     function less(file::AbstractString, line::Integer)
-        pager = get(ENV, "PAGER", "more")
+        pager = shell_split(get(ENV, "PAGER", "more"))
         g = pager == "more" ? "" : "g"
         run(Cmd(`$pager +$(line)$(g) \"$file\"`, windows_verbatim = true))
     end
 else
     function less(file::AbstractString, line::Integer)
-        pager = split(get(ENV, "PAGER", "less"))
+        pager = shell_split(get(ENV, "PAGER", "less"))
         run(`$pager +$(line)g $file`)
     end
 end

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -93,7 +93,7 @@ edit(file, line::Integer) = error("could not find source file for function")
 if Sys.iswindows()
     function less(file::AbstractString, line::Integer)
         pager = shell_split(get(ENV, "PAGER", "more"))
-        g = pager == "more" ? "" : "g"
+        g = pager[1] == "more" ? "" : "g"
         run(Cmd(`$pager +$(line)$(g) \"$file\"`, windows_verbatim = true))
     end
 else

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -98,7 +98,7 @@ if Sys.iswindows()
     end
 else
     function less(file::AbstractString, line::Integer)
-        pager = get(ENV, "PAGER", "less")
+        pager = split(get(ENV, "PAGER", "less"))
         run(`$pager +$(line)g $file`)
     end
 end


### PR DESCRIPTION
For some reason (that I don't know), my pager is defined to be "less -R", which is not recognized as the name of a program (when using e.g. `@less`), unless it's split. I don't know whether it's common for a program name (without options) in "ENV" to have spaces, but this fix would break that. I also don't know if this fix shoud be applied on windows?