### PR TITLE
fix parsing of `vect` and `ref` with semicolons

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -5,6 +5,7 @@
 (define (deparse-arglist l (sep ", "))
   (if (has-parameters? l)
       (string (string.join (map deparse (cdr l)) sep)
+              (if (length= (cdr l) 1) "," "")
               "; "
               (string.join (map deparse (cdar l)) ", "))
       (string.join (map deparse l) sep)))
@@ -66,26 +67,16 @@
                           (not (= (string.char (string (cadr e)) 0) #\=)))
                      (string ":" (deparse (cadr e)))
                      (string ":(" (deparse (cadr e)) ")")))
-                ((vect)   (string #\[ (deparse-arglist (cdr e)) #\]))
-                ((vcat)
-                 (string #\[
-                         ;; note: this is a parser quasi-bug; arguably `[a,b;c]` should
-                         ;; be a `vect` expression with parameters, not `vcat`
-                         (deparse-arglist (cdr e) (if (has-parameters? (cdr e))
-                                                      ", " "; "))
-                         #\]))
+                ((vect)  (string #\[ (deparse-arglist (cdr e) ", ") #\]))
+                ((vcat)  (string #\[ (deparse-arglist (cdr e) "; ") #\]))
                 ((typed_vcat)  (string (deparse (cadr e))
                                        (deparse (cons 'vcat (cddr e)))))
                 ((hcat)        (string #\[ (deparse-arglist (cdr e) " ") #\]))
                 ((typed_hcat)  (string (deparse (cadr e))
                                        (deparse (cons 'hcat (cddr e)))))
                 ((row)        (deparse-arglist (cdr e) " "))
-                ((braces)     (string #\{ (deparse-arglist (cdr e)) #\}))
-                ((bracescat)
-                 (string #\{
-                         (deparse-arglist (cdr e) (if (has-parameters? (cdr e))
-                                                      ", " "; "))
-                         #\}))
+                ((braces)     (string #\{ (deparse-arglist (cdr e) ", ") #\}))
+                ((bracescat)  (string #\{ (deparse-arglist (cdr e) "; ") #\}))
                 ((const)  (string "const " (deparse (cadr e))))
                 ((global local)
                  (string (car e) " " (string.join (map deparse (cdr e)) ", ")))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2102,6 +2102,8 @@
 
    'curly
    (lambda (e)
+     (if (has-parameters? (cddr e))
+         (error (string "unexpected semicolon in \"" (deparse e) "\"")))
      (let* ((p (extract-implicit-whereparams e))
             (curlyparams (car p))
             (whereparams (cdr p)))
@@ -2293,7 +2295,10 @@
      `(call colon ,.(map expand-forms (cdr e))))
 
    'vect
-   (lambda (e) (expand-forms `(call (top vect) ,@(cdr e))))
+   (lambda (e)
+     (if (has-parameters? (cdr e))
+         (error "unexpected semicolon in array expression"))
+     (expand-forms `(call (top vect) ,@(cdr e))))
 
    'hcat
    (lambda (e) (expand-forms `(call hcat ,.(map expand-forms (cdr e)))))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -629,6 +629,16 @@ end
 @test parse("{:a=>1, :b=>2}") == Expr(:braces, Expr(:call, :(=>), QuoteNode(:a), 1),
                                       Expr(:call, :(=>), QuoteNode(:b), 2))
 
+@test parse("[a,b;c]")  == Expr(:vect, Expr(:parameters, :c), :a, :b)
+@test parse("[a,;c]")   == Expr(:vect, Expr(:parameters, :c), :a)
+@test parse("a[b,c;d]") == Expr(:ref, :a, Expr(:parameters, :d), :b, :c)
+@test parse("a[b,;d]")  == Expr(:ref, :a, Expr(:parameters, :d), :b)
+@test_throws ParseError parse("[a,;,b]")
+@test parse("{a,b;c}")  == Expr(:braces, Expr(:parameters, :c), :a, :b)
+@test parse("{a,;c}")   == Expr(:braces, Expr(:parameters, :c), :a)
+@test parse("a{b,c;d}") == Expr(:curly, :a, Expr(:parameters, :d), :b, :c)
+@test parse("a{b,;d}")  == Expr(:curly, :a, Expr(:parameters, :d), :b)
+
 # this now is parsed as getindex(Pair{Any,Any}, ...)
 @test_throws MethodError eval(parse("(Any=>Any)[]"))
 @test_throws MethodError eval(parse("(Any=>Any)[:a=>1,:b=>2]"))

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -301,8 +301,8 @@ p = ccall((:cholmod_l_allocate_sparse, :libcholmod), Ptr{CHOLMOD.C_Sparse{Float6
 @test CHOLMOD.free_sparse!(p)
 
 for elty in (Float64, Complex{Float64})
-    A1 = sparse([1:5, 1;], [1:5, 2;], elty == Float64 ? randn(6) : complex.(randn(6), randn(6)))
-    A2 = sparse([1:5, 1;], [1:5, 2;], elty == Float64 ? randn(6) : complex.(randn(6), randn(6)))
+    A1 = sparse([1:5; 1], [1:5; 2], elty == Float64 ? randn(6) : complex.(randn(6), randn(6)))
+    A2 = sparse([1:5; 1], [1:5; 2], elty == Float64 ? randn(6) : complex.(randn(6), randn(6)))
     A1pd = A1'A1
     A1Sparse = CHOLMOD.Sparse(A1)
     A2Sparse = CHOLMOD.Sparse(A2)
@@ -444,11 +444,11 @@ for elty in (Float64, Complex{Float64})
         svec = ones(elty, 5)
         @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense(svec), CHOLMOD.SCALAR, A1Sparse)
         @test CHOLMOD.scale!(CHOLMOD.Dense(svec), CHOLMOD.ROW, A1Sparse) == A1Sparse
-        @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense([svec, 1;]), CHOLMOD.ROW, A1Sparse)
+        @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense([svec; 1]), CHOLMOD.ROW, A1Sparse)
         @test CHOLMOD.scale!(CHOLMOD.Dense(svec), CHOLMOD.COL, A1Sparse) == A1Sparse
-        @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense([svec, 1;]), CHOLMOD.COL, A1Sparse)
+        @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense([svec; 1]), CHOLMOD.COL, A1Sparse)
         @test CHOLMOD.scale!(CHOLMOD.Dense(svec), CHOLMOD.SYM, A1Sparse) == A1Sparse
-        @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense([svec, 1;]), CHOLMOD.SYM, A1Sparse)
+        @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense([svec; 1]), CHOLMOD.SYM, A1Sparse)
         @test_throws DimensionMismatch CHOLMOD.scale!(CHOLMOD.Dense(svec), CHOLMOD.SYM, CHOLMOD.Sparse(A1[:,1:4]))
     else
         @test_throws MethodError CHOLMOD.copy(A1Sparse, 0, 1) == A1Sparse


### PR DESCRIPTION
This changes the parsing of the esoteric forms `[a,b;c,...]` and `a[b,c;d,...]`, which can be parsed and used in macros, but aren't valid in the language otherwise. Previously they were parsed as `vcat` expressions, which is wrong since they contain commas and are therefore `vect` or `ref` expressions.