### PR TITLE
REPL: indent line left-right with Meta-Arrow{Left,Right}

### DIFF
--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -184,7 +184,8 @@ to do so).
 | `meta-l`            | Change the next word to lowercase                                                                          |
 | `^/`, `^_`          | Undo previous editing action                                                                               |
 | `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method                 |
-
+| `meta-Left Arrow`   | indent the current line on the left                                                                        |
+| `meta-Right Arrow`  | indent the current line on the right                                                                       |
 
 
 ### Customizing keybindings

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -766,3 +766,27 @@ end
     @test edit!(edit_undo!) == ""
     @test edit!(edit_undo!) == "" # nothing more to undo (this "beeps")
 end
+
+@testset "edit_indent_{left,right}" begin
+    local buf = IOBuffer()
+    write(buf, "1\n22\n333")
+    seek(buf, 0)
+    @test LineEdit.edit_indent(buf, -1) == false
+    @test transform!(buf->LineEdit.edit_indent(buf, -1), buf) == ("1\n22\n333", 0, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, +1), buf) == (" 1\n22\n333", 1, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, +2), buf) == ("   1\n22\n333", 3, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, -2), buf) == (" 1\n22\n333", 1, 0)
+    seek(buf, 0) # if the cursor is already on the left column, it stays there
+    @test transform!(buf->LineEdit.edit_indent(buf, -2), buf) == ("1\n22\n333", 0, 0)
+    seek(buf, 3) # between the two "2"
+    @test transform!(buf->LineEdit.edit_indent(buf, +3), buf) == ("1\n   22\n333", 6, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, -9), buf) == ("1\n22\n333", 3, 0)
+    seekend(buf) # position 8
+    @test transform!(buf->LineEdit.edit_indent(buf, +3), buf) == ("1\n22\n   333", 11, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, -1), buf) == ("1\n22\n  333", 10, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, -2), buf) == ("1\n22\n333", 8, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, -1), buf) == ("1\n22\n333", 8, 0)
+    @test transform!(buf->LineEdit.edit_indent(buf, +3), buf) == ("1\n22\n   333", 11, 0)
+    seek(buf, 5) # left column
+    @test transform!(buf->LineEdit.edit_indent(buf, -2), buf) == ("1\n22\n 333", 5, 0)
+end


### PR DESCRIPTION
I'm not sure if we want to indent by 1 character by default (the current state of this PR), or by 4, or to align to 4 characters like tab and backspace do... Experience will tell! Once visual selection of code is enabled, it will be easy to extend this to indent a block of code at once.