### PR TITLE
remove additional rule that parameters must match for dispatch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,15 @@ Language changes
     For example, `f() = (global sin = "gluttony"; nothing)` will now resolve which module
     contains `sin` eagerly, rather than delaying that decision until `f` is run. ([#22984]).
 
+  * Dispatch rules have been simplified:
+    matching methods is now determined exclusively by subtyping;
+    the rule that method type parameters must be also be captured has been removed.
+    Instead, attempting to access the uncontrained parameters will throw an `UndefVarError`.
+    Linting in package tests is recommended to confirm that the set of methods
+    which might throw `UndefVarError` when accessing the static parameters
+    (`need_to_handle_undef_sparam = Set{Any}(m.sig for m in Test.detect_unbound_args(Base, recursive=true))`)
+    is equal (`==`) to some known set (`expected = Set()`). ([#TBD])
+
 
 Breaking changes
 ----------------

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -122,15 +122,6 @@ end
 
 ## promotion mechanism ##
 
-promote_type()  = Bottom
-promote_type(T) = T
-promote_type(T, S, U, V...) = (@_inline_meta; promote_type(T, promote_type(S, U, V...)))
-
-promote_type(::Type{Bottom}, ::Type{Bottom}) = Bottom
-promote_type(::Type{T}, ::Type{T}) where {T} = T
-promote_type(::Type{T}, ::Type{Bottom}) where {T} = T
-promote_type(::Type{Bottom}, ::Type{T}) where {T} = T
-
 """
     promote_type(type1, type2)
 
@@ -151,6 +142,17 @@ julia> promote_type(Float32, BigInt)
 BigFloat
 ```
 """
+function promote_type end
+
+promote_type()  = Bottom
+promote_type(T) = T
+promote_type(T, S, U, V...) = (@_inline_meta; promote_type(T, promote_type(S, U, V...)))
+
+promote_type(::Type{Bottom}, ::Type{Bottom}) = Bottom
+promote_type(::Type{T}, ::Type{T}) where {T} = T
+promote_type(::Type{T}, ::Type{Bottom}) where {T} = T
+promote_type(::Type{Bottom}, ::Type{T}) where {T} = T
+
 function promote_type(::Type{T}, ::Type{S}) where {T,S}
     @_inline_meta
     # Try promote_rule in both orders. Typically only one is defined,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -737,9 +737,9 @@ function _dump_function(@nospecialize(f), @nospecialize(t), native::Bool, wrappe
     t = to_tuple_type(t)
     ft = isa(f, Type) ? Type{f} : typeof(f)
     tt = Tuple{ft, t.parameters...}
-    (ti, env) = ccall(:jl_match_method, Any, (Any, Any), tt, meth.sig)::SimpleVector
-    meth = func_for_method_checked(meth, tt)
-    linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt), meth, tt, env, world)
+    (ti, env) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), tt, meth.sig)::SimpleVector
+    meth = func_for_method_checked(meth, ti)
+    linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt), meth, ti, env, world)
     # get the code for it
     return _dump_function_linfo(linfo, world, native, wrapper, strip_ir_metadata, dump_module, syntax, optimize, params)
 end

--- a/src/ast.c
+++ b/src/ast.c
@@ -897,7 +897,8 @@ jl_value_t *jl_parse_eval_all(const char *fname,
             jl_get_ptls_states()->world_age = jl_world_counter;
             form = scm_to_julia(fl_ctx, expansion, 0);
             jl_sym_t *head = NULL;
-            if (jl_is_expr(form)) head = ((jl_expr_t*)form)->head;
+            if (jl_is_expr(form))
+                head = ((jl_expr_t*)form)->head;
             JL_SIGATOMIC_END();
             jl_get_ptls_states()->world_age = jl_world_counter;
             if (head == jl_incomplete_sym)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -459,12 +459,14 @@ int jl_tuple_isa(jl_value_t **child, size_t cl, jl_datatype_t *pdt);
 
 int jl_has_intersect_type_not_kind(jl_value_t *t);
 int jl_subtype_invariant(jl_value_t *a, jl_value_t *b, int ta);
+int jl_has_concrete_subtype(jl_value_t *typ);
 jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np);
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p);
 JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
 void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr);
 jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty);
 jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
