### PR TITLE
eliminate full from test/math.jl and test/linalg/uniformscaling.jl.

### DIFF
--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -110,10 +110,10 @@ let
                 else
                     T = LowerTriangular(view(randn(3,3), 1:3, 1:3))
                 end
-                @test @inferred(T + J) == full(T) + J
-                @test @inferred(J + T) == J + full(T)
-                @test @inferred(T - J) == full(T) - J
-                @test @inferred(J - T) == J - full(T)
+                @test @inferred(T + J) == Array(T) + J
+                @test @inferred(J + T) == J + Array(T)
+                @test @inferred(T - J) == Array(T) - J
+                @test @inferred(J - T) == J - Array(T)
                 @test @inferred(T\I) == inv(T)
 
                 if isa(A, Array)
@@ -121,10 +121,10 @@ let
                 else
                     T = LinAlg.UnitLowerTriangular(view(randn(3,3), 1:3, 1:3))
                 end
-                @test @inferred(T + J) == full(T) + J
-                @test @inferred(J + T) == J + full(T)
-                @test @inferred(T - J) == full(T) - J
-                @test @inferred(J - T) == J - full(T)
+                @test @inferred(T + J) == Array(T) + J
+                @test @inferred(J + T) == J + Array(T)
+                @test @inferred(T - J) == Array(T) - J
+                @test @inferred(J - T) == J - Array(T)
                 @test @inferred(T\I) == inv(T)
 
                 if isa(A, Array)
@@ -132,10 +132,10 @@ let
                 else
                     T = UpperTriangular(view(randn(3,3), 1:3, 1:3))
                 end
-                @test @inferred(T + J) == full(T) + J
-                @test @inferred(J + T) == J + full(T)
-                @test @inferred(T - J) == full(T) - J
-                @test @inferred(J - T) == J - full(T)
+                @test @inferred(T + J) == Array(T) + J
+                @test @inferred(J + T) == J + Array(T)
+                @test @inferred(T - J) == Array(T) - J
+                @test @inferred(J - T) == J - Array(T)
                 @test @inferred(T\I) == inv(T)
 
                 if isa(A, Array)
@@ -143,10 +143,10 @@ let
                 else
                     T = LinAlg.UnitUpperTriangular(view(randn(3,3), 1:3, 1:3))
                 end
-                @test @inferred(T + J) == full(T) + J
-                @test @inferred(J + T) == J + full(T)
-                @test @inferred(T - J) == full(T) - J
-                @test @inferred(J - T) == J - full(T)
+                @test @inferred(T + J) == Array(T) + J
+                @test @inferred(J + T) == J + Array(T)
+                @test @inferred(T - J) == Array(T) - J
+                @test @inferred(J - T) == J - Array(T)
                 @test @inferred(T\I) == inv(T)
 
                 @test @inferred(I\A) == A

--- a/test/math.jl
+++ b/test/math.jl
@@ -294,11 +294,11 @@ end
     TAA = rand(2,2)
     TAA = (TAA + TAA.')/2.
     STAA = Symmetric(TAA)
-    @test full(atanh.(STAA)) == atanh.(TAA)
-    @test full(asinh.(STAA)) == asinh.(TAA)
-    @test full(acosh.(STAA+Symmetric(ones(TAA)))) == acosh.(TAA+ones(TAA))
-    @test full(acsch.(STAA+Symmetric(ones(TAA)))) == acsch.(TAA+ones(TAA))
-    @test full(acoth.(STAA+Symmetric(ones(TAA)))) == acoth.(TAA+ones(TAA))
+    @test Array(atanh.(STAA)) == atanh.(TAA)
+    @test Array(asinh.(STAA)) == asinh.(TAA)
+    @test Array(acosh.(STAA+Symmetric(ones(TAA)))) == acosh.(TAA+ones(TAA))
+    @test Array(acsch.(STAA+Symmetric(ones(TAA)))) == acsch.(TAA+ones(TAA))
+    @test Array(acoth.(STAA+Symmetric(ones(TAA)))) == acoth.(TAA+ones(TAA))
 end
 
 @testset "check exp2(::Integer) matches exp2(::Float)" begin


### PR DESCRIPTION
Another small step towards deprecation of `full`. Ref. JuliaLang/LinearAlgebra.jl#229, JuliaLang/LinearAlgebra.jl#231, JuliaLang/julia#18850, and linked threads. Best!