### PR TITLE
yak shaving, full deprecation style

### DIFF
--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -72,11 +72,10 @@ function convert(::Type{Diagonal}, A::AbstractTriangular)
 end
 
 function convert(::Type{Bidiagonal}, A::AbstractTriangular)
-    fA = full(A)
-    if fA == diagm(diag(A)) + diagm(diag(fA, 1), 1)
-        return Bidiagonal(diag(A), diag(fA,1), :U)
-    elseif fA == diagm(diag(A)) + diagm(diag(fA, -1), -1)
-        return Bidiagonal(diag(A), diag(fA,-1), :L)
+    if isbanded(A, 0, 1) # is upper bidiagonal
+        return Bidiagonal(diag(A), diag(A, 1), :U)
+    elseif isbanded(A, -1, 0) # is lower bidiagonal
+        return Bidiagonal(diag(A), diag(A, -1), :L)
     else
         throw(ArgumentError("matrix cannot be represented as Bidiagonal"))
     end
@@ -86,9 +85,8 @@ convert(::Type{SymTridiagonal}, A::AbstractTriangular) =
     convert(SymTridiagonal, convert(Tridiagonal, A))
 
 function convert(::Type{Tridiagonal}, A::AbstractTriangular)
-    fA = full(A)
-    if fA == diagm(diag(A)) + diagm(diag(fA, 1), 1) + diagm(diag(fA, -1), -1)
-        return Tridiagonal(diag(fA, -1), diag(A), diag(fA,1))
+    if isbanded(A, -1, 1) # is tridiagonal
+        return Tridiagonal(diag(A, -1), diag(A), diag(A, 1))
     else
         throw(ArgumentError("matrix cannot be represented as Tridiagonal"))
     end

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -2,7 +2,10 @@
 
 # Methods operating on different special matrix types
 
+
 # Interconversion between special matrix types
+
+# conversions from Diagonal to other special matrix types
 convert(::Type{Bidiagonal}, A::Diagonal) =
     Bidiagonal(A.diag, fill!(similar(A.diag, length(A.diag)-1), 0), :U)
 convert(::Type{SymTridiagonal}, A::Diagonal) =
@@ -11,86 +14,53 @@ convert(::Type{Tridiagonal}, A::Diagonal) =
     Tridiagonal(fill!(similar(A.diag, length(A.diag)-1), 0), A.diag,
                 fill!(similar(A.diag, length(A.diag)-1), 0))
 
-function convert(::Type{Diagonal}, A::Union{Bidiagonal, SymTridiagonal})
-    if !iszero(A.ev)
+# conversions from Bidiagonal to other special matrix types
+convert(::Type{Diagonal}, A::Bidiagonal) =
+    iszero(A.ev) ? Diagonal(A.dv) :
         throw(ArgumentError("matrix cannot be represented as Diagonal"))
-    end
-    Diagonal(A.dv)
-end
-
-function convert(::Type{SymTridiagonal}, A::Bidiagonal)
-    if !iszero(A.ev)
+convert(::Type{SymTridiagonal}, A::Bidiagonal) =
+    iszero(A.ev) ? SymTridiagonal(A.dv, A.ev) :
         throw(ArgumentError("matrix cannot be represented as SymTridiagonal"))
-    end
-    SymTridiagonal(A.dv, A.ev)
-end
-
-convert(::Type{Tridiagonal}, A::Bidiagonal{T}) where {T} =
+convert(::Type{Tridiagonal}, A::Bidiagonal) =
     Tridiagonal(A.uplo == 'U' ? fill!(similar(A.ev), 0) : A.ev, A.dv,
                 A.uplo == 'U' ? A.ev : fill!(similar(A.ev), 0))
 
-function convert(::Type{Bidiagonal}, A::SymTridiagonal)
-    if !iszero(A.ev)
-        throw(ArgumentError("matrix cannot be represented as Bidiagonal"))
-    end
-    Bidiagonal(A.dv, A.ev, :U)
-end
-
-function convert(::Type{Diagonal}, A::Tridiagonal)
-    if !(iszero(A.dl) && iszero(A.du))
+# conversions from SymTridiagonal to other special matrix types
+convert(::Type{Diagonal}, A::SymTridiagonal) =
+    iszero(A.ev) ? Diagonal(A.dv) :
         throw(ArgumentError("matrix cannot be represented as Diagonal"))
