### PR TITLE
faster sparse(::Diagonal)

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -763,6 +763,11 @@ function sparse(B::Bidiagonal)
     return sparse([1:m;1:m-1],[1:m;2:m],[B.dv;B.ev], Int(m), Int(m)) # upper bidiagonal
 end
 
+function sparse(D::Diagonal{T}) where T
+    m = length(D.diag)
+    return SparseMatrixCSC(m, m, collect(1:(m+1)), collect(1:m), Vector{T}(D.diag))
+end
+
 ## Transposition and permutation methods
 
 """

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1305,6 +1305,9 @@ end
     B = Bidiagonal(randn(5),randn(4),:L)
     S = sparse(B)
     @test norm(Array(B) - Array(S)) == 0.0
+    D = Diagonal(randn(5))
+    S = sparse(D)
+    @test norm(Array(D) - Array(S)) == 0.0
 end
 
 @testset "spdiagm promotion" begin


### PR DESCRIPTION
Missing method `sparse(::Diagonal)`:

| Size          | master                                  | PR                                    | speedup |
|---------------|-----------------------------------------|---------------------------------------|---------|
| 100x100       | 29.076 μs (7 allocations: 4.45 KiB)     | 210.451 ns (5 allocations: 1.86 KiB)  | 140     |
| 1000x1000     | 2.600 ms (7 allocations: 39.89 KiB)     | 1.450 μs (5 allocations: 16.05 KiB)   | 2k    |
| 10000x10000   | 283.301 ms (12 allocations: 391.22 KiB) | 14.472 μs (7 allocations: 156.58 KiB) | 20k     |
| 100000x100000 | 27.050 s (12 allocations: 3.82 MiB)     | 169.198 μs (7 allocations: 1.53 MiB)  | 160k    |