### PR TITLE
Deprecate countnz in favor of using count(predicate, x)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1275,7 +1275,7 @@ function cat_t(dims, T::Type, X...)
     catdims = dims2cat(dims)
     shape = cat_shape(catdims, (), map(cat_size, X)...)
     A = cat_similar(X[1], T, shape)
-    if T <: Number && countnz(catdims) > 1
+    if T <: Number && count(!iszero, catdims) > 1
         fill!(A, zero(T))
     end
     return _cat(A, shape, catdims, X...)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1945,14 +1945,14 @@ julia> find(zeros(3))
 ```
 """
 function find(A)
-    nnzA = countnz(A)
+    nnzA = count(t -> t != 0, A)
     I = Vector{Int}(nnzA)
-    count = 1
+    cnt = 1
     inds = _index_remapper(A)
     for (i,a) in enumerate(A)
         if a != 0
-            I[count] = inds[i]
-            count += 1
+            I[cnt] = inds[i]
+            cnt += 1
         end
     end
     return I
@@ -1991,15 +1991,15 @@ julia> findn(A)
 ```
 """
 function findn(A::AbstractMatrix)
-    nnzA = countnz(A)
+    nnzA = count(t -> t != 0, A)
     I = similar(A, Int, nnzA)
     J = similar(A, Int, nnzA)
-    count = 1
+    cnt = 1
     for j=indices(A,2), i=indices(A,1)
         if A[i,j] != 0
-            I[count] = i
-            J[count] = j
-            count += 1
+            I[cnt] = i
+            J[cnt] = j
+            cnt += 1
         end
     end
     return (I, J)
@@ -2024,19 +2024,19 @@ julia> findnz(A)
 ```
 """
 function findnz(A::AbstractMatrix{T}) where T
-    nnzA = countnz(A)
+    nnzA = count(t -> t != 0, A)
     I = zeros(Int, nnzA)
     J = zeros(Int, nnzA)
     NZs = Array{T,1}(nnzA)
-    count = 1
+    cnt = 1
     if nnzA > 0
         for j=indices(A,2), i=indices(A,1)
             Aij = A[i,j]
             if Aij != 0
