### PR TITLE
Don't throw in cholfact if matrix is not Hermitian

### DIFF
--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -52,6 +52,9 @@ function CholeskyPivoted(A::AbstractMatrix{T}, uplo::Char, piv::Vector{BlasInt},
     CholeskyPivoted{T,typeof(A)}(A, uplo, piv, rank, tol, info)
 end
 
+# make a copy that allow inplace Cholesky factorization
+@inline choltype(A) = promote_type(typeof(chol(one(eltype(A)))), Float32)
+@inline cholcopy(A) = copy_oftype(A, choltype(A))
 
 # _chol!. Internal methods for calling unpivoted Cholesky
 ## BLAS/LAPACK element types
@@ -62,6 +65,13 @@ end
 function _chol!(A::StridedMatrix{<:BlasFloat}, ::Type{LowerTriangular})
     C, info = LAPACK.potrf!('L', A)
     return LowerTriangular(C), info
+end
+function _chol!(A::StridedMatrix)
+    if !ishermitian(A) # return with info = 1 if not Hermitian
+        return UpperTriangular(A), convert(BlasInt, 1)
+    else
+        return _chol!(A, UpperTriangular)
+    end
 end
 
 ## Non BLAS/LAPACK element types (generic)
@@ -124,10 +134,6 @@ end
 
 chol!(x::Number, uplo) = ((C, info) = _chol!(x, uplo); @assertposdef C info)
 
-non_hermitian_error(f) = throw(ArgumentError("matrix is not symmetric/" *
-    "Hermitian. This error can be avoided by calling $f(Hermitian(A)) " *
-    "which will ignore either the upper or lower triangle of the matrix."))
-
 # chol!. Destructive methods for computing Cholesky factor of real symmetric or Hermitian
 # matrix
 function chol!(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix})
@@ -135,8 +141,7 @@ function chol!(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix})
     @assertposdef C info
 end
 function chol!(A::StridedMatrix)
-    ishermitian(A) || non_hermitian_error("chol!")
-    C, info = _chol!(A, UpperTriangular)
+    C, info = _chol!(A)
     @assertposdef C info
 end
 
@@ -145,8 +150,7 @@ end
 # chol. Non-destructive methods for computing Cholesky factor of a real symmetric or
 # Hermitian matrix. Promotes elements to a type that is stable under square roots.
 function chol(A::RealHermSymComplexHerm)
-    T = promote_type(typeof(chol(one(eltype(A)))), Float32)
-    AA = similar(A, T, size(A))
+    AA = similar(A, choltype(A), size(A))
     if A.uplo == 'U'
         copy!(AA, A.data)
     else
@@ -181,8 +185,7 @@ julia> U'U
 ```
 """
 function chol(A::AbstractMatrix)
-    ishermitian(A) || non_hermitian_error("chol")
-    return chol(Hermitian(A))
+    return chol!(cholcopy(A))
 end
 
 ## Numbers
@@ -235,8 +238,11 @@ ERROR: InexactError: convert(Int64, 6.782329983125268)
 ```
 """
 function cholfact!(A::StridedMatrix, ::Val{false}=Val(false))
-    ishermitian(A) || non_hermitian_error("cholfact!")
-    return cholfact!(Hermitian(A), Val(false))
+    if !ishermitian(A) # return with info = 1 if not Hermitian
+        return Cholesky(A, 'U', convert(BlasInt, 1))
+    else
+        return cholfact!(Hermitian(A), Val(false))
+    end
 end
 
 
@@ -250,9 +256,8 @@ end
 
 ### Non BLAS/LAPACK element types (generic). Since generic fallback for pivoted Cholesky
 ### is not implemented yet we throw an error
-cholfact!(A::RealHermSymComplexHerm{<:Real}, ::Val{true};
-    tol = 0.0) =
-        throw(ArgumentError("generic pivoted Cholesky factorization is not implemented yet"))
+cholfact!(A::RealHermSymComplexHerm{<:Real}, ::Val{true}; tol = 0.0) =
+    throw(ArgumentError("generic pivoted Cholesky factorization is not implemented yet"))
 
 ### for StridedMatrices, check that matrix is symmetric/Hermitian
 """
@@ -264,17 +269,17 @@ factorization produces a number not representable by the element type of `A`,
 e.g. for integer types.
 """
 function cholfact!(A::StridedMatrix, ::Val{true}; tol = 0.0)
-    ishermitian(A) || non_hermitian_error("cholfact!")
-    return cholfact!(Hermitian(A), Val(true); tol = tol)
+    if !ishermitian(A) # return with info = 1 if not Hermitian
+        return CholeskyPivoted(A, 'U', Vector{BlasInt}(),convert(BlasInt, 1),
+                               0.0, convert(BlasInt, 1))
+    else
+        return cholfact!(Hermitian(A), Val(true); tol = tol)
+    end
 end
 
 # cholfact. Non-destructive methods for computing Cholesky factorization of real symmetric
 # or Hermitian matrix
 ## No pivoting (default)
-cholfact(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix}, ::Val{false}=Val(false)) =
-    cholfact!(copy_oftype(A, promote_type(typeof(chol(one(eltype(A)))),Float32)))
-
-### for StridedMatrices, check that matrix is symmetric/Hermitian
 """
     cholfact(A, Val(false)) -> Cholesky
 
