### PR TITLE
World counter type fix

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -170,9 +170,9 @@ primitive type Int8    <: Signed   8 end
 primitive type Int16   <: Signed   16 end
 primitive type UInt16  <: Unsigned 16 end
 #primitive type Int32   <: Signed   32 end
-primitive type UInt32  <: Unsigned 32 end
+#primitive type UInt32  <: Unsigned 32 end
 #primitive type Int64   <: Signed   64 end
-primitive type UInt64  <: Unsigned 64 end
+#primitive type UInt64  <: Unsigned 64 end
 primitive type Int128  <: Signed   128 end
 primitive type UInt128 <: Unsigned 128 end
 

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1297,9 +1297,11 @@ void jl_init_primitives(void)
     add_builtin("GlobalRef", (jl_value_t*)jl_globalref_type);
 
     add_builtin("Bool", (jl_value_t*)jl_bool_type);
-    add_builtin("UInt8", (jl_value_t*)jl_uint8_type);
     add_builtin("Int32", (jl_value_t*)jl_int32_type);
     add_builtin("Int64", (jl_value_t*)jl_int64_type);
+    add_builtin("UInt8", (jl_value_t*)jl_uint8_type);
+    add_builtin("UInt32", (jl_value_t*)jl_uint32_type);
+    add_builtin("UInt64", (jl_value_t*)jl_uint64_type);
 #ifdef _P64
     add_builtin("Int", (jl_value_t*)jl_int64_type);
 #else

--- a/src/init.c
+++ b/src/init.c
@@ -787,8 +787,6 @@ void jl_get_builtin_hooks(void)
     jl_int8_type    = (jl_datatype_t*)core("Int8");
     jl_int16_type   = (jl_datatype_t*)core("Int16");
     jl_uint16_type  = (jl_datatype_t*)core("UInt16");
-    jl_uint32_type  = (jl_datatype_t*)core("UInt32");
-    jl_uint64_type  = (jl_datatype_t*)core("UInt64");
 
     jl_float16_type = (jl_datatype_t*)core("Float16");
     jl_float32_type = (jl_datatype_t*)core("Float32");
@@ -800,6 +798,8 @@ void jl_get_builtin_hooks(void)
     jl_datatype_t *jl_integer_type = (jl_datatype_t*)core("Integer");
     jl_bool_type->super = jl_integer_type;
     jl_uint8_type->super = jl_unsigned_type;
+    jl_uint32_type->super = jl_unsigned_type;
+    jl_uint64_type->super = jl_unsigned_type;
     jl_int32_type->super = jl_signed_type;
     jl_int64_type->super = jl_signed_type;
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1924,8 +1924,8 @@ void jl_init_types(void)
                             jl_type_type, // TupleType
                             jl_any_type, // TupleType
                             jl_any_type, // SimpleVector{TupleType}
-                            jl_long_type, // Int
-                            jl_long_type, // Int
+                            jl_ulong_type, // UInt
+                            jl_ulong_type, // UInt
                             jl_any_type, // Any
                             jl_bool_type,
                             jl_bool_type,
@@ -2059,7 +2059,7 @@ void jl_init_types(void)
                             jl_sym_type,
                             jl_int32_type,
                             jl_type_type,
-                            jl_long_type,
+                            jl_ulong_type,
                             jl_any_type, // Union{Array, Void}
                             jl_any_type, // TypeMap
                             jl_simplevector_type,
@@ -2102,8 +2102,8 @@ void jl_init_types(void)
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
-                            jl_long_type,
-                            jl_long_type,
+                            jl_ulong_type,
+                            jl_ulong_type,
                             jl_bool_type,
                             jl_uint8_type,
                             jl_bool_type,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1858,6 +1858,10 @@ void jl_init_types(void)
                                          jl_any_type, jl_emptysvec, 64);
     jl_uint8_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt8"), core,
                                          jl_any_type, jl_emptysvec, 8);
+    jl_uint32_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt32"), core,
+                                         jl_any_type, jl_emptysvec, 32);
+    jl_uint64_type = jl_new_primitivetype((jl_value_t*)jl_symbol("UInt64"), core,
+                                         jl_any_type, jl_emptysvec, 64);
 
     jl_ssavalue_type = jl_new_datatype(jl_symbol("SSAValue"), core, jl_any_type, jl_emptysvec,
                                        jl_perm_symsvec(1, "id"),

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1607,7 +1607,8 @@ static void jl_init_serializer2(int for_serialize)
                      jl_globalref_type->name, jl_typeofbottom_type->name,
                      jl_string_type->name, jl_abstractstring_type->name,
 
-                     jl_int32_type, jl_int64_type, jl_bool_type, jl_uint8_type,
+                     jl_int32_type, jl_int64_type, jl_bool_type,
+                     jl_uint8_type, jl_uint32_type, jl_uint64_type,
 
                      // empirical list of very common symbols
                      #include "common_symbols1.inc"


### PR DESCRIPTION
The world age counter is `size_t` on the C side (eg, in `_jl_method_instance_t`) which is always unsigned, but set to `jl_long_type` (`Int`) on the julia side.  This seems dangerous because we use `typemax(UInt)` as an upper bound for the world age in various places in C but sometimes read these in julia, which I assume could result in the julia side seeing `max_world` as `typemin(Int)`, eg, here

https://github.com/JuliaLang/julia/blob/1216e5f60cd2b23e29856b5227399ab0f3abef76/base/inference.jl#L3044

Unfortunately the fix here moves a couple of type definitions back into C to make this work on both 32 and 64 bit. We could avoid that by making the world age an `Int` instead, but I thought I'd keep this as non-intrusive as possible.

Ref: https://github.com/JuliaLang/julia/issues/23981 (the change here is not a fix for that issue, merely fixing an oddity I noticed while in the process of debugging).