### PR TITLE
More specific methods to replace `join(args...)`

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -241,7 +241,10 @@ function join(io::IO, strings, delim)
     end
 end
 join(io::IO, strings) = join(io, strings, "")
-join(args...) = sprint(join, args...)
+
+join(strings) = sprint(join, strings)
+join(strings, delim) = sprint(join, strings, delim)
+join(strings, delim, last) = sprint(join, strings, delim, last)
 
 ## string escaping & unescaping ##
 

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -140,6 +140,7 @@ end
     @test join("HELLO",'-') == "H-E-L-L-O"
     @test join(1:5, ", ", " and ") == "1, 2, 3, 4 and 5"
     @test join(["apples", "bananas", "pineapples"], ", ", " and ") == "apples, bananas and pineapples"
+    @test_throws MethodError join(1, 2, 3, 4)
 end
 
 # issue #9178 `join` calls `done()` twice on the iterables


### PR DESCRIPTION
Fix #24433