### PR TITLE
Losen some linalg tests

### DIFF
--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -398,7 +398,7 @@ end
         fullDD = copy!(Matrix{Matrix{T}}(2, 2), DD)
         fullBB = copy!(Matrix{Matrix{T}}(2, 2), BB)
         for f in (*, Ac_mul_B, A_mul_Bc, Ac_mul_Bc, At_mul_B, A_mul_Bt, At_mul_Bt)
-            @test f(D, B)::typeof(D) == f(Matrix(D), Matrix(B))
+            @test f(D, B)::typeof(D) ≈ f(Matrix(D), Matrix(B)) atol=2 * eps()
             @test f(DD, BB)::typeof(DD) == f(fullDD, fullBB)
         end
     end

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -252,7 +252,7 @@ let n = 12 #Size of matrix problem to test
                                 D, Vecs = eig(fA)
                                 @test DT ≈ D
                                 @test abs.(VT'Vecs) ≈ eye(elty, n)
-                                @test eigvecs(A) ≈ eigvecs(fA)
+                                Test.test_approx_eq_modphase(eigvecs(A), eigvecs(fA))
                                 #call to LAPACK.stein here
                                 Test.test_approx_eq_modphase(eigvecs(A,eigvals(A)),eigvecs(A))
                             elseif elty != Int


### PR DESCRIPTION
They produce results with slightly different phase (sign) or imaginary part.

This cause test failure on aarch64 similar to https://github.com/JuliaLang/julia/pull/15478 .
