### PR TITLE
Correct default of writable in doc for IOBuffer

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -32,7 +32,7 @@ StringVector(n::Integer) = Vector{UInt8}(_string_n(n))
 # IOBuffers behave like Files. They are typically readable and writable. They are seekable. (They can be appendable).
 
 """
-    IOBuffer([data,],[readable::Bool=true, writable::Bool=true, [maxsize::Int=typemax(Int)]])
+    IOBuffer([data, ][readable::Bool=true, writable::Bool=false[, maxsize::Int=typemax(Int)]])
 
 Create an `IOBuffer`, which may optionally operate on a pre-existing array. If the
 readable/writable arguments are given, they restrict whether or not the buffer may be read


### PR DESCRIPTION
Changed default for writable to false in the docs. Also removed superfluous comma in doc, and adjusted brackets for optionals.

I'm not sure if there's  standard style for such brackets (they seem to be inconsistently used), and that's certainly the least important thing, here.