### PR TITLE
Update 'julia-config.jl' for static AOT Julia compilation

### DIFF
--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -4,7 +4,8 @@
 const options = [
     "--cflags",
     "--ldflags",
-    "--ldlibs"
+    "--ldlibs",
+    "--all"
 ];
 
 threadingOn() = ccall(:jl_threading_enabled, Cint, ()) != 0
@@ -87,6 +88,8 @@ function main()
             println(cflags())
         elseif args == "--ldlibs"
             println(ldlibs())
+        elseif args == "--all"
+            println("$(cflags()) $(ldflags()) $(ldlibs())")
         end
     end
 end

--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -36,7 +36,7 @@ end
 function ldflags()
     fl = "-L$(shell_escape(libDir()))"
     if Sys.iswindows()
-        fl = fl * " -Wl,--stack,8388608"
+        fl = fl * " -Wl,--export-all-symbols -Wl,--stack,8388608"
     elseif Sys.islinux()
         fl = fl * " -Wl,--export-dynamic"
     end
@@ -50,9 +50,9 @@ function ldlibs()
         "julia"
     end
     if Sys.isunix()
-        return "-Wl,-rpath,$(shell_escape(libDir())) -Wl,-rpath,$(shell_escape(private_libDir())) -l$libname"
+        return "-Wl,-rpath,$(shell_escape(libDir())) -Wl,-rpath,$(shell_escape(private_libDir())) -Wl,-rpath,\$ORIGIN -l$libname"
     else
-        return "-l$libname -lopenlibm"
+        return "-Wl,-rpath,\$ORIGIN -l$libname -lopenlibm"
     end
 end
 


### PR DESCRIPTION
Add flags required for static AOT Julia compilation, and '--all' option to output all flags.
See [static-julia](https://github.com/JuliaComputing/static-julia) project.