### PR TITLE
fix #23978, deprecation message for Base.Test

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1356,17 +1356,7 @@ end
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
 
-module Test
-for f in [Symbol("@inferred"), Symbol("@test"), Symbol("@test_approx_eq"),
-          Symbol("@test_approx_eq_eps"), Symbol("@test_broken"), Symbol("@test_nowarn"),
-          Symbol("@test_skip"), Symbol("@test_throws"), Symbol("@test_warn"),
-          Symbol("@testset"), :GenericArray, :GenericDict, :GenericSet, :GenericString,
-          :detect_ambiguities, :detect_unbound_args]
-    @eval Base.@deprecate_moved $f "Test" true true
-end
-end
-export Test
-deprecate(@__MODULE__, :Test)
+@deprecate_binding Test nothing true ", run `using Test` instead"
 
 @deprecate_moved SharedArray "SharedArrays" true true
 


### PR DESCRIPTION
The binding deprecation mechanism is probably better for this case. After:

```
julia> using Base.Test
WARNING: Base.Test is deprecated, run `using Test` instead.
  likely near no file:0

julia> using Test

julia> @test true
Test Passed
```

To do this, I added a rule that if a deprecated binding has `nothing` as its value, then it's not actually imported, so it won't conflict with importing the replacement. I suppose we can revisit that if we ever need to deprecate a variable whose correct value is actually `nothing`...