### PR TITLE
circle-ci: enable ipv6 socket test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -53,7 +53,8 @@ jobs:
           /tmp/julia/bin/julia --precompiled=no -e 'true' &&
           /tmp/julia/bin/julia-debug --precompiled=no -e 'true' &&
           pushd /tmp/julia/share/julia/test &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30 &&
+          sudo sysctl -w net.ipv6.conf.lo.disable_ipv6=0 &&
+          /tmp/julia/bin/julia --check-bounds=yes runtests.jl | bar -i 30 &&
           /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg &&
           popd &&
           mkdir /tmp/embedding-test &&


### PR DESCRIPTION
[bsd skip][av skip][travis skip]