### PR TITLE
Make utility for generating git url string

### DIFF
--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -10,11 +10,15 @@ const URL_REGEX = r"""
 )?
 (?<host>[A-Za-z0-9\-\.]+)
 (?(<scheme>)
-    (?:\:(?<port>\d+))?  # only parse port when not using SCP-like syntax
+    (?:\:(?<port>\d+))?  # only parse port when not using scp-like syntax
     |
     :?
 )
-(?<path>.*?)$
+(?<path>
+    (?(<scheme>)/|(?<=:))  # scp-like syntax must be preceeded by a colon
+    .*
+)?
+$
 """x
 
 function version()

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -65,3 +65,41 @@ if Sys.iswindows()
 else Sys.isunix()
     posixpath(path) = path
 end
+
+function git_url(;
+        scheme::AbstractString="",
+        username::AbstractString="",
+        password::AbstractString="",
+        host::AbstractString="",
+        port::Union{AbstractString,Integer}="",
+        path::AbstractString="")
+
+    port_str = string(port)
+    scp_syntax = isempty(scheme)
+
+    isempty(host) && throw(ArgumentError("A host needs to be specified"))
+    scp_syntax && !isempty(port_str) && throw(ArgumentError("Port cannot be specified when using scp-like syntax"))
+
+    io = IOBuffer()
+    !isempty(scheme) && print(io, scheme, "://")
+
+    if !isempty(username) || !isempty(password)
+        print(io, username)
+        !isempty(password) && print(io, ':', password)
+        print(io, '@')
+    end
+
+    print(io, host)
+    !isempty(port_str) && print(io, ':', port_str)
+
+    if !isempty(path)
+        if scp_syntax
+            print(io, ':')
+        elseif !startswith(path, '/')
+            print(io, '/')
+        end
+        print(io, path)
+    end
+
+    return String(take!(io))
+end

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -70,6 +70,37 @@ else Sys.isunix()
     posixpath(path) = path
 end
 
