### PR TITLE
deprecate `issubtype` in favor of `<:`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -234,6 +234,8 @@ Deprecated or removed
   * The function `showall` is deprecated. Showing entire values is the default, unless an
     `IOContext` specifying `:limit=>true` is in use ([#22847]).
 
+  * `issubtype` has been deprecated in favor of `<:` (which used to be an alias for `issubtype`).
+
   * Calling `write` on non-isbits arrays is deprecated in favor of explicit loops or
     `serialize` ([#6466]).
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -143,7 +143,7 @@ export
     fieldtype, getfield, setfield!, nfields, throw, tuple, ===, isdefined, eval,
     # sizeof    # not exported, to avoid conflicting with Base.sizeof
     # type reflection
-    issubtype, typeof, isa, typeassert,
+    <:, typeof, isa, typeassert,
     # method reflection
     applicable, invoke,
     # constants

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1338,6 +1338,8 @@ end
 
 # BEGIN 0.7 deprecations
 
+@deprecate issubtype (<:)
+
 # 12807
 start(::Union{Process, ProcessChain}) = 1
 done(::Union{Process, ProcessChain}, i::Int) = (i == 3)

--- a/base/docs/helpdb/Base.jl
+++ b/base/docs/helpdb/Base.jl
@@ -1547,23 +1547,6 @@ by `show` generally includes Julia-specific formatting and type information.
 show(x)
 
 """
-    issubtype(type1, type2)
-
-Return `true` if and only if all values of `type1` are also of `type2`. Can also be written
-using the `<:` infix operator as `type1 <: type2`.
-
-# Examples
-```jldoctest
-julia> issubtype(Int8, Int32)
-false
-
-julia> Int8 <: Integer
-true
-```
-"""
-issubtype(type1, type2)
-
-"""
     finalizer(x, f)
 
 Register a function `f(x)` to be called when there are no program-accessible references to

--- a/base/int.jl
+++ b/base/int.jl
@@ -431,8 +431,8 @@ end
 for to in BitInteger_types, from in (BitInteger_types..., Bool)
     if !(to === from)
         if to.size < from.size
-            if issubtype(to, Signed)
-                if issubtype(from, Unsigned)
+            if to <: Signed
+                if from <: Unsigned
                     @eval convert(::Type{$to}, x::($from)) =
                         checked_trunc_sint($to, check_top_bit(x))
                 else
@@ -449,8 +449,8 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
             @eval convert(::Type{$to}, x::($from)) = zext_int($to, x) & $to(1)
             @eval rem(x::($from), ::Type{$to}) = convert($to, x)
         elseif from.size < to.size
-            if issubtype(from, Signed)
-                if issubtype(to, Unsigned)
+            if from <: Signed
+                if to <: Unsigned
                     @eval convert(::Type{$to}, x::($from)) =
                         sext_int($to, check_top_bit(x))
                 else
@@ -463,7 +463,7 @@ for to in BitInteger_types, from in (BitInteger_types..., Bool)
                 @eval rem(x::($from), ::Type{$to}) = convert($to, x)
             end
         else
-            if !(issubtype(from, Signed) === issubtype(to, Signed))
+            if !((from <: Signed) === (to <: Signed))
                 # raise InexactError if x's top bit is set
                 @eval convert(::Type{$to}, x::($from)) = bitcast($to, check_top_bit(x))
             else

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -5,7 +5,8 @@
 """
     <:(T1, T2)
 
-Subtype operator, equivalent to `issubtype(T1, T2)`.
+Subtype operator: returns `true` if and only if all values of type `T1` are
+also of type `T2`.
 
 ```jldoctest
 julia> Float64 <: AbstractFloat
@@ -18,14 +19,14 @@ julia> Matrix{Float64} <: Matrix{AbstractFloat}
 false
 ```
 """
-const (<:) = issubtype
+(<:)
 
 """
     >:(T1, T2)
 
-Supertype operator, equivalent to `issubtype(T2, T1)`.
+Supertype operator, equivalent to `T2 <: T1`.
 """
-const (>:)(@nospecialize(a), @nospecialize(b)) = issubtype(b, a)
+const (>:)(@nospecialize(a), @nospecialize(b)) = (b <: a)
 
 """
     supertype(T::DataType)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -405,7 +405,7 @@ function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp}) where
 end
 
 function round(::Type{T}, x::Rational{Bool}) where T
-    if denominator(x) == false && issubtype(T, Union{Integer, Bool})
+    if denominator(x) == false && (T <: Union{Integer, Bool})
         throw(DivideError())
     end
     convert(T, x)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -197,7 +197,6 @@ end
 
 function showerror(io::IO, ex::TypeError)
     print(io, "TypeError: ")
-    ctx = isempty(ex.context) ? "" : "in $(ex.context), "
     if ex.expected === Bool
         print(io, "non-boolean ($(typeof(ex.got))) used in boolean context")
     else
@@ -206,7 +205,12 @@ function showerror(io::IO, ex::TypeError)
         else
             tstr = string(typeof(ex.got))
         end
-        print(io, "$(ex.func): $(ctx)expected $(ex.expected), got $tstr")
+        if isempty(ex.context)
+            ctx = "in $(ex.func)"
+        else
+            ctx = "in $(ex.func), in $(ex.context)"
+        end
+        print(io, ctx, ", expected $(ex.expected), got ", tstr)
     end
 end
 

--- a/contrib/julia.lang
+++ b/contrib/julia.lang
@@ -197,7 +197,6 @@
     <context id="builtin-function" style-ref="builtin-function">
       <keyword>is</keyword>
       <keyword>typeof</keyword>
-      <keyword>issubtype</keyword>
       <keyword>isa</keyword>
       <keyword>typeassert</keyword>
       <keyword>apply</keyword>

--- a/doc/src/devdocs/functions.md
+++ b/doc/src/devdocs/functions.md
@@ -110,7 +110,7 @@ a method table via special arrangement.
 The "builtin" functions, defined in the `Core` module, are:
 
 ```
-=== typeof sizeof issubtype isa typeassert throw tuple getfield setfield! fieldtype
+=== typeof sizeof <: isa typeassert throw tuple getfield setfield! fieldtype
 nfields isdefined arrayref arrayset arraysize applicable invoke apply_type _apply
 _expr svec
 ```

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -464,7 +464,7 @@ code get triggered often--it will be easiest if you make the following definitio
 ```julia-repl
 julia> function mysubtype(a,b)
            ccall(:jl_breakpoint, Void, (Any,), nothing)
-           issubtype(a, b)
+           a <: b
        end
 ```
 

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -307,7 +307,7 @@ higher-level, Julia-friendly API.
 
 ## Be careful with type equality
 
-You generally want to use [`isa()`](@ref) and `<:` ([`issubtype()`](@ref)) for testing types,
+You generally want to use [`isa()`](@ref) and [`<:`](@ref) for testing types,
 not `==`. Checking types for exact equality typically only makes sense when comparing to a known
 concrete type (e.g. `T == Float64`), or if you *really, really* know what you're doing.
 

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -88,8 +88,7 @@ Base.identity
 
 ```@docs
 Base.supertype
-Core.issubtype
-Base.:(<:)
+Core.:(<:)
 Base.:(>:)
 Base.subtypes
 Base.typemin

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -286,12 +286,12 @@ JL_CALLABLE(jl_f_sizeof)
 
 JL_CALLABLE(jl_f_issubtype)
 {
-    JL_NARGS(issubtype, 2, 2);
+    JL_NARGS(<:, 2, 2);
     jl_value_t *a = args[0], *b = args[1];
     if (jl_is_typevar(a)) a = ((jl_tvar_t*)a)->ub; // TODO should we still allow this?
     if (jl_is_typevar(b)) b = ((jl_tvar_t*)b)->ub;
-    JL_TYPECHK(issubtype, type, a);
-    JL_TYPECHK(issubtype, type, b);
+    JL_TYPECHK(<:, type, a);
+    JL_TYPECHK(<:, type, b);
     return (jl_subtype(a,b) ? jl_true : jl_false);
 }
 
@@ -1083,7 +1083,7 @@ void jl_init_primitives(void)
     add_builtin_func("===", jl_f_is);
     add_builtin_func("typeof", jl_f_typeof);
     add_builtin_func("sizeof", jl_f_sizeof);
-    add_builtin_func("issubtype", jl_f_issubtype);
+    add_builtin_func("<:", jl_f_issubtype);
     add_builtin_func("isa", jl_f_isa);
     add_builtin_func("typeassert", jl_f_typeassert);
     add_builtin_func("throw", jl_f_throw);

--- a/src/init.c
+++ b/src/init.c
@@ -817,7 +817,7 @@ void jl_get_builtins(void)
 {
     jl_builtin_throw = core("throw");           jl_builtin_is = core("===");
     jl_builtin_typeof = core("typeof");         jl_builtin_sizeof = core("sizeof");
-    jl_builtin_issubtype = core("issubtype");   jl_builtin_isa = core("isa");
+    jl_builtin_issubtype = core("<:");          jl_builtin_isa = core("isa");
     jl_builtin_typeassert = core("typeassert"); jl_builtin__apply = core("_apply");
     jl_builtin_isdefined = core("isdefined");   jl_builtin_nfields = core("nfields");
     jl_builtin_tuple = core("tuple");           jl_builtin_svec = core("svec");

--- a/src/module.c
+++ b/src/module.c
@@ -512,10 +512,14 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
             }
             else {
                 jl_methtable_t *mt = jl_gf_mtable(v);
-                if (mt != NULL && mt->defs.unknown != jl_nothing) {
+                if (mt != NULL && (mt->defs.unknown != jl_nothing ||
+                                   jl_isa(v, (jl_value_t*)jl_builtin_type))) {
                     jl_printf(JL_STDERR, ", use ");
-                    jl_static_show(JL_STDERR, (jl_value_t*)mt->module);
-                    jl_printf(JL_STDERR, ".%s", jl_symbol_name(mt->name));
+                    if (mt->module != jl_core_module) {
+                        jl_static_show(JL_STDERR, (jl_value_t*)mt->module);
+                        jl_printf(JL_STDERR, ".");
+                    }
+                    jl_printf(JL_STDERR, "%s", jl_symbol_name(mt->name));
                     jl_printf(JL_STDERR, " instead");
                 }
             }

--- a/test/core.jl
+++ b/test/core.jl
@@ -1983,8 +1983,8 @@ mutable struct A7652
 end
 a7652 = A7652(0)
 t_a7652 = A7652
-f7652() = issubtype(fieldtype(t_a7652, :a), Int)
-@test f7652() == issubtype(fieldtype(A7652, :a), Int) == true
+f7652() = fieldtype(t_a7652, :a) <: Int
+@test f7652() == (fieldtype(A7652, :a) <: Int) == true
 g7652() = fieldtype(DataType, :types)
 @test g7652() == fieldtype(DataType, :types) == SimpleVector
 @test fieldtype(t_a7652, 1) == Int

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -277,17 +277,17 @@ let undefvar
     err_str = @except_str 0::Bool TypeError
     @test err_str == "TypeError: non-boolean ($Int) used in boolean context"
     err_str = @except_str 0::AbstractFloat TypeError
-    @test err_str == "TypeError: typeassert: expected AbstractFloat, got $Int"
+    @test err_str == "TypeError: in typeassert, expected AbstractFloat, got $Int"
     err_str = @except_str 0::7 TypeError
-    @test err_str == "TypeError: typeassert: expected Type, got $Int"
+    @test err_str == "TypeError: in typeassert, expected Type, got $Int"
     err_str = @except_str "" <: AbstractString TypeError
-    @test err_str == "TypeError: issubtype: expected Type, got String"
+    @test err_str == "TypeError: in <:, expected Type, got String"
     err_str = @except_str AbstractString <: "" TypeError
-    @test err_str == "TypeError: issubtype: expected Type, got String"
+    @test err_str == "TypeError: in <:, expected Type, got String"
     err_str = @except_str Type{""} TypeError
-    @test err_str == "TypeError: Type: in parameter, expected Type, got String"
+    @test err_str == "TypeError: in Type, in parameter, expected Type, got String"
     err_str = @except_str TypeWithIntParam{Any} TypeError
-    @test err_str == "TypeError: TypeWithIntParam: in T, expected T<:Integer, got Type{Any}"
+    @test err_str == "TypeError: in TypeWithIntParam, in T, expected T<:Integer, got Type{Any}"
 
     err_str = @except_str mod(1,0) DivideError
     @test err_str == "DivideError: integer division error"

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -7,7 +7,7 @@ macro UnionAll(var, expr)
     Expr(:where, esc(expr), esc(var))
 end
 
-const issub = issubtype
+const issub = (<:)
 issub_strict(@nospecialize(x),@nospecialize(y)) = issub(x,y) && !issub(y,x)
 isequal_type(@nospecialize(x),@nospecialize(y)) = issub(x,y) && issub(y,x)
 notequal_type(@nospecialize(x),@nospecialize(y)) = !isequal_type(x, y)
@@ -501,13 +501,13 @@ function test_old()
 
     # issue #6561
     # TODO: note that NTuple now means "tuples of all the same type"
-    #@test issubtype(Array{Tuple}, Array{NTuple})
+    #@test (Array{Tuple} <: Array{NTuple})
     @test issub_strict(NTuple, Tuple)
     @test issub_strict(NTuple, Tuple{Vararg})
     @test isequal_type(Tuple, Tuple{Vararg})
-    #@test issubtype(Array{Tuple{Vararg{Any}}}, Array{NTuple})
-    #@test issubtype(Array{Tuple{Vararg}}, Array{NTuple})
-    @test !issubtype(Type{Tuple{Void}}, Tuple{Type{Void}})
+    #@test (Array{Tuple{Vararg{Any}}} <: Array{NTuple})
+    #@test (Array{Tuple{Vararg}} <: Array{NTuple})
+    @test !(Type{Tuple{Void}} <: Tuple{Type{Void}})
 end
 
 const menagerie =


### PR DESCRIPTION
Similar deal to `===` and `is`, so seems like we should do it.