### PR TITLE
wrap range variable in a let block for at_threads

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -25,7 +25,8 @@ function _threadsfor(iter,lbody)
     lidx = iter.args[1]         # index
     range = iter.args[2]
     quote
-        range = $(esc(range))
+        local threadsfor_fun
+        let range = $(esc(range))
         function threadsfor_fun(onethread=false)
             r = range # Load into local variable
             lenr = length(r)
@@ -62,6 +63,7 @@ function _threadsfor(iter,lbody)
                 local $(esc(lidx)) = Base.unsafe_getindex(r,i)
                 $(esc(lbody))
             end
+        end
         end
         # Hack to make nested threaded loops kinda work
         if threadid() != 1 || in_threaded_loop[]


### PR DESCRIPTION
This works around performance issues I have been seeing due to #15276.

In particular this function showed no performance scaling when i recently introduced threading to students:

```julia
function threaded_sum(arr)
    @assert length(arr) % nthreads() == 0
    results::Vector{Float64} = zeros(eltype(arr), nthreads())
    @threads for tid in 1:nthreads()
        # split work
        len = div(length(arr), nthreads())
        domain = ((tid-1)*len +1):tid*len
        acc = zero(eltype(arr))
        @simd for i in domain
            @inbounds acc += arr[i]
        end
        results[tid] = acc
    end
    sum(results)
end
```

```
julia> data = rand(100_000);
julia> @benchmark threaded_sum($data)
BenchmarkTools.Trial: 
  memory estimate:  6.09 MiB
  allocs estimate:  398994
  --------------
  minimum time:     7.674 ms (0.00% GC)
  median time:      8.117 ms (0.00% GC)
  mean time:        8.681 ms (1.45% GC)
  maximum time:     31.901 ms (75.30% GC)
  --------------
  samples:          576
  evals/sample:     1
@benchmark my_sum($data)
BenchmarkTools.Trial: 
  memory estimate:  96 bytes
  allocs estimate:  1
  --------------
  minimum time:     11.491 μs (0.00% GC)
  median time:      14.117 μs (0.00% GC)
  mean time:        23.058 μs (0.00% GC)
  maximum time:     417.783 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

These numbers are for single threaded performance and where `my_sum` is simple `threaded_sum` without `@threads`.

Adding `code_warntype(STDOUT, threadsfor_fun, (Bool,))` in line https://github.com/JuliaLang/julia/blob/52d81b037a25799ac7a93415c70edb1c991bb421/base/threadingconstructs.jl#L65
Shows that the example function which is type-stable without `@threads` becomes https://gist.github.com/vchuravy/e60e0e63b79de59f92c95a5864c66f37.

The change in this PR introduces a let block for the range variable eliminating almost all type-instability https://gist.github.com/vchuravy/0a4203674d02c92afee9b10b58756bbe and drastically improves performance:

```
julia> @benchmark threaded_sum($data)
BenchmarkTools.Trial: 
  memory estimate:  160 bytes
  allocs estimate:  3
  --------------
  minimum time:     11.806 μs (0.00% GC)
  median time:      11.917 μs (0.00% GC)
  mean time:        12.687 μs (0.00% GC)
  maximum time:     260.019 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```