### PR TITLE
fix printing expressions like Ref{<:Real}

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -535,6 +535,7 @@ show_unquoted(io::IO, ex, ::Int,::Int) = show(io, ex)
 
 const indent_width = 4
 const quoted_syms = Set{Symbol}([:(:),:(::),:(:=),:(=),:(==),:(!=),:(===),:(!==),:(=>),:(>=),:(<=)])
+const uni_syms = Set{Symbol}([:(::), :(<:), :(>:)])
 const uni_ops = Set{Symbol}([:(+), :(-), :(!), :(¬), :(~), :(<:), :(>:), :(√), :(∛), :(∜)])
 const expr_infix_wide = Set{Symbol}([
     :(=), :(+=), :(-=), :(*=), :(/=), :(\=), :(^=), :(&=), :(|=), :(÷=), :(%=), :(>>>=), :(>>=), :(<<=),
@@ -994,8 +995,8 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, head)
 
     # type annotation (i.e. "::Int")
-    elseif head === Symbol("::") && nargs == 1
-        print(io, "::")
+    elseif head in uni_syms && nargs == 1
+        print(io, head)
         show_unquoted(io, args[1], indent)
 
     # var-arg declaration or expansion

--- a/test/show.jl
+++ b/test/show.jl
@@ -415,6 +415,8 @@ end
 @test_repr "a::b where T"
 @test_repr "X where (T=1)"
 @test_repr "X where T = 1"
+@test_repr "Array{<:Real}"
+@test_repr "Array{>:Real}"
 
 let oldout = STDOUT, olderr = STDERR
     local rdout, wrout, rderr, wrerr, out, err, rd, wr


### PR DESCRIPTION
fixes #23457

Previously they were not explicitly handled by show_unquoted,
ending up being printed as Expr. This was not parsable back
to their original meaning.

This was easier to track down than I thought, mostly thanks to Revise.jl