### PR TITLE
fix `tuple_type_head` and `tuple_type_tail` on `UnionAll`

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -86,13 +86,13 @@ end
 argtail(x, rest...) = rest
 tail(x::Tuple) = argtail(x...)
 
-tuple_type_head(T::UnionAll) = tuple_type_head(T.body)
+tuple_type_head(T::UnionAll) = (@_pure_meta; UnionAll(T.var, tuple_type_head(T.body)))
 function tuple_type_head(T::DataType)
     @_pure_meta
     T.name === Tuple.name || throw(MethodError(tuple_type_head, (T,)))
     return unwrapva(T.parameters[1])
 end
-tuple_type_tail(T::UnionAll) = tuple_type_tail(T.body)
+tuple_type_tail(T::UnionAll) = (@_pure_meta; UnionAll(T.var, tuple_type_tail(T.body)))
 function tuple_type_tail(T::DataType)
     @_pure_meta
     T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -291,3 +291,7 @@ let
 
     test_15703()
 end
+
+# https://github.com/JuliaLang/julia/issues/21026#issuecomment-317113307
+const VecTuple21026{T} = Tuple{VecElement{T}}
+@test convert(VecTuple21026, (1,)) === (VecElement(1),)


### PR DESCRIPTION
Fixes an issue mentioned in https://github.com/JuliaLang/julia/issues/21026#issuecomment-317113307. A small part of #22051.