### PR TITLE
Make --quiet and --banner independent (fix #23380)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -338,7 +338,10 @@ Command-line option changes
   * New option `--warn-overwrite={yes|no}` to control the warning for overwriting method
     definitions. The default is `no` ([#23002]).
 
-  * The `-q` and `--quiet` flags have been deprecated in favor of `--banner={yes|no}` ([#23342]).
+  * New option `--banner={yes,no}` allows suppressing or forcing the printing of the
+    startup banner, overriding the default behavior (banner in REPL, no banner otherwise).
+    The `--quiet` option implies `--banner=no` even in REPL mode but can be overridden by
+    passing `--quiet` together with `--banner=yes` ([#23342]).
 
 Julia v0.6.0 Release Notes
 ==========================

--- a/base/client.jl
+++ b/base/client.jl
@@ -251,9 +251,10 @@ function process_options(opts::JLOptions)
         length(idxs) > 0 && deleteat!(ARGS, idxs[1])
     end
     repl                  = true
+    quiet                 = (opts.quiet != 0)
+    banner                = (opts.banner == 1 || opts.banner != 0 && opts.isinteractive != 0)
     startup               = (opts.startupfile != 2)
     history_file          = (opts.historyfile != 0)
-    banner                = (opts.banner != 0)
     color_set             = (opts.color != 0)
     global have_color     = (opts.color == 1)
     global is_interactive = (opts.isinteractive != 0)
@@ -317,7 +318,7 @@ function process_options(opts::JLOptions)
         break
     end
     repl |= is_interactive
-    return (banner,repl,startup,color_set,history_file)
+    return (quiet,banner,repl,startup,color_set,history_file)
 end
 
 function load_juliarc()
@@ -380,7 +381,7 @@ function _start()
     opts = JLOptions()
     @eval Main include(x) = $include(Main, x)
     try
-        (banner,repl,startup,color_set,history_file) = process_options(opts)
+        (quiet,banner,repl,startup,color_set,history_file) = process_options(opts)
 
         local term
         global active_repl
@@ -396,7 +397,7 @@ function _start()
                 banner && REPL.banner(term,term)
                 if term.term_type == "dumb"
                     active_repl = REPL.BasicREPL(term)
-                    banner && warn("Terminal not fully functional")
+                    quiet || warn("Terminal not fully functional")
                 else
                     active_repl = REPL.LineEditREPL(term, true)
                     active_repl.history_file = history_file

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1707,9 +1707,6 @@ export hex2num
 # issue #5148, PR #23259
 # warning for `const` on locals should be changed to an error in julia-syntax.scm
 
-# issue #23342, PR #23343
-# `-q` and `--quiet` are deprecated in jloptions.c
-
 # issue #17886
 # deprecations for filter[!] with 2-arg functions are in associative.jl
 

--- a/base/options.jl
+++ b/base/options.jl
@@ -2,6 +2,7 @@
 
 # NOTE: This type needs to be kept in sync with jl_options in src/julia.h
 struct JLOptions
+    quiet::Int8
     banner::Int8
     julia_home::Ptr{UInt8}
     julia_bin::Ptr{UInt8}

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -33,7 +33,8 @@ JL_DLLEXPORT const char *jl_get_default_sysimg_path(void)
 }
 
 
-jl_options_t jl_options = { 1,    // banner
+jl_options_t jl_options = { 0,    // quiet
+                            -1,   // banner
                             NULL, // julia_home
                             NULL, // julia_bin
                             NULL, // eval
@@ -102,6 +103,7 @@ static const char opts[]  =
 
     // interactive options
     " -i                        Interactive mode; REPL runs and isinteractive() is true\n"
+    " -q, --quiet               Quiet startup: no banner, suppress REPL warnings\n"
     " --banner={yes|no}         Enable or disable startup banner\n"
     " --color={yes|no}          Enable or disable color text\n"
     " --history-file={yes|no}   Load or save history\n\n"
@@ -315,8 +317,9 @@ restart_switch:
             jl_options.image_file_specified = 1;
             break;
         case 'q': // quiet
-            jl_printf(JL_STDERR, "-q and --quiet are deprecated, use --banner=no instead\n");
-            jl_options.banner = 0;
+            jl_options.quiet = 1;
+            if (jl_options.banner < 0)
+                jl_options.banner = 0;
             break;
         case opt_banner: // banner
             if (!strcmp(optarg,"yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1671,6 +1671,7 @@ JL_DLLEXPORT void jl_(void *jl_value);
 // julia options -----------------------------------------------------------
 // NOTE: This struct needs to be kept in sync with JLOptions type in base/options.jl
 typedef struct {
+    int8_t quiet;
     int8_t banner;
     const char *julia_home;
     const char *julia_bin;

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -22,8 +22,18 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
         @test startswith(read(`$exename --help`, String), header)
     end
 
-    # --banner
-    # This flag is indirectly tested in test/repl.jl
+    # --quiet, --banner
+    let t(q,b) = "Base.JLOptions().quiet == $q && Base.JLOptions().banner == $b"
+        @test success(`$exename                 -e $(t(0, -1))`)
+        @test success(`$exename -q              -e $(t(1,  0))`)
+        @test success(`$exename --quiet         -e $(t(1,  0))`)
+        @test success(`$exename --banner=no     -e $(t(0,  0))`)
+        @test success(`$exename --banner=yes    -e $(t(0,  1))`)
+        @test success(`$exename -q --banner=no  -e $(t(1,  0))`)
+        @test success(`$exename -q --banner=yes -e $(t(1,  1))`)
+        @test success(`$exename --banner=no  -q -e $(t(1,  0))`)
+        @test success(`$exename --banner=yes -q -e $(t(1,  1))`)
+    end
 
     # --home
     @test success(`$exename -H $JULIA_HOME`)
@@ -72,7 +82,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     end
 
     # --procs
-    @test readchomp(`$exename --banner=no -p 2 -e "println(nworkers())"`) == "2"
+    @test readchomp(`$exename -q -p 2 -e "println(nworkers())"`) == "2"
     @test !success(`$exename -p 0`)
     @test !success(`$exename --procs=1.0`)
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -614,7 +614,7 @@ let exename = Base.julia_cmd()
         TestHelpers.with_fake_pty() do slave, master
             nENV = copy(ENV)
             nENV["TERM"] = "dumb"
-            p = spawn(setenv(`$exename --startup-file=no --banner=no`,nENV),slave,slave,slave)
+            p = spawn(setenv(`$exename --startup-file=no -q`,nENV),slave,slave,slave)
             output = readuntil(master,"julia> ")
             if ccall(:jl_running_on_valgrind,Cint,()) == 0
                 # If --trace-children=yes is passed to valgrind, we will get a
@@ -631,7 +631,7 @@ let exename = Base.julia_cmd()
     end
 
     # Test stream mode
-    outs, ins, p = readandwrite(`$exename --startup-file=no --banner=no`)
+    outs, ins, p = readandwrite(`$exename --startup-file=no -q`)
     write(ins,"1\nquit()\n")
     @test read(outs, String) == "1\n"
 end # let exename


### PR DESCRIPTION
This allows `--banner={yes,no}` to be set independently from `--quiet`, which, without an explicit `--banner` flag implies `--banner=no`. Adds tests for both options and their interaction.