### PR TITLE
Explicitly add `-lpthread` when building curl

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -10,6 +10,12 @@ endif
 
 CURL_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
 
+# On older Linuces (those that use OpenSSL < 1.1) we include `libpthread` explicitly.
+# It doesn't hurt to include it explicitly elsewhere, so we do so.
+ifeq ($(OS),Linux)
+CURL_LDFLAGS += -lpthread
+endif
+
 $(SRCCACHE)/curl-$(CURL_VER).tar.bz2: | $(SRCCACHE)
 	$(JLDOWNLOAD) $@ https://curl.haxx.se/download/curl-$(CURL_VER).tar.bz2
 


### PR DESCRIPTION
This is necessary on older Linuces (such as Ubuntu 12.04 x86) that have
older OpenSSL library versions.  Curl switched over to a threaded DNS
resolver by default in version 7.55, and this requires `libpthread`.
However, their build system relies on the fact that OpenSSL (usually)
provides the proper linkage flags, and so breaks on older Linuces.  See
[0] for more details.

[0] https://curl.haxx.se/mail/lib-2017-09/0112.html