-                I[count] = i
-                J[count] = j
-                NZs[count] = Aij
-                count += 1
+                I[cnt] = i
+                J[cnt] = j
+                NZs[cnt] = Aij
+                cnt += 1
             end
         end
     end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1614,9 +1614,9 @@ julia> ror(A,5)
 """
 ror(B::BitVector, i::Integer) = ror!(similar(B), B, i)
 
-## countnz & find ##
+## count & find ##
 
-function countnz(B::BitArray)
+function count(B::BitArray)
     n = 0
     Bc = B.chunks
     @inbounds for i = 1:length(Bc)
@@ -1624,7 +1624,6 @@ function countnz(B::BitArray)
     end
     return n
 end
-count(B::BitArray) = countnz(B)
 
 # returns the index of the next non-zero element, or 0 if all zeros
 function findnext(B::BitArray, start::Integer)
@@ -1778,7 +1777,7 @@ end
 
 function find(B::BitArray)
     l = length(B)
-    nnzB = countnz(B)
+    nnzB = count(B)
     I = Vector{Int}(nnzB)
     nnzB == 0 && return I
     Bc = B.chunks
@@ -1812,15 +1811,15 @@ end
 findn(B::BitVector) = find(B)
 
 function findn(B::BitMatrix)
-    nnzB = countnz(B)
+    nnzB = count(B)
     I = Vector{Int}(nnzB)
     J = Vector{Int}(nnzB)
-    count = 1
+    cnt = 1
     for j = 1:size(B,2), i = 1:size(B,1)
         if B[i,j]
-            I[count] = i
-            J[count] = j
-            count += 1
+            I[cnt] = i
+            J[cnt] = j
+            cnt += 1
         end
     end
     return I, J
@@ -1834,7 +1833,7 @@ end
 ## Reductions ##
 
 sum(A::BitArray, region) = reducedim(+, A, region)
-sum(B::BitArray) = countnz(B)
+sum(B::BitArray) = count(B)
 
 function all(B::BitArray)
     isempty(B) && return true

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1739,6 +1739,13 @@ end
 
 @deprecate IOContext(io::IO, key, value) IOContext(io, key=>value)
 
+# PR #23485
+export foo
+function countnz(x)
+    depwarn("countnz(x) is deprecated, use either count(!iszero, x) or count(t -> t != 0, x) instead.", :depwarn)
+    return count(t -> t != 0, x)
+end
+
 # issue #22791
 @deprecate select partialsort
 @deprecate select! partialsort!

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -488,7 +488,6 @@ export
     minmax,
     ndims,
     nonzeros,
-    countnz,
     ones,
     parent,
     parentindexes,

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -133,7 +133,7 @@ end
 
 ## Structure query functions
 
-issymmetric(A::BitMatrix) = size(A, 1)==size(A, 2) && countnz(A - A.')==0
+issymmetric(A::BitMatrix) = size(A, 1)==size(A, 2) && count(!iszero, A - A.')==0
 ishermitian(A::BitMatrix) = issymmetric(A)
 
 function nonzero_chunks(chunks::Vector{UInt64}, pos0::Int, pos1::Int)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -394,7 +394,7 @@ wrapped with `LogicalIndex` upon calling `to_indices`.
 struct LogicalIndex{T, A<:AbstractArray{Bool}} <: AbstractVector{T}
     mask::A
     sum::Int
-    LogicalIndex{T,A}(mask::A) where {T,A<:AbstractArray{Bool}} = new(mask, countnz(mask))
+    LogicalIndex{T,A}(mask::A) where {T,A<:AbstractArray{Bool}} = new(mask, count(mask))
 end
 LogicalIndex(mask::AbstractVector{Bool}) = LogicalIndex{Int, typeof(mask)}(mask)
 LogicalIndex(mask::AbstractArray{Bool, N}) where {N} = LogicalIndex{CartesianIndex{N}, typeof(mask)}(mask)
@@ -574,9 +574,12 @@ end
 
 ##
 
+# small helper function since we cannot use a closure in a generated function
+_countnz(x) = x != 0
+
 @generated function findn(A::AbstractArray{T,N}) where {T,N}
     quote
-        nnzA = countnz(A)
+        nnzA = count(_countnz, A)
         @nexprs $N d->(I_d = Vector{Int}(nnzA))
         k = 1
         @nloops $N i A begin
@@ -1301,7 +1304,7 @@ end
 
 @generated function findn(B::BitArray{N}) where N
     quote
-        nnzB = countnz(B)
+        nnzB = count(B)
         I = ntuple(x->Vector{Int}(nnzB), Val($N))
         if nnzB > 0
             count = 1

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -359,7 +359,7 @@ julia> sum(1:20)
 ```
 """
 sum(a) = mapreduce(identity, +, a)
-sum(a::AbstractArray{Bool}) = countnz(a)
+sum(a::AbstractArray{Bool}) = count(a)
 
 
 # Kahan (compensated) summation: O(1) error growth, at the expense
@@ -670,7 +670,7 @@ function contains(eq::Function, itr, x)
 end
 
 
-## countnz & count
+## count
 
 """
     count(p, itr) -> Integer
@@ -703,22 +703,3 @@ function count(pred, a::AbstractArray)
     return n
 end
 count(itr) = count(identity, itr)
-
-"""
-    countnz(A) -> Integer
-
-Counts the number of nonzero values in array `A` (dense or sparse). Note that this is not a constant-time operation.
-For sparse matrices, one should usually use [`nnz`](@ref), which returns the number of stored values.
-
-```jldoctest
-julia> A = [1 2 4; 0 0 1; 1 1 0]
-3×3 Array{Int64,2}:
- 1  2  4
- 0  0  1
- 1  1  0
-
-julia> countnz(A)
-6
-```
-"""
-countnz(a) = count(x -> x != 0, a)

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -14,7 +14,7 @@ import Base.LinAlg: At_ldiv_B!, Ac_ldiv_B!, A_rdiv_B!, A_rdiv_Bc!
 
 import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     atan, atand, atanh, broadcast!, chol, conj!, cos, cosc, cosd, cosh, cospi, cot,
-    cotd, coth, countnz, csc, cscd, csch, adjoint!, diag, diff, done, dot, eig,
+    cotd, coth, count, csc, cscd, csch, adjoint!, diag, diff, done, dot, eig,
     exp10, exp2, eye, findn, floor, hash, indmin, inv, issymmetric, istril, istriu,
     log10, log2, lu, next, sec, secd, sech, show, sin,
     sinc, sind, sinh, sinpi, squeeze, start, sum, summary, tan,

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -70,9 +70,9 @@ julia> nnz(A)
 3
 ```
 """
