### PR TITLE
Change the default of confirming REPL-exit to false

### DIFF
--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -255,7 +255,7 @@ Options(;
         hascolor = true,
         extra_keymap = AnyDict[],
         backspace_align = true, backspace_adjust = backspace_align,
-        confirm_exit = true) =
+        confirm_exit = false) =
             Options(hascolor, extra_keymap, backspace_align, backspace_adjust, confirm_exit)
 
 ## LineEditREPL ##


### PR DESCRIPTION
The default could also be changed but I am of the opinion that if this is not enabled by default, it is perhaps not so much point to have the functionality at all.

This PR was made as a response to some of the reactions in https://github.com/JuliaLang/julia/pull/24816 after it got merged. Perhaps we can continue the discussion here whether to revert this feature or change the default.

