### PR TITLE
min, max, minmax use isless for comparison (fix #23094)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1697,7 +1697,7 @@ end
 
 Returns the maximum element of the collection `itr` and its index. If there are multiple
 maximal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`. Other than the treatment of NaN, the result is in line with `max`.
+all elements are `NaN`. Other than the treatment of `NaN`, the result is in line with `max`.
 
 The collection must not be empty.
 
@@ -1737,7 +1737,7 @@ end
 
 Returns the minimum element of the collection `itr` and its index. If there are multiple
 minimal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`. Other than the treatment of NaN, the result is in line with `min`.
+all elements are `NaN`. Other than the treatment of `NaN`, the result is in line with `min`.
 
 The collection must not be empty.
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1697,7 +1697,7 @@ end
 
 Returns the maximum element of the collection `itr` and its index. If there are multiple
 maximal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`. The result is in line with `max`.
+all elements are `NaN`. Except of that, the result is in line with `max`.
 
 The collection must not be empty.
 
@@ -1723,7 +1723,7 @@ function findmax(a)
     while !done(a, s)
         ai, s = next(a, s)
         i += 1
-        ai != ai && continue
+        ai != ai && continue # assume x != x => x is a NaN
         if m != m || isless(m, ai)
             m = ai
             mi = i
@@ -1737,7 +1737,7 @@ end
 
 Returns the minimum element of the collection `itr` and its index. If there are multiple
 minimal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`. The result is in line with `min`.
+all elements are `NaN`. Except of that, the result is in line with `min`.
 
 The collection must not be empty.
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1697,7 +1697,7 @@ end
 
 Returns the maximum element of the collection `itr` and its index. If there are multiple
 maximal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`.
+all elements are `NaN`. The result is in line with `max`.
 
 The collection must not be empty.
 
@@ -1723,7 +1723,8 @@ function findmax(a)
     while !done(a, s)
         ai, s = next(a, s)
         i += 1
-        if ai > m || m!=m
+        ai != ai && continue
+        if m != m || isless(m, ai)
             m = ai
             mi = i
         end
@@ -1736,7 +1737,7 @@ end
 
 Returns the minimum element of the collection `itr` and its index. If there are multiple
 minimal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`.
+all elements are `NaN`. The result is in line with `min`.
 
 The collection must not be empty.
 
@@ -1762,7 +1763,8 @@ function findmin(a)
     while !done(a, s)
         ai, s = next(a, s)
         i += 1
-        if ai < m || m!=m
+        ai != ai && continue
+        if m != m || isless(ai, m)
             m = ai
             mi = i
         end

--- a/base/array.jl
+++ b/base/array.jl
@@ -1697,7 +1697,7 @@ end
 
 Returns the maximum element of the collection `itr` and its index. If there are multiple
 maximal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`. Except of that, the result is in line with `max`.
+all elements are `NaN`. Other than the treatment of NaN, the result is in line with `max`.
 
 The collection must not be empty.
 
@@ -1737,7 +1737,7 @@ end
 
 Returns the minimum element of the collection `itr` and its index. If there are multiple
 minimal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`. Except of that, the result is in line with `min`.
+all elements are `NaN`. Other than the treatment of NaN, the result is in line with `min`.
 
 The collection must not be empty.
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1697,7 +1697,7 @@ end
 
 Returns the maximum element of the collection `itr` and its index. If there are multiple
 maximal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`.
+all elements are `NaN`. The result is in line with `max`.
 
 The collection must not be empty.
 
@@ -1723,7 +1723,8 @@ function findmax(a)
     while !done(a, s)
         ai, s = next(a, s)
         i += 1
-        if ai > m || m!=m
+        ai != ai && continue     
+        if m != m || isless(m, ai)
             m = ai
             mi = i
         end
@@ -1736,7 +1737,7 @@ end
 
 Returns the minimum element of the collection `itr` and its index. If there are multiple
 minimal elements, then the first one will be returned. `NaN` values are ignored, unless
-all elements are `NaN`.
+all elements are `NaN`. The result is in line with `min`.
 
 The collection must not be empty.
 
@@ -1762,7 +1763,8 @@ function findmin(a)
     while !done(a, s)
         ai, s = next(a, s)
         i += 1
-        if ai < m || m!=m
+        ai != ai && continue     
+        if m != m || isless(ai, m)
             m = ai
             mi = i
         end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -359,7 +359,7 @@ julia> max(2, 5, 1)
 5
 ```
 """
-max(x, y) = ifelse(y < x, x, y)
+max(x, y) = ifelse(isless(y, x), x, y)
 
 """
     min(x, y, ...)
@@ -373,7 +373,7 @@ julia> min(2, 5, 1)
 1
 ```
 """
-min(x,y) = ifelse(y < x, y, x)
+min(x,y) = ifelse(isless(y, x), y, x)
 
 """
     minmax(x, y)
@@ -386,7 +386,7 @@ julia> minmax('c','b')
 ('b', 'c')
 ```
 """
-minmax(x,y) = y < x ? (y, x) : (x, y)
+minmax(x,y) = isless(y, x) ? (y, x) : (x, y)
 
 scalarmax(x,y) = max(x,y)
 scalarmax(x::AbstractArray, y::AbstractArray) = throw(ArgumentError("ordering is not well-defined for arrays"))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -495,6 +495,20 @@ end
     @test indmax(5:-2:1) == 1
     @test findmin(5:-2:1) == (1,3)
     @test indmin(5:-2:1) == 3
+
+    #23094
+    @test findmax(Set(["abc"])) == ("abc", 1)
+    @test findmin(["abc", "a"]) == ("a", 2)
+    @test_throws MethodError findmax([Set([1]), Set([2])])
+    @test findmin([0.0, -0.0]) == (-0.0, 2)
+    @test findmax([0.0, -0.0]) == (0.0, 1)
+    @test findmin([-0.0, 0.0]) == (-0.0, 1)
+    @test findmax([-0.0, 0.0]) == (0.0, 2)
+    @test isnan(findmin([NaN, NaN, 0.0/0.0])[1])
+    @test findmin([NaN, NaN, 0.0/0.0])[2] == 1
+    @test isnan(findmax([NaN, NaN, 0.0/0.0])[1])
+    @test findmax([NaN, NaN, 0.0/0.0])[2] == 1
+    
 end
 
 @testset "permutedims" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -497,13 +497,13 @@ end
     @test indmin(5:-2:1) == 3
 
     #23094
-    @test findmax(Set(["abc"])) == ("abc", 1)
-    @test findmin(["abc", "a"]) == ("a", 2)
+    @test findmax(Set(["abc"])) === ("abc", 1)
+    @test findmin(["abc", "a"]) === ("a", 2)
     @test_throws MethodError findmax([Set([1]), Set([2])])
-    @test findmin([0.0, -0.0]) == (-0.0, 2)
-    @test findmax([0.0, -0.0]) == (0.0, 1)
-    @test findmin([-0.0, 0.0]) == (-0.0, 1)
-    @test findmax([-0.0, 0.0]) == (0.0, 2)
+    @test findmin([0.0, -0.0]) === (-0.0, 2)
+    @test findmax([0.0, -0.0]) === (0.0, 1)
+    @test findmin([-0.0, 0.0]) === (-0.0, 1)
+    @test findmax([-0.0, 0.0]) === (0.0, 2)
     @test isnan(findmin([NaN, NaN, 0.0/0.0])[1])
     @test findmin([NaN, NaN, 0.0/0.0])[2] == 1
     @test isnan(findmax([NaN, NaN, 0.0/0.0])[1])

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -495,6 +495,20 @@ end
     @test indmax(5:-2:1) == 1
     @test findmin(5:-2:1) == (1,3)
     @test indmin(5:-2:1) == 3
+
+    #23094
+    @test findmax(Set(["abc"])) == ("abc", 1)
+    @test findmin(["abc", "a"]) == ("a", 2)
+    @test_throws MethodError findmax([Set([1]), Set([2])])
+    @test findmin([0.0, -0.0]) == (-0.0, 2)
+    @test findmax([0.0, -0.0]) == (0.0, 1)
+    @test findmin([-0.0, 0.0]) == (-0.0, 1)
+    @test findmax([-0.0, 0.0]) == (0.0, 2)
+    @test isnan(findmin([NaN, NaN, 0.0/0.0])[1])
+    @test findmin([NaN, NaN, 0.0/0.0])[2] == 1
+    @test isnan(findmax([NaN, NaN, 0.0/0.0])[1])
+    @test findmax([NaN, NaN, 0.0/0.0])[2] == 1
+
 end
 
 @testset "permutedims" begin

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -58,24 +58,28 @@ p = 1=>:foo
 @test_throws ArgumentError Base.scalarmax('a',['c','d'])
 @test_throws ArgumentError Base.scalarmax(['a','b'],'c')
 
-s1 = Set([1])
-s2 = Set([2])
-@test_throws MethodError min(s1, s2)
-@test_throws MethodError max(s1, s2)
-@test_throws MethodError minmax(s1, s2)
+@test_throws MethodError min(Set([1]), Set([2]))
+@test_throws MethodError max(Set([1]), Set([2]))
+@test_throws MethodError minmax(Set([1]), Set([2]))
 
-struct TO
-  x
+# Test if isless (not <) is used by min, max, minmax
+# and commutativity.
+struct TO23094
+    x::Int
 end
-Base.isless(a::TO, b::TO) = isless(a.x, b.x)
-Base.isequal(a::TO, b::TO) = isequal(a.x, b.x)
+Base.isless(a::TO23094, b::TO23094) = isless(a.x, b.x)
+Base.isequal(a::TO23094, b::TO23094) = isequal(a.x, b.x)
+import Base.<
+<(a::TO23094, b::TO23094) = error("< should not be called")
 
-@test min(TO(1), TO(2)) == TO(1)
-@test min(TO(2), TO(1)) == TO(1)
-@test max(TO(1), TO(2)) == TO(2)
-@test max(TO(2), TO(1)) == TO(2)
-@test minmax(TO(1), TO(2)) == (TO(1), TO(2))
-@test minmax(TO(2), TO(1)) == (TO(1), TO(2))
+@test isequal(min(TO23094(1), TO23094(2)), TO23094(1))
+@test isequal(min(TO23094(2), TO23094(1)), TO23094(1))
+@test isequal(max(TO23094(1), TO23094(2)), TO23094(2))
+@test isequal(max(TO23094(2), TO23094(1)), TO23094(2))
+@test isequal(minmax(TO23094(1), TO23094(2))[1], TO23094(1))
+@test isequal(minmax(TO23094(1), TO23094(2))[2], TO23094(2))
+@test isequal(minmax(TO23094(2), TO23094(1))[1], TO23094(1))
+@test isequal(minmax(TO23094(2), TO23094(1))[2], TO23094(2))
 
 @test lexless('a','b')
 

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -58,6 +58,25 @@ p = 1=>:foo
 @test_throws ArgumentError Base.scalarmax('a',['c','d'])
 @test_throws ArgumentError Base.scalarmax(['a','b'],'c')
 
+s1 = Set([1])
+s2 = Set([2])
+@test_throws MethodError min(s1, s2)
+@test_throws MethodError max(s1, s2)
+@test_throws MethodError minmax(s1, s2)
+
+struct TO
+  x
+end
+Base.isless(a::TO, b::TO) = isless(a.x, b.x)
+Base.isequal(a::TO, b::TO) = isequal(a.x, b.x)
+
+@test min(TO(1), TO(2)) == TO(1)
+@test min(TO(2), TO(1)) == TO(1)
+@test max(TO(1), TO(2)) == TO(2)
+@test max(TO(2), TO(1)) == TO(2)
+@test minmax(TO(1), TO(2)) == (TO(1), TO(2))
+@test minmax(TO(2), TO(1)) == (TO(1), TO(2))
+
 @test lexless('a','b')
 
 @test 1 .!= 2


### PR DESCRIPTION
Changed only min, max, minmax in operators.jl. maybe have to look at findmin, findmax in order to make the results of those compatible with min, max, minmax. That is currently not the case for floating point numbers. 

fix #23094