### PR TITLE
correct posixly shell quoting

### DIFF
--- a/base/distributed/Distributed.jl
+++ b/base/distributed/Distributed.jl
@@ -14,7 +14,7 @@ using Base: Process, Semaphore, JLOptions, AnyDict, buffer_writes, wait_connecte
             VERSION_STRING, sync_begin, sync_add, sync_end, async_run_thunk,
             binding_module, notify_error, atexit, julia_exename, julia_cmd,
             AsyncGenerator, display_error, acquire, release, invokelatest, warn_once,
-            shell_escape, uv_error
+            shell_escape_posixly, uv_error
 
 # NOTE: clusterserialize.jl imports additional symbols from Base.Serializer for use
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -94,6 +94,8 @@ hash(x::AndCmds, h::UInt) = hash(x.a, hash(x.b, h))
 
 shell_escape(cmd::Cmd; special::AbstractString="") =
     shell_escape(cmd.exec..., special=special)
+shell_escape_posixly(cmd::Cmd) =
+    shell_escape_posixly(cmd.exec...)
 
 function show(io::IO, cmd::Cmd)
     print_env = cmd.env !== nothing


### PR DESCRIPTION
Ensures that `addprocs` arguments will be passed through a posix shell correctly, (including those with shell-metacharacters such as being added in #21849 for `-C`, but also weird cases like `--` and files named `\r`).

fix #10120