### PR TITLE
Fix `expanduser` with empty string

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -338,6 +338,7 @@ expanduser(path::AbstractString) = path # on windows, ~ means "temporary file"
 else
 function expanduser(path::AbstractString)
     i = start(path)
+    if done(path,i) return path end
     c, i = next(path,i)
     if c != '~' return path end
     if done(path,i) return homedir() end

--- a/test/path.jl
+++ b/test/path.jl
@@ -10,6 +10,7 @@ for S in (String, GenericString)
     @test basename(S("foo$(sep)bar")) == "bar"
     @test dirname(S("foo$(sep)bar")) == "foo"
 
+    @test expanduser(S("")) == ""
     @test expanduser(S("x")) == "x"
     @test expanduser(S("~")) == (Sys.iswindows() ? "~" : homedir())
 


### PR DESCRIPTION
Fixed missed corner case where an empty string is passed into `expanduser`.