### PR TITLE
Change in `generic_vecnorm`s

### DIFF
--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -280,10 +280,10 @@ diag(A::AbstractVector) = throw(ArgumentError("use diagm instead of diag to cons
 function generic_vecnormMinusInf(x)
     s = start(x)
     (v, s) = next(x, s)
-    minabs = norm(v)
+    minabs = norm(v,-Inf)
     while !done(x, s)
         (v, s) = next(x, s)
-        vnorm = norm(v)
+        vnorm = norm(v,-Inf)
         minabs = ifelse(isnan(minabs) | (minabs < vnorm), minabs, vnorm)
     end
     return float(minabs)
@@ -292,10 +292,10 @@ end
 function generic_vecnormInf(x)
     s = start(x)
     (v, s) = next(x, s)
-    maxabs = norm(v)
+    maxabs = norm(v,Inf)
     while !done(x, s)
         (v, s) = next(x, s)
-        vnorm = norm(v)
+        vnorm = norm(v,Inf)
         maxabs = ifelse(isnan(maxabs) | (maxabs > vnorm), maxabs, vnorm)
     end
     return float(maxabs)
@@ -304,12 +304,12 @@ end
 function generic_vecnorm1(x)
     s = start(x)
     (v, s) = next(x, s)
-    av = float(norm(v))
+    av = float(norm(v,1))
     T = typeof(av)
     sum::promote_type(Float64, T) = av
     while !done(x, s)
         (v, s) = next(x, s)
-        sum += norm(v)
+        sum += norm(v,1)
     end
     return convert(T, sum)
 end
@@ -352,21 +352,21 @@ function generic_vecnormp(x, p)
         (maxabs == 0 || isinf(maxabs)) && return maxabs
         T = typeof(maxabs)
     else
-        T = typeof(float(norm(v)))
+        T = typeof(float(norm(v,p)))
     end
     spp::promote_type(Float64, T) = p
     if -1 <= p <= 1 || (isfinite(_length(x)*maxabs^spp) && maxabs^spp != 0) # scaling not necessary
         sum::promote_type(Float64, T) = norm(v)^spp
         while !done(x, s)
             (v, s) = next(x, s)
-            sum += norm(v)^spp
+            sum += norm(v,p)^spp
         end
         return convert(T, sum^inv(spp))
     else # rescaling
         sum = (norm(v)/maxabs)^spp
         while !done(x, s)
             (v, s) = next(x, s)
-            sum += (norm(v)/maxabs)^spp
+            sum += (norm(v,p)/maxabs)^spp
         end
         return convert(T, maxabs*sum^inv(spp))
     end


### PR DESCRIPTION
By default, `generic_vecnorm` of `1,2,Inf,-Inf,p`, takes `norm(v)^p` (taking `p` as the general case which includes 1,2,Inf,-Inf). Normally, `v` is a `Number` so `norm(v)` just applies the 
```julia 
@inline vecnorm(x::Number, p::Real=2) = p == 0 ? (x==0 ? zero(abs(x)) : oneunit(abs(x))) : abs(x)
 ```
method.
This change is made because in some _strange_ cases, `v` is not a `Number` but an `Array` and it's more convenient to take `norm(v,p)` instead of `norm(v)`.