### PR TITLE
hex2bytes for Vector{UInt8}

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -762,6 +762,7 @@ export
     graphemes,
     hex,
     hex2bytes,
+    hex2bytes!,
     ind2chr,
     info,
     is_assigned_char,

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -495,7 +495,7 @@ julia> s = UInt8["01abEF"...]
  0x45
  0x46
 
-julia> d =zeros(UInt8, 3)
+julia> d = zeros(UInt8, 3)
 3-element Array{UInt8,1}:
  0x00
  0x00

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -482,6 +482,33 @@ Convert the first `n` hexadecimal bytes array to its binary representation. The
 results are populated into a destination array. The function returns the number of bytes
 copied into the destination array. The size of destination array must be at least half
 of the `n` parameter.
+
+# Examples
+```
+    julia> s = UInt8["01abEF"...]
+    6-element Array{UInt8,1}:
+     0x30
+     0x31
+     0x61
+     0x62
+     0x45
+     0x46
+
+    julia> d =zeros(UInt8, 3)
+    3-element Array{UInt8,1}:
+     0x00
+     0x00
+     0x00
+
+    julia> hex2bytes!(d, s, 6)
+    3
+
+    julia> d
+    3-element Array{UInt8,1}:
+     0x01
+     0xab
+     0xef
+```
 """
 function hex2bytes!(d::Vector{UInt8}, s::Vector{UInt8}, n::Int=length(s))
     if isodd(n)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -466,8 +466,11 @@ end
 """
     hex2bytes(s::AbstractVector{UInt8})
 
-Convert the hexadecimal bytes array to its binary representation. Returns
-`Vector{UInt8}`, i.e. a vector of bytes.
+Given an array `s` of ASCII codes for a sequence of hexadecimal digits, returns a
+`Vector{UInt8}` of bytes  corresponding to the binary representation: each successive pair
+of hexadecimal digits in `s` gives the value of one byte in the return vector.
+
+The length of `s` must be even, and the returned array has half of the length of `s`.
 """
 @inline function hex2bytes(s::AbstractVector{UInt8})
     len = length(s)
@@ -481,12 +484,13 @@ end
 """
     hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
 
-Converts the hexadecimal bytes vector to its binary representation. The results are
-populated into a destination vector. The function returns the destination vector.
+Convert an array `s` of bytes representing a hexadecimal string to its binary
+representation, similar to [`hex2bytes`](@ref) except that the output is written in-place
+in `d`.   The length of `s` must be exactly twice the length of `d`.
 
 # Examples
 ```jldoctest
-julia> s = UInt8["01abEF"...]
+julia> s = b"01abEF"
 6-element Array{UInt8,1}:
  0x30
  0x31

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -478,8 +478,7 @@ end
     hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
 
 Convert the hexadecimal bytes vector to its binary representation. The results are
-populated into a destination vector. The function returns the number of bytes copied
-into the destination vector.
+populated into a destination vector. The function returns the destination vector.
 
 # Examples
 ```jldoctest

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -470,7 +470,11 @@ Convert the hexadecimal bytes array to its binary representation. Returns
 `Vector{UInt8}`, i.e. a vector of bytes.
 """
 @inline function hex2bytes(s::AbstractVector{UInt8})
-    d = zeros(UInt8, div(endof(s), 2))
+    len = length(s)
+    if isodd(len)
+        throw(ArgumentError("source vector length must be even"))
+    end
+    d = zeros(UInt8, div(len, 2))
     return hex2bytes!(d, s)
 end
 
@@ -521,7 +525,6 @@ function hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
         n += number_from_hex(c2)
         d[j+=1] = (n & 0xFF)
     end
-    resize!(d, j)
     return d
 end
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -466,11 +466,11 @@ end
 """
     hex2bytes(s::AbstractVector{UInt8})
 
