### PR TITLE
replace Array{...}(shape...)-like calls in test/a*

### DIFF
--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -129,7 +129,7 @@ OffsetVector{T,AA<:AbstractArray} = OffsetArray{T,1,AA}
 OffsetArray(A::AbstractArray{T,N}, offsets::NTuple{N,Int}) where {T,N} = OffsetArray{T,N,typeof(A)}(A, offsets)
 OffsetArray(A::AbstractArray{T,N}, offsets::Vararg{Int,N}) where {T,N} = OffsetArray(A, offsets)
 
-OffsetArray{T,N}(inds::Indices{N}) where {T,N} = OffsetArray{T,N,Array{T,N}}(Array{T,N}(map(length, inds)), map(indsoffset, inds))
+OffsetArray{T,N}(inds::Indices{N}) where {T,N} = OffsetArray{T,N,Array{T,N}}(Array{T,N}(uninitialized, map(length, inds)), map(indsoffset, inds))
 OffsetArray{T}(inds::Indices{N}) where {T,N} = OffsetArray{T,N}(inds)
 
 Base.IndexStyle(::Type{T}) where {T<:OffsetArray} = Base.IndexStyle(parenttype(T))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -447,7 +447,7 @@ function test_primitives(::Type{T}, shape, ::Type{TestAbstractArray}) where T
     @test_throws DimensionMismatch reshape(B, (0, 1))
 
     # copy!(dest::AbstractArray, src::AbstractArray)
-    @test_throws BoundsError copy!(Array{Int}(10), [1:11...])
+    @test_throws BoundsError copy!(Vector{Int}(uninitialized, 10), [1:11...])
 
     # convert{T, N}(::Type{Array}, A::AbstractArray{T, N})
     X = [1:10...]
@@ -542,14 +542,14 @@ function test_cat(::Type{TestAbstractArray})
     A = T24Linear([1:24...])
     b_int = reshape([1:27...], 3, 3, 3)
     b_float = reshape(Float64[1:27...], 3, 3, 3)
-    b2hcat = Array{Float64}(3, 6, 3)
+    b2hcat = Array{Float64}(uninitialized, 3, 6, 3)
     b1 = reshape([1:9...], 3, 3)
     b2 = reshape([10:18...], 3, 3)
     b3 = reshape([19:27...], 3, 3)
     b2hcat[:, :, 1] = hcat(b1, b1)
     b2hcat[:, :, 2] = hcat(b2, b2)
     b2hcat[:, :, 3] = hcat(b3, b3)
-    b3hcat = Array{Float64}(3, 9, 3)
+    b3hcat = Array{Float64}(uninitialized, 3, 9, 3)
     b3hcat[:, :, 1] = hcat(b1, b1, b1)
     b3hcat[:, :, 2] = hcat(b2, b2, b2)
     b3hcat[:, :, 3] = hcat(b3, b3, b3)
@@ -674,7 +674,7 @@ function test_map(::Type{TestAbstractArray})
         end
 
         # AbstractArray map for N-arg case
-        A = Array{Int}(10)
+        A = Array{Int}(uninitialized, 10)
         f(x, y, z) = x + y + z
         D = Float64[1:10...]
 
@@ -869,7 +869,7 @@ end
 @testset "ImageCore #40" begin
     Base.convert(::Type{Array{T,n}}, a::Array{T,n}) where {T<:Number,n} = a
     Base.convert(::Type{Array{T,n}}, a::Array) where {T<:Number,n} =
-        copy!(Array{T,n}(size(a)), a)
+        copy!(Array{T,n}(uninitialized, size(a)), a)
     @test isa(similar(Dict(:a=>1, :b=>2.0), Pair{Union{},Union{}}), Dict{Union{}, Union{}})
 end
 

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -219,8 +219,10 @@ end
 
 foo(::Type{Array{T,N}}, A::MyArray{T,N}) where {T,N} = A.data
 foo(::Type{Array{T,N}}, A::MyArray{T,N}) where {T<:AbstractFloat,N} = A.data
