### PR TITLE
WIP: corrupted isbits Union fields when uninitialized

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -235,6 +235,7 @@ static MDNode *tbaa_arraylen;       // The len in a jl_array_t
 static MDNode *tbaa_arrayflags;     // The flags in a jl_array_t
 static MDNode *tbaa_const;      // Memory that is immutable by the time LLVM can see it
 static MDNode *tbaa_arrayselbyte;   // a selector byte in a isbits Union jl_array_t
+static MDNode *tbaa_unionselbyte;   // a selector byte in isbits Union struct fields
 
 // Basic DITypes
 static DICompositeType *jl_value_dillvmt;
@@ -5959,6 +5960,7 @@ static void init_julia_llvm_meta(void)
     tbaa_arrayflags = tbaa_make_child("jtbaa_arrayflags", tbaa_array_scalar).first;
     tbaa_const = tbaa_make_child("jtbaa_const", nullptr, true).first;
     tbaa_arrayselbyte = tbaa_make_child("jtbaa_arrayselbyte", tbaa_array_scalar).first;
+    tbaa_unionselbyte = tbaa_make_child("jtbaa_unionselbyte", tbaa_data_scalar).first;
 }
 
 static void init_julia_llvm_env(Module *m)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -735,6 +735,11 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
         if (jl_field_isptr(type, i)) {
             *(jl_value_t**)((char*)jl_data_ptr(jv)+jl_field_offset(type,i)) = NULL;
         }
+        jl_value_t *ft = jl_field_type(type, i);
+        if (jl_is_uniontype(ft)) {
+            uint8_t *psel = &((uint8_t *)jv)[jl_field_offset(type, i) + jl_field_size(type, i) - 1];
+            *psel = 0;
+        }
     }
     return jv;
 }

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -734,11 +734,13 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
     for(size_t i=na; i < nf; i++) {
         if (jl_field_isptr(type, i)) {
             *(jl_value_t**)((char*)jl_data_ptr(jv)+jl_field_offset(type,i)) = NULL;
-        }
-        jl_value_t *ft = jl_field_type(type, i);
-        if (jl_is_uniontype(ft)) {
-            uint8_t *psel = &((uint8_t *)jv)[jl_field_offset(type, i) + jl_field_size(type, i) - 1];
-            *psel = 0;
+
+        } else {
+            jl_value_t *ft = jl_field_type(type, i);
+            if (jl_is_uniontype(ft)) {
+                uint8_t *psel = &((uint8_t *)jv)[jl_field_offset(type, i) + jl_field_size(type, i) - 1];
+                *psel = 0;
+            }
         }
     }
     return jv;

--- a/test/core.jl
+++ b/test/core.jl
@@ -5505,6 +5505,13 @@ x.u = initvalue2(Base.uniontypes(U)[1])
 x.u = initvalue(Base.uniontypes(U)[2])
 @test x.u === initvalue(Base.uniontypes(U)[2])
 
+v = Vector{Float64}(8000000);
+mutable struct UnionField2
+    x::Union{Void, Int}
+    UnionField2() = new()
+end
+@test UnionField2().x === nothing
+
 # PR #23367
 struct A23367
     x::Union{Int8, Int16, NTuple{7, Int8}, Void}

--- a/test/core.jl
+++ b/test/core.jl
@@ -5512,6 +5512,26 @@ mutable struct UnionField2
 end
 @test UnionField2().x === nothing
 
+struct UnionField3
+    x::Union{Void, Int}
+    UnionField3() = new()
+end
+@test UnionField3().x === nothing
+
+mutable struct UnionField4
+    x::Union{Void, Float64}
+    y::Union{Void, Int8}
+    UnionField4() = new()
+end
+@test UnionField4().x === nothing
+
+struct UnionField5
+    x::Union{Void, Float64}
+    y::Union{Void, Int8}
+    UnionField5() = new()
+end
+@test UnionField5().x === nothing
+
 # PR #23367
 struct A23367
     x::Union{Int8, Int16, NTuple{7, Int8}, Void}


### PR DESCRIPTION
The minimum repro is
```julia
v = Vector{Float64}(8000000);
mutable struct UnionField2
    x::Union{Void, Int}
    UnionField2() = new()
end
UnionField2().x
```
I think this is what's needed in `datatype.c`? But I'm not sure what/where the corresponding fix would be in `codegen.cpp`; @vtjnash could you take a look? Also happy to take a stab if you could point me to the right place.