### PR TITLE
Backport symbol versioning patch from LLVM 4.0

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -461,6 +461,7 @@ $(eval $(call LLVM_PATCH,llvm-D33179))
 $(eval $(call LLVM_PATCH,llvm-PR29010-i386-xmm)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-3.9.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-D37939-Mem2Reg-Also-handle-memcpy))
+$(eval $(call LLVM_PATCH,llvm-D31524-sovers_4.0)) # Remove for 4.0
 ifeq ($(BUILD_LLVM_CLANG),1)
 $(eval $(call LLVM_PATCH,compiler_rt-3.9-glibc_2.25.90)) # Remove for 5.0
 endif

--- a/deps/patches/llvm-D31524-sovers_4.0.patch
+++ b/deps/patches/llvm-D31524-sovers_4.0.patch
@@ -1,0 +1,82 @@
+From cd789d8cfe12aa374e66eafc748f4fc06e149ca7 Mon Sep 17 00:00:00 2001
+From: Sylvestre Ledru <sylvestre@debian.org>
+Date: Mon, 17 Apr 2017 20:51:50 +0000
+Subject: [PATCH] Add a linker script to version LLVM symbols
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Summary:
+This patch adds a very simple linker script to version the lib's symbols
+and thus trying to avoid crashes if an application loads two different
+LLVM versions (as long as they do not share data between them).
+
+Note that we deliberately *don't* make LLVM_5.0 depend on LLVM_4.0:
+they're incompatible and the whole point of this patch is
+to tell the linker that.
+
+
+Avoid unexpected crashes when two LLVM versions are used in the same process.
+
+Author: Rebecca N. Palmer <rebecca_palmer@zoho.com>
+Author: Lisandro Damían Nicanor Pérez Meyer <lisandro@debian.org>
+Author: Sylvestre Ledru <sylvestre@debian.org>
+Bug-Debian:  https://bugs.debian.org/848368
+
+
+Reviewers: beanz, rnk
+
+Reviewed By: rnk
+
+Subscribers: mgorny, llvm-commits
+
+Differential Revision: https://reviews.llvm.org/D31524
+
+git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@300496 91177308-0d34-0410-b5e6-96231b3b80d8
+---
+ cmake/modules/AddLLVM.cmake                   | 3 ++-
+ tools/llvm-shlib/CMakeLists.txt               | 6 +++++-
+ tools/llvm-shlib/simple_version_script.map.in | 1 +
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+ create mode 100644 tools/llvm-shlib/simple_version_script.map.in
+
+diff --git a/cmake/modules/AddLLVM.cmake b/cmake/modules/AddLLVM.cmake
+index 7f7608cff33..e011bb40275 100644
+--- a/cmake/modules/AddLLVM.cmake
++++ b/cmake/modules/AddLLVM.cmake
+@@ -81,8 +81,9 @@ function(add_llvm_symbol_exports target_name export_file)
+     # Gold and BFD ld require a version script rather than a plain list.
+     set(native_export_file "${target_name}.exports")
+     # FIXME: Don't write the "local:" line on OpenBSD.
++    # in the export file, also add a linker script to version LLVM symbols (form: LLVM_N.M)
+     add_custom_command(OUTPUT ${native_export_file}
+-      COMMAND echo "{" > ${native_export_file}
++      COMMAND echo "LLVM_${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR} {" > ${native_export_file}
+       COMMAND grep -q "[[:alnum:]]" ${export_file} && echo "  global:" >> ${native_export_file} || :
+       COMMAND sed -e "s/$/;/" -e "s/^/    /" < ${export_file} >> ${native_export_file}
+       COMMAND echo "  local: *;" >> ${native_export_file}
+diff --git a/tools/llvm-shlib/CMakeLists.txt b/tools/llvm-shlib/CMakeLists.txt
+index c68a2b0e60e..27815868629 100644
+--- a/tools/llvm-shlib/CMakeLists.txt
++++ b/tools/llvm-shlib/CMakeLists.txt
+@@ -38,8 +38,12 @@ add_llvm_library(LLVM SHARED DISABLE_LLVM_LINK_LLVM_DYLIB SONAME ${SOURCES})
+ 
+ list(REMOVE_DUPLICATES LIB_NAMES)
+ if(("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux") OR (MINGW) OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD") OR ("${CMAKE_SYSTEM_NAME}" STREQUAL "DragonFly")) # FIXME: It should be "GNU ld for elf"
++  configure_file(
++  ${CMAKE_CURRENT_SOURCE_DIR}/simple_version_script.map.in
++  ${LLVM_LIBRARY_DIR}/tools/llvm-shlib/simple_version_script.map)
++
+   # GNU ld doesn't resolve symbols in the version script.
+-  set(LIB_NAMES -Wl,--whole-archive ${LIB_NAMES} -Wl,--no-whole-archive)
++  set(LIB_NAMES -Wl,--version-script,${LLVM_LIBRARY_DIR}/tools/llvm-shlib/simple_version_script.map -Wl,--whole-archive ${LIB_NAMES} -Wl,--no-whole-archive)
+ elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+   set(LIB_NAMES -Wl,-all_load ${LIB_NAMES})
+ endif()
+diff --git a/tools/llvm-shlib/simple_version_script.map.in b/tools/llvm-shlib/simple_version_script.map.in
+new file mode 100644
+index 00000000000..e9515fe7862
+--- /dev/null
++++ b/tools/llvm-shlib/simple_version_script.map.in
+@@ -0,0 +1 @@
++LLVM_@LLVM_VERSION_MAJOR@.@LLVM_VERSION_MINOR@ { global: *; };


### PR DESCRIPTION
Should help with crashes when loading multiple libLLVM versions in
the same process, as happens with mesa/llvmpipe when mesa is
dynamically linked against libLLVM. See

  https://github.com/JuliaLang/julia/issues/19606

patch: https://reviews.llvm.org/D31524
commit: https://reviews.llvm.org/rL300496