### PR TITLE
fix an invariance bug in `limit_type_depth`. part of #23786

### DIFF
--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1218,3 +1218,10 @@ let c(::Type{T}, x) where {T<:Array} = T,
     f() = c(Vector{Any[Int][1]}, [1])
     @test f() === Vector{Int}
 end
+
+# issue #23786
+struct T23786{D<:Tuple{Vararg{Vector{T} where T}}, N}
+end
+let t = Tuple{Type{T23786{D, N} where N where D<:Tuple{Vararg{Array{T, 1} where T, N} where N}}}
+    @test Core.Inference.limit_type_depth(t, 4) >: t
+end


### PR DESCRIPTION
This fixes the specific issue reported, but after this I get a SIGILL in the package's tests. Running just the last testset gives

```
broadcast! matching indices: Error During Test
  Got an exception of type MethodError outside of a @test
  MethodError: Base.Broadcast.promote_containertype(::Type{TypeSortedCollections.TypeSortedCollection}, ::Type{TypeSortedCollections.TypeSortedCollection}) is ambiguous. Candidates:
    promote_containertype(::Type{TypeSortedCollections.TypeSortedCollection}, _) in TypeSortedCollections at /home/jeff/.julia/v0.7/TypeSortedCollections/src/TypeSortedCollections.jl:199
    promote_containertype(_, ::Type{TypeSortedCollections.TypeSortedCollection}) in TypeSortedCollections at /home/jeff/.julia/v0.7/TypeSortedCollections/src/TypeSortedCollections.jl:200
    promote_containertype(::Type{T}, ::Type{T}) where T in Base.Broadcast at broadcast.jl:43
  Possible fix, define
    promote_containertype(::Type{TypeSortedCollections.TypeSortedCollection}, ::Type{TypeSortedCollections.TypeSortedCollection})
```

but with the full suite this turns into a SIGILL.