### PR TITLE
Shred CredentialPayload upon approval/rejection

### DIFF
--- a/base/libgit2/gitcredential.jl
+++ b/base/libgit2/gitcredential.jl
@@ -297,7 +297,6 @@ function approve(cfg::GitConfig, cred::UserPasswordCredentials, url::AbstractStr
     end
 
     securezero!(git_cred)
-
     nothing
 end
 
@@ -310,7 +309,5 @@ function reject(cfg::GitConfig, cred::UserPasswordCredentials, url::AbstractStri
     end
 
     securezero!(git_cred)
-    securezero!(cred)
-
     nothing
 end

--- a/test/libgit2-helpers.jl
+++ b/test/libgit2-helpers.jl
@@ -53,7 +53,7 @@ function credential_loop(
         LibGit2.reject(payload, shred=true)
     end
 
-    return git_error, num_authentications
+    return git_error, num_authentications, payload
 end
 
 function credential_loop(

--- a/test/libgit2-helpers.jl
+++ b/test/libgit2-helpers.jl
@@ -32,7 +32,7 @@ function credential_loop(
 
         # Check if the callback provided us with valid credentials
         if !isnull(payload.credential) && get(payload.credential) == valid_credential
-            LibGit2.approve(payload)
+            LibGit2.approve(payload, shred=false)
             break
         end
 
@@ -48,9 +48,9 @@ function credential_loop(
         LibGit2.GitError(err)
     end
 
-    # Reject the credential when an authentication error occurs
+    # Reject and shred the credential when an authentication error occurs
     if git_error.code == LibGit2.Error.EAUTH
-        LibGit2.reject(payload)
+        LibGit2.reject(payload, shred=true)
     end
 
     return git_error, num_authentications

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -2430,7 +2430,7 @@ mktempdir() do dir
                 payload = CredentialPayload(valid_cred, allow_ssh_agent=false,
                                             allow_git_helpers=false)
                 credential_loop(valid_cred, "ssh://github.com/repo", Nullable(""),
-                    Cuint(LibGit2.Consts.CREDTYPE_SSH_KEY), payload)
+                                Cuint(LibGit2.Consts.CREDTYPE_SSH_KEY), payload)
             end
 
             err, auth_attempts = challenge_prompt(expect_ssh_ex, [])
@@ -2444,7 +2444,7 @@ mktempdir() do dir
                 payload = CredentialPayload(valid_cred, allow_ssh_agent=false,
                                             allow_git_helpers=false)
                 credential_loop(valid_cred, "https://github.com/repo", Nullable(""),
-                    Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT), payload)
+                                Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT), payload)
             end
 
             err, auth_attempts = challenge_prompt(expect_https_ex, [])
@@ -2465,7 +2465,7 @@ mktempdir() do dir
                 payload = CredentialPayload(valid_cred, allow_ssh_agent=false,
                                             allow_git_helpers=false)
                 credential_loop(valid_cred, "foo://github.com/repo", Nullable(""),
-                    $allowed_types, payload)
+                                $allowed_types, payload)
             end
 
             err, auth_attempts = challenge_prompt(ex, [])

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1534,7 +1534,7 @@ mktempdir() do dir
 
         url = "https://github.com/JuliaLang/Example.jl"
         cred_id = LibGit2.credential_identifier(url)
-        cred = LibGit2.UserPasswordCredentials(deepcopy("julia"), deepcopy("password"))
+        cred = LibGit2.UserPasswordCredentials("julia", "password")
 
         @test !haskey(cache, cred_id)
 
@@ -1549,11 +1549,11 @@ mktempdir() do dir
         @test haskey(cache, cred_id)
         @test cache[cred_id] === cred
 
-        # Reject an approved should cause it to be removed and erased
+        # Reject an approved should cause it to be removed
         LibGit2.reject(cache, cred, url)
         @test !haskey(cache, cred_id)
-        @test cred.user != "julia"
-        @test cred.pass != "password"
+        @test cred.user == "julia"
+        @test cred.pass == "password"
     end
 
     @testset "Git credential username" begin

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1692,6 +1692,8 @@ mktempdir() do dir
                 ]
 
                 @test LibGit2.credential_helpers(cfg, GitCredential("https", "github.com")) == expected
