### PR TITLE
Deprecate payload keyword accepting `Nullable{AbstractCredentials}`

### DIFF
--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -265,7 +265,8 @@ function fetch(repo::GitRepo; remote::AbstractString="origin",
         GitRemoteAnon(repo, remoteurl)
     end
     try
-        fo = FetchOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
+        p = CredentialPayload(payload)
+        fo = FetchOptions(callbacks=RemoteCallbacks(credentials_cb(), p))
         fetch(rmt, refspecs, msg="from $(url(rmt))", options = fo)
     finally
         close(rmt)
@@ -299,7 +300,8 @@ function push(repo::GitRepo; remote::AbstractString="origin",
         GitRemoteAnon(repo, remoteurl)
     end
     try
-        push_opts=PushOptions(callbacks=RemoteCallbacks(credentials_cb(), payload))
+        p = CredentialPayload(payload)
+        push_opts = PushOptions(callbacks=RemoteCallbacks(credentials_cb(), p))
         push(rmt, refspecs, force=force, options=push_opts)
     finally
         close(rmt)
@@ -504,11 +506,12 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
                payload::Nullable{<:AbstractCredentials}=Nullable{AbstractCredentials}())
     # setup clone options
     lbranch = Base.cconvert(Cstring, branch)
-    fetch_opts=FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), payload))
+    p = CredentialPayload(payload)
+    fetch_opts = FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), p))
     clone_opts = CloneOptions(
                 bare = Cint(isbare),
                 checkout_branch = isempty(lbranch) ? Cstring(C_NULL) : Base.unsafe_convert(Cstring, lbranch),
-                fetch_opts=fetch_opts,
+                fetch_opts = fetch_opts,
                 remote_cb = remote_cb
             )
     return clone(repo_url, repo_path, clone_opts)

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -259,7 +259,7 @@ function fetch(repo::GitRepo; remote::AbstractString="origin",
                remoteurl::AbstractString="",
                refspecs::Vector{<:AbstractString}=AbstractString[],
                payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}=CredentialPayload())
-    p = deprecate_nullable_creds(:fetch, "repo", payload)
+    p = reset!(deprecate_nullable_creds(:fetch, "repo", payload))
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
     else
@@ -294,7 +294,7 @@ function push(repo::GitRepo; remote::AbstractString="origin",
               refspecs::Vector{<:AbstractString}=AbstractString[],
               force::Bool=false,
               payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}=CredentialPayload())
-    p = deprecate_nullable_creds(:push, "repo", payload)
+    p = reset!(deprecate_nullable_creds(:push, "repo", payload))
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
     else
@@ -505,7 +505,7 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
                payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}=CredentialPayload())
     # setup clone options
     lbranch = Base.cconvert(Cstring, branch)
