### PR TITLE
Improve constructor of Set from Set

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -4,6 +4,7 @@ mutable struct Set{T} <: AbstractSet{T}
     dict::Dict{T,Void}
 
     Set{T}() where {T} = new(Dict{T,Void}())
+    Set{T}(s::Set{T}) where {T} = new(Dict{T,Void}(s.dict))
     Set{T}(itr) where {T} = union!(new(Dict{T,Void}()), itr)
 end
 Set() = Set{Any}()
@@ -54,7 +55,7 @@ end
 
 delete!(s::Set, x) = (delete!(s.dict, x); s)
 
-copy(s::Set) = union!(similar(s), s)
+copy(s::Set{T}) where T = Set{T}(s)
 
 sizehint!(s::Set, newsz) = (sizehint!(s.dict, newsz); s)
 empty!(s::Set) = (empty!(s.dict); s)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -19,6 +19,19 @@ using Main.TestHelpers.OAs
         @test isa(Set(f17741(x) for x = 1:3), Set{Int})
         @test isa(Set(f17741(x) for x = -1:1), Set{Integer})
     end
+    let s1 = Set(["foo", "bar"]), s2 = Set(s1)
+        @test s1 == s2
+        x = pop!(s1)
+        @test s1 != s2
+        @test !(x in s1)
+        @test x in s2
+        push!(s1, "baz")
+        push!(s2, "baz2")
+        @test "baz" in s1
+        @test !("baz" in s2)
+        @test !("baz2" in s1)
+        @test "baz2" in s2
+    end
 end
 
 @testset "hash" begin


### PR DESCRIPTION
A followup to #24345 (and it is safe to merge after that PR is merged).

Currently construction of `Set` from `Set` uses `union!` treating the old set as an iterator. For large `Set`s it is much faster to copy the internal `dict::Dict{T,Void}` instead.

Here is a benchmark:
```
using BenchmarkTools

function f(s)
    s2 = similar(s)
    s2.dict = Dict(s.dict)
    s2
end

s = Set(1:10^6)

@benchmark Set($s)
# BenchmarkTools.Trial:
#   memory estimate:  34.50 MiB
#   allocs estimate:  48
#   --------------
#   minimum time:     115.747 ms (3.05% GC)
#   median time:      120.646 ms (3.25% GC)
#   mean time:        122.179 ms (4.71% GC)
#   maximum time:     184.478 ms (36.91% GC)
#   --------------
#   samples:          41
#   evals/sample:     1

@benchmark f($s)
# BenchmarkTools.Trial:
#   memory estimate:  18.00 MiB
#   allocs estimate:  11
#   --------------
#   minimum time:     6.299 ms (0.00% GC)
#   median time:      9.818 ms (1.34% GC)
#   mean time:        9.423 ms (23.95% GC)
#   maximum time:     73.674 ms (90.61% GC)
#   --------------
#   samples:          530
#   evals/sample:     1
```