### PR TITLE
Add colon indexing to numbers.

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -62,9 +62,14 @@ function getindex(x::Number, I::Integer...)
     @boundscheck all([i == 1 for i in I]) || throw(BoundsError())
     x
 end
+function getindex(x::Number, c::Colon)
+    x
+end
 first(x::Number) = x
 last(x::Number) = x
 copy(x::Number) = x  # some code treats numbers as collection-like
+
+
 
 """
     divrem(x, y)


### PR DESCRIPTION
Sometimes it's practical to call numbers via colon indexing
```julia
julia> import Base: getindex;
julia> getindex(x::Number,c::Colon) = x;
julia> 3[:]
3
julia> 3 == 3[:]
true
```
