### PR TITLE
Point links in Dates docs to release-0.6 on 0.6

### DIFF
--- a/doc/src/manual/dates.md
+++ b/doc/src/manual/dates.md
@@ -125,7 +125,7 @@ julia> for i = 1:10^5
        end
 ```
 
-A full suite of parsing and formatting tests and examples is available in [`tests/dates/io.jl`](https://github.com/JuliaLang/julia/blob/master/test/dates/io.jl).
+A full suite of parsing and formatting tests and examples is available in [`tests/dates/io.jl`](https://github.com/JuliaLang/julia/blob/release-0.6/test/dates/io.jl).
 
 ## Durations/Comparisons
 
@@ -505,7 +505,7 @@ julia> filter(dr) do x
  2014-11-11
 ```
 
-Additional examples and tests are available in [`test/dates/adjusters.jl`](https://github.com/JuliaLang/julia/blob/master/test/dates/adjusters.jl).
+Additional examples and tests are available in [`test/dates/adjusters.jl`](https://github.com/JuliaLang/julia/blob/release-0.6/test/dates/adjusters.jl).
 
 ## Period Types
 


### PR DESCRIPTION
Currently there are links in the Dates section of the manual that point to files on master. Besides being not generally great, this didn't really pose a problem until Dates moved to the stdlib on master, which made these links 404s, thereby causing the docs build to fail on release-0.6.

The links were adjusted on master in #24821.