### PR TITLE
fix boundscheck value propagation codegen bug

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1100,9 +1100,8 @@ static bool bounds_check_enabled(jl_codectx_t &ctx, jl_value_t *inbounds) {
 static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_value_t *ty, Value *i, Value *len, jl_value_t *boundscheck)
 {
     Value *im1 = ctx.builder.CreateSub(i, ConstantInt::get(T_size, 1));
-    jl_cgval_t ib = emit_expr(ctx, boundscheck);
 #if CHECK_BOUNDS==1
-    if (bounds_check_enabled(ctx, ib.constant)) {
+    if (bounds_check_enabled(ctx, boundscheck)) {
         Value *ok = ctx.builder.CreateICmpULT(im1, len);
         BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
         BasicBlock *passBB = BasicBlock::Create(jl_LLVMContext, "pass");
@@ -1630,9 +1629,8 @@ static Value *emit_array_nd_index(
     Value *a = boxed(ctx, ainfo);
     Value *i = ConstantInt::get(T_size, 0);
     Value *stride = ConstantInt::get(T_size, 1);
-    jl_cgval_t ib = emit_expr(ctx, inbounds);
 #if CHECK_BOUNDS==1
-    bool bc = bounds_check_enabled(ctx, ib.constant);
+    bool bc = bounds_check_enabled(ctx, inbounds);
     BasicBlock *failBB = NULL, *endBB = NULL;
     if (bc) {
         failBB = BasicBlock::Create(jl_LLVMContext, "oob");

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -245,3 +245,8 @@ let c = [1,2,3]
     len2 = issue22582!(c, true)
     @test len1 == len2
 end
+
+# PR #23595
+@generated f23595(g, args...) = Expr(:call, :g, Expr(:(...), :args))
+x23595 = rand(1)
+@test f23595(Core.arrayref, true, x23595, 1) == x23595[]


### PR DESCRIPTION
Fixes leftover typos from #22826 that can induce segfaults. I found the test case for triggering the segfault, and Jameson gave me the diff (implemented here) that fixes it.

Before this PR:

```julia
julia> @generated f(g, args...) = Expr(:call, :g, Expr(:(...), :args))
f (generic function with 1 method)

julia> f(Core.arrayref, true, [1.0,1.0], 1)

signal (11): Segmentation fault: 11
while loading no file, in expression starting on line 0
```

After this PR:

```julia

julia> @generated f(g, args...) = Expr(:call, :g, Expr(:(...), :args))
f (generic function with 1 method)

julia> f(Core.arrayref, true, [1.0,1.0], 1)
1.0
```