### PR TITLE
Fix dict tab completion for command strings

### DIFF
--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -425,11 +425,17 @@ function dict_identifier_key(str,tag)
     return (obj, partial_key, begin_of_key)
 end
 
+# This is needed as repr() function can return output with ANSI escape sequences
+# the regex is found in https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+function escape_ansi(line)
+    replace(line, r"(\x9B|\x1B\[)[0-?]*[ -\/]*[@-~]", "")
+end
+
 # This needs to be a separate non-inlined function, see #19441
 @noinline function find_dict_matches(identifier, partial_key)
     matches = []
     for key in keys(identifier)
-        rkey = repr(key)
+        rkey = escape_ansi(repr(key))
         startswith(rkey,partial_key) && push!(matches,rkey)
     end
     return matches

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -744,6 +744,12 @@ function test_dict_completion(dict_name)
     c, r = test_complete(s)
     @test c == Any[":α]"]
 end
+
+# The test below can only fail when Base.have_color==true
+# Test that the keys returned do not contain ANSI escape sequences
+# This fails after https://github.com/JuliaLang/julia/commit/228a3136fff5917b11fb99f188beec7e70e9449e
+@test Base.REPLCompletions.find_dict_matches(Dict(`ls`=>5),"")[1]=="`ls`"
+
 test_dict_completion("CompletionFoo.test_dict")
 test_dict_completion("CompletionFoo.test_customdict")
 test_dict_completion("test_repl_comp_dict")


### PR DESCRIPTION
Fix dict tab completion for command strings. Example:
```
julia> d=Dict(`ls`=>5)
julia> d[`l<tab>
```
This issue is caused by commit 228a3136fff5917b11fb99f188beec7e70e9449e. @Keno 