### PR TITLE
deprecate expand(module, ex) to Meta.lower(module, ex)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -378,10 +378,13 @@ Deprecated or removed
   * The `bkfact`/`bkfact!` methods that accepted `uplo` and `issymmetric` symbols have been deprecated
     in favor of using `Hermitian` (or `Symmetric`) views ([#22605]).
 
-  * The function `current_module` is deprecated and replaced with `@__MODULE__` ([#22064]).
-    This caused the deprecation of some reflection methods (such as `macroexpand` and `isconst`),
-    which now require a module argument.
-    And it caused the bugfix of other default arguments to use the Main module (including `whos`, `which`).
+  * The function `current_module` is deprecated and replaced with `@__MODULE__`.
+    This caused the deprecation of some reflection methods (such as `macroexpand` and
+    `isconst`), which now require a module argument. And it caused the bugfix of other
+    default arguments to use the Main module (including `whos`, `which`)  ([#22064]).
+
+  * `expand(ex)` and `expand(module, ex)` have been deprecated in favor of
+    `Meta.lower(module, ex)` ([#22064, #24278]).
 
   * The `Operators` module is deprecated. Instead, import required operators explicitly
     from `Base`, e.g. `import Base: +, -, *, /` ([#22251]).

--- a/base/client.jl
+++ b/base/client.jl
@@ -153,7 +153,7 @@ function eval_user_input(@nospecialize(ast), show_value)
                 display_error(lasterr,bt)
                 errcount, lasterr = 0, ()
             else
-                ast = expand(Main, ast)
+                ast = Meta.lower(Main, ast)
                 value = eval(Main, ast)
                 eval(Main, Expr(:body, Expr(:(=), :ans, QuoteNode(value)), Expr(:return, nothing)))
                 if !(value === nothing) && show_value
@@ -210,7 +210,7 @@ function parse_input_line(s::String; filename::String="none")
                s, sizeof(s), filename, sizeof(filename))
     if ex isa Symbol && all(equalto('_'), string(ex))
         # remove with 0.7 deprecation
-        expand(Main, ex)  # to get possible warning about using _ as an rvalue
+        Meta.lower(Main, ex)  # to get possible warning about using _ as an rvalue
     end
     return ex
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1254,9 +1254,10 @@ _current_module() = ccall(:jl_get_current_module, Ref{Module}, ())
     depwarn("binding_module(symbol) is deprecated, use `binding_module(module, symbol)` instead.", :binding_module)
     return binding_module(_current_module(), s)
 end
+export expand
 @noinline function expand(@nospecialize(x))
-    depwarn("expand(x) is deprecated, use `expand(module, x)` instead.", :expand)
-    return expand(_current_module(), x)
+    depwarn("expand(x) is deprecated, use `Meta.lower(module, x)` instead.", :expand)
+    return Meta.lower(_current_module(), x)
 end
 @noinline function macroexpand(@nospecialize(x))
     depwarn("macroexpand(x) is deprecated, use `macroexpand(module, x)` instead.", :macroexpand)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -936,7 +936,6 @@ export
 
 # syntax
     esc,
-    expand,
     gensym,
     macroexpand,
     @macroexpand1,

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -46,15 +46,6 @@ copy_exprargs(x::Array{Any,1}) = Any[copy_exprs(a) for a in x]
 ==(x::QuoteNode, y::QuoteNode) = isequal(x.value, y.value)
 
 """
-    expand(m, x)
-
-Takes the expression `x` and returns an equivalent expression in lowered form
-for executing in module `m`.
-See also [`code_lowered`](@ref).
-"""
-expand(m::Module, @nospecialize(x)) = ccall(:jl_expand, Any, (Any, Any), x, m)
-
-"""
     macroexpand(m::Module, x; recursive=true)
 
 Takes the expression `x` and returns an equivalent expression with all macros removed (expanded)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -417,7 +417,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
     if isa(ex0, Expr) && ex0.head == :macrocall # Make @edit @time 1+2 edit the macro by using the types of the *expressions*
         return Expr(:call, fcn, esc(ex0.args[1]), Tuple{#=__source__=#LineNumberNode, #=__module__=#Module, Any[ Core.Typeof(a) for a in ex0.args[3:end] ]...})
     end
-    ex = expand(__module__, ex0)
+    ex = Meta.lower(__module__, ex0)
     exret = Expr(:none)
     if !isa(ex, Expr)
         exret = Expr(:call, :error, "expression is not a function call or symbol")

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -56,4 +56,13 @@ macro dump(expr)
     dump(expr)
 end
 
+"""
+    lower(m, x)
+
+Takes the expression `x` and returns an equivalent expression in lowered form
+for executing in module `m`.
+See also [`code_lowered`](@ref).
+"""
+lower(m::Module, @nospecialize(x)) = ccall(:jl_expand, Any, (Any, Any), x, m)
+
 end # module

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -348,7 +348,7 @@ function get_type(sym::Expr, fn::Module)
     # try to analyze nests of calls. if this fails, try using the expanded form.
     val, found = try_get_type(sym, fn)
     found && return val, found
-    return try_get_type(expand(fn, sym), fn)
+    return try_get_type(Meta.lower(fn, sym), fn)
 end
 
 function get_type(sym, fn::Module)

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -78,7 +78,7 @@ the expression. Macro expansion involves a handoff from [`eval()`](@ref) (in Jul
 function `jl_macroexpand()` (written in `flisp`) to the Julia macro itself (written in - what
 else - Julia) via `fl_invoke_julia_macro()`, and back.
 
-Typically, macro expansion is invoked as a first step during a call to [`expand()`](@ref)/`jl_expand()`,
+Typically, macro expansion is invoked as a first step during a call to [`Meta.lower()`](@ref)/`jl_expand()`,
 although it can also be invoked directly by a call to [`macroexpand()`](@ref)/`jl_macroexpand()`.
 
 ## [Type Inference](@id dev-type-inference)

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -91,12 +91,12 @@ julia> macroexpand(@__MODULE__, :(@edit println("")) )
 The functions `Base.Meta.show_sexpr` and [`dump`](@ref) are used to display S-expr style views
 and depth-nested detail views for any expression.
 
-Finally, the [`expand`](@ref) function gives the `lowered` form of any expression and is of
+Finally, the [`Meta.lower`](@ref) function gives the `lowered` form of any expression and is of
 particular interest for understanding both macros and top-level statements such as function declarations
 and variable assignments:
 
 ```jldoctest
-julia> expand(@__MODULE__, :(f() = 1) )
+julia> Meta.lower(@__MODULE__, :(f() = 1) )
 :(begin
         $(Expr(:method, :f))
         $(Expr(:method, :f, :((Core.svec)((Core.svec)((Core.Typeof)(f)), (Core.svec)())), CodeInfo(:(begin

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -344,10 +344,10 @@ Base.@functionloc
 ```@docs
 Base.gc
 Base.gc_enable
+Meta.lower
 Base.macroexpand
 Base.@macroexpand
 Base.@macroexpand1
-Base.expand
 Base.code_lowered
 Base.@code_lowered
 Base.code_typed

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -318,12 +318,12 @@ end
 
 # make sure scalars are inlined, which causes f.(x,scalar) to lower to a "thunk"
 import Base.Meta: isexpr
-@test isexpr(expand(Main, :(f.(x,y))), :call)
-@test isexpr(expand(Main, :(f.(x,1))), :thunk)
-@test isexpr(expand(Main, :(f.(x,1.0))), :thunk)
-@test isexpr(expand(Main, :(f.(x,$π))), :thunk)
-@test isexpr(expand(Main, :(f.(x,"hello"))), :thunk)
-@test isexpr(expand(Main, :(f.(x,$("hello")))), :thunk)
+@test isexpr(Meta.lower(Main, :(f.(x,y))), :call)
+@test isexpr(Meta.lower(Main, :(f.(x,1))), :thunk)
+@test isexpr(Meta.lower(Main, :(f.(x,1.0))), :thunk)
+@test isexpr(Meta.lower(Main, :(f.(x,$π))), :thunk)
+@test isexpr(Meta.lower(Main, :(f.(x,"hello"))), :thunk)
+@test isexpr(Meta.lower(Main, :(f.(x,$("hello")))), :thunk)
 
 # PR #17623: Fused binary operators
 @test [true] .* [true] == [true]

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1252,18 +1252,18 @@ end
              f21104rt(Float64))
 
 # test for malformed syntax errors
-@test Expr(:error, "more arguments than types for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (), x)))
-@test Expr(:error, "more arguments than types for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B,), x, y)))
-@test Expr(:error, "more arguments than types for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B,), x, y, z)))
-@test Expr(:error, "more arguments than types for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B,), x, y)))
-@test Expr(:error, "more arguments than types for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B,), x, y, z)))
-@test Expr(:error, "more arguments than types for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B, C), x, y, z)))
-@test Expr(:error, "more types than arguments for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B,),)))
-@test Expr(:error, "more types than arguments for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B, C), )))
-@test Expr(:error, "more types than arguments for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B..., C...), )))
-@test Expr(:error, "only the trailing ccall argument type should have '...'") == expand(@__MODULE__, :(ccall(:fn, A, (B..., C...), x)))
-@test Expr(:error, "only the trailing ccall argument type should have '...'") == expand(@__MODULE__, :(ccall(:fn, A, (B..., C...), x, y, z)))
-@test Expr(:error, "more types than arguments for ccall") == expand(@__MODULE__, :(ccall(:fn, A, (B, C...), )))
+@test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (), x)))
+@test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B,), x, y)))
+@test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B,), x, y, z)))
+@test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B,), x, y)))
+@test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B,), x, y, z)))
+@test Expr(:error, "more arguments than types for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B, C), x, y, z)))
+@test Expr(:error, "more types than arguments for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B,),)))
+@test Expr(:error, "more types than arguments for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B, C), )))
+@test Expr(:error, "more types than arguments for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B..., C...), )))
+@test Expr(:error, "only the trailing ccall argument type should have '...'") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B..., C...), x)))
+@test Expr(:error, "only the trailing ccall argument type should have '...'") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B..., C...), x, y, z)))
+@test Expr(:error, "more types than arguments for ccall") == Meta.lower(@__MODULE__, :(ccall(:fn, A, (B, C...), )))
 
 # cfunction on non-function singleton
 struct CallableSingleton

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -67,7 +67,7 @@ end
 function test_jl_dump_compiles_toplevel_thunks()
     tfile = tempname()
     io = open(tfile, "w")
-    topthunk = expand(Main, :(for i in 1:10; end))
+    topthunk = Meta.lower(Main, :(for i in 1:10; end))
     ccall(:jl_dump_compiles, Void, (Ptr{Void},), io.handle)
     Core.eval(Main, topthunk)
     ccall(:jl_dump_compiles, Void, (Ptr{Void},), C_NULL)

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Basic goto tests
-expand(x) = Base.expand(@__MODULE__, x)
 
 function goto_test1()
     @goto a
@@ -15,10 +14,10 @@ end
 @test eval(:(@label a)) === nothing
 
 @test Expr(:error, "label \"a\" referenced but not defined") ==
-    expand(:(@goto a))
+    Meta.lower(@__MODULE__, :(@goto a))
 
 @test Expr(:error, "label \"a\" defined multiple times") ==
-    expand(quote
+    Meta.lower(@__MODULE__, quote
         function goto_test2()
             @goto a
             @label a
@@ -29,7 +28,7 @@ end
 
 
 @test Expr(:error, "label \"a\" referenced but not defined") ==
-    expand(quote
+    Meta.lower(@__MODULE__, quote
         function goto_test3()
             @goto a
             return
@@ -37,7 +36,7 @@ end
     end)
 
 @test Expr(:error, "misplaced label") ==
-    expand(quote
+    Meta.lower(@__MODULE__, quote
         function goto_test4()
             @goto a
             try
@@ -60,7 +59,7 @@ macro goto_test5_macro3()
 end
 
 @test Expr(:error, "label \"a\" referenced but not defined") ==
-    expand(quote
+    Meta.lower(@__MODULE__, quote
         function goto_test5_1()
             @goto a
             @goto_test5_macro1
@@ -68,7 +67,7 @@ end
         end
     end)
 
-let e = expand(quote
+let e = Meta.lower(@__MODULE__, quote
         function goto_test5_2()
             @goto_test5_macro2
             @label a
@@ -89,7 +88,7 @@ end
 
 
 @test Expr(:error, "goto from a try/finally block is not permitted") ==
-    expand(quote
+    Meta.lower(@__MODULE__, quote
         function goto_test6()
             try
                 @goto a

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -88,7 +88,7 @@ tag = Base.have_color ? Base.text_colors[Base.error_color()] : "ARRAY{FLOAT64,N}
 # Make sure emphasis is not used for other functions
 tag = Base.have_color ? Base.text_colors[Base.error_color()] : "ANY"
 iob = IOBuffer()
-show(iob, expand(Main, :(x -> x^2)))
+show(iob, Meta.lower(Main, :(x -> x^2)))
 str = String(take!(iob))
 @test isempty(search(str, tag))
 

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -98,7 +98,7 @@ for (frame, func, inlined) in zip(trace, [g,h,f], (can_inline, can_inline, false
 end
 end
 
-let src = expand(Main, quote let x = 1 end end).args[1]::CodeInfo,
+let src = Meta.lower(Main, quote let x = 1 end end).args[1]::CodeInfo,
     li = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ()),
     sf
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -70,7 +70,7 @@ end
     sym = Symbol(Char(0xdcdb))
     @test string(sym) == string(Char(0xdcdb))
     @test String(sym) == string(Char(0xdcdb))
-    @test expand(Main, sym) === sym
+    @test Meta.lower(Main, sym) === sym
     res = string(parse(string(Char(0xdcdb)," = 1"),1,raise=false)[1])
     @test res == """\$(Expr(:error, "invalid character \\\"\\udcdb\\\"\"))"""
 end


### PR DESCRIPTION
This pull request deprecates `expand([module, ]ex)` to `Meta.lower(module, ex)`, addressing #23808. Best!