### PR TITLE
Fix IOBuffer documentation

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -36,8 +36,8 @@ StringVector(n::Integer) = Vector{UInt8}(_string_n(n))
 
 Create an `IOBuffer`, which may optionally operate on a pre-existing array. If the
 readable/writable arguments are given, they restrict whether or not the buffer may be read
-from or written to respectively. By default the buffer is readable but not writable. The
-last argument optionally specifies a size beyond which the buffer may not be grown.
+from or written to respectively. The last argument optionally specifies a size beyond which
+the buffer may not be grown.
 """
 IOBuffer(data::AbstractVector{UInt8}, readable::Bool=true, writable::Bool=false, maxsize::Int=typemax(Int)) =
     GenericIOBuffer(data, readable, writable, true, false, maxsize)


### PR DESCRIPTION
Removed the sentence since the defaults can be seen from the signature.