### PR TITLE
replace Array{...}(shape...)-like calls in stdlib

### DIFF
--- a/stdlib/Base64/src/buffer.jl
+++ b/stdlib/Base64/src/buffer.jl
@@ -7,7 +7,7 @@ mutable struct Buffer
     size::Int
 
     function Buffer(bufsize)
-        data = Vector{UInt8}(bufsize)
+        data = Vector{UInt8}(uninitialized, bufsize)
         return new(data, pointer(data), 0)
     end
 end

--- a/stdlib/CRC32c/test/runtests.jl
+++ b/stdlib/CRC32c/test/runtests.jl
@@ -49,7 +49,7 @@ crc32c_sw(a::Union{Array{UInt8},Base.FastContiguousSubArray{UInt8,N,<:Array{UInt
 crc32c_sw(s::String, crc::UInt32=0x00000000) = unsafe_crc32c_sw(s, sizeof(s), crc)
 function crc32c_sw(io::IO, nb::Integer, crc::UInt32=0x00000000)
     nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0"))
-    buf = Array{UInt8}(min(nb, 24576))
+    buf = Vector{UInt8}(uninitialized, min(nb, 24576))
     while !eof(io) && nb > 24576
         n = readbytes!(io, buf)
         crc = unsafe_crc32c_sw(buf, n, crc)

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -483,7 +483,7 @@ end
 
 function format(dt::TimeType, fmt::DateFormat, bufsize=12)
     # preallocate to reduce resizing
-    io = IOBuffer(Vector{UInt8}(bufsize), true, true)
+    io = IOBuffer(Vector{UInt8}(uninitialized, bufsize), true, true)
     format(io, dt, fmt)
     String(io.data[1:io.ptr - 1])
 end

--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -301,7 +301,7 @@ number of components may be less than the total number of `DatePart`.
         values, pos, num_parsed = tryparsenext_core(str, pos, len, df, true)
         t = unsafe_get(values)
         types = $(Expr(:tuple, tokens...))
-        result = Vector{Any}(num_parsed)
+        result = Vector{Any}(uninitialized, num_parsed)
         for (i, typ) in enumerate(types)
             i > num_parsed && break
             result[i] = typ(t[i])  # Constructing types takes most of the time

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -291,7 +291,7 @@ end
 @test_throws MethodError dr .+ 1
 a = Dates.DateTime(2013, 1, 1)
 b = Dates.DateTime(2013, 2, 1)
-@test map!(x->x + Dates.Day(1), Array{Dates.DateTime}(32), dr) == [(a + Dates.Day(1)):Dates.Day(1):(b + Dates.Day(1));]
+@test map!(x->x + Dates.Day(1), Vector{Dates.DateTime}(uninitialized, 32), dr) == [(a + Dates.Day(1)):Dates.Day(1):(b + Dates.Day(1));]
 @test map(x->x + Dates.Day(1), dr) == [(a + Dates.Day(1)):Dates.Day(1):(b + Dates.Day(1));]
 
 @test map(x->a in x, drs[1:4]) == [true, true, false, true]
@@ -369,7 +369,7 @@ end
 @test_throws MethodError dr .+ 1
 a = Dates.Date(2013, 1, 1)
 b = Dates.Date(2013, 2, 1)
-@test map!(x->x + Dates.Day(1), Array{Dates.Date}(32), dr) == [(a + Dates.Day(1)):Dates.Day(1):(b + Dates.Day(1));]
+@test map!(x->x + Dates.Day(1), Vector{Dates.Date}(uninitialized, 32), dr) == [(a + Dates.Day(1)):Dates.Day(1):(b + Dates.Day(1));]
 @test map(x->x + Dates.Day(1), dr) == [(a + Dates.Day(1)):Dates.Day(1):(b + Dates.Day(1));]
 
 @test map(x->a in x, drs[1:4]) == [true, true, false, true]

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -138,8 +138,8 @@ mutable struct DLMOffsets <: DLMHandler
     bufflen::Int
 
     function DLMOffsets(sbuff::String)
-        offsets = Vector{Vector{Int}}(1)
-        offsets[1] = Vector{Int}(offs_chunk_size)
+        offsets = Vector{Vector{Int}}(uninitialized, 1)
+        offsets[1] = Vector{Int}(uninitialized, offs_chunk_size)
         thresh = ceil(min(typemax(UInt), Base.Sys.total_memory()) / sizeof(Int) / 5)
         new(offsets, 1, thresh, sizeof(sbuff))
     end
@@ -163,7 +163,7 @@ function store_cell(dlmoffsets::DLMOffsets, row::Int, col::Int,
                 return
             end
         end
-        offsets = Vector{Int}(offs_chunk_size)
+        offsets = Vector{Int}(uninitialized, offs_chunk_size)
         push!(oarr, offsets)
         offidx = 1
     end
@@ -202,7 +202,7 @@ function DLMStore(::Type{T}, dims::NTuple{2,Integer},
     nrows <= 0 && throw(ArgumentError("number of rows in dims must be > 0, got $nrows"))
     ncols <= 0 && throw(ArgumentError("number of columns in dims must be > 0, got $ncols"))
     hdr_offset = has_header ? 1 : 0
-    DLMStore{T}(fill(SubString(sbuff,1,0), 1, ncols), Matrix{T}(nrows-hdr_offset, ncols),
+    DLMStore{T}(fill(SubString(sbuff,1,0), 1, ncols), Matrix{T}(uninitialized, nrows-hdr_offset, ncols),
         nrows, ncols, 0, 0, hdr_offset, sbuff, auto, eol)
 end
 

--- a/stdlib/DelimitedFiles/test/runtests.jl
+++ b/stdlib/DelimitedFiles/test/runtests.jl
@@ -230,7 +230,7 @@ end
     for data in ["A B C", "A B C\n"]
         data,hdr = readdlm(IOBuffer(data), header=true)
         @test hdr == AbstractString["A" "B" "C"]
-        @test data == Array{Float64}(0, 3)
+        @test data == Matrix{Float64}(uninitialized, 0, 3)
     end
 end
 

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -173,7 +173,7 @@ function mmap(io::IO,
 
     len = prod(dims) * sizeof(T)
     len >= 0 || throw(ArgumentError("requested size must be ≥ 0, got $len"))
-    len == 0 && return Array{T}(ntuple(x->0,Val(N)))
+    len == 0 && return Array{T}(uninitialized, ntuple(x->0,Val(N)))
     len < typemax(Int) - PAGESIZE || throw(ArgumentError("requested size must be < $(typemax(Int)-PAGESIZE), got $len"))
 
     offset >= 0 || throw(ArgumentError("requested offset must be ≥ 0, got $offset"))

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -48,8 +48,8 @@ close(s)
 gc(); gc()
 
 s = open(f->f,file,"w")
-@test Mmap.mmap(file) == Array{UInt8}(0) # requested len=0 on empty file
-@test Mmap.mmap(file,Vector{UInt8},0) == Array{UInt8}(0)
+@test Mmap.mmap(file) == Vector{UInt8}() # requested len=0 on empty file
+@test Mmap.mmap(file,Vector{UInt8},0) == Vector{UInt8}()
 s = open(file, "r+")
 m = Mmap.mmap(s,Vector{UInt8},12)
 m[:] = b"Hello World\n"

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -333,8 +333,8 @@ function count_flat(data::Vector{T}) where T<:Unsigned
         end
         linecount[ip] = get(linecount, ip, 0)+1
     end
-    iplist = Vector{T}(0)
-    n = Vector{Int}(0)
+    iplist = Vector{T}()
+    n = Vector{Int}()
     for (k,v) in linecount
         push!(iplist, k)
         push!(n, v)
@@ -447,8 +447,8 @@ function tree_aggregate(data::Vector{UInt64})
         treecount[tmp] = get(treecount, tmp, 0) + 1
         istart = iend + 1 + btskip
     end
-    bt = Vector{Vector{UInt64}}(0)
-    counts = Vector{Int}(0)
+    bt = Vector{Vector{UInt64}}()
+    counts = Vector{Int}()
     for (k, v) in treecount
         if !isempty(k)
             push!(bt, k)
@@ -467,7 +467,7 @@ function tree_format(lilist::Vector{StackFrame}, counts::Vector{Int}, level::Int
     ntext = cols - nindent - ndigcounts - ndigline - 5
     widthfile = floor(Integer, 0.4ntext)
     widthfunc = floor(Integer, 0.6ntext)
-    strs = Vector{String}(length(lilist))
+    strs = Vector{String}(uninitialized, length(lilist))
     showextra = false
     if level > nindent
         nextra = level - nindent
@@ -531,9 +531,9 @@ function tree(io::IO, bt::Vector{Vector{UInt64}}, counts::Vector{Int},
         end
         # Generate counts
         dlen = length(d)
-        lilist = Vector{StackFrame}(dlen)
-        group = Vector{Vector{Int}}(dlen)
-        n = Vector{Int}(dlen)
+        lilist = Vector{StackFrame}(uninitialized, dlen)
+        group = Vector{Vector{Int}}(uninitialized, dlen)
+        n = Vector{Int}(uninitialized, dlen)
         i = 1
         for (key, v) in d
             lilist[i] = key
@@ -554,9 +554,9 @@ function tree(io::IO, bt::Vector{Vector{UInt64}}, counts::Vector{Int},
         end
         # Generate counts, and do the code lookup
         dlen = length(d)
-        lilist = Vector{StackFrame}(dlen)
-        group = Vector{Vector{Int}}(dlen)
-        n = Vector{Int}(dlen)
+        lilist = Vector{StackFrame}(uninitialized, dlen)
+        group = Vector{Vector{Int}}(uninitialized, dlen)
+        n = Vector{Int}(uninitialized, dlen)
         i = 1
         for (key, v) in d
             lilist[i] = lidict[key]
@@ -659,7 +659,7 @@ truncto(str::Symbol, w::Int) = truncto(string(str), w)
 
 # Order alphabetically (file, function) and then by line number
 function liperm(lilist::Vector{StackFrame})
-    comb = Vector{String}(length(lilist))
+    comb = Vector{String}(uninitialized, length(lilist))
     for i = 1:length(lilist)
         li = lilist[i]
         if li != UNKNOWN

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -39,7 +39,7 @@ mutable struct SharedArray{T,N} <: DenseArray{T,N}
     loc_subarr_1d::SubArray{T,1,Array{T,1},Tuple{UnitRange{Int}},true}
 
     function SharedArray{T,N}(d,p,r,sn,s) where {T,N}
-        S = new(RRID(),d,p,r,sn,s,0,view(Array{T}(ntuple(d->0,N)), 1:0))
+        S = new(RRID(),d,p,r,sn,s,0,view(Array{T}(uninitialized, ntuple(d->0,N)), 1:0))
         sa_refs[S.id] = WeakRef(S)
         S
     end
@@ -105,7 +105,7 @@ function SharedArray{T,N}(dims::Dims{N}; init=false, pids=Int[]) where {T,N}
     pids, onlocalhost = shared_pids(pids)
 
     local shm_seg_name = ""
-    local s = Array{T}(ntuple(d->0,N))
+    local s = Array{T}(uninitialized, ntuple(d->0,N))
     local S
     local shmmem_create_pid
     try
@@ -125,7 +125,7 @@ function SharedArray{T,N}(dims::Dims{N}; init=false, pids=Int[]) where {T,N}
 
         func_mapshmem = () -> shm_mmap_array(T, dims, shm_seg_name, JL_O_RDWR)
 
-        refs = Vector{Future}(length(pids))
+        refs = Vector{Future}(uninitialized, length(pids))
         for (i, p) in enumerate(pids)
             refs[i] = remotecall(func_mapshmem, p)
         end
@@ -202,11 +202,11 @@ function SharedArray{T,N}(filename::AbstractString, dims::NTuple{N,Int}, offset:
     end
 
     # Create the file if it doesn't exist, map it if it does
-    refs = Vector{Future}(length(pids))
+    refs = Vector{Future}(uninitialized, length(pids))
     func_mmap = mode -> open(filename, mode) do io
         Mmap.mmap(io, Array{T,N}, dims, offset; shared=true)
     end
-    s = Array{T}(ntuple(d->0,N))
+    s = Array{T}(uninitialized, ntuple(d->0,N))
     if onlocalhost
         s = func_mmap(mode)
         refs[1] = remotecall(pids[1]) do
@@ -267,7 +267,7 @@ function finalize_refs(S::SharedArray{T,N}) where T where N
         empty!(S.pids)
         empty!(S.refs)
         init_loc_flds(S)
-        S.s = Array{T}(ntuple(d->0,N))
+        S.s = Array{T}(uninitialized, ntuple(d->0,N))
         delete!(sa_refs, S.id)
     end
     S
@@ -286,7 +286,7 @@ function reshape(a::SharedArray{T}, dims::NTuple{N,Int}) where {T,N}
     if length(a) != prod(dims)
         throw(DimensionMismatch("dimensions must be consistent with array size"))
     end
-    refs = Array{Future}(length(a.pids))
+    refs = Vector{Future}(uninitialized, length(a.pids))
     for (i, p) in enumerate(a.pids)
         refs[i] = remotecall(p, a.refs[i], dims) do r,d
             reshape(fetch(r),d)
@@ -415,9 +415,9 @@ function init_loc_flds(S::SharedArray{T,N}, empty_local=false) where T where N
     else
         S.pidx = 0
         if empty_local
-            S.s = Array{T}(ntuple(d->0,N))
+            S.s = Array{T}(uninitialized, ntuple(d->0,N))
         end
-        S.loc_subarr_1d = view(Array{T}(ntuple(d->0,N)), 1:0)
+        S.loc_subarr_1d = view(Array{T}(uninitialized, ntuple(d->0,N)), 1:0)
     end
 end
 
@@ -626,7 +626,7 @@ function shm_mmap_array(T, dims, shm_seg_name, mode)
     local A = nothing
 
     if (prod(dims) == 0) || (sizeof(T) == 0)
-        return Array{T}(dims)
+        return Array{T}(uninitialized, dims)
     end
 
     try

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -47,7 +47,7 @@ end
 d = SharedArrays.shmem_rand(1:100, dims)
 a = convert(Array, d)
 
-partsums = Array{Int}(length(procs(d)))
+partsums = Vector{Int}(uninitialized, length(procs(d)))
 @sync begin
     for (i, p) in enumerate(procs(d))
         @async partsums[i] = remotecall_fetch(p, d) do D
@@ -142,7 +142,7 @@ write(fn3, ones(UInt8, 4))
 S = SharedArray{UInt8}(fn3, sz, 4, mode="a+", init=D->D[localindexes(D)]=0x02)
 len = prod(sz)+4
 @test filesize(fn3) == len
-filedata = Array{UInt8}(len)
+filedata = Vector{UInt8}(uninitialized, len)
 read!(fn3, filedata)
 @test all(filedata[1:4] .== 0x01)
 @test all(filedata[5:end] .== 0x02)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1021,7 +1021,7 @@ function testset_forloop(args, testloop, source)
         end
     end
     quote
-        arr = Array{Any,1}(0)
+        arr = Vector{Any}()
         local first_iteration = true
         local ts
         try
@@ -1428,8 +1428,8 @@ struct GenericArray{T,N} <: AbstractArray{T,N}
     a::Array{T,N}
 end
 
-GenericArray{T}(args...) where {T} = GenericArray(Array{T}(args...))
-GenericArray{T,N}(args...) where {T,N} = GenericArray(Array{T,N}(args...))
+GenericArray{T}(args...) where {T} = GenericArray(Array{T}(uninitialized, args...))
+GenericArray{T,N}(args...) where {T,N} = GenericArray(Array{T,N}(uninitialized, args...))
 
 Base.keys(a::GenericArray) = keys(a.a)
 Base.indices(a::GenericArray) = indices(a.a)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -59,7 +59,7 @@ end
     end
 end
 @testset "@test and elements of an array" begin
-    a = Array{Float64, 5}(2, 2, 2, 2, 2)
+    a = Array{Float64, 5}(uninitialized, 2, 2, 2, 2, 2)
     a[1, 1, 1, 1, 1] = 10
     @test a[1, 1, 1, 1, 1] == 10
     @test a[1, 1, 1, 1, 1] != 2


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in stdlib. Ref. #24595. Best!