### PR TITLE
REPL: more deleted words pushed into the kill ring

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -621,45 +621,54 @@ function edit_werase(buf::IOBuffer)
     pos1 = position(buf)
     char_move_word_left(buf, isspace)
     pos0 = position(buf)
-    pos0 < pos1 || return false
     edit_splice!(buf, pos0 => pos1)
-    true
 end
 
 function edit_werase(s::MIState)
     push_undo(s)
-    edit_werase(buffer(s)) ? refresh_line(s) : pop_undo(s)
-    :edit_werase
+    if push_kill!(s, edit_werase(buffer(s)), rev=true)
+        refresh_line(s)
+        :edit_werase
+    else
+        pop_undo(s)
+        :ignore
+    end
 end
 
 function edit_delete_prev_word(buf::IOBuffer)
     pos1 = position(buf)
     char_move_word_left(buf)
     pos0 = position(buf)
-    pos0 < pos1 || return false
     edit_splice!(buf, pos0 => pos1)
-    true
 end
 
 function edit_delete_prev_word(s::MIState)
     push_undo(s)
-    edit_delete_prev_word(buffer(s)) ? refresh_line(s) : pop_undo(s)
-    :edit_delete_prev_word
+    if push_kill!(s, edit_delete_prev_word(buffer(s)), rev=true)
+        refresh_line(s)
+        :edit_delete_prev_word
+    else
+        pop_undo(s)
+        :ignore
+    end
 end
 
 function edit_delete_next_word(buf::IOBuffer)
     pos0 = position(buf)
     char_move_word_right(buf)
     pos1 = position(buf)
-    pos0 < pos1 || return false
     edit_splice!(buf, pos0 => pos1)
-    true
 end
 
 function edit_delete_next_word(s)
     push_undo(s)
-    edit_delete_next_word(buffer(s)) ? refresh_line(s) : pop_undo(s)
-    :edit_delete_next_word
+    if push_kill!(s, edit_delete_next_word(buffer(s)))
+        refresh_line(s)
+        :edit_delete_next_word
+    else
+        pop_undo(s)
+        :ignore
+    end
 end
 
 function edit_yank(s::MIState)
@@ -687,10 +696,12 @@ function edit_yank_pop(s::MIState, require_previous_yank=true)
     end
 end
 
-function push_kill!(s::MIState, killed::String, concat=false)
+function push_kill!(s::MIState, killed::String, concat = s.key_repeats > 0; rev=false)
     isempty(killed) && return false
-    if concat
-        s.kill_ring[end] *= killed
+    if concat && !isempty(s.kill_ring)
+        s.kill_ring[end] = rev ?
+            killed * s.kill_ring[end] : # keep expected order for backward deletion
+            s.kill_ring[end] * killed
     else
         push!(s.kill_ring, killed)
         length(s.kill_ring) > KILL_RING_MAX[] && shift!(s.kill_ring)
@@ -708,7 +719,7 @@ function edit_kill_line(s::MIState)
         killbuf = killbuf[1:end-1]
         char_move_left(buf)
     end
-    push_kill!(s, killbuf, s.key_repeats > 0) || return :ignore
+    push_kill!(s, killbuf) || return :ignore
     edit_splice!(buf, pos => position(buf))
     refresh_line(s)
     :edit_kill_line
@@ -716,7 +727,7 @@ end
 
 function edit_copy_region(s::MIState)
     buf = buffer(s)
-    push_kill!(s, content(buf, region(buf))) || return :ignore
+    push_kill!(s, content(buf, region(buf)), false) || return :ignore
     if REGION_ANIMATION_DURATION[] > 0.0
         edit_exchange_point_and_mark(s)
         sleep(REGION_ANIMATION_DURATION[])
@@ -727,7 +738,7 @@ end
 
 function edit_kill_region(s::MIState)
     push_undo(s)
-    if push_kill!(s, edit_splice!(s))
+    if push_kill!(s, edit_splice!(s), false)
         refresh_line(s)
         :edit_kill_region
     else
@@ -807,6 +818,7 @@ edit_clear(buf::IOBuffer) = truncate(buf, 0)
 
 function edit_clear(s::MIState)
     push_undo(s)
+    push_kill!(s, content(s), false) || return :ignore
     edit_clear(buffer(s))
     refresh_line(s)
     :edit_clear


### PR DESCRIPTION
The two ways of deleting the previous word, deleting
the next word and clearing the space now hook into the
kill ring. Implements item 2 of #8447.