### PR TITLE
replace Array{...}(shape...)-like calls in test/sparse

### DIFF
--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -266,12 +266,12 @@ end
         b = sprandn(5, 5, 0.2)
         @test (maximum(abs.(a\b - Array(a)\Array(b))) < 1000*eps())
         # test error throwing for bwdTrisolve
-        @test_throws DimensionMismatch a\Matrix{Float64}(6, 6)
+        @test_throws DimensionMismatch a\Matrix{Float64}(I, 6, 6)
         a = LowerTriangular(I + tril(0.1*sprandn(5, 5, 0.2)))
         b = sprandn(5, 5, 0.2)
         @test (maximum(abs.(a\b - Array(a)\Array(b))) < 1000*eps())
         # test error throwing for fwdTrisolve
-        @test_throws DimensionMismatch a\Matrix{Float64}(6, 6)
+        @test_throws DimensionMismatch a\Matrix{Float64}(I, 6, 6)
 
 
 
@@ -426,7 +426,7 @@ end
         @test_throws ArgumentError permute!(X, A, p, q, (D = copy(C); resize!(D.nzval, nnz(A) - 1); D))
     end
     @testset "common error checking of permute[!] methods / source-workcolptr compat" begin
-        @test_throws DimensionMismatch permute!(A, p, q, C, Vector{eltype(A.rowval)}(length(A.colptr) - 1))
+        @test_throws DimensionMismatch permute!(A, p, q, C, Vector{eltype(A.rowval)}(uninitialized, length(A.colptr) - 1))
     end
     @testset "common error checking of permute[!] methods / permutation validity" begin
         @test_throws ArgumentError permute!(A, (r = copy(p); r[2] = r[1]; r), q)
@@ -508,16 +508,16 @@ end
         @test var(sparse(Int[])) === NaN
 
         for f in (sum, prod, var)
-            @test isequal(f(spzeros(0, 1), 1), f(Array{Int}(0, 1), 1))
-            @test isequal(f(spzeros(0, 1), 2), f(Array{Int}(0, 1), 2))
-            @test isequal(f(spzeros(0, 1), (1, 2)), f(Array{Int}(0, 1), (1, 2)))
-            @test isequal(f(spzeros(0, 1), 3), f(Array{Int}(0, 1), 3))
+            @test isequal(f(spzeros(0, 1), 1), f(Matrix{Int}(I, 0, 1), 1))
+            @test isequal(f(spzeros(0, 1), 2), f(Matrix{Int}(I, 0, 1), 2))
+            @test isequal(f(spzeros(0, 1), (1, 2)), f(Matrix{Int}(I, 0, 1), (1, 2)))
+            @test isequal(f(spzeros(0, 1), 3), f(Matrix{Int}(I, 0, 1), 3))
         end
         for f in (minimum, maximum, findmin, findmax)
             @test_throws ArgumentError f(spzeros(0, 1), 1)
-            @test isequal(f(spzeros(0, 1), 2), f(Array{Int}(0,1), 2))
+            @test isequal(f(spzeros(0, 1), 2), f(Matrix{Int}(I, 0, 1), 2))
             @test_throws ArgumentError f(spzeros(0, 1), (1, 2))
-            @test isequal(f(spzeros(0, 1), 3), f(Array{Int}(0,1), 3))
+            @test isequal(f(spzeros(0, 1), 3), f(Matrix{Int}(I, 0, 1), 3))
         end
     end
 end
@@ -1035,7 +1035,7 @@ end
     @test indmax(S) == indmax(A) == CartesianIndex(1,1)
     @test indmin(S) == indmin(A) == CartesianIndex(1,1)
 
-    A = Array{Int}(0,0)
+    A = Matrix{Int}(I, 0, 0)
     S = sparse(A)
     iA = try indmax(A) end
     iS = try indmax(S) end

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -426,7 +426,7 @@ end
 
 @testset "Concatenation" begin
     let m = 80, n = 100
-        A = Array{SparseVector{Float64,Int}}(n)
+        A = Vector{SparseVector{Float64,Int}}(uninitialized, n)
         tnnz = 0
         for i = 1:length(A)
             A[i] = sprand(m, 0.3)

--- a/test/sparse/spqr.jl
+++ b/test/sparse/spqr.jl
@@ -41,7 +41,7 @@ nn = 100
         @test R0[1:n, :] ≈ F[:R]
         @test norm(R0[n + 1:end, :], 1) < 1e-12
 
-        offsizeA = Matrix{Float64}(m+1, m+1)
+        offsizeA = Matrix{Float64}(I, m+1, m+1)
         @test_throws DimensionMismatch A_mul_B!(Q, offsizeA)
         @test_throws DimensionMismatch Ac_mul_B!(Q, offsizeA)
         @test_throws DimensionMismatch A_mul_B!(offsizeA, Q)


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in test/sparse. Ref. #24595. Best!