### PR TITLE
preserve `elseif` syntax in parser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,9 @@ Language changes
   * `{ }` expressions now use `braces` and `bracescat` as expression heads instead
     of `cell1d` and `cell2d`, and parse similarly to `vect` and `vcat` ([#8470]).
 
+  * Nested `if` expressions that arise from the keyword `elseif` now use `elseif`
+    as their expression head instead of `if` ([#21774]).
+
 Breaking changes
 ----------------
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -557,7 +557,11 @@ function show_block(io::IO, head, args::Vector, body, indent::Int)
     print(io, head)
     if !isempty(args)
         print(io, ' ')
-        show_list(io, args, ", ", indent)
+        if head === :elseif
+            show_list(io, args, " ", indent)
+        else
+            show_list(io, args, ", ", indent)
+        end
     end
 
     ind = head === :module || head === :baremodule ? indent : indent + indent_width
@@ -880,9 +884,18 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, "function ", args[1], " end")
 
     # block with argument
-    elseif head in (:for,:while,:function,:if) && nargs==2
+    elseif head in (:for,:while,:function,:if,:elseif) && nargs==2
         show_block(io, head, args[1], args[2], indent)
         print(io, "end")
+
+    elseif (head === :if || head === :elseif) && nargs == 3
+        show_block(io, head, args[1], args[2], indent)
+        if isa(args[3],Expr) && args[3].head == :elseif
+            show_unquoted(io, args[3], indent, prec)
+        else
+            show_block(io, "else", args[3], indent)
+            print(io, "end")
+        end
 
     elseif head === :module && nargs==3 && isa(args[1],Bool)
         show_block(io, args[1] ? :module : :baremodule, args[2], args[3], indent)
@@ -944,11 +957,6 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
 
     elseif head === :line && 1 <= nargs <= 2
         show_linenumber(io, args...)
-
-    elseif head === :if && nargs == 3     # if/else
-        show_block(io, "if",   args[1], args[2], indent)
-        show_block(io, "else", args[3], indent)
-        print(io, "end")
 
     elseif head === :try && 3 <= nargs <= 4
         show_block(io, "try", args[1], indent)

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -466,8 +466,8 @@ if a
     b
 elseif c
     d
-else e
-    f
+else
+    e
 end
 ```
 
@@ -475,9 +475,8 @@ parses as:
 
 ```
 (if a (block (line 2) b)
-    (block (line 3) (if c (block (line 4) d)
-                             (block (line 5) e
-                                    (line 6) f))))
+    (elseif (block (line 3) c) (block (line 4) d)
+            (block (line 5 e))))
 ```
 
 A `while` loop parses as `(while condition body)`.

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1656,15 +1656,6 @@
                             (if ,g ,g
                                 ,(loop (cdr tail)))))))))))
 
-(define (expand-forms e)
-  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null meta)))
-      e
-      (let ((ex (get expand-table (car e) #f)))
-        (if ex
-            (ex e)
-            (cons (car e)
-                  (map expand-forms (cdr e)))))))
-
 (define (expand-for while lhs X body)
   ;; (for (= lhs X) body)
   (let ((coll  (make-ssavalue))
@@ -1870,6 +1861,15 @@
                 (extract (cdr params) (cons T newparams) (cons (list (car p) T (cadr p)) whereparams)))
               (extract (cdr params) (cons p newparams) whereparams)))))
   (extract (cddr e) '() '()))
+
+(define (expand-forms e)
+  (if (or (atom? e) (memq (car e) '(quote inert top core globalref outerref line module toplevel ssavalue null meta)))
+      e
+      (let ((ex (get expand-table (car e) #f)))
+        (if ex
+            (ex e)
+            (cons (car e)
+                  (map expand-forms (cdr e)))))))
 
 ;; table mapping expression head to a function expanding that form
 (define expand-table
@@ -3493,7 +3493,7 @@ f(x) = yt(x)
              (if value
                  (compile (cadr e) break-labels value tail)
                  #f))
-            ((if)
+            ((if elseif)
              (let ((test `(gotoifnot ,(compile-cond (cadr e) break-labels) _))
                    (end-jump `(goto _))
                    (val (if (and value (not tail)) (new-mutable-var) #f)))

--- a/test/show.jl
+++ b/test/show.jl
@@ -236,6 +236,45 @@ end"""
     return
 end"""
 
+@test_repr """if a
+# line meta
+b
+end
+"""
+
+@test_repr """if a
+# line meta
+b
+elseif c
+# line meta
+d
+end
+"""
+
+@test_repr """if a
+# line meta
+b
+elseif c
+# line meta
+d
+else
+# line meta
+e
+end
+"""
+
+@test_repr """if a
+# line meta
+b
+elseif c
+# line meta
+d
+elseif e
+# line meta
+f
+end
+"""
+
 # issue #7188
 @test sprint(show, :foo) == ":foo"
 @test sprint(show, Symbol("foo bar")) == "Symbol(\"foo bar\")"


### PR DESCRIPTION
Part of #21774. I think this change is particularly useful, since

- macros like `@static` should be able to handle `elseif` chains; `elseif`s are arguably part of the same outermost expression and so should all be evaluated in the same stage
- much nicer representation from `show`
- it's very minimally breaking, since it only changes the interior of `if` blocks, and `:elseif` expressions are semantically identical to `if` expressions