### PR TITLE
Some alignment fix in the runtime

### DIFF
--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -229,24 +229,6 @@ CRC_TARGET static inline uint32_t crc32cb(uint32_t crc, uint32_t val)
     asm("crc32cb %w0, %w1, %w2" : "=r"(res) : "r"(crc), "r"(val));
     return res;
 }
-static inline uint64_t unaligned_i64(const char *ptr)
-{
-    uint64_t val;
-    memcpy(&val, ptr, 8);
-    return val;
-}
-static inline uint32_t unaligned_i32(const char *ptr)
-{
-    uint32_t val;
-    memcpy(&val, ptr, 4);
-    return val;
-}
-static inline uint16_t unaligned_i16(const char *ptr)
-{
-    uint16_t val;
-    memcpy(&val, ptr, 2);
-    return val;
-}
 
 // Modified from the SSE4.2 version.
 CRC_TARGET static uint32_t crc32c_armv8(uint32_t crc, const char *buf, size_t len)
@@ -270,11 +252,11 @@ CRC_TARGET static uint32_t crc32c_armv8(uint32_t crc, const char *buf, size_t le
         const char *buf2 = end;
         const char *buf3 = end + LONG;
         do {
-            crc = crc32cx(crc, unaligned_i64(buf));
+            crc = crc32cx(crc, jl_load_unaligned_i64(buf));
             buf += 8;
-            crc1 = crc32cx(crc1, unaligned_i64(buf2));
+            crc1 = crc32cx(crc1, jl_load_unaligned_i64(buf2));
             buf2 += 8;
-            crc2 = crc32cx(crc2, unaligned_i64(buf3));
+            crc2 = crc32cx(crc2, jl_load_unaligned_i64(buf3));
             buf3 += 8;
         } while (buf < end);
         crc = crc32c_shift(crc32c_long, crc) ^ crc1;
@@ -292,11 +274,11 @@ CRC_TARGET static uint32_t crc32c_armv8(uint32_t crc, const char *buf, size_t le
         const char *buf2 = end;
         const char *buf3 = end + SHORT;
         do {
-            crc = crc32cx(crc, unaligned_i64(buf));
+            crc = crc32cx(crc, jl_load_unaligned_i64(buf));
             buf += 8;
-            crc1 = crc32cx(crc1, unaligned_i64(buf2));
+            crc1 = crc32cx(crc1, jl_load_unaligned_i64(buf2));
             buf2 += 8;
-            crc2 = crc32cx(crc2, unaligned_i64(buf3));
+            crc2 = crc32cx(crc2, jl_load_unaligned_i64(buf3));
             buf3 += 8;
         } while (buf < end);
         crc = crc32c_shift(crc32c_short, crc) ^ crc1;
@@ -310,9 +292,9 @@ CRC_TARGET static uint32_t crc32c_armv8(uint32_t crc, const char *buf, size_t le
         const char *end = buf + SHORT;
         const char *buf2 = end;
         do {
-            crc = crc32cx(crc, unaligned_i64(buf));
+            crc = crc32cx(crc, jl_load_unaligned_i64(buf));
             buf += 8;
-            crc1 = crc32cx(crc1, unaligned_i64(buf2));
+            crc1 = crc32cx(crc1, jl_load_unaligned_i64(buf2));
             buf2 += 8;
         } while (buf < end);
         crc = crc32c_shift(crc32c_short, crc) ^ crc1;
@@ -324,15 +306,15 @@ CRC_TARGET static uint32_t crc32c_armv8(uint32_t crc, const char *buf, size_t le
        block */
     const char *end = buf + len - 8;
     while (buf <= end) {
-        crc = crc32cx(crc, unaligned_i64(buf));
+        crc = crc32cx(crc, jl_load_unaligned_i64(buf));
         buf += 8;
     }
     if (len & 4) {
-        crc = crc32cw(crc, unaligned_i32(buf));
+        crc = crc32cw(crc, jl_load_unaligned_i32(buf));
         buf += 4;
     }
     if (len & 2) {
-        crc = crc32ch(crc, unaligned_i16(buf));
+        crc = crc32ch(crc, jl_load_unaligned_i16(buf));
         buf += 2;
     }
     if (len & 1)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -485,33 +485,34 @@ JL_DLLEXPORT jl_datatype_t *jl_new_primitivetype(jl_value_t *name, jl_module_t *
 
 // bits constructors ----------------------------------------------------------
 
-typedef struct {
-    int64_t a;
-    int64_t b;
-} bits128_t;
-
-// TODO: do we care that this has invalid alignment assumptions?
 JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, void *data)
 {
+    // data may not have the alignment required by the data type.
     jl_ptls_t ptls = jl_get_ptls_states();
     assert(jl_is_datatype(dt));
     jl_datatype_t *bt = (jl_datatype_t*)dt;
     size_t nb = jl_datatype_size(bt);
     if (nb == 0)               return jl_new_struct_uninit(bt); // returns bt->instance
     if (bt == jl_uint8_type)   return jl_box_uint8(*(uint8_t*)data);
-    if (bt == jl_int64_type)   return jl_box_int64(*(int64_t*)data);
+    if (bt == jl_int64_type)   return jl_box_int64(jl_load_unaligned_i64(data));
     if (bt == jl_bool_type)    return (*(int8_t*)data) ? jl_true : jl_false;
-    if (bt == jl_int32_type)   return jl_box_int32(*(int32_t*)data);
-    if (bt == jl_float64_type) return jl_box_float64(*(double*)data);
+    if (bt == jl_int32_type)   return jl_box_int32(jl_load_unaligned_i32(data));
+    if (bt == jl_float64_type) {
+        double f;
+        memcpy(&f, data, 8);
+        return jl_box_float64(f);
+    }
 
     jl_value_t *v = jl_gc_alloc(ptls, nb, bt);
     switch (nb) {
-    case  1: *(int8_t*)   jl_data_ptr(v) = *(int8_t*)data;    break;
-    case  2: *(int16_t*)  jl_data_ptr(v) = *(int16_t*)data;   break;
-    case  4: *(int32_t*)  jl_data_ptr(v) = *(int32_t*)data;   break;
-    case  8: *(int64_t*)  jl_data_ptr(v) = *(int64_t*)data;   break;
-    case 16: *(bits128_t*)jl_data_ptr(v) = *(bits128_t*)data; break;
-    default: memcpy(jl_data_ptr(v), data, nb);
+    case  1: *(uint8_t*) v = *(uint8_t*)data;    break;
+    case  2: *(uint16_t*)v = jl_load_unaligned_i16(data);   break;
+    case  4: *(uint32_t*)v = jl_load_unaligned_i32(data);   break;
+    case  8: *(uint64_t*)v = jl_load_unaligned_i64(data);   break;
+    case 16:
+        memcpy(jl_assume_aligned(v, 16), data, 16);
+        break;
+    default: memcpy(v, data, nb);
     }
     return v;
 }
@@ -521,21 +522,24 @@ JL_DLLEXPORT jl_value_t *jl_typemax_uint(jl_value_t *bt)
 {
     uint64_t data = 0xffffffffffffffffULL;
     jl_value_t *v = jl_gc_alloc(jl_get_ptls_states(), sizeof(size_t), bt);
-    memcpy(jl_data_ptr(v), &data, sizeof(size_t));
+    memcpy(v, &data, sizeof(size_t));
     return v;
 }
 
 void jl_assign_bits(void *dest, jl_value_t *bits)
 {
+    // bits must be a heap box.
     size_t nb = jl_datatype_size(jl_typeof(bits));
     if (nb == 0) return;
     switch (nb) {
-    case  1: *(int8_t*)dest    = *(int8_t*)jl_data_ptr(bits);    break;
-    case  2: *(int16_t*)dest   = *(int16_t*)jl_data_ptr(bits);   break;
-    case  4: *(int32_t*)dest   = *(int32_t*)jl_data_ptr(bits);   break;
-    case  8: *(int64_t*)dest   = *(int64_t*)jl_data_ptr(bits);   break;
-    case 16: *(bits128_t*)dest = *(bits128_t*)jl_data_ptr(bits); break;
-    default: memcpy(dest, jl_data_ptr(bits), nb);
+    case  1: *(uint8_t*)dest    = *(uint8_t*)bits;    break;
+    case  2: jl_store_unaligned_i16(dest, *(uint16_t*)bits); break;
+    case  4: jl_store_unaligned_i32(dest, *(uint32_t*)bits); break;
+    case  8: jl_store_unaligned_i64(dest, *(uint64_t*)bits); break;
+    case 16:
+        memcpy(dest, jl_assume_aligned(bits, 16), 16);
+        break;
+    default: memcpy(dest, bits, nb);
     }
 }
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -37,7 +37,6 @@ JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t 
     JL_TYPECHK(pointerref, pointer, p);
     JL_TYPECHK(pointerref, long, i)
     JL_TYPECHK(pointerref, long, align);
-    // TODO: alignment
     jl_value_t *ety = jl_tparam0(jl_typeof(p));
     if (ety == (jl_value_t*)jl_any_type) {
         jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
@@ -58,7 +57,6 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
     JL_TYPECHK(pointerset, pointer, p);
     JL_TYPECHK(pointerset, long, i);
     JL_TYPECHK(pointerref, long, align);
-    // TODO: alignment
     jl_value_t *ety = jl_tparam0(jl_typeof(p));
     if (ety == (jl_value_t*)jl_any_type) {
         jl_value_t **pp = (jl_value_t**)(jl_unbox_long(p) + (jl_unbox_long(i)-1)*sizeof(void*));
@@ -67,11 +65,12 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
     else {
         if (!jl_is_datatype(ety))
             jl_error("pointerset: invalid pointer");
-        size_t nb = LLT_ALIGN(jl_datatype_size(ety), jl_datatype_align(ety));
+        size_t elsz = jl_datatype_size(ety);
+        size_t nb = LLT_ALIGN(elsz, jl_datatype_align(ety));
         char *pp = (char*)jl_unbox_long(p) + (jl_unbox_long(i)-1)*nb;
         if (jl_typeof(x) != ety)
             jl_error("pointerset: type mismatch in assign");
-        jl_assign_bits(pp, x);
+        memcpy(pp, x, elsz);
     }
     return p;
 }


### PR DESCRIPTION
Do not load/store non-single-byte integer from a pointer that isn't necessarily aligned.
This mainly affect ARM which can segfault on unaligned integer memory access.

Also remove some `jl_data_ptr` which is a no-op and is confusing when reading the code...