### PR TITLE
[RFC] VersionNumber: make number type platform-independent (UInt32)

### DIFF
--- a/base/pkg/resolve/versionweight.jl
+++ b/base/pkg/resolve/versionweight.jl
@@ -74,7 +74,7 @@ struct VWPreBuildItem
     i::Int
 end
 VWPreBuildItem() = VWPreBuildItem(0, HierarchicalValue(Int), 0)
-VWPreBuildItem(i::Int) = VWPreBuildItem(1, HierarchicalValue(Int), i)
+VWPreBuildItem(i::Integer) = VWPreBuildItem(1, HierarchicalValue(Int), i)
 VWPreBuildItem(s::String) = VWPreBuildItem(1, HierarchicalValue(Int[s...]), 0)
 
 Base.zero(::Type{VWPreBuildItem}) = VWPreBuildItem()
@@ -105,7 +105,7 @@ end
 
 const _vwprebuild_zero = VWPreBuild(0, HierarchicalValue(VWPreBuildItem))
 
-function VWPreBuild(ispre::Bool, desc::Tuple{Vararg{Union{Int,String}}})
+function VWPreBuild(ispre::Bool, desc::Tuple{Vararg{Union{Integer,String}}})
     isempty(desc) && return _vwprebuild_zero
     desc == ("",) && return VWPreBuild(ispre ? -1 : 1, HierarchicalValue(VWPreBuildItem[]))
     nonempty = ispre ? -1 : 0

--- a/base/version.jl
+++ b/base/version.jl
@@ -2,21 +2,23 @@
 
 ## semantic version numbers (http://semver.org)
 
-struct VersionNumber
-    major::Int
-    minor::Int
-    patch::Int
-    prerelease::Tuple{Vararg{Union{Int,String}}}
-    build::Tuple{Vararg{Union{Int,String}}}
+const VInt = UInt32
 
-    function VersionNumber(major::Int, minor::Int, patch::Int,
-            pre::Tuple{Vararg{Union{Int,String}}},
-            bld::Tuple{Vararg{Union{Int,String}}})
+struct VersionNumber
+    major::VInt
+    minor::VInt
+    patch::VInt
+    prerelease::Tuple{Vararg{Union{UInt64,String}}}
+    build::Tuple{Vararg{Union{UInt64,String}}}
+
+    function VersionNumber(major::VInt, minor::VInt, patch::VInt,
+            pre::Tuple{Vararg{Union{UInt64,String}}},
+            bld::Tuple{Vararg{Union{UInt64,String}}})
         major >= 0 || throw(ArgumentError("invalid negative major version: $major"))
         minor >= 0 || throw(ArgumentError("invalid negative minor version: $minor"))
         patch >= 0 || throw(ArgumentError("invalid negative patch version: $patch"))
         for ident in pre
-            if isa(ident,Int)
+            if ident isa Integer
                 ident >= 0 || throw(ArgumentError("invalid negative pre-release identifier: $ident"))
             else
                 if !ismatch(r"^(?:|[0-9a-z-]*[a-z-][0-9a-z-]*)$"i, ident) ||
@@ -26,7 +28,7 @@ struct VersionNumber
             end
         end
         for ident in bld
-            if isa(ident,Int)
+            if ident isa Integer
                 ident >= 0 || throw(ArgumentError("invalid negative build identifier: $ident"))
             else
                 if !ismatch(r"^(?:|[0-9a-z-]*[a-z-][0-9a-z-]*)$"i, ident) ||
@@ -41,9 +43,9 @@ end
 VersionNumber(major::Integer, minor::Integer = 0, patch::Integer = 0,
         pre::Tuple{Vararg{Union{Integer,AbstractString}}} = (),
         bld::Tuple{Vararg{Union{Integer,AbstractString}}} = ()) =
-    VersionNumber(Int(major), Int(minor), Int(patch),
-        map(x->isa(x,Integer) ? Int(x) : String(x), pre),
-        map(x->isa(x,Integer) ? Int(x) : String(x), bld))
+    VersionNumber(VInt(major), VInt(minor), VInt(patch),
+        map(x->x isa Integer ? UInt64(x) : String(x), pre),
+        map(x->x isa Integer ? UInt64(x) : String(x), bld))
 
 function print(io::IO, v::VersionNumber)
     v == typemax(VersionNumber) && return print(io, "∞")
@@ -82,7 +84,7 @@ function split_idents(s::AbstractString)
     idents = split(s, '.')
     ntuple(length(idents)) do i
         ident = idents[i]
