### PR TITLE
Fix computation of condition number in trsen!

### DIFF
--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -142,7 +142,7 @@ ordschur(schur::Schur, select::Union{Vector{Bool},BitVector}) =
 Same as [`ordschur`](@ref) but overwrites the input arguments.
 """
 ordschur!(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat} =
-    LinAlg.LAPACK.trsen!(convert(Vector{BlasInt}, select), T, Z)
+    LinAlg.LAPACK.trsen!(convert(Vector{BlasInt}, select), T, Z)[1:3]
 
 """
     ordschur(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -555,22 +555,34 @@ end
     end
 end
 
-@testset "trexc" begin
+@testset "trsen" begin
     @testset for elty in (Float32, Float64, Complex64, Complex128)
-        for c in ('V', 'N')
-            A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])
-            T,Q,d = schur(A)
-            Base.LinAlg.LAPACK.trsen!('N',c,Array{LinAlg.BlasInt}([0,1,0,0]),T,Q)
-            @test d[1] ≈ T[2,2]
-            @test d[2] ≈ T[1,1]
-            if c == 'V'
-                @test  Q*T*Q' ≈ A
+        for job in ('N', 'E', 'V', 'B')
+            for c in ('V', 'N')
+                A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])
+                T,Q,d = schur(A)
+                s, sep = Base.LinAlg.LAPACK.trsen!(job,c,Array{LinAlg.BlasInt}([0,1,0,0]),T,Q)[4:5]
+                @test d[1] ≈ T[2,2]
+                @test d[2] ≈ T[1,1]
+                if c == 'V'
+                    @test  Q*T*Q' ≈ A
+                end
+                if job == 'N' || job == 'V'
+                    @test iszero(s)
+                else
+                    @test s ≈ 0.8080423 atol=1e-6
+                end
+                if job == 'N' || job == 'E'
+                    @test iszero(sep)
+                else
+                    @test sep ≈ 2. atol=3e-1
+                end
             end
         end
     end
 end
 
-@testset "trexc and trsen" begin
+@testset "trexc" begin
     @testset for elty in (Float32, Float64, Complex64, Complex128)
         for c in ('V', 'N')
             A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])


### PR DESCRIPTION
As mentioned [here](https://discourse.julialang.org/t/getting-the-reciprocal-condition-number-when-computing-the-reordered-schur-factorization/5653), Julia segfaults when `compq` is not `'N'`.