### PR TITLE
Make `keys(::Tuple)` return a `Tuple`.

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -38,7 +38,7 @@ start(t::Tuple) = 1
 done(t::Tuple, i::Int) = (length(t) < i)
 next(t::Tuple, i::Int) = (t[i], i+1)
 
-keys(t::Tuple) = 1:length(t)
+keys(t::Tuple) = ntuple(identity, Val(length(t)))
 
 prevind(t::Tuple, i::Integer) = Int(i)-1
 nextind(t::Tuple, i::Integer) = Int(i)+1

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -243,6 +243,8 @@ end
 
     @test reverse(()) === ()
     @test reverse((1,2,3)) === (3,2,1)
+
+    @test keys((1, 2.0, :c)) === (1, 2, 3)
 end
 # issue #21697
 @test_throws ArgumentError ntuple(identity, -1)


### PR DESCRIPTION
This seems the most sensible choice to me, so that `keys((1, 2.0, :c)) === (1, 2, 3)`.

I will find this useful where I tend to use things like `map` on `keys` and it's really, really nice to preserve the properties of the container when you do this. Mapping keys of a tuple *might* also be a nicer replacement for some particular usages of `ntuple`. (Use `map(f, keys(t))` instead of `ntuple(f, Val(length(t)))`).

Relatedly, I've been thinking about generalizing `getindex` for getting multiple elements out of dictionaries (#24019) and other containers including tuples, and it seems the easiest definition goes like:
```julia
getindices(A, inds) = map(i -> A[i], inds)
```
where I feel you also want something like this:
```julia
t::Tuple
map(i -> t[i], keys(t)) === t
```
which is provided by this PR.