### PR TITLE
Deprecate `+`/`-` methods for `array+scalar` etc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -431,6 +431,10 @@ Deprecated or removed
   * `map` on dictionaries previously operated on `key=>value` pairs. This behavior is deprecated,
     and in the future `map` will operate only on values ([#5794]).
 
+  * Automatically broadcasted `+` and `-` for `array + scalar`, `scalar - array`, and so-on have
+    been deprecated due to inconsistency with linear algebra. Use `.+` and `.-` for these operations
+    instead.
+
 Command-line option changes
 ---------------------------
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1258,7 +1258,7 @@ function _cat(A, shape::NTuple{N}, catdims, X...) where N
     for x in X
         for i = 1:N
             if concat[i]
-                inds[i] = offsets[i] + cat_indices(x, i)
+                inds[i] = offsets[i] .+ cat_indices(x, i)
                 offsets[i] += cat_size(x, i)
             else
                 inds[i] = 1:shape[i]

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -438,7 +438,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
         for c in CartesianRange(indices(A))
             for i in 1:ndims(A)
                 n = inner[i]
-                inner_indices[i] = (1:n) + ((c[i] - 1) * n)
+                inner_indices[i] = (1:n) .+ ((c[i] - 1) * n)
             end
             fill!(view(R, inner_indices...), A[c])
         end
@@ -453,7 +453,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
     for i in 1:length(outer)
         B = view(R, src_indices...)
         for j in 2:outer[i]
-            dest_indices[i] += inner_shape[i]
+            dest_indices[i] = dest_indices[i] .+ inner_shape[i]
             R[dest_indices...] = B
         end
         src_indices[i] = dest_indices[i] = 1:shape[i]

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -40,7 +40,7 @@ for f in (:+, :-)
     end
 end
 
-for f in (:/, :\, :*, :+, :-)
+for f in (:/, :\, :*)
     if f != :/
         @eval ($f)(A::Number, B::AbstractArray) = broadcast($f, A, B)
     end

--- a/base/dates/periods.jl
+++ b/base/dates/periods.jl
@@ -358,8 +358,6 @@ GeneralPeriod = Union{Period, CompoundPeriod}
 
 for op in (:+, :-)
     @eval begin
-        ($op)(x::GeneralPeriod, Y::StridedArray{<:GeneralPeriod}) = broadcast($op, x, Y)
-        ($op)(Y::StridedArray{<:GeneralPeriod}, x::GeneralPeriod) = broadcast($op, Y, x)
         ($op)(X::StridedArray{<:GeneralPeriod}, Y::StridedArray{<:GeneralPeriod}) =
             reshape(CompoundPeriod[($op)(x, y) for (x, y) in zip(X, Y)], promote_shape(size(X), size(Y)))
     end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1766,6 +1766,17 @@ import .Iterators.enumerate
 # issue #5794
 @deprecate map(f, d::T) where {T<:Associative}  T( f(p) for p in pairs(d) )
 
+# PR #22932
+@deprecate +(a::Number, b::AbstractArray) broadcast(+, a, b)
+@deprecate +(a::AbstractArray, b::Number) broadcast(+, a, b)
+@deprecate -(a::Number, b::AbstractArray) broadcast(-, a, b)
+@deprecate -(a::AbstractArray, b::Number) broadcast(-, a, b)
+
+@deprecate +(a::Dates.GeneralPeriod, b::StridedArray{<:Dates.GeneralPeriod}) broadcast(+, a, b)
+@deprecate +(a::StridedArray{<:Dates.GeneralPeriod}, b::Dates.GeneralPeriod) broadcast(+, a, b)
+@deprecate -(a::Dates.GeneralPeriod, b::StridedArray{<:Dates.GeneralPeriod}) broadcast(-, a, b)
+@deprecate -(a::StridedArray{<:Dates.GeneralPeriod}, b::Dates.GeneralPeriod) broadcast(-, a, b)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -613,7 +613,7 @@ function base(b::Integer, n::BigInt, pad::Integer=1)
     nd  = max(nd1, pad)
     sv  = Base.StringVector(nd + isneg(n))
     MPZ.get_str!(pointer(sv) + nd - nd1, b, n)
-    @inbounds for i = (1:nd-nd1) + isneg(n)
+    @inbounds for i = (1:nd-nd1) .+ isneg(n)
         sv[i] = '0' % UInt8
     end
     isneg(n) && (sv[1] = '-' % UInt8)

--- a/base/linalg/arpack.jl
+++ b/base/linalg/arpack.jl
@@ -51,8 +51,8 @@ function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Functio
             throw(ARPACKException(info[]))
         end
 
-        x = view(workd, ipntr[1]+zernm1)
-        y = view(workd, ipntr[2]+zernm1)
+        x = view(workd, ipntr[1] .+ zernm1)
+        y = view(workd, ipntr[2] .+ zernm1)
         if mode == 1  # corresponds to dsdrv1, dndrv1 or zndrv1
             if ido[] == 1
                 matvecA!(y, x)
@@ -87,7 +87,7 @@ function aupd_wrapper(T, matvecA!::Function, matvecB::Function, solveSI::Functio
             if ido[] == -1
                 y[:] = solveSI(matvecB(x))
             elseif  ido[] == 1
-                y[:] = solveSI(view(workd,ipntr[3]+zernm1))
+                y[:] = solveSI(view(workd,ipntr[3] .+ zernm1))
             elseif ido[] == 2
                 y[:] = matvecB(x)
             elseif ido[] == 99

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -120,10 +120,10 @@ function kron(a::BitMatrix, b::BitMatrix)
     R = falses(mA*mB, nA*nB)
 
     for i = 1:mA
-        ri = (1:mB)+(i-1)*mB
+        ri = (1:mB) .+ ((i-1)*mB)
         for j = 1:nA
             if a[i,j]
-                rj = (1:nB)+(j-1)*nB
+                rj = (1:nB) .+ ((j-1)*nB)
                 R[ri,rj] = b
             end
         end

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -321,7 +321,7 @@ A_mul_Bt(A::AbstractTriangular, B::RealHermSymComplexSym) = A*B
 Ac_mul_B(A::RealHermSymComplexHerm, B::AbstractTriangular) = A*B
 A_mul_Bc(A::AbstractTriangular, B::RealHermSymComplexHerm) = A*B
 
-for T in (:Symmetric, :Hermitian), op in (:+, :-, :*, :/)
+for T in (:Symmetric, :Hermitian), op in (:*, :/)
     # Deal with an ambiguous case
     @eval ($op)(A::$T, x::Bool) = ($T)(($op)(A.data, x), Symbol(A.uplo))
     S = T == :Hermitian ? :Real : :Number

--- a/base/linalg/transpose.jl
+++ b/base/linalg/transpose.jl
@@ -63,8 +63,8 @@ end
 function transposeblock!(f, B::AbstractMatrix, A::AbstractMatrix, m::Int, n::Int, offseti::Int, offsetj::Int)
     if m*n<=transposebaselength
         @inbounds begin
-            for j = offsetj+(1:n)
-                for i = offseti+(1:m)
+            for j = offsetj .+ (1:n)
+                for i = offseti .+ (1:m)
                     B[j,i] = f(A[i,j])
                 end
             end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1144,7 +1144,7 @@ end
 @inline unchecked_bool_convert(x::Real) = x == 1
 
 function copy_to_bitarray_chunks!(Bc::Vector{UInt64}, pos_d::Int, C::StridedArray{<:Real}, pos_s::Int, numbits::Int)
-    @inbounds for i = (1:numbits) + pos_s - 1
+    @inbounds for i = (1:numbits) .+ (pos_s - 1)
         try_bool_conversion(C[i])
     end
 

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -614,7 +614,7 @@ function shell_completions(string, pos)
         r = first(last_parse):prevind(last_parse, last(last_parse))
         partial = scs[r]
         ret, range = completions(partial, endof(partial))
-        range += first(r) - 1
+        range = range .+ (first(r) - 1)
         return ret, range, true
     end
     return String[], 0:-1, false

--- a/base/show.jl
+++ b/base/show.jl
@@ -1653,7 +1653,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 print(io, i == first(rowsA) ? pre : presp)
                 print_matrix_row(io, X,Lalign,i,colsA[1:length(Lalign)],sep)
                 print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)))
