### PR TITLE
Small fixes to llvm dump functions

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6736,6 +6736,11 @@ extern "C" void jl_dump_llvm_metadata(void *v)
     llvm_dump((Metadata*)v);
 }
 
+extern "C" void jl_dump_llvm_debugloc(void *v)
+{
+    llvm_dump((DebugLoc*)v);
+}
+
 extern void jl_write_bitcode_func(void *F, char *fname) {
     std::error_code EC;
     raw_fd_ostream OS(fname, EC, sys::fs::F_None);

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -1,6 +1,7 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
 #include <llvm/Support/Debug.h>
+#include <llvm/IR/DebugLoc.h>
 
 enum AddressSpace {
     Generic = 0,
@@ -16,7 +17,7 @@ static inline void llvm_dump(llvm::Value *v)
 {
 #if JL_LLVM_VERSION >= 50000
     v->print(llvm::dbgs(), true);
-    putchar('\n');
+    llvm::dbgs() << "\n";
 #else
     v->dump();
 #endif
@@ -29,7 +30,7 @@ static inline void llvm_dump(llvm::Type *v)
 #else
     v->dump();
 #endif
-    putchar('\n');
+    llvm::dbgs() << "\n";
 }
 
 static inline void llvm_dump(llvm::Function *f)
@@ -54,8 +55,18 @@ static inline void llvm_dump(llvm::Metadata *m)
 {
 #if JL_LLVM_VERSION >= 50000
     m->print(llvm::dbgs());
-    putchar('\n');
+    llvm::dbgs() << "\n";
 #else
     m->dump();
 #endif
+}
+
+static inline void llvm_dump(llvm::DebugLoc *dbg)
+{
+#if JL_LLVM_VERSION >= 50000
+    dbg->print(llvm::dbgs());
+#else
+    dbg->dump();
+#endif
+    llvm::dbgs() << "\n";
 }


### PR DESCRIPTION
* Use the same stream for new line as other dump outputs
* Add dump function for DebugLoc