### PR TITLE
parseable printing of all type names and TypeVars

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -144,7 +144,8 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
     n = length(ms)
     if header
         m = n==1 ? "method" : "methods"
-        ns = isself ? string(name) : string("(::", name, ")")
+        sname = string(name)
+        ns = (isself || '#' in sname) ? sname : string("(::", name, ")")
         what = startswith(ns, '@') ? "macro" : "generic function"
         print(io, "# $n $m for ", what, " \"", ns, "\":")
     end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -109,7 +109,8 @@ function show(io::IO, ::MIME"text/plain", f::Function)
                  ft == typeof(getfield(ft.name.module, name))
         n = length(methods(f))
         m = n==1 ? "method" : "methods"
-        ns = isself ? string(name) : string("(::", name, ")")
+        sname = string(name)
+        ns = (isself || '#' in sname) ? sname : string("(::", ft, ")")
         what = startswith(ns, '@') ? "macro" : "generic function"
         print(io, ns, " (", what, " with $n $m)")
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -181,10 +181,15 @@ end
 function show(io::IO, f::Function)
     ft = typeof(f)
     mt = ft.name.mt
-    if !isdefined(mt, :module) || is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
-        print(io, mt.name)
+    if isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
+        getfield(mt.module, mt.name) === f
+        if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
+            print(io, mt.name)
+        else
+            print(io, mt.module, ".", mt.name)
+        end
     else
-        print(io, mt.module, ".", mt.name)
+        show_default(io, f)
     end
 end
 
@@ -208,16 +213,88 @@ function print_without_params(@nospecialize(x))
     return false
 end
 
+has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Cint, (Any, Any), t, v)!=0
+
+function io_has_tvar_name(io::IOContext, name::Symbol, @nospecialize(x))
+    for (key, val) in io.dict
+        if key === :unionall_env && val isa TypeVar && val.name === name && has_typevar(x, val)
+            return true
+        end
+    end
+    return false
+end
+io_has_tvar_name(io::IO, name::Symbol, @nospecialize(x)) = false
+
 function show(io::IO, x::UnionAll)
     if print_without_params(x)
         return show(io, unwrap_unionall(x).name)
     end
+
+    if x.var.name == :_ || io_has_tvar_name(io, x.var.name, x)
+        counter = 1
+        while true
+            newname = Symbol(x.var.name, counter)
+            if !io_has_tvar_name(io, newname, x)
+                newtv = TypeVar(newname, x.var.lb, x.var.ub)
+                x = UnionAll(newtv, x{newtv})
+                break
+            end
+            counter += 1
+        end
+    end
+
     show(IOContext(io, :unionall_env => x.var), x.body)
     print(io, " where ")
     show(io, x.var)
 end
 
 show(io::IO, x::DataType) = show_datatype(io, x)
+
+function show_type_name(io::IO, tn::TypeName)
+    globname = isdefined(tn, :mt) ? tn.mt.name : nothing
+    globfunc = false
+    if globname !== nothing
+        globname_str = string(globname)
+        if ('#' ∉ globname_str && '@' ∉ globname_str && isdefined(tn, :module) &&
+            isbindingresolved(tn.module, globname) && isdefined(tn.module, globname) &&
+            isa(getfield(tn.module, globname), tn.wrapper) && isleaftype(tn.wrapper))
+            globfunc = true
+        end
+    end
+    sym = globfunc ? globname : tn.name
+    sym_str = string(sym)
+    hidden = !globfunc && '#' ∈ sym_str
+    quo = false
+    if hidden
+        print(io, "getfield(")
+    elseif globfunc
+        print(io, "typeof(")
+    end
+    if isdefined(tn, :module) && !(is_exported_from_stdlib(sym, tn.module) || (tn.module === Main && !hidden))
+        show(io, tn.module)
+        if !hidden
+            print(io, ".")
+            if globfunc && !is_id_start_char(first(sym_str))
+                print(io, ":")
+                if sym == :(==)
+                    print(io, "(")
+                    quo = true
+                end
+            end
+        end
+    end
+    if hidden
+        print(io, ", Symbol(\"", sym_str, "\"))")
+    else
+        print(io, sym_str)
+        if globfunc
+            print(io, ")")
+            if quo
+                print(io, ")")
+            end
+        end
+    end
+end
 
 function show_datatype(io::IO, x::DataType)
     istuple = x.name === Tuple.name
@@ -228,7 +305,7 @@ function show_datatype(io::IO, x::DataType)
         if istuple && n > 3 && all(i -> (x.parameters[1] === i), x.parameters)
             print(io, "NTuple{", n, ',', x.parameters[1], "}")
         else
-            show(io, x.name)
+            show_type_name(io, x.name)
             # Do not print the type parameters for the primary type if we are
             # printing a method signature or type parameter.
             # Always print the type parameter if we are printing the type directly
@@ -241,7 +318,7 @@ function show_datatype(io::IO, x::DataType)
             print(io, '}')
         end
     else
-        show(io, x.name)
+        show_type_name(io, x.name)
     end
 end
 
@@ -272,11 +349,7 @@ macro show(exs...)
 end
 
 function show(io::IO, tn::TypeName)
