### PR TITLE
fix matrix power of Symmetric/Hermitian

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -317,34 +317,12 @@ kron(a::AbstractMatrix, b::AbstractVector) = kron(a, reshape(b, length(b), 1))
 kron(a::AbstractVector, b::AbstractMatrix) = kron(reshape(a, length(a), 1), b)
 
 # Matrix power
-(^)(A::AbstractMatrix{T}, p::Integer) where {T} = p < 0 ? Base.power_by_squaring(inv(A), -p) : Base.power_by_squaring(A, p)
-function (^)(A::AbstractMatrix{T}, p::Real) where T
-    # For integer powers, use repeated squaring
-    if isinteger(p)
-        TT = Base.promote_op(^, eltype(A), typeof(p))
-        return (TT == eltype(A) ? A : copy!(similar(A, TT), A))^Integer(p)
-    end
-
-    # If possible, use diagonalization
-    if T <: Real && issymmetric(A)
-        return (Symmetric(A)^p)
-    end
-    if ishermitian(A)
-        return (Hermitian(A)^p)
-    end
-
-    n = checksquare(A)
-
-    # Quicker return if A is diagonal
-    if isdiag(A)
-        retmat = copy(A)
-        for i in 1:n
-            retmat[i, i] = retmat[i, i] ^ p
-        end
-        return retmat
-    end
-
-    # Otherwise, use Schur decomposition
+(^)(A::AbstractMatrix, p::Integer) = p < 0 ? Base.power_by_squaring(inv(A), -p) : Base.power_by_squaring(A, p)
+function integerpow(A::AbstractMatrix{T}, p) where T
+    TT = Base.promote_op(^, T, typeof(p))
+    return (TT == T ? A : copy!(similar(A, TT), A))^Integer(p)
+end
+function schurpow(A::AbstractMatrix, p)
     if istriu(A)
         # Integer part
         retmat = A ^ floor(p)
@@ -375,6 +353,32 @@ function (^)(A::AbstractMatrix{T}, p::Real) where T
     else
         return retmat
     end
+end
+function (^)(A::AbstractMatrix{T}, p::Real) where T
+    n = checksquare(A)
+
+    # For integer powers, use power_by_squaring
+    isinteger(p) && return integerpow(A, p)
+
+    # If possible, use diagonalization
+    if issymmetric(A)
+        return (Symmetric(A)^p)
+    end
+    if ishermitian(A)
+        return (Hermitian(A)^p)
+    end
+
+    # Quicker return if A is diagonal
+    if isdiag(A)
+        retmat = copy(A)
+        for i in 1:n
+            retmat[i, i] = retmat[i, i] ^ p
+        end
+        return retmat
+    end
+
+    # Otherwise, use Schur decomposition
+    return schurpow(A, p)
 end
 (^)(A::AbstractMatrix, p::Number) = expm(p*logm(A))
 

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -35,6 +35,7 @@ end
         asym = a.'+a                 # symmetric indefinite
         aherm = a'+a                 # Hermitian indefinite
         apos  = a'*a                 # Hermitian positive definite
+        aposs = apos + apos.'        # Symmetric positive definite
         ε = εa = eps(abs(float(one(eltya))))
 
         x = randn(n)
@@ -238,29 +239,27 @@ end
                 end
 
                 @testset "pow" begin
