### PR TITLE
Add docstrings to exported modules

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -709,7 +709,11 @@ module Collections
         @eval Base.@deprecate_moved $f "DataStructures"
     end
 end
+@doc """
+Collections will be removed from Base. Use DataStructures instead.
+""" -> Collections
 export Collections
+
 
 # Broadcast now returns a BitArray when the resulting eltype is Bool (#17623)
 @deprecate bitbroadcast broadcast
@@ -1324,6 +1328,9 @@ module Operators
         end
     end
 end
+@doc """
+Base.Operators is deprecated, use Base instead.
+""" -> Operators
 export Operators
 
 # PR #21956
@@ -1355,6 +1362,15 @@ module DSP
 end
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
+@doc """
+DFT will be removed from Base. Use the package with the same name instead.
+""" -> DFT
+@doc """
+DSP will be removed from Base. Use the package with the same name instead.
+""" -> DSP
+@doc """
+FFTW will be removed from Base. Use the package with the same name instead.
+""" -> FFTW
 
 module Test
 for f in [Symbol("@inferred"), Symbol("@test"), Symbol("@test_approx_eq"),

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1363,7 +1363,7 @@ end
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
 @doc """
-DFT will be removed from Base. Use the package with the same name instead.
+DFT will be removed from Base. Use `AbstractFFTs` instead.
 """ -> DFT
 @doc """
 DSP will be removed from Base. Use the package with the same name instead.

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -711,7 +711,6 @@ module Collections
 end
 export Collections
 
-
 # Broadcast now returns a BitArray when the resulting eltype is Bool (#17623)
 @deprecate bitbroadcast broadcast
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -709,9 +709,6 @@ module Collections
         @eval Base.@deprecate_moved $f "DataStructures"
     end
 end
-@doc """
-Collections will be removed from Base. Use DataStructures instead.
-""" -> Collections
 export Collections
 
 
@@ -1328,9 +1325,6 @@ module Operators
         end
     end
 end
-@doc """
-Base.Operators is deprecated, use Base instead.
-""" -> Operators
 export Operators
 
 # PR #21956
@@ -1362,15 +1356,6 @@ module DSP
 end
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
-@doc """
-DFT will be removed from Base. Use `AbstractFFTs` instead.
-""" -> DFT
-@doc """
-DSP will be removed from Base. Use the package with the same name instead.
-""" -> DSP
-@doc """
-FFTW will be removed from Base. Use the package with the same name instead.
-""" -> FFTW
 
 module Test
 for f in [Symbol("@inferred"), Symbol("@test"), Symbol("@test_approx_eq"),

--- a/base/distributed/Distributed.jl
+++ b/base/distributed/Distributed.jl
@@ -1,10 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Distributed
-
-@doc """
+"""
 Tools for distributed parallel calculations.
-""" -> Distributed
+"""
+module Distributed
 
 # imports for extension
 import Base: getindex, wait, put!, take!, fetch, isready, push!, length,

--- a/base/distributed/Distributed.jl
+++ b/base/distributed/Distributed.jl
@@ -2,6 +2,10 @@
 
 module Distributed
 
+@doc """
+Tools for distributed parallel calculations.
+""" -> Distributed
+
 # imports for extension
 import Base: getindex, wait, put!, take!, fetch, isready, push!, length,
              hash, ==, connect, kill, serialize, deserialize, close, showerror

--- a/base/distributed/Distributed.jl
+++ b/base/distributed/Distributed.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-Tools for distributed parallel calculations.
+Tools for distributed parallel processing.
 """
 module Distributed
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1493,7 +1493,7 @@ See the manual section on [Tuple Types](@ref).
 Tuple
 
 @doc """
-The standard library of Julia.
+The base library of Julia.
 """ -> kw"Base"
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1492,4 +1492,8 @@ See the manual section on [Tuple Types](@ref).
 """
 Tuple
 
+@doc """
+The standard library of Julia.
+""" -> Base
+
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1494,6 +1494,6 @@ Tuple
 
 @doc """
 The standard library of Julia.
-""" -> Base
+""" -> kw"Base"
 
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1492,8 +1492,9 @@ See the manual section on [Tuple Types](@ref).
 """
 Tuple
 
-@doc """
+"""
 The base library of Julia.
-""" -> kw"Base"
+"""
+kw"Base"
 
 end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Iterators
+@doc """
+Methods for working with Iterators.
+""" -> Iterators
 
 import Base: start, done, next, isempty, length, size, eltype, iteratorsize, iteratoreltype, indices, ndims, pairs
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Iterators
-@doc """
+"""
 Methods for working with Iterators.
-""" -> Iterators
+"""
+module Iterators
 
 import Base: start, done, next, isempty, length, size, eltype, iteratorsize, iteratoreltype, indices, ndims, pairs
 

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Libc
+@doc """
+Interface to libc, the C standard library.
+""" -> Libc
 
 import Base: transcode
 

--- a/base/libdl.jl
+++ b/base/libdl.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Libdl
+@doc """
+Interface to libdl. Provides dynamic linking support.
+""" -> Libdl
 
 export DL_LOAD_PATH, RTLD_DEEPBIND, RTLD_FIRST, RTLD_GLOBAL, RTLD_LAZY, RTLD_LOCAL,
     RTLD_NODELETE, RTLD_NOLOAD, RTLD_NOW, dlclose, dlopen, dlopen_e, dlsym, dlsym_e,

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module LibGit2
-@doc """
+"""
 Interface to [libgit2](https://libgit2.github.com/).
-""" -> LibGit2
+"""
+module LibGit2
 
 import Base: merge!, ==
 

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module LibGit2
+@doc """
+Interface to [libgit2](https://libgit2.github.com/).
+""" -> LibGit2
 
 import Base: merge!, ==
 

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module BLAS
+@doc """
+Interfaces to BLAS subroutines.
+""" -> BLAS
 
 import ..axpy!, ..axpby!
 import Base: copy!

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -2,7 +2,7 @@
 
 module BLAS
 @doc """
-Interfaces to BLAS subroutines.
+Interface to BLAS subroutines.
 """ -> BLAS
 
 import ..axpy!, ..axpby!

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -1,7 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-## The LAPACK module of interfaces to LAPACK subroutines
 module LAPACK
+@doc """
+Interfaces to LAPACK subroutines.
+""" -> LAPACK
 
 const liblapack = Base.liblapack_name
 

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -1,6 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module LinAlg
+@doc """
+Linear algebra module. Provides array arithmetic,
+matrix factorizations and other linear algebra related
+functionality.
+""" -> LinAlg
 
 import Base: \, /, *, ^, +, -, ==
 import Base: A_mul_Bt, At_ldiv_Bt, A_rdiv_Bc, At_ldiv_B, Ac_mul_Bc, A_mul_Bc, Ac_mul_B,

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -1,11 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module LinAlg
-@doc """
+"""
 Linear algebra module. Provides array arithmetic,
 matrix factorizations and other linear algebra related
 functionality.
-""" -> LinAlg
+"""
+module LinAlg
 
 import Base: \, /, *, ^, +, -, ==
 import Base: A_mul_Bt, At_ldiv_Bt, A_rdiv_Bc, At_ldiv_B, Ac_mul_Bc, A_mul_Bc, Ac_mul_B,

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Markdown
-@doc """
+"""
 Tools for working with the Markdown file format. Mainly for documentation.
-""" -> Markdown
+"""
+module Markdown
 
 import Base: show, ==
 import Core: @doc_str

--- a/base/markdown/Markdown.jl
+++ b/base/markdown/Markdown.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Markdown
+@doc """
+Tools for working with the Markdown file format. Mainly for documentation.
+""" -> Markdown
 
 import Base: show, ==
 import Core: @doc_str

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Meta
-@doc """
+"""
 Convenience functions for metaprogramming.
-""" -> Meta
+"""
+module Meta
 
 export quot,
        isexpr,

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Meta
-#
-# convenience functions for metaprogramming
-#
+@doc """
+Convenience functions for metaprogramming.
+""" -> Meta
 
 export quot,
        isexpr,

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Profile
-@doc """
+"""
 Profiling support, main entry point is the [`@profile`](@ref) macro.
-""" -> Profile
+"""
+module Profile
 
 import Base.StackTraces: lookup, UNKNOWN, show_spec_linfo
 using Base: iszero

--- a/base/profile.jl
+++ b/base/profile.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Profile
+@doc """
+Profiling support, main entry point is the [`@profile`](@ref) macro.
+""" -> Profile
 
 import Base.StackTraces: lookup, UNKNOWN, show_spec_linfo
 using Base: iszero

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -1,6 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Serializer
+@doc """
+Provide serialization of Julia code via the functions
+* [`serialize`](@ref)
+* [`deserialize`](@ref)
+""" -> Serializer
 
 import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
 import Core: svec

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -1,11 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Serializer
-@doc """
+"""
 Provide serialization of Julia code via the functions
 * [`serialize`](@ref)
 * [`deserialize`](@ref)
-""" -> Serializer
+"""
+module Serializer
 
 import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
 import Core: svec

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module SparseArrays
-@doc """
+"""
 Support for sparse arrays. Provides [`AbstractSparseArray`](@ref) and subtypes.
-""" -> SparseArrays
+"""
+module SparseArrays
 
 using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail
 using Base.Sort: Forward

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module SparseArrays
+@doc """
+Support for sparse arrays. Provides [`AbstractSparseArray`](@ref) and subtypes.
+""" -> SparseArrays
 
 using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail
 using Base.Sort: Forward

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-Support for sparse arrays. Provides [`AbstractSparseArray`](@ref) and subtypes.
+Support for sparse arrays. Provides `AbstractSparseArray` and subtypes.
 """
 module SparseArrays
 

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module StackTraces
-@doc """
+"""
 Tools for collecting and manipulating stack traces. Mainly used for building errors.
-""" -> StackTraces
+"""
+module StackTraces
 
 
 import Base: hash, ==, show

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module StackTraces
+@doc """
+Tools for collecting and manipulating stack traces. Mainly used for building errors.
+""" -> StackTraces
 
 
 import Base: hash, ==, show

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Sys
+@doc """
+Methods for retrieving informations about hardware and the operating system.
+""" -> Sys
 
 export CPU_CORES,
        WORD_SIZE,

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -2,7 +2,7 @@
 
 module Sys
 @doc """
-Methods for retrieving informations about hardware and the operating system.
+Provide methods for retrieving information about hardware and the operating system.
 """ -> Sys
 
 export CPU_CORES,

--- a/base/threads.jl
+++ b/base/threads.jl
@@ -1,6 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Threads
+@doc """
+Experimental multithreading support.
+""" -> Threads
 
 include("threadingconstructs.jl")
 include("atomics.jl")

--- a/base/threads.jl
+++ b/base/threads.jl
@@ -1,9 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module Threads
-@doc """
+"""
 Experimental multithreading support.
-""" -> Threads
+"""
+module Threads
 
 include("threadingconstructs.jl")
 include("atomics.jl")

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -88,6 +88,29 @@ primitive type
 ;
 ```
 
+## Base Modules
+```@docs
+Base.BLAS
+Base.Dates
+Base.Distributed
+Base.Docs
+Base.Iterators
+Base.LAPACK
+Base.LibGit2
+Base.Libc
+Base.Libdl
+Base.LinAlg
+Base.Markdown
+Base.Meta
+Base.Pkg
+Base.Profile
+Base.Serializer
+Base.SparseArrays
+Base.StackTraces
+Base.Sys
+Base.Threads
+```
+
 ## All Objects
 
 ```@docs

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -2,6 +2,10 @@
 
 __precompile__(true)
 
+"""
+Utilities for reading and writing delimited files, for example ".csv".
+See [`readdlm`](@ref) and [`writedlm`](@ref).
+"""
 module DelimitedFiles
 
 using Mmap

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -1,5 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+Low level module for mmap (memory mapping of files).
+"""
 module Mmap
 
 const PAGESIZE = Int(Sys.isunix() ? ccall(:jl_getpagesize, Clong, ()) : ccall(:jl_getallocationgranularity, Clong, ()))

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -1,5 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+Provide the [`SharedArray`](@ref) type. It represents an array, which is shared across multiple processes, on a single machine.
+"""
 module SharedArrays
 
 using Mmap, Base.Distributed

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1066,3 +1066,18 @@ end
 end
 @test Main.f23011() == 2
 @test docstrings_equal(@doc(Main.f23011), doc"second")
+
+@testset "exported modules are documented" begin
+    function exported_submodules(M)
+        symbols = filter(names(M)) do name
+            getfield(M, name) isa Module
+        end
+        getfield.(M, collect(symbols))
+    end
+
+    for M in exported_submodules(Base)
+        docstring = string(Docs.doc(M))
+        M == Base && continue  # TODO fix
+        @test !contains(docstring, "No documentation found.")
+    end
+end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1066,18 +1066,3 @@ end
 end
 @test Main.f23011() == 2
 @test docstrings_equal(@doc(Main.f23011), doc"second")
-
-@testset "exported modules are documented" begin
-    function exported_submodules(M)
-        symbols = filter(names(M)) do name
-            getfield(M, name) isa Module
-        end
-        getfield.(M, collect(symbols))
-    end
-
-    for M in exported_submodules(Base)
-        docstring = string(Docs.doc(M))
-        M == Base && continue  # Base is documented as a keyword
-        @test !contains(docstring, "No documentation found.")
-    end
-end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1077,7 +1077,7 @@ end
 
     for M in exported_submodules(Base)
         docstring = string(Docs.doc(M))
-        M == Base && continue  # TODO fix
+        M == Base && continue  # Base is documented as a keyword
         @test !contains(docstring, "No documentation found.")
     end
 end


### PR DESCRIPTION
This PR at least adds stubs and a test that docstrings exist. 
~~I failed to add a docstring to Base itself, how do I do that?~~
fix #23959