### PR TITLE
Add patch set for LLVM 5.0

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -482,6 +482,14 @@ $(eval $(call LLVM_PATCH,llvm-D33129-scevexpander-non-integral)) # Remove for 5.
 $(eval $(call LLVM_PATCH,llvm-Yet-another-fix))
 $(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-loadcse-addrspace_4.0))
+else ifeq ($(LLVM_VER_SHORT),5.0)
+# Cygwin and openSUSE still use win32-threads mingw, https://llvm.org/bugs/show_bug.cgi?id=26365
+$(eval $(call LLVM_PATCH,llvm-5.0.0_threads))
+$(eval $(call LLVM_PATCH,llvm-3.9.0_D27296-libssp))
+$(eval $(call LLVM_PATCH,llvm-D27629-AArch64-large_model_4.0))
+$(eval $(call LLVM_PATCH,llvm-loadcse-addrspace_5.0))
+$(eval $(call LLVM_PATCH,llvm-D34078-vectorize-fdiv))
+$(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 endif # LLVM_VER
 
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_PATCH_PREV)

--- a/deps/patches/llvm-5.0.0_threads.patch
+++ b/deps/patches/llvm-5.0.0_threads.patch
@@ -1,0 +1,2072 @@
+From 069fcb1fd3871ea14c8567763226464d605a90f3 Mon Sep 17 00:00:00 2001
+From: Alex Crichton <alex@alexcrichton.com>
+Date: Thu, 28 Jan 2016 20:44:50 -0800
+Subject: [PATCH] Don't compile usage of std::thread
+
+As of the time of this writing it's not actually used anywhere meaningfullly
+throughout the LLVM repo that we need, and it unfortunately uses `std::thread`
+which isn't available in mingw-w64 toolchains with the win32 threading model
+(the one that we use).
+
+The change made to achive this was to just always use the single-threaded
+support in `include/llvm/Support/thread.h`, and hopefuly that'll be enough...
+
+For reference, the upstream LLVM bug has been reported [1]
+
+[1]: https://llvm.org/bugs/show_bug.cgi?id=26365
+---
+ include/llvm/Support/ThreadPool.h         |   4 +
+ include/llvm/Support/thread.h             |   2 +-
+ lib/CodeGen/ParallelCG.cpp                |   2 +
+ lib/LTO/LTO.cpp                           |   6 +-
+ lib/LTO/LTOBackend.cpp                    |   2 +
+ lib/LTO/ThinLTOCodeGenerator.cpp          |   6 +-
+ lib/Support/ThreadPool.cpp                |   6 +-
+ test/CMakeLists.txt                       |   1 -
+ tools/lli/CMakeLists.txt                  |   4 -
+ tools/lli/ChildTarget/CMakeLists.txt      |  13 --
+ tools/lli/ChildTarget/ChildTarget.cpp     |  67 -------
+ tools/lli/ChildTarget/LLVMBuild.txt       |  21 ---
+ tools/lli/LLVMBuild.txt                   |   3 -
+ tools/lli/OrcLazyJIT.cpp                  |   2 +
+ tools/lli/OrcLazyJIT.h                    | 201 ---------------------
+ tools/lli/RemoteJITUtils.h                | 152 ----------------
+ tools/lli/lli.cpp                         |   7 +
+ tools/llvm-cov/CodeCoverage.cpp           |   4 +
+ tools/llvm-cov/CoverageExporterJson.cpp   |   2 +
+ tools/llvm-cov/CoverageFilters.cpp        |   2 +
+ tools/llvm-cov/CoverageFilters.h          | 127 -------------
+ tools/llvm-cov/CoverageReport.cpp         |   2 +
+ tools/llvm-cov/CoverageReport.h           |  53 ------
+ tools/llvm-cov/CoverageSummaryInfo.cpp    |   2 +
+ tools/llvm-cov/CoverageSummaryInfo.h      | 178 ------------------
+ tools/llvm-cov/CoverageViewOptions.h      |  68 -------
+ tools/llvm-cov/RenderingSupport.h         |  61 -------
+ tools/llvm-cov/SourceCoverageView.cpp     |   2 +
+ tools/llvm-cov/SourceCoverageView.h       | 289 ------------------------------
+ tools/llvm-cov/SourceCoverageViewHTML.cpp |   3 +
+ tools/llvm-cov/SourceCoverageViewHTML.h   |  96 ----------
+ tools/llvm-cov/SourceCoverageViewText.cpp |   3 +
+ tools/llvm-cov/SourceCoverageViewText.h   |  89 ---------
+ tools/llvm-cov/TestingSupport.cpp         |   2 +
+ tools/llvm-cov/gcov.cpp                   |   2 +
+ tools/llvm-cov/llvm-cov.cpp               |   4 +
+ tools/llvm-profdata/llvm-profdata.cpp     |   5 +
+ tools/sancov/sancov.cc                    |   5 +
+ unittests/Support/ThreadPool.cpp          |   4 +
+ 39 files changed, 73 insertions(+), 1429 deletions(-)
+ delete mode 100644 tools/lli/ChildTarget/CMakeLists.txt
+ delete mode 100644 tools/lli/ChildTarget/ChildTarget.cpp
+ delete mode 100644 tools/lli/ChildTarget/LLVMBuild.txt
+ delete mode 100644 tools/lli/OrcLazyJIT.h
+ delete mode 100644 tools/lli/RemoteJITUtils.h
+ delete mode 100644 tools/llvm-cov/CoverageFilters.h
+ delete mode 100644 tools/llvm-cov/CoverageReport.h
+ delete mode 100644 tools/llvm-cov/CoverageSummaryInfo.h
+ delete mode 100644 tools/llvm-cov/CoverageViewOptions.h
+ delete mode 100644 tools/llvm-cov/RenderingSupport.h
+ delete mode 100644 tools/llvm-cov/SourceCoverageView.h
+ delete mode 100644 tools/llvm-cov/SourceCoverageViewHTML.h
+ delete mode 100644 tools/llvm-cov/SourceCoverageViewText.h
+
+diff --git a/include/llvm/Support/ThreadPool.h b/include/llvm/Support/ThreadPool.h
+index 9ada946c6da..c62e5917a2a 100644
+--- a/include/llvm/Support/ThreadPool.h
++++ b/include/llvm/Support/ThreadPool.h
+@@ -16,6 +16,8 @@
+ 
+ #include "llvm/Support/thread.h"
+ 
++# if 0
++
+ #include <future>
+ 
+ #include <atomic>
+@@ -97,4 +99,6 @@ private:
+ };
+ }
+ 
++# endif
++
+ #endif // LLVM_SUPPORT_THREAD_POOL_H
+diff --git a/include/llvm/Support/thread.h b/include/llvm/Support/thread.h
+index 787a513d601..6668edb1887 100644
+--- a/include/llvm/Support/thread.h
++++ b/include/llvm/Support/thread.h
+@@ -19,7 +19,7 @@
+ 
+ #include "llvm/Config/llvm-config.h"
+ 
+-#if LLVM_ENABLE_THREADS
++#if LLVM_ENABLE_THREADS && 0
+ 
+ #include <thread>
+ 
+diff --git a/lib/CodeGen/ParallelCG.cpp b/lib/CodeGen/ParallelCG.cpp
+index 50dd44fa659..e91898e0fa7 100644
+--- a/lib/CodeGen/ParallelCG.cpp
++++ b/lib/CodeGen/ParallelCG.cpp
+@@ -50,6 +50,7 @@ std::unique_ptr<Module> llvm::splitCodeGen(
+     return M;
+   }
+ 
++#if 0
+   // Create ThreadPool in nested scope so that threads will be joined
+   // on destruction.
+   {
+@@ -96,5 +97,6 @@ std::unique_ptr<Module> llvm::splitCodeGen(
+         PreserveLocals);
+   }
+ 
++#endif
+   return {};
+ }
+diff --git a/lib/LTO/LTO.cpp b/lib/LTO/LTO.cpp
+index 19973946ac5..fbb899c88f7 100644
+--- a/lib/LTO/LTO.cpp
++++ b/lib/LTO/LTO.cpp
+@@ -808,7 +808,6 @@ public:
+ 
+ namespace {
+ class InProcessThinBackend : public ThinBackendProc {
+-  ThreadPool BackendThreadPool;
+   AddStreamFn AddStream;
+   NativeObjectCache Cache;
+   TypeIdSummariesByGuidTy TypeIdSummariesByGuid;
+@@ -823,7 +822,6 @@ public:
+       const StringMap<GVSummaryMapTy> &ModuleToDefinedGVSummaries,
+       AddStreamFn AddStream, NativeObjectCache Cache)
+       : ThinBackendProc(Conf, CombinedIndex, ModuleToDefinedGVSummaries),
+-        BackendThreadPool(ThinLTOParallelismLevel),
+         AddStream(std::move(AddStream)), Cache(std::move(Cache)) {
+     // Create a mapping from type identifier GUIDs to type identifier summaries.
+     // This allows backends to use the type identifier GUIDs stored in the
+@@ -877,6 +875,7 @@ public:
+       const FunctionImporter::ExportSetTy &ExportList,
+       const std::map<GlobalValue::GUID, GlobalValue::LinkageTypes> &ResolvedODR,
+       MapVector<StringRef, BitcodeModule> &ModuleMap) override {
++#if 0
+     StringRef ModulePath = BM.getModuleIdentifier();
+     assert(ModuleToDefinedGVSummaries.count(ModulePath));
+     const GVSummaryMapTy &DefinedGlobals =
+@@ -904,11 +903,14 @@ public:
+         BM, std::ref(CombinedIndex), std::ref(ImportList), std::ref(ExportList),
+         std::ref(ResolvedODR), std::ref(DefinedGlobals), std::ref(ModuleMap),
+         std::ref(TypeIdSummariesByGuid));
++#endif
+     return Error::success();
+   }
+ 
+   Error wait() override {
++#if 0
+     BackendThreadPool.wait();
++#endif
+     if (Err)
+       return std::move(*Err);
+     else
+diff --git a/lib/LTO/LTOBackend.cpp b/lib/LTO/LTOBackend.cpp
+index 3f72e446cdf..fad7c163959 100644
+--- a/lib/LTO/LTOBackend.cpp
++++ b/lib/LTO/LTOBackend.cpp
+@@ -283,6 +283,7 @@ void codegen(Config &Conf, TargetMachine *TM, AddStreamFn AddStream,
+ void splitCodeGen(Config &C, TargetMachine *TM, AddStreamFn AddStream,
+                   unsigned ParallelCodeGenParallelismLevel,
+                   std::unique_ptr<Module> Mod) {
++#if 0
+   ThreadPool CodegenThreadPool(ParallelCodeGenParallelismLevel);
+   unsigned ThreadCount = 0;
+   const Target *T = &TM->getTarget();
+@@ -326,6 +327,7 @@ void splitCodeGen(Config &C, TargetMachine *TM, AddStreamFn AddStream,
+   // variables, we need to wait for the worker threads to terminate before we
+   // can leave the function scope.
+   CodegenThreadPool.wait();
++#endif
+ }
+ 
+ Expected<const Target *> initAndLookupTarget(Config &C, Module &Mod) {
+diff --git a/lib/LTO/ThinLTOCodeGenerator.cpp b/lib/LTO/ThinLTOCodeGenerator.cpp
+index 1efd481b246..6b7b525f010 100644
+--- a/lib/LTO/ThinLTOCodeGenerator.cpp
++++ b/lib/LTO/ThinLTOCodeGenerator.cpp
+@@ -68,8 +68,8 @@ extern cl::opt<bool> LTOStripInvalidDebugInfo;
+ 
+ namespace {
+ 
+-static cl::opt<int>
+-    ThreadCount("threads", cl::init(llvm::heavyweight_hardware_concurrency()));
++static cl::opt<int> ThreadCount("threads",
++                                cl::init(1));
+ 
+ // Simple helper to save temporary files for debug.
+ static void saveTempBitcode(const Module &TheModule, StringRef TempDir,
+@@ -832,6 +832,7 @@ static std::string writeGeneratedObject(int count, StringRef CacheEntryPath,
+ 
+ // Main entry point for the ThinLTO processing
+ void ThinLTOCodeGenerator::run() {
++#if 0
+   // Prepare the resulting object vector
+   assert(ProducedBinaries.empty() && "The generator should not be reused");
+   if (SavedObjectsDirectoryPath.empty())
+@@ -1052,4 +1053,5 @@ void ThinLTOCodeGenerator::run() {
+   if (llvm::AreStatisticsEnabled())
+     llvm::PrintStatistics();
+   reportAndResetTimings();
++#endif
+ }
+diff --git a/lib/Support/ThreadPool.cpp b/lib/Support/ThreadPool.cpp
+index 22b7550d497..985403442e4 100644
+--- a/lib/Support/ThreadPool.cpp
++++ b/lib/Support/ThreadPool.cpp
+@@ -11,6 +11,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++#if 0
++
+ #include "llvm/Support/ThreadPool.h"
+ 
+ #include "llvm/Config/llvm-config.h"
+@@ -18,7 +20,7 @@
+ 
+ using namespace llvm;
+ 
+-#if LLVM_ENABLE_THREADS
++#if LLVM_ENABLE_THREADS && 0
+ 
+ // Default to std::thread::hardware_concurrency
+ ThreadPool::ThreadPool() : ThreadPool(std::thread::hardware_concurrency()) {}
+@@ -143,3 +145,5 @@ ThreadPool::~ThreadPool() {
+ }
+ 
+ #endif
++
++#endif
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 124f0c72fd7..853adf6cf8a 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -35,7 +35,6 @@ set(LLVM_TEST_DEPENDS
+           count
+           llc
+           lli
+-          lli-child-target
+           llvm-ar
+           llvm-as
+           llvm-bcanalyzer
+diff --git a/tools/lli/CMakeLists.txt b/tools/lli/CMakeLists.txt
+index f02e19313b7..ca2e82abcd0 100644
+--- a/tools/lli/CMakeLists.txt
++++ b/tools/lli/CMakeLists.txt
+@@ -1,7 +1,3 @@
+-if ( LLVM_INCLUDE_UTILS )
+-  add_subdirectory(ChildTarget)
+-endif()
+-
+ set(LLVM_LINK_COMPONENTS
+   CodeGen
+   Core
+diff --git a/tools/lli/ChildTarget/CMakeLists.txt b/tools/lli/ChildTarget/CMakeLists.txt
+deleted file mode 100644
+index f08ce57c295..00000000000
+--- a/tools/lli/ChildTarget/CMakeLists.txt
++++ /dev/null
+@@ -1,13 +0,0 @@
+-set(LLVM_LINK_COMPONENTS
+-  OrcJIT
+-  RuntimeDyld
+-  Support
+-  )
+-
+-add_llvm_utility(lli-child-target
+-  ChildTarget.cpp
+-
+-  DEPENDS
+-  intrinsics_gen
+-)
+-
+diff --git a/tools/lli/ChildTarget/ChildTarget.cpp b/tools/lli/ChildTarget/ChildTarget.cpp
+deleted file mode 100644
+index 77b1d47a946..00000000000
+--- a/tools/lli/ChildTarget/ChildTarget.cpp
++++ /dev/null
+@@ -1,67 +0,0 @@
+-#include "llvm/ExecutionEngine/Orc/OrcABISupport.h"
+-#include "llvm/ExecutionEngine/Orc/OrcRemoteTargetServer.h"
+-#include "llvm/Support/Debug.h"
+-#include "llvm/Support/DynamicLibrary.h"
+-#include "llvm/Support/Process.h"
+-#include <sstream>
+-
+-#include "../RemoteJITUtils.h"
+-
+-using namespace llvm;
+-using namespace llvm::orc;
+-using namespace llvm::sys;
+-
+-#ifdef __x86_64__
+-typedef OrcX86_64_SysV HostOrcArch;
+-#else
+-typedef OrcGenericABI HostOrcArch;
+-#endif
+-
+-ExitOnError ExitOnErr;
+-
+-int main(int argc, char *argv[]) {
+-
+-  if (argc != 3) {
+-    errs() << "Usage: " << argv[0] << " <input fd> <output fd>\n";
+-    return 1;
+-  }
+-
+-  ExitOnErr.setBanner(std::string(argv[0]) + ":");
+-
+-  int InFD;
+-  int OutFD;
+-  {
+-    std::istringstream InFDStream(argv[1]), OutFDStream(argv[2]);
+-    InFDStream >> InFD;
+-    OutFDStream >> OutFD;
+-  }
+-
+-  if (sys::DynamicLibrary::LoadLibraryPermanently(nullptr)) {
+-    errs() << "Error loading program symbols.\n";
+-    return 1;
+-  }
+-
+-  auto SymbolLookup = [](const std::string &Name) {
+-    return RTDyldMemoryManager::getSymbolAddressInProcess(Name);
+-  };
+-
+-  auto RegisterEHFrames = [](uint8_t *Addr, uint32_t Size) {
+-    RTDyldMemoryManager::registerEHFramesInProcess(Addr, Size);
+-  };
+-
+-  auto DeregisterEHFrames = [](uint8_t *Addr, uint32_t Size) {
+-    RTDyldMemoryManager::deregisterEHFramesInProcess(Addr, Size);
+-  };
+-
+-  FDRawChannel Channel(InFD, OutFD);
+-  typedef remote::OrcRemoteTargetServer<FDRawChannel, HostOrcArch> JITServer;
+-  JITServer Server(Channel, SymbolLookup, RegisterEHFrames, DeregisterEHFrames);
+-
+-  while (!Server.receivedTerminate())
+-    ExitOnErr(Server.handleOne());
+-
+-  close(InFD);
+-  close(OutFD);
+-
+-  return 0;
+-}
+diff --git a/tools/lli/ChildTarget/LLVMBuild.txt b/tools/lli/ChildTarget/LLVMBuild.txt
+deleted file mode 100644
+index daf6df11324..00000000000
+--- a/tools/lli/ChildTarget/LLVMBuild.txt
++++ /dev/null
+@@ -1,21 +0,0 @@
+-;===- ./tools/lli/ChildTarget/LLVMBuild.txt --------------------*- Conf -*--===;
+-;
+-;                     The LLVM Compiler Infrastructure
+-;
+-; This file is distributed under the University of Illinois Open Source
+-; License. See LICENSE.TXT for details.
+-;
+-;===------------------------------------------------------------------------===;
+-;
+-; This is an LLVMBuild description file for the components in this subdirectory.
+-;
+-; For more information on the LLVMBuild system, please see:
+-;
+-;   http://llvm.org/docs/LLVMBuild.html
+-;
+-;===------------------------------------------------------------------------===;
+-
+-[component_0]
+-type = Tool
+-name = lli-child-target
+-parent = lli
+diff --git a/tools/lli/LLVMBuild.txt b/tools/lli/LLVMBuild.txt
+index 9d889bf4c2e..47385048e08 100644
+--- a/tools/lli/LLVMBuild.txt
++++ b/tools/lli/LLVMBuild.txt
+@@ -15,9 +15,6 @@
+ ;
+ ;===------------------------------------------------------------------------===;
+ 
+-[common]
+-subdirectories = ChildTarget
+-
+ [component_0]
+ type = Tool
+ name = lli
+diff --git a/tools/lli/OrcLazyJIT.cpp b/tools/lli/OrcLazyJIT.cpp
+index f1a752e0790..adc0e0db3f8 100644
+--- a/tools/lli/OrcLazyJIT.cpp
++++ b/tools/lli/OrcLazyJIT.cpp
+@@ -1,4 +1,5 @@
+ //===- OrcLazyJIT.cpp - Basic Orc-based JIT for lazy execution ------------===//
++#if 0
+ //
+ //                     The LLVM Compiler Infrastructure
+ //
+@@ -164,3 +165,4 @@ int llvm::runOrcLazyJIT(std::vector<std::unique_ptr<Module>> Ms,
+ 
+   return 1;
+ }
++#endif
+diff --git a/tools/lli/OrcLazyJIT.h b/tools/lli/OrcLazyJIT.h
+deleted file mode 100644
+index 47a2acc4d7e..00000000000
+--- a/tools/lli/OrcLazyJIT.h
++++ /dev/null
+@@ -1,201 +0,0 @@
+-//===- OrcLazyJIT.h - Basic Orc-based JIT for lazy execution ----*- C++ -*-===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-//
+-// Simple Orc-based JIT. Uses the compile-on-demand layer to break up and
+-// lazily compile modules.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_TOOLS_LLI_ORCLAZYJIT_H
+-#define LLVM_TOOLS_LLI_ORCLAZYJIT_H
+-
+-#include "llvm/ADT/STLExtras.h"
+-#include "llvm/ADT/Twine.h"
+-#include "llvm/ExecutionEngine/JITSymbol.h"
+-#include "llvm/ExecutionEngine/Orc/CompileOnDemandLayer.h"
+-#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
+-#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+-#include "llvm/ExecutionEngine/Orc/IndirectionUtils.h"
+-#include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
+-#include "llvm/ExecutionEngine/Orc/IRTransformLayer.h"
+-#include "llvm/ExecutionEngine/Orc/LambdaResolver.h"
+-#include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+-#include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
+-#include "llvm/ExecutionEngine/SectionMemoryManager.h"
+-#include "llvm/IR/DataLayout.h"
+-#include "llvm/IR/GlobalValue.h"
+-#include "llvm/IR/Mangler.h"
+-#include "llvm/IR/Module.h"
+-#include "llvm/Support/raw_ostream.h"
+-#include "llvm/Target/TargetMachine.h"
+-#include <algorithm>
+-#include <functional>
+-#include <memory>
+-#include <set>
+-#include <string>
+-#include <vector>
+-
+-namespace llvm {
+-
+-class OrcLazyJIT {
+-public:
+-
+-  using CompileCallbackMgr = orc::JITCompileCallbackManager;
+-  using ObjLayerT = orc::RTDyldObjectLinkingLayer;
+-  using CompileLayerT = orc::IRCompileLayer<ObjLayerT, orc::SimpleCompiler>;
+-  using TransformFtor =
+-          std::function<std::shared_ptr<Module>(std::shared_ptr<Module>)>;
+-  using IRDumpLayerT = orc::IRTransformLayer<CompileLayerT, TransformFtor>;
+-  using CODLayerT = orc::CompileOnDemandLayer<IRDumpLayerT, CompileCallbackMgr>;
+-  using IndirectStubsManagerBuilder = CODLayerT::IndirectStubsManagerBuilderT;
+-  using ModuleHandleT = CODLayerT::ModuleHandleT;
+-
+-  OrcLazyJIT(std::unique_ptr<TargetMachine> TM,
+-             std::unique_ptr<CompileCallbackMgr> CCMgr,
+-             IndirectStubsManagerBuilder IndirectStubsMgrBuilder,
+-             bool InlineStubs)
+-      : TM(std::move(TM)), DL(this->TM->createDataLayout()),
+-	CCMgr(std::move(CCMgr)),
+-	ObjectLayer([]() { return std::make_shared<SectionMemoryManager>(); }),
+-        CompileLayer(ObjectLayer, orc::SimpleCompiler(*this->TM)),
+-        IRDumpLayer(CompileLayer, createDebugDumper()),
+-        CODLayer(IRDumpLayer, extractSingleFunction, *this->CCMgr,
+-                 std::move(IndirectStubsMgrBuilder), InlineStubs),
+-        CXXRuntimeOverrides(
+-            [this](const std::string &S) { return mangle(S); }) {}
+-
+-  ~OrcLazyJIT() {
+-    // Run any destructors registered with __cxa_atexit.
+-    CXXRuntimeOverrides.runDestructors();
+-    // Run any IR destructors.
+-    for (auto &DtorRunner : IRStaticDestructorRunners)
+-      if (auto Err = DtorRunner.runViaLayer(CODLayer)) {
+-        // FIXME: OrcLazyJIT should probably take a "shutdownError" callback to
+-        //        report these errors on.
+-        report_fatal_error(std::move(Err));
+-      }
+-  }
+-
+-  Error addModule(std::shared_ptr<Module> M) {
+-    if (M->getDataLayout().isDefault())
+-      M->setDataLayout(DL);
+-
+-    // Rename, bump linkage and record static constructors and destructors.
+-    // We have to do this before we hand over ownership of the module to the
+-    // JIT.
+-    std::vector<std::string> CtorNames, DtorNames;
+-    {
+-      unsigned CtorId = 0, DtorId = 0;
+-      for (auto Ctor : orc::getConstructors(*M)) {
+-        std::string NewCtorName = ("$static_ctor." + Twine(CtorId++)).str();
+-        Ctor.Func->setName(NewCtorName);
+-        Ctor.Func->setLinkage(GlobalValue::ExternalLinkage);
+-        Ctor.Func->setVisibility(GlobalValue::HiddenVisibility);
+-        CtorNames.push_back(mangle(NewCtorName));
+-      }
+-      for (auto Dtor : orc::getDestructors(*M)) {
+-        std::string NewDtorName = ("$static_dtor." + Twine(DtorId++)).str();
+-        Dtor.Func->setLinkage(GlobalValue::ExternalLinkage);
+-        Dtor.Func->setVisibility(GlobalValue::HiddenVisibility);
+-        DtorNames.push_back(mangle(Dtor.Func->getName()));
+-        Dtor.Func->setName(NewDtorName);
+-      }
+-    }
+-
+-    // Symbol resolution order:
+-    //   1) Search the JIT symbols.
+-    //   2) Check for C++ runtime overrides.
+-    //   3) Search the host process (LLI)'s symbol table.
+-    if (ModulesHandle == CODLayerT::ModuleHandleT()) {
+-      auto Resolver =
+-        orc::createLambdaResolver(
+-          [this](const std::string &Name) -> JITSymbol {
+-            if (auto Sym = CODLayer.findSymbol(Name, true))
+-              return Sym;
+-            return CXXRuntimeOverrides.searchOverrides(Name);
+-          },
+-          [](const std::string &Name) {
+-            if (auto Addr =
+-                RTDyldMemoryManager::getSymbolAddressInProcess(Name))
+-              return JITSymbol(Addr, JITSymbolFlags::Exported);
+-            return JITSymbol(nullptr);
+-          }
+-        );
+-
+-      // Add the module to the JIT.
+-      if (auto ModulesHandleOrErr =
+-          CODLayer.addModule(std::move(M), std::move(Resolver)))
+-        ModulesHandle = std::move(*ModulesHandleOrErr);
+-      else
+-        return ModulesHandleOrErr.takeError();
+-
+-    } else
+-      if (auto Err = CODLayer.addExtraModule(ModulesHandle, std::move(M)))
+-        return Err;
+-
+-    // Run the static constructors, and save the static destructor runner for
+-    // execution when the JIT is torn down.
+-    orc::CtorDtorRunner<CODLayerT> CtorRunner(std::move(CtorNames),
+-                                              ModulesHandle);
+-    if (auto Err = CtorRunner.runViaLayer(CODLayer))
+-      return Err;
+-
+-    IRStaticDestructorRunners.emplace_back(std::move(DtorNames),
+-                                           ModulesHandle);
+-
+-    return Error::success();
+-  }
+-
+-  JITSymbol findSymbol(const std::string &Name) {
+-    return CODLayer.findSymbol(mangle(Name), true);
+-  }
+-
+-  JITSymbol findSymbolIn(ModuleHandleT H, const std::string &Name) {
+-    return CODLayer.findSymbolIn(H, mangle(Name), true);
+-  }
+-
+-private:
+-  std::string mangle(const std::string &Name) {
+-    std::string MangledName;
+-    {
+-      raw_string_ostream MangledNameStream(MangledName);
+-      Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
+-    }
+-    return MangledName;
+-  }
+-
+-  static std::set<Function*> extractSingleFunction(Function &F) {
+-    std::set<Function*> Partition;
+-    Partition.insert(&F);
+-    return Partition;
+-  }
+-
+-  static TransformFtor createDebugDumper();
+-
+-  std::unique_ptr<TargetMachine> TM;
+-  DataLayout DL;
+-  SectionMemoryManager CCMgrMemMgr;
+-
+-  std::unique_ptr<CompileCallbackMgr> CCMgr;
+-  ObjLayerT ObjectLayer;
+-  CompileLayerT CompileLayer;
+-  IRDumpLayerT IRDumpLayer;
+-  CODLayerT CODLayer;
+-
+-  orc::LocalCXXRuntimeOverrides CXXRuntimeOverrides;
+-  std::vector<orc::CtorDtorRunner<CODLayerT>> IRStaticDestructorRunners;
+-  CODLayerT::ModuleHandleT ModulesHandle;
+-};
+-
+-int runOrcLazyJIT(std::vector<std::unique_ptr<Module>> Ms,
+-                  const std::vector<std::string> &Args);
+-
+-} // end namespace llvm
+-
+-#endif // LLVM_TOOLS_LLI_ORCLAZYJIT_H
+diff --git a/tools/lli/RemoteJITUtils.h b/tools/lli/RemoteJITUtils.h
+deleted file mode 100644
+index 4e948413865..00000000000
+--- a/tools/lli/RemoteJITUtils.h
++++ /dev/null
+@@ -1,152 +0,0 @@
+-//===-- RemoteJITUtils.h - Utilities for remote-JITing with LLI -*- C++ -*-===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-//
+-// Utilities for remote-JITing with LLI.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_TOOLS_LLI_REMOTEJITUTILS_H
+-#define LLVM_TOOLS_LLI_REMOTEJITUTILS_H
+-
+-#include "llvm/ExecutionEngine/Orc/RawByteChannel.h"
+-#include "llvm/ExecutionEngine/RTDyldMemoryManager.h"
+-#include <mutex>
+-
+-#if !defined(_MSC_VER) && !defined(__MINGW32__)
+-#include <unistd.h>
+-#else
+-#include <io.h>
+-#endif
+-
+-/// RPC channel that reads from and writes from file descriptors.
+-class FDRawChannel final : public llvm::orc::rpc::RawByteChannel {
+-public:
+-  FDRawChannel(int InFD, int OutFD) : InFD(InFD), OutFD(OutFD) {}
+-
+-  llvm::Error readBytes(char *Dst, unsigned Size) override {
+-    assert(Dst && "Attempt to read into null.");
+-    ssize_t Completed = 0;
+-    while (Completed < static_cast<ssize_t>(Size)) {
+-      ssize_t Read = ::read(InFD, Dst + Completed, Size - Completed);
+-      if (Read <= 0) {
+-        auto ErrNo = errno;
+-        if (ErrNo == EAGAIN || ErrNo == EINTR)
+-          continue;
+-        else
+-          return llvm::errorCodeToError(
+-                   std::error_code(errno, std::generic_category()));
+-      }
+-      Completed += Read;
+-    }
+-    return llvm::Error::success();
+-  }
+-
+-  llvm::Error appendBytes(const char *Src, unsigned Size) override {
+-    assert(Src && "Attempt to append from null.");
+-    ssize_t Completed = 0;
+-    while (Completed < static_cast<ssize_t>(Size)) {
+-      ssize_t Written = ::write(OutFD, Src + Completed, Size - Completed);
+-      if (Written < 0) {
+-        auto ErrNo = errno;
+-        if (ErrNo == EAGAIN || ErrNo == EINTR)
+-          continue;
+-        else
+-          return llvm::errorCodeToError(
+-                   std::error_code(errno, std::generic_category()));
+-      }
+-      Completed += Written;
+-    }
+-    return llvm::Error::success();
+-  }
+-
+-  llvm::Error send() override { return llvm::Error::success(); }
+-
+-private:
+-  int InFD, OutFD;
+-};
+-
+-// launch the remote process (see lli.cpp) and return a channel to it.
+-std::unique_ptr<FDRawChannel> launchRemote();
+-
+-namespace llvm {
+-
+-// ForwardingMM - Adapter to connect MCJIT to Orc's Remote8
+-// memory manager.
+-class ForwardingMemoryManager : public llvm::RTDyldMemoryManager {
+-public:
+-  void setMemMgr(std::unique_ptr<RuntimeDyld::MemoryManager> MemMgr) {
+-    this->MemMgr = std::move(MemMgr);
+-  }
+-
+-  void setResolver(std::shared_ptr<JITSymbolResolver> Resolver) {
+-    this->Resolver = std::move(Resolver);
+-  }
+-
+-  uint8_t *allocateCodeSection(uintptr_t Size, unsigned Alignment,
+-                               unsigned SectionID,
+-                               StringRef SectionName) override {
+-    return MemMgr->allocateCodeSection(Size, Alignment, SectionID, SectionName);
+-  }
+-
+-  uint8_t *allocateDataSection(uintptr_t Size, unsigned Alignment,
+-                               unsigned SectionID, StringRef SectionName,
+-                               bool IsReadOnly) override {
+-    return MemMgr->allocateDataSection(Size, Alignment, SectionID, SectionName,
+-                                       IsReadOnly);
+-  }
+-
+-  void reserveAllocationSpace(uintptr_t CodeSize, uint32_t CodeAlign,
+-                              uintptr_t RODataSize, uint32_t RODataAlign,
+-                              uintptr_t RWDataSize,
+-                              uint32_t RWDataAlign) override {
+-    MemMgr->reserveAllocationSpace(CodeSize, CodeAlign, RODataSize, RODataAlign,
+-                                   RWDataSize, RWDataAlign);
+-  }
+-
+-  bool needsToReserveAllocationSpace() override {
+-    return MemMgr->needsToReserveAllocationSpace();
+-  }
+-
+-  void registerEHFrames(uint8_t *Addr, uint64_t LoadAddr,
+-                        size_t Size) override {
+-    MemMgr->registerEHFrames(Addr, LoadAddr, Size);
+-  }
+-
+-  void deregisterEHFrames() override {
+-    MemMgr->deregisterEHFrames();
+-  }
+-
+-  bool finalizeMemory(std::string *ErrMsg = nullptr) override {
+-    return MemMgr->finalizeMemory(ErrMsg);
+-  }
+-
+-  void notifyObjectLoaded(RuntimeDyld &RTDyld,
+-                          const object::ObjectFile &Obj) override {
+-    MemMgr->notifyObjectLoaded(RTDyld, Obj);
+-  }
+-
+-  // Don't hide the sibling notifyObjectLoaded from RTDyldMemoryManager.
+-  using RTDyldMemoryManager::notifyObjectLoaded;
+-
+-  JITSymbol findSymbol(const std::string &Name) override {
+-    return Resolver->findSymbol(Name);
+-  }
+-
+-  JITSymbol
+-  findSymbolInLogicalDylib(const std::string &Name) override {
+-    return Resolver->findSymbolInLogicalDylib(Name);
+-  }
+-
+-private:
+-  std::unique_ptr<RuntimeDyld::MemoryManager> MemMgr;
+-  std::shared_ptr<JITSymbolResolver> Resolver;
+-};
+-}
+-
+-#endif
+diff --git a/tools/lli/lli.cpp b/tools/lli/lli.cpp
+index 091ca22b4e8..77ff6d4a01c 100644
+--- a/tools/lli/lli.cpp
++++ b/tools/lli/lli.cpp
+@@ -13,6 +13,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++#if 0
++
+ #include "OrcLazyJIT.h"
+ #include "RemoteJITUtils.h"
+ #include "llvm/IR/LLVMContext.h"
+@@ -757,3 +759,8 @@ std::unique_ptr<FDRawChannel> launchRemote() {
+   return llvm::make_unique<FDRawChannel>(PipeFD[1][0], PipeFD[0][1]);
+ #endif
+ }
++#endif
++
++int main(int argc, char **argv, char * const *envp) {
++  return 0;
++}
+diff --git a/tools/llvm-cov/CodeCoverage.cpp b/tools/llvm-cov/CodeCoverage.cpp
+index 3cbd6591134..2b270a35edb 100644
+--- a/tools/llvm-cov/CodeCoverage.cpp
++++ b/tools/llvm-cov/CodeCoverage.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- CodeCoverage.cpp - Coverage tool based on profiling instrumentation-===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -879,7 +880,10 @@ int reportMain(int argc, const char *argv[]) {
+   return Tool.run(CodeCoverageTool::Report, argc, argv);
+ }
+ 
++
+ int exportMain(int argc, const char *argv[]) {
+   CodeCoverageTool Tool;
+   return Tool.run(CodeCoverageTool::Export, argc, argv);
+ }
++
++#endif
+diff --git a/tools/llvm-cov/CoverageExporterJson.cpp b/tools/llvm-cov/CoverageExporterJson.cpp
+index ef50bba2123..d3d0a8f5f01 100644
+--- a/tools/llvm-cov/CoverageExporterJson.cpp
++++ b/tools/llvm-cov/CoverageExporterJson.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- CoverageExporterJson.cpp - Code coverage export --------------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -419,3 +420,4 @@ void exportCoverageDataToJson(const CoverageMapping &CoverageMapping,
+ 
+   Exporter.print();
+ }
++#endif
+diff --git a/tools/llvm-cov/CoverageFilters.cpp b/tools/llvm-cov/CoverageFilters.cpp
+index 325dd723578..8a41ba8c1d8 100644
+--- a/tools/llvm-cov/CoverageFilters.cpp
++++ b/tools/llvm-cov/CoverageFilters.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- CoverageFilters.cpp - Function coverage mapping filters ------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -57,3 +58,4 @@ CoverageFiltersMatchAll::matches(const coverage::FunctionRecord &Function) {
+   }
+   return true;
+ }
++#endif
+diff --git a/tools/llvm-cov/CoverageFilters.h b/tools/llvm-cov/CoverageFilters.h
+deleted file mode 100644
+index 756c4b47872..00000000000
+--- a/tools/llvm-cov/CoverageFilters.h
++++ /dev/null
+@@ -1,127 +0,0 @@
+-//===- CoverageFilters.h - Function coverage mapping filters --------------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-//
+-// These classes provide filtering for function coverage mapping records.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_COVERAGEFILTERS_H
+-#define LLVM_COV_COVERAGEFILTERS_H
+-
+-#include "llvm/ProfileData/Coverage/CoverageMapping.h"
+-#include <memory>
+-#include <vector>
+-
+-namespace llvm {
+-
+-/// \brief Matches specific functions that pass the requirement of this filter.
+-class CoverageFilter {
+-public:
+-  virtual ~CoverageFilter() {}
+-
+-  /// \brief Return true if the function passes the requirements of this filter.
+-  virtual bool matches(const coverage::FunctionRecord &Function) {
+-    return true;
+-  }
+-};
+-
+-/// \brief Matches functions that contain a specific string in their name.
+-class NameCoverageFilter : public CoverageFilter {
+-  StringRef Name;
+-
+-public:
+-  NameCoverageFilter(StringRef Name) : Name(Name) {}
+-
+-  bool matches(const coverage::FunctionRecord &Function) override;
+-};
+-
+-/// \brief Matches functions whose name matches a certain regular expression.
+-class NameRegexCoverageFilter : public CoverageFilter {
+-  StringRef Regex;
+-
+-public:
+-  NameRegexCoverageFilter(StringRef Regex) : Regex(Regex) {}
+-
+-  bool matches(const coverage::FunctionRecord &Function) override;
+-};
+-
+-/// \brief Matches numbers that pass a certain threshold.
+-template <typename T> class StatisticThresholdFilter {
+-public:
+-  enum Operation { LessThan, GreaterThan };
+-
+-protected:
+-  Operation Op;
+-  T Threshold;
+-
+-  StatisticThresholdFilter(Operation Op, T Threshold)
+-      : Op(Op), Threshold(Threshold) {}
+-
+-  /// \brief Return true if the given number is less than
+-  /// or greater than the certain threshold.
+-  bool PassesThreshold(T Value) const {
+-    switch (Op) {
+-    case LessThan:
+-      return Value < Threshold;
+-    case GreaterThan:
+-      return Value > Threshold;
+-    }
+-    return false;
+-  }
+-};
+-
+-/// \brief Matches functions whose region coverage percentage
+-/// is above/below a certain percentage.
+-class RegionCoverageFilter : public CoverageFilter,
+-                             public StatisticThresholdFilter<double> {
+-public:
+-  RegionCoverageFilter(Operation Op, double Threshold)
+-      : StatisticThresholdFilter(Op, Threshold) {}
+-
+-  bool matches(const coverage::FunctionRecord &Function) override;
+-};
+-
+-/// \brief Matches functions whose line coverage percentage
+-/// is above/below a certain percentage.
+-class LineCoverageFilter : public CoverageFilter,
+-                           public StatisticThresholdFilter<double> {
+-public:
+-  LineCoverageFilter(Operation Op, double Threshold)
+-      : StatisticThresholdFilter(Op, Threshold) {}
+-
+-  bool matches(const coverage::FunctionRecord &Function) override;
+-};
+-
+-/// \brief A collection of filters.
+-/// Matches functions that match any filters contained
+-/// in an instance of this class.
+-class CoverageFilters : public CoverageFilter {
+-protected:
+-  std::vector<std::unique_ptr<CoverageFilter>> Filters;
+-
+-public:
+-  /// \brief Append a filter to this collection.
+-  void push_back(std::unique_ptr<CoverageFilter> Filter);
+-
+-  bool empty() const { return Filters.empty(); }
+-
+-  bool matches(const coverage::FunctionRecord &Function) override;
+-};
+-
+-/// \brief A collection of filters.
+-/// Matches functions that match all of the filters contained
+-/// in an instance of this class.
+-class CoverageFiltersMatchAll : public CoverageFilters {
+-public:
+-  bool matches(const coverage::FunctionRecord &Function) override;
+-};
+-
+-} // namespace llvm
+-
+-#endif // LLVM_COV_COVERAGEFILTERS_H
+diff --git a/tools/llvm-cov/CoverageReport.cpp b/tools/llvm-cov/CoverageReport.cpp
+index c68bb9048df..b17831bcaa8 100644
+--- a/tools/llvm-cov/CoverageReport.cpp
++++ b/tools/llvm-cov/CoverageReport.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- CoverageReport.cpp - Code coverage report -------------------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -386,3 +387,4 @@ void CoverageReport::renderFileReports(raw_ostream &OS,
+ }
+ 
+ } // end namespace llvm
++#endif
+diff --git a/tools/llvm-cov/CoverageReport.h b/tools/llvm-cov/CoverageReport.h
+deleted file mode 100644
+index 071be2e2159..00000000000
+--- a/tools/llvm-cov/CoverageReport.h
++++ /dev/null
+@@ -1,53 +0,0 @@
+-//===- CoverageReport.h - Code coverage report ---------------------------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-//
+-// This class implements rendering of a code coverage report.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_COVERAGEREPORT_H
+-#define LLVM_COV_COVERAGEREPORT_H
+-
+-#include "CoverageSummaryInfo.h"
+-#include "CoverageViewOptions.h"
+-
+-namespace llvm {
+-
+-/// \brief Displays the code coverage report.
+-class CoverageReport {
+-  const CoverageViewOptions &Options;
+-  const coverage::CoverageMapping &Coverage;
+-
+-  void render(const FileCoverageSummary &File, raw_ostream &OS) const;
+-  void render(const FunctionCoverageSummary &Function, const DemangleCache &DC,
+-              raw_ostream &OS) const;
+-
+-public:
+-  CoverageReport(const CoverageViewOptions &Options,
+-                 const coverage::CoverageMapping &Coverage)
+-      : Options(Options), Coverage(Coverage) {}
+-
+-  void renderFunctionReports(ArrayRef<std::string> Files,
+-                             const DemangleCache &DC, raw_ostream &OS);
+-
+-  /// Prepare file reports for the files specified in \p Files.
+-  static std::vector<FileCoverageSummary>
+-  prepareFileReports(const coverage::CoverageMapping &Coverage,
+-                     FileCoverageSummary &Totals, ArrayRef<std::string> Files);
+-
+-  /// Render file reports for every unique file in the coverage mapping.
+-  void renderFileReports(raw_ostream &OS) const;
+-
+-  /// Render file reports for the files specified in \p Files.
+-  void renderFileReports(raw_ostream &OS, ArrayRef<std::string> Files) const;
+-};
+-
+-} // end namespace llvm
+-
+-#endif // LLVM_COV_COVERAGEREPORT_H
+diff --git a/tools/llvm-cov/CoverageSummaryInfo.cpp b/tools/llvm-cov/CoverageSummaryInfo.cpp
+index 21aa7ff73a0..5a325b40cf8 100644
+--- a/tools/llvm-cov/CoverageSummaryInfo.cpp
++++ b/tools/llvm-cov/CoverageSummaryInfo.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- CoverageSummaryInfo.cpp - Coverage summary for function/file -------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -81,3 +82,4 @@ void FunctionCoverageSummary::update(const FunctionCoverageSummary &Summary) {
+   LineCoverage.NotCovered =
+       std::min(LineCoverage.NotCovered, Summary.LineCoverage.NotCovered);
+ }
++#endif
+diff --git a/tools/llvm-cov/CoverageSummaryInfo.h b/tools/llvm-cov/CoverageSummaryInfo.h
+deleted file mode 100644
+index 680fc375768..00000000000
+--- a/tools/llvm-cov/CoverageSummaryInfo.h
++++ /dev/null
+@@ -1,178 +0,0 @@
+-//===- CoverageSummaryInfo.h - Coverage summary for function/file ---------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-//
+-// These structures are used to represent code coverage metrics
+-// for functions/files.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_COVERAGESUMMARYINFO_H
+-#define LLVM_COV_COVERAGESUMMARYINFO_H
+-
+-#include "llvm/ProfileData/Coverage/CoverageMapping.h"
+-#include "llvm/Support/raw_ostream.h"
+-
+-namespace llvm {
+-
+-/// \brief Provides information about region coverage for a function/file.
+-struct RegionCoverageInfo {
+-  /// \brief The number of regions that were executed at least once.
+-  size_t Covered;
+-
+-  /// \brief The number of regions that weren't executed.
+-  size_t NotCovered;
+-
+-  /// \brief The total number of regions in a function/file.
+-  size_t NumRegions;
+-
+-  RegionCoverageInfo() : Covered(0), NotCovered(0), NumRegions(0) {}
+-
+-  RegionCoverageInfo(size_t Covered, size_t NumRegions)
+-      : Covered(Covered), NotCovered(NumRegions - Covered),
+-        NumRegions(NumRegions) {}
+-
+-  RegionCoverageInfo &operator+=(const RegionCoverageInfo &RHS) {
+-    Covered += RHS.Covered;
+-    NotCovered += RHS.NotCovered;
+-    NumRegions += RHS.NumRegions;
+-    return *this;
+-  }
+-
+-  bool isFullyCovered() const { return Covered == NumRegions; }
+-
+-  double getPercentCovered() const {
+-    if (NumRegions == 0)
+-      return 0.0;
+-    return double(Covered) / double(NumRegions) * 100.0;
+-  }
+-};
+-
+-/// \brief Provides information about line coverage for a function/file.
+-struct LineCoverageInfo {
+-  /// \brief The number of lines that were executed at least once.
+-  size_t Covered;
+-
+-  /// \brief The number of lines that weren't executed.
+-  size_t NotCovered;
+-
+-  /// \brief The total number of lines in a function/file.
+-  size_t NumLines;
+-
+-  LineCoverageInfo() : Covered(0), NotCovered(0), NumLines(0) {}
+-
+-  LineCoverageInfo(size_t Covered, size_t NumLines)
+-      : Covered(Covered), NotCovered(NumLines - Covered), NumLines(NumLines) {}
+-
+-  LineCoverageInfo &operator+=(const LineCoverageInfo &RHS) {
+-    Covered += RHS.Covered;
+-    NotCovered += RHS.NotCovered;
+-    NumLines += RHS.NumLines;
+-    return *this;
+-  }
+-
+-  bool isFullyCovered() const { return Covered == NumLines; }
+-
+-  double getPercentCovered() const {
+-    if (NumLines == 0)
+-      return 0.0;
+-    return double(Covered) / double(NumLines) * 100.0;
+-  }
+-};
+-
+-/// \brief Provides information about function coverage for a file.
+-struct FunctionCoverageInfo {
+-  /// \brief The number of functions that were executed.
+-  size_t Executed;
+-
+-  /// \brief The total number of functions in this file.
+-  size_t NumFunctions;
+-
+-  FunctionCoverageInfo() : Executed(0), NumFunctions(0) {}
+-
+-  FunctionCoverageInfo(size_t Executed, size_t NumFunctions)
+-      : Executed(Executed), NumFunctions(NumFunctions) {}
+-
+-  void addFunction(bool Covered) {
+-    if (Covered)
+-      ++Executed;
+-    ++NumFunctions;
+-  }
+-
+-  bool isFullyCovered() const { return Executed == NumFunctions; }
+-
+-  double getPercentCovered() const {
+-    if (NumFunctions == 0)
+-      return 0.0;
+-    return double(Executed) / double(NumFunctions) * 100.0;
+-  }
+-};
+-
+-/// \brief A summary of function's code coverage.
+-struct FunctionCoverageSummary {
+-  StringRef Name;
+-  uint64_t ExecutionCount;
+-  RegionCoverageInfo RegionCoverage;
+-  LineCoverageInfo LineCoverage;
+-
+-  FunctionCoverageSummary(StringRef Name) : Name(Name), ExecutionCount(0) {}
+-
+-  FunctionCoverageSummary(StringRef Name, uint64_t ExecutionCount,
+-                          const RegionCoverageInfo &RegionCoverage,
+-                          const LineCoverageInfo &LineCoverage)
+-      : Name(Name), ExecutionCount(ExecutionCount),
+-        RegionCoverage(RegionCoverage), LineCoverage(LineCoverage) {
+-  }
+-
+-  /// \brief Compute the code coverage summary for the given function coverage
+-  /// mapping record.
+-  static FunctionCoverageSummary
+-  get(const coverage::FunctionRecord &Function);
+-
+-  /// \brief Update the summary with information from another instantiation
+-  /// of this function.
+-  void update(const FunctionCoverageSummary &Summary);
+-};
+-
+-/// \brief A summary of file's code coverage.
+-struct FileCoverageSummary {
+-  StringRef Name;
+-  RegionCoverageInfo RegionCoverage;
+-  LineCoverageInfo LineCoverage;
+-  FunctionCoverageInfo FunctionCoverage;
+-  FunctionCoverageInfo InstantiationCoverage;
+-
+-  FileCoverageSummary(StringRef Name) : Name(Name) {}
+-
+-  void addFunction(const FunctionCoverageSummary &Function) {
+-    RegionCoverage += Function.RegionCoverage;
+-    LineCoverage += Function.LineCoverage;
+-    FunctionCoverage.addFunction(/*Covered=*/Function.ExecutionCount > 0);
+-  }
+-
+-  void addInstantiation(const FunctionCoverageSummary &Function) {
+-    InstantiationCoverage.addFunction(/*Covered=*/Function.ExecutionCount > 0);
+-  }
+-};
+-
+-/// \brief A cache for demangled symbols.
+-struct DemangleCache {
+-  StringMap<std::string> DemangledNames;
+-
+-  /// \brief Demangle \p Sym if possible. Otherwise, just return \p Sym.
+-  StringRef demangle(StringRef Sym) const {
+-    const auto DemangledName = DemangledNames.find(Sym);
+-    if (DemangledName == DemangledNames.end())
+-      return Sym;
+-    return DemangledName->getValue();
+-  }
+-};
+-
+-} // namespace llvm
+-
+-#endif // LLVM_COV_COVERAGESUMMARYINFO_H
+diff --git a/tools/llvm-cov/CoverageViewOptions.h b/tools/llvm-cov/CoverageViewOptions.h
+deleted file mode 100644
+index 266b380b7d3..00000000000
+--- a/tools/llvm-cov/CoverageViewOptions.h
++++ /dev/null
+@@ -1,68 +0,0 @@
+-//===- CoverageViewOptions.h - Code coverage display options -------------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_COVERAGEVIEWOPTIONS_H
+-#define LLVM_COV_COVERAGEVIEWOPTIONS_H
+-
+-#include "RenderingSupport.h"
+-#include <vector>
+-
+-namespace llvm {
+-
+-/// \brief The options for displaying the code coverage information.
+-struct CoverageViewOptions {
+-  enum class OutputFormat {
+-    Text,
+-    HTML
+-  };
+-
+-  bool Debug;
+-  bool Colors;
+-  bool ShowLineNumbers;
+-  bool ShowLineStats;
+-  bool ShowRegionMarkers;
+-  bool ShowLineStatsOrRegionMarkers;
+-  bool ShowExpandedRegions;
+-  bool ShowFunctionInstantiations;
+-  bool ShowFullFilenames;
+-  OutputFormat Format;
+-  std::string ShowOutputDirectory;
+-  std::vector<std::string> DemanglerOpts;
+-  uint32_t TabSize;
+-  std::string ProjectTitle;
+-  std::string CreatedTimeStr;
+-
+-  /// \brief Change the output's stream color if the colors are enabled.
+-  ColoredRawOstream colored_ostream(raw_ostream &OS,
+-                                    raw_ostream::Colors Color) const {
+-    return llvm::colored_ostream(OS, Color, Colors);
+-  }
+-
+-  /// \brief Check if an output directory has been specified.
+-  bool hasOutputDirectory() const { return !ShowOutputDirectory.empty(); }
+-
+-  /// \brief Check if a demangler has been specified.
+-  bool hasDemangler() const { return !DemanglerOpts.empty(); }
+-
+-  /// \brief Check if a project title has been specified.
+-  bool hasProjectTitle() const { return !ProjectTitle.empty(); }
+-
+-  /// \brief Check if the created time of the profile data file is available.
+-  bool hasCreatedTime() const { return !CreatedTimeStr.empty(); }
+-
+-  /// \brief Get the LLVM version string.
+-  std::string getLLVMVersionString() const {
+-    std::string VersionString = "Generated by llvm-cov -- llvm version ";
+-    VersionString += LLVM_VERSION_STRING;
+-    return VersionString;
+-  }
+-};
+-}
+-
+-#endif // LLVM_COV_COVERAGEVIEWOPTIONS_H
+diff --git a/tools/llvm-cov/RenderingSupport.h b/tools/llvm-cov/RenderingSupport.h
+deleted file mode 100644
+index aa70fbc23e3..00000000000
+--- a/tools/llvm-cov/RenderingSupport.h
++++ /dev/null
+@@ -1,61 +0,0 @@
+-//===- RenderingSupport.h - output stream rendering support functions  ----===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_RENDERINGSUPPORT_H
+-#define LLVM_COV_RENDERINGSUPPORT_H
+-
+-#include "llvm/Support/raw_ostream.h"
+-#include <utility>
+-
+-namespace llvm {
+-
+-/// \brief A helper class that resets the output stream's color if needed
+-/// when destroyed.
+-class ColoredRawOstream {
+-  ColoredRawOstream(const ColoredRawOstream &OS) = delete;
+-
+-public:
+-  raw_ostream &OS;
+-  bool IsColorUsed;
+-
+-  ColoredRawOstream(raw_ostream &OS, bool IsColorUsed)
+-      : OS(OS), IsColorUsed(IsColorUsed) {}
+-
+-  ColoredRawOstream(ColoredRawOstream &&Other)
+-      : OS(Other.OS), IsColorUsed(Other.IsColorUsed) {
+-    // Reset the other IsColorUsed so that the other object won't reset the
+-    // color when destroyed.
+-    Other.IsColorUsed = false;
+-  }
+-
+-  ~ColoredRawOstream() {
+-    if (IsColorUsed)
+-      OS.resetColor();
+-  }
+-};
+-
+-template <typename T>
+-inline raw_ostream &operator<<(const ColoredRawOstream &OS, T &&Value) {
+-  return OS.OS << std::forward<T>(Value);
+-}
+-
+-/// \brief Change the color of the output stream if the `IsColorUsed` flag
+-/// is true. Returns an object that resets the color when destroyed.
+-inline ColoredRawOstream colored_ostream(raw_ostream &OS,
+-                                         raw_ostream::Colors Color,
+-                                         bool IsColorUsed = true,
+-                                         bool Bold = false, bool BG = false) {
+-  if (IsColorUsed)
+-    OS.changeColor(Color, Bold, BG);
+-  return ColoredRawOstream(OS, IsColorUsed);
+-}
+-
+-} // namespace llvm
+-
+-#endif // LLVM_COV_RENDERINGSUPPORT_H
+diff --git a/tools/llvm-cov/SourceCoverageView.cpp b/tools/llvm-cov/SourceCoverageView.cpp
+index 52b8ff1747f..84c2cb7e8d6 100644
+--- a/tools/llvm-cov/SourceCoverageView.cpp
++++ b/tools/llvm-cov/SourceCoverageView.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- SourceCoverageView.cpp - Code coverage view for source code --------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -265,3 +266,4 @@ void SourceCoverageView::print(raw_ostream &OS, bool WholeFile,
+ 
+   renderViewFooter(OS);
+ }
++#endif
+diff --git a/tools/llvm-cov/SourceCoverageView.h b/tools/llvm-cov/SourceCoverageView.h
+deleted file mode 100644
+index 9cb608fed60..00000000000
+--- a/tools/llvm-cov/SourceCoverageView.h
++++ /dev/null
+@@ -1,289 +0,0 @@
+-//===- SourceCoverageView.h - Code coverage view for source code ----------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-///
+-/// \file This class implements rendering for code coverage of source code.
+-///
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_SOURCECOVERAGEVIEW_H
+-#define LLVM_COV_SOURCECOVERAGEVIEW_H
+-
+-#include "CoverageViewOptions.h"
+-#include "llvm/ProfileData/Coverage/CoverageMapping.h"
+-#include "llvm/Support/MemoryBuffer.h"
+-#include <vector>
+-
+-namespace llvm {
+-
+-class SourceCoverageView;
+-
+-/// \brief A view that represents a macro or include expansion.
+-struct ExpansionView {
+-  coverage::CounterMappingRegion Region;
+-  std::unique_ptr<SourceCoverageView> View;
+-
+-  ExpansionView(const coverage::CounterMappingRegion &Region,
+-                std::unique_ptr<SourceCoverageView> View)
+-      : Region(Region), View(std::move(View)) {}
+-  ExpansionView(ExpansionView &&RHS)
+-      : Region(std::move(RHS.Region)), View(std::move(RHS.View)) {}
+-  ExpansionView &operator=(ExpansionView &&RHS) {
+-    Region = std::move(RHS.Region);
+-    View = std::move(RHS.View);
+-    return *this;
+-  }
+-
+-  unsigned getLine() const { return Region.LineStart; }
+-  unsigned getStartCol() const { return Region.ColumnStart; }
+-  unsigned getEndCol() const { return Region.ColumnEnd; }
+-
+-  friend bool operator<(const ExpansionView &LHS, const ExpansionView &RHS) {
+-    return LHS.Region.startLoc() < RHS.Region.startLoc();
+-  }
+-};
+-
+-/// \brief A view that represents a function instantiation.
+-struct InstantiationView {
+-  StringRef FunctionName;
+-  unsigned Line;
+-  std::unique_ptr<SourceCoverageView> View;
+-
+-  InstantiationView(StringRef FunctionName, unsigned Line,
+-                    std::unique_ptr<SourceCoverageView> View)
+-      : FunctionName(FunctionName), Line(Line), View(std::move(View)) {}
+-
+-  friend bool operator<(const InstantiationView &LHS,
+-                        const InstantiationView &RHS) {
+-    return LHS.Line < RHS.Line;
+-  }
+-};
+-
+-/// \brief Coverage statistics for a single line.
+-struct LineCoverageStats {
+-  uint64_t ExecutionCount;
+-  unsigned RegionCount;
+-  bool Mapped;
+-
+-  LineCoverageStats() : ExecutionCount(0), RegionCount(0), Mapped(false) {}
+-
+-  bool isMapped() const { return Mapped; }
+-
+-  bool hasMultipleRegions() const { return RegionCount > 1; }
+-
+-  void addRegionStartCount(uint64_t Count) {
+-    // The max of all region starts is the most interesting value.
+-    addRegionCount(RegionCount ? std::max(ExecutionCount, Count) : Count);
+-    ++RegionCount;
+-  }
+-
+-  void addRegionCount(uint64_t Count) {
+-    Mapped = true;
+-    ExecutionCount = Count;
+-  }
+-};
+-
+-/// \brief A file manager that handles format-aware file creation.
+-class CoveragePrinter {
+-public:
+-  struct StreamDestructor {
+-    void operator()(raw_ostream *OS) const;
+-  };
+-
+-  using OwnedStream = std::unique_ptr<raw_ostream, StreamDestructor>;
+-
+-protected:
+-  const CoverageViewOptions &Opts;
+-
+-  CoveragePrinter(const CoverageViewOptions &Opts) : Opts(Opts) {}
+-
+-  /// \brief Return `OutputDir/ToplevelDir/Path.Extension`. If \p InToplevel is
+-  /// false, skip the ToplevelDir component. If \p Relative is false, skip the
+-  /// OutputDir component.
+-  std::string getOutputPath(StringRef Path, StringRef Extension,
+-                            bool InToplevel, bool Relative = true) const;
+-
+-  /// \brief If directory output is enabled, create a file in that directory
+-  /// at the path given by getOutputPath(). Otherwise, return stdout.
+-  Expected<OwnedStream> createOutputStream(StringRef Path, StringRef Extension,
+-                                           bool InToplevel) const;
+-
+-  /// \brief Return the sub-directory name for file coverage reports.
+-  static StringRef getCoverageDir() { return "coverage"; }
+-
+-public:
+-  static std::unique_ptr<CoveragePrinter>
+-  create(const CoverageViewOptions &Opts);
+-
+-  virtual ~CoveragePrinter() {}
+-
+-  /// @name File Creation Interface
+-  /// @{
+-
+-  /// \brief Create a file to print a coverage view into.
+-  virtual Expected<OwnedStream> createViewFile(StringRef Path,
+-                                               bool InToplevel) = 0;
+-
+-  /// \brief Close a file which has been used to print a coverage view.
+-  virtual void closeViewFile(OwnedStream OS) = 0;
+-
+-  /// \brief Create an index which lists reports for the given source files.
+-  virtual Error createIndexFile(ArrayRef<std::string> SourceFiles,
+-                                const coverage::CoverageMapping &Coverage) = 0;
+-
+-  /// @}
+-};
+-
+-/// \brief A code coverage view of a source file or function.
+-///
+-/// A source coverage view and its nested sub-views form a file-oriented
+-/// representation of code coverage data. This view can be printed out by a
+-/// renderer which implements the Rendering Interface.
+-class SourceCoverageView {
+-  /// A function or file name.
+-  StringRef SourceName;
+-
+-  /// A memory buffer backing the source on display.
+-  const MemoryBuffer &File;
+-
+-  /// Various options to guide the coverage renderer.
+-  const CoverageViewOptions &Options;
+-
+-  /// Complete coverage information about the source on display.
+-  coverage::CoverageData CoverageInfo;
+-
+-  /// A container for all expansions (e.g macros) in the source on display.
+-  std::vector<ExpansionView> ExpansionSubViews;
+-
+-  /// A container for all instantiations (e.g template functions) in the source
+-  /// on display.
+-  std::vector<InstantiationView> InstantiationSubViews;
+-
+-  /// Get the first uncovered line number for the source file.
+-  unsigned getFirstUncoveredLineNo();
+-
+-protected:
+-  struct LineRef {
+-    StringRef Line;
+-    int64_t LineNo;
+-
+-    LineRef(StringRef Line, int64_t LineNo) : Line(Line), LineNo(LineNo) {}
+-  };
+-
+-  using CoverageSegmentArray = ArrayRef<const coverage::CoverageSegment *>;
+-
+-  /// @name Rendering Interface
+-  /// @{
+-
+-  /// \brief Render a header for the view.
+-  virtual void renderViewHeader(raw_ostream &OS) = 0;
+-
+-  /// \brief Render a footer for the view.
+-  virtual void renderViewFooter(raw_ostream &OS) = 0;
+-
+-  /// \brief Render the source name for the view.
+-  virtual void renderSourceName(raw_ostream &OS, bool WholeFile) = 0;
+-
+-  /// \brief Render the line prefix at the given \p ViewDepth.
+-  virtual void renderLinePrefix(raw_ostream &OS, unsigned ViewDepth) = 0;
+-
+-  /// \brief Render the line suffix at the given \p ViewDepth.
+-  virtual void renderLineSuffix(raw_ostream &OS, unsigned ViewDepth) = 0;
+-
+-  /// \brief Render a view divider at the given \p ViewDepth.
+-  virtual void renderViewDivider(raw_ostream &OS, unsigned ViewDepth) = 0;
+-
+-  /// \brief Render a source line with highlighting.
+-  virtual void renderLine(raw_ostream &OS, LineRef L,
+-                          const coverage::CoverageSegment *WrappedSegment,
+-                          CoverageSegmentArray Segments, unsigned ExpansionCol,
+-                          unsigned ViewDepth) = 0;
+-
+-  /// \brief Render the line's execution count column.
+-  virtual void renderLineCoverageColumn(raw_ostream &OS,
+-                                        const LineCoverageStats &Line) = 0;
+-
+-  /// \brief Render the line number column.
+-  virtual void renderLineNumberColumn(raw_ostream &OS, unsigned LineNo) = 0;
+-
+-  /// \brief Render all the region's execution counts on a line.
+-  virtual void renderRegionMarkers(raw_ostream &OS,
+-                                   CoverageSegmentArray Segments,
+-                                   unsigned ViewDepth) = 0;
+-
+-  /// \brief Render the site of an expansion.
+-  virtual void
+-  renderExpansionSite(raw_ostream &OS, LineRef L,
+-                      const coverage::CoverageSegment *WrappedSegment,
+-                      CoverageSegmentArray Segments, unsigned ExpansionCol,
+-                      unsigned ViewDepth) = 0;
+-
+-  /// \brief Render an expansion view and any nested views.
+-  virtual void renderExpansionView(raw_ostream &OS, ExpansionView &ESV,
+-                                   unsigned ViewDepth) = 0;
+-
+-  /// \brief Render an instantiation view and any nested views.
+-  virtual void renderInstantiationView(raw_ostream &OS, InstantiationView &ISV,
+-                                       unsigned ViewDepth) = 0;
+-
+-  /// \brief Render \p Title, a project title if one is available, and the
+-  /// created time.
+-  virtual void renderTitle(raw_ostream &OS, StringRef CellText) = 0;
+-
+-  /// \brief Render the table header for a given source file.
+-  virtual void renderTableHeader(raw_ostream &OS, unsigned FirstUncoveredLineNo,
+-                                 unsigned IndentLevel) = 0;
+-
+-  /// @}
+-
+-  /// \brief Format a count using engineering notation with 3 significant
+-  /// digits.
+-  static std::string formatCount(uint64_t N);
+-
+-  /// \brief Check if region marker output is expected for a line.
+-  bool shouldRenderRegionMarkers(bool LineHasMultipleRegions) const;
+-
+-  /// \brief Check if there are any sub-views attached to this view.
+-  bool hasSubViews() const;
+-
+-  SourceCoverageView(StringRef SourceName, const MemoryBuffer &File,
+-                     const CoverageViewOptions &Options,
+-                     coverage::CoverageData &&CoverageInfo)
+-      : SourceName(SourceName), File(File), Options(Options),
+-        CoverageInfo(std::move(CoverageInfo)) {}
+-
+-public:
+-  static std::unique_ptr<SourceCoverageView>
+-  create(StringRef SourceName, const MemoryBuffer &File,
+-         const CoverageViewOptions &Options,
+-         coverage::CoverageData &&CoverageInfo);
+-
+-  virtual ~SourceCoverageView() {}
+-
+-  /// \brief Return the source name formatted for the host OS.
+-  std::string getSourceName() const;
+-
+-  const CoverageViewOptions &getOptions() const { return Options; }
+-
+-  /// \brief Add an expansion subview to this view.
+-  void addExpansion(const coverage::CounterMappingRegion &Region,
+-                    std::unique_ptr<SourceCoverageView> View);
+-
+-  /// \brief Add a function instantiation subview to this view.
+-  void addInstantiation(StringRef FunctionName, unsigned Line,
+-                        std::unique_ptr<SourceCoverageView> View);
+-
+-  /// \brief Print the code coverage information for a specific portion of a
+-  /// source file to the output stream.
+-  void print(raw_ostream &OS, bool WholeFile, bool ShowSourceName,
+-             unsigned ViewDepth = 0);
+-};
+-
+-} // namespace llvm
+-
+-#endif // LLVM_COV_SOURCECOVERAGEVIEW_H
+diff --git a/tools/llvm-cov/SourceCoverageViewHTML.cpp b/tools/llvm-cov/SourceCoverageViewHTML.cpp
+index 64b888e89d7..929b224b66b 100644
+--- a/tools/llvm-cov/SourceCoverageViewHTML.cpp
++++ b/tools/llvm-cov/SourceCoverageViewHTML.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- SourceCoverageViewHTML.cpp - A html code coverage view -------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -636,3 +637,5 @@ void SourceCoverageViewHTML::renderTableHeader(raw_ostream &OS,
+      << SourceLabel;
+   renderLineSuffix(OS, ViewDepth);
+ }
++
++#endif
+diff --git a/tools/llvm-cov/SourceCoverageViewHTML.h b/tools/llvm-cov/SourceCoverageViewHTML.h
+deleted file mode 100644
+index 94b08a5e7fc..00000000000
+--- a/tools/llvm-cov/SourceCoverageViewHTML.h
++++ /dev/null
+@@ -1,96 +0,0 @@
+-//===- SourceCoverageViewHTML.h - A html code coverage view ---------------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-///
+-/// \file This file defines the interface to the html coverage renderer.
+-///
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_SOURCECOVERAGEVIEWHTML_H
+-#define LLVM_COV_SOURCECOVERAGEVIEWHTML_H
+-
+-#include "SourceCoverageView.h"
+-
+-namespace llvm {
+-
+-struct FileCoverageSummary;
+-
+-/// \brief A coverage printer for html output.
+-class CoveragePrinterHTML : public CoveragePrinter {
+-public:
+-  Expected<OwnedStream> createViewFile(StringRef Path,
+-                                       bool InToplevel) override;
+-
+-  void closeViewFile(OwnedStream OS) override;
+-
+-  Error createIndexFile(ArrayRef<std::string> SourceFiles,
+-                        const coverage::CoverageMapping &Coverage) override;
+-
+-  CoveragePrinterHTML(const CoverageViewOptions &Opts)
+-      : CoveragePrinter(Opts) {}
+-
+-private:
+-  void emitFileSummary(raw_ostream &OS, StringRef SF,
+-                       const FileCoverageSummary &FCS,
+-                       bool IsTotals = false) const;
+-};
+-
+-/// \brief A code coverage view which supports html-based rendering.
+-class SourceCoverageViewHTML : public SourceCoverageView {
+-  void renderViewHeader(raw_ostream &OS) override;
+-
+-  void renderViewFooter(raw_ostream &OS) override;
+-
+-  void renderSourceName(raw_ostream &OS, bool WholeFile) override;
+-
+-  void renderLinePrefix(raw_ostream &OS, unsigned ViewDepth) override;
+-
+-  void renderLineSuffix(raw_ostream &OS, unsigned ViewDepth) override;
+-
+-  void renderViewDivider(raw_ostream &OS, unsigned ViewDepth) override;
+-
+-  void renderLine(raw_ostream &OS, LineRef L,
+-                  const coverage::CoverageSegment *WrappedSegment,
+-                  CoverageSegmentArray Segments, unsigned ExpansionCol,
+-                  unsigned ViewDepth) override;
+-
+-  void renderExpansionSite(raw_ostream &OS, LineRef L,
+-                           const coverage::CoverageSegment *WrappedSegment,
+-                           CoverageSegmentArray Segments, unsigned ExpansionCol,
+-                           unsigned ViewDepth) override;
+-
+-  void renderExpansionView(raw_ostream &OS, ExpansionView &ESV,
+-                           unsigned ViewDepth) override;
+-
+-  void renderInstantiationView(raw_ostream &OS, InstantiationView &ISV,
+-                               unsigned ViewDepth) override;
+-
+-  void renderLineCoverageColumn(raw_ostream &OS,
+-                                const LineCoverageStats &Line) override;
+-
+-  void renderLineNumberColumn(raw_ostream &OS, unsigned LineNo) override;
+-
+-  void renderRegionMarkers(raw_ostream &OS, CoverageSegmentArray Segments,
+-                           unsigned ViewDepth) override;
+-
+-  void renderTitle(raw_ostream &OS, StringRef Title) override;
+-
+-  void renderTableHeader(raw_ostream &OS, unsigned FirstUncoveredLineNo,
+-                         unsigned IndentLevel) override;
+-
+-public:
+-  SourceCoverageViewHTML(StringRef SourceName, const MemoryBuffer &File,
+-                         const CoverageViewOptions &Options,
+-                         coverage::CoverageData &&CoverageInfo)
+-      : SourceCoverageView(SourceName, File, Options, std::move(CoverageInfo)) {
+-  }
+-};
+-
+-} // namespace llvm
+-
+-#endif // LLVM_COV_SOURCECOVERAGEVIEWHTML_H
+diff --git a/tools/llvm-cov/SourceCoverageViewText.cpp b/tools/llvm-cov/SourceCoverageViewText.cpp
+index 4ad120f642e..03422a36a37 100644
+--- a/tools/llvm-cov/SourceCoverageViewText.cpp
++++ b/tools/llvm-cov/SourceCoverageViewText.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- SourceCoverageViewText.cpp - A text-based code coverage view -------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -237,3 +238,5 @@ void SourceCoverageViewText::renderTitle(raw_ostream &OS, StringRef Title) {
+ 
+ void SourceCoverageViewText::renderTableHeader(raw_ostream &, unsigned,
+                                                unsigned) {}
++
++#endif
+diff --git a/tools/llvm-cov/SourceCoverageViewText.h b/tools/llvm-cov/SourceCoverageViewText.h
+deleted file mode 100644
+index c3f20de9297..00000000000
+--- a/tools/llvm-cov/SourceCoverageViewText.h
++++ /dev/null
+@@ -1,89 +0,0 @@
+-//===- SourceCoverageViewText.h - A text-based code coverage view ---------===//
+-//
+-//                     The LLVM Compiler Infrastructure
+-//
+-// This file is distributed under the University of Illinois Open Source
+-// License. See LICENSE.TXT for details.
+-//
+-//===----------------------------------------------------------------------===//
+-///
+-/// \file This file defines the interface to the text-based coverage renderer.
+-///
+-//===----------------------------------------------------------------------===//
+-
+-#ifndef LLVM_COV_SOURCECOVERAGEVIEWTEXT_H
+-#define LLVM_COV_SOURCECOVERAGEVIEWTEXT_H
+-
+-#include "SourceCoverageView.h"
+-
+-namespace llvm {
+-
+-/// \brief A coverage printer for text output.
+-class CoveragePrinterText : public CoveragePrinter {
+-public:
+-  Expected<OwnedStream> createViewFile(StringRef Path,
+-                                       bool InToplevel) override;
+-
+-  void closeViewFile(OwnedStream OS) override;
+-
+-  Error createIndexFile(ArrayRef<std::string> SourceFiles,
+-                        const coverage::CoverageMapping &Coverage) override;
+-
+-  CoveragePrinterText(const CoverageViewOptions &Opts)
+-      : CoveragePrinter(Opts) {}
+-};
+-
+-/// \brief A code coverage view which supports text-based rendering.
+-class SourceCoverageViewText : public SourceCoverageView {
+-  void renderViewHeader(raw_ostream &OS) override;
+-
+-  void renderViewFooter(raw_ostream &OS) override;
+-
+-  void renderSourceName(raw_ostream &OS, bool WholeFile) override;
+-
+-  void renderLinePrefix(raw_ostream &OS, unsigned ViewDepth) override;
+-
+-  void renderLineSuffix(raw_ostream &OS, unsigned ViewDepth) override;
+-
+-  void renderViewDivider(raw_ostream &OS, unsigned ViewDepth) override;
+-
+-  void renderLine(raw_ostream &OS, LineRef L,
+-                  const coverage::CoverageSegment *WrappedSegment,
+-                  CoverageSegmentArray Segments, unsigned ExpansionCol,
+-                  unsigned ViewDepth) override;
+-
+-  void renderExpansionSite(raw_ostream &OS, LineRef L,
+-                           const coverage::CoverageSegment *WrappedSegment,
+-                           CoverageSegmentArray Segments, unsigned ExpansionCol,
+-                           unsigned ViewDepth) override;
+-
+-  void renderExpansionView(raw_ostream &OS, ExpansionView &ESV,
+-                           unsigned ViewDepth) override;
+-
+-  void renderInstantiationView(raw_ostream &OS, InstantiationView &ISV,
+-                               unsigned ViewDepth) override;
+-
+-  void renderLineCoverageColumn(raw_ostream &OS,
+-                                const LineCoverageStats &Line) override;
+-
+-  void renderLineNumberColumn(raw_ostream &OS, unsigned LineNo) override;
+-
+-  void renderRegionMarkers(raw_ostream &OS, CoverageSegmentArray Segments,
+-                           unsigned ViewDepth) override;
+-
+-  void renderTitle(raw_ostream &OS, StringRef Title) override;
+-
+-  void renderTableHeader(raw_ostream &OS, unsigned FirstUncoveredLineNo,
+-                         unsigned IndentLevel) override;
+-
+-public:
+-  SourceCoverageViewText(StringRef SourceName, const MemoryBuffer &File,
+-                         const CoverageViewOptions &Options,
+-                         coverage::CoverageData &&CoverageInfo)
+-      : SourceCoverageView(SourceName, File, Options, std::move(CoverageInfo)) {
+-  }
+-};
+-
+-} // namespace llvm
+-
+-#endif // LLVM_COV_SOURCECOVERAGEVIEWTEXT_H
+diff --git a/tools/llvm-cov/TestingSupport.cpp b/tools/llvm-cov/TestingSupport.cpp
+index 4713d75f17d..5c2916220dc 100644
+--- a/tools/llvm-cov/TestingSupport.cpp
++++ b/tools/llvm-cov/TestingSupport.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- TestingSupport.cpp - Convert objects files into test files --------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -93,3 +94,4 @@ int convertForTestingMain(int argc, const char *argv[]) {
+ 
+   return 0;
+ }
++#endif
+diff --git a/tools/llvm-cov/gcov.cpp b/tools/llvm-cov/gcov.cpp
+index 4df7f015fd1..7790789b522 100644
+--- a/tools/llvm-cov/gcov.cpp
++++ b/tools/llvm-cov/gcov.cpp
+@@ -1,3 +1,4 @@
++#if 0
+ //===- gcov.cpp - GCOV compatible LLVM coverage tool ----------------------===//
+ //
+ //                     The LLVM Compiler Infrastructure
+@@ -143,3 +144,4 @@ int gcovMain(int argc, const char *argv[]) {
+                    Options);
+   return 0;
+ }
++#endif
+diff --git a/tools/llvm-cov/llvm-cov.cpp b/tools/llvm-cov/llvm-cov.cpp
+index 15841587025..5103688cd7c 100644
+--- a/tools/llvm-cov/llvm-cov.cpp
++++ b/tools/llvm-cov/llvm-cov.cpp
+@@ -11,6 +11,7 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++#if 0
+ #include "llvm/ADT/StringRef.h"
+ #include "llvm/ADT/StringSwitch.h"
+ #include "llvm/Support/CommandLine.h"
+@@ -57,8 +58,10 @@ static int versionMain(int argc, const char *argv[]) {
+   cl::PrintVersionMessage();
+   return 0;
+ }
++#endif
+ 
+ int main(int argc, const char **argv) {
++#if 0
+   // Print a stack trace if we signal out.
+   sys::PrintStackTraceOnErrorSignal(argv[0]);
+   PrettyStackTraceProgram X(argc, argv);
+@@ -96,5 +99,6 @@ int main(int argc, const char **argv) {
+       errs().resetColor();
+   }
+   helpMain(argc, argv);
++#endif
+   return 1;
+ }
+diff --git a/tools/llvm-profdata/llvm-profdata.cpp b/tools/llvm-profdata/llvm-profdata.cpp
+index eee242107da..595dc0e2c64 100644
+--- a/tools/llvm-profdata/llvm-profdata.cpp
++++ b/tools/llvm-profdata/llvm-profdata.cpp
+@@ -11,6 +11,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++#if 0
++
+ #include "llvm/ADT/SmallSet.h"
+ #include "llvm/ADT/SmallVector.h"
+ #include "llvm/ADT/StringRef.h"
+@@ -754,8 +756,10 @@ static int show_main(int argc, const char *argv[]) {
+     return showSampleProfile(Filename, ShowCounts, ShowAllFunctions,
+                              ShowFunction, OS);
+ }
++#endif
+ 
+ int main(int argc, const char *argv[]) {
++#if 0
+   // Print a stack trace if we signal out.
+   sys::PrintStackTraceOnErrorSignal(argv[0]);
+   PrettyStackTraceProgram X(argc, argv);
+@@ -794,5 +798,6 @@ int main(int argc, const char *argv[]) {
+     errs() << ProgName << ": Unknown command!\n";
+ 
+   errs() << "USAGE: " << ProgName << " <merge|show> [args...]\n";
++#endif
+   return 1;
+ }
+diff --git a/tools/sancov/sancov.cc b/tools/sancov/sancov.cc
+index 7f103ebb904..31de719f8c8 100644
+--- a/tools/sancov/sancov.cc
++++ b/tools/sancov/sancov.cc
+@@ -10,6 +10,7 @@
+ // This file is a command-line tool for reading and analyzing sanitizer
+ // coverage.
+ //===----------------------------------------------------------------------===//
++#if 0
+ #include "llvm/ADT/STLExtras.h"
+ #include "llvm/ADT/StringExtras.h"
+ #include "llvm/ADT/Twine.h"
+@@ -1199,8 +1200,10 @@ readSymbolizeAndMergeCmdArguments(std::vector<std::string> FileNames) {
+ }
+ 
+ } // namespace
++#endif
+ 
+ int main(int Argc, char **Argv) {
++#if 0
+   // Print stack trace if we signal out.
+   sys::PrintStackTraceOnErrorSignal(Argv[0]);
+   PrettyStackTraceProgram X(Argc, Argv);
+@@ -1264,4 +1267,6 @@ int main(int Argc, char **Argv) {
+   case PrintCovPointsAction:
+     llvm_unreachable("unsupported action");
+   }
++#endif
++  return 1;
+ }
+diff --git a/unittests/Support/ThreadPool.cpp b/unittests/Support/ThreadPool.cpp
+index 0da33ad50c0..50287484f29 100644
+--- a/unittests/Support/ThreadPool.cpp
++++ b/unittests/Support/ThreadPool.cpp
+@@ -7,6 +7,8 @@
+ //
+ //===----------------------------------------------------------------------===//
+ 
++#if 0
++
+ #include "llvm/Support/ThreadPool.h"
+ 
+ #include "llvm/ADT/STLExtras.h"
+@@ -164,3 +166,5 @@ TEST_F(ThreadPoolTest, PoolDestruction) {
+   }
+   ASSERT_EQ(5, checked_in);
+ }
++
++#endif
+-- 
+2.14.1
+

--- a/deps/patches/llvm-D34078-vectorize-fdiv.patch
+++ b/deps/patches/llvm-D34078-vectorize-fdiv.patch
@@ -1,0 +1,56 @@
+From f94d12b6108b944199b715f31f25a022f75d2feb Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sat, 10 Jun 2017 08:45:13 -0400
+Subject: [PATCH 4/4] Enable support for floating-point division reductions
+
+Similar to fsub, fdiv can also be vectorized using fmul.
+---
+ lib/Transforms/Utils/LoopUtils.cpp               |  1 +
+ test/Transforms/LoopVectorize/float-reduction.ll | 22 ++++++++++++++++++++++
+ 2 files changed, 23 insertions(+)
+
+diff --git a/lib/Transforms/Utils/LoopUtils.cpp b/lib/Transforms/Utils/LoopUtils.cpp
+index 3c522786641..a4aced53a95 100644
+--- a/lib/Transforms/Utils/LoopUtils.cpp
++++ b/lib/Transforms/Utils/LoopUtils.cpp
+@@ -451,6 +451,7 @@ RecurrenceDescriptor::isRecurrenceInstr(Instruction *I, RecurrenceKind Kind,
+     return InstDesc(Kind == RK_IntegerOr, I);
+   case Instruction::Xor:
+     return InstDesc(Kind == RK_IntegerXor, I);
++  case Instruction::FDiv:
+   case Instruction::FMul:
+     return InstDesc(Kind == RK_FloatMult, I, UAI);
+   case Instruction::FSub:
+diff --git a/test/Transforms/LoopVectorize/float-reduction.ll b/test/Transforms/LoopVectorize/float-reduction.ll
+index f3b95d0ead7..669c54d55a2 100644
+--- a/test/Transforms/LoopVectorize/float-reduction.ll
++++ b/test/Transforms/LoopVectorize/float-reduction.ll
+@@ -44,3 +44,25 @@ for.body:                                         ; preds = %for.body, %entry
+ for.end:                                          ; preds = %for.body
+   ret float %sub
+ }
++
++;CHECK-LABEL: @foodiv(
++;CHECK: fdiv fast <4 x float>
++;CHECK: ret
++define float @foodiv(float* nocapture %A, i32* nocapture %n) nounwind uwtable readonly ssp {
++entry:
++  br label %for.body
++
++for.body:                                         ; preds = %for.body, %entry
++  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
++  %sum.04 = phi float [ 1.000000e+00, %entry ], [ %sub, %for.body ]
++  %arrayidx = getelementptr inbounds float, float* %A, i64 %indvars.iv
++  %0 = load float, float* %arrayidx, align 4
++  %sub = fdiv fast float %sum.04, %0
++  %indvars.iv.next = add i64 %indvars.iv, 1
++  %lftr.wideiv = trunc i64 %indvars.iv.next to i32
++  %exitcond = icmp eq i32 %lftr.wideiv, 200
++  br i1 %exitcond, label %for.end, label %for.body
++
++for.end:                                          ; preds = %for.body
++  ret float %sub
++}
+-- 
+2.14.1
+

--- a/deps/patches/llvm-loadcse-addrspace_5.0.patch
+++ b/deps/patches/llvm-loadcse-addrspace_5.0.patch
@@ -1,0 +1,104 @@
+From b252987fe34a314524428d27a85a87fdd746e0b5 Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sun, 18 Jun 2017 16:45:38 -0400
+Subject: [PATCH 2/4] Disable LoadCSE and Store forwarding between different
+ address space or between non-integral pointer and integers.
+
+---
+ lib/Analysis/Loads.cpp                             | 30 +++++++++++++++++++
+ .../InstCombine/non-integral-pointers.ll           | 34 ++++++++++++++++++++++
+ 2 files changed, 64 insertions(+)
+
+diff --git a/lib/Analysis/Loads.cpp b/lib/Analysis/Loads.cpp
+index 591b0fc481d..e9c8be82b03 100644
+--- a/lib/Analysis/Loads.cpp
++++ b/lib/Analysis/Loads.cpp
+@@ -380,6 +380,21 @@ Value *llvm::FindAvailablePtrLoadStore(Value *Ptr, Type *AccessTy,
+         if (LI->isAtomic() < AtLeastAtomic)
+           return nullptr;
+ 
++        if (AccessTy->isPointerTy()) {
++          PointerType *Ty1 = cast<PointerType>(AccessTy);
++          if (PointerType *Ty2 = dyn_cast<PointerType>(LI->getType())) {
++            if (Ty1->getAddressSpace() != Ty2->getAddressSpace()) {
++              return nullptr;
++            }
++          }
++          else if (DL.isNonIntegralPointerType(Ty1)) {
++            return nullptr;
++          }
++        }
++        else if (DL.isNonIntegralPointerType(LI->getType())) {
++          return nullptr;
++        }
++
+         if (IsLoadCSE)
+             *IsLoadCSE = true;
+         return LI;
+@@ -399,6 +414,21 @@ Value *llvm::FindAvailablePtrLoadStore(Value *Ptr, Type *AccessTy,
+         if (SI->isAtomic() < AtLeastAtomic)
+           return nullptr;
+ 
++        if (AccessTy->isPointerTy()) {
++          PointerType *Ty1 = cast<PointerType>(AccessTy);
++          if (PointerType *Ty2 = dyn_cast<PointerType>(SI->getValueOperand()->getType())) {
++            if (Ty1->getAddressSpace() != Ty2->getAddressSpace()) {
++              return nullptr;
++            }
++          }
++          else if (DL.isNonIntegralPointerType(Ty1)) {
++            return nullptr;
++          }
++        }
++        else if (DL.isNonIntegralPointerType(SI->getValueOperand()->getType())) {
++          return nullptr;
++        }
++
+         if (IsLoadCSE)
+           *IsLoadCSE = false;
+         return SI->getOperand(0);
+diff --git a/test/Transforms/InstCombine/non-integral-pointers.ll b/test/Transforms/InstCombine/non-integral-pointers.ll
+index 4f54fe6737d..96a2b2edaf1 100644
+--- a/test/Transforms/InstCombine/non-integral-pointers.ll
++++ b/test/Transforms/InstCombine/non-integral-pointers.ll
+@@ -46,3 +46,37 @@ entry:
+   store i8 addrspace(3)* %val, i8 addrspace(3)** %ptr1
+   ret void
+ }
++
++define i64 @g(i8 addrspace(4)** %gp) {
++  ; CHECK-LABEL: @g(
++  ; CHECK: load
++  %.pre = load i8 addrspace(4)*, i8 addrspace(4)** %gp, align 8
++  %v74 = call i8 addrspace(4)* @alloc()
++  %v75 = addrspacecast i8 addrspace(4)* %v74 to i8*
++  %v76 = bitcast i8* %v75 to i8 addrspace(4)**
++  %v77 = getelementptr i8 addrspace(4)*, i8 addrspace(4)** %v76, i64 -1
++  ; CHECK: store
++  store i8 addrspace(4)* %.pre, i8 addrspace(4)** %v77, align 8
++  %v80 = bitcast i8 addrspace(4)** %v77 to i64*
++  ; CHECK: load
++  ; CHECK-NOT: ptrtoint
++  %v81 = load i64, i64* %v80, align 8
++  ret i64 %v81
++}
++
++define i64 @g2(i8* addrspace(4)* %gp) {
++  ; CHECK-LABEL: @g2(
++  ; CHECK: load
++  %.pre = load i8*, i8* addrspace(4)* %gp, align 8
++  %v74 = call i8 addrspace(4)* @alloc()
++  %v76 = bitcast i8 addrspace(4)* %v74 to i8* addrspace(4)*
++  %v77 = getelementptr i8*, i8* addrspace(4)* %v76, i64 -1
++  ; CHECK: store
++  store i8* %.pre, i8* addrspace(4)* %v77, align 8
++  %v80 = bitcast i8* addrspace(4)* %v77 to i64 addrspace(4)*
++  ; CHECK-NOT: store
++  %v81 = load i64, i64 addrspace(4)* %v80, align 8
++  ret i64 %v81
++}
++
++declare i8 addrspace(4)* @alloc()
+-- 
+2.14.1
+


### PR DESCRIPTION
The one patch that isn't included is the `llvm-Yet-another-fix.patch`, which was my comment in https://reviews.llvm.org/D33110#783268. I'm not sure if the issue is fixed in LLVM but I didn't see any issue without it. I do remember @keno mentioned that he found a test case himself so maybe it was integrated in a less obvious way?

Together with https://github.com/JuliaLang/julia/pull/23892, compilation and all tests passes (on anubis) with LLVM assertion enabled.
