### PR TITLE
Ensure immutable isbits Union fields get set correctly

### DIFF
--- a/base/fastmath.jl
+++ b/base/fastmath.jl
@@ -296,34 +296,18 @@ asin_fast(x::FloatTypes) = asin(x)
 
 # explicit implementations
 
-# FIXME: Change to `ccall((:sincos, libm))` when `Ref` calling convention can be
-#        stack allocated.
 @inline function sincos_fast(v::Float64)
-    return Base.llvmcall("""
-    %f = bitcast i8 *%1 to void (double, double *, double *)*
-    %ps = alloca double
-    %pc = alloca double
-    call void %f(double %0, double *%ps, double *%pc)
-    %s = load double, double* %ps
-    %c = load double, double* %pc
-    %res0 = insertvalue [2 x double] undef, double %s, 0
-    %res = insertvalue [2 x double] %res0, double %c, 1
-    ret [2 x double] %res
-    """, Tuple{Float64,Float64}, Tuple{Float64,Ptr{Void}}, v, cglobal((:sincos, libm)))
+     s = Ref{Cdouble}()
+     c = Ref{Cdouble}()
+     ccall((:sincos, libm), Void, (Cdouble, Ptr{Cdouble}, Ptr{Cdouble}), v, s, c)
+     return (s[], c[])
 end
 
 @inline function sincos_fast(v::Float32)
-    return Base.llvmcall("""
-    %f = bitcast i8 *%1 to void (float, float *, float *)*
-    %ps = alloca float
-    %pc = alloca float
-    call void %f(float %0, float *%ps, float *%pc)
-    %s = load float, float* %ps
-    %c = load float, float* %pc
-    %res0 = insertvalue [2 x float] undef, float %s, 0
-    %res = insertvalue [2 x float] %res0, float %c, 1
-    ret [2 x float] %res
-    """, Tuple{Float32,Float32}, Tuple{Float32,Ptr{Void}}, v, cglobal((:sincosf, libm)))
+     s = Ref{Cfloat}()
+     c = Ref{Cfloat}()
+     ccall((:sincosf, libm), Void, (Cfloat, Ptr{Cfloat}, Ptr{Cfloat}), v, s, c)
+     return (s[], c[])
 end
 
 @inline function sincos_fast(v::Float16)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1583,9 +1583,8 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         if (jl_is_long(argi_root))
             continue;
         jl_cgval_t arg_root = emit_expr(ctx, argi_root);
-        Value *gcuse = arg_root.gcroot ? ctx.builder.CreateLoad(arg_root.gcroot) : arg_root.V;
-        if (gcuse) {
-            gc_uses.push_back(gcuse);
+        if (arg_root.Vboxed || arg_root.V) {
+            gc_uses.push_back(arg_root.Vboxed ? arg_root.Vboxed : arg_root.V);
         }
     }
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -170,15 +170,8 @@ static DIType *julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxe
         return jl_pvalue_dillvmt;
     jl_datatype_t *jdt = (jl_datatype_t*)jt;
     // always return the boxed representation for types with hidden content
-    if (jl_is_abstracttype(jt) || jl_is_array_type(jt) ||
-        jt == (jl_value_t*)jl_sym_type || jt == (jl_value_t*)jl_module_type ||
-        jt == (jl_value_t*)jl_simplevector_type || jt == (jl_value_t*)jl_datatype_type ||
-        jt == (jl_value_t*)jl_method_instance_type)
-        return jl_pvalue_dillvmt;
-    if (jdt->ditype != NULL) {
-        DIType* t = (DIType*)jdt->ditype;
-        return t;
-    }
+    if (jdt->ditype != NULL)
+        return (DIType*)jdt->ditype;
     if (jl_is_primitivetype(jt)) {
         uint64_t SizeInBits = jl_datatype_nbits(jdt);
 #if JL_LLVM_VERSION >= 40000
@@ -198,11 +191,11 @@ static DIType *julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxe
         return t;
 #endif
     }
