### PR TITLE
cxx initialization: make constructor explicit

### DIFF
--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -542,7 +542,7 @@ void CloneCtx::check_partial(Group &grp, Target &tgt)
         grp.clone_fs.insert(i);
         all_origs.insert(orig_f);
     }
-    std::set<Function*> sets[2]{all_origs, {}};
+    std::set<Function*> sets[2]{all_origs, std::set<Function*>{}};
     auto *cur_set = &sets[0];
     auto *next_set = &sets[1];
     // Reduce dispatch by expand the cloning set to functions that are directly called by


### PR DESCRIPTION
clang in macOS 10.9 incorrectly marks this as required (as seen in https://build.julialang.org/builders/build_osx10.9-x64/builds/1596/steps/shell_1/logs/stdio)