### PR TITLE
Revert "Replace --quiet with --banner (#23343)"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -338,8 +338,6 @@ Command-line option changes
   * New option `--warn-overwrite={yes|no}` to control the warning for overwriting method
     definitions. The default is `no` ([#23002]).
 
-  * The `-q` and `--quiet` flags have been deprecated in favor of `--banner={yes|no}` ([#23342]).
-
 Julia v0.6.0 Release Notes
 ==========================
 
@@ -1196,4 +1194,3 @@ Command-line option changes
 [#23157]: https://github.com/JuliaLang/julia/issues/23157
 [#23187]: https://github.com/JuliaLang/julia/issues/23187
 [#23207]: https://github.com/JuliaLang/julia/issues/23207
-[#23342]: https://github.com/JuliaLang/julia/issues/23342

--- a/base/client.jl
+++ b/base/client.jl
@@ -253,7 +253,7 @@ function process_options(opts::JLOptions)
     repl                  = true
     startup               = (opts.startupfile != 2)
     history_file          = (opts.historyfile != 0)
-    banner                = (opts.banner != 0)
+    quiet                 = (opts.quiet != 0)
     color_set             = (opts.color != 0)
     global have_color     = (opts.color == 1)
     global is_interactive = (opts.isinteractive != 0)
@@ -317,7 +317,7 @@ function process_options(opts::JLOptions)
         break
     end
     repl |= is_interactive
-    return (banner,repl,startup,color_set,history_file)
+    return (quiet,repl,startup,color_set,history_file)
 end
 
 function load_juliarc()
@@ -380,7 +380,7 @@ function _start()
     opts = JLOptions()
     @eval Main include(x) = $include(Main, x)
     try
-        (banner,repl,startup,color_set,history_file) = process_options(opts)
+        (quiet,repl,startup,color_set,history_file) = process_options(opts)
 
         local term
         global active_repl
@@ -393,10 +393,10 @@ function _start()
                 term = Terminals.TTYTerminal(get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb"), STDIN, STDOUT, STDERR)
                 global is_interactive = true
                 color_set || (global have_color = Terminals.hascolor(term))
-                banner && REPL.banner(term,term)
+                quiet || REPL.banner(term,term)
                 if term.term_type == "dumb"
                     active_repl = REPL.BasicREPL(term)
-                    banner && warn("Terminal not fully functional")
+                    quiet || warn("Terminal not fully functional")
                 else
                     active_repl = REPL.LineEditREPL(term, true)
                     active_repl.history_file = history_file

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1707,9 +1707,6 @@ export hex2num
 # issue #5148, PR #23259
 # warning for `const` on locals should be changed to an error in julia-syntax.scm
 
-# issue #23342, PR #23343
-# `-q` and `--quiet` are deprecated in jloptions.c
-
 # issue #17886
 # deprecations for filter[!] with 2-arg functions are in associative.jl
 

--- a/base/options.jl
+++ b/base/options.jl
@@ -2,7 +2,7 @@
 
 # NOTE: This type needs to be kept in sync with jl_options in src/julia.h
 struct JLOptions
-    banner::Int8
+    quiet::Int8
     julia_home::Ptr{UInt8}
     julia_bin::Ptr{UInt8}
     eval::Ptr{UInt8}

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -108,8 +108,8 @@ Run processes on hosts listed in <file>
 Interactive mode; REPL runs and isinteractive() is true
 
 .TP
---banner={yes|no}
-Enable or disable startup banner
+-q, --quiet
+Quiet startup without banner
 
 .TP
 --color={yes|no}

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -114,7 +114,7 @@ julia [switches] -- [programfile] [args...]
  --machinefile <file>      Run processes on hosts listed in <file>
 
  -i                        Interactive mode; REPL runs and isinteractive() is true
- --banner={yes|no}         Enable or disable startup banner
+ -q, --quiet               Quiet startup (no banner)
  --color={yes|no}          Enable or disable color text
  --history-file={yes|no}   Load or save history
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -33,7 +33,7 @@ JL_DLLEXPORT const char *jl_get_default_sysimg_path(void)
 }
 
 
-jl_options_t jl_options = { 1,    // banner
+jl_options_t jl_options = { 0,    // quiet
                             NULL, // julia_home
                             NULL, // julia_bin
                             NULL, // eval
@@ -102,7 +102,7 @@ static const char opts[]  =
 
     // interactive options
     " -i                        Interactive mode; REPL runs and isinteractive() is true\n"
-    " --banner={yes|no}         Enable or disable startup banner\n"
+    " -q, --quiet               Quiet startup\n"
     " --color={yes|no}          Enable or disable color text\n"
     " --history-file={yes|no}   Load or save history\n\n"
 
@@ -170,8 +170,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_output_ji,
            opt_use_precompiled,
            opt_use_compilecache,
-           opt_incremental,
-           opt_banner
+           opt_incremental
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:ip:O:g:";
     static const struct option longopts[] = {
@@ -181,7 +180,6 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "version",         no_argument,       0, 'v' },
         { "help",            no_argument,       0, 'h' },
         { "quiet",           no_argument,       0, 'q' },
-        { "banner",          required_argument, 0, opt_banner },
         { "home",            required_argument, 0, 'H' },
         { "eval",            required_argument, 0, 'e' },
         { "print",           required_argument, 0, 'E' },
@@ -282,6 +280,9 @@ restart_switch:
         case 'h': // help
             jl_printf(JL_STDOUT, "%s%s", usage, opts);
             jl_exit(0);
+        case 'q': // quiet
+            jl_options.quiet = 1;
+            break;
         case 'g': // debug info
             if (optarg != NULL) {
                 if (!strcmp(optarg,"0"))
@@ -313,18 +314,6 @@ restart_switch:
         case 'J': // sysimage
             jl_options.image_file = strdup(optarg);
             jl_options.image_file_specified = 1;
-            break;
-        case 'q': // quiet
-            jl_printf(JL_STDERR, "-q and --quiet are deprecated, use --banner=no instead\n");
-            jl_options.banner = 0;
-            break;
-        case opt_banner: // banner
-            if (!strcmp(optarg,"yes"))
-                jl_options.banner = 1;
-            else if (!strcmp(optarg,"no"))
-                jl_options.banner = 0;
-            else
-                jl_errorf("julia: invalid argument to --banner={yes|no} (%s)", optarg);
             break;
         case opt_use_precompiled:
             if (!strcmp(optarg,"yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1671,7 +1671,7 @@ JL_DLLEXPORT void jl_(void *jl_value);
 // julia options -----------------------------------------------------------
 // NOTE: This struct needs to be kept in sync with JLOptions type in base/options.jl
 typedef struct {
-    int8_t banner;
+    int8_t quiet;
     const char *julia_home;
     const char *julia_bin;
     const char *eval;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -22,7 +22,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
         @test startswith(read(`$exename --help`, String), header)
     end
 
-    # --banner
+    # --quiet
     # This flag is indirectly tested in test/repl.jl
 
     # --home
@@ -72,7 +72,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     end
 
     # --procs
-    @test readchomp(`$exename --banner=no -p 2 -e "println(nworkers())"`) == "2"
+    @test readchomp(`$exename -q -p 2 -e "println(nworkers())"`) == "2"
     @test !success(`$exename -p 0`)
     @test !success(`$exename --procs=1.0`)
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -614,7 +614,7 @@ let exename = Base.julia_cmd()
         TestHelpers.with_fake_pty() do slave, master
             nENV = copy(ENV)
             nENV["TERM"] = "dumb"
-            p = spawn(setenv(`$exename --startup-file=no --banner=no`,nENV),slave,slave,slave)
+            p = spawn(setenv(`$exename --startup-file=no --quiet`,nENV),slave,slave,slave)
             output = readuntil(master,"julia> ")
             if ccall(:jl_running_on_valgrind,Cint,()) == 0
                 # If --trace-children=yes is passed to valgrind, we will get a
@@ -631,7 +631,7 @@ let exename = Base.julia_cmd()
     end
 
     # Test stream mode
-    outs, ins, p = readandwrite(`$exename --startup-file=no --banner=no`)
+    outs, ins, p = readandwrite(`$exename --startup-file=no --quiet`)
     write(ins,"1\nquit()\n")
     @test read(outs, String) == "1\n"
 end # let exename


### PR DESCRIPTION
This reverts commit dcb46b36d83962bdd6170db66644573503b499b8
and clarify the help message of `--quiet`.

Fix #23380
Reopen #23342

AFAICT there isn't a clear need for #23342 since quite startup seems to cover all usecases. The discoverability of `-q` is also pretty good (it's in `-h`) and the name is pretty standard (`gdb`, `python`).
