### PR TITLE
add few missing methods for set-like operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -469,6 +469,20 @@ Library improvements
       linear-to-cartesian conversion ([#24715])
     - It has a new constructor taking an array
 
+  * several missing set-like operations have been added ([#23528]):
+    `union`, `intersect`, `symdiff`, `setdiff` are now implemented for
+    all collections with arbitrary many arguments, as well as the
+    mutating counterparts (`union!` etc.). The performance is also
+    much better in many cases. Note that this change is slightly
+    breaking: all the non-mutating functions always return a new
+    object even if only one argument is passed. Moreover the semantics
+    of `intersect` and `symdiff` is changed for vectors:
+    + `intersect` doesn't preserve the multiplicity anymore (use `filter` for
+      the old behavior)
+    + `symdiff` has been made consistent with the corresponding methods for
+      other containers, by taking the multiplicity of the arguments into account.
+      Use `unique` to get the old behavior.
+
   * The type `LinearIndices` has been added, providing conversion from
     cartesian incices to linear indices using the normal indexing operation. ([#24715])
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -580,8 +580,10 @@ julia> empty([1.0, 2.0, 3.0], String)
 0-element Array{String,1}
 ```
 """
-empty(a::AbstractVector) = empty(a, eltype(a))
-empty(a::AbstractVector, ::Type{T}) where {T} = Vector{T}()
+empty(a::AbstractVector{T}, ::Type{U}=T) where {T,U} = Vector{U}()
+
+# like empty, but should return a mutable collection, a Vector by default
+emptymutable(a::AbstractVector{T}, ::Type{U}=T) where {T,U} = Vector{U}()
 
 ## from general iterable to any array
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -2253,22 +2253,6 @@ function union(vs...)
 end
 # setdiff only accepts two args
 
-"""
-    setdiff(a, b)
-
-Construct the set of elements in `a` but not `b`. Maintains order with arrays. Note that
-both arguments must be collections, and both will be iterated over. In particular,
-`setdiff(set,element)` where `element` is a potential member of `set`, will not work in
-general.
-
-# Examples
-```jldoctest
-julia> setdiff([1,2,3],[3,4,5])
-2-element Array{Int64,1}:
- 1
- 2
-```
-"""
 function setdiff(a, b)
     args_type = promote_type(eltype(a), eltype(b))
     bset = Set(b)
@@ -2287,21 +2271,5 @@ end
 # recursing. Has the advantage of keeping order, too, but
 # not as fast as other methods that make a single pass and
 # store counts with a Dict.
-symdiff(a) = a
 symdiff(a, b) = union(setdiff(a,b), setdiff(b,a))
-"""
-    symdiff(a, b, rest...)
-
-Construct the symmetric difference of elements in the passed in sets or arrays.
-Maintains order with arrays.
-
-# Examples
-```jldoctest
-julia> symdiff([1,2,3],[3,4,5],[4,5,6])
-3-element Array{Int64,1}:
- 1
- 2
- 6
-```
-"""
 symdiff(a, b, rest...) = symdiff(a, symdiff(b, rest...))

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -32,7 +32,12 @@ BitSet(itr) = union!(BitSet(), itr)
 
 eltype(::Type{BitSet}) = Int
 similar(s::BitSet) = BitSet()
+
+empty(s::BitSet, ::Type{Int}=Int) = BitSet()
+emptymutable(s::BitSet, ::Type{Int}=Int) = BitSet()
+
 copy(s1::BitSet) = copy!(BitSet(), s1)
+copymutable(s::BitSet) = copy(s)
 
 """
     copy!(dst, src)
@@ -48,8 +53,6 @@ function copy!(dest::BitSet, src::BitSet)
     dest.offset = src.offset
     dest
 end
-
-copymutable(s::BitSet) = copy(s)
 
 eltype(s::BitSet) = Int
 
@@ -256,7 +259,6 @@ isempty(s::BitSet) = _check0(s.bits, 1, length(s.bits))
 # Mathematical set functions: union!, intersect!, setdiff!, symdiff!
 
 union(s::BitSet, sets...) = union!(copy(s), sets...)
-union!(s::BitSet, ns) = foldl(push!, s, ns)
 union!(s1::BitSet, s2::BitSet) = _matched_map!(|, s1, s2)
 
 intersect(s1::BitSet, s2::BitSet) =

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -49,6 +49,8 @@ function copy!(dest::BitSet, src::BitSet)
     dest
 end
 
+copymutable(s::BitSet) = copy(s)
+
 eltype(s::BitSet) = Int
 
 sizehint!(s::BitSet, n::Integer) = (sizehint!(s.bits, (n+63) >> 6); s)
@@ -253,49 +255,18 @@ isempty(s::BitSet) = _check0(s.bits, 1, length(s.bits))
 
 # Mathematical set functions: union!, intersect!, setdiff!, symdiff!
 
-union(s::BitSet) = copy(s)
-union(s1::BitSet, s2::BitSet) = union!(copy(s1), s2)
-union(s1::BitSet, ss::BitSet...) = union(s1, union(ss...))
-union(s::BitSet, ns) = union!(copy(s), ns)
-union!(s::BitSet, ns) = (for n in ns; push!(s, n); end; s)
+union(s::BitSet, sets...) = union!(copy(s), sets...)
+union!(s::BitSet, ns) = foldl(push!, s, ns)
 union!(s1::BitSet, s2::BitSet) = _matched_map!(|, s1, s2)
 
-intersect(s1::BitSet) = copy(s1)
-intersect(s1::BitSet, ss::BitSet...) = intersect(s1, intersect(ss...))
-function intersect(s1::BitSet, ns)
-    s = BitSet()
-    for n in ns
-        n in s1 && push!(s, n)
-    end
-    s
-end
 intersect(s1::BitSet, s2::BitSet) =
     length(s1.bits) < length(s2.bits) ? intersect!(copy(s1), s2) : intersect!(copy(s2), s1)
-"""
-    intersect!(s1::BitSet, s2::BitSet)
 
-Intersects sets `s1` and `s2` and overwrites the set `s1` with the result. If needed, `s1`
-will be expanded to the size of `s2`.
-"""
 intersect!(s1::BitSet, s2::BitSet) = _matched_map!(&, s1, s2)
 
-setdiff(s::BitSet, ns) = setdiff!(copy(s), ns)
-setdiff!(s::BitSet, ns) = (for n in ns; delete!(s, n); end; s)
 setdiff!(s1::BitSet, s2::BitSet) = _matched_map!((p, q) -> p & ~q, s1, s2)
 
-symdiff(s::BitSet, ns) = symdiff!(copy(s), ns)
-"""
-    symdiff!(s, itr)
-
-For each element in `itr`, destructively toggle its inclusion in set `s`.
-"""
-symdiff!(s::BitSet, ns) = (for n in ns; int_symdiff!(s, n); end; s)
-"""
-    symdiff!(s, n)
-
-The set `s` is destructively modified to toggle the inclusion of integer `n`.
-"""
-symdiff!(s::BitSet, n::Integer) = int_symdiff!(s, n)
+symdiff!(s::BitSet, ns) = foldl(int_symdiff!, s, ns)
 
 function int_symdiff!(s::BitSet, n::Integer)
     n0 = _check_bitset_bounds(n)
@@ -305,6 +276,8 @@ function int_symdiff!(s::BitSet, n::Integer)
 end
 
 symdiff!(s1::BitSet, s2::BitSet) = _matched_map!(xor, s1, s2)
+
+filter!(f, s::BitSet) = unsafe_filter!(f, s)
 
 @inline in(n::Int, s::BitSet) = _bits_getindex(s.bits, n, s.offset)
 @inline in(n::Integer, s::BitSet) = _is_convertible_Int(n) ? in(Int(n), s) : false

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -234,9 +234,7 @@ Base.intersect
 Base.setdiff
 Base.setdiff!
 Base.symdiff
-Base.symdiff!(::BitSet, ::Integer)
-Base.symdiff!(::BitSet, ::Any)
-Base.symdiff!(::BitSet, ::BitSet)
+Base.symdiff!
 Base.intersect!
 Base.issubset
 ```

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -932,7 +932,7 @@ end
     @test isequal(setdiff([1,2,3,4], [7,8,9]), [1,2,3,4])
     @test isequal(setdiff([1,2,3,4], Int64[]), Int64[1,2,3,4])
     @test isequal(setdiff([1,2,3,4], [1,2,3,4,5]), Int64[])
-    @test isequal(symdiff([1,2,3], [4,3,4]), [1,2,4])
+    @test isequal(symdiff([1,2,3], [4,3,4]), [1,2])
     @test isequal(symdiff(['e','c','a'], ['b','a','d']), ['e','c','b','d'])
     @test isequal(symdiff([1,2,3], [4,3], [5]), [1,2,4,5])
     @test isequal(symdiff([1,2,3,4,5], [1,2,3], [3,4]), [3,5])

--- a/test/bitset.jl
+++ b/test/bitset.jl
@@ -195,7 +195,7 @@ end
     @test intersect(BitSet([1,2,3])) == BitSet([1,2,3])
     @test intersect(BitSet(1:7), BitSet(3:10)) ==
     	  intersect(BitSet(3:10), BitSet(1:7)) == BitSet(3:7)
-    @test intersect(BitSet(1:10), BitSet(1:4), 1:5, [2,3,10]) == [2,3]
+    @test intersect(BitSet(1:10), BitSet(1:4), 1:5, [2,3,10]) == BitSet([2,3])
 end
 
 @testset "setdiff, symdiff" begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -157,14 +157,14 @@ end
 end
 
 @testset "union" begin
-    for S in (Set, BitSet)
+    for S in (Set, BitSet, Vector)
         s = ∪(S([1,2]), S([3,4]))
-        @test isequal(s, S([1,2,3,4]))
+        @test s == S([1,2,3,4])
         s = union(S([5,6,7,8]), S([7,8,9]))
-        @test isequal(s, S([5,6,7,8,9]))
+        @test s == S([5,6,7,8,9])
         s = S([1,3,5,7])
-        union!(s,(2,3,4,5))
-        @test isequal(s,S([1,2,3,4,5,7]))
+        union!(s, (2,3,4,5))
+        @test s == S([1,3,5,7,2,4]) # order matters for Vector
         let s1 = S([1, 2, 3])
             @test s1 !== union(s1) == s1
             @test s1 !== union(s1, 2:4) == S([1,2,3,4])
@@ -173,17 +173,21 @@ end
             @test s1 === union!(s1, [2,3,4], S([5])) == S([1,2,3,4,5])
         end
     end
-    @test typeof(union(Set([1]), BitSet())) === Set{Int}
-    @test typeof(union(BitSet([1]), Set())) === BitSet
+    @test union(Set([1]), BitSet()) isa Set{Int}
+    @test union(BitSet([1]), Set()) isa BitSet
+    @test union([1], BitSet()) isa Vector{Int}
+    # union must uniquify
+    @test union([1, 2, 1]) == union!([1, 2, 1]) == [1, 2]
+    @test union([1, 2, 1], [2, 2]) == union!([1, 2, 1], [2, 2]) == [1, 2]
 end
 
 @testset "intersect" begin
-    for S in (Set, BitSet)
-        s = ∩(S([1,2]), S([3,4]))
-        @test isequal(s, S())
+    for S in (Set, BitSet, Vector)
+        s = S([1,2]) ∩ S([3,4])
+        @test s == S()
         s = intersect(S([5,6,7,8]), S([7,8,9]))
-        @test isequal(s, S([7,8]))
-        @test isequal(intersect(S([2,3,1]), S([4,2,3]), S([5,4,3,2])), S([2,3]))
+        @test s == S([7,8])
+        @test intersect(S([2,3,1]), S([4,2,3]), S([5,4,3,2])) == S([2,3])
         let s1 = S([1,2,3])
             @test s1 !== intersect(s1) == s1
             @test s1 !== intersect(s1, 2:10) == S([2,3])
@@ -192,18 +196,22 @@ end
             @test s1 === intersect!(s1, [2,3,4], 3:4) == S([3])
         end
     end
-    @test typeof(intersect(Set([1]), BitSet())) === Set{Int}
-    @test typeof(intersect(BitSet([1]), Set())) === BitSet
+    @test intersect(Set([1]), BitSet()) isa Set{Int}
+    @test intersect(BitSet([1]), Set()) isa BitSet
+    @test intersect([1], BitSet()) isa Vector{Int}
+    # intersect must uniquify
+    @test intersect([1, 2, 1]) == intersect!([1, 2, 1]) == [1, 2]
+    @test intersect([1, 2, 1], [2, 2]) == intersect!([1, 2, 1], [2, 2]) == [2]
 end
 
 @testset "setdiff" begin
-    for S in (Set, BitSet)
-        @test isequal(setdiff(S([1,2,3]), S()),        S([1,2,3]))
-        @test isequal(setdiff(S([1,2,3]), S([1])),     S([2,3]))
-        @test isequal(setdiff(S([1,2,3]), S([1,2])),   S([3]))
-        @test isequal(setdiff(S([1,2,3]), S([1,2,3])), S())
-        @test isequal(setdiff(S([1,2,3]), S([4])),     S([1,2,3]))
-        @test isequal(setdiff(S([1,2,3]), S([4,1])),   S([2,3]))
+    for S in (Set, BitSet, Vector)
+        @test setdiff(S([1,2,3]), S())        == S([1,2,3])
+        @test setdiff(S([1,2,3]), S([1]))     == S([2,3])
+        @test setdiff(S([1,2,3]), S([1,2]))   == S([3])
+        @test setdiff(S([1,2,3]), S([1,2,3])) == S()
+        @test setdiff(S([1,2,3]), S([4]))     == S([1,2,3])
+        @test setdiff(S([1,2,3]), S([4,1]))   == S([2,3])
         let s1 = S([1, 2, 3])
             @test s1 !== setdiff(s1) == s1
             @test s1 !== setdiff(s1, 2:10) == S([1])
@@ -212,8 +220,13 @@ end
             @test s1 === setdiff!(s1, S([2,3,4]), S([1])) == S()
         end
     end
-    @test typeof(setdiff(Set([1]), BitSet())) === Set{Int}
-    @test typeof(setdiff(BitSet([1]), Set())) === BitSet
+
+    @test setdiff(Set([1]), BitSet()) isa Set{Int}
+    @test setdiff(BitSet([1]), Set()) isa BitSet
+    @test setdiff([1], BitSet()) isa Vector{Int}
+    # setdiff must uniquify
+    @test setdiff([1, 2, 1]) == setdiff!([1, 2, 1]) == [1, 2]
+    @test setdiff([1, 2, 1], [2, 2]) == setdiff!([1, 2, 1], [2, 2]) == [1]
 
     s = Set([1,3,5,7])
     setdiff!(s,(3,5))
@@ -240,7 +253,7 @@ end
 end
 
 @testset "issubset, symdiff" begin
-    for S in (Set, BitSet)
+    for S in (Set, BitSet, Vector)
         for (l,r) in ((S([1,2]),     S([3,4])),
                       (S([5,6,7,8]), S([7,8,9])),
                       (S([1,2]),     S([3,4])),
@@ -255,16 +268,22 @@ end
             @test issubset(intersect(l,r), r)
             @test issubset(l, union(l,r))
             @test issubset(r, union(l,r))
-            @test isequal(union(intersect(l,r),symdiff(l,r)), union(l,r))
+            if S === Vector
+                @test sort(union(intersect(l,r),symdiff(l,r))) == sort(union(l,r))
+            else
+                @test union(intersect(l,r),symdiff(l,r)) == union(l,r)
+            end
         end
-        @test ⊆(S([1]), S([1,2]))
-        @test ⊊(S([1]), S([1,2]))
-        @test !⊊(S([1]), S([1]))
-        @test ⊈(S([1]), S([2]))
-        @test ⊇(S([1,2]), S([1]))
-        @test ⊋(S([1,2]), S([1]))
-        @test !⊋(S([1]), S([1]))
-        @test ⊉(S([1]), S([2]))
+        if S !== Vector
+            @test ⊆(S([1]), S([1,2]))
+            @test ⊊(S([1]), S([1,2]))
+            @test !⊊(S([1]), S([1]))
+            @test ⊈(S([1]), S([2]))
+            @test ⊇(S([1,2]), S([1]))
+            @test ⊋(S([1,2]), S([1]))
+            @test !⊋(S([1]), S([1]))
+            @test ⊉(S([1]), S([2]))
+        end
         let s1 = S([1,2,3,4])
             @test s1 !== symdiff(s1) == s1
             @test s1 !== symdiff(s1, S([2,4,5,6])) == S([1,3,5,6])
@@ -272,6 +291,13 @@ end
             @test s1 === symdiff!(s1, S([2,4,5,6]), [1,6,7]) == S([3,5,7])
         end
     end
+    @test symdiff(Set([1,2,3,4]), Set([2,4,5,6])) == Set([1,3,5,6])
+    @test symdiff(Set([1]), BitSet()) isa Set{Int}
+    @test symdiff(BitSet([1]), Set{Int}()) isa BitSet
+    @test symdiff([1], BitSet()) isa Vector{Int}
+    # symdiff must NOT uniquify
+    @test symdiff([1, 2, 1]) == symdiff!([1, 2, 1]) == [2]
+    @test symdiff([1, 2, 1], [2, 2]) == symdiff!([1, 2, 1], [2, 2]) == [2]
 end
 
 @testset "unique" begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -157,42 +157,64 @@ end
 end
 
 @testset "union" begin
-    @test isequal(union(Set([1])),Set([1]))
-    s = ∪(Set([1,2]), Set([3,4]))
-    @test isequal(s, Set([1,2,3,4]))
-    s = union(Set([5,6,7,8]), Set([7,8,9]))
-    @test isequal(s, Set([5,6,7,8,9]))
-    s = Set([1,3,5,7])
-    union!(s,(2,3,4,5))
-    @test isequal(s,Set([1,2,3,4,5,7]))
-    @test ===(typeof(union(Set([1]), BitSet())), Set{Int})
-    @test isequal(union(Set([1,2,3]), 2:4), Set([1,2,3,4]))
-    @test isequal(union(Set([1,2,3]), [2,3,4]), Set([1,2,3,4]))
-    @test isequal(union(Set([1,2,3]), [2,3,4], Set([5])), Set([1,2,3,4,5]))
+    for S in (Set, BitSet)
+        s = ∪(S([1,2]), S([3,4]))
+        @test isequal(s, S([1,2,3,4]))
+        s = union(S([5,6,7,8]), S([7,8,9]))
+        @test isequal(s, S([5,6,7,8,9]))
+        s = S([1,3,5,7])
+        union!(s,(2,3,4,5))
+        @test isequal(s,S([1,2,3,4,5,7]))
+        let s1 = S([1, 2, 3])
+            @test s1 !== union(s1) == s1
+            @test s1 !== union(s1, 2:4) == S([1,2,3,4])
+            @test s1 !== union(s1, [2,3,4]) == S([1,2,3,4])
+            @test s1 !== union(s1, [2,3,4], S([5])) == S([1,2,3,4,5])
+            @test s1 === union!(s1, [2,3,4], S([5])) == S([1,2,3,4,5])
+        end
+    end
+    @test typeof(union(Set([1]), BitSet())) === Set{Int}
+    @test typeof(union(BitSet([1]), Set())) === BitSet
 end
+
 @testset "intersect" begin
-    @test isequal(intersect(Set([1])),Set([1]))
-    s = ∩(Set([1,2]), Set([3,4]))
-    @test isequal(s, Set())
-    s = intersect(Set([5,6,7,8]), Set([7,8,9]))
-    @test isequal(s, Set([7,8]))
-    @test isequal(intersect(Set([2,3,1]), Set([4,2,3]), Set([5,4,3,2])), Set([2,3]))
-    @test ===(typeof(intersect(Set([1]), BitSet())), Set{Int})
-    @test isequal(intersect(Set([1,2,3]), 2:10), Set([2,3]))
-    @test isequal(intersect(Set([1,2,3]), [2,3,4]), Set([2,3]))
-    @test isequal(intersect(Set([1,2,3]), [2,3,4], 3:4), Set([3]))
+    for S in (Set, BitSet)
+        s = ∩(S([1,2]), S([3,4]))
+        @test isequal(s, S())
+        s = intersect(S([5,6,7,8]), S([7,8,9]))
+        @test isequal(s, S([7,8]))
+        @test isequal(intersect(S([2,3,1]), S([4,2,3]), S([5,4,3,2])), S([2,3]))
+        let s1 = S([1,2,3])
+            @test s1 !== intersect(s1) == s1
+            @test s1 !== intersect(s1, 2:10) == S([2,3])
+            @test s1 !== intersect(s1, [2,3,4]) == S([2,3])
+            @test s1 !== intersect(s1, [2,3,4], 3:4) == S([3])
+            @test s1 === intersect!(s1, [2,3,4], 3:4) == S([3])
+        end
+    end
+    @test typeof(intersect(Set([1]), BitSet())) === Set{Int}
+    @test typeof(intersect(BitSet([1]), Set())) === BitSet
 end
+
 @testset "setdiff" begin
-    @test isequal(setdiff(Set([1,2,3]), Set()),        Set([1,2,3]))
-    @test isequal(setdiff(Set([1,2,3]), Set([1])),     Set([2,3]))
-    @test isequal(setdiff(Set([1,2,3]), Set([1,2])),   Set([3]))
-    @test isequal(setdiff(Set([1,2,3]), Set([1,2,3])), Set())
-    @test isequal(setdiff(Set([1,2,3]), Set([4])),     Set([1,2,3]))
-    @test isequal(setdiff(Set([1,2,3]), Set([4,1])),   Set([2,3]))
-    @test ===(typeof(setdiff(Set([1]), BitSet())), Set{Int})
-    @test isequal(setdiff(Set([1,2,3]), 2:10), Set([1]))
-    @test isequal(setdiff(Set([1,2,3]), [2,3,4]), Set([1]))
-    @test_throws MethodError setdiff(Set([1,2,3]), Set([2,3,4]), Set([1]))
+    for S in (Set, BitSet)
+        @test isequal(setdiff(S([1,2,3]), S()),        S([1,2,3]))
+        @test isequal(setdiff(S([1,2,3]), S([1])),     S([2,3]))
+        @test isequal(setdiff(S([1,2,3]), S([1,2])),   S([3]))
+        @test isequal(setdiff(S([1,2,3]), S([1,2,3])), S())
+        @test isequal(setdiff(S([1,2,3]), S([4])),     S([1,2,3]))
+        @test isequal(setdiff(S([1,2,3]), S([4,1])),   S([2,3]))
+        let s1 = S([1, 2, 3])
+            @test s1 !== setdiff(s1) == s1
+            @test s1 !== setdiff(s1, 2:10) == S([1])
+            @test s1 !== setdiff(s1, [2,3,4]) == S([1])
+            @test s1 !== setdiff(s1, S([2,3,4]), S([1])) == S()
+            @test s1 === setdiff!(s1, S([2,3,4]), S([1])) == S()
+        end
+    end
+    @test typeof(setdiff(Set([1]), BitSet())) === Set{Int}
+    @test typeof(setdiff(BitSet([1]), Set())) === BitSet
+
     s = Set([1,3,5,7])
     setdiff!(s,(3,5))
     @test isequal(s,Set([1,7]))
@@ -200,6 +222,7 @@ end
     setdiff!(s, Set([2,4,5,6]))
     @test isequal(s,Set([1,3]))
 end
+
 @testset "ordering" begin
     @test Set() < Set([1])
     @test Set([1]) < Set([1,2])
@@ -215,33 +238,42 @@ end
     @test !(Set([1,2,3]) >= Set([1,2,4]))
     @test !(Set([1,2,3]) <= Set([1,2,4]))
 end
+
 @testset "issubset, symdiff" begin
-    for (l,r) in ((Set([1,2]),     Set([3,4])),
-                  (Set([5,6,7,8]), Set([7,8,9])),
-                  (Set([1,2]),     Set([3,4])),
-                  (Set([5,6,7,8]), Set([7,8,9])),
-                  (Set([1,2,3]),   Set()),
-                  (Set([1,2,3]),   Set([1])),
-                  (Set([1,2,3]),   Set([1,2])),
-                  (Set([1,2,3]),   Set([1,2,3])),
-                  (Set([1,2,3]),   Set([4])),
-                  (Set([1,2,3]),   Set([4,1])))
-        @test issubset(intersect(l,r), l)
-        @test issubset(intersect(l,r), r)
-        @test issubset(l, union(l,r))
-        @test issubset(r, union(l,r))
-        @test isequal(union(intersect(l,r),symdiff(l,r)), union(l,r))
+    for S in (Set, BitSet)
+        for (l,r) in ((S([1,2]),     S([3,4])),
+                      (S([5,6,7,8]), S([7,8,9])),
+                      (S([1,2]),     S([3,4])),
+                      (S([5,6,7,8]), S([7,8,9])),
+                      (S([1,2,3]),   S()),
+                      (S([1,2,3]),   S([1])),
+                      (S([1,2,3]),   S([1,2])),
+                      (S([1,2,3]),   S([1,2,3])),
+                      (S([1,2,3]),   S([4])),
+                      (S([1,2,3]),   S([4,1])))
+            @test issubset(intersect(l,r), l)
+            @test issubset(intersect(l,r), r)
+            @test issubset(l, union(l,r))
+            @test issubset(r, union(l,r))
+            @test isequal(union(intersect(l,r),symdiff(l,r)), union(l,r))
+        end
+        @test ⊆(S([1]), S([1,2]))
+        @test ⊊(S([1]), S([1,2]))
+        @test !⊊(S([1]), S([1]))
+        @test ⊈(S([1]), S([2]))
+        @test ⊇(S([1,2]), S([1]))
+        @test ⊋(S([1,2]), S([1]))
+        @test !⊋(S([1]), S([1]))
+        @test ⊉(S([1]), S([2]))
+        let s1 = S([1,2,3,4])
+            @test s1 !== symdiff(s1) == s1
+            @test s1 !== symdiff(s1, S([2,4,5,6])) == S([1,3,5,6])
+            @test s1 !== symdiff(s1, S([2,4,5,6]), [1,6,7]) == S([3,5,7])
+            @test s1 === symdiff!(s1, S([2,4,5,6]), [1,6,7]) == S([3,5,7])
+        end
     end
-    @test ⊆(Set([1]), Set([1,2]))
-    @test ⊊(Set([1]), Set([1,2]))
-    @test !⊊(Set([1]), Set([1]))
-    @test ⊈(Set([1]), Set([2]))
-    @test ⊇(Set([1,2]), Set([1]))
-    @test ⊋(Set([1,2]), Set([1]))
-    @test !⊋(Set([1]), Set([1]))
-    @test ⊉(Set([1]), Set([2]))
-    @test symdiff(Set([1,2,3,4]), Set([2,4,5,6])) == Set([1,3,5,6])
 end
+
 @testset "unique" begin
     u = unique([1, 1, 2])
     @test in(1, u)
@@ -307,11 +339,10 @@ end
     @test allunique(4:-1:5)       # empty range
     @test allunique(7:-1:1)       # negative step
 end
-@testset "filter" begin
-    s = Set([1,2,3,4])
-    @test isequal(filter(isodd,s), Set([1,3]))
-    filter!(isodd, s)
-    @test isequal(s, Set([1,3]))
+@testset "filter(f, ::$S)" for S = (Set, BitSet)
+    s = S([1,2,3,4])
+    @test s !== filter( isodd, s) == S([1,3])
+    @test s === filter!(isodd, s) == S([1,3])
 end
 @testset "first" begin
     @test_throws ArgumentError first(Set())


### PR DESCRIPTION
For `intersect`, `union`, `setdiff` and `symdiff`, and their mutating variants for `Set` and `IntSet`, there is now support for arbitrary many arguments consistently. What breaks is for one-argument versions: for example we had `s=Set(); union(s) !== s` but `symdiff(s) === s`. I chose here to always return a copy (this should be the only regression in terms of performance). Also, I realize that having `setdiff` accepting more or less than two arguments may be controversial; I find it natural, but can remove this bit if requested.
This should not get merged until nanosoldier runs the [corresponding benchmarks](https://github.com/JuliaCI/BaseBenchmarks.jl/pull/109). 

PS: nice to have those improvements with a net decrease of LOC! (in particular when there are 28 more lines for tests)

EDIT: also, this takes care of improving the complexity of some operations mentioned [here](https://github.com/JuliaLang/julia/pull/23139#issuecomment-320444057).
EDIT: this also adds `filter`/`filter!` for `IntSet` returning an `IntSet` (like for `Set` and `Dict`).