### PR TITLE
rename `--precompiled` and `--compilecache` command line options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -431,6 +431,10 @@ Command-line option changes
     The `--quiet` option implies `--banner=no` even in REPL mode but can be overridden by
     passing `--quiet` together with `--banner=yes` ([#23342]).
 
+  * The option `--precompiled` has been renamed to `--sysimage-native-code` ([#23054]).
+
+  * The option `--compilecache` has been renamed to `--compiled-modules` ([#23054]).
+
 Julia v0.6.0 Release Notes
 ==========================
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -269,7 +269,7 @@ order to throw an error if Julia attempts to precompile it.
 using `__precompile__()`. Failure to do so can result in a runtime error when loading the module.
 """
 function __precompile__(isprecompilable::Bool=true)
-    if (JLOptions().use_compilecache != 0 &&
+    if (JLOptions().use_compiled_modules != 0 &&
         isprecompilable != (0 != ccall(:jl_generating_output, Cint, ())) &&
         !(isprecompilable && toplevel_load[]))
         throw(PrecompilableError(isprecompilable))
@@ -361,7 +361,7 @@ function _require(mod::Symbol)
 
         # attempt to load the module file via the precompile cache locations
         doneprecompile = false
-        if JLOptions().use_compilecache != 0
+        if JLOptions().use_compiled_modules != 0
             doneprecompile = _require_search_from_serialized(mod, path)
             if !isa(doneprecompile, Bool)
                 return # success
@@ -400,7 +400,7 @@ function _require(mod::Symbol)
         try
             Base.include_relative(Main, path)
         catch ex
-            if doneprecompile === true || JLOptions().use_compilecache == 0 || !precompilableerror(ex, true)
+            if doneprecompile === true || JLOptions().use_compiled_modules == 0 || !precompilableerror(ex, true)
                 rethrow() # rethrow non-precompilable=true errors
             end
             # the file requested `__precompile__`, so try to build a cache file and use that

--- a/base/options.jl
+++ b/base/options.jl
@@ -31,8 +31,8 @@ struct JLOptions
     worker::Int8
     cookie::Ptr{UInt8}
     handle_signals::Int8
-    use_precompiled::Int8
-    use_compilecache::Int8
+    use_sysimage_native_code::Int8
+    use_compiled_modules::Int8
     bindto::Ptr{UInt8}
     outputbc::Ptr{UInt8}
     outputunoptbc::Ptr{UInt8}

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -609,7 +609,7 @@ function build(pkg::AbstractString, build_file::AbstractString, errfile::Abstrac
     cmd = ```
         $(Base.julia_cmd()) -O0
         --color=$(Base.have_color ? "yes" : "no")
-        --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
+        --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
         --history-file=no
         --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
         --eval $code
@@ -717,7 +717,7 @@ function test!(pkg::AbstractString,
                     $(Base.julia_cmd())
                     --code-coverage=$(coverage ? "user" : "none")
                     --color=$(Base.have_color ? "yes" : "no")
-                    --compilecache=$(Bool(Base.JLOptions().use_compilecache) ? "yes" : "no")
+                    --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
                     --check-bounds=yes
                     --warn-overwrite=yes
                     --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -99,11 +99,13 @@ julia [switches] -- [programfile] [args...]
  -h, --help                Print this message
 
  -J, --sysimage <file>     Start up with the given system image file
- --precompiled={yes|no}    Use precompiled code from system image if available
- --compilecache={yes|no}   Enable/disable incremental precompilation of modules
  -H, --home <dir>          Set location of `julia` executable
  --startup-file={yes|no}   Load ~/.juliarc.jl
  --handle-signals={yes|no} Enable or disable Julia's default signal handlers
+ --sysimage-native-code={yes|no}
+                           Use native code from system image if available
+ --compiled-modules={yes|no}
+                           Enable or disable incremental precompilation of modules
 
  -e, --eval <expr>         Evaluate <expr>
  -E, --print <expr>        Evaluate and show <expr>
@@ -118,6 +120,9 @@ julia [switches] -- [programfile] [args...]
  --color={yes|no}          Enable or disable color text
  --history-file={yes|no}   Load or save history
 
+ --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)
+ --warn-overwrite={yes|no} Enable or disable method overwrite warnings
+
  --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation
  -C, --cpu-target <target> Limit usage of cpu features up to <target>
  -O, --optimize={0,1,2,3}  Set the optimization level (default is 2 if unspecified or 3 if specified as -O)
@@ -125,9 +130,6 @@ julia [switches] -- [programfile] [args...]
  --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)
  --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)
  --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)
-
- --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)
- --warn-overwrite={yes|no} Enable or disable method overwrite warnings
 
  --output-o name           Generate an object file (including system image data)
  --output-ji name          Generate a system image data file (.ji)

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -382,8 +382,8 @@ A few other points to be aware of:
    of these and to create a single unique instance of others.
 
 It is sometimes helpful during module development to turn off incremental precompilation. The
-command line flag `--compilecache={yes|no}` enables you to toggle module precompilation on and
-off. When Julia is started with `--compilecache=no` the serialized modules in the compile cache
+command line flag `--compiled-modules={yes|no}` enables you to toggle module precompilation on and
+off. When Julia is started with `--compiled-modules=no` the serialized modules in the compile cache
 are ignored when loading modules and module dependencies. `Base.compilecache` can still be called
 manually and it will respect `__precompile__()` directives for the module. The state of this command
 line flag is passed to [`Pkg.build`](@ref) to disable automatic precompilation triggering when installing,

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -67,8 +67,8 @@ jl_options_t jl_options = { 0,    // quiet
                             0,    // worker
                             NULL, // cookie
                             JL_OPTIONS_HANDLE_SIGNALS_ON,
-                            JL_OPTIONS_USE_PRECOMPILED_YES,
-                            JL_OPTIONS_USE_COMPILECACHE_YES,
+                            JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES,
+                            JL_OPTIONS_USE_COMPILED_MODULES_YES,
                             NULL, // bind-to
                             NULL, // output-bc
                             NULL, // output-unopt-bc
@@ -86,11 +86,13 @@ static const char opts[]  =
 
     // startup options
     " -J, --sysimage <file>     Start up with the given system image file\n"
-    " --precompiled={yes|no}    Use precompiled code from system image if available\n"
-    " --compilecache={yes|no}   Enable/disable incremental precompilation of modules\n"
     " -H, --home <dir>          Set location of `julia` executable\n"
     " --startup-file={yes|no}   Load ~/.juliarc.jl\n"
-    " --handle-signals={yes|no} Enable or disable Julia's default signal handlers\n\n"
+    " --handle-signals={yes|no} Enable or disable Julia's default signal handlers\n"
+    " --sysimage-native-code={yes|no}\n"
+    "                           Use native code from system image if available\n"
+    " --compiled-modules={yes|no}\n"
+    "                           Enable or disable incremental precompilation of modules\n\n"
 
     // actions
     " -e, --eval <expr>         Evaluate <expr>\n"
@@ -109,6 +111,10 @@ static const char opts[]  =
     " --color={yes|no}          Enable or disable color text\n"
     " --history-file={yes|no}   Load or save history\n\n"
 
+    // error and warning options
+    " --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings (\"error\" turns warnings into errors)\n"
+    " --warn-overwrite={yes|no} Enable or disable method overwrite warnings\n\n"
+
     // code generation options
     " --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation\n"
     " -C, --cpu-target <target> Limit usage of cpu features up to <target>; set to \"help\" to see the available options\n"
@@ -125,10 +131,6 @@ static const char opts[]  =
     " --polly={yes|no}          Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)\n"
 #endif
     " --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)\n\n"
-
-    // error and warning options
-    " --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings (\"error\" turns warnings into errors)\n\n"
-    " --warn-overwrite={yes|no} Enable or disable method overwrite warnings"
 
     // compiler output options
     " --output-o name           Generate an object file (including system image data)\n"
@@ -174,7 +176,9 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_use_precompiled,
            opt_use_compilecache,
            opt_incremental,
-           opt_banner
+           opt_banner,
+           opt_sysimage_native_code,
+           opt_compiled_modules
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:ip:O:g:";
     static const struct option longopts[] = {
@@ -190,8 +194,10 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "print",           required_argument, 0, 'E' },
         { "load",            required_argument, 0, 'L' },
         { "sysimage",        required_argument, 0, 'J' },
-        { "precompiled",     required_argument, 0, opt_use_precompiled },
-        { "compilecache",    required_argument, 0, opt_use_compilecache },
+        { "precompiled",     required_argument, 0, opt_use_precompiled },   // deprecated
+        { "sysimage-native-code", required_argument, 0, opt_sysimage_native_code },
+        { "compilecache",    required_argument, 0, opt_use_compilecache },  // deprecated
+        { "compiled-modules",    required_argument, 0, opt_compiled_modules },
         { "cpu-target",      required_argument, 0, 'C' },
         { "procs",           required_argument, 0, 'p' },
         { "machinefile",     required_argument, 0, opt_machinefile },
@@ -331,20 +337,26 @@ restart_switch:
                 jl_errorf("julia: invalid argument to --banner={yes|no} (%s)", optarg);
             break;
         case opt_use_precompiled:
+            jl_printf(JL_STDOUT, "WARNING: julia --precompiled option is deprecated, use --sysimage-native-code instead.\n");
+            // fall through
+        case opt_sysimage_native_code:
             if (!strcmp(optarg,"yes"))
-                jl_options.use_precompiled = JL_OPTIONS_USE_PRECOMPILED_YES;
+                jl_options.use_sysimage_native_code = JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES;
             else if (!strcmp(optarg,"no"))
-                jl_options.use_precompiled = JL_OPTIONS_USE_PRECOMPILED_NO;
+                jl_options.use_sysimage_native_code = JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_NO;
             else
-                jl_errorf("julia: invalid argument to --precompiled={yes|no} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --sysimage-native-code={yes|no} (%s)", optarg);
             break;
         case opt_use_compilecache:
+            jl_printf(JL_STDOUT, "WARNING: julia --compilecache option is deprecated, use --compiled-modules instead.\n");
+            // fall through
+        case opt_compiled_modules:
             if (!strcmp(optarg,"yes"))
-                jl_options.use_compilecache = JL_OPTIONS_USE_COMPILECACHE_YES;
+                jl_options.use_compiled_modules = JL_OPTIONS_USE_COMPILED_MODULES_YES;
             else if (!strcmp(optarg,"no"))
-                jl_options.use_compilecache = JL_OPTIONS_USE_COMPILECACHE_NO;
+                jl_options.use_compiled_modules = JL_OPTIONS_USE_COMPILED_MODULES_NO;
             else
-                jl_errorf("julia: invalid argument to --compilecache={yes|no} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --compiled-modules={yes|no} (%s)", optarg);
             break;
         case 'C': // cpu-target
             jl_options.cpu_target = strdup(optarg);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1702,8 +1702,8 @@ typedef struct {
     int8_t worker;
     const char *cookie;
     int8_t handle_signals;
-    int8_t use_precompiled;
-    int8_t use_compilecache;
+    int8_t use_sysimage_native_code;
+    int8_t use_compiled_modules;
     const char *bindto;
     const char *outputbc;
     const char *outputunoptbc;
@@ -1769,11 +1769,11 @@ JL_DLLEXPORT int jl_generating_output(void);
 #define JL_OPTIONS_HANDLE_SIGNALS_ON 1
 #define JL_OPTIONS_HANDLE_SIGNALS_OFF 0
 
-#define JL_OPTIONS_USE_PRECOMPILED_YES 1
-#define JL_OPTIONS_USE_PRECOMPILED_NO 0
+#define JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES 1
+#define JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_NO 0
 
-#define JL_OPTIONS_USE_COMPILECACHE_YES 1
-#define JL_OPTIONS_USE_COMPILECACHE_NO 0
+#define JL_OPTIONS_USE_COMPILED_MODULES_YES 1
+#define JL_OPTIONS_USE_COMPILED_MODULES_NO 0
 
 // Version information
 #include "julia_version.h"

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -163,7 +163,7 @@ static void jl_load_sysimg_so(void)
 #endif
     int imaging_mode = jl_generating_output() && !jl_options.incremental;
     // in --build mode only use sysimg data, not precompiled native code
-    if (!imaging_mode && jl_options.use_precompiled==JL_OPTIONS_USE_PRECOMPILED_YES) {
+    if (!imaging_mode && jl_options.use_sysimage_native_code==JL_OPTIONS_USE_SYSIMAGE_NATIVE_CODE_YES) {
         sysimg_gvars_base = (uintptr_t*)jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars_base");
         sysimg_gvars_offsets = (const int32_t*)jl_dlsym(jl_sysimg_handle,
                                                         "jl_sysimg_gvars_offsets");

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -387,7 +387,7 @@ finally
     rm(dir2, recursive=true)
 end
 
-# test --compilecache=no command line option
+# test --compiled-modules=no command line option
 let dir = mktempdir(),
     Time_module = :Time4b3a94a1a081a8cb
 
@@ -406,7 +406,7 @@ let dir = mktempdir(),
             Base.compilecache(:Time4b3a94a1a081a8cb)
         end)
 
-        exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
+        exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no`
 
         testcode = """
             insert!(LOAD_PATH, 1, $(repr(dir)))
@@ -415,12 +415,12 @@ let dir = mktempdir(),
             getfield($Time_module, :time)
         """
 
-        t1_yes = readchomp(`$exename --compilecache=yes -E $(testcode)`)
-        t2_yes = readchomp(`$exename --compilecache=yes -E $(testcode)`)
+        t1_yes = readchomp(`$exename --compiled-modules=yes -E $(testcode)`)
+        t2_yes = readchomp(`$exename --compiled-modules=yes -E $(testcode)`)
         @test t1_yes == t2_yes
 
-        t1_no = readchomp(`$exename --compilecache=no -E $(testcode)`)
-        t2_no = readchomp(`$exename --compilecache=no -E $(testcode)`)
+        t1_no = readchomp(`$exename --compiled-modules=no -E $(testcode)`)
+        t2_no = readchomp(`$exename --compiled-modules=no -E $(testcode)`)
         @test t1_no != t2_no
         @test parse(Float64, t1_no) < parse(Float64, t2_no)
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -41,7 +41,7 @@ include_string_test_func = include_string(@__MODULE__, "include_string_test() = 
 
 @test isdir(@__DIR__)
 @test @__DIR__() == dirname(@__FILE__)
-let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`,
+let exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no`,
     wd = sprint(show, abspath(pwd(), "")),
     s_dir = sprint(show, joinpath(realpath(tempdir()), ""))
     @test wd != s_dir

--- a/test/workspace.jl
+++ b/test/workspace.jl
@@ -67,7 +67,7 @@ mktempdir() do dir
             nothing
         """)
         # Ensure that STDIO doesn't get swallowed (helps with debugging)
-        cmd = `$(Base.julia_cmd()) --startup-file=no --precompiled=yes --compilecache=yes $(joinpath(dir, "testdriver.jl"))`
+        cmd = `$(Base.julia_cmd()) --startup-file=no --sysimage-native-code=yes --compiled-modules=yes $(joinpath(dir, "testdriver.jl"))`
         @test success(pipeline(cmd, stdout=STDOUT, stderr=STDERR))
     end
 end


### PR DESCRIPTION
`--precompiled` becomes `--sysimage-native-code`, and `--compilecache` becomes `--compiled-modules`.

I also noticed that we were missing newline characters after the warn-overwrite option. I also took the liberty of moving the warning options higher up in the help text, since they're generally more used than the compiler options.

part of #23054