### PR TITLE
avoid nested SubString construction

### DIFF
--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -46,6 +46,7 @@ function SubString(s::SubString, i::Int, j::Int)
     j <= endof(s) || throw(BoundsError(s, j))
     SubString(s.string, s.offset + i, s.offset + j)
 end
+SubString{T}(s::T, i::Int, j::Int) where {T<:SubString} = SubString(s, i, j)
 
 SubString(s::AbstractString) = SubString(s, 1, endof(s))
 SubString{T}(s::T) where {T<:AbstractString} = SubString{T}(s, 1, endof(s))

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -115,7 +115,7 @@ end
 # SubString created from SubString
 let str = "Hello, world!"
     u = SubString(str, 2, 5)
-    
+
     @test SubString(u, 2, 3) == SubString{typeof(u)}(u, 2, 3)
     @test typeof(SubString(u, 2, 3)) == typeof(SubString{typeof(u)}(u, 2, 3))
 

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -115,6 +115,10 @@ end
 # SubString created from SubString
 let str = "Hello, world!"
     u = SubString(str, 2, 5)
+    
+    @test SubString(u, 2, 3) == SubString{typeof(u)}(u, 2, 3)
+    @test typeof(SubString(u, 2, 3)) == typeof(SubString{typeof(u)}(u, 2, 3))
+
     for idx in 1:4
         @test SubString(u, 2, idx) == u[2:idx]
         @test SubString(u, 2:idx) == u[2:idx]


### PR DESCRIPTION
Currently:
```
x = "123"
y = SubString(x, 1, 2)
z1 = SubString(y, 1, 1)
z2 = SubString{typeof(y)}(y, 1, 1)
```
yields:
```
julia> typeof(z1)
SubString{String}

julia> typeof(z2)
SubString{SubString{String}}
```
This PR is intends to make this consistent and `z1` and `z2` should be `SubString{String}` avoiding unnecessary nesting of `SubString`.