### PR TITLE
Convert cygwin paths to windows paths.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,7 +230,7 @@ $(build_depsbindir)/stringreplace: $(JULIAHOME)/contrib/stringreplace.c | $(buil
 	@$(call PRINT_CC, $(HOSTCC) -o $(build_depsbindir)/stringreplace $(JULIAHOME)/contrib/stringreplace.c)
 
 julia-base-cache: julia-sysimg-$(JULIA_BUILD_MODE) | $(DIRS) $(build_datarootdir)/julia
-	@$(call exec,$(JULIA_EXECUTABLE) $(JULIAHOME)/etc/write_base_cache.jl $(build_datarootdir)/julia/base.cache)
+	@$(call exec,$(JULIA_EXECUTABLE) $(call cygpath_w,$(JULIAHOME)/etc/write_base_cache.jl) $(call cygpath_w,$(build_datarootdir)/julia/base.cache))
 
 # public libraries, that are installed in $(prefix)/lib
 JL_LIBS := julia julia-debug


### PR DESCRIPTION
Fixes build on windows apparently broken by #24120.