### PR TITLE
push Base.push! and LibGit2.push! apart

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2353,6 +2353,8 @@ end
 @deprecate logspace(start, stop)     logspace(start, stop, 50)
 
 @deprecate merge!(repo::LibGit2.GitRepo, args...; kwargs...) LibGit2.merge!(repo, args...; kwargs...)
+@deprecate push!(w::LibGit2.GitRevWalker, arg) LibGit2.push!(w, arg)
+
 
 # 24490 - warnings and messages
 const log_info_to = Dict{Tuple{Union{Module,Nothing},Union{Symbol,Nothing}},IO}()

--- a/base/libgit2/callbacks.jl
+++ b/base/libgit2/callbacks.jl
@@ -343,7 +343,7 @@ end
 function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
                         oid_ptr::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Cvoid})
     fhead_vec = unsafe_pointer_to_objref(payload)::Vector{FetchHead}
-    push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url),
+    Base.push!(fhead_vec, FetchHead(unsafe_string(ref_name), unsafe_string(remote_url),
         unsafe_load(oid_ptr), is_merge == 1))
     return Cint(0)
 end

--- a/base/libgit2/commit.jl
+++ b/base/libgit2/commit.jl
@@ -113,7 +113,7 @@ function commit(repo::GitRepo, msg::AbstractString;
     # Retrieve parents from HEAD
     if isempty(parent_ids)
         try # if throws then HEAD not found -> empty repo
-            push!(parent_ids, GitHash(repo, refname))
+            Base.push!(parent_ids, GitHash(repo, refname))
         end
     end
 
@@ -127,7 +127,7 @@ function commit(repo::GitRepo, msg::AbstractString;
     parents = GitCommit[]
     try
         for id in parent_ids
-            push!(parents, GitCommit(repo, id))
+            Base.push!(parents, GitCommit(repo, id))
         end
         commit_id = commit(repo, refname, msg, auth_sig, comm_sig, tree, parents...)
     finally

--- a/base/libgit2/gitcredential.jl
+++ b/base/libgit2/gitcredential.jl
@@ -227,7 +227,7 @@ function credential_helpers(cfg::GitConfig, cred::GitCredential)
             return GitCredentialHelper[]
         end
 
-        push!(helpers, parse(GitCredentialHelper, value))
+        Base.push!(helpers, parse(GitCredentialHelper, value))
     end
 
     return helpers

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -206,7 +206,7 @@ function diff_files(repo::GitRepo, branch1::AbstractString, branch2::AbstractStr
             delta = diff[i]
             delta === nothing && break
             if Consts.DELTA_STATUS(delta.status) in filter
-                push!(files, unsafe_string(delta.new_file.path))
+                Base.push!(files, unsafe_string(delta.new_file.path))
             end
         end
         close(diff)

--- a/base/libgit2/reference.jl
+++ b/base/libgit2/reference.jl
@@ -350,7 +350,7 @@ function Base.map(f::Function, bi::GitBranchIter)
         if res === nothing
             res = Vector{typeof(val)}()
         end
-        push!(res, val)
+        Base.push!(res, val)
         val, s = next(bi, s)
     end
     return res

--- a/base/libgit2/utils.jl
+++ b/base/libgit2/utils.jl
@@ -71,7 +71,7 @@ function features()
     feat = ccall((:git_libgit2_features, :libgit2), Cint, ())
     res = Consts.GIT_FEATURE[]
     for f in instances(Consts.GIT_FEATURE)
-        isset(feat, Cuint(f)) && push!(res, f)
+        isset(feat, Cuint(f)) && Base.push!(res, f)
     end
     return res
 end

--- a/base/libgit2/walker.jl
+++ b/base/libgit2/walker.jl
@@ -64,12 +64,12 @@ Start the [`GitRevWalker`](@ref) `walker` at commit `cid`. This function can be 
 to apply a function to all commits since a certain year, by passing the first commit
 of that year as `cid` and then passing the resulting `w` to [`map`](@ref LibGit2.map).
 """
-function Base.push!(w::GitRevWalker, cid::GitHash)
+function push!(w::GitRevWalker, cid::GitHash)
     @check ccall((:git_revwalk_push, :libgit2), Cint, (Ptr{Cvoid}, Ptr{GitHash}), w.ptr, Ref(cid))
     return w
 end
 
-function Base.push!(w::GitRevWalker, range::AbstractString)
+function push!(w::GitRevWalker, range::AbstractString)
     @check ccall((:git_revwalk_push_range, :libgit2), Cint, (Ptr{Cvoid}, Ptr{UInt8}), w.ptr, range)
     return w
 end
@@ -126,7 +126,7 @@ function Base.map(f::Function, walker::GitRevWalker;
     repo = repository(walker)
     while !done(walker, s)
         val = f(s[1], repo)
-        push!(res, val)
+        Base.push!(res, val)
         val, s = next(walker, s)
         c +=1
         count == c && break


### PR DESCRIPTION
I just noticed that #24818 was incomplete while working on another PR: I know little about `LibGit2`, but its `push!` seems quite different from Base's. I also noticed 3 other functions for which the same serparation could be done, but I'm not sure, so I ask for feedback about them: `count`, `map`, `split`. LibGit2 may legitimately extend base functions in this case, the only "problem" is that it clutters the documentation at the REPL (not importing this module would solve this problem, but I guess it's not doable). 