### PR TITLE
Show Dates.format docstring with code table

### DIFF
--- a/doc/src/stdlib/dates.md
+++ b/doc/src/stdlib/dates.md
@@ -27,7 +27,7 @@ Base.Dates.DateTime(::Base.Dates.Period...)
 Base.Dates.DateTime(::Function, ::Any...)
 Base.Dates.DateTime(::Base.Dates.TimeType)
 Base.Dates.DateTime(::AbstractString, ::AbstractString)
-Base.Dates.format
+Base.Dates.format(::Base.Dates.TimeType, ::AbstractString)
 Base.Dates.DateFormat
 Base.Dates.@dateformat_str
 Base.Dates.DateTime(::AbstractString, ::Base.Dates.DateFormat)


### PR DESCRIPTION
Displays the `Dates.format` docstring which [explains the formatting codes](https://github.com/JuliaLang/julia/blob/cv/dates-format-docs/base/dates/io.jl#L493) rather than the docstring for the [internal format methods](https://github.com/JuliaLang/julia/blob/cv/dates-format-docs/base/dates/io.jl#L29).