### PR TITLE
RFC: refactor String constructors, remove some conversions

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1696,6 +1696,14 @@ export hex2num
 @deprecate ctranspose adjoint
 @deprecate ctranspose! adjoint!
 
+@deprecate convert(::Type{Vector{UInt8}}, s::AbstractString)  Vector{UInt8}(s)
+@deprecate convert(::Type{Array{UInt8}}, s::AbstractString)   Vector{UInt8}(s)
+@deprecate convert(::Type{Vector{Char}}, s::AbstractString)   Vector{Char}(s)
+@deprecate convert(::Type{Symbol}, s::AbstractString)         Symbol(s)
+@deprecate convert(::Type{String}, s::Symbol)                 String(s)
+@deprecate convert(::Type{String}, v::Vector{UInt8})          String(v)
+@deprecate convert(::Type{S}, g::UTF8proc.GraphemeIterator) where {S<:AbstractString}  convert(S, g.s)
+
 # issue #5148, PR #23259
 # warning for `const` on locals should be changed to an error in julia-syntax.scm
 

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -59,7 +59,8 @@ struct StackFrame # this type should be kept platform-agnostic so that profiles 
     pointer::UInt64  # Large enough to be read losslessly on 32- and 64-bit machines.
 end
 
-StackFrame(func, file, line) = StackFrame(func, file, line, Nullable{Core.MethodInstance}(), false, false, 0)
+StackFrame(func, file, line) = StackFrame(Symbol(func), Symbol(file), line,
+                                          Nullable{Core.MethodInstance}(), false, false, 0)
 
 """
     StackTrace

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -10,20 +10,15 @@ next(s::AbstractString, i::Integer) = next(s,Int(i))
 string() = ""
 string(s::AbstractString) = s
 
-"""
-    String(s::AbstractString)
+(::Type{Vector{UInt8}})(s::AbstractString) = Vector{UInt8}(String(s))
+(::Type{Array{UInt8}})(s::AbstractString) = Vector{UInt8}(s)
+(::Type{Vector{Char}})(s::AbstractString) = collect(s)
 
-Convert a string to a contiguous byte array representation encoded as UTF-8 bytes.
-This representation is often appropriate for passing strings to C.
-"""
-String(s::AbstractString) = print_to_string(s)
+Symbol(s::AbstractString) = Symbol(String(s))
 
-convert(::Type{Vector{UInt8}}, s::AbstractString) = convert(Vector{UInt8}, String(s))
-convert(::Type{Array{UInt8}}, s::AbstractString) = convert(Vector{UInt8}, s)
-convert(::Type{String}, s::AbstractString) = String(s)
-convert(::Type{Vector{Char}}, s::AbstractString) = collect(s)
-convert(::Type{Symbol}, s::AbstractString) = Symbol(s)
-convert(::Type{String}, s::Symbol) = unsafe_string(Cstring(s))
+# string types are convertible
+convert(::Type{T}, s::T) where {T<:AbstractString} = s
+convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)
 
 ## generic supplied functions ##
 
@@ -40,7 +35,6 @@ getindex(s::AbstractString, v::AbstractVector{Bool}) =
     throw(ArgumentError("logical indexing not supported for strings"))
 
 get(s::AbstractString, i::Integer, default) = isvalid(s,i) ? s[i] : default
-Symbol(s::AbstractString) = Symbol(String(s))
 
 """
     sizeof(s::AbstractString)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -42,9 +42,17 @@ end
 
 _string_n(n::Integer) = ccall(:jl_alloc_string, Ref{String}, (Csize_t,), n)
 
-convert(::Type{Vector{UInt8}}, s::String) = ccall(:jl_string_to_array, Ref{Vector{UInt8}}, (Any,), s)
-convert(::Type{String}, s::String) = s
-convert(::Type{String}, v::Vector{UInt8}) = String(v)
+"""
+    String(s::AbstractString)
+
+Convert a string to a contiguous byte array representation encoded as UTF-8 bytes.
+This representation is often appropriate for passing strings to C.
+"""
+String(s::AbstractString) = print_to_string(s)
+
+String(s::Symbol) = unsafe_string(Cstring(s))
+
+(::Type{Vector{UInt8}})(s::String) = ccall(:jl_string_to_array, Ref{Vector{UInt8}}, (Any,), s)
 
 ## low-level functions ##
 
@@ -394,7 +402,7 @@ function string(a::Union{String,Char}...)
 end
 
 function reverse(s::String)
-    dat = convert(Vector{UInt8},s)
+    dat = Vector{UInt8}(s)
     n = length(dat)
     n <= 1 && return s
     buf = StringVector(n)

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -30,6 +30,10 @@ SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j
 SubString(s::SubString, i::Int, j::Int) = SubString(s.string, s.offset+i, s.offset+j)
 SubString(s::AbstractString, i::Integer, j::Integer) = SubString(s, Int(i), Int(j))
 SubString(s::AbstractString, i::Integer) = SubString(s, i, endof(s))
