### PR TITLE
diag of SparseMatrixCSC should always return SparseVector

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -312,6 +312,8 @@ Deprecated or removed
   * `Base.cpad` has been removed; use an appropriate combination of `rpad` and `lpad`
     instead ([#23187]).
 
+  * `Base.SparseArrays.SpDiagIterator` has been removed ([#23261]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -879,7 +879,7 @@ for f in (:\, :Ac_ldiv_B, :At_ldiv_B)
             if m == n
                 if istril(A)
                     if istriu(A)
-                        return ($f)(Diagonal(A), B)
+                        return ($f)(Diagonal(Vector(diag(A))), B)
                     else
                         return ($f)(LowerTriangular(A), B)
                     end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -3412,8 +3412,6 @@ function trace(A::SparseMatrixCSC{Tv}) where Tv
     s
 end
 
-diag(A::SparseMatrixCSC{Tv}) where {Tv} = Tv[d for d in SpDiagIterator(A)]
-
 function diagm(v::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     if size(v,1) != 1 && size(v,2) != 1
         throw(DimensionMismatch("input should be nx1 or 1xn"))

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -3383,11 +3383,12 @@ end
 
 function diag(A::SparseMatrixCSC{Tv,Ti}, d::Integer=0) where {Tv,Ti}
     m, n = size(A)
-    if !(-m <= d <= n)
-        throw(ArgumentError("requested diagonal, $d, out of bounds in matrix of size ($m, $n)"))
+    k = Int(d)
+    if !(-m <= k <= n)
+        throw(ArgumentError("requested diagonal, $k, out of bounds in matrix of size ($m, $n)"))
     end
-    l = d < 0 ? min(m+d,n) : min(n-d,m)
-    r, c = d <= 0 ? (-d, 0) : (0, d) # start row/col -1
+    l = k < 0 ? min(m+k,n) : min(n-k,m)
+    r, c = k <= 0 ? (-k, 0) : (0, k) # start row/col -1
     ind = Vector{Ti}()
     val = Vector{Tv}()
     for i in 1:l

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -3381,21 +3381,17 @@ function expandptr(V::Vector{<:Integer})
 end
 
 
-function diag(A::SparseMatrixCSC{Tv,Ti}, d::Int=0) where {Tv,Ti}
+function diag(A::SparseMatrixCSC{Tv,Ti}, d::Integer=0) where {Tv,Ti}
     m, n = size(A)
     if !(-m <= d <= n)
         throw(ArgumentError("requested diagonal, $d, out of bounds in matrix of size ($m, $n)"))
     end
-    if d <= 0
-        rrange = (1-d):min(m, min(m,n)-d)
-        crange = 1:min(n, m+d)
-    else # d > 0
-        rrange = 1:min(m, n-d)
-        crange = (1+d):min(n, min(m,n)+d)
-    end
+    l = d < 0 ? min(m+d,n) : min(n-d,m)
+    r, c = d <= 0 ? (-d, 0) : (0, d) # start row/col -1
     ind = Vector{Ti}()
     val = Vector{Tv}()
-    for (i, (r, c)) in enumerate(zip(rrange, crange))
+    for i in 1:l
+        r += 1; c += 1
         r1 = Int(A.colptr[c])
         r2 = Int(A.colptr[c+1]-1)
         r1 > r2 && continue
@@ -3404,7 +3400,7 @@ function diag(A::SparseMatrixCSC{Tv,Ti}, d::Int=0) where {Tv,Ti}
         push!(ind, i)
         push!(val, A.nzval[r1])
     end
-    return SparseVector{Tv,Ti}(length(rrange), ind, val)
+    return SparseVector{Tv,Ti}(l, ind, val)
 end
 
 function trace(A::SparseMatrixCSC{Tv}) where Tv

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1323,6 +1323,16 @@ end
     @test diagm(sparse(ones(5,1))) == speye(5)
 end
 
+@testset "diag" begin
+    for T in (Float64, Complex128)
+        S = sprand(T, 5, 5, 0.5)
+        A = Matrix(S)
+        @test diag(S)::SparseVector{T,Int}     == diag(A)
+        @test diag(S, 1)::SparseVector{T,Int}  == diag(A, 1)
+        @test diag(S, -1)::SparseVector{T,Int} == diag(A, -1)
+    end
+end
+
 @testset "expandptr" begin
     A = speye(5)
     @test Base.SparseArrays.expandptr(A.colptr) == collect(1:5)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1325,11 +1325,18 @@ end
 
 @testset "diag" begin
     for T in (Float64, Complex128)
-        S = sprand(T, 5, 5, 0.5)
-        A = Matrix(S)
-        @test diag(S)::SparseVector{T,Int}     == diag(A)
-        @test diag(S, 1)::SparseVector{T,Int}  == diag(A, 1)
-        @test diag(S, -1)::SparseVector{T,Int} == diag(A, -1)
+        S1 = sprand(T,  5,  5, 0.5)
+        S2 = sprand(T, 10,  5, 0.5)
+        S3 = sprand(T,  5, 10, 0.5)
+        for S in (S1, S2, S3)
+            A = Matrix(S)
+            @test diag(S)::SparseVector{T,Int}  == diag(A)
+            for k in -5:5
+                @test diag(S, k)::SparseVector{T,Int}  == diag(A, k)
+            end
+            @test_throws ArgumentError diag(S, -size(S,1)-1)
+            @test_throws ArgumentError diag(S,  size(S,2)+1)
+        end
     end
 end
 

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1331,7 +1331,7 @@ end
         for S in (S1, S2, S3)
             A = Matrix(S)
             @test diag(S)::SparseVector{T,Int}  == diag(A)
-            for k in -5:5
+            for k in -size(S,1):size(S,2)
                 @test diag(S, k)::SparseVector{T,Int}  == diag(A, k)
             end
             @test_throws ArgumentError diag(S, -size(S,1)-1)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1330,9 +1330,9 @@ end
         S3 = sprand(T,  5, 10, 0.5)
         for S in (S1, S2, S3)
             A = Matrix(S)
-            @test diag(S)::SparseVector{T,Int}  == diag(A)
+            @test diag(S)::SparseVector{T,Int} == diag(A)
             for k in -size(S,1):size(S,2)
-                @test diag(S, k)::SparseVector{T,Int}  == diag(A, k)
+                @test diag(S, k)::SparseVector{T,Int} == diag(A, k)
             end
             @test_throws ArgumentError diag(S, -size(S,1)-1)
             @test_throws ArgumentError diag(S,  size(S,2)+1)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1338,6 +1338,10 @@ end
             @test_throws ArgumentError diag(S,  size(S,2)+1)
         end
     end
+    # test that stored zeros are still stored zeros in the diagonal
+    S = sparse([1,3],[1,3],[0.0,0.0]); V = diag(S)
+    @test V.nzind == [1,3]
+    @test V.nzval == [0.0,0.0]
 end
 
 @testset "expandptr" begin


### PR DESCRIPTION
`diag(A::SparseMatrixCSC, k::Int=0)` now dispatches [here](https://github.com/JuliaLang/julia/blob/3f86c1a3137bca611c7637715be194bb811a6af8/base/linalg/dense.jl#L279) and then to getindex for sparse matrices. Will do some benchmarking if it is worth updating `SpDiagIterator`, or keep it as is.

fix JuliaLang/LinearAlgebra.jl#411