### PR TITLE
improved product iterator

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -610,7 +610,7 @@ prod_iteratorsize(a, b) = SizeUnknown()
 
 size(P::ProductIterator) = _prod_size(P.iterators)
 _prod_size(::Tuple{}) = ()
-_prod_size(t::Tuple) = tuple(_prod_size1(t[1], iteratorsize(t[1]))..., _prod_size(tail(t))...)
+_prod_size(t::Tuple) = (_prod_size1(t[1], iteratorsize(t[1]))..., _prod_size(tail(t))...)
 _prod_size1(a, ::HasShape)  = size(a)
 _prod_size1(a, ::HasLength) = (length(a),)
 _prod_size1(a, A) =
@@ -618,7 +618,7 @@ _prod_size1(a, A) =
 
 indices(P::ProductIterator) = _prod_indices(P.iterators)
 _prod_indices(::Tuple{}) = ()
-_prod_indices(t::Tuple) = tuple(_prod_indices1(t[1], iteratorsize(t[1]))..., _prod_indices(tail(t))...)
+_prod_indices(t::Tuple) = (_prod_indices1(t[1], iteratorsize(t[1]))..., _prod_indices(tail(t))...)
 _prod_indices1(a, ::HasShape)  = indices(a)
 _prod_indices1(a, ::HasLength) = (OneTo(length(a)),)
 _prod_indices1(a, A) =
@@ -658,7 +658,7 @@ function next(P::ProductIterator, state)
     iter1 = first(iterators)
     value1, state1 = next(iter1, states[1])
     tailstates = tail(states)
-    values = (value1, map(unsafe_get, state[3])...) # safe if not done(P, state)
+    values = (value1, map(unsafe_get, nvalues)...) # safe if not done(P, state)
     if done(iter1, state1)
         d, tailstates, nvalues = _prod_next(tail(iterators), tailstates, nvalues)
         if !d # only restart iter1 if not completely done

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -4,7 +4,7 @@ module Iterators
 
 import Base: start, done, next, isempty, length, size, eltype, iteratorsize, iteratoreltype, indices, ndims
 
-using Base: tuple_type_cons, SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds
+using Base: tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape, IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds
 
 export enumerate, zip, rest, countfrom, take, drop, cycle, repeated, product, flatten, partition
 
@@ -575,63 +575,18 @@ iteratoreltype(::Type{<:Repeated}) = HasEltype()
 
 
 # Product -- cartesian product of iterators
-
-abstract type AbstractProdIterator end
-
-length(p::AbstractProdIterator) = prod(size(p))
-_length(p::AbstractProdIterator) = prod(map(unsafe_length, indices(p)))
-size(p::AbstractProdIterator) = _prod_size(p.a, p.b, iteratorsize(p.a), iteratorsize(p.b))
-indices(p::AbstractProdIterator) = _prod_indices(p.a, p.b, iteratorsize(p.a), iteratorsize(p.b))
-ndims(p::AbstractProdIterator) = length(indices(p))
-
-# generic methods to handle size of Prod* types
-_prod_size(a, ::HasShape)  = size(a)
-_prod_size(a, ::HasLength) = (length(a),)
-_prod_size(a, A) =
-    throw(ArgumentError("Cannot compute size for object of type $(typeof(a))"))
-_prod_size(a, b, ::HasLength, ::HasLength)  = (length(a),  length(b))
-_prod_size(a, b, ::HasLength, ::HasShape)   = (length(a),  size(b)...)
-_prod_size(a, b, ::HasShape,  ::HasLength)  = (size(a)..., length(b))
-_prod_size(a, b, ::HasShape,  ::HasShape)   = (size(a)..., size(b)...)
-_prod_size(a, b, A, B) =
-    throw(ArgumentError("Cannot construct size for objects of types $(typeof(a)) and $(typeof(b))"))
-
-_prod_indices(a, ::HasShape)  = indices(a)
-_prod_indices(a, ::HasLength) = (OneTo(length(a)),)
-_prod_indices(a, A) =
-    throw(ArgumentError("Cannot compute indices for object of type $(typeof(a))"))
-_prod_indices(a, b, ::HasLength, ::HasLength)  = (OneTo(length(a)),  OneTo(length(b)))
-_prod_indices(a, b, ::HasLength, ::HasShape)   = (OneTo(length(a)),  indices(b)...)
-_prod_indices(a, b, ::HasShape,  ::HasLength)  = (indices(a)..., OneTo(length(b)))
-_prod_indices(a, b, ::HasShape,  ::HasShape)   = (indices(a)..., indices(b)...)
-_prod_indices(a, b, A, B) =
-    throw(ArgumentError("Cannot construct indices for objects of types $(typeof(a)) and $(typeof(b))"))
-
-# one iterator
-struct Prod1{I} <: AbstractProdIterator
-    a::I
+struct ProductIterator{T<:Tuple}
+    iterators::T
 end
