### PR TITLE
Integrate interpreter frames into backtraces

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -95,8 +95,8 @@ function firstcaller(bt::Array{Ptr{Void},1}, funcsyms)
             found && @goto found
             found = lkup.func in funcsyms
             # look for constructor type name
-            if !found && !isnull(lkup.linfo)
-                li = get(lkup.linfo)
+            if !found && lkup.linfo != nothing
+                li = lkup.linfo
                 ft = ccall(:jl_first_argument_datatype, Any, (Any,), li.def.sig)
                 if isa(ft,DataType) && ft.name === Type.body.name
                     ft = unwrap_unionall(ft.parameters[1])

--- a/base/task.jl
+++ b/base/task.jl
@@ -7,8 +7,8 @@ struct CapturedException <: Exception
     ex::Any
     processed_bt::Vector{Any}
 
-    function CapturedException(ex, bt_raw::Vector{Ptr{Void}})
-        # bt_raw MUST be an Array of code pointers than can be processed by jl_lookup_code_address
+    function CapturedException(ex, bt_raw::Vector)
+        # bt_raw MUST be a vector that can be processed by StackTraces.stacktrace
         # Typically the result of a catch_backtrace()
 
         # Process bt_raw so that it can be safely serialized

--- a/base/util.jl
+++ b/base/util.jl
@@ -350,8 +350,8 @@ const log_warn_to = Dict{Tuple{Union{Module,Void},Union{Symbol,Void}},IO}()
 const log_error_to = Dict{Tuple{Union{Module,Void},Union{Symbol,Void}},IO}()
 
 function _redirect(io::IO, log_to::Dict, sf::StackTraces.StackFrame)
-    isnull(sf.linfo) && return io
-    mod = get(sf.linfo).def
+    (sf.linfo isa Core.MethodInstance) || return io
+    mod = sf.linfo.def
     isa(mod, Method) && (mod = mod.module)
     fun = sf.func
     if haskey(log_to, (mod,fun))
@@ -374,10 +374,10 @@ function _redirect(io::IO, log_to::Dict, fun::Symbol)
         stack::Vector{StackFrame} = StackTraces.lookup(trace)
         filter!(frame -> !frame.from_c, stack)
         for frame in stack
-            isnull(frame.linfo) && continue
+            (frame.linfo isa Core.MethodInstance) || continue
             sf = frame
             break_next_frame && (@goto skip)
-            mod = get(frame.linfo).def
+            mod = frame.linfo.def
             isa(mod, Method) && (mod = mod.module)
             mod === Base || continue
             sff = string(frame.func)

