### PR TITLE
Remove overwriting empty vector constructor

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -158,8 +158,6 @@ Array{T}(d::Integer...) where {T} = Array{T}(convert(Tuple{Vararg{Int}}, d))
 # dimensionality but not type specified, accepting dims as series of Integers
 Vector(m::Integer) = Vector{Any}(Int(m))
 Matrix(m::Integer, n::Integer) = Matrix{Any}(Int(m), Int(n))
-# empty vector constructor
-Vector() = Vector{Any}(0)
 
 
 include("associative.jl")


### PR DESCRIPTION
This constructor overwrites what was added in #24652. As long as memory is uninitialized (rather than zeroed) by default, these constructors do the same thing. Removing this constructor fixes a method overwritten warning during the build:

```
WARNING: Method definition (::Type{Array{T, 1} where T})() in module Base at sysimg.jl:147 overwritten at sysimg.jl:162.
```