### PR TITLE
add mechanism for spoofing inference work-limiting heuristics

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -456,6 +456,7 @@ struct GeneratedFunctionStub
     spnames::Union{Nothing, Array{Any,1}}
     line::Int
     file::Symbol
+    expand_early::Bool
 end
 
 # invoke and wrap the results of @generated

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -371,9 +371,13 @@ function _validate(linfo::MethodInstance, src::CodeInfo, kind::String)
 end
 
 function get_staged(li::MethodInstance)
-    return ccall(:jl_code_for_staged, Any, (Any,), li)::CodeInfo
+    try
+        # user code might throw errors – ignore them
+        return ccall(:jl_code_for_staged, Any, (Any,), li)::CodeInfo
+    catch
+        return nothing
+    end
 end
-
 
 mutable struct OptimizationState
     linfo::MethodInstance
@@ -472,12 +476,7 @@ end
 function retrieve_code_info(linfo::MethodInstance)
     m = linfo.def::Method
     if isdefined(m, :generator)
-        try
-            # user code might throw errors – ignore them
-            c = get_staged(linfo)
-        catch
-            return nothing
-        end
+        return get_staged(linfo)
     else
         # TODO: post-inference see if we can swap back to the original arrays?
         if isa(m.source, Array{UInt8,1})
@@ -2090,6 +2089,24 @@ end
 
 const deprecated_sym = Symbol("deprecated.jl")
 
+function method_for_inference_heuristics(infstate::InferenceState)
+    m = infstate.src.method_for_inference_heuristics
+    return isa(m, Method) ? m : infstate.linfo.def
+end
+
+function method_for_inference_heuristics(method::Method, @nospecialize(sig), sparams, world)
+    if isdefined(method, :generator) && method.generator.expand_early
+        method_instance = code_for_method(method, sig, sparams, world, false)
+        if isa(method_instance, MethodInstance)
+            cinfo = get_staged(method_instance)
+            if isa(cinfo, CodeInfo) && isa(cinfo.method_for_inference_heuristics, Method)
+                return cinfo.method_for_inference_heuristics
+            end
+        end
+    end
+    return method
+ end
+
 function abstract_call_method(method::Method, @nospecialize(sig), sparams::SimpleVector, sv::InferenceState)
     # TODO: remove with 0.7 deprecations
     if method.file === deprecated_sym && method.sig == (Tuple{Type{T},Any} where T)
@@ -2103,16 +2120,18 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
     cyclei = 0
     infstate = sv
     edgecycle = false
+    checked_method = method_for_inference_heuristics(method, sig, sparams, sv.params.world)
     while !(infstate === nothing)
         infstate = infstate::InferenceState
-        if method === infstate.linfo.def
-            if infstate.linfo.specTypes == sig
-                # avoid widening when detecting self-recursion
-                # TODO: merge call cycle and return right away
-                topmost = nothing
-                edgecycle = true
-                break
-            end
+        if infstate.linfo.specTypes == sig
+            # avoid widening when detecting self-recursion
+            # TODO: merge call cycle and return right away
+            topmost = nothing
+            edgecycle = true
+            break
+        end
+        working_method = method_for_inference_heuristics(infstate)
+        if checked_method === working_method
             if topmost === nothing
                 # inspect the parent of this edge,
                 # to see if they are the same Method as sv
@@ -2131,7 +2150,8 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
                     # then check the parent link
                     if topmost === nothing && parent !== nothing
                         parent = parent::InferenceState
-                        if parent.cached && parent.linfo.def === sv.linfo.def
+                        parent_method = method_for_inference_heuristics(parent)
+                        if parent.cached && parent_method === working_method
                             topmost = infstate
                             edgecycle = true
                         end

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -3396,6 +3396,7 @@ function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
                     method = linfo.def::Method
                     tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
                     tree.code = Any[ Expr(:return, quoted(linfo.inferred_const)) ]
+                    tree.method_for_inference_heuristics = nothing
                     tree.slotnames = Any[ compiler_temp_sym for i = 1:method.nargs ]
                     tree.slotflags = UInt8[ 0 for i = 1:method.nargs ]
                     tree.slottypes = nothing

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -2089,7 +2089,7 @@ end
 
 const deprecated_sym = Symbol("deprecated.jl")
 
-function method_for_inference_heuristics(cinfo, default::Method)::Method
+function method_for_inference_heuristics(cinfo, default)
     if isa(cinfo, CodeInfo)
         # appropriate format for `sig` is svec(ftype, argtypes, world)
         sig = cinfo.signature_for_inference_heuristics
