### PR TITLE
vectorized float() deprecations

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -347,7 +347,7 @@ similar(B::BitArray, dims::Dims) = BitArray(dims...)
 
 similar(B::BitArray, T::Type{Bool}, dims::Dims) = BitArray(dims)
 # changing type to a non-Bool returns an Array
-# (this triggers conversions like float(bitvector) etc.)
+# (this triggers conversions like float.(bitvector) etc.)
 similar(B::BitArray, T::Type, dims::Dims) = Array{T}(dims)
 
 function fill!(B::BitArray, x)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -290,7 +290,9 @@ for f in (
 end
 # base/complex.jl
 @dep_vectorize_1arg Complex round
-@dep_vectorize_1arg Complex float
+# float(A) -> float.(A)
+@dep_vectorize_1arg Number float
+@dep_vectorize_1arg AbstractString float
 # base/dates/*.jl
 for f in (:unix2datetime, :rata2datetime, :julian2datetime)  # base/dates/conversions.jl
     @eval Dates Base.@dep_vectorize_1arg Real $f

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -290,9 +290,7 @@ for f in (
 end
 # base/complex.jl
 @dep_vectorize_1arg Complex round
-# float(A) -> float.(A)
-@dep_vectorize_1arg Number float
-@dep_vectorize_1arg AbstractString float
+@dep_vectorize_1arg Complex float
 # base/dates/*.jl
 for f in (:unix2datetime, :rata2datetime, :julian2datetime)  # base/dates/conversions.jl
     @eval Dates Base.@dep_vectorize_1arg Real $f
@@ -1594,6 +1592,10 @@ end
 @deprecate readstring(cmd::AbstractCmd) read(cmd, String)
 
 @deprecate momenttype(::Type{T}) where {T} typeof((zero(T)*zero(T) + zero(T)*zero(T))/2) false
+
+# PR #22966
+@dep_vectorize_1arg Number float
+@dep_vectorize_1arg AbstractString float
 
 # END 0.7 deprecations
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -850,21 +850,13 @@ truncmask(x, mask) = x
 
 ## Array operations on floating point numbers ##
 
-float(A::AbstractArray{<:AbstractFloat}) = A
-
-function float(A::AbstractArray{T}) where T
-    if !isleaftype(T)
-        error("`float` not defined on abstractly-typed arrays; please convert to a more specific type")
-    end
-    convert(AbstractArray{typeof(float(zero(T)))}, A)
-end
-
-float(r::StepRange) = float(r.start):float(r.step):float(last(r))
-float(r::UnitRange) = float(r.start):float(last(r))
-float(r::StepRangeLen) = StepRangeLen(float(r.ref), float(r.step), length(r), r.offset)
-function float(r::LinSpace)
-    LinSpace(float(r.start), float(r.stop), length(r))
-end
+# Optimizations for broadcasting float()
+broadcast(::typeof(float), A::AbstractArray{<:AbstractFloat}) = A
+# Ranges
+broadcast(::typeof(float), r::StepRange)    = float(r.start):float(r.step):float(last(r))
+broadcast(::typeof(float), r::UnitRange)    = float(r.start):float(last(r))
+broadcast(::typeof(float), r::StepRangeLen) = StepRangeLen(float(r.ref), float(r.step), length(r), r.offset)
+broadcast(::typeof(float), r::LinSpace)     = LinSpace(float(r.start), float(r.stop), length(r))
 
 # big, broadcast over arrays
 # TODO: do the definitions below primarily pertaining to integers belong in float.jl?

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -98,8 +98,8 @@ end
 
 ## norm and rank
 
-svd(A::BitMatrix) = svd(float(A))
-qr(A::BitMatrix) = qr(float(A))
+svd(A::BitMatrix) = svd(float.(A))
+qr(A::BitMatrix) = qr(float.(A))
 
 ## kron
 

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -408,7 +408,7 @@ julia> expm(A)
 ```
 """
 expm(A::StridedMatrix{<:BlasFloat}) = expm!(copy(A))
-expm(A::StridedMatrix{<:Integer}) = expm!(float(A))
+expm(A::StridedMatrix{<:Integer}) = expm!(float.(A))
 expm(x::Number) = exp(x)
 
 ## Destructive matrix exponential using algorithm from Higham, 2008,
@@ -926,7 +926,7 @@ function sylvester(A::StridedMatrix{T},B::StridedMatrix{T},C::StridedMatrix{T}) 
     Y, scale = LAPACK.trsyl!('N','N', RA, RB, D)
     scale!(QA*A_mul_Bc(Y,QB), inv(scale))
 end
-sylvester(A::StridedMatrix{T}, B::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = sylvester(float(A), float(B), float(C))
+sylvester(A::StridedMatrix{T}, B::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = sylvester(float.(A), float.(B), float.(C))
 
 sylvester(a::Union{Real,Complex}, b::Union{Real,Complex}, c::Union{Real,Complex}) = -c / (a + b)
 
@@ -946,5 +946,5 @@ function lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:BlasFloat}
     Y, scale = LAPACK.trsyl!('N', T <: Complex ? 'C' : 'T', R, R, D)
     scale!(Q*A_mul_Bc(Y,Q), inv(scale))
 end
-lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = lyap(float(A), float(C))
+lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:Integer} = lyap(float.(A), float.(C))
 lyap(a::T, c::T) where {T<:Number} = -c/(2a)

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -213,8 +213,6 @@ end
 
 float(x::AbstractString) = parse(Float64,x)
 
-float(a::AbstractArray{<:AbstractString}) = map!(float, similar(a,typeof(float(0))), a)
-
 ## interface to parser ##
 
 function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=true)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -417,8 +417,6 @@ julia> full(A)
 """
 full
 
-float(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), float.(S.nzval))
-
 complex(S::SparseMatrixCSC) = SparseMatrixCSC(S.m, S.n, copy(S.colptr), copy(S.rowval), complex(copy(S.nzval)))
 
 # Construct a sparse vector

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -852,10 +852,6 @@ function reinterpret(::Type{T}, x::AbstractSparseVector{Tv}) where {T,Tv}
     SparseVector(length(x), copy(nonzeroinds(x)), reinterpret(T, nonzeros(x)))
 end
 
-float(x::AbstractSparseVector{<:AbstractFloat}) = x
-float(x::AbstractSparseVector) =
-    SparseVector(length(x), copy(nonzeroinds(x)), float(nonzeros(x)))
-
 complex(x::AbstractSparseVector{<:Complex}) = x
 complex(x::AbstractSparseVector) =
     SparseVector(length(x), copy(nonzeroinds(x)), complex(nonzeros(x)))

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -155,7 +155,7 @@ lufact(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) where {T<:Abstr
     "Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for ",
     "sparse floating point LU using UMFPACK or lufact(Array(A)) for generic ",
     "dense LU.")))
-lufact(A::SparseMatrixCSC) = lufact(float(A))
+lufact(A::SparseMatrixCSC) = lufact(float.(A))
 
 
 size(F::UmfpackLU) = (F.m, F.n)

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -198,7 +198,7 @@ Hinv = Rational{BigInt}[(-1)^(i+j)*(i+j-1)*binomial(nHilbert+i-1,nHilbert-j)*
     for i = big(1):nHilbert,j=big(1):nHilbert]
 @test inv(H) == Hinv
 setprecision(2^10) do
-    @test norm(Array{Float64}(inv(float(H)) - float(Hinv))) < 1e-100
+    @test norm(Array{Float64}(inv(float.(H)) - float.(Hinv))) < 1e-100
 end
 
 # Test balancing in eigenvector calculations

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -747,7 +747,7 @@ test_linspace_identity(linspace(1f0, 1f0, 1), linspace(-1f0, -1f0, 1))
 # PR 12200 and related
 for _r in (1:2:100, 1:100, 1f0:2f0:100f0, 1.0:2.0:100.0,
            linspace(1, 100, 10), linspace(1f0, 100f0, 10))
-    float_r = float(_r)
+    float_r = float.(_r)
     big_r = big.(_r)
     @test typeof(big_r).name === typeof(_r).name
     if eltype(_r) <: AbstractFloat

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -83,7 +83,7 @@
 @test sum([3.0]) === 3.0
 
 z = reshape(1:16, (2,2,2,2))
-fz = float(z)
+fz = float.(z)
 @test sum(z) === 136
 @test sum(fz) === 136.0
 
@@ -95,7 +95,7 @@ a = sum(sin, z)
 @test a ≈ sum(sin.(fz))
 
 z = [-4, -3, 2, 5]
-fz = float(z)
+fz = float.(z)
 a = randn(32) # need >16 elements to trigger BLAS code path
 b = complex.(randn(32), randn(32))
 

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -230,7 +230,7 @@ for n in [0:10; 100; 101; 1000; 1001]
     for rev in [false,true]
         # insertion sort (stable) as reference
         pi = sortperm(v, alg=InsertionSort, rev=rev)
-        @test pi == sortperm(float(v), alg=InsertionSort, rev=rev)
+        @test pi == sortperm(float.(v), alg=InsertionSort, rev=rev)
         @test isperm(pi)
         si = v[pi]
         @test [sum(si .== x) for x in r] == h
@@ -245,7 +245,7 @@ for n in [0:10; 100; 101; 1000; 1001]
         # stable algorithms
         for alg in [MergeSort]
             p = sortperm(v, alg=alg, rev=rev)
-            @test p == sortperm(float(v), alg=alg, rev=rev)
+            @test p == sortperm(float.(v), alg=alg, rev=rev)
             @test p == pi
             s = copy(v)
             permute!(s, p)
@@ -257,7 +257,7 @@ for n in [0:10; 100; 101; 1000; 1001]
         # unstable algorithms
         for alg in [QuickSort, PartialQuickSort(n)]
             p = sortperm(v, alg=alg, rev=rev)
-            @test p == sortperm(float(v), alg=alg, rev=rev)
+            @test p == sortperm(float.(v), alg=alg, rev=rev)
             @test isperm(p)
             @test v[p] == si
             s = copy(v)

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -467,12 +467,12 @@ for elty in (Float64, Complex{Float64})
     @test CHOLMOD.Sparse(CHOLMOD.Dense(A1Sparse)) == A1Sparse
 end
 
-Af = float([4 12 -16; 12 37 -43; -16 -43 98])
+Af = float.([4 12 -16; 12 37 -43; -16 -43 98])
 As = sparse(Af)
-Lf = float([2 0 0; 6 1 0; -8 5 3])
-LDf = float([4 0 0; 3 1 0; -4 5 9])  # D is stored along the diagonal
-L_f = float([1 0 0; 3 1 0; -4 5 1])  # L by itself in LDLt of Af
-D_f = float([4 0 0; 0 1 0; 0 0 9])
+Lf = float.([2 0 0; 6 1 0; -8 5 3])
+LDf = float.([4 0 0; 3 1 0; -4 5 9])  # D is stored along the diagonal
+L_f = float.([1 0 0; 3 1 0; -4 5 1])  # L by itself in LDLt of Af
+D_f = float.([4 0 0; 0 1 0; 0 0 9])
 
 # cholfact, no permutation
 Fs = cholfact(As, perm=[1:3;])

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1225,9 +1225,9 @@ end
 
 @testset "float" begin
     A = sprand(Bool, 5,5,0.0)
-    @test eltype(float(A)) == Float64  # issue #11658
+    @test eltype(float.(A)) == Float64  # issue #11658
     A = sprand(Bool, 5,5,0.2)
-    @test float(A) == float(Array(A))
+    @test float.(A) == float.(Array(A))
 end
 
 @testset "sparsevec" begin

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -285,8 +285,8 @@ let a = SparseVector(8, [2, 5, 6], Int32[12, 35, 72])
     @test exact_equal(au, SparseVector(8, [2, 5, 6], UInt32[12, 35, 72]))
 
     # float
-    af = float(a)
-    @test float(af) == af
+    af = float.(a)
+    @test float.(af) == af
     @test isa(af, SparseVector{Float64,Int})
     @test exact_equal(af, SparseVector(8, [2, 5, 6], [12., 35., 72.]))
     @test sparsevec(transpose(transpose(af))) == af

--- a/test/sparse/umfpack.jl
+++ b/test/sparse/umfpack.jl
@@ -27,12 +27,12 @@
 
             b = [8., 45., -3., 3., 19.]
             x = lua\b
-            @test x ≈ float([1:5;])
+            @test x ≈ float.([1:5;])
 
             @test A*x ≈ b
             z = complex.(b,zeros(b))
             x = Base.SparseArrays.A_ldiv_B!(lua, z)
-            @test x ≈ float([1:5;])
+            @test x ≈ float.([1:5;])
             @test z === x
             y = similar(z)
             A_ldiv_B!(y, lua, complex.(b,zeros(b)))
@@ -42,12 +42,12 @@
 
             b = [8., 20., 13., 6., 17.]
             x = lua'\b
-            @test x ≈ float([1:5;])
+            @test x ≈ float.([1:5;])
 
             @test A'*x ≈ b
             z = complex.(b,zeros(b))
             x = Base.SparseArrays.Ac_ldiv_B!(lua, z)
-            @test x ≈ float([1:5;])
+            @test x ≈ float.([1:5;])
             @test x === z
             y = similar(x)
             Base.SparseArrays.Ac_ldiv_B!(y, lua, complex.(b,zeros(b)))
@@ -55,11 +55,11 @@
 
             @test A'*x ≈ b
             x = lua.'\b
-            @test x ≈ float([1:5;])
+            @test x ≈ float.([1:5;])
 
             @test A.'*x ≈ b
             x = Base.SparseArrays.At_ldiv_B!(lua,complex.(b,zeros(b)))
-            @test x ≈ float([1:5;])
+            @test x ≈ float.([1:5;])
             y = similar(x)
             Base.SparseArrays.At_ldiv_B!(y, lua,complex.(b,zeros(b)))
             @test y ≈ x


### PR DESCRIPTION
Vectorized `float()` is currently deprecated only for `AbstractArray{<:Complex}`, but not for other types of numbers or strings.

This PR deprecates all vectorized versions of float, replacing uses of such with `broadcast()`, and adding a few broadcast specializations where necessary to maintain the efficiency of a few specialized vectorized versions.

This came up over at https://github.com/JuliaArrays/StaticArrays.jl/issues/247