### PR TITLE
print Pair with spaces arount "=>"

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -2085,7 +2085,7 @@ julia> S
 Set([1])
 
 julia> pop!(Dict(1=>2))
-1=>2
+1 => 2
 ```
 """
 pop!(collection)

--- a/base/show.jl
+++ b/base/show.jl
@@ -282,18 +282,24 @@ has_tight_type(p::Pair) =
     typeof(p.first)  == typeof(p).parameters[1] &&
     typeof(p.second) == typeof(p).parameters[2]
 
+print_with_arrow(p::Pair, compact::Bool) = has_tight_type(p) || compact
+
+isdelimited(io::IO, x) = true
+
+isdelimited(io::IO, p::Pair) = !print_with_arrow(p, get(io, :compact, false))
+
 function show(io::IO, p::Pair)
     compact = get(io, :compact, false)
-    iocompact = IOContext(io, :compact => true)
-    has_tight_type(p) || compact || return show_default(iocompact, p)
+    iocompact = IOContext(io, :compact => get(io, :compact, true))
+    print_with_arrow(p, compact) || return show_default(iocompact, p)
 
-    isa(p.first,Pair) && print(io, "(")
+    isdelimited(iocompact, p.first) || print(io, "(")
     show(iocompact, p.first)
-    isa(p.first,Pair) && print(io, ")")
+    isdelimited(iocompact, p.first) || print(io, ")")
     print(io, compact ? "=>" : " => ")
-    isa(p.second,Pair) && print(io, "(")
+    isdelimited(iocompact, p.second) || print(io, "(")
     show(iocompact, p.second)
-    isa(p.second,Pair) && print(io, ")")
+    isdelimited(iocompact, p.second) || print(io, ")")
     nothing
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -282,16 +282,14 @@ has_tight_type(p::Pair) =
     typeof(p.first)  == typeof(p).parameters[1] &&
     typeof(p.second) == typeof(p).parameters[2]
 
-print_with_arrow(p::Pair, compact::Bool) = has_tight_type(p) || compact
-
 isdelimited(io::IO, x) = true
 
-isdelimited(io::IO, p::Pair) = !print_with_arrow(p, get(io, :compact, false))
+isdelimited(io::IO, p::Pair) = !has_tight_type(p)
 
 function show(io::IO, p::Pair)
     compact = get(io, :compact, false)
     iocompact = IOContext(io, :compact => get(io, :compact, true))
-    print_with_arrow(p, compact) || return show_default(iocompact, p)
+    has_tight_type(p) || return show_default(iocompact, p)
 
     isdelimited(iocompact, p.first) || print(io, "(")
     show(iocompact, p.first)

--- a/base/show.jl
+++ b/base/show.jl
@@ -278,18 +278,21 @@ print(io::IO, n::Unsigned) = print(io, dec(n))
 
 show(io::IO, p::Ptr) = print(io, typeof(p), " @0x$(hex(UInt(p), Sys.WORD_SIZE>>2))")
 
+has_tight_type(p::Pair) =
+    typeof(p.first)  == typeof(p).parameters[1] &&
+    typeof(p.second) == typeof(p).parameters[2]
+
 function show(io::IO, p::Pair)
-    if typeof(p.first) != typeof(p).parameters[1] ||
-       typeof(p.second) != typeof(p).parameters[2]
-        return show_default(io, p)
-    end
+    compact = get(io, :compact, false)
+    iocompact = IOContext(io, :compact => true)
+    has_tight_type(p) || compact || return show_default(iocompact, p)
 
     isa(p.first,Pair) && print(io, "(")
-    show(io, p.first)
+    show(iocompact, p.first)
     isa(p.first,Pair) && print(io, ")")
-    print(io, "=>")
+    print(io, compact ? "=>" : " => ")
     isa(p.second,Pair) && print(io, "(")
-    show(io, p.second)
+    show(iocompact, p.second)
     isa(p.second,Pair) && print(io, ")")
     nothing
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -455,9 +455,8 @@ let d = Dict(1 => 2, 3 => 45)
     @test contains(result, summary(d))
 
     # Is every pair in the string?
-    # Compare by removing spaces
     for el in d
-        @test contains(replace(result, " ", ""), string(el))
+        @test contains(result, string(el))
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -470,13 +470,6 @@ function f13127()
 end
 @test f13127() == "$(curmod_prefix)f"
 
-let a = Pair(1.0,2.0)
-    @test sprint(show,a) == "1.0=>2.0"
-end
-let a = Pair(Pair(1,2),Pair(3,4))
-    @test sprint(show,a) == "(1=>2)=>(3=>4)"
-end
-
 #test methodshow.jl functions
 @test Base.inbase(Base)
 @test Base.inbase(LinAlg)
@@ -817,4 +810,16 @@ end
     @test sprint(show, Val(Float64))  == "Val{Float64}()"  # Val of a type
     @test sprint(show, Val(:Float64)) == "Val{:Float64}()" # Val of a symbol
     @test sprint(show, Val(true))     == "Val{true}()"     # Val of a value
+end
+
+@testset "printing of Pair's" begin
+    for (p, s) in (Pair(1.0,2.0)                          => "1.0 => 2.0",
+                   Pair(Pair(1,2), Pair(3,4))             => "(1=>2) => (3=>4)",
+                   Pair{Integer,Int64}(1, 2)              => "Pair{Integer,Int64}(1, 2)",
+                   (Pair{Integer,Int64}(1, 2) => 3)       => "(1=>2) => 3",
+                   ((1+2im) => (3+4im))                   => "1+2im => 3+4im",
+                   Pair{Any,Any}(Pair{Real,Int}(1, 2), 3) => "Pair{Any,Any}(1=>2, 3)")
+
+        @test sprint(show, p) == s
+    end
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -816,9 +816,9 @@ end
     for (p, s) in (Pair(1.0,2.0)                          => "1.0 => 2.0",
                    Pair(Pair(1,2), Pair(3,4))             => "(1=>2) => (3=>4)",
                    Pair{Integer,Int64}(1, 2)              => "Pair{Integer,Int64}(1, 2)",
-                   (Pair{Integer,Int64}(1, 2) => 3)       => "(1=>2) => 3",
+                   (Pair{Integer,Int64}(1, 2) => 3)       => "Pair{Integer,Int64}(1, 2) => 3",
                    ((1+2im) => (3+4im))                   => "1+2im => 3+4im",
-                   Pair{Any,Any}(Pair{Real,Int}(1, 2), 3) => "Pair{Any,Any}(1=>2, 3)")
+                   (1 => 2 => Pair{Real,Int64}(3, 4))     => "1 => (2=>Pair{Real,Int64}(3, 4))")
 
         @test sprint(show, p) == s
     end

--- a/test/show.jl
+++ b/test/show.jl
@@ -822,4 +822,9 @@ end
 
         @test sprint(show, p) == s
     end
+    # - when the context has :compact=>false, print pair's member non-compactly
+    # - if one member is printed as "Pair{...}(...)", no need to put parens around
+    s = IOBuffer()
+    show(IOContext(s, :compact => false), (1=>2) => Pair{Any,Any}(3,4))
+    @test String(take!(s)) == "(1 => 2) => Pair{Any,Any}(3, 4)"
 end


### PR DESCRIPTION
* Put spaces only when printing non-compactly.
* The first and second elements of a pair are printed compactly.
* When printed compactly, a pair always use "=>" even when the type
  of the pair don't match its elements.

One good example: 
```
julia> 1+2im=>3+4im # before
1 + 2im=>3 + 4im

julia> 1+2im=>3+4im # after
1+2im => 3+4im
```
This may be even better by printing  `(1+2im) => (3+4im)`, but this will be for another time.

 