@@ -2106,7 +2106,7 @@ function method_for_inference_heuristics(cinfo, default::Method)::Method
     return default
 end
 
-function method_for_inference_heuristics(method::Method, @nospecialize(sig), sparams, world)::Method
+function method_for_inference_heuristics(method::Method, @nospecialize(sig), sparams, world)
     if isdefined(method, :generator) && method.generator.expand_early
         method_instance = code_for_method(method, sig, sparams, world, false)
         if isa(method_instance, MethodInstance)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2046,8 +2046,9 @@ void jl_init_types(void)
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(9,
+                        jl_perm_symsvec(10,
                             "code",
+                            "method_for_inference_heuristics"
                             "slottypes",
                             "ssavaluetypes",
                             "slotflags",
@@ -2056,8 +2057,9 @@ void jl_init_types(void)
                             "inlineable",
                             "propagate_inbounds",
                             "pure"),
-                        jl_svec(9,
+                        jl_svec(10,
                             jl_array_any_type,
+                            jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_array_uint8_type,
@@ -2066,7 +2068,7 @@ void jl_init_types(void)
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 9);
+                        0, 1, 10);
 
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2048,7 +2048,7 @@ void jl_init_types(void)
                         jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(10,
                             "code",
-                            "method_for_inference_heuristics"
+                            "signature_for_inference_heuristics"
                             "slottypes",
                             "ssavaluetypes",
                             "slotflags",

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2048,7 +2048,7 @@ void jl_init_types(void)
                         jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(10,
                             "code",
-                            "signature_for_inference_heuristics"
+                            "signature_for_inference_heuristics",
                             "slottypes",
                             "ssavaluetypes",
                             "slotflags",

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -362,7 +362,8 @@
                                                            'nothing
                                                            (cons 'list (map car sparams)))
                                                       ,(if (null? loc) 0 (cadr loc))
-                                                      (inert ,(if (null? loc) 'none (caddr loc))))))))
+                                                      (inert ,(if (null? loc) 'none (caddr loc)))
+                                                      false)))))
                              (list gf))
                            '()))
             (types (llist-types argl))

--- a/src/julia.h
+++ b/src/julia.h
@@ -229,6 +229,7 @@ typedef struct _jl_llvm_functions_t {
 // This type describes a single function body
 typedef struct _jl_code_info_t {
     jl_array_t *code;  // Any array of statements
+    jl_value_t *method_for_inference_heuristics; // optional method used during inference
     jl_value_t *slottypes; // types of variable slots (or `nothing`)
     jl_value_t *ssavaluetypes;  // types of ssa values (or count of them)
     jl_array_t *slotflags;  // local var bit flags

--- a/src/julia.h
+++ b/src/julia.h
@@ -229,7 +229,7 @@ typedef struct _jl_llvm_functions_t {
 // This type describes a single function body
 typedef struct _jl_code_info_t {
     jl_array_t *code;  // Any array of statements
-    jl_value_t *method_for_inference_heuristics; // optional method used during inference
+    jl_value_t *signature_for_inference_heuristics; // optional method used during inference
     jl_value_t *slottypes; // types of variable slots (or `nothing`)
     jl_value_t *ssavaluetypes;  // types of ssa values (or count of them)
     jl_array_t *slotflags;  // local var bit flags

--- a/src/method.c
+++ b/src/method.c
@@ -187,6 +187,7 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
                 jl_array_del_end(meta, na - ins);
         }
     }
+    li->method_for_inference_heuristics = jl_nothing;
     jl_array_t *vinfo = (jl_array_t*)jl_exprarg(ast, 1);
     jl_array_t *vis = (jl_array_t*)jl_array_ptr_ref(vinfo, 0);
     size_t nslots = jl_array_len(vis);
@@ -255,6 +256,7 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
         (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t),
                                        jl_code_info_type);
     src->code = NULL;
+    src->method_for_inference_heuristics = NULL;
     src->slotnames = NULL;
     src->slotflags = NULL;
     src->slottypes = NULL;

--- a/src/method.c
+++ b/src/method.c
@@ -187,7 +187,7 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
                 jl_array_del_end(meta, na - ins);
         }
     }
-    li->method_for_inference_heuristics = jl_nothing;
+    li->signature_for_inference_heuristics = jl_nothing;
     jl_array_t *vinfo = (jl_array_t*)jl_exprarg(ast, 1);
     jl_array_t *vis = (jl_array_t*)jl_array_ptr_ref(vinfo, 0);
     size_t nslots = jl_array_len(vis);
@@ -256,7 +256,7 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
         (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t),
                                        jl_code_info_type);
     src->code = NULL;
