### PR TITLE
default PROFILE_JL_THREADING to off

### DIFF
--- a/src/threading.h
+++ b/src/threading.h
@@ -11,7 +11,7 @@ extern "C" {
 #include "threadgroup.h"
 #include "julia.h"
 
-#define PROFILE_JL_THREADING            1
+#define PROFILE_JL_THREADING            0
 
 // thread ID
 extern jl_ptls_t *jl_all_tls_states;


### PR DESCRIPTION
following the discussion on [discourse](https://discourse.julialang.org/t/thread-overhead-variability-across-machines/7320)
this disables `PROFILE_JL_THREADING` which can cause latency.