### PR TITLE
small change in rational constructor

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,7 +11,7 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
-        num2, den2 = (den < 0) ? divgcd(-num, -den) : divgcd(num, den)
+        num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end
 end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,8 +11,8 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
-        g = den < 0 ? -gcd(den, num) : gcd(den, num)
-        new(div(num, g), div(den, g))
+        num2, den2 = (den < 0) ? divgcd(-num, -den) : divgcd(num, den)
+        new(num2, den2)
     end
 end
 Rational(n::T, d::T) where {T<:Integer} = Rational{T}(n,d)


### PR DESCRIPTION
This small change is required for a custom type of mine that represents integers as their prime factorization. In this format, `*`, `lcd` and `gcd` are easy, and so is `divgcd`. However, general `div` is not necessarily easy.

This PR also fixes consistency. On master `divgcd` is used in the various `//` methods, but not in the actual `Rational` constructor itself.