### PR TITLE
print output from info and warnings in one shot, to prevent interleaving when used async

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -448,9 +448,11 @@ MY INFO: hello world
 See also [`logging`](@ref).
 """
 function info(io::IO, msg...; prefix="INFO: ")
-    io = redirect(io, log_info_to, :info)
-    print_with_color(info_color(), io, prefix; bold = true)
-    println_with_color(info_color(), io, chomp(string(msg...)))
+    buf = IOBuffer()
+    iob = redirect(IOContext(buf, io), log_info_to, :info)
+    print_with_color(info_color(), iob, prefix; bold = true)
+    println_with_color(info_color(), iob, chomp(string(msg...)))
+    print(io, String(take!(buf)))
     return
 end
 info(msg...; prefix="INFO: ") = info(STDERR, msg..., prefix=prefix)
@@ -483,16 +485,18 @@ function warn(io::IO, msg...;
         (key in have_warned) && return
         push!(have_warned, key)
     end
-    io = redirect(io, log_warn_to, :warn)
-    print_with_color(warn_color(), io, prefix; bold = true)
-    print_with_color(warn_color(), io, str)
+    buf = IOBuffer()
+    iob = redirect(IOContext(buf, io), log_warn_to, :warn)
+    print_with_color(warn_color(), iob, prefix; bold = true)
+    print_with_color(warn_color(), iob, str)
     if bt !== nothing
-        show_backtrace(io, bt)
+        show_backtrace(iob, bt)
     end
     if filename !== nothing
-        print(io, "\nin expression starting at $filename:$lineno")
+        print(iob, "\nin expression starting at $filename:$lineno")
     end
-    println(io)
+    println(iob)
+    print(io, String(take!(buf)))
     return
 end
 


### PR DESCRIPTION
Fixes #21348