### PR TITLE
avoid calling `check_ambiguous_matches` when trying to add same Method

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1420,6 +1420,12 @@ JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method
             (jl_tupletype_t*)type, simpletype, jl_emptysvec, (jl_value_t*)method, 0, &method_defs,
             method->min_world, ~(size_t)0, &oldvalue);
     if (oldvalue) {
+        if (oldvalue == (jl_value_t*)method) {
+            // redundant add of same method; no need to do anything
+            JL_UNLOCK(&mt->writelock);
+            JL_GC_POP();
+            return;
+        }
         method->ambig = ((jl_method_t*)oldvalue)->ambig;
         method_overwrite(newentry, (jl_method_t*)oldvalue);
     }

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -979,10 +979,10 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
     if ((jl_value_t*)simpletype == jl_nothing) {
         jl_typemap_entry_t *ml = jl_typemap_assoc_by_type(*cache, type, NULL, 0, offs, min_world);
         if (ml && ml->simplesig == (void*)jl_nothing) {
-            if (newvalue == ml->func.value) // no change. TODO: involve world in computation!
-                return ml;
             if (overwritten != NULL)
                 *overwritten = ml->func.value;
+            if (newvalue == ml->func.value) // no change. TODO: involve world in computation!
+                return ml;
             if (newvalue == NULL)  // don't overwrite with guard entries
                 return ml;
             ml->max_world = min_world - 1;


### PR DESCRIPTION
I believe #24083 might have fixed part of #23456 --- after that the assertion `assert(closure->after)` in `check_ambiguous_visitor` fails for me instead. That seems to happen because the method list for the precompiled NullableArrays package has two references to `Base.:(==)(Base.Nullable{S}, Base.Nullable{T}) where T where S`. When we try to add the same method again, `jl_method_table_insert` calls `check_ambiguous_matches`, which doesn't expect to be called on a signature already in the table.

Should fix #23456.
