### PR TITLE
use interpreter when possible in `--compile=no` mode

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -81,8 +81,8 @@ function _depwarn(msg, opts, bt, caller)
     end
 end
 
-firstcaller(bt::Array{Ptr{Void},1}, funcsym::Symbol) = firstcaller(bt, (funcsym,))
-function firstcaller(bt::Array{Ptr{Void},1}, funcsyms)
+firstcaller(bt::Vector, funcsym::Symbol) = firstcaller(bt, (funcsym,))
+function firstcaller(bt::Vector, funcsyms)
     # Identify the calling line
     found = false
     lkup = StackTraces.UNKNOWN

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3692,7 +3692,8 @@ function finish(me::InferenceState)
             end
         end
 
-        if !already_inferred
+        # don't store inferred code if we've decided to interpret this function
+        if !already_inferred && me.linfo.jlcall_api != 4
             const_flags = (me.const_ret) << 1 | me.const_api
             if me.const_ret
                 if isa(me.bestguess, Const)

--- a/src/Makefile
+++ b/src/Makefile
@@ -87,6 +87,7 @@ PUBLIC_HEADERS += $(LIBUV_INC)/uv*
 endif
 PUBLIC_HEADER_TARGETS := $(addprefix $(build_includedir)/julia/,$(notdir $(PUBLIC_HEADERS)))
 
+ifeq ($(JULIACODEGEN),LLVM)
 # In LLVM < 3.4, --ldflags includes both options and libraries, so use it both before and after --libs
 # In LLVM >= 3.4, --ldflags has only options, and --system-libs has the libraries.
 ifneq ($(USE_LLVM_SHLIB),1)
@@ -95,6 +96,7 @@ else
 LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM
 FLAGS += -DLLVM_SHLIB
 endif # USE_LLVM_SHLIB == 1
+endif
 
 COMMON_LIBS := -L$(build_shlibdir) -L$(build_libdir) $(LIBUV) $(LIBUTF8PROC) $(NO_WHOLE_ARCHIVE) $(LLVMLINK) $(OSLIBS)
 DEBUG_LIBS := $(WHOLE_ARCHIVE) $(BUILDDIR)/flisp/libflisp-debug.a $(WHOLE_ARCHIVE) $(BUILDDIR)/support/libsupport-debug.a $(COMMON_LIBS)

--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -9,8 +9,7 @@ int globalUnique = 0;
 
 #define UNAVAILABLE { jl_errorf("%s: not available in this build of Julia", __func__); }
 
-void jl_dump_native(const char *bc_fname, const char *obj_fname, const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
-void jl_dump_objfile(char *fname, int jit_model, const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
+void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *sysimg_data, size_t sysimg_len) UNAVAILABLE
 int32_t jl_get_llvm_gv(jl_value_t *p) UNAVAILABLE
 void jl_write_malloc_log(void) UNAVAILABLE
 void jl_write_coverage_data(void) UNAVAILABLE
@@ -18,11 +17,13 @@ void jl_write_coverage_data(void) UNAVAILABLE
 JL_DLLEXPORT void jl_clear_malloc_data(void) UNAVAILABLE
 JL_DLLEXPORT void jl_extern_c(jl_function_t *f, jl_value_t *rt, jl_value_t *argt, char *name) UNAVAILABLE
 JL_DLLEXPORT void *jl_function_ptr(jl_function_t *f, jl_value_t *rt, jl_value_t *argt) UNAVAILABLE
-JL_DLLEXPORT const jl_value_t *jl_dump_function_asm(void *f, int raw_mc) UNAVAILABLE
+JL_DLLEXPORT const jl_value_t *jl_dump_function_asm(void *f, int raw_mc, const char* asm_variant) UNAVAILABLE
 JL_DLLEXPORT const jl_value_t *jl_dump_function_ir(void *f, uint8_t strip_ir_metadata, uint8_t dump_module) UNAVAILABLE
 
 JL_DLLEXPORT void *jl_LLVMCreateDisasm(const char *TripleName, void *DisInfo, int TagType, void *GetOpInfo, void *SymbolLookUp) UNAVAILABLE
 JL_DLLEXPORT size_t jl_LLVMDisasmInstruction(void *DC, uint8_t *Bytes, uint64_t BytesSize, uint64_t PC, char *OutString, size_t OutStringSize) UNAVAILABLE
+
+int32_t jl_assign_functionID(const char *fname) UNAVAILABLE
 
 void jl_init_codegen(void) { }
 void jl_fptr_to_llvm(jl_fptr_t fptr, jl_method_instance_t *lam, int specsig)
@@ -42,13 +43,29 @@ void jl_register_fptrs(uint64_t sysimage_base, const struct _jl_sysimg_fptrs_t *
     (void)sysimage_base; (void)fptrs; (void)linfos; (void)n;
 }
 
-void jl_compile_linfo(jl_method_instance_t *li) { }
+jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t *src, size_t world, const jl_cgparams_t *params)
+{
+    jl_method_instance_t *li = *pli;
+    jl_llvm_functions_t decls = {};
+
+    if (jl_is_method(li->def.method)) {
+        jl_printf(JL_STDERR, "code missing for ");
+        jl_static_show(JL_STDERR, (jl_value_t*)li);
+        jl_printf(JL_STDERR, " : sysimg may not have been built with --compile=all\n");
+    }
+    else {
+        jl_printf(JL_STDERR, "top level expression cannot be compiled in this build of Julia");
+    }
+    return decls;
+}
 
 jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs);
