### PR TITLE
remove visible `include` identifier in `Main`

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -378,7 +378,7 @@ function _start()
     empty!(ARGS)
     append!(ARGS, Core.ARGS)
     opts = JLOptions()
-    @eval Main include(x) = $include(Main, x)
+    @eval Main using Base.MainInclude
     try
         (quiet,repl,startup,color_set,history_file) = process_options(opts)
         banner = opts.banner == 1

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -690,9 +690,9 @@ function workspace()
     m = Core.Main # now grab a handle to the new Main module
     ccall(:jl_add_standard_imports, Void, (Any,), m)
     eval(m, Expr(:toplevel,
-        :(const Base = $b),
-        :(const LastMain = $last),
-        :(include(x) = $include($m, x))))
+                 :(const Base = $b),
+                 :(const LastMain = $last),
+                 :(using Base.MainInclude)))
     empty!(package_locks)
     return m
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -42,6 +42,11 @@ let SOURCE_PATH = ""
 end
 INCLUDE_STATE = 1 # include = Core.include
 
+baremodule MainInclude
+export include
+include(fname::AbstractString) = Main.Base.include(Main, fname)
+end
+
 include("coreio.jl")
 
 eval(x) = Core.eval(Base, x)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -821,3 +821,6 @@ let flags = Cmd(filter(a->!contains(a, "depwarn"), collect(test_exeflags)))
         error("Deprecation test failed, cmd : $cmd")
     end
 end
+
+# PR #23664, make sure names don't get added to the default `Main` workspace
+@test readlines(`$(Base.julia_cmd()) --startup-file=no -e 'foreach(println, names(Main))'`) == ["Base","Core","Main"]


### PR DESCRIPTION
This removes `include` from the list of names in `Main`, purely for usability and aesthetics, e.g. when calling `whos` (or whatever it will be renamed to). This matches the approach we're still using for `eval`.