### PR TITLE
Add leaftypes and abstracts functions to Base.Meta

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -56,4 +56,18 @@ macro dump(expr)
     dump(expr)
 end
 
+"""
+    leaftypes(t::Type) -> Vector{DataType}
+
+Return an array of all concrete subtypes of `t`, including `t` if it is concrete.
+"""
+leaftypes(t::Type) = isleaftype(t) ? [t] : vcat(leaftypes.(subtypes(t))...)
+
+"""
+    abstracts(t::Type) -> Vector{DataType}
+
+Return an array of all abstract subtypes of `t`, including `t` if it is abstract.
+"""
+abstracts(t::Type) = isleaftype(t) ? DataType[] : vcat(t, abstracts.(subtypes(t))...)
+
 end # module

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -60,20 +60,20 @@ macro dump(expr)
 end
 
 """
-    leaftypes(t::Type) -> Vector{Union{DataType, UnionAll}}
+    leaftypes(t::Type) -> Vector{Type}
 
 Return an array containing all concrete subtypes of `t`, or only `t` if it is concrete.
 """
-function leaftypes(t::Type)::Vector{Union{DataType, UnionAll}}
+function leaftypes(t::Type)::Vector{Type}
     isleaftype(t) ? [t] : vcat(leaftypes.(subtypes(t))...)
 end
 
 """
-    abstracts(t::Type) -> Vector{Union{DataType, UnionAll}}
+    abstracts(t::Type) -> Vector{Type}
 
 Return an array containing all abstract subtypes of `t`, which may include `t`.
 """
-function abstracts(t::Type)::Vector{Union{DataType, UnionAll}}
+function abstracts(t::Type)::Vector{Type}
     isleaftype(t) ? DataType[] : vcat(t, abstracts.(subtypes(t))...)
 end
 

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -8,7 +8,10 @@ module Meta
 export quot,
        isexpr,
        show_sexpr,
-       @dump
+       @dump,
+       leaftypes,
+       abstracts
+
 
 quot(ex) = Expr(:quote, ex)
 
@@ -57,17 +60,21 @@ macro dump(expr)
 end
 
 """
-    leaftypes(t::Type) -> Vector{DataType}
+    leaftypes(t::Type) -> Vector{Union{DataType, UnionAll}}
 
 Return an array of all concrete subtypes of `t`, including `t` if it is concrete.
 """
-leaftypes(t::Type) = isleaftype(t) ? [t] : vcat(leaftypes.(subtypes(t))...)
+function leaftypes(t::Type)::Vector{Union{DataType, UnionAll}}
+    return isleaftype(t) ? [t] : vcat(leaftypes.(subtypes(t))...)
+end
 
 """
-    abstracts(t::Type) -> Vector{DataType}
+    abstracts(t::Type) -> Vector{Union{DataType, UnionAll}}
 
 Return an array of all abstract subtypes of `t`, including `t` if it is abstract.
 """
-abstracts(t::Type) = isleaftype(t) ? DataType[] : vcat(t, abstracts.(subtypes(t))...)
+function abstracts(t::Type)::Vector{Union{DataType, UnionAll}}
+    return isleaftype(t) ? DataType[] : vcat(t, abstracts.(subtypes(t))...)
+end
 
 end # module

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -62,19 +62,19 @@ end
 """
     leaftypes(t::Type) -> Vector{Union{DataType, UnionAll}}
 
-Return an array of all concrete subtypes of `t`, including `t` if it is concrete.
+Return an array containing all concrete subtypes of `t`, or only `t` if it is concrete.
 """
 function leaftypes(t::Type)::Vector{Union{DataType, UnionAll}}
-    return isleaftype(t) ? [t] : vcat(leaftypes.(subtypes(t))...)
+    isleaftype(t) ? [t] : vcat(leaftypes.(subtypes(t))...)
 end
 
 """
     abstracts(t::Type) -> Vector{Union{DataType, UnionAll}}
 
-Return an array of all abstract subtypes of `t`, including `t` if it is abstract.
+Return an array containing all abstract subtypes of `t`, which may include `t`.
 """
 function abstracts(t::Type)::Vector{Union{DataType, UnionAll}}
-    return isleaftype(t) ? DataType[] : vcat(t, abstracts.(subtypes(t))...)
+    isleaftype(t) ? DataType[] : vcat(t, abstracts.(subtypes(t))...)
 end
 
 end # module

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -188,3 +188,25 @@ let oldout = STDOUT
         redirect_stdout(oldout)
     end
 end
+
+@testset "leaftypes/abstracts" begin
+    abstract type Foo end
+    abstract type Bar
+    abstract type Baz <: Bar end
+    abstract type Qux <: Baz end
+    abstract type Quux <: Qux end
+    struct Corge <: Baz end
+    struct Uier <: Baz end
+    struct Grault <: Qux end
+    struct Waldo end
+
+    @test isempty(leaftypes(Foo))
+    @test leaftypes(Waldo) == [Waldo]
+    @test Set(leaftypes(Bar)) == Set([Corge, Uier, Grault])
+    @test leaftypes(Qux) == [Grault]
+
+    @test abstracts(Foo) == [Foo]
+    @test Set(abstracts(Bar)) == Set([Bar, Baz, Qux, Quux])
+    @test Set(abstracts(Qux)) == Set([Qux, Quux])
+    @test isempty(abstracts(Grault))
+end

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -189,17 +189,17 @@ let oldout = STDOUT
     end
 end
 
-@testset "leaftypes/abstracts" begin
-    abstract type Foo end
-    abstract type Bar end
-    abstract type Baz <: Bar end
-    abstract type Qux <: Baz end
-    abstract type Quux <: Qux end
-    struct Corge <: Baz end
-    struct Uier <: Baz end
-    struct Grault <: Qux end
-    struct Waldo end
+abstract type Foo end
+abstract type Bar end
+abstract type Baz <: Bar end
+abstract type Qux <: Baz end
+abstract type Quux <: Qux end
+struct Corge <: Baz end
+struct Uier <: Baz end
+struct Grault <: Qux end
+struct Waldo end
 
+@testset "leaftypes/abstracts" begin
     @test isempty(leaftypes(Foo))
     @test leaftypes(Waldo) == [Waldo]
     @test Set(leaftypes(Bar)) == Set([Corge, Uier, Grault])

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -191,7 +191,7 @@ end
 
 @testset "leaftypes/abstracts" begin
     abstract type Foo end
-    abstract type Bar
+    abstract type Bar end
     abstract type Baz <: Bar end
     abstract type Qux <: Baz end
     abstract type Quux <: Qux end


### PR DESCRIPTION
I thought this might be pretty useful, it came out of a brief discussion on Slack:

![](http://i.imgur.com/YNqoYZh.png)

A few questions:

* This would probably benefit from multithreading, right? 
* Are the type signatures on these methods correct? 
* It would appear that `leaftypes(Any)` recurses infinitely, can anyone tell me why that might be? I don't know if it's just that my computer is not fast enough :sweat_smile:
* Should this go anywhere in the manual? 
