### PR TITLE
REPL: enable visual selection

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -23,6 +23,9 @@ const text_colors = AnyDict(
     :default       => "\033[39m",
     :bold          => "\033[1m",
     :underline     => "\033[4m",
+    :blink         => "\033[5m",
+    :reverse       => "\033[7m",
+    :hidden        => "\033[8m",
     :nothing       => "",
 )
 
@@ -31,10 +34,13 @@ for i in 0:255
 end
 
 const disable_text_style = AnyDict(
-    :bold => "\033[22m",
+    :bold      => "\033[22m",
     :underline => "\033[24m",
-    :normal => "",
-    :default => "",
+    :blink     => "\033[25m",
+    :reverse   => "\033[27m",
+    :hidden    => "\033[28m",
+    :normal    => "",
+    :default   => "",
 )
 
 # Create a docstring with an automatically generated list

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -165,7 +165,9 @@ to do so).
 | Page-down, `meta-N` | Change to the next history entry                                                                           |
 | `meta-<`            | Change to the first history entry (of the current session if it is before the current position in history) |
 | `meta->`            | Change to the last history entry                                                                           |
-| `^-Space`           | Set the "mark" in the editing region                                                                       |
+| `^-Space`           | Set the "mark" in the editing region (and de-activate the region if it's active)                           |
+| `^-Space ^-Space`   | Set the "mark" in the editing region and make the region "active", i.e. highlighted                        |
+| `^G`                | De-activate the region (i.e. make it not highlighted)                                                      |
 | `^X^X`              | Exchange the current position with the mark                                                                |
 | **Editing**         |                                                                                                            |
 | Backspace, `^H`     | Delete the previous character                                                                              |

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -161,6 +161,7 @@ to do so).
 | End, `^E`           | Move to end of line                                                                                        |
 | Up arrow, `^P`      | Move up one line (or change to the previous history entry that matches the text before the cursor)         |
 | Down arrow, `^N`    | Move down one line (or change to the next history entry that matches the text before the cursor)           |
+| Shift-Arrow Key     | Move cursor according to the direction of the Arrow key, while activating the region ("shift selection")   |
 | Page-up, `meta-P`   | Change to the previous history entry                                                                       |
 | Page-down, `meta-N` | Change to the next history entry                                                                           |
 | `meta-<`            | Change to the first history entry (of the current session if it is before the current position in history) |

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -22,9 +22,12 @@ charpos(buf, pos=position(buf)) = Base.unsafe_ind2chr(content(buf), pos+1)-1
 function transform!(f, s, i = -1) # i is char-based (not bytes) buffer position
     buf = buffer(s)
     i >= 0 && charseek(buf, i)
-    action = f(s)
-    if s isa LineEdit.MIState && action isa Symbol
-        s.last_action = action # simulate what happens in LineEdit.prompt!
+    # simulate what happens in LineEdit.set_action!
+    s isa LineEdit.MIState && (s.current_action = :unknown)
+    status = f(s)
+    if s isa LineEdit.MIState && status != :ignore
+        # simulate what happens in LineEdit.prompt!
+        s.last_action = s.current_action
     end
     content(s), charpos(buf), charpos(buf, getmark(buf))
 end


### PR DESCRIPTION
Like in ipython and emacs, when the mark is set twice in a row,
the region is set to "active", which means visually that
it is highlighted. Once it's active, setting the mark or pressing
Ctrl-G de-activates the region.