-                print_matrix_row(io, X,Ralign,i,n-length(Ralign)+colsA,sep)
+                print_matrix_row(io, X, Ralign, i, (n - length(Ralign)) .+ colsA, sep)
                 print(io, i == last(rowsA) ? post : postsp)
                 if i != last(rowsA); println(io); end
             end
@@ -1681,7 +1681,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 print(io, i == first(rowsA) ? pre : presp)
                 print_matrix_row(io, X,Lalign,i,colsA[1:length(Lalign)],sep)
                 print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)))
-                print_matrix_row(io, X,Ralign,i,n-length(Ralign)+colsA,sep)
+                print_matrix_row(io, X,Ralign,i,(n-length(Ralign)).+colsA,sep)
                 print(io, i == last(rowsA) ? post : postsp)
                 if i != rowsA[end] || i == rowsA[halfheight]; println(io); end
                 if i == rowsA[halfheight]

--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -811,7 +811,7 @@ end
 function get_perm(F::Factor)
     s = unsafe_load(pointer(F))
     p = unsafe_wrap(Array, s.Perm, s.n, false)
-    p + 1
+    p .+ 1
 end
 get_perm(FC::FactorComponent) = get_perm(Factor(FC))
 

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -775,7 +775,7 @@ function kron(a::SparseMatrixCSC{Tv,Ti}, b::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti
             stopB = colptrB[i+1]-1
             lB = stopB - startB + 1
 
-            ptr_range = (1:lB) + (colptr[col]-1)
+            ptr_range = (1:lB) .+ (colptr[col]-1)
 
             colptr[col+1] = colptr[col] + lA * lB
             col += 1
@@ -787,7 +787,7 @@ function kron(a::SparseMatrixCSC{Tv,Ti}, b::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti
                     nzval[ptr] = nzvalA[ptrA] * nzvalB[ptrB]
                     ptrB += 1
                 end
-                ptr_range += lB
+                ptr_range = ptr_range .+ lB
             end
         end
     end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -3115,13 +3115,13 @@ function hcat(X::SparseMatrixCSC...)
     nX_sofar = 0
     @inbounds for i = 1 : num
         XI = X[i]
-        colptr[(1 : nX[i] + 1) + nX_sofar] = XI.colptr .+ nnz_sofar
+        colptr[(1 : nX[i] + 1) .+ nX_sofar] = XI.colptr .+ nnz_sofar
         if nnzX[i] == length(XI.rowval)
-            rowval[(1 : nnzX[i]) + nnz_sofar] = XI.rowval
-            nzval[(1 : nnzX[i]) + nnz_sofar] = XI.nzval
+            rowval[(1 : nnzX[i]) .+ nnz_sofar] = XI.rowval
+            nzval[(1 : nnzX[i]) .+ nnz_sofar] = XI.nzval
         else
-            rowval[(1 : nnzX[i]) + nnz_sofar] = XI.rowval[1:nnzX[i]]
-            nzval[(1 : nnzX[i]) + nnz_sofar] = XI.nzval[1:nnzX[i]]
+            rowval[(1 : nnzX[i]) .+ nnz_sofar] = XI.rowval[1:nnzX[i]]
+            nzval[(1 : nnzX[i]) .+ nnz_sofar] = XI.nzval[1:nnzX[i]]
         end
         nnz_sofar += nnzX[i]
         nX_sofar += nX[i]
@@ -3166,9 +3166,9 @@ function blkdiag(X::SparseMatrixCSC...)
     nX_sofar = 0
     mX_sofar = 0
     for i = 1 : num
-        colptr[(1 : nX[i] + 1) + nX_sofar] = X[i].colptr .+ nnz_sofar
-        rowval[(1 : nnzX[i]) + nnz_sofar] = X[i].rowval .+ mX_sofar
-        nzval[(1 : nnzX[i]) + nnz_sofar] = X[i].nzval
+        colptr[(1 : nX[i] + 1) .+ nX_sofar] = X[i].colptr .+ nnz_sofar
+        rowval[(1 : nnzX[i]) .+ nnz_sofar] = X[i].rowval .+ mX_sofar
+        nzval[(1 : nnzX[i]) .+ nnz_sofar] = X[i].nzval
         nnz_sofar += nnzX[i]
         nX_sofar += nX[i]
         mX_sofar += mX[i]

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -994,7 +994,7 @@ function hvcat(rows::Tuple{Vararg{Int}}, X::_SparseConcatGroup...)
     tmp_rows = Vector{SparseMatrixCSC}(nbr)
     k = 0
     @inbounds for i = 1 : nbr
-        tmp_rows[i] = hcat(X[(1 : rows[i]) + k]...)
+        tmp_rows[i] = hcat(X[(1 : rows[i]) .+ k]...)
         k += rows[i]
     end
     vcat(tmp_rows...)
@@ -1827,7 +1827,7 @@ for isunittri in (true, false), islowertri in (true, false)
                 nzrange = $( (islowertri && !istrans) || (!islowertri && istrans) ?
                     :(b.nzind[1]:b.n) :
                     :(1:b.nzind[end]) )
-                nzrangeviewbnz = view(b.nzval, nzrange - b.nzind[1] + 1)
+                nzrangeviewbnz = view(b.nzval, nzrange .- (b.nzind[1] - 1))
                 nzrangeviewA = $tritype(view(A.data, nzrange, nzrange))
                 ($func)(nzrangeviewA, nzrangeviewbnz)
                 # could strip any miraculous zeros here perhaps
@@ -1892,7 +1892,7 @@ function sort(x::SparseVector{Tv,Ti}; kws...) where {Tv,Ti}
     n,k = length(x),length(allvals)
     z = findfirst(sinds,k)
     newnzind = collect(Ti,1:k-1)
-    newnzind[z:end]+= n-k+1
+    newnzind[z:end] .+= n-k+1
     newnzvals = allvals[deleteat!(sinds[1:k],z)]
     SparseVector(n,newnzind,newnzvals)
 end

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -147,9 +147,9 @@ Base.eachindex(::IndexLinear, A::OffsetVector) = indices(A, 1)
 # Implementations of indices and indices1. Since bounds-checking is
 # performance-critical and relies on indices, these are usually worth
 # optimizing thoroughly.
-@inline Base.indices(A::OffsetArray, d) = 1 <= d <= length(A.offsets) ? indices(parent(A))[d] + A.offsets[d] : (1:1)
+@inline Base.indices(A::OffsetArray, d) = 1 <= d <= length(A.offsets) ? indices(parent(A))[d] .+ A.offsets[d] : (1:1)
 @inline Base.indices(A::OffsetArray) = _indices(indices(parent(A)), A.offsets)  # would rather use ntuple, but see #15276
-@inline _indices(inds, offsets) = (inds[1]+offsets[1], _indices(tail(inds), tail(offsets))...)
+@inline _indices(inds, offsets) = (inds[1] .+ offsets[1], _indices(tail(inds), tail(offsets))...)
 _indices(::Tuple{}, ::Tuple{}) = ()
 Base.indices1(A::OffsetArray{T,0}) where {T} = 1:1  # we only need to specialize this one
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1664,21 +1664,21 @@ end
 
 @testset "binary ops on bool arrays" begin
     A = Array(trues(5))
-    @test A + true == [2,2,2,2,2]
+    @test A .+ true == [2,2,2,2,2]
     A = Array(trues(5))
-    @test A + false == [1,1,1,1,1]
+    @test A .+ false == [1,1,1,1,1]
     A = Array(trues(5))
-    @test true + A == [2,2,2,2,2]
+    @test true .+ A == [2,2,2,2,2]
     A = Array(trues(5))
-    @test false + A == [1,1,1,1,1]
+    @test false .+ A == [1,1,1,1,1]
     A = Array(trues(5))
-    @test A - true == [0,0,0,0,0]
+    @test A .- true == [0,0,0,0,0]
     A = Array(trues(5))
-    @test A - false == [1,1,1,1,1]
+    @test A .- false == [1,1,1,1,1]
     A = Array(trues(5))
-    @test true - A == [0,0,0,0,0]
+    @test true .- A == [0,0,0,0,0]
     A = Array(trues(5))
-    @test false - A == [-1,-1,-1,-1,-1]
+    @test false .- A == [-1,-1,-1,-1,-1]
 end
 
 @testset "simple transposes" begin
@@ -1734,8 +1734,8 @@ module RetTypeDecl
     broadcast(::typeof(*), x::MeterUnits{T,1}, y::MeterUnits{T,1}) where {T} = MeterUnits{T,2}(x.val*y.val)
     convert(::Type{MeterUnits{T,pow}}, y::Real) where {T,pow} = MeterUnits{T,pow}(convert(T,y))
 
-    @test @inferred(m+[m,m]) == [m+m,m+m]
-    @test @inferred([m,m]+m) == [m+m,m+m]
+    @test @inferred(m .+ [m,m]) == [m+m,m+m]
+    @test @inferred([m,m] .+ m) == [m+m,m+m]
     @test @inferred(broadcast(*,m,[m,m])) == [m2,m2]
     @test @inferred(broadcast(*,[m,m],m)) == [m2,m2]
     @test @inferred([m 2m; m m]*[m,m]) == [3m2,2m2]
@@ -1847,7 +1847,7 @@ copy!(S, A)
 @test flipdim(A, 1) == flipdim(B, 1) == flipdim(S, 2)
 @test flipdim(A, 2) == flipdim(B, 2) == flipdim(S, 2)
 
-@test A + 1 == B + 1 == S + 1
+@test A .+ 1 == B .+ 1 == S .+ 1
 @test 2*A == 2*B == 2*S
 @test A/3 == B/3 == S/3
 
@@ -1951,7 +1951,7 @@ end
 
 #issue #18336
 @test cumsum([-0.0, -0.0])[1] === cumsum([-0.0, -0.0])[2] === -0.0
-@test cumprod(-0.0im + (0:0))[1] === Complex(0.0, -0.0)
+@test cumprod(-0.0im .+ (0:0))[1] === Complex(0.0, -0.0)
 
 module TestNLoops15895
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -216,8 +216,8 @@ let A = [sqrt(i)+j for i = 1:3, j=1:4]
     @test atan2.(log.(A), sum(A,1)) == broadcast(atan2, broadcast(log, A), sum(A, 1))
 end
 let x = sin.(1:10)
-    @test atan2.((x->x+1).(x), (x->x+2).(x)) == broadcast(atan2, x+1, x+2) == broadcast(atan2, x.+1, x.+2)
-    @test sin.(atan2.([x+1,x+2]...)) == sin.(atan2.(x+1,x+2)) == @. sin(atan2(x+1,x+2))
+    @test atan2.((x->x+1).(x), (x->x+2).(x)) == broadcast(atan2, x.+1, x.+2)
+    @test sin.(atan2.([x.+1,x.+2]...)) == sin.(atan2.(x.+1 ,x.+2)) == @. sin(atan2(x+1,x+2))
     @test sin.(atan2.(x, 3.7)) == broadcast(x -> sin(atan2(x,3.7)), x)
     @test atan2.(x, 3.7) == broadcast(x -> atan2(x,3.7), x) == broadcast(atan2, x, 3.7)
 end
@@ -411,7 +411,6 @@ end
 @test (-).(C_NULL, C_NULL)::UInt == 0
 @test (+).(1, Ref(2)) == fill(3)
 @test (+).(Ref(1), Ref(2)) == fill(3)
-@test (+).([[0,2], [1,3]], [1,-1]) == [[1,3], [0,2]]
 @test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) == [[1,1], [2,2]]
 
 # Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722),

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -897,8 +897,8 @@ end
 @testset "round and float, PR #8291" begin
     @test round(Complex(1.125, 0.875), 2) == Complex(1.12, 0.88)
     @test round(Complex(1.5, 0.5), RoundDown, RoundUp) == Complex(1.0, 1.0)
-    @test round.([1:5;] + im) == [1:5;] + im
-    @test round.([1:5;] + 0.5im) == [1.0:5.0;]
+    @test round.([1:5;] .+ im) == [1:5;] .+ im
+    @test round.([1:5;] .+ 0.5im) == [1.0:5.0;]
 
     @test float(Complex(1, 2)) == Complex(1.0, 2.0)
     @test round(float(Complex(π, ℯ)),3) == Complex(3.142, 2.718)

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -29,9 +29,9 @@
 
 t = Dates.Year(1)
 t2 = Dates.Year(2)
-@test ([t, t, t, t, t] + Dates.Year(1)) == ([t2, t2, t2, t2, t2])
-@test (Dates.Year(1) + [t, t, t, t, t]) == ([t2, t2, t2, t2, t2])
-@test ([t2, t2, t2, t2, t2] - Dates.Year(1)) == ([t, t, t, t, t])
+@test ([t, t, t, t, t] .+ Dates.Year(1)) == ([t2, t2, t2, t2, t2])
+@test (Dates.Year(1) .+ [t, t, t, t, t]) == ([t2, t2, t2, t2, t2])
+@test ([t2, t2, t2, t2, t2] .- Dates.Year(1)) == ([t, t, t, t, t])
 @test_throws MethodError ([t, t, t, t, t] .* Dates.Year(1)) == ([t, t, t, t, t])
 @test ([t, t, t, t, t] * 1) == ([t, t, t, t, t])
 @test ([t, t, t, t, t] .% t2) == ([t, t, t, t, t])
@@ -352,15 +352,15 @@ cpa = [1y + 1s 1m + 1s 1w + 1s 1d + 1s; 1h + 1s 1mi + 1s 2m + 1s 1s + 1ms]
 @test cpa .+ 1y == [2y + 1s 1y + 1m + 1s 1y + 1w + 1s 1y + 1d + 1s; 1y + 1h + 1s 1y + 1mi + 1s 1y + 2m + 1s 1y + 1ms + 1s]
 @test cpa .+ (1y + 1m) == [2y + 1m + 1s 1y + 2m + 1s 1y + 1m + 1w + 1s 1y + 1m + 1d + 1s; 1y + 1m + 1h + 1s 1y + 1m + 1mi + 1s 1y + 3m + 1s 1y + 1m + 1s + 1ms]
 
-@test 1y + pa == [2y 1y + 1m 1y + 1w 1y + 1d; 1y + 1h 1y + 1mi 1y + 1s 1y + 1ms]
-@test (1y + 1m) + pa == [2y + 1m 1y + 2m 1y + 1m + 1w 1y + 1m + 1d; 1y + 1m + 1h 1y + 1m + 1mi 1y + 1m + 1s 1y + 1m + 1ms]
-@test pa + 1y == [2y 1y + 1m 1y + 1w 1y + 1d; 1y + 1h 1y + 1mi 1y + 1s 1y + 1ms]
-@test pa + (1y + 1m) == [2y + 1m 1y + 2m 1y + 1m + 1w 1y + 1m + 1d; 1y + 1m + 1h 1y + 1m + 1mi 1y + 1m + 1s 1y + 1m + 1ms]
+@test 1y .+ pa == [2y 1y + 1m 1y + 1w 1y + 1d; 1y + 1h 1y + 1mi 1y + 1s 1y + 1ms]
+@test (1y + 1m) .+ pa == [2y + 1m 1y + 2m 1y + 1m + 1w 1y + 1m + 1d; 1y + 1m + 1h 1y + 1m + 1mi 1y + 1m + 1s 1y + 1m + 1ms]
+@test pa .+ 1y == [2y 1y + 1m 1y + 1w 1y + 1d; 1y + 1h 1y + 1mi 1y + 1s 1y + 1ms]
+@test pa .+ (1y + 1m) == [2y + 1m 1y + 2m 1y + 1m + 1w 1y + 1m + 1d; 1y + 1m + 1h 1y + 1m + 1mi 1y + 1m + 1s 1y + 1m + 1ms]
 
-@test 1y + cpa == [2y + 1s 1y + 1m + 1s 1y + 1w + 1s 1y + 1d + 1s; 1y + 1h + 1s 1y + 1mi + 1s 1y + 2m + 1s 1y + 1ms + 1s]
-@test (1y + 1m) + cpa == [2y + 1m + 1s 1y + 2m + 1s 1y + 1m + 1w + 1s 1y + 1m + 1d + 1s; 1y + 1m + 1h + 1s 1y + 1m + 1mi + 1s 1y + 3m + 1s 1y + 1m + 1s + 1ms]
-@test cpa + 1y == [2y + 1s 1y + 1m + 1s 1y + 1w + 1s 1y + 1d + 1s; 1y + 1h + 1s 1y + 1mi + 1s 1y + 2m + 1s 1y + 1ms + 1s]
-@test cpa + (1y + 1m) == [2y + 1m + 1s 1y + 2m + 1s 1y + 1m + 1w + 1s 1y + 1m + 1d + 1s; 1y + 1m + 1h + 1s 1y + 1m + 1mi + 1s 1y + 3m + 1s 1y + 1m + 1s + 1ms]
+@test 1y .+ cpa == [2y + 1s 1y + 1m + 1s 1y + 1w + 1s 1y + 1d + 1s; 1y + 1h + 1s 1y + 1mi + 1s 1y + 2m + 1s 1y + 1ms + 1s]
+@test (1y + 1m) .+ cpa == [2y + 1m + 1s 1y + 2m + 1s 1y + 1m + 1w + 1s 1y + 1m + 1d + 1s; 1y + 1m + 1h + 1s 1y + 1m + 1mi + 1s 1y + 3m + 1s 1y + 1m + 1s + 1ms]
+@test cpa .+ 1y == [2y + 1s 1y + 1m + 1s 1y + 1w + 1s 1y + 1d + 1s; 1y + 1h + 1s 1y + 1mi + 1s 1y + 2m + 1s 1y + 1ms + 1s]
+@test cpa .+ (1y + 1m) == [2y + 1m + 1s 1y + 2m + 1s 1y + 1m + 1w + 1s 1y + 1m + 1d + 1s; 1y + 1m + 1h + 1s 1y + 1m + 1mi + 1s 1y + 3m + 1s 1y + 1m + 1s + 1ms]
 
 @test 1y .- pa == [0y 1y-1m 1y-1w 1y-1d; 1y-1h 1y-1mi 1y-1s 1y-1ms]
 @test (1y + 1m) .- pa == [1m 1y 1y + 1m-1w 1y + 1m-1d; 1y + 1m-1h 1y + 1m-1mi 1y + 1m-1s 1y + 1m-1ms]
@@ -371,16 +371,6 @@ cpa = [1y + 1s 1m + 1s 1w + 1s 1d + 1s; 1h + 1s 1mi + 1s 2m + 1s 1s + 1ms]
 @test (1y + 1m) .- cpa == [1m-1s 1y-1s 1y + 1m-1w-1s 1y + 1m-1d-1s; 1y + 1m-1h-1s 1y + 1m-1mi-1s 1y-1m-1s 1y + 1m-1s-1ms]
 @test cpa .- 1y == [1s -1y + 1m + 1s -1y + 1w + 1s -1y + 1d + 1s; -1y + 1h + 1s -1y + 1mi + 1s -1y + 2m + 1s -1y + 1ms + 1s]
 @test cpa .- (1y + 1m) == [-1m + 1s -1y + 1s -1y-1m + 1w + 1s -1y-1m + 1d + 1s; -1y-1m + 1h + 1s -1y-1m + 1mi + 1s -1y + 1m + 1s -1y + -1m + 1s + 1ms]
-
-@test 1y - pa == [0y 1y-1m 1y-1w 1y-1d; 1y-1h 1y-1mi 1y-1s 1y-1ms]
-@test (1y + 1m) - pa == [1m 1y 1y + 1m-1w 1y + 1m-1d; 1y + 1m-1h 1y + 1m-1mi 1y + 1m-1s 1y + 1m-1ms]
-@test pa - (1y + 1m) == [-1m -1y -1y-1m + 1w -1y-1m + 1d; -1y-1m + 1h -1y-1m + 1mi -1y-1m + 1s -1y-1m + 1ms]
-@test pa - 1y == [0y 1m-1y -1y + 1w -1y + 1d; -1y + 1h -1y + 1mi -1y + 1s -1y + 1ms]
-
-@test 1y - cpa == [-1s 1y-1m-1s 1y-1w-1s 1y-1d-1s; 1y-1h-1s 1y-1mi-1s 1y-2m-1s 1y-1ms-1s]
-@test (1y + 1m) - cpa == [1m-1s 1y-1s 1y + 1m-1w-1s 1y + 1m-1d-1s; 1y + 1m-1h-1s 1y + 1m-1mi-1s 1y-1m-1s 1y + 1m-1s-1ms]
-@test cpa - 1y == [1s -1y + 1m + 1s -1y + 1w + 1s -1y + 1d + 1s; -1y + 1h + 1s -1y + 1mi + 1s -1y + 2m + 1s -1y + 1ms + 1s]
-@test cpa - (1y + 1m) == [-1m + 1s -1y + 1s -1y-1m + 1w + 1s -1y-1m + 1d + 1s; -1y-1m + 1h + 1s -1y-1m + 1mi + 1s -1y + 1m + 1s -1y + -1m + 1s + 1ms]
 
 @test [1y 1m; 1w 1d] + [1h 1mi; 1s 1ms] == [1y + 1h 1m + 1mi; 1w + 1s 1d + 1ms]
 @test [1y 1m; 1w 1d] - [1h 1mi; 1s 1ms] == [1y-1h 1m-1mi; 1w-1s 1d-1ms]

--- a/test/dates/ranges.jl
+++ b/test/dates/ranges.jl
@@ -277,7 +277,7 @@ drs2 = map(x->Dates.Date(first(x)):step(x):Dates.Date(last(x)), drs)
     end
     true
 end
-@test_throws MethodError dr + 1
+@test_throws MethodError dr .+ 1
 a = Dates.DateTime(2013, 1, 1)
 b = Dates.DateTime(2013, 2, 1)
 @test map!(x->x + Dates.Day(1), Array{Dates.DateTime}(32), dr) == [(a + Dates.Day(1)):(b + Dates.Day(1));]
@@ -355,7 +355,7 @@ drs = Any[dr, dr1, dr2, dr3, dr4, dr5, dr6, dr7, dr8, dr9, dr10,
     end
     true
 end
-@test_throws MethodError dr + 1
+@test_throws MethodError dr .+ 1
 a = Dates.Date(2013, 1, 1)
 b = Dates.Date(2013, 2, 1)
 @test map!(x->x + Dates.Day(1), Array{Dates.Date}(32), dr) == [(a + Dates.Day(1)):(b + Dates.Day(1));]
@@ -538,7 +538,7 @@ drs = Any[dr, dr1, dr2, dr3, dr8, dr9, dr10,
 @test all(x->reverse(x) == last(x): - step(x):first(x), drs)
 @test all(x->minimum(x) == (step(x) < zero(step(x)) ? last(x) : first(x)), drs[4:end])
 @test all(x->maximum(x) == (step(x) < zero(step(x)) ? first(x) : last(x)), drs[4:end])
-@test_throws MethodError dr + 1
+@test_throws MethodError dr .+ 1
 
 a = Dates.Time(23, 1, 1)
 @test map(x->a in x, drs[1:4]) == [true, true, false, true]

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -8,13 +8,13 @@ types = Any[
 ]
 vals = vcat(
     typemin(Int64),
-    -Int64(maxintfloat(Float64))+Int64[-4:1;],
+    -Int64(maxintfloat(Float64)) .+ Int64[-4:1;],
     typemin(Int32),
-    -Integer(maxintfloat(Float32))+(-4:1),
+    -Integer(maxintfloat(Float32)) .+ (-4:1),
     -2:2,
-    Integer(maxintfloat(Float32))+(-1:4),
+    Integer(maxintfloat(Float32)) .+ (-1:4),
     typemax(Int32),
-    Int64(maxintfloat(Float64))+Int64[-1:4;],
+    Int64(maxintfloat(Float64)) .+ Int64[-1:4;],
     typemax(Int64),
 )
 

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -565,7 +565,7 @@ tpara18457(::Type{A}) where {A<:AbstractMyType18457} = tpara18457(supertype(A))
 @test tpara18457(MyType18457{true}) === true
 
 @testset "type inference error #19322" begin
-    Y_19322 = reshape(round.(Int, abs.(randn(5*1000)))+1,1000,5)
+    Y_19322 = reshape(round.(Int, abs.(randn(5*1000))) .+ 1, 1000, 5)
 
     function FOO_19322(Y::AbstractMatrix; frac::Float64=0.3, nbins::Int=100, n_sims::Int=100)
         num_iters, num_chains = size(Y)

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -259,7 +259,7 @@ end
 end
 
 @testset "isposdef" begin
-    @test isposdef(Diagonal(1.0 + rand(n)))
+    @test isposdef(Diagonal(1.0 .+ rand(n)))
     @test !isposdef(Diagonal(-1.0 * rand(n)))
 end
 

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -397,12 +397,12 @@ end
         @test Y - I == T([0 -1; -1 0])
         @test Y * I == Y
 
-        @test Y + 1 == T([2 0; 0 2])
-        @test Y - 1 == T([0 -2; -2 0])
+        @test Y .+ 1 == T([2 0; 0 2])
+        @test Y .- 1 == T([0 -2; -2 0])
         @test Y * 2 == T([2 -2; -2 2])
         @test Y / 1 == Y
 
-        @test T([true false; false true]) + true == T([2 1; 1 2])
+        @test T([true false; false true]) .+ true == T([2 1; 1 2])
     end
 
     @test_throws ArgumentError Hermitian(X) + 2im*I
@@ -432,8 +432,8 @@ end
 @testset "inversion of Hilbert matrix" begin
     for T in (Float64, Complex128)
         H = T[1/(i + j - 1) for i in 1:8, j in 1:8]
-        @test norm(inv(Symmetric(H))*(H*ones(8))-1) ≈ 0 atol = 1e-5
-        @test norm(inv(Hermitian(H))*(H*ones(8))-1) ≈ 0 atol = 1e-5
+        @test norm(inv(Symmetric(H))*(H*ones(8)) .- 1) ≈ 0 atol = 1e-5
+        @test norm(inv(Hermitian(H))*(H*ones(8)) .- 1) ≈ 0 atol = 1e-5
     end
 end
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -28,7 +28,7 @@ let n = 12 #Size of matrix problem to test
             b = rand(1:100, n)
             c = rand(1:100, n-1)
         else
-            d = convert(Vector{elty}, 1. + randn(n))
+            d = convert(Vector{elty}, 1 .+ randn(n))
             dl = convert(Vector{elty}, randn(n - 1))
             du = convert(Vector{elty}, randn(n - 1))
             v = convert(Vector{elty}, randn(n))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1706,7 +1706,7 @@ let ≈(x,y) = x==y && typeof(x)==typeof(y)
     for t in [Float32,Float64]
         # try different vector lengths
         for n in [0,3,255,256]
-            r = (1:n)-div(n,2)
+            r = (1:n) .- div(n,2)
             y = t[x/4 for x in r]
             @test trunc.(y) ≈ t[div(i,4) for i in r]
             @test floor.(y) ≈ t[i>>2 for i in r]

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -383,7 +383,7 @@ v = OffsetArray(rand(8), (-2,))
 @test flipdim(A, 1) == OffsetArray(flipdim(parent(A), 1), A.offsets)
 @test flipdim(A, 2) == OffsetArray(flipdim(parent(A), 2), A.offsets)
 
-@test A+1 == OffsetArray(parent(A)+1, A.offsets)
+@test A .+ 1 == OffsetArray(parent(A) .+ 1, A.offsets)
 @test 2*A == OffsetArray(2*parent(A), A.offsets)
 @test A+A == OffsetArray(parent(A)+parent(A), A.offsets)
 @test A.*A == OffsetArray(parent(A).*parent(A), A.offsets)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -33,7 +33,7 @@ for region in Any[
     # With init=false
     r2 = similar(r)
     fill!(r, 1)
-    @test sum!(r, Areduc, init=false) ≈ safe_sum(Areduc, region)+1
+    @test sum!(r, Areduc, init=false) ≈ safe_sum(Areduc, region) .+ 1
     fill!(r, 2.2)
     @test prod!(r, Areduc, init=false) ≈ safe_prod(Areduc, region)*2.2
     fill!(r, 1.8)
@@ -41,9 +41,9 @@ for region in Any[
     fill!(r, -0.2)
     @test minimum!(r, Areduc, init=false) ≈ fill!(r2, -0.2)
     fill!(r, 8.1)
-    @test sum!(abs, r, Areduc, init=false) ≈ safe_sumabs(Areduc, region)+8.1
+    @test sum!(abs, r, Areduc, init=false) ≈ safe_sumabs(Areduc, region) .+ 8.1
     fill!(r, 8.1)
-    @test sum!(abs2, r, Areduc, init=false) ≈ safe_sumabs2(Areduc, region)+8.1
+    @test sum!(abs2, r, Areduc, init=false) ≈ safe_sumabs2(Areduc, region) .+ 8.1
     fill!(r, 1.5)
     @test maximum!(abs, r, Areduc, init=false) ≈ fill!(r2, 1.5)
     fill!(r, -1.5)
@@ -71,11 +71,11 @@ r = fill(NaN, map(length, Base.reduced_indices(indices(Breduc), 1)))
 @test sum(abs2, Breduc, 1) ≈ safe_sumabs2(Breduc, 1)
 
 fill!(r, 4.2)
-@test sum!(r, Breduc, init=false) ≈ safe_sum(Breduc, 1)+4.2
+@test sum!(r, Breduc, init=false) ≈ safe_sum(Breduc, 1) .+ 4.2
 fill!(r, -6.3)
-@test sum!(abs, r, Breduc, init=false) ≈ safe_sumabs(Breduc, 1)-6.3
+@test sum!(abs, r, Breduc, init=false) ≈ safe_sumabs(Breduc, 1) .- 6.3
 fill!(r, -1.1)
-@test sum!(abs2, r, Breduc, init=false) ≈ safe_sumabs2(Breduc, 1)-1.1
+@test sum!(abs2, r, Breduc, init=false) ≈ safe_sumabs2(Breduc, 1) .- 1.1
 
 # Small arrays with init=false
 A = reshape(1:15, 3, 5)

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -693,7 +693,7 @@ end
     SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1], Float64[]),
     SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[], Float64[1.0]),
     SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1], Float64[1.0]))
