### PR TITLE
RFC: make indexable collection API more uniform (keys, values, pairs)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -194,6 +194,10 @@ This section lists changes that do not have deprecation warnings.
     This avoids stack overflows in the common case of definitions like
     `f(x, y) = f(promote(x, y)...)` ([#22801]).
 
+  * `findmin`, `findmax`, `indmin`, and `indmax` used to always return linear indices.
+    They now return `CartesianIndex`es for all but 1-d arrays, and in general return
+    the `keys` of indexed collections (e.g. dictionaries) ([#22907]).
+
 Library improvements
 --------------------
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -69,9 +69,9 @@ function indices(A)
     map(OneTo, size(A))
 end
 
-# Performance optimization: get rid of a branch on `d` in `indices(A,
-# d)` for d=1. 1d arrays are heavily used, and the first dimension
-# comes up in other applications.
+# Performance optimization: get rid of a branch on `d` in `indices(A, d)`
+# for d=1. 1d arrays are heavily used, and the first dimension comes up
+# in other applications.
 indices1(A::AbstractArray{<:Any,0}) = OneTo(1)
 indices1(A::AbstractArray) = (@_inline_meta; indices(A)[1])
 indices1(iter) = OneTo(length(iter))
@@ -103,6 +103,10 @@ julia> extrema(b)
 """
 linearindices(A) = (@_inline_meta; OneTo(_length(A)))
 linearindices(A::AbstractVector) = (@_inline_meta; indices1(A))
+
+keys(a::AbstractArray) = CartesianRange(indices(a))
+keys(a::AbstractVector) = linearindices(a)
+
 eltype(::Type{<:AbstractArray{E}}) where {E} = E
 elsize(::AbstractArray{T}) where {T} = sizeof(T)
 
@@ -756,8 +760,11 @@ start(A::AbstractArray) = (@_inline_meta; itr = eachindex(A); (itr, start(itr)))
 next(A::AbstractArray, i) = (@_propagate_inbounds_meta; (idx, s) = next(i[1], i[2]); (A[idx], (i[1], s)))
 done(A::AbstractArray, i) = (@_propagate_inbounds_meta; done(i[1], i[2]))
 
+# `eachindex` is mostly an optimization of `keys`
+eachindex(itrs...) = keys(itrs...)
+
 # eachindex iterates over all indices. IndexCartesian definitions are later.
-eachindex(A::Union{Number,AbstractVector}) = (@_inline_meta(); indices1(A))
+eachindex(A::AbstractVector) = (@_inline_meta(); indices1(A))
 
 """
     eachindex(A...)
@@ -825,6 +832,9 @@ function _maxlength(A, B, C...)
 end
 
 isempty(a::AbstractArray) = (_length(a) == 0)
+
+# keys with an IndexStyle
+keys(s::IndexStyle, A::AbstractArray, B::AbstractArray...) = eachindex(s, A, B...)
 
 ## Conversions ##
 
@@ -1739,7 +1749,7 @@ _sub2ind_vec(i) = ()
 function ind2sub(inds::Union{DimsInteger{N},Indices{N}}, ind::AbstractVector{<:Integer}) where N
     M = length(ind)
     t = ntuple(n->similar(ind),Val(N))
-    for (i,idx) in enumerate(IndexLinear(), ind)
+    for (i,idx) in pairs(IndexLinear(), ind)
         sub = ind2sub(inds, idx)
         for j = 1:N
             t[j][i] = sub[j]

--- a/base/array.jl
+++ b/base/array.jl
@@ -2072,13 +2072,13 @@ function findmax(a)
     if isempty(a)
         throw(ArgumentError("collection must be non-empty"))
     end
-    s = start(a)
-    mi = i = 1
-    m, s = next(a, s)
-    while !done(a, s)
+    p = pairs(a)
+    s = start(p)
+    (mi, m), s = next(p, s)
+    i = mi
+    while !done(p, s)
         m != m && break
-        ai, s = next(a, s)
-        i += 1
+        (i, ai), s = next(p, s)
         if ai != ai || isless(m, ai)
             m = ai
             mi = i
@@ -2113,13 +2113,13 @@ function findmin(a)
     if isempty(a)
         throw(ArgumentError("collection must be non-empty"))
     end
-    s = start(a)
-    mi = i = 1
-    m, s = next(a, s)
-    while !done(a, s)
+    p = pairs(a)
+    s = start(p)
+    (mi, m), s = next(p, s)
+    i = mi
+    while !done(p, s)
         m != m && break
-        ai, s = next(a, s)
-        i += 1
+        (i, ai), s = next(p, s)
         if ai != ai || isless(ai, m)
             m = ai
             mi = i

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -69,11 +69,18 @@ end
 
 in(k, v::KeyIterator) = get(v.dict, k, secret_table_token) !== secret_table_token
 
+"""
+    keys(iterator)
+
+For an iterator or collection that has keys and values (e.g. arrays and dictionaries),
+return an iterator over the keys.
+"""
+function keys end
 
 """
     keys(a::Associative)
 
-Return an iterator over all keys in a collection.
+Return an iterator over all keys in an associative collection.
 `collect(keys(a))` returns an array of keys.
 Since the keys are stored internally in a hash table,
 the order in which they are returned may vary.
@@ -94,7 +101,6 @@ julia> collect(keys(a))
 ```
 """
 keys(a::Associative) = KeyIterator(a)
-eachindex(a::Associative) = KeyIterator(a)
 
 """
     values(a::Associative)
@@ -120,6 +126,15 @@ julia> collect(values(a))
 ```
 """
 values(a::Associative) = ValueIterator(a)
+
+"""
+    pairs(collection)
+
+Return an iterator over `key => value` pairs for any
+collection that maps a set of keys to a set of values.
+This includes arrays, where the keys are the array indices.
+"""
+pairs(collection) = Generator(=>, keys(collection), values(collection))
 
 function copy(a::Associative)
     b = similar(a)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1733,6 +1733,11 @@ end
 
 @deprecate promote_noncircular promote false
 
+import .Iterators.enumerate
+
+@deprecate enumerate(i::IndexLinear,    A::AbstractArray)  pairs(i, A)
+@deprecate enumerate(i::IndexCartesian, A::AbstractArray)  pairs(i, A)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -676,3 +676,13 @@ false
 ```
 """
 isempty(itr) = done(itr, start(itr))
+
+"""
+    values(iterator)
+
+For an iterator or collection that has keys and values, return an iterator
+over the values.
+This function simply returns its argument by default, since the elements
+of a general iterator are normally considered its "values".
+"""
+values(itr) = itr

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -688,6 +688,7 @@ export
     mapreducedim,
     merge!,
     merge,
+    pairs,
     #pop!,
     #push!,
     reduce,

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -4,7 +4,7 @@
 module IteratorsMD
     import Base: eltype, length, size, start, done, next, first, last, in, getindex,
                  setindex!, IndexStyle, min, max, zero, one, isless, eachindex,
-                 ndims, iteratorsize, convert
+                 ndims, iteratorsize, convert, show
 
     import Base: +, -, *
     import Base: simd_outer_range, simd_inner_length, simd_index
@@ -80,6 +80,7 @@ module IteratorsMD
     @inline _flatten(i, I...)                 = (i, _flatten(I...)...)
     @inline _flatten(i::CartesianIndex, I...) = (i.I..., _flatten(I...)...)
     CartesianIndex(index::Tuple{Vararg{Union{Integer, CartesianIndex}}}) = CartesianIndex(index...)
+    show(io::IO, i::CartesianIndex) = (print(io, "CartesianIndex"); show(io, i.I))
 
     # length
     length(::CartesianIndex{N}) where {N} = N

--- a/base/number.jl
+++ b/base/number.jl
@@ -49,6 +49,7 @@ ndims(::Type{<:Number}) = 0
 length(x::Number) = 1
 endof(x::Number) = 1
 iteratorsize(::Type{<:Number}) = HasShape()
+keys(::Number) = OneTo(1)
 
 getindex(x::Number) = x
 function getindex(x::Number, i::Integer)

--- a/base/process.jl
+++ b/base/process.jl
@@ -822,7 +822,7 @@ wait(x::ProcessChain) = for p in x.processes; wait(p); end
 show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")
 
 # allow the elements of the Cmd to be accessed as an array or iterator
-for f in (:length, :endof, :start, :eachindex, :eltype, :first, :last)
+for f in (:length, :endof, :start, :keys, :eltype, :first, :last)
     @eval $f(cmd::Cmd) = $f(cmd.exec)
 end
 for f in (:next, :done, :getindex)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -316,7 +316,7 @@ unsafe_chr2ind(s::AbstractString, i::Integer) = map_chr_ind(s, i, first, last)
 struct EachStringIndex{T<:AbstractString}
     s::T
 end
-eachindex(s::AbstractString) = EachStringIndex(s)
+keys(s::AbstractString) = EachStringIndex(s)
 
 length(e::EachStringIndex) = length(e.s)
 start(e::EachStringIndex) = start(e.s)

--- a/base/test.jl
+++ b/base/test.jl
@@ -1415,7 +1415,7 @@ end
 GenericArray{T}(args...) where {T} = GenericArray(Array{T}(args...))
 GenericArray{T,N}(args...) where {T,N} = GenericArray(Array{T,N}(args...))
 
-Base.eachindex(a::GenericArray) = eachindex(a.a)
+Base.keys(a::GenericArray) = keys(a.a)
 Base.indices(a::GenericArray) = indices(a.a)
 Base.length(a::GenericArray) = length(a.a)
 Base.size(a::GenericArray) = size(a.a)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -38,9 +38,9 @@ start(t::Tuple) = 1
 done(t::Tuple, i::Int) = (length(t) < i)
 next(t::Tuple, i::Int) = (t[i], i+1)
 
-eachindex(t::Tuple) = 1:length(t)
+keys(t::Tuple) = 1:length(t)
 
-function eachindex(t::Tuple, t2::Tuple...)
+function keys(t::Tuple, t2::Tuple...)
     @_inline_meta
     1:_maxlength(t, t2...)
 end

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -196,6 +196,7 @@ Base.delete!
 Base.pop!(::Any, ::Any, ::Any)
 Base.keys
 Base.values
+Base.pairs
 Base.merge
 Base.merge!(::Associative, ::Associative...)
 Base.merge!(::Function, ::Associative, ::Associative...)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -835,3 +835,12 @@ end
 @testset "checkbounds_indices method ambiguities #20989" begin
     @test Base.checkbounds_indices(Bool, (1:1,), ([CartesianIndex(1)],))
 end
+
+# keys, values, pairs
+for A in (rand(2), rand(2,3))
+    local A
+    for (i, v) in pairs(A)
+        @test A[i] == v
+    end
+    @test collect(values(A)) == collect(A)
+end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1214,10 +1214,10 @@ end
 @testset "eachindexvalue" begin
     A14 = [11 13; 12 14]
     R = CartesianRange(indices(A14))
-    @test [a for (a,b) in enumerate(IndexLinear(),    A14)] == [1,2,3,4]
-    @test [a for (a,b) in enumerate(IndexCartesian(), A14)] == vec(collect(R))
-    @test [b for (a,b) in enumerate(IndexLinear(),    A14)] == [11,12,13,14]
-    @test [b for (a,b) in enumerate(IndexCartesian(), A14)] == [11,12,13,14]
+    @test [a for (a,b) in pairs(IndexLinear(),    A14)] == [1,2,3,4]
+    @test [a for (a,b) in pairs(IndexCartesian(), A14)] == vec(collect(R))
+    @test [b for (a,b) in pairs(IndexLinear(),    A14)] == [11,12,13,14]
+    @test [b for (a,b) in pairs(IndexCartesian(), A14)] == [11,12,13,14]
 end
 
 @testset "reverse" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -503,7 +503,7 @@ end
     @test indmin(5:-2:1) == 3
 
     #23094
-    @test findmax(Set(["abc"])) === ("abc", 1)
+    @test_throws MethodError findmax(Set(["abc"]))
     @test findmin(["abc", "a"]) === ("a", 2)
     @test_throws MethodError findmax([Set([1]), Set([2])])
     @test findmin([0.0, -0.0]) === (-0.0, 2)
@@ -1813,6 +1813,11 @@ b, bi = findmax(B)
 s, si = findmax(S)
 @test a == b == s
 @test ai == bi == si
+
+for X in (A, B, S)
+    @test findmin(X) == findmin(Dict(pairs(X)))
+    @test findmax(X) == findmax(Dict(pairs(X)))
+end
 
 fill!(B, 2)
 @test all(x->x==2, B)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -156,9 +156,9 @@ end
 
 A = [1.0 5.0 6.0;
      5.0 2.0 4.0]
-for (tup, rval, rind) in [((1,), [1.0 2.0 4.0], [1 4 6]),
-                          ((2,), reshape([1.0,2.0], 2, 1), reshape([1,4], 2, 1)),
-                          ((1,2), fill(1.0,1,1),fill(1,1,1))]
+for (tup, rval, rind) in [((1,), [1.0 2.0 4.0], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+                          ((2,), reshape([1.0,2.0], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,2)], 2, 1)),
+                          ((1,2), fill(1.0,1,1),fill(CartesianIndex(1,1),1,1))]
     @test findmin(A, tup) == (rval, rind)
     @test findmin!(similar(rval), similar(rind), A) == (rval, rind)
     @test isequal(minimum(A, tup), rval)
@@ -166,9 +166,9 @@ for (tup, rval, rind) in [((1,), [1.0 2.0 4.0], [1 4 6]),
     @test isequal(minimum!(copy(rval), A, init=false), rval)
 end
 
-for (tup, rval, rind) in [((1,), [5.0 5.0 6.0], [2 3 5]),
-                          ((2,), reshape([6.0,5.0], 2, 1), reshape([5,2], 2, 1)),
-                          ((1,2), fill(6.0,1,1),fill(5,1,1))]
+for (tup, rval, rind) in [((1,), [5.0 5.0 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                          ((2,), reshape([6.0,5.0], 2, 1), reshape([CartesianIndex(1,3),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(6.0,1,1),fill(CartesianIndex(1,3),1,1))]
     @test findmax(A, tup) == (rval, rind)
     @test findmax!(similar(rval), similar(rind), A) == (rval, rind)
     @test isequal(maximum(A, tup), rval)
@@ -180,9 +180,9 @@ end
 
 A = [1.0 3.0 6.0;
      NaN 2.0 4.0]
-for (tup, rval, rind) in [((1,), [NaN 2.0 4.0], [2 4 6]),
-                          ((2,), reshape([1.0, NaN], 2, 1), reshape([1,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN 2.0 4.0], [CartesianIndex(2,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+                          ((2,), reshape([1.0, NaN], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmin(A, tup), (rval, rind))
     @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(minimum(A, tup), rval)
@@ -191,9 +191,9 @@ for (tup, rval, rind) in [((1,), [NaN 2.0 4.0], [2 4 6]),
     @test isequal(Base.reducedim!(min, copy(rval), A), rval)
 end
 
-for (tup, rval, rind) in [((1,), [NaN 3.0 6.0], [2 3 5]),
-                          ((2,), reshape([6.0, NaN], 2, 1), reshape([5,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN 3.0 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                          ((2,), reshape([6.0, NaN], 2, 1), reshape([CartesianIndex(1,3),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmax(A, tup), (rval, rind))
     @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(maximum(A, tup), rval)
@@ -204,9 +204,9 @@ end
 
 A = [1.0 NaN 6.0;
      NaN 2.0 4.0]
-for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [2 3 6]),
-                          ((2,), reshape([NaN, NaN], 2, 1), reshape([3,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(2,3)]),
+                          ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmin(A, tup), (rval, rind))
     @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(minimum(A, tup), rval)
@@ -214,9 +214,9 @@ for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [2 3 6]),
     @test isequal(minimum!(copy(rval), A, init=false), rval)
 end
 
-for (tup, rval, rind) in [((1,), [NaN NaN 6.0], [2 3 5]),
-                          ((2,), reshape([NaN, NaN], 2, 1), reshape([3,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN NaN 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                          ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmax(A, tup), (rval, rind))
     @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(maximum(A, tup), rval)
@@ -226,9 +226,9 @@ end
 
 A = [Inf -Inf Inf  -Inf;
      Inf  Inf -Inf -Inf]
-for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [1 3 6 7]),
-                          ((2,), reshape([-Inf -Inf], 2, 1), reshape([3,6], 2, 1)),
-                          ((1,2), fill(-Inf,1,1),fill(3,1,1))]
+for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [CartesianIndex(1,1) CartesianIndex(1,2) CartesianIndex(2,3) CartesianIndex(1,4)]),
+                          ((2,), reshape([-Inf -Inf], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,3)], 2, 1)),
+                          ((1,2), fill(-Inf,1,1),fill(CartesianIndex(1,2),1,1))]
     @test isequal(findmin(A, tup), (rval, rind))
     @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(minimum(A, tup), rval)
@@ -236,9 +236,9 @@ for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [1 3 6 7]),
     @test isequal(minimum!(copy(rval), A, init=false), rval)
 end
 
-for (tup, rval, rind) in [((1,), [Inf Inf Inf -Inf], [1 4 5 7]),
-                          ((2,), reshape([Inf Inf], 2, 1), reshape([1,2], 2, 1)),
-                          ((1,2), fill(Inf,1,1),fill(1,1,1))]
+for (tup, rval, rind) in [((1,), [Inf Inf Inf -Inf], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(1,3) CartesianIndex(1,4)]),
+                          ((2,), reshape([Inf Inf], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(Inf,1,1),fill(CartesianIndex(1,1),1,1))]
     @test isequal(findmax(A, tup), (rval, rind))
     @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(maximum(A, tup), rval)
@@ -281,7 +281,7 @@ for (tup, rval, rind) in [((2,), [BigInt(-10)], [1])]
 end
 
 A = [BigInt(10) BigInt(-10)]
-for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([2], 1,1))]
+for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([CartesianIndex(1,2)], 1, 1))]
     @test isequal(findmin(A, tup), (rval, rind))
     @test isequal(findmin!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(minimum(A, tup), rval)
@@ -289,7 +289,7 @@ for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([2], 1,1)
     @test isequal(minimum!(copy(rval), A, init=false), rval)
 end
 
-for (tup, rval, rind) in [((2,), reshape([BigInt(10)], 1, 1), reshape([1], 1, 1))]
+for (tup, rval, rind) in [((2,), reshape([BigInt(10)], 1, 1), reshape([CartesianIndex(1,1)], 1, 1))]
     @test isequal(findmax(A, tup), (rval, rind))
     @test isequal(findmax!(similar(rval), similar(rind), A), (rval, rind))
     @test isequal(maximum(A, tup), rval)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -998,8 +998,8 @@ end
 
     S = spzeros(10,8)
     A = Array(S)
-    @test indmax(S) == indmax(A) == 1
-    @test indmin(S) == indmin(A) == 1
+    @test indmax(S) == indmax(A) == CartesianIndex(1,1)
+    @test indmin(S) == indmin(A) == CartesianIndex(1,1)
 
     A = Array{Int}(0,0)
     S = sparse(A)
@@ -1015,15 +1015,15 @@ end
 
 A = sparse([1.0 5.0 6.0;
             5.0 2.0 4.0])
-for (tup, rval, rind) in [((1,), [1.0 2.0 4.0], [1 4 6]),
-                          ((2,), reshape([1.0,2.0], 2, 1), reshape([1,4], 2, 1)),
-                          ((1,2), fill(1.0,1,1),fill(1,1,1))]
+for (tup, rval, rind) in [((1,), [1.0 2.0 4.0], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+                          ((2,), reshape([1.0,2.0], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,2)], 2, 1)),
+                          ((1,2), fill(1.0,1,1),fill(CartesianIndex(1,1),1,1))]
     @test findmin(A, tup) == (rval, rind)
 end
 
-for (tup, rval, rind) in [((1,), [5.0 5.0 6.0], [2 3 5]),
-                          ((2,), reshape([6.0,5.0], 2, 1), reshape([5,2], 2, 1)),
-                          ((1,2), fill(6.0,1,1),fill(5,1,1))]
+for (tup, rval, rind) in [((1,), [5.0 5.0 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                          ((2,), reshape([6.0,5.0], 2, 1), reshape([CartesianIndex(1,3),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(6.0,1,1),fill(CartesianIndex(1,3),1,1))]
     @test findmax(A, tup) == (rval, rind)
 end
 
@@ -1031,43 +1031,43 @@ end
 
 A = sparse([1.0 5.0 6.0;
             NaN 2.0 4.0])
-for (tup, rval, rind) in [((1,), [NaN 2.0 4.0], [2 4 6]),
-                          ((2,), reshape([1.0, NaN], 2, 1), reshape([1,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN 2.0 4.0], [CartesianIndex(2,1) CartesianIndex(2,2) CartesianIndex(2,3)]),
+                          ((2,), reshape([1.0, NaN], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmin(A, tup), (rval, rind))
 end
 
-for (tup, rval, rind) in [((1,), [NaN 5.0 6.0], [2 3 5]),
-                          ((2,), reshape([6.0, NaN], 2, 1), reshape([5,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN 5.0 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                          ((2,), reshape([6.0, NaN], 2, 1), reshape([CartesianIndex(1,3),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmax(A, tup), (rval, rind))
 end
 
 A = sparse([1.0 NaN 6.0;
             NaN 2.0 4.0])
-for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [2 3 6]),
-                          ((2,), reshape([NaN, NaN], 2, 1), reshape([3,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN NaN 4.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(2,3)]),
+                          ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmin(A, tup), (rval, rind))
 end
 
-for (tup, rval, rind) in [((1,), [NaN NaN 6.0], [2 3 5]),
-                          ((2,), reshape([NaN, NaN], 2, 1), reshape([3,2], 2, 1)),
-                          ((1,2), fill(NaN,1,1),fill(2,1,1))]
+for (tup, rval, rind) in [((1,), [NaN NaN 6.0], [CartesianIndex(2,1) CartesianIndex(1,2) CartesianIndex(1,3)]),
+                          ((2,), reshape([NaN, NaN], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(NaN,1,1),fill(CartesianIndex(2,1),1,1))]
     @test isequal(findmax(A, tup), (rval, rind))
 end
 
 A = sparse([Inf -Inf Inf  -Inf;
             Inf  Inf -Inf -Inf])
-for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [1 3 6 7]),
-                          ((2,), reshape([-Inf -Inf], 2, 1), reshape([3,6], 2, 1)),
-                          ((1,2), fill(-Inf,1,1),fill(3,1,1))]
+for (tup, rval, rind) in [((1,), [Inf -Inf -Inf -Inf], [CartesianIndex(1,1) CartesianIndex(1,2) CartesianIndex(2,3) CartesianIndex(1,4)]),
+                          ((2,), reshape([-Inf -Inf], 2, 1), reshape([CartesianIndex(1,2),CartesianIndex(2,3)], 2, 1)),
+                          ((1,2), fill(-Inf,1,1),fill(CartesianIndex(1,2),1,1))]
     @test isequal(findmin(A, tup), (rval, rind))
 end
 
-for (tup, rval, rind) in [((1,), [Inf Inf Inf -Inf], [1 4 5 7]),
-                          ((2,), reshape([Inf Inf], 2, 1), reshape([1,2], 2, 1)),
-                          ((1,2), fill(Inf,1,1),fill(1,1,1))]
+for (tup, rval, rind) in [((1,), [Inf Inf Inf -Inf], [CartesianIndex(1,1) CartesianIndex(2,2) CartesianIndex(1,3) CartesianIndex(1,4)]),
+                          ((2,), reshape([Inf Inf], 2, 1), reshape([CartesianIndex(1,1),CartesianIndex(2,1)], 2, 1)),
+                          ((1,2), fill(Inf,1,1),fill(CartesianIndex(1,1),1,1))]
     @test isequal(findmax(A, tup), (rval, rind))
 end
 
@@ -1090,11 +1090,11 @@ for (tup, rval, rind) in [((2,), [BigInt(-10)], [1])]
 end
 
 A = sparse([BigInt(10) BigInt(-10)])
-for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([2], 1, 1))]
+for (tup, rval, rind) in [((2,), reshape([BigInt(-10)], 1, 1), reshape([CartesianIndex(1,2)], 1, 1))]
     @test isequal(findmin(A, tup), (rval, rind))
 end
 
-for (tup, rval, rind) in [((2,), reshape([BigInt(10)], 1, 1), reshape([1], 1, 1))]
+for (tup, rval, rind) in [((2,), reshape([BigInt(10)], 1, 1), reshape([CartesianIndex(1,1)], 1, 1))]
     @test isequal(findmax(A, tup), (rval, rind))
 end
 


### PR DESCRIPTION
The first commit adds `pairs`, which is supposed to return a key-value iterator for any indexable collection, and adds methods of `keys` and `values` for arrays and sets.

The second commit is just a demo of this, generalizing `findmin` and `findmax` so that the identity `findmax(array) == findmax(Dict(pairs(array)))` holds. This is a breaking change, since previously these functions only returned indices 1:n.

Discussion questions:

- Do we want fallbacks `values(x) = x` and (maybe) `keys(x) = countfrom(1)`? This would allow us to keep the old behavior of `findmin` on generic iterators with the same code. Or, we need some way to identify iterators that support `keys` and `values`, or we could decide that `findmin` only works on indexable collections.
- `keys` for a 1-d array returns an integer range, but for other arrays returns a `CartesianRange`. Seems ok to me?
- Do we want `CartesianIndex` to be the "official" array index type, or should we deprecate it and just use tuples?