### PR TITLE
Patch LLVM for PTX ISA 6.0 support

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -439,11 +439,10 @@ $(eval $(call LLVM_PATCH,llvm-3.9.0_win64-reloc-dwarf)) # modified version appli
 $(eval $(call LLVM_PATCH,llvm-3.9.0_D27296-libssp))
 $(eval $(call LLVM_PATCH,llvm-D27609-AArch64-UABS_G3)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D27629-AArch64-large_model))
-# patches for NVPTX
-$(eval $(call LLVM_PATCH,llvm-NVPTX-addrspaces))
-$(eval $(call LLVM_PATCH,llvm-D9168_argument_alignment)) # Remove for 4.0
-$(eval $(call LLVM_PATCH,llvm-D23597_sdag_names)) # Dep for D24300, remove for 4.0
-$(eval $(call LLVM_PATCH,llvm-D24300_ptx_intrinsics)) # Remove for 4.0
+$(eval $(call LLVM_PATCH,llvm-NVPTX-addrspaces)) # NVPTX
+$(eval $(call LLVM_PATCH,llvm-D9168_argument_alignment)) # NVPTX, Remove for 4.0
+$(eval $(call LLVM_PATCH,llvm-D23597_sdag_names))     # NVPTX, Remove for 4.0
+$(eval $(call LLVM_PATCH,llvm-D24300_ptx_intrinsics)) # NVPTX, Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D27389)) # Julia issue #19792, Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D27397)) # Julia issue #19792, Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D28009)) # Julia issue #19792, Remove for 4.0
@@ -460,6 +459,7 @@ $(eval $(call LLVM_PATCH,llvm-rL293230-icc17-cmake)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D32593))
 $(eval $(call LLVM_PATCH,llvm-D33179))
 $(eval $(call LLVM_PATCH,llvm-PR29010-i386-xmm)) # Remove for 4.0
