### PR TITLE
Unify function references in docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -217,7 +217,7 @@ Library improvements
 
   * The `crc32c` function for CRC-32c checksums is now exported ([#22274]).
 
-  * The output of `versioninfo()` is now controlled with keyword arguments ([#21974]).
+  * The output of `versioninfo` is now controlled with keyword arguments ([#21974]).
 
   * The function `LibGit2.set_remote_url` now always sets both the fetch and push URLs for a
     git repo. Additionally, the argument order was changed to be consistent with the git
@@ -889,7 +889,7 @@ Deprecated or removed
     `pop!(ENV, k, def)`. Be aware that `pop!` returns `k` or `def`, whereas `delete!`
     returns `ENV` or `def` ([#18012]).
 
-  * infix operator `$` has been deprecated in favor of infix `⊻` or function `xor()` ([#18977]).
+  * infix operator `$` has been deprecated in favor of infix `⊻` or function `xor` ([#18977]).
 
   * The single-argument form of `write` (`write(x)`, with implicit `STDOUT` output stream),
     has been deprecated in favor of the explicit equivalent `write(STDOUT, x)` ([#17654]).

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -15,7 +15,7 @@ up to 100 tasks will be used for concurrent mapping.
 
 `ntasks` can also be specified as a zero-arg function. In this case, the
 number of tasks to run in parallel is checked before processing every element and a new
-task started if the value of `ntasks_func()` is less than the current number
+task started if the value of `ntasks_func` is less than the current number
 of tasks.
 
 If `batch_size` is specified, the collection is processed in batch mode. `f` must
@@ -285,7 +285,7 @@ Returns an iterator which applies `f` to each element of `c` asynchronously
 and collects output into `results`.
 
 Keyword args `ntasks` and `batch_size` have the same behavior as in
-[`asyncmap()`](@ref). If `batch_size` is specified, `f` must
+[`asyncmap`](@ref). If `batch_size` is specified, `f` must
 be a function which operates on an array of argument tuples.
 
 !!! note
@@ -360,7 +360,7 @@ end
 Apply `f` to each element of `c` using at most `ntasks` asynchronous tasks.
 
 Keyword args `ntasks` and `batch_size` have the same behavior as in
-[`asyncmap()`](@ref). If `batch_size` is specified, `f` must
+[`asyncmap`](@ref). If `batch_size` is specified, `f` must
 be a function which operates on an array of argument tuples.
 
 !!! note
@@ -415,7 +415,7 @@ length(itr::AsyncGenerator) = length(itr.collector.enumerator)
 """
     asyncmap!(f, results, c...; ntasks=0, batch_size=nothing)
 
-Like [`asyncmap()`](@ref), but stores output in `results` rather than
+Like [`asyncmap`](@ref), but stores output in `results` rather than
 returning a collection.
 """
 function asyncmap!(f, r, c1, c...; ntasks=0, batch_size=nothing)

--- a/base/distributed/remotecall.jl
+++ b/base/distributed/remotecall.jl
@@ -94,7 +94,7 @@ RemoteChannel(pid::Integer=myid()) = RemoteChannel{Channel{Any}}(pid, RRID())
 """
     RemoteChannel(f::Function, pid::Integer=myid())
 
-Create references to remote channels of a specific size and type. `f()` is a function that
+Create references to remote channels of a specific size and type. `f` is a function that
 when executed on `pid` must return an implementation of an `AbstractChannel`.
 
 For example, `RemoteChannel(()->Channel{Int}(10), pid)`, will return a reference to a

--- a/base/distributed/workerpool.jl
+++ b/base/distributed/workerpool.jl
@@ -190,7 +190,7 @@ const _default_worker_pool = Ref{Nullable}(Nullable{WorkerPool}())
 """
     default_worker_pool()
 
-`WorkerPool` containing idle `workers()` - used by `remote(f)` and [`pmap`](@ref) (by default).
+`WorkerPool` containing idle `workers` - used by `remote(f)` and [`pmap`](@ref) (by default).
 """
 function default_worker_pool()
     # On workers retrieve the default worker pool from the master when accessed

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -132,7 +132,7 @@ kw"primitive type"
 """
 `macro` defines a method to include generated code in the final body of a program. A
 macro maps a tuple of arguments to a returned expression, and the resulting expression
-is compiled directly rather than requiring a runtime `eval()` call. Macro arguments may
+is compiled directly rather than requiring a runtime `eval` call. Macro arguments may
 include expressions, literal values, and symbols. For example:
 
     macro sayhello(name)
@@ -189,7 +189,7 @@ modify the global variable `z`:
     julia> z
     6
 
-Without the `global` declaration in `foo()`, a new local variable would have been
+Without the `global` declaration in `foo`, a new local variable would have been
 created inside foo(), and the `z` in the global scope would have remained equal to `3`.
 """
 kw"global"

--- a/base/env.jl
+++ b/base/env.jl
@@ -143,7 +143,7 @@ end
 """
     withenv(f::Function, kv::Pair...)
 
-Execute `f()` in an environment that is temporarily modified (not replaced as in `setenv`)
+Execute `f` in an environment that is temporarily modified (not replaced as in `setenv`)
 by zero or more `"var"=>val` arguments `kv`. `withenv` is generally used via the
 `withenv(kv...) do ... end` syntax. A value of `nothing` can be used to temporarily unset an
 environment variable (if it is set). When `withenv` returns, the original environment has

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -224,7 +224,7 @@ _maybetail(t::Tuple) = tail(t)
 
 Represent an AbstractUnitRange of indices as a vector of the indices themselves.
 
-Upon calling `to_indices()`, Colons are converted to Slice objects to represent
+Upon calling `to_indices`, Colons are converted to Slice objects to represent
 the indices over which the Colon spans. Slice objects are themselves unit
 ranges with the same indices as those they wrap. This means that indexing into
 Slice objects with an integer always returns that exact integer, and they

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1194,7 +1194,7 @@ end
 """
     @printf([io::IOStream], "%Fmt", args...)
 
-Print `args` using C `printf()` style format specification string, with some caveats:
+Print `args` using C `printf` style format specification string, with some caveats:
 `Inf` and `NaN` are printed consistently as `Inf` and `NaN` for flags `%a`, `%A`,
 `%e`, `%E`, `%f`, `%F`, `%g`, and `%G`. Furthermore, if a floating point number is
 equally close to the numeric values of two possible output strings, the output

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -1,7 +1,7 @@
 # Julia ASTs
 
 Julia has two representations of code. First there is a surface syntax AST returned by the parser
-(e.g. the [`parse()`](@ref) function), and manipulated by macros. It is a structured representation
+(e.g. the [`parse`](@ref) function), and manipulated by macros. It is a structured representation
 of code as it is written, constructed by `julia-parser.scm` from a character stream. Next there
 is a lowered form, or IR (intermediate representation), which is used by type inference and code
 generation. In the lowered form there are fewer types of nodes, all macros are expanded, and all

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -10,7 +10,7 @@ returns symbols for all bindings in `m`, regardless of export status.
 
 ## DataType fields
 
-The names of `DataType` fields may be interrogated using [`fieldnames()`](@ref). For example,
+The names of `DataType` fields may be interrogated using [`fieldnames`](@ref). For example,
 given the following type, `fieldnames(Point)` returns an arrays of [`Symbol`](@ref) elements representing
 the field names:
 
@@ -49,7 +49,7 @@ of these fields is the `types` field observed in the example above.
 
 ## Subtypes
 
-The *direct* subtypes of any `DataType` may be listed using [`subtypes()`](@ref). For example,
+The *direct* subtypes of any `DataType` may be listed using [`subtypes`](@ref). For example,
 the abstract `DataType` [`AbstractFloat`](@ref) has four (concrete) subtypes:
 
 ```jldoctest
@@ -62,7 +62,7 @@ julia> subtypes(AbstractFloat)
 ```
 
 Any abstract subtype will also be included in this list, but further subtypes thereof will not;
-recursive application of [`subtypes()`](@ref) may be used to inspect the full type tree.
+recursive application of [`subtypes`](@ref) may be used to inspect the full type tree.
 
 ## DataType layout
 
@@ -73,12 +73,12 @@ returns the (byte) offset for field *i* relative to the start of the type.
 
 ## Function methods
 
-The methods of any generic function may be listed using [`methods()`](@ref). The method dispatch
-table may be searched for methods accepting a given type using [`methodswith()`](@ref).
+The methods of any generic function may be listed using [`methods`](@ref). The method dispatch
+table may be searched for methods accepting a given type using [`methodswith`](@ref).
 
 ## Expansion and lowering
 
-As discussed in the [Metaprogramming](@ref) section, the [`macroexpand()`](@ref) function gives
+As discussed in the [Metaprogramming](@ref) section, the [`macroexpand`](@ref) function gives
 the unquoted and interpolated expression (`Expr`) form for a given macro. To use `macroexpand`,
 `quote` the expression block itself (otherwise, the macro will be evaluated and the result will
 be passed instead!). For example:
@@ -88,10 +88,10 @@ julia> macroexpand(@__MODULE__, :(@edit println("")) )
 :((Base.edit)(println, (Base.typesof)("")))
 ```
 
-The functions `Base.Meta.show_sexpr()` and [`dump()`](@ref) are used to display S-expr style views
+The functions `Base.Meta.show_sexpr` and [`dump`](@ref) are used to display S-expr style views
 and depth-nested detail views for any expression.
 
-Finally, the [`expand()`](@ref) function gives the `lowered` form of any expression and is of
+Finally, the [`expand`](@ref) function gives the `lowered` form of any expression and is of
 particular interest for understanding both macros and top-level statements such as function declarations
 and variable assignments:
 
@@ -113,7 +113,7 @@ Inspecting the lowered form for functions requires selection of the specific met
 because generic functions may have many methods with different type signatures. For this purpose,
 method-specific code-lowering is available using [`code_lowered(f::Function, (Argtypes...))`](@ref),
 and the type-inferred form is available using [`code_typed(f::Function, (Argtypes...))`](@ref).
-[`code_warntype(f::Function, (Argtypes...))`](@ref) adds highlighting to the output of [`code_typed()`](@ref)
+[`code_warntype(f::Function, (Argtypes...))`](@ref) adds highlighting to the output of [`code_typed`](@ref)
 (see [`@code_warntype`](@ref)).
 
 Closer to the machine, the LLVM intermediate representation of a function may be printed using

--- a/doc/src/devdocs/stdio.md
+++ b/doc/src/devdocs/stdio.md
@@ -50,7 +50,7 @@ $ echo hello | julia -e 'println(typeof((STDIN, STDOUT, STDERR)))' | cat
 Tuple{Base.PipeEndpoint,Base.PipeEndpoint,Base.TTY}
 ```
 
-The [`Base.read()`](@ref) and [`Base.write()`](@ref) methods for these streams use [`ccall`](@ref)
+The [`Base.read`](@ref) and [`Base.write`](@ref) methods for these streams use [`ccall`](@ref)
 to call libuv wrappers in `src/jl_uv.c`, e.g.:
 
 ```

--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -24,7 +24,7 @@ Julia session, type:
 include(joinpath(JULIA_HOME, Base.DATAROOTDIR, "julia", "build_sysimg.jl"))
 ```
 
-This will include a `build_sysimg()` function:
+This will include a `build_sysimg` function:
 
 ```@docs
 BuildSysImg.build_sysimg

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -76,7 +76,7 @@ omitted it will default to [`Float64`](@ref).
 
 The syntax `[A, B, C, ...]` constructs a 1-d array (vector) of its arguments. If all
 arguments have a common [promotion type](@ref conversion-and-promotion) then they get
-converted to that type using `convert()`.
+converted to that type using `convert`.
 
 ### Concatenation
 
@@ -94,11 +94,11 @@ The concatenation functions are used so often that they have special syntax:
 
 | Expression        | Calls             |
 |:----------------- |:----------------- |
-| `[A; B; C; ...]`  | [`vcat()`](@ref)  |
-| `[A B C ...]`     | [`hcat()`](@ref)  |
-| `[A B; C D; ...]` | [`hvcat()`](@ref) |
+| `[A; B; C; ...]`  | [`vcat`](@ref)  |
+| `[A B C ...]`     | [`hcat`](@ref)  |
+| `[A B; C D; ...]` | [`hvcat`](@ref) |
 
-[`hvcat()`](@ref) concatenates in both dimension 1 (with semicolons) and dimension 2 (with spaces).
+[`hvcat`](@ref) concatenates in both dimension 1 (with semicolons) and dimension 2 (with spaces).
 
 ### Typed array initializers
 
@@ -278,7 +278,7 @@ julia> x[1, [2 3; 4 1]]
 ```
 
 Empty ranges of the form `n:n-1` are sometimes used to indicate the inter-index location between
-`n-1` and `n`. For example, the [`searchsorted()`](@ref) function uses this convention to indicate
+`n-1` and `n`. For example, the [`searchsorted`](@ref) function uses this convention to indicate
 the insertion point of a value not found in a sorted array:
 
 ```jldoctest
@@ -311,7 +311,7 @@ Just as in [Indexing](@ref man-array-indexing), the `end` keyword may be used
 to represent the last index of each dimension within the indexing brackets, as
 determined by the size of the array being assigned into. Indexed assignment
 syntax without the `end` keyword is equivalent to a call to
-[`setindex!()`](@ref):
+[`setindex!`](@ref):
 
 ```
 setindex!(A, X, I_1, I_2, ..., I_n)
@@ -440,7 +440,7 @@ vector of `CartesianIndex{N}`s where its values are `true`. A logical index
 must be a vector of the same length as the dimension it indexes into, or it
 must be the only index provided and match the size and dimensionality of the
 array it indexes into. It is generally more efficient to use boolean arrays as
-indices directly instead of first calling [`find()`](@ref).
+indices directly instead of first calling [`find`](@ref).
 
 ```jldoctest
 julia> x = reshape(1:16, 4, 4)
@@ -546,7 +546,7 @@ Note that comparisons such as `==` operate on whole arrays, giving a single bool
 answer. Use dot operators like `.==` for elementwise comparisons. (For comparison
 operations like `<`, *only* the elementwise `.<` version is applicable to arrays.)
 
-Also notice the difference between `max.(a,b)`, which `broadcast`s [`max()`](@ref)
+Also notice the difference between `max.(a,b)`, which `broadcast`s [`max`](@ref)
 elementwise over `a` and `b`, and `maximum(a)`, which finds the largest value within
 `a`. The same relationship holds for `min.(a,b)` and `minimum(a)`.
 
@@ -565,7 +565,7 @@ julia> repmat(a,1,3)+A
  1.56851  1.86401  1.67846
 ```
 
-This is wasteful when dimensions get large, so Julia offers [`broadcast()`](@ref), which expands
+This is wasteful when dimensions get large, so Julia offers [`broadcast`](@ref), which expands
 singleton dimensions in array arguments to match the corresponding dimension in the other array
 without using extra memory, and applies the given function elementwise:
 
@@ -587,14 +587,14 @@ julia> broadcast(+, a, b)
 
 [Dotted operators](@ref man-dot-operators) such as `.+` and `.*` are equivalent
 to `broadcast` calls (except that they fuse, as described below). There is also a
-[`broadcast!()`](@ref) function to specify an explicit destination (which can also
-be accessed in a fusing fashion by `.=` assignment), and functions [`broadcast_getindex()`](@ref)
-and [`broadcast_setindex!()`](@ref) that broadcast the indices before indexing. Moreover, `f.(args...)`
+[`broadcast!`](@ref) function to specify an explicit destination (which can also
+be accessed in a fusing fashion by `.=` assignment), and functions [`broadcast_getindex`](@ref)
+and [`broadcast_setindex!`](@ref) that broadcast the indices before indexing. Moreover, `f.(args...)`
 is equivalent to `broadcast(f, args...)`, providing a convenient syntax to broadcast any function
 ([dot syntax](@ref man-vectorized)). Nested "dot calls" `f.(...)` (including calls to `.+` etcetera)
 [automatically fuse](@ref man-dot-operators) into a single `broadcast` call.
 
-Additionally, [`broadcast()`](@ref) is not limited to arrays (see the function documentation),
+Additionally, [`broadcast`](@ref) is not limited to arrays (see the function documentation),
 it also handles tuples and treats any argument that is not an array, tuple or `Ref` (except for `Ptr`) as a "scalar".
 
 ```jldoctest
@@ -627,13 +627,13 @@ The `AbstractArray` type includes anything vaguely array-like, and implementatio
 be quite different from conventional arrays. For example, elements might be computed on request
 rather than stored. However, any concrete `AbstractArray{T,N}` type should generally implement
 at least [`size(A)`](@ref) (returning an `Int` tuple), [`getindex(A,i)`](@ref) and [`getindex(A,i1,...,iN)`](@ref getindex);
-mutable arrays should also implement [`setindex!()`](@ref). It is recommended that these operations
+mutable arrays should also implement [`setindex!`](@ref). It is recommended that these operations
 have nearly constant time complexity, or technically Õ(1) complexity, as otherwise some array
 functions may be unexpectedly slow. Concrete types should also typically provide a [`similar(A,T=eltype(A),dims=size(A))`](@ref)
-method, which is used to allocate a similar array for [`copy()`](@ref) and other out-of-place
+method, which is used to allocate a similar array for [`copy`](@ref) and other out-of-place
 operations. No matter how an `AbstractArray{T,N}` is represented internally, `T` is the type of
 object returned by *integer* indexing (`A[1, ..., 1]`, when `A` is not empty) and `N` should be
-the length of the tuple returned by [`size()`](@ref).
+the length of the tuple returned by [`size`](@ref).
 
 `DenseArray` is an abstract subtype of `AbstractArray` intended to include all arrays that are
 laid out at regular offsets in memory, and which can therefore be passed to external C and Fortran
@@ -650,9 +650,9 @@ basic storage-specific operations are all that have to be implemented for [`Arra
 that the rest of the array library can be implemented in a generic manner.
 
 `SubArray` is a specialization of `AbstractArray` that performs indexing by reference rather than
-by copying. A `SubArray` is created with the [`view()`](@ref) function, which is called the same
-way as [`getindex()`](@ref) (with an array and a series of index arguments). The result of [`view()`](@ref)
-looks the same as the result of [`getindex()`](@ref), except the data is left in place. [`view()`](@ref)
+by copying. A `SubArray` is created with the [`view`](@ref) function, which is called the same
+way as [`getindex`](@ref) (with an array and a series of index arguments). The result of [`view`](@ref)
+looks the same as the result of [`getindex`](@ref), except the data is left in place. [`view`](@ref)
 stores the input index vectors in a `SubArray` object, which can later be used to index the original
 array indirectly.  By putting the [`@views`](@ref) macro in front of an expression or
 block of code, any `array[...]` slice in that expression will be converted to
@@ -743,10 +743,10 @@ them is by doing a double transpose.
 In some applications, it is convenient to store explicit zero values in a `SparseMatrixCSC`. These
 *are* accepted by functions in `Base` (but there is no guarantee that they will be preserved in
 mutating operations). Such explicitly stored zeros are treated as structural nonzeros by many
-routines. The [`nnz()`](@ref) function returns the number of elements explicitly stored in the
+routines. The [`nnz`](@ref) function returns the number of elements explicitly stored in the
 sparse data structure, including structural nonzeros. In order to count the exact number of
 numerical nonzeros, use [`count(!iszero, x)`](@ref), which inspects every stored element of a sparse
-matrix. [`dropzeros()`](@ref), and the in-place [`dropzeros!()`](@ref), can be used to
+matrix. [`dropzeros`](@ref), and the in-place [`dropzeros!`](@ref), can be used to
 remove stored zeros from the sparse matrix.
 
 ```jldoctest
@@ -781,8 +781,8 @@ stored zeros. (See [Sparse Matrix Storage](@ref man-csc).).
 
 ### Sparse Vector and Matrix Constructors
 
-The simplest way to create sparse arrays is to use functions equivalent to the [`zeros()`](@ref)
-and [`eye()`](@ref) functions that Julia provides for working with dense arrays. To produce
+The simplest way to create sparse arrays is to use functions equivalent to the [`zeros`](@ref)
+and [`eye`](@ref) functions that Julia provides for working with dense arrays. To produce
 sparse arrays instead, you can use the same names with an `sp` prefix:
 
 ```jldoctest
@@ -796,7 +796,7 @@ julia> speye(3,5)
   [3, 3]  =  1.0
 ```
 
-The [`sparse()`](@ref) function is often a handy way to construct sparse arrays. For
+The [`sparse`](@ref) function is often a handy way to construct sparse arrays. For
 example, to construct a sparse matrix we can input a vector `I` of row indices, a vector
 `J` of column indices, and a vector `V` of stored values (this is also known as the
 [COO (coordinate) format](https://en.wikipedia.org/wiki/Sparse_matrix#Coordinate_list_.28COO.29)).
@@ -823,8 +823,8 @@ julia> R = sparsevec(I,V)
   [5]  =  3
 ```
 
-The inverse of the [`sparse()`](@ref) and [`sparsevec`](@ref) functions is
-[`findnz()`](@ref), which retrieves the inputs used to create the sparse array.
+The inverse of the [`sparse`](@ref) and [`sparsevec`](@ref) functions is
+[`findnz`](@ref), which retrieves the inputs used to create the sparse array.
 There is also a [`findn`](@ref) function which only returns the index vectors.
 
 ```jldoctest sparse_function
@@ -846,7 +846,7 @@ julia> findn(R)
 ```
 
 Another way to create a sparse array is to convert a dense array into a sparse array using
-the [`sparse()`](@ref) function:
+the [`sparse`](@ref) function:
 
 ```jldoctest
 julia> sparse(eye(5))
@@ -863,7 +863,7 @@ julia> sparse([1.0, 0.0, 1.0])
   [3]  =  1.0
 ```
 
-You can go in the other direction using the [`Array`](@ref) constructor. The [`issparse()`](@ref)
+You can go in the other direction using the [`Array`](@ref) constructor. The [`issparse`](@ref)
 function can be used to query if a matrix is sparse.
 
 ```jldoctest
@@ -876,7 +876,7 @@ true
 Arithmetic operations on sparse matrices also work as they do on dense matrices. Indexing of,
 assignment into, and concatenation of sparse matrices work in the same way as dense matrices.
 Indexing operations, especially assignment, are expensive, when carried out one element at a time.
-In many cases it may be better to convert the sparse matrix into `(I,J,V)` format using [`findnz()`](@ref),
+In many cases it may be better to convert the sparse matrix into `(I,J,V)` format using [`findnz`](@ref),
 manipulate the values or the structure in the dense vectors `(I,J,V)`, and then reconstruct
 the sparse matrix.
 
@@ -894,7 +894,7 @@ section of the standard library reference.
 | Sparse                     | Dense                  | Description                                                                                                                                                           |
 |:-------------------------- |:---------------------- |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [`spzeros(m,n)`](@ref)     | [`zeros(m,n)`](@ref)   | Creates a *m*-by-*n* matrix of zeros. ([`spzeros(m,n)`](@ref) is empty.)                                                                                              |
-| [`spones(S)`](@ref)        | [`ones(m,n)`](@ref)    | Creates a matrix filled with ones. Unlike the dense version, [`spones()`](@ref) has the same sparsity pattern as *S*.                                                 |
+| [`spones(S)`](@ref)        | [`ones(m,n)`](@ref)    | Creates a matrix filled with ones. Unlike the dense version, [`spones`](@ref) has the same sparsity pattern as *S*.                                                 |
 | [`speye(n)`](@ref)         | [`eye(n)`](@ref)       | Creates a *n*-by-*n* identity matrix.                                                                                                                                 |
 | [`full(S)`](@ref)          | [`sparse(A)`](@ref)    | Interconverts between dense and sparse formats.                                                                                                                       |
 | [`sprand(m,n,d)`](@ref)    | [`rand(m,n)`](@ref)    | Creates a *m*-by-*n* random matrix (of density *d*) with iid non-zero elements distributed uniformly on the half-open interval ``[0, 1)``.                            |

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -153,8 +153,8 @@ For example, to match C prototypes of the form:
 typedef returntype (*functiontype)(argumenttype,...)
 ```
 
-The function [`cfunction()`](@ref) generates the C-compatible function pointer for a call to a
-Julia function. Arguments to [`cfunction()`](@ref) are as follows:
+The function [`cfunction`](@ref) generates the C-compatible function pointer for a call to a
+Julia function. Arguments to [`cfunction`](@ref) are as follows:
 
 1. A Julia Function
 2. Return type
@@ -195,7 +195,7 @@ In order to pass this function to C, we obtain its address using the function `c
 julia> const mycompare_c = cfunction(mycompare, Cint, Tuple{Ref{Cdouble}, Ref{Cdouble}});
 ```
 
-[`cfunction()`](@ref) accepts three arguments: the Julia function (`mycompare`), the return type
+[`cfunction`](@ref) accepts three arguments: the Julia function (`mycompare`), the return type
 (`Cint`), and a tuple type of the input argument types, in this case to sort an array of `Cdouble`
 ([`Float64`](@ref)) elements.
 
@@ -239,7 +239,7 @@ Julia code from a C header file.)
 
 ### Auto-conversion:
 
-Julia automatically inserts calls to the [`Base.cconvert()`](@ref) function to convert each argument
+Julia automatically inserts calls to the [`Base.cconvert`](@ref) function to convert each argument
 to the specified type. For example, the following call:
 
 ```julia
@@ -254,12 +254,12 @@ ccall((:foo, "libfoo"), Void, (Int32, Float64),
       Base.unsafe_convert(Float64, Base.cconvert(Float64, y)))
 ```
 
-[`Base.cconvert()`](@ref) normally just calls [`convert()`](@ref), but can be defined to return an
+[`Base.cconvert`](@ref) normally just calls [`convert`](@ref), but can be defined to return an
 arbitrary new object more appropriate for passing to C.
 This should be used to perform all allocations of memory that will be accessed by the C code.
 For example, this is used to convert an `Array` of objects (e.g. strings) to an array of pointers.
 
-[`Base.unsafe_convert()`](@ref) handles conversion to `Ptr` types. It is considered unsafe because
+[`Base.unsafe_convert`](@ref) handles conversion to `Ptr` types. It is considered unsafe because
 converting an object to a native pointer can hide the object from the garbage collector, causing
 it to be freed prematurely.
 
@@ -323,9 +323,9 @@ same:
     (for example, to pass a `Float64` array to a function that operates on uninterpreted bytes), you
     can declare the argument as `Ptr{Void}`.
 
-    If an array of eltype `Ptr{T}` is passed as a `Ptr{Ptr{T}}` argument, [`Base.cconvert()`](@ref)
+    If an array of eltype `Ptr{T}` is passed as a `Ptr{Ptr{T}}` argument, [`Base.cconvert`](@ref)
     will attempt to first make a null-terminated copy of the array with each element replaced by its
-    [`Base.cconvert()`](@ref) version. This allows, for example, passing an `argv` pointer array of type
+    [`Base.cconvert`](@ref) version. This allows, for example, passing an `argv` pointer array of type
     `Vector{String}` to an argument of type `Ptr{Ptr{Cchar}}`.
 
 On all systems we currently support, basic C/C++ value types may be translated to Julia types
@@ -555,7 +555,7 @@ allocated in Julia to be freed by an external library) is equally invalid.
 In Julia code wrapping calls to external C routines, ordinary (non-pointer) data should be declared
 to be of type `T` inside the [`ccall`](@ref), as they are passed by value.  For C code accepting
 pointers, `Ref{T}` should generally be used for the types of input arguments, allowing the use
-of pointers to memory managed by either Julia or C through the implicit call to [`Base.cconvert()`](@ref).
+of pointers to memory managed by either Julia or C through the implicit call to [`Base.cconvert`](@ref).
  In contrast, pointers returned by the C function called should be declared to be of output type
 `Ptr{T}`, reflecting that the memory pointed to is managed by C only. Pointers contained in C
 structs should be represented as fields of type `Ptr{T}` within the corresponding Julia struct
@@ -590,12 +590,12 @@ For translating a C argument list to Julia:
 
       * `Any`
       * argument value must be a valid Julia object
-      * currently unsupported by [`cfunction()`](@ref)
+      * currently unsupported by [`cfunction`](@ref)
   * `jl_value_t**`
 
       * `Ref{Any}`
       * argument value must be a valid Julia object (or `C_NULL`)
-      * currently unsupported by [`cfunction()`](@ref)
+      * currently unsupported by [`cfunction`](@ref)
   * `T*`
 
       * `Ref{T}`, where `T` is the Julia type corresponding to `T`
@@ -603,7 +603,7 @@ For translating a C argument list to Julia:
         object
   * `(T*)(...)` (e.g. a pointer to a function)
 
-      * `Ptr{Void}` (you may need to use [`cfunction()`](@ref) explicitly to create this pointer)
+      * `Ptr{Void}` (you may need to use [`cfunction`](@ref) explicitly to create this pointer)
   * `...` (e.g. a vararg)
 
       * `T...`, where `T` is the Julia type
@@ -654,7 +654,7 @@ For translating a C return type to Julia:
           * `Ptr{T}`, where `T` is the Julia type corresponding to `T`
   * `(T*)(...)` (e.g. a pointer to a function)
 
-      * `Ptr{Void}` (you may need to use [`cfunction()`](@ref) explicitly to create this pointer)
+      * `Ptr{Void}` (you may need to use [`cfunction`](@ref) explicitly to create this pointer)
 
 ### Passing Pointers for Modifying Inputs
 
@@ -728,7 +728,7 @@ end
 
 The [GNU Scientific Library](https://www.gnu.org/software/gsl/) (here assumed to be accessible
 through `:libgsl`) defines an opaque pointer, `gsl_permutation *`, as the return type of the C
-function `gsl_permutation_alloc()`. As user code never has to look inside the `gsl_permutation`
+function `gsl_permutation_alloc`. As user code never has to look inside the `gsl_permutation`
 struct, the corresponding Julia wrapper simply needs a new type declaration, `gsl_permutation`,
 that has no internal fields and whose sole purpose is to be placed in the type parameter of a
 `Ptr` type.  The return type of the [`ccall`](@ref) is declared as `Ptr{gsl_permutation}`, since
@@ -757,7 +757,7 @@ end
 
 Here, the input `p` is declared to be of type `Ref{gsl_permutation}`, meaning that the memory
 that `p` points to may be managed by Julia or by C. A pointer to memory allocated by C should
-be of type `Ptr{gsl_permutation}`, but it is convertable using [`Base.cconvert()`](@ref) and therefore
+be of type `Ptr{gsl_permutation}`, but it is convertable using [`Base.cconvert`](@ref) and therefore
 can be used in the same (covariant) context of the input argument to a [`ccall`](@ref). A pointer
 to memory allocated by Julia must be of type `Ref{gsl_permutation}`, to ensure that the memory
 address pointed to is valid and that Julia's garbage collector manages the chunk of memory pointed
@@ -809,7 +809,7 @@ the C function may end up throwing an invalid memory access exception.
 
 ## Garbage Collection Safety
 
-When passing data to a [`ccall`](@ref), it is best to avoid using the [`pointer()`](@ref) function.
+When passing data to a [`ccall`](@ref), it is best to avoid using the [`pointer`](@ref) function.
 Instead define a convert method and pass the variables directly to the [`ccall`](@ref). [`ccall`](@ref)
 automatically arranges that all of its arguments will be preserved from garbage collection until
 the call returns. If a C API will store a reference to memory allocated by Julia, after the [`ccall`](@ref)
@@ -818,9 +818,9 @@ way to handle this is to make a global variable of type `Array{Ref,1}` to hold t
 the C library notifies you that it is finished with them.
 
 Whenever you have created a pointer to Julia data, you must ensure the original data exists until
-you are done with using the pointer. Many methods in Julia such as [`unsafe_load()`](@ref) and
-[`String()`](@ref) make copies of data instead of taking ownership of the buffer, so that it is
-safe to free (or alter) the original data without affecting Julia. A notable exception is [`unsafe_wrap()`](@ref)
+you are done with using the pointer. Many methods in Julia such as [`unsafe_load`](@ref) and
+[`String`](@ref) make copies of data instead of taking ownership of the buffer, so that it is
+safe to free (or alter) the original data without affecting Julia. A notable exception is [`unsafe_wrap`](@ref)
 which, for performance reasons, shares (or can be told to take ownership of) the underlying buffer.
 
 The garbage collector does not guarantee any order of finalization. That is, if `a` contained
@@ -923,8 +923,8 @@ unlike the equivalent Julia functions exposed by `Core.Intrinsics`.
 
 ## Accessing Global Variables
 
-Global variables exported by native libraries can be accessed by name using the [`cglobal()`](@ref)
-function. The arguments to [`cglobal()`](@ref) are a symbol specification identical to that used
+Global variables exported by native libraries can be accessed by name using the [`cglobal`](@ref)
+function. The arguments to [`cglobal`](@ref) are a symbol specification identical to that used
 by [`ccall`](@ref), and a type describing the value stored in the variable:
 
 ```julia-repl
@@ -933,7 +933,7 @@ Ptr{Int32} @0x00007f418d0816b8
 ```
 
 The result is a pointer giving the address of the value. The value can be manipulated through
-this pointer using [`unsafe_load()`](@ref) and [`unsafe_store!()`](@ref).
+this pointer using [`unsafe_load`](@ref) and [`unsafe_store!`](@ref).
 
 ## Accessing Data through a Pointer
 
@@ -943,7 +943,7 @@ cause Julia to terminate abruptly.
 Given a `Ptr{T}`, the contents of type `T` can generally be copied from the referenced memory
 into a Julia object using `unsafe_load(ptr, [index])`. The index argument is optional (default
 is 1), and follows the Julia-convention of 1-based indexing. This function is intentionally similar
-to the behavior of [`getindex()`](@ref) and [`setindex!()`](@ref) (e.g. `[]` access syntax).
+to the behavior of [`getindex`](@ref) and [`setindex!`](@ref) (e.g. `[]` access syntax).
 
 The return value will be a new object initialized to contain a copy of the contents of the referenced
 memory. The referenced memory can safely be freed or released.

--- a/doc/src/manual/complex-and-rational-numbers.md
+++ b/doc/src/manual/complex-and-rational-numbers.md
@@ -111,9 +111,9 @@ julia> angle(1 + 2im) # phase angle in radians
 1.1071487177940904
 ```
 
-As usual, the absolute value ([`abs()`](@ref)) of a complex number is its distance from zero.
-[`abs2()`](@ref) gives the square of the absolute value, and is of particular use for complex
-numbers where it avoids taking a square root. [`angle()`](@ref) returns the phase angle in radians
+As usual, the absolute value ([`abs`](@ref)) of a complex number is its distance from zero.
+[`abs2`](@ref) gives the square of the absolute value, and is of particular use for complex
+numbers where it avoids taking a square root. [`angle`](@ref) returns the phase angle in radians
 (also known as the *argument* or *arg* function). The full gamut of other [Elementary Functions](@ref)
 is also defined for complex numbers:
 
@@ -135,7 +135,7 @@ julia> sinh(1 + 2im)
 ```
 
 Note that mathematical functions typically return real values when applied to real numbers and
-complex values when applied to complex numbers. For example, [`sqrt()`](@ref) behaves differently
+complex values when applied to complex numbers. For example, [`sqrt`](@ref) behaves differently
 when applied to `-1` versus `-1 + 0im` even though `-1 == -1 + 0im`:
 
 ```jldoctest
@@ -159,7 +159,7 @@ julia> a = 1; b = 2; a + b*im
 1 + 2im
 ```
 
-However, this is *not* recommended; Use the [`complex()`](@ref) function instead to construct
+However, this is *not* recommended; Use the [`complex`](@ref) function instead to construct
 a complex value directly from its real and imaginary parts:
 
 ```jldoctest
@@ -209,7 +209,7 @@ julia> -4//-12
 
 This normalized form for a ratio of integers is unique, so equality of rational values can be
 tested by checking for equality of the numerator and denominator. The standardized numerator and
-denominator of a rational value can be extracted using the [`numerator()`](@ref) and [`denominator()`](@ref)
+denominator of a rational value can be extracted using the [`numerator`](@ref) and [`denominator`](@ref)
 functions:
 
 ```jldoctest

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -354,7 +354,7 @@ following additional outer constructor method:
 julia> Point(x::Int64, y::Float64) = Point(convert(Float64,x),y);
 ```
 
-This method uses the [`convert()`](@ref) function to explicitly convert `x` to [`Float64`](@ref)
+This method uses the [`convert`](@ref) function to explicitly convert `x` to [`Float64`](@ref)
 and then delegates construction to the general constructor for the case where both arguments are
 [`Float64`](@ref). With this method definition what was previously a [`MethodError`](@ref) now
 successfully creates a point of type `Point{Float64}`:
@@ -513,7 +513,7 @@ table for the `Type` type. This means that you can declare more flexible constru
 for abstract types, by explicitly defining methods for the appropriate types.
 
 However, in some cases you could consider adding methods to `Base.convert` *instead* of defining
-a constructor, because Julia falls back to calling [`convert()`](@ref) if no matching constructor
+a constructor, because Julia falls back to calling [`convert`](@ref) if no matching constructor
 is found. For example, if no constructor `T(args...) = ...` exists `Base.convert(::Type{T}, args...) = ...`
 is called.
 

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -6,8 +6,8 @@ Julia provides a variety of control flow constructs:
   * [Conditional Evaluation](@ref man-conditional-evaluation): `if`-`elseif`-`else` and `?:` (ternary operator).
   * [Short-Circuit Evaluation](@ref): `&&`, `||` and chained comparisons.
   * [Repeated Evaluation: Loops](@ref man-loops): `while` and `for`.
-  * [Exception Handling](@ref): `try`-`catch`, [`error()`](@ref) and [`throw()`](@ref).
-  * [Tasks (aka Coroutines)](@ref man-tasks): [`yieldto()`](@ref).
+  * [Exception Handling](@ref): `try`-`catch`, [`error`](@ref) and [`throw`](@ref).
+  * [Tasks (aka Coroutines)](@ref man-tasks): [`yieldto`](@ref).
 
 The first five control flow mechanisms are standard to high-level programming languages. [`Task`](@ref)s
 are not so standard: they provide non-local control flow, making it possible to switch between
@@ -565,7 +565,7 @@ below all interrupt the normal flow of control.
 | [`UndefVarError`](@ref)       |
 | `UnicodeError`                |
 
-For example, the [`sqrt()`](@ref) function throws a [`DomainError`](@ref) if applied to a negative
+For example, the [`sqrt`](@ref) function throws a [`DomainError`](@ref) if applied to a negative
 real value:
 
 ```jldoctest
@@ -584,10 +584,10 @@ You may define your own exceptions in the following way:
 julia> struct MyCustomException <: Exception end
 ```
 
-### The [`throw()`](@ref) function
+### The [`throw`](@ref) function
 
-Exceptions can be created explicitly with [`throw()`](@ref). For example, a function defined only
-for nonnegative numbers could be written to [`throw()`](@ref) a [`DomainError`](@ref) if the argument
+Exceptions can be created explicitly with [`throw`](@ref). For example, a function defined only
+for nonnegative numbers could be written to [`throw`](@ref) a [`DomainError`](@ref) if the argument
 is negative:
 
 ```jldoctest
@@ -646,11 +646,11 @@ julia> Base.showerror(io::IO, e::MyUndefVarError) = print(io, e.var, " not defin
 
 ### Errors
 
-The [`error()`](@ref) function is used to produce an [`ErrorException`](@ref) that interrupts
+The [`error`](@ref) function is used to produce an [`ErrorException`](@ref) that interrupts
 the normal flow of control.
 
 Suppose we want to stop execution immediately if the square root of a negative number is taken.
-To do this, we can define a fussy version of the [`sqrt()`](@ref) function that raises an error
+To do this, we can define a fussy version of the [`sqrt`](@ref) function that raises an error
 if its argument is negative:
 
 ```jldoctest fussy_sqrt
@@ -799,7 +799,7 @@ julia> try error() end # Returns nothing
 The power of the `try/catch` construct lies in the ability to unwind a deeply nested computation
 immediately to a much higher level in the stack of calling functions. There are situations where
 no error has occurred, but the ability to unwind the stack and pass a value to a higher level
-is desirable. Julia provides the [`rethrow()`](@ref), [`backtrace()`](@ref) and [`catch_backtrace()`](@ref)
+is desirable. Julia provides the [`rethrow`](@ref), [`backtrace`](@ref) and [`catch_backtrace`](@ref)
 functions for more advanced error handling.
 
 ### `finally` Clauses
@@ -855,7 +855,7 @@ multiple tasks reading from and writing to it.
 Let's define a producer task, which produces values via the [`put!`](@ref) call.
 To consume values, we need to schedule the producer to run in a new task. A special [`Channel`](@ref)
 constructor which accepts a 1-arg function as an argument can be used to run a task bound to a channel.
-We can then [`take!()`](@ref) values repeatedly from the channel object:
+We can then [`take!`](@ref) values repeatedly from the channel object:
 
 ```jldoctest producer
 julia> function producer(c::Channel)
@@ -888,7 +888,7 @@ julia> take!(chnl)
 ```
 
 One way to think of this behavior is that `producer` was able to return multiple times. Between
-calls to [`put!()`](@ref), the producer's execution is suspended and the consumer has control.
+calls to [`put!`](@ref), the producer's execution is suspended and the consumer has control.
 
 The returned [`Channel`](@ref) can be used as an iterable object in a `for` loop, in which case the
 loop variable takes on all the produced values. The loop is terminated when the channel is closed.
@@ -906,16 +906,16 @@ stop
 ```
 
 Note that we did not have to explicitly close the channel in the producer. This is because
-the act of binding a [`Channel`](@ref) to a [`Task()`](@ref) associates the open lifetime of
+the act of binding a [`Channel`](@ref) to a [`Task`](@ref) associates the open lifetime of
 a channel with that of the bound task. The channel object is closed automatically when the task
 terminates. Multiple channels can be bound to a task, and vice-versa.
 
-While the [`Task()`](@ref) constructor expects a 0-argument function, the [`Channel()`](@ref)
+While the [`Task`](@ref) constructor expects a 0-argument function, the [`Channel`](@ref)
 method which creates a channel bound task expects a function that accepts a single argument of
 type [`Channel`](@ref). A common pattern is for the producer to be parameterized, in which case a partial
 function application is needed to create a 0 or 1 argument [anonymous function](@ref man-anonymous-functions).
 
-For [`Task()`](@ref) objects this can be done either directly or by use of a convenience macro:
+For [`Task`](@ref) objects this can be done either directly or by use of a convenience macro:
 
 ```julia
 function mytask(myarg)
@@ -927,8 +927,8 @@ taskHdl = Task(() -> mytask(7))
 taskHdl = @task mytask(7)
 ```
 
-To orchestrate more advanced work distribution patterns, [`bind()`](@ref) and [`schedule()`](@ref)
-can be used in conjunction with [`Task()`](@ref) and [`Channel()`](@ref)
+To orchestrate more advanced work distribution patterns, [`bind`](@ref) and [`schedule`](@ref)
+can be used in conjunction with [`Task`](@ref) and [`Channel`](@ref)
 constructors to explicitly link a set of channels with a set of producer/consumer tasks.
 
 Note that currently Julia tasks are not scheduled to run on separate CPU cores.
@@ -936,27 +936,27 @@ True kernel threads are discussed under the topic of [Parallel Computing](@ref).
 
 ### Core task operations
 
-Let us explore the low level construct [`yieldto()`](@ref) to underestand how task switching works.
+Let us explore the low level construct [`yieldto`](@ref) to underestand how task switching works.
 `yieldto(task,value)` suspends the current task, switches to the specified `task`, and causes
-that task's last [`yieldto()`](@ref) call to return the specified `value`. Notice that [`yieldto()`](@ref)
+that task's last [`yieldto`](@ref) call to return the specified `value`. Notice that [`yieldto`](@ref)
 is the only operation required to use task-style control flow; instead of calling and returning
 we are always just switching to a different task. This is why this feature is also called "symmetric
 coroutines"; each task is switched to and from using the same mechanism.
 
-[`yieldto()`](@ref) is powerful, but most uses of tasks do not invoke it directly. Consider why
+[`yieldto`](@ref) is powerful, but most uses of tasks do not invoke it directly. Consider why
 this might be. If you switch away from the current task, you will probably want to switch back
 to it at some point, but knowing when to switch back, and knowing which task has the responsibility
-of switching back, can require considerable coordination. For example, [`put!()`](@ref) and [`take!()`](@ref)
+of switching back, can require considerable coordination. For example, [`put!`](@ref) and [`take!`](@ref)
 are blocking operations, which, when used in the context of channels maintain state to remember
-who the consumers are. Not needing to manually keep track of the consuming task is what makes [`put!()`](@ref)
-easier to use than the low-level [`yieldto()`](@ref).
+who the consumers are. Not needing to manually keep track of the consuming task is what makes [`put!`](@ref)
+easier to use than the low-level [`yieldto`](@ref).
 
-In addition to [`yieldto()`](@ref), a few other basic functions are needed to use tasks effectively.
+In addition to [`yieldto`](@ref), a few other basic functions are needed to use tasks effectively.
 
-  * [`current_task()`](@ref) gets a reference to the currently-running task.
-  * [`istaskdone()`](@ref) queries whether a task has exited.
-  * [`istaskstarted()`](@ref) queries whether a task has run yet.
-  * [`task_local_storage()`](@ref) manipulates a key-value store specific to the current task.
+  * [`current_task`](@ref) gets a reference to the currently-running task.
+  * [`istaskdone`](@ref) queries whether a task has exited.
+  * [`istaskstarted`](@ref) queries whether a task has run yet.
+  * [`task_local_storage`](@ref) manipulates a key-value store specific to the current task.
 
 ### Tasks and events
 
@@ -964,23 +964,23 @@ Most task switches occur as a result of waiting for events such as I/O requests,
 by a scheduler included in the standard library. The scheduler maintains a queue of runnable tasks,
 and executes an event loop that restarts tasks based on external events such as message arrival.
 
-The basic function for waiting for an event is [`wait()`](@ref). Several objects implement [`wait()`](@ref);
-for example, given a `Process` object, [`wait()`](@ref) will wait for it to exit. [`wait()`](@ref)
-is often implicit; for example, a [`wait()`](@ref) can happen inside a call to [`read()`](@ref)
+The basic function for waiting for an event is [`wait`](@ref). Several objects implement [`wait`](@ref);
+for example, given a `Process` object, [`wait`](@ref) will wait for it to exit. [`wait`](@ref)
+is often implicit; for example, a [`wait`](@ref) can happen inside a call to [`read`](@ref)
 to wait for data to be available.
 
-In all of these cases, [`wait()`](@ref) ultimately operates on a [`Condition`](@ref) object, which
-is in charge of queueing and restarting tasks. When a task calls [`wait()`](@ref) on a [`Condition`](@ref),
+In all of these cases, [`wait`](@ref) ultimately operates on a [`Condition`](@ref) object, which
+is in charge of queueing and restarting tasks. When a task calls [`wait`](@ref) on a [`Condition`](@ref),
 the task is marked as non-runnable, added to the condition's queue, and switches to the scheduler.
 The scheduler will then pick another task to run, or block waiting for external events. If all
-goes well, eventually an event handler will call [`notify()`](@ref) on the condition, which causes
+goes well, eventually an event handler will call [`notify`](@ref) on the condition, which causes
 tasks waiting for that condition to become runnable again.
 
 A task created explicitly by calling [`Task`](@ref) is initially not known to the scheduler. This
-allows you to manage tasks manually using [`yieldto()`](@ref) if you wish. However, when such
+allows you to manage tasks manually using [`yieldto`](@ref) if you wish. However, when such
 a task waits for an event, it still gets restarted automatically when the event happens, as you
 would expect. It is also possible to make the scheduler run a task whenever it can, without necessarily
-waiting for any events. This is done by calling [`schedule()`](@ref), or using the [`@schedule`](@ref)
+waiting for any events. This is done by calling [`schedule`](@ref), or using the [`@schedule`](@ref)
 or [`@async`](@ref) macros (see [Parallel Computing](@ref) for more details).
 
 ### Task states

--- a/doc/src/manual/conversion-and-promotion.md
+++ b/doc/src/manual/conversion-and-promotion.md
@@ -89,12 +89,12 @@ since type constructors fall back to convert methods.
 Some languages consider parsing strings as numbers or formatting numbers as strings to be conversions
 (many dynamic languages will even perform conversion for you automatically), however Julia does
 not: even though some strings can be parsed as numbers, most strings are not valid representations
-of numbers, and only a very limited subset of them are. Therefore in Julia the dedicated `parse()`
+of numbers, and only a very limited subset of them are. Therefore in Julia the dedicated `parse`
 function must be used to perform this operation, making it more explicit.
 
 ### Defining New Conversions
 
-To define a new conversion, simply provide a new method for `convert()`. That's really all there
+To define a new conversion, simply provide a new method for `convert`. That's really all there
 is to it. For example, the method to convert a real number to a boolean is this:
 
 ```julia

--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -98,7 +98,7 @@ noting the transition `"yyyymm"` from one period character to the next.
 Support for text-form month parsing is also supported through the `u` and `U` characters, for
 abbreviated and full-length month names, respectively. By default, only English month names are
 supported, so `u` corresponds to "Jan", "Feb", "Mar", etc. And `U` corresponds to "January", "February",
-"March", etc. Similar to other name=>value mapping functions [`dayname()`](@ref) and [`monthname()`](@ref),
+"March", etc. Similar to other name=>value mapping functions [`dayname`](@ref) and [`monthname`](@ref),
 custom locales can be loaded by passing in the `locale=>Dict{String,Int}` mapping to the `MONTHTOVALUEABBR`
 and `MONTHTOVALUE` dicts for abbreviated and full-name month names, respectively.
 
@@ -296,10 +296,10 @@ julia> Dates.dayofquarter(t)
 31
 ```
 
-The [`dayname()`](@ref) and [`monthname()`](@ref) methods can also take an optional `locale` keyword
+The [`dayname`](@ref) and [`monthname`](@ref) methods can also take an optional `locale` keyword
 that can be used to return the name of the day or month of the year for other languages/locales.
 There are also versions of these functions returning the abbreviated names, namely
-[`dayabbr()`](@ref) and [`monthabbr()`](@ref).
+[`dayabbr`](@ref) and [`monthabbr`](@ref).
 First the mapping is loaded into the `LOCALES` variable:
 
 ```jldoctest tdate2
@@ -328,7 +328,7 @@ julia> Dates.monthabbr(t;locale="french")
 ```
 
 Since the abbreviated versions of the days are not loaded, trying to use the
-function `dayabbr()` will error.
+function `dayabbr` will error.
 
 ```jldoctest tdate2
 julia> Dates.dayabbr(t;locale="french")
@@ -451,7 +451,7 @@ julia> Dates.lastdayofquarter(Date(2014,7,16)) # Adjusts to the last day of the 
 2014-09-30
 ```
 
-The next two higher-order methods, [`tonext()`](@ref), and [`toprev()`](@ref), generalize working
+The next two higher-order methods, [`tonext`](@ref), and [`toprev`](@ref), generalize working
 with temporal expressions by taking a `DateFunction` as first argument, along with a starting
 [`TimeType`](@ref). A `DateFunction` is just a function, usually anonymous, that takes a single
 [`TimeType`](@ref) as input and returns a [`Bool`](@ref), `true` indicating a satisfied
@@ -481,7 +481,7 @@ julia> Dates.tonext(Date(2014,7,13)) do x
 2014-11-27
 ```
 
-The [`Base.filter()`](@ref) method can be used to obtain all valid dates/moments in a specified
+The [`Base.filter`](@ref) method can be used to obtain all valid dates/moments in a specified
 range:
 
 ```jldoctest
@@ -545,7 +545,7 @@ julia> div(y3,3) # mirrors integer division
 ## Rounding
 
 [`Date`](@ref) and [`DateTime`](@ref) values can be rounded to a specified resolution (e.g., 1
-month or 15 minutes) with [`floor()`](@ref), [`ceil()`](@ref), or [`round()`](@ref):
+month or 15 minutes) with [`floor`](@ref), [`ceil`](@ref), or [`round`](@ref):
 
 ```jldoctest
 julia> floor(Date(1985, 8, 16), Dates.Month)
@@ -558,8 +558,8 @@ julia> round(DateTime(2016, 8, 6, 20, 15), Dates.Day)
 2016-08-07T00:00:00
 ```
 
-Unlike the numeric [`round()`](@ref) method, which breaks ties toward the even number by default,
-the [`TimeType`](@ref)[`round()`](@ref) method uses the `RoundNearestTiesUp` rounding mode. (It's
+Unlike the numeric [`round`](@ref) method, which breaks ties toward the even number by default,
+the [`TimeType`](@ref)[`round`](@ref) method uses the `RoundNearestTiesUp` rounding mode. (It's
 difficult to guess what breaking ties to nearest "even" [`TimeType`](@ref) would entail.) Further
 details on the available `RoundingMode` s can be found in the [API reference](@ref stdlib-dates).
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -94,7 +94,7 @@ julia> x
  3
 ```
 
-Here we created a function `change_array!()`, that assigns `5` to the first element of the passed
+Here we created a function `change_array!`, that assigns `5` to the first element of the passed
 array (bound to `x` at the call site, and bound to `A` within the function). Notice that, after
 the function call, `x` is still bound to the same array, but the content of that array changed:
 the variables `A` and `x` were distinct bindings refering to the same mutable `Array` object.
@@ -242,11 +242,11 @@ Stacktrace:
 ```
 
 This behavior is an inconvenient consequence of the requirement for type-stability.  In the case
-of [`sqrt()`](@ref), most users want `sqrt(2.0)` to give a real number, and would be unhappy if
-it produced the complex number `1.4142135623730951 + 0.0im`.  One could write the [`sqrt()`](@ref)
+of [`sqrt`](@ref), most users want `sqrt(2.0)` to give a real number, and would be unhappy if
+it produced the complex number `1.4142135623730951 + 0.0im`.  One could write the [`sqrt`](@ref)
 function to switch to a complex-valued output only when passed a negative number (which is what
-[`sqrt()`](@ref) does in some other languages), but then the result would not be [type-stable](@ref man-type-stability)
-and the [`sqrt()`](@ref) function would have poor performance.
+[`sqrt`](@ref) does in some other languages), but then the result would not be [type-stable](@ref man-type-stability)
+and the [`sqrt`](@ref) function would have poor performance.
 
 In these and other cases, you can get the result you want by choosing an *input type* that conveys
 your willingness to accept an *output type* in which the result can be represented:

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -143,7 +143,7 @@ julia> +(1,2,3)
 
 The infix form is exactly equivalent to the function application form -- in fact the former is
 parsed to produce the function call internally. This also means that you can assign and pass around
-operators such as [`+()`](@ref) and [`*()`](@ref) just like you would with other function values:
+operators such as [`+`](@ref) and [`*`](@ref) just like you would with other function values:
 
 ```jldoctest
 julia> f = +;
@@ -160,14 +160,14 @@ A few special expressions correspond to calls to functions with non-obvious name
 
 | Expression        | Calls                  |
 |:----------------- |:---------------------- |
-| `[A B C ...]`     | [`hcat()`](@ref)       |
-| `[A; B; C; ...]`  | [`vcat()`](@ref)       |
-| `[A B; C D; ...]` | [`hvcat()`](@ref)      |
-| `A'`              | [`adjoint()`](@ref) |
-| `A.'`             | [`transpose()`](@ref)  |
-| `1:n`             | [`colon()`](@ref)      |
-| `A[i]`            | [`getindex()`](@ref)   |
-| `A[i]=x`          | [`setindex!()`](@ref)  |
+| `[A B C ...]`     | [`hcat`](@ref)       |
+| `[A; B; C; ...]`  | [`vcat`](@ref)       |
+| `[A B; C D; ...]` | [`hvcat`](@ref)      |
+| `A'`              | [`adjoint`](@ref) |
+| `A.'`             | [`transpose`](@ref)  |
+| `1:n`             | [`colon`](@ref)      |
+| `A[i]`            | [`getindex`](@ref)   |
+| `A[i]=x`          | [`setindex!`](@ref)  |
 
 ## [Anonymous Functions](@id man-anonymous-functions)
 
@@ -192,7 +192,7 @@ This creates a function taking one argument `x` and returning the value of the p
 name based on consecutive numbering.
 
 The primary use for anonymous functions is passing them to functions which take other functions
-as arguments. A classic example is [`map()`](@ref), which applies a function to each value of
+as arguments. A classic example is [`map`](@ref), which applies a function to each value of
 an array and returns a new array containing the resulting values:
 
 ```jldoctest
@@ -204,7 +204,7 @@ julia> map(round, [1.2,3.5,1.7])
 ```
 
 This is fine if a named function effecting the transform already exists to pass as the first argument
-to [`map()`](@ref). Often, however, a ready-to-use, named function does not exist. In these
+to [`map`](@ref). Often, however, a ready-to-use, named function does not exist. In these
 situations, the anonymous function construct allows easy creation of a single-use function object
 without needing a name:
 
@@ -219,7 +219,7 @@ julia> map(x -> x^2 + 2x - 1, [1,3,-1])
 An anonymous function accepting multiple arguments can be written using the syntax `(x,y,z)->2x+y-z`.
 A zero-argument anonymous function is written as `()->3`. The idea of a function with no arguments
 may seem strange, but is useful for "delaying" a computation. In this usage, a block of code is
-wrapped in a zero-argument function, which is later invoked by calling it as `f()`.
+wrapped in a zero-argument function, which is later invoked by calling it as `f`.
 
 ## Multiple Return Values
 
@@ -507,7 +507,7 @@ the `b` in `a=b` refers to a `b` in an outer scope, not the subsequent argument 
 
 Passing functions as arguments to other functions is a powerful technique, but the syntax for
 it is not always convenient. Such calls are especially awkward to write when the function argument
-requires multiple lines. As an example, consider calling [`map()`](@ref) on a function with several
+requires multiple lines. As an example, consider calling [`map`](@ref) on a function with several
 cases:
 
 ```julia
@@ -538,16 +538,16 @@ end
 ```
 
 The `do x` syntax creates an anonymous function with argument `x` and passes it as the first argument
-to [`map()`](@ref). Similarly, `do a,b` would create a two-argument anonymous function, and a
+to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function, and a
 plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 
-How these arguments are initialized depends on the "outer" function; here, [`map()`](@ref) will
+How these arguments are initialized depends on the "outer" function; here, [`map`](@ref) will
 sequentially set `x` to `A`, `B`, `C`, calling the anonymous function on each, just as would happen
 in the syntax `map(func, [A, B, C])`.
 
 This syntax makes it easier to use functions to effectively extend the language, since calls look
-like normal code blocks. There are many possible uses quite different from [`map()`](@ref), such
-as managing system state. For example, there is a version of [`open()`](@ref) that runs code ensuring
+like normal code blocks. There are many possible uses quite different from [`map`](@ref), such
+as managing system state. For example, there is a version of [`open`](@ref) that runs code ensuring
 that the opened file is eventually closed:
 
 ```julia
@@ -569,8 +569,8 @@ function open(f::Function, args...)
 end
 ```
 
-Here, [`open()`](@ref) first opens the file for writing and then passes the resulting output stream
-to the anonymous function you defined in the `do ... end` block. After your function exits, [`open()`](@ref)
+Here, [`open`](@ref) first opens the file for writing and then passes the resulting output stream
+to the anonymous function you defined in the `do ... end` block. After your function exits, [`open`](@ref)
 will make sure that the stream is properly closed, regardless of whether your function exited
 normally or threw an exception. (The `try/finally` construct will be described in [Control Flow](@ref).)
 

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -162,7 +162,7 @@ UInt8
 ```
 
 The minimum and maximum representable values of primitive numeric types such as integers are given
-by the [`typemin()`](@ref) and [`typemax()`](@ref) functions:
+by the [`typemin`](@ref) and [`typemax`](@ref) functions:
 
 ```jldoctest
 julia> (typemin(Int32), typemax(Int32))
@@ -183,7 +183,7 @@ julia> for T in [Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt12
 UInt128: [0,340282366920938463463374607431768211455]
 ```
 
-The values returned by [`typemin()`](@ref) and [`typemax()`](@ref) are always of the given argument
+The values returned by [`typemin`](@ref) and [`typemax`](@ref) are always of the given argument
 type. (The above expression uses several features we have yet to introduce, including [for loops](@ref man-loops),
 [Strings](@ref man-strings), and [Interpolation](@ref), but should be easy enough to understand for users
 with some existing programming experience.)
@@ -212,7 +212,7 @@ is recommended instead.
 ### Division errors
 
 Integer division (the `div` function) has two exceptional cases: dividing by zero, and dividing
-the lowest negative number ([`typemin()`](@ref)) by -1. Both of these cases throw a [`DivideError`](@ref).
+the lowest negative number ([`typemin`](@ref)) by -1. Both of these cases throw a [`DivideError`](@ref).
 The remainder and modulus functions (`rem` and `mod`) throw a [`DivideError`](@ref) when their
 second argument is zero.
 
@@ -371,7 +371,7 @@ julia> 0 * Inf
 NaN
 ```
 
-The [`typemin()`](@ref) and [`typemax()`](@ref) functions also apply to floating-point types:
+The [`typemin`](@ref) and [`typemax`](@ref) functions also apply to floating-point types:
 
 ```jldoctest
 julia> (typemin(Float16),typemax(Float16))
@@ -390,7 +390,7 @@ Most real numbers cannot be represented exactly with floating-point numbers, and
 it is important to know the distance between two adjacent representable floating-point numbers,
 which is often known as [machine epsilon](https://en.wikipedia.org/wiki/Machine_epsilon).
 
-Julia provides [`eps()`](@ref), which gives the distance between `1.0` and the next larger representable
+Julia provides [`eps`](@ref), which gives the distance between `1.0` and the next larger representable
 floating-point value:
 
 ```jldoctest
@@ -405,7 +405,7 @@ julia> eps() # same as eps(Float64)
 ```
 
 These values are `2.0^-23` and `2.0^-52` as [`Float32`](@ref) and [`Float64`](@ref) values,
-respectively. The [`eps()`](@ref) function can also take a floating-point value as an
+respectively. The [`eps`](@ref) function can also take a floating-point value as an
 argument, and gives the absolute difference between that value and the next representable
 floating point value. That is, `eps(x)` yields a value of the same type as `x` such that
 `x + eps(x)` is the next representable floating-point value larger than `x`:
@@ -430,7 +430,7 @@ numbers are densest in the real number line near zero, and grow sparser exponent
 farther away from zero. By definition, `eps(1.0)` is the same as `eps(Float64)` since `1.0` is
 a 64-bit floating-point value.
 
-Julia also provides the [`nextfloat()`](@ref) and [`prevfloat()`](@ref) functions which return
+Julia also provides the [`nextfloat`](@ref) and [`prevfloat`](@ref) functions which return
 the next largest or smallest representable floating-point number to the argument respectively:
 
 ```jldoctest
@@ -478,8 +478,8 @@ The default mode used is always [`RoundNearest`](@ref), which rounds to the near
 value, with ties rounded towards the nearest value with an even least significant bit.
 
 !!! warning
-    Rounding is generally only correct for basic arithmetic functions ([`+()`](@ref), [`-()`](@ref),
-    [`*()`](@ref), [`/()`](@ref) and [`sqrt()`](@ref)) and type conversion operations. Many other
+    Rounding is generally only correct for basic arithmetic functions ([`+`](@ref), [`-`](@ref),
+    [`*`](@ref), [`/`](@ref) and [`sqrt`](@ref)) and type conversion operations. Many other
     functions assume the default [`RoundNearest`](@ref) mode is set, and can give erroneous results
     when operating under other rounding modes.
 
@@ -511,7 +511,7 @@ the [GNU Multiple Precision Arithmetic Library (GMP)](https://gmplib.org) and th
 respectively. The [`BigInt`](@ref) and [`BigFloat`](@ref) types are available in Julia for arbitrary
 precision integer and floating point numbers respectively.
 
-Constructors exist to create these types from primitive numerical types, and [`parse()`](@ref)
+Constructors exist to create these types from primitive numerical types, and [`parse`](@ref)
 can be used to construct them from `AbstractString`s.  Once created, they participate in arithmetic
 with all other numeric types thanks to Julia's [type promotion and conversion mechanism](@ref conversion-and-promotion):
 
@@ -556,7 +556,7 @@ BigInt
 ```
 
 The default precision (in number of bits of the significand) and rounding mode of [`BigFloat`](@ref)
-operations can be changed globally by calling [`setprecision()`](@ref) and [`setrounding()`](@ref),
+operations can be changed globally by calling [`setprecision`](@ref) and [`setrounding`](@ref),
 and all further calculations will take these changes in account.  Alternatively, the precision
 or the rounding can be changed only within the execution of a particular block of code by using
 the same functions with a `do` block:

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -31,7 +31,7 @@ to generically build upon those behaviors.
 | `HasEltype()`                                | `eltype(IterType)` |
 | `EltypeUnknown()`                            | (*none*)           |
 
-Sequential iteration is implemented by the methods [`start()`](@ref), [`done()`](@ref), and [`next()`](@ref). Instead
+Sequential iteration is implemented by the methods [`start`](@ref), [`done`](@ref), and [`next`](@ref). Instead
 of mutating objects as they are iterated over, Julia provides these three methods to keep track
 of the iteration state externally from the object. The `start(iter)` method returns the initial
 state for the iterable object `iter`. That state gets passed along to `done(iter, state)`, which
@@ -92,7 +92,7 @@ julia> for i in Squares(7)
 49
 ```
 
-We can use many of the builtin methods that work with iterables, like [`in()`](@ref), [`mean()`](@ref) and [`std()`](@ref):
+We can use many of the builtin methods that work with iterables, like [`in`](@ref), [`mean`](@ref) and [`std`](@ref):
 
 ```jldoctest squaretype
 julia> 25 in Squares(10)
@@ -107,11 +107,11 @@ julia> std(Squares(100))
 
 There are a few more methods we can extend to give Julia more information about this iterable
 collection.  We know that the elements in a `Squares` sequence will always be `Int`. By extending
-the [`eltype()`](@ref) method, we can give that information to Julia and help it make more specialized
+the [`eltype`](@ref) method, we can give that information to Julia and help it make more specialized
 code in the more complicated methods. We also know the number of elements in our sequence, so
-we can extend [`length()`](@ref), too.
+we can extend [`length`](@ref), too.
 
-Now, when we ask Julia to [`collect()`](@ref) all the elements into an array it can preallocate a `Vector{Int}`
+Now, when we ask Julia to [`collect`](@ref) all the elements into an array it can preallocate a `Vector{Int}`
 of the right size instead of blindly [`push!`](@ref)ing each element into a `Vector{Any}`:
 
 ```jldoctest squaretype
@@ -146,7 +146,7 @@ be used in their specific case.
 
 For the `Squares` iterable above, we can easily compute the `i`th element of the sequence by squaring
 it.  We can expose this as an indexing expression `S[i]`. To opt into this behavior, `Squares`
-simply needs to define [`getindex()`](@ref):
+simply needs to define [`getindex`](@ref):
 
 ```jldoctest squaretype
 julia> function Base.getindex(S::Squares, i::Int)
@@ -158,7 +158,7 @@ julia> Squares(100)[23]
 529
 ```
 
-Additionally, to support the syntax `S[end]`, we must define [`endof()`](@ref) to specify the last valid
+Additionally, to support the syntax `S[end]`, we must define [`endof`](@ref) to specify the last valid
 index:
 
 ```jldoctest squaretype
@@ -168,7 +168,7 @@ julia> Squares(23)[end]
 529
 ```
 
-Note, though, that the above *only* defines [`getindex()`](@ref) with one integer index. Indexing with
+Note, though, that the above *only* defines [`getindex`](@ref) with one integer index. Indexing with
 anything other than an `Int` will throw a [`MethodError`](@ref) saying that there was no matching method.
 In order to support indexing with ranges or vectors of `Int`s, separate methods must be written:
 
@@ -199,10 +199,10 @@ ourselves, we can officially define it as a subtype of an [`AbstractArray`](@ref
 | `setindex!(A, v, i::Int)`                       |                                          | (if `IndexLinear`) Scalar indexed assignment                                           |
 | `setindex!(A, v, I::Vararg{Int, N})`            |                                          | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexed assignment       |
 | **Optional methods**                            | **Default definition**                   | **Brief description**                                                                 |
-| `IndexStyle(::Type)`                            | `IndexCartesian()`                       | Returns either `IndexLinear()` or `IndexCartesian()`. See the description below.      |
-| `getindex(A, I...)`                             | defined in terms of scalar `getindex()`  | [Multidimensional and nonscalar indexing](@ref man-array-indexing)                    |
-| `setindex!(A, I...)`                            | defined in terms of scalar `setindex!()` | [Multidimensional and nonscalar indexed assignment](@ref man-array-indexing)          |
-| `start()`/`next()`/`done()`                     | defined in terms of scalar `getindex()`  | Iteration                                                                             |
+| `IndexStyle(::Type)`                            | `IndexCartesian`                       | Returns either `IndexLinear()` or `IndexCartesian()`. See the description below.      |
+| `getindex(A, I...)`                             | defined in terms of scalar `getindex`  | [Multidimensional and nonscalar indexing](@ref man-array-indexing)                    |
+| `setindex!(A, I...)`                            | defined in terms of scalar `setindex!` | [Multidimensional and nonscalar indexed assignment](@ref man-array-indexing)          |
+| `start`/`next`/`done`                           | defined in terms of scalar `getindex`  | Iteration                                                                             |
 | `length(A)`                                     | `prod(size(A))`                          | Number of elements                                                                    |
 | `similar(A)`                                    | `similar(A, eltype(A), size(A))`         | Return a mutable array with the same shape and element type                           |
 | `similar(A, ::Type{S})`                         | `similar(A, S, size(A))`                 | Return a mutable array with the same shape and the specified element type             |
@@ -233,7 +233,7 @@ efficiently converts the indices into one linear index and then calls the above 
 arrays, on the other hand, require methods to be defined for each supported dimensionality with
 `ndims(A)` `Int` indices. For example, the built-in [`SparseMatrixCSC`](@ref) type only
 supports two dimensions, so it just defines
-`getindex(A::SparseMatrixCSC, i::Int, j::Int)`. The same holds for `setindex!()`.
+`getindex(A::SparseMatrixCSC, i::Int, j::Int)`. The same holds for `setindex!`.
 
 Returning to the sequence of squares from above, we could instead define it as a subtype of an
 `AbstractArray{Int, 1}`:
@@ -251,7 +251,7 @@ julia> Base.getindex(S::SquaresVector, i::Int) = i*i
 ```
 
 Note that it's very important to specify the two parameters of the `AbstractArray`; the first
-defines the [`eltype()`](@ref), and the second defines the [`ndims()`](@ref). That supertype and those three
+defines the [`eltype`](@ref), and the second defines the [`ndims`](@ref). That supertype and those three
 methods are all it takes for `SquaresVector` to be an iterable, indexable, and completely functional
 array:
 
@@ -302,8 +302,8 @@ julia> Base.getindex(A::SparseArray{T,N}, I::Vararg{Int,N}) where {T,N} = get(A.
 julia> Base.setindex!(A::SparseArray{T,N}, v, I::Vararg{Int,N}) where {T,N} = (A.data[I] = v)
 ```
 
-Notice that this is an `IndexCartesian` array, so we must manually define [`getindex()`](@ref) and [`setindex!()`](@ref)
-at the dimensionality of the array. Unlike the `SquaresVector`, we are able to define [`setindex!()`](@ref),
+Notice that this is an `IndexCartesian` array, so we must manually define [`getindex`](@ref) and [`setindex!`](@ref)
+at the dimensionality of the array. Unlike the `SquaresVector`, we are able to define [`setindex!`](@ref),
 and so we can mutate the array:
 
 ```jldoctest squarevectype
@@ -327,7 +327,7 @@ julia> A[:] = 1:length(A); A
 ```
 
 The result of indexing an `AbstractArray` can itself be an array (for instance when indexing by
-a `Range`). The `AbstractArray` fallback methods use [`similar()`](@ref) to allocate an `Array` of the
+a `Range`). The `AbstractArray` fallback methods use [`similar`](@ref) to allocate an `Array` of the
 appropriate size and element type, which is filled in using the basic indexing method described
 above. However, when implementing an array wrapper you often want the result to be wrapped as
 well:
@@ -342,8 +342,8 @@ julia> A[1:2,:]
 In this example it is accomplished by defining `Base.similar{T}(A::SparseArray, ::Type{T}, dims::Dims)`
 to create the appropriate wrapped array. (Note that while `similar` supports 1- and 2-argument
 forms, in most case you only need to specialize the 3-argument form.) For this to work it's important
-that `SparseArray` is mutable (supports `setindex!`). Defining `similar()`, `getindex()` and
-`setindex!()` for `SparseArray` also makes it possible to [`copy()`](@ref) the array:
+that `SparseArray` is mutable (supports `setindex!`). Defining `similar`, `getindex` and
+`setindex!` for `SparseArray` also makes it possible to [`copy`](@ref) the array:
 
 ```jldoctest squarevectype
 julia> copy(A)

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -191,27 +191,27 @@ ourselves, we can officially define it as a subtype of an [`AbstractArray`](@ref
 
 ## [Abstract Arrays](@id man-interface-array)
 
-| Methods to implement                            |                                          | Brief description                                                                     |
-|:----------------------------------------------- |:---------------------------------------- |:------------------------------------------------------------------------------------- |
-| `size(A)`                                       |                                          | Returns a tuple containing the dimensions of `A`                                      |
-| `getindex(A, i::Int)`                           |                                          | (if `IndexLinear`) Linear scalar indexing                                              |
-| `getindex(A, I::Vararg{Int, N})`                |                                          | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexing                 |
-| `setindex!(A, v, i::Int)`                       |                                          | (if `IndexLinear`) Scalar indexed assignment                                           |
-| `setindex!(A, v, I::Vararg{Int, N})`            |                                          | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexed assignment       |
-| **Optional methods**                            | **Default definition**                   | **Brief description**                                                                 |
-| `IndexStyle(::Type)`                            | `IndexCartesian`                       | Returns either `IndexLinear()` or `IndexCartesian()`. See the description below.      |
+| Methods to implement                            |                                        | Brief description                                                                     |
+|:----------------------------------------------- |:-------------------------------------- |:------------------------------------------------------------------------------------- |
+| `size(A)`                                       |                                        | Returns a tuple containing the dimensions of `A`                                      |
+| `getindex(A, i::Int)`                           |                                        | (if `IndexLinear`) Linear scalar indexing                                             |
+| `getindex(A, I::Vararg{Int, N})`                |                                        | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexing             |
+| `setindex!(A, v, i::Int)`                       |                                        | (if `IndexLinear`) Scalar indexed assignment                                          |
+| `setindex!(A, v, I::Vararg{Int, N})`            |                                        | (if `IndexCartesian`, where `N = ndims(A)`) N-dimensional scalar indexed assignment   |
+| **Optional methods**                            | **Default definition**                 | **Brief description**                                                                 |
+| `IndexStyle(::Type)`                            | `IndexCartesian()`                     | Returns either `IndexLinear()` or `IndexCartesian()`. See the description below.      |
 | `getindex(A, I...)`                             | defined in terms of scalar `getindex`  | [Multidimensional and nonscalar indexing](@ref man-array-indexing)                    |
 | `setindex!(A, I...)`                            | defined in terms of scalar `setindex!` | [Multidimensional and nonscalar indexed assignment](@ref man-array-indexing)          |
 | `start`/`next`/`done`                           | defined in terms of scalar `getindex`  | Iteration                                                                             |
-| `length(A)`                                     | `prod(size(A))`                          | Number of elements                                                                    |
-| `similar(A)`                                    | `similar(A, eltype(A), size(A))`         | Return a mutable array with the same shape and element type                           |
-| `similar(A, ::Type{S})`                         | `similar(A, S, size(A))`                 | Return a mutable array with the same shape and the specified element type             |
-| `similar(A, dims::NTuple{Int})`                 | `similar(A, eltype(A), dims)`            | Return a mutable array with the same element type and size *dims*                     |
-| `similar(A, ::Type{S}, dims::NTuple{Int})`      | `Array{S}(dims)`                         | Return a mutable array with the specified element type and size                       |
-| **Non-traditional indices**                     | **Default definition**                   | **Brief description**                                                                 |
-| `indices(A)`                                    | `map(OneTo, size(A))`                    | Return the `AbstractUnitRange` of valid indices                                       |
-| `Base.similar(A, ::Type{S}, inds::NTuple{Ind})` | `similar(A, S, Base.to_shape(inds))`     | Return a mutable array with the specified indices `inds` (see below)                  |
-| `Base.similar(T::Union{Type,Function}, inds)`   | `T(Base.to_shape(inds))`                 | Return an array similar to `T` with the specified indices `inds` (see below)          |
+| `length(A)`                                     | `prod(size(A))`                        | Number of elements                                                                    |
+| `similar(A)`                                    | `similar(A, eltype(A), size(A))`       | Return a mutable array with the same shape and element type                           |
+| `similar(A, ::Type{S})`                         | `similar(A, S, size(A))`               | Return a mutable array with the same shape and the specified element type             |
+| `similar(A, dims::NTuple{Int})`                 | `similar(A, eltype(A), dims)`          | Return a mutable array with the same element type and size *dims*                     |
+| `similar(A, ::Type{S}, dims::NTuple{Int})`      | `Array{S}(dims)`                       | Return a mutable array with the specified element type and size                       |
+| **Non-traditional indices**                     | **Default definition**                 | **Brief description**                                                                 |
+| `indices(A)`                                    | `map(OneTo, size(A))`                  | Return the `AbstractUnitRange` of valid indices                                       |
+| `Base.similar(A, ::Type{S}, inds::NTuple{Ind})` | `similar(A, S, Base.to_shape(inds))`   | Return a mutable array with the specified indices `inds` (see below)                  |
+| `Base.similar(T::Union{Type,Function}, inds)`   | `T(Base.to_shape(inds))`               | Return an array similar to `T` with the specified indices `inds` (see below)          |
 
 If a type is defined as a subtype of `AbstractArray`, it inherits a very large set of rich behaviors
 including iteration and multidimensional indexing built on top of single-element access.  See

--- a/doc/src/manual/linear-algebra.md
+++ b/doc/src/manual/linear-algebra.md
@@ -175,17 +175,17 @@ as well as whether hooks to various optimized methods for them in LAPACK are ava
 
 ### Elementary operations
 
-| Matrix type               | `+` | `-` | `*` | `\` | Other functions with optimized methods                              |
-|:------------------------- |:--- |:--- |:--- |:--- |:------------------------------------------------------------------- |
-| [`Symmetric`](@ref)       |     |     |     | MV  | [`inv()`](@ref), [`sqrt()`](@ref), [`exp()`](@ref)                |
-| [`Hermitian`](@ref)       |     |     |     | MV  | [`inv()`](@ref), [`sqrt()`](@ref), [`exp()`](@ref)                |
-| [`UpperTriangular`](@ref) |     |     | MV  | MV  | [`inv()`](@ref), [`det()`](@ref)                                    |
-| [`LowerTriangular`](@ref) |     |     | MV  | MV  | [`inv()`](@ref), [`det()`](@ref)                                    |
-| [`SymTridiagonal`](@ref)  | M   | M   | MS  | MV  | [`eigmax()`](@ref), [`eigmin()`](@ref)                              |
-| [`Tridiagonal`](@ref)     | M   | M   | MS  | MV  |                                                                     |
-| [`Bidiagonal`](@ref)      | M   | M   | MS  | MV  |                                                                     |
-| [`Diagonal`](@ref)        | M   | M   | MV  | MV  | [`inv()`](@ref), [`det()`](@ref), [`logdet()`](@ref), [`/()`](@ref) |
-| [`UniformScaling`](@ref)  | M   | M   | MVS | MVS | [`/()`](@ref)                                                       |
+| Matrix type               | `+` | `-` | `*` | `\` | Other functions with optimized methods                      |
+|:------------------------- |:--- |:--- |:--- |:--- |:----------------------------------------------------------- |
+| [`Symmetric`](@ref)       |     |     |     | MV  | [`inv`](@ref), [`sqrt`](@ref), [`exp`](@ref)                |
+| [`Hermitian`](@ref)       |     |     |     | MV  | [`inv`](@ref), [`sqrt`](@ref), [`exp`](@ref)                |
+| [`UpperTriangular`](@ref) |     |     | MV  | MV  | [`inv`](@ref), [`det`](@ref)                                |
+| [`LowerTriangular`](@ref) |     |     | MV  | MV  | [`inv`](@ref), [`det`](@ref)                                |
+| [`SymTridiagonal`](@ref)  | M   | M   | MS  | MV  | [`eigmax`](@ref), [`eigmin`](@ref)                          |
+| [`Tridiagonal`](@ref)     | M   | M   | MS  | MV  |                                                             |
+| [`Bidiagonal`](@ref)      | M   | M   | MS  | MV  |                                                             |
+| [`Diagonal`](@ref)        | M   | M   | MV  | MV  | [`inv`](@ref), [`det`](@ref), [`logdet`](@ref), [`/`](@ref) |
+| [`UniformScaling`](@ref)  | M   | M   | MVS | MVS | [`/`](@ref)                                                 |
 
 Legend:
 
@@ -197,16 +197,16 @@ Legend:
 
 ### Matrix factorizations
 
-| Matrix type               | LAPACK | [`eig()`](@ref) | [`eigvals()`](@ref) | [`eigvecs()`](@ref) | [`svd()`](@ref) | [`svdvals()`](@ref) |
-|:------------------------- |:------ |:--------------- |:------------------- |:------------------- |:--------------- |:------------------- |
-| [`Symmetric`](@ref)       | SY     |                 | ARI                 |                     |                 |                     |
-| [`Hermitian`](@ref)       | HE     |                 | ARI                 |                     |                 |                     |
-| [`UpperTriangular`](@ref) | TR     | A               | A                   | A                   |                 |                     |
-| [`LowerTriangular`](@ref) | TR     | A               | A                   | A                   |                 |                     |
-| [`SymTridiagonal`](@ref)  | ST     | A               | ARI                 | AV                  |                 |                     |
-| [`Tridiagonal`](@ref)     | GT     |                 |                     |                     |                 |                     |
-| [`Bidiagonal`](@ref)      | BD     |                 |                     |                     | A               | A                   |
-| [`Diagonal`](@ref)        | DI     |                 | A                   |                     |                 |                     |
+| Matrix type               | LAPACK | [`eig`](@ref) | [`eigvals`](@ref) | [`eigvecs`](@ref) | [`svd`](@ref) | [`svdvals`](@ref) |
+|:------------------------- |:------ |:------------- |:----------------- |:----------------- |:------------- |:----------------- |
+| [`Symmetric`](@ref)       | SY     |               | ARI               |                   |               |                   |
+| [`Hermitian`](@ref)       | HE     |               | ARI               |                   |               |                   |
+| [`UpperTriangular`](@ref) | TR     | A             | A                 | A                 |               |                   |
+| [`LowerTriangular`](@ref) | TR     | A             | A                 | A                 |               |                   |
+| [`SymTridiagonal`](@ref)  | ST     | A             | ARI               | AV                |               |                   |
+| [`Tridiagonal`](@ref)     | GT     |               |                   |                   |               |                   |
+| [`Bidiagonal`](@ref)      | BD     |               |                   |                   | A             | A                 |
+| [`Diagonal`](@ref)        | DI     |               | A                 |                   |               |                   |
 
 Legend:
 

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -266,7 +266,7 @@ situations like hash key comparisons:
 | [`isinf(x)`](@ref)      | `x` is infinite           |
 | [`isnan(x)`](@ref)      | `x` is not a number       |
 
-[`isequal()`](@ref) considers `NaN`s equal to each other:
+[`isequal`](@ref) considers `NaN`s equal to each other:
 
 ```jldoctest
 julia> isequal(NaN, NaN)
@@ -279,7 +279,7 @@ julia> isequal(NaN, NaN32)
 true
 ```
 
-`isequal()` can also be used to distinguish signed zeros:
+`isequal` can also be used to distinguish signed zeros:
 
 ```jldoctest
 julia> -0.0 == 0.0
@@ -292,9 +292,9 @@ false
 Mixed-type comparisons between signed integers, unsigned integers, and floats can be tricky. A
 great deal of care has been taken to ensure that Julia does them correctly.
 
-For other types, `isequal()` defaults to calling [`==()`](@ref), so if you want to define
-equality for your own types then you only need to add a [`==()`](@ref) method.  If you define
-your own equality function, you should probably define a corresponding [`hash()`](@ref) method
+For other types, `isequal` defaults to calling [`==`](@ref), so if you want to define
+equality for your own types then you only need to add a [`==`](@ref) method.  If you define
+your own equality function, you should probably define a corresponding [`hash`](@ref) method
 to ensure that `isequal(x,y)` implies `hash(x) == hash(y)`.
 
 ### Chaining comparisons
@@ -462,7 +462,7 @@ See [Conversion and Promotion](@ref conversion-and-promotion) for how to define 
 | [`cld(x,y)`](@ref)    | ceiling division; quotient rounded towards `+Inf`                                                         |
 | [`rem(x,y)`](@ref)    | remainder; satisfies `x == div(x,y)*y + rem(x,y)`; sign matches `x`                                       |
 | [`mod(x,y)`](@ref)    | modulus; satisfies `x == fld(x,y)*y + mod(x,y)`; sign matches `y`                                         |
-| [`mod1(x,y)`](@ref)   | `mod()` with offset 1; returns `r∈(0,y]` for `y>0` or `r∈[y,0)` for `y<0`, where `mod(r, y) == mod(x, y)` |
+| [`mod1(x,y)`](@ref)   | `mod` with offset 1; returns `r∈(0,y]` for `y>0` or `r∈[y,0)` for `y<0`, where `mod(r, y) == mod(x, y)` |
 | [`mod2pi(x)`](@ref)   | modulus with respect to 2pi;  `0 <= mod2pi(x)    < 2pi`                                                   |
 | [`divrem(x,y)`](@ref) | returns `(div(x,y),rem(x,y))`                                                                             |
 | [`fldmod(x,y)`](@ref) | returns `(fld(x,y),mod(x,y))`                                                                             |
@@ -498,7 +498,7 @@ See [Conversion and Promotion](@ref conversion-and-promotion) for how to define 
 | [`exponent(x)`](@ref)    | binary exponent of `x`                                                     |
 | [`significand(x)`](@ref) | binary significand (a.k.a. mantissa) of a floating-point number `x`        |
 
-For an overview of why functions like [`hypot()`](@ref), [`expm1()`](@ref), and [`log1p()`](@ref)
+For an overview of why functions like [`hypot`](@ref), [`expm1`](@ref), and [`log1p`](@ref)
 are necessary and useful, see John D. Cook's excellent pair of blog posts on the subject: [expm1, log1p, erfc](https://www.johndcook.com/blog/2010/06/07/math-library-functions-that-seem-unnecessary/),
 and [hypot](https://www.johndcook.com/blog/2010/06/02/whats-so-hard-about-finding-a-hypotenuse/).
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -70,7 +70,7 @@ true
 **The key point here is that Julia code is internally represented as a data structure that is accessible
 from the language itself.**
 
-The [`dump()`](@ref) function provides indented and annotated display of `Expr` objects:
+The [`dump`](@ref) function provides indented and annotated display of `Expr` objects:
 
 ```jldoctest prog
 julia> dump(ex2)
@@ -157,10 +157,10 @@ julia> typeof(ex)
 Expr
 ```
 
-(to view the structure of this expression, try `ex.head` and `ex.args`, or use [`dump()`](@ref)
+(to view the structure of this expression, try `ex.head` and `ex.args`, or use [`dump`](@ref)
 as above or [`Meta.@dump`](@ref))
 
-Note that equivalent expressions may be constructed using [`parse()`](@ref) or the direct `Expr`
+Note that equivalent expressions may be constructed using [`parse`](@ref) or the direct `Expr`
 form:
 
 ```jldoctest
@@ -243,10 +243,10 @@ The use of `$` for expression interpolation is intentionally reminiscent of [str
 and [command interpolation](@ref command-interpolation). Expression interpolation allows convenient, readable programmatic
 construction of complex Julia expressions.
 
-### [`eval()`](@ref) and effects
+### [`eval`](@ref) and effects
 
 Given an expression object, one can cause Julia to evaluate (execute) it at global scope using
-[`eval()`](@ref):
+[`eval`](@ref):
 
 ```jldoctest interp1
 julia> :(1 + 2)
@@ -268,8 +268,8 @@ julia> eval(ex)
 3
 ```
 
-Every [module](@ref modules) has its own [`eval()`](@ref) function that evaluates expressions in its global
-scope. Expressions passed to [`eval()`](@ref) are not limited to returning values -- they can
+Every [module](@ref modules) has its own [`eval`](@ref) function that evaluates expressions in its global
+scope. Expressions passed to [`eval`](@ref) are not limited to returning values -- they can
 also have side-effects that alter the state of the enclosing module's environment:
 
 ```jldoctest
@@ -290,7 +290,7 @@ Here, the evaluation of an expression object causes a value to be assigned to th
 `x`.
 
 Since expressions are just `Expr` objects which can be constructed programmatically and then evaluated,
-it is possible to dynamically generate arbitrary code which can then be run using [`eval()`](@ref).
+it is possible to dynamically generate arbitrary code which can then be run using [`eval`](@ref).
 Here is a simple example:
 
 ```julia-repl
@@ -320,7 +320,7 @@ value 1 and the variable `b`. Note the important distinction between the way `a`
 
 As hinted above, one extremely useful feature of Julia is the capability to generate and manipulate
 Julia code within Julia itself. We have already seen one example of a function returning `Expr`
-objects: the [`parse()`](@ref) function, which takes a string of Julia code and returns the corresponding
+objects: the [`parse`](@ref) function, which takes a string of Julia code and returns the corresponding
 `Expr`. A function can also take one or more `Expr` objects as arguments, and return another
 `Expr`. Here is a simple, motivating example:
 
@@ -363,7 +363,7 @@ julia> eval(ex)
 
 Macros provide a method to include generated code in the final body of a program. A macro maps
 a tuple of arguments to a returned *expression*, and the resulting expression is compiled directly
-rather than requiring a runtime [`eval()`](@ref) call. Macro arguments may include expressions,
+rather than requiring a runtime [`eval`](@ref) call. Macro arguments may include expressions,
 literal values, and symbols.
 
 ### Basics
@@ -410,7 +410,7 @@ julia> @sayhello("human")
 Hello, human
 ```
 
-We can view the quoted return expression using the function [`macroexpand()`](@ref) (**important note:**
+We can view the quoted return expression using the function [`macroexpand`](@ref) (**important note:**
 this is an extremely useful tool for debugging macros):
 
 ```julia-repl sayhello2
@@ -433,7 +433,7 @@ julia> @macroexpand @sayhello "human"
 
 ### Hold up: why macros?
 
-We have already seen a function `f(::Expr...) -> Expr` in a previous section. In fact, [`macroexpand()`](@ref)
+We have already seen a function `f(::Expr...) -> Expr` in a previous section. In fact, [`macroexpand`](@ref)
 is also such a function. So, why do macros exist?
 
 Macros are necessary because they execute when code is parsed, therefore, macros allow the programmer
@@ -451,7 +451,7 @@ julia> ex = macroexpand(Main, :(@twostep :(1, 2, 3)) );
 I execute at parse time. The argument is: $(Expr(:quote, :((1, 2, 3))))
 ```
 
-The first call to [`println()`](@ref) is executed when [`macroexpand()`](@ref) is called. The
+The first call to [`println`](@ref) is executed when [`macroexpand`](@ref) is called. The
 resulting expression contains *only* the second `println`:
 
 ```julia-repl whymacros
@@ -484,7 +484,7 @@ above; it passes the tuple `(expr1, expr2, ...)` as one argument to the macro:
 ```
 
 It is important to emphasize that macros receive their arguments as expressions, literals, or
-symbols. One way to explore macro arguments is to call the [`show()`](@ref) function within the
+symbols. One way to explore macro arguments is to call the [`show`](@ref) function within the
 macro body:
 
 ```jldoctest
@@ -610,7 +610,7 @@ There is yet another case that the actual `@assert` macro handles: what if, in a
 "a should equal b," we wanted to print their values? One might naively try to use string interpolation
 in the custom message, e.g., `@assert a==b "a ($a) should equal b ($b)!"`, but this won't work
 as expected with the above macro. Can you see why? Recall from [string interpolation](@ref string-interpolation) that
-an interpolated string is rewritten to a call to [`string()`](@ref). Compare:
+an interpolated string is rewritten to a call to [`string`](@ref). Compare:
 
 ```jldoctest
 julia> typeof(:("a should equal b"))
@@ -633,7 +633,7 @@ Expr
 
 So now instead of getting a plain string in `msg_body`, the macro is receiving a full expression
 that will need to be evaluated in order to display as expected. This can be spliced directly into
-the returned expression as an argument to the [`string()`](@ref) call; see [`error.jl`](https://github.com/JuliaLang/julia/blob/master/base/error.jl)
+the returned expression as an argument to the [`string`](@ref) call; see [`error.jl`](https://github.com/JuliaLang/julia/blob/master/base/error.jl)
 for the complete implementation.
 
 The `@assert` macro makes great use of splicing into quoted expressions to simplify the manipulation
@@ -670,7 +670,7 @@ end
 ```
 
 Here, we want `t0`, `t1`, and `val` to be private temporary variables, and we want `time` to refer
-to the [`time()`](@ref) function in the standard library, not to any `time` variable the user
+to the [`time`](@ref) function in the standard library, not to any `time` variable the user
 might have (the same applies to `println`). Imagine the problems that could occur if the user
 expression `ex` also contained assignments to a variable called `t0`, or defined its own `time`
 variable. We might get errors, or mysteriously incorrect behavior.
@@ -678,7 +678,7 @@ variable. We might get errors, or mysteriously incorrect behavior.
 Julia's macro expander solves these problems in the following way. First, variables within a macro
 result are classified as either local or global. A variable is considered local if it is assigned
 to (and not declared global), declared local, or used as a function argument name. Otherwise,
-it is considered global. Local variables are then renamed to be unique (using the [`gensym()`](@ref)
+it is considered global. Local variables are then renamed to be unique (using the [`gensym`](@ref)
 function, which generates new symbols), and global variables are resolved within the macro definition
 environment. Therefore both of the above concerns are handled; the macro's locals will not conflict
 with any user variables, and `time` and `println` will refer to the standard library definitions.
@@ -697,7 +697,7 @@ end
 
 Here the user expression `ex` is a call to `time`, but not the same `time` function that the macro
 uses. It clearly refers to `MyModule.time`. Therefore we must arrange for the code in `ex` to
-be resolved in the macro call environment. This is done by "escaping" the expression with [`esc()`](@ref):
+be resolved in the macro call environment. This is done by "escaping" the expression with [`esc`](@ref):
 
 ```julia
 macro time(ex)
@@ -763,7 +763,7 @@ while we want `@time` to be usable with minimum impact on the wrapped code.
 When a significant amount of repetitive boilerplate code is required, it is common to generate
 it programmatically to avoid redundancy. In most languages, this requires an extra build step,
 and a separate program to generate the repetitive code. In Julia, expression interpolation and
-[`eval()`](@ref) allow such code generation to take place in the normal course of program execution.
+[`eval`](@ref) allow such code generation to take place in the normal course of program execution.
 For example, the following code defines a series of operators on three arguments in terms of their
 2-argument forms:
 
@@ -984,9 +984,9 @@ performance optimization, so it is invalid to depend too closely on this behavio
 The number of times a generated function is generated *might* be only once, but it *might* also
 be more often, or appear to not happen at all. As a consequence, you should *never* write a generated
 function with side effects - when, and how often, the side effects occur is undefined. (This is
-true for macros too - and just like for macros, the use of [`eval()`](@ref) in a generated function
+true for macros too - and just like for macros, the use of [`eval`](@ref) in a generated function
 is a sign that you're doing something the wrong way.) However, unlike macros, the runtime system
-cannot correctly handle a call to [`eval()`](@ref), so it is disallowed.
+cannot correctly handle a call to [`eval`](@ref), so it is disallowed.
 
 It is also important to see how `@generated` functions interact with method redefinition.
 Following the principle that a correct `@generated` function must not observe any
@@ -1119,7 +1119,7 @@ to build some more advanced (and valid) functionality...
 
 ### An advanced example
 
-Julia's base library has a [`sub2ind()`](@ref) function to calculate a linear index into an n-dimensional
+Julia's base library has a [`sub2ind`](@ref) function to calculate a linear index into an n-dimensional
 array, based on a set of n multilinear indices - in other words, to calculate the index `i` that
 can be used to index into an array `A` using `A[i]`, instead of `A[x,y,z,...]`. One possible implementation
 is the following:

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -163,7 +163,7 @@ f (generic function with 2 methods)
 ```
 
 This output tells us that `f` is a function object with two methods. To find out what the signatures
-of those methods are, use the [`methods()`](@ref) function:
+of those methods are, use the [`methods`](@ref) function:
 
 ```julia-repl
 julia> methods(f)
@@ -453,7 +453,7 @@ This monotonically increasing value tracks each method definition operation.
 This allows describing "the set of method definitions visible to a given runtime environment"
 as a single number, or "world age".
 It also allows comparing the methods available in two worlds just by comparing their ordinal value.
-In the example above, we see that the "current world" (in which the method `newfun()` exists),
+In the example above, we see that the "current world" (in which the method `newfun` exists),
 is one greater than the task-local "runtime world" that was fixed when the execution of `tryeval` started.
 
 Sometimes it is necessary to get around this (for example, if you are implementing the above REPL).

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -361,7 +361,7 @@ code to help the user avoid other wrong-behavior situations:
    emitted when the incremental precompile flag is set.
 2. `global const` statements from local scope after `__init__()` has been started (see issue #12010
    for plans to add an error for this)
-3. Replacing a module (or calling [`workspace()`](@ref)) is a runtime error while doing an incremental precompile.
+3. Replacing a module (or calling [`workspace`](@ref)) is a runtime error while doing an incremental precompile.
 
 A few other points to be aware of:
 
@@ -384,7 +384,7 @@ A few other points to be aware of:
 It is sometimes helpful during module development to turn off incremental precompilation. The
 command line flag `--compilecache={yes|no}` enables you to toggle module precompilation on and
 off. When Julia is started with `--compilecache=no` the serialized modules in the compile cache
-are ignored when loading modules and module dependencies. `Base.compilecache()` can still be called
+are ignored when loading modules and module dependencies. `Base.compilecache` can still be called
 manually and it will respect `__precompile__()` directives for the module. The state of this command
-line flag is passed to [`Pkg.build()`](@ref) to disable automatic precompilation triggering when installing,
+line flag is passed to [`Pkg.build`](@ref) to disable automatic precompilation triggering when installing,
 updating, and explicitly building packages.

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -361,7 +361,7 @@ code to help the user avoid other wrong-behavior situations:
    emitted when the incremental precompile flag is set.
 2. `global const` statements from local scope after `__init__()` has been started (see issue #12010
    for plans to add an error for this)
-3. Replacing a module (or calling [`workspace`](@ref)) is a runtime error while doing an incremental precompile.
+3. Replacing a module (or calling [`workspace()`](@ref)) is a runtime error while doing an incremental precompile.
 
 A few other points to be aware of:
 

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -8,7 +8,7 @@ functionality.
 
 ## Basic Stream I/O
 
-All Julia streams expose at least a [`read()`](@ref) and a [`write()`](@ref) method, taking the
+All Julia streams expose at least a [`read`](@ref) and a [`write`](@ref) method, taking the
 stream as their first argument, e.g.:
 
 ```julia-repl
@@ -19,11 +19,11 @@ julia> read(STDIN,Char)
 '\n': ASCII/Unicode U+000a (category Cc: Other, control)
 ```
 
-Note that [`write()`](@ref) returns 11, the number of bytes (in `"Hello World"`) written to [`STDOUT`](@ref),
+Note that [`write`](@ref) returns 11, the number of bytes (in `"Hello World"`) written to [`STDOUT`](@ref),
 but this return value is suppressed with the `;`.
 
 Here Enter was pressed again so that Julia would read the newline. Now, as you can see from this
-example, [`write()`](@ref) takes the data to write as its second argument, while [`read()`](@ref)
+example, [`write`](@ref) takes the data to write as its second argument, while [`read`](@ref)
 takes the type of the data to be read as the second argument.
 
 For example, to read a simple byte array, we could do:
@@ -69,7 +69,7 @@ abcd
 Note that depending on your terminal settings, your TTY may be line buffered and might thus require
 an additional enter before the data is sent to Julia.
 
-To read every line from [`STDIN`](@ref) you can use [`eachline()`](@ref):
+To read every line from [`STDIN`](@ref) you can use [`eachline`](@ref):
 
 ```julia
 for line in eachline(STDIN)
@@ -77,7 +77,7 @@ for line in eachline(STDIN)
 end
 ```
 
-or [`read()`](@ref) if you wanted to read by character instead:
+or [`read`](@ref) if you wanted to read by character instead:
 
 ```julia
 while !eof(STDIN)
@@ -88,7 +88,7 @@ end
 
 ## Text I/O
 
-Note that the [`write()`](@ref) method mentioned above operates on binary streams. In particular,
+Note that the [`write`](@ref) method mentioned above operates on binary streams. In particular,
 values do not get converted to any canonical text representation but are written out as is:
 
 ```jldoctest
@@ -96,10 +96,10 @@ julia> write(STDOUT,0x61);  # suppress return value 1 with ;
 a
 ```
 
-Note that `a` is written to [`STDOUT`](@ref) by the [`write()`](@ref) function and that the returned
+Note that `a` is written to [`STDOUT`](@ref) by the [`write`](@ref) function and that the returned
 value is `1` (since `0x61` is one byte).
 
-For text I/O, use the [`print()`](@ref) or [`show()`](@ref) methods, depending on your needs (see
+For text I/O, use the [`print`](@ref) or [`show`](@ref) methods, depending on your needs (see
 the standard library reference for a detailed discussion of the difference between the two):
 
 ```jldoctest
@@ -116,7 +116,7 @@ should print a shorter output (if applicable).
 
 ## Working with Files
 
-Like many other environments, Julia has an [`open()`](@ref) function, which takes a filename and
+Like many other environments, Julia has an [`open`](@ref) function, which takes a filename and
 returns an `IOStream` object that you can use to read and write things from the file. For example
 if we have a file, `hello.txt`, whose contents are `Hello, World!`:
 
@@ -150,7 +150,7 @@ julia> close(f)
 Examining `hello.txt` again will show its contents have been changed.
 
 Opening a file, doing something to its contents, and closing it again is a very common pattern.
-To make this easier, there exists another invocation of [`open()`](@ref) which takes a function
+To make this easier, there exists another invocation of [`open`](@ref) which takes a function
 as its first argument and filename as its second, opens the file, calls the function with the
 file as an argument, and then closes it again. For example, given a function:
 
@@ -196,7 +196,7 @@ Task (runnable) @0x00007fd31dc11ae0
 ```
 
 To those familiar with the Unix socket API, the method names will feel familiar, though their
-usage is somewhat simpler than the raw Unix socket API. The first call to [`listen()`](@ref) will
+usage is somewhat simpler than the raw Unix socket API. The first call to [`listen`](@ref) will
 create a server waiting for incoming connections on the specified port (2000) in this case. The
 same function may also be used to create various other kinds of servers:
 
@@ -228,12 +228,12 @@ listen on TCP, but rather on a named pipe (Windows) or UNIX domain socket. Also 
 named pipe format has to be a specific pattern such that the name prefix (`\\.\pipe\`) uniquely
 identifies the [file type](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365783(v=vs.85).aspx).
 The difference between TCP and named pipes or
-UNIX domain sockets is subtle and has to do with the [`accept()`](@ref) and [`connect()`](@ref)
-methods. The [`accept()`](@ref) method retrieves a connection to the client that is connecting on
-the server we just created, while the [`connect()`](@ref) function connects to a server using the
-specified method. The [`connect()`](@ref) function takes the same arguments as [`listen()`](@ref),
+UNIX domain sockets is subtle and has to do with the [`accept`](@ref) and [`connect`](@ref)
+methods. The [`accept`](@ref) method retrieves a connection to the client that is connecting on
+the server we just created, while the [`connect`](@ref) function connects to a server using the
+specified method. The [`connect`](@ref) function takes the same arguments as [`listen`](@ref),
 so, assuming the environment (i.e. host, cwd, etc.) is the same you should be able to pass the same
-arguments to [`connect()`](@ref) as you did to listen to establish the connection. So let's try that
+arguments to [`connect`](@ref) as you did to listen to establish the connection. So let's try that
 out (after having created the server above):
 
 ```julia-repl
@@ -244,13 +244,13 @@ julia> Hello World
 ```
 
 As expected we saw "Hello World" printed. So, let's actually analyze what happened behind the
-scenes. When we called [`connect()`](@ref), we connect to the server we had just created. Meanwhile,
+scenes. When we called [`connect`](@ref), we connect to the server we had just created. Meanwhile,
 the accept function returns a server-side connection to the newly created socket and prints "Hello
 World" to indicate that the connection was successful.
 
 A great strength of Julia is that since the API is exposed synchronously even though the I/O is
 actually happening asynchronously, we didn't have to worry callbacks or even making sure that
-the server gets to run. When we called [`connect()`](@ref) the current task waited for the connection
+the server gets to run. When we called [`connect`](@ref) the current task waited for the connection
 to be established and only continued executing after that was done. In this pause, the server
 task resumed execution (because a connection request was now available), accepted the connection,
 printed the message and waited for the next client. Reading and writing works in the same way.
@@ -280,7 +280,7 @@ julia> println(clientside,"Hello World from the Echo Server")
 Hello World from the Echo Server
 ```
 
-As with other streams, use [`close()`](@ref) to disconnect the socket:
+As with other streams, use [`close`](@ref) to disconnect the socket:
 
 ```julia-repl
 julia> close(clientside)
@@ -288,7 +288,7 @@ julia> close(clientside)
 
 ## Resolving IP Addresses
 
-One of the [`connect()`](@ref) methods that does not follow the [`listen()`](@ref) methods is
+One of the [`connect`](@ref) methods that does not follow the [`listen`](@ref) methods is
 `connect(host::String,port)`, which will attempt to connect to the host given by the `host` parameter
 on the port given by the port parameter. It allows you to do things like:
 
@@ -297,7 +297,7 @@ julia> connect("google.com",80)
 TCPSocket(RawFD(30) open, 0 bytes waiting)
 ```
 
-At the base of this functionality is [`getaddrinfo()`](@ref), which will do the appropriate address
+At the base of this functionality is [`getaddrinfo`](@ref), which will do the appropriate address
 resolution:
 
 ```julia-repl

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -14,7 +14,7 @@ may trip up Julia users accustomed to MATLAB:
   * Julia does not automatically grow arrays in an assignment statement. Whereas in MATLAB `a(4) = 3.2`
     can create the array `a = [0 0 0 3.2]` and `a(5) = 7` can grow it into `a = [0 0 0 3.2 7]`, the
     corresponding Julia statement `a[5] = 7` throws an error if the length of `a` is less than 5 or
-    if this statement is the first use of the identifier `a`. Julia has [`push!()`](@ref) and [`append!()`](@ref),
+    if this statement is the first use of the identifier `a`. Julia has [`push!`](@ref) and [`append!`](@ref),
     which grow `Vector`s much more efficiently than MATLAB's `a(end+1) = val`.
   * The imaginary unit `sqrt(-1)` is represented in Julia as [`im`](@ref), not `i` or `j` as in MATLAB.
   * In Julia, literal numbers without a decimal point (such as `42`) create integers instead of floating
@@ -32,7 +32,7 @@ may trip up Julia users accustomed to MATLAB:
       with semicolons (`[x; y; z]`).
     - To concatenate in the second ("horizontal") dimension use either [`hcat(x,y,z)`](@ref) or separate
       with spaces (`[x y z]`).
-    - To construct block matrices (concatenating in the first two dimensions), use either [`hvcat()`](@ref)
+    - To construct block matrices (concatenating in the first two dimensions), use either [`hvcat`](@ref)
       or combine spaces and semicolons (`[a b; c d]`).
   * In Julia, `a:b` and `a:b:c` construct `Range` objects. To construct a full vector like in MATLAB,
     use [`collect(a:b)`](@ref). Generally, there is no need to call `collect` though. `Range` will
@@ -46,17 +46,17 @@ may trip up Julia users accustomed to MATLAB:
   * A Julia script may contain any number of functions, and all definitions will be externally visible
     when the file is loaded. Function definitions can be loaded from files outside the current working
     directory.
-  * In Julia, reductions such as [`sum()`](@ref), [`prod()`](@ref), and [`max()`](@ref) are performed
+  * In Julia, reductions such as [`sum`](@ref), [`prod`](@ref), and [`max`](@ref) are performed
     over every element of an array when called with a single argument, as in `sum(A)`, even if `A`
     has more than one dimension.
-  * In Julia, functions such as [`sort()`](@ref) that operate column-wise by default (`sort(A)` is
+  * In Julia, functions such as [`sort`](@ref) that operate column-wise by default (`sort(A)` is
     equivalent to `sort(A,1)`) do not have special behavior for `1xN` arrays; the argument is returned
     unmodified since it still performs `sort(A,1)`. To sort a `1xN` matrix like a vector, use `sort(A,2)`.
   * In Julia, parentheses must be used to call a function with zero arguments, like in [`tic()`](@ref)
     and [`toc()`](@ref).
   * Julia discourages the used of semicolons to end statements. The results of statements are not
     automatically printed (except at the interactive prompt), and lines of code do not need to end
-    with semicolons. [`println()`](@ref) or [`@printf()`](@ref) can be used to print specific output.
+    with semicolons. [`println`](@ref) or [`@printf`](@ref) can be used to print specific output.
   * In Julia, if `A` and `B` are arrays, logical comparison operations like `A == B` do not return
     an array of booleans. Instead, use `A .== B`, and similarly for the other boolean operators like
     [`<`](@ref), [`>`](@ref) and `=`.
@@ -67,7 +67,7 @@ may trip up Julia users accustomed to MATLAB:
     parentheses may be required (e.g., to select elements of `A` equal to 1 or 2 use `(A .== 1) | (A .== 2)`).
   * In Julia, the elements of a collection can be passed as arguments to a function using the splat
     operator `...`, as in `xs=[1,2]; f(xs...)`.
-  * Julia's [`svd()`](@ref) returns singular values as a vector instead of as a dense diagonal matrix.
+  * Julia's [`svd`](@ref) returns singular values as a vector instead of as a dense diagonal matrix.
   * In Julia, `...` is not used to continue lines of code. Instead, incomplete expressions automatically
     continue onto the next line.
   * In both Julia and MATLAB, the variable `ans` is set to the value of the last expression issued
@@ -79,9 +79,9 @@ may trip up Julia users accustomed to MATLAB:
     scope.
   * In MATLAB, an idiomatic way to remove unwanted values is to use logical indexing, like in the
     expression `x(x>3)` or in the statement `x(x>3) = []` to modify `x` in-place. In contrast, Julia
-    provides the higher order functions [`filter()`](@ref) and [`filter!()`](@ref), allowing users
+    provides the higher order functions [`filter`](@ref) and [`filter!`](@ref), allowing users
     to write `filter(z->z>3, x)` and `filter!(z->z>3, x)` as alternatives to the corresponding transliterations
-    `x[x.>3]` and `x = x[x.>3]`. Using [`filter!()`](@ref) reduces the use of temporary arrays.
+    `x[x.>3]` and `x = x[x.>3]`. Using [`filter!`](@ref) reduces the use of temporary arrays.
   * The analogue of extracting (or "dereferencing") all elements of a cell array, e.g. in `vertcat(A{:})`
     in MATLAB, is written using the splat operator in Julia, e.g. as `vcat(A...)`.
 
@@ -108,8 +108,8 @@ For users coming to Julia from R, these are some noteworthy differences:
   * Like many languages, Julia does not always allow operations on vectors of different lengths, unlike
     R where the vectors only need to share a common index range.  For example, `c(1, 2, 3, 4) + c(1, 2)`
     is valid R but the equivalent `[1, 2, 3, 4] + [1, 2]` will throw an error in Julia.
-  * Julia's [`map()`](@ref) takes the function first, then its arguments, unlike `lapply(<structure>, function, ...)`
-    in R. Similarly Julia's equivalent of `apply(X, MARGIN, FUN, ...)` in R is [`mapslices()`](@ref)
+  * Julia's [`map`](@ref) takes the function first, then its arguments, unlike `lapply(<structure>, function, ...)`
+    in R. Similarly Julia's equivalent of `apply(X, MARGIN, FUN, ...)` in R is [`mapslices`](@ref)
     where the function is the first argument.
   * Multivariate apply in R, e.g. `mapply(choose, 11:13, 1:3)`, can be written as `broadcast(binomial, 11:13, 1:3)`
     in Julia. Equivalently Julia offers a shorter dot syntax for vectorizing functions `binomial.(11:13, 1:3)`.
@@ -136,7 +136,7 @@ For users coming to Julia from R, these are some noteworthy differences:
   * Julia is careful to distinguish scalars, vectors and matrices.  In R, `1` and `c(1)` are the same.
     In Julia, they can not be used interchangeably. One potentially confusing result of this is that
     `x' * y` for vectors `x` and `y` is a 1-element vector, not a scalar. To get a scalar, use [`dot(x, y)`](@ref).
-  * Julia's [`diag()`](@ref) and [`diagm()`](@ref) are not like R's.
+  * Julia's [`diag`](@ref) and [`diagm`](@ref) are not like R's.
   * Julia cannot assign to the results of function calls on the left hand side of an assignment operation:
     you cannot write `diag(M) = ones(n)`.
   * Julia discourages populating the main namespace with functions. Most statistical functionality
@@ -154,15 +154,15 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, values are passed and assigned by reference. If a function modifies an array, the changes
     will be visible in the caller. This is very different from R and allows new functions to operate
     on large data structures much more efficiently.
-  * In Julia, vectors and matrices are concatenated using [`hcat()`](@ref), [`vcat()`](@ref) and
-    [`hvcat()`](@ref), not `c`, `rbind` and `cbind` like in R.
+  * In Julia, vectors and matrices are concatenated using [`hcat`](@ref), [`vcat`](@ref) and
+    [`hvcat`](@ref), not `c`, `rbind` and `cbind` like in R.
   * In Julia, a range like `a:b` is not shorthand for a vector like in R, but is a specialized `Range`
     that is used for iteration without high memory overhead. To convert a range into a vector, use
     [`collect(a:b)`](@ref).
-  * Julia's [`max()`](@ref) and [`min()`](@ref) are the equivalent of `pmax` and `pmin` respectively
-    in R, but both arguments need to have the same dimensions.  While [`maximum()`](@ref) and [`minimum()`](@ref)
+  * Julia's [`max`](@ref) and [`min`](@ref) are the equivalent of `pmax` and `pmin` respectively
+    in R, but both arguments need to have the same dimensions.  While [`maximum`](@ref) and [`minimum`](@ref)
     replace `max` and `min` in R, there are important differences.
-  * Julia's [`sum()`](@ref), [`prod()`](@ref), [`maximum()`](@ref), and [`minimum()`](@ref) are different
+  * Julia's [`sum`](@ref), [`prod`](@ref), [`maximum`](@ref), and [`minimum`](@ref) are different
     from their counterparts in R. They all accept one or two arguments. The first argument is an iterable
     collection such as an array.  If there is a second argument, then this argument indicates the
     dimensions, over which the operation is carried out.  For instance, let `A=[[1 2],[3 4]]` in Julia
@@ -172,8 +172,8 @@ For users coming to Julia from R, these are some noteworthy differences:
     `sum(B,1)=11` and `sum(B,2)=12`.  If the second argument is a vector, then it specifies all the
     dimensions over which the sum is performed, e.g., `sum(A,[1,2])=10`.  It should be noted that
     there is no error checking regarding the second argument.
-  * Julia has several functions that can mutate their arguments. For example, it has both [`sort()`](@ref)
-    and [`sort!()`](@ref).
+  * Julia has several functions that can mutate their arguments. For example, it has both [`sort`](@ref)
+    and [`sort!`](@ref).
   * In R, performance requires vectorization. In Julia, almost the opposite is true: the best performing
     code is often achieved by using devectorized loops.
   * Julia is eagerly evaluated and does not support R-style lazy evaluation. For most users, this
@@ -183,9 +183,9 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, `return` does not require parentheses.
   * In R, an idiomatic way to remove unwanted values is to use logical indexing, like in the expression
     `x[x>3]` or in the statement `x = x[x>3]` to modify `x` in-place. In contrast, Julia provides
-    the higher order functions [`filter()`](@ref) and [`filter!()`](@ref), allowing users to write
+    the higher order functions [`filter`](@ref) and [`filter!`](@ref), allowing users to write
     `filter(z->z>3, x)` and `filter!(z->z>3, x)` as alternatives to the corresponding transliterations
-    `x[x.>3]` and `x = x[x.>3]`. Using [`filter!()`](@ref) reduces the use of temporary arrays.
+    `x[x.>3]` and `x = x[x.>3]`. Using [`filter!`](@ref) reduces the use of temporary arrays.
 
 ## Noteworthy differences from Python
 
@@ -257,7 +257,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     C/C++ (i.e. `a = myfunction(&b)`.
   * Julia does not require the use of semicolons to end statements. The results of expressions are
     not automatically printed (except at the interactive prompt, i.e. the REPL), and lines of code
-    do not need to end with semicolons. [`println()`](@ref) or [`@printf()`](@ref) can be used to
+    do not need to end with semicolons. [`println`](@ref) or [`@printf`](@ref) can be used to
     print specific output. In the REPL, `;` can be used to suppress output. `;` also has a different
     meaning within `[ ]`, something to watch out for. `;` can be used to separate expressions on a
     single line, but are not strictly necessary in many cases, and are more an aid to readability.

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -26,8 +26,8 @@ Remote references come in two flavors: [`Future`](@ref) and [`RemoteChannel`](@r
 
 A remote call returns a [`Future`](@ref) to its result. Remote calls return immediately; the process
 that made the call proceeds to its next operation while the remote call happens somewhere else.
-You can wait for a remote call to finish by calling [`wait()`](@ref) on the returned [`Future`](@ref),
-and you can obtain the full value of the result using [`fetch()`](@ref).
+You can wait for a remote call to finish by calling [`wait`](@ref) on the returned [`Future`](@ref),
+and you can obtain the full value of the result using [`fetch`](@ref).
 
 On the other hand, [`RemoteChannel`](@ref) s are rewritable. For example, multiple processes can
 co-ordinate their processing by referencing the same remote `Channel`.
@@ -55,9 +55,9 @@ julia> fetch(s)
  1.16296  1.60607
 ```
 
-The first argument to [`remotecall()`](@ref) is the function to call. Most parallel programming
-in Julia does not reference specific processes or the number of processes available, but [`remotecall()`](@ref)
-is considered a low-level interface providing finer control. The second argument to [`remotecall()`](@ref)
+The first argument to [`remotecall`](@ref) is the function to call. Most parallel programming
+in Julia does not reference specific processes or the number of processes available, but [`remotecall`](@ref)
+is considered a low-level interface providing finer control. The second argument to [`remotecall`](@ref)
 is the `id` of the process that will do the work, and the remaining arguments will be passed to
 the function being called.
 
@@ -68,7 +68,7 @@ argument on the process specified by the first argument.
 
 Occasionally you might want a remotely-computed value immediately. This typically happens when
 you read from a remote object to obtain data needed by the next local operation. The function
-[`remotecall_fetch()`](@ref) exists for this purpose. It is equivalent to `fetch(remotecall(...))`
+[`remotecall_fetch`](@ref) exists for this purpose. It is equivalent to `fetch(remotecall(...))`
 but is more efficient.
 
 ```julia-repl
@@ -79,7 +79,7 @@ julia> remotecall_fetch(getindex, 2, r, 1, 1)
 Remember that [`getindex(r,1,1)`](@ref) is [equivalent](@ref man-array-indexing) to `r[1,1]`, so this call fetches
 the first element of the future `r`.
 
-The syntax of [`remotecall()`](@ref) is not especially convenient. The macro [`@spawn`](@ref)
+The syntax of [`remotecall`](@ref) is not especially convenient. The macro [`@spawn`](@ref)
 makes things easier. It operates on an expression rather than a function, and picks where to do
 the operation for you:
 
@@ -97,15 +97,15 @@ julia> fetch(s)
 ```
 
 Note that we used `1 .+ fetch(r)` instead of `1 .+ r`. This is because we do not know where the
-code will run, so in general a [`fetch()`](@ref) might be required to move `r` to the process
+code will run, so in general a [`fetch`](@ref) might be required to move `r` to the process
 doing the addition. In this case, [`@spawn`](@ref) is smart enough to perform the computation
-on the process that owns `r`, so the [`fetch()`](@ref) will be a no-op (no work is done).
+on the process that owns `r`, so the [`fetch`](@ref) will be a no-op (no work is done).
 
 (It is worth noting that [`@spawn`](@ref) is not built-in but defined in Julia as a [macro](@ref man-macros).
 It is possible to define your own such constructs.)
 
 An important thing to remember is that, once fetched, a [`Future`](@ref) will cache its value
-locally. Further [`fetch()`](@ref) calls do not entail a network hop. Once all referencing [`Future`](@ref)s
+locally. Further [`fetch`](@ref) calls do not entail a network hop. Once all referencing [`Future`](@ref)s
 have fetched, the remote stored value is deleted.
 
 ## Code Availability and Loading Packages
@@ -192,7 +192,7 @@ The base Julia installation has in-built support for two types of clusters:
   * A cluster spanning machines using the `--machinefile` option. This uses a passwordless `ssh` login
     to start Julia worker processes (from the same path as the current host) on the specified machines.
 
-Functions [`addprocs()`](@ref), [`rmprocs()`](@ref), [`workers()`](@ref), and others are available
+Functions [`addprocs`](@ref), [`rmprocs`](@ref), [`workers`](@ref), and others are available
 as a programmatic means of adding, removing and querying the processes in a cluster.
 
 Note that workers do not run a `.juliarc.jl` startup script, nor do they synchronize their global
@@ -209,7 +209,7 @@ the number of messages and the amount of data sent is critical to achieving perf
 To this end, it is important to understand the data movement performed by Julia's various parallel
 programming constructs.
 
-[`fetch()`](@ref) can be considered an explicit data movement operation, since it directly asks
+[`fetch`](@ref) can be considered an explicit data movement operation, since it directly asks
 that an object be moved to the local machine. [`@spawn`](@ref) (and a few related constructs)
 also moves data, but this is not as obvious, hence it can be called an implicit data movement
 operation. Consider these two approaches to constructing and squaring a random matrix:
@@ -420,12 +420,12 @@ Here each iteration applies `f` to a randomly-chosen sample from a vector `a` sh
 As you could see, the reduction operator can be omitted if it is not needed. In that case, the
 loop executes asynchronously, i.e. it spawns independent tasks on all available workers and returns
 an array of [`Future`](@ref) immediately without waiting for completion. The caller can wait for
-the [`Future`](@ref) completions at a later point by calling [`fetch()`](@ref) on them, or wait
+the [`Future`](@ref) completions at a later point by calling [`fetch`](@ref) on them, or wait
 for completion at the end of the loop by prefixing it with [`@sync`](@ref), like `@sync @parallel for`.
 
 In some cases no reduction operator is needed, and we merely wish to apply a function to all integers
 in some range (or, more generally, to all elements in some collection). This is another useful
-operation called *parallel map*, implemented in Julia as the [`pmap()`](@ref) function. For example,
+operation called *parallel map*, implemented in Julia as the [`pmap`](@ref) function. For example,
 we could compute the singular values of several large random matrices in parallel as follows:
 
 ```julia-repl
@@ -434,9 +434,9 @@ julia> M = Matrix{Float64}[rand(1000,1000) for i = 1:10];
 julia> pmap(svd, M);
 ```
 
-Julia's [`pmap()`](@ref) is designed for the case where each function call does a large amount
+Julia's [`pmap`](@ref) is designed for the case where each function call does a large amount
 of work. In contrast, `@parallel for` can handle situations where each iteration is tiny, perhaps
-merely summing two numbers. Only worker processes are used by both [`pmap()`](@ref) and `@parallel for`
+merely summing two numbers. Only worker processes are used by both [`pmap`](@ref) and `@parallel for`
 for the parallel computation. In case of `@parallel for`, the final reduction is done on the calling
 process.
 
@@ -445,7 +445,7 @@ process.
 ## Scheduling
 
 Julia's parallel programming platform uses [Tasks (aka Coroutines)](@ref man-tasks) to switch among multiple
-computations. Whenever code performs a communication operation like [`fetch()`](@ref) or [`wait()`](@ref),
+computations. Whenever code performs a communication operation like [`fetch`](@ref) or [`wait`](@ref),
 the current task is suspended and a scheduler picks another task to run. A task is restarted when
 the event it is waiting for completes.
 
@@ -465,7 +465,7 @@ julia> pmap(svd, M);
 
 If one process handles both 800×800 matrices and another handles both 600×600 matrices, we will
 not get as much scalability as we could. The solution is to make a local task to "feed" work to
-each process when it completes its current task. For example, consider a simple [`pmap()`](@ref)
+each process when it completes its current task. For example, consider a simple [`pmap`](@ref)
 implementation:
 
 ```julia
@@ -501,10 +501,10 @@ use it to create a "feeder" task for each process. Each task picks the next inde
 be computed, then waits for its process to finish, then repeats until we run out of indexes. Note
 that the feeder tasks do not begin to execute until the main task reaches the end of the [`@sync`](@ref)
 block, at which point it surrenders control and waits for all the local tasks to complete before
-returning from the function. The feeder tasks are able to share state via `nextidx()` because
+returning from the function. The feeder tasks are able to share state via `nextidx` because
 they all run on the same process. No locking is required, since the threads are scheduled cooperatively
 and not preemptively. This means context switches only occur at well-defined points: in this case,
-when [`remotecall_fetch()`](@ref) is called.
+when [`remotecall_fetch`](@ref) is called.
 
 ## Channels
 
@@ -519,9 +519,9 @@ to complete.
 
 A channel can be visualized as a pipe, i.e., it has a write end and read end.
 
-  * Multiple writers in different tasks can write to the same channel concurrently via [`put!()`](@ref)
+  * Multiple writers in different tasks can write to the same channel concurrently via [`put!`](@ref)
     calls.
-  * Multiple readers in different tasks can read data concurrently via [`take!()`](@ref) calls.
+  * Multiple readers in different tasks can read data concurrently via [`take!`](@ref) calls.
   * As an example:
 
     ```julia
@@ -529,7 +529,7 @@ A channel can be visualized as a pipe, i.e., it has a write end and read end.
     c1 = Channel(32)
     c2 = Channel(32)
 
-    # and a function `foo()` which reads items from from c1, processes the item read
+    # and a function `foo` which reads items from from c1, processes the item read
     # and writes a result to c2,
     function foo()
         while true
@@ -539,7 +539,7 @@ A channel can be visualized as a pipe, i.e., it has a write end and read end.
         end
     end
 
-    # we can schedule `n` instances of `foo()` to be active concurrently.
+    # we can schedule `n` instances of `foo` to be active concurrently.
     for _ in 1:n
         @schedule foo()
     end
@@ -549,13 +549,13 @@ A channel can be visualized as a pipe, i.e., it has a write end and read end.
     to the maximum number of elements that can be held in the channel at any time. For example, `Channel(32)`
     creates a channel that can hold a maximum of 32 objects of any type. A `Channel{MyType}(64)` can
     hold up to 64 objects of `MyType` at any time.
-  * If a [`Channel`](@ref) is empty, readers (on a [`take!()`](@ref) call) will block until data is available.
-  * If a [`Channel`](@ref) is full, writers (on a [`put!()`](@ref) call) will block until space becomes available.
-  * [`isready()`](@ref) tests for the presence of any object in the channel, while [`wait()`](@ref)
+  * If a [`Channel`](@ref) is empty, readers (on a [`take!`](@ref) call) will block until data is available.
+  * If a [`Channel`](@ref) is full, writers (on a [`put!`](@ref) call) will block until space becomes available.
+  * [`isready`](@ref) tests for the presence of any object in the channel, while [`wait`](@ref)
     waits for an object to become available.
   * A [`Channel`](@ref) is in an open state initially. This means that it can be read from and written to
-    freely via [`take!()`](@ref) and [`put!()`](@ref) calls. [`close()`](@ref) closes a [`Channel`](@ref).
-    On a closed [`Channel`](@ref), [`put!()`](@ref) will fail. For example:
+    freely via [`take!`](@ref) and [`put!`](@ref) calls. [`close`](@ref) closes a [`Channel`](@ref).
+    On a closed [`Channel`](@ref), [`put!`](@ref) will fail. For example:
 
 ```julia-repl
 julia> c = Channel(2);
@@ -570,7 +570,7 @@ ERROR: InvalidStateException("Channel is closed.",:closed)
 [...]
 ```
 
-  * [`take!()`](@ref) and [`fetch()`](@ref) (which retrieves but does not remove the value) on a closed
+  * [`take!`](@ref) and [`fetch`](@ref) (which retrieves but does not remove the value) on a closed
     channel successfully return any existing values until it is emptied. Continuing the above example:
 
 ```julia-repl
@@ -683,7 +683,7 @@ too.
 Remote references always refer to an implementation of an `AbstractChannel`.
 
 A concrete implementation of an `AbstractChannel` (like `Channel`), is required to implement
-[`put!()`](@ref), [`take!()`](@ref), [`fetch()`](@ref), [`isready()`](@ref) and [`wait()`](@ref).
+[`put!`](@ref), [`take!`](@ref), [`fetch`](@ref), [`isready`](@ref) and [`wait`](@ref).
 The remote object referred to by a [`Future`](@ref) is stored in a `Channel{Any}(1)`, i.e., a
 `Channel` of size 1 capable of holding objects of `Any` type.
 
@@ -691,13 +691,13 @@ The remote object referred to by a [`Future`](@ref) is stored in a `Channel{Any}
 other implementation of an `AbstractChannel`.
 
 The constructor `RemoteChannel(f::Function, pid)()` allows us to construct references to channels
-holding more than one value of a specific type. `f()` is a function executed on `pid` and it must
+holding more than one value of a specific type. `f` is a function executed on `pid` and it must
 return an `AbstractChannel`.
 
 For example, `RemoteChannel(()->Channel{Int}(10), pid)`, will return a reference to a channel
 of type `Int` and size 10. The channel exists on worker `pid`.
 
-Methods [`put!()`](@ref), [`take!()`](@ref), [`fetch()`](@ref), [`isready()`](@ref) and [`wait()`](@ref)
+Methods [`put!`](@ref), [`take!`](@ref), [`fetch`](@ref), [`isready`](@ref) and [`wait`](@ref)
 on a [`RemoteChannel`](@ref) are proxied onto the backing store on the remote process.
 
 [`RemoteChannel`](@ref) can thus be used to refer to user implemented `AbstractChannel` objects.
@@ -796,7 +796,7 @@ The notifications are done via sending of "tracking" messages--an "add reference
 a reference is serialized to a different process and a "delete reference" message when a reference
 is locally garbage collected.
 
-Since [`Future`](@ref)s are write-once and cached locally, the act of [`fetch()`](@ref)ing a
+Since [`Future`](@ref)s are write-once and cached locally, the act of [`fetch`](@ref)ing a
 [`Future`](@ref) also updates reference tracking information on the node owning the value.
 
 The node which owns the value frees it once all references to it are cleared.
@@ -809,10 +809,10 @@ of the object and the current memory pressure in the system.
 
 In case of remote references, the size of the local reference object is quite small, while the
 value stored on the remote node may be quite large. Since the local object may not be collected
-immediately, it is a good practice to explicitly call [`finalize()`](@ref) on local instances
-of a [`RemoteChannel`](@ref), or on unfetched [`Future`](@ref)s. Since calling [`fetch()`](@ref)
+immediately, it is a good practice to explicitly call [`finalize`](@ref) on local instances
+of a [`RemoteChannel`](@ref), or on unfetched [`Future`](@ref)s. Since calling [`fetch`](@ref)
 on a [`Future`](@ref) also removes its reference from the remote store, this is not required on
-fetched [`Future`](@ref)s. Explicitly calling [`finalize()`](@ref) results in an immediate message
+fetched [`Future`](@ref)s. Explicitly calling [`finalize`](@ref) results in an immediate message
 sent to the remote node to go ahead and remove its reference to the value.
 
 Once finalized, a reference becomes invalid and cannot be used in any further calls.
@@ -831,8 +831,8 @@ data jointly accessible to two or more processes on the same machine.
 and is efficient because the underlying memory is available to the local process. Therefore,
 most algorithms work naturally on [`SharedArray`](@ref)s, albeit in single-process mode. In cases
 where an algorithm insists on an [`Array`](@ref) input, the underlying array can be retrieved
-from a [`SharedArray`](@ref) by calling [`sdata()`](@ref). For other `AbstractArray` types, [`sdata()`](@ref)
-just returns the object itself, so it's safe to use [`sdata()`](@ref) on any `Array`-type object.
+from a [`SharedArray`](@ref) by calling [`sdata`](@ref). For other `AbstractArray` types, [`sdata`](@ref)
+just returns the object itself, so it's safe to use [`sdata`](@ref) on any `Array`-type object.
 
 The constructor for a shared array is of the form:
 
@@ -874,7 +874,7 @@ julia> S
  2  7  4  4
 ```
 
-[`Base.localindexes()`](@ref) provides disjoint one-dimensional ranges of indexes, and is sometimes
+[`Base.localindexes`](@ref) provides disjoint one-dimensional ranges of indexes, and is sometimes
 convenient for splitting up tasks among processes. You can, of course, divide the work any way
 you wish:
 
@@ -1035,8 +1035,8 @@ A Julia cluster has the following characteristics:
 Connections between workers (using the in-built TCP/IP transport) is established in the following
 manner:
 
-  * [`addprocs()`](@ref) is called on the master process with a `ClusterManager` object.
-  * [`addprocs()`](@ref) calls the appropriate [`launch()`](@ref) method which spawns required number
+  * [`addprocs`](@ref) is called on the master process with a `ClusterManager` object.
+  * [`addprocs`](@ref) calls the appropriate [`launch`](@ref) method which spawns required number
     of worker processes on appropriate machines.
   * Each worker starts listening on a free port and writes out its host and port information to [`STDOUT`](@ref).
   * The cluster manager captures the [`STDOUT`](@ref) of each worker and makes it available to the
@@ -1061,8 +1061,8 @@ and multi-processor hardware.
 Thus, a minimal cluster manager would need to:
 
   * be a subtype of the abstract `ClusterManager`
-  * implement [`launch()`](@ref), a method responsible for launching new workers
-  * implement [`manage()`](@ref), which is called at various events during a worker's lifetime (for
+  * implement [`launch`](@ref), a method responsible for launching new workers
+  * implement [`manage`](@ref), which is called at various events during a worker's lifetime (for
     example, sending an interrupt signal)
 
 [`addprocs(manager::FooManager)`](@ref addprocs) requires `FooManager` to implement:
@@ -1094,15 +1094,15 @@ function manage(manager::LocalManager, id::Integer, config::WorkerConfig, op::Sy
 end
 ```
 
-The [`launch()`](@ref) method takes the following arguments:
+The [`launch`](@ref) method takes the following arguments:
 
-  * `manager::ClusterManager`: the cluster manager that [`addprocs()`](@ref) is called with
-  * `params::Dict`: all the keyword arguments passed to [`addprocs()`](@ref)
+  * `manager::ClusterManager`: the cluster manager that [`addprocs`](@ref) is called with
+  * `params::Dict`: all the keyword arguments passed to [`addprocs`](@ref)
   * `launched::Array`: the array to append one or more `WorkerConfig` objects to
   * `c::Condition`: the condition variable to be notified as and when workers are launched
 
-The [`launch()`](@ref) method is called asynchronously in a separate task. The termination of
-this task signals that all requested workers have been launched. Hence the [`launch()`](@ref)
+The [`launch`](@ref) method is called asynchronously in a separate task. The termination of
+this task signals that all requested workers have been launched. Hence the [`launch`](@ref)
 function MUST exit as soon as all the requested workers have been launched.
 
 Newly launched workers are connected to each other and the master process in an all-to-all manner.
@@ -1122,7 +1122,7 @@ As an example of a non-TCP/IP transport, an implementation may choose to use MPI
 `--worker` must NOT be specified. Instead, newly launched workers should call `init_worker(cookie)`
 before using any of the parallel constructs.
 
-For every worker launched, the [`launch()`](@ref) method must add a `WorkerConfig` object (with
+For every worker launched, the [`launch`](@ref) method must add a `WorkerConfig` object (with
 appropriate fields initialized) to `launched`
 
 ```julia
@@ -1225,8 +1225,8 @@ When using custom transports:
     must be called. This launches a new task that handles reading and writing of messages from/to
     the worker represented by the `IO` objects.
   * `init_worker(cookie, manager::FooManager)` MUST be called as part of worker process initialization.
-  * Field `connect_at::Any` in `WorkerConfig` can be set by the cluster manager when [`launch()`](@ref)
-    is called. The value of this field is passed in in all [`connect()`](@ref) callbacks. Typically,
+  * Field `connect_at::Any` in `WorkerConfig` can be set by the cluster manager when [`launch`](@ref)
+    is called. The value of this field is passed in in all [`connect`](@ref) callbacks. Typically,
     it carries information on *how to connect* to a worker. For example, the TCP/IP socket transport
     uses this field to specify the `(host, port)` tuple at which to connect to a worker.
 
@@ -1344,7 +1344,7 @@ julia> Threads.nthreads()
 4
 ```
 
-But we are currently on the master thread. To check, we use the command [`Threads.threadid()`](@ref)
+But we are currently on the master thread. To check, we use the function [`Threads.threadid`](@ref)
 
 ```julia-repl
 julia> Threads.threadid()
@@ -1408,12 +1408,12 @@ All I/O tasks, timers, REPL commands, etc are multiplexed onto a single OS threa
 loop. A patched version of libuv ([http://docs.libuv.org/en/v1.x/](http://docs.libuv.org/en/v1.x/))
 provides this functionality. Yield points provide for co-operatively scheduling multiple tasks
 onto the same OS thread. I/O tasks and timers yield implicitly while waiting for the event to
-occur. Calling [`yield()`](@ref) explicitly allows for other tasks to be scheduled.
+occur. Calling [`yield`](@ref) explicitly allows for other tasks to be scheduled.
 
 Thus, a task executing a [`ccall`](@ref) effectively prevents the Julia scheduler from executing any other
 tasks till the call returns. This is true for all calls into external libraries. Exceptions are
 calls into custom C code that call back into Julia (which may then yield) or C code that calls
-`jl_yield()` (C equivalent of [`yield()`](@ref)).
+`jl_yield()` (C equivalent of [`yield`](@ref)).
 
 Note that while Julia code runs on a single thread (by default), libraries used by Julia may launch
 their own internal threads. For example, the BLAS library may start as many threads as there are

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -74,7 +74,7 @@ On the first call (`@time f(1)`), `f` gets compiled.  (If you've not yet used [`
 in this session, it will also compile functions needed for timing.)  You should not take the results
 of this run seriously. For the second run, note that in addition to reporting the time, it also
 indicated that a large amount of memory was allocated. This is the single biggest advantage of
-[`@time`](@ref) vs. functions like [`tic()`](@ref) and [`toc()`](@ref), which only report time.
+[`@time`](@ref) vs. functions like [`tic`](@ref) and [`toc`](@ref), which only report time.
 
 Unexpected memory allocation is almost always a sign of some problem with your code, usually a
 problem with type-stability. Consequently, in addition to the allocation itself, it's very likely
@@ -549,7 +549,7 @@ easily be fixed as follows:
 pos(x) = x < 0 ? zero(x) : x
 ```
 
-There is also a [`one()`](@ref) function, and a more general [`oftype(x, y)`](@ref) function, which
+There is also a [`one`](@ref) function, and a more general [`oftype(x, y)`](@ref) function, which
 returns `y` converted to the type of `x`.
 
 ## Avoid changing the type of a variable
@@ -810,7 +810,7 @@ Consider the following contrived example. Imagine we wanted to write a function 
 [`Vector`](@ref) and returns a square [`Matrix`](@ref) with either the rows or the columns filled with copies
 of the input vector. Assume that it is not important whether rows or columns are filled with these
 copies (perhaps the rest of the code can be easily adapted accordingly). We could conceivably
-do this in at least four ways (in addition to the recommended call to the built-in [`repmat()`](@ref)):
+do this in at least four ways (in addition to the recommended call to the built-in [`repmat`](@ref)):
 
 ```julia
 function copy_cols(x::Vector{T}) where T
@@ -997,7 +997,7 @@ An alternative is to create a "view" of the array, which is
 an array object (a `SubArray`) that actually references the data
 of the original array in-place, without making a copy.  (If you
 write to a view, it modifies the original array's data as well.)
-This can be done for individual slices by calling [`view()`](@ref),
+This can be done for individual slices by calling [`view`](@ref),
 or more simply for a whole expression or block of code by putting
 [`@views`](@ref) in front of that expression.  For example:
 
@@ -1125,7 +1125,7 @@ These are some minor points that might help in tight inner loops.
 
   * Avoid unnecessary arrays. For example, instead of [`sum([x,y,z])`](@ref) use `x+y+z`.
   * Use [`abs2(z)`](@ref) instead of [`abs(z)^2`](@ref) for complex `z`. In general, try to rewrite
-    code to use [`abs2()`](@ref) instead of [`abs()`](@ref) for complex arguments.
+    code to use [`abs2`](@ref) instead of [`abs`](@ref) for complex arguments.
   * Use [`div(x,y)`](@ref) for truncating division of integers instead of [`trunc(x/y)`](@ref), [`fld(x,y)`](@ref)
     instead of [`floor(x/y)`](@ref), and [`cld(x,y)`](@ref) instead of [`ceil(x/y)`](@ref).
 
@@ -1208,7 +1208,7 @@ following additional properties:
   * The loop must be an innermost loop.
   * The loop body must be straight-line code. This is why `@inbounds` is currently needed for all
     array accesses. The compiler can sometimes turn short `&&`, `||`, and `?:` expressions into straight-line
-    code, if it is safe to evaluate all operands unconditionally. Consider using [`ifelse()`](@ref)
+    code, if it is safe to evaluate all operands unconditionally. Consider using [`ifelse`](@ref)
     instead of `?:` in the loop if it is safe to do so.
   * Accesses must have a stride pattern and cannot be "gathers" (random-index reads) or "scatters"
     (random-index writes).
@@ -1295,7 +1295,7 @@ on this particular computer), the main difference is that the expression `1 / (2
 `idx = 1 / (2*dx)`. In the loop, the expression `... / (2*dx)` then becomes `... * idx`, which
 is much faster to evaluate. Of course, both the actual optimization that is applied by the compiler
 as well as the resulting speedup depend very much on the hardware. You can examine the change
-in generated code by using Julia's [`code_native()`](@ref) function.
+in generated code by using Julia's [`code_native`](@ref) function.
 
 ## Treat Subnormal Numbers as Zeros
 
@@ -1359,7 +1359,7 @@ a = rand(Float32,1000) * 1.f-9
 
 ## [[`@code_warntype`](@ref)](@id man-code-warntype)
 
-The macro [`@code_warntype`](@ref) (or its function variant [`code_warntype()`](@ref)) can sometimes
+The macro [`@code_warntype`](@ref) (or its function variant [`code_warntype`](@ref)) can sometimes
 be helpful in diagnosing type-related problems. Here's an example:
 
 ```julia

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1208,8 +1208,8 @@ following additional properties:
   * The loop must be an innermost loop.
   * The loop body must be straight-line code. This is why `@inbounds` is currently needed for all
     array accesses. The compiler can sometimes turn short `&&`, `||`, and `?:` expressions into straight-line
-    code, if it is safe to evaluate all operands unconditionally. Consider using [`ifelse`](@ref)
-    instead of `?:` in the loop if it is safe to do so.
+    code, if it is safe to evaluate all operands unconditionally. Consider using the [`ifelse`](@ref)
+    function instead of `?:` in the loop if it is safe to do so.
   * Accesses must have a stride pattern and cannot be "gathers" (random-index reads) or "scatters"
     (random-index writes).
   * The stride should be unit stride.

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -200,12 +200,12 @@ useful way to view the results.
 ## Accumulation and clearing
 
 Results from [`@profile`](@ref) accumulate in a buffer; if you run multiple pieces of code under
-[`@profile`](@ref), then [`Profile.print()`](@ref) will show you the combined results. This can
-be very useful, but sometimes you want to start fresh; you can do so with [`Profile.clear()`](@ref).
+[`@profile`](@ref), then [`Profile.print`](@ref) will show you the combined results. This can
+be very useful, but sometimes you want to start fresh; you can do so with [`Profile.clear`](@ref).
 
 ## Options for controlling the display of profile results
 
-[`Profile.print()`](@ref) has more options than we've described so far. Let's see the full declaration:
+[`Profile.print`](@ref) has more options than we've described so far. Let's see the full declaration:
 
 ```julia
 function print(io::IO = STDOUT, data = fetch(); kwargs...)
@@ -215,7 +215,7 @@ Let's first discuss the two positional arguments, and later the keyword argument
 
   * `io` -- Allows you to save the results to a buffer, e.g. a file, but the default is to print to `STDOUT`
     (the console).
-  * `data` -- Contains the data you want to analyze; by default that is obtained from [`Profile.fetch()`](@ref),
+  * `data` -- Contains the data you want to analyze; by default that is obtained from [`Profile.fetch`](@ref),
     which pulls out the backtraces from a pre-allocated buffer. For example, if you want to profile
     the profiler, you could say:
 
@@ -261,7 +261,7 @@ end
 
 ## Configuration
 
-[`@profile`](@ref) just accumulates backtraces, and the analysis happens when you call [`Profile.print()`](@ref).
+[`@profile`](@ref) just accumulates backtraces, and the analysis happens when you call [`Profile.print`](@ref).
 For a long-running computation, it's entirely possible that the pre-allocated buffer for storing
 backtraces will be filled. If that happens, the backtraces stop but your computation continues.
 As a consequence, you may miss some important profiling data (you will get a warning when that
@@ -307,6 +307,6 @@ first line of any function directly called from the REPL will exhibit allocation
 that happen in the REPL code itself. More significantly, JIT-compilation also adds to allocation
 counts, because much of Julia's compiler is written in Julia (and compilation usually requires
 memory allocation). The recommended procedure is to force compilation by executing all the commands
-you want to analyze, then call [`Profile.clear_malloc_data()`](@ref) to reset all allocation counters.
+you want to analyze, then call [`Profile.clear_malloc_data`](@ref) to reset all allocation counters.
  Finally, execute the desired commands and quit Julia to trigger the generation of the `.mem`
 files.

--- a/doc/src/manual/profile.md
+++ b/doc/src/manual/profile.md
@@ -200,8 +200,8 @@ useful way to view the results.
 ## Accumulation and clearing
 
 Results from [`@profile`](@ref) accumulate in a buffer; if you run multiple pieces of code under
-[`@profile`](@ref), then [`Profile.print`](@ref) will show you the combined results. This can
-be very useful, but sometimes you want to start fresh; you can do so with [`Profile.clear`](@ref).
+[`@profile`](@ref), then [`Profile.print()`](@ref) will show you the combined results. This can
+be very useful, but sometimes you want to start fresh; you can do so with [`Profile.clear()`](@ref).
 
 ## Options for controlling the display of profile results
 
@@ -215,7 +215,7 @@ Let's first discuss the two positional arguments, and later the keyword argument
 
   * `io` -- Allows you to save the results to a buffer, e.g. a file, but the default is to print to `STDOUT`
     (the console).
-  * `data` -- Contains the data you want to analyze; by default that is obtained from [`Profile.fetch`](@ref),
+  * `data` -- Contains the data you want to analyze; by default that is obtained from [`Profile.fetch()`](@ref),
     which pulls out the backtraces from a pre-allocated buffer. For example, if you want to profile
     the profiler, you could say:
 
@@ -261,7 +261,7 @@ end
 
 ## Configuration
 
-[`@profile`](@ref) just accumulates backtraces, and the analysis happens when you call [`Profile.print`](@ref).
+[`@profile`](@ref) just accumulates backtraces, and the analysis happens when you call [`Profile.print()`](@ref).
 For a long-running computation, it's entirely possible that the pre-allocated buffer for storing
 backtraces will be filled. If that happens, the backtraces stop but your computation continues.
 As a consequence, you may miss some important profiling data (you will get a warning when that
@@ -307,6 +307,6 @@ first line of any function directly called from the REPL will exhibit allocation
 that happen in the REPL code itself. More significantly, JIT-compilation also adds to allocation
 counts, because much of Julia's compiler is written in Julia (and compilation usually requires
 memory allocation). The recommended procedure is to force compilation by executing all the commands
-you want to analyze, then call [`Profile.clear_malloc_data`](@ref) to reset all allocation counters.
+you want to analyze, then call [`Profile.clear_malloc_data()`](@ref) to reset all allocation counters.
  Finally, execute the desired commands and quit Julia to trigger the generation of the `.mem`
 files.

--- a/doc/src/manual/running-external-programs.md
+++ b/doc/src/manual/running-external-programs.md
@@ -47,7 +47,7 @@ julia> chomp(a) == "hello"
 true
 ```
 
-More generally, you can use [`open()`](@ref) to read from or write to an external command.
+More generally, you can use [`open`](@ref) to read from or write to an external command.
 
 ```jldoctest
 julia> open(`less`, "w", STDOUT) do io
@@ -245,7 +245,7 @@ hello | sort
 
 This expression invokes the `echo` command with three words as arguments: `hello`, `|`, and `sort`.
 The result is that a single line is printed: `hello | sort`. How, then, does one construct a
-pipeline? Instead of using `'|'` inside of backticks, one uses [`pipeline()`](@ref):
+pipeline? Instead of using `'|'` inside of backticks, one uses [`pipeline`](@ref):
 
 ```jldoctest
 julia> run(pipeline(`echo hello`, `sort`))

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -5,7 +5,7 @@ easy to use programmatically.
 
 ## Viewing a stack trace
 
-The primary function used to obtain a stack trace is [`stacktrace()`](@ref):
+The primary function used to obtain a stack trace is [`stacktrace`](@ref):
 
 ```julia-repl
 julia> stacktrace()
@@ -16,7 +16,7 @@ julia> stacktrace()
  (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
-Calling [`stacktrace()`](@ref) returns a vector of [`StackFrame`](@ref) s. For ease of use, the
+Calling [`stacktrace`](@ref) returns a vector of [`StackFrame`](@ref) s. For ease of use, the
 alias [`StackTrace`](@ref) can be used in place of `Vector{StackFrame}`. (Examples with `[...]`
 indicate that output may vary depending on how the code is run.)
 
@@ -47,8 +47,8 @@ julia> grandparent()
 [...]
 ```
 
-Note that when calling [`stacktrace()`](@ref) you'll typically see a frame with `eval(...) at boot.jl`.
-When calling [`stacktrace()`](@ref) from the REPL you'll also have a few extra frames in the stack
+Note that when calling [`stacktrace`](@ref) you'll typically see a frame with `eval(...) at boot.jl`.
+When calling [`stacktrace`](@ref) from the REPL you'll also have a few extra frames in the stack
 from `REPL.jl`, usually looking something like this:
 
 ```julia-repl
@@ -69,7 +69,7 @@ julia> example()
 Each [`StackFrame`](@ref) contains the function name, file name, line number, lambda info, a flag
 indicating whether the frame has been inlined, a flag indicating whether it is a C function (by
 default C functions do not appear in the stack trace), and an integer representation of the pointer
-returned by [`backtrace()`](@ref):
+returned by [`backtrace`](@ref):
 
 ```julia-repl
 julia> top_frame = stacktrace()[1]
@@ -126,13 +126,13 @@ julia> example()
 ```
 
 You may notice that in the example above the first stack frame points points at line 4, where
-[`stacktrace()`](@ref) is called, rather than line 2, where *bad_function* is called, and `bad_function`'s
-frame is missing entirely. This is understandable, given that [`stacktrace()`](@ref) is called
+[`stacktrace`](@ref) is called, rather than line 2, where *bad_function* is called, and `bad_function`'s
+frame is missing entirely. This is understandable, given that [`stacktrace`](@ref) is called
 from the context of the *catch*. While in this example it's fairly easy to find the actual source
 of the error, in complex cases tracking down the source of the error becomes nontrivial.
 
-This can be remedied by calling [`catch_stacktrace()`](@ref) instead of [`stacktrace()`](@ref).
-Instead of returning callstack information for the current context, [`catch_stacktrace()`](@ref)
+This can be remedied by calling [`catch_stacktrace`](@ref) instead of [`stacktrace`](@ref).
+Instead of returning callstack information for the current context, [`catch_stacktrace`](@ref)
 returns stack information for the context of the most recent exception:
 
 ```julia-repl
@@ -181,10 +181,10 @@ ERROR: Whoops!
 [...]
 ```
 
-## Comparison with [`backtrace()`](@ref)
+## Comparison with [`backtrace`](@ref)
 
-A call to [`backtrace()`](@ref) returns a vector of `Ptr{Void}`, which may then be passed into
-[`stacktrace()`](@ref) for translation:
+A call to [`backtrace`](@ref) returns a vector of `Ptr{Void}`, which may then be passed into
+[`stacktrace`](@ref) for translation:
 
 ```julia-repl
 julia> trace = backtrace()
@@ -220,8 +220,8 @@ julia> stacktrace(trace)
  (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
-Notice that the vector returned by [`backtrace()`](@ref) had 21 pointers, while the vector returned
-by [`stacktrace()`](@ref) only has 5. This is because, by default, [`stacktrace()`](@ref) removes
+Notice that the vector returned by [`backtrace`](@ref) had 21 pointers, while the vector returned
+by [`stacktrace`](@ref) only has 5. This is because, by default, [`stacktrace`](@ref) removes
 any lower-level C functions from the stack. If you want to include stack frames from C calls,
 you can do it like this:
 
@@ -257,8 +257,8 @@ julia> stacktrace(trace, true)
  ip:0xffffffffffffffff
 ```
 
-Individual pointers returned by [`backtrace()`](@ref) can be translated into [`StackFrame`](@ref)
-s by passing them into [`StackTraces.lookup()`](@ref):
+Individual pointers returned by [`backtrace`](@ref) can be translated into [`StackFrame`](@ref)
+s by passing them into [`StackTraces.lookup`](@ref):
 
 ```julia-repl
 julia> pointer = backtrace()[1];

--- a/doc/src/manual/stacktraces.md
+++ b/doc/src/manual/stacktraces.md
@@ -16,7 +16,7 @@ julia> stacktrace()
  (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at event.jl:73
 ```
 
-Calling [`stacktrace`](@ref) returns a vector of [`StackFrame`](@ref) s. For ease of use, the
+Calling [`stacktrace()`](@ref) returns a vector of [`StackFrame`](@ref) s. For ease of use, the
 alias [`StackTrace`](@ref) can be used in place of `Vector{StackFrame}`. (Examples with `[...]`
 indicate that output may vary depending on how the code is run.)
 
@@ -47,8 +47,8 @@ julia> grandparent()
 [...]
 ```
 
-Note that when calling [`stacktrace`](@ref) you'll typically see a frame with `eval(...) at boot.jl`.
-When calling [`stacktrace`](@ref) from the REPL you'll also have a few extra frames in the stack
+Note that when calling [`stacktrace()`](@ref) you'll typically see a frame with `eval(...) at boot.jl`.
+When calling [`stacktrace()`](@ref) from the REPL you'll also have a few extra frames in the stack
 from `REPL.jl`, usually looking something like this:
 
 ```julia-repl

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -22,7 +22,7 @@ There are a few noteworthy high-level features about Julia's strings:
 
   * The built-in concrete type used for strings (and string literals) in Julia is [`String`](@ref).
     This supports the full range of [Unicode](https://en.wikipedia.org/wiki/Unicode) characters via
-    the [UTF-8](https://en.wikipedia.org/wiki/UTF-8) encoding. (A [`transcode()`](@ref) function is
+    the [UTF-8](https://en.wikipedia.org/wiki/UTF-8) encoding. (A [`transcode`](@ref) function is
     provided to convert to/from other Unicode encodings.)
   * All string types are subtypes of the abstract type `AbstractString`, and external packages define
     additional `AbstractString` subtypes (e.g. for other encodings).  If you define a function expecting
@@ -72,9 +72,9 @@ julia> Char(120)
 'x': ASCII/Unicode U+0078 (category Ll: Letter, lowercase)
 ```
 
-Not all integer values are valid Unicode code points, but for performance, the `Char()` conversion
+Not all integer values are valid Unicode code points, but for performance, the `Char` conversion
 does not check that every character value is valid. If you want to check that each converted value
-is a valid code point, use the [`isvalid()`](@ref) function:
+is a valid code point, use the [`isvalid`](@ref) function:
 
 ```jldoctest
 julia> Char(0x110000)
@@ -314,7 +314,7 @@ For example, the [LegacyStrings.jl](https://github.com/JuliaArchive/LegacyString
 implements `UTF16String` and `UTF32String` types. Additional discussion of other encodings and
 how to implement support for them is beyond the scope of this document for the time being. For
 further discussion of UTF-8 encoding issues, see the section below on [byte array literals](@ref man-byte-array-literals).
-The [`transcode()`](@ref) function is provided to convert data between the various UTF-xx encodings,
+The [`transcode`](@ref) function is provided to convert data between the various UTF-xx encodings,
 primarily for working with external data and libraries.
 
 ## Concatenation
@@ -359,7 +359,7 @@ implies commutativity.
 ## [Interpolation](@id string-interpolation)
 
 Constructing strings using concatenation can become a bit cumbersome, however. To reduce the need for these
-verbose calls to [`string()`](@ref) or repeated multiplications, Julia allows interpolation into string literals
+verbose calls to [`string`](@ref) or repeated multiplications, Julia allows interpolation into string literals
 using `$`, as in Perl:
 
 ```jldoctest stringconcat
@@ -378,7 +378,7 @@ julia> "1 + 2 = $(1 + 2)"
 "1 + 2 = 3"
 ```
 
-Both concatenation and string interpolation call [`string()`](@ref) to convert objects into string
+Both concatenation and string interpolation call [`string`](@ref) to convert objects into string
 form. Most non-`AbstractString` objects are converted to strings closely corresponding to how
 they are entered as literal expressions:
 
@@ -393,7 +393,7 @@ julia> "v: $v"
 "v: [1, 2, 3]"
 ```
 
-[`string()`](@ref) is the identity for `AbstractString` and `Char` values, so these are interpolated
+[`string`](@ref) is the identity for `AbstractString` and `Char` values, so these are interpolated
 into strings as themselves, unquoted and unescaped:
 
 ```jldoctest
@@ -474,7 +474,7 @@ julia> "1 + 2 = 3" == "1 + 2 = $(1 + 2)"
 true
 ```
 
-You can search for the index of a particular character using the [`search()`](@ref) function:
+You can search for the index of a particular character using the [`search`](@ref) function:
 
 ```jldoctest
 julia> search("xylophone", 'x')
@@ -500,7 +500,7 @@ julia> search("xylophone", 'o', 8)
 0
 ```
 
-You can use the [`contains()`](@ref) function to check if a substring is contained in a string:
+You can use the [`contains`](@ref) function to check if a substring is contained in a string:
 
 ```jldoctest
 julia> contains("Hello, world.", "world")
@@ -516,9 +516,9 @@ julia> contains("Xylophon", 'o')
 true
 ```
 
-The last example shows that [`contains()`](@ref) can also look for a character literal.
+The last example shows that [`contains`](@ref) can also look for a character literal.
 
-Two other handy string functions are [`repeat()`](@ref) and [`join()`](@ref):
+Two other handy string functions are [`repeat`](@ref) and [`join`](@ref):
 
 ```jldoctest
 julia> repeat(".:Z:.", 10)
@@ -535,7 +535,7 @@ Some other useful functions include:
   * [`i = start(str)`](@ref start) gives the first valid index at which a character can be found in `str`
     (typically 1).
   * [`c, j = next(str,i)`](@ref next) returns next character at or after the index `i` and the next valid
-    character index following that. With [`start()`](@ref) and [`endof()`](@ref), can be used to iterate
+    character index following that. With [`start`](@ref) and [`endof`](@ref), can be used to iterate
     through the characters in `str`.
   * [`ind2chr(str,i)`](@ref) gives the number of characters in `str` up to and including any at index
     `i`.
@@ -569,7 +569,7 @@ julia> typeof(ans)
 Regex
 ```
 
-To check if a regex matches a string, use [`ismatch()`](@ref):
+To check if a regex matches a string, use [`ismatch`](@ref):
 
 ```jldoctest
 julia> ismatch(r"^\s*(?:#|$)", "not a comment")
@@ -579,10 +579,10 @@ julia> ismatch(r"^\s*(?:#|$)", "# a comment")
 true
 ```
 
-As one can see here, [`ismatch()`](@ref) simply returns true or false, indicating whether the
+As one can see here, [`ismatch`](@ref) simply returns true or false, indicating whether the
 given regex matches the string or not. Commonly, however, one wants to know not just whether a
 string matched, but also *how* it matched. To capture this information about a match, use the
-[`match()`](@ref) function instead:
+[`match`](@ref) function instead:
 
 ```jldoctest
 julia> match(r"^\s*(?:#|$)", "not a comment")
@@ -591,7 +591,7 @@ julia> match(r"^\s*(?:#|$)", "# a comment")
 RegexMatch("#")
 ```
 
-If the regular expression does not match the given string, [`match()`](@ref) returns `nothing`
+If the regular expression does not match the given string, [`match`](@ref) returns `nothing`
 -- a special value that does not print anything at the interactive prompt. Other than not printing,
 it is a completely normal value and you can test for it programmatically:
 
@@ -604,7 +604,7 @@ else
 end
 ```
 
-If a regular expression does match, the value returned by [`match()`](@ref) is a `RegexMatch`
+If a regular expression does match, the value returned by [`match`](@ref) is a `RegexMatch`
 object. These objects record how the expression matches, including the substring that the pattern
 matches and any captured substrings, if there are any. This example only captures the portion
 of the substring that matches, but perhaps we want to capture any non-blank text after the comment
@@ -615,7 +615,7 @@ julia> m = match(r"^\s*(?:#\s*(.*?)\s*$|$)", "# a comment ")
 RegexMatch("# a comment ", 1="a comment")
 ```
 
-When calling [`match()`](@ref), you have the option to specify an index at which to start the
+When calling [`match`](@ref), you have the option to specify an index at which to start the
 search. For example:
 
 ```jldoctest
@@ -706,7 +706,7 @@ julia> m[2]
 "45"
 ```
 
-Captures can be referenced in a substitution string when using [`replace()`](@ref) by using `\n`
+Captures can be referenced in a substitution string when using [`replace`](@ref) by using `\n`
 to refer to the nth capture group and prefixing the substitution string with `s`. Capture group
 0 refers to the entire match object. Named capture groups can be referenced in the substitution
 with `g<groupname>`. For example:

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -111,8 +111,8 @@ end
 ```
 
 The Julia standard library uses this convention throughout and contains examples of functions
-with both copying and modifying forms (e.g., [`sort()`](@ref) and [`sort!()`](@ref)), and others
-which are just modifying (e.g., [`push!()`](@ref), [`pop!()`](@ref), [`splice!()`](@ref)).  It
+with both copying and modifying forms (e.g., [`sort`](@ref) and [`sort!`](@ref)), and others
+which are just modifying (e.g., [`push!`](@ref), [`pop!`](@ref), [`splice!`](@ref)).  It
 is typical for such functions to also return the modified array for convenience.
 
 ## Avoid strange type `Union`s
@@ -156,11 +156,11 @@ uses (e.g. `a[i]::Int`) than to try to pack many alternatives into one type.
 ## Use naming conventions consistent with Julia's `base/`
 
   * modules and type names use capitalization and camel case: `module SparseArrays`, `struct UnitRange`.
-  * functions are lowercase ([`maximum()`](@ref), [`convert()`](@ref)) and, when readable, with multiple
-    words squashed together ([`isequal()`](@ref), [`haskey()`](@ref)). When necessary, use underscores
-    as word separators. Underscores are also used to indicate a combination of concepts ([`remotecall_fetch()`](@ref)
-    as a more efficient implementation of `fetch(remotecall(...))`) or as modifiers ([`sum_kbn()`](@ref)).
-  * conciseness is valued, but avoid abbreviation ([`indexin()`](@ref) rather than `indxin()`) as
+  * functions are lowercase ([`maximum`](@ref), [`convert`](@ref)) and, when readable, with multiple
+    words squashed together ([`isequal`](@ref), [`haskey`](@ref)). When necessary, use underscores
+    as word separators. Underscores are also used to indicate a combination of concepts ([`remotecall_fetch`](@ref)
+    as a more efficient implementation of `fetch(remotecall(...))`) or as modifiers ([`sum_kbn`](@ref)).
+  * conciseness is valued, but avoid abbreviation ([`indexin`](@ref) rather than `indxin`) as
     it becomes difficult to remember whether and how particular words are abbreviated.
 
 If a function name requires multiple words, consider whether it might represent more than one
@@ -235,7 +235,7 @@ with the "values" as subtypes.
 
 Be aware of when a macro could really be a function instead.
 
-Calling [`eval()`](@ref) inside a macro is a particularly dangerous warning sign; it means the
+Calling [`eval`](@ref) inside a macro is a particularly dangerous warning sign; it means the
 macro will only work when called at the top level. If such a macro is written as a function instead,
 it will naturally have access to the run-time values it needs.
 
@@ -307,7 +307,7 @@ higher-level, Julia-friendly API.
 
 ## Be careful with type equality
 
-You generally want to use [`isa()`](@ref) and [`<:`](@ref) for testing types,
+You generally want to use [`isa`](@ref) and [`<:`](@ref) for testing types,
 not `==`. Checking types for exact equality typically only makes sense when comparing to a known
 concrete type (e.g. `T == Float64`), or if you *really, really* know what you're doing.
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -41,7 +41,7 @@ up front are:
     where the combination of static compilation with polymorphism makes this distinction significant.
   * Only values, not variables, have types -- variables are simply names bound to values.
   * Both abstract and concrete types can be parameterized by other types. They can also be parameterized
-    by symbols, by values of any type for which [`isbits()`](@ref) returns true (essentially, things
+    by symbols, by values of any type for which [`isbits`](@ref) returns true (essentially, things
     like numbers and bools that are stored like C types or structs with no pointers to other objects),
     and also by tuples thereof. Type parameters may be omitted when they do not need to be referenced
     or restricted.
@@ -80,7 +80,7 @@ This allows a type assertion to be attached to any expression in-place.
 When appended to a variable on the left-hand side of an assignment, or as part of a `local` declaration,
 the `::` operator means something a bit different: it declares the variable to always have the
 specified type, like a type declaration in a statically-typed language such as C. Every value
-assigned to the variable will be converted to the declared type using [`convert()`](@ref):
+assigned to the variable will be converted to the declared type using [`convert`](@ref):
 
 ```jldoctest
 julia> function foo()
@@ -334,7 +334,7 @@ Foo
 
 When a type is applied like a function it is called a *constructor*. Two constructors are generated
 automatically (these are called *default constructors*). One accepts any arguments and calls
-[`convert()`](@ref) to convert them to the types of the fields, and the other accepts arguments
+[`convert`](@ref) to convert them to the types of the fields, and the other accepts arguments
 that match the field types exactly. The reason both of these are generated is that this makes
 it easier to add new definitions without inadvertently replacing a default constructor.
 
@@ -1111,7 +1111,7 @@ julia> isa(1, AbstractFloat)
 false
 ```
 
-The [`typeof()`](@ref) function, already used throughout the manual in examples, returns the type
+The [`typeof`](@ref) function, already used throughout the manual in examples, returns the type
 of its argument. Since, as noted above, types are objects, they also have types, and we can ask
 what their types are:
 
@@ -1139,7 +1139,7 @@ DataType
 
 `DataType` is its own type.
 
-Another operation that applies to some types is [`supertype()`](@ref), which reveals a type's
+Another operation that applies to some types is [`supertype`](@ref), which reveals a type's
 supertype. Only declared types (`DataType`) have unambiguous supertypes:
 
 ```jldoctest
@@ -1156,7 +1156,7 @@ julia> supertype(Any)
 Any
 ```
 
-If you apply [`supertype()`](@ref) to other type objects (or non-type objects), a [`MethodError`](@ref)
+If you apply [`supertype`](@ref) to other type objects (or non-type objects), a [`MethodError`](@ref)
 is raised:
 
 ```jldoctest
@@ -1170,7 +1170,7 @@ Closest candidates are:
 ## Custom pretty-printing
 
 Often, one wants to customize how instances of a type are displayed.  This is accomplished by
-overloading the [`show()`](@ref) function.  For example, suppose we define a type to represent
+overloading the [`show`](@ref) function.  For example, suppose we define a type to represent
 complex numbers in polar form:
 
 ```jldoctest polartype
@@ -1202,7 +1202,7 @@ julia> Base.show(io::IO, z::Polar) = print(io, z.r, " * exp(", z.Θ, "im)")
 More fine-grained control over display of `Polar` objects is possible. In particular, sometimes
 one wants both a verbose multi-line printing format, used for displaying a single object in the
 REPL and other interactive environments, and also a more compact single-line format used for
-[`print()`](@ref) or for displaying the object as part of another object (e.g. in an array). Although
+[`print`](@ref) or for displaying the object as part of another object (e.g. in an array). Although
 by default the `show(io, z)` function is called in both cases, you can define a *different* multi-line
 format for displaying an object by overloading a three-argument form of `show` that takes the
 `text/plain` MIME type as its second argument (see [Multimedia I/O](@ref)), for example:
@@ -1227,7 +1227,7 @@ julia> [Polar(3, 4.0), Polar(4.0,5.3)]
 
 where the single-line `show(io, z)` form is still used for an array of `Polar` values.   Technically,
 the REPL calls `display(z)` to display the result of executing a line, which defaults to `show(STDOUT, MIME("text/plain"), z)`,
-which in turn defaults to `show(STDOUT, z)`, but you should *not* define new [`display()`](@ref)
+which in turn defaults to `show(STDOUT, z)`, but you should *not* define new [`display`](@ref)
 methods unless you are defining a new multimedia display handler (see [Multimedia I/O](@ref)).
 
 Moreover, you can also define `show` methods for other MIME types in order to enable richer display
@@ -1405,7 +1405,7 @@ a single value of type `T` as an argument.
 
 ### Checking if a `Nullable` object has a value
 
-You can check if a `Nullable` object has any value using [`isnull()`](@ref):
+You can check if a `Nullable` object has any value using [`isnull`](@ref):
 
 ```jldoctest
 julia> isnull(Nullable{Float64}())
@@ -1417,7 +1417,7 @@ false
 
 ### Safely accessing the value of a `Nullable` object
 
-You can safely access the value of a `Nullable` object using [`get()`](@ref):
+You can safely access the value of a `Nullable` object using [`get`](@ref):
 
 ```jldoctest
 julia> get(Nullable{Float64}())
@@ -1430,12 +1430,12 @@ julia> get(Nullable(1.0))
 ```
 
 If the value is not present, as it would be for `Nullable{Float64}`, a [`NullException`](@ref)
-error will be thrown. The error-throwing nature of the `get()` function ensures that any
+error will be thrown. The error-throwing nature of the `get` function ensures that any
 attempt to access a missing value immediately fails.
 
 In cases for which a reasonable default value exists that could be used when a `Nullable`
 object's value turns out to be missing, you can provide this default value as a second argument
-to `get()`:
+to `get`:
 
 ```jldoctest
 julia> get(Nullable{Float64}(), 0.0)
@@ -1446,15 +1446,15 @@ julia> get(Nullable(1.0), 0.0)
 ```
 
 !!! tip
-    Make sure the type of the default value passed to `get()` and that of the `Nullable`
-    object match to avoid type instability, which could hurt performance. Use [`convert()`](@ref)
+    Make sure the type of the default value passed to `get` and that of the `Nullable`
+    object match to avoid type instability, which could hurt performance. Use [`convert`](@ref)
     manually if needed.
 
 ### Performing operations on `Nullable` objects
 
 `Nullable` objects represent values that are possibly missing, and it
 is possible to write all code using these objects by first testing to see if
-the value is missing with [`isnull()`](@ref), and then doing an appropriate
+the value is missing with [`isnull`](@ref), and then doing an appropriate
 action. However, there are some common use cases where the code could be more
 concise or clear by using a higher-order function.
 
@@ -1503,7 +1503,7 @@ example, we will assume that the best solution is to propagate the missing
 values forward; that is, if any input is missing, we simply produce a missing
 output.
 
-The `broadcast()` function makes this task easy; we can simply pass the
+The `broadcast` function makes this task easy; we can simply pass the
 `root` function we wrote to `broadcast`:
 
 ```jldoctest nullableroot
@@ -1518,9 +1518,9 @@ Nullable{Float64}()
 ```
 
 If one or more of the inputs is missing, then the output of
-`broadcast()` will be missing.
+`broadcast` will be missing.
 
-There exists special syntactic sugar for the `broadcast()` function
+There exists special syntactic sugar for the `broadcast` function
 using a dot notation:
 
 ```jldoctest nullableroot
@@ -1528,7 +1528,7 @@ julia> root.(Nullable(1), Nullable(-9), Nullable(20))
 Nullable{Float64}(5.0)
 ```
 
-In particular, the regular arithmetic operators can be `broadcast()`
+In particular, the regular arithmetic operators can be `broadcast`
 conveniently using `.`-prefixed operators:
 
 ```jldoctest

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -304,8 +304,8 @@ julia> odd(3)
 true
 ```
 
-Julia provides built-in, efficient functions to test for oddness and evenness called [`iseven()`](@ref)
-and [`isodd()`](@ref) so the above definitions should only be taken as examples.
+Julia provides built-in, efficient functions to test for oddness and evenness called [`iseven`](@ref)
+and [`isodd`](@ref) so the above definitions should only be taken as examples.
 
 ### Hard vs. Soft Local Scope
 

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -2,7 +2,7 @@
 
 ## [Iteration](@id lib-collections-iteration)
 
-Sequential iteration is implemented by the methods [`start()`](@ref), [`done()`](@ref), and [`next()`](@ref).
+Sequential iteration is implemented by the methods [`start`](@ref), [`done`](@ref), and [`next`](@ref).
 The general `for` loop:
 
 ```julia
@@ -161,8 +161,8 @@ Partially implemented by:
 
 ## Associative Collections
 
-[`Dict`](@ref) is the standard associative collection. Its implementation uses [`hash()`](@ref)
-as the hashing function for the key, and [`isequal()`](@ref) to determine equality. Define these
+[`Dict`](@ref) is the standard associative collection. Its implementation uses [`hash`](@ref)
+as the hashing function for the key, and [`isequal`](@ref) to determine equality. Define these
 two functions for custom types to override how they are stored in a hash table.
 
 [`ObjectIdDict`](@ref) is a special hash table where the keys are always object identities.
@@ -170,7 +170,7 @@ two functions for custom types to override how they are stored in a hash table.
 [`WeakKeyDict`](@ref) is a hash table implementation where the keys are weak references to objects, and
 thus may be garbage collected even when referenced in a hash table.
 
-[`Dict`](@ref)s can be created by passing pair objects constructed with `=>()` to a [`Dict`](@ref)
+[`Dict`](@ref)s can be created by passing pair objects constructed with `=>` to a [`Dict`](@ref)
 constructor: `Dict("A"=>1, "B"=>2)`. This call will attempt to infer type information from the
 keys and values (i.e. this example creates a `Dict{String, Int64}`). To explicitly specify types
 use the syntax `Dict{KeyType,ValueType}(...)`. For example, `Dict{String,Int32}("A"=>1, "B"=>2)`.

--- a/doc/src/stdlib/libdl.md
+++ b/doc/src/stdlib/libdl.md
@@ -1,6 +1,6 @@
 # Dynamic Linker
 
-The names in `Base.Libdl` are not exported and need to be called e.g. as `Libdl.dlopen()`.
+The names in `Base.Libdl` are not exported and need to be called e.g. as `Libdl.dlopen`.
 
 ```@docs
 Base.Libdl.dlopen

--- a/doc/src/stdlib/test.md
+++ b/doc/src/stdlib/test.md
@@ -23,7 +23,7 @@ see if your code is correct by checking that the results are what you expect. It
 to ensure your code still works after you make changes, and can be used when developing as a way
 of specifying the behaviors your code should have when complete.
 
-Simple unit testing can be performed with the `@test()` and `@test_throws()` macros:
+Simple unit testing can be performed with the `@test` and `@test_throws` macros:
 
 ```@docs
 Base.Test.@test
@@ -60,7 +60,7 @@ ERROR: There was an error during testing
 ```
 
 If the condition could not be evaluated because an exception was thrown, which occurs in this
-case because `length()` is not defined for symbols, an `Error` object is returned and an exception
+case because `length` is not defined for symbols, an `Error` object is returned and an exception
 is thrown:
 
 ```julia-repl
@@ -79,7 +79,7 @@ Error During Test
 ERROR: There was an error during testing
 ```
 
-If we expect that evaluating an expression *should* throw an exception, then we can use `@test_throws()`
+If we expect that evaluating an expression *should* throw an exception, then we can use `@test_throws`
 to check that this occurs:
 
 ```jldoctest testfoo
@@ -95,7 +95,7 @@ of inputs. In the event a test fails, the default behavior is to throw an except
 However, it is normally preferable to run the rest of the tests first to get a better picture
 of how many errors there are in the code being tested.
 
-The `@testset()` macro can be used to group tests into *sets*. All the tests in a test set will
+The `@testset` macro can be used to group tests into *sets*. All the tests in a test set will
 be run, and at the end of the test set a summary will be printed. If any of the tests failed,
 or could not be evaluated due to an error, the test set will then throw a `TestSetException`.
 
@@ -167,7 +167,7 @@ ERROR: Some tests did not pass: 3 passed, 1 failed, 0 errored, 0 broken.
 
 As calculations on floating-point values can be imprecise, you can perform approximate equality
 checks using either `@test a ≈ b` (where `≈`, typed via tab completion of `\approx`, is the
-[`isapprox()`](@ref) function) or use [`isapprox()`](@ref) directly.
+[`isapprox`](@ref) function) or use [`isapprox`](@ref) directly.
 
 ```jldoctest
 julia> @test 1 ≈ 0.999999999
@@ -188,7 +188,7 @@ Base.Test.@test_nowarn
 
 ## Broken Tests
 
-If a test fails consistently it can be changed to use the `@test_broken()` macro. This will denote
+If a test fails consistently it can be changed to use the `@test_broken` macro. This will denote
 the test as `Broken` if the test continues to fail and alerts the user via an `Error` if the test
 succeeds.
 
@@ -196,7 +196,7 @@ succeeds.
 Base.Test.@test_broken
 ```
 
-`@test_skip()` is also available to skip a test without evaluation, but counting the skipped test
+`@test_skip` is also available to skip a test without evaluation, but counting the skipped test
 in the test set reporting. The test will not run but gives a `Broken` `Result`.
 
 ```@docs


### PR DESCRIPTION
We are a bit inconsistent with how functions are referenced and mentioned. Consider for instance: ``...by first calling [`find()`](@ref).`` This is IMO misleading (there is no zero-arg `find` method) and should rather be referenced without the parentheses.

This is just a naive regex find and replace, so probably a lot of errors.