### PR TITLE
Fix chol! for uniform scaling, add test

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -356,7 +356,7 @@ function _chol!(J::UniformScaling, uplo)
     UniformScaling(c), info
 end
 
-chol!(J::UniformScaling, uplo) = ((J, info) = _chol!(J, uplo); @assertposdef J info)
+chol!(J::UniformScaling, args...) = ((J, info) = _chol!(J, nothing); @assertposdef J info)
 
 """
     chol(J::UniformScaling) -> C

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -186,6 +186,7 @@ end
     for T in (Float64, Complex64, BigFloat, Int)
         λ = T(4)
         @test chol(λ*I) ≈ √λ*I
+        @test LinAlg.chol!(copy(λ*I)) ≈ √λ*I
         @test_throws LinAlg.PosDefException chol(-λ*I)
     end
 end


### PR DESCRIPTION
Changed the function so that its argument structure matches `chol` and added a test