### PR TITLE
make I consistently provide identity behavior in type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -255,6 +255,9 @@ This section lists changes that do not have deprecation warnings.
   * All command line arguments passed via `-e`, `-E`, and `-L` will be executed in the order
     given on the command line ([#23665]).
 
+  * `I` now yields `UniformScaling{Bool}(true)` rather than `UniformScaling{Int64}(1)`
+    to better preserve types in operations involving `I` ([#24396]).
+
   * The return type of `reinterpret` has changed to `ReinterpretArray`. `reinterpret` on sparse
     arrays has been discontinued.
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1919,7 +1919,7 @@ test5536(a::Union{Real, AbstractArray}) = "Non-splatting"
 # issue #6142
 import Base: +
 mutable struct A6142 <: AbstractMatrix{Float64}; end
-+(x::A6142, y::UniformScaling{TJ}) where {TJ} = "UniformScaling method called"
++(x::A6142, y::UniformScaling) = "UniformScaling method called"
 +(x::A6142, y::AbstractArray) = "AbstractArray method called"
 @test A6142() + I == "UniformScaling method called"
 +(x::A6142, y::AbstractRange) = "AbstractRange method called" #16324 ambiguity

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -51,7 +51,7 @@ end
 end
 
 @testset "det and logdet" begin
-    @test det(I) === 1
+    @test det(I) === true
     @test det(1.0I) === 1.0
     @test det(0I) === 0
     @test det(0.0I) === 0.0
@@ -215,4 +215,15 @@ end
     @test 0denseI != 2I != 0denseI # test generic path / inequality on diag
     @test alltwos != 2I != alltwos # test generic path / inequality off diag
     @test rdenseI !=  I != rdenseI # test square matrix check
+end
+
+@testset "operations involving I should preserve eltype" begin
+    @test isa(Int8(1) + I, Int8)
+    @test isa(Float16(1) + I, Float16)
+    @test eltype(Int8(1)I) == Int8
+    @test eltype(Float16(1)I) == Float16
+    @test eltype(fill(Int8(1), 2, 2)I) == Int8
+    @test eltype(fill(Float16(1), 2, 2)I) == Float16
+    @test eltype(fill(Int8(1), 2, 2) + I) == Int8
+    @test eltype(fill(Float16(1), 2, 2) + I) == Float16
 end


### PR DESCRIPTION
Presently `I` is `UniformScaling{Int64}(1)`, which consistently provides identity behavior in value but inconsistently in type:
```julia
julia> typeof(Float32(1)I) # as expected
UniformScaling{Float32}

julia> typeof(Float32(1) + I) # as expected
Float32

julia> typeof(fill(Float32(1), 3, 3) + I) # as expected
Array{Float32,2}

julia> typeof(fill(Float32(1), 3, 3)I) # as expected
Array{Float32,2}

julia> typeof(Int32(1)I) # expect Int32, get Int64?
UniformScaling{Int64}

julia> typeof(Int32(1) + I) # expect Int32, get Int64?
Int64

julia> typeof(fill(Int32(1), 3, 3) + I) # expect eltype Int32, get eltype Int64?
Array{Int64,2}

julia> typeof(fill(Int32(1), 3, 3)I) # expect eltype Int32, get eltype Int64?
Array{Int64,2}

julia> typeof(fill(true, 3, 3)I) # expect eltype Bool, get eltype Int64?
Array{Int64,2}
```
This pull request makes `I` yield `UniformScaling{Bool}(true)` instead, which consistently provides identity behavior not merely in value but also in type. Ref. JuliaLang/LinearAlgebra.jl#454, and particularly the latter paragraphs in https://github.com/JuliaLang/LinearAlgebra.jl/issues/454, which this pull request partially addresses. Best!