### PR TITLE
prevent versioninfo(verbose=true) init Pkg accidentally

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -331,7 +331,6 @@ function versioninfo(io::IO=STDOUT; verbose::Bool=false, packages::Bool=false)
         println(io, "Packages:")
         println(io, "  Package Directory: ", Pkg.dir())
         print(io, "  Package Status:")
-
         if isdir(Pkg.dir())
             println(io, "")
             Pkg.status(io)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -330,8 +330,14 @@ function versioninfo(io::IO=STDOUT; verbose::Bool=false, packages::Bool=false)
     if packages || verbose
         println(io, "Packages:")
         println(io, "  Package Directory: ", Pkg.dir())
-        println(io, "  Package Status:")
-        Pkg.status(io)
+        print(io, "  Package Status:")
+
+        if isdir(Pkg.dir())
+            println(io, "")
+            Pkg.status(io)
+        else
+            println(io, " no packages installed")
+        end
     end
 end
 

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -65,21 +65,6 @@ temp_pkg_dir() do
     @test_throws PkgError Pkg.installed("MyFakePackage")
     @test Pkg.installed("Example") === nothing
 
-    # check that versioninfo(io; verbose=true) doesn't error, produces some output
-    # and doesn't invoke Pkg.status which will error if JULIA_PKGDIR is set
-    mktempdir() do dir
-        withenv("JULIA_PKGDIR" => dir) do
-            buf = PipeBuffer()
-            versioninfo(buf, verbose=true)
-            ver = read(buf, String)
-            @test startswith(ver, "Julia Version $VERSION")
-            @test contains(ver, "Environment:")
-            @test contains(ver, "Package Status:")
-            @test contains(ver, "no packages installed")
-            @test isempty(readdir(dir))
-        end
-    end
-
     # Check that setprotocol! works.
     begin
         try

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -65,13 +65,20 @@ temp_pkg_dir() do
     @test_throws PkgError Pkg.installed("MyFakePackage")
     @test Pkg.installed("Example") === nothing
 
-    # check that versioninfo(io; verbose=true) doesn't error and produces some output
-    # (done here since it calls Pkg.status which might error or clone metadata)
-    buf = PipeBuffer()
-    versioninfo(buf, verbose=true)
-    ver = read(buf, String)
-    @test startswith(ver, "Julia Version $VERSION")
-    @test contains(ver, "Environment:")
+    # check that versioninfo(io; verbose=true) doesn't error, produces some output
+    # and doesn't invoke Pkg.status which will error if JULIA_PKGDIR is set
+    mktempdir() do dir
+        withenv("JULIA_PKGDIR" => dir) do
+            buf = PipeBuffer()
+            versioninfo(buf, verbose=true)
+            ver = read(buf, String)
+            @test startswith(ver, "Julia Version $VERSION")
+            @test contains(ver, "Environment:")
+            @test contains(ver, "Package Status:")
+            @test contains(ver, "no packages installed")
+            @test isempty(readdir(dir))
+        end
+    end
 
     # Check that setprotocol! works.
     begin

--- a/test/version.jl
+++ b/test/version.jl
@@ -275,3 +275,21 @@ for t = 1:1_000
         @test (v ∈ a && v ∈ b) ? (v ∈ i) : (v ∉ i)
     end
 end
+
+# PR #23075
+@testset "versioninfo" begin
+    # check that versioninfo(io; verbose=true) doesn't error, produces some output
+    # and doesn't invoke Pkg.status which will error if JULIA_PKGDIR is set
+    mktempdir() do dir
+        withenv("JULIA_PKGDIR" => dir) do
+            buf = PipeBuffer()
+            versioninfo(buf, verbose=true)
+            ver = read(buf, String)
+            @test startswith(ver, "Julia Version $VERSION")
+            @test contains(ver, "Environment:")
+            @test contains(ver, "Package Status:")
+            @test contains(ver, "no packages installed")
+            @test isempty(readdir(dir))
+        end
+    end
+end


### PR DESCRIPTION
```
mv ~/.julia/v0.7 ~/.julia/v0.7.bak
./julia --startup-file=no -e 'versioninfo(verbose=true)'
```
This will init METADATA before this PR.