### PR TITLE
display non-compactly arrays with only one column

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1743,7 +1743,7 @@ function showarray(io::IO, X::AbstractArray, repr::Bool = true; header = true)
     if repr && ndims(X) == 1
         return show_vector(io, X, "[", "]")
     end
-    if !haskey(io, :compact) && size(X, 2) != 1
+    if !haskey(io, :compact) && length(indices(X, 2)) > 1
         io = IOContext(io, :compact => true)
     end
     if !repr && get(io, :limit, false) && eltype(X) === Method

--- a/base/show.jl
+++ b/base/show.jl
@@ -1386,7 +1386,10 @@ end
 function alignment(io::IO, x::Pair)
     s = sprint(0, show, x, env=io)
     if has_tight_type(x) # i.e. use "=>" for display
-        left = length(sprint(0, show, x.first, env=io)) + 2isa(x.first, Pair) # 2 for parens
+        iocompact = IOContext(io, :compact => get(io, :compact, true))
+        left = length(sprint(0, show, x.first, env=iocompact))
+        left += 2 * !isdelimited(iocompact, x.first) # for parens around p.first
+        left += !get(io, :compact, false) # spaces are added around "=>"
         (left+1, length(s)-left-1) # +1 for the "=" part of "=>"
     else
         (0, length(s)) # as for x::Any
@@ -1740,7 +1743,7 @@ function showarray(io::IO, X::AbstractArray, repr::Bool = true; header = true)
     if repr && ndims(X) == 1
         return show_vector(io, X, "[", "]")
     end
-    if !haskey(io, :compact)
+    if !haskey(io, :compact) && size(X, 2) != 1
         io = IOContext(io, :compact => true)
     end
     if !repr && get(io, :limit, false) && eltype(X) === Method

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -969,8 +969,8 @@ end
     @test sprint((io, x) -> show(io, MIME("text/plain"), x), a) ==
         join([
             "4-element Array{Complex{Float64},1}:",
-            "     1.0+1.0e-10im",
-            " 2.0e-15-2.0e-5im ",
-            " 1.0e-15+2.0im    ",
-            "     1.0+2.0e-15im"], "\n")
+            "     1.0 + 1.0e-10im",
+            " 2.0e-15 - 2.0e-5im ",
+            " 1.0e-15 + 2.0im    ",
+            "     1.0 + 2.0e-15im"], "\n")
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -830,13 +830,37 @@ end
 end
 
 @testset "alignment for pairs" begin  # (#22899)
-    @test replstr([1=>22,33=>4]) == "2-element Array{Pair{$Int,$Int},1}:\n  1=>22\n 33=>4 "
+    @test replstr([1=>22,33=>4]) == "2-element Array{Pair{$Int,$Int},1}:\n  1 => 22\n 33 => 4 "
     # first field may have "=>" in its representation
     @test replstr(Pair[(1=>2)=>3, 4=>5]) ==
-        "2-element Array{Pair,1}:\n (1=>2)=>3\n      4=>5"
+        "2-element Array{Pair,1}:\n (1=>2) => 3\n      4 => 5"
     @test replstr(Any[Dict(1=>2)=> (3=>4), 1=>2]) ==
-        "2-element Array{Any,1}:\n Dict(1=>2)=>(3=>4)\n          1=>2     "
+        "2-element Array{Any,1}:\n Dict(1=>2) => (3=>4)\n          1 => 2     "
     # left-alignment when not using the "=>" symbol
     @test replstr(Pair{Integer,Int64}[1=>2, 33=>4]) ==
         "2-element Array{Pair{Integer,Int64},1}:\n Pair{Integer,Int64}(1, 2) \n Pair{Integer,Int64}(33, 4)"
+end
+
+@testset "display arrays non-compactly when size(⋅, 2) == 1" begin
+    # 0-dim
+    @test replstr(zeros(Complex{Int})) == "0-dimensional Array{Complex{$Int},0}:\n0 + 0im"
+    A = Array{Pair}(); A[] = 1=>2
+    @test replstr(A) == "0-dimensional Array{Pair,0}:\n1 => 2"
+    # 1-dim
+    @test replstr(zeros(Complex{Int}, 2)) ==
+        "2-element Array{Complex{$Int},1}:\n 0 + 0im\n 0 + 0im"
+    @test replstr([1=>2, 3=>4]) == "2-element Array{Pair{$Int,$Int},1}:\n 1 => 2\n 3 => 4"
+    # 2-dim
+    @test replstr(zeros(Complex{Int}, 2, 1)) ==
+        "2×1 Array{Complex{$Int},2}:\n 0 + 0im\n 0 + 0im"
+    @test replstr(zeros(Complex{Int}, 1, 2)) ==
+        "1×2 Array{Complex{$Int},2}:\n 0+0im  0+0im"
+    @test replstr([1=>2 3=>4]) == "1×2 Array{Pair{$Int,$Int},2}:\n 1=>2  3=>4"
+    @test replstr([1=>2 for x in 1:2, y in 1:1]) ==
+        "2×1 Array{Pair{$Int,$Int},2}:\n 1 => 2\n 1 => 2"
+    # 3-dim
+    @test replstr(zeros(Complex{Int}, 1, 1, 1)) ==
+        "1×1×1 Array{Complex{$Int},3}:\n[:, :, 1] =\n 0 + 0im"
+    @test replstr(zeros(Complex{Int}, 1, 2, 1)) ==
+        "1×2×1 Array{Complex{$Int},3}:\n[:, :, 1] =\n 0+0im  0+0im"
 end


### PR DESCRIPTION
When there is only one column, there is almost all the horizontal space to print one element, so this can as well be printed non-compactly.
Together with  #22916 and #22899, this allows to print vectors of pairs more similarly to `Dict`:
```
julia> d = Dict(1=>22, 33=>4)
Dict{Int64,Int64} with 2 entries:
  33 => 4
  1  => 22

julia> sort!(collect(d)) # I always do this
2-element Array{Pair{Int64,Int64},1}:
  1 => 22
 33 => 4

julia> sort!(collect(d)) # before those PRs
2-element Array{Pair{Int64,Int64},1}:
 1=>22
 33=>4
```
The last difference I would like to see addressed eventually is the alignment of the first elements of the pairs.
