### PR TITLE
fix #24097: switch mandelbrot micro benchmark to user-defined abs2, added Go

### DIFF
--- a/test/perf/micro/Makefile
+++ b/test/perf/micro/Makefile
@@ -84,7 +84,8 @@ benchmarks/fortran%.csv: bin/fperf%
 benchmarks/go.csv: export GOPATH=$(abspath gopath)
 benchmarks/go.csv: perf.go
 	#CGO_LDFLAGS="$(LIBBLAS) $(LIBM)" go get github.com/gonum/blas/cgo
-	CGO_LDFLAGS="-lblas $(LIBM)" go get github.com/gonum/blas/cgo
+	go get github.com/gonum/blas/blas64
+	go get github.com/gonum/blas/cgo
 	go get github.com/gonum/matrix/mat64
 	go get github.com/gonum/stat
 	for t in 1 2 3 4 5; do go run $<; done >$@
@@ -115,7 +116,6 @@ benchmarks/stata.csv: perf.do
 
 benchmarks/lua.csv: perf.lua
 	for t in 1 2 3 4 5; do scilua $<; done >$@
-#	for t in 1 2 3 4 5; do gsl-shell $<; done >$@
 
 benchmarks/java.csv: java/src/main/java/PerfBLAS.java
 	cd java; sh setup.sh; for t in 1 2 3 4 5; do mvn -q exec:java; done >../$@
@@ -126,10 +126,11 @@ benchmarks/scala.csv: scala/src/main/scala/perf.scala scala/build.sbt
 BENCHMARKS = \
 	benchmarks/c.csv \
 	benchmarks/fortran.csv \
+	benchmarks/go.csv \
 	benchmarks/java.csv \
 	benchmarks/javascript.csv \
 	benchmarks/julia.csv \
- 	benchmarks/lua.csv \
+	benchmarks/lua.csv \
 	benchmarks/mathematica.csv \
 	benchmarks/matlab.csv \
 	benchmarks/octave.csv \
@@ -138,7 +139,6 @@ BENCHMARKS = \
 
 # These were formerly listed in BENCHMARKS, but I can't get them to run
 # 2017-09-27 johnfgibson
-#	benchmarks/go.csv \
 #	benchmarks/scala.csv
 
 

