### PR TITLE
Add `Tuple(::CartesianIndex)` 

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -88,6 +88,10 @@ module IteratorsMD
 
     # indexing
     getindex(index::CartesianIndex, i::Integer) = index.I[i]
+    eltype(index::CartesianIndex) = eltype(index.I)
+
+    # access to index tuple
+    Tuple(index::CartesianIndex) = index.I
 
     # zeros and ones
     zero(::CartesianIndex{N}) where {N} = zero(CartesianIndex{N})

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1554,6 +1554,8 @@ end
     @test min(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((2,2))
     @test max(CartesianIndex((2,3)), CartesianIndex((5,2))) == CartesianIndex((5,3))
 
+    @test Tuple(I1) == (2,3,0)
+
     # CartesianIndex allows construction at a particular dimensionality
     @test length(CartesianIndex{3}()) == 3
     @test length(CartesianIndex{3}(1,2)) == 3


### PR DESCRIPTION
~Make iterating a CartesianIndex equivalent to iterating the tuple it holds, being consistent with its indexing behavior. This is especially useful for destructuring as in e.g. `i, j = indmax(A)`.~

Just add `Tuple(::CartesianIndex)` as per discussion below. Destructuring now would require `i, j = Tuple(indmax(A))`, but it's still possible without explicitly accessing the `I` field.