### PR TITLE
fix #23236; dot operator in comprehension

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1707,6 +1707,7 @@
     (if (and (null? splat)
              (length= expr 3) (eq? (car expr) 'call)
              (eq? (caddr expr) argname)
+             (not (dotop? (cadr expr)))
              (not (expr-contains-eq argname (cadr expr))))
         (cadr expr)  ;; eta reduce `x->f(x)` => `f`
         `(-> ,argname (block ,@splat ,expr)))))

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -247,6 +247,11 @@ let x = [1:4;]
     @test sin.(f17300kw.(x, y=1)) == sin.(f17300kw.(x; y=1)) == sin.(x .+ 1)
 end
 
+# issue #23236
+let X = [[true,false],[false,true]]
+    @test [.!x for x in X] == [[false,true],[true,false]]
+end
+
 # splice escaping of @.
 let x = [4, -9, 1, -16]
     @test [2, 3, 4, 5] == @.(1 + sqrt($sort(abs(x))))


### PR DESCRIPTION
Comprehension eta-reduction needs to know that dot operators are not function names.