### PR TITLE
Separate SSH prompting from ENV logic

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -111,8 +111,9 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
             end
         end
 
-        # For SSH we need a public key location
-        if !isfile(publickey)
+        # For SSH we need a public key location. Avoid asking about the public key as
+        # typically this will just annoy users.
+        if !isfile(publickey) && isfile(privatekey)
             response = Base.prompt("Public key location for '$prompt_url'",
                 default=publickey)
             isnull(response) && return user_abort()

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -76,11 +76,6 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
         end
     end
 
-    # If the private key changed, invalidate the cached public key
-    if privatekey != creds.prvkey
-        creds.pubkey = ""
-    end
-
     publickey = Base.get(ENV, "SSH_PUB_KEY_PATH") do
         default = privatekey * ".pub"
         if isempty(creds.pubkey) && isfile(default)
@@ -110,6 +105,7 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
             isnull(response) && return user_abort()
             privatekey = unsafe_get(response)
 
+            # Only update the public key if the private key changed
             if !haskey(ENV, "SSH_PUB_KEY_PATH") && privatekey != creds.prvkey
                 publickey = privatekey * ".pub"
             end

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -111,8 +111,6 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
             end
         end
 
-        isfile(privatekey) || warn("Private key not found")
-
         # For SSH we need a public key location
         if !haskey(ENV, "SSH_PUB_KEY_PATH") && !isfile(publickey)
             response = Base.prompt("Public key location for '$prompt_url'",

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -99,27 +99,27 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
         prompt_url = git_url(scheme=p.scheme, host=p.host, username=username)
 
         # For SSH we need a private key location
-        if !haskey(ENV,"SSH_KEY_PATH") && !isfile(privatekey)
+        if !isfile(privatekey)
             response = Base.prompt("Private key location for '$prompt_url'",
                 default=privatekey)
             isnull(response) && return user_abort()
             privatekey = unsafe_get(response)
 
             # Only update the public key if the private key changed
-            if !haskey(ENV, "SSH_PUB_KEY_PATH") && privatekey != creds.prvkey
+            if privatekey != creds.prvkey
                 publickey = privatekey * ".pub"
             end
         end
 
         # For SSH we need a public key location
-        if !haskey(ENV, "SSH_PUB_KEY_PATH") && !isfile(publickey)
+        if !isfile(publickey)
             response = Base.prompt("Public key location for '$prompt_url'",
                 default=publickey)
             isnull(response) && return user_abort()
             publickey = unsafe_get(response)
         end
 
-        if !haskey(ENV,"SSH_KEY_PASS") && isempty(passphrase) && is_passphrase_required(privatekey)
+        if isempty(passphrase) && is_passphrase_required(privatekey)
             if Sys.iswindows()
                 response = Base.winprompt(
                     "Your SSH Key requires a password, please enter it now:",

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -124,7 +124,7 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
             if Sys.iswindows()
                 response = Base.winprompt(
                     "Your SSH Key requires a password, please enter it now:",
-                    "Passphrase required", privatekey; prompt_username = false)
+                    "Passphrase required", privatekey; prompt_username=false)
                 isnull(response) && return user_abort()
                 passphrase = unsafe_get(response)[2]
             else
@@ -162,8 +162,9 @@ function authenticate_userpass(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayl
         if isempty(username) || isempty(userpass)
             prompt_url = git_url(scheme=p.scheme, host=p.host)
             if Sys.iswindows()
-                response = Base.winprompt("Please enter your credentials for '$prompt_url'", "Credentials required",
-                    isempty(username) ? p.username : username; prompt_username = true)
+                response = Base.winprompt(
+                    "Please enter your credentials for '$prompt_url'", "Credentials required",
+                    isempty(username) ? p.username : username; prompt_username=true)
                 isnull(response) && return user_abort()
                 username, userpass = unsafe_get(response)
             else

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -65,9 +65,44 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
         err == 0 && return Cint(0)
     end
 
+    username = username_ptr != Cstring(C_NULL) ? unsafe_string(username_ptr) : ""
+
+    privatekey = if haskey(ENV,"SSH_KEY_PATH")
+        ENV["SSH_KEY_PATH"]
+    else
+        keydefpath = creds.prvkey # check if credentials were already used
+        if isempty(keydefpath)
+            defaultkeydefpath = joinpath(homedir(), ".ssh", "id_rsa")
+            if isfile(defaultkeydefpath)
+                keydefpath = defaultkeydefpath
+            end
+        end
+        keydefpath
+    end
+
+    # If the private key changed, invalidate the cached public key
+    if privatekey != creds.prvkey
+        creds.pubkey = ""
+    end
+
+    publickey = if haskey(ENV,"SSH_PUB_KEY_PATH")
+        ENV["SSH_PUB_KEY_PATH"]
+    else
+        keydefpath = creds.pubkey # check if credentials were already used
+        if isempty(keydefpath)
+            keydefpath = privatekey * ".pub"
+        end
+        keydefpath
+    end
+
+    passphrase = if haskey(ENV,"SSH_KEY_PASS")
+        ENV["SSH_KEY_PASS"]
+    else
+        creds.pass
+    end
+
     if p.allow_prompt
         # if username is not provided or empty, then prompt for it
-        username = username_ptr != Cstring(C_NULL) ? unsafe_string(username_ptr) : ""
         if isempty(username)
             prompt_url = git_url(scheme=p.scheme, host=p.host)
             response = Base.prompt("Username for '$prompt_url'", default=creds.user)
@@ -78,68 +113,40 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
         prompt_url = git_url(scheme=p.scheme, host=p.host, username=username)
 
         # For SSH we need a private key location
-        privatekey = if haskey(ENV,"SSH_KEY_PATH")
-            ENV["SSH_KEY_PATH"]
-        else
-            keydefpath = creds.prvkey # check if credentials were already used
-            if isempty(keydefpath)
-                defaultkeydefpath = joinpath(homedir(),".ssh","id_rsa")
-                if isempty(keydefpath) && isfile(defaultkeydefpath)
-                    keydefpath = defaultkeydefpath
-                else
-                    response = Base.prompt("Private key location for '$prompt_url'",
-                        default=keydefpath)
-                    isnull(response) && return user_abort()
-                    keydefpath = unsafe_get(response)
-                end
+        if !haskey(ENV,"SSH_KEY_PATH") && isempty(privatekey)
+            response = Base.prompt("Private key location for '$prompt_url'",
+                default=privatekey)
+            isnull(response) && return user_abort()
+            privatekey = unsafe_get(response)
+
+            if !haskey(ENV, "SSH_PUB_KEY_PATH") && privatekey != creds.prvkey
+                publickey = privatekey * ".pub"
             end
-            keydefpath
         end
 
         isfile(privatekey) || warn("Private key not found")
 
-        # If the private key changed, invalidate the cached public key
-        (privatekey != creds.prvkey) &&
-            (creds.pubkey = "")
-
-        # For SSH we need a public key location, look for environment vars SSH_* as well
-        publickey = if haskey(ENV,"SSH_PUB_KEY_PATH")
-            ENV["SSH_PUB_KEY_PATH"]
-        else
-            keydefpath = creds.pubkey # check if credentials were already used
-            if isempty(keydefpath)
-                if isempty(keydefpath)
-                    keydefpath = privatekey*".pub"
-                end
-                if !isfile(keydefpath)
-                    response = Base.prompt("Public key location for '$prompt_url'",
-                        default=keydefpath)
-                    isnull(response) && return user_abort()
-                    keydefpath = unsafe_get(response)
-                end
-            end
-            keydefpath
+        # For SSH we need a public key location
+        if !haskey(ENV, "SSH_PUB_KEY_PATH") && !isfile(publickey)
+            response = Base.prompt("Public key location for '$prompt_url'",
+                default=publickey)
+            isnull(response) && return user_abort()
+            publickey = unsafe_get(response)
         end
 
-        passphrase = if haskey(ENV,"SSH_KEY_PASS")
-            ENV["SSH_KEY_PASS"]
-        else
-            passdef = creds.pass # check if credentials were already used
-            if isempty(passdef) && is_passphrase_required(privatekey)
-                if Sys.iswindows()
-                    response = Base.winprompt(
-                        "Your SSH Key requires a password, please enter it now:",
-                        "Passphrase required", privatekey; prompt_username = false)
-                    isnull(response) && return user_abort()
-                    passdef = unsafe_get(response)[2]
-                else
-                    response = Base.prompt("Passphrase for $privatekey", password=true)
-                    isnull(response) && return user_abort()
-                    passdef = unsafe_get(response)
-                    isempty(passdef) && return user_abort()  # Ambiguous if EOF or newline
-                end
+        if !haskey(ENV,"SSH_KEY_PASS") && isempty(passphrase) && is_passphrase_required(privatekey)
+            if Sys.iswindows()
+                response = Base.winprompt(
+                    "Your SSH Key requires a password, please enter it now:",
+                    "Passphrase required", privatekey; prompt_username = false)
+                isnull(response) && return user_abort()
+                passphrase = unsafe_get(response)[2]
+            else
+                response = Base.prompt("Passphrase for $privatekey", password=true)
+                isnull(response) && return user_abort()
+                passphrase = unsafe_get(response)
+                isempty(passphrase) && return user_abort()  # Ambiguous if EOF or newline
             end
-            passdef
         end
 
         creds.user = username # save credentials

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1825,7 +1825,6 @@ mktempdir() do dir
                 # User provides an empty private key which triggers a re-prompt
                 challenges = [
                     "Private key location for 'git@github.com':" => "\n",
-                    "Public key location for 'git@github.com':" => "\n",
                     "Private key location for 'git@github.com':" => "\x04",
                 ]
                 err, auth_attempts = challenge_prompt(ssh_ex, challenges)

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1847,16 +1847,32 @@ mktempdir() do dir
             end
             =#
 
+            # Explicitly set the public key ENV variable to a non-existent file.
+            withenv("SSH_KEY_PATH" => valid_key,
+                    "SSH_PUB_KEY_PATH" => valid_key * ".public") do
+                @test !isfile(ENV["SSH_PUB_KEY_PATH"])
+
+                challenges = [
+                    # "Private key location for 'git@github.com' [$valid_key]:" => "\n"
+                    "Public key location for 'git@github.com' [$valid_key.public]:" => "$valid_key.pub\n"
+                ]
+                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                @test err == git_ok
+                @test auth_attempts == 1
+            end
+
             # TODO: Tests are currently broken. Credential callback currently infinite loops
             # and never prompts user to change private keys.
             #=
-            withenv("SSH_KEY_PATH" => valid_key, "SSH_PUB_KEY_PATH" => valid_key * ".public") do
-                @test !isfile(ENV["SSH_PUB_KEY_PATH"])
+            # Explicitly set the public key ENV variable to a public key that doesn't match
+            # the private key.
+            withenv("SSH_KEY_PATH" => valid_key,
+                    "SSH_PUB_KEY_PATH" => invalid_key * ".pub") do
+                @test isfile(ENV["SSH_PUB_KEY_PATH"])
 
-                # User explicitly sets the SSH_PUB_KEY_PATH incorrectly.
                 challenges = [
                     "Private key location for 'git@github.com' [$valid_key]:" => "\n"
-                    "Public key location for 'git@github.com':" => "$valid_key.pub\n"
+                    "Public key location for 'git@github.com' [$invalid_key.pub]:" => "$valid_key.pub\n"
                 ]
                 err, auth_attempts = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1825,7 +1825,7 @@ mktempdir() do dir
                 # User provides an empty private key which triggers a re-prompt
                 challenges = [
                     "Private key location for 'git@github.com':" => "\n",
-                    "Public key location for 'git@github.com' [.pub]:" => "\n",
+                    "Public key location for 'git@github.com':" => "\n",
                     "Private key location for 'git@github.com':" => "\x04",
                 ]
                 err, auth_attempts = challenge_prompt(ssh_ex, challenges)


### PR DESCRIPTION
Separating some of the SSH callback logic so that `allow_prompt` only enables/disables interactive user prompting. Other changes include:

* Avoid asking for a public key if the private key file does not exist
* Avoid setting "~/.ssh/id_rsa" as the default private key if it does not exist (defaults to "" instead)
* Avoid setting "$private_key.pub" as the default public key if it does not exist (defaults to "" instead)
* Avoid invalidating the public key before the credentials should be "saved"
* Remove private key missing warning. Either the user will be re-prompted or an error will be displayed
* Avoid prompting for a public key as much as possible

Part of #20725.