-    @test_throws ArgumentError CHOLMOD.Sparse(size(A_)..., A_.colptr - 1, A_.rowval - 1, A_.nzval)
+    @test_throws ArgumentError CHOLMOD.Sparse(size(A_)..., A_.colptr .- 1, A_.rowval .- 1, A_.nzval)
     @test_throws ArgumentError CHOLMOD.Sparse(A_)
 end
 

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -448,15 +448,15 @@ end
     for f in (sum, prod, minimum, maximum)
         # Test with a map function that maps to non-zero
         for arr in (se33, sA, pA)
-            @test f(x->x+1, arr) ≈ f(arr+1)
+            @test f(x->x+1, arr) ≈ f(arr .+ 1)
         end
 
         # case where f(0) would throw
-        @test f(x->sqrt(x-1), pA+1) ≈ f(sqrt.(pA))
+        @test f(x->sqrt(x-1), pA .+ 1) ≈ f(sqrt.(pA))
         # these actually throw due to #10533
-        # @test f(x->sqrt(x-1), pA+1, 1) ≈ f(sqrt(pA), 1)
-        # @test f(x->sqrt(x-1), pA+1, 2) ≈ f(sqrt(pA), 2)
-        # @test f(x->sqrt(x-1), pA+1, 3) ≈ f(pA)
+        # @test f(x->sqrt(x-1), pA .+ 1, 1) ≈ f(sqrt(pA), 1)
+        # @test f(x->sqrt(x-1), pA .+ 1, 2) ≈ f(sqrt(pA), 2)
+        # @test f(x->sqrt(x-1), pA .+ 1, 3) ≈ f(pA)
     end
 
     @testset "empty cases" begin
