### PR TITLE
Undeprecate +/- for UniformScaling and Number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,10 @@ Language changes
     of the `:quote` expression head (though `:quote` `Expr`s are still used for quoted
     expressions) ([#23885]).
 
+  * The `+` and `-` methods for `Number` and `UniformScaling` are not ambiguous anymore since `+`
+    and `-` no longer do automatic broadcasting. Hence the methods for `UniformScaling` and `Number` are
+    no longer deprecated ([#23923]).
+
 Breaking changes
 ----------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -149,11 +149,6 @@ function delete!(::EnvHash, k::AbstractString, def)
     haskey(ENV,k) ? delete!(ENV,k) : def
 end
 
-@deprecate (+)(J::UniformScaling, x::Number) J.λ + x
-@deprecate (+)(x::Number, J::UniformScaling) x + J.λ
-@deprecate (-)(J::UniformScaling, x::Number) J.λ - x
-@deprecate (-)(x::Number, J::UniformScaling) x - J.λ
-
 # Deprecate methods that convert Diagonal and Bidiagonal to <:AbstractTriangular.
 function convert(::Type{UpperTriangular}, A::Diagonal)
     depwarn(string("`convert(::Type{UpperTriangular}, A::Diagonal)` and other methods ",

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -77,6 +77,11 @@ istril(::UniformScaling) = true
 issymmetric(::UniformScaling) = true
 ishermitian(J::UniformScaling) = isreal(J.λ)
 
+(+)(J::UniformScaling, x::Number) = J.λ + x
+(+)(x::Number, J::UniformScaling) = x + J.λ
+(-)(J::UniformScaling, x::Number) = J.λ - x
+(-)(x::Number, J::UniformScaling) = x - J.λ
+
 (+)(J1::UniformScaling, J2::UniformScaling) = UniformScaling(J1.λ+J2.λ)
 (+)(B::BitArray{2}, J::UniformScaling)      = Array(B) + J
 (+)(J::UniformScaling, B::BitArray{2})      = J + Array(B)

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -37,10 +37,16 @@ end
     @test UniformScaling(4.32) ≉ 4.3*ones(2,2) rtol=0.1 atol=0.01
 end
 
-@testset "* and / with number" begin
+@testset "arithmetic with Number" begin
     α = randn()
+    @test α + I == α + 1
+    @test I + α == α + 1
+    @test α - I == α - 1
+    @test I - α == 1 - α
     @test α .* UniformScaling(1.0) == UniformScaling(1.0) .* α
     @test UniformScaling(α)./α == UniformScaling(1.0)
+    @test α * UniformScaling(1.0) == UniformScaling(1.0) * α
+    @test UniformScaling(α)/α == UniformScaling(1.0)
 end
 
 @testset "det and logdet" begin


### PR DESCRIPTION
With https://github.com/JuliaLang/julia/pull/22932, these a no longer ambiguous and we can therefore remove the deprecations.