### PR TITLE
fix vecnorm for sparse matrices

### DIFF
--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -514,7 +514,7 @@ end
 diff(a::SparseMatrixCSC, dim::Integer)= dim==1 ? sparse_diff1(a) : sparse_diff2(a)
 
 ## norm and rank
-vecnorm(A::SparseMatrixCSC, p::Real=2) = vecnorm(A.nzval, p)
+vecnorm(A::SparseMatrixCSC, p::Real=2) = vecnorm(view(A.nzval, 1:nnz(A)), p)
 
 function norm(A::SparseMatrixCSC,p::Real=2)
     m, n = size(A)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1619,6 +1619,13 @@ end
     @test norm(Ai,1) ≈ norm(Array(Ai),1)
     @test norm(Ai,Inf) ≈ norm(Array(Ai),Inf)
     @test vecnorm(Ai) ≈ vecnorm(Array(Ai))
+    # make certain entries in nzval beyond
+    # the range specified in colptr do not
+    # impact vecnorm of a sparse matrix
+    foo = speye(4)
+    resize!(foo.nzval, 5)
+    setindex!(foo.nzval, NaN, 5)
+    @test vecnorm(foo) == 2.0
 end
 
 @testset "sparse matrix cond" begin


### PR DESCRIPTION
Reduced from the failures in #17507. Failure and fix demo:
```julia
julia> @test (foo = speye(4); resize!(foo.nzval, 5)[5] = NaN; vecnorm(foo) == 2.0)
Test Failed
  Expression: begin
    foo = speye(4)
    (resize!(foo.nzval, 5))[5] = NaN
    vecnorm(foo) == 2.0
end
ERROR: There was an error during testing

julia> Base.LinAlg.vecnorm(A::SparseMatrixCSC, p::Real=2) = vecnorm(view(A.nzval, 1:nnz(A)), p)

julia> @test (foo = speye(4); resize!(foo.nzval, 5)[5] = NaN; vecnorm(foo) == 2.0)
Test Passed
```
Best!