### PR TITLE
Fix vecnorm for Vector{Vector{T}}

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -431,7 +431,7 @@ julia> vecnorm([1 2 3 4 5 6 7 8 9])
 ```
 """
 function vecnorm(itr, p::Real=2)
-    isempty(itr) && return float(real(zero(eltype(itr))))
+    isempty(itr) && return float(norm(zero(eltype(itr))))
     if p == 2
         return vecnorm2(itr)
     elseif p == 1
@@ -439,8 +439,7 @@ function vecnorm(itr, p::Real=2)
     elseif p == Inf
         return vecnormInf(itr)
     elseif p == 0
-        return convert(typeof(float(real(zero(eltype(itr))))),
-               countnz(itr))
+        return typeof(float(norm(first(itr))))(count(!iszero, itr))
     elseif p == -Inf
         return vecnormMinusInf(itr)
     else

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -457,8 +457,8 @@ end
     # @test find(s) == [1,2,3,4,5]
     @test find(c -> c == 'l', s) == [3]
     g = graphemes("日本語")
-    @test find(g) == [1,2,3]
     @test find(isascii, g) == Int[]
+    @test find((i % 2 for i in 1:10)) == collect(1:2:9)
 end
 @testset "findn" begin
     b = findn(ones(2,2,2,2))

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -270,7 +270,8 @@ end
 
 @testset "generic vecnorm for arrays of arrays" begin
     x = Vector{Int}[[1,2], [3,4]]
-    @test norm(x) ≈ sqrt(30)
+    @test @inferred(norm(x)) ≈ sqrt(30)
+    @test norm(x, 0) == length(x)
     @test norm(x, 1) ≈ sqrt(5) + 5
     @test norm(x, 3) ≈ cbrt(sqrt(125)+125)
 end


### PR DESCRIPTION
Realized this issue today when working on a problem where we were using `Vector{SVector{2,Float64}}`. The return types of the empty case and zero norm were computed incorrectly which caused type instability of `norm`.

@stevengj A separate issue but why is the inner norm the two norm regardless of the outer norm? I would have expected `norm([[1,1], [1,1]], Inf)` to be one.