### PR TITLE
Fix duplicated backslash in path delimiters

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -57,12 +57,12 @@ endif
 	@echo "const VERSION_STRING = \"$(JULIA_VERSION)\"" >> $@
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
 ifeq ($(OS),WINNT)
-	@echo 'const SYSCONFDIR = "$(subst /,\\\\,$(sysconfdir_rel))"' >> $@
-	@echo 'const DATAROOTDIR = "$(subst /,\\\\,$(datarootdir_rel))"' >> $@
-	@echo 'const DOCDIR = "$(subst /,\\\\,$(docdir_rel))"' >> $@
-	@echo 'const LIBDIR = "$(subst /,\\\\,$(libdir_rel))"' >> $@
-	@echo 'const PRIVATE_LIBDIR = "$(subst /,\\\\,$(private_libdir_rel))"' >> $@
-	@echo 'const INCLUDEDIR = "$(subst /,\\\\,$(includedir_rel))"' >> $@
+	@printf 'const SYSCONFDIR = "%s"\n' '$(subst /,\\,$(sysconfdir_rel))' >> $@
+	@printf 'const DATAROOTDIR = "%s"\n' '$(subst /,\\,$(datarootdir_rel))' >> $@
+	@printf 'const DOCDIR = "%s"\n' '$(subst /,\\,$(docdir_rel))' >> $@
+	@printf 'const LIBDIR = "%s"\n' '$(subst /,\\,$(libdir_rel))' >> $@
+	@printf 'const PRIVATE_LIBDIR = "%s"\n' '$(subst /,\\,$(private_libdir_rel))' >> $@
+	@printf 'const INCLUDEDIR = "%s"\n' '$(subst /,\\,$(includedir_rel))' >> $@
 else
 	@echo "const SYSCONFDIR = \"$(sysconfdir_rel)\"" >> $@
 	@echo "const DATAROOTDIR = \"$(datarootdir_rel)\"" >> $@

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -33,11 +33,10 @@ end
 
 if Sys.iswindows()
     @testset "path variables use correct path delimiters on windows" begin
-        @test !contains(Base.SYSCONFDIR, "/")
-        @test !contains(Base.DATAROOTDIR, "/")
-        @test !contains(Base.DOCDIR, "/")
-        @test !contains(Base.LIBDIR, "/")
-        @test !contains(Base.PRIVATE_LIBDIR, "/")
-        @test !contains(Base.INCLUDEDIR, "/")
+        for path in (Base.SYSCONFDIR, Base.DATAROOTDIR, Base.DOCDIR,
+                     Base.LIBDIR, Base.PRIVATE_LIBDIR, Base.INCLUDEDIR)
+            @test !contains(path, "/")
+            @test !contains(path, "\\\\")
+        end
     end
 end


### PR DESCRIPTION
See discussion in #24034. The high level gist is that what echo does
with escaped backslashes depends on whether we're talking about the
shell (and if so which) or the command. Use printf instead, which
handles this consistently. Also add a test to make sure this
doesn't regress.