### PR TITLE
Allow nchar to be greater than string length in first/last

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -614,7 +614,11 @@ julia> first("1234", 10)
 """
 function first(str::AbstractString, nchar::Integer)
     s = start(str)
-    (nchar == 0 || isempty(str)) && return str[s:(s-1)]
+    nchar == 0 && return str[s:(s-1)]
+    if isempty(str)
+        nchar > 0 && return str[s:(s-1)]
+        throw(ArgumentError("nchar must be greater or equal than 0"))
+    end
     nchar == 1 && return str[s:s]
     idx = min(endof(str), nextind(str, s, nchar-1))
     str[s:idx]
@@ -642,7 +646,11 @@ julia> last("1234", 10)
 """
 function last(str::AbstractString, nchar::Integer)
     e = endof(str)
-    (nchar == 0 || isempty(str)) && return str[e:(e-1)]
+    nchar == 0  && return str[e:(e-1)]
+    if isempty(str)
+        nchar > 0 && return str[e:(e-1)]
+        throw(ArgumentError("nchar must be greater or equal than 0"))
+    end
     nchar == 1 && return str[e:e]
     idx = max(start(str), prevind(str, e, nchar-1))
     str[idx:e]

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -595,7 +595,7 @@ end
 """
     first(str::AbstractString, nchar::Integer)
 
-Get a string consisting of the first `nchar` characters of `str`.
+Get a string consisting of at most the first `nchar` characters of `str`.
 
 ```jldoctest
 julia> first("∀ϵ≠0: ϵ²>0", 0)
@@ -606,19 +606,24 @@ julia> first("∀ϵ≠0: ϵ²>0", 1)
 
 julia> first("∀ϵ≠0: ϵ²>0", 3)
 "∀ϵ≠"
+
+julia> first("1234", 10)
+"1234"
 ```
 """
 function first(str::AbstractString, nchar::Integer)
+    s = start(str)
     if 0 <= nchar <= 1
-        return str[1:nchar]
+        return str[s:(s-1+nchar)]
     end
-    str[1:nextind(str, 1, nchar-1)]
+    idx = min(endof(str), nextind(str, s, nchar-1))
+    str[s:idx]
 end
 
 """
     last(str::AbstractString, nchar::Integer)
 
-Get a string consisting of the last `nchar` characters of `str`.
+Get a string consisting of at most the last `nchar` characters of `str`.
 
 ```jldoctest
 julia> last("∀ϵ≠0: ϵ²>0", 0)
@@ -629,6 +634,9 @@ julia> last("∀ϵ≠0: ϵ²>0", 1)
 
 julia> last("∀ϵ≠0: ϵ²>0", 3)
 "²>0"
+
+julia> last("1234", 10)
+"1234"
 ```
 """
 function last(str::AbstractString, nchar::Integer)
@@ -636,7 +644,8 @@ function last(str::AbstractString, nchar::Integer)
     if 0 <= nchar <= 1
         return str[(e-nchar+1):e]
     end
-    str[prevind(str, e, nchar-1):e]
+    idx = max(start(str), prevind(str, e, nchar-1))
+    str[idx:e]
 end
 
 # reverse-order iteration for strings and indices thereof

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -595,7 +595,8 @@ end
 """
     first(str::AbstractString, nchar::Integer)
 
-Get a string consisting of at most the first `nchar` characters of `str`.
+Get a string consisting of the first `nchar` characters of `str` unless `str`
+is shorter than `nchar` characters, in which case a string equal to `str` is returned.
 
 ```jldoctest
 julia> first("∀ϵ≠0: ϵ²>0", 0)
@@ -622,7 +623,8 @@ end
 """
     last(str::AbstractString, nchar::Integer)
 
