### PR TITLE
correct serialization of SubString{<:AbstractString}

### DIFF
--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -302,9 +302,9 @@ function serialize(s::AbstractSerializer, ss::String)
     write(s.io, ss)
 end
 
-function serialize(s::AbstractSerializer, ss::SubString{T}) where T<:AbstractString
+function serialize(s::AbstractSerializer, ss::SubString{String})
     # avoid saving a copy of the parent string, keeping the type of ss
-    serialize_any(s, convert(SubString{T}, convert(T,ss)))
+    serialize_any(s, SubString(String(ss)))
 end
 
 # Don't serialize the pointers

--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -31,6 +31,24 @@ create_serialization_stream() do s
     @test data[end] == UInt8(Serializer.sertag(Symbol))
 end
 
+# SubString
+
+create_serialization_stream() do s
+    ss = Any[SubString("12345", 2, 4),
+             SubString(GenericString("12345"), 2, 4),
+             SubString(s"12345", 2, 4),
+             SubString(GenericString(s"12345"), 2, 4),]
+    for x in ss
+        serialize(s, x)
+    end
+    seek(s, 0)
+    for x in ss
+        y = deserialize(s)
+        @test x == y
+        @test typeof(x) == typeof(y)
+    end
+end
+
 # Boolean & Empty & Nothing
 create_serialization_stream() do s
     serialize(s, true)


### PR DESCRIPTION
Fixes #24266.
We are able to safely reduce the size of serialized `SubString{T}` only when `T` is `String`.

The added tests without the proposed fix cause StackOverflow.