### PR TITLE
Add `empty` and change `similar(::Associative)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1339,6 +1339,13 @@ Deprecated or removed
 
   * `linspace` and `logspace` now require an explicit number of elements to be supplied rather than defaulting to `50`.
 
+  * Introduced the `empty` function, the functional pair to `empty!` which returns a new,
+    empty container ([#24390]).
+
+  * `similar(::Associative)` has been deprecated in favor of `empty(::Associative)`, and
+    `similar(::Associative, ::Pair{K, V})` has been deprecated in favour of
+    `empty(::Associative, K, V)` ([#24390]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -566,6 +566,24 @@ indices of `A`.
 similar(f, shape::Tuple) = f(to_shape(shape))
 similar(f, dims::DimOrInd...) = similar(f, dims)
 
+"""
+    empty(v::AbstractVector, [eltype])
+
+Create an empty vector similar to `v`, optionally changing the `eltype`.
+
+# Examples
+
+```jldoctest
+julia> empty([1.0, 2.0, 3.0])
+0-element Array{Float64,1}
+
+julia> empty([1.0, 2.0, 3.0], String)
+0-element Array{String,1}
+```
+"""
+empty(a::AbstractVector) = empty(a, eltype(a))
+empty(a::AbstractVector, ::Type{T}) where {T} = Vector{T}()
+
 ## from general iterable to any array
 
 function copy!(dest::AbstractArray, src)

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -105,7 +105,7 @@ function deepcopy_internal(x::Dict, stackdict::ObjectIdDict)
         return (stackdict[x] = copy(x))
     end
 
-    dest = similar(x)
+    dest = empty(x)
     stackdict[x] = dest
     for (k, v) in x
         dest[deepcopy_internal(k, stackdict)] = deepcopy_internal(v, stackdict)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2172,6 +2172,10 @@ end
 
 @deprecate merge!(repo::LibGit2.GitRepo, args...; kwargs...) LibGit2.merge!(repo, args...; kwargs...)
 
+# issue #24019
+@deprecate similar(a::Associative) empty(a)
+@deprecate similar(a::Associative, ::Type{Pair{K,V}}) where {K, V} empty(a, K, V)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/env.jl
+++ b/base/env.jl
@@ -73,8 +73,6 @@ variables.
 """
 const ENV = EnvDict()
 
-similar(::EnvDict) = Dict{String,String}()
-
 getindex(::EnvDict, k::AbstractString) = access_env(k->throw(KeyError(k)), k)
 get(::EnvDict, k::AbstractString, def) = access_env(k->def, k)
 get(f::Callable, ::EnvDict, k::AbstractString) = access_env(k->f(), k)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -649,6 +649,7 @@ export
     deleteat!,
     eltype,
     empty!,
+    empty,
     endof,
     filter!,
     filter,

--- a/base/pkg/query.jl
+++ b/base/pkg/query.jl
@@ -42,9 +42,9 @@ end
 
 # Specialized copy for the avail argument below because the deepcopy is slow
 function availcopy(avail)
-    new_avail = similar(avail)
+    new_avail = empty(avail)
     for (pkg, vers_avail) in avail
-        new_vers_avail = similar(vers_avail)
+        new_vers_avail = empty(vers_avail)
         for (version, pkg_avail) in vers_avail
             new_vers_avail[version] = copy(pkg_avail)
         end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -328,3 +328,10 @@ any(x::Tuple{}) = false
 any(x::Tuple{Bool}) = x[1]
 any(x::Tuple{Bool, Bool}) = x[1]|x[2]
 any(x::Tuple{Bool, Bool, Bool}) = x[1]|x[2]|x[3]
+
+"""
+    empty(x::Tuple)
+
+Returns an empty tuple, `()`.
+"""
+empty(x::Tuple) = ()

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -68,8 +68,7 @@ function WeakKeyDict(kv)
     end
 end
 
-similar(d::WeakKeyDict{K,V}) where {K,V} = WeakKeyDict{K,V}()
-similar(d::WeakKeyDict, ::Type{Pair{K,V}}) where {K,V} = WeakKeyDict{K,V}()
+empty(d::WeakKeyDict, ::Type{K}, ::Type{V}) where {K, V} = WeakKeyDict{K, V}()
 
 # conversion between Dict types
 function convert(::Type{WeakKeyDict{K,V}},d::Associative) where V where K

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -870,10 +870,22 @@ end
     Base.convert(::Type{Array{T,n}}, a::Array{T,n}) where {T<:Number,n} = a
     Base.convert(::Type{Array{T,n}}, a::Array) where {T<:Number,n} =
         copy!(Array{T,n}(uninitialized, size(a)), a)
-    @test isa(similar(Dict(:a=>1, :b=>2.0), Pair{Union{},Union{}}), Dict{Union{}, Union{}})
+    @test isa(empty(Dict(:a=>1, :b=>2.0), Union{}, Union{}), Dict{Union{}, Union{}})
 end
 
 @testset "zero-dimensional copy" begin
     Z = Array{Int,0}(uninitialized); Z[] = 17
     @test Z == collect(Z) == copy(Z)
+end
+
+@testset "empty" begin
+    @test isempty([])
+    v = [1, 2, 3]
+    v2 = empty(v)
+    v3 = empty(v, Float64)
+    @test !isempty(v)
+    empty!(v)
+    @test isempty(v)
+    @test isempty(v2::Vector{Int})
+    @test isempty(v3::Vector{Float64})
 end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -389,7 +389,7 @@ end
     a[1] = a
     a[a] = 2
 
-    sa = similar(a)
+    sa = empty(a)
     @test isempty(sa)
     @test isa(sa, ObjectIdDict)
 
@@ -515,8 +515,8 @@ import Base.ImmutableDict
     @test get(d, k1, :default) === :default
     @test d1["key1"] === v1
     @test d4["key1"] === v2
-    @test similar(d3) === d
-    @test similar(d) === d
+    @test empty(d3) === d
+    @test empty(d) === d
 
     @test_throws KeyError d[k1]
     @test_throws KeyError d1["key2"]
@@ -657,8 +657,8 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     @test !isempty(wkd)
 
     wkd = empty!(wkd)
-    @test wkd == similar(wkd)
-    @test typeof(wkd) == typeof(similar(wkd))
+    @test wkd == empty(wkd)
+    @test typeof(wkd) == typeof(empty(wkd))
     @test length(wkd) == 0
     @test isempty(wkd)
     @test isa(wkd, WeakKeyDict)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -83,6 +83,8 @@ end
         @test Tuple{Int,Vararg{Any}}.ninitialized == 1
         @test Tuple{Any,Any,Vararg{Any}}.ninitialized == 2
     end
+
+    @test empty((1, 2.0, "c")) === ()
 end
 
 @testset "size" begin


### PR DESCRIPTION
This work relates to #24019, the theme of which is making the indexing interface for `AbstractArray` and `Associative` much more similar (which I hope will make working with containers more seamless). 

For arrays, `similar` returns arrays with the same `keys`, whereas for dictionaries, `similar` returns empty dictionaries. If we are going to make the semantics of indexing and so-on more consistent between arrays and dicts, then to me it makes sense to have:

 * An `empty` function which is the functional companion of mutating `empty!` and predicate `isempty`, and replaces `similar(::Associative)`.
 * A `similar` function that always preserves the existence of indices. *Occasionally* this might be a nice performance hack for creating new `Dict`s, but much more importantly this will be very useful for user-defined `Associative`s which may have immutable or expensive-to-insert keys, but freely mutable values.

I'm a bit new to the `Associative` code base... Please note that the signatures I've created for `empty` and `similar` make more sense in a world where `Associatives` iterate values, not key-value `Pair`s, which is another breaking (v1.0) suggestion in #24019.