### PR TITLE
there is no full

### DIFF
--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -105,10 +105,10 @@ function schur(A::StridedMatrix)
     SchurF = schurfact(A)
     SchurF[:T], SchurF[:Z], SchurF[:values]
 end
-schur(A::Symmetric) = schur(full(A))
-schur(A::Hermitian) = schur(full(A))
-schur(A::UpperTriangular) = schur(full(A))
-schur(A::LowerTriangular) = schur(full(A))
+schur(A::Symmetric) = schur(copy!(similar(parent(A)), A))
+schur(A::Hermitian) = schur(copy!(similar(parent(A)), A))
+schur(A::UpperTriangular) = schur(copy!(similar(parent(A)), A))
+schur(A::LowerTriangular) = schur(copy!(similar(parent(A)), A))
 schur(A::Tridiagonal) = schur(Matrix(A))
 
 

--- a/base/linalg/special.jl
+++ b/base/linalg/special.jl
@@ -116,12 +116,11 @@ for op in (:+, :-)
     end
     for matrixtype in (:SymTridiagonal,:Tridiagonal,:Bidiagonal,:Matrix)
         @eval begin
-            ($op)(A::AbstractTriangular, B::($matrixtype)) = ($op)(full(A), B)
-            ($op)(A::($matrixtype), B::AbstractTriangular) = ($op)(A, full(B))
+            ($op)(A::AbstractTriangular, B::($matrixtype)) = ($op)(copy!(similar(parent(A)), A), B)
+            ($op)(A::($matrixtype), B::AbstractTriangular) = ($op)(A, copy!(similar(parent(B)), B))
         end
     end
 end
 
-A_mul_Bc!(A::AbstractTriangular, B::QRCompactWYQ) = A_mul_Bc!(full!(A),B)
-A_mul_Bc!(A::AbstractTriangular, B::QRPackedQ) = A_mul_Bc!(full!(A),B)
-A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(full(A), B)
+A_mul_Bc!(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc!(full!(A), B)
+A_mul_Bc(A::AbstractTriangular, B::Union{QRCompactWYQ,QRPackedQ}) = A_mul_Bc(copy!(similar(parent(A)), A), B)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -300,7 +300,7 @@ A_mul_B!(C::StridedMatrix{T}, A::Hermitian{T,<:StridedMatrix}, B::StridedMatrix{
 A_mul_B!(C::StridedMatrix{T}, A::StridedMatrix{T}, B::Hermitian{T,<:StridedMatrix}) where {T<:BlasComplex} =
     BLAS.hemm!('R', B.uplo, one(T), B.data, A, zero(T), C)
 
-*(A::HermOrSym, B::HermOrSym) = A*full(B)
+*(A::HermOrSym, B::HermOrSym) = A * copy!(similar(parent(B)), B)
 
 # Fallbacks to avoid generic_matvecmul!/generic_matmatmul!
 ## Symmetric{<:Number} and Hermitian{<:Real} are invariant to transpose; peel off the t

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -426,7 +426,7 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 +(A::UnitLowerTriangular, B::LowerTriangular) = LowerTriangular(tril(A.data, -1) + B.data + I)
 +(A::UnitUpperTriangular, B::UnitUpperTriangular) = UpperTriangular(triu(A.data, 1) + triu(B.data, 1) + 2I)
 +(A::UnitLowerTriangular, B::UnitLowerTriangular) = LowerTriangular(tril(A.data, -1) + tril(B.data, -1) + 2I)
-+(A::AbstractTriangular, B::AbstractTriangular) = full(A) + full(B)
++(A::AbstractTriangular, B::AbstractTriangular) = copy!(similar(parent(A)), A) + copy!(similar(parent(B)), B)
 
 -(A::UpperTriangular, B::UpperTriangular) = UpperTriangular(A.data - B.data)
 -(A::LowerTriangular, B::LowerTriangular) = LowerTriangular(A.data - B.data)
@@ -436,15 +436,15 @@ scale!(c::Number, A::Union{UpperTriangular,LowerTriangular}) = scale!(A,c)
 -(A::UnitLowerTriangular, B::LowerTriangular) = LowerTriangular(tril(A.data, -1) - B.data + I)
 -(A::UnitUpperTriangular, B::UnitUpperTriangular) = UpperTriangular(triu(A.data, 1) - triu(B.data, 1))
 -(A::UnitLowerTriangular, B::UnitLowerTriangular) = LowerTriangular(tril(A.data, -1) - tril(B.data, -1))
--(A::AbstractTriangular, B::AbstractTriangular) = full(A) - full(B)
+-(A::AbstractTriangular, B::AbstractTriangular) = copy!(similar(parent(A)), A) - copy!(similar(parent(B)), B)
 
 ######################
 # BlasFloat routines #
 ######################
 
 A_mul_B!(A::Tridiagonal, B::AbstractTriangular) = A*full!(B)
-A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::Tridiagonal) = A_mul_B!(C, full(A), B)
-A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractTriangular) = A_mul_B!(C, A, full(B))
+A_mul_B!(C::AbstractMatrix, A::AbstractTriangular, B::Tridiagonal) = A_mul_B!(C, copy!(similar(parent(A)), A), B)
+A_mul_B!(C::AbstractMatrix, A::Tridiagonal, B::AbstractTriangular) = A_mul_B!(C, A, copy!(similar(parent(B)), B))
 A_mul_Bt!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, transpose!(C, B))
 A_mul_Bc!(C::AbstractMatrix, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, adjoint!(C, B))
 A_mul_Bc!(C::AbstractVecOrMat, A::AbstractTriangular, B::AbstractVecOrMat) = A_mul_B!(A, adjoint!(C, B))
