### PR TITLE
Moved contrib/ctags to github.com/JuliaEditorSupport/julia-ctags

### DIFF
--- a/contrib/ctags
+++ b/contrib/ctags
@@ -1,4 +1,0 @@
---langdef=julia
---langmap=julia:.jl
---regex-julia=/^[ \t]*(function|macro|abstract type|primitive type|struct|mutable struct|typealias)[ \t]+([^ \t({[]+).*$/\2/f,function/
---regex-julia=/^[ \t]*(([^@#$ \t({[]+)|\(([^@#$ \t({[]+)\)|\((\$)\))[ \t]*(\{.*\})?[ \t]*\([^#]*\)[ \t]*=([^=].*$|$)/\2\3\4/f,function/


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/24584 and https://github.com/JuliaEditorSupport/julia-ctags