### PR TITLE
Deprecate cumsum, cumprod, cumsum_kbn, and accumulate when dim isn't specified

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -663,6 +663,9 @@ Deprecated or removed
   * `a:b` is deprecated for constructing a `StepRange` when `a` and `b` have physical units
     (Dates and Times). Use `a:s:b`, where `s = Dates.Day(1)` or `s = Dates.Second(1)`.
 
+  * `cumsum`, `cumprod`, `accumulate`, and their mutating versions now require a `dim`
+    argument instead of defaulting to using the first dimension ([#24684]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -265,12 +265,12 @@ end
 # TODO: Needs a separate IndexCartesian method, this is only fast for IndexLinear
 
 """
-    cumsum_kbn(A, [dim::Integer=1])
+    cumsum_kbn(A, dim::Integer)
 
 Cumulative sum along a dimension, using the Kahan-Babuska-Neumaier compensated summation
-algorithm for additional accuracy. The dimension defaults to 1.
+algorithm for additional accuracy.
 """
-function cumsum_kbn(A::AbstractArray{T}, axis::Integer=1) where T<:AbstractFloat
+function cumsum_kbn(A::AbstractArray{T}, axis::Integer) where T<:AbstractFloat
     dimsA = size(A)
     ndimsA = ndims(A)
     axis_size = dimsA[axis]

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2105,6 +2105,9 @@ end
     @deprecate chol!(x::Number, uplo) chol(x) false
 end
 
+@deprecate cumsum(A::AbstractArray)     cumsum(A, 1)
+@deprecate cumsum_kbn(A::AbstractArray) cumsum_kbn(A, 1)
+@deprecate cumprod(A::AbstractArray)    cumprod(A, 1)
 
 # issue #16307
 @deprecate finalizer(o, f::Function) finalizer(f, o)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -691,9 +691,9 @@ function _cumsum!(out, v, axis, ::TypeArithmetic)
 end
 
 """
-    cumsum(A, dim)
+    cumsum(A, axis::Integer)
 
-Cumulative sum along a dimension `dim`. See also [`cumsum!`](@ref)
+Cumulative sum along the axis `axis`. See also [`cumsum!`](@ref)
 to use a preallocated output array, both for performance and to control the precision of the
 output (e.g. to avoid overflow).
 
@@ -743,9 +743,9 @@ julia> cumsum([fill(1, 2) for i in 1:3])
 cumsum(x::AbstractVector) = cumsum(x, 1)
 
 """
-    cumsum!(B, A, dim::Integer)
+    cumsum!(B, A, axis::Integer)
 
-Cumulative sum of `A` along a dimension, storing the result in `B`. See also [`cumsum`](@ref).
+Cumulative sum of `A` along the axis `axis`, storing the result in `B`. See also [`cumsum`](@ref).
 """
 cumsum!(B, A, axis::Integer) = accumulate!(+, B, A, axis)
 
@@ -757,9 +757,9 @@ Cumulative sum of a vector `x`, storing the result in `y`. See also [`cumsum`](@
 cumsum!(y::AbstractVector, x::AbstractVector) = cumsum!(y, x, 1)
 
 """
-    cumprod(A, dim)
+    cumprod(A, axis::Integer)
 
-Cumulative product along a dimension `dim`. See also
+Cumulative product along the axis `axis`. See also
 [`cumprod!`](@ref) to use a preallocated output array, both for performance and
 to control the precision of the output (e.g. to avoid overflow).
 
@@ -806,9 +806,9 @@ julia> cumprod([fill(1//3, 2, 2) for i in 1:3])
 cumprod(x::AbstractVector) = cumprod(x, 1)
 
 """
-    cumprod!(B, A, dim::Integer)
+    cumprod!(B, A, axis::Integer)
 
-Cumulative product of `A` along a dimension, storing the result in `B`.
+Cumulative product of `A` along the axis `axis`, storing the result in `B`.
 See also [`cumprod`](@ref).
 """
 cumprod!(B, A, axis::Integer) = accumulate!(*, B, A, axis)
@@ -822,9 +822,9 @@ See also [`cumprod`](@ref).
 cumprod!(y::AbstractVector, x::AbstractVector) = cumprod!(y, x, 1)
 
 """
-    accumulate(op, A, dim)
+    accumulate(op, A, axis::Integer)
 
-Cumulative operation `op` along a dimension `dim`. See also
+Cumulative operation `op` along the axis `axis`. See also
 [`accumulate!`](@ref) to use a preallocated output array, both for performance and
 to control the precision of the output (e.g. to avoid overflow). For common operations
 there are specialized variants of `accumulate`, see:
@@ -875,9 +875,9 @@ julia> accumulate(*, [1,2,3])
 accumulate(op, x::AbstractVector) = accumulate(op, x, 1)
 
 """
-    accumulate!(op, B, A, dim)
+    accumulate!(op, B, A, axis::Integer)
 
-Cumulative operation `op` on `A` along a dimension, storing the result in `B`.
+Cumulative operation `op` on `A` along the axis `axis`, storing the result in `B`.
 See also [`accumulate`](@ref).
 """
 function accumulate!(op, B, A, axis::Integer)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -632,7 +632,6 @@ end
     A1 = reshape(repmat([1,2],1,12),2,3,4)
     A2 = reshape(repmat([1 2 3],2,4),2,3,4)
     A3 = reshape(repmat([1 2 3 4],6,1),2,3,4)
-    @test isequal(cumsum(A),A1)
     @test isequal(cumsum(A,1),A1)
     @test isequal(cumsum(A,2),A2)
     @test isequal(cumsum(A,3),A3)
@@ -931,7 +930,7 @@ end
 end
 
 # issue #2342
-@test isequal(cumsum([1 2 3]), [1 2 3])
+@test isequal(cumsum([1 2 3], 1), [1 2 3])
 
 @testset "set-like operations" begin
     @test isequal(union([1,2,3], [4,3,4]), [1,2,3,4])


### PR DESCRIPTION
...and dimension is larger than one

Fixes #19451 