### PR TITLE
Support using EOF char (^D) to abort credential prompt

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1632,6 +1632,16 @@ function SymTridiagonal(dv::AbstractVector{T}, ev::AbstractVector{S}) where {T,S
     SymTridiagonal(convert(Vector{R}, dv), convert(Vector{R}, ev))
 end
 
+# PR #23092
+@eval LibGit2 begin
+    function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
+        Base.depwarn(string(
+            "`LibGit2.prompt(msg::AbstractString; default::AbstractString=\"\", password::Bool=false)` is deprecated, use ",
+            "`get(Base.prompt(msg, default=default, password=password), \"\")` instead."), :prompt)
+        Base.get(Base.prompt(msg, default=default, password=password), "")
+    end
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -71,19 +71,18 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
     end
 
     if creds.prompt_if_incorrect
-        # if username is not provided, then prompt for it
-        username = if username_ptr == Cstring(C_NULL)
+        # if username is not provided or empty, then prompt for it
+        username = username_ptr != Cstring(C_NULL) ? unsafe_string(username_ptr) : ""
+        if isempty(username)
             uname = creds.user # check if credentials were already used
             prompt_url = git_url(scheme=schema, host=host)
             if !isusedcreds
-                uname
+                username = uname
             else
                 response = prompt("Username for '$prompt_url'", default=uname)
                 isnull(response) && return user_abort()
-                unsafe_get(response)
+                username = unsafe_get(response)
             end
-        else
-            unsafe_string(username_ptr)
         end
 
         prompt_url = git_url(scheme=schema, host=host, username=username)

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -78,9 +78,9 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
             if !isusedcreds
                 uname
             else
-                res = prompt("Username for '$prompt_url'", default=uname)
-                isnull(res) && return user_abort()
-                unsafe_get(res)
+                response = prompt("Username for '$prompt_url'", default=uname)
+                isnull(response) && return user_abort()
+                unsafe_get(response)
             end
         else
             unsafe_string(username_ptr)
@@ -98,9 +98,10 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
                 if isempty(keydefpath) && isfile(defaultkeydefpath)
                     keydefpath = defaultkeydefpath
                 else
-                    res = prompt("Private key location for '$prompt_url'", default=keydefpath)
-                    isnull(res) && return user_abort()
-                    keydefpath = unsafe_get(res)
+                    response = prompt("Private key location for '$prompt_url'",
+                        default=keydefpath)
+                    isnull(response) && return user_abort()
+                    keydefpath = unsafe_get(response)
                 end
             end
             keydefpath
@@ -122,9 +123,10 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
                     keydefpath = privatekey*".pub"
                 end
                 if !isfile(keydefpath)
-                    res = prompt("Public key location for '$prompt_url'", default=keydefpath)
-                    isnull(res) && return user_abort()
-                    keydefpath = unsafe_get(res)
+                    response = prompt("Public key location for '$prompt_url'",
+                        default=keydefpath)
+                    isnull(response) && return user_abort()
+                    keydefpath = unsafe_get(response)
                 end
             end
             keydefpath
@@ -136,15 +138,15 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
             passdef = creds.pass # check if credentials were already used
             if (isempty(passdef) || isusedcreds) && is_passphrase_required(privatekey)
                 if Sys.iswindows()
-                    res = Base.winprompt(
+                    response = Base.winprompt(
                         "Your SSH Key requires a password, please enter it now:",
                         "Passphrase required", privatekey; prompt_username = false)
-                    isnull(res) && return user_abort()
-                    passdef = unsafe_get(res)[2]
+                    isnull(response) && return user_abort()
+                    passdef = unsafe_get(response)[2]
                 else
-                    res = prompt("Passphrase for $privatekey", password=true)
-                    isnull(res) && return user_abort()
-                    passdef = unsafe_get(res)
+                    response = prompt("Passphrase for $privatekey", password=true)
+                    isnull(response) && return user_abort()
+                    passdef = unsafe_get(response)
                     isempty(passdef) && return user_abort()  # Ambiguous if EOF or newline
                 end
             end
@@ -176,21 +178,21 @@ function authenticate_userpass(creds::UserPasswordCredentials, libgit2credptr::P
         prompt_url = git_url(scheme=schema, host=host)
         if Sys.iswindows()
             if isempty(username) || isempty(userpass) || isusedcreds
-                res = Base.winprompt("Please enter your credentials for '$prompt_url'", "Credentials required",
-                        isempty(username) ? urlusername : username; prompt_username = true)
-                isnull(res) && return user_abort()
-                username, userpass = unsafe_get(res)
+                response = Base.winprompt("Please enter your credentials for '$prompt_url'", "Credentials required",
+                    isempty(username) ? urlusername : username; prompt_username = true)
+                isnull(response) && return user_abort()
+                username, userpass = unsafe_get(response)
             end
         elseif isusedcreds
-            res = prompt("Username for '$prompt_url'",
+            response = prompt("Username for '$prompt_url'",
                 default=isempty(username) ? urlusername : username)
-            isnull(res) && return user_abort()
-            username = unsafe_get(res)
+            isnull(response) && return user_abort()
+            username = unsafe_get(response)
 
             prompt_url = git_url(scheme=schema, host=host, username=username)
-            res = prompt("Password for '$prompt_url'", password=true)
-            isnull(res) && return user_abort()
-            userpass = unsafe_get(res)
+            response = prompt("Password for '$prompt_url'", password=true)
+            isnull(response) && return user_abort()
+            userpass = unsafe_get(response)
             isempty(userpass) && return user_abort()  # Ambiguous if EOF or newline
         end
 

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -79,7 +79,7 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
             if !isusedcreds
                 username = uname
             else
-                response = prompt("Username for '$prompt_url'", default=uname)
+                response = Base.prompt("Username for '$prompt_url'", default=uname)
                 isnull(response) && return user_abort()
                 username = unsafe_get(response)
             end
@@ -97,7 +97,7 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
                 if isempty(keydefpath) && isfile(defaultkeydefpath)
                     keydefpath = defaultkeydefpath
                 else
-                    response = prompt("Private key location for '$prompt_url'",
+                    response = Base.prompt("Private key location for '$prompt_url'",
                         default=keydefpath)
                     isnull(response) && return user_abort()
                     keydefpath = unsafe_get(response)
@@ -122,7 +122,7 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
                     keydefpath = privatekey*".pub"
                 end
                 if !isfile(keydefpath)
-                    response = prompt("Public key location for '$prompt_url'",
+                    response = Base.prompt("Public key location for '$prompt_url'",
                         default=keydefpath)
                     isnull(response) && return user_abort()
                     keydefpath = unsafe_get(response)
@@ -143,7 +143,7 @@ function authenticate_ssh(creds::SSHCredentials, libgit2credptr::Ptr{Ptr{Void}},
                     isnull(response) && return user_abort()
                     passdef = unsafe_get(response)[2]
                 else
-                    response = prompt("Passphrase for $privatekey", password=true)
+                    response = Base.prompt("Passphrase for $privatekey", password=true)
                     isnull(response) && return user_abort()
                     passdef = unsafe_get(response)
                     isempty(passdef) && return user_abort()  # Ambiguous if EOF or newline
@@ -183,13 +183,13 @@ function authenticate_userpass(creds::UserPasswordCredentials, libgit2credptr::P
                 username, userpass = unsafe_get(response)
             end
         elseif isusedcreds
-            response = prompt("Username for '$prompt_url'",
+            response = Base.prompt("Username for '$prompt_url'",
                 default=isempty(username) ? urlusername : username)
             isnull(response) && return user_abort()
             username = unsafe_get(response)
 
             prompt_url = git_url(scheme=schema, host=host, username=username)
-            response = prompt("Password for '$prompt_url'", password=true)
+            response = Base.prompt("Password for '$prompt_url'", password=true)
             isnull(response) && return user_abort()
             userpass = unsafe_get(response)
             isempty(userpass) && return user_abort()  # Ambiguous if EOF or newline

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -41,12 +41,16 @@ function prompt(msg::AbstractString; default::AbstractString="", password::Bool=
     end
     msg = !isempty(default) ? msg*" [$default]:" : msg*":"
     uinput = if password
-        Base.getpass(msg)
+        Base.getpass(msg)  # Automatically chomps. We cannot tell EOF from '\n'.
     else
         print(msg)
-        readline()
+        readline(chomp=false)
     end
-    isempty(uinput) ? default : uinput
+    if !password
+        isempty(uinput) && return Nullable{String}()  # Encountered EOF
+        uinput = chomp(uinput)
+    end
+    Nullable{String}(isempty(uinput) ? default : uinput)
 end
 
 function features()

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -35,24 +35,6 @@ isset(val::Integer, flag::Integer) = (val & flag == flag)
 reset(val::Integer, flag::Integer) = (val &= ~flag)
 toggle(val::Integer, flag::Integer) = (val |= flag)
 
-function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)
-    if Sys.iswindows() && password
-        error("Command line prompt not supported for password entry on windows. Use winprompt instead")
-    end
-    msg = !isempty(default) ? msg*" [$default]:" : msg*":"
-    uinput = if password
-        Base.getpass(msg)  # Automatically chomps. We cannot tell EOF from '\n'.
-    else
-        print(msg)
-        readline(chomp=false)
-    end
-    if !password
-        isempty(uinput) && return Nullable{String}()  # Encountered EOF
-        uinput = chomp(uinput)
-    end
-    Nullable{String}(isempty(uinput) ? default : uinput)
-end
-
 function features()
     feat = ccall((:git_libgit2_features, :libgit2), Cint, ())
     res = Consts.GIT_FEATURE[]


### PR DESCRIPTION
Part of #20725.

Supports using EOF to abort the credential prompt. This is important as newlines can be used to select the default value.

Note that for password prompts it is currently not possible to tell the difference between an EOF and a newline. The PR behaviour is to assume an EOF was given.

Additional changes include:
- Deprecate `LibGit2.prompt(::AbstractString) -> String` with `Base.prompt(::AbstractString) -> Nullable{String}`
- Lots of tests cases relating to using newline / EOF in the credential prompts (possible now that we have a reliable way of aborting)
- Introduces `LibGit2.user_abort` function which is only meant for internal use.
- An empty SSH username no longer aborts (replaced by EOF abort)
- An empty SSH username_ptr string now triggers a prompt (previously would abort)
- Test function `credential_loop` can now distinguish between "" and C_NULL.
