### PR TITLE
WIP: Pkg3-style package loading

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -264,14 +264,14 @@ end
 Force reloading of a package, even if it has been loaded before. This is intended for use
 during package development as code is modified.
 """
-function reload(name::AbstractString)
+function reload(from::Module, name::AbstractString)
     if contains(name, Filesystem.path_separator) || contains(name, ".")
         # for reload("path/file.jl") just ask for include instead
         error("use `include` instead of `reload` to load source files")
     else
         # reload("Package") is ok
         unreference_module(Symbol(name))
-        require(Symbol(name))
+        require(from, Symbol(name))
     end
 end
 
@@ -299,6 +299,7 @@ Windows.
 """
 function require(from::Module, mod::Symbol)
     if !root_module_exists(mod)
+        info("@$(getpid()): require($from, $mod)")
         _require(from, mod)
         # After successfully loading, notify downstream consumers
         if toplevel_load[] && myid() == 1 && nprocs() > 1

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -467,8 +467,8 @@ unshift!(Base._included_files, (@__MODULE__, joinpath(@__DIR__, "sysimg.jl")))
 Base.init_load_path(ccall(:jl_get_julia_home, Any, ()))
 
 # load some stdlib packages but don't put their names in Main
-Base.require(:DelimitedFiles)
-Base.require(:Test)
+Base.require(Base, :DelimitedFiles)
+Base.require(Base, :Test)
 
 empty!(LOAD_PATH)
 

--- a/src/dump.c
+++ b/src/dump.c
@@ -1921,7 +1921,7 @@ static int size_isgreater(const void *a, const void *b)
     return *(size_t*)b - *(size_t*)a;
 }
 
-static jl_value_t *read_verify_mod_list(ios_t *s, arraylist_t *dependent_worlds)
+static jl_value_t *read_verify_mod_list(jl_module_t *from, ios_t *s, arraylist_t *dependent_worlds)
 {
     if (!jl_main_module->uuid) {
         return jl_get_exceptionf(jl_errorexception_type,
@@ -1944,9 +1944,9 @@ static jl_value_t *read_verify_mod_list(ios_t *s, arraylist_t *dependent_worlds)
         static jl_value_t *require_func = NULL;
         if (!require_func)
             require_func = jl_get_global(jl_base_module, jl_symbol("require"));
-        jl_value_t *reqargs[2] = {require_func, (jl_value_t*)sym};
+        jl_value_t *reqargs[3] = {require_func, (jl_value_t*)from, (jl_value_t*)sym};
         JL_TRY {
-            m = (jl_module_t*)jl_apply(reqargs, 2);
+            m = (jl_module_t*)jl_apply(reqargs, 3);
         }
         JL_CATCH {
             ios_close(s);
@@ -2655,7 +2655,7 @@ static int trace_method(jl_typemap_entry_t *entry, void *closure)
     return 1;
 }
 
-static jl_value_t *_jl_restore_incremental(ios_t *f)
+static jl_value_t *_jl_restore_incremental(jl_module_t *from, ios_t *f)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (ios_eof(f) || !jl_read_verify_header(f)) {
@@ -2678,7 +2678,7 @@ static jl_value_t *_jl_restore_incremental(ios_t *f)
     arraylist_new(&dependent_worlds, 0);
 
     // verify that the system state is valid
-    jl_value_t *verify_result = read_verify_mod_list(f, &dependent_worlds);
+    jl_value_t *verify_result = read_verify_mod_list(from, f, &dependent_worlds);
     if (!jl_is_array(verify_result)) {
         arraylist_free(&dependent_worlds);
         ios_close(f);
@@ -2747,21 +2747,21 @@ static jl_value_t *_jl_restore_incremental(ios_t *f)
     return (jl_value_t*)restored;
 }
 
-JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz)
+JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(jl_module_t *from, const char *buf, size_t sz)
 {
     ios_t f;
     ios_static_buffer(&f, (char*)buf, sz);
-    return _jl_restore_incremental(&f);
+    return _jl_restore_incremental(from, &f);
 }
 
-JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname)
+JL_DLLEXPORT jl_value_t *jl_restore_incremental(jl_module_t *from, const char *fname)
 {
     ios_t f;
     if (ios_file(&f, fname, 1, 0, 0, 0) == NULL) {
         return jl_get_exceptionf(jl_errorexception_type,
             "Cache file \"%s\" not found.\n", fname);
     }
-    return _jl_restore_incremental(&f);
+    return _jl_restore_incremental(from, &f);
 }
 
 // --- init ---

--- a/src/julia.h
+++ b/src/julia.h
@@ -1356,8 +1356,8 @@ JL_DLLEXPORT void jl_save_system_image(const char *fname);
 JL_DLLEXPORT void jl_restore_system_image(const char *fname);
 JL_DLLEXPORT void jl_restore_system_image_data(const char *buf, size_t len);
 JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist);
-JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname);
-JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz);
+JL_DLLEXPORT jl_value_t *jl_restore_incremental(jl_module_t *from, const char *fname);
+JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(jl_module_t *from, const char *buf, size_t sz);
 
 // front end interface
 JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len,

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -150,14 +150,14 @@ try
     @test __precompile__(true) === nothing
 
     # Issue #21307
