### PR TITLE
REPL: newline auto-indents like line above

### DIFF
--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -507,3 +507,26 @@ end
     @test bufpos(s) == 26
     @test bufferdata(s) == "for x=1:10\n    éé=3\n    \nend"
 end
+
+@testset "newline alignment feature" begin
+    term = TestHelpers.FakeTerminal(IOBuffer(), IOBuffer(), IOBuffer())
+    s = LineEdit.init_state(term, ModalInterface([Prompt("test> ")]))
+    function bufferdata(s)
+        buf = LineEdit.buffer(s)
+        String(buf.data[1:buf.size])
+    end
+
+    LineEdit.edit_insert(s, "for x=1:10\n    é = 1")
+    LineEdit.edit_insert_newline(s)
+    @test bufferdata(s) == "for x=1:10\n    é = 1\n    "
+    LineEdit.edit_insert(s, " b = 2")
+    LineEdit.edit_insert_newline(s)
+    @test bufferdata(s) == "for x=1:10\n    é = 1\n     b = 2\n     "
+    # after an empty line, should still insert the expected number of spaces
+    LineEdit.edit_insert_newline(s)
+    @test bufferdata(s) == "for x=1:10\n    é = 1\n     b = 2\n     \n     "
+    LineEdit.edit_insert_newline(s, 0)
+    @test bufferdata(s) == "for x=1:10\n    é = 1\n     b = 2\n     \n     \n"
+    LineEdit.edit_insert_newline(s, 2)
+    @test bufferdata(s) == "for x=1:10\n    é = 1\n     b = 2\n     \n     \n\n  "
+end


### PR DESCRIPTION
This is a dumb heuristic, but easily predictable, and probably more useful than the current behavior of placing the cursor at the beginning of the line. 
To make it more practical, this is probably conditionned to merging #22939 first, because the pattern of needing to delete 1 indentation (i.e. 4 spaces at a time) would become much more common.