### PR TITLE
Use sudo: required on Travis to activate premium VMs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-sudo: false
+sudo: required
 dist: trusty
 matrix:
   include:


### PR DESCRIPTION
Travis has temporarily given us access to premium VMs. They're automatically chosen when setting `sudo: required`, so this activates them.