### PR TITLE
Switch back to GCC 5 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,29 +5,37 @@ matrix:
   include:
     - os: linux
       env: ARCH="i686"
-      compiler: "g++ -m32"
+      compiler: "g++-5 -m32"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
             - libssl1.0.0
             - bar
             - time
-            - gcc-multilib
-            - g++-multilib
+            - binutils
+            - gcc-5
+            - g++-5
+            - gcc-5-multilib
+            - g++-5-multilib
             - make:i386
             - libssl-dev:i386
-            - gfortran
-            - gfortran-multilib
+            - gfortran-5
+            - gfortran-5-multilib
     - os: linux
       env: ARCH="x86_64"
-      compiler: "g++ -m64"
+      compiler: "g++-5 -m64"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
             - libssl1.0.0
             - bar
             - time
-            - gfortran
+            - g++-5
+            - gfortran-5
     - os: osx
       env: ARCH="x86_64"
       osx_image: xcode8
@@ -56,6 +64,12 @@ before_install:
     - make check-whitespace
     - if [ `uname` = "Linux" ]; then
         contrib/travis_fastfail.sh || exit 1;
+        mkdir -p $HOME/bin;
+        ln -s /usr/bin/gcc-5 $HOME/bin/gcc;
+        ln -s /usr/bin/g++-5 $HOME/bin/g++;
+        ln -s /usr/bin/gfortran-5 $HOME/bin/gfortran;
+        ln -s /usr/bin/gcc-5 $HOME/bin/x86_64-linux-gnu-gcc;
+        ln -s /usr/bin/g++-5 $HOME/bin/x86_64-linux-gnu-g++;
         gcc --version;
         BAR="bar -i 30";
         BUILDOPTS="-j5 VERBOSE=1 FORCE_ASSERTIONS=1 LLVM_ASSERTIONS=1";


### PR DESCRIPTION
Revert "Use default system compiler version on Travis (#22820)"

This reverts commit 2641555d35ee8c763c449811cbe9cacb8a38a7eb.

GCC 4.8 miscompiles our LLVM pass.

Let's see if this actually fix #23839

[av skip]
