### PR TITLE
Remove warning for non occurring static parameter in method definition

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -764,17 +764,7 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata,
                           m->line);
     }
 
-    int ishidden = !!strchr(jl_symbol_name(name), '#');
-    if (!ishidden) {
-        jl_value_t *atemp = argtype;
-        while (jl_is_unionall(atemp)) {
-            jl_unionall_t *ua = (jl_unionall_t*)atemp;
-            jl_tvar_t *tv = ua->var;
-            atemp = ua->body;
-        }
-    }
     jl_check_static_parameter_conflicts(m, f, tvars);
-
     jl_method_table_insert(mt, m, NULL);
     if (jl_newmeth_tracer)
         jl_call_tracer(jl_newmeth_tracer, (jl_value_t*)m);

--- a/src/method.c
+++ b/src/method.c
@@ -770,14 +770,6 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata,
         while (jl_is_unionall(atemp)) {
             jl_unionall_t *ua = (jl_unionall_t*)atemp;
             jl_tvar_t *tv = ua->var;
-            if (!jl_has_typevar(ua->body, tv)) {
-                jl_exceptionf(jl_argumenterror_type,
-                              "static parameter %s does not occur in signature for %s defined at %s:%d",
-                              jl_symbol_name(tv->name),
-                              jl_symbol_name(name),
-                              jl_symbol_name(m->file),
-                              m->line);
-            }
             atemp = ua->body;
         }
     }

--- a/src/method.c
+++ b/src/method.c
@@ -771,10 +771,12 @@ JL_DLLEXPORT void jl_method_def(jl_svec_t *argdata,
             jl_unionall_t *ua = (jl_unionall_t*)atemp;
             jl_tvar_t *tv = ua->var;
             if (!jl_has_typevar(ua->body, tv)) {
-                jl_printf(JL_STDERR, "WARNING: static parameter %s does not occur in signature for %s",
-                          jl_symbol_name(tv->name), jl_symbol_name(name));
-                print_func_loc(JL_STDERR, m);
-                jl_printf(JL_STDERR, ".\n");
+                jl_exceptionf(jl_argumenterror_type,
+                              "static parameter %s does not occur in signature for %s defined at %s:%d",
+                              jl_symbol_name(tv->name),
+                              jl_symbol_name(name),
+                              jl_symbol_name(m->file),
+                              m->line);
             }
             atemp = ua->body;
         }

--- a/test/core.jl
+++ b/test/core.jl
@@ -4611,11 +4611,6 @@ end
 gc_enable(true)
 
 # issue #18710
-bad_tvars() where {T} = 1
-@test isa(@which(bad_tvars()), Method)
-@test bad_tvars() === 1
-bad_tvars2() where {T} = T
-@test_throws UndefVarError(:T) bad_tvars2()
 missing_tvar(::T...) where {T} = T
 @test_throws UndefVarError(:T) missing_tvar()
 @test missing_tvar(1) === Int
@@ -5635,3 +5630,5 @@ function hh6614()
     x, y
 end
 @test hh6614() == (1, 2)
+
+@test !success(`$(Base.julia_cmd()) -e 'f_17319(x) where {T} = x'`)

--- a/test/core.jl
+++ b/test/core.jl
@@ -4611,6 +4611,11 @@ end
 gc_enable(true)
 
 # issue #18710
+bad_tvars() where {T} = 1
+@test isa(@which(bad_tvars()), Method)
+@test bad_tvars() === 1
+bad_tvars2() where {T} = T
+@test_throws UndefVarError(:T) bad_tvars2()
 missing_tvar(::T...) where {T} = T
 @test_throws UndefVarError(:T) missing_tvar()
 @test missing_tvar(1) === Int
@@ -5630,5 +5635,3 @@ function hh6614()
     x, y
 end
 @test hh6614() == (1, 2)
-
-@test !success(`$(Base.julia_cmd()) -e 'f_17319(x) where {T} = x'`)


### PR DESCRIPTION
These type of exceptions doesn't seem to be catchable with the standard `@test_throws` framework so I just checked the exit status.