### PR TITLE
fix #19182: convert([Un]Signed, x::BigInt)

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -229,6 +229,7 @@ widen(::Type{BigInt})  = BigInt
 signed(x::BigInt) = x
 
 convert(::Type{BigInt}, x::BigInt) = x
+convert(::Type{Signed}, x::BigInt) = x
 
 hastypemax(::Type{BigInt}) = false
 
@@ -323,7 +324,7 @@ end
 
 rem(x::Integer, ::Type{BigInt}) = convert(BigInt, x)
 
-function convert(::Type{T}, x::BigInt) where T<:Unsigned
+function convert(::Type{T}, x::BigInt) where T<:Base.BitUnsigned
     if sizeof(T) < sizeof(Limb)
         convert(T, convert(Limb,x))
     else
@@ -332,7 +333,7 @@ function convert(::Type{T}, x::BigInt) where T<:Unsigned
     end
 end
 
-function convert(::Type{T}, x::BigInt) where T<:Signed
+function convert(::Type{T}, x::BigInt) where T<:Base.BitSigned
     n = abs(x.size)
     if sizeof(T) < sizeof(Limb)
         SLimb = typeof(Signed(one(Limb)))

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -374,3 +374,10 @@ end
 
 @test BigInt <: Signed
 @test big(1) isa Signed
+
+let x = big(1)
+    @test signed(x) === x
+    @test convert(Signed, x) === x
+    @test Signed(x) === x
+    @test_throws MethodError convert(Unsigned, x) # could change in the future
+end


### PR DESCRIPTION
For me, having `Unsigned(::BigInt)` throwing a `MethodError` is good enough, but I can update with a more specific error if requested.