### PR TITLE
fix most doctest errors

### DIFF
--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -972,7 +972,7 @@ julia> parse("x = ")
 julia> parse("1.0.2")
 ERROR: ParseError("invalid numeric constant \\\"1.0.\\\"")
 Stacktrace:
-  [...]
+[...]
 
 julia> parse("1.0.2"; raise = false)
 :($(Expr(:error, "invalid numeric constant \"1.0.\"")))
@@ -1328,10 +1328,12 @@ The argument `val` to a function or constructor is outside the valid domain.
 # Examples
 ```jldoctest
 julia> sqrt(-1)
-ERROR: DomainError with -1:
-sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
+ERROR: DomainError with -1.0:
+sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 Stacktrace:
- [1] sqrt(::Int64) at ./math.jl:443
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
+ [2] sqrt at ./math.jl:462 [inlined]
+ [3] sqrt(::Int64) at ./math.jl:472
 ```
 """
 DomainError

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -100,7 +100,7 @@ is always recursive. For a non recursive macro version, see [`@macroexpand1`](@r
 * While [`macroexpand`](@ref) has an explicit `module` argument, `@macroexpand` always
 expands with respect to the module in which it is called.
 This is best seen in the following example:
-```jldoctest
+```julia-repl
 julia> module M
            macro m()
                1

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -298,6 +298,7 @@ julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]
 julia> C = cholfact(A)
 Base.LinAlg.Cholesky{Float64,Array{Float64,2}} with factor:
 [2.0 6.0 -8.0; 0.0 1.0 5.0; 0.0 0.0 3.0]
+successful: true
 
 julia> C[:U]
 3×3 UpperTriangular{Float64,Array{Float64,2}}:

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -133,6 +133,7 @@ julia> F = lufact(A)
 Base.LinAlg.LU{Float64,Array{Float64,2}} with factors L and U:
 [1.0 0.0; 1.5 1.0]
 [4.0 3.0; 0.0 -1.5]
+successful: true
 
 julia> F[:L] * F[:U] == A[F[:p], :]
 true

--- a/base/math.jl
+++ b/base/math.jl
@@ -484,10 +484,12 @@ julia> hypot(a, a)
 1.4142135623730951e10
 
 julia> √(a^2 + a^2) # a^2 overflows
-ERROR: DomainError with -2914184810805067776:
-sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
+ERROR: DomainError with -2.914184810805068e18:
+sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 Stacktrace:
- [1] sqrt(::Int64) at ./math.jl:447
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
+ [2] sqrt at ./math.jl:462 [inlined]
+ [3] sqrt(::Int64) at ./math.jl:472
 ```
 """
 hypot(x::Number, y::Number) = hypot(promote(x, y)...)

--- a/base/random.jl
+++ b/base/random.jl
@@ -1344,10 +1344,10 @@ julia> rng = MersenneTwister(1234);
 julia> randn(rng, Complex128)
 0.6133070881429037 - 0.6376291670853887im
 
