### PR TITLE
Hermitian conj!/conj test typo

### DIFF
--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -381,7 +381,7 @@ end
     c = Hermitian(b + b')
     @test conj(c) == conj(Array(c))
     cc = copy(c)
-    @test conj!(c) == conj(Array(c))
+    @test conj!(c) == conj(Array(cc))
 end
 
 @testset "Issue # 19225" begin


### PR DESCRIPTION
The test for Hermitian conj (from JuliaLang/LinearAlgebra.jl#353) has a typo and does not do what it intends to do. However, it still passes based on how the Hermitian matrix is generated (the off-diagonal both have +/- 0im terms) but will not pass in general.
Consider the case:

```
a = [4 1-3im; 1+3im 7]
b = Hermitian(a)
conj!(b) == conj(Array(b)) #this fails
```