### PR TITLE
Fix a typo in the JS benchmarks

### DIFF
--- a/test/perf/micro/perf.js
+++ b/test/perf/micro/perf.js
@@ -404,7 +404,7 @@
 
     function matmul(A,B,m,l,n) {
         var C, i, j, k, total;
-        C = new Array(m*n);
+        C = new Float64Array(m*n);
         i = 0;
         j = 0;
         k = 0;


### PR DESCRIPTION
see https://github.com/JuliaLang/julia/issues/24680; looks like a typo in which "Array" was accidentally used instead of "float64Array"