### PR TITLE
Correct signature of * for strings

### DIFF
--- a/doc/src/stdlib/strings.md
+++ b/doc/src/stdlib/strings.md
@@ -3,7 +3,7 @@
 ```@docs
 Base.length(::AbstractString)
 Base.sizeof(::AbstractString)
-Base.:*(::AbstractString, ::AbstractString...)
+Base.:*(::Union{Char, AbstractString}, ::Union{Char, AbstractString}...)
 Base.:^(::AbstractString, ::Integer)
 Base.string
 Base.repeat(::AbstractString, ::Integer)

--- a/doc/src/stdlib/strings.md
+++ b/doc/src/stdlib/strings.md
@@ -3,7 +3,7 @@
 ```@docs
 Base.length(::AbstractString)
 Base.sizeof(::AbstractString)
-Base.:*(::AbstractString, ::Any...)
+Base.:*(::AbstractString, ::AbstractString...)
 Base.:^(::AbstractString, ::Integer)
 Base.string
 Base.repeat(::AbstractString, ::Integer)


### PR DESCRIPTION
Now the documentation of `*` for strings shows wrong docstring. This change should fix it.