### PR TITLE
update code and tests to limit false sharing and unnecessary creation of globals

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -154,7 +154,7 @@ for mime in ["application/atom+xml", "application/ecmascript",
              "application/x-latex", "application/xhtml+xml", "application/xml",
              "application/xml-dtd", "image/svg+xml", "model/vrml",
              "model/x3d+vrml", "model/x3d+xml"]
-    istextmime(::MIME{Symbol(mime)}) = true
+    global istextmime(::MIME{Symbol(mime)}) = true
 end
 
 ###########################################################################

--- a/base/nullable.jl
+++ b/base/nullable.jl
@@ -388,6 +388,7 @@ all(f::typeof(hasvalue), t::Tuple{}) = true
 
 # Note this list does not include sqrt since it can raise a DomainError
 for op in (+, -, abs, abs2)
+    global null_safe_op
     null_safe_op(::typeof(op), ::NullSafeTypes) = true
     null_safe_op(::typeof(op), ::Type{Complex{S}}) where {S} = null_safe_op(op, S)
     null_safe_op(::typeof(op), ::Type{Rational{S}}) where {S} = null_safe_op(op, S)
@@ -404,11 +405,13 @@ null_safe_op(::typeof(!), ::Type{Bool}) = true
 for op in (+, -, *, /, &, |, <<, >>, >>>,
            scalarmin, scalarmax)
     # to fix ambiguities
+    global null_safe_op
     null_safe_op(::typeof(op), ::NullSafeFloats, ::NullSafeFloats) = true
     null_safe_op(::typeof(op), ::NullSafeSignedInts, ::NullSafeSignedInts) = true
     null_safe_op(::typeof(op), ::NullSafeUnsignedInts, ::NullSafeUnsignedInts) = true
 end
 for op in (+, -, *, /)
+    global null_safe_op
     null_safe_op(::typeof(op), ::Type{Complex{S}}, ::Type{T}) where {S,T} =
         null_safe_op(op, T, S)
     null_safe_op(::typeof(op), ::Type{Rational{S}}, ::Type{T}) where {S,T} =

--- a/base/test.jl
+++ b/base/test.jl
@@ -1010,7 +1010,7 @@ function testset_forloop(args, testloop)
     end
     quote
         arr = Array{Any,1}(0)
-        first_iteration = true
+        local first_iteration = true
         local ts
         try
             $(Expr(:for, Expr(:block, [esc(v) for v in loopvars]...), blk))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -158,7 +158,7 @@ end
             @test ind2sub((0:3,3:5,-101:-100), l) == (i-1, j+2, k-102)
         end
 
-        A = reshape(collect(1:9), (3,3))
+        local A = reshape(collect(1:9), (3,3))
         @test ind2sub(size(A), 6) == (3,2)
         @test sub2ind(size(A), 3, 2) == 6
         @test ind2sub(A, 6) == (3,2)

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -6,7 +6,7 @@ for l in bt
     lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), l, true)
     if lkup[1][1] == :backtrace
         @test lkup[1][5] == false # fromC
-        have_backtrace = true
+        global have_backtrace = true
         break
     end
 end
@@ -115,10 +115,10 @@ hasbt = hasbt2 = false
 for sfs in lkup
     for sf in sfs
         if sf.func == :bt
-            hasbt = true
+            global hasbt = true
         end
         if sf.func == :bt2
-            hasbt2 = true
+            global hasbt2 = true
         end
     end
 end
@@ -138,10 +138,10 @@ hasme = hasbtmacro = false
 for sfs in lkup
     for sf in sfs
         if sf.func == Symbol("macro expansion")
-            hasme = true
+            global hasme = true
         end
         if sf.func == :btmacro
-            hasbtmacro = true
+            global hasbtmacro = true
         end
     end
 end

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -250,21 +250,22 @@ function bigfib(n)
 end
 @test [bigfib(n) for n=0:10] == [0,1,1,2,3,5,8,13,21,34,55]
 
-n = bigfib(1000001)
-@test ndigits(n) == 208988
-@test mod(n,big(10)^15) == 359244926937501
-@test div(n,big(10)^208973) == 316047687386689
+let s, n = bigfib(1000001)
+    @test ndigits(n) == 208988
+    @test mod(n,big(10)^15) == 359244926937501
+    @test div(n,big(10)^208973) == 316047687386689
 
-s = string(n)
-@test length(s) == 208988
-@test endswith(s, "359244926937501")
-@test startswith(s, "316047687386689")
+    s = string(n)
+    @test length(s) == 208988
+    @test endswith(s, "359244926937501")
+    @test startswith(s, "316047687386689")
+end
 
 # serialization (#5133)
-let n = parse(BigInt,"359334085968622831041960188598043661065388726959079837")
+let n = parse(BigInt, "359334085968622831041960188598043661065388726959079837"),
     b = IOBuffer()
-    serialize(b,n)
-    seek(b,0)
+    serialize(b, n)
+    seek(b, 0)
     @test deserialize(b) == n
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -1,24 +1,27 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Test various constructors
-c=Channel(1)
-@test eltype(c) == Any
-@test put!(c, 1) == 1
-@test isready(c) == true
-@test take!(c) == 1
-@test isready(c) == false
+let c = Channel(1)
+    @test eltype(c) == Any
+    @test put!(c, 1) == 1
+    @test isready(c) == true
+    @test take!(c) == 1
+    @test isready(c) == false
+end
 
 @test eltype(Channel(1.0)) == Any
 
-c=Channel{Int}(1)
-@test eltype(c) == Int
-@test_throws MethodError put!(c, "Hello")
+let c = Channel{Int}(1)
+    @test eltype(c) == Int
+    @test_throws MethodError put!(c, "Hello")
+end
 
-c=Channel{Int}(Inf)
-@test eltype(c) == Int
-pvals = map(i->put!(c,i), 1:10^6)
-tvals = Int[take!(c) for i in 1:10^6]
-@test pvals == tvals
+let c = Channel{Int}(Inf)
+    @test eltype(c) == Int
+    pvals = map(i->put!(c,i), 1:10^6)
+    tvals = Int[take!(c) for i in 1:10^6]
+    @test pvals == tvals
+end
 
 # Uncomment line below once deprecation support has been removed.
 # @test_throws MethodError Channel()
@@ -45,35 +48,40 @@ testcpt(Inf)
 
 # Test multiple "for" loops waiting on the same channel which
 # is closed after adding a few elements.
-c=Channel(32)
-results=[]
-@sync begin
-    for i in 1:20
-        @async for ii in c
-            push!(results, ii)
+let c = Channel(32),
+    results = []
+    @sync begin
+        for i in 1:20
+            @async for ii in c
+                push!(results, ii)
+            end
         end
+        sleep(1.0)
+        for i in 1:5
+            put!(c,i)
+        end
+        close(c)
     end
-    sleep(1.0)
-    for i in 1:5
-        put!(c,i)
-    end
-    close(c)
+    @test sum(results) == 15
 end
-@test sum(results) == 15
 
 # Test channel iterator with done() being called multiple times
 # This needs to be explicitly tested since `take!` is called
 # in `done()` and not `next()`
-c=Channel(32); foreach(i->put!(c,i), 1:10); close(c)
-s=start(c)
-@test done(c,s) == false
-res = Int[]
-while !done(c,s)
-    @test done(c,s) == false
-    v,s = next(c,s)
-    push!(res,v)
+let s, c = Channel(32)
+    foreach(i -> put!(c, i), 1:10)
+    close(c)
+    s = start(c)
+    @test done(c, s) == false
+    res = Int[]
+    while !done(c, s)
+        local v
+        @test done(c,s) == false
+        v, s = next(c, s)
+        push!(res, v)
+    end
+    @test res == Int[1:10...]
 end
-@test res == Int[1:10...]
 
 # Tests for channels bound to tasks.
 for N in [0,10]
@@ -188,7 +196,6 @@ for N in [0,10]
         @test_throws ErrorException take!(chnl)
     end
 end
-
 
 # Testing timedwait on multiple channels
 @sync begin

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -3,8 +3,13 @@
 catcmd = `cat`
 if Sys.iswindows()
     busybox = joinpath(JULIA_HOME, "busybox.exe")
-    try # use busybox-w32 on windows
+    havebb = try # use busybox-w32 on windows
         success(`$busybox`)
+        true
+    catch
+        false
+    end
+    if havebb
         catcmd = `$busybox cat`
     end
 end

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -40,8 +40,8 @@ end
     @test ipermute!(permute!([1:10;], a),a) == [1:10;]
 
     # PR 12785
-    let a = 2:-1:1
-        @test ipermute!(permute!([1, 2], a), a) == [1, 2]
+    let ai = 2:-1:1
+        @test ipermute!(permute!([1, 2], ai), ai) == [1, 2]
     end
 end
 

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -73,8 +73,8 @@ let a = Any[[1]], q = QuoteNode([1])
 end
 
 # issue #13124
-let a = rand(3, 5)
-    b = (a,a)
+let a = rand(3, 5),
+    b = (a,a),
     c = deepcopy(b)
     @test c[1] === c[2]
 end
@@ -83,8 +83,9 @@ end
 @test isnull(deepcopy(Nullable{Array}()))
 
 # issue #15250
-let a1 = Core.svec(1, 2, 3, []), a2 = Core.svec(1, 2, 3)
-    a3 = Core.svec(a1,a1)
+let a1 = Core.svec(1, 2, 3, []),
+    a2 = Core.svec(1, 2, 3),
+    a3 = Core.svec(a1,a1),
     b1 = deepcopy(a1)
     @test a1 == b1
     @test a1 !== b1

--- a/test/datafmt.jl
+++ b/test/datafmt.jl
@@ -132,15 +132,19 @@ end
 @test isequaldlm(readdlm(IOBuffer("1,2,3\n #with leading whitespace\n4,5,6"), ','), [1. 2. 3.;" " "" "";4. 5. 6.], Any)
 
 # test skipstart
-let x = ["a" "b" "c"; "d" "e" "f"; "g" "h" "i"; "A" "B" "C"; 1 2 3; 4 5 6; 7 8 9], io = IOBuffer()
+let x = ["a" "b" "c"; "d" "e" "f"; "g" "h" "i"; "A" "B" "C"; 1 2 3; 4 5 6; 7 8 9],
+    io = IOBuffer()
+
     writedlm(io, x, quotes=false)
     seek(io, 0)
     (data, hdr) = readdlm(io, header=true, skipstart=3)
     @test data == [1 2 3; 4 5 6; 7 8 9]
     @test hdr == ["A" "B" "C"]
 end
-let x = ["a" "b" "\nc"; "d" "\ne" "f"; "g" "h" "i\n"; "A" "B" "C"; 1 2 3; 4 5 6; 7 8 9]
+
+let x = ["a" "b" "\nc"; "d" "\ne" "f"; "g" "h" "i\n"; "A" "B" "C"; 1 2 3; 4 5 6; 7 8 9],
     io = IOBuffer()
+
     writedlm(io, x, quotes=true)
     seek(io, 0)
     (data, hdr) = readdlm(io, header=true, skipstart=6)

--- a/test/dates/accessors.jl
+++ b/test/dates/accessors.jl
@@ -149,8 +149,8 @@ check = (52, 52, 52, 52, 52, 52, 52, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2)
 for i = 1:21
     @test Dates.week(dt) == check[i]
     @test Dates.week(dt1) == check[i]
-    dt = dt + Dates.Day(1)
-    dt1 = dt1 + Dates.Day(1)
+    global dt = dt + Dates.Day(1)
+    global dt1 = dt1 + Dates.Day(1)
 end
 # Tests from http://www.epochconverter.com/date-and-time/weeknumbers-by-year.php?year=2000
 dt = Dates.DateTime(2000, 12, 25)
@@ -158,8 +158,8 @@ dt1 = Dates.Date(2000, 12, 25)
 for i = 1:21
     @test Dates.week(dt) == check[i]
     @test Dates.week(dt1) == check[i]
-    dt = dt + Dates.Day(1)
-    dt1 = dt1 + Dates.Day(1)
+    global dt = dt + Dates.Day(1)
+    global dt1 = dt1 + Dates.Day(1)
 end
 # Test from http://www.epochconverter.com/date-and-time/weeknumbers-by-year.php?year=2030
 dt = Dates.DateTime(2030, 12, 23)
@@ -167,8 +167,8 @@ dt1 = Dates.Date(2030, 12, 23)
 for i = 1:21
     @test Dates.week(dt) == check[i]
     @test Dates.week(dt1) == check[i]
-    dt = dt + Dates.Day(1)
-    dt1 = dt1 + Dates.Day(1)
+    global dt = dt + Dates.Day(1)
+    global dt1 = dt1 + Dates.Day(1)
 end
 # Tests from http://www.epochconverter.com/date-and-time/weeknumbers-by-year.php?year=2004
 dt = Dates.DateTime(2004, 12, 20)
