### PR TITLE
don't give a parse error for `(x)ᵀ`

### DIFF
--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -203,7 +203,7 @@ value_t fl_julia_strip_op_suffix(fl_context_t *fl_ctx, value_t *args, uint32_t n
         i = j;
     }
     if (!op[i]) return args[0]; // no suffix to strip
-    if (!i) lerror(fl_ctx, symbol(fl_ctx, "error"), "invalid operator");
+    if (!i) return args[0]; // only suffix chars --- might still be a valid identifier
     char *opnew = strncpy((char*)malloc(i+1), op, i);
     opnew[i] = 0;
     value_t opnew_symbol = symbol(fl_ctx, opnew);

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1037,6 +1037,8 @@ for bad in ('=', '$', ':', "||", "&&", "->", "<:")
 end
 @test Base.operator_precedence(:+̂) == Base.operator_precedence(:+)
 
+@test Meta.parse("(x)ᵀ") == Expr(:call, :*, :x, :ᵀ)
+
 # issue #19351
 # adding return type decl should not affect parse of function body
 @test :(t(abc) = 3).args[2] == :(t(abc)::Int = 3).args[2]


### PR DESCRIPTION
The operator suffix feature unintentionally disallowed using identifiers in certain contexts if they happened to consist entirely of valid operator suffix characters. I should have realized it at the time, but this was not a good place to throw an error, since it causes just asking whether a certain symbol is an operator to give a parse error.