### PR TITLE
Remove default value 50 from linspace and logspace `n` arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1306,6 +1306,8 @@ Deprecated or removed
 
   * `EnvHash` has been renamed to `EnvDict` ([#24167]).
 
+  * `linspace` and `logspace` now require an explicit number of elements to be supplied rather than defaulting to `50`.
+
 Command-line option changes
 ---------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2132,6 +2132,9 @@ finalizer(f::Ptr{Void}, o::Function) = invoke(finalizer, Tuple{Ptr{Void}, Any}, 
     Base.@deprecate_binding broadcast_t broadcast false ", broadcast_t(f, ::Type{ElType}, shape, iter, As...)` should become `broadcast(f, Broadcast.DefaultArrayStyle{N}(), ElType, shape, As...))` (see the manual chapter Interfaces)"
 end
 
+# issue #24794
+@deprecate linspace(start, stop)     linspace(start, stop, 50)
+@deprecate logspace(start, stop)     logspace(start, stop, 50)
 
 # END 0.7 deprecations
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -232,7 +232,7 @@ function LinSpace(start, stop, len::Integer)
 end
 
 """
-    linspace(start, stop, n=50)
+    linspace(start, stop, n)
 
 Construct a range of `n` linearly spaced elements from `start` to `stop`.
 
@@ -241,8 +241,8 @@ julia> linspace(1.3,2.9,9)
 1.3:0.2:2.9
 ```
 """
-linspace(start, stop, len::Real=50) = linspace(promote(start, stop)..., Int(len))
-linspace(start::T, stop::T, len::Real=50) where {T} = linspace(start, stop, Int(len))
+linspace(start, stop, len::Real) = linspace(promote(start, stop)..., Int(len))
+linspace(start::T, stop::T, len::Real) where {T} = linspace(start, stop, Int(len))
 
 linspace(start::Real, stop::Real, len::Integer) = linspace(promote(start, stop)..., len)
 linspace(start::T, stop::T, len::Integer) where {T<:Integer} = linspace(Float64, start, stop, len, 1)
@@ -318,7 +318,7 @@ function print_range(io::IO, r::AbstractRange,
 end
 
 """
-    logspace(start::Real, stop::Real, n::Integer=50; base=10)
+    logspace(start::Real, stop::Real, n::Integer; base=10)
 
 Construct a vector of `n` logarithmically spaced numbers from `base^start` to `base^stop`.
 
@@ -340,7 +340,7 @@ julia> logspace(1.,10.,5,base=2)
  1024.0
 ```
 """
-logspace(start::Real, stop::Real, n::Integer=50; base=10) = base.^linspace(start, stop, n)
+logspace(start::Real, stop::Real, n::Integer; base=10) = base.^linspace(start, stop, n)
 
 ## interface implementations
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1139,7 +1139,7 @@ let r = @inferred(colon(big(1.0),big(2.0),big(5.0)))
 end
 
 @testset "issue #14420" begin
-    for r in (linspace(0.10000000000000045, 1), 0.10000000000000045:(1-0.10000000000000045)/49:1)
+    for r in (linspace(0.10000000000000045, 1, 50), 0.10000000000000045:(1-0.10000000000000045)/49:1)
         local r
         @test r[1] === 0.10000000000000045
         @test r[end] === 1.0
@@ -1191,11 +1191,9 @@ end
 
 @testset "logspace" begin
     n = 10; a = 2; b = 4
-    # test default values; n = 50, base = 10
-    @test logspace(a, b) == logspace(a, b, 50) == 10 .^ linspace(a, b, 50)
+    # test default values; base = 10
     @test logspace(a, b, n) == 10 .^ linspace(a, b, n)
     for base in (10, 2, ℯ)
-        @test logspace(a, b, base=base) == logspace(a, b, 50, base=base) == base.^linspace(a, b, 50)
         @test logspace(a, b, n, base=base) == base.^linspace(a, b, n)
     end
 end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1192,8 +1192,10 @@ end
 @testset "logspace" begin
     n = 10; a = 2; b = 4
     # test default values; base = 10
+    @test logspace(a, b, 50) == 10 .^ linspace(a, b, 50)
     @test logspace(a, b, n) == 10 .^ linspace(a, b, n)
     for base in (10, 2, ℯ)
+        @test logspace(a, b, 50, base=base) == base.^linspace(a, b, 50)
         @test logspace(a, b, n, base=base) == base.^linspace(a, b, n)
     end
 end


### PR DESCRIPTION
Fixes #24794.

