### PR TITLE
fix findfirst and findlast to not call deprecated methods

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1642,7 +1642,7 @@ julia> findfirst(zeros(3))
 0
 ```
 """
-findfirst(A) = findnext(A, 1)
+findfirst(A) = findnext(x -> x != 0, A, 1)
 
 """
     findnext(predicate::Function, A, i::Integer)
@@ -1759,7 +1759,7 @@ julia> findlast(A)
 0
 ```
 """
-findlast(A) = findprev(A, endof(A))
+findlast(A) = findprev(x -> x != 0, A, endof(A))
 
 """
     findprev(predicate::Function, A, i::Integer)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -426,6 +426,8 @@ end
 
 @testset "find, findfirst, findnext, findlast, findprev" begin
     a = [0,1,2,3,0,1,2,3]
+    @test findfirst(a) == 2
+    @test findlast(a) == 8
     @test find(!iszero, a) == [2,3,4,6,7,8]
     @test find(a.==2) == [3,7]
     @test find(isodd,a) == [2,4,6,8]


### PR DESCRIPTION
`findnext` and `findprev` without a predicate are now deprecated.