### PR TITLE
LibGit2 RemoteCallback refactoring

### DIFF
--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -238,10 +238,6 @@ function is_ancestor_of(a::AbstractString, b::AbstractString, repo::GitRepo)
     merge_base(repo, a, b) == A
 end
 
-function make_payload(payload::Nullable{<:AbstractCredentials})
-    Ref{Nullable{AbstractCredentials}}(payload)
-end
-
 """
     fetch(repo::GitRepo; kwargs...)
 
@@ -269,7 +265,6 @@ function fetch(repo::GitRepo; remote::AbstractString="origin",
         GitRemoteAnon(repo, remoteurl)
     end
     try
-        payload = make_payload(payload)
         fo = FetchOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
         fetch(rmt, refspecs, msg="from $(url(rmt))", options = fo)
     finally
@@ -304,7 +299,6 @@ function push(repo::GitRepo; remote::AbstractString="origin",
         GitRemoteAnon(repo, remoteurl)
     end
     try
-        payload = make_payload(payload)
         push_opts=PushOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
         push(rmt, refspecs, force=force, options=push_opts)
     finally
@@ -510,7 +504,6 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
                payload::Nullable{<:AbstractCredentials}=Nullable{AbstractCredentials}())
     # setup clone options
     lbranch = Base.cconvert(Cstring, branch)
-    payload = make_payload(payload)
     fetch_opts=FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), payload))
     clone_opts = CloneOptions(
                 bare = Cint(isbare),

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -184,7 +184,7 @@ Matches the [`git_remote_callbacks`](https://libgit2.github.com/libgit2/#HEAD/ty
 end
 
 function RemoteCallbacks(credentials::Ptr{Void}, payload::Ref{Nullable{AbstractCredentials}})
-    RemoteCallbacks(credentials=credentials_cb(), payload=pointer_from_objref(payload))
+    RemoteCallbacks(credentials=credentials, payload=pointer_from_objref(payload))
 end
 
 """

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -187,6 +187,10 @@ function RemoteCallbacks(credentials::Ptr{Void}, payload::Ref{Nullable{AbstractC
     RemoteCallbacks(credentials=credentials, payload=pointer_from_objref(payload))
 end
 
+function RemoteCallbacks(credentials::Ptr{Void}, payload::Nullable{<:AbstractCredentials})
+    RemoteCallbacks(credentials, Ref{Nullable{AbstractCredentials}}(payload))
+end
+
 """
     LibGit2.ProxyOptions
 


### PR DESCRIPTION
Part of #20725.

Changes include:
* Fixes mistake where `credentials` parameter was ignored in `RemoteCallback` constructor
* Eliminates `make_payload` function in favor of creating a new `RemoteCallback` constructor