### PR TITLE
replace Array{...}(shape...)-like calls in base/linalg/[l-z]*

### DIFF
--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -66,7 +66,7 @@ function generic_lufact!(A::StridedMatrix{T}, ::Val{Pivot} = Val(true)) where {T
     m, n = size(A)
     minmn = min(m,n)
     info = 0
-    ipiv = Vector{BlasInt}(minmn)
+    ipiv = Vector{BlasInt}(uninitialized, minmn)
     @inbounds begin
         for k = 1:minmn
             # find index max
@@ -388,7 +388,7 @@ end
 function lufact!(A::Tridiagonal{T,V}, pivot::Union{Val{false}, Val{true}} = Val(true)) where {T,V}
     n = size(A, 1)
     info = 0
-    ipiv = Vector{BlasInt}(n)
+    ipiv = Vector{BlasInt}(uninitialized, n)
     dl = A.dl
     d = A.d
     du = A.du

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -324,7 +324,7 @@ function herk_wrapper!(C::Union{StridedMatrix{T}, StridedMatrix{Complex{T}}}, tA
     end
 
     # Result array does not need to be initialized as long as beta==0
-    #    C = Matrix{T}(mA, mA)
+    #    C = Matrix{T}(uninitialized, mA, mA)
 
     if stride(A, 1) == stride(C, 1) == 1 && stride(A, 2) >= size(A, 1) && stride(C, 2) >= size(C, 1)
         return copytri!(BLAS.herk!('U', tA, one(T), A, zero(T), C), 'U', true)
@@ -471,9 +471,9 @@ function generic_matmatmul(tA, tB, A::AbstractVecOrMat{T}, B::AbstractMatrix{S})
 end
 
 const tilebufsize = 10800  # Approximately 32k/3
-const Abuf = Vector{UInt8}(tilebufsize)
-const Bbuf = Vector{UInt8}(tilebufsize)
-const Cbuf = Vector{UInt8}(tilebufsize)
+const Abuf = Vector{UInt8}(uninitialized, tilebufsize)
+const Bbuf = Vector{UInt8}(uninitialized, tilebufsize)
+const Cbuf = Vector{UInt8}(uninitialized, tilebufsize)
 
 function generic_matmatmul!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
     mA, nA = lapack_size(tA, A)

--- a/base/linalg/qr.jl
+++ b/base/linalg/qr.jl
@@ -162,7 +162,7 @@ end
 function qrfactPivotedUnblocked!(A::StridedMatrix)
     m, n = size(A)
     piv = collect(UnitRange{BlasInt}(1,n))
-    τ = Vector{eltype(A)}(min(m,n))
+    τ = Vector{eltype(A)}(uninitialized, min(m,n))
     for j = 1:min(m,n)
 
         # Find column with maximum norm in trailing submatrix

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -35,13 +35,13 @@ const ConjRowVector{T,CV<:ConjVector} = RowVector{T,CV}
 @inline RowVector{T}(vec::AbstractVector{T}) where {T} = RowVector{T,typeof(vec)}(vec)
 
 # Constructors that take a size and default to Array
-@inline RowVector{T}(n::Int) where {T} = RowVector{T}(Vector{transpose_type(T)}(n))
+@inline RowVector{T}(n::Int) where {T} = RowVector{T}(Vector{transpose_type(T)}(uninitialized, n))
 @inline RowVector{T}(n1::Int, n2::Int) where {T} = n1 == 1 ?
-    RowVector{T}(Vector{transpose_type(T)}(n2)) :
+    RowVector{T}(Vector{transpose_type(T)}(uninitialized, n2)) :
     error("RowVector expects 1×N size, got ($n1,$n2)")
-@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(Vector{transpose_type(T)}(n[1]))
+@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[1]))
 @inline RowVector{T}(n::Tuple{Int,Int}) where {T} = n[1] == 1 ?
-    RowVector{T}(Vector{transpose_type(T)}(n[2])) :
+    RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[2])) :
     error("RowVector expects 1×N size, got $n")
 
 # Conversion of underlying storage

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -106,13 +106,13 @@ parent(A::AbstractTriangular) = A.data
 # then handle all methods that requires specific handling of upper/lower and unit diagonal
 
 function convert(::Type{Matrix{T}}, A::LowerTriangular) where T
-    B = Matrix{T}(size(A, 1), size(A, 1))
+    B = Matrix{T}(uninitialized, size(A, 1), size(A, 1))
     copy!(B, A.data)
     tril!(B)
     B
 end
 function convert(::Type{Matrix{T}}, A::UnitLowerTriangular) where T
-    B = Matrix{T}(size(A, 1), size(A, 1))
+    B = Matrix{T}(uninitialized, size(A, 1), size(A, 1))
     copy!(B, A.data)
     tril!(B)
     for i = 1:size(B,1)
@@ -121,13 +121,13 @@ function convert(::Type{Matrix{T}}, A::UnitLowerTriangular) where T
     B
 end
 function convert(::Type{Matrix{T}}, A::UpperTriangular) where T
-    B = Matrix{T}(size(A, 1), size(A, 1))
+    B = Matrix{T}(uninitialized, size(A, 1), size(A, 1))
     copy!(B, A.data)
     triu!(B)
     B
 end
 function convert(::Type{Matrix{T}}, A::UnitUpperTriangular) where T
-    B = Matrix{T}(size(A, 1), size(A, 1))
+    B = Matrix{T}(uninitialized, size(A, 1), size(A, 1))
     copy!(B, A.data)
     triu!(B)
     for i = 1:size(B,1)
@@ -1927,7 +1927,7 @@ function log(A0::UpperTriangular{T}) where T<:BlasFloat
         R[i+1,i] = R[i,i+1]
     end
     x,V = eig(R)
-    w = Vector{Float64}(m)
+    w = Vector{Float64}(uninitialized, m)
     for i = 1:m
         x[i] = (x[i] + 1) / 2
         w[i] = V[1,i]^2

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -349,7 +349,7 @@ function inv_usmani(a::V, b::V, c::V) where {T,V<:AbstractVector{T}}
     for i=n-1:-1:1
         φ[i] = b[i]*φ[i+1]-a[i]*c[i]*φ[i+2]
     end
-    α = Matrix{T}(n, n)
+    α = Matrix{T}(uninitialized, n, n)
     for i=1:n, j=1:n
         sign = (i+j)%2==0 ? (+) : (-)
         if i<j

--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -264,7 +264,7 @@ end
 # in A to matrices of type T and sizes given by n[k:end].  n is an array
 # so that the same promotion code can be used for hvcat.  We pass the type T
 # so that we can re-use this code for sparse-matrix hcat etcetera.
-promote_to_arrays_(n::Int, ::Type{Matrix}, J::UniformScaling{T}) where {T} = copy!(Matrix{T}(n,n), J)
+promote_to_arrays_(n::Int, ::Type{Matrix}, J::UniformScaling{T}) where {T} = copy!(Matrix{T}(uninitialized, n,n), J)
 promote_to_arrays_(n::Int, ::Type, A::AbstractVecOrMat) = A
 promote_to_arrays(n,k, ::Type) = ()
 promote_to_arrays(n,k, ::Type{T}, A) where {T} = (promote_to_arrays_(n[k], T, A),)


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in base/linalg/[l-z]*.jl (less base/linalg/lapack.jl). Ref. #24595. Best!