### PR TITLE
Fix GC preserve optimization

### DIFF
--- a/test/llvmpasses/alloc-opt2.jl
+++ b/test/llvmpasses/alloc-opt2.jl
@@ -46,8 +46,48 @@ L3:
 """)
 # CHECK-LABEL: }
 
+# CHECK-LABEL: @preserve_branches2
+# CHECK: alloca i64
+# CHECK: call %jl_value_t*** @julia.ptls_states()
+# CHECK: L1:
+# CHECK-NEXT: call void @llvm.lifetime.start{{.*}}(i64 8,
+# CHECK-NEXT: @llvm.julia.gc_preserve_begin{{.*}}%jl_value_t addrspace(10)* %v2
+# CHECK-NEXT: @external_function()
+# CHECK-NEXT: br i1 %b2, label %L2, label %L3
+
+# CHECK: L2:
+# CHECK-NOT: call void @llvm.lifetime.end{{.*}}(i64 8,
+# CHECK: @external_function()
+# CHECK-NEXT: br label %L3
+
+# CHECK: L3:
+# CHECK-NEXT: call void @llvm.lifetime.end{{.*}}(i64 8,
+println("""
+define void @preserve_branches2(i8* %fptr, i1 %b, i1 %b2) {
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+  %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
+  %v2 = call %jl_value_t addrspace(10)* @external_function2()
+  br i1 %b, label %L1, label %L3
+
+L1:
+  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(10)* %v, %jl_value_t addrspace(10)* %v2)
+  call void @external_function()
+  br i1 %b2, label %L2, label %L3
+
+L2:
+  call void @external_function()
+  br label %L3
+
+L3:
+  ret void
+}
+""")
+# CHECK-LABEL: }
+
 println("""
 declare void @external_function()
+declare %jl_value_t addrspace(10)* @external_function2()
 declare %jl_value_t*** @julia.ptls_states()
 declare noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, %jl_value_t addrspace(10)*)
 declare i64 @julia.pointer_from_objref(%jl_value_t addrspace(11)*)


### PR DESCRIPTION
Only remove the call if all of the arguments are eliminated.

This was the reason for and is based on https://github.com/JuliaLang/julia/pull/24474.
