### PR TITLE
Render URL and name of Markdown links in terminal

### DIFF
--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -134,7 +134,7 @@ end
 terminline(io::IO, f::Footnote) = with_output_format(:bold, terminline, io, "[^$(f.id)]")
 
 function terminline(io::IO, md::Link)
-    terminline(io, md.text)
+    terminline(io, "$(terminline(md.text)) ($(md.url))")
 end
 
 function terminline(io::IO, code::Code)

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -224,7 +224,7 @@ World""" |> plain == "Hello\n\n---\n\nWorld\n"
 
 # multiple whitespace is ignored
 @test sprint(term, md"a  b") == "  a b\n"
-@test sprint(term, md"[x](https://julialang.org)") == "  x\n"
+@test sprint(term, md"[x](https://julialang.org)") == "  x (https://julialang.org)\n"
 @test sprint(term, md"![x](https://julialang.org)") == "  (Image: x)\n"
 
 # enumeration is normalized


### PR DESCRIPTION
Currently links in docstrings are rendered like this:

`[Google](https://google.com)` -> `Google` which makes them unusable from the terminal.

This PR changes this to:

`[Google](https://google.com)` -> `Google (https://google.com)`