### PR TITLE
add missing `export full`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1891,7 +1891,7 @@ end
 @deprecate diagm(x::Number) fill(x, 1, 1)
 
 ## deprecate full
-
+export full
 # full no-op fallback
 function full(A::AbstractArray)
     depwarn(string(


### PR DESCRIPTION
Missed in #24250
```
julia> full(sprand(2, 2, 0.))
ERROR: UndefVarError: full not defined
```