### PR TITLE
Fix conversion from sparse Cholesky to LDLt when factorization is supernodal.

### DIFF
--- a/base/sparse/cholmod.jl
+++ b/base/sparse/cholmod.jl
@@ -1444,9 +1444,7 @@ function ldltfact!(F::Factor{Tv}, A::Sparse{Tv}; shift::Real=0.0) where Tv
     set_print_level(cm, 0)
 
     # Makes it an LDLt
-    unsafe_store!(common_final_ll[], 0)
-    # Really make sure it's an LDLt by avoiding supernodal factorization
-    unsafe_store!(common_supernodal[], 0)
+    change_factor!(eltype(F), false, false, true, false, F)
 
     # Compute the numerical factorization
     factorize_p!(A, shift, F, cm)

--- a/test/sparse/cholmod.jl
+++ b/test/sparse/cholmod.jl
@@ -691,6 +691,11 @@ end
     s = unsafe_load(pointer(F))
     @test s.is_super == 0
     @test F\b ≈ ones(m + n)
+    F2 = cholfact(M)
+    @test !LinAlg.issuccess(F2)
+    ldltfact!(F2, M)
+    @test LinAlg.issuccess(F2)
+    @test F2\b ≈ ones(m + n)
 end
 
 @testset "Test that imaginary parts in Hermitian{T,SparseMatrixCSC{T}} are ignored" begin


### PR DESCRIPTION
CHOLMOD strikes again. I realized that the old method for converting to LDLt only worked for smaller matrices where CHOLMOD defaults to the simplistic method. When the factorization was supernodal, CHOLMOD just silently returned the (failed) Cholesky version.