### PR TITLE
RFC: add command option to remove method redefinition warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ define sysimg_builder
 $$(build_private_libdir)/sys$1.o: $$(build_private_libdir)/inference.ji $$(JULIAHOME)/VERSION $$(BASE_SRCS)
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \
 	$$(call spawn,$3) $2 -C $$(JULIA_CPU_TARGET) --output-o $$(call cygpath_w,$$@) $$(JULIA_SYSIMG_BUILD_FLAGS) \
-		--startup-file=no --sysimage $$(call cygpath_w,$$<) sysimg.jl $$(RELBUILDROOT) \
+		--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) sysimg.jl $$(RELBUILDROOT) \
 		|| { echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***' && false; } )
 .SECONDARY: $(build_private_libdir)/sys$1.o
 endef

--- a/NEWS.md
+++ b/NEWS.md
@@ -302,6 +302,12 @@ Deprecated or removed
   * `Base.cpad` has been removed; use an appropriate combination of `rpad` and `lpad`
     instead ([#23187]).
 
+Command-line option changes
+---------------------------
+
+  * New option `--warn-overwrite={yes|no}` to control the warning for overwriting method
+    definitions. The default is `no` ([#23002]).
+
 Julia v0.6.0 Release Notes
 ==========================
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -509,7 +509,7 @@ function create_expr_cache(input::String, output::String, concrete_deps::Vector{
         """
     io = open(pipeline(detach(`$(julia_cmd()) -O0
                               --output-ji $output --output-incremental=yes
-                              --startup-file=no --history-file=no
+                              --startup-file=no --history-file=no --warn-overwrite=yes
                               --color=$(have_color ? "yes" : "no")
                               --eval $code_object`), stderr=STDERR),
               "w", STDOUT)

--- a/base/options.jl
+++ b/base/options.jl
@@ -23,6 +23,7 @@ struct JLOptions
     debug_level::Int8
     check_bounds::Int8
     depwarn::Int8
+    overwritewarn::Int8
     can_inline::Int8
     polly::Int8
     fast_math::Int8

--- a/base/options.jl
+++ b/base/options.jl
@@ -23,7 +23,7 @@ struct JLOptions
     debug_level::Int8
     check_bounds::Int8
     depwarn::Int8
-    overwritewarn::Int8
+    warn_overwrite::Int8
     can_inline::Int8
     polly::Int8
     fast_math::Int8

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -719,6 +719,7 @@ function test!(pkg::AbstractString,
                     --color=$(Base.have_color ? "yes" : "no")
                     --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
                     --check-bounds=yes
+                    --warn-overwrite=yes
                     --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
                     $test_path
                     ```

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -161,6 +161,10 @@ or adhere to declarations in source code
 Enable or disable syntax and method deprecation warnings ('error' turns warnings into errors)
 
 .TP
+--warn-overwrite={yes|no}
+Enable or disable method overwrite warnings
+
+.TP
 --output-o <name>
 Generate an object file (including system image data)
 

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -127,6 +127,7 @@ julia [switches] -- [programfile] [args...]
  --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)
 
  --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)
+ --warn-overwrite={yes|no} Enable or disable method overwrite warnings
 
  --output-o name           Generate an object file (including system image data)
  --output-ji name          Generate a system image data file (.ji)

--- a/src/gf.c
+++ b/src/gf.c
@@ -1223,7 +1223,7 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
     jl_method_t *method = (jl_method_t*)newentry->func.method;
     jl_module_t *newmod = method->module;
     jl_module_t *oldmod = oldvalue->module;
-    if (jl_options.overwritewarn == JL_OPTIONS_DEPWARN_ON && (newmod != jl_main_module || oldmod != jl_main_module)) {
+    if (jl_options.overwritewarn == JL_OPTIONS_DEPWARN_ON) {
         JL_STREAM *s = JL_STDERR;
         jl_printf(s, "WARNING: Method definition ");
         jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1223,7 +1223,7 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
     jl_method_t *method = (jl_method_t*)newentry->func.method;
     jl_module_t *newmod = method->module;
     jl_module_t *oldmod = oldvalue->module;
-    if (jl_options.overwritewarn == JL_OPTIONS_DEPWARN_ON) {
+    if (jl_options.warn_overwrite == JL_OPTIONS_WARN_OVERWRITE_ON) {
         JL_STREAM *s = JL_STDERR;
         jl_printf(s, "WARNING: Method definition ");
         jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);

--- a/src/gf.c
+++ b/src/gf.c
@@ -1223,7 +1223,7 @@ static void method_overwrite(jl_typemap_entry_t *newentry, jl_method_t *oldvalue
     jl_method_t *method = (jl_method_t*)newentry->func.method;
     jl_module_t *newmod = method->module;
     jl_module_t *oldmod = oldvalue->module;
-    if (newmod != jl_main_module || oldmod != jl_main_module) {
+    if (jl_options.overwritewarn == JL_OPTIONS_DEPWARN_ON && (newmod != jl_main_module || oldmod != jl_main_module)) {
         JL_STREAM *s = JL_STDERR;
         jl_printf(s, "WARNING: Method definition ");
         jl_static_show_func_sig(s, (jl_value_t*)newentry->sig);

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -58,6 +58,7 @@ jl_options_t jl_options = { 0,    // quiet
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
                             1,    // deprecation warning
+                            1,    // method overwrite warning
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly
                             JL_OPTIONS_FAST_MATH_DEFAULT,
@@ -123,6 +124,7 @@ static const char opts[]  =
 
     // error and warning options
     " --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings (\"error\" turns warnings into errors)\n\n"
+    " --overwritewarn={yes|no}  Enable or disable method overwrite warnings"
 
     // compiler output options
     " --output-o name           Generate an object file (including system image data)\n"
@@ -156,6 +158,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_output_unopt_bc,
            opt_output_bc,
            opt_depwarn,
+           opt_overwritewarn,
            opt_inline,
            opt_polly,
            opt_math_mode,
@@ -201,6 +204,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "output-ji",       required_argument, 0, opt_output_ji },
         { "output-incremental",required_argument, 0, opt_incremental },
         { "depwarn",         required_argument, 0, opt_depwarn },
+        { "overwritewarn",   required_argument, 0, opt_overwritewarn },
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
         { "math-mode",       required_argument, 0, opt_math_mode },
@@ -477,6 +481,14 @@ restart_switch:
                 jl_options.depwarn = JL_OPTIONS_DEPWARN_ERROR;
             else
                 jl_errorf("julia: invalid argument to --depwarn={yes|no|error} (%s)", optarg);
+            break;
+        case opt_overwritewarn:
+            if (!strcmp(optarg,"yes"))
+                jl_options.overwritewarn = JL_OPTIONS_OVERWRITEWARN_ON;
+            else if (!strcmp(optarg,"no"))
+                jl_options.overwritewarn = JL_OPTIONS_OVERWRITEWARN_OFF;
+            else
+                jl_errorf("julia: invalid argument to --overwritewarn={yes|no|} (%s)", optarg);
             break;
         case opt_inline:
             if (!strcmp(optarg,"yes"))

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -58,7 +58,7 @@ jl_options_t jl_options = { 0,    // quiet
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
                             1,    // deprecation warning
-                            1,    // method overwrite warning
+                            0,    // method overwrite warning
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly
                             JL_OPTIONS_FAST_MATH_DEFAULT,

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -124,7 +124,7 @@ static const char opts[]  =
 
     // error and warning options
     " --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings (\"error\" turns warnings into errors)\n\n"
-    " --overwritewarn={yes|no}  Enable or disable method overwrite warnings"
+    " --warn-overwrite={yes|no} Enable or disable method overwrite warnings"
 
     // compiler output options
     " --output-o name           Generate an object file (including system image data)\n"
@@ -158,7 +158,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_output_unopt_bc,
            opt_output_bc,
            opt_depwarn,
-           opt_overwritewarn,
+           opt_warn_overwrite,
            opt_inline,
            opt_polly,
            opt_math_mode,
@@ -204,7 +204,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "output-ji",       required_argument, 0, opt_output_ji },
         { "output-incremental",required_argument, 0, opt_incremental },
         { "depwarn",         required_argument, 0, opt_depwarn },
-        { "overwritewarn",   required_argument, 0, opt_overwritewarn },
+        { "warn-overwrite",  required_argument, 0, opt_warn_overwrite },
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
         { "math-mode",       required_argument, 0, opt_math_mode },
@@ -482,13 +482,13 @@ restart_switch:
             else
                 jl_errorf("julia: invalid argument to --depwarn={yes|no|error} (%s)", optarg);
             break;
-        case opt_overwritewarn:
+        case opt_warn_overwrite:
             if (!strcmp(optarg,"yes"))
-                jl_options.overwritewarn = JL_OPTIONS_OVERWRITEWARN_ON;
+                jl_options.warn_overwrite = JL_OPTIONS_WARN_OVERWRITE_ON;
             else if (!strcmp(optarg,"no"))
-                jl_options.overwritewarn = JL_OPTIONS_OVERWRITEWARN_OFF;
+                jl_options.warn_overwrite = JL_OPTIONS_WARN_OVERWRITE_OFF;
             else
-                jl_errorf("julia: invalid argument to --overwritewarn={yes|no|} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --warn-overwrite={yes|no|} (%s)", optarg);
             break;
         case opt_inline:
             if (!strcmp(optarg,"yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1692,6 +1692,7 @@ typedef struct {
     int8_t debug_level;
     int8_t check_bounds;
     int8_t depwarn;
+    int8_t overwritewarn;
     int8_t can_inline;
     int8_t polly;
     int8_t fast_math;
@@ -1751,6 +1752,9 @@ JL_DLLEXPORT int jl_generating_output(void);
 #define JL_OPTIONS_DEPWARN_OFF 0
 #define JL_OPTIONS_DEPWARN_ON 1
 #define JL_OPTIONS_DEPWARN_ERROR 2
+
+#define JL_OPTIONS_OVERWRITEWARN_OFF 0
+#define JL_OPTIONS_OVERWRITEWARN_ON 1
 
 #define JL_OPTIONS_POLLY_ON 1
 #define JL_OPTIONS_POLLY_OFF 0

--- a/src/julia.h
+++ b/src/julia.h
@@ -1692,7 +1692,7 @@ typedef struct {
     int8_t debug_level;
     int8_t check_bounds;
     int8_t depwarn;
-    int8_t overwritewarn;
+    int8_t warn_overwrite;
     int8_t can_inline;
     int8_t polly;
     int8_t fast_math;
@@ -1753,8 +1753,8 @@ JL_DLLEXPORT int jl_generating_output(void);
 #define JL_OPTIONS_DEPWARN_ON 1
 #define JL_OPTIONS_DEPWARN_ERROR 2
 
-#define JL_OPTIONS_OVERWRITEWARN_OFF 0
-#define JL_OPTIONS_OVERWRITEWARN_ON 1
+#define JL_OPTIONS_WARN_OVERWRITE_OFF 0
+#define JL_OPTIONS_WARN_OVERWRITE_ON 1
 
 #define JL_OPTIONS_POLLY_ON 1
 #define JL_OPTIONS_POLLY_OFF 0

--- a/test/core.jl
+++ b/test/core.jl
@@ -5100,7 +5100,6 @@ m22929_2.x = m22929_1
 @test isdefined_22929_1(m22929_2)
 @test isdefined_22929_x(m22929_2)
 
-<<<<<<< 9f974bf8b47c781e5d89f43c4a278aa84c8c3c34
 # Union type sorting
 for T in (
         (Void, Int8),
@@ -5174,30 +5173,4 @@ module GlobalDef18933
     @test @which(sincos) === Base.Math
     @test @isdefined sincos
     @test sincos === Base.sincos
-end
-
-let exename = `$(Base.julia_cmd()) --startup-file=no`
-    for (mac, flag, pfix, msg) in [("@test_nowarn", ``, "_1", ""),
-                                   ("@test_warn",   `--overwritewarn=yes`, "_2", "\"WARNING: Method definition\"")]
-        str = """
-        using Base.Test
-        try
-            # issue #18725
-            $mac $msg @eval Main begin
-                f18725$(pfix)(x) = 1
-                f18725$(pfix)(x) = 2
-            end
-            @test Main.f18725$(pfix)(0) == 2
-            # PR #23030
-            $mac $msg @eval Main module Module23030$(pfix)
-                f23030$(pfix)(x) = 1
-                f23030$(pfix)(x) = 2
-            end
-        catch
-            exit(-1)
-        end
-        exit(0)
-        """
-        run(`$exename $flag -e $str`)
-    end
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -4680,17 +4680,6 @@ end
 @test f14893() == 14893
 @test M14893.f14893() == 14893
 
-# issue #18725
-@test_nowarn @eval Main begin
-    f18725(x) = 1
-    f18725(x) = 2
-end
-@test Main.f18725(0) == 2
-@test_warn "WARNING: Method definition f18725(Any) in module Module18725" @eval Main module Module18725
-    f18725(x) = 1
-    f18725(x) = 2
-end
-
 # issue #19599
 f19599(x::((S)->Vector{S})(T)...) where {T} = 1
 @test f19599([1],[1]) == 1
@@ -5111,6 +5100,7 @@ m22929_2.x = m22929_1
 @test isdefined_22929_1(m22929_2)
 @test isdefined_22929_x(m22929_2)
 
+<<<<<<< 9f974bf8b47c781e5d89f43c4a278aa84c8c3c34
 # Union type sorting
 for T in (
         (Void, Int8),
@@ -5184,4 +5174,30 @@ module GlobalDef18933
     @test @which(sincos) === Base.Math
     @test @isdefined sincos
     @test sincos === Base.sincos
+end
+
+let exename = `$(Base.julia_cmd()) --startup-file=no`
+    for (mac, flag, pfix, msg) in [("@test_nowarn", ``, "_1", ""),
+                                   ("@test_warn",   `--overwritewarn=yes`, "_2", "\"WARNING: Method definition\"")]
+        str = """
+        using Base.Test
+        try
+            # issue #18725
+            $mac $msg @eval Main begin
+                f18725$(pfix)(x) = 1
+                f18725$(pfix)(x) = 2
+            end
+            @test Main.f18725$(pfix)(0) == 2
+            # PR #23030
+            $mac $msg @eval Main module Module23030$(pfix)
+                f23030$(pfix)(x) = 1
+                f23030$(pfix)(x) = 2
+            end
+        catch
+            exit(-1)
+        end
+        exit(0)
+        """
+        run(`$exename $flag -e $str`)
+    end
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -239,7 +239,7 @@ let
     redir_err = "redirect_stderr(STDOUT)"
     exename = Base.julia_cmd()
     script = "$redir_err; module A; f() = 1; end; A.f() = 1"
-    warning_str = read(`$exename --startup-file=no -e $script`, String)
+    warning_str = read(`$exename --warn-overwrite=yes --startup-file=no -e $script`, String)
     @test contains(warning_str, "f()")
 end
 


### PR DESCRIPTION
With #265 fixed, more and more workflow seems to move towards redefining methods while keeping Julia running, even methods that exist in modules, e.g. https://github.com/timholy/Revise.jl. Also in interactive sessions like IJulia, redefining methods  is very common.

Since this seems to be the way people will develop code, it is nice to be able to turn off the method redefinition warnings globally. This PR adds a command line option to turn them off.
 