### PR TITLE
REPL: fix newline indentation when point before 1st non-space

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -480,7 +480,8 @@ function edit_insert_newline(s::PromptState, align=-1)
     buf = buffer(s)
     if align < 0
         beg = beginofline(buf)
-        align = findnext(_notspace, buf.data[beg+1:buf.size], 1) - 1
+        align = min(findnext(_notspace, buf.data[beg+1:buf.size], 1) - 1,
+                    position(buf) - beg) # indentation must not increase
         align < 0 && (align = buf.size-beg)
     end
     edit_insert(buf, '\n' * ' '^align)

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -565,4 +565,12 @@ end
     @test bufferdata(s) == "for x=1:10\n    é = 1\n     b = 2\n     \n     \n"
     LineEdit.edit_insert_newline(s, 2)
     @test bufferdata(s) == "for x=1:10\n    é = 1\n     b = 2\n     \n     \n\n  "
+    # test when point before first letter of the line
+    for i=6:10
+        LineEdit.edit_clear(s)
+        LineEdit.edit_insert(s, "begin\n    x")
+        seek(LineEdit.buffer(s), i)
+        LineEdit.edit_insert_newline(s)
+        @test bufferdata(s) == "begin\n" * ' '^(i-6) * "\n    x"
+    end
 end


### PR DESCRIPTION
Fixes bug reported [here](https://github.com/JuliaLang/julia/pull/22948#issuecomment-324173991). Thanks @fredrikekre !