### PR TITLE
Fix bug introduced in #23285 for means along dimensions of empty arrays

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -59,7 +59,7 @@ julia> mean!([1. 1.], v)
 """
 function mean!(R::AbstractArray, A::AbstractArray)
     sum!(R, A; init=true)
-    scale!(R, _length(R) // max(1, _length(A)))
+    scale!(R, max(1, _length(R)) // _length(A))
     return R
 end
 

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -440,3 +440,13 @@ end
     @test (A'A - size(A, 1)*Base.mean(A, 1)'*Base.mean(A, 1))/4 == cov(A)
 end
 
+@testset "Mean along dimension of empty array" begin
+    a0  = zeros(0)
+    a00 = zeros(0, 0)
+    a01 = zeros(0, 1)
+    a10 = zeros(1, 0)
+    @test isequal(mean(a0, 1)      , fill(NaN, 1))
+    @test isequal(mean(a00, (1, 2)), fill(NaN, 1, 1))
+    @test isequal(mean(a01, 1)     , fill(NaN, 1, 1))
+    @test isequal(mean(a10, 2)     , fill(NaN, 1, 1))
+end


### PR DESCRIPTION
Bug found in https://github.com/JuliaStats/DataArrays.jl/issues/285

cc: @rofinn 