### PR TITLE
RFC: evaluate `for` iterator in outer scope

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -70,6 +70,9 @@ Language changes
     warning, so that this syntax can be disallowed or given a new meaning in a
     future version ([#5148]).
 
+  * In `for i in x`, `x` used to be evaluated in a new scope enclosing the `for` loop.
+    Now it is evaluated in the scope outside the `for` loop.
+
 Breaking changes
 ----------------
 

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -305,6 +305,13 @@
 (define (eq-sym? a b)
   (or (eq? a b) (and (ssavalue? a) (ssavalue? b) (eqv? (cdr a) (cdr b)))))
 
+(define (blockify e)
+  (if (and (pair? e) (eq? (car e) 'block))
+      (if (null? (cdr e))
+          `(block (null))
+          e)
+      `(block ,e)))
+
 (define (make-var-info name) (list name '(core Any) 0))
 (define vinfo:name car)
 (define vinfo:type cadr)

--- a/test/core.jl
+++ b/test/core.jl
@@ -2921,6 +2921,13 @@ function f11065()
 end
 @test_throws UndefVarError f11065()
 
+# for loop iterator expression should be evaluated in outer scope
+let
+    for i in (local a = 1:2)
+    end
+    @test a == 1:2
+end
+
 # issue #11295
 function f11295(x...)
     call = Expr(x...)


### PR DESCRIPTION
Since it's scope season, here's another issue that, in a way, is the flip side of #22659.

Reasoning by the following transformation:

```
for i in itr
    body
end
```

to

```
foreach(i->body, itr)
```

`itr` should be evaluated in the surrounding scope. However, we currently enclose the entire `for` loop in a new scope, in addition to the per-iteration scope. I believe this is unnecessary.

The breakage here is extremely minor, since for this to matter you basically have to write `for i in (a = b)`, which nobody ever does. Code that does do that is likely to keep working, since you can still see `a` inside the loop.