### PR TITLE
clarify Timer docstrings, add example

### DIFF
--- a/base/event.jl
+++ b/base/event.jl
@@ -347,11 +347,11 @@ end
 """
     Timer(delay, repeat=0)
 
-Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object). 
+Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object).
 
-Waiting tasks are woken after an intial delay of `delay` seconds, and then repeating with the given 
-`repeat` interval in seconds. If `repeat` is equal to `0`, the timer is only triggered once. When 
-the timer is closed (by [`close`](@ref) waiting tasks are woken with an error. Use [`isopen`](@ref) 
+Waiting tasks are woken after an intial delay of `delay` seconds, and then repeating with the given
+`repeat` interval in seconds. If `repeat` is equal to `0`, the timer is only triggered once. When
+the timer is closed (by [`close`](@ref) waiting tasks are woken with an error. Use [`isopen`](@ref)
 to check whether a timer is still active.
 """
 mutable struct Timer
@@ -450,18 +450,18 @@ end
 """
     Timer(callback::Function, delay, repeat=0)
 
-Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object) and 
-calls the function `callback`. 
+Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object) and
+calls the function `callback`.
 
-Waiting tasks are woken and the function `callback` is called after an intial delay of `delay` seconds, 
-and then repeating with the given `repeat` interval in seconds. If `repeat` is equal to `0`, the timer 
-is only triggered once. The function `callback` is called with a single argument, the timer itself. 
-When the timer is closed (by [`close`](@ref) waiting tasks are woken with an error. Use [`isopen`](@ref) 
+Waiting tasks are woken and the function `callback` is called after an intial delay of `delay` seconds,
+and then repeating with the given `repeat` interval in seconds. If `repeat` is equal to `0`, the timer
+is only triggered once. The function `callback` is called with a single argument, the timer itself.
+When the timer is closed (by [`close`](@ref) waiting tasks are woken with an error. Use [`isopen`](@ref)
 to check whether a timer is still active.
 
 # Examples
 
-Here the first number is printed after a delay of two seconds, then the following numbers are printed quickly. 
+Here the first number is printed after a delay of two seconds, then the following numbers are printed quickly.
 
 ```julia-repl
 julia> begin

--- a/base/event.jl
+++ b/base/event.jl
@@ -465,11 +465,11 @@ Here the first number is printed after a delay of two seconds, then the followin
 
 ```julia-repl
 julia> begin
-           i=0
-           cb(timer) = println(global i+=1)
-           t=Timer(cb, 2,0.2)
+           i = 0
+           cb(timer) = (global i += 1; println(i))
+           t = Timer(cb, 2, 0.2)
            wait(t)
-           sleep(.5)
+           sleep(0.5)
            close(t)
        end
 1

--- a/base/event.jl
+++ b/base/event.jl
@@ -347,9 +347,12 @@ end
 """
     Timer(delay, repeat=0)
 
-Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object) at
-a specified interval.  Times are in seconds.  Waiting tasks are woken with an error when the
-timer is closed (by [`close`](@ref). Use [`isopen`](@ref) to check whether a timer is still active.
+Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object). 
+
+Waiting tasks are woken after an intial delay of `delay` seconds, and then repeating with the given 
+`repeat` interval in seconds. If `repeat` is equal to `0`, the timer is only triggered once. When 
+the timer is closed (by [`close`](@ref) waiting tasks are woken with an error. Use [`isopen`](@ref) 
+to check whether a timer is still active.
 """
 mutable struct Timer
     handle::Ptr{Void}
@@ -447,11 +450,32 @@ end
 """
     Timer(callback::Function, delay, repeat=0)
 
-Create a timer to call the given `callback` function. The `callback` is passed one argument,
-the timer object itself. The callback will be invoked after the specified initial `delay`,
-and then repeating with the given `repeat` interval. If `repeat` is `0`, the timer is only
-triggered once. Times are in seconds. A timer is stopped and has its resources freed by
-calling [`close`](@ref) on it.
+Create a timer that wakes up tasks waiting for it (by calling [`wait`](@ref) on the timer object) and 
+calls the function `callback`. 
+
+Waiting tasks are woken and the function `callback` is called after an intial delay of `delay` seconds, 
+and then repeating with the given `repeat` interval in seconds. If `repeat` is equal to `0`, the timer 
+is only triggered once. The function `callback` is called with a single argument, the timer itself. 
+When the timer is closed (by [`close`](@ref) waiting tasks are woken with an error. Use [`isopen`](@ref) 
+to check whether a timer is still active.
+
+# Examples
+
+Here the first number is printed after a delay of two seconds, then the following numbers are printed quickly. 
+
+```julia-repl
+julia> begin
+       i=0
+       cb(timer) = println(global i +=1)
+       t=Timer(cb, 2,0.2)
+       wait(t)
+       sleep(.5)
+       close(t)
+       end
+1
+2
+3
+```
 """
 function Timer(cb::Function, timeout::Real, repeat::Real=0.0)
     t = Timer(timeout, repeat)

--- a/base/event.jl
+++ b/base/event.jl
@@ -466,7 +466,7 @@ Here the first number is printed after a delay of two seconds, then the followin
 ```julia-repl
 julia> begin
            i=0
-           cb(timer) = println(global i +=1)
+           cb(timer) = println(global i+=1)
            t=Timer(cb, 2,0.2)
            wait(t)
            sleep(.5)

--- a/base/event.jl
+++ b/base/event.jl
@@ -465,12 +465,12 @@ Here the first number is printed after a delay of two seconds, then the followin
 
 ```julia-repl
 julia> begin
-       i=0
-       cb(timer) = println(global i +=1)
-       t=Timer(cb, 2,0.2)
-       wait(t)
-       sleep(.5)
-       close(t)
+           i=0
+           cb(timer) = println(global i +=1)
+           t=Timer(cb, 2,0.2)
+           wait(t)
+           sleep(.5)
+           close(t)
        end
 1
 2


### PR DESCRIPTION
I was confused by the `Timer` docstrings, so I tried to make them more clear. I didn't add a doc test because it seems wasteful to have a test that is mostly sleeping. I don't have a local build of julia to build the docs with, so I just tried to get the formatting right. 

Normally I would have re-used most of the text and just made a small entry for the callback variant, but one docstring is on a type, and one is on a method, so I just repeated everything.