### PR TITLE
Fix docstrings for mapfoldl and mapfoldr

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -60,8 +60,10 @@ mapfoldl(f, op, v0, itr) = mapfoldl_impl(f, op, v0, itr, start(itr))
 """
     mapfoldl(f, op, itr)
 
-Like `mapfoldl(f, op, v0, itr)`, but using the first element of `itr` as `v0`. In general,
-this cannot be used with empty collections (see `reduce(op, itr)`).
+Like `mapfoldl(f, op, v0, itr)`, but using the first element of `itr` to generate `v0`.
+Specifically, `mapfoldl(f, op, itr)` produces the same result as
+`mapfoldl(f, op, f(first(itr)), drop(itr, 1))`.
+In general, this cannot be used with empty collections (see [`reduce(op, itr)`](@ref)).
 """
 function mapfoldl(f, op, itr)
     i = start(itr)
@@ -90,7 +92,7 @@ foldl(op, v0, itr) = mapfoldl(identity, op, v0, itr)
     foldl(op, itr)
 
 Like `foldl(op, v0, itr)`, but using the first element of `itr` as `v0`. In general, this
-cannot be used with empty collections (see `reduce(op, itr)`).
+cannot be used with empty collections (see [`reduce(op, itr)`](@ref)).
 
 ```jldoctest
 julia> foldl(-, 2:5)
@@ -128,8 +130,10 @@ mapfoldr(f, op, v0, itr) = mapfoldr_impl(f, op, v0, itr, endof(itr))
 """
     mapfoldr(f, op, itr)
 
-Like `mapfoldr(f, op, v0, itr)`, but using the first element of `itr` as `v0`. In general,
-this cannot be used with empty collections (see `reduce(op, itr)`).
+Like `mapfoldr(f, op, v0, itr)`, but using the first element of `itr` to generate `v0`.
+Specifically, `mapfoldr(f, op, itr)` produces the same result as
+`mapfoldr(f, op, f(last(itr)), take(itr, length(itr)-1))`.
+In general, this cannot be used with empty collections (see [`reduce(op, itr)`](@ref)).
 """
 function mapfoldr(f, op, itr)
     i = endof(itr)
@@ -156,7 +160,7 @@ foldr(op, v0, itr) = mapfoldr(identity, op, v0, itr)
     foldr(op, itr)
 
 Like `foldr(op, v0, itr)`, but using the last element of `itr` as `v0`. In general, this
-cannot be used with empty collections (see `reduce(op, itr)`).
+cannot be used with empty collections (see [`reduce(op, itr)`](@ref)).
 
 ```jldoctest
 julia> foldr(-, 2:5)


### PR DESCRIPTION
Saying that the element will be used *as* `v0` is wrong, since `f` will be applied to it first.

I'm less certain about the "Specifically, ..." sentences, but I thought I'd throw them out there to see if folks thought they were helpful.