### PR TITLE
Revert "Few missing arnoldi tests (#22963)"

### DIFF
--- a/test/linalg/arnoldi.jl
+++ b/test/linalg/arnoldi.jl
@@ -31,10 +31,6 @@ using Base.Test
         (d,v) = eigs(a, nev=3)
         @test a*v[:,2] ≈ d[2]*v[:,2]
         @test norm(v) > testtol # eigenvectors cannot be null vectors
-        (d,v) = eigs(a, I, nev=3) # test eigs(A, B; kwargs...)
-        @test a*v[:,2] ≈ d[2]*v[:,2]
-        @test norm(v) > testtol # eigenvectors cannot be null vectors
-        @test_warn "Use symbols instead of strings for specifying which eigenvalues to compute" eigs(a, which="LM")
         # (d,v) = eigs(a, b, nev=3, tol=1e-8) # not handled yet
         # @test a*v[:,2] ≈ d[2]*b*v[:,2] atol=testtol
         # @test norm(v) > testtol # eigenvectors cannot be null vectors


### PR DESCRIPTION
This reverts commit 5041126e522bae08d509fa9fb2e9dc02c16466a2.

This has been frequently failing on 64-bit Linux Travis with

```
Error in testset linalg/arnoldi:
Error During Test
  Test threw an exception of type Base.LinAlg.ARPACKException
  Expression: (eigs(speye(50), nev=10))[1] ≈ ones(10)
  Base.LinAlg.ARPACKException("unspecified ARPACK error: 3")
```

I'm having trouble reproducing locally, but this should be looked into in more detail. Kind of odd that adding a test earlier in the file would cause one later to fail - there might be some bad state in the library we aren't managing properly?