### PR TITLE
part 1 of #9147: zero-initialize all Arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -298,6 +298,10 @@ for (fname, felt) in ((:zeros,:zero), (:ones,:one))
     end
 end
 
+function zeros(T::Union{BitIntegerType,Type{Float64},Type{Float32},Type{Float16}}, dims::Tuple)
+    Array{T}(Dims(dims))
+end
+
 """
     eye([T::Type=Float64,] m::Integer, n::Integer)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -298,9 +298,9 @@ for (fname, felt) in ((:zeros,:zero), (:ones,:one))
     end
 end
 
-function zeros(T::Union{BitIntegerType,Type{Float64},Type{Float32},Type{Float16}}, dims::Tuple)
-    Array{T}(Dims(dims))
-end
+#function zeros(T::Union{BitIntegerType,Type{Float64},Type{Float32},Type{Float16}}, dims::Tuple)
+#    Array{T}(Dims(dims))
+#end
 
 """
     eye([T::Type=Float64,] m::Integer, n::Integer)

--- a/src/array.c
+++ b/src/array.c
@@ -97,7 +97,7 @@ static jl_array_t *_new_array_(jl_value_t *atype, uint32_t ndims, size_t *dims,
         // No allocation or safepoint allowed after this
         a->flags.how = 0;
         data = (char*)a + doffs;
-        if (tot > 0)
+        if (tot > 0 && !isunboxed)
             memset(data, 0, tot);
     }
     else {

--- a/src/julia.h
+++ b/src/julia.h
@@ -134,7 +134,7 @@ typedef struct {
     /*
       how - allocation style
       0 = data is inlined, or a foreign pointer we don't manage
-      1 = julia-allocated buffer that needs to be marked
+      1 = allocated by jl_gc_alloc_array_storage
       2 = malloc-allocated pointer this array object manages
       3 = has a pointer to the object that owns the data
     */
@@ -672,10 +672,6 @@ STATIC_INLINE void jl_gc_wb_back(void *ptr) // ptr isa jl_value_t*
         jl_gc_queue_root((jl_value_t*)ptr);
     }
 }
-
-JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz);
-JL_DLLEXPORT void *jl_gc_managed_realloc(void *d, size_t sz, size_t oldsz,
-                                         int isaligned, jl_value_t *owner);
 
 // object accessors -----------------------------------------------------------
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -306,6 +306,10 @@ jl_svec_t *jl_perm_symsvec(size_t n, ...);
 // pointer fields.
 #define jl_datatype_layout_n_nonptr(layout) ((uint32_t*)(layout))[-1]
 
+JL_DLLEXPORT void *jl_gc_alloc_array_storage(size_t sz);
+JL_DLLEXPORT void *jl_gc_realloc_array_storage(void *d, size_t sz, size_t oldsz, jl_value_t *owner);
+JL_DLLEXPORT void *jl_gc_counted_realloc_with_align(void *d, size_t sz, size_t oldsz,
+                                                    int isaligned, jl_value_t *owner);
 jl_value_t *jl_gc_realloc_string(jl_value_t *s, size_t sz);
 
 jl_code_info_t *jl_type_infer(jl_method_instance_t **li, size_t world, int force);


### PR DESCRIPTION
This handles the Array part of zero-initializing, using `calloc` where possible, and assuming zero-filling in `zeros`. The hardest part is that there is no `calloc_aligned` or `re_calloc`, and certainly no `re_calloc_aligned` :) This is probably not optimal yet; ideas are welcome.

@nanosoldier `runbenchmarks(ALL, vs = ":master")`