### PR TITLE
Improve typejoin involving an empty tuple

### DIFF
--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -34,11 +34,14 @@ function typejoin(@nospecialize(a), @nospecialize(b))
         end
         ap, bp = a.parameters, b.parameters
         lar = length(ap)::Int; lbr = length(bp)::Int
+        if lar == 0
+            return Tuple{Vararg{tailjoin(bp,1)}}
+        end
+        if lbr == 0
+            return Tuple{Vararg{tailjoin(ap,1)}}
+        end
         laf, afixed = full_va_len(ap)
         lbf, bfixed = full_va_len(bp)
-        if lar==0 || lbr==0
-            return Tuple
-        end
         if laf < lbf
             if isvarargtype(ap[lar]) && !afixed
                 c = Vector{Any}(laf)

--- a/test/core.jl
+++ b/test/core.jl
@@ -106,6 +106,7 @@ Type{Integer}  # cache this
                    Tuple{Int8,Vararg{Integer}})
 @test Base.typeseq(typejoin(Union{Int,AbstractString},Int), Union{Int,AbstractString})
 @test Base.typeseq(typejoin(Union{Int,AbstractString},Int8), Any)
+@test typejoin(Tuple{}, Tuple{Int}) == Tuple{Vararg{Int}}
 
 # typejoin associativity
 abstract type Foo____{K} end


### PR DESCRIPTION
Don't just return `Tuple` when joining an empty and a non-empty tuple, instead return the appropriate vararg tuple, similar to otherwise joining tuples of unequal length.

Split out from #23077 as this should hopefully be uncontroversial.