### PR TITLE
Fix #24707, issues with unbound type variables in eltype and promote_rule

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -110,7 +110,7 @@ keys(a::AbstractVector) = linearindices(a)
 prevind(::AbstractArray, i::Integer) = Int(i)-1
 nextind(::AbstractArray, i::Integer) = Int(i)+1
 
-eltype(::Type{<:AbstractArray{E}}) where {E} = E
+eltype(::Type{<:AbstractArray{E}}) where {E} = @isdefined(E) ? E : Any
 elsize(::AbstractArray{T}) where {T} = sizeof(T)
 
 """

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -147,7 +147,9 @@ function convert(::Type{Matrix{T}}, A::Bidiagonal) where T
 end
 convert(::Type{Matrix}, A::Bidiagonal{T}) where {T} = convert(Matrix{T}, A)
 convert(::Type{Array}, A::Bidiagonal) = convert(Matrix, A)
-promote_rule(::Type{Matrix{T}}, ::Type{<:Bidiagonal{S}}) where {T,S} = Matrix{promote_type(T,S)}
+promote_rule(::Type{Matrix{T}}, ::Type{<:Bidiagonal{S}}) where {T,S} =
+    @isdefined(T) && @isdefined(S) ? Matrix{promote_type(T,S)} : Matrix
+promote_rule(::Type{Matrix}, ::Type{<:Bidiagonal}) = Matrix
 
 #Converting from Bidiagonal to Tridiagonal
 Tridiagonal(M::Bidiagonal{T}) where {T} = convert(Tridiagonal{T}, M)
@@ -157,7 +159,9 @@ function convert(::Type{Tridiagonal{T}}, A::Bidiagonal) where T
     z = fill!(similar(ev), zero(T))
     A.uplo == 'U' ? Tridiagonal(z, dv, ev) : Tridiagonal(ev, dv, z)
 end
-promote_rule(::Type{<:Tridiagonal{T}}, ::Type{<:Bidiagonal{S}}) where {T,S} = Tridiagonal{promote_type(T,S)}
+promote_rule(::Type{<:Tridiagonal{T}}, ::Type{<:Bidiagonal{S}}) where {T,S} =
+    @isdefined(T) && @isdefined(S) ? Tridiagonal{promote_type(T,S)} : Tridiagonal
+promote_rule(::Type{<:Tridiagonal}, ::Type{<:Bidiagonal}) = Tridiagonal
 
 # No-op for trivial conversion Bidiagonal{T} -> Bidiagonal{T}
 convert(::Type{Bidiagonal{T}}, A::Bidiagonal{T}) where {T} = A

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -66,7 +66,6 @@ first(t::Tuple) = t[1]
 # eltype
 
 eltype(::Type{Tuple{}}) = Bottom
-eltype(::Type{Tuple{Vararg{E}}}) where {E} = E
 function eltype(t::Type{<:Tuple{Vararg{E}}}) where {E}
     if @isdefined(E)
         return E

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -261,7 +261,6 @@ end
     # TODO: review this list and remove everything between test_broken and test
     let need_to_handle_undef_sparam =
             Set{Method}(detect_unbound_args(Core; recursive=true))
-        pop!(need_to_handle_undef_sparam, which(Core.Inference.eltype, Tuple{Type{Tuple{Vararg{E}}} where E}))
         pop!(need_to_handle_undef_sparam, which(Core.Inference.eltype, Tuple{Type{Tuple{Any}}}))
         @test_broken need_to_handle_undef_sparam == Set()
         pop!(need_to_handle_undef_sparam, which(Core.Inference.cat, Tuple{Any, AbstractArray}))
@@ -271,7 +270,6 @@ end
     let need_to_handle_undef_sparam =
             Set{Method}(detect_unbound_args(Base; recursive=true))
         pop!(need_to_handle_undef_sparam, which(Base._totuple, (Type{Tuple{Vararg{E}}} where E, Any, Any)))
-        pop!(need_to_handle_undef_sparam, which(Base.eltype, Tuple{Type{Tuple{Vararg{E}}} where E}))
         pop!(need_to_handle_undef_sparam, which(Base.eltype, Tuple{Type{Tuple{Any}}}))
         pop!(need_to_handle_undef_sparam, first(methods(Base.same_names)))
         @test_broken need_to_handle_undef_sparam == Set()

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2240,3 +2240,7 @@ end
 #     @test_throws ArgumentError zeros(2)[false]
 #     @test_throws ArgumentError zeros(2)[true]
 # end
+
+@testset "issue 24707" begin
+    @test eltype(Vector{Tuple{V}} where V<:Integer) >: Tuple{Integer}
+end

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -364,3 +364,12 @@ import Base.LinAlg: fillslots!, UnitLowerTriangular
         end
     end
 end
+
+@testset "pathological promotion (#24707)" begin
+    @test promote_type(Matrix{Int}, Bidiagonal{Tuple{S}} where S<:Integer) <: Matrix
+    @test promote_type(Matrix{Tuple{T}} where T<:Integer, Bidiagonal{Tuple{S}} where S<:Integer) <: Matrix
+    @test promote_type(Matrix{Tuple{T}} where T<:Integer, Bidiagonal{Int}) <: Matrix
+    @test promote_type(Tridiagonal{Int}, Bidiagonal{Tuple{S}} where S<:Integer) <: Tridiagonal
+    @test promote_type(Tridiagonal{Tuple{T}} where T<:Integer, Bidiagonal{Tuple{S}} where S<:Integer) <: Tridiagonal
+    @test promote_type(Tridiagonal{Tuple{T}} where T<:Integer, Bidiagonal{Int}) <: Tridiagonal
+end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -355,3 +355,7 @@ end
     @test convert(Tuple{Complex, Complex}, (1, 2.0)) ===
         (Complex(1), Complex(2.0))
 end
+
+@testset "issue 24707" begin
+    @test eltype(Tuple{Vararg{T}} where T<:Integer) >: Integer
+end


### PR DESCRIPTION
Compared to https://github.com/JuliaLang/julia/issues/24707#issuecomment-346799331 I use more refined types for `eltype(::Type{<:Tuple})` (by using machinery already in place) and the `promote_rule` cases than `Any` and `Union`, where I hope the latter make sense. (But triggering these rules as part of a `promote` call seems extremely unlikely to occur in practice anyway.)

For the `eltype(::Type{<:AbstractArray})` case the following should also work and enable figuring out tighter element types than `Any`, but it makes me feel a bit uneasy, so I haven't included it for now:
```julia
eltype(t::Type{<:AbstractArray{E}}) where {E} = @isdefined(E) ? E : _compute_eltype(t)
eltype(t::Type{<:AbstractArray}) = _compute_eltype(t)
function _compute_eltype(t::Type{<:AbstractArray})
    @_pure_meta
    t isa Union && return typejoin(eltype(t.a), eltype(t.b))
    t´ = unwrap_unionall(t)
    while t´.name.wrapper != AbstractArray
        t´ = supertype(t´)
    end
    return rewrap_unionall(t´.parameters[1], t)
end
```
If would allow e.g.
```julia
julia> eltype(Union{Vector{Int}, Vector{Int16}})
Signed

julia> eltype(Vector{Tuple{V}} where V<:Integer)
Tuple{V} where V<:Integer
```
which both just give `Any` with the current PR (and the latter fails on master).