### PR TITLE
Add patch number  to MPFR get_version

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -27,8 +27,11 @@ import Base.Math.lgamma_r
 
 import Base.FastMath.sincos_fast
 
-get_version() = VersionNumber(unsafe_string(ccall((:mpfr_get_version,:libmpfr), Ptr{Cchar}, ())))
-get_patches() = split(unsafe_string(ccall((:mpfr_get_patches,:libmpfr), Ptr{Cchar}, ())),' ')
+function get_version()
+    version = unsafe_string(ccall((:mpfr_get_version,:libmpfr), Ptr{Cchar}, ()))
+    build = replace(unsafe_string(ccall((:mpfr_get_patches,:libmpfr), Ptr{Cchar}, ())), ' ', '.')
+    isempty(build) ? VersionNumber(version) : VersionNumber(version * '+' * build)
+end
 
 function __init__()
     try

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -887,7 +887,7 @@ setprecision(256) do
 end
 
 # issue #22758
-if MPFR.get_version() > v"3.1.5" || "r11590" in MPFR.get_patches()
+if MPFR.get_version() > v"3.1.5" || "r11590" in MPFR.get_version().build
     setprecision(2_000_000) do
         @test abs(sin(big(pi)/6) - 0.5) < ldexp(big(1.0),-1_999_000)
     end


### PR DESCRIPTION
1. Gets rid of an unnecessary function
2. Uses the patch field which VersionNumber is meant for