### PR TITLE
Added utility functions expmin and expmax

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -811,6 +811,8 @@ export
 
 # bigfloat & precision
     precision,
+    expmin,
+    expmax,
     rounding,
     setprecision,
     setrounding,

--- a/base/float.jl
+++ b/base/float.jl
@@ -590,6 +590,34 @@ precision(::Type{Float64}) = 53
 precision(::T) where {T<:AbstractFloat} = precision(T)
 
 """
+    expmin(num::AbstractFloat)
+
+Get the minimum exponent e of a normalized floating point number. In other
+words, return the minimum integer e such that the floating point number 1.5 *
+2^e is normalized.
+"""
+function expmin end
+
+expmin(::Type{Float16}) = -14
+expmin(::Type{Float32}) = -126
+expmin(::Type{Float64}) = -1022
+expmin(::T) where {T<:AbstractFloat} = expmin(T)
+
+"""
+    expmax(num::AbstractFloat)
+
+Get the maximum exponent e of a finite floating point number. In other
+words, return the maximum integer e such that the floating point number 1.5 *
+2^e is finite.
+"""
+function expmax end
+
+expmax(::Type{Float16}) = 15
+expmax(::Type{Float32}) = 127
+expmax(::Type{Float64}) = 1023
+expmax(::T) where {T<:AbstractFloat} = expmax(T)
+
+"""
     uabs(x::Integer)
 
 Returns the absolute value of `x`, possibly returning a different type should the

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -11,8 +11,8 @@ import
         exp, exp2, exponent, factorial, floor, fma, hypot, isinteger,
         isfinite, isinf, isnan, ldexp, log, log2, log10, max, min, mod, modf,
         nextfloat, prevfloat, promote_rule, rem, rem2pi, round, show, float,
-        sum, sqrt, string, print, trunc, precision, exp10, expm1,
-        gamma, lgamma, log1p,
+        sum, sqrt, string, print, trunc, precision, expmin, expmax, exp10,
+        expm1, gamma, lgamma, log1p,
         eps, signbit, sin, cos, sincos, tan, sec, csc, cot, acos, asin, atan,
         cosh, sinh, tanh, sech, csch, coth, acosh, asinh, atanh, atan2,
         cbrt, typemax, typemin, unsafe_trunc, realmin, realmax, rounding,
@@ -963,6 +963,24 @@ get_emin_max() = ccall((:mpfr_get_emin_max, :libmpfr), Clong, ())
 
 set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Void, (Clong,), x)
 set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Void, (Clong,), x)
+
+"""
+    expmin(BigFloat)
+
+Get the current minimum exponent e of a normalized [`BigFloat`](@ref) number.
+In other words, return the minimum integer e such that the [`BigFloat`](@ref)
+number 1.5 * 2^e is normalized.
+"""
+expmin(::Type{BigFloat}) = get_emin() - 1 # The '- 1' is to make it work as Base.exponent
+
+"""
+    expmax(BigFloat)
+
+Get the current maximum exponent e of a finite [`BigFloat`](@ref) number. In
+other words, return the maximum integer e such that the [`BigFloat`](@ref)
+number 1.5 * 2^e is finite.
+"""
+expmax(::Type{BigFloat}) = get_emax() - 1 # The '- 1' is to make it work as Base.exponent
 
 function Base.deepcopy_internal(x::BigFloat, stackdict::ObjectIdDict)
     haskey(stackdict, x) && return stackdict[x]

--- a/test/floatfuncs.jl
+++ b/test/floatfuncs.jl
@@ -4,6 +4,26 @@ using Test
 
 # test the basic floating point functions
 
+@testset "expminmax" begin
+    for elty in (Float16, Float32, Float64)
+        x = convert(elty,-2.0)
+        maxfinite = prevfloat(convert(elty,Inf))
+        minnormalized = nextfloat(convert(elty,0.0))/eps(elty)
+        @test exponent(maxfinite) == expmax(elty)
+        @test expmax(x) == expmax(elty)
+        @test exponent(minnormalized) == expmin(elty)
+        @test expmin(x) == expmin(elty)
+    end
+    #BigFloat does not have denormalized numbers
+    x = convert(BigFloat,-2.0)
+    maxfinite = prevfloat(convert(BigFloat,Inf))
+    minnormalized = nextfloat(convert(BigFloat,0.0))
+    @test exponent(maxfinite) == expmax(BigFloat)
+    @test expmax(x) == expmax(BigFloat)
+    @test exponent(minnormalized) == expmin(BigFloat)
+    @test expmin(x) == expmin(BigFloat)
+end
+
 @testset "flipsign" begin
     for elty in (Float32,Float64)
         x = convert(elty,-2.0)


### PR DESCRIPTION
Julia needs a way to find the minimum and maximum exponents of normalized floating point numbers.