-    if (jl_is_structtype(jt) && jdt->layout) {
+    if (jl_is_structtype(jt) && jdt->uid && jdt->layout && !jl_is_layout_opaque(jdt->layout)) {
         size_t ntypes = jl_datatype_nfields(jdt);
         const char *tname = jl_symbol_name(jdt->name->name);
         std::stringstream unique_name;
-        unique_name << tname << "_" << globalUnique++;
+        unique_name << jdt->uid;
         llvm::DICompositeType *ct = dbuilder->createStructType(
                 NULL,                       // Scope
                 tname,                      // Name
@@ -219,8 +212,15 @@ static DIType *julia_type_to_di(jl_value_t *jt, DIBuilder *dbuilder, bool isboxe
                 );
         jdt->ditype = ct;
         std::vector<llvm::Metadata*> Elements;
-        for (unsigned i = 0; i < ntypes; i++)
-            Elements.push_back(julia_type_to_di(jl_svecref(jdt->types, i), dbuilder, false));
+        for (unsigned i = 0; i < ntypes; i++) {
+            jl_value_t *el = jl_svecref(jdt->types, i);
+            DIType *di;
+            if (jl_field_isptr(jdt, i))
+                di = jl_pvalue_dillvmt;
+            else
+                di = julia_type_to_di(el, dbuilder, false);
+            Elements.push_back(di);
+        }
         dbuilder->replaceArrays(ct, dbuilder->getOrCreateArray(ArrayRef<Metadata*>(Elements)));
         return ct;
     }
@@ -233,7 +233,7 @@ static Value *emit_pointer_from_objref(jl_codectx_t &ctx, Value *V)
 {
     unsigned AS = cast<PointerType>(V->getType())->getAddressSpace();
     if (AS != AddressSpace::Tracked && AS != AddressSpace::Derived)
-        return ctx.builder.CreateBitCast(V, T_pjlvalue);
+        return ctx.builder.CreatePtrToInt(V, T_size);
     V = ctx.builder.CreateBitCast(decay_derived(V),
             PointerType::get(T_jlvalue, AddressSpace::Derived));
     CallInst *Call = ctx.builder.CreateCall(prepare_call(pointer_from_objref_func), V);
@@ -427,18 +427,14 @@ static Type *bitstype_to_llvm(jl_value_t *bt)
     assert(jl_is_primitivetype(bt));
     if (bt == (jl_value_t*)jl_bool_type)
         return T_int8;
-    if (bt == (jl_value_t*)jl_long_type)
-        return T_size;
+    if (bt == (jl_value_t*)jl_int32_type)
+        return T_int32;
+    if (bt == (jl_value_t*)jl_int64_type)
+        return T_int64;
     if (bt == (jl_value_t*)jl_float32_type)
         return T_float32;
     if (bt == (jl_value_t*)jl_float64_type)
         return T_float64;
-    if (jl_is_cpointer_type(bt)) {
-        Type *lt = julia_type_to_llvm(jl_tparam0(bt));
-        if (lt == T_void)
-            return T_pint8;
-        return PointerType::get(lt, 0);
-    }
     int nb = jl_datatype_size(bt);
     return Type::getIntNTy(jl_LLVMContext, nb * 8);
 }
@@ -481,121 +477,116 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, jl_unionall_t *ua, bool *isbox
         return bitstype_to_llvm(jt);
     bool isTuple = jl_is_tuple_type(jt);
     jl_datatype_t *jst = (jl_datatype_t*)jt;
-    if (jl_is_structtype(jt) && !(jst->layout && jl_is_layout_opaque(jst->layout))) {
-        if (jst->struct_decl == NULL) {
-            size_t i, ntypes = jl_svec_len(jst->types);
-            if (ntypes == 0 || (jst->layout && jl_datatype_nbits(jst) == 0))
-                return T_void;
-            if (!julia_struct_has_layout(jst, ua))
-                return NULL;
-            StructType *structdecl;
-            if (!isTuple) {
-                structdecl = StructType::create(jl_LLVMContext, jl_symbol_name(jst->name->name));
-                jst->struct_decl = structdecl;
-            }
-            std::vector<Type*> latypes(0);
-            bool isarray = true;
-            bool isvector = true;
-            jl_value_t *jlasttype = NULL;
-            Type *lasttype = NULL;
-            bool allghost = true;
-            for (i = 0; i < ntypes; i++) {
-                jl_value_t *ty = jl_svecref(jst->types, i);
-                if (jlasttype != NULL && ty != jlasttype)
-                    isvector = false;
-                jlasttype = ty;
-                bool isptr;
-                size_t fsz = 0, al = 0;
-                if (jst->layout) {
-                    isptr = jl_field_isptr(jst, i);
-                    fsz = jl_field_size(jst, i);
-                    al = jl_field_align(jst, i);
-                }
-                else { // compute what jl_compute_field_offsets would say
-                    isptr = !jl_islayout_inline(ty, &fsz, &al);
-                    if (!isptr && jl_is_uniontype(jst))
-                        fsz += 1;
-                }
-                Type *lty;
-                if (isptr)
-                    lty = T_pjlvalue;
-                else if (ty == (jl_value_t*)jl_bool_type)
-                    lty = T_int8;
-                else if (jl_is_uniontype(ty)) {
-                    // pick an Integer type size such that alignment will be correct
-                    // and always end with an Int8 (selector byte)
-                    lty = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), (fsz - 1) / al);
-                    std::vector<Type*> Elements(2);
-                    Elements[0] = lty;
-                    Elements[1] = T_int8;
-                    unsigned remainder = (fsz - 1) % al;
-                    while (remainder--)
-                        Elements.push_back(T_int8);
-                    lty = StructType::get(jl_LLVMContext, makeArrayRef(Elements));
-                }
-                else
-                    lty = julia_type_to_llvm(ty);
-                if (lasttype != NULL && lasttype != lty)
-                    isarray = false;
-                lasttype = lty;
-                if (type_is_ghost(lty))
-                    lty = NoopType;
-                else
-                    allghost = false;
-                latypes.push_back(lty);
-            }
-            if (allghost) {
-                assert(jst->layout == NULL); // otherwise should have been caught above
-                jst->struct_decl = T_void;
-            }
-            else if (!isTuple) {
-                if (jl_is_vecelement_type(jt))
-                    // VecElement type is unwrapped in LLVM
-                    jst->struct_decl = latypes[0];
-                else
-                    structdecl->setBody(latypes);
-            }
-            else {
-                if (isarray && lasttype != T_int1 && !type_is_ghost(lasttype)) {
-                    if (isvector && jl_special_vector_alignment(ntypes, jlasttype) != 0)
-                        jst->struct_decl = VectorType::get(lasttype, ntypes);
-                    else
-                        jst->struct_decl = ArrayType::get(lasttype, ntypes);
-                }
-                else {
-                    jst->struct_decl = StructType::get(jl_LLVMContext, ArrayRef<Type*>(&latypes[0], ntypes));
-                }
-            }
-#ifndef JL_NDEBUG
-            // If LLVM and Julia disagree about alignment, much trouble ensues, so check it!
-            if (jst->layout) {
-                const DataLayout &DL =
-#if JL_LLVM_VERSION >= 40000
-                    jl_data_layout;
-#else
-                    jl_ExecutionEngine->getDataLayout();
-#endif
-                unsigned llvm_alignment = DL.getABITypeAlignment((Type*)jst->struct_decl);
-                unsigned julia_alignment = jl_datatype_align(jst);
-                // Check that the alignment adheres to the heap alignment.
-                assert(julia_alignment <= JL_HEAP_ALIGNMENT);
-                // TODO: Fix alignment calculation in LLVM, as well as in the GC and the struct declaration
-                if (llvm_alignment  <= JL_HEAP_ALIGNMENT)
-                    assert(julia_alignment == llvm_alignment);
-            }
-#endif
-        }
+    if (jst->struct_decl != NULL)
         return (Type*)jst->struct_decl;
+    if (jl_is_structtype(jt) && !(jst->layout && jl_is_layout_opaque(jst->layout))) {
+        size_t i, ntypes = jl_svec_len(jst->types);
+        if (ntypes == 0 || (jst->layout && jl_datatype_nbits(jst) == 0))
+            return T_void;
+        if (!julia_struct_has_layout(jst, ua))
+            return NULL;
+        std::vector<Type*> latypes(ntypes);
+        bool isarray = true;
+        bool isvector = true;
+        jl_value_t *jlasttype = NULL;
+        Type *lasttype = NULL;
+        bool allghost = true;
+        for (i = 0; i < ntypes; i++) {
+            jl_value_t *ty = jl_svecref(jst->types, i);
+            if (jlasttype != NULL && ty != jlasttype)
+                isvector = false;
+            jlasttype = ty;
+            bool isptr;
+            size_t fsz = 0, al = 0;
+            if (jst->layout) {
+                isptr = jl_field_isptr(jst, i);
+                fsz = jl_field_size(jst, i);
+                al = jl_field_align(jst, i);
+            }
+            else { // compute what jl_compute_field_offsets would say
+                isptr = !jl_islayout_inline(ty, &fsz, &al);
+                if (!isptr && jl_is_uniontype(jst))
+                    fsz += 1;
+            }
+            Type *lty;
+            if (isptr)
+                lty = T_pjlvalue;
+            else if (ty == (jl_value_t*)jl_bool_type)
+                lty = T_int8;
+            else if (jl_is_uniontype(ty)) {
+                // pick an Integer type size such that alignment will be correct
+                // and always end with an Int8 (selector byte)
+                lty = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), (fsz - 1) / al);
+                std::vector<Type*> Elements(2);
+                Elements[0] = lty;
+                Elements[1] = T_int8;
+                unsigned remainder = (fsz - 1) % al;
+                while (remainder--)
+                    Elements.push_back(T_int8);
+                lty = StructType::get(jl_LLVMContext, Elements);
+            }
+            else
+                lty = julia_type_to_llvm(ty);
+            if (lasttype != NULL && lasttype != lty)
+                isarray = false;
+            lasttype = lty;
+            if (type_is_ghost(lty))
+                lty = NoopType;
+            else
+                allghost = false;
+            latypes[i] = lty;
+        }
+        Type *decl;
+        if (allghost) {
+            assert(jst->layout == NULL); // otherwise should have been caught above
+            decl = T_void;
+        }
+        else if (jl_is_vecelement_type(jt)) {
+            // VecElement type is unwrapped in LLVM
+            decl = latypes[0];
+        }
+        else if (isTuple && isarray && lasttype != T_int1 && !type_is_ghost(lasttype)) {
+            if (isvector && jl_special_vector_alignment(ntypes, jlasttype) != 0)
+                decl = VectorType::get(lasttype, ntypes);
+            else
+                decl = ArrayType::get(lasttype, ntypes);
+        }
+        else {
+            decl = StructType::get(jl_LLVMContext, latypes);
+        }
+        jst->struct_decl = decl;
+#ifndef JL_NDEBUG
+        // If LLVM and Julia disagree about alignment, much trouble ensues, so check it!
+        if (jst->layout) {
+            const DataLayout &DL =
+#if JL_LLVM_VERSION >= 40000
+                jl_data_layout;
+#else
+                jl_ExecutionEngine->getDataLayout();
+#endif
+            unsigned llvm_alignment = DL.getABITypeAlignment((Type*)jst->struct_decl);
+            unsigned julia_alignment = jl_datatype_align(jst);
+            // Check that the alignment adheres to the heap alignment.
+            assert(julia_alignment <= JL_HEAP_ALIGNMENT);
+            // TODO: Fix alignment calculation in LLVM, as well as in the GC and the struct declaration
+            if (llvm_alignment <= JL_HEAP_ALIGNMENT)
+                assert(julia_alignment == llvm_alignment);
+        }
+#endif
+        return decl;
     }
     // TODO: enable this (with tests):
     // if (jl_is_uniontype(ty)) {
-    //     size_t fsz = 0, al = 0;
-    //     bool isptr = !jl_islayout_inline(ty, &fsz, &al);
-    //     // pick an Integer type size such that alignment will be correct
-    //     return StructType::get(jl_LLVMContext, makeArrayRef({
-    //                 ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al),
-    //                                (fsz + al - 1) / al),
-    //                 T_int8 }));
+    //  // pick an Integer type size such that alignment will be correct
+    //  // and always end with an Int8 (selector byte)
+    //  lty = ArrayType::get(IntegerType::get(jl_LLVMContext, 8 * al), (fsz - 1) / al);
+    //  std::vector<Type*> Elements(2);
+    //  Elements[0] = lty;
+    //  Elements[1] = T_int8;
+    //  unsigned remainder = (fsz - 1) % al;
+    //  while (remainder--)
+    //      Elements.push_back(T_int8);
+    //  lty = StructType::get(jl_LLVMContext, makeArrayRef(Elements));
     // }
     if (isboxed) *isboxed = true;
     return T_pjlvalue;
