### PR TITLE
LibGit2 credential approval/rejection

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1810,6 +1810,11 @@ end
 # `SSHCredentials` and `UserPasswordCredentials` constructors using `prompt_if_incorrect`
 # are deprecated in base/libgit2/types.jl.
 
+# PR #23711
+@eval LibGit2 begin
+    @deprecate get_creds!(cache::CachedCredentials, credid, default) get!(cache, credid, default)
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -45,7 +45,7 @@ function user_abort()
           (Cint, Cstring),
           Cint(Error.Callback), "Aborting, user cancelled credential request.")
 
-    return Cint(Error.EAUTH)
+    return Cint(Error.EUSER)
 end
 
 function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, username_ptr)

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -245,8 +245,11 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
         # modification only is in effect for the first callback since `allowed_types` cannot
         # be mutated.
         if !isnull(p.explicit)
-            p.credential = p.explicit
             cred = unsafe_get(p.explicit)
+
+            # Copy explicit credentials to avoid mutating approved credentials.
+            p.credential = Nullable(deepcopy(cred))
+
             if isa(cred, SSHCredentials)
                 allowed_types &= Cuint(Consts.CREDTYPE_SSH_KEY)
             elseif isa(cred, UserPasswordCredentials)

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -266,7 +266,8 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
             creds = SSHCredentials(p.username)
             if !isnull(p.cache)
                 credid = "ssh://$(p.host)"
-                creds = get_creds!(unsafe_get(p.cache), credid, creds)
+                # Perform a copy as we do not want to mutate approved credentials
+                creds = deepcopy(get(unsafe_get(p.cache), credid, creds))
             end
             p.credential = Nullable(creds)
         end
@@ -279,7 +280,8 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
             creds = UserPasswordCredentials(p.username)
             if !isnull(p.cache)
                 credid = "$(isempty(p.scheme) ? "ssh" : p.scheme)://$(p.host)"
-                creds = get_creds!(unsafe_get(p.cache), credid, creds)
+                # Perform a copy as we do not want to mutate approved credentials
+                creds = deepcopy(get(unsafe_get(p.cache), credid, creds))
             end
             p.credential = Nullable(creds)
         end

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -231,13 +231,14 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
 
     # Parse URL only during the first call to this function. Future calls will use the
     # information cached inside the payload.
-    if isempty(p.host)
-        url = match(URL_REGEX, unsafe_string(url_ptr))
+    if isempty(p.url)
+        p.url = unsafe_string(url_ptr)
+        m = match(URL_REGEX, p.url)
 
-        p.scheme = url[:scheme] === nothing ? "" : url[:scheme]
-        p.username = url[:user] === nothing ? "" : url[:user]
-        p.host = url[:host]
-        p.path = url[:path]
+        p.scheme = m[:scheme] === nothing ? "" : m[:scheme]
+        p.username = m[:user] === nothing ? "" : m[:user]
+        p.host = m[:host]
+        p.path = m[:path]
 
         # When an explicit credential is supplied we will make sure to use the given
         # credential during the first callback by modifying the allowed types. The

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1136,11 +1136,9 @@ struct CachedCredentials <: AbstractCredentials
     CachedCredentials() = new(Dict{String,AbstractCredentials}())
 end
 
-"Obtain the cached credentials for the given host+protocol (credid), or return and store the default if not found"
-get_creds!(collection::CachedCredentials, credid, default) = get!(collection.cred, credid, default)
-
 Base.haskey(cache::CachedCredentials, cred_id) = Base.haskey(cache.cred, cred_id)
 Base.getindex(cache::CachedCredentials, cred_id) = Base.getindex(cache.cred, cred_id)
+Base.get!(cache::CachedCredentials, cred_id, default) = Base.get!(cache.cred, cred_id, default)
 
 function securezero!(p::CachedCredentials)
     foreach(securezero!, values(p.cred))

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1139,7 +1139,8 @@ end
 "Obtain the cached credentials for the given host+protocol (credid), or return and store the default if not found"
 get_creds!(collection::CachedCredentials, credid, default) = get!(collection.cred, credid, default)
 
-get(cache::CachedCredentials, credid, default) = Base.get(cache.cred, credid, default)
+Base.haskey(cache::CachedCredentials, cred_id) = Base.haskey(cache.cred, cred_id)
+Base.getindex(cache::CachedCredentials, cred_id) = Base.getindex(cache.cred, cred_id)
 
 function securezero!(p::CachedCredentials)
     foreach(securezero!, values(p.cred))

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1178,6 +1178,7 @@ mutable struct CredentialPayload <: Payload
     credential::Nullable{AbstractCredentials}
     first_pass::Bool
     use_ssh_agent::Bool
+    url::String
     scheme::String
     username::String
     host::String