+$(eval $(call LLVM_PATCH,llvm-3.9.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 else ifeq ($(LLVM_VER_SHORT),4.0)
 # Cygwin and openSUSE still use win32-threads mingw, https://llvm.org/bugs/show_bug.cgi?id=26365
 $(eval $(call LLVM_PATCH,llvm-4.0.0_threads))
@@ -480,6 +480,7 @@ $(eval $(call LLVM_PATCH,llvm-D32208-coerce-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D32623-GVN-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D33129-scevexpander-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-Yet-another-fix))
+$(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 endif # LLVM_VER
 
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_PATCH_PREV)

--- a/deps/patches/llvm-3.9.0-D37576-NVPTX-sm_70.patch
+++ b/deps/patches/llvm-3.9.0-D37576-NVPTX-sm_70.patch
@@ -1,0 +1,62 @@
+From 4059d374ce981827223ab6b1dae7af4ec5f8e74a Mon Sep 17 00:00:00 2001
+From: Artem Belevich <tra@google.com>
+Date: Thu, 7 Sep 2017 18:14:32 +0000
+Subject: [PATCH] [CUDA] Added rudimentary support for CUDA-9 and sm_70.
+
+For now CUDA-9 is not included in the list of CUDA versions clang
+searches for, so the path to CUDA-9 must be explicitly passed
+via --cuda-path=.
+
+On LLVM side NVPTX added sm_70 GPU type which bumps required
+PTX version to 6.0, but otherwise is equivalent to sm_62 at the moment.
+
+Differential Revision: https://reviews.llvm.org/D37576
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@312734 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ lib/Target/NVPTX/NVPTX.td           | 5 +++++
+ test/CodeGen/NVPTX/sm-version-70.ll | 5 +++++
+ 2 files changed, 10 insertions(+)
+ create mode 100644 test/CodeGen/NVPTX/sm-version-70.ll
+
+diff --git a/lib/Target/NVPTX/NVPTX.td b/lib/Target/NVPTX/NVPTX.td
+index c77ddbc9978..aba37d36359 100644
+--- a/lib/Target/NVPTX/NVPTX.td
++++ b/lib/Target/NVPTX/NVPTX.td
+@@ -50,6 +50,8 @@ def SM61 : SubtargetFeature<"sm_61", "SmVersion", "61",
+                              "Target SM 6.1">;
+ def SM62 : SubtargetFeature<"sm_62", "SmVersion", "62",
+                              "Target SM 6.2">;
++def SM70 : SubtargetFeature<"sm_70", "SmVersion", "70",
++                             "Target SM 7.0">;
+ 
+ def SATOM : SubtargetFeature<"satom", "HasAtomScope", "true",
+                              "Atomic operations with scope">;
+@@ -67,6 +69,8 @@ def PTX43 : SubtargetFeature<"ptx43", "PTXVersion", "43",
+                              "Use PTX version 4.3">;
+ def PTX50 : SubtargetFeature<"ptx50", "PTXVersion", "50",
+                              "Use PTX version 5.0">;
++def PTX60 : SubtargetFeature<"ptx60", "PTXVersion", "60",
++                             "Use PTX version 6.0">;
+ 
+ //===----------------------------------------------------------------------===//
+ // NVPTX supported processors.
+@@ -87,6 +91,7 @@ def : Proc<"sm_53", [SM53, PTX42]>;
+ def : Proc<"sm_60", [SM60, PTX50]>;
+ def : Proc<"sm_61", [SM61, PTX50]>;
+ def : Proc<"sm_62", [SM62, PTX50]>;
++def : Proc<"sm_70", [SM70, PTX60]>;
+ 
+ def NVPTXInstrInfo : InstrInfo {
+ }
+diff --git a/test/CodeGen/NVPTX/sm-version-70.ll b/test/CodeGen/NVPTX/sm-version-70.ll
+new file mode 100644
+index 00000000000..8b72d50747a
+--- /dev/null
++++ b/test/CodeGen/NVPTX/sm-version-70.ll
+@@ -0,0 +1,5 @@
++; RUN: llc < %s -march=nvptx -mcpu=sm_70 | FileCheck %s
++; RUN: llc < %s -march=nvptx64 -mcpu=sm_70 | FileCheck %s
++
++; CHECK: .version 6.0
++; CHECK: .target sm_70

--- a/deps/patches/llvm-4.0.0-D37576-NVPTX-sm_70.patch
+++ b/deps/patches/llvm-4.0.0-D37576-NVPTX-sm_70.patch
@@ -1,0 +1,62 @@
+From 4059d374ce981827223ab6b1dae7af4ec5f8e74a Mon Sep 17 00:00:00 2001
+From: Artem Belevich <tra@google.com>
+Date: Thu, 7 Sep 2017 18:14:32 +0000
+Subject: [PATCH] [CUDA] Added rudimentary support for CUDA-9 and sm_70.
+
+For now CUDA-9 is not included in the list of CUDA versions clang
+searches for, so the path to CUDA-9 must be explicitly passed
+via --cuda-path=.
+
+On LLVM side NVPTX added sm_70 GPU type which bumps required
+PTX version to 6.0, but otherwise is equivalent to sm_62 at the moment.
+
+Differential Revision: https://reviews.llvm.org/D37576
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@312734 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ lib/Target/NVPTX/NVPTX.td           | 5 +++++
+ test/CodeGen/NVPTX/sm-version-70.ll | 5 +++++
+ 2 files changed, 10 insertions(+)
+ create mode 100644 test/CodeGen/NVPTX/sm-version-70.ll
+
+diff --git a/lib/Target/NVPTX/NVPTX.td b/lib/Target/NVPTX/NVPTX.td
+index c77ddbc9978..aba37d36359 100644
+--- a/lib/Target/NVPTX/NVPTX.td
++++ b/lib/Target/NVPTX/NVPTX.td
+@@ -50,6 +50,8 @@ def SM61 : SubtargetFeature<"sm_61", "SmVersion", "61",
+                              "Target SM 6.1">;
+ def SM62 : SubtargetFeature<"sm_62", "SmVersion", "62",
+                              "Target SM 6.2">;
++def SM70 : SubtargetFeature<"sm_70", "SmVersion", "70",
++                             "Target SM 7.0">;
+ 
+ def SATOM : SubtargetFeature<"satom", "HasAtomScope", "true",
+                              "Atomic operations with scope">;
+@@ -67,6 +69,8 @@ def PTX43 : SubtargetFeature<"ptx43", "PTXVersion", "43",
+                              "Use PTX version 4.3">;
+ def PTX50 : SubtargetFeature<"ptx50", "PTXVersion", "50",
+                              "Use PTX version 5.0">;
++def PTX60 : SubtargetFeature<"ptx60", "PTXVersion", "60",
++                             "Use PTX version 6.0">;
+ 
+ //===----------------------------------------------------------------------===//
+ // NVPTX supported processors.
+@@ -87,6 +91,7 @@ def : Proc<"sm_53", [SM53, PTX42]>;
+ def : Proc<"sm_60", [SM60, PTX50, SATOM]>;
+ def : Proc<"sm_61", [SM61, PTX50, SATOM]>;
+ def : Proc<"sm_62", [SM62, PTX50, SATOM]>;
++def : Proc<"sm_70", [SM70, PTX60, SATOM]>;
+ 
+ def NVPTXInstrInfo : InstrInfo {
+ }
+diff --git a/test/CodeGen/NVPTX/sm-version-70.ll b/test/CodeGen/NVPTX/sm-version-70.ll
+new file mode 100644
+index 00000000000..8b72d50747a
+--- /dev/null
++++ b/test/CodeGen/NVPTX/sm-version-70.ll
+@@ -0,0 +1,5 @@
++; RUN: llc < %s -march=nvptx -mcpu=sm_70 | FileCheck %s
++; RUN: llc < %s -march=nvptx64 -mcpu=sm_70 | FileCheck %s
++
++; CHECK: .version 6.0
++; CHECK: .target sm_70


### PR DESCRIPTION
This is required for supporting newer NVIDIA GPUs, running under CUDA 9.0.

Patch from https://github.com/llvm-mirror/llvm/commit/4059d374ce981827223ab6b1dae7af4ec5f8e74a, just adds the necessary subtarget features.
We might also want some relevant intrinsics at some point (eg. https://github.com/llvm-mirror/llvm/commit/34fb94caca2715263dcaeb4566d805881328f507 or https://github.com/llvm-mirror/llvm/commit/c02a4f5a57b8786e77949bba6c6383cd068d2105), but we're just using inline assembly for now.

Ref https://github.com/JuliaGPU/CUDAnative.jl/pull/107