### PR TITLE
RFC: preserve more syntax in parsing `?`, `do`, and `elseif`

### DIFF
--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -13,13 +13,13 @@ such as a `ccall` to a non-existent function.
 """
 macro static(ex)
     if isa(ex, Expr)
-        if ex.head === :if || ex.head === :&& || ex.head === :||
+        if ex.head === :if || ex.head === :&& || ex.head === :|| || ex.head === :?
             cond = eval(__module__, ex.args[1])
             if xor(cond, ex.head === :||)
                 return esc(ex.args[2])
             elseif length(ex.args) == 3
                 return esc(ex.args[3])
-            elseif ex.head === :if
+            elseif ex.head === :if || ex.head === :?
                 return nothing
             else
                 return cond

--- a/base/show.jl
+++ b/base/show.jl
@@ -557,7 +557,11 @@ function show_block(io::IO, head, args::Vector, body, indent::Int)
     print(io, head)
     if !isempty(args)
         print(io, ' ')
-        show_list(io, args, ", ", indent)
+        if head === :elseif
+            show_list(io, args, " ", indent)
+        else
+            show_list(io, args, ", ", indent)
+        end
     end
 
     ind = head === :module || head === :baremodule ? indent : indent + indent_width
@@ -880,9 +884,18 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, "function ", args[1], " end")
 
     # block with argument
-    elseif head in (:for,:while,:function,:if) && nargs==2
+    elseif head in (:for,:while,:function,:if,:elseif) && nargs==2
         show_block(io, head, args[1], args[2], indent)
         print(io, "end")
+
+    elseif (head === :if || head === :elseif) && nargs == 3
+        show_block(io, head, args[1], args[2], indent)
+        if isa(args[3],Expr) && args[3].head == :elseif
+            show_unquoted(io, args[3], indent, prec)
+        else
+            show_block(io, "else", args[3], indent)
+            print(io, "end")
+        end
 
     elseif head === :module && nargs==3 && isa(args[1],Bool)
         show_block(io, args[1] ? :module : :baremodule, args[2], args[3], indent)
@@ -944,11 +957,6 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
 
     elseif head === :line && 1 <= nargs <= 2
         show_linenumber(io, args...)
-
-    elseif head === :if && nargs == 3     # if/else
-        show_block(io, "if",   args[1], args[2], indent)
-        show_block(io, "else", args[3], indent)
-        print(io, "end")
 
     elseif head === :try && 3 <= nargs <= 4
         show_block(io, "try", args[1], indent)

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -760,7 +760,7 @@
                     (let ((t (with-whitespace-newline (peek-token s))))
                       (if (not (ts:space? s))
                           (syntax-deprecation s (string (deparse ex) " ? " (deparse then) " :" t) (string (deparse ex) " ? " (deparse then) " : " t))))
-                    (list 'if ex then (parse-eq* s)))))
+                    (list '? ex then (parse-eq* s)))))
           (else ex))))
 
 (define (parse-arrow s) (parse-RtoL s parse-or         is-prec-arrow? (eq? t '-->) parse-arrow))
@@ -1138,7 +1138,7 @@
                          (if (eq? (peek-token s) 'do)
                              (begin
                                (take-token s)
-                               `(call ,ex ,@params ,(parse-do s) ,@args))
+                               `(do (call ,ex ,@params ,@args) ,(parse-do s)))
                              `(call ,ex ,@al))))))
                (if macrocall?
                    (map (lambda (x)  ;; parse `a=b` as `=` instead of `kw` in macrocall
@@ -1296,31 +1296,33 @@
           `(for ,(if (length= ranges 1) (car ranges) (cons 'block ranges))
                 ,body)))
 
-       ((if)
+       ((if elseif)
         (if (newline? (peek-token s))
             (error (string "missing condition in \"if\" at " current-filename
                            ":" (- (input-port-line (ts:port s)) 1))))
-        (let* ((test (parse-cond s))
+        (let* ((lno (line-number-node s))  ;; line number for elseif condition
+               (test (parse-cond s))
+               (test (if (eq? word 'elseif)
+                         `(block ,lno ,test)
+                         test))
                (then (if (memq (require-token s) '(else elseif))
                          '(block)
                          (parse-block s)))
                (nxt  (require-token s)))
           (take-token s)
           (case nxt
-            ((end)     (list 'if test then))
+            ((end)     (list word test then))
             ((elseif)
              (if (newline? (peek-token s))
                  (error (string "missing condition in \"elseif\" at " current-filename
                                 ":" (- (input-port-line (ts:port s)) 1))))
-             `(if ,test ,then
-                  ;; line number for elseif condition
-                  (block ,(line-number-node s)
-                         ,(parse-resword s 'if))))
+             `(,word ,test ,then
+                     ,(parse-resword s 'elseif)))
             ((else)
              (if (eq? (peek-token s) 'if)
                  (error "use \"elseif\" instead of \"else if\""))
-             (begin0 (list 'if test then (parse-block s))
-                     (expect-end s word)))
+             (begin0 (list word test then (parse-block s))
+                     (expect-end s 'if)))
             (else      (error (string "unexpected \"" nxt "\""))))))
        ((let)
         (let ((binds (if (memv (peek-token s) '(#\newline #\;))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1656,15 +1656,6 @@
                             (if ,g ,g
                                 ,(loop (cdr tail)))))))))))
 
-(define (expand-forms e)
-  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null meta)))
-      e
-      (let ((ex (get expand-table (car e) #f)))
-        (if ex
-            (ex e)
-            (cons (car e)
-                  (map expand-forms (cdr e)))))))
-
 (define (expand-for while lhs X body)
   ;; (for (= lhs X) body)
   (let ((coll  (make-ssavalue))
@@ -1871,12 +1862,22 @@
               (extract (cdr params) (cons p newparams) whereparams)))))
   (extract (cddr e) '() '()))
 
+(define (expand-forms e)
+  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null meta)))
+      e
+      (let ((ex (get expand-table (car e) #f)))
+        (if ex
+            (ex e)
+            (cons (car e)
+                  (map expand-forms (cdr e)))))))
+
 ;; table mapping expression head to a function expanding that form
 (define expand-table
   (table
    'function       expand-function-def
    'stagedfunction expand-function-def
    '->             expand-arrow
+   '?              (lambda (e) (expand-forms (cons 'if (cdr e))))
    'let            expand-let
    'macro          expand-macro-def
    'type           expand-type-def
@@ -2178,6 +2179,17 @@
                  (else
                   (map expand-forms e))))
          (map expand-forms e)))
+
+   'do
+   (lambda (e)
+     (let* ((call (cadr e))
+            (f    (cadr call))
+            (argl (cddr call))
+            (af   (caddr e)))
+       (expand-forms
+        (if (has-parameters? argl)
+            `(call ,f ,(car argl) ,af ,@(cdr argl))
+            `(call ,f ,af ,@argl)))))
 
    'tuple
    (lambda (e)
@@ -3493,7 +3505,7 @@ f(x) = yt(x)
              (if value
                  (compile (cadr e) break-labels value tail)
                  #f))
-            ((if)
+            ((if elseif)
              (let ((test `(gotoifnot ,(compile-cond (cadr e) break-labels) _))
                    (end-jump `(goto _))
                    (val (if (and value (not tail)) (new-mutable-var) #f)))

--- a/test/show.jl
+++ b/test/show.jl
@@ -236,6 +236,45 @@ end"""
     return
 end"""
 
+@test_repr """if a
+# line meta
+b
+end
+"""
+
+@test_repr """if a
+# line meta
+b
+elseif c
+# line meta
+d
+end
+"""
+
+@test_repr """if a
+# line meta
+b
+elseif c
+# line meta
+d
+else
+# line meta
+e
+end
+"""
+
+@test_repr """if a
+# line meta
+b
+elseif c
+# line meta
+d
+elseif e
+# line meta
+f
+end
+"""
+
 # issue #7188
 @test sprint(show, :foo) == ":foo"
 @test sprint(show, Symbol("foo bar")) == "Symbol(\"foo bar\")"


### PR DESCRIPTION
A part of #21774 that I find pretty agreeable.

- `?` - just uses `?` as the expression head instead of `if`
- `do` parses as `(do <function call expr> <function argument expr>)`
- `if` parses the same as before, except nested `if`s that come from `elseif` use `elseif` as the expression head instead of `if`, and are nested directly inside the `if` expression without intervening blocks, line nodes, etc. I also tried a flat representation (adding N arguments to `if`), but it was hard to deal with. The nested structure is easier since you only need to write code to handle 2- or 3-argument `if`, and treat `elseif` the same as `if`.

This should be non-breaking for users, and a living nightmare for macro authors :)
