### PR TITLE
Add documentation of SubString

### DIFF
--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -555,6 +555,23 @@ Some other useful functions include:
     `i`.
   * [`chr2ind(str,j)`](@ref) gives the index at which the `j`th character in `str` occurs.
 
+
+It is possible to create a view into a string using the type `SubString`, for example:
+
+```jldoctest
+julia> str = "long string"
+"long string"
+
+julia> substr = SubString(str, 1, 4)
+"long"
+
+julia> typeof(substr)
+SubString{String}
+```
+
+`SubString` works like [`getindex`](@ref), but it does not make a copy of the parent string. Several
+standard functions like [`chop`](@ref), [`chomp`](@ref) or [`strip`](@ref) return a `SubString`.
+
 ## [Non-Standard String Literals](@id non-standard-string-literals)
 
 There are situations when you want to construct a string or use string semantics, but the behavior

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -228,7 +228,9 @@ julia> str[6:6]
 The former is a single character value of type `Char`, while the latter is a string value that
 happens to contain only a single character. In Julia these are very different things.
 
-It is possible to create a view into a string using the type `SubString`, for example:
+Range indexing makes a copy of the selected part of the original string.
+Alternatively, it is possible to create a view into a string using the type `SubString`,
+for example:
 
 ```jldoctest
 julia> str = "long string"
@@ -241,8 +243,8 @@ julia> typeof(substr)
 SubString{String}
 ```
 
-`SubString` works like [`getindex`](@ref), but it does not make a copy of the parent string. Several
-standard functions like [`chop`](@ref), [`chomp`](@ref) or [`strip`](@ref) return a `SubString`.
+Several standard functions like [`chop`](@ref), [`chomp`](@ref) or [`strip`](@ref)
+return a `SubString`.
 
 ## Unicode and UTF-8
 

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -228,6 +228,22 @@ julia> str[6:6]
 The former is a single character value of type `Char`, while the latter is a string value that
 happens to contain only a single character. In Julia these are very different things.
 
+It is possible to create a view into a string using the type `SubString`, for example:
+
+```jldoctest
+julia> str = "long string"
+"long string"
+
+julia> substr = SubString(str, 1, 4)
+"long"
+
+julia> typeof(substr)
+SubString{String}
+```
+
+`SubString` works like [`getindex`](@ref), but it does not make a copy of the parent string. Several
+standard functions like [`chop`](@ref), [`chomp`](@ref) or [`strip`](@ref) return a `SubString`.
+
 ## Unicode and UTF-8
 
 Julia fully supports Unicode characters and strings. As [discussed above](@ref man-characters), in character
@@ -554,23 +570,6 @@ Some other useful functions include:
   * [`ind2chr(str,i)`](@ref) gives the number of characters in `str` up to and including any at index
     `i`.
   * [`chr2ind(str,j)`](@ref) gives the index at which the `j`th character in `str` occurs.
-
-
-It is possible to create a view into a string using the type `SubString`, for example:
-
-```jldoctest
-julia> str = "long string"
-"long string"
-
-julia> substr = SubString(str, 1, 4)
-"long"
-
-julia> typeof(substr)
-SubString{String}
-```
-
-`SubString` works like [`getindex`](@ref), but it does not make a copy of the parent string. Several
-standard functions like [`chop`](@ref), [`chomp`](@ref) or [`strip`](@ref) return a `SubString`.
 
 ## [Non-Standard String Literals](@id non-standard-string-literals)
 


### PR DESCRIPTION
`SubString` first appears in the section of regular expressions, but it is not mentioned earlier. I suggest to add documentation of `SubString` as it is returned by several functions from the standard library.