### PR TITLE
Enable dmesg printing on fail on circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -62,9 +62,9 @@ jobs:
             "$(cd julia-src && make print-CC)" &&
           mv julia-src project
 #      - run: cd project && make -C doc deploy
-#       - run:
-#           command: sudo dmesg
-#           when: on_fail
+      - run:
+          command: sudo dmesg
+          when: on_fail
       - save_cache:
           key: ccache-{{ checksum "/tmp/weeknumber" }}
           paths:


### PR DESCRIPTION
This should show us if there's any OOM or other network related issues assuming the kernel is verbose enough.....

Potentially helps figuring out https://github.com/JuliaLang/julia/issues/24329

I'll probably restart the CI a few times and manually stop any CI that's not relevant.