### PR TITLE
add parse(Complex{T}, s)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -325,6 +325,8 @@ Library improvements
   * The function `randn` now accepts complex arguments (`Complex{T <: AbstractFloat}`)
     ([#21973]).
 
+  * `parse(Complex{T}, string)` is now implemented ([#24713]).
+
   * The function `rand` can now pick up random elements from strings, associatives
     and sets ([#22228], [#21960], [#18155], [#22224]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -325,7 +325,7 @@ Library improvements
   * The function `randn` now accepts complex arguments (`Complex{T <: AbstractFloat}`)
     ([#21973]).
 
-  * `parse(Complex{T}, string)` is now implemented ([#24713]).
+  * `parse(Complex{T}, string)` can parse complex numbers in common formats ([#24713]).
 
   * The function `rand` can now pick up random elements from strings, associatives
     and sets ([#22228], [#21960], [#18155], [#22224]).

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -125,6 +125,7 @@ convert(::Type{BigFloat}, x::Union{Float16,Float32}) = BigFloat(Float64(x))
 convert(::Type{BigFloat}, x::Rational) = BigFloat(numerator(x)) / BigFloat(denominator(x))
 
 function tryparse(::Type{BigFloat}, s::AbstractString, base::Int=0)
+    !isempty(s) && isspace(s[end]) && return tryparse(BigFloat, rstrip(s), base)
     z = BigFloat()
     err = ccall((:mpfr_set_str, :libmpfr), Int32, (Ref{BigFloat}, Cstring, Int32, Int32), z, s, base, ROUNDING_MODE[])
     err == 0 ? Nullable(z) : Nullable{BigFloat}()

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -10,8 +10,8 @@ import Base.Checked: add_with_overflow, mul_with_overflow
 Parse a string as a number. For `Integer` types, a base can be specified
 (the default is 10). For floating-point types, the string is parsed as a decimal
 floating-point number.  `Complex` types are parsed from decimal strings
-of the form `"R±Iim"` as a `Complex(R,I)` of the requested type; `i` or `j` can also be
-used instead of `im`.  If the string does not contain a valid number, an error is raised.
+of the form `"R±Iim"` as a `Complex(R,I)` of the requested type; `"i"` or `"j"` can also be
+used instead of `"im"`.  If the string does not contain a valid number, an error is raised.
 
 ```jldoctest
 julia> parse(Int, "1234")

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -298,7 +298,8 @@ function tryparse_internal(::Type{Complex{T}}, s::Union{String,SubString{String}
 end
 
 # the ±1 indexing above for ascii chars is specific to String, so convert:
-tryparse(T::Type{<:Complex}, s::AbstractString) = tryparse(T, String(s))
+tryparse_internal(T::Type{<:Complex}, s::AbstractString, i::Int, e::Int, raise::Bool) =
+    tryparse_internal(T, String(s), i, e, raise)
 
 # fallback methods for tryparse_internal
 tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int) where T<:Real =

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -236,7 +236,7 @@ tryparse_internal(::Type{Float32}, s::SubString{String}, startpos::Int, endpos::
 tryparse(::Type{T}, s::AbstractString) where {T<:Union{Float32,Float64}} = tryparse(T, String(s))
 
 tryparse(::Type{Float16}, s::AbstractString) = convert(Nullable{Float16}, tryparse(Float32, s))
-tryparse_internal(::Type{Float16}, s::SubString{String}, startpos::Int, endpos::Int) =
+tryparse_internal(::Type{Float16}, s::AbstractString, startpos::Int, endpos::Int) =
     convert(Nullable{Float16}, tryparse_internal(Float32, s, startpos, endpos))
 
 ## string to complex functions ##

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -10,7 +10,7 @@ import Base.Checked: add_with_overflow, mul_with_overflow
 Parse a string as a number. For `Integer` types, a base can be specified
 (the default is 10). For floating-point types, the string is parsed as a decimal
 floating-point number.  `Complex` types are parsed from decimal strings
-of the form `R±Iim` as a `Complex(R,I)` of the requested type; `i` or `j` can also be
+of the form `"R±Iim"` as a `Complex(R,I)` of the requested type; `i` or `j` can also be
 used instead of `im`.  If the string does not contain a valid number, an error is raised.
 
 ```jldoctest

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -226,12 +226,12 @@ end
 tryparse(::Type{Float64}, s::String) = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8},Csize_t,Csize_t), s, 0, sizeof(s))
 tryparse(::Type{Float64}, s::SubString{String}) = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset, s.endof)
 tryparse_internal(::Type{Float64}, s::String, startpos::Int, endpos::Int) = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8},Csize_t,Csize_t), s, startpos-1, endpos-startpos+1)
-tryparse_internal(::Type{Float64}, s::SubString{String}, startpos::Int, endpos::Int) = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset+startpos-1, s.offset+endpos-startpos+1)
+tryparse_internal(::Type{Float64}, s::SubString{String}, startpos::Int, endpos::Int) = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset+startpos-1, endpos-startpos+1)
 
 tryparse(::Type{Float32}, s::String) = ccall(:jl_try_substrtof, Nullable{Float32}, (Ptr{UInt8},Csize_t,Csize_t), s, 0, sizeof(s))
 tryparse(::Type{Float32}, s::SubString{String}) = ccall(:jl_try_substrtof, Nullable{Float32}, (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset, s.endof)
 tryparse_internal(::Type{Float32}, s::String, startpos::Int, endpos::Int) = ccall(:jl_try_substrtof, Nullable{Float32}, (Ptr{UInt8},Csize_t,Csize_t), s, startpos-1, endpos-startpos+1)
-tryparse_internal(::Type{Float32}, s::SubString{String}, startpos::Int, endpos::Int) = ccall(:jl_try_substrtof, Nullable{Float32}, (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset+startpos-1, s.offset+endpos-startpos+1)
+tryparse_internal(::Type{Float32}, s::SubString{String}, startpos::Int, endpos::Int) = ccall(:jl_try_substrtof, Nullable{Float32}, (Ptr{UInt8},Csize_t,Csize_t), s.string, s.offset+startpos-1, endpos-startpos+1)
 
 tryparse(::Type{T}, s::AbstractString) where {T<:Union{Float32,Float64}} = tryparse(T, String(s))
 

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -157,7 +157,7 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     return Nullable{T}(n)
 end
 
-function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString},
+function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString{String}},
         startpos::Int, endpos::Int, base::Integer, raise::Bool)
     if isempty(sbuff)
         raise && throw(ArgumentError("input string is empty"))

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -7,9 +7,11 @@ import Base.Checked: add_with_overflow, mul_with_overflow
 """
     parse(type, str, [base])
 
-Parse a string as a number. If the type is an integer type, then a base can be specified
-(the default is 10). If the type is a floating point type, the string is parsed as a decimal
-floating point number. If the string does not contain a valid number, an error is raised.
+Parse a string as a number. For `Integer` types, a base can be specified
+(the default is 10). For floating-point types, the string is parsed as a decimal
+floating-point number.  `Complex` types are parsed from decimal strings
+of the form `R±Iim` as a `Complex(R,I)` of the requested type; `i` or `j` can also be
+used instead of `im`.  If the string does not contain a valid number, an error is raised.
 
 ```jldoctest
 julia> parse(Int, "1234")

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -393,22 +393,17 @@ end
 
 function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{Bool,2}, row::Int, col::Int)
     n = tryparse_internal(Bool, sbuff, startpos, endpos, 0, false)
-    isnull(n) || (cells[row, col] = get(n))
+    isnull(n) || (cells[row, col] = unsafe_get(n))
     isnull(n)
 end
 function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{T,2}, row::Int, col::Int) where T<:Integer
     n = tryparse_internal(T, sbuff, startpos, endpos, 0, false)
-    isnull(n) || (cells[row, col] = get(n))
+    isnull(n) || (cells[row, col] = unsafe_get(n))
     isnull(n)
 end
-function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{Float64,2}, row::Int, col::Int)
-    n = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8},Csize_t,Csize_t), sbuff, startpos-1, endpos-startpos+1)
-    isnull(n) || (cells[row, col] = get(n))
-    isnull(n)
-end
-function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{Float32,2}, row::Int, col::Int)
-    n = ccall(:jl_try_substrtof, Nullable{Float32}, (Ptr{UInt8}, Csize_t, Csize_t), sbuff, startpos-1, endpos-startpos+1)
-    isnull(n) || (cells[row, col] = get(n))
+function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{T,2}, row::Int, col::Int) where T<:Union{Real,Complex}
+    n = tryparse_internal(T, sbuff, startpos, endpos, false)
+    isnull(n) || (cells[row, col] = unsafe_get(n))
     isnull(n)
 end
 function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{<:AbstractString,2}, row::Int, col::Int)
@@ -421,15 +416,15 @@ function colval(sbuff::String, startpos::Int, endpos::Int, cells::Array{Any,2}, 
     if len > 0
         # check Inteter
         ni64 = tryparse_internal(Int, sbuff, startpos, endpos, 0, false)
-        isnull(ni64) || (cells[row, col] = get(ni64); return false)
+        isnull(ni64) || (cells[row, col] = unsafe_get(ni64); return false)
 
         # check Bool
         nb = tryparse_internal(Bool, sbuff, startpos, endpos, 0, false)
-        isnull(nb) || (cells[row, col] = get(nb); return false)
+        isnull(nb) || (cells[row, col] = unsafe_get(nb); return false)
 
         # check float64
         nf64 = ccall(:jl_try_substrtod, Nullable{Float64}, (Ptr{UInt8}, Csize_t, Csize_t), sbuff, startpos-1, endpos-startpos+1)
-        isnull(nf64) || (cells[row, col] = get(nf64); return false)
+        isnull(nf64) || (cells[row, col] = unsafe_get(nf64); return false)
     end
     cells[row, col] = SubString(sbuff, startpos, endpos)
     false

--- a/stdlib/DelimitedFiles/test/runtests.jl
+++ b/stdlib/DelimitedFiles/test/runtests.jl
@@ -290,3 +290,7 @@ let d = TextDisplay(IOBuffer())
     display(d, "text/csv", [3 1 4])
     @test String(take!(d.io)) == "3,1,4\n"
 end
+
+@testset "complex" begin
+    @test readdlm(IOBuffer("3+4im, 4+5im"), ',', Complex{Int}) == [3+4im 4+5im]
+end

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -7,22 +7,10 @@ import Base.MPFR
         x = BigFloat(12)
     end
     x = BigFloat(12)
-    y = BigFloat(x)
-    @test x ≈ y
-    y = BigFloat(0xc)
-    @test x ≈ y
-    y = BigFloat(12.)
-    @test x ≈ y
-    y = BigFloat(BigInt(12))
-    @test x ≈ y
-    y = BigFloat(BigFloat(12))
-    @test x ≈ y
-    y = parse(BigFloat,"12")
-    @test x ≈ y
-    y = BigFloat(Float32(12.))
-    @test x ≈ y
-    y = BigFloat(12//1)
-    @test x ≈ y
+    @test x == BigFloat(x) == BigFloat(0xc) == BigFloat(12.) ==
+          BigFloat(BigInt(12)) == BigFloat(BigFloat(12)) == parse(BigFloat,"12") ==
+          parse(BigFloat,"12 ") == parse(BigFloat," 12") == parse(BigFloat," 12 ") ==
+          BigFloat(Float32(12.)) == BigFloat(12//1)
 
     @test typeof(BigFloat(typemax(Int8))) == BigFloat
     @test typeof(BigFloat(typemax(Int16))) == BigFloat

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -236,6 +236,8 @@ end
             n = Complex(r, sign == '+' ? i : -i)
             s = string(s1, r, s2, sign, s3, i, Im, s4)
             @test n === parse(Complex{Int}, s)
+            @test Complex(r) === parse(Complex{Int}, string(s1, r, s2))
+            @test Complex(0,i) === parse(Complex{Int}, string(s3, i, Im, s4))
             for T in (Float64, BigFloat)
                 nT = parse(Complex{T}, s)
                 @test nT isa Complex{T}
@@ -246,4 +248,8 @@ end
         end
     end
     @test parse(Complex{Int}, SubString("xxxxxx1+2imxxxx", 7, 10)) === 1+2im
+    for T in (Int, Float64), bad in ("3 + 4*im", "3 + 4", "1+2ij", "1im-3im", "++4im")
+        @test_throws ArgumentError parse(Complex{T}, bad)
+    end
+    @test_throws ArgumentError parse(Complex{Int}, "3 + 4.2im")
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -247,6 +247,7 @@ end
             end
         end
     end
+    @test parse(Complex{Float16}, "3.3+4i") === Complex{Float16}(3.3+4im)
     @test parse(Complex{Int}, SubString("xxxxxx1+2imxxxx", 7, 10)) === 1+2im
     for T in (Int, Float64), bad in ("3 + 4*im", "3 + 4", "1+2ij", "1im-3im", "++4im")
         @test_throws ArgumentError parse(Complex{T}, bad)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -245,4 +245,5 @@ end
             end
         end
     end
+    @test parse(Complex{Int}, SubString("xxxxxx1+2imxxxx", 7, 10)) === 1+2im
 end

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -229,3 +229,20 @@ end
 @test tryparse(Float32, "1.23") === Nullable(1.23f0)
 @test tryparse(Float16, "1.23") === Nullable(Float16(1.23))
 
+# parsing complex numbers (#22250)
+@testset "complex parsing" begin
+    for r in (1,0,-1), i in (1,0,-1), sign in ('-','+'), Im in ("i","j","im")
+        for s1 in (""," "), s2 in (""," "), s3 in (""," "), s4 in (""," ")
+            n = Complex(r, sign == '+' ? i : -i)
+            s = string(s1, r, s2, sign, s3, i, Im, s4)
+            @test n === parse(Complex{Int}, s)
+            for T in (Float64, BigFloat)
+                nT = parse(Complex{T}, s)
+                @test nT isa Complex{T}
+                @test nT == n
+                @test n == parse(Complex{T}, string(s1, r, ".0", s2, sign, s3, i, ".0", Im, s4))
+                @test n*parse(T,"1e-3") == parse(Complex{T}, string(s1, r, "e-3", s2, sign, s3, i, "e-3", Im, s4))
+            end
+        end
+    end
+end


### PR DESCRIPTION
Closes #22250.   `parse(Complex{T}, s::String)` now works, supporting `a ± bIM` for `IM` in (`i`,`j`,`im`), with arbitrary whitespace.

Closes #21935.  `readdlm(io, ',', Complex{T})` now works.

I also needed a fix for `parse(BigFloat, s)`, because it was failing if `s` had trailing whitespace (which is allowed by other number parsers in Julia).  Added a test, and tightened up the `BigFloat` parsing tests (which were using `≈` when they could/should have been using `==`).