### PR TITLE
Add `docstrloc` function

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1233,7 +1233,6 @@ export
     @html_str,
     @doc,
     @doc_str,
-    docstrloc,
 
     # output
     @show,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1233,6 +1233,7 @@ export
     @html_str,
     @doc,
     @doc_str,
+    docstrloc,
 
     # output
     @show,

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -66,11 +66,13 @@ const LINE_NUMBER = @__LINE__() + 1
 "DocsTest"
 module DocsTest
 
+const F1_LINE_NUMBER = @__LINE__() + 1
 "f-1"
 function f(x)
     x
 end
 
+const F2_LINE_NUMBER = @__LINE__() + 1
 "f-2"
 f(x, y) = x + y
 
@@ -308,6 +310,19 @@ end
 let a = @doc(DocsTest.multidoc),
     b = @doc(DocsTest.multidoc!)
     @test docstrings_equal(a, b)
+end
+
+let a = docstrloc(DocsTest.f, Tuple{Any})
+    @test a == [(@__FILE__, DocsTest.F1_LINE_NUMBER)]
+end
+
+let a = docstrloc(DocsTest.f, Tuple{Any, Any})
+    @test a == [(@__FILE__, DocsTest.F2_LINE_NUMBER)]
+end
+
+let a = docstrloc(DocsTest.f)
+    @test a == [(@__FILE__, DocsTest.F1_LINE_NUMBER),
+                (@__FILE__, DocsTest.F2_LINE_NUMBER)]
 end
 
 "BareModule"

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -312,15 +312,15 @@ let a = @doc(DocsTest.multidoc),
     @test docstrings_equal(a, b)
 end
 
-let a = docstrloc(DocsTest.f, Tuple{Any})
+let a = Docs.docstrloc(DocsTest.f, Tuple{Any})
     @test a == [(@__FILE__, DocsTest.F1_LINE_NUMBER)]
 end
 
-let a = docstrloc(DocsTest.f, Tuple{Any, Any})
+let a = Docs.docstrloc(DocsTest.f, Tuple{Any, Any})
     @test a == [(@__FILE__, DocsTest.F2_LINE_NUMBER)]
 end
 
-let a = docstrloc(DocsTest.f)
+let a = Docs.docstrloc(DocsTest.f)
     @test a == [(@__FILE__, DocsTest.F1_LINE_NUMBER),
                 (@__FILE__, DocsTest.F2_LINE_NUMBER)]
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -325,6 +325,10 @@ let a = Docs.docstrloc(DocsTest.f)
                 (@__FILE__, DocsTest.F2_LINE_NUMBER)]
 end
 
+let a = Docs.docstrloc(DocsTest.Foo)
+    @test a == []
+end
+
 "BareModule"
 baremodule BareModule
 


### PR DESCRIPTION
This new function has a signature similar to `Docs.doc`, but instead returns the
locations of matching docstrings in a manner similar to `functionloc`.

This came out of the discussion in #18745.