-Get a string consisting of at most the last `nchar` characters of `str`.
+Get a string consisting of the last `nchar` characters of `str` unless `str`
+is shorter than `nchar` characters, in which case a string equal to `str` is returned.
 
 ```jldoctest
 julia> last("∀ϵ≠0: ϵ²>0", 0)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -613,9 +613,8 @@ julia> first("1234", 10)
 """
 function first(str::AbstractString, nchar::Integer)
     s = start(str)
-    if 0 <= nchar <= 1
-        return str[s:(s-1+nchar)]
-    end
+    (nchar == 0 || isempty(str)) && return str[s:(s-1)]
+    nchar == 1 && return str[s:s]
     idx = min(endof(str), nextind(str, s, nchar-1))
     str[s:idx]
 end
@@ -641,9 +640,8 @@ julia> last("1234", 10)
 """
 function last(str::AbstractString, nchar::Integer)
     e = endof(str)
-    if 0 <= nchar <= 1
-        return str[(e-nchar+1):e]
-    end
+    (nchar == 0 || isempty(str)) && return str[e:(e-1)]
+    nchar == 1 && return str[e:e]
     idx = max(start(str), prevind(str, e, nchar-1))
     str[idx:e]
 end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -637,23 +637,24 @@ end
 end
 
 @testset "first and last" begin
-    s = "∀ϵ≠0: ϵ²>0"
-    @test_throws ArgumentError first(s, -1)
-    @test first(s, 0) == ""
-    @test first(s, 1) == "∀"
-    @test first(s, 2) == "∀ϵ"
-    @test first(s, 3) == "∀ϵ≠"
-    @test first(s, 4) == "∀ϵ≠0"
-    @test first(s, length(s)) == s
-    @test_throws BoundsError first(s, length(s)+1)
-    @test_throws ArgumentError last(s, -1)
-    @test last(s, 0) == ""
-    @test last(s, 1) == "0"
-    @test last(s, 2) == ">0"
-    @test last(s, 3) == "²>0"
-    @test last(s, 4) == "ϵ²>0"
-    @test last(s, length(s)) == s
-    @test_throws BoundsError last(s, length(s)+1)
+    let s = "∀ϵ≠0: ϵ²>0"
+        @test_throws ArgumentError first(s, -1)
+        @test first(s, 0) == ""
+        @test first(s, 1) == "∀"
+        @test first(s, 2) == "∀ϵ"
+        @test first(s, 3) == "∀ϵ≠"
+        @test first(s, 4) == "∀ϵ≠0"
+        @test first(s, length(s)) == s
+        @test first(s, length(s)+1) == s
+        @test_throws ArgumentError last(s, -1)
+        @test last(s, 0) == ""
+        @test last(s, 1) == "0"
+        @test last(s, 2) == ">0"
+        @test last(s, 3) == "²>0"
+        @test last(s, 4) == "ϵ²>0"
+        @test last(s, length(s)) == s
+        @test last(s, length(s)+1) == s
+    end
 end
 
 @testset "invalid code point" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -637,7 +637,7 @@ end
 end
 
 @testset "first and last" begin
-    let s = "∀ϵ≠0: ϵ²>0"
+    for s in ["∀ϵ≠0: ϵ²>0", s"∀ϵ≠0: ϵ²>0", SubString("∀ϵ≠0: ϵ²>0", 1)]
         @test_throws ArgumentError first(s, -1)
         @test first(s, 0) == ""
         @test first(s, 1) == "∀"
@@ -654,6 +654,16 @@ end
         @test last(s, 4) == "ϵ²>0"
         @test last(s, length(s)) == s
         @test last(s, length(s)+1) == s
+    end
+    for s in ["", s"", SubString("", 1)]
+        @test_throws ArgumentError first(s, -1)
+        @test first(s, 0) == ""
+        @test first(s, 1) == ""
+        @test first(s, 2) == ""
+        @test_throws ArgumentError last(s, -1)
+        @test last(s, 0) == ""
+        @test last(s, 1) == ""
+        @test last(s, 2) == ""
     end
 end
 


### PR DESCRIPTION
PR following the discussion in https://github.com/JuliaLang/julia/pull/23960#discussion_r150067576.
For string `str` it allows `nchar` to be greater than `length(str)`. In such a case the whole contents of the original string is returned.
This returned whole string does not have to be of the same type as `str` as in general `getindex` my return a string of different type than the original string.

CC @stevengj 