### PR TITLE
eliminate full from test/linalg/special.jl

### DIFF
--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -9,66 +9,66 @@ srand(1)
     a = [1.0:n;]
     A = Diagonal(a)
     @testset for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
-       @test full(convert(newtype, Diagonal(GenericArray(a)))) == full(A)
+       @test Matrix(convert(newtype, A)) == Matrix(A)
+       @test Matrix(convert(newtype, Diagonal(GenericArray(a)))) == Matrix(A)
     end
 
     @testset for isupper in (true, false)
         A = Bidiagonal(a, [1.0:n-1;], ifelse(isupper, :U, :L))
         for newtype in [Bidiagonal, Tridiagonal, Matrix]
-           @test full(convert(newtype, A)) == full(A)
-           @test full(newtype(A)) == full(A)
+           @test Matrix(convert(newtype, A)) == Matrix(A)
+           @test Matrix(newtype(A)) == Matrix(A)
         end
         @test_throws ArgumentError convert(SymTridiagonal, A)
         tritype = isupper ? UpperTriangular : LowerTriangular
-        @test full(tritype(A)) == full(A)
+        @test Matrix(tritype(A)) == Matrix(A)
 
         A = Bidiagonal(a, zeros(n-1), ifelse(isupper, :U, :L)) #morally Diagonal
         for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Tridiagonal, Matrix]
-           @test full(convert(newtype, A)) == full(A)
-           @test full(newtype(A)) == full(A)
+           @test Matrix(convert(newtype, A)) == Matrix(A)
+           @test Matrix(newtype(A)) == Matrix(A)
         end
-        @test full(tritype(A)) == full(A)
+        @test Matrix(tritype(A)) == Matrix(A)
     end
 
     A = SymTridiagonal(a, [1.0:n-1;])
     for newtype in [Tridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test Matrix(convert(newtype, A)) == Matrix(A)
     end
     for newtype in [Diagonal, Bidiagonal]
        @test_throws ArgumentError convert(newtype,A)
     end
     A = SymTridiagonal(a, zeros(n-1))
-    @test full(convert(Bidiagonal,A)) == full(A)
+    @test Matrix(convert(Bidiagonal,A)) == Matrix(A)
 
     A = Tridiagonal(zeros(n-1), [1.0:n;], zeros(n-1)) #morally Diagonal
     for newtype in [Diagonal, Bidiagonal, SymTridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test Matrix(convert(newtype, A)) == Matrix(A)
     end
     A = Tridiagonal(ones(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
     for newtype in [SymTridiagonal, Matrix]
-       @test full(convert(newtype, A)) == full(A)
+       @test Matrix(convert(newtype, A)) == Matrix(A)
     end
     for newtype in [Diagonal, Bidiagonal]
         @test_throws ArgumentError convert(newtype,A)
     end
     A = Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)) #not morally Diagonal
-    @test full(convert(Bidiagonal, A)) == full(A)
+    @test Matrix(convert(Bidiagonal, A)) == Matrix(A)
     A = UpperTriangular(Tridiagonal(zeros(n-1), [1.0:n;], ones(n-1)))
-    @test full(convert(Bidiagonal, A)) == full(A)
+    @test Matrix(convert(Bidiagonal, A)) == Matrix(A)
     A = Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)) #not morally Diagonal
-    @test full(convert(Bidiagonal, A)) == full(A)
+    @test Matrix(convert(Bidiagonal, A)) == Matrix(A)
     A = LowerTriangular(Tridiagonal(ones(n-1), [1.0:n;], zeros(n-1)))
-    @test full(convert(Bidiagonal, A)) == full(A)
+    @test Matrix(convert(Bidiagonal, A)) == Matrix(A)
     @test_throws ArgumentError convert(SymTridiagonal,A)
 
-    A = LowerTriangular(full(Diagonal(a))) #morally Diagonal
+    A = LowerTriangular(Matrix(Diagonal(a))) #morally Diagonal
     for newtype in [Diagonal, Bidiagonal, SymTridiagonal, LowerTriangular, Matrix]
