### PR TITLE
Fix orgrq! implementation for nonsquare matrices

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -2559,8 +2559,10 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgrq!(A::StridedMatrix{$elty}, tau::StridedVector{$elty}, k::Integer = length(tau))
             chkstride1(A,tau)
-            m = size(A, 1)
-            n = min(m, size(A, 2))
+            m, n = size(A)
+            if n < m
+                throw(DimensionMismatch("input matrix A has dimensions ($m,$n), but cannot have fewer columns than rows"))
+            end
             if k > n
                 throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= n = $n"))
             end
@@ -2580,11 +2582,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
                     resize!(work, lwork)
                 end
             end
-            if n < size(A,2)
-                A[:,1:n]
-            else
-                A
-            end
+            A
         end
 
         #      SUBROUTINE DORMLQ( SIDE, TRANS, M, N, K, A, LDA, TAU, C, LDC,

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -316,6 +316,15 @@ end
         @test_throws DimensionMismatch LAPACK.ormrq!('R','N',A,zeros(elty,11),rand(elty,10,10))
         @test_throws DimensionMismatch LAPACK.ormrq!('L','N',A,zeros(elty,11),rand(elty,10,10))
 
+        A = rand(elty,10,11)
+        Q = copy(A)
+        Q,tau = LAPACK.gerqf!(Q)
+        R = triu(Q[:,2:11])
+        LAPACK.orgrq!(Q,tau)
+        @test Q*Q' ≈ eye(elty,10)
+        @test R*Q ≈ A
+        @test_throws DimensionMismatch LAPACK.orgrq!(zeros(elty,11,10),zeros(elty,10))
+
         C = rand(elty,10,10)
         V = rand(elty,10,10)
         T = zeros(elty,10,11)


### PR DESCRIPTION
The implementation of orgrq! followed the implementation of orgqr!,
resulting in erroneous behavior for nonsquare matrices. This commit
provides a fix.