### PR TITLE
use named tuples as keyword varargs. fixes #4916

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,11 @@ New language features
   * Named tuples, with the syntax `(a=1, b=2)`. These behave very similarly to tuples,
     except components can also be accessed by name using dot syntax `t.a` ([#22194]).
 
+  * Keyword argument containers (`kw` in `f(; kw...)`) are now named tuples. Dictionary
+    functions like `haskey` and indexing can be used on them, and name-value pairs can be
+    iterated using `pairs(kw)`. `kw` can no longer contain multiple entries for the same
+    argument name ([#4916]).
+
  * Custom infix operators can now be defined by appending Unicode
    combining marks, primes, and sub/superscripts to other operators.
    For example, `+̂ₐ″` is parsed as an infix operator with the same

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -149,8 +149,6 @@ export
     # constants
     nothing, Main
 
-const AnyVector = Array{Any,1}
-
 abstract type Number end
 abstract type Real     <: Number end
 abstract type AbstractFloat <: Real end
@@ -459,6 +457,44 @@ function (g::GeneratedFunctionStub)(@nospecialize args...)
         return lam
     else
         return Expr(Symbol("with-static-parameters"), lam, g.spnames...)
+    end
+end
+
+NamedTuple() = NamedTuple{(),Tuple{}}(())
+
+"""
+    NamedTuple{names}(args::Tuple)
+
+Construct a named tuple with the given `names` (a tuple of Symbols) from a tuple of values.
+"""
+NamedTuple{names}(args::Tuple) where {names} = NamedTuple{names,typeof(args)}(args)
+
+using .Intrinsics: sle_int, add_int
+
+macro generated()
+    return Expr(:generated)
+end
+
+function NamedTuple{names,T}(args::T) where {names, T <: Tuple}
+    if @generated
+        N = nfields(names)
+        flds = Array{Any,1}(uninitialized, N)
+        i = 1
+        while sle_int(i, N)
+            arrayset(false, flds, :(getfield(args, $i)), i)
+            i = add_int(i, 1)
+        end
+        Expr(:new, :(NamedTuple{names,T}), flds...)
+    else
+        N = nfields(names)
+        NT = NamedTuple{names,T}
+        flds = Array{Any,1}(uninitialized, N)
+        i = 1
+        while sle_int(i, N)
+            arrayset(false, flds, getfield(args, i), i)
+            i = add_int(i, 1)
+        end
+        ccall(:jl_new_structv, Any, (Any, Ptr{Void}, UInt32), NT, fields, N)::NT
     end
 end
 

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -57,6 +57,7 @@ include("reduce.jl")
 include("bitarray.jl")
 include("bitset.jl")
 include("associative.jl")
+include("namedtuple.jl")
 
 # core docsystem
 include("docs/core.jl")

--- a/base/distributed/cluster.jl
+++ b/base/distributed/cluster.jl
@@ -381,7 +381,7 @@ function addprocs(manager::ClusterManager; kwargs...)
 end
 
 function addprocs_locked(manager::ClusterManager; kwargs...)
-    params = merge(default_addprocs_params(), AnyDict(kwargs))
+    params = merge(default_addprocs_params(), AnyDict(pairs(kwargs)))
     topology(Symbol(params[:topology]))
 
     if PGRP.topology != :all_to_all

--- a/base/distributed/managers.jl
+++ b/base/distributed/managers.jl
@@ -36,8 +36,8 @@ end
 
 function check_addprocs_args(kwargs)
     valid_kw_names = collect(keys(default_addprocs_params()))
-    for keyname in kwargs
-        !(keyname[1] in valid_kw_names) && throw(ArgumentError("Invalid keyword argument $(keyname[1])"))
+    for keyname in keys(kwargs)
+        !(keyname in valid_kw_names) && throw(ArgumentError("Invalid keyword argument $(keyname)"))
     end
 end
 

--- a/base/distributed/messages.jl
+++ b/base/distributed/messages.jl
@@ -38,17 +38,17 @@ null_id(id) =  id == RRID(0, 0)
 struct CallMsg{Mode} <: AbstractMsg
     f::Function
     args::Tuple
-    kwargs::Array
+    kwargs
 end
 struct CallWaitMsg <: AbstractMsg
     f::Function
     args::Tuple
-    kwargs::Array
+    kwargs
 end
 struct RemoteDoMsg <: AbstractMsg
     f::Function
     args::Tuple
-    kwargs::Array
+    kwargs
 end
 struct ResultMsg <: AbstractMsg
     value::Any

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -634,26 +634,6 @@ function vector_any(@nospecialize xs...)
     a
 end
 
-function as_kwargs(xs::Union{AbstractArray,Associative})
-    n = length(xs)
-    to = Vector{Any}(uninitialized, n*2)
-    i = 1
-    for (k, v) in xs
-        to[i]   = k::Symbol
-        to[i+1] = v
-        i += 2
-    end
-    return to
-end
-
-function as_kwargs(xs)
-    to = Vector{Any}()
-    for (k, v) in xs
-        ccall(:jl_array_ptr_1d_push2, Void, (Any, Any, Any), to, k::Symbol, v)
-    end
-    return to
-end
-
 """
     invokelatest(f, args...; kwargs...)
 

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -406,7 +406,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
             return quote
                 local arg1 = $(esc(args[1]))
                 $(fcn)(Core.kwfunc(arg1),
-                       Tuple{Vector{Any}, Core.Typeof(arg1),
+                       Tuple{NamedTuple, Core.Typeof(arg1),
                              $(typesof)($(map(esc, args[2:end])...)).parameters...})
             end
         elseif ex0.head == :call

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -75,7 +75,7 @@ function arg_decl_parts(m::Method)
 end
 
 function kwarg_decl(m::Method, kwtype::DataType)
-    sig = rewrap_unionall(Tuple{kwtype, Core.AnyVector, unwrap_unionall(m.sig).parameters...}, m.sig)
+    sig = rewrap_unionall(Tuple{kwtype, NamedTuple, unwrap_unionall(m.sig).parameters...}, m.sig)
     kwli = ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), kwtype.name.mt, sig, typemax(UInt))
     if kwli !== nothing
         kwli = kwli::Method

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+if module_name(@__MODULE__) === :Base
+
 """
     NamedTuple{names,T}(args::Tuple)
 
@@ -25,16 +27,6 @@ function NamedTuple{names,T}(args::Tuple) where {names, T <: Tuple}
 end
 
 """
-    NamedTuple{names}(args::Tuple)
-
-Construct a named tuple with the given `names` (a tuple of Symbols) from a tuple of
-values.
-"""
-function NamedTuple{names}(args::Tuple) where {names}
-    NamedTuple{names,typeof(args)}(args)
-end
-
-"""
     NamedTuple{names}(nt::NamedTuple)
 
 Construct a named tuple by selecting fields in `names` (a tuple of Symbols) from
@@ -50,7 +42,7 @@ function NamedTuple{names}(nt::NamedTuple) where {names}
     end
 end
 
-NamedTuple() = NamedTuple{(),Tuple{}}(())
+end # if Base
 
 length(t::NamedTuple) = nfields(t)
 start(t::NamedTuple) = 1
@@ -60,6 +52,8 @@ endof(t::NamedTuple) = nfields(t)
 getindex(t::NamedTuple, i::Int) = getfield(t, i)
 getindex(t::NamedTuple, i::Symbol) = getfield(t, i)
 indexed_next(t::NamedTuple, i::Int, state) = (getfield(t, i), i+1)
+isempty(::NamedTuple{()}) = true
+isempty(::NamedTuple) = false
 
 convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names,T}) where {names,T} = nt
 convert(::Type{NamedTuple{names}}, nt::NamedTuple{names}) where {names} = nt
@@ -213,3 +207,32 @@ values(nt::NamedTuple) = Tuple(nt)
 haskey(nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key)
 get(nt::NamedTuple, key::Union{Integer, Symbol}, default) = haskey(nt, key) ? getfield(nt, key) : default
 get(f::Callable, nt::NamedTuple, key::Union{Integer, Symbol}) = haskey(nt, key) ? getfield(nt, key) : f()
+
+@pure function diff_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+    names = Symbol[]
+    for n in an
+        if !sym_in(n, bn)
+            push!(names, n)
+        end
+    end
+    (names...,)
+end
+
+"""
+    structdiff(a::NamedTuple{an}, b::Union{NamedTuple{bn},Type{NamedTuple{bn}}}) where {an,bn}
+
+Construct a copy of named tuple `a`, except with fields that exist in `b` removed.
+`b` can be a named tuple, or a type of the form `NamedTuple{field_names}`.
+"""
+function structdiff(a::NamedTuple{an}, b::Union{NamedTuple{bn}, Type{NamedTuple{bn}}}) where {an, bn}
+    if @generated
+        names = diff_names(an, bn)
+        types = Tuple{Any[ fieldtype(a, n) for n in names ]...}
+        vals = Any[ :(getfield(a, $(QuoteNode(n)))) for n in names ]
+        :( NamedTuple{$names,$types}(($(vals...),)) )
+    else
+        names = diff_names(an, bn)
+        types = Tuple{Any[ fieldtype(typeof(a), n) for n in names ]...}
+        NamedTuple{names,types}(map(n->getfield(a, n), names))
+    end
+end

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -311,14 +311,13 @@ function showerror(io::IO, ex::MethodError)
     ft = typeof(f)
     name = ft.name.mt.name
     f_is_function = false
-    kwargs = Any[]
+    kwargs = NamedTuple()
     if startswith(string(ft.name.name), "#kw#")
         f = ex.args[2]
         ft = typeof(f)
         name = ft.name.mt.name
         arg_types_param = arg_types_param[3:end]
-        temp = ex.args[1]
-        kwargs = Any[(temp[i*2-1], temp[i*2]) for i in 1:(length(temp) ÷ 2)]
+        kwargs = ex.args[1]
         ex = MethodError(f, ex.args[3:end])
     end
     if f == Base.convert && length(arg_types_param) == 2 && !is_arg_types
@@ -362,7 +361,7 @@ function showerror(io::IO, ex::MethodError)
         end
         if !isempty(kwargs)
             print(io, "; ")
-            for (i, (k, v)) in enumerate(kwargs)
+            for (i, (k, v)) in enumerate(pairs(kwargs))
                 print(io, k, "=")
                 show(IOContext(io, :limit => true), v)
                 i == length(kwargs) || print(io, ", ")
@@ -452,7 +451,7 @@ function showerror_nostdio(err, msg::AbstractString)
     ccall(:jl_printf, Cint, (Ptr{Void},Cstring), stderr_stream, "\n")
 end
 
-function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
+function show_method_candidates(io::IO, ex::MethodError, kwargs::NamedTuple = NamedTuple())
     is_arg_types = isa(ex.args, DataType)
     arg_types = is_arg_types ? ex.args : typesof(ex.args...)
     arg_types_param = Any[arg_types.parameters...]
@@ -582,7 +581,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::Vector=Any[])
                 if !isempty(kwargs)
                     unexpected = Symbol[]
                     if isempty(kwords) || !(any(endswith(string(kword), "...") for kword in kwords))
-                        for (k, v) in kwargs
+                        for (k, v) in pairs(kwargs)
                             if !(k in kwords)
                                 push!(unexpected, k)
                             end

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -517,14 +517,12 @@ function f(x; y=0, kwargs...)
 end
 ```
 
-Inside `f`, `kwargs` will be a collection of `(key,value)` tuples, where each `key` is a symbol.
-Such collections can be passed as keyword arguments using a semicolon in a call, e.g. `f(x, z=1; kwargs...)`.
-Dictionaries can also be used for this purpose.
+Inside `f`, `kwargs` will be a named tuple. Named tuples (as well as dictionaries) can be passed as
+keyword arguments using a semicolon in a call, e.g. `f(x, z=1; kwargs...)`.
 
-One can also pass `(key,value)` tuples, or any iterable expression (such as a `=>` pair) that
-can be assigned to such a tuple, explicitly after a semicolon. For example, `plot(x, y; (:width,2))`
-and `plot(x, y; :width => 2)` are equivalent to `plot(x, y, width=2)`. This is useful in situations
-where the keyword name is computed at runtime.
+One can also pass `key => value` expressions after a semicolon. For example, `plot(x, y; :width => 2)`
+is equivalent to `plot(x, y, width=2)`. This is useful in situations where the keyword name is computed
+at runtime.
 
 The nature of keyword arguments makes it possible to specify the same argument more than once.
 For example, in the call `plot(x, y; options..., width=2)` it is possible that the `options` structure

--- a/src/array.c
+++ b/src/array.c
@@ -1139,15 +1139,6 @@ JL_DLLEXPORT void jl_array_ptr_1d_append(jl_array_t *a, jl_array_t *a2)
     }
 }
 
-JL_DLLEXPORT void jl_array_ptr_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c)
-{
-    assert(jl_typeis(a, jl_array_any_type));
-    jl_array_grow_end(a, 2);
-    size_t n = jl_array_nrows(a);
-    jl_array_ptr_set(a, n - 2, b);
-    jl_array_ptr_set(a, n - 1, c);
-}
-
 JL_DLLEXPORT jl_value_t *(jl_array_data_owner)(jl_array_t *a)
 {
     return jl_array_data_owner(a);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -962,12 +962,12 @@ JL_CALLABLE(jl_f_invoke_kwsorter)
                                                       jl_nfields(argtypes));
     }
     if (jl_is_tuple_type(argtypes)) {
-        // construct a tuple type for invoking a keyword sorter by putting `Vector{Any}`
+        // construct a tuple type for invoking a keyword sorter by putting the kw container type
         // and the type of the function at the front.
         size_t i, nt = jl_nparams(argtypes) + 2;
         if (nt < jl_page_size/sizeof(jl_value_t*)) {
             jl_value_t **types = (jl_value_t**)alloca(nt*sizeof(jl_value_t*));
-            types[0] = jl_array_any_type; types[1] = jl_typeof(func);
+            types[0] = (jl_value_t*)jl_namedtuple_type; types[1] = jl_typeof(func);
             for(i=2; i < nt; i++)
                 types[i] = jl_tparam(argtypes,i-2);
             argtypes = (jl_value_t*)jl_apply_tuple_type_v(types, nt);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1239,7 +1239,6 @@ JL_DLLEXPORT void jl_array_grow_beg(jl_array_t *a, size_t inc);
 JL_DLLEXPORT void jl_array_del_beg(jl_array_t *a, size_t dec);
 JL_DLLEXPORT void jl_array_sizehint(jl_array_t *a, size_t sz);
 JL_DLLEXPORT void jl_array_ptr_1d_push(jl_array_t *a, jl_value_t *item);
-JL_DLLEXPORT void jl_array_ptr_1d_push2(jl_array_t *a, jl_value_t *b, jl_value_t *c);
 JL_DLLEXPORT void jl_array_ptr_1d_append(jl_array_t *a, jl_array_t *a2);
 JL_DLLEXPORT jl_value_t *jl_apply_array_type(jl_value_t *type, size_t dim);
 // property access

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -354,7 +354,7 @@ const valid_opt_types = [Bool, Bool, Bool, Bool, Bool, NTuple{2,Integer}, Char, 
 
 function val_opts(opts)
     d = Dict{Symbol,Union{Bool,NTuple{2,Integer},Char,Integer}}()
-    for (opt_name, opt_val) in opts
+    for (opt_name, opt_val) in pairs(opts)
         in(opt_name, valid_opts) ||
             throw(ArgumentError("unknown option $opt_name"))
         opt_typ = valid_opt_types[findfirst(equalto(opt_name), valid_opts)]

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -265,6 +265,7 @@ end
         pop!(need_to_handle_undef_sparam, which(Core.Inference.eltype, Tuple{Type{Tuple{Any}}}))
         @test_broken need_to_handle_undef_sparam == Set()
         pop!(need_to_handle_undef_sparam, which(Core.Inference.cat, Tuple{Any, AbstractArray}))
+        pop!(need_to_handle_undef_sparam, first(methods(Core.Inference.same_names)))
         @test need_to_handle_undef_sparam == Set()
     end
     let need_to_handle_undef_sparam =

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -188,14 +188,14 @@ function test4974(;kwargs...)
     end
 end
 
-@test test4974(a=1) == (2, [(:a, 1)])
+@test test4974(a=1) == (2, (a=1,))
 
 @testset "issue #7704, computed keywords" begin
-    @test kwf1(1; (:tens, 2)) == 21
+    @test kwf1(1; :tens => 2) == 21
     let p = (:hundreds, 3),
         q = (:tens, 1)
-        @test kwf1(0; p, q) == 310
-        @test kwf1(0; q, hundreds=4) == 410
+        @test kwf1(0; p[1]=>p[2], q[1]=>q[2]) == 310
+        @test kwf1(0; q[1]=>q[2], hundreds=4) == 410
     end
 end
 @testset "with anonymous functions, issue #2773" begin
@@ -304,7 +304,7 @@ end
     @test f(get_next(), a=get_next(), get_next(),
             b=get_next(), get_next(),
             [get_next(), get_next()]...; c=get_next(),
-            [(:d, get_next()), (:f, get_next())]...) ==
+            (d = get_next(), f = get_next())...) ==
                 ((1,3,5,6,7),
-                 Any[(:a,2), (:b,4), (:c,8), (:d,9), (:f,10)])
+                 (a = 2, b = 4, c = 8, d = 9, f = 10))
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -148,12 +148,12 @@ end
 
 c7line = @__LINE__() + 1
 method_c7(a, b; kargs...) = a
-Base.show_method_candidates(buf, MethodError(method_c7, (1, 1)), [(:x, 1), (:y, 2)])
+Base.show_method_candidates(buf, MethodError(method_c7, (1, 1)), (x = 1, y = 2))
 test_have_color(buf, "\e[0m\nClosest candidates are:\n  method_c7(::Any, ::Any; kargs...)$cfile$c7line\e[0m",
                      "\nClosest candidates are:\n  method_c7(::Any, ::Any; kargs...)$cfile$c7line")
 c8line = @__LINE__() + 1
 method_c8(a, b; y=1, w=1) = a
-Base.show_method_candidates(buf, MethodError(method_c8, (1, 1)), [(:x, 1), (:y, 2), (:z, 1), (:w, 1)])
+Base.show_method_candidates(buf, MethodError(method_c8, (1, 1)), (x = 1, y = 2, z = 1, w = 1))
 test_have_color(buf, "\e[0m\nClosest candidates are:\n  method_c8(::Any, ::Any; y, w)$cfile$c8line\e[1m\e[31m got unsupported keyword arguments \"x\", \"z\"\e[0m\e[0m",
                      "\nClosest candidates are:\n  method_c8(::Any, ::Any; y, w)$cfile$c8line got unsupported keyword arguments \"x\", \"z\"")
 
@@ -161,7 +161,7 @@ ac15639line = @__LINE__
 addConstraint_15639(c::Int32) = c
 addConstraint_15639(c::Int64; uncset=nothing) = addConstraint_15639(Int32(c), uncset=uncset)
 
-Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), [(:uncset, nothing)])
+Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), (uncset = nothing,))
 test_have_color(buf, "\e[0m\nClosest candidates are:\n  addConstraint_15639(::Int32)$cfile$(ac15639line + 1)\e[1m\e[31m got unsupported keyword argument \"uncset\"\e[0m\n  addConstraint_15639(\e[1m\e[31m::Int64\e[0m; uncset)$cfile$(ac15639line + 2)\e[0m",
                      "\nClosest candidates are:\n  addConstraint_15639(::Int32)$cfile$(ac15639line + 1) got unsupported keyword argument \"uncset\"\n  addConstraint_15639(!Matched::Int64; uncset)$cfile$(ac15639line + 2)")
 
@@ -536,7 +536,7 @@ foo_9965(x::Int) = 2x
     end
     @test typeof(ex) == MethodError
     io = IOBuffer()
-    Base.show_method_candidates(io, ex, [(:w,true)])
+    Base.show_method_candidates(io, ex, (w = true,))
     @test contains(String(take!(io)), "got unsupported keyword argument \"w\"")
 end
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -827,7 +827,7 @@ let f = function (x; kw...)
     g = function (x; a = 2)
             return (x, a)
         end
-    @test f(1) == (1, Any[])
+    @test f(1) == (1, NamedTuple())
     @test g(1) == (1, 2)
 end
 
@@ -1226,3 +1226,6 @@ end
     @test raw"x \\\" y" == "x \\\" y"
     @test raw"x \\\ y" == "x \\\\\\ y"
 end
+
+# issue #9972
+@test Meta.lower(@__MODULE__, :(f(;3))) == Expr(:error, "invalid keyword argument syntax \"3\"")


### PR DESCRIPTION
Same highly-biased benchmark as #21915 (~100x speedup):

```
julia> f(;kw...) = g(;kw...);

julia> g(;kw...) = kw;

julia> c = g(a=1,b=2);

julia> @time for i = 1:10000; f(a=1,b=2); end
  0.000010 seconds

julia> @time for i = 1:10000; f(;c...); end
  0.000577 seconds (20.00 k allocations: 625.000 KiB)
```

This also helps a lot towards #9551. The PR makes the lowering of keyword argument methods simpler and easier to optimize (note the net code deletion). In fact I think just a bit of constant propagation (#24362) on top of this will solve the problem entirely.

Also fixes #9972.
