### PR TITLE
Add settings to CredentialPayload

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -445,6 +445,10 @@ Deprecated or removed
 
   * `contains(eq, itr, item)` is deprecated in favor of `any` with a predicate ([#23716]).
 
+  * Constructors for `LibGit2.UserPasswordCredentials` and `LibGit2.SSHCredentials` which take a
+    `prompt_if_incorrect` argument are deprecated. Instead, prompting behavior is controlled using
+    the `allow_prompt` keyword in the `LibGit2.CredentialPayload` constructor ([#23690]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1806,6 +1806,10 @@ end
 
 @deprecate contains(eq::Function, itr, x) any(y->eq(y,x), itr)
 
+# PR #23690
+# `SSHCredentials` and `UserPasswordCredentials` constructors using `prompt_if_incorrect`
+# are deprecated in base/libgit2/types.jl.
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -57,15 +57,12 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
     end
 
     # first try ssh-agent if credentials support its usage
-    if p.use_ssh_agent == 'Y' && username_ptr != Cstring(C_NULL)
+    if p.use_ssh_agent && username_ptr != Cstring(C_NULL)
         err = ccall((:git_cred_ssh_key_from_agent, :libgit2), Cint,
                     (Ptr{Ptr{Void}}, Cstring), libgit2credptr, username_ptr)
-        if err == 0
-            p.use_ssh_agent = 'U'  # used ssh-agent only one time
-            return Cint(0)
-        else
-            p.use_ssh_agent = 'E'
-        end
+
+        p.use_ssh_agent = false  # use ssh-agent only one time
+        err == 0 && return Cint(0)
     end
 
     if p.allow_prompt

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -68,7 +68,7 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
         end
     end
 
-    if creds.prompt_if_incorrect
+    if p.allow_prompt
         # if username is not provided or empty, then prompt for it
         username = username_ptr != Cstring(C_NULL) ? unsafe_string(username_ptr) : ""
         if isempty(username)
@@ -166,7 +166,7 @@ function authenticate_userpass(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayl
         creds.pass = ""
     end
 
-    if creds.prompt_if_incorrect
+    if p.allow_prompt
         username = creds.user
         userpass = creds.pass
         if isempty(username) || isempty(userpass)
@@ -266,7 +266,7 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
     # use ssh key or ssh-agent
     if isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_KEY))
         if isnull(p.credential) || !isa(unsafe_get(p.credential), SSHCredentials)
-            creds = SSHCredentials(p.username, "", true)
+            creds = SSHCredentials(p.username)
             if !isnull(p.cache)
                 credid = "ssh://$(p.host)"
                 creds = get_creds!(unsafe_get(p.cache), credid, creds)
@@ -279,7 +279,7 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
 
     if isset(allowed_types, Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT))
         if isnull(p.credential) || !isa(unsafe_get(p.credential), UserPasswordCredentials)
-            creds = UserPasswordCredentials(p.username, "", true)
+            creds = UserPasswordCredentials(p.username)
             if !isnull(p.cache)
                 credid = "$(isempty(p.scheme) ? "ssh" : p.scheme)://$(p.host)"
                 creds = get_creds!(unsafe_get(p.cache), credid, creds)

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1066,8 +1066,8 @@ abstract type AbstractCredentials end
 mutable struct UserPasswordCredentials <: AbstractCredentials
     user::String
     pass::String
-    function UserPasswordCredentials(u::AbstractString="", p::AbstractString="")
-        c = new(u, p)
+    function UserPasswordCredentials(user::AbstractString="", pass::AbstractString="")
+        c = new(user, pass)
         finalizer(c, securezero!)
         return c
     end
@@ -1099,8 +1099,9 @@ mutable struct SSHCredentials <: AbstractCredentials
     pass::String
     prvkey::String
     pubkey::String
-    function SSHCredentials(u::AbstractString="", p::AbstractString="", prvkey::AbstractString="", pubkey::AbstractString="")
-        c = new(u, p, prvkey, pubkey)
+    function SSHCredentials(user::AbstractString="", pass::AbstractString="",
+                            prvkey::AbstractString="", pubkey::AbstractString="")
+        c = new(user, pass, prvkey, pubkey)
         finalizer(c, securezero!)
         return c
     end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1147,15 +1147,15 @@ end
 """
     LibGit2.CredentialPayload
 
-Retains state between multiple calls to the credential callback. A single
-`CredentialPayload` instance will be used when authentication fails for a URL but different
-instances will be used when the URL has changed.
+Retains the state between multiple calls to the credential callback for the same URL.
+A `CredentialPayload` instance is expected to be `reset!` whenever it will be used with a
+different URL.
 """
 mutable struct CredentialPayload <: Payload
     explicit::Nullable{AbstractCredentials}
     cache::Nullable{CachedCredentials}
-    allow_ssh_agent::Bool
-    allow_prompt::Bool
+    allow_ssh_agent::Bool  # Allow the use of the SSH agent to get credentials
+    allow_prompt::Bool     # Allow prompting the user for credentials
 
     # Ephemeral state fields
     credential::Nullable{AbstractCredentials}

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1159,7 +1159,7 @@ mutable struct CredentialPayload <: Payload
     # Ephemeral state fields
     credential::Nullable{AbstractCredentials}
     first_pass::Bool
-    use_ssh_agent::Char
+    use_ssh_agent::Bool
     scheme::String
     username::String
     host::String
@@ -1192,7 +1192,7 @@ the credential callback.
 function reset!(p::CredentialPayload)
     p.credential = Nullable{AbstractCredentials}()
     p.first_pass = true
-    p.use_ssh_agent = p.allow_ssh_agent ? 'Y' : 'N'
+    p.use_ssh_agent = p.allow_ssh_agent
     p.scheme = ""
     p.username = ""
     p.host = ""

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1153,6 +1153,7 @@ instances will be used when the URL has changed.
 mutable struct CredentialPayload <: Payload
     explicit::Nullable{AbstractCredentials}
     cache::Nullable{CachedCredentials}
+    allow_ssh_agent::Bool
     allow_prompt::Bool
 
     # Ephemeral state fields
@@ -1167,8 +1168,9 @@ mutable struct CredentialPayload <: Payload
     function CredentialPayload(
             credential::Nullable{<:AbstractCredentials}=Nullable{AbstractCredentials}(),
             cache::Nullable{CachedCredentials}=Nullable{CachedCredentials}();
+            allow_ssh_agent::Bool=true,
             allow_prompt::Bool=true)
-        payload = new(credential, cache, allow_prompt)
+        payload = new(credential, cache, allow_ssh_agent, allow_prompt)
         return reset!(payload)
     end
 end
@@ -1190,7 +1192,7 @@ the credential callback.
 function reset!(p::CredentialPayload)
     p.credential = Nullable{AbstractCredentials}()
     p.first_pass = true
-    p.use_ssh_agent = 'Y'
+    p.use_ssh_agent = p.allow_ssh_agent ? 'Y' : 'N'
     p.scheme = ""
     p.username = ""
     p.host = ""

--- a/test/libgit2-helpers.jl
+++ b/test/libgit2-helpers.jl
@@ -61,29 +61,14 @@ function credential_loop(
         valid_credential::SSHCredentials,
         url::AbstractString,
         user::Nullable{<:AbstractString}=Nullable{String}(),
-        payload::CredentialPayload=CredentialPayload();
-        use_ssh_agent::Bool=false)
-
-    if !use_ssh_agent
-        payload.use_ssh_agent = 'N'
-    end
-
+        payload::CredentialPayload=CredentialPayload(allow_ssh_agent=false))
     credential_loop(valid_credential, url, user, 0x000046, payload)
 end
 
 function credential_loop(
-        valid_credential::UserPasswordCredentials,
+        valid_credential::AbstractCredentials,
         url::AbstractString,
         user::AbstractString,
-        payload::CredentialPayload=CredentialPayload())
+        payload::CredentialPayload=CredentialPayload(allow_ssh_agent=false))
     credential_loop(valid_credential, url, Nullable(user), payload)
