### PR TITLE
REPL: add an Option type to handle REPL options

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -551,7 +551,7 @@ end
 # on the right
 function edit_backspace(s::PromptState, align::Bool=false, adjust=align)
     push_undo(s)
-    if edit_backspace(buffer(s), align)
+    if edit_backspace(buffer(s), align, adjust)
         refresh_line(s)
     else
         pop_undo(s)

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -241,15 +241,20 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
     dopushdisplay && popdisplay(d)
 end
 
-## Custom Options
+## User Options
 
 mutable struct Options
+    hascolor::Bool
+    extra_keymap::Union{Dict,Vector{<:Dict}}
     backspace_align::Bool
     backspace_adjust::Bool
 end
 
-Options(; backspace_align=true, backspace_adjust=backspace_align) =
-    Options(backspace_align, backspace_adjust)
+Options(;
+        hascolor = true,
+        extra_keymap = AnyDict[],
+        backspace_align = true, backspace_adjust = backspace_align) =
+            Options(hascolor, extra_keymap, backspace_align, backspace_adjust)
 
 ## LineEditREPL ##
 
@@ -714,8 +719,9 @@ enable_promptpaste(v::Bool) = JL_PROMPT_PASTE[] = v
 
 function setup_interface(
     repl::LineEditREPL;
-    hascolor::Bool = repl.hascolor,
-    extra_repl_keymap::Union{Dict,Vector{<:Dict}} = Dict{Any,Any}[]
+    # those keyword arguments may be deprecated eventually in favor of the Options mechanism
+    hascolor::Bool = repl.options.hascolor,
+    extra_repl_keymap::Union{Dict,Vector{<:Dict}} = repl.options.extra_keymap
 )
     ###
     #

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -330,7 +330,7 @@ let buf = IOBuffer()
     @test position(buf) == 0
     LineEdit.edit_move_right(buf)
     @test nb_available(buf) == 0
-    LineEdit.edit_backspace(buf)
+    LineEdit.edit_backspace(buf, false, false)
     @test content(buf) == "a"
 end
 
@@ -699,9 +699,9 @@ end
     @test edit!(edit_undo!) == "one two three"
 
     LineEdit.move_line_end(s)
-    LineEdit.edit_backspace(s)
-    LineEdit.edit_backspace(s)
-    @test edit!(LineEdit.edit_backspace) == "one two th"
+    LineEdit.edit_backspace(s, false, false)
+    LineEdit.edit_backspace(s, false, false)
+    @test edit!(s->LineEdit.edit_backspace(s, false, false)) == "one two th"
     @test edit!(edit_undo!) == "one two thr"
     @test edit!(edit_undo!) == "one two thre"
     @test edit!(edit_undo!) == "one two three"


### PR DESCRIPTION
It was previously not practical to disable the "align" feature 
of backspace (#22939): overwriting the '\b' binding with:
`'\b' => (s,o...) -> Base.LineEdit.edit_backspace(s, false)`
worked to a certain extent, but for example it was disabling
the feature that '\b' must get you out of shell/help mode.

A new experimental Option type is introduced here, which is
meant to conveniently allow users to pass options controlling
the REPL behavior. For example:
```
atreplinit() do repl
    repl.options = Base.REPL.Options(backspace_align = false)
end
```

Also the `Options` alternative is offered to setup the `extra_repl_keymap` (and `hascolor`), instead of using the less direct `setup_interface` (but no more complicated though). Eventually, probably only one way should be supported. We could even have the following simplified API for simple but common needs: 
```
atreplinit(backspace_align=true, extra_keymap=Dict(...))
```
I didn't document this yet, until this is approved or becomes less experimental.

cc. @vtjnash who had asked me how to disable `backspace_align`.