### PR TITLE
replace GenericArray(shape...) calls with GenericArray(uninitialized, shape...)

### DIFF
--- a/test/random.jl
+++ b/test/random.jl
@@ -368,8 +368,8 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
         a4 = rand(rng..., C, b2, u3)                 ::Array{T, 2}
         a5 = rand!(rng..., Array{T}(5), C)           ::Vector{T}
         a6 = rand!(rng..., Array{T}(2, 3), C)        ::Array{T, 2}
-        a7 = rand!(rng..., GenericArray{T}(5), C)    ::GenericArray{T, 1}
-        a8 = rand!(rng..., GenericArray{T}(2, 3), C) ::GenericArray{T, 2}
+        a7 = rand!(rng..., GenericArray{T}(uninitialized, 5), C)    ::GenericArray{T, 1}
+        a8 = rand!(rng..., GenericArray{T}(uninitialized, 2, 3), C) ::GenericArray{T, 2}
         @test size(a1) == (5,)
         @test size(a2) == size(a3) == (2, 3)
         for a in [a0, a1..., a2..., a3..., a4..., a5..., a6..., a7..., a8...]
@@ -391,8 +391,8 @@ for rng in ([], [MersenneTwister(0)], [RandomDevice()])
             X = T == Bool ? T[0,1] : T[0,1,2]
             for A in (Vector{T}(uninitialized, 5),
                         Matrix{T}(uninitialized, 2, 3),
-                        GenericArray{T}(5),
-                        GenericArray{T}(2, 3))
+                        GenericArray{T}(uninitialized, 5),
+                        GenericArray{T}(uninitialized, 2, 3))
                 local A
                 f!(rng..., A)                    ::typeof(A)
                 if f! === rand!


### PR DESCRIPTION
This pull request replaces `GenericArray(shape...)` calls with `GenericArray(uninitialized, shape...)`, as `GenericArray` is simply a wrapper around `Array` that forwards `GenericArray(args...)` to `Array(args...)`. Ref. #24595. Best!