### PR TITLE
travis-ci: separate cache creation into a separate build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,97 @@
 language: cpp
 sudo: false
 dist: trusty
-matrix:
-  include:
-    - os: linux
+
+branches:
+  only:
+    - master
+    - /^release-.*/
+    - /^v\d+\.\d+\.\d+$/
+
+notifications:
+    email: false
+    irc:
+        channels:
+            - "chat.freenode.net#julia-notifications"
+        on_success: change
+        on_failure: always
+    webhooks:
+        urls:
+          - http://status.julialang.org/put/travis
+
+
+matrix-aliases:
+    - &julia-linux-install
+        - gcc --version
+        - BAR="bar -i 30"
+        - BUILDOPTS="-j3 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1"
+        - echo "override ARCH=$ARCH" >> Make.user
+        - TESTSTORUN="all"
+
+    - &julia-macos-install
+        - brew update
+        - brew install -v jq pv
+        - BAR="pv -i 30"
+        - brew tap staticfloat/julia
+        - brew uninstall --force --ignore-dependencies $(brew deps --HEAD julia)
+        - brew install -v --only-dependencies --HEAD julia
+        - brew install -v staticfloat/juliadeps/libgfortran llvm39-julia
+        - BUILDOPTS="-j3 USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm39-julia)/bin/llvm-config LLVM_SIZE=$(brew --prefix llvm39-julia)/bin/llvm-size"
+        - BUILDOPTS="$BUILDOPTS VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include FORCE_ASSERTIONS=1"
+        - BUILDOPTS="$BUILDOPTS LIBBLAS=-lopenblas LIBBLASNAME=libopenblas LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas"
+        - for lib in LLVM SUITESPARSE ARPACK BLAS LAPACK GMP MPFR PCRE LIBUNWIND; do
+              BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1";
+          done
+        - export LDFLAGS="-L$(brew --prefix openblas-julia)/lib -L$(brew --prefix suite-sparse-julia)/lib"
+        - export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib:/lib:/usr/lib:$(brew --prefix openblas-julia)/lib:$(brew --prefix suite-sparse-julia)/lib:$(brew --prefix arpack-julia)/lib"
+        - export JULIA_MACOS_SPAWN="DYLD_FALLBACK_LIBRARY_PATH=\"$DYLD_FALLBACK_LIBRARY_PATH\" \$1"
+        - export BUILDOPTS="$BUILDOPTS spawn=\$(JULIA_MACOS_SPAWN)"
+        - make $BUILDOPTS -C contrib -f repackage_system_suitesparse4.make
+        - TESTSTORUN="all"
+
+    - &dep-stage
+      stage: pre-populate dependency cache
+      script: true
+
+    - &test-stage
+      stage: test
+      script:
+          # compile / install Julia
+          - make $BUILDOPTS -C base version_git.jl.phony
+          # build sequentially, since travis seems to have a hard time generating the debug and release sysimg simultaneously
+          - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia debug | moreutils/ts -s "%.s"
+          - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia release | moreutils/ts -s "%.s"
+          - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
+          - make $BUILDOPTS NO_GIT=1 build-stats
+          - du -sk /tmp/julia/*
+          - if [ `uname` = "Darwin" ]; then
+              for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do
+                  install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;
+              done;
+            fi
+          - cd .. && mv julia julia2
+          # run tests
+          - /tmp/julia/bin/julia --precompiled=no -e 'true' &&
+              /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
+          - /tmp/julia/bin/julia -e 'versioninfo()'
+          - pushd /tmp/julia/share/julia/test
+          - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 &&
+              /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
+              /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg
+          - popd
+          # test that the embedding code works on our installation
+          - mkdir /tmp/embedding-test &&
+              make check -C /tmp/julia/share/doc/julia/examples/embedding \
+                   JULIA="DYLD_FALLBACK_LIBRARY_PATH='$DYLD_FALLBACK_LIBRARY_PATH' /tmp/julia/bin/julia" \
+                   BIN=/tmp/embedding-test \
+                         "$(cd julia2 && make print-CC)"
+          # restore initial state
+          - mv julia2 julia
+      after_success:
+          - cd julia && make -C doc deploy
+
+    - &julia-linux-i386
+      os: linux
       env: ARCH="i686"
       compiler: "g++ -m32"
       addons:
@@ -18,7 +106,10 @@ matrix:
             - libssl-dev:i386
             - gfortran
             - gfortran-multilib
-    - os: linux
+      install: *julia-linux-install
+
+    - &julia-linux-x86_64
+      os: linux
       env: ARCH="x86_64"
       compiler: "g++ -m64"
       addons:
@@ -28,68 +119,38 @@ matrix:
             - bar
             - time
             - gfortran
-    - os: osx
+      install: *julia-linux-install
+
+    - &julia-macos
+      os: osx
       env: ARCH="x86_64"
       osx_image: xcode8
-cache:
-  directories:
-    - $TRAVIS_BUILD_DIR/deps/srccache
-    - $TRAVIS_BUILD_DIR/deps/scratch
-    - $TRAVIS_BUILD_DIR/deps/usr-staging
-branches:
-  only:
-    - master
-    - /^release-.*/
-    - /^v\d+\.\d+\.\d+$/
-notifications:
-    email: false
-    irc:
-        channels:
-            - "chat.freenode.net#julia-notifications"
-        on_success: change
-        on_failure: always
-    webhooks:
-        urls:
-          - http://status.julialang.org/put/travis
-          - http://julia.mit.edu:8000/travis-hook
+      install: *julia-macos-install
+
+jobs:
+    include:
+        - <<: *dep-stage
+          <<: *julia-linux-i386
+        - <<: *dep-stage
+          <<: *julia-linux-x86_64
+        - <<: *test-stage
+          <<: *julia-linux-i386
+        - <<: *test-stage
+          <<: *julia-linux-x86_64
+        - <<: *test-stage
+          <<: *julia-macos
+
 before_install:
     - make check-whitespace
