### PR TITLE
replace Array{...}(shape...)-like calls in test/r*

### DIFF
--- a/test/random.jl
+++ b/test/random.jl
@@ -49,14 +49,14 @@ end
 # rand from AbstractArray
 let mt = MersenneTwister()
     @test rand(mt, 0:3:1000) in 0:3:1000
-    @test issubset(rand!(mt, Array{Int}(100), 0:3:1000), 0:3:1000)
+    @test issubset(rand!(mt, Vector{Int}(uninitialized, 100), 0:3:1000), 0:3:1000)
     coll = Any[2, UInt128(128), big(619), "string"]
     @test rand(mt, coll) in coll
     @test issubset(rand(mt, coll, 2, 3), coll)
 
     # check API with default RNG:
     rand(0:3:1000)
-    rand!(Array{Int}(100), 0:3:1000)
+    rand!(Vector{Int}(uninitialized, 100), 0:3:1000)
     rand(coll)
     rand(coll, 2, 3)
 end
@@ -137,13 +137,13 @@ emantissa           = Int64(2)^52
 ziggurat_exp_r      = parse(BigFloat,"7.69711747013104971404462804811408952334296818528283253278834867283241051210533")
 exp_section_area    = (ziggurat_exp_r + 1)*exp(-ziggurat_exp_r)
 
-ki = Array{UInt64}(ziggurat_table_size)
-wi = Array{Float64}(ziggurat_table_size)
-fi = Array{Float64}(ziggurat_table_size)
+ki = Vector{UInt64}(uninitialized, ziggurat_table_size)
+wi = Vector{Float64}(uninitialized, ziggurat_table_size)
+fi = Vector{Float64}(uninitialized, ziggurat_table_size)
 # Tables for exponential variates
-ke = Array{UInt64}(ziggurat_table_size)
-we = Array{Float64}(ziggurat_table_size)
-fe = Array{Float64}(ziggurat_table_size)
+ke = Vector{UInt64}(uninitialized, ziggurat_table_size)
+we = Vector{Float64}(uninitialized, ziggurat_table_size)
+fe = Vector{Float64}(uninitialized, ziggurat_table_size)
 function randmtzig_fill_ziggurat_tables() # Operates on the global arrays
     wib = big.(wi)
     fib = big.(fi)
@@ -253,7 +253,7 @@ end
 # test code paths of rand!
 
 let mt = MersenneTwister(0)
-    A128 = Array{UInt128}(0)
+    A128 = Vector{UInt128}()
     @test length(rand!(mt, A128)) == 0
     for (i,n) in enumerate([1, 3, 5, 6, 10, 11, 30])
         resize!(A128, n)
@@ -270,8 +270,8 @@ let mt = MersenneTwister(0)
 
     srand(mt, 0)
     for (i,T) in enumerate([Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, Float16, Float32])
