### PR TITLE
Allow `open(f,filename,...)` for `f` being any callable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -364,6 +364,10 @@ Library improvements
     This supersedes the old behavior of reinterpret on Arrays. As a result, reinterpreting
     arrays with different alignment requirements (removed in 0.6) is once again allowed ([#23750]).
 
+  * The function-taking form of `open` now accepts any callable as its first argument,
+    not just subtypes of `Function`. ([#24527])
+
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -178,7 +178,7 @@ function open(fname::AbstractString, mode::AbstractString)
 end
 
 """
-    open(f::Function, args...)
+    open(f, args...)
 
 Apply the function `f` to the result of `open(args...)` and close the resulting file
 descriptor upon completion.
@@ -188,7 +188,7 @@ descriptor upon completion.
 open(f->read(f, String), "file.txt")
 ```
 """
-function open(f::Function, args...)
+function open(f, args...)
     io = open(args...)
     try
         f(io)

--- a/base/process.jl
+++ b/base/process.jl
@@ -613,13 +613,13 @@ function open(cmds::AbstractCmd, mode::AbstractString="r", other::Redirectable=D
 end
 
 """
-    open(f::Function, command, mode::AbstractString="r", stdio=DevNull)
+    open(f, command, mode::AbstractString="r", stdio=DevNull)
 
 Similar to `open(command, mode, stdio)`, but calls `f(stream)` on the resulting process
 stream, then closes the input stream and waits for the process to complete.
 Returns the value returned by `f`.
 """
-function open(f::Function, cmds::AbstractCmd, args...)
+function open(f, cmds::AbstractCmd, args...)
     P = open(cmds, args...)
     ret = try
         f(P)

--- a/test/read.jl
+++ b/test/read.jl
@@ -521,8 +521,9 @@ f2 = Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
 close(f1)
 close(f2)
 rm(f)
-
 end # mktempdir() do dir
+
+
 
 @testset "countlines" begin
     @test countlines(IOBuffer("\n")) == 1
@@ -536,4 +537,19 @@ end # mktempdir() do dir
     @test countlines(file,'\r') == 0
     @test countlines(file,'\n') == 4
     rm(file)
+end
+
+
+# ensure opening can take functions or nonfunctions as its first arg
+struct NonFunctionCallable
+    f
+end
+(self::NonFunctionCallable)(args...) = self.f(args...)
+
+let t = "a modern language"
+    c = `$echocmd $t`
+    f, fh = mktemp()
+    write(fh, t)
+    close(fh)
+    @test open(NonFunctionCallable(readline), f) == open(readline, f) == t
 end

--- a/test/read.jl
+++ b/test/read.jl
@@ -547,7 +547,6 @@ end
 (self::NonFunctionCallable)(args...) = self.f(args...)
 
 let t = "a modern language"
-    c = `$echocmd $t`
     f, fh = mktemp()
     write(fh, t)
     close(fh)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -510,3 +510,17 @@ end
 #    @test sizeof(readstring(stdout)) == 1048576 * 2 # make sure we get all the data
 #    @test success(p)
 #end
+
+
+
+# ensure opening can take functions or nonfunctions as its first arg
+struct NonFunctionCallable
+    f
+end
+(self::NonFunctionCallable)(args...) = self.f(args...)
+
+let t = "a modern language"
+    c = `$echocmd $t`
+
+    @test open(NonFunctionCallable(readline), c) == open(readline, c) == t
+end


### PR DESCRIPTION
Since `Functions` are not the only thing that is callable,
they should not be the only things allowed as first arguments.

Though one can always do
```
open(t -> mycallable(t), "temp.txt")
```


This broke me using ExpectationStubs.jl.

I don't believe this introduces an ambiguity, so it should be fine.