### PR TITLE
suppress warning for redefining docstrings if the symbol is in Main

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -232,10 +232,11 @@ Adds a new docstring `str` to the docsystem of `__module__` for `binding` and si
 function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize sig = Union{})
     initmeta(__module__)
     m = get!(meta(__module__), b, MultiDoc())
-    if haskey(m.docs, sig) && __module__ != Main
+    if haskey(m.docs, sig)
         # We allow for docstrings to be updated, but print a warning since it is possible
-        # that over-writing a docstring *may* have been accidental.
-        warn("replacing docs for '$b :: $sig' in module '$(__module__)'.")
+        # that over-writing a docstring *may* have been accidental.  The warning
+        # is suppressed for symbols in Main, for interactive use (#23011).
+        __module__ == Main || warn("replacing docs for '$b :: $sig' in module '$(__module__)'.")
     else
         # The ordering of docstrings for each Binding is defined by the order in which they
         # are initially added. Replacing a specific docstring does not change it's ordering.

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -232,7 +232,7 @@ Adds a new docstring `str` to the docsystem of `__module__` for `binding` and si
 function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize sig = Union{})
     initmeta(__module__)
     m = get!(meta(__module__), b, MultiDoc())
-    if haskey(m.docs, sig)
+    if haskey(m.docs, sig) && __module__ != Main
         # We allow for docstrings to be updated, but print a warning since it is possible
         # that over-writing a docstring *may* have been accidental.
         warn("replacing docs for '$b :: $sig' in module '$(__module__)'.")

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1047,3 +1047,11 @@ let foo_docs = meta(I22105)[@var(I22105.foo)].docs
     @test docstr.data[:typesig] === Union{}
     @test docstr.data[:binding] == Binding(I22105, :foo)
 end
+
+# issue #23011
+@test_nowarn @eval Main begin
+    @doc "first" f23011() = 1
+    @doc "second" f23011() = 2
+end
+@test Main.f23011() == 2
+@test docstring_startswith(@doc(Main.f23011), doc"second")

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1054,4 +1054,4 @@ end
     @doc "second" f23011() = 2
 end
 @test Main.f23011() == 2
-@test docstring_startswith(@doc(Main.f23011), doc"second")
+@test docstrings_equal(@doc(Main.f23011), doc"second")


### PR DESCRIPTION
This fixes #23011.