### PR TITLE
REPL: fix edit_insert when indent < 0

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -448,18 +448,13 @@ end
 
 function edit_insert(s::PromptState, c)
     buf = s.input_buffer
-    function line_size()
-        p = position(buf)
-        seek(buf, rsearch(buf.data, '\n', p))
-        ls = p - position(buf)
-        seek(buf, p)
-        return ls
-    end
     str = string(c)
     edit_insert(buf, str)
-    offset = s.ias.curs_row == 1 ? sizeof(prompt_string(s.p.prompt)) : s.indent
+    offset = s.ias.curs_row == 1 || s.indent < 0 ?
+        sizeof(prompt_string(s.p.prompt)) : s.indent
     if !('\n' in str) && eof(buf) &&
-        ((line_size() + offset + sizeof(str) - 1) < width(terminal(s)))
+        ((position(buf) - beginofline(buf) + # size of current line
+          offset + sizeof(str) - 1) < width(terminal(s)))
         # Avoid full update when appending characters to the end
         # and an update of curs_row isn't necessary (conservatively estimated)
         write(terminal(s), str)


### PR DESCRIPTION
This is mostly a non-visible change, but the heuristic to decide to refresh the line in `edit_insert` is more correct.