### PR TITLE
define Symbol(s::Symbol) = s for performance

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -389,6 +389,7 @@ function Symbol(a::Array{UInt8,1})
                  ccall(:jl_array_ptr, Ptr{UInt8}, (Any,), a),
                  Intrinsics.arraylen(a))
 end
+Symbol(s::Symbol) = s
 
 # docsystem basics
 macro doc(x...)


### PR DESCRIPTION
Before, `Symbol(:symbol)` was calling the generic
`Symbo(x...)` method which in turns calls `string(x...)`;
this is too slow for just returning the argument.