-Convert the hexadecimal bytes array to its binary representation. Returns an
+Convert the hexadecimal bytes array to its binary representation. Returns
 `Vector{UInt8}`, i.e. a vector of bytes.
 """
 @inline function hex2bytes(s::AbstractVector{UInt8})
-    d = Vector{UInt8}(div(length(s), 2))
+    d = zeros(UInt8, div(endof(s), 2))
     return hex2bytes!(d, s)
 end
 
@@ -479,34 +479,33 @@ end
 
 Convert the hexadecimal bytes vector to its binary representation. The results are
 populated into a destination vector. The function returns the number of bytes copied
-into the destination array. The size of destination array must be half of the source
-vector. `@view` macro can be used to pass `SubArray`s as arguments.
+into the destination vector.
 
 # Examples
-```
-    julia> s = UInt8["01abEF"...]
-    6-element Array{UInt8,1}:
-     0x30
-     0x31
-     0x61
-     0x62
-     0x45
-     0x46
+```jldoctest
+julia> s = UInt8["01abEF"...]
+6-element Array{UInt8,1}:
+ 0x30
+ 0x31
+ 0x61
+ 0x62
+ 0x45
+ 0x46
 
-    julia> d =zeros(UInt8, 3)
-    3-element Array{UInt8,1}:
-     0x00
-     0x00
-     0x00
+julia> d =zeros(UInt8, 3)
+3-element Array{UInt8,1}:
+ 0x00
+ 0x00
+ 0x00
 
-    julia> hex2bytes!(d, s)
-    3
+julia> hex2bytes!(d, s)
+3
 
-    julia> d
-    3-element Array{UInt8,1}:
-     0x01
-     0xab
-     0xef
+julia> d
+3-element Array{UInt8,1}:
+ 0x01
+ 0xab
+ 0xef
 ```
 """
 function hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
@@ -550,7 +549,6 @@ end
 
 Convert an array of bytes to its hexadecimal representation.
 All characters are in lower-case.
-it
 # Examples
 ```jldoctest
 julia> a = hex(12345)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -499,9 +499,6 @@ julia> d =zeros(UInt8, 3)
  0x00
 
 julia> hex2bytes!(d, s)
-3
-
-julia> d
 3-element Array{UInt8,1}:
  0x01
  0xab

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -477,7 +477,7 @@ end
 """
     hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
 
-Convert the hexadecimal bytes vector to its binary representation. The results are
+Converts the hexadecimal bytes vector to its binary representation. The results are
 populated into a destination vector. The function returns the destination vector.
 
 # Examples
@@ -514,8 +514,7 @@ function hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
     while !done(s, i)
         n = 0
         c1, i = next(s, i)
-        done(s, i) && throw(ArgumentError(
-            "string length must be even: length($(repr(s))) == $(length(s))"))
+        done(s, i) && throw(ArgumentError("source vector length must be even"))
         c2, i = next(s, i)
         n = number_from_hex(c1)
         n <<= 4
@@ -537,7 +536,7 @@ end
     return (DIGIT_ZERO <= c <= DIGIT_NINE) ? c - DIGIT_ZERO :
         (LATIN_UPPER_A <= c <= LATIN_UPPER_F) ? c - LATIN_UPPER_A + 10 :
         (LATIN_A <= c <= LATIN_F) ? c - LATIN_A + 10 :
-        throw(ArgumentError("Not a hexadecimal number"))
+        throw(ArgumentError("not a hexadecimal number: '$(Char(c))'"))
 end
 
 """

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -463,12 +463,7 @@ julia> hex2bytes(a)
 function hex2bytes end
 
 hex2bytes(s::AbstractString) = hex2bytes(Vector{UInt8}(String(s)))
-
-function hex2bytes(s::AbstractVector{UInt8})
-    len = length(s)
-    isodd(len) && throw(ArgumentError("source vector length must be even"))
-    return hex2bytes!(Vector{UInt8}(len >> 1), s)
-end
+hex2bytes(s::AbstractVector{UInt8}) = hex2bytes!(Vector{UInt8}(length(s) >> 1), s)
 
 """
     hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -482,8 +482,8 @@ function hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
         isodd(length(s)) && throw(ArgumentError("input hex array must have even length"))
         throw(ArgumentError("output array must be half length of input array"))
     end
-    j = start(d) - 1
-    for i = start(s):2:endof(s)
+    j = first(eachindex(d)) - 1
+    for i = first(eachindex(s)):2:endof(s)
         @inbounds d[j += 1] = number_from_hex(s[i]) << 4 + number_from_hex(s[i+1])
     end
     return d

--- a/doc/src/stdlib/numbers.md
+++ b/doc/src/stdlib/numbers.md
@@ -59,6 +59,7 @@ Base.Math.exponent
 Base.complex(::Complex)
 Base.bswap
 Base.hex2bytes
+Base.hex2bytes!
 Base.bytes2hex
 ```
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -247,3 +247,24 @@ bin_val = hex2bytes("07bf")
 
 #non-hex characters
 @test_throws ArgumentError hex2bytes("0123456789abcdefABCDEFGH")
