### PR TITLE
preserve `do` syntax in AST

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,9 @@ Language changes
     assignment or `block` of assignments, and the second argument is a block of
     statements ([#21774]).
 
+  * `do` syntax now parses to an expression with head `:do`, instead of as a function
+    call ([#21774]).
+
   * Parsed and lowered forms of type definitions have been synchronized with their
     new keywords ([#23157]). Expression heads are renamed as follows:
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -876,7 +876,7 @@ function show_unquoted_quote_expr(io::IO, value, indent::Int, prec::Int)
             print(io, "end")
         else
             print(io, ":(")
-            show_unquoted(io, value, indent+indent_width, -1)
+            show_unquoted(io, value, indent+2, -1)  # +2 for `:(`
             print(io, ")")
         end
     end
@@ -1080,6 +1080,17 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
 
     elseif head === :function && nargs == 1
         print(io, "function ", args[1], " end")
+
+    elseif head === :do && nargs == 2
+        show_unquoted(io, args[1], indent, -1)
+        print(io, " do ")
+        show_list(io, args[2].args[1].args, ", ", 0)
+        for stmt in args[2].args[2].args
+            print(io, '\n', " "^(indent + indent_width))
+            show_unquoted(io, stmt, indent + indent_width, -1)
+        end
+        print(io, '\n', " "^indent)
+        print(io, "end")
 
     # block with argument
     elseif head in (:for,:while,:function,:if,:elseif,:let) && nargs==2

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -358,7 +358,7 @@ f(x) do a,b
 end
 ```
 
-parses as `(call f (-> (tuple a b) (block body)) x)`.
+parses as `(do (call f x) (-> (tuple a b) (block body)))`.
 
 ### Operators
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1188,7 +1188,7 @@
                          (if (eq? (peek-token s) 'do)
                              (begin
                                (take-token s)
-                               `(call ,ex ,@params ,(parse-do s) ,@args))
+                               `(do (call ,ex ,@params ,@args) ,(parse-do s)))
                              `(call ,ex ,@al))))))
                (if macrocall?
                    (map (lambda (x)  ;; parse `a=b` as `=` instead of `kw` in macrocall

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2229,6 +2229,17 @@
                   (map expand-forms e))))
          (map expand-forms e)))
 
+   'do
+   (lambda (e)
+     (let* ((call (cadr e))
+            (f    (cadr call))
+            (argl (cddr call))
+            (af   (caddr e)))
+       (expand-forms
+        (if (has-parameters? argl)
+            `(call ,f ,(car argl) ,af ,@(cdr argl))
+            `(call ,f ,af ,@argl)))))
+
    'tuple
    (lambda (e)
      (cond ((and (length> e 1) (pair? (cadr e)) (eq? (caadr e) 'parameters))

--- a/test/show.jl
+++ b/test/show.jl
@@ -17,8 +17,8 @@ struct T5589
 end
 @test replstr(T5589(Vector{String}(uninitialized, 100))) == "$(curmod_prefix)T5589([#undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef  …  #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef])"
 
-@test replstr(Meta.parse("mutable struct X end")) == ":(mutable struct X\n        #= none:1 =#\n    end)"
-@test replstr(Meta.parse("struct X end")) == ":(struct X\n        #= none:1 =#\n    end)"
+@test replstr(Meta.parse("mutable struct X end")) == ":(mutable struct X\n      #= none:1 =#\n  end)"
+@test replstr(Meta.parse("struct X end")) == ":(struct X\n      #= none:1 =#\n  end)"
 let s = "ccall(:f, Int, (Ptr{Void},), &x)"
     @test replstr(Meta.parse(s)) == ":($s)"
 end
@@ -282,6 +282,22 @@ d
 elseif e
 # line meta
 f
+end
+"""
+
+@test_repr """f(x, y) do z, w
+# line meta
+a
+# line meta
+b
+end
+"""
+
+@test_repr """f(x, y) do z
+# line meta
+a
+# line meta
+b
 end
 """
 


### PR DESCRIPTION
part of #21774