### PR TITLE
Fix support of gc_preserve intrinsics in the allocation optimization pass

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -764,6 +764,8 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                         std::vector<int> args;
                         for (Use &U : CI->arg_operands()) {
                             Value *V = U;
+                            if (isa<Constant>(V))
+                                continue;
                             int Num = Number(S, V);
                             if (Num >= 0)
                                 args.push_back(Num);

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -188,6 +188,13 @@ function two_breakpoint(a::Float64)
     ccall(:jl_breakpoint, Void, (Ref{Float64},), a)
 end
 
+function load_dummy_ref(x::Int)
+    r = Ref{Int}(x)
+    Base.@gc_preserve r begin
+        unsafe_load(Ptr{Int}(pointer_from_objref(r)))
+    end
+end
+
 if opt_level > 0
     breakpoint_f64_ir = get_llvm((a)->ccall(:jl_breakpoint, Void, (Ref{Float64},), a),
                                  Tuple{Float64})
@@ -198,6 +205,12 @@ if opt_level > 0
     two_breakpoint_ir = get_llvm(two_breakpoint, Tuple{Float64})
     @test !contains(two_breakpoint_ir, "jl_gc_pool_alloc")
     @test contains(two_breakpoint_ir, "llvm.lifetime.end")
+
+    @test load_dummy_ref(1234) === 1234
+    load_dummy_ref_ir = get_llvm(load_dummy_ref, Tuple{Int})
+    @test !contains(load_dummy_ref_ir, "jl_gc_pool_alloc")
+    # Hopefully this is reliable enough. LLVM should be able to optimize this to a direct return.
+    @test contains(load_dummy_ref_ir, "ret $Iptr %0")
 end
 
 # Issue 22770


### PR DESCRIPTION
* Be more conservative about identifying LLVM intrinsics.
  Only handle ones that has an associated intrinsic ID.
* Handle gc_preserve intrinsic similar to operand bundle.