-void jl_generate_fptr(jl_method_instance_t *li)
+jl_generic_fptr_t jl_generate_fptr(jl_method_instance_t *li, const char *F, size_t world)
 {
-    li->fptr = (jl_fptr_t)&jl_interpret_call;
-    li->jlcall_api = JL_API_INTERPRETED;
+    jl_generic_fptr_t fptr;
+    fptr.fptr = (jl_fptr_t)&jl_interpret_call;
+    fptr.jlcall_api = JL_API_INTERPRETED;
+    return fptr;
 }
 
 JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION(void)

--- a/src/ast.c
+++ b/src/ast.c
@@ -43,7 +43,7 @@ jl_sym_t *enter_sym;   jl_sym_t *leave_sym;
 jl_sym_t *exc_sym;     jl_sym_t *error_sym;
 jl_sym_t *new_sym;     jl_sym_t *using_sym;
 jl_sym_t *const_sym;   jl_sym_t *thunk_sym;
-jl_sym_t *anonymous_sym;  jl_sym_t *underscore_sym;
+jl_sym_t *underscore_sym;
 jl_sym_t *abstracttype_sym; jl_sym_t *primtype_sym;
 jl_sym_t *structtype_sym; jl_sym_t *foreigncall_sym;
 jl_sym_t *global_sym; jl_sym_t *list_sym;
@@ -312,7 +312,6 @@ void jl_init_frontend(void)
     const_sym = jl_symbol("const");
     global_sym = jl_symbol("global");
     thunk_sym = jl_symbol("thunk");