@@ -1844,8 +1844,8 @@ end
         @test Y - I == T(sparse([0 -1; -1 0]))
         @test Y * I == Y
 
-        @test Y + 1 == T(sparse([2 0; 0 2]))
-        @test Y - 1 == T(sparse([0 -2; -2 0]))
+        @test Y .+ 1 == T(sparse([2 0; 0 2]))
+        @test Y .- 1 == T(sparse([0 -2; -2 0]))
         @test Y * 2 == T(sparse([2 -2; -2 2]))
         @test Y / 1 == Y
     end

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -6,7 +6,7 @@ let
     @noinline child() = stacktrace()
     @noinline parent() = child()
     @noinline grandparent() = parent()
-    line_numbers = @__LINE__() - [3, 2, 1]
+    line_numbers = @__LINE__() .- [3, 2, 1]
     stack = grandparent()
 
     # Basic tests.

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -349,7 +349,7 @@ y = [0.40003674665581906,0.4085630862624367,0.41662034698690303,0.41662034698690
 
 # variance of complex arrays (#13309)
 let z = rand(Complex128, 10)
-    @test var(z) ≈ invoke(var, Tuple{Any}, z) ≈ cov(z) ≈ var(z,1)[1] ≈ sum(abs2, z - mean(z))/9
+    @test var(z) ≈ invoke(var, Tuple{Any}, z) ≈ cov(z) ≈ var(z,1)[1] ≈ sum(abs2, z .- mean(z))/9
     @test isa(var(z), Float64)
     @test isa(invoke(var, Tuple{Any}, z), Float64)
     @test isa(cov(z), Float64)


### PR DESCRIPTION
There has been much discussion around this lately. This PR deprecates `array + scalar` (and related) in favor of `array .+ scalar` for v0.7 (with the possibility of introducing behavior such that `matrix + scalar == matrix + scalar*I` in v1.0 in a separate PR).

The arguments for changing the behavior of `array + scalar` from elementwise are:

 * Apart from the binary `Number`/`AbstractArray` methods deprecated in this PR, all the other methods of `+`, `-`, `*`, `/` involving `AbstractArray` are motivated by and consistent with linear algebra. For instance `vector + vector` is defined because `vector` belongs to a vector space (not because `vector .+ vector` is inconvenient) and a such, the entire container adds (not just the elements). However, the current element-wise definition seems to be incorrect for linear algebra. For instance, if I write a polynomial function such as `f(a,b,c,x) = a*x^2 + b*x + c`, I expect it to work for any `x` that belongs to a field/ring/whatever. However, this definition is broken if `x` is a square matrix - you expect behavior like `f(a,b,c,x) = a*x^2 + b*x + c*I` but currently the `c` is added to all parts of the matrix, not just the diagonal part. It is therefore difficult to write generic code that works for a wide range of types of `x` (though I would note `a*x*x + b*x + c*one(x)` currently works for `x::Number` and `x::AbstractMatrix`, though the extra `one` seems unnatural).
 * It seems to violate a property of `one` that you might expect, whereby `array + scalar != array + scalar*one(array)`
 * AFAIK these are the last auto-vectorized methods that haven't been deprecated as a part of the dot-call changes (e.g. `sin(array)` no longer works; rather `sin.(array)` is necessary). In this situation, I would actually argue that `array .+ scalar` for elementwise addition is less confusing... it's less of a special case.

The primary arguments against (that I am aware of) are:

 * The current `array + scalar` behavior is convenient (though `.+` is hardly much harder to type that `+`).
 * We tried this once before and it was difficult (before the dot-call convention was introduced and well-known?)