-end
-
-function credential_loop(
-        valid_credential::SSHCredentials,
-        url::AbstractString,
-        user::AbstractString,
-        payload::CredentialPayload=CredentialPayload();
-        use_ssh_agent::Bool=false)
-    credential_loop(valid_credential, url, Nullable(user), payload, use_ssh_agent=use_ssh_agent)
 end

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -9,7 +9,8 @@ mktempdir() do dir
     @testset "Cloning repository" begin
         @testset "with 'https' protocol" begin
             repo_path = joinpath(dir, "Example1")
-            repo = LibGit2.clone(repo_url, repo_path)
+            payload = LibGit2.CredentialPayload(allow_prompt=false)
+            repo = LibGit2.clone(repo_url, repo_path, payload=payload)
             try
                 @test isdir(repo_path)
                 @test isdir(joinpath(repo_path, ".git"))
@@ -23,7 +24,7 @@ mktempdir() do dir
                 repo_path = joinpath(dir, "Example2")
                 # credentials are required because github tries to authenticate on unknown repo
                 cred = LibGit2.UserPasswordCredentials("JeffBezanson", "hunter2") # make sure Jeff is using a good password :)
-                payload = LibGit2.CredentialPayload(cred)
+                payload = LibGit2.CredentialPayload(cred, allow_prompt=false)
                 LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
                 error("unexpected")
             catch ex
