### PR TITLE
fix array printing when small number of rows

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1582,7 +1582,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 if i == rowsA[halfheight]
                     print(io, i == first(rowsA) ? pre : presp)
                     print_matrix_vdots(io, vdots,A,sep,vmod,1)
-                    print(io, i == last(rowsA) ? post : postsp*'\n')
+                    print(io, i == last(rowsA) ? post : postsp * '\n')
                 end
             end
         else # neither rows nor cols fit, so use all 3 kinds of dots
@@ -1603,7 +1603,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                     print_matrix_vdots(io, vdots,Lalign,sep,vmod,1)
                     print(io, ddots)
                     print_matrix_vdots(io, vdots,Ralign,sep,vmod,r)
-                    print(io, i == last(rowsA) ? post : postsp*'\n')
+                    print(io, i == last(rowsA) ? post : postsp * '\n')
                 end
             end
         end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1578,11 +1578,11 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 print(io, i == first(rowsA) ? pre : presp)
                 print_matrix_row(io, X,A,i,colsA,sep)
                 print(io, i == last(rowsA) ? post : postsp)
-                if i != rowsA[end]; println(io); end
+                if i != rowsA[end] || i == rowsA[halfheight]; println(io); end
                 if i == rowsA[halfheight]
                     print(io, i == first(rowsA) ? pre : presp)
                     print_matrix_vdots(io, vdots,A,sep,vmod,1)
-                    println(io, i == last(rowsA) ? post : postsp)
+                    print(io, i == last(rowsA) ? post : postsp*'\n')
                 end
             end
         else # neither rows nor cols fit, so use all 3 kinds of dots
@@ -1597,15 +1597,21 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
                 print(io, (i - first(rowsA)) % hmod == 0 ? hdots : repeat(" ", length(hdots)))
                 print_matrix_row(io, X,Ralign,i,n-length(Ralign)+colsA,sep)
                 print(io, i == last(rowsA) ? post : postsp)
-                if i != rowsA[end]; println(io); end
+                if i != rowsA[end] || i == rowsA[halfheight]; println(io); end
                 if i == rowsA[halfheight]
                     print(io, i == first(rowsA) ? pre : presp)
                     print_matrix_vdots(io, vdots,Lalign,sep,vmod,1)
                     print(io, ddots)
                     print_matrix_vdots(io, vdots,Ralign,sep,vmod,r)
-                    println(io, i == last(rowsA) ? post : postsp)
+                    print(io, i == last(rowsA) ? post : postsp*'\n')
                 end
             end
+        end
+        if isempty(rowsA)
+            print(io, pre)
+            print(io, vdots)
+            length(colsA) > 1 && print(io, "    ", ddots)
+            print(io, post)
         end
     end
 end
@@ -1753,7 +1759,14 @@ function showarray(io::IO, X::AbstractArray, repr::Bool = true; header = true)
     end
     (!repr && header) && print(io, summary(X))
     if !isempty(X)
-        (!repr && header) && println(io, ":")
+        if !repr && header
+            print(io, ":")
+            if get(io, :limit, false) && displaysize(io)[1]-4 <= 0
+                return print(io, " …")
+            else
+                println(io)
+            end
+        end
         if ndims(X) == 0
             if isassigned(X)
                 return show(io, X[])

--- a/test/show.jl
+++ b/test/show.jl
@@ -882,10 +882,13 @@ end
 end
 
 @testset "Array printing with limited rows" begin
-    buf = IOBuffer()
-    arrstr(A, rows) = (Base.showarray(IOContext(buf, displaysize=(rows, 80), limit=true),
-                                      A, false, header=true);
-                       String(take!(buf)))
+    arrstr = let buf = IOBuffer()
+        function (A, rows)
+            Base.showarray(IOContext(buf, displaysize=(rows, 80), limit=true),
+                           A, false, header=true)
+            String(take!(buf))
+        end
+    end
     A = Int64[1]
     @test arrstr(A, 4) == "1-element Array{Int64,1}: …"
     @test arrstr(A, 5) == "1-element Array{Int64,1}:\n 1"
@@ -897,8 +900,8 @@ end
 
     @test arrstr(zeros(4, 3), 4)  == "4×3 Array{Float64,2}: …"
     @test arrstr(zeros(4, 30), 4) == "4×30 Array{Float64,2}: …"
-    @test arrstr(zeros(4, 3), 5)  =="4×3 Array{Float64,2}:\n ⋮      ⋱  "
-    @test arrstr(zeros(4, 30), 5) =="4×30 Array{Float64,2}:\n ⋮      ⋱  "
+    @test arrstr(zeros(4, 3), 5)  == "4×3 Array{Float64,2}:\n ⋮      ⋱  "
+    @test arrstr(zeros(4, 30), 5) == "4×30 Array{Float64,2}:\n ⋮      ⋱  "
     @test arrstr(zeros(4, 3), 6)  == "4×3 Array{Float64,2}:\n 0.0  0.0  0.0\n ⋮            "
     @test arrstr(zeros(4, 30), 6) ==
               string("4×30 Array{Float64,2}:\n",

--- a/test/show.jl
+++ b/test/show.jl
@@ -880,3 +880,28 @@ end
     @test replstr(zeros(Complex{Int}, 1, 2, 1)) ==
         "1×2×1 Array{Complex{$Int},3}:\n[:, :, 1] =\n 0+0im  0+0im"
 end
+
+@testset "Array printing with limited rows" begin
+    buf = IOBuffer()
+    arrstr(A, rows) = (Base.showarray(IOContext(buf, displaysize=(rows, 80), limit=true),
+                                      A, false, header=true);
+                       String(take!(buf)))
+    A = Int64[1]
+    @test arrstr(A, 4) == "1-element Array{Int64,1}: …"
+    @test arrstr(A, 5) == "1-element Array{Int64,1}:\n 1"
+    push!(A, 2)
+    @test arrstr(A, 5) == "2-element Array{Int64,1}:\n ⋮"
+    @test arrstr(A, 6) == "2-element Array{Int64,1}:\n 1\n 2"
+    push!(A, 3)
+    @test arrstr(A, 6) == "3-element Array{Int64,1}:\n 1\n ⋮"
+
+    @test arrstr(zeros(4, 3), 4)  == "4×3 Array{Float64,2}: …"
+    @test arrstr(zeros(4, 30), 4) == "4×30 Array{Float64,2}: …"
+    @test arrstr(zeros(4, 3), 5)  =="4×3 Array{Float64,2}:\n ⋮      ⋱  "
+    @test arrstr(zeros(4, 30), 5) =="4×30 Array{Float64,2}:\n ⋮      ⋱  "
+    @test arrstr(zeros(4, 3), 6)  == "4×3 Array{Float64,2}:\n 0.0  0.0  0.0\n ⋮            "
+    @test arrstr(zeros(4, 30), 6) ==
+              string("4×30 Array{Float64,2}:\n",
+                     " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
+                     " ⋮                        ⋮              ⋱            ⋮                      ")
+end


### PR DESCRIPTION
This is quite similar to #22917 (printing `Dict`). It's rare to have so few rows available on screen, but still worth it to get the printing right (although I expected it takes me less time to fix...)