### PR TITLE
Change srand default seed to 0 from nothing in testdefs

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -2,7 +2,7 @@
 
 using Test
 
-function runtests(name, isolate=true; seed=nothing)
+function runtests(name, isolate=true; seed=0)
     old_print_setting = Test.TESTSET_PRINT_ENABLE[]
     Test.TESTSET_PRINT_ENABLE[] = false
     try

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -2,7 +2,7 @@
 
 using Test
 
-function runtests(name, isolate=true; seed=0)
+function runtests(name, isolate=true; seed=nothing)
     old_print_setting = Test.TESTSET_PRINT_ENABLE[]
     Test.TESTSET_PRINT_ENABLE[] = false
     try
@@ -17,7 +17,8 @@ function runtests(name, isolate=true; seed=0)
         @eval(m, using Test)
         ex = quote
             @timed @testset $"$name" begin
-                srand($seed)
+                # srand(nothing) will fail
+                $seed != nothing && srand($seed)
                 include($"$name.jl")
             end
         end


### PR DESCRIPTION
This [seems to be killing coverage](https://buildog.julialang.org/#/builders/16/builds/10/steps/8/logs/stdio), because `srand(nothing)` doesn't work anymore. `0` is the default `MersenneTwister` seed, I think? Should we be using `make_seed()` instead?