### PR TITLE
RFC: store strings in comparison test results instead of the original objects

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -132,7 +132,7 @@ function show_default(io::IO, @nospecialize(x))
     nb = sizeof(x)
     if nf != 0 || nb == 0
         if !show_circular(io, x)
-            recur_io = IOContext(io, :SHOWN_SET => x)
+            recur_io = IOContext(io, Pair{Symbol,Any}(:SHOWN_SET, x))
             for i in 1:nf
                 f = fieldname(t, i)
                 if !isdefined(x, f)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -70,7 +70,7 @@ function Base.show(io::IO, t::Pass)
     if t.test_type == :test_throws
         # The correct type of exception was thrown
         print(io, "\n      Thrown: ", typeof(t.value))
-    elseif t.test_type == :test && isa(t.data, Expr)
+    elseif t.test_type == :test && t.data !== nothing
         # The test was an expression, so display the term-by-term
         # evaluated version as well
         print(io, "\n   Evaluated: ", t.data)
@@ -103,7 +103,7 @@ function Base.show(io::IO, t::Fail)
         # An exception was expected, but no exception was thrown
         print(io, "\n    Expected: ", t.data)
         print(io, "\n  No exception thrown")
-    elseif t.test_type == :test && isa(t.data, Expr)
+    elseif t.test_type == :test && t.data !== nothing
         # The test was an expression, so display the term-by-term
         # evaluated version as well
         print(io, "\n   Evaluated: ", t.data)
@@ -227,7 +227,10 @@ function eval_test(evaluated::Expr, quoted::Expr, source::LineNumberNode)
     else
         throw(ArgumentError("Unhandled expression type: $(evaluated.head)"))
     end
-    Returned(res, quoted, source)
+    Returned(res,
+             # stringify arguments in case of failure, for easy remote printing
+             res ? quoted : sprint(io->print(IOContext(io, :limit => true), quoted)),
+             source)
 end
 
 const comparison_prec = Base.operator_precedence(:(==))


### PR DESCRIPTION
This avoids deserialization errors; might fix #20230.

Motivated by a nasty one of these I got recently: https://ci.appveyor.com/project/JuliaLang/julia/build/1.0.21696/job/ernf3v0vhorc5w0f
