### PR TITLE
Rename LibGit2 credential types

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1621,10 +1621,10 @@ import .Iterators.enumerate
 
 # PR #23640
 # when this deprecation is deleted, remove all calls to it, and replace all keywords of:
-# `payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}` with
+# `payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}` with
 # `payload::CredentialPayload` from base/libgit2/libgit2.jl
 @eval LibGit2 function deprecate_nullable_creds(f, sig, payload)
-    if isa(payload, Nullable{<:AbstractCredentials})
+    if isa(payload, Nullable{<:AbstractCredential})
         # Note: Be careful not to show the contents of the credentials as it could reveal a
         # password.
         if isnull(payload)
@@ -1685,7 +1685,7 @@ end
 @deprecate zeros(D::Diagonal, ::Type{T}, dims::Integer...) where {T}    fill!(similar(D, T, dims), 0)
 
 # PR #23690
-# `SSHCredentials` and `UserPasswordCredentials` constructors using `prompt_if_incorrect`
+# `SSHCredential` and `UserPasswordCredential` constructors using `prompt_if_incorrect`
 # are deprecated in base/libgit2/types.jl.
 
 # deprecate ones/zeros methods accepting an array as first argument
@@ -2175,6 +2175,13 @@ end
 # issue #24019
 @deprecate similar(a::Associative) empty(a)
 @deprecate similar(a::Associative, ::Type{Pair{K,V}}) where {K, V} empty(a, K, V)
+
+# PR #24594
+@eval LibGit2 begin
+    @deprecate AbstractCredentials AbstractCredential false
+    @deprecate UserPasswordCredentials UserPasswordCredential false
+    @deprecate SSHCredentials SSHCredential false
+end
 
 # END 0.7 deprecations
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1621,10 +1621,10 @@ import .Iterators.enumerate
 
 # PR #23640
 # when this deprecation is deleted, remove all calls to it, and replace all keywords of:
-# `payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}` with
-# `payload::CredentialPayload` from base/libgit2/libgit2.jl
+# `payload::Union{CredentialPayload,Nullable{<:Union{AbstractCredential, CachedCredentials}}}`
+#  with `payload::CredentialPayload` from base/libgit2/libgit2.jl
 @eval LibGit2 function deprecate_nullable_creds(f, sig, payload)
-    if isa(payload, Nullable{<:AbstractCredential})
+    if isa(payload, Nullable{<:Union{AbstractCredential, CachedCredentials}})
         # Note: Be careful not to show the contents of the credentials as it could reveal a
         # password.
         if isnull(payload)

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -62,7 +62,7 @@ function exhausted_abort()
 end
 
 function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, username_ptr)
-    cred = Base.get(p.credential)::SSHCredentials
+    cred = Base.get(p.credential)::SSHCredential
     revised = false
 
     # Use a filled credential as-is on the first pass. Reset password on sucessive calls.
@@ -174,7 +174,7 @@ function authenticate_ssh(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload, 
 end
 
 function authenticate_userpass(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayload)
-    cred = Base.get(p.credential)::UserPasswordCredentials
+    cred = Base.get(p.credential)::UserPasswordCredential
     revised = false
 
     # Use a filled credential as-is on the first pass. Reset password on sucessive calls.
@@ -288,9 +288,9 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
             # Copy explicit credentials to avoid mutating approved credentials.
             p.credential = Nullable(deepcopy(cred))
 
-            if isa(cred, SSHCredentials)
+            if isa(cred, SSHCredential)
                 allowed_types &= Cuint(Consts.CREDTYPE_SSH_KEY)
-            elseif isa(cred, UserPasswordCredentials)
+            elseif isa(cred, UserPasswordCredential)
                 allowed_types &= Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT)
             else
                 allowed_types &= Cuint(0)  # Unhandled credential type
@@ -312,16 +312,16 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Void}}, url_ptr::Cstring,
 
     # use ssh key or ssh-agent
     if isset(allowed_types, Cuint(Consts.CREDTYPE_SSH_KEY))
