### PR TITLE
fix FFTW deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1320,6 +1320,7 @@ module DFT
             @eval Base.@deprecate_moved $f "FFTW"
         end
     end
+    Base.deprecate(DFT, :FFTW, 2)
     export FFTW
 end
 using .DFT
@@ -1331,6 +1332,7 @@ module DSP
         @eval Base.@deprecate_moved $f "DSP"
     end
 end
+deprecate(Base, :DSP, 2)
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
 


### PR DESCRIPTION
This fixes #24532: there was a missing deprecation for the `Base.FFTW` module itself that prevented FFTW.jl symbols from being imported into a module.