### PR TITLE
Add GPU support to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ Julia is built and tested regularly on the following platforms:
 |                  | ARM v7 (32-bit)  |    | ✓        | Official      |
 |                  | ARM v8 (64-bit)  |    | ✓        | Official      |
 |                  | PowerPC (64-bit) |    |          | Community     |
-|                  | PTX (64-bit)     | ✓  |          | Community. [Needs external packages](https://github.com/JuliaGPU/CUDAnative.jl)     |
+|                  | PTX (64-bit)     | [✓](http://ci.maleadt.net:8010/)  |          | [Community](https://github.com/JuliaGPU/CUDAnative.jl)     |
 | macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 | Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 |                  | i686 (32-bit)    | ✓  | ✓        | Official      |
 | FreeBSD 11.0+    | x86-64 (64-bit)  | ✓  |          | Community     |
 
 All systems marked with ✓ for CI are tested using continuous integration for every commit.
-Systems with ✓ for binaries have official binaries available on the [downloads](https://julialang.org/downloads) page and are tested regularly.
+Systems with ✓ for binaries have official binaries available on the [downloads](https://julialang.org/downloads) page and are tested regularly. The PTX backend needs a source build and the [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl) package.
 The systems listed here with neither CI nor official binaries are known to build and work, but ongoing support for those platforms is dependent on community efforts.
 It's possible that Julia will build and work on other platforms too, and we're always looking to better our platform coverage.
 If you're using Julia on a platform not listed here, let us know!

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Julia is built and tested regularly on the following platforms:
 |                  | ARM v7 (32-bit)  |    | ✓        | Official      |
 |                  | ARM v8 (64-bit)  |    | ✓        | Official      |
 |                  | PowerPC (64-bit) |    |          | Community     |
+|                  | PTX (64-bit)     | ✓  |          | Community. [Needs external packages](https://github.com/JuliaGPU/CUDAnative.jl)     |
 | macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 | Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 |                  | i686 (32-bit)    | ✓  | ✓        | Official      |

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Julia is built and tested regularly on the following platforms:
 |                  | ARM v7 (32-bit)  |    | ✓        | Official      |
 |                  | ARM v8 (64-bit)  |    | ✓        | Official      |
 |                  | PowerPC (64-bit) |    |          | Community     |
-|                  | PTX (64-bit)     | [✓](http://ci.maleadt.net:8010/)  |          | [Community](https://github.com/JuliaGPU/CUDAnative.jl)     |
+|                  | PTX (64-bit)     | [✓](http://ci.maleadt.net:8010/)  |          | [External](https://github.com/JuliaGPU/CUDAnative.jl)     |
 | macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 | Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 |                  | i686 (32-bit)    | ✓  | ✓        | Official      |


### PR DESCRIPTION
We have fantastic PTX support now thanks to @maleadt  and a growing ecosystem of packages that use it. I have been using it for the last few weeks.

I think this deserves a mention in the README, but with the caveats that external packages are needed.