-        if isnull(p.credential) || !isa(unsafe_get(p.credential), SSHCredentials)
-            p.credential = Nullable(SSHCredentials(p.username))
+        if isnull(p.credential) || !isa(unsafe_get(p.credential), SSHCredential)
+            p.credential = Nullable(SSHCredential(p.username))
         end
         err = authenticate_ssh(libgit2credptr, p, username_ptr)
         err == 0 && return err
     end
 
     if isset(allowed_types, Cuint(Consts.CREDTYPE_USERPASS_PLAINTEXT))
-        if isnull(p.credential) || !isa(unsafe_get(p.credential), UserPasswordCredentials)
-            p.credential = Nullable(UserPasswordCredentials(p.username))
+        if isnull(p.credential) || !isa(unsafe_get(p.credential), UserPasswordCredential)
+            p.credential = Nullable(UserPasswordCredential(p.username))
         end
         err = authenticate_userpass(libgit2credptr, p)
         err == 0 && return err

--- a/base/libgit2/gitcredential.jl
+++ b/base/libgit2/gitcredential.jl
@@ -42,7 +42,7 @@ function GitCredential(cfg::GitConfig, url::AbstractString)
     fill!(cfg, parse(GitCredential, url))
 end
 
-function GitCredential(cred::UserPasswordCredentials, url::AbstractString)
+function GitCredential(cred::UserPasswordCredential, url::AbstractString)
     git_cred = parse(GitCredential, url)
     git_cred.username = Nullable{String}(deepcopy(cred.user))
     git_cred.password = Nullable{String}(deepcopy(cred.pass))
@@ -285,10 +285,10 @@ function use_http_path(cfg::GitConfig, cred::GitCredential)
     return use_path
 end
 
-approve(cfg::GitConfig, cred::AbstractCredentials, url::AbstractString) = nothing
-reject(cfg::GitConfig, cred::AbstractCredentials, url::AbstractString) = nothing
+approve(cfg::GitConfig, cred::AbstractCredential, url::AbstractString) = nothing
+reject(cfg::GitConfig, cred::AbstractCredential, url::AbstractString) = nothing
 
-function approve(cfg::GitConfig, cred::UserPasswordCredentials, url::AbstractString)
+function approve(cfg::GitConfig, cred::UserPasswordCredential, url::AbstractString)
     git_cred = GitCredential(cred, url)
     git_cred.use_http_path = use_http_path(cfg, git_cred)
 
@@ -300,7 +300,7 @@ function approve(cfg::GitConfig, cred::UserPasswordCredentials, url::AbstractStr
     nothing
 end
 
-function reject(cfg::GitConfig, cred::UserPasswordCredentials, url::AbstractString)
+function reject(cfg::GitConfig, cred::UserPasswordCredential, url::AbstractString)
     git_cred = GitCredential(cred, url)
     git_cred.use_http_path = use_http_path(cfg, git_cred)
 

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -262,7 +262,7 @@ Equivalent to `git fetch [<remoteurl>|<repo>] [<refspecs>]`.
 function fetch(repo::GitRepo; remote::AbstractString="origin",
                remoteurl::AbstractString="",
                refspecs::Vector{<:AbstractString}=AbstractString[],
-               payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}=CredentialPayload())
+               payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}=CredentialPayload())
     p = reset!(deprecate_nullable_creds(:fetch, "repo", payload), GitConfig(repo))
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
@@ -304,7 +304,7 @@ function push(repo::GitRepo; remote::AbstractString="origin",
               remoteurl::AbstractString="",
               refspecs::Vector{<:AbstractString}=AbstractString[],
               force::Bool=false,
-              payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}=CredentialPayload())
+              payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}=CredentialPayload())
     p = reset!(deprecate_nullable_creds(:push, "repo", payload), GitConfig(repo))
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
@@ -520,7 +520,7 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
                branch::AbstractString="",
                isbare::Bool = false,
                remote_cb::Ptr{Void} = C_NULL,