-        ismatch(r"^\d+$", ident) ? parse(Int, ident) : String(ident)
+        ismatch(r"^\d+$", ident) ? parse(UInt64, ident) : String(ident)
     end
 end
 
@@ -91,9 +93,9 @@ function VersionNumber(v::AbstractString)
     m = match(VERSION_REGEX, v)
     m === nothing && throw(ArgumentError("invalid version string: $v"))
     major, minor, patch, minus, prerl, plus, build = m.captures
-    major = parse(Int, major)
-    minor = minor !== nothing ? parse(Int, minor) : 0
-    patch = patch !== nothing ? parse(Int, patch) : 0
+    major = parse(VInt, major)
+    minor = minor !== nothing ? parse(VInt, minor) : VInt(0)
+    patch = patch !== nothing ? parse(VInt, patch) : VInt(0)
     if prerl !== nothing && !isempty(prerl) && prerl[1] == '-'
         prerl = prerl[2:end] # strip leading '-'
     end
@@ -107,15 +109,21 @@ convert(::Type{VersionNumber}, v::AbstractString) = VersionNumber(v)
 macro v_str(v); VersionNumber(v); end
 
 typemin(::Type{VersionNumber}) = v"0-"
-typemax(::Type{VersionNumber}) = VersionNumber(typemax(Int),typemax(Int),typemax(Int),(),("",))
 
-ident_cmp(a::Int, b::Int) = cmp(a,b)
-ident_cmp(a::Int, b::String) = isempty(b) ? +1 : -1
-ident_cmp(a::String, b::Int) = isempty(a) ? -1 : +1
-ident_cmp(a::String, b::String) = cmp(a,b)
+function typemax(::Type{VersionNumber})
+    ∞ = typemax(VInt)
+    VersionNumber(∞, ∞, ∞, (), ("",))
+end
 
-function ident_cmp(A::Tuple{Vararg{Union{Int,String}}},
-                   B::Tuple{Vararg{Union{Int,String}}})
+ident_cmp(a::Integer, b::Integer) = cmp(a, b)
+ident_cmp(a::Integer, b::String ) = isempty(b) ? +1 : -1
+ident_cmp(a::String,  b::Integer) = isempty(a) ? -1 : +1
+ident_cmp(a::String,  b::String ) = cmp(a, b)
+
+function ident_cmp(
+    A::Tuple{Vararg{Union{Integer,String}}},
+    B::Tuple{Vararg{Union{Integer,String}}},
+)
     i = start(A)
     j = start(B)
     while !done(A,i) && !done(B,i)
@@ -132,8 +140,8 @@ function ==(a::VersionNumber, b::VersionNumber)
     (a.major != b.major) && return false
     (a.minor != b.minor) && return false
     (a.patch != b.patch) && return false
-    (ident_cmp(a.prerelease,b.prerelease) != 0) && return false
-    (ident_cmp(a.build,b.build) != 0) && return false
+    (ident_cmp(a.prerelease, b.prerelease) != 0) && return false
+    (ident_cmp(a.build, b.build) != 0) && return false
     return true
 end
 
@@ -186,7 +194,7 @@ function check_new_version(existing::Vector{VersionNumber}, ver::VersionNumber)
         end
         error("$ver is not a valid initial version (try 0.0.0, 0.0.1, 0.1 or 1.0)")
     end
-    idx = searchsortedlast(existing,ver)
+    idx = searchsortedlast(existing, ver)
     prv = existing[idx]
     ver == prv && error("version $ver already exists")
     nxt = thismajor(ver) != thismajor(prv) ? nextmajor(prv) :

--- a/test/version.jl
+++ b/test/version.jl
@@ -95,6 +95,10 @@ show(io,v"4.3.2+1.a")
 # typemin and typemax
 @test typemin(VersionNumber) == v"0-"
 @test typemax(VersionNumber) == v"∞"
+let ∞ = typemax(UInt32)
+    @test typemin(VersionNumber) == VersionNumber(0, 0, 0, ("",), ())
+    @test typemax(VersionNumber) == VersionNumber(∞, ∞, ∞, (), ("",))
+end
 
 # issupbuild
 import Base.issupbuild


### PR DESCRIPTION
It seemed strange that we could represent higher version numbers on 64-bit systems than 32-bit systems (not that it practically matters). This commit makes the representation of version numbers platform-independent, using UInt32 everywhere instead of Int.