### PR TITLE
`ones` should call `oneunit`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -441,7 +441,7 @@ See also [`zeros`](@ref), [`similar`](@ref).
 """
 function ones end
 
-for (fname, felt) in ((:zeros,:zero), (:ones,:one))
+for (fname, felt) in ((:zeros,:zero), (:ones,:oneunit))
     @eval begin
         # allow signature of similar
         $fname(a::AbstractArray, T::Type, dims::Tuple) = fill!(similar(a, T, dims), $felt(T))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2,7 +2,7 @@
 
 # Array test
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using TestHelpers.OAs
+using TestHelpers: OAs, Furlong
 
 @testset "basics" begin
     @test length([1, 2, 3]) == 3
@@ -2175,6 +2175,10 @@ end
     oarr = zeros(randn(3), UInt16, 1:3, -1:0)
     @test indices(oarr) == (1:3, -1:0)
     test_zeros(oarr.parent, Matrix{UInt16}, (3, 2))
+
+    # works with oneunit rather than one
+    @test eltype(ones(Furlong{3, Int16}, 2)) === Furlong{3, Int16}
+    @test eltype(zeros(Furlong{2, Int32}, 2)) === Furlong{2, Int32}
 end
 
 # issue #11053


### PR DESCRIPTION
According to docstring, `ones` creates an array of `T`, hence it should call `oneunit` rather than `one`. See #16116 and #20268.

This PR requests makes the following call successful:

~~~Julia
using Unitful
ones(typeof(1u"m"), 2)
~~~

Another option would be to add `oneunits` to Base?