### PR TITLE
Omit module prefix when printing types which are reachable from Main

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -1000,3 +1000,28 @@ end
     s = String(take!(io))
     @test contains(s, " in Base.Math ")
 end
+
+module TestShowType
+    export TypeA
+    struct TypeA end
+end
+
+@testset "module prefix when printing type" begin
+    @test sprint(show, TestShowType.TypeA) == "$(@__MODULE__).TestShowType.TypeA"
+
+    b = IOBuffer()
+    show(IOContext(b, :module => @__MODULE__), TestShowType.TypeA)
+    @test String(take!(b)) == "$(@__MODULE__).TestShowType.TypeA"
+
+    b = IOBuffer()
+    show(IOContext(b, :module => TestShowType), TestShowType.TypeA)
+    @test String(take!(b)) == "TypeA"
+
+    using .TestShowType
+
+    @test sprint(show, TypeA) == "$(@__MODULE__).TestShowType.TypeA"
+
+    b = IOBuffer()
+    show(IOContext(b, :module => @__MODULE__), TypeA)
+    @test String(take!(b)) == "TypeA"
+end


### PR DESCRIPTION
Only add the module prefix when it is actually required to access the type from `Main`.

As discussed on Slack some time ago, this is an attempt at improving the printing of types defined outside Base. I'm really not familiar with this, so there might be better ways of doing this. Also, I'm not sure how to test this given that tests do not run in Main.

The improvement is the most visible for types defined in packages for which the package name is just the plural of the type name. Before:
```julia
julia> using CategoricalArrays

julia> CategoricalArray(1:2)
2-element CategoricalArrays.CategoricalArray{Int64,1,UInt32}:
...
```

After:
```julia
julia> using CategoricalArrays

julia> CategoricalArray(1:2)
2-element CategoricalArray{Int64,1,UInt32}:
...
```