### PR TITLE
deprecate `union()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -262,6 +262,9 @@ Deprecated or removed
     full path if you need access to executables or libraries in the `JULIA_HOME` directory, e.g.
     `joinpath(JULIA_HOME, "7z.exe")` for `7z.exe` ([#21540]).
 
+  * Calling `union` with no arguments is deprecated; construct an empty set with an appropriate
+    element type using `Set{T}()` instead ([#23144]).
+
 Julia v0.6.0 Release Notes
 ==========================
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1334,6 +1334,8 @@ end
 
 @deprecate issubtype (<:)
 
+@deprecate union() Set()
+
 # 12807
 start(::Union{Process, ProcessChain}) = 1
 done(::Union{Process, ProcessChain}, i::Int) = (i == 3)

--- a/base/set.jl
+++ b/base/set.jl
@@ -65,7 +65,6 @@ done(s::Set, state) = done(s.dict, state)
 # NOTE: manually optimized to take advantage of Dict representation
 next(s::Set, i)     = (s.dict.keys[i], skip_deleted(s.dict, i+1))
 
-union() = Set()
 union(s::Set) = copy(s)
 function union(s::Set, sets::Set...)
     u = Set{join_eltype(s, sets...)}()

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -138,7 +138,6 @@ for data_in in ((7,8,4,5),
 end
 
 # union
-@test isequal(union(),Set())
 @test isequal(union(Set([1])),Set([1]))
 s = ∪(Set([1,2]), Set([3,4]))
 @test isequal(s, Set([1,2,3,4]))


### PR DESCRIPTION
This method dates from 2011, and we've generally moved away from having 0-arg methods of functions like this. It returns a `Set{Any}`, which would be better to discourage.