### PR TITLE
Clarify meaning of p in hexadecimal floating-point literals

### DIFF
--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -218,7 +218,8 @@ second argument is zero.
 
 ## Floating-Point Numbers
 
-Literal floating-point numbers are represented in the standard formats:
+Literal floating-point numbers are represented in the standard formats, using
+[E-notation](https://en.wikipedia.org/wiki/Scientific_notation#E-notation) when necessary:
 
 ```jldoctest
 julia> 1.0
@@ -267,7 +268,8 @@ julia> typeof(ans)
 Float32
 ```
 
-Hexadecimal floating-point literals are also valid, but only as [`Float64`](@ref) values:
+Hexadecimal floating-point literals are also valid, but only as [`Float64`](@ref) values,
+with `p` preceding the base-2 exponent:
 
 ```jldoctest
 julia> 0x1p0


### PR DESCRIPTION
While it should be almost safe to expect that everybody knows the E-notation (but I think it's good anyway to point to Wikipedia for those who don't know it), hexadecimal floating-point literals may be less known, in particular the meaning of `p`.

I skipped CIs because this PR changes only text of documentation, no doctests.