@@ -1211,6 +1212,7 @@ function reset!(p::CredentialPayload)
     p.credential = Nullable{AbstractCredentials}()
     p.first_pass = true
     p.use_ssh_agent = p.allow_ssh_agent
+    p.url = ""
     p.scheme = ""
     p.username = ""
     p.host = ""
@@ -1224,8 +1226,7 @@ function approve(p::CredentialPayload)
     cred = unsafe_get(p.credential)
 
     if !isnull(p.cache)
-        url = git_url(scheme=p.scheme, host=p.host, username=p.username, path=p.path)
-        approve(unsafe_get(p.cache), cred, url)
+        approve(unsafe_get(p.cache), cred, p.url)
     end
 end
 
@@ -1234,7 +1235,6 @@ function reject(p::CredentialPayload)
     cred = unsafe_get(p.credential)
 
     if !isnull(p.cache)
-        url = git_url(scheme=p.scheme, host=p.host, username=p.username, path=p.path)
-        reject(unsafe_get(p.cache), cred, url)
+        reject(unsafe_get(p.cache), cred, p.url)
     end
 end

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -156,3 +156,14 @@ function git_url(;
 
     return String(take!(io))
 end
+
+function credential_identifier(scheme::AbstractString, host::AbstractString)
+    string(isempty(scheme) ? "ssh" : scheme, "://", host)
+end
+
+function credential_identifier(url::AbstractString)
+    m = match(URL_REGEX, url)
+    scheme = m[:scheme] === nothing ? "" : m[:scheme]
+    host = m[:host]
+    credential_identifier(scheme, host)
+end

--- a/doc/src/devdocs/libgit2.md
+++ b/doc/src/devdocs/libgit2.md
@@ -91,7 +91,6 @@ Base.LibGit2.fullname
 Base.LibGit2.features
 Base.LibGit2.filename
 Base.LibGit2.filemode
-Base.LibGit2.get_creds!
 Base.LibGit2.gitdir
 Base.LibGit2.@githash_str
 Base.LibGit2.head

--- a/test/libgit2-helpers.jl
+++ b/test/libgit2-helpers.jl
@@ -31,6 +31,7 @@ function credential_loop(
 
         # Check if the callback provided us with valid credentials
         if !isnull(payload.credential) && get(payload.credential) == valid_credential
+            LibGit2.approve(payload)
             break
         end
 
@@ -44,6 +45,11 @@ function credential_loop(
         LibGit2.GitError(LibGit2.Error.None, LibGit2.Error.GIT_OK, "No errors")
     else
         LibGit2.GitError(err)
+    end
+
+    # Reject the credential when an authentication error occurs
+    if git_error.code == LibGit2.Error.EAUTH
+        LibGit2.reject(payload)
     end
 
     return git_error, num_authentications

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1643,7 +1643,7 @@ mktempdir() do dir
             "No errors")
 
         abort_prompt = LibGit2.GitError(
-            LibGit2.Error.Callback, LibGit2.Error.EAUTH,
+            LibGit2.Error.Callback, LibGit2.Error.EUSER,
             "Aborting, user cancelled credential request.")
 
         incompatible_error = LibGit2.GitError(

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -2057,7 +2057,7 @@ mktempdir() do dir
                 quote
                     include($LIBGIT2_HELPER_PATH)
                     cache = CachedCredentials()
-                    $(cached_cred !== nothing && :(LibGit2.get_creds!(cache, $cred_id, $cached_cred)))
+                    $(cached_cred !== nothing && :(LibGit2.approve(cache, $cached_cred, $url)))
                     payload = CredentialPayload(cache)
                     err, auth_attempts = credential_loop($valid_cred, $url, "", payload)
                     (err, auth_attempts, cache)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -562,10 +562,10 @@ let a = [1,2,3]
     @test unsafe_securezero!(Ptr{Void}(pointer(a)), sizeof(a)) == Ptr{Void}(pointer(a))
     @test a == [0,0,0]
 end
-let creds = Base.LibGit2.CachedCredentials()
-    LibGit2.get_creds!(creds, "foo", LibGit2.SSHCredentials()).pass = "bar"
-    securezero!(creds)
-    @test LibGit2.get_creds!(creds, "foo", nothing).pass == "\0\0\0"
+let cache = Base.LibGit2.CachedCredentials()
+    get!(cache, "foo", LibGit2.SSHCredentials("", "bar"))
+    securezero!(cache)
+    @test cache["foo"].pass == "\0\0\0"
 end
 
 # Test that we can VirtualProtect jitted code to writable


### PR DESCRIPTION
Previously the credential callback would mutate the explicitly provided credential or cached credential. With this change we never mutate explicitly provided credentials and only add/replace credentials in the cache when they have successfully been used.

Additionally, this PR lays the ground work for integrating other credential storage systems such as the [git credential helpers](https://git-scm.com/docs/gitcredentials#gitcredentials-helper) and removes the LibGit2 function `get_creds!`.

Part of #20725.