### PR TITLE
RFC / WIP: no longer warn in code_warntype for variables not used in the body

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -347,14 +347,35 @@ problematic for performance, so the results need to be used judiciously.
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
 function code_warntype(io::IO, f, @nospecialize(t))
+    function slots_used(ci, slotnames)
+        used = falses(length(slotnames))
+        scan_exprs!(used, ci.code)
+        return used
+    end
+
+    function scan_exprs!(used, exprs)
+        for ex in exprs
+            if isa(ex, Slot)
+                used[ex.id] = true
+            elseif isa(ex, Expr)
+                scan_exprs!(used, ex.args)
+            end
+        end
+    end
+
     emph_io = IOContext(io, :TYPEEMPHASIZE => true)
     for (src, rettype) in code_typed(f, t)
         println(emph_io, "Variables:")
         slotnames = sourceinfo_slotnames(src)
+        used_slotids = slots_used(src, slotnames)
         for i = 1:length(slotnames)
             print(emph_io, "  ", slotnames[i])
-            if isa(src.slottypes, Array)
-                show_expr_type(emph_io, src.slottypes[i], true)
+            if used_slotids[i]
+                if isa(src.slottypes, Array)
+                    show_expr_type(emph_io, src.slottypes[i], true)
+                end
+            else
+                print(emph_io, " <optimized out>")
             end
             print(emph_io, '\n')
         end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -92,6 +92,11 @@ show(iob, expand(Main, :(x -> x^2)))
 str = String(take!(iob))
 @test isempty(search(str, tag))
 
+# Make sure non used variables are not emphasized
+has_unused() = (a = rand(5))
+@test !warntype_hastag(has_unused, Tuple{}, tag)
+@test warntype_hastag(has_unused, Tuple{}, "<optimized out>")
+
 module ImportIntrinsics15819
 # Make sure changing the lookup path of an intrinsic doesn't break
 # the heuristic for type instability warning.


### PR DESCRIPTION
The fact that `@code_warntype` shows unused variables in red is something that keeps tripping up users (both new and experienced), see e.g. https://discourse.julialang.org/t/question-about-type-stability-of-arrays-in-julia-0-6/5389.

This PR traverses the codeinfo to check if the variable is actually used somewhere in the body. If not, we no longer print the variable in red even if it is inferred as a non concrete type. 

Before:

![image](https://user-images.githubusercontent.com/1282691/29356286-0ebfa9a8-8274-11e7-8e12-f910d14f8aa3.png)

After:

![image](https://user-images.githubusercontent.com/1282691/29356292-13aeb90e-8274-11e7-9821-047e7e6356f4.png)


Maybe the `(Unused in body)` is too verbose?

Will add test / docs later if people think this is a good idea. Also, I'm new to the codeinfo data structure so someone should probably look over that code. CI skipped as to not waste resources so don't merge.