### PR TITLE
fix #15723, `findfirst` on strings

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -107,6 +107,9 @@ linearindices(A::AbstractVector) = (@_inline_meta; indices1(A))
 keys(a::AbstractArray) = CartesianRange(indices(a))
 keys(a::AbstractVector) = linearindices(a)
 
+prevind(::AbstractArray, i::Integer) = Int(i)-1
+nextind(::AbstractArray, i::Integer) = Int(i)+1
+
 eltype(::Type{<:AbstractArray{E}}) where {E} = E
 elsize(::AbstractArray{T}) where {T} = sizeof(T)
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1621,10 +1621,13 @@ julia> findnext(A,3)
 ```
 """
 function findnext(A, start::Integer)
-    for i = start:length(A)
+    l = endof(A)
+    i = start
+    while i <= l
         if A[i] != 0
             return i
         end
+        i = nextind(A, i)
     end
     return 0
 end
@@ -1671,10 +1674,13 @@ julia> findnext(A,4,3)
 ```
 """
 function findnext(A, v, start::Integer)
-    for i = start:length(A)
+    l = endof(A)
+    i = start
+    while i <= l
         if A[i] == v
             return i
         end
+        i = nextind(A, i)
     end
     return 0
 end
@@ -1720,10 +1726,13 @@ julia> findnext(isodd, A, 2)
 ```
 """
 function findnext(testf::Function, A, start::Integer)
-    for i = start:length(A)
+    l = endof(A)
+    i = start
+    while i <= l
         if testf(A[i])
             return i
         end
+        i = nextind(A, i)
     end
     return 0
 end
@@ -1770,8 +1779,10 @@ julia> findprev(A,1)
 ```
 """
 function findprev(A, start::Integer)
-    for i = start:-1:1
+    i = start
+    while i >= 1
         A[i] != 0 && return i
+        i = prevind(A, i)
     end
     return 0
 end
@@ -1801,7 +1812,7 @@ julia> findlast(A)
 0
 ```
 """
-findlast(A) = findprev(A, length(A))
+findlast(A) = findprev(A, endof(A))
 
 """
     findprev(A, v, i::Integer)
@@ -1823,8 +1834,10 @@ julia> findprev(A, 1, 1)
 ```
 """
 function findprev(A, v, start::Integer)
-    for i = start:-1:1
+    i = start
+    while i >= 1
         A[i] == v && return i
+        i = prevind(A, i)
     end
     return 0
 end
@@ -1852,7 +1865,7 @@ julia> findlast(A,3)
 0
 ```
 """
-findlast(A, v) = findprev(A, v, length(A))
+findlast(A, v) = findprev(A, v, endof(A))
 
 """
     findprev(predicate::Function, A, i::Integer)
@@ -1875,8 +1888,10 @@ julia> findprev(isodd, A, 3)
 ```
 """
 function findprev(testf::Function, A, start::Integer)
-    for i = start:-1:1
+    i = start
+    while i >= 1
         testf(A[i]) && return i
+        i = prevind(A, i)
     end
     return 0
 end
@@ -1901,7 +1916,7 @@ julia> findlast(x -> x > 5, A)
 0
 ```
 """
-findlast(testf::Function, A) = findprev(testf, A, length(A))
+findlast(testf::Function, A) = findprev(testf, A, endof(A))
 
 """
     find(f::Function, A)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -133,6 +133,12 @@ module IteratorsMD
         return h
     end
 
+    # nextind with CartesianIndex
+    function Base.nextind(a::AbstractArray{<:Any,N}, i::CartesianIndex{N}) where {N}
+        _, ni = next(CartesianRange(indices(a)), i)
+        return ni
+    end
+
     # Iteration
     """
         CartesianRange(sz::Dims) -> R

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -170,9 +170,7 @@ end
 ## Generic indexing functions ##
 
 prevind(s::DirectIndexString, i::Integer) = Int(i)-1
-prevind(s::AbstractArray    , i::Integer) = Int(i)-1
 nextind(s::DirectIndexString, i::Integer) = Int(i)+1
-nextind(s::AbstractArray    , i::Integer) = Int(i)+1
 
 """
     prevind(str::AbstractString, i::Integer)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -40,6 +40,9 @@ next(t::Tuple, i::Int) = (t[i], i+1)
 
 keys(t::Tuple) = 1:length(t)
 
+prevind(t::Tuple, i::Integer) = Int(i)-1
+nextind(t::Tuple, i::Integer) = Int(i)+1
+
 function keys(t::Tuple, t2::Tuple...)
     @_inline_meta
     1:_maxlength(t, t2...)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -844,3 +844,7 @@ for A in (rand(2), rand(2,3))
     end
     @test collect(values(A)) == collect(A)
 end
+
+# nextind
+@test nextind(zeros(4), 2) == 3
+@test nextind(zeros(2,3), CartesianIndex(2,1)) == CartesianIndex(1, 2)

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -379,3 +379,9 @@ end
 @test rsearchindex("\U1f596\U1f596", "\U1f596\U1f596", endof("\U1f596\U1f596\U1f596")) == 1
 
 @test_throws ErrorException "ab" ∈ "abc"
+
+# issue #15723
+@test findfirst("⨳(", '(') == 4
+@test findnext("(⨳(", '(', 2) == 5
+@test findlast("(⨳(", '(') == 5
+@test findprev("(⨳(", '(', 2) == 1


### PR DESCRIPTION
Makes findfirst, findlast, findnext, and findprev more generic by using endof, nextind, and prevind. Also adds a `nextind` method for arrays and `CartesianIndex`.

These functions are scheduled for a refactoring, but in the meantime might as well make them work better.
