### PR TITLE
disallow global method definitions inside functions; require `eval`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3927,8 +3927,9 @@ f(x) = yt(x)
             ((boundscheck) (if tail (emit-return e) e))
 
             ((method)
-             ;; TODO: we might want to disallow this
-             ;;(check-top-level e)
+             (if (not (null? (cadr lam)))
+                 (error (string "Global method definition" (linenode-string current-loc)
+                                " needs to be placed at the top level, or use \"eval\".")))
              (if (length> e 2)
                  (begin (emit `(method ,(or (cadr e) 'false)
                                        ,(compile (caddr e) break-labels #t #f)

--- a/test/core.jl
+++ b/test/core.jl
@@ -3225,7 +3225,7 @@ end
 
 g11858(x::Float64) = x
 f11858(a) = for Baz in a
-    (f::Baz)(x) = f(float(x))
+    @eval (f::$Baz)(x) = f(float(x))
 end
 f11858(Any[Type{Foo11858}, Type{Bar11858}, typeof(g11858)])
 
@@ -4158,10 +4158,10 @@ end
 end
 @test f15425(1) === nothing
 
-# issue #15809 --- TODO: this code should be disallowed
+# issue #15809
+# but note, direct global method defs inside functions have since been disallowed
 function f15809()
-    global g15809
-    g15809(x::T) where {T} = T
+    @eval g15809(x::T) where {T} = T
 end
 f15809()
 @test g15809(2) === Int
@@ -5150,8 +5150,7 @@ end
 f21568() = 0
 function foo21568()
     y = 1
-    global f21568
-    f21568(x::AbstractArray{T,1}) where {T<:Real} = y
+    @eval f21568(x::AbstractArray{T,1}) where {T<:Real} = $y
 end
 foo21568()
 @test f21568([0]) == 1

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -695,7 +695,7 @@ end
 
 # First test the world issue condition.
 let foo() = begin
-        Issue19774.f(x::Int) = 2
+        @eval Issue19774.f(x::Int) = 2
         return Issue19774.f(0)
     end
     @test foo() == 1    # We should be using the original function.
@@ -703,7 +703,7 @@ end
 
 # Now check that invokelatest fixes that issue.
 let foo() = begin
-        Issue19774.f(x::Int) = 3
+        @eval Issue19774.f(x::Int) = 3
         return Base.invokelatest(Issue19774.f, 0)
     end
     @test foo() == 3
@@ -717,7 +717,7 @@ end
 @test Kwargs19774.f(2, 3; z=1) == 7
 
 let foo() = begin
-        Kwargs19774.f(x::Int, y::Int; z=3) = z
+        @eval Kwargs19774.f(x::Int, y::Int; z=3) = z
         return Base.invokelatest(Kwargs19774.f, 2, 3; z=1)
     end
     @test foo() == 1

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -334,7 +334,7 @@ g15844 = let
 end
 
 function add_method_to_glob_fn!()
-    global function f15844(x::Int64)
+    @eval global function f15844(x::Int64)
         3x
     end
 end


### PR DESCRIPTION
This disallows the following pattern, something @vtjnash and I have been planning to change:

```
function f()
    global function g()
        ...
    end
end
```

Such code is equivalent to function `f` calling `eval` on the inner method definition, so we feel it's better to require explicit `eval` calls to do this. For instance, it makes it easier to answer "does my code do eval-like things like changing methods at run time?"

Note this *only* affects global method definitions inside other functions (not inside `let` blocks etc. at the top level, not involving `eval` or `@eval`, not inner functions, etc.). I think this pattern is fairly rare.

With this change, `method` expressions are known to only occur at the top level (in lowered form), which is a useful property to have.