### PR TITLE
RFC: Change the behavior of `precompile` depending on current mode

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1734,8 +1734,25 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
     jl_code_info_t *src = NULL;
     if (!jl_is_rettype_inferred(li))
         src = jl_type_infer(&li, world, 0);
-    if (li->jlcall_api != 2)
-        jl_compile_linfo(&li, src, world, &jl_default_cgparams);
+    if (li->jlcall_api != 2) {
+        if (jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc) {
+            // If we are saving LLVM or native code, generate the LLVM IR so that it'll
+            // be included in the saved LLVM module.
+            jl_compile_linfo(&li, src, world, &jl_default_cgparams);
+        }
+        else if (!jl_options.outputji) {
+            // If we are only saving ji files (e.g. package pre-compilation for now),
+            // don't bother generating anything since it won't be saved.
+            // Otherwise (this branch), assuming we are at runtime (normal JIT) and
+            // we should generate the native code.
+            jl_ptls_t ptls = jl_get_ptls_states();
+            size_t last_age = ptls->world_age;
+            ptls->world_age = world;
+            jl_generic_fptr_t fptr;
+            jl_compile_method_internal(&fptr, li);
+            ptls->world_age = last_age;
+        }
+    }
     return 1;
 }
 


### PR DESCRIPTION
The expected behavior of `precompile` should be doing as much compilation as what would have been done before actually calling the function. The previous version of the function does not generate native code so it does not completely eliminate latency before the function is actually executed for the first time.
Of course, such compilation is also only necessary if it will be used later. Therefore we can skip some of the work if we know that the result will be discarded.

In summary, with this patch, the behavior of `precompile` will be different depending on which mode julia is running.

1. During sysimg generation (more specifically, when we are saving llvm IR or object code) the behavior will be the same as before since we only need to generate the llvm IR for it to be cached in the sysimg.
2. During package precompilation (or otherwise outputting only ji files) do not generate either llvm IR or native code since they won't be saved.
3. If we are not saving anything and is therefore in normal mode, generate the native code since this is likely what the caller is expecting.

Ref https://discourse.julialang.org/t/profiling-compilation-time/5849/8
In principle this can also slightly reduce package precompilation time (before we can actually save the LLVM IR or native code).
