### PR TITLE
WIP: Preserve concrete Union types in collect() with generators

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1207,6 +1207,10 @@ end
     @test isequal([1,2,3], [a for (a,b) in enumerate(2:4)])
     @test isequal([2,3,4], [b for (a,b) in enumerate(2:4)])
 
+    @test [s for s in Union{String, Void}["a", nothing]] isa Vector{Union{String, Void}}
+    @test [s for s in Union{String, Void}["a"]] isa Vector{Union{String, Void}}
+    @test [s for s in Vector{Union{String, Void}}()] isa Vector{Union{String, Void}}
+
     @testset "comprehension in let-bound function" begin
         let x⊙y = sum([x[i]*y[i] for i=1:length(x)])
             @test [1,2] ⊙ [3,4] == 11

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -142,3 +142,45 @@ end
                  for n = 0:5:100-q-d
                  for p = 100-q-d-n
                  if p < n < d < q] == [(50,30,15,5), (50,30,20,0), (50,40,10,0), (75,20,5,0)]
+
+@testset "return type of map() and collect() on generators" begin
+    x = ["a", "b"]
+    res = @inferred collect(s for s in x)
+    @test res isa Vector{String}
+    res = @inferred map(identity, x)
+    @test res isa Vector{String}
+    res = @inferred collect(s === nothing for s in x)
+    @test res isa Vector{Bool}
+    res = @inferred map(s -> s === nothing, x)
+    @test res isa Vector{Bool}
+
+    y = Union{String, Void}["a", nothing]
+    f(::Void) = nothing
+    f(s::String) = s == "a"
+    res = @inferred collect(s for s in y)
+    @test res isa Vector{Union{String, Void}}
+    res = @inferred map(identity, y)
+    @test res isa Vector{Union{String, Void}}
+    res = @inferred collect(s === nothing for s in y)
+    @test res isa Vector{Bool}
+    res = @inferred map(s -> s === nothing, y)
+    @test res isa Vector{Bool}
+    res = @inferred collect(f(s) for s in y)
+    @test res isa Vector{Union{Bool, Void}}
+    res = @inferred map(f, y)
+    @test res isa Vector{Union{Bool, Void}}
+
+    y[2] = "c"
+    res = @inferred collect(s for s in y)
+    @test res isa Vector{Union{String, Void}}
+    res = @inferred map(identity, y)
+    @test res isa Vector{Union{String, Void}}
+    res = @inferred collect(s === nothing for s in y)
+    @test res isa Vector{Bool}
+    res = @inferred map(s -> s === nothing, y)
+    @test res isa Vector{Bool}
+    res = @inferred collect(f(s) for s in y)
+    @test res isa Vector{Union{Bool, Void}}
+    res = @inferred map(f, y)
+    @test res isa Vector{Union{Bool, Void}}
+end


### PR DESCRIPTION
When `return_type()` gives a `Union` of concrete types, use it as the element
type of the array instead of the type of the first element and progressively 
making it broader as needed (often ending with element type `Any`).

This means that no reallocation will be needed anymore if/when encoutering
an element with a new type. Note that the inferred element type may still be
broader than the actual contents of the array, for example with
`(x for x in Union{Int, Void}[1])`.

Using a `Union` element type also has the advantage of using the more efficient
layout for `isbitsunion` types and of allowing for more efficient generated code
when using the resulting array. This is particularly noticeable with array
comprehensions, which inherit the behavior of `collect()`.

------

Cf. https://github.com/JuliaData/Nulls.jl/issues/6#issuecomment-332691025 and following comments.

This change is surprisingly not disruptive at all, probably because code is not supposed to rely on inference. I'm still uncertain about at least one issue: whether it makes sense to apply this strategy only to `Union`s of concrete types. The clearest performance gain should be for `isbitsunion` types (efficient memory layout for the resulting array), but it should also be noticeable for other `Union`s of concrete types (at least for code reusing the resulting array, since branches on the type will be used). `Union`s of abstract types shouldn't get a better performance, but maybe for simplicity/consistency we could treat them the same?

Simple benchmark on realistic data with missing values:
```julia
julia> using Nulls

julia> x = Union{Float64,Null}[rand() > .2 ? rand() : null for _ in 1:10_000];

# On master, second run
julia> @time map(s -> s == 0, x);
  0.125965 seconds (29.25 k allocations: 1.572 MiB)

# On this PR, second run
julia> @time map(s -> s == 0, x);
  0.048889 seconds (14.63 k allocations: 789.467 KiB)
```

Note that `s == 0` returns `null` for `null` inputs (with Nulls master), so with this PR the output of `map` is a `Vector{Union{Bool, Null}}`, which means that its narrow typing will help performance down the line too. The remaining allocations will probably be reduced by general optimizations for `Union`.


Cc: @davidanthoff @quinnj