### PR TITLE
Fix deprecations of #23812 for sparse find methods

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1284,7 +1284,7 @@ dropzeros(A::SparseMatrixCSC, trim::Bool = true) = dropzeros!(copy(A), trim)
 
 function find(S::SparseMatrixCSC)
     if !(eltype(S) <: Bool)
-        depwarn("In the future `find(A)` will only work on boolean collections. Use `find(x->x!=0, A)` instead.", :find)
+        Base.depwarn("In the future `find(A)` will only work on boolean collections. Use `find(x->x!=0, A)` instead.", :find)
     end
     return find(x->x!=0, S)
 end

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -651,7 +651,7 @@ end
 
 function find(x::SparseVector)
     if !(eltype(x) <: Bool)
-        depwarn("In the future `find(A)` will only work on boolean collections. Use `find(x->x!=0, A)` instead.", :find)
+        Base.depwarn("In the future `find(A)` will only work on boolean collections. Use `find(x->x!=0, A)` instead.", :find)
     end
     return find(x->x!=0, x)
 end


### PR DESCRIPTION
Before:
```julia
julia> find(spzeros(10))
ERROR: UndefVarError: depwarn not defined
Stacktrace:
 [1] find(::SparseVector{Float64,Int64}) at ./sparse/sparsevector.jl:654

julia> find(spzeros(10, 10))
ERROR: UndefVarError: depwarn not defined
Stacktrace:
 [1] find(::SparseMatrixCSC{Float64,Int64}) at ./sparse/sparsematrix.jl:1287
```