### PR TITLE
Docstring for Pair

### DIFF
--- a/base/pair.jl
+++ b/base/pair.jl
@@ -8,7 +8,9 @@ Construct a `Pair` object with type `Pair{typeof(x), typeof(y)}`. The elements
 are stored in the fields `first` and `second`. They can also be accessed via
 iteration.
 
-See also [`Dict`].
+See also [`Dict`](@ref).
+
+# Examples
 
 ```jldoctest
 julia> p = "foo" => 7
@@ -31,7 +33,6 @@ struct Pair{A,B}
     first::A
     second::B
 end
-
 const => = Pair
 
 start(p::Pair) = 1

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -8,10 +8,9 @@ Construct a `Pair` object with type `Pair{typeof(x), typeof(y)}`. The elements
 are stored in the fields `first` and `second`. They can also be accessed via
 iteration.
 
-See also [`Dict`](@ref).
+See also: [`Dict`](@ref)
 
 # Examples
-
 ```jldoctest
 julia> p = "foo" => 7
 "foo"=>7

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -1,5 +1,32 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    Pair(x, y)
+    x => y
+
+Construct a `Pair` object with type `Pair{typeof(x), typeof(y)}`. The elements
+are stored in the fields `first` and `second`. They can also be accessed via
+iteration.
+
+See also [`Dict`].
+
+```jldoctest
+julia> p = "foo" => 7
+"foo"=>7
+
+julia> typeof(p)
+Pair{String,Int64}
+
+julia> p.first
+"foo"
+
+julia> for x in p
+           println(x)
+       end
+foo
+7
+```
+"""
 struct Pair{A,B}
     first::A
     second::B

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -47,7 +47,7 @@ Fully implemented by:
   * `EachLine`
   * `AbstractString`
   * [`Set`](@ref)
-  * `Pair`
+  * [`Pair`](@ref)
 
 ## General Collections
 
@@ -266,3 +266,10 @@ Fully implemented by:
 
   * `Vector` (a.k.a. 1-dimensional [`Array`](@ref))
   * `BitVector` (a.k.a. 1-dimensional [`BitArray`](@ref))
+
+## Utility Collections
+
+```@docs
+Base.Pair
+```
+

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -47,6 +47,7 @@ Fully implemented by:
   * `EachLine`
   * `AbstractString`
   * [`Set`](@ref)
+  * `Pair`
 
 ## General Collections
 

--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -272,4 +272,3 @@ Fully implemented by:
 ```@docs
 Base.Pair
 ```
-


### PR DESCRIPTION
First PR here — followed `CONTRIBUTING.md` for adding a docstring. Not sure if `Pair` needs a blob in the manual,  unless I make a section like "Utility Collections".

Prompted by #23979.

Edit: fix #23979