### PR TITLE
fix macroexpansion scope miscalculation

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -4989,7 +4989,7 @@ let a_foo = Foo22256(Bar22256{true}(2))
     @test a_foo.bar.inner == 3
 end
 
-# macro hygiene scope (#22307)
+# macro hygiene scope (#22307, #23239)
 macro a22307()
     return esc(:a22307)
 end
@@ -5002,6 +5002,36 @@ function c22307()
 end
 a22307 = 2
 @test c22307() == 2
+
+macro identity23239b(x)
+    return esc(x)
+end
+macro identity23239c(x)
+    return quote
+        $(esc(x))
+    end
+end
+macro assign23239d(x, v)
+    return esc(:($x = $v))
+end
+macro assign23239e(x, v)
+    return quote
+        $(esc(:($x = $v)))
+    end
+end
+macro aa23239()
+    return quote
+        a = 1
+        @identity23239b b = 2
+        @identity23239c c = 3
+        @assign23239d d 4
+        @assign23239e e 5
+        (a, b, c, d, e)
+    end
+end
+f23239() = @aa23239()
+@test @inferred(f23239()) === (1, 2, 3, 4, 5)
+
 
 # issue #22026
 module M22026

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -771,19 +771,29 @@ macro iter()
 end
 end
 let ex = expand(M16096, :(@iter))
-    @test isa(ex, Expr) && ex.head === :body
+    @test isa(ex, Expr) && ex.head === :thunk
 end
 let ex = expand(Main, :($M16096.@iter))
-    @test isa(ex, Expr) && ex.head === :body
+    @test isa(ex, Expr) && ex.head === :thunk
 end
-let ex = expand(@__MODULE__, :(@M16096.iter))
-    @test isa(ex, Expr) && ex.head === :body
+let thismodule = @__MODULE__,
+    ex = expand(thismodule, :(@M16096.iter))
+    @test isa(ex, Expr) && ex.head === :thunk
     @test !isdefined(M16096, :foo16096)
-    @test eval(@__MODULE__, ex) === nothing
+    local_foo16096 = eval(@__MODULE__, ex)
+    @test local_foo16096(2.0) == 1
     @test !@isdefined foo16096
-    @test isdefined(M16096, :foo16096)
+    @test !@isdefined it
+    @test !isdefined(M16096, :foo16096)
+    @test !isdefined(M16096, :it)
+    @test typeof(local_foo16096).name.module === thismodule
+    @test typeof(local_foo16096).name.mt.module === thismodule
+    @test getfield(thismodule, typeof(local_foo16096).name.mt.name) === local_foo16096
+    @test getfield(thismodule, typeof(local_foo16096).name.name) === typeof(local_foo16096)
+    @test !isdefined(M16096, typeof(local_foo16096).name.mt.name)
+    @test !isdefined(M16096, typeof(local_foo16096).name.name)
 end
-@test M16096.foo16096(2.0) == 1
+
 macro f16096()
     quote
         g16096($(esc(:x))) = 2x
@@ -794,7 +804,7 @@ let g = @f16096
 end
 macro f16096_2()
     quote
-        g16096_2(;$(esc(:x))=2) = 2x
+        g16096_2(; $(esc(:x))=2) = 2x
     end
 end
 let g = @f16096_2


### PR DESCRIPTION
previously, we were treating hygienic-scope as also introducing a new scope-block
that was wrong (and inconsistent with previous behavior)

also, we were failing to set the outermost flag when entering a
hygienic-scope block, further compounding the above error

fix #23239