+SubString{T}(s::T) where {T<:AbstractString} = SubString(s, 1, endof(s))
+
+String(p::SubString{String}) =
+    unsafe_string(pointer(p.string, p.offset+1), nextind(p, p.endof)-1)
 
 sizeof(s::SubString{String}) = s.endof == 0 ? 0 : nextind(s, s.endof) - 1
 
@@ -72,11 +76,6 @@ chr2ind(s::SubString{<:DirectIndexString}, i::Integer) = begin checkbounds(s,i);
 
 nextind(s::SubString, i::Integer) = nextind(s.string, i+s.offset)-s.offset
 prevind(s::SubString, i::Integer) = prevind(s.string, i+s.offset)-s.offset
-
-convert(::Type{SubString{T}}, s::T) where {T<:AbstractString} = SubString(s, 1, endof(s))
-
-String(p::SubString{String}) =
-    unsafe_string(pointer(p.string, p.offset+1), nextind(p, p.endof)-1)
 
 function getindex(s::AbstractString, r::UnitRange{Int})
     checkbounds(s, r) || throw(BoundsError(s, r))

--- a/base/strings/utf8proc.jl
+++ b/base/strings/utf8proc.jl
@@ -500,8 +500,6 @@ end
 hash(g::GraphemeIterator, h::UInt) = hash(g.s, h)
 isless(g1::GraphemeIterator, g2::GraphemeIterator) = isless(g1.s, g2.s)
 
-convert(::Type{S}, g::GraphemeIterator) where {S<:AbstractString} = convert(S, g.s)
-
 show(io::IO, g::GraphemeIterator{S}) where {S} = print(io, "length-$(length(g)) GraphemeIterator{$S} for \"$(g.s)\"")
 
 ############################################################################

--- a/base/test.jl
+++ b/base/test.jl
@@ -1366,7 +1366,6 @@ with string types besides the standard `String` type.
 struct GenericString <: AbstractString
     string::AbstractString
 end
-Base.convert(::Type{GenericString}, s::AbstractString) = GenericString(s)
 Base.endof(s::GenericString) = endof(s.string)
 Base.next(s::GenericString, i::Int) = next(s.string, i)
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -189,16 +189,15 @@ end
 struct tstStringType <: AbstractString
     data::Array{UInt8,1}
 end
-tstr = tstStringType("12")
+tstr = tstStringType(Vector{UInt8}("12"))
 @test_throws ErrorException endof(tstr)
 @test_throws ErrorException next(tstr, Bool(1))
 
 gstr = GenericString("12")
-@test typeof(string(gstr))==GenericString
+@test string(gstr) isa GenericString
 
-@test convert(Array{UInt8}, gstr) ==[49;50]
-@test convert(Array{Char,1}, gstr) ==['1';'2']
-@test convert(Symbol, gstr)==Symbol("12")
+@test Array{UInt8}(gstr) == [49, 50]
+@test Array{Char,1}(gstr) == ['1', '2']
 
 @test gstr[1] == '1'
 @test gstr[1:1] == "1"

--- a/test/unicode/utf8.jl
+++ b/test/unicode/utf8.jl
@@ -4,7 +4,7 @@
     let ch = 0x10000
         for hi = 0xd800:0xdbff
             for lo = 0xdc00:0xdfff
-                @test convert(String, Vector{UInt8}(String(Char[hi, lo]))) == string(Char(ch))
+                @test String(Vector{UInt8}(String(Char[hi, lo]))) == string(Char(ch))
                 ch += 1
             end
         end
@@ -41,7 +41,7 @@ end
 end
 
 @testset "string convert" begin
-    @test convert(String, b"this is a test\xed\x80\x80") == "this is a test\ud000"
+    @test String(b"this is a test\xed\x80\x80") == "this is a test\ud000"
     ## Specifically check UTF-8 string whose lead byte is same as a surrogate
-    @test convert(String, b"\xed\x9f\xbf") == "\ud7ff"
+    @test String(b"\xed\x9f\xbf") == "\ud7ff"
 end

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -310,7 +310,6 @@ end
         g = graphemes(str)
         h = hash(str)
         @test hash(g) == h
-        @test convert(GenericString, g) == str
         @test repr(g) == "length-14 GraphemeIterator{String} for \"$str\""
     end
 end


### PR DESCRIPTION
This is another experiment arising from #15120. String methods seem to be an example of uncertainty around what should be conversions vs. constructors; the choices there have been a bit random. I think the plan for #15120 helps significantly: the rule will be simply (1) make everything a constructor, (2) very occasionally and judiciously add a small number of `convert` methods to identify the "safe" cases. Here the only `convert` method left is

```
convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)
```

which says "string types can be implicitly converted to each other".

As part of this, I deprecated conversion among strings, symbols, and arrays. I feel arrays and strings are not the same Kind of Thing, and those conversions should not have existed. I suspect that most uses of those conversions are via constructor syntax, which is why fixing #15120 will be good: if you want a constructor, define a constructor.

I also deprecated the conversion from GraphemeIterator to string, since we generally don't have conversions like that.