### PR TITLE
Make no-index A[] check bounds like everyone else

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -756,7 +756,7 @@ function getindex end
 
 # This is more complicated than it needs to be in order to get Win64 through bootstrap
 @eval getindex(A::Array, i1::Int) = arrayref($(Expr(:boundscheck)), A, i1)
-@eval getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref($(Expr(:boundscheck)), A, i1, i2, I...)) # TODO: REMOVE FOR #14770
+@eval getindex(A::Array, i1::Int, i2::Int, I::Int...) = (@_inline_meta; arrayref($(Expr(:boundscheck)), A, i1, i2, I...))
 
 # Faster contiguous indexing using copy! for UnitRange and Colon
 function getindex(A::Array, I::UnitRange{Int})
@@ -795,7 +795,7 @@ function setindex! end
 
 @eval setindex!(A::Array{T}, x, i1::Int) where {T} = arrayset($(Expr(:boundscheck)), A, convert(T,x)::T, i1)
 @eval setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T} =
-    (@_inline_meta; arrayset($(Expr(:boundscheck)), A, convert(T,x)::T, i1, i2, I...)) # TODO: REMOVE FOR #14770
+    (@_inline_meta; arrayset($(Expr(:boundscheck)), A, convert(T,x)::T, i1, i2, I...))
 
 # These are redundant with the abstract fallbacks but needed for bootstrap
 function setindex!(A::Array, x, I::AbstractVector{Int})
@@ -2231,7 +2231,6 @@ end
 findin(a, b) = _findin(a, b)
 
 # Copying subregions
-# TODO: DEPRECATE FOR #14770
 function indcopy(sz::Dims, I::Vector)
     n = length(I)
     s = sz[n]

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -100,7 +100,7 @@ parentindexes(a::AbstractArray) = ntuple(i->OneTo(size(a,i)), ndims(a))
 _maybe_reshape_parent(A::AbstractArray, ::NTuple{1, Bool}) = reshape(A, Val(1))
 _maybe_reshape_parent(A::AbstractArray{<:Any,1}, ::NTuple{1, Bool}) = reshape(A, Val(1))
 _maybe_reshape_parent(A::AbstractArray{<:Any,N}, ::NTuple{N, Bool}) where {N} = A
-_maybe_reshape_parent(A::AbstractArray, ::NTuple{N, Bool}) where {N} = reshape(A, Val(N)) # TODO: DEPRECATE FOR #14770
+_maybe_reshape_parent(A::AbstractArray, ::NTuple{N, Bool}) where {N} = reshape(A, Val(N))
 """
     view(A, inds...)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -301,7 +301,7 @@ function test_scalar_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where
         end
     end
     # Test zero-dimensional accesses
-    @test A[1] == B[1] == 1 
+    @test A[1] == B[1] == 1
     # Test multidimensional scalar indexed assignment
     C = T(Int, shape)
     D1 = T(Int, shape)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -301,7 +301,7 @@ function test_scalar_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where
         end
     end
     # Test zero-dimensional accesses
-    @test A[] == B[] == A[1] == B[1] == 1
+    @test A[1] == B[1] == 1 
     # Test multidimensional scalar indexed assignment
     C = T(Int, shape)
     D1 = T(Int, shape)
@@ -361,9 +361,17 @@ function test_scalar_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where
     end
     @test C == B == A
     # Test zero-dimensional setindex
-    A[] = 0; B[] = 0
-    @test A[] == B[] == 0
-    @test A == B
+    if length(A) == 1
+        A[] = 0; B[] = 0
+        @test A[] == B[] == 0
+        @test A == B
+    else
+        # TODO: Re-enable after PLI deprecation
+        # @test_throws BoundsError A[] = 0
+        # @test_throws BoundsError B[] = 0
+        # @test_throws BoundsError A[]
+        # @test_throws BoundsError B[]
+    end
 end
 
 function test_vector_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where T
@@ -489,10 +497,10 @@ function test_getindex_internals(::Type{T}, shape, ::Type{TestAbstractArray}) wh
     A = reshape(collect(1:N), shape)
     B = T(A)
 
-    @test getindex(A) == 1
-    @test getindex(B) == 1
-    @test Base.unsafe_getindex(A) == 1
-    @test Base.unsafe_getindex(B) == 1
+    @test getindex(A, 1) == 1
+    @test getindex(B, 1) == 1
+    @test Base.unsafe_getindex(A, 1) == 1
+    @test Base.unsafe_getindex(B, 1) == 1
 end
 
 function test_getindex_internals(::Type{TestAbstractArray})
@@ -509,8 +517,8 @@ function test_setindex!_internals(::Type{T}, shape, ::Type{TestAbstractArray}) w
     A = reshape(collect(1:N), shape)
     B = T(A)
 
-    Base.unsafe_setindex!(B, 1)
-    @test B[1] == 1
+    Base.unsafe_setindex!(B, 2, 1)
+    @test B[1] == 2
 end
 
 function test_setindex!_internals(::Type{TestAbstractArray})

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -206,9 +206,16 @@ timesofar("constructors")
 @testset "Indexing" begin
     @testset "0d for size $sz" for (sz,T) in allsizes
         b1 = rand!(falses(sz...))
-        @check_bit_operation getindex(b1)         Bool
-        @check_bit_operation setindex!(b1, true)  T
-        @check_bit_operation setindex!(b1, false) T
+        if length(b1) == 1
+            @check_bit_operation getindex(b1)         Bool
+            @check_bit_operation setindex!(b1, true)  T
+            @check_bit_operation setindex!(b1, false) T
+        else
+            # TODO: Re-enable after PLI deprecation is removed
+            # @test_throws getindex(b1)
+            # @test_throws setindex!(b1, true)
+            # @test_throws setindex!(b1, false)
+        end
     end
 
     @testset "linear for size $sz" for (sz,T) in allsizes[2:end]

--- a/test/core.jl
+++ b/test/core.jl
@@ -2332,7 +2332,7 @@ end
 
 # pull request #9534
 @test try; a,b,c = 1,2; catch ex; (ex::BoundsError).a === (1,2) && ex.i == 3; end
-@test try; [][]; catch ex; isempty((ex::BoundsError).a::Array{Any,1}) && ex.i == (1,); end
+# @test try; [][]; catch ex; isempty((ex::BoundsError).a::Array{Any,1}) && ex.i == (1,); end # TODO: Re-enable after PLI
 @test try; [][1,2]; catch ex; isempty((ex::BoundsError).a::Array{Any,1}) && ex.i == (1,2); end
 @test try; [][10]; catch ex; isempty((ex::BoundsError).a::Array{Any,1}) && ex.i == (10,); end
 f9534a() = (a=1+2im; getfield(a, -100))


### PR DESCRIPTION
In #23628, we deprecated omitting indices over dimensions that are not of length 1.  Unfortunately the 0-index case got left behind.  This brings it into consistency.

In short, once this deprecation is removed, `A[]` will _also_ assert that there is only one element in `A`.