### PR TITLE
Calculate trace(PtP1) correctly in C micro benchmark

### DIFF
--- a/test/perf/micro/perf.c
+++ b/test/perf/micro/perf.c
@@ -173,8 +173,8 @@ struct double_pair randmatstat(int t) {
                     4*n, 4*n, 4*n, 1.0, PtP1, 4*n, PtP1, 4*n, 0.0, PtP2, 4*n);
         cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans,
                     4*n, 4*n, 4*n, 1.0, PtP2, 4*n, PtP2, 4*n, 0.0, PtP1, 4*n);
-        for (int j=0; j < n; j++) {
-            v[i] += PtP1[(n+1)*j];
+        for (int j=0; j < 4*n; j++) {
+            v[i] += PtP1[(4*n+1)*j];
         }
         cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
                     2*n, 2*n, 2*n, 1.0, Q, 2*n, Q, 2*n, 0.0, QtQ1, 2*n);


### PR DESCRIPTION
While digging deep into the micro benchmarks and their implementations (so as to orient myself for updates to #22433), I found out that the C implementation of `randmatstat` is not calculating the trace of `(P.'*P)^4` properly, as it's assuming a square `n x n` matrix instead of a `4n x 4n` matrix.

I was also told that there might be implementations in other languages with the same issue, but I would prefer to address them as separate PRs.