### PR TITLE
Added a new FAQ making clear RHS always returned with

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -221,7 +221,7 @@ end
 threearr() = x,y = [3,3] # returns an array
 
 typeof(threetup()) === Tuple{Int,Int}
-typeof(threearr()) === Array{Int64,1}
+typeof(threearr()) === Array{Int,1}
 ```
 
 Thus, for the sake of readability, it is often worth writing explicit return statements.

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -226,8 +226,6 @@ typeof(threetup()) === Tuple{Int,Int}
 typeof(threearr()) === Array{Int,1}
 ```
 
-Thus, for the sake of readability, it is often worth writing return statements on a new line.
-
 ## Types, type declarations, and constructors
 
 ### [What does "type-stable" mean?](@id man-type-stability)

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -194,37 +194,39 @@ c = 3::Int64
 If Julia were a language that made more liberal use of ASCII characters, the splatting operator
 might have been written as `...->` instead of `...`.
 
-### Is the last assigned variable always returned?
+### What is the return value of an assignment?
 
-No! The operator `=` always returns the right-hand side, therefore:
+The operator `=` always returns the right-hand side, therefore:
 
 ```jldoctest
-function getthree()
+function threeint()
     x::Int = 3.
     x # returns variable x
 end
-function getthreequick()
+function threefloat()
     x::Int = 3. # returns 3.
 end
 
-typeof(getthree()) === Int
-typeof(getthreequick()) === Float64
+typeof(threeint()) === Int
+typeof(threefloat()) === Float64
 ```
 
 and similarly:
 
 ```jldoctest
 function threetup()
-    x,y = [3,3]
+    x,y = [3, 3]
     x,y # returns a tuple
 end
-threearr() = x,y = [3,3] # returns an array
+function threearr()
+    x,y = [3, 3] # returns an array
+end
 
 typeof(threetup()) === Tuple{Int,Int}
 typeof(threearr()) === Array{Int64,1}
 ```
 
-Thus, for the sake of readability, it is often worth writing explicit return statements.
+Thus, for the sake of readability, it is often worth writing return statements on a new line.
 
 ## Types, type declarations, and constructors
 

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -199,31 +199,45 @@ might have been written as `...->` instead of `...`.
 The operator `=` always returns the right-hand side, therefore:
 
 ```jldoctest
-function threeint()
-    x::Int = 3.
-    x # returns variable x
-end
-function threefloat()
-    x::Int = 3. # returns 3.
-end
+julia> function threeint()
+           x::Int = 3.0
+           x # returns variable x
+       end
+threeint (generic function with 1 method)
 
-typeof(threeint()) === Int
-typeof(threefloat()) === Float64
+julia> function threefloat()
+           x::Int = 3.0 # returns 3.0
+       end
+threefloat (generic function with 1 method)
+
+julia> threeint()
+3
+
+julia> threefloat()
+3.0
 ```
 
 and similarly:
 
 ```jldoctest
-function threetup()
-    x,y = [3, 3]
-    x,y # returns a tuple
-end
-function threearr()
-    x,y = [3, 3] # returns an array
-end
+julia> function threetup()
+           x, y = [3, 3]
+           x, y # returns a tuple
+       end
+threetup (generic function with 1 method)
 
-typeof(threetup()) === Tuple{Int,Int}
-typeof(threearr()) === Array{Int,1}
+julia> function threearr()
+           x, y = [3, 3] # returns an array
+       end
+threearr (generic function with 1 method)
+
+julia> threetup()
+(3, 3)
+
+julia> threearr()
+2-element Array{Int64,1}:
+ 3
+ 3
 ```
 
 ## Types, type declarations, and constructors

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -194,6 +194,38 @@ c = 3::Int64
 If Julia were a language that made more liberal use of ASCII characters, the splatting operator
 might have been written as `...->` instead of `...`.
 
+### Is the last assigned variable always returned?
+
+No! The operator `=` always returns the right-hand side, therefore:
+
+```jldoctest
+function getthree()
+    x::Int = 3.
+    x # returns variable x
+end
+function getthreequick()
+    x::Int = 3. # returns 3.
+end
+
+typeof(getthree()) === Int
+typeof(getthreequick()) === Float64
+```
+
+and similarly:
+
+```jldoctest
+function threetup()
+    x,y = [3,3]
+    x,y # returns a tuple
+end
+threearr() = x,y = [3,3] # returns an array
+
+typeof(threetup()) === Tuple{Int,Int}
+typeof(threearr()) === Array{Int64,1}
+```
+
+Thus, for the sake of readability, it is often worth writing explicit return statements.
+
 ## Types, type declarations, and constructors
 
 ### [What does "type-stable" mean?](@id man-type-stability)


### PR DESCRIPTION
This comes up quite frequently so I thought it might be useful to add an FAQ.

e.g. See: #7341 and https://stackoverflow.com/questions/46660487/function-return-type-from-assignement

Maybe it could use a better title?