@@ -177,8 +177,8 @@ check = (52, 52, 52, 52, 52, 52, 52, 53, 53, 53, 53, 53, 53, 53, 1, 1, 1, 1, 1, 
 for i = 1:21
     @test Dates.week(dt) == check[i]
     @test Dates.week(dt1) == check[i]
-    dt = dt + Dates.Day(1)
-    dt1 = dt1 + Dates.Day(1)
+    global dt = dt + Dates.Day(1)
+    global dt1 = dt1 + Dates.Day(1)
 end
 
 # Vectorized accessors

--- a/test/dates/adjusters.jl
+++ b/test/dates/adjusters.jl
@@ -106,7 +106,7 @@ g = Dates.Date(2014, 1, 12)
 dt = a
 for i = 0:364
     @test Dates.firstdayofweek(dt) == a + Dates.Week(div(i, 7))
-    dt += Dates.Day(1)
+    global dt += Dates.Day(1)
 end
 a = Dates.DateTime(2014, 1, 6)
 b = Dates.DateTime(2014, 1, 7)
@@ -125,7 +125,7 @@ g = Dates.DateTime(2014, 1, 12)
 dt = a
 for i = 0:364
     @test Dates.firstdayofweek(dt) == a + Dates.Week(div(i, 7))
-    dt += Dates.Day(1)
+    global dt += Dates.Day(1)
 end
 @test Dates.firstdayofweek(Dates.DateTime(2013, 12, 24)) == Dates.DateTime(2013, 12, 23)
 # Test last day of week; Sunday = last day of week
@@ -147,7 +147,7 @@ g = Dates.Date(2014, 1, 12)
 dt = a
 for i = 0:364
     @test Dates.lastdayofweek(dt) == g + Dates.Week(div(i, 7))
-    dt += Dates.Day(1)
+    global dt += Dates.Day(1)
 end
 a = Dates.DateTime(2014, 1, 6)
 b = Dates.DateTime(2014, 1, 7)
@@ -166,7 +166,7 @@ g = Dates.DateTime(2014, 1, 12)
 dt = a
 for i = 0:364
     @test Dates.lastdayofweek(dt) == g + Dates.Week(div(i, 7))
-    dt += Dates.Day(1)
+    global dt += Dates.Day(1)
 end
 @test Dates.lastdayofweek(Dates.DateTime(2013, 12, 24)) == Dates.DateTime(2013, 12, 29)
 
@@ -193,7 +193,7 @@ end
 firstday = Dates.Date(2014, 1, 1)
 lastday = Dates.Date(2014, 12, 31)
 for i = 0:364
-    dt = firstday + Dates.Day(i)
+    global dt = firstday + Dates.Day(i)
 
     @test Dates.firstdayofyear(dt) == firstday
     @test Dates.firstdayofyear(DateTime(dt)) == DateTime(firstday)

--- a/test/dates/io.jl
+++ b/test/dates/io.jl
@@ -377,7 +377,7 @@ let f = "YY"
 end
 
 # Issue: https://github.com/quinnj/TimeZones.jl/issues/19
-let
+let dt
     Zulu = String
 
     function Dates.tryparsenext(d::Dates.DatePart{'Z'}, str, i, len)
@@ -422,7 +422,7 @@ end
 
 # Issue 21001
 for (ms, str) in zip([0, 1, 20, 300, 450, 678], ["0", "001", "02", "3", "45", "678"])
-    dt = DateTime(2000, 1, 1, 0, 0, 0, ms)
+    local dt = DateTime(2000, 1, 1, 0, 0, 0, ms)
     @test Dates.format(dt, "s") == str
     @test Dates.format(dt, "ss") == rpad(str, 2, '0')
     @test Dates.format(dt, "sss") == rpad(str, 3, '0')
@@ -446,7 +446,7 @@ end
 end
 
 # Time Parsing
-let
+let t
     time_tuple(t::Dates.Time) = (
         Dates.hour(t), Dates.minute(t), Dates.second(t),
         Dates.millisecond(t), Dates.microsecond(t), Dates.nanosecond(t)

--- a/test/dates/periods.jl
+++ b/test/dates/periods.jl
@@ -389,6 +389,7 @@ cpa = [1y + 1s 1m + 1s 1w + 1s 1d + 1s; 1h + 1s 1mi + 1s 2m + 1s 1s + 1ms]
 let types = (Dates.Week, Dates.Day, Dates.Hour, Dates.Minute,
              Dates.Second, Dates.Millisecond, Dates.Microsecond, Dates.Nanosecond)
     for i in 1:length(types), j in i:length(types), x in (0, 1, 235, -4677, 15250)
+        local T, U, y, z
         T = types[i]
         U = types[j]
         y = T(x)
@@ -400,6 +401,7 @@ end
 
 # Equality and hashing between OtherPeriod types
 for x in (0, 1, 235, -4677, 15250)
+    local x, y, z
     y = Dates.Year(x)
     z = convert(Dates.Month, y)
     @test y == z

--- a/test/dates/query.jl
+++ b/test/dates/query.jl
@@ -125,12 +125,12 @@ Dates.LOCALES["french"] = Dates.DateLocale(
 dt = Dates.DateTime(2000, 1, 1)
 for i = 1:366
     @test Dates.dayofyear(dt) == i
-    dt += Dates.Day(1)
+    global dt += Dates.Day(1)
 end
 dt = Dates.DateTime(2001, 1, 1)
 for i = 1:365
     @test Dates.dayofyear(dt) == i
-    dt += Dates.Day(1)
+    global dt += Dates.Day(1)
 end
 
 @test Dates.quarterofyear(Dates.Date(2000, 1, 1))  == 1

--- a/test/dates/ranges.jl
+++ b/test/dates/ranges.jl
@@ -415,8 +415,8 @@ c = Dates.Date(2013, 6, 1)
 @test [c:Dates.Month(-1):a;] == reverse([a:Dates.Month(1):c;])
 
 @test length(range(Date(2000), 366)) == 366
-let n=100000
-    a = Dates.Date(2000)
+let n = 100000
+    local a = Dates.Date(2000)
     for i = 1:n
         @test length(range(a, i)) == i
     end
@@ -453,18 +453,19 @@ b = Dates.Date(2013, 2, 1)
 @test length(Dates.Date(2000, 6, 23):Dates.Year(-10):Dates.Date(1900, 2, 28)) == 11
 @test length(Dates.Date(2000, 1, 1):Dates.Year(1):Dates.Date(2000, 2, 1)) == 1
 
-let n=100000
-    a = b = Dates.Date(0)
+let n = 100000
+    local a, b
+    a= b = Dates.Date(0)
     for i = 1:n
         @test length(a:Dates.Year(1):b) == i
         b += Dates.Year(1)
     end
 end
 
-let n=10000
-    a = Dates.Date(1985, 12, 5)
-    b = Dates.Date(1986, 12, 27)
-    c = Dates.DateTime(1985, 12, 5)
+let n = 10000,
+    a = Dates.Date(1985, 12, 5),
+    b = Dates.Date(1986, 12, 27),
+    c = Dates.DateTime(1985, 12, 5),
     d = Dates.DateTime(1986, 12, 27)
     for i = 1:n
         @test length(a:Dates.Month(1):b) == 13
@@ -474,16 +475,15 @@ let n=10000
         a += Dates.Day(1)
         b += Dates.Day(1)
     end
-    return b
 end
 
-let n=100000
+let n = 100000
+    local a, b
     a = b = Dates.Date(2000)
     for i = 1:n
         @test length(a:Dates.Month(1):b) == i
         b += Dates.Month(1)
     end
-    return b
 end
 
 @test length(Dates.Year(1):Dates.Year(1):Dates.Year(10)) == 10

--- a/test/dates/rounding.jl
+++ b/test/dates/rounding.jl
@@ -116,6 +116,7 @@ dt = Dates.DateTime(-1, 12, 29, 19, 19, 19, 19)
 for dt in [Dates.DateTime(2016, 1, 1), Dates.DateTime(-2016, 1, 1)]
     local dt
     for p in [Dates.Year, Dates.Month, Dates.Day, Dates.Hour, Dates.Minute, Dates.Second]
+        local p
         @test floor(dt, p) == dt
         @test ceil(dt, p) == dt
     end
@@ -134,6 +135,7 @@ dt = Dates.DateTime(2016, 2, 28, 12)
 # Test rounding to invalid resolutions
 dt = Dates.DateTime(2016, 2, 28, 12, 15)
 for p in [Dates.Year, Dates.Month, Dates.Week, Dates.Day, Dates.Hour]
+    local p
     for v in [-1, 0]
         @test_throws DomainError floor(dt, p(v))
         @test_throws DomainError ceil(dt, p(v))

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -174,11 +174,10 @@ end
 import Base.hash
 hash(x::I1438T, h::UInt) = hash(x.id, h)
 
-let
-    local seq, xs, s
-    seq = [26,28,29,30,31,32,33,34,35,36,-32,-35,-34,-28,37,38,39,40,-30,
-           -31,41,42,43,44,-33,-36,45,46,47,48,-37,-38,49,50,51,52,-46,-50,53]
-    xs = [ I1438T(id) for id=1:53 ]
+let seq, xs, s
+    seq = [26, 28, 29, 30, 31, 32, 33, 34, 35, 36, -32, -35, -34, -28, 37, 38, 39, 40, -30,
+           -31, 41, 42, 43, 44, -33, -36, 45, 46, 47, 48, -37, -38, 49, 50, 51, 52, -46, -50, 53]
+    xs = [ I1438T(id) for id = 1:53 ]
     s = Set()
     for id in seq
         if id > 0
@@ -197,39 +196,41 @@ end
 @test !isequal(Dict(1 => 1), Dict(1 => 2))
 @test !isequal(Dict(1 => 1), Dict(2 => 1))
 
-# Generate some data to populate dicts to be compared
-data_in = [ (rand(1:1000), randstring(2)) for _ in 1:1001 ]
+let
+    # Generate some data to populate dicts to be compared
+    data_in = [ (rand(1:1000), randstring(2)) for _ in 1:1001 ]
 
-# Populate the first dict
-d1 = Dict{Int, AbstractString}()
-for (k,v) in data_in
-    d1[k] = v
-end
-data_in = collect(d1)
-# shuffle the data
-for i in 1:length(data_in)
-    j = rand(1:length(data_in))
-    data_in[i], data_in[j] = data_in[j], data_in[i]
-end
-# Inserting data in different (shuffled) order should result in
-# equivalent dict.
-d2 = Dict{Int, AbstractString}()
-for (k,v) in data_in
-    d2[k] = v
-end
+    # Populate the first dict
+    d1 = Dict{Int, AbstractString}()
+    for (k, v) in data_in
+        d1[k] = v
+    end
+    data_in = collect(d1)
+    # shuffle the data
+    for i in 1:length(data_in)
+        j = rand(1:length(data_in))
+        data_in[i], data_in[j] = data_in[j], data_in[i]
+    end
+    # Inserting data in different (shuffled) order should result in
+    # equivalent dict.
+    d2 = Dict{Int, AbstractString}()
+    for (k, v) in data_in
+        d2[k] = v
+    end
 
-@test  isequal(d1, d2)
-d3 = copy(d2)
-d4 = copy(d2)
-# Removing an item gives different dict
-delete!(d1, data_in[rand(1:length(data_in))][1])
-@test !isequal(d1, d2)
-# Changing a value gives different dict
-d3[data_in[rand(1:length(data_in))][1]] = randstring(3)
-!isequal(d1, d3)
-# Adding a pair gives different dict
-d4[1001] = randstring(3)
-@test !isequal(d1, d4)
+    @test  isequal(d1, d2)
+    d3 = copy(d2)
+    d4 = copy(d2)
+    # Removing an item gives different dict
+    delete!(d1, data_in[rand(1:length(data_in))][1])
+    @test !isequal(d1, d2)
+    # Changing a value gives different dict
+    d3[data_in[rand(1:length(data_in))][1]] = randstring(3)
+    !isequal(d1, d3)
+    # Adding a pair gives different dict
+    d4[1001] = randstring(3)
+    @test !isequal(d1, d4)
+end
 
 @test isequal(Dict(), sizehint!(Dict(),96))
 
@@ -341,7 +342,7 @@ end
 
 # issue #8877
 let a = Dict("foo"  => 0.0, "bar" => 42.0),
-        b = Dict("フー" => 17, "バー" => 4711)
+    b = Dict("フー" => 17, "バー" => 4711)
     @test typeof(merge(a, b)) === Dict{String,Float64}
 end
 
@@ -423,14 +424,16 @@ let d = Dict{Int,Int}()
 end
 
 # iteration
-d = Dict('a'=>1, 'b'=>1, 'c'=> 3)
-@test [d[k] for k in keys(d)] == [d[k] for k in eachindex(d)] ==
-      [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]
+let d = Dict('a'=>1, 'b'=>1, 'c'=> 3)
+    @test [d[k] for k in keys(d)] == [d[k] for k in eachindex(d)] ==
+          [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]
+end
 
 # generators, similar
-d = Dict(:a=>"a")
-# TODO: restore when 0.7 deprecation is removed
-#@test @inferred(map(identity, d)) == d
+let d = Dict(:a=>"a")
+    # TODO: restore when 0.7 deprecation is removed
+    #@test @inferred(map(identity, d)) == d
+end
 
 # Issue 12451
 @test_throws ArgumentError Dict(0)
@@ -545,7 +548,7 @@ let badKeys = [
     "ECGRATE_ema5.0","FIO2_emv5.0","RESPRATE_emv5.0","7wu3ty0a4fs","BVO",
     "4UrCWXUsaT"
 ]
-    d = Dict{AbstractString,Int}()
+    local d = Dict{AbstractString,Int}()
     for i = 1:length(badKeys)
         d[badKeys[i]] = i
     end
@@ -556,7 +559,7 @@ let badKeys = [
 
     # Walk through all possible hash values (mod size of hash table)
     for offset = 0:1023
-        d2 = Dict{MyString,Int}()
+        local d2 = Dict{MyString,Int}()
         hashoffset[] = offset
         for i = 1:length(badKeys)
             d2[MyString(badKeys[i])] = i
@@ -585,7 +588,7 @@ let badKeys = UInt16[0xb800,0xa501,0xcdff,0x6303,0xe40a,0xcf0e,0xf3df,0xae99,0x9
                      0x8c48,0xdf49,0x5743]
     # Walk through all possible hash values (mod size of hash table)
     for offset = 0:1023
-        d2 = Dict{MyInt, Int}()
+        local d2 = Dict{MyInt, Int}()
         hashoffset[] = offset
         for i = 1:length(badKeys)
             d2[MyInt(badKeys[i])] = i

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -77,11 +77,11 @@ include(joinpath(dir, "wordcount.jl"))
 
 # the 0mq clustermanager depends on package ZMQ. Just making sure the
 # code loads using a stub module definition for ZMQ.
-zmq_found=true
+zmq_found = true
 try
     using ZMQ
 catch
-    zmq_found=false
+    global zmq_found = false
 end
 
 if !zmq_found

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -127,12 +127,12 @@ end
 @test prevfloat(-Inf16) === -Inf16
 
 # rounding in conversions
-let
-    for ff in [.3325f0, -.3325f0]
-        f16 = Float16(ff)
+let f
+    for f32 in [.3325f0, -.3325f0]
+        f16 = Float16(f32)
         # need to round away from 0. make sure we picked closest number.
-        @test abs(ff-f16) < abs(ff-nextfloat(f16))
-        @test abs(ff-f16) < abs(ff-prevfloat(f16))
+        @test abs(f32 - f16) < abs(f32 - nextfloat(f16))
+        @test abs(f32 - f16) < abs(f32 - prevfloat(f16))
     end
     # halfway between and last bit is 1
     f = reinterpret(Float32,                           0b00111110101010100011000000000000)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -28,14 +28,17 @@ function coerce(T::Type, x)
     end
 end
 
-for T=types[2:end], x=vals
-    a = coerce(T,x)
+for T = types[2:end],
+    x = vals,
+    a = coerce(T, x)
     @test hash(a,zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt))
 end
 
-for T=types, S=types, x=vals
-    a = coerce(T,x)
-    b = coerce(S,x)
+for T = types,
+    S = types,
+    x = vals,
+    a = coerce(T, x),
+    b = coerce(S, x)
     #println("$(typeof(a)) $a")
     #println("$(typeof(b)) $b")
     @test isequal(a,b) == (hash(a)==hash(b))

--- a/test/int.jl
+++ b/test/int.jl
@@ -126,9 +126,9 @@ for T in (Int8, Int16, Int32, Int64)
     @test convert(T, max_val) == max_val
     @test_throws InexactError convert(T, max_val+1)
 
-    m = Int128(typemin(T))
-    @test convert(T, m) == m
-    @test_throws InexactError convert(T, m-1)
+    min_val = Int128(typemin(T))
+    @test convert(T, min_val) == min_val
+    @test_throws InexactError convert(T, min_val-1)
 end
 
 for T in (UInt8, UInt16, UInt32, UInt64)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -143,10 +143,10 @@ close(io)
 end
 
 # issue 5453
-let io=IOBuffer("abcdef")
-a = Array{UInt8}(1024)
-@test_throws EOFError read!(io,a)
-@test eof(io)
+let io = IOBuffer("abcdef"),
+    a = Array{UInt8}(1024)
+    @test_throws EOFError read!(io,a)
+    @test eof(io)
 end
 
 @test isempty(readlines(IOBuffer(), chomp=false))
@@ -169,7 +169,10 @@ let io=IOBuffer("hello")
 end
 
 # pr #11554
-let io=IOBuffer(SubString("***αhelloworldω***",4,16)), io2 = IOBuffer(b"goodnightmoon", true, true)
+let a,
+    io = IOBuffer(SubString("***αhelloworldω***", 4, 16)),
+    io2 = IOBuffer(b"goodnightmoon", true, true)
+
     @test read(io, Char) == 'α'
     @test_throws ArgumentError write(io,"!")
     @test_throws ArgumentError write(io,'β')

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -210,7 +210,10 @@ let (a, b) = (1:3, [4 6;
 end
 
 # with 1D inputs
-let (a, b, c) = (1:2, 1.0:10.0, Int32(1):Int32(0))
+let a = 1:2,
+    b = 1.0:10.0,
+    c = Int32(1):Int32(0)
+
     # length
     @test length(product(a))       == 2
     @test length(product(a, b))    == 20
@@ -233,7 +236,10 @@ let (a, b, c) = (1:2, 1.0:10.0, Int32(1):Int32(0))
 end
 
 # with multidimensional inputs
-let (a, b, c) = (randn(4, 4), randn(3, 3, 3), randn(2, 2, 2, 2))
+let a = randn(4, 4),
+    b = randn(3, 3, 3),
+    c = randn(2, 2, 2, 2)
+
     args = Any[(a,),
                (a, a),
                (a, b),
@@ -275,11 +281,11 @@ let iters = (1:2,
 end
 
 # product of finite length and infinite length iterators
-let a = 1:2
-    b = countfrom(1)
-    ab = product(a, b)
-    ba = product(b, a)
-    abexp = [(1, 1), (2, 1), (1, 2), (2, 2), (1, 3), (2, 3)]
+let a = 1:2,
+    b = countfrom(1),
+    ab = product(a, b),
+    ba = product(b, a),
+    abexp = [(1, 1), (2, 1), (1, 2), (2, 2), (1, 3), (2, 3)],
     baexp = [(1, 1), (2, 1), (3, 1), (4, 1), (5, 1), (6, 1)]
     for (expected, actual) in zip([abexp, baexp], [ab, ba])
         for (i, el) in enumerate(actual)

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -192,8 +192,7 @@ end
 
 # issue #7704, computed keywords
 @test kwf1(1; (:tens, 2)) == 21
-let
-    p = (:hundreds, 3)
+let p = (:hundreds, 3),
     q = (:tens, 1)
     @test kwf1(0; p, q) == 310
     @test kwf1(0; q, hundreds=4) == 410
@@ -213,7 +212,7 @@ end
 @test ((a=1,b=2)->(a,b))(5,6) == (5,6)
 
 # issue #9948
-f9948, getx9948 = let
+f9948, getx9948 = let x
     x = 3
     h(;x=x) = x
     getx() = x

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -11,8 +11,6 @@ n2 = 2*n1
 
 srand(1234321)
 
-a = rand(n,n)
-
 areal = randn(n,n)/2
 aimg  = randn(n,n)/2
 breal = randn(n,2)/2

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -480,8 +480,7 @@ end
 @test !isdiag(LowerTriangular(rand(4, 4)))
 
 # Test throwing in fallbacks for non BlasFloat/BlasComplex in A_rdiv_Bx!
-let
-    n = 5
+let n = 5
     A = rand(Float16, n, n)
     B = rand(Float16, n-1, n-1)
     @test_throws DimensionMismatch A_rdiv_B!(A, LowerTriangular(B))

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -56,25 +56,25 @@ end
 @test sprint(show,UniformScaling(one(Complex128))) == "UniformScaling{Complex{Float64}}\n(1.0 + 0.0im)*I"
 @test sprint(show,UniformScaling(one(Float32))) == "UniformScaling{Float32}\n1.0*I"
 
-λ = complex(randn(),randn())
-J = UniformScaling(λ)
-@testset "transpose, conj, inv" begin
-    @test ndims(J) == 2
-    @test transpose(J) == J
-    @test J*eye(2) == conj(J'eye(2)) # ctranpose (and A(c)_mul_B)
-    @test I + I === UniformScaling(2) # +
-    @test inv(I) == I
-    @test inv(J) == UniformScaling(inv(λ))
-    @test cond(I) == 1
-    @test cond(J) == (λ ≠ zero(λ) ? one(real(λ)) : oftype(real(λ), Inf))
-end
+let
+    λ = complex(randn(),randn())
+    J = UniformScaling(λ)
+    @testset "transpose, conj, inv" begin
+        @test ndims(J) == 2
+        @test transpose(J) == J
+        @test J*eye(2) == conj(J'eye(2)) # ctranpose (and A(c)_mul_B)
+        @test I + I === UniformScaling(2) # +
+        @test inv(I) == I
+        @test inv(J) == UniformScaling(inv(λ))
+        @test cond(I) == 1
+        @test cond(J) == (λ ≠ zero(λ) ? one(real(λ)) : oftype(real(λ), Inf))
+    end
 
-B = bitrand(2,2)
-@test B + I == B + eye(B)
-@test I + B == B + eye(B)
-
-@testset "binary ops with matrices" begin
-    let AA = randn(2, 2)
+    @testset "binary ops with matrices" begin
+        B = bitrand(2, 2)
+        @test B + I == B + eye(B)
+        @test I + B == B + eye(B)
+        AA = randn(2, 2)
         for SS in (sprandn(3,3, 0.5), speye(Int, 3))
             for (A, S) in ((AA, SS), (view(AA, 1:2, 1:2), view(SS, 1:3, 1:3)))
                 @test @inferred(A + I) == A + eye(A)

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -179,7 +179,7 @@ let f = keymap_fcn([test_keymap_7, test_keymap_6])
     buf = IOBuffer("abd")
     f(buf)
     @test a_foo == 3
-    a_foo = 0
+    global a_foo = 0
     f(buf)
     @test a_foo == 3
     f(buf)
@@ -370,6 +370,7 @@ let buf = IOBuffer()
 end
 
 @testset "edit_word_transpose" begin
+    local buf, mode
     buf = IOBuffer()
     mode = Ref{Symbol}()
     transpose!(i) = transform!(buf -> LineEdit.edit_transpose_words(buf, mode[]),
@@ -401,7 +402,7 @@ end
     @test transpose!(13) == ("àbç gh    def", 13)
 end
 
-let s = new_state()
+let s = new_state(),
     buf = buffer(s)
 
     edit_insert(s,"first line\nsecond line\nthird line")
@@ -446,10 +447,9 @@ end
 # julia> is 6 characters + 1 character for space,
 # so the rest of the terminal is 73 characters
 #########################################################################
-let
-    buf = IOBuffer(
-    "begin\nprint(\"A very very very very very very very very very very very very ve\")\nend")
-    seek(buf,4)
+let buf = IOBuffer(
+        "begin\nprint(\"A very very very very very very very very very very very very ve\")\nend")
+    seek(buf, 4)
     outbuf = IOBuffer()
     termbuf = Base.Terminals.TerminalBuffer(outbuf)
     term = TestHelpers.FakeTerminal(IOBuffer(), IOBuffer(), IOBuffer())
@@ -459,6 +459,7 @@ let
 end
 
 @testset "function prompt indentation" begin
+    local s, term, ps, buf, outbuf, termbuf
     s = new_state()
     term = Base.LineEdit.terminal(s)
     # default prompt: PromptState.indent should not be set to a final fixed value
@@ -583,7 +584,7 @@ end
 end
 
 @testset "change case on the right" begin
-    buf = IOBuffer()
+    local buf = IOBuffer()
     edit_insert(buf, "aa bb CC")
     seekstart(buf)
     LineEdit.edit_upper_case(buf)
@@ -595,6 +596,7 @@ end
 end
 
 @testset "kill ring" begin
+    local buf
     s = new_state()
     buf = buffer(s)
     edit_insert(s, "ça ≡ nothing")

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -847,8 +847,8 @@ i3 = trunc(Integer,f)
 @test_throws ArgumentError parse(BigFloat, "1\0")
 
 # serialization (issue #12386)
-let b = IOBuffer()
-    x = 2.1*big(pi)
+let b = IOBuffer(),
+    x = 2.1 * big(pi)
     serialize(b, x)
     seekstart(b)
     @test deserialize(b) == x
@@ -860,11 +860,10 @@ end
 # test constructors and `big` with additional precision and rounding mode:
 for prec in (10, 100, 1000)
     for val in ("3.1", pi, "-1.3", 3.1)
-        let
-            a = BigFloat(val)
-            b = BigFloat(val, prec)
-            c = BigFloat(val, RoundUp)
-            d = BigFloat(val, prec, RoundDown)
+        let a = BigFloat(val),
+            b = BigFloat(val, prec),
+            c = BigFloat(val, RoundUp),
+            d = BigFloat(val, prec, RoundDown),
             e = BigFloat(val, prec, RoundUp)
 
             @test precision(a) == precision(BigFloat)

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -3,20 +3,23 @@
 @test ifelse(true, 1, 2) == 1
 @test ifelse(false, 1, 2) == 2
 
-s = Set()
-ifelse(true, push!(s, 1), push!(s, 2))
-@test s == Set([1, 2])
+let s = Set()
+    ifelse(true, push!(s, 1), push!(s, 2))
+    @test s == Set([1, 2])
+end
 
-s = Set()
-true ? push!(s, 1) : push!(s, 2)
-false ? push!(s, 3) : push!(s, 4)
-@test s == Set([1, 4])
+let s = Set()
+    true ? push!(s, 1) : push!(s, 2)
+    false ? push!(s, 3) : push!(s, 4)
+    @test s == Set([1, 4])
+end
 
-B = [true true false]
-@test ifelse.(B, 1, 2) == [1 1 2]
-@test ifelse.(B, 1, [2 3 4]) == [1 1 4]
-@test ifelse.(B, [2 3 4], 1) == [2 3 1]
-@test ifelse.(B, [2 3 4], [5 6 7]) == [2 3 7]
+let B = [true true false]
+    @test ifelse.(B, 1, 2) == [1 1 2]
+    @test ifelse.(B, 1, [2 3 4]) == [1 1 4]
+    @test ifelse.(B, [2 3 4], 1) == [2 3 1]
+    @test ifelse.(B, [2 3 4], [5 6 7]) == [2 3 7]
+end
 
 @test reverse(Pair(1,2)) == Pair(2,1)
 @test reverse(Pair("13","24")) == Pair("24","13")

--- a/test/random.jl
+++ b/test/random.jl
@@ -1,8 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+srand(0)
+
 # Issue #6573
-srand(0); rand(); x = rand(384)
-@test find(x .== rand()) == []
+let
+    rand()
+    x = rand(384)
+    @test find(x .== rand()) == []
+end
 
 @test rand() != rand()
 @test 0.0 <= rand() < 1.0
@@ -23,19 +28,23 @@ srand(0); rand(); x = rand(384)
 
 # Test array filling, Issues #7643, #8360
 @test rand(MersenneTwister(0), 1) == [0.8236475079774124]
-A = zeros(2, 2)
-rand!(MersenneTwister(0), A)
-@test A == [0.8236475079774124  0.16456579813368521;
-            0.9103565379264364  0.17732884646626457]
-A = zeros(2, 2)
-@test_throws BoundsError rand!(MersenneTwister(0), A, 5)
-@test rand(MersenneTwister(0), Int64, 1) == [4439861565447045202]
-A = zeros(Int64, 2, 2)
-rand!(MersenneTwister(0), A)
-@test A == [858542123778948672  5715075217119798169;
-            8690327730555225005 8435109092665372532]
-A = zeros(UInt128, 2, 2)
-@test_throws BoundsError rand!(MersenneTwister(0), A, 5)
+let A = zeros(2, 2)
+    rand!(MersenneTwister(0), A)
+    @test A == [0.8236475079774124  0.16456579813368521;
+                0.9103565379264364  0.17732884646626457]
+end
+let A = zeros(2, 2)
+    @test_throws BoundsError rand!(MersenneTwister(0), A, 5)
+    @test rand(MersenneTwister(0), Int64, 1) == [4439861565447045202]
+end
+let A = zeros(Int64, 2, 2)
+    rand!(MersenneTwister(0), A)
+    @test A == [858542123778948672  5715075217119798169;
+                8690327730555225005 8435109092665372532]
+end
+let A = zeros(UInt128, 2, 2)
+    @test_throws BoundsError rand!(MersenneTwister(0), A, 5)
+end
 
 # rand from AbstractArray
 let mt = MersenneTwister()
@@ -54,15 +63,17 @@ end
 
 # randn
 @test randn(MersenneTwister(42)) == -0.5560268761463861
-A = zeros(2, 2)
-randn!(MersenneTwister(42), A)
-@test A == [-0.5560268761463861  0.027155338009193845;
-            -0.444383357109696  -0.29948409035891055]
+let A = zeros(2, 2)
+    randn!(MersenneTwister(42), A)
+    @test A == [-0.5560268761463861  0.027155338009193845;
+                -0.444383357109696  -0.29948409035891055]
+end
 
-B = zeros(Complex128, 2)
-randn!(MersenneTwister(42), B)
-@test B == [Complex128(-0.5560268761463861,-0.444383357109696),
-            Complex128(0.027155338009193845,-0.29948409035891055)] * 0.7071067811865475244008
+let B = zeros(Complex128, 2)
+    randn!(MersenneTwister(42), B)
+    @test B == [Complex128(-0.5560268761463861,-0.444383357109696),
+                Complex128(0.027155338009193845,-0.29948409035891055)] * 0.7071067811865475244008
+end
 
 for T in (Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128, BigInt,
           Float16, Float32, Float64, Rational{Int})
@@ -88,7 +99,7 @@ end
 
 
 if sizeof(Int32) < sizeof(Int)
-    r = rand(Int32(-1):typemax(Int32))
+    local r = rand(Int32(-1):typemax(Int32))
     @test typeof(r) == Int32
     @test -1 <= r <= typemax(Int32)
     @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(UInt64,1:k)).u for k in 13 .+ Int64(2).^(32:62)])
@@ -101,6 +112,7 @@ end
 
 # BigInt specific
 for T in [UInt32, UInt64, UInt128, Int128]
+    local r, s
     s = big(typemax(T)-1000) : big(typemax(T)) + 10000
     @test rand(s) != rand(s)
     @test big(typemax(T)-1000) <= rand(s) <= big(typemax(T)) + 10000
@@ -200,16 +212,17 @@ randmtzig_fill_ziggurat_tables()
 
 #same random numbers on for small ranges on all systems
 
-seed = rand(UInt) #leave state nondeterministic as above
-srand(seed)
-r = map(Int64,rand(map(Int32,97:122)))
-srand(seed)
-@test r == rand(map(Int64,97:122))
-
-srand(seed)
-r = map(UInt64,rand(map(UInt32,97:122)))
-srand(seed)
-@test r == rand(map(UInt64,97:122))
+let
+    global global_seed = rand(UInt) #leave state nondeterministic as above
+    srand(global_seed)
+    r = map(Int64, rand(map(Int32, 97:122)))
+    srand(global_seed)
+    @test r == rand(map(Int64, 97:122))
+    srand(global_seed)
+    r = map(UInt64, rand(map(UInt32, 97:122)))
+    srand(global_seed)
+    @test r == rand(map(UInt64, 97:122))
+end
 
 @test all([div(0x000100000000,k)*k - 1 == Base.Random.RangeGenerator(map(UInt64,1:k)).u for k in 13 .+ Int64(2).^(1:30)])
 @test all([div(0x000100000000,k)*k - 1 == Base.Random.RangeGenerator(map(Int64,1:k)).u for k in 13 .+ Int64(2).^(1:30)])
@@ -231,9 +244,10 @@ u4 = uuid4()
 @test_throws ArgumentError UUID("z50e8400-e29b-41d4-a716-446655440000")
 
 #issue 8257
-i8257 = 1:1/3:100
-for i = 1:100
-    @test rand(i8257) in i8257
+let i8257 = 1:1/3:100
+    for i = 1:100
+        @test rand(i8257) in i8257
+    end
 end
 
 # test code paths of rand!
@@ -483,7 +497,7 @@ let mta = MersenneTwister(42), mtb = MersenneTwister(42)
 end
 
 # test PRNG jump
-let mta = MersenneTwister(seed), mtb = MersenneTwister(seed)
+let mta = MersenneTwister(global_seed), mtb = MersenneTwister(global_seed)
     step = 25000*2
     size = 4
     jump25000  = "35931a4947eeab70a9abbfaca4a79cfcf2610a35a586c6f4e4bdfa826d538cbfb0432c37321fcec4f6c98de3df06685087032988b0ad9a2144562aa82e06f2f6f256b5b412c524e35383a894da7b04e142c4156290585186d8fc06d3141a778220c2519a851b5a9e5947a3f745b71804631988825e21dba40392ff4c036b30d2d013b45e2be94b5e130a9c6424d2e82f48c855c81bd10757fdb5a91e23e9e312e430514ea31631d8897b4cf26eb39b37be0c92706e5637d4b34c1e4046b741e455df195cb512e8e0f8d578175a3da5e00d7ce247d9b92042b1b515d01f7f89fe661ebccb06dfb77bc0fbb99806921b472ccce58f2166ac058d9cf427ad7d74986e60a56d2fee0a8b680e466a8ea4e508a76c058b6f97b99c9aa5b10297b1a1bd6a8e80f3a79e008fa55a4a8915fbdec78b6b117ad67e195311fe79fc084c33f6db546f5b7602d010fa8b830e3f1b00cef00ee16840178fc7e9aa5f1cee625d43de8488bf6c8bd379ea6f97c55c7a9ee091477a23533d5e52e194bd9d4e17b02a64a2736feb3779fabd5777e448ffee0f2d4b38a8e7441822b882fc6df0bde8541e85c0c78a05936cff0c88a50980b7a84971fba3650991fe2cba425ac4b4289e7b06ce2cfabfcc8a553201e8c74b45e4ae74b6d054e37af95e6fd55e029b7c526b85ecfb3be8db670218ee3dda7b2a54ab1ed26eefe4cd1d2a9c589a6e94d0aa3ebe29e40e616aa0b731061c3d6e247ec610024a1a97b7adb7919308b0fb5dd5d51a58aa2f55d77b88037de7c1a74823c96cb09d22dd7f90dba14eefdcffaab34d323c829f24742f6f6b32b0724a26ae4a81130a8a275d30c21e6245fa27cf26d606a49bccba2980697c32d9efe583c4ee2140569025c4f044d744bc40cec1660d9e4d2de3a4de83bae4f0a9fdb34ef4509b2b4e6c37967a485a52d69d1573bb826bc64c966de9c792b7c2f07b645c56a29381911a98928e48516f246a55bcaa78f3c7d1c30127df5f06ba0a2d6a5e54605a20e60fab30c01a9472cb610ca0ef2418a985af00c7e47539111bf539dd554297d0374a7ff627d879600595b442c8dcffcffa3bbb07e5c7882ff0858142be4deac448698f0917fe2b7a9b686a9df1fa929f06a51aff992a6ee0b0605f8b34b87600cfa0af2475333b78625ce1520c793dc5080218247b4e41bbd7d9dab163470fe17a3d2622cdce979cc5565b0bc04eabaf656f21fa072a18ab33c656b665248ef20321407fef263b1c67316f2c6f236951990099e42d4614d8e08b27aa89d9f4548fa321d4b381d2da04fd7f17d6b9a68adfd0e4427196d25dcad869f8a155c6242f7d072baa5e7405ceb65dfaa3eb864bfe679a17df34273fde5037befe9ed5391b932cee271f59128c61ab3f0fc3f7cf8ff051fbda8382c64579efddd494c79850c56bda73bcd39c20c2820d191995b3335253c3b0ac8f5e5373f40c228886e6c526c2c249a5304578ba2a80f591c34ca1eaa84d6cc9399cf3f1207e61c4acada647e4e87ad5fba84aeeff6b6881d35bda77c74384fc5e279a0f495d509bc882c2b8bc790651a6d7a4ecba23a3f05111e1d8be37c03439fbd484668ceab69a52b7d519b169cbbcf634ee5e3bf78a5f8771f95fea03f2cb889e116a9f5de3abeacb8e42475fb5d022484b02d11f1e406332e0a773098fc4f0baa57cda2863c554f291d4eb74e63e4b3d44b0ed156bff1820003d407a3aaa9e6dfaa226ba7ef2fd0eff90a5482926f47f24f67019edccb6fd329eef30b5fb2125276aa1fe75a702b32c907ab133c72a74e77e0a5eb48fc5176b9d65b75b0038e1a9ed74ec2a3dcd2348fa54256f082abc01a301bacef7380f20ee0411c08a35dafdaae9f9fc123448da28626ffcc654e9d522bc8b8776b13a3310f7eeb4d27290ef4cbc7492fbcb5409d455748a8a1f087430cf5e6f453e2caa0c5343fcf4374cc38bead49941d8ab59b4d5181716c238aa88dbf1c4a2da3a9a9b9435d5ee1d51d27b0655a4308c1252aaf633cd8f44a351ffc8cec65de0b7e4e2556100e2ae9bc511044351109a6254b2d387b1a72c768f43fa7be6b93806e323b55c3e7925ed627dc708fde0954b299b1ca33bb7fbe33e0f9e4ce5b4f26efaf8e5b9507ada4f8658998eb7167afbd4482ee47cc60f4039d6a77c1fb126033bfc2e7c6162ff7561f22e263325c53a014a4ac9390fe6fab5d433c1e9896fe561f22fc8290f3f4560b676f3dfbfd1fe605343a0685349241b83a28d61cc0292d1f638a36d3d87bfa9f72f9df1cfe90692dfda5bd5e698362f5316984cbe73a132a801acbca76b5f5c23d98a217f2159b6cbbcdf8f52d23ea24c9471a31562a651b20e05cd0300ee500a450cfdaa4d2d83f7e7e27f8b7c793cf80f8067dadef77e49a64c373b97bac4dd472e5145072c73d0fdd68d9646c8a8ed9aec6c40bc915ae44ae27391ca0f1a4d2cb1c3d097be614e6eba807f4549d769a5872f268ccf770f2682d844490348f0b6a0d2b51aadbb5523cf708b66f9928eed12b35a39cf42d283b29f5283e1c8ba1f73457af17b14cdfdf9a85b0589acf1f9504e46b0bab8be848dac5673587035b99f56c41d3195bbba1616b149a22193cfb760d6bf2d84861653cd21be9a2d33187cb25d47fbecdd4626d1d97202f460a39b7128cadb77ddf682feca61fb6de0290df598a565a6361a91d76c0c685046489ed4cb1dcc4f1cea849c12dc4a3d38d3010567f387590532b78927e92f0b718c84e882b3df071a78a011d0fd56d4101dcb009914a16a781b240a6fb2440c72b0ffb365be9d3459d114e665a0d35d7b8bd280101d85d1211d939ba0b15ab528c4f9dd2b001172561d211671b96873010ae3c2b8317f773d735698914228764b831423ae19dd4bbb008b9f1bd1e3ebdd626e629a46a9dd70bdd4bb30e2279e83c12bbbead6479b5f9980b1a9c785395520703a9367d931b45c1566c9d314b1745cafc6d0667cc9bc94d0c53a960c829eb09b768ab6bb2133e4fea1d939f3d3f8e1237210cf3577c830f0493073dc1d189abf27402b8b31b7c172c43dbf331a0828adfe737380e763d0ab0bfaaf94ec04830f94380a83718f340c4eeb20d7eb22b94613be84a9ed332ab364efff6cb37eec35d186185cca725e7a748f6bdb427604fb1628d49a7424a5a62a2e930fe142b035503af332fe748d5e63591b9ac54071ca843d5e474a48837de8b80387f3269ab50d2fd99c08c971e015d13fa02c7c315922ce58bdacbf8ee48827851a61fca59882d7eadcce3166dfe012aa9ec849e698e776a4d384f4755b506a222636942a81bbbffa1ff47e4d81fe68120aebcfd1a7e0000fd0cffdc44e1f0cd69ea2b4936564c78af51fed1cc8e34f0b46d6330b4b50ddee09335b7b0be0bc9f7f8e48415e15d08f811653d21bc6dd152742b086caadcc6dff5e27b40da42c2f1ebf3dd2bd51c418718e499859239317fcab10892eadf1c0ebf7a4246bce4cce3617193032f3e41b977dc8650298ac39631c527460364effea0f0bfd043df72ead0406aba1bcd636d65d7b89979eb8e1";
@@ -610,10 +624,9 @@ end
     @test rand(m, Int) ∉ (a, b, c, d)
 end
 
-@testset "MersenneTwister($seed_) & srand(m::MersenneTwister, $seed_) produce the same stream" for seed_ in [0:5; 10000:10005]
-    # "seed_" instead of "seed" because `seed` is a global variable in this file, and there is an "overwriting" warning
-    m = MersenneTwister(seed_)
+@testset "MersenneTwister($seed) & srand(m::MersenneTwister, $seed) produce the same stream" for seed in [0:5; 10000:10005]
+    m = MersenneTwister(seed)
     a = [rand(m) for _=1:100]
-    srand(m, seed_)
+    srand(m, seed)
     @test a == [rand(m) for _=1:100]
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -210,12 +210,13 @@ L64 = @inferred(linspace(Int64(1), Int64(4), 4))
 @test L32[4] == 4 && L64[4] == 4
 @test @inferred(linspace(1.0, 2.0, 2.0f0)) === linspace(1.0, 2.0, 2)
 
-r = 5:-1:1
-@test r[1]==5
-@test r[2]==4
-@test r[3]==3
-@test r[4]==2
-@test r[5]==1
+let r = 5:-1:1
+    @test r[1]==5
+    @test r[2]==4
+    @test r[3]==3
+    @test r[4]==2
+    @test r[5]==1
+end
 
 @test length(.1:.1:.3) == 3
 @test length(1.1:1.1:3.3) == 3
@@ -236,13 +237,13 @@ r = 5:-1:1
 @test isempty((1:4)[5:4])
 @test_throws BoundsError (1:10)[8:-1:-2]
 
-r = typemax(Int)-5:typemax(Int)-1
-@test_throws BoundsError r[7]
+let r = typemax(Int)-5:typemax(Int)-1
+    @test_throws BoundsError r[7]
+end
 
 @test findin([5.2, 3.3], 3:20) == findin([5.2, 3.3], collect(3:20))
 
-let
-    span = 5:20
+let span = 5:20,
     r = -7:3:42
     @test findin(r, span) == 5:10
     r = 15:-2:-38
@@ -333,11 +334,13 @@ end
 #@test (3 in 3+0*(1:5))
 #@test !(4 in 3+0*(1:5))
 
-r = 0.0:0.01:1.0
-@test (r[30] in r)
-r = (-4*Int64(maxintfloat(Int === Int32 ? Float32 : Float64))):5
-@test (3 in r)
-@test (3.0 in r)
+let r = 0.0:0.01:1.0
+    @test (r[30] in r)
+end
+let r = (-4*Int64(maxintfloat(Int === Int32 ? Float32 : Float64))):5
+    @test (3 in r)
+    @test (3.0 in r)
+end
 
 @test !(1 in 1:0)
 @test !(1.0 in 1.0:0.0)
@@ -384,7 +387,7 @@ end
 @test_throws OverflowError length(typemin(Int):typemax(Int))
 @test_throws OverflowError length(-1:typemax(Int)-1)
 
-let s = 0
+let s = 0, n
     # loops ending at typemax(Int)
     for i = (typemax(Int)-1):typemax(Int)
         s += 1
@@ -519,14 +522,17 @@ end
 @test [0.0:prevfloat(0.1):0.3;] == [0.0, prevfloat(0.1), prevfloat(0.2), 0.3]
 @test [0.0:nextfloat(0.1):0.3;] == [0.0, nextfloat(0.1), nextfloat(0.2)]
 
-for T = (Float32, Float64,)# BigFloat),
-    local T
-    for a = -5:25, s = [-5:-1;1:25;], d = 1:25, n = -1:15
-    denom = convert(T,d)
-    strt = convert(T,a)/denom
-    Δ     = convert(T,s)/denom
-    stop  = convert(T,(a+(n-1)*s))/denom
-    vals  = T[a:s:a+(n-1)*s;]./denom
+for T = (Float32, Float64,), # BigFloat),
+    a = -5:25,
+    s = [-5:-1; 1:25; ],
+    d = 1:25,
+    n = -1:15
+
+    denom = convert(T, d)
+    strt = convert(T, a)/denom
+    Δ     = convert(T, s)/denom
+    stop  = convert(T, (a + (n - 1) * s)) / denom
+    vals  = T[a:s:(a + (n - 1) * s); ] ./ denom
     r = strt:Δ:stop
     @test [r;] == vals
     @test [linspace(strt, stop, length(r));] == vals
@@ -538,7 +544,6 @@ for T = (Float32, Float64,)# BigFloat),
     @test [r[2:2:n];] == [r;][2:2:n]
     @test [r[n:-1:2];] == [r;][n:-1:2]
     @test [r[n:-2:1];] == [r;][n:-2:1]
-    end
 end
 
 # issue #20373 (unliftable ranges with exact end points)
@@ -637,8 +642,9 @@ for T = (Float32, Float64)
 end
 
 # issue #20380
-r = LinSpace(1,4,4)
-@test isa(r[1:4], LinSpace)
+let r = LinSpace(1,4,4)
+    @test isa(r[1:4], LinSpace)
+end
 
 # linspace with 1 or 0 elements (whose step length is NaN)
 @test issorted(linspace(1,1,0))
@@ -710,42 +716,49 @@ let r1 = 1.0:0.1:2.0, r2 = 1.0f0:0.2f0:3.0f0, r3 = 1:2:21
     @test r3 + r3 == 2 * r3
 end
 
-# issue #7114d
-r = -0.004532318104333742:1.2597349521122731e-5:0.008065031416788989
-@test length(r[1:end-1]) == length(r) - 1
-@test isa(r[1:2:end],AbstractRange) && length(r[1:2:end]) == div(length(r)+1, 2)
-@test r[3:5][2] ≈ r[4]
-@test r[5:-2:1][2] ≈ r[3]
-@test_throws BoundsError r[0:10]
-@test_throws BoundsError r[1:10000]
+# issue #7114
+let r = -0.004532318104333742:1.2597349521122731e-5:0.008065031416788989
+    @test length(r[1:end-1]) == length(r) - 1
+    @test isa(r[1:2:end],AbstractRange) && length(r[1:2:end]) == div(length(r)+1, 2)
+    @test r[3:5][2] ≈ r[4]
+    @test r[5:-2:1][2] ≈ r[3]
+    @test_throws BoundsError r[0:10]
+    @test_throws BoundsError r[1:10000]
+end
 
-r = linspace(1/3,5/7,6)
-@test length(r) == 6
-@test r[1] == 1/3
-@test abs(r[end] - 5/7) <= eps(5/7)
-r = linspace(0.25,0.25,1)
-@test length(r) == 1
-@test_throws ArgumentError linspace(0.25,0.5,1)
+let r = linspace(1/3, 5/7, 6)
+    @test length(r) == 6
+    @test r[1] == 1/3
+    @test abs(r[end] - 5/7) <= eps(5/7)
+end
+
+let r = linspace(0.25, 0.25, 1)
+    @test length(r) == 1
+    @test_throws ArgumentError linspace(0.25,0.5,1)
+end
+
 
 # issue #7426
 @test [typemax(Int):1:typemax(Int);] == [typemax(Int)]
 
 #issue #7484
-r7484 = 0.1:0.1:1
-@test [reverse(r7484);] == reverse([r7484;])
+let r7484 = 0.1:0.1:1
+    @test [reverse(r7484);] == reverse([r7484;])
+end
 
 # issue #7387
 for r in (0:1, 0.0:1.0)
     local r
     @test [r .+ im;] == [r;] .+ im
     @test [r .- im;] == [r;] .- im
-    @test [r*im;] == [r;]*im
-    @test [r/im;] == [r;]/im
+    @test [r * im;] == [r;] * im
+    @test [r / im;] == [r;] / im
 end
 
 # Preservation of high precision upon addition
-r = (-0.1:0.1:0.3) + broadcast(+, -0.3:0.1:0.1, 1e-12)
-@test r[3] == 1e-12
+let r = (-0.1:0.1:0.3) + broadcast(+, -0.3:0.1:0.1, 1e-12)
+    @test r[3] == 1e-12
+end
 
 # issue #7709
 @test length(map(identity, 0x01:0x05)) == 5
@@ -844,14 +857,15 @@ let io = IOBuffer()
 end
 
 # issue 10950
-r = 1//2:3
-@test length(r) == 3
-i = 1
-for x in r
-    @test x == i//2
-    i += 2
+let r = 1//2:3
+    @test length(r) == 3
+    i = 1
+    for x in r
+        @test x == i//2
+        i += 2
+    end
+    @test i == 7
 end
-@test i == 7
 
 # stringmime/show should display the range or linspace nicely
 # to test print_range in range.jl
@@ -1028,72 +1042,80 @@ let r = 1:3, a = [1,2,3]
 end
 
 # OneTo
-r = Base.OneTo(-5)
-@test isempty(r)
-@test length(r) == 0
-@test size(r) == (0,)
-r = Base.OneTo(3)
-@test !isempty(r)
-@test length(r) == 3
-@test size(r) == (3,)
-@test step(r) == 1
-@test first(r) == 1
-@test last(r) == 3
-@test minimum(r) == 1
-@test maximum(r) == 3
-@test r[2] == 2
-@test r[2:3] === 2:3
-@test_throws BoundsError r[4]
-@test_throws BoundsError r[0]
-@test broadcast(+, r, 1) === 2:4
-@test 2*r === 2:2:6
-@test r + r === 2:2:6
-k = 0
-for i in r
-    local i
-    @test i == (k+=1)
+let r = Base.OneTo(-5)
+    @test isempty(r)
+    @test length(r) == 0
+    @test size(r) == (0,)
 end
-@test intersect(r, Base.OneTo(2)) == Base.OneTo(2)
-@test intersect(r, 0:5) == 1:3
-@test intersect(r, 2) === intersect(2, r) === 2:2
-@test findin(r, r) === findin(r, 1:length(r)) === findin(1:length(r), r) === 1:length(r)
-r2 = Base.OneTo(7)
-@test findin(r2, 2:length(r2)-1) === 2:length(r2)-1
-@test findin(2:length(r2)-1, r2) === 1:length(r2)-2
-io = IOBuffer()
-show(io, r)
-str = String(take!(io))
-@test str == "Base.OneTo(3)"
+let r = Base.OneTo(3)
+    @test !isempty(r)
+    @test length(r) == 3
+    @test size(r) == (3,)
+    @test step(r) == 1
+    @test first(r) == 1
+    @test last(r) == 3
+    @test minimum(r) == 1
+    @test maximum(r) == 3
+    @test r[2] == 2
+    @test r[2:3] === 2:3
+    @test_throws BoundsError r[4]
+    @test_throws BoundsError r[0]
+    @test broadcast(+, r, 1) === 2:4
+    @test 2*r === 2:2:6
+    @test r + r === 2:2:6
+    k = 0
+    for i in r
+        @test i == (k += 1)
+    end
+    @test intersect(r, Base.OneTo(2)) == Base.OneTo(2)
+    @test intersect(r, 0:5) == 1:3
+    @test intersect(r, 2) === intersect(2, r) === 2:2
+    @test findin(r, r) === findin(r, 1:length(r)) === findin(1:length(r), r) === 1:length(r)
+    io = IOBuffer()
+    show(io, r)
+    str = String(take!(io))
+    @test str == "Base.OneTo(3)"
+end
+let r = Base.OneTo(7)
+    @test findin(r, 2:(length(r) - 1)) === 2:(length(r) - 1)
+    @test findin(2:(length(r) - 1), r) === 1:(length(r) - 2)
+end
 
 # linspace of other types
-r = linspace(0, 3//10, 4)
-@test eltype(r) == Rational{Int}
-@test r[2] === 1//10
+let r = linspace(0, 3//10, 4)
+    @test eltype(r) == Rational{Int}
+    @test r[2] === 1//10
+end
 
-a, b = 1.0, nextfloat(1.0)
-ba, bb = BigFloat(a), BigFloat(b)
-r = linspace(ba, bb, 3)
-@test eltype(r) == BigFloat
-@test r[1] == a && r[3] == b
-@test r[2] == (ba+bb)/2
+let a = 1.0,
+    b = nextfloat(1.0),
+    ba = BigFloat(a),
+    bb = BigFloat(b),
+    r = linspace(ba, bb, 3)
+    @test eltype(r) == BigFloat
+    @test r[1] == a && r[3] == b
+    @test r[2] == (ba+bb)/2
+end
 
-a, b = rand(10), rand(10)
-r = linspace(a, b, 5)
-@test r[1] == a && r[5] == b
-for i = 2:4
-    local i
-    x = ((5-i)//4)*a + ((i-1)//4)*b
-    @test r[i] == x
+let (a, b) = (rand(10), rand(10)),
+    r = linspace(a, b, 5)
+    @test r[1] == a && r[5] == b
+    for i = 2:4
+        x = ((5 - i) // 4) * a + ((i - 1) // 4) * b
+        @test r[i] == x
+    end
 end
 
 # issue #23178
-r = linspace(Float16(0.1094), Float16(0.9697), 300)
-@test r[1] == Float16(0.1094)
-@test r[end] == Float16(0.9697)
+let r = linspace(Float16(0.1094), Float16(0.9697), 300)
+    @test r[1] == Float16(0.1094)
+    @test r[end] == Float16(0.9697)
+end
 
 # issue #20382
-r = @inferred(colon(big(1.0),big(2.0),big(5.0)))
-@test eltype(r) == BigFloat
+let r = @inferred(colon(big(1.0),big(2.0),big(5.0)))
+    @test eltype(r) == BigFloat
+end
 
 # issue #14420
 for r in (linspace(0.10000000000000045, 1), 0.10000000000000045:(1-0.10000000000000045)/49:1)

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -78,14 +78,20 @@ fill!(r, -1.1)
 @test sum!(abs2, r, Breduc, init=false) ≈ safe_sumabs2(Breduc, 1) .- 1.1
 
 # Small arrays with init=false
-A = reshape(1:15, 3, 5)
-R = ones(Int, 3)
-@test sum!(R, A, init=false) == [36,41,46]
-R = ones(Int, 1, 5)
-@test sum!(R, A, init=false) == [7 16 25 34 43]
-R = [2]
-A = reshape(1:6, 3, 2)
-@test prod!(R, A, init=false) == [1440]
+let A = reshape(1:15, 3, 5)
+    R = ones(Int, 3)
+    @test sum!(R, A, init=false) == [36,41,46]
+    R = ones(Int, 1, 5)
+    @test sum!(R, A, init=false) == [7 16 25 34 43]
+end
+let R = [2]
+    A = reshape(1:6, 3, 2)
+    @test prod!(R, A, init=false) == [1440]
+
+    # min/max
+    @test reducedim(max, A, 1) == [3 6]
+    @test reducedim(min, A, 2) == reshape([1,2,3], 3, 1)
+end
 
 # Small integers
 @test @inferred(sum(Int8[1], 1)) == [1]
@@ -99,23 +105,21 @@ A = reshape(1:6, 3, 2)
 @test typeof(@inferred(Base.prod(abs, [1.0+1.0im], 1))) == Vector{Float64}
 @test typeof(@inferred(Base.prod(abs2, [1.0+1.0im], 1))) == Vector{Float64}
 
-# min/max
-@test reducedim(max, A, 1) == [3 6]
-@test reducedim(min, A, 2) == reshape([1,2,3], 3, 1)
-
 # Heterogeneously typed arrays
 @test sum(Union{Float32, Float64}[1.0], 1) == [1.0]
 @test prod(Union{Float32, Float64}[1.0], 1) == [1.0]
 
 @test reducedim((a,b) -> a|b, [true false; false false], 1, false) == [true false]
-R = reducedim((a,b) -> a+b, [1 2; 3 4], 2, 0.0)
-@test eltype(R) == Float64
-@test R ≈ [3,7]
+let R = reducedim((a,b) -> a+b, [1 2; 3 4], 2, 0.0)
+    @test eltype(R) == Float64
+    @test R ≈ [3,7]
+end
 @test reducedim((a,b) -> a+b, [1 2; 3 4], 1, 0) == [4 6]
 
 # inferred return types
-rt = Base.return_types(reducedim, Tuple{Function, Array{Float64, 3}, Int, Float64})
-@test length(rt) == 1 && rt[1] == Array{Float64, 3}
+let rt = Base.return_types(reducedim, Tuple{Function, Array{Float64, 3}, Int, Float64})
+    @test length(rt) == 1 && rt[1] == Array{Float64, 3}
+end
 
 @testset "empty cases" begin
     A = Array{Int}(0,1)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -644,7 +644,7 @@ let exename = Base.julia_cmd()
 
     # Test stream mode
     outs, ins, p = readandwrite(`$exename --startup-file=no -q`)
-    write(ins,"1\nquit()\n")
+    write(ins, "1\nquit()\n")
     @test read(outs, String) == "1\n"
 end # let exename
 

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -2,82 +2,83 @@
 
 using Base.REPLCompletions
 
-ex = quote
-    module CompletionFoo
-    mutable struct Test_y
-        yy
+let ex = quote
+        module CompletionFoo
+        mutable struct Test_y
+            yy
+        end
+        mutable struct Test_x
+            xx :: Test_y
+        end
+        type_test = Test_x(Test_y(1))
+        (::Test_y)() = "", ""
+        module CompletionFoo2
+
+        end
+        const bar = 1
+        foo() = bar
+        macro foobar()
+            :()
+        end
+
+        # Support non-Dict Associatives, #19441
+        mutable struct CustomDict{K, V} <: Associative{K, V}
+            mydict::Dict{K, V}
+        end
+
+        Base.keys(d::CustomDict) = collect(keys(d.mydict))
+        Base.length(d::CustomDict) = length(d.mydict)
+
+        test(x::T, y::T) where {T<:Real} = pass
+        test(x::Real, y::Real) = pass
+        test(x::AbstractArray{T}, y) where {T<:Real} = pass
+        test(args...) = pass
+
+        test1(x::Type{Float64}) = pass
+
+        test2(x::AbstractString) = pass
+        test2(x::Char) = pass
+        test2(x::Cmd) = pass
+
+        test3(x::AbstractArray{Int}, y::Int) = pass
+        test3(x::AbstractArray{Float64}, y::Float64) = pass
+
+        test4(x::AbstractString, y::AbstractString) = pass
+        test4(x::AbstractString, y::Regex) = pass
+
+        test5(x::Array{Bool,1}) = pass
+        test5(x::BitArray{1}) = pass
+        test5(x::Float64) = pass
+        const a=x->x
+        test6()=[a, a]
+        test7() = rand() > 0.5 ? 1 : 1.0
+        test8() = Any[1][1]
+        kwtest(; x=1, y=2, w...) = pass
+
+        array = [1, 1]
+        varfloat = 0.1
+
+        const tuple = (1, 2)
+
+        test_y_array=[CompletionFoo.Test_y(rand()) for i in 1:10]
+        test_dict = Dict("abc"=>1, "abcd"=>10, :bar=>2, :bar2=>9, Base=>3,
+                         contains=>4, `ls`=>5, 66=>7, 67=>8, ("q",3)=>11,
+                         "α"=>12, :α=>13)
+        test_customdict = CustomDict(test_dict)
+
+        macro teststr_str(s) end
+        macro tϵsτstρ_str(s) end
+        macro testcmd_cmd(s) end
+        macro tϵsτcmδ_cmd(s) end
+
+        end
+        test_repl_comp_dict = CompletionFoo.test_dict
+        test_repl_comp_customdict = CompletionFoo.test_customdict
+        test_dict_ℂ = Dict(1=>2)
     end
-    mutable struct Test_x
-        xx :: Test_y
-    end
-    type_test = Test_x(Test_y(1))
-    (::Test_y)() = "", ""
-    module CompletionFoo2
-
-    end
-    const bar = 1
-    foo() = bar
-    macro foobar()
-        :()
-    end
-
-    # Support non-Dict Associatives, #19441
-    mutable struct CustomDict{K, V} <: Associative{K, V}
-        mydict::Dict{K, V}
-    end
-
-    Base.keys(d::CustomDict) = collect(keys(d.mydict))
-    Base.length(d::CustomDict) = length(d.mydict)
-
-    test(x::T, y::T) where {T<:Real} = pass
-    test(x::Real, y::Real) = pass
-    test(x::AbstractArray{T}, y) where {T<:Real} = pass
-    test(args...) = pass
-
-    test1(x::Type{Float64}) = pass
-
-    test2(x::AbstractString) = pass
-    test2(x::Char) = pass
-    test2(x::Cmd) = pass
-
-    test3(x::AbstractArray{Int}, y::Int) = pass
-    test3(x::AbstractArray{Float64}, y::Float64) = pass
-
-    test4(x::AbstractString, y::AbstractString) = pass
-    test4(x::AbstractString, y::Regex) = pass
-
-    test5(x::Array{Bool,1}) = pass
-    test5(x::BitArray{1}) = pass
-    test5(x::Float64) = pass
-    const a=x->x
-    test6()=[a, a]
-    test7() = rand() > 0.5 ? 1 : 1.0
-    test8() = Any[1][1]
-    kwtest(; x=1, y=2, w...) = pass
-
-    array = [1, 1]
-    varfloat = 0.1
-
-    const tuple = (1, 2)
-
-    test_y_array=[CompletionFoo.Test_y(rand()) for i in 1:10]
-    test_dict = Dict("abc"=>1, "abcd"=>10, :bar=>2, :bar2=>9, Base=>3,
-                     contains=>4, `ls`=>5, 66=>7, 67=>8, ("q",3)=>11,
-                     "α"=>12, :α=>13)
-    test_customdict = CustomDict(test_dict)
-
-    macro teststr_str(s) end
-    macro tϵsτstρ_str(s) end
-    macro testcmd_cmd(s) end
-    macro tϵsτcmδ_cmd(s) end
-
-    end
-    test_repl_comp_dict = CompletionFoo.test_dict
-    test_repl_comp_customdict = CompletionFoo.test_customdict
-    test_dict_ℂ = Dict(1=>2)
+    ex.head = :toplevel
+    eval(Main, ex)
 end
-ex.head = :toplevel
-eval(Main, ex)
 
 function temp_pkg_dir_noinit(fn::Function)
     # Used in tests below to set up and tear down a sandboxed package directory
@@ -100,208 +101,241 @@ test_complete(s) = completions(s,endof(s))
 test_scomplete(s) = shell_completions(s,endof(s))
 test_bslashcomplete(s) = bslash_completions(s,endof(s))[2]
 
-s = ""
-c,r = test_complete(s)
-@test "CompletionFoo" in c
-@test isempty(r)
-@test s[r] == ""
+let s = ""
+    c, r = test_complete(s)
+    @test "CompletionFoo" in c
+    @test isempty(r)
+    @test s[r] == ""
+end
 
-s = "Comp"
-c,r = test_complete(s)
-@test "CompletionFoo" in c
-@test r == 1:4
-@test s[r] == "Comp"
+let s = "Comp"
+    c, r = test_complete(s)
+    @test "CompletionFoo" in c
+    @test r == 1:4
+    @test s[r] == "Comp"
+end
 
-s = "Main.Comp"
-c,r = test_complete(s)
-@test "CompletionFoo" in c
-@test r == 6:9
-@test s[r] == "Comp"
+let s = "Main.Comp"
+    c, r = test_complete(s)
+    @test "CompletionFoo" in c
+    @test r == 6:9
+    @test s[r] == "Comp"
+end
 
-s = "Main.CompletionFoo."
-c,r = test_complete(s)
-@test "bar" in c
-@test r == 20:19
-@test s[r] == ""
+let s = "Main.CompletionFoo."
+    c, r = test_complete(s)
+    @test "bar" in c
+    @test r == 20:19
+    @test s[r] == ""
+end
 
-s = "Main.CompletionFoo.f"
-c,r = test_complete(s)
-@test "foo" in c
-@test r == 20:20
-@test s[r] == "f"
-@test !("foobar" in c)
+let s = "Main.CompletionFoo.f"
+    c, r = test_complete(s)
+    @test "foo" in c
+    @test r == 20:20
+    @test s[r] == "f"
+    @test !("foobar" in c)
+end
 
 # issue #6424
-s = "Main.CompletionFoo.@f"
-c,r = test_complete(s)
-@test "@foobar" in c
-@test r == 20:21
-@test s[r] == "@f"
-@test !("foo" in c)
+let s = "Main.CompletionFoo.@f"
+    c, r = test_complete(s)
+    @test "@foobar" in c
+    @test r == 20:21
+    @test s[r] == "@f"
+    @test !("foo" in c)
+end
 
-s = "Main.CompletionFoo.type_test.x"
-c,r = test_complete(s)
-@test "xx" in c
-@test r == 30:30
-@test s[r] == "x"
+let s = "Main.CompletionFoo.type_test.x"
+    c, r = test_complete(s)
+    @test "xx" in c
+    @test r == 30:30
+    @test s[r] == "x"
+end
 
-s = "Main.CompletionFoo.bar.no_val_available"
-c,r = test_complete(s)
-@test length(c)==0
+let s = "Main.CompletionFoo.bar.no_val_available"
+    c, r = test_complete(s)
+    @test length(c)==0
+end
+
 #cannot do dot completion on infix operator
-s = "+."
-c,r = test_complete(s)
-@test length(c)==0
+let s = "+."
+    c, r = test_complete(s)
+    @test length(c)==0
+end
 
 # To complete on a variable of a type, the type T of the variable
 # must be a concrete type, hence Base.isstructtype(T) returns true,
 # for the completion to succeed. That why `xx :: Test_y` of `Test_x`.
-s = "Main.CompletionFoo.type_test.xx.y"
-c,r = test_complete(s)
-@test "yy" in c
-@test r == 33:33
-@test s[r] == "y"
+let s = "Main.CompletionFoo.type_test.xx.y"
+    c, r = test_complete(s)
+    @test "yy" in c
+    @test r == 33:33
+    @test s[r] == "y"
+end
 
 # issue #6333
-s = "Base.return_types(getin"
-c,r = test_complete(s)
-@test "getindex" in c
-@test r == 19:23
-@test s[r] == "getin"
+let s = "Base.return_types(getin"
+    c, r = test_complete(s)
+    @test "getindex" in c
+    @test r == 19:23
+    @test s[r] == "getin"
+end
 
 # issue #23193: after `using`, identifiers can be prefixed by module names
-s = "using Base.Test, Base.Random"
-c,r = test_complete(s)
-@test !("RandomDevice" in c)
+let s = "using Base.Test, Base.Random"
+    c, r = test_complete(s)
+    @test !("RandomDevice" in c)
+end
 
 # issue #23226: identifiers must be separated by a comma (not a newline)
-s = "using Base\nusi"
-c,r = test_complete(s)
-@test "using" in c
+let s = "using Base\nusi"
+    c, r = test_complete(s)
+    @test "using" in c
+end
 
 # issue 23292
-@test_nowarn test_complete("test7().")
-c,r = test_complete("test8().")
-@test isempty(c)
+let
+    @test_nowarn test_complete("test7().")
+    c, r = test_complete("test8().")
+    @test isempty(c)
+end
 
 # inexistent completion inside a string
-s = "Pkg.add(\"lol"
-c,r,res = test_complete(s)
-@test res == false
+let s = "Pkg.add(\"lol"
+    c, r, res = test_complete(s)
+    @test res == false
+end
 
 # test latex symbol completions
-s = "\\alpha"
-c,r = test_bslashcomplete(s)
-@test c[1] == "α"
-@test r == 1:length(s)
-@test length(c) == 1
+let s = "\\alpha"
+    c, r = test_bslashcomplete(s)
+    @test c[1] == "α"
+    @test r == 1:length(s)
+    @test length(c) == 1
+end
 
 # test latex symbol completions after unicode #9209
-s = "α\\alpha"
-c,r = test_bslashcomplete(s)
-@test c[1] == "α"
-@test r == 3:sizeof(s)
-@test length(c) == 1
+let s = "α\\alpha"
+    c, r = test_bslashcomplete(s)
+    @test c[1] == "α"
+    @test r == 3:sizeof(s)
+    @test length(c) == 1
+end
 
 # test emoji symbol completions
-s = "\\:koala:"
-c,r = test_bslashcomplete(s)
-@test c[1] == "🐨"
-@test r == 1:sizeof(s)
-@test length(c) == 1
+let s = "\\:koala:"
+    c, r = test_bslashcomplete(s)
+    @test c[1] == "🐨"
+    @test r == 1:sizeof(s)
+    @test length(c) == 1
+end
 
-s = "\\:ko"
-c,r = test_bslashcomplete(s)
-@test "\\:koala:" in c
+let s = "\\:ko"
+    c, r = test_bslashcomplete(s)
+    @test "\\:koala:" in c
+end
 
 # test emoji symbol completions after unicode #9209
-s = "α\\:koala:"
-c,r = test_bslashcomplete(s)
-@test c[1] == "🐨"
-@test r == 3:sizeof(s)
-@test length(c) == 1
+let s = "α\\:koala:"
+    c, r = test_bslashcomplete(s)
+    @test c[1] == "🐨"
+    @test r == 3:sizeof(s)
+    @test length(c) == 1
+end
 
 # test latex symbol completions in strings should not work when there
 # is a backslash in front of `\alpha` because it interferes with path completion on windows
-s = "cd(\"path_to_an_empty_folder_should_not_complete_latex\\\\\\alpha"
-c,r,res = test_complete(s)
-@test length(c) == 0
+let s = "cd(\"path_to_an_empty_folder_should_not_complete_latex\\\\\\alpha"
+    c, r, res = test_complete(s)
+    @test length(c) == 0
+end
 
 # test latex symbol completions in strings
-s = "\"C:\\\\ \\alpha"
-c,r,res = test_complete(s)
-@test c[1] == "α"
-@test r == 7:12
-@test length(c) == 1
+let s = "\"C:\\\\ \\alpha"
+    c, r, res = test_complete(s)
+    @test c[1] == "α"
+    @test r == 7:12
+    @test length(c) == 1
+end
 
-s = "\\a"
-c, r, res = test_complete(s)
-"\\alpha" in c
-@test r == 1:2
-@test s[r] == "\\a"
+let s = "\\a"
+    c, r, res = test_complete(s)
+    "\\alpha" in c
+    @test r == 1:2
+    @test s[r] == "\\a"
+end
 
 # `cd("C:\U should not make the repl crash due to escaping see comment #9137
-s = "cd(\"C:\\U"
-c,r,res = test_complete(s)
+let s = "cd(\"C:\\U"
+    c, r, res = test_complete(s)
+end
 
 # Test method completions
-s = "max("
-c, r, res = test_complete(s)
-@test !res
-@test let found = false
-    for m in methods(max)
-        if !found
-            found = (c[1] == string(m))
+let s = "max("
+    c, r, res = test_complete(s)
+    @test !res
+    @test let found = false
+        for m in methods(max)
+            if !found
+                found = (c[1] == string(m))
+            end
         end
+        found
     end
-    found
+    @test r == 1:3
+    @test s[r] == "max"
 end
-@test r == 1:3
-@test s[r] == "max"
 
 # Test completion of methods with input concrete args and args where typeinference determine their type
-s = "CompletionFoo.test(1,1, "
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Int, Int})))
-@test length(c) == 3
-@test r == 1:18
-@test s[r] == "CompletionFoo.test"
+let s = "CompletionFoo.test(1,1, "
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Int, Int})))
+    @test length(c) == 3
+    @test r == 1:18
+    @test s[r] == "CompletionFoo.test"
+end
 
-s = "CompletionFoo.test(CompletionFoo.array,"
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Array{Int, 1}, Any})))
-@test length(c) == 2
-@test r == 1:18
-@test s[r] == "CompletionFoo.test"
+let s = "CompletionFoo.test(CompletionFoo.array,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Array{Int, 1}, Any})))
+    @test length(c) == 2
+    @test r == 1:18
+    @test s[r] == "CompletionFoo.test"
+end
 
