### PR TITLE
Evaluate Circle CI (23171 but from a branch in JuliaLang)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,82 @@
+version: 2
+workflows:
+  version: 2
+  linux-builds:
+    jobs:
+      - build-x86_64
+      - build-i686
+
+jobs:
+  build-x86_64:
+    docker:
+#      - image: ubuntu:14.04
+      - image: circleci/python:2.7
+        environment:
+          JULIA_CPU_CORES: 4
+          JULIA_TEST_MAXRSS_MB: 800
+          ARCH: x86_64
+#    resource_class: xlarge
+    steps: &steps
+#          apt-get update &&
+#            curl make patch m4 xz-utils git time ccache bar
+      - run: | # install build dependencies
+          sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
+            time ccache bar &&
+          for prog in gcc g++ gfortran; do
+            sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
+          done
+      - checkout # circle ci code checkout step - TODO checkout PR merge commit
+# (FIXME: need to unset url."ssh://git@github.com".insteadOf or libgit2 tests fail)
+      - run: | # set versioning info and Make.user variables
+          git config --global --unset url."ssh://git@github.com".insteadOf &&
+          make -C base version_git.jl.phony &&
+          echo "override ARCH = $ARCH" | tee -a Make.user &&
+          for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
+            echo "override $var = 1" | tee -a Make.user;
+          done &&
+          echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
+      - restore_cache: # silly to take a checksum of the tag file here instead of
+          keys: # its contents but this is the only thing that works on circle
+            - ccache-{{ checksum "/tmp/weeknumber" }}
+      - run: | # build deps
+          contrib/download_cmake.sh &&
+          make -j8 -C deps || make
+      - run: | # build julia, output ccache stats when done
+          make -j8 all &&
+          make prefix=/tmp/julia install &&
+          ccache -s &&
+          make build-stats
+      - run: | # move source tree out of the way, run tests from install tree
+          cd .. &&
+          mv project julia-src &&
+          /tmp/julia/bin/julia -e 'versioninfo()' &&
+          /tmp/julia/bin/julia --precompiled=no -e 'true' &&
+          /tmp/julia/bin/julia-debug --precompiled=no -e 'true' &&
+          pushd /tmp/julia/share/julia/test &&
+          /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30 &&
+          /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg &&
+          popd &&
+          mkdir /tmp/embedding-test &&
+          make check -C /tmp/julia/share/doc/julia/examples/embedding \
+            JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
+            "$(cd julia-src && make print-CC)" &&
+          mv julia-src project
+#      - run: cd project && make -C doc deploy
+#       - run:
+#           command: sudo dmesg
+#           when: on_fail
+      - save_cache:
+          key: ccache-{{ checksum "/tmp/weeknumber" }}
+          paths:
+            - ~/.ccache
+
+  build-i686:
+    docker:
+#      - image: ubuntu:14.04
+      - image: circleci/python:2.7
+        environment:
+          JULIA_CPU_CORES: 4
+          JULIA_TEST_MAXRSS_MB: 800
+          ARCH: i686
+#    resource_class: xlarge
+    steps: *steps

--- a/circle.yml
+++ b/circle.yml
@@ -9,26 +9,26 @@ workflows:
 jobs:
   build-i686:
     docker:
-#      - image: ubuntu:14.04
       - image: circleci/python:2.7
         environment:
           JULIA_CPU_CORES: 6
           JULIA_TEST_MAXRSS_MB: 800
           ARCH: i686
-#    resource_class: xlarge
     steps: &steps
-#          apt-get update &&
-#            curl make patch m4 xz-utils git time ccache bar
       - run: | # install build dependencies
           sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
             time ccache bar &&
           for prog in gcc g++ gfortran; do
             sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
           done
-      - checkout # circle ci code checkout step - TODO checkout PR merge commit
+      - checkout # circle ci code checkout step
 # (FIXME: need to unset url."ssh://git@github.com".insteadOf or libgit2 tests fail)
-      - run: | # set versioning info and Make.user variables
+      - run: | # checkout merge commit, set versioning info and Make.user variables
           git config --global --unset url."ssh://git@github.com".insteadOf &&
+          if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+            git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge &&
+            git checkout -qf FETCH_HEAD;
+          fi &&
           make -C base version_git.jl.phony &&
           echo "override ARCH = $ARCH" | tee -a Make.user &&
           for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
@@ -38,7 +38,7 @@ jobs:
       - restore_cache: # silly to take a checksum of the tag file here instead of
           keys: # its contents but this is the only thing that works on circle
             - ccache-{{ checksum "/tmp/weeknumber" }}
-      - run: | # build deps
+      - run: | # compile julia deps
           contrib/download_cmake.sh &&
           make -j8 -C deps || make
       - run: | # build julia, output ccache stats when done

--- a/circle.yml
+++ b/circle.yml
@@ -3,18 +3,18 @@ workflows:
   version: 2
   linux-builds:
     jobs:
-      - build-x86_64
       - build-i686
+      - build-x86_64
 
 jobs:
-  build-x86_64:
+  build-i686:
     docker:
 #      - image: ubuntu:14.04
       - image: circleci/python:2.7
         environment:
-          JULIA_CPU_CORES: 4
+          JULIA_CPU_CORES: 6
           JULIA_TEST_MAXRSS_MB: 800
-          ARCH: x86_64
+          ARCH: i686
 #    resource_class: xlarge
     steps: &steps
 #          apt-get update &&
@@ -70,13 +70,11 @@ jobs:
           paths:
             - ~/.ccache
 
-  build-i686:
+  build-x86_64:
     docker:
-#      - image: ubuntu:14.04
       - image: circleci/python:2.7
         environment:
-          JULIA_CPU_CORES: 4
+          JULIA_CPU_CORES: 6
           JULIA_TEST_MAXRSS_MB: 800
-          ARCH: i686
-#    resource_class: xlarge
+          ARCH: x86_64
     steps: *steps


### PR DESCRIPTION
See #23171, this is the same thing but I'm trying to get the Circle CI webhook to recognize the PR and build from the JuliaLang account instead of my fork. ~~It might only work if `circle.yml` (or `.circle/config.yml`) is on master?~~  edit: I think something's wrong with PR's from forks? Not sure, contacted circle support to see if I can figure out what's wrong.