### PR TITLE
[Release-0.6] Fix missing bounds checks for trailing zero dimensions

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -407,9 +407,10 @@ function checkbounds_indices(::Type{Bool}, IA::Tuple, I::Tuple{Any})
 end
 function checkbounds_linear_indices(::Type{Bool}, IA::Tuple{Vararg{OneTo}}, i)
     @_inline_meta
-    if checkindex(Bool, IA[1], i)
+    ts = trailingsize(IA)
+    if checkindex(Bool, IA[1], i) && ts > 0
         return true
-    elseif checkindex(Bool, OneTo(trailingsize(IA)), i)  # partial linear indexing
+    elseif checkindex(Bool, OneTo(ts), i)  # partial linear indexing
         partial_linear_indexing_warning_lookup(length(IA))
         return true # TODO: Return false after the above function is removed in deprecated.jl
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2104,3 +2104,8 @@ Base.:(==)(a::T11053, b::T11053) = a.a == b.a
 
 #15907
 @test typeof(Array{Int,0}()) == Array{Int,0}
+
+@testset "issue 23629" begin
+    @test_throws BoundsError zeros(2,3,0)[2,3]
+    @test_throws BoundsError checkbounds(zeros(2,3,0), 2, 3)
+end


### PR DESCRIPTION
This fixes issue #23629 for 0.6. It is done independently from the fix for master (in #23628) due to all the deprecation changes.

Cc @ararslan.  This should presumably be re-targeted to your backports PR branch, but I wanted to make sure tests passed independently first.