### PR TITLE
Add Julia port of Openlibm asin

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -270,7 +270,7 @@ sqrt_fast(x::FloatTypes) = sqrt_llvm(x)
 
 const libm = Base.libm_name
 
-for f in (:acos, :acosh, :asin, :asinh, :atan, :atanh, :cbrt, :cos,
+for f in (:acos, :acosh, :asinh, :atan, :atanh, :cbrt, :cos,
           :cosh, :exp2, :expm1, :lgamma, :log10, :log1p, :log2,
           :log, :sin, :sinh, :tan, :tanh)
     f_fast = fast_op[f]
@@ -291,6 +291,8 @@ atan2_fast(x::Float32, y::Float32) =
     ccall(("atan2f",libm), Float32, (Float32,Float32), x, y)
 atan2_fast(x::Float64, y::Float64) =
     ccall(("atan2",libm), Float64, (Float64,Float64), x, y)
+
+asin_fast(x::FloatTypes) = asin(x)
 
 # explicit implementations
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -436,7 +436,7 @@ julia> log1p(0)
 ```
 """
 log1p(x)
-for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
+for f in (:sin, :cos, :tan, :acos, :acosh, :atanh, :log, :log2, :log10,
           :lgamma, :log1p)
     @eval begin
         @inline ($f)(x::Float64) = nan_dom_err(ccall(($(string(f)), libm), Float64, (Float64,), x), x)
@@ -444,6 +444,8 @@ for f in (:sin, :cos, :tan, :asin, :acos, :acosh, :atanh, :log, :log2, :log10,
         @inline ($f)(x::Real) = ($f)(float(x))
     end
 end
+
+@inline asin(x::Real) = asin(float(x))
 
 """
     sincos(x)

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -9,9 +9,10 @@ struct DoubleFloat32
     hi::Float64
 end
 
-# *_kernel functions are only valid for |x| < pi/4 = 0.7854
-# translated from openlibm code: k_sin.c, k_cos.c, k_sinf.c, k_cosf.c
-# which are made available under the following licence:
+# sin_kernel and cos_kernel functions are only valid for |x| < pi/4 = 0.7854
+# translated from openlibm code: k_sin.c, k_cos.c, k_sinf.c, k_cosf.c.
+# asin functions are based on openlibm code: e_asin.c, e_asinf.c. The above
+# functions are made available under the following licence:
 
 ## Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
 ##
@@ -79,6 +80,111 @@ end
 # fallback methods
 sin_kernel(x::Real) = sin(x)
 cos_kernel(x::Real) = cos(x)
+
+# Inverse trigonometric functions
+
+# asin methods
+ASIN_X_MIN_THRESHOLD(::Type{Float32}) = 2.0f0^-12
+ASIN_X_MIN_THRESHOLD(::Type{Float64}) = sqrt(eps(Float64))
+
+asin_p(t::Float64) =
+    t*@horner(t,
+    1.66666666666666657415e-01,
+    -3.25565818622400915405e-01,
+    2.01212532134862925881e-01,
+    -4.00555345006794114027e-02,
+    7.91534994289814532176e-04,
+    3.47933107596021167570e-05)
+
+asin_q(t::Float64) =
+    @horner(t,
+    1.0,
+    -2.40339491173441421878e+00,
+    2.02094576023350569471e+00,
+    -6.88283971605453293030e-01,
+    7.70381505559019352791e-02)
+
+asin_p(t::Float32) =
+    t*@horner(t,
+    1.6666586697f-01,
+    -4.2743422091f-02,
+    -8.6563630030f-03)
+
+asin_q(t::Float32) = @horner(t, 1.0f0, -7.0662963390f-01)
+
+@inline function asin_kernel(t::Float64, x::Float64)
+    pio2_lo = 6.12323399573676603587e-17
+    s = sqrt_llvm(t)
+    p = asin_p(t) # numerator polynomial
+    q = asin_q(t) # denominator polynomial
+    if abs(x) >= 0.975 # |x| > 0.975
+        Rx = p/q
+        return flipsign(pi/2 - (2.0*(s + s*Rx) - pio2_lo), x)
+    else
+        s0 = reinterpret(Float64, (reinterpret(UInt64, s) >> 32) << 32)
+        c = (t - s0*s0)/(s + s0)
+        Rx = p/q
+        p = 2.0*s*Rx - (pio2_lo - 2.0*c)
+        q = pi/4 - 2.0*s0
+        return flipsign(pi/4 - (p-q), x)
+    end
+end
+@inline function asin_kernel(t::Float32, x::Float32)
+    s = sqrt_llvm(Float64(t))
+    p = asin_p(t) # numerator polynomial
+    q = asin_q(t) # denominator polynomial
+    Rx = p/q # rational approximation
+    flipsign(Float32(pi/2 - 2*(s + s*Rx)), x)
+end
+
+@noinline asin_domain_error(x) = throw(DomainError(x, "asin(x) is not defined for |x|>1."))
+function asin(x::T) where T<:Union{Float32, Float64}
+    # Method :
+    #    Since  asin(x) = x + x^3/6 + x^5*3/40 + x^7*15/336 + ...
+    #    we approximate asin(x) on [0,0.5] by
+    #        asin(x) = x + x*x^2*R(x^2)
+    #    where
+    #        R(x^2) is a rational approximation of (asin(x)-x)/x^3
+    #    and its remez error is bounded by
+    #        |(asin(x)-x)/x^3 - R(x^2)| < 2^(-58.75)
+    #
+    #    For x in [0.5,1]
+    #        asin(x) = pi/2-2*asin(sqrt((1-x)/2))
+    #    Let y = (1-x), z = y/2, s := sqrt(z), and pio2_hi+pio2_lo=pi/2;
+    #    then for x>0.98
+    #        asin(x) = pi/2 - 2*(s+s*z*R(z))
+    #            = pio2_hi - (2*(s+s*z*R(z)) - pio2_lo)
+    #    For x<=0.98, let pio4_hi = pio2_hi/2, then
+    #        f = hi part of s;
+    #        c = sqrt(z) - f = (z-f*f)/(s+f)     ...f+c=sqrt(z)
+    #    and
+    #        asin(x) = pi/2 - 2*(s+s*z*R(z))
+    #            = pio4_hi+(pio4-2s)-(2s*z*R(z)-pio2_lo)
+    #            = pio4_hi+(pio4-2f)-(2s*z*R(z)-(pio2_lo+2c))
+    #
+    # Special cases:
+    #    if |x|>1, throw DomainError
+    absx = abs(x)
+    if absx >= T(1.0) # |x|>= 1
+        if absx == T(1.0)
+            return flipsign(T(pi)/2, x)
+        end
+        asin_domain_error(x)
+    elseif absx < T(1.0)/2
+        # if |x| sufficiently small, |x| is a good approximation
+        if absx < ASIN_X_MIN_THRESHOLD(T)
+            return x
+        end
+        # else if |x|<0.5 we use a rational approximation R(x)=p(x)/q(x) such that
+        # tan(x) ≈ x+x*R(x)
+        x² = x*x
+        Rx = asin_p(x²)/asin_q(x²) # rational approximation
+        return muladd(x, Rx, x)
+    end
+    # else 1/2 <= |x| < 1
+    t = (T(1.0) - absx)/2
+    return asin_kernel(t, x)
+end
 
 # multiply in extended precision
 function mulpi_ext(x::Float64)

--- a/test/math.jl
+++ b/test/math.jl
@@ -678,3 +678,23 @@ let x = 2.0
     @test exp2(Float22716(x)) === 2^x
     @test exp10(Float22716(x)) === 10^x
 end
+
+@testset "asin #23088" begin
+    for T in (Float32, Float64)
+        @test asin(zero(T)) === zero(T)
+        @test asin(-zero(T)) === -zero(T)
+        @test asin(nextfloat(zero(T))) === nextfloat(zero(T))
+        @test asin(prevfloat(zero(T))) === prevfloat(zero(T))
+        @test asin(one(T)) === T(pi)/2
+        @test asin(-one(T)) === -T(pi)/2
+        for x in (0.45, 0.6, 0.98)
+            by = T(asin(big(x)))
+            @test abs(asin(T(x)) - by)/eps(by) <= one(T)
+            bym = T(asin(big(-x)))
+            @test abs(asin(T(-x)) - bym)/eps(bym) <= one(T)
+        end
+        @test_throws DomainError asin(-T(Inf))
+        @test_throws DomainError asin(T(Inf))
+        @test asin(T(NaN)) === T(NaN)
+    end
+end


### PR DESCRIPTION
Based on openlibm, so I should do the whole license-thing
 - [x] fix license info

`asin` is not really tested in Base besides some basic tests that it works, as it is assumed that openlibm tests itself, so I might want to add some tests here. 
- [x] add tests

```julia

using Plots
plotly()
function scaled_big_error{T}(f, x::T)
    fx = f(x)
    fbx = f(big(x))
    abs(big(fx)-fbx)/big(eps(T(fbx)))
end

histogram(linspace(-1,1, 1000000), x->scaled_big_error(asin, x))
```

Should be equivalent to openlibm. Accuracy is often within 0.5 ulp, but can go higher.
*Float64*
![asin](https://user-images.githubusercontent.com/8431156/28864450-dfcdaea4-776c-11e7-9a70-2ba4bfcaed6b.png)
*Float32*
<s>(just realized that those computations should be in Float32 as well... will fix)</s>
![asinf](https://user-images.githubusercontent.com/8431156/28921423-33388bf6-7856-11e7-941b-0c62b0a62db2.png)

Tests ran succesfully locally.

*Common `asin` function with type specific kernels*
I've merged the two methods in one main methods calling out to `@horner` based methods for the polynomials `p` and `q`. 