### PR TITLE
REPL: Add ^P and ^N to modal prefix searching

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1614,8 +1614,6 @@ AnyDict(
     "^X^X" => (s,o...)->edit_exchange_point_and_mark(s),
     "^B" => (s,o...)->edit_move_left(s),
     "^F" => (s,o...)->edit_move_right(s),
-    "^P" => (s,o...)->edit_move_up(s),
-    "^N" => (s,o...)->edit_move_down(s),
     # Meta B
     "\eb" => (s,o...)->edit_move_word_left(s),
     # Meta F
@@ -1682,8 +1680,8 @@ AnyDict(
 )
 
 const history_keymap = AnyDict(
-    "^P" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
-    "^N" => (s,o...)->(edit_move_down(s) || history_next(s, mode(s).hist)),
+    "^P" => (s,o...)->(history_prev(s, mode(s).hist)),
+    "^N" => (s,o...)->(history_next(s, mode(s).hist)),
     # Up Arrow
     "\e[A" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
     # Down Arrow
@@ -1730,8 +1728,8 @@ function setup_prefix_keymap(hp, parent_prompt)
     p = PrefixHistoryPrompt(hp, parent_prompt)
     p.keymap_dict = keymap([prefix_history_keymap])
     pkeymap = AnyDict(
-        "^P" => (s,o...)->(edit_move_up(s) || enter_prefix_search(s, p, true)),
-        "^N" => (s,o...)->(edit_move_down(s) || enter_prefix_search(s, p, false)),
+        "^P" => (s,o...)->(enter_prefix_search(s, p, true)),
+        "^N" => (s,o...)->(enter_prefix_search(s, p, false)),
         # Up Arrow
         "\e[A" => (s,o...)->(edit_move_up(s) || enter_prefix_search(s, p, true)),
         # Down Arrow

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1684,6 +1684,8 @@ AnyDict(
 const history_keymap = AnyDict(
     "^P" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
     "^N" => (s,o...)->(edit_move_down(s) || history_next(s, mode(s).hist)),
+    "\ep" => (s,o...)->(history_prev(s, mode(s).hist)),
+    "\en" => (s,o...)->(history_next(s, mode(s).hist)),
     # Up Arrow
     "\e[A" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
     # Down Arrow

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1614,6 +1614,8 @@ AnyDict(
     "^X^X" => (s,o...)->edit_exchange_point_and_mark(s),
     "^B" => (s,o...)->edit_move_left(s),
     "^F" => (s,o...)->edit_move_right(s),
+    "^P" => (s,o...)->edit_move_up(s),
+    "^N" => (s,o...)->edit_move_down(s),
     # Meta B
     "\eb" => (s,o...)->edit_move_word_left(s),
     # Meta F
@@ -1680,8 +1682,8 @@ AnyDict(
 )
 
 const history_keymap = AnyDict(
-    "^P" => (s,o...)->(history_prev(s, mode(s).hist)),
-    "^N" => (s,o...)->(history_next(s, mode(s).hist)),
+    "^P" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
+    "^N" => (s,o...)->(edit_move_down(s) || history_next(s, mode(s).hist)),
     # Up Arrow
     "\e[A" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
     # Down Arrow
@@ -1696,6 +1698,8 @@ const history_keymap = AnyDict(
 
 const prefix_history_keymap = merge!(
     AnyDict(
+        "^P" => (s,data,c)->history_prev_prefix(data, data.histprompt.hp, data.prefix),
+        "^N" => (s,data,c)->history_next_prefix(data, data.histprompt.hp, data.prefix),
         # Up Arrow
         "\e[A" => (s,data,c)->history_prev_prefix(data, data.histprompt.hp, data.prefix),
         # Down Arrow
@@ -1726,6 +1730,8 @@ function setup_prefix_keymap(hp, parent_prompt)
     p = PrefixHistoryPrompt(hp, parent_prompt)
     p.keymap_dict = keymap([prefix_history_keymap])
     pkeymap = AnyDict(
+        "^P" => (s,o...)->(edit_move_up(s) || enter_prefix_search(s, p, true)),
+        "^N" => (s,o...)->(edit_move_down(s) || enter_prefix_search(s, p, false)),
         # Up Arrow
         "\e[A" => (s,o...)->(edit_move_up(s) || enter_prefix_search(s, p, true)),
         # Down Arrow

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1614,6 +1614,8 @@ AnyDict(
     "^X^X" => (s,o...)->edit_exchange_point_and_mark(s),
     "^B" => (s,o...)->edit_move_left(s),
     "^F" => (s,o...)->edit_move_right(s),
+    "^P" => (s,o...)->edit_move_up(s),
+    "^N" => (s,o...)->edit_move_down(s),
     # Meta B
     "\eb" => (s,o...)->edit_move_word_left(s),
     # Meta F
@@ -1680,8 +1682,8 @@ AnyDict(
 )
 
 const history_keymap = AnyDict(
-    "^P" => (s,o...)->(history_prev(s, mode(s).hist)),
-    "^N" => (s,o...)->(history_next(s, mode(s).hist)),
+    "^P" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
+    "^N" => (s,o...)->(edit_move_down(s) || history_next(s, mode(s).hist)),
     # Up Arrow
     "\e[A" => (s,o...)->(edit_move_up(s) || history_prev(s, mode(s).hist)),
     # Down Arrow
@@ -1728,8 +1730,8 @@ function setup_prefix_keymap(hp, parent_prompt)
     p = PrefixHistoryPrompt(hp, parent_prompt)
     p.keymap_dict = keymap([prefix_history_keymap])
     pkeymap = AnyDict(
-        "^P" => (s,o...)->(enter_prefix_search(s, p, true)),
-        "^N" => (s,o...)->(enter_prefix_search(s, p, false)),
+        "^P" => (s,o...)->(edit_move_up(s) || enter_prefix_search(s, p, true)),
+        "^N" => (s,o...)->(edit_move_down(s) || enter_prefix_search(s, p, false)),
         # Up Arrow
         "\e[A" => (s,o...)->(edit_move_up(s) || enter_prefix_search(s, p, true)),
         # Down Arrow

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -152,16 +152,14 @@ to do so).
 | **Cursor movement** |                                                                                                            |
 | Right arrow, `^F`   | Move right one character                                                                                   |
 | Left arrow, `^B`    | Move left one character                                                                                    |
+| ctrl-Right, `meta-F`| Move right one word                                                                                        |
+| ctrl-Left, `meta-B` | Move left one word                                                                                         |
 | Home, `^A`          | Move to beginning of line                                                                                  |
 | End, `^E`           | Move to end of line                                                                                        |
-| `^P`                | Change to the previous or next history entry                                                               |
-| `^N`                | Change to the next history entry                                                                           |
-| Up arrow            | Move up one line (or to the previous history entry)                                                        |
-| Down arrow          | Move down one line (or to the next history entry)                                                          |
-| Page-up             | Change to the previous history entry that matches the text before the cursor                               |
-| Page-down           | Change to the next history entry that matches the text before the cursor                                   |
-| `meta-f`            | Move right one word                                                                                        |
-| `meta-b`            | Move left one word                                                                                         |
+| Up arrow, `^P`      | Move up one line (or change to the previous history entry that matches the text before the cursor)         |
+| Down arrow, `^N`    | Move down one line (or change to the next history entry that matches the text before the cursor)           |
+| Page-up             | Change to the previous history entry                                                                       |
+| Page-down           | Change to the next history entry                                                                           |
 | `meta-<`            | Change to the first history entry (of the current session if it is before the current position in history) |
 | `meta->`            | Change to the last history entry                                                                           |
 | `^-Space`           | Set the "mark" in the editing region                                                                       |
@@ -173,7 +171,7 @@ to do so).
 | `meta-d`            | Forward delete the next word                                                                               |
 | `^W`                | Delete previous text up to the nearest whitespace                                                          |
 | `meta-w`            | Copy the current region in the kill ring                                                                   |
-| `meta-W`            | "Kill" the current region, placing the text in the kill ring                                                |
+| `meta-W`            | "Kill" the current region, placing the text in the kill ring                                               |
 | `^K`                | "Kill" to end of line, placing the text in the kill ring                                                   |
 | `^Y`                | "Yank" insert the text from the kill ring                                                                  |
 | `meta-y`            | Replace a previously yanked text with an older entry from the kill ring                                    |

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -158,8 +158,8 @@ to do so).
 | End, `^E`           | Move to end of line                                                                                        |
 | Up arrow, `^P`      | Move up one line (or change to the previous history entry that matches the text before the cursor)         |
 | Down arrow, `^N`    | Move down one line (or change to the next history entry that matches the text before the cursor)           |
-| Page-up             | Change to the previous history entry                                                                       |
-| Page-down           | Change to the next history entry                                                                           |
+| Page-up, `meta-P`   | Change to the previous history entry                                                                       |
+| Page-down, `meta-N` | Change to the next history entry                                                                           |
 | `meta-<`            | Change to the first history entry (of the current session if it is before the current position in history) |
 | `meta->`            | Change to the last history entry                                                                           |
 | `^-Space`           | Set the "mark" in the editing region                                                                       |


### PR DESCRIPTION
I don't know if these bindings were left out intentionally or not (there is one mention, https://github.com/JuliaLang/julia/pull/8879#issuecomment-66570950, which may suggest it), but I never use the arrow keys, so didn't know that this functionality was in the REPL already. I assume I'm not the only Emacs user with this habit, and most other people don't use ^P or ^N anyway, I guess?