### PR TITLE
Deprecate readstring in favor of read(io, String)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -197,6 +197,8 @@ Deprecated or removed
 
   * The method `String(io::IOBuffer)` is deprecated to `String(take!(copy(io)))` ([#21438]).
 
+  * The function `readstring` is deprecated in favor of `read(io, String)` ([#22793])
+
   * The function `showall` is deprecated. Showing entire values is the default, unless an
     `IOContext` specifying `:limit=>true` is in use ([#22847]).
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -334,7 +334,7 @@ end
 
 function load_machine_file(path::AbstractString)
     machines = []
-    for line in split(readstring(path),'\n'; keep=false)
+    for line in split(read(path, String),'\n'; keep=false)
         s = split(line, '*'; keep = false)
         map!(strip, s, s)
         if length(s) > 1
@@ -413,7 +413,7 @@ function _start()
                 # note: currently IOStream is used for file STDIN
                 if isa(STDIN,File) || isa(STDIN,IOStream)
                     # reading from a file, behave like include
-                    eval(Main,parse_input_line(readstring(STDIN)))
+                    eval(Main,parse_input_line(read(STDIN, String)))
                 else
                     # otherwise behave repl-like
                     while !eof(STDIN)

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -117,7 +117,7 @@ readdlm(input, dlm::Char, T::Type, eol::Char; opts...) =
 readdlm_auto(input::Vector{UInt8}, dlm::Char, T::Type, eol::Char, auto::Bool; opts...) =
     readdlm_string(String(input), dlm, T, eol, auto, val_opts(opts))
 readdlm_auto(input::IO, dlm::Char, T::Type, eol::Char, auto::Bool; opts...) =
-    readdlm_string(readstring(input), dlm, T, eol, auto, val_opts(opts))
+    readdlm_string(read(input, String), dlm, T, eol, auto, val_opts(opts))
 function readdlm_auto(input::AbstractString, dlm::Char, T::Type, eol::Char, auto::Bool; opts...)
     optsd = val_opts(opts)
     use_mmap = get(optsd, :use_mmap, Sys.iswindows() ? false : true)
@@ -131,7 +131,7 @@ function readdlm_auto(input::AbstractString, dlm::Char, T::Type, eol::Char, auto
         # jl_try_substrtod to segfault below.
         return readdlm_string(unsafe_string(pointer(a),length(a)), dlm, T, eol, auto, optsd)
     else
-        return readdlm_string(readstring(input), dlm, T, eol, auto, optsd)
+        return readdlm_string(read(input, String), dlm, T, eol, auto, optsd)
     end
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1581,6 +1581,10 @@ end
 
 @deprecate String(io::GenericIOBuffer) String(take!(copy(io)))
 
+
+@deprecate readstring(s::IO) read(s, String)
+@deprecate readstring(filename::String) read(filename, String)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1581,10 +1581,10 @@ end
 
 @deprecate String(io::GenericIOBuffer) String(take!(copy(io)))
 
-
 @deprecate readstring(s::IO) read(s, String)
-@deprecate readstring(filename::String) read(filename, String)
+@deprecate readstring(filename::AbstractString) read(filename, String)
 @deprecate readstring(cmd::AbstractCmd) read(cmd, String)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1584,7 +1584,7 @@ end
 
 @deprecate readstring(s::IO) read(s, String)
 @deprecate readstring(filename::String) read(filename, String)
-
+@deprecate readstring(cmd::AbstractCmd) read(cmd, String)
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -419,7 +419,7 @@ function summarize(io::IO, m::Module, binding)
     if isfile(readme)
         println(io, "Displaying the `README.md` for the module instead.\n")
         println(io, "---\n")
-        println(io, readstring(readme))
+        println(io, read(readme, String))
     else
         println(io, "No docstring or `README.md` found for module `", m, "`.\n")
     end

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1278,6 +1278,10 @@ hash
     read(stream::IO, T)
 
 Read a single value of type `T` from `stream`, in canonical binary representation.
+
+    read(stream::IO, String)
+
+Read the entirety of `stream`, as a String.
 """
 read(stream, t)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1069,7 +1069,6 @@ export
     readdlm,
     readline,
     readlines,
-    readstring,
     readuntil,
     redirect_stderr,
     redirect_stdin,

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -132,7 +132,7 @@ if Sys.isapple()
             print(io, x)
         end
     end
-    clipboard() = readstring(`pbpaste`)
+    clipboard() = read(`pbpaste`, String)
 
 elseif Sys.islinux()
     _clipboardcmd = nothing
@@ -158,7 +158,7 @@ elseif Sys.islinux()
         cmd = c == :xsel  ? `xsel --nodetach --output --clipboard` :
               c == :xclip ? `xclip -quiet -out -selection clipboard` :
             error("unexpected clipboard command: $c")
-        readstring(pipeline(cmd, stderr=STDERR))
+        read(pipeline(cmd, stderr=STDERR), String)
     end
 
 elseif Sys.iswindows()
@@ -274,7 +274,7 @@ function versioninfo(io::IO=STDOUT; verbose::Bool=false, packages::Bool=false)
             try lsb = readchomp(pipeline(`lsb_release -ds`, stderr=DevNull)) end
         end
         if Sys.iswindows()
-            try lsb = strip(readstring(`$(ENV["COMSPEC"]) /c ver`)) end
+            try lsb = strip(read(`$(ENV["COMSPEC"]) /c ver`, String)) end
         end
         if !isempty(lsb)
             println(io, "      ", lsb)
@@ -694,7 +694,7 @@ function runtests(tests = ["all"], numcores = ceil(Int, Sys.CPU_CORES / 2))
         buf = PipeBuffer()
         versioninfo(buf)
         error("A test has failed. Please submit a bug report (https://github.com/JuliaLang/julia/issues)\n" *
-              "including error messages above and the output of versioninfo():\n$(readstring(buf))")
+              "including error messages above and the output of versioninfo():\n$(read(buf, String))")
     end
 end
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -163,6 +163,10 @@ write(filename::AbstractString, args...) = open(io->write(io, args...), filename
 
 Open a file and read its contents. `args` is passed to `read`: this is equivalent to
 `open(io->read(io, args...), filename)`.
+
+    read(filename::AbstractString, String)
+
+Read the entire contents of a file as a string.
 """
 read(filename::AbstractString, args...) = open(io->read(io, args...), filename)
 read!(filename::AbstractString, a) = open(io->read!(io, a), filename)

--- a/base/io.jl
+++ b/base/io.jl
@@ -481,9 +481,9 @@ end
     readchomp(x)
 
 Read the entirety of `x` as a string and remove a single trailing newline.
-Equivalent to `chomp!(readstring(x))`.
+Equivalent to `chomp!(read(x, String))`.
 """
-readchomp(x) = chomp!(readstring(x))
+readchomp(x) = chomp!(read(x, String))
 
 # read up to nb bytes into nb, returning # bytes read
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -525,15 +525,7 @@ function read(s::IO, nb::Integer = typemax(Int))
     return resize!(b, nr)
 end
 
-"""
-    readstring(stream::IO)
-    readstring(filename::AbstractString)
-
-Read the entire contents of an I/O stream or a file as a string.
-The text is assumed to be encoded in UTF-8.
-"""
-readstring(s::IO) = String(read(s))
-readstring(filename::AbstractString) = open(readstring, filename)
+read(s::IO, ::Type{String}) = String(read(s))
 
 ## high-level iterator interfaces ##
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -144,7 +144,10 @@ end
 Apply the function `f` to the result of `open(args...)` and close the resulting file
 descriptor upon completion.
 
-**Example**: `open(f->read(f, String), "file.txt")`
+# Examples
+```julia-repl
+open(f->read(f, String), "file.txt")
+```
 """
 function open(f::Function, args...)
     io = open(args...)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -144,7 +144,7 @@ end
 Apply the function `f` to the result of `open(args...)` and close the resulting file
 descriptor upon completion.
 
-**Example**: `open(readstring, "file.txt")`
+**Example**: `open(f->read(f, String), "file.txt")`
 """
 function open(f::Function, args...)
     io = open(args...)

--- a/base/markdown/Julia/interp.jl
+++ b/base/markdown/Julia/interp.jl
@@ -2,7 +2,7 @@
 
 function Base.parse(stream::IO; greedy::Bool = true, raise::Bool = true)
     pos = position(stream)
-    ex, Δ = Base.parse(readstring(stream), 1, greedy = greedy, raise = raise)
+    ex, Δ = Base.parse(read(stream, String), 1, greedy = greedy, raise = raise)
     seek(stream, pos + Δ - 1)
     return ex
 end

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -24,7 +24,7 @@ include(joinpath("render", "terminal", "render.jl"))
 export readme, license, @md_str, @doc_str
 
 parse(markdown::AbstractString; flavor = julia) = parse(IOBuffer(markdown), flavor = flavor)
-parse_file(file::AbstractString; flavor = julia) = parse(readstring(file), flavor = flavor)
+parse_file(file::AbstractString; flavor = julia) = parse(read(file, String), flavor = flavor)
 
 readme(pkg::AbstractString; flavor = github) = parse_file(Pkg.dir(pkg, "README.md"), flavor = flavor)
 readme(pkg::Module; flavor = github) = readme(string(pkg), flavor = flavor)

--- a/base/markdown/parse/util.jl
+++ b/base/markdown/parse/util.jl
@@ -200,7 +200,7 @@ end
 
 function showrest(io::IO)
     start = position(io)
-    show(readstring(io))
+    show(read(io, String))
     println()
     seek(io, start)
 end

--- a/base/pkg/read.jl
+++ b/base/pkg/read.jl
@@ -5,7 +5,7 @@ module Read
 import ...LibGit2, ..Cache, ..Reqs, ...Pkg.PkgError, ..Dir
 using ..Types
 
-readstrip(path...) = strip(readstring(joinpath(path...)))
+readstrip(path...) = strip(read(joinpath(path...), String))
 
 url(pkg::AbstractString) = readstrip(Dir.path("METADATA"), pkg, "url")
 sha1(pkg::AbstractString, ver::VersionNumber) =

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -66,7 +66,6 @@ precompile(Tuple{typeof(Base.Sort.Float.right), Base.Order.ReverseOrdering{Base.
 precompile(Tuple{typeof(Base.stat), Int64})
 precompile(Tuple{typeof(Base.readbytes_all!), Base.IOStream, Array{UInt8, 1}, Int64})
 precompile(Tuple{typeof(Base.read), Base.IOStream})
-precompile(Tuple{typeof(Base.open), typeof(Base.readstring), String})
 precompile(Tuple{typeof(Base.rstrip), Base.SubString{String}, Array{Char, 1}})
 precompile(Tuple{typeof(Base.lstrip), Base.SubString{String}, Array{Char, 1}})
 precompile(Tuple{getfield(Base, Symbol("#kw##split")), Array{Any, 1}, typeof(Base.split), String, Char})

--- a/base/process.jl
+++ b/base/process.jl
@@ -648,8 +648,6 @@ function read(cmd::AbstractCmd)
     return bytes
 end
 
-readstring(cmd::AbstractCmd) = String(read(cmd))
-
 """
     run(command, args...)
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -648,6 +648,8 @@ function read(cmd::AbstractCmd)
     return bytes
 end
 
+read(cmd::AbstractCmd, ::Type{String}) = String(read(cmd))
+
 """
     run(command, args...)
 

--- a/base/random.jl
+++ b/base/random.jl
@@ -218,7 +218,7 @@ function make_seed()
         seed = reinterpret(UInt64, time())
         seed = hash(seed, UInt64(getpid()))
         try
-        seed = hash(seed, parse(UInt64, readstring(pipeline(`ifconfig`, `sha1sum`))[1:40], 16))
+        seed = hash(seed, parse(UInt64, read(pipeline(`ifconfig`, `sha1sum`), String)[1:40], 16))
         end
         return make_seed(seed)
     end

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -960,7 +960,7 @@ function write_response_buffer(s::PromptState, data)
     offset = s.input_buffer.ptr
     ptr = data.response_buffer.ptr
     seek(data.response_buffer, 0)
-    write(s.input_buffer, readstring(data.response_buffer))
+    write(s.input_buffer, read(data.response_buffer, String))
     s.input_buffer.ptr = offset + ptr - 2
     data.response_buffer.ptr = ptr
     refresh_line(s)
@@ -1101,7 +1101,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, s::SearchState)
     offset = buf.ptr
     ptr = s.response_buffer.ptr
     seek(s.response_buffer, 0)
-    write(buf, readstring(s.response_buffer))
+    write(buf, read(s.response_buffer, String))
     buf.ptr = offset + ptr - 1
     s.response_buffer.ptr = ptr
     s.ias = refresh_multi_line(termbuf, s.terminal, buf, s.ias, s.backward ? "(reverse-i-search)`" : "(forward-i-search)`")

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -592,9 +592,9 @@ function print_shmem_limits(slen)
             return
         end
 
-        shmmax_MB = div(parse(Int, split(readstring(`sysctl $(pfx).shmmax`))[end]), 1024*1024)
-        page_size = parse(Int, split(readstring(`getconf PAGE_SIZE`))[end])
-        shmall_MB = div(parse(Int, split(readstring(`sysctl $(pfx).shmall`))[end]) * page_size, 1024*1024)
+        shmmax_MB = div(parse(Int, split(read(`sysctl $(pfx).shmmax`, String))[end]), 1024*1024)
+        page_size = parse(Int, split(read(`getconf PAGE_SIZE`, String))[end])
+        shmall_MB = div(parse(Int, split(read(`sysctl $(pfx).shmall`, String))[end]) * page_size, 1024*1024)
 
         println("System max size of single shmem segment(MB) : ", shmmax_MB,
             "\nSystem max size of all shmem segments(MB) : ", shmall_MB,

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -362,7 +362,7 @@ function displaysize(io::TTY)
         if ispty(io)
             # io is actually a libuv pipe but a cygwin/msys2 pty
             try
-                h, w = parse.(Int, split(readstring(open(Base.Cmd(String["stty", "size"]), "r", io).out)))
+                h, w = parse.(Int, split(read(open(Base.Cmd(String["stty", "size"]), "r", io).out, String)))
                 h > 0 || (h = default_size[1])
                 w > 0 || (w = default_size[2])
                 return h, w

--- a/base/test.jl
+++ b/base/test.jl
@@ -513,7 +513,7 @@ macro test_warn(msg, expr)
                         $(esc(expr))
                     end
                 end
-                @test ismatch_warn($(esc(msg)), readstring(fname))
+                @test ismatch_warn($(esc(msg)), read(fname, String))
                 ret
             finally
                 eval(Base, Expr(:(=), :have_color, have_color))

--- a/doc/NEWS-update.jl
+++ b/doc/NEWS-update.jl
@@ -3,7 +3,7 @@
 
 NEWS = get(ARGS, 1, "NEWS.md")
 
-s = readstring(NEWS)
+s = read(NEWS, String)
 
 s = s[1:match(r"\[#[0-9]+\]:", s).offset-1];
 

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -67,7 +67,7 @@ When the cursor is at the beginning of the line, the prompt can be changed to a 
 julia> ? # upon typing ?, the prompt changes (in place) to: help?>
 
 help?> string
-search: string String stringmime Cstring Cwstring RevString readstring randstring bytestring SubString
+search: string String stringmime Cstring Cwstring RevString randstring bytestring SubString
 
   string(xs...)
 

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -156,7 +156,7 @@ file as an argument, and then closes it again. For example, given a function:
 
 ```julia
 function read_and_capitalize(f::IOStream)
-    return uppercase(readstring(f))
+    return uppercase(read(f, String))
 end
 ```
 
@@ -175,7 +175,7 @@ anonymous function on the fly:
 
 ```julia-repl
 julia> open("hello.txt") do f
-           uppercase(readstring(f))
+           uppercase(read(f, String))
        end
 "HELLO AGAIN."
 ```

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -37,10 +37,10 @@ The `hello` is the output of the `echo` command, sent to [`STDOUT`](@ref). The r
 returns `nothing`, and throws an [`ErrorException`](@ref) if the external command fails to run
 successfully.
 
-If you want to read the output of the external command, [`readstring()`](@ref) can be used instead:
+If you want to read the output of the external command, [`read`](@ref) can be used instead:
 
 ```jldoctest
-julia> a = readstring(`echo hello`)
+julia> a = read(`echo hello`, String)
 "hello\n"
 
 julia> chomp(a) == "hello"
@@ -306,7 +306,7 @@ pipeline(`do_work`, stdout=pipeline(`sort`, "out.txt"), stderr="errs.txt")
 When reading and writing to both ends of a pipeline from a single process, it is important to
 avoid forcing the kernel to buffer all of the data.
 
-For example, when reading all of the output from a command, call `readstring(out)`, not `wait(process)`,
+For example, when reading all of the output from a command, call `read(out, String)`, not `wait(process)`,
 since the former will actively consume all of the data written by the process, whereas the latter
 will attempt to store the data in the kernel's buffers while waiting for a reader to be connected.
 
@@ -314,7 +314,7 @@ Another common solution is to separate the reader and writer of the pipeline int
 
 ```julia
 writer = @async write(process, "data")
-reader = @async do_compute(readstring(process))
+reader = @async do_compute(read(process, String))
 wait(process)
 fetch(reader)
 ```

--- a/doc/src/stdlib/io-network.md
+++ b/doc/src/stdlib/io-network.md
@@ -71,7 +71,6 @@ Base.Printf.@sprintf
 Base.sprint
 Base.showerror
 Base.dump
-Base.readstring
 Base.readline
 Base.readuntil
 Base.readlines

--- a/examples/wordcount.jl
+++ b/examples/wordcount.jl
@@ -75,7 +75,7 @@ end
 function wordcount_files(result_file,inputs...)
     text = ""
     for file in inputs
-        text *= readstring(file)
+        text *= read(file, String)
     end
     wc = parallel_wordcount(text)
     open(result_file,"w") do f

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -77,7 +77,7 @@ end
 
 function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=10, debug::Bool=true)
     function format_output(output)
-        debug ? "Process output found:\n\"\"\"\n$(readstring(seekstart(out)))\n\"\"\"" : ""
+        debug ? "Process output found:\n\"\"\"\n$(read(seekstart(out), String))\n\"\"\"" : ""
     end
     out = IOBuffer()
     with_fake_pty() do slave, master

--- a/test/base64.jl
+++ b/test/base64.jl
@@ -18,7 +18,7 @@ end
 
 open(fname, "r") do f
     ipipe = Base64DecodePipe(f)
-    @test readstring(ipipe) == inputText
+    @test read(ipipe, String) == inputText
     @test close(ipipe) === nothing
 end
 rm(fname)
@@ -28,19 +28,19 @@ rm(fname)
 
 # Decode with max line chars = 76 and padding
 ipipe = Base64DecodePipe(IOBuffer(encodedMaxLine76))
-@test readstring(ipipe) == inputText
+@test read(ipipe, String) == inputText
 
 # Decode with max line chars = 76 and no padding
 ipipe = Base64DecodePipe(IOBuffer(encodedMaxLine76[1:end-1]))
-@test readstring(ipipe) == inputText
+@test read(ipipe, String) == inputText
 
 # Decode with two padding characters ("==")
 ipipe = Base64DecodePipe(IOBuffer(string(encodedMaxLine76[1:end-2],"==")))
-@test readstring(ipipe) == inputText[1:end-1]
+@test read(ipipe, String) == inputText[1:end-1]
 
 # Test incorrect format
 ipipe = Base64DecodePipe(IOBuffer(encodedMaxLine76[1:end-3]))
-@test_throws ArgumentError readstring(ipipe)
+@test_throws ArgumentError read(ipipe, String)
 
 # issue #21314
 @test base64decode(chomp("test")) == base64decode("test")

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -888,7 +888,7 @@ let A = [1]
 end
 
 # Pointer finalizer at exit (PR #19911)
-let result = readstring(`$(Base.julia_cmd()) --startup-file=no -e "A = Ref{Cint}(42); finalizer(A, cglobal((:c_exit_finalizer, \"$libccalltest\"), Void))"`)
+let result = read(`$(Base.julia_cmd()) --startup-file=no -e "A = Ref{Cint}(42); finalizer(A, cglobal((:c_exit_finalizer, \"$libccalltest\"), Void))"`, String)
     @test result == "c_exit_finalizer: 42, 0"
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -235,7 +235,7 @@ let t, run = Ref(0)
     local newstderr, errstream
     try
         newstderr = redirect_stderr()
-        errstream = @async readstring(newstderr[1])
+        errstream = @async read(newstderr[1], String)
         yield(t)
     finally
         redirect_stderr(oldstderr)
@@ -253,7 +253,7 @@ let t, run = Ref(0)
     t.state = :invalid
     try
         newstderr = redirect_stderr()
-        errstream = @async readstring(newstderr[1])
+        errstream = @async read(newstderr[1], String)
         yield()
     finally
         redirect_stderr(oldstderr)

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -460,7 +460,7 @@ let dir = mktempdir()
         let fname = tempname()
             try
                 @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
-                @test Test.ismatch_warn("WARNING: replacing module $Test_module.\n", readstring(fname))
+                @test Test.ismatch_warn("WARNING: replacing module $Test_module.\n", read(fname, String))
             finally
                 rm(fname, force=true)
             end
@@ -472,7 +472,7 @@ let dir = mktempdir()
             try
                 @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
                 # e.g `@test_nowarn`
-                @test Test.ismatch_warn(r"^(?!.)"s, readstring(fname))
+                @test Test.ismatch_warn(r"^(?!.)"s, read(fname, String))
             finally
                 rm(fname, force=true)
             end

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -94,7 +94,7 @@ end
 let x = [0.1 0.3 0.5], io = IOBuffer()
     writedlm(io, x, ", ")
     seek(io, 0)
-    @test readstring(io) == "0.1, 0.3, 0.5\n"
+    @test read(io, String) == "0.1, 0.3, 0.5\n"
 end
 
 let x = [0.1 0.3 0.5], io = IOBuffer()

--- a/test/file.jl
+++ b/test/file.jl
@@ -314,7 +314,7 @@ ispath(path) && rm(path)
 print(f, "Here is some text")
 close(f)
 @test isfile(p) == true
-@test readstring(p) == "Here is some text"
+@test read(p, String) == "Here is some text"
 rm(p)
 
 let
@@ -382,7 +382,7 @@ function check_cp(orig_path::AbstractString, copied_path::AbstractString, follow
                 # copied_path must also be a file.
                 @test isfile(copied_path)
                 # copied_path must have same content
-                @test readstring(orig_path) == readstring(copied_path)
+                @test read(orig_path, String) == read(copied_path, String)
             end
         end
     elseif isdir(orig_path)
@@ -391,7 +391,7 @@ function check_cp(orig_path::AbstractString, copied_path::AbstractString, follow
         # copied_path must also be a file.
         @test isfile(copied_path)
         # copied_path must have same content
-        @test readstring(orig_path) == readstring(copied_path)
+        @test read(orig_path, String) == read(copied_path, String)
     end
 end
 
@@ -718,7 +718,7 @@ if !Sys.iswindows()
         islink(s) && @test readlink(s) == readlink(d)
         islink(s) && @test isabspath(readlink(s)) == isabspath(readlink(d))
         # all should contain the same
-        @test readstring(s) == readstring(d) == file_txt
+        @test read(s, String) == read(d, String) == file_txt
     end
 
     function mv_check(s, d, d_mv, file_txt; remove_destination=true)
@@ -736,7 +736,7 @@ if !Sys.iswindows()
         islink(s) && @test readlink(s) == readlink(d_mv)
         islink(s) && @test isabspath(readlink(s)) == isabspath(readlink(d_mv))
         # all should contain the same
-        @test readstring(s) == readstring(d_mv) == file_txt
+        @test read(s, String) == read(d_mv, String) == file_txt
         # d => d_mv same file/dir
         @test Base.samefile(stat_d, stat_d_mv)
     end
@@ -780,7 +780,7 @@ if !Sys.iswindows()
             # Expect no link because a file is copied (follow_symlinks=false does not effect this)
             @test isfile(d) && !islink(d)
             # all should contain otherfile_content
-            @test readstring(d) == otherfile_content
+            @test read(d, String) == otherfile_content
         end
     end
     # mv ----------------------------------------------------
@@ -840,7 +840,7 @@ if !Sys.iswindows()
         rel_dl = "rel_linkto_targetdir"
         rel_dir = joinpath("..", "targetdir")
         symlink(rel_dir, rel_dl)
-        rel_file_read_txt = readstring(rel_file)
+        rel_file_read_txt = read(rel_file, String)
         cd(pwd_)
         # Setup copytodir
         copytodir = joinpath(tmpdir, "copytodir")

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -640,7 +640,7 @@ end
 # issue #20733
 # run this test in a separate process to avoid interfering with `getindex`
 let def = "Base.getindex(t::NTuple{3,NTuple{2,Int}}, i::Int, j::Int, k::Int) = (t[1][i], t[2][j], t[3][k])"
-    @test readstring(`$(Base.julia_cmd()) --startup-file=no -E "$def;test(t) = t[2,1,2];test(((3,4), (5,6), (7,8)))"`) ==
+    @test read(`$(Base.julia_cmd()) --startup-file=no -E "$def;test(t) = t[2,1,2];test(((3,4), (5,6), (7,8)))"`, String) ==
         "(4, 5, 8)\n"
 end
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -52,7 +52,7 @@ end
 let io = IOBuffer("hamster\nguinea pig\nturtle")
 @test position(io) == 0
 @test readline(io) == "hamster"
-@test readstring(io) == "guinea pig\nturtle"
+@test read(io, String) == "guinea pig\nturtle"
 @test_throws EOFError read(io,UInt8)
 seek(io,0)
 @test read(io,UInt8) == convert(UInt8, 'h')
@@ -122,7 +122,7 @@ skip(io,3)
 @test write(io,b"apples") === 3
 skip(io,71)
 @test write(io,'y') === 1
-@test readstring(io) == "happy"
+@test read(io, String) == "happy"
 @test eof(io)
 write(io,zeros(UInt8,73))
 write(io,'a')
@@ -179,22 +179,22 @@ let io=IOBuffer(SubString("***αhelloworldω***",4,16)), io2 = IOBuffer(b"goodni
     @test read(io, Char) == 'ω'
     @test_throws EOFError read(io,UInt8)
     skip(io, -3)
-    @test readstring(io) == "dω"
+    @test read(io, String) == "dω"
     @test bufcontents(io) == "αhelloworldω"
     @test_throws ArgumentError write(io,"!")
     @test take!(io) == b"αhelloworldω"
     seek(io, 2)
     seekend(io2)
     write(io2, io)
-    @test readstring(io) == ""
-    @test readstring(io2) == ""
+    @test read(io, String) == ""
+    @test read(io2, String) == ""
     @test String(take!(io)) == "αhelloworldω"
     seek(io2, 0)
     truncate(io2, io2.size - 2)
-    @test readstring(io2) == "goodnightmoonhelloworld"
+    @test read(io2, String) == "goodnightmoonhelloworld"
     seek(io2, 0)
     write(io2, io2)
-    @test readstring(io2) == ""
+    @test read(io2, String) == ""
     @test bufcontents(io2) == "goodnightmoonhelloworld"
 end
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -299,7 +299,7 @@ mktempdir() do dir
 
                 # test remote's representation in the repo's config
                 config = joinpath(cache_repo, ".git", "config")
-                lines = split(open(readstring, config, "r"), "\n")
+                lines = split(open(x->read(x, String), config, "r"), "\n")
                 @test any(map(x->x == "[remote \"upstream\"]", lines))
 
                 remote = LibGit2.get(LibGit2.GitRemote, repo, branch)
@@ -1101,7 +1101,7 @@ mktempdir() do dir
 
     @testset "Examine test repository" begin
         @testset "files" begin
-            @test read(joinpath(test_repo, test_file), String) == readstring(joinpath(cache_repo, test_file))
+            @test read(joinpath(test_repo, test_file), String) == read(joinpath(cache_repo, test_file), String)
         end
 
         @testset "tags & branches" begin

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1101,7 +1101,7 @@ mktempdir() do dir
 
     @testset "Examine test repository" begin
         @testset "files" begin
-            @test readstring(joinpath(test_repo, test_file)) == readstring(joinpath(cache_repo, test_file))
+            @test read(joinpath(test_repo, test_file), String) == readstring(joinpath(cache_repo, test_file))
         end
 
         @testset "tags & branches" begin
@@ -1650,7 +1650,7 @@ mktempdir() do dir
         if !Sys.iswindows()
             try
                 # SSHD needs to be executed by its full absolute path
-                sshd_command = strip(readstring(`which sshd`))
+                sshd_command = strip(read(`which sshd`, String))
             catch
                 warn("Skipping SSH tests (Are `which` and `sshd` installed?)")
             end
@@ -1806,7 +1806,7 @@ mktempdir() do dir
                         end
                     catch err
                         println("SSHD logfile contents follows:")
-                        println(readstring(logfile))
+                        println(read(logfile, String))
                         rethrow(err)
                     finally
                         rm(logfile)
@@ -1826,7 +1826,7 @@ mktempdir() do dir
         if Sys.islinux()
             try
                 # OpenSSL needs to be on the path
-                openssl_installed = !isempty(readstring(`openssl version`))
+                openssl_installed = !isempty(read(`openssl version`, String))
             catch
                 warn("Skipping hostname verification tests. Is `openssl` on the path?")
             end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -239,7 +239,7 @@ let
     redir_err = "redirect_stderr(STDOUT)"
     exename = Base.julia_cmd()
     script = "$redir_err; module A; f() = 1; end; A.f() = 1"
-    warning_str = readstring(`$exename --startup-file=no -e $script`)
+    warning_str = read(`$exename --startup-file=no -e $script`, String)
     @test contains(warning_str, "f()")
 end
 

--- a/test/mmap.jl
+++ b/test/mmap.jl
@@ -52,7 +52,7 @@ m = Mmap.mmap(file,Vector{UInt8},12)
 m[:] = b"Hello World\n"
 Mmap.sync!(m)
 finalize(m); m=nothing; gc()
-@test open(readstring,file) == "Hello World\n"
+@test open(x->read(x, String),file) == "Hello World\n"
 
 s = open(file, "r")
 close(s)

--- a/test/perf/perfutil.jl
+++ b/test/perf/perfutil.jl
@@ -21,7 +21,7 @@ if codespeed
     csdata["project"] = "Julia"
     csdata["branch"] = Base.GIT_VERSION_INFO.branch
     csdata["executable"] = ENV["JULIA_FLAVOR"]
-    csdata["environment"] = chomp(readstring(`hostname`))
+    csdata["environment"] = chomp(read(`hostname`, String))
     csdata["result_date"] = join( split(Base.GIT_VERSION_INFO.date_string)[1:2], " " )    #Cut the timezone out
 end
 

--- a/test/perf/report.jl
+++ b/test/perf/report.jl
@@ -2,7 +2,7 @@
 
 using HTTPClient.HTTPC
 
-env_name = chomp(readstring(`hostname`))
+env_name = chomp(read(`hostname`, String))
 commit = Base.GIT_VERSION_INFO.commit
 flavor = ENV["JULIA_FLAVOR"]
 json = "{\"env\": \"$env_name\", \"blas\":\"$flavor\", \"commit\":\"$commit\"}"

--- a/test/perf/shootout/k_nucleotide.jl
+++ b/test/perf/shootout/k_nucleotide.jl
@@ -65,7 +65,7 @@ function k_nucleotide(infile="knucleotide-input.txt")
     for line in eachline(input)
         startswith(line, ">THREE ") && break
     end
-    data = collect(readstring(input))
+    data = collect(read(input, String))
     # delete the newlines and convert to upper case
     i, j = 1, 1
     while i <= length(data)

--- a/test/perf/shootout/regex_dna.jl
+++ b/test/perf/shootout/regex_dna.jl
@@ -33,7 +33,7 @@ const subs = [
 ]
 
 function regex_dna(infile="regexdna-input.txt")
-    seq = readstring(infile)
+    seq = read(infile, String)
     l1 = length(seq)
 
     seq = replace(seq, r">.*\n|\n", "")

--- a/test/perf/spell/perf.jl
+++ b/test/perf/spell/perf.jl
@@ -28,7 +28,7 @@ end
 if !isfile("big.txt")
     download("http://norvig.com/big.txt", "big.txt")
 end
-const NWORDS = train(words(readstring("big.txt")))
+const NWORDS = train(words(read("big.txt", String)))
 
 const alphabet = "abcdefghijklmnopqrstuvwxyz"
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -10,7 +10,7 @@ function capture_stdout(f::Function)
                     f()
                 end
             end
-            return readstring(fname)
+            return read(fname, String)
         finally
             rm(fname, force=true)
         end
@@ -69,7 +69,7 @@ temp_pkg_dir() do
     # (done here since it calls Pkg.status which might error or clone metadata)
     buf = PipeBuffer()
     versioninfo(buf, verbose=true)
-    ver = readstring(buf)
+    ver = read(buf, String)
     @test startswith(ver, "Julia Version $VERSION")
     @test contains(ver, "Environment:")
 
@@ -408,13 +408,13 @@ temp_pkg_dir() do
         touch(depsbuild)
         # Pkg.build works without the src directory now
         # but it's probably fine to require it.
-        msg = readstring(`$(Base.julia_cmd()) --startup-file=no -e 'redirect_stderr(STDOUT); Pkg.build("BuildFail")'`)
+        msg = read(`$(Base.julia_cmd()) --startup-file=no -e 'redirect_stderr(STDOUT); Pkg.build("BuildFail")'`, String)
         @test contains(msg, "Building BuildFail")
         @test !contains(msg, "ERROR")
         open(depsbuild, "w") do fd
             println(fd, "error(\"Throw build error\")")
         end
-        msg = readstring(`$(Base.julia_cmd()) --startup-file=no -e 'redirect_stderr(STDOUT); Pkg.build("BuildFail")'`)
+        msg = read(`$(Base.julia_cmd()) --startup-file=no -e 'redirect_stderr(STDOUT); Pkg.build("BuildFail")'`, String)
         @test contains(msg, "Building BuildFail")
         @test contains(msg, "ERROR")
         @test contains(msg, "Pkg.build(\"BuildFail\")")
@@ -425,7 +425,7 @@ temp_pkg_dir() do
     let package = "Example"
         Pkg.rm(package)  # Remove package if installed
         @test Pkg.installed(package) === nothing  # Registered with METADATA but not installed
-        msg = readstring(ignorestatus(`$(Base.julia_cmd()) --startup-file=no -e "redirect_stderr(STDOUT); Pkg.build(\"$package\")"`))
+        msg = read(ignorestatus(`$(Base.julia_cmd()) --startup-file=no -e "redirect_stderr(STDOUT); Pkg.build(\"$package\")"`), String)
         @test contains(msg, "$package is not an installed package")
         @test !contains(msg, "signal (15)")
     end
@@ -533,8 +533,8 @@ temp_pkg_dir() do
         end
 
         Pkg.add(package)
-        msg = readstring(ignorestatus(`$(Base.julia_cmd()) --startup-file=no -e
-            "redirect_stderr(STDOUT); using Example; Pkg.update(\"$package\")"`))
+        msg = read(ignorestatus(`$(Base.julia_cmd()) --startup-file=no -e
+            "redirect_stderr(STDOUT); using Example; Pkg.update(\"$package\")"`), String)
         @test contains(msg, "- $package\nRestart Julia to use the updated versions.")
     end
 
@@ -559,23 +559,23 @@ temp_pkg_dir() do
         withenv((Sys.iswindows() ? "USERPROFILE" : "HOME") => home) do
             code = "redirect_stderr(STDOUT); Pkg.build(\"$package\")"
 
-            msg = readstring(`$(Base.julia_cmd()) --startup-file=no -e $code`)
+            msg = read(`$(Base.julia_cmd()) --startup-file=no -e $code`, String)
             @test contains(msg, "INFO: JULIA_RC_LOADED defined false")
             @test contains(msg, "INFO: Main.JULIA_RC_LOADED defined false")
 
-            msg = readstring(`$(Base.julia_cmd()) --startup-file=yes -e $code`)
+            msg = read(`$(Base.julia_cmd()) --startup-file=yes -e $code`, String)
             @test contains(msg, "INFO: JULIA_RC_LOADED defined false")
             @test contains(msg, "INFO: Main.JULIA_RC_LOADED defined true")
 
             code = "redirect_stderr(STDOUT); Pkg.test(\"$package\")"
 
-            msg = readstring(`$(Base.julia_cmd()) --startup-file=no -e $code`)
+            msg = read(`$(Base.julia_cmd()) --startup-file=no -e $code`, String)
             @test contains(msg, "INFO: JULIA_RC_LOADED defined false")
             @test contains(msg, "INFO: Main.JULIA_RC_LOADED defined false")
 
             # Note: Since both the startup-file and "runtests.jl" are run in the Main
             # module any global variables created in the .juliarc.jl can be referenced.
-            msg = readstring(`$(Base.julia_cmd()) --startup-file=yes -e $code`)
+            msg = read(`$(Base.julia_cmd()) --startup-file=yes -e $code`, String)
             @test contains(msg, "INFO: JULIA_RC_LOADED defined true")
             @test contains(msg, "INFO: Main.JULIA_RC_LOADED defined true")
         end

--- a/test/read.jl
+++ b/test/read.jl
@@ -185,10 +185,10 @@ for (name, f) in l
     ]
         write(filename, text)
 
-        verbose && println("$name readstring...")
-        @test readstring(io()) == text
+        verbose && println("$name read(io, String)...")
+        @test read(io(), String) == text
 
-        @test readstring(io()) == readstring(filename)
+        @test read(io(), String) == read(filename, String)
 
 
         verbose && println("$name read...")
@@ -285,7 +285,7 @@ for (name, f) in l
             cleanup()
         end
         verbose && println("$name seekend...")
-        @test readstring(seekend(io())) == ""
+        @test read(seekend(io()), String) == ""
     end
 
 
@@ -293,11 +293,11 @@ for (name, f) in l
     to = open("$filename.to", "w")
     write(to, io())
     close(to)
-    @test readstring("$filename.to") == text
+    @test read("$filename.to", String) == text
 
     verbose && println("$name write(filename, ...)")
     write("$filename.to", io())
-    @test readstring("$filename.to") == text
+    @test read("$filename.to", String) == text
 
     verbose && println("$name write(::IOBuffer, ...)")
     to = IOBuffer(copy(Vector{UInt8}(text)), false, true)
@@ -432,8 +432,8 @@ for i = 1:2
     @test !eof(f2)
     @test position(f1) == 0
     @test position(f2) == 0
-    @test readstring(f1) == readstring(f2) == "abc"
-    @test readstring(f1) == readstring(f2) == ""
+    @test read(f1, String) == read(f2, String) == "abc"
+    @test read(f1, String) == read(f2, String) == ""
     @test position(f1) == 3
     @test position(f2) == 3
     @test eof(f1)
@@ -486,7 +486,7 @@ f2 = Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
 @test !eof(f1)
 @test seekstart(f1) == f1
 @test seekstart(f2) == f2
-@test readstring(f1) == readstring(f2) == "abc\0\0\0\0\0\0\0**"
+@test read(f1, String) == read(f2, String) == "abc\0\0\0\0\0\0\0**"
 close(f1)
 close(f2)
 rm(f)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -29,7 +29,7 @@ match(pat, target)
 # Issue 9545 (32 bit)
 buf = PipeBuffer()
 show(buf, r"")
-@test readstring(buf) == "r\"\""
+@test read(buf, String) == "r\"\""
 
 # see #10994, #11447: PCRE2 allows NUL chars in the pattern
 @test ismatch(Regex("^a\0b\$"), "a\0b")

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -136,7 +136,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
                 @test contains(s, "echo \$123 >$tmp") # make sure we echoed the input
             end
             @test readuntil(stdout_read, "\n") == "\e[0m\n"
-            @test readstring(tmp) == "123\n"
+            @test read(tmp, String) == "123\n"
         finally
             rm(tmp, force=true)
         end
@@ -209,7 +209,7 @@ end
 function buffercontents(buf::IOBuffer)
     p = position(buf)
     seek(buf,0)
-    c = readstring(buf)
+    c = read(buf, String)
     seek(buf,p)
     c
 end
@@ -603,7 +603,7 @@ end
 if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     outs, ins, p = readandwrite(`$exename --startup-file=no --quiet`)
     write(ins,"1\nquit()\n")
-    @test readstring(outs) == "1\n"
+    @test read(outs, String) == "1\n"
 end
 end # let exename
 
@@ -751,7 +751,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
             @test isempty(search(output, "julia> "))
 
             # Check the history file
-            history = readstring(histfile)
+            history = read(histfile, String)
             @test ismatch(r"""
                           ^\#\ time:\ .*\n
                            \#\ mode:\ julia\n

--- a/test/show.jl
+++ b/test/show.jl
@@ -367,10 +367,10 @@ let oldout = STDOUT, olderr = STDERR
         # pr 16917
         rdout, wrout = redirect_stdout()
         @test wrout === STDOUT
-        out = @async readstring(rdout)
+        out = @async read(rdout, String)
         rderr, wrerr = redirect_stderr()
         @test wrerr === STDERR
-        err = @async readstring(rderr)
+        err = @async read(rderr, String)
         @test dump(Int64) === nothing
         if !Sys.iswindows()
             close(wrout)
@@ -409,7 +409,7 @@ let filename = tempname()
         end
     end
     @test ret == [1,3]
-    @test chomp(readstring(filename)) == "hello"
+    @test chomp(read(filename, String)) == "hello"
     ret = open(filename, "w") do f
         redirect_stderr(f) do
             warn("hello")
@@ -419,7 +419,7 @@ let filename = tempname()
     @test ret == [2]
 
     # STDIN is unavailable on the workers. Run test on master.
-    @test contains(readstring(filename), "WARNING: hello")
+    @test contains(read(filename, String), "WARNING: hello")
     ret = eval(Main, quote
         remotecall_fetch(1, $filename) do fname
             open(fname) do f
@@ -757,7 +757,7 @@ function static_shown(x)
     Base.link_pipe(p; julia_only_read=true, julia_only_write=true)
     ccall(:jl_static_show, Void, (Ptr{Void}, Any), p.in, x)
     @async close(p.in)
-    return readstring(p.out)
+    return read(p.out, String)
 end
 
 # Test for PR 17803
@@ -782,7 +782,7 @@ let fname = tempname()
                 @show zeros(2, 2)
             end
         end
-        @test readstring(fname) == "zeros(2, 2) = 2×2 Array{Float64,2}:\n 0.0  0.0\n 0.0  0.0\n"
+        @test read(fname, String) == "zeros(2, 2) = 2×2 Array{Float64,2}:\n 0.0  0.0\n 0.0  0.0\n"
     finally
         rm(fname, force=true)
     end

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -89,7 +89,7 @@ for testport in [0, defaultport]
         close(sock)
     end
     wait(port)
-    @test readstring(connect(fetch(port))) == "Hello World\n" * ("a1\n"^100)
+    @test read(connect(fetch(port)), String) == "Hello World\n" * ("a1\n"^100)
     wait(tsk)
 end
 
@@ -105,7 +105,7 @@ mktempdir() do tmpdir
         close(sock)
     end
     wait(c)
-    @test readstring(connect(socketname)) == "Hello World\n"
+    @test read(connect(socketname), String) == "Hello World\n"
     wait(tsk)
 end
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -384,7 +384,7 @@ end
 
 # make sure windows_verbatim strips quotes
 if Sys.iswindows()
-    read(`cmd.exe /c dir /b spawn.jl`, String) == readstring(Cmd(`cmd.exe /c dir /b "\"spawn.jl\""`, windows_verbatim=true))
+    read(`cmd.exe /c dir /b spawn.jl`, String) == read(Cmd(`cmd.exe /c dir /b "\"spawn.jl\""`, windows_verbatim=true), String)
 end
 
 # make sure Cmd is nestable

--- a/test/test.jl
+++ b/test/test.jl
@@ -542,7 +542,7 @@ let io = IOBuffer()
     @test !contains(str, "backtrace()")
 end
 
-msg = readstring(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
+msg = read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
 using Base.Test
 
 foo(x) = length(x)^2
@@ -560,7 +560,7 @@ foo(x) = length(x)^2
         @test foo(zeros(2)) == 4
         @test foo(ones(4)) == 15
     end
-end'`), stderr=DevNull))
+end'`), stderr=DevNull), String)
 
 @test contains(msg,
 """
@@ -573,7 +573,7 @@ Foo Tests     |    2     2      4
 """)
 
 # 20489
-msg = split(readstring(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
-Test.print_test_results(Test.DefaultTestSet(""))'`), stderr=DevNull)), "\n")[1]
+msg = split(read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --color=no -e '
+Test.print_test_results(Test.DefaultTestSet(""))'`), stderr=DevNull), String), "\n")[1]
 
 @test msg == rstrip(msg)


### PR DESCRIPTION
Here is a a pull request for Deprecating `readstring` in favor of `read(io, String)` closes #22793.
