### PR TITLE
Better representations of expressions

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -180,6 +180,16 @@ end
 show(io::IO, z::Complex{Bool}) =
     print(io, z == im ? "im" : "Complex($(z.re),$(z.im))")
 
+function show_unquoted(io::IO, z::Complex, ::Int, prec::Int)
+    if operator_precedence(:+) <= prec
+        print(io, "(")
+        show(io, z)
+        print(io, ")")
+    else
+        show(io, z)
+    end
+end
+
 function read(s::IO, ::Type{Complex{T}}) where T<:Real
     r = read(s,T)
     i = read(s,T)

--- a/base/show.jl
+++ b/base/show.jl
@@ -803,9 +803,10 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
                     all(!isa(a, Expr) || a.head !== :... for a in func_args)
                 sep = " $func "
                 # parenthesize (-x) ^ y for negative x
-                if func == :^ && ((func_args[1] isa Expr && func_args[1].head === :call &&
-                                   func_args[1].args[1] === :-) ||
-                                  (func_args[1] isa Real && func_args[1] < 0))
+                if (operator_precedence(func) == operator_precedence(:^) &&
+                    ((func_args[1] isa Expr && func_args[1].head === :call &&
+                      func_args[1].args[1] in uni_ops) ||
+                     (func_args[1] isa Real && func_args[1] < 0)))
                     encl_inds = [1]
                 else
                     encl_inds = []

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1262,6 +1262,7 @@ representation](@ref)) which takes the square of a specific instance of our `Pol
 julia> a = Polar(3, 4.0)
 Polar{Float64} complex number:
    3.0 * exp(4.0im)
+
 julia> print(:($a^2))
 3.0 * exp(4.0im) ^ 2
 ```
@@ -1282,6 +1283,7 @@ julia> function Base.show_unquoted(io::IO, z::Polar, ::Int, precedence::Int)
                show(io, z)
            end
        end
+
 julia> :($a^2)
 :((3.0 * exp(4.0im)) ^ 2)
 ```

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1267,7 +1267,7 @@ julia> print(:($a^2))
 ```
 
 Because the operator `^` has higher precedence than `*` (see [Operator Precedence](@ref)), this
-representation does not faithfully represent the expression `a ^ 2` which should be equal to `(3.0 *
+output does not faithfully represent the expression `a ^ 2` which should be equal to `(3.0 *
 exp(4.0im)) ^ 2`.  To solve this issue, we must make a custom method for `Base.show_unquoted(io::IO,
 z::Polar, indent::Int, precedence::Int)`, which is called internally by the expression object when
 printing:

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1252,6 +1252,53 @@ julia> show(STDOUT, "text/html", Polar(3.0,4.0))
 <p>An HTML renderer would display this as: <code>Polar{Float64}</code> complex number: 3.0 <i>e</i><sup>4.0 <i>i</i></sup></p>
 ```
 
+As a rule of thumb, the single-line `show` method should print a valid Julia expression for creating
+the shown object.  When this `show` method contains infix operators, such as the multiplication
+operator (`*`) in our single-line `show` method for `Polar` above, it may not parse correctly when
+printed as part of another object.  To see this, consider the expression object (see [Program
+representation](@ref)) which takes the square of a specific instance of our `Polar` type:
+
+```jldoctest polartype
+julia> a = Polar(3, 4.0)
+Polar{Float64} complex number:
+   3.0 * exp(4.0im)
+julia> print(:($a^2))
+3.0 * exp(4.0im) ^ 2
+```
+
+Because the operator `^` has higher precedence than `*` (see [Operator Precedence](@ref)), this
+representation does not faithfully represent the expression `a ^ 2` which should be equal to `(3.0 *
+exp(4.0im)) ^ 2`.  To solve this issue, we must make a custom method for `Base.show_unquoted(io::IO,
+z::Polar, indent::Int, precedence::Int)`, which is called internally by the expression object when
+printing:
+
+```jldoctest polartype
+julia> function Base.show_unquoted(io::IO, z::Polar, ::Int, precedence::Int)
+           if Base.operator_precedence(:*) <= precedence
+               print(io, "(")
+               show(io, z)
+               print(io, ")")
+           else
+               show(io, z)
+           end
+       end
+julia> :($a^2)
+:((3.0 * exp(4.0im)) ^ 2)
+```
+
+The method defined above adds parentheses around the call to `show` when the precedence of the
+calling operator is higher than or equal to the precedence of multiplication.  This check allows
+expressions which parse correctly without the parentheses (such as `:($a + 2)` and `:($a == 2)`) to
+omit them when printing:
+
+```jldoctest polartype
+julia> :($a + 2)
+:(3.0 * exp(4.0im) + 2)
+
+julia> :($a == 2)
+:(3.0 * exp(4.0im) == 2)
+```
+
 ## "Value types"
 
 In Julia, you can't dispatch on a *value* such as `true` or `false`. However, you can dispatch

--- a/test/show.jl
+++ b/test/show.jl
@@ -94,10 +94,13 @@ end
 @test_repr "(a / b) / (c / d / e)"
 @test_repr "(a == b == c) != (c == d < e)"
 
-# Exponentiation of negative numbers or negated symbols
-@test_repr "(-1)^-1"
+# Exponentiation (operator_precedence(:^)) and unary operators
+@test_repr "(-1)^a"
 @test_repr "(-2.1)^-1"
+@test_repr "(-x)^a"
 @test_repr "(-a)^-1"
+@test_repr "(!x)↑!a"
+
 
 # control structures (shamelessly stolen from base/bitarray.jl)
 @test_repr """mutable struct BitArray{N} <: AbstractArray{Bool, N}

--- a/test/show.jl
+++ b/test/show.jl
@@ -94,6 +94,11 @@ end
 @test_repr "(a / b) / (c / d / e)"
 @test_repr "(a == b == c) != (c == d < e)"
 
+# Exponentiation of negative numbers or negated symbols
+@test_repr "(-1)^-1"
+@test_repr "(-2.1)^-1"
+@test_repr "(-a)^-1"
+
 # control structures (shamelessly stolen from base/bitarray.jl)
 @test_repr """mutable struct BitArray{N} <: AbstractArray{Bool, N}
     # line meta

--- a/test/show.jl
+++ b/test/show.jl
@@ -105,6 +105,7 @@ end
 
 # Complex
 
+# parse(repr(:(...))) returns a double-quoted block, so we need to eval twice to unquote it
 @test iszero(eval(eval(parse(repr(:($(1 + 2im) - $(1 + 2im)))))))
 
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -94,12 +94,18 @@ end
 @test_repr "(a / b) / (c / d / e)"
 @test_repr "(a == b == c) != (c == d < e)"
 
-# Exponentiation (operator_precedence(:^)) and unary operators
+# Exponentiation (>= operator_precedence(:^)) and unary operators
 @test_repr "(-1)^a"
 @test_repr "(-2.1)^-1"
 @test_repr "(-x)^a"
 @test_repr "(-a)^-1"
 @test_repr "(!x)↑!a"
+@test_repr "(!x).a"
+@test_repr "(!x)::a"
+
+# Complex
+
+@test iszero(eval(eval(parse(repr(:($(1 + 2im) - $(1 + 2im)))))))
 
 
 # control structures (shamelessly stolen from base/bitarray.jl)


### PR DESCRIPTION
This supersedes https://github.com/JuliaLang/julia/pull/22839

There were also problems with representing `(-a).b`, `(-a)::b`, etc. Should be fixed by this PR.  I also added info to the manual on how to make sure that custom types print correctly inside expressions.