### PR TITLE
fix run-time implementation of ashr_int intrinsic

### DIFF
--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -806,10 +806,8 @@ bi_iintrinsic_fast(LLVMXor, xor_op, xor_int, u)
 bi_iintrinsic_cnvtb_fast(LLVMShl, shl_op, shl_int, u, 1)
 #define lshr_op(a,b) (b >= 8 * sizeof(a)) ? 0 : a >> b
 bi_iintrinsic_cnvtb_fast(LLVMLShr, lshr_op, lshr_int, u, 1)
-#define ashr_op(a,b) \
-        /* if ((signed)a > 0) [in two's complement] ? ... : ...) */ \
-        (a >> (host_char_bit * sizeof(a) - 1)) ? ~(b >= 8 * sizeof(a) ? 0 : (~a) >> b) : (b >= 8 * sizeof(a) ? 0 : a >> b)
-bi_iintrinsic_cnvtb_fast(LLVMAShr, ashr_op, ashr_int, u, 1)
+#define ashr_op(a,b) (b < 0 || b >= 8 * sizeof(a) ? 0 : a >> b)
+bi_iintrinsic_cnvtb_fast(LLVMAShr, ashr_op, ashr_int, , 1)
 //#define bswap_op(a) __builtin_bswap(a)
 //un_iintrinsic_fast(LLVMByteSwap, bswap_op, bswap_int, u)
 un_iintrinsic_slow(LLVMByteSwap, bswap_int, u)

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -82,3 +82,7 @@ end
 @test compiled_conv(UInt32, UInt64(0xC000_BA98_8765_4321)) ==
     (0x87654321, 0x0000000087654321, 0xffffffff87654321, 0xc005d4c4, 0xc000ba9880000000)
 @test_throws ErrorException compiled_conv(Bool, im)
+
+let f = Core.Intrinsics.ashr_int
+    @test f(Int8(-17), 1) == -9
+end


### PR DESCRIPTION
This was causing tests to fail under the interpreter.

Apparently in `~a` where `a` is a uint8, C implicitly converts `a` to an `int` before applying `~`? This caused `Int8(-17) >> 1` to give 119 instead of -9 (missing the top bit).