### PR TITLE
fix #22868, parse errors for `x@time` and `@ time`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,10 @@ This section lists changes that do not have deprecation warnings.
   * The `Diagonal` type definition has changed from `Diagonal{T}` to
     `Diagonal{T,V<:AbstractVector{T}}` ([#22718]).
 
+  * Spaces are no longer allowed between `@` and the name of a macro in a macro call ([#22868]).
+
+  * Juxtaposition of a non-literal with a macro call (`x@macro`) is no longer valid syntax ([#22868]).
+
 Library improvements
 --------------------
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -975,7 +975,8 @@
 (define (juxtapose? s expr t)
   (and (or (number? expr)
            (large-number? expr)
-           (not (number? t))    ;; disallow "x.3" and "sqrt(2)2"
+           (and (not (number? t))    ;; disallow "x.3" and "sqrt(2)2"
+                (not (eqv? t #\@)))  ;; disallow "x@time"
            ;; to allow x'y as a special case
            #;(and (pair? expr) (memq (car expr) '(|'| |.'|))
                 (not (memv t '(#\( #\[ #\{))))
@@ -2160,6 +2161,9 @@
           ;; macro call
           ((eqv? t #\@)
            (take-token s)
+           (let ((nxt (peek-token s)))
+             (if (ts:space? s)
+                 (disallowed-space '@ nxt)))
            (with-space-sensitive
             (let ((startloc  (line-number-node s))
                   (head (if (eq? (peek-token s) '|.|)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1247,3 +1247,7 @@ end === (3, String)
 
 # issue #22840
 @test parse("[:a :b]") == Expr(:hcat, QuoteNode(:a), QuoteNode(:b))
+
+# issue #22868
+@test_throws ParseError parse("x@time 2")
+@test_throws ParseError parse("@ time")


### PR DESCRIPTION
I think allowing these was just a bug; seems ok to me to make it an error.