-    end
-    Diagonal(A.d)
-end
-
-function convert(::Type{Bidiagonal}, A::Tridiagonal)
-    if iszero(A.dl)
-        return Bidiagonal(A.d, A.du, :U)
-    elseif iszero(A.du)
-        return Bidiagonal(A.d, A.dl, :L)
-    else
+convert(::Type{Bidiagonal}, A::SymTridiagonal) =
+    iszero(A.ev) ? Bidiagonal(A.dv, A.ev, :U) :
         throw(ArgumentError("matrix cannot be represented as Bidiagonal"))
-    end
-end
-
-function convert(::Type{SymTridiagonal}, A::Tridiagonal)
-    if A.dl != A.du
-        throw(ArgumentError("matrix cannot be represented as SymTridiagonal"))
-    end
-    SymTridiagonal(A.d, A.dl)
-end
-
-function convert(::Type{Tridiagonal}, A::SymTridiagonal)
+convert(::Type{Tridiagonal}, A::SymTridiagonal) =
     Tridiagonal(copy(A.ev), A.dv, A.ev)
-end
 
-function convert(::Type{Diagonal}, A::AbstractTriangular)
-    if !isdiag(A)
+# conversions from Tridiagonal to other special matrix types
+convert(::Type{Diagonal}, A::Tridiagonal) =
+    iszero(A.dl) && iszero(A.du) ? Diagonal(A.d) :
         throw(ArgumentError("matrix cannot be represented as Diagonal"))
-    end
-    Diagonal(diag(A))
-end
-
-function convert(::Type{Bidiagonal}, A::AbstractTriangular)
-    if isbanded(A, 0, 1) # is upper bidiagonal
-        return Bidiagonal(diag(A), diag(A, 1), :U)
-    elseif isbanded(A, -1, 0) # is lower bidiagonal
-        return Bidiagonal(diag(A), diag(A, -1), :L)
-    else
+convert(::Type{Bidiagonal}, A::Tridiagonal) =
+    iszero(A.dl) ? Bidiagonal(A.d, A.du, :U) :
+    iszero(A.du) ? Bidiagonal(A.d, A.dl, :L) :
         throw(ArgumentError("matrix cannot be represented as Bidiagonal"))
-    end
-end
+convert(::Type{SymTridiagonal}, A::Tridiagonal) =
+    A.dl == A.du ? SymTridiagonal(A.d, A.dl) :
+        throw(ArgumentError("matrix cannot be represented as SymTridiagonal"))
 
+# conversions from AbstractTriangular to special matrix types
+convert(::Type{Diagonal}, A::AbstractTriangular) =
+    isdiag(A) ? Diagonal(diag(A)) :
+        throw(ArgumentError("matrix cannot be represented as Diagonal"))
+convert(::Type{Bidiagonal}, A::AbstractTriangular) =
+    isbanded(A, 0, 1) ? Bidiagonal(diag(A), diag(A,  1), :U) : # is upper bidiagonal
+    isbanded(A, -1, 0) ? Bidiagonal(diag(A), diag(A, -1), :L) : # is lower bidiagonal
+        throw(ArgumentError("matrix cannot be represented as Bidiagonal"))
 convert(::Type{SymTridiagonal}, A::AbstractTriangular) =
     convert(SymTridiagonal, convert(Tridiagonal, A))
-
-function convert(::Type{Tridiagonal}, A::AbstractTriangular)
-    if isbanded(A, -1, 1) # is tridiagonal
-        return Tridiagonal(diag(A, -1), diag(A), diag(A, 1))
-    else
+convert(::Type{Tridiagonal}, A::AbstractTriangular) =
+    isbanded(A, -1, 1) ? Tridiagonal(diag(A, -1), diag(A), diag(A, 1)) : # is tridiagonal
         throw(ArgumentError("matrix cannot be represented as Tridiagonal"))