-    p = deprecate_nullable_creds(:clone, "repo_url, repo_path", payload)
+    p = reset!(deprecate_nullable_creds(:clone, "repo_url, repo_path", payload))
     fetch_opts = FetchOptions(callbacks = RemoteCallbacks(credentials_cb(), p))
     clone_opts = CloneOptions(
                 bare = Cint(isbare),

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -218,10 +218,6 @@ function RemoteCallbacks(credentials_cb::Ptr{Void}, payload::Payload)
     RemoteCallbacks(credentials_cb, Ref(payload))
 end
 
-function RemoteCallbacks(credentials_cb::Ptr{Void}, credentials)
-    RemoteCallbacks(credentials_cb, CredentialPayload(credentials))
-end
-
 """
     LibGit2.ProxyOptions
 

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1135,8 +1135,11 @@ Retains state between multiple calls to the credential callback. A single
 instances will be used when the URL has changed.
 """
 mutable struct CredentialPayload <: Payload
-    credential::Nullable{AbstractCredentials}
+    explicit::Nullable{AbstractCredentials}
     cache::Nullable{CachedCredentials}
+
+    # Ephemeral state fields
+    credential::Nullable{AbstractCredentials}
     first_pass::Bool
     use_ssh_agent::Char
     scheme::String
@@ -1145,7 +1148,8 @@ mutable struct CredentialPayload <: Payload
     path::String
 
     function CredentialPayload(credential::Nullable{<:AbstractCredentials}, cache::Nullable{CachedCredentials})
-        new(credential, cache, true, 'Y', "", "", "", "")
+        payload = new(credential, cache)
+        return reset!(payload)
     end
 end
 
@@ -1159,4 +1163,22 @@ end
 
 function CredentialPayload()
     CredentialPayload(Nullable{AbstractCredentials}(), Nullable{CachedCredentials}())
+end
+
+"""
+    reset!(payload) -> CredentialPayload
+
+Reset the `payload` state back to the initial values so that it can be used again within
+the credential callback.
+"""
+function reset!(p::CredentialPayload)
+    p.credential = Nullable{AbstractCredentials}()
+    p.first_pass = true
+    p.use_ssh_agent = 'Y'
+    p.scheme = ""
+    p.username = ""
+    p.host = ""
+    p.path = ""
+
+    return p
 end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1149,14 +1149,6 @@ mutable struct CredentialPayload <: Payload
     end
 end
 
-function CredentialPayload(credential::Nullable{<:AbstractCredentials})
-    CredentialPayload(credential, Nullable{CachedCredentials}())
-end
-
-function CredentialPayload(cache::Nullable{CachedCredentials})
-    CredentialPayload(Nullable{AbstractCredentials}(), cache)
-end
-
 function CredentialPayload(credential::AbstractCredentials)
     CredentialPayload(Nullable(credential), Nullable{CachedCredentials}())
 end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1157,6 +1157,14 @@ function CredentialPayload(cache::Nullable{CachedCredentials})
     CredentialPayload(Nullable{AbstractCredentials}(), cache)
 end
 
+function CredentialPayload(credential::AbstractCredentials)
+    CredentialPayload(Nullable(credential), Nullable{CachedCredentials}())
+end
+
+function CredentialPayload(cache::CachedCredentials)
+    CredentialPayload(Nullable{AbstractCredentials}(), Nullable(cache))
+end
+
 function CredentialPayload()
     CredentialPayload(Nullable{AbstractCredentials}(), Nullable{CachedCredentials}())
 end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -425,7 +425,7 @@ function update(branch::AbstractString, upkgs::Set{String})
                         prev_sha = string(LibGit2.head_oid(repo))
                         success = true
                         try
-                            LibGit2.fetch(repo, payload = Nullable(creds))
+                            LibGit2.fetch(repo, payload=LibGit2.CredentialPayload(creds))
                             LibGit2.merge!(repo, fastforward=true)
                         catch err
                             cex = CapturedException(err, catch_backtrace())

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -23,7 +23,8 @@ mktempdir() do dir
                 repo_path = joinpath(dir, "Example2")
                 # credentials are required because github tries to authenticate on unknown repo
                 cred = LibGit2.UserPasswordCredentials("JeffBezanson", "hunter2") # make sure Jeff is using a good password :)
-                LibGit2.clone(repo_url*randstring(10), repo_path, payload=Nullable(cred))
+                payload = LibGit2.CredentialPayload(cred)
+                LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)
@@ -36,7 +37,8 @@ mktempdir() do dir
                 repo_path = joinpath(dir, "Example3")
                 # credentials are required because github tries to authenticate on unknown repo
                 cred = LibGit2.UserPasswordCredentials("","") # empty credentials cause authentication error
-                LibGit2.clone(repo_url*randstring(10), repo_path, payload=Nullable(cred))
+                payload = LibGit2.CredentialPayload(cred)
+                LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1946,7 +1946,7 @@ mktempdir() do dir
             valid_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.SSHCredentials($username, $passphrase, $valid_p_key, $(valid_p_key * ".pub"))
