### PR TITLE
fix LAPACK.ormlq! and postmultiplication with LQPackedQ

### DIFF
--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -2600,13 +2600,13 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
             chkside(side)
             chkstride1(A, C, tau)
             m,n = ndims(C) == 2 ? size(C) : (size(C, 1), 1)
-            mA, nA  = size(A)
+            nA = size(A, 2)
             k   = length(tau)
             if side == 'L' && m != nA
                 throw(DimensionMismatch("for a left-sided multiplication, the first dimension of C, $m, must equal the second dimension of A, $nA"))
             end
-            if side == 'R' && n != mA
-                throw(DimensionMismatch("for a right-sided multiplication, the second dimension of C, $n, must equal the first dimension of A, $mA"))
+            if side == 'R' && n != nA
+                throw(DimensionMismatch("for a right-sided multiplication, the second dimension of C, $n, must equal the second dimension of A, $nA"))
             end
             if side == 'L' && k > m
                 throw(DimensionMismatch("invalid number of reflectors: k = $k should be <= m = $m"))

--- a/base/linalg/lq.jl
+++ b/base/linalg/lq.jl
@@ -92,17 +92,22 @@ full(Q::LQPackedQ; thin::Bool = true) =
 
 size(A::LQ, dim::Integer) = size(A.factors, dim)
 size(A::LQ) = size(A.factors)
-function size(A::LQPackedQ, dim::Integer)
-    if 0 < dim && dim <= 2
-        return size(A.factors, dim)
-    elseif 0 < dim && dim > 2
-        return 1
-    else
+
+# size(Q::LQPackedQ) yields the shape of Q's square form
+function size(Q::LQPackedQ)
+    n = size(Q.factors, 2)
+    return n, n
+end
+function size(Q::LQPackedQ, dim::Integer)
+    if dim < 1
         throw(BoundsError())
+    elseif dim <= 2 # && 1 <= dim
+        return size(Q.factors, 2)
+    else # 2 < dim
+        return 1
     end
 end
 
-size(A::LQPackedQ) = size(A.factors)
 
 ## Multiplication by LQ
 A_mul_B!(A::LQ{T}, B::StridedVecOrMat{T}) where {T<:BlasFloat} =

--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -105,7 +105,12 @@ bimg  = randn(n,2)/2
 end
 
 @testset "correct form of Q from lq(...) (#23729)" begin
-    # matrices with more rows than columns
+    # where the original matrix (say A) is square or has more rows than columns,
+    # then A's factorization's triangular factor (say L) should have the same shape
+    # as A independent of form (thin, square), and A's factorization's orthogonal
+    # factor (say Q) should be a square matrix of order of A's number of columns
+    # independent of form (thin, square), and L and Q should have
+    # multiplication-compatible shapes.
     m, n = 4, 2
     A = randn(m, n)
     for thin in (true, false)
@@ -114,13 +119,22 @@ end
         @test size(Q) == (n, n)
         @test isapprox(A, L*Q)
     end
-    # matrices with more columns than rows
+    # where the original matrix has strictly fewer rows than columns ...
     m, n = 2, 4
     A = randn(m, n)
+    # ... then, for a thin factorization of A, L should be a square matrix
+    # of order of A's number of rows, Q should have the same shape as A,
+    # and L and Q should have multiplication-compatible shapes
     Lthin, Qthin = lq(A, thin = true)
     @test size(Lthin) == (m, m)
     @test size(Qthin) == (m, n)
     @test isapprox(A, Lthin * Qthin)
+    # ... and, for a non-thin factorization of A, L should have the same shape as A,
+    # Q should be a square matrix of order of A's number of columns, and L and Q
+    # should have multiplication-compatible shape. but instead the L returned has
+    # no zero-padding on the right / is L for the thin factorization, so for
+    # L and Q to have multiplication-compatible shapes, L must be zero-padded
+    # to have the shape of A.
     Lsquare, Qsquare = lq(A, thin = false)
     @test size(Lsquare) == (m, m)
     @test size(Qsquare) == (n, n)
@@ -156,4 +170,14 @@ end
     @test implicitQ[n, 1] == explicitQ[n, 1]
     @test implicitQ[1, n] == explicitQ[1, n]
     @test implicitQ[n, n] == explicitQ[n, n]
+end
+
+@testset "size on LQPackedQ (#23780)" begin
+    # size(Q::LQPackedQ) yields the shape of Q's square form
+    for ((mA, nA), nQ) in (
+        ((3, 3), 3), # A 3-by-3 => square Q 3-by-3
+        ((3, 4), 4), # A 3-by-4 => square Q 4-by-4
+        ((4, 3), 3) )# A 4-by-3 => square Q 3-by-3
+        @test size(lqfact(randn(mA, nA))[:Q]) == (nQ, nQ)
+    end
 end


### PR DESCRIPTION
This pull request fixes `LAPACK.ormlq!`'s shape checks, consequently fixing the bug in postmultiplication with `LQPackedQ`s identified in JuliaLang/LinearAlgebra.jl#469.  ~This pull request also makes `LQPackedQ`'s context-dependent postmultiplication behavior (see https://github.com/JuliaLang/julia/pull/23785#discussion_r140058503) consistent across all existing out-of-place multiplication methods (`*`, `A[c]_mul_B[c]`)~ (edit: botched) and tests those methods' behavior. Best!

(The first commit is JuliaLang/julia#23785, which I will rebase out.)