### PR TITLE
Improved nextind and prevind

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -231,6 +231,9 @@ This section lists changes that do not have deprecation warnings.
 Library improvements
 --------------------
 
+  * The functions `nextind` and `prevind` now accept `nchar` argument that indicates
+    number of characters to move ([#23805]).
+
   * The functions `strip`, `lstrip` and `rstrip` now return `SubString` ([#22496]).
 
   * The functions `strwidth` and `charwidth` have been merged into `textwidth`([#20816]).

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -107,6 +107,25 @@ function prevind(s::String, i::Integer)
     j
 end
 
+function prevind(s::String, i::Integer, nchar::Integer)
+    nchar > 0 || throw(ArgumentError("nchar must be greater than 0"))
+    j = Int(i)
+    e = sizeof(s)
+    while nchar > 0
+        if j > e
+            j = endof(s)
+        else
+            j -= 1
+            @inbounds while j > 0 && is_valid_continuation(codeunit(s,j))
+                j -= 1
+            end
+        end
+        nchar -= 1
+        j <= 0 && return j - nchar
+    end
+    j
+end
+
 function nextind(s::String, i::Integer)
     j = Int(i)
     if j < 1
@@ -116,6 +135,25 @@ function nextind(s::String, i::Integer)
     j += 1
     @inbounds while j <= e && is_valid_continuation(codeunit(s,j))
         j += 1
+    end
+    j
+end
+
+function nextind(s::String, i::Integer, nchar::Integer)
+    nchar > 0 || throw(ArgumentError("nchar must be greater than 0"))
+    j = Int(i)
+    e = sizeof(s)
+    while nchar > 0
+        if j < 1
+            j = 1
+        else
+            j += 1
+            @inbounds while j <= e && is_valid_continuation(codeunit(s,j))
+                j += 1
+            end
+        end
+        nchar -= 1
+        j > e && return j + nchar
     end
     j
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -610,11 +610,11 @@ let
 
         for x in -10:20
             n = p = x
-            for i in 1:40
+            for j in 1:40
                 p = prevind(strs[i], p)
-                @test prevind(strs[i], x, i) == p
+                @test prevind(strs[i], x, j) == p
                 n = nextind(strs[i], n)
-                @test nextind(strs[i], x, i) == n
+                @test nextind(strs[i], x, j) == n
             end
         end
     end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -548,57 +548,10 @@ end
     @test "a" * 'b' * 'c' == "abc"
 end
 
-<<<<<<< 19921aa00468edf11f3d61f8c9b8d639ec71cd23
 @testset "unrecognized escapes in string/char literals" begin
     @test_throws ParseError parse("\"\\.\"")
     @test_throws ParseError parse("\'\\.\'")
-=======
-# Simple case, with just ANSI Latin 1 characters
-@test "áB" != CharStr("áá") # returns false with bug
-@test cmp("áB", CharStr("áá")) == -1 # returns 0 with bug
-
-# Case with Unicode characters
-@test cmp("\U1f596\U1f596", CharStr("\U1f596")) == 1   # Gives BoundsError with bug
-@test cmp(CharStr("\U1f596"), "\U1f596\U1f596") == -1
-
-# repeat function
-@inferred repeat(GenericString("x"), 1)
-@test repeat("xx",3) == repeat("x",6) == repeat('x',6) == repeat(GenericString("x"), 6) == "xxxxxx"
-@test repeat("αα",3) == repeat("α",6) == repeat('α',6) == repeat(GenericString("α"), 6) == "αααααα"
-@test repeat("x",1) == repeat('x',1) == "x"^1 == 'x'^1 == GenericString("x")^1 == "x"
-@test repeat("x",0) == repeat('x',0) == "x"^0 == 'x'^0 == GenericString("x")^0 == ""
-
-for S in ["xxx", "ååå", "∀∀∀", "🍕🍕🍕"]
-    c = S[1]
-    s = string(c)
-    @test_throws ArgumentError repeat(c, -1)
-    @test_throws ArgumentError repeat(s, -1)
-    @test_throws ArgumentError repeat(S, -1)
-    @test repeat(c, 0) == ""
-    @test repeat(s, 0) == ""
-    @test repeat(S, 0) == ""
-    @test repeat(c, 1) == s
-    @test repeat(s, 1) == s
-    @test repeat(S, 1) == S
-    @test repeat(c, 3) == S
-    @test repeat(s, 3) == S
-    @test repeat(S, 3) == S*S*S
 end
-
-# issue #12495: check that logical indexing attempt raises ArgumentError
-@test_throws ArgumentError "abc"[[true, false, true]]
-@test_throws ArgumentError "abc"[BitArray([true, false, true])]
-
-@test "ab" * "cd" == "abcd"
-@test 'a' * "bc" == "abc"
-@test "ab" * 'c' == "abc"
-@test 'a' * 'b' == "ab"
-@test 'a' * "b" * 'c' == "abc"
-@test "a" * 'b' * 'c' == "abc"
-
-# unrecognized escapes in string/char literals
-@test_throws ParseError parse("\"\\.\"")
-@test_throws ParseError parse("\'\\.\'")
 
 # prevind and nextind tests
 
@@ -670,5 +623,4 @@ let
 
     @test prevind(strs[2], -1) == 0
     @test prevind(strs[2], -1, 1) == 0
->>>>>>> improved prevind and nextind
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -553,74 +553,73 @@ end
     @test_throws ParseError parse("\'\\.\'")
 end
 
-# prevind and nextind tests
+@testset "prevind and nextind" begin
+    let strs = Any["∀α>β:α+1>β", GenericString("∀α>β:α+1>β")]
+        for i in 1:2
+            @test prevind(strs[i], 1) == 0
+            @test prevind(strs[i], 1, 1) == 0
+            @test prevind(strs[i], 2) == 1
+            @test prevind(strs[i], 2, 1) == 1
+            @test prevind(strs[i], 4) == 1
+            @test prevind(strs[i], 4, 1) == 1
+            @test prevind(strs[i], 5) == 4
+            @test prevind(strs[i], 5, 1) == 4
+            @test prevind(strs[i], 5, 2) == 1
+            @test prevind(strs[i], 5, 3) == 0
+            @test prevind(strs[i], 15) == 14
+            @test prevind(strs[i], 15, 1) == 14
+            @test prevind(strs[i], 15, 2) == 13
+            @test prevind(strs[i], 15, 3) == 12
+            @test prevind(strs[i], 15, 4) == 10
+            @test prevind(strs[i], 15, 10) == 0
+            @test prevind(strs[i], 15, 9) == 1
+            @test prevind(strs[i], 15, 10) == 0
+            @test prevind(strs[i], 16) == 15
+            @test prevind(strs[i], 16, 1) == 15
+            @test prevind(strs[i], 16, 2) == 14
+            @test prevind(strs[i], 20) == 15
+            @test prevind(strs[i], 20, 1) == 15
+            @test prevind(strs[i], 20, 10) == 1
+            @test_throws ArgumentError prevind(strs[i], 20, 0)
 
-let
-    strs = Any["∀α>β:α+1>β", GenericString("∀α>β:α+1>β")]
-    for i in 1:2
-        @test prevind(strs[i], 1) == 0
-        @test prevind(strs[i], 1, 1) == 0
-        @test prevind(strs[i], 2) == 1
-        @test prevind(strs[i], 2, 1) == 1
-        @test prevind(strs[i], 4) == 1
-        @test prevind(strs[i], 4, 1) == 1
-        @test prevind(strs[i], 5) == 4
-        @test prevind(strs[i], 5, 1) == 4
-        @test prevind(strs[i], 5, 2) == 1
-        @test prevind(strs[i], 5, 3) == 0
-        @test prevind(strs[i], 15) == 14
-        @test prevind(strs[i], 15, 1) == 14
-        @test prevind(strs[i], 15, 2) == 13
-        @test prevind(strs[i], 15, 3) == 12
-        @test prevind(strs[i], 15, 4) == 10
-        @test prevind(strs[i], 15, 10) == 0
-        @test prevind(strs[i], 15, 9) == 1
-        @test prevind(strs[i], 15, 10) == 0
-        @test prevind(strs[i], 16) == 15
-        @test prevind(strs[i], 16, 1) == 15
-        @test prevind(strs[i], 16, 2) == 14
-        @test prevind(strs[i], 20) == 15
-        @test prevind(strs[i], 20, 1) == 15
-        @test prevind(strs[i], 20, 10) == 1
-        @test_throws ArgumentError prevind(strs[i], 20, 0)
+            @test nextind(strs[i], -1) == 1
+            @test nextind(strs[i], -1, 1) == 1
+            @test nextind(strs[i], 0, 2) == 4
+            @test nextind(strs[i], 0, 20) == 26
+            @test nextind(strs[i], 0, 10) == 15
+            @test nextind(strs[i], 1) == 4
+            @test nextind(strs[i], 1, 1) == 4
+            @test nextind(strs[i], 1, 2) == 6
+            @test nextind(strs[i], 1, 9) == 15
+            @test nextind(strs[i], 1, 10) == 17
+            @test nextind(strs[i], 2) == 4
+            @test nextind(strs[i], 2, 1) == 4
+            @test nextind(strs[i], 3) == 4
+            @test nextind(strs[i], 3, 1) == 4
+            @test nextind(strs[i], 4) == 6
+            @test nextind(strs[i], 4, 1) == 6
+            @test nextind(strs[i], 14) == 15
+            @test nextind(strs[i], 14, 1) == 15
+            @test nextind(strs[i], 15) == 17
+            @test nextind(strs[i], 15, 1) == 17
+            @test nextind(strs[i], 20) == 21
+            @test nextind(strs[i], 20, 1) == 21
+            @test_throws ArgumentError nextind(strs[i], 20, 0)
 
-        @test nextind(strs[i], -1) == 1
-        @test nextind(strs[i], -1, 1) == 1
-        @test nextind(strs[i], 0, 2) == 4
-        @test nextind(strs[i], 0, 20) == 26
-        @test nextind(strs[i], 0, 10) == 15
-        @test nextind(strs[i], 1) == 4
-        @test nextind(strs[i], 1, 1) == 4
-        @test nextind(strs[i], 1, 2) == 6
-        @test nextind(strs[i], 1, 9) == 15
-        @test nextind(strs[i], 1, 10) == 17
-        @test nextind(strs[i], 2) == 4
-        @test nextind(strs[i], 2, 1) == 4
-        @test nextind(strs[i], 3) == 4
-        @test nextind(strs[i], 3, 1) == 4
-        @test nextind(strs[i], 4) == 6
-        @test nextind(strs[i], 4, 1) == 6
-        @test nextind(strs[i], 14) == 15
-        @test nextind(strs[i], 14, 1) == 15
-        @test nextind(strs[i], 15) == 17
-        @test nextind(strs[i], 15, 1) == 17
-        @test nextind(strs[i], 20) == 21
-        @test nextind(strs[i], 20, 1) == 21
-        @test_throws ArgumentError nextind(strs[i], 20, 0)
-
-        for x in -10:20
-            n = p = x
-            for j in 1:40
-                p = prevind(strs[i], p)
-                @test prevind(strs[i], x, j) == p
-                n = nextind(strs[i], n)
-                @test nextind(strs[i], x, j) == n
+            for x in -10:20
+                n = p = x
+                for j in 1:40
+                    p = prevind(strs[i], p)
+                    @test prevind(strs[i], x, j) == p
+                    n = nextind(strs[i], n)
+                    @test nextind(strs[i], x, j) == n
+                end
             end
         end
-    end
-    @test prevind(strs[1], -1) == -2
-    @test prevind(strs[1], -1, 1) == -2
+        @test prevind(strs[1], -1) == -2
+        @test prevind(strs[1], -1, 1) == -2
 
-    @test prevind(strs[2], -1) == 0
-    @test prevind(strs[2], -1, 1) == 0
+        @test prevind(strs[2], -1) == 0
+        @test prevind(strs[2], -1, 1) == 0
+    end
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -548,7 +548,127 @@ end
     @test "a" * 'b' * 'c' == "abc"
 end
 
+<<<<<<< 19921aa00468edf11f3d61f8c9b8d639ec71cd23
 @testset "unrecognized escapes in string/char literals" begin
     @test_throws ParseError parse("\"\\.\"")
     @test_throws ParseError parse("\'\\.\'")
+=======
+# Simple case, with just ANSI Latin 1 characters
+@test "áB" != CharStr("áá") # returns false with bug
+@test cmp("áB", CharStr("áá")) == -1 # returns 0 with bug
+
+# Case with Unicode characters
+@test cmp("\U1f596\U1f596", CharStr("\U1f596")) == 1   # Gives BoundsError with bug
+@test cmp(CharStr("\U1f596"), "\U1f596\U1f596") == -1
+
+# repeat function
+@inferred repeat(GenericString("x"), 1)
+@test repeat("xx",3) == repeat("x",6) == repeat('x',6) == repeat(GenericString("x"), 6) == "xxxxxx"
+@test repeat("αα",3) == repeat("α",6) == repeat('α',6) == repeat(GenericString("α"), 6) == "αααααα"
+@test repeat("x",1) == repeat('x',1) == "x"^1 == 'x'^1 == GenericString("x")^1 == "x"
+@test repeat("x",0) == repeat('x',0) == "x"^0 == 'x'^0 == GenericString("x")^0 == ""
+
+for S in ["xxx", "ååå", "∀∀∀", "🍕🍕🍕"]
+    c = S[1]
+    s = string(c)
+    @test_throws ArgumentError repeat(c, -1)
+    @test_throws ArgumentError repeat(s, -1)
+    @test_throws ArgumentError repeat(S, -1)
+    @test repeat(c, 0) == ""
+    @test repeat(s, 0) == ""
+    @test repeat(S, 0) == ""
+    @test repeat(c, 1) == s
+    @test repeat(s, 1) == s
+    @test repeat(S, 1) == S
+    @test repeat(c, 3) == S
+    @test repeat(s, 3) == S
+    @test repeat(S, 3) == S*S*S
+end
+
+# issue #12495: check that logical indexing attempt raises ArgumentError
+@test_throws ArgumentError "abc"[[true, false, true]]
+@test_throws ArgumentError "abc"[BitArray([true, false, true])]
+
+@test "ab" * "cd" == "abcd"
+@test 'a' * "bc" == "abc"
+@test "ab" * 'c' == "abc"
+@test 'a' * 'b' == "ab"
+@test 'a' * "b" * 'c' == "abc"
+@test "a" * 'b' * 'c' == "abc"
+
+# unrecognized escapes in string/char literals
+@test_throws ParseError parse("\"\\.\"")
+@test_throws ParseError parse("\'\\.\'")
+
+# prevind and nextind tests
+
+let
+    strs = Any["∀α>β:α+1>β", GenericString("∀α>β:α+1>β")]
+    for i in 1:2
+        @test prevind(strs[i], 1) == 0
+        @test prevind(strs[i], 1, 1) == 0
+        @test prevind(strs[i], 2) == 1
+        @test prevind(strs[i], 2, 1) == 1
+        @test prevind(strs[i], 4) == 1
+        @test prevind(strs[i], 4, 1) == 1
+        @test prevind(strs[i], 5) == 4
+        @test prevind(strs[i], 5, 1) == 4
+        @test prevind(strs[i], 5, 2) == 1
+        @test prevind(strs[i], 5, 3) == 0
+        @test prevind(strs[i], 15) == 14
+        @test prevind(strs[i], 15, 1) == 14
+        @test prevind(strs[i], 15, 2) == 13
+        @test prevind(strs[i], 15, 3) == 12
+        @test prevind(strs[i], 15, 4) == 10
+        @test prevind(strs[i], 15, 10) == 0
+        @test prevind(strs[i], 15, 9) == 1
+        @test prevind(strs[i], 15, 10) == 0
+        @test prevind(strs[i], 16) == 15
+        @test prevind(strs[i], 16, 1) == 15
+        @test prevind(strs[i], 16, 2) == 14
+        @test prevind(strs[i], 20) == 15
+        @test prevind(strs[i], 20, 1) == 15
+        @test prevind(strs[i], 20, 10) == 1
+        @test_throws ArgumentError prevind(strs[i], 20, 0)
+
+        @test nextind(strs[i], -1) == 1
+        @test nextind(strs[i], -1, 1) == 1
+        @test nextind(strs[i], 0, 2) == 4
+        @test nextind(strs[i], 0, 20) == 26
+        @test nextind(strs[i], 0, 10) == 15
+        @test nextind(strs[i], 1) == 4
+        @test nextind(strs[i], 1, 1) == 4
+        @test nextind(strs[i], 1, 2) == 6
+        @test nextind(strs[i], 1, 9) == 15
+        @test nextind(strs[i], 1, 10) == 17
+        @test nextind(strs[i], 2) == 4
+        @test nextind(strs[i], 2, 1) == 4
+        @test nextind(strs[i], 3) == 4
+        @test nextind(strs[i], 3, 1) == 4
+        @test nextind(strs[i], 4) == 6
+        @test nextind(strs[i], 4, 1) == 6
+        @test nextind(strs[i], 14) == 15
+        @test nextind(strs[i], 14, 1) == 15
+        @test nextind(strs[i], 15) == 17
+        @test nextind(strs[i], 15, 1) == 17
+        @test nextind(strs[i], 20) == 21
+        @test nextind(strs[i], 20, 1) == 21
+        @test_throws ArgumentError nextind(strs[i], 20, 0)
+
+        for x in -10:20
+            n = p = x
+            for i in 1:40
+                p = prevind(strs[i], p)
+                @test prevind(strs[i], x, i) == p
+                n = nextind(strs[i], n)
+                @test nextind(strs[i], x, i) == n
+            end
+        end
+    end
+    @test prevind(strs[1], -1) == -2
+    @test prevind(strs[1], -1, 1) == -2
+
+    @test prevind(strs[2], -1) == 0
+    @test prevind(strs[2], -1, 1) == 0
+>>>>>>> improved prevind and nextind
 end


### PR DESCRIPTION
First part of implementation of #23765. Extends `prevind` and `nextind` with `nchar` parameter.
Additionally ensures `prevind` and `nextind` have consistent return value across different types of strings. In particular:
* `prevind` always returns a result between `start(str)-1` and `endof(str)`
* `nextind` always returns a result between `start(str)` and `endof(str)+1`
