### PR TITLE
deprecate zeros(D::Diagonal[, opts...]) methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -401,6 +401,8 @@ Deprecated or removed
   * `eye` has been deprecated in favor of `I` and `Matrix` constructors. Please see the
     deprecation warnings for replacement details ([#24438]).
 
+  * `zeros(D::Diagonal[, opts...])` has been deprecated ([#24654]).
+
   * Using Bool values directly as indices is now deprecated and will be an error in the future. Convert
     them to `Int` before indexing if you intend to access index `1` for `true` and `0` for `false`.
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1783,6 +1783,12 @@ function spdiagm(x, d, m::Integer, n::Integer)
     return sparse(I, J, V, m, n)
 end
 
+# deprecate zeros(D::Diagonal[, opts...])
+@deprecate zeros(D::Diagonal)                         Diagonal(fill!(similar(D.diag), 0))
+@deprecate zeros(D::Diagonal, ::Type{T}) where {T}    Diagonal(fill!(similar(D.diag, T), 0))
+@deprecate zeros(D::Diagonal, ::Type{T}, dims::Dims) where {T}          fill!(similar(D, T, dims), 0)
+@deprecate zeros(D::Diagonal, ::Type{T}, dims::Integer...) where {T}    fill!(similar(D, T, dims), 0)
+
 # PR #23690
 # `SSHCredentials` and `UserPasswordCredentials` constructors using `prompt_if_incorrect`
 # are deprecated in base/libgit2/types.jl.

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -61,11 +61,6 @@ convert(::Type{Array}, D::Diagonal) = convert(Matrix, D)
 similar(D::Diagonal, ::Type{T}) where {T} = Diagonal(similar(D.diag, T))
 similar(D::Diagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
 
-Base.zeros(D::Diagonal) = Diagonal(fill!(similar(D.diag), 0))
-Base.zeros(D::Diagonal, ::Type{T}) where {T} = Diagonal(fill!(similar(D, T), 0))
-Base.zeros(D::Diagonal, ::Type{T}, dims::Dims) where {T} = fill!(similar(D, T, dims), 0)
-Base.zeros(D::Diagonal, ::Type{T}, dims::Integer...) where {T} = fill!(similar(D, T, dims), 0)
-
 copy!(D1::Diagonal, D2::Diagonal) = (copy!(D1.diag, D2.diag); D1)
 
 size(D::Diagonal) = (length(D.diag),length(D.diag))

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -107,7 +107,7 @@ srand(1)
                 target = scale!(Uc, inv.(D.diag))
                 @test A_rdiv_B!(Uc, D) ≈ target atol=atol_three
                 @test_throws DimensionMismatch A_rdiv_B!(Matrix{elty}(I, n-1, n-1), D)
-                @test_throws SingularException A_rdiv_B!(Uc, zeros(D))
+                @test_throws SingularException A_rdiv_B!(Uc, Diagonal(fill!(similar(D.diag), 0)))
                 @test A_rdiv_Bt!(Uc, D) ≈ target atol=atol_three
                 @test A_rdiv_Bc!(Uc, conj(D)) ≈ target atol=atol_three
                 @test A_ldiv_B!(D, Matrix{eltype(D)}(I, size(D))) ≈ D \ Matrix{eltype(D)}(I, size(D)) atol=atol_three
@@ -188,11 +188,11 @@ srand(1)
     @testset "triu/tril" begin
         @test istriu(D)
         @test istril(D)
-        @test triu(D,1)  == zeros(D)
+        @test iszero(triu(D,1))
         @test triu(D,0)  == D
         @test triu(D,-1) == D
         @test tril(D,1)  == D
-        @test tril(D,-1) == zeros(D)
+        @test iszero(tril(D,-1))
         @test tril(D,0)  == D
         @test_throws ArgumentError tril(D, -n - 2)
         @test_throws ArgumentError tril(D, n)


### PR DESCRIPTION
This pull request deprecates the idiosyncratic `zeros(D::Diagonal[, opts...])` methods. Ref. #24595 for background. Best!