### PR TITLE
Precompile stdlib images and include them in sysimg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,7 @@ CORE_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/reflection.jl \
 		base/tuple.jl)
 BASE_SRCS := $(sort $(shell find $(JULIAHOME)/base -name \*.jl) $(shell find $(BUILDROOT)/base -name \*.jl))
+STDLIB_SRCS := $(sort $(shell find $(JULIAHOME)/stdlib/*/src -name \*.jl))
 
 $(build_private_libdir)/inference.ji: $(CORE_SRCS) | $(build_private_libdir)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
@@ -208,7 +209,7 @@ $(build_private_libdir)/inference.ji: $(CORE_SRCS) | $(build_private_libdir)
 RELBUILDROOT := $(shell $(JULIAHOME)/contrib/relative_path.sh "$(JULIAHOME)/base" "$(BUILDROOT)/base/")
 COMMA:=,
 define sysimg_builder
-$$(build_private_libdir)/sys$1.o: $$(build_private_libdir)/inference.ji $$(JULIAHOME)/VERSION $$(BASE_SRCS)
+$$(build_private_libdir)/sys$1.o: $$(build_private_libdir)/inference.ji $$(JULIAHOME)/VERSION $$(BASE_SRCS) $$(STDLIB_SRCS)
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \
 	if $$(call spawn,$3) $2 -C "$$(JULIA_CPU_TARGET)" --output-o $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
 		--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) sysimg.jl $$(RELBUILDROOT); then \

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -485,10 +485,17 @@ using Base
 unshift!(Base._included_files, (@__MODULE__, joinpath(@__DIR__, "sysimg.jl")))
 
 # load some stdlib packages but don't put their names in Main
-Base.require(:DelimitedFiles)
-Base.require(:Test)
+Base.require(:Base64)
+Base.require(:CRC32c)
 Base.require(:Dates)
+Base.require(:DelimitedFiles)
+Base.require(:FileWatching)
+Base.require(:Mmap)
+Base.require(:Profile)
+Base.require(:SharedArrays)
 Base.require(:SuiteSparse)
+Base.require(:Test)
+
 
 empty!(LOAD_PATH)
 

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 module Base64
 
 export

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -1,3 +1,6 @@
+
+__precompile__(true)
+
 """
 Standard library module for computing the CRC-32c checksum.
 

--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 """
     Dates
 

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 """
 Utilities for monitoring files and file descriptors for events.
 """

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 """
 Low level module for mmap (memory mapping of files).
 """

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 """
 Profiling support, main entry point is the [`@profile`](@ref) macro.
 """

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 """
 Provide the [`SharedArray`](@ref) type. It represents an array, which is shared across multiple processes, on a single machine.
 """

--- a/stdlib/SuiteSparse/src/SuiteSparse.jl
+++ b/stdlib/SuiteSparse/src/SuiteSparse.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+__precompile__(true)
+
 module SuiteSparse
 
 import Base: At_ldiv_B, Ac_ldiv_B, A_ldiv_B!

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -215,10 +215,11 @@ try
 
         modules, deps1 = Base.cache_dependencies(cachefile)
         @test modules == merge(Dict(s => Base.module_uuid(getfield(Foo, s)) for s in
-                                    [:Base, :Core, Foo2_module, FooBase_module, :Main, :Test]),
+                                    [:Base, :Core, Foo2_module, FooBase_module, :Main]),
                                # plus modules included in the system image
                                Dict(s => Base.module_uuid(Base.root_module(s)) for s in
-                                    [:DelimitedFiles, :Mmap, :Base64, :Dates, :SuiteSparse]))
+                                    [:Base64, :CRC32c, :Dates, :DelimitedFiles, :FileWatching, :Mmap,
+                                     :Profile, :SharedArrays, :SuiteSparse, :Test]))
         @test discard_module.(deps) == deps1
 
         @test current_task()(0x01, 0x4000, 0x30031234) == 2


### PR DESCRIPTION
* Marks all of stdlib as `__precompile__(true)`
* Includes all of stdlib in `base\sysimg.jl`
* Ensures that sysimg get's rebuild when stlib files change

fixes #24765
fixes #24697