### PR TITLE
RFC: deprecate parsing `*` inside `<<`. part of #13079

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,9 @@ Language changes
   * Declaring arguments as `x::ANY` to avoid specialization has been replaced
     by `@nospecialize x`. ([#22666]).
 
+  * The parsing of `1<<2*3` as `1<<(2*3)` is deprecated, and will change to
+    `(1<<2)*3` in a future version ([#13079]).
+
 Breaking changes
 ----------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1563,6 +1563,12 @@ end
 # ::ANY is deprecated in src/method.c
 # also remove all instances of `jl_ANY_flag` in src/
 
+# issue #13079
+# in julia-parser.scm:
+#     move prec-bitshift after prec-rational
+#     remove parse-with-chains-warn and bitshift-warn
+# update precedence table in doc/src/manual/mathematical-operations.md
+
 # PR #22182
 @deprecate is_apple   Sys.isapple
 @deprecate is_bsd     Sys.isbsd

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -271,7 +271,7 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
 end
 
 max_values(::Type) = typemax(Int)
-max_values(T::Type{<:Union{Void,BitIntegerSmall}}) = 1 << 8*sizeof(T)
+max_values(T::Type{<:Union{Void,BitIntegerSmall}}) = 1 << (8*sizeof(T))
 max_values(T::Union) = max(max_values(T.a), max_values(T.b))
 max_values(::Type{Bool}) = 2
 

--- a/base/grisu/fastshortest.jl
+++ b/base/grisu/fastshortest.jl
@@ -55,7 +55,7 @@ const SmallPowersOfTen = [
         1000000, 10000000, 100000000, 1000000000]
 
 function bigpowten(n,n_bits)
-    guess = (n_bits + 1) * 1233 >> 12
+    guess = ((n_bits + 1) * 1233) >> 12
     guess += 1
     i = SmallPowersOfTen[guess+1]
     return n < i ? (SmallPowersOfTen[guess], guess-1) : (i,guess)

--- a/base/multinverses.jl
+++ b/base/multinverses.jl
@@ -135,12 +135,12 @@ end
 UnsignedMultiplicativeInverse(x::Unsigned) = UnsignedMultiplicativeInverse{typeof(x)}(x)
 
 function div(a::T, b::SignedMultiplicativeInverse{T}) where T
-    x = ((widen(a)*b.multiplier) >>> sizeof(a)*8) % T
+    x = ((widen(a)*b.multiplier) >>> (sizeof(a)*8)) % T
     x += (a*b.addmul) % T
     ifelse(abs(b.divisor) == 1, a*b.divisor, (signbit(x) + (x >> b.shift)) % T)
 end
 function div(a::T, b::UnsignedMultiplicativeInverse{T}) where T
-    x = ((widen(a)*b.multiplier) >>> sizeof(a)*8) % T
+    x = ((widen(a)*b.multiplier) >>> (sizeof(a)*8)) % T
     x = ifelse(b.add, convert(T, convert(T, (convert(T, a - x) >>> 1)) + x), x)
     ifelse(b.divisor == 1, a, x >>> b.shift)
 end

--- a/base/random.jl
+++ b/base/random.jl
@@ -614,7 +614,7 @@ function rand!(r::MersenneTwister, A::Array{UInt128}, n::Int=length(A))
     if n > 0
         u = rand_ui2x52_raw(r)
         for i = 1:n
-            @inbounds A[i] ⊻= u << 12*i
+            @inbounds A[i] ⊻= u << (12*i)
         end
     end
     A


### PR DESCRIPTION
Fortunately it's possible to have a really smooth deprecation here, warning only for un-parenthesized uses of `a<<b*c` syntax, which I think makes this change quite palatable.

Another motivation for this change is that `1//2<<3` parses as `(1//2)<<3`, but there are no methods of `<<` for `Rational` --- it's practically a method error built in to the syntax! This also makes the deprecation easier since we don't have to worry about those cases.