### PR TITLE
[WIP] add some junk

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -123,7 +123,7 @@ export
     SimpleVector, AbstractArray, DenseArray,
     # special objects
     Function, CodeInfo, Method, MethodTable, TypeMapEntry, TypeMapLevel,
-    Module, Symbol, Task, Array, WeakRef, VecElement,
+    Module, Symbol, Task, Array, junk, WeakRef, VecElement,
     # numeric types
     Number, Real, Integer, Bool, Ref, Ptr,
     AbstractFloat, Float16, Float32, Float64,
@@ -350,25 +350,44 @@ unsafe_convert(::Type{T}, x::T) where {T} = x
 const NTuple{N,T} = Tuple{Vararg{T,N}}
 
 
-# primitive array constructors
-Array{T,N}(d::NTuple{N,Int}) where {T,N} =
-    ccall(:jl_new_array, Array{T,N}, (Any, Any), Array{T,N}, d)
-Array{T,1}(d::NTuple{1,Int}) where {T} = Array{T,1}(getfield(d,1))
-Array{T,2}(d::NTuple{2,Int}) where {T} = Array{T,2}(getfield(d,1), getfield(d,2))
-Array{T,3}(d::NTuple{3,Int}) where {T} = Array{T,3}(getfield(d,1), getfield(d,2), getfield(d,3))
-Array{T,N}(d::Vararg{Int,N}) where {T,N} = ccall(:jl_new_array, Array{T,N}, (Any, Any), Array{T,N}, d)
-Array{T,1}(m::Int) where {T} = ccall(:jl_alloc_array_1d, Array{T,1}, (Any, Int), Array{T,1}, m)
-Array{T,2}(m::Int, n::Int) where {T} =
+## primitive Array constructors
+function junk end
+# type and dimensionality specified, accepting dims as series of Ints
+Array{T,1}(::typeof(junk), m::Int) where {T} =
+    ccall(:jl_alloc_array_1d, Array{T,1}, (Any, Int), Array{T,1}, m)
+Array{T,2}(::typeof(junk), m::Int, n::Int) where {T} =
     ccall(:jl_alloc_array_2d, Array{T,2}, (Any, Int, Int), Array{T,2}, m, n)
-Array{T,3}(m::Int, n::Int, o::Int) where {T} =
+Array{T,3}(::typeof(junk), m::Int, n::Int, o::Int) where {T} =
     ccall(:jl_alloc_array_3d, Array{T,3}, (Any, Int, Int, Int), Array{T,3}, m, n, o)
+Array{T,N}(::typeof(junk), d::Vararg{Int,N}) where {T,N} =
+    ccall(:jl_new_array, Array{T,N}, (Any, Any), Array{T,N}, d)
+# type and dimensionality specified, accepting dims as tuples of Ints
+Array{T,1}(::typeof(junk), d::NTuple{1,Int}) where {T} = Array{T,1}(junk, getfield(d,1))
+Array{T,2}(::typeof(junk), d::NTuple{2,Int}) where {T} = Array{T,2}(junk, getfield(d,1), getfield(d,2))
+Array{T,3}(::typeof(junk), d::NTuple{3,Int}) where {T} = Array{T,3}(junk, getfield(d,1), getfield(d,2), getfield(d,3))
+Array{T,N}(::typeof(junk), d::NTuple{N,Int}) where {T,N} = ccall(:jl_new_array, Array{T,N}, (Any, Any), Array{T,N}, d)
+# type but not dimensionality specified
+Array{T}(::typeof(junk), m::Int) where {T} = Array{T,1}(junk, m)
+Array{T}(::typeof(junk), m::Int, n::Int) where {T} = Array{T,2}(junk, m, n)
+Array{T}(::typeof(junk), m::Int, n::Int, o::Int) where {T} = Array{T,3}(junk, m, n, o)
+Array{T}(::typeof(junk), d::NTuple{N,Int}) where {T,N} = Array{T,N}(junk, d)
+# empty vector constructor
+Array{T,1}() where {T} = Array{T,1}(junk, 0)
 
-Array{T}(d::NTuple{N,Int}) where {T,N} = Array{T,N}(d)
-Array{T}(m::Int) where {T} = Array{T,1}(m)
-Array{T}(m::Int, n::Int) where {T} = Array{T,2}(m, n)
-Array{T}(m::Int, n::Int, o::Int) where {T} = Array{T,3}(m, n, o)
+## preexisting Array constructors, i.e. without junk, to deprecate
+# type and dimensionality specified, accepting dims as series of Ints
+Array{T,1}(m::Int) where {T} = Array{T,1}(junk, m)
+Array{T,2}(m::Int, n::Int) where {T} = Array{T,2}(junk, m, n)
+Array{T,3}(m::Int, n::Int, o::Int) where {T} = Array{T,3}(junk, m, n, o)
+Array{T,N}(d::Vararg{Int,N}) where {T,N} = Array{T,N}(junk, d)
+# type and dimensionality specified, accepting dims as tuples of Ints
+Array{T,N}(d::NTuple{N,Int}) where {T,N} = Array{T,N}(junk, d)
+# type but not dimensionality specified
+Array{T}(m::Int) where {T} = Array{T}(junk, m)
+Array{T}(m::Int, n::Int) where {T} = Array{T}(junk, m, n)
+Array{T}(m::Int, n::Int, o::Int) where {T} = Array{T}(junk, m, n, o)
+Array{T}(d::NTuple{N,Int}) where {T,N} = Array{T}(junk, d)
 
