### PR TITLE
Faster, more correct complex^complex

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -267,9 +267,6 @@ This section lists changes that do not have deprecation warnings.
   * The return type of `reinterpret` has changed to `ReinterpretArray`. `reinterpret` on sparse
     arrays has been discontinued.
 
-  * `x^y` for complex arguments now throws a `DomainError` in some cases that would have
-    previously given `NaN` results ([#24570]).
-
   * `Base.find_in_path` is now `Base.find_package` or `Base.find_source_file` ([#24320])
 
 Library improvements

--- a/NEWS.md
+++ b/NEWS.md
@@ -267,6 +267,9 @@ This section lists changes that do not have deprecation warnings.
   * The return type of `reinterpret` has changed to `ReinterpretArray`. `reinterpret` on sparse
     arrays has been discontinued.
 
+  * `x^y` for complex arguments now throws a `DomainError` in some cases that would have
+    previously given `NaN` results ([#24570]).
+
   * `Base.find_in_path` is now `Base.find_package` or `Base.find_source_file` ([#24320])
 
 Library improvements

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -676,15 +676,18 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
                 return ip < 0 ? power_by_squaring(inv(z), -ip) : power_by_squaring(z, ip)
             end
         elseif isreal(z)
+            # (note: if both z and p are complex with ±0.0 imaginary parts,
+            #  the sign of the ±0.0 imaginary part of the result is ambiguous)
             if iszero(real(z))
                 return pᵣ > 0 ? complex(z) : Complex(T(NaN),T(NaN)) # 0 or NaN+NaN*im
             elseif real(z) > 0
-                # (if both z and p are complex with ±0.0 imaginary parts, the sign of
-                #  the ±0.0 imaginary part of the result is ambiguous)
                 return Complex(real(z)^pᵣ, z isa Real ? -imag(p) : flipsign(imag(z), pᵣ))
             else
                 zᵣ = real(z)
                 rᵖ = (-zᵣ)^pᵣ
+                # figuring out the sign of 0.0 when p is a complex number
+                # with zero imaginary part and integer/2 real part could be
+                # improved here, but it's not clear if it's worth it…
                 phaseᵣ = cospi(pᵣ)
                 phaseᵢ = flipsign(sinpi(pᵣ),imag(z))
                 return complex(rᵖ * phaseᵣ, rᵖ * phaseᵢ)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -692,8 +692,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
                     return rᵖ * complex(cospi(pᵣ), flipsign(sinpi(pᵣ),imag(z)))
                 else
                     iszero(rᵖ) && return zero(Complex{T}) # no way to get correct signs of 0.0
-                    isnan(rᵖ) && return complex(rᵖ,rᵖ) # propagate NaN
-                    return Complex(T(NaN),T(NaN)) # non-finite phase angle
+                    return Complex(T(NaN),T(NaN)) # non-finite phase angle or NaN input
                 end
             end
         else
@@ -725,8 +724,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
         return rᵖ * cis(ϕ)
     else
         iszero(rᵖ) && return zero(Complex{T}) # no way to get correct signs of 0.0
-        isnan(ϕ) && (isnan(z) || isnan(p)) && return complex(ϕ,ϕ) # propagate NaN
-        return Complex(T(NaN),T(NaN)) # non-finite phase angle
+        return Complex(T(NaN),T(NaN)) # non-finite phase angle or NaN input
     end
 end
 _cpow(z, p) = _cpow(float(z), float(p))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -655,8 +655,12 @@ function _cpow(z, p)
             # |p| < typemax(Int32) serves two purposes: it prevents overflow
             # when converting p to Int, and it also turns out to be roughly
             # the crossover point for exp(p*log(z)) or similar to be faster.
-            ip = convert(Int, pᵣ)
             zf = float(z)
+            if iszero(pᵣ) && iszero(zf) # fix signs of imaginary part for 0^0
+                zer = flipsign(copysign(zero(real(zf)),pᵣ), imag(zf))
+                return Complex(one(real(zf)), zer)
+            end
+            ip = convert(Int, pᵣ)
             return ip < 0 ? power_by_squaring(inv(zf), -ip) : power_by_squaring(zf, ip)
         elseif isreal(z)
             if iszero(real(z))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -688,9 +688,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
                 # figuring out the sign of 0.0 when p is a complex number
                 # with zero imaginary part and integer/2 real part could be
                 # improved here, but it's not clear if it's worth it…
-                phaseᵣ = cospi(pᵣ)
-                phaseᵢ = flipsign(sinpi(pᵣ),imag(z))
-                return complex(rᵖ * phaseᵣ, rᵖ * phaseᵢ)
+                return rᵖ * complex(cospi(pᵣ), flipsign(sinpi(pᵣ),imag(z)))
             end
         else
             return abs(z)^pᵣ * cis(pᵣ*angle(z))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -647,8 +647,6 @@ function exp10(z::Complex{T}) where T<:AbstractFloat
 end
 exp10(z::Complex) = exp10(float(z))
 
-@noinline _cpow_domain_error_angle(z,p) = throw(DomainError((z,p), "z^p gave non-finite phase angle"))
-
 # _cpow helper function to avoid method ambiguity with ^(::Complex,::Real)
 function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:AbstractFloat}
     if isreal(p)
@@ -695,7 +693,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
                 else
                     iszero(rᵖ) && return zero(Complex{T}) # no way to get correct signs of 0.0
                     isnan(rᵖ) && return complex(rᵖ,rᵖ) # propagate NaN
-                    _cpow_domain_error_angle(z,p)
+                    return Complex(T(NaN),T(NaN)) # non-finite phase angle
                 end
             end
         else
@@ -728,7 +726,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
     else
         iszero(rᵖ) && return zero(Complex{T}) # no way to get correct signs of 0.0
         isnan(ϕ) && (isnan(z) || isnan(p)) && return complex(ϕ,ϕ) # propagate NaN
-        _cpow_domain_error_angle(z,p)
+        return Complex(T(NaN),T(NaN)) # non-finite phase angle
     end
 end
 _cpow(z, p) = _cpow(float(z), float(p))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -682,7 +682,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
                 return Complex(real(z)^pᵣ, flipsign(imag(z), pᵣ))
             else
                 zᵣ = real(z)
-                return (-zᵣ)^pᵣ * cis(pᵣ*T(π))
+                return (-zᵣ)^pᵣ * cis(pᵣ*copysign(T(π),imag(z)))
             end
         else
             return abs(z)^pᵣ * cis(pᵣ*angle(z))
@@ -695,7 +695,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
             return zᵣ^pᵣ * cis(pᵢ*log(zᵣ))
         else
             r = -zᵣ
-            θ = T(π)
+            θ = copysign(T(π),imag(z))
             return (r^pᵣ * exp(-pᵢ*θ)) * cis(pᵣ*θ + pᵢ*log(r))
         end
     else

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -693,7 +693,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
                     # improved here, but it's not clear if it's worth it…
                     return rᵖ * complex(cospi(pᵣ), flipsign(sinpi(pᵣ),imag(z)))
                 else
-                    iszero(rᵖ) && return zero(z) # no way to get correct signs of 0.0
+                    iszero(rᵖ) && return zero(Complex{T}) # no way to get correct signs of 0.0
                     isnan(rᵖ) && return complex(rᵖ,rᵖ) # propagate NaN
                     _cpow_domain_error_angle(z,p)
                 end
@@ -726,7 +726,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
     if isfinite(ϕ)
         return rᵖ * cis(ϕ)
     else
-        iszero(rᵖ) && return zero(z) # no way to get correct signs of 0.0
+        iszero(rᵖ) && return zero(Complex{T}) # no way to get correct signs of 0.0
         isnan(ϕ) && (isnan(z) || isnan(p)) && return complex(ϕ,ϕ) # propagate NaN
         _cpow_domain_error_angle(z,p)
     end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -679,10 +679,15 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
             if iszero(real(z))
                 return pᵣ > 0 ? complex(z) : Complex(T(NaN),T(NaN)) # 0 or NaN+NaN*im
             elseif real(z) > 0
-                return Complex(real(z)^pᵣ, flipsign(imag(z), pᵣ))
+                # (if both z and p are complex with ±0.0 imaginary parts, the sign of
+                #  the ±0.0 imaginary part of the result is ambiguous)
+                return Complex(real(z)^pᵣ, z isa Real ? -imag(p) : flipsign(imag(z), pᵣ))
             else
                 zᵣ = real(z)
-                return (-zᵣ)^pᵣ * cis(pᵣ*copysign(T(π),imag(z)))
+                rᵖ = (-zᵣ)^pᵣ
+                phaseᵣ = cospi(pᵣ)
+                phaseᵢ = flipsign(sinpi(pᵣ),imag(z))
+                return complex(rᵖ * phaseᵣ, rᵖ * phaseᵢ)
             end
         else
             return abs(z)^pᵣ * cis(pᵣ*angle(z))

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -681,7 +681,7 @@ function _cpow(z::Union{T,Complex{T}}, p::Union{T,Complex{T}}) where {T<:Abstrac
             if iszero(real(z))
                 return pᵣ > 0 ? complex(z) : Complex(T(NaN),T(NaN)) # 0 or NaN+NaN*im
             elseif real(z) > 0
-                return Complex(real(z)^pᵣ, z isa Real ? -imag(p) : flipsign(imag(z), pᵣ))
+                return Complex(real(z)^pᵣ, z isa Real ? ifelse(real(z) < 1, -imag(p), imag(p)) : flipsign(imag(z), pᵣ))
             else
                 zᵣ = real(z)
                 rᵖ = (-zᵣ)^pᵣ
@@ -729,6 +729,10 @@ _cpow(z, p) = _cpow(float(z), float(p))
 function ^(z::Complex{T}, p::S) where {T<:Real,S<:Real}
     P = promote_type(T,S)
     return Complex{P}(z) ^ P(p)
+end
+function ^(z::T, p::Complex{S}) where {T<:Real,S<:Real}
+    P = promote_type(T,S)
+    return P(z) ^ Complex{P}(p)
 end
 
 function sin(z::Complex{T}) where T

--- a/base/mathconstants.jl
+++ b/base/mathconstants.jl
@@ -82,7 +82,7 @@ catalan = 0.9159655941772...
 catalan
 
 # loop over types to prevent ambiguities for ^(::Number, x)
-for T in (AbstractIrrational, Rational, Integer, Number)
+for T in (AbstractIrrational, Rational, Integer, Number, Complex)
     Base.:^(::Irrational{:ℯ}, x::T) = exp(x)
 end
 Base.literal_pow(::typeof(^), ::Irrational{:ℯ}, ::Val{p}) where {p} = exp(p)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1021,16 +1021,22 @@ end
             @test z^p ≋ c
             if isreal(p)
                 @test z^(p + 1e-15im) ≈ z^(p - 1e-15im) ≈ c
+                if isinteger(p)
+                    @test isequal(z^Integer(pr), z^p)
+                end
+            elseif (zr != 0 || !signbit(zr)) && (zi != 0 || !signbit(zi))
+                @test isequal((Complex{Int}(z*10)//10)^p, z^p)
             end
         end
     end
 
+    @test 2 ^ (0.3 + 0.0im) === 2.0 ^ (0.3 + 0.0im) === conj(2.0 ^ (0.3 - 0.0im)) ≋  2.0 ^ (0.3 + 1e-15im)
     @test 0.2 ^ (0.3 + 0.0im) === conj(0.2 ^ (0.3 - 0.0im)) ≋  0.2 ^ (0.3 + 1e-15im)
     @test (0.0 - 0.0im)^2.0 === (0.0 - 0.0im)^2 === (0.0 - 0.0im)^1.1 === (0.0 - 0.0im) ^ (1.1 + 2.3im) === 0.0 - 0.0im
     @test (0.0 - 0.0im)^-2.0 ≋ (0.0 - 0.0im)^-2 ≋ (0.0 - 0.0im)^-1.1 ≋ (0.0 - 0.0im) ^ (-1.1 + 2.3im) ≋ NaN + NaN*im
     @test (1.0+0.0)^(1.2+0.7im) === 1.0 + 0.0im
     @test (-1.0+0.0)^(2.0+0.7im) ≈ exp(-0.7π)
-    @test (-4.0+0.0im)^1.5 === (-4.0)^(1.5+0.0im) === 0.0 - 8.0im
+    @test (-4.0+0.0im)^1.5 === (-4.0)^(1.5+0.0im) === (-4)^(1.5+0.0im) === (-4)^(3//2+0im) === 0.0 - 8.0im
 
     # issue #24515:
     @test (Inf + Inf*im)^2.0 ≋ (Inf + Inf*im)^2 ≋ NaN + Inf*im

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1058,9 +1058,9 @@ end
 
     # The following cases should arguably give Inf + Inf*im, but currently
     # give partial NaNs instead.  Marking as broken for now (since Julia 0.4 at least),
-    # in the hopes that someday we can fix these corner cases.  (Python gets them wrong too.)
-    @test_broken (Inf + 1im)^3 ≟ (Inf + 1im)^3.0 ≟ (Inf + 1im)^(3+0im) ≟ Inf + Inf*im
-    @test_broken (Inf + 1im)^3.1 ≟ (Inf + 1im)^(3.1+0im) ≟ Inf + Inf*im
+    # in the hope that someday we can fix these corner cases.  (Python gets them wrong too.)
+    @test_broken (Inf + 1im)^3 === (Inf + 1im)^3.0 === (Inf + 1im)^(3+0im) === Inf + Inf*im
+    @test_broken (Inf + 1im)^3.1 === (Inf + 1im)^(3.1+0im) === Inf + Inf*im
 
     # cases where phase angle is non-finite throw DomainError:
     @test_throws DomainError Inf ^ (2 + 3im)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1062,17 +1062,10 @@ end
     @test_broken (Inf + 1im)^3 === (Inf + 1im)^3.0 === (Inf + 1im)^(3+0im) === Inf + Inf*im
     @test_broken (Inf + 1im)^3.1 === (Inf + 1im)^(3.1+0im) === Inf + Inf*im
 
-    # cases where phase angle is non-finite throw DomainError:
-    @test_throws DomainError Inf ^ (2 + 3im)
-    @test_throws DomainError (Inf + 1im) ^ (2 + 3im)
-    @test_throws DomainError (Inf*im) ^ (2 + 3im)
-    @test_throws DomainError 3^(Inf*im)
-    @test_throws DomainError (-3)^(Inf + 0im)
-    @test_throws DomainError (-3)^(Inf + 1im)
-    @test_throws DomainError (3+1im)^Inf
-    @test_throws DomainError (3+1im)^(Inf + 1im)
-    @test_throws DomainError (1e200+1e-200im)^Inf  # angle(z) underflows
-    @test_throws DomainError (1e200+1e-200im)^(Inf+1im)
+    # cases where phase angle is non-finite yield NaN + NaN*im:
+    @test NaN + NaN*im ≟ Inf ^ (2 + 3im) ≟ (Inf + 1im) ^ (2 + 3im) ≟ (Inf*im) ^ (2 + 3im) ≟
+          3^(Inf*im) ≟ (-3)^(Inf + 0im) ≟ (-3)^(Inf + 1im) ≟ (3+1im)^Inf ≟
+          (3+1im)^(Inf + 1im) ≟ (1e200+1e-200im)^Inf ≟ (1e200+1e-200im)^(Inf+1im)
 
     @test @inferred(2.0^(3.0+0im)) === @inferred((2.0+0im)^(3.0+0im)) === @inferred((2.0+0im)^3.0) === 8.0+0.0im
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1073,4 +1073,6 @@ end
     @test_throws DomainError (3+1im)^(Inf + 1im)
     @test_throws DomainError (1e200+1e-200im)^Inf  # angle(z) underflows
     @test_throws DomainError (1e200+1e-200im)^(Inf+1im)
+
+    @test @inferred(2.0^(3.0+0im)) === @inferred((2.0+0im)^(3.0+0im)) === @inferred((2.0+0im)^3.0) === 8.0+0.0im
 end


### PR DESCRIPTION
This PR fixes the incorrect behaviors for `complex^complex` identified in #24515, and it also makes the code significantly faster without (as far as I can tell) sacrificing accuracy.  On my machine, it is around 60% faster for `complex^complex` and 120% faster for `real^complex` in double precision.

The old code had two completely separate implementations, one for floating-point types and one for other types, despite the fact that both produced floating-point results.  The floating-point version was based on `z^p = exp(p * log(z))`, whereas the other version first converted `z` to polar form and then exponentiated.  The latter approach seems to be significantly faster and no less accurate, so I now use that in all cases (with various special-case optimizations for real z and/or p).  By unifying the implementations, the code is also significantly shorter.

~~Marked as **breaking** only because this throws exceptions in some cases where the old code would have silently returned NaNs.~~ Returns NaN as before.

See also the discussions in #2891, #3246, 06530b6ea8c87842cba9e06d38f2fc02e29ddb24.

To do:
- [x] Tests: need to cover all of the branches and edge cases.
- [x] Fixes/tests for Inf and NaN cases
- [x] Decide whether to throw `DomainError` for `(0.0+0.0im)^-1.0` and other cases ala #5234