### PR TITLE
Fix a small number of invalid unsafe code

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -171,6 +171,8 @@ that N is inbounds on either array. Incorrect usage may corrupt or segfault your
 the same manner as C.
 """
 function unsafe_copy!(dest::Array{T}, doffs, src::Array{T}, soffs, n) where T
+    t1 = @_gc_preserve_begin dest
+    t2 = @_gc_preserve_begin src
     if isbits(T)
         unsafe_copy!(pointer(dest, doffs), pointer(src, soffs), n)
     elseif isbitsunion(T)
@@ -185,6 +187,8 @@ function unsafe_copy!(dest::Array{T}, doffs, src::Array{T}, soffs, n) where T
         ccall(:jl_array_ptr_copy, Void, (Any, Ptr{Void}, Any, Ptr{Void}, Int),
               dest, pointer(dest, doffs), src, pointer(src, soffs), n)
     end
+    @_gc_preserve_end t2
+    @_gc_preserve_end t1
     return dest
 end
 
@@ -1570,6 +1574,7 @@ function vcat(arrays::Vector{T}...) where T
     else
         elsz = Core.sizeof(Ptr{Void})
     end
+    t = @_gc_preserve_begin arr
     for a in arrays
         na = length(a)
         nba = na * elsz
@@ -1589,6 +1594,7 @@ function vcat(arrays::Vector{T}...) where T
         end
         ptr += nba
     end
+    @_gc_preserve_end t
     return arr
 end
 

--- a/base/datafmt.jl
+++ b/base/datafmt.jl
@@ -130,7 +130,7 @@ function readdlm_auto(input::AbstractString, dlm::Char, T::Type, eol::Char, auto
         # TODO: It would be nicer to use String(a) without making a copy,
         # but because the mmap'ed array is not NUL-terminated this causes
         # jl_try_substrtod to segfault below.
-        return readdlm_string(unsafe_string(pointer(a),length(a)), dlm, T, eol, auto, optsd)
+        return readdlm_string(Base.@gc_preserve(a, unsafe_string(pointer(a),length(a))), dlm, T, eol, auto, optsd)
     else
         return readdlm_string(read(input, String), dlm, T, eol, auto, optsd)
     end
@@ -220,7 +220,7 @@ function DLMStore(::Type{T}, dims::NTuple{2,Integer},
 end
 
 _chrinstr(sbuff::String, chr::UInt8, startpos::Int, endpos::Int) =
-    (endpos >= startpos) && (C_NULL != ccall(:memchr, Ptr{UInt8},
+    Base.@gc_preserve sbuff (endpos >= startpos) && (C_NULL != ccall(:memchr, Ptr{UInt8},
     (Ptr{UInt8}, Int32, Csize_t), pointer(sbuff)+startpos-1, chr, endpos-startpos+1))
 
 function store_cell(dlmstore::DLMStore{T}, row::Int, col::Int,

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -46,7 +46,7 @@ function deepcopy_internal(x::String, stackdict::ObjectIdDict)
     if haskey(stackdict, x)
         return stackdict[x]
     end
-    y = unsafe_string(pointer(x), sizeof(x))
+    y = @gc_preserve x unsafe_string(pointer(x), sizeof(x))
     stackdict[x] = y
     return y
 end

--- a/base/env.jl
+++ b/base/env.jl
@@ -99,7 +99,7 @@ if Sys.iswindows()
         blk = block[2]
         len = ccall(:wcslen, UInt, (Ptr{UInt16},), pos)
         buf = Vector{UInt16}(len)
-        unsafe_copy!(pointer(buf), pos, len)
+        @gc_preserve buf unsafe_copy!(pointer(buf), pos, len)
         env = transcode(String, buf)
         m = match(r"^(=?[^=]+)=(.*)$"s, env)
         if m === nothing

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -252,7 +252,7 @@ function tryparse_internal(::Type{BigInt}, s::AbstractString, startpos::Int, end
     if Base.containsnul(bstr)
         err = -1 # embedded NUL char (not handled correctly by GMP)
     else
-        err = MPZ.set_str!(z, pointer(bstr)+(i-start(bstr)), base)
+        err = Base.@gc_preserve bstr MPZ.set_str!(z, pointer(bstr)+(i-start(bstr)), base)
     end
     if err != 0
         raise && throw(ArgumentError("invalid BigInt: $(repr(bstr))"))
@@ -612,7 +612,7 @@ function base(b::Integer, n::BigInt, pad::Integer=1)
     nd1 = ndigits(n, b)
     nd  = max(nd1, pad)
     sv  = Base.StringVector(nd + isneg(n))
-    MPZ.get_str!(pointer(sv) + nd - nd1, b, n)
+    Base.@gc_preserve sv MPZ.get_str!(pointer(sv) + nd - nd1, b, n)
     @inbounds for i = (1:nd-nd1) .+ isneg(n)
         sv[i] = '0' % UInt8
     end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -264,7 +264,7 @@ end
 function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)
     olb = lb = length(b)
     nr = 0
-    while nr < nb
+    @gc_preserve b while nr < nb
         if lb < nr+1
             lb = max(65536, (nr+1) * 2)
             resize!(b, lb)
@@ -284,8 +284,8 @@ function readbytes_some!(s::IOStream, b::Array{UInt8}, nb)
     if nb > lb
         resize!(b, nb)
     end
-    nr = Int(ccall(:ios_read, Csize_t, (Ptr{Void}, Ptr{Void}, Csize_t),
-                   s.ios, pointer(b), nb))
+    nr = @gc_preserve b Int(ccall(:ios_read, Csize_t, (Ptr{Void}, Ptr{Void}, Csize_t),
+                                  s.ios, pointer(b), nb))
     if lb > olb && lb > nr
         resize!(b, nr)
     end

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -249,7 +249,7 @@ function gethostname()
         ccall(:gethostname, Int32, (Ptr{UInt8}, UInt), hn, length(hn))
     end
     systemerror("gethostname", err != 0)
-    return unsafe_string(pointer(hn))
+    return Base.@gc_preserve hn unsafe_string(pointer(hn))
 end
 
 ## system error handling ##
@@ -305,7 +305,7 @@ if Sys.iswindows()
         p = lpMsgBuf[]
         len == 0 && return ""
         buf = Vector{UInt16}(len)
-        unsafe_copy!(pointer(buf), p, len)
+        Base.@gc_preserve buf unsafe_copy!(pointer(buf), p, len)
         ccall(:LocalFree, stdcall, Ptr{Void}, (Ptr{Void},), p)
         return transcode(String, buf)
     end

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -313,21 +313,21 @@ function dot(DX::Union{DenseArray{T},StridedVector{T}}, DY::Union{DenseArray{T},
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     end
-    dot(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
+    Base.@gc_preserve DX DY dot(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 function dotc(DX::Union{DenseArray{T},StridedVector{T}}, DY::Union{DenseArray{T},StridedVector{T}}) where T<:BlasComplex
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     end
-    dotc(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
+    Base.@gc_preserve DX DY dotc(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 function dotu(DX::Union{DenseArray{T},StridedVector{T}}, DY::Union{DenseArray{T},StridedVector{T}}) where T<:BlasComplex
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     end
-    dotu(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
+    Base.@gc_preserve DX DY dotu(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 
 ## nrm2
@@ -364,7 +364,7 @@ for (fname, elty, ret_type) in ((:dnrm2_,:Float64,:Float64),
         end
     end
 end
-nrm2(x::Union{StridedVector,Array}) = nrm2(length(x), pointer(x), stride1(x))
+nrm2(x::Union{StridedVector,Array}) = Base.@gc_preserve x nrm2(length(x), pointer(x), stride1(x))
 
 ## asum
 
@@ -397,7 +397,7 @@ for (fname, elty, ret_type) in ((:dasum_,:Float64,:Float64),
         end
     end
 end
-asum(x::Union{StridedVector,Array}) = asum(length(x), pointer(x), stride1(x))
+asum(x::Union{StridedVector,Array}) = Base.@gc_preserve x asum(length(x), pointer(x), stride1(x))
 
 ## axpy
 
@@ -445,7 +445,7 @@ function axpy!(alpha::Number, x::Union{DenseArray{T},StridedVector{T}}, y::Union
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
-    axpy!(length(x), convert(T,alpha), pointer(x), stride(x, 1), pointer(y), stride(y, 1))
+    Base.@gc_preserve x y axpy!(length(x), convert(T,alpha), pointer(x), stride(x, 1), pointer(y), stride(y, 1))
     y
 end
 
@@ -460,7 +460,7 @@ function axpy!(alpha::Number, x::Array{T}, rx::Union{UnitRange{Ti},AbstractRange
     if minimum(ry) < 1 || maximum(ry) > length(y)
         throw(ArgumentError("range out of bounds for y, of length $(length(y))"))
     end
-    axpy!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    Base.@gc_preserve x y axpy!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
     y
 end
 
@@ -509,7 +509,7 @@ function axpby!(alpha::Number, x::Union{DenseArray{T},StridedVector{T}}, beta::N
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
-    axpby!(length(x), convert(T,alpha), pointer(x), stride(x, 1), convert(T,beta), pointer(y), stride(y, 1))
+    Base.@gc_preserve x y axpby!(length(x), convert(T,alpha), pointer(x), stride(x, 1), convert(T,beta), pointer(y), stride(y, 1))
     y
 end
 
@@ -526,7 +526,7 @@ for (fname, elty) in ((:idamax_,:Float64),
         end
     end
 end
-iamax(dx::Union{StridedVector,Array}) = iamax(length(dx), pointer(dx), stride1(dx))
+iamax(dx::Union{StridedVector,Array}) = Base.@gc_preserve dx iamax(length(dx), pointer(dx), stride1(dx))
 
 # Level 2
 ## mv
@@ -1526,7 +1526,10 @@ function copy!(dest::Array{T}, rdest::Union{UnitRange{Ti},AbstractRange{Ti}},
     if length(rdest) != length(rsrc)
         throw(DimensionMismatch("ranges must be of the same length"))
     end
-    BLAS.blascopy!(length(rsrc), pointer(src)+(first(rsrc)-1)*sizeof(T), step(rsrc),
-                   pointer(dest)+(first(rdest)-1)*sizeof(T), step(rdest))
+    Base.@gc_preserve src dest BLAS.blascopy!(length(rsrc),
+                                              pointer(src) + (first(rsrc) - 1) * sizeof(T),
+                                              step(rsrc),
+                                              pointer(dest) + (first(rdest) - 1) * sizeof(T),
+                                              step(rdest))
     dest
 end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -30,7 +30,7 @@ scale!(s::T, X::Array{T}) where {T<:BlasFloat} = scale!(X, s)
 scale!(X::Array{T}, s::Number) where {T<:BlasFloat} = scale!(X, convert(T, s))
 function scale!(X::Array{T}, s::Real) where T<:BlasComplex
     R = typeof(real(zero(T)))
-    BLAS.scal!(2*length(X), convert(R,s), convert(Ptr{R},pointer(X)), 1)
+    Base.@gc_preserve X BLAS.scal!(2*length(X), convert(R,s), convert(Ptr{R},pointer(X)), 1)
     X
 end
 
@@ -119,7 +119,7 @@ function norm(x::StridedVector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}) w
     if minimum(rx) < 1 || maximum(rx) > length(x)
         throw(BoundsError(x, rx))
     end
-    BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
+    Base.@gc_preserve x BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
 end
 
 vecnorm1(x::Union{Array{T},StridedVector{T}}) where {T<:BlasReal} =

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -53,7 +53,7 @@ elseif Sys.isapple()
                         (Cstring, Ptr{Void}, Ptr{Void}, Csize_t, Culong),
                         path, attr_list, buf, sizeof(buf), FSOPT_NOFOLLOW)
             systemerror(:getattrlist, ret ≠ 0)
-            filename_length = unsafe_load(
+            filename_length = @gc_preserve buf unsafe_load(
               convert(Ptr{UInt32}, pointer(buf) + 8))
             if (filename_length + header_size) > length(buf)
                 resize!(buf, filename_length + header_size)

--- a/base/mmap.jl
+++ b/base/mmap.jl
@@ -290,7 +290,7 @@ Forces synchronization between the in-memory version of a memory-mapped `Array` 
 function sync!(m::Array{T}, flags::Integer=MS_SYNC) where T
     offset = rem(UInt(pointer(m)), PAGESIZE)
     ptr = pointer(m) - offset
-    @static if Sys.isunix()
+    Base.@gc_preserve m @static if Sys.isunix()
         systemerror("msync",
                     ccall(:msync, Cint, (Ptr{Void}, Csize_t, Cint), ptr, length(m) * sizeof(T), flags) != 0)
     else

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -171,10 +171,12 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
 
     len = endpos - startpos + 1
     p   = pointer(sbuff) + startpos - 1
-    (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-        p, "true", 4)) && (return Nullable(true))
-    (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-        p, "false", 5)) && (return Nullable(false))
+    @gc_preserve sbuff begin
+        (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
+                                  p, "true", 4)) && (return Nullable(true))
+        (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
+                                  p, "false", 5)) && (return Nullable(false))
+    end
 
     if raise
         substr = SubString(sbuff, orig_start, orig_end) # show input string in the error to avoid confusion

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -123,7 +123,7 @@ function err_message(errno)
     buffer = Vector{UInt8}(256)
     ccall((:pcre2_get_error_message_8, PCRE_LIB), Void,
           (Int32, Ptr{UInt8}, Csize_t), errno, buffer, sizeof(buffer))
-    unsafe_string(pointer(buffer))
+    Base.@gc_preserve buffer unsafe_string(pointer(buffer))
 end
 
 function exec(re,subject,offset,options,match_data)

--- a/base/random/generation.jl
+++ b/base/random/generation.jl
@@ -58,7 +58,7 @@ function _rand(rng::AbstractRNG, gen::BigFloatRandGenerator)
         limbs[end] |= Limb_high_bit
     end
     z.sign = 1
-    unsafe_copy!(z.d, pointer(limbs), gen.nlimbs)
+    Base.@gc_preserve limbs unsafe_copy!(z.d, pointer(limbs), gen.nlimbs)
     (z, randbool)
 end
 
@@ -382,7 +382,7 @@ rand(s::Union{Associative,AbstractSet}, dims::Dims) = rand(GLOBAL_RNG, s, dims)
 
 ## random characters from a string
 
-isvalid_unsafe(s::String, i) = !Base.is_valid_continuation(unsafe_load(pointer(s), i))
+isvalid_unsafe(s::String, i) = !Base.is_valid_continuation(Base.@gc_preserve s unsafe_load(pointer(s), i))
 isvalid_unsafe(s::AbstractString, i) = isvalid(s, i)
 _endof(s::String) = sizeof(s)
 _endof(s::AbstractString) = endof(s)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -76,7 +76,8 @@ codeunit(s::AbstractString, i::Integer)
     @gc_preserve s unsafe_load(pointer(s, i))
 end
 
-write(io::IO, s::String) = unsafe_write(io, pointer(s), reinterpret(UInt, sizeof(s)))
+write(io::IO, s::String) =
+    @gc_preserve s unsafe_write(io, pointer(s), reinterpret(UInt, sizeof(s)))
 
 ## comparison ##
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2108,6 +2108,9 @@ static Value *boxed(jl_codectx_t &ctx, const jl_cgval_t &vinfo)
         return UndefValue::get(T_prjlvalue);
     if (vinfo.constant)
         return maybe_decay_untracked(literal_pointer_val(ctx, vinfo.constant));
+    // This can happen in early bootstrap for `gc_preserve_begin` return value.
+    if (jt == (jl_value_t*)jl_void_type)
+        return maybe_decay_untracked(literal_pointer_val(ctx, jl_nothing));
     if (vinfo.isboxed) {
         assert(vinfo.V == vinfo.Vboxed);
         return vinfo.V;


### PR DESCRIPTION
Started as trying to fix #23520 but as the title said, this end up fixing only a small number of them -- basically all use of `pointer` were wrong. Also marked a few even more invalid places where managed pointer is passed to `unsafe_wrap` (the fix for those will be much more involved).

The only unrelated change is https://github.com/JuliaLang/julia/compare/yyc/gc/safe_unsafe_write?expand=1#diff-b103e3ad474d354f14374e435955adcbL516 which is what I happened to notice when fixing the function.

Should in principle have no effect on performance but inlining may still be sensitive in some cases so 

@nanosoldier `runbenchmarks(ALL, vs=":master")`