+int jl_subtype_matching(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
 // specificity comparison assuming !(a <: b) and !(b <: a)
 JL_DLLEXPORT int jl_type_morespecific_no_subtype(jl_value_t *a, jl_value_t *b);
 jl_value_t *jl_instantiate_type_with(jl_value_t *t, jl_value_t **env, size_t n);
@@ -481,7 +483,6 @@ void jl_assign_bits(void *dest, jl_value_t *bits);
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n);
 jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module);
 jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, int iskw);
-jl_function_t *jl_module_call_func(jl_module_t *m);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 
 jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded);
@@ -498,8 +499,6 @@ jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
 int jl_is_toplevel_only_expr(jl_value_t *e);
 jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr, jl_module_t *inmodule);
 
-jl_method_instance_t *jl_method_lookup_by_type(jl_methtable_t *mt, jl_tupletype_t *types,
-                                               int cache, int inexact, int allow_exec, size_t world);
 jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt, jl_value_t **args, size_t nargs, int cache, size_t world);
 jl_value_t *jl_gf_invoke(jl_tupletype_t *types, jl_value_t **args, size_t nargs);
 jl_method_instance_t *jl_lookup_generic(jl_value_t **args, uint32_t nargs, uint32_t callsite, size_t world);
@@ -909,9 +908,9 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
                                       size_t min_world, size_t max_world,
                                       jl_value_t **overwritten);
 
-jl_typemap_entry_t *jl_typemap_assoc_by_type(union jl_typemap_t ml_or_cache, jl_tupletype_t *types, jl_svec_t **penv,
-        int8_t inexact, int8_t subtype, int8_t offs, size_t world);
-static jl_typemap_entry_t *const INEXACT_ENTRY = (jl_typemap_entry_t*)(uintptr_t)-1;
+jl_typemap_entry_t *jl_typemap_assoc_by_type(
+        union jl_typemap_t ml_or_cache, jl_tupletype_t *types, jl_svec_t **penv,
+        int8_t subtype, int8_t offs, size_t world);
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs, size_t world);
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t **args, size_t n, size_t world);
 STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(union jl_typemap_t ml_or_cache, jl_value_t **args, size_t n, int8_t offs, size_t world)

--- a/test/core.jl
+++ b/test/core.jl
@@ -124,21 +124,6 @@ end
 
 @test promote_type(Bool,Bottom) === Bool
 
-# ntuples
-nttest1(x::NTuple{n,Int}) where {n} = n
-@test nttest1(()) == 0
-@test nttest1((1,2)) == 2
-@test NTuple <: Tuple
-@test (NTuple{T,Int32} where T) <: Tuple{Vararg{Int32}}
-@test !((NTuple{T,Int32} where T) <: Tuple{Int32,Vararg{Int32}})
-@test Tuple{Vararg{Int32}} <: (NTuple{T,Int32} where T)
-@test Tuple{Int32,Vararg{Int32}} <: (NTuple{T,Int32} where T)
-
-# #17198
-@test_throws MethodError convert(Tuple{Int}, (1.0, 2.0, 3.0))
-# #21238
-@test_throws MethodError convert(Tuple{Int,Int,Int}, (1, 2))
-
 # type declarations
 
 abstract type Sup_{A,B} end
@@ -1466,8 +1451,8 @@ end
 import Base: promote_rule
 promote_rule(A::Type{SIQ{T,T2}},B::Type{SIQ{S,S2}}) where {T,T2,S,S2} = SIQ{promote_type(T,S)}
 @test_throws ErrorException promote_type(SIQ{Int},SIQ{Float64})
