### PR TITLE
Document that the REPL workflow assumes your module is in LOAD_PATH

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -418,7 +418,7 @@ function _require(mod::Symbol)
         name = string(mod)
         path = find_in_path(name, nothing)
         if path === nothing
-            throw(ArgumentError("Module $name not found in current path.\nRun `Pkg.add(\"$name\")` to install the $name package."))
+            throw(ArgumentError("Module $name not found in LOAD_PATH or `Pkg.dir()`.\nRun `Pkg.add(\"$name\")` to install the $name package."))
         end
 
         # attempt to load the module file via the precompile cache locations

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -418,7 +418,7 @@ function _require(mod::Symbol)
         name = string(mod)
         path = find_in_path(name, nothing)
         if path === nothing
-            throw(ArgumentError("Module $name not found in LOAD_PATH or `Pkg.dir()`.\nRun `Pkg.add(\"$name\")` to install the $name package."))
+            throw(ArgumentError("Module $name not found in `LOAD_PATH` or `Pkg.dir()`.\nRun `Pkg.add(\"$name\")` to install the $name package."))
         end
 
         # attempt to load the module file via the precompile cache locations

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -10,7 +10,7 @@ using Documenter
 # Include the `build_sysimg` file.
 
 baremodule GenStdLib end
-isdefined(:build_sysimg) || @eval module BuildSysImg
+@isdefined(build_sysimg) || @eval module BuildSysImg
     include(joinpath(@__DIR__, "..", "contrib", "build_sysimg.jl"))
 end
 

--- a/doc/src/manual/workflow-tips.md
+++ b/doc/src/manual/workflow-tips.md
@@ -23,12 +23,15 @@ line. A common pattern includes the following elements:
 
     end
     ```
-  * **Ensure that Julia can find your module file** In order for `import Tmp` to work, the file `Tmp.jl` must be in one of Julia's [Module file paths](@ref). For example, if `Tmp.jl` is in `/home/user/projects`, then you can add that directory to the [`LOAD_PATH`](@ref) with:
-
+  * **Ensure that Julia can find your module file** In order for `import Tmp` to work, the file `Tmp.jl` must be in one of Julia's [Module file paths](@ref). For example, if `Tmp.jl` is in your current working directory, then you can add [`@__DIR__`](@ref) to the [`LOAD_PATH`](@ref) with:
+    ```julia
+    push!(LOAD_PATH, @__DIR__)
     ```
+    Alternatively, if `Tmp.jl` is in `/home/user/projects`, then you can do
+    ```julia
     push!(LOAD_PATH, "/home/user/projects")
     ```
-    (Note that `~` does not automatically expand to your home directory in this context, so you cannot abbreviate the path above to `"~/projects"`.). 
+    (Note that `~` does not automatically expand to your home directory in this context, so you cannot abbreviate the path above to `"~/projects"`.).
   * **Put your test code in another file.** Create another file, say `tst.jl`, which begins with
 
     ```julia

--- a/doc/src/manual/workflow-tips.md
+++ b/doc/src/manual/workflow-tips.md
@@ -23,6 +23,12 @@ line. A common pattern includes the following elements:
 
     end
     ```
+  * **Ensure that Julia can find your module file** In order for `import Tmp` to work, the file `Tmp.jl` must be in one of Julia's [Module file paths](@ref). For example, if `Tmp.jl` is in `/home/user/projects`, then you can add that directory to the [`LOAD_PATH`](@ref) with:
+
+    ```
+    push!(LOAD_PATH, "/home/user/projects")
+    ```
+    (Note that `~` does not automatically expand to your home directory in this context, so you cannot abbreviate the path above to `"~/projects"`.). 
   * **Put your test code in another file.** Create another file, say `tst.jl`, which begins with
 
     ```julia


### PR DESCRIPTION
Inspired by https://discourse.julialang.org/t/repl-workflow-reload-doesnt-work/6571 I noticed that the [workflow tips](https://docs.julialang.org/en/stable/manual/workflow-tips/#A-basic-editor/REPL-workflow-1) section of the manual quietly assumes that the module the user is developing is on the LOAD_PATH. I've added a bullet point to make that requirement explicit. 

Please let me know if the wording of this is OK. 