### PR TITLE
printing Dict: don't show ellipsis when everything fits

### DIFF
--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -15,14 +15,14 @@ function show(io::IO, ::MIME"text/plain", iter::Union{KeyIterator,ValueIterator}
         rows < 2 && (print(io, " …"); return)
         cols < 4 && (cols = 4)
         cols -= 2 # For prefix "  "
-        rows -= 2 # For summary and final ⋮ continuation lines
+        rows -= 1 # For summary
     else
         rows = cols = 0
     end
 
     for (i, v) in enumerate(iter)
         print(io, "\n  ")
-        limit && i >= rows && (print(io, "⋮"); break)
+        limit && rows <= i < length(iter) && (print(io, "⋮"); break)
 
         if limit
             str = sprint(0, show, v, env=io)
@@ -44,7 +44,7 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
 
     print(io, summary(t))
     isempty(t) && return
-    print(io, ":\n  ")
+    print(io, ":")
     show_circular(io, t) && return
     if limit
         sz = displaysize(io)
@@ -52,7 +52,7 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
         rows < 2   && (print(io, " …"); return)
         cols < 12  && (cols = 12) # Minimum widths of 2 for key, 4 for value
         cols -= 6 # Subtract the widths of prefix "  " separator " => "
-        rows -= 2 # Subtract the summary and final ⋮ continuation lines
+        rows -= 1 # Subtract the summary
 
         # determine max key width to align the output, caching the strings
         ks = Vector{AbstractString}(min(rows, length(t)))
@@ -73,11 +73,9 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
         rows = cols = 0
     end
 
-    first = true
     for (i, (k, v)) in enumerate(t)
-        first || print(io, "\n  ")
-        first = false
-        limit && i > rows && (print(io, rpad("⋮", keylen), " => ⋮"); break)
+        print(io, "\n  ")
+        limit && rows <= i < length(t) && (print(io, rpad("⋮", keylen), " => ⋮"); break)
 
         if limit
             key = rpad(_truncate_at_width_or_chars(ks[i], keylen, "\r\n"), keylen)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -17,12 +17,12 @@ function show(io::IO, ::MIME"text/plain", iter::Union{KeyIterator,ValueIterator}
         cols -= 2 # For prefix "  "
         rows -= 1 # For summary
     else
-        rows = cols = 0
+        rows = cols = typemax(Int)
     end
 
     for (i, v) in enumerate(iter)
         print(io, "\n  ")
-        limit && rows <= i < length(iter) && (print(io, "⋮"); break)
+        i == rows < length(iter) && (print(io, "⋮"); break)
 
         if limit
             str = sprint(0, show, v, env=io)
@@ -70,12 +70,12 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
             keylen = max(cld(cols, 3), cols - vallen)
         end
     else
-        rows = cols = 0
+        rows = cols = typemax(Int)
     end
 
     for (i, (k, v)) in enumerate(t)
         print(io, "\n  ")
-        limit && rows <= i < length(t) && (print(io, rpad("⋮", keylen), " => ⋮"); break)
+        i == rows < length(t) && (print(io, rpad("⋮", keylen), " => ⋮"); break)
 
         if limit
             key = rpad(_truncate_at_width_or_chars(ks[i], keylen, "\r\n"), keylen)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -608,3 +608,40 @@ let buf = IOBuffer()
     show(buf, methods(f22798))
     @test contains(String(take!(buf)), "f22798(x::Integer, y)")
 end
+
+@testset "Dict printing with limited rows" begin
+    buf = IOBuffer()
+    io = IOContext(IOContext(buf, :displaysize => (4, 80)), :limit => true)
+    d = Dict(1=>2)
+    show(io, MIME"text/plain"(), d)
+    @test String(take!(buf)) == "Dict{Int64,Int64} with 1 entry: …"
+    show(io, MIME"text/plain"(), keys(d))
+    @test String(take!(buf)) ==
+        "Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys: …"
+
+    io = IOContext(io, :displaysize => (5, 80))
+    show(io, MIME"text/plain"(), d)
+    @test String(take!(buf)) == "Dict{Int64,Int64} with 1 entry:\n  1 => 2"
+    show(io, MIME"text/plain"(), keys(d))
+    @test String(take!(buf)) ==
+        "Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys:\n  1"
+    push!(d, 3=>4)
+    show(io, MIME"text/plain"(), d)
+    @test String(take!(buf)) == "Dict{Int64,Int64} with 2 entries:\n  ⋮ => ⋮"
+    show(io, MIME"text/plain"(), keys(d))
+    @test String(take!(buf)) ==
+        "Base.KeyIterator for a Dict{Int64,Int64} with 2 entries. Keys:\n  ⋮"
+
+    io = IOContext(io, :displaysize => (6, 80))
+    show(io, MIME"text/plain"(), d)
+    @test String(take!(buf)) =="Dict{Int64,Int64} with 2 entries:\n  3 => 4\n  1 => 2"
+    show(io, MIME"text/plain"(), keys(d))
+    @test String(take!(buf)) ==
+        "Base.KeyIterator for a Dict{Int64,Int64} with 2 entries. Keys:\n  3\n  1"
+    push!(d, 5=>6)
+    show(io, MIME"text/plain"(), d)
+    @test String(take!(buf)) == "Dict{Int64,Int64} with 3 entries:\n  3 => 4\n  ⋮ => ⋮"
+    show(io, MIME"text/plain"(), keys(d))
+    @test String(take!(buf)) ==
+        "Base.KeyIterator for a Dict{Int64,Int64} with 3 entries. Keys:\n  3\n  ⋮"
+end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -614,34 +614,34 @@ end
     io = IOContext(IOContext(buf, :displaysize => (4, 80)), :limit => true)
     d = Dict(1=>2)
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{Int64,Int64} with 1 entry: …"
+    @test String(take!(buf)) == "Dict{$Int,$Int} with 1 entry: …"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys: …"
+        "Base.KeyIterator for a Dict{$Int,$Int} with 1 entry. Keys: …"
 
     io = IOContext(io, :displaysize => (5, 80))
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{Int64,Int64} with 1 entry:\n  1 => 2"
+    @test String(take!(buf)) == "Dict{$Int,$Int} with 1 entry:\n  1 => 2"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys:\n  1"
+        "Base.KeyIterator for a Dict{$Int,$Int} with 1 entry. Keys:\n  1"
     push!(d, 3=>4)
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{Int64,Int64} with 2 entries:\n  ⋮ => ⋮"
+    @test String(take!(buf)) == "Dict{$Int,$Int} with 2 entries:\n  ⋮ => ⋮"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{Int64,Int64} with 2 entries. Keys:\n  ⋮"
+        "Base.KeyIterator for a Dict{$Int,$Int} with 2 entries. Keys:\n  ⋮"
 
     io = IOContext(io, :displaysize => (6, 80))
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) =="Dict{Int64,Int64} with 2 entries:\n  3 => 4\n  1 => 2"
+    @test String(take!(buf)) =="Dict{$Int,$Int} with 2 entries:\n  3 => 4\n  1 => 2"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{Int64,Int64} with 2 entries. Keys:\n  3\n  1"
+        "Base.KeyIterator for a Dict{$Int,$Int} with 2 entries. Keys:\n  3\n  1"
     push!(d, 5=>6)
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{Int64,Int64} with 3 entries:\n  3 => 4\n  ⋮ => ⋮"
+    @test String(take!(buf)) == "Dict{$Int,$Int} with 3 entries:\n  3 => 4\n  ⋮ => ⋮"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{Int64,Int64} with 3 entries. Keys:\n  3\n  ⋮"
+        "Base.KeyIterator for a Dict{$Int,$Int} with 3 entries. Keys:\n  3\n  ⋮"
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -612,36 +612,38 @@ end
 @testset "Dict printing with limited rows" begin
     buf = IOBuffer()
     io = IOContext(IOContext(buf, :displaysize => (4, 80)), :limit => true)
-    d = Dict(1=>2)
+    d = Base.ImmutableDict(1=>2)
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{$Int,$Int} with 1 entry: …"
+    @test String(take!(buf)) == "Base.ImmutableDict{$Int,$Int} with 1 entry: …"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{$Int,$Int} with 1 entry. Keys: …"
+        "Base.KeyIterator for a Base.ImmutableDict{$Int,$Int} with 1 entry. Keys: …"
 
     io = IOContext(io, :displaysize => (5, 80))
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{$Int,$Int} with 1 entry:\n  1 => 2"
+    @test String(take!(buf)) == "Base.ImmutableDict{$Int,$Int} with 1 entry:\n  1 => 2"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{$Int,$Int} with 1 entry. Keys:\n  1"
-    push!(d, 3=>4)
+        "Base.KeyIterator for a Base.ImmutableDict{$Int,$Int} with 1 entry. Keys:\n  1"
+    d = Base.ImmutableDict(d, 3=>4)
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{$Int,$Int} with 2 entries:\n  ⋮ => ⋮"
+    @test String(take!(buf)) == "Base.ImmutableDict{$Int,$Int} with 2 entries:\n  ⋮ => ⋮"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{$Int,$Int} with 2 entries. Keys:\n  ⋮"
+        "Base.KeyIterator for a Base.ImmutableDict{$Int,$Int} with 2 entries. Keys:\n  ⋮"
 
     io = IOContext(io, :displaysize => (6, 80))
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) =="Dict{$Int,$Int} with 2 entries:\n  3 => 4\n  1 => 2"
+    @test String(take!(buf)) ==
+        "Base.ImmutableDict{$Int,$Int} with 2 entries:\n  3 => 4\n  1 => 2"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{$Int,$Int} with 2 entries. Keys:\n  3\n  1"
-    push!(d, 5=>6)
+        "Base.KeyIterator for a Base.ImmutableDict{$Int,$Int} with 2 entries. Keys:\n  3\n  1"
+    d = Base.ImmutableDict(d, 5=>6)
     show(io, MIME"text/plain"(), d)
