### PR TITLE
deprecate orthogonal decomposition keyword "thin" to "full"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -381,6 +381,10 @@ Deprecated or removed
   * The `cholfact`/`cholfact!` methods that accepted an `uplo` symbol have been deprecated
     in favor of using `Hermitian` (or `Symmetric`) views ([#22187], [#22188]).
 
+  * The `thin` keyword argument for orthogonal decomposition methods has
+    been deprecated in favor of `full`, which has the opposite meaning:
+    `thin == true` if and only if `full == false` ([#24279]).
+
   * `isposdef(A::AbstractMatrix, UL::Symbol)` and `isposdef!(A::AbstractMatrix, UL::Symbol)`
     have been deprecated in favor of `isposdef(Hermitian(A, UL))` and `isposdef!(Hermitian(A, UL))`
     respectively ([#22245]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2031,6 +2031,9 @@ end
 @deprecate strwidth textwidth
 @deprecate charwidth textwidth
 
+# TODO: after 0.7, remove thin keyword argument and associated logic from...
+# (1) base/linalg/svd.jl
+
 @deprecate find(x::Number)            find(!iszero, x)
 @deprecate findnext(A, v, i::Integer) findnext(equalto(v), A, i)
 @deprecate findfirst(A, v)            findfirst(equalto(v), A)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2034,6 +2034,7 @@ end
 # TODO: after 0.7, remove thin keyword argument and associated logic from...
 # (1) base/linalg/svd.jl
 # (2) base/linalg/qr.jl
+# (3) base/linalg/lq.jl
 
 @deprecate find(x::Number)            find(!iszero, x)
 @deprecate findnext(A, v, i::Integer) findnext(equalto(v), A, i)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2033,6 +2033,7 @@ end
 
 # TODO: after 0.7, remove thin keyword argument and associated logic from...
 # (1) base/linalg/svd.jl
+# (2) base/linalg/qr.jl
 
 @deprecate find(x::Number)            find(!iszero, x)
 @deprecate findnext(A, v, i::Integer) findnext(equalto(v), A, i)

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -182,11 +182,27 @@ similar(B::Bidiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spze
 
 #Singular values
 svdvals!(M::Bidiagonal{<:BlasReal}) = LAPACK.bdsdc!(M.uplo, 'N', M.dv, M.ev)[1]
-function svdfact!(M::Bidiagonal{<:BlasReal}; thin::Bool=true)
+function svdfact!(M::Bidiagonal{<:BlasReal}; full::Bool = false, thin::Union{Bool,Void} = nothing)
+    # DEPRECATION TODO: remove deprecated thin argument and associated logic after 0.7
+    if thin != nothing
+        Base.depwarn(string("the `thin` keyword argument in `svdfact!(A; thin = $(thin))` has ",
+            "been deprecated in favor of `full`, which has the opposite meaning, ",
+            "e.g. `svdfact!(A; full = $(!thin))`."), :svdfact!)
+        full::Bool = !thin
+    end
     d, e, U, Vt, Q, iQ = LAPACK.bdsdc!(M.uplo, 'I', M.dv, M.ev)
     SVD(U, d, Vt)
 end
-svdfact(M::Bidiagonal; thin::Bool=true) = svdfact!(copy(M),thin=thin)
+function svdfact(M::Bidiagonal; full::Bool = false, thin::Union{Bool,Void} = nothing)
+    # DEPRECATION TODO: remove deprecated thin argument and associated logic after 0.7
+    if thin != nothing
+        Base.depwarn(string("the `thin` keyword argument in `svdfact(A; thin = $(thin))` has ",
+            "been deprecated in favor of `full`, which has the opposite meaning, ",
+            "e.g. `svdfact(A; full = $(!thin))`."), :svdfact)
+        full::Bool = !thin
+    end
+    return svdfact!(copy(M), full = full)
+end
 
 ####################
 # Generic routines #

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -1263,7 +1263,7 @@ function pinv(A::StridedMatrix{T}, tol::Real) where T
             return B
         end
     end
-    SVD         = svdfact(A, thin=true)
+    SVD         = svdfact(A, full = false)
     Stype       = eltype(SVD.S)
     Sinv        = zeros(Stype, length(SVD.S))
     index       = SVD.S .> tol*maximum(SVD.S)
@@ -1305,7 +1305,7 @@ julia> nullspace(M)
 function nullspace(A::StridedMatrix{T}) where T
     m, n = size(A)
     (m == 0 || n == 0) && return eye(T, n)
-    SVD = svdfact(A, thin = false)
+    SVD = svdfact(A, full = true)
     indstart = sum(SVD.S .> max(m,n)*maximum(SVD.S)*eps(eltype(SVD.S))) + 1
     return SVD.Vt[indstart:end,:]'
 end

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -21,7 +21,7 @@ bimg  = randn(n,2)/2
 
 # helper functions to unambiguously recover explicit forms of an implicit QR Q
 squareQ(Q::LinAlg.AbstractQ) = A_mul_B!(Q, eye(eltype(Q), size(Q.factors, 1)))
-truncatedQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
+rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
 
 @testset for eltya in (Float32, Float64, Complex64, Complex128, BigFloat, Int)
     raw_a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
@@ -75,9 +75,9 @@ truncatedQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
                 q,r   = qra[:Q], qra[:R]
                 @test_throws KeyError qra[:Z]
                 @test q'*squareQ(q) ≈ eye(a_1)
-                @test q'*truncatedQ(q) ≈ eye(a_1, n1)
+                @test q'*rectangularQ(q) ≈ eye(a_1, n1)
                 @test q*r ≈ a[:, 1:n1]
-                @test q*b[1:n1] ≈ truncatedQ(q)*b[1:n1] atol=100ε
+                @test q*b[1:n1] ≈ rectangularQ(q)*b[1:n1] atol=100ε
                 @test q*b ≈ squareQ(q)*b atol=100ε
                 @test_throws DimensionMismatch q*b[1:n1 + 1]
                 @test_throws DimensionMismatch b[1:n1 + 1]*q'
@@ -163,7 +163,7 @@ end
 
 @testset "Issue 7304" begin
     A = [-√.5 -√.5; -√.5 √.5]
-    Q = truncatedQ(qrfact(A)[:Q])
+    Q = rectangularQ(qrfact(A)[:Q])
     @test vecnorm(A-Q) < eps()
 end
 


### PR DESCRIPTION
This pull request deprecates the `thin` keyword argument to orthogonal factorizations in favor of `square`, addressing JuliaLang/LinearAlgebra.jl#472. Best!