### PR TITLE
size -> indices to fix show of multidimensional OffsetArrays

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1915,7 +1915,7 @@ function show_nd(io::IO, a::AbstractArray, print_matrix, label_slices)
                 if length(ind) > 10
                     if ii == ind[4] && all(d->idxs[d]==first(tailinds[d]),1:i-1)
                         for j=i+1:nd
-                            szj = size(a,j+2)
+                            szj = length(indices(a, j+2))
                             indj = tailinds[j]
                             if szj>10 && first(indj)+2 < idxs[j] <= last(indj)-3
                                 @goto skip

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -176,6 +176,7 @@ cmp_showf(Base.print_matrix, io, OffsetArray(rand(5,5), (10,-9)))       # rows&c
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,5), (10,-9)))    # columns fit
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(5,10^3), (10,-9)))    # rows fit
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,10^3), (10,-9))) # neither fits
+cmp_showf(Base.show, io, OffsetArray(rand(1,1,10^3,1), (1,2,3,4)))      # issue in #24393
 targets1 = ["0-dimensional $OAs_name.OffsetArray{Float64,0,Array{Float64,0}}:\n1.0",
             "$OAs_name.OffsetArray{Float64,1,Array{Float64,1}} with indices 2:2:\n 1.0",
             "$OAs_name.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",


### PR DESCRIPTION
`show` of multidimensional `OffsetArrays` failed due to a `size` call.
```
julia> OffsetArray(Float64, -10:10, -7:7, -128:512, -5:5)
OffsetArray(::Array{Float64,4}, -10:10, -7:7, -128:512, -5:5) with eltype Float64 with indices -10:10×-7:7×-128:512×-5:5:
[:, :, -128, -5] =
[...]

Error showing value of type OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}:
ERROR: size not supported for arrays with indices (-10:10, -7:7, -128:512, -5:5); see http://docs.julialang.org/en/latest/devdocs/offset-arrays/
Stacktrace:
 [1] show_nd(::IOContext{Base.Terminals.TTYTerminal}, ::OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}, ::getfield(Base, Symbol("##291#292")), ::Bool) at ./show.jl:1918
 [2] #showarray#290(::Bool, ::Function, ::IOContext{Base.Terminals.TTYTerminal}, ::OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}, ::Bool) at ./show.jl:2039
 [3] show(::IOContext{Base.Terminals.TTYTerminal}, ::MIME{Symbol("text/plain")}, ::OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}) at ./replutil.jl:139
 [4] display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::MIME{Symbol("text/plain")}, ::OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}) at ./repl/REPL.jl:125
 [5] display(::Base.REPL.REPLDisplay{Base.REPL.LineEditREPL}, ::OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}) at ./repl/REPL.jl:128
 [6] display(::OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}) at ./multimedia.jl:277
 [7] (::getfield(Base, Symbol("#inner#4")){Array{Any,1},typeof(display),Tuple{OffsetArrays.OffsetArray{Float64,4,Array{Float64,4}}}})() at ./essentials.jl:669
 [8] print_response(::Base.Terminals.TTYTerminal, ::Any, ::Void, ::Bool, ::Bool, ::Void) at ./repl/REPL.jl:146
 [9] print_response(::Base.REPL.LineEditREPL, ::Any, ::Void, ::Bool, ::Bool) at ./repl/REPL.jl:132
 [10] (::getfield(Base.REPL, Symbol("#do_respond#17")){Bool,getfield(Base.REPL, Symbol("##27#37")){Base.REPL.LineEditREPL,Base.REPL.REPLHistoryProvider},Base.REPL.LineEditREPL,Base.LineEdit.Prompt})(::Base.LineEdit.MIState, ::Base.GenericIOBuffer{Array{UInt8,1}}, ::Bool) at ./repl/REPL.jl:674
```