### PR TITLE
implement islower, isupper and istitle for String

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -205,6 +205,11 @@ Library improvements
   * Mutating versions of `randperm` and `randcycle` have been added:
     `randperm!` and `randcycle!` ([#22723]).
 
+  * `islower`, `isupper` for strings have beed un-deprecated in favor of a refined behavior:
+    e.g. `islower(s)` returns `true` if all letters in `s` are lowercase, and if there
+    is at least on letter in `s` (the old behavior was `all(islower, s)`); also, a new
+    function `istitle` is provided.
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1273,7 +1273,7 @@ function (::Type{Matrix})()
 end
 
 for name in ("alnum", "alpha", "cntrl", "digit", "number", "graph",
-             "lower", "print", "punct", "space", "upper", "xdigit")
+             "print", "punct", "space", "xdigit")
     f = Symbol("is",name)
     @eval @deprecate ($f)(s::AbstractString) all($f, s)
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -772,6 +772,7 @@ export
     ispunct,
     isspace,
     isupper,
+    istitle,
     isvalid,
     isxdigit,
     join,

--- a/test/unicode/utf8proc.jl
+++ b/test/unicode/utf8proc.jl
@@ -320,3 +320,17 @@ end
     @test eltype(g) == SubString{String}
     @test collect(g) == ["1","2","3","α","5"]
 end
+
+@testset "islower, isupper, istitle for strings" begin
+    for f in islower, isupper, istitle
+        @test !f("")
+        @test !f("; == :")
+    end
+    @test islower(" aa; b => ab")
+    @test isupper(" AA; B => AB")
+    @test istitle(" Aa; B => Ab")
+    str = randstring(['a':'z'; 'A':'Z'; '0':'1'; collect("; .-"^10);], 100)
+    @test str |> lowecase |> islower
+    @test str |> uppercase |> isupper
+    @test str |> titlecase |> istitle
+end


### PR DESCRIPTION
`islower` and `isupper` were deprecated to a simplistic
behavior which left to be desired; the new functions
check that the predicate is true *only* for letters,
and that there is at least one letter. This is the behavior
of some other languages (e.g. Python) and is inspired by
http://www.unicode.org/L2/L1999/99190.htm.
Also, `islower(lowercase(s))` is now true for many more
strings (false only if s doesn't contain any letter).

Note: I'm still confused by the difference between `isupper` and `istitle` for characters - this may need to be adjusted.