### PR TITLE
improve regex search functions signatures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -984,6 +984,9 @@ Deprecated or removed
     predicates for some methods ([#24673]
 
   * `ismatch(regex, str)` has been deprecated in favor of `contains(str, regex)` ([#24673]).
+    `idx` argument in `contains(str, regex, idx)` now specifies an index at which to start
+    the search. In `ismatch` it was undocumented and was interpreted as an offset from the
+    start of the string where the search should start.
 
   * `linspace` and `logspace` now require an explicit number of elements to be
     supplied rather than defaulting to `50`([#24794], [#24805]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -984,9 +984,8 @@ Deprecated or removed
     predicates for some methods ([#24673]
 
   * `ismatch(regex, str)` has been deprecated in favor of `contains(str, regex)` ([#24673]).
-    `idx` argument in `contains(str, regex, idx)` now specifies an index at which to start
-    the search. In `ismatch` it was undocumented and was interpreted as an offset from the
-    start of the string where the search should start.
+    Also `ismatch(regex, str, offset)` is deprecated, use `SubString` to get
+    a desired offset of `str`.
 
   * `linspace` and `logspace` now require an explicit number of elements to be
     supplied rather than defaulting to `50`([#24794], [#24805]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1240,6 +1240,14 @@ end
 
 @deprecate ismatch(r::Regex, s::AbstractString) contains(s, r)
 
+function ismatch(r::Regex, s::AbstractString, offset::Integer)
+    depwarn("`ismatch(regex, str, offset)` is deprecated. " *
+            "You can use `contains(SubString(str, offset+1), regex)` instead.", :ismatch)
+    compile(r)
+    return PCRE.exec(r.regex, String(s), offset, r.match_options,
+                     r.match_data)
+end
+
 @deprecate findin(a, b) findall(occursin(b), a)
 
 @deprecate find findall

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1239,14 +1239,7 @@ end
 @deprecate rsearchindex(s::AbstractString, c::Char, i::Integer) findprev(equalto(c), s, i)
 
 @deprecate ismatch(r::Regex, s::AbstractString) contains(s, r)
-
-function ismatch(r::Regex, s::AbstractString, offset::Integer)
-    depwarn("`ismatch(regex, str, offset)` is deprecated. " *
-            "You can use `contains(SubString(str, offset+1), regex)` instead.", :ismatch)
-    compile(r)
-    return PCRE.exec(r.regex, String(s), offset, r.match_options,
-                     r.match_data)
-end
+@deprecate ismatch(r::Regex, s::AbstractString, offset::Integer) contains(SubString(s, offset+1), r)
 
 @deprecate findin(a, b) findall(occursin(b), a)
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -141,16 +141,14 @@ function getindex(m::RegexMatch, name::Symbol)
 end
 getindex(m::RegexMatch, name::AbstractString) = m[Symbol(name)]
 
-function contains(s::AbstractString, r::Regex, idx::Integer=firstindex(s))
+function contains(s::AbstractString, r::Regex)
     compile(r)
-    return PCRE.exec(r.regex, String(s), idx-1, r.match_options,
-                     r.match_data)
+    return PCRE.exec(r.regex, String(s), 0, r.match_options, r.match_data)
 end
 
-function contains(s::SubString{String}, r::Regex, idx::Integer=firstindex(s))
+function contains(s::SubString{String}, r::Regex)
     compile(r)
-    return PCRE.exec(r.regex, s, idx-1, r.match_options,
-                     r.match_data)
+    return PCRE.exec(r.regex, s, 0, r.match_options, r.match_data)
 end
 
 (r::Regex)(s) = contains(s, r)
@@ -280,8 +278,8 @@ function findnext(re::Regex, str::Union{String,SubString{String}}, idx::Integer)
     PCRE.exec(re.regex, str, idx-1, opts, re.match_data) ?
         ((Int(re.ovec[1])+1):thisind(str,Int(re.ovec[2]))) : (0:-1)
 end
-findnext(r::Regex, s::AbstractString, idx::Integer) = findnext(String(s), r, idx)
-findfirst(r::Regex, s::AbstractString) = findnext(r,s,firstindex(s))
+findnext(r::Regex, s::AbstractString, idx::Integer) = findnext(r, String(s), idx)
+findfirst(r::Regex, s::AbstractString) = findnext(r, s, firstindex(s))
 
 struct SubstitutionString{T<:AbstractString} <: AbstractString
     string::T

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -426,12 +426,10 @@ julia> findprev("Julia", "JuliaLang", 6)
 findprev(t::AbstractString, s::AbstractString, i::Integer) = _rsearch(s, t, i)
 
 """
-    contains(haystack::AbstractString, needle::Union{AbstractString,Char})
-    contains(haystack::AbstractString, needle::Regex, [idx::Integer])
+    contains(haystack::AbstractString, needle::Union{AbstractString,Char,Regex})
 
 Determine whether the second argument is a substring of the first. If `needle`
 is a regular expression, checks whether `haystack` contains a match.
-The optional `idx` argument specifies an index at which to start the search.
 
 # Examples
 ```jldoctest
@@ -443,9 +441,6 @@ true
 
 julia> contains("aba", r"a.a")
 true
-
-julia> contains("aba", r"a.a", 2)
-false
 
 julia> contains("abba", r"a.a")
 false

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -426,10 +426,12 @@ julia> findprev("Julia", "JuliaLang", 6)
 findprev(t::AbstractString, s::AbstractString, i::Integer) = _rsearch(s, t, i)
 
 """
-    contains(haystack::AbstractString, needle::Union{AbstractString,Regex,Char})
+    contains(haystack::AbstractString, needle::Union{AbstractString,Char})
+    contains(haystack::AbstractString, needle::Regex, [idx::Integer])
 
 Determine whether the second argument is a substring of the first. If `needle`
 is a regular expression, checks whether `haystack` contains a match.
+The optional `idx` argument specifies an index at which to start the search.
 
 # Examples
 ```jldoctest
@@ -441,6 +443,9 @@ true
 
 julia> contains("aba", r"a.a")
 true
+
+julia> contains("aba", r"a.a", 2)
+false
 
 julia> contains("abba", r"a.a")
 false

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -21,6 +21,9 @@ for f in [matchall, collect_eachmatch]
     @test f(r"GCG","GCGCG",overlap=true) == ["GCG","GCG"]
 end
 
+# Issue #24157
+@test matchall(r"fé", "café") == ["fé"]
+
 # Issue 8278
 target = """71.163.72.113 - - [30/Jul/2014:16:40:55 -0700] "GET emptymind.org/thevacantwall/wp-content/uploads/2013/02/DSC_006421.jpg HTTP/1.1" 200 492513 "http://images.search.yahoo.com/images/view;_ylt=AwrB8py9gdlTGEwADcSjzbkF;_ylu=X3oDMTI2cGZrZTA5BHNlYwNmcC1leHAEc2xrA2V4cARvaWQDNTA3NTRiMzYzY2E5OTEwNjBiMjc2YWJhMjkxMTEzY2MEZ3BvcwM0BGl0A2Jpbmc-?back=http%3A%2F%2Fus.yhs4.search.yahoo.com%2Fyhs%2Fsearch%3Fei%3DUTF-8%26p%3Dapartheid%2Bwall%2Bin%2Bpalestine%26type%3Dgrvydef%26param1%3D1%26param2%3Dsid%253Db01676f9c26355f014f8a9db87545d61%2526b%253DChrome%2526ip%253D71.163.72.113%2526p%253Dgroovorio%2526x%253DAC811262A746D3CD%2526dt%253DS940%2526f%253D7%2526a%253Dgrv_tuto1_14_30%26hsimp%3Dyhs-fullyhosted_003%26hspart%3Dironsource&w=588&h=387&imgurl=occupiedpalestine.files.wordpress.com%2F2012%2F08%2F5-peeking-through-the-wall.jpg%3Fw%3D588%26h%3D387&rurl=http%3A%2F%2Fwww.stopdebezetting.com%2Fwereldpers%2Fcompare-the-berlin-wall-vs-israel-s-apartheid-wall-in-palestine.html&size=49.0KB&name=...+%3Cb%3EApartheid+wall+in+Palestine%3C%2Fb%3E...+%7C+Or+you+go+peeking+through+the+%3Cb%3Ewall%3C%2Fb%3E&p=apartheid+wall+in+palestine&oid=50754b363ca991060b276aba291113cc&fr2=&fr=&tt=...+%3Cb%3EApartheid+wall+in+Palestine%3C%2Fb%3E...+%7C+Or+you+go+peeking+through+the+%3Cb%3Ewall%3C%2Fb%3E&b=0&ni=21&no=4&ts=&tab=organic&sigr=13evdtqdq&sigb=19k7nsjvb&sigi=12o2la1db&sigt=12lia2m0j&sign=12lia2m0j&.crumb=.yUtKgFI6DE&hsimp=yhs-fullyhosted_003&hspart=ironsource" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36"""
 pat = r"""([\d\.]+) ([\w.-]+) ([\w.-]+) (\[.+\]) "([^"\r\n]*|[^"\r\n\[]*\[.+\][^"]+|[^"\r\n]+.[^"]+)" (\d{3}) (\d+|-) ("(?:[^"]|\")+)"? ("(?:[^"]|\")+)"?"""
@@ -34,9 +37,13 @@ show(buf, r"")
 # see #10994, #11447: PCRE2 allows NUL chars in the pattern
 @test contains("a\0b", Regex("^a\0b\$"))
 
-# regex match / search string must be a String
-@test_throws ArgumentError match(r"test", GenericString("this is a test"))
-@test_throws ArgumentError findfirst(r"test", GenericString("this is a test"))
+# regex match / findfirst string must be a String
+@test match(r"test", GenericString("some test")).match == match(r"test", "some test").match
+@test findfirst(GenericString("this is a test"), r"test") == findfirst("this is a test", r"test")
+@test findfirst("", r"ABC") == 0:-1
+@test findnext("", r"ABC", 1) == 0:-1
+@test findfirst("_ABC_", r"A.C") == 2:4
+@test findnext("_ABC_", r"A.C", 3) == 0:-1
 
 # Named subpatterns
 let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -39,11 +39,11 @@ show(buf, r"")
 
 # regex match / findfirst string must be a String
 @test match(r"test", GenericString("some test")).match == match(r"test", "some test").match
-@test findfirst(GenericString("this is a test"), r"test") == findfirst("this is a test", r"test")
-@test findfirst("", r"ABC") == 0:-1
-@test findnext("", r"ABC", 1) == 0:-1
-@test findfirst("_ABC_", r"A.C") == 2:4
-@test findnext("_ABC_", r"A.C", 3) == 0:-1
+@test findfirst(r"test", GenericString("this is a test")) == findfirst(r"test", "this is a test")
+@test findfirst(r"ABC", "") == 0:-1
+@test findnext(r"ABC", "", 1) == 0:-1
+@test findfirst(r"A.C", "_ABC_") == 2:4
+@test findnext(r"A.C", "_ABC_", 3) == 0:-1
 
 # Named subpatterns
 let m = match(r"(?<a>.)(.)(?<b>.)", "xyz")


### PR DESCRIPTION
This PR proposes the following changes:
* Line 170: `ismatch` should not accept any `SubString` but only `SubString{String}` as `PCRE.exec` assumes UTF-8 encoded string;
* there was a mix of two approaches in search functions: some of them accepted any `AbstractString` and converted it to `String` if needed; some of them threw an error for non-UTF-8 string; as all their docstrings indicated they should accept `AbstractString` I have made all functions accept any `AbstractString` and convert it to `String` if needed.

All the changes should be non-breaking.