### PR TITLE
Add another LLVM patch for non-integral ptrtoint fix on LLVM 4.0

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -481,6 +481,7 @@ $(eval $(call LLVM_PATCH,llvm-D32623-GVN-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D33129-scevexpander-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-Yet-another-fix))
 $(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
+$(eval $(call LLVM_PATCH,llvm-loadcse-addrspace_4.0))
 endif # LLVM_VER
 
 $(LLVM_BUILDDIR_withtype)/build-configured: $(LLVM_PATCH_PREV)

--- a/deps/patches/llvm-loadcse-addrspace_4.0.patch
+++ b/deps/patches/llvm-loadcse-addrspace_4.0.patch
@@ -1,0 +1,61 @@
+From 01ae2614aa184fcf88b0880f5944a23da6f215db Mon Sep 17 00:00:00 2001
+From: Yichao Yu <yyc1992@gmail.com>
+Date: Sun, 18 Jun 2017 16:45:38 -0400
+Subject: [PATCH] Disable LoadCSE and Store forwarding between different
+ address space or between non-integral pointer and integers.
+
+---
+ lib/Analysis/Loads.cpp | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/lib/Analysis/Loads.cpp b/lib/Analysis/Loads.cpp
+index e46541e6538..971ce37a4a5 100644
+--- a/lib/Analysis/Loads.cpp
++++ b/lib/Analysis/Loads.cpp
+@@ -362,6 +362,21 @@ Value *llvm::FindAvailableLoadedValue(LoadInst *Load,
+         if (LI->isAtomic() < Load->isAtomic())
+           return nullptr;
+ 
++        if (Load->getType()->isPointerTy()) {
++          PointerType *Ty1 = cast<PointerType>(Load->getType());
++          if (PointerType *Ty2 = dyn_cast<PointerType>(LI->getType())) {
++            if (Ty1->getAddressSpace() != Ty2->getAddressSpace()) {
++              return nullptr;
++            }
++          }
++          else if (DL.isNonIntegralPointerType(Ty1)) {
++            return nullptr;
++          }
++        }
++        else if (DL.isNonIntegralPointerType(LI->getType())) {
++          return nullptr;
++        }
++
+         if (IsLoadCSE)
+             *IsLoadCSE = true;
+         return LI;
+@@ -381,6 +396,21 @@ Value *llvm::FindAvailableLoadedValue(LoadInst *Load,
+         if (SI->isAtomic() < Load->isAtomic())
+           return nullptr;
+ 
++        if (Load->getType()->isPointerTy()) {
++          PointerType *Ty1 = cast<PointerType>(Load->getType());
++          if (PointerType *Ty2 = dyn_cast<PointerType>(SI->getValueOperand()->getType())) {
++            if (Ty1->getAddressSpace() != Ty2->getAddressSpace()) {
++              return nullptr;
++            }
++          }
++          else if (DL.isNonIntegralPointerType(Ty1)) {
++            return nullptr;
++          }
++        }
++        else if (DL.isNonIntegralPointerType(SI->getValueOperand()->getType())) {
++          return nullptr;
++        }
++
+         if (IsLoadCSE)
+           *IsLoadCSE = false;
+         return SI->getOperand(0);
+-- 
+2.13.1
+


### PR DESCRIPTION
This has been lying around for a really long time. Apparently no one need LLVM 4.0 ;-p

Mostly just for completeness. A updated version is also included in https://github.com/JuliaLang/julia/pull/23893 for LLVM 5.0.

All tests pass locally (on anubis).
