### PR TITLE
Switch to kernel.org mirror, improve build parallelization on appveyor

### DIFF
--- a/contrib/windows/Vagrantfile
+++ b/contrib/windows/Vagrantfile
@@ -13,7 +13,7 @@ mkdir -Force $cyginstall | Out-Null
 foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,cmake,p7zip",
     "mingw64-$arch-gcc-g++,mingw64-$arch-gcc-fortran")) {
   & "$cyginstall\\$setup" -q -n -R $cyginstall -l $cyginstall\\packages `
-    -s http://mirrors.mit.edu/cygwin -g -P $pkg | Where-Object `
+    -s http://mirrors.kernel.org/sourceware/cygwin -g -P $pkg | Where-Object `
     -FilterScript {$_ -notlike "Installing file *"} | Write-Output
 }
 & "$cyginstall\\bin\\sh" -lc "if ! [ -e julia$bits ]; then git clone \\

--- a/contrib/windows/appveyor_build.sh
+++ b/contrib/windows/appveyor_build.sh
@@ -204,6 +204,7 @@ fi
 echo 'FORCE_ASSERTIONS = 1' >> Make.user
 
 cat Make.user
+make -j3 VERBOSE=1 all
 make -j3 VERBOSE=1 install
 make VERBOSE=1 -C examples
 cp usr/bin/busybox.exe julia-*/bin

--- a/contrib/windows/install-cygwin.ps1
+++ b/contrib/windows/install-cygwin.ps1
@@ -4,6 +4,6 @@ mkdir -Force C:\cygdownloads | Out-Null
 (new-object net.webclient).DownloadFile(
   "http://cygwin.com/$setup", "C:\cygdownloads\$setup")
 & "C:\cygdownloads\$setup" -q -n -R C:\cygwin-$env:ARCH `
-  -l C:\cygdownloads -s http://mirrors.mit.edu/cygwin -g -I `
+  -l C:\cygdownloads -s http://mirrors.kernel.org/sourceware/cygwin -g -I `
   -P "make,curl,time,p7zip,mingw64-$env:ARCH-gcc-g++,mingw64-$env:ARCH-gcc-fortran" | Where-Object `
   -FilterScript {$_ -notlike "Installing file *"} | Write-Output


### PR DESCRIPTION
I'm not sure if there's a great reason for this, but `make -jN install` currently does
the release sysimg and the debug sysimg sequentially, when they could be built
simultaneously - doing `make -jN all` then `make -jN install` should save a few minutes

edit: doing this on travis provoked the oom killer, so making this a just-appveyor change for now