### PR TITLE
Add deprecation warning for reinterpret(::Type, ::ReinterpretArray, ::Dims)

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2033,6 +2033,7 @@ end
 # issue #22849
 @deprecate reinterpret(::Type{T}, a::Array{S}, dims::NTuple{N,Int}) where {T, S, N} reshape(reinterpret(T, vec(a)), dims)
 @deprecate reinterpret(::Type{T}, a::SparseMatrixCSC{S}, dims::NTuple{N,Int}) where {T, S, N} reinterpret(T, reshape(a, dims))
+@deprecate reinterpret(::Type{T}, a::ReinterpretArray{S}, dims::NTuple{N,Int}) where {T, S, N} reshape(reinterpret(T, vec(a)), dims)
 
 # issue #24006
 @deprecate linearindices(s::AbstractString) eachindex(s)


### PR DESCRIPTION
It may seem strange to add a deprecation warning for a type that didn't previously exist.
However, formerly `reinterpret` returned an `Array`, and you could call `reinterpret`
on the result again. Now, the first `reinterpret` call returns a `ReinterpretArray`,
and consequently a second `reinterpret` will throw an error.

This fixes the following:
```julia
julia> a = rand(Float32, 6)
6-element Array{Float32,1}:
 0.121465445f0
 0.05222106f0 
 0.0607363f0  
 0.29994643f0 
 0.73788464f0 
 0.18708313f0 

julia> b = reinterpret(Int32, a, (2, 3))
WARNING: reinterpret(::Type{T}, a::Array{S}, dims::NTuple{N, Int}) where {T, S, N} is deprecated, use reshape(reinterpret(T, vec(a)), dims) instead.
Stacktrace:
 [1] depwarn at ./deprecated.jl:68 [inlined]
 [2] reinterpret(::Type{Int32}, ::Array{Float32,1}, ::Tuple{Int64,Int64}) at ./deprecated.jl:56
 [3] top-level scope
 [4] eval(::Module, ::Expr) at ./repl/REPL.jl:3
 [5] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./repl/REPL.jl:69
 [6] macro expansion at /home/tim/.julia/v0.7/Revise/src/Revise.jl:447 [inlined]
 [7] (::getfield(Revise, Symbol("##15#16")){Base.REPL.REPLBackend})() at ./event.jl:95
in expression starting at no file:0
2×3 reshape(reinterpret(Int32, ::Array{Float32,1}), 2, 3) with eltype Int32:
 1039712992  1031325344  1060955650
 1029039552  1050251924  1044353720

julia> c = reinterpret(UInt32, b, (2, 3))
ERROR: MethodError: no method matching reinterpret(::Type{UInt32}, ::Base.ReinterpretArray{Int32,1,Float32,Array{Float32,1}}, ::Tuple{Int64,Int64})
Closest candidates are:
  reinterpret(::Type{T}, ::Base.ReshapedArray, ::Tuple{Vararg{Int64,N}} where N) where T at reshapedarray.jl:181
  reinterpret(::Type{T}, ::SparseMatrixCSC{S,Ti} where Ti<:Integer, ::Tuple{Vararg{Int64,N}}) where {T, S, N} at deprecated.jl:55
  reinterpret(::Type{T}, ::Array{S,N} where N, ::Tuple{Vararg{Int64,N}}) where {T, S, N} at deprecated.jl:55
  ...
Stacktrace:
 [1] reinterpret(::Type{UInt32}, ::Base.ReshapedArray{Int32,2,Base.ReinterpretArray{Int32,1,Float32,Array{Float32,1}},Tuple{}}, ::Tuple{Int64,Int64}) at ./reshapedarray.jl:181
 [2] top-level scope
```
I didn't add a test because we don't usually test deprecation warnings.