### PR TITLE
Internalize LLVM C API extensions from LLVM.jl

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,8 @@ LLVMLINK :=
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-ptls llvm-muladd \
 	llvm-late-gc-lowering llvm-lower-handlers llvm-gc-invariant-verifier \
-	llvm-propagate-addrspaces llvm-multiversioning llvm-alloc-opt cgmemmgr
+	llvm-propagate-addrspaces llvm-multiversioning llvm-alloc-opt cgmemmgr \
+	llvm-api
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -33,6 +33,7 @@
     julia_type_to_llvm;
     _IO_stdin_used;
     __ZN4llvm23createLowerSimdLoopPassEv;
+    LLVMExtra*;
 
     /* freebsd */
     environ;

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -4,6 +4,9 @@
 //
 // These are part of the Julia repository as they need to be
 // built with the same C++ toolchain Julia & LLVM are built with
+//
+// They are not to be considered a stable API, and will be removed
+// when better package build systems are available
 
 #include <llvm-c/Core.h>
 #include <llvm-c/Types.h>

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -31,23 +31,23 @@ namespace llvm {
 //
 // The LLVMInitialize* functions and friends are defined `static inline`
 
-extern "C" void LLVMExtraInitializeAllTargetInfos() {
+extern "C" JL_DLLEXPORT void LLVMExtraInitializeAllTargetInfos() {
   InitializeAllTargetInfos();
 }
 
-extern "C" void LLVMExtraInitializeAllTargets() { InitializeAllTargets(); }
+extern "C" JL_DLLEXPORT void LLVMExtraInitializeAllTargets() { InitializeAllTargets(); }
 
-extern "C" void LLVMExtraInitializeAllTargetMCs() { InitializeAllTargetMCs(); }
+extern "C" JL_DLLEXPORT void LLVMExtraInitializeAllTargetMCs() { InitializeAllTargetMCs(); }
 
-extern "C" void LLVMExtraInitializeAllAsmPrinters() {
+extern "C" JL_DLLEXPORT void LLVMExtraInitializeAllAsmPrinters() {
   InitializeAllAsmPrinters();
 }
 
-extern "C" void LLVMExtraInitializeAllAsmParsers() {
+extern "C" JL_DLLEXPORT void LLVMExtraInitializeAllAsmParsers() {
   InitializeAllAsmParsers();
 }
 
-extern "C" void LLVMExtraInitializeAllDisassemblers() {
+extern "C" JL_DLLEXPORT void LLVMExtraInitializeAllDisassemblers() {
   InitializeAllDisassemblers();
 }
 
@@ -57,19 +57,19 @@ extern "C" void LLVMExtraInitializeAllDisassemblers() {
 #error LLVM_NATIVE_TARGET not defined
 #endif
 
-extern "C" LLVMBool LLVMExtraInitializeNativeTarget() {
+extern "C" JL_DLLEXPORT LLVMBool LLVMExtraInitializeNativeTarget() {
   return InitializeNativeTarget();
 }
 
-extern "C" LLVMBool LLVMExtraInitializeNativeAsmParser() {
+extern "C" JL_DLLEXPORT LLVMBool LLVMExtraInitializeNativeAsmParser() {
   return InitializeNativeTargetAsmParser();
 }
 
-extern "C" LLVMBool LLVMExtraInitializeNativeAsmPrinter() {
+extern "C" JL_DLLEXPORT LLVMBool LLVMExtraInitializeNativeAsmPrinter() {
   return InitializeNativeTargetAsmPrinter();
 }
 
-extern "C" LLVMBool LLVMExtraInitializeNativeDisassembler() {
+extern "C" JL_DLLEXPORT LLVMBool LLVMExtraInitializeNativeDisassembler() {
   return InitializeNativeTargetDisassembler();
 }
 
@@ -79,7 +79,7 @@ extern "C" LLVMBool LLVMExtraInitializeNativeDisassembler() {
 typedef struct LLVMOpaquePass *LLVMPassRef;
 DEFINE_STDCXX_CONVERSION_FUNCTIONS(Pass, LLVMPassRef)
 
-extern "C" void LLVMExtraAddPass(LLVMPassManagerRef PM, LLVMPassRef P) {
+extern "C" JL_DLLEXPORT void LLVMExtraAddPass(LLVMPassManagerRef PM, LLVMPassRef P) {
   unwrap(PM)->add(unwrap(P));
 }
 
@@ -114,7 +114,7 @@ private:
   jl_value_t *Callback;
 };
 
-extern "C" LLVMPassRef LLVMExtraCreateModulePass(const char *Name,
+extern "C" JL_DLLEXPORT LLVMPassRef LLVMExtraCreateModulePass(const char *Name,
                                                  jl_value_t *Callback) {
   return wrap(new JuliaModulePass(Name, Callback));
 }
@@ -141,7 +141,7 @@ private:
   jl_value_t *Callback;
 };
 
-extern "C" LLVMPassRef LLVMExtraCreateFunctionPass(const char *Name,
+extern "C" JL_DLLEXPORT LLVMPassRef LLVMExtraCreateFunctionPass(const char *Name,
                                                    jl_value_t *Callback) {
   return wrap(new JuliaFunctionPass(Name, Callback));
 }
@@ -168,7 +168,7 @@ private:
   jl_value_t *Callback;
 };
 
-extern "C" LLVMPassRef LLVMExtraCreateBasicBlockPass(const char *Name,
+extern "C" JL_DLLEXPORT LLVMPassRef LLVMExtraCreateBasicBlockPass(const char *Name,
                                                      jl_value_t *Callback) {
   return wrap(new JuliaBasicBlockPass(Name, Callback));
 }
@@ -178,8 +178,8 @@ extern "C" LLVMPassRef LLVMExtraCreateBasicBlockPass(const char *Name,
 
 #if JL_LLVM_VERSION < 40000
 
-extern "C" unsigned
-LLVMGetAttributeCountAtIndex_D26392(LLVMValueRef F, LLVMAttributeIndex Idx) {
+extern "C" JL_DLLEXPORT unsigned
+LLVMExtraGetAttributeCountAtIndex_D26392(LLVMValueRef F, LLVMAttributeIndex Idx) {
   auto Fn = unwrap<Function>(F);
   if (Fn->getAttributes().isEmpty())
     return 0;
@@ -187,8 +187,8 @@ LLVMGetAttributeCountAtIndex_D26392(LLVMValueRef F, LLVMAttributeIndex Idx) {
     return LLVMGetAttributeCountAtIndex(F, Idx);
 }
 
-extern "C" unsigned
-LLVMGetCallSiteAttributeCount_D26392(LLVMValueRef C, LLVMAttributeIndex Idx) {
+extern "C" JL_DLLEXPORT unsigned
+LLVMExtraGetCallSiteAttributeCount_D26392(LLVMValueRef C, LLVMAttributeIndex Idx) {
   CallSite CS(unwrap<Instruction>(C));
   if (CS.getAttributes().isEmpty())
     return 0;
@@ -201,25 +201,25 @@ LLVMGetCallSiteAttributeCount_D26392(LLVMValueRef C, LLVMAttributeIndex Idx) {
 
 // Various missing functions
 
-extern "C" unsigned int LLVMExtraGetDebugMDVersion() {
+extern "C" JL_DLLEXPORT unsigned int LLVMExtraGetDebugMDVersion() {
   return DEBUG_METADATA_VERSION;
 }
 
-extern "C" LLVMContextRef LLVMExtraGetValueContext(LLVMValueRef V) {
+extern "C" JL_DLLEXPORT LLVMContextRef LLVMExtraGetValueContext(LLVMValueRef V) {
   return wrap(&unwrap(V)->getContext());
 }
 
 extern ModulePass *createNVVMReflectPass();
-extern "C" void LLVMExtraAddMVVMReflectPass(LLVMPassManagerRef PM) {
+extern "C" JL_DLLEXPORT void LLVMExtraAddMVVMReflectPass(LLVMPassManagerRef PM) {
   createNVVMReflectPass();
 }
 
-extern "C" void LLVMExtraAddTargetLibraryInfoByTiple(const char *T,
+extern "C" JL_DLLEXPORT void LLVMExtraAddTargetLibraryInfoByTiple(const char *T,
                                                      LLVMPassManagerRef PM) {
   unwrap(PM)->add(new TargetLibraryInfoWrapperPass(Triple(T)));
 }
 
-extern "C" void LLVMExtraAddInternalizePassWithExportList(
+extern "C" JL_DLLEXPORT void LLVMExtraAddInternalizePassWithExportList(
     LLVMPassManagerRef PM, const char **ExportList, size_t Length) {
   auto PreserveFobj = [=](const GlobalValue &GV) {
     for (size_t i = 0; i < Length; i++) {

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -1,0 +1,234 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+// Extensions of the LLVM C API for LLVM.jl
+//
+// These are part of the Julia repository as they need to be
+// built with the same C++ toolchain Julia & LLVM are built with
+
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
+#include <llvm/ADT/Triple.h>
+#include <llvm/Analysis/TargetLibraryInfo.h>
+#include <llvm/IR/Attributes.h>
+#include <llvm/IR/CallSite.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalValue.h>
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/TargetSelect.h>
+#include <llvm/Transforms/IPO.h>
+
+#include "julia.h"
+#include "llvm-version.h"
+
+using namespace llvm::legacy;
+
+namespace llvm {
+
+
+// Initialization functions
+//
+// The LLVMInitialize* functions and friends are defined `static inline`
+
+extern "C" void LLVMExtraInitializeAllTargetInfos() {
+  InitializeAllTargetInfos();
+}
+
+extern "C" void LLVMExtraInitializeAllTargets() { InitializeAllTargets(); }
+
+extern "C" void LLVMExtraInitializeAllTargetMCs() { InitializeAllTargetMCs(); }
+
+extern "C" void LLVMExtraInitializeAllAsmPrinters() {
+  InitializeAllAsmPrinters();
+}
+
+extern "C" void LLVMExtraInitializeAllAsmParsers() {
+  InitializeAllAsmParsers();
+}
+
+extern "C" void LLVMExtraInitializeAllDisassemblers() {
+  InitializeAllDisassemblers();
+}
+
+// These functions return true on failure.
+
+#ifndef LLVM_NATIVE_TARGET
+#error LLVM_NATIVE_TARGET not defined
+#endif
+
+extern "C" LLVMBool LLVMExtraInitializeNativeTarget() {
+  return InitializeNativeTarget();
+}
+
+extern "C" LLVMBool LLVMExtraInitializeNativeAsmParser() {
+  return InitializeNativeTargetAsmParser();
+}
+
+extern "C" LLVMBool LLVMExtraInitializeNativeAsmPrinter() {
+  return InitializeNativeTargetAsmPrinter();
+}
+
+extern "C" LLVMBool LLVMExtraInitializeNativeDisassembler() {
+  return InitializeNativeTargetDisassembler();
+}
+
+
+// Infrastructure for writing LLVM passes in Julia
+
+typedef struct LLVMOpaquePass *LLVMPassRef;
+DEFINE_STDCXX_CONVERSION_FUNCTIONS(Pass, LLVMPassRef)
+
+extern "C" void LLVMExtraAddPass(LLVMPassManagerRef PM, LLVMPassRef P) {
+  unwrap(PM)->add(unwrap(P));
+}
+
+StringMap<char *> PassIDs;
+char &CreatePassID(const char *Name) {
+  std::string NameStr(Name);
+  if (PassIDs.find(NameStr) != PassIDs.end())
+    return *PassIDs[NameStr];
+  else
+    return *(PassIDs[NameStr] = new char);
+}
+
+class JuliaModulePass : public ModulePass {
+public:
+  JuliaModulePass(const char *Name, jl_value_t *Callback)
+      : ModulePass(CreatePassID(Name)), Callback(Callback) {}
+
+  bool runOnModule(Module &M) {
+    jl_value_t **argv;
+    JL_GC_PUSHARGS(argv, 2);
+    argv[0] = Callback;
+    argv[1] = jl_box_voidpointer(wrap(&M));
+
+    jl_value_t *ret = jl_apply(argv, 2);
+    bool changed = jl_unbox_bool(ret);
+
+    JL_GC_POP();
+    return changed;
+  }
+
+private:
+  jl_value_t *Callback;
+};
+
+extern "C" LLVMPassRef LLVMExtraCreateModulePass(const char *Name,
+                                                 jl_value_t *Callback) {
+  return wrap(new JuliaModulePass(Name, Callback));
+}
+
+class JuliaFunctionPass : public FunctionPass {
+public:
+  JuliaFunctionPass(const char *Name, jl_value_t *Callback)
+      : FunctionPass(CreatePassID(Name)), Callback(Callback) {}
+
+  bool runOnFunction(Function &Fn) {
+    jl_value_t **argv;
+    JL_GC_PUSHARGS(argv, 2);
+    argv[0] = Callback;
+    argv[1] = jl_box_voidpointer(wrap(&Fn));
+
+    jl_value_t *ret = jl_apply(argv, 2);
+    bool changed = jl_unbox_bool(ret);
+
+    JL_GC_POP();
+    return changed;
+  }
+
+private:
+  jl_value_t *Callback;
+};
+
+extern "C" LLVMPassRef LLVMExtraCreateFunctionPass(const char *Name,
+                                                   jl_value_t *Callback) {
+  return wrap(new JuliaFunctionPass(Name, Callback));
+}
+
+class JuliaBasicBlockPass : public BasicBlockPass {
+public:
+  JuliaBasicBlockPass(const char *Name, jl_value_t *Callback)
+      : BasicBlockPass(CreatePassID(Name)), Callback(Callback) {}
+
+  bool runOnBasicBlock(BasicBlock &BB) {
+    jl_value_t **argv;
+    JL_GC_PUSHARGS(argv, 2);
+    argv[0] = Callback;
+    argv[1] = jl_box_voidpointer(wrap(&BB));
+
+    jl_value_t *ret = jl_apply(argv, 2);
+    bool changed = jl_unbox_bool(ret);
+
+    JL_GC_POP();
+    return changed;
+  }
+
+private:
+  jl_value_t *Callback;
+};
+
+extern "C" LLVMPassRef LLVMExtraCreateBasicBlockPass(const char *Name,
+                                                     jl_value_t *Callback) {
+  return wrap(new JuliaBasicBlockPass(Name, Callback));
+}
+
+
+// Bugfixes
+
+#if JL_LLVM_VERSION < 40000
+
+extern "C" unsigned
+LLVMGetAttributeCountAtIndex_D26392(LLVMValueRef F, LLVMAttributeIndex Idx) {
+  auto Fn = unwrap<Function>(F);
+  if (Fn->getAttributes().isEmpty())
+    return 0;
+  else
+    return LLVMGetAttributeCountAtIndex(F, Idx);
+}
+
+extern "C" unsigned
+LLVMGetCallSiteAttributeCount_D26392(LLVMValueRef C, LLVMAttributeIndex Idx) {
+  CallSite CS(unwrap<Instruction>(C));
+  if (CS.getAttributes().isEmpty())
+    return 0;
+  else
+    return LLVMGetCallSiteAttributeCount(C, Idx);
+}
+
+#endif
+
+
+// Various missing functions
+
+extern "C" unsigned int LLVMExtraGetDebugMDVersion() {
+  return DEBUG_METADATA_VERSION;
+}
+
+extern "C" LLVMContextRef LLVMExtraGetValueContext(LLVMValueRef V) {
+  return wrap(&unwrap(V)->getContext());
+}
+
+extern ModulePass *createNVVMReflectPass();
+extern "C" void LLVMExtraAddMVVMReflectPass(LLVMPassManagerRef PM) {
+  createNVVMReflectPass();
+}
+
+extern "C" void LLVMExtraAddTargetLibraryInfoByTiple(const char *T,
+                                                     LLVMPassManagerRef PM) {
+  unwrap(PM)->add(new TargetLibraryInfoWrapperPass(Triple(T)));
+}
+
+extern "C" void LLVMExtraAddInternalizePassWithExportList(
+    LLVMPassManagerRef PM, const char **ExportList, size_t Length) {
+  auto PreserveFobj = [=](const GlobalValue &GV) {
+    for (size_t i = 0; i < Length; i++) {
+      if (strcmp(ExportList[i], GV.getName().data()) == 0)
+        return true;
+    }
+    return false;
+  };
+  unwrap(PM)->add(createInternalizePass(PreserveFobj));
+}
+
+} // namespace llvm


### PR DESCRIPTION
After having let users struggle with source builds of Julia in order to run LLVM.jl -> CUDAnative.jl -> CuArrays.jl, I think the easiest short-term solution is to internalize the LLVM C API extensions and build them together with Julia (these were hard to build because of a missing `llvm-config`, C++ ABI compatibility issues, etc). Because even with BinDeps2, it doesn't seem like building against the Julia build tree is going to be easy to support, and it also doesn't fix the problem for people who run `make install` (`llvm-config` isn't installed) or use an external package manager.

Putting these API extensions in the Julia repo restricts our ability to iterate freely on LLVM.jl, but I guess that's the price to pay. Besides, the set of extensions has been relatively stable, and future extensions might be considered backportable in order to get them out there more quickly.

Most of these extensions should find their way upstream at some point, but I haven't got the time|motivation for that (esp. with us sticking to 3.9 which would then require additional patches to be backported etc).
Rust has a similar set of extensions: https://github.com/rust-lang/rust/tree/master/src/rustllvm

Ref https://github.com/maleadt/LLVM.jl/pull/68

TODO:
- [x] format the code
- [x] make sure it builds with other supported LLVM versions: tested with 3.9, 4.0, 5.0