-product(a) = Prod1(a)
 
-eltype(::Type{Prod1{I}}) where {I} = Tuple{eltype(I)}
-size(p::Prod1) = _prod_size(p.a, iteratorsize(p.a))
-indices(p::Prod1) = _prod_indices(p.a, iteratorsize(p.a))
-
-@inline start(p::Prod1) = start(p.a)
-@inline function next(p::Prod1, st)
-    n, st = next(p.a, st)
-    (n,), st
+struct ProductIteratorState{T,S}
+    done::Bool
+    states::T
+    values::S
+    ProductIteratorState{T,S}(done, states::T, values::S) where {T,S} = new(done, states, values)
+    ProductIteratorState{T,S}(done, states::T) where {T,S} = new(done, states)
 end
-@inline done(p::Prod1, st) = done(p.a, st)
-
-iteratoreltype(::Type{Prod1{I}}) where {I} = iteratoreltype(I)
-iteratorsize(::Type{Prod1{I}}) where {I} = iteratorsize(I)
-
-# two iterators
-struct Prod2{I1, I2} <: AbstractProdIterator
-    a::I1
-    b::I2
-end
+ProductIteratorState(done, states::T, values::S) where {T,S} = ProductIteratorState{T,S}(done, states, values)
 
 """
     product(iters...)
@@ -648,54 +603,12 @@ julia> collect(Iterators.product(1:2,3:5))
  (2, 3)  (2, 4)  (2, 5)
 ```
 """
-product(a, b) = Prod2(a, b)
+product(iters...) = ProductIterator(iters)
 
-eltype(::Type{Prod2{I1,I2}}) where {I1,I2} = Tuple{eltype(I1), eltype(I2)}
-
-iteratoreltype(::Type{Prod2{I1,I2}}) where {I1,I2} = and_iteratoreltype(iteratoreltype(I1),iteratoreltype(I2))
-iteratorsize(::Type{Prod2{I1,I2}}) where {I1,I2} = prod_iteratorsize(iteratorsize(I1),iteratorsize(I2))
-
-function start(p::AbstractProdIterator)
-    s1, s2 = start(p.a), start(p.b)
-    s1, s2, Nullable{eltype(p.b)}(), (done(p.a,s1) || done(p.b,s2))
-end
-
-@inline function prod_next(p, st)
-    s1, s2 = st[1], st[2]
-    v1, s1 = next(p.a, s1)
-
-    nv2 = st[3]
-    if isnull(nv2)
-        v2, s2 = next(p.b, s2)
-    else
-        v2 = nv2.value
-    end
-
-    if done(p.a, s1)
-        return (v1,v2), (start(p.a), s2, Nullable{eltype(nv2)}(), done(p.b,s2))
-    end
-    return (v1,v2), (s1, s2, Nullable(v2), false)
-end
-
-@inline next(p::Prod2, st) = prod_next(p, st)
-@inline done(p::AbstractProdIterator, st) = st[4]
-
-# n iterators
-struct Prod{I1, I2<:AbstractProdIterator} <: AbstractProdIterator
-    a::I1
-    b::I2
-end
-product(a, b, c...) = Prod(a, product(b, c...))
-
-eltype(::Type{Prod{I1,I2}}) where {I1,I2} = tuple_type_cons(eltype(I1), eltype(I2))
-
-iteratoreltype(::Type{Prod{I1,I2}}) where {I1,I2} = and_iteratoreltype(iteratoreltype(I1),iteratoreltype(I2))
-iteratorsize(::Type{Prod{I1,I2}}) where {I1,I2} = prod_iteratorsize(iteratorsize(I1),iteratorsize(I2))
-
-@inline function next(p::Prod, st)
-    x = prod_next(p, st)
-    ((x[1][1],x[1][2]...), x[2])
-end
+iteratorsize(::Type{ProductIterator{Tuple{}}}) = HasShape()
+iteratorsize(::Type{ProductIterator{Tuple{I}}}) where {I} = iteratorsize(I)
+iteratorsize(::Type{ProductIterator{T}}) where {T<:Tuple} =
+    prod_iteratorsize( iteratorsize(tuple_type_head(T)), iteratorsize(ProductIterator{tuple_type_tail(T)}) )
 
 prod_iteratorsize(::Union{HasLength,HasShape}, ::Union{HasLength,HasShape}) = HasShape()
 # products can have an infinite iterator
