### PR TITLE
Make include accept arbitrary number of string inputs

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -28,6 +28,9 @@ function include(path::AbstractString)
     end
     result
 end
+
+include(path::AbstractString...) = include(joinpath(path...))
+
 let SOURCE_PATH = ""
     # simple, race-y TLS, relative include
     global _include


### PR DESCRIPTION
This method will make `include` support a call syntax like
```julia
include(@__DIR__, "filename.jl")
include(path_variable, "filename.jl")
```
which is simpler than
```julia
include(joinpath(@__DIR__, "filename.jl"))
include(joinpath(path_variable, "filename.jl"))
```

This is my first PR to julia, I apologize in advance for any breach of protocol.