### PR TITLE
Make rand{,n,exp}(()) return a scalar, not 0-d array

### DIFF
--- a/base/random/generation.jl
+++ b/base/random/generation.jl
@@ -132,6 +132,7 @@ rand(r::AbstractRNG, dims::Integer...) = rand(r, Dims(dims))
 rand(                dims::Integer...) = rand(Dims(dims))
 
 rand(r::AbstractRNG, T::Type, dims::Dims)                   = rand!(r, Array{T}(dims))
+rand(r::AbstractRNG, T::Type, ::Tuple{})                    = rand(r, T)
 rand(                T::Type, dims::Dims)                   = rand(GLOBAL_RNG, T, dims)
 rand(r::AbstractRNG, T::Type, d::Integer, dims::Integer...) = rand(r, T, Dims((d, dims...)))
 rand(                T::Type, d::Integer, dims::Integer...) = rand(T, Dims((d, dims...)))

--- a/base/random/normal.jl
+++ b/base/random/normal.jl
@@ -177,6 +177,8 @@ for randfun in [:randn, :randexp]
 
         # generating arrays
         $randfun(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) where {T} = $randfun!(rng, Array{T}(dims))
+        # 0-d arrays return a scalar instead
+        $randfun(rng::AbstractRNG, ::Type{T}, dims::Tuple{}                  ) where {T} = $randfun(rng, T)
         # Note that this method explicitly does not define $randfun(rng, T),
         # in order to prevent an infinite recursion.
         $randfun(rng::AbstractRNG, ::Type{T}, dim1::Integer, dims::Integer...) where {T} = $randfun!(rng, Array{T}(dim1, dims...))

--- a/base/random/normal.jl
+++ b/base/random/normal.jl
@@ -178,7 +178,7 @@ for randfun in [:randn, :randexp]
         # generating arrays
         $randfun(rng::AbstractRNG, ::Type{T}, dims::Dims                     ) where {T} = $randfun!(rng, Array{T}(dims))
         # 0-d arrays return a scalar instead
-        $randfun(rng::AbstractRNG, ::Type{T}, dims::Tuple{}                  ) where {T} = $randfun(rng, T)
+        $randfun(rng::AbstractRNG, ::Type{T}, ::Tuple{}                      ) where {T} = $randfun(rng, T)
         # Note that this method explicitly does not define $randfun(rng, T),
         # in order to prevent an infinite recursion.
         $randfun(rng::AbstractRNG, ::Type{T}, dim1::Integer, dims::Integer...) where {T} = $randfun!(rng, Array{T}(dim1, dims...))

--- a/test/random.jl
+++ b/test/random.jl
@@ -21,6 +21,11 @@ srand(0); rand(); x = rand(384)
 # Try a seed larger than 2^32
 @test rand(MersenneTwister(5294967296)) == 0.3498809918210497
 
+# Test that the empty tuple makes a scalar, not a 0-d array
+@test rand(MersenneTwister(0), ()) == 0.8236475079774124
+@test randn(MersenneTwister(42), ()) == -0.5560268761463861
+@test randexp(MersenneTwister(42), ()) == 0.8064248352460865
+
 # Test array filling, Issues #7643, #8360
 @test rand(MersenneTwister(0), 1) == [0.8236475079774124]
 A = zeros(2, 2)


### PR DESCRIPTION
Ref: https://github.com/JuliaLang/LinearAlgebra.jl/issues/465

This effectively makes `rand([RNG,] [T,] dims) == rand([RNG,] [T,] dims...)`. (No, I don't mean they actually compare equal in this PR, they just do the same thing.) Probably less confusing.

You can still make a 0-d array by explicitly constructing and calling `rand!` on it, e. g.:
```julia
oldrand(::Tuple{}) = rand!(zeros())
```