+"""
+    LibGit2.git_url(; kwargs...) -> String
+
+Create a string based upon the URL components provided. When the `scheme` keyword is not
+provided the URL produced will use the alternative [scp-like syntax](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a).
+
+# Keywords
+
+  * `scheme::AbstractString=""`: the URL scheme which identifies the protocol to be used.
+    For HTTP use "http", SSH use "ssh", etc. When `scheme` is not provided the output format
+    will be "ssh" but using the scp-like syntax.
+  * `username::AbstractString=""`: the username to use in the output if provided.
+  * `password::AbstractString=""`: the password to use in the output if provided.
+  * `host::AbstractString=""`: the hostname to use in the output. A hostname is required to
+    be specified.
+  * `port::Union{AbstractString,Integer}=""`: the port number to use in the output if
+    provided. Cannot be specified when using the scp-like syntax.
+  * `path::AbstractString=""`: the path to use in the output if provided.
+
+# Examples
+```jldoctest
+julia> LibGit2.git_url(username="git", host="github.com", path="JuliaLang/julia.git")
+"git@github.com:JuliaLang/julia.git"
+
+julia> LibGit2.git_url(scheme="https", host="github.com", path="/JuliaLang/julia.git")
+"https://github.com/JuliaLang/julia.git"
+
+julia> LibGit2.git_url(scheme="ssh", username="git", host="github.com", port=2222, path="JuliaLang/julia.git")
+"ssh://git@github.com:2222/JuliaLang/julia.git"
+```
+"""
 function git_url(;
         scheme::AbstractString="",
         username::AbstractString="",

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -3,7 +3,7 @@
 # Parse "GIT URLs" syntax (URLs and a scp-like syntax). For details see:
 # https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a
 const URL_REGEX = r"""
-^(?:(?<scheme>ssh|git|https?)://)?
+^(?:(?<scheme>ssh|git|https?)://)?+
 (?:
     (?<user>.*?)
     (?:\:(?<password>.*?))?@

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -194,6 +194,11 @@ end
         @test m[:path] === nothing
     end
 
+    @testset "HTTPS URL, invalid path" begin
+        m = match(LibGit2.URL_REGEX, "https://git@server:repo")
+        @test m === nothing
+    end
+
     # scp-like syntax should have a colon separating the hostname from the path
     @testset "scp-like syntax, invalid path" begin
         m = match(LibGit2.URL_REGEX, "git@server/repo")

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -195,6 +195,94 @@ end
     end
 end
 
+@testset "Git URL formatting" begin
+    @testset "HTTPS URL" begin
+        url = LibGit2.git_url(
+            scheme="https",
+            username="user",
+            password="pass",
+            host="server.com",
+            port=80,
+            path="/org/project.git")
+        @test url == "https://user:pass@server.com:80/org/project.git"
+    end
+
+    @testset "SSH URL" begin
+        url = LibGit2.git_url(
+            scheme="ssh",
+            username="user",
+            password="pass",
+            host="server",
+            port="22",
+            path="/project.git")
+        @test url == "ssh://user:pass@server:22/project.git"
+    end
+
+    @testset "SSH URL, scp-like syntax" begin
+        url = LibGit2.git_url(
+            scheme="",
+            username="user",
+            host="server",
+            path="project.git")
+        @test url == "user@server:project.git"
+    end
+
+    @testset "HTTPS URL, realistic" begin
+        url = LibGit2.git_url(
+            scheme="https",
+            host="github.com",
+            path="/JuliaLang/Example.jl.git")
+        @test url == "https://github.com/JuliaLang/Example.jl.git"
+    end
+
+    @testset "SSH URL, realistic" begin
+        url = LibGit2.git_url(
+            username="git",
+            host="github.com",
+            path="JuliaLang/Example.jl.git")
+        @test url == "git@github.com:JuliaLang/Example.jl.git"
+    end
+
+    @testset "HTTPS URL, no path" begin
+        url = LibGit2.git_url(
+            scheme="https",
+            username="user",
+            password="pass",
+            host="server.com",
+            port="80")
+        @test url == "https://user:pass@server.com:80"
+    end
+
+    @testset "scp-like syntax, no path" begin
+        url = LibGit2.git_url(
+            username="user",
+            host="server.com")
+        @test url == "user@server.com"
+    end
+
+    @testset "HTTP URL, path missing slash prefix" begin
+        url = LibGit2.git_url(
+            scheme="http",
+            host="server.com",
+            path="path")
+        @test url == "http://server.com/path"
+    end
+
+    @testset "empty" begin
+        @test_throws ArgumentError LibGit2.git_url()
+
+        @test LibGit2.git_url(host="server.com") == "server.com"
+        url = LibGit2.git_url(
+            scheme="",
+            username="",
+            password="",
+            host="server.com",
+            port="",
+            path="")
+        @test url == "server.com"
+    end
+end
+
 mktempdir() do dir
     # test parameters
     repo_url = "https://github.com/JuliaLang/Example.jl"

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -183,7 +183,7 @@ end
 
     @testset "HTTPS URL, no path" begin
         m = match(LibGit2.URL_REGEX, "https://user:pass@server.com:80")
-        @test m[:path] == ""
+        @test m[:path] === nothing
     end
 
     @testset "scp-like syntax, no path" begin
@@ -191,7 +191,13 @@ end
         @test m[:path] == ""
 
         m = match(LibGit2.URL_REGEX, "user@server")
-        @test m[:path] == ""
+        @test m[:path] === nothing
+    end
+
+    # scp-like syntax should have a colon separating the hostname from the path
+    @testset "scp-like syntax, invalid path" begin
+        m = match(LibGit2.URL_REGEX, "git@server/repo")
+        @test m === nothing
     end
 end
 
@@ -1575,7 +1581,7 @@ mktempdir() do dir
     # systems.
     if Sys.isunix()
         @testset "SSH credential prompt" begin
-            url = "git@github.com/test/package.jl"
+            url = "git@github.com:test/package.jl"
 
             key_dir = joinpath(dirname(@__FILE__), "libgit2")
             valid_key = joinpath(key_dir, "valid")


### PR DESCRIPTION
Part of #20725.

Various parts of the callback code create URLs for displaying information to the user. The `git_url` function allows us to consistently create these URL strings and allows us to test behaviour.