### PR TITLE
Make next behave like nextind for String

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -231,12 +231,22 @@ end
     end
     trailing = utf8_trailing[b + 1]
     if l < i + trailing
-        return '\ufffd', i+1
+        for j in (i+1):l
+            @inbounds if !is_valid_continuation(codeunit(s, j))
+                return '\ufffd' j
+            end
+        end
+        return '\ufffd', l+1
     end
-    c::UInt32 = 0
-    @inbounds for j = 1:(trailing + 1)
+    @inbounds c::UInt32 = codeunit(s, i)
+    i += 1
+    @inbounds for j = 1:trailing
+        b = codeunit(s, i)
+        if !is_valid_continuation(b)
+            return '\ufffd', i
+        end
         c <<= 6
-        c += codeunit(s, i)
+        c += b
         i += 1
     end
     c -= utf8_offset[trailing + 1]

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -198,10 +198,24 @@ end
     @test lcfirst("")==""
     @test lcfirst("*")=="*"
 end
+
+# test next for invalid UTF-8 AbstractStrings
+@testset "next for invalid UTF-8" begin
+    srand(1)
+    let s = "1"*String(rand(0x00:0xff, 2^16)), i = 1, j = 1
+        while !done(s, i)
+            c, i = next(s, i)
+            j = nextind(s, j)
+            @test i == j
+        end
+    end
+end
+
 # test AbstractString functions at beginning of string.jl
 struct tstStringType <: AbstractString
     data::Array{UInt8,1}
 end
+
 @testset "AbstractString functions" begin
     tstr = tstStringType(Vector{UInt8}("12"))
     @test_throws ErrorException endof(tstr)


### PR DESCRIPTION
Here is an example implementation of https://github.com/JuliaLang/julia/issues/24420 so that we can have a look what overhead it creates. Basically it adds one `is_valid_continuation` check at each iteration.