### PR TITLE
[release-0.6] win: avoid stack overflow in initial deserialization

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -94,7 +94,7 @@ jl_get_ptls_states_func jl_get_ptls_states_getter(void)
 // Apparently windows doesn't have a static TLS model (or one that can be
 // reliably used from a shared library) either..... Use `TLSAlloc` instead.
 
-static DWORD jl_tls_key;
+DWORD jl_tls_key;
 
 // Put this here for now. We can move this out later if we find more use for it.
 BOOLEAN WINAPI DllMain(IN HINSTANCE hDllHandle, IN DWORD nReason,


### PR DESCRIPTION
fix #22866 [release-0.6 only]