### PR TITLE
Allow ... to parse as an identifier

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -109,7 +109,7 @@
 ; operators that are special forms, not function names
 (define syntactic-operators
   (append! (add-dots '(= += -= *= /= //= |\\=| ^= ÷= %= <<= >>= >>>= |\|=| &= ⊻=))
-           '(:= --> $= && |\|\|| |.| ... ->)))
+           '(:= --> $= && |\|\|| |.| ->)))
 (define syntactic-unary-operators '($ & |::|))
 
 (define syntactic-op? (Set syntactic-operators))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -1372,3 +1372,14 @@ end
 @test parse("@foo [1] + [2]") == parse("@foo([1] + [2])")
 @test parse("@Mdl.foo[1] + [2]") == parse("@Mdl.foo([1]) + [2]")
 @test parse("@Mdl.foo [1] + [2]") == parse("@Mdl.foo([1] + [2])")
+
+# Allow ... as an identifier without borking splatting
+let ... = (:)
+    f(x...) = x
+    @test f(1,2) == (1,2)
+    @test f([1,2]...) == (1,2)
+    A = rand(2,3)
+    @test A[..., ...] == A[..., :] == A[:, ...] == A[:, :]
+    ... = 1
+    @test A[..., ..., ...] == A[1, ...] == A[1, 1]
+end


### PR DESCRIPTION
Simple change.  Doesn't give `...` a meaning yet.  First part of #5405.