### PR TITLE
Add REPL completion for tilde paths

### DIFF
--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -467,7 +467,7 @@ function completions(string, pos)
         m = match(r"[\t\n\r\"><=*?|]| (?!\\)", reverse(partial))
         startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
-        
+
         expanded = complete_expanduser(replace(string[r], r"\\ ", " "), startpos:pos)
         expanded[3] && return expanded  # If user expansion available, return it
 

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -468,7 +468,7 @@ function completions(string, pos)
         startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
 
-        expanded = complete_expanduser(replace(string[r], r"\\ ", " "), startpos:pos)
+        expanded = complete_expanduser(replace(string[r], r"\\ ", " "), r)
         expanded[3] && return expanded  # If user expansion available, return it
 
         paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -186,6 +186,11 @@ function complete_path(path::AbstractString, pos; use_envpath=false)
     return matchList, startpos:pos, !isempty(matchList)
 end
 
+function complete_expanduser(path::AbstractString, r)
+    expanded = expanduser(path)
+    return String[expanded], r, path != expanded
+end
+
 # Determines whether method_complete should be tried. It should only be done if
 # the string endswiths ',' or '(' when disregarding whitespace_chars
 function should_method_complete(s::AbstractString)
@@ -462,13 +467,19 @@ function completions(string, pos)
         m = match(r"[\t\n\r\"><=*?|]| (?!\\)", reverse(partial))
         startpos = nextind(partial, reverseind(partial, m.offset))
         r = startpos:pos
+        
+        expanded = complete_expanduser(replace(string[r], r"\\ ", " "), startpos:pos)
+        expanded[3] && return expanded  # If user expansion available, return it
+
         paths, r, success = complete_path(replace(string[r], r"\\ ", " "), pos)
+
         if inc_tag == :string &&
            length(paths) == 1 &&                              # Only close if there's a single choice,
            !isdir(expanduser(replace(string[startpos:start(r)-1] * paths[1], r"\\ ", " "))) &&  # except if it's a directory
            (length(string) <= pos || string[pos+1] != '"')    # or there's already a " at the cursor.
             paths[1] *= "\""
         end
+
         #Latex symbols can be completed for strings
         (success || inc_tag==:cmd) && return sort!(paths), r, success
     end

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -679,6 +679,18 @@ let #test that it can auto complete with spaces in file/path
     rm(dir, recursive=true)
 end
 
+let  # Test tilde path completion
+    c, r, res = test_complete("\"~/julia")
+    if !Sys.iswindows()
+        @test res && c == String[homedir() * "/julia"]
+    else
+        @test !res
+    end
+
+    c, r, res = test_complete("\"foo~bar")
+    @test !res
+end
+
 # Test the completion returns nothing when the folder do not exist
 c,r = test_complete("cd(\"folder_do_not_exist_77/file")
 @test length(c) == 0

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -568,10 +568,11 @@ if Sys.isunix()
         path = homedir()
         dir = joinpath(path, "tmpfoobar")
         mkdir(dir)
-        s = "\"~/tmpfoob"
+        s = "\"" * path * "/tmpfoob"
         c,r = test_complete(s)
         @test "tmpfoobar/" in c
-        @test r == 4:10
+        l = 3 + length(path)
+        @test r == l:l+6
         @test s[r] == "tmpfoob"
         s = "\"~"
         @test "tmpfoobar/" in c


### PR DESCRIPTION
Autocompletes tilde expansion (using `expanduser`) in REPL strings and commands.

Overrides path completions if a user expansion is available. For example, `~/Docu` will autocomplete to `/home/user/Docu` after one `<TAB>`, and then to `/home/user/Documents` after a second `<TAB>`.

Closes #22599.