@@ -704,6 +617,71 @@ prod_iteratorsize(a, ::IsInfinite) = IsInfinite()
 prod_iteratorsize(::IsInfinite, b) = IsInfinite()
 prod_iteratorsize(a, b) = SizeUnknown()
 
+size(P::ProductIterator) = _prod_size(P.iterators)
+_prod_size(::Tuple{}) = ()
+_prod_size(t::Tuple) = tuple(_prod_size1(t[1], iteratorsize(t[1]))..., _prod_size(tail(t))...)
+_prod_size1(a, ::HasShape)  = size(a)
+_prod_size1(a, ::HasLength) = (length(a),)
+_prod_size1(a, A) =
+    throw(ArgumentError("Cannot compute size for object of type $(typeof(a))"))
+
+indices(P::ProductIterator) = _prod_indices(P.iterators)
+_prod_indices(::Tuple{}) = ()
+_prod_indices(t::Tuple) = tuple(_prod_indices1(t[1], iteratorsize(t[1]))..., _prod_indices(tail(t))...)
+_prod_indices1(a, ::HasShape)  = indices(a)
+_prod_indices1(a, ::HasLength) = (OneTo(length(a)),)
+_prod_indices1(a, A) =
+    throw(ArgumentError("Cannot compute indices for object of type $(typeof(a))"))
+
+ndims(p::ProductIterator) = length(indices(p))
+length(P::ProductIterator) = prod(size(P))
+_length(p::ProductIterator) = prod(map(unsafe_length, indices(p)))
+
+iteratoreltype(::Type{ProductIterator{Tuple{}}}) = HasEltype()
+iteratoreltype(::Type{ProductIterator{Tuple{I}}}) where {I} = iteratoreltype(I)
+function iteratoreltype(::Type{ProductIterator{T}}) where {T<:Tuple}
+    I = tuple_type_head(T)
+    P = ProductIterator{tuple_type_tail(T)}
+    iteratoreltype(I) == EltypeUnknown() ? EltypeUnknown() : iteratoreltype(P)
+end
+
+Base.eltype(P::ProductIterator) = _prod_eltype(P.iterators)
+_prod_eltype(::Tuple{}) = Tuple{}
+_prod_eltype(t::Tuple) = Base.tuple_type_cons(eltype(t[1]),_prod_eltype(tail(t)))
+
+function Base.start(P::ProductIterator)
+    iterators = P.iterators
+    states = map(start, iterators)
+    if any(map(done, iterators, states))
+        return ProductIteratorState{typeof(states),eltype(P)}(true, states)
+    else
+        return ProductIteratorState{typeof(states),eltype(P)}(false, _prod_start(iterators, states)...)
+    end
+end
+Base.next(P::ProductIterator, state) = state.values, ProductIteratorState(_prod_next(P.iterators, state.states, state.values)...)
+Base.done(P::ProductIterator, state) = state.done
+
+_prod_start(iterators::Tuple{}, states::Tuple{}) = (), ()
+function _prod_start(iterators, states)
+    val, state = next(iterators[1], states[1])
+    tailstates, tailvals = _prod_start(tail(iterators), tail(states))
+    return (state, tailstates...), (val, tailvals...)
+end
+_prod_next(iterators::Tuple{}, states::Tuple{}, values::Tuple{}) = true, (), ()
+function _prod_next(iterators, states, values)
+    if !done(iterators[1], states[1])
+        nextval, nextstate = next(iterators[1], states[1])
+        return false, tuple(nextstate, tail(states)...), tuple(nextval, tail(values)...)
+    else
+        d, nextstates, nextvals = _prod_next(tail(iterators), tail(states), tail(values))
+        if d # all iterators are done
+            return true, states, values
+        else
+            nextval, nextstate = next(iterators[1], start(iterators[1]))
+            return false, tuple(nextstate, nextstates...), tuple(nextval, nextvals...)
+        end
+    end
+end
 
 # flatten an iterator of iterators
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -314,7 +314,7 @@ end
 @test Base.iteratorsize(product(1:2))                        == Base.HasShape()
 @test Base.iteratorsize(product(1:2, 1:2))                   == Base.HasShape()
 @test Base.iteratorsize(product(take(1:2, 1), take(1:2, 1))) == Base.HasShape()
