### PR TITLE
Define method for complex(x::Irrational)

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -141,6 +141,8 @@ end
 big(x::Irrational) = convert(BigFloat,x)
 big(::Type{<:Irrational}) = BigFloat
 
+complex(x::Irrational) = Complex{Real}(x, 0)
+
 ## specific irrational mathematical constants
 
 @irrational π        3.14159265358979323846  pi

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -948,8 +948,12 @@ end
 
 @testset "Complex Irrationals, issue #21204" begin
     for x in (pi, e, catalan) # No need to test all of them
+        w = complex(x)
+        @test typeof(w) === Complex{Real}
+        @test real(w) === x
+        @test imag(w) === 0
         z = Complex(x, x)
-        @test typeof(z) == Complex{typeof(x)}
+        @test typeof(z) === Complex{typeof(x)}
         @test exp(z) ≈ exp(x) * cis(x)
         @test log1p(z) ≈ log(1 + z)
         @test exp2(z) ≈ exp(z * log(2))


### PR DESCRIPTION
Create a `Complex{Real}` instance which preserves precision of the irrational
number.

Closes #22878, see #21204.