### PR TITLE
Test filter! deprecation function

### DIFF
--- a/test/dict.jl
+++ b/test/dict.jl
@@ -520,6 +520,9 @@ end
     @test filter(f, d) == filter!(f, copy(d)) ==
           invoke(filter!, Tuple{Function,Associative}, f, copy(d)) ==
           Dict(zip(2:2:1000, 2:2:1000))
+    g = (p1, p2) -> iseven(p1)
+    @test_warn "In `filter!(f, dict)`, `f` is now passed a single pair instead of two arguments." filter!(g, copy(d))
+    @test filter!(g, copy(d)) == filter!(f, copy(d))
 end
 
 struct MyString <: AbstractString


### PR DESCRIPTION
I'm not trying to test the deprecated method itself so much as [this wrapper](https://codecov.io/gh/JuliaLang/julia/src/master/base/associative.jl#L368) we have around it, which is chilling in base. If we don't want to test deprecation pass throughs at all feel free to close!