### PR TITLE
[ WIP ] Changes for LLVM 5 release

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2306,7 +2306,7 @@ static void emit_signal_fence(jl_codectx_t &ctx)
     ctx.builder.CreateCall(InlineAsm::get(FunctionType::get(T_void, false), "",
                                       "~{memory}", true));
 #else
-    ctx.builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SingleThread);
+    ctx.builder.CreateFence(AtomicOrdering::SequentiallyConsistent, SyncScope::SingleThread);
 #endif
 }
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1290,7 +1290,7 @@ uint64_t jl_get_llvm_fptr(void *function)
     Function *F = (Function*)function;
     uint64_t addr = getAddressForFunction(F->getName());
     if (!addr) {
-	auto expected_addr = jl_ExecutionEngine->findUnmangledSymbol(F->getName()).getAddress();
+        auto expected_addr = jl_ExecutionEngine->findUnmangledSymbol(F->getName()).getAddress();
         // TODO : Handle error in expected_addr
         addr = *expected_addr;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1289,8 +1289,11 @@ uint64_t jl_get_llvm_fptr(void *function)
 {
     Function *F = (Function*)function;
     uint64_t addr = getAddressForFunction(F->getName());
-    if (!addr)
-        addr = jl_ExecutionEngine->findUnmangledSymbol(F->getName()).getAddress();
+    if (!addr) {
+	auto expected_addr = jl_ExecutionEngine->findUnmangledSymbol(F->getName()).getAddress();
+        // TODO : Handle error in expected_addr
+        addr = *expected_addr;
+    }
     return addr;
 }
 
@@ -6846,7 +6849,7 @@ extern "C" void *jl_init_llvm(void)
     // to ensure compatibility with GCC codes
     options.StackAlignmentOverride = 16;
 #endif
-    EngineBuilder eb((std::unique_ptr<Module>(engine_module)));
+    llvm::EngineBuilder eb((std::unique_ptr<Module>(engine_module)));
     std::string ErrorStr;
     eb  .setEngineKind(EngineKind::JIT)
         .setMCJITMemoryManager(std::unique_ptr<RTDyldMemoryManager>{createRTDyldMemoryManager()})

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -12,6 +12,9 @@
 #include "llvm/ExecutionEngine/Orc/LazyEmittingLayer.h"
 #if JL_LLVM_VERSION >= 50000
 #  include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+#  include "llvm/ExecutionEngine/JITEventListener.h"
+#  include "llvm/ExecutionEngine/ExecutionEngine.h"
+#  include "llvm/ExecutionEngine/Orc/CompileUtils.h"
 #else
 #  include "llvm/ExecutionEngine/Orc/ObjectLinkingLayer.h"
 #endif
@@ -116,19 +119,19 @@ class JuliaOJIT {
     public:
         DebugObjectRegistrar(JuliaOJIT &JIT);
         template <typename ObjSetT, typename LoadResult>
-        void operator()(RTDyldObjectLinkingLayerBase::ObjSetHandleT H, const ObjSetT &Objects,
+        void operator()(RTDyldObjectLinkingLayerBase::ObjHandleT H, const ObjSetT &Objects,
                         const LoadResult &LOS);
     private:
         void NotifyGDB(object::OwningBinary<object::ObjectFile> &DebugObj);
         std::vector<object::OwningBinary<object::ObjectFile>> SavedObjects;
-        std::unique_ptr<JITEventListener> JuliaListener;
+        std::unique_ptr<llvm::JITEventListener> JuliaListener;
         JuliaOJIT &JIT;
     };
 
 public:
-    typedef RTDyldObjectLinkingLayer<DebugObjectRegistrar> ObjLayerT;
-    typedef orc::IRCompileLayer<ObjLayerT> CompileLayerT;
-    typedef CompileLayerT::ModuleSetHandleT ModuleHandleT;
+    typedef RTDyldObjectLinkingLayer ObjLayerT;
+    typedef orc::IRCompileLayer<ObjLayerT, orc::SimpleCompiler> CompileLayerT;
+    typedef CompileLayerT::ModuleHandleT ModuleHandleT;
     typedef StringMap<void*> SymbolTableT;
     typedef object::OwningBinary<object::ObjectFile> OwningObj;
 

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1091,11 +1091,11 @@ bool LateLowerGCFrame::CleanupIR(Function &F) {
     size_t maxframeargs = 0;
     PointerType *T_pprjlvalue = T_prjlvalue->getPointerTo();
     Instruction *StartOff = &*(F.getEntryBlock().begin());
-    AllocaInst *Frame = new AllocaInst(T_prjlvalue, ConstantInt::get(T_int32, maxframeargs),
+    AllocaInst *Frame = new AllocaInst(T_prjlvalue, 
 #if JL_LLVM_VERSION >= 50000
-        0,
+       0,  // llvm::AddressSpace::ADDRESS_SPACE_GENERIC
 #endif
-        "", StartOff);
+        ConstantInt::get(T_int32, maxframeargs),"", StartOff);
     for (BasicBlock &BB : F) {
         for (auto it = BB.begin(); it != BB.end();) {
             auto *CI = dyn_cast<CallInst>(&*it);


### PR DESCRIPTION
Changes to compile with LLVM 5.

jitlayers.cpp still needs to be addressed for compile errors.

Will implement version-specific compilation after getting all files to compile and all tests to pass.