-               payload::Union{CredentialPayload,Nullable{<:AbstractCredentials}}=CredentialPayload())
+               payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}=CredentialPayload())
     # setup clone options
     lbranch = Base.cconvert(Cstring, branch)
     @Base.gc_preserve lbranch begin

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -262,7 +262,7 @@ Equivalent to `git fetch [<remoteurl>|<repo>] [<refspecs>]`.
 function fetch(repo::GitRepo; remote::AbstractString="origin",
                remoteurl::AbstractString="",
                refspecs::Vector{<:AbstractString}=AbstractString[],
-               payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}=CredentialPayload())
+               payload::Union{CredentialPayload,Nullable{<:Union{AbstractCredential, CachedCredentials}}}=CredentialPayload())
     p = reset!(deprecate_nullable_creds(:fetch, "repo", payload), GitConfig(repo))
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
@@ -304,7 +304,7 @@ function push(repo::GitRepo; remote::AbstractString="origin",
               remoteurl::AbstractString="",
               refspecs::Vector{<:AbstractString}=AbstractString[],
               force::Bool=false,
-              payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}=CredentialPayload())
+              payload::Union{CredentialPayload,Nullable{<:Union{AbstractCredential, CachedCredentials}}}=CredentialPayload())
     p = reset!(deprecate_nullable_creds(:push, "repo", payload), GitConfig(repo))
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
@@ -520,7 +520,7 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
                branch::AbstractString="",
                isbare::Bool = false,
                remote_cb::Ptr{Void} = C_NULL,
-               payload::Union{CredentialPayload,Nullable{<:AbstractCredential}}=CredentialPayload())
+               payload::Union{CredentialPayload,Nullable{<:Union{AbstractCredential, CachedCredentials}}}=CredentialPayload())
     # setup clone options
     lbranch = Base.cconvert(Cstring, branch)
     @Base.gc_preserve lbranch begin

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1215,7 +1215,7 @@ function isfilled(cred::SSHCredential)
 end
 
 "Caches credential information for re-use"
-struct CachedCredentials <: AbstractCredential
+struct CachedCredentials
     cred::Dict{String,AbstractCredential}
     CachedCredentials() = new(Dict{String,AbstractCredential}())
 end

--- a/base/libgit2/types.jl
+++ b/base/libgit2/types.jl
@@ -1128,58 +1128,57 @@ end
 
 import Base.securezero!
 
-"Abstract credentials payload"
-abstract type AbstractCredentials end
+abstract type AbstractCredential end
 
 """
-    isfilled(cred::AbstractCredentials) -> Bool
+    isfilled(cred::AbstractCredential) -> Bool
 
 Verifies that a credential is ready for use in authentication.
 """
-isfilled(::AbstractCredentials)
+isfilled(::AbstractCredential)
 
-"Credentials that support only `user` and `password` parameters"
-mutable struct UserPasswordCredentials <: AbstractCredentials
+"Credential that support only `user` and `password` parameters"
+mutable struct UserPasswordCredential <: AbstractCredential
     user::String
     pass::String
-    function UserPasswordCredentials(user::AbstractString="", pass::AbstractString="")
+    function UserPasswordCredential(user::AbstractString="", pass::AbstractString="")
         c = new(user, pass)
         finalizer(securezero!, c)
         return c
     end
 
     # Deprecated constructors
-    function UserPasswordCredentials(u::AbstractString,p::AbstractString,prompt_if_incorrect::Bool)
+    function UserPasswordCredential(u::AbstractString,p::AbstractString,prompt_if_incorrect::Bool)
         Base.depwarn(string(
-            "`UserPasswordCredentials` no longer supports the `prompt_if_incorrect` parameter. ",
+            "`UserPasswordCredential` no longer supports the `prompt_if_incorrect` parameter. ",
             "Use the `allow_prompt` keyword in supported by `LibGit2.CredentialPayload` ",
-            "instead."), :UserPasswordCredentials)
-        UserPasswordCredentials(u, p)
+            "instead."), :UserPasswordCredential)
+        UserPasswordCredential(u, p)
     end
-    UserPasswordCredentials(prompt_if_incorrect::Bool) = UserPasswordCredentials("","",prompt_if_incorrect)
+    UserPasswordCredential(prompt_if_incorrect::Bool) = UserPasswordCredential("","",prompt_if_incorrect)
 end
 
-function securezero!(cred::UserPasswordCredentials)
+function securezero!(cred::UserPasswordCredential)
     securezero!(cred.user)
     securezero!(cred.pass)
     return cred
 end
 
