### PR TITLE
make similar(A<:HermOrSym, opts...) consistently preserve A's storage type and uplo flag

### DIFF
--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -444,3 +444,17 @@ end
         @test norm(inv(Hermitian(H))*(H*ones(8)) .- 1) ≈ 0 atol = 1e-5
     end
 end
+
+@testset "similar should preserve underlying storage type and uplo flag" begin
+    m, n = 4, 3
+    sparsemat = sprand(m, m, 0.5)
+    for SymType in (Symmetric, Hermitian)
+        symsparsemat = SymType(sparsemat)
+        @test isa(similar(symsparsemat), typeof(symsparsemat))
+        @test similar(symsparsemat).uplo == symsparsemat.uplo
+        @test isa(similar(symsparsemat, Float32), SymType{Float32,<:SparseMatrixCSC{Float32}})
+        @test similar(symsparsemat, Float32).uplo == symsparsemat.uplo
+        @test isa(similar(symsparsemat, (n, n)), typeof(sparsemat))
+        @test isa(similar(symsparsemat, Float32, (n, n)), SparseMatrixCSC{Float32})
+    end
+end


### PR DESCRIPTION
This pull request makes `similar(A<:Union{Symmetric,Hermitian}, opts...)` consistently preserve `A`'s underlying storage type and `uplo` flag. For example, this pull request makes: (1) `similar(Symmetric(sprand(4, 4, 0.5)), Float32, (3, 3))` yield a `SparseMatrixCSC{Float32}` rather than the present `Matrix{Float32}`; and (2) `similar(Symmetric(rand(4, 4), :L)).uplo` yield `'L'` . Ref. https://github.com/JuliaLang/LinearAlgebra.jl/issues/271. Best!