### PR TITLE
Refactor LibGit2 credential_loop tests

### DIFF
--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -53,7 +53,7 @@ function with_fake_pty(f)
     end
 end
 
-function challenge_prompt(code::AbstractString, challenges; timeout::Integer=10, debug::Bool=true)
+function challenge_prompt(code::Expr, challenges; timeout::Integer=10, debug::Bool=true)
     output_file = tempname()
     wrapped_code = """
     result = let

--- a/test/libgit2-helpers.jl
+++ b/test/libgit2-helpers.jl
@@ -39,7 +39,14 @@ function credential_loop(
         end
     end
 
-    return err, num_authentications
+    # Note: LibGit2.GitError(0) will not work if an error message has been set.
+    git_error = if err == 0
+        LibGit2.GitError(LibGit2.Error.None, LibGit2.Error.GIT_OK, "No errors")
+    else
+        LibGit2.GitError(err)
+    end
+
+    return git_error, num_authentications
 end
 
 function credential_loop(

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1635,24 +1635,24 @@ mktempdir() do dir
             username = "git"
             passphrase = "secret"
 
-            ssh_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.SSHCredentials("$username", "", "$valid_key", "$valid_key.pub")
-            credential_loop(valid_cred, "$url", "$username")
-            """
+            ssh_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = SSHCredentials($username, "", $valid_key, $(valid_key * ".pub"))
+                credential_loop(valid_cred, $url, $username)
+            end
 
-            ssh_p_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.SSHCredentials("$username", "$passphrase", "$valid_p_key", "$valid_p_key.pub")
-            credential_loop(valid_cred, "$url", "$username")
-            """
+            ssh_p_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = SSHCredentials($username, $passphrase, $valid_p_key, $(valid_p_key * ".pub"))
+                credential_loop(valid_cred, $url, $username)
+            end
 
             # SSH requires username
-            ssh_u_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.SSHCredentials("$username", "", "$valid_key", "$valid_key.pub")
-            credential_loop(valid_cred, "$url")
-            """
+            ssh_u_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = SSHCredentials($username, "", $valid_key, $(valid_key * ".pub"))
+                credential_loop(valid_cred, $url)
+            end
 
             # Note: We cannot use the default ~/.ssh/id_rsa for tests since we cannot be
             # sure a users will actually have these files. Instead we will use the ENV
@@ -1660,7 +1660,7 @@ mktempdir() do dir
 
             # Default credentials are valid
             withenv("SSH_KEY_PATH" => valid_key) do
