### PR TITLE
Add a multinomial() function to Base

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -356,6 +356,7 @@ export
     modf,
     mod2pi,
     muladd,
+    multinomial,
     nextfloat,
     nextpow,
     nextpow2,

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -889,3 +889,29 @@ function binomial(n::T, k::T) where T<:Integer
     end
     convert(T, copysign(x, sgn))
 end
+
+"""
+    multinomial(n, k...)
+
+Number of ways partition `n` into groups of sizes `k[1]...k[end]`.
+Needs `sum(k) == n`; throws a DomainError() otherwise.
+
+# Examples
+```jldoctest
+julia> multinomial(7, 3, 2, 2)
+210
+
+julia> factorial(7) ÷ (factorial(3) * factorial(2) * factorial(2))
+210
+```
+"""
+function multinomial(n, k...)
+    i = 1
+    for k_i in k
+        i *= binomial(n, k_i)
+        n -= k_i
+    end
+    n == 0 || throw(DomainError("multinomial($n, $(join(k, ", "))) is undefined"))
+    i
+end
+

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -195,6 +195,11 @@ end
     @test binomial(BigInt(1), 2)  == BigInt(0)
     @test binomial(BigInt(-53), 42) == parse(BigInt,"959509335087854414441273718")
     @test binomial(BigInt(113), BigInt(42)) == parse(BigInt,"18672199984318438125634054194360")
+    @test multinomial(BigInt(1), -1, 2) == BigInt(0)
+    @test multinomial(BigInt(1), 2, -1)  == BigInt(0)
+    @test multinomial(BigInt(-53), 42, -95) == BigInt(0)
+    @test multinomial(BigInt(113), BigInt(42), BigInt(71)) == parse(BigInt,"18672199984318438125634054194360")
+    @test multinomial(BigInt(200), BigInt(140), BigInt(60)) == parse(BigInt,"7040504849268924926147025804879358372000504061178480")
 end
 a = rand(1:100, 10000)
 b = map(BigInt, a)

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -16,6 +16,25 @@
     @test_throws InexactError binomial(Int64(67), Int64(30))
 end
 
+@testset "multinomial" begin
+    # same tests as for binomial
+    @test multinomial(5,-1,6) == 0
+    @test multinomial(5,10,-5) == 0
+    @test multinomial(5,3,2) == 10
+    @test multinomial(2,1,1) == 2
+    @test multinomial(1,2,-1) == 0
+    @test multinomial(-2,1,-3) == 0
+    @test multinomial(2,-1,3) == 0
+
+    # some extra tests
+    @test multinomial(7,3,2,2) == 210
+    @test multinomial(7,3,1,3) == 140
+
+    # exceptions
+    @test_throws InexactError multinomial(Int64(67), Int64(30), Int64(37))
+    @test_throws DomainError multinomial(10, 5, 4)
+end
+
 @testset "permutations" begin
     p = shuffle([1:1000;])
     @test isperm(p)


### PR DESCRIPTION
This is roughly as useful as `binomial()`, so might as well offer it by default as well. For me personally, it took me a while to realize that this is how easy it is to implement in terms of `binomial()`; I'm hoping that adding it to `Base` saves others the time it cost me.

One could argue that there's redundancy in the current parameter specification. E.g. in Sage, one only passes the `k` vector; `n` is implied from their sum anyway. That makes sense, but I like the recognizability of the common notation

     /     n     \
    |             |
    | k_1,k_2,k_3 |
     \           /

I'm not married to the idea though and I'd be happy to change it.