### PR TITLE
Add deprecated `ind2sub(::NTuple{N,Integer}, ::CartesianIndex{N})`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1804,6 +1804,10 @@ import .Iterators.enumerate
     return p
 end
 
+# ease transition for return type change of e.g. indmax due to PR #22907 when used in the
+# common pattern `ind2sub(size(a), indmax(a))`
+@deprecate(ind2sub(dims::NTuple{N,Integer}, idx::CartesianIndex{N}) where N, Tuple(idx))
+
 @deprecate contains(eq::Function, itr, x) any(y->eq(y,x), itr)
 
 # PR #23690


### PR DESCRIPTION
Makes the return type change of #22907 less breaking by allowing the
common pattern `ind2sub(size(a), indmax(a))` to still work, ref https://github.com/JuliaLang/julia/pull/22907#issuecomment-328432200 in particular.

Directly introducing a new method as deprecated is a bit strange, but IMHO this might still make sense.