### PR TITLE
replace Array{...}(shape...)-like calls in test/linalg

### DIFF
--- a/test/linalg/generic.jl
+++ b/test/linalg/generic.jl
@@ -206,7 +206,7 @@ end
             @test scale!(similar(a), [1.; 2.], a) == a.*[1; 2]
             @test scale!(similar(a), [1; 2], a) == a.*[1; 2]
             @test_throws DimensionMismatch scale!(similar(a), ones(3), a)
-            @test_throws DimensionMismatch scale!(Array{Float64}(3, 2), a, ones(3))
+            @test_throws DimensionMismatch scale!(Matrix{Float64}(uninitialized, 3, 2), a, ones(3))
 
             if isa(a, Array)
                 @test scale!(similar(a), a, [1.; 2.; 3.]) == a.*[1 2 3]

--- a/test/linalg/pinv.jl
+++ b/test/linalg/pinv.jl
@@ -9,7 +9,7 @@ using Test
 srand(12345)
 
 function hilb(T::Type, n::Integer)
-    a=Array{T}(n,n)
+    a = Matrix{T}(uninitialized, n, n)
     for i=1:n
         for j=1:n
             a[j,i]=one(T)/(i+j-one(T))
@@ -20,7 +20,7 @@ end
 hilb(n::Integer) = hilb(Float64,n)
 
 function hilb(T::Type, m::Integer, n::Integer)
-    a=Array{T}(m,n)
+    a = Matrix{T}(uninitialized, m, n)
     for i=1:n
         for j=1:m
             a[j,i]=one(T)/(i+j-one(T))
@@ -67,7 +67,7 @@ tridiag(m::Integer, n::Integer) = tridiag(Float64, m::Integer, n::Integer)
 
 function randn_float64(m::Integer, n::Integer)
     a=randn(m,n)
-    b=Array{Float64}(m,n)
+    b = Matrix{Float64}(uninitialized, m, n)
     for i=1:n
         for j=1:m
             b[j,i]=convert(Float64,a[j,i])
@@ -78,7 +78,7 @@ end
 
 function randn_float32(m::Integer, n::Integer)
     a=randn(m,n)
-    b=Array{Float32}(m,n)
+    b = Matrix{Float32}(uninitialized, m, n)
     for i=1:n
         for j=1:m
             b[j,i]=convert(Float32,a[j,i])

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -298,7 +298,7 @@ for elty1 in (Float32, Float64, BigFloat, Complex64, Complex128, Complex{BigFloa
                 @test A1'A2' ≈ Matrix(A1)'Matrix(A2)'
                 @test A1/A2 ≈ Matrix(A1)/Matrix(A2)
                 @test A1\A2 ≈ Matrix(A1)\Matrix(A2)
-                offsizeA = Matrix{Float64}(n+1, n+1)
+                offsizeA = Matrix{Float64}(I, n+1, n+1)
                 @test_throws DimensionMismatch offsizeA / A2
                 @test_throws DimensionMismatch offsizeA / A2.'
                 @test_throws DimensionMismatch offsizeA / A2'


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in test/linalg. Ref. #24595. Best!