### PR TITLE
add an enum type for jlcall_api

### DIFF
--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -48,7 +48,7 @@ jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint
 void jl_generate_fptr(jl_method_instance_t *li)
 {
     li->fptr = (jl_fptr_t)&jl_interpret_call;
-    li->jlcall_api = 4;
+    li->jlcall_api = JL_API_INTERPRETED;
 }
 
 JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION(void)

--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -384,7 +384,7 @@ public:
                 const char *F = linfo->functionObjectsDecls.functionObject;
                 if (!linfo->fptr && F && sName.equals(F)) {
                     int jlcall_api = jl_jlcall_api(F);
-                    if (linfo->inferred || jlcall_api != 1) {
+                    if (linfo->inferred || jlcall_api != JL_API_GENERIC) {
                         linfo->jlcall_api = jlcall_api;
                         linfo->fptr = (jl_fptr_t)(uintptr_t)Addr;
                     }

--- a/src/dump.c
+++ b/src/dump.c
@@ -720,7 +720,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
                 backedges = NULL;
         }
         jl_serialize_value(s, (jl_value_t*)backedges);
-        write_uint8(s->s, li->jlcall_api == 2 ? 2 : 0);
+        write_uint8(s->s, li->jlcall_api == JL_API_CONST ? JL_API_CONST : 0);
     }
     else if (jl_typeis(v, jl_module_type)) {
         jl_serialize_module(s, (jl_module_t*)v);

--- a/src/gf.c
+++ b/src/gf.c
@@ -208,7 +208,7 @@ void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr)
     }
     jl_method_instance_t *li = jl_new_method_instance_uninit();
     li->fptr = fptr;
-    li->jlcall_api = 1;
+    li->jlcall_api = JL_API_GENERIC;
     li->specTypes = (jl_value_t*)jl_anytuple_type;
     li->min_world = 1;
     li->max_world = ~(size_t)0;