-s = "CompletionFoo.test(1,1,1,"
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Any, Any, Any})))
-@test r == 1:18
-@test s[r] == "CompletionFoo.test"
+let s = "CompletionFoo.test(1,1,1,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(first(methods(Main.CompletionFoo.test, Tuple{Any, Any, Any})))
+    @test r == 1:18
+    @test s[r] == "CompletionFoo.test"
+end
 
-s = "CompletionFoo.test1(Int,"
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 0
-@test r == 1:19
-@test s[r] == "CompletionFoo.test1"
+let s = "CompletionFoo.test1(Int,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 0
+    @test r == 1:19
+    @test s[r] == "CompletionFoo.test1"
+end
 
-s = "CompletionFoo.test1(Float64,"
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 1
-@test r == 1:19
-@test s[r] == "CompletionFoo.test1"
+let s = "CompletionFoo.test1(Float64,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 1
+    @test r == 1:19
+    @test s[r] == "CompletionFoo.test1"
+end
 
-s = "prevind(\"θ\",1,"
-c, r, res = test_complete(s)
-@test c[1] == string(first(methods(prevind, Tuple{String, Int})))
-@test r == 1:7
-@test s[r] == "prevind"
+let s = "prevind(\"θ\",1,"
+    c, r, res = test_complete(s)
+    @test c[1] == string(first(methods(prevind, Tuple{String, Int})))
+    @test r == 1:7
+    @test s[r] == "prevind"
+end
 
 for (T, arg) in [(String,"\")\""),(Char, "')'")]
     s = "(1, CompletionFoo.test2($arg,"
