### PR TITLE
define hash(::MersenneTwister)

### DIFF
--- a/base/dSFMT.jl
+++ b/base/dSFMT.jl
@@ -2,7 +2,7 @@
 
 module dSFMT
 
-import Base: copy, copy!, ==
+import Base: copy, copy!, ==, hash
 
 export DSFMT_state, dsfmt_get_min_array_size, dsfmt_get_idstring,
        dsfmt_init_gen_rand, dsfmt_init_by_array, dsfmt_gv_init_by_array,
@@ -32,6 +32,8 @@ copy!(dst::DSFMT_state, src::DSFMT_state) = (copy!(dst.val, src.val); dst)
 copy(src::DSFMT_state) = DSFMT_state(copy(src.val))
 
 ==(s1::DSFMT_state, s2::DSFMT_state) = s1.val == s2.val
+
+hash(s::DSFMT_state, h::UInt) = hash(s.val, h)
 
 function dsfmt_get_idstring()
     idstring = ccall((:dsfmt_get_idstring,:libdSFMT),

--- a/base/random.jl
+++ b/base/random.jl
@@ -4,7 +4,7 @@ module Random
 
 using Base.dSFMT
 using Base.GMP: Limb, MPZ
-import Base: copymutable, copy, copy!, ==
+import Base: copymutable, copy, copy!, ==, hash
 
 export srand,
        rand, rand!,
@@ -134,6 +134,7 @@ copy(src::MersenneTwister) =
 ==(r1::MersenneTwister, r2::MersenneTwister) =
     r1.seed == r2.seed && r1.state == r2.state && isequal(r1.vals, r2.vals) && r1.idx == r2.idx
 
+hash(r::MersenneTwister, h::UInt) = foldr(hash, h, (r.seed, r.state, r.vals, r.idx))
 
 ## Low level API for MersenneTwister
 

--- a/test/random.jl
+++ b/test/random.jl
@@ -500,12 +500,14 @@ end
 srand(typemax(UInt))
 srand(typemax(UInt128))
 
-# copy and ==
+# copy, == and hash
 let seed = rand(UInt32, 10)
     r = MersenneTwister(seed)
     @test r == MersenneTwister(seed) # r.vals should be all zeros
+    @test hash(r) == hash(MersenneTwister(seed))
     s = copy(r)
     @test s == r && s !== r
+    @test hash(s) == hash(r)
     skip, len = rand(0:2000, 2)
     for j=1:skip
         rand(r)
@@ -513,6 +515,9 @@ let seed = rand(UInt32, 10)
     end
     @test rand(r, len) == rand(s, len)
     @test s == r
+    @test hash(s) == hash(r)
+    h = rand(UInt)
+    @test hash(s, h) == hash(r, h)
 end
 
 # MersenneTwister initialization with invalid values


### PR DESCRIPTION
I'm not sure how it's useful, but currently equality doesn't imply hash-equality, which is recommended in the docs. Also, it seems this could have helped [here](https://discourse.julialang.org/t/unit-tests-with-random-seed-local-vs-travis/5041/3). 