### PR TITLE
 [Release-0.6] Fix IntSet overflow with large unsigned ints

### DIFF
--- a/base/intset.jl
+++ b/base/intset.jl
@@ -21,7 +21,7 @@ sizehint!(s::IntSet, n::Integer) = (_resize0!(s.bits, max(n, length(s.bits))); s
 @inline function _setint!(s::IntSet, idx::Integer, b::Bool)
     if idx > length(s.bits)
         b || return s # setting a bit to zero outside the set's bits is a no-op
-        newlen = idx + idx>>1 # This operation may overflow; we want saturation
+        newlen = Int(idx) + Int(idx)>>1 # This operation may overflow; we want saturation
         _resize0!(s.bits, ifelse(newlen<0, typemax(Int), newlen))
     end
     @inbounds s.bits[idx] = b

--- a/test/intset.jl
+++ b/test/intset.jl
@@ -285,3 +285,10 @@ end
     @test pop!(s, 100, 0) === 0
     @test pop!(s, 99, 0) === 99
 end
+
+@testset "unsigned overflow" begin
+    @test IntSet(UInt8(2^8-1)) == IntSet(2^8-1)
+    @test [x for x in IntSet(UInt8(2^8-1))] == [UInt8(2^8-1)]
+    @test IntSet(UInt16(2^16-1)) == IntSet(2^16-1)
+    @test [x for x in IntSet(UInt16(2^16-1))] == [UInt16(2^16-1)]
+end


### PR DESCRIPTION
This is already fixed on master through a larger, unrelated change.  This is a very minimal patch to correct the bad behavior.

Ref https://discourse.julialang.org/t/intset-crashes-julia-0-6-1/6727/5