-                payload = CredentialPayload(Nullable(valid_cred))
+                payload = CredentialPayload(valid_cred)
                 credential_loop(valid_cred, $url, $username, payload)
             end
 
@@ -1954,7 +1954,7 @@ mktempdir() do dir
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.SSHCredentials($username, $passphrase, $valid_p_key, $(valid_p_key * ".pub"))
                 invalid_cred = LibGit2.SSHCredentials($username, "", $invalid_key, $(invalid_key * ".pub"))
-                payload = CredentialPayload(Nullable(invalid_cred))
+                payload = CredentialPayload(invalid_cred)
                 credential_loop(valid_cred, $url, $username, payload, use_ssh_agent=false)
             end
 
@@ -1981,7 +1981,7 @@ mktempdir() do dir
             valid_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
-                payload = CredentialPayload(Nullable(valid_cred))
+                payload = CredentialPayload(valid_cred)
                 credential_loop(valid_cred, $url, "", payload)
             end
 
@@ -1989,7 +1989,7 @@ mktempdir() do dir
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
                 invalid_cred = LibGit2.UserPasswordCredentials($invalid_username, $invalid_password)
-                payload = CredentialPayload(Nullable(invalid_cred))
+                payload = CredentialPayload(invalid_cred)
                 credential_loop(valid_cred, $url, "", payload)
             end
 
@@ -2018,7 +2018,7 @@ mktempdir() do dir
                 valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
                 cache = CachedCredentials()
                 LibGit2.get_creds!(cache, $cred_id, valid_cred)
-                payload = CredentialPayload(Nullable(cache))
+                payload = CredentialPayload(cache)
                 credential_loop(valid_cred, $url, "", payload)
             end
 
@@ -2026,7 +2026,7 @@ mktempdir() do dir
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
                 cache = CachedCredentials()
-                payload = CredentialPayload(Nullable(cache))
+                payload = CredentialPayload(cache)
                 err, auth_attempts = credential_loop(valid_cred, $url, "", payload)
                 (err, auth_attempts, cache)
             end
@@ -2037,7 +2037,7 @@ mktempdir() do dir
                 invalid_cred = LibGit2.UserPasswordCredentials($invalid_username, $invalid_password, true)
                 cache = CachedCredentials()
                 LibGit2.get_creds!(cache, $cred_id, invalid_cred)
-                payload = CredentialPayload(Nullable(cache))
+                payload = CredentialPayload(cache)
                 err, auth_attempts = credential_loop(valid_cred, $url, "", payload)
                 (err, auth_attempts, cache)
             end
@@ -2077,7 +2077,7 @@ mktempdir() do dir
             expect_ssh_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
-                payload = CredentialPayload(Nullable(valid_cred))
+                payload = CredentialPayload(valid_cred)
                 credential_loop(valid_cred, "ssh://github.com/repo", Nullable(""),
                     Cuint(LibGit2.Consts.CREDTYPE_SSH_KEY), payload)
             end
@@ -2086,7 +2086,7 @@ mktempdir() do dir
             expect_https_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.SSHCredentials("foo", "", "", "")
-                payload = CredentialPayload(Nullable(valid_cred))
+                payload = CredentialPayload(valid_cred)
                 credential_loop(valid_cred, "https://github.com/repo", Nullable(""),
                     Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT), payload)
             end
@@ -2110,7 +2110,7 @@ mktempdir() do dir
             ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
-                payload = CredentialPayload(Nullable(valid_cred))
+                payload = CredentialPayload(valid_cred)
                 credential_loop(valid_cred, "foo://github.com/repo", Nullable(""),
                     $allowed_types, payload)
             end


### PR DESCRIPTION
Deprecates using LibGit2 functions which use the `payload` keyword and accept `Nullable{AbstractCredentials}`. These keywords now expect a `CredentialPayload` instead.

This PR allows us to move the `prompt_if_incorrect` logic out of the `AbstractCredentials` and into `CredentialPayload`. Moving the logic will be done in a future PR to keep reviewing simple.

Part of #20725