### PR TITLE
make similar(A<:AbstractTriangular, opts...) consistently preserve A's underlying storage type

### DIFF
--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -30,10 +30,12 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
         convert(::Type{AbstractMatrix{T}}, A::$t) where {T} = convert($t{T}, A)
         convert(::Type{Matrix}, A::$t{T}) where {T} = convert(Matrix{T}, A)
 
-        function similar(A::$t, ::Type{T}) where T
-            B = similar(A.data, T)
-            return $t(B)
-        end
+        # For A<:AbstractTriangular, similar(A[, neweltype]) should yield a matrix with the same
+        # triangular type and underlying storage type as A. The following method covers these cases.
+        similar(A::$t, ::Type{T}) where {T} = $t(similar(parent(A), T))
+        # On the other hand, similar(A, [neweltype,] shape...) should yield a matrix of the underlying
+        # storage type of A (not wrapped in a triangular type). The following method covers these cases.
+        similar(A::$t, ::Type{T}, dims::Dims{N}) where {T,N} = similar(parent(A), T, dims)
 
         copy(A::$t) = $t(copy(A.data))
 

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -516,3 +516,15 @@ using Main.TestHelpers.Furlong
 let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
     @test sqrt(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
 end
+
+@testset "similar should preserve underlying storage type" begin
+    m, n = 4, 3
+    sparsemat = sprand(m, m, 0.5)
+    for TriType in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
+        trisparsemat = TriType(sparsemat)
+        @test isa(similar(trisparsemat), typeof(trisparsemat))
+        @test isa(similar(trisparsemat, Float32), TriType{Float32,<:SparseMatrixCSC{Float32}})
+        @test isa(similar(trisparsemat, (n, n)), typeof(sparsemat))
+        @test isa(similar(trisparsemat, Float32, (n, n)), SparseMatrixCSC{Float32})
+    end
+end


### PR DESCRIPTION
This pull request makes `similar(A<:AbstractTriangular, opts...)` consistently preserve `A`'s underlying storage type. For example, this pull request makes `similar(UpperTriangular(sprand(4, 4, 0.5)), Float32, (3, 3))` yield a `SparseMatrixCSC{Float32}` rather than the present `Matrix{Float32}`. Ref. https://github.com/JuliaLang/LinearAlgebra.jl/issues/271. Best!