### PR TITLE
Add SUPPORT.md file containing links to Julia support resources

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,12 @@
+# Getting support for Julia
+
+We use the GitHub issue tracker for bug reports and feature requests only. If
+what you'd like to do is best described as a bug report or a code contribution
+then you should submit a GitHub issue or pull request as usual. Please see our
+[Notes for Julia
+Contributors](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md)
+for how to file a bug report, our contributor checklist and other helpful
+information. But if you have come here for help, or if you are unsure whether
+the behavior you're experiencing is a bug, then you should see our [Community
+page](https://julialang.org/community/) for a list of other places where you can
+get support first.


### PR DESCRIPTION
The SUPPORT.md file points people to Julia support resources. It will show up in a link above the issue report form on GitHub.

Closes #22964 

[ci skip]