+
+                println(STDERR, "The following 'Resetting the helper list...' warning is expected:")
                 @test_broken LibGit2.credential_helpers(cfg, GitCredential("https", "mygithost")) == expected[2]
             end
         end

--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1839,7 +1839,7 @@ mktempdir() do dir
 
             # ENV credentials are valid
             withenv("SSH_KEY_PATH" => valid_key) do
-                err, auth_attempts = challenge_prompt(ssh_ex, [])
+                err, auth_attempts, p = challenge_prompt(ssh_ex, [])
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -1849,7 +1849,7 @@ mktempdir() do dir
                 challenges = [
                     "Passphrase for $valid_p_key:" => "$passphrase\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_p_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1862,7 +1862,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com' [$valid_p_key]:" => "\n",
                     "Passphrase for $valid_p_key:" => "$passphrase\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_p_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 2
 
@@ -1870,7 +1870,7 @@ mktempdir() do dir
                 challenges = [
                     "Passphrase for $valid_p_key:" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_p_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
 
@@ -1878,14 +1878,14 @@ mktempdir() do dir
                 challenges = [
                     "Passphrase for $valid_p_key:" => "\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_p_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
             end
 
             # ENV credential requiring passphrase
             withenv("SSH_KEY_PATH" => valid_p_key, "SSH_KEY_PASS" => passphrase) do
-                err, auth_attempts = challenge_prompt(ssh_p_ex, [])
+                err, auth_attempts, p = challenge_prompt(ssh_p_ex, [])
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -1896,7 +1896,7 @@ mktempdir() do dir
                 challenges = [
                     "Username for 'github.com':" => "$username\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_u_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1904,7 +1904,7 @@ mktempdir() do dir
                 challenges = [
                     "Username for 'github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_u_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
 
@@ -1913,7 +1913,7 @@ mktempdir() do dir
                     "Username for 'github.com':" => "\n",
                     "Username for 'github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_u_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 2
 
@@ -1924,7 +1924,7 @@ mktempdir() do dir
                     "Private key location for 'foo@github.com' [$valid_key]:" => "\n",
                     "Username for 'github.com' [foo]:" => "\x04",  # Need to manually abort
                 ]
-                err, auth_attempts = challenge_prompt(ssh_u_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_u_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 3
 
@@ -1934,7 +1934,7 @@ mktempdir() do dir
                 challenges = [
                     "Username for 'github.com':" => "$username\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_user_empty_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_user_empty_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -1955,7 +1955,7 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com':" => "$valid_key\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1964,7 +1964,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com':" => "$valid_p_key\n",
                     "Passphrase for $valid_p_key:" => "$passphrase\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_p_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_p_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
 
@@ -1972,7 +1972,7 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 1
 
@@ -1981,7 +1981,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com':" => "\n",
                     "Private key location for 'git@github.com':" => "\x04",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == abort_prompt
                 @test auth_attempts == 2
 
@@ -1992,7 +1992,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com' [foo]:" => "foo\n",
                     "Private key location for 'git@github.com' [foo]:" => "foo\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == prompt_limit
                 @test auth_attempts == 3
             end
@@ -2004,7 +2004,7 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com' [$invalid_key]:" => "$valid_key\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 2
 
@@ -2014,7 +2014,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com' [$invalid_key]:" => "\n",
                     "Private key location for 'git@github.com' [$invalid_key]:" => "\n",
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == prompt_limit
                 @test auth_attempts == 4
             end
@@ -2028,7 +2028,7 @@ mktempdir() do dir
                     # "Private key location for 'git@github.com' [$valid_key]:" => "\n"
                     "Public key location for 'git@github.com' [$valid_key.public]:" => "$valid_key.pub\n"
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
             end
@@ -2043,7 +2043,7 @@ mktempdir() do dir
                     "Private key location for 'git@github.com' [$valid_key]:" => "\n"
                     "Public key location for 'git@github.com' [$invalid_key.pub]:" => "$valid_key.pub\n"
                 ]
-                err, auth_attempts = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 2
             end
@@ -2066,7 +2066,7 @@ mktempdir() do dir
                 "Username for 'https://github.com':" => "$valid_username\n",
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
-            err, auth_attempts = challenge_prompt(https_ex, challenges)
+            err, auth_attempts, p = challenge_prompt(https_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 1
 
@@ -2074,7 +2074,7 @@ mktempdir() do dir
             challenges = [
                 "Username for 'https://github.com':" => "\x04",
             ]
-            err, auth_attempts = challenge_prompt(https_ex, challenges)
+            err, auth_attempts, p = challenge_prompt(https_ex, challenges)
             @test err == abort_prompt
             @test auth_attempts == 1
 
@@ -2083,7 +2083,7 @@ mktempdir() do dir
                 "Username for 'https://github.com':" => "foo\n",
                 "Password for 'https://foo@github.com':" => "\x04",
             ]
-            err, auth_attempts = challenge_prompt(https_ex, challenges)
+            err, auth_attempts, p = challenge_prompt(https_ex, challenges)
             @test err == abort_prompt
             @test auth_attempts == 1
 
@@ -2093,7 +2093,7 @@ mktempdir() do dir
                 "Username for 'https://github.com':" => "foo\n",
                 "Password for 'https://foo@github.com':" => "\n",
             ]
-            err, auth_attempts = challenge_prompt(https_ex, challenges)
+            err, auth_attempts, p = challenge_prompt(https_ex, challenges)
             @test err == abort_prompt
             @test auth_attempts == 1
 
@@ -2107,7 +2107,7 @@ mktempdir() do dir
                 "Username for 'https://github.com' [foo]:" => "foo\n",
                 "Password for 'https://foo@github.com':" => "bar\n",
             ]
-            err, auth_attempts = challenge_prompt(https_ex, challenges)
+            err, auth_attempts, p = challenge_prompt(https_ex, challenges)
             @test err == prompt_limit
             @test auth_attempts == 3
         end
@@ -2129,14 +2129,14 @@ mktempdir() do dir
 
             # An empty string username_ptr
             ex = gen_ex(username="")
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == exhausted_error
             @test auth_attempts == 3
 
             # A null username_ptr passed into `git_cred_ssh_key_from_agent` can cause a
             # segfault.
             ex = gen_ex(username=nothing)
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == exhausted_error
             @test auth_attempts == 2
         end
@@ -2183,7 +2183,7 @@ mktempdir() do dir
 
                     # Automatically use the default key
                     ex = gen_ex(valid_cred)
-                    err, auth_attempts = challenge_prompt(ex, [])
+                    err, auth_attempts, p = challenge_prompt(ex, [])
                     @test err == git_ok
                     @test auth_attempts == 1
 
@@ -2193,7 +2193,7 @@ mktempdir() do dir
                         "Private key location for 'git@github.com' [$default_key]:" => "\n",
                         "Passphrase for $default_key:" => "$passphrase\n",
                     ]
-                    err, auth_attempts = challenge_prompt(ex, challenges)
+                    err, auth_attempts, p = challenge_prompt(ex, challenges)
                     @test err == git_ok
                     @test auth_attempts == 1
                 end
@@ -2212,8 +2212,7 @@ mktempdir() do dir
                 include($LIBGIT2_HELPER_PATH)
                 payload = CredentialPayload(allow_prompt=true, allow_ssh_agent=false,
                                             allow_git_helpers=false)
-                err, auth_attempts = credential_loop($valid_cred, $url, "git", payload)
-                (err, auth_attempts, payload.credential)
+                credential_loop($valid_cred, $url, "git", payload)
             end
 
             withenv("SSH_KEY_PATH" => nothing,
@@ -2225,10 +2224,10 @@ mktempdir() do dir
                 challenges = [
                     "Private key location for 'git@github.com':" => "~/valid\n",
                 ]
-                err, auth_attempts, credential = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 1
-                @test get(credential).prvkey == abspath(valid_key)
+                @test get(p.credential).prvkey == abspath(valid_key)
             end
 
             withenv("SSH_KEY_PATH" => valid_key,
@@ -2241,10 +2240,10 @@ mktempdir() do dir
                     "Private key location for 'git@github.com' [$valid_key]:" => "\n",
                     "Public key location for 'git@github.com' [$invalid_key.pub]:" => "~/valid.pub\n",
                 ]
-                err, auth_attempts, credential = challenge_prompt(ssh_ex, challenges)
+                err, auth_attempts, p = challenge_prompt(ssh_ex, challenges)
                 @test err == git_ok
                 @test auth_attempts == 2
-                @test get(credential).pubkey == abspath(valid_key * ".pub")
+                @test get(p.credential).pubkey == abspath(valid_key * ".pub")
             end
         end
 
@@ -2272,13 +2271,13 @@ mktempdir() do dir
             # Explicitly provided credential is correct. Note: allowing prompting and
             # SSH agent to ensure they are skipped.
             ex = gen_ex(valid_cred, allow_prompt=true, allow_ssh_agent=true)
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
             # Explicitly provided credential is incorrect
             ex = gen_ex(invalid_cred, allow_prompt=false, allow_ssh_agent=false)
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == exhausted_error
             @test auth_attempts == 3
         end
@@ -2300,13 +2299,13 @@ mktempdir() do dir
 
             # Explicitly provided credential is correct
             ex = gen_ex(valid_cred, allow_prompt=true)
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == git_ok
             @test auth_attempts == 1
 
             # Explicitly provided credential is incorrect
             ex = gen_ex(invalid_cred, allow_prompt=false)
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == exhausted_error
             @test auth_attempts == 2
         end
@@ -2330,13 +2329,12 @@ mktempdir() do dir
                     $(cached_cred !== nothing && :(LibGit2.approve(cache, $cached_cred, $url)))
                     payload = CredentialPayload(cache, allow_prompt=$allow_prompt,
                                                 allow_git_helpers=false)
-                    err, auth_attempts = credential_loop($valid_cred, $url, "", payload)
-                    (err, auth_attempts, cache)
+                    credential_loop($valid_cred, $url, "", payload)
                 end
             end
 
             # Cache contains a correct credential
-            err, auth_attempts = challenge_prompt(gen_ex(cached_cred=valid_cred), [])
+            err, auth_attempts, p = challenge_prompt(gen_ex(cached_cred=valid_cred), [])
             @test err == git_ok
             @test auth_attempts == 1
 
@@ -2346,7 +2344,8 @@ mktempdir() do dir
                 "Username for 'https://github.com':" => "$valid_username\n",
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
-            err, auth_attempts, cache = challenge_prompt(ex, challenges)
+            err, auth_attempts, p = challenge_prompt(ex, challenges)
+            cache = get(p.cache)
             @test err == git_ok
             @test auth_attempts == 1
             @test typeof(cache) == LibGit2.CachedCredentials
@@ -2358,7 +2357,8 @@ mktempdir() do dir
                 "Username for 'https://github.com' [alice]:" => "$valid_username\n",
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
-            err, auth_attempts, cache = challenge_prompt(ex, challenges)
+            err, auth_attempts, p = challenge_prompt(ex, challenges)
+            cache = get(p.cache)
             @test err == git_ok
             @test auth_attempts == 2
             @test typeof(cache) == LibGit2.CachedCredentials
@@ -2371,7 +2371,8 @@ mktempdir() do dir
                 "Password for 'https://foo@github.com':" => "bar\n",
                 "Username for 'https://github.com' [foo]:" => "\x04",
             ]
-            err, auth_attempts, cache = challenge_prompt(ex, challenges)
+            err, auth_attempts, p = challenge_prompt(ex, challenges)
+            cache = get(p.cache)
             @test err == abort_prompt
             @test auth_attempts == 3
             @test typeof(cache) == LibGit2.CachedCredentials
@@ -2379,7 +2380,8 @@ mktempdir() do dir
 
             # An EAUTH error should remove credentials from the cache
             ex = gen_ex(cached_cred=invalid_cred, allow_prompt=false)
-            err, auth_attempts, cache = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
+            cache = get(p.cache)
             @test err == exhausted_error
             @test auth_attempts == 2
             @test typeof(cache) == LibGit2.CachedCredentials
@@ -2405,9 +2407,7 @@ mktempdir() do dir
                     payload = CredentialPayload(Nullable{AbstractCredentials}(),
                                                 Nullable{CachedCredentials}(), cfg,
                                                 allow_git_helpers=true)
-                    err, auth_attempts = credential_loop($valid_cred, $url,
-                                                         Nullable{String}(), payload)
-                    (err, auth_attempts, payload.credential)
+                    credential_loop($valid_cred, $url, Nullable{String}(), payload)
                 end
             end
 
@@ -2416,12 +2416,12 @@ mktempdir() do dir
                 "Username for 'https://github.com' [$valid_username]:" => "\n",
                 "Password for 'https://$valid_username@github.com':" => "$valid_password\n",
             ]
-            err, auth_attempts, credential = challenge_prompt(https_ex, challenges)
+            err, auth_attempts, p = challenge_prompt(https_ex, challenges)
             @test err == git_ok
             @test auth_attempts == 1
 
             # Verify credential wasn't accidentally zeroed (#24731)
-            @test get(credential) == valid_cred
+            @test get(p.credential) == valid_cred
         end
 
         @testset "Incompatible explicit credentials" begin
@@ -2435,7 +2435,7 @@ mktempdir() do dir
                                 Cuint(LibGit2.Consts.CREDTYPE_SSH_KEY), payload)
             end
 
