### PR TITLE
fix `promote_rule` for `Bidiagonal` and `Tridiagonal`

### DIFF
--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -148,7 +148,7 @@ end
 convert(::Type{Matrix}, A::Bidiagonal{T}) where {T} = convert(Matrix{T}, A)
 convert(::Type{Array}, A::Bidiagonal) = convert(Matrix, A)
 full(A::Bidiagonal) = convert(Array, A)
-promote_rule(::Type{Matrix{T}}, ::Type{Bidiagonal{S}}) where {T,S} = Matrix{promote_type(T,S)}
+promote_rule(::Type{Matrix{T}}, ::Type{<:Bidiagonal{S}}) where {T,S} = Matrix{promote_type(T,S)}
 
 #Converting from Bidiagonal to Tridiagonal
 Tridiagonal(M::Bidiagonal{T}) where {T} = convert(Tridiagonal{T}, M)
@@ -158,7 +158,7 @@ function convert(::Type{Tridiagonal{T}}, A::Bidiagonal) where T
     z = fill!(similar(ev), zero(T))
     A.uplo == 'U' ? Tridiagonal(z, dv, ev) : Tridiagonal(ev, dv, z)
 end
-promote_rule(::Type{Tridiagonal{T}}, ::Type{Bidiagonal{S}}) where {T,S} = Tridiagonal{promote_type(T,S)}
+promote_rule(::Type{<:Tridiagonal{T}}, ::Type{<:Bidiagonal{S}}) where {T,S} = Tridiagonal{promote_type(T,S)}
 
 # No-op for trivial conversion Bidiagonal{T} -> Bidiagonal{T}
 convert(::Type{Bidiagonal{T}}, A::Bidiagonal{T}) where {T} = A

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -286,7 +286,9 @@ end
     C = Tridiagonal(rand(Float64,9),rand(Float64,10),rand(Float64,9))
     @test promote_rule(Matrix{Float64}, Bidiagonal{Float64}) == Matrix{Float64}
     @test promote(B,A) == (B, convert(Matrix{Float64}, A))
+    @test promote(B,A) isa Tuple{Matrix{Float64}, Matrix{Float64}}
     @test promote(C,A) == (C,Tridiagonal(zeros(Float64,9),convert(Vector{Float64},A.dv),convert(Vector{Float64},A.ev)))
+    @test promote(C,A) isa Tuple{Tridiagonal, Tridiagonal}
 end
 
 import Base.LinAlg: fillslots!, UnitLowerTriangular


### PR DESCRIPTION
Noticed as part of #23491