### PR TITLE
RFC: Handle long tuples by wrapping in an iterator type

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -833,4 +833,39 @@ function next(itr::PartitionIterator, state)
     return resize!(v, i), state
 end
 
+# Iterator used to limit codegen and memory allocation for operations on long tuples
+struct TupleInterval{N,T}
+    t::NTuple{N,T}
+    start::Int
+    stop::Int
+end
+
+TupleInterval(t::NTuple{N,T}) where {N,T} = TupleInterval{N,T}(t, 1, length(t))
+TupleInterval(t::Tuple) = TupleInterval{length(t),Any}(t, 1, length(t))
+
+Base.iterator(t::Tuple) = TupleInterval(t)
+
+# Iterator traits
+Base.iteratoreltype(::Type{TupleInterval{N,T}}) where {N,T} = Base.HasEltype()
+Base.iteratoreltype(::Type{TupleInterval{N,Any}}) where N = Base.EltypeUnknown()
+Base.eltype(::Type{TupleInterval{N,T}}) where {N,T} = T
+
+Base.start(ti::TupleInterval) = ti.start
+Base.next(ti::TupleInterval, s) = ti.t[s], s+1
+Base.done(ti::TupleInterval, s) = s > ti.stop
+
+Base.length(ti::TupleInterval) = (l = ti.stop - ti.start + 1; max(0, l))
+Base.isempty(ti::TupleInterval) = ti.start > ti.stop
+
+Base.getindex(ti::TupleInterval, i::Int) = ti.t[i+ti.start-1]
+
+function Base.tail(ti::TupleInterval{N,T}) where {N,T}
+    ret = TupleInterval{N,T}(ti.t, ti.start+1, ti.stop)
+    isempty(ret) ? () : ret
+end
+function Base.front(ti::TupleInterval{N,T}) where {N,T}
+    ret = TupleInterval{N,T}(ti.t, ti.start, ti.stop-1)
+    isempty(ret) ? () : ret
+end
+
 end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -105,6 +105,44 @@ function _front(v, t...)
     (v, _front(t...)...)
 end
 
