### PR TITLE
require explicit predicates in `find` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -297,6 +297,9 @@ Library improvements
 
   * REPL Undo via Ctrl-/ and Ctrl-_
 
+  * New function `equalto(x)`, which returns a function that compares its argument to `x`
+    using `isequal` ([#23812]).
+
 Compiler/Runtime improvements
 -----------------------------
 
@@ -488,6 +491,12 @@ Deprecated or removed
 
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
+
+  * Methods of `findfirst`, `findnext`, `findlast`, and `findprev` that accept a value to
+    search for are deprecated in favor of passing a predicate ([#19186], [#10593]).
+
+  * `find` functions now operate only on booleans by default. To look for non-zeros, use
+    `x->x!=0` or `!iszero` ([#23120]).
 
 Command-line option changes
 ---------------------------

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -75,7 +75,7 @@ function permute!!(a, p::AbstractVector{<:Integer})
     count = 0
     start = 0
     while count < length(a)
-        ptr = start = findnext(p, start+1)
+        ptr = start = findnext(!iszero, p, start+1)
         temp = a[start]
         next = p[start]
         count += 1
@@ -125,7 +125,7 @@ function ipermute!!(a, p::AbstractVector{<:Integer})
     count = 0
     start = 0
     while count < length(a)
-        start = findnext(p, start+1)
+        start = findnext(!iszero, p, start+1)
         temp = a[start]
         next = p[start]
         count += 1

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -370,7 +370,7 @@ function val_opts(opts)
     for (opt_name, opt_val) in opts
         in(opt_name, valid_opts) ||
             throw(ArgumentError("unknown option $opt_name"))
-        opt_typ = valid_opt_types[findfirst(valid_opts, opt_name)]
+        opt_typ = valid_opt_types[findfirst(equalto(opt_name), valid_opts)]
         isa(opt_val, opt_typ) ||
             throw(ArgumentError("$opt_name should be of type $opt_typ, got $(typeof(opt_val))"))
         d[opt_name] = opt_val

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1918,6 +1918,14 @@ end
 @deprecate strwidth textwidth
 @deprecate charwidth textwidth
 
+@deprecate find(x::Number)            find(!iszero, x)
+@deprecate findnext(A, v, i::Integer) findnext(equalto(v), A, i)
+@deprecate findfirst(A, v)            findfirst(equalto(v), A)
+@deprecate findprev(A, v, i::Integer) findprev(equalto(v), A, i)
+@deprecate findlast(A, v)             findlast(equalto(v), A)
+# also remove deprecation warnings in find* functions in array.jl, sparse/sparsematrix.jl,
+# and sparse/sparsevector.jl.
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/event.jl
+++ b/base/event.jl
@@ -234,7 +234,7 @@ function ensure_rescheduled(othertask::Task)
         # if the current task was queued,
         # also need to return it to the runnable state
         # before throwing an error
-        i = findfirst(Workqueue, ct)
+        i = findfirst(t->t===ct, Workqueue)
         i == 0 || deleteat!(Workqueue, i)
         ct.state = :runnable
     end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -859,6 +859,7 @@ export
     identity,
     isbits,
     isequal,
+    equalto,
     isimmutable,
     isless,
     ifelse,

--- a/base/file.jl
+++ b/base/file.jl
@@ -271,7 +271,7 @@ function tempname(temppath::AbstractString,uunique::UInt32)
     tempp = cwstring(temppath)
     tname = Vector{UInt16}(32767)
     uunique = ccall(:GetTempFileNameW,stdcall,UInt32,(Ptr{UInt16},Ptr{UInt16},UInt32,Ptr{UInt16}), tempp,temp_prefix,uunique,tname)
-    lentname = findfirst(tname,0)-1
+    lentname = findfirst(iszero,tname)-1
     if uunique == 0 || lentname <= 0
         error("GetTempFileName failed: $(Libc.FormatMessage())")
     end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -1583,7 +1583,7 @@ function builtin_tfunction(@nospecialize(f), argtypes::Array{Any,1},
         end
         tf = t_ifunc[iidx]
     else
-        fidx = findfirst(t_ffunc_key, f)
+        fidx = findfirst(x->x===f, t_ffunc_key)
         if fidx == 0
             # unknown/unhandled builtin function
             return Any
@@ -4757,7 +4757,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, mod::Module, params:
                 elseif f == Main.Core.arrayref
                     return plus_saturate(argcost, isknowntype(ex.typ) ? 4 : params.inline_nonleaf_penalty)
                 end
-                fidx = findfirst(t_ffunc_key, f)
+                fidx = findfirst(x->x===f, t_ffunc_key)
                 if fidx == 0
                     # unknown/unhandled builtin or anonymous function
                     # Use the generic cost of a direct function call
@@ -5604,7 +5604,7 @@ function _getfield_elim_pass!(e::Expr, sv::InferenceState)
             if alloc !== false
                 flen, fnames = alloc
                 if isa(j, QuoteNode)
-                    j = findfirst(fnames, j.value)
+                    j = findfirst(equalto(j.value), fnames)
                 end
                 if 1 <= j <= flen
                     ok = true
@@ -5899,7 +5899,7 @@ function replace_getfield!(e::Expr, tupname, vals, field_names, sv::InferenceSta
                 a.args[3]
             else
                 @assert isa(a.args[3], QuoteNode)
-                findfirst(field_names, a.args[3].value)
+                findfirst(equalto(a.args[3].value), field_names)
             end
             @assert(idx > 0) # clients should check that all getfields are valid
             val = vals[idx]

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -972,3 +972,22 @@ julia> filter(!isalpha, str)
 ```
 """
 !(f::Function) = (x...)->!f(x...)
+
+struct EqualTo{T} <: Function
+    x::T
+
+    EqualTo(x::T) where {T} = new{T}(x)
+end
+
+(f::EqualTo)(y) = isequal(f.x, y)
+
+"""
+    equalto(x)
+
+Create a function that compares its argument to `x` using [`isequal`](@ref); i.e. returns
+`y->isequal(x,y)`.
+
+The returned function is of type `Base.EqualTo`. This allows dispatching to
+specialized methods by using e.g. `f::Base.EqualTo` in a method signature.
+"""
+const equalto = EqualTo

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -148,7 +148,7 @@ function _copy!(P::PermutedDimsArray{T,N,perm}, src) where {T,N,perm}
         copy!(parent(P), src) # it's not permuted
     else
         R1 = CartesianRange(indices(src)[1:d])
-        d1 = findfirst(perm, d+1)  # first permuted dim of dest
+        d1 = findfirst(equalto(d+1), perm)  # first permuted dim of dest
         R2 = CartesianRange(indices(src)[d+2:d1-1])
         R3 = CartesianRange(indices(src)[d1+1:end])
         _permutedims!(P, src, R1, R2, R3, d+1, d1)

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -359,7 +359,7 @@ function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Ava
             vmaskp[vn] = falses(luds)
         end
         for (vn,a) in fdepsp
-            vmind = findfirst(uniqdepssets, a.requires)
+            vmind = findfirst(equalto(a.requires), uniqdepssets)
             @assert vmind > 0
             vm = vmaskp[vn]
             vm[vmind] = true
@@ -389,7 +389,7 @@ function prune_versions(reqs::Requires, deps::Dict{String,Dict{VersionNumber,Ava
         nc = length(vmask0_uniq)
         classes = [VersionNumber[] for c0 = 1:nc]
         for (vn,vm) in vmaskp
-            c0 = findfirst(vmask0_uniq, vm)
+            c0 = findfirst(equalto(vm), vmask0_uniq)
             push!(classes[c0], vn)
         end
         map(sort!, classes)

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -819,7 +819,6 @@ precompile(Tuple{Type{BoundsError}, Array{Int64, 2}, Tuple{Base.UnitRange{Int64}
 precompile(Tuple{typeof(Base.throw_boundserror), Array{Int64, 2}, Tuple{Base.UnitRange{Int64}, Int64}})
 precompile(Tuple{getfield(Base.Cartesian, Symbol("#@nexprs")), Int64, Expr})
 precompile(Tuple{typeof(Base.Cartesian._nexprs), Int64, Expr})
-precompile(Tuple{typeof(Core.Inference.findnext), Array{Function, 1}, typeof(===), Int64})
 precompile(Tuple{typeof(Core.Inference.builtin_tfunction), typeof(===), Array{Any, 1}, Core.Inference.InferenceState, Core.Inference.InferenceParams})
 precompile(Tuple{typeof(Core.Inference.typeinf_frame), Core.MethodInstance, Bool, Bool, Core.Inference.InferenceParams})
 precompile(Tuple{typeof(Core.Inference.typeinf), Core.Inference.InferenceState})

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -620,10 +620,10 @@ const _space = UInt8(' ')
 
 _notspace(c) = c != _space
 
-beginofline(buf, pos=position(buf)) = findprev(buf.data, _newline, pos)
+beginofline(buf, pos=position(buf)) = findprev(equalto(_newline), buf.data, pos)
 
 function endofline(buf, pos=position(buf))
-    eol = findnext(buf.data[pos+1:buf.size], _newline, 1)
+    eol = findnext(equalto(_newline), buf.data[pos+1:buf.size], 1)
     eol == 0 ? buf.size : pos + eol - 1
 end
 

--- a/base/sharedarray.jl
+++ b/base/sharedarray.jl
@@ -390,7 +390,7 @@ sub_1dim(S::SharedArray, pidx) = view(S.s, range_1dim(S, pidx))
 
 function init_loc_flds(S::SharedArray{T,N}, empty_local=false) where T where N
     if myid() in S.pids
-        S.pidx = findfirst(S.pids, myid())
+        S.pidx = findfirst(equalto(myid()), S.pids)
         if isa(S.refs[1], Future)
             refid = remoteref_id(S.refs[S.pidx])
         else

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -111,17 +111,13 @@ Base.find(::Function, ::Any)
 Base.findn
 Base.findnz
 Base.findfirst(::Any)
-Base.findfirst(::Any, ::Any)
 Base.findfirst(::Function, ::Any)
 Base.findlast(::Any)
-Base.findlast(::Any, ::Any)
 Base.findlast(::Function, ::Any)
 Base.findnext(::Any, ::Integer)
 Base.findnext(::Function, ::Any, ::Integer)
-Base.findnext(::Any, ::Any, ::Integer)
 Base.findprev(::Any, ::Integer)
 Base.findprev(::Function, ::Any, ::Integer)
-Base.findprev(::Any, ::Any, ::Integer)
 Base.permutedims
 Base.permutedims!
 Base.PermutedDimsArray

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -136,6 +136,7 @@ Core.invoke
 Base.invokelatest
 Base.:(|>)
 Base.:(∘)
+Base.equalto
 ```
 
 ## Syntax

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -427,44 +427,44 @@ end
     @test X[Y[end],1] == 5
     @test X[end,Y[end]] == 11
 end
+
 @testset "find, findfirst, findnext, findlast, findprev" begin
     a = [0,1,2,3,0,1,2,3]
-    @test find(a) == [2,3,4,6,7,8]
+    @test find(!iszero, a) == [2,3,4,6,7,8]
     @test find(a.==2) == [3,7]
     @test find(isodd,a) == [2,4,6,8]
-    @test findfirst(a) == 2
+    @test findfirst(!iszero, a) == 2
     @test findfirst(a.==0) == 1
     @test findfirst(a.==5) == 0
-    @test findfirst([1,2,4,1,2,3,4], 3) == 6
+    @test findfirst(equalto(3), [1,2,4,1,2,3,4]) == 6
+    @test findfirst(!equalto(1), [1,2,4,1,2,3,4]) == 2
     @test findfirst(isodd, [2,4,6,3,9,2,0]) == 4
     @test findfirst(isodd, [2,4,6,2,0]) == 0
-    @test findnext(a,4) == 4
-    @test findnext(a,5) == 6
-    @test findnext(a,1) == 2
-    @test findnext(a,1,4) == 6
-    @test findnext(a,5,4) == 0
-    @test findlast(a) == 8
+    @test findnext(!iszero,a,4) == 4
+    @test findnext(!iszero,a,5) == 6
+    @test findnext(!iszero,a,1) == 2
+    @test findnext(equalto(1),a,4) == 6
+    @test findnext(equalto(5),a,4) == 0
+    @test findlast(!iszero, a) == 8
     @test findlast(a.==0) == 5
     @test findlast(a.==5) == 0
-    @test findlast([1,2,4,1,2,3,4], 3) == 6
+    @test findlast(equalto(3), [1,2,4,1,2,3,4]) == 6
     @test findlast(isodd, [2,4,6,3,9,2,0]) == 5
     @test findlast(isodd, [2,4,6,2,0]) == 0
-    @test findprev(a,4) == 4
-    @test findprev(a,5) == 4
-    @test findprev(a,1) == 0
-    @test findprev(a,1,4) == 2
-    @test findprev(a,1,8) == 6
+    @test findprev(!iszero,a,4) == 4
+    @test findprev(!iszero,a,5) == 4
+    @test findprev(!iszero,a,1) == 0
+    @test findprev(equalto(1),a,4) == 2
+    @test findprev(equalto(1),a,8) == 6
     @test findprev(isodd, [2,4,5,3,9,2,0], 7) == 5
     @test findprev(isodd, [2,4,5,3,9,2,0], 2) == 0
 end
 @testset "find with general iterables" begin
     s = "julia"
-    # FIXME once 16269 is resolved
-    # @test find(s) == [1,2,3,4,5]
     @test find(c -> c == 'l', s) == [3]
     g = graphemes("日本語")
     @test find(isascii, g) == Int[]
-    @test find((i % 2 for i in 1:10)) == collect(1:2:9)
+    @test find(!iszero, (i % 2 for i in 1:10)) == collect(1:2:9)
 end
 @testset "findn" begin
     b = findn(ones(2,2,2,2))

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1069,9 +1069,9 @@ timesofar("datamove")
 
         @check_bit_operation findfirst(b1) Int
 
-        @check_bit_operation findfirst(b1, true)  Int
-        @check_bit_operation findfirst(b1, false) Int
-        @check_bit_operation findfirst(b1, 3)     Int
+        @check_bit_operation findfirst(!iszero, b1)    Int
+        @check_bit_operation findfirst(iszero, b1)     Int
+        @check_bit_operation findfirst(equalto(3), b1) Int
 
         @check_bit_operation findfirst(x->x, b1)     Int
         @check_bit_operation findfirst(x->!x, b1)    Int

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1102,7 +1102,7 @@ isdefined_f3(x) = isdefined(x, 3)
 @test find_call(first(code_typed(isdefined_f3, Tuple{Tuple{Vararg{Int}}})[1]).code, isdefined, 3)
 
 let isa_tfunc = Core.Inference.t_ffunc_val[
-        findfirst(Core.Inference.t_ffunc_key, isa)][3]
+        findfirst(x->x===isa, Core.Inference.t_ffunc_key)][3]
     @test isa_tfunc(Array, Const(AbstractArray)) === Const(true)
     @test isa_tfunc(Array, Type{AbstractArray}) === Const(true)
     @test isa_tfunc(Array, Type{AbstractArray{Int}}) == Bool
@@ -1142,7 +1142,7 @@ let isa_tfunc = Core.Inference.t_ffunc_val[
 end
 
 let subtype_tfunc = Core.Inference.t_ffunc_val[
-        findfirst(Core.Inference.t_ffunc_key, <:)][3]
+        findfirst(x->x===(<:), Core.Inference.t_ffunc_key)][3]
     @test subtype_tfunc(Type{<:Array}, Const(AbstractArray)) === Const(true)
     @test subtype_tfunc(Type{<:Array}, Type{AbstractArray}) === Const(true)
     @test subtype_tfunc(Type{<:Array}, Type{AbstractArray{Int}}) == Bool

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -51,8 +51,8 @@ end
 
 @testset "Check library features" begin
     f = LibGit2.features()
-    @test findfirst(f, LibGit2.Consts.FEATURE_SSH) > 0
-    @test findfirst(f, LibGit2.Consts.FEATURE_HTTPS) > 0
+    @test findfirst(equalto(LibGit2.Consts.FEATURE_SSH), f) > 0
+    @test findfirst(equalto(LibGit2.Consts.FEATURE_HTTPS), f) > 0
 end
 
 @testset "OID" begin

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -364,7 +364,7 @@ I,J,N = findnz(z)
 @test I == [-1]
 @test J == [0]
 @test N == [2]
-@test find(h) == [-2:1;]
+@test find(!iszero,h) == [-2:1;]
 @test find(x->x>0, h) == [-1,1]
 @test find(x->x<0, h) == [-2,0]
 @test find(x->x==0, h) == [2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ end
 const node1_tests = String[]
 function move_to_node1(t)
     if t in tests
-        splice!(tests, findfirst(tests, t))
+        splice!(tests, findfirst(equalto(t), tests))
         push!(node1_tests, t)
     end
 end

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -256,10 +256,12 @@ let x = SparseVector(10, [2, 7, 9], [2.0, 7.0, 9.0])
 end
 
 # find and findnz tests
-@test find(spv_x1) == find(x1_full)
-@test findnz(spv_x1) == (find(x1_full), filter(x->x!=0, x1_full))
+@test find(!iszero, spv_x1) == find(!iszero, x1_full)
+@test find(spv_x1 .> 1) == find(x1_full .> 1)
+@test find(x->x>1, spv_x1) == find(x->x>1, x1_full)
+@test findnz(spv_x1) == (find(!iszero, x1_full), filter(x->x!=0, x1_full))
 let xc = SparseVector(8, [2, 3, 5], [1.25, 0, -0.75]), fc = Array(xc)
-    @test find(xc) == find(fc)
+    @test find(!iszero, xc) == find(!iszero, fc)
     @test findnz(xc) == ([2, 5], [1.25, -0.75])
 end
 

--- a/test/strings/search.jl
+++ b/test/strings/search.jl
@@ -381,7 +381,7 @@ end
 @test_throws ErrorException "ab" ∈ "abc"
 
 # issue #15723
-@test findfirst("⨳(", '(') == 4
-@test findnext("(⨳(", '(', 2) == 5
-@test findlast("(⨳(", '(') == 5
-@test findprev("(⨳(", '(', 2) == 1
+@test findfirst(equalto('('), "⨳(") == 4
+@test findnext(equalto('('), "(⨳(", 2) == 5
+@test findlast(equalto('('), "(⨳(") == 5
+@test findprev(equalto('('), "(⨳(", 2) == 1

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -25,7 +25,7 @@ function test_threaded_loop_and_atomic_add()
     @test x[] == 10000
     # Next test checks that all loop iterations ran,
     # and were unique (via pigeon-hole principle).
-    @test findfirst(found,false) == 0
+    @test !(false in found)
     if was_inorder
         println(STDERR, "Warning: threaded loop executed in order")
     end


### PR DESCRIPTION
I also tried out using `equalto(x)` as a predicate, and I really think we should adopt it. It reads nicely (`!equalto(x)` also works) and will cut down the number of function types.

fix #23120, fix #19186

Part of https://github.com/JuliaLang/julia/issues/10593.