### PR TITLE
fix isapprox between UniformScaling and AbstractMatrix lacking specified rtol

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -215,15 +215,17 @@ function isapprox(J1::UniformScaling{T}, J2::UniformScaling{S};
             atol::Real=0, rtol::Real=Base.rtoldefault(T,S,atol), nans::Bool=false) where {T<:Number,S<:Number}
     isapprox(J1.λ, J2.λ, rtol=rtol, atol=atol, nans=nans)
 end
-function isapprox(J::UniformScaling,A::AbstractMatrix;
-                  atol::Real=0,
-                  rtol::Real=rtoldefault(promote_leaf_eltypes(A),eltype(J),atol),
-                  nans::Bool=false, norm::Function=vecnorm)
+function isapprox(J::UniformScaling, A::AbstractMatrix;
+                  atol::Real = 0,
+                  rtol::Real = Base.rtoldefault(promote_leaf_eltypes(A), eltype(J), atol),
+                  nans::Bool = false, norm::Function = vecnorm)
     n = checksquare(A)
-    Jnorm = norm === vecnorm ? abs(J.λ)*sqrt(n) : (norm === Base.norm ? abs(J.λ) : norm(Diagonal(fill(J.λ, n))))
-    return norm(A - J) <= max(atol, rtol*max(norm(A), Jnorm))
+    normJ = norm === Base.norm ? abs(J.λ) :
+            norm === vecnorm   ? abs(J.λ) * sqrt(n) :
+                                 norm(Diagonal(fill(J.λ, n)))
+    return norm(A - J) <= max(atol, rtol * max(norm(A), normJ))
 end
-isapprox(A::AbstractMatrix,J::UniformScaling;kwargs...) = isapprox(J,A;kwargs...)
+isapprox(A::AbstractMatrix, J::UniformScaling; kwargs...) = isapprox(J, A; kwargs...)
 
 function copy!(A::AbstractMatrix, J::UniformScaling)
     size(A,1)==size(A,2) || throw(DimensionMismatch("a UniformScaling can only be copied to a square matrix"))

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -35,6 +35,7 @@ end
     @test 4.3*eye(2) ≈ UniformScaling(4.32) rtol=0.1 atol=0.01
     @test [4.3201 0.002;0.001 4.32009] ≈ UniformScaling(4.32) rtol=0.1 atol=0.
     @test UniformScaling(4.32) ≉ 4.3*ones(2,2) rtol=0.1 atol=0.01
+    @test UniformScaling(4.32) ≈ 4.32*eye(2)
 end
 
 @testset "arithmetic with Number" begin


### PR DESCRIPTION
`isapprox` between `UniformScaling`s and `AbstractMatrix`s fails on master when relative tolerance is not specified (due to a missing `Base.` qualification on an `rtoldefault(...)` call). This pull request fixes that issue. Best!