### PR TITLE
Improve SubString nextind/prevind

### DIFF
--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -106,7 +106,7 @@ function nextind(s::SubString{String}, i::Integer)
     # make sure that nonnegative value is returned
     j = Int(i)
     j < 1 && return 1
-    # the transofrmation below is valid if j>=0
+    # the transformation below is valid if j>=0
     nextind(s.string, j+s.offset)-s.offset
 end
 
@@ -115,14 +115,14 @@ function prevind(s::SubString{String}, i::Integer)
     # make sure that value not greater than endof(s) is returned
     j = Int(i)
     j > e && return e
-    # the transofrmation below is valid if j<=endof(s)+1
+    # the transformation below is valid if j<=endof(s)+1
     prevind(s.string, j+s.offset)-s.offset
 end
 
 function nextind(s::SubString{String}, i::Integer, nchar::Integer)
     j = Int(i)
     # if j < 1 the first valid value of j is the same as for j equal to 0
-    # and the transofrmation below is valid if j>=0
+    # and the transformation below is valid if j>=0
     j < 0 && (j = 0)
     nextind(s.string, j+s.offset, nchar)-s.offset
 end
@@ -131,7 +131,7 @@ function prevind(s::SubString{String}, i::Integer, nchar::Integer)
     e = endof(s)
     j = Int(i)
     # if j > endof(s) the first valid value of j is the same as for j equal to endof(s)+1
-    # and the transofrmation below is valid if j<=endof(s)+1
+    # and the transformation below is valid if j<=endof(s)+1
     j > e && (j = e+1)
     prevind(s.string, j+s.offset, nchar)-s.offset
 end

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -47,6 +47,8 @@ function SubString(s::SubString, i::Int, j::Int)
     j <= endof(s) || throw(BoundsError(s, j))
     SubString(s.string, s.offset + i, s.offset + j)
 end
