### PR TITLE
REPL: implement transpose current line with line above/below

### DIFF
--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -179,6 +179,8 @@ to do so).
 | `^Y`                | "Yank" insert the text from the kill ring                                                                  |
 | `meta-y`            | Replace a previously yanked text with an older entry from the kill ring                                    |
 | `^T`                | Transpose the characters about the cursor                                                                  |
+| `meta-Up arrow`     | Transpose current line with line above                                                                     |
+| `meta-Down arrow`   | Transpose current line with line below                                                                     |
 | `meta-u`            | Change the next word to uppercase                                                                          |
 | `meta-c`            | Change the next word to titlecase                                                                          |
 | `meta-l`            | Change the next word to lowercase                                                                          |

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -766,3 +766,21 @@ end
     @test edit!(edit_undo!) == ""
     @test edit!(edit_undo!) == "" # nothing more to undo (this "beeps")
 end
+
+@testset "edit_transpose_lines_{up,down}!" begin
+    local buf
+    buf = IOBuffer()
+    write(buf, "l1\nl2\nl3")
+    seek(buf, 0)
+    @test LineEdit.edit_transpose_lines_up!(buf) == false
+    @test transform!(LineEdit.edit_transpose_lines_up!, buf) == ("l1\nl2\nl3", 0, 0)
+    @test transform!(LineEdit.edit_transpose_lines_down!, buf) == ("l2\nl1\nl3", 3, 0)
+    @test LineEdit.edit_transpose_lines_down!(buf) == true
+    @test String(take!(copy(buf))) == "l2\nl3\nl1"
+    @test LineEdit.edit_transpose_lines_down!(buf) == false
+    @test String(take!(copy(buf))) == "l2\nl3\nl1" # no change
+    LineEdit.edit_move_right(buf)
+    @test transform!(LineEdit.edit_transpose_lines_up!, buf) == ("l2\nl1\nl3", 4, 0)
+    LineEdit.edit_move_right(buf)
+    @test transform!(LineEdit.edit_transpose_lines_up!, buf) == ("l1\nl2\nl3", 2, 0)
+end


### PR DESCRIPTION
I have had this locally for few months and have found it pretty handy. This is a shortcut for "kill line" -> "move up/down" -> "yank line" -> "go back to your position in line". I have bound it to "Meta-ArrowUp/Down".