-    Base.require(Foo2_module)
+    Base.require(Main, Foo2_module)
     @eval let Foo2_module = $(QuoteNode(Foo2_module)), # use @eval to see the results of loading the compile
               Foo = root_module(Foo2_module)
         Foo.override(::Int) = 'a'
         Foo.override(::Float32) = 'b'
     end
 
-    Base.require(Foo_module)
+    Base.require(Main, Foo_module)
 
     @eval let Foo_module = $(QuoteNode(Foo_module)), # use @eval to see the results of loading the compile
               Foo = root_module(Foo_module)
@@ -175,7 +175,7 @@ try
     # use _require_from_serialized to ensure that the test fails if
     # the module doesn't reload from the image:
     @test_warn "WARNING: replacing module $Foo_module." begin
-        ms = Base._require_from_serialized(Foo_module, cachefile)
+        ms = Base._require_from_serialized(Main, Foo_module, cachefile)
         @test isa(ms, Array{Any,1})
         Base.register_all(ms)
     end
@@ -319,7 +319,7 @@ try
     fb_uuid1 = Base.module_uuid(FooBar1)
     @test fb_uuid != fb_uuid1
 
-    reload("FooBar")
+    reload(Main, "FooBar")
     @test fb_uuid != Base.module_uuid(root_module(:FooBar))
     @test fb_uuid1 == Base.module_uuid(FooBar1)
     fb_uuid = Base.module_uuid(root_module(:FooBar))
@@ -328,7 +328,7 @@ try
     @test !Base.stale_cachefile(FooBar1_file, joinpath(dir2, "FooBar1.ji"))
     @test !Base.stale_cachefile(FooBar_file, joinpath(dir2, "FooBar.ji"))
 
-    reload("FooBar1")
+    reload(Main, "FooBar1")
     @test fb_uuid == Base.module_uuid(root_module(:FooBar))
     @test fb_uuid1 != Base.module_uuid(root_module(:FooBar1))
 
@@ -354,7 +354,7 @@ try
           end
           """)
     @test_warn "ERROR: LoadError: break me\nStacktrace:\n [1] error" try
-        Base.require(:FooBar2)
+        Base.require(Main, :FooBar2)
         error("\"LoadError: break me\" test failed")
     catch exc
         isa(exc, ErrorException) || rethrow(exc)
@@ -394,7 +394,7 @@ try
           """)
     rm(FooBarT_file)
     @test Base.stale_cachefile(FooBarT2_file, joinpath(dir2, "FooBarT2.ji"))
-    @test Base.require(:FooBarT2) isa Module
+    @test Base.require(Main, :FooBarT2) isa Module
 finally
     splice!(Base.LOAD_CACHE_PATH, 1:2)
     splice!(LOAD_PATH, 1)
@@ -527,7 +527,7 @@ let dir = mktempdir()
               """)
         Base.compilecache("$(Test2_module)")
         @test !Base.isbindingresolved(Main, Test2_module)
-        Base.require(Test2_module)
+        Base.require(Main, Test2_module)
         @test take!(loaded_modules) == Test1_module
         @test take!(loaded_modules) == Test2_module
         write(joinpath(dir, "$(Test3_module).jl"),
@@ -536,7 +536,7 @@ let dir = mktempdir()
                   using $(Test3_module)
               end
               """)
-        Base.require(Test3_module)
+        Base.require(Main, Test3_module)
         @test take!(loaded_modules) == Test3_module
     finally
         pop!(Base.package_callbacks)
@@ -554,7 +554,7 @@ let module_name = string("a",randstring())
         touch(file_name)
         code = """module $(module_name)\nend\n"""
         write(file_name, code)
-        reload(module_name)
+        reload(Main, module_name)
         @test isa(root_module(Symbol(module_name)), Module)
         @test shift!(LOAD_PATH) == path
         rm(file_name)


### PR DESCRIPTION
The first step here is to thread a `from` module through all require-related calls so that we can look up the name of the module to be loaded in the context of the module into which it's being loaded. Each module will have a map from package names to UUIDs/paths which indicate the identity of each dependency it loads.