### PR TITLE
Deprecate array of arrays special casing in .=

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -660,6 +660,9 @@ This section lists changes that do not have deprecation warnings.
     functions yielding a boolean result.  If you want `Array{Bool}`, use
     `broadcast!` or `.=` ([#17623]).
 
+  * Broadcast `A[I...] .= X` with entirely scalar indices `I` is deprecated as
+    its behavior will change in the future.  Use `A[I...] = X` instead.
+
   * Operations like `.+` and `.*` on `Range` objects are now generic
     `broadcast` calls (see [above](#language-changes)) and produce an `Array`.
     If you want a `Range` result, use `+` and `*`, etcetera ([#17623]).

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -534,10 +534,7 @@ end
 # explicit calls to view.   (All of this can go away if slices
 # are changed to generate views by default.)
 
-Base.@propagate_inbounds dotview(args...) = getindex(args...)
-Base.@propagate_inbounds dotview(A::AbstractArray, args...) = view(A, args...)
-Base.@propagate_inbounds dotview(A::AbstractArray{<:AbstractArray}, args::Integer...) = getindex(A, args...)
-
+Base.@propagate_inbounds dotview(args...) = Base.maybeview(args...)
 
 ############################################################
 # The parser turns @. into a call to the __dot__ macro,

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1797,6 +1797,14 @@ function toc()
     return t
 end
 
+# A[I...] .= with scalar indices should modify the element at A[I...]
+function Broadcast.dotview(A::AbstractArray, args::Number...)
+    depwarn("the behavior of `A[I...] .= X` with scalar indices will change in the future. Use `A[I...] = X` instead.", :broadcast!)
+    view(A, args...)
+end
+Broadcast.dotview(A::AbstractArray{<:AbstractArray}, args::Integer...) = getindex(A, args...)
+# Upon removing deprecations, also enable the @testset "scalar .=" in test/broadcast.jl
+
 # PR #23816: deprecation of gradient
 export gradient
 @eval Base.LinAlg begin

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -525,3 +525,16 @@ let t = (0, 1, 2)
     o = 1
     @test @inferred(broadcast(+, t, o)) == (1, 2, 3)
 end
+
+# TODO: Enable after deprecations introduced in 0.7 are removed.
+# @testset "scalar .=" begin
+#     A = [[1,2,3],4:5,6]
+#     A[1] .= 0
+#     @test A[1] == [0,0,0]
+#     @test_throws ErrorException A[2] .= 0
+#     @test_throws MethodError A[3] .= 0
+#     A = [[1,2,3],4:5]
+#     A[1] .= 0
+#     @test A[1] == [0,0,0]
+#     @test_throws ErrorException A[2] .= 0
+# end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -539,7 +539,7 @@ end
     @test x == [5,6,35,4]
     x[Y[2:3]] .= 7:8
     @test x == [5,8,7,4]
-    @. x[(3,)..., ()...] += 3 # @. should convert to .+=, test compatibility with @views
+    x[(3,)..., ()...] += 3
     @test x == [5,8,10,4]
     i = Int[]
     # test that lhs expressions in update operations are evaluated only once:


### PR DESCRIPTION
This commit deprecates the special-casing for arrays of arrays when using `A[I...] .=` with entirely scalar indices.  Once this deprecation goes away, `A[1] .= 0` will *always* modify the element that is stored at `A[1]`.  The outer array `A` will not be modified, regardless of its element type.  I have chosen to use the same internal machinery from `@views` for this; when the deprecation is removed the syntactic transform will behave like `broadcast!(identity, @views A[I...], X)`.

Edit: Fixes #20158.