### PR TITLE
Document const with multiple variables.

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -281,6 +281,12 @@ constant in this way.
 ```julia
 const x = 5
 ```
+
+Multiple variables can be declared within a single `const`:
+```julia
+const y, z = 7, 11
+```
+
 Note that "constant-ness" is not enforced inside containers, so if `x` is an array or
 dictionary (for example) you can still add and remove elements.
 

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -470,6 +470,11 @@ julia> const e  = 2.71828182845904523536;
 julia> const pi = 3.14159265358979323846;
 ```
 
+Multiple variables can be declared in a single `const` statement:
+```jldoctest
+julia> const a, b = 1, 2
+```
+
 The `const` declaration should only be used in global scope on globals.
 It is difficult for the compiler to optimize code involving global variables, since
 their values (or even their types) might change at almost any time. If a global variable will


### PR DESCRIPTION
Add a sentence about the `const a, b = ...` form to both the docstring of `const`, and the "Constants" subsection of the manual. Used slightly different wording in each, to be similar to the context.

This is a minor documentation change, in response to [this discussion](https://discourse.julialang.org/t/is-const-tuple-documented/6194).