### PR TITLE
Implement ASM_COPY_STACK on ARM

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1068,6 +1068,12 @@ jl_assume_aligned(T ptr, unsigned align)
 #define jl_assume_aligned(ptr, align) (ptr)
 #endif
 
+#if jl_has_builtin(__builtin_unreachable) || defined(_COMPILER_GCC_) || defined(_COMPILER_INTEL_)
+#  define jl_unreachable() __builtin_unreachable()
+#else
+#  define jl_unreachable() ((void)jl_assume(0))
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Also change the AArch64 version to use a relative jump instead of loading the address in register.
This should make the code robust even if the compiler decide to pick a unusual register (fp or lr)
to store the function address.

Add `jl_unreachable` so that the compiler can know that the inline asm never returns.