### PR TITLE
fix #24305, stack overflow when intersecting sequence of big unions

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2092,11 +2092,15 @@ static jl_value_t *intersect_all(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
     e->Runions.depth = 0;
     e->Runions.more = 0;
     memset(e->Runions.stack, 0, sizeof(e->Runions.stack));
-    int lastset = 0, niter = 0;
+    jl_value_t **is;
+    JL_GC_PUSHARGS(is, 2);
+    int lastset = 0, niter = 0, total_iter = 0;
     jl_value_t *ii = intersect(x, y, e, 0);
     while (e->Runions.more) {
-        if (e->emptiness_only && ii != jl_bottom_type)
+        if (e->emptiness_only && ii != jl_bottom_type) {
+            JL_GC_POP();
             return ii;
+        }
         e->Runions.depth = 0;
         int set = e->Runions.more - 1;
         e->Runions.more = 0;
@@ -2105,8 +2109,6 @@ static jl_value_t *intersect_all(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
             statestack_set(&e->Runions, i, 0);
         lastset = set;
 
-        jl_value_t **is;
-        JL_GC_PUSHARGS(is, 2);
         is[0] = ii;
         is[1] = intersect(x, y, e, 0);
         if (is[0] == jl_bottom_type)
@@ -2118,10 +2120,13 @@ static jl_value_t *intersect_all(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
             ii = jl_type_union(is, 2);
             niter++;
         }
-        JL_GC_POP();
-        if (niter > 3)
+        total_iter++;
+        if (niter > 3 || total_iter > 400000) {
+            JL_GC_POP();
             return y;
+        }
     }
+    JL_GC_POP();
     return ii;
 }
 


### PR DESCRIPTION
There are two issues here. First, the `JL_GC_PUSH` in the loop was doing repeated allocas, leading to a stack overflow.

With that fixed, the stack overflow turns into an apparent hang due to matching a 6-element Union with 9 arguments (6^9). This was only an issue in global scope since in that case the arguments were `Any`. That can be fixed by moving the `Any` case above the Union case in intersection. Doing that broke one test, but that test was checking `B <: typeintersect(A, B)`, which is not correct in general, so changing it should be legitimate.

For reference, the culprit here is the `hvcat` method in sparsevector.jl that uses `_TypedDenseConcatGroup`. It would be nice to be able to do without those large union types. Large union types whose components have free variables will tend to hit exponential-time cases in subtyping.