### PR TITLE
fix promotion of diagonal integer matrix to non-integer power

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -405,7 +405,8 @@ function (^)(A::AbstractMatrix{T}, p::Real) where T
 
     # Quicker return if A is diagonal
     if isdiag(A)
-        retmat = copy(A)
+        TT = promote_op(^, T, typeof(p))
+        retmat = copy_oftype(A, TT)
         for i in 1:n
             retmat[i, i] = retmat[i, i] ^ p
         end

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -581,6 +581,11 @@ end
     end
 end
 
+@testset "diagonal integer matrix to real power" begin
+    A = Matrix(Diagonal([1, 2, 3]))
+    @test A^2.3 ≈ float(A)^2.3
+end
+
 @testset "issue #23366 (Int Matrix to Int power)" begin
     @testset "Tests for $elty" for elty in (Int128, Int16, Int32, Int64, Int8,
                                             UInt128, UInt16, UInt32, UInt64, UInt8,


### PR DESCRIPTION
```julia
julia> A = [1 0; 0 2];

julia> A^2.5
ERROR: InexactError: convert(Int64, 5.656854249492381)
Stacktrace:
 [1] convert at ./float.jl:703 [inlined]
 [2] setindex! at ./array.jl:802 [inlined]
 [3] ^(::Array{Int64,2}, ::Float64) at ./linalg/dense.jl:410
```