### PR TITLE
improve heuristics for executing top-level code

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -1679,7 +1679,8 @@ jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **pli, size_t w
                 return li->functionObjectsDecls;
             }
         }
-        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF) {
+        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF &&
+            jl_is_method(li->def.method)) {
             jl_code_info_t *src = jl_code_for_interpreter(li);
             if (!jl_code_requires_compiler(src)) {
                 li->inferred = (jl_value_t*)src;

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -20,10 +20,10 @@
 @test isempty(sprint(io->warn(io, "testonce", once=true)))
 @test !isempty(sprint(io->warn(io, "testonce", once=true, key=hash("testonce",hash("testanother")))))
 let bt = backtrace()
-    ws = split(chomp(sprint(warn, "test", bt)), '\n')
+    ws = split(chomp(sprint(io->warn(io, "test", bt = bt))), '\n')
     bs = split(chomp(sprint(Base.show_backtrace, bt)), '\n')
     @test contains(ws[1],"WARNING: test")
-    for (l,b) in zip(ws[2:end],bs)
+    for (l,b) in zip(ws[2:end],bs[2:end])
         @test contains(l, b)
     end
 end


### PR DESCRIPTION
This refactors the code that decides how to execute top-level expressions, separating the identification of key features of the code from using it to make decisions.

It also skips inference for blocks containing load-time-ish forms like method and type definitions, since it's probably not profitable and helps avoid unsoundness issues like #24316. Of course it doesn't fully fix ~~ #24569, but will help in common cases. The reduction in compiler time also makes `using DataFrames` (with `--compiled-modules=no`) about 10% faster for me.