### PR TITLE
enable switching the default RNG (fix #23199)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1730,6 +1730,8 @@ end
 
 @deprecate IOContext(io::IO, key, value) IOContext(io, key=>value)
 
+@eval Base.Random Base.@deprecate_binding GLOBAL_RNG srand(MersenneTwister(0))
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/random/RNGs.jl
+++ b/base/random/RNGs.jl
@@ -178,15 +178,9 @@ function srand(r::MersenneTwister, seed::Vector{UInt32})
     return r
 end
 
-srand(r::MersenneTwister=GLOBAL_RNG) = srand(r, make_seed())
+srand(r::MersenneTwister=defaultRNG()) = srand(r, make_seed())
 srand(r::MersenneTwister, n::Integer) = srand(r, make_seed(n))
-srand(seed::Union{Integer,Vector{UInt32}}) = srand(GLOBAL_RNG, seed)
-
-
-### Global RNG (must be defined after srand)
-
-const GLOBAL_RNG = MersenneTwister(0)
-
+srand(seed::Union{Integer,Vector{UInt32}}) = srand(defaultRNG(), seed)
 
 ### generation
 

--- a/base/random/generation.jl
+++ b/base/random/generation.jl
@@ -4,14 +4,14 @@
 
 ## from types: rand(::Type, [dims...])
 
-### GLOBAL_RNG fallback for all types
+### defaultRNG() fallback for all types
 
-@inline rand(T::Type) = rand(GLOBAL_RNG, T)
+@inline rand(T::Type) = rand(defaultRNG(), T)
 
 ### random floats
 
 # CloseOpen(T) is the fallback for an AbstractFloat T
-@inline rand(r::AbstractRNG=GLOBAL_RNG, ::Type{T}=Float64) where {T<:AbstractFloat} =
+@inline rand(r::AbstractRNG=defaultRNG(), ::Type{T}=Float64) where {T<:AbstractFloat} =
     rand(r, CloseOpen(T))
 
 # generic random generation function which can be used by RNG implementors
@@ -119,20 +119,20 @@ function rand!(r::AbstractRNG, A::AbstractArray{T}, ::Type{X}=T) where {T,X}
     A
 end
 
-rand!(A::AbstractArray, ::Type{X}) where {X} = rand!(GLOBAL_RNG, A, X)
+rand!(A::AbstractArray, ::Type{X}) where {X} = rand!(defaultRNG(), A, X)
 # NOTE: if the second parameter above is defaulted to eltype(A) and the
 # method below is removed, then some specialized methods (e.g. for
 # rand!(::Array{Float64})) will fail to be called
-rand!(A::AbstractArray) = rand!(GLOBAL_RNG, A)
+rand!(A::AbstractArray) = rand!(defaultRNG(), A)
 
 
 rand(r::AbstractRNG, dims::Dims)       = rand(r, Float64, dims)
-rand(                dims::Dims)       = rand(GLOBAL_RNG, dims)
+rand(                dims::Dims)       = rand(defaultRNG(), dims)
 rand(r::AbstractRNG, dims::Integer...) = rand(r, Dims(dims))
 rand(                dims::Integer...) = rand(Dims(dims))
 
 rand(r::AbstractRNG, T::Type, dims::Dims)                   = rand!(r, Array{T}(dims))
-rand(                T::Type, dims::Dims)                   = rand(GLOBAL_RNG, T, dims)
+rand(                T::Type, dims::Dims)                   = rand(defaultRNG(), T, dims)
 rand(r::AbstractRNG, T::Type, d::Integer, dims::Integer...) = rand(r, T, Dims((d, dims...)))
 rand(                T::Type, d::Integer, dims::Integer...) = rand(T, Dims((d, dims...)))
 # note: the above methods would trigger an ambiguity warning if d was not separated out:
@@ -159,7 +159,7 @@ function rand!(rng::AbstractRNG, A::AbstractArray, I::FloatInterval{BigFloat})
     A
 end
 
-rand!(A::AbstractArray, I::FloatInterval) = rand!(GLOBAL_RNG, A, I)
+rand!(A::AbstractArray, I::FloatInterval) = rand!(defaultRNG(), A, I)
 
 ## Generate random integer within a range
 
@@ -301,7 +301,7 @@ rand!(rng::AbstractRNG, A::AbstractArray,
 ## random values from AbstractArray
 
 rand(rng::AbstractRNG, r::AbstractArray) = @inbounds return r[rand(rng, 1:length(r))]
-rand(                  r::AbstractArray) = rand(GLOBAL_RNG, r)
+rand(                  r::AbstractArray) = rand(defaultRNG(), r)
 
 ### arrays
 
@@ -313,13 +313,13 @@ function rand!(rng::AbstractRNG, A::AbstractArray, r::AbstractArray)
     return A
 end
 
-rand!(A::AbstractArray, r::AbstractArray) = rand!(GLOBAL_RNG, A, r)
+rand!(A::AbstractArray, r::AbstractArray) = rand!(defaultRNG(), A, r)
 
 rand(rng::AbstractRNG, r::AbstractArray{T}, dims::Dims) where {T} =
     rand!(rng, Array{T}(dims), r)
-rand(                  r::AbstractArray, dims::Dims)       = rand(GLOBAL_RNG, r, dims)
+rand(                  r::AbstractArray, dims::Dims)       = rand(defaultRNG(), r, dims)
 rand(rng::AbstractRNG, r::AbstractArray, dims::Integer...) = rand(rng, r, Dims(dims))
-rand(                  r::AbstractArray, dims::Integer...) = rand(GLOBAL_RNG, r, Dims(dims))
+rand(                  r::AbstractArray, dims::Integer...) = rand(defaultRNG(), r, Dims(dims))
 
 
 ## random values from Dict, Set, IntSet
@@ -356,7 +356,7 @@ nth(iter::AbstractArray, n::Integer) = iter[n]
 
 rand(r::AbstractRNG, s::Union{Associative,AbstractSet}) = nth(s, rand(r, 1:length(s)))
 
-rand(s::Union{Associative,AbstractSet}) = rand(GLOBAL_RNG, s)
+rand(s::Union{Associative,AbstractSet}) = rand(defaultRNG(), s)
 
 ### arrays
 
@@ -371,7 +371,7 @@ end
 rand!(r::AbstractRNG, A::AbstractArray, s::Union{Associative,AbstractSet}) =
     rand!(r, A, collect(s))
 
-rand!(A::AbstractArray, s::Union{Associative,AbstractSet}) = rand!(GLOBAL_RNG, A, s)
+rand!(A::AbstractArray, s::Union{Associative,AbstractSet}) = rand!(defaultRNG(), A, s)
 
 rand(r::AbstractRNG, s::Associative{K,V}, dims::Dims) where {K,V} =
     rand!(r, Array{Pair{K,V}}(dims), s)
@@ -379,8 +379,8 @@ rand(r::AbstractRNG, s::Associative{K,V}, dims::Dims) where {K,V} =
 rand(r::AbstractRNG, s::AbstractSet{T}, dims::Dims) where {T} = rand!(r, Array{T}(dims), s)
 rand(r::AbstractRNG, s::Union{Associative,AbstractSet}, dims::Integer...) =
     rand(r, s, Dims(dims))
-rand(s::Union{Associative,AbstractSet}, dims::Integer...) = rand(GLOBAL_RNG, s, Dims(dims))
-rand(s::Union{Associative,AbstractSet}, dims::Dims) = rand(GLOBAL_RNG, s, dims)
+rand(s::Union{Associative,AbstractSet}, dims::Integer...) = rand(defaultRNG(), s, Dims(dims))
+rand(s::Union{Associative,AbstractSet}, dims::Dims) = rand(defaultRNG(), s, dims)
 
 
 ## random characters from a string
@@ -398,19 +398,19 @@ function rand(rng::AbstractRNG, s::AbstractString)::Char
     end
 end
 
-rand(s::AbstractString) = rand(GLOBAL_RNG, s)
+rand(s::AbstractString) = rand(defaultRNG(), s)
 
 ### arrays
 
 # we use collect(str), which is most of the time more efficient than specialized methods
 # (except maybe for very small arrays)
 rand!(rng::AbstractRNG, A::AbstractArray, str::AbstractString) = rand!(rng, A, collect(str))
-rand!(A::AbstractArray, str::AbstractString) = rand!(GLOBAL_RNG, A, str)
+rand!(A::AbstractArray, str::AbstractString) = rand!(defaultRNG(), A, str)
 rand(rng::AbstractRNG, str::AbstractString, dims::Dims) =
     rand!(rng, Array{eltype(str)}(dims), str)
 
 rand(rng::AbstractRNG, str::AbstractString, d::Integer, dims::Integer...) =
     rand(rng, str, Dims((d, dims...)))
 
-rand(str::AbstractString, dims::Dims) = rand(GLOBAL_RNG, str, dims)
-rand(str::AbstractString, d::Integer, dims::Integer...) = rand(GLOBAL_RNG, str, d, dims...)
+rand(str::AbstractString, dims::Dims) = rand(defaultRNG(), str, dims)
+rand(str::AbstractString, d::Integer, dims::Integer...) = rand(defaultRNG(), str, d, dims...)

--- a/base/random/misc.jl
+++ b/base/random/misc.jl
@@ -11,7 +11,7 @@ function rand!(rng::AbstractRNG, B::BitArray)
 end
 
 """
-    bitrand([rng=GLOBAL_RNG], [dims...])
+    bitrand([rng=defaultRNG()], [dims...])
 
 Generate a `BitArray` of random boolean values.
 
@@ -43,7 +43,7 @@ bitrand(dims::Integer...) = rand!(BitArray(convert(Dims, dims)))
 ## randstring (often useful for temporary filenames/dirnames)
 
 """
-    randstring([rng=GLOBAL_RNG], [chars], [len=8])
+    randstring([rng=defaultRNG()], [chars], [len=8])
 
 Create a random string of length `len`, consisting of characters from
 `chars`, which defaults to the set of upper- and lower-case letters
@@ -73,8 +73,8 @@ let b = UInt8['0':'9';'A':'Z';'a':'z']
     global randstring
     randstring(r::AbstractRNG, chars=b, n::Integer=8) = String(rand(r, chars, n))
     randstring(r::AbstractRNG, n::Integer) = randstring(r, b, n)
-    randstring(chars=b, n::Integer=8) = randstring(GLOBAL_RNG, chars, n)
-    randstring(n::Integer) = randstring(GLOBAL_RNG, b, n)
+    randstring(chars=b, n::Integer=8) = randstring(defaultRNG(), chars, n)
+    randstring(n::Integer) = randstring(defaultRNG(), b, n)
 end
 
 
@@ -125,7 +125,7 @@ end
 Like [`randsubseq`](@ref), but the results are stored in `S`
 (which is resized as needed).
 """
-randsubseq!(S::AbstractArray, A::AbstractArray, p::Real) = randsubseq!(GLOBAL_RNG, S, A, p)
+randsubseq!(S::AbstractArray, A::AbstractArray, p::Real) = randsubseq!(defaultRNG(), S, A, p)
 
 randsubseq(r::AbstractRNG, A::AbstractArray{T}, p::Real) where {T} =
     randsubseq!(r, T[], A, p)
@@ -138,7 +138,7 @@ element of `A` is included (in order) with independent probability `p`. (Complex
 linear in `p*length(A)`, so this function is efficient even if `p` is small and `A` is
 large.) Technically, this process is known as "Bernoulli sampling" of `A`.
 """
-randsubseq(A::AbstractArray, p::Real) = randsubseq(GLOBAL_RNG, A, p)
+randsubseq(A::AbstractArray, p::Real) = randsubseq(defaultRNG(), A, p)
 
 
 ## rand_lt (helper function)
@@ -157,7 +157,7 @@ end
 ## shuffle & shuffle!
 
 """
-    shuffle!([rng=GLOBAL_RNG,] v::AbstractArray)
+    shuffle!([rng=defaultRNG(),] v::AbstractArray)
 
 In-place version of [`shuffle`](@ref): randomly permute `v` in-place,
 optionally supplying the random-number generator `rng`.
@@ -198,10 +198,10 @@ function shuffle!(r::AbstractRNG, a::AbstractArray)
     return a
 end
 
-shuffle!(a::AbstractArray) = shuffle!(GLOBAL_RNG, a)
+shuffle!(a::AbstractArray) = shuffle!(defaultRNG(), a)
 
 """
-    shuffle([rng=GLOBAL_RNG,] v::AbstractArray)
+    shuffle([rng=defaultRNG(),] v::AbstractArray)
 
 Return a randomly permuted copy of `v`. The optional `rng` argument specifies a random
 number generator (see [Random Numbers](@ref)).
@@ -227,13 +227,13 @@ julia> shuffle(rng, collect(1:10))
 ```
 """
 shuffle(r::AbstractRNG, a::AbstractArray) = shuffle!(r, copymutable(a))
-shuffle(a::AbstractArray) = shuffle(GLOBAL_RNG, a)
+shuffle(a::AbstractArray) = shuffle(defaultRNG(), a)
 
 
 ## randperm & randperm!
 
 """
-    randperm([rng=GLOBAL_RNG,] n::Integer)
+    randperm([rng=defaultRNG(),] n::Integer)
 
 Construct a random permutation of length `n`. The optional `rng`
 argument specifies a random number generator (see [Random Numbers](@ref)).
@@ -251,10 +251,10 @@ julia> randperm(MersenneTwister(1234), 4)
 ```
 """
 randperm(r::AbstractRNG, n::Integer) = randperm!(r, Vector{Int}(n))
-randperm(n::Integer) = randperm(GLOBAL_RNG, n)
+randperm(n::Integer) = randperm(defaultRNG(), n)
 
 """
-    randperm!([rng=GLOBAL_RNG,] A::Array{<:Integer})
+    randperm!([rng=defaultRNG(),] A::Array{<:Integer})
 
 Construct in `A` a random permutation of length `length(A)`. The
 optional `rng` argument specifies a random number generator (see
@@ -288,13 +288,13 @@ function randperm!(r::AbstractRNG, a::Array{<:Integer})
     return a
 end
 
-randperm!(a::Array{<:Integer}) = randperm!(GLOBAL_RNG, a)
+randperm!(a::Array{<:Integer}) = randperm!(defaultRNG(), a)
 
 
 ## randcycle & randcycle!
 
 """
-    randcycle([rng=GLOBAL_RNG,] n::Integer)
+    randcycle([rng=defaultRNG(),] n::Integer)
 
 Construct a random cyclic permutation of length `n`. The optional `rng`
 argument specifies a random number generator, see [Random Numbers](@ref).
@@ -312,10 +312,10 @@ julia> randcycle(MersenneTwister(1234), 6)
 ```
 """
 randcycle(r::AbstractRNG, n::Integer) = randcycle!(r, Vector{Int}(n))
-randcycle(n::Integer) = randcycle(GLOBAL_RNG, n)
+randcycle(n::Integer) = randcycle(defaultRNG(), n)
 
 """
-    randcycle!([rng=GLOBAL_RNG,] A::Array{<:Integer})
+    randcycle!([rng=defaultRNG(),] A::Array{<:Integer})
 
 Construct in `A` a random cyclic permutation of length `length(A)`.
 The optional `rng` argument specifies a random number generator, see
@@ -348,7 +348,7 @@ function randcycle!(r::AbstractRNG, a::Array{<:Integer})
     return a
 end
 
-randcycle!(a::Array{<:Integer}) = randcycle!(GLOBAL_RNG, a)
+randcycle!(a::Array{<:Integer}) = randcycle!(defaultRNG(), a)
 
 
 ## random UUID generation
@@ -360,7 +360,7 @@ struct UUID
 end
 
 """
-    uuid1([rng::AbstractRNG=GLOBAL_RNG]) -> UUID
+    uuid1([rng::AbstractRNG=defaultRNG()]) -> UUID
 
 Generates a version 1 (time-based) universally unique identifier (UUID), as specified
 by RFC 4122. Note that the Node ID is randomly generated (does not identify the host)
@@ -374,7 +374,7 @@ julia> Base.Random.uuid1(rng)
 2cc938da-5937-11e7-196e-0f4ef71aa64b
 ```
 """
-function uuid1(rng::AbstractRNG=GLOBAL_RNG)
+function uuid1(rng::AbstractRNG=defaultRNG())
     u = rand(rng, UInt128)
 
     # mask off clock sequence and node
@@ -398,7 +398,7 @@ function uuid1(rng::AbstractRNG=GLOBAL_RNG)
 end
 
 """
-    uuid4([rng::AbstractRNG=GLOBAL_RNG]) -> UUID
+    uuid4([rng::AbstractRNG=defaultRNG()]) -> UUID
 
 Generates a version 4 (random or pseudo-random) universally unique identifier (UUID),
 as specified by RFC 4122.
@@ -411,7 +411,7 @@ julia> Base.Random.uuid4(rng)
 82015f10-44cc-4827-996e-0f4ef71aa64b
 ```
 """
-function uuid4(rng::AbstractRNG=GLOBAL_RNG)
+function uuid4(rng::AbstractRNG=defaultRNG())
     u = rand(rng, UInt128)
     u &= 0xffffffffffff0fff3fffffffffffffff
     u |= 0x00000000000040008000000000000000

--- a/base/random/normal.jl
+++ b/base/random/normal.jl
@@ -10,7 +10,7 @@
 ## randn
 
 """
-    randn([rng=GLOBAL_RNG], [T=Float64], [dims...])
+    randn([rng=defaultRNG()], [T=Float64], [dims...])
 
 Generate a normally-distributed random number of type `T`
 with mean 0 and standard deviation 1.
@@ -33,7 +33,7 @@ julia> randn(rng, Complex64, (2, 3))
   0.611224+1.56403im   0.355204-0.365563im  0.0905552+1.31012im
 ```
 """
-@inline function randn(rng::AbstractRNG=GLOBAL_RNG)
+@inline function randn(rng::AbstractRNG=defaultRNG())
     @inbounds begin
         r = rand_ui52(rng)
         rabs = Int64(r>>1) # One bit for the sign
@@ -71,7 +71,7 @@ randn(rng::AbstractRNG, ::Type{Complex{T}}) where {T<:AbstractFloat} =
 ## randexp
 
 """
-    randexp([rng=GLOBAL_RNG], [T=Float64], [dims...])
+    randexp([rng=defaultRNG()], [T=Float64], [dims...])
 
 Generate a random number of type `T` according to the
 exponential distribution with scale 1.
@@ -93,7 +93,7 @@ julia> randexp(rng, 3, 3)
  0.695867  0.693292  0.643644
 ```
 """
-@inline function randexp(rng::AbstractRNG=GLOBAL_RNG)
+@inline function randexp(rng::AbstractRNG=defaultRNG())
     @inbounds begin
         ri = rand_ui52(rng)
         idx = ri & 0xFF
@@ -117,7 +117,7 @@ end
 ## arrays & other scalar methods
 
 """
-    randn!([rng=GLOBAL_RNG], A::AbstractArray) -> A
+    randn!([rng=defaultRNG()], A::AbstractArray) -> A
 
 Fill the array `A` with normally-distributed (mean 0, standard deviation 1) random numbers.
 Also see the [`rand`](@ref) function.
@@ -138,7 +138,7 @@ julia> randn!(rng, zeros(5))
 function randn! end
 
 """
-    randexp!([rng=GLOBAL_RNG], A::AbstractArray) -> A
+    randexp!([rng=defaultRNG()], A::AbstractArray) -> A
 
 Fill the array `A` with random numbers following the exponential distribution
 (with scale 1).
@@ -163,7 +163,7 @@ for randfun in [:randn, :randexp]
     @eval begin
         # scalars
         $randfun(rng::AbstractRNG, T::BitFloatType) = convert(T, $randfun(rng))
-        $randfun(::Type{T}) where {T} = $randfun(GLOBAL_RNG, T)
+        $randfun(::Type{T}) where {T} = $randfun(defaultRNG(), T)
 
         # filling arrays
         function $randfun!(rng::AbstractRNG, A::AbstractArray{T}) where T
@@ -173,19 +173,19 @@ for randfun in [:randn, :randexp]
             A
         end
 
-        $randfun!(A::AbstractArray) = $randfun!(GLOBAL_RNG, A)
+        $randfun!(A::AbstractArray) = $randfun!(defaultRNG(), A)
 
         # generating arrays
         $randfun(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) where {T} = $randfun!(rng, Array{T}(dims))
         # Note that this method explicitly does not define $randfun(rng, T),
         # in order to prevent an infinite recursion.
         $randfun(rng::AbstractRNG, ::Type{T}, dim1::Integer, dims::Integer...) where {T} = $randfun!(rng, Array{T}(dim1, dims...))
-        $randfun(                  ::Type{T}, dims::Dims                     ) where {T} = $randfun(GLOBAL_RNG, T, dims)
-        $randfun(                  ::Type{T}, dims::Integer...               ) where {T} = $randfun(GLOBAL_RNG, T, dims...)
+        $randfun(                  ::Type{T}, dims::Dims                     ) where {T} = $randfun(defaultRNG(), T, dims)
+        $randfun(                  ::Type{T}, dims::Integer...               ) where {T} = $randfun(defaultRNG(), T, dims...)
         $randfun(rng::AbstractRNG,            dims::Dims                     )           = $randfun(rng, Float64, dims)
         $randfun(rng::AbstractRNG,            dims::Integer...               )           = $randfun(rng, Float64, dims...)
-        $randfun(                             dims::Dims                     )           = $randfun(GLOBAL_RNG, Float64, dims)
-        $randfun(                             dims::Integer...               )           = $randfun(GLOBAL_RNG, Float64, dims...)
+        $randfun(                             dims::Dims                     )           = $randfun(defaultRNG(), Float64, dims)
+        $randfun(                             dims::Integer...               )           = $randfun(defaultRNG(), Float64, dims...)
     end
 end
 

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1333,7 +1333,7 @@ function findnz(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
 end
 
 
-import Base.Random.GLOBAL_RNG
+import Base.Random.defaultRNG
 function sprand_IJ(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat)
     ((m < 0) || (n < 0)) && throw(ArgumentError("invalid Array dimensions"))
     0 <= density <= 1 || throw(ArgumentError("$density not in [0,1]"))
@@ -1411,18 +1411,18 @@ function sprand(m::Integer, n::Integer, density::AbstractFloat,
     N == 0 && return spzeros(T,m,n)
     N == 1 && return rand() <= density ? sparse([1], [1], rfn(1)) : spzeros(T,1,1)
 
-    I,J = sprand_IJ(GLOBAL_RNG, m, n, density)
+    I,J = sprand_IJ(defaultRNG(), m, n, density)
     sparse_IJ_sorted!(I, J, rfn(length(I)), m, n, +)  # it will never need to combine
 end
 
 truebools(r::AbstractRNG, n::Integer) = ones(Bool, n)
 
-sprand(m::Integer, n::Integer, density::AbstractFloat) = sprand(GLOBAL_RNG,m,n,density)
+sprand(m::Integer, n::Integer, density::AbstractFloat) = sprand(defaultRNG(),m,n,density)
 
 sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,rand,Float64)
 sprand(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r,m,n,density,(r, i) -> rand(r, T, i), T)
 sprand(r::AbstractRNG, ::Type{Bool}, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density, truebools, Bool)
-sprand(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T, m, n, density)
+sprand(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(defaultRNG(), T, m, n, density)
 
 
 """
@@ -1445,7 +1445,7 @@ julia> sprandn(rng, 2, 2, 0.75)
 ```
 """
 sprandn(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,randn,Float64)
-sprandn(m::Integer, n::Integer, density::AbstractFloat) = sprandn(GLOBAL_RNG,m,n,density)
+sprandn(m::Integer, n::Integer, density::AbstractFloat) = sprandn(defaultRNG(),m,n,density)
 
 
 """

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -449,28 +449,28 @@ copy!(A::SparseMatrixCSC, B::SparseVector{TvB,TiB}) where {TvB,TiB} =
 
 
 ### Rand Construction
-sprand(n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where {T} = sprand(GLOBAL_RNG, n, p, rfn, T)
+sprand(n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where {T} = sprand(defaultRNG(), n, p, rfn, T)
 function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where T
     I = randsubseq(r, 1:convert(Int, n), p)
     V = rfn(r, T, length(I))
     SparseVector(n, I, V)
 end
 
-sprand(n::Integer, p::AbstractFloat, rfn::Function) = sprand(GLOBAL_RNG, n, p, rfn)
+sprand(n::Integer, p::AbstractFloat, rfn::Function) = sprand(defaultRNG(), n, p, rfn)
 function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function)
     I = randsubseq(r, 1:convert(Int, n), p)
     V = rfn(r, length(I))
     SparseVector(n, I, V)
 end
 
-sprand(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, rand)
+sprand(n::Integer, p::AbstractFloat) = sprand(defaultRNG(), n, p, rand)
 
 sprand(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, rand)
 sprand(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(r, n, p, (r, i) -> rand(r, T, i))
 sprand(r::AbstractRNG, ::Type{Bool}, n::Integer, p::AbstractFloat) = sprand(r, n, p, truebools)
-sprand(::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T, n, p)
+sprand(::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(defaultRNG(), T, n, p)
 
-sprandn(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, randn)
+sprandn(n::Integer, p::AbstractFloat) = sprand(defaultRNG(), n, p, randn)
 sprandn(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, randn)
 
 ## Indexing into Matrices can return SparseVectors

--- a/test/random.jl
+++ b/test/random.jl
@@ -550,7 +550,7 @@ let seed = rand(UInt32, 10)
 end
 
 # srand(rng, ...) returns rng (#21248)
-let g = Base.Random.GLOBAL_RNG,
+let g = Base.Random.defaultRNG(),
     m = MersenneTwister(0)
     @test srand() === g
     @test srand(rand(UInt)) === g


### PR DESCRIPTION
Thanks to #265 fixed, we can use `globalRNG()` instead of `GLOBAL_RNG`, and a user can redefine this function to return a custom RNG. Even if the multi-threading story is not clarified for the global RNG, at least it doesn't seem to me to make things worst in this respect. Moreover, it's a good way for library author to not make assumptions about the default RNG. 

EDIT: the first version of this PR was simply defining `globalRNG() = GLOBAL_RNG`, and changing `GLOBAL_RNG` to `globalRNG()` everywhere. Following the discussion, which pointed at the bad API of redefining a Base function (via `Base.Random.globalRNG() = myrng`), it is updated as follows: it's possible to change the type of the default RNG, which can be got via `defaultRNG()`, using the `srand` function: `srand(RNG_Type, [seed])` is the same as `srand(seed)` if `defaultRNG()` is of type `RNG_Type`; otherwise initialize with `seed` a new RNG of the specified type and make it the new default RNG. 