### PR TITLE
Remove obsolete chol!(Number) method. 

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2089,6 +2089,10 @@ end
 @deprecate range(start::DateTime, len::Integer)  range(start, Dates.Day(1), len)
 @deprecate range(start::Date, len::Integer)      range(start, Dates.Day(1), len)
 
+@eval LinAlg begin
+    @deprecate chol!(x::Number, uplo) chol(x) false
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -132,8 +132,6 @@ function _chol!(x::Number, uplo)
     rx == abs(x) ? (rval, convert(BlasInt, 0)) : (rval, convert(BlasInt, 1))
 end
 
-chol!(x::Number, uplo) = ((C, info) = _chol!(x, uplo); @assertposdef C info)
-
 # chol!. Destructive methods for computing Cholesky factor of real symmetric or Hermitian
 # matrix
 function chol!(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix})


### PR DESCRIPTION
Supersedes #24224. The method should have been removed as part of https://github.com/JuliaLang/julia/commit/597d945adc083c031806bc7c4510f4cdeb0a23b9. It is not exported and probably not used by anyone.