### PR TITLE
Add matrix, an operation to convert an array to a matrix (like vec)

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -33,10 +33,44 @@ julia> vec(a)
  6
 ```
 
-See also [`reshape`](@ref).
+See also [`reshape`](@ref), [`mat`](@ref).
 """
 vec(a::AbstractArray) = reshape(a,_length(a))
 vec(a::AbstractVector) = a
+
+
+"""
+    mat(a::AbstractArray) -> Matrix
+
+Reshape the array `a` as a two-dimensional matrix.
+The matrix will have the same size in the first dimension,
+and all other dimensions (if any) will be combined.
+If applied to a vector, this results in a matrix with a single column.
+The resulting array shares the same underlying data as `a`,
+so modifying one will also modify the other.
+
+# Examples
+```jldoctest
+
+julia> a = [1,2,3]
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
+
+julia> mat(a)
+3×1 Array{Int64,2}:
+ 1
+ 2
+ 3
+```
+
+See also [`reshape`](@ref), [`vec`](@ref).
+"""
+mat(a::AbstractArray) = reshape(a,Val(2))
+mat(a::AbstractMatrix) = a
+
+
 
 _sub(::Tuple{}, ::Tuple{}) = ()
 _sub(t::Tuple, ::Tuple{}) = t

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -10,7 +10,7 @@ all(::typeof(isinteger), ::AbstractArray{<:Integer}) = true
 ## Constructors ##
 
 """
-    vec(a::AbstractArray) -> Vector
+    vec(a::AbstractArray) -> AbstractVector
 
 Reshape the array `a` as a one-dimensional column vector. The resulting array
 shares the same underlying data as `a`, so modifying one will also modify the
@@ -40,7 +40,7 @@ vec(a::AbstractVector) = a
 
 
 """
-    mat(a::AbstractArray) -> Matrix
+    mat(a::AbstractArray) -> AbstractMatrix
 
 Reshape the array `a` as a two-dimensional matrix.
 The matrix will have the same size in the first dimension,

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -33,14 +33,14 @@ julia> vec(a)
  6
 ```
 
-See also [`reshape`](@ref), [`mat`](@ref).
+See also [`reshape`](@ref), [`matrix`](@ref).
 """
 vec(a::AbstractArray) = reshape(a,_length(a))
 vec(a::AbstractVector) = a
 
 
 """
-    mat(a::AbstractArray) -> AbstractMatrix
+    matrix(a::AbstractArray) -> AbstractMatrix
 
 Reshape the array `a` as a two-dimensional matrix.
 The matrix will have the same size in the first dimension,
@@ -58,7 +58,7 @@ julia> a = [1,2,3]
  2
  3
 
-julia> mat(a)
+julia> matrix(a)
 3×1 Array{Int64,2}:
  1
  2
@@ -67,8 +67,8 @@ julia> mat(a)
 
 See also [`reshape`](@ref), [`vec`](@ref).
 """
-mat(a::AbstractArray) = reshape(a,Val(2))
-mat(a::AbstractMatrix) = a
+matrix(a::AbstractArray) = reshape(a,Val(2))
+matrix(a::AbstractMatrix) = a
 
 
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -476,6 +476,7 @@ export
     linspace,
     logspace,
     mapslices,
+    mat,
     max,
     maximum!,
     maximum,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -476,7 +476,7 @@ export
     linspace,
     logspace,
     mapslices,
-    mat,
+    matrix,
     max,
     maximum!,
     maximum,

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -166,6 +166,21 @@ end
     end
 end
 
+
+@testset "vec and mat" begin
+    a = [1, 2, 3, 4]
+    @test a == vec(a)
+    @test mat(a) == [1 2 3 4]'
+
+    b = [1 3; 2 4]
+    @test vec(b) == a
+    @test b == mat(b)
+
+    c = [100a + 10b + c for a in 1:2, b in 1:3, c in 1:2]
+    @test mat(c) == [111 121 131 112 122 132; 211 221 231 212 222 232]
+    @test vec(c) == vec(mat(c)) == vec(mat(vec(c)))
+end
+
 @test reshape(1:5, (5,)) === 1:5
 @test reshape(1:5, 5) === 1:5
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -167,18 +167,18 @@ end
 end
 
 
-@testset "vec and mat" begin
+@testset "vec and matrix" begin
     a = [1, 2, 3, 4]
     @test a == vec(a)
-    @test mat(a) == [1 2 3 4]'
+    @test matrix(a) == [1 2 3 4]'
 
     b = [1 3; 2 4]
     @test vec(b) == a
-    @test b == mat(b)
+    @test b == matrix(b)
 
     c = [100a + 10b + c for a in 1:2, b in 1:3, c in 1:2]
-    @test mat(c) == [111 121 131 112 122 132; 211 221 231 212 222 232]
-    @test vec(c) == vec(mat(c)) == vec(mat(vec(c)))
+    @test matrix(c) == [111 121 131 112 122 132; 211 221 231 212 222 232]
+    @test vec(c) == vec(matrix(c)) == vec(matrix(vec(c)))
 end
 
 @test reshape(1:5, (5,)) === 1:5


### PR DESCRIPTION
We have `vec` which is a short-hand for `reshape(x, Val(1))`.
I propose that we should have `mat` as well, as a shorthand for `reshape(x,Val(2))`.

Obviously `vec` is the most common case of reshaping,
but I suggest that `mat` comes in second, and is much more common than the general `reshape`.
In particular for converting a Vector into a single column matrix.
Very common for interfacing with various libraries.

My old trick for that was to double transpose it (`x''`), but since as of 0.6 we take vector transpose seriously, that won't work. (Plus this way is nonallocating).
