### PR TITLE
Make partial_inst a global root.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1977,7 +1977,7 @@ module_binding: {
     }
 
 finlist: {
-        // Scan a finalizer list. see `gc_mark_finlist_t`
+        // Scan a finalizer (or format compatible) list. see `gc_mark_finlist_t`
         gc_mark_finlist_t *finlist = gc_pop_markdata(&sp, gc_mark_finlist_t);
         jl_value_t **begin = finlist->begin;
         jl_value_t **end = finlist->end;
@@ -2276,6 +2276,8 @@ static void mark_roots(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp)
     // constants
     gc_mark_queue_obj(gc_cache, sp, jl_typetype_type);
     gc_mark_queue_obj(gc_cache, sp, jl_emptytuple_type);
+
+    gc_mark_queue_finlist(gc_cache, sp, &partial_inst, 0);
 }
 
 // find unmarked objects that need to be finalized from the finalizer list "list".

--- a/src/gc.h
+++ b/src/gc.h
@@ -188,7 +188,7 @@ typedef struct {
     uint8_t bits; // GC bits of the module (the bits to mark the binding buffer with)
 } gc_mark_binding_t;
 
-// Finalizer list
+// Finalizer (or object) list
 typedef struct {
     jl_value_t **begin;
     jl_value_t **end;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1080,7 +1080,7 @@ static void check_datatype_parameters(jl_typename_t *tn, jl_value_t **params, si
     JL_GC_POP();
 }
 
-static arraylist_t partial_inst;
+arraylist_t partial_inst;
 int inside_typedef = 0;
 
 static jl_value_t *extract_wrapper(jl_value_t *t)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1001,6 +1001,8 @@ extern jl_sym_t *isdefined_sym; extern jl_sym_t *nospecialize_sym;
 void jl_register_fptrs(uint64_t sysimage_base, const char *base, const int32_t *offsets,
                        jl_method_instance_t **linfos, size_t n);
 
+extern arraylist_t partial_inst;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Types in this list might not be rooted anywhere else.

Found with aggressive GC stress test when running `core` test.

Can be triggered with
```diff
diff --git a/src/jltypes.c b/src/jltypes.c
index 3a2bdcd00f..561ba02425 100644
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1233,6 +1233,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value

     // move array of instantiated parameters to heap; we need to keep it
     if (p == NULL) {
+        jl_gc_collect(0);
         p = jl_alloc_svec_uninit(ntp);
         for(size_t i=0; i < ntp; i++)
             jl_svecset(p, i, iparams[i]);
```

Running `julia -e 'struct T22624{A,B,C}; v::Vector{T22624{Int64,A}}; end'`

AFAICT this is the right fix unless there's some assumptions about the reachability of objects in this array that's recently broken.