@@ -604,7 +595,7 @@ static Type *julia_struct_to_llvm(jl_value_t *jt, jl_unionall_t *ua, bool *isbox
 static bool is_datatype_all_pointers(jl_datatype_t *dt)
 {
     size_t i, l = jl_datatype_nfields(dt);
-    for(i=0; i < l; i++) {
+    for (i = 0; i < l; i++) {
         if (!jl_field_isptr(dt, i)) {
             return false;
         }
@@ -623,9 +614,9 @@ static bool is_tupletype_homogeneous(jl_svec_t *t, bool allow_va = false)
                 return true;
             return false;
         }
-        for(i=1; i < l; i++) {
-            if (allow_va && i == l - 1 && jl_is_vararg_type(jl_svecref(t,i))) {
-                if (t0 != jl_unwrap_vararg(jl_svecref(t,i)))
+        for (i = 1; i < l; i++) {
+            if (allow_va && i == l - 1 && jl_is_vararg_type(jl_svecref(t, i))) {
+                if (t0 != jl_unwrap_vararg(jl_svecref(t, i)))
                     return false;
                 continue;
             }
@@ -1210,9 +1201,10 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         return ghostValue(jltype);
     if (isboxed)
         elty = T_prjlvalue;
-    Value *data = ptr;
-    if (ptr->getType()->getContainedType(0) != elty)
-        data = emit_bitcast(ctx, ptr, PointerType::get(elty, 0));
+    Type *ptrty = PointerType::get(elty, ptr->getType()->getPointerAddressSpace());
+    Value *data;
+    if (ptr->getType() != ptrty)
+        data = emit_bitcast(ctx, ptr, ptrty);
     else
         data = ptr;
     if (idx_0based)
@@ -1260,14 +1252,16 @@ static void typed_store(jl_codectx_t &ctx,
             emit_write_barrier(ctx, parent, r);
     }
     Value *data;
-    if (ptr->getType()->getContainedType(0) != elty) {
+    Type *ptrty = PointerType::get(elty, ptr->getType()->getPointerAddressSpace());
+    if (ptr->getType() != ptrty) {
         if (isboxed) {
             data = emit_bitcast(ctx, ptr, T_pprjlvalue);
         } else {
-            data = emit_bitcast(ctx, ptr, PointerType::get(elty, cast<PointerType>(ptr->getType())->getAddressSpace()));
+            data = emit_bitcast(ctx, ptr, ptrty);
         }
-    } else
+    } else {
         data = ptr;
+    }
     Instruction *store = ctx.builder.CreateAlignedStore(r, ctx.builder.CreateGEP(data,
         idx_0based), isboxed ? alignment : julia_alignment(r, jltype, alignment));
     if (tbaa)
@@ -2258,67 +2252,81 @@ static jl_cgval_t emit_new_struct(jl_codectx_t &ctx, jl_value_t *ty, size_t narg
     if (nf > 0) {
         if (jl_isbits(sty)) {
             Type *lt = julia_type_to_llvm(ty);
+            unsigned na = (nargs - 1 < nf) ? (nargs - 1) : nf;
+
             // whether we should perform the initialization with the struct as a IR value
             // or instead initialize the stack buffer with stores
             bool init_as_value = false;
             if (lt->isVectorTy() ||
-                jl_is_vecelement_type(ty) ||
-                type_is_ghost(lt)) // maybe also check the size ?
+                    jl_is_vecelement_type(ty)) { // maybe also check the size ?
                 init_as_value = true;
+            }
 
-            unsigned na = (nargs - 1 < nf) ? (nargs - 1) : nf;
             Value *strct;
-            if (init_as_value)
-                strct = UndefValue::get(lt == T_void ? NoopType : lt);
+            if (type_is_ghost(lt))
+                strct = NULL;
+            else if (init_as_value)
+                strct = UndefValue::get(lt);
             else
                 strct = emit_static_alloca(ctx, lt);
 
             for (unsigned i = 0; i < na; i++) {
                 jl_value_t *jtype = jl_svecref(sty->types, i);
-                Type *fty = julia_struct_to_llvm(jtype, NULL, NULL);
                 const jl_cgval_t &fval_info = argv[i + 1];
                 emit_typecheck(ctx, fval_info, jtype, "new");
+                Type *fty;
+                if (type_is_ghost(lt))
+                    continue;
+                else if (jl_is_vecelement_type(ty))
+                    fty = lt;
+                else
+                    fty = cast<CompositeType>(lt)->getTypeAtIndex(i);
+                if (type_is_ghost(fty))
+                    continue;
                 Value *dest = NULL;
                 if (!init_as_value) {
-                    bool isunion = jl_is_uniontype(jtype);
-                    if (!type_is_ghost(fty) || isunion) {
-                        // avoid unboxing the argument explicitly
-                        // and use memcpy instead
-                        dest = ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, i);
-                        if (isunion) {
-                            // compute tindex from rhs
-                            jl_cgval_t rhs_union = convert_julia_type(ctx, fval_info, jtype);
-                            if (rhs_union.typ == jl_bottom_type)
-                                return jl_cgval_t();
-                            Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jtype);
-                            tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
-                            StructType *lt_i = cast<StructType>(cast<GetElementPtrInst>(dest)->getResultElementType());
-                            Value *ptindex = ctx.builder.CreateConstInBoundsGEP2_32(
-                                    lt_i, dest, 0, lt_i->getNumElements() - 1);
-                            ctx.builder.CreateStore(tindex, ptindex);
-                            if (!rhs_union.isghost) {
-                                emit_unionmove(ctx, dest, fval_info, NULL, false, NULL);
-                            }
-                            continue;
-                        }
-                    }
+                    // avoid unboxing the argument explicitly
+                    // and use memcpy instead
+                    dest = ctx.builder.CreateConstInBoundsGEP2_32(lt, strct, 0, i);
                 }
-                if (!type_is_ghost(fty)) {
-                    Value *fval = NULL;
+                Value *fval = NULL;
+                if (jl_is_uniontype(jtype)) {
+                    assert(!init_as_value && "unimplemented");
+                    StructType *lt_i = cast<StructType>(fty);
+                    // compute tindex from rhs
+                    jl_cgval_t rhs_union = convert_julia_type(ctx, fval_info, jtype);
+                    if (rhs_union.typ == jl_bottom_type)
+                        return jl_cgval_t();
+                    Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jtype);
+                    tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
+                    Value *ptindex = ctx.builder.CreateConstInBoundsGEP2_32(
+                            lt_i, dest, 0, lt_i->getNumElements() - 1);
+                    ctx.builder.CreateStore(tindex, ptindex);
+                    if (!rhs_union.isghost)
+                        emit_unionmove(ctx, dest, fval_info, NULL, false, NULL);
+                    // If you wanted to implement init_as_value,
+                    // would need to emit the union-move into temporary memory,
+                    // then load it and combine with the tindex.
+                    // But more efficient to just store it directly.
+                }
+                else {
                     fval = emit_unbox(ctx, fty, fval_info, jtype, dest);
-                    if (init_as_value) {
-                        if (lt->isVectorTy())
-                            strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32, i));
-                        else if (jl_is_vecelement_type(ty))
-                            strct = fval;  // VecElement type comes unwrapped in LLVM.
-                        else if (lt->isAggregateType())
-                            strct = ctx.builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&i, 1));
-                        else
-                            assert(false);
-                    }
+                }
+                if (init_as_value) {
+                    assert(fval);
+                    if (lt->isVectorTy())
+                        strct = ctx.builder.CreateInsertElement(strct, fval, ConstantInt::get(T_int32, i));
+                    else if (jl_is_vecelement_type(ty))
+                        strct = fval;  // VecElement type comes unwrapped in LLVM.
+                    else if (lt->isAggregateType())
+                        strct = ctx.builder.CreateInsertValue(strct, fval, ArrayRef<unsigned>(&i, 1));
+                    else
+                        assert(false);
                 }
             }
-            if (init_as_value)
+            if (type_is_ghost(lt))
+                return mark_julia_const(sty->instance);
+            else if (init_as_value)
                 return mark_julia_type(ctx, strct, false, ty);
             else
                 return mark_julia_slot(strct, ty, NULL, tbaa_stack);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -391,9 +391,14 @@ static MDNode *best_tbaa(jl_value_t *jt) {
 // metadata tracking for a llvm Value* during codegen
 struct jl_cgval_t {
     Value *V; // may be of type T* or T, or set to NULL if ghost (or if the value has not been initialized yet, for a variable definition)
+    // For unions, we may need to keep a reference to the boxed part individually.
+    // If this is non-NULL, then, at runtime, we satisfy the invariant that (for the corresponding
+    // runtime values) if `(TIndex | 0x80) != 0`, then `Vboxed == V` (by value).
+    // For conenience, we also set this value of isboxed values, in which case
+    // it is equal (at compile time) to V.
+    Value *Vboxed;
     Value *TIndex; // if `V` is an unboxed (tagged) Union described by `typ`, this gives the DataType index (1-based, small int) as an i8
     jl_value_t *constant; // constant value (rooted in linfo.def.roots)
-    Value *gcroot; // the gcroot associated with V (if it has one)
     jl_value_t *typ; // the original type of V, never NULL
     bool isboxed; // whether this value is a jl_value_t* allocated on the heap with the right type tag
     bool isghost; // whether this value is "ghost"
@@ -411,23 +416,24 @@ struct jl_cgval_t {
     //}
     jl_cgval_t(Value *V, Value *gcroot, bool isboxed, jl_value_t *typ, Value *tindex) : // general constructor (with pointer type auto-detect)
         V(V), // V is allowed to be NULL in a jl_varinfo_t context, but not during codegen contexts
+        Vboxed(isboxed ? V : nullptr),
         TIndex(tindex),
         constant(NULL),
-        gcroot(gcroot),
         typ(typ),
         isboxed(isboxed),
         isghost(false),
         isimmutable(isboxed && jl_is_immutable_datatype(typ)),
         tbaa(isboxed ? best_tbaa(typ) : nullptr)
     {
+        assert(gcroot == nullptr);
         assert(!(isboxed && TIndex != NULL));
         assert(TIndex == NULL || TIndex->getType() == T_int8);
     }
     jl_cgval_t(jl_value_t *typ) : // ghost value constructor
         V(NULL),
+        Vboxed(NULL),
         TIndex(NULL),
         constant(((jl_datatype_t*)typ)->instance),
-        gcroot(NULL),
         typ(typ),
         isboxed(false),
         isghost(true),
@@ -439,9 +445,9 @@ struct jl_cgval_t {
     }
     jl_cgval_t(const jl_cgval_t &v, jl_value_t *typ, Value *tindex) : // copy constructor with new type
         V(v.V),
+        Vboxed(v.Vboxed),
         TIndex(tindex),
         constant(v.constant),
-        gcroot(v.gcroot),
         typ(typ),
         isboxed(v.isboxed),
         isghost(v.isghost),
@@ -459,9 +465,9 @@ struct jl_cgval_t {
     }
     jl_cgval_t() : // undef / unreachable / default constructor
         V(UndefValue::get(T_void)),
+        Vboxed(NULL),
         TIndex(NULL),
         constant(NULL),
-        gcroot(NULL),
         typ(jl_bottom_type),
         isboxed(false),
         isghost(true),
@@ -570,7 +576,6 @@ public:
 };
 
 static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr);
-static Value *emit_local_root(jl_codectx_t &ctx, jl_varinfo_t *vi = NULL);
 static Value *global_binding_pointer(jl_codectx_t &ctx, jl_module_t *m, jl_sym_t *s,
                                      jl_binding_t **pbnd, bool assign);
 static jl_cgval_t emit_checked_var(jl_codectx_t &ctx, Value *bp, jl_sym_t *name, bool isvol, MDNode *tbaa);
@@ -714,8 +719,8 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
             return v; // not worth trying to improve type info
         if (!isbits_spec(typ)) {
             // discovered that this union-split type must actually be isboxed
-            if (v.V) {
-                return jl_cgval_t(v.V, v.gcroot, true, typ, NULL);
+            if (v.Vboxed) {
+                return jl_cgval_t(v.Vboxed, nullptr, true, typ, NULL);
             }
             else {
                 // type mismatch (there weren't any boxed values in the union)
@@ -730,7 +735,7 @@ static inline jl_cgval_t update_julia_type(jl_codectx_t &ctx, const jl_cgval_t &
     return jl_cgval_t(v, typ, NULL);
 }
 
-static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, bool needsroot = true);
+static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ);
 
 // --- allocating local variables ---
 
@@ -811,8 +816,154 @@ static void jl_rethrow_with_add(const char *fmt, ...)
     jl_rethrow();
 }
 
+static jl_cgval_t convert_julia_type_union(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ)
+{
+    // previous value was a split union, compute new index, or box
+    Value *new_tindex = ConstantInt::get(T_int8, 0x80);
+    SmallBitVector skip_box(1, true);
+    Value *tindex = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x7f));
+    if (jl_is_uniontype(typ)) {
+        // compute the TIndex mapping from v.typ -> typ
+        unsigned counter = 0;
+        for_each_uniontype_small(
+            // for each old union-split value
+            [&](unsigned idx, jl_datatype_t *jt) {
+                unsigned new_idx = get_box_tindex(jt, typ);
+                bool t;
+                if (new_idx) {
+                    // found a matching element,
+                    // match it against either the unboxed index
+                    Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
+                    new_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, new_idx), new_tindex);
+                    t = true;
+                }
+                else if (!jl_subtype((jl_value_t*)jt, typ)) {
+                    // new value doesn't need to be boxed
+                    // since it isn't part of the new union
+                    t = true;
+                }
+                else {
+                    // will actually need to box this element
+                    // since it appeared as a leaftype in the original type
+                    // but not in the remark type
+                    t = false;
+                }
+                skip_box.resize(idx + 1, t);
+            },
+            v.typ,
+            counter);
+    }
+
+    // some of the values are still unboxed
+    if (!isa<Constant>(new_tindex)) {
+        Value *wasboxed = NULL;
+        // If the old value was boxed and unknown (type tag 0x80),
+        // it is possible that the tag was actually one of the types
+        // that are now explicitly represented. To find out, we need
+        // to compare typeof(v.Vboxed) (i.e. the type of the unknown
+        // value) against all the types that are now explicitly
+        // selected and select the appropriate one as our new tindex.
+        if (v.Vboxed) {
+            wasboxed = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x80));
+            new_tindex = ctx.builder.CreateOr(wasboxed, new_tindex);
+            wasboxed = ctx.builder.CreateICmpNE(wasboxed, ConstantInt::get(T_int8, 0));
+
+            BasicBlock *currBB = ctx.builder.GetInsertBlock();
+
+            // We lazily create a BB for this, once we decide that we
+            // actually need it.
+            Value *union_box_dt = NULL;
+            BasicBlock *union_isaBB = NULL;
+            auto maybe_setup_union_isa = [&]() {
+                union_isaBB = BasicBlock::Create(jl_LLVMContext, "union_isa", ctx.f);
+                ctx.builder.SetInsertPoint(union_isaBB);
+                union_box_dt = emit_typeof(ctx, v.Vboxed);
+            };
+
+            // If we don't find a match. The type remains unknown
+            // (0x80). We could use `v.Tindex`, here, since we know
+            // it has to be 0x80, but it seems likely the backend
+            // will like the explicit constant better.
+            Value *union_box_tindex = ConstantInt::get(T_int8, 0x80);
+            unsigned counter = 0;
+            for_each_uniontype_small(
+                // for each new union-split value
+                [&](unsigned idx, jl_datatype_t *jt) {
+                    unsigned old_idx = get_box_tindex(jt, v.typ);
+                    if (old_idx == 0) {
+                        // didn't handle this item before, select its new union index
+                        maybe_setup_union_isa();
+                        Value *cmp = ctx.builder.CreateICmpEQ(maybe_decay_untracked(literal_pointer_val(ctx, (jl_value_t*)jt)), union_box_dt);
+                        union_box_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, 0x80 | idx), union_box_tindex);
+                    }
+                },
+                typ,
+                counter);
+            if (union_box_dt) {
+                BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_union_isa", ctx.f);
+                ctx.builder.CreateBr(postBB);
+                ctx.builder.SetInsertPoint(currBB);
+                Value *wasunknown = ctx.builder.CreateICmpEQ(v.TIndex, ConstantInt::get(T_int8, 0x80));
+                ctx.builder.CreateCondBr(wasunknown, union_isaBB, postBB);
+                ctx.builder.SetInsertPoint(postBB);
+                PHINode *tindex_phi = ctx.builder.CreatePHI(T_int8, 2);
+                tindex_phi->addIncoming(new_tindex, currBB);
+                tindex_phi->addIncoming(union_box_tindex, union_isaBB);
+                new_tindex = tindex_phi;
+            }
+        }
+        if (!skip_box.all()) {
+            // some values weren't unboxed in the new union
+            // box them now (tindex above already selected 0x80 = box for them)
+            Value *boxv = box_union(ctx, v, skip_box);
+            if (v.Vboxed) {
+                // If the value is boxed both before and after, we don't need
+                // to touch it at all. Otherwise we're either transitioning
+                // unboxed->boxed, or leaving an unboxed value in place.
+                Value *isboxed = ctx.builder.CreateICmpNE(
+                    ctx.builder.CreateAnd(new_tindex, ConstantInt::get(T_int8, 0x80)),
+                    ConstantInt::get(T_int8, 0));
+                boxv = ctx.builder.CreateSelect(
+                    ctx.builder.CreateAnd(wasboxed, isboxed), v.Vboxed, boxv);
+            }
+            if (v.V == NULL) {
+                // v.V might be NULL if it was all ghost objects before
+                return jl_cgval_t(boxv, NULL, false, typ, new_tindex);
+            } else {
+                Value *isboxv = ctx.builder.CreateIsNotNull(boxv);
+                Value *slotv;
+                MDNode *tbaa;
+                bool isimmutable;
+                if (v.ispointer()) {
+                    slotv = v.V;
+                    tbaa = v.tbaa;
+                    isimmutable = v.isimmutable;
+                }
+                else {
+                    slotv = emit_static_alloca(ctx, v.V->getType());
+                    ctx.builder.CreateStore(v.V, slotv);
+                    tbaa = tbaa_stack;
+                    isimmutable = true;
+                }
+                slotv = ctx.builder.CreateSelect(isboxv,
+                            decay_derived(boxv),
+                            decay_derived(emit_bitcast(ctx, slotv, boxv->getType())));
+                jl_cgval_t newv = jl_cgval_t(slotv, NULL, false, typ, new_tindex);
+                newv.Vboxed = boxv;
+                newv.tbaa = tbaa;
+                newv.isimmutable = isimmutable;
+                return newv;
+            }
+        }
+    }
+    else {
+        return jl_cgval_t(boxed(ctx, v), NULL, true, typ, NULL);
+    }
+    return jl_cgval_t(v, typ, new_tindex);
+}
+
 // given a value marked with type `v.typ`, compute the mapping and/or boxing to return a value of type `typ`
