### PR TITLE
Separate out Circle steps and give them names

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,52 +15,75 @@ jobs:
           JULIA_TEST_MAXRSS_MB: 800
           ARCH: i686
     steps: &steps
-      - run: | # install build dependencies
-          sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
-            time ccache bar &&
-          for prog in gcc g++ gfortran; do
-            sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
-          done
+      - run:
+          name: Install build dependencies
+          command: |
+            sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
+              time ccache bar
+            for prog in gcc g++ gfortran; do
+              sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
+            done
       - checkout # circle ci code checkout step
 # (FIXME: need to unset url."ssh://git@github.com".insteadOf or libgit2 tests fail)
-      - run: | # checkout merge commit, set versioning info and Make.user variables
-          git config --global --unset url."ssh://git@github.com".insteadOf &&
-          if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-            git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge &&
-            git checkout -qf FETCH_HEAD;
-          fi &&
-          make -C base version_git.jl.phony &&
-          echo "override ARCH = $ARCH" | tee -a Make.user &&
-          for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
-            echo "override $var = 1" | tee -a Make.user;
-          done &&
-          echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
+      - run:
+          name: Checkout PR merge commit
+          command: |
+            git config --global --unset url."ssh://git@github.com".insteadOf
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge
+              git checkout -qf FETCH_HEAD;
+            fi
+      - run:
+          name: Set versioning info and Make.user variables
+          command: |
+            make -C base version_git.jl.phony
+            echo "override ARCH = $ARCH" | tee -a Make.user
+            for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
+              echo "override $var = 1" | tee -a Make.user;
+            done
+            echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
       - restore_cache: # silly to take a checksum of the tag file here instead of
           keys: # its contents but this is the only thing that works on circle
             - ccache-{{ checksum "/tmp/weeknumber" }}
-      - run: | # compile julia deps
-          contrib/download_cmake.sh &&
-          make -j8 -C deps || make
-      - run: | # build julia, output ccache stats when done
-          make -j8 all &&
-          make prefix=/tmp/julia install &&
-          ccache -s &&
-          make build-stats
-      - run: | # move source tree out of the way, run tests from install tree
-          cd .. &&
-          mv project julia-src &&
-          /tmp/julia/bin/julia -e 'versioninfo()' &&
-          /tmp/julia/bin/julia --precompiled=no -e 'true' &&
-          /tmp/julia/bin/julia-debug --precompiled=no -e 'true' &&
-          pushd /tmp/julia/share/julia/test &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30 &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg &&
-          popd &&
-          mkdir /tmp/embedding-test &&
-          make check -C /tmp/julia/share/doc/julia/examples/embedding \
-            JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
-            "$(cd julia-src && make print-CC)" &&
-          mv julia-src project
+      - run:
+          name: Compile Julia dependencies
+          command: |
+            contrib/download_cmake.sh
+            make -j8 -C deps || make
+      - run:
+          name: Build Julia and output ccache stats
+          command: |
+            make -j8 all
+            make prefix=/tmp/julia install
+            ccache -s
+            make build-stats
+      - run:
+          name: Check built executables
+          command: | # also move source tree out of the way
+            cd ..
+            mv project julia-src
+            /tmp/julia/bin/julia -e 'versioninfo()'
+            /tmp/julia/bin/julia --precompiled=no -e 'true'
+            /tmp/julia/bin/julia-debug --precompiled=no -e 'true'
+      - run:
+          name: Test all --skip socket
+          command: |
+            cd /tmp/julia/share/julia/test
+            /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30
+      - run:
+          name: Test libgit2-online download pkg
+          command: |
+            cd /tmp/julia/share/julia/test
+            /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg
+      - run:
+          name: Run embedding example
+          command: | # move the source tree back
+            cd ..
+            mkdir /tmp/embedding-test
+            make check -C /tmp/julia/share/doc/julia/examples/embedding \
+              JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
+              "$(cd julia-src && make print-CC)"
+            mv julia-src project
 #      - run: cd project && make -C doc deploy
 #       - run:
 #           command: sudo dmesg


### PR DESCRIPTION
Without this change, the Circle steps have the contents of the commands smashed together as the step names. This gives each step a clear name. To see the commands executed, just expand the step in the web UI and it's the first thing shown.

The more important change here is that some of the larger steps are separated out into smaller, more modular steps. This avoids the Circle web UI being unable to fetch the log, which happens with the enormous logs generated by running everything in a single step.

[av skip] [bsd skip]