### PR TITLE
add sparse(S::UniformScaling, dims::Dims{2}) method

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1522,7 +1522,8 @@ function Base.isone(A::SparseMatrixCSC)
     return true
 end
 
-sparse(s::UniformScaling, m::Integer, n::Integer) = SparseMatrixCSC(s, Dims((m, n)))
+sparse(s::UniformScaling, dims::Dims{2}) = SparseMatrixCSC(s, dims)
+sparse(s::UniformScaling, m::Integer, n::Integer) = sparse(s, Dims((m, n)))
 
 # TODO: More appropriate location?
 conj!(A::SparseMatrixCSC) = (@inbounds broadcast!(conj, A.nzval, A.nzval); A)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -48,6 +48,12 @@ end
     @test SparseMatrixCSC{Float64,Int32}(2I, 3, 3)::SparseMatrixCSC{Float64,Int32} == 2*eye(3)
     @test SparseMatrixCSC{Float64,Int32}(0I, 3, 3)::SparseMatrixCSC{Float64,Int32} == spzeros(Float64, Int32, 3, 3)
 end
+@testset "sparse(S::UniformScaling, shape...) convenience constructors" begin
+    # we exercise these methods only lightly as these methods call the SparseMatrixCSC
+    # constructor methods well-exercised by the immediately preceding testset
+    @test sparse(2I, 3, 4)::SparseMatrixCSC{Int,Int} == Matrix(2I, 3, 4)
+    @test sparse(2I, (3, 4))::SparseMatrixCSC{Int,Int} == Matrix(2I, 3, 4)
+end
 
 se33 = SparseMatrixCSC{Float64}(I, 3, 3)
 do33 = ones(3)


### PR DESCRIPTION
This pull request adds a `sparse(s::UniformScaling, dims::Dims{2})` method (essentially identical to the existing `sparse(s::UniformScaling, m::Integer, n::Integer)` method). (This method's absence from #24372 was an oversight.) Best!