### PR TITLE
replace Array{...}(shape...)-like calls in base/a*

### DIFF
--- a/base/associative.jl
+++ b/base/associative.jl
@@ -349,7 +349,7 @@ Dict{Int64,String} with 2 entries:
 ```
 """
 function filter!(f, d::Associative)
-    badkeys = Vector{keytype(d)}(0)
+    badkeys = Vector{keytype(d)}()
     try
         for (k,v) in d
             # don't delete!(d, k) here, since associative types
@@ -368,7 +368,7 @@ end
 function filter!_dict_deprecation(e, f, d::Associative)
     if isa(e, MethodError) && e.f === f
         depwarn("In `filter!(f, dict)`, `f` is now passed a single pair instead of two arguments.", :filter!)
-        badkeys = Vector{keytype(d)}(0)
+        badkeys = Vector{keytype(d)}()
         for (k,v) in d
             # don't delete!(d, k) here, since associative types
             # may not support mutation during iteration
@@ -495,7 +495,7 @@ See [`Dict`](@ref) for further help.
 mutable struct ObjectIdDict <: Associative{Any,Any}
     ht::Vector{Any}
     ndel::Int
-    ObjectIdDict() = new(Vector{Any}(32), 0)
+    ObjectIdDict() = new(Vector{Any}(uninitialized, 32), 0)
 
     function ObjectIdDict(itr)
         d = ObjectIdDict()

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -246,7 +246,7 @@ end
 
 # Special handling for some types.
 function asyncmap(f, s::AbstractString; kwargs...)
-    s2 = Array{Char,1}(length(s))
+    s2 = Vector{Char}(uninitialized, length(s))
     asyncmap!(f, s2, s; kwargs...)
     return convert(String, s2)
 end


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in base/a*.jl. Ref. #24595. Best!