### PR TITLE
fix spurious exception printing on custom topologies

### DIFF
--- a/base/distributed/process_messages.jl
+++ b/base/distributed/process_messages.jl
@@ -196,11 +196,14 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
         end
     catch e
         # Check again as it may have been set in a message handler but not propagated to the calling block above
-        wpid = worker_id_from_socket(r_stream)
-        if (wpid < 1)
+        if wpid < 1
+            wpid = worker_id_from_socket(r_stream)
+        end
+
+        if wpid < 1
             println(STDERR, e, CapturedException(e, catch_backtrace()))
             println(STDERR, "Process($(myid())) - Unknown remote, closing connection.")
-        else
+        elseif !(wpid in map_del_wrkr)
             werr = worker_from_id(wpid)
             oldstate = werr.state
             set_worker_state(werr, W_TERMINATED)

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -21,7 +21,7 @@ end
 
 function remove_workers_and_test()
     while nworkers() > 0
-        rmprocs(workers()[1]; waitfor=2.0)
+        rmprocs(workers()[1])
         test_worker_counts()
         if nworkers() == nprocs()
             break


### PR DESCRIPTION
I could finally reproduce the spurious warnings first reported at https://github.com/JuliaLang/julia/pull/21933#issuecomment-308018234 locally.

This PR fixes the same.  