### PR TITLE
random: remove useless @inline

### DIFF
--- a/base/random/RNGs.jl
+++ b/base/random/RNGs.jl
@@ -236,8 +236,8 @@ rand(r::MersenneTwister, I::FloatInterval) = rand_generic(r, I)
 #### integers
 
 rand(r::MersenneTwister,
-             ::Type{T}) where {T<:Union{Bool,Int8,UInt8,Int16,UInt16,Int32,UInt32}} =
-                 rand_ui52_raw(r) % T
+     ::Type{T}) where {T<:Union{Bool,Int8,UInt8,Int16,UInt16,Int32,UInt32}} =
+    rand_ui52_raw(r) % T
 
 function rand(r::MersenneTwister, ::Type{UInt64})
     reserve(r, 2)

--- a/base/random/generation.jl
+++ b/base/random/generation.jl
@@ -6,12 +6,12 @@
 
 ### GLOBAL_RNG fallback for all types
 
-@inline rand(T::Type) = rand(GLOBAL_RNG, T)
+rand(::Type{T}) where {T} = rand(GLOBAL_RNG, T)
 
 ### random floats
 
 # CloseOpen(T) is the fallback for an AbstractFloat T
-@inline rand(r::AbstractRNG=GLOBAL_RNG, ::Type{T}=Float64) where {T<:AbstractFloat} =
+rand(r::AbstractRNG=GLOBAL_RNG, ::Type{T}=Float64) where {T<:AbstractFloat} =
     rand(r, CloseOpen(T))
 
 # generic random generation function which can be used by RNG implementors
@@ -95,8 +95,8 @@ rand_generic(rng::AbstractRNG, I::FloatInterval{BigFloat}) =
 rand_ui10_raw(r::AbstractRNG) = rand(r, UInt16)
 rand_ui23_raw(r::AbstractRNG) = rand(r, UInt32)
 
-@inline rand_ui52_raw(r::AbstractRNG) = reinterpret(UInt64, rand(r, Close1Open2()))
-@inline rand_ui52(r::AbstractRNG) = rand_ui52_raw(r) & 0x000fffffffffffff
+rand_ui52_raw(r::AbstractRNG) = reinterpret(UInt64, rand(r, Close1Open2()))
+rand_ui52(r::AbstractRNG) = rand_ui52_raw(r) & 0x000fffffffffffff
 
 ### random complex numbers
 
@@ -131,10 +131,14 @@ rand(                dims::Dims)       = rand(GLOBAL_RNG, dims)
 rand(r::AbstractRNG, dims::Integer...) = rand(r, Dims(dims))
 rand(                dims::Integer...) = rand(Dims(dims))
 
-rand(r::AbstractRNG, T::Type, dims::Dims)                   = rand!(r, Array{T}(dims))
-rand(                T::Type, dims::Dims)                   = rand(GLOBAL_RNG, T, dims)
-rand(r::AbstractRNG, T::Type, d::Integer, dims::Integer...) = rand(r, T, Dims((d, dims...)))
-rand(                T::Type, d::Integer, dims::Integer...) = rand(T, Dims((d, dims...)))
+rand(r::AbstractRNG, ::Type{T}, dims::Dims) where {T} = rand!(r, Array{T}(dims))
+rand(                ::Type{T}, dims::Dims) where {T} = rand(GLOBAL_RNG, T, dims)
+
+rand(r::AbstractRNG, ::Type{T}, d::Integer, dims::Integer...) where {T} =
+    rand(r, T, Dims((d, dims...)))
+
+rand(                ::Type{T}, d::Integer, dims::Integer...) where {T} =
+    rand(T, Dims((d, dims...)))
 # note: the above methods would trigger an ambiguity warning if d was not separated out:
 # rand(r, ()) would match both this method and rand(r, dims::Dims)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop

--- a/base/random/normal.jl
+++ b/base/random/normal.jl
@@ -45,7 +45,7 @@ julia> randn(rng, Complex64, (2, 3))
 end
 
 # this unlikely branch is put in a separate function for better efficiency
-function randn_unlikely(rng, idx, rabs, x)
+@noinline function randn_unlikely(rng, idx, rabs, x)
     @inbounds if idx == 0
         while true
             xx = -ziggurat_nor_inv_r*log(rand(rng))
@@ -93,7 +93,7 @@ julia> randexp(rng, 3, 3)
  0.695867  0.693292  0.643644
 ```
 """
-@inline function randexp(rng::AbstractRNG=GLOBAL_RNG)
+function randexp(rng::AbstractRNG=GLOBAL_RNG)
     @inbounds begin
         ri = rand_ui52(rng)
         idx = ri & 0xFF
@@ -103,7 +103,7 @@ julia> randexp(rng, 3, 3)
     end
 end
 
-function randexp_unlikely(rng, idx, x)
+@noinline function randexp_unlikely(rng, idx, x)
     @inbounds if idx == 0
         return ziggurat_exp_r - log(rand(rng))
     elseif (fe[idx] - fe[idx+1])*rand(rng) + fe[idx+1] < exp(-x)


### PR DESCRIPTION
I did more or less what was suggested [here](https://github.com/JuliaLang/julia/pull/21401#issuecomment-315067146) for files in "random/", i.e. remove `@inline` annotations and check if performance is degraded. According to "BaseBenchmarks/src/random", there are two regressions:
1. `randn`, for which I guess it's too critical, so I re-added `@inline`
2. ~~`randstring`: by maybe about 30%. It was not obvious which set of `@inline` are contributing to the regression, but I would believe that it's not a time critical function, so that it would be OK.~~ (EDIT: not anymore on master, see post below)

I didn't run the whole BaseBenchmarks suite locally, so will run it here to check for other possible regressions: @nanosoldier `runbenchmarks(ALL, vs=":master")`