### PR TITLE
Make behavior of `^(::Matrix{<:Integer},::Integer)` consistent with behavior of `^(::Integer, ::Integer)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -146,6 +146,10 @@ This section lists changes that do not have deprecation warnings.
   * Worker-worker connections are setup lazily for an `:all_to_all` topology. Use keyword
     arg `lazy=false` to force all connections to be setup during a `addprocs` call. ([#22814])
 
+  * `^(A::Matrix{S}, p::T) where S<:Integer, T<:Integer` now throws a `DomainError` if
+    `p<0` and `A!=I` and `A!=-I`. It also promotes types in the same way as
+    `^(x::S, p::T)` ([#23366])
+
 Library improvements
 --------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -146,9 +146,13 @@ This section lists changes that do not have deprecation warnings.
   * Worker-worker connections are setup lazily for an `:all_to_all` topology. Use keyword
     arg `lazy=false` to force all connections to be setup during a `addprocs` call. ([#22814])
 
-  * `^(A::Matrix{S}, p::T) where S<:Integer, T<:Integer` now throws a `DomainError` if
-    `p<0` and `A!=I` and `A!=-I`. It also promotes types in the same way as
-    `^(x::S, p::T)` ([#23366])
+  * `^(A::AbstractMatrix{<:Integer}, p::Integer)` now throws a `DomainError`
+    if `p < 0`, unless `A == one(A)` or `A == -one(A)` (same as for
+    `^(A::Integer, p::Integer)`) ([#23366]).
+
+  * `^(A::AbstractMatrix{<:Integer}, p::Integer)` now promotes the element type in the same
+    way as `^(A::Integer, p::Integer)`. This means, for instance, that `[1 1; 0 1]^big(1)`
+    will return a `Matrix{BigInt}` instead of a `Matrix{Int}` ([#23366]).
 
 Library improvements
 --------------------

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -162,8 +162,11 @@ invmod(n::Integer, m::Integer) = invmod(promote(n,m)...)
 to_power_type(x) = convert(Base.promote_op(*, typeof(x), typeof(x)), x)
 @noinline throw_domerr_powbysq(::Any, p) = throw(DomainError(p,
     string("Cannot raise an integer x to a negative power ", p, '.',
-           "\nMake x a float by adding a zero decimal (e.g., 2.0^$p instead ",
-           "of 2^$p), or write 1/x^$(-p), float(x)^$p, or (x//1)^$p")))
+           "\nConvert input to float.")))
+@noinline throw_domerr_powbysq(::Integer, p) = throw(DomainError(p,
+   string("Cannot raise an integer x to a negative power ", p, '.',
+          "\nMake x a float by adding a zero decimal (e.g., 2.0^$p instead ",
+          "of 2^$p), or write 1/x^$(-p), float(x)^$p, or (x//1)^$p")))
 @noinline throw_domerr_powbysq(::AbstractMatrix, p) = throw(DomainError(p,
    string("Cannot raise an integer matrix x to a negative power ", p, '.',
           "\nMake x a float matrix by adding a zero decimal ",

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -160,10 +160,15 @@ invmod(n::Integer, m::Integer) = invmod(promote(n,m)...)
 
 # ^ for any x supporting *
 to_power_type(x) = convert(Base.promote_op(*, typeof(x), typeof(x)), x)
-@noinline throw_domerr_powbysq(p) = throw(DomainError(p,
+@noinline throw_domerr_powbysq(::Any, p) = throw(DomainError(p,
     string("Cannot raise an integer x to a negative power ", p, '.',
            "\nMake x a float by adding a zero decimal (e.g., 2.0^$p instead ",
            "of 2^$p), or write 1/x^$(-p), float(x)^$p, or (x//1)^$p")))
+@noinline throw_domerr_powbysq(::AbstractMatrix, p) = throw(DomainError(p,
+   string("Cannot raise an integer matrix x to a negative power ", p, '.',
+          "\nMake x a float matrix by adding a zero decimal ",
+          "(e.g., [2.0 1.0;1.0 0.0]^$p instead ",
+          "of [2 1;1 0]^$p), or write float(x)^$p or Rational.(x)^$p")))
 function power_by_squaring(x_, p::Integer)
     x = to_power_type(x_)
     if p == 1
@@ -175,7 +180,7 @@ function power_by_squaring(x_, p::Integer)
     elseif p < 0
         isone(x) && return copy(x)
         isone(-x) && return iseven(p) ? one(x) : copy(x)
-        throw_domerr_powbysq(p)
+        throw_domerr_powbysq(x, p)
     end
     t = trailing_zeros(p) + 1
     p >>= t
@@ -195,7 +200,7 @@ function power_by_squaring(x_, p::Integer)
 end
 power_by_squaring(x::Bool, p::Unsigned) = ((p==0) | x)
 function power_by_squaring(x::Bool, p::Integer)
-    p < 0 && !x && throw_domerr_powbysq(p)
+    p < 0 && !x && throw_domerr_powbysq(x, p)
     return (p==0) | x
 end
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -159,7 +159,7 @@ end
 invmod(n::Integer, m::Integer) = invmod(promote(n,m)...)
 
 # ^ for any x supporting *
-to_power_type(x) = convert(Base.promote_op(*, typeof(x), typeof(x)), x)
+to_power_type(x) = convert(promote_op(*, typeof(x), typeof(x)), x)
 @noinline throw_domerr_powbysq(::Any, p) = throw(DomainError(p,
     string("Cannot raise an integer x to a negative power ", p, '.',
            "\nConvert input to float.")))

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -159,8 +159,7 @@ end
 invmod(n::Integer, m::Integer) = invmod(promote(n,m)...)
 
 # ^ for any x supporting *
-to_power_type(x::Number) = oftype(x*x, x)
-to_power_type(x) = x
+to_power_type(x) = convert(Base.promote_op(*, typeof(x), typeof(x)), x)
 @noinline throw_domerr_powbysq(p) = throw(DomainError(p,
     string("Cannot raise an integer x to a negative power ", p, '.',
            "\nMake x a float by adding a zero decimal (e.g., 2.0^$p instead ",
@@ -174,8 +173,8 @@ function power_by_squaring(x_, p::Integer)
     elseif p == 2
         return x*x
     elseif p < 0
-        x == 1 && return copy(x)
-        x == -1 && return iseven(p) ? one(x) : copy(x)
+        isone(x) && return copy(x)
+        isone(-x) && return iseven(p) ? one(x) : copy(x)
         throw_domerr_powbysq(p)
     end
     t = trailing_zeros(p) + 1

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -357,14 +357,15 @@ kron(a::AbstractMatrix, b::AbstractVector) = kron(a, reshape(b, length(b), 1))
 kron(a::AbstractVector, b::AbstractMatrix) = kron(reshape(a, length(a), 1), b)
 
 # Matrix power
-(^)(A::AbstractMatrix, p::Integer) = p < 0 ? Base.power_by_squaring(inv(A), -p) : Base.power_by_squaring(A, p)
+(^)(A::AbstractMatrix, p::Integer) = p < 0 ? power_by_squaring(inv(A), -p) : power_by_squaring(A, p)
 function (^)(A::AbstractMatrix{T}, p::Integer) where T<:Integer
-    TT = Base.promote_op(^, T, typeof(p)) # make sure that e.g. [1 1;1 0]^big(3)
+    # make sure that e.g. [1 1;1 0]^big(3)
     # gets promotes in a similar way as 2^big(3)
-    return Base.power_by_squaring(convert(AbstractMatrix{TT}, A), p)
+    TT = promote_op(^, T, typeof(p))
+    return power_by_squaring(convert(AbstractMatrix{TT}, A), p)
 end
 function integerpow(A::AbstractMatrix{T}, p) where T
-    TT = Base.promote_op(^, T, typeof(p))
+    TT = promote_op(^, T, typeof(p))
     return (TT == T ? A : copy!(similar(A, TT), A))^Integer(p)
 end
 function schurpow(A::AbstractMatrix, p)

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -360,29 +360,7 @@ kron(a::AbstractVector, b::AbstractMatrix) = kron(reshape(a, length(a), 1), b)
 (^)(A::AbstractMatrix, p::Integer) = p < 0 ? Base.power_by_squaring(inv(A), -p) : Base.power_by_squaring(A, p)
 function (^)(A::AbstractMatrix{T}, p::Integer) where T<:Integer
     TT = Base.promote_op(^, T, typeof(p))
-    if p<0
-        # if !isone(A) and !isone(-A), throw a domain error
-        m, n = size(A)
-        if m != n || !isdiag(A)
-            Base.throw_domerr_powbysq(p)
-        end
-        is_eye, is_minus_eye = true, true
-        for i = 1:m
-            is_eye = is_eye && A[i, i] == 1
-            is_minus_eye = is_minus_eye && A[i, i] == -1
-            if !is_eye && !is_minus_eye
-                Base.throw_domerr_powbysq(p)
-            end
-        end
-        # if isone(A) or isone(-A), return one(A) or -one(A)
-        if is_eye
-            return copy!(similar(A, TT), A)
-        else
-            return iseven(p) ? eye(TT, m, n) : copy!(similar(A, TT), A)
-        end
-    else
-        return Base.power_by_squaring(TT == T ? A : copy!(similar(A, TT), A), p)
-    end
+    return Base.power_by_squaring(TT == T ? A : copy!(similar(A, TT), A), p)
 end
 function integerpow(A::AbstractMatrix{T}, p) where T
     TT = Base.promote_op(^, T, typeof(p))

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -359,8 +359,9 @@ kron(a::AbstractVector, b::AbstractMatrix) = kron(reshape(a, length(a), 1), b)
 # Matrix power
 (^)(A::AbstractMatrix, p::Integer) = p < 0 ? Base.power_by_squaring(inv(A), -p) : Base.power_by_squaring(A, p)
 function (^)(A::AbstractMatrix{T}, p::Integer) where T<:Integer
-    TT = Base.promote_op(^, T, typeof(p))
-    return Base.power_by_squaring(TT == T ? A : copy!(similar(A, TT), A), p)
+    TT = Base.promote_op(^, T, typeof(p)) # make sure that e.g. [1 1;1 0]^big(3)
+    # gets promotes in a similar way as 2^big(3)
+    return Base.power_by_squaring(convert(AbstractMatrix{TT}, A), p)
 end
 function integerpow(A::AbstractMatrix{T}, p) where T
     TT = Base.promote_op(^, T, typeof(p))

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -374,7 +374,7 @@ function (^)(A::AbstractMatrix{T}, p::Integer) where T<:Integer
                 Base.throw_domerr_powbysq(p)
             end
         end
-        # if isone(A) or isone(A), return one(A) or -one(A)
+        # if isone(A) or isone(-A), return one(A) or -one(A)
         if is_eye
             return copy!(similar(A, TT), A)
         else is_minus_eye

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -377,7 +377,7 @@ function (^)(A::AbstractMatrix{T}, p::Integer) where T<:Integer
         # if isone(A) or isone(-A), return one(A) or -one(A)
         if is_eye
             return copy!(similar(A, TT), A)
-        else is_minus_eye
+        else
             return iseven(p) ? eye(TT, m, n) : copy!(similar(A, TT), A)
         end
     else

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -235,7 +235,7 @@ ERROR: DomainError with -5:
 Cannot raise an integer x to a negative power -5.
 Make x a float by adding a zero decimal (e.g., 2.0^-5 instead of 2^-5), or write 1/x^5, float(x)^-5, or (x//1)^-5
 Stacktrace:
- [1] throw_domerr_powbysq(::Int64) at ./intfuncs.jl:163
+ [1] throw_domerr_powbysq(::Int64, ::Int64) at ./intfuncs.jl:163
  [2] power_by_squaring at ./intfuncs.jl:178 [inlined]
  [3] ^ at ./intfuncs.jl:202 [inlined]
  [4] literal_pow(::Base.#^, ::Int64, ::Val{-5}) at ./intfuncs.jl:213

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -235,7 +235,7 @@ ERROR: DomainError with -5:
 Cannot raise an integer x to a negative power -5.
 Make x a float by adding a zero decimal (e.g., 2.0^-5 instead of 2^-5), or write 1/x^5, float(x)^-5, or (x//1)^-5
 Stacktrace:
- [1] throw_domerr_powbysq(::Int64, ::Int64) at ./intfuncs.jl:163
+ [1] throw_domerr_powbysq(::Int64) at ./intfuncs.jl:163
  [2] power_by_squaring at ./intfuncs.jl:178 [inlined]
  [3] ^ at ./intfuncs.jl:202 [inlined]
  [4] literal_pow(::Base.#^, ::Int64, ::Val{-5}) at ./intfuncs.jl:213

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -582,6 +582,25 @@ end
     end
 end
 
+@testset "issue #23366 (Int Matrix to Int power)" begin
+    @testset "Tests for $elty" for elty in (Int128, Int16, Int32, Int64, Int8,
+                                            UInt128, UInt16, UInt32, UInt64, UInt8,
+                                            BigInt)
+        @test_throws DomainError elty[1 1;1 0]^-2
+        @test elty[1 1;1 0]^2 == elty[2 1;1 1]
+        I_ = elty[1 0;0 1]
+        @test I_^-1 == I_
+        if !(elty<:Unsigned)
+            @test (-I_)^-1 == -I_
+            @test (-I_)^-2 == I_
+        end
+        for elty2 = (Int64, BigInt)
+            TT = Base.promote_op(^, elty, elty2)
+            @test Base.return_types(^, (Array{elty,2}, elty2)) == [Array{TT,2}]
+        end
+    end
+end
+
 @testset "Least squares solutions" begin
     a = [ones(20) 1:20 1:20]
     b = reshape(eye(8, 5), 20, 2)

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -587,16 +587,20 @@ end
                                             UInt128, UInt16, UInt32, UInt64, UInt8,
                                             BigInt)
         @test_throws DomainError elty[1 1;1 0]^-2
-        @test elty[1 1;1 0]^2 == elty[2 1;1 1]
+        @test (@inferred elty[1 1;1 0]^2) == elty[2 1;1 1]
         I_ = elty[1 0;0 1]
         @test I_^-1 == I_
         if !(elty<:Unsigned)
-            @test (-I_)^-1 == -I_
-            @test (-I_)^-2 == I_
+            @test (@inferred (-I_)^-1) == -I_
+            @test (@inferred (-I_)^-2) == I_
         end
+        # make sure that type promotion for ^(::Matrix{<:Integer}, ::Integer)
+        # is analogous to type promotion for ^(::Integer, ::Integer)
+        # e.g. [1 1;1 0]^big(10000) should return Matrix{BigInt}, the same
+        # way as 2^big(10000) returns BigInt
         for elty2 = (Int64, BigInt)
             TT = Base.promote_op(^, elty, elty2)
-            @test Base.return_types(^, (Array{elty,2}, elty2)) == [Array{TT,2}]
+            @test (@inferred elty[1 1;1 0]^elty2(1))::Matrix{TT} == [1 1;1 0]
         end
     end
 end

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -245,10 +245,18 @@ end
                 @testset "pow" begin
                     # Integer power
                     @test (asym)^2   ≈ (Symmetric(asym)^2)::Symmetric
-                    @test (asym)^-2  ≈ (Symmetric(asym)^-2)::Symmetric
+                    if eltya <: Integer && !isone(asym) && !isone(-asym)
+                        @test_throws DomainError (asym)^-2
+                    else
+                        @test (asym)^-2  ≈ (Symmetric(asym)^-2)::Symmetric
+                    end
                     @test (aposs)^2  ≈ (Symmetric(aposs)^2)::Symmetric
                     @test (aherm)^2  ≈ (Hermitian(aherm)^2)::Hermitian
-                    @test (aherm)^-2 ≈ (Hermitian(aherm)^-2)::Hermitian
+                    if eltya <: Integer && !isone(aherm) && !isone(-aherm)
+                        @test_throws DomainError (aherm)^-2
+                    else
+                        @test (aherm)^-2 ≈ (Hermitian(aherm)^-2)::Hermitian
+                    end
                     @test (apos)^2   ≈ (Hermitian(apos)^2)::Hermitian
                     # integer floating point power
                     @test (asym)^2.0   ≈ (Symmetric(asym)^2.0)::Symmetric


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#459. Makes `^(::Matrix{S},::T) where {S<:Integer, T<:Integer}` type stable. Also ensures the same promotion rules as `^(::S, ::T)`.