### PR TITLE
treat String as immutable in `===`. part of #22193

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2349,7 +2349,8 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
     if ((jl_is_type_type(rt1) && jl_is_leaf_type(jl_tparam0(rt1))) ||
         (jl_is_type_type(rt2) && jl_is_leaf_type(jl_tparam0(rt2)))) // can compare leaf types by pointer
         ptr_comparable = 1;
-    if (rt1 == (jl_value_t*)jl_simplevector_type && rt2 == (jl_value_t*)jl_simplevector_type)
+    if ((rt1 == (jl_value_t*)jl_string_type && rt2 == (jl_value_t*)jl_string_type) ||
+        (rt1 == (jl_value_t*)jl_simplevector_type && rt2 == (jl_value_t*)jl_simplevector_type))
         ptr_comparable = 0; // technically mutable, but compared by contents
     if (ptr_comparable) {
         Value *varg1 = arg1.constant ? literal_pointer_val(ctx, arg1.constant) : arg1.V;

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -488,7 +488,7 @@ let d = ImmutableDict{String, String}(),
     @test (k1 => v2) in d3
     @test (k1 => v1) in d4
     @test (k1 => v2) in d4
-    @test !in(k2 => "value2", d4, ===)
+    @test in(k2 => "value2", d4, ===)
     @test in(k2 => v2, d4, ===)
     @test in(k2 => NaN, dnan, isequal)
     @test in(k2 => NaN, dnan, ===)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -8,6 +8,16 @@
 @test eltype(GenericString) == Char
 @test start("abc") == 1
 @test cmp("ab","abc") == -1
+@test "abc" === "abc"
+@test "ab"  !== "abc"
+@test string("ab", 'c') === "abc"
+codegen_egal_of_strings(x, y) = (x===y, x!==y)
+@test codegen_egal_of_strings(string("ab", 'c'), "abc") === (true, false)
+let strs = ["", "a", "a b c", "до свидания"]
+    for x in strs, y in strs
+        @test (x === y) == (object_id(x) == object_id(y))
+    end
+end
 
 # {starts,ends}with
 @test startswith("abcd", 'a')


### PR DESCRIPTION
This is potentially unsafe if somebody assumes that `ismutable(a) && a === b` implies `pointer(a) == pointer(b)`. Hopefully in contexts where that matters you would just look at `pointer(a)` directly.