### PR TITLE
use colors for error message and stacktrace in warn nowarn test macros

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -513,6 +513,7 @@ macro test_warn(msg, expr)
                         $(esc(expr))
                     end
                 end
+                eval(Base, Expr(:(=), :have_color, have_color))
                 @test ismatch_warn($(esc(msg)), read(fname, String))
                 ret
             finally


### PR DESCRIPTION
Previously, the color state wasn't reset when the `@test` call was being made.