### PR TITLE
[RFC] Fix potential seqfault in testing for ambiguity

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1302,8 +1302,10 @@ function detect_unbound_args(mods...;
                     if has_unbound_vars(m.sig)
                         tuple_sig = Base.unwrap_unionall(m.sig)::DataType
                         if Base.isvatuple(tuple_sig)
-                            params = tuple_sig.parameters[1:(end - 1)]
-                            tuple_sig = Base.rewrap_unionall(Tuple{params...}, m.sig)
+                            params = tuple_sig.parameters[1:end-1]
+                            # tuple_sig = Base.rewrap_unionall(Tuple{params...}, m.sig)
+                            tuple_sig = Tuple{params...}
+                            @assert !isa(tuple_sig, UnionAll) # jl_gf_invoke will seqfault on UnionAll
                             mf = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt), tuple_sig, typemax(UInt))
                             if mf != nothing && mf.func !== m && mf.func.sig <: tuple_sig
                                 continue


### PR DESCRIPTION
fixes #24460

`jl_gf_invoke_lookup` seqfaults on a `UnionAll` since that has no field `parameters`,
I think it was originally intended to just take a tuple type. 
`Base.rewrap_unionall` only returns a `UnionAll` if `m.sig` is a `UnionAll` so I suspect
that this codepath was just never tested with a `UnionAll`

cc: @timholy