-julia> randn(rng, Complex64, (2, 4))
-2×4 Array{Complex{Float32},2}:
- -0.349649-0.638457im  0.376756-0.192146im  -0.396334-0.0136413im  -0.585317+0.0778497im
-  0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im    -0.177608+0.261427im
+julia> randn(rng, Complex64, (2, 3))
+2×3 Array{Complex{Float32},2}:
+ -0.349649-0.638457im  0.376756-0.192146im  -0.396334-0.0136413im
+  0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im
 ```
 """
 @inline function randn(rng::AbstractRNG=GLOBAL_RNG)

--- a/base/set.jl
+++ b/base/set.jl
@@ -333,8 +333,8 @@ julia> sort!(B);  # unique! is able to process sorted data much more efficiently
 
 julia> unique!(B)
 3-element Array{Int64,1}:
- 6
- 7
+  6
+  7
  42
 ```
 """

--- a/base/sparse/spqr.jl
+++ b/base/sparse/spqr.jl
@@ -187,7 +187,7 @@ Row permutation:
  3
  4
  2
-Columns permutation:
+Column permutation:
 2-element Array{Int64,1}:
  1
  2

--- a/doc/src/devdocs/cartesian.md
+++ b/doc/src/devdocs/cartesian.md
@@ -51,7 +51,7 @@ practice is to read from left to right, which is why `@nloops` is `@nloops 3 i A
 is `@nref 3 A i` (as in `A[i_1,i_2,i_3]`, where the array comes first).
 
 If you're developing code with Cartesian, you may find that debugging is easier when you examine
-the generated code, using `macroexpand`:
+the generated code, using `@macroexpand`:
 
 ```@meta
 DocTestSetup = quote
@@ -60,7 +60,7 @@ end
 ```
 
 ```jldoctest
-julia> macroexpand(:(@nref 2 A i))
+julia> @macroexpand @nref 2 A i
 :(A[i_1, i_2])
 ```
 

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -84,7 +84,7 @@ the unquoted and interpolated expression (`Expr`) form for a given macro. To use
 be passed instead!). For example:
 
 ```jldoctest
-julia> macroexpand( :(@edit println("")) )
+julia> macroexpand(@__MODULE__, :(@edit println("")) )
 :((Base.edit)(println, (Base.typesof)("")))
 ```
 
@@ -96,7 +96,7 @@ particular interest for understanding both macros and top-level statements such 
 and variable assignments:
 
 ```jldoctest
-julia> expand( :(f() = 1) )
+julia> expand(@__MODULE__, :(f() = 1) )
 :(begin
         $(Expr(:method, :f))
         $(Expr(:method, :f, :((Core.svec)((Core.svec)((Core.Typeof)(f)), (Core.svec)())), CodeInfo(:(begin

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -238,7 +238,7 @@ julia> MyType{Float32, 5}
 MyType{Float32,5}
 
 julia> MyType.body.body.name.cache
-svec(MyType{Float32,5}, MyType{Int64,2}, #undef, #undef, #undef, #undef, #undef, #undef)
+svec(MyType{Int64,2}, MyType{Float32,5}, #undef, #undef, #undef, #undef, #undef, #undef)
 ```
 
 (The cache is pre-allocated to have length 8, but only the first two entries are populated.) Consequently,

--- a/doc/src/manual/complex-and-rational-numbers.md
+++ b/doc/src/manual/complex-and-rational-numbers.md
@@ -140,10 +140,12 @@ when applied to `-1` versus `-1 + 0im` even though `-1 == -1 + 0im`:
 
 ```jldoctest
 julia> sqrt(-1)
-ERROR: DomainError:
-sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
+ERROR: DomainError with -1.0:
+sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 Stacktrace:
- [1] sqrt(::Int64) at ./math.jl:447
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
+ [2] sqrt at ./math.jl:462 [inlined]
+ [3] sqrt(::Int64) at ./math.jl:472
 
 julia> sqrt(-1 + 0im)
 0.0 + 1.0im

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -299,9 +299,9 @@ julia> Point{Int64}(1, 2) ## explicit T ##
 Point{Int64}(1, 2)
 
 julia> Point{Int64}(1.0,2.5) ## explicit T ##
-ERROR: InexactError()
+ERROR: InexactError: convert(Int64, 2.5)
 Stacktrace:
- [1] convert(::Type{Int64}, ::Float64) at ./float.jl:680
+ [1] convert at ./float.jl:681 [inlined]
  [2] Point{Int64}(::Float64, ::Float64) at ./none:2
 
 julia> Point{Float64}(1.0, 2.5) ## explicit T ##

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -570,10 +570,12 @@ real value:
 
 ```jldoctest
 julia> sqrt(-1)
-ERROR: DomainError:
-sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
+ERROR: DomainError with -1.0:
+sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 Stacktrace:
- [1] sqrt(::Int64) at ./math.jl:447
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
+ [2] sqrt at ./math.jl:462 [inlined]
+ [3] sqrt(::Int64) at ./math.jl:472
 ```
 
 You may define your own exceptions in the following way:
@@ -589,14 +591,15 @@ for nonnegative numbers could be written to [`throw()`](@ref) a [`DomainError`](
 is negative:
 
 ```jldoctest
-julia> f(x) = x>=0 ? exp(-x) : throw(DomainError())
+julia> f(x) = x>=0 ? exp(-x) : throw(DomainError(x, "argument must be nonnegative"))
 f (generic function with 1 method)
 
 julia> f(1)
 0.36787944117144233
 
 julia> f(-1)
-ERROR: DomainError:
+ERROR: DomainError with -1:
+argument must be nonnegative
 Stacktrace:
  [1] f(::Int64) at ./none:1
 ```
@@ -605,7 +608,7 @@ Note that [`DomainError`](@ref) without parentheses is not an exception, but a t
 It needs to be called to obtain an `Exception` object:
 
 ```jldoctest
-julia> typeof(DomainError()) <: Exception
+julia> typeof(DomainError(nothing)) <: Exception
 true
 
 julia> typeof(DomainError) <: Exception
@@ -759,9 +762,13 @@ julia> sqrt_second(9)
 3.0
 
 julia> sqrt_second(-9)
-ERROR: DomainError:
+ERROR: DomainError with -9.0:
+sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 Stacktrace:
- [1] sqrt_second(::Int64) at ./none:7
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
+ [2] sqrt at ./math.jl:462 [inlined]
+ [3] sqrt at ./math.jl:472 [inlined]
+ [4] sqrt_second(::Int64) at ./none:7
 ```
 
 Note that the symbol following `catch` will always be interpreted as a name for the exception,

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -119,9 +119,9 @@ julia> convert(Bool, 0)
 false
 
 julia> convert(Bool, 1im)
-ERROR: InexactError()
+ERROR: InexactError: convert(Bool, 0 + 1im)
 Stacktrace:
- [1] convert(::Type{Bool}, ::Complex{Int64}) at ./complex.jl:31
+ [1] convert(::Type{Bool}, ::Complex{Int64}) at ./complex.jl:37
 
 julia> convert(Bool, 0im)
 false

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -225,18 +225,21 @@ Certain operations make mathematical sense but result in errors:
 
 ```jldoctest
 julia> sqrt(-2.0)
-ERROR: DomainError:
-sqrt will only return a complex result if called with a complex argument. Try sqrt(complex(x)).
+ERROR: DomainError with -2.0:
+sqrt will only return a complex result if called with a complex argument. Try sqrt(Complex(x)).
 Stacktrace:
- [1] sqrt(::Float64) at ./math.jl:438
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
+ [2] sqrt(::Float64) at ./math.jl:462
 
 julia> 2^-5
-ERROR: DomainError:
-Cannot raise an integer x to a negative power -n.
-Make x a float by adding a zero decimal (e.g. 2.0^-n instead of 2^-n), or write 1/x^n, float(x)^-n, or (x//1)^-n.
+ERROR: DomainError with -5:
+Cannot raise an integer x to a negative power -5.
+Make x a float by adding a zero decimal (e.g., 2.0^-5 instead of 2^-5), or write 1/x^5, float(x)^-5, or (x//1)^-5
 Stacktrace:
- [1] power_by_squaring(::Int64, ::Int64) at ./intfuncs.jl:173
- [2] literal_pow(::Base.#^, ::Int64, ::Type{Val{-5}}) at ./intfuncs.jl:208
+ [1] throw_domerr_powbysq(::Int64) at ./intfuncs.jl:163
+ [2] power_by_squaring at ./intfuncs.jl:178 [inlined]
+ [3] ^ at ./intfuncs.jl:202 [inlined]
+ [4] literal_pow(::Base.#^, ::Int64, ::Val{-5}) at ./intfuncs.jl:213
 ```
 
 This behavior is an inconvenient consequence of the requirement for type-stability.  In the case

--- a/doc/src/manual/linear-algebra.md
+++ b/doc/src/manual/linear-algebra.md
@@ -62,6 +62,7 @@ julia> factorize(A)
 Base.LinAlg.LU{Float64,Array{Float64,2}} with factors L and U:
 [1.0 0.0 0.0; -0.15 1.0 0.0; -0.3 -0.132196 1.0]
 [-10.0 2.3 4.0; 0.0 2.345 -3.4; 0.0 0.0 -5.24947]
+successful: true
 ```
 
 Since `A` is not Hermitian, symmetric, triangular, tridiagonal, or bidiagonal, an LU factorization may be the
@@ -249,4 +250,3 @@ of the standard library documentation.
 | `Eigen`           | [Spectral decomposition](https://en.wikipedia.org/wiki/Eigendecomposition_(matrix))                            |
 | `SVD`             | [Singular value decomposition](https://en.wikipedia.org/wiki/Singular_value_decomposition)                     |
 | `GeneralizedSVD`  | [Generalized SVD](https://en.wikipedia.org/wiki/Generalized_singular_value_decomposition#Higher_order_version) |
-

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -400,23 +400,26 @@ julia> Int8(127)
 127
 
 julia> Int8(128)
-ERROR: InexactError()
+ERROR: InexactError: trunc(Int8, 128)
 Stacktrace:
- [1] Int8(::Int64) at ./sysimg.jl:102
+ [1] throw_inexacterror(::Symbol, ::Type{Int8}, ::Int64) at ./int.jl:34
+ [2] checked_trunc_sint at ./int.jl:419 [inlined]
+ [3] convert at ./int.jl:439 [inlined]
+ [4] Int8(::Int64) at ./sysimg.jl:102
 
 julia> Int8(127.0)
 127
 
 julia> Int8(3.14)
-ERROR: InexactError()
+ERROR: InexactError: convert(Int8, 3.14)
 Stacktrace:
- [1] convert(::Type{Int8}, ::Float64) at ./float.jl:659
+ [1] convert at ./float.jl:660 [inlined]
  [2] Int8(::Float64) at ./sysimg.jl:102
 
 julia> Int8(128.0)
-ERROR: InexactError()
+ERROR: InexactError: convert(Int8, 128.0)
 Stacktrace:
- [1] convert(::Type{Int8}, ::Float64) at ./float.jl:659
+ [1] convert at ./float.jl:660 [inlined]
  [2] Int8(::Float64) at ./sysimg.jl:102
 
 julia> 127 % Int8
@@ -429,9 +432,9 @@ julia> round(Int8,127.4)
 127
 
 julia> round(Int8,127.6)
-ERROR: InexactError()
+ERROR: InexactError: trunc(Int8, 128.0)
 Stacktrace:
- [1] trunc(::Type{Int8}, ::Float64) at ./float.jl:652
+ [1] trunc at ./float.jl:653 [inlined]
  [2] round(::Type{Int8}, ::Float64) at ./float.jl:338
 ```
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -421,9 +421,9 @@ Hello, human
 We can view the quoted return expression using the function [`macroexpand()`](@ref) (**important note:**
 this is an extremely useful tool for debugging macros):
 
-```jldoctest sayhello2
-julia> ex = macroexpand( :(@sayhello("human")) )
-:((println)("Hello, ", "human"))
+```julia-repl sayhello2
+julia> ex = macroexpand(Main, :(@sayhello("human")) )
+:((Main.println)("Hello, ", "human"))
 
 julia> typeof(ex)
 Expr
@@ -448,21 +448,21 @@ Macros are necessary because they execute when code is parsed, therefore, macros
 to generate and include fragments of customized code *before* the full program is run. To illustrate
 the difference, consider the following example:
 
-```jldoctest whymacros
+```julia-repl whymacros
 julia> macro twostep(arg)
            println("I execute at parse time. The argument is: ", arg)
            return :(println("I execute at runtime. The argument is: ", $arg))
        end
 @twostep (macro with 1 method)
 
-julia> ex = macroexpand( :(@twostep :(1, 2, 3)) );
+julia> ex = macroexpand(Main, :(@twostep :(1, 2, 3)) );
 I execute at parse time. The argument is: $(Expr(:quote, :((1, 2, 3))))
 ```
 
 The first call to [`println()`](@ref) is executed when [`macroexpand()`](@ref) is called. The
 resulting expression contains *only* the second `println`:
 
-```jldoctest whymacros
+```julia-repl whymacros
 julia> typeof(ex)
 Expr
 
@@ -596,21 +596,21 @@ Now `@assert` has two modes of operation, depending upon the number of arguments
 If there's only one argument, the tuple of expressions captured by `msgs` will be empty and it
 will behave the same as the simpler definition above. But now if the user specifies a second argument,
 it is printed in the message body instead of the failing expression. You can inspect the result
-of a macro expansion with the aptly named [`macroexpand()`](@ref) function:
+of a macro expansion with the aptly named [`@macroexpand`](@ref) macro:
 
-```jldoctest assert2
-julia> macroexpand(:(@assert a == b))
-:(if a == b
-        nothing
+```julia-repl assert2
+julia> @macroexpand @assert a == b
+:(if Main.a == Main.b
+        Main.nothing
     else
-        (throw)((AssertionError)("a == b"))
+        (Main.throw)((Main.AssertionError)("a == b"))
     end)
 
-julia> macroexpand(:(@assert a==b "a should equal b!"))
-:(if a == b
-        nothing
+julia> @macroexpand @assert a==b "a should equal b!"
+:(if Main.a == Main.b
+        Main.nothing
     else
-        (throw)((AssertionError)("a should equal b!"))
+        (Main.throw)((Main.AssertionError)("a should equal b!"))
     end)
 ```
 

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -513,15 +513,10 @@ julia> contains("Xylophon", "a")
 false
 
 julia> contains("Xylophon", 'o')
-ERROR: MethodError: no method matching contains(::String, ::Char)
-Closest candidates are:
-  contains(!Matched::Function, ::Any, !Matched::Any) at reduce.jl:664
-  contains(::AbstractString, !Matched::AbstractString) at strings/search.jl:378
+true
 ```
 
-The last error is because `'o'` is a character literal, and [`contains()`](@ref) is a generic
-function that looks for subsequences. To look for an element in a sequence, you must use [`in()`](@ref)
-instead.
+The last example shows that [`contains()`](@ref) can also look for a character literal.
 
 Two other handy string functions are [`repeat()`](@ref) and [`join()`](@ref):
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1318,7 +1318,8 @@ for cases where you don't need a more elaborate hierarchy.
 ```jldoctest valtype
 julia> struct Val{x}
        end
-       Base.@pure Val(x) = Val{x}()
+
+julia> Base.@pure Val(x) = Val{x}()
 Val
 ```
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -343,9 +343,9 @@ must be convertible to `Int`:
 
 ```jldoctest footype
 julia> Foo((), 23.5, 1)
-ERROR: InexactError()
+ERROR: InexactError: convert(Int64, 23.5)
 Stacktrace:
- [1] convert(::Type{Int64}, ::Float64) at ./float.jl:680
+ [1] convert at ./float.jl:681 [inlined]
  [2] Foo(::Tuple{}, ::Float64, ::Int64) at ./none:2
 ```
 
@@ -1318,7 +1318,8 @@ for cases where you don't need a more elaborate hierarchy.
 ```jldoctest valtype
 julia> struct Val{x}
        end
-Base.@pure Val(x) = Val{x}()
+       Base.@pure Val(x) = Val{x}()
+Val
 ```
 
 There is no more to the implementation of `Val` than this.  Some functions in Julia's standard


### PR DESCRIPTION
Most of the errors came from `InexactError/DomainError` which now take arguments, and from `macroexpand` which must be given a module. Sometimes, I had to disable the doctest (using `julia-repl` instead), because at the repl some identifier are prefixed with `Main.`, which is not the case when doctesting. But it could be better to put back `jldoctest` even if it errors out when doctesting, to catch future other errors. For one example (`randn`), the problem came from using too much horizontal space (some values were replaced by horizontal dots); I don't know if the screen width can be parameterized in doctests, but it was simpler to change the array dimensions. 