### PR TITLE
Display method's module for text/html

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -262,6 +262,7 @@ function show(io::IO, ::MIME"text/html", m::Method; kwtype::Nullable{DataType}=N
         end
     end
     print(io, ")")
+    print(io, " in ", m.module)
     if line > 0
         u = url(m)
         if isempty(u)

--- a/test/show.jl
+++ b/test/show.jl
@@ -992,3 +992,11 @@ end
     p = PermutedDimsArray(r, (2, 1))
     @test summary(p) == "2×4 PermutedDimsArray(reshape(view(::Array{Int16,3}, :, 3, 2:5), 4, 2), (2, 1)) with eltype Int16"
 end
+
+@testset "Methods" begin
+    m = @which sin(1.0)
+    io = IOBuffer()
+    show(io, "text/html", m)
+    s = String(take!(io))
+    @test contains(s, " in Base.Math ")
+end


### PR DESCRIPTION
When I submitted #19162, I forgot to update the `show` method for `MIME"text/html"`.  I don't use IJulia notebooks often, and only recently noticed the inconsistency with the output in the REPL.

I'm pretty sure that there are no tests that need to be updated after this change, which surprised me.