### PR TITLE
inv of Symmetric/Hermitian with more eltypes than BlasFloat

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -364,8 +364,8 @@ function _inv(A::HermOrSym)
     end
     B
 end
-inv(A::Hermitian{T,S}) where {T<:BlasFloat,S<:StridedMatrix} = Hermitian{T,S}(_inv(A), A.uplo)
-inv(A::Symmetric{T,S}) where {T<:BlasFloat,S<:StridedMatrix} = Symmetric{T,S}(_inv(A), A.uplo)
+inv(A::Hermitian{<:Any,<:StridedMatrix}) = Hermitian(_inv(A), Symbol(A.uplo))
+inv(A::Symmetric{<:Any,<:StridedMatrix}) = Symmetric(_inv(A), Symbol(A.uplo))
 
 eigfact!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}) = Eigen(LAPACK.syevr!('V', 'A', A.uplo, A.data, 0.0, 0.0, 0, 0, -1.0)...)
 

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -176,6 +176,17 @@ end
                 end
             end
 
+            @testset "inversion" begin
+                for uplo in (:U, :L)
+                    @test inv(Symmetric(asym, uplo))::Symmetric ≈ inv(asym)
+                    @test inv(Hermitian(aherm, uplo))::Hermitian ≈ inv(aherm)
+                    @test inv(Symmetric(a, uplo))::Symmetric ≈ inv(Matrix(Symmetric(a, uplo)))
+                    if eltya <: Real
+                        @test inv(Hermitian(a, uplo))::Hermitian ≈ inv(Matrix(Hermitian(a, uplo)))
+                    end
+                end
+            end
+
             # Revisit when implemented in julia
             if eltya != BigFloat
                 @testset "cond" begin
@@ -183,19 +194,6 @@ end
                         @test cond(Symmetric(asym)) ≈ cond(asym)
                     end
                     @test cond(Hermitian(aherm)) ≈ cond(aherm)
-                end
-
-                @testset "inversion" begin
-                    @test inv(Symmetric(asym)) ≈ inv(asym)
-                    @test inv(Hermitian(aherm)) ≈ inv(aherm)
-                    for uplo in (:U, :L)
-                        @test inv(Symmetric(asym, uplo)) ≈ inv(full(Symmetric(asym, uplo)))
-                        @test inv(Hermitian(aherm, uplo)) ≈ inv(full(Hermitian(aherm, uplo)))
-                        @test inv(Symmetric(a, uplo)) ≈ inv(full(Symmetric(a, uplo)))
-                        if eltya <: Real
-                            @test inv(Hermitian(a, uplo)) ≈ inv(full(Hermitian(a, uplo)))
-                        end
-                    end
                 end
 
                 @testset "symmetric eigendecomposition" begin


### PR DESCRIPTION
#22686 and #22767 implemented the infrastructure to invert `Symmetric` / `Hermitian` matrices with any element type that supports LU factorization (and backsolve). The relaxations here are necessary as well. For instance, before this `inv(::Symmetric{Int})` returned a `Matrix` rather than `Symmetric` and `inv(::Symmetric{Int})` `MethodError`d.