-    @test String(take!(buf)) == "Dict{$Int,$Int} with 3 entries:\n  3 => 4\n  ⋮ => ⋮"
+    @test String(take!(buf)) ==
+        "Base.ImmutableDict{$Int,$Int} with 3 entries:\n  5 => 6\n  ⋮ => ⋮"
     show(io, MIME"text/plain"(), keys(d))
     @test String(take!(buf)) ==
-        "Base.KeyIterator for a Dict{$Int,$Int} with 3 entries. Keys:\n  3\n  ⋮"
+        "Base.KeyIterator for a Base.ImmutableDict{$Int,$Int} with 3 entries. Keys:\n  5\n  ⋮"
 end


### PR DESCRIPTION
Here is before/after, depending on the number of rows available on screen
``` 
julia> Dict(1=>2) # before, rows=4 # this line becomes hidden after printing the next prompt 
Dict{Int64,Int64} with 1 entry:
   …

julia> keys(Dict(1=>2))
Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys: …

julia> Dict(1=>2) # after
Dict{Int64,Int64} with 1 entry: …

julia> Dict(1=>2) # before, rows=5
Dict{Int64,Int64} with 1 entry:
  ⋮ => ⋮

julia> keys(Dict(1=>2))
Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys:
  ⋮

julia> Dict(1=>2) # after, rows=5
Dict{Int64,Int64} with 1 entry:
  1 => 2

julia> keys(Dict(1=>2))
Base.KeyIterator for a Dict{Int64,Int64} with 1 entry. Keys:
  1
```