### PR TITLE
Cache the source text for Base and update guidelines for using Revise

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,10 +225,9 @@ your changes.
 Here is the standard procedure:
 
 1. If you are planning changes to any types or macros, make those
-   changes, commit them, and build julia using `make`. (This is
+   changes and build julia using `make`. (This is
    necessary because `Revise` cannot handle changes to type
-   definitions or macros.) By making a git commit, you "shield" these
-   changes from the `git stash` procedure described below. Unless it's
+   definitions or macros.) Unless it's
    required to get Julia to build, you do not have to add any
    functionality based on the new types, just the type definitions
    themselves.
@@ -241,27 +240,12 @@ Revise.track(Base)
 ```
 
 3. Edit files in `base/`, save your edits, and test the
-   functionality. Once you are satisfied that things work as desired,
-   make another commit and rebuild julia.
+   functionality.
 
-Should you for some reason need to quit and restart your REPL session
-before finishing your changes, the procedure above will fail because
-`Revise.track`
-[cannot detect changes in source files that occurred after Julia was built](https://github.com/JuliaLang/julia/issues/23448)---it
-will only detect changes to source files that occur after tracking is
-initiated.  Consequently, any changes made prior to
-`Revise.track(Base)` will not be incorporated into your new REPL
-session. You can work around this by temporarily reverting all source
-files to their original state. From somewhere in the `julia`
-directory, start your REPL session and do the following:
-
-```julia
-shell> git stash  # ensure that the code in `base/` matches its state when you built julia
-
-julia> Revise.track(Base)  # Revise's source code cache is synchronized with what's running
-
-shell> git stash pop  # restore any in-progress changes (will now be tracked)
-```
+If you need to restart your Julia session, just start at step 2 above.
+`Revise.track(Base)` will note any changes from when Julia was last
+built and incorporate them automatically. You only need to rebuild
+Julia if you made code-changes that Revise cannot handle.
 
 ### Code Formatting Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ julia-sysimg-release : julia-inference julia-ui-release
 julia-sysimg-debug : julia-inference julia-ui-debug
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys-debug$(CPUID_TAG).$(SHLIB_EXT) JULIA_BUILD_MODE=debug
 
-julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest
+julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest julia-base-cache
 
 debug release : % : julia-%
 
@@ -240,6 +240,8 @@ endif
 $(build_depsbindir)/stringreplace: $(JULIAHOME)/contrib/stringreplace.c | $(build_depsbindir)
 	@$(call PRINT_CC, $(HOSTCC) -o $(build_depsbindir)/stringreplace $(JULIAHOME)/contrib/stringreplace.c)
 
+julia-base-cache: julia-sysimg-$(JULIA_BUILD_MODE) | $(DIRS) $(build_datarootdir)/julia
+	@$(call exec,$(JULIA_EXECUTABLE) $(JULIAHOME)/etc/write_base_cache.jl $(build_datarootdir)/julia/base.cache)
 
 # public libraries, that are installed in $(prefix)/lib
 JL_LIBS := julia julia-debug

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -218,7 +218,7 @@ function _include_dependency(modstring::AbstractString, _path::AbstractString)
         path = joinpath(dirname(prev), _path)
     end
     if _track_dependencies[]
-        push!(_require_dependencies, (modstring, path, mtime(path)))
+        push!(_require_dependencies, (modstring, normpath(path), mtime(path)))
     end
     return path, prev
 end
@@ -733,6 +733,10 @@ function read_dependency_src(io::IO, filename::AbstractString)
     modules, files, required_modules, srctextpos = parse_cache_header(io)
     srctextpos == 0 && error("no source-text stored in cache file")
     seek(io, srctextpos)
+    _read_dependency_src(io, filename)
+end
+
+function _read_dependency_src(io::IO, filename::AbstractString)
     while !eof(io)
         filenamelen = ntoh(read(io, Int32))
         filenamelen == 0 && break

--- a/etc/write_base_cache.jl
+++ b/etc/write_base_cache.jl
@@ -1,0 +1,12 @@
+# Write the sys source cache in format readable by Base._read_dependency_src
+cachefile = ARGS[1]
+open(cachefile, "w") do io
+    for (_, filename) in Base._included_files
+        src = read(filename, String)
+        write(io, hton(Int32(sizeof(filename))))
+        write(io, filename)
+        write(io, hton(UInt64(sizeof(src))))
+        write(io, src)
+    end
+    write(io, Int32(0))
+end

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -685,6 +685,23 @@ JL_DLLEXPORT jl_value_t *jl_load_(jl_module_t *module, jl_value_t *str)
     return jl_load(module, (const char*)jl_string_data(str));
 }
 
+JL_DLLEXPORT jl_value_t *jl_prepend_cwd(jl_value_t *str)
+{
+    size_t sz = 1024;
+    char path[1024];
+    int c = uv_cwd(path, &sz);
+    if (c < 0) {
+        jl_errorf("could not get current directory");
+    }
+    path[sz] = '/';  // fix later with normpath if Windows
+    const char *fstr = (const char*)jl_string_data(str);
+    if (strlen(fstr) + sz >= 1024) {
+        jl_errorf("use a bigger buffer for jl_fullpath");
+    }
+    strcpy(path + sz + 1, fstr);
+    return jl_cstr_to_string(path);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
When building Julia, this keeps track of the files used by `sysimg.jl`, and then after building finishes it copies the contents of those files to a cache file `<juliasrcdir>/usr/share/julia/base.cache`. This allows Revise (and presumably other packages like Gallium) to detect changes that you've made to the source files that define Base. This makes it trivial to hack on Base without rebuilding Julia: you just say `Revise.track(Base)`, and any previous and future edits to the source files get incorporated into your running session automatically.

In my opinion this change, in conjunction with https://github.com/timholy/Revise.jl/pull/49, eliminates the last vestige of any kind of "dicey" behavior in Revise. (Previously, the need to parse the source to extract the list of `include`d files was a major wart, because there were many ways that parsing could fail.) AFAIK its only limitations now stem from those of the fix to #265.

As a heads-up, once this merges I may start looking into what it will take to make Revise one of the "default packages" that gets installed & run by every user. (Configurably, of course.)
