### PR TITLE
Uninline trig functions.

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -25,7 +25,7 @@ end
 # Trigonometric functions
 # sin methods
 @noinline sin_domain_error(x) = throw(DomainError(x, "sin(x) is only defined for finite x."))
-@inline function sin(x::T) where T<:Union{Float32, Float64}
+function sin(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx < T(pi)/4 #|x| ~<= pi/4, no need for reduction
         if absx < sqrt(eps(T))
@@ -94,7 +94,7 @@ end
 
 # cos methods
 @noinline cos_domain_error(x) = throw(DomainError(x, "cos(x) is only defined for finite x."))
-@inline function cos(x::T) where T<:Union{Float32, Float64}
+function cos(x::T) where T<:Union{Float32, Float64}
     absx = abs(x)
     if absx < T(pi)/4
         if absx < sqrt(eps(T)/T(2.0))
@@ -167,7 +167,7 @@ end
 
 Simultaneously compute the sine and cosine of `x`, where the `x` is in radians.
 """
-@inline function sincos(x::T) where T<:Union{Float32, Float64}
+function sincos(x::T) where T<:Union{Float32, Float64}
     if abs(x) < T(pi)/4
         if x == zero(T)
             return x, one(T)


### PR DESCRIPTION
The resulting code for functions that calls `sin` or `cos` is increased substantially when inlined (think `f(x)=sin(x)+cos(x)`). I didn't do it for `tan`, `atan`, `atan2` either, so might just have been the remains of some trial-and-error learning about performance sensitive code on my part.

Would appreciate if someone ran nanosoldier here.