@@ -528,7 +528,7 @@ for (t, uploc, isunitc) in ((:LowerTriangular, 'L', 'N'),
             elseif p == Inf
                 return inv(LAPACK.trcon!('I', $uploc, $isunitc, A.data))
             else # use fallback
-                return cond(full(A), p)
+                return cond(copy!(similar(parent(A)), A), p)
             end
         end
     end
@@ -2210,7 +2210,7 @@ eigfact(A::AbstractTriangular) = Eigen(eigvals(A), eigvecs(A))
 # Generic singular systems
 for func in (:svd, :svdfact, :svdfact!, :svdvals)
     @eval begin
-        ($func)(A::AbstractTriangular) = ($func)(full(A))
+        ($func)(A::AbstractTriangular) = ($func)(copy!(similar(parent(A)), A))
     end
 end
 


### PR DESCRIPTION
After #24137, #24138, and the long series of prior `full` disambiguations/rewrites, only thirteen `full` calls remain. All such calls are on `[Unit](Upper|Lower)Triangular`/`Symmetric`/`Hermitian` matrices and unambiguously mean `copy!(similar(parent(A)), A)`. A number of options for eliminating these calls follow below.

This pull request implements the simplest, most conservative option: replace the remaining calls with `copy!(similar(parent(A)), A)`.

Another option is to introduce the generic function discussed in #23270. #24148 provides a sketch of this option. (After some thought, that generic function has (in an abstract sense) the semantics of `widen`. So presently #24148 extends `widen` instead of introducing a new exported name.) But this approach seems heavy handed now: Thirteen calls to `copy!(similar(parent(A)), A)` in a specific context don't alone seem worth exporting a new generic name from Base (nor worth extending an existing Base export in a major way). The generic function in #23270/#24148 may find other uses, but playing with those other uses / carefully vetting behavior prior to introducing such functionality seems wise. And we can introduce such functionality after 1.0, but we can't change or remove it in the 1.x series if we inject it now.

In any case, `copy!(similar(parent(A)), A)` isn't bad to write on the few occasions one needs to, is quite clear, and provides more opportunity for optimization than existing alternatives. So at this point I err on the (conservative) side of the approach in this pull request. If we really need a new name, we can introduce it later. Best!

(Also note: In https://github.com/JuliaLang/julia/pull/24137#issuecomment-336656037 Andreas and I discuss fleshing out the (unexported) `full!(A::Union{[Unit](Upper|Lower)Triangular,Symmetric,Hermitian})` (which fills `A`'s parent with `A`'s contents and returns the parent) and renaming it to better reflect is semantics (e.g. to `fillparent!(A)`). Then one could write either `copy!(similar(parent(A)), A)` or `fillparent!(copy(A))` for this operation. And if it proves necessary, introducing an unexported `filledparent(A)` or so would then be natural.)