### PR TITLE
replace RowVector(shape...) constructors/calls with RowVector(uninitialized, shape...)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -427,6 +427,13 @@ Deprecated or removed
   * `whos` has been renamed `varinfo`, and now returns a markdown table instead of printing
     output ([#12131]).
 
+  * Uninitialized `RowVector` constructors of the form `RowVector{T}(shape...)` have been
+    deprecated in favor of equivalents accepting `uninitialized` (an alias for
+    `Uninitialized()`) as their first argument, as in
+    `RowVector{T}(uninitialized, shape...)`. For example, `RowVector{Int}(3)` is now
+    `RowVector{Int}(uninitialized, 3)`, and `RowVector{Float32}((1, 4))` is now
+    `RowVector{Float32}(uninitialized, (1, 4))` ([#24786]).
+
   * `writecsv(io, a; opts...)` has been deprecated in favor of
     `writedlm(io, a, ','; opts...)` ([#23529]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2109,6 +2109,12 @@ end
     @deprecate chol!(x::Number, uplo) chol(x) false
 end
 
+# deprecate RowVector{T}(shape...) constructors to RowVector{T}(uninitialized, shape...) equivalents
+@deprecate RowVector{T}(n::Int) where {T}               RowVector{T}(uninitialized, n)
+@deprecate RowVector{T}(n1::Int, n2::Int) where {T}     RowVector{T}(uninitialized, n1, n2)
+@deprecate RowVector{T}(n::Tuple{Int}) where {T}        RowVector{T}(uninitialized, n)
+@deprecate RowVector{T}(n::Tuple{Int,Int}) where {T}    RowVector{T}(uninitialized, n)
+
 @deprecate cumsum(A::AbstractArray)     cumsum(A, 1)
 @deprecate cumsum_kbn(A::AbstractArray) cumsum_kbn(A, 1)
 @deprecate cumprod(A::AbstractArray)    cumprod(A, 1)

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -45,11 +45,6 @@ const ConjRowVector{T,CV<:ConjVector} = RowVector{T,CV}
 @inline RowVector{T}(::Uninitialized, n::Tuple{Int,Int}) where {T} =
     n[1] == 1 ? RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[2])) :
         error("RowVector expects 1×N size, got $n")
-# to deprecate, RowVector{T}(shape...) constructors
-@inline RowVector{T}(n::Int) where {T} = RowVector{T}(uninitialized, n)
-@inline RowVector{T}(n1::Int, n2::Int) where {T} = RowVector{T}(uninitialized, n1, n2)
-@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(uninitializd, n)
-@inline RowVector{T}(n::Tuple{Int,Int}) where {T} = RowVector{T}(uninitialized, n)
 
 # Conversion of underlying storage
 convert(::Type{RowVector{T,V}}, rowvec::RowVector) where {T,V<:AbstractVector} =

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -35,14 +35,21 @@ const ConjRowVector{T,CV<:ConjVector} = RowVector{T,CV}
 @inline RowVector{T}(vec::AbstractVector{T}) where {T} = RowVector{T,typeof(vec)}(vec)
 
 # Constructors that take a size and default to Array
-@inline RowVector{T}(n::Int) where {T} = RowVector{T}(Vector{transpose_type(T)}(uninitialized, n))
-@inline RowVector{T}(n1::Int, n2::Int) where {T} = n1 == 1 ?
-    RowVector{T}(Vector{transpose_type(T)}(uninitialized, n2)) :
-    error("RowVector expects 1×N size, got ($n1,$n2)")
-@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[1]))
-@inline RowVector{T}(n::Tuple{Int,Int}) where {T} = n[1] == 1 ?
-    RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[2])) :
-    error("RowVector expects 1×N size, got $n")
+@inline RowVector{T}(::Uninitialized, n::Int) where {T} =
+    RowVector{T}(Vector{transpose_type(T)}(uninitialized, n))
+@inline RowVector{T}(::Uninitialized, n1::Int, n2::Int) where {T} =
+    n1 == 1 ? RowVector{T}(Vector{transpose_type(T)}(uninitialized, n2)) :
+        error("RowVector expects 1×N size, got ($n1,$n2)")
+@inline RowVector{T}(::Uninitialized, n::Tuple{Int}) where {T} =
+    RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[1]))
+@inline RowVector{T}(::Uninitialized, n::Tuple{Int,Int}) where {T} =
+    n[1] == 1 ? RowVector{T}(Vector{transpose_type(T)}(uninitialized, n[2])) :
+        error("RowVector expects 1×N size, got $n")
+# to deprecate, RowVector{T}(shape...) constructors
+@inline RowVector{T}(n::Int) where {T} = RowVector{T}(uninitialized, n)
+@inline RowVector{T}(n1::Int, n2::Int) where {T} = RowVector{T}(uninitialized, n1, n2)
+@inline RowVector{T}(n::Tuple{Int}) where {T} = RowVector{T}(uninitializd, n)
+@inline RowVector{T}(n::Tuple{Int,Int}) where {T} = RowVector{T}(uninitialized, n)
 
 # Conversion of underlying storage
 convert(::Type{RowVector{T,V}}, rowvec::RowVector) where {T,V<:AbstractVector} =

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -6,10 +6,10 @@
 
     @test RowVector(v) == [1 2 3]
     @test RowVector{Int}(v) == [1 2 3]
-    @test size(RowVector{Int}(3)) === (1,3)
-    @test size(RowVector{Int}(1,3)) === (1,3)
-    @test size(RowVector{Int}((3,))) === (1,3)
-    @test size(RowVector{Int}((1,3))) === (1,3)
+    @test size(RowVector{Int}(uninitialized, 3)) === (1,3)
+    @test size(RowVector{Int}(uninitialized, 1,3)) === (1,3)
+    @test size(RowVector{Int}(uninitialized, (3,))) === (1,3)
+    @test size(RowVector{Int}(uninitialized, (1,3))) === (1,3)
     @test_throws ErrorException RowVector{Float64, Vector{Int}}(v)
 
     @test (v.')::RowVector == [1 2 3]


### PR DESCRIPTION
This pull request deprecates uninitialized-`RowVector` constructors of the form `RowVector{T}(shape...)` in favor of `RowVector{T}(uninitialized, shape...)` equivalents. For background, please see #24595. Best!

Tangentially, these methods do not appear to see use anywhere. Should we simply deprecate these methods altogether?