-    if is_exported_from_stdlib(tn.name, tn.module) || tn.module === Main
-        print(io, tn.name)
-    else
-        print(io, tn.module, '.', tn.name)
-    end
+    show_type_name(io, tn)
 end
 
 show(io::IO, ::Void) = print(io, "nothing")

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -347,7 +347,7 @@ let err_str,
     err_str = @except_str randn(1)() MethodError
     @test contains(err_str, "MethodError: objects of type Array{Float64,1} are not callable")
 end
-@test stringmime("text/plain", FunctionLike()) == "(::FunctionLike) (generic function with 0 methods)"
+@test stringmime("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 0 methods)"
 @test ismatch(r"^@doc \(macro with \d+ method[s]?\)$", stringmime("text/plain", getfield(Base, Symbol("@doc"))))
 
 method_defs_lineno = @__LINE__() + 1
@@ -385,7 +385,7 @@ let err_str,
                      "@doc(__source__::LineNumberNode, __module__::Module, x...) in Core at boot.jl:")
     @test startswith(sprint(show, which(FunctionLike(), Tuple{})),
                      "(::$(curmod_prefix)FunctionLike)() in $curmod_str at $sp:$(method_defs_lineno + 7)")
-    @test stringmime("text/plain", FunctionLike()) == "(::FunctionLike) (generic function with 1 method)"
+    @test stringmime("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 1 method)"
     @test stringmime("text/plain", Core.arraysize) == "arraysize (built-in function)"
 
     err_str = @except_stackframe Symbol() ErrorException

--- a/test/show.jl
+++ b/test/show.jl
@@ -507,7 +507,7 @@ function f13127()
     show(buf, f)
     String(take!(buf))
 end
-@test f13127() == "$(curmod_prefix)f"
+@test startswith(f13127(), "getfield($(@__MODULE__), Symbol(\"")
 
 #test methodshow.jl functions
 @test Base.inbase(Base)
@@ -736,7 +736,7 @@ let sv = Core.svec(:a, :b, :c)
     @test repr == "SimpleVector\n  1: Symbol a\n  2: Symbol b\n  3: #undef\n"
 end
 let repr = sprint(dump, sin)
-    @test repr == "sin (function of type Base.#sin)\n"
+    @test repr == "sin (function of type typeof(sin))\n"
 end
 let repr = sprint(dump, Base.Test)
     @test repr == "Module Base.Test\n"
@@ -946,4 +946,34 @@ end
               string("4×30 Array{Float64,2}:\n",
                      " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  …  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
                      " ⋮                        ⋮              ⋱            ⋮                      ")
+end
+
+module UnexportedOperators
+function + end
+function == end
+end
+
+@testset "Parseable printing of types" begin
+    @test repr(typeof(print)) == "typeof(print)"
+    @test repr(typeof(Base.show_default)) == "typeof(Base.show_default)"
+    @test repr(typeof(UnexportedOperators.:+)) == "typeof($(curmod_prefix)UnexportedOperators.:+)"
+    @test repr(typeof(UnexportedOperators.:(==))) == "typeof($(curmod_prefix)UnexportedOperators.:(==))"
+    anonfn = x->2x
+    modname = string(@__MODULE__)
+    anonfn_type_repr = "getfield($modname, Symbol(\"$(typeof(anonfn).name.name)\"))"
+    @test repr(typeof(anonfn)) == anonfn_type_repr
+    @test repr(anonfn) == anonfn_type_repr * "()"
+    @test stringmime("text/plain", anonfn) == "$(typeof(anonfn).name.mt.name) (generic function with 1 method)"
+    mkclosure = x->y->x+y
+    clo = mkclosure(10)
+    @test stringmime("text/plain", clo) == "$(typeof(clo).name.mt.name) (generic function with 1 method)"
+end
+
+let x = TypeVar(:_), y = TypeVar(:_)
+    @test repr(UnionAll(x, UnionAll(y, Pair{x,y}))) == "Pair{_1,_2} where _2 where _1"
+    @test repr(UnionAll(x, UnionAll(y, Pair{UnionAll(x,Ref{x}),y}))) == "Pair{Ref{_1} where _1,_1} where _1"
+    x = TypeVar(:a)
+    y = TypeVar(:a)
+    z = TypeVar(:a)
+    @test repr(UnionAll(z, UnionAll(x, UnionAll(y, Tuple{x,y,z})))) == "Tuple{a1,a2,a} where a2 where a1 where a"
 end


### PR DESCRIPTION
Also adjust generic function printing so that when `(::x)` is printed, `x` is more likely to be the type of the function.

Demo:

```
julia> typeof(x->x)
getfield(Main, Symbol("##1#2"))

julia> getfield(Main, Symbol("##1#2"))
getfield(Main, Symbol("##1#2"))

julia> repr(x->x)
"getfield(Main, Symbol(\"##3#4\"))()"

julia> typeof(Base.cconvert)
typeof(Base.cconvert)

julia> let x = TypeVar(:_), y = TypeVar(:_)
         repr(UnionAll(x, UnionAll(y, Pair{x,y})))
       end
"Pair{_1,_2} where _2 where _1"
```