### PR TITLE
add optional argument to code_lowered to enable generator expansion

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -442,9 +442,11 @@ macro which(ex0::Symbol)
 end
 
 for fname in [:code_typed, :code_lowered]
+    add_arg_expr = fname == :code_lowered ? :(push!(thecall.args, true)) : nothing
     @eval begin
         macro ($fname)(ex0)
             thecall = gen_call_with_extracted_types(__module__, $(Expr(:quote, fname)), ex0)
+            $(add_arg_expr)
             quote
                 results = $thecall
                 length(results) == 1 ? results[1] : results

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -442,11 +442,9 @@ macro which(ex0::Symbol)
 end
 
 for fname in [:code_typed, :code_lowered]
-    add_arg_expr = fname == :code_lowered ? :(push!(thecall.args, true)) : nothing
     @eval begin
         macro ($fname)(ex0)
             thecall = gen_call_with_extracted_types(__module__, $(Expr(:quote, fname)), ex0)
-            $(add_arg_expr)
             quote
                 results = $thecall
                 length(results) == 1 ? results[1] : results

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -714,7 +714,7 @@ uncompressed_ast(m::Core.MethodInstance) = uncompressed_ast(m.def)
 
 function method_instances(@nospecialize(f), @nospecialize(t), world::UInt = typemax(UInt))
     tt = signature_type(f, t)
-    results = Vector{Any}()
+    results = Vector{Union{Method,Core.MethodInstance}}()
     for method_data in _methods_by_ftype(tt, -1, world)
         mtypes, msp, m = method_data
         instance = Core.Inference.code_for_method(m, mtypes, msp, world, false)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -561,13 +561,32 @@ end
 tt_cons(@nospecialize(t), @nospecialize(tup)) = (@_pure_meta; Tuple{t, (isa(tup, Type) ? tup.parameters : tup)...})
 
 """
-    code_lowered(f, types)
+    code_lowered(f, types, expand_generated = false)
 
 Returns an array of lowered ASTs for the methods matching the given generic function and type signature.
+
+If `expand_generated` is `false`, then the `CodeInfo` instances returned for `@generated`
+methods will correspond to the generators' lowered ASTs. If `expand_generated` is `true`,
+these `CodeInfo` instances will correspond to the lowered ASTs of the method bodies yielded
+by expanding the generators.
 """
-function code_lowered(@nospecialize(f), @nospecialize t = Tuple)
-    asts = map(methods(f, t)) do m
-        return uncompressed_ast(m::Method)
+function code_lowered(@nospecialize(f), @nospecialize(t = Tuple), expand_generated::Bool = false)
+    if expand_generated
+        ft = isa(f,Type) ? Type{f} : typeof(f)
+        tt = isa(t,Type) ? Tuple{ft, t.parameters...} : Tuple{ft, t...}
+        asts = map(_methods_by_ftype(tt, -1, typemax(UInt))) do method_data
+            mtypes, msp, m = method_data
+            if isdefined(m, :generator)
+                instance = Core.Inference.code_for_method(m, mtypes, msp, typemax(UInt), false)
+                return Core.Inference.get_staged(instance::Core.MethodInstance)
+            else
+                return uncompressed_ast(m::Method)
+            end
+        end
+    else
+        asts = map(methods(f, t)) do m
+            return uncompressed_ast(m::Method)
+        end
     end
     return asts
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -580,7 +580,7 @@ Note that an error will be thrown if `types` are not leaf types when `expand_gen
 function code_lowered(@nospecialize(f), @nospecialize(t = Tuple), expand_generated::Bool = true)
     return map(method_instances(f, t)) do m
         if expand_generated && isgenerated(m)
-            if isa(m, MethodInstance)
+            if isa(m, Core.MethodInstance)
                 return Core.Inference.get_staged(m)
             else # isa(m, Method)
                 error("Could not expand generator for `@generated` method ", m, ". ",


### PR DESCRIPTION
Attempt at fixing #22874. It works, but I'm not sure if this is how it should be implemented.

From Jeff's/Yichao's comments in that issue:

> The problem is abstract types, for which we don't invoke generators. In those cases, we'd have to give an error (perhaps until we have fallback code for generated functions)

> It should always be safe for @code_lowered though. For code_lowered I guess we can have arguments to control this (just like code_llvm) and pick a reasonable default behavior?

By default, I've disabled generator expansion for `code_lowered` and enabled it for `@code_lowered`. I guess the mismatch could be a point of confusion...

I'll add some tests once I get confirmation that this is going in the right direction.

