### PR TITLE
fix #23107, ensure `Array` constructor always makes new arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -563,6 +563,12 @@ convert(::Type{Array{T,n}}, x::AbstractArray{S,n}) where {T,n,S} = copy!(Array{T
 
 promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(promote_type(T,S), a, b)
 
+# constructors should make copies
+
+if module_name(@__MODULE__) === :Base  # avoid method overwrite
+(::Type{T})(x::T) where {T<:Array} = copy(x)
+end
+
 ## copying iterators to containers
 
 """

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -555,6 +555,10 @@ reinterpret(B::BitArray, dims::NTuple{N,Int}) where {N} = reshape(B, dims)
 
 BitArray(A::AbstractArray{<:Any,N}) where {N} = convert(BitArray{N}, A)
 
+if module_name(@__MODULE__) === :Base  # avoid method overwrite
+(::Type{T})(x::T) where {T<:BitArray} = copy(x)
+end
+
 """
     BitArray(itr)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -90,6 +90,13 @@ using TestHelpers.OAs
     @test ndims(a) == 5
     @test a[2,1,2,2,1] == b[14]
     @test a[2,2,2,2,2] == b[end]
+
+    # issue #23107
+    a = [1,2,3]
+    @test typeof(a)(a) !== a
+    @test Array(a) !== a
+    @test Array{eltype(a)}(a) !== a
+    @test Vector(a) !== a
 end
 @testset "reshaping SubArrays" begin
     a = collect(reshape(1:5, 1, 5))

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -190,6 +190,11 @@ timesofar("utils")
         @test Array(one(BitMatrix(2,2))) == eye(2,2)
         @test_throws DimensionMismatch one(BitMatrix(2,3))
     end
+
+    # constructors should copy
+    a = trues(3)
+    @test BitArray(a) !== a
+    @test BitArray{1}(a) !== a
 end
 
 timesofar("constructors")


### PR DESCRIPTION
Fix #23107.