@@ -412,7 +412,7 @@ JL_DLLEXPORT jl_method_instance_t* jl_set_method_inferred(
     jl_gc_wb(li, inferred);
     if (const_flags & 1) {
         assert(const_flags & 2);
-        li->jlcall_api = 2;
+        li->jlcall_api = JL_API_CONST;
     }
     if (const_flags & 2) {
         li->inferred_const = inferred_const;
@@ -1653,14 +1653,14 @@ JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int
 jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **pli, size_t world)
 {
     jl_method_instance_t *li = *pli;
-    if (li->jlcall_api == 2)
+    if (li->jlcall_api == JL_API_CONST)
         return li->functionObjectsDecls;
     if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF ||
         jl_options.compile_enabled == JL_OPTIONS_COMPILE_MIN) {
         // copy fptr from the template method definition
         jl_method_t *def = li->def.method;
         if (jl_is_method(def) && def->unspecialized) {
-            if (def->unspecialized->jlcall_api == 2) {
+            if (def->unspecialized->jlcall_api == JL_API_CONST) {
                 li->functionObjectsDecls.functionObject = NULL;
                 li->functionObjectsDecls.specFunctionObject = NULL;
                 li->inferred = def->unspecialized->inferred;
@@ -1668,7 +1668,7 @@ jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **pli, size_t w
                 li->inferred_const = def->unspecialized->inferred_const;
                 if (li->inferred_const)
                     jl_gc_wb(li, li->inferred_const);
-                li->jlcall_api = 2;
+                li->jlcall_api = JL_API_CONST;
                 return li->functionObjectsDecls;
             }
             if (def->unspecialized->fptr) {
@@ -1686,7 +1686,7 @@ jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **pli, size_t w
         }
     }
     jl_llvm_functions_t decls = li->functionObjectsDecls;
-    if (decls.functionObject != NULL || li->jlcall_api == 2)
+    if (decls.functionObject != NULL || li->jlcall_api == JL_API_CONST)
         return decls;
 
     jl_code_info_t *src = NULL;
@@ -1699,7 +1699,7 @@ jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **pli, size_t w
     }
     // check again, because jl_type_infer may have changed li or compiled it
     decls = li->functionObjectsDecls;
-    if (decls.functionObject != NULL || li->jlcall_api == 2)
+    if (decls.functionObject != NULL || li->jlcall_api == JL_API_CONST)
         return decls;
     return jl_compile_linfo(&li, src, world, &jl_default_cgparams);
 }
@@ -1764,7 +1764,7 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
     jl_code_info_t *src = NULL;
     if (!jl_is_rettype_inferred(li))
         src = jl_type_infer(&li, world, 0);
-    if (li->jlcall_api != 2) {
+    if (li->jlcall_api != JL_API_CONST) {
         if (jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc) {
             // If we are saving LLVM or native code, generate the LLVM IR so that it'll
             // be included in the saved LLVM module.

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -636,7 +636,7 @@ static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s, int start,
 
 jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs)
 {
-    if (lam->jlcall_api == 2)
+    if (lam->jlcall_api == JL_API_CONST)
         return lam->inferred_const;
     jl_code_info_t *src = (jl_code_info_t*)lam->inferred;
     if (!src || (jl_value_t*)src == jl_nothing) {

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -243,7 +243,7 @@ static void _compile_all_deq(jl_array_t *found)
             jl_gc_wb(m, linfo);
         }
 
-        if (linfo->jlcall_api == 2)
+        if (linfo->jlcall_api == JL_API_CONST)
             continue;
         src = m->source;
         // TODO: the `unspecialized` field is not yet world-aware, so we can't store
@@ -251,7 +251,7 @@ static void _compile_all_deq(jl_array_t *found)
         //src = jl_type_infer(&linfo, jl_world_counter, 1);
         //m->unspecialized = linfo;
         //jl_gc_wb(m, linfo);
-        //if (linfo->jlcall_api == 2)
+        //if (linfo->jlcall_api == JL_API_CONST)
         //    continue;
 
         // first try to create leaf signatures from the signature declaration and compile those
@@ -272,7 +272,7 @@ static int compile_all_enq__(jl_typemap_entry_t *ml, void *env)
     if (m->source &&
         (!m->unspecialized ||
          (m->unspecialized->functionObjectsDecls.functionObject == NULL &&
-          m->unspecialized->jlcall_api != 2 &&
+          m->unspecialized->jlcall_api != JL_API_CONST &&
           m->unspecialized->fptr == NULL))) {
         // found a lambda that still needs to be compiled
         jl_array_ptr_1d_push(found, (jl_value_t*)ml);
@@ -309,7 +309,7 @@ static int precompile_enq_specialization_(jl_typemap_entry_t *l, void *closure)
 {
     if (jl_is_method_instance(l->func.value) &&
             l->func.linfo->functionObjectsDecls.functionObject == NULL &&
-            l->func.linfo->jlcall_api != 2)
+            l->func.linfo->jlcall_api != JL_API_CONST)
         jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)l->sig);
     return 1;
 }

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -648,7 +648,7 @@ static void jl_write_values(jl_serializer_state *s)
                 newm->unspecialized_ducttape = NULL;
                 if (jl_is_method(m->def.method)) {
                     uintptr_t fptr_id = jl_fptr_id((void*)(uintptr_t)m->fptr);
-                    if (m->jlcall_api == 2) {
+                    if (m->jlcall_api == JL_API_CONST) {
                     }
                     else if (fptr_id >= 2) {
                         //write_int8(s->s, -li->jlcall_api);
@@ -950,7 +950,7 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
             }
             else {
                 uintptr_t base = (uintptr_t)fvars.base;
-                assert(jl_is_method(li->def.method) && li->jlcall_api && li->jlcall_api != 2);
+                assert(jl_is_method(li->def.method) && li->jlcall_api && li->jlcall_api != JL_API_CONST);
                 linfos[i] = li;
                 int32_t offset = fvars.offsets[i];
                 for (; clone_idx < fvars.nclones; clone_idx++) {

--- a/src/threading.c
+++ b/src/threading.c
@@ -307,7 +307,7 @@ static jl_value_t *ti_run_fun(const jl_generic_fptr_t *fptr, jl_method_instance_
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     JL_TRY {
-        (void)jl_assume(fptr->jlcall_api != 2);
+        (void)jl_assume(fptr->jlcall_api != JL_API_CONST);
         jl_call_fptr_internal(fptr, mfunc, args, nargs);
     }
     JL_CATCH {


### PR DESCRIPTION
We could consider switching to `JL_ABI_` and `jlcall_abi` for these as well, but existing identifiers used `api` so I went with that for now.