### PR TITLE
hint to `mapslices` from `map`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1938,6 +1938,8 @@ map(f, A::Union{AbstractArray,AbstractSet}) = collect_similar(A, Generator(f,A))
 Transform collection `c` by applying `f` to each element. For multiple collection arguments,
 apply `f` elementwise.
 
+See also: [`mapslices`](@ref)
+
 # Examples
 ```jldoctest
 julia> map(x -> x * 2, [1, 2, 3])


### PR DESCRIPTION
"can I apply function to columns of a matrix or rows ? something like map..."
I see this question asked a lot lately - so i think the best way is to hint at `mapslices` from the documentation of `map`.

See [#23788]