-    - if [ `uname` = "Linux" ]; then
-        contrib/travis_fastfail.sh || exit 1;
-        gcc --version;
-        BAR="bar -i 30";
-        BUILDOPTS="-j3 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1";
-        echo "override ARCH=$ARCH" >> Make.user;
-        TESTSTORUN="all";
-      elif [ `uname` = "Darwin" ]; then
-        brew update;
-        brew install -v jq pv;
-        BAR="pv -i 30";
-        contrib/travis_fastfail.sh || exit 1;
-        brew tap staticfloat/julia;
-        brew rm --force $(brew deps --HEAD julia);
-        brew install -v --only-dependencies --HEAD julia;
-        brew install -v staticfloat/juliadeps/libgfortran llvm39-julia;
-        BUILDOPTS="-j3 USECLANG=1 LLVM_CONFIG=$(brew --prefix llvm39-julia)/bin/llvm-config LLVM_SIZE=$(brew --prefix llvm39-julia)/bin/llvm-size";
-        BUILDOPTS="$BUILDOPTS VERBOSE=1 USE_BLAS64=0 SUITESPARSE_INC=-I$(brew --prefix suite-sparse-julia)/include FORCE_ASSERTIONS=1";
-        BUILDOPTS="$BUILDOPTS LIBBLAS=-lopenblas LIBBLASNAME=libopenblas LIBLAPACK=-lopenblas LIBLAPACKNAME=libopenblas";
-        for lib in LLVM SUITESPARSE ARPACK BLAS LAPACK GMP MPFR PCRE LIBUNWIND; do
-            BUILDOPTS="$BUILDOPTS USE_SYSTEM_$lib=1";
-        done;
-        export LDFLAGS="-L$(brew --prefix openblas-julia)/lib -L$(brew --prefix suite-sparse-julia)/lib";
-        export DYLD_FALLBACK_LIBRARY_PATH="/usr/local/lib:/lib:/usr/lib:$(brew --prefix openblas-julia)/lib:$(brew --prefix suite-sparse-julia)/lib:$(brew --prefix arpack-julia)/lib";
-        export JULIA_MACOS_SPAWN="DYLD_FALLBACK_LIBRARY_PATH=\"$DYLD_FALLBACK_LIBRARY_PATH\" \$1";
-        export BUILDOPTS="$BUILDOPTS spawn=\$(JULIA_MACOS_SPAWN)";
-        make $BUILDOPTS -C contrib -f repackage_system_suitesparse4.make;
-        TESTSTORUN="all --skip linalg/triangular subarray"; fi # TODO: re enable these if possible without timing out
+    - contrib/travis_fastfail.sh || exit 1;
+    - contrib/download_cmake.sh
     - git clone -q git://git.kitenet.net/moreutils
