### PR TITLE
RFC: make `promote` throw an error if no arguments can be changed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -178,6 +178,11 @@ This section lists changes that do not have deprecation warnings.
     of the output was shrunk to fit the union of the type of each element in the input.
     ([#22696])
 
+  * The `promote` function now raises an error if its arguments are of different types
+    and if attempting to convert them to a common type fails to change any of their types.
+    This avoids stack overflows in the common case of definitions like
+    `f(x, y) = f(promote(x, y)...)` ([#22801]).
+
 Library improvements
 --------------------
 

--- a/base/dates/types.jl
+++ b/base/dates/types.jl
@@ -340,7 +340,7 @@ Base.typemin(::Union{Time, Type{Time}}) = Time(0)
 Base.eltype(::Type{T}) where {T<:Period} = T
 Base.promote_rule(::Type{Date}, x::Type{DateTime}) = DateTime
 Base.isless(x::T, y::T) where {T<:TimeType} = isless(value(x), value(y))
-Base.isless(x::TimeType, y::TimeType) = isless(Base.promote_noncircular(x, y)...)
+Base.isless(x::TimeType, y::TimeType) = isless(promote(x, y)...)
 (==)(x::T, y::T) where {T<:TimeType} = (==)(value(x), value(y))
 function ==(a::Time, b::Time)
     return hour(a) == hour(b) && minute(a) == minute(b) &&

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1752,6 +1752,8 @@ end
 @deprecate selectperm partialsortperm
 @deprecate selectperm! partialsortperm!
 
+@deprecate promote_noncircular promote false
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/int.jl
+++ b/base/int.jl
@@ -84,7 +84,7 @@ signbit(x::Unsigned) = false
 flipsign(x::T, y::T) where {T<:BitSigned} = flipsign_int(x, y)
 flipsign(x::BitSigned, y::BitSigned) = flipsign_int(promote(x, y)...) % typeof(x)
 
-flipsign(x::Signed, y::Signed)  = convert(typeof(x), flipsign(promote_noncircular(x, y)...))
+flipsign(x::Signed, y::Signed)  = convert(typeof(x), flipsign(promote(x, y)...))
 flipsign(x::Signed, y::Float16) = flipsign(x, bitcast(Int16, y))
 flipsign(x::Signed, y::Float32) = flipsign(x, bitcast(Int32, y))
 flipsign(x::Signed, y::Float64) = flipsign(x, bitcast(Int64, y))

--- a/base/range.jl
+++ b/base/range.jl
@@ -241,7 +241,7 @@ julia> linspace(1.3,2.9,9)
 1.3:0.2:2.9
 ```
 """
-linspace(start, stop, len::Real=50) = linspace(promote_noncircular(start, stop)..., Int(len))
+linspace(start, stop, len::Real=50) = linspace(promote(start, stop)..., Int(len))
 linspace(start::T, stop::T, len::Real=50) where {T} = linspace(start, stop, Int(len))
 
 linspace(start::Real, stop::Real, len::Integer) = linspace(promote(start, stop)..., len)
@@ -947,7 +947,7 @@ function _define_range_op(@nospecialize f)
 
         $f(r1::Union{StepRangeLen, OrdinalRange, LinSpace},
            r2::Union{StepRangeLen, OrdinalRange, LinSpace}) =
-               $f(promote_noncircular(r1, r2)...)
+               $f(promote(r1, r2)...)
     end
 end
 _define_range_op(:+)

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -84,7 +84,7 @@ function add12(x::T, y::T) where {T}
     x, y = ifelse(abs(y) > abs(x), (y, x), (x, y))
     canonicalize2(x, y)
 end
-add12(x, y) = add12(promote_noncircular(x, y)...)
+add12(x, y) = add12(promote(x, y)...)
 
 """
     zhi, zlo = mul12(x, y)
@@ -116,7 +116,7 @@ function mul12(x::T, y::T) where {T<:AbstractFloat}
     ifelse(iszero(h) | !isfinite(h), (h, h), canonicalize2(h, fma(x, y, -h)))
 end
 mul12(x::T, y::T) where {T} = (p = x * y; (p, zero(p)))
-mul12(x, y) = mul12(promote_noncircular(x, y)...)
+mul12(x, y) = mul12(promote(x, y)...)
 
 """
     zhi, zlo = div12(x, y)
@@ -152,7 +152,7 @@ function div12(x::T, y::T) where {T<:AbstractFloat}
     ifelse(iszero(r) | !isfinite(r), (r, r), (ldexp(rh, xe-ye), ldexp(rl, xe-ye)))
 end
 div12(x::T, y::T) where {T} = (p = x / y; (p, zero(p)))
-div12(x, y) = div12(promote_noncircular(x, y)...)
+div12(x, y) = div12(promote(x, y)...)
 
 
 ## TwicePrecision
@@ -269,7 +269,7 @@ function +(x::TwicePrecision{T}, y::TwicePrecision{T}) where T
     s = abs(x.hi) > abs(y.hi) ? (((x.hi - r) + y.hi) + y.lo) + x.lo : (((y.hi - r) + x.hi) + x.lo) + y.lo
     TwicePrecision(canonicalize2(r, s)...)
 end
-+(x::TwicePrecision, y::TwicePrecision) = +(promote_noncircular(x, y)...)
++(x::TwicePrecision, y::TwicePrecision) = +(promote(x, y)...)
 
 -(x::TwicePrecision, y::TwicePrecision) = x + (-y)
 -(x::TwicePrecision, y::Number) = x + (-y)
@@ -292,7 +292,7 @@ function *(x::TwicePrecision{T}, y::TwicePrecision{T}) where {T}
     ret = TwicePrecision{T}(canonicalize2(zh, (x.hi * y.lo + x.lo * y.hi) + zl)...)
     ifelse(iszero(zh) | !isfinite(zh), TwicePrecision{T}(zh, zh), ret)
 end
-*(x::TwicePrecision, y::TwicePrecision) = *(promote_noncircular(x, y)...)
+*(x::TwicePrecision, y::TwicePrecision) = *(promote(x, y)...)
 
 function /(x::TwicePrecision, v::Number)
     x / TwicePrecision{typeof(x.hi/v)}(v)


### PR DESCRIPTION
Fixes #22801.
