### PR TITLE
fix part of #24166: bug in diagonal typevars on the right

### DIFF
--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -116,6 +116,21 @@ function test_diagonal()
     # don't consider a diagonal variable concrete if it already has an abstract lower bound
     @test isequal_type(Tuple{Vararg{A}} where A>:Integer,
                        Tuple{Vararg{A}} where A>:Integer)
+
+    # issue #24166
+    @test !issub(Tuple{T, T, Ref{T}} where T, Tuple{S, S, Ref{Q} where Q} where S)
+    @test !issub(Tuple{T, T, Ref{T}} where T, Tuple{S, S, Ref{Q} where Q} where S<:Integer)
+    @test !issub(Tuple{T, T, Ref{T}} where T, Tuple{S, S, Ref{Q} where Q} where S<:Int)
+    @test  issub(Tuple{T, T, Ref{T}} where T<:Int, Tuple{S, S, Ref{Q} where Q} where S)
+    @test !issub(Tuple{T, T, Ref{T}} where T>:Int, Tuple{S, S, Ref{Q} where Q} where S)
+    @test !issub(Tuple{T, T, Ref{T}} where T>:Integer, Tuple{S, S, Ref{Q} where Q} where S)
+    @test !issub(Tuple{T, T, Ref{T}} where T>:Any, Tuple{S, S, Ref{Q} where Q} where S)
+
+    @test  issub(Tuple{T, T} where Int<:T<:Int, Tuple{T, T} where Int<:T<:Int)
+    @test  issub(Tuple{T, T} where T>:Int, Tuple{T, T} where T>:Int)
+    @test  issub(Tuple{Tuple{T, T} where T>:Int}, Tuple{Tuple{T, T} where T>:Int})
+    @test  issub(Tuple{Tuple{T, T} where T>:Int}, Tuple{Tuple{T, T}} where T>:Int)
+    @test  issub(Tuple{Tuple{T, T}} where T>:Int, Tuple{Tuple{T, T} where T>:Int})
 end
 
 # level 3: UnionAll


### PR DESCRIPTION
The first problem is a case like this:

```
(Tuple{T, T, Ref{T}} where T)  <:  (Tuple{S, S, Ref{Q} where Q} where S)
```

where `S` is diagonal but `T` is not. `S` is more constrained so this should be false. This is fixed by adding a check that a var (T) appearing as the lower bound of a diagonal var (S) must itself be diagonal.

The second problem is this:

```
(Tuple{T, T} where T>:Int)  <:  (Tuple{S, S} where S>:Int)
```

Though this seems absurd, the issue is that S's lower bound comes out to `Union{T,Int}` which we then think is not concrete. Determining whether a lower bound is concrete enough is still an open problem, but I put a band-aid on this by simplifying `Union{T,S}` given `T>:S` to `T`.