-                    @test (asym)^2     ≈ Array(Symmetric(asym)^2)
-                    @test (asym)^-2    ≈ Array(Symmetric(asym)^-2)
-                    @test (aherm)^2    ≈ Array(Hermitian(aherm)^2)
-                    @test (aherm)^-2   ≈ Array(Hermitian(aherm)^-2)
-                    if eltya == Int
-                        @test (asym)^2.0   ≈ real(Array(Symmetric(asym)^2.0))
-                        @test (asym)^-2.0  ≈ real(Array(Symmetric(asym)^-2.0))
-                        @test (aherm)^2.0  ≈ real(Array(Hermitian(aherm)^2.0))
-                        @test (aherm)^-2.0 ≈ real(Array(Hermitian(aherm)^-2.0))
-                        @test (apos)^2.0   ≈ real(Array(Hermitian(apos)^2.0))
-                    elseif eltya <: Real
-                        @test (asym)^2.0   ≈ real(Array(Symmetric(asym)^2.0)) rtol=100*n^2*eps(real(eltya))
-                        @test (asym)^-2.0  ≈ real(Array(Symmetric(asym)^-2.0)) rtol=100*n^2*eps(real(eltya))
-                        @test (aherm)^2.0  ≈ real(Array(Hermitian(aherm)^2.0)) rtol=100*n^2*eps(real(eltya))
-                        @test (aherm)^-2.0 ≈ real(Array(Hermitian(aherm)^-2.0)) rtol=100*n^2*eps(real(eltya))
-                        @test (apos)^2.0   ≈ real(Array(Hermitian(apos)^2.0)) rtol=100*n^2*eps(real(eltya))
-                    else
-                        @test (asym)^2.0   ≈ Array(Symmetric(asym)^2.0) rtol=100*n^2*eps(real(eltya))
-                        @test (asym)^-2.0  ≈ Array(Symmetric(asym)^-2.0) rtol=100*n^2*eps(real(eltya))
-                        @test (aherm)^2.0  ≈ Array(Hermitian(aherm)^2.0) rtol=100*n^2*eps(real(eltya))
-                        @test (aherm)^-2.0 ≈ Array(Hermitian(aherm)^-2.0) rtol=100*n^2*eps(real(eltya))
-                        @test (apos)^2.0   ≈ Array(Hermitian(apos)^2.0) rtol=100*n^2*eps(real(eltya))
-                    end
+                    # Integer power
+                    @test (asym)^2   ≈ (Symmetric(asym)^2)::Symmetric
+                    @test (asym)^-2  ≈ (Symmetric(asym)^-2)::Symmetric
+                    @test (aposs)^2  ≈ (Symmetric(aposs)^2)::Symmetric
+                    @test (aherm)^2  ≈ (Hermitian(aherm)^2)::Hermitian
+                    @test (aherm)^-2 ≈ (Hermitian(aherm)^-2)::Hermitian
+                    @test (apos)^2   ≈ (Hermitian(apos)^2)::Hermitian
+                    # integer floating point power
+                    @test (asym)^2.0   ≈ (Symmetric(asym)^2.0)::Symmetric
+                    @test (asym)^-2.0  ≈ (Symmetric(asym)^-2.0)::Symmetric
+                    @test (aposs)^2.0  ≈ (Symmetric(aposs)^2.0)::Symmetric
+                    @test (aherm)^2.0  ≈ (Hermitian(aherm)^2.0)::Hermitian
+                    @test (aherm)^-2.0 ≈ (Hermitian(aherm)^-2.0)::Hermitian
+                    @test (apos)^2.0   ≈ (Hermitian(apos)^2.0)::Hermitian
+                    # non-integer floating point power
+                    @test (asym)^2.5   ≈ (Symmetric(asym)^2.5)::Symmetric
+                    @test (asym)^-2.5  ≈ (Symmetric(asym)^-2.5)::Symmetric
+                    @test (aposs)^2.5  ≈ (Symmetric(aposs)^2.5)::Symmetric
+                    @test (aherm)^2.5  ≈ (Hermitian(aherm)^2.5)#::Hermitian
+                    @test (aherm)^-2.5 ≈ (Hermitian(aherm)^-2.5)#::Hermitian
+                    @test (apos)^2.5   ≈ (Hermitian(apos)^2.5)::Hermitian
                 end
             end
         end


### PR DESCRIPTION
The general matrix power does a `isinteger`check first and dispatch to `power_by_squaring`, so this enables that for `HermOrSym` as well. For example:

Master:
```julia
julia> S = Symmetric(rand(3,3));

julia> S^2.
3×3 Symmetric{Complex{Float64},Array{Complex{Float64},2}}:
 0.875994+0.0im  0.883107+0.0im  1.04351+0.0im
 0.883107+0.0im   1.55223+0.0im   1.2839+0.0im
  1.04351+0.0im    1.2839+0.0im   1.5004+0.0im
```

PR:
```julia
julia> S = Symmetric(rand(3,3));

julia> S^2.
3×3 Symmetric{Float64,Array{Float64,2}}:
 0.453002  0.536602  0.645242
 0.536602  1.37305   0.922992
 0.645242  0.922992  0.999679
```