### PR TITLE
Fix while loop variable issue in cartesian.jl

### DIFF
--- a/base/cartesian.jl
+++ b/base/cartesian.jl
@@ -302,6 +302,7 @@ function lreplace!(str::AbstractString, r::LReplace)
     pat = r.pat_str
     j = start(pat)
     matching = false
+    local istart::Int
     while !done(str, i)
         cstr, i = next(str, i)
         if !matching

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -3,3 +3,5 @@
 @test Base.Cartesian.exprresolve(:(1 + 3)) == 4
 ex = Base.Cartesian.exprresolve(:(if 5 > 4; :x; else :y; end))
 @test ex.args[2] == QuoteNode(:x)
+
+@test Base.Cartesian.lreplace!("val_col", Base.Cartesian.LReplace{String}(:col, "col", 1)) == "val_1"


### PR DESCRIPTION
Before:
```julia
julia> str = "val_col"
"val_col"

julia> r = Base.Cartesian.LReplace{String}(:col, "col", 1)
Base.Cartesian.LReplace{String}(:col, "col", 1)

julia> Base.Cartesian.lreplace!(str, r)
(str, r, i, pat, matching) = ("val_col", Base.Cartesian.LReplace{String}(:col, "col", 1), 1, "col", false)
ERROR: UndefVarError: istart not defined
Stacktrace:
 [1] lreplace!(::String, ::Base.Cartesian.LReplace{String}) at ./REPL[17]:30
```

After:
```julia
julia> r = Base.Cartesian.LReplace{String}(:col, "col", 1)
Base.Cartesian.LReplace{String}(:col, "col", 1)

julia> str = "val_col"
"val_col"

julia> Base.Cartesian.lreplace!(str, r)
"val_1"
```

Due to #23397, right?