### PR TITLE
Build failed  with LLVM=svn

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -744,7 +744,11 @@ struct math_builder {
         if (jl_options.fast_math != JL_OPTIONS_FAST_MATH_OFF &&
             (always_fast ||
              jl_options.fast_math == JL_OPTIONS_FAST_MATH_ON)) {
+#if JL_LLVM_VERSION >= 60000
+            fmf.setFast();
+#else
             fmf.setUnsafeAlgebra();
+#endif
         }
 #if JL_LLVM_VERSION >= 50000
         if (contract)

--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -65,15 +65,27 @@ static bool checkCombine(Module *m, Instruction *addOp, Value *maybeMul, Value *
         auto newaddend = builder.CreateFNeg(addend);
         // Might be a const
         if (auto neginst = dyn_cast<Instruction>(newaddend))
+#if JL_LLVM_VERSION >= 60000
+            neginst->setFast(true);
+#else
             neginst->setHasUnsafeAlgebra(true);
+#endif
         addend = newaddend;
     }
     Instruction *newv = builder.CreateCall(muladdf, {mul1, mul2, addend});
+#if JL_LLVM_VERSION >= 60000
+    newv->setFast(true);
+#else
     newv->setHasUnsafeAlgebra(true);
+#endif
     if (negres) {
         // Shouldn't be a constant
         newv = cast<Instruction>(builder.CreateFNeg(newv));
+#if JL_LLVM_VERSION >= 60000
+        newv->setFast(true);
+#else
         newv->setHasUnsafeAlgebra(true);
+#endif
     }
     addOp->replaceAllUsesWith(newv);
     addOp->eraseFromParent();
@@ -91,14 +103,22 @@ bool CombineMulAdd::runOnFunction(Function &F)
             it++;
             switch (I.getOpcode()) {
             case Instruction::FAdd: {
+#if JL_LLVM_VERSION >= 60000
+                if (!I.isFast())
+#else
                 if (!I.hasUnsafeAlgebra())
+#endif
                     continue;
                 checkCombine(m, &I, I.getOperand(0), I.getOperand(1), false, false) ||
                     checkCombine(m, &I, I.getOperand(1), I.getOperand(0), false, false);
                 break;
             }
             case Instruction::FSub: {
+#if JL_LLVM_VERSION >= 60000
+                if (!I.isFast())
+#else
                 if (!I.hasUnsafeAlgebra())
+#endif
                     continue;
                 checkCombine(m, &I, I.getOperand(0), I.getOperand(1), true, false) ||
                     checkCombine(m, &I, I.getOperand(1), I.getOperand(0), true, true);

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -152,7 +152,11 @@ void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const
     }
     for (chainVector::const_iterator K=chain.begin(); K!=chain.end(); ++K) {
         DEBUG(dbgs() << "LSL: marking " << **K << "\n");
+#if JL_LLVM_VERSION >= 60000
+        (*K)->setFast(true);
+#else
         (*K)->setHasUnsafeAlgebra(true);
+#endif
     }
 }
 


### PR DESCRIPTION
just googling the error message and found API changes: https://reviews.llvm.org/rL317488

I add some macros for them, but I do not know what these APIs are at all.
It compiled.

```patch
diff --git a/src/intrinsics.cpp b/src/intrinsics.cpp
index db06dc3..d64c22b 100644
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -744,7 +744,11 @@ struct math_builder {
         if (jl_options.fast_math != JL_OPTIONS_FAST_MATH_OFF &&
             (always_fast ||
              jl_options.fast_math == JL_OPTIONS_FAST_MATH_ON)) {
+#if JL_LLVM_VERSION >= 60000
+            fmf.setFast();
+#else
             fmf.setUnsafeAlgebra();
+#endif
         }
 #if JL_LLVM_VERSION >= 50000
         if (contract)
diff --git a/src/llvm-muladd.cpp b/src/llvm-muladd.cpp
index a8b635f..a720a9d 100644
--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -65,15 +65,27 @@ static bool checkCombine(Module *m, Instruction *addOp, Value *maybeMul, Value *
         auto newaddend = builder.CreateFNeg(addend);
         // Might be a const
         if (auto neginst = dyn_cast<Instruction>(newaddend))
+#if JL_LLVM_VERSION >= 60000
+            neginst->setFast(true);
+#else
             neginst->setHasUnsafeAlgebra(true);
+#endif
         addend = newaddend;
     }
     Instruction *newv = builder.CreateCall(muladdf, {mul1, mul2, addend});
+#if JL_LLVM_VERSION >= 60000
+    newv->setFast(true);
+#else
     newv->setHasUnsafeAlgebra(true);
+#endif
     if (negres) {
         // Shouldn't be a constant
         newv = cast<Instruction>(builder.CreateFNeg(newv));
+#if JL_LLVM_VERSION >= 60000
+        newv->setFast(true);
+#else
         newv->setHasUnsafeAlgebra(true);
+#endif
     }
     addOp->replaceAllUsesWith(newv);
     addOp->eraseFromParent();
@@ -91,14 +103,22 @@ bool CombineMulAdd::runOnFunction(Function &F)
             it++;
             switch (I.getOpcode()) {
             case Instruction::FAdd: {
+#if JL_LLVM_VERSION >= 60000
+                if (!I.isFast())
+#else
                 if (!I.hasUnsafeAlgebra())
+#endif
                     continue;
                 checkCombine(m, &I, I.getOperand(0), I.getOperand(1), false, false) ||
                     checkCombine(m, &I, I.getOperand(1), I.getOperand(0), false, false);
                 break;
             }
             case Instruction::FSub: {
+#if JL_LLVM_VERSION >= 60000
+                if (!I.isFast())
+#else
                 if (!I.hasUnsafeAlgebra())
+#endif
                     continue;
                 checkCombine(m, &I, I.getOperand(0), I.getOperand(1), true, false) ||
                     checkCombine(m, &I, I.getOperand(1), I.getOperand(0), true, true);
diff --git a/src/llvm-simdloop.cpp b/src/llvm-simdloop.cpp
index 87f4d95..aef3d59 100644
--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -152,7 +152,11 @@ void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const
     }
     for (chainVector::const_iterator K=chain.begin(); K!=chain.end(); ++K) {
         DEBUG(dbgs() << "LSL: marking " << **K << "\n");
+#if JL_LLVM_VERSION >= 60000
+        (*K)->setFast(true);
+#else
         (*K)->setHasUnsafeAlgebra(true);
+#endif
     }
 }
```