### PR TITLE
Fix inferrability of split

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -578,3 +578,8 @@ end
 
 # ref issue #17351
 @test @inferred(flipdim(view([1 2; 3 4], :, 1), 1)) == [3, 1]
+
+let
+    s = view(reshape(1:6, 2, 3), 1:2, 1:2)
+    @test @inferred(s[2,2,1]) === 4
+end


### PR DESCRIPTION
Looks like we had failed to test the inferrability of `IteratorsMD.split`, and it had regressed as a consequence of the improvements that made inference guaranteed to converge (which basically prevent the "build up an output tuple" style of programming). So this makes two compile-time passes through the tuple but I don't see a better alternative.