### PR TITLE
constructors for Array from UniformScaling

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -378,6 +378,10 @@ Matrix{T}(s::UniformScaling, dims::Dims{2}) where {T} = setindex!(zeros(T, dims)
 Matrix{T}(s::UniformScaling, m::Integer, n::Integer) where {T} = Matrix{T}(s, Dims((m, n)))
 Matrix(s::UniformScaling, m::Integer, n::Integer) = Matrix(s, Dims((m, n)))
 Matrix(s::UniformScaling, dims::Dims{2}) = Matrix{eltype(s)}(s, dims)
+Array{T}(s::UniformScaling, dims::Dims{2}) where {T} = Matrix{T}(s, dims)
+Array{T}(s::UniformScaling, m::Integer, n::Integer) where {T} = Matrix{T}(s, m, n)
+Array(s::UniformScaling, m::Integer, n::Integer) = Matrix(s, m, n)
+Array(s::UniformScaling, dims::Dims{2}) = Matrix(s, dims)
 
 ## Diagonal construction from UniformScaling
 Diagonal{T}(s::UniformScaling, m::Integer) where {T} = Diagonal{T}(fill(T(s.λ), m))

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -191,16 +191,18 @@ end
     end
 end
 
-@testset "Matrix construction from UniformScaling" begin
+@testset "Matrix/Array construction from UniformScaling" begin
     I2_33 = [2 0 0; 0 2 0; 0 0 2]
     I2_34 = [2 0 0 0; 0 2 0 0; 0 0 2 0]
     I2_43 = [2 0 0; 0 2 0; 0 0 2; 0 0 0]
-    @test Matrix(2I, 3, 3)::Matrix{Int} == I2_33
-    @test Matrix(2I, 3, 4)::Matrix{Int} == I2_34
-    @test Matrix(2I, 4, 3)::Matrix{Int} == I2_43
-    @test Matrix(2.0I, 3, 3)::Matrix{Float64} == I2_33
-    @test Matrix{Real}(2I, 3, 3)::Matrix{Real} == I2_33
-    @test Matrix{Float64}(2I, 3, 3)::Matrix{Float64} == I2_33
+    for ArrType in (Matrix, Array)
+        @test ArrType(2I, 3, 3)::Matrix{Int} == I2_33
+        @test ArrType(2I, 3, 4)::Matrix{Int} == I2_34
+        @test ArrType(2I, 4, 3)::Matrix{Int} == I2_43
+        @test ArrType(2.0I, 3, 3)::Matrix{Float64} == I2_33
+        @test ArrType{Real}(2I, 3, 3)::Matrix{Real} == I2_33
+        @test ArrType{Float64}(2I, 3, 3)::Matrix{Float64} == I2_33
+    end
 end
 
 @testset "Diagonal construction from UniformScaling" begin


### PR DESCRIPTION
This pull request adds constructors for `Array` from `UniformScaling` (essentially aliases for the same methods for `Matrix`). (These methods' absence from #24372 was an oversight.) Best!