### PR TITLE
Don't print type prefix for String array

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1913,7 +1913,8 @@ function array_eltype_show_how(X)
         str = string(e)
     end
     # Types hard-coded here are those which are created by default for a given syntax
-    isleaftype(e), (!isempty(X) && (e===Float64 || e===Int || e===Char) ? "" : str)
+    (isleaftype(e),
+     (!isempty(X) && (e===Float64 || e===Int || e===Char || e===String) ? "" : str))
 end
 
 function show_vector(io::IO, v, opn, cls)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -269,7 +269,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
         cp(testfile, joinpath(dir, ".juliarc.jl"))
 
         withenv((Sys.iswindows() ? "USERPROFILE" : "HOME") => dir) do
-            output = "String[\"foo\", \"-bar\", \"--baz\"]"
+            output = "[\"foo\", \"-bar\", \"--baz\"]"
             @test readchomp(`$exename $testfile foo -bar --baz`) == output
             @test readchomp(`$exename $testfile -- foo -bar --baz`) == output
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar --baz`) ==
@@ -283,7 +283,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
 
             @test !success(`$exename --foo $testfile`)
             @test readchomp(`$exename -L $testfile -e 'exit(0)' -- foo -bar -- baz`) ==
-                "String[\"foo\", \"-bar\", \"--\", \"baz\"]"
+                "[\"foo\", \"-bar\", \"--\", \"baz\"]"
         end
     end
 
@@ -330,7 +330,7 @@ let exename = `$(Base.julia_cmd()) --precompiled=yes --startup-file=no`
     end
 
     # issue #10562
-    @test readchomp(`$exename -e 'println(ARGS);' ''`) == "String[\"\"]"
+    @test readchomp(`$exename -e 'println(ARGS);' ''`) == "[\"\"]"
 
     # issue #12679
     @test readchomp(pipeline(ignorestatus(`$exename --startup-file=no --compile=yes -ioo`),

--- a/test/show.jl
+++ b/test/show.jl
@@ -13,7 +13,7 @@ replstr(x) = sprint((io,x) -> show(IOContext(io, :limit => true, :displaysize =>
 struct T5589
     names::Vector{String}
 end
-@test replstr(T5589(Array{String,1}(100))) == "$(curmod_prefix)T5589(String[#undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef  …  #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef])"
+@test replstr(T5589(Array{String,1}(100))) == "$(curmod_prefix)T5589([#undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef  …  #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef])"
 
 @test replstr(parse("mutable struct X end")) == ":(mutable struct X\n        #= none:1 =#\n    end)"
 @test replstr(parse("struct X end")) == ":(struct X\n        #= none:1 =#\n    end)"


### PR DESCRIPTION
This brings `show(::IO, ::Vector{String})` in line with show for other vectors of types constructed from literals. 

Before:
```julia
julia> string(["foo", "bar"])
"String[\"foo\", \"bar\"]"
```

After:
```julia
julia> string(["foo", "bar"])
"[\"foo\", \"bar\"]"
```