### PR TITLE
Add should_resolve kw to pin

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -289,9 +289,8 @@ function free(pkgs)
     end
 end
 
-function pin(pkg::AbstractString, head::AbstractString)
+function pin(pkg::AbstractString, head::AbstractString; should_resolve = true)
     ispath(pkg,".git") || throw(PkgError("$pkg is not a git repo"))
-    should_resolve = true
     with(GitRepo, pkg) do repo
         id = if isempty(head) # get HEAD commit
             # no need to resolve, branch will be from HEAD
@@ -338,15 +337,15 @@ function pin(pkg::AbstractString, head::AbstractString)
     should_resolve && resolve()
     nothing
 end
-pin(pkg::AbstractString) = pin(pkg, "")
+pin(pkg::AbstractString; should_resolve = true) = pin(pkg, "", should_resolve = should_resolve)
 
-function pin(pkg::AbstractString, ver::VersionNumber)
+function pin(pkg::AbstractString, ver::VersionNumber; should_resolve = true)
     ispath(pkg,".git") || throw(PkgError("$pkg is not a git repo"))
     Read.isinstalled(pkg) || throw(PkgError("$pkg cannot be pinned – not an installed package"))
     avail = Read.available(pkg)
     isempty(avail) && throw(PkgError("$pkg cannot be pinned – not a registered package"))
     haskey(avail,ver) || throw(PkgError("$pkg – $ver is not a registered version"))
-    pin(pkg, avail[ver].sha1)
+    pin(pkg, avail[ver].sha1, should_resolve = should_resolve)
 end
 
 function update(branch::AbstractString, upkgs::Set{String})

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -201,12 +201,15 @@ You can also supply an iterable collection of package names, e.g., `Pkg.free(("P
 free(pkg) = cd(Entry.free,splitjl.(pkg))
 
 """
-    pin(pkg)
+    pin(pkg; should_resolve = true)
 
 Pin `pkg` at the current version. To go back to using the newest compatible released
-version, use `Pkg.free(pkg)`
+version, use `Pkg.free(pkg)`. Set `should_resolve` to false to disable resolution after
+pinning.
 """
-pin(pkg::AbstractString) = cd(Entry.pin,splitjl(pkg))
+pin(pkg::AbstractString; should_resolve = true) = cd(splitjl(pkg)) do splitpkg
+    Entry.pin(splitpkg, should_resolve = should_resolve)
+end
 
 """
     pin(pkg, version)


### PR DESCRIPTION
Should allow suppression of version resolution after pinning, which I think will solve some bugs in my experiments in automatic version bounding.