### PR TITLE
RFC: allocate fresh bindings on each iteration of `while` loops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,9 @@ Language changes
   * In `for i in x`, `x` used to be evaluated in a new scope enclosing the `for` loop.
     Now it is evaluated in the scope outside the `for` loop.
 
+  * Variable bindings local to `while` loop bodies are now freshly allocated on each loop iteration,
+    matching the behavior of `for` loops.
+
 Breaking changes
 ----------------
 

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -416,10 +416,9 @@ outer local `x`.
 
 ### For Loops and Comprehensions
 
-`for` loops and [Comprehensions](@ref) have the following behavior: any new variables introduced
-in their body scopes are freshly allocated for each loop iteration. This is in contrast to `while`
-loops which reuse the variables for all iterations. Therefore these constructs are similar to
-`while` loops with `let` blocks inside:
+`for` loops, `while` loops, and [Comprehensions](@ref) have the following behavior: any new variables
+introduced in their body scopes are freshly allocated for each loop iteration, as if the loop body
+were surrounded by a `let` block:
 
 ```jldoctest
 julia> Fs = Array{Any}(2);

--- a/test/core.jl
+++ b/test/core.jl
@@ -5133,6 +5133,17 @@ let a = []
     @test a == [false, false]
 end
 
+# while loop scope
+let a = [], i = 0
+    while i < (local b = 2)
+        push!(a, @isdefined(j))
+        local j = 1
+        i += 1
+    end
+    @test a == [false, false]
+    @test b == 2
+end
+
 mutable struct MyStruct22929
     x::MyStruct22929
     MyStruct22929() = new()


### PR DESCRIPTION
For a long time, we've had `for` loops and comprehensions allocate new bindings on each iteration, but not done this for `while` loops. The more imperative nature of `while` loops makes this defensible, but I believe `while` loops will also benefit from per-iteration bindings, plus it's simpler to have all loops behave the same. It's easy to get variables shared by all iterations by declaring them outside the loop.

Similar to #23387, this also removes the outer scope "wrapper" from `while` loops.