--- a/src/Makefile
+++ b/src/Makefile
@@ -184,6 +184,7 @@ $(BUILDDIR)/ast.o $(BUILDDIR)/ast.dbg.obj: $(BUILDDIR)/julia_flisp.boot.inc $(SR
 $(BUILDDIR)/codegen.o $(BUILDDIR)/codegen.dbg.obj: $(addprefix $(SRCDIR)/,\
 	intrinsics.cpp jitlayers.h intrinsics.h debuginfo.h codegen_shared.h cgutils.cpp ccall.cpp abi_*.cpp processor.h)
 $(BUILDDIR)/processor.o $(BUILDDIR)/processor.dbg.obj: $(addprefix $(SRCDIR)/,processor_*.cpp processor.h features_*.h)
+$(BUILDDIR)/interpreter.o $(BUILDDIR)/interpreter.dbg.obj: $(SRCDIR)/interpreter-stacktrace.c
 $(BUILDDIR)/anticodegen.o $(BUILDDIR)/anticodegen.dbg.obj: $(SRCDIR)/intrinsics.h
 $(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: \
 	$(addprefix $(SRCDIR)/,debuginfo.h processor.h)

--- a/src/gc.c
+++ b/src/gc.c
@@ -194,17 +194,22 @@ static void jl_gc_run_finalizers_in_list(jl_ptls_t ptls, arraylist_t *list)
     // from jl_apply_with_saved_exception_state; to hoist state saving out of the loop
     jl_value_t *exc = ptls->exception_in_transit;
     jl_array_t *bt = NULL;
-    JL_GC_PUSH2(&exc, &bt);
-    if (ptls->bt_size > 0)
-        bt = (jl_array_t*)jl_get_backtrace();
+    jl_array_t *bt2 = NULL;
+    JL_GC_PUSH3(&exc, &bt, &bt2);
+    if (ptls->bt_size > 0) {
+        jl_get_backtrace(&bt, &bt2);
+        ptls->bt_size = 0;
+    }
     for (size_t i = 2;i < len;i += 2)
         run_finalizer(ptls, items[i], items[i + 1]);
     ptls->exception_in_transit = exc;
     if (bt != NULL) {
+        // This is sufficient because bt2 roots the managed values
+        memcpy(ptls->bt_data, bt->data, jl_array_len(bt) * sizeof(void*));
         ptls->bt_size = jl_array_len(bt);
-        memcpy(ptls->bt_data, bt->data, ptls->bt_size * sizeof(void*));
     }
     JL_GC_POP();
+    // matches the jl_gc_push_arraylist above
     JL_GC_POP();
 }
 
@@ -2434,6 +2439,18 @@ static void jl_gc_queue_remset(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp, j
     ptls2->heap.rem_bindings.len = n_bnd_refyoung;
 }
 
+static void jl_gc_queue_bt_buf(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp, jl_ptls_t ptls2)
+{
+    size_t n = 0;
+    while (n+2 < ptls2->bt_size) {
+        if (ptls2->bt_data[n] == (uintptr_t)-1) {
+            gc_mark_queue_obj(gc_cache, sp, (jl_value_t*)ptls2->bt_data[n+1]);
+            n += 2;
+        }
+        n++;
+    }
+}
+
 // Only one thread should be running in this function
 static int _jl_gc_collect(jl_ptls_t ptls, int full)
 {
@@ -2454,6 +2471,8 @@ static int _jl_gc_collect(jl_ptls_t ptls, int full)
         jl_gc_queue_remset(gc_cache, &sp, ptls2);
         // 2.2. mark every thread local root
         jl_gc_queue_thread_local(gc_cache, &sp, ptls2);
+        // 2.3. mark any managed objects in the backtrace buffer
+        jl_gc_queue_bt_buf(gc_cache, &sp, ptls2);
     }
 
     // 3. walk roots

--- a/src/interpreter-stacktrace.c
+++ b/src/interpreter-stacktrace.c
@@ -1,0 +1,247 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// #include'd from interpreter.c
+
+// Backtrace support
+#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_) || defined(_OS_WINDOWS_)
+extern uintptr_t __start_jl_interpreter_frame_val;
+uintptr_t __start_jl_interpreter_frame = (uintptr_t)&__start_jl_interpreter_frame_val;
+extern uintptr_t __stop_jl_interpreter_frame_val;
+uintptr_t __stop_jl_interpreter_frame = (uintptr_t)&__stop_jl_interpreter_frame_val;
+
+#define SECT_INTERP JL_SECTION("jl_interpreter_frame_val")
+#if defined(_CPU_X86_) && defined(_OS_WINDOWS_)
+#define MANGLE(x) "@" x "@8"
+#else
+#define MANGLE(x) x
+#endif
+
+#if defined(_OS_LINUX_) || defined(_OS_FREEBSD_)
+#define ASM_ENTRY                               \
+    ".text\n"                                   \
+    ".p2align 4,0x90\n"                         \
+    ".global enter_interpreter_frame\n"         \
+    ".type enter_interpreter_frame,@function\n"
+#if defined(_OS_LINUX_)
+#define ASM_END ".previous\n"
+#else
+#define ASM_END
+#endif
+#else
+#define ASM_ENTRY                               \
+    ".text\n"                                   \
+    ".globl enter_interpreter_frame\n"
+#define ASM_END
+#endif
+
+#elif defined(_OS_DARWIN_)
+extern uintptr_t __start_jl_interpreter_frame_val __asm("section$start$__TEXT$__jif");
+uintptr_t __start_jl_interpreter_frame = (uintptr_t)&__start_jl_interpreter_frame_val;
+extern uintptr_t __stop_jl_interpreter_frame_val __asm("section$end$__TEXT$__jif");
+uintptr_t __stop_jl_interpreter_frame = (uintptr_t)&__stop_jl_interpreter_frame_val;
+
+#define SECT_INTERP JL_SECTION("__TEXT,__jif")
+
+#define MANGLE(x) "_" x
+#define ASM_ENTRY \
+    ".section __TEXT,__text,regular,pure_instructions\n" \
+    ".globl _enter_interpreter_frame\n"
+#define ASM_END ".previous"
+
+#else
+#define SECT_INTERP
+#define NO_INTERP_BT
+#warning "Interpreter backtraces not implemented for this platform"
+#endif
+
+
+// This function is special. The unwinder looks for this function to find interpreter
+// stack frames.
+#ifdef _CPU_X86_64_
+
+#ifdef _OS_WINDOWS_
+size_t STACK_PADDING = 40;
+#else
+size_t STACK_PADDING = 8;
+#endif
+
+asm(
+    ASM_ENTRY
+    MANGLE("enter_interpreter_frame") ":\n"
+    ".cfi_startproc\n"
+    // sizeof(struct interpreter_state) is 44, but we need to be 8 byte aligned,
+    // so subtract 48. For compact unwind info, we need to only have one subq,
+    // so combine in the stack realignment for a total of 56 bytes.
+    "\tsubq $56, %rsp\n"
+    ".cfi_def_cfa_offset 64\n"
+#ifdef _OS_WINDOWS_
+    "\tmovq %rcx, %rax\n"
+    "\tleaq 8(%rsp), %rcx\n"
+#else
+     "\tmovq %rdi, %rax\n"
+     "\tleaq 8(%rsp), %rdi\n"
+#endif
+    // Zero out the src field
+    "\tmovq $0, 8(%rsp)\n"
+#ifdef _OS_WINDOWS_
+    // Make space for the register parameter area
+    "\tsubq $32, %rsp\n"
+#endif
+    // The L here conviences the OS X linker not to terminate the unwind info early
+    "Lenter_interpreter_frame_start_val:\n"
+    "\tcallq *%rax\n"
+    "Lenter_interpreter_frame_end_val:\n"
+#ifdef _OS_WINDOWS_
+    "\taddq $32, %rsp\n"
+#endif
+    "\taddq $56, %rsp\n"
+#ifndef _OS_DARWIN_
+    // Somehow this throws off compact unwind info on OS X
+    ".cfi_def_cfa_offset 8\n"
+#endif
+    "\tretq\n"
+    ".cfi_endproc\n"
+    ASM_END
+    );
+
+#define CALLBACK_ABI
+static_assert(sizeof(interpreter_state) <= 48, "Update assembly code above");
+
+#elif defined(_CPU_X86_)
+
+size_t STACK_PADDING = 12;
+asm(
+     ASM_ENTRY
+     MANGLE("enter_interpreter_frame") ":\n"
+     ".cfi_startproc\n"
+#ifdef _OS_WINDOWS_
+/*
+ * On win32, we set -mincoming-stack-boundary=2. This causes GCC to emit stack
+ * realignment gadgets into the prologue of every function. Unfortunately for
+ * us there are two different kinds of such gadgets and since we don't know
+ * which one the target function is going to use, we can't use the same trick
+ * as everywhere else. From https://gcc.gnu.org/ml/gcc/2007-12/msg00503.html,
+ * the two prologues are:
+ *
+ *     pushl     %ebp
+ *     movl      %esp, %ebp
+ *     andl      $-16, %esp
+ *
+ * and
+ *
+ *     pushl     %edi                     // Save callee save reg edi
+ *     leal      8(%esp), %edi            // Save address of parameter frame
+ *     andl      $-16, %esp               // Align local stack
+ *     pushl     $4(%edi)                 //  save return address
+ *     pushl     %ebp                     //  save old ebp
+ *     movl      %esp, %ebp               //  point ebp to pseudo frame
+ *
+ * From the perspective of the unwinder, the first case looks like a regular
+ * (without the realignment gadget) stack frame. However, for the second one,
+ * the compiler deliberately constructs a "fake stack frame" that has an
+ * incorrect stack address for the previous frame. To work around all of this,
+ * use ebp based addressing on win32
+ */
+#define FP_CAPTURE_OFFSET 32
+    "\tpushl %ebp\n"
+    ".cfi_def_cfa_offset 8\n"
+    "\tmovl %esp, %ebp\n"
+#endif
+     // sizeof(struct interpreter_state) is 32
+     "\tsubl $32, %esp\n"
+#ifdef _OS_WINDOWS_
+     ".cfi_def_cfa_offset 40\n"
+#else
+     ".cfi_def_cfa_offset 36\n"
+#endif
+     "\tmovl %ecx, %eax\n"
+     "\tmovl %esp, %ecx\n"
+     // Zero out the src field
+     "\tmovl $0, (%esp)\n"
+     // Restore 16 byte stack alignment
+#ifdef _OS_WINDOWS_
+     // Technically not necessary, because we don't assume this alignment, but
+     // let's be nice if we ever start doing that.
+     "\tsubl $8, %esp\n"
+#else
+     "\tsubl $12, %esp\n"
+#endif
+     ".cfi_def_cfa_offset 48\n"
+     "Lenter_interpreter_frame_start_val:\n"
+     "\tcalll *%eax\n"
+     "Lenter_interpreter_frame_end_val:\n"
+#ifdef _OS_WINDOWS_
+     "\taddl $40, %esp\n"
+     ".cfi_def_cfa_offset 8\n"
+     "\tpopl %ebp\n"
+#else
+     "\taddl $44, %esp\n"
+#endif
+     ".cfi_def_cfa_offset 4\n"
+     "\tret\n"
+     ".cfi_endproc\n"
+     ASM_END
+     );
+
+#define CALLBACK_ABI  __attribute__((fastcall))
+static_assert(sizeof(interpreter_state) <= 32, "Update assembly code above");
+
+#else
+#warning "Interpreter backtraces not implemented for this platform"
+#define NO_INTERP_BT
+#endif
+
+#ifndef NO_INTERP_BT
+extern uintptr_t enter_interpreter_frame_start_val asm("Lenter_interpreter_frame_start_val");
+extern uintptr_t enter_interpreter_frame_end_val asm("Lenter_interpreter_frame_end_val");
+uintptr_t enter_interpreter_frame_start = (uintptr_t)&enter_interpreter_frame_start_val;
+uintptr_t enter_interpreter_frame_end = (uintptr_t)&enter_interpreter_frame_end_val;
+
+JL_DLLEXPORT int jl_is_interpreter_frame(uintptr_t ip)
+{
+    return __start_jl_interpreter_frame <= ip && ip <= __stop_jl_interpreter_frame;
+}
+
+JL_DLLEXPORT int jl_is_enter_interpreter_frame(uintptr_t ip)
+{
+    return enter_interpreter_frame_start <= ip && ip <= enter_interpreter_frame_end;
+}
+
+JL_DLLEXPORT size_t jl_capture_interp_frame(uintptr_t *data, uintptr_t sp, uintptr_t fp, size_t space_remaining)
+{
+#ifdef FP_CAPTURE_OFFSET
+    interpreter_state *s = (interpreter_state *)(fp-FP_CAPTURE_OFFSET);
+#else
+    interpreter_state *s = (interpreter_state *)(sp+STACK_PADDING);
+#endif
+    if (space_remaining <= 1 || s->src == 0)
+        return 0;
+    // Sentinel value to indicate an interpreter frame
+    data[0] = (uintptr_t)-1;
+    data[1] = (uintptr_t)s->src;
+    data[2] = (uintptr_t)s->ip;
+    return 2;
+}
+
+extern void * CALLBACK_ABI enter_interpreter_frame(void * CALLBACK_ABI (*callback)(interpreter_state *, void *), void *arg);
+#else
+JL_DLLEXPORT int jl_is_interpreter_frame(uintptr_t ip)
+{
+    return 0;
+}
+
+JL_DLLEXPORT int jl_is_enter_interpreter_frame(uintptr_t ip)
+{
+    return 0;
+}
+
+JL_DLLEXPORT size_t jl_capture_interp_frame(uintptr_t *data, uintptr_t sp, uintptr_t fp, size_t space_remaining)
+{
+    return 0;
+}
+#define CALLBACK_ABI
+void *NOINLINE enter_interpreter_frame(void *(*callback)(interpreter_state *, void *), void *arg) {
+    interpreter_state state = {};
+    return callback(&state, arg);
+}
+#endif

--- a/src/julia.h
+++ b/src/julia.h
@@ -43,12 +43,15 @@
 #  define JL_NORETURN __attribute__ ((noreturn))
 #  define JL_CONST_FUNC __attribute__((const))
 #  define JL_USED_FUNC __attribute__((used))
+#  define JL_SECTION(name) __attribute__((section(name)))
 #elif defined(_COMPILER_MICROSOFT_)
 #  define JL_NORETURN __declspec(noreturn)
 // This is the closest I can find for __attribute__((const))
 #  define JL_CONST_FUNC __declspec(noalias)
 // Does MSVC have this?
 #  define JL_USED_FUNC
+// TODO: Figure out what to do on MSVC
+#  define JL_SECTION(x)
 #else
 #  define JL_NORETURN
 #  define JL_CONST_FUNC

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -687,7 +687,7 @@ size_t rec_backtrace_ctx(uintptr_t *data, size_t maxsize, bt_context_t *ctx);
 #ifdef LIBOSXUNWIND
 size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize, bt_context_t *ctx);
 #endif
