### PR TITLE
Fix LibGit2 securezero! issue

### DIFF
--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -187,8 +187,10 @@ function authenticate_userpass(libgit2credptr::Ptr{Ptr{Void}}, p::CredentialPayl
     if p.use_git_helpers && (!revised || !isfilled(cred))
         git_cred = GitCredential(p.config, p.url)
 
-        cred.user = Base.get(git_cred.username, "")
-        cred.pass = Base.get(git_cred.password, "")
+        # Use `deepcopy` to ensure zeroing the `git_cred` doesn't also zero the `cred`s copy
+        cred.user = deepcopy(Base.get(git_cred.username, ""))
+        cred.pass = deepcopy(Base.get(git_cred.password, ""))
+        securezero!(git_cred)
         revised = true
 
         p.use_git_helpers = false

--- a/base/libgit2/gitcredential.jl
+++ b/base/libgit2/gitcredential.jl
@@ -44,8 +44,8 @@ end
 
 function GitCredential(cred::UserPasswordCredentials, url::AbstractString)
     git_cred = parse(GitCredential, url)
-    git_cred.username = Nullable{String}(cred.user)
-    git_cred.password = Nullable{String}(cred.pass)
+    git_cred.username = Nullable{String}(deepcopy(cred.user))
+    git_cred.password = Nullable{String}(deepcopy(cred.pass))
     return git_cred
 end
 

--- a/base/libgit2/gitcredential.jl
+++ b/base/libgit2/gitcredential.jl
@@ -296,6 +296,8 @@ function approve(cfg::GitConfig, cred::UserPasswordCredentials, url::AbstractStr
         approve(helper, git_cred)
     end
 
+    securezero!(git_cred)
+
     nothing
 end
 

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -2405,12 +2405,6 @@ mktempdir() do dir
                                                 allow_git_helpers=true)
                     err, auth_attempts = credential_loop($valid_cred, $url,
                                                          Nullable{String}(), payload)
-
-                    # Triggering a garbage collection will cause the internal GitCredential
-                    # used in `authenticate_userpass` to be securely wiped but this should
-                    # not cause the payload credential to be wiped (#24731).
-                    gc()
-
                     (err, auth_attempts, payload.credential)
                 end
             end
@@ -2423,6 +2417,8 @@ mktempdir() do dir
             err, auth_attempts, credential = challenge_prompt(https_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 1
+
+            # Verify credential wasn't accidentally zeroed (#24731)
             @test get(credential) == valid_cred
         end
 


### PR DESCRIPTION
Another reminder of the [dangers with `securezero!`](https://github.com/JuliaLang/julia/issues/23232). When running on 32-bit machines the `GitCredential` finalizer was causing copies of Strings to get wiped out. Fixes this issue:

```
Error During Test at /buildworker/worker/package_linux32/build/usr/share/julia/test/libgit2.jl:2387
  Got an exception of type ErrorException outside of a @test
  Could not locate challenge: "Password for 'https://julia@github.com':". Process output found:
  """
  Username for 'https://github.com' [julia]:
  ERROR: ArgumentError: embedded NULs are not allowed in C strings: "Password for 'https://\0\0\0\0\0@github.com':"
  ...
  """
```