### PR TITLE
Add gc use intrinisic

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -438,4 +438,6 @@ show(@nospecialize a) = show(STDOUT, a)
 print(@nospecialize a...) = print(STDOUT, a...)
 println(@nospecialize a...) = println(STDOUT, a...)
 
+gcuse(@nospecialize a) = ccall(:jl_gc_use, Void, (Any,), a)
+
 ccall(:jl_set_istopmod, Void, (Any, Bool), Core, true)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1687,6 +1687,13 @@ static jl_cgval_t emit_ccall(jl_codectx_t &ctx, jl_value_t **args, size_t nargs)
         emit_signal_fence(ctx);
         return ghostValue(jl_void_type);
     }
+    else if (is_libjulia_func(jl_gc_use)) {
+        assert(lrt == T_void);
+        assert(!isVa && !llvmcall && nargt == 1);
+        ctx.builder.CreateCall(prepare_call(gc_use_func), {decay_derived(boxed(ctx, argv[0]))});
+        JL_GC_POP();
+        return ghostValue(jl_void_type);
+    }
     else if (_is_libjulia_func((uintptr_t)ptls_getter, "jl_get_ptls_states")) {
         assert(lrt == T_pint8);
         assert(!isVa && !llvmcall && nargt == 0);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -357,6 +357,7 @@ static GlobalVariable *jlgetworld_global;
 
 // placeholder functions
 static Function *gcroot_flush_func;
+static Function *gc_use_func;
 static Function *except_enter_func;
 static Function *pointer_from_objref_func;
 
@@ -6488,6 +6489,12 @@ static void init_julia_llvm_env(Module *m)
                                          Function::ExternalLinkage,
                                          "julia.gcroot_flush");
     add_named_global(gcroot_flush_func, (void*)NULL, /*dllimport*/false);
+
+    gc_use_func = Function::Create(FunctionType::get(T_void,
+                                         ArrayRef<Type*>(PointerType::get(T_jlvalue, AddressSpace::Derived)), false),
+                                         Function::ExternalLinkage,
+                                         "julia.gc_use");
+    add_named_global(gc_use_func, (void*)NULL, /*dllimport*/false);
 
     pointer_from_objref_func = Function::Create(FunctionType::get(T_pjlvalue,
                                          ArrayRef<Type*>(PointerType::get(T_jlvalue, AddressSpace::Derived)), false),

--- a/src/julia.h
+++ b/src/julia.h
@@ -648,6 +648,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_alloc_1w(void);
 JL_DLLEXPORT jl_value_t *jl_gc_alloc_2w(void);
 JL_DLLEXPORT jl_value_t *jl_gc_alloc_3w(void);
 JL_DLLEXPORT jl_value_t *jl_gc_allocobj(size_t sz);
+JL_DLLEXPORT void jl_gc_use(jl_value_t *a);
 
 JL_DLLEXPORT void jl_clear_malloc_data(void);
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -305,6 +305,10 @@ JL_DLLEXPORT jl_value_t *jl_value_ptr(jl_value_t *a)
 {
     return a;
 }
+JL_DLLEXPORT void jl_gc_use(jl_value_t *a)
+{
+    (void)a;
+}
 
 // parsing --------------------------------------------------------------------
 


### PR DESCRIPTION
Now that our gc root placement pass is significantly more aggressive about
dropping roots, we need to be a bit more careful about our use of pointer,
etc. This adds a low-level, zero-overhead intrinsic for annotating gc uses to keep objects
alive even if they would be otherwise unreferenced.

As an initial use case, we get rid of a number of uses of `pointer` in string,
but creating a new `unsafe_load` that keeps the string alive.