### PR TITLE
REPL: complete after using: modules can contain dots

### DIFF
--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -368,7 +368,7 @@ function afterusing(string::String, startpos::Int)
     r = search(rstr, r"\s(gnisu|tropmi)\b")
     isempty(r) && return false
     fr = reverseind(str, last(r))
-    return ismatch(r"^\b(using|import)\s*(\w+\s*,\s*)*\w*$", str[fr:end])
+    return ismatch(r"^\b(using|import)\s*((\w+[.])*\w+\s*,\s*)*\w*$", str[fr:end])
 end
 
 function bslash_completions(string, pos)

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -162,6 +162,11 @@ c,r = test_complete(s)
 @test r == 19:23
 @test s[r] == "getin"
 
+# issue #23193: after `using`, identifiers can be prefixed by module names
+s = "using Base.Test, Base.Random"
+c,r = test_complete(s)
+@test !("RandomDevice" in c)
+
 # inexistent completion inside a string
 s = "Pkg.add(\"lol"
 c,r,res = test_complete(s)


### PR DESCRIPTION
e.g. in the following, the <TAB> key should complete only
with modules names, i.e. "Random", but not "RandomDevice"

julia> using Base.Test, Base.Random<TAB>