### PR TITLE
Always use SHA-256 in hostname verification test

### DIFF
--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -2383,7 +2383,7 @@ mktempdir() do dir
                 pem = joinpath(root, common_name * ".pem")
 
                 # Generated a certificate which has the CN set correctly but no subjectAltName
-                run(pipeline(`openssl req -new -x509 -newkey rsa:2048 -nodes -keyout $key -out $cert -days 1 -subj "/CN=$common_name"`, stderr=DevNull))
+                run(pipeline(`openssl req -new -x509 -newkey rsa:2048 -sha256 -nodes -keyout $key -out $cert -days 1 -subj "/CN=$common_name"`, stderr=DevNull))
                 run(`openssl x509 -in $cert -out $pem -outform PEM`)
 
                 # Find an available port by listening


### PR DESCRIPTION
On CentOS 6 the version of openssl would default to creating SHA-1 certificates which mbedTLS treats as invalid. By adding the `-sha256` flag when we create the self-signed certificate this is no longer an issue.

Fixes #23682