### PR TITLE
Add a README note referencing FreeBSD Pkg segfaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ Some known issues on FreeBSD are:
 * The x86 architecture does not support threading due to lack of compiler runtime library support, so you may need to
   set `JULIA_THREADS=0` in your `Make.user` if you're on a 32-bit system.
 
+* The `Pkg` test suite segfaults on FreeBSD 11.1, likely due to a change in FreeBSD's default handling of stack guarding.
+  See [issue #23328](https://github.com/JuliaLang/julia/issues/23328) for more information.
+
 ### Windows
 
 In order to build Julia on Windows, see [README.windows](https://github.com/JuliaLang/julia/blob/master/README.windows.md).


### PR DESCRIPTION
#23328 is a notable unsolved issue with FreeBSD 11.1, so this adds a note about it to the "known issues on FreeBSD" section of the README.

Note: CI skipped.