### PR TITLE
iszero and isone specializations for SparseMatrixCSC

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1553,6 +1553,7 @@ end
 
 sparse(S::UniformScaling, m::Integer, n::Integer=m) = speye_scaled(S.λ, m, n)
 
+Base.iszero(A::SparseMatrixCSC) = iszero(view(A.nzval, 1:(A.colptr[size(A, 2) + 1] - 1)))
 
 function Base.isone(A::SparseMatrixCSC)
     m, n = size(A)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1553,6 +1553,18 @@ end
 
 sparse(S::UniformScaling, m::Integer, n::Integer=m) = speye_scaled(S.λ, m, n)
 
+
+function Base.isone(A::SparseMatrixCSC)
+    m, n = size(A)
+    m == n && A.colptr[n+1] >= n+1 || return false
+    for j in 1:n, k in A.colptr[j]:(A.colptr[j+1] - 1)
+        i, x = A.rowval[k], A.nzval[k]
+        ifelse(i == j, isone(x), iszero(x)) || return false
+    end
+    return true
+end
+
+
 # TODO: More appropriate location?
 conj!(A::SparseMatrixCSC) = (@inbounds broadcast!(conj, A.nzval, A.nzval); A)
 (-)(A::SparseMatrixCSC) = SparseMatrixCSC(A.m, A.n, copy(A.colptr), copy(A.rowval), map(-, A.nzval))

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -5,6 +5,14 @@
     @test !issparse(ones(5,5))
 end
 
+@testset "isone specialization for SparseMatrixCSC" begin
+    @test isone(sparse(I, 3, 3))    # test success
+    @test !isone(sparse(I, 3, 4))   # test failure for non-square matrix
+    @test !isone(spzeros(3, 3))     # test failure for too few stored entries
+    @test !isone(sparse(2I, 3, 3))  # test failure for non-one diagonal entries
+    @test !isone(sparse(Bidiagonal(fill(1, 3), fill(1, 2), :U))) # test failure for non-zero off-diag entries
+end
+
 @testset "indtype" begin
     @test Base.SparseArrays.indtype(sparse(ones(Int8,2),ones(Int8,2),rand(2))) == Int8
 end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -5,6 +5,12 @@
     @test !issparse(ones(5,5))
 end
 
+@testset "iszero specialization for SparseMatrixCSC" begin
+    @test !iszero(sparse(I, 3, 3))                  # test failure
+    @test iszero(spzeros(3, 3))                     # test success with no stored entries
+    @test iszero(setindex!(sparse(I, 3, 3), 0, :))  # test success with stored zeros
+    @test iszero(SparseMatrixCSC(2, 2, [1,2,3], [1,2], [0,0,1])) # test success with nonzeros beyond data range
+end
 @testset "isone specialization for SparseMatrixCSC" begin
     @test isone(sparse(I, 3, 3))    # test success
     @test !isone(sparse(I, 3, 4))   # test failure for non-square matrix


### PR DESCRIPTION
This pull request provides `iszero` and `isone` specializations for `SparseMatrixCSC` that should be much more efficient than the fallback. Best!