### PR TITLE
Use abs2(z) in mandel function for 2x speedup

### DIFF
--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -43,7 +43,7 @@ function mandel(z)
     c = z
     maxiter = 80
     for n = 1:maxiter
-        if abs(z) > 2
+        if abs2(z) > 4
             return n-1
         end
         z = z^2 + c


### PR DESCRIPTION
Avoids `hypot` call as described here: https://discourse.julialang.org/t/julia-vs-r-vs-python/4997/4
Drops `mandelperf()` time from 120 to 65 microseconds on my machine.