### PR TITLE
fix soundness of inferred typevar bounds

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -623,7 +623,9 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
             jl_value_t *oldval = e->envout[e->envidx];
             // if we try to assign different variable values (due to checking
             // multiple union members), consider the value unknown.
-            if (!oldval || !jl_is_typevar(oldval) || !jl_is_long(val))
+            if (oldval && !jl_egal(oldval, val))
+                e->envout[e->envidx] = (jl_value_t*)u->var;
+            else
                 e->envout[e->envidx] = fix_inferred_var_bound(u->var, val);
             // TODO: substitute the value (if any) of this variable into previous envout entries
         }

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1274,3 +1274,18 @@ let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     @test opt.min_valid === Core.Inference.min_world(opt.linfo) > 2
     @test opt.nargs == 3
 end
+
+# approximate static parameters due to unions
+let T1 = Array{Float64}, T2 = Array{_1,2} where _1
+    inference_test_copy(a::T) where {T<:Array} = ccall(:jl_array_copy, Ref{T}, (Any,), a)
+    rt = Base.return_types(inference_test_copy, (Union{T1,T2},))[1]
+    @test rt >: T1 && rt >: T2
+
+    el(x::T) where {T} = eltype(T)
+    rt = Base.return_types(el, (Union{T1,Array{Float32,2}},))[1]
+    @test rt >: Union{Type{Float64}, Type{Float32}}
+
+    g(x::Ref{T}) where {T} = T
+    rt = Base.return_types(g, (Union{Ref{Array{Float64}}, Ref{Array{Float32}}},))[1]
+    @test rt >: Union{Type{Array{Float64}}, Type{Array{Float32}}}
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1254,3 +1254,8 @@ for it = 1:5
 end
 
 @test round.(x_24305, 2) == [1.78, 1.42, 1.24]
+
+# PR #24399
+let (t, e) = intersection_env(Tuple{Union{Int,Int8}}, Tuple{T} where T)
+    @test e[1] isa TypeVar
+end


### PR DESCRIPTION
Extracted from #24399. This makes sure that inferred static parameter values always encompass all possible types no matter what signature we throw at matching_methods.

There's a comment in the code that indicates I tried to fix this before, but the code doesn't really seem to do what the comment describes. This change matches the comment much better.