### PR TITLE
 Support sprint using functions with keywords

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2137,6 +2137,9 @@ end
 @deprecate linspace(start, stop)     linspace(start, stop, 50)
 @deprecate logspace(start, stop)     logspace(start, stop, 50)
 
+# PR #24727
+@deprecate sprint(size::Integer, f::Function, args...; env=nothing) _sprint(f, args; size=size, env=env)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -151,7 +151,7 @@ big(::Type{<:AbstractIrrational}) = BigFloat
 
 # align along = for nice Array printing
 function alignment(io::IO, x::AbstractIrrational)
-    m = match(r"^(.*?)(=.*)$", sprint(0, showcompact, x, env=io))
-    m === nothing ? (length(sprint(0, showcompact, x, env=io)), 0) :
+    m = match(r"^(.*?)(=.*)$", _sprint(showcompact, (x,), env=io))
+    m === nothing ? (length(_sprint(showcompact, (x,), env=io)), 0) :
     (length(m.captures[1]), length(m.captures[2]))
 end

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -151,7 +151,7 @@ big(::Type{<:AbstractIrrational}) = BigFloat
 
 # align along = for nice Array printing
 function alignment(io::IO, x::AbstractIrrational)
-    m = match(r"^(.*?)(=.*)$", _sprint(showcompact, (x,), env=io))
-    m === nothing ? (length(_sprint(showcompact, (x,), env=io)), 0) :
-    (length(m.captures[1]), length(m.captures[2]))
+    s = _sprint(showcompact, (x,), env=io)
+    m = match(r"^(.*?)(=.*)$", s)
+    m === nothing ? (length(s), 0) : (length(m.captures[1]), length(m.captures[2]))
 end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -25,7 +25,7 @@ function show(io::IO, ::MIME"text/plain", iter::Union{KeyIterator,ValueIterator}
         i == rows < length(iter) && (print(io, "⋮"); break)
 
         if limit
-            str = sprint(0, show, v, env=io)
+            str = _sprint(show, (v,), env=io)
             str = _truncate_at_width_or_chars(str, cols, "\r\n")
             print(io, str)
         else
@@ -61,8 +61,8 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
         vallen = 0
         for (i, (k, v)) in enumerate(t)
             i > rows && break
-            ks[i] = sprint(0, show, k, env=recur_io)
-            vs[i] = sprint(0, show, v, env=recur_io)
+            ks[i] = _sprint(show, (k,), env=recur_io)
+            vs[i] = _sprint(show, (v,), env=recur_io)
             keylen = clamp(length(ks[i]), keylen, cols)
             vallen = clamp(length(vs[i]), vallen, cols)
         end
@@ -80,7 +80,7 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
         if limit
             key = rpad(_truncate_at_width_or_chars(ks[i], keylen, "\r\n"), keylen)
         else
-            key = sprint(0, show, k, env=recur_io)
+            key = _sprint(show, (k,), env=recur_io)
         end
         print(recur_io, key)
         print(io, " => ")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1577,20 +1577,20 @@ alignment(io::IO, x::Number) = (length(_sprint(show, (x,), env=io)), 0)
 alignment(io::IO, x::Integer) = (length(_sprint(show, (x,), env=io)), 0)
 "`alignment(4.23)` yields (1,3) for `4` and `.23`"
 function alignment(io::IO, x::Real)
-    m = match(r"^(.*?)((?:[\.eE].*)?)$", _sprint(show, (x,), env=io))
-    m === nothing ? (length(_sprint(show, (x,), env=io)), 0) :
-                   (length(m.captures[1]), length(m.captures[2]))
+    s = _sprint(show, (x,), env=io)
+    m = match(r"^(.*?)((?:[\.eE].*)?)$", s)
+    m === nothing ? (length(s), 0) : (length(m.captures[1]), length(m.captures[2]))
 end
 "`alignment(1 + 10im)` yields (3,5) for `1 +` and `_10im` (plus sign on left, space on right)"
 function alignment(io::IO, x::Complex)
-    m = match(r"^(.*[^e][\+\-])(.*)$", _sprint(show, (x,), env=io))
-    m === nothing ? (length(_sprint(show, (x,), env=io)), 0) :
-                   (length(m.captures[1]), length(m.captures[2]))
+    s = _sprint(show, (x,), env=io)
+    m = match(r"^(.*[^e][\+\-])(.*)$", s)
+    m === nothing ? (length(s), 0) : (length(m.captures[1]), length(m.captures[2]))
 end
 function alignment(io::IO, x::Rational)
-    m = match(r"^(.*?/)(/.*)$", _sprint(show, (x,), env=io))
-    m === nothing ? (length(_sprint(show, (x,), env=io)), 0) :
-                   (length(m.captures[1]), length(m.captures[2]))
+    s = _sprint(show, (x,), env=io)
+    m = match(r"^(.*?/)(/.*)$", s)
+    m === nothing ? (length(s), 0) : (length(m.captures[1]), length(m.captures[2]))
 end
 
 function alignment(io::IO, x::Pair)

--- a/base/show.jl
+++ b/base/show.jl
@@ -1571,33 +1571,33 @@ dump(arg; maxdepth=DUMP_DEFAULT_MAXDEPTH) = dump(IOContext(STDOUT::IO, :limit =>
 `alignment(X)` returns a tuple (left,right) showing how many characters are
 needed on either side of an alignment feature such as a decimal point.
 """
-alignment(io::IO, x::Any) = (0, length(sprint(0, show, x, env=io)))
-alignment(io::IO, x::Number) = (length(sprint(0, show, x, env=io)), 0)
+alignment(io::IO, x::Any) = (0, length(_sprint(show, (x,), env=io)))
+alignment(io::IO, x::Number) = (length(_sprint(show, (x,), env=io)), 0)
 "`alignment(42)` yields (2,0)"
-alignment(io::IO, x::Integer) = (length(sprint(0, show, x, env=io)), 0)
+alignment(io::IO, x::Integer) = (length(_sprint(show, (x,), env=io)), 0)
 "`alignment(4.23)` yields (1,3) for `4` and `.23`"
 function alignment(io::IO, x::Real)
-    m = match(r"^(.*?)((?:[\.eE].*)?)$", sprint(0, show, x, env=io))
-    m === nothing ? (length(sprint(0, show, x, env=io)), 0) :
+    m = match(r"^(.*?)((?:[\.eE].*)?)$", _sprint(show, (x,), env=io))
+    m === nothing ? (length(_sprint(show, (x,), env=io)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
 "`alignment(1 + 10im)` yields (3,5) for `1 +` and `_10im` (plus sign on left, space on right)"
 function alignment(io::IO, x::Complex)
-    m = match(r"^(.*[^e][\+\-])(.*)$", sprint(0, show, x, env=io))
-    m === nothing ? (length(sprint(0, show, x, env=io)), 0) :
+    m = match(r"^(.*[^e][\+\-])(.*)$", _sprint(show, (x,), env=io))
+    m === nothing ? (length(_sprint(show, (x,), env=io)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
 function alignment(io::IO, x::Rational)
-    m = match(r"^(.*?/)(/.*)$", sprint(0, show, x, env=io))
-    m === nothing ? (length(sprint(0, show, x, env=io)), 0) :
+    m = match(r"^(.*?/)(/.*)$", _sprint(show, (x,), env=io))
+    m === nothing ? (length(_sprint(show, (x,), env=io)), 0) :
                    (length(m.captures[1]), length(m.captures[2]))
 end
 
 function alignment(io::IO, x::Pair)
-    s = sprint(0, show, x, env=io)
+    s = _sprint(show, (x,), env=io)
     if has_tight_type(x) # i.e. use "=>" for display
         iocompact = IOContext(io, :compact => get(io, :compact, true))
-        left = length(sprint(0, show, x.first, env=iocompact))
+        left = length(_sprint(show, (x.first,), env=iocompact))
         left += 2 * !isdelimited(iocompact, x.first) # for parens around p.first
         left += !get(io, :compact, false) # spaces are added around "=>"
         (left+1, length(s)-left-1) # +1 for the "=" part of "=>"
@@ -1676,7 +1676,7 @@ function print_matrix_row(io::IO,
         if isassigned(X,Int(i),Int(j)) # isassigned accepts only `Int` indices
             x = X[i,j]
             a = alignment(io, x)
-            sx = sprint(0, show, x, env=io)
+            sx = _sprint(show, (x,), env=io)
         else
             a = undef_ref_alignment
             sx = undef_ref_str

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -29,7 +29,7 @@ getindex(s::AbstractString, i::Colon) = s
 getindex(s::AbstractString, r::UnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
 # TODO: handle other ranges with stride ±1 specially?
 getindex(s::AbstractString, v::AbstractVector{<:Integer}) =
-    sprint(length(v), io->(for i in v; write(io,s[i]) end))
+    _sprint(io->(for i in v; write(io,s[i]) end), size=length(v))
 getindex(s::AbstractString, v::AbstractVector{Bool}) =
     throw(ArgumentError("logical indexing not supported for strings"))
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -748,7 +748,7 @@ let a = Vector{Any}(uninitialized, 10000)
     a[2] = "elemA"
     a[4] = "elemB"
     a[11] = "elemC"
-    repr = sprint(0, dump, a; env= (:limit => true))
+    repr = Base._sprint(dump, (a,); env=(:limit => true))
     @test repr == "Array{Any}((10000,))\n  1: #undef\n  2: String \"elemA\"\n  3: #undef\n  4: String \"elemB\"\n  5: #undef\n  ...\n  9996: #undef\n  9997: #undef\n  9998: #undef\n  9999: #undef\n  10000: #undef\n"
 end
 

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -257,3 +257,10 @@ for i = 1:10
     print(buf, join(s22021, "\n"))
     @test isvalid(String, take!(buf))
 end
+
+@testset "sprint keywords" begin
+    f(io::IO; keyword=nothing) = print(io, keyword)
+
+    @test sprint(f) == "nothing"
+    @test sprint(f, keyword=true) == "true"
+end


### PR DESCRIPTION
Allows the following to work:
```julia
julia> f(io; keyword=nothing) = print(io, keyword)
f (generic function with 1 method)

julia> sprint(f, keyword=true)
ERROR: MethodError: no method matching sprint(::#f; keyword=true)
Closest candidates are:
  sprint(::Function, ::Any...) at strings/io.jl:82 got unsupported keyword argument "keyword"
  sprint(::Integer, ::Function, ::Any...; env) at strings/io.jl:59 got unsupported keyword argument "keyword"
```