### PR TITLE
Document macros goto and label

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -503,8 +503,8 @@ end
 
 `@goto name` unconditionally jumps to the statement at the location [`@label name`](@ref).
 
-`@label` and `@goto` cannot create jumps to top-level statements. Attempts cause an
-error. To use `@goto` at the top-level, enclose the `@label` and `@goto` in a block.
+`@label` and `@goto` cannot create jumps to different top-level statements. Attempts cause an
+error. To still use `@goto`, enclose the `@label` and `@goto` in a block.
 """
 macro goto(name::Symbol)
     return esc(Expr(:symbolicgoto, name))

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -488,10 +488,24 @@ macro inbounds(blk)
         Expr(:inbounds, :pop))
 end
 
+"""
+    @label name
+
+Labels a statement with the symbolic label `name`. The label marks the end-point
+of an unconditional jump with [`@goto name`](@ref).
+"""
 macro label(name::Symbol)
     return esc(Expr(:symboliclabel, name))
 end
 
+"""
+    @goto name
+
+`@goto name` unconditionally jumps to the statement at the location [`@label name`](@ref).
+
+`@label` and `@goto` cannot create jumps to top-level statements. Attempts cause an
+error. To use `@goto` at the top-level, enclose the `@label` and `@goto` in a block.
+"""
 macro goto(name::Symbol)
     return esc(Expr(:symbolicgoto, name))
 end

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -152,6 +152,8 @@ Base.@noinline
 Base.@nospecialize
 Base.gensym
 Base.@gensym
+Base.@goto
+Base.@label
 Base.@polly
 Base.parse(::AbstractString, ::Int)
 Base.parse(::AbstractString)


### PR DESCRIPTION
This connects with issues #7706 and #13617 and the stall pull request #15490. This pull request here only adds docstrings which then end up in the syntax section of stdlib/base.md, but does not change the manual.