-JL_DLLEXPORT jl_value_t *jl_get_backtrace(void);
+JL_DLLEXPORT void jl_get_backtrace(jl_array_t **bt, jl_array_t **bt2);
 JL_DLLEXPORT jl_value_t *jl_apply_with_saved_exception_state(jl_value_t **args, uint32_t nargs, int drop_exceptions);
 void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_t *bt_size);
 JL_DLLEXPORT void jl_raise_debugger(void);
@@ -706,6 +706,9 @@ STATIC_INLINE char *jl_copy_str(char **to, const char *from)
     memcpy(*to, from, len);
     return *to;
 }
+JL_DLLEXPORT int jl_is_interpreter_frame(uintptr_t ip);
+JL_DLLEXPORT int jl_is_enter_interpreter_frame(uintptr_t ip);
+JL_DLLEXPORT size_t jl_capture_interp_frame(uintptr_t *data, uintptr_t sp, uintptr_t fp, size_t space_remaining);
 
 // timers
 // Returns time in nanosec

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -241,9 +241,12 @@ JL_DLLEXPORT jl_value_t *jl_apply_with_saved_exception_state(jl_value_t **args, 
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *exc = ptls->exception_in_transit;
     jl_array_t *bt = NULL;
-    JL_GC_PUSH2(&exc, &bt);
-    if (ptls->bt_size > 0)
-        bt = (jl_array_t*)jl_get_backtrace();
+    jl_array_t *bt2 = NULL;
+    JL_GC_PUSH3(&exc, &bt, &bt2);
+    if (ptls->bt_size > 0) {
+        jl_get_backtrace(&bt, &bt2);
+        ptls->bt_size = 0;
+    }
     jl_value_t *v;
     JL_TRY {
         v = jl_apply(args, nargs);
@@ -259,8 +262,9 @@ JL_DLLEXPORT jl_value_t *jl_apply_with_saved_exception_state(jl_value_t **args, 
     }
     ptls->exception_in_transit = exc;
     if (bt != NULL) {
+        // This is sufficient because bt2 roots the gc-managed values
+        memcpy(ptls->bt_data, bt->data, jl_array_len(bt) * sizeof(void*));
         ptls->bt_size = jl_array_len(bt);
-        memcpy(ptls->bt_data, bt->data, ptls->bt_size * sizeof(void*));
     }
     JL_GC_POP();
     return v;

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -25,13 +25,14 @@ extern "C" {
 #endif
 
 static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *context);
-static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp);
+static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, uintptr_t *fp);
 
