### PR TITLE
Pkg.status() shows downgraded packages, fixes #17571

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -127,7 +127,8 @@ end
 function status(io::IO; pkgname::AbstractString = "")
     showpkg(pkg) = isempty(pkgname) ? true : (pkg == pkgname)
     reqs = Reqs.parse("REQUIRE")
-    instd = Read.installed()
+    all_avail = Read.available()
+    instd = Read.installed(all_avail)
     required = sort!(collect(keys(reqs)))
     if !isempty(required)
         showpkg("") && println(io, "$(length(required)) required packages:")
@@ -136,7 +137,7 @@ function status(io::IO; pkgname::AbstractString = "")
                 showpkg(pkg) && status(io,pkg,"not found")
             else
                 ver,fix = pop!(instd,pkg)
-                showpkg(pkg) && status(io,pkg,ver,fix)
+                showpkg(pkg) && status(io,pkg,ver,fix,all_avail,instd)
             end
         end
     end
@@ -145,7 +146,7 @@ function status(io::IO; pkgname::AbstractString = "")
         showpkg("") && println(io, "$(length(additional)) additional packages:")
         for pkg in additional
             ver,fix = instd[pkg]
-            showpkg(pkg) && status(io,pkg,ver,fix)
+            showpkg(pkg) && status(io,pkg,ver,fix,all_avail,instd)
         end
     end
     if isempty(required) && isempty(additional)
@@ -155,31 +156,55 @@ end
 
 status(io::IO, pkg::AbstractString) = status(io, pkgname = pkg)
 
-function status(io::IO, pkg::AbstractString, ver::VersionNumber, fix::Bool)
+function status(io::IO, pkg::AbstractString, ver::VersionNumber, fix::Bool, avail::Dict, instd::Dict)
     @printf io " - %-29s " pkg
-    fix || return println(io,ver)
-    @printf io "%-19s" ver
-    if ispath(pkg,".git")
-        prepo = GitRepo(pkg)
-        try
-            with(LibGit2.head(prepo)) do phead
-                if LibGit2.isattached(prepo)
-                    print(io, LibGit2.shortname(phead))
+    if !fix
+        maxver = maximum(keys(avail[pkg]))
+        reqs = avail[pkg][maxver].requires
+        if maxver != ver
+            @printf io "%-19s" ver
+            heldby = String[]
+            required = String[]
+            for (req, reqver) in reqs
+                req == "julia" && continue
+                if !haskey(instd, req)
+                    push!(required, req)
                 else
-                    print(io, string(LibGit2.GitHash(phead))[1:8])
+                    !in(instd[req][1], reqver) && push!(heldby, req)
                 end
             end
-            attrs = AbstractString[]
-            isfile("METADATA",pkg,"url") || push!(attrs,"unregistered")
-            LibGit2.isdirty(prepo) && push!(attrs,"dirty")
-            isempty(attrs) || print(io, " (",join(attrs,", "),")")
-        catch err
-            print_with_color(Base.error_color(), io, " broken-repo (unregistered)")
-        finally
-            close(prepo)
+            length(heldby) > 0 && print(io, "held back by ",join(heldby,", "), "; ")
+            print(io, "most recent $maxver")
+            length(required) > 0 && print(io, " requires: ",join(required,", "))
+        else
+            print(io, ver)
         end
     else
-        print_with_color(Base.warn_color(), io, "non-repo (unregistered)")
+        @printf io "%-19s" ver
+        if ispath(pkg,".git")
+            prepo = GitRepo(pkg)
+            try
+                with(LibGit2.head(prepo)) do phead
+                    oid = LibGit2.GitHash(phead)
+                    fix && if LibGit2.isattached(prepo)
+                        print(io, LibGit2.shortname(phead))
+                    else
+                        print(io, string(oid)[1:8])
+                    end
+
+                    attrs = AbstractString[]
+                    isfile("METADATA",pkg,"url") || push!(attrs,"unregistered")
+                    LibGit2.isdirty(prepo) && push!(attrs,"dirty")
+                    isempty(attrs) || print(io, " (",join(attrs,", "),")")
+                end
+            catch err
+                print_with_color(Base.error_color(), io, " broken-repo (unregistered)")
+            finally
+                close(prepo)
+            end
+        else
+            print_with_color(Base.warn_color(), io, "non-repo (unregistered)")
+        end
     end
     println(io)
 end


### PR DESCRIPTION
Pkg.status() shows downgraded packages, #17571.

NB. There is no additional performance overhead from reading the METADATA state, I reuse its state from another call.

Result:
```julia
julia> Pkg.status()
No packages installed

julia> Pkg.add("HttpParser")
INFO: Cloning cache of HttpCommon from https://github.com/JuliaWeb/HttpCommon.jl.git
INFO: Cloning cache of HttpParser from https://github.com/JuliaWeb/HttpParser.jl.git
INFO: Installing BinDeps v0.7.0
INFO: Installing Compat v0.31.0
INFO: Installing HttpCommon v0.2.7
INFO: Installing HttpParser v0.3.0
INFO: Installing SHA v0.5.1
INFO: Installing URIParser v0.2.0
INFO: Building HttpParser

julia> Pkg.status()
1 required packages:
 - HttpParser                    0.3.0
5 additional packages:
 - BinDeps                       0.7.0
 - Compat                        0.31.0
 - HttpCommon                    0.2.7
 - SHA                           0.5.1
 - URIParser                     0.2.0

julia> Pkg.pin("Compat", v"0.7.0")
INFO: Creating Compat branch pinned.7985d34a.tmp
INFO: Downgrading BinDeps: v0.7.0 => v0.3.15
INFO: Downgrading HttpCommon: v0.2.7 => v0.2.4
INFO: Downgrading HttpParser: v0.3.0 => v0.1.1
INFO: Downgrading SHA: v0.5.1 => v0.2.0
INFO: Downgrading URIParser: v0.2.0 => v0.1.3
INFO: Building HttpParser

julia> Pkg.status()
1 required packages:
 - HttpParser                    0.1.1              held back by Compat; most recent 0.3.0
5 additional packages:
 - BinDeps                       0.3.15             held back by Compat; most recent 0.7.0
 - Compat                        0.7.0              pinned.7985d34a.tmp
 - HttpCommon                    0.2.4              held back by Compat; most recent 0.2.7
 - SHA                           0.2.0              held back by Compat; most recent 0.5.1
 - URIParser                     0.1.3              held back by Compat; most recent 0.2.0

julia> Pkg.free("Compat")
INFO: Freeing Compat
INFO: Upgrading BinDeps: v0.3.15 => v0.7.0
INFO: Upgrading HttpCommon: v0.2.4 => v0.2.7
INFO: Upgrading HttpParser: v0.1.1 => v0.3.0
INFO: Upgrading SHA: v0.2.0 => v0.5.1
INFO: Upgrading URIParser: v0.1.3 => v0.2.0
INFO: Building HttpParser

julia> Pkg.status()
1 required packages:
 - HttpParser                    0.3.0
5 additional packages:
 - BinDeps                       0.7.0
 - Compat                        0.31.0
 - HttpCommon                    0.2.7
 - SHA                           0.5.1
 - URIParser                     0.2.0
```