### PR TITLE
test-codegen: replace tempname/open/close/stat by mktemp

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -59,7 +59,8 @@ function test_jl_dump_compiles()
         test_jl_dump_compiles_internal(1)
         ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
 
-        @test stat(io).size == 0
+        flush(io)
+        @test stat(io).size != 0
     end
 end
 
@@ -73,6 +74,7 @@ function test_jl_dump_compiles_toplevel_thunks()
         eval(expand(Main, :(for i in 1:10 end)))
         ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
 
+        flush(io)
         @test stat(io).size == 0
     end
 end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -49,21 +49,18 @@ end
 # Have to go through pains with recursive function (eval probably not required) to make sure
 # that inlining won't happen.
 function test_jl_dump_compiles()
-    tfile = tempname()
-    io = open(tfile, "w")
-    ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
-    eval(@noinline function test_jl_dump_compiles_internal(x)
-        if x > 0
-            test_jl_dump_compiles_internal(x-1)
-        end
-        end)
-    test_jl_dump_compiles_internal(1)
-    ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
-    close(io)
-    tstats = stat(tfile)
-    tempty = tstats.size == 0
-    rm(tfile)
-    @test tempty == false
+    mktemp() do tfile, io
+        ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
+        eval(@noinline function test_jl_dump_compiles_internal(x)
+            if x > 0
+                test_jl_dump_compiles_internal(x-1)
+            end
+            end)
+        test_jl_dump_compiles_internal(1)
+        ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
+
+        @test stat(io).size == 0
+    end
 end
 
 # This function tests if a toplevel thunk is output if jl_dump_compiles is enabled.
@@ -71,14 +68,13 @@ end
 function test_jl_dump_compiles_toplevel_thunks()
     tfile = tempname()
     io = open(tfile, "w")
-    ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
-    eval(expand(Main, :(for i in 1:10 end)))
-    ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
-    close(io)
-    tstats = stat(tfile)
-    tempty = tstats.size == 0
-    rm(tfile)
-    @test tempty == true
+    mktemp() do tfile, io
+        ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
+        eval(expand(Main, :(for i in 1:10 end)))
+        ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)
+
+        @test stat(io).size == 0
+    end
 end
 
 if opt_level > 0


### PR DESCRIPTION
This seems like a [flaky test on Windows][1],
```
    FAILURE
Error in testset codegen:
Test Failed
  Expression: tempty == true
   Evaluated: false == true
ERROR: LoadError: Test run finished with errors
while loading C:\projects\julia\julia-a661736be5\share\julia\test\runtests.jl, in expression starting on line 29
Command exited with code 1
```
and without being able to reproduce, I'm going to guess it's a race condition betweeen `close` and `stat`. If so, replacing the `stat (2)` syscall by `fstat (2)` may fix it.  At the Julia level, that means calling `stat` on the iostream instead.

[1]: https://ci.appveyor.com/project/JuliaLang/julia/build/1.0.17932/job/kn10okpwqrbs0126