### PR TITLE
Allow optimizing for size for a specific target in sysimg

### DIFF
--- a/doc/src/devdocs/sysimg.md
+++ b/doc/src/devdocs/sysimg.md
@@ -57,7 +57,7 @@ Multiple targets are separated by `;` in the option.
 The syntax for each target is a CPU name followed by multiple features separated by `,`.
 All features supported by LLVM is supported and a feature can be disabled with a `-` prefix.
 (`+` prefix is also allowed and ignored to be consistent with LLVM syntax).
-Additionally, two special features are supported to control the function cloning behavior.
+Additionally, a few special features are supported to control the function cloning behavior.
 
 1. `clone_all`
 
@@ -77,6 +77,16 @@ Additionally, two special features are supported to control the function cloning
     The `n`th target (0-based) will be used as the base target instead of the default (`0`th) one.
     The base target has to be either `0` or another `clone_all` target.
     Specifying a non default `clone_all` target as the base target will cause an error.
+
+3. `opt_size`
+
+    This cause the function for the targe to be optimize for size when there isn't a significant
+    runtime performance impact. This corresponds to `-Os` GCC and Clang option.
+
+4. `min_size`
+
+    This cause the function for the targe to be optimize for size that might have
+    a significant runtime performance impact. This corresponds to `-Oz` Clang option.
 
 ### Implementation overview
 

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -49,7 +49,7 @@
 // Features that are not recognized will be passed to LLVM directly during codegen
 // but ignored otherwise.
 
-// Two special features are supported:
+// A few special features are supported:
 // 1. `clone_all`
 //
 //     This forces the target to have all functions in sysimg cloned.
@@ -63,6 +63,14 @@
 //     will use the version in the base target. This option causes the base target to be
 //     fully cloned (as if `clone_all` is specified for it) if it is not the default target (0).
 //     The index can only be smaller than the current index.
+//
+// 3. `opt_size`
+//
+//     Optimize for size with minimum performance impact. Clang/GCC's `-Os`.
+//
+// 4. `min_size`
+//
+//     Optimize only for size. Clang's `-Oz`.
 
 bool jl_processor_print_help = false;
 
@@ -548,6 +556,20 @@ parse_cmdline(const char *option, F &&feature_cb)
                     arg.en.flags &= ~JL_TARGET_CLONE_ALL;
                 }
             }
+            else if (llvm::StringRef(fname, p - fname) == "opt_size") {
+                if (disable)
+                    jl_error("Invalid target option: disabled opt_size.");
+                if (arg.en.flags & JL_TARGET_MINSIZE)
+                    jl_error("Conflicting target option: both opt_size and min_size are specified.");
+                arg.en.flags |= JL_TARGET_OPTSIZE;
+            }
+            else if (llvm::StringRef(fname, p - fname) == "min_size") {
+                if (disable)
+                    jl_error("Invalid target option: disabled min_size.");
+                if (arg.en.flags & JL_TARGET_OPTSIZE)
+                    jl_error("Conflicting target option: both opt_size and min_size are specified.");
+                arg.en.flags |= JL_TARGET_MINSIZE;
+            }
             else if (int base = get_clone_base(fname, p)) {
                 if (disable)
                     jl_error("Invalid target option: disabled base index.");
@@ -702,6 +724,14 @@ static inline void check_cmdline(T &&cmdline, bool imaging)
         }
         if (cmdline[0].en.flags & JL_TARGET_CLONE_ALL) {
             jl_error("\"clone_all\" feature specified "
+                     "without a `--output-` flag specified");
+        }
+        if (cmdline[0].en.flags & JL_TARGET_OPTSIZE) {
+            jl_error("\"opt_size\" feature specified "
+                     "without a `--output-` flag specified");
+        }
+        if (cmdline[0].en.flags & JL_TARGET_MINSIZE) {
+            jl_error("\"min_size\" feature specified "
                      "without a `--output-` flag specified");
         }
     }

--- a/src/processor.h
+++ b/src/processor.h
@@ -103,6 +103,10 @@ enum {
     JL_TARGET_CLONE_SIMD = 1 << 4,
     // The CPU name is unknown
     JL_TARGET_UNKNOWN_NAME = 1 << 5,
+    // Optimize for size for this target
+    JL_TARGET_OPTSIZE = 1 << 6,
+    // Only optimize for size for this target
+    JL_TARGET_MINSIZE = 1 << 7,
 };
 
 #define JL_FEATURE_DEF_NAME(name, bit, llvmver, str) JL_FEATURE_DEF(name, bit, llvmver)


### PR DESCRIPTION
Before Jeff asks, the size impact is pretty small...... With one full clone, I measure a 2-3% decrease in `.text` size so I assume it's around 4-6% per target. Since most of the inlining are done in type inference I guess this shouldn't be too surprising. It's a little funny though that I measure a smaller size with `opt_size` than `min_size` by 1%.....
