### PR TITLE
add support of cartesian range indexing for AbstractArray

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -905,8 +905,19 @@ julia> getindex(A, 2:4)
  3
  2
  4
+
+ julia> getindex(A, CartesianRange((2:4,)))
+3-element Array{Int64,1}:
+ 3
+ 2
+ 4
 ```
 """
+function getindex{T,N}(A::AbstractArray{T,N}, cr::CartesianRange{CartesianIndex{N}})
+    # transform cartesian range to unit range
+    ur = map((x,y)->x:y, cr.start.I, cr.stop.I)
+    A[ur...]
+end 
 function getindex(A::AbstractArray, I...)
     @_propagate_inbounds_meta
     error_if_canonical_indexing(IndexStyle(A), A, I...)
@@ -990,6 +1001,11 @@ _unsafe_ind2sub(sz, i) = (@_inline_meta; ind2sub(sz, i))
 
 Store values from array `X` within some subset of `A` as specified by `inds`.
 """
+function setindex!{T,N}(A::AbstractArray{T,N}, v, cr::CartesianRange{CartesianIndex{N}})
+    # transfer cartesian range to unit range
+    ur = map((x,y)->x:y, cr.start.I, cr.stop.I)
+    A[ur...] = v
+end 
 function setindex!(A::AbstractArray, v, I...)
     @_propagate_inbounds_meta
     error_if_canonical_indexing(IndexStyle(A), A, I...)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -111,6 +111,11 @@ end
     @test checkbounds(Bool, A, [CartesianIndex((5, 5))], 3) == false
     @test checkbounds(Bool, A, [CartesianIndex((5, 4))], 4) == false
 end
+@testset "cartesian range" begin
+    @test A[CartesianRange((1:2, 2:3, 1:2))] == A[1:2, 2:3, 1:2]
+    A[CartesianRange((4:5, 1:2, 1:2))] = reshape(Array(1:8), (2,2,2))
+    @test A[CartesianRange((4:5, 1:2, 1:2))] == reshape(Array(1:8), (2,2,2))
+end 
 
 @testset "sub2ind & ind2sub" begin
     @testset "0-dimensional" begin


### PR DESCRIPTION
CartesianIndex was supported, but not CartesianRange. This PR add the support of CartesianRange indexing.
We can do the following:
```
A[CartesianRange((4:5, 1:2, 1:2))] = reshape(Array(1:8), (2,2,2))
A[CartesianRange((4:5, 1:2, 1:2))] == reshape(Array(1:8), (2,2,2))
```

This was motivated by a `type piracy` issue.
https://github.com/seung-lab/BigArrays.jl/issues/21