### PR TITLE
make performancetips code consistent with offset arrays

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1094,7 +1094,7 @@ Sometimes you can enable better optimization by promising certain program proper
   * Write `@simd` in front of `for` loops that are amenable to vectorization. **This feature is experimental**
     and could change or disappear in future versions of Julia.
 
-The common ideom of using 1:n to index into an AbstractArray is not safe if the Array uses unconventional indexing,
+The common idiom of using 1:n to index into an AbstractArray is not safe if the Array uses unconventional indexing,
 and may cause a segmentation fault if bounds checking is turned off. Use `linearindices(x)` instead (see also
 [offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays)).
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1095,7 +1095,7 @@ Sometimes you can enable better optimization by promising certain program proper
     and could change or disappear in future versions of Julia.
 
 The common idiom of using 1:n to index into an AbstractArray is not safe if the Array uses unconventional indexing,
-and may cause a segmentation fault if bounds checking is turned off. Use `linearindices(x)` or `eachindex(x)` 
+and may cause a segmentation fault if bounds checking is turned off. Use `linearindices(x)` or `eachindex(x)`
 instead (see also [offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays)).
 
 Note: While `@simd` needs to be placed directly in front of a loop, both `@inbounds` and `@fastmath`

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1094,6 +1094,10 @@ Sometimes you can enable better optimization by promising certain program proper
   * Write `@simd` in front of `for` loops that are amenable to vectorization. **This feature is experimental**
     and could change or disappear in future versions of Julia.
 
+The common ideom of using 1:n to index into an AbstractArray is not safe if the Array uses unconventional indexing,
+and may cause a segmentation fault if bounds checking is turned off. Use `linearindices(x)` instead (see also
+[offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays)).
+
 Note: While `@simd` needs to be placed directly in front of a loop, both `@inbounds` and `@fastmath`
 can be applied to several statements at once, e.g. using `begin` ... `end`, or even to a whole
 function.

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1173,32 +1173,32 @@ Here is an example with all three kinds of markup. This program first calculates
 of a one-dimensional array, and then evaluates the L2-norm of the result:
 
 ```julia
-function init!(u)
-    inds = linearindices(u)
-    dx = 1.0 / (length(inds)-1)
-    @fastmath @inbounds @simd for i in inds
+function init!(u::Vector)
+    n = length(u)
+    dx = 1.0 / (n-1)
+    @fastmath @inbounds @simd for i in 1:n #by asserting that `u` is a `Vector` we can assume it has 1-based indexing
         u[i] = sin(2pi*dx*i)
     end
 end
 
-function deriv!(u, du)
-    inds = linearindices(u)
-    dx = 1.0 / (length(inds)-1)
-    @fastmath @inbounds du[inds[1]] = (u[inds[2]] - u[inds[1]]) / dx
-    @fastmath @inbounds @simd for i in inds[2:end-1]
+function deriv!(u::Vector, du)
+    n = length(u)
+    dx = 1.0 / (n-1)
+    @fastmath @inbounds du[1] = (u[2] - u[1]) / dx
+    @fastmath @inbounds @simd for i in 2:n-1
         du[i] = (u[i+1] - u[i-1]) / (2*dx)
     end
-    @fastmath @inbounds du[end] = (u[end] - u[end-1]) / dx
+    @fastmath @inbounds du[n] = (u[n] - u[n-1]) / dx
 end
 
-function norm(u)
-    inds = linearindices(u)
+function norm(u::Vector)
+    n = length(u)
     T = eltype(u)
     s = zero(T)
-    @fastmath @inbounds @simd for i in inds
+    @fastmath @inbounds @simd for i in 1:n
         s += u[i]^2
     end
-    @fastmath @inbounds return sqrt(s/length(inds))
+    @fastmath @inbounds return sqrt(s/n)
 end
 
 function main()

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -601,7 +601,7 @@ This should be written as:
 
 ```jldoctest
 julia> function fill_twos!(a)
-           for i=linearindices(a)
+           for i=eachindex(a)
                a[i] = 2
            end
        end
@@ -1095,8 +1095,8 @@ Sometimes you can enable better optimization by promising certain program proper
     and could change or disappear in future versions of Julia.
 
 The common idiom of using 1:n to index into an AbstractArray is not safe if the Array uses unconventional indexing,
