### PR TITLE
RFC: deprecate `rethrow()`, add 2-argument `throw(e, bt)`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2150,6 +2150,11 @@ end
 
 @deprecate merge!(repo::LibGit2.GitRepo, args...; kwargs...) LibGit2.merge!(repo, args...; kwargs...)
 
+function rethrow()
+    depwarn("`rethrow()` is deprecated in favor of `rethrow(err)` or `throw(err, backtrace)`.", :rethrow)
+    ccall(:jl_rethrow, Bottom, ())
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/event.jl
+++ b/base/event.jl
@@ -47,9 +47,9 @@ function wait(c::Condition)
 
     try
         return wait()
-    catch
+    catch ex
         filter!(x->x!==ct, c.waitq)
-        rethrow()
+        rethrow(ex)
     end
 end
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -118,7 +118,7 @@ function mkpath(path::AbstractString, mode::Unsigned=0o777)
         if isa(err, SystemError) && isdir(path)
             return
         else
-            rethrow()
+            rethrow(err)
         end
     end
 end
@@ -147,7 +147,7 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
             if force && isa(err, UVError) && err.code==Base.UV_ENOENT
                 return
             end
-            rethrow()
+            rethrow(err)
         end
     else
         if recursive

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -528,7 +528,7 @@ function add_tfunc(f::Function, minarg::Int, maxarg::Int, @nospecialize(tfunc), 
     push!(t_ffunc_cost, cost)
 end
 
-add_tfunc(throw, 1, 1, (@nospecialize(x)) -> Bottom, 0)
+add_tfunc(throw, 1, 2, (@nospecialize(x...)) -> Bottom, 0)
 
 # the inverse of typeof_tfunc
 # returns (type, isexact)

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -636,9 +636,9 @@ else
         if downloadcmd == :wget
             try
                 run(`wget -O $filename $url`)
-            catch
+            catch e
                 rm(filename)  # wget always creates a file
-                rethrow()
+                rethrow(e)
             end
         elseif downloadcmd == :curl
             run(`curl -g -L -f -o $filename $url`)

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -276,7 +276,7 @@ function fetch(repo::GitRepo; remote::AbstractString="origin",
         if isa(err, GitError) && err.code == Error.EAUTH
             reject(payload)
         end
-        rethrow()
+        rethrow(err)
     finally
         close(rmt)
     end
@@ -318,7 +318,7 @@ function push(repo::GitRepo; remote::AbstractString="origin",
         if isa(err, GitError) && err.code == Error.EAUTH
             reject(payload)
         end
-        rethrow()
+        rethrow(err)
     finally
         close(rmt)
     end
@@ -538,7 +538,7 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
             if isa(err, GitError) && err.code == Error.EAUTH
                 reject(payload)
             end
-            rethrow()
+            rethrow(err)
         end
     end
     approve(payload)
@@ -902,9 +902,9 @@ state of `repo` will not be corrupted.
 """
 function transact(f::Function, repo::GitRepo)
     state = snapshot(repo)
-    try f(repo) catch
+    try f(repo) catch e
         restore(state, repo)
-        rethrow()
+        rethrow(e)
     finally
         close(repo)
     end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -442,7 +442,7 @@ function _require(mod::Symbol)
             return
         catch ex
             if doneprecompile === true || JLOptions().use_compiled_modules == 0 || !precompilableerror(ex, true)
-                rethrow() # rethrow non-precompilable=true errors
+                rethrow(ex) # rethrow non-precompilable=true errors
             end
             # the file requested `__precompile__`, so try to build a cache file and use that
             cachefile = compilecache(mod)

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -283,7 +283,7 @@ function display(x)
                 return display(displays[i], x)
             catch e
                 isa(e, MethodError) && e.f in (display, show) ||
-                    rethrow()
+                    rethrow(e)
             end
         end
     end
@@ -297,7 +297,7 @@ function display(m::MIME, x)
                 return display(displays[i], m, x)
             catch e
                 isa(e, MethodError) && e.f == display ||
-                    rethrow()
+                    rethrow(e)
             end
         end
     end
@@ -342,7 +342,7 @@ function redisplay(x)
                 return redisplay(displays[i], x)
             catch e
                 isa(e, MethodError) && e.f in (redisplay, display, show) ||
-                    rethrow()
+                    rethrow(e)
             end
         end
     end
@@ -356,7 +356,7 @@ function redisplay(m::Union{MIME,AbstractString}, x)
                 return redisplay(displays[i], m, x)
             catch e
                 isa(e, MethodError) && e.f in (redisplay, display) ||
-                    rethrow()
+                    rethrow(e)
             end
         end
     end

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -220,7 +220,7 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
                     hit_eof = true
                     break
                 else
-                    rethrow()
+                    rethrow(e)
                 end
             end
             ast = Base.parse_input_line(line)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -434,8 +434,11 @@ JL_CALLABLE(jl_f_typeassert)
 
 JL_CALLABLE(jl_f_throw)
 {
-    JL_NARGS(throw, 1, 1);
-    jl_throw(args[0]);
+    JL_NARGS(throw, 1, 2);
+    if (nargs == 2)
+        jl_throw_with_bt(args[0], args[1]);
+    else
+        jl_throw(args[0]);
     return jl_nothing;
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1552,6 +1552,7 @@ JL_DLLEXPORT void jl_switchto(jl_task_t **pt);
 JL_DLLEXPORT void JL_NORETURN jl_throw(jl_value_t *e);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow(void);
 JL_DLLEXPORT void JL_NORETURN jl_rethrow_other(jl_value_t *e);
+JL_DLLEXPORT void JL_NORETURN jl_throw_with_bt(jl_value_t *e, jl_value_t *bt);
 JL_DLLEXPORT void JL_NORETURN jl_no_exc_handler(jl_value_t *e);
 
 #include "locks.h"   // requires jl_task_t definition

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -700,7 +700,8 @@ size_t rec_backtrace_ctx(uintptr_t *data, size_t maxsize, bt_context_t *ctx);
 #ifdef LIBOSXUNWIND
 size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize, bt_context_t *ctx);
 #endif
-JL_DLLEXPORT void jl_get_backtrace(jl_array_t **bt, jl_array_t **bt2);
+JL_DLLEXPORT void jl_get_backtrace(jl_value_t **bt, jl_value_t **bt2);
+void jl_clear_backtrace(jl_ptls_t ptls);
 JL_DLLEXPORT jl_value_t *jl_apply_with_saved_exception_state(jl_value_t **args, uint32_t nargs, int drop_exceptions);
 void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_t *bt_size);
 JL_DLLEXPORT void jl_raise_debugger(void);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -109,6 +109,8 @@ struct _jl_tls_states_t {
     size_t bt_size;
     // JL_MAX_BT_SIZE + 1 elements long
     uintptr_t *bt_data;
+    // a julia object representation of the backtrace data, if we have one
+    struct _jl_value_t *julia_bt;
     // Atomically set by the sender, reset by the handler.
     volatile sig_atomic_t signal_request;
     // Allow the sigint to be raised asynchronously

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -139,11 +139,16 @@ JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp)
     return bt;
 }
 
-JL_DLLEXPORT void jl_get_backtrace(jl_array_t **btout, jl_array_t **bt2out)
+JL_DLLEXPORT void jl_get_backtrace(jl_value_t **btout, jl_value_t **bt2out)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_array_t *bt = NULL;
     jl_array_t *bt2 = NULL;
+    if (ptls->julia_bt != NULL) {
+        *btout = ptls->julia_bt;
+        *bt2out = jl_nothing;
+        return;
+    }
     JL_GC_PUSH2(&bt, &bt2);
     if (array_ptr_void_type == NULL) {
         array_ptr_void_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_voidpointer_type, jl_box_long(1));
@@ -160,11 +165,16 @@ JL_DLLEXPORT void jl_get_backtrace(jl_array_t **btout, jl_array_t **bt2out)
         }
         n++;
     }
-    *btout = bt;
-    *bt2out = bt2;
+    *btout = (jl_value_t*)bt;
+    *bt2out = (jl_value_t*)bt2;
     JL_GC_POP();
 }
 
+void jl_clear_backtrace(jl_ptls_t ptls)
+{
+    ptls->bt_size = 0;
+    ptls->julia_bt = NULL;
+}
 
 #if defined(_OS_WINDOWS_)
 #ifdef _CPU_X86_64_

--- a/src/task.c
+++ b/src/task.c
@@ -313,7 +313,7 @@ static void ctx_switch(jl_ptls_t ptls, jl_task_t **pt)
 #endif
     if (!jl_setjmp(ptls->current_task->ctx, 0)) {
         // backtraces don't survive task switches, see e.g. issue #12485
-        ptls->bt_size = 0;
+        jl_clear_backtrace(ptls);
         jl_task_t *lastt = ptls->current_task;
 #ifdef COPY_STACKS
         save_stack(ptls, lastt, pt); // allocates (gc-safepoint, and can also fail)
@@ -586,6 +586,13 @@ JL_DLLEXPORT void jl_rethrow(void)
 
 JL_DLLEXPORT void jl_rethrow_other(jl_value_t *e)
 {
+    throw_internal(e);
+}
+
+JL_DLLEXPORT void jl_throw_with_bt(jl_value_t *e, jl_value_t *bt)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    ptls->julia_bt = bt;
     throw_internal(e);
 }
 

--- a/src/threading.c
+++ b/src/threading.c
@@ -283,6 +283,7 @@ static void ti_initthread(int16_t tid)
         abort();
     }
     ptls->bt_data = (uintptr_t*)bt_data;
+    ptls->julia_bt = NULL;
     jl_init_thread_heap(ptls);
     jl_install_thread_signal_handler(ptls);
 

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -804,7 +804,7 @@ end
 function break_21369()
     try
         error("uhoh")
-    catch
+    catch err
         eval(:(inf_error_21369(false)))
         bt = catch_backtrace()
         i = 1
@@ -817,7 +817,7 @@ function break_21369()
             i += 1
         end
         @test fr.func === :break_21369
-        rethrow()
+        rethrow(err)
     end
 end
 @test_throws ErrorException break_21369()  # not TypeError

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -335,7 +335,7 @@ end
             if isa(e, Base.UVError) && Base.uverrorname(e) == "EPERM"
                 warn("UDP broadcast test skipped (permission denied upon send, restrictive firewall?)")
             else
-                rethrow()
+                rethrow(e)
             end
         end
         [close(s) for s in [a, b, c]]


### PR DESCRIPTION
This helps issue #19979. The idea is that `rethrow()` is just too implicit; it depends on hidden internal state when it should be lexically scoped.

This keeps `rethrow(e)` for now, since maintaining the backtrace manually is significantly more annoying than just passing an exception object (which you probably have anyway).

The remaining gap in functionality is addressed by adding `throw(e, bt)`. Reusing a backtrace is the only difference between `throw` and `rethrow`, so `rethrow` could be fully replaced by this eventually.
