### PR TITLE
Deprecate DateTime() Date() Time()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -970,6 +970,10 @@ Deprecated or removed
 
   * `Base.@gc_preserve` has been deprecated in favor of `GC.@preserve` ([#25616]).
 
+  * `DateTime()`, `Date()`, and `Time()` have been deprecated, instead use `DateTime(1)`, `Date(1)`
+    and `Time(0)` respectively. In a future release `DateTime()`, `Date()`, and `Time()` will be
+    alternatives to `now()` ([#23724]).
+
 Command-line option changes
 ---------------------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -971,8 +971,7 @@ Deprecated or removed
   * `Base.@gc_preserve` has been deprecated in favor of `GC.@preserve` ([#25616]).
 
   * `DateTime()`, `Date()`, and `Time()` have been deprecated, instead use `DateTime(1)`, `Date(1)`
-    and `Time(0)` respectively. In a future release `DateTime()`, `Date()`, and `Time()` will be
-    alternatives to `now()` ([#23724]).
+    and `Time(0)` respectively ([#23724]).
 
 Command-line option changes
 ---------------------------

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -23,7 +23,7 @@ Dates.Time
 
 ```@docs
 Dates.DateTime(::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
-Dates.DateTime(::Dates.Period...)
+Dates.DateTime(::Dates.Period)
 Dates.DateTime(::Function, ::Any...)
 Dates.DateTime(::Dates.TimeType)
 Dates.DateTime(::AbstractString, ::AbstractString)
@@ -32,13 +32,13 @@ Dates.DateFormat
 Dates.@dateformat_str
 Dates.DateTime(::AbstractString, ::Dates.DateFormat)
 Dates.Date(::Int64, ::Int64, ::Int64)
-Dates.Date(::Dates.Period...)
+Dates.Date(::Dates.Period)
 Dates.Date(::Function, ::Any, ::Any, ::Any)
 Dates.Date(::Dates.TimeType)
 Dates.Date(::AbstractString, ::AbstractString)
 Dates.Date(::AbstractString, ::Dates.DateFormat)
 Dates.Time(::Int64::Int64, ::Int64, ::Int64, ::Int64, ::Int64)
-Dates.Time(::Dates.TimePeriod...)
+Dates.Time(::Dates.TimePeriod)
 Dates.Time(::Function, ::Any...)
 Dates.Time(::Dates.DateTime)
 Dates.now()

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -41,3 +41,7 @@ import Base.range
 @deprecate range(start::DateTime, len::Integer)  range(start, Day(1), len) false
 @deprecate range(start::Date, len::Integer)      range(start, Day(1), len) false
 
+# PR #23724
+@deprecate DateTime() DateTime(1)
+@deprecate Date() Date(1)
+@deprecate Time() Time(0)

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -258,10 +258,10 @@ end
 Construct a `DateTime` type by `Period` type parts. Arguments may be in any order. DateTime
 parts not provided will default to the value of `Dates.default(period)`.
 """
-function DateTime(periods::Period...)
+function DateTime(period::Period, periods::Period...)
     y = Year(1); m = Month(1); d = Day(1)
     h = Hour(0); mi = Minute(0); s = Second(0); ms = Millisecond(0)
-    for p in periods
+    for p in (period, periods...)
         isa(p, Year) && (y = p::Year)
         isa(p, Month) && (m = p::Month)
         isa(p, Day) && (d = p::Day)
@@ -279,9 +279,9 @@ end
 Construct a `Date` type by `Period` type parts. Arguments may be in any order. `Date` parts
 not provided will default to the value of `Dates.default(period)`.
 """
-function Date(periods::Period...)
+function Date(period::Period, periods::Period...)
     y = Year(1); m = Month(1); d = Day(1)
-    for p in periods
+    for p in (period, periods...)
         isa(p, Year) && (y = p::Year)
         isa(p, Month) && (m = p::Month)
         isa(p, Day) && (d = p::Day)
@@ -295,10 +295,10 @@ end
 Construct a `Time` type by `Period` type parts. Arguments may be in any order. `Time` parts
 not provided will default to the value of `Dates.default(period)`.
 """
-function Time(periods::TimePeriod...)
+function Time(period::TimePeriod, periods::TimePeriod...)
     h = Hour(0); mi = Minute(0); s = Second(0)
     ms = Millisecond(0); us = Microsecond(0); ns = Nanosecond(0)
-    for p in periods
+    for p in (period, periods...)
         isa(p, Hour) && (h = p::Hour)
         isa(p, Minute) && (mi = p::Minute)
         isa(p, Second) && (s = p::Second)
@@ -313,13 +313,6 @@ end
 DateTime(y, m=1, d=1, h=0, mi=0, s=0, ms=0) = DateTime(Int64(y), Int64(m), Int64(d), Int64(h), Int64(mi), Int64(s), Int64(ms))
 Date(y, m=1, d=1) = Date(Int64(y), Int64(m), Int64(d))
 Time(h, mi=0, s=0, ms=0, us=0, ns=0) = Time(Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns))
-
-# Empty constructors default to 'now'
-if VERSION >= v"0.8-"
-    DateTime() = now()
-    Date() = today()
-    Time() = Time(now())
-end
 
 # Traits, Equality
 Base.isfinite(::Union{Type{T}, T}) where {T<:TimeType} = true

--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -314,6 +314,13 @@ DateTime(y, m=1, d=1, h=0, mi=0, s=0, ms=0) = DateTime(Int64(y), Int64(m), Int64
 Date(y, m=1, d=1) = Date(Int64(y), Int64(m), Int64(d))
 Time(h, mi=0, s=0, ms=0, us=0, ns=0) = Time(Int64(h), Int64(mi), Int64(s), Int64(ms), Int64(us), Int64(ns))
 
+# Empty constructors default to 'now'
+if VERSION >= v"0.8-"
+    DateTime() = now()
+    Date() = today()
+    Time() = Time(now())
+end
+
 # Traits, Equality
 Base.isfinite(::Union{Type{T}, T}) where {T<:TimeType} = true
 calendar(dt::DateTime) = ISOCalendar

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -111,15 +111,6 @@ end
                      Dates.Microsecond(20), Dates.Nanosecond(25)) == Dates.Time(4, 0, 10, 15, 20, 25)
 end
 
-@testset "empty constructors" begin
-    if VERSION >= v"0.8-"
-        present = now()
-        @test Dates.DateTime(present) <= Dates.DateTime()
-        @test Dates.Date(present) <= Dates.Date()
-        @test Dates.Time(present) <= Dates.Time()
-    end
-end
-
 @testset "various input types for Date/DateTime" begin
     test = Dates.Date(1, 1, 1)
     @test Dates.Date(Int8(1), Int8(1), Int8(1)) == test

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -110,6 +110,16 @@ end
     @test Dates.Time(Dates.Hour(4), Dates.Second(10), Dates.Millisecond(15),
                      Dates.Microsecond(20), Dates.Nanosecond(25)) == Dates.Time(4, 0, 10, 15, 20, 25)
 end
+
+@testset "empty constructors" begin
+    if VERSION >= v"0.8-"
+        present = now()
+        @test Dates.DateTime(present) <= Dates.DateTime()
+        @test Dates.Date(present) <= Dates.Date()
+        @test Dates.Time(present) <= Dates.Time()
+    end
+end
+
 @testset "various input types for Date/DateTime" begin
     test = Dates.Date(1, 1, 1)
     @test Dates.Date(Int8(1), Int8(1), Int8(1)) == test


### PR DESCRIPTION
Will be `now` after julia 0.7.