-script:
+    - make -C moreutils mispipe
+
+before_script:
     - echo BUILDOPTS=$BUILDOPTS
     - export BUILDOPTS
     # compile / install dependencies
-    - contrib/download_cmake.sh
-    - make -C moreutils mispipe
-    - make $BUILDOPTS -C base version_git.jl.phony
     # capture the log, but only print it if `make deps` fails
     # try to show the end of the log first, because this log might be very long (> 4MB)
     # and thus be truncated by travis
@@ -104,35 +165,13 @@ script:
           cat deps.log;
           echo "-- end of deps build log -----------------------------------------------";
           false; }
-    # compile / install Julia
-    - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
-    - make $BUILDOPTS NO_GIT=1 build-stats
-    - du -sk /tmp/julia/*
-    - if [ `uname` = "Darwin" ]; then
-        for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do
-            install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;
-        done;
-      fi
-    - cd .. && mv julia julia2
-    # run tests
-    - /tmp/julia/bin/julia --precompiled=no -e 'true' &&
-        /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
-    - /tmp/julia/bin/julia -e 'versioninfo()'
-    - pushd /tmp/julia/share/julia/test
-    - export JULIA_CPU_CORES=2 && export JULIA_TEST_MAXRSS_MB=600 &&
-        /tmp/julia/bin/julia --check-bounds=yes runtests.jl $TESTSTORUN &&
-        /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg
-    - popd
-    # test that the embedding code works on our installation
-    - mkdir /tmp/embedding-test &&
-        make check -C /tmp/julia/share/doc/julia/examples/embedding \
-             JULIA="DYLD_FALLBACK_LIBRARY_PATH='$DYLD_FALLBACK_LIBRARY_PATH' /tmp/julia/bin/julia" \
-             BIN=/tmp/embedding-test \
-             "$(cd julia2 && make print-CC)"
-    # restore initial state and prepare for travis caching
-    - mv julia2 julia &&
-        rm -f julia/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
-# uncomment the following if failures are suspected to be due to the out-of-memory killer
-#    - dmesg
-after_success:
-    - cd julia && make -C doc deploy
+
+# prepare for travis caching
+before_cache:
+    - rm -f $TRAVIS_BUILD_DIR/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
+
+cache:
+  directories:
+    - $TRAVIS_BUILD_DIR/deps/srccache
+    - $TRAVIS_BUILD_DIR/deps/scratch
+    - $TRAVIS_BUILD_DIR/deps/usr-staging

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,9 @@ julia_flisp.boot.inc.phony: julia-deps
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src julia_flisp.boot.inc.phony
 
 # Build the HTML docs (skipped if already exists, notably in tarballs)
-$(BUILDROOT)/doc/_build/html/en/index.html: $(shell find $(BUILDROOT)/base $(BUILDROOT)/doc \( -path $(BUILDROOT)/doc/_build -o -path $(BUILDROOT)/doc/deps -o -name *_constants.jl -o -name *_h.jl \) -prune -o -type f -print)
+$(BUILDROOT)/doc/_build/html/en/index.html: \
+   $(shell find $(BUILDROOT)/base $(BUILDROOT)/doc \( -path $(BUILDROOT)/doc/_build -o -path $(BUILDROOT)/doc/deps -o -name *_constants.jl -o -name *_h.jl \) \
+                 -prune -o -type f -print)
 	@$(MAKE) docs
 
 # doc needs to live under $(build_docdir), not under $(build_datarootdir)/julia/
@@ -329,8 +331,8 @@ define stringreplace
 	$(build_depsbindir)/stringreplace $$(strings -t x - $1 | grep '$2' | awk '{print $$1;}') '$3' 255 "$(call cygpath_w,$1)"
 endef
 
-install: $(build_depsbindir)/stringreplace $(BUILDROOT)/doc/_build/html/en/index.html
-	@$(MAKE) $(QUIET_MAKE) all
+install: all $(build_depsbindir)/stringreplace
+	@$(MAKE) $(QUIET_MAKE) $(BUILDROOT)/doc/_build/html/en/index.html
 	@for subdir in $(bindir) $(datarootdir)/julia/site/$(VERSDIR) $(docdir) $(man1dir) $(includedir)/julia $(libdir) $(private_libdir) $(sysconfdir); do \
 		mkdir -p $(DESTDIR)$$subdir; \
 	done


### PR DESCRIPTION
Redesigns our travis file such that the cache-building step of CI is run separately.