### PR TITLE
REPL shell mode for Windows

### DIFF
--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -779,13 +779,9 @@ function setup_interface(
             (repl.envcolors ? Base.input_color : repl.input_color) : "",
         repl = repl,
         complete = ShellCompletionProvider(),
-        # Transform "foo bar baz" into `foo bar baz` (shell quoting)
-        # and pass into Base.repl_cmd for processing (handles `ls` and `cd`
-        # special)
+        # Pass entered line into Base.repl_cmd for processing (handles `cd` special)
         on_done = respond(repl, julia_prompt) do line
-            Expr(:call, :(Base.repl_cmd),
-                :(Base.cmd_gen($(Base.shell_parse(line)[1]))),
-                outstream(repl))
+            Expr(:call, :(Base.repl_cmd), line, outstream(repl))
         end)
 
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -147,7 +147,7 @@ The absolute path of the shell with which Julia should execute external commands
 falls back to `/bin/sh` if `$SHELL` is unset.
 
 On Windows, `$JULIA_SHELL` can be set to `cmd`, `powershell`, `busybox` or `""`.
-If set to `""` external commands are executed directly. Defaults to `cmd` if 
+If set to `""` external commands are executed directly. Defaults to `cmd` if
 `$JULIA_SHELL` is not set.
 
 ### `JULIA_EDITOR`

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -146,10 +146,9 @@ The absolute path of the shell with which Julia should execute external commands
 (via `Base.repl_cmd()`). Defaults to the environment variable `$SHELL`, and
 falls back to `/bin/sh` if `$SHELL` is unset.
 
-!!! note
-
-    On Windows, this environment variable is ignored, and external commands are
-    executed directly.
+On Windows, `$JULIA_SHELL` can be set to `cmd`, `powershell`, `busybox` or `""`.
+If set to `""` external commands are executed directly. Defaults to `cmd` if 
+`$JULIA_SHELL` is not set.
 
 ### `JULIA_EDITOR`
 

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -117,6 +117,7 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 shell> echo hello
 hello
 ```
+See [`JULIA_SHELL`](@ref) in the Environment Variables section of the manual.
 
 ### Search modes
 

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -117,7 +117,7 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 shell> echo hello
 hello
 ```
-See [`JULIA_SHELL`](@ref) in the Environment Variables section of the manual.
+See [JULIA_SHELL](@ref) in the Environment Variables section of the manual.
 
 ### Search modes
 


### PR DESCRIPTION
Replaces stale PR #21294
cc: @stevengj

Summary:

- `JULIA_SHELL` can be set to:
-- `cmd`
-- `powershell`
-- `busybox`
-- "" for no shell, execute command directly (current behavior)
- `cmd` is default for Windows users.

- For Windows, the raw line is processed, rather than converting to `Cmd` and then re-assembling into a Windows command line. Windows shell commands are passed as a string anyway, so this gives the user more control over any escaping. I think it works quite well.

- Modified special handling of `cd`. When there are 2 or more arguments, command line is processed as normal, rather than throwing an error. This allows commands such as `cd $dir && $command` to be executed.
