### PR TITLE
RFC: appveyor ci: use pre-existing cygwin setup file (if present)

### DIFF
--- a/contrib/windows/install-cygwin.ps1
+++ b/contrib/windows/install-cygwin.ps1
@@ -1,8 +1,18 @@
 $setup = "setup-$env:ARCH.exe".Replace("i686", "x86")
+if ( $env:ARCH -eq "x86_64" ) {
+$cygwin = "C:\cygwin64"
+} else {
+$cygwin = "C:\cygwin"
+}
 
 mkdir -Force C:\cygdownloads | Out-Null
+if ( Test-Path "$cygwin\$setup" ) {
+Copy-Item "$cygwin\$setup" "C:\cygdownloads\$setup"
+} else {
 (new-object net.webclient).DownloadFile(
   "http://cygwin.com/$setup", "C:\cygdownloads\$setup")
+}
+
 & "C:\cygdownloads\$setup" -q -n -R C:\cygwin-$env:ARCH `
   -l C:\cygdownloads -s http://mirrors.kernel.org/sourceware/cygwin -g -I `
   -P "make,curl,time,p7zip,mingw64-$env:ARCH-gcc-g++,mingw64-$env:ARCH-gcc-fortran" | Where-Object `


### PR DESCRIPTION
The goal of this is to reduce the impact of network unreliability
to reach the https://cygwin.com server (observed fairly frequently of late).

We could also instead run this file through the caching server. Or reduce the fatality of the error (we likely have already downloaded the file locally, since it's part of the cache).