### PR TITLE
replace a use of full in base/deprecated.jl

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1304,7 +1304,7 @@ next(p::Union{Process, ProcessChain}, i::Int) = (getindex(p, i), i + 1)
 end
 
 import .LinAlg: cond
-@deprecate cond(F::LinAlg.LU, p::Integer) cond(full(F), p)
+@deprecate cond(F::LinAlg.LU, p::Integer) cond(convert(AbstractArray, F), p)
 
 # PR #21359
 import .Random: srand


### PR DESCRIPTION
One small step towards deprecation of `full`. Ref. JuliaLang/LinearAlgebra.jl#229, JuliaLang/LinearAlgebra.jl#231, JuliaLang/julia#18850, and linked threads. Best!