-nnz(S::SparseMatrixCSC) = Int(S.colptr[S.n + 1]-1)
-countnz(S::SparseMatrixCSC) = countnz(S.nzval)
-count(S::SparseMatrixCSC) = count(S.nzval)
+nnz(S::SparseMatrixCSC)         = Int(S.colptr[S.n + 1] - 1)
+count(S::SparseMatrixCSC)       = count(S.nzval)
+count(pred, S::SparseMatrixCSC) = count(pred, S.nzval) + pred(zero(eltype(S)))*(prod(size(S)) - nnz(S))
 
 """
     nonzeros(A)
@@ -1910,11 +1910,6 @@ findmax(A::SparseMatrixCSC) = (r=findmax(A,(1,2)); (r[1][1], r[2][1]))
 
 indmin(A::SparseMatrixCSC) = findmin(A)[2]
 indmax(A::SparseMatrixCSC) = findmax(A)[2]
-
-#all(A::SparseMatrixCSC{Bool}, region) = reducedim(all,A,region,true)
-#any(A::SparseMatrixCSC{Bool}, region) = reducedim(any,A,region,false)
-#sum(A::SparseMatrixCSC{Bool}, region) = reducedim(+,A,region,0,Int)
-#sum(A::SparseMatrixCSC{Bool}) = countnz(A)
 
 ## getindex
 function rangesearch(haystack::Range, needle)

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -37,11 +37,11 @@ const SparseVectorUnion{T} = Union{SparseVector{T}, SparseColumnView{T}}
 
 ### Basic properties
 
-length(x::SparseVector) = x.n
-size(x::SparseVector) = (x.n,)
-nnz(x::SparseVector) = length(x.nzval)
-countnz(x::SparseVector) = countnz(x.nzval)
-count(x::SparseVector) = count(x.nzval)
+length(x::SparseVector)   = x.n
+size(x::SparseVector)     = (x.n,)
+nnz(x::SparseVector)      = length(x.nzval)
+count(x::SparseVector)    = count(x.nzval)
+count(f, x::SparseVector) = count(f, x.nzval) + f(zero(eltype(x)))*(length(x) - nnz(x))
 
 nonzeros(x::SparseVector) = x.nzval
 function nonzeros(x::SparseColumnView)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -745,7 +745,7 @@ In some applications, it is convenient to store explicit zero values in a `Spars
 mutating operations). Such explicitly stored zeros are treated as structural nonzeros by many
 routines. The [`nnz()`](@ref) function returns the number of elements explicitly stored in the
 sparse data structure, including structural nonzeros. In order to count the exact number of
-numerical nonzeros, use [`countnz()`](@ref), which inspects every stored element of a sparse
+numerical nonzeros, use [`count(!iszero, x)`](@ref), which inspects every stored element of a sparse
 matrix. [`dropzeros()`](@ref), and the in-place [`dropzeros!()`](@ref), can be used to
 remove stored zeros from the sparse matrix.
 

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -42,7 +42,6 @@ Base.length(::AbstractArray)
 Base.eachindex
 Base.linearindices
 Base.IndexStyle
-Base.countnz
 Base.conj!
 Base.stride
 Base.strides

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -6,7 +6,7 @@ using TestHelpers.OAs
 
 @testset "basics" begin
     @test length([1, 2, 3]) == 3
-    @test countnz([1, 2, 3]) == 3
+    @test count(!iszero, [1, 2, 3]) == 3
 
     let a = ones(4), b = a+a, c = a-a
         @test b[1] === 2. && b[2] === 2. && b[3] === 2. && b[4] === 2.

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -471,20 +471,20 @@ timesofar("constructors")
         @check_bit_operation setindex!(b1, true, t1) BitMatrix
 
         t1 = bitrand(n1, n2)
-        b2 = bitrand(countnz(t1))
+        b2 = bitrand(count(t1))
         @check_bit_operation setindex!(b1, b2, t1) BitMatrix
 
         m1 = rand(1:n1)
         m2 = rand(1:n2)
         t1 = bitrand(n1)
-        b2 = bitrand(countnz(t1), m2)
+        b2 = bitrand(count(t1), m2)
         k2 = randperm(m2)
         @check_bit_operation setindex!(b1, b2, t1, 1:m2)       BitMatrix
         @check_bit_operation setindex!(b1, b2, t1, n2-m2+1:n2) BitMatrix
         @check_bit_operation setindex!(b1, b2, t1, k2)         BitMatrix
 
         t2 = bitrand(n2)
-        b2 = bitrand(m1, countnz(t2))
+        b2 = bitrand(m1, count(t2))
         k1 = randperm(m1)
         @check_bit_operation setindex!(b1, b2, 1:m1, t2)       BitMatrix
         @check_bit_operation setindex!(b1, b2, n1-m1+1:n1, t2) BitMatrix
@@ -1056,9 +1056,9 @@ end
 
 timesofar("datamove")
 
-@testset "countnz & find" begin
+@testset "count & find" begin
     for m = 0:v1, b1 in Any[bitrand(m), trues(m), falses(m)]
-        @check_bit_operation countnz(b1) Int
+        @check_bit_operation count(b1) Int
 
         @check_bit_operation findfirst(b1) Int
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -318,7 +318,7 @@ struct SomeFunctor end
 @test contains("quick fox", "fox") == true
 @test contains("quick fox", "lazy dog") == false
 
-# count & countnz
+# count
 
 @test count(x->x>0, Int[]) == count(Bool[]) == 0
 @test count(x->x>0, -3:5) == count((-3:5) .> 0) == 5
@@ -333,10 +333,10 @@ end
 @test count(iseven(x) for x in 1:10 if x < 7) == 3
 @test count(iseven(x) for x in 1:10 if x < -7) == 0
 
-@test countnz(Int[]) == 0
-@test countnz(Int[0]) == 0
-@test countnz(Int[1]) == 1
-@test countnz([1, 0, 2, 0, 3, 0, 4]) == 4
+@test count(!iszero, Int[]) == 0
+@test count(!iszero, Int[0]) == 0
+@test count(!iszero, Int[1]) == 1
+@test count(!iszero, [1, 0, 2, 0, 3, 0, 4]) == 4
 
 
 ## cumsum, cummin, cummax

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -689,56 +689,56 @@ end
 
 @testset "setindex" begin
     a = spzeros(Int, 10, 10)
-    @test countnz(a) == 0
+    @test count(!iszero, a) == 0
     a[1,:] = 1
-    @test countnz(a) == 10
+    @test count(!iszero, a) == 10
     @test a[1,:] == sparse(ones(Int,10))
     a[:,2] = 2
-    @test countnz(a) == 19
+    @test count(!iszero, a) == 19
     @test a[:,2] == 2*sparse(ones(Int,10))
     b = copy(a)
 
     # Zero-assignment behavior of setindex!(A, v, i, j)
     a[1,3] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 18
+    @test count(!iszero, a) == 18
     a[2,1] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 18
+    @test count(!iszero, a) == 18
 
     # Zero-assignment behavior of setindex!(A, v, I, J)
     a[1,:] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 9
+    @test count(!iszero, a) == 9
     a[2,:] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 8
+    @test count(!iszero, a) == 8
     a[:,1] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 8
+    @test count(!iszero, a) == 8
     a[:,2] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 0
+    @test count(!iszero, a) == 0
     a = copy(b)
     a[:,:] = 0
     @test nnz(a) == 19
-    @test countnz(a) == 0
+    @test count(!iszero, a) == 0
 
     # Zero-assignment behavior of setindex!(A, B::SparseMatrixCSC, I, J)
     a = copy(b)
     a[1:2,:] = spzeros(2, 10)
     @test nnz(a) == 19
-    @test countnz(a) == 8
+    @test count(!iszero, a) == 8
     a[1:2,1:3] = sparse([1 0 1; 0 0 1])
     @test nnz(a) == 20
-    @test countnz(a) == 11
+    @test count(!iszero, a) == 11
     a = copy(b)
     a[1:2,:] = let c = sparse(ones(2,10)); fill!(c.nzval, 0); c; end
     @test nnz(a) == 19
-    @test countnz(a) == 8
+    @test count(!iszero, a) == 8
     a[1:2,1:3] = let c = sparse(ones(2,3)); c[1,2] = c[2,1] = c[2,2] = 0; c; end
     @test nnz(a) == 20
-    @test countnz(a) == 11
+    @test count(!iszero, a) == 11
 
     a[1,:] = 1:10
     @test a[1,:] == sparse([1:10;])
@@ -782,34 +782,34 @@ end
     A = spzeros(Int, 10, 20)
     A[1:5,1:10] = 10
     A[1:5,1:10] = 10
-    @test countnz(A) == 50
+    @test count(!iszero, A) == 50
     @test A[1:5,1:10] == 10 * ones(Int, 5, 10)
     A[6:10,11:20] = 0
-    @test countnz(A) == 50
+    @test count(!iszero, A) == 50
     A[6:10,11:20] = 20
-    @test countnz(A) == 100
+    @test count(!iszero, A) == 100
     @test A[6:10,11:20] == 20 * ones(Int, 5, 10)
     A[4:8,8:16] = 15
-    @test countnz(A) == 121
+    @test count(!iszero, A) == 121
     @test A[4:8,8:16] == 15 * ones(Int, 5, 9)
 
     ASZ = 1000
     TSZ = 800
     A = sprand(ASZ, 2*ASZ, 0.0001)
     B = copy(A)
-    nA = countnz(A)
+    nA = count(!iszero, A)
     x = A[1:TSZ, 1:(2*TSZ)]
-    nx = countnz(x)
+    nx = count(!iszero, x)
     A[1:TSZ, 1:(2*TSZ)] = 0
-    nB = countnz(A)
+    nB = count(!iszero, A)
     @test nB == (nA - nx)
     A[1:TSZ, 1:(2*TSZ)] = x
-    @test countnz(A) == nA
+    @test count(!iszero, A) == nA
     @test A == B
     A[1:TSZ, 1:(2*TSZ)] = 10
-    @test countnz(A) == nB + 2*TSZ*TSZ
+    @test count(!iszero, A) == nB + 2*TSZ*TSZ
     A[1:TSZ, 1:(2*TSZ)] = x
-    @test countnz(A) == nA
+    @test count(!iszero, A) == nA
     @test A == B
 
     A = speye(Int, 5)
@@ -820,17 +820,17 @@ end
     @test A[I] == A[X] == collect(1:10)
     A[I] = zeros(Int, 10)
     @test nnz(A) == 13
-    @test countnz(A) == 3
+    @test count(!iszero, A) == 3
     @test A[I] == A[X] == zeros(Int, 10)
     c = collect(11:20); c[1] = c[3] = 0
     A[I] = c
     @test nnz(A) == 13
-    @test countnz(A) == 11
+    @test count(!iszero, A) == 11
     @test A[I] == A[X] == c
     A = speye(Int, 5)
     A[I] = c
     @test nnz(A) == 12
-    @test countnz(A) == 11
+    @test count(!iszero, A) == 11
     @test A[I] == A[X] == c
 
     S = sprand(50, 30, 0.5, x -> round.(Int, rand(x) * 100))
@@ -839,14 +839,14 @@ end
     FI = Array(I)
     @test sparse(FS[FI]) == S[I] == S[FI]
     @test sum(S[FI]) + sum(S[.!FI]) == sum(S)
-    @test countnz(I) == count(I)
+    @test count(!iszero, I) == count(I)
 
     sumS1 = sum(S)
     sumFI = sum(S[FI])
     nnzS1 = nnz(S)
     S[FI] = 0
     sumS2 = sum(S)
-    cnzS2 = countnz(S)
+    cnzS2 = count(!iszero, S)
     @test sum(S[FI]) == 0
     @test nnz(S) == nnzS1
     @test (sum(S) + sumFI) == sumS1
@@ -857,7 +857,7 @@ end
     S[FI] = 0
     @test sum(S) == sumS2
     @test nnz(S) == nnzS3
-    @test countnz(S) == cnzS2
+    @test count(!iszero, S) == cnzS2
 
     S[FI] = [1:sum(FI);]
     @test sum(S) == sumS2 + sum(1:sum(FI))
@@ -1148,11 +1148,11 @@ end
     sm = sparse(D)
     sv = sparsevec(D)
 
-    @test countnz(sm) == 10
-    @test countnz(sv) == 10
+    @test count(!iszero, sm) == 10
+    @test count(!iszero, sv) == 10
 
-    @test countnz(sparse(Diagonal(Int[]))) == 0
-    @test countnz(sparsevec(Diagonal(Int[]))) == 0
+    @test count(!iszero, sparse(Diagonal(Int[]))) == 0
+    @test count(!iszero, sparsevec(Diagonal(Int[]))) == 0
 end
 
 @testset "explicit zeros" begin

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -20,7 +20,7 @@ let x = spv_x1
     @test size(x,2) == 1
     @test !isempty(x)
 
-    @test countnz(x) == 3
+    @test count(!iszero, x) == 3
     @test nnz(x) == 3
     @test SparseArrays.nonzeroinds(x) == [2, 5, 6]
     @test nonzeros(x) == [1.25, -0.75, 3.5]

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -73,7 +73,7 @@ end
     xd = full(A)\b
 
     # check that basic solution has more zeros
-    @test countnz(xs) < countnz(xd)
+    @test count(!iszero, xs) < count(!iszero, xd)
     @test A*xs ≈ A*xd
 end
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -421,7 +421,7 @@ msk = ones(Bool, 2, 2)
 msk[2,1] = false
 sA = view(A, :, :, 1)
 sA[msk] = 1.0
-@test sA[msk] == ones(countnz(msk))
+@test sA[msk] == ones(count(msk))
 
 # bounds checking upon construction; see #4044, #10296
 @test_throws BoundsError view(1:10, 8:11)


### PR DESCRIPTION
As discussed in https://github.com/JuliaLang/julia/issues/23005, it is ambiguous which kind of non-zero to test with (`!iszero` or `t -> t != 0`) so with this PR the user is required to be explicit. To summarize the difference
```julia
julia> map(t -> t == 0, [rand(2) for i in 1:3])
3-element Array{Bool,1}:
 false
 false
 false

julia> map(!iszero, [rand(2) for i in 1:3])
3-element Array{Bool,1}:
 true
 true
 true

julia> map(t -> t != 0, ["Julia" for i in 1:3])
3-element Array{Bool,1}:
 true
 true
 true

julia> map(!iszero, ["Julia" for i in 1:3])
ERROR: MethodError: no method matching zero(::String)
Closest candidates are:
  zero(::Type{Base.LibGit2.GitHash}) at libgit2/oid.jl:166
  zero(::Type{Base.Pkg.Resolve.VersionWeights.VWPreBuildItem}) at pkg/resolve/versionweight.jl:80
  zero(::Type{Base.Pkg.Resolve.VersionWeights.VWPreBuild}) at pkg/resolve/versionweight.jl:122
  ...
Stacktrace:
 [1] iszero(::String) at ./number.jl:27
 [2] (::getfield(Base, Symbol("##61#62")){typeof(iszero)})(::String, ::Vararg{String,N} where N) at ./operators.jl:974
 [3] _collect at ./array.jl:678 [inlined]
 [4] collect_similar(::Array{String,1}, ::Base.Generator{Array{String,1},getfield(Base, Symbol("##61#62")){typeof(iszero)}}) at ./array.jl:625
 [5] map(::Function, ::Array{String,1}) at ./abstractarray.jl:1969
```
The deprecation suggests `!iszero` as well as `t -> t != 0` but still calls `t -> t != 0` to avoid breaking current behavior. We might want to revisit sparse string arrays which is the only thing I'm aware of that relies on this behavior but that is for a different PR.