### PR TITLE
fieldtype validation: disallow `Vararg` as a field type

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -380,7 +380,7 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
     }
     else if (ex->head == primtype_sym) {
         if (inside_typedef)
-            jl_error("cannot eval a new bits type definition while defining another type");
+            jl_error("cannot eval a new primitive type definition while defining another type");
         jl_value_t *name = args[0];
         jl_value_t *super = NULL, *para = NULL, *vnb = NULL, *temp = NULL;
         jl_datatype_t *dt = NULL;
@@ -395,11 +395,11 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
         assert(jl_is_svec(para));
         vnb  = eval(args[2], s);
         if (!jl_is_long(vnb))
-            jl_errorf("invalid declaration of bits type %s",
+            jl_errorf("invalid declaration of primitive type %s",
                       jl_symbol_name((jl_sym_t*)name));
         ssize_t nb = jl_unbox_long(vnb);
-        if (nb < 1 || nb>=(1<<23) || (nb&7) != 0)
-            jl_errorf("invalid number of bits in type %s",
+        if (nb < 1 || nb >= (1 << 23) || (nb & 7) != 0)
+            jl_errorf("invalid number of bits in primitive type %s",
                       jl_symbol_name((jl_sym_t*)name));
         dt = jl_new_primitivetype(name, modu, NULL, (jl_svec_t*)para, nb);
         w = dt->name->wrapper;
@@ -428,7 +428,7 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
     }
     else if (ex->head == structtype_sym) {
         if (inside_typedef)
-            jl_error("cannot eval a new data type definition while defining another type");
+            jl_error("cannot eval a new struct type definition while defining another type");
         jl_value_t *name = args[0];
         jl_value_t *para = eval(args[1], s);
         jl_value_t *temp = NULL;
@@ -462,12 +462,13 @@ static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
             jl_set_datatype_super(dt, super);
             dt->types = (jl_svec_t*)eval(args[4], s);
             jl_gc_wb(dt, dt->types);
-            for(size_t i=0; i < jl_svec_len(dt->types); i++) {
+            for (size_t i = 0; i < jl_svec_len(dt->types); i++) {
                 jl_value_t *elt = jl_svecref(dt->types, i);
-                if (!jl_is_type(elt) && !jl_is_typevar(elt))
+                if ((!jl_is_type(elt) && !jl_is_typevar(elt)) || jl_is_vararg_type(elt)) {
                     jl_type_error_rt(jl_symbol_name(dt->name->name),
                                      "type definition",
                                      (jl_value_t*)jl_type_type, elt);
+                }
             }
             jl_reinstantiate_inner_types(dt);
         }

--- a/test/core.jl
+++ b/test/core.jl
@@ -1276,14 +1276,13 @@ let
     @test foo(x) == [1.0, 2.0, 3.0]
 end
 
-# TODO!!
 # issue #4115
-#mutable struct Foo4115
-#end
-#const Foo4115s = NTuple{3,Union{Foo4115,Type{Foo4115}}}
-#baz4115(x::Foo4115s) = x
-#@test baz4115(convert(Tuple{Type{Foo4115},Type{Foo4115},Foo4115},
-#                      (Foo4115,Foo4115,Foo4115()))) == (Foo4115,Foo4115,Foo4115())
+mutable struct Foo4115 end
+const Foo4115s = NTuple{3, Union{Foo4115, Type{Foo4115}}}
+baz4115(x::Foo4115s) = x
+let t = (Foo4115, Foo4115, Foo4115())
+    @test_throws MethodError baz4115(t)
+end
 
 # issue #4129
 mutable struct Foo4129; end
@@ -4857,6 +4856,12 @@ end
 let a = Array{Core.TypeofBottom, 1}(2)
     @test a[1] == Union{}
     @test a == [Union{}, Union{}]
+end
+
+@test_throws TypeError(:T17951, "type definition", Type, Vararg) @eval begin
+    struct T17951
+        x::Vararg
+    end
 end
 
 # issue #21178


### PR DESCRIPTION
fix #17951

also tried to fix up some error messages to reflect the recent bitstype / type -> primitive / struct renamings