### PR TITLE
generated functions, next generation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,10 @@ New language features
  * The macro call syntax `@macroname[args]` is now available and is parsed
    as `@macroname([args])` ([#23519]).
 
+  * The construct `if @generated ...; else ...; end` can be used to provide both
+    `@generated` and normal implementations of part of a function. Surrounding code
+    will be common to both versions ([#23168]).
+
 Language changes
 ----------------
 

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -642,7 +642,7 @@ finddoc(λ, def) = false
 
 # Predicates and helpers for `docm` expression selection:
 
-const FUNC_HEADS    = [:function, :stagedfunction, :macro, :(=)]
+const FUNC_HEADS    = [:function, :macro, :(=)]
 const BINDING_HEADS = [:typealias, :const, :global, :(=)]  # deprecation: remove `typealias` post-0.6
 # For the special `:@mac` / `:(Base.@mac)` syntax for documenting a macro after definition.
 isquotedmacrocall(x) =

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -577,12 +577,18 @@ _valuefields(::Type{<:AbstractTriangular}) = [:data]
 
 const SpecialArrays = Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal,AbstractTriangular}
 
-@generated function fillslots!(A::SpecialArrays, x)
-    ex = :(xT = convert(eltype(A), x))
-    for field in _valuefields(A)
-        ex = :($ex; fill!(A.$field, xT))
+function fillslots!(A::SpecialArrays, x)
+    xT = convert(eltype(A), x)
+    if @generated
+        quote
+            $([ :(fill!(A.$field, xT)) for field in _valuefields(A) ]...)
+        end
+    else
+        for field in _valuefields(A)
+            fill!(getfield(A, field), xT)
+        end
     end
-    :($ex;return A)
+    return A
 end
 
 # for historical reasons:

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -1011,17 +1011,16 @@ syntax tree.
 A very special macro is `@generated`, which allows you to define so-called *generated functions*.
 These have the capability to generate specialized code depending on the types of their arguments
 with more flexibility and/or less code than what can be achieved with multiple dispatch. While
-macros work with expressions at parsing-time and cannot access the types of their inputs, a generated
+macros work with expressions at parse time and cannot access the types of their inputs, a generated
 function gets expanded at a time when the types of the arguments are known, but the function is
 not yet compiled.
 
 Instead of performing some calculation or action, a generated function declaration returns a quoted
 expression which then forms the body for the method corresponding to the types of the arguments.
-When called, the body expression is first evaluated and compiled, then the returned expression
-is compiled and run. To make this efficient, the result is often cached. And to make this inferable,
-only a limited subset of the language is usable. Thus, generated functions provide a flexible
-framework to move work from run-time to compile-time, at the expense of greater restrictions on
-the allowable constructs.
+When a generated function is called, the expression it returns is compiled and then run.
+To make this efficient, the result is usually cached. And to make this inferable, only a limited
+subset of the language is usable. Thus, generated functions provide a flexible way to move work from
+run time to compile time, at the expense of greater restrictions on allowed constructs.
 
 When defining generated functions, there are four main differences to ordinary functions:
 
@@ -1037,7 +1036,7 @@ When defining generated functions, there are four main differences to ordinary f
    This means they can only read global constants, and cannot have any side effects.
    In other words, they must be completely pure.
    Due to an implementation limitation, this also means that they currently cannot define a closure
-   or untyped generator.
+   or generator.
 
 It's easiest to illustrate this with an example. We can declare a generated function `foo` as
 
@@ -1052,9 +1051,8 @@ foo (generic function with 1 method)
 Note that the body returns a quoted expression, namely `:(x * x)`, rather than just the value
 of `x * x`.
 
-From the caller's perspective, they are very similar to regular functions; in fact, you don't
-have to know if you're calling a regular or generated function - the syntax and result of the
-call is just the same. Let's see how `foo` behaves:
+From the caller's perspective, this is identical to a regular function; in fact, you don't
+have to know whether you're calling a regular or generated function. Let's see how `foo` behaves:
 
 ```jldoctest generated
 julia> x = foo(2); # note: output is from println() statement in the body
@@ -1198,7 +1196,7 @@ end and at the call site; however, *don't copy them*, for the following reasons:
     when, how often or how many times these side-effects will occur
   * the `bar` function solves a problem that is better solved with multiple dispatch - defining `bar(x) = x`
     and `bar(x::Integer) = x ^ 2` will do the same thing, but it is both simpler and faster.
-  * the `baz` function is pathologically insane
+  * the `baz` function is pathological
 
 Note that the set of operations that should not be attempted in a generated function is unbounded,
 and the runtime system can currently only detect a subset of the invalid operations. There are
@@ -1316,3 +1314,59 @@ the two tuples, multiplication and addition/subtraction. All the looping is perf
 and we avoid looping during execution entirely. Thus, we only loop *once per type*, in this case
 once per `N` (except in edge cases where the function is generated more than once - see disclaimer
 above).
+
+### Optionally-generated functions
+
+Generated functions can achieve high efficiency at run time, but come with a compile time cost:
+a new function body must be generated for every combination of concrete argument types.
+Typically, Julia is able to compile "generic" versions of functions that will work for any
+arguments, but with generated functions this is impossible.
+This means that programs making heavy use of generated functions might be impossible to
+statically compile.
+
+To solve this problem, the language provides syntax for writing normal, non-generated
+alternative implementations of generated functions.
+Applied to the `sub2ind` example above, it would look like this:
+
+```julia
+function sub2ind_gen(dims::NTuple{N}, I::Integer...) where N
+    if N != length(I)
+        throw(ArgumentError("Number of dimensions must match number of indices."))
+    end
+    if @generated
+        ex = :(I[$N] - 1)
+        for i = (N - 1):-1:1
+            ex = :(I[$i] - 1 + dims[$i] * $ex)
+        end
+        return :($ex + 1)
+    else
+        ind = I[N] - 1
+        for i = (N - 1):-1:1
+            ind = I[i] - 1 + dims[i]*ind
+        end
+        return ind + 1
+    end
+end
+```
+
+Internally, this code creates two implementations of the function: a generated one where
+the first block in `if @generated` is used, and a normal one where the `else` block is used.
+Inside the `then` part of the `if @generated` block, code has the same semantics as other
+generated functions: argument names refer to types, and the code should return an expression.
+Multiple `if @generated` blocks may occur, in which case the generated implementation uses
+all of the `then` blocks and the alternate implementation uses all of the `else` blocks.
+
+Notice that we added an error check to the top of the function.
+This code will be common to both versions, and is run-time code in both versions
+(it will be quoted and returned as an expression from the generated version).
+That means that the values and types of local variables are not available at code generation
+time --- the code-generation code can only see the types of arguments.
+
+In this style of definition, the code generation feature is essentially an optional
+optimization.
+The compiler will use it if convenient, but otherwise may choose to use the normal
+implementation instead.
+This style is preferred, since it allows the compiler to make more decisions and compile
+programs in more ways, and since normal code is more readable than code-generating code.
+However, which implementation is used depends on compiler implementation details, so it
+is essential for the two implementations to behave identically.

--- a/src/ast.c
+++ b/src/ast.c
@@ -55,7 +55,8 @@ jl_sym_t *meta_sym; jl_sym_t *compiler_temp_sym;
 jl_sym_t *inert_sym; jl_sym_t *vararg_sym;
 jl_sym_t *unused_sym; jl_sym_t *static_parameter_sym;
 jl_sym_t *polly_sym; jl_sym_t *inline_sym;
-jl_sym_t *propagate_inbounds_sym;
+jl_sym_t *propagate_inbounds_sym; jl_sym_t *generated_sym;
+jl_sym_t *generated_only_sym;
 jl_sym_t *isdefined_sym; jl_sym_t *nospecialize_sym;
 jl_sym_t *macrocall_sym;
 jl_sym_t *hygienicscope_sym;
@@ -343,6 +344,8 @@ void jl_init_frontend(void)
     hygienicscope_sym = jl_symbol("hygienic-scope");
     gc_preserve_begin_sym = jl_symbol("gc_preserve_begin");
     gc_preserve_end_sym = jl_symbol("gc_preserve_end");
+    generated_sym = jl_symbol("generated");
+    generated_only_sym = jl_symbol("generated_only");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -358,6 +358,20 @@
   (and (if one (length= e 3) (length> e 2))
        (eq? (car e) 'meta) (eq? (cadr e) 'nospecialize)))
 
+(define (if-generated? e)
+  (and (length= e 4) (eq? (car e) 'if) (equal? (cadr e) '(generated))))
+
+(define (generated-meta? e)
+  (and (length= e 3) (eq? (car e) 'meta) (eq? (cadr e) 'generated)))
+
+(define (generated_only-meta? e)
+  (and (length= e 2) (eq? (car e) 'meta) (eq? (cadr e) 'generated_only)))
+
+(define (function-def? e)
+  (and (pair? e) (or (eq? (car e) 'function) (eq? (car e) '->)
+                     (and (eq? (car e) '=) (length= e 3)
+                          (eventually-call? (cadr e))))))
+
 ;; flatten nested expressions with the given head
 ;; (op (op a b) c) => (op a b c)
 (define (flatten-ex head e)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1193,8 +1193,6 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
                 li->inferred &&
                 // and there is something to delete (test this before calling jl_ast_flag_inlineable)
                 li->inferred != jl_nothing &&
-                // don't delete the code for the generator
-                li != li->def.method->generator &&
                 // don't delete inlineable code, unless it is constant
                 (li->jlcall_api == 2 || !jl_ast_flag_inlineable((jl_array_t*)li->inferred)) &&
                 // don't delete code when generating a precompile file
@@ -3842,11 +3840,10 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr)
         }
         Value *a1 = boxed(ctx, emit_expr(ctx, args[1]));
         Value *a2 = boxed(ctx, emit_expr(ctx, args[2]));
-        Value *mdargs[4] = {
+        Value *mdargs[3] = {
             /*argdata*/a1,
             /*code*/a2,
-            /*module*/literal_pointer_val(ctx, (jl_value_t*)ctx.module),
-            /*isstaged*/literal_pointer_val(ctx, args[3])
+            /*module*/literal_pointer_val(ctx, (jl_value_t*)ctx.module)
         };
         ctx.builder.CreateCall(prepare_call(jlmethod_func), makeArrayRef(mdargs));
         return ghostValue(jl_void_type);
@@ -6359,7 +6356,6 @@ static void init_julia_llvm_env(Module *m)
     std::vector<Type*> mdargs(0);
     mdargs.push_back(T_prjlvalue);
     mdargs.push_back(T_prjlvalue);
-    mdargs.push_back(T_pjlvalue);
     mdargs.push_back(T_pjlvalue);
     jlmethod_func =
         Function::Create(FunctionType::get(T_void, mdargs, false),

--- a/src/dump.c
+++ b/src/dump.c
@@ -1454,7 +1454,7 @@ static jl_value_t *jl_deserialize_value_method(jl_serializer_state *s, jl_value_
     m->unspecialized = (jl_method_instance_t*)jl_deserialize_value(s, (jl_value_t**)&m->unspecialized);
     if (m->unspecialized)
         jl_gc_wb(m, m->unspecialized);
-    m->generator = (jl_method_instance_t*)jl_deserialize_value(s, (jl_value_t**)&m->generator);
+    m->generator = jl_deserialize_value(s, (jl_value_t**)&m->generator);
     if (m->generator)
         jl_gc_wb(m, m->generator);
     m->invokes.unknown = jl_deserialize_value(s, (jl_value_t**)&m->invokes);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -322,7 +322,7 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
         JL_GC_PUSH2(&atypes, &meth);
         atypes = eval(args[1], s);
         meth = eval(args[2], s);
-        jl_method_def((jl_svec_t*)atypes, (jl_code_info_t*)meth, s->module, args[3]);
+        jl_method_def((jl_svec_t*)atypes, (jl_code_info_t*)meth, s->module);
         JL_GC_POP();
         return jl_nothing;
     }

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2061,7 +2061,7 @@ void jl_init_types(void)
                             jl_simplevector_type,
                             jl_any_type,
                             jl_any_type, // jl_method_instance_type
-                            jl_any_type, // jl_method_instance_type
+                            jl_any_type,
                             jl_array_any_type,
                             jl_any_type,
                             jl_int32_type,
@@ -2174,7 +2174,6 @@ void jl_init_types(void)
 #endif
     jl_svecset(jl_methtable_type->types, 8, jl_int32_type); // uint32_t
     jl_svecset(jl_method_type->types, 10, jl_method_instance_type);
-    jl_svecset(jl_method_type->types, 11, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 13, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 14, jl_voidpointer_type);

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -286,9 +286,35 @@
                (map (lambda (x) (replace-outer-vars x renames))
                     (cdr e))))))
 
+(define (make-generator-function name sp-names arg-names body)
+  (let ((arg-names (append sp-names
+                           (map (lambda (n)
+                                  (if (eq? n '|#self#|) (gensy) n))
+                                arg-names))))
+    (let ((body (insert-after-meta body  ;; don't specialize on generator arguments
+                                   `((meta nospecialize ,@arg-names)))))
+      `(block
+        (global ,name)
+        (function (call ,name ,@arg-names) ,body)))))
+
+;; select the `then` or `else` part of `if @generated` based on flag `genpart`
+(define (generated-part- x genpart)
+  (cond ((or (atom? x) (quoted? x) (function-def? x)) x)
+        ((if-generated? x)
+         (if genpart `($ ,(caddr x)) (cadddr x)))
+        (else (cons (car x)
+                    (map (lambda (e) (generated-part- e genpart)) (cdr x))))))
+
+(define (generated-version body)
+  `(block
+    ,(julia-bq-macro (generated-part- body #t))))
+
+(define (non-generated-version body)
+  (generated-part- body #f))
+
 ;; construct the (method ...) expression for one primitive method definition,
 ;; assuming optional and keyword args are already handled
-(define (method-def-expr- name sparams argl body isstaged (rett '(core Any)))
+(define (method-def-expr- name sparams argl body (rett '(core Any)))
   (if
    (any kwarg? argl)
    ;; has optional positional args
@@ -307,20 +333,39 @@
             (dfl  (map caddr kws)))
         (receive
          (vararg req) (separate vararg? argl)
-         (optional-positional-defs name sparams req opt dfl body isstaged
+         (optional-positional-defs name sparams req opt dfl body
                                    (append req opt vararg) rett)))))
    ;; no optional positional args
-   (let ((names (map car sparams)))
-     (let ((anames (llist-vars argl)))
-       (if (has-dups (filter (lambda (x) (not (eq? x UNUSED))) anames))
-           (error "function argument names not unique"))
-       (if (has-dups names)
-           (error "function static parameter names not unique"))
-       (if (any (lambda (x) (and (not (eq? x UNUSED)) (memq x names))) anames)
-           (error "function argument and static parameter names must be distinct")))
+   (let ((names (map car sparams))
+         (anames (llist-vars argl)))
+     (if (has-dups (filter (lambda (x) (not (eq? x UNUSED))) anames))
+         (error "function argument names not unique"))
+     (if (has-dups names)
+         (error "function static parameter names not unique"))
+     (if (any (lambda (x) (and (not (eq? x UNUSED)) (memq x names))) anames)
+         (error "function argument and static parameter names must be distinct"))
      (if (or (and name (not (sym-ref? name))) (eq? name 'true) (eq? name 'false))
          (error (string "invalid function name \"" (deparse name) "\"")))
-     (let* ((types (llist-types argl))
+     (let* ((generator (if (expr-contains-p if-generated? body (lambda (x) (not (function-def? x))))
+                           (let* ((gen    (generated-version body))
+                                  (nongen (non-generated-version body))
+                                  (gname  (symbol (string (gensy) "#" (current-julia-module-counter))))
+                                  (gf     (make-generator-function gname names (llist-vars argl) gen))
+                                  (loc    (function-body-lineno body)))
+                             (set! body (insert-after-meta
+                                         nongen
+                                         `((meta generated
+                                                 (new (core GeneratedFunctionStub)
+                                                      ,gname
+                                                      ,(cons 'list anames)
+                                                      ,(if (null? sparams)
+                                                           'nothing
+                                                           (cons 'list (map car sparams)))
+                                                      ,(if (null? loc) 0 (cadr loc))
+                                                      (inert ,(if (null? loc) 'none (caddr loc))))))))
+                             (list gf))
+                           '()))
+            (types (llist-types argl))
             (body  (method-lambda-expr argl body rett))
             ;; HACK: the typevars need to be bound to ssavalues, since this code
             ;; might be moved to a different scope by closure-convert.
@@ -329,7 +374,7 @@
             (mdef
              (if (null? sparams)
                  `(method ,name (call (core svec) (call (core svec) ,@(dots->vararg types)) (call (core svec)))
-                          ,body ,isstaged)
+                          ,body)
                  `(method ,name
                           (block
                            ,@(let loop ((n       names)
@@ -350,10 +395,12 @@
                                                              (replace-vars ty renames))
                                                            types)))
                                  (call (core svec) ,@temps)))
-                          ,body ,isstaged))))
+                          ,body))))
        (if (or (symbol? name) (globalref? name))
-           `(block (method ,name) ,mdef (unnecessary ,name))  ;; return the function
-           mdef)))))
+           `(block ,@generator (method ,name) ,mdef (unnecessary ,name))  ;; return the function
+           (if (not (null? generator))
+               `(block ,@generator ,mdef)
+               mdef))))))
 
 ;; wrap expr in nested scopes assigning names to vals
 (define (scopenest names vals expr)
@@ -365,10 +412,8 @@
 
 (define empty-vector-any '(call (core AnyVector) 0))
 
-(define (keywords-method-def-expr name sparams argl body isstaged rett)
+(define (keywords-method-def-expr name sparams argl body rett)
   (let* ((kargl (cdar argl))  ;; keyword expressions (= k v)
-         (annotations (map (lambda (a) `(meta nospecialize ,(arg-name (cadr (caddr a)))))
-                           (filter nospecialize-meta? kargl)))
          (kargl (map (lambda (a)
                        (if (nospecialize-meta? a) (caddr a) a))
                      kargl))
