### PR TITLE
fix IntSet tests invalid since #23138

### DIFF
--- a/test/intset.jl
+++ b/test/intset.jl
@@ -252,9 +252,7 @@ end
 
 @testset "setlike" begin
     p = IntSet([1,2,5,6])
-    resize!(p.bits, 6)
     q = IntSet([1,3,5,7])
-    resize!(q.bits, 8)
     a = Set(p)
     b = Set(q)
     for f in (union, intersect, setdiff, symdiff)


### PR DESCRIPTION
Since #23138 IntSet have the length of their underlying BitVector be
a multiple of 64, so resizing them to something else breaks
this invariant.

cc @mbauman : you made these tests in #20456, what was the intent of this manual resizing?