### PR TITLE
Fix & deprecation message and two uses of that syntax

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -904,15 +904,15 @@ end
 
 function _calculate_buffer_size!(buf, fmt, x::BigFloat)
     ccall((:mpfr_snprintf,:libmpfr),
-        Int32, (Ptr{UInt8}, Culong, Ptr{UInt8}, Ptr{BigFloat}...),
-        buf, 0, fmt, &x)
+        Int32, (Ptr{UInt8}, Culong, Ptr{UInt8}, Ref{BigFloat}...),
+        buf, 0, fmt, x)
 end
 
 function _fill_buffer!(buf, fmt, x::BigFloat)
     s = length(buf)
     # we temporarily need one more item in buffer to capture null termination
     resize!(buf, s + 1)
-    n = ccall((:mpfr_sprintf,:libmpfr), Int32, (Ptr{UInt8}, Ptr{UInt8}, Ptr{BigFloat}...), buf, fmt, &x)
+    n = ccall((:mpfr_sprintf,:libmpfr), Int32, (Ptr{UInt8}, Ptr{UInt8}, Ref{BigFloat}...), buf, fmt, x)
     @assert n + 1 == length(buf)
     @assert last(buf) == 0x00
     resize!(buf, s)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3517,7 +3517,7 @@ f(x) = yt(x)
                                             (deprecation-message
                                              (string "Syntax \"&argument\"" (linenode-string current-loc)
                                                      " is deprecated. Remove the \"&\" and use a \"Ref\" argument "
-                                                     "type instead."))))
+                                                     "type instead." #\newline))))
                                       (list-tail e 6))
                             ;; NOTE: 2nd to 5th arguments of ccall must be left in place
                             ;;       the 1st should be compiled if an atom.


### PR DESCRIPTION
The deprecation of unary `&` in `ccall` introduced in #23555 omits a trailing newline in the deprecation message, which causes results like this:
```
Syntax "&argument" is deprecated. Remove the "&" and use a "Ref" argument type instead.5
```
The first commit in this PR adds a newline to the message.

The second commit fixes the use of the deprecated syntax in mpfr.jl introduced in #23388.