### PR TITLE
add *(::Union{Regex, AbstractString, AbstractChar}...)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,7 +24,7 @@ New library functions
 Standard library changes
 ------------------------
 
-* Cmd interpolation (``` `$(x::Cmd) a b c` ``` where) now propagates `x`'s process flags (environment, flags, working directory, etc) if `x` is the first interpolant and errors otherwise ([#24353]).
+* `Regex` can now be multiplied (`*`) and exponentiated (`^`), like strings ([#23422]).
 
 #### LinearAlgebra
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -571,7 +571,9 @@ end
 *(r::Regex) = r # avoids wrapping r in a useless subpattern
 
 wrap_string(r::Regex, unshared::UInt32) = string("(?", regex_opts_str(r.compile_options & unshared), ':', r.pattern, ')')
-wrap_string(s::Union{AbstractString,AbstractChar}, ::UInt32) = string("\\Q", s, "\\E")
+# if s contains raw"\E", split '\' and 'E' within two distinct \Q...\E groups:
+wrap_string(s::AbstractString, ::UInt32) =  string("\\Q", replace(s, raw"\E" => raw"\\E\QE"), "\\E")
+wrap_string(s::AbstractChar, ::UInt32) = string("\\Q", s, "\\E")
 
 regex_opts_str(opts) = (isassigned(_regex_opts_str) ? _regex_opts_str[] : init_regex())[opts]
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -517,3 +517,49 @@ function hash(r::Regex, h::UInt)
     h = hash(r.compile_options, h)
     h = hash(r.match_options, h)
 end
+
+## String operations ##
+
+unwrap_string(r::Regex) = r.pattern
+unwrap_string(s::Union{AbstractString,AbstractChar}) = s
+
+"""
+    *(s::Regex, t::Union{Regex,AbstractString,AbstractChar}) -> Regex
+    *(s::Union{Regex,AbstractString,AbstractChar}, t::Regex) -> Regex
+
+Concatenate regexes, strings and/or characters, producing a [`Regex`](@ref).
+
+!!! compat "Julia 1.2"
+     This method requires at least Julia 1.2.
+
+# Examples
+```jldoctest
+julia> r"Hello " * "world"
+r"Hello world"
+
+julia> 'j' * r"ulia"
+r"julia"
+```
+"""
+function *(r1::Union{Regex,AbstractString,AbstractChar}, rs::Union{Regex,AbstractString,AbstractChar}...)
+    opts = unique((r.compile_options, r.match_options) for r in (r1, rs...) if r isa Regex)
+    length(opts) == 1 ||
+        throw(ArgumentError("cannot multiply regexes with incompatible options"))
+    Regex(string(unwrap_string(r1), unwrap_string.(rs)...), opts[1][1], opts[1][2])
+end
+
+"""
+    ^(s::Regex, n::Integer)
+
+Repeat a regex `n` times.
+
+!!! compat "Julia 1.2"
+     This method requires at least Julia 1.2.
+
+# Examples
+```jldoctest
+julia> r"Test "^3
+r"Test Test Test "
+```
+"""
+^(r::Regex, i::Integer) = Regex(r.pattern^i, r.compile_options, r.match_options)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -534,13 +534,13 @@ meaning that the contained characters are devoid of any special meaning
 
 # Examples
 ```jldoctest
-julia> r"Hello|Good bye" * ' ' * "world"
-r"(?:Hello|Good bye) world"
+julia> match(r"Hello|Good bye" * ' ' * "world", "Hello world")
+RegexMatch("Hello world")
 
 julia> r = r"a|b" * "c|d"
 r"(?:a|b)\\Qc|d\\E"
 
-match(r, "ac") == nothing
+julia> match(r, "ac") == nothing
 true
 
 julia> match(r, "ac|d")

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -562,7 +562,7 @@ function *(r1::Union{Regex,AbstractString,AbstractChar}, rs::Union{Regex,Abstrac
                 r.compile_options & ~mask == compile_opts ||
                 throw(ArgumentError("cannot multiply regexes: incompatible options"))
         end
-        shared &= r.compile_options & mask
+        shared &= r.compile_options
     end
     unshared = mask & ~shared
     Regex(string(unwrap_string(r1, unshared), unwrap_string.(rs, Ref(unshared))...), compile_opts | shared, match_opts)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -559,6 +559,8 @@ function *(r1::Union{Regex,AbstractString,AbstractChar}, rs::Union{Regex,Abstrac
     Regex(string(unwrap_string(r1, unshared), unwrap_string.(rs, Ref(unshared))...), compile_opts | shared, match_opts)
 end
 
+*(r::Regex) = r # avoids wrapping r in a useless subpattern
+
 unwrap_string(r::Regex, unshared::UInt32) = string("(?", regex_opts_str(r.compile_options & unshared), ':', r.pattern, ')')
 unwrap_string(s::Union{AbstractString,AbstractChar}, ::UInt32) = string("(?:", s, ')')
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -525,6 +525,9 @@ end
     *(s::Union{Regex,AbstractString,AbstractChar}, t::Regex) -> Regex
 
 Concatenate regexes, strings and/or characters, producing a [`Regex`](@ref).
+String and character arguments must be matched exactly in the resulting regex,
+meaning that the contained characters are devoid of any special meaning
+(they are quoted with "\\Q" and "\\E").
 
 !!! compat "Julia 1.2"
      This method requires at least Julia 1.2.
@@ -533,6 +536,15 @@ Concatenate regexes, strings and/or characters, producing a [`Regex`](@ref).
 ```jldoctest
 julia> r"Hello|Good bye" * ' ' * "world"
 r"(?:Hello|Good bye) world"
+
+julia> r = r"a|b" * "c|d"
+r"(?:a|b)\\Qc|d\\E"
+
+match(r, "ac") == nothing
+true
+
+julia> match(r, "ac|d")
+RegexMatch("ac|d")
 ```
 """
 function *(r1::Union{Regex,AbstractString,AbstractChar}, rs::Union{Regex,AbstractString,AbstractChar}...)
@@ -559,7 +571,7 @@ end
 *(r::Regex) = r # avoids wrapping r in a useless subpattern
 
 unwrap_string(r::Regex, unshared::UInt32) = string("(?", regex_opts_str(r.compile_options & unshared), ':', r.pattern, ')')
-unwrap_string(s::Union{AbstractString,AbstractChar}, ::UInt32) = s # no need to wrap in subpattern
+unwrap_string(s::Union{AbstractString,AbstractChar}, ::UInt32) = string("\\Q", s, "\\E")
 
 regex_opts_str(opts) = (isassigned(_regex_opts_str) ? _regex_opts_str[] : init_regex())[opts]
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -565,13 +565,13 @@ function *(r1::Union{Regex,AbstractString,AbstractChar}, rs::Union{Regex,Abstrac
         shared &= r.compile_options
     end
     unshared = mask & ~shared
-    Regex(string(unwrap_string(r1, unshared), unwrap_string.(rs, Ref(unshared))...), compile_opts | shared, match_opts)
+    Regex(string(wrap_string(r1, unshared), wrap_string.(rs, Ref(unshared))...), compile_opts | shared, match_opts)
 end
 
 *(r::Regex) = r # avoids wrapping r in a useless subpattern
 
-unwrap_string(r::Regex, unshared::UInt32) = string("(?", regex_opts_str(r.compile_options & unshared), ':', r.pattern, ')')
-unwrap_string(s::Union{AbstractString,AbstractChar}, ::UInt32) = string("\\Q", s, "\\E")
+wrap_string(r::Regex, unshared::UInt32) = string("(?", regex_opts_str(r.compile_options & unshared), ':', r.pattern, ')')
+wrap_string(s::Union{AbstractString,AbstractChar}, ::UInt32) = string("\\Q", s, "\\E")
 
 regex_opts_str(opts) = (isassigned(_regex_opts_str) ? _regex_opts_str[] : init_regex())[opts]
 
@@ -601,8 +601,6 @@ init_regex() = _regex_opts_str[] = foldl(0:15, init=ImmutableDict{UInt32,String}
 end
 
 
-
-
 """
     ^(s::Regex, n::Integer)
 
@@ -613,8 +611,11 @@ Repeat a regex `n` times.
 
 # Examples
 ```jldoctest
-julia> r"Test "^3
-r"(?:Test ){3}"
+julia> r"Test "^2
+r"(?:Test ){2}"
+
+julia> match(r"Test "^2, "Test Test ")
+RegexMatch("Test Test ")
 ```
 """
 ^(r::Regex, i::Integer) = Regex(string("(?:", r.pattern, "){$i}"), r.compile_options, r.match_options)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -529,8 +529,8 @@ String and character arguments must be matched exactly in the resulting regex,
 meaning that the contained characters are devoid of any special meaning
 (they are quoted with "\\Q" and "\\E").
 
-!!! compat "Julia 1.2"
-     This method requires at least Julia 1.2.
+!!! compat "Julia 1.3"
+     This method requires at least Julia 1.3.
 
 # Examples
 ```jldoctest
@@ -608,8 +608,8 @@ end
 
 Repeat a regex `n` times.
 
-!!! compat "Julia 1.2"
-     This method requires at least Julia 1.2.
+!!! compat "Julia 1.3"
+     This method requires at least Julia 1.3.
 
 # Examples
 ```jldoctest

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -925,6 +925,7 @@ function setup_interface(
             oldpos = firstindex(input)
             firstline = true
             isprompt_paste = false
+            jl_prompt_len = 7 # "julia> "
             while oldpos <= lastindex(input) # loop until all lines have been executed
                 if JL_PROMPT_PASTE[]
                     # Check if the next statement starts with "julia> ", in that case
@@ -934,7 +935,6 @@ function setup_interface(
                         oldpos >= sizeof(input) && return
                     end
                     # Check if input line starts with "julia> ", remove it if we are in prompt paste mode
-                    jl_prompt_len = 7
                     if (firstline || isprompt_paste) && startswith(SubString(input, oldpos), JULIA_PROMPT)
                         isprompt_paste = true
                         oldpos += jl_prompt_len
@@ -959,7 +959,7 @@ function setup_interface(
                         tail = lstrip(tail)
                     end
                     if isprompt_paste # remove indentation spaces corresponding to the prompt
-                        tail = replace(tail, r"^ {7}"m => "") # 7: jl_prompt_len
+                        tail = replace(tail, r"^"m * ' '^jl_prompt_len => "")
                     end
                     LineEdit.replace_line(s, tail, true)
                     LineEdit.refresh_line(s)
@@ -969,7 +969,7 @@ function setup_interface(
                 line = strip(input[oldpos:prevind(input, pos)])
                 if !isempty(line)
                     if isprompt_paste # remove indentation spaces corresponding to the prompt
-                        line = replace(line, r"^ {7}"m => "") # 7: jl_prompt_len
+                        line = replace(line, r"^"m * ' '^jl_prompt_len => "")
                     end
                     # put the line on the screen and history
                     LineEdit.replace_line(s, line)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -107,6 +107,10 @@
         @test r"a"im * r"b"im == r"(?:a)(?:b)"im
         @test r"a"im * r"b"i  == r"(?m:a)(?:b)"i
 
+        r = r"" * raw"a\Eb|c"
+        @test match(r, raw"a\Eb|c").match == raw"a\Eb|c"
+        @test match(r, raw"c") == nothing
+
         # error for really incompatible options
         @test_throws ArgumentError r"a" * Regex("b", Base.DEFAULT_COMPILER_OPTS & ~Base.PCRE.UCP, Base.DEFAULT_MATCH_OPTS)
         @test_throws ArgumentError r"a" * Regex("b", Base.DEFAULT_COMPILER_OPTS, Base.DEFAULT_MATCH_OPTS & ~Base.PCRE.NO_UTF_CHECK)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -82,25 +82,25 @@
         @test *(r"a") == r"a"
 
         @test r"a" * r"b" == r"(?:a)(?:b)"
-        @test r"a" * "b"  == r"(?:a)(?:b)"
-        @test r"a" * 'b'  == r"(?:a)(?:b)"
-        @test "a"  * r"b" == r"(?:a)(?:b)"
-        @test 'a'  * r"b" == r"(?:a)(?:b)"
+        @test r"a" * "b"  == r"(?:a)b"
+        @test r"a" * 'b'  == r"(?:a)b"
+        @test "a"  * r"b" == r"a(?:b)"
+        @test 'a'  * r"b" == r"a(?:b)"
         for a = (r"a", "a", 'a'),
             b = (r"b", "b", 'b'),
             c = (r"c", "c", 'c')
             a isa Regex || b isa Regex || c isa Regex || continue
-            @test a * b * c == r"(?:a)(?:b)(?:c)"
+            @test match(a * b * c, "abc") !== nothing
         end
         for s = ["thiscat", "thishat", "thatcat", "thathat"]
             @test match(r"this|that" * r"cat|hat", s) !== nothing
         end
 
         @test r"a"i * r"b"i == r"(?:a)(?:b)"i
-        @test r"a"i * "b"   == r"(?:a)(?:b)"i
-        @test r"a"i * 'b'   == r"(?:a)(?:b)"i
-        @test "a"   * r"b"i == r"(?:a)(?:b)"i
-        @test 'a'   * r"b"i == r"(?:a)(?:b)"i
+        @test r"a"i * "b"   == r"(?:a)b"i
+        @test r"a"i * 'b'   == r"(?:a)b"i
+        @test "a"   * r"b"i == r"a(?:b)"i
+        @test 'a'   * r"b"i == r"a(?:b)"i
 
         @test r"a"i  * r"b"m  == r"(?i:a)(?m:b)"
         @test r"a"im * r"b"m  == r"(?i:a)(?:b)"m

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -82,10 +82,10 @@
         @test *(r"a") == r"a"
 
         @test r"a" * r"b" == r"(?:a)(?:b)"
-        @test r"a" * "b"  == r"(?:a)b"
-        @test r"a" * 'b'  == r"(?:a)b"
-        @test "a"  * r"b" == r"a(?:b)"
-        @test 'a'  * r"b" == r"a(?:b)"
+        @test r"a" * "b"  == r"(?:a)\Qb\E"
+        @test r"a" * 'b'  == r"(?:a)\Qb\E"
+        @test "a"  * r"b" == r"\Qa\E(?:b)"
+        @test 'a'  * r"b" == r"\Qa\E(?:b)"
         for a = (r"a", "a", 'a'),
             b = (r"b", "b", 'b'),
             c = (r"c", "c", 'c')
@@ -97,10 +97,10 @@
         end
 
         @test r"a"i * r"b"i == r"(?:a)(?:b)"i
-        @test r"a"i * "b"   == r"(?:a)b"i
-        @test r"a"i * 'b'   == r"(?:a)b"i
-        @test "a"   * r"b"i == r"a(?:b)"i
-        @test 'a'   * r"b"i == r"a(?:b)"i
+        @test r"a"i * "b"   == r"(?:a)\Qb\E"i
+        @test r"a"i * 'b'   == r"(?:a)\Qb\E"i
+        @test "a"   * r"b"i == r"\Qa\E(?:b)"i
+        @test 'a'   * r"b"i == r"\Qa\E(?:b)"i
 
         @test r"a"i  * r"b"m  == r"(?i:a)(?m:b)"
         @test r"a"im * r"b"m  == r"(?i:a)(?:b)"m

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -79,6 +79,8 @@
     @test endswith("abc", r"C"i)
 
     @testset "multiplication & exponentiation" begin
+        @test *(r"a") == r"a"
+
         @test r"a" * r"b" == r"(?:a)(?:b)"
         @test r"a" * "b"  == r"(?:a)(?:b)"
         @test r"a" * 'b'  == r"(?:a)(?:b)"

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -78,6 +78,29 @@
     @test !endswith("abc", r"C")
     @test endswith("abc", r"C"i)
 
+    @testset "multiplication & exponentiation" begin
+        @test r"a" * r"b" == r"ab"
+        @test r"a" * "b" == r"ab"
+        @test r"a" * 'b' == r"ab"
+        @test "a" * r"b" == r"ab"
+        @test 'a' * r"b" == r"ab"
+        for a = (r"a", "a", 'a'),
+            b = (r"b", "b", 'b'),
+            c = (r"c", "c", 'c')
+            a isa Regex || b isa Regex || c isa Regex || continue
+            @test a * b * c == r"abc"
+        end
+        @test r"a"i * r"b"i == r"ab"i
+        @test r"a"i * "b" == r"ab"i
+        @test r"a"i * 'b' == r"ab"i
+        @test "a" * r"b"i == r"ab"i
+        @test 'a' * r"b"i == r"ab"i
+        @test_throws ArgumentError r"a"i * r"b"
+        @test_throws ArgumentError r"a" * r"b"i
+
+        @test r"abc"^ 2 == r"abcabc"
+    end
+
     # Test that PCRE throws the correct kind of error
     # TODO: Uncomment this once the corresponding change has propagated to CI
     #@test_throws ErrorException Base.PCRE.info(C_NULL, Base.PCRE.INFO_NAMECOUNT, UInt32)


### PR DESCRIPTION
I needed it recently and got frustrated that it doesn't work:
```
julia> const width = 7
julia> replace(line, r"^" * ' '^width, "") # ok, doesn't work, have to look up how to do repetition in PCRE...
julia> replace(line, r"^ {$width}", "") # ah crap, cannot do string interpolation...
julia> replace(line, r"^ {7}, "") # NOTE:  this 7 corresponds to `width`, don't forget to update it when needed
```
So yes there is a way to achieve what is needed with the `Regex` constructor, but allowing `*` is more regex-noobie friendly.

I don't know if it's a good idea, but don't foresee a problem with it; note that I didn't go so far as making `Regex <: AbstractString`, as I didn't expect to get support for that ;-)