### PR TITLE
Use reverse iteration protocol in `mapfoldr_impl`

### DIFF
--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -404,3 +404,6 @@ test18695(r) = sum( t^2 for t in r )
 # test neutral element not picked incorrectly for &, |
 @test @inferred(foldl(&, Int[1])) === 1
 @test_throws ArgumentError foldl(&, Int[])
+
+# issue #24823
+@test foldr(Pair, 0, Iterators.filter(iseven, 1:6)) === foldr(Pair, 0, 2:2:6) === (2=>(4=>(6=>0)))


### PR DESCRIPTION
This PR addresses the issue #24823. I replace the `getindex` and `endof` by the reverse iteration protocol in the function `mapfoldr_impl`.