### PR TITLE
replace Array{...}() calls throughout test, base, and stdlib

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -336,7 +336,7 @@ fill(v, dims::Integer...) = fill!(Array{typeof(v)}(uninitialized, dims...), v)
     zeros([A::AbstractArray,] [T=eltype(A)::Type,] [dims=size(A)::Tuple])
 
 Create an array of all zeros with the same layout as `A`, element type `T` and size `dims`.
-The `A` argument can be skipped, which behaves like `Array{Float64,0}()` was passed.
+The `A` argument can be skipped, which behaves like `Array{Float64,0}(uninitialized)` was passed.
 For convenience `dims` may also be passed in variadic form.
 
 # Examples
@@ -379,7 +379,7 @@ function zeros end
     ones([A::AbstractArray,] [T=eltype(A)::Type,] [dims=size(A)::Tuple])
 
 Create an array of all ones with the same layout as `A`, element type `T` and size `dims`.
-The `A` argument can be skipped, which behaves like `Array{Float64,0}()` was passed.
+The `A` argument can be skipped, which behaves like `Array{Float64,0}(uninitialized)` was passed.
 For convenience `dims` may also be passed in variadic form.
 
 # Examples
@@ -530,7 +530,7 @@ function _collect(cont, itr, ::HasEltype, isz::SizeUnknown)
     return a
 end
 
-_collect_indices(::Tuple{}, A) = copy!(Array{eltype(A)}(), A)
+_collect_indices(::Tuple{}, A) = copy!(Array{eltype(A),0}(uninitialized), A)
 _collect_indices(indsA::Tuple{Vararg{OneTo}}, A) =
     copy!(Array{eltype(A)}(uninitialized, length.(indsA)), A)
 function _collect_indices(indsA, A)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -874,6 +874,6 @@ end
 end
 
 @testset "zero-dimensional copy" begin
-    Z = Array{Int}(); Z[] = 17
+    Z = Array{Int,0}(uninitialized); Z[] = 17
     @test Z == collect(Z) == copy(Z)
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2204,7 +2204,7 @@ Base.:(==)(a::T11053, b::T11053) = a.a == b.a
 @test [T11053(1)] * 5 == [T11053(1)] .* 5 == [T11053(5.0)]
 
 #15907
-@test typeof(Array{Int,0}()) == Array{Int,0}
+@test typeof(Array{Int,0}(uninitialized)) == Array{Int,0}
 
 # check a == b for arrays of Union type (#22403)
 let TT = Union{UInt8, Int8}

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -80,7 +80,7 @@ end
 let gens_dims = [((i for i = 1:5),                    1),
                  ((i for i = 1:5, j = 1:5),           2),
                  ((i for i = 1:5, j = 1:5, k = 1:5),  3),
-                 ((i for i = Array{Int}()),           0),
+                 ((i for i = Array{Int,0}(uninitialized)),           0),
                  ((i for i = Vector{Int}(uninitialized, 1)),          1),
                  ((i for i = Matrix{Int}(uninitialized, 1, 2)),       2),
                  ((i for i = Array{Int}(uninitialized, 1, 2, 3)),    3)]

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1108,7 +1108,7 @@ test_const_return(()->sizeof(Int), Tuple{}, sizeof(Int))
 test_const_return(()->sizeof(1), Tuple{}, sizeof(Int))
 test_const_return(()->sizeof(DataType), Tuple{}, sizeof(DataType))
 test_const_return(()->sizeof(1 < 2), Tuple{}, 1)
-@eval test_const_return(()->Core.sizeof($(Array{Int}())), Tuple{}, sizeof(Int))
+@eval test_const_return(()->Core.sizeof($(Array{Int,0}(uninitialized))), Tuple{}, sizeof(Int))
 @eval test_const_return(()->Core.sizeof($(Matrix{Float32}(uninitialized, 2, 2))), Tuple{}, 4 * 2 * 2)
 
 # Make sure Core.sizeof with a ::DataType as inferred input type is inferred but not constant.

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -432,7 +432,7 @@ end
 
 @testset "reverse iterators" begin
     squash(A) = reshape(A, length(A))
-    Z = Array{Int}(); Z[] = 17 # zero-dimensional test case
+    Z = Array{Int,0}(uninitialized); Z[] = 17 # zero-dimensional test case
     for itr in (2:10, "∀ϵ>0", 1:0, "", (2,3,5,7,11), [2,3,5,7,11], rand(5,6), Z, 3, true, 'x', 4=>5,
                 eachindex("∀ϵ>0"), view(Z), view(rand(5,6),2:4,2:6), (x^2 for x in 1:10),
                 Iterators.Filter(isodd, 1:10), flatten((1:10, 50:60)), enumerate("foo"),

--- a/test/show.jl
+++ b/test/show.jl
@@ -902,7 +902,7 @@ end
 @testset "display arrays non-compactly when size(⋅, 2) == 1" begin
     # 0-dim
     @test replstr(zeros(Complex{Int})) == "0-dimensional Array{Complex{$Int},0}:\n0 + 0im"
-    A = Array{Pair}(); A[] = 1=>2
+    A = Array{Pair,0}(uninitialized); A[] = 1=>2
     @test replstr(A) == "0-dimensional Array{Pair,0}:\n1 => 2"
     # 1-dim
     @test replstr(zeros(Complex{Int}, 2)) ==


### PR DESCRIPTION
This pull request replaces `Array{...}()` calls in test, base, and stdlib. Ref #24595, #24777, and #24778. Best!