### PR TITLE
Fix Pkg.free() so that it never removes the specified package

### DIFF
--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -237,31 +237,6 @@ function checkout(pkg::AbstractString, branch::AbstractString, do_merge::Bool, d
     end
 end
 
-function free(pkg::AbstractString)
-    ispath(pkg,".git") || throw(PkgError("$pkg is not a git repo"))
-    Read.isinstalled(pkg) || throw(PkgError("$pkg cannot be freed – not an installed package"))
-    avail = Read.available(pkg)
-    isempty(avail) && throw(PkgError("$pkg cannot be freed – not a registered package"))
-    with(GitRepo, pkg) do repo
-        LibGit2.isdirty(repo) && throw(PkgError("$pkg cannot be freed – repo is dirty"))
-        info("Freeing $pkg")
-        vers = sort!(collect(keys(avail)), rev=true)
-        while true
-            for ver in vers
-                sha1 = avail[ver].sha1
-                LibGit2.iscommit(sha1, repo) || continue
-                LibGit2.transact(repo) do r
-                    LibGit2.isdirty(repo) && throw(PkgError("$pkg is dirty, bailing"))
-                    LibGit2.checkout!(repo, sha1)
-                end
-                return resolve()
-            end
-            isempty(Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail])) && continue
-            throw(PkgError("can't find any registered versions of $pkg to checkout"))
-        end
-    end
-end
-
 function free(pkgs)
     try
         for pkg in pkgs
@@ -287,6 +262,8 @@ function free(pkgs)
         resolve()
     end
 end
+
+free(pkg::AbstractString) = free([pkg])
 
 function pin(pkg::AbstractString, head::AbstractString)
     ispath(pkg,".git") || throw(PkgError("$pkg is not a git repo"))

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -250,11 +250,11 @@ function free(pkg::AbstractString)
             for ver in vers
                 sha1 = avail[ver].sha1
                 LibGit2.iscommit(sha1, repo) || continue
-                return LibGit2.transact(repo) do r
+                LibGit2.transact(repo) do r
                     LibGit2.isdirty(repo) && throw(PkgError("$pkg is dirty, bailing"))
                     LibGit2.checkout!(repo, sha1)
-                    resolve()
                 end
+                return resolve()
             end
             isempty(Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail])) && continue
             throw(PkgError("can't find any registered versions of $pkg to checkout"))

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -255,6 +255,9 @@ function free(pkgs)
                     break
                 end
             end
+            # Add package to REQUIRE if it wasn't present already
+            # so that resolve() does not remove it
+            edit(Reqs.add, pkg)
             isempty(Cache.prefetch(pkg, Read.url(pkg), [a.sha1 for (v,a)=avail])) && continue
             throw(PkgError("Can't find any registered versions of $pkg to checkout"))
         end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -675,3 +675,17 @@ temp_pkg_dir(initialize=false) do
                     "INFO: Building Normal") Pkg.Entry.build!(["Exit", "Normal", "Exit", "Normal"], errors)
     end
 end
+
+@testset "issue #17994" begin
+    temp_pkg_dir() do
+        @test Pkg.installed("Example.jl") === nothing
+        Pkg.add("Example.jl")
+        @test [keys(Pkg.installed())...] == ["Example"]
+        Pkg.checkout("Example.jl")
+        Pkg.rm("Example.jl")
+        Pkg.free("Example.jl")
+        iob = IOBuffer()
+        Pkg.status("Example.jl", iob)
+        @test String(take!(iob)) == "No packages installed\n"
+    end
+end

--- a/test/pkg.jl
+++ b/test/pkg.jl
@@ -684,8 +684,10 @@ end
         Pkg.checkout("Example.jl")
         Pkg.rm("Example.jl")
         Pkg.free("Example.jl")
+        @test [keys(Pkg.installed())...] == ["Example"]
         iob = IOBuffer()
         Pkg.status("Example.jl", iob)
-        @test String(take!(iob)) == "No packages installed\n"
+        str = chomp(String(take!(iob)))
+        @test endswith(str, string(Pkg.installed("Example.jl")))
     end
 end


### PR DESCRIPTION
The first commit adds a test which is supposed to fail on Windows only. The second commit fixes it.

However, I don't think this solves #17994, since the change just allows the package removal to complete without breaking further `Pkg` calls. We should probably also change `Pkg.free("X")` to add `X` to REQUIRE so that there's no risk of the package being removed by `resolve`, since this is what #17994 is about.