### PR TITLE
WIP/RFC: add push function: non-mutable counterpart of push!

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -875,12 +875,17 @@ end
 
 
 """
+    copymutable(a::AbstractArray) -> AbstractArray
+    copymutable(a::AbstractSet)   -> AbstractSet
+    copymutable(a::AbstractDict)  -> AbstractDict
     copymutable(a)
 
-Make a mutable copy of an array or iterable `a`.  For `a::Array`,
-this is equivalent to `copy(a)`, but for other array types it may
-differ depending on the type of `similar(a)`.  For generic iterables
-this is equivalent to `collect(a)`.
+Make a mutable copy of a collection `a`. For mutable collections,
+this is in general equivalent to `copy(a)`, but not necessarily
+(it depends on the type of `similar(a)` for arrays).
+If `a::Union{AbstractArray,AbstractSet,AbstractDict}`, the copy is an instance
+of the same abstract collection type.
+For generic iterables this is equivalent to `collect(a)`.
 
 # Examples
 ```jldoctest
@@ -898,7 +903,21 @@ function copymutable(a::AbstractArray)
     @_propagate_inbounds_meta
     copyto!(similar(a), a)
 end
-copymutable(itr) = collect(itr)
+copymutable(itr) = ismutable(itr) ? copy(itr) : collect(itr)
+
+"""
+    ismutable(T)
+
+Predicate on the mutability of a collection of type `T`, which defaults to `false`.
+If `ismutable(T)` is `true`, `copy(::T)` must be defined.
+The definition `ismutable(x) = ismutable(typeof(x))` is provided for convenience so
+that instances can be passed instead of types. However the form that accepts a type
+argument should be defined for new types.
+"""
+ismutable(::Type) = false
+ismutable(a) = ismutable(typeof(a))
+
+ismutable(::Type{<:Array}) = true
 
 zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -643,6 +643,8 @@ length(d::IdDict) = d.count
 
 copy(d::IdDict) = typeof(d)(d)
 
+ismutable(::Type{<:IdDict}) = true
+
 get!(d::IdDict{K,V}, @nospecialize(key), @nospecialize(default)) where {K, V} = (d[key] = get(d, key, default))::V
 
 function get(default::Callable, d::IdDict{K,V}, @nospecialize(key)) where {K, V}
@@ -679,7 +681,7 @@ end
 IdSet{T}(itr) where {T} = union!(IdSet{T}(), itr)
 IdSet() = IdSet{Any}()
 
-copymutable(s::IdSet) = typeof(s)(s)
+ismutable(::Type{<:IdSet}) = true
 copy(s::IdSet) = typeof(s)(s)
 
 isempty(s::IdSet) = isempty(s.dict)

--- a/base/array.jl
+++ b/base/array.jl
@@ -828,6 +828,7 @@ _deleteat!(a::Vector, i::Integer, delta::Integer) =
     push!(collection, items...) -> collection
 
 Insert one or more `items` at the end of `collection`.
+See also the non-mutating variant [`push`](@ref).
 
 # Examples
 ```jldoctest
@@ -867,6 +868,9 @@ end
 Create a new collection containing all the elements from `coll` (in the same order
 for ordered collections) plus the provided new `items` (inserted at the end
 for ordered collections).
+The type of the returned collection may differ from that of `coll` if
+`coll` is immutable.
+See also the mutating variant [`push!`](@ref).
 
 # Examples
 ```jldoctest
@@ -884,10 +888,7 @@ julia> a
  2
 ```
 """
-function push end
-
-push(a::Union{Vector,Associative,AbstractSet}, item) = push!(copy(a), item)
-push(a::Union{Vector,Associative,AbstractSet}, items...) = push!(copy(a), items...)
+push(a, items...) = push!(copymutable(a), items...)
 
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -1100,6 +1100,7 @@ end
     pushfirst!(collection, items...) -> collection
 
 Insert one or more `items` at the beginning of `collection`.
