### PR TITLE
fix backedge restore list order in incremental serializer

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -940,8 +940,8 @@ static void jl_collect_backedges_to(jl_method_instance_t *caller, jl_array_t *di
     jl_array_t **pcallees = (jl_array_t**)ptrhash_bp(&edges_map, (void*)caller),
                 *callees = *pcallees;
     if (callees != HT_NOTFOUND) {
-        arraylist_push(to_restore, (void*)pcallees);
         arraylist_push(to_restore, (void*)callees);
+        arraylist_push(to_restore, (void*)pcallees);
         *pcallees = (jl_array_t*) HT_NOTFOUND;
         jl_array_ptr_1d_append(direct_callees, callees);
         size_t i, l = jl_array_len(callees);


### PR DESCRIPTION
Found this while working on #22974. The different alloc pattern there somehow exposed it. Thanks to @Keno for debugging help.

I'm hoping this might fix #22552.
