### PR TITLE
Add missing `io` argument to Markdown function

### DIFF
--- a/base/markdown/render/rich.jl
+++ b/base/markdown/render/rich.jl
@@ -14,7 +14,7 @@ function tohtml(io::IO, m::MIME"image/png", img)
     print(io, "\" />")
 end
 
-function tohtml(m::MIME"image/svg+xml", img)
+function tohtml(io::IO, m::MIME"image/svg+xml", img)
     show(io, m, img)
 end
 


### PR DESCRIPTION
The function body references a nonexistent `io` argument.