@@ -314,18 +319,11 @@ julia> C[:L] * C[:U] == A
 true
 ```
 """
-function cholfact(A::StridedMatrix, ::Val{false}=Val(false))
-    ishermitian(A) || non_hermitian_error("cholfact")
-    return cholfact(Hermitian(A))
-end
+cholfact(A::Union{StridedMatrix,RealHermSymComplexHerm{<:Real,<:StridedMatrix}},
+    ::Val{false}=Val(false)) = cholfact!(cholcopy(A))
 
 
 ## With pivoting
-cholfact(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix}, ::Val{true}; tol = 0.0) =
-        cholfact!(copy_oftype(A, promote_type(typeof(chol(one(eltype(A)))),Float32)),
-            Val(true); tol = tol)
-
-### for StridedMatrices, check that matrix is symmetric/Hermitian
 """
     cholfact(A, Val(true); tol = 0.0) -> CholeskyPivoted
 
@@ -338,10 +336,8 @@ The following functions are available for `PivotedCholesky` objects:
 The argument `tol` determines the tolerance for determining the rank.
 For negative values, the tolerance is the machine precision.
 """
-function cholfact(A::StridedMatrix, ::Val{true}; tol = 0.0)
-    ishermitian(A) || non_hermitian_error("cholfact")
-    return cholfact(Hermitian(A), Val(true); tol = tol)
-end
+cholfact(A::Union{StridedMatrix,RealHermSymComplexHerm{<:Real,<:StridedMatrix}},
+    ::Val{true}; tol = 0.0) = cholfact!(cholcopy(A), Val(true); tol = tol)
 
 ## Number
 function cholfact(x::Number, uplo::Symbol=:U)

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -67,8 +67,8 @@ function _chol!(A::StridedMatrix{<:BlasFloat}, ::Type{LowerTriangular})
     return LowerTriangular(C), info
 end
 function _chol!(A::StridedMatrix)
-    if !ishermitian(A) # return with info = 1 if not Hermitian
-        return UpperTriangular(A), convert(BlasInt, 1)
+    if !ishermitian(A) # return with info = -1 if not Hermitian
+        return UpperTriangular(A), convert(BlasInt, -1)
     else
         return _chol!(A, UpperTriangular)
     end
@@ -184,9 +184,7 @@ julia> U'U
  2.0  50.0
 ```
 """
-function chol(A::AbstractMatrix)
-    return chol!(cholcopy(A))
-end
+chol(A::AbstractMatrix) = chol!(cholcopy(A))
 
 ## Numbers
 """
@@ -238,8 +236,8 @@ ERROR: InexactError: convert(Int64, 6.782329983125268)
 ```
 """
 function cholfact!(A::StridedMatrix, ::Val{false}=Val(false))
-    if !ishermitian(A) # return with info = 1 if not Hermitian
-        return Cholesky(A, 'U', convert(BlasInt, 1))
+    if !ishermitian(A) # return with info = -1 if not Hermitian
+        return Cholesky(A, 'U', convert(BlasInt, -1))
     else
         return cholfact!(Hermitian(A), Val(false))
     end
@@ -269,9 +267,9 @@ factorization produces a number not representable by the element type of `A`,
 e.g. for integer types.
 """
 function cholfact!(A::StridedMatrix, ::Val{true}; tol = 0.0)
-    if !ishermitian(A) # return with info = 1 if not Hermitian
+    if !ishermitian(A) # return with info = -1 if not Hermitian
         return CholeskyPivoted(A, 'U', Vector{BlasInt}(),convert(BlasInt, 1),
-                               0.0, convert(BlasInt, 1))
+                               tol, convert(BlasInt, -1))
     else
         return cholfact!(Hermitian(A), Val(true); tol = tol)
     end

--- a/base/linalg/exceptions.jl
+++ b/base/linalg/exceptions.jl
@@ -32,6 +32,15 @@ end
 struct PosDefException <: Exception
     info::BlasInt
 end
+function Base.showerror(io::IO, ex::PosDefException)
+    print(io, "PosDefException: matrix is not ")
+    if ex.info == -1
+        print(io, "Hermitian")
+    else
+        print(io, "positive definite")
+    end
+    print(io, "; Cholesky factorization failed.")
+end
 
 struct RankDeficientException <: Exception
     info::BlasInt

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -261,14 +261,14 @@ end
     end
 end
 
-@testset "throw if non-Hermitian" begin
+@testset "handling of non-Hermitian" begin
     R = randn(5, 5)
     C = complex.(R, R)
     for A in (R, C)
-        @test_throws ArgumentError cholfact(A)
-        @test_throws ArgumentError cholfact!(copy(A))
-        @test_throws ArgumentError chol(A)
-        @test_throws ArgumentError Base.LinAlg.chol!(copy(A))
+        @test cholfact(A).info == 1
+        @test cholfact!(copy(A)).info == 1
+        @test_throws PosDefException chol(A)
+        @test_throws PosDefException Base.LinAlg.chol!(copy(A))
     end
 end
 

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -265,8 +265,8 @@ end
     R = randn(5, 5)
     C = complex.(R, R)
     for A in (R, C)
-        @test cholfact(A).info == 1
-        @test cholfact!(copy(A)).info == 1
+        @test !LinAlg.issuccess(cholfact(A))
+        @test !LinAlg.issuccess(cholfact!(copy(A)))
         @test_throws PosDefException chol(A)
         @test_throws PosDefException Base.LinAlg.chol!(copy(A))
     end


### PR DESCRIPTION
As discussed [here](https://github.com/JuliaLang/LinearAlgebra.jl/issues/182) and comments below.

We could perhaps dedicate an info code for non-hermitianness, like `-1` or something instead? Then we could throw a more targeted error message (similar to what we had before this PR) or throw a `HermitianException`, instead of
```julia
julia> A = rand(5,5); x = rand(5); cholfact(A)\x
ERROR: Base.LinAlg.PosDefException(1)
Stacktrace:
 [1] A_ldiv_B! at ./linalg/cholesky.jl:412 [inlined]
 [2] \(::Base.LinAlg.Cholesky{Float64,Array{Float64,2}}, ::Array{Float64,1}) at ./linalg/factorization.jl:71
```

Thoughts?