-static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ, bool needsroot)
+static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_value_t *typ)
 {
     if (typ == (jl_value_t*)jl_typeofbottom_type)
         return ghostValue(typ); // normalize TypeofBottom to Type{Union{}}
@@ -825,8 +976,8 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
     if (jl_is_leaf_type(typ)) {
         if (v.TIndex && !isbits_spec(typ)) {
             // discovered that this union-split type must actually be isboxed
-            if (v.V) {
-                return jl_cgval_t(v.V, v.gcroot, true, typ, NULL);
+            if (v.Vboxed) {
+                return jl_cgval_t(v.Vboxed, nullptr, true, typ, NULL);
             }
             else {
                 // type mismatch: there weren't any boxed values in the union
@@ -845,145 +996,7 @@ static jl_cgval_t convert_julia_type(jl_codectx_t &ctx, const jl_cgval_t &v, jl_
     else {
         bool makeboxed = false;
         if (v.TIndex) {
-            // previous value was a split union, compute new index, or box
-            new_tindex = ConstantInt::get(T_int8, 0x80);
-            SmallBitVector skip_box(1, true);
-            Value *tindex = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x7f));
-            if (jl_is_uniontype(typ)) {
-                // compute the TIndex mapping from v.typ -> typ
-                unsigned counter = 0;
-                for_each_uniontype_small(
-                        // for each old union-split value
-                        [&](unsigned idx, jl_datatype_t *jt) {
-                            unsigned new_idx = get_box_tindex(jt, typ);
-                            bool t;
-                            if (new_idx) {
-                                // found a matching element,
-                                // match it against either the unboxed index
-                                Value *cmp = ctx.builder.CreateICmpEQ(tindex, ConstantInt::get(T_int8, idx));
-                                new_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, new_idx), new_tindex);
-                                t = true;
-                            }
-                            else if (!jl_subtype((jl_value_t*)jt, typ)) {
-                                // new value doesn't need to be boxed
-                                // since it isn't part of the new union
-                                t = true;
-                            }
-                            else {
-                                // will actually need to box this element
-                                // since it appeared as a leaftype in the original type
-                                // but not in the remark type
-                                t = false;
-                            }
-                            skip_box.resize(idx + 1, t);
-                        },
-                        v.typ,
-                        counter);
-            }
-
-            // some of the values are still unboxed
-            if (!isa<Constant>(new_tindex)) {
-                Value *wasboxed = NULL;
-                // check if some of the old values might have been boxed
-                // and copy that information over into the new tindex
-                if (v.ispointer() && v.V && !isa<AllocaInst>(v.V)) {
-                    wasboxed = ctx.builder.CreateAnd(v.TIndex, ConstantInt::get(T_int8, 0x80));
-                    new_tindex = ctx.builder.CreateOr(wasboxed, new_tindex);
-                    wasboxed = ctx.builder.CreateICmpNE(wasboxed, ConstantInt::get(T_int8, 0));
-
-                    // may need to handle compute_box_tindex for some of the values
-                    BasicBlock *currBB = ctx.builder.GetInsertBlock();
-                    Value *union_box_dt = NULL;
-                    Value *union_box_tindex = ConstantInt::get(T_int8, 0x80);
-                    unsigned counter = 0;
-                    for_each_uniontype_small(
-                            // for each new union-split value
-                            [&](unsigned idx, jl_datatype_t *jt) {
-                                unsigned old_idx = get_box_tindex(jt, v.typ);
-                                if (old_idx == 0) {
-                                    if (!union_box_dt) {
-                                        BasicBlock *isaBB = BasicBlock::Create(jl_LLVMContext, "union_isa", ctx.f);
-                                        ctx.builder.SetInsertPoint(isaBB);
-                                        union_box_dt = emit_typeof(ctx, v.V);
-                                    }
-                                    // didn't handle this item before, select its new union index
-                                    Value *cmp = ctx.builder.CreateICmpEQ(maybe_decay_untracked(literal_pointer_val(ctx, (jl_value_t*)jt)), union_box_dt);
-                                    union_box_tindex = ctx.builder.CreateSelect(cmp, ConstantInt::get(T_int8, 0x80 | idx), union_box_tindex);
-                                }
-                            },
-                            typ,
-                            counter);
-                    if (union_box_dt) {
-                        BasicBlock *isaBB = ctx.builder.GetInsertBlock();
-                        BasicBlock *postBB = BasicBlock::Create(jl_LLVMContext, "post_union_isa", ctx.f);
-                        ctx.builder.CreateBr(postBB);
-                        ctx.builder.SetInsertPoint(currBB);
-                        Value *wasunknown = ctx.builder.CreateICmpEQ(v.TIndex, ConstantInt::get(T_int8, 0x80));
-                        ctx.builder.CreateCondBr(wasunknown, isaBB, postBB);
-                        ctx.builder.SetInsertPoint(postBB);
-                        PHINode *tindex_phi = ctx.builder.CreatePHI(T_int8, 2);
-                        tindex_phi->addIncoming(new_tindex, currBB);
-                        tindex_phi->addIncoming(union_box_tindex, isaBB);
-                        new_tindex = tindex_phi;
-                    }
-
-                }
-
-                if (!skip_box.all()) {
-                    // some values weren't unboxed in the new union
-                    // box them now (tindex above already selected 0x80 = box for them)
-                    // root the result, and return a new mark_julia_slot over the result
-                    Value *boxv = box_union(ctx, v, skip_box);
-                    Value *froot = NULL;
-                    if (needsroot) {
-                        // build a new gc-root, as needed
-                        froot = emit_local_root(ctx);
-                        Value *newroot = boxv;
-                        if (wasboxed || v.gcroot) { // oldbox might be all ghost values (which don't need roots)
-                            // store either the old box or the new box into the gc-root (skip_box ensures these are mutually-exclusive)
-                            // need to clone the value from `v.gcroot` if this isn't a new box
-                            Value *oldroot;
-                            if (v.gcroot)
-                                oldroot = ctx.builder.CreateLoad(v.gcroot);
-                            else
-                                oldroot = v.V;
-                            newroot = ctx.builder.CreateSelect(wasboxed, emit_bitcast(ctx, oldroot, boxv->getType()), newroot);
-                        }
-                        ctx.builder.CreateStore(newroot, froot);
-                    }
-                    if (v.V == NULL) {
-                        // v.V might be NULL if it was all ghost objects before
-                        return jl_cgval_t(boxv, froot, false, typ, new_tindex);
-                    }
-                    else {
-                        Value *isboxv = ctx.builder.CreateIsNotNull(boxv);
-                        Value *slotv;
-                        MDNode *tbaa;
-                        bool isimmutable;
-                        if (v.ispointer()) {
-                            slotv = v.V;
-                            tbaa = v.tbaa;
-                            isimmutable = v.isimmutable;
-                        }
-                        else {
-                            slotv = emit_static_alloca(ctx, v.V->getType());
-                            ctx.builder.CreateStore(v.V, slotv);
-                            tbaa = tbaa_stack;
-                            isimmutable = true;
-                        }
-                        slotv = ctx.builder.CreateSelect(isboxv,
-                            decay_derived(boxv), emit_bitcast(ctx, slotv, boxv->getType()));
-                        jl_cgval_t newv = jl_cgval_t(slotv, froot, false, typ, new_tindex);
-                        newv.tbaa = tbaa;
-                        newv.isimmutable = isimmutable;
-                        return newv;
-                    }
-                }
-            }
-            else {
-                new_tindex = NULL;
-                makeboxed = true;
-            }
+            return convert_julia_type_union(ctx, v, typ);
         }
         else if (!v.isboxed && jl_is_uniontype(typ)) {
             // previous value was unboxed (leaftype), statically compute union tindex
@@ -1981,20 +1994,6 @@ static void simple_use_analysis(jl_codectx_t &ctx, jl_value_t *expr)
 
 // ---- Get Element Pointer (GEP) instructions within the GC frame ----
 
-// Emit a gc-root slot indicator
-static Value *emit_local_root(jl_codectx_t &ctx, jl_varinfo_t *vi)
-{
-    Instruction *newroot = new AllocaInst(T_prjlvalue, 0, "gcroot", /*InsertBefore*/ctx.ptlsStates);
-    if (vi) {
-        vi->boxroot->replaceAllUsesWith(newroot);
-        newroot->takeName(vi->boxroot);
-        vi->boxroot->eraseFromParent();
-        vi->boxroot = newroot;
-    }
-
-    return newroot;
-}
-
 static void jl_add_method_root(jl_codectx_t &ctx, jl_value_t *val)
 {
     if (jl_is_leaf_type(val) || jl_is_bool(val) || jl_is_symbol(val) ||
@@ -2905,9 +2904,7 @@ static jl_cgval_t emit_call_function_object(jl_method_instance_t *li, jl_llvm_fu
                                          jlretty,
                                          tindex,
                                          tbaa_stack);
-                // root this, if the return value was a box (tindex & 0x80) != 0
-                retval.gcroot = emit_local_root(ctx);
-                ctx.builder.CreateStore(box, retval.gcroot);
+                retval.Vboxed = box;
                 break;
             }
             case jl_returninfo_t::Ghosts:
@@ -3272,7 +3269,6 @@ static jl_cgval_t emit_local(jl_codectx_t &ctx, jl_value_t *slotload)
     if (vi.boxroot != NULL) {
         Value *boxed = ctx.builder.CreateLoad(vi.boxroot, vi.isVolatile);
         Value *box_isnull;
-        v.gcroot = vi.boxroot;
         if (vi.usedUndef)
             box_isnull = ctx.builder.CreateICmpNE(boxed, maybe_decay_untracked(V_null));
         if (vi.pTIndex) {
@@ -3284,11 +3280,11 @@ static jl_cgval_t emit_local(jl_codectx_t &ctx, jl_value_t *slotload)
             if (vi.usedUndef)
                 isnull = ctx.builder.CreateSelect(load_unbox, isnull, box_isnull);
             if (v.V) { // v.V will be null if it is a union of all ghost values
-                boxed = decay_derived(boxed);
                 v.V = ctx.builder.CreateSelect(load_unbox, emit_bitcast(ctx,
-                    decay_derived(v.V), boxed->getType()), boxed);
+                    decay_derived(v.V), boxed->getType()), decay_derived(boxed));
             } else
                 v.V = boxed;
+            v.Vboxed = boxed;
             v = update_julia_type(ctx, v, typ);
         }
         else {
@@ -3372,26 +3368,15 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
                 size_t min_align;
                 dest = try_emit_union_alloca(ctx, ((jl_uniontype_t*)jt), allunbox, min_align);
                 Value *isboxed = NULL;
-                if (slot.ispointer() && slot.V != NULL && !isa<AllocaInst>(slot.V)) {
+                if (slot.isboxed || slot.Vboxed != nullptr) {
                     isboxed = ctx.builder.CreateICmpNE(
                             ctx.builder.CreateAnd(slot.TIndex, ConstantInt::get(T_int8, 0x80)),
                             ConstantInt::get(T_int8, 0));
                 }
                 if (dest)
                     emit_unionmove(ctx, dest, slot, isboxed, false, NULL);
-                Value *gcroot = NULL;
                 if (isboxed) {
-                    Value *box;
-                    if (slot.gcroot) {
-                        gcroot = emit_local_root(ctx);
-                        // This might load the wrong object in general, but if it gets selected, below,
-                        // we know that it was in fact the one we wanted.
-                        box = ctx.builder.CreateLoad(slot.gcroot);
-                    } else {
-                        gcroot = emit_static_alloca(ctx, T_pjlvalue);
-                        box = V_null;
-                    }
-                    ctx.builder.CreateStore(box, gcroot);
+                    Value *box = slot.Vboxed ? slot.Vboxed : V_null;
                     if (dest) // might be all ghost values
                         dest = ctx.builder.CreateSelect(isboxed,
                             decay_derived(box),
@@ -3402,8 +3387,9 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
                 else {
                     assert(allunbox && "Failed to allocate correct union-type storage.");
                 }
+                Value *box = slot.Vboxed;
                 slot = mark_julia_slot(dest, slot.typ, slot.TIndex, tbaa_stack);
-                slot.gcroot = gcroot;
+                slot.Vboxed = box;
             }
             else {
                 bool isboxed;
@@ -3449,14 +3435,9 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
     if (!vi.used)
         return;
 
-    bool needs_root = false;
-    if ((!vi.isSA && rval_info.gcroot) || !rval_info.isboxed)
-        // rval needed a gcroot, so lval will need one too
-        needs_root = true;
-
     // convert rval-type to lval-type
     jl_value_t *slot_type = vi.value.typ;
-    rval_info = convert_julia_type(ctx, rval_info, slot_type, /*needs-root*/true);
+    rval_info = convert_julia_type(ctx, rval_info, slot_type);
     if (rval_info.typ == jl_bottom_type)
         return;
 
@@ -3491,18 +3472,13 @@ static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
     // store boxed variables
     Value *isboxed = NULL;
     if (vi.boxroot) {
-        if (isa<AllocaInst>(vi.boxroot) && needs_root)
-            emit_local_root(ctx, &vi); // promote variable slot to a gcroot
         Value *rval;
         if (vi.pTIndex && rval_info.TIndex) {
             ctx.builder.CreateStore(rval_info.TIndex, vi.pTIndex, vi.isVolatile);
             isboxed = ctx.builder.CreateICmpNE(
                     ctx.builder.CreateAnd(rval_info.TIndex, ConstantInt::get(T_int8, 0x80)),
                     ConstantInt::get(T_int8, 0));
-            rval = maybe_decay_untracked(V_null);
-            if (rval_info.ispointer() && rval_info.V != NULL && !isa<AllocaInst>(rval_info.V) &&
-                !(isa<Constant>(isboxed) && cast<ConstantInt>(isboxed)->isZero())) // might be all ghost values or otherwise definitely not boxed
-                rval = ctx.builder.CreateLoad(rval_info.gcroot);
+            rval = maybe_decay_untracked(rval_info.Vboxed ? rval_info.Vboxed : V_null);
             assert(!vi.value.constant);
         }
         else {
@@ -4576,8 +4552,7 @@ static Function *gen_jlcall_wrapper(jl_method_instance_t *lam, const jl_returnin
                                  jlretty,
                                  ctx.builder.CreateExtractValue(call, 1),
                                  tbaa_stack);
-        retval.gcroot = emit_local_root(ctx);
-        ctx.builder.CreateStore(ctx.builder.CreateExtractValue(call, 0), retval.gcroot);
+        retval.Vboxed = ctx.builder.CreateExtractValue(call, 0);
         break;
     case jl_returninfo_t::Ghosts:
         retval = mark_julia_slot(NULL, jlretty, call, tbaa_stack);
@@ -5254,10 +5229,8 @@ static std::unique_ptr<Module> emit_function(
                 }
             }
             else {
-                Value *argp = boxed(ctx, theArg); // skip the temporary gcroot since it would be folded to argp anyways
+                Value *argp = boxed(ctx, theArg);
                 ctx.builder.CreateStore(argp, vi.boxroot);
-                if (!theArg.isboxed)
-                    emit_local_root(ctx, &vi); // create a root for vi
             }
             // get arrayvar data if applicable
             if (arrayvars.find(i) != arrayvars.end()) {
@@ -5284,7 +5257,6 @@ static std::unique_ptr<Module> emit_function(
                                   ConstantInt::get(T_int32, nreq - 1)) });
             restTuple->setAttributes(jltuple_func->getAttributes());
             ctx.builder.CreateStore(restTuple, vi.boxroot);
-            emit_local_root(ctx, &vi); // create a root for vi
         }
     }
 
@@ -5537,7 +5509,7 @@ static std::unique_ptr<Module> emit_function(
             // this is basically a copy of emit_assignment,
             // but where the assignment slot is the retval
             jl_cgval_t retvalinfo = emit_expr(ctx, jl_exprarg(expr, 0));
-            retvalinfo = convert_julia_type(ctx, retvalinfo, jlrettype, /*needs-root*/false);
+            retvalinfo = convert_julia_type(ctx, retvalinfo, jlrettype);
             if (retvalinfo.typ == jl_bottom_type) {
                 ctx.builder.CreateUnreachable();
                 find_next_stmt(-1);
@@ -5572,20 +5544,13 @@ static std::unique_ptr<Module> emit_function(
                     }
                     else {
                         data = maybe_decay_untracked(V_null);
-                        if (retvalinfo.ispointer() && !isa<AllocaInst>(retvalinfo.V)) {
+                        if (retvalinfo.Vboxed) {
                             // also need to account for the possibility the return object is boxed
                             // and avoid / skip copying it to the stack
                             isboxed_union = ctx.builder.CreateICmpNE(
                                     ctx.builder.CreateAnd(tindex, ConstantInt::get(T_int8, 0x80)),
                                     ConstantInt::get(T_int8, 0));
-                            // Lift the select, because gcroot may be NULL if
-                            // there's no boxed value.
-                            if (isa<Constant>(isboxed_union))
-                                data = cast<ConstantInt>(isboxed_union)->isZero() ? data : ctx.builder.CreateLoad(retvalinfo.gcroot);
-                            else
-                                data = ctx.builder.CreateSelect(isboxed_union,
-                                    ctx.builder.CreateLoad(retvalinfo.gcroot),
-                                    data);
+                            data = ctx.builder.CreateSelect(isboxed_union, retvalinfo.Vboxed, data);
                         }
                     }
                 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6505,7 +6505,7 @@ static void init_julia_llvm_env(Module *m)
                                          "julia.gc_use");
     add_named_global(gc_use_func, (void*)NULL, /*dllimport*/false);
 
-    pointer_from_objref_func = Function::Create(FunctionType::get(T_pjlvalue,
+    pointer_from_objref_func = Function::Create(FunctionType::get(T_size,
                                          ArrayRef<Type*>(PointerType::get(T_jlvalue, AddressSpace::Derived)), false),
                                          Function::ExternalLinkage,
                                          "julia.pointer_from_objref");

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -784,6 +784,8 @@ JL_DLLEXPORT jl_value_t *jl_get_nth_field(jl_value_t *v, size_t i)
     if (jl_is_uniontype(ty)) {
         uint8_t sel = ((uint8_t*)v)[offs + jl_field_size(st, i) - 1];
         ty = jl_nth_union_component(ty, sel);
+        if (jl_is_datatype_singleton((jl_datatype_t*)ty))
+            return ((jl_datatype_t*)ty)->instance;
     }
     return jl_new_bits(ty, (char*)v + offs);
 }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -146,99 +146,113 @@ static Value *uint_cnvt(jl_codectx_t &ctx, Type *to, Value *x)
     return ctx.builder.CreateZExt(x, to);
 }
 
-#if JL_LLVM_VERSION >= 40000
-#define LLVM_FP(a,b) APFloat(a(),b)
-#else
-#define LLVM_FP(a,b) APFloat(a,b)
-#endif
-static Constant *julia_const_to_llvm(void *ptr, jl_value_t *bt)
+static Constant *julia_const_to_llvm(const void *ptr, jl_datatype_t *bt)
 {
     // assumes `jl_isbits(bt)`.
     // `ptr` can point to a inline field, do not read the tag from it.
     // make sure to return exactly the type specified by
     // julia_type_to_llvm as this will be assumed by the callee.
-    if (bt == (jl_value_t*)jl_bool_type)
-        return ConstantInt::get(T_int8, (*(uint8_t*)ptr) ? 1 : 0);
+    if (bt == jl_bool_type)
+        return ConstantInt::get(T_int8, (*(const uint8_t*)ptr) ? 1 : 0);
 
-    if (bt == (jl_value_t*)jl_ssavalue_type)
-        return NULL;
+    if (jl_is_vecelement_type((jl_value_t*)bt))
+        bt = (jl_datatype_t*)jl_tparam0(bt);
 
-    if (jl_is_vecelement_type(bt))
-        bt = jl_tparam0(bt);
+    Type *lt = julia_struct_to_llvm((jl_value_t*)bt, NULL, NULL);
 
-    if (jl_is_cpointer_type(bt))
-        return ConstantExpr::getIntToPtr(ConstantInt::get(T_size, *(uintptr_t*)ptr), julia_type_to_llvm(bt));
+    if (type_is_ghost(lt))
+        return UndefValue::get(NoopType);
+
     if (jl_is_primitivetype(bt)) {
+        if (lt->isFloatTy()) {
+            uint32_t data32 = *(const uint32_t*)ptr;
+            return ConstantFP::get(jl_LLVMContext,
+                    APFloat(lt->getFltSemantics(), APInt(32, data32)));
+        }
+        if (lt->isDoubleTy()) {
+            uint64_t data64 = *(const uint64_t*)ptr;
+            return ConstantFP::get(jl_LLVMContext,
+                    APFloat(lt->getFltSemantics(), APInt(64, data64)));
+        }
         int nb = jl_datatype_size(bt);
-        // TODO: non-power-of-2 size datatypes may not be interpreted correctly on big-endian systems
-        switch (nb) {
-        case 1: {
-            uint8_t data8 = *(uint8_t*)ptr;
-            return ConstantInt::get(T_int8, data8);
+        APInt val(8 * nb, 0);
+        void *bits = const_cast<uint64_t*>(val.getRawData());
+        assert(sys::IsLittleEndianHost);
+        memcpy(bits, ptr, nb);
+        if (lt->isFloatingPointTy()) {
+            return ConstantFP::get(jl_LLVMContext,
+                    APFloat(lt->getFltSemantics(), val));
         }
-        case 2: {
-            uint16_t data16 = *(uint16_t*)ptr;
-            return ConstantInt::get(T_int16, data16);
-        }
-        case 4: {
-            uint32_t data32 = *(uint32_t*)ptr;
-            if (bt == (jl_value_t*)jl_float32_type)
-                return ConstantFP::get(jl_LLVMContext,
-                        LLVM_FP(APFloat::IEEEsingle,
-                            APInt(32, data32)));
-            return ConstantInt::get(T_int32, data32);
-        }
-        case 8: {
-            uint64_t data64 = *(uint64_t*)ptr;
-            if (bt == (jl_value_t*)jl_float64_type)
-                return ConstantFP::get(jl_LLVMContext,
-                        LLVM_FP(APFloat::IEEEdouble,
-                            APInt(64, data64)));
-            return ConstantInt::get(T_int64, data64);
-        }
-        default:
-            size_t nw = (nb+sizeof(uint64_t)-1)/sizeof(uint64_t);
-            uint64_t *data = (uint64_t*)ptr;
-            APInt val;
-#if !defined(_P64)
-            // malloc may not be 16-byte aligned on P32,
-            // but we must ensure that llvm's uint64_t reads don't fall
-            // off the end of a page
-            // where 16-byte alignment requirement == (8-byte typetag) % (uint64_t ArrayRef access)
-            if (nb % 16 != 0) {
-                uint64_t *data_a64 = (uint64_t*)alloca(sizeof(uint64_t)*nw);
-                memcpy(data_a64, data, nb);
-                val = APInt(8*nb, ArrayRef<uint64_t>(data_a64, nw));
-            }
-            else
-#endif
-            val = APInt(8*nb, ArrayRef<uint64_t>(data, nw));
-            return ConstantInt::get(IntegerType::get(jl_LLVMContext,8*nb),val);
-        }
+        assert(cast<IntegerType>(lt)->getBitWidth() == 8u * nb);
+        return ConstantInt::get(lt, val);
     }
+
+    CompositeType *lct = cast<CompositeType>(lt);
     size_t nf = jl_datatype_nfields(bt);
-    Constant **fields = (Constant**)alloca(nf * sizeof(Constant*));
+    std::vector<Constant*> fields(nf);
     for (size_t i = 0; i < nf; i++) {
-        size_t offs = jl_field_offset((jl_datatype_t*)bt, i);
+        size_t offs = jl_field_offset(bt, i);
+        assert(!jl_field_isptr(bt, i));
         jl_value_t *ft = jl_field_type(bt, i);
-        Constant *val = julia_const_to_llvm((char*)ptr + offs, ft);
-        if (val == NULL)
-            return NULL;
+        Type *lft = lct->getTypeAtIndex(i);
+        const uint8_t *ov = (const uint8_t*)ptr + offs;
+        Constant *val;
+        if (jl_is_uniontype(ft)) {
+            // compute the same type layout as julia_struct_to_llvm
+            size_t fsz = jl_field_size(bt, i);
+            size_t al = jl_field_align(bt, i);
+            uint8_t sel = ((const uint8_t*)ptr)[offs + fsz - 1];
+            jl_value_t *active_ty = jl_nth_union_component(ft, sel);
+            size_t active_sz = jl_datatype_size(active_ty);
+            ArrayType *aty = cast<ArrayType>(cast<StructType>(lft)->getTypeAtIndex(0u));
+            assert(aty->getElementType() == IntegerType::get(jl_LLVMContext, 8 * al) &&
+                   aty->getNumElements() == (fsz - 1) / al);
+            std::vector<Constant*> ArrayElements(0);
+            for (unsigned j = 0; j < aty->getNumElements(); j++) {
+                APInt Elem(8 * al, 0);
+                void *bits = const_cast<uint64_t*>(Elem.getRawData());
+                if (active_sz > al) {
+                    memcpy(bits, ov, al);
+                    active_sz -= al;
+                }
+                else if (active_sz > 0) {
+                    memcpy(bits, ov, active_sz);
+                    active_sz = 0;
+                }
+                ov += al;
+                ArrayElements.push_back(ConstantInt::get(aty->getElementType(), Elem));
+            }
+            std::vector<Constant*> Elements(0);
+            Elements.push_back(ConstantArray::get(aty, ArrayElements));
+            unsigned remainder = (fsz - 1) % al;
+            while (remainder--) {
+                uint8_t byte;
+                if (active_sz > 0) {
+                    byte = *ov;
+                    active_sz -= 1;
+                }
+                else {
+                    byte = 0;
+                }
+                ov += 1;
+                APInt Elem(8, byte);
+                Elements.push_back(ConstantInt::get(T_int8, Elem));
+            }
+            Elements.push_back(ConstantInt::get(T_int8, sel));
+            val = ConstantStruct::get(cast<StructType>(lft), Elements);
+        }
+        else {
+            val = julia_const_to_llvm(ov, (jl_datatype_t*)ft);
+        }
         fields[i] = val;
     }
 
-    Type *t = julia_struct_to_llvm(bt, NULL, NULL);
-    if (type_is_ghost(t))
-        return UndefValue::get(NoopType);
-    if (t->isVectorTy())
-        return ConstantVector::get(ArrayRef<Constant*>(fields, nf));
-    if (StructType *st = dyn_cast<StructType>(t)) {
-        return ConstantStruct::get(st, ArrayRef<Constant*>(fields, nf));
-    }
-    else {
-        ArrayType *at = cast<ArrayType>(t);
-        return ConstantArray::get(at, ArrayRef<Constant*>(fields, nf));
-    }
+    if (lct->isVectorTy())
+        return ConstantVector::get(fields);
+    if (StructType *st = dyn_cast<StructType>(lct))
+        return ConstantStruct::get(st, fields);
+    ArrayType *at = cast<ArrayType>(lct);
+    return ConstantArray::get(at, fields);
 }
 
 static Constant *julia_const_to_llvm(jl_value_t *e)
@@ -250,7 +264,7 @@ static Constant *julia_const_to_llvm(jl_value_t *e)
     jl_value_t *bt = jl_typeof(e);
     if (!jl_isbits(bt))
         return NULL;
-    return julia_const_to_llvm(e, bt);
+    return julia_const_to_llvm(e, (jl_datatype_t*)bt);
 }
 
 static jl_cgval_t ghostValue(jl_value_t *ty);
@@ -577,15 +591,15 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
     Value *idx = emit_unbox(ctx, T_size, i, (jl_value_t*)jl_long_type);
     Value *im1 = ctx.builder.CreateSub(idx, ConstantInt::get(T_size, 1));
 
-    if (!jl_isbits(ety)) {
-        if (ety == (jl_value_t*)jl_any_type) {
-            Value *thePtr = emit_unbox(ctx, T_pprjlvalue, e, e.typ);
-            return mark_julia_type(
-                    ctx,
-                    ctx.builder.CreateAlignedLoad(ctx.builder.CreateGEP(thePtr, im1), align_nb),
-                    true,
-                    ety);
-        }
+    if (ety == (jl_value_t*)jl_any_type) {
+        Value *thePtr = emit_unbox(ctx, T_pprjlvalue, e, e.typ);
+        return mark_julia_type(
+                ctx,
+                ctx.builder.CreateAlignedLoad(ctx.builder.CreateGEP(T_prjlvalue, thePtr, im1), align_nb),
+                true,
+                ety);
+    }
+    else if (!jl_isbits(ety)) {
         if (!jl_is_structtype(ety) || jl_is_array_type(ety) || !jl_is_leaf_type(ety)) {
             emit_error(ctx, "pointerref: invalid pointer type");
             return jl_cgval_t();
@@ -597,16 +611,17 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
         im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));
         Value *thePtr = emit_unbox(ctx, T_pint8, e, e.typ);
-        thePtr = ctx.builder.CreateGEP(emit_bitcast(ctx, thePtr, T_pint8), im1);
+        thePtr = ctx.builder.CreateGEP(T_int8, emit_bitcast(ctx, thePtr, T_pint8), im1);
         ctx.builder.CreateMemCpy(emit_bitcast(ctx, strct, T_pint8), thePtr, size, 1);
         return mark_julia_type(ctx, strct, true, ety);
     }
-
-    bool isboxed;
-    Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
-    assert(!isboxed);
-    Value *thePtr = emit_unbox(ctx, ptrty, e, e.typ);
-    return typed_load(ctx, thePtr, im1, ety, tbaa_data, true, align_nb);
+    else {
+        bool isboxed;
+        Type *ptrty = julia_type_to_llvm(ety, &isboxed);
+        assert(!isboxed);
+        Value *thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
+        return typed_load(ctx, thePtr, im1, ety, tbaa_data, true, align_nb);
+    }
 }
 
 static jl_cgval_t emit_runtime_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
@@ -644,7 +659,15 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
     Value *im1 = ctx.builder.CreateSub(idx, ConstantInt::get(T_size, 1));
 
     Value *thePtr;
-    if (!jl_isbits(ety) && ety != (jl_value_t*)jl_any_type) {
+    if (ety == (jl_value_t*)jl_any_type) {
+        // unsafe_store to Ptr{Any} is allowed to implicitly drop GC roots.
+        thePtr = emit_unbox(ctx, T_psize, e, e.typ);
+        Instruction *store = ctx.builder.CreateAlignedStore(
+          emit_pointer_from_objref(ctx, boxed(ctx, x)),
+            ctx.builder.CreateGEP(T_size, thePtr, im1), align_nb);
+        tbaa_decorate(tbaa_data, store);
+    }
+    else if (!jl_isbits(ety)) {
         if (!jl_is_structtype(ety) || jl_is_array_type(ety) || !jl_is_leaf_type(ety)) {
             emit_error(ctx, "pointerset: invalid pointer type");
             return jl_cgval_t();
@@ -653,23 +676,15 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
         uint64_t size = jl_datatype_size(ety);
         im1 = ctx.builder.CreateMul(im1, ConstantInt::get(T_size,
                     LLT_ALIGN(size, jl_datatype_align(ety))));
-        ctx.builder.CreateMemCpy(ctx.builder.CreateGEP(thePtr, im1),
+        ctx.builder.CreateMemCpy(ctx.builder.CreateGEP(T_int8, thePtr, im1),
                              data_pointer(ctx, x, T_pint8), size, align_nb);
     }
     else {
         bool isboxed;
-        Type *ptrty = julia_type_to_llvm(e.typ, &isboxed);
+        Type *ptrty = julia_type_to_llvm(ety, &isboxed);
         assert(!isboxed);
-        thePtr = emit_unbox(ctx, ptrty, e, e.typ);
-        if (ety == (jl_value_t*)jl_any_type) {
-            // unsafe_store to Ptr{Any} is allowed to implicitly drop GC roots.
-            Instruction *store = ctx.builder.CreateAlignedStore(
-              emit_pointer_from_objref(ctx, boxed(ctx, x)),
-                ctx.builder.CreateGEP(thePtr, im1), align_nb);
-            tbaa_decorate(tbaa_data, store);
-        } else {
-            typed_store(ctx, thePtr, im1, x, ety, tbaa_data, NULL, align_nb);
-        }
+        thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
+        typed_store(ctx, thePtr, im1, x, ety, tbaa_data, NULL, align_nb);
     }
     return mark_julia_type(ctx, thePtr, false, aty);
 }

--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -491,6 +491,7 @@ void AllocOpt::replaceUsesWith(Instruction *orig_inst, Instruction *new_inst,
         }
         else if (auto call = dyn_cast<CallInst>(user)) {
             if (ptr_from_objref && ptr_from_objref == call->getCalledFunction()) {
+                new_i = new PtrToIntInst(new_i, T_size, "", call);
                 call->replaceAllUsesWith(new_i);
                 call->eraseFromParent();
                 return;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1156,10 +1156,9 @@ bool LateLowerGCFrame::CleanupIR(Function &F) {
                 (gc_use_func != nullptr && callee == gc_use_func)) {
                 /* No replacement */
             } else if (pointer_from_objref_func != nullptr && callee == pointer_from_objref_func) {
-                auto *ASCI = new AddrSpaceCastInst(CI->getOperand(0),
-                    CI->getType(), "", CI);
-                ASCI->takeName(CI);
-                CI->replaceAllUsesWith(ASCI);
+                auto *ptr = new PtrToIntInst(CI->getOperand(0), CI->getType(), "", CI);
+                ptr->takeName(CI);
+                CI->replaceAllUsesWith(ptr);
             } else if (alloc_obj_func && callee == alloc_obj_func) {
                 assert(CI->getNumArgOperands() == 3);
                 auto sz = (size_t)cast<ConstantInt>(CI->getArgOperand(1))->getZExtValue();

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -887,9 +887,12 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
                     n += jl_static_show_x(out, *(jl_value_t**)fld_ptr, depth);
                 }
                 else {
-                    n += jl_static_show_x_(out, (jl_value_t*)fld_ptr,
-                                           (jl_datatype_t*)jl_field_type(vt, i),
-                                           depth);
+                    jl_datatype_t *ft = (jl_datatype_t*)jl_field_type(vt, i);
+                    if (jl_is_uniontype(ft)) {
+                        uint8_t sel = ((uint8_t*)fld_ptr)[jl_field_size(vt, i) - 1];
+                        ft = (jl_datatype_t*)jl_nth_union_component((jl_value_t*)ft, sel);
+                    }
+                    n += jl_static_show_x_(out, (jl_value_t*)fld_ptr, ft, depth);
                 }
                 if (istuple && tlen == 1)
                     n += jl_printf(out, ",");

--- a/test/core.jl
+++ b/test/core.jl
@@ -5316,6 +5316,26 @@ x.u = initvalue2(Base.uniontypes(U)[1])
 x.u = initvalue(Base.uniontypes(U)[2])
 @test x.u === initvalue(Base.uniontypes(U)[2])
 
+struct AA
+    x::Union{Int8, Int16, NTuple{7, Int8}, Void}
+end
+struct B
+    x::Int8
+    y::AA
+    z::Int8
+end
+b = B(91, AA(ntuple(i -> Int8(i), Val(7))), 23)
+
+@test b.x === Int8(91)
+@test b.z === Int8(23)
+@test b.y === AA(ntuple(i -> Int8(i), Val(7)))
+@test sizeof(b) == 12
+@test AA(Int8(1)).x === Int8(1)
+@test AA(Int8(0)).x === Int8(0)
+@test AA(Int16(1)).x === Int16(1)
+@test AA(nothing).x === nothing
+@test sizeof(b.y) == 8
+
 for U in boxedunions
     local U
     for N in (1, 2, 3, 4)

--- a/test/core.jl
+++ b/test/core.jl
@@ -5316,19 +5316,23 @@ x.u = initvalue2(Base.uniontypes(U)[1])
 x.u = initvalue(Base.uniontypes(U)[2])
 @test x.u === initvalue(Base.uniontypes(U)[2])
 
-struct AA
+# PR #23367
+struct A23367
     x::Union{Int8, Int16, NTuple{7, Int8}, Void}
 end
-struct B
+struct B23367
     x::Int8
-    y::AA
+    y::A23367
     z::Int8
 end
 @noinline compare(a, b) = (a === b) # test code-generation of `is`
+@noinline get_x(a::A23367) = a.x
+function constant23367 end
 let
-    b = B(91, AA(ntuple(i -> Int8(i), Val(7))), 23)
+    b = B23367(91, A23367(ntuple(i -> Int8(i), Val(7))), 23)
+    @eval @noinline constant23367(a, b) = (a ? b : $b)
     b2 = Ref(b)[] # copy b via field assignment
-    b3 = B[b][1] # copy b via array assignment
+    b3 = B23367[b][1] # copy b via array assignment
     @test pointer_from_objref(b) == pointer_from_objref(b)
     @test pointer_from_objref(b) != pointer_from_objref(b2)
     @test pointer_from_objref(b) != pointer_from_objref(b3)
@@ -5340,13 +5344,19 @@ let
     @test object_id(b) === object_id(b2) == object_id(b3)
     @test b.x === Int8(91)
     @test b.z === Int8(23)
-    @test b.y === AA((Int8(1), Int8(2), Int8(3), Int8(4), Int8(5), Int8(6), Int8(7)))
+    @test b.y === A23367((Int8(1), Int8(2), Int8(3), Int8(4), Int8(5), Int8(6), Int8(7)))
     @test sizeof(b) == 12
-    @test AA(Int8(1)).x === Int8(1)
-    @test AA(Int8(0)).x === Int8(0)
-    @test AA(Int16(1)).x === Int16(1)
-    @test AA(nothing).x === nothing
+    @test A23367(Int8(1)).x === Int8(1)
+    @test A23367(Int8(0)).x === Int8(0)
+    @test A23367(Int16(1)).x === Int16(1)
+    @test A23367(nothing).x === nothing
     @test sizeof(b.y) == 8
+    @test get_x(A23367(Int8(1))) === Int8(1)
+
+    # test code-generation of constants
+    other = B23367(91, A23367(nothing), 23)
+    @test constant23367(true, other) === other
+    @test constant23367(false, other) === b
 end
 
 for U in boxedunions
@@ -5364,10 +5374,12 @@ for U in boxedunions
 end
 
 # unsafe_wrap
-A4 = [1, 2, 3]
-@test_throws ArgumentError unsafe_wrap(Array, convert(Ptr{Union{Int, Void}}, pointer(A4)), 3)
-A5 = [1 2 3; 4 5 6]
-@test_throws ArgumentError unsafe_wrap(Array, convert(Ptr{Union{Int, Void}}, pointer(A5)), 6)
+let
+    A4 = [1, 2, 3]
+    @test_throws ArgumentError unsafe_wrap(Array, convert(Ptr{Union{Int, Void}}, pointer(A4)), 3)
+    A5 = [1 2 3; 4 5 6]
+    @test_throws ArgumentError unsafe_wrap(Array, convert(Ptr{Union{Int, Void}}, pointer(A5)), 6)
+end
 
 # copy!
 A23567 = Vector{Union{Float64, Void}}(5)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -76,6 +76,8 @@ end
     a = Base.cconvert(Ptr{LibGit2.StrArrayStruct}, p)
     b = Base.unsafe_convert(Ptr{LibGit2.StrArrayStruct}, a)
     @test p == convert(Vector{String}, unsafe_load(b))
+    @noinline gcuse(a) = a
+    gcuse(a)
 end
 
 @testset "Signature" begin


### PR DESCRIPTION
@vtjnash, this isn't quite right yet. When constructed, the selector byte and any non-union fields aren't getting set correctly.

I'm kind of just taking a stab here, and I'm guessing that my use of `fval_info` and `dest` are not quite right, hence the non-working solution here. For example, when I run
```julia
struct BitsUnion
    x::Union{Int64, Float64}
end
BitsUnion(5.0)
```
the `fval_info` is
```
(lldb) call jl_(fval_info.constant)
#<null>
(lldb) call jl_(fval_info.typ)
Float64
(lldb) p fval_info.isimmutable
(const bool) $0 = false
```
I'm not sure why the `fval_info.constant` isn't set, but that causes problems when we try to `compute_tindex_unboxed` later against `BitsUnion`. 

I won't be able to do much else on this for the rest of the day, but any pointers/tips/direction you or @yuyichao could provide would be much appreciated.

fix #23351