### PR TITLE
Fast revert "Doc author, committer, message"

### DIFF
--- a/base/libgit2/commit.jl
+++ b/base/libgit2/commit.jl
@@ -1,13 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-"""
-    message(c::GitCommit, raw::Bool=false)
-
-Return the commit message describing the changes made in commit `c`. If
-`raw` is `false`, return a slightly "cleaned up" message (which has any
-leading newlines removed). If `raw` is `true`, the message is not stripped
-of any such newlines.
-"""
 function message(c::GitCommit, raw::Bool=false)
     local msg_ptr::Cstring
     msg_ptr = raw ? ccall((:git_commit_message_raw, :libgit2), Cstring, (Ptr{Void},), c.ptr) :
@@ -18,26 +10,12 @@ function message(c::GitCommit, raw::Bool=false)
     return unsafe_string(msg_ptr)
 end
 
-"""
-    author(c::GitCommit)
-
-Return the [`Signature`](@ref) of the author of the commit `c`. The author is
-the person who made changes to the relevant file(s). See also [`committer`](@ref).
-"""
 function author(c::GitCommit)
     ptr = ccall((:git_commit_author, :libgit2), Ptr{SignatureStruct}, (Ptr{Void},), c.ptr)
     @assert ptr != C_NULL
     return Signature(ptr)
 end
 
-"""
-    committer(c::GitCommit)
-
-Return the [`Signature`](@ref) of the committer of the commit `c`. The committer is
-the person who committed the changes originally authored by the [`author`](@ref), but
-need not be the same as the `author`, for example, if the `author` emailed a patch to
-a `committer` who committed it.
-"""
 function committer(c::GitCommit)
     ptr = ccall((:git_commit_committer, :libgit2), Ptr{SignatureStruct}, (Ptr{Void},), c.ptr)
     @assert ptr != C_NULL

--- a/doc/src/devdocs/libgit2.md
+++ b/doc/src/devdocs/libgit2.md
@@ -53,7 +53,6 @@ Base.LibGit2.UserPasswordCredentials
 Base.LibGit2.add_fetch!
 Base.LibGit2.add_push!
 Base.LibGit2.addblob!
-Base.LibGit2.author
 Base.LibGit2.authors
 Base.LibGit2.branch
 Base.LibGit2.branch!
@@ -61,7 +60,6 @@ Base.LibGit2.checkout!
 Base.LibGit2.checkused!
 Base.LibGit2.clone
 Base.LibGit2.commit
-Base.LibGit2.committer
 Base.LibGit2.create_branch
 Base.LibGit2.credentials_callback
 Base.LibGit2.credentials_cb
@@ -90,7 +88,6 @@ Base.LibGit2.isorphan
 Base.LibGit2.lookup_branch
 Base.LibGit2.mirror_callback
 Base.LibGit2.mirror_cb
-Base.LibGit2.message
 Base.LibGit2.name
 Base.LibGit2.need_update
 Base.LibGit2.objtype


### PR DESCRIPTION
This reverts JuliaLang/julia#23062 because it is broken on CI. (`Signature` ref is missing from `@ref` docs). Will merge shortly to keep CI happy unless informed there's a fix already on it's way.