### PR TITLE
FileWatching: fix use-after-free

### DIFF
--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -189,11 +189,11 @@ mutable struct _FDWatcher
             associate_julia_struct(handle, this)
             err = ccall(:uv_poll_init_socket, Int32, (Ptr{Void},   Ptr{Void}, Ptr{Void}),
                                                       eventloop(), handle,    fd.handle)
-            finalizer(uvfinalize, this)
             if err != 0
                 Libc.free(handle)
                 throw(UVError("FDWatcher", err))
             end
+            finalizer(uvfinalize, this)
             return this
         end
     end


### PR DESCRIPTION
Noticed this when the tests `assert(0)`-ed locally. I'm not sure why we haven't seen it before when running on AV.