-    end
-end
+
 
 # Constructs two method definitions taking into account (assumed) commutativity
 # e.g. @commutative f(x::S, y::T) where {S,T} = x+y is the same is defining

--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -380,3 +380,57 @@ end
     @test_throws ErrorException adjoint(rand(2,2,2,2))
     @test_throws ErrorException transpose(rand(2,2,2,2))
 end
+
+@testset "generic functions for checking whether matrices have banded structure" begin
+    using Base.LinAlg: isbanded
+    pentadiag = [1 2 3; 4 5 6; 7 8 9]
+    tridiag   = [1 2 0; 4 5 6; 0 8 9]
+    ubidiag   = [1 2 0; 0 5 6; 0 0 9]
+    lbidiag   = [1 0 0; 4 5 0; 0 8 9]
+    adiag     = [1 0 0; 0 5 0; 0 0 9]
+    @testset "istriu" begin
+        @test !istriu(pentadiag)
+        @test istriu(pentadiag, -2)
+        @test !istriu(tridiag)
+        @test istriu(tridiag, -1)
+        @test istriu(ubidiag)
+        @test !istriu(ubidiag, 1)
+        @test !istriu(lbidiag)
+        @test istriu(lbidiag, -1)
+        @test istriu(adiag)
+    end
+    @testset "istril" begin
+        @test !istril(pentadiag)
+        @test istril(pentadiag, 2)
+        @test !istril(tridiag)
+        @test istril(tridiag, 1)
+        @test !istril(ubidiag)
+        @test istril(ubidiag, 1)
+        @test istril(lbidiag)
+        @test !istril(lbidiag, -1)
+        @test istril(adiag)
+    end
+    @testset "isbanded" begin
+        @test isbanded(pentadiag, -2, 2)
+        @test !isbanded(pentadiag, -1, 2)
+        @test !isbanded(pentadiag, -2, 1)
+        @test isbanded(tridiag, -1, 1)
+        @test !isbanded(tridiag, 0, 1)
+        @test !isbanded(tridiag, -1, 0)
+        @test isbanded(ubidiag, 0, 1)
+        @test !isbanded(ubidiag, 1, 1)
+        @test !isbanded(ubidiag, 0, 0)
+        @test isbanded(lbidiag, -1, 0)
+        @test !isbanded(lbidiag, 0, 0)
+        @test !isbanded(lbidiag, -1, -1)
+        @test isbanded(adiag, 0, 0)
+        @test !isbanded(adiag, -1, -1)
+        @test !isbanded(adiag, 1, 1)
+    end
+    @testset "isdiag" begin
+        @test !isdiag(tridiag)
+        @test !isdiag(ubidiag)
+        @test !isdiag(lbidiag)
+        @test isdiag(adiag)
+    end
+end


### PR DESCRIPTION
**tl;dr**
This pull request eliminates a few uses of `full` from base/linalg/special.jl, via a minor yak shave. Ref. JuliaLang/LinearAlgebra.jl#229, JuliaLang/LinearAlgebra.jl#231, JuliaLang/julia#18850, and linked threads.

**details**
The eliminated uses of `full` were part of ad hoc checks for upper bidiagonal, lower bidiagonal, and tridiagonal band structure in conversions between structured and/or annotated matrix types.

The first commit generalizes existing and introduces new (not exported) generic functions that perform the necessary upper bidiagonal, lower bidiagonal, and tridiagonal band structure checks. Specifically, the first commit extends `istri[u|l](A)` to `istri[u|l](A, k)` matching `tri[u|l](A, k)`, implements `isbanded(A, kl, ku)` as a short child of `istri[u|l](A, k)`, (re)implements `isdiag(A)`, `isbidiag[u|l](A)`, and `istridiag(A)` as short children of `isbanded(A, ul, uk)`, and tests and documents all those functions.

The second commit eliminates the uses of `full` in question via the functions provided by the first commit.

The third commit then cleans up the complete set of surrounding structured and/or annotated matrix interconversion methods, at a pleasing LOC reduction.

Best!