+SubString{T}(s::T, i::Int, j::Int) where {T<:SubString} = SubString(s, i, j)
+
 
 SubString(s::AbstractString) = SubString(s, 1, endof(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, endof(s))

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -47,8 +47,6 @@ function SubString(s::SubString, i::Int, j::Int)
     j <= endof(s) || throw(BoundsError(s, j))
     SubString(s.string, s.offset + i, s.offset + j)
 end
-SubString{T}(s::T, i::Int, j::Int) where {T<:SubString} = SubString(s, i, j)
-
 
 SubString(s::AbstractString) = SubString(s, 1, endof(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, endof(s))

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -119,6 +119,23 @@ function prevind(s::SubString{String}, i::Integer)
     prevind(s.string, j+s.offset)-s.offset
 end
 
+function nextind(s::SubString{String}, i::Integer, nchar::Integer)
+    j = Int(i)
+    # if j < 1 the first valid value of j is the same as for j equal to 0
+    # and the transofrmation below is valid if j>=0
+    j < 0 && (j = 0)
+    nextind(s.string, j+s.offset, nchar)-s.offset
+end
+
+function prevind(s::SubString{String}, i::Integer, nchar::Integer)
+    e = endof(s)
+    j = Int(i)
+    # if j > endof(s) the first valid value of j is the same as for j equal to endof(s)+1
+    # and the transofrmation below is valid if j<=endof(s)+1
+    j > e && (j = e+1)
+    prevind(s.string, j+s.offset, nchar)-s.offset
+end
+
 function getindex(s::AbstractString, r::UnitRange{Int})
     checkbounds(s, r) || throw(BoundsError(s, r))
     SubString(s, first(r), last(r))

--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -100,8 +100,24 @@ function thisind(s::SubString{String}, i::Integer)
     j-offset
 end
 
-nextind(s::SubString, i::Integer) = nextind(s.string, i+s.offset)-s.offset
-prevind(s::SubString, i::Integer) = prevind(s.string, i+s.offset)-s.offset
+# need to define nextind and prevind only for SubString{String}
+# as other cases are handled by definitions for AbstractString
+function nextind(s::SubString{String}, i::Integer)
+    # make sure that nonnegative value is returned
+    j = Int(i)
+    j < 1 && return 1
+    # the transofrmation below is valid if j>=0
+    nextind(s.string, j+s.offset)-s.offset
+end
+
+function prevind(s::SubString{String}, i::Integer)
+    e = endof(s)
+    # make sure that value not greater than endof(s) is returned
+    j = Int(i)
+    j > e && return e
+    # the transofrmation below is valid if j<=endof(s)+1
+    prevind(s.string, j+s.offset)-s.offset
+end
 
 function getindex(s::AbstractString, r::UnitRange{Int})
     checkbounds(s, r) || throw(BoundsError(s, r))

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1380,7 +1380,9 @@ the `AbstractString` interface, in order to ensure that functions can work
 with string types besides the standard `String` type.
 """
 struct GenericString <: AbstractString
-    string::AbstractString
+    string::String
+
+    GenericString(s::AbstractString) = new(String(s))
 end
 Base.endof(s::GenericString) = endof(s.string)
 Base.next(s::GenericString, i::Int) = next(s.string, i)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -592,8 +592,11 @@ end
 end
 
 @testset "prevind and nextind" begin
-    let strs = Any["∀α>β:α+1>β", GenericString("∀α>β:α+1>β")]
-        for i in 1:2
+    let str = "∀α>β:α+1>β", strs = Any[str, GenericString(str),
+                                       SubString(str, 1), SubString(str, 1, 4),
+                                       SubString(GenericString(str), 1),
+                                       SubString(GenericString(str), 1, 4)]
+        for i in 1:5
             @test prevind(strs[i], 1) == 0
             @test prevind(strs[i], 1, 1) == 0
             @test prevind(strs[i], 2) == 1
@@ -659,7 +662,64 @@ end
 
         @test prevind(strs[2], -1) == 0
         @test prevind(strs[2], -1, 1) == 0
+
+        @test prevind(strs[3], -1) == -2
+        @test prevind(strs[3], -1, 1) == -2
+        @test prevind(strs[4], -1) == -2
+        @test prevind(strs[4], -1, 1) == -2
+
+        @test prevind(strs[5], -4) == 0
+        @test prevind(strs[5], -4, 1) == 0
+        @test prevind(strs[6], -4) == 0
+        @test prevind(strs[6], -4, 1) == 0
+
+        @test prevind(strs[7], -4) == -5
+        @test prevind(strs[7], -4, 1) == -5
+
+        @test prevind(strs[8], -4) == 0
+        @test prevind(strs[8], -4, 1) == 0
     end
+
+    let strs = Any["1234567", GenericString("1234567")]
+        for i in 1:2
+            @test prevind(SubString(strs[i], 1, 3), 10) == 3
+            @test prevind(SubString(strs[i], 1, 3), 10, 1) == 3
+            @test prevind(SubString(strs[i], 1, 3), 10, 2) == 2
+            @test prevind(SubString(strs[i], 1, 3), 3) == 2
+            @test prevind(SubString(strs[i], 1, 3), 2) == 1
+            @test prevind(SubString(strs[i], 1, 3), 1) == 0
+            @test prevind(SubString(strs[i], 1, 3), 3, 1) == 2
+            @test prevind(SubString(strs[i], 1, 3), 2, 1) == 1
+            @test prevind(SubString(strs[i], 1, 3), 1, 1) == 0
+            @test prevind(SubString(strs[i], 1, 3), 3, 2) == 1
+            @test prevind(SubString(strs[i], 1, 3), 2, 2) == 0
+
+            @test nextind(SubString(strs[i], 3), -6) == 1
+            @test nextind(SubString(strs[i], 3), -6, 1) == 1
+            @test nextind(SubString(strs[i], 3), -6, 2) == 2
+            @test nextind(SubString(strs[i], 3), 1) == 2
+            @test nextind(SubString(strs[i], 3), 2) == 3
+            @test nextind(SubString(strs[i], 3), 3) == 4
+            @test nextind(SubString(strs[i], 3), 4) == 5
+            @test nextind(SubString(strs[i], 3), 1, 1) == 2
+            @test nextind(SubString(strs[i], 3), 2, 1) == 3
+            @test nextind(SubString(strs[i], 3), 3, 1) == 4
+            @test nextind(SubString(strs[i], 3), 4, 1) == 5
+            @test nextind(SubString(strs[i], 3), 1, 2) == 3
+            @test nextind(SubString(strs[i], 3), 2, 2) == 4
+            @test nextind(SubString(strs[i], 3), 3, 2) == 5
+            @test nextind(SubString(strs[i], 3), 4, 2) == 6
+        end
+    end
+
+    @test prevind(SubString("1234567", 1, 3), 0) == -1
+    @test prevind(SubString(GenericString("1234567"), 1, 3), 0) == 0
+    @test prevind(SubString("1234567", 1, 3), 0, 1) == -1
+    @test prevind(SubString(GenericString("1234567"), 1, 3), 0, 1) == 0
+    @test prevind(SubString("1234567", 1, 3), 1, 2) == -1
+    @test prevind(SubString(GenericString("1234567"), 1, 3), 1, 2) == 0
+    @test prevind(SubString("1234567", 1, 3), 0, 2) == -2
+    @test prevind(SubString(GenericString("1234567"), 1, 3), 0, 2) == 0
 end
 
 @testset "first and last" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -592,11 +592,9 @@ end
 end
 
 @testset "prevind and nextind" begin
-    let str = "∀α>β:α+1>β", strs = Any[str, GenericString(str),
-                                       SubString(str, 1), SubString(str, 1, 4),
-                                       SubString(GenericString(str), 1),
-                                       SubString(GenericString(str), 1, 4)]
-        for i in 1:5
+    let str = "∀α>β:α+1>β", strs = Any[str, GenericString(str), SubString(str, 1),
+                                       SubString(GenericString(str), 1)]
+        for i in 1:length(strs)
             @test prevind(strs[i], 1) == 0
             @test prevind(strs[i], 1, 1) == 0
             @test prevind(strs[i], 2) == 1
@@ -656,7 +654,26 @@ end
                     @test nextind(strs[i], x, j) == n
                 end
             end
+
+            let ss = SubString(strs[i], 1, 4)
+                @test prevind(ss, 0) < 1
+                @test prevind(ss, 0, 1) < 1
+                @test prevind(ss, 1, 2) < 1
+                @test prevind(ss, 0, 2) < 1
+            end
+            let ss = SubString(strs[i], 7, 10)
+                @test prevind(ss, 1) < 1
+                @test prevind(ss, 1, 1) < 1
+                @test prevind(ss, 0) < 1
+                @test prevind(ss, 0, 1) < 1
+                @test prevind(ss, 1, 2) < 1
+                @test nextind(ss, 4) > endof(ss)
+                @test nextind(ss, 4, 1) > endof(ss)
+                @test nextind(ss, 9) > endof(ss)
+                @test nextind(ss, 9, 1) > endof(ss)
+            end
         end
+
         @test prevind(strs[1], -1) == -2
         @test prevind(strs[1], -1, 1) == -2
 
@@ -665,23 +682,13 @@ end
 
         @test prevind(strs[3], -1) == -2
         @test prevind(strs[3], -1, 1) == -2
-        @test prevind(strs[4], -1) == -2
-        @test prevind(strs[4], -1, 1) == -2
 
-        @test prevind(strs[5], -4) == 0
-        @test prevind(strs[5], -4, 1) == 0
-        @test prevind(strs[6], -4) == 0
-        @test prevind(strs[6], -4, 1) == 0
-
-        @test prevind(strs[7], -4) == -5
-        @test prevind(strs[7], -4, 1) == -5
-
-        @test prevind(strs[8], -4) == 0
-        @test prevind(strs[8], -4, 1) == 0
+        @test prevind(strs[4], -4) == 0
+        @test prevind(strs[4], -4, 1) == 0
     end
 
     let strs = Any["1234567", GenericString("1234567")]
-        for i in 1:2
+        for i in 1:length(strs)
             @test prevind(SubString(strs[i], 1, 3), 10) == 3
             @test prevind(SubString(strs[i], 1, 3), 10, 1) == 3
             @test prevind(SubString(strs[i], 1, 3), 10, 2) == 2
@@ -711,15 +718,6 @@ end
             @test nextind(SubString(strs[i], 3), 4, 2) == 6
         end
     end
-
-    @test prevind(SubString("1234567", 1, 3), 0) == -1
-    @test prevind(SubString(GenericString("1234567"), 1, 3), 0) == 0
-    @test prevind(SubString("1234567", 1, 3), 0, 1) == -1
-    @test prevind(SubString(GenericString("1234567"), 1, 3), 0, 1) == 0
-    @test prevind(SubString("1234567", 1, 3), 1, 2) == -1
-    @test prevind(SubString(GenericString("1234567"), 1, 3), 1, 2) == 0
-    @test prevind(SubString("1234567", 1, 3), 0, 2) == -2
-    @test prevind(SubString(GenericString("1234567"), 1, 3), 0, 2) == 0
 end
 
 @testset "first and last" begin


### PR DESCRIPTION
This PR introduces the following changes:
* improve performance of `nextind` and `prevind` with `nchar` for `SubString{String}` (now it does not use generic `prevind`/`nextind` but a specialized method for `String`)
* make `prevind` and `nextind` work consistently with any type of `SubString`:
    * if the original string (`string` field) is `String` or `DirectIndexString` then `prevind`/`nextind` simply shifts the output by `offset` as in this case `prevind` can return negative values;
    * if the original string is not `String` then we have to handle the restriction that `prevind` in this case should not return negative values (i.e. the minimum value of `prevind` is `0`);
* fix a bug that made it possible that `nextind` returned a non-positive value, e.g. in the expression `nextind(SubString("1234234", 3), -6)`; the general contract is that `nextind` must always return a positive index; now it is checked; a similar fix is implemented for `prevind` returning something beyond `endof` (e.g. `prevind(SubString("12345678", 1, 1), 10)`).

(the first change improves performance of new functionality in 0.7, the second and third change fix wrong behavior that was present in 0.6)

@nalimilan The only area I do not touch are behavior of `prevind` and `nextind` for `DirectIndexString` as I understand they are to be removed anyway (and they do not work consistently with all other functionality for strings now anyway).

The test code for this is a bit complex - I can separate different cases (but the test code will be more verbose) if more clarity is required.