-        A = Array{T}(16)
-        B = Array{T}(31)
+        A = Vector{T}(uninitialized, 16)
+        B = Vector{T}(uninitialized, 31)
         rand!(mt, A)
         rand!(mt, B)
         @test A[end] == Any[21,0x7b,17385,0x3086,-1574090021,0xadcb4460,6797283068698303107,0x4e91c9c4d4f5f759,
@@ -282,7 +282,7 @@ let mt = MersenneTwister(0)
     end
 
     srand(mt, 0)
-    AF64 = Array{Float64}(Base.Random.dsfmt_get_min_array_size()-1)
+    AF64 = Vector{Float64}(uninitialized, Base.Random.dsfmt_get_min_array_size()-1)
     @test rand!(mt, AF64)[end] == 0.957735065345398
     @test rand!(mt, AF64)[end] == 0.6492481059865669
     resize!(AF64, 2*length(mt.vals))
@@ -291,10 +291,10 @@ end
 
 # Issue #9037
 let mt = MersenneTwister(0)
-    a = Array{Float64}(0)
+    a = Vector{Float64}()
     resize!(a, 1000) # could be 8-byte aligned
-    b = Array{Float64}(1000) # should be 16-byte aligned
-    c8 = Array{UInt64}(1001)
+    b = Vector{Float64}(uninitialized, 1000) # should be 16-byte aligned
+    c8 = Vector{UInt64}(uninitialized, 1001)
     pc8 = pointer(c8)
     if Int(pc8) % 16 == 0
         # Make sure pc8 is not 16-byte aligned since that's what we want to test.
@@ -389,7 +389,10 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
     for f! in [rand!, randn!, randexp!]
         for T in functypes[f!]
             X = T == Bool ? T[0,1] : T[0,1,2]
-            for A in (Array{T}(5), Array{T}(2, 3), GenericArray{T}(5), GenericArray{T}(2, 3))
+            for A in (Vector{T}(uninitialized, 5),
+                        Matrix{T}(uninitialized, 2, 3),
+                        GenericArray{T}(5),
+                        GenericArray{T}(2, 3))
                 local A
                 f!(rng..., A)                    ::typeof(A)
                 if f! === rand!
@@ -483,7 +486,7 @@ let mta = MersenneTwister(42), mtb = MersenneTwister(42)
     @test eltype(randperm(UInt(1))) === Int
     @test_throws ErrorException randperm(-1)
 
-    A, B = Vector{Int}(10), Vector{Int}(10)
+    A, B = Vector{Int}(uninitialized, 10), Vector{Int}(uninitialized, 10)
     @test randperm!(mta, A) == randperm!(mtb, B)
     @test randperm!(A) === A
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -179,11 +179,11 @@ for (name, f) in l
     @test read(io(), Int) == read(filename,Int)
     s1 = io()
     s2 = IOBuffer(text)
-    @test read!(s1, Array{UInt32}(2)) == read!(s2, Array{UInt32}(2))
+    @test read!(s1, Vector{UInt32}(uninitialized, 2)) == read!(s2, Vector{UInt32}(uninitialized, 2))
     @test !eof(s1)
-    @test read!(s1, Array{UInt8}(5)) == read!(s2, Array{UInt8}(5))
+    @test read!(s1, Vector{UInt8}(uninitialized, 5)) == read!(s2, Vector{UInt8}(uninitialized, 5))
     @test !eof(s1)
-    @test read!(s1, Array{UInt8}(1)) == read!(s2, Array{UInt8}(1))
+    @test read!(s1, Vector{UInt8}(uninitialized, 1)) == read!(s2, Vector{UInt8}(uninitialized, 1))
     @test eof(s1)
     @test_throws EOFError read(s1, UInt8)
     @test eof(s1)
@@ -192,16 +192,16 @@ for (name, f) in l
 
     verbose && println("$name eof...")
     n = length(text) - 1
-    @test read!(io(), Vector{UInt8}(n)) ==
-          read!(IOBuffer(text), Vector{UInt8}(n))
-    @test (s = io(); read!(s, Vector{UInt8}(n)); !eof(s))
+    @test read!(io(), Vector{UInt8}(uninitialized, n)) ==
+          read!(IOBuffer(text), Vector{UInt8}(uninitialized, n))
+    @test (s = io(); read!(s, Vector{UInt8}(uninitialized, n)); !eof(s))
     n = length(text)
-    @test read!(io(), Vector{UInt8}(n)) ==
-          read!(IOBuffer(text), Vector{UInt8}(n))
-    @test (s = io(); read!(s, Vector{UInt8}(n)); eof(s))
+    @test read!(io(), Vector{UInt8}(uninitialized, n)) ==
+          read!(IOBuffer(text), Vector{UInt8}(uninitialized, n))
+    @test (s = io(); read!(s, Vector{UInt8}(uninitialized, n)); eof(s))
     n = length(text) + 1
-    @test_throws EOFError read!(io(), Vector{UInt8}(n))
-    @test_throws EOFError read!(io(), Vector{UInt8}(n))
+    @test_throws EOFError read!(io(), Vector{UInt8}(uninitialized, n))
+    @test_throws EOFError read!(io(), Vector{UInt8}(uninitialized, n))
 
     old_text = text
     cleanup()
@@ -233,8 +233,8 @@ for (name, f) in l
         verbose && println("$name readbytes!...")
         l = length(text)
         for n = [1, 2, l-2, l-1, l, l+1, l+2]
-            a1 = Vector{UInt8}(n)
-            a2 = Vector{UInt8}(n)
+            a1 = Vector{UInt8}(uninitialized, n)
+            a2 = Vector{UInt8}(uninitialized, n)
             s1 = io()
             s2 = IOBuffer(text)
             n1 = readbytes!(s1, a1)
@@ -251,14 +251,14 @@ for (name, f) in l
         verbose && println("$name read!...")
         l = length(text)
         for n = [1, 2, l-2, l-1, l]
-            @test read!(io(), Vector{UInt8}(n)) ==
-                  read!(IOBuffer(text), Vector{UInt8}(n))
-            @test read!(io(), Vector{UInt8}(n)) ==
-                  read!(filename, Vector{UInt8}(n))
+            @test read!(io(), Vector{UInt8}(uninitialized, n)) ==
+                  read!(IOBuffer(text), Vector{UInt8}(uninitialized, n))
+            @test read!(io(), Vector{UInt8}(uninitialized, n)) ==
+                  read!(filename, Vector{UInt8}(uninitialized, n))
 
             cleanup()
         end
-        @test_throws EOFError read!(io(), Vector{UInt8}(length(text)+1))
+        @test_throws EOFError read!(io(), Vector{UInt8}(uninitialized, length(text)+1))
 
 
         verbose && println("$name readuntil...")
@@ -302,7 +302,7 @@ for (name, f) in l
 
     if !(typeof(io()) in [Base.PipeEndpoint, Pipe, TCPSocket])
         verbose && println("$name position...")
-        @test (s = io(); read!(s, Vector{UInt8}(4)); position(s))  == 4
+        @test (s = io(); read!(s, Vector{UInt8}(uninitialized, 4)); position(s))  == 4
 
         verbose && println("$name seek...")
         for n = 0:length(text)-1

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -122,7 +122,7 @@ let rt = Base.return_types(reducedim, Tuple{Function, Array{Float64, 3}, Int, Fl
 end
 
 @testset "empty cases" begin
-    A = Array{Int}(0,1)
+    A = Matrix{Int}(uninitialized, 0,1)
     @test sum(A) === 0
     @test prod(A) === 1
     @test_throws ArgumentError minimum(A)

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -291,7 +291,7 @@ let undefvar
 
     err_str = @except_str mod(1,0) DivideError
     @test err_str == "DivideError: integer division error"
-    err_str = @except_str Array{Any,1}(1)[1] UndefRefError
+    err_str = @except_str Vector{Any}(uninitialized, 1)[1] UndefRefError
     @test err_str == "UndefRefError: access to undefined reference"
     err_str = @except_str undefvar UndefVarError
     @test err_str == "UndefVarError: undefvar not defined"


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in test/r*.jl. Ref. #24595. Best!