### PR TITLE
deprecate sparse(s::UniformScaling, m::Integer) in favor of three-arg equivalent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -409,6 +409,9 @@ Deprecated or removed
   * `readcsv(io[, T::Type]; opts...)` has been deprecated in favor of
     `readdlm(io, ','[, T]; opts...)` ([#23530]).
 
+  * `sparse(s::UniformScaling, m::Integer)` has been deprecated in favor of the
+    three-argument equivalent `sparse(s::UniformScaling, m, n)` ([#24472]).
+
   * The `cholfact`/`cholfact!` methods that accepted an `uplo` symbol have been deprecated
     in favor of using `Hermitian` (or `Symmetric`) views ([#22187], [#22188]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1825,6 +1825,8 @@ function toc()
     return t
 end
 
+@eval Base.SparseArrays @deprecate sparse(s::UniformScaling, m::Integer) sparse(s, m, m)
+
 # A[I...] .= with scalar indices should modify the element at A[I...]
 function Broadcast.dotview(A::AbstractArray, args::Number...)
     depwarn("the behavior of `A[I...] .= X` with scalar indices will change in the future. Use `A[I...] = X` instead.", :broadcast!)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1530,7 +1530,7 @@ if not specified.
 multiple `α` of the identity matrix.
 """
 speye(::Type{T}, m::Integer, n::Integer) where {T} = SparseMatrixCSC{T}(UniformScaling(one(T)), Dims((m, n)))
-sparse(s::UniformScaling, m::Integer, n::Integer=m) = SparseMatrixCSC(s, Dims((m, n)))
+sparse(s::UniformScaling, m::Integer, n::Integer) = SparseMatrixCSC(s, Dims((m, n)))
 
 function one(S::SparseMatrixCSC{T}) where T
     m,n = size(S)

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -64,7 +64,7 @@ nn = 100
     end
 
     # Make sure that conversion to Sparse doesn't use SuiteSparse's symmetric flag
-    @test qrfact(sparse(one(eltyA)I, 5))\ones(eltyA, 5) == ones(5)
+    @test qrfact(sparse(one(eltyA)I, 5, 5))\ones(eltyA, 5) == ones(5)
 end
 
 @testset "basic solution of rank deficient ls" begin


### PR DESCRIPTION
Per triage, this pull request deprecates `sparse(s::UniformScaling, m::Integer)` in favor of the three-argument equivalent `sparse(s::UniformScaling, m::Integer, n::Integer)`. Best!