### PR TITLE
Refine liveness of phi and select

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -263,3 +263,35 @@ end
 @generated f23595(g, args...) = Expr(:call, :g, Expr(:(...), :args))
 x23595 = rand(1)
 @test f23595(Core.arrayref, true, x23595, 1) == x23595[]
+
+# Issue #22421
+@noinline f22421_1(x) = x[] + 1
+@noinline f22421_2(x) = x[] + 2
+@noinline f22421_3(x, y, z, v) = x[] + y[] + z[] + v
+function g22421_1(x, y, b)
+    # Most likely generates a branch with phi node
+    if b
+        z = x
+        v = f22421_1(y)
+    else
+        z = y
+        v = f22421_2(x)
+    end
+    return f22421_3(x, y, z, v)
+end
+function g22421_2(x, y, b)
+    # Most likely generates a select
+    return f22421_3(x, y, b ? x : y, 1)
+end
+
+@test g22421_1(Ref(1), Ref(2), true) === 7
+@test g22421_1(Ref(3), Ref(4), false) === 16
+@test g22421_2(Ref(5), Ref(6), true) === 17
+@test g22421_2(Ref(7), Ref(8), false) === 24
+
+if opt_level > 0
+    @test !contains(get_llvm(g22421_1, Tuple{Base.RefValue{Int},Base.RefValue{Int},Bool}),
+                    "%gcframe")
+    @test !contains(get_llvm(g22421_2, Tuple{Base.RefValue{Int},Base.RefValue{Int},Bool}),
+                    "%gcframe")
+end

--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -289,6 +289,27 @@ top:
     ret %jl_value_t addrspace(10)* %v1
 }
 
+define void @refine_select_phi(%jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y, i1 %b) {
+; CHECK-LABEL: @refine_select_phi
+; CHECK-NOT: %gcframe
+top:
+  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %s = select i1 %b, %jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y
+  br i1 %b, label %L1, label %L2
+
+L1:
+  br label %L3
+
+L2:
+  br label %L3
+
+L3:
+  %p = phi %jl_value_t addrspace(10)* [ %x, %L1 ], [ %y, %L2 ]
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %s)
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  ret void
+}
+
 !0 = !{!"jtbaa"}
 !1 = !{!"jtbaa_const", !0, i64 0}
 !2 = !{!1, !1, i64 0, i64 1}


### PR DESCRIPTION
If both inputs are rooted then we don't need to root the result.
Rename `LoadRefinements` to `Refinements` since it's not load specific anymore.

Fix #22421

This is based on https://github.com/JuliaLang/julia/pull/23993 to reduce conflict.

llvmpasses test will come later.

The handling of `LiftPhi` and `LiftSelect` isn't very pretty but hopefully good enough ;-p...
