### PR TITLE
unmerge Base.merge! and LibGit2.merge!

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2137,6 +2137,8 @@ end
 @deprecate linspace(start, stop)     linspace(start, stop, 50)
 @deprecate logspace(start, stop)     logspace(start, stop, 50)
 
+@deprecate merge!(repo::LibGit2.GitRepo, args...; kwargs...) LibGit2.merge!(repo, args...; kwargs...)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -5,7 +5,7 @@ Interface to [libgit2](https://libgit2.github.com/).
 """
 module LibGit2
 
-import Base: merge!, ==
+import Base: ==
 
 export with, GitRepo, GitConfig
 


### PR DESCRIPTION
LibGit2's `merge!` is not really the same meaning as Base's, which I think should mostly concern data structures (`Associative`). LibGit2 imports Base's `merge!` since #11196, but I can't find there a discution about this point. It may not be so important, but it really clutters `merge!`'s help, and I believe most users are not concerned by LibGit2.