### PR TITLE
22018: make finalizer(f, x) return x rather than nothing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -151,6 +151,8 @@ This section lists changes that do not have deprecation warnings.
 
   * Juxtaposing string literals (e.g. `"x"y`) is now a syntax error ([#20575]).
 
+  * `finalizer(function, object)` now returns `object` rather than `nothing` ([#24679]).
+
   * Macro calls with `for` expressions are now parsed as generators inside
     function argument lists ([#18650]). Examples:
 

--- a/base/distributed/remotecall.jl
+++ b/base/distributed/remotecall.jl
@@ -58,7 +58,11 @@ end
 
 function finalize_ref(r::AbstractRemoteRef)
     if r.where > 0 # Handle the case of the finalizer having been called manually
-        islocked(client_refs) && return finalizer(finalize_ref, r) # delay finalizer for later, when it's not already locked
+        if islocked(client_refs)
+            # delay finalizer for later, when it's not already locked
+            finalizer(finalize_ref, r)
+            return nothing
+        end
         delete!(client_refs, r)
         if isa(r, RemoteChannel)
             send_del_client(r)

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -8,8 +8,8 @@
     finalizer(f, x)
 
 Register a function `f(x)` to be called when there are no program-accessible references to
-`x`. The type of `x` must be a `mutable struct`, otherwise the behavior of this function is
-unpredictable.
+`x`, and return `x`. The type of `x` must be a `mutable struct`, otherwise the behavior of
+this function is unpredictable.
 """
 function finalizer(@nospecialize(f), @nospecialize(o))
     if isimmutable(o)
@@ -17,6 +17,7 @@ function finalizer(@nospecialize(f), @nospecialize(o))
     end
     ccall(:jl_gc_add_finalizer_th, Void, (Ptr{Void}, Any, Any),
           Core.getptls(), o, f)
+    return o
 end
 
 function finalizer(f::Ptr{Void}, o::T) where T
@@ -26,6 +27,7 @@ function finalizer(f::Ptr{Void}, o::T) where T
     end
     ccall(:jl_gc_add_ptr_finalizer, Void, (Ptr{Void}, Any, Ptr{Void}),
           Core.getptls(), o, f)
+    return o
 end
 
 """

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -21,7 +21,10 @@ mutable struct WeakKeyDict{K,V} <: Associative{K,V}
         t = new(Dict{Any,V}(), Threads.RecursiveSpinLock(), identity)
         t.finalizer = function (k)
             # when a weak key is finalized, remove from dictionary if it is still there
-            islocked(t) && return finalizer(t.finalizer, k)
+            if islocked(t)
+                finalizer(t.finalizer, k)
+                return nothing
+            end
             delete!(t, k)
         end
         return t


### PR DESCRIPTION
This pull request makes `finalizer(f, x)` return `x` rather than `nothing`, addressing #22018.

I found only two calls to `finalizer` that make use of the return value. Both calls are of the form `islocked(...) && return finalizer(..., ...)`, which I've naively rewritten `islocked(...) && (finalizer(...); return nothing)`. Not being familiar with the associated code I cannot assess whether this rewrite is reasonable. Best!