### PR TITLE
REPL: reference the global MIState as a LineEditREPL field

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -15,7 +15,7 @@ abstract type ModeState end
 export run_interface, Prompt, ModalInterface, transition, reset_state, edit_insert, keymap
 
 struct ModalInterface <: TextInterface
-    modes::Array{Base.LineEdit.TextInterface,1}
+    modes::Vector{TextInterface}
 end
 
 mutable struct Prompt <: TextInterface
@@ -2148,8 +2148,8 @@ function init_state(terminal, m::ModalInterface)
     s
 end
 
-function run_interface(terminal, m::ModalInterface)
-    s::MIState = init_state(terminal, m)
+
+function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=init_state(terminal, m))
     while !s.aborted
         buf, ok, suspend = prompt!(terminal, m, s)
         while suspend
@@ -2233,7 +2233,7 @@ keymap_data(s::PromptState, prompt::Prompt) = prompt.repl
 keymap(ms::MIState, m::ModalInterface) = keymap(state(ms), mode(ms))
 keymap_data(ms::MIState, m::ModalInterface) = keymap_data(state(ms), mode(ms))
 
-function prompt!(term, prompt, s = init_state(term, prompt))
+function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_state(term, prompt))
     Base.reseteof(term)
     raw!(term, true)
     enable_bracketed_paste(term)

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -33,7 +33,8 @@ import ..LineEdit:
     history_last,
     history_search,
     accept_result,
-    terminal
+    terminal,
+    MIState
 
 abstract type AbstractREPL end
 
@@ -273,11 +274,12 @@ mutable struct LineEditREPL <: AbstractREPL
     waserror::Bool
     specialdisplay::Union{Void,Display}
     options::Options
+    mistate::Union{MIState,Void}
     interface::ModalInterface
     backendref::REPLBackendRef
     LineEditREPL(t,hascolor,prompt_color,input_color,answer_color,shell_color,help_color,history_file,in_shell,in_help,envcolors) =
         new(t,true,prompt_color,input_color,answer_color,shell_color,help_color,history_file,in_shell,
-            in_help,envcolors,false,nothing, Options())
+            in_help,envcolors,false,nothing, Options(), nothing)
 end
 outstream(r::LineEditREPL) = r.t
 specialdisplay(r::LineEditREPL) = r.specialdisplay
@@ -985,7 +987,8 @@ function run_frontend(repl::LineEditREPL, backend::REPLBackendRef)
         interface = repl.interface
     end
     repl.backendref = backend
-    run_interface(repl.t, interface)
+    repl.mistate = LineEdit.init_state(terminal(repl), interface)
+    run_interface(terminal(repl), interface, repl.mistate)
     dopushdisplay && popdisplay(d)
 end
 


### PR DESCRIPTION
Supersedes #24735 (cc. @staticfloat). As far as I'm concerned, I find this useful for debugging purposes when hacking the REPL code, but other people seem to need it too. 
@davidanthoff could you confirm this version fits the bill for you?