-size_t jl_unw_stepn(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, size_t maxsize)
+size_t jl_unw_stepn(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, size_t maxsize, int add_interp_frames)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     volatile size_t n = 0;
-    uintptr_t nullsp;
+    uintptr_t thesp;
+    uintptr_t thefp;
 #if defined(_OS_WINDOWS_) && !defined(_CPU_X86_64_)
     assert(!jl_in_stackwalk);
     jl_in_stackwalk = 1;
@@ -47,9 +48,15 @@ size_t jl_unw_stepn(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, size_t ma
                n = maxsize; // return maxsize + 1 if ran out of space
                break;
            }
-           if (!jl_unw_step(cursor, &ip[n], sp ? &sp[n] : &nullsp))
+           if (!jl_unw_step(cursor, &ip[n], &thesp, &thefp))
                break;
-           n++;
+           if (sp)
+                sp[n] = thesp;
+            if (add_interp_frames && jl_is_enter_interpreter_frame(ip[n])) {
+                n += jl_capture_interp_frame(&ip[n], thesp, thefp, maxsize-n-1) + 1;
+            } else {
+                n++;
+            }
         }
         n++;
 #if !defined(_OS_WINDOWS_)
@@ -76,7 +83,7 @@ size_t rec_backtrace_ctx(uintptr_t *data, size_t maxsize,
     bt_cursor_t cursor;
     if (!jl_unw_init(&cursor, context))
         return 0;
-    n = jl_unw_stepn(&cursor, data, NULL, maxsize);
+    n = jl_unw_stepn(&cursor, data, NULL, maxsize, 1);
     return n > maxsize ? maxsize : n;
 }
 
