### PR TITLE
Backport of misc codegen changes

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6914,7 +6914,6 @@ extern "C" void jl_dump_llvm_inst_function(void *v)
 extern "C" void jl_dump_llvm_type(void *v)
 {
     llvm_dump((Type*)v);
-    putchar('\n');
 }
 
 extern "C" void jl_dump_llvm_module(void *v)

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -12,6 +12,7 @@ static inline void llvm_dump(llvm::Value *v)
 {
 #if JL_LLVM_VERSION >= 50000
     v->print(llvm::dbgs(), true);
+    putchar('\n');
 #else
     v->dump();
 #endif
@@ -24,6 +25,7 @@ static inline void llvm_dump(llvm::Type *v)
 #else
     v->dump();
 #endif
+    putchar('\n');
 }
 
 static inline void llvm_dump(llvm::Function *f)

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -70,16 +70,13 @@ using namespace llvm;
 
 RTDyldMemoryManager* createRTDyldMemoryManager(void);
 
-static Type *T_void;
 static IntegerType *T_uint32;
 static IntegerType *T_uint64;
 static IntegerType *T_size;
 static Type *T_psize;
-static Type *T_pvoidfunc;
 static Type *T_pjlvalue;
 void jl_init_jit(Type *T_pjlvalue_)
 {
-    T_void = Type::getVoidTy(jl_LLVMContext);
     T_uint32 = Type::getInt32Ty(jl_LLVMContext);
     T_uint64 = Type::getInt64Ty(jl_LLVMContext);
     if (sizeof(size_t) == 8)
@@ -87,7 +84,6 @@ void jl_init_jit(Type *T_pjlvalue_)
     else
         T_size = T_uint32;
     T_psize = PointerType::get(T_size, 0);
-    T_pvoidfunc = FunctionType::get(T_void, /*isVarArg*/false)->getPointerTo();
     T_pjlvalue = T_pjlvalue_;
 }
 


### PR DESCRIPTION
From #21849

1. Remove unused types in `jitlayers.h`
2. Fix 5.0 `llvm_dump` definitions.