### PR TITLE
avoid early deletion of current_task gc-root

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -103,7 +103,6 @@ typedef struct _jl_tls_states_t {
     void *stackbase;
     char *stack_lo;
     char *stack_hi;
-    jl_jmp_buf *volatile jmp_target;
     jl_jmp_buf base_ctx; // base context of stack
     jl_jmp_buf *safe_restore;
     int16_t tid;


### PR DESCRIPTION
since save_stack can allocate, need to delay clearing the gc-root
for the new task until between the allocation and the stack copy

(bug introduced by the fix for #6597)