### PR TITLE
fix over-eager removal of `newvar` nodes in the presence of `isdefined`

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -5117,6 +5117,15 @@ f_isdefined_va(::T...) where {T} = @isdefined T
 @test !f_isdefined_va()
 @test f_isdefined_va(1, 2, 3)
 
+# @isdefined in a loop
+let a = []
+    for i = 1:2
+        push!(a, @isdefined(j))
+        local j = 1
+    end
+    @test a == [false, false]
+end
+
 mutable struct MyStruct22929
     x::MyStruct22929
     MyStruct22929() = new()


### PR DESCRIPTION
Bug noticed in https://github.com/JuliaLang/julia/pull/23260#issuecomment-323164608