### PR TITLE
Fix IndexLinear views with a 1-dimensional parent having offset indices

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -285,6 +285,9 @@ end
 # Computing the first index simply steps through the indices, accumulating the
 # sum of index each multiplied by the parent's stride.
 # The running sum is `f`; the cumulative stride product is `s`.
+# If the parent is a vector, then we offset the parent's own indices with parameters of I
+compute_offset1(parent::AbstractVector, stride1::Integer, I::Tuple{AbstractRange}) =
+    (@_inline_meta; first(I[1]) - first(indices1(I[1]))*stride1)
 # If the result is one-dimensional and it's a Colon, then linear
 # indexing uses the indices along the given dimension. Otherwise
 # linear indexing always starts with 1.

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -115,6 +115,17 @@ S = view(A, :, :)
 @test S[1,4] == S[4] == 4
 @test_throws BoundsError S[1,1]
 @test indices(S) === (0:1, 3:4)
+# https://github.com/JuliaArrays/OffsetArrays.jl/issues/27
+g = OffsetArray(collect(-2:3), (-3,))
+gv = view(g, -1:2)
+@test indices(gv, 1) === Base.OneTo(4)
+@test collect(gv) == collect(-1:2)
+gv = view(g, OffsetArray(-1:2, (-2,)))
+@test indices(gv, 1) === -1:2
+@test collect(gv) == collect(-1:2)
+gv = view(g, OffsetArray(-1:2, (-1,)))
+@test indices(gv, 1) === 0:3
+@test collect(gv) == collect(-1:2)
 
 # iteration
 for (a,d) in zip(A, A0)


### PR DESCRIPTION
Fixes https://github.com/JuliaArrays/OffsetArrays.jl/issues/27

For the backport, change `AbstractRange` to `Range`.