### PR TITLE
Descriptive BoundsError for multiple assignment

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -57,7 +57,7 @@ end
 # while reducing to plain next() for arbitrary iterables.
 indexed_next(t::Tuple, i::Int, state) = (t[i], i+1)
 indexed_next(a::Array, i::Int, state) = (a[i], i+1)
-indexed_next(I, i, state) = done(I,state) ? throw(BoundsError()) : next(I, state)
+indexed_next(I, i, state) = done(I,state) ? throw(BoundsError(I, i)) : next(I, state)
 
 # Use dispatch to avoid a branch in first
 first(::Tuple{}) = throw(ArgumentError("tuple must be non-empty"))

--- a/test/core.jl
+++ b/test/core.jl
@@ -2231,6 +2231,12 @@ f9534h(a,b,c...) = c[a]
 @test f9534h(4,2,3,4,5,6) == 6
 @test try; f9534h(5,2,3,4,5,6) catch ex; (ex::BoundsError).a === (3,4,5,6) && ex.i == 5; end
 
+# issue #7978, comment 332352438
+f7978a() = 1
+@test try; a, b = f7978a() catch ex; (ex::BoundsError).a == 1 && ex.i == 2; end
+f7978b() = 1, 2
+@test try; a, b, c = f7978b() catch ex; (ex::BoundsError).a == (1, 2) && ex.i == 3; end
+
 # issue #9535
 counter9535 = 0
 f9535() = (global counter9535; counter9535 += 1; counter9535)


### PR DESCRIPTION
This changes
```julia
julia> foo() = 1
foo (generic function with 1 method)

julia> x, y = foo()
ERROR: BoundsError
Stacktrace:
 [1] indexed_next(::Int64, ::Int64, ::Bool) at ./tuple.jl:56
```

to

```julia
julia> g() = 1
g (generic function with 1 method)

julia> a, b = g()
ERROR: BoundsError: attempt to access 1
  at index [2]
Stacktrace:
 [1] indexed_next(::Int64, ::Int64, ::Bool) at ./tuple.jl:60

julia> f() = 1, 2
f (generic function with 1 method)

julia> a, b, c = f()
ERROR: BoundsError: attempt to access (1, 2)
  at index [3]
Stacktrace:
 [1] indexed_next(::Tuple{Int64,Int64}, ::Int64, ::Int64) at ./tuple.jl:58
```

ref. #7978