### PR TITLE
Add mechanism for binding deprecation messages

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -112,9 +112,12 @@ end
 
 deprecate(m::Module, s::Symbol, flag=1) = ccall(:jl_deprecate_binding, Void, (Any, Any, Cint), m, s, flag)
 
-macro deprecate_binding(old, new, export_old=true)
+macro deprecate_binding(old, new, export_old=true, dep_message=nothing)
     return Expr(:toplevel,
          export_old ? Expr(:export, esc(old)) : nothing,
+         dep_message != nothing ? Expr(:const, Expr(:(=),
+             esc(Symbol(string("_dep_message_",old))), esc(dep_message))) :
+             nothing,
          Expr(:const, Expr(:(=), esc(old), esc(new))),
          Expr(:call, :deprecate, __module__, Expr(:quote, old)))
 end
@@ -1716,8 +1719,8 @@ import .LinAlg: diagm
 @eval LinAlg.LAPACK @deprecate laver() version() false
 
 # PR #23427
-@deprecate_binding e          ℯ
-@deprecate_binding eu         ℯ
+@deprecate_binding e          ℯ true ", use ℯ (\\euler) or Base.MathConstants.e"
+@deprecate_binding eu         ℯ true ", use ℯ (\\euler) or Base.MathConstants.e"
 @deprecate_binding γ          MathConstants.γ
 @deprecate_binding eulergamma MathConstants.eulergamma
 @deprecate_binding catalan    MathConstants.catalan

--- a/src/module.c
+++ b/src/module.c
@@ -492,6 +492,19 @@ JL_DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var)
 extern const char *jl_filename;
 extern int jl_lineno;
 
+char dep_message_prefix[] = "_dep_message_";
+
+jl_binding_t *jl_get_dep_message_binding(jl_module_t *m, jl_binding_t *deprecated_binding)
+{
+    size_t prefix_len = strlen(dep_message_prefix);
+    size_t name_len = strlen(jl_symbol_name(deprecated_binding->name));
+    char *dep_binding_name = (char*)alloca(prefix_len+name_len+1);
+    memcpy(dep_binding_name, dep_message_prefix, prefix_len);
+    memcpy(dep_binding_name + prefix_len, jl_symbol_name(deprecated_binding->name), name_len);
+    dep_binding_name[prefix_len+name_len] = '\0';
+    return jl_get_binding(m, jl_symbol(dep_binding_name));
+}
+
 void jl_binding_deprecation_warning(jl_binding_t *b)
 {
     // Only print a warning for deprecated == 1 (renamed).
@@ -500,29 +513,42 @@ void jl_binding_deprecation_warning(jl_binding_t *b)
     if (b->deprecated == 1 && jl_options.depwarn) {
         if (jl_options.depwarn != JL_OPTIONS_DEPWARN_ERROR)
             jl_printf(JL_STDERR, "WARNING: ");
-        if (b->owner)
+        jl_binding_t *dep_message_binding = NULL;
+        if (b->owner) {
             jl_printf(JL_STDERR, "%s.%s is deprecated",
                       jl_symbol_name(b->owner->name), jl_symbol_name(b->name));
+            dep_message_binding = jl_get_dep_message_binding(b->owner, b);
+        }
         else
             jl_printf(JL_STDERR, "%s is deprecated", jl_symbol_name(b->name));
-        jl_value_t *v = b->value;
-        if (v) {
-            if (jl_is_type(v) || jl_is_module(v)) {
-                jl_printf(JL_STDERR, ", use ");
-                jl_static_show(JL_STDERR, v);
-                jl_printf(JL_STDERR, " instead");
+
+        if (dep_message_binding && dep_message_binding->value) {
+            if (jl_isa(dep_message_binding->value, (jl_value_t*)jl_string_type)) {
+                jl_uv_puts(JL_STDERR, jl_string_data(dep_message_binding->value),
+                    jl_string_len(dep_message_binding->value));
+            } else {
+                jl_static_show(JL_STDERR, dep_message_binding->value);
             }
-            else {
-                jl_methtable_t *mt = jl_gf_mtable(v);
-                if (mt != NULL && (mt->defs.unknown != jl_nothing ||
-                                   jl_isa(v, (jl_value_t*)jl_builtin_type))) {
+        } else {
+            jl_value_t *v = b->value;
+            if (v) {
+                if (jl_is_type(v) || jl_is_module(v)) {
                     jl_printf(JL_STDERR, ", use ");
-                    if (mt->module != jl_core_module) {
-                        jl_static_show(JL_STDERR, (jl_value_t*)mt->module);
-                        jl_printf(JL_STDERR, ".");
-                    }
-                    jl_printf(JL_STDERR, "%s", jl_symbol_name(mt->name));
+                    jl_static_show(JL_STDERR, v);
                     jl_printf(JL_STDERR, " instead");
+                }
+                else {
+                    jl_methtable_t *mt = jl_gf_mtable(v);
+                    if (mt != NULL && (mt->defs.unknown != jl_nothing ||
+                                       jl_isa(v, (jl_value_t*)jl_builtin_type))) {
+                        jl_printf(JL_STDERR, ", use ");
+                        if (mt->module != jl_core_module) {
+                            jl_static_show(JL_STDERR, (jl_value_t*)mt->module);
+                            jl_printf(JL_STDERR, ".");
+                        }
+                        jl_printf(JL_STDERR, "%s", jl_symbol_name(mt->name));
+                        jl_printf(JL_STDERR, " instead");
+                    }
                 }
             }
         }


### PR DESCRIPTION
Now, when encountering a deprecated binding `foo`, we will look up
`_dep_message_foo` in that binding's owner module and print the
value of that binding (if it exists).

Demo:
```
julia> e
WARNING: Base.e is deprecated, use ℯ (\euler) or Base.MathConstants.e.
  likely near no file:0
ℯ = 2.7182818284590...
```

Fixes #23526.