### PR TITLE
Add `\approxeq` (`≊`) as an alias to `isapprox` as well

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -226,6 +226,7 @@ function isapprox(x::Number, y::Number; atol::Real=0, rtol::Real=rtoldefault(x,y
 end
 
 const ≈ = isapprox
+const ≊ = isapprox
 ≉(args...; kws...) = !≈(args...; kws...)
 
 # default tolerance arguments

--- a/test/floatapprox.jl
+++ b/test/floatapprox.jl
@@ -69,3 +69,6 @@ for elty in (Float16,Float32,Float64)
     @test [half, nan, half] ≉ [half, nan, half]
     @test [half, nan, half] ≈ [half, nan, half] nans=true
 end
+
+# pull request #23478
+@test 5.0 ≊ 4.999999999999993


### PR DESCRIPTION
It seems to me that this would be another reasonable shortcut