### PR TITLE
Fix 22577. Add string macros to REPLCompletion.

### DIFF
--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -10,13 +10,18 @@ function completes_global(x, name)
     return startswith(x, name) && !('#' in x)
 end
 
+function appendmacro!(syms, macros, needle, endchar)
+    append!(syms, s[2:end-sizeof(needle)]*endchar for s in filter(x -> endswith(x, needle), macros))
+end
+
 function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, all::Bool=false, imported::Bool=false)
     ssyms = names(mod, all, imported)
     filter!(ffunc, ssyms)
     syms = String[string(s) for s in ssyms]
-    str_macros = [s[2:end-4]*"\"" for s in filter(x->startswith(x, "@" * name) && endswith(x, "_str"), syms)]
+    macros =  filter(x -> startswith(x, "@" * name), syms)
+    appendmacro!(syms, macros, "_str", "\"")
+    appendmacro!(syms, macros, "_cmd", "`")
     filter!(x->completes_global(x, name), syms)
-    append!(syms, str_macros)
     return syms
 end
 

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -14,7 +14,10 @@ function filtered_mod_names(ffunc::Function, mod::Module, name::AbstractString, 
     ssyms = names(mod, all, imported)
     filter!(ffunc, ssyms)
     syms = String[string(s) for s in ssyms]
+    str_macros = [s[2:end-4]*"\"" for s in filter(x->startswith(x, "@" * name) && endswith(x, "_str"), syms)]
     filter!(x->completes_global(x, name), syms)
+    append!(syms, str_macros)
+    return syms
 end
 
 # REPL Symbol Completions

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -64,13 +64,17 @@ ex = quote
                      contains=>4, `ls`=>5, 66=>7, 67=>8, ("q",3)=>11,
                      "α"=>12, :α=>13)
     test_customdict = CustomDict(test_dict)
+
+    macro colorant_str(s)
+    end
+
+    macro testcmd_cmd(s)
+    end
+
     end
     test_repl_comp_dict = CompletionFoo.test_dict
     test_repl_comp_customdict = CompletionFoo.test_customdict
     test_dict_ℂ = Dict(1=>2)
-
-    macro colorant_str(s)
-    end
 end
 ex.head = :toplevel
 eval(Main, ex)
@@ -762,3 +766,6 @@ c, r, res = test_complete("ra")
 
 c, r, res = test_complete("CompletionFoo.colora")
 @test "colorant\"" in c
+
+c, r, res = test_complete("CompletionFoo.testc")
+@test "testcmd`" in c

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -68,6 +68,9 @@ ex = quote
     test_repl_comp_dict = CompletionFoo.test_dict
     test_repl_comp_customdict = CompletionFoo.test_customdict
     test_dict_ℂ = Dict(1=>2)
+
+    macro colorant_str(s)
+    end
 end
 ex.head = :toplevel
 eval(Main, ex)
@@ -752,3 +755,10 @@ test_dict_completion("test_repl_comp_customdict")
 
 # Issue #23004: this should not throw:
 @test REPLCompletions.dict_identifier_key("test_dict_ℂ[\\", :other) isa Tuple
+
+# Test for #22577
+c, r, res = test_complete("ra")
+@test "raw\"" in c
+
+c, r, res = test_complete("CompletionFoo.colora")
+@test "colorant\"" in c

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -66,9 +66,9 @@ ex = quote
     test_customdict = CustomDict(test_dict)
 
     macro teststr_str(s) end
-    macro tϵsτstr_str(s) end
+    macro tϵsτstρ_str(s) end
     macro testcmd_cmd(s) end
-    macro tϵsτcmd_cmd(s) end
+    macro tϵsτcmδ_cmd(s) end
 
     end
     test_repl_comp_dict = CompletionFoo.test_dict
@@ -765,9 +765,9 @@ test_dict_completion("test_repl_comp_customdict")
     c, r, res = test_complete("CompletionFoo.tests")
     @test "teststr\"" in c
     c, r, res = test_complete("CompletionFoo.tϵsτs")
-    @test "tϵsτstr\"" in c
+    @test "tϵsτstρ\"" in c
     c, r, res = test_complete("CompletionFoo.testc")
     @test "testcmd`" in c
     c, r, res = test_complete("CompletionFoo.tϵsτc")
-    @test "tϵsτcmd`" in c
+    @test "tϵsτcmδ`" in c
 end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -760,12 +760,11 @@ test_dict_completion("test_repl_comp_customdict")
 # Issue #23004: this should not throw:
 @test REPLCompletions.dict_identifier_key("test_dict_ℂ[\\", :other) isa Tuple
 
-# Test for #22577
-c, r, res = test_complete("ra")
-@test "raw\"" in c
-
-c, r, res = test_complete("CompletionFoo.colora")
-@test "colorant\"" in c
-
-c, r, res = test_complete("CompletionFoo.testc")
-@test "testcmd`" in c
+@testset "completion of string/cmd macros (#22577)" begin
+    c, r, res = test_complete("ra")
+    @test "raw\"" in c
+    c, r, res = test_complete("CompletionFoo.colora")
+    @test "colorant\"" in c
+    c, r, res = test_complete("CompletionFoo.testc")
+    @test "testcmd`" in c
+end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -65,11 +65,10 @@ ex = quote
                      "α"=>12, :α=>13)
     test_customdict = CustomDict(test_dict)
 
-    macro colorant_str(s)
-    end
-
-    macro testcmd_cmd(s)
-    end
+    macro teststr_str(s) end
+    macro tϵsτstr_str(s) end
+    macro testcmd_cmd(s) end
+    macro tϵsτcmd_cmd(s) end
 
     end
     test_repl_comp_dict = CompletionFoo.test_dict
@@ -763,8 +762,12 @@ test_dict_completion("test_repl_comp_customdict")
 @testset "completion of string/cmd macros (#22577)" begin
     c, r, res = test_complete("ra")
     @test "raw\"" in c
-    c, r, res = test_complete("CompletionFoo.colora")
-    @test "colorant\"" in c
+    c, r, res = test_complete("CompletionFoo.tests")
+    @test "teststr\"" in c
+    c, r, res = test_complete("CompletionFoo.tϵsτs")
+    @test "tϵsτstr\"" in c
     c, r, res = test_complete("CompletionFoo.testc")
     @test "testcmd`" in c
+    c, r, res = test_complete("CompletionFoo.tϵsτc")
+    @test "tϵsτcmd`" in c
 end


### PR DESCRIPTION
String macros can now be completed as:
```
julia> macro colorant_str(s) end
@colorant_str (macro with 1 method)

julia> color<tab>
julia> colorant"
```