### PR TITLE
Emit explanatory error message for iteration on CartesianIndex

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -147,6 +147,11 @@ module IteratorsMD
         return ni
     end
 
+    # Iteration over the elements of CartesianIndex cannot be supported until its length can be inferred,
+    # see #23719
+    Base.start(::CartesianIndex) =
+        error("iteration is deliberately unsupported for CartesianIndex. Use `I` rather than `I...`, or use `Tuple(I)...`")
+
     # Iteration
     """
         CartesianRange(sz::Dims) -> R


### PR DESCRIPTION
As suggested in #23982. Sometimes these messages are helpful, but they can occasionally cause problems. In this case the most confusing part of the message would be if someone hit this in the context of
```julia
julia> I = CartesianIndex(1,2,3)
CartesianIndex(1, 2, 3)

julia> for i in I
           @show i
       end
ERROR: iteration is deliberately unsupported for CartesianIndex. Use `I` rather than `I...`, or use `Tuple(I)...`
```
and the user might wonder what splatting has to do with it. Nevertheless I suspect that splatting is how most people hit this issue.

But I am not attached to this. I've also deliberately not added a test for this behavior, since once the length can be inferred we will want to support iteration over the elements of `CartesianIndex`.