-f4731(x::T...) where {T} = 0
-f4731(x...) = ""
+f4731(x::T...) where {T} = ""
+f4731(x...) = 0
 g4731() = f4731()
 @test f4731() == ""
 @test g4731() == ""
@@ -3464,9 +3449,13 @@ end
 @test_throws MethodError @eval @m8846(a,b,c)
 
 # a simple case of parametric dispatch with unions
-let foo(x::Union{T,Void},y::Union{T,Void}) where {T} = 1
+let foo(x::Union{T, Void}, y::Union{T, Void}) where {T} = 1
     @test foo(1, nothing) === 1
-    @test_throws MethodError foo(nothing, nothing)  # can't determine T
+    @test foo(nothing, nothing) === 1
+end
+let foo(x::Union{T, Void}, y::Union{T, Void}) where {T} = T
+    @test foo(1, nothing) === Int
+    @test_throws UndefVarError(:T) foo(nothing, nothing)
 end
 
 module TestMacroGlobalFunction
@@ -4556,8 +4545,15 @@ gc_enable(true)
 
 # issue #18710
 bad_tvars() where {T} = 1
-@test_throws ErrorException @which(bad_tvars())
-@test_throws MethodError bad_tvars()
+@test isa(@which(bad_tvars()), Method)
+@test bad_tvars() === 1
+bad_tvars2() where {T} = T
+@test_throws UndefVarError(:T) bad_tvars2()
+missing_tvar(::T...) where {T} = T
+@test_throws UndefVarError(:T) missing_tvar()
+@test missing_tvar(1) === Int
+@test missing_tvar(1, 2, 3) === Int
+@test_throws MethodError missing_tvar(1, 2, "3")
 
 # issue #19059 - test for lowering of `let` with assignment not adding Box in simple cases
 contains_Box(e::GlobalRef) = (e.name === :Box)
@@ -5098,7 +5094,7 @@ f_isdefined_cl_6() = (local x; () -> @isdefined x)
 f_isdefined_tv(::T) where {T} = @isdefined T
 @test f_isdefined_tv(1)
 f_isdefined_va(::T...) where {T} = @isdefined T
-@test_throws MethodError f_isdefined_va()
+@test !f_isdefined_va()
 @test f_isdefined_va(1, 2, 3)
 
 mutable struct MyStruct22929

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -348,7 +348,8 @@ for (f, t) in Any[(definitely_not_in_sysimg, Tuple{}),
                   (Base.:+, Tuple{Int, Int})]
     meth = which(f, t)
     tt = Tuple{typeof(f), t.parameters...}
-    env = (ccall(:jl_match_method, Any, (Any, Any), tt, meth.sig))[2]
+    (ti, env) = ccall(:jl_type_intersection_with_env, Any, (Any, Any), tt, meth.sig)::SimpleVector
+    @test ti === tt # intersection should be a subtype
     world = typemax(UInt)
     linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt), meth, tt, env, world)
     params = Base.CodegenParams()

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -14,7 +14,7 @@ notequal_type(@nospecialize(x),@nospecialize(y)) = !isequal_type(x, y)
 
 _type_intersect(@nospecialize(x), @nospecialize(y)) = ccall(:jl_intersect_types, Any, (Any, Any), x, y)
 
-intersection_env(@nospecialize(x), @nospecialize(y)) = ccall(:jl_env_from_type_intersection, Any, (Any,Any), x, y)
+intersection_env(@nospecialize(x), @nospecialize(y)) = ccall(:jl_type_intersection_with_env, Any, (Any,Any), x, y)
 
 # level 1: no varags, union, UnionAll
 function test_1()


### PR DESCRIPTION
matching a method signature is a simple subtyping test,
with no additional rule to ensure that all parameters have a value

and adds a Test for possibly unbound parameters,
which allows detecting methods definitions that this change affects