### PR TITLE
Don't use colors in prompts if `--color=no` is provided

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -419,9 +419,8 @@ function _start()
                     active_repl = REPL.BasicREPL(term)
                     quiet || warn("Terminal not fully functional")
                 else
-                    active_repl = REPL.LineEditREPL(term, true)
+                    active_repl = REPL.LineEditREPL(term, have_color, true)
                     active_repl.history_file = history_file
-                    active_repl.hascolor = have_color
                 end
                 # Make sure any displays pushed in .juliarc.jl ends up above the
                 # REPLDisplay

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -284,13 +284,13 @@ specialdisplay(r::LineEditREPL) = r.specialdisplay
 specialdisplay(r::AbstractREPL) = nothing
 terminal(r::LineEditREPL) = r.t
 
-LineEditREPL(t::TextTerminal, envcolors::Bool=false) =
-    LineEditREPL(t, true,
-        Base.text_colors[:green],
-        Base.input_color(),
-        Base.answer_color(),
-        Base.text_colors[:red],
-        Base.text_colors[:yellow],
+LineEditREPL(t::TextTerminal, hascolor::Bool, envcolors::Bool=false) =
+    LineEditREPL(t, hascolor,
+        hascolor ? Base.text_colors[:green] : "",
+        hascolor ? Base.input_color() : "",
+        hascolor ? Base.answer_color() : "",
+        hascolor ? Base.text_colors[:red] : "",
+        hascolor ? Base.text_colors[:yellow] : "",
         false, false, false, envcolors
     )
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -19,7 +19,7 @@ function fake_repl(f)
     Base.link_pipe(stdout, julia_only_read=true, julia_only_write=true)
     Base.link_pipe(stderr, julia_only_read=true, julia_only_write=true)
 
-    repl = Base.REPL.LineEditREPL(TestHelpers.FakeTerminal(stdin.out, stdout.in, stderr.in))
+    repl = Base.REPL.LineEditREPL(TestHelpers.FakeTerminal(stdin.out, stdout.in, stderr.in), true)
     f(stdin.in, stdout.out, repl)
     t = @async begin
         close(stdin.in)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/24737

@Keno does this look like the right fix?