@@ -312,117 +346,134 @@ for (T, arg) in [(String,"\")\""),(Char, "')'")]
     @test s[r] == "CompletionFoo.test2"
 end
 
-s = "(1, CompletionFoo.test2(`')'`,"
-c, r, res = test_complete(s)
-@test c[1] == string(first(methods(Main.CompletionFoo.test2, Tuple{Cmd})))
-@test length(c) == 1
+let s = "(1, CompletionFoo.test2(`')'`,"
+    c, r, res = test_complete(s)
+    @test c[1] == string(first(methods(Main.CompletionFoo.test2, Tuple{Cmd})))
+    @test length(c) == 1
+end
 
-s = "CompletionFoo.test3([1, 2] + CompletionFoo.varfloat,"
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(first(methods(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
-@test length(c) == 1
+let s = "CompletionFoo.test3([1, 2] + CompletionFoo.varfloat,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(first(methods(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
+    @test length(c) == 1
+end
 
-s = "CompletionFoo.test3([1.,2.], 1.,"
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(first(methods(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
-@test r == 1:19
-@test length(c) == 1
-@test s[r] == "CompletionFoo.test3"
+let s = "CompletionFoo.test3([1.,2.], 1.,"
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(first(methods(Main.CompletionFoo.test3, Tuple{Array{Float64, 1}, Float64})))
+    @test r == 1:19
+    @test length(c) == 1
+    @test s[r] == "CompletionFoo.test3"
+end
 
-s = "CompletionFoo.test4(\"e\",r\" \","
-c, r, res = test_complete(s)
-@test !res
-@test c[1] == string(first(methods(Main.CompletionFoo.test4, Tuple{String, Regex})))
-@test r == 1:19
-@test length(c) == 1
-@test s[r] == "CompletionFoo.test4"
+let s = "CompletionFoo.test4(\"e\",r\" \","
+    c, r, res = test_complete(s)
+    @test !res
+    @test c[1] == string(first(methods(Main.CompletionFoo.test4, Tuple{String, Regex})))
+    @test r == 1:19
+    @test length(c) == 1
+    @test s[r] == "CompletionFoo.test4"
+end
 
 # (As discussed in #19829, the Base.REPLCompletions.get_type function isn't
 #  powerful enough to analyze general dot calls because it can't handle
 #  anonymous-function evaluation.)
-s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
-c, r, res = test_complete(s)
-@test !res
-@test_broken length(c) == 1
-@test_broken c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
+let s = "CompletionFoo.test5(push!(Base.split(\"\",' '),\"\",\"\").==\"\","
+    c, r, res = test_complete(s)
+    @test !res
+    @test_broken length(c) == 1
+    @test_broken c[1] == string(first(methods(Main.CompletionFoo.test5, Tuple{BitArray{1}})))
+end
 
-s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 1
-@test c[1] == string(first(methods(Main.CompletionFoo.test4, Tuple{String, String})))
+let s = "CompletionFoo.test4(CompletionFoo.test_y_array[1]()[1], CompletionFoo.test_y_array[1]()[2], "
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 1
+    @test c[1] == string(first(methods(Main.CompletionFoo.test4, Tuple{String, String})))
+end
 
 # Test that string escaption is handled correct
-s = """CompletionFoo.test4("\\"","""
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 2
+let s = """CompletionFoo.test4("\\"","""
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 2
+end
 
 ########## Test where the current inference logic fails ########
 # Fails due to inferrence fails to determine a concrete type for arg 1
 # But it returns AbstractArray{T,N} and hence is able to remove test5(x::Float64) from the suggestions
-s = "CompletionFoo.test5(AbstractArray[[]][1],"
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 2
+let s = "CompletionFoo.test5(AbstractArray[[]][1],"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 2
+end
 
 # equivalent to above but due to the time macro the completion fails to find the concrete type
-s = "CompletionFoo.test3(@time([1, 2] + CompletionFoo.varfloat),"
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 2
+let s = "CompletionFoo.test3(@time([1, 2] + CompletionFoo.varfloat),"
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 2
+end
 #################################################################
 
-s = "CompletionFoo.kwtest( "
-c, r, res = test_complete(s)
-@test !res
-@test length(c) == 1
-@test contains(c[1], "x, y, w...")
+let s = "CompletionFoo.kwtest( "
+    c, r, res = test_complete(s)
+    @test !res
+    @test length(c) == 1
+    @test contains(c[1], "x, y, w...")
+end
 
 # Test of inference based getfield completion
-s = "(1+2im)."
-c,r = test_complete(s)
-@test length(c)==2
-@test r == (endof(s)+1):endof(s)
-@test c == ["im","re"]
+let s = "(1+2im)."
+    c,r = test_complete(s)
+    @test length(c) == 2
+    @test r == (endof(s) + 1):endof(s)
+    @test c == ["im", "re"]
+end
 
-s = "((1+2im))."
-c,r = test_complete(s)
-@test length(c)==2
-@test r == (endof(s)+1):endof(s)
-@test c == ["im","re"]
+let s = "((1+2im))."
+    c, r = test_complete(s)
+    @test length(c) == 2
+    @test r == (endof(s) + 1):endof(s)
+    @test c == ["im", "re"]
+end
 
-s = "CompletionFoo.test_y_array[1]."
-c,r = test_complete(s)
-@test length(c)==1
-@test r == (endof(s)+1):endof(s)
-@test c[1] == "yy"
+let s = "CompletionFoo.test_y_array[1]."
+    c, r = test_complete(s)
+    @test length(c) == 1
+    @test r == (endof(s) + 1):endof(s)
+    @test c[1] == "yy"
+end
 
-s = "CompletionFoo.Test_y(rand()).y"
-c,r = test_complete(s)
-@test length(c)==1
-@test r == endof(s):endof(s)
-@test c[1] == "yy"
+let s = "CompletionFoo.Test_y(rand()).y"
+    c, r = test_complete(s)
+    @test length(c) == 1
+    @test r == endof(s):endof(s)
+    @test c[1] == "yy"
+end
 
-s = "CompletionFoo.test6()[1](CompletionFoo.Test_y(rand())).y"
-c,r = test_complete(s)
-@test length(c)==1
-@test r == endof(s):endof(s)
-@test c[1] == "yy"
+let s = "CompletionFoo.test6()[1](CompletionFoo.Test_y(rand())).y"
+    c, r = test_complete(s)
+    @test length(c) == 1
+    @test r == endof(s):endof(s)
+    @test c[1] == "yy"
+end
 
 # Test completion in multi-line comments
-s = "#=\n\\alpha"
-c, r, res = test_complete(s)
-@test c[1] == "α"
-@test r == 4:9
-@test length(c) == 1
+let s = "#=\n\\alpha"
+    c, r, res = test_complete(s)
+    @test c[1] == "α"
+    @test r == 4:9
+    @test length(c) == 1
+end
 
 # Test that completion do not work in multi-line comments
-s = "#=\nmax"
-c, r, res = test_complete(s)
-@test length(c) == 0
+let s = "#=\nmax"
+    c, r, res = test_complete(s)
+    @test length(c) == 0
+end
 
 # Test completion of packages
 mkp(p) = ((@assert !isdir(p)); mkpath(p))
@@ -466,7 +517,7 @@ try
     touch(joinpath(Pack_folder2, "Test_pack2.jl"))
 
     # Test it completes on folders
-    c,r,res = test_complete("using Test_p")
+    c, r, res = test_complete("using Test_p")
     @test !("Test_pack" in c)
     @test "Test_pack2" in c
 
@@ -474,7 +525,7 @@ try
     cd(Pack_folder) do
         open("Text.txt","w") do f end
         open("Pack.jl","w") do f end
-        c,r,res = test_complete("using ")
+        c, r, res = test_complete("using ")
         @test "Pack" in c
         @test !("Text.txt" in c)
     end
@@ -484,17 +535,19 @@ finally
 end
 
 # Test $ in shell-mode
-s = "cd \$(max"
-c, r, res = test_scomplete(s)
-@test "max" in c
-@test r == 6:8
-@test s[r] == "max"
+let s = "cd \$(max"
+    c, r, res = test_scomplete(s)
+    @test "max" in c
+    @test r == 6:8
+    @test s[r] == "max"
+end
 
 # The return type is of importance, before #8995 it would return nothing
 # which would raise an error in the repl code.
 @test (String[], 0:-1, false) == test_scomplete("\$a")
 
 if Sys.isunix()
+let s, c, r
     #Assume that we can rely on the existence and accessibility of /tmp
 
     # Tests path in Julia code and closing " if it's a file
@@ -551,7 +604,7 @@ if Sys.isunix()
     # Pressing tab after having entered "/tmp " should not
     # attempt to complete "/tmp" but rather work on the current
     # working directory again.
-    let
+    let s, c, r, file
         file = joinpath(path, "repl completions")
         s = "/tmp "
         c,r = test_scomplete(s)
@@ -559,7 +612,7 @@ if Sys.isunix()
     end
 
     # Test completing paths with an escaped trailing space
-    let
+    let s, c, r, file
         file = joinpath(tempdir(), "repl completions")
         touch(file)
         s = string(tempdir(), "/repl\\ ")
@@ -570,7 +623,7 @@ if Sys.isunix()
     end
 
     # Tests homedir expansion
-    let
+    let path, s, c, r
         path = homedir()
         dir = joinpath(path, "tmpfoobar")
         mkdir(dir)
@@ -587,7 +640,7 @@ if Sys.isunix()
     end
 
     # Tests detecting of files in the env path (in shell mode)
-    let
+    let path, s, c, r, file
         oldpath = ENV["PATH"]
         path = tempdir()
         # PATH can also contain folders which we aren't actually allowed to read.
@@ -637,12 +690,14 @@ if Sys.isunix()
         end
     end
 end
+end
 
-let #test that it can auto complete with spaces in file/path
-    path = tempdir()
-    space_folder = randstring() * " α"
-    dir = joinpath(path, space_folder)
+#test that it can auto complete with spaces in file/path
+let path = tempdir(),
+    space_folder = randstring() * " α",
+    dir = joinpath(path, space_folder),
     dir_space = replace(space_folder, " ", "\\ ")
+
     mkdir(dir)
     cd(path) do
         open(joinpath(space_folder, "space .file"),"w") do f
@@ -685,8 +740,8 @@ let #test that it can auto complete with spaces in file/path
     rm(dir, recursive=true)
 end
 
-let  # Test tilde path completion
-    c, r, res = test_complete("\"~/julia")
+# Test tilde path completion
+let (c, r, res) = test_complete("\"~/julia")
     if !Sys.iswindows()
         @test res && c == String[homedir() * "/julia"]
     else
@@ -698,8 +753,9 @@ let  # Test tilde path completion
 end
 
 # Test the completion returns nothing when the folder do not exist
-c,r = test_complete("cd(\"folder_do_not_exist_77/file")
-@test length(c) == 0
+let (c, r) = test_complete("cd(\"folder_do_not_exist_77/file")
+    @test length(c) == 0
+end
 
 if Sys.iswindows()
     tmp = tempname()
@@ -731,17 +787,21 @@ if Sys.iswindows()
 end
 
 # auto completions of true and false... issue #14101
-s = "tru"
-c, r, res = test_complete(s)
-@test "true" in c
-s = "fals"
-c, r, res = test_complete(s)
-@test "false" in c
+let s = "tru"
+    c, r, res = test_complete(s)
+    @test "true" in c
+end
+
+let s = "fals"
+    c, r, res = test_complete(s)
+    @test "false" in c
+end
 
 # Don't crash when attempting to complete a tuple, #15329
-s = "CompletionFoo.tuple."
-c, r, res = test_complete(s)
-@test isempty(c)
+let s = "CompletionFoo.tuple."
+    c, r, res = test_complete(s)
+    @test isempty(c)
+end
 
 # test Dicts
 function test_dict_completion(dict_name)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -309,8 +309,7 @@ end
 
 
 # issue 11845
-let
-    buf = IOBuffer()
+let buf = IOBuffer()
     showerror(buf, MethodError(convert, (3, 1.0)))
     showerror(buf, MethodError(convert, (Int, 1.0)))
     showerror(buf, MethodError(convert, Tuple{Type, Float64}))
@@ -446,12 +445,12 @@ withenv("JULIA_EDITOR" => nothing, "VISUAL" => nothing, "EDITOR" => nothing) do
 end
 
 # Issue #14684: `display` should print associative types in full.
-let d = Dict(1 => 2, 3 => 45)
-    buf = IOBuffer()
+let d = Dict(1 => 2, 3 => 45),
+    buf = IOBuffer(),
     td = TextDisplay(buf)
+
     display(td, d)
     result = String(take!(td.io))
-
     @test contains(result, summary(d))
 
     # Is every pair in the string?
@@ -617,6 +616,7 @@ let buf = IOBuffer()
 end
 
 @testset "Dict printing with limited rows" begin
+    local buf
     buf = IOBuffer()
     io = IOContext(buf, :displaysize => (4, 80), :limit => true)
     d = Base.ImmutableDict(1=>2)

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -449,8 +449,10 @@ let b = IOBuffer()
 end
 
 # issue #1770
-let a = ['T', 'e', 's', 't']
+let a = ['T', 'e', 's', 't'],
     f = IOBuffer()
+
+    # issue #1770
     serialize(f, a)
     seek(f, 0)
     @test deserialize(f) == a

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -101,7 +101,7 @@ s = Set([1])
 @test isequal(empty!(s), Set())
 
 # rehash!
-let
+let s
     # Use a pointer type to have defined behavior for uninitialized
     # array element
     s = Set(["a", "b", "c"])
@@ -120,9 +120,10 @@ let
 end
 
 # start, done, next
-for data_ in ((7,8,4,5),
-              ("hello", 23, 2.7, (), [], (1,8)))
-    s = Set(data_)
+for data_in in ((7, 8, 4, 5),
+              ("hello", 23, 2.7, (), [], (1, 8)))
+    local data_in, s, t
+    s = Set(data_in)
 
     s_new = Set()
     for el in s
@@ -224,17 +225,19 @@ end
 @test symdiff(Set([1,2,3,4]), Set([2,4,5,6])) == Set([1,3,5,6])
 
 # unique
-u = unique([1,1,2])
-@test in(1,u)
-@test in(2,u)
-@test length(u) == 2
-@test unique(iseven, [5,1,8,9,3,4,10,7,2,6]) == [5,8]
-@test unique(n->n % 3, [5,1,8,9,3,4,10,7,2,6]) == [5,1,9]
+let u = unique([1, 1, 2])
+    @test in(1, u)
+    @test in(2, u)
+    @test length(u) == 2
+    @test unique(iseven, [5, 1, 8, 9, 3, 4, 10, 7, 2, 6]) == [5, 8]
+    @test unique(n -> n % 3, [5, 1, 8, 9, 3, 4, 10, 7, 2, 6]) == [5, 1, 9]
+end
+
 # issue 20105
 @test @inferred(unique(x for x in 1:1)) == [1]
-@test unique(x for x in Any[1,1.0])::Vector{Real} == [1]
-@test unique(x for x in Real[1,1.0])::Vector{Real} == [1]
-@test unique(Integer[1,1,2])::Vector{Integer} == [1,2]
+@test unique(x for x in Any[1, 1.0])::Vector{Real} == [1]
+@test unique(x for x in Real[1, 1.0])::Vector{Real} == [1]
+@test unique(Integer[1, 1, 2])::Vector{Integer} == [1, 2]
 
 # unique!
 @testset "unique!" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -17,13 +17,13 @@ end
 
 @test replstr(parse("mutable struct X end")) == ":(mutable struct X\n        #= none:1 =#\n    end)"
 @test replstr(parse("struct X end")) == ":(struct X\n        #= none:1 =#\n    end)"
-s = "ccall(:f, Int, (Ptr{Void},), &x)"
-@test replstr(parse(s)) == ":($s)"
+let s = "ccall(:f, Int, (Ptr{Void},), &x)"
+    @test replstr(parse(s)) == ":($s)"
+end
 
 # recursive array printing
 # issue #10353
-let
-    a = Any[]
+let a = Any[]
     push!(a,a)
     show(IOBuffer(), a)
     push!(a,a)
@@ -419,7 +419,7 @@ end
 @test_repr "Array{>:Real}"
 
 let oldout = STDOUT, olderr = STDERR
-    local rdout, wrout, rderr, wrerr, out, err, rd, wr
+    local rdout, wrout, rderr, wrerr, out, err, rd, wr, io
     try
         # pr 16917
         rdout, wrout = redirect_stdout()
@@ -596,14 +596,15 @@ end
 
 
 # test structured zero matrix printing for select structured types
-A = reshape(1:16,4,4)
-@test replstr(Diagonal(A)) == "4×4 Diagonal{$(Int),Array{$(Int),1}}:\n 1  ⋅   ⋅   ⋅\n ⋅  6   ⋅   ⋅\n ⋅  ⋅  11   ⋅\n ⋅  ⋅   ⋅  16"
-@test replstr(Bidiagonal(A,:U)) == "4×4 Bidiagonal{$(Int),Array{$(Int),1}}:\n 1  5   ⋅   ⋅\n ⋅  6  10   ⋅\n ⋅  ⋅  11  15\n ⋅  ⋅   ⋅  16"
-@test replstr(Bidiagonal(A,:L)) == "4×4 Bidiagonal{$(Int),Array{$(Int),1}}:\n 1  ⋅   ⋅   ⋅\n 2  6   ⋅   ⋅\n ⋅  7  11   ⋅\n ⋅  ⋅  12  16"
-@test replstr(SymTridiagonal(A+A')) == "4×4 SymTridiagonal{$(Int),Array{$(Int),1}}:\n 2   7   ⋅   ⋅\n 7  12  17   ⋅\n ⋅  17  22  27\n ⋅   ⋅  27  32"
-@test replstr(Tridiagonal(diag(A,-1),diag(A),diag(A,+1))) == "4×4 Tridiagonal{$(Int),Array{$(Int),1}}:\n 1  5   ⋅   ⋅\n 2  6  10   ⋅\n ⋅  7  11  15\n ⋅  ⋅  12  16"
-@test replstr(UpperTriangular(copy(A))) == "4×4 UpperTriangular{$Int,Array{$Int,2}}:\n 1  5   9  13\n ⋅  6  10  14\n ⋅  ⋅  11  15\n ⋅  ⋅   ⋅  16"
-@test replstr(LowerTriangular(copy(A))) == "4×4 LowerTriangular{$Int,Array{$Int,2}}:\n 1  ⋅   ⋅   ⋅\n 2  6   ⋅   ⋅\n 3  7  11   ⋅\n 4  8  12  16"
+let A = reshape(1:16, 4, 4)
+    @test replstr(Diagonal(A)) == "4×4 Diagonal{$(Int),Array{$(Int),1}}:\n 1  ⋅   ⋅   ⋅\n ⋅  6   ⋅   ⋅\n ⋅  ⋅  11   ⋅\n ⋅  ⋅   ⋅  16"
+    @test replstr(Bidiagonal(A, :U)) == "4×4 Bidiagonal{$(Int),Array{$(Int),1}}:\n 1  5   ⋅   ⋅\n ⋅  6  10   ⋅\n ⋅  ⋅  11  15\n ⋅  ⋅   ⋅  16"
+    @test replstr(Bidiagonal(A, :L)) == "4×4 Bidiagonal{$(Int),Array{$(Int),1}}:\n 1  ⋅   ⋅   ⋅\n 2  6   ⋅   ⋅\n ⋅  7  11   ⋅\n ⋅  ⋅  12  16"
+    @test replstr(SymTridiagonal(A + A')) == "4×4 SymTridiagonal{$(Int),Array{$(Int),1}}:\n 2   7   ⋅   ⋅\n 7  12  17   ⋅\n ⋅  17  22  27\n ⋅   ⋅  27  32"
+    @test replstr(Tridiagonal(diag(A, -1), diag(A), diag(A, +1))) == "4×4 Tridiagonal{$(Int),Array{$(Int),1}}:\n 1  5   ⋅   ⋅\n 2  6  10   ⋅\n ⋅  7  11  15\n ⋅  ⋅  12  16"
+    @test replstr(UpperTriangular(copy(A))) == "4×4 UpperTriangular{$Int,Array{$Int,2}}:\n 1  5   9  13\n ⋅  6  10  14\n ⋅  ⋅  11  15\n ⋅  ⋅   ⋅  16"
+    @test replstr(LowerTriangular(copy(A))) == "4×4 LowerTriangular{$Int,Array{$Int,2}}:\n 1  ⋅   ⋅   ⋅\n 2  6   ⋅   ⋅\n 3  7  11   ⋅\n 4  8  12  16"
+end
 
 # Vararg methods in method tables
 function test_mt(f, str)
@@ -678,8 +679,9 @@ end
 @test contains(sprint((io, x) -> show(IOContext(io, :limit => true), x), ones(30, 30)), "\u2026")
 
 # showcompact() also sets :multiline=>false (#16817)
-let io = IOBuffer()
+let io = IOBuffer(),
     x = [1, 2]
+
     showcompact(io, x)
     @test String(take!(io)) == "[1, 2]"
     showcompact(IOContext(io, :compact => true), x)

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -26,8 +26,9 @@ function simd_loop_with_multiple_reductions(x, y, z)
 end
 
 for T in [Int32,Int64,Float32,Float64]
-   # Try various lengths to make sure "remainder loop" works
-   for n in [0,1,2,3,4,255,256,257]
+    # Try various lengths to make sure "remainder loop" works
+    for n in [0,1,2,3,4,255,256,257]
+        local n, a, b, c, s, t
         # Dataset chosen so that results will be exact with only 24 bits of mantissa
         a = convert(Array{T},[2*j+1 for j in 1:n])
         b = convert(Array{T},[3*j+2 for j in 1:n])

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -8,7 +8,7 @@ using Base.Order: Forward
 @test sort(['a':'z';], rev=true) == ['z':-1:'a';]
 @test sortperm([2,3,1]) == [3,1,2]
 @test sortperm!([1,2,3], [2,3,1]) == [3,1,2]
-let s = view([1,2,3,4], 1:3)
+let s = view([1,2,3,4], 1:3),
     r = sortperm!(s, [2,3,1])
     @test r == [3,1,2]
     @test r === s
@@ -223,6 +223,7 @@ end
 srand(0xdeadbeef)
 
 for n in [0:10; 100; 101; 1000; 1001]
+    local r
     r = -5:5
     v = rand(r,n)
     h = [sum(v .== x) for x in r]
@@ -324,8 +325,11 @@ inds = [
     193,193,193,194,194,194,195,195,195,196,196,197,197,197,
     198,198,198,199,199,199,200,200,200
 ]
-sp = sortperm(inds)
-@test all(issorted, [sp[inds.==x] for x in 1:200])
+
+let sp = sortperm(inds)
+    @test all(issorted, [sp[inds.==x] for x in 1:200])
+end
+
 for alg in [InsertionSort, MergeSort]
     sp = sortperm(inds, alg=alg)
     @test all(issorted, [sp[inds.==x] for x in 1:200])

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -149,6 +149,7 @@ pred = afiro'*sol
 @test norm(afiro * (convert(Matrix, y) - convert(Matrix, pred))) < 1e-8
 
 let # Issue 9160
+    local A, B
     A = sprand(10, 10, 0.1)
     A = convert(SparseMatrixCSC{Float64,CHOLMOD.SuiteSparse_long}, A)
     cmA = CHOLMOD.Sparse(A)
@@ -257,6 +258,7 @@ unsafe_store!(puint,  5, 3*div(sizeof(Csize_t), 4) + 5*div(sizeof(Ptr{Void}), 4)
 
 ## High level interface
 for elty in (Float64, Complex{Float64})
+    local A, b
     if elty == Float64
         A = randn(5, 5)
         b = randn(5)
@@ -639,23 +641,24 @@ Fnew = deserialize(b)
 @test_throws MethodError cholfact(Hermitian(speye(Complex{BigFloat}, 5)))
 
 # test \ for Factor and StridedVecOrMat
-let x = rand(5)
+let x = rand(5),
     A = cholfact(sparse(diagm(x.\1)))
     @test A\view(ones(10),1:2:10) ≈ x
     @test A\view(eye(5,5),:,:) ≈ diagm(x)
 end
 
 # Real factorization and complex rhs
-A = sprandn(5,5,0.4) |> t -> t't + I
-B = complex.(randn(5,2), randn(5,2))
-@test cholfact(A)\B ≈ A\B
+let A = sprandn(5, 5, 0.4) |> t -> t't + I,
+    B = complex.(randn(5, 2), randn(5, 2))
+    @test cholfact(A)\B ≈ A\B
+end
 
 # Make sure that ldltfact performs an LDLt (Issue #19032)
-let m = 400, n = 500
-    A = sprandn(m, n, .2)
-    M = [speye(n) A'; A -speye(m)]
-    b = M*ones(m + n)
-    F = ldltfact(M)
+let m = 400, n = 500,
+    A = sprandn(m, n, .2),
+    M = [speye(n) A'; A -speye(m)],
+    b = M * ones(m + n),
+    F = ldltfact(M),
     s = unsafe_load(pointer(F))
     @test s.is_super == 0
     @test F\b ≈ ones(m + n)
@@ -668,7 +671,7 @@ let Apre = sprandn(10, 10, 0.2) - I
     for A in (Symmetric(Apre), Hermitian(Apre),
               Symmetric(Apre + 10I), Hermitian(Apre + 10I),
               Hermitian(complex(Apre)), Hermitian(complex(Apre) + 10I))
-        local A
+        local A, x, b
         x = ones(10)
         b = A*x
         @test x ≈ A\b
@@ -677,8 +680,8 @@ let Apre = sprandn(10, 10, 0.2) - I
 end
 
 # Check that Symmetric{SparseMatrixCSC} can be constructed from CHOLMOD.Sparse
-let A = sprandn(10, 10, 0.1)
-    B = SparseArrays.CHOLMOD.Sparse(A)
+let A = sprandn(10, 10, 0.1),
+    B = SparseArrays.CHOLMOD.Sparse(A),
     C = B'B
     # Change internal representation to symmetric (upper/lower)
     o = fieldoffset(CHOLMOD.C_Sparse{eltype(C)}, find(fieldnames(CHOLMOD.C_Sparse{eltype(C)}) .== :stype)[1])
@@ -718,6 +721,7 @@ for F in (cholfact(AtA), cholfact(AtA, perm=1:5), ldltfact(AtA), ldltfact(AtA, p
     B0 = F\ones(5)
     #Test both sparse/dense and vectors/matrices
     for Ctest in (C0, sparse(C0), [C0 2*C0], sparse([C0 2*C0]))
+        local B, C, F1
         C = copy(Ctest)
         F1 = copy(F)
         B = (AtA+C*C')\ones(5)
@@ -745,6 +749,7 @@ for F in (cholfact(AtA), cholfact(AtA, perm=1:5), ldltfact(AtA), ldltfact(AtA, p
 end
 
 @testset "Issue #22335" begin
+    local A, F
     A = speye(3)
     @test LinAlg.issuccess(cholfact(A))
     A[3, 3] = -1

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -94,26 +94,28 @@ end
     end
 end
 
-a116 = copy(reshape(1:16, 4, 4))
-s116 = sparse(a116)
+let
+    a116 = copy(reshape(1:16, 4, 4))
+    s116 = sparse(a116)
 
-@testset "sparse ref" begin
-    p = [4, 1, 2, 3, 2]
-    @test Array(s116[p,:]) == a116[p,:]
-    @test Array(s116[:,p]) == a116[:,p]
-    @test Array(s116[p,p]) == a116[p,p]
-end
+    @testset "sparse ref" begin
+        p = [4, 1, 2, 3, 2]
+        @test Array(s116[p,:]) == a116[p,:]
+        @test Array(s116[:,p]) == a116[:,p]
+        @test Array(s116[p,p]) == a116[p,p]
+    end
 
-@testset "sparse assignment" begin
-    p = [4, 1, 3]
-    a116[p, p] = -1
-    s116[p, p] = -1
-    @test a116 == s116
+    @testset "sparse assignment" begin
+        p = [4, 1, 3]
+        a116[p, p] = -1
+        s116[p, p] = -1
+        @test a116 == s116
 
-    p = [2, 1, 4]
-    a116[p, p] = reshape(1:9, 3, 3)
-    s116[p, p] = reshape(1:9, 3, 3)
-    @test a116 == s116
+        p = [2, 1, 4]
+        a116[p, p] = reshape(1:9, 3, 3)
+        s116[p, p] = reshape(1:9, 3, 3)
+        @test a116 == s116
+    end
 end
 
 @testset "squeeze" begin
@@ -276,9 +278,9 @@ end
 sA = sprandn(3, 7, 0.5)
 sC = similar(sA)
 dA = Array(sA)
-b = randn(7)
 
 @testset "scale and scale!" begin
+    b = randn(7)
     @test dA * Diagonal(b) == sA * Diagonal(b)
     @test dA * Diagonal(b) == scale!(sC, sA, b)
     @test dA * Diagonal(b) == scale!(copy(sA), b)
@@ -294,17 +296,17 @@ b = randn(7)
     @test 0.5 * dA            == scale!(sC, sA, 0.5)
     @test 0.5 * dA            == scale!(0.5, copy(sA))
     @test scale!(sC, 0.5, sA) == scale!(sC, sA, 0.5)
-end
 
-@testset "inverse scale!" begin
-    bi = inv.(b)
-    dAt = transpose(dA)
-    sAt = transpose(sA)
-    @test scale!(copy(dAt), bi) ≈ Base.LinAlg.A_rdiv_B!(copy(sAt), Diagonal(b))
-    @test scale!(copy(dAt), bi) ≈ Base.LinAlg.A_rdiv_Bt!(copy(sAt), Diagonal(b))
-    @test scale!(copy(dAt), conj(bi)) ≈ Base.LinAlg.A_rdiv_Bc!(copy(sAt), Diagonal(b))
-    @test_throws DimensionMismatch Base.LinAlg.A_rdiv_B!(copy(sAt), Diagonal(ones(length(b) + 1)))
-    @test_throws LinAlg.SingularException Base.LinAlg.A_rdiv_B!(copy(sAt), Diagonal(zeros(length(b))))
+    @testset "inverse scale!" begin
+        bi = inv.(b)
+        dAt = transpose(dA)
+        sAt = transpose(sA)
+        @test scale!(copy(dAt), bi) ≈ Base.LinAlg.A_rdiv_B!(copy(sAt), Diagonal(b))
+        @test scale!(copy(dAt), bi) ≈ Base.LinAlg.A_rdiv_Bt!(copy(sAt), Diagonal(b))
+        @test scale!(copy(dAt), conj(bi)) ≈ Base.LinAlg.A_rdiv_Bc!(copy(sAt), Diagonal(b))
+        @test_throws DimensionMismatch Base.LinAlg.A_rdiv_B!(copy(sAt), Diagonal(ones(length(b) + 1)))
+        @test_throws LinAlg.SingularException Base.LinAlg.A_rdiv_B!(copy(sAt), Diagonal(zeros(length(b))))
+    end
 end
 
 @testset "copy!" begin
@@ -1315,67 +1317,69 @@ end
 end
 
 @testset "error conditions for reinterpret, reshape, and squeeze" begin
-    A = sprand(Bool, 5,5,0.2)
-    @test_throws ArgumentError reinterpret(Complex128,A)
-    @test_throws ArgumentError reinterpret(Complex128,A,(5,5))
-    @test_throws DimensionMismatch reinterpret(Int8,A,(20,))
-    @test_throws DimensionMismatch reshape(A,(20,2))
-    @test_throws ArgumentError squeeze(A,(1,1))
+    local A = sprand(Bool, 5, 5, 0.2)
+    @test_throws ArgumentError reinterpret(Complex128, A)
+    @test_throws ArgumentError reinterpret(Complex128, A,(5, 5))
+    @test_throws DimensionMismatch reinterpret(Int8, A,(20,))
+    @test_throws DimensionMismatch reshape(A,(20, 2))
+    @test_throws ArgumentError squeeze(A,(1, 1))
 end
 
 @testset "similar with type conversion" begin
-    A = speye(5)
-    @test size(similar(A,Complex128,Int)) == (5,5)
-    @test typeof(similar(A,Complex128,Int)) == SparseMatrixCSC{Complex128,Int}
-    @test size(similar(A,Complex128,Int8)) == (5,5)
-    @test typeof(similar(A,Complex128,Int8)) == SparseMatrixCSC{Complex128,Int8}
-    @test similar(A,Complex128,(6,6)) == spzeros(Complex128,6,6)
-    @test convert(Matrix,A) == Array(A)
+    local A = speye(5)
+    @test size(similar(A, Complex128, Int)) == (5, 5)
+    @test typeof(similar(A, Complex128, Int)) == SparseMatrixCSC{Complex128, Int}
+    @test size(similar(A, Complex128, Int8)) == (5, 5)
+    @test typeof(similar(A, Complex128, Int8)) == SparseMatrixCSC{Complex128, Int8}
+    @test similar(A, Complex128,(6, 6)) == spzeros(Complex128, 6, 6)
+    @test convert(Matrix, A) == Array(A)
 end
 
 @testset "float" begin
-    A = sprand(Bool, 5,5,0.0)
+    local A
+    A = sprand(Bool, 5, 5, 0.0)
     @test eltype(float(A)) == Float64  # issue #11658
-    A = sprand(Bool, 5,5,0.2)
+    A = sprand(Bool, 5, 5, 0.2)
     @test float(A) == float(Array(A))
 end
 
 @testset "sparsevec" begin
-    A = sparse(ones(5,5))
+    local A = sparse(ones(5, 5))
     @test all(Array(sparsevec(A)) .== ones(25))
-    @test all(Array(sparsevec([1:5;],1)) .== ones(5))
+    @test all(Array(sparsevec([1:5;], 1)) .== ones(5))
     @test_throws ArgumentError sparsevec([1:5;], [1:4;])
 end
 
 @testset "sparse" begin
-    A = sparse(ones(5,5))
+    local A = sparse(ones(5, 5))
     @test sparse(A) == A
-    @test sparse([1:5;],[1:5;],1) == speye(5)
+    @test sparse([1:5;], [1:5;], 1) == speye(5)
 end
 
 @testset "speye and one" begin
-    A = sparse(ones(5,5))
+    local A = sparse(ones(5, 5))
     @test speye(A) == speye(5)
     @test eye(A) == speye(5)
     @test one(A) == speye(5)
-    @test_throws DimensionMismatch one(sprand(5,6,0.2))
+    @test_throws DimensionMismatch one(sprand(5, 6, 0.2))
     @test eltype(speye(Real, 5, 5)) === Real
 end
 
 @testset "istriu/istril" begin
-    A = sparse(triu(rand(5,5)))
+    local A
+    A = sparse(triu(rand(5, 5)))
     @test istriu(A)
-    @test !istriu(sparse(ones(5,5)))
-    A = sparse(tril(rand(5,5)))
+    @test !istriu(sparse(ones(5, 5)))
+    A = sparse(tril(rand(5, 5)))
     @test istril(A)
-    @test !istril(sparse(ones(5,5)))
+    @test !istril(sparse(ones(5, 5)))
 end
 
 @testset "droptol" begin
     srand(1234321)
-    A = triu(sprand(10,10,0.2))
-    @test Base.droptol!(A,0.01).colptr == [1,1,1,2,2,3,4,6,6,7,9]
-    @test isequal(Base.droptol!(sparse([1], [1], [1]), 1), SparseMatrixCSC(1,1,Int[1,1],Int[],Int[]))
+    local A = triu(sprand(10, 10, 0.2))
+    @test Base.droptol!(A, 0.01).colptr == [1,1,1,2,2,3,4,6,6,7,9]
+    @test isequal(Base.droptol!(sparse([1], [1], [1]), 1), SparseMatrixCSC(1, 1, Int[1, 1], Int[], Int[]))
 end
 
 @testset "dropzeros[!]" begin
@@ -1385,7 +1389,7 @@ end
     targetnumposzeros = 5
     targetnumnegzeros = 5
     for (m, n) in ((largedim, largedim), (smalldim, largedim), (largedim, smalldim))
-        A = sprand(m, n, nzprob)
+        local A = sprand(m, n, nzprob)
         struczerosA = find(x -> x == 0, A)
         poszerosinds = unique(rand(struczerosA, targetnumposzeros))
         negzerosinds = unique(rand(struczerosA, targetnumnegzeros))
@@ -1410,7 +1414,7 @@ end
         end
     end
     # original lone dropzeros test
-    A = sparse([1 2 3; 4 5 6; 7 8 9])
+    local A = sparse([1 2 3; 4 5 6; 7 8 9])
     A.nzval[2] = A.nzval[6] = A.nzval[7] = 0
     @test dropzeros!(A).colptr == [1, 3, 5, 7]
     # test for issue #5169, modified for new behavior following #15242/#14798
@@ -1439,7 +1443,7 @@ end
         S2 = sprand(T, 10,  5, 0.5)
         S3 = sprand(T,  5, 10, 0.5)
         for S in (S1, S2, S3)
-            A = Matrix(S)
+            local A = Matrix(S)
             @test diag(S)::SparseVector{T,Int} == diag(A)
             for k in -size(S,1):size(S,2)
                 @test diag(S, k)::SparseVector{T,Int} == diag(A, k)
@@ -1455,7 +1459,7 @@ end
 end
 
 @testset "expandptr" begin
-    A = speye(5)
+    local A = speye(5)
     @test Base.SparseArrays.expandptr(A.colptr) == collect(1:5)
     A[1,2] = 1
     @test Base.SparseArrays.expandptr(A.colptr) == [1; 2; 2; 3; 4; 5]
@@ -1463,7 +1467,7 @@ end
 end
 
 @testset "triu/tril" begin
-    A = sprand(5,5,0.2)
+    local A = sprand(5,5,0.2)
     AF = Array(A)
     @test Array(triu(A,1)) == triu(AF,1)
     @test Array(tril(A,1)) == tril(AF,1)
@@ -1483,6 +1487,7 @@ end
 end
 
 @testset "norm" begin
+    local A
     A = sparse(Int[],Int[],Float64[],0,0)
     @test norm(A) == zero(eltype(A))
     A = sparse([1.0])
@@ -1492,6 +1497,7 @@ end
 end
 
 @testset "ishermitian/issymmetric" begin
+    local A
     # real matrices
     A = speye(5,5)
     @test ishermitian(A) == true
@@ -1576,7 +1582,7 @@ end
 end
 
 @testset "UniformScaling" begin
-    A = sprandn(10,10,0.5)
+    local A = sprandn(10, 10, 0.5)
     @test A + I == Array(A) + I
     @test I + A == I + Array(A)
     @test A - I == Array(A) - I
@@ -1629,10 +1635,10 @@ end
 end
 
 @testset "sparse matrix cond" begin
-    A = sparse(reshape([1.0],1,1))
-    Ac = sprandn(20,20,.5) + im* sprandn(20,20,.5)
-    Ar = sprandn(20,20,.5)
-    @test cond(A,1) == 1.0
+    local A = sparse(reshape([1.0], 1, 1))
+    Ac = sprandn(20, 20,.5) + im* sprandn(20, 20,.5)
+    Ar = sprandn(20, 20,.5)
+    @test cond(A, 1) == 1.0
     # For a discussion of the tolerance, see #14778
     if Base.USE_GPL_LIBS
         @test 0.99 <= cond(Ar, 1) \ norm(Ar, 1) * norm(inv(Array(Ar)), 1) < 3
@@ -1696,28 +1702,29 @@ end
 end
 
 @testset "spones" begin
-    A = 2. * speye(5,5)
+    local A = 2. * speye(5, 5)
     @test Array(spones(A)) == eye(Array(A))
 end
 
 @testset "factorization" begin
-    A = spdiagm(rand(5)) + sprandn(5,5,0.2) + im*sprandn(5,5,0.2)
+    local A
+    A = spdiagm(rand(5)) + sprandn(5, 5, 0.2) + im*sprandn(5, 5, 0.2)
     A = A + A'
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(Array(A))))
-    A = spdiagm(rand(5)) + sprandn(5,5,0.2) + im*sprandn(5,5,0.2)
+    A = spdiagm(rand(5)) + sprandn(5, 5, 0.2) + im*sprandn(5, 5, 0.2)
     A = A*A'
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(Array(A))))
-    A = spdiagm(rand(5)) + sprandn(5,5,0.2)
+    A = spdiagm(rand(5)) + sprandn(5, 5, 0.2)
     A = A + A.'
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(Array(A))))
-    A = spdiagm(rand(5)) + sprandn(5,5,0.2)
+    A = spdiagm(rand(5)) + sprandn(5, 5, 0.2)
     A = A*A.'
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(Array(A))))
     @test factorize(triu(A)) == triu(A)
     @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrixCSC{Float64, Int}})
     @test factorize(tril(A)) == tril(A)
     @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrixCSC{Float64, Int}})
-    @test !Base.USE_GPL_LIBS || factorize(A[:,1:4])\ones(size(A,1)) ≈ Array(A[:,1:4])\ones(size(A,1))
+    @test !Base.USE_GPL_LIBS || factorize(A[:, 1:4])\ones(size(A, 1)) ≈ Array(A[:, 1:4])\ones(size(A, 1))
     @test_throws ErrorException chol(A)
     @test_throws ErrorException lu(A)
     @test_throws ErrorException eig(A)
@@ -1725,6 +1732,7 @@ end
 end
 
 @testset "issue #13792, use sparse triangular solvers for sparse triangular solves" begin
+    local A, n, x
     n = 100
     A = sprandn(n, n, 0.5) + sqrt(n)*I
     x = LowerTriangular(A)*ones(n)
@@ -1812,7 +1820,7 @@ end
 end
 
 @testset "row indexing a SparseMatrixCSC with non-Int integer type" begin
-    A = sparse(UInt32[1,2,3], UInt32[1,2,3], [1.0,2.0,3.0])
+    local A = sparse(UInt32[1,2,3], UInt32[1,2,3], [1.0,2.0,3.0])
     @test A[1,1:3] == A[1,:] == [1,0,0]
 end
 
@@ -1887,7 +1895,7 @@ end
 end
 
 @testset "setindex issue #20657" begin
-    A = spzeros(3, 3)
+    local A = spzeros(3, 3)
     I = [1, 1, 1]; J = [1, 1, 1]
     A[I, 1] = 1
     @test nnz(A) == 1
@@ -1954,6 +1962,7 @@ end
 end
 
 @testset "check buffers" for n in 1:3
+    local A
     colptr = [1,2,3,4]
     rowval = [1,2,3]
     nzval1  = ones(0)
@@ -1967,6 +1976,7 @@ end
 end
 
 @testset "reverse search direction if step < 0 #21986" begin
+    local A, B
     srand(1234)
     A = sprand(5, 5, 1/5)
     A = max.(A, A')

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -1096,18 +1096,21 @@ s14046 = sprand(5, 1.0)
 
 # Issue 14589
 # test vectors with no zero elements
-x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
-@test collect(sort(x)) == sort(collect(x))
+let x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
+    @test collect(sort(x)) == sort(collect(x))
+end
 # test vectors with all zero elements
-x = sparsevec(Int64[], Float64[], 7)
-@test collect(sort(x)) == sort(collect(x))
+let x = sparsevec(Int64[], Float64[], 7)
+    @test collect(sort(x)) == sort(collect(x))
+end
 # test vector with sparsity approx 1/2
-x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
-@test collect(sort(x)) == sort(collect(x))
-# apply three distinct tranformations where zeros sort into start/middle/end
-@test collect(sort(x, by=abs)) == sort(collect(x), by=abs)
-@test collect(sort(x, by=sign)) == sort(collect(x), by=sign)
-@test collect(sort(x, by=inv)) == sort(collect(x), by=inv)
+let x = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 15)
+    @test collect(sort(x)) == sort(collect(x))
+    # apply three distinct tranformations where zeros sort into start/middle/end
+    @test collect(sort(x, by=abs)) == sort(collect(x), by=abs)
+    @test collect(sort(x, by=sign)) == sort(collect(x), by=sign)
+    @test collect(sort(x, by=inv)) == sort(collect(x), by=inv)
+end
 
 # fill!
 for Tv in [Float32, Float64, Int64, Int32, Complex128]

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -156,9 +156,10 @@ X = [2 3 1 -1; 7 4 5 -4]
 @test std([1 2 3 4 5; 6 7 8 9 10], 2) ≈ sqrt.([2.5 2.5]')
 @test std([1 2 3 4 5; 6 7 8 9 10], 2; corrected=false) ≈ sqrt.([2.0 2.0]')
 
-A = Complex128[exp(i*im) for i in 1:10^4]
-@test varm(A,0.) ≈ sum(map(abs2,A))/(length(A)-1)
-@test varm(A,mean(A)) ≈ var(A)
+let A = Complex128[exp(i*im) for i in 1:10^4]
+    @test varm(A, 0.) ≈ sum(map(abs2, A)) / (length(A) - 1)
+    @test varm(A, mean(A)) ≈ var(A)
+end
 
 # test covariance
 
@@ -344,8 +345,9 @@ end
 @test quantile([1, 2, 3, 4], ()) == ()
 
 # StatsBase issue 164
-y = [0.40003674665581906,0.4085630862624367,0.41662034698690303,0.41662034698690303,0.42189053966652057,0.42189053966652057,0.42553514344518345,0.43985732442991354]
-@test issorted(quantile(y, linspace(0.01, 0.99, 17)))
+let y = [0.40003674665581906, 0.4085630862624367, 0.41662034698690303, 0.41662034698690303, 0.42189053966652057, 0.42189053966652057, 0.42553514344518345, 0.43985732442991354]
+    @test issorted(quantile(y, linspace(0.01, 0.99, 17)))
+end
 
 # variance of complex arrays (#13309)
 let z = rand(Complex128, 10)
@@ -365,27 +367,29 @@ let v = varm([1.0+2.0im], 0; corrected = false)
 end
 
 # cov and cor of complex arrays (issue #21093)
-x = [2.7 - 3.3im, 0.9 + 5.4im, 0.1 + 0.2im, -1.7 - 5.8im, 1.1 + 1.9im]
-y = [-1.7 - 1.6im, -0.2 + 6.5im, 0.8 - 10.0im, 9.1 - 3.4im, 2.7 - 5.5im]
-@test cov(x, y) ≈ 4.8365 - 12.119im
-@test cov(y, x) ≈ 4.8365 + 12.119im
-@test cov(x, reshape(y, :, 1)) ≈ reshape([4.8365 - 12.119im], 1, 1)
-@test cov(reshape(x, :, 1), y) ≈ reshape([4.8365 - 12.119im], 1, 1)
-@test cov(reshape(x, :, 1), reshape(y, :, 1)) ≈ reshape([4.8365 - 12.119im], 1, 1)
-@test cov([x y]) ≈ [21.779 4.8365-12.119im;
-                    4.8365+12.119im 54.548]
-@test cor(x, y) ≈ 0.14032104449218274 - 0.35160772008699703im
-@test cor(y, x) ≈ 0.14032104449218274 + 0.35160772008699703im
-@test cor(x, reshape(y, :, 1)) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
-@test cor(reshape(x, :, 1), y) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
-@test cor(reshape(x, :, 1), reshape(y, :, 1)) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
-@test cor([x y]) ≈ [1.0                                          0.14032104449218274-0.35160772008699703im
-                    0.14032104449218274+0.35160772008699703im  1.0]
+let x = [2.7 - 3.3im, 0.9 + 5.4im, 0.1 + 0.2im, -1.7 - 5.8im, 1.1 + 1.9im],
+    y = [-1.7 - 1.6im, -0.2 + 6.5im, 0.8 - 10.0im, 9.1 - 3.4im, 2.7 - 5.5im]
+    @test cov(x, y) ≈ 4.8365 - 12.119im
+    @test cov(y, x) ≈ 4.8365 + 12.119im
+    @test cov(x, reshape(y, :, 1)) ≈ reshape([4.8365 - 12.119im], 1, 1)
+    @test cov(reshape(x, :, 1), y) ≈ reshape([4.8365 - 12.119im], 1, 1)
+    @test cov(reshape(x, :, 1), reshape(y, :, 1)) ≈ reshape([4.8365 - 12.119im], 1, 1)
+    @test cov([x y]) ≈ [21.779 4.8365-12.119im;
+                        4.8365+12.119im 54.548]
+    @test cor(x, y) ≈ 0.14032104449218274 - 0.35160772008699703im
+    @test cor(y, x) ≈ 0.14032104449218274 + 0.35160772008699703im
+    @test cor(x, reshape(y, :, 1)) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
+    @test cor(reshape(x, :, 1), y) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
+    @test cor(reshape(x, :, 1), reshape(y, :, 1)) ≈ reshape([0.14032104449218274 - 0.35160772008699703im], 1, 1)
+    @test cor([x y]) ≈ [1.0                                          0.14032104449218274-0.35160772008699703im
+                        0.14032104449218274+0.35160772008699703im  1.0]
+end
 
 # Issue #17153 and PR #17154
-let a = rand(10,10)
-    b = deepcopy(a)
+let a = rand(10,10),
+    b = deepcopy(a),
     x = median(a, 1)
+
     @test b == a
     x = median(a, 2)
     @test b == a

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -51,16 +51,17 @@ str = "s\u2200"
 # issue #3597
 @test string(GenericString("Test")[1:1], "X") == "TX"
 
+let b, n
 for T = (UInt8,Int8,UInt16,Int16,UInt32,Int32,UInt64,Int64,UInt128,Int128,BigInt),
-    b = 2:62, _ = 1:10
-    n = T != BigInt ? rand(T) : BigInt(rand(Int128))
-    @test parse(T,base(b,n),b) == n
+        b = 2:62,
+        _ = 1:10
+    n = (T != BigInt) ? rand(T) : BigInt(rand(Int128))
+    @test parse(T, base(b, n), b) == n
+end
 end
 
-# issue #6027
-let
-    # make symbol with invalid char
-    sym = Symbol(Char(0xdcdb))
+# issue #6027 - make symbol with invalid char
+let sym = Symbol(Char(0xdcdb)), res
     @test string(sym) == string(Char(0xdcdb))
     @test String(sym) == string(Char(0xdcdb))
     @test expand(Main, sym) === sym

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -61,7 +61,7 @@ for i = 1:size(cx,1)
         @test st == escape_string(string(ch))
     end
     for j = 1:size(cx,1)
-        str = string(ch, cx[j,2])
+        local str = string(ch, cx[j,2])
         @test str == unescape_string(escape_string(str))
     end
     @test repr(ch) == "'$(isprint(ch) ? ch : st)'"

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -25,66 +25,71 @@ for i1 = 1:length(u8str2)
     end
 end
 
-str="tempus fugit"              #length(str)==12
-ss=SubString(str,1,length(str)) #match source string
-@test length(ss)==length(str)
+let str="tempus fugit"              #length(str)==12
+    ss=SubString(str,1,length(str)) #match source string
+    @test length(ss)==length(str)
 
-ss=SubString(str,1,0)    #empty SubString
-@test length(ss)==0
+    ss=SubString(str,1,0)    #empty SubString
+    @test length(ss)==0
 
-ss=SubString(str,14,20)  #start indexed beyond source string length
-@test length(ss)==0
+    ss=SubString(str,14,20)  #start indexed beyond source string length
+    @test length(ss)==0
 
-ss=SubString(str,10,16)  #end indexed beyond source string length
-@test length(ss)==3
+    ss=SubString(str,10,16)  #end indexed beyond source string length
+    @test length(ss)==3
 
-str2=""
-ss=SubString(str2,1,4)  #empty source string
-@test length(ss)==0
+    str2=""
+    ss=SubString(str2,1,4)  #empty source string
+    @test length(ss)==0
 
-ss=SubString(str2,1,1)  #empty source string, identical start and end index
-@test length(ss)==0
+    ss=SubString(str2,1,1)  #empty source string, identical start and end index
+    @test length(ss)==0
+end
 
-@test SubString("foobar",big(1),big(3)) == "foo"
+@test SubString("foobar", big(1), big(3)) == "foo"
 
-str = "aa\u2200\u2222bb"
-u = SubString(str, 3, 6)
-@test length(u)==2
-b = IOBuffer()
-write(b, u)
-@test String(take!(b)) == "\u2200\u2222"
+let str = "aa\u2200\u2222bb"
+    u = SubString(str, 3, 6)
+    @test length(u) == 2
+    b = IOBuffer()
+    write(b, u)
+    @test String(take!(b)) == "\u2200\u2222"
 
-@test_throws ArgumentError SubString(str, 4, 5)
-@test_throws BoundsError next(u, 0)
-@test_throws BoundsError next(u, 7)
-@test_throws BoundsError getindex(u, 0)
-@test_throws BoundsError getindex(u, 7)
-@test_throws BoundsError getindex(u, 0:1)
-@test_throws BoundsError getindex(u, 7:7)
-@test reverseind(u, 1) == 4
-@test typeof(Base.cconvert(Ptr{Int8},u)) == SubString{String}
-@test Base.cconvert(Ptr{Int8},u) == u
+    @test_throws ArgumentError SubString(str, 4, 5)
+    @test_throws BoundsError next(u, 0)
+    @test_throws BoundsError next(u, 7)
+    @test_throws BoundsError getindex(u, 0)
+    @test_throws BoundsError getindex(u, 7)
+    @test_throws BoundsError getindex(u, 0:1)
+    @test_throws BoundsError getindex(u, 7:7)
+    @test reverseind(u, 1) == 4
+    @test typeof(Base.cconvert(Ptr{Int8}, u)) == SubString{String}
+    @test Base.cconvert(Ptr{Int8}, u) == u
+end
 
-str = "føøbar"
-u = SubString(str, 4, 3)
-@test length(u)==0
-b = IOBuffer()
-write(b, u)
-@test String(take!(b)) == ""
+let str = "føøbar"
+    u = SubString(str, 4, 3)
+    @test length(u) == 0
+    b = IOBuffer()
+    write(b, u)
+    @test String(take!(b)) == ""
+end
 
-str = "føøbar"
-u = SubString(str, 10, 10)
-@test length(u)==0
-b = IOBuffer()
-write(b, u)
-@test String(take!(b)) == ""
+let str = "føøbar"
+    u = SubString(str, 10, 10)
+    @test length(u) == 0
+    b = IOBuffer()
+    write(b, u)
+    @test String(take!(b)) == ""
+end
 
 # search and SubString (issue #5679)
-str = "Hello, world!"
-u = SubString(str, 1, 5)
-@test rsearch(u, "World") == 0:-1
-@test rsearch(u, 'z') == 0
-@test rsearch(u, "ll") == 3:4
+let str = "Hello, world!"
+    u = SubString(str, 1, 5)
+    @test rsearch(u, "World") == 0:-1
+    @test rsearch(u, 'z') == 0
+    @test rsearch(u, "ll") == 3:4
+end
 
 # sizeof
 @test sizeof(SubString("abc\u2222def",4,4)) == 3
@@ -105,7 +110,7 @@ u = SubString(str, 1, 5)
 @test ismatch(Regex(""), SubString("",1,0))
 
 # isvalid(), chr2ind() and ind2chr() for SubString{DirectIndexString}
-let s="lorem ipsum",
+let ss, s="lorem ipsum",
     sdict=Dict(SubString(s,1,11)=>s,
                SubString(s,1,6)=>"lorem ",
                SubString(s,1,0)=>"",
@@ -135,17 +140,18 @@ end #let
 
 #for isvalid(SubString{String})
 let s = "Σx + βz - 2"
-  for i in -1:length(s)+2
-      ss=SubString(s,1,i)
-      @test isvalid(ss,i)==isvalid(s,i)
-  end
+    for i in -1:(length(s) + 2)
+        local ss = SubString(s, 1, i)
+        @test isvalid(ss, i) == isvalid(s, i)
+    end
 end
 
-ss=SubString("hello",1,5)
-@test_throws BoundsError ind2chr(ss, -1)
-@test_throws BoundsError chr2ind(ss, -1)
-@test_throws BoundsError chr2ind(ss, 10)
-@test_throws BoundsError ind2chr(ss, 10)
+let ss=SubString("hello",1,5)
+    @test_throws BoundsError ind2chr(ss, -1)
+    @test_throws BoundsError chr2ind(ss, -1)
+    @test_throws BoundsError chr2ind(ss, 10)
+    @test_throws BoundsError ind2chr(ss, 10)
+end
 
 # length(SubString{String}) performance specialization
 let s = "|η(α)-ϕ(κ)| < ε"
@@ -157,10 +163,11 @@ end
 
 ## Reverse strings ##
 
-rs = RevString("foobar")
-@test length(rs) == 6
-@test sizeof(rs) == 6
-@test isascii(rs)
+let rs = RevString("foobar")
+    @test length(rs) == 6
+    @test sizeof(rs) == 6
+    @test isascii(rs)
+end
 
 # issue #4586
 @test rsplit(RevString("ailuj"),'l') == ["ju","ia"]
@@ -194,22 +201,23 @@ end
 ## Cstring tests ##
 
 # issue #13974: comparison against pointers
+let
+    str = String("foobar")
+    ptr = pointer(str)
+    cstring = Cstring(ptr)
+    @test ptr == cstring
+    @test cstring == ptr
 
-str = String("foobar")
-ptr = pointer(str)
-cstring = Cstring(ptr)
-@test ptr == cstring
-@test cstring == ptr
+    # convenient NULL string creation from Ptr{Void}
+    nullstr = Cstring(C_NULL)
 
-# convenient NULL string creation from Ptr{Void}
-nullstr = Cstring(C_NULL)
+    # Comparisons against NULL strings
+    @test ptr != nullstr
+    @test nullstr != ptr
 
-# Comparisons against NULL strings
-@test ptr != nullstr
-@test nullstr != ptr
-
-# Short-hand comparison against C_NULL
-@test nullstr == C_NULL
-@test C_NULL == nullstr
-@test cstring != C_NULL
-@test C_NULL != cstring
+    # Short-hand comparison against C_NULL
+    @test nullstr == C_NULL
+    @test C_NULL == nullstr
+    @test cstring != C_NULL
+    @test C_NULL != cstring
+end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -19,9 +19,13 @@
 @test strip("foobarfoo", ['f','o']) == "bar"
 @test strip("foobarfoo", ('f','o')) == "bar"
 
-for s in ("", " ", " abc", "abc ", "  abc  "), f in (lstrip, rstrip, strip)
+let s, f
+for s in ("", " ", " abc", "abc ", "  abc  "),
+    f in (lstrip, rstrip, strip)
+
     fs = f(s)
     for T = (String, GenericString)
+        local t, b
         t = convert(T,s)
         ft = f(t)
         @test s == t
@@ -34,6 +38,7 @@ for s in ("", " ", " abc", "abc ", "  abc  "), f in (lstrip, rstrip, strip)
         @test fs == fb
         @test typeof(fb) == SubString{T}
     end
+end
 end
 
 # split

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -405,9 +405,10 @@ sA = view(A, 1:2:3, 3, 1:2:8)
 @test sA[:] == A[sA.indexes...][:]
 test_bounds(sA)
 
-a = [5:8;]
-@test parent(a) == a
-@test parentindexes(a) == (1:4,)
+let a = [5:8;]
+    @test parent(a) == a
+    @test parentindexes(a) == (1:4,)
+end
 
 # issue #6218 - logical indexing
 A = rand(2, 2, 3)
@@ -450,7 +451,7 @@ let a = [1,2,3],
     @test b == view(a, UInt(1):UInt(2)) == view(view(a, :), UInt(1):UInt(2)) == [1,2]
 end
 
-let A = reshape(1:4, 2, 2)
+let A = reshape(1:4, 2, 2),
     B = view(A, :, :)
     @test parent(B) === A
     @test parent(view(B, 0x1, :)) === parent(view(B, 0x1, :)) === A

--- a/test/topology.jl
+++ b/test/topology.jl
@@ -119,14 +119,16 @@ end
 
 # Initially only master-slave connections ought to be setup
 expected_num_conns = 8
-num_conns = sum(asyncmap(p->remotecall_fetch(count_connected_workers,p), workers()))
-@test num_conns == expected_num_conns
+let num_conns = sum(asyncmap(p->remotecall_fetch(count_connected_workers,p), workers()))
+    @test num_conns == expected_num_conns
+end
 
 for (i, (from,to)) in enumerate(combinations)
     remotecall_wait(topid->remotecall_fetch(myid, topid), from, to)
-    expected_num_conns += 2    # one connection endpoint on both from and to
-    num_conns = sum(asyncmap(p->remotecall_fetch(count_connected_workers,p), workers()))
-    @test num_conns == expected_num_conns
+    global expected_num_conns += 2    # one connection endpoint on both from and to
+    let num_conns = sum(asyncmap(p->remotecall_fetch(count_connected_workers,p), workers()))
+        @test num_conns == expected_num_conns
+    end
 end
 
 # With lazy=false, all connections ought to be setup during `addprocs`

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -36,14 +36,13 @@ struct Bunch{N,T}
 end
 
 unpeel(x) = x.elts[1].value
-
 @test unpeel(Bunch{2,Float64}((Base.VecElement(5.0),
                                Base.VecElement(4.0)))) === 5.0
 
-rewrap(x) = VecElement(x.elts[1].value+0)
-b = Bunch((VecElement(1.0), VecElement(2.0)))
-
-@test rewrap(b)===VecElement(1.0)
+rewrap(x) = VecElement(x.elts[1].value + 0)
+let b = Bunch((VecElement(1.0), VecElement(2.0)))
+    @test rewrap(b) === VecElement(1.0)
+end
 
 struct Herd{N,T}
     elts::NTuple{N,Base.VecElement{T}}
@@ -66,10 +65,11 @@ struct Gr{N, T}
     w::T
 end
 
-a = Vector{Gr{2,Float64}}(2)
-a[2] = Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
-a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
-@test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
+let a = Vector{Gr{2,Float64}}(2)
+    a[2] = Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
+    a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
+    @test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
+end
 
 @test isa(VecElement((1,2)), VecElement{Tuple{Int,Int}})
 


### PR DESCRIPTION
This is not intended to change the functionality being tested, just reduce the number of globals left around afterwards. Thus, it's not NFC, but it should be reasonably close. Since this resulted in a lot of indentation changes, the `?w=1` diff is a bit smaller, although still pretty large. Since this does need to hit quite a few files, I expect I'll eventually need to try to merge this fairly quickly.

Ref #19324, as this is rebased from that PR based on Stefan's suggestion of https://github.com/JuliaLang/julia/pull/19324#issuecomment-260477852