### PR TITLE
Print some useful info when hitting some cases of invalid UTF-8

### DIFF
--- a/base/strings/errors.jl
+++ b/base/strings/errors.jl
@@ -3,7 +3,7 @@
 ##    Error messages for Unicode / UTF support
 
 const UTF_ERR_SHORT             = "invalid UTF-8 sequence starting at index <<1>> (0x<<2>> missing one or more continuation bytes)"
-const UTF_ERR_INVALID_INDEX     = "invalid character index"
+const UTF_ERR_INVALID_INDEX     = "invalid character index <<1>> (0x<<2>> is a continuation byte)"
 
 struct UnicodeError <: Exception
     errmsg::AbstractString   ##< A UTF_ERR_ message

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -645,3 +645,18 @@ end
     @test last(s, length(s)) == s
     @test_throws BoundsError last(s, length(s)+1)
 end
+
+@testset "invalid code point" begin
+    s = String([0x61, 0xba, 0x41])
+    @test !isvalid(s)
+    @test_throws UnicodeError s[2]
+    e = try
+        s[2]
+    catch e
+        e
+    end
+    b = IOBuffer()
+    show(b, e)
+    @test String(take!(b)) == "UnicodeError: invalid character index 2 (0xba is a continuation byte)"
+end
+


### PR DESCRIPTION
Right now we get
```julia
julia> s = String([0x61, 0xba, 0x41]);

julia> s[2]
ERROR: UnicodeError: invalid character index
Stacktrace:
 [1] slow_utf8_next(::Ptr{UInt8}, ::UInt8, ::Int64, ::Int64) at ./strings/string.jl:172
 [2] next at ./strings/string.jl:204 [inlined]
 [3] getindex(::String, ::Int64) at ./strings/basic.jl:32
```
which is not that useful if this happens in a super long string. With this PR, it would print
```julia
julia> s[2]
ERROR: UnicodeError: invalid character index 2 (0xba is a continuation byte)
Stacktrace:
 [1] slow_utf8_next(::Ptr{UInt8}, ::UInt8, ::Int64, ::Int64) at ./strings/string.jl:172
 [2] next at ./strings/string.jl:204 [inlined]
 [3] getindex(::String, ::Int64) at ./strings/basic.jl:32
```