### PR TITLE
sysinfo: fix the unit of maxrss on FreeBSD

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -193,6 +193,14 @@ function set_process_title(title::AbstractString)
     Base.uv_error("set_process_title", err)
 end
 
+"""
+    Sys.maxrss()
+
+Get the maximum resident set size utilized in bytes.
+See also:
+    - man page of getrusage(2) on Linux and FreeBSD.
+    - windows api `GetProcessMemoryInfo`
+"""
 maxrss() = ccall(:jl_maxrss, Csize_t, ())
 
 """

--- a/src/sys.c
+++ b/src/sys.c
@@ -768,11 +768,13 @@ JL_DLLEXPORT size_t jl_maxrss(void)
     GetProcessMemoryInfo( GetCurrentProcess( ), &counter, sizeof(counter) );
     return (size_t)counter.PeakWorkingSetSize;
 
+// FIXME: `rusage` is available on OpenBSD, DragonFlyBSD and NetBSD as well.
+//        All of them return `ru_maxrss` in kilobytes.
 #elif defined(_OS_LINUX_) || defined(_OS_DARWIN_) || defined (_OS_FREEBSD_)
     struct rusage rusage;
     getrusage( RUSAGE_SELF, &rusage );
 
-#if defined(_OS_LINUX_)
+#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
     return (size_t)(rusage.ru_maxrss * 1024);
 #else
     return (size_t)rusage.ru_maxrss;


### PR DESCRIPTION
The value from `rusage.ru_maxrss` is in kilobytes.