### PR TITLE
RFC: Add similar for PermutedDimsArray

### DIFF
--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -186,4 +186,19 @@ end
     P
 end
 
+function Base.similar(a::PermutedDimsArray{T,N,perm,iperm}, ::Type{S}) where {T,S,N,perm,iperm}
+    new_parent = similar(a.parent, S)
+    PermutedDimsArray{S,N,perm,iperm,typeof(new_parent)}(new_parent)
+end
+
+function Base.similar(a::PermutedDimsArray{T,N,perm,iperm}, ::Type{S}, dims::Dims{N}) where {T,S,N,perm,iperm}
+    new_parent = similar(a.parent, S, ntuple(i->dims[perm[i]], N))
+    PermutedDimsArray{S,N,perm,iperm,typeof(new_parent)}(new_parent)
+end
+
+function Base.similar(a::PermutedDimsArray{T,N,perm,iperm}, dims::Dims{N}) where {T,N,perm,iperm}
+    new_parent = similar(a.parent, ntuple(i->dims[perm[i]], N))
+    PermutedDimsArray{T,N,perm,iperm,typeof(new_parent)}(new_parent)
+end
+
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -546,6 +546,11 @@ end
     @test strides(cp) == (9,3,1)
     ap = PermutedDimsArray(collect(a), (2,1,3))
     @test strides(ap) == (3,1,12)
+    @test isa(similar(ap, Float64), PermutedDimsArray{Float64, 3})
+    @test size(similar(ap, (10, 11, 12))) == (10, 11, 12)
+    sap = similar(ap, Float64, (10, 11, 12))
+    @test isa(sap, PermutedDimsArray{Float64, 3})
+    @test size(sap.parent) == (11, 10, 12)
 
     for A in [rand(1,2,3,4),rand(2,2,2,2),rand(5,6,5,6),rand(1,1,1,1)]
         perm = randperm(4)


### PR DESCRIPTION
This allows you to do things like:
```
julia> A = [1 2 3;4 5 6]
2×3 Array{Int64,2}:
 1  2  3
 4  5  6

julia> X = PermutedDimsArray(A, [2,1])
3×2 PermutedDimsArray{Int64,2,(2, 1),(2, 1),Array{Int64,2}}:
 1  4
 2  5
 3  6

julia> Y = Base.collect_similar(X, (x for x in Any[1 2.0; 3 4; 4 6]))
3×2 PermutedDimsArray{Real,2,(2, 1),(2, 1),Array{Real,2}}:
 1  2.0
 3  4
 4  6

julia> Y.parent
2×3 Array{Real,2}:
 1    3  4
 2.0  4  6
```
In particular I wanted for collecting into an array from an iterator that yielded its elements in transposed order, but it seems like a sensible definition regardless.