### PR TITLE
WIP: Change macros, functions and methods `show` for consistency.

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -66,8 +66,16 @@ function arg_decl_parts(m::Method)
         for t in tv
             show_env = ImmutableDict(show_env, :unionall_env => t)
         end
-        decls = Any[argtype_decl(show_env, argnames[i], sig, i, m.nargs, m.isva)
+        decls = begin
+            if startswith(string(m.name), "@")
+                Any[argtype_decl(show_env, argnames[i], sig, i, m.nargs, m.isva)
+                    for i = 1:m.nargs
+                    if argnames[i] ∉ (:__source__, :__module__)]
+            else
+                Any[argtype_decl(show_env, argnames[i], sig, i, m.nargs, m.isva)
                     for i = 1:m.nargs]
+            end
+        end
     else
         decls = Any[("", "") for i = 1:length(sig.parameters)]
     end
@@ -154,7 +162,7 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
         m = n==1 ? "method" : "methods"
         sname = string(name)
         ns = (isself || '#' in sname) ? sname : string("(::", name, ")")
-        what = startswith(ns, '@') ? "macro" : "generic function"
+        what = startswith(ns, '@') ? "macro" : "function"
         print(io, "# $n $m for ", what, " \"", ns, "\":")
     end
     kwtype = isdefined(mt, :kwsorter) ? Nullable{DataType}(typeof(mt.kwsorter)) : Nullable{DataType}()

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -111,7 +111,7 @@ function show(io::IO, ::MIME"text/plain", f::Function)
         m = n==1 ? "method" : "methods"
         sname = string(name)
         ns = (isself || '#' in sname) ? sname : string("(::", ft, ")")
-        what = startswith(ns, '@') ? "macro" : "generic function"
+        what = startswith(ns, '@') ? "macro" : "function"
         print(io, ns, " (", what, " with $n $m)")
     end
 end


### PR DESCRIPTION
This is a follow up to https://github.com/JuliaLang/julia/pull/24462 (document macro dispatch).

**NOTE**: edited as per @yuyichao comment.

Changes are:
1. Don't use the term *generic*.
2. Exclude `__source__` and `__module__` arguments from macros that where recently introduced.


## Macros

### Example

```julia
julia> macro foo() end
@foo (macro with 1 method)

julia> macro foo(arg) :($arg) end
@foo (macro with 2 methods)

julia> macro foo(arg::Symbol) :(@show $arg) end
@foo (macro with 3 methods)

julia> macro foo(arg::Symbol, block::Expr) :($block) end
@foo (macro with 4 methods)

julia> foo = getfield(@__MODULE__, Symbol("@foo"))
@foo (macro with 4 methods)
```

### Before

```julia
julia> methods(foo)
# 4 methods for macro "@foo":
[1] @foo(__source__::LineNumberNode, __module__::Module, arg::Symbol, block::Expr) in Main at REPL[51]:1
[2] @foo(__source__::LineNumberNode, __module__::Module, arg::Symbol) in Main at REPL[50]:1
[3] @foo(__source__::LineNumberNode, __module__::Module) in Main at REPL[48]:1
[4] @foo(__source__::LineNumberNode, __module__::Module, arg) in Main at REPL[49]:1
```

### After

```julia
julia> methods(foo)
# 4 methods for macro "@foo":
[1] @foo(arg::Symbol, block::Expr) in Main at REPL[6]:1
[2] @foo(arg::Symbol) in Main at REPL[5]:1
[3] @foo() in Main at REPL[3]:1
[4] @foo(arg) in Main at REPL[4]:1
```

## Functions

### Before

```julia
julia> foo() = nothing
foo (generic function with 1 method)

julia> foo(__source__) = :foo
foo (generic function with 2 methods)

julia> methods(foo)
# 2 methods for generic function "foo":
[1] foo() in Main at REPL[1]:1
[2] foo(__source__) in Main at REPL[2]:1
```
### After

```julia
julia> foo() = nothing
foo (function with 1 method)

julia> foo(__source__) = :foo
foo (function with 2 methods)

julia> methods(foo)
# 2 methods for function "foo":
[1] foo() in Main at REPL[1]:1
[2] foo(__source__) in Main at REPL[2]:1    # this arg should still show for functions
```