### PR TITLE
Don't use global opt_level from in addOptimizationPasses

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -139,7 +139,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     }
     PM->add(createPropagateJuliaAddrspaces());
     PM->add(createTypeBasedAAWrapperPass());
-    if (jl_options.opt_level >= 3) {
+    if (opt_level >= 3) {
         PM->add(createBasicAAWrapperPass());
     }
     // list of passes from vmkit
@@ -238,12 +238,12 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     PM->add(createLoopDeletionPass());          // Delete dead loops
     PM->add(createJumpThreadingPass());         // Thread jumps
 
-    if (jl_options.opt_level >= 3) {
+    if (opt_level >= 3) {
         PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
     }
 
     PM->add(createAggressiveDCEPass());         // Delete dead instructions
-    if (jl_options.opt_level >= 3)
+    if (opt_level >= 3)
         PM->add(createInstructionCombiningPass());   // Clean up after SLP loop vectorizer
     PM->add(createLoopVectorizePass());         // Vectorize loops
     PM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer


### PR DESCRIPTION
`addOptimizationPasses` is getting the opt_level passed as an argument, but a couple of places for `-O3`
were still using the global opt_level.