### PR TITLE
Don't require read permissions by default for Mmap.mmap

### DIFF
--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -54,7 +54,7 @@ function settings(s::Int, shared::Bool)
         mode = mode & 3
         prot = mode == 0 ? PROT_READ : mode == 1 ? PROT_WRITE : PROT_READ | PROT_WRITE
         if prot & PROT_READ == 0
-            throw(ArgumentError("mmap requires read permissions on the file (choose r+)"))
+            throw(ArgumentError("mmap requires read permissions on the file (open with \"r+\" mode to override)"))
         end
     end
     return prot, flags, (prot & PROT_WRITE) > 0
@@ -222,13 +222,13 @@ mmap(file::AbstractString,
      ::Type{T}=Vector{UInt8},
      dims::NTuple{N,Integer}=(div(filesize(file),sizeof(eltype(T))),),
      offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) where {T<:Array,N} =
-    open(io->mmap(io, T, dims, offset; grow=grow, shared=shared), file, isfile(file) ? "r+" : "w+")::Array{eltype(T),N}
+    open(io->mmap(io, T, dims, offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::Array{eltype(T),N}
 
 # using a length argument instead of dims
 mmap(io::IO, ::Type{T}, len::Integer, offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where {T<:Array} =
     mmap(io, T, (len,), offset; grow=grow, shared=shared)
 mmap(file::AbstractString, ::Type{T}, len::Integer, offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) where {T<:Array} =
-    open(io->mmap(io, T, (len,), offset; grow=grow, shared=shared), file, isfile(file) ? "r+" : "w+")::Vector{eltype(T)}
+    open(io->mmap(io, T, (len,), offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::Vector{eltype(T)}
 
 # constructors for non-file-backed (anonymous) mmaps
 mmap(::Type{T}, dims::NTuple{N,Integer}; shared::Bool=true) where {T<:Array,N} = mmap(Anonymous(), T, dims, Int64(0); shared=shared)
@@ -267,13 +267,13 @@ function mmap(io::IOStream, ::Type{<:BitArray}, dims::NTuple{N,Integer},
 end
 
 mmap(file::AbstractString, ::Type{T}, dims::NTuple{N,Integer}, offset::Integer=Int64(0);grow::Bool=true, shared::Bool=true) where {T<:BitArray,N} =
-    open(io->mmap(io, T, dims, offset; grow=grow, shared=shared), file, isfile(file) ? "r+" : "w+")::BitArray{N}
+    open(io->mmap(io, T, dims, offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::BitArray{N}
 
 # using a length argument instead of dims
 mmap(io::IO, ::Type{T}, len::Integer, offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where {T<:BitArray} =
     mmap(io, T, (len,), offset; grow=grow, shared=shared)
 mmap(file::AbstractString, ::Type{T}, len::Integer, offset::Integer=Int64(0); grow::Bool=true, shared::Bool=true) where {T<:BitArray} =
-    open(io->mmap(io, T, (len,), offset; grow=grow, shared=shared), file, isfile(file) ? "r+" : "w+")::BitVector
+    open(io->mmap(io, T, (len,), offset; grow=grow, shared=shared), file, isfile(file) ? "r" : "w+")::BitVector
 
 # constructors for non-file-backed (anonymous) mmaps
 mmap(::Type{T}, dims::NTuple{N,Integer}; shared::Bool=true) where {T<:BitArray,N} = mmap(Anonymous(), T, dims, Int64(0); shared=shared)

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -50,7 +50,7 @@ gc(); gc()
 s = open(f->f,file,"w")
 @test Mmap.mmap(file) == Array{UInt8}(0) # requested len=0 on empty file
 @test Mmap.mmap(file,Vector{UInt8},0) == Array{UInt8}(0)
-s = open(file, "w")
+s = open(file, "r+")
 m = Mmap.mmap(s,Vector{UInt8},12)
 m[:] = b"Hello World\n"
 Mmap.sync!(m)

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -74,10 +74,11 @@ end
 gc(); gc()
 
 sz = filesize(file)
-m = Mmap.mmap(file, Vector{UInt8}, sz+1)
+s = open(file, "r+")
+m = Mmap.mmap(s, Vector{UInt8}, sz+1)
 @test length(m) == sz+1 # test growing
 @test m[end] == 0x00
-finalize(m); m=nothing; gc()
+close(s); finalize(m); m=nothing; gc()
 sz = filesize(file)
 m = Mmap.mmap(file, Vector{UInt8}, 1, sz)
 @test length(m) == 1
@@ -85,10 +86,11 @@ m = Mmap.mmap(file, Vector{UInt8}, 1, sz)
 finalize(m); m=nothing; gc()
 sz = filesize(file)
 # test where offset is actually > than size of file; file is grown with zeroed bytes
-m = Mmap.mmap(file, Vector{UInt8}, 1, sz+1)
+s = open(file, "r+")
+m = Mmap.mmap(s, Vector{UInt8}, 1, sz+1)
 @test length(m) == 1
 @test m[1] == 0x00
-finalize(m); m=nothing; gc()
+close(s); finalize(m); m=nothing; gc()
 
 s = open(file, "r")
 m = Mmap.mmap(s)

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -221,10 +221,11 @@ open(file,"w") do f
     write(f,UInt8(1))
 end
 @test filesize(file) == 9
-m = Mmap.mmap(file, BitArray, (72,))
+s = open(file, "r+")
+m = Mmap.mmap(s, BitArray, (72,))
 @test Base._check_bitarray_consistency(m)
 @test length(m) == 72
-finalize(m); m = nothing; gc()
+close(s); finalize(m); m = nothing; gc()
 rm(file)
 
 # Mmap.mmap with an offset

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -80,10 +80,11 @@ m = Mmap.mmap(s, Vector{UInt8}, sz+1)
 @test m[end] == 0x00
 close(s); finalize(m); m=nothing; gc()
 sz = filesize(file)
+s = open(file, "r+")
 m = Mmap.mmap(file, Vector{UInt8}, 1, sz)
 @test length(m) == 1
 @test m[1] == 0x00
-finalize(m); m=nothing; gc()
+close(s); finalize(m); m=nothing; gc()
 sz = filesize(file)
 # test where offset is actually > than size of file; file is grown with zeroed bytes
 s = open(file, "r+")

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -50,10 +50,11 @@ gc(); gc()
 s = open(f->f,file,"w")
 @test Mmap.mmap(file) == Array{UInt8}(0) # requested len=0 on empty file
 @test Mmap.mmap(file,Vector{UInt8},0) == Array{UInt8}(0)
-m = Mmap.mmap(file,Vector{UInt8},12)
+s = open(file, "w")
+m = Mmap.mmap(s,Vector{UInt8},12)
 m[:] = b"Hello World\n"
 Mmap.sync!(m)
-finalize(m); m=nothing; gc()
+close(s); finalize(m); m=nothing; gc()
 @test open(x->read(x, String),file) == "Hello World\n"
 
 s = open(file, "r")

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -81,7 +81,7 @@ m = Mmap.mmap(s, Vector{UInt8}, sz+1)
 close(s); finalize(m); m=nothing; gc()
 sz = filesize(file)
 s = open(file, "r+")
-m = Mmap.mmap(file, Vector{UInt8}, 1, sz)
+m = Mmap.mmap(s, Vector{UInt8}, 1, sz)
 @test length(m) == 1
 @test m[1] == 0x00
 close(s); finalize(m); m=nothing; gc()


### PR DESCRIPTION
(on an unrelated note, it'd be nice if `Pkg.test("Mmap")` could be made to work w/ the new `stdlib` setup)