### PR TITLE
Relocate Circle config and add arch to cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
           echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
       - restore_cache: # silly to take a checksum of the tag file here instead of
           keys: # its contents but this is the only thing that works on circle
-            - ccache-{{ checksum "/tmp/weeknumber" }}
+            - ccache-{{ arch }}-{{ checksum "/tmp/weeknumber" }}
       - run: | # compile julia deps
           contrib/download_cmake.sh &&
           make -j8 -C deps || make
@@ -66,7 +66,7 @@ jobs:
           command: sudo dmesg
           when: on_fail
       - save_cache:
-          key: ccache-{{ checksum "/tmp/weeknumber" }}
+          key: ccache-{{ arch }}-{{ checksum "/tmp/weeknumber" }}
           paths:
             - ~/.ccache
 


### PR DESCRIPTION
According to [this discussion](https://discuss.circleci.com/t/version-isnt-an-allowed-key/12125), CircleCI may not correctly identify the version in use if the configuration file is circle.yml in the project's root directory, as this was the recommended location for Circle v1.0. In v2.0, the recommended location is .circleci/config.yml. Thus we should move it over to that location to ensure that our version is idenified correctly. This should hopefully fix https://github.com/JuliaLang/julia/pull/24768#issuecomment-346953452.

To avoid breakages as Circle introduces more architectures, a cache template key `{{ arch }}` was added. Circle recommends using this for any builds that use cached dependencies. Since we use ccache, we should add `{{ arch }}` to our cache file names. See [this announcement](https://discuss.circleci.com/t/use-the-arch-cache-template-key-if-you-rely-on-cached-compiled-binary-dependencies/16129).