### PR TITLE
make default value of `rev` keyword argument type stable

### DIFF
--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -64,12 +64,16 @@ ordtype(o::Perm,            vs::AbstractArray) = ordtype(o.order, o.data)
 ordtype(o::By,              vs::AbstractArray) = try typeof(o.by(vs[1])) catch; Any end
 ordtype(o::Ordering,        vs::AbstractArray) = eltype(vs)
 
+_ord(lt::typeof(isless), by::typeof(identity), order::Ordering) = order
+_ord(lt::typeof(isless), by,                   order::Ordering) = By(by)
+_ord(lt,                 by::typeof(identity), order::Ordering) = Lt(lt)
+_ord(lt,                 by,                   order::Ordering) = Lt((x,y)->lt(by(x),by(y)))
+
+ord(lt, by, rev::Void, order::Ordering=Forward) = _ord(lt, by, order)
+
 function ord(lt, by, rev::Bool, order::Ordering=Forward)
-    o = (lt===isless) & (by===identity) ? order  :
-        (lt===isless) & (by!==identity) ? By(by) :
-        (lt!==isless) & (by===identity) ? Lt(lt) :
-                                          Lt((x,y)->lt(by(x),by(y)))
-    rev ? ReverseOrdering(o) : o
+    o = _ord(lt, by, order)
+    return rev ? ReverseOrdering(o) : o
 end
 
 end

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -79,7 +79,7 @@ true
 ```
 """
 issorted(itr;
-    lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
+    lt=isless, by=identity, rev::Union{Bool,Void}=nothing, order::Ordering=Forward) =
     issorted(itr, ord(lt,by,rev,order))
 
 function partialsort!(v::AbstractVector, k::Union{Int,OrdinalRange}, o::Ordering)
@@ -140,7 +140,7 @@ julia> a
 ```
 """
 partialsort!(v::AbstractVector, k::Union{Int,OrdinalRange};
-             lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
+             lt=isless, by=identity, rev::Union{Bool,Void}=nothing, order::Ordering=Forward) =
     partialsort!(v, k, ord(lt,by,rev,order))
 
 """
@@ -272,9 +272,8 @@ for s in [:searchsortedfirst, :searchsortedlast, :searchsorted]
     @eval begin
         $s(v::AbstractVector, x, o::Ordering) = (inds = indices(v, 1); $s(v,x,first(inds),last(inds),o))
         $s(v::AbstractVector, x;
-           lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward) =
+           lt=isless, by=identity, rev::Union{Bool,Void}=nothing, order::Ordering=Forward) =
             $s(v,x,ord(lt,by,rev,order))
-        $s(v::AbstractVector, x) = $s(v, x, Forward)
     end
 end
 
@@ -604,7 +603,7 @@ function sort!(v::AbstractVector;
                alg::Algorithm=defalg(v),
                lt=isless,
                by=identity,
-               rev::Bool=false,
+               rev::Union{Bool,Void}=nothing,
                order::Ordering=Forward)
     ordr = ord(lt,by,rev,order)
     if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
@@ -695,7 +694,7 @@ function partialsortperm!(ix::AbstractVector{<:Integer}, v::AbstractVector,
                           k::Union{Int, OrdinalRange};
                           lt::Function=isless,
                           by::Function=identity,
-                          rev::Bool=false,
+                          rev::Union{Bool,Void}=nothing,
                           order::Ordering=Forward,
                           initialized::Bool=false)
     if !initialized
@@ -746,7 +745,7 @@ function sortperm(v::AbstractVector;
                   alg::Algorithm=DEFAULT_UNSTABLE,
                   lt=isless,
                   by=identity,
-                  rev::Bool=false,
+                  rev::Union{Bool,Void}=nothing,
                   order::Ordering=Forward)
     ordr = ord(lt,by,rev,order)
     if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
@@ -795,7 +794,7 @@ function sortperm!(x::AbstractVector{<:Integer}, v::AbstractVector;
                    alg::Algorithm=DEFAULT_UNSTABLE,
                    lt=isless,
                    by=identity,
-                   rev::Bool=false,
+                   rev::Union{Bool,Void}=nothing,
                    order::Ordering=Forward,
                    initialized::Bool=false)
     if indices(x,1) != indices(v,1)
@@ -862,7 +861,7 @@ function sort(A::AbstractArray, dim::Integer;
               alg::Algorithm=DEFAULT_UNSTABLE,
               lt=isless,
               by=identity,
-              rev::Bool=false,
+              rev::Union{Bool,Void}=nothing,
               order::Ordering=Forward,
               initialized::Bool=false)
     order = ord(lt,by,rev,order)


### PR DESCRIPTION
This lets us remove the method overwrite during sysimg build, and allows us to fix #9498. There's no user-visible change except that `rev=nothing` will now work (though it's undocumented), which seems harmless enough to me. We can easily remove this later if constant propagation permits.