### PR TITLE
Cleanup lower PTLS pass

### DIFF
--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -1,3 +1,7 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include <llvm/Support/Debug.h>
+
 enum AddressSpace {
     Generic = 0,
     Tracked = 10, Derived = 11, CalleeRooted = 12,

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -35,18 +35,11 @@ extern Function *juliapersonality_func;
 #endif
 
 
-#ifdef JULIA_ENABLE_THREADING
-extern size_t jltls_states_func_idx;
-extern size_t jltls_offset_idx;
-#endif
-
 typedef struct {Value *gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
 
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
 void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump_native=false);
 void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL);
-GlobalVariable *jl_emit_sysimg_slot(Module *m, Type *typ, const char *name,
-                                    uintptr_t init, size_t &idx);
 void* jl_get_globalvar(GlobalVariable *gv);
 GlobalVariable *jl_get_global_for(const char *cname, void *addr, Module *M);
 void jl_add_to_shadow(Module *m);

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1532,7 +1532,7 @@ static void addRetNoAlias(Function *F)
 }
 
 bool LateLowerGCFrame::DefineFunctions(Module &M) {
-    ptls_getter = M.getFunction("jl_get_ptls_states");
+    ptls_getter = M.getFunction("julia.ptls_states");
     gc_flush_func = M.getFunction("julia.gcroot_flush");
     gc_preserve_begin_func = M.getFunction("llvm.julia.gc_preserve_begin");
     gc_preserve_end_func = M.getFunction("llvm.julia.gc_preserve_end");

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -3,7 +3,7 @@
 #define DEBUG_TYPE "lower_ptls"
 #undef DEBUG
 
-// LLVM pass to optimize TLS access and remove references to julia intrinsics
+// LLVM pass to lower TLS access and remove references to julia intrinsics
 
 #include "llvm-version.h"
 #include "support/dtypes.h"
@@ -24,50 +24,51 @@
 
 #include "julia.h"
 #include "julia_internal.h"
+#include "codegen_shared.h"
 #include "julia_assert.h"
 
 using namespace llvm;
 
-extern std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=nullptr, bool isConstant=false);
+std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=nullptr,
+                                           bool isConstant=false);
 
 namespace {
 
 struct LowerPTLS: public ModulePass {
     static char ID;
-    LowerPTLS(bool _imaging_mode=false)
+    LowerPTLS(bool imaging_mode=false)
         : ModulePass(ID),
-          imaging_mode(_imaging_mode)
+          imaging_mode(imaging_mode)
     {}
 
 private:
-    bool imaging_mode;
+    const bool imaging_mode;
+    Module *M;
+    Function *ptls_getter;
+    LLVMContext *ctx;
+    MDNode *tbaa_const;
+    PointerType *T_ptls_getter;
+    PointerType *T_ppjlvalue;
+    PointerType *T_pppjlvalue;
+    Type *T_int8;
+    Type *T_size;
+    PointerType *T_pint8;
+#ifdef JULIA_ENABLE_THREADING
+    GlobalVariable *ptls_slot{nullptr};
+    GlobalVariable *ptls_offset{nullptr};
+    void set_ptls_attrs(CallInst *ptlsStates) const;
+    Instruction *emit_ptls_tp(Value *offset, Instruction *insertBefore) const;
+    template<typename T> T *add_comdat(T *G) const;
+    GlobalVariable *create_aliased_global(Type *T, StringRef name) const;
+#else
+    GlobalVariable *static_tls;
+#endif
+    void fix_ptls_use(CallInst *ptlsStates) const;
     bool runOnModule(Module &M) override;
-    void runOnFunction(LLVMContext &ctx, Module &M, Function *F,
-                       Function *ptls_getter, Type *T_ppjlvalue, MDNode *tbaa_const);
 };
 
-static void ensure_global(const char *name, Type *t, Module &M,
-                          bool dllimport=false)
-{
-    if (M.getNamedValue(name))
-        return;
-    GlobalVariable *proto = new GlobalVariable(M, t, false,
-                                               GlobalVariable::ExternalLinkage,
-                                               NULL, name);
-#ifdef _OS_WINDOWS_
-    // setting JL_DLLEXPORT correctly only matters when building a binary
-    // (global_proto will strip this from the JIT)
-    if (dllimport) {
-        // add the __declspec(dllimport) attribute
-        proto->setDLLStorageClass(GlobalValue::DLLImportStorageClass);
-    }
-#else // _OS_WINDOWS_
-    (void)proto;
-#endif // _OS_WINDOWS_
-}
-
 #ifdef JULIA_ENABLE_THREADING
-static void setCallPtlsAttrs(CallInst *ptlsStates)
+void LowerPTLS::set_ptls_attrs(CallInst *ptlsStates) const
 {
 #if JL_LLVM_VERSION >= 50000
     ptlsStates->addAttribute(AttributeList::FunctionIndex, Attribute::ReadNone);
@@ -78,11 +79,8 @@ static void setCallPtlsAttrs(CallInst *ptlsStates)
 #endif
 }
 
-static Instruction *emit_ptls_tp(LLVMContext &ctx, Value *offset, Type *T_ppjlvalue,
-                                 Instruction *insertBefore)
+Instruction *LowerPTLS::emit_ptls_tp(Value *offset, Instruction *insertBefore) const
 {
-    auto T_int8 = Type::getInt8Ty(ctx);
-    auto T_pint8 = PointerType::get(T_int8, 0);
 #if defined(_CPU_X86_64_) || defined(_CPU_X86_)
     if (insertBefore->getFunction()->callsFunctionThatReturnsTwice()) {
         // Workaround LLVM bug by hiding the offset computation
@@ -118,7 +116,7 @@ static Instruction *emit_ptls_tp(LLVMContext &ctx, Value *offset, Type *T_ppjlva
                                      false);
             tls = CallInst::Create(tp, "ptls_i8", insertBefore);
         }
-        return new BitCastInst(tls, PointerType::get(T_ppjlvalue, 0), "ptls", insertBefore);
+        return new BitCastInst(tls, T_pppjlvalue, "ptls", insertBefore);
     }
 #endif
     // AArch64/ARM doesn't seem to have this issue.
@@ -139,34 +137,52 @@ static Instruction *emit_ptls_tp(LLVMContext &ctx, Value *offset, Type *T_ppjlva
     const char *asm_str = nullptr;
     assert(0 && "Cannot emit thread pointer for this architecture.");
 #endif
-    if (!offset) {
-        auto T_size = (sizeof(size_t) == 8 ? Type::getInt64Ty(ctx) : Type::getInt32Ty(ctx));
+    if (!offset)
         offset = ConstantInt::getSigned(T_size, jl_tls_offset);
-    }
     auto tp = InlineAsm::get(FunctionType::get(T_pint8, false), asm_str, "=r", false);
     Value *tls = CallInst::Create(tp, "thread_ptr", insertBefore);
     tls = GetElementPtrInst::Create(T_int8, tls, {offset}, "ptls_i8", insertBefore);
-    return new BitCastInst(tls, PointerType::get(T_ppjlvalue, 0), "ptls", insertBefore);
+    return new BitCastInst(tls, T_pppjlvalue, "ptls", insertBefore);
 }
 
+GlobalVariable *LowerPTLS::create_aliased_global(Type *T, StringRef name) const
+{
+    // Create a static global variable and points a global alias to it so that
+    // the address is visible externally but LLVM can still assume that the
+    // address of this variable doesn't need dynamic relocation
+    // (can be accessed with a single PC-rel load).
+    auto GV = new GlobalVariable(*M, T, false, GlobalVariable::InternalLinkage,
+                                 Constant::getNullValue(T), name + ".real");
+    add_comdat(GlobalAlias::create(T, 0, GlobalVariable::ExternalLinkage,
+                                   name, GV, M));
+    return GV;
+}
+
+template<typename T>
+inline T *LowerPTLS::add_comdat(T *G) const
+{
+#if defined(_OS_WINDOWS_)
+    // Add comdat information to make MSVC link.exe happy
+    // it's valid to emit this for ld.exe too,
+    // but makes it very slow to link for no benefit
+#if defined(_COMPILER_MICROSOFT_)
+    Comdat *jl_Comdat = G->getParent()->getOrInsertComdat(G->getName());
+    // ELF only supports Comdat::Any
+    jl_Comdat->setSelectionKind(Comdat::NoDuplicates);
+    G->setComdat(jl_Comdat);
+#endif
+    // add __declspec(dllexport) to everything marked for export
+    if (G->getLinkage() == GlobalValue::ExternalLinkage)
+        G->setDLLStorageClass(GlobalValue::DLLExportStorageClass);
+    else
+        G->setDLLStorageClass(GlobalValue::DefaultStorageClass);
+#endif
+    return G;
+}
 #endif
 
-void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
-                              Function *ptls_getter, Type *T_ppjlvalue, MDNode *tbaa_const)
+void LowerPTLS::fix_ptls_use(CallInst *ptlsStates) const
 {
-    CallInst *ptlsStates = NULL;
-    for (auto I = F->getEntryBlock().begin(), E = F->getEntryBlock().end();
-         I != E; ++I) {
-        if (CallInst *callInst = dyn_cast<CallInst>(&*I)) {
-            if (callInst->getCalledValue() == ptls_getter) {
-                ptlsStates = callInst;
-                break;
-            }
-        }
-    }
-    if (!ptlsStates)
-        return;
-
     if (ptlsStates->use_empty()) {
         ptlsStates->eraseFromParent();
         return;
@@ -174,86 +190,96 @@ void LowerPTLS::runOnFunction(LLVMContext &ctx, Module &M, Function *F,
 
 #ifdef JULIA_ENABLE_THREADING
     if (imaging_mode) {
-        GlobalVariable *GV = cast<GlobalVariable>(
-            M.getNamedValue("jl_get_ptls_states.ptr"));
         if (jl_tls_elf_support) {
-            GlobalVariable *OffsetGV = cast<GlobalVariable>(
-                M.getNamedValue("jl_tls_offset.val"));
             // if (offset != 0)
             //     ptls = tp + offset;
             // else
             //     ptls = getter();
-            auto offset = new LoadInst(OffsetGV, "", ptlsStates);
+            auto offset = new LoadInst(T_size, ptls_offset, "", false, ptlsStates);
             offset->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
             auto cmp = new ICmpInst(ptlsStates, CmpInst::ICMP_NE, offset,
                                     Constant::getNullValue(offset->getType()));
-            MDBuilder MDB(ctx);
+            MDBuilder MDB(*ctx);
             SmallVector<uint32_t, 2> Weights{9, 1};
             TerminatorInst *fastTerm;
             TerminatorInst *slowTerm;
             SplitBlockAndInsertIfThenElse(cmp, ptlsStates, &fastTerm, &slowTerm,
                                           MDB.createBranchWeights(Weights));
 
-            auto fastTLS = emit_ptls_tp(ctx, offset, T_ppjlvalue, fastTerm);
-            auto phi = PHINode::Create(PointerType::get(T_ppjlvalue, 0), 2, "", ptlsStates);
+            auto fastTLS = emit_ptls_tp(offset, fastTerm);
+            auto phi = PHINode::Create(T_pppjlvalue, 2, "", ptlsStates);
             ptlsStates->replaceAllUsesWith(phi);
             ptlsStates->moveBefore(slowTerm);
-            auto getter = new LoadInst(GV, "", ptlsStates);
+            auto getter = new LoadInst(T_ptls_getter, ptls_slot, "", false, ptlsStates);
             getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
             ptlsStates->setCalledFunction(getter);
-            setCallPtlsAttrs(ptlsStates);
+            set_ptls_attrs(ptlsStates);
 
             phi->addIncoming(fastTLS, fastTLS->getParent());
             phi->addIncoming(ptlsStates, ptlsStates->getParent());
 
             return;
         }
-        auto getter = new LoadInst(GV, "", ptlsStates);
+        // In imaging mode, we emit the function address as a load of a static
+        // variable to be filled (in `staticdata.c`) at initialization time of the sysimg.
+        // This way we can by pass the extra indirection in `jl_get_ptls_states`
+        // since we may not know which getter function to use ahead of time.
+        auto getter = new LoadInst(T_ptls_getter, ptls_slot, "", false, ptlsStates);
         getter->setMetadata(llvm::LLVMContext::MD_tbaa, tbaa_const);
         ptlsStates->setCalledFunction(getter);
-        setCallPtlsAttrs(ptlsStates);
+        set_ptls_attrs(ptlsStates);
     }
     else if (jl_tls_offset != -1) {
-        ptlsStates->replaceAllUsesWith(emit_ptls_tp(ctx, nullptr, T_ppjlvalue, ptlsStates));
+        ptlsStates->replaceAllUsesWith(emit_ptls_tp(nullptr, ptlsStates));
         ptlsStates->eraseFromParent();
     }
     else {
-        setCallPtlsAttrs(ptlsStates);
+        // use the address of the actual getter function directly
+        auto val = ConstantInt::get(T_size, (uintptr_t)jl_get_ptls_states_getter());
+        ptlsStates->setCalledFunction(ConstantExpr::getIntToPtr(val, T_ptls_getter));
+        set_ptls_attrs(ptlsStates);
     }
 #else
-    ptlsStates->replaceAllUsesWith(M.getNamedValue("jl_tls_states"));
+    ptlsStates->replaceAllUsesWith(static_tls);
     ptlsStates->eraseFromParent();
 #endif
 }
 
-bool LowerPTLS::runOnModule(Module &M)
+bool LowerPTLS::runOnModule(Module &_M)
 {
-    MDNode *tbaa_const = tbaa_make_child("jtbaa_const", nullptr, true).first;
-
-    Function *ptls_getter = M.getFunction("jl_get_ptls_states");
+    M = &_M;
+    ptls_getter = M->getFunction("julia.ptls_states");
     if (!ptls_getter)
-        return true;
-    LLVMContext &ctx = M.getContext();
-    FunctionType *functype = ptls_getter->getFunctionType();
-    auto T_ppjlvalue =
-        cast<PointerType>(functype->getReturnType())->getElementType();
+        return false;
+
+    ctx = &M->getContext();
+    tbaa_const = tbaa_make_child("jtbaa_const", nullptr, true).first;
+
+    auto FT_ptls_getter = ptls_getter->getFunctionType();
+    T_ptls_getter = FT_ptls_getter->getPointerTo();
+    T_pppjlvalue = cast<PointerType>(FT_ptls_getter->getReturnType());
+    T_ppjlvalue = cast<PointerType>(T_pppjlvalue->getElementType());
+    T_int8 = Type::getInt8Ty(*ctx);
+    T_size = sizeof(size_t) == 8 ? Type::getInt64Ty(*ctx) : Type::getInt32Ty(*ctx);
+    T_pint8 = T_int8->getPointerTo();
 #ifdef JULIA_ENABLE_THREADING
     if (imaging_mode) {
-        ensure_global("jl_get_ptls_states.ptr", functype->getPointerTo(), M);
-        ensure_global("jl_tls_offset.val",
-                      sizeof(size_t) == 8 ? Type::getInt64Ty(ctx) : Type::getInt32Ty(ctx), M);
+        ptls_slot = create_aliased_global(T_ptls_getter, "jl_get_ptls_states_slot");
+        ptls_offset = create_aliased_global(T_size, "jl_tls_offset");
     }
 #else
-    ensure_global("jl_tls_states", T_ppjlvalue, M, imaging_mode);
+    static_tls = new GlobalVariable(*M, T_ppjlvalue, false, GlobalVariable::ExternalLinkage,
+                                    NULL, "jl_tls_states");
 #endif
-    for (auto F = M.begin(), E = M.end(); F != E; ++F) {
-        if (F->isDeclaration())
-            continue;
-        runOnFunction(ctx, M, &*F, ptls_getter, T_ppjlvalue, tbaa_const);
+
+    for (auto it = ptls_getter->user_begin(); it != ptls_getter->user_end();) {
+        auto call = cast<CallInst>(*it);
+        ++it;
+        assert(call->getCalledValue() == ptls_getter);
+        fix_ptls_use(call);
     }
-#ifndef JULIA_ENABLE_THREADING
+    assert(ptls_getter->use_empty());
     ptls_getter->eraseFromParent();
-#endif
     return true;
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -159,14 +159,11 @@ static void jl_load_sysimg_so(void)
         assert(sysimg_fptrs.base);
         globalUnique = *(size_t*)jl_dlsym(jl_sysimg_handle, "jl_globalUnique");
 #ifdef JULIA_ENABLE_THREADING
-        size_t tls_getter_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
-                                                   "jl_ptls_states_getter_idx");
-        *sysimg_gvars(sysimg_gvars_base, tls_getter_idx - 1) =
-            (uintptr_t)jl_get_ptls_states_getter();
-        size_t tls_offset_idx = *(size_t*)jl_dlsym(jl_sysimg_handle,
-                                                   "jl_tls_offset_idx");
-        *sysimg_gvars(sysimg_gvars_base, tls_offset_idx - 1) =
-            (uintptr_t)(jl_tls_offset == -1 ? 0 : jl_tls_offset);
+        uintptr_t *tls_getter_slot = (uintptr_t*)jl_dlsym(jl_sysimg_handle,
+                                                          "jl_get_ptls_states_slot");
+        *tls_getter_slot = (uintptr_t)jl_get_ptls_states_getter();
+        size_t *tls_offset_idx = (size_t*)jl_dlsym(jl_sysimg_handle, "jl_tls_offset");
+        *tls_offset_idx = (uintptr_t)(jl_tls_offset == -1 ? 0 : jl_tls_offset);
 #endif
 
 #ifdef _OS_WINDOWS_

--- a/test/llvmpasses/alloc-opt.jl
+++ b/test/llvmpasses/alloc-opt.jl
@@ -13,7 +13,7 @@ println("""
 # CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(11)* {{.*}}, !tbaa !0
 println("""
 define %jl_value_t addrspace(10)* @return_obj() {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   ret %jl_value_t addrspace(10)* %v
@@ -31,7 +31,7 @@ define %jl_value_t addrspace(10)* @return_obj() {
 # CHECK-NOT: @llvm.lifetime.end
 println("""
 define i64 @return_load(i64 %i) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   %v64 = bitcast %jl_value_t addrspace(10)* %v to i64 addrspace(10)*
@@ -46,7 +46,7 @@ define i64 @return_load(i64 %i) {
 
 # CHECK-LABEL: @return_tag
 # CHECK: alloca i128, align 8
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK: call void @llvm.lifetime.start{{.*}}(i64 16, i8*
@@ -54,7 +54,7 @@ define i64 @return_load(i64 %i) {
 # CHECK-NOT: @llvm.lifetime.end
 println("""
 define %jl_value_t addrspace(10)* @return_tag() {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
@@ -67,13 +67,13 @@ define %jl_value_t addrspace(10)* @return_tag() {
 # CHECK-LABEL: }
 
 # CHECK-LABEL: @ccall_obj
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @jl_gc_pool_alloc
 # CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(11)* {{.*}}, !tbaa !0
 println("""
 define void @ccall_obj(i8* %fptr) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   %f = bitcast i8* %fptr to void (%jl_value_t addrspace(10)*)*
@@ -85,7 +85,7 @@ define void @ccall_obj(i8* %fptr) {
 
 # CHECK-LABEL: @ccall_ptr
 # CHECK: alloca i64
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK: call void @llvm.lifetime.start{{.*}}(i64 8, i8*
@@ -95,7 +95,7 @@ define void @ccall_obj(i8* %fptr) {
 # CHECK-NEXT: ret void
 println("""
 define void @ccall_ptr(i8* %fptr) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
@@ -108,13 +108,13 @@ define void @ccall_ptr(i8* %fptr) {
 # CHECK-LABEL: }
 
 # CHECK-LABEL: @ccall_unknown_bundle
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @jl_gc_pool_alloc
 # CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(11)* {{.*}}, !tbaa !0
 println("""
 define void @ccall_unknown_bundle(i8* %fptr) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
@@ -128,7 +128,7 @@ define void @ccall_unknown_bundle(i8* %fptr) {
 
 # CHECK-LABEL: @lifetime_branches
 # CHECK: alloca i64
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK: L1:
 # CHECK-NEXT: call void @llvm.lifetime.start{{.*}}(i64 8,
 # CHECK: %f = bitcast i8* %fptr to void (i64)*
@@ -144,7 +144,7 @@ define void @ccall_unknown_bundle(i8* %fptr) {
 # CHECK-NEXT: call void @llvm.lifetime.end{{.*}}(i64 8,
 println("""
 define void @lifetime_branches(i8* %fptr, i1 %b, i1 %b2) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   br i1 %b, label %L1, label %L3
 
@@ -168,13 +168,13 @@ L3:
 # CHECK-LABEL: }
 
 # CHECK-LABEL: @object_field
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @jl_gc_pool_alloc
 # CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(11)* {{.*}}, !tbaa !0
 println("""
 define void @object_field(%jl_value_t addrspace(10)* %field) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
   %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
@@ -187,14 +187,14 @@ define void @object_field(%jl_value_t addrspace(10)* %field) {
 
 # CHECK-LABEL: @memcpy_opt
 # CHECK: alloca i128, align 16
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK: call void @llvm.memcpy.p0i8.p0i8.i64
 println("""
 define void @memcpy_opt(i8* %v22) {
 top:
-  %v6 = call %jl_value_t*** @jl_get_ptls_states()
+  %v6 = call %jl_value_t*** @julia.ptls_states()
   %v18 = bitcast %jl_value_t*** %v6 to i8*
   %v19 = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %v18, $isz 16, %jl_value_t addrspace(10)* @tag)
   %v20 = bitcast %jl_value_t addrspace(10)* %v19 to i8 addrspace(10)*
@@ -207,7 +207,7 @@ top:
 
 # CHECK-LABEL: @preserve_opt
 # CHECK: alloca i128, align 16
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
 # CHECK: @llvm.lifetime.start
@@ -218,7 +218,7 @@ top:
 println("""
 define void @preserve_opt(i8* %v22) {
 top:
-  %v6 = call %jl_value_t*** @jl_get_ptls_states()
+  %v6 = call %jl_value_t*** @julia.ptls_states()
   %v18 = bitcast %jl_value_t*** %v6 to i8*
   %v19 = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %v18, $isz 16, %jl_value_t addrspace(10)* @tag)
   %v20 = bitcast %jl_value_t addrspace(10)* %v19 to i8 addrspace(10)*
@@ -234,7 +234,7 @@ top:
 
 # CHECK-LABEL: @preserve_branches
 # CHECK: alloca i64
-# CHECK: call %jl_value_t*** @jl_get_ptls_states()
+# CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK: L1:
 # CHECK-NEXT: call void @llvm.lifetime.start{{.*}}(i64 8,
 # CHECK-NEXT: @external_function()
@@ -249,7 +249,7 @@ top:
 # CHECK-NEXT: call void @llvm.lifetime.end{{.*}}(i64 8,
 println("""
 define void @preserve_branches(i8* %fptr, i1 %b, i1 %b2) {
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
   br i1 %b, label %L1, label %L3
 
@@ -273,7 +273,7 @@ L3:
 # CHECK: declare noalias %jl_value_t addrspace(10)* @jl_gc_big_alloc(i8*,
 println("""
 declare void @external_function()
-declare %jl_value_t*** @jl_get_ptls_states()
+declare %jl_value_t*** @julia.ptls_states()
 declare noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, %jl_value_t addrspace(10)*)
 declare i64 @julia.pointer_from_objref(%jl_value_t addrspace(11)*)
 declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)

--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -4,14 +4,14 @@
 
 declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
 declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
-declare %jl_value_t*** @jl_get_ptls_states()
+declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
 declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
 
 define void @simple(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @simple
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
 ; CHECK: call %jl_value_t addrspace(10)* @jl_box_int64
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
@@ -34,7 +34,7 @@ define void @leftover_alloca(%jl_value_t addrspace(10)* %a) {
 ; relying on mem2reg to catch simple cases such as this earlier
 ; CHECK-LABEL: @leftover_alloca
 ; CHECK: %var = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %var = alloca %jl_value_t addrspace(10)*
     store %jl_value_t addrspace(10)* %a, %jl_value_t addrspace(10)** %var
     %b = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %var
@@ -48,7 +48,7 @@ declare void @union_arg({%jl_value_t addrspace(10)*, i8})
 
 define void @simple_union() {
 ; CHECK-LABEL: @simple_union
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
 ; CHECK: %a = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
     %a = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
 ; CHECK: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
@@ -62,7 +62,7 @@ declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
 
 define void @select_simple(i64 %a, i64 %b) {
 ; CHECK-LABEL: @select_simple
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
     %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
     %cmp = icmp eq i64 %a, %b
@@ -75,7 +75,7 @@ define void @phi_simple(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @phi_simple
 ; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %cmp = icmp eq i64 %a, %b
     br i1 %cmp, label %alabel, label %blabel
 alabel:
@@ -97,7 +97,7 @@ declare void @one_arg_decayed(i64 addrspace(12)*)
 define void @select_lift(i64 %a, i64 %b) {
 ; CHECK-LABEL: @select_lift
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
     %adecayed = addrspacecast %jl_value_t addrspace(10)* %aboxed to i64 addrspace(12)*
     %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
@@ -112,7 +112,7 @@ define void @select_lift(i64 %a, i64 %b) {
 define void @phi_lift(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @phi_lift
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %cmp = icmp eq i64 %a, %b
     br i1 %cmp, label %alabel, label %blabel
 alabel:
@@ -132,7 +132,7 @@ common:
 define void @phi_lift_union(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @phi_lift_union
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %cmp = icmp eq i64 %a, %b
     br i1 %cmp, label %alabel, label %blabel
 alabel:
@@ -158,7 +158,7 @@ define void @live_if_live_out(i64 %a, i64 %b) {
 ; CHECK-LABEL: @live_if_live_out
 top:
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
 ; The failure case is failing to realize that `aboxed` is live across the first
 ; one_arg_boxed safepoint and putting bboxed in the same root slot
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
@@ -175,7 +175,7 @@ succ:
 define %jl_value_t addrspace(10)* @ret_use(i64 %a, i64 %b) {
 ; CHECK-LABEL: @ret_use
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
 ; CHECK: store %jl_value_t addrspace(10)* %aboxed
     %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
@@ -186,7 +186,7 @@ define i8 @nosafepoint(%jl_value_t addrspace(10)* dereferenceable(16)) {
 ; CHECK-LABEL: @nosafepoint
 ; CHECK-NOT: %gcframe
 top:
-  %1 = call %jl_value_t*** @jl_get_ptls_states()
+  %1 = call %jl_value_t*** @julia.ptls_states()
   %2 = bitcast %jl_value_t*** %1 to %jl_value_t addrspace(10)**
   %3 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %2, i64 3
   %4 = bitcast %jl_value_t addrspace(10)** %3 to i64**
@@ -204,7 +204,7 @@ top:
 define void @global_ref() {
 ; CHECK-LABEL: @global_ref
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %loaded = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** getelementptr (%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** inttoptr (i64 140540744325952 to %jl_value_t addrspace(10)**), i64 1)
 ; CHECK: store %jl_value_t addrspace(10)* %loaded, %jl_value_t addrspace(10)**
     call void @one_arg_boxed(%jl_value_t addrspace(10)* %loaded)
@@ -215,7 +215,7 @@ define %jl_value_t addrspace(10)* @no_redundant_rerooting(i64 %a, i1 %cond) {
 ; CHECK-LABEL: @no_redundant_rerooting
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
 top:
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
 ; CHECK: store %jl_value_t addrspace(10)* %aboxed
 ; CHECK-NEXT: call void @jl_safepoint()
@@ -239,7 +239,7 @@ define void @memcpy_use(i64 %a, i64 *%aptr) {
 ; CHECK-LABEL: @memcpy_use
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
 top:
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
 ; CHECK: store %jl_value_t addrspace(10)* %aboxed
     call void @jl_safepoint()
@@ -255,7 +255,7 @@ define void @gc_preserve(i64 %a) {
 ; CHECK-LABEL: @gc_preserve
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
 top:
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
 ; CHECK: store %jl_value_t addrspace(10)* %aboxed
     call void @jl_safepoint()
@@ -279,7 +279,7 @@ define %jl_value_t addrspace(10)* @gv_const() {
 ; CHECK-LABEL: @gv_const
 ; CHECK-NOT: %gcframe
 top:
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %v10 = load %jl_value_t*, %jl_value_t** @gv1, !tbaa !2
     %v1 = addrspacecast %jl_value_t* %v10 to %jl_value_t addrspace(10)*
     %v2 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** @gv2, !tbaa !2
@@ -293,7 +293,7 @@ define void @refine_select_phi(%jl_value_t addrspace(10)* %x, %jl_value_t addrsp
 ; CHECK-LABEL: @refine_select_phi
 ; CHECK-NOT: %gcframe
 top:
-  %ptls = call %jl_value_t*** @jl_get_ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
   %s = select i1 %b, %jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y
   br i1 %b, label %L1, label %L2
 

--- a/test/llvmpasses/lower-handlers.ll
+++ b/test/llvmpasses/lower-handlers.ll
@@ -3,11 +3,11 @@
 attributes #1 = { returns_twice }
 declare i32 @julia.except_enter() #1
 declare void @jl_pop_handler(i32)
-declare i8**** @jl_get_ptls_states()
+declare i8**** @julia.ptls_states()
 
 define void @simple() {
 top:
-    %ptls = call i8**** @jl_get_ptls_states()
+    %ptls = call i8**** @julia.ptls_states()
 ; CHECK: call void @llvm.lifetime.start
 ; CHECK: call void @jl_enter_handler
 ; CHECK: setjmp

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -2,7 +2,7 @@
 
 %jl_value_t = type opaque
 
-declare %jl_value_t*** @jl_get_ptls_states()
+declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
 declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
 declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
@@ -10,7 +10,7 @@ declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
 define void @argument_refinement(%jl_value_t addrspace(10)* %a) {
 ; CHECK-LABEL: @argument_refinement
 ; CHECK-NOT: %gcframe
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %casted1 = bitcast %jl_value_t addrspace(10)* %a to %jl_value_t addrspace(10)* addrspace(10)*
     %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
     call void @jl_safepoint()
@@ -23,7 +23,7 @@ define void @argument_refinement(%jl_value_t addrspace(10)* %a) {
 define void @heap_refinement1(i64 %a) {
 ; CHECK-LABEL: @heap_refinement1
 ; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
     %casted1 = bitcast %jl_value_t addrspace(10)* %aboxed to %jl_value_t addrspace(10)* addrspace(10)*
     %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
@@ -39,7 +39,7 @@ define void @heap_refinement1(i64 %a) {
 define void @heap_refinement2(i64 %a) {
 ; CHECK-LABEL: @heap_refinement2
 ; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
     %casted1 = bitcast %jl_value_t addrspace(10)* %aboxed to %jl_value_t addrspace(10)* addrspace(10)*
     %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
@@ -55,7 +55,7 @@ declare %jl_value_t addrspace(10)* @allocate_some_value()
 ; Check that the way we compute rooting is compatible with refinements
 define void @issue22770() {
 ; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
     %y = call %jl_value_t addrspace(10)* @allocate_some_value()
     %casted1 = bitcast %jl_value_t addrspace(10)* %y to %jl_value_t addrspace(10)* addrspace(10)*
     %x = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1

--- a/test/llvmpasses/returnstwicegc.ll
+++ b/test/llvmpasses/returnstwicegc.ll
@@ -4,7 +4,7 @@
 
 declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
 declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
-declare %jl_value_t*** @jl_get_ptls_states()
+declare %jl_value_t*** @julia.ptls_states()
 declare i32 @sigsetjmp(i8*, i32) returns_twice
 declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
 
@@ -15,7 +15,7 @@ define void @try_catch(i64 %a, i64 %b)
 top:
     %sigframe = alloca [208 x i8], align 16
     %sigframe.sub = getelementptr inbounds [208 x i8], [208 x i8]* %sigframe, i64 0, i64 0
-    call %jl_value_t*** @jl_get_ptls_states()
+    call %jl_value_t*** @julia.ptls_states()
     %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 %a)
     %val = call i32 @sigsetjmp(i8 *%sigframe.sub, i32 0) returns_twice
     %cmp = icmp eq i32 %val, 0

--- a/test/llvmpasses/safepoint_stress.jl
+++ b/test/llvmpasses/safepoint_stress.jl
@@ -4,10 +4,10 @@ println("""
 %jl_value_t = type opaque
 declare %jl_value_t addrspace(10)* @alloc()
 declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
-declare %jl_value_t*** @jl_get_ptls_states()
+declare %jl_value_t*** @julia.ptls_states()
 
 define void @stress(i64 %a, i64 %b) {
-    %ptls = call %jl_value_t*** @jl_get_ptls_states()
+    %ptls = call %jl_value_t*** @julia.ptls_states()
 """)
 
 # CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 10002


### PR DESCRIPTION
* Branch on whether the pass is running on sysimg or jit rather than
  whether we are in imaging mode or not.

  This eliminate the need to setup hooks in the JIT to handle sysimg code.

* Move the set up of system image global variables completely to the pass.

  Decouple it from the gvars array and codegen no longer need to know
  how the tls access will be lowered.

* Make the tls getter function an intrinsic

  Making it easier to catch when the function is used incorrectly.
  Also make it impossible for the JIT to use a wrong function address.

Note that with these changes, the lower PTLS pass isn't an pure optimization anymore.
It is now required to generate valid code to access the TLS states.