### PR TITLE
Fix slicedim on BitVectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -205,6 +205,10 @@ This section lists changes that do not have deprecation warnings.
   * The `openspecfun` library is no longer built and shipped with Julia, as it is no longer
     used internally ([#22390]).
 
+  * `slicedim(b::BitVector, 1, x)` now consistently returns the same thing that `b[x]` would,
+    consistent with its documentation. Previously it would return a `BitArray{0}` for scalar
+    `x` ([#20233]).
+
 Library improvements
 --------------------
 

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1252,18 +1252,6 @@ end
 
 ## Data movement ##
 
-# preserve some special behavior
-function slicedim(A::BitVector, d::Integer, i::Integer)
-    d >= 1 || throw(ArgumentError("dimension must be ≥ 1"))
-    if d > 1
-        i == 1 || throw_boundserror(A, (:, ntuple(k->1,d-2)..., i))
-        A[:]
-    else
-        fill!(BitArray{0}(), A[i]) # generic slicedim would return A[i] here
-    end
-end
-
-
 # TODO some of this could be optimized
 
 function flipdim(A::BitArray, d::Integer)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1055,7 +1055,10 @@ timesofar("binary comparison")
         b2 = circshift!(i1, b1, -j)
         i2 = circshift!(b1, -j)
         @test b2 == i2
+
+        @check_bit_operation slicedim(b1, 1, m) Bool
     end
+    @check_bit_operation slicedim(b1, 1, :) BitVector
 end
 
 timesofar("datamove")


### PR DESCRIPTION
ensure `slicedim(b::BitVector, 1, x) == b[x]`. Fixes https://github.com/JuliaLang/julia/issues/20233.