+See also the non-mutating variant [`pushfirst`](@ref).
 
 # Examples
 ```jldoctest
@@ -1119,6 +1120,40 @@ function pushfirst!(a::Array{T,1}, item) where T
     a[1] = item
     return a
 end
+
+
+"""
+    pushfirst(coll, items...) -> collection
+
+Create a new collection containing all the elements from an ordered collection `coll`
+plus the provided new `items` (inserted at the end).
+The type of the returned collection may differ from that of `coll` if
+`coll` is immutable.
+See also the mutating variant [`pushfirst!`](@ref).
+
+Insert one or more `items` at the beginning of `collection`.
+See also the mutating variant [`pushfirst!`](@ref).
+
+# Examples
+```jldoctest
+julia> a = [1, 2, 3, 4]; pushfirst(a, 5, 6)
+6-element Array{Int64,1}:
+ 5
+ 6
+ 1
+ 2
+ 3
+ 4
+
+julia> a
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+```
+"""
+pushfirst(a, items...) = push!(copymutable(a), items...)
 
 """
     popfirst!(collection) -> item

--- a/base/array.jl
+++ b/base/array.jl
@@ -862,6 +862,35 @@ function push!(a::Array{Any,1}, @nospecialize item)
 end
 
 """
+    push(coll, items...)
+
+Create a new collection containing all the elements from `coll` (in the same order
+for ordered collections) plus the provided new `items` (inserted at the end
+for ordered collections).
+
+# Examples
+```jldoctest
+julia> a = [1, 2]; push(a, 3, 4)
+
+4-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+
+julia> a
+2-element Array{Int64,1}:
+ 1
+ 2
+```
+"""
+function push end
+
+push(a::Union{Vector,Associative,AbstractSet}, item) = push!(copy(a), item)
+push(a::Union{Vector,Associative,AbstractSet}, items...) = push!(copy(a), items...)
+
+
+"""
     append!(collection, collection2) -> collection.
 
 Add the elements of `collection2` to the end of `collection`.

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -805,7 +805,7 @@ function get(dict::ImmutableDict, key, default)
 end
 
 push(dict::ImmutableDict, KV::Pair) = ImmutableDict(dict, KV)
-push(dict::ImmutableDict, KVs::Pair...) = foldl(push, dict, KVs)
+push(dict::ImmutableDict, KVs::Pair...) = foldl(push, KVs, init=dict)
 
 # this actually defines reverse iteration (e.g. it should not be used for merge/copy/filter type operations)
 function iterate(d::ImmutableDict{K,V}, t=d) where {K, V}

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -118,6 +118,11 @@ Dict() = Dict{Any,Any}()
 Dict(kv::Tuple{}) = Dict()
 copy(d::Dict) = Dict(d)
 
+# Dict is the default mutable fall-back
+copymutable(d::AbstractDict{K,V}) where {K,V} = ismutable(d) ? copy(d) : Dict{K,V}(d)
+
+ismutable(::Type{<:Dict}) = true
+
 const AnyDict = Dict{Any,Any}
 
 Dict(ps::Pair{K,V}...) where {K,V} = Dict{K,V}(ps)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -777,6 +777,9 @@ function get(dict::ImmutableDict, key, default)
     return default
 end
 
+push(dict::ImmutableDict, KV::Pair) = ImmutableDict(dict, KV)
+push(dict::ImmutableDict, KVs::Pair...) = foldl(push, dict, KVs)
+
 # this actually defines reverse iteration (e.g. it should not be used for merge/copy/filter type operations)
 function iterate(d::ImmutableDict{K,V}, t=d) where {K, V}
     !isdefined(t, :parent) && return nothing

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -637,6 +637,7 @@ end
     delete!(collection, key)
 
 Delete the element with the given key in a collection, and return the collection.
+See also the non-mutating variant [`delete`](@ref).
 
 # Examples
 ```jldoctest
@@ -667,6 +668,7 @@ Create and return a new collection containing all the elements from `coll`
 with key different from `k`.
 The type of the returned collection may differ from that of `coll` if
 `coll` is immutable.
