### PR TITLE
fix inference of e.g. `Generator(=>, x, y)`

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -37,6 +37,8 @@ Generator(f, I1, I2, Is...) = Generator(a->f(a...), zip(I1, I2, Is...))
 
 Generator(::Type{T}, iter::I) where {T,I} = Generator{I,Type{T}}(T, iter)
 
+Generator(::Type{T}, I1, I2, Is...) where {T} = Generator(a->T(a...), zip(I1, I2, Is...))
+
 start(g::Generator) = (@_inline_meta; start(g.iter))
 done(g::Generator, s) = (@_inline_meta; done(g.iter, s))
 function next(g::Generator, s)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -131,6 +131,11 @@ let gen = ((x,y) for x in 1:10, y in 1:10 if x % 2 == 0 && y % 2 == 0),
     @test collect(gen) == collect(gen2)
 end
 
+# inference on vararg generator of a type (see #22907 comments)
+let f(x) = collect(Base.Generator(=>, x, x))
+    @test @inferred(f((1,2))) == [1=>1, 2=>2]
+end
+
 # generators with nested loops (#4867)
 @test [(i,j) for i=1:3 for j=1:i] == [(1,1), (2,1), (2,2), (3,1), (3,2), (3,3)]
 


### PR DESCRIPTION
Reported in https://github.com/JuliaLang/julia/pull/22907#issuecomment-336400235