### PR TITLE
Fixed a typo in example of `Base.SubString`

### DIFF
--- a/base/strings/types.jl
+++ b/base/strings/types.jl
@@ -21,6 +21,7 @@ julia> SubString("abc", 1:2)
 
 julia> SubString("abc", 2)
 "bc"
+```
 """
 struct SubString{T<:AbstractString} <: AbstractString
     string::T


### PR DESCRIPTION
Dear, developers.
There was no " \`\`\` " corresponding to " \`\`\`jldoctest ".
So, I've added it.