### PR TITLE
Improve documentation of egal

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -163,8 +163,9 @@ const ≠ = !=
     ≡(x,y) -> Bool
 
 Determine whether `x` and `y` are identical, in the sense that no program could distinguish
-them. Compares mutable objects by address in memory, and compares immutable objects (such as
-numbers) by contents at the bit level. This function is sometimes called `egal`.
+them. First it compares types of `x` and `y`. If they are identical it compares mutable
+objects by address in memory, and compares immutable objects (such as numbers) by contents at
+the bit level. This function is sometimes called `egal`.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -163,9 +163,9 @@ const ≠ = !=
     ≡(x,y) -> Bool
 
 Determine whether `x` and `y` are identical, in the sense that no program could distinguish
-them. First it compares types of `x` and `y`. If they are identical it compares mutable
-objects by address in memory, and compares immutable objects (such as numbers) by contents at
-the bit level. This function is sometimes called `egal`.
+them. First it compares the types of `x` and `y`. If those are identical, it compares mutable
+objects by address in memory and immutable objects (such as numbers) by contents at the bit
+level. This function is sometimes called `egal`.
 
 # Examples
 ```jldoctest

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -165,7 +165,7 @@ const ≠ = !=
 Determine whether `x` and `y` are identical, in the sense that no program could distinguish
 them. First it compares the types of `x` and `y`. If those are identical, it compares mutable
 objects by address in memory and immutable objects (such as numbers) by contents at the bit
-level. This function is sometimes called `egal`.
+level. This function is sometimes called "egal".
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
I propose to add information that `===` first compares types of its arguments.

For instance take two immutable objects having the same contents on bit level:
```
julia> zero(Int8) === zero(UInt8)
false
```
or two mutable objects having the same address in memory:
```
julia> x = [1]
1-element Array{Int64,1}:
 1

julia> y = reinterpret(Float64, x)
1-element Array{Float64,1}:
 4.94066e-324

julia> x === y
false
```