### PR TITLE
make sure eltype(A::HermOrSym) === eltype(parent(A))

### DIFF
--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Symmetric and Hermitian matrices
-struct Symmetric{T,S<:AbstractMatrix} <: AbstractMatrix{T}
+struct Symmetric{T,S<:AbstractMatrix{T}} <: AbstractMatrix{T}
     data::S
     uplo::Char
 end
@@ -42,7 +42,7 @@ Note that `Supper` will not be equal to `Slower` unless `A` is itself symmetric 
 """
 Symmetric(A::AbstractMatrix, uplo::Symbol=:U) = (checksquare(A); Symmetric{eltype(A),typeof(A)}(A, char_uplo(uplo)))
 
-struct Hermitian{T,S<:AbstractMatrix} <: AbstractMatrix{T}
+struct Hermitian{T,S<:AbstractMatrix{T}} <: AbstractMatrix{T}
     data::S
     uplo::Char
 end

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -463,3 +463,9 @@ end
         @test isa(similar(symsparsemat, Float32, (n, n)), SparseMatrixCSC{Float32})
     end
 end
+
+@testset "#24572: eltype(A::HermOrSym) === eltype(parent(A))" begin
+    A = rand(Float32, 3, 3)
+    @test_throws TypeError Symmetric{Float64,Matrix{Float32}}(A, 'U')
+    @test_throws TypeError Hermitian{Float64,Matrix{Float32}}(A, 'U')
+end


### PR DESCRIPTION
Makes sure we cannot end up with:
```julia
julia> A = rand(Complex{Float64}, 4, 4);

julia> S = Symmetric{Float64,Matrix{Complex{Float64}}}(A, 'U');

julia> H = Hermitian{Float64,Matrix{Complex{Float64}}}(A, 'U');

julia> eltype(S) === eltype(parent(S))
false

julia> eltype(H) === eltype(parent(H))
false
```