### PR TITLE
Fix unused variable warning when building with Clang

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -860,9 +860,9 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     if (S.AllPtrNumbering.find(Phi) != S.AllPtrNumbering.end())
                         continue;
                     auto Num = LiftPhi(S, Phi);
-                    auto lift = cast<PHINode>(S.ReversePtrNumbering[Num]);
                     SmallVector<int, 1> RefinedPtr(0);
                     // DISABLED DUE TO BUG IN THE ALGORITHM (#24098)
+                    //auto lift = cast<PHINode>(S.ReversePtrNumbering[Num]);
                     //for (unsigned i = 0; i < nIncoming; ++i)
                     //    RefinedPtr[i] = Number(S, lift->getIncomingValue(i));
                     S.Refinements[Num] = std::move(RefinedPtr);


### PR DESCRIPTION
This moves the definition of a variable whose only use is within some commented-out logic to the comment, which avoids an unused variable warning. When the logic is uncommented, the variable will be defined and all will be well.

Part of my never-ending quest to avoid Clang warnings when compiling.