### PR TITLE
evaluate args to `@show` before trying to print

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -336,8 +336,10 @@ Show an expression and result, returning the result.
 macro show(exs...)
     blk = Expr(:block)
     for ex in exs
+        sym = gensym()
+        push!(blk.args, :($(sym) = begin value=$(esc(ex)) end))
         push!(blk.args, :(print($(sprint(show_unquoted,ex)*" = "))))
-        push!(blk.args, :(show(STDOUT, "text/plain", begin value=$(esc(ex)) end)))
+        push!(blk.args, :(show(STDOUT, "text/plain", $(sym))))
         push!(blk.args, :(println()))
     end
     isempty(exs) || push!(blk.args, :value)

--- a/test/show.jl
+++ b/test/show.jl
@@ -854,6 +854,24 @@ let fname = tempname()
     end
 end
 
+# Test @show only prints for defined variables
+let fname = tempname()
+    try
+        open(fname, "w") do fout
+            redirect_stdout(fout) do
+                try
+                  @show 0 undefvar
+                catch e
+                  isa(e, UndefVarError) || rethrow()
+                end
+            end
+        end
+        @test read(fname, String) == "0 = 0\n"
+    finally
+        rm(fname, force=true)
+    end
+end
+
 struct f_with_params{t} <: Function
 end
 


### PR DESCRIPTION
Before https://github.com/JuliaLang/julia/pull/22253

```
julia> @show undefvar
ERROR: UndefVarError: undefvar not defined

julia> @show 0 undefvar
0 = 0
ERROR: UndefVarError: undefvar not defined
```

after

```
julia> @show undefvar
undefvar = ERROR: UndefVarError: undefvar not defined

julia> @show 0 undefvar
0 = 0
undefvar = ERROR: UndefVarError: undefvar not defined
```

This PR should restore the original behavior.