### PR TITLE
parametrize Tridiagonal on the wrapped vector type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -121,10 +121,11 @@ This section lists changes that do not have deprecation warnings.
     longer present. Use `first(R)` and `last(R)` to obtain
     start/stop. ([#20974])
 
-  * The `Diagonal`, `Bidiagonal` and `SymTridiagonal` type definitions have changed from
-    `Diagonal{T}`, `Bidiagonal{T}` and `SymTridiagonal{T}` to `Diagonal{T,V<:AbstractVector{T}}`,
-    `Bidiagonal{T,V<:AbstractVector{T}}` and `SymTridiagonal{T,V<:AbstractVector{T}}`
-    respectively ([#22718], [#22925], [#23035]).
+  * The `Diagonal`, `Bidiagonal`, `Tridiagonal` and `SymTridiagonal` type definitions have
+    changed from `Diagonal{T}`, `Bidiagonal{T}`, `Tridiagonal{T}` and `SymTridiagonal{T}`
+    to `Diagonal{T,V<:AbstractVector{T}}`, `Bidiagonal{T,V<:AbstractVector{T}}`,
+    `Tridiagonal{T,V<:AbstractVector{T}}` and `SymTridiagonal{T,V<:AbstractVector{T}}`
+    respectively ([#22718], [#22925], [#23035], [#23154]).
 
   * `isapprox(x,y)` now tests `norm(x-y) <= max(atol, rtol*max(norm(x), norm(y)))`
     rather than `norm(x-y) <= atol + ...`, and `rtol` defaults to zero
@@ -196,9 +197,10 @@ Library improvements
 
   * `Char`s can now be concatenated with `String`s and/or other `Char`s using `*` ([#22532]).
 
-  * `Diagonal`, `Bidiagonal` and `SymTridiagonal` are now parameterized on the type of the
-    wrapped vectors, allowing `Diagonal`, `Bidiagonal` and `SymTridiagonal` matrices with
-    arbitrary `AbstractVector`s ([#22718], [#22925], [#23035]).
+  * `Diagonal`, `Bidiagonal`, `Tridiagonal` and `SymTridiagonal` are now parameterized on
+    the type of the wrapped vectors, allowing `Diagonal`, `Bidiagonal`, `Tridiagonal` and
+    `SymTridiagonal` matrices with arbitrary `AbstractVector`s
+    ([#22718], [#22925], [#23035], [#23154]).
 
   * Mutating versions of `randperm` and `randcycle` have been added:
     `randperm!` and `randcycle!` ([#22723]).
@@ -261,8 +263,9 @@ Deprecated or removed
   * `Bidiagonal` constructors now use a `Symbol` (`:U` or `:L`) for the upper/lower
     argument, instead of a `Bool` or a `Char` ([#22703]).
 
-  * `Bidiagonal` and `SymTridiagonal` constructors that automatically converted the input
-    vectors to the same type are deprecated in favor of explicit conversion ([#22925], [#23035]).
+  * `Bidiagonal`, `Tridiagonal` and `SymTridiagonal` constructors that automatically
+    converted the input vectors to the same type are deprecated in favor of explicit
+    conversion ([#22925], [#23035], [#23154].
 
   * Calling `nfields` on a type to find out how many fields its instances have is deprecated.
     Use `fieldcount` instead. Use `nfields` only to get the number of fields in a specific object ([#22350]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1652,6 +1652,14 @@ function SymTridiagonal(dv::AbstractVector{T}, ev::AbstractVector{S}) where {T,S
     SymTridiagonal(convert(Vector{R}, dv), convert(Vector{R}, ev))
 end
 
+# PR #23154
+# also uncomment constructor tests in test/linalg/tridiag.jl
+function Tridiagonal(dl::AbstractVector{Tl}, d::AbstractVector{Td}, du::AbstractVector{Tu}) where {Tl,Td,Tu}
+    depwarn(string("Tridiagonal(dl::AbstractVector{Tl}, d::AbstractVector{Td}, du::AbstractVector{Tu}) ",
+        "where {Tl, Td, Tu} is deprecated; convert all vectors to the same type instead."), :Tridiagonal)
+    Tridiagonal(map(v->convert(Vector{promote_type(Tl,Td,Tu)}, v), (dl, d, du))...)
+end
+
 # PR #23092
 @eval LibGit2 begin
     function prompt(msg::AbstractString; default::AbstractString="", password::Bool=false)

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -153,8 +153,10 @@ promote_rule(::Type{Matrix{T}}, ::Type{Bidiagonal{S}}) where {T,S} = Matrix{prom
 #Converting from Bidiagonal to Tridiagonal
 Tridiagonal(M::Bidiagonal{T}) where {T} = convert(Tridiagonal{T}, M)
 function convert(::Type{Tridiagonal{T}}, A::Bidiagonal) where T
-    z = zeros(T, size(A)[1]-1)
-    A.uplo == 'U' ? Tridiagonal(z, convert(Vector{T},A.dv), convert(Vector{T},A.ev)) : Tridiagonal(convert(Vector{T},A.ev), convert(Vector{T},A.dv), z)
+    dv = convert(AbstractVector{T}, A.dv)
+    ev = convert(AbstractVector{T}, A.ev)
+    z = fill!(similar(ev), zero(T))
+    A.uplo == 'U' ? Tridiagonal(z, dv, ev) : Tridiagonal(ev, dv, z)
 end
 promote_rule(::Type{Tridiagonal{T}}, ::Type{Bidiagonal{S}}) where {T,S} = Tridiagonal{promote_type(T,S)}
 

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -116,7 +116,7 @@ julia> A = [1 2 3; 2 1 2; 3 2 1]
 julia> F = bkfact(Symmetric(A, :L))
 Base.LinAlg.BunchKaufman{Float64,Array{Float64,2}}
 D factor:
-3×3 Tridiagonal{Float64}:
+3×3 Tridiagonal{Float64,Array{Float64,1}}:
  1.0  3.0    ⋅
  3.0  1.0   0.0
   ⋅   0.0  -1.0

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -41,10 +41,17 @@ B = randn(n,2)
             @test ST == Matrix(ST)
             @test ST.dv === x
             @test ST.ev === y
+            TT = (Tridiagonal(y, x, y))::Tridiagonal{elty, typeof(x)}
+            @test TT == Matrix(TT)
+            @test TT.dl === y
+            @test TT.d  === x
+            @test TT.du === y
         end
         # enable when deprecations for 0.7 are dropped
         # @test_throws MethodError SymTridiagonal(dv, GenericArray(ev))
         # @test_throws MethodError SymTridiagonal(GenericArray(dv), ev)
+        # @test_throws MethodError Tridiagonal(GenericArray(ev), dv, GenericArray(ev))
+        # @test_throws MethodError Tridiagonal(ev, GenericArray(dv), ev)
     end
 
     @testset "size and Array" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -598,7 +598,7 @@ A = reshape(1:16,4,4)
 @test replstr(Bidiagonal(A,:U)) == "4×4 Bidiagonal{$(Int),Array{$(Int),1}}:\n 1  5   ⋅   ⋅\n ⋅  6  10   ⋅\n ⋅  ⋅  11  15\n ⋅  ⋅   ⋅  16"
 @test replstr(Bidiagonal(A,:L)) == "4×4 Bidiagonal{$(Int),Array{$(Int),1}}:\n 1  ⋅   ⋅   ⋅\n 2  6   ⋅   ⋅\n ⋅  7  11   ⋅\n ⋅  ⋅  12  16"
 @test replstr(SymTridiagonal(A+A')) == "4×4 SymTridiagonal{$(Int),Array{$(Int),1}}:\n 2   7   ⋅   ⋅\n 7  12  17   ⋅\n ⋅  17  22  27\n ⋅   ⋅  27  32"
-@test replstr(Tridiagonal(diag(A,-1),diag(A),diag(A,+1))) == "4×4 Tridiagonal{$Int}:\n 1  5   ⋅   ⋅\n 2  6  10   ⋅\n ⋅  7  11  15\n ⋅  ⋅  12  16"
+@test replstr(Tridiagonal(diag(A,-1),diag(A),diag(A,+1))) == "4×4 Tridiagonal{$(Int),Array{$(Int),1}}:\n 1  5   ⋅   ⋅\n 2  6  10   ⋅\n ⋅  7  11  15\n ⋅  ⋅  12  16"
 @test replstr(UpperTriangular(copy(A))) == "4×4 UpperTriangular{$Int,Array{$Int,2}}:\n 1  5   9  13\n ⋅  6  10  14\n ⋅  ⋅  11  15\n ⋅  ⋅   ⋅  16"
 @test replstr(LowerTriangular(copy(A))) == "4×4 LowerTriangular{$Int,Array{$Int,2}}:\n 1  ⋅   ⋅   ⋅\n 2  6   ⋅   ⋅\n 3  7  11   ⋅\n 4  8  12  16"
 


### PR DESCRIPTION
Last PR in this series. This is definitely not as straight forward as #22718, #22925 and #23035 so please review carefully. It took some thinking to do this in a nice way, hence I saved it for last. I am quite pleased with the current implementation.

The internal field `.du2` was only used in `lufact!`, and for all other operations it should have been considered hidden. Since we never initialize that field otherwise, other operations on `Tridiagonal` should allocate less after this change:
@nanosoldier `runbenchmarks("linalg", vs = ":master")`

The other good thing with not initializing that field always, is that we don't need to use similar, to construct it, since that is not applicable for all `AbstractVector`s (e.g. `Tridiagonal(1:2, 1:3, 1:2)` would not work, how to construct the `.du2` field?). Now it is only needed in `lufact!`.