### PR TITLE
make IOBuffer(array) writable by default

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -32,14 +32,14 @@ StringVector(n::Integer) = Vector{UInt8}(_string_n(n))
 # IOBuffers behave like Files. They are typically readable and writable. They are seekable. (They can be appendable).
 
 """
-    IOBuffer([data, ][readable::Bool=true, writable::Bool=false[, maxsize::Int=typemax(Int)]])
+    IOBuffer([data, ][readable::Bool=true, writable::Bool=true[, maxsize::Int=typemax(Int)]])
 
 Create an `IOBuffer`, which may optionally operate on a pre-existing array. If the
 readable/writable arguments are given, they restrict whether or not the buffer may be read
 from or written to respectively. The last argument optionally specifies a size beyond which
 the buffer may not be grown.
 """
-IOBuffer(data::AbstractVector{UInt8}, readable::Bool=true, writable::Bool=false, maxsize::Integer=typemax(Int)) =
+IOBuffer(data::AbstractVector{UInt8}, readable::Bool=true, writable::Bool=true, maxsize::Integer=typemax(Int)) =
     GenericIOBuffer(data, readable, writable, true, false, maxsize)
 function IOBuffer(readable::Bool, writable::Bool)
     b = IOBuffer(StringVector(32), readable, writable)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -191,8 +191,8 @@ julia> String(take!(io))
 "Haho"
 ```
 """
-IOBuffer(str::String) = IOBuffer(Vector{UInt8}(str))
-IOBuffer(s::SubString{String}) = IOBuffer(view(Vector{UInt8}(s.string), s.offset + 1 : s.offset + sizeof(s)))
+IOBuffer(str::String) = IOBuffer(Vector{UInt8}(str), true, false)
+IOBuffer(s::SubString{String}) = IOBuffer(view(Vector{UInt8}(s.string), s.offset + 1 : s.offset + sizeof(s)), true, false)
 
 # join is implemented using IO
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -296,7 +296,7 @@ end
 let
     # IOBuffer(array) is writable by default.
     buf = IOBuffer(UInt8[])
-    @test write(buf, b"foobar") == 3
+    @test write(buf, b"foobar") == 6
     # IOBuffer(string) is not writable.
     buf = IOBuffer("foo")
     @test_throws ArgumentError write(buf, b"foobar")

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -292,3 +292,12 @@ let
     io = IOBuffer(Int64(10))
     @test io isa IOBuffer
 end
+
+let
+    # IOBuffer(array) is writable by default.
+    buf = IOBuffer(UInt8[])
+    @test write(buf, b"foobar") == 3
+    # IOBuffer(string) is not writable.
+    buf = IOBuffer("foo")
+    @test_throws ArgumentError write(buf, b"foobar")
+end


### PR DESCRIPTION
`IOBuffer(UInt8[])` is not writable by default while `IOBuffer()` is. This looks inconsistent to me, and so I'd like to make `IOBuffer(array)` writable by default. `IOBuffer(string)` is kept as-is because making it writable may result in an expected behavior.