### PR TITLE
Remove unused LibGit2 methods

### DIFF
--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1066,11 +1066,6 @@ import Base.securezero!
 "Abstract credentials payload"
 abstract type AbstractCredentials end
 
-"Checks if credentials were used"
-checkused!(p::AbstractCredentials) = true
-"Resets credentials for another use"
-reset!(p::AbstractCredentials, cnt::Int=3) = nothing
-
 "Credentials that support only `user` and `password` parameters"
 mutable struct UserPasswordCredentials <: AbstractCredentials
     user::String

--- a/doc/src/devdocs/libgit2.md
+++ b/doc/src/devdocs/libgit2.md
@@ -65,7 +65,6 @@ Base.LibGit2.authors
 Base.LibGit2.branch
 Base.LibGit2.branch!
 Base.LibGit2.checkout!
-Base.LibGit2.checkused!
 Base.LibGit2.clone
 Base.LibGit2.commit
 Base.LibGit2.committer


### PR DESCRIPTION
These methods were supposed to be removed in #23575.