### PR TITLE
respecialize normalized vararg type parameters as part of precise_container_type

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -4992,7 +4992,11 @@ function inlining_pass(e::Expr, sv::InferenceState, stmts, ins)
                         tmpv = newvar!(sv, t)
                         push!(newstmts, Expr(:(=), tmpv, aarg))
                     end
-                    tp = t.parameters
+                    if isa(aarg, Slot) && slot_id(aarg) == sv.nargs && isa(sv.vararg_type_container, DataType)
+                        tp = sv.vararg_type_container.parameters
+                    else
+                        tp = t.parameters
+                    end
                     newargs[i-2] = Any[ mk_getfield(tmpv,j,tp[j]) for j=1:length(tp) ]
                 else
                     # not all args expandable

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -922,6 +922,14 @@ let niter = 0
     @test niter == 4
 end
 
+# issue #22875
+
+typeargs = (Type{Int},)
+@test Base.Core.Inference.return_type((args...) -> one(args...), typeargs) === Int
+
+typeargs = (Type{Int},Type{Int},Type{Int},Type{Int},Type{Int},Type{Int})
+@test Base.Core.Inference.return_type(promote_type, typeargs) === Type{Int}
+
 # demonstrate that inference must converge
 # while doing constant propagation
 Base.@pure plus1(x) = x + 1


### PR DESCRIPTION
Fix #22875:

```julia
julia> @inline g(args...) = one(args...)
g (generic function with 1 method)

julia> f(args...) = g(args...)
f (generic function with 1 method)

# this previously inferred as Any
julia> @code_warntype f(Int)
Variables:
  #self#::#f
  args::Any

Body:
  begin
      return 1
  end::Int64

# this was also previously inferred as Any
julia> @code_warntype Base.promote_type(Int, Float64, Int, Int, Int, Int)
Variables:
  #self#::Base.#promote_type
  T::Any
  S::Any
  U::Any
  V::Any

Body:
  begin
      return Float64
  end::Type{Float64}
```

This still needs tests, which I'll get to tomorrow (or after dinner, if I'm feeling plucky).

Many thanks to @vtjnash for once again guiding me through the dark waters of inference.

