### PR TITLE
LQPackedQ postmultiplication fixup

### DIFF
--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -107,10 +107,10 @@ end
 @testset "correct form of Q from lq(...) (#23729)" begin
     # where the original matrix (say A) is square or has more rows than columns,
     # then A's factorization's triangular factor (say L) should have the same shape
-    # as A independent of form (thin, square), and A's factorization's orthogonal
-    # factor (say Q) should be a square matrix of order of A's number of columns
-    # independent of form (thin, square), and L and Q should have
-    # multiplication-compatible shapes.
+    # as A independent of factorization form (truncated, square), and A's factorization's
+    # orthogonal factor (say Q) should be a square matrix of order of A's number of
+    # columns independent of factorization form (truncated, square), and L and Q
+    # should have multiplication-compatible shapes.
     m, n = 4, 2
     A = randn(m, n)
     for thin in (true, false)
@@ -122,18 +122,18 @@ end
     # where the original matrix has strictly fewer rows than columns ...
     m, n = 2, 4
     A = randn(m, n)
-    # ... then, for a thin factorization of A, L should be a square matrix
+    # ... then, for a truncated factorization of A, L should be a square matrix
     # of order of A's number of rows, Q should have the same shape as A,
     # and L and Q should have multiplication-compatible shapes
     Lthin, Qthin = lq(A, thin = true)
     @test size(Lthin) == (m, m)
     @test size(Qthin) == (m, n)
     @test isapprox(A, Lthin * Qthin)
-    # ... and, for a non-thin factorization of A, L should have the same shape as A,
-    # Q should be a square matrix of order of A's number of columns, and L and Q
-    # should have multiplication-compatible shape. but instead the L returned has
-    # no zero-padding on the right / is L for the thin factorization, so for
-    # L and Q to have multiplication-compatible shapes, L must be zero-padded
+    # ... and, for a square/non-truncated factorization of A, L should have the
+    # same shape as A, Q should be a square matrix of order of A's number of columns,
+    # and L and Q should have multiplication-compatible shape. but instead the L returned
+    # has no zero-padding on the right / is L for the truncated factorization,
+    # so for L and Q to have multiplication-compatible shapes, L must be zero-padded
     # to have the shape of A.
     Lsquare, Qsquare = lq(A, thin = false)
     @test size(Lsquare) == (m, m)
@@ -148,14 +148,14 @@ end
         return implicitQ, explicitQ
     end
 
-    m, n = 3, 3 # thin Q 3-by-3, square Q 3-by-3
+    m, n = 3, 3 # truncated Q 3-by-3, square Q 3-by-3
     implicitQ, explicitQ = getqs(lqfact(randn(m, n)))
     @test implicitQ[1, 1] == explicitQ[1, 1]
     @test implicitQ[m, 1] == explicitQ[m, 1]
     @test implicitQ[1, n] == explicitQ[1, n]
     @test implicitQ[m, n] == explicitQ[m, n]
 
-    m, n = 3, 4 # thin Q 3-by-4, square Q 4-by-4
+    m, n = 3, 4 # truncated Q 3-by-4, square Q 4-by-4
     implicitQ, explicitQ = getqs(lqfact(randn(m, n)))
     @test implicitQ[1, 1] == explicitQ[1, 1]
     @test implicitQ[m, 1] == explicitQ[m, 1]
@@ -164,7 +164,7 @@ end
     @test implicitQ[m+1, 1] == explicitQ[m+1, 1]
     @test implicitQ[m+1, n] == explicitQ[m+1, n]
 
-    m, n = 4, 3 # thin Q 3-by-3, square Q 3-by-3
+    m, n = 4, 3 # truncated Q 3-by-3, square Q 3-by-3
     implicitQ, explicitQ = getqs(lqfact(randn(m, n)))
     @test implicitQ[1, 1] == explicitQ[1, 1]
     @test implicitQ[n, 1] == explicitQ[n, 1]
@@ -200,21 +200,21 @@ end
         @test Ac_mul_Bc(C, implicitQ) ≈ Ac_mul_Bc(C, explicitQ)
     end
     # where the LQ-factored matrix has at least as many rows m as columns n,
-    # Q's square and thin forms have the same shape (n-by-n). hence we expect
+    # Q's square and truncated forms have the same shape (n-by-n). hence we expect
     # _only_ *-by-n (n-by-*) C to work in A_mul_B*(C, Q) (Ac_mul_B*(C, Q)) ops.
     # and hence the n-by-n C tests above suffice.
     #
     # where the LQ-factored matrix has more columns n than rows m,
-    # Q's square form is n-by-n whereas its thin form is m-by-n.
-    # hence we need also test *-by-m (m-by-*) C with
-    # A_mul_B*(C, Q) (Ac_mul_B*(C, Q)) ops, as below via m-by-m C.
+    # Q's square form is n-by-n whereas its truncated form is m-by-n.
+    # hence we need also test *-by-m C with
+    # A*_mul_B(C, Q) ops, as below via m-by-m C.
     mA, nA = 3, 4
     implicitQ, explicitQ = getqs(lqfact(randn(mA, nA)))
     C = randn(mA, mA)
     zeroextCright = hcat(C, zeros(eltype(C), mA))
     zeroextCdown = vcat(C, zeros(eltype(C), (1, mA)))
     @test *(C, implicitQ) ≈ *(zeroextCright, explicitQ)
-    @test A_mul_Bc(C, implicitQ) ≈ A_mul_Bc(zeroextCright, explicitQ)
     @test Ac_mul_B(C, implicitQ) ≈ Ac_mul_B(zeroextCdown, explicitQ)
-    @test Ac_mul_Bc(C, implicitQ) ≈ Ac_mul_Bc(zeroextCdown, explicitQ)
+    @test_throws DimensionMismatch A_mul_Bc(C, implicitQ)
+    @test_throws DimensionMismatch Ac_mul_Bc(C, implicitQ)
 end


### PR DESCRIPTION
In JuliaLang/julia#23803 I incorrectly extended `LQPackedQ`'s context-dependent multiplication behavior to some methods that should not have that behavior. This pull request makes `LQPackedQ`'s postmultiplication  behavior context-dependent only where necessary, and adds additional commentary describing the intended behavior. Best!