### PR TITLE
Do not save and restore signal mask when initializing tasks

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -284,7 +284,7 @@ void NOINLINE jl_set_base_ctx(char *__stk)
     jl_ptls_t ptls = jl_get_ptls_states();
     ptls->stackbase = (char*)(((uintptr_t)__stk + sizeof(*__stk))&-16); // also ensures stackbase is 16-byte aligned
 #ifndef ASM_COPY_STACKS
-    if (jl_setjmp(ptls->base_ctx, 1)) {
+    if (jl_setjmp(ptls->base_ctx, 0)) {
         start_task();
     }
 #endif


### PR DESCRIPTION
This is consistent with what we do with `ASM_COPY_STACK`
and it causes new tasks to be initialized to the wrong signal masks now that we initialize
tasks before signal handlers.

This cause ARM core test to fail after #24066 since the task running the test
have SIGINT masked off.