### PR TITLE
Ensure sizeof returns correctly for isbits Union arrays. Fixes #23321

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -259,6 +259,10 @@ JL_CALLABLE(jl_f_sizeof)
     jl_value_t *x = args[0];
     if (jl_is_unionall(x) || jl_is_uniontype(x)) {
         x = jl_unwrap_unionall(x);
+        size_t elsize = 0, al = 0;
+        int isinline = jl_islayout_inline(x, &elsize, &al);
+        if (isinline)
+            return jl_box_long(elsize);
         if (!jl_is_datatype(x))
             jl_error("argument is an abstract type; size is indeterminate");
     }
@@ -270,8 +274,9 @@ JL_CALLABLE(jl_f_sizeof)
             jl_error("type does not have a fixed size");
         return jl_box_long(jl_datatype_size(x));
     }
-    if (jl_is_array(x))
+    if (jl_is_array(x)) {
         return jl_box_long(jl_array_len(x) * ((jl_array_t*)x)->elsize);
+    }
     if (jl_is_string(x))
         return jl_box_long(jl_string_len(x));
     if (jl_is_symbol(x))

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2718,12 +2718,14 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             auto len = emit_arraylen(ctx, obj, ary_ex);
             jl_value_t *ety = jl_tparam0(sty);
             Value *elsize;
+            size_t elsz = 0, al = 0;
+            bool isboxed = !jl_islayout_inline(ety, &elsz, &al);
             if (!jl_has_free_typevars(ety)) {
-                if (!jl_array_store_unboxed(ety)) {
+                if (isboxed) {
                     elsize = ConstantInt::get(T_size, sizeof(void*));
                 }
                 else {
-                    elsize = ConstantInt::get(T_size, jl_datatype_size(ety));
+                    elsize = ConstantInt::get(T_size, elsz);
                 }
             }
             else {

--- a/test/core.jl
+++ b/test/core.jl
@@ -5232,6 +5232,11 @@ const unboxedunions = [Union{Int8, Void}, Union{Int8, Float16, Void},
 @test Base.bitsunionsize(unboxedunions[3]) == 16
 @test Base.bitsunionsize(unboxedunions[4]) == 8
 
+@test sizeof(unboxedunions[1]) == 1
+@test sizeof(unboxedunions[2]) == 2
+@test sizeof(unboxedunions[3]) == 16
+@test sizeof(unboxedunions[4]) == 8
+
 initvalue(::Type{Void}) = nothing
 initvalue(::Type{Char}) = '\0'
 initvalue(::Type{Date}) = Date(0, 12, 31)
@@ -5259,11 +5264,11 @@ for U in boxedunions
     for N in (1, 2, 3, 4)
         A = Array{U}(ntuple(x->0, N)...)
         @test isempty(A)
-        @test Core.sizeof(A) == 0
+        @test sizeof(A) == 0
 
         A = Array{U}(ntuple(x->10, N)...)
         @test length(A) == 10^N
-        @test Core.sizeof(A) == sizeof(Int) * (10^N)
+        @test sizeof(A) == sizeof(Int) * (10^N)
         @test !isassigned(A, 1)
     end
 end
@@ -5278,13 +5283,13 @@ for U in unboxedunions
     for N in (1, 2, 3, 4)
         A = Array{U}(ntuple(x->0, N)...)
         @test isempty(A)
-        @test Core.sizeof(A) == 0
+        @test sizeof(A) == 0
 
         len = ntuple(x->10, N)
         mxsz = maximum(sizeof, Base.uniontypes(U))
         A = Array{U}(len)
         @test length(A) == prod(len)
-        @test Core.sizeof(A) == prod(len) * mxsz
+        @test sizeof(A) == prod(len) * mxsz
         @test isassigned(A, 1)
         @test isassigned(A, length(A))
 
@@ -5312,7 +5317,7 @@ for U in unboxedunions
 
         # reshape
         A3 = reshape(A, (div(prod(len), 2), 2))
-        @test Core.sizeof(A) == prod(len) * mxsz
+        @test sizeof(A) == prod(len) * mxsz
         @test isassigned(A, 1)
         @test A[1] === initvalue2(F)
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -690,8 +690,8 @@ end
 @test sizeof(Symbol("")) == 0
 @test_throws(ErrorException("argument is an abstract type; size is indeterminate"),
              sizeof(Real))
-@test_throws ErrorException sizeof(Union{Complex64,Complex128})
-@test_throws ErrorException sizeof(Union{Int8,UInt8})
+@test sizeof(Union{Complex64,Complex128}) == 16
+@test sizeof(Union{Int8,UInt8}) == 1
 @test_throws ErrorException sizeof(AbstractArray)
 @test_throws ErrorException sizeof(Tuple)
 @test_throws ErrorException sizeof(Tuple{Any,Any})


### PR DESCRIPTION
The only other question I have is whether we should also define `sizeof(Union{Void, Int8})`, i.e. should sizeof return for isbits Unions? I feel like we should, mainly because it _does_ actually have a definitize size now in structs & array elements.