-    anonymous_sym = jl_symbol("anonymous");
     underscore_sym = jl_symbol("_");
     amp_sym = jl_symbol("&");
     abstracttype_sym = jl_symbol("abstract_type");

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -16,11 +16,13 @@ extern "C" {
 
 typedef struct {
     jl_code_info_t *src; // contains the names and number of slots
+    jl_method_instance_t *mi; // MethodInstance we're executing, or NULL if toplevel
     jl_module_t *module; // context for globals
     jl_value_t **locals; // slots for holding local slots and ssavalues
     jl_svec_t *sparam_vals; // method static parameters, if eval-ing a method body
     size_t ip; // Points to the currently-evaluating statement
     int preevaluation; // use special rules for pre-evaluating expressions
+    int continue_at; // statement index to jump to after leaving exception handler (0 if none)
 } interpreter_state;
 
 #include "interpreter-stacktrace.c"
@@ -53,6 +55,8 @@ SECT_INTERP CALLBACK_ABI void *jl_interpret_toplevel_expr_in_callback(interprete
     s->module = args->m;
     s->sparam_vals = args->sparam_vals;
     s->preevaluation = (s->sparam_vals != NULL);
+    s->continue_at = 0;
+    s->mi = NULL;
 
     JL_TRY {
         ptls->current_task->current_module = ptls->current_module = args->m;
@@ -259,7 +263,7 @@ SECT_INTERP static jl_value_t *eval(jl_value_t *e, interpreter_state *s)
             defined = jl_boundp(modu, (jl_sym_t*)sym);
         }
         else if (jl_is_expr(sym) && ((jl_expr_t*)sym)->head == static_parameter_sym) {
-            ssize_t n = jl_unbox_long(args[0]);
+            ssize_t n = jl_unbox_long(jl_exprarg(sym, 0));
             assert(n > 0);
             if (s->sparam_vals && n <= jl_svec_len(s->sparam_vals)) {
                 jl_value_t *sp = jl_svecref(s->sparam_vals, n - 1);
@@ -544,6 +548,8 @@ SECT_INTERP CALLBACK_ABI void *jl_toplevel_eval_body_callback(interpreter_state 
     struct jl_toplevel_eval_body_args *args =
         (struct jl_toplevel_eval_body_args*)vargs;
     s->module = args->m;
+    s->continue_at = 0;
+    s->mi = NULL;
     jl_value_t *ret = eval_body(args->stmts, s, 0, 1);
     jl_get_ptls_states()->world_age = last_age;
     return ret;
@@ -627,6 +633,11 @@ SECT_INTERP static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s
                 if (!jl_setjmp(__eh.eh_ctx,1)) {
                     return eval_body(stmts, s, s->ip + 1, toplevel);
                 }
+                else if (s->continue_at) {
+                    s->ip = s->continue_at;
+                    s->continue_at = 0;
+                    continue;
+                }
                 else {
 #ifdef _OS_WINDOWS_
                     if (jl_get_ptls_states()->exception_in_transit == jl_stackovf_exception)
@@ -638,7 +649,16 @@ SECT_INTERP static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s
             }
             else if (head == leave_sym) {
                 int hand_n_leave = jl_unbox_long(jl_exprarg(stmt,0));
-                jl_pop_handler(hand_n_leave);
+                assert(hand_n_leave > 0);
+                // equivalent to jl_pop_handler(hand_n_leave) :
+                jl_ptls_t ptls = jl_get_ptls_states();
+                jl_handler_t *eh = ptls->current_task->eh;
+                while (--hand_n_leave > 0)
+                    eh = eh->prev;
+                jl_eh_restore_state(eh);
+                // pop jmp_bufs from stack
+                s->continue_at = s->ip + 1;
+                jl_longjmp(eh->eh_ctx, 1);
             }
             else if (toplevel && jl_is_toplevel_only_expr(stmt)) {
                 jl_toplevel_eval(s->module, stmt);
@@ -715,6 +735,8 @@ SECT_INTERP CALLBACK_ABI void *jl_interpret_call_callback(interpreter_state *s, 
     s->module = args->lam->def.method->module;
     s->locals = locals + 2;
     s->sparam_vals = args->lam->sparam_vals;
+    s->continue_at = 0;
+    s->mi = args->lam;
     size_t i;
     for (i = 0; i < args->lam->def.method->nargs; i++) {
         if (args->lam->def.method->isva && i == args->lam->def.method->nargs - 1)
@@ -750,6 +772,8 @@ SECT_INTERP CALLBACK_ABI void *jl_interpret_toplevel_thunk_callback(interpreter_
     s->locals = locals;
     s->module = args->m;
     s->sparam_vals = jl_emptysvec;
+    s->continue_at = 0;
+    s->mi = NULL;
     size_t last_age = jl_get_ptls_states()->world_age;
     jl_value_t *r = eval_body(stmts, s, 0, 1);
     jl_get_ptls_states()->world_age = last_age;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -317,6 +317,9 @@ jl_llvm_functions_t jl_compile_linfo(
         const jl_cgparams_t *params);
 jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **li, size_t world);
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
+jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs);
+jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *lam);
+int jl_code_requires_compiler(jl_code_info_t *src);
 jl_code_info_t *jl_new_code_info_from_ast(jl_expr_t *ast);
 
 STATIC_INLINE jl_value_t *jl_compile_method_internal(jl_generic_fptr_t *fptr,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -991,7 +991,7 @@ extern jl_sym_t *enter_sym;   extern jl_sym_t *leave_sym;
 extern jl_sym_t *exc_sym;     extern jl_sym_t *new_sym;
 extern jl_sym_t *compiler_temp_sym; extern jl_sym_t *foreigncall_sym;
 extern jl_sym_t *const_sym;   extern jl_sym_t *thunk_sym;
-extern jl_sym_t *anonymous_sym;  extern jl_sym_t *underscore_sym;
+extern jl_sym_t *underscore_sym;
 extern jl_sym_t *abstracttype_sym; extern jl_sym_t *primtype_sym;
 extern jl_sym_t *structtype_sym;
 extern jl_sym_t *global_sym; extern jl_sym_t *unused_sym;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -46,6 +46,16 @@
 // For C++, C++11 or MSVC is required. Both provide `static_assert`.
 #endif
 
+#ifndef alignof
+#  ifndef __cplusplus
+#    ifdef __GNUC__
+#      define alignof _Alignof
+#    else
+#      define alignof(...) 1
+#    endif
+#  endif
+#endif
+
 #if jl_has_builtin(__builtin_assume)
 #define jl_assume(cond) (__extension__ ({               \
                 __typeof__(cond) cond_ = (cond);        \

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -198,6 +198,20 @@ static uintptr_t jl_fptr_id(void *fptr)
         return *(uintptr_t*)pbp;
 }
 
+int32_t jl_jlcall_api(const char *fname)
+{
+    // give the function an index in the constant lookup table
+    if (fname == NULL)
+        return 0;
+    if (!strncmp(fname, "japi3_", 6)) // jlcall abi 3 from JIT
+        return JL_API_WITH_PARAMETERS;
+    assert(!strncmp(fname, "japi1_", 6) ||  // jlcall abi 1 from JIT
+           !strncmp(fname, "jsys1_", 6) ||  // jlcall abi 1 from sysimg
+           !strncmp(fname, "jlcall_", 7) || // jlcall abi 1 from JIT wrapping a specsig method
+           !strncmp(fname, "jlsysw_", 7));  // jlcall abi 1 from sysimg wrapping a specsig method
+    return JL_API_GENERIC;
+}
+
 
 #define jl_serialize_value(s, v) jl_serialize_value_(s,(jl_value_t*)(v))
 static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v);

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -1,18 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-bt = backtrace()
-have_backtrace = false
-for l in bt
-    lkup = ccall(:jl_lookup_code_address, Any, (Ptr{Void}, Cint), l, true)
-    if lkup[1][1] == :backtrace
-        @test lkup[1][5] == false # fromC
-        global have_backtrace = true
-        break
-    end
-end
-
-@test have_backtrace
-
 # Test location information for inlined code (ref issues #1334 #12544)
 module test_inline_bt
 using Test
@@ -176,7 +163,7 @@ let
     end
 end
 let st = stacktrace(bt23971)
-    @test st[1].func == :anonymous
+    @test StackTraces.is_top_level_frame(st[1])
     @test string(st[1].file) == @__FILE__
     @test !contains(string(st[2].file), "missing")
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -5581,8 +5581,6 @@ let x5 = UnionField5(nothing, Int8(3))
     @test x5 == x5copy
     @test object_id(x5) === object_id(x5copy)
     @test hash(x5) === hash(x5copy)
-    @test pointer_from_objref(x5) === pointer_from_objref(x5)
-    @test pointer_from_objref(x5) !== pointer_from_objref(x5copy)
 end
 
 


### PR DESCRIPTION
Also make `JULIACODEGEN=none` builds work again.

With this, `./julia --compile=no` gives a fun low-latency version of julia. It will run everything in a (very slow) interpreter except code with `foreigncall` (or llvmcall). Next steps are to merge #23973, support some common ccalls in the interpreter (in practice, many call known run-time system functions), and work out ways to interpret some functions automatically (e.g. interpret functions with no loops until they're called some number of times).