-                err, auth_attempts = challenge_prompt(ssh_cmd, [])
+                err, auth_attempts = challenge_prompt(ssh_ex, [])
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -1670,7 +1670,7 @@ mktempdir() do dir
                 challenges = [
                     "Passphrase for $valid_p_key:" => "$passphrase\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1683,7 +1683,7 @@ mktempdir() do dir
                     # "Private key location for 'git@github.com' [$valid_p_key]:" => "\n",
                     "Passphrase for $valid_p_key:" => "$passphrase\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 5
 
@@ -1691,7 +1691,7 @@ mktempdir() do dir
                 challenges = [
                     "Passphrase for $valid_p_key:" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
 
@@ -1699,13 +1699,13 @@ mktempdir() do dir
                 challenges = [
                     "Passphrase for $valid_p_key:" => "\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
             end
 
             withenv("SSH_KEY_PATH" => valid_p_key, "SSH_KEY_PASS" => passphrase) do
-                err, auth_attempts = challenge_prompt(ssh_p_cmd, [])
+                err, auth_attempts = challenge_prompt(ssh_p_ex, [])
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -1716,7 +1716,7 @@ mktempdir() do dir
                 challenges = [
                     "Username for 'github.com':" => "$username\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1724,7 +1724,7 @@ mktempdir() do dir
                 challenges = [
                     "Username for 'github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
 
@@ -1733,7 +1733,7 @@ mktempdir() do dir
                     "Username for 'github.com':" => "\n",
                     "Username for 'github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 5  # Should ideally be <= 2
 
@@ -1743,22 +1743,22 @@ mktempdir() do dir
                     "Username for 'github.com' [foo]:" => "\n",
                     "Username for 'github.com' [foo]:" => "\x04",  # Need to manually abort
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 6
 
                 # Credential callback is given an empty string in the `username_ptr`
                 # instead of the typical C_NULL.
-                ssh_user_empty_cmd = """
-                include("$LIBGIT2_HELPER_PATH")
-                valid_cred = LibGit2.SSHCredentials("$username", "", "$valid_key", "$valid_key.pub")
-                credential_loop(valid_cred, "$url", "")
-                """
+                ssh_user_empty_ex = quote
+                    include($LIBGIT2_HELPER_PATH)
+                    valid_cred = LibGit2.SSHCredentials($username, "", $valid_key, $(valid_key * ".pub"))
+                    credential_loop(valid_cred, $url, "")
+                end
 
                 challenges = [
                     "Username for 'github.com':" => "$username\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_user_empty_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_user_empty_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -1779,7 +1779,7 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com':" => "$valid_key\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1788,7 +1788,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com':" => "$valid_p_key\n",
                     "Passphrase for $valid_p_key:" => "$passphrase\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1796,7 +1796,7 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
 
@@ -1806,7 +1806,7 @@ mktempdir() do dir
                     "Public key location for 'git@github.com' [.pub]:" => "\n",
                     "Private key location for 'git@github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 2
             end
@@ -1820,7 +1820,7 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com' [$invalid_key]:" => "$valid_key\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 2
             end
@@ -1837,7 +1837,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com' [$valid_key]:" => "\n"
                     "Public key location for 'git@github.com':" => "$valid_key.pub\n"
                 ]
-                err, auth_attempts = challenge_prompt(ssh_cmd, challenges)
+                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 2
             end
@@ -1850,18 +1850,18 @@ mktempdir() do dir
             valid_username = "julia"
             valid_password = randstring(16)
 
-            https_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("$valid_username", "$valid_password")
-            credential_loop(valid_cred, "$url")
-            """
+            https_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                credential_loop(valid_cred, $url)
+            end
 
             # User provides a valid username and password
             challenges = [
                 "Username for 'https://github.com':" => "$valid_username\n",
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
-            err, auth_attempts = challenge_prompt(https_cmd, challenges)
+            err, auth_attempts = challenge_prompt(https_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 1
 
@@ -1869,7 +1869,7 @@ mktempdir() do dir
             challenges = [
                 "Username for 'https://github.com':" => "\x04",
             ]
-            err, auth_attempts = challenge_prompt(https_cmd, challenges)
+            err, auth_attempts = challenge_prompt(https_ex, challenges)
             @test err == abort_prompt
             @test auth_attempts == 1
 
@@ -1878,7 +1878,7 @@ mktempdir() do dir
                 "Username for 'https://github.com':" => "foo\n",
                 "Password for 'https://foo@github.com':" => "\x04",
             ]
-            err, auth_attempts = challenge_prompt(https_cmd, challenges)
+            err, auth_attempts = challenge_prompt(https_ex, challenges)
             @test err == abort_prompt
             @test auth_attempts == 1
 
@@ -1888,7 +1888,7 @@ mktempdir() do dir
                 "Username for 'https://github.com':" => "foo\n",
                 "Password for 'https://foo@github.com':" => "\n",
             ]
-            err, auth_attempts = challenge_prompt(https_cmd, challenges)
+            err, auth_attempts = challenge_prompt(https_ex, challenges)
             @test err == abort_prompt
             @test auth_attempts == 1
 
@@ -1900,7 +1900,7 @@ mktempdir() do dir
                 "Username for 'https://github.com' [foo]:" => "$valid_username\n",
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
-            err, auth_attempts = challenge_prompt(https_cmd, challenges)
+            err, auth_attempts = challenge_prompt(https_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 5
         end
@@ -1913,30 +1913,30 @@ mktempdir() do dir
             username = "git"
             passphrase = "secret"
 
-            valid_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.SSHCredentials("$username", "$passphrase", "$valid_p_key", "$valid_p_key.pub")
-            payload = CredentialPayload(Nullable(valid_cred))
-            credential_loop(valid_cred, "$url", "$username", payload)
-            """
+            valid_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.SSHCredentials($username, $passphrase, $valid_p_key, $(valid_p_key * ".pub"))
+                payload = CredentialPayload(Nullable(valid_cred))
+                credential_loop(valid_cred, $url, $username, payload)
+            end
 
-            invalid_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.SSHCredentials("$username", "$passphrase", "$valid_p_key", "$valid_p_key.pub")
-            invalid_cred = LibGit2.SSHCredentials("$username", "", "$invalid_key", "$invalid_key.pub")
-            invalid_cred.usesshagent = "N"  # Disable SSH agent use
-            payload = CredentialPayload(Nullable(invalid_cred))
-            credential_loop(valid_cred, "$url", "$username", payload)
-            """
+            invalid_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.SSHCredentials($username, $passphrase, $valid_p_key, $(valid_p_key * ".pub"))
+                invalid_cred = LibGit2.SSHCredentials($username, "", $invalid_key, $(invalid_key * ".pub"))
+                invalid_cred.usesshagent = "N"  # Disable SSH agent use
+                payload = CredentialPayload(Nullable(invalid_cred))
+                credential_loop(valid_cred, $url, $username, payload)
+            end
 
             # Explicitly provided credential is correct
-            err, auth_attempts = challenge_prompt(valid_cmd, [])
+            err, auth_attempts = challenge_prompt(valid_ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
             # Explicitly provided credential is incorrect
             # TODO: Unless the SSH agent is disabled we may get caught in an infinite loop
-            err, auth_attempts = challenge_prompt(invalid_cmd, [])
+            err, auth_attempts = challenge_prompt(invalid_ex, [])
             @test err == eauth_error
             @test auth_attempts == 4
         end
@@ -1949,28 +1949,28 @@ mktempdir() do dir
             invalid_username = "alice"
             invalid_password = randstring(15)
 
-            valid_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("$valid_username", "$valid_password")
-            payload = CredentialPayload(Nullable(valid_cred))
-            credential_loop(valid_cred, "$url", "", payload)
-            """
+            valid_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                payload = CredentialPayload(Nullable(valid_cred))
+                credential_loop(valid_cred, $url, "", payload)
+            end
 
-            invalid_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("$valid_username", "$valid_password")
-            invalid_cred = LibGit2.UserPasswordCredentials("$invalid_username", "$invalid_password")
-            payload = CredentialPayload(Nullable(invalid_cred))
-            credential_loop(valid_cred, "$url", "", payload)
-            """
+            invalid_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                invalid_cred = LibGit2.UserPasswordCredentials($invalid_username, $invalid_password)
+                payload = CredentialPayload(Nullable(invalid_cred))
+                credential_loop(valid_cred, $url, "", payload)
+            end
 
             # Explicitly provided credential is correct
-            err, auth_attempts = challenge_prompt(valid_cmd, [])
+            err, auth_attempts = challenge_prompt(valid_ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
             # Explicitly provided credential is incorrect
-            err, auth_attempts = challenge_prompt(invalid_cmd, [])
+            err, auth_attempts = challenge_prompt(invalid_ex, [])
             @test err == eauth_error
             @test auth_attempts == 4
         end
@@ -1984,39 +1984,37 @@ mktempdir() do dir
             invalid_username = "alice"
             invalid_password = randstring(15)
 
+            valid_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                cache = CachedCredentials()
+                LibGit2.get_creds!(cache, $cred_id, valid_cred)
+                payload = CredentialPayload(Nullable(cache))
+                credential_loop(valid_cred, $url, "", payload)
+            end
 
+            add_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                cache = CachedCredentials()
+                payload = CredentialPayload(Nullable(cache))
+                err, auth_attempts = credential_loop(valid_cred, $url, "", payload)
+                (err, auth_attempts, cache)
+            end
 
-            valid_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("$valid_username", "$valid_password")
-            cache = CachedCredentials()
-            LibGit2.get_creds!(cache, "$cred_id", valid_cred)
-            payload = CredentialPayload(Nullable(cache))
-            credential_loop(valid_cred, "$url", "", payload)
-            """
-
-            add_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("$valid_username", "$valid_password")
-            cache = CachedCredentials()
-            payload = CredentialPayload(Nullable(cache))
-            err, auth_attempts = credential_loop(valid_cred, "$url", "", payload)
-            (err, auth_attempts, cache)
-            """
-
-            replace_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("$valid_username", "$valid_password")
-            invalid_cred = LibGit2.UserPasswordCredentials("$invalid_username", "$invalid_password", true)
-            cache = CachedCredentials()
-            LibGit2.get_creds!(cache, "$cred_id", invalid_cred)
-            payload = CredentialPayload(Nullable(cache))
-            err, auth_attempts = credential_loop(valid_cred, "$url", "", payload)
-            (err, auth_attempts, cache)
-            """
+            replace_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                invalid_cred = LibGit2.UserPasswordCredentials($invalid_username, $invalid_password, true)
+                cache = CachedCredentials()
+                LibGit2.get_creds!(cache, $cred_id, invalid_cred)
+                payload = CredentialPayload(Nullable(cache))
+                err, auth_attempts = credential_loop(valid_cred, $url, "", payload)
+                (err, auth_attempts, cache)
+            end
 
             # Cache contains a correct credential
-            err, auth_attempts = challenge_prompt(valid_cmd, [])
+            err, auth_attempts = challenge_prompt(valid_ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
@@ -2026,7 +2024,7 @@ mktempdir() do dir
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
             expected_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password)
-            err, auth_attempts, cache = challenge_prompt(add_cmd, challenges)
+            err, auth_attempts, cache = challenge_prompt(add_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 1
             @test typeof(cache) == LibGit2.CachedCredentials
@@ -2038,7 +2036,7 @@ mktempdir() do dir
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
             expected_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password)
-            err, auth_attempts, cache = challenge_prompt(replace_cmd, challenges)
+            err, auth_attempts, cache = challenge_prompt(replace_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 4
             @test typeof(cache) == LibGit2.CachedCredentials
@@ -2047,28 +2045,28 @@ mktempdir() do dir
 
         @testset "Incompatible explicit credentials" begin
             # User provides a user/password credential where a SSH credential is required.
-            expect_ssh_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
-            payload = CredentialPayload(Nullable(valid_cred))
-            credential_loop(valid_cred, "ssh://github.com/repo", Nullable(""),
-                Cuint(LibGit2.Consts.CREDTYPE_SSH_KEY), payload)
-            """
+            expect_ssh_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
+                payload = CredentialPayload(Nullable(valid_cred))
+                credential_loop(valid_cred, "ssh://github.com/repo", Nullable(""),
+                    Cuint(LibGit2.Consts.CREDTYPE_SSH_KEY), payload)
+            end
 
             # User provides a SSH credential where a user/password credential is required.
-            expect_https_cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.SSHCredentials("foo", "", "", "")
-            payload = CredentialPayload(Nullable(valid_cred))
-            credential_loop(valid_cred, "https://github.com/repo", Nullable(""),
-                Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT), payload)
-            """
+            expect_https_ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.SSHCredentials("foo", "", "", "")
+                payload = CredentialPayload(Nullable(valid_cred))
+                credential_loop(valid_cred, "https://github.com/repo", Nullable(""),
+                    Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT), payload)
+            end
 
-            err, auth_attempts = challenge_prompt(expect_ssh_cmd, [])
+            err, auth_attempts = challenge_prompt(expect_ssh_ex, [])
             @test err == incompatible_error
             @test auth_attempts == 1
 
-            err, auth_attempts = challenge_prompt(expect_https_cmd, [])
+            err, auth_attempts = challenge_prompt(expect_https_ex, [])
             @test err == incompatible_error
             @test auth_attempts == 1
         end
@@ -2080,15 +2078,15 @@ mktempdir() do dir
                 Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT)
 
             # User provides a user/password credential where a SSH credential is required.
-            cmd = """
-            include("$LIBGIT2_HELPER_PATH")
-            valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
-            payload = CredentialPayload(Nullable(valid_cred))
-            credential_loop(valid_cred, "foo://github.com/repo", Nullable(""),
-                Cuint($allowed_types), payload)
-            """
+            ex = quote
+                include($LIBGIT2_HELPER_PATH)
+                valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
+                payload = CredentialPayload(Nullable(valid_cred))
+                credential_loop(valid_cred, "foo://github.com/repo", Nullable(""),
+                    $allowed_types, payload)
+            end
 
-            err, auth_attempts = challenge_prompt(cmd, [])
+            err, auth_attempts = challenge_prompt(ex, [])
             @test err == git_ok
             @test auth_attempts == 1
         end


### PR DESCRIPTION
- Modified `credential_loop` to return a `LibGit2.GitError`.
- Modified `challenge_prompt` to take a an `Expr` instead of a `String`.