### PR TITLE
fix prompt-indentation when bracket pasting

### DIFF
--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -889,6 +889,9 @@ function setup_interface(
                         # (avoids modifying the user's current leading wip line)
                         tail = lstrip(tail)
                     end
+                    if isprompt_paste # remove indentation spaces corresponding to the prompt
+                        tail = replace(tail, r"^ {7}"m, "") # 7: jl_prompt_len
+                    end
                     LineEdit.replace_line(s, tail)
                     LineEdit.refresh_line(s)
                     break
@@ -896,6 +899,9 @@ function setup_interface(
                 # get the line and strip leading and trailing whitespace
                 line = strip(input[oldpos:prevind(input, pos)])
                 if !isempty(line)
+                    if isprompt_paste # remove indentation spaces corresponding to the prompt
+                        line = replace(line, r"^ {7}"m, "") # 7: jl_prompt_len
+                    end
                     # put the line on the screen and history
                     LineEdit.replace_line(s, line)
                     LineEdit.commit_line(s)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -561,6 +561,18 @@ fake_repl() do stdin_write, stdout_read, repl
     wait(c)
     @test Main.A == 1
 
+    # Test that indentation corresponding to the prompt is removed
+    sendrepl2("""\e[200~julia> begin\n           α=1\n           β=2\n       end\n\e[201~""")
+    wait(c)
+    readuntil(stdout_read, "begin")
+    @test readuntil(stdout_read, "end") == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
+    # for incomplete input (`end` below is added after the end of bracket paste)
+    sendrepl2("""\e[200~julia> begin\n           α=1\n           β=2\n\e[201~end""")
+    wait(c)
+    readuntil(stdout_read, "begin")
+    readuntil(stdout_read, "begin")
+    @test readuntil(stdout_read, "end") == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
+
     # Close repl
     write(stdin_write, '\x04')
     wait(repltask)


### PR DESCRIPTION
Cf. problem reported there:
https://github.com/JuliaLang/julia/pull/22948#issuecomment-324093541
Bracket pasting was not removing the indentation corresponding
to the prompt (i.e. 7 spaces for "julia> ").