-Array{T,1}() where {T} = Array{T,1}(0)
 
 # primitive Symbol constructors
 function Symbol(s::String)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -130,17 +130,37 @@ include("abstractarray.jl")
 include("subarray.jl")
 include("reinterpretarray.jl")
 
-# Array convenience converting constructors
+
+# ## dims-type-converting Array constructors for convenience
+# type and dimensionality specified, accepting dims as series of Integers
+Vector{T}(::typeof(junk), m::Integer) where {T} = Vector{T}(junk, Int(m))
+Matrix{T}(::typeof(junk), m::Integer, n::Integer) where {T} = Matrix{T}(junk, Int(m), Int(n))
+# type but not dimensionality specified, accepting dims as series of Integers
+Array{T}(::typeof(junk), m::Integer) where {T} = Array{T,1}(junk, Int(m))
+Array{T}(::typeof(junk), m::Integer, n::Integer) where {T} = Array{T,2}(junk, Int(m), Int(n))
+Array{T}(::typeof(junk), m::Integer, n::Integer, o::Integer) where {T} = Array{T,3}(junk, Int(m), Int(n), Int(o))
+Array{T}(::typeof(junk), d::Integer...) where {T} = Array{T}(junk, convert(Tuple{Vararg{Int}}, d))
+# dimensionality but not type specified, accepting dims as series of Integers
+Vector(::typeof(junk), m::Integer) = Vector{Any}(junk, Int(m))
+Matrix(::typeof(junk), m::Integer, n::Integer) = Matrix{Any}(junk, Int(m), Int(n))
+# empty vector constructor
+Vector() = Vector{Any}(junk, 0)
+
+## preexisting dims-type-converting Array constructors for convenience, i.e. without junk, to deprecate
+# type and dimensionality specified, accepting dims as series of Integers
+Vector{T}(m::Integer) where {T} = Vector{T}(Int(m))
+Matrix{T}(m::Integer, n::Integer) where {T} = Matrix{T}(Int(m), Int(n))
+# type but not dimensionality specified, accepting dims as series of Integers
 Array{T}(m::Integer) where {T} = Array{T,1}(Int(m))
 Array{T}(m::Integer, n::Integer) where {T} = Array{T,2}(Int(m), Int(n))
 Array{T}(m::Integer, n::Integer, o::Integer) where {T} = Array{T,3}(Int(m), Int(n), Int(o))
 Array{T}(d::Integer...) where {T} = Array{T}(convert(Tuple{Vararg{Int}}, d))
-
-Vector() = Array{Any,1}(0)
-Vector{T}(m::Integer) where {T} = Array{T,1}(Int(m))
-Vector(m::Integer) = Array{Any,1}(Int(m))
-Matrix{T}(m::Integer, n::Integer) where {T} = Matrix{T}(Int(m), Int(n))
+# dimensionality but not type specified, accepting dims as series of Integers
+Vector(m::Integer) = Vector{Any}(Int(m))
 Matrix(m::Integer, n::Integer) = Matrix{Any}(Int(m), Int(n))
+# empty vector constructor
+Vector() = Vector{Any}(0)
+
 
 # numeric operations
 include("hashing.jl")

--- a/test/core.jl
+++ b/test/core.jl
@@ -4481,7 +4481,8 @@ end
 B14878(ng) = B14878()
 function trigger14878()
     w = A14878()
-    w.ext[:14878] = B14878(junk)  # junk not defined!
+    # w.ext[:14878] = B14878(junk)  # junk not defined!
+    w.ext[:14878] = B14878(otherjunk)  # junk got defined!
     return w
 end
 @test_throws UndefVarError trigger14878()


### PR DESCRIPTION
Per triage, base needs more `junk`. This pull request adds some `junk`. Specifically, this pull request explores https://github.com/JuliaLang/julia/issues/11557#issuecomment-339776065 / https://github.com/JuliaLang/julia/issues/16029#issuecomment-339787801 by replacing the existing primitive `Array` constructors with `junk` equivalents, e.g. `Array{T,N}(d::Vararg{Int,N})` -> `Array{T,N}(junk, d::Vararg{Int,N})`, and reimplementing the existing constructors in terms of those `junk` equivalents. The next step would be deprecating the existing constructors in favor of those `junk` equivalents. Best!