### PR TITLE
Doctests and consistency for factorizations

### DIFF
--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -88,7 +88,7 @@ lufact(A::Union{AbstractMatrix{T}, AbstractMatrix{Complex{T}}},
 
 # for all other types we must promote to a type which is stable under division
 """
-    lufact(A [,pivot=Val(true)]) -> F::LU
+    lufact(A, pivot=Val(true)) -> F::LU
 
 Compute the LU factorization of `A`.
 


### PR DESCRIPTION
All the other `lufact` and `qrfact` methods don't have the square brackets.