### PR TITLE
REPL: tab/backspace aligns to 4

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -478,7 +478,7 @@ function edit_insert(buf::IOBuffer, c)
     end
 end
 
-function edit_backspace(s::PromptState, multispaces::Bool=true)
+function edit_backspace(s::PromptState, multispaces::Bool=false)
     if edit_backspace(s.input_buffer, multispaces)
         refresh_line(s)
     else
@@ -486,7 +486,7 @@ function edit_backspace(s::PromptState, multispaces::Bool=true)
     end
 end
 
-function edit_backspace(buf::IOBuffer, multispaces::Bool=true)
+function edit_backspace(buf::IOBuffer, multispaces::Bool=false)
     oldpos = position(buf)
     if oldpos > 0
         c = char_move_left(buf)
@@ -1386,7 +1386,7 @@ AnyDict(
     end,
     '\n' => KeyAlias('\r'),
     # Backspace/^H
-    '\b' => (s,o...)->edit_backspace(s),
+    '\b' => (s,o...)->edit_backspace(s, true),
     127 => KeyAlias('\b'),
     # Meta Backspace
     "\e\b" => (s,o...)->edit_delete_prev_word(s),

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -435,28 +435,75 @@ end
         buf = LineEdit.buffer(s)
         String(buf.data[1:buf.size])
     end
+    move_left(s, n) = for x = 1:n
+        LineEdit.edit_move_left(s)
+    end
+
+    bufpos(s::Base.LineEdit.MIState) = position(LineEdit.buffer(s))
 
     LineEdit.edit_insert(s, "for x=1:10\n")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    "
-    LineEdit.edit_backspace(s, true)
+    LineEdit.edit_backspace(s, true, false)
     @test bufferdata(s) == "for x=1:10\n"
     LineEdit.edit_insert(s, "  ")
+    @test bufpos(s) == 13
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    "
     LineEdit.edit_insert(s, "  ")
-    LineEdit.edit_backspace(s, true)
+    LineEdit.edit_backspace(s, true, false)
     @test bufferdata(s) == "for x=1:10\n    "
     LineEdit.edit_insert(s, "éé=3   ")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    éé=3    "
-    LineEdit.edit_backspace(s, true)
+    LineEdit.edit_backspace(s, true, false)
     @test bufferdata(s) == "for x=1:10\n    éé=3"
     LineEdit.edit_insert(s, "\n    1∉x  ")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x     "
-    LineEdit.edit_backspace(s, false)
+    LineEdit.edit_backspace(s, false, false)
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x    "
-    LineEdit.edit_backspace(s, true)
+    LineEdit.edit_backspace(s, true, false)
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x "
+    LineEdit.edit_move_word_left(s)
+    LineEdit.edit_tab(s)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n        1∉x "
+    LineEdit.move_line_start(s)
+    @test bufpos(s) == 22
+    LineEdit.edit_tab(s, true)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n        1∉x "
+    @test bufpos(s) == 30
+    LineEdit.edit_move_left(s)
+    @test bufpos(s) == 29
+    LineEdit.edit_backspace(s, true, true)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x "
+    @test bufpos(s) == 26
+    LineEdit.edit_tab(s, false) # same as edit_tab(s, true) here
+    @test bufpos(s) == 30
+    move_left(s, 6)
+    @test bufpos(s) == 24
+    LineEdit.edit_backspace(s, true, true)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x "
+    @test bufpos(s) == 22
+    LineEdit.edit_kill_line(s)
+    LineEdit.edit_insert(s, ' '^10)
+    move_left(s, 7)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n          "
+    @test bufpos(s) == 25
+    LineEdit.edit_tab(s, true, false)
+    @test bufpos(s) == 32
+    move_left(s, 7)
+    LineEdit.edit_tab(s, true, true)
+    @test bufpos(s) == 26
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    "
+    # test again the same, when there is a next line
+    LineEdit.edit_insert(s, "      \nend")
+    move_left(s, 11)
+    @test bufpos(s) == 25
+    LineEdit.edit_tab(s, true, false)
+    @test bufpos(s) == 32
+    move_left(s, 7)
+    LineEdit.edit_tab(s, true, true)
+    @test bufpos(s) == 26
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    \nend"
 end

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -427,3 +427,36 @@ end
         "\r\e[2C    julia = :fun\n" *
         "\r\e[2Cend\r\e[5C"
 end
+
+@testset "tab/backspace alignment feature" begin
+    term = TestHelpers.FakeTerminal(IOBuffer(), IOBuffer(), IOBuffer())
+    s = LineEdit.init_state(term, ModalInterface([Prompt("test> ")]))
+    function bufferdata(s)
+        buf = LineEdit.buffer(s)
+        String(buf.data[1:buf.size])
+    end
+
+    LineEdit.edit_insert(s, "for x=1:10\n")
+    LineEdit.edit_tab(s)
+    @test bufferdata(s) == "for x=1:10\n    "
+    LineEdit.edit_backspace(s)
+    @test bufferdata(s) == "for x=1:10\n"
+    LineEdit.edit_insert(s, "  ")
+    LineEdit.edit_tab(s)
+    @test bufferdata(s) == "for x=1:10\n    "
+    LineEdit.edit_insert(s, "  ")
+    LineEdit.edit_backspace(s)
+    @test bufferdata(s) == "for x=1:10\n    "
+    LineEdit.edit_insert(s, "éé=3   ")
+    LineEdit.edit_tab(s)
+    @test bufferdata(s) == "for x=1:10\n    éé=3    "
+    LineEdit.edit_backspace(s)
+    @test bufferdata(s) == "for x=1:10\n    éé=3"
+    LineEdit.edit_insert(s, "\n    1∉x  ")
+    LineEdit.edit_tab(s)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x     "
+    LineEdit.edit_backspace(s, false)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x    "
+    LineEdit.edit_backspace(s)
+    @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x "
+end

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -439,24 +439,24 @@ end
     LineEdit.edit_insert(s, "for x=1:10\n")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    "
-    LineEdit.edit_backspace(s)
+    LineEdit.edit_backspace(s, true)
     @test bufferdata(s) == "for x=1:10\n"
     LineEdit.edit_insert(s, "  ")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    "
     LineEdit.edit_insert(s, "  ")
-    LineEdit.edit_backspace(s)
+    LineEdit.edit_backspace(s, true)
     @test bufferdata(s) == "for x=1:10\n    "
     LineEdit.edit_insert(s, "éé=3   ")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    éé=3    "
-    LineEdit.edit_backspace(s)
+    LineEdit.edit_backspace(s, true)
     @test bufferdata(s) == "for x=1:10\n    éé=3"
     LineEdit.edit_insert(s, "\n    1∉x  ")
     LineEdit.edit_tab(s)
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x     "
     LineEdit.edit_backspace(s, false)
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x    "
-    LineEdit.edit_backspace(s)
+    LineEdit.edit_backspace(s, true)
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    1∉x "
 end


### PR DESCRIPTION
When pressing tab, compute the number of spaces to insert so that the cursor is aligned to a multiple of 4 chars.
When pressing backspace, delete up to 4 spaces so that the cursor is aligned to a multiple of 4 chars.

EDIT: to disable the backspace part of this, you can put the following in your [custom keymap](https://docs.julialang.org/en/latest/manual/interacting-with-julia/#Customizing-keybindings-1): `'\b' => (s,o...)->Base.LineEdit.edit_backspace(s, false),`.
To bind "shift-tab" to this instead: `"\e[Z" => (s,o...)->Base.LineEdit.edit_backspace(s, true),`.