### PR TITLE
Make print_matrix O(1) again

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1617,9 +1617,8 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
     postsp = ""
     @assert strwidth(hdots) == strwidth(ddots)
     sepsize = length(sep)
-    inds1, inds2 = indices(X,1), indices(X,2)
-    m, n = length(inds1), length(inds2)
-    rowsA, colsA = collect(inds1), collect(inds2)
+    rowsA, colsA = indices(X,1), indices(X,2)
+    m, n = length(rowsA), length(colsA)
     # To figure out alignments, only need to look at as many rows as could
     # fit down screen. If screen has at least as many rows as A, look at A.
     # If not, then we only need to look at the first and last chunks of A,


### PR DESCRIPTION
Thanks @sbromberger for reporting this on Slack

Previously, printing an array `A` at the REPL would allocate `O(sum(size(A)))` memory. This change was made to support `OffsetArrays` but `OffsetArrays` appears to work with this new version too. 