### PR TITLE
Fix parse call in core test

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -255,7 +255,7 @@ end
 @test_throws TypeError typeassert_instead_of_decl()
 
 # type declarations on globals not implemented yet
-@test_throws ErrorException eval(parse("global x20327::Int"))
+@test_throws ErrorException eval(Meta.parse("global x20327::Int"))
 
 y20327 = 1
 @test_throws TypeError y20327::Float64


### PR DESCRIPTION
Caught it in local testing, no idea why it didn't show up on CI. (are we passing stderr on correctly?)