### PR TITLE
Add a means of skipping CI on Circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,56 +15,68 @@ jobs:
           JULIA_TEST_MAXRSS_MB: 800
           ARCH: i686
     steps: &steps
-      - run: | # install build dependencies
-          sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
-            time ccache bar &&
-          for prog in gcc g++ gfortran; do
-            sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
-          done
+      - run:
+          name: Install build dependencies
+          command: |
+            sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
+              time ccache bar
+            for prog in gcc g++ gfortran; do
+              sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
+            done
       - checkout # circle ci code checkout step
 # (FIXME: need to unset url."ssh://git@github.com".insteadOf or libgit2 tests fail)
-      - run: | # checkout merge commit, set versioning info and Make.user variables
-          git config --global --unset url."ssh://git@github.com".insteadOf &&
-          if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-            git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge &&
-            git checkout -qf FETCH_HEAD;
-          fi &&
-          make -C base version_git.jl.phony &&
-          echo "override ARCH = $ARCH" | tee -a Make.user &&
-          for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
-            echo "override $var = 1" | tee -a Make.user;
-          done &&
-          echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
+      - run:
+          name: Checkout merge commit, set versioning info and Make.user variables
+          command: |
+            git config --global --unset url."ssh://git@github.com".insteadOf
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge
+              git checkout -qf FETCH_HEAD;
+            fi
+            make -C base version_git.jl.phony
+            echo "override ARCH = $ARCH" | tee -a Make.user
+            for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
+              echo "override $var = 1" | tee -a Make.user;
+            done
+            echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
       - restore_cache: # silly to take a checksum of the tag file here instead of
           keys: # its contents but this is the only thing that works on circle
             - ccache-{{ checksum "/tmp/weeknumber" }}
-      - run: | # compile julia deps
-          contrib/download_cmake.sh &&
-          make -j8 -C deps || make
-      - run: | # build julia, output ccache stats when done
-          make -j8 all &&
-          make prefix=/tmp/julia install &&
-          ccache -s &&
-          make build-stats
-      - run: | # move source tree out of the way, run tests from install tree
-          cd .. &&
-          mv project julia-src &&
-          /tmp/julia/bin/julia -e 'versioninfo()' &&
-          /tmp/julia/bin/julia --sysimage-native-code=no -e 'true' &&
-          /tmp/julia/bin/julia-debug --sysimage-native-code=no -e 'true' &&
-          pushd /tmp/julia/share/julia/test &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30 &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg &&
-          popd &&
-          mkdir /tmp/embedding-test &&
-          make check -C /tmp/julia/share/doc/julia/examples/embedding \
-            JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
-            "$(cd julia-src && make print-CC)" &&
-          mv julia-src project
-#      - run: cd project && make -C doc deploy
-#       - run:
-#           command: sudo dmesg
-#           when: on_fail
+      - run:
+          name: Compile Julia dependencies
+          command: |
+            contrib/download_cmake.sh
+            make -j8 -C deps || make
+      - run:
+          name: Build Julia, output ccache stats when done
+          command: |
+            make -j8 all
+            make prefix=/tmp/julia install
+            ccache -s
+            make build-stats
+      - run:
+          name: Move source tree out of the way, run tests from install tree
+          command: |
+            cd ..
+            mv project julia-src
+            /tmp/julia/bin/julia -e 'versioninfo()'
+            /tmp/julia/bin/julia --sysimage-native-code=no -e 'true'
+            /tmp/julia/bin/julia-debug --sysimage-native-code=no -e 'true'
+            pushd /tmp/julia/share/julia/test
+            /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30
+            /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg
+            popd
+            mkdir /tmp/embedding-test
+            make check -C /tmp/julia/share/doc/julia/examples/embedding \
+              JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
+              "$(cd julia-src && make print-CC)"
+            mv julia-src project
+#     - run:
+#         name: Deploy documentation
+#         command: cd project && make -C doc deploy
+#     - run:
+#         command: sudo dmesg
+#         when: on_fail
       - save_cache:
           key: ccache-{{ checksum "/tmp/weeknumber" }}
           paths:

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,17 @@ jobs:
               sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
             done
       - checkout # circle ci code checkout step
+      - run:
+          name: Check for a request to skip CI
+          command: |
+            msg="$(git rev-list --format=%B --max-count=1 $CIRCLE_SHA1)"
+            # [ci skip] was recognized in Circle 1.0 but not in 2.0
+            # Here we're also adding [circle skip], which is non-standard
+            if [[ $msg == *"[ci skip]"* ]] || [[ $msg == *"[skip ci]"* ]] || \
+               [[ $msg == *"[circle skip]"* ]] || [[ $msg == *"[skip circle]"* ]]; then
+              echo "User requested to skip CI, failing early"
+              exit 1
+            fi
 # (FIXME: need to unset url."ssh://git@github.com".insteadOf or libgit2 tests fail)
       - run:
           name: Checkout merge commit, set versioning info and Make.user variables


### PR DESCRIPTION
This PR has two distinct commits:

1. Add a `name` attribute to most of the steps that run on Circle. This improves readability. To see the exact command, one need only expand the step in the Circle web UI. Further, remove unnecessary `&&`s in the commands. These are presumably there to ensure that each step stops on the first encountered failure, but Circle steps run in `/bin/bash -eo pipefail`, so this is unnecessary. This also improves readability.

2. Add recognition for the standard `[ci skip]` and `[skip ci]` available from Travis, AppVeyor, and our custom FreeBSD CI. While this doesn't avoid running the build at all like it does with the other services, it does stop it early, before building Julia and running the tests. This should free up Circle workers for other PRs. Also add `[circle skip]` and `[skip circle]` akin to that available by AppVeyor and our FreeBSD CI.

For ease of review it might help to view the diffs of the two commits separately.

I can remove the first commit if it's for some reason controversial, but I really think it would be helpful for improving readability both in the web UI and in simply reading the YAML config.