-    src->method_for_inference_heuristics = NULL;
+    src->signature_for_inference_heuristics = NULL;
     src->slotnames = NULL;
     src->slotflags = NULL;
     src->slottypes = NULL;

--- a/src/method.c
+++ b/src/method.c
@@ -442,8 +442,8 @@ static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
             else if (jl_expr_nargs(st) == 2 && jl_exprarg(st, 0) == (jl_value_t*)generated_sym) {
                 m->generator = NULL;
                 jl_value_t *gexpr = jl_exprarg(st, 1);
-                if (jl_expr_nargs(gexpr) == 6) {
-                    // expects (new (core GeneratedFunctionStub) funcname argnames sp line file)
+                if (jl_expr_nargs(gexpr) == 7) {
+                    // expects (new (core GeneratedFunctionStub) funcname argnames sp line file expandearly)
                     jl_value_t *funcname = jl_exprarg(gexpr, 1);
                     assert(jl_is_symbol(funcname));
                     if (jl_get_global(m->module, (jl_sym_t*)funcname) != NULL) {

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -576,7 +576,7 @@ static jl_code_info_t *expr_to_code_info(jl_value_t *expr)
     jl_gc_wb(src, src->slotflags);
     src->ssavaluetypes = jl_box_long(0);
     jl_gc_wb(src, src->ssavaluetypes);
-    src->method_for_inference_heuristics = jl_nothing;
+    src->signature_for_inference_heuristics = jl_nothing;
 
     JL_GC_POP();
     return src;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -576,6 +576,7 @@ static jl_code_info_t *expr_to_code_info(jl_value_t *expr)
     jl_gc_wb(src, src->slotflags);
     src->ssavaluetypes = jl_box_long(0);
     jl_gc_wb(src, src->ssavaluetypes);
+    src->method_for_inference_heuristics = jl_nothing;
 
     JL_GC_POP();
     return src;

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1381,17 +1381,13 @@ end
 x, y = rand(), rand()
 result = f24852_kernel(x, y)
 
-# TODO: The commented out tests here are the ones where `signature_for_inference_heuristics`
-# is inflated; these tests cause segfaults. Probably due to incorrect CodeInfo
-# construction/initialization happening somewhere...
-
 @test result === f24852_late_expr(x, y)
 @test result === f24852_late_uninflated(x, y)
-# @test result === f24852_late_inflated(x, y)
+@test result === f24852_late_inflated(x, y)
 
 @test result === f24852_early_expr(x, y)
 @test result === f24852_early_uninflated(x, y)
-# @test result === f24852_early_inflated(x, y)
+@test result === f24852_early_inflated(x, y)
 
 # TODO: test that `expand_early = true` + inflated `signature_for_inference_heuristics`
 # can be used to tighten up some inference result.

--- a/test/inference.jl
+++ b/test/inference.jl
@@ -1340,7 +1340,7 @@ end
 
 function f24852_gen_cinfo_inflated(X, Y, f, x, y)
     method, code_info = f24852_kernel_cinfo(x, y)
-    code_info.method_for_inference_heuristics = method
+    code_info.signature_for_inference_heuristics = Core.Inference.svec(f, (x, y), typemax(UInt))
     return code_info
 end
 
@@ -1381,7 +1381,7 @@ end
 x, y = rand(), rand()
 result = f24852_kernel(x, y)
 
-# TODO: The commented out tests here are the ones where `method_for_inference_heuristics`
+# TODO: The commented out tests here are the ones where `signature_for_inference_heuristics`
 # is inflated; these tests cause segfaults. Probably due to incorrect CodeInfo
 # construction/initialization happening somewhere...
 
@@ -1393,5 +1393,5 @@ result = f24852_kernel(x, y)
 @test result === f24852_early_uninflated(x, y)
 # @test result === f24852_early_inflated(x, y)
 
-# TODO: test that `expand_early = true` + inflated `method_for_inference_heuristics`
+# TODO: test that `expand_early = true` + inflated `signature_for_inference_heuristics`
 # can be used to tighten up some inference result.


### PR DESCRIPTION
ref #24676 

- [x] add `method_for_inference_limit_heuristics` field to CodeInfo 
- [x] add mechanism for early generator expansion
- [x] create some way to set the flag for early generator expansion
- [x] fix inevitable bugs
- [x] add tests

With what I've got so far, everything seems fine as long as the `method_for_inference_heuristics` is never inflated. Returning a `CodeInfo` with an inflated `method_for_inference_heuristics` field, however, seems to result in a segfault, so I'm pretty sure I've missed some places in `src` that still need updating. @keno Any tips here?