+See also the mutating variant [`delete!`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -636,7 +636,7 @@ end
 """
     delete!(collection, key)
 
-Delete the mapping for the given key in a collection, and return the collection.
+Delete the element with the given key in a collection, and return the collection.
 
 # Examples
 ```jldoctest
@@ -659,6 +659,33 @@ function delete!(h::Dict, key)
     end
     return h
 end
+
+"""
+    delete(coll, k)
+
+Create and return a new collection containing all the elements from `coll`
+with key different from `k`.
+The type of the returned collection may differ from that of `coll` if
+`coll` is immutable.
+
+# Examples
+```jldoctest
+julia> d = Dict("a"=>1, "b"=>2)
+Dict{String,Int64} with 2 entries:
+  "b" => 2
+  "a" => 1
+
+julia> delete(d, "b")
+Dict{String,Int64} with 1 entry:
+  "a" => 1
+
+julia> d
+Dict{String,Int64} with 2 entries:
+  "b" => 2
+  "a" => 1
+```
+"""
+delete(coll, k) = delete!(copymutable(coll), k)
 
 function skip_deleted(h::Dict, i)
     L = length(h.slots)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -467,6 +467,7 @@ export
     pop!,
     prepend!,
     push!,
+    push,
     resize!,
     popfirst!,
     pushfirst!,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -482,6 +482,7 @@ export
     collect,
     count,
     delete!,
+    delete,
     deleteat!,
     eltype,
     empty!,

--- a/base/set.jl
+++ b/base/set.jl
@@ -56,10 +56,12 @@ end
 
 delete!(s::Set, x) = (delete!(s.dict, x); s)
 
-copy(s::Set) = copymutable(s)
+copy(s::Set) = typeof(s)(s)
 
 # Set is the default mutable fall-back
-copymutable(s::AbstractSet{T}) where {T} = Set{T}(s)
+copymutable(s::AbstractSet{T}) where {T} = ismutable(s) ? copy(s) : Set{T}(s)
+
+ismutable(::Type{<:Set}) = true
 
 sizehint!(s::Set, newsz) = (sizehint!(s.dict, newsz); s)
 empty!(s::Set) = (empty!(s.dict); s)

--- a/base/show.jl
+++ b/base/show.jl
@@ -269,6 +269,7 @@ short
 ```
 """
 IOContext(io::IO, KV::Pair, KVs::Pair...) = IOContext(IOContext(io, KV), KVs...)
+push(io::IO, KVs::Pair...) = IOContext(io, KVs...)
 
 show(io::IO, ctx::IOContext) = (print(io, "IOContext("); show(io, ctx.io); print(io, ")"))
 

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -205,6 +205,7 @@ Base.get!(::Any, ::Any, ::Any)
 Base.get!(::Function, ::Any, ::Any)
 Base.getkey
 Base.delete!
+Base.delete
 Base.pop!(::Any, ::Any, ::Any)
 Base.keys
 Base.values
@@ -266,8 +267,10 @@ Partially implemented by:
 
 ```@docs
 Base.push!
+Base.push
 Base.pop!
 Base.pushfirst!
+Base.pushfirst
 Base.popfirst!
 Base.insert!
 Base.deleteat!

--- a/doc/src/manual/style-guide.md
+++ b/doc/src/manual/style-guide.md
@@ -112,7 +112,7 @@ end
 
 Julia Base uses this convention throughout and contains examples of functions
 with both copying and modifying forms (e.g., [`sort`](@ref) and [`sort!`](@ref)), and others
-which are just modifying (e.g., [`push!`](@ref), [`pop!`](@ref), [`splice!`](@ref)).  It
+which are just modifying (e.g., [`pop!`](@ref), [`splice!`](@ref)).  It
 is typical for such functions to also return the modified array for convenience.
 
 ## Avoid strange type `Union`s


### PR DESCRIPTION
This is for
1. a bit of convenience for `IOContext`. I always found it a bit strange to describe `IOContext` as an immutable dictionary, but to not have a way to push elements to if without calling its constructor, so now we can do `push(io, :compact => true)` instead of `IOContext(io, :compact => true)`;
2. and to claim `push` in base (i.e. set/reserve the meaning, for use by package implementing immutable data structures, see e.g. https://github.com/JuliaCollections/FunctionalCollections.jl/); few more functions could be added, like `pop` and `append`.
 
