### PR TITLE
Removed default descriptions from multidimensional.jl

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -642,7 +642,7 @@ end
 """
     cumsum(A, dim=1)
 
-Cumulative sum along a dimension `dim` (defaults to 1). See also [`cumsum!`](@ref)
+Cumulative sum along a dimension `dim`. See also [`cumsum!`](@ref)
 to use a preallocated output array, both for performance and to control the precision of the
 output (e.g. to avoid overflow).
 
@@ -671,15 +671,14 @@ end
 """
     cumsum!(B, A, dim::Integer=1)
 
-Cumulative sum of `A` along a dimension, storing the result in `B`. The dimension defaults
-to 1. See also [`cumsum`](@ref).
+Cumulative sum of `A` along a dimension, storing the result in `B`. See also [`cumsum`](@ref).
 """
 cumsum!(B, A, axis::Integer=1) = accumulate!(+, B, A, axis)
 
 """
     cumprod(A, dim=1)
 
-Cumulative product along a dimension `dim` (defaults to 1). See also
+Cumulative product along a dimension `dim`. See also
 [`cumprod!`](@ref) to use a preallocated output array, both for performance and
 to control the precision of the output (e.g. to avoid overflow).
 
@@ -705,7 +704,7 @@ cumprod(A::AbstractArray, axis::Integer=1) = accumulate(*, A, axis)
 """
     cumprod!(B, A, dim::Integer=1)
 
-Cumulative product of `A` along a dimension, storing the result in `B`. The dimension defaults to 1.
+Cumulative product of `A` along a dimension, storing the result in `B`. 
 See also [`cumprod`](@ref).
 """
 cumprod!(B, A, axis::Integer=1) = accumulate!(*, B, A, axis)
@@ -713,7 +712,7 @@ cumprod!(B, A, axis::Integer=1) = accumulate!(*, B, A, axis)
 """
     accumulate(op, A, dim=1)
 
-Cumulative operation `op` along a dimension `dim` (defaults to 1). See also
+Cumulative operation `op` along a dimension `dim`. See also
 [`accumulate!`](@ref) to use a preallocated output array, both for performance and
 to control the precision of the output (e.g. to avoid overflow). For common operations
 there are specialized variants of `accumulate`, see:
@@ -797,8 +796,7 @@ end
 """
     accumulate!(op, B, A, dim=1)
 
-Cumulative operation `op` on `A` along a dimension, storing the result in `B`.
-The dimension defaults to 1. See also [`accumulate`](@ref).
+Cumulative operation `op` on `A` along a dimension, storing the result in `B`. See also [`accumulate`](@ref).
 """
 function accumulate!(op, B, A, axis::Integer=1)
     axis > 0 || throw(ArgumentError("axis must be a positive integer"))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -704,7 +704,7 @@ cumprod(A::AbstractArray, axis::Integer=1) = accumulate(*, A, axis)
 """
     cumprod!(B, A, dim::Integer=1)
 
-Cumulative product of `A` along a dimension, storing the result in `B`. 
+Cumulative product of `A` along a dimension, storing the result in `B`.
 See also [`cumprod`](@ref).
 """
 cumprod!(B, A, axis::Integer=1) = accumulate!(*, B, A, axis)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -796,7 +796,8 @@ end
 """
     accumulate!(op, B, A, dim=1)
 
-Cumulative operation `op` on `A` along a dimension, storing the result in `B`. See also [`accumulate`](@ref).
+Cumulative operation `op` on `A` along a dimension, storing the result in `B`.
+See also [`accumulate`](@ref).
 """
 function accumulate!(op, B, A, axis::Integer=1)
     axis > 0 || throw(ArgumentError("axis must be a positive integer"))


### PR DESCRIPTION
Removed default descriptions which were redundant with the method signature.

E.g.
```julia
cumsum!(B, A, dim::Integer=1)

  Cumulative sum of A along a dimension, storing the result in B. The dimension defaults to 1. See also cumsum.
```