### PR TITLE
Fix a type-stability problem for linspace

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -309,6 +309,7 @@ end
 ## StepRangeLen
 
 # Use TwicePrecision only for Float64; use Float64 for T<:Union{Float16,Float32}
+# See also _linspace1
 # Ratio-of-integers constructors
 function steprangelen_hp(::Type{Float64}, ref::Tuple{Integer,Integer},
                          step::Tuple{Integer,Integer}, nb::Integer,
@@ -651,7 +652,12 @@ function _linspace1(::Type{T}, start, stop, len::Integer) where T
     if len <= 1
         len == 1 && (start == stop || throw(ArgumentError("linspace($start, $stop, $len): endpoints differ")))
         # Ensure that first(r)==start and last(r)==stop even for len==0
-        return StepRangeLen(TwicePrecision(start, zero(T)), TwicePrecision(start, -stop), len, 1)
+        # The output type must be consistent with steprangelen_hp
+        if T<:Union{Float32,Float16}
+            return StepRangeLen{T}(Float64(start), Float64(start) - Float64(stop), len, 1)
+        else
+            return StepRangeLen(TwicePrecision(start, zero(T)), TwicePrecision(start, -stop), len, 1)
+        end
     end
     throw(ArgumentError("should only be called for len < 2, got $len"))
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -204,6 +204,9 @@ end
         @test L32[3] == 3 && L64[3] == 3
         @test L32[4] == 4 && L64[4] == 4
         @test @inferred(linspace(1.0, 2.0, 2.0f0)) === linspace(1.0, 2.0, 2)
+        @test @inferred(linspace(1.0, 2.0, 2))[1] === 1.0
+        @test @inferred(linspace(1.0f0, 2.0f0, 2))[1] === 1.0f0
+        @test @inferred(linspace(Float16(1.0), Float16(2.0), 2))[1] === Float16(1.0)
 
         let r = 5:-1:1
             @test r[1]==5


### PR DESCRIPTION
Ref https://discourse.julialang.org/t/type-inference-on-linspace-fails-when-given-float32-arguments-on-0-6-1/7281

**Not** backportable to 0.6.
