### PR TITLE
User experience improvements for Git credential helpers

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -187,11 +187,9 @@ function authenticate_userpass(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayl
     if p.use_git_helpers && (!revised || !isfilled(cred))
         git_cred = GitCredential(p.config, p.url)
 
-        if isfilled(git_cred)
-            cred.user = Base.get(git_cred.username, "")
-            cred.pass = Base.get(git_cred.password, "")
-            revised = true
-        end
+        cred.user = Base.get(git_cred.username, "")
+        cred.pass = Base.get(git_cred.password, "")
+        revised = true
 
         p.use_git_helpers = false
     end


### PR DESCRIPTION
Follow up to #23824. After using this feature heavily for a day I found a couple of minor issues I missed:

1. Specifying the username in the git configuration file would not be used as the default username at the prompt.
2. The [`useHttpPath`](https://git-scm.com/docs/gitcredentials#gitcredentials-useHttpPath) variable is now fully supported (I misunderstood how this feature worked originally).