### PR TITLE
REPL: ask for confirmation before exiting with ^D

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1880,6 +1880,16 @@ function edit_insert_tab(buf::IOBuffer, jump_spaces=false, delete_trailing=jump_
     return true
 end
 
+function edit_abort(s, confirm::Bool=options(s).confirm_exit; key="^D")
+    set_action!(s, :edit_abort)
+    if !confirm || s.last_action == :edit_abort
+        println(terminal(s))
+        :abort
+    else
+        println("Type $key again to exit.\n")
+        refresh_line(s)
+    end
+end
 
 const default_keymap =
 AnyDict(
@@ -1906,8 +1916,7 @@ AnyDict(
         if buffer(s).size > 0
             edit_delete(s)
         else
-            println(terminal(s))
-            return :abort
+            edit_abort(s)
         end
     end,
     # Ctrl-Space

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -81,7 +81,14 @@ mutable struct PromptState <: ModeState
     beeping::Float64
 end
 
-options(s::PromptState) = isdefined(s.p, :repl) ? s.p.repl.options : Base.REPL.Options()
+options(s::PromptState) =
+    if isdefined(s.p, :repl) && isdefined(s.p.repl, :options)
+        # we can't test isa(s.p.repl, LineEditREPL) as LineEditREPL is defined
+        # in the REPL module
+        s.p.repl.options
+    else
+        Base.REPL.Options(confirm_exit=false)
+    end
 
 function setmark(s::MIState, guess_region_active::Bool=true)
     guess_region_active && activate_region(s, s.key_repeats > 0)

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -248,13 +248,15 @@ mutable struct Options
     extra_keymap::Union{Dict,Vector{<:Dict}}
     backspace_align::Bool
     backspace_adjust::Bool
+    confirm_exit::Bool # ^D must be repeated to confirm exit
 end
 
 Options(;
         hascolor = true,
         extra_keymap = AnyDict[],
-        backspace_align = true, backspace_adjust = backspace_align) =
-            Options(hascolor, extra_keymap, backspace_align, backspace_adjust)
+        backspace_align = true, backspace_adjust = backspace_align,
+        confirm_exit = true) =
+            Options(hascolor, extra_keymap, backspace_align, backspace_adjust, confirm_exit)
 
 ## LineEditREPL ##
 

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -8,7 +8,7 @@ isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__),
 using Main.TestHelpers
 import Base: REPL, LineEdit
 
-function fake_repl(f)
+function fake_repl(f; options::REPL.Options=REPL.Options(confirm_exit=false))
     # Use pipes so we can easily do blocking reads
     # In the future if we want we can add a test that the right object
     # gets displayed by intercepting the display
@@ -20,6 +20,8 @@ function fake_repl(f)
     Base.link_pipe(stderr, julia_only_read=true, julia_only_write=true)
 
     repl = Base.REPL.LineEditREPL(TestHelpers.FakeTerminal(stdin.out, stdout.in, stderr.in), true)
+    repl.options = options
+
     f(stdin.in, stdout.out, repl)
     t = @async begin
         close(stdin.in)


### PR DESCRIPTION
As `^D` is easy to type by mistake, in particular as it's also the binding to delete a character, let's ask for confirmation when it's pressed:
```julia
julia> Type ^D again to exit.

julia>
```
This is customizable via `REPL.Options.confirm_exit`.

(this was made easy to implement thanks the first commit in #24725, where the REPL state records the last "action" and can recognize when it's repeated; note that the `key_repeats` variable was not enough, as `^D` does two things, so the REPL would exit directly if the 1st `^D` deletes a character and the 2nd requests exit). 