-        @test full(convert(newtype, A)) == full(A)
+        @test Matrix(convert(newtype, A)) == Matrix(A)
     end
-    A = UpperTriangular(full(Diagonal(a))) #morally Diagonal
+    A = UpperTriangular(Matrix(Diagonal(a))) #morally Diagonal
     for newtype in [Diagonal, Bidiagonal, SymTridiagonal, UpperTriangular, Matrix]
-        @test full(convert(newtype, A)) == full(A)
+        @test Matrix(convert(newtype, A)) == Matrix(A)
     end
     A = UpperTriangular(triu(rand(n,n)))
     for newtype in [Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal]
@@ -84,26 +84,26 @@ end
         for type2 in Spectypes
            B = convert(type1,A)
            C = convert(type2,A)
-           @test full(B + C) ≈ full(A + A)
-           @test full(B - C) ≈ full(A - A)
+           @test Matrix(B + C) ≈ Matrix(A + A)
+           @test Matrix(B - C) ≈ Matrix(A - A)
        end
     end
     B = SymTridiagonal(a, ones(n-1))
     for Spectype in [Diagonal, Bidiagonal, Tridiagonal, Matrix]
-        @test full(B + convert(Spectype,A)) ≈ full(B + A)
-        @test full(convert(Spectype,A) + B) ≈ full(B + A)
-        @test full(B - convert(Spectype,A)) ≈ full(B - A)
-        @test full(convert(Spectype,A) - B) ≈ full(A - B)
+        @test Matrix(B + convert(Spectype,A)) ≈ Matrix(B + A)
+        @test Matrix(convert(Spectype,A) + B) ≈ Matrix(B + A)
+        @test Matrix(B - convert(Spectype,A)) ≈ Matrix(B - A)
+        @test Matrix(convert(Spectype,A) - B) ≈ Matrix(A - B)
     end
 
     C = rand(n,n)
     for TriType in [Base.LinAlg.UnitLowerTriangular, Base.LinAlg.UnitUpperTriangular, UpperTriangular, LowerTriangular]
         D = TriType(C)
         for Spectype in [Diagonal, Bidiagonal, Tridiagonal, Matrix]
-            @test full(D + convert(Spectype,A)) ≈ full(D + A)
-            @test full(convert(Spectype,A) + D) ≈ full(A + D)
-            @test full(D - convert(Spectype,A)) ≈ full(D - A)
-            @test full(convert(Spectype,A) - D) ≈ full(A - D)
+            @test Matrix(D + convert(Spectype,A)) ≈ Matrix(D + A)
+            @test Matrix(convert(Spectype,A) + D) ≈ Matrix(A + D)
+            @test Matrix(D - convert(Spectype,A)) ≈ Matrix(D - A)
+            @test Matrix(convert(Spectype,A) - D) ≈ Matrix(A - D)
         end
     end
 end
@@ -114,11 +114,11 @@ end
         atri = typ(a)
         b = rand(n,n)
         qrb = qrfact(b,Val(true))
-        @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
-        @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+        @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ Matrix(atri) * qrb[:Q]'
+        @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ Matrix(atri) * qrb[:Q]'
         qrb = qrfact(b,Val(false))
-        @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ full(atri) * qrb[:Q]'
-        @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ full(atri) * qrb[:Q]'
+        @test Base.LinAlg.A_mul_Bc(atri,qrb[:Q]) ≈ Matrix(atri) * qrb[:Q]'
+        @test Base.LinAlg.A_mul_Bc!(copy(atri),qrb[:Q]) ≈ Matrix(atri) * qrb[:Q]'
     end
 end
 


### PR DESCRIPTION
Another small step towards deprecation of `full`. Ref. JuliaLang/LinearAlgebra.jl#229, JuliaLang/LinearAlgebra.jl#231, JuliaLang/julia#18850, and linked threads. Best!