### PR TITLE
RFC: fix #18650, parsing generator expressions containing macro calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,16 @@ This section lists changes that do not have deprecation warnings.
 
   * Juxtaposing string literals (e.g. `"x"y`) is now a syntax error ([#20575]).
 
+  * Macro calls with `for` expressions are now parsed as generators inside
+    function argument lists ([#18650]). Examples:
+
+    + `sum(@inbounds a[i] for i = 1:n)` used to give a syntax error, but is now
+      parsed as `sum(@inbounds(a[i]) for i = 1:n)`.
+
+    + `sum(@m x for i = 1:n end)` used to parse the argument to `sum` as a 2-argument
+      call to macro `@m`, but now parses it as a generator plus a syntax error
+      for the dangling `end`.
+
   * `@__DIR__` returns the current working directory rather than `nothing` when not run
     from a file ([#21759]).
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1276,3 +1276,9 @@ end
 @test parse("(::A)") == Expr(Symbol("::"), :A)
 @test_throws ParseError parse("(::, 1)")
 @test_throws ParseError parse("(1, ::)")
+
+# issue #18650
+let ex = parse("maximum(@elapsed sleep(1) for k = 1:10)")
+    @test isa(ex, Expr) && ex.head === :call && ex.args[2].head === :generator &&
+        ex.args[2].args[1].head === :macrocall
+end


### PR DESCRIPTION
Previously `@mac x for i = ...` always parsed as a macro call wrapping a `for` loop, except inside square brackets (giving a comprehension). Now it will parse as a generator when it occurs inside a function call argument list.

This is very lightly breaking, since (1) it's very unusual to write a for loop inside an argument list, (2) most (all?) forms of this either gave a syntax error before, or will give a syntax error after this change.

I'm a bit on the fence about this. The new parsing is more useful, but means that in `f(<something>)` vs. `(<something>)`, the `<something>` can parse differently.