-@test Base.iteratorsize(product(take(1:2, 2)))               == Base.HasLength()
+@test Base.iteratorsize(product(take(1:2, 2)))               == Base.HasShape()
 @test Base.iteratorsize(product([1 2; 3 4]))                 == Base.HasShape()
 
 # iteratoreltype trait business


### PR DESCRIPTION
This is basically a complete replacement of the implementation of the `product` iterator in `Base.Iterators`. It is more efficient and remains type stable for a larger number of iterators. The current product iterator starts allocating for 6 or more iterators, whereas the implementation in this PR remains type stable and therefore allocation free up to 14 iterators. 

In the benchmark below, I also compare to the more specialised but therefore also more efficient `CartesianRange` iterator. The current implementation seems almost as efficient for the case where all iterators are ranges, so that `CartesianRange` could maybe become a disguised `product` iterator that wraps the output tuple in a `CartesianIndex`.

I think @JeffBezanson implemented the current `product` iterator in master, and @timholy did most of the `CartesianRange` work.

Benchmark:
```julia
using BenchmarkTools
using Base.Iterators.product
@noinline dosomething(x) = x
function mycount(itr)
    n = 0
    for x in itr
        dosomething(x)
        n+=1
    end
    return n
end
times=Vector(14)
for N = 1:14
    iter = product(ntuple(n->1:4, Val(N))...) # or iter = CartesianRange(...)
    times[N] = @benchmark mycount($iter)
end
```
and results in

 | N  | PR `product` | `CartesianRange` | master `product` |
| --- |---|---|---|
 |   1  |  Trial(8.665 ns)    |  Trial(7.146 ns)    |  Trial(7.766 ns)    |
 |   2  |  Trial(93.655 ns)   |  Trial(83.618 ns)   |  Trial(88.639 ns)   |
 |   3  |  Trial(367.870 ns)  |  Trial(345.069 ns)  |  Trial(700.325 ns)  |
 |   4  |  Trial(1.774 μs)    |  Trial(1.718 μs)    |  Trial(4.662 μs)    |
 |   5  |  Trial(7.556 μs)    |  Trial(6.608 μs)    |  Trial(26.906 μs)   |
 |   6  |  Trial(35.315 μs)   |  Trial(32.732 μs)   |  Trial(15.894 ms)   |
 |   7  |  Trial(142.293 μs)  |  Trial(130.331 μs)  |  Trial(64.895 ms)   |
 |   8  |  Trial(612.727 μs)  |  Trial(576.491 μs)  |  Trial(279.602 ms)  |
 |   9  |  Trial(2.643 ms)    |  Trial(2.326 ms)    |  Trial(1.231 s)     |
 |  10  |  Trial(11.177 ms)   |  Trial(10.756 ms)   |  Trial(4.361 s)     |
 |  11  |  Trial(54.838 ms)   |  Trial(47.823 ms)   |  Trial(19.058 s)    |
 |  12  |  Trial(245.494 ms)  |  Trial(234.108 ms)  |  ???    |
 |  13  |  Trial(1.095 s)     |  Trial(949.563 ms)  |  ???    |
 |  14  |  Trial(5.247 s)     |  Trial(4.466 s)     |  ???    |