### PR TITLE
Use _chsize_s on Windows for truncate

### DIFF
--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -566,11 +566,7 @@ int ios_trunc(ios_t *s, size_t size)
 #if !defined(_OS_WINDOWS_)
         if (ftruncate(s->fd, size) == 0)
 #else
-        #if !defined(__MINGW32__) || defined(MINGW_HAS_SECURE_API)
-            if (_chsize_s(s->fd, size) == 0)
-        #else
-            if (_chsize(s->fd, size) == 0)
-        #endif
+        if (_chsize_s(s->fd, size) == 0)
 #endif
             return 0;
     }

--- a/src/support/ios.c
+++ b/src/support/ios.c
@@ -566,7 +566,11 @@ int ios_trunc(ios_t *s, size_t size)
 #if !defined(_OS_WINDOWS_)
         if (ftruncate(s->fd, size) == 0)
 #else
-        if (_chsize(s->fd, size) == 0)
+        #if !defined(__MINGW32__) || defined(MINGW_HAS_SECURE_API)
+            if (_chsize_s(s->fd, size) == 0)
+        #else
+            if (_chsize(s->fd, size) == 0)
+        #endif
 #endif
             return 0;
     }


### PR DESCRIPTION
Proposal to fix https://github.com/JuliaLang/julia/issues/24466 .  Should allow files >2 GB to be truncated on Windows.