### PR TITLE
Clarify --inline={yes|no} documentation

### DIFF
--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -116,6 +116,7 @@ julia [switches] -- [programfile] [args...]
  --machinefile <file>      Run processes on hosts listed in <file>
 
  -i                        Interactive mode; REPL runs and isinteractive() is true
+ -q, --quiet               Quiet startup: no banner, suppress REPL warnings
  --banner={yes|no}         Enable or disable startup banner
  --color={yes|no}          Enable or disable color text
  --history-file={yes|no}   Load or save history
@@ -124,10 +125,10 @@ julia [switches] -- [programfile] [args...]
  --warn-overwrite={yes|no} Enable or disable method overwrite warnings
 
  --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation
- -C, --cpu-target <target> Limit usage of cpu features up to <target>
- -O, --optimize={0,1,2,3}  Set the optimization level (default is 2 if unspecified or 3 if specified as -O)
- -g, -g <level>            Enable / Set the level of debug info generation (default is 1 if unspecified or 2 if specified as -g)
- --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)
+ -C, --cpu-target <target> Limit usage of cpu features up to <target>; set to "help" to see the available options
+ -O, --optimize={0,1,2,3}  Set the optimization level (default level is 2 if unspecified or 3 if used without a level)
+ -g, -g <level>            Enable / Set the level of debug info generation (default level is 1 if unspecified or 2 if used without a level)
+ --inline={yes|no}         Control whether inlining is permitted, including overriding @inline declarations
  --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)
  --math-mode={ieee,fast}   Disallow or enable unsafe floating point optimizations (overrides @fastmath declaration)
 

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -125,7 +125,7 @@ static const char opts[]  =
 #else
         " (default level is 1 if unspecified or 2 if used without a level)\n"
 #endif
-    " --inline={yes|no}         Control whether inlining is permitted (overrides functions declared as @inline)\n"
+    " --inline={yes|no}         Control whether inlining is permitted, including overriding @inline declarations\n"
     " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
 #ifdef USE_POLLY
     " --polly={yes|no}          Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)\n"


### PR DESCRIPTION
As discussed on Slack, the current wording may be confusing, as it may suggest that only explicit inlining is affected. The revised wording avoids the ambiguity. This commit includes an update of the manual.

(I've run `make check-whitespace` locally.)

cc @JeffBezanson @StefanKarpinski 