### PR TITLE
Fix compilation on LLVM SVN

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6834,8 +6834,10 @@ extern "C" void *jl_init_llvm(void)
         // Generate simpler code for JIT
         .setRelocationModel(Reloc::Static)
 #ifdef _P64
+        // Make sure we are using the large code model on 64bit
+        // Let LLVM pick a default suitable for jitting on 32bit
         .setCodeModel(CodeModel::Large)
-#else
+#elif JL_LLVM_VERSION < 60000
         .setCodeModel(CodeModel::JITDefault)
 #endif
 #ifdef DISABLE_OPT


### PR DESCRIPTION
* Parsing llvm IR text will now verify the whole module by default.

  Ref https://reviews.llvm.org/D38184
  Disable that using an option that's only meant for testing.
  I'm not entirely sure this is the right way to do things but I got no reply from LLVM-dev as usual so at least this fixes the issue http://lists.llvm.org/pipermail/llvm-dev/2017-October/118090.html.

* Remove use of `JITDefault` relocation model on 32bit.

  It should not be needed anymore and the `EngineBuilder` will use it automatically.