### PR TITLE
fix codegen bug in `===` on two `SimpleVector`s

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2349,6 +2349,8 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
     if ((jl_is_type_type(rt1) && jl_is_leaf_type(jl_tparam0(rt1))) ||
         (jl_is_type_type(rt2) && jl_is_leaf_type(jl_tparam0(rt2)))) // can compare leaf types by pointer
         ptr_comparable = 1;
+    if (rt1 == (jl_value_t*)jl_simplevector_type && rt2 == (jl_value_t*)jl_simplevector_type)
+        ptr_comparable = 0; // technically mutable, but compared by contents
     if (ptr_comparable) {
         Value *varg1 = arg1.constant ? literal_pointer_val(ctx, arg1.constant) : arg1.V;
         Value *varg2 = arg2.constant ? literal_pointer_val(ctx, arg2.constant) : arg2.V;

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -183,3 +183,11 @@ let was_gced = false
     end
     foo22770()
 end
+
+function egal_svecs()
+    a = Core.svec(:a, :b)
+    b = Core.svec(:a, :b)
+    a === b
+end
+@test egal_svecs()
+@test Core.svec(:a, :b) === Core.svec(:a, :b)


### PR DESCRIPTION
Found while working on #22193. String and SimpleVector are the two types marked as mutable but treated as immutable by `===` (only true for String after #22193). Not a big deal for SimpleVector, since it's very rarely used; might as well just fix the bug here.