### PR TITLE
remove incorrect count(S) methods and fix count(pred, S) methods for sparse S

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -70,8 +70,7 @@ julia> nnz(A)
 ```
 """
 nnz(S::SparseMatrixCSC)         = Int(S.colptr[S.n + 1] - 1)
-count(S::SparseMatrixCSC)       = count(S.nzval)
-count(pred, S::SparseMatrixCSC) = count(pred, S.nzval) + pred(zero(eltype(S)))*(prod(size(S)) - nnz(S))
+count(pred, S::SparseMatrixCSC) = count(pred, view(S.nzval, 1:nnz(S))) + pred(zero(eltype(S)))*(prod(size(S)) - nnz(S))
 
 """
     nonzeros(A)

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -40,7 +40,6 @@ const SparseVectorUnion{T} = Union{SparseVector{T}, SparseColumnView{T}}
 length(x::SparseVector)   = x.n
 size(x::SparseVector)     = (x.n,)
 nnz(x::SparseVector)      = length(x.nzval)
-count(x::SparseVector)    = count(x.nzval)
 count(f, x::SparseVector) = count(f, x.nzval) + f(zero(eltype(x)))*(length(x) - nnz(x))
 
 nonzeros(x::SparseVector) = x.nzval

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -2109,3 +2109,11 @@ end
     @test similar(A, Float32, Int8, 6, 6) == similar(A, Float32, Int8, (6, 6))
     @test similar(A, Float32, Int8, 6) == similar(A, Float32, Int8, (6,))
 end
+
+@testset "count specializations" begin
+    # count should throw for sparse arrays for which zero(eltype) does not exist
+    @test_throws MethodError count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Any[true, true]))
+    @test_throws MethodError count(SparseVector(2, Int[1], Any[true]))
+    # count should run only over S.nzval[1:nnz(S)], not S.nzval in full
+    @test count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Bool[true, true, true])) == 2
+end


### PR DESCRIPTION
This pull request removes two incorrect`count(S::SparseVecOrMat)` methods and fixes the two `count(pred, S::SparseVecOrMat)` methods. For failure mode descriptions / illustrations, please see this pull request's tests. Best!