### PR TITLE
stacktraces for macroexpand

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3811,18 +3811,14 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr)
                 true, jl_any_type);
     }
     else if (head == copyast_sym) {
-        jl_value_t *arg = args[0];
-        if (jl_is_quotenode(arg)) {
-            jl_value_t *arg1 = jl_fieldref(arg, 0);
-            if (!(jl_is_expr(arg1) || jl_typeis(arg1, jl_array_any_type) || jl_is_quotenode(arg1))) {
-                // elide call to jl_copy_ast when possible
-                return emit_expr(ctx, arg);
-            }
+        jl_cgval_t ast = emit_expr(ctx, args[0]);
+        if (ast.typ != (jl_value_t*)jl_expr_type && ast.typ != (jl_value_t*)jl_any_type) {
+            // elide call to jl_copy_ast when possible
+            return ast;
         }
-        jl_cgval_t ast = emit_expr(ctx, arg);
         return mark_julia_type(ctx,
                 ctx.builder.CreateCall(prepare_call(jlcopyast_func),
-                    maybe_decay_untracked(boxed(ctx, ast))), true, ast.typ);
+                    maybe_decay_untracked(boxed(ctx, ast))), true, jl_expr_type);
     }
     else if (head == simdloop_sym) {
         llvm::annotateSimdLoop(ctx.builder.GetInsertBlock());

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -65,7 +65,7 @@
 ;; note: expansion of stuff inside module is delayed, so the contents obey
 ;; toplevel expansion order (don't expand until stuff before is evaluated).
 (define (expand-toplevel-expr-- e)
-  (let ((ex0 (julia-expand-macros e)))
+  (let ((ex0 (julia-expand-macroscope e)))
     (if (and (pair? ex0) (eq? (car ex0) 'toplevel))
         ex0
         (let* ((ex (julia-expand0 ex0))
@@ -218,17 +218,6 @@
 (define (jl-expand-to-thunk expr)
   (parser-wrap (lambda ()
                  (expand-toplevel-expr expr))))
-
-; macroexpand only
-(define (jl-macroexpand expr)
-  (reset-gensyms)
-  (parser-wrap (lambda ()
-                 (julia-expand-macros expr))))
-
-(define (jl-macroexpand-1 expr)
-  (reset-gensyms)
-  (parser-wrap (lambda ()
-                 (julia-expand-macros expr 1))))
 
 ; run whole frontend on a string. useful for testing.
 (define (fe str)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3245,7 +3245,7 @@ f(x) = yt(x)
                             ,@top-stmts
                             (block ,@sp-inits
                                    (method ,name ,(cl-convert sig fname lam namemap toplevel interp)
-                                           ,(julia-expand-macros `(quote ,newlam))
+                                           ,(julia-bq-macro newlam)
                                            ,(last e)))))))
                  ;; local case - lift to a new type at top level
                  (let* ((exists (get namemap name #f))
@@ -4004,4 +4004,4 @@ f(x) = yt(x)
 (define (julia-expand ex)
   (julia-expand1
    (julia-expand0
-    (julia-expand-macros ex))))
+     julia-expand-macroscope ex)))

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -46,10 +46,6 @@
                         (call (top append_any) ,@forms)))
                (loop (cdr p) (cons (julia-bq-bracket (car p) d) q)))))))
 
-(define (julia-bq-expand-hygienic x unhygienic)
-  (let ((expanded (julia-bq-expand x 0)))
-    (if unhygienic expanded `(escape ,expanded))))
-
 ;; hygiene
 
 ;; return the names of vars introduced by forms, instead of their transformations.
@@ -297,7 +293,7 @@
          (case (car e)
            ((ssavalue) e)
            ((escape) (if (null? parent-scope)
-              (julia-expand-macroscopes (cadr e))
+              (julia-expand-macroscopes- (cadr e))
               (let* ((scope (car parent-scope))
                      (env (car scope))
                      (m (cadr scope))
@@ -476,6 +472,27 @@
   ;; and wrap globals in (globalref module var) for macro's home module
   (resolve-expansion-vars-with-new-env e '() m '() #f #t))
 
+(define (julia-expand-quotes e)
+  (cond ((not (pair? e)) e)
+        ((eq? (car e) 'inert) e)
+        ((eq? (car e) 'module) e)
+        ((eq? (car e) 'quote)
+         (julia-expand-quotes (julia-bq-macro (cadr e))))
+        ((not (contains (lambda (e) (and (pair? e) (eq? (car e) 'quote))) (cdr e))) e)
+        (else
+         (cons (car e) (map julia-expand-quotes (cdr e))))))
+
+(define (julia-expand-macroscopes- e)
+  (cond ((not (pair? e)) e)
+        ((eq? (car e) 'inert) e)
+        ((eq? (car e) 'module) e)
+        ((eq? (car e) 'hygienic-scope)
+         (let ((form (cadr e)) ;; form is the expression returned from expand-macros
+               (modu (caddr e))) ;; m is the macro's def module
+           (resolve-expansion-vars form modu)))
+        (else
+         (map julia-expand-macroscopes- e))))
+
 (define (rename-symbolic-labels- e relabels parent-scope)
   (cond
    ((or (not (pair? e)) (quoted? e)) e)
@@ -502,48 +519,15 @@
 
 ;; macro expander entry point
 
-(define (julia-expand-macros e (max-depth -1))
-  (julia-expand-macroscopes
-    (rename-symbolic-labels
-     (julia-expand-macros- '() e max-depth))))
-
-(define (julia-expand-macros- m e max-depth)
-  (cond ((= max-depth 0)   e)
-        ((not (pair? e)) e)
-        ((eq? (car e) 'quote)
-         ;; backquote is essentially a built-in unhygienic macro at the moment
-         (julia-expand-macros- m (julia-bq-expand-hygienic (cadr e) (null? m)) max-depth))
-        ((eq? (car e) 'inert) e)
-        ((eq? (car e) 'macrocall)
-         ;; expand macro
-         (let ((form (apply invoke-julia-macro (if (null? m) 'false (car m)) (cdr e))))
-           (if (not form)
-               (error (string "macro \"" (cadr e) "\" not defined")))
-           (if (and (pair? form) (eq? (car form) 'error))
-               (error (cadr form)))
-           (let* ((modu (cdr form)) ;; modu is the macro's def module
-                  (form (car form)) ;; form is the expression returned from expand-macros
-                  (form (julia-expand-macros- (cons modu m) form (- max-depth 1))))
-             (if (and (pair? form) (eq? (car form) 'escape))
-                 (cadr form) ; immediately fold away (hygienic-scope (escape ...))
-                 `(hygienic-scope ,form ,modu)))))
-        ((eq? (car e) 'module) e)
-        ((eq? (car e) 'escape)
-         (let ((m (if (null? m) m (cdr m))))
-           `(escape ,(julia-expand-macros- m (cadr e) max-depth))))
-        (else
-         (map (lambda (ex)
-                (julia-expand-macros- m ex max-depth))
-              e))))
-
 ;; TODO: delete this file and fold this operation into resolve-scopes
-(define (julia-expand-macroscopes e)
-  (cond ((not (pair? e)) e)
-        ((eq? (car e) 'inert) e)
-        ((eq? (car e) 'module) e)
-        ((eq? (car e) 'hygienic-scope)
-           (let ((form (cadr e)) ;; form is the expression returned from expand-macros
-                 (modu (caddr e))) ;; m is the macro's def module
-             (resolve-expansion-vars form modu)))
-        (else
-         (map julia-expand-macroscopes e))))
+(define (julia-expand-macroscope e)
+  (julia-expand-macroscopes-
+    (rename-symbolic-labels
+      (julia-expand-quotes e))))
+
+(define (contains-macrocall e)
+  (and (pair? e)
+    (contains (lambda (e) (and (pair? e) (eq? (car e) 'macrocall))) e)))
+
+(define (julia-bq-macro x)
+  (julia-bq-expand x 0))

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -706,7 +706,18 @@ end
 )
 
 # Issue #13905.
-@test @macroexpand(@doc "" f() = @x) == Expr(:error, UndefVarError(Symbol("@x")))
+let err = try; @macroexpand(@doc "" f() = @x); false; catch ex; ex; end
+    __source__ = LineNumberNode(@__LINE__() -  1, Symbol(@__FILE__))
+    err::LoadError
+    @test err.file === string(__source__.file)
+    @test err.line === __source__.line
+    err = err.error::LoadError
+    @test err.file === string(__source__.file)
+    @test err.line === __source__.line
+    err = err.error::UndefVarError
+    @test err.var == Symbol("@x")
+ end
+
 
 # Undocumented DataType Summaries.
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -823,10 +823,16 @@ module B15838
 end
 @test A15838.@f() === nothing
 @test A15838.@f(1) === :b
-let nometh = expand(@__MODULE__, :(A15838.@f(1, 2))), __source__ = LineNumberNode(@__LINE__, Symbol(@__FILE__))
-    @test (nometh::Expr).head === :error
-    @test length(nometh.args) == 1
-    e = nometh.args[1]::MethodError
+let ex = :(A15838.@f(1, 2)), __source__ = LineNumberNode(@__LINE__, Symbol(@__FILE__))
+    nometh = try
+        macroexpand(@__MODULE__, ex)
+        false
+    catch ex
+        ex
+    end::LoadError
+    @test nometh.file === string(__source__.file)
+    @test nometh.line === __source__.line
+    e = nometh.error::MethodError
     @test e.f === getfield(A15838, Symbol("@f"))
     @test e.args === (__source__, @__MODULE__, 1, 2)
 end

--- a/test/printf.jl
+++ b/test/printf.jl
@@ -1,5 +1,18 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+macro test_throws(ty, ex)
+    return quote
+        Test.@test_throws $(esc(ty)) try
+            $(esc(ex))
+        catch err
+            @test err isa LoadError
+            @test err.file === $(string(__source__.file))
+            @test err.line === $(__source__.line)
+            rethrow(err.error)
+        end
+    end
+end
+
 # printf
 # int
 @test (@sprintf "%d" typemax(Int64)) == "9223372036854775807"
@@ -189,14 +202,14 @@ end
 # escape %
 @test (@sprintf "%%") == "%"
 @test (@sprintf "%%s") == "%s"
-@test_throws ArgumentError eval(:(@sprintf "%"))
+@test_throws ArgumentError("invalid printf format string: \"%\"") @macroexpand(@sprintf "%") #" (fixes syntax highlighting)
 
 # argument count
-@test_throws ArgumentError eval(:(@sprintf "%s"))
-@test_throws ArgumentError eval(:(@sprintf "%s" "1" "2"))
+@test_throws ArgumentError("@sprintf: wrong number of arguments (0) should be (1)") @macroexpand(@sprintf "%s")
+@test_throws ArgumentError("@sprintf: wrong number of arguments (2) should be (1)") @macroexpand(@sprintf "%s" "1" "2")
 
 # no interpolation
-@test_throws ArgumentError eval(:(@sprintf "$n"))
+@test_throws ArgumentError("@sprintf: format must be a plain static string (no interpolation or prefix)") @macroexpand(@sprintf "$n")
 
 # type width specifier parsing (ignored)
 @test (@sprintf "%llf" 1.2) == "1.200000"
@@ -242,7 +255,7 @@ end
 # invalid format specifiers, not "diouxXDOUeEfFgGaAcCsSpn"
 for c in "bBhHIjJkKlLmMNPqQrRtTvVwWyYzZ"
     fmt_str = string("%", c)
-    @test_throws ArgumentError eval(:(@sprintf $fmt_str 1))
+    @test_throws ArgumentError("@sprintf: first argument must be a format string") @macroexpand(@sprintf $fmt_str 1)
 end
 
 # combo
@@ -255,7 +268,7 @@ end
 @test (@sprintf "%s %s %s %d %d %d %f %f %f" Any[10^x+y for x=1:3,y=1:3 ]...) == "11 101 1001 12 102 1002 13.000000 103.000000 1003.000000"
 
 # @printf
-@test_throws ArgumentError eval(:(@printf 1))
+@test_throws ArgumentError("@printf: first or second argument must be a format string") @macroexpand(@printf 1)
 
 # Check bug with trailing nul printing BigFloat
 @test (@sprintf("%.330f", BigFloat(1)))[end] != '\0'

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -246,26 +246,27 @@ let
     @test TestMod7648.TestModSub9475 == @which a9475
 end
 
-@test_throws ArgumentError which(===, Tuple{Int, Int})
-@test_throws ArgumentError code_typed(===, Tuple{Int, Int})
-@test_throws ArgumentError code_llvm(===, Tuple{Int, Int})
-@test_throws ArgumentError code_native(===, Tuple{Int, Int})
-@test_throws ArgumentError Base.return_types(===, Tuple{Int, Int})
+@test_throws ArgumentError("argument is not a generic function") which(===, Tuple{Int, Int})
+@test_throws ArgumentError("argument is not a generic function") code_typed(===, Tuple{Int, Int})
+@test_throws ArgumentError("argument is not a generic function") code_llvm(===, Tuple{Int, Int})
+@test_throws ArgumentError("argument is not a generic function") code_native(===, Tuple{Int, Int})
+@test_throws ArgumentError("argument is not a generic function") Base.return_types(===, Tuple{Int, Int})
 
 module TestingExported
 using Base.Test
+include("testenv.jl") # for curmod_str
 import Base.isexported
 global this_is_not_defined
 export this_is_not_defined
-@test_throws ErrorException which(:this_is_not_defined)
-@test_throws ErrorException @which this_is_not_defined
-@test_throws ErrorException which(:this_is_not_exported)
+@test_throws ErrorException("\"this_is_not_defined\" is not defined in module Main") which(:this_is_not_defined)
+@test_throws ErrorException("\"this_is_not_defined\" is not defined in module $curmod_str") @which this_is_not_defined
+@test_throws ErrorException("\"this_is_not_exported\" is not defined in module Main") which(:this_is_not_exported)
 @test isexported(@__MODULE__, :this_is_not_defined)
 @test !isexported(@__MODULE__, :this_is_not_exported)
 const a_value = 1
 @test Base.which_module(@__MODULE__, :a_value) === @__MODULE__
 @test @which(a_value) === @__MODULE__
-@test_throws ErrorException which(:a_value)
+@test_throws ErrorException("\"a_value\" is not defined in module Main") which(:a_value)
 @test which(:Core) === Main
 @test !isexported(@__MODULE__, :a_value)
 end
@@ -668,7 +669,8 @@ let
     @test @inferred wrapperT(ReflectionExample{T, Int64} where T) == ReflectionExample
     @test @inferred wrapperT(ReflectionExample) == ReflectionExample
     @test @inferred wrapperT(Union{ReflectionExample{Union{},1},ReflectionExample{Float64,1}}) == ReflectionExample
-    @test_throws ErrorException Base.typename(Union{Int, Float64})
+    @test_throws(ErrorException("typename does not apply to unions whose components have different typenames"),
+                 Base.typename(Union{Int, Float64}))
 end
 
 # Issue #20086

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -486,7 +486,15 @@ let
     @test (@macroexpand @fastmath 1+2    ) == :(Base.FastMath.add_fast(1,2))
     @test (@macroexpand @fastmath +      ) == :(Base.FastMath.add_fast)
     @test (@macroexpand @fastmath min(1) ) == :(Base.FastMath.min_fast(1))
-    @test (@macroexpand @doc "" f() = @x) == Expr(:error, UndefVarError(Symbol("@x")))
+    let err = try; @macroexpand @doc "" f() = @x; catch ex; ex; end
+        file, line = @__FILE__, @__LINE__() - 1
+        err = err::LoadError
+        @test err.file == file && err.line == line
+        err = err.error::LoadError
+        @test err.file == file && err.line == line
+        err = err.error::UndefVarError
+        @test err == UndefVarError(Symbol("@x"))
+    end
     @test (@macroexpand @seven_dollar $bar) == 7
     x = 2
     @test (@macroexpand @seven_dollar 1+$x) == :(1 + $(Expr(:$, :x)))

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -74,24 +74,37 @@ import Base.SimdLoop.SimdError
 
 # Test that @simd rejects inner loop body with invalid control flow statements
 # issue #8613
-@test_throws SimdError eval(:(begin
+macro test_throws(ty, ex)
+    return quote
+        Test.@test_throws $(esc(ty)) try
+            $(esc(ex))
+        catch err
+            @test err isa LoadError
+            @test err.file === $(string(__source__.file))
+            @test err.line === $(__source__.line + 1)
+            rethrow(err.error)
+        end
+    end
+end
+
+@test_throws SimdError("break is not allowed inside a @simd loop body") @macroexpand begin
     @simd for x = 1:10
         x == 1 && break
     end
-end))
+end
 
-@test_throws SimdError eval(:(begin
+@test_throws SimdError("continue is not allowed inside a @simd loop body") @macroexpand begin
     @simd for x = 1:10
         x < 5 && continue
     end
-end))
+end
 
-@test_throws SimdError eval(:(begin
+@test_throws SimdError("@goto is not allowed inside a @simd loop body") @macroexpand begin
     @simd for x = 1:10
         x == 1 || @goto exit_loop
     end
     @label exit_loop
-end))
+end
 
 # @simd with cartesian iteration
 function simd_cartesian_range!(indexes, crng)


### PR DESCRIPTION
This PR allows errors thrown in `macroexpand` to propagate out directly, rather than discarding their stacktrace in order to wrap them in `Expr(:error)` constructs. It also makes the flisp-julia interface non-reentrant, allowing us to eliminate some complexity from ast.c.

Obligatory examples:
```julia
julia> macro error(msg); error(msg); end
@error (macro with 1 method)

julia> macroexpand(Main, :(@error "in a macro"))
ERROR: LoadError: in a macro
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] @error(::LineNumberNode, ::Module, ::Any) at ./REPL[1]:1
 [3] #macroexpand#39 at ./expr.jl:84 [inlined]
 [4] macroexpand(::Module, ::Any) at ./expr.jl:83
while loading REPL[2], in expression starting on line 1

julia> @printf "%z" b
ERROR: LoadError: ArgumentError: invalid printf format string: "%z"
Stacktrace:
 [1] next_or_die(::String, ::Int64) at ./printf.jl:85
 [2] parse1 at ./printf.jl:126 [inlined]
 [3] parse(::String) at ./printf.jl:46
 [4] gen(::String) at ./printf.jl:14
 [5] _printf(::String, ::Symbol, ::String, ::Tuple{Symbol}) at ./printf.jl:1148
 [6] @printf(::LineNumberNode, ::Module, ::Vararg{Any,N} where N) at ./printf.jl:1218
while loading REPL[8], in expression starting on line 1
```