### PR TITLE
Add '-Wl,--export-all-symbols' flag on Windows

### DIFF
--- a/contrib/julia-config.jl
+++ b/contrib/julia-config.jl
@@ -36,7 +36,7 @@ end
 function ldflags()
     fl = "-L$(shell_escape(libDir()))"
     if Sys.iswindows()
-        fl = fl * " -Wl,--stack,8388608"
+        fl = fl * " -Wl,--export-all-symbols -Wl,--stack,8388608"
     elseif Sys.islinux()
         fl = fl * " -Wl,--export-dynamic"
     end


### PR DESCRIPTION
This is a temporary hack, which should not be necessary in future, see issue #24010