-function Base.:(==)(a::UserPasswordCredentials, b::UserPasswordCredentials)
+function Base.:(==)(a::UserPasswordCredential, b::UserPasswordCredential)
     a.user == b.user && a.pass == b.pass
 end
 
-function isfilled(cred::UserPasswordCredentials)
+function isfilled(cred::UserPasswordCredential)
     !isempty(cred.user) && !isempty(cred.pass)
 end
 
-"SSH credentials type"
-mutable struct SSHCredentials <: AbstractCredentials
+"SSH credential type"
+mutable struct SSHCredential <: AbstractCredential
     user::String
     pass::String
     prvkey::String
     pubkey::String
-    function SSHCredentials(user::AbstractString="", pass::AbstractString="",
+    function SSHCredential(user::AbstractString="", pass::AbstractString="",
                             prvkey::AbstractString="", pubkey::AbstractString="")
         c = new(user, pass, prvkey, pubkey)
         finalizer(securezero!, c)
@@ -1187,18 +1186,18 @@ mutable struct SSHCredentials <: AbstractCredentials
     end
 
     # Deprecated constructors
-    function SSHCredentials(u::AbstractString,p::AbstractString,prvkey::AbstractString,pubkey::AbstractString,prompt_if_incorrect::Bool)
+    function SSHCredential(u::AbstractString,p::AbstractString,prvkey::AbstractString,pubkey::AbstractString,prompt_if_incorrect::Bool)
         Base.depwarn(string(
-            "`SSHCredentials` no longer supports the `prompt_if_incorrect` parameter. ",
+            "`SSHCredential` no longer supports the `prompt_if_incorrect` parameter. ",
             "Use the `allow_prompt` keyword in supported by `LibGit2.CredentialPayload` ",
-            "instead."), :SSHCredentials)
-        SSHCredentials(u, p, prvkey, pubkey)
+            "instead."), :SSHCredential)
+        SSHCredential(u, p, prvkey, pubkey)
     end
-    SSHCredentials(u::AbstractString, p::AbstractString, prompt_if_incorrect::Bool) = SSHCredentials(u,p,"","",prompt_if_incorrect)
-    SSHCredentials(prompt_if_incorrect::Bool) = SSHCredentials("","","","",prompt_if_incorrect)
+    SSHCredential(u::AbstractString, p::AbstractString, prompt_if_incorrect::Bool) = SSHCredential(u,p,"","",prompt_if_incorrect)
+    SSHCredential(prompt_if_incorrect::Bool) = SSHCredential("","","","",prompt_if_incorrect)
 end
 
-function securezero!(cred::SSHCredentials)
+function securezero!(cred::SSHCredential)
     securezero!(cred.user)
     securezero!(cred.pass)
     securezero!(cred.prvkey)
@@ -1206,19 +1205,19 @@ function securezero!(cred::SSHCredentials)
     return cred
 end
 
-function Base.:(==)(a::SSHCredentials, b::SSHCredentials)
+function Base.:(==)(a::SSHCredential, b::SSHCredential)
     a.user == b.user && a.pass == b.pass && a.prvkey == b.prvkey && a.pubkey == b.pubkey
 end
 
-function isfilled(cred::SSHCredentials)
+function isfilled(cred::SSHCredential)
     !isempty(cred.user) && isfile(cred.prvkey) && isfile(cred.pubkey) &&
     (!isempty(cred.pass) || !is_passphrase_required(cred.prvkey))
 end
 
-"Credentials that support caching"
-struct CachedCredentials <: AbstractCredentials
-    cred::Dict{String,AbstractCredentials}
-    CachedCredentials() = new(Dict{String,AbstractCredentials}())
+"Caches credential information for re-use"
+struct CachedCredentials <: AbstractCredential
+    cred::Dict{String,AbstractCredential}
+    CachedCredentials() = new(Dict{String,AbstractCredential}())
 end
 
 Base.haskey(cache::CachedCredentials, cred_id) = Base.haskey(cache.cred, cred_id)
@@ -1230,13 +1229,13 @@ function securezero!(p::CachedCredentials)
     return p
 end
 
-function approve(cache::CachedCredentials, cred::AbstractCredentials, url::AbstractString)
+function approve(cache::CachedCredentials, cred::AbstractCredential, url::AbstractString)
     cred_id = credential_identifier(url)
     cache.cred[cred_id] = cred
     nothing
 end
 
