### PR TITLE
fix a seed for rand in a Lapack test (fix #24155)

### DIFF
--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -425,13 +425,15 @@ end
 
 @testset "sysv" begin
     @testset for elty in (Float32, Float64, Complex64, Complex128)
-        A = rand(elty,10,10)
-        A = A + A.' #symmetric!
-        b = rand(elty,10)
-        c = A \ b
-        b,A = LAPACK.sysv!('U',A,b)
-        @test b ≈ c
-        @test_throws DimensionMismatch LAPACK.sysv!('U',A,rand(elty,11))
+        guardsrand(123) do
+            A = rand(elty,10,10)
+            A = A + A.' #symmetric!
+            b = rand(elty,10)
+            c = A \ b
+            b,A = LAPACK.sysv!('U',A,b)
+            @test b ≈ c
+            @test_throws DimensionMismatch LAPACK.sysv!('U',A,rand(elty,11))
+        end
     end
 end
 


### PR DESCRIPTION
The seed was originally globally fixed in this file, but then locally scoped
as a result of #16940. But it was needed in the "sysv" testset.