### PR TITLE
Fix PHI node refinement in gcframe allocation

### DIFF
--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -289,27 +289,6 @@ top:
     ret %jl_value_t addrspace(10)* %v1
 }
 
-define void @refine_select_phi(%jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y, i1 %b) {
-; CHECK-LABEL: @refine_select_phi
-; CHECK-NOT: %gcframe
-top:
-  %ptls = call %jl_value_t*** @julia.ptls_states()
-  %s = select i1 %b, %jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y
-  br i1 %b, label %L1, label %L2
-
-L1:
-  br label %L3
-
-L2:
-  br label %L3
-
-L3:
-  %p = phi %jl_value_t addrspace(10)* [ %x, %L1 ], [ %y, %L2 ]
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %s)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
-  ret void
-}
-
 !0 = !{!"jtbaa"}
 !1 = !{!"jtbaa_const", !0, i64 0}
 !2 = !{!1, !1, i64 0, i64 1}

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -76,6 +76,116 @@ define void @issue22770() {
     ret void
 }
 
+define void @refine_select_phi(%jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y, i1 %b) {
+; CHECK-LABEL: @refine_select_phi
+; CHECK-NOT: %gcframe
+top:
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+  %s = select i1 %b, %jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y
+  br i1 %b, label %L1, label %L2
+
+L1:
+  br label %L3
+
+L2:
+  br label %L3
+
+L3:
+  %p = phi %jl_value_t addrspace(10)* [ %x, %L1 ], [ %y, %L2 ]
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %s)
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  ret void
+}
+
+define void @dont_refine_loop(%jl_value_t addrspace(10)* %x) {
+; CHECK-LABEL: @dont_refine_loop
+; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+top:
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+  br label %L1
+
+L1:
+  %continue = phi i1 [ true, %top ], [ false, %L1 ]
+  %p = phi %jl_value_t addrspace(10)* [ %x, %top ], [ %v, %L1 ]
+  %v = call %jl_value_t addrspace(10)* @allocate_some_value()
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  br i1 %continue, label %L1, label %L2
+
+L2:
+  ret void
+}
+
+@gv1 = external global %jl_value_t*
+
+define void @refine_loop_const(%jl_value_t addrspace(10)* %x) {
+; CHECK-LABEL: @refine_loop_const
+; CHECK-NOT: %gcframe
+top:
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+  br label %L1
+
+L1:
+  %continue = phi i1 [ true, %top ], [ false, %L1 ]
+  %p = phi %jl_value_t addrspace(10)* [ %x, %top ], [ %v, %L1 ]
+  %v0 = load %jl_value_t*, %jl_value_t** @gv1, !tbaa !4
+  %v = addrspacecast %jl_value_t* %v0 to %jl_value_t addrspace(10)*
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  br i1 %continue, label %L1, label %L2
+
+L2:
+  ret void
+}
+
+define void @refine_loop_indirect(%jl_value_t addrspace(10)* %x) {
+; CHECK-LABEL: @refine_loop_indirect
+; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+top:
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+  %a = call %jl_value_t addrspace(10)* @allocate_some_value()
+  br label %L1
+
+L1:
+  %continue = phi i1 [ true, %top ], [ false, %L1 ]
+; `%v` is not a valid refinement incoming value of the phi node `%p`,
+; however, `%v` can be refined to `%a` and `%a` is a valid refinement
+; of the phi node. Therefore, we need only one gc slot for `%a`.
+  %p = phi %jl_value_t addrspace(10)* [ %x, %top ], [ %v, %L1 ]
+  %ca = bitcast %jl_value_t addrspace(10)* %a to %jl_value_t addrspace(10)* addrspace(10)*
+  %v = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %ca, !tbaa !1
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  br i1 %continue, label %L1, label %L2
+
+L2:
+  ret void
+}
+
+define void @refine_loop_indirect2(%jl_value_t addrspace(10)* %x) {
+; CHECK-LABEL: @refine_loop_indirect2
+; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+top:
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+  %a = call %jl_value_t addrspace(10)* @allocate_some_value()
+  br label %L1
+
+L1:
+  %continue = phi i1 [ true, %top ], [ false, %L1 ]
+; `%p` has circular dependency but it can only be derived from `%a` which dominate `%p`.
+  %p = phi %jl_value_t addrspace(10)* [ %a, %top ], [ %v, %L1 ]
+  %ca = bitcast %jl_value_t addrspace(10)* %p to %jl_value_t addrspace(10)* addrspace(10)*
+  %v = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %ca, !tbaa !1
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  br i1 %continue, label %L1, label %L2
+
+L2:
+  ret void
+}
+
 !0 = !{!"jtbaa"}
 !1 = !{!2, !2, i64 0}
 !2 = !{!"jtbaa_immut", !0, i64 0}
+!3 = !{!"jtbaa_const", !0, i64 0}
+!4 = !{!3, !3, i64 0, i64 1}


### PR DESCRIPTION
Also have better handling of values that aren't used but are live.

Like last time, test will come later.

It took me a while to convince myself that this is actually as accurate as we can get without major change to how refinements are done. If the incoming value of a phi node does not dominate the phi node itself (and isn't externally rooted) there isn't any case where we can refine the phi node to that incoming value.

@Keno, is there any guarantee on the ordering of the number? If, for example, a dominate b implies a certain order of their number than some of the retry loops can possibly be removed/simplified.
