### PR TITLE
initialize Arrays with great dignity

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1298,6 +1298,42 @@ julia> B = Array{Float64}(2) # N determined by the input
 Array{T,N}(dims)
 
 """
+    Uninitialized
+
+Singleton type used in array initialization, indicating the array-constructor-caller
+would like an uninitialized array. See also [`uninitialized`](@ref),
+an alias for `Uninitialized()`.
+
+# Examples
+```julia-repl
+julia> Array{Float64,1}(Uninitialized(), 3)
+3-element Array{Float64,1}:
+ 2.2752528595e-314
+ 2.202942107e-314
+ 2.275252907e-314
+```
+"""
+Uninitialized
+
+"""
+    uninitialized
+
+Alias for `Uninitialized()`, which constructs an instance of the singleton type
+[`Uninitialized`](@ref), used in array initialization to indicate the
+array-constructor-caller would like an uninitialized array.
+
+# Examples
+```julia-repl
+julia> Array{Float64,1}(uninitialized, 3)
+3-element Array{Float64,1}:
+ 2.2752528595e-314
+ 2.202942107e-314
+ 2.275252907e-314
+```
+"""
+uninitialized
+
+"""
     +(x, y...)
 
 Addition operator. `x+y+z+...` calls this function with all arguments, i.e. `+(x, y, z, ...)`.

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -130,17 +130,37 @@ include("abstractarray.jl")
 include("subarray.jl")
 include("reinterpretarray.jl")
 
-# Array convenience converting constructors
+
+# ## dims-type-converting Array constructors for convenience
+# type and dimensionality specified, accepting dims as series of Integers
+Vector{T}(::Uninitialized, m::Integer) where {T} = Vector{T}(uninitialized, Int(m))
+Matrix{T}(::Uninitialized, m::Integer, n::Integer) where {T} = Matrix{T}(uninitialized, Int(m), Int(n))
+# type but not dimensionality specified, accepting dims as series of Integers
+Array{T}(::Uninitialized, m::Integer) where {T} = Array{T,1}(uninitialized, Int(m))
+Array{T}(::Uninitialized, m::Integer, n::Integer) where {T} = Array{T,2}(uninitialized, Int(m), Int(n))
+Array{T}(::Uninitialized, m::Integer, n::Integer, o::Integer) where {T} = Array{T,3}(uninitialized, Int(m), Int(n), Int(o))
+Array{T}(::Uninitialized, d::Integer...) where {T} = Array{T}(uninitialized, convert(Tuple{Vararg{Int}}, d))
+# dimensionality but not type specified, accepting dims as series of Integers
+Vector(::Uninitialized, m::Integer) = Vector{Any}(uninitialized, Int(m))
+Matrix(::Uninitialized, m::Integer, n::Integer) = Matrix{Any}(uninitialized, Int(m), Int(n))
+# empty vector constructor
+Vector() = Vector{Any}(uninitialized, 0)
+
+## preexisting dims-type-converting Array constructors for convenience, i.e. without uninitialized, to deprecate
+# type and dimensionality specified, accepting dims as series of Integers
+Vector{T}(m::Integer) where {T} = Vector{T}(Int(m))
+Matrix{T}(m::Integer, n::Integer) where {T} = Matrix{T}(Int(m), Int(n))
+# type but not dimensionality specified, accepting dims as series of Integers
 Array{T}(m::Integer) where {T} = Array{T,1}(Int(m))
 Array{T}(m::Integer, n::Integer) where {T} = Array{T,2}(Int(m), Int(n))
 Array{T}(m::Integer, n::Integer, o::Integer) where {T} = Array{T,3}(Int(m), Int(n), Int(o))
 Array{T}(d::Integer...) where {T} = Array{T}(convert(Tuple{Vararg{Int}}, d))
-
-Vector() = Array{Any,1}(0)
-Vector{T}(m::Integer) where {T} = Array{T,1}(Int(m))
-Vector(m::Integer) = Array{Any,1}(Int(m))
-Matrix{T}(m::Integer, n::Integer) where {T} = Matrix{T}(Int(m), Int(n))
+# dimensionality but not type specified, accepting dims as series of Integers
+Vector(m::Integer) = Vector{Any}(Int(m))
 Matrix(m::Integer, n::Integer) = Matrix{Any}(Int(m), Int(n))
+# empty vector constructor
+Vector() = Vector{Any}(0)
+
 
 include("associative.jl")
 

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -8,6 +8,8 @@ Base.AbstractVector
 Base.AbstractMatrix
 Core.Array
 Core.Array(::Any)
+Core.Uninitialized
+Core.uninitialized
 Base.Vector
 Base.Vector(::Any)
 Base.Matrix


### PR DESCRIPTION
This pull request replaces the existing primitive `Array` constructors with equivalents requiring `uninitialized` as their first argument, e.g. `Array{T,N}(d::VarArg{Int,N}) -> Array{T,N}(uninitialized, d::VarArg{Int,N})`, and reimplements the existing constructors in terms of those new equivalents.

This pull request is the equivalent of #24400 with `uninitialized` in place of `junk`, and is the first 1.0-necessary step for #24595.

Question: `uninitialized` is presently a methodless function (as with `junk` in #24400), which makes sense only if we plan to simultaneously introduce a convenience constructor `uninitialized(T, shape...)`. But if we do not introduce such a convenience constructor, then perhaps `uninitialized` should instead be a type. IIRC, whether we should introduce such a convenience constructor hasn't been explicitly decided yet. Thoughts? Thanks and best!