### PR TITLE
Make findn and findnz behavior match nnz

### DIFF
--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -1267,7 +1267,7 @@ function find(p::Function, S::SparseMatrixCSC)
     return sub2ind(sz, I, J)
 end
 
-findn(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = _findn(x->x!=0, S)
+findn(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = _findn(x->true, S)
 
 function _findn(p::Function, S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     numnz = nnz(S)
@@ -1283,12 +1283,6 @@ function _findn(p::Function, S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
         end
     end
 
-    count -= 1
-    if numnz != count
-        deleteat!(I, (count+1):numnz)
-        deleteat!(J, (count+1):numnz)
-    end
-
     return (I, J)
 end
 
@@ -1300,19 +1294,10 @@ function findnz(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
 
     count = 1
     @inbounds for col = 1 : S.n, k = S.colptr[col] : (S.colptr[col+1]-1)
-        if S.nzval[k] != 0
-            I[count] = S.rowval[k]
-            J[count] = col
-            V[count] = S.nzval[k]
-            count += 1
-        end
-    end
-
-    count -= 1
-    if numnz != count
-        deleteat!(I, (count+1):numnz)
-        deleteat!(J, (count+1):numnz)
-        deleteat!(V, (count+1):numnz)
+        I[count] = S.rowval[k]
+        J[count] = col
+        V[count] = S.nzval[k]
+        count += 1
     end
 
     return (I, J, V)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -526,9 +526,9 @@ end
     @test_throws ArgumentError sparsevec([3,5,7],[0.1,0.0,3.2],4)
 end
 
-@testset "issue #5386" begin
+@testset "what used to be issue #5386" begin
     K,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
-    @test length(K) == length(J) == length(V) == 1
+    @test length(K) == length(J) == length(V) == 2
 end
 
 @testset "issue described in https://groups.google.com/d/msg/julia-users/Yq4dh8NOWBQ/GU57L90FZ3EJ" begin


### PR DESCRIPTION
such that length of returned vectors is `nnz`.

This is a minimal fix of JuliaLang/LinearAlgebra.jl#453.

Longer term we should consider the names of these functions. It has previously been proposed that the `n` and `nz` part should be something like `filled`/`stored`. However, there is also an inconsistency in the `find` part because some `find` functions only return a (linear) index (even it doesn't makes sense such as for dictionaries) while others return both indices and values.