### PR TITLE
[release-0.6] help #24383 inference and load time regression

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -515,7 +515,10 @@ function _methods_by_ftype(t::ANY, lim::Int, world::UInt, min::Array{UInt,1}, ma
         end
     end
     if 1 < nu <= 64
-        return _methods_by_ftype(Any[tp...], t, length(tp), lim, [], world, min, max)
+        ms = _methods_by_ftype(Any[tp...], t, length(tp), lim, [], world, min, max)
+        if all(m->isleaftype(m[1]), ms)
+            return ms
+        end
     end
     # XXX: the following can return incorrect answers that the above branch would have corrected
     return ccall(:jl_matching_methods, Any, (Any, Cint, Cint, UInt, Ptr{UInt}, Ptr{UInt}), t, lim, 0, world, min, max)

--- a/src/dump.c
+++ b/src/dump.c
@@ -3035,6 +3035,8 @@ static jl_datatype_t *jl_recache_type(jl_datatype_t *dt, size_t start, jl_value_
         t = dt;
     }
     assert(t->uid != 0);
+    if (t == dt && v == NULL)
+        return t;
     // delete / replace any other usages of this type in the backref list
     // with the newly constructed object
     size_t i = start;
@@ -3087,8 +3089,7 @@ static void jl_recache_types(void)
             if (jl_is_datatype(o)) {
                 dt = (jl_datatype_t*)o;
                 v = dt->instance;
-                assert(dt->uid == -1);
-                t = jl_recache_type(dt, i + 2, NULL);
+                t = dt->uid == -1 ? jl_recache_type(dt, i + 2, NULL) : dt;
             }
             else {
                 dt = (jl_datatype_t*)jl_typeof(o);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -591,7 +591,9 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
             jl_value_t *oldval = e->envout[e->envidx];
             // if we try to assign different variable values (due to checking
             // multiple union members), consider the value unknown.
-            if (!oldval || !jl_is_typevar(oldval) || !jl_is_long(val))
+            if (oldval && !jl_egal(oldval, val))
+                e->envout[e->envidx] = (jl_value_t*)u->var;
+            else
                 e->envout[e->envidx] = val;
             // TODO: substitute the value (if any) of this variable into previous envout entries
         }

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -959,3 +959,18 @@ for i in 1:3
     ir = sprint(io->code_llvm(io, f22290, Tuple{}))
     @test contains(ir, "julia_f22290")
 end
+
+# approximate static parameters due to unions
+let T1 = Array{Float64}, T2 = Array{_1,2} where _1
+    inference_test_copy(a::T) where {T<:Array} = ccall(:jl_array_copy, Ref{T}, (Any,), a)
+    rt = Base.return_types(inference_test_copy, (Union{T1,T2},))[1]
+    @test rt >: T1 && rt >: T2
+
+    el(x::T) where {T} = eltype(T)
+    rt = Base.return_types(el, (Union{T1,Array{Float32,2}},))[1]
+    @test rt >: Union{Type{Float64}, Type{Float32}}
+
+    g(x::Ref{T}) where {T} = T
+    rt = Base.return_types(g, (Union{Ref{Array{Float64}}, Ref{Array{Float32}}},))[1]
+    @test rt >: Union{Type{Array{Float64}}, Type{Array{Float32}}}
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1149,3 +1149,8 @@ end
               Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64,
               Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64,
               Int64,Float64,Int64,Float64,Int64,Float64,Int64,Float64} <: (Tuple{Vararg{T}} where T<:Number))
+
+# PR #24399
+let (t, e) = intersection_env(Tuple{Union{Int,Int8}}, Tuple{T} where T)
+    @test e[1] isa TypeVar
+end


### PR DESCRIPTION
If this works, a similar version is applicable to master.

This change has two parts. First, I modified the union-splitting logic in method lookup to only infer split signatures that are concrete. This prunes a bunch of the inference tree, reducing BandedMatrices.ji from ~100MB to ~40MB.

Next there is a load time problem where `jl_recache_types` is O(n^2). (A lot of time is also spent inserting methods and backedges, but if the `jl_recache_types` change works it's an easy fix.) @vtjnash will have to review to see if this is valid. If it's not, it can be dropped from the patch and there's still a significant improvement.

With this, `using BandedMatrices` (including precompilation) takes ~3 minutes for me instead of ~20.

ref #24383