@@ -37,7 +38,7 @@ mktempdir() do dir
                 repo_path = joinpath(dir, "Example3")
                 # credentials are required because github tries to authenticate on unknown repo
                 cred = LibGit2.UserPasswordCredentials("","") # empty credentials cause authentication error
-                payload = LibGit2.CredentialPayload(cred)
+                payload = LibGit2.CredentialPayload(cred, allow_prompt=false)
                 LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
                 error("unexpected")
             catch ex

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1949,22 +1949,22 @@ mktempdir() do dir
             invalid_key = joinpath(KEY_DIR, "invalid")
             invalid_cred = LibGit2.SSHCredentials(username, "", invalid_key, invalid_key * ".pub")
 
-            function gen_ex(cred)
+            function gen_ex(cred; allow_prompt=true)
                 quote
                     include($LIBGIT2_HELPER_PATH)
-                    payload = CredentialPayload($cred)
+                    payload = CredentialPayload($cred, allow_prompt=$allow_prompt)
                     credential_loop($valid_cred, $url, $username, payload, use_ssh_agent=false)
                 end
             end
 
             # Explicitly provided credential is correct
-            ex = gen_ex(valid_cred)
+            ex = gen_ex(valid_cred, allow_prompt=true)
             err, auth_attempts = challenge_prompt(ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
             # Explicitly provided credential is incorrect
-            ex = gen_ex(invalid_cred)
+            ex = gen_ex(invalid_cred, allow_prompt=false)
             err, auth_attempts = challenge_prompt(ex, [])
             @test err == eauth_error
             @test auth_attempts == 2
@@ -1976,22 +1976,22 @@ mktempdir() do dir
             valid_cred = LibGit2.UserPasswordCredentials("julia", randstring(16))
             invalid_cred = LibGit2.UserPasswordCredentials("alice", randstring(15))
 
-            function gen_ex(cred)
+            function gen_ex(cred; allow_prompt=true)
                 quote
                     include($LIBGIT2_HELPER_PATH)
-                    payload = CredentialPayload($cred)
+                    payload = CredentialPayload($cred, allow_prompt=$allow_prompt)
                     credential_loop($valid_cred, $url, "", payload)
                 end
             end
 
             # Explicitly provided credential is correct
-            ex = gen_ex(valid_cred)
+            ex = gen_ex(valid_cred, allow_prompt=true)
             err, auth_attempts = challenge_prompt(ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
             # Explicitly provided credential is incorrect
-            ex = gen_ex(invalid_cred)
+            ex = gen_ex(invalid_cred, allow_prompt=false)
             err, auth_attempts = challenge_prompt(ex, [])
             @test err == eauth_error
             @test auth_attempts == 2
@@ -2003,11 +2003,11 @@ mktempdir() do dir
 
             valid_username = "julia"
             valid_password = randstring(16)
-            valid_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password, true)
+            valid_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password)
 
             invalid_username = "alice"
             invalid_password = randstring(15)
-            invalid_cred = LibGit2.UserPasswordCredentials(invalid_username, invalid_password, true)
+            invalid_cred = LibGit2.UserPasswordCredentials(invalid_username, invalid_password)
 
             function gen_ex(; cached_cred=nothing)
                 quote


### PR DESCRIPTION
Allows users to control whether the SSH agent or prompting should be allowed when authenticating.  Removes the last piece of payload state stored in `UserPasswordCredentials` and `SSHCredentials`. With the removal of `prompt_if_incorrect` we can deprecate most of the original constructors.

Part of #20725.