### PR TITLE
Pass codegen params to setup_module from emit_function.

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4986,7 +4986,7 @@ static std::unique_ptr<Module> emit_function(
 
     // allocate Function declarations and wrapper objects
     Module *M = new Module(ctx.name, jl_LLVMContext);
-    jl_setup_module(M);
+    jl_setup_module(M, params);
     jl_returninfo_t returninfo = {};
     Function *f = NULL;
     Function *fwrap = NULL;


### PR DESCRIPTION
Broke codegen hooks as used by CUDAnative, ref https://github.com/JuliaLang/julia/commit/954595f318ba5bebf644de22cb5c8b0f63acd041#diff-6d4d21428a67320600faf5a1a9f3a16aL4417. 
@vtjnash, did you remove the params arg for a specific reason?