@@ -110,7 +117,7 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp)
             jl_array_grow_end(ip, maxincr);
             if (returnsp) jl_array_grow_end(sp, maxincr);
             n = jl_unw_stepn(&cursor, (uintptr_t*)jl_array_data(ip) + offset,
-                    returnsp ? (uintptr_t*)jl_array_data(sp) + offset : NULL, maxincr);
+                    returnsp ? (uintptr_t*)jl_array_data(sp) + offset : NULL, maxincr, 0);
             offset += maxincr;
         } while (n > maxincr);
         jl_array_del_end(ip, maxincr - n);
@@ -121,18 +128,30 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp)
     return bt;
 }
 
-JL_DLLEXPORT jl_value_t *jl_get_backtrace(void)
+JL_DLLEXPORT void jl_get_backtrace(jl_array_t **btout, jl_array_t **bt2out)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_array_t *bt = NULL;
-    JL_GC_PUSH1(&bt);
+    jl_array_t *bt2 = NULL;
+    JL_GC_PUSH2(&bt, &bt2);
     if (array_ptr_void_type == NULL) {
         array_ptr_void_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_voidpointer_type, jl_box_long(1));
     }
     bt = jl_alloc_array_1d(array_ptr_void_type, ptls->bt_size);
     memcpy(bt->data, ptls->bt_data, ptls->bt_size * sizeof(void*));
