### PR TITLE
eliminate full from test/sparse/[spqr|cholmod|sparse].jl

### DIFF
--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -728,20 +728,20 @@ for F in (cholfact(AtA), cholfact(AtA, perm=1:5), ldltfact(AtA), ldltfact(AtA, p
 
         #Test update
         F11 = CHOLMOD.lowrankupdate(F1, C)
-        @test full(sparse(F11)) ≈ AtA+C*C'
+        @test Array(sparse(F11)) ≈ AtA+C*C'
         @test F11\ones(5) ≈ B
         #Make sure we get back the same factor again
         F10 = CHOLMOD.lowrankdowndate(F11, C)
-        @test full(sparse(F10)) ≈ AtA
+        @test Array(sparse(F10)) ≈ AtA
         @test F10\ones(5) ≈ B0
 
         #Test in-place update
         CHOLMOD.lowrankupdate!(F1, C)
-        @test full(sparse(F1)) ≈ AtA+C*C'
+        @test Array(sparse(F1)) ≈ AtA+C*C'
         @test F1\ones(5) ≈ B
         #Test in-place downdate
         CHOLMOD.lowrankdowndate!(F1, C)
-        @test full(sparse(F1)) ≈ AtA
+        @test Array(sparse(F1)) ≈ AtA
         @test F1\ones(5) ≈ B0
 
         @test C == Ctest    #Make sure C didn't change

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -592,7 +592,7 @@ end
 
         @test R == real.(S) == real(S)
         @test I == imag.(S) == imag(S)
-        @test conj(full(S)) == conj.(S) == conj(S)
+        @test conj(Array(S)) == conj.(S) == conj(S)
         @test real.(spR) == R
         @test nnz(imag.(spR)) == nnz(imag(spR)) == 0
         @test abs.(S) == abs.(D)

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -36,7 +36,7 @@ nn = 100
         @test (eye(m)*Q)*Q' ≈ eye(m)
 
         # test that Q'Pl*A*Pr = R
-        R0 = Q'*full(A[F[:prow], F[:pcol]])
+        R0 = Q'*Array(A[F[:prow], F[:pcol]])
         @test R0[1:n, :] ≈ F[:R]
         @test norm(R0[n + 1:end, :], 1) < 1e-12
 
@@ -70,7 +70,7 @@ end
     A = sprandn(m, 5, 0.9)*sprandn(5, n, 0.9)
     b = randn(m)
     xs = A\b
-    xd = full(A)\b
+    xd = Array(A)\b
 
     # check that basic solution has more zeros
     @test count(!iszero, xs) < count(!iszero, xd)


### PR DESCRIPTION
Another small step towards deprecation of `full`. Ref. JuliaLang/LinearAlgebra.jl#229, JuliaLang/LinearAlgebra.jl#231, JuliaLang/julia#18850, and linked threads. Best!