### PR TITLE
Don't mark loads from semi-boxed unions as nonnull

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3334,7 +3334,7 @@ static jl_cgval_t emit_local(jl_codectx_t &ctx, jl_value_t *slotload)
         Value *box_isnull;
         if (vi.usedUndef)
             box_isnull = ctx.builder.CreateICmpNE(boxed, maybe_decay_untracked(V_null));
-        maybe_mark_load_dereferenceable(boxed, vi.usedUndef, typ);
+        maybe_mark_load_dereferenceable(boxed, vi.usedUndef || vi.pTIndex, typ);
         if (vi.pTIndex) {
             // value is either boxed in the stack slot, or unboxed in value
             // as indicated by testing (pTIndex & 0x80)

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -10,6 +10,12 @@ const Iptr = sizeof(Int) == 8 ? "i64" : "i32"
 get_llvm(@nospecialize(f), @nospecialize(t), strip_ir_metadata=true, dump_module=false) =
     sprint(code_llvm, f, t, strip_ir_metadata, dump_module)
 
+get_llvm_noopt(@nospecialize(f), @nospecialize(t), strip_ir_metadata=true, dump_module=false) =
+    Base._dump_function(f, t,
+                #=native=# false, #=wrapper=# false, #=strip=# strip_ir_metadata,
+                #=dump_module=# dump_module, #=syntax=#:att, #=optimize=#false)
+
+
 if opt_level > 0
     # Make sure getptls call is removed at IR level with optimization on
     @test !contains(get_llvm(identity, Tuple{String}), " call ")
@@ -306,3 +312,14 @@ if opt_level > 0
                     "%gcframe")
     @test !contains(get_llvm(g24108, Tuple{B24108}), "%gcframe")
 end
+
+# Issue 24632
+function foo24632(y::Bool)
+    x::Union{Int, String} = y ? "ABC" : 1
+    isa(x, Int) ? x : 0
+end
+
+# A bit coarse-grained perhaps, but ok for now. What we want to check is that the load from
+# the semi-boxed union on the if-branch of the `isa` is not annotated !nonnull
+@test contains(get_llvm_noopt(foo24632, (Bool,), false), "!dereferenceable_or_null")
+@test !contains(get_llvm_noopt(foo24632, (Bool,), false), "!nonnull")


### PR DESCRIPTION
This is a bit of an interesting case. Even though we have concrete
type information for the variable (we know it's an Int on the isa
branch), we're dealing with a semi-unboxed union. We need to make
sure not to claim to know that the pointer is non-null, because
it actually might be (and in fact always is in this example).

Fixes #24632