+    bt2 = jl_alloc_array_1d(jl_array_any_type, 0);
+    // Scan the stack for any interpeter frames
+    size_t n = 0;
+    while (n < ptls->bt_size) {
+        if (ptls->bt_data[n] == (uintptr_t)-1) {
+            jl_array_ptr_1d_push(bt2, (jl_value_t*)ptls->bt_data[n+1]);
+            n += 2;
+        }
+        n++;
+    }
+    *btout = bt;
+    *bt2out = bt2;
     JL_GC_POP();
-    return (jl_value_t*)bt;
 }
 
 
@@ -245,12 +264,14 @@ static int readable_pointer(LPCVOID pointer)
     return 1;
 }
 
-static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp)
+static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, uintptr_t *fp)
 {
     // Might be called from unmanaged thread.
 #ifndef _CPU_X86_64_
     *ip = (uintptr_t)cursor->stackframe.AddrPC.Offset;
     *sp = (uintptr_t)cursor->stackframe.AddrStack.Offset;
+    if (fp)
+        *fp = (uintptr_t)cursor->stackframe.AddrFrame.Offset;
     if (*ip == 0 || *ip == ((uintptr_t)0)-1) {
         if (!readable_pointer((LPCVOID)*sp))
             return 0;
@@ -265,6 +286,8 @@ static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp)
 #else
     *ip = (uintptr_t)cursor->Rip;
     *sp = (uintptr_t)cursor->Rsp;
+    if (fp)
+        *fp = (uintptr_t)cursor->Rbp;
     if (*ip == 0 || *ip == ((uintptr_t)0)-1) {
         if (!readable_pointer((LPCVOID)*sp))
             return 0;
@@ -313,7 +336,7 @@ static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *context)
     return unw_init_local(cursor, context) == 0;
 }
 