-and may cause a segmentation fault if bounds checking is turned off. Use `linearindices(x)` instead (see also
-[offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays)).
+and may cause a segmentation fault if bounds checking is turned off. Use `linearindices(x)` or `eachindex(x)` 
+instead (see also [offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays)).
 
 Note: While `@simd` needs to be placed directly in front of a loop, both `@inbounds` and `@fastmath`
 can be applied to several statements at once, e.g. using `begin` ... `end`, or even to a whole
@@ -1107,7 +1107,7 @@ Here is an example with both `@inbounds` and `@simd` markup:
 ```julia
 function inner(x, y)
     s = zero(eltype(x))
-    for i=linearindices(x)
+    for i=eachindex(x)
         @inbounds s += x[i]*y[i]
     end
     s
@@ -1115,7 +1115,7 @@ end
 
 function innersimd(x, y)
     s = zero(eltype(x))
-    @simd for i=linearindices(x)
+    @simd for i=eachindex(x)
         @inbounds s += x[i]*y[i]
     end
     s

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -805,36 +805,36 @@ do this in at least four ways (in addition to the recommended call to the built-
 
 ```julia
 function copy_cols(x::Vector{T}) where T
-    n = indices(x, 1)
-    out = similar(Array{T},n, n)
-    for i = n
+    inds = indices(x, 1)
+    out = similar(Array{T}, inds, inds)
+    for i = inds
         out[:, i] = x
     end
     out
 end
 
 function copy_rows(x::Vector{T}) where T
-    n = indices(x, 1)
-    out = similar(Array{T},n, n)
-    for i = n
+    inds = indices(x, 1)
+    out = similar(Array{T}, inds, inds)
+    for i = inds
         out[i, :] = x
     end
     out
 end
 
 function copy_col_row(x::Vector{T}) where T
-    n = indices(x, 1)
-    out = similar(Array{T},n, n)
-    for col = n, row = n
+    inds = indices(x, 1)
+    out = similar(Array{T}, inds, inds)
+    for col = inds, row = inds
         out[row, col] = x[row]
     end
     out
 end
 
 function copy_row_col(x::Vector{T}) where T
-    n = indices(x, 1)
-    out = similar(Array{T},n, n)
-    for row = n, col = n
+    inds = indices(x, 1)
+    out = similar(Array{T}, inds, inds)
+    for row = inds, col = inds
         out[row, col] = x[col]
     end
     out
@@ -1174,31 +1174,31 @@ of a one-dimensional array, and then evaluates the L2-norm of the result:
 
 ```julia
 function init!(u)
-    n = linearindices(u)
-    dx = 1.0 / (length(n)-1)
-    @fastmath @inbounds @simd for i in n
+    inds = linearindices(u)
+    dx = 1.0 / (length(inds)-1)
+    @fastmath @inbounds @simd for i in inds
         u[i] = sin(2pi*dx*i)
     end
 end
 
 function deriv!(u, du)
-    n = linearindices(u)
-    dx = 1.0 / (length(n)-1)
-    @fastmath @inbounds du[n[1]] = (u[n[2]] - u[n[1]]) / dx
-    @fastmath @inbounds @simd for i in n[2:end-1]
+    inds = linearindices(u)
+    dx = 1.0 / (length(inds)-1)
+    @fastmath @inbounds du[inds[1]] = (u[inds[2]] - u[inds[1]]) / dx
+    @fastmath @inbounds @simd for i in inds[2:end-1]
         du[i] = (u[i+1] - u[i-1]) / (2*dx)
     end
     @fastmath @inbounds du[end] = (u[end] - u[end-1]) / dx
 end
 
 function norm(u)
-    n = linearindices(u)
+    inds = linearindices(u)
     T = eltype(u)
     s = zero(T)
-    @fastmath @inbounds @simd for i in n
+    @fastmath @inbounds @simd for i in inds
         s += u[i]^2
     end
-    @fastmath @inbounds return sqrt(s/n)
+    @fastmath @inbounds return sqrt(s/length(inds))
 end
 
 function main()


### PR DESCRIPTION
As remarked on Discourse (https://discourse.julialang.org/t/is-inbounds-really-necessary/5654/12) the performance tips code for inbounds is not consistent with recommended style.

The performance tips e.g. use 1:n to iterate over an array to demonstrate a case where it is safe to use `@inbounds`. But that very example is used here: https://docs.julialang.org/en/latest/devdocs/offset-arrays/#Background-1 to describe a situation where it is NOT safe to use `@inbounds` because the array could be an offsetarray.

When used as in the context here it is still safe, because the array is initialized in the previous line, but it is possibly misleading.

I updated the code examples on the page to be consistent with the generalized-array syntax as I understand it.