### PR TITLE
Restore repeat performance for arrays of scalars

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -424,6 +424,10 @@ _rshps(shp, shp_i, sz, i, ::Tuple{}) =
 _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
     "($n) cannot be less than number of dimensions of input ($N)"))
 
+# We need special handling when repeating arrays of arrays
+cat_fill!(R, X, inds) = (R[inds...] = X)
+cat_fill!(R, X::AbstractArray, inds) = fill!(view(R, inds...), X)
+
 @noinline function _repeat(A::AbstractArray, inner, outer)
     shape, inner_shape = rep_shapes(A, inner, outer)
 
@@ -442,7 +446,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
                 n = inner[i]
                 inner_indices[i] = (1:n) .+ ((c[i] - 1) * n)
             end
-            fill!(view(R, inner_indices...), A[c])
+            cat_fill!(R, A[c], inner_indices)
         end
     end
 


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/23670#issuecomment-334717846

@nanosoldier `runbenchmarks(ALL, vs=":master")`