### PR TITLE
Consolidate SVD tests a bit.

### DIFF
--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -96,26 +96,28 @@ a2img  = randn(n,n)/2
             @test gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' ≈ c
         end
     end
-end
-
-@testset "Number input" begin
-    x, y = randn(2)
-    @test svdfact(x)    == svdfact(      fill(x, 1, 1))
-    @test svdvals(x)    == first(svdvals(fill(x, 1, 1)))
-    @test svd(x)        == first.(svd(   fill(x, 1, 1)))
-    @test svdfact(x, y) == svdfact(      fill(x, 1, 1), fill(y, 1, 1))
-    @test svdvals(x, y) == first(svdvals(fill(x, 1, 1), fill(y, 1, 1)))
-    @test svd(x, y)     == first.(svd(   fill(x, 1, 1), fill(y, 1, 1)))
-end
-
-@testset "isequal, ==, and hash" begin
-    x, y   = rand(), NaN
-    Fx, Fy = svdfact(x), svdfact(y)
-    @test   Fx == Fx
-    @test !(Fy == Fy)
-    @test isequal(Fy, Fy)
-    @test hash(Fx)          == hash(Fx)
-    @test hash(Fx, UInt(1)) == hash(Fx, UInt(1))
-    @test hash(Fy)          == hash(Fy)
-    @test hash(Fy, UInt(1)) == hash(Fy, UInt(1))
+    if eltya <: Base.LinAlg.BlasReal
+        @testset "Number input" begin
+            x, y = randn(eltya, 2)
+            @test svdfact(x)    == svdfact(      fill(x, 1, 1))
+            @test svdvals(x)    == first(svdvals(fill(x, 1, 1)))
+            @test svd(x)        == first.(svd(   fill(x, 1, 1)))
+            @test svdfact(x, y) == svdfact(      fill(x, 1, 1), fill(y, 1, 1))
+            @test svdvals(x, y) ≈ first(svdvals(fill(x, 1, 1), fill(y, 1, 1)))
+            @test svd(x, y)     == first.(svd(   fill(x, 1, 1), fill(y, 1, 1)))
+        end
+    end
+    if eltya != Int
+        @testset "isequal, ==, and hash" begin
+            x, y   = rand(eltya), convert(eltya, NaN)
+            Fx, Fy = svdfact(x), svdfact(y)
+            @test   Fx == Fx
+            @test !(Fy == Fy)
+            @test isequal(Fy, Fy)
+            @test hash(Fx)          == hash(Fx)
+            @test hash(Fx, UInt(1)) == hash(Fx, UInt(1))
+            @test hash(Fy)          == hash(Fy)
+            @test hash(Fy, UInt(1)) == hash(Fy, UInt(1))
+        end
+    end
 end

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -99,12 +99,12 @@ a2img  = randn(n,n)/2
     if eltya <: Base.LinAlg.BlasReal
         @testset "Number input" begin
             x, y = randn(eltya, 2)
-            @test svdfact(x)    == svdfact(      fill(x, 1, 1))
+            @test svdfact(x)    == svdfact(fill(x, 1, 1))
             @test svdvals(x)    == first(svdvals(fill(x, 1, 1)))
-            @test svd(x)        == first.(svd(   fill(x, 1, 1)))
-            @test svdfact(x, y) == svdfact(      fill(x, 1, 1), fill(y, 1, 1))
-            @test svdvals(x, y) ≈ first(svdvals(fill(x, 1, 1), fill(y, 1, 1)))
-            @test svd(x, y)     == first.(svd(   fill(x, 1, 1), fill(y, 1, 1)))
+            @test svd(x)        == first.(svd(fill(x, 1, 1)))
+            @test svdfact(x, y) == svdfact(fill(x, 1, 1), fill(y, 1, 1))
+            @test svdvals(x, y) ≈  first(svdvals(fill(x, 1, 1), fill(y, 1, 1)))
+            @test svd(x, y)     == first.(svd(fill(x, 1, 1), fill(y, 1, 1)))
         end
     end
     if eltya != Int


### PR DESCRIPTION
The number tests fail without that `isapprox` and they need quite
a few more for Complex types. This could probably be made to work
more nicely in the future. We don't have a `NaN` for `Int`, I think.