### PR TITLE
a couple small items to help out the compiler

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -723,22 +723,7 @@ end
     return (v.dict.vals[i], skip_deleted(v.dict,i+1))
 end
 
-function filter_in_one_pass!(f, d::Associative)
-    try
-        for (k, v) in d
-            if !f(k => v)
-                delete!(d, k)
-            end
-        end
-    catch e
-        return filter!_dict_deprecation(e, f, d)
-    end
-    return d
-end
-
-# For these Associative types, it is safe to implement filter!
-# by deleting keys during iteration.
-filter!(f, d::Union{ObjectIdDict,Dict}) = filter_in_one_pass!(f, d)
+filter!(f, d::Dict) = filter_in_one_pass!(f, d)
 
 struct ImmutableDict{K,V} <: Associative{K,V}
     parent::ImmutableDict{K,V}

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -460,8 +460,6 @@ function __init__()
     init_threadcall()
 end
 
-include("precompile.jl")
-
 INCLUDE_STATE = 3 # include = include_relative
 
 end # baremodule Base
@@ -494,3 +492,5 @@ end
 empty!(LOAD_PATH)
 
 Base.isfile("userimg.jl") && Base.include(Main, "userimg.jl")
+
+Base.include(Base, "precompile.jl")


### PR DESCRIPTION
- avoid making lots of Pair types in `filter!` on ObjectIdDict
- move precompile.jl later to reduce method invalidations