-foo(::Type{Array{S,N}}, A::AbstractArray{T,N}) where {S<:AbstractFloat,N,T<:AbstractFloat} = copy!(Array{S}(size(A)), A)
-foo(::Type{Array{S,N}}, A::MyArray{T,N}) where {S<:AbstractFloat,N,T<:AbstractFloat} = copy!(Array{S}(size(A)), A.data)
+foo(::Type{Array{S,N}}, A::MyArray{T,N}) where {S<:AbstractFloat,N,T<:AbstractFloat} =
+    copy!(Array{S}(uninitialized, unsize(A)), A.data)
+foo(::Type{Array{S,N}}, A::AbstractArray{T,N}) where {S<:AbstractFloat,N,T<:AbstractFloat} =
+    copy!(Array{S}(uninitialized, size(A)), A)
 end
 
 @test isempty(detect_ambiguities(Ambig17648))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -60,7 +60,7 @@ using Main.TestHelpers.OAs
     a[:, [1 2]] = 2
     @test a == 2ones(2,2)
 
-    a = Array{Float64}(2, 2, 2, 2, 2)
+    a = Array{Float64}(uninitialized, 2, 2, 2, 2, 2)
     a[1,1,1,1,1] = 10
     a[1,2,1,1,2] = 20
     a[1,1,2,2,1] = 30
@@ -295,19 +295,19 @@ end
     @test length(rt) == 1 && rt[1] == Array{Int32, 3}
 end
 @testset "construction" begin
-    @test typeof(Vector{Int}(3)) == Vector{Int}
+    @test typeof(Vector{Int}(uninitialized, 3)) == Vector{Int}
     @test typeof(Vector{Int}()) == Vector{Int}
-    @test typeof(Vector(3)) == Vector{Any}
+    @test typeof(Vector(uninitialized, 3)) == Vector{Any}
     @test typeof(Vector()) == Vector{Any}
-    @test typeof(Matrix{Int}(2,3)) == Matrix{Int}
-    @test typeof(Matrix(2,3)) == Matrix{Any}
+    @test typeof(Matrix{Int}(uninitialized, 2,3)) == Matrix{Int}
+    @test typeof(Matrix(uninitialized, 2,3)) == Matrix{Any}
 
-    @test size(Vector{Int}(3)) == (3,)
+    @test size(Vector{Int}(uninitialized, 3)) == (3,)
     @test size(Vector{Int}()) == (0,)
-    @test size(Vector(3)) == (3,)
+    @test size(Vector(uninitialized, 3)) == (3,)
     @test size(Vector()) == (0,)
-    @test size(Matrix{Int}(2,3)) == (2,3)
-    @test size(Matrix(2,3)) == (2,3)
+    @test size(Matrix{Int}(uninitialized, 2,3)) == (2,3)
+    @test size(Matrix(uninitialized, 2,3)) == (2,3)
 
     # TODO: will throw MethodError after 0.6 deprecations are deleted
     dw = Base.JLOptions().depwarn
@@ -399,9 +399,9 @@ end
     @test_throws MethodError UInt8[1:3]
     @test_throws MethodError UInt8[1:3,]
     @test_throws MethodError UInt8[1:3,4:6]
-    a = Array{UnitRange{Int}}(1); a[1] = 1:3
+    a = Vector{UnitRange{Int}}(uninitialized, 1); a[1] = 1:3
     @test _array_equiv([1:3,], a)
-    a = Array{UnitRange{Int}}(2); a[1] = 1:3; a[2] = 4:6
+    a = Vector{UnitRange{Int}}(uninitialized, 2); a[1] = 1:3; a[2] = 4:6
     @test _array_equiv([1:3,4:6], a)
 end
 
@@ -816,7 +816,7 @@ end
     R = repeat(A, inner = (1, 1, 2), outer = (1, 1, 1))
     T = reshape([1:4; 1:4; 5:8; 5:8], 2, 2, 4)
     @test R == T
