### PR TITLE
fix three parsing issues

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1021,14 +1021,14 @@
               (let ((nch (peek-char (ts:port s))))
                 (if (or (and (char? nch) (char-numeric? nch))
                         (and (eqv? nch #\.) (read-char (ts:port s))))
-                    (let ((num (parse-juxtapose
-                                (read-number (ts:port s) (eqv? nch #\.) (eq? op '-))
-                                s)))
-                      (if (is-prec-power? (peek-token s))
-                          ;; -2^x parsed as (- (^ 2 x))
+                    (let ((num (read-number (ts:port s) (eqv? nch #\.) (eq? op '-))))
+                      (if (or (memv (peek-token s) '(#\[ #\{))
+                              (is-prec-power? (peek-token s)))
+                          ;; `[`, `{` (issue #18851) and `^` have higher precedence than
+                          ;; unary negation; -2^x parsed as (- (^ 2 x)).
                           (begin (ts:put-back! s (maybe-negate op num) spc)
                                  (list 'call op (parse-factor s)))
-                          num))
+                          (parse-juxtapose num s)))
                     (parse-unary-call s op #t spc)))
               (parse-unary-call s op (unary-op? op) spc)))
         (parse-juxtapose (parse-factor s) s))))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2213,7 +2213,7 @@
                       (or (not (symbol? nxt))
                           (ts:space? s)))
                  ':
-                 (if (ts:space? s)
+                 (if (or (ts:space? s) (eqv? nxt #\newline))
                      (error "space not allowed after \":\" used for quoting")
                      (list 'quote (parse-atom s #f))))))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -74,6 +74,14 @@ macro test999_str(args...); args; end
 @test_throws ParseError Meta.parse("x 'y")
 @test Meta.parse("x'y") == Expr(:call, :*, Expr(Symbol("'"), :x), :y)
 
+# issue #18851
+@test Meta.parse("-2[m]") == Expr(:call, :-, Expr(:ref, 2, :m))
+@test Meta.parse("+2[m]") == Expr(:call, :+, Expr(:ref, 2, :m))
+@test Meta.parse("!2[3]") == Expr(:call, :!, Expr(:ref, 2, 3))
+@test Meta.parse("-2{m}") == Expr(:call, :-, Expr(:curly, 2, :m))
+@test Meta.parse("+2{m}") == Expr(:call, :+, Expr(:curly, 2, :m))
+@test Meta.parse("-2(m)") == Expr(:call, :*, -2, :m)
+
 # issue #8301
 @test_throws ParseError Meta.parse("&*s")
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -973,6 +973,12 @@ end
 # issue #20575
 @test_throws ParseError Meta.parse("\"a\"x")
 @test_throws ParseError Meta.parse("\"a\"begin end")
+@test_throws ParseError Meta.parse("\"a\"begin end\"b\"")
+
+# issue #16427
+@test_throws ParseError Meta.parse("for i=1:1 end(3)")
+@test_throws ParseError Meta.parse("begin end(3)")
+@test_throws ParseError Meta.parse("while false end(3)")
 
 # comment 298107224 on pull #21607
 module Test21607

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -60,6 +60,9 @@ macro test999_str(args...); args; end
 
 # issue #5997
 @test_throws ParseError Meta.parse(": x")
+@test_throws ParseError Meta.parse("""begin
+    :
+    x""")
 @test_throws ParseError Meta.parse("d[: 2]")
 
 # issue #6770


### PR DESCRIPTION
Was just browsing for parser issues to fix pre-1.0. Here's a grab-bag.

- fix #16427, disallow juxtaposition with block forms
- fix #16916, disallow newline after `:`
- fix #18851, parse `-2[x]` as `(call - (ref 2 x))`