-function reject(cache::CachedCredentials, cred::AbstractCredentials, url::AbstractString)
+function reject(cache::CachedCredentials, cred::AbstractCredential, url::AbstractString)
     cred_id = credential_identifier(url)
     if haskey(cache.cred, cred_id)
         delete!(cache.cred, cred_id)
@@ -1252,7 +1251,7 @@ A `CredentialPayload` instance is expected to be `reset!` whenever it will be us
 different URL.
 """
 mutable struct CredentialPayload <: Payload
-    explicit::Nullable{AbstractCredentials}
+    explicit::Nullable{AbstractCredential}
     cache::Nullable{CachedCredentials}
     allow_ssh_agent::Bool    # Allow the use of the SSH agent to get credentials
     allow_git_helpers::Bool  # Allow the use of git credential helpers
@@ -1261,7 +1260,7 @@ mutable struct CredentialPayload <: Payload
     config::GitConfig
 
     # Ephemeral state fields
-    credential::Nullable{AbstractCredentials}
+    credential::Nullable{AbstractCredential}
     first_pass::Bool
     use_ssh_agent::Bool
     use_env::Bool
@@ -1274,7 +1273,7 @@ mutable struct CredentialPayload <: Payload
     host::String
 
     function CredentialPayload(
-            credential::Nullable{<:AbstractCredentials}=Nullable{AbstractCredentials}(),
+            credential::Nullable{<:AbstractCredential}=Nullable{AbstractCredential}(),
             cache::Nullable{CachedCredentials}=Nullable{CachedCredentials}(),
             config::GitConfig=GitConfig();
             allow_ssh_agent::Bool=true,
@@ -1286,12 +1285,12 @@ mutable struct CredentialPayload <: Payload
     end
 end
 
-function CredentialPayload(credential::AbstractCredentials; kwargs...)
+function CredentialPayload(credential::AbstractCredential; kwargs...)
     CredentialPayload(Nullable(credential), Nullable{CachedCredentials}(); kwargs...)
 end
 
 function CredentialPayload(cache::CachedCredentials; kwargs...)
-    CredentialPayload(Nullable{AbstractCredentials}(), Nullable(cache); kwargs...)
+    CredentialPayload(Nullable{AbstractCredential}(), Nullable(cache); kwargs...)
 end
 
 """
