### PR TITLE
Relax test tolerance for Float32

### DIFF
--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -574,7 +574,7 @@ end
             @test coth(acoth(coth(A))) ≈ coth(A)
 
             # Definition of principal values (Aprahamian & Higham, 2016, pp. 4-5)
-            abstol = 1e-8 * norm(acosh(A))
+            abstol = sqrt(eps(real(elty))) * vecnorm(acosh(A))
             @test all(z -> (0 < real(z) < π ||
                             abs(real(z)) < abstol && imag(z) >= 0 ||
                             abs(real(z) - π) < abstol && imag(z) <= 0),


### PR DESCRIPTION
This fix a test failure on aarch64 due to a real part of half ulp.