### PR TITLE
specialized complex^real methods

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -631,7 +631,7 @@ function log1p(z::Complex{T}) where T
     end
 end
 
-function ^(z::Complex{T}, p::Complex{T})::Complex{T} where T<:AbstractFloat
+function ^(z::Complex{T}, p::Union{T,Complex{T}})::Complex{T} where T<:AbstractFloat
     if p == 2 #square
         zr, zi = reim(z)
         x = (zr-zi)*(zr+zi)
@@ -682,7 +682,7 @@ function exp10(z::Complex{T}) where T<:AbstractFloat
 end
 exp10(z::Complex) = exp10(float(z))
 
-function ^(z::T, p::T) where T<:Complex
+function ^(z::Complex{T}, p::Union{T,Complex{T}}) where T<:Real
     if isinteger(p)
         rp = real(p)
         if rp < 0
@@ -748,6 +748,11 @@ end
 ^(z::Complex{<:AbstractFloat}, n::Integer) =
     n>=0 ? power_by_squaring(z,n) : power_by_squaring(inv(z),-n)
 ^(z::Complex{<:Integer}, n::Integer) = power_by_squaring(z,n) # DomainError for n<0
+
+function ^(z::Complex{T}, p::S) where {T<:Real,S<:Real}
+    P = promote_type(T,S)
+    return Complex{P}(z) ^ P(p)
+end
 
 function sin(z::Complex{T}) where T
     F = float(T)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -631,7 +631,24 @@ function log1p(z::Complex{T}) where T
     end
 end
 
-function ^(z::Complex{T}, p::Union{T,Complex{T}})::Complex{T} where T<:AbstractFloat
+function exp2(z::Complex{T}) where T<:AbstractFloat
+    er = exp2(real(z))
+    theta = imag(z) * log(convert(T, 2))
+    s, c = sincos(theta)
+    Complex(er * c, er * s)
+end
+exp2(z::Complex) = exp2(float(z))
+
+function exp10(z::Complex{T}) where T<:AbstractFloat
+    er = exp10(real(z))
+    theta = imag(z) * log(convert(T, 10))
+    s, c = sincos(theta)
+    Complex(er * c, er * s)
+end
+exp10(z::Complex) = exp10(float(z))
+
+# _cpow helper function to avoid method ambiguity with ^(::Complex,::Real)
+function _cpow(z::Complex{T}, p::Union{T,Complex{T}})::Complex{T} where T<:AbstractFloat
     if p == 2 #square
         zr, zi = reim(z)
         x = (zr-zi)*(zr+zi)
@@ -665,24 +682,7 @@ function ^(z::Complex{T}, p::Union{T,Complex{T}})::Complex{T} where T<:AbstractF
         Complex(one(T), zer)
     end
 end
-
-function exp2(z::Complex{T}) where T<:AbstractFloat
-    er = exp2(real(z))
-    theta = imag(z) * log(convert(T, 2))
-    s, c = sincos(theta)
-    Complex(er * c, er * s)
-end
-exp2(z::Complex) = exp2(float(z))
-
-function exp10(z::Complex{T}) where T<:AbstractFloat
-    er = exp10(real(z))
-    theta = imag(z) * log(convert(T, 10))
-    s, c = sincos(theta)
-    Complex(er * c, er * s)
-end
-exp10(z::Complex) = exp10(float(z))
-
-function ^(z::Complex{T}, p::Union{T,Complex{T}}) where T<:Real
+function _cpow(z::Complex{T}, p::Union{T,Complex{T}}) where T<:Real
     if isinteger(p)
         rp = real(p)
         if rp < 0
@@ -738,6 +738,8 @@ function ^(z::Complex{T}, p::Union{T,Complex{T}}) where T<:Real
 
     Complex(re, im)
 end
+^(z::Complex{T}, p::Complex{T}) where T<:Real = _cpow(z, p)
+^(z::Complex{T}, p::T) where T<:Real = _cpow(z, p)
 
 ^(z::Complex, n::Bool) = n ? z : one(z)
 ^(z::Complex, n::Integer) = z^Complex(n)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -426,7 +426,7 @@ end
 
 ^(x::Number, y::Rational) = x^(y.num/y.den)
 ^(x::T, y::Rational) where {T<:AbstractFloat} = x^convert(T,y)
-^(x::Complex{T}, y::Rational) where {T<:AbstractFloat} = x^convert(T,y)
+^(z::Complex{T}, p::Rational) where {T<:Real} = z^convert(typeof(one(T)^p), p)
 
 ^(z::Complex{<:Rational}, n::Bool) = n ? z : one(z) # to resolve ambiguity
 function ^(z::Complex{<:Rational}, n::Integer)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -989,3 +989,12 @@ end
         @test isequal(one(T) / complex(one(T), -zero(T)), Complex(one(T),  zero(T)))
     end
 end
+
+@testset "complex^real, issue #14342" begin
+    for T in (Float32, Float64, BigFloat), p in (T(-21//10), -21//10)
+        z = T(2)+0im
+        @test real(z^p) ≈ 2^p
+        @test signbit(imag(z^p))
+    end
+    @test (2+0im)^(-21//10) === (2//1+0im)^(-21//10) === 2^-2.1 - 0.0im
+end


### PR DESCRIPTION
This adds specialized methods for `complex^real`, which would previously have first promoted to `complex^complex`.  Fixes #14342.

The performance improvement seems to be very small in typical cases (e.g. 6-8% for `Complex{Float64}^Float64`), but it fixes a longstanding bug in the sign of the zero imaginary part for `(2.0+0im)^-2.1` and similar.