### PR TITLE
enable LLVM'S AMDGPU backend

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -50,7 +50,7 @@ endif
 endif # LLVM_VER != svn
 
 # Figure out which targets to build
-LLVM_TARGETS := host;NVPTX
+LLVM_TARGETS := host;NVPTX;AMDGPU
 
 LLVM_CFLAGS :=
 LLVM_CXXFLAGS :=


### PR DESCRIPTION
First step of mmany to also support AMD GPUs.
My current plan is for develop to mimick CUDAnative.jl with the actual compiler being developed outside of base.
Nevertheless it would be great if we could ship with the AMDGPU backend enabled for 1.0.