### PR TITLE
replace Array(shape...)-like calls in base/distributed/*

### DIFF
--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -595,8 +595,8 @@ end
 
 additional_io_objs=Dict()
 function launch_additional(np::Integer, cmd::Cmd)
-    io_objs = Vector{Any}(np)
-    addresses = Vector{Any}(np)
+    io_objs = Vector{Any}(uninitialized, np)
+    addresses = Vector{Any}(uninitialized, np)
 
     for i in 1:np
         io = open(detach(cmd), "r+")

--- a/base/distributed/macros.jl
+++ b/base/distributed/macros.jl
@@ -214,7 +214,7 @@ function splitrange(N::Int, np::Int)
     each = div(N,np)
     extras = rem(N,np)
     nchunks = each > 0 ? np : extras
-    chunks = Vector{UnitRange{Int}}(nchunks)
+    chunks = Vector{UnitRange{Int}}(uninitialized, nchunks)
     lo = 1
     for i in 1:nchunks
         hi = lo + each - 1

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -122,7 +122,7 @@ end
 function launch(manager::SSHManager, params::Dict, launched::Array, launch_ntfy::Condition)
     # Launch one worker on each unique host in parallel. Additional workers are launched later.
     # Wait for all launches to complete.
-    launch_tasks = Vector{Any}(length(manager.machines))
+    launch_tasks = Vector{Any}(uninitialized, length(manager.machines))
 
     for (i,(machine, cnt)) in enumerate(manager.machines)
         let machine=machine, cnt=cnt

--- a/base/distributed/pmap.jl
+++ b/base/distributed/pmap.jl
@@ -255,7 +255,7 @@ julia> collect(c)
 ```
 """
 function head_and_tail(c, n)
-    head = Vector{eltype(c)}(n)
+    head = Vector{eltype(c)}(uninitialized, n)
     s = start(c)
     i = 0
     while i < n && !done(c, s)


### PR DESCRIPTION
This pull request replaces `Array{...}(shape...)`-like calls in base/distributed/*. Split out from #24756 as these changes seemingly made CI unhappy. But I think I found and fixed the issue, so hopefully these changes will now pass CI. (If they do pass CI, having already gone through a few CI rounds and a review in #24756, I plan to merge these changes this evening PT or later.) Ref. #24595. Best!