### PR TITLE
NEWS: doc removal of include_from_node1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,11 @@ This section lists changes that do not have deprecation warnings.
 
   * Juxtaposition of a non-literal with a macro call (`x@macro`) is no longer valid syntax ([#22868]).
 
+  * On a cluster, all files are now loaded from the local file system rather than node 1 ([#22588]).
+    To load the same file everywhere from node 1, one possible alternative is to broadcast a call to `include_string`:
+    `@everywhere include_string(Main, $(read("filename", String)), "filename")`.
+    Improving upon this API is left as an opportunity for packages.
+
 Library improvements
 --------------------
 

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -344,7 +344,7 @@ The function `count_heads` simply adds together `n` random bits. Here is how we 
 trials on two machines, and add together the results:
 
 ```julia-repl
-julia> @everywhere include("count_heads.jl")
+julia> @everywhere include_string(Main, $(read("count_heads.jl", String)), "count_heads.jl")
 
 julia> a = @spawn count_heads(100000000)
 Future(2, 1, 6, Nullable{Any}())


### PR DESCRIPTION
NEWS and doc updates for PR #22588. I couldn't find many places in the docs that talked about `include_from_node1` behavior existing, so let me know if you know of or find any others.