### PR TITLE
deprecate vectorized methods hiding in Dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -299,8 +299,8 @@ Deprecated or removed
   * Calling `union` with no arguments is deprecated; construct an empty set with an appropriate
     element type using `Set{T}()` instead ([#23144]).
 
-  * Vectorized `DateTime` and `Date` methods have been deprecated in favor of dot-syntax
-    ([#CATS]).
+  * Vectorized `DateTime`, `Date`, and `format` methods have been deprecated in favor of
+    dot-syntax ([#23207]).
 
   * `Base.cpad` has been removed; use an appropriate combination of `rpad` and `lpad`
     instead ([#23187]).
@@ -1160,3 +1160,4 @@ Command-line option changes
 [#23144]: https://github.com/JuliaLang/julia/issues/23144
 [#23157]: https://github.com/JuliaLang/julia/issues/23157
 [#23187]: https://github.com/JuliaLang/julia/issues/23187
+[#23207]: https://github.com/JuliaLang/julia/issues/23207

--- a/NEWS.md
+++ b/NEWS.md
@@ -299,6 +299,8 @@ Deprecated or removed
   * Calling `union` with no arguments is deprecated; construct an empty set with an appropriate
     element type using `Set{T}()` instead ([#23144]).
 
+  * Vectorized `DateTime` methods have been deprecated in favor of dot-syntax ([#CATS]).
+
   * `Base.cpad` has been removed; use an appropriate combination of `rpad` and `lpad`
     instead ([#23187]).
 
@@ -1156,3 +1158,4 @@ Command-line option changes
 [#23117]: https://github.com/JuliaLang/julia/issues/23117
 [#23144]: https://github.com/JuliaLang/julia/issues/23144
 [#23157]: https://github.com/JuliaLang/julia/issues/23157
+[#23187]: https://github.com/JuliaLang/julia/issues/23187

--- a/NEWS.md
+++ b/NEWS.md
@@ -299,7 +299,8 @@ Deprecated or removed
   * Calling `union` with no arguments is deprecated; construct an empty set with an appropriate
     element type using `Set{T}()` instead ([#23144]).
 
-  * Vectorized `DateTime` methods have been deprecated in favor of dot-syntax ([#CATS]).
+  * Vectorized `DateTime` and `Date` methods have been deprecated in favor of dot-syntax
+    ([#CATS]).
 
   * `Base.cpad` has been removed; use an appropriate combination of `rpad` and `lpad`
     instead ([#23187]).

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -559,7 +559,6 @@ function Base.string(dt::Date)
 end
 
 # vectorized
-
 function format(Y::AbstractArray{<:TimeType}, f::AbstractString; locale::Locale=ENGLISH)
     format(Y, DateFormat(f, locale))
 end

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -559,18 +559,6 @@ function Base.string(dt::Date)
 end
 
 # vectorized
-function DateTime(Y::AbstractArray{<:AbstractString}, f::AbstractString; locale::Locale=ENGLISH)
-    DateTime(Y, DateFormat(f, locale))
-end
-function DateTime(Y::AbstractArray{<:AbstractString}, df::DateFormat=ISODateTimeFormat)
-    return reshape(DateTime[parse(DateTime, y, df) for y in Y], size(Y))
-end
-function Date(Y::AbstractArray{<:AbstractString}, f::AbstractString; locale::Locale=ENGLISH)
-    Date(Y, DateFormat(f, locale))
-end
-function Date(Y::AbstractArray{<:AbstractString}, df::DateFormat=ISODateFormat)
-    return reshape(Date[Date(parse(Date, y, df)) for y in Y], size(Y))
-end
 
 function format(Y::AbstractArray{<:TimeType}, f::AbstractString; locale::Locale=ENGLISH)
     format(Y, DateFormat(f, locale))

--- a/base/dates/io.jl
+++ b/base/dates/io.jl
@@ -557,11 +557,3 @@ function Base.string(dt::Date)
     dd = lpad(d, 2, "0")
     return "$yy-$mm-$dd"
 end
-
-# vectorized
-function format(Y::AbstractArray{<:TimeType}, f::AbstractString; locale::Locale=ENGLISH)
-    format(Y, DateFormat(f, locale))
-end
-function format(Y::AbstractArray{T}, df::DateFormat=default_format(T)) where T<:TimeType
-    return reshape([format(y, df) for y in Y], size(Y))
-end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1584,6 +1584,14 @@ for op in (:exp, :exp2, :exp10, :log, :log2, :log10,
     @eval @deprecate ($op)(x::AbstractSparseVector{<:Number,<:Integer}) ($op).(x)
 end
 
+# deprecate reamining vectorized methods from Base.Dates
+@eval Dates @deprecate(
+    DateTime(Y::AbstractArray{<:AbstractString}, f::AbstractString; locale::Locale=ENGLISH),
+    DateTime.(Y, f; locale=locale) )
+@eval Dates @deprecate(
+    DateTime(Y::AbstractArray{<:AbstractString}, df::DateFormat=ISODateTimeFormat),
+    DateTime.(Y, df) )
+
 # PR #22182
 @deprecate is_apple   Sys.isapple
 @deprecate is_bsd     Sys.isbsd

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1591,6 +1591,12 @@ end
 @eval Dates @deprecate(
     DateTime(Y::AbstractArray{<:AbstractString}, df::DateFormat=ISODateTimeFormat),
     DateTime.(Y, df) )
+@eval Dates @deprecate(
+    Date(Y::AbstractArray{<:AbstractString}, f::AbstractString; locale::Locale=ENGLISH),
+    Date.(Y, f; locale=locale) )
+@eval Dates @deprecate(
+    Date(Y::AbstractArray{<:AbstractString}, df::DateFormat=ISODateFormat),
+    Date.(Y, df) )
 
 # PR #22182
 @deprecate is_apple   Sys.isapple

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1584,7 +1584,7 @@ for op in (:exp, :exp2, :exp10, :log, :log2, :log10,
     @eval @deprecate ($op)(x::AbstractSparseVector{<:Number,<:Integer}) ($op).(x)
 end
 
-# deprecate reamining vectorized methods from Base.Dates
+# deprecate remaining vectorized methods from Base.Dates
 @eval Dates @deprecate(
     DateTime(Y::AbstractArray{<:AbstractString}, f::AbstractString; locale::Locale=ENGLISH),
     DateTime.(Y, f; locale=locale) )
@@ -1597,6 +1597,12 @@ end
 @eval Dates @deprecate(
     Date(Y::AbstractArray{<:AbstractString}, df::DateFormat=ISODateFormat),
     Date.(Y, df) )
+@eval Dates @deprecate(
+    format(Y::AbstractArray{<:TimeType}, f::AbstractString; locale::Locale=ENGLISH),
+    format.(Y, f; locale=locale) )
+@eval Dates @deprecate(
+    format(Y::AbstractArray{T}, df::DateFormat=default_format(T)) where {T<:TimeType},
+    format.(Y, df) )
 
 # PR #22182
 @deprecate is_apple   Sys.isapple

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -323,15 +323,15 @@ f = "ymd"
 dr = ["2000-01-01", "2000-01-02", "2000-01-03", "2000-01-04", "2000-01-05",
       "2000-01-06", "2000-01-07", "2000-01-08", "2000-01-09", "2000-01-10"]
 dr2 = [Dates.Date(2000) : Dates.Date(2000, 1, 10);]
-@test Dates.Date(dr) == dr2
-@test Dates.Date(dr, "yyyy-mm-dd") == dr2
+@test Dates.Date.(dr) == dr2
+@test Dates.Date.(dr, "yyyy-mm-dd") == dr2
 @test Dates.DateTime.(dr) == Dates.DateTime.(dr2)
 @test Dates.DateTime.(dr, "yyyy-mm-dd") == Dates.DateTime.(dr2)
 
 @test Dates.format(dr2) == dr
 @test Dates.format(dr2, "yyyy-mm-dd") == dr
 
-@test typeof(Dates.Date(dr)) == Array{Date, 1}
+@test typeof(Dates.Date.(dr)) == Array{Date, 1}
 
 # Issue 13
 t = Dates.DateTime(1, 1, 1, 14, 51, 0, 118)

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -326,7 +326,7 @@ dr2 = [Dates.Date(2000) : Dates.Date(2000, 1, 10);]
 @test Dates.Date(dr) == dr2
 @test Dates.Date(dr, "yyyy-mm-dd") == dr2
 @test Dates.DateTime.(dr) == Dates.DateTime.(dr2)
-@test Dates.DateTime(dr, "yyyy-mm-dd") == Dates.DateTime.(dr2)
+@test Dates.DateTime.(dr, "yyyy-mm-dd") == Dates.DateTime.(dr2)
 
 @test Dates.format(dr2) == dr
 @test Dates.format(dr2, "yyyy-mm-dd") == dr

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -319,14 +319,14 @@ f = "ymd"
 @test Dates.Date(string(Dates.Date(dt))) == Dates.Date(dt)
 @test Dates.DateTime(string(dt)) == dt
 
-# Vectorized
+# formerly vectorized Date/DateTime/format methods
 dr = ["2000-01-01", "2000-01-02", "2000-01-03", "2000-01-04", "2000-01-05",
       "2000-01-06", "2000-01-07", "2000-01-08", "2000-01-09", "2000-01-10"]
 dr2 = [Dates.Date(2000) : Dates.Date(2000, 1, 10);]
 @test Dates.Date.(dr) == dr2
-@test Dates.Date.(dr, "yyyy-mm-dd") == dr2
+@test Dates.Date.(dr, dateformat"yyyy-mm-dd") == dr2
 @test Dates.DateTime.(dr) == Dates.DateTime.(dr2)
-@test Dates.DateTime.(dr, "yyyy-mm-dd") == Dates.DateTime.(dr2)
+@test Dates.DateTime.(dr, dateformat"yyyy-mm-dd") == Dates.DateTime.(dr2)
 
 @test Dates.format.(dr2, "yyyy-mm-dd") == dr
 

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -328,8 +328,7 @@ dr2 = [Dates.Date(2000) : Dates.Date(2000, 1, 10);]
 @test Dates.DateTime.(dr) == Dates.DateTime.(dr2)
 @test Dates.DateTime.(dr, "yyyy-mm-dd") == Dates.DateTime.(dr2)
 
-@test Dates.format(dr2) == dr
-@test Dates.format(dr2, "yyyy-mm-dd") == dr
+@test Dates.format.(dr2, "yyyy-mm-dd") == dr
 
 @test typeof(Dates.Date.(dr)) == Array{Date, 1}
 


### PR DESCRIPTION
This pull request gleefully deprecates a few vectorized methods that were hiding in `Dates`. Addresses #23167. Best!