### PR TITLE
Make exception types consistent

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -8,10 +8,12 @@
 The objects called do not have matching dimensionality. Optional argument `msg` is a
 descriptive error string.
 """
-mutable struct DimensionMismatch <: Exception
-    msg::AbstractString
+struct DimensionMismatch <: Exception
+    msg::String
+    DimensionMismatch() = new("")
+    DimensionMismatch(msg::AbstractString) = new(msg)
 end
-DimensionMismatch() = DimensionMismatch("")
+
 
 ## Type aliases for convenience ##
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -9,11 +9,9 @@ The objects called do not have matching dimensionality. Optional argument `msg` 
 descriptive error string.
 """
 struct DimensionMismatch <: Exception
-    msg::String
-    DimensionMismatch() = new("")
-    DimensionMismatch(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
-
+DimensionMismatch() = DimensionMismatch("")
 
 ## Type aliases for convenience ##
 """

--- a/base/associative.jl
+++ b/base/associative.jl
@@ -8,7 +8,7 @@
 An indexing operation into an `Associative` (`Dict`) or `Set` like object tried to access or
 delete a non-existent element.
 """
-mutable struct KeyError <: Exception
+struct KeyError <: Exception
     key
 end
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -195,8 +195,8 @@ end
 Expr(@nospecialize args...) = _expr(args...)
 
 abstract type Exception end
-mutable struct ErrorException <: Exception
-    msg::AbstractString
+struct ErrorException <: Exception
+    msg::String
     ErrorException(msg::AbstractString) = new(msg)
 end
 
@@ -204,32 +204,32 @@ macro _noinline_meta()
     Expr(:meta, :noinline)
 end
 
-struct BoundsError        <: Exception
+struct BoundsError <: Exception
     a::Any
     i::Any
     BoundsError() = new()
     BoundsError(@nospecialize(a)) = (@_noinline_meta; new(a))
     BoundsError(@nospecialize(a), i) = (@_noinline_meta; new(a,i))
 end
-struct DivideError        <: Exception end
-struct OutOfMemoryError   <: Exception end
-struct ReadOnlyMemoryError<: Exception end
-struct SegmentationFault  <: Exception end
-struct StackOverflowError <: Exception end
-struct UndefRefError      <: Exception end
-struct UndefVarError      <: Exception
+struct DivideError         <: Exception end
+struct OutOfMemoryError    <: Exception end
+struct ReadOnlyMemoryError <: Exception end
+struct SegmentationFault   <: Exception end
+struct StackOverflowError  <: Exception end
+struct UndefRefError       <: Exception end
+struct UndefVarError <: Exception
     var::Symbol
 end
 struct InterruptException <: Exception end
 struct DomainError <: Exception
     val
-    msg
-    DomainError(@nospecialize(val)) = (@_noinline_meta; new(val))
+    msg::String
+    DomainError(@nospecialize(val)) = (@_noinline_meta; new(val, ""))
     DomainError(@nospecialize(val), @nospecialize(msg)) = (@_noinline_meta; new(val, msg))
 end
-mutable struct TypeError <: Exception
+struct TypeError <: Exception
     func::Symbol
-    context::AbstractString
+    context::String
     expected::Type
     got
 end
@@ -237,18 +237,19 @@ struct InexactError <: Exception
     func::Symbol
     T::Type
     val
-
     InexactError(f::Symbol, @nospecialize(T), @nospecialize(val)) = (@_noinline_meta; new(f, T, val))
 end
 struct OverflowError <: Exception
-    msg
+    msg::String
+    OverflowError(msg::AbstractString) = new(msg)
 end
 
-mutable struct ArgumentError <: Exception
-    msg::AbstractString
+struct ArgumentError <: Exception
+    msg::String
+    ArgumentError(msg::AbstractString) = new(msg)
 end
 
-mutable struct MethodError <: Exception
+struct MethodError <: Exception
     f
     args
     world::UInt
@@ -257,23 +258,24 @@ end
 const typemax_UInt = ccall(:jl_typemax_uint, Any, (Any,), UInt)
 MethodError(@nospecialize(f), @nospecialize(args)) = MethodError(f, args, typemax_UInt)
 
-mutable struct AssertionError <: Exception
-    msg::AbstractString
+struct AssertionError <: Exception
+    msg::String
     AssertionError() = new("")
-    AssertionError(msg) = new(msg)
+    AssertionError(msg::AbstractString) = new(msg)
 end
 
 #Generic wrapping of arbitrary exceptions
 #Subtypes should put the exception in an 'error' field
 abstract type WrappedException <: Exception end
 
-mutable struct LoadError <: WrappedException
-    file::AbstractString
+struct LoadError <: WrappedException
+    file::String
     line::Int
     error
+    LoadError(file::AbstractString, line::Integer, error) = new(file,line,error)
 end
 
-mutable struct InitError <: WrappedException
+struct InitError <: WrappedException
     mod::Symbol
     error
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -196,8 +196,7 @@ Expr(@nospecialize args...) = _expr(args...)
 
 abstract type Exception end
 struct ErrorException <: Exception
-    msg::String
-    ErrorException(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 macro _noinline_meta()
@@ -223,13 +222,13 @@ end
 struct InterruptException <: Exception end
 struct DomainError <: Exception
     val
-    msg::String
+    msg::AbstractString
     DomainError(@nospecialize(val)) = (@_noinline_meta; new(val, ""))
     DomainError(@nospecialize(val), @nospecialize(msg)) = (@_noinline_meta; new(val, msg))
 end
 struct TypeError <: Exception
     func::Symbol
-    context::String
+    context::AbstractString
     expected::Type
     got
 end
@@ -240,13 +239,11 @@ struct InexactError <: Exception
     InexactError(f::Symbol, @nospecialize(T), @nospecialize(val)) = (@_noinline_meta; new(f, T, val))
 end
 struct OverflowError <: Exception
-    msg::String
-    OverflowError(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 struct ArgumentError <: Exception
-    msg::String
-    ArgumentError(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 struct MethodError <: Exception
@@ -259,20 +256,18 @@ const typemax_UInt = ccall(:jl_typemax_uint, Any, (Any,), UInt)
 MethodError(@nospecialize(f), @nospecialize(args)) = MethodError(f, args, typemax_UInt)
 
 struct AssertionError <: Exception
-    msg::String
-    AssertionError() = new("")
-    AssertionError(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
+AssertionError() = AssertionError("")
 
 #Generic wrapping of arbitrary exceptions
 #Subtypes should put the exception in an 'error' field
 abstract type WrappedException <: Exception end
 
 struct LoadError <: WrappedException
-    file::String
+    file::AbstractString
     line::Int
     error
-    LoadError(file::AbstractString, line::Integer, error) = new(file,line,error)
 end
 
 struct InitError <: WrappedException

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -247,9 +247,8 @@ function close_chnl_on_taskdone(t::Task, ref::WeakRef)
 end
 
 struct InvalidStateException <: Exception
-    msg::String
+    msg::AbstractString
     state::Symbol
-    InvalidStateException(msg::AbstractString, state::Symbol) = new(msg, state)
 end
 
 """

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -246,9 +246,10 @@ function close_chnl_on_taskdone(t::Task, ref::WeakRef)
     end
 end
 
-mutable struct InvalidStateException <: Exception
-    msg::AbstractString
+struct InvalidStateException <: Exception
+    msg::String
     state::Symbol
+    InvalidStateException(msg::AbstractString, state::Symbol) = new(msg, state)
 end
 
 """

--- a/base/codevalidation.jl
+++ b/base/codevalidation.jl
@@ -44,11 +44,10 @@ const SIGNATURE_NARGS_MISMATCH = "method signature does not match number of meth
 const SLOTNAMES_NARGS_MISMATCH = "CodeInfo for method contains fewer slotnames than the number of method arguments"
 
 struct InvalidCodeError <: Exception
-    kind::String
+    kind::AbstractString
     meta::Any
-    InvalidCodeError(kind::AbstractString) = new(kind, nothing)
-    InvalidCodeError(kind::AbstractString, meta) = new(kind, meta)
 end
+InvalidCodeError(kind::AbstractString) = InvalidCodeError(kind, nothing)
 
 
 """

--- a/base/codevalidation.jl
+++ b/base/codevalidation.jl
@@ -46,9 +46,10 @@ const SLOTNAMES_NARGS_MISMATCH = "CodeInfo for method contains fewer slotnames t
 struct InvalidCodeError <: Exception
     kind::String
     meta::Any
+    InvalidCodeError(kind::AbstractString) = new(kind, nothing)
+    InvalidCodeError(kind::AbstractString, meta) = new(kind, meta)
 end
 
-InvalidCodeError(kind) = InvalidCodeError(kind, nothing)
 
 """
     validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo)

--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -892,7 +892,7 @@ After a client Julia process has exited, further attempts to reference the dead 
 throw this exception.
 """
 ProcessExitedException()
-mutable struct ProcessExitedException <: Exception end
+struct ProcessExitedException <: Exception end
 
 worker_from_id(i) = worker_from_id(PGRP, i)
 function worker_from_id(pg::ProcessGroup, i)

--- a/base/distributed/pmap.jl
+++ b/base/distributed/pmap.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-mutable struct BatchProcessingError <: Exception
+struct BatchProcessingError <: Exception
     data
     ex
 end

--- a/base/distributed/process_messages.jl
+++ b/base/distributed/process_messages.jl
@@ -16,7 +16,7 @@ end
 wait(rv::RemoteValue) = wait(rv.c)
 
 ## core messages: do, call, fetch, wait, ref, put! ##
-mutable struct RemoteException <: Exception
+struct RemoteException <: Exception
     pid::Int
     captured::CapturedException
 end

--- a/base/io.jl
+++ b/base/io.jl
@@ -7,15 +7,15 @@
 
 No more data was available to read from a file or stream.
 """
-mutable struct EOFError <: Exception end
+struct EOFError <: Exception end
 
 """
     SystemError(prefix::AbstractString, [errno::Int32])
 
 A system call failed with an error code (in the `errno` global variable).
 """
-mutable struct SystemError <: Exception
-    prefix::AbstractString
+struct SystemError <: Exception
+    prefix::String
     errnum::Int32
     extrainfo
     SystemError(p::AbstractString, e::Integer, extrainfo) = new(p, e, extrainfo)

--- a/base/io.jl
+++ b/base/io.jl
@@ -15,7 +15,7 @@ struct EOFError <: Exception end
 A system call failed with an error code (in the `errno` global variable).
 """
 struct SystemError <: Exception
-    prefix::String
+    prefix::AbstractString
     errnum::Int32
     extrainfo
     SystemError(p::AbstractString, e::Integer, extrainfo) = new(p, e, extrainfo)

--- a/base/libgit2/error.jl
+++ b/base/libgit2/error.jl
@@ -66,7 +66,8 @@ end
 struct GitError <: Exception
     class::Class
     code::Code
-    msg::AbstractString
+    msg::String
+    GitError(class::Class, code::Code, msg::AbstractString) = new(class,code,msg)
 end
 Base.show(io::IO, err::GitError) = print(io, "GitError(Code:$(err.code), Class:$(err.class), $(err.msg))")
 

--- a/base/libgit2/error.jl
+++ b/base/libgit2/error.jl
@@ -66,8 +66,7 @@ end
 struct GitError <: Exception
     class::Class
     code::Code
-    msg::String
-    GitError(class::Class, code::Code, msg::AbstractString) = new(class,code,msg)
+    msg::AbstractString
 end
 Base.show(io::IO, err::GitError) = print(io, "GitError(Code:$(err.code), Class:$(err.class), $(err.msg))")
 

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -53,10 +53,10 @@ unpreserve_handle(x) = (v = uvhandles[x]::Int; v == 1 ? pop!(uvhandles,x) : (uvh
 
 ## Libuv error handling ##
 
-mutable struct UVError <: Exception
-    prefix::AbstractString
+struct UVError <: Exception
+    prefix::String
     code::Int32
-    UVError(p::AbstractString,code::Integer)=new(p,code)
+    UVError(p::AbstractString, code::Integer) = new(p,code)
 end
 
 struverror(err::Int32) = unsafe_string(ccall(:uv_strerror,Cstring,(Int32,),err))

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -54,7 +54,7 @@ unpreserve_handle(x) = (v = uvhandles[x]::Int; v == 1 ? pop!(uvhandles,x) : (uvh
 ## Libuv error handling ##
 
 struct UVError <: Exception
-    prefix::String
+    prefix::AbstractString
     code::Int32
     UVError(p::AbstractString, code::Integer) = new(p,code)
 end

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -246,8 +246,9 @@ float(a::AbstractArray{<:AbstractString}) = map!(float, similar(a,typeof(float(0
 The expression passed to the `parse` function could not be interpreted as a valid Julia
 expression.
 """
-mutable struct ParseError <: Exception
-    msg::AbstractString
+struct ParseError <: Exception
+    msg::String
+    ParseError(msg::AbstractString) = new(msg)
 end
 
 """

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -247,8 +247,7 @@ The expression passed to the `parse` function could not be interpreted as a vali
 expression.
 """
 struct ParseError <: Exception
-    msg::String
-    ParseError(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 """

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -732,8 +732,9 @@ function test!(pkg::AbstractString,
     isfile(reqs_path) && resolve()
 end
 
-mutable struct PkgTestError <: Exception
+struct PkgTestError <: Exception
     msg::String
+    PkgTestError(msg::AbstractString) = new(msg)
 end
 
 function Base.showerror(io::IO, ex::PkgTestError, bt; backtrace=true)

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -733,8 +733,7 @@ function test!(pkg::AbstractString,
 end
 
 struct PkgTestError <: Exception
-    msg::String
-    PkgTestError(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 function Base.showerror(io::IO, ex::PkgTestError, bt; backtrace=true)

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -21,11 +21,10 @@ const DEFAULT_META = "https://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
 
 struct PkgError <: Exception
-    msg::String
+    msg::AbstractString
     ex::Nullable{Exception}
-    PkgError(msg::AbstractString) = new(msg, Nullable{Exception}())
-    PkgError(msg::AbstractString, ex::Nullable{Exception}) = new(msg, ex)
 end
+PkgError(msg::AbstractString) = PkgError(msg, Nullable{Exception}())
 function Base.showerror(io::IO, pkgerr::PkgError)
     print(io, pkgerr.msg)
     if !isnull(pkgerr.ex)

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -20,11 +20,12 @@ export dir, init, rm, add, available, installed, status, clone, checkout,
 const DEFAULT_META = "https://github.com/JuliaLang/METADATA.jl"
 const META_BRANCH = "metadata-v2"
 
-mutable struct PkgError <: Exception
-    msg::AbstractString
+struct PkgError <: Exception
+    msg::String
     ex::Nullable{Exception}
+    PkgError(msg::AbstractString) = new(msg, Nullable{Exception}())
+    PkgError(msg::AbstractString, ex::Nullable{Exception}) = new(msg, ex)
 end
-PkgError(msg::AbstractString) = PkgError(msg, Nullable{Exception}())
 function Base.showerror(io::IO, pkgerr::PkgError)
     print(io, pkgerr.msg)
     if !isnull(pkgerr.ex)

--- a/base/pkg/resolve/maxsum.jl
+++ b/base/pkg/resolve/maxsum.jl
@@ -10,7 +10,7 @@ export UnsatError, Graph, Messages, maxsum
 
 # An exception type used internally to signal that an unsatisfiable
 # constraint was detected
-mutable struct UnsatError <: Exception
+struct UnsatError <: Exception
     info
 end
 

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -8,8 +8,7 @@ export @simd, simd_outer_range, simd_inner_length, simd_index
 
 # Error thrown from ill-formed uses of @simd
 struct SimdError <: Exception
-    msg::String
-    SimdError(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 # Parse iteration space expression

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -7,8 +7,9 @@ module SimdLoop
 export @simd, simd_outer_range, simd_inner_length, simd_index
 
 # Error thrown from ill-formed uses of @simd
-mutable struct SimdError <: Exception
+struct SimdError <: Exception
     msg::String
+    SimdError(msg::AbstractString) = new(msg)
 end
 
 # Parse iteration space expression

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -582,9 +582,10 @@ end
 
 ##
 
-mutable struct DNSError <: Exception
-    host::AbstractString
+struct DNSError <: Exception
+    host::String
     code::Int32
+    DNSError(host::AbstractString, code::Integer) = new(host,code)
 end
 
 function show(io::IO, err::DNSError)

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -583,9 +583,8 @@ end
 ##
 
 struct DNSError <: Exception
-    host::String
+    host::AbstractString
     code::Int32
-    DNSError(host::AbstractString, code::Integer) = new(host,code)
 end
 
 function show(io::IO, err::DNSError)

--- a/base/sparse/cholmod_h.jl
+++ b/base/sparse/cholmod_h.jl
@@ -71,8 +71,7 @@ const VTypes = Union{Complex128, Float64}
 const VRealTypes = Union{Float64}
 
 struct CHOLMODException <: Exception
-    msg::String
-    CHOLMODException(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 macro isok(A)

--- a/base/sparse/cholmod_h.jl
+++ b/base/sparse/cholmod_h.jl
@@ -70,8 +70,9 @@ end
 const VTypes = Union{Complex128, Float64}
 const VRealTypes = Union{Float64}
 
-mutable struct CHOLMODException <: Exception
-    msg::AbstractString
+struct CHOLMODException <: Exception
+    msg::String
+    CHOLMODException(msg::AbstractString) = new(msg)
 end
 
 macro isok(A)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -11,8 +11,9 @@ using ..SparseArrays
 import ..SparseArrays: increment, increment!, decrement, decrement!, nnz
 
 include("umfpack_h.jl")
-mutable struct MatrixIllConditionedException <: Exception
-    message::AbstractString
+struct MatrixIllConditionedException <: Exception
+    msg::String
+    MatrixIllConditionedException(msg::AbstractString) = new(msg)
 end
 
 function umferror(status::Integer)

--- a/base/sparse/umfpack.jl
+++ b/base/sparse/umfpack.jl
@@ -12,8 +12,7 @@ import ..SparseArrays: increment, increment!, decrement, decrement!, nnz
 
 include("umfpack_h.jl")
 struct MatrixIllConditionedException <: Exception
-    msg::String
-    MatrixIllConditionedException(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 function umferror(status::Integer)

--- a/base/strings/errors.jl
+++ b/base/strings/errors.jl
@@ -5,10 +5,11 @@
 const UTF_ERR_SHORT             = "invalid UTF-8 sequence starting at index <<1>> (0x<<2>> missing one or more continuation bytes)"
 const UTF_ERR_INVALID_INDEX     = "invalid character index"
 
-mutable struct UnicodeError <: Exception
-    errmsg::AbstractString      ##< A UTF_ERR_ message
-    errpos::Int32               ##< Position of invalid character
-    errchr::UInt32              ##< Invalid character
+struct UnicodeError <: Exception
+    errmsg::String           ##< A UTF_ERR_ message
+    errpos::Int32            ##< Position of invalid character
+    errchr::UInt32           ##< Invalid character
+    UnicodeError(errmsg::AbstractString, errpos::Integer, errchr::Integer) = new(errmsg, errpos, errchr)
 end
 
 show(io::IO, exc::UnicodeError) = print(io, replace(replace(string("UnicodeError: ",exc.errmsg),

--- a/base/strings/errors.jl
+++ b/base/strings/errors.jl
@@ -6,10 +6,9 @@ const UTF_ERR_SHORT             = "invalid UTF-8 sequence starting at index <<1>
 const UTF_ERR_INVALID_INDEX     = "invalid character index"
 
 struct UnicodeError <: Exception
-    errmsg::String           ##< A UTF_ERR_ message
+    errmsg::AbstractString   ##< A UTF_ERR_ message
     errpos::Int32            ##< Position of invalid character
     errchr::UInt32           ##< Invalid character
-    UnicodeError(errmsg::AbstractString, errpos::Integer, errchr::Integer) = new(errmsg, errpos, errchr)
 end
 
 show(io::IO, exc::UnicodeError) = print(io, replace(replace(string("UnicodeError: ",exc.errmsg),

--- a/base/task.jl
+++ b/base/task.jl
@@ -3,7 +3,7 @@
 ## basic task functions and TLS
 
 # Container for a captured exception and its backtrace. Can be serialized.
-mutable struct CapturedException <: Exception
+struct CapturedException <: Exception
     ex::Any
     processed_bt::Vector{Any}
 
@@ -26,7 +26,7 @@ function showerror(io::IO, ce::CapturedException)
     showerror(io, ce.ex, ce.processed_bt, backtrace=true)
 end
 
-mutable struct CompositeException <: Exception
+struct CompositeException <: Exception
     exceptions::Vector{Any}
     CompositeException() = new(Any[])
     CompositeException(exceptions) = new(exceptions)

--- a/base/task.jl
+++ b/base/task.jl
@@ -29,7 +29,7 @@ end
 struct CompositeException <: Exception
     exceptions::Vector{Any}
     CompositeException() = new(Any[])
-    CompositeException(exceptions) = new(exceptions)
+    CompositeException(exceptions::Vector{Any}) = new(exceptions)
 end
 length(c::CompositeException) = length(c.exceptions)
 push!(c::CompositeException, ex) = push!(c.exceptions, ex)

--- a/base/task.jl
+++ b/base/task.jl
@@ -29,7 +29,7 @@ end
 struct CompositeException <: Exception
     exceptions::Vector{Any}
     CompositeException() = new(Any[])
-    CompositeException(exceptions::Vector{Any}) = new(exceptions)
+    CompositeException(exceptions) = new(exceptions)
 end
 length(c::CompositeException) = length(c.exceptions)
 push!(c::CompositeException, ex) = push!(c.exceptions, ex)

--- a/base/test.jl
+++ b/base/test.jl
@@ -569,7 +569,7 @@ function finish end
 
 Thrown when a test set finishes and not all tests passed.
 """
-mutable struct TestSetException <: Exception
+struct TestSetException <: Exception
     pass::Int
     fail::Int
     error::Int
@@ -596,12 +596,12 @@ end
 
 A simple fallback test set that throws immediately on a failure.
 """
-struct FallbackTestSet <: AbstractTestSet
-end
+struct FallbackTestSet <: AbstractTestSet end
 fallback_testset = FallbackTestSet()
 
-mutable struct FallbackTestSetException <: Exception
+struct FallbackTestSetException <: Exception
     msg::String
+    FallbackTestSetException(msg::AbstractString) = new(msg)
 end
 
 function Base.showerror(io::IO, ex::FallbackTestSetException, bt; backtrace=true)

--- a/base/test.jl
+++ b/base/test.jl
@@ -600,8 +600,7 @@ struct FallbackTestSet <: AbstractTestSet end
 fallback_testset = FallbackTestSet()
 
 struct FallbackTestSetException <: Exception
-    msg::String
-    FallbackTestSetException(msg::AbstractString) = new(msg)
+    msg::AbstractString
 end
 
 function Base.showerror(io::IO, ex::FallbackTestSetException, bt; backtrace=true)

--- a/test/core.jl
+++ b/test/core.jl
@@ -825,6 +825,12 @@ let
 end
 
 # accessing fields by index
+mutable struct TestMutable
+    file::String
+    line::Int
+    error
+end
+
 let
     local z = complex(3, 4)
     v = Int[0,0]
@@ -836,16 +842,27 @@ let
     @test_throws BoundsError getfield(z, 0)
     @test_throws BoundsError getfield(z, 3)
 
-    strct = LoadError("", 0, "")
-    setfield!(strct, 2, 8)
-    @test strct.line == 8
-    setfield!(strct, 3, "hi")
-    @test strct.error == "hi"
-    setfield!(strct, 1, "yo")
-    @test strct.file == "yo"
+    strct = LoadError("yofile", 0, "bad")
     @test_throws BoundsError getfield(strct, 10)
-    @test_throws BoundsError setfield!(strct, 0, "")
-    @test_throws BoundsError setfield!(strct, 4, "")
+    @test_throws ErrorException setfield!(strct, 0, "")
+    @test_throws ErrorException setfield!(strct, 4, "")
+    @test strct.file == "yofile"
+    @test strct.line == 0
+    @test strct.error == "bad"
+    @test getfield(strct, 1) == "yofile"
+    @test getfield(strct, 2) == 0
+    @test getfield(strct, 3) == "bad"
+
+    mstrct = TestMutable("melm", 1, nothing)
+    setfield!(mstrct, 2, 8)
+    @test mstrct.line == 8
+    setfield!(mstrct, 3, "hi")
+    @test mstrct.error == "hi"
+    setfield!(mstrct, 1, "yo")
+    @test mstrct.file == "yo"
+    @test_throws BoundsError getfield(mstrct, 10)
+    @test_throws BoundsError setfield!(mstrct, 0, "")
+    @test_throws BoundsError setfield!(mstrct, 4, "")
 end
 
 # allow typevar in Union to match as long as the arguments contain


### PR DESCRIPTION
I noticed that Base is very inconsistent regarding whether `Exception`'s are `mutable struct` or `struct` and whether the `msg` is `msg::String` or `msg::AbstractString`. I have tried to make them all uniform in this PR.