### PR TITLE
Remove idling worker as soon as there's no more tests to run

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,11 +91,13 @@ cd(dirname(@__FILE__)) do
                         print_with_color(:white, rpad(rss_str,rss_align," "), "\n")
                     end
                 end
+                if p != 1
+                    # Free up memory =)
+                    rmprocs(p, waitfor=30)
+                end
             end
         end
     end
-    # Free up memory =)
-    n > 1 && rmprocs(workers(), waitfor=30)
     for t in node1_tests
         # As above, try to run each test
         # which must run on node 1. If


### PR DESCRIPTION
Might help test memory usage a little.
More importantly, this makes it much easier for external scheduler to track when the test process
is finished and a new process can be scheduled.