### PR TITLE
RFC: Widen less aggressively in tmerge

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2798,17 +2798,6 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
     if !(isa(typea,Type) || isa(typea,TypeVar)) || !(isa(typeb,Type) || isa(typeb,TypeVar))
         return Any
     end
-    if (typea <: Tuple) && (typeb <: Tuple)
-        if isa(typea, DataType) && isa(typeb, DataType) && length(typea.parameters) == length(typeb.parameters) && !isvatuple(typea) && !isvatuple(typeb)
-            return typejoin(typea, typeb)
-        end
-        if isa(typea, Union) || isa(typeb, Union) || (isa(typea,DataType) && length(typea.parameters)>3) ||
-            (isa(typeb,DataType) && length(typeb.parameters)>3)
-            # widen tuples faster (see #6704), but not too much, to make sure we can infer
-            # e.g. (t::Union{Tuple{Bool},Tuple{Bool,Int}})[1]
-            return Tuple
-        end
-    end
     u = Union{typea, typeb}
     if unionlen(u) > MAX_TYPEUNION_LEN
         u = typejoin(typea, typeb)

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2810,9 +2810,12 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
         end
     end
     u = Union{typea, typeb}
-    if unionlen(u) > MAX_TYPEUNION_LEN || type_too_complex(u, MAX_TYPE_DEPTH)
-        # don't let type unions get too big
-        # TODO: something smarter, like a common supertype
+    if unionlen(u) > MAX_TYPEUNION_LEN
+        u = typejoin(typea, typeb)
+    end
+    if type_too_complex(u, MAX_TYPE_DEPTH)
+        # helps convergence speed (large types that are changing value become very slow to
+        # work with very quickly)
         return Any
     end
     return u

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1291,3 +1291,6 @@ let T1 = Array{Float64}, T2 = Array{_1,2} where _1
     rt = Base.return_types(g, (Union{Ref{Array{Float64}}, Ref{Array{Float32}}},))[1]
     @test rt >: Union{Type{Array{Float64}}, Type{Array{Float32}}}
 end
+
+f_23077(x) = (Int8(0), Int16(0), Int32(0), Int64(0))[x]
+@test Base.return_types(f_23077, Tuple{Int})[1] <: Signed

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1294,3 +1294,5 @@ end
 
 f_23077(x) = (Int8(0), Int16(0), Int32(0), Int64(0))[x]
 @test Base.return_types(f_23077, Tuple{Int})[1] <: Signed
+g_23077(x,y,z) = x ? y ? z ? (1,) : (1,1.0) : (1,1) : (1,1.0,1)
+@test Base.return_types(g_23077, Tuple{Bool,Bool,Bool})[1] <: Tuple{Int,Vararg{Real}}


### PR DESCRIPTION
I admit I don't have any practical use cases where this leads to a noticeable improvement in the inference result, but if nothing else, it's at least a net reduction of code. And (at least locally) the test times, which at least in part are quite inference-heavy, don't seem to be adversely affected, so why not...

~~~Even if the changes to `tmerge` have some downsides I missed, the change to `typejoin` should hopefully by uncontroversial. The current behavior (and it looks like it has been like this more less since the dawn of time):~~~
```julia
julia> typejoin(NTuple{2,Int}, NTuple{3,Int})
Tuple{Int64,Int64,Vararg{Int64,N} where N}

julia> typejoin(NTuple{1,Int}, NTuple{3,Int})
Tuple{Int64,Vararg{Int64,N} where N}

julia> typejoin(NTuple{0,Int}, NTuple{3,Int})
Tuple
```
~~~While with this PR, the last one gives `Tuple{Vararg{Int64,N} where N}`, which is more in line with he others.~~~ EDIT: The `typejoin` change was separated out to #24485.