@@ -403,6 +448,8 @@
                                 keynames))
          ;; list of function's initial line number and meta nodes (empty if none)
          (prologue (extract-method-prologue body))
+         (annotations (map (lambda (a) `(meta nospecialize ,(arg-name (cadr (caddr a)))))
+                           (filter nospecialize-meta? kargl)))
          ;; body statements
          (stmts (cdr body))
          (positional-sparams
@@ -427,7 +474,7 @@
         ,(method-def-expr-
           name positional-sparams (append pargl vararg)
           `(block
-            ,@prologue
+            ,@(without-generated prologue)
             ,(let (;; call mangled(vals..., [rest_kw,] pargs..., [vararg]...)
                    (ret `(return (call ,mangled
                                        ,@(if ordered-defaults keynames vals)
@@ -437,8 +484,7 @@
                                              (list `(... ,(arg-name (car vararg)))))))))
                (if ordered-defaults
                    (scopenest keynames vals ret)
-                   ret)))
-          #f)
+                   ret))))
 
         ;; call with keyword args pre-sorted - original method code goes here
         ,(method-def-expr-
@@ -457,7 +503,7 @@
           (insert-after-meta `(block
                                ,@stmts)
                              annotations)
-          isstaged rett)
+          rett)
 
         ;; call with unsorted keyword args. this sorts and re-dispatches.
         ,(method-def-expr-
@@ -539,8 +585,7 @@
                                        ,@(if (null? restkw) '() (list rkw))
                                        ,@(map arg-name pargl)
                                        ,@(if (null? vararg) '()
-                                             (list `(... ,(arg-name (car vararg)))))))))
-          #f)
+                                             (list `(... ,(arg-name (car vararg))))))))))
         ;; return primary function
         ,(if (not (symbol? name))
              '(null) name)))))
@@ -552,6 +597,11 @@
                     (and (pair? e) (or (eq? (car e) 'line) (eq? (car e) 'meta))))
                   (cdr body))
       '()))
+
+(define (without-generated stmts)
+  (filter (lambda (x) (not (or (generated-meta? x)
+                               (generated_only-meta? x))))
+          stmts))
 
 ;; keep only sparams used by `expr` or other sparams
 (define (filter-sparams expr sparams)
@@ -566,8 +616,8 @@
           (else
            (loop filtered (cdr params))))))
 
-(define (optional-positional-defs name sparams req opt dfl body isstaged overall-argl rett)
-  (let ((prologue (extract-method-prologue body)))
+(define (optional-positional-defs name sparams req opt dfl body overall-argl rett)
+  (let ((prologue (without-generated (extract-method-prologue body))))
     `(block
       ,@(map (lambda (n)
                (let* ((passed (append req (list-head opt n)))
@@ -596,9 +646,9 @@
                            `(block
                              ,@prologue
                              (call ,(arg-name (car req)) ,@(map arg-name (cdr passed)) ,@vals)))))
-                 (method-def-expr- name sp passed body #f)))
+                 (method-def-expr- name sp passed body)))
              (iota (length opt)))
-      ,(method-def-expr- name sparams overall-argl body isstaged rett))))
+      ,(method-def-expr- name sparams overall-argl body rett))))
 
 ;; strip empty (parameters ...), normalizing `f(x;)` to `f(x)`.
 (define (remove-empty-parameters argl)
@@ -627,14 +677,14 @@
 ;; definitions without keyword arguments are passed to method-def-expr-,
 ;; which handles optional positional arguments by adding the needed small
 ;; boilerplate definitions.
-(define (method-def-expr name sparams argl body isstaged rett)
+(define (method-def-expr name sparams argl body rett)
   (let ((argl (remove-empty-parameters argl)))
     (if (has-parameters? argl)
         ;; has keywords
         (begin (check-kw-args (cdar argl))
-               (keywords-method-def-expr name sparams argl body isstaged rett))
+               (keywords-method-def-expr name sparams argl body rett))
         ;; no keywords
-        (method-def-expr- name sparams argl body isstaged rett))))
+        (method-def-expr- name sparams argl body rett))))
 
 (define (struct-def-expr name params super fields mut)
   (receive
@@ -763,12 +813,12 @@
                          ,@sig)
                   new-params)))))
 
-(define (ctor-def keyword name Tname params bounds sig ctor-body body wheres)
+(define (ctor-def name Tname params bounds sig ctor-body body wheres)
   (let* ((curly?     (and (pair? name) (eq? (car name) 'curly)))
          (curlyargs  (if curly? (cddr name) '()))
          (name       (if curly? (cadr name) name)))
     (cond ((not (eq? name Tname))
-           `(,keyword ,(with-wheres `(call ,(if curly?
+           `(function ,(with-wheres `(call ,(if curly?
                                                 `(curly ,name ,@curlyargs)
                                                 name)
                                            ,@sig)
@@ -777,7 +827,7 @@
                       ;; new{...} inside a non-ctor inner definition.
                       ,(ctor-body body '())))
           (wheres
-           `(,keyword ,(with-wheres `(call ,(if curly?
+           `(function ,(with-wheres `(call ,(if curly?
                                                 `(curly ,name ,@curlyargs)
                                                 name)
                                            ,@sig)
@@ -791,7 +841,7 @@
                  (syntax-deprecation #f
                                      (string "inner constructor " name "(...)" (linenode-string (function-body-lineno body)))
                                      (deparse `(where (call (curly ,name ,@params) ...) ,@params))))
-             `(,keyword ,sig ,(ctor-body body params)))))))
+             `(function ,sig ,(ctor-body body params)))))))
 
 (define (function-body-lineno body)
   (let ((lnos (filter (lambda (e) (and (pair? e) (eq? (car e) 'line)))
@@ -818,18 +868,14 @@
    (pattern-set
     ;; definitions without `where`
     (pattern-lambda (function       (-$ (call name . sig) (|::| (call name . sig) _t)) body)
-                    (ctor-def (car __) name Tname params bounds sig ctor-body body #f))
-    (pattern-lambda (stagedfunction (-$ (call name . sig) (|::| (call name . sig) _t)) body)
-                    (ctor-def (car __) name Tname params bounds sig ctor-body body #f))
+                    (ctor-def name Tname params bounds sig ctor-body body #f))
     (pattern-lambda (= (-$ (call name . sig) (|::| (call name . sig) _t)) body)
-                    (ctor-def 'function name Tname params bounds sig ctor-body body #f))
+                    (ctor-def name Tname params bounds sig ctor-body body #f))
     ;; definitions with `where`
     (pattern-lambda (function       (where (-$ (call name . sig) (|::| (call name . sig) _t)) . wheres) body)
-                    (ctor-def (car __) name Tname params bounds sig ctor-body body wheres))
-    (pattern-lambda (stagedfunction (where (-$ (call name . sig) (|::| (call name . sig) _t)) . wheres) body)
-                    (ctor-def (car __) name Tname params bounds sig ctor-body body wheres))
+                    (ctor-def name Tname params bounds sig ctor-body body wheres))
     (pattern-lambda (= (where (-$ (call name . sig) (|::| (call name . sig) _t)) . wheres) body)
-                    (ctor-def 'function name Tname params bounds sig ctor-body body wheres)))
+                    (ctor-def name Tname params bounds sig ctor-body body wheres)))
 
    ;; flatten `where`s first
    (pattern-replace
@@ -970,7 +1016,7 @@
                 (loop (if isseq F (cdr F)) (cdr A) stmts
                       (list* (if isamp `(& ,ca) ca) C) (list* g GC))))))))
 
-(define (expand-function-def e)   ;; handle function or stagedfunction
+(define (expand-function-def e)   ;; handle function definitions
   (define (just-arglist? ex)
     (and (pair? ex)
          (or (memq (car ex) '(tuple block))
@@ -1054,7 +1100,6 @@
                                       (where  where)
                                       (else   '())))
                   (sparams (map analyze-typevar raw-typevars))
-                  (isstaged (eq? (car e) 'stagedfunction))
                   (adj-decl (lambda (n) (if (and (decl? n) (length= n 2))
                                             `(|::| |#self#| ,(cadr n))
                                             n)))
@@ -1083,7 +1128,7 @@
                                                                   (cdr argl)))
                                                       ,@raw-typevars))))
              (expand-forms
-              (method-def-expr name sparams argl body isstaged rett))))
+              (method-def-expr name sparams argl body rett))))
           (else
            (error (string "invalid assignment location \"" (deparse name) "\""))))))
 
@@ -1888,7 +1933,6 @@
 (define expand-table
   (table
    'function       expand-function-def
-   'stagedfunction expand-function-def
    '->             expand-arrow
    'let            expand-let
    'macro          expand-macro-def
@@ -3225,8 +3269,7 @@ f(x) = yt(x)
                             ,@top-stmts
                             (block ,@sp-inits
                                    (method ,name ,(cl-convert sig fname lam namemap toplevel interp)
-                                           ,(julia-bq-macro newlam)
-                                           ,(last e)))))))
+                                           ,(julia-bq-macro newlam)))))))
                  ;; local case - lift to a new type at top level
                  (let* ((exists (get namemap name #f))
                         (type-name  (or exists
@@ -3303,8 +3346,7 @@ f(x) = yt(x)
                                                                    (if iskw
                                                                        (caddr (lam:args lam2))
                                                                        (car (lam:args lam2)))
-                                                                   #f closure-param-names)
-                                                  ,(last e)))))))
+                                                                   #f closure-param-names)))))))
                         (mk-closure  ;; expression to make the closure
                          (let* ((var-exprs (map (lambda (v)
                                                   (let ((cv (assq v (cadr (lam:vinfo lam)))))
@@ -3750,8 +3792,7 @@ f(x) = yt(x)
              (if (length> e 2)
                  (begin (emit `(method ,(or (cadr e) 'false)
                                        ,(compile (caddr e) break-labels #t #f)
-                                       ,(linearize (cadddr e))
-                                       ,(if (car (cddddr e)) 'true 'false)))
+                                       ,(linearize (cadddr e))))
                         (if value (compile '(null) break-labels value tail)))
                  (cond (tail  (emit-return e))
                        (value e)

--- a/src/julia.h
+++ b/src/julia.h
@@ -248,7 +248,7 @@ typedef struct _jl_method_t {
     jl_svec_t *sparam_syms;  // symbols giving static parameter names
     jl_value_t *source;  // original code template (jl_code_info_t, but may be compressed), null for builtins
     struct _jl_method_instance_t *unspecialized;  // unspecialized executable method instance, or null
-    struct _jl_method_instance_t *generator;  // executable code-generating function if available
+    jl_value_t *generator;  // executable code-generating function if available
     jl_array_t *roots;  // pointers in generated code (shared to reduce memory), or null
 
     // cache of specializations of this method for invoke(), i.e.
@@ -1055,7 +1055,7 @@ JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name,
                                                  jl_module_t *module,
                                                  jl_value_t **bp, jl_value_t *bp_owner,
                                                  jl_binding_t *bnd);
-JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_code_info_t *f, jl_module_t *module, jl_value_t *isstaged);
+JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata, jl_code_info_t *f, jl_module_t *module);
 JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo);
 JL_DLLEXPORT jl_code_info_t *jl_copy_code_info(jl_code_info_t *src);
 JL_DLLEXPORT size_t jl_get_world_counter(void);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1000,6 +1000,8 @@ extern jl_sym_t *isdefined_sym;
 extern jl_sym_t *nospecialize_sym;
 extern jl_sym_t *boundscheck_sym;
 extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
+extern jl_sym_t *generated_sym;
+extern jl_sym_t *generated_only_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -400,11 +400,6 @@
       (apply append (map decl-vars* (cdr e)))
       (list (decl-var* e))))
 
-(define (function-def? e)
-  (and (pair? e) (or (eq? (car e) 'function) (eq? (car e) '->)
-                     (and (eq? (car e) '=) (length= e 3)
-                          (eventually-call? (cadr e))))))
-
 ;; count hygienic / escape pairs
 ;; and fold together a list resulting from applying the function to
 ;; any block at the same hygienic scope

--- a/src/utils.scm
+++ b/src/utils.scm
@@ -40,12 +40,13 @@
                 (cdr expr)))))
 
 ;; same as above, with predicate
-(define (expr-contains-p p expr)
-  (or (p expr)
-      (and (pair? expr)
-           (not (quoted? expr))
-           (any (lambda (y) (expr-contains-p p y))
-                (cdr expr)))))
+(define (expr-contains-p p expr (filt (lambda (x) #t)))
+  (and (filt expr)
+       (or (p expr)
+           (and (pair? expr)
+                (not (quoted? expr))
+                (any (lambda (y) (expr-contains-p p y filt))
+                     (cdr expr))))))
 
 ;; find all subexprs satisfying `p`, applying `key` to each one
 (define (expr-find-all p expr key (filt (lambda (x) #t)))

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -761,7 +761,7 @@ world = typemax(UInt)
 mtypes, msp, m = Base._methods_by_ftype(T22979, -1, world)[]
 instance = Core.Inference.code_for_method(m, mtypes, msp, world, false)
 cinfo_generated = Core.Inference.get_staged(instance)
-cinfo_ungenerated = Base.uncompressed_ast(m)
+@test_throws ErrorException Base.uncompressed_ast(m)
 
 test_similar_codeinfo(@code_lowered(f22979(x22979...)), cinfo_generated)
 
@@ -770,7 +770,4 @@ cinfos = code_lowered(f22979, typeof.(x22979), true)
 cinfo = cinfos[]
 test_similar_codeinfo(cinfo, cinfo_generated)
 
-cinfos = code_lowered(f22979, typeof.(x22979), false)
-@test length(cinfos) == 1
-cinfo = cinfos[]
-test_similar_codeinfo(cinfo, cinfo_ungenerated)
+@test_throws ErrorException code_lowered(f22979, typeof.(x22979), false)


### PR DESCRIPTION
~~Updated description: https://github.com/JuliaLang/julia/pull/23168#issuecomment-321089698~~
Now: https://github.com/JuliaLang/julia/pull/23168#issuecomment-337048264

This also replaces the `stagedfunction` expression head with metadata. It's more flexible, there are fewer pieces of code that need to propagate the `staged` bit, and we won't need to worry about handling `stagedfunction` expressions anywhere.

Interestingly, `stagedfunction` was neither an AST form nor an IR form, only returned from the `@generated` macro and immediately lowered away, so it probably doesn't even need a deprecation.