+"""
+    iter = Base.iterator(t::Tuple)
+
+Return an iterable object, where the iterator type depends on the length of `t`.
+For short tuples, `iterator(t)` returns `t`.
+Long tuples are wrapped in a `TupleIterator`, allow algorithms written for tuples
+to fall back to generic iterator interfaces.
+
+# Example
+
+Here's how `map` is defined for tuples:
+```
+map(f, t::Tuple) = _map(f, Base.iterator(t))
+# Implementation for short tuples
+_map(f, t::Tuple) = (f(t[1]), _map(f, Base.tail(t))...)
+_map(f, ::Tuple{}) = ()
+# Implementation for long tuples
+_map(f, iter) = (map(f, iter)...)
+```
+"""
+iterator(t::Tuple{}) = t
+iterator(t::Tuple{Any}) = t
+iterator(t::Tuple{Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+iterator(t::Tuple{Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any}) = t
+# See iterators.jl for arbitrary-length tuples
+
 ## mapping ##
 
 """


### PR DESCRIPTION
The aim of this PR is to make it easier to properly handle long tuples. This has been a recurring theme, and our inability to handle this problem currently stands in the way of supporting a nice (possibly-exportable) interface for tuples. I thought we were in better shape because of the new inliner, but that turns out to be only a portion of the battle, and that a datatype issue is probably the bigger barrier. (For some algorithms it might be easier if our tuple representation were more like lisp's `car/cdr` representation, but that would likely make it worse for other purposes, and some functions like `front` would not be helped by changing our representation this way.)

This (modest) PR demonstrates an obvious alternative solution, wrapping long tuples in a generic iterator type. In my mind, the biggest disadvantage of this solution is that we'll be forced to adopt an indirection pattern:
```julia
foo(t::Tuple) = _foo(iterator(t))
_foo(t::Tuple) = # the implementation for short tuples
_foo(iter) = (foo(iter)...)  # for long tuples we fall back on general iterables
# or maybe
_foo(iter::TupleIterator{N,T}) where {N,T} = (foo(iter)...)::NTuple{N,T}
```
where I'm assuming that `foo` make sense for both tuples and general iterables and that we already have an implementation for general iterables we can rely on.

This essentially codifies [`map`-style dispatch](https://github.com/JuliaLang/julia/blob/d012a5dbb4b7ef2ce745c36464c0a38a2adeb395/base/tuple.jl#L150-L167), but unifies `Any16` and `All16` into a single parametric type. At least for some purposes, this may leverage generic iterator machinery to save a bit of work, especially if we already want to have an implementation for general iterables anyway.

Just to show you that this works:
```julia
julia> t = (1:1000...);

julia> ltsqr(x) = x^2
ltsqr (generic function with 1 method)

julia> naivemap(f, t::Tuple) = (f(t[1]), naivemap(f, Base.tail(t))...)
naivemap (generic function with 1 method)

julia> naivemap(f, ::Tuple{}) = ()
naivemap (generic function with 2 methods)

julia> @time naivemap(ltsqr, t);
  4.961925 seconds (1.74 M allocations: 107.640 MiB, 0.57% gc time)

julia> @time naivemap(ltsqr, t);
  0.053179 seconds (875.61 k allocations: 36.446 MiB, 5.66% gc time)

julia> ltmap(f, t::Tuple) = _ltmap(f, Base.iterator(t))
ltmap (generic function with 1 method)

julia> _ltmap(f, t::Tuple) = (f(t[1]), _ltmap(f, Base.tail(t))...)
_ltmap (generic function with 1 method)

julia> _ltmap(f, ::Tuple{}) = ()
_ltmap (generic function with 2 methods)

julia> _ltmap(f, iter) = (map(f, iter)...)
_ltmap (generic function with 3 methods)

julia> @time ltmap(ltsqr, t);
  0.042729 seconds (29.34 k allocations: 1.607 MiB)

julia> @time ltmap(ltsqr, t);
  0.000062 seconds (990 allocations: 78.875 KiB)
```
So it's both faster to compile and faster to execute.

One feature of this that's a little bit fancier than strictly necessary is that it basically implements "SubArrays for tuples" (the `start/stop` fields in `TupleInterval`). Not including them might (now or someday) allow one to make the length of the output tuple inferrable. But I was trading that off against the possibility that people would end up using lispy tuple implementations on `TupleInterval` objects too, and with these fields it becomes possible to efficiently implement `tail`, `front`, `take`, `drop`, and `split`. The biggest downside is that you still don't get good performance if you use the lispy tuple implementation for large tuples, because you still have to incrementally create the *output* tuple. But I thought I'd float this version by people and see what folks think.

If you _don't_ have to create the output tuple, then thanks to the new Union-splitting this also results in a performance improvement. Here's a recursive `sum` operation:
```julia
julia> tsum(t) = tsum(0, t)
tsum (generic function with 1 method)                                                                                                                                                                                                        
                                                                                                                                                                                                                                             
julia> tsum(s, t) = tsum(s + t[1], Base.tail(t))
tsum (generic function with 2 methods)                                                                                                                                                                                                       
                                                                                                                                                                                                                                             
julia> tsum(s, ::Tuple{}) = s
tsum (generic function with 3 methods)
```
After warmup:
```julia
julia> t = (1:300...);

julia> y = Base.iterator(t);

julia> @time tsum(t)
  0.003135 seconds (1.12 k allocations: 746.984 KiB)
45150

julia> @time tsum(y)
  0.000187 seconds (5 allocations: 176 bytes)
45150
```
One concern though is that I get a StackOverflow if `t = (1:1000...)` (but not with plain tuples). Not quite sure why.