-            err, auth_attempts = challenge_prompt(expect_ssh_ex, [])
+            err, auth_attempts, p = challenge_prompt(expect_ssh_ex, [])
             @test err == incompatible_error
             @test auth_attempts == 1
 
@@ -2449,7 +2449,7 @@ mktempdir() do dir
                                 Cuint(LibGit2.Consts.CREDTYPE_USERPASS_PLAINTEXT), payload)
             end
 
-            err, auth_attempts = challenge_prompt(expect_https_ex, [])
+            err, auth_attempts, p = challenge_prompt(expect_https_ex, [])
             @test err == incompatible_error
             @test auth_attempts == 1
         end
@@ -2470,7 +2470,7 @@ mktempdir() do dir
                                 $allowed_types, payload)
             end
 
-            err, auth_attempts = challenge_prompt(ex, [])
+            err, auth_attempts, p = challenge_prompt(ex, [])
             @test err == git_ok
             @test auth_attempts == 1
         end
@@ -2504,11 +2504,11 @@ mktempdir() do dir
             ]
             first_result, second_result = challenge_prompt(ex, challenges)
 
-            err, auth_attempts = first_result
+            err, auth_attempts, p = first_result
             @test err == git_ok
             @test auth_attempts == 1
 
-            err, auth_attempts = second_result
+            err, auth_attempts, p = second_result
             @test err == git_ok
             @test auth_attempts == 1
         end


### PR DESCRIPTION
As [I mentioned](https://github.com/JuliaLang/julia/pull/24731#discussion_r153049762) in #24731 there were some security issues with `CredentialPayload` where credentials were not being zeroed after they were done being used.

The changes in this PR ensure that credential information is wiped out during normal use and fixes some minor issues where credentials were being wiped too early when they were rejected. Note that I am specifically not wiping the `explicit` and `cache` fields from `CredentialPayload` as this is credential information being provided from the caller and should be wiped by the caller.

Additionally, I addressed some minor details including:
* Properly showing process output within `challenge_prompt` (assists in debugging)
* Displaying a message about the expected warning during LibGit2 tests
* Code indentation