### PR TITLE
eliminate full from test/linalg/[dense|diagonal.jl]

### DIFF
--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -134,12 +134,12 @@ bimg  = randn(n,2)/2
         @test factorize(A) == Bidiagonal(d,e,:U)
         if eltya <: Real
             A = diagm(d) + diagm(e,1) + diagm(e,-1)
-            @test full(factorize(A)) ≈ full(factorize(SymTridiagonal(d,e)))
+            @test Matrix(factorize(A)) ≈ Matrix(factorize(SymTridiagonal(d,e)))
             A = diagm(d) + diagm(e,1) + diagm(e,-1) + diagm(f,2) + diagm(f,-2)
             @test inv(factorize(A)) ≈ inv(factorize(Symmetric(A)))
         end
         A = diagm(d) + diagm(e,1) + diagm(e2,-1)
-        @test full(factorize(A)) ≈ full(factorize(Tridiagonal(e2,d,e)))
+        @test Matrix(factorize(A)) ≈ Matrix(factorize(Tridiagonal(e2,d,e)))
         A = diagm(d) + diagm(e,1) + diagm(f,2)
         @test factorize(A) == UpperTriangular(A)
     end

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -152,19 +152,19 @@ srand(1)
 
         # Performance specialisations for A*_mul_B!
         vvv = similar(vv)
-        @test (r = full(D) * vv   ; A_mul_B!(vvv, D, vv)  ≈ r ≈ vvv)
-        @test (r = full(D)' * vv  ; Ac_mul_B!(vvv, D, vv) ≈ r ≈ vvv)
-        @test (r = full(D).' * vv ; At_mul_B!(vvv, D, vv) ≈ r ≈ vvv)
+        @test (r = Matrix(D) * vv   ; A_mul_B!(vvv, D, vv)  ≈ r ≈ vvv)
+        @test (r = Matrix(D)' * vv  ; Ac_mul_B!(vvv, D, vv) ≈ r ≈ vvv)
+        @test (r = Matrix(D).' * vv ; At_mul_B!(vvv, D, vv) ≈ r ≈ vvv)
 
         UUU = similar(UU)
-        @test (r = full(D) * UU   ; A_mul_B!(UUU, D, UU) ≈ r ≈ UUU)
-        @test (r = full(D)' * UU  ; Ac_mul_B!(UUU, D, UU) ≈ r ≈ UUU)
-        @test (r = full(D).' * UU ; At_mul_B!(UUU, D, UU) ≈ r ≈ UUU)
+        @test (r = Matrix(D) * UU   ; A_mul_B!(UUU, D, UU) ≈ r ≈ UUU)
+        @test (r = Matrix(D)' * UU  ; Ac_mul_B!(UUU, D, UU) ≈ r ≈ UUU)
+        @test (r = Matrix(D).' * UU ; At_mul_B!(UUU, D, UU) ≈ r ≈ UUU)
 
         # make sure that A_mul_B{c,t}! works with B as a Diagonal
         VV = Array(D)
         DD = copy(D)
-        r  = VV * full(D)
+        r  = VV * Matrix(D)
         @test Array(A_mul_B!(VV, DD)) ≈ r ≈ Array(D)*Array(D)
         DD = copy(D)
         r  = VV * (Array(D).')


### PR DESCRIPTION
Another small step towards deprecation of `full`. Ref. JuliaLang/LinearAlgebra.jl#229, JuliaLang/LinearAlgebra.jl#231, JuliaLang/julia#18850, and linked threads. Best!