--- a/test/perf/micro/bin/table.pl
+++ b/test/perf/micro/bin/table.pl
@@ -10,7 +10,6 @@ while (<>) {
 }
 
 our @benchmarks = qw(
-  iteration_mandelbrot
   iteration_pi_sum
   recursion_fibonacci
   recursion_quicksort  
@@ -18,6 +17,7 @@ our @benchmarks = qw(
   print_to_file
   matrix_statistics
   matrix_multiply
+  userfunc_mandelbrot
 );
 
 our $c_ver = `gcc -v 2>&1 | grep "gcc version" | cut -f3 -d" "`;
@@ -27,9 +27,9 @@ our $python_ver = `python3 -V 2>&1 | cut -f2 -d" "`;
 our $matlab_ver = `matlab -nodisplay -nojvm -nosplash -r "version -release, quit" | tail -n 3 | head -n 1`;
 our $R_ver = `R --version | grep "R version" | cut -f3 -d" "`;
 our $octave_ver = `octave -v | grep version | cut -f4 -d" "`;
-#our $go_ver = `go version | cut -f3 -d" "`;
+our $go_ver = `go version | cut -f3 -d" "`;
 #our $lua_ver = `scilua -v 2>&1 | grep Shell | cut -f3 -d" " | cut -f1 -d,`;
-our $lua_ver = "scilua v1.0.0-b12";
+our $lua_ver = "scilua v1.0.0-b12"; # scilua has no run-time versioninfo function
 our $javascript_ver = `nodejs -e "console.log(process.versions.v8)"`;
 our $mathematica_ver = `echo quit | math -version | head -n 1 | cut -f2 -d" "`;
 #our $stata_ver = `stata -q -b version && grep version stata.log | cut -f2 -d" " && rm stata.log`;
@@ -47,11 +47,11 @@ our %systems = (
   "mathematica"=> ["Mathe-matica" , $mathematica_ver ],
   "r"          => ["R"           , $R_ver ],
   "octave"     => ["Octave"      , $octave_ver ],
-#  "go"         => ["Go"          , $go_ver ],
+  "go"         => ["Go"          , $go_ver ],
 #  "stata"      => ["Stata"       , $stata_ver ],
 );
 
-our @systems = qw(c julia lua fortran java javascript matlab python mathematica r octave);
+our @systems = qw(c julia lua fortran go java javascript mathematica python matlab r octave);
 #our @systems = qw(lua);
 
 print qq[<table class="benchmarks">\n];
@@ -76,7 +76,6 @@ for my $benchmark (@benchmarks) {
   print qq[<th>$benchmark</th>];
   for my $system (@systems) {
     printf qq[<td class="data">%.2f</td>], $_{$benchmark}{$system}/$_{$benchmark}{'c'};
-    #printf qq[<td class="data">%.3f</td>], $_{$benchmark}{$system};
   }
   print qq[</tr>\n];
 }

--- a/test/perf/micro/java/src/main/java/PerfPure.java
+++ b/test/perf/micro/java/src/main/java/PerfPure.java
@@ -297,7 +297,7 @@ public class PerfPure {
         double cReal = zReal;
         double cImag = zImag;
         for (n=0; n<=79; ++n) {
-            if (complexAbs(zReal,zImag) > 2.0) {
+            if (complexAbs2(zReal,zImag) > 4.0) {
                 n -= 1;
                 break;
             }
@@ -316,6 +316,10 @@ public class PerfPure {
 
     private double complexAbs(double zReal, double zImag) {
         return Math.sqrt(zReal*zReal + zImag*zImag);
+    }
+
+    private double complexAbs2(double zReal, double zImag) {
+        return zReal*zReal + zImag*zImag;
     }
 
     protected int mandelperf() {

--- a/test/perf/micro/java/src/main/java/PerfPure.java
+++ b/test/perf/micro/java/src/main/java/PerfPure.java
@@ -71,7 +71,7 @@ public class PerfPure {
             if (t < tmin) tmin = t;
         }
         assert(mandel_sum == 14720) : "value was "+mandel_sum;
-        print_perf("iteration_mandelbrot", tmin);
+        print_perf("userfunc_mandelbrot", tmin);
 
         // sort
         tmin = Long.MAX_VALUE;

--- a/test/perf/micro/perf.R
+++ b/test/perf/micro/perf.R
@@ -88,12 +88,15 @@ assert(!is.unsorted(sortperf(5000)))
 timeit('recursion_quicksort', sortperf, 5000)
 
 ## mandel ##
+Mod2 = function(z) {
+     return(Re(z)*Re(z) + Im(z)*Im(z))
+}
 
 mandel = function(z) {
     c = z
     maxiter = 80
     for (n in 1:maxiter) {
-        if (Mod(z) > 2) return(n-1)
+        if (Mod2(z) > 4) return(n-1)
         z = z^2+c
     }
     return(maxiter)
@@ -114,7 +117,7 @@ mandelperf = function() {
 }
 
 assert(sum(mandelperf()) == 14791)
-timeit("iteration_mandelbrot", mandelperf)
+timeit("userfunc_mandelbrot", mandelperf)
 
 ## pi_sum ##
 

--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -57,11 +57,15 @@ double *matmul_aat(int n, double *b) {
     return c;
 }
 
+double cabs2(double complex z) {
+  return creal(z)*creal(z) + cimag(z)*cimag(z);
+}
+
 int mandel(double complex z) {
     int maxiter = 80;
     double complex c = z;
     for (int n = 0; n < maxiter; ++n) {
-        if (cabs(z) > 2.0) {
+        if (cabs2(z) > 4.0) {
             return n;
         }
         z = z*z+c;
@@ -321,7 +325,7 @@ int main() {
         if (t < tmin) tmin = t;
     }
     assert(mandel_sum2 == 14791 * NITER);
-    print_perf("iteration_mandelbrot", tmin / 100);
+    print_perf("userfunc_mandelbrot", tmin / 100);
 
     // sort
     tmin = INFINITY;

--- a/test/perf/micro/perf.f90
+++ b/test/perf/micro/perf.f90
@@ -195,10 +195,15 @@ integer, intent(in) :: n
 integer :: i , unit
 open(unit=1, file="foo")
 do i = 1, n
-  write(unit=1, fmt=*) i, i
+    write(unit=1, fmt=*) i, i
 end do
 close(unit=1)
 end subroutine
+
+real(dp) function abs2(z) result(r)
+complex(dp), intent(in) :: z
+    r = real(z)*real(z) + imag(z)*imag(z);
+end function
 
 integer function mandel(z0) result(r)
 complex(dp), intent(in) :: z0
@@ -208,7 +213,7 @@ maxiter = 80
 z = z0
 c = z0
 do n = 1, maxiter
-    if (abs(z) > 2) then
+    if (abs2(z) > 4) then
         r = n-1
         return
     end if
@@ -382,7 +387,7 @@ do i = 1, 5
     if (t2-t1 < tmin) tmin = t2-t1
 end do
 call assert(f == 14791)
-print "('fortran,iteration_mandelbrot,',f0.6)", sysclock2ms(tmin) / NRUNS
+print "('fortran,userfunc_mandelbrot,',f0.6)", sysclock2ms(tmin) / NRUNS
 
 tmin = huge(0_i64)
 do i = 1, 5

--- a/test/perf/micro/perf.go
+++ b/test/perf/micro/perf.go
@@ -20,10 +20,12 @@ import (
 	"fmt"
 	"log"
 	"math"
-	"math/cmplx"
+//	"math/cmplx"
 	"math/rand"
 	"strconv"
 	"testing"
+	"os"
+	"bufio"
 
 	"github.com/gonum/blas/blas64"
 	"github.com/gonum/blas/cgo"
@@ -35,7 +37,7 @@ func init() {
 	// Use the BLAS implementation specified in CGO_LDFLAGS. This line can be
 	// commented out to use the native Go BLAS implementation found in
 	// github.com/gonum/blas/native.
-	blas64.Use(cgo.Implementation{})
+	//blas64.Use(cgo.Implementation{})
 
 	// These are here so that toggling the BLAS implementation does not make imports unused
 	_ = cgo.Implementation{}
@@ -49,6 +51,23 @@ func fib(n int) int {
 		return n
 	}
 	return fib(n-1) + fib(n-2)
+}
+
+// print to file descriptor
+
+func printfd(n int) {
+	f, err := os.Create("/dev/null")
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+
+	for i := 0; i < n; i++ {
+		_, err = fmt.Fprintf(w, "%d %d\n", i, i)
+	}
+	w.Flush()
+	f.Close()
 }
 
 // quicksort
@@ -151,12 +170,14 @@ func randmatmul(n int) *mat64.Dense {
 }
 
 // mandelbrot
-
+func abs2(z complex128) float64 {
+	return real(z)*real(z) + imag(z)*imag(z)
+}
 func mandel(z complex128) int {
 	maxiter := 80
 	c := z
 	for n := 0; n < maxiter; n++ {
-		if cmplx.Abs(z) > 2 {
+		if abs2(z) > 4 {
 			return n
 		}
 		z = z*z + c
@@ -253,12 +274,21 @@ var benchmarks = []struct {
 	},
 
 	{
-		name: "iteration_mandelbrot",
+		name: "userfunc_mandelbrot",
 		fn: func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if mandelperf() != 14791 {
 					b.Fatal("unexpected value for mandelperf")
 				}
+			}
+		},
+	},
+
+	{
+		name: "print_to_file",
+		fn: func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				printfd(100000)
 			}
 		},
 	},

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -39,11 +39,15 @@ A = ones(200,200)
 
 ## mandelbrot set: complex arithmetic and comprehensions ##
 
+function myabs2(z)
+    return real(z)*real(z) + imag(z)*imag(z)
+end
+
 function mandel(z)
     c = z
     maxiter = 80
     for n = 1:maxiter
-        if abs(z) > 2
+        if myabs2(z) > 4
             return n-1
         end
         z = z^2 + c
@@ -53,7 +57,7 @@ end
 
 mandelperf() = [ mandel(complex(r,i)) for i=-1.:.1:1., r=-2.0:.1:0.5 ]
 @test sum(mandelperf()) == 14791
-@timeit mandelperf() "iteration_mandelbrot" "Calculation of mandelbrot set"
+@timeit mandelperf() "userfunc_mandelbrot" "Calculation of mandelbrot set"
 
 ## numeric vector sort ##
 

--- a/test/perf/micro/perf.js
+++ b/test/perf/micro/perf.js
@@ -50,7 +50,7 @@
     //        t = (new Date()).getTime()-t;
     //        if (t < tmin) { tmin = t; }
     //    }
-    console.log("javascript,print_to_file," + 9999);
+    //   console.log("javascript,print_to_file," + 9999);
 
     // mandelbrot set //
 
@@ -60,6 +60,9 @@
     }
     function complex_abs(z) {
         return Math.sqrt(z.re*z.re + z.im*z.im);
+    }
+    function complex_abs2(z) {
+        return z.re*z.re + z.im*z.im;
     }
     function complex_add(z,w) {
         return new Complex(z.re+w.re, z.im+w.im);
@@ -74,7 +77,7 @@
         maxiter = 80;
         n = 0;
         for (n = 0; n < maxiter; n++) {
-            if (complex_abs(z) > 2) { return n; }
+            if (complex_abs2(z) > 4) { return n; }
             z = complex_add(complex_multiply(z,z),c);
         }
         return maxiter;
@@ -113,7 +116,7 @@
         t = (new Date()).getTime()-t;
         if (t < tmin) { tmin=t; }
     }
-    console.log("javascript,iteration_mandelbrot," + tmin/1000);
+    console.log("javascript,userfunc_mandelbrot," + tmin/1000);
 
     // numeric vector sort //
 

--- a/test/perf/micro/perf.lua
+++ b/test/perf/micro/perf.lua
@@ -69,11 +69,15 @@ end
 
 timeit(parseint, 'parse_integers')
 
+local function cabs2( z )
+   return z[1]*z[1] + z[2]*z[2]
+end
+
 local function mandel(z)
     local c = z
     local maxiter = 80
     for n = 1, maxiter do
-        if cabs(z) > 2 then
+        if cabs2(z) > 4 then
             return n-1
         end
         z = z*z + c
@@ -91,7 +95,7 @@ local function mandelperf()
     return a
 end
 
-timeit(mandelperf, 'iteration_mandelbrot', function(a) assert(sum(a) == 14791) end)
+timeit(mandelperf, 'userfunc_mandelbrot', function(a) assert(sum(a) == 14791) end)
 
 local function qsort(a, lo, hi)
     local i, j = lo, hi

--- a/test/perf/micro/perf.m
+++ b/test/perf/micro/perf.m
@@ -24,7 +24,7 @@ function perf()
 	
 	mandel(complex(-.53,.68));
 	assert(sum(sum(mandelperf(true))) == 14791)
-	timeit('iteration_mandelbrot', @mandelperf, true)
+	timeit('userfunc_mandelbrot', @mandelperf, true)
 	
 	assert(issorted(sortperf(5000)))
 	timeit('recursion_quicksort', @sortperf, 5000)
@@ -106,11 +106,15 @@ end
 
 %% mandelbrot set: complex arithmetic and comprehensions %%
 
+function r = abs2(z)
+    r = real(z)*real(z) + imag(z)*imag(z)
+end
+
 function n = mandel(z)
     n = 0;
     c = z;
     for n=0:79
-        if abs(z)>2
+        if abs2(z)>4
             return
         end
         z = z^2+c;

--- a/test/perf/micro/perf.nb
+++ b/test/perf/micro/perf.nb
@@ -91,6 +91,11 @@ test[And @@ And @@@ Thread /@ Thread[A.ConjugateTranspose[A] == 200]];
 
 (* mandelbrot set: complex arithmetic and comprehensions *)
 
+ClearAll[abs2];
+(*abs2[z_] := Module[
+	Re(z)*Re(z) + Im(z)*Im(z);
+];*)
+
 ClearAll[mandel];
 (*mandel[zin_] := Module[
 	{z, c, maxiter, n},
@@ -98,7 +103,7 @@ ClearAll[mandel];
 	c = z;
 	maxiter = 80;
 	Do[
-		If[ Abs[z] > 2,
+		If[ Abs2[z] > 4,
 			maxiter = n-1;
 			Break[]
 		];
@@ -128,7 +133,7 @@ ClearAll[mandelperf];
 mandelperf[] := Table[mandel[r + i*I], {i, -1., 1., 0.1}, {r, -2.0, 0.5, 0.1}];
 
 test[ Total[mandelperf[], 2] == 14791];
-timeit[mandelperf[], "iteration_mandelbrot"];
+timeit[mandelperf[], "userfunc_mandelbrot"];
 
 (* numeric vector sort *)
 

--- a/test/perf/micro/perf.py
+++ b/test/perf/micro/perf.py
@@ -63,11 +63,14 @@ def randmatmul(n):
 
 ## mandelbrot ##
 
+def abs2(z):
+    return real(z)*real(z) +  imag(z)*imag(z)
+
 def mandel(z):
     maxiter = 80
     c = z
     for n in range(maxiter):
-        if abs(z) > 2:
+        if abs2(z) > 4:
             return n
         z = z*z + c
     return maxiter
@@ -139,7 +142,7 @@ if __name__=="__main__":
         mandelperf()
         t = time.time()-t
         if t < tmin: tmin = t
-    print_perf ("iteration_mandelbrot", tmin)
+    print_perf ("userfunc_mandelbrot", tmin)
 
     tmin = float('inf')
     for i in range(mintrials):


### PR DESCRIPTION
Fix for [#24907](https://github.com/JuliaLang/julia/issues/24097): switched mandelbrot micro benchmark to user-defined `abs2` and the benchmark name to `userfunc_mandelbrot`. Also got Go working again and added to the benchmark suite. 

BTW, julia-0.7.0-DEV improves on 0.6.0 a few percent in the geometric mean of the microbenchmarks, going from 1.08 to 1.04, enough to bring it under LuaJIT at ~1.07 (this is just 0.6.0 -> 0.7.0 with `abs2` held constant), consistently on repeated runs on a quiescent machine. The noise level for most languages is under 1%.