### PR TITLE
Inlining statement cost: don't penalize call-Exprs that throw

### DIFF
--- a/base/inference.jl
+++ b/base/inference.jl
@@ -4756,6 +4756,8 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, mod::Module, params:
                     return argcost
                 elseif f == Main.Core.arrayref
                     return plus_saturate(argcost, isknowntype(ex.typ) ? 4 : params.inline_nonleaf_penalty)
+                elseif f == Main.Core.throw
+                    return 0 # errors are not part of the typical runtime cost, don't penalize error branches
                 end
                 fidx = findfirst(x->x===f, t_ffunc_key)
                 if fidx == 0

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -97,7 +97,8 @@ params = Core.Inference.InferenceParams(typemax(UInt))
 # Get the CodeInfo object
 ci = (@code_typed fill(3, (5, 5)))[1]  # we'll try this on the code for `fill(3, (5, 5))`
 # Calculate cost of each statement
-cost(stmt) = Core.Inference.statement_cost(stmt, ci, Base, params)
+cost(stmt::Expr) = Core.Inference.statement_cost(stmt, 0, ci, Base, params)
+cost(stmt) = 0
 cst = map(cost, ci.code)
 ```
 


### PR DESCRIPTION
#22732 seems to have missed one other form of `throw`: `Expr(:call, throw, ...)`. Noticed while looking into performance of #23939.

@nanosoldier `runbenchmarks(ALL, vs=":master")`
