### PR TITLE
deprecate eye(::Type{Diagonal{T}}, n), introduce Diagonal[{T}](s::UniformScaling, n)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -305,6 +305,9 @@ Library improvements
 
   * The `crc32c` function for CRC-32c checksums is now exported ([#22274]).
 
+  * `eye(::Type{Diagonal{T}}, m::Integer)` has been deprecated in favor of
+    `Diagonal{T}(I, m)` ([#24413]).
+
   * The output of `versioninfo` is now controlled with keyword arguments ([#21974]).
 
   * The function `LibGit2.set_remote_url` now always sets both the fetch and push URLs for a

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1786,6 +1786,8 @@ end
     @deprecate get_creds!(cache::CachedCredentials, credid, default) get!(cache, credid, default)
 end
 
+@deprecate eye(::Type{Diagonal{T}}, n::Int) where {T} Diagonal{T}(I, n)
+
 export tic, toq, toc
 function tic()
     depwarn("tic() is deprecated, use @time, @elapsed, or calls to time_ns() instead.", :tic)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -341,8 +341,6 @@ function logdet(D::Diagonal{<:Complex}) # make sure branch cut is correct
     z = sum(log, D.diag)
     complex(real(z), rem2pi(imag(z), RoundNearest))
 end
-# identity matrices via eye(Diagonal{type},n)
-eye(::Type{Diagonal{T}}, n::Int) where {T} = Diagonal(ones(T,n))
 
 # Matrix functions
 for f in (:exp, :log, :sqrt,

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -381,3 +381,7 @@ Matrix(s::UniformScaling, dims::Dims{2}) = Matrix{eltype(s)}(s, dims)
 # convenience variations that accept a single integer to specify dims
 Matrix{T}(s::UniformScaling, m::Integer) where {T} = Matrix{T}(s, m, m)
 Matrix(s::UniformScaling, m::Integer) = Matrix(s, m, m)
+
+## Diagonal construction from UniformScaling
+Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))
+Diagonal(s::UniformScaling, m::Integer) = Diagonal{eltype(s)}(s, m)

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -29,7 +29,6 @@ srand(1)
     end
 
     @testset "Basic properties" begin
-        @test eye(Diagonal{elty},n) == Diagonal(ones(elty,n))
         @test_throws ArgumentError size(D,0)
         @test typeof(convert(Diagonal{Complex64},D)) <: Diagonal{Complex64}
         @test typeof(convert(AbstractMatrix{Complex64},D)) <: Diagonal{Complex64}

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -201,6 +201,13 @@ end
     @test Matrix{Float64}(2I, 3, 3)::Matrix{Float64} == 2*eye(3)
 end
 
+@testset "Diagonal construction from UniformScaling" begin
+    @test Diagonal(2I, 3)::Diagonal{Int} == 2*eye(3)
+    @test Diagonal(2.0I, 3)::Diagonal{Float64} == 2*eye(3)
+    @test Diagonal{Real}(2I, 3)::Diagonal{Real} == 2*eye(3)
+    @test Diagonal{Float64}(2I, 3)::Diagonal{Float64} == 2*eye(3)
+end
+
 @testset "equality comparison of matrices with UniformScaling" begin
     # AbstractMatrix methods
     diagI = Diagonal(fill(1, 3))


### PR DESCRIPTION
This pull request first provides `Diagonal[{T}](s::UniformScaling, n)` constructors as in JuliaLang/julia#24372, and then deprecates `eye(::Type{Diagonal{T}}, n)` in favor of those constructors. (That `eye` method is the sole `eye` method in base that accepts a container type as argument.) Ref. https://github.com/JuliaLang/julia/issues/11557#issuecomment-339776065 and https://github.com/JuliaLang/LinearAlgebra.jl/issues/454. Best!