+
+function test_23161()
+    arr = UInt8["0123456789abcdefABCDEF"...]
+    arr1 = Vector{UInt8}(11)
+    @test hex2bytes!(arr1, arr) == 11
+    @test "0123456789abcdefabcdef" == bytes2hex(arr1)
+    @test hex2bytes("0123456789abcdefABCDEF") == hex2bytes(arr)
+    @test hex2bytes!(arr1, UInt8[""...]) == 0
+    @test hex2bytes(UInt8[""...]) == UInt8[]
+
+    # odd size
+    @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEF0"...])
+
+    # Input array size smaller than the number of bytes to be converted.
+    @test_throws ArgumentError hex2bytes!(arr1, arr, 24)
+
+    #non-hex characters
+    @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEFGH"...])
+end
+
+test_23161()

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -251,17 +251,14 @@ bin_val = hex2bytes("07bf")
 function test_23161()
     arr = UInt8["0123456789abcdefABCDEF"...]
     arr1 = Vector{UInt8}(11)
-    @test hex2bytes!(arr1, arr) == 11
+    @test hex2bytes!(arr1, arr) == arr1
     @test "0123456789abcdefabcdef" == bytes2hex(arr1)
     @test hex2bytes("0123456789abcdefABCDEF") == hex2bytes(arr)
-    @test hex2bytes!(arr1, UInt8[""...]) == 0
+    @test hex2bytes!(arr1, UInt8[""...]) == arr1
     @test hex2bytes(UInt8[""...]) == UInt8[]
 
     # odd size
     @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEF0"...])
-
-    # Input array size smaller than the number of bytes to be converted.
-    @test_throws ArgumentError hex2bytes!(arr1, arr, 24)
 
     #non-hex characters
     @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEFGH"...])

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -249,22 +249,22 @@ bin_val = hex2bytes("07bf")
 @test_throws ArgumentError hex2bytes("0123456789abcdefABCDEFGH")
 
 @testset "Issue 23161" begin
-    arr = UInt8["0123456789abcdefABCDEF"...]
+    arr = b"0123456789abcdefABCDEF"
     arr1 = Vector{UInt8}(11)
     @test hex2bytes!(arr1, arr) == arr1
     @test "0123456789abcdefabcdef" == bytes2hex(arr1)
     @test hex2bytes("0123456789abcdefABCDEF") == hex2bytes(arr)
-    @test hex2bytes!(arr1, UInt8[""...]) == arr1
-    @test hex2bytes(UInt8[""...]) == UInt8[]
-    @test hex2bytes(view(UInt8["012345"...],1:6)) == UInt8[0x01,0x23,0x45]
+    @test hex2bytes!(arr1, b"") == arr1
+    @test hex2bytes(b"") == UInt8[]
+    @test hex2bytes(view(b"012345",1:6)) == UInt8[0x01,0x23,0x45]
     @test begin
-        s = view(UInt8["012345ab"...],1:6)
+        s = view(b"012345ab",1:6)
         d = view(zeros(UInt8, 10),1:3)
         hex2bytes!(d,s) == UInt8[0x01,0x23,0x45]
     end
     # odd size
-    @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEF0"...])
+    @test_throws ArgumentError hex2bytes(b"0123456789abcdefABCDEF0")
 
     #non-hex characters
