### PR TITLE
Rename Base.runtests() to Base.test()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -464,6 +464,8 @@ Deprecated or removed
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
 
+  * `Base.runtests` has been renamed to `Base.test` for consistency with `Pkg.test` ([#23755]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1855,6 +1855,13 @@ end
     nothing
 end
 
+# PR #23755
+# we need to use depwarn() directly since the function is not exported
+function runtests(args...)
+    depwarn("Base.runtests is deprecated, use Base.test instead.", :runtests)
+    Base.test(args...)
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -700,12 +700,12 @@ end
 # testing
 
 """
-    runtests([tests=["all"] [, numcores=ceil(Int, Sys.CPU_CORES / 2) ]])
+    test([tests=["all"] [, numcores=ceil(Int, Sys.CPU_CORES / 2) ]])
 
 Run the Julia unit tests listed in `tests`, which can be either a string or an array of
 strings, using `numcores` processors. (not exported)
 """
-function runtests(tests = ["all"], numcores = ceil(Int, Sys.CPU_CORES / 2))
+function test(tests = ["all"], numcores = ceil(Int, Sys.CPU_CORES / 2))
     if isa(tests,AbstractString)
         tests = split(tests)
     end

--- a/doc/src/stdlib/test.md
+++ b/doc/src/stdlib/test.md
@@ -10,10 +10,10 @@ end
 
 Julia is under rapid development and has an extensive test suite to verify functionality across
 multiple platforms. If you build Julia from source, you can run this test suite with `make test`.
-In a binary install, you can run the test suite using `Base.runtests()`.
+In a binary install, you can run the test suite using `Base.test()`.
 
 ```@docs
-Base.runtests
+Base.test
 ```
 
 ## Basic Unit Tests


### PR DESCRIPTION
`test()` is simpler and consistent with `Pkg.test()`.

Fixes #23482.