### PR TITLE
option to not delay TCPServer socket creation

### DIFF
--- a/base/socket.jl
+++ b/base/socket.jl
@@ -312,10 +312,11 @@ mutable struct TCPServer <: LibuvServer
         return tcp
     end
 end
-function TCPServer()
+function TCPServer(; delay=true)
     tcp = TCPServer(Libc.malloc(_sizeof_uv_tcp), StatusUninit)
-    err = ccall(:uv_tcp_init, Cint, (Ptr{Void}, Ptr{Void}),
-                eventloop(), tcp.handle)
+    af_spec = delay ? 0 : 2   # AF_UNSPEC is 0, AF_INET is 2
+    err = ccall(:uv_tcp_init_ex, Cint, (Ptr{Void}, Ptr{Void}, Cuint),
+                eventloop(), tcp.handle, af_spec)
     uv_error("failed to create tcp server", err)
     tcp.status = StatusInit
     return tcp

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -312,6 +312,10 @@ mutable struct TCPServer <: LibuvServer
         return tcp
     end
 end
+
+# Keyword arg "delay": if true, libuv delays creation of socket fd till bind.
+# It can be set to false if there is a need to set socket options before
+# further calls to `bind` and `listen`, e.g. `SO_REUSEPORT`.
 function TCPServer(; delay=true)
     tcp = TCPServer(Libc.malloc(_sizeof_uv_tcp), StatusUninit)
     af_spec = delay ? 0 : 2   # AF_UNSPEC is 0, AF_INET is 2

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -407,3 +407,10 @@ end
         @test test_connect(addr)
     end
 end
+
+@testset "TCPServer constructor" begin
+    s = Base.TCPServer(; delay=false)
+    if ccall(:jl_has_so_reuseport, Int32, ()) == 1
+        @test 0 == ccall(:jl_tcp_reuseport, Int32, (Ptr{Void},), s.handle)
+    end
+end


### PR DESCRIPTION
This change adds an option to TCPServer socket constructor to not delay creation of the socket. This will allow TCP servers to set socket options like `SO_REUSEPORT` before the socket is bound and listened on.

With early initialization:

```
tan@tanlt ~/temp/soreuseport $ julia ./soreuseport.jl false &
[1] 23061
tan@tanlt ~/temp/soreuseport $ creating socket bound to 8010...
has reuseport
tcp_reuseport returned 0
listening...
accepting...

tan@tanlt ~/temp/soreuseport $ julia ./soreuseport.jl false
creating socket bound to 8010...
has reuseport
tcp_reuseport returned 0
listening...
accepting...
```

But that is not possible with delayed initialization:

```
tan@tanlt ~/temp/soreuseport $ julia ./soreuseport.jl true &
[1] 22977
tan@tanlt ~/temp/soreuseport $ creating socket bound to 8010...
has reuseport
tcp_reuseport returned -1
listening...
accepting...

tan@tanlt ~/temp/soreuseport $ julia ./soreuseport.jl true
creating socket bound to 8010...
has reuseport
tcp_reuseport returned -1
listening...
ERROR: LoadError: listen: address already in use (EADDRINUSE)
Stacktrace:
 [1] uv_error at ./libuv.jl:68 [inlined]
 [2] #listen#369 at ./stream.jl:933 [inlined]
 [3] listen at ./stream.jl:933 [inlined]
 [4] run_server(::Bool) at /home/tan/temp/soreuseport/soreuseport.jl:13
 [5] include_relative(::Module, ::String) at ./loading.jl:533
 [6] include(::Module, ::String) at ./sysimg.jl:14
 [7] process_options(::Base.JLOptions) at ./client.jl:325
 [8] _start() at ./client.jl:391
in expression starting at /home/tan/temp/soreuseport/soreuseport.jl:22
```

My `soreuseport.jl` is:

```
function run_server(delay)
    println("creating socket bound to 8010...")
    s = Base.TCPServer(; delay=delay)
    if ccall(:jl_has_so_reuseport, Int32, ()) == 1
        println("has reuseport")
        rc = ccall(:jl_tcp_reuseport, Int32, (Ptr{Void},), s.handle)
        println("tcp_reuseport returned ", rc)
    else
        println("no reuseport")
    end
    bind(s, Base.InetAddr(ip"0.0.0.0", 8010))
    println("listening...")
    listen(s)
    println("accepting...")
    s1 = accept(s)
    println("accepted, closing...")
    close(s1)
    close(s)
    println("done")
end

run_server(parse(Bool, ARGS[1]))
```