### PR TITLE
Iterators.Reverse type for reverse-order iteration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -274,6 +274,9 @@ Library improvements
     For example, `x^-1` is now essentially a synonym for `inv(x)`, and works
     in a type-stable way even if `typeof(x) != typeof(inv(x))` ([#24240]).
 
+  * New `Iterators.reverse(itr)` for reverse-order iteration ([#24187]).  Iterator
+    types `T` can implement `start` etc. for `Iterators.Reverse{T}` to support this.
+
   * The functions `nextind` and `prevind` now accept `nchar` argument that indicates
     the number of characters to move ([#23805]).
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -620,7 +620,7 @@ function _collect(cont, itr, ::HasEltype, isz::SizeUnknown)
     return a
 end
 
-_collect_indices(::Tuple{}, A) = copy!(Vector{eltype(A)}(), A)
+_collect_indices(::Tuple{}, A) = copy!(Array{eltype(A)}(), A)
 _collect_indices(indsA::Tuple{Vararg{OneTo}}, A) =
     copy!(Array{eltype(A)}(length.(indsA)), A)
 function _collect_indices(indsA, A)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1450,7 +1450,8 @@ end
 """
     reverse(v [, start=1 [, stop=length(v) ]] )
 
-Return a copy of `v` reversed from start to stop.
+Return a copy of `v` reversed from start to stop.  See also [`Iterators.reverse`](@ref)
+for reverse-order iteration without making a copy.
 
 # Examples
 ```jldoctest

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -9,6 +9,7 @@ module IteratorsMD
     import Base: +, -, *
     import Base: simd_outer_range, simd_inner_length, simd_index
     using Base: IndexLinear, IndexCartesian, AbstractCartesianIndex, fill_to_length, tail
+    using Base.Iterators: Reverse
 
     export CartesianIndex, CartesianRange
 
@@ -314,6 +315,33 @@ module IteratorsMD
         i, j = split(R.indices, V)
         CartesianRange(i), CartesianRange(j)
     end
+
+    # reversed CartesianRange iteration
+    @inline function start(r::Reverse{<:CartesianRange})
+        iterfirst, iterlast = last(r.itr), first(r.itr)
+        if any(map(<, iterfirst.I, iterlast.I))
+            return iterlast-1
+        end
+        iterfirst
+    end
+    @inline function next(r::Reverse{<:CartesianRange}, state)
+        state, CartesianIndex(dec(state.I, last(r.itr).I, first(r.itr).I))
+    end
+    # decrement & carry
+    @inline dec(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
+    @inline dec(state::Tuple{Int}, start::Tuple{Int}, stop::Tuple{Int}) = (state[1]-1,)
+    @inline function dec(state, start, stop)
+        if state[1] > stop[1]
+            return (state[1]-1,tail(state)...)
+        end
+        newtail = dec(tail(state), tail(start), tail(stop))
+        (start[1], newtail...)
+    end
+    @inline done(r::Reverse{<:CartesianRange}, state) = state.I[end] < first(r.itr.indices[end])
+    # 0-d cartesian ranges are special-cased to iterate once and only once
+    start(iter::Reverse{<:CartesianRange{0}}) = false
+    next(iter::Reverse{<:CartesianRange{0}}, state) = CartesianIndex(), true
+    done(iter::Reverse{<:CartesianRange{0}}, state) = state
 end  # IteratorsMD
 
 

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -638,3 +638,11 @@ function last(str::AbstractString, nchar::Integer)
     end
     str[prevind(str, e, nchar-1):e]
 end
+
+# reverse-order iteration for strings and indices thereof
+start(r::Iterators.Reverse{<:AbstractString}) = endof(r.itr)
+done(r::Iterators.Reverse{<:AbstractString}, i) = i < start(r.itr)
+next(r::Iterators.Reverse{<:AbstractString}, i) = (r.itr[i], prevind(r.itr, i))
+start(r::Iterators.Reverse{<:EachStringIndex}) = endof(r.itr.s)
+done(r::Iterators.Reverse{<:EachStringIndex}, i) = i < start(r.itr.s)
+next(r::Iterators.Reverse{<:EachStringIndex}, i) = (i, prevind(r.itr.s, i))

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -133,6 +133,7 @@ main utility is for reversed-order string processing, especially for reversed
 regular-expression searches.  See also [`reverseind`](@ref) to convert indices
 in `s` to indices in `reverse(s)` and vice-versa, and [`graphemes`](@ref)
 to operate on user-visible "characters" (graphemes) rather than codepoints.
+See also [`Iterators.reverse`](@ref) for reverse-order iteration without making a copy.
 
 # Examples
 ```jldoctest

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -136,6 +136,25 @@ define an informal interface that enable many fancier behaviors. In some cases, 
 to additionally specialize those extra behaviors when they know a more efficient algorithm can
 be used in their specific case.
 
+It is also often useful to allow iteration over a collection in *reverse order*
+by iterating over [`Iterators.reverse(iterator)`](@ref).  To actually support
+reverse-order iteration, however, an iterator
+type `T` needs to implement `start`, `next`, and `done` methods for `Iterators.Reverse{T}`.
+(Given `r::Iterators.Reverse{T}`, the underling iterator of type `T` is `r.itr`.)
+In our `Squares` example, we would implement `Iterators.Reverse{Squares}` methods:
+
+```jldoctest squaretype
+julia> Base.start(rS::Iterators.Reverse{Squares}) = rS.itr.count
+
+julia> Base.next(::Iterators.Reverse{Squares}, state) = (state*state, state-1)
+
+julia> Base.done(::Iterators.Reverse{Squares}, state) = state < 1
+
+julia> collect(Iterators.reverse(Squares(10)))' # transposed to save space
+1×10 RowVector{Int64,Array{Int64,1}}:
+ 100  81  64  49  36  25  16  9  4  1
+```
+
 ## Indexing
 
 | Methods to implement | Brief description                |

--- a/doc/src/stdlib/iterators.md
+++ b/doc/src/stdlib/iterators.md
@@ -12,4 +12,6 @@ Base.Iterators.repeated
 Base.Iterators.product
 Base.Iterators.flatten
 Base.Iterators.partition
+Base.Iterators.filter
+Base.Iterators.reverse
 ```

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -872,3 +872,8 @@ end
         copy!(Array{T,n}(size(a)), a)
     @test isa(similar(Dict(:a=>1, :b=>2.0), Pair{Union{},Union{}}), Dict{Union{}, Union{}})
 end
+
+@testset "zero-dimensional copy" begin
+    Z = Array{Int}(); Z[] = 17
+    @test Z == collect(Z) == copy(Z)
+end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -429,3 +429,21 @@ end
     @test length(arr) == 0
     @test eltype(arr) == Int
 end
+
+@testset "reverse iterators" begin
+    squash(A) = reshape(A, length(A))
+    Z = Array{Int}(); Z[] = 17 # zero-dimensional test case
+    for itr in (2:10, "∀ϵ>0", 1:0, "", (2,3,5,7,11), [2,3,5,7,11], rand(5,6), Z, 3, true, 'x', 4=>5,
+                eachindex("∀ϵ>0"), view(Z), view(rand(5,6),2:4,2:6), (x^2 for x in 1:10),
+                Iterators.Filter(isodd, 1:10), flatten((1:10, 50:60)), enumerate("foo"),
+                pairs(50:60), zip(1:10,21:30,51:60), product(1:3, 10:12), repeated(3.14159, 5))
+        @test squash(collect(Iterators.reverse(itr))) == reverse(squash(collect(itr)))
+    end
+    @test collect(take(Iterators.reverse(cycle(1:3)), 7)) == collect(take(cycle(3:-1:1), 7))
+    let r = repeated(3.14159)
+        @test Iterators.reverse(r) === r
+    end
+    let t = (2,3,5,7,11)
+        @test Iterators.reverse(Iterators.reverse(t)) === t
+    end
+end


### PR DESCRIPTION
This PR closes #23972 by adding a new ~~`Reversed{T}`~~ `Iterators.Reverse{T}` wrapper type for reverse-order iteration.

The basic idea (suggested by @Keno) is that you can just loop over `Iterators.reverse(iter)` and it will go in reverse order, as long as `start` etcetera have been defined for `Reverse{T}`.  Initially, I've implemented reverse iterators for `AbstractArray`, `AbstractString`, `Tuple`, `Generator`, and some other iterator types (zip, product, etc)..

~~I use `Reversed` and not `Reverse` because the latter name is already used for `Base.Order.Reverse`.~~

To do:
 - [x] Tests
 - [x] More documentation
 - [x] Reverse-iteration support for other iterator types?  (I've added most of the low-hanging fruit, I think.  Other cases can go in separate PRs.)