### PR TITLE
Use JuliaLibm log functions in Main.Math.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2169,8 +2169,8 @@ end
 @deprecate merge!(repo::LibGit2.GitRepo, args...; kwargs...) LibGit2.merge!(repo, args...; kwargs...)
 
 # Remember to delete the module when removing this
-@eval Math.JuliaLibm begin
-    Base.@deprecate log(x) Base.log(x)
+@eval Base.Math module JuliaLibm
+    Base.@deprecate log Base.log
 end
 
 # END 0.7 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2168,6 +2168,11 @@ end
 
 @deprecate merge!(repo::LibGit2.GitRepo, args...; kwargs...) LibGit2.merge!(repo, args...; kwargs...)
 
+# Remember to delete the module when removing this
+@eval Math.JuliaLibm begin
+    Base.@deprecate log(x) Base.log(x)
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/math.jl
+++ b/base/math.jl
@@ -984,7 +984,4 @@ include(joinpath("special", "gamma.jl"))
 include(joinpath("special", "rem_pio2.jl"))
 include(joinpath("special", "log.jl"))
 
-module JuliaLibm
-end
-
 end # module

--- a/base/math.jl
+++ b/base/math.jl
@@ -985,7 +985,6 @@ include(joinpath("special", "rem_pio2.jl"))
 include(joinpath("special", "log.jl"))
 
 module JuliaLibm
-include(joinpath("special", "log.jl"))
 end
 
 end # module

--- a/base/math.jl
+++ b/base/math.jl
@@ -376,9 +376,6 @@ atanh(x::Number)
 
 Compute the natural logarithm of `x`. Throws [`DomainError`](@ref) for negative
 [`Real`](@ref) arguments. Use complex negative arguments to obtain complex results.
-
-There is an experimental variant in the `Base.Math.JuliaLibm` module, which is typically
-faster and more accurate.
 """
 log(x::Number)
 
@@ -422,9 +419,6 @@ log10(x)
 Accurate natural logarithm of `1+x`. Throws [`DomainError`](@ref) for [`Real`](@ref)
 arguments less than -1.
 
-There is an experimental variant in the `Base.Math.JuliaLibm` module, which is typically
-faster and more accurate.
-
 # Examples
 ```jldoctest
 julia> log1p(-0.5)
@@ -435,7 +429,7 @@ julia> log1p(0)
 ```
 """
 log1p(x)
-for f in (:acosh, :atanh, :log, :log2, :log10, :lgamma, :log1p)
+for f in (:acosh, :atanh, :log2, :log10, :lgamma)
     @eval begin
         @inline ($f)(x::Float64) = nan_dom_err(ccall(($(string(f)), libm), Float64, (Float64,), x), x)
         @inline ($f)(x::Float32) = nan_dom_err(ccall(($(string(f, "f")), libm), Float32, (Float32,), x), x)
@@ -988,6 +982,7 @@ include(joinpath("special", "exp10.jl"))
 include(joinpath("special", "trig.jl"))
 include(joinpath("special", "gamma.jl"))
 include(joinpath("special", "rem_pio2.jl"))
+include(joinpath("special", "log.jl"))
 
 module JuliaLibm
 include(joinpath("special", "log.jl"))

--- a/test/math.jl
+++ b/test/math.jl
@@ -559,7 +559,7 @@ end
 end
 
 @testset "log/log1p" begin
-    # if using Tang's algorithm, should be accurate to within 0.56 ulps
+    # using Tang's algorithm, should be accurate to within 0.56 ulps
     X = rand(100)
     for x in X
         for n = -5:5
@@ -568,16 +568,16 @@ end
             for T in (Float32,Float64)
                 xt = T(x)
 
-                y = Base.Math.JuliaLibm.log(xt)
+                y = log(xt)
                 yb = log(big(xt))
                 @test abs(y-yb) <= 0.56*eps(T(yb))
 
-                y = Base.Math.JuliaLibm.log1p(xt)
+                y = log1p(xt)
                 yb = log1p(big(xt))
                 @test abs(y-yb) <= 0.56*eps(T(yb))
 
                 if n <= 0
-                    y = Base.Math.JuliaLibm.log1p(-xt)
+                    y = log1p(-xt)
                     yb = log1p(big(-xt))
                     @test abs(y-yb) <= 0.56*eps(T(yb))
                 end


### PR DESCRIPTION
These should be just as precise as openlibm (own experience and https://tpapp.github.io/post/log1p/ ) but I will ofc provide solid numbers on this.

@stevengj raised the point that it's concerning that log1p seems a bit slower for small values as per the blog post above, and these are the values where you *really* want log1p. I'll benchmark this further and if it is the case, my idea is to do openlibm port for the small x part and tang's for the larger x's.

Should the old ones (those in a module) be deprecated? They've been mentioned in the docstrings, so...