-    @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEFGH"...])
+    @test_throws ArgumentError hex2bytes(b"0123456789abcdefABCDEFGH")
 end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -256,7 +256,12 @@ bin_val = hex2bytes("07bf")
     @test hex2bytes("0123456789abcdefABCDEF") == hex2bytes(arr)
     @test hex2bytes!(arr1, UInt8[""...]) == arr1
     @test hex2bytes(UInt8[""...]) == UInt8[]
-
+    @test hex2bytes(view(UInt8["012345"...],1:6)) == UInt8[0x01,0x23,0x45]
+    @test begin
+        s = view(UInt8["012345ab"...],1:6)
+        d = view(zeros(UInt8, 10),1:3)
+        hex2bytes!(d,s) == UInt8[0x01,0x23,0x45]
+    end
     # odd size
     @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEF0"...])
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -248,7 +248,7 @@ bin_val = hex2bytes("07bf")
 #non-hex characters
 @test_throws ArgumentError hex2bytes("0123456789abcdefABCDEFGH")
 
-function test_23161()
+@testset "Issue 23161" begin
     arr = UInt8["0123456789abcdefABCDEF"...]
     arr1 = Vector{UInt8}(11)
     @test hex2bytes!(arr1, arr) == arr1
@@ -263,5 +263,3 @@ function test_23161()
     #non-hex characters
     @test_throws ArgumentError hex2bytes(UInt8["0123456789abcdefABCDEFGH"...])
 end
-
-test_23161()

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -250,11 +250,11 @@ bin_val = hex2bytes("07bf")
 
 @testset "Issue 23161" begin
     arr = b"0123456789abcdefABCDEF"
-    arr1 = Vector{UInt8}(11)
-    @test hex2bytes!(arr1, arr) == arr1
+    arr1 = Vector{UInt8}(length(arr) >> 1)
+    @test hex2bytes!(arr1, arr) === arr1 # check in-place
     @test "0123456789abcdefabcdef" == bytes2hex(arr1)
     @test hex2bytes("0123456789abcdefABCDEF") == hex2bytes(arr)
-    @test hex2bytes!(arr1, b"") == arr1
+    @test_throws ArgumentError hex2bytes!(arr1, b"") # incorrect arr1 length
     @test hex2bytes(b"") == UInt8[]
     @test hex2bytes(view(b"012345",1:6)) == UInt8[0x01,0x23,0x45]
     @test begin


### PR DESCRIPTION
`function hex2bytes(d::Vector{UInt8}, s::Vector{UInt8}, nInBytes::Int=length(s)) -> Int`

1. The loop is not optimized for SIMD as the branching in the internal loops is too high
2. Computation is carried out on the word boundary. 

Benchmark numbers attached:

```
julia> @benchmark f_hsS_NOSIMD()   <- hex2bytes(::AbstractString)
BenchmarkTools.Trial: 
  memory estimate:  5.00 MiB
  allocs estimate:  2
  --------------
  minimum time:     56.887 ms (0.00% GC)
  median time:      58.451 ms (0.00% GC)
  mean time:        58.693 ms (0.16% GC)
  maximum time:     65.453 ms (0.00% GC)
  --------------
  samples:          86
  evals/sample:     1

julia> 

julia> @benchmark f_hsB_NOSIMD()
BenchmarkTools.Trial: 
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     43.811 ms (0.00% GC)
  median time:      44.620 ms (0.00% GC)
  mean time:        44.876 ms (0.00% GC)
  maximum time:     50.646 ms (0.00% GC)
  --------------
  samples:          112
  evals/sample:     1

julia> @benchmark f_hsB_SIMD()
BenchmarkTools.Trial: 
  memory estimate:  16 bytes
  allocs estimate:  1
  --------------
  minimum time:     44.923 ms (0.00% GC)
  median time:      45.786 ms (0.00% GC)
  mean time:        46.127 ms (0.00% GC)
  maximum time:     53.770 ms (0.00% GC)
  --------------
  samples:          109
  evals/sample:     1

```

Fix #23161