### PR TITLE
deepcopy: update the meaning for objects like BigInt

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -662,13 +662,4 @@ Base.add_with_overflow(a::BigInt, b::BigInt) = a + b, false
 Base.sub_with_overflow(a::BigInt, b::BigInt) = a - b, false
 Base.mul_with_overflow(a::BigInt, b::BigInt) = a * b, false
 
-function Base.deepcopy_internal(x::BigInt, stackdict::ObjectIdDict)
-    if haskey(stackdict, x)
-        return stackdict[x]
-    end
-    y = MPZ.set(x)
-    stackdict[x] = y
-    return y
-end
-
 end # module

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -964,17 +964,6 @@ get_emin_max() = ccall((:mpfr_get_emin_max, :libmpfr), Clong, ())
 set_emax!(x) = ccall((:mpfr_set_emax, :libmpfr), Void, (Clong,), x)
 set_emin!(x) = ccall((:mpfr_set_emin, :libmpfr), Void, (Clong,), x)
 
-function Base.deepcopy_internal(x::BigFloat, stackdict::ObjectIdDict)
-    haskey(stackdict, x) && return stackdict[x]
-    prec = precision(x)
-    y = BigFloat(zero(Clong), zero(Cint), zero(Clong), C_NULL)
-    ccall((:mpfr_init2,:libmpfr), Void, (Ref{BigFloat}, Clong), y, prec)
-    finalizer(cglobal((:mpfr_clear, :libmpfr)), y)
-    ccall((:mpfr_set, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}, Int32), y, x, ROUNDING_MODE[])
-    stackdict[x] = y
-    return y
-end
-
 function Base.lerpi(j::Integer, d::Integer, a::BigFloat, b::BigFloat)
     t = BigFloat(j)/d
     fma(t, b, fma(-t, a, a))

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -322,8 +322,6 @@ using .Sort
 include("fastmath.jl")
 using .FastMath
 
-function deepcopy_internal end
-
 # BigInts and BigFloats
 include("gmp.jl")
 using .GMP

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -101,33 +101,6 @@ end
     @test a3[1] === a3[2]
 end
 
-@testset "issue #16667" begin
-    let x = BigInt[1:1000;], y = deepcopy(x), v
-        # Finalize the original values to make sure the deep copy is indeed
-        # independent
-        for v in x
-            finalize(v)
-        end
-        # Allocate some memory to make it more likely to trigger an error
-        # if `deepcopy` went wrong
-        x = BigInt[1:1000;]
-        @test y == x
-    end
-    let x = BigFloat[1:1000;], y, z, v
-        y, z = setprecision(2) do
-            deepcopy(x), BigFloat[1:1000;]
-        end
-        for v in x
-            finalize(v)
-        end
-        x = BigFloat[1:1000;]
-        # Make sure the difference in precision doesn't affect deep copy
-        @test y == x
-        # Check that the setprecision indeed does something
-        @test z != x
-    end
-end
-
 mutable struct Foo19921
     a::String
 end

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -119,3 +119,11 @@ end
         @test bar2.fooDict[bar2.foo] != nothing
     end
 end
+
+# issue #16667 (Specific fixes for BigFloat, BigInt only)
+let a1 = [big"1.5", big"1e42"], a2 = [big"123", big"456"]
+    b1 = deepcopy(a1)
+    @test a1[1] === b1[1]
+    b2 = deepcopy(a2)
+    @test a2[1] === b2[1]
+end


### PR DESCRIPTION
Starting from bug #16667, two fixes have been proposed: #16826 which implements `deepcopy(::BigInt)` as the identity, and #16999 which implements `deepcopy` by creating a totally independant new `BigInt` object.

As far as I could understand, the rationale for the latter (which was the one merged), was to follow a strict interpretation of the docstring for `deepcopy`, which mentions in particular a "fully independent object" and also "Calling deepcopy on an object should generally have the same effect as serializing and then deserializing it." @yuyichao argued for example that this definition forces us to implement `deepcopy` such that its result is indistiguishable from serializing and then deserializing. 

I believe the correct fix to the initial bug is the first PR, as I see no point in forcing wasting resources on copying the internals of `BigInt` when the semantics and the API for this type is to be immutable. If the definition of `deepcopy` prevents defining `deepcopy(x::BigInt) = x`, then the definition needs to be fixed, which is what I tried to do here (suggestions for improvements are very welcome), in addition to defining `deepcopy` as the identity. I also cherry-picked the tests implemented by @ScottPJones in his PR. 

It's possible that I missed a use case for the stricter interpretation (copying the internals), but none have been exhibited so far. On the other hand,  the use case for `deepcopy == identity`  is simply performance, for when one has to deepcopy a structure containing `BigInt`s.