### PR TITLE
specify alignment for printing Pair in arrays

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1384,9 +1384,13 @@ function alignment(io::IO, x::Rational)
 end
 
 function alignment(io::IO, x::Pair)
-    m = match(r"^(.*?=)(>.*)$", sprint(0, show, x, env=io))
-    m === nothing ? (length(sprint(0, show, x, env=io)), 0) :
-                    (length(m.captures[1]), length(m.captures[2]))
+    s = sprint(0, show, x, env=io)
+    if has_tight_type(x) # i.e. use "=>" for display
+        left = length(sprint(0, show, x.first, env=io)) + 2isa(x.first, Pair) # 2 for parens
+        (left+1, length(s)-left-1) # +1 for the "=" part of "=>"
+    else
+        (0, length(s)) # as for x::Any
+    end
 end
 
 const undef_ref_str = "#undef"

--- a/base/show.jl
+++ b/base/show.jl
@@ -1383,6 +1383,12 @@ function alignment(io::IO, x::Rational)
                    (length(m.captures[1]), length(m.captures[2]))
 end
 
+function alignment(io::IO, x::Pair)
+    m = match(r"^(.*?=)(>.*)$", sprint(0, show, x, env=io))
+    m === nothing ? (length(sprint(0, show, x, env=io)), 0) :
+                    (length(m.captures[1]), length(m.captures[2]))
+end
+
 const undef_ref_str = "#undef"
 const undef_ref_alignment = (3,3)
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -830,13 +830,13 @@ end
 end
 
 @testset "alignment for pairs" begin  # (#22899)
-    @test replstr([1=>22,33=>4]) == "2-element Array{Pair{Int64,Int64},1}:\n  1=>22\n 33=>4 "
+    @test replstr([1=>22,33=>4]) == "2-element Array{Pair{$Int,$Int},1}:\n  1=>22\n 33=>4 "
     # first field may have "=>" in its representation
     @test replstr(Pair[(1=>2)=>3, 4=>5]) ==
         "2-element Array{Pair,1}:\n (1=>2)=>3\n      4=>5"
     @test replstr(Any[Dict(1=>2)=> (3=>4), 1=>2]) ==
         "2-element Array{Any,1}:\n Dict(1=>2)=>(3=>4)\n          1=>2     "
     # left-alignment when not using the "=>" symbol
-    @test replstr(Pair{Integer,Int}[1=>2, 33=>4]) ==
+    @test replstr(Pair{Integer,Int64}[1=>2, 33=>4]) ==
         "2-element Array{Pair{Integer,Int64},1}:\n Pair{Integer,Int64}(1, 2) \n Pair{Integer,Int64}(33, 4)"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -828,3 +828,15 @@ end
     show(IOContext(s, :compact => false), (1=>2) => Pair{Any,Any}(3,4))
     @test String(take!(s)) == "(1 => 2) => Pair{Any,Any}(3, 4)"
 end
+
+@testset "alignment for pairs" begin  # (#22899)
+    @test replstr([1=>22,33=>4]) == "2-element Array{Pair{Int64,Int64},1}:\n  1=>22\n 33=>4 "
+    # first field may have "=>" in its representation
+    @test replstr(Pair[(1=>2)=>3, 4=>5]) ==
+        "2-element Array{Pair,1}:\n (1=>2)=>3\n      4=>5"
+    @test replstr(Any[Dict(1=>2)=> (3=>4), 1=>2]) ==
+        "2-element Array{Any,1}:\n Dict(1=>2)=>(3=>4)\n          1=>2     "
+    # left-alignment when not using the "=>" symbol
+    @test replstr(Pair{Integer,Int}[1=>2, 33=>4]) ==
+        "2-element Array{Pair{Integer,Int64},1}:\n Pair{Integer,Int64}(1, 2) \n Pair{Integer,Int64}(33, 4)"
+end


### PR DESCRIPTION
Before:
```
julia> [1=>22, 33=>4]
2-element Array{Pair{Int64,Int64},1}:
 1=>22
 33=>4
```
After:
```
julia> [1=>22, 33=>4]
2-element Array{Pair{Int64,Int64},1}:
  1=>22
 33=>4
```