### PR TITLE
Add squeeze(f, A, dims) for reductions to drop dims

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -183,6 +183,9 @@ Library improvements
   * The function `randn` now accepts complex arguments (`Complex{T <: AbstractFloat}`)
     ([#21973]).
 
+  * A new `squeeze(f, A, dims)` method computes the reduction `f` over the region in
+    `A` described by `dims` and then drops those dimensions from the result ([#23500]).
+
   * The function `rand` can now pick up random elements from strings, associatives
     and sets ([#22228], [#21960], [#18155], [#22224]).
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -83,6 +83,12 @@ end
 
 squeeze(A::AbstractArray, dim::Integer) = squeeze(A, (Int(dim),))
 
+"""
+    squeeze(f, A, dims)
+
+Compute reduction `f` over dimensions `dims` in array `A` and drop those dimensions from the result.
+"""
+squeeze(f, A::AbstractArray, dims::Union{Dims, Integer}) = squeeze(f(A, dims), dims)
 
 ## Unary operators ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -219,6 +219,17 @@ end
     @test_throws ArgumentError squeeze(a, 4)
     @test_throws ArgumentError squeeze(a, 6)
 
+    @test @inferred(squeeze(sum, a, 1)) == @inferred(squeeze(sum, a, (1,))) == reshape(sum(a, 1), (1, 8, 8, 1))
+    @test @inferred(squeeze(sum, a, 3)) == @inferred(squeeze(sum, a, (3,))) == reshape(sum(a, 3), (1, 1, 8, 1))
+    @test @inferred(squeeze(sum, a, 4)) == @inferred(squeeze(sum, a, (4,))) == reshape(sum(a, 4), (1, 1, 8, 1))
+    @test @inferred(squeeze(sum, a, (1, 5))) == squeeze(sum, a, (5, 1)) == reshape(sum(a, (5, 1)), (1, 8, 8))
+    @test @inferred(squeeze(sum, a, (1, 2, 5))) == squeeze(sum, a, (5, 2, 1)) == reshape(sum(a, (5, 2, 1)), (8, 8))
+    @test_throws ArgumentError squeeze(sum, a, 0)
+    @test_throws ArgumentError squeeze(sum, a, (1, 1))
+    @test_throws ArgumentError squeeze(sum, a, (1, 2, 1))
+    @test_throws ArgumentError squeeze(sum, a, (1, 1, 2))
+    @test_throws ArgumentError squeeze(sum, a, 6)
+
     sz = (5,8,7)
     A = reshape(1:prod(sz),sz...)
     @test A[2:6] == [2:6;]


### PR DESCRIPTION
This simple definition makes it easier to write reductions that drop the dimensions over which they reduce. Fixes #16606, addresses part of the root issue in #22000.