### PR TITLE
Revert problematic commit backported to 0.6.1

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1162,10 +1162,10 @@ static int check_ambiguous_visitor(jl_typemap_entry_t *oldentry, struct typemap_
             jl_static_show_func_sig(s, isect);
             jl_printf(s, "\nbefore the new definition.\n");
         }
+        return 1;  // there may be multiple ambiguities, keep going
     }
-    if (!msp || closure->after) {
+    else if (closure->after) {
         // record that this method definition is being partially replaced
-        // (either with a real definition, or an ambiguity error)
         if (closure->shadowed == NULL) {
             closure->shadowed = oldentry->func.value;
         }

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -85,16 +85,6 @@ cfunction(ambig, Int, (UInt8, Int))  # test for a crash (doesn't throw an error)
 ambig(x, y::Integer) = 3
 @test_throws MethodError ambig(2, 0x03)
 
-# Method overwriting by an ambiguity should also invalidate the method cache (#21963)
-ambig(x::Union{Char, Int8}) = 'r'
-@test ambig('c') == 'r'
-@test ambig(Int8(1)) == 'r'
-@test_throws MethodError ambig(Int16(1))
-ambig(x::Union{Char, Int16}) = 's'
-@test_throws MethodError ambig('c')
-@test ambig(Int8(1)) == 'r'
-@test ambig(Int16(1)) == 's'
-
 # Automatic detection of ambiguities
 module Ambig1
 ambig(x, y) = 1


### PR DESCRIPTION
Reverts commit 4aa8d72bcdf162de33d663f4519b4d30d8d374a2.

This change was causing SIGABRT in certain cases of ambiguous method definitions or serialization.