### PR TITLE
fixes enum capitalization

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -29,10 +29,10 @@ end
 @noinline enum_argument_error(typename, x) = throw(ArgumentError(string("invalid value for Enum $(typename): $x")))
 
 """
-    @enum EnumName[::BaseType] EnumValue1[=x] EnumValue2[=y]
+    @enum EnumName[::BaseType] value1[=x] value2[=y]
 
 Create an `Enum{BaseType}` subtype with name `EnumName` and enum member values of
-`EnumValue1` and `EnumValue2` with optional assigned values of `x` and `y`, respectively.
+`value1` and `value2` with optional assigned values of `x` and `y`, respectively.
 `EnumName` can be used just like other types and enum member values as regular values, such as
 
 # Examples

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -491,10 +491,10 @@ enumerated types (see `@enum`).
 
 # Example
 ```jldoctest
-julia> @enum Colors Red Blue Green
+julia> @enum Color red blue green
 
-julia> instances(Colors)
-(Red::Colors = 0, Blue::Colors = 1, Green::Colors = 2)
+julia> instances(Color)
+(red::Color = 0, blue::Color = 1, green::Color = 2)
 ```
 """
 function instances end


### PR DESCRIPTION
This brings the example in the `instances` docstring in line with the naming convention used elsewhere in the enum docs. See #19506