### PR TITLE
Fix cgmemmgr for high address allocations

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -731,6 +731,13 @@ endif
 
 JULIA_CPU_TARGET ?= native
 
+ifneq ($(OS),WINNT)
+# Windows headers with this configuration conflicts with LLVM
+# (Symbol renames are done with macros)
+# We mainly need this on linux for cgmemmgr so don't worry about windows for now...
+JCXXFLAGS += -D_FILE_OFFSET_BITS=64
+endif
+
 # Set some ARCH-specific flags
 ifneq ($(USEICC),1)
 ifeq ($(ISX86),1)


### PR DESCRIPTION
This can certainly happen on 32bit with enough allocation.
It's not entirely clear if it can happen on any 64bit linux but a solution seems possible so it's also included.

This was caught a few weeks ago when running 32bit version under rr in chaos mode......
