### PR TITLE
remove Matrix[{T}](s::UniformScaling, n::Integer) constructors

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -378,9 +378,6 @@ Matrix{T}(s::UniformScaling, dims::Dims{2}) where {T} = setindex!(zeros(T, dims)
 Matrix{T}(s::UniformScaling, m::Integer, n::Integer) where {T} = Matrix{T}(s, Dims((m, n)))
 Matrix(s::UniformScaling, m::Integer, n::Integer) = Matrix(s, Dims((m, n)))
 Matrix(s::UniformScaling, dims::Dims{2}) = Matrix{eltype(s)}(s, dims)
-# convenience variations that accept a single integer to specify dims
-Matrix{T}(s::UniformScaling, m::Integer) where {T} = Matrix{T}(s, m, m)
-Matrix(s::UniformScaling, m::Integer) = Matrix(s, m, m)
 
 ## Diagonal construction from UniformScaling
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -191,12 +191,10 @@ end
 end
 
 @testset "Matrix construction from UniformScaling" begin
-    @test Matrix(2I, 3)::Matrix{Int} == 2*eye(3)
     @test Matrix(2I, 3, 3)::Matrix{Int} == 2*eye(3)
     @test Matrix(2I, 3, 4)::Matrix{Int} == 2*eye(3, 4)
     @test Matrix(2I, 4, 3)::Matrix{Int} == 2*eye(4, 3)
     @test Matrix(2.0I, 3, 3)::Matrix{Float64} == 2*eye(3)
-    @test Matrix{Real}(2I, 3)::Matrix{Real} == 2*eye(3)
     @test Matrix{Real}(2I, 3, 3)::Matrix{Real} == 2*eye(3)
     @test Matrix{Float64}(2I, 3, 3)::Matrix{Float64} == 2*eye(3)
 end


### PR DESCRIPTION
Per triage, this pull request removes `Matrix[{T}](s::UniformScaling, n::Integer)` constructors. (No need for a deprecation as these constructor were introduced in this dev cycle.) Best!