### PR TITLE
Remove outdated remark from zip's docs.

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -202,8 +202,6 @@ end
 For a set of iterable objects, returns an iterable of tuples, where the `i`th tuple contains
 the `i`th component of each input iterable.
 
-Note that [`zip`](@ref) is its own inverse: `collect(zip(zip(a...)...)) == collect(a)`.
-
 # Examples
 ```jldoctest
 julia> a = 1:5


### PR DESCRIPTION
More recently the equivalence is ``collect(zip(zip(a...)...)) == map(Tuple,a)``. Anyway, the remark is likely to open more questions then it answers for those who call ``?zip``.