@@ -1302,7 +1301,7 @@ the credential callback. If a `config` is provided the configuration will also b
 """
 function reset!(p::CredentialPayload, config::GitConfig=p.config)
     p.config = config
-    p.credential = Nullable{AbstractCredentials}()
+    p.credential = Nullable{AbstractCredential}()
     p.first_pass = true
     p.use_ssh_agent = p.allow_ssh_agent
     p.use_env = true

--- a/doc/src/devdocs/libgit2.md
+++ b/doc/src/devdocs/libgit2.md
@@ -150,9 +150,8 @@ Base.LibGit2.with
 Base.LibGit2.with_warn
 Base.LibGit2.workdir
 Base.LibGit2.GitObject(::Base.LibGit2.GitTreeEntry)
-Base.LibGit2.AbstractCredentials
-Base.LibGit2.UserPasswordCredentials
-Base.LibGit2.SSHCredentials
+Base.LibGit2.UserPasswordCredential
+Base.LibGit2.SSHCredential
 Base.LibGit2.isfilled
 Base.LibGit2.CachedCredentials
 Base.LibGit2.CredentialPayload

--- a/test/libgit2-helpers.jl
+++ b/test/libgit2-helpers.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import Base.LibGit2: AbstractCredentials, UserPasswordCredentials, SSHCredentials,
+import Base.LibGit2: AbstractCredential, UserPasswordCredential, SSHCredential,
     CachedCredentials, CredentialPayload, Payload
 
 const DEFAULT_PAYLOAD = CredentialPayload(allow_ssh_agent=false, allow_git_helpers=false)
@@ -10,7 +10,7 @@ Emulates the LibGit2 credential loop to allows testing of the credential_callbac
 without having to authenticate against a real server.
 """
 function credential_loop(
-        valid_credential::AbstractCredentials,
+        valid_credential::AbstractCredential,
         url::AbstractString,
         user::Nullable{<:AbstractString},
         allowed_types::UInt32,
@@ -58,7 +58,7 @@ function credential_loop(
 end
 
 function credential_loop(
-        valid_credential::UserPasswordCredentials,
+        valid_credential::UserPasswordCredential,
         url::AbstractString,
         user::Nullable{<:AbstractString}=Nullable{String}(),
         payload::CredentialPayload=DEFAULT_PAYLOAD;
@@ -67,7 +67,7 @@ function credential_loop(
 end
 
 function credential_loop(
-        valid_credential::SSHCredentials,
+        valid_credential::SSHCredential,
         url::AbstractString,
         user::Nullable{<:AbstractString}=Nullable{String}(),
         payload::CredentialPayload=DEFAULT_PAYLOAD;
@@ -76,7 +76,7 @@ function credential_loop(
 end
 
 function credential_loop(
-        valid_credential::AbstractCredentials,
+        valid_credential::AbstractCredential,
         url::AbstractString,
         user::AbstractString,
         payload::CredentialPayload=DEFAULT_PAYLOAD;

--- a/test/libgit2-online.jl
+++ b/test/libgit2-online.jl
@@ -23,7 +23,7 @@ mktempdir() do dir
             try
                 repo_path = joinpath(dir, "Example2")
                 # credentials are required because github tries to authenticate on unknown repo
-                cred = LibGit2.UserPasswordCredentials("JeffBezanson", "hunter2") # make sure Jeff is using a good password :)
+                cred = LibGit2.UserPasswordCredential("JeffBezanson", "hunter2") # make sure Jeff is using a good password :)
                 payload = LibGit2.CredentialPayload(cred, allow_prompt=false, allow_git_helpers=false)
                 LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
                 error("unexpected")
@@ -37,7 +37,7 @@ mktempdir() do dir
             try
                 repo_path = joinpath(dir, "Example3")
                 # credentials are required because github tries to authenticate on unknown repo
-                cred = LibGit2.UserPasswordCredentials("","") # empty credentials cause authentication error
+                cred = LibGit2.UserPasswordCredential("","") # empty credentials cause authentication error
                 payload = LibGit2.CredentialPayload(cred, allow_prompt=false, allow_git_helpers=false)
                 LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
                 error("unexpected")

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1515,17 +1515,17 @@ mktempdir() do dir
     @testset "Credentials" begin
         creds_user = "USER"
         creds_pass = "PASS"
-        creds = LibGit2.UserPasswordCredentials(creds_user, creds_pass)
+        creds = LibGit2.UserPasswordCredential(creds_user, creds_pass)
         @test creds.user == creds_user
         @test creds.pass == creds_pass
-        creds2 = LibGit2.UserPasswordCredentials(creds_user, creds_pass)
+        creds2 = LibGit2.UserPasswordCredential(creds_user, creds_pass)
         @test creds == creds2
-        sshcreds = LibGit2.SSHCredentials(creds_user, creds_pass)
+        sshcreds = LibGit2.SSHCredential(creds_user, creds_pass)
         @test sshcreds.user == creds_user
         @test sshcreds.pass == creds_pass
         @test isempty(sshcreds.prvkey)
         @test isempty(sshcreds.pubkey)
-        sshcreds2 = LibGit2.SSHCredentials(creds_user, creds_pass)
+        sshcreds2 = LibGit2.SSHCredential(creds_user, creds_pass)
         @test sshcreds == sshcreds2
     end
 
@@ -1534,7 +1534,7 @@ mktempdir() do dir
 
         url = "https://github.com/JuliaLang/Example.jl"
         cred_id = LibGit2.credential_identifier(url)
-        cred = LibGit2.UserPasswordCredentials("julia", "password")
+        cred = LibGit2.UserPasswordCredential("julia", "password")
 
         @test !haskey(cache, cred_id)
 
@@ -1812,11 +1812,11 @@ mktempdir() do dir
             username = "git"
 
             valid_key = joinpath(KEY_DIR, "valid")
-            valid_cred = LibGit2.SSHCredentials(username, "", valid_key, valid_key * ".pub")
+            valid_cred = LibGit2.SSHCredential(username, "", valid_key, valid_key * ".pub")
 
             valid_p_key = joinpath(KEY_DIR, "valid-passphrase")
             passphrase = "secret"
-            valid_p_cred = LibGit2.SSHCredentials(username, passphrase, valid_p_key, valid_p_key * ".pub")
+            valid_p_cred = LibGit2.SSHCredential(username, passphrase, valid_p_key, valid_p_key * ".pub")
 
             invalid_key = joinpath(KEY_DIR, "invalid")
 
@@ -2054,7 +2054,7 @@ mktempdir() do dir
 
             valid_username = "julia"
             valid_password = randstring(16)
-            valid_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password)
+            valid_cred = LibGit2.UserPasswordCredential(valid_username, valid_password)
 
             https_ex = quote
                 include($LIBGIT2_HELPER_PATH)
@@ -2116,7 +2116,7 @@ mktempdir() do dir
             url = "github.com:test/package.jl"
 
             valid_key = joinpath(KEY_DIR, "valid")
-            valid_cred = LibGit2.SSHCredentials("git", "", valid_key, valid_key * ".pub")
+            valid_cred = LibGit2.SSHCredential("git", "", valid_key, valid_key * ".pub")
 
             function gen_ex(; username="git")
                 quote
@@ -2149,11 +2149,11 @@ mktempdir() do dir
                 mkdir(dirname(default_key))
 
                 valid_key = joinpath(KEY_DIR, "valid")
-                valid_cred = LibGit2.SSHCredentials("git", "", valid_key, valid_key * ".pub")
+                valid_cred = LibGit2.SSHCredential("git", "", valid_key, valid_key * ".pub")
 
                 valid_p_key = joinpath(KEY_DIR, "valid-passphrase")
                 passphrase = "secret"
-                valid_p_cred = LibGit2.SSHCredentials("git", passphrase, valid_p_key, valid_p_key * ".pub")
+                valid_p_cred = LibGit2.SSHCredential("git", passphrase, valid_p_key, valid_p_key * ".pub")
 
                 function gen_ex(cred)
                     quote
@@ -2206,7 +2206,7 @@ mktempdir() do dir
             url = "git@github.com:test/package.jl"
 
             valid_key = joinpath(KEY_DIR, "valid")
-            valid_cred = LibGit2.SSHCredentials("git", "", valid_key, valid_key * ".pub")
+            valid_cred = LibGit2.SSHCredential("git", "", valid_key, valid_key * ".pub")
 
             invalid_key = joinpath(KEY_DIR, "invalid")
 
@@ -2255,10 +2255,10 @@ mktempdir() do dir
 
             valid_p_key = joinpath(KEY_DIR, "valid-passphrase")
             passphrase = "secret"
-            valid_cred = LibGit2.SSHCredentials(username, passphrase, valid_p_key, valid_p_key * ".pub")
+            valid_cred = LibGit2.SSHCredential(username, passphrase, valid_p_key, valid_p_key * ".pub")
 
             invalid_key = joinpath(KEY_DIR, "invalid")
-            invalid_cred = LibGit2.SSHCredentials(username, "", invalid_key, invalid_key * ".pub")
+            invalid_cred = LibGit2.SSHCredential(username, "", invalid_key, invalid_key * ".pub")
 
             function gen_ex(cred; allow_prompt=true, allow_ssh_agent=false)
                 quote
@@ -2291,8 +2291,8 @@ mktempdir() do dir
         @testset "HTTPS explicit credentials" begin
             url = "https://github.com/test/package.jl"
 
-            valid_cred = LibGit2.UserPasswordCredentials("julia", randstring(16))
-            invalid_cred = LibGit2.UserPasswordCredentials("alice", randstring(15))
+            valid_cred = LibGit2.UserPasswordCredential("julia", randstring(16))
+            invalid_cred = LibGit2.UserPasswordCredential("alice", randstring(15))
 
             function gen_ex(cred; allow_prompt=true)
                 quote
@@ -2326,11 +2326,11 @@ mktempdir() do dir
 
             valid_username = "julia"
             valid_password = randstring(16)
-            valid_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password)
+            valid_cred = LibGit2.UserPasswordCredential(valid_username, valid_password)
 
             invalid_username = "alice"
             invalid_password = randstring(15)
-            invalid_cred = LibGit2.UserPasswordCredentials(invalid_username, invalid_password)
+            invalid_cred = LibGit2.UserPasswordCredential(invalid_username, invalid_password)
 
             function gen_ex(; cached_cred=nothing, allow_prompt=true)
                 quote
@@ -2409,7 +2409,7 @@ mktempdir() do dir
 
             valid_username = "julia"
             valid_password = randstring(16)
-            valid_cred = LibGit2.UserPasswordCredentials(valid_username, valid_password)
+            valid_cred = LibGit2.UserPasswordCredential(valid_username, valid_password)
 
             config_path = joinpath(dir, config_file)
             write(config_path, """
@@ -2420,7 +2420,7 @@ mktempdir() do dir
             https_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 LibGit2.with(LibGit2.GitConfig($config_path, LibGit2.Consts.CONFIG_LEVEL_APP)) do cfg
-                    payload = CredentialPayload(Nullable{AbstractCredentials}(),
+                    payload = CredentialPayload(Nullable{AbstractCredential}(),
                                                 Nullable{CachedCredentials}(), cfg,
                                                 allow_git_helpers=true)
                     credential_loop($valid_cred, $url, Nullable{String}(), payload, shred=false)
@@ -2442,7 +2442,7 @@ mktempdir() do dir
 
         @testset "Incompatible explicit credentials" begin
             # User provides a user/password credential where a SSH credential is required.
-            valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
+            valid_cred = LibGit2.UserPasswordCredential("foo", "bar")
             expect_ssh_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 payload = CredentialPayload($valid_cred, allow_ssh_agent=false,
@@ -2459,7 +2459,7 @@ mktempdir() do dir
 
 
             # User provides a SSH credential where a user/password credential is required.
-            valid_cred = LibGit2.SSHCredentials("foo", "", "", "")
+            valid_cred = LibGit2.SSHCredential("foo", "", "", "")
             expect_https_ex = quote
                 include($LIBGIT2_HELPER_PATH)
                 payload = CredentialPayload($valid_cred, allow_ssh_agent=false,
@@ -2484,7 +2484,7 @@ mktempdir() do dir
             # User provides a user/password credential where a SSH credential is required.
             ex = quote
                 include($LIBGIT2_HELPER_PATH)
-                valid_cred = LibGit2.UserPasswordCredentials("foo", "bar")
+                valid_cred = LibGit2.UserPasswordCredential("foo", "bar")
                 payload = CredentialPayload(valid_cred, allow_ssh_agent=false,
                                             allow_git_helpers=false)
                 credential_loop(valid_cred, "foo://github.com/repo", Nullable(""),
@@ -2508,7 +2508,7 @@ mktempdir() do dir
             # Users should be able to re-use the same payload if the state is reset
             ex = quote
                 include($LIBGIT2_HELPER_PATH)
-                valid_cred = LibGit2.UserPasswordCredentials($valid_username, $valid_password)
+                valid_cred = LibGit2.UserPasswordCredential($valid_username, $valid_password)
                 user = Nullable{String}()
                 payload = CredentialPayload(allow_git_helpers=false)
                 first_result = credential_loop(valid_cred, $(urls[1]), user, payload)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -566,7 +566,7 @@ let a = [1,2,3]
     @test a == [0,0,0]
 end
 let cache = Base.LibGit2.CachedCredentials()
-    get!(cache, "foo", LibGit2.SSHCredentials("", "bar"))
+    get!(cache, "foo", LibGit2.SSHCredential("", "bar"))
     securezero!(cache)
     @test cache["foo"].pass == "\0\0\0"
 end


### PR DESCRIPTION
Rename plural type names `AbstractCredentials`, `UserPasswordCredentials`, and `SSHCredentials` respectively to use singular form `AbstractCredential`, `UserPasswordCredential`, and `SSHCredential`. Note that there isn't anything wrong with using credentials to describe a single credential but it seems out of place in the type system.

Additionally, `CachedCredentials` (note this contains multiple credentials) is no longer a subtype of `AbstractCredentials`. 