-    A = Array{Int}(2, 2, 2)
+    A = Array{Int}(uninitialized, 2, 2, 2)
     A[:, :, 1] = [1 2;
                     3 4]
     A[:, :, 2] = [5 6;
@@ -1111,7 +1111,7 @@ end
 end
 
 @testset "fill" begin
-    @test fill!(Array{Float64}(1),-0.0)[1] === -0.0
+    @test fill!(Float64[1.0], -0.0)[1] === -0.0
     A = ones(3,3)
     S = view(A, 2, 1:3)
     fill!(S, 2)
@@ -1120,7 +1120,7 @@ end
     @test A == [1 1 3; 2 2 3; 1 1 1]
     rt = Base.return_types(fill!, Tuple{Array{Int32, 3}, UInt8})
     @test length(rt) == 1 && rt[1] == Array{Int32, 3}
-    A = Array{Union{UInt8,Int8}}(3)
+    A = Vector{Union{UInt8,Int8}}(uninitialized, 3)
     fill!(A, UInt8(3))
     @test A == [0x03, 0x03, 0x03]
     # Issue #9964
@@ -1266,7 +1266,7 @@ end
     @test isequal(flipdim(1:10, 1), 10:-1:1)
     @test_throws ArgumentError flipdim(1:10, 2)
     @test_throws ArgumentError flipdim(1:10, -1)
-    @test isequal(flipdim(Array{Int}(0,0),1), Array{Int}(0,0))  # issue #5872
+    @test isequal(flipdim(Matrix{Int}(uninitialized, 0,0),1), Matrix{Int}(uninitialized, 0,0))  # issue #5872
 
     a = rand(5,3)
     @test flipdim(flipdim(a,2),2) == a
@@ -1393,25 +1393,25 @@ end
 @test pr8622() == [0,3,1,0]
 
 #6828 - size of specific dimensions
-let a = Array{Float64}(10)
+let a = Array{Float64}(uninitialized, 10)
     @test size(a) == (10,)
     @test size(a, 1) == 10
     @test size(a,2,1) == (1,10)
-    aa = Array{Float64}(2,3)
+    aa = Array{Float64}(uninitialized, 2,3)
     @test size(aa) == (2,3)
     @test size(aa,4,3,2,1) == (1,1,3,2)
     @test size(aa,1,2) == (2,3)
-    aaa = Array{Float64}(9,8,7,6,5,4,3,2,1)
+    aaa = Array{Float64}(uninitialized, 9,8,7,6,5,4,3,2,1)
     @test size(aaa,1,1) == (9,9)
     @test size(aaa,4) == 6
     @test size(aaa,9,8,7,6,5,4,3,2,19,8,7,6,5,4,3,2,1) == (1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,9)
 
     #18459 Test Array{T, N} constructor
-    b = Array{Float64, 1}(10)
+    b = Vector{Float64}(uninitialized, 10)
     @test size(a) == size(b)
-    bb = Array{Float64, 2}(2,3)
+    bb = Matrix{Float64}(uninitialized, 2,3)
     @test size(aa) == size(bb)
-    bbb = Array{Float64, 9}(9,8,7,6,5,4,3,2,1)
+    bbb = Array{Float64,9}(uninitialized, 9,8,7,6,5,4,3,2,1)
     @test size(aaa) == size(bbb)
 end
 
@@ -2076,21 +2076,21 @@ end # module AutoRetType
     @test isa(cat((1,2), densevec, densemat), Array)
 end
 
-@testset "type constructor Array{T, N}(d...) works (especially for N>3)" begin
-    a = Array{Float64}(10)
-    b = Array{Float64, 1}(10)
+@testset "type constructor Array{T, N}(uninitialized, d...) works (especially for N>3)" begin
+    a = Array{Float64}(uninitialized, 10)
+    b = Vector{Float64}(uninitialized, 10)
     @test size(a) == (10,)
     @test size(a, 1) == 10
     @test size(a,2,1) == (1,10)
     @test size(a) == size(b)
-    a = Array{Float64}(2,3)
-    b = Array{Float64, 2}(2,3)
+    a = Array{Float64}(uninitialized, 2,3)
+    b = Matrix{Float64}(uninitialized, 2,3)
     @test size(a) == (2,3)
     @test size(a,4,3,2,1) == (1,1,3,2)
     @test size(a,1,2) == (2,3)
     @test size(a) == size(b)
-    a = Array{Float64}(9,8,7,6,5,4,3,2,1)
-    b = Array{Float64, 9}(9,8,7,6,5,4,3,2,1)
+    a = Array{Float64}(uninitialized, 9,8,7,6,5,4,3,2,1)
+    b = Array{Float64,9}(uninitialized, 9,8,7,6,5,4,3,2,1)
     @test size(a,1,1) == (9,9)
     @test size(a,4) == 6
     @test size(a,9,8,7,6,5,4,3,2,19,8,7,6,5,4,3,2,1) == (1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,9)


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in test/a*.jl. Ref. #24595. Best!