### PR TITLE
replace OffsetArray(inds...) constructors/calls with OffsetArray(uninitialized, inds...)

### DIFF
--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -129,8 +129,10 @@ OffsetVector{T,AA<:AbstractArray} = OffsetArray{T,1,AA}
 OffsetArray(A::AbstractArray{T,N}, offsets::NTuple{N,Int}) where {T,N} = OffsetArray{T,N,typeof(A)}(A, offsets)
 OffsetArray(A::AbstractArray{T,N}, offsets::Vararg{Int,N}) where {T,N} = OffsetArray(A, offsets)
 
-OffsetArray{T,N}(inds::Indices{N}) where {T,N} = OffsetArray{T,N,Array{T,N}}(Array{T,N}(uninitialized, map(length, inds)), map(indsoffset, inds))
-OffsetArray{T}(inds::Indices{N}) where {T,N} = OffsetArray{T,N}(inds)
+OffsetArray{T,N}(::Uninitialized, inds::Indices{N}) where {T,N} =
+    OffsetArray{T,N,Array{T,N}}(Array{T,N}(uninitialized, map(length, inds)), map(indsoffset, inds))
+OffsetArray{T}(::Uninitialized, inds::Indices{N}) where {T,N} =
+    OffsetArray{T,N}(uninitialized, inds)
 
 Base.IndexStyle(::Type{T}) where {T<:OffsetArray} = Base.IndexStyle(parenttype(T))
 parenttype(::Type{OffsetArray{T,N,AA}}) where {T,N,AA} = AA

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -230,7 +230,7 @@ v = view(A0, 1:1, i1)
 @test indices(v) === (Base.OneTo(1), -4:-3)
 
 # copy! and fill!
-a = OffsetArray{Int}((-3:-1,))
+a = OffsetArray{Int}(uninitialized, (-3:-1,))
 fill!(a, -1)
 copy!(a, (1,2))   # non-array iterables
 @test a[-3] == 1
@@ -274,7 +274,7 @@ copy!(a, -3, b, 2)
 @test a[-3] == 2
 @test a[-2] == a[-1] == -1
 @test_throws BoundsError copy!(a, -3, b, 1, 4)
-am = OffsetArray{Int}((1:1, 7:9))  # for testing linear indexing
+am = OffsetArray{Int}(uninitialized, (1:1, 7:9))  # for testing linear indexing
 fill!(am, -1)
 copy!(am, b)
 @test am[1] == 1


### PR DESCRIPTION
This pull request replaces `OffsetArray(inds...)` constructors and calls with `OffsetArray(uninitialized, inds...)`. Ref #24595. Best!