### PR TITLE
add news item for `Base.find_in_path` change (#24320)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -264,6 +264,8 @@ This section lists changes that do not have deprecation warnings.
   * The return type of `reinterpret` has changed to `ReinterpretArray`. `reinterpret` on sparse
     arrays has been discontinued.
 
+  * `Base.find_in_path` is now `Base.find_package` or `Base.find_source_file` ([#24320])
+
 Library improvements
 --------------------
 
@@ -1496,3 +1498,4 @@ Command-line option changes
 [#23233]: https://github.com/JuliaLang/julia/issues/23233
 [#23342]: https://github.com/JuliaLang/julia/issues/23342
 [#23404]: https://github.com/JuliaLang/julia/issues/23404
+[#24320]: https://github.com/JuliaLang/julia/issues/24320


### PR DESCRIPTION
I ran into this undocumented breaking change as I was trying to get Atom.jl working on 0.7, I thought it could be NEWS-worthy. 