### PR TITLE
fix crash in generated code for `isdefined(::DataType, n)`

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2816,6 +2816,13 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             stt == jl_module_type) { // TODO: use ->layout here instead of leaf_type
             return false;
         }
+        if (jl_is_type_type((jl_value_t*)stt)) {
+            // the representation type of Type{T} is either DataType, or unknown
+            if (jl_is_leaf_type(jl_tparam0(stt)))
+                stt = jl_datatype_type;
+            else
+                return false;
+        }
         assert(jl_is_datatype(stt));
 
         ssize_t fieldidx = -1;

--- a/test/core.jl
+++ b/test/core.jl
@@ -5347,6 +5347,13 @@ f_isdefined_va(::T...) where {T} = @isdefined T
 @test !f_isdefined_va()
 @test f_isdefined_va(1, 2, 3)
 
+# note: the constant `5` here should be > DataType.ninitialized.
+# This tests that there's no crash due to accessing Type.body.layout.
+let f(n) = isdefined(typeof(n), 5)
+    @test f(0) === false
+    @test isdefined(Int, 5) === false
+end
+
 # @isdefined in a loop
 let a = []
     for i = 1:2


### PR DESCRIPTION
Discovered while updating #22194. So you see, generalizing the object model is good for catching bugs :-P