### PR TITLE
Add tests for mean and var on arrays with unitful elements.

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -175,7 +175,7 @@ function varm!(R::AbstractArray{S}, A::AbstractArray, m::AbstractArray; correcte
         fill!(R, convert(S, NaN))
     else
         rn = div(_length(A), _length(R)) - Int(corrected)
-        scale!(centralize_sumabs2!(R, A, m), convert(S, 1/rn))
+        scale!(centralize_sumabs2!(R, A, m), one(S)/rn)
     end
     return R
 end

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -406,12 +406,20 @@ end
 # dimensional correctness
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using TestHelpers.Furlong
-let r = Furlong(1):Furlong(1):Furlong(2), a = collect(r)
+@testset "Unitful elements" begin
+    r = Furlong(1):Furlong(1):Furlong(2)
+    a = collect(r)
     @test sum(r) == sum(a) == Furlong(3)
     @test cumsum(r) == Furlong.([1,3])
     @test mean(r) == mean(a) == median(a) == median(r) == Furlong(1.5)
     @test var(r) == var(a) == Furlong{2}(0.5)
     @test std(r) == std(a) == Furlong{1}(sqrt(0.5))
+
+    # Issue #21786
+    A = [Furlong{1}(rand(-5:5)) for i in 1:2, j in 1:2]
+    @test mean(mean(A, 1), 2)[1] === mean(A)
+    @test var(A, 1)[1] === var(A[:, 1])
+    @test_broken std(A, 1)[1] === std(A[:, 1])
 end
 
 # Issue #22901


### PR DESCRIPTION
Fix `var` along a dimension for arrays with unitful elements.

I'm not sure what to do with `std` along a dimension because it calls the in-place `sqrt!` on the output from `var` which errors because the units change under `sqrt`. This problem is similar to all of our (dense) factorizations which are done in-place but where the units change. Consequently, they fail unless the array is abstractly typed. For now, I've just added a `@test_broken` for `std`.