-static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp)
+static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, uintptr_t *fp)
 {
     unw_word_t reg;
     if (unw_get_reg(cursor, UNW_REG_IP, &reg) < 0)
@@ -322,6 +345,15 @@ static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp)
     if (unw_get_reg(cursor, UNW_REG_SP, &reg) < 0)
         return 0;
     *sp = reg;
+#ifdef UNW_REG_FP
+    if (unw_get_reg(cursor, UNW_REG_FP, &reg) < 0)
+        return 0;
+    if (fp)
+        *fp = reg;
+#else
+    if (fp)
+        *fp = 0;
+#endif
     return unw_step(cursor) > 0;
 }
 
@@ -337,7 +369,7 @@ size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize,
     bt_cursor_t cursor;
     if (!jl_unw_init_dwarf(&cursor, context))
         return 0;
-    n = jl_unw_stepn(&cursor, data, NULL, maxsize);
+    n = jl_unw_stepn(&cursor, data, NULL, maxsize, 1);
     return n > maxsize ? maxsize : n;
 }
 #endif
@@ -349,7 +381,7 @@ static int jl_unw_init(bt_cursor_t *cursor, bt_context_t *context)
     return 0;
 }
 
-static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp)
+static int jl_unw_step(bt_cursor_t *cursor, uintptr_t *ip, uintptr_t *sp, uintptr_t *fp)
 {
     return 0;
 }

--- a/src/threading.c
+++ b/src/threading.c
@@ -276,6 +276,7 @@ static void ti_initthread(int16_t tid)
     ptls->defer_signal = 0;
     ptls->current_module = NULL;
     void *bt_data = malloc(sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
+    memset(bt_data, 0, sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
     if (bt_data == NULL) {
         jl_printf(JL_STDERR, "could not allocate backtrace buffer\n");
         gc_debug_critical_error();

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -149,3 +149,22 @@ end
 @test hasbtmacro
 
 end
+
+# Interpreter backtraces
+bt = eval(quote
+    try
+        error()
+    catch
+        catch_backtrace()
+    end
+end)
+lkup = map(StackTraces.lookup, bt)
+hastoplevel = false
+for sfs in lkup
+    for sf in sfs
+        if sf.linfo isa CodeInfo
+            global hastoplevel = true
+        end
+    end
+end
+@test hastoplevel

--- a/test/distributed_exec.jl
+++ b/test/distributed_exec.jl
@@ -433,7 +433,7 @@ let ex
     @test length(bt) > 1
     frame, repeated = bt[1]::Tuple{StackFrame, Int}
     @test frame.func == :foo
-    @test isnull(frame.linfo)
+    @test frame.linfo == nothing
     @test repeated == 1
 end
 

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -34,8 +34,8 @@ let
     frame2 = deserialize(b)
     @test frame !== frame2
     @test frame == frame2
-    @test !isnull(frame.linfo)
-    @test isnull(frame2.linfo)
+    @test frame.linfo !== nothing
+    @test frame2.linfo === nothing
 end
 
 # Test from_c
@@ -120,7 +120,7 @@ let ctestptr = cglobal((:ctest, "libccalltest")),
 
     @test length(ctest) == 1
     @test ctest[1].func === :ctest
-    @test isnull(ctest[1].linfo)
+    @test ctest[1].linfo === nothing
     @test ctest[1].from_c
     @test ctest[1].pointer === UInt64(ctestptr)
 end


### PR DESCRIPTION
Before:
```
julia> let
       error()
       end
ERROR:
Stacktrace:
 [1] error() at ./error.jl:44
```

After:
```
julia> let
       error()
       end
ERROR:
Stacktrace:
 [1] error() at ./error.jl:44
 [2] macro expansion at REPL[0]:2 [inlined]
 [3] In toplevel scope
```

The extra `macro expansion` frame is a pre-existing julia bug (#23971)
that this PR doesn't address.

The mechanism used here is to add a no-inline enter_interpreter stack frame that has
a known stack layout (since it only has one local variable) and can thus be used
to retrieve the interpreter state. I do not believe that this is guaranteed by the
C standard, so depending on the whims of the compiler we may have to eventually write
this function in assembly, but it seems to work well enough for now.

One significant complication is that the backtrace buffer may now contain pointers
to gc-managed data, so we need to make the gc aware that and can't be as non-chalant
about copying the buffer around anymore.