### PR TITLE
give better and earlier error for misplaced top-level-only constructs

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3970,8 +3970,6 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr)
         return jl_cgval_t((jl_value_t*)jl_void_type);
     }
     else {
-        if (!strcmp(jl_symbol_name(head), "$"))
-            jl_error("syntax: prefix \"$\" in non-quoted expression");
         if (jl_is_toplevel_only_expr(expr) &&
             !jl_is_method(ctx.linfo->def.method)) {
             // call interpreter to run a toplevel expr from inside a

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1157,3 +1157,10 @@ end
 @test Meta.parse("2e-3_") == Expr(:call, :*, 2e-3, :_)
 @test Meta.parse("2e3_\"x\"") == Expr(:call, :*, 2e3, Expr(:macrocall, Symbol("@__str"), LineNumberNode(1, :none), "x"))
 
+# misplaced top-level expressions
+@test_throws ErrorException("syntax: \"\$\" expression outside quote") eval(@__MODULE__, Meta.parse("x->\$x"))
+@test Meta.lower(@__MODULE__, Expr(:$, :x)) == Expr(:error, "\"\$\" expression outside quote")
+@test Meta.lower(@__MODULE__, :(x->import Foo)) == Expr(:error, "\"import\" expression not at top level")
+@test Meta.lower(@__MODULE__, :(x->module Foo end)) == Expr(:error, "\"module\" expression not at top level")
+@test Meta.lower(@__MODULE__, :(x->struct Foo end)) == Expr(:error, "\"struct\" expression not at top level")
+@test Meta.lower(@__MODULE__, :(x->abstract type Foo end)) == Expr(:error, "\"abstract type\" expression not at top level")


### PR DESCRIPTION
Before:
```
julia> function f()
       struct Foo
       end
       end
f (generic function with 1 method)

julia> f()
ERROR: error compiling f: type definition not allowed inside a local scope
```

After:
```
julia> function f()
       struct Foo
       end
       end
ERROR: syntax: "struct" expression not at top level
```

This is a much better way to give the error, and also works towards eliminating the last few small differences between interpreted and compiled code.