### PR TITLE
deprecate writecsv in favor of writedlm

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -266,6 +266,9 @@ Deprecated or removed
   * The keyword `immutable` is fully deprecated to `struct`, and
     `type` is fully deprecated to `mutable struct` ([#19157], [#20418]).
 
+  * `writecsv(io, a; opts...)` has been deprecated in favor of
+    `writedlm(io, a, ','; opts...)` ([#23529]).
+
   * The method `srand(rng, filename, n=4)` has been deprecated ([#21359]).
 
   * The `cholfact`/`cholfact!` methods that accepted an `uplo` symbol have been deprecated

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -6,7 +6,7 @@ module DataFmt
 
 import Base: _default_delims, tryparse_internal, show
 
-export countlines, readdlm, readcsv, writedlm, writecsv
+export countlines, readdlm, readcsv, writedlm
 
 invalid_dlm(::Type{Char})   = reinterpret(Char, 0xfffffffe)
 invalid_dlm(::Type{UInt8})  = 0xfe
@@ -702,13 +702,6 @@ For example, two vectors `x` and `y` of the same length can be written as two co
 tab-delimited text to `f` by either `writedlm(f, [x y])` or by `writedlm(f, zip(x, y))`.
 """
 writedlm(io, a; opts...) = writedlm(io, a, '\t'; opts...)
-
-"""
-    writecsv(filename, A; opts)
-
-Equivalent to [`writedlm`](@ref) with `delim` set to comma.
-"""
-writecsv(io, a; opts...) = writedlm(io, a, ','; opts...)
 
 show(io::IO, ::MIME"text/csv", a) = writedlm(io, a, ',')
 show(io::IO, ::MIME"text/tab-separated-values", a) = writedlm(io, a, '\t')

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1707,6 +1707,9 @@ export hex2num
 @deprecate_binding φ          MathConstants.φ
 @deprecate_binding golden     MathConstants.golden
 
+# deprecate writecsv
+@deprecate writecsv(io, a; opts...) writedlm(io, a, ','; opts...)
+
 # PR #23271
 function IOContext(io::IO; kws...)
     depwarn("IOContext(io, k=v, ...) is deprecated, use IOContext(io, :k => v, ...) instead.", :IOContext)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1074,7 +1074,6 @@ export
     unmark,
     watch_file,
     write,
-    writecsv,
     writedlm,
     TCPSocket,
     UDPSocket,

--- a/doc/src/stdlib/io-network.md
+++ b/doc/src/stdlib/io-network.md
@@ -84,7 +84,6 @@ Base.DataFmt.readdlm(::Any, ::Type)
 Base.DataFmt.readdlm(::Any)
 Base.DataFmt.writedlm
 Base.DataFmt.readcsv
-Base.DataFmt.writecsv
 Base.Base64.Base64EncodePipe
 Base.Base64.Base64DecodePipe
 Base.Base64.base64encode

--- a/test/perf/kernel/perf.jl
+++ b/test/perf/kernel/perf.jl
@@ -102,7 +102,7 @@ d = randn(len)
 
 @timeit (for n in 1:10; a = arith_vectorized(b,c,d); end) "vectorize" "Vectorized arithmetic"
 
-writecsv("random.csv", rand(100000,4))
+writedlm("random.csv", rand(100000, 4), ',')
 
 function parsecsv()
     for line in eachline("random.csv")


### PR DESCRIPTION
This pull request deprecates `writecsv(io, a; opts...)` in favor of `writedlm(io, a, ','; opts...)`, addressing part of #23414. Best!