### PR TITLE
Make expand/Meta.lower slightly usable again

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -65,4 +65,18 @@ See also [`code_lowered`](@ref).
 """
 lower(m::Module, @nospecialize(x)) = ccall(:jl_expand, Any, (Any, Any), x, m)
 
+"""
+    @lower [m] x
+
+Return lowered form of the expression `x` in module `m`.
+By default `m` is the module in which the macro is called.
+See also [`lower`](@ref).
+"""
+macro lower(code)
+    return :(lower($__module__, $(QuoteNode(code))))
+end
+macro lower(mod, code)
+    return :(lower($(esc(mod)), $(QuoteNode(code))))
+end
+
 end # module

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -342,6 +342,7 @@ Base.@functionloc
 Base.gc
 Base.gc_enable
 Meta.lower
+Meta.@lower
 Base.macroexpand
 Base.@macroexpand
 Base.@macroexpand1

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -188,3 +188,30 @@ let oldout = STDOUT
         redirect_stdout(oldout)
     end
 end
+
+macro is_dollar_expr(ex)
+    return Meta.isexpr(ex, :$)
+end
+
+module TestExpandModule
+macro is_in_def_module()
+    return __module__ === @__MODULE__
+end
+end
+
+let a = 1
+    @test @is_dollar_expr $a
+    @test !TestExpandModule.@is_in_def_module
+    @test @eval TestExpandModule @is_in_def_module
+
+    @test Meta.lower(@__MODULE__, :($a)) === 1
+    @test !Meta.lower(@__MODULE__, :(@is_dollar_expr $a))
+    @test Meta.@lower @is_dollar_expr $a
+    @test Meta.@lower @__MODULE__() @is_dollar_expr $a
+    @test !Meta.@lower TestExpandModule.@is_in_def_module
+    @test Meta.@lower TestExpandModule @is_in_def_module
+
+    @test macroexpand(@__MODULE__, :($a)) === 1
+    @test !macroexpand(@__MODULE__, :(@is_dollar_expr $a))
+    @test @macroexpand @is_dollar_expr $a
+end


### PR DESCRIPTION
The expand function is now basically unusable for quick checking in the REPL.
What was previously

```
expand(:(...))
```

is now

```
Meta.lower(@__MODULE__, :(...))
```

or at least

```
Meta.lower(Main, :(...))
```

which are prohibitively long making the simplest way to work in the REPL
to use the deprecated `expand`, ignoring all the depwarns...

There are two ways to deal with the problem,

1. Define a module local version similar to `eval`, `include` etc.

   This was the plan/mentioned when the module argument was added but is now effectively killed
   when the function is renamed, the reason I increasingly dislike that change.

2. Define a macro

   This makes certain case easier (when the expression has `Expr(:$)`)
   while doesn't really help with some other cases (when the expression is not a simple literal).

The second way doesn't solve all the problems but at least it is still possible and easy to do.