### PR TITLE
replace Array{...}(shape...)-like calls in test/[s-z]*

### DIFF
--- a/test/serialize.jl
+++ b/test/serialize.jl
@@ -235,7 +235,7 @@ create_serialization_stream() do s # small 1d array
     arr4 = reshape([true, false, false, false, true, false, false, false, true], 3, 3)
     serialize(s, arr4)       # boolean array
 
-    arr5 = Array{TA1}(3)
+    arr5 = Vector{TA1}(uninitialized, 3)
     arr5[2] = TA1(0x01)
     serialize(s, arr5)
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -13,7 +13,7 @@ replstr(x) = sprint((io,x) -> show(IOContext(io, :limit => true, :displaysize =>
 struct T5589
     names::Vector{String}
 end
-@test replstr(T5589(Array{String,1}(100))) == "$(curmod_prefix)T5589([#undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef  …  #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef])"
+@test replstr(T5589(Vector{String}(uninitialized, 100))) == "$(curmod_prefix)T5589([#undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef  …  #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef, #undef])"
 
 @test replstr(Meta.parse("mutable struct X end")) == ":(mutable struct X\n        #= none:1 =#\n    end)"
 @test replstr(Meta.parse("struct X end")) == ":(struct X\n        #= none:1 =#\n    end)"
@@ -139,7 +139,7 @@ end
         # line meta
         nc = num_bit_chunks(n)
         # line meta
-        chunks = Array{UInt64,1}(nc)
+        chunks = Vector{UInt64}(uninitialized, nc)
         # line meta
         if nc > 0
             # line meta
@@ -326,11 +326,11 @@ export D, E, F
 end"
 
 # issue #19840
-@test_repr "Array{Int}(0)"
-@test_repr "Array{Int}(0,0)"
-@test_repr "Array{Int}(0,0,0)"
-@test_repr "Array{Int}(0,1)"
-@test_repr "Array{Int}(0,0,1)"
+@test_repr "Array{Int}(uninitialized, 0)"
+@test_repr "Array{Int}(uninitialized, 0,0)"
+@test_repr "Array{Int}(uninitialized, 0,0,0)"
+@test_repr "Array{Int}(uninitialized, 0,1)"
+@test_repr "Array{Int}(uninitialized, 0,0,1)"
 
 # issue #8994
 @test_repr "get! => 2"
@@ -693,7 +693,7 @@ end
 
 # PR 17117
 # test show array
-let s = IOBuffer(Array{UInt8}(0), true, true)
+let s = IOBuffer(Vector{UInt8}(), true, true)
     Base.showarray(s, [1, 2, 3], false, header = false)
     @test String(resize!(s.data, s.size)) == " 1\n 2\n 3"
 end
@@ -744,7 +744,7 @@ end
 let repr = sprint(dump, Test)
     @test repr == "Module Test\n"
 end
-let a = Array{Any}(10000)
+let a = Vector{Any}(uninitialized, 10000)
     a[2] = "elemA"
     a[4] = "elemB"
     a[11] = "elemC"

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -116,23 +116,23 @@ function simd_cartesian_range!(indexes, crng)
 end
 
 crng = CartesianRange(2:4, 0:1, 1:1, 3:5)
-indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
+indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indexes == vec(collect(crng))
 
 crng = CartesianRange(-1:1, 1:3)
-indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
+indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indexes == vec(collect(crng))
 
 crng = CartesianRange(-1:-1, 1:3)
-indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
+indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indexes == vec(collect(crng))
 
 crng = CartesianRange(2:4)
-indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
+indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indexes == collect(crng)
 
 crng = CartesianRange()
-indexes = simd_cartesian_range!(Array{eltype(crng)}(0), crng)
+indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indexes == vec(collect(crng))
 
 # @simd with array as "range"

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -74,7 +74,7 @@ B = view(A, 1:3, 2, 1:3)
     end
     Ip = I.parameters
     NP = length(Ip)
-    indexexprs = Array{Expr}(NP)
+    indexexprs = Vector{Expr}(uninitialized, NP)
     j = 1
     for i = 1:NP
         if Ip[i] == Int

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -283,7 +283,7 @@ end
 
     @testset "Issue 23161" begin
         arr = b"0123456789abcdefABCDEF"
-        arr1 = Vector{UInt8}(length(arr) >> 1)
+        arr1 = Vector{UInt8}(uninitialized, length(arr) >> 1)
         @test hex2bytes!(arr1, arr) === arr1 # check in-place
         @test "0123456789abcdefabcdef" == bytes2hex(arr1)
         @test hex2bytes("0123456789abcdefABCDEF") == hex2bytes(arr)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -33,7 +33,7 @@ _Agen(A, i1, i2, i3) = [A[j1,j2,j3] for j1 in i1, j2 in i2, j3 in i3]
 _Agen(A, i1, i2, i3, i4) = [A[j1,j2,j3,j4] for j1 in i1, j2 in i2, j3 in i3, j4 in i4]
 
 function replace_colon(A::AbstractArray, I)
-    Iout = Array{Any}(length(I))
+    Iout = Vector{Any}(uninitialized, length(I))
     I == (:,) && return (1:length(A),)
     for d = 1:length(I)
         Iout[d] = isa(I[d], Colon) ? (1:size(A,d)) : I[d]
@@ -52,7 +52,7 @@ tup2val(::NTuple{N}) where {N} = Val(N)
 # it's good to copy the contents to an Array. This version protects against
 # `similar` ever changing its meaning.
 function copy_to_array(A::AbstractArray)
-    Ac = Array{eltype(A)}(size(A))
+    Ac = Array{eltype(A)}(uninitialized, size(A))
     copy!(Ac, A)
 end
 

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -47,8 +47,8 @@ function test_threaded_atomic_minmax(m::T,n::T) where T
     mid = m + (n-m)>>1
     x = Atomic{T}(mid)
     y = Atomic{T}(mid)
-    oldx = Array{T}(n-m+1)
-    oldy = Array{T}(n-m+1)
+    oldx = Vector{T}(uninitialized, n-m+1)
+    oldy = Vector{T}(uninitialized, n-m+1)
     @threads for i = m:n
         oldx[i-m+1] = atomic_min!(x, T(i))
         oldy[i-m+1] = atomic_max!(y, T(i))

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -65,7 +65,7 @@ struct Gr{N, T}
     w::T
 end
 
-let a = Vector{Gr{2,Float64}}(2)
+let a = Vector{Gr{2,Float64}}(uninitialized, 2)
     a[2] = Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)
     a[1] = Gr(5.0, Bunch((VecElement(6.0), VecElement(7.0))), 8.0)
     @test a[2] == Gr(1.0, Bunch((VecElement(2.0), VecElement(3.0))), 4.0)


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in test/[s-z]*.jl. Ref. #24595. Best!