### PR TITLE
Remove the "experimental" status from non-1 indexing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -226,6 +226,10 @@ Language changes
   * `try` blocks without `catch` or `finally` are no longer allowed. An explicit empty
     `catch` block should be written instead ([#27554]).
 
+  * `AbstractArray` types that use unconventional (not 1-based) indexing can now support
+    `size`, `length`, and `@inbounds`. To optionally enforce conventional indices,
+    you can `@assert !has_offset_axes(A)`.
+
 Breaking changes
 ----------------
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -83,6 +83,17 @@ function axes(A)
     map(OneTo, size(A))
 end
 
+"""
+    has_offset_axes(A)
+    has_offset_axes(A, B, ...)
+
+Return `true` if the indices of `A` start with something other than 1 along any axis.
+If multiple arguments are passed, equivalent to `has_offset_axes(A) | has_offset_axes(B) | ...`.
+"""
+has_offset_axes(A)    = _tuple_any(x->first(x)!=1, axes(A))
+has_offset_axes(A...) = _tuple_any(has_offset_axes, A)
+has_offset_axes(::Colon) = false
+
 # Performance optimization: get rid of a branch on `d` in `axes(A, d)`
 # for d=1. 1d arrays are heavily used, and the first dimension comes up
 # in other applications.

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -86,9 +86,9 @@ end
 # Performance optimization: get rid of a branch on `d` in `axes(A, d)`
 # for d=1. 1d arrays are heavily used, and the first dimension comes up
 # in other applications.
-indices1(A::AbstractArray{<:Any,0}) = OneTo(1)
-indices1(A::AbstractArray) = (@_inline_meta; axes(A)[1])
-indices1(iter) = OneTo(length(iter))
+axes1(A::AbstractArray{<:Any,0}) = OneTo(1)
+axes1(A::AbstractArray) = (@_inline_meta; axes(A)[1])
+axes1(iter) = OneTo(length(iter))
 
 unsafe_indices(A) = axes(A)
 unsafe_indices(r::AbstractRange) = (OneTo(unsafe_length(r)),) # Ranges use checked_sub for size
@@ -161,7 +161,7 @@ _length(A) = (@_inline_meta; length(A))
 eachindex(itrs...) = keys(itrs...)
 
 # eachindex iterates over all indices. IndexCartesian definitions are later.
-eachindex(A::AbstractVector) = (@_inline_meta(); indices1(A))
+eachindex(A::AbstractVector) = (@_inline_meta(); axes1(A))
 
 """
     eachindex(A...)
@@ -210,7 +210,7 @@ function eachindex(A::AbstractArray, B::AbstractArray...)
     eachindex(IndexStyle(A,B...), A, B...)
 end
 eachindex(::IndexLinear, A::AbstractArray) = (@_inline_meta; OneTo(_length(A)))
-eachindex(::IndexLinear, A::AbstractVector) = (@_inline_meta; indices1(A))
+eachindex(::IndexLinear, A::AbstractVector) = (@_inline_meta; axes1(A))
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
     @_inline_meta
     indsA = eachindex(IndexLinear(), A)
@@ -509,7 +509,7 @@ function checkindex(::Type{Bool}, inds::AbstractUnitRange, r::AbstractRange)
     @_propagate_inbounds_meta
     isempty(r) | (checkindex(Bool, inds, first(r)) & checkindex(Bool, inds, last(r)))
 end
-checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractVector{Bool}) = indx == indices1(I)
+checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractVector{Bool}) = indx == axes1(I)
 checkindex(::Type{Bool}, indx::AbstractUnitRange, I::AbstractArray{Bool}) = false
 function checkindex(::Type{Bool}, inds::AbstractUnitRange, I::AbstractArray)
     @_inline_meta
@@ -1148,9 +1148,9 @@ get(A::AbstractArray, I::Dims, default) = checkbounds(Bool, A, I...) ? A[I...] :
 
 function get!(X::AbstractVector{T}, A::AbstractVector, I::Union{AbstractRange,AbstractVector{Int}}, default::T) where T
     # 1d is not linear indexing
-    ind = findall(in(indices1(A)), I)
+    ind = findall(in(axes1(A)), I)
     X[ind] = A[I[ind]]
-    Xind = indices1(X)
+    Xind = axes1(X)
     X[first(Xind):first(ind)-1] = default
     X[last(ind)+1:last(Xind)] = default
     X
@@ -1776,9 +1776,9 @@ _sub2ind(inds::Union{DimsInteger,Indices}, I1::AbstractVector{T}, I::AbstractVec
     _sub2ind_vecs(inds, I1, I...)
 function _sub2ind_vecs(inds, I::AbstractVector...)
     I1 = I[1]
-    Iinds = indices1(I1)
+    Iinds = axes1(I1)
     for j = 2:length(I)
-        indices1(I[j]) == Iinds || throw(DimensionMismatch("indices of I[1] ($(Iinds)) does not match indices of I[$j] ($(indices1(I[j])))"))
+        axes1(I[j]) == Iinds || throw(DimensionMismatch("indices of I[1] ($(Iinds)) does not match indices of I[$j] ($(axes1(I[j])))"))
     end
     Iout = similar(I1)
     _sub2ind!(Iout, inds, Iinds, I)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -165,8 +165,6 @@ julia> length([1 2; 3 4])
 ```
 """
 length(t::AbstractArray) = (@_inline_meta; prod(size(t)))
-_length(A::AbstractArray) = (@_inline_meta; prod(map(unsafe_length, axes(A)))) # circumvent missing size
-_length(A) = (@_inline_meta; length(A))
 
 # `eachindex` is mostly an optimization of `keys`
 eachindex(itrs...) = keys(itrs...)
@@ -220,7 +218,7 @@ function eachindex(A::AbstractArray, B::AbstractArray...)
     @_inline_meta
     eachindex(IndexStyle(A,B...), A, B...)
 end
-eachindex(::IndexLinear, A::AbstractArray) = (@_inline_meta; OneTo(_length(A)))
+eachindex(::IndexLinear, A::AbstractArray) = (@_inline_meta; OneTo(length(A)))
 eachindex(::IndexLinear, A::AbstractVector) = (@_inline_meta; axes1(A))
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
     @_inline_meta
@@ -755,7 +753,7 @@ function copyto!(::IndexStyle, dest::AbstractArray, ::IndexCartesian, src::Abstr
 end
 
 function copyto!(dest::AbstractArray, dstart::Integer, src::AbstractArray)
-    copyto!(dest, dstart, src, first(LinearIndices(src)), _length(src))
+    copyto!(dest, dstart, src, first(LinearIndices(src)), length(src))
 end
 
 function copyto!(dest::AbstractArray, dstart::Integer, src::AbstractArray, sstart::Integer)
@@ -848,7 +846,7 @@ function iterate(A::AbstractArray, state=(eachindex(A),))
     A[y[1]], (state[1], tail(y)...)
 end
 
-isempty(a::AbstractArray) = (_length(a) == 0)
+isempty(a::AbstractArray) = (length(a) == 0)
 
 
 ## range conversions ##

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -39,7 +39,7 @@ julia> vec(1:3)
 
 See also [`reshape`](@ref).
 """
-vec(a::AbstractArray) = reshape(a,_length(a))
+vec(a::AbstractArray) = reshape(a,length(a))
 vec(a::AbstractVector) = a
 
 _sub(::Tuple{}, ::Tuple{}) = ()
@@ -72,7 +72,7 @@ squeeze(A; dims) = _squeeze(A, dims)
 function _squeeze(A::AbstractArray, dims::Dims)
     for i in 1:length(dims)
         1 <= dims[i] <= ndims(A) || throw(ArgumentError("squeezed dims must be in range 1:ndims(A)"))
-        _length(axes(A, dims[i])) == 1 || throw(ArgumentError("squeezed dims must all be size 1"))
+        length(axes(A, dims[i])) == 1 || throw(ArgumentError("squeezed dims must all be size 1"))
         for j = 1:i-1
             dims[j] == dims[i] && throw(ArgumentError("squeezed dims must be unique"))
         end
@@ -158,7 +158,7 @@ function reverse(A::AbstractArray; dims::Integer)
     B = similar(A)
     nnd = 0
     for i = 1:nd
-        nnd += Int(_length(inds[i])==1 || i==d)
+        nnd += Int(length(inds[i])==1 || i==d)
     end
     indsd = inds[d]
     sd = first(indsd)+last(indsd)

--- a/base/array.jl
+++ b/base/array.jl
@@ -445,6 +445,7 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
 end
 
 function _one(unit::T, x::AbstractMatrix) where T
+    @assert !has_offset_axes(x)
     m,n = size(x)
     m==n || throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
     # Matrix{T}(I, m, m)
@@ -748,6 +749,7 @@ function setindex! end
 function setindex!(A::Array, X::AbstractArray, I::AbstractVector{Int})
     @_propagate_inbounds_meta
     @boundscheck setindex_shape_check(X, length(I))
+    @assert !has_offset_axes(X)
     X′ = unalias(A, X)
     I′ = unalias(A, I)
     count = 1
@@ -876,6 +878,7 @@ append!(a::Vector, iter) = _append!(a, IteratorSize(iter), iter)
 push!(a::Vector, iter...) = append!(a, iter)
 
 function _append!(a, ::Union{HasLength,HasShape}, iter)
+    @assert !has_offset_axes(a)
     n = length(a)
     resize!(a, n+length(iter))
     @inbounds for (i,item) in zip(n+1:length(a), iter)
@@ -923,6 +926,7 @@ prepend!(a::Vector, iter) = _prepend!(a, IteratorSize(iter), iter)
 pushfirst!(a::Vector, iter...) = prepend!(a, iter)
 
 function _prepend!(a, ::Union{HasLength,HasShape}, iter)
+    @assert !has_offset_axes(a)
     n = length(iter)
     _growbeg!(a, n)
     i = 0

--- a/base/array.jl
+++ b/base/array.jl
@@ -548,9 +548,9 @@ end
 
 _collect_indices(::Tuple{}, A) = copyto!(Array{eltype(A),0}(undef), A)
 _collect_indices(indsA::Tuple{Vararg{OneTo}}, A) =
-    copyto!(Array{eltype(A)}(undef, _length.(indsA)), A)
+    copyto!(Array{eltype(A)}(undef, length.(indsA)), A)
 function _collect_indices(indsA, A)
-    B = Array{eltype(A)}(undef, _length.(indsA))
+    B = Array{eltype(A)}(undef, length.(indsA))
     copyto!(B, CartesianIndices(axes(B)), A, CartesianIndices(indsA))
 end
 
@@ -868,7 +868,7 @@ themselves in another collection. The result is of the preceding example is equi
 """
 function append!(a::Array{<:Any,1}, items::AbstractVector)
     itemindices = eachindex(items)
-    n = _length(itemindices)
+    n = length(itemindices)
     _growend!(a, n)
     copyto!(a, length(a)-n+1, items, first(itemindices), n)
     return a
@@ -912,7 +912,7 @@ function prepend! end
 
 function prepend!(a::Array{<:Any,1}, items::AbstractVector)
     itemindices = eachindex(items)
-    n = _length(itemindices)
+    n = length(itemindices)
     _growbeg!(a, n)
     if a === items
         copyto!(a, 1, items, n+1, n)

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -78,7 +78,7 @@ function alignment(io::IO, X::AbstractVecOrMat,
             break
         end
     end
-    if 1 < length(a) < _length(axes(X,2))
+    if 1 < length(a) < length(axes(X,2))
         while sum(map(sum,a)) + sep*length(a) >= cols_otherwise
             pop!(a)
         end
@@ -168,7 +168,7 @@ function print_matrix(io::IO, X::AbstractVecOrMat,
     @assert textwidth(hdots) == textwidth(ddots)
     sepsize = length(sep)
     rowsA, colsA = axes(X,1), axes(X,2)
-    m, n = _length(rowsA), _length(colsA)
+    m, n = length(rowsA), length(colsA)
     # To figure out alignments, only need to look at as many rows as could
     # fit down screen. If screen has at least as many rows as A, look at A.
     # If not, then we only need to look at the first and last chunks of A,
@@ -266,10 +266,10 @@ function show_nd(io::IO, a::AbstractArray, print_matrix::Function, label_slices:
             for i = 1:nd
                 ii = idxs[i]
                 ind = tailinds[i]
-                if _length(ind) > 10
+                if length(ind) > 10
                     if ii == ind[firstindex(ind)+3] && all(d->idxs[d]==first(tailinds[d]),1:i-1)
                         for j=i+1:nd
-                            szj = _length(axes(a, j+2))
+                            szj = length(axes(a, j+2))
                             indj = tailinds[j]
                             if szj>10 && first(indj)+2 < idxs[j] <= last(indj)-3
                                 @goto skip
@@ -313,7 +313,7 @@ print_array(io::IO, X::AbstractArray) = show_nd(io, X, print_matrix, true)
 # implements: show(io::IO, ::MIME"text/plain", X::AbstractArray)
 function show(io::IO, ::MIME"text/plain", X::AbstractArray)
     # 0) compute new IOContext
-    if !haskey(io, :compact) && _length(axes(X, 2)) > 1
+    if !haskey(io, :compact) && length(axes(X, 2)) > 1
         io = IOContext(io, :compact => true)
     end
     if get(io, :limit, false) && eltype(X) === Method
@@ -359,7 +359,7 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
     @assert !isempty(X)
     limit = get(io, :limit, false)::Bool
     indr, indc = axes(X,1), axes(X,2)
-    nr, nc = _length(indr), _length(indc)
+    nr, nc = length(indr), length(indc)
     rdots, cdots = false, false
     rr1, rr2 = UnitRange{Int}(indr), 1:0
     cr1, cr2 = UnitRange{Int}(indc), 1:0
@@ -432,7 +432,7 @@ function show_vector(io::IO, v, opn='[', cls=']')
     # directly or indirectly, the context now knows about eltype(v)
     io = IOContext(io, :typeinfo => eltype(v), :compact => get(io, :compact, true))
     limited = get(io, :limit, false)
-    if limited && _length(v) > 20
+    if limited && length(v) > 20
         inds = axes1(v)
         show_delim_array(io, v, opn, ",", "", false, inds[1], inds[1]+9)
         print(io, "  …  ")

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -433,7 +433,7 @@ function show_vector(io::IO, v, opn='[', cls=']')
     io = IOContext(io, :typeinfo => eltype(v), :compact => get(io, :compact, true))
     limited = get(io, :limit, false)
     if limited && _length(v) > 20
-        inds = indices1(v)
+        inds = axes1(v)
         show_delim_array(io, v, opn, ",", "", false, inds[1], inds[1]+9)
         print(io, "  …  ")
         show_delim_array(io, v, "", ",", cls, false, inds[end-9], inds[end])

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -504,7 +504,7 @@ Base.@propagate_inbounds _newindex(ax::Tuple{}, I::Tuple{}) = ()
 @inline function _newindexer(indsA::Tuple)
     ind1 = indsA[1]
     keep, Idefault = _newindexer(tail(indsA))
-    (Base._length(ind1)!=1, keep...), (first(ind1), Idefault...)
+    (Base.length(ind1)!=1, keep...), (first(ind1), Idefault...)
 end
 
 @inline function Base.getindex(bc::Broadcasted, I::Union{Integer,CartesianIndex})

--- a/base/c.jl
+++ b/base/c.jl
@@ -267,6 +267,7 @@ transcode(T, src::String) = transcode(T, codeunits(src))
 transcode(::Type{String}, src) = String(transcode(UInt8, src))
 
 function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
+    @assert !has_offset_axes(src)
     dst = UInt16[]
     i, n = 1, length(src)
     n > 0 || return dst
@@ -317,6 +318,7 @@ function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
 end
 
 function transcode(::Type{UInt8}, src::AbstractVector{UInt16})
+    @assert !has_offset_axes(src)
     n = length(src)
     n == 0 && return UInt8[]
 

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -64,6 +64,7 @@ isperm(p::Tuple{Int}) = p[1] == 1
 isperm(p::Tuple{Int,Int}) = ((p[1] == 1) & (p[2] == 2)) | ((p[1] == 2) & (p[2] == 1))
 
 function permute!!(a, p::AbstractVector{<:Integer})
+    @assert !has_offset_axes(a, p)
     count = 0
     start = 0
     while count < length(a)
@@ -114,6 +115,7 @@ julia> A
 permute!(a, p::AbstractVector) = permute!!(a, copymutable(p))
 
 function invpermute!!(a, p::AbstractVector{<:Integer})
+    @assert !has_offset_axes(a, p)
     count = 0
     start = 0
     while count < length(a)
@@ -194,6 +196,7 @@ julia> B[invperm(v)]
 ```
 """
 function invperm(a::AbstractVector)
+    @assert !has_offset_axes(a)
     b = zero(a) # similar vector of zeros
     n = length(a)
     @inbounds for (i, j) in enumerate(a)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1747,6 +1747,7 @@ end
 @deprecate mapfoldl(f, op, v0, itr) mapfoldl(f, op, itr; init=v0)
 @deprecate mapfoldr(f, op, v0, itr) mapfoldr(f, op, itr; init=v0)
 
+
 @deprecate startswith(a::Vector{UInt8}, b::Vector{UInt8}) length(a) >= length(b) && view(a, 1:length(b)) == b
 
 # PR #27859
@@ -1758,6 +1759,8 @@ function print(io::IO, ::Nothing)
     depwarn("Calling `print` on `nothing` is deprecated; use `show`, `repr`, or custom output instead.", :print)
     show(io, nothing)
 end
+
+@deprecate indices1 axes1
 
 # END 0.7 deprecations
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1761,6 +1761,7 @@ function print(io::IO, ::Nothing)
 end
 
 @deprecate indices1 axes1
+@deprecate _length length
 
 # END 0.7 deprecations
 

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -179,16 +179,16 @@ function setindex_shape_check(X::AbstractArray, I::Integer...)
 end
 
 setindex_shape_check(X::AbstractArray) =
-    (_length(X)==1 || throw_setindex_mismatch(X,()))
+    (length(X)==1 || throw_setindex_mismatch(X,()))
 
 setindex_shape_check(X::AbstractArray, i::Integer) =
-    (_length(X)==i || throw_setindex_mismatch(X, (i,)))
+    (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
 setindex_shape_check(X::AbstractArray{<:Any,1}, i::Integer) =
-    (_length(X)==i || throw_setindex_mismatch(X, (i,)))
+    (length(X)==i || throw_setindex_mismatch(X, (i,)))
 
 setindex_shape_check(X::AbstractArray{<:Any,1}, i::Integer, j::Integer) =
-    (_length(X)==i*j || throw_setindex_mismatch(X, (i,j)))
+    (length(X)==i*j || throw_setindex_mismatch(X, (i,j)))
 
 function setindex_shape_check(X::AbstractArray{<:Any,2}, i::Integer, j::Integer)
     if length(X) != i*j
@@ -291,7 +291,6 @@ first(S::Slice) = first(S.indices)
 last(S::Slice) = last(S.indices)
 size(S::Slice) = (length(S.indices),)
 length(S::Slice) = length(S.indices)
-_length(S::Slice) = length(S.indices)
 unsafe_length(S::Slice) = unsafe_length(S.indices)
 getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -289,9 +289,8 @@ axes1(S::Slice{<:OneTo}) = S.indices
 
 first(S::Slice) = first(S.indices)
 last(S::Slice) = last(S.indices)
-errmsg(A) = error("size not supported for arrays with indices $(axes(A)); see https://docs.julialang.org/en/latest/devdocs/offset-arrays/")
-size(S::Slice) = first(S.indices) == 1 ? (length(S.indices),) : errmsg(S)
-length(S::Slice) = first(S.indices) == 1 ? length(S.indices) : errmsg(S)
+size(S::Slice) = (length(S.indices),)
+length(S::Slice) = length(S.indices)
 _length(S::Slice) = length(S.indices)
 unsafe_length(S::Slice) = unsafe_length(S.indices)
 getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -282,10 +282,10 @@ end
 Slice(S::Slice) = S
 axes(S::Slice) = (S,)
 unsafe_indices(S::Slice) = (S,)
-indices1(S::Slice) = S
+axes1(S::Slice) = S
 axes(S::Slice{<:OneTo}) = (S.indices,)
 unsafe_indices(S::Slice{<:OneTo}) = (S.indices,)
-indices1(S::Slice{<:OneTo}) = S.indices
+axes1(S::Slice{<:OneTo}) = S.indices
 
 first(S::Slice) = first(S.indices)
 last(S::Slice) = last(S.indices)
@@ -361,7 +361,7 @@ LinearIndices(A::Union{AbstractArray,SimpleVector}) = LinearIndices(axes(A))
 
 # AbstractArray implementation
 IndexStyle(::Type{<:LinearIndices}) = IndexLinear()
-axes(iter::LinearIndices) = map(indices1, iter.indices)
+axes(iter::LinearIndices) = map(axes1, iter.indices)
 size(iter::LinearIndices) = map(unsafe_length, iter.indices)
 function getindex(iter::LinearIndices, i::Int)
     @_inline_meta

--- a/base/io.jl
+++ b/base/io.jl
@@ -542,7 +542,7 @@ function write(s::IO, a::Array)
 end
 
 function write(s::IO, a::SubArray{T,N,<:Array}) where {T,N}
-    if !isbitstype(T)
+    if !isbitstype(T) || !isa(a, StridedArray)
         return invoke(write, Tuple{IO, AbstractArray}, s, a)
     end
     elsz = sizeof(T)

--- a/base/io.jl
+++ b/base/io.jl
@@ -804,6 +804,7 @@ The size of `b` will be increased if needed (i.e. if `nb` is greater than `lengt
 and enough bytes could be read), but it will never be decreased.
 """
 function readbytes!(s::IO, b::AbstractArray{UInt8}, nb=length(b))
+    @assert !has_offset_axes(b)
     olb = lb = length(b)
     nr = 0
     while nr < nb && !eof(s)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -16,6 +16,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
 
     function GenericIOBuffer{T}(data::T, readable::Bool, writable::Bool, seekable::Bool, append::Bool,
                                 maxsize::Integer) where T<:AbstractVector{UInt8}
+        @assert !has_offset_axes(data)
         new(data,readable,writable,seekable,append,length(data),maxsize,1,-1)
     end
 end
@@ -167,6 +168,7 @@ function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
 end
 
 function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
+    @assert !has_offset_axes(a)
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
@@ -401,6 +403,7 @@ function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
 end
 
 function write_sub(to::GenericIOBuffer, a::AbstractArray{UInt8}, offs, nel)
+    @assert !has_offset_axes(a)
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
     end

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -774,10 +774,10 @@ _prod_size1(a, A) =
 
 axes(P::ProductIterator) = _prod_indices(P.iterators)
 _prod_indices(::Tuple{}) = ()
-_prod_indices(t::Tuple) = (_prod_indices1(t[1], IteratorSize(t[1]))..., _prod_indices(tail(t))...)
-_prod_indices1(a, ::HasShape)  = axes(a)
-_prod_indices1(a, ::HasLength) = (OneTo(length(a)),)
-_prod_indices1(a, A) =
+_prod_indices(t::Tuple) = (_prod_axes1(t[1], IteratorSize(t[1]))..., _prod_indices(tail(t))...)
+_prod_axes1(a, ::HasShape)  = axes(a)
+_prod_axes1(a, ::HasLength) = (OneTo(length(a)),)
+_prod_axes1(a, A) =
     throw(ArgumentError("Cannot compute indices for object of type $(typeof(a))"))
 
 ndims(p::ProductIterator) = length(axes(p))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -782,7 +782,6 @@ _prod_axes1(a, A) =
 
 ndims(p::ProductIterator) = length(axes(p))
 length(P::ProductIterator) = prod(size(P))
-_length(p::ProductIterator) = prod(map(unsafe_length, axes(p)))
 
 IteratorEltype(::Type{ProductIterator{Tuple{}}}) = HasEltype()
 IteratorEltype(::Type{ProductIterator{Tuple{I}}}) where {I} = IteratorEltype(I)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -247,7 +247,7 @@ module IteratorsMD
         convert(Tuple{Vararg{UnitRange{Int}}}, R)
 
     # AbstractArray implementation
-    Base.axes(iter::CartesianIndices{N,R}) where {N,R} = map(Base.indices1, iter.indices)
+    Base.axes(iter::CartesianIndices{N,R}) where {N,R} = map(Base.axes1, iter.indices)
     Base.IndexStyle(::Type{CartesianIndices{N,R}}) where {N,R} = IndexCartesian()
     @inline function Base.getindex(iter::CartesianIndices{N,<:NTuple{N,Base.OneTo}}, I::Vararg{Int, N}) where {N}
         @boundscheck checkbounds(iter, I...)
@@ -255,7 +255,7 @@ module IteratorsMD
     end
     @inline function Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R}
         @boundscheck checkbounds(iter, I...)
-        CartesianIndex(I .- first.(Base.indices1.(iter.indices)) .+ first.(iter.indices))
+        CartesianIndex(I .- first.(Base.axes1.(iter.indices)) .+ first.(iter.indices))
     end
 
     ndims(R::CartesianIndices) = ndims(typeof(R))
@@ -463,7 +463,7 @@ index_dimsum() = ()
 index_lengths() = ()
 @inline index_lengths(::Real, rest...) = (1, index_lengths(rest...)...)
 @inline index_lengths(A::AbstractArray, rest...) = (length(A), index_lengths(rest...)...)
-@inline index_lengths(A::Slice, rest...) = (_length(indices1(A)), index_lengths(rest...)...)
+@inline index_lengths(A::Slice, rest...) = (_length(axes1(A)), index_lengths(rest...)...)
 
 # shape of array to create for getindex() with indices I, dropping scalars
 # returns a Tuple{Vararg{AbstractUnitRange}} of indices

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -647,7 +647,10 @@ _iterable(X::AbstractArray, I...) = X
     end
 end
 
-diff(a::AbstractVector) = [ a[i+1] - a[i] for i=1:length(a)-1 ]
+function diff(a::AbstractVector)
+    @assert !has_offset_axes(a)
+    [ a[i+1] - a[i] for i=1:length(a)-1 ]
+end
 
 """
     diff(A::AbstractVector)
@@ -1455,6 +1458,7 @@ function _extrema_dims(A::AbstractArray, dims)
 end
 
 @noinline function extrema!(B, A)
+    @assert !has_offset_axes(B, A)
     sA = size(A)
     sB = size(B)
     for I in CartesianIndices(sB)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -321,7 +321,7 @@ module IteratorsMD
     end
 
     simd_inner_length(iter::CartesianIndices{0}, ::CartesianIndex) = 1
-    simd_inner_length(iter::CartesianIndices, I::CartesianIndex) = Base._length(iter.indices[1])
+    simd_inner_length(iter::CartesianIndices, I::CartesianIndex) = Base.length(iter.indices[1])
 
     simd_index(iter::CartesianIndices{0}, ::CartesianIndex, I1::Int) = first(iter)
     @inline function simd_index(iter::CartesianIndices, Ilast::CartesianIndex, I1::Int)
@@ -463,7 +463,7 @@ index_dimsum() = ()
 index_lengths() = ()
 @inline index_lengths(::Real, rest...) = (1, index_lengths(rest...)...)
 @inline index_lengths(A::AbstractArray, rest...) = (length(A), index_lengths(rest...)...)
-@inline index_lengths(A::Slice, rest...) = (_length(axes1(A)), index_lengths(rest...)...)
+@inline index_lengths(A::Slice, rest...) = (length(axes1(A)), index_lengths(rest...)...)
 
 # shape of array to create for getindex() with indices I, dropping scalars
 # returns a Tuple{Vararg{AbstractUnitRange}} of indices
@@ -898,7 +898,7 @@ circshift!(dest::AbstractArray, src, shiftamt) = circshift!(dest, src, (shiftamt
                              inds::Tuple{AbstractUnitRange,Vararg{Any}},
                              shiftamt::Tuple{Integer,Vararg{Any}})
     ind1, d = inds[1], shiftamt[1]
-    s = mod(d, _length(ind1))
+    s = mod(d, length(ind1))
     sf, sl = first(ind1)+s, last(ind1)-s
     r1, r2 = first(ind1):sf-1, sf:last(ind1)
     r3, r4 = first(ind1):sl, sl+1:last(ind1)
@@ -946,7 +946,7 @@ true
 function circcopy!(dest, src)
     dest === src && throw(ArgumentError("dest and src must be separate arrays"))
     indssrc, indsdest = axes(src), axes(dest)
-    if (szsrc = map(_length, indssrc)) != (szdest = map(_length, indsdest))
+    if (szsrc = map(length, indssrc)) != (szdest = map(length, indsdest))
         throw(DimensionMismatch("src and dest must have the same sizes (got $szsrc and $szdest)"))
     end
     shift = map((isrc, idest)->first(isrc)-first(idest), indssrc, indsdest)
@@ -958,7 +958,7 @@ end
 @inline function _circcopy!(dest, rdest, indsdest::Tuple{AbstractUnitRange,Vararg{Any}},
                             src,  rsrc,  indssrc::Tuple{AbstractUnitRange,Vararg{Any}})
     indd1, inds1 = indsdest[1], indssrc[1]
-    l = _length(indd1)
+    l = length(indd1)
     s = mod(first(inds1)-first(indd1), l)
     sdf = first(indd1)+s
     rd1, rd2 = first(indd1):sdf-1, sdf:last(indd1)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -169,7 +169,7 @@ function check_reducedims(R, A)
     had_nonreduc = false
     for i = 1:ndims(A)
         Ri, Ai = axes(R, i), axes(A, i)
-        sRi, sAi = _length(Ri), _length(Ai)
+        sRi, sAi = length(Ri), length(Ai)
         if sRi == 1
             if sAi > 1
                 if had_nonreduc
@@ -209,7 +209,7 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArray)
 
     if has_fast_linear_indexing(A) && lsiz > 16
         # use mapreduce_impl, which is probably better tuned to achieve higher performance
-        nslices = div(_length(A), lsiz)
+        nslices = div(length(A), lsiz)
         ibase = first(LinearIndices(A))-1
         for i = 1:nslices
             @inbounds R[i] = op(R[i], mapreduce_impl(f, op, A, ibase+1, ibase+lsiz))
@@ -795,7 +795,7 @@ function _findmax(A, region)
     end
 end
 
-reducedim1(R, A) = _length(axes1(R)) == 1
+reducedim1(R, A) = length(axes1(R)) == 1
 
 """
     argmin(A; dims) -> indices

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -221,7 +221,7 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArray)
     keep, Idefault = Broadcast.shapeindexer(indsRt)
     if reducedim1(R, A)
         # keep the accumulator as a local variable when reducing along the first dimension
-        i1 = first(indices1(R))
+        i1 = first(axes1(R))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
             r = R[i1,IR]
@@ -663,7 +663,7 @@ function findminmax!(f, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
     y = iterate(ks)
     zi = zero(eltype(ks))
     if reducedim1(Rval, A)
-        i1 = first(indices1(Rval))
+        i1 = first(axes1(Rval))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
             tmpRv = Rval[i1,IR]
@@ -795,7 +795,7 @@ function _findmax(A, region)
     end
 end
 
-reducedim1(R, A) = _length(indices1(R)) == 1
+reducedim1(R, A) = _length(axes1(R)) == 1
 
 """
     argmin(A; dims) -> indices

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -145,6 +145,7 @@ _reshape(parent::Array, dims::Dims) = reshape(parent, dims)
 
 # When reshaping Vector->Vector, don't wrap with a ReshapedArray
 function _reshape(v::AbstractVector, dims::Dims{1})
+    @assert !has_offset_axes(v)
     len = dims[1]
     len == length(v) || _throw_dmrs(_length(v), "length", len)
     v

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -102,12 +102,12 @@ reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = _reshape
 @inline function _reshape_uncolon(A, dims)
     @noinline throw1(dims) = throw(DimensionMismatch(string("new dimensions $(dims) ",
         "may have at most one omitted dimension specified by `Colon()`")))
-    @noinline throw2(A, dims) = throw(DimensionMismatch(string("array size $(_length(A)) ",
+    @noinline throw2(A, dims) = throw(DimensionMismatch(string("array size $(length(A)) ",
         "must be divisible by the product of the new dimensions $dims")))
     pre = _before_colon(dims...)
     post = _after_colon(dims...)
     any(d -> d isa Colon, post) && throw1(dims)
-    sz, remainder = divrem(_length(A), prod(pre)*prod(post))
+    sz, remainder = divrem(length(A), prod(pre)*prod(post))
     remainder == 0 || throw2(A, dims)
     (pre..., Int(sz), post...)
 end
@@ -124,8 +124,8 @@ end
 # Move elements from inds to out until out reaches the desired
 # dimensionality N, either filling with OneTo(1) or collapsing the
 # product of trailing dims into the last element
-rdims_trailing(l, inds...) = _length(l) * rdims_trailing(inds...)
-rdims_trailing(l) = _length(l)
+rdims_trailing(l, inds...) = length(l) * rdims_trailing(inds...)
+rdims_trailing(l) = length(l)
 rdims(out::Val{N}, inds::Tuple) where {N} = rdims(ntuple(i -> OneTo(1), Val(N)), inds)
 rdims(out::Tuple{}, inds::Tuple{}) = () # N == 0, M == 0
 rdims(out::Tuple{}, inds::Tuple{Any}) = ()
@@ -147,12 +147,12 @@ _reshape(parent::Array, dims::Dims) = reshape(parent, dims)
 function _reshape(v::AbstractVector, dims::Dims{1})
     @assert !has_offset_axes(v)
     len = dims[1]
-    len == length(v) || _throw_dmrs(_length(v), "length", len)
+    len == length(v) || _throw_dmrs(length(v), "length", len)
     v
 end
 # General reshape
 function _reshape(parent::AbstractArray, dims::Dims)
-    n = _length(parent)
+    n = length(parent)
     prod(dims) == n || _throw_dmrs(n, "size", dims)
     __reshape((parent, IndexStyle(parent)), dims)
 end
@@ -167,7 +167,7 @@ _reshape(R::ReshapedArray, dims::Dims) = _reshape(R.parent, dims)
 
 function __reshape(p::Tuple{AbstractArray,IndexCartesian}, dims::Dims)
     parent = p[1]
-    strds = front(size_to_strides(map(_length, axes(parent))..., 1))
+    strds = front(size_to_strides(map(length, axes(parent))..., 1))
     strds1 = map(s->max(1,Int(s)), strds)  # for resizing empty arrays
     mi = map(SignedMultiplicativeInverse, strds1)
     ReshapedArray(parent, dims, reverse(mi))

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -186,7 +186,7 @@ size(A::ReshapedArray) = A.dims
 similar(A::ReshapedArray, eltype::Type, dims::Dims) = similar(parent(A), eltype, dims)
 IndexStyle(::Type{<:ReshapedArrayLF}) = IndexLinear()
 parent(A::ReshapedArray) = A.parent
-parentindices(A::ReshapedArray) = map(s->1:s, size(parent(A)))
+parentindices(A::ReshapedArray) = map(OneTo, size(parent(A)))
 reinterpret(::Type{T}, A::ReshapedArray, dims::Dims) where {T} = reinterpret(T, parent(A), dims)
 elsize(::Type{<:ReshapedArray{<:Any,<:Any,P}}) where {P} = elsize(P)
 

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -44,7 +44,7 @@ check_body!(x) = true
 simd_outer_range(r) = 0:0
 
 # Get trip count for inner loop.
-@inline simd_inner_length(r,j::Int) = Base._length(r)
+@inline simd_inner_length(r,j::Int) = Base.length(r)
 
 # Construct user-level element from original range, outer loop index j, and inner loop index i.
 @inline simd_index(r,j::Int,i) = (@inbounds ret = r[i+firstindex(r)]; ret)

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -10,7 +10,7 @@ using .Base: copymutable, LinearIndices, _length, (:),
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
     extrema, sub_with_overflow, add_with_overflow, oneunit, div, getindex, setindex!,
-    length, resize!, fill, Missing
+    length, resize!, fill, Missing, has_offset_axes
 
 using .Base: >>>, !==
 
@@ -225,6 +225,7 @@ function searchsorted(v::AbstractVector, x, ilo::Int, ihi::Int, o::Ordering)
 end
 
 function searchsortedlast(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
+    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -234,6 +235,7 @@ function searchsortedlast(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
 end
 
 function searchsortedfirst(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
+    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
     if step(a) == 0
         lt(o, first(a), x) ? length(a) + 1 : 1
     else
@@ -243,6 +245,7 @@ function searchsortedfirst(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
 end
 
 function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrdering)
+    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -251,6 +254,7 @@ function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderin
 end
 
 function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrdering)
+    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
     if step(a) == 0
         lt(o, first(a), x) ? length(a)+1 : 1
     else
@@ -259,6 +263,7 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderi
 end
 
 function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOrdering)
+    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
     if lt(o, first(a), x)
         if step(a) == 0
             length(a) + 1
@@ -271,6 +276,7 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOr
 end
 
 function searchsortedlast(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOrdering)
+    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
     if lt(o, x, first(a))
         0
     elseif step(a) == 0

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -5,7 +5,7 @@ module Sort
 import ..@__MODULE__, ..parentmodule
 const Base = parentmodule(@__MODULE__)
 using .Base.Order
-using .Base: copymutable, LinearIndices, _length, (:),
+using .Base: copymutable, LinearIndices, length, (:),
     eachindex, axes, first, last, similar, start, next, done, zip, OrdinalRange,
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
@@ -628,7 +628,7 @@ function sort!(v::AbstractVector;
                order::Ordering=Forward)
     ordr = ord(lt,by,rev,order)
     if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
-        n = _length(v)
+        n = length(v)
         if n > 1
             min, max = extrema(v)
             (diff, o1) = sub_with_overflow(max, min)
@@ -786,7 +786,7 @@ function sortperm(v::AbstractVector;
                   order::Ordering=Forward)
     ordr = ord(lt,by,rev,order)
     if ordr === Forward && isa(v,Vector) && eltype(v)<:Integer
-        n = _length(v)
+        n = length(v)
         if n > 1
             min, max = extrema(v)
             (diff, o1) = sub_with_overflow(max, min)
@@ -911,7 +911,7 @@ function sort(A::AbstractArray;
         Base.depwarn("`initialized` keyword argument is deprecated", :sort)
     end
     order = ord(lt,by,rev,order)
-    n = _length(axes(A, dim))
+    n = length(axes(A, dim))
     if dim != 1
         pdims = (dim, setdiff(1:ndims(A), dim)...)  # put the selected dimension first
         Ap = permutedims(A, pdims)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -263,12 +263,12 @@ function length(s::String, i::Int, j::Int)
     j < i && return 0
     @inbounds i, k = thisind(s, i), i
     c = j - i + (i == k)
-    _length(s, i, j, c)
+    length(s, i, j, c)
 end
 
-length(s::String) = _length(s, 1, ncodeunits(s), ncodeunits(s))
+length(s::String) = length(s, 1, ncodeunits(s), ncodeunits(s))
 
-@inline function _length(s::String, i::Int, n::Int, c::Int)
+@inline function length(s::String, i::Int, n::Int, c::Int)
     i < n || return c
     @inbounds b = codeunit(s, i)
     @inbounds while true

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -68,7 +68,7 @@ parentindices(V::SubArray) = V.indices
 
 From an array view `A`, returns the corresponding indices in the parent.
 """
-parentindices(a::AbstractArray) = ntuple(i->OneTo(size(a,i)), ndims(a))
+parentindices(a::AbstractArray) = map(OneTo, size(a))
 
 ## Aliasing detection
 dataids(A::SubArray) = (dataids(A.parent)..., _splatmap(dataids, A.indices)...)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -286,7 +286,7 @@ end
 # The running sum is `f`; the cumulative stride product is `s`.
 # If the parent is a vector, then we offset the parent's own indices with parameters of I
 compute_offset1(parent::AbstractVector, stride1::Integer, I::Tuple{AbstractRange}) =
-    (@_inline_meta; first(I[1]) - first(indices1(I[1]))*stride1)
+    (@_inline_meta; first(I[1]) - first(axes1(I[1]))*stride1)
 # If the result is one-dimensional and it's a Colon, then linear
 # indexing uses the indices along the given dimension. Otherwise
 # linear indexing always starts with 1.

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -20,6 +20,7 @@ length(@nospecialize t::Tuple) = nfields(t)
 firstindex(@nospecialize t::Tuple) = 1
 lastindex(@nospecialize t::Tuple) = length(t)
 size(@nospecialize(t::Tuple), d) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
+axes(@nospecialize t::Tuple) = OneTo(length(t))
 @eval getindex(t::Tuple, i::Int) = getfield(t, i, $(Expr(:boundscheck)))
 @eval getindex(t::Tuple, i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...,)
@@ -394,6 +395,14 @@ any(x::Tuple{}) = false
 any(x::Tuple{Bool}) = x[1]
 any(x::Tuple{Bool, Bool}) = x[1]|x[2]
 any(x::Tuple{Bool, Bool, Bool}) = x[1]|x[2]|x[3]
+
+# equivalent to any(f, t), to be used only in bootstrap
+_tuple_any(f::Function, t::Tuple) = _tuple_any(f, false, t...)
+function _tuple_any(f::Function, tf::Bool, a, b...)
+    @_inline_meta
+    _tuple_any(f, tf | f(a), b...)
+end
+_tuple_any(f::Function, tf::Bool) = tf
 
 """
     empty(x::Tuple)

--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -1,17 +1,25 @@
 # [Arrays with custom indices](@id man-custom-indices)
 
-Julia 0.5 adds experimental support for arrays with arbitrary indices. Conventionally, Julia's
+Conventionally, Julia's
 arrays are indexed starting at 1, whereas some other languages start numbering at 0, and yet others
 (e.g., Fortran) allow you to specify arbitrary starting indices.  While there is much merit in
 picking a standard (i.e., 1 for Julia), there are some algorithms which simplify considerably
-if you can index outside the range `1:size(A,d)` (and not just `0:size(A,d)-1`, either). Such
-array types are expected to be supplied through packages.
+if you can index outside the range `1:size(A,d)` (and not just `0:size(A,d)-1`, either).
+To facilitate such computations, Julia supports arrays with arbitrary indices.
 
 The purpose of this page is to address the question, "what do I have to do to support such arrays
 in my own code?"  First, let's address the simplest case: if you know that your code will never
 need to handle arrays with unconventional indexing, hopefully the answer is "nothing." Old code,
 on conventional arrays, should function essentially without alteration as long as it was using
 the exported interfaces of Julia.
+If you find it more convenient to just force your users to supply traditional arrays where indexing starts at one, you can add
+
+```julia
+@assert !Base.has_offset_axes(arrays...)
+```
+
+where `arrays...` is a list of the array objects that you wish to check for anything that
+violates 1-based indexing.
 
 ## Generalizing existing code
 
@@ -19,16 +27,16 @@ As an overview, the steps are:
 
   * replace many uses of `size` with `axes`
   * replace `1:length(A)` with `eachindex(A)`, or in some cases `LinearIndices(A)`
-  * replace `length(A)` with `length(LinearIndices(A))`
   * replace explicit allocations like `Array{Int}(size(B))` with `similar(Array{Int}, axes(B))`
 
 These are described in more detail below.
 
-### Background
+### Things to watch out for
 
-Because unconventional indexing breaks deeply-held assumptions throughout the Julia ecosystem,
-early adopters running code that has not been updated are likely to experience errors.  The most
-frustrating bugs would be incorrect results or segfaults (total crashes of Julia).  For example,
+Because unconventional indexing breaks many people's assumptions that all arrays start indexing with 1, there is always the chance that using such arrays will trigger errors.
+The most
+frustrating bugs would be incorrect results or segfaults (total crashes of Julia).
+For example,
 consider the following function:
 
 ```julia
@@ -42,15 +50,9 @@ function mycopy!(dest::AbstractVector, src::AbstractVector)
 end
 ```
 
-This code implicitly assumes that vectors are indexed from 1. Previously that was a safe assumption,
-so this code was fine, but (depending on what types the user passes to this function) it may no
-longer be safe.  If this code continued to work when passed a vector with non-1 indices, it would
-either produce an incorrect answer or it would segfault.  (If you do get segfaults, to help locate
+This code implicitly assumes that vectors are indexed from 1; if `dest` starts at a different index than `src`, there is a chance that this code would trigger a segfault.
+(If you do get segfaults, to help locate
 the cause try running julia with the option `--check-bounds=yes`.)
-
-To ensure that such errors are caught, in Julia 0.5 both `length` and `size`**should** throw an
-error when passed an array with non-1 indexing.  This is designed to force users of such arrays
-to check the code, and inspect it for whether it needs to be generalized.
 
 ### Using `axes` for bounds checks and loop iteration
 
@@ -62,14 +64,7 @@ is `axes(A, d)`.
 Base implements a custom range type, `OneTo`, where `OneTo(n)` means the same thing as `1:n` but
 in a form that guarantees (via the type system) that the lower index is 1. For any new [`AbstractArray`](@ref)
 type, this is the default returned by `axes`, and it indicates that this array type uses "conventional"
-1-based indexing.  Note that if you don't want to be bothered supporting arrays with non-1 indexing,
-you can add the following line:
-
-```julia
-@assert all(x->isa(x, Base.OneTo), axes(A))
-```
-
-at the top of any function.
+1-based indexing.
 
 For bounds checking, note that there are dedicated functions `checkbounds` and `checkindex` which
 can sometimes simplify such tests.
@@ -115,39 +110,10 @@ then "wrap" it in a type that shifts the indices.)
 Note also that `similar(Array{Int}, (axes(A, 2),))` would allocate an `AbstractVector{Int}`
 (i.e., 1-dimensional array) that matches the indices of the columns of `A`.
 
-### Deprecations
-
-In generalizing Julia's code base, at least one deprecation was unavoidable: earlier versions
-of Julia defined `first(::Colon) = 1`, meaning that the first index along a dimension indexed
-by `:` is 1. This definition can no longer be justified, so it was deprecated. There is no provided
-replacement, because the proper replacement depends on what you are doing and might need to know
-more about the array. However, it appears that many uses of `first(::Colon)` are really about
-computing an index offset; when that is the case, a candidate replacement is:
-
-```julia
-indexoffset(r::AbstractVector) = first(r) - 1
-indexoffset(::Colon) = 0
-```
-
-In other words, while `first(:)` does not itself make sense, in general you can say that the offset
-associated with a colon-index is zero.
-
 ## Writing custom array types with non-1 indexing
 
 Most of the methods you'll need to define are standard for any `AbstractArray` type, see [Abstract Arrays](@ref man-interface-array).
 This page focuses on the steps needed to define unconventional indexing.
-
-### Do **not** implement `size` or `length`
-
-Perhaps the majority of pre-existing code that uses `size` will not work properly for arrays with
-non-1 indices.  For that reason, it is much better to avoid implementing these methods, and use
-the resulting `MethodError` to identify code that needs to be audited and perhaps generalized.
-
-### Do **not** annotate bounds checks
-
-Julia 0.5 includes `@boundscheck` to annotate code that can be removed for callers that exploit
-`@inbounds`. Initially, it seems far preferable to run with bounds checking always enabled (i.e.,
-omit the `@boundscheck` annotation so the check always runs).
 
 ### Custom `AbstractUnitRange` types
 
@@ -223,15 +189,21 @@ Base.reshape(A::AbstractArray, shape::Tuple{ZeroRange,Vararg{ZeroRange}}) = ...
 
 and you can `reshape` an array so that the result has custom indices.
 
-## Summary
+### For objects that mimic AbstractArray but are not subtypes
 
-Writing code that doesn't make assumptions about indexing requires a few extra abstractions, but
-hopefully the necessary changes are relatively straightforward.
+`has_offset_axes` depends on having `axes` defined for the objects you call it on. If there is
+some reason you don't have an `axes` method defined for your object, consider defining a method
+```julia
+Base.has_offset_axes(obj::MyNon1IndexedArraylikeObject) = true
+```
+This will allow code that assumes 1-based indexing to detect a problem
+and throw a helpful error, rather than returning incorrect results or
+segfaulting julia.
 
-As a reminder, this support is still experimental. While much of Julia's base code has been updated
-to support unconventional indexing, without a doubt there are many omissions that will be discovered
-only through usage.  Moreover, at the time of this writing, most packages do not support unconventional
-indexing.  As a consequence, early adopters should be prepared to identify and/or fix bugs.  On
-the other hand, only through practical usage will it become clear whether this experimental feature
-should be retained in future versions of Julia; consequently, interested parties are encouraged
-to accept some ownership for putting it through its paces.
+### Catching errors
+
+If your new array type triggers errors in other code, one helpful debugging step can be to comment out `@boundscheck` in your `getindex` and `setindex!` implementation.
+This will ensure that every element access checks bounds. Or, restart julia with `--check-bounds=yes`.
+
+In some cases it may also be helpful to temporarily disable `size` and `length` for your new array type,
+since code that makes incorrect assumptions frequently uses these functions.

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -4,6 +4,8 @@ __precompile__(true)
 
 module Base64
 
+using Base: has_offset_axes
+
 export
     Base64EncodePipe,
     base64encode,

--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -109,6 +109,7 @@ function Base.read(pipe::Base64DecodePipe, ::Type{UInt8})
 end
 
 function Base.readbytes!(pipe::Base64DecodePipe, data::AbstractVector{UInt8}, nb::Integer=length(data))
+    @assert !has_offset_axes(data)
     filled::Int = 0
     while filled < nb && !eof(pipe)
         if length(data) == filled

--- a/stdlib/Distributed/src/pmap.jl
+++ b/stdlib/Distributed/src/pmap.jl
@@ -187,7 +187,7 @@ function wrap_batch(f, p, handle_errors)
             remotecall_fetch(f, p, batch)
         catch e
             if handle_errors
-                return Any[BatchProcessingError(batch[i], e) for i in 1:length(batch)]
+                return Any[BatchProcessingError(b, e) for b in batch]
             else
                 rethrow(e)
             end

--- a/stdlib/Future/src/Future.jl
+++ b/stdlib/Future/src/Future.jl
@@ -23,8 +23,8 @@ copy!(dst::AbstractDict, src::AbstractDict) = merge!(empty!(dst), src)
 copy!(dst::AbstractVector, src::AbstractVector) = append!(empty!(dst), src)
 
 function copy!(dst::AbstractArray, src::AbstractArray)
-    size(dst) == size(src) || throw(ArgumentError(
-        "arrays must have the same size for copy! (consider using `copyto!`)"))
+    axes(dst) == axes(src) || throw(ArgumentError(
+        "arrays must have the same axes for copy! (consider using `copyto!`)"))
     copyto!(dst, src)
 end
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -17,7 +17,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
-using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
+using Base: hvcat_fill, iszero, IndexLinear, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_vcat, has_offset_axes
 using Base.Broadcast: Broadcasted
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -18,11 +18,8 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
 using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
-    @propagate_inbounds, @pure, reduce, typed_vcat
+    @propagate_inbounds, @pure, reduce, typed_vcat, has_offset_axes
 using Base.Broadcast: Broadcasted
-
-# We use `_length` because of non-1 indices; releases after julia 0.5
-# can go back to `length`. `_length(A)` is equivalent to `length(LinearIndices(A))`.
 
 export
 # Modules

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -144,8 +144,8 @@ similar(A::AdjOrTransAbsVec) = wrapperop(A)(similar(A.parent))
 similar(A::AdjOrTransAbsVec, ::Type{T}) where {T} = wrapperop(A)(similar(A.parent, Base.promote_op(wrapperop(A), T)))
 # for matrices, the semantics of the wrapped and unwrapped types are generally the same
 # and as you are allocating with similar anyway, you might as well get something unwrapped
-similar(A::AdjOrTrans) = similar(A.parent, eltype(A), size(A))
-similar(A::AdjOrTrans, ::Type{T}) where {T} = similar(A.parent, T, size(A))
+similar(A::AdjOrTrans) = similar(A.parent, eltype(A), axes(A))
+similar(A::AdjOrTrans, ::Type{T}) where {T} = similar(A.parent, T, axes(A))
 similar(A::AdjOrTrans, ::Type{T}, dims::Dims{N}) where {T,N} = similar(A.parent, T, dims)
 
 # sundry basic definitions
@@ -197,6 +197,7 @@ broadcast(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...
 *(u::AdjointAbsVec, v::AbstractVector) = dot(u.parent, v)
 *(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)
 function *(u::TransposeAbsVec, v::AbstractVector)
+    @assert !has_offset_axes(u, v)
     @boundscheck length(u) == length(v) || throw(DimensionMismatch())
     return sum(@inbounds(u[k]*v[k]) for k in 1:length(u))
 end

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -7,6 +7,7 @@ Interface to BLAS subroutines.
 
 import ..axpy!, ..axpby!
 import Base: copyto!
+using Base: has_offset_axes
 
 export
 # Level 1
@@ -321,6 +322,7 @@ for (fname, elty) in ((:cblas_zdotu_sub,:ComplexF64),
 end
 
 function dot(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasReal
+    @assert !has_offset_axes(DX, DY)
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -328,6 +330,7 @@ function dot(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T}
     GC.@preserve DX DY dot(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 function dotc(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasComplex
+    @assert !has_offset_axes(DX, DY)
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -335,6 +338,7 @@ function dotc(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T
     GC.@preserve DX DY dotc(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 function dotu(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasComplex
+    @assert !has_offset_axes(DX, DY)
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -515,6 +519,7 @@ for (fname, elty) in ((:daxpby_,:Float64), (:saxpby_,:Float32),
 end
 
 function axpby!(alpha::Number, x::Union{DenseArray{T},AbstractVector{T}}, beta::Number, y::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasFloat
+    @assert !has_offset_axes(x, y)
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
@@ -553,6 +558,7 @@ for (fname, elty) in ((:dgemv_,:Float64),
              #*     .. Array Arguments ..
              #      DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function gemv!(trans::AbstractChar, alpha::($elty), A::AbstractVecOrMat{$elty}, X::AbstractVector{$elty}, beta::($elty), Y::AbstractVector{$elty})
+            @assert !has_offset_axes(A, X, Y)
             m,n = size(A,1),size(A,2)
             if trans == 'N' && (length(X) != n || length(Y) != m)
                 throw(DimensionMismatch("A has dimensions $(size(A)), X has length $(length(X)) and Y has length $(length(Y))"))
@@ -637,6 +643,7 @@ for (fname, elty) in ((:dgbmv_,:Float64),
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function gbmv!(trans::AbstractChar, m::Integer, kl::Integer, ku::Integer, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x, y)
             chkstride1(A)
             ccall((@blasfunc($fname), libblas), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt},
@@ -684,6 +691,7 @@ for (fname, elty, lib) in ((:dsymv_,:Float64,libblas),
              #     .. Array Arguments ..
              #      DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function symv!(uplo::AbstractChar, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x, y)
             m, n = size(A)
             if m != n
                 throw(DimensionMismatch("matrix A is $m by $n but must be square"))
@@ -735,6 +743,7 @@ for (fname, elty) in ((:zhemv_,:ComplexF64),
                       (:chemv_,:ComplexF32))
     @eval begin
         function hemv!(uplo::AbstractChar, α::$elty, A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, β::$elty, y::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x, y)
             m, n = size(A)
             if m != n
                 throw(DimensionMismatch("matrix A is $m by $n but must be square"))
@@ -779,6 +788,7 @@ for (fname, elty) in ((:dsbmv_,:Float64),
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function sbmv!(uplo::AbstractChar, k::Integer, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x, y)
             chkstride1(A)
             ccall((@blasfunc($fname), libblas), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
@@ -842,6 +852,7 @@ for (fname, elty) in ((:zhbmv_,:ComplexF64),
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function hbmv!(uplo::AbstractChar, k::Integer, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x, y)
             chkstride1(A)
             ccall((@blasfunc($fname), libblas), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
@@ -897,6 +908,7 @@ for (fname, elty) in ((:dtrmv_,:Float64),
                 # *     .. Array Arguments ..
                 #       DOUBLE PRECISION A(LDA,*),X(*)
         function trmv!(uplo::AbstractChar, trans::AbstractChar, diag::AbstractChar, A::AbstractMatrix{$elty}, x::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x)
             n = checksquare(A)
             if n != length(x)
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -950,6 +962,7 @@ for (fname, elty) in ((:dtrsv_,:Float64),
                 #       .. Array Arguments ..
                 #       DOUBLE PRECISION A(LDA,*),X(*)
         function trsv!(uplo::AbstractChar, trans::AbstractChar, diag::AbstractChar, A::AbstractMatrix{$elty}, x::AbstractVector{$elty})
+            @assert !has_offset_axes(A, x)
             n = checksquare(A)
             if n != length(x)
                 throw(DimensionMismatch("size of A is $n != length(x) = $(length(x))"))
@@ -983,6 +996,7 @@ for (fname, elty) in ((:dger_,:Float64),
                       (:cgerc_,:ComplexF32))
     @eval begin
         function ger!(α::$elty, x::AbstractVector{$elty}, y::AbstractVector{$elty}, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, x, y)
             m, n = size(A)
             if m != length(x) || n != length(y)
                 throw(DimensionMismatch("A has size ($m,$n), x has length $(length(x)), y has length $(length(y))"))
@@ -1015,6 +1029,7 @@ for (fname, elty, lib) in ((:dsyr_,:Float64,libblas),
                            (:csyr_,:ComplexF32,liblapack))
     @eval begin
         function syr!(uplo::AbstractChar, α::$elty, x::AbstractVector{$elty}, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, x)
             n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -1044,6 +1059,7 @@ for (fname, elty, relty) in ((:zher_,:ComplexF64, :Float64),
                              (:cher_,:ComplexF32, :Float32))
     @eval begin
         function her!(uplo::AbstractChar, α::$relty, x::AbstractVector{$elty}, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, x)
             n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -1086,6 +1102,7 @@ for (gemm, elty) in
 #           if any([stride(A,1), stride(B,1), stride(C,1)] .!= 1)
 #               error("gemm!: BLAS module requires contiguous matrix columns")
 #           end  # should this be checked on every call?
+            @assert !has_offset_axes(A, B, C)
             m = size(A, transA == 'N' ? 1 : 2)
             ka = size(A, transA == 'N' ? 2 : 1)
             kb = size(B, transB == 'N' ? 1 : 2)
@@ -1145,6 +1162,7 @@ for (mfname, elty) in ((:dsymm_,:Float64),
              #     .. Array Arguments ..
              #     DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
         function symm!(side::AbstractChar, uplo::AbstractChar, alpha::($elty), A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty}, beta::($elty), C::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B, C)
             m, n = size(C)
             j = checksquare(A)
             if j != (side == 'L' ? m : n)
@@ -1213,6 +1231,7 @@ for (mfname, elty) in ((:zhemm_,:ComplexF64),
              #     .. Array Arguments ..
              #     DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
         function hemm!(side::AbstractChar, uplo::AbstractChar, alpha::($elty), A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty}, beta::($elty), C::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B, C)
             m, n = size(C)
             j = checksquare(A)
             if j != (side == 'L' ? m : n)
@@ -1278,6 +1297,7 @@ for (fname, elty) in ((:dsyrk_,:Float64),
        function syrk!(uplo::AbstractChar, trans::AbstractChar,
                       alpha::($elty), A::AbstractVecOrMat{$elty},
                       beta::($elty), C::AbstractMatrix{$elty})
+           @assert !has_offset_axes(A, C)
            n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
@@ -1334,6 +1354,7 @@ for (fname, elty, relty) in ((:zherk_, :ComplexF64, :Float64),
        #       COMPLEX A(LDA,*),C(LDC,*)
        function herk!(uplo::AbstractChar, trans::AbstractChar, α::$relty, A::AbstractVecOrMat{$elty},
                       β::$relty, C::AbstractMatrix{$elty})
+           @assert !has_offset_axes(A, C)
            n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n
@@ -1377,6 +1398,7 @@ for (fname, elty) in ((:dsyr2k_,:Float64),
         function syr2k!(uplo::AbstractChar, trans::AbstractChar,
                         alpha::($elty), A::AbstractVecOrMat{$elty}, B::AbstractVecOrMat{$elty},
                         beta::($elty), C::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B, C)
             n = checksquare(C)
             nn = size(A, trans == 'N' ? 1 : 2)
             if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
@@ -1417,6 +1439,7 @@ for (fname, elty1, elty2) in ((:zher2k_,:ComplexF64,:Float64), (:cher2k_,:Comple
        function her2k!(uplo::AbstractChar, trans::AbstractChar, alpha::($elty1),
                        A::AbstractVecOrMat{$elty1}, B::AbstractVecOrMat{$elty1},
                        beta::($elty2), C::AbstractMatrix{$elty1})
+           @assert !has_offset_axes(A, B, C)
            n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
@@ -1504,6 +1527,7 @@ for (mmname, smname, elty) in
         #       DOUBLE PRECISION A(LDA,*),B(LDB,*)
         function trmm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::Number,
                        A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             m, n = size(B)
             nA = checksquare(A)
             if nA != (side == 'L' ? m : n)
@@ -1531,6 +1555,7 @@ for (mmname, smname, elty) in
         #       DOUBLE PRECISION A(LDA,*),B(LDB,*)
         function trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar,
                        alpha::$elty, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             m, n = size(B)
             k = checksquare(A)
             if k != (side == 'L' ? m : n)

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -11,6 +11,11 @@ struct BunchKaufman{T,S<:AbstractMatrix} <: Factorization{T}
     symmetric::Bool
     rook::Bool
     info::BlasInt
+
+    function BunchKaufman{T,S}(LD, ipiv, uplo, symmetric, rook, info) where {T,S<:AbstractMatrix}
+        @assert !has_offset_axes(LD)
+        new(LD, ipiv, uplo, symmetric, rook, info)
+    end
 end
 BunchKaufman(A::AbstractMatrix{T}, ipiv::Vector{BlasInt}, uplo::AbstractChar, symmetric::Bool,
              rook::Bool, info::BlasInt) where {T} =
@@ -121,6 +126,7 @@ issymmetric(B::BunchKaufman) = B.symmetric
 ishermitian(B::BunchKaufman) = !B.symmetric
 
 function _ipiv2perm_bk(v::AbstractVector{T}, maxi::Integer, uplo::AbstractChar) where T
+    @assert !has_offset_axes(v)
     p = T[1:maxi;]
     uploL = uplo == 'L'
     i = uploL ? 1 : maxi

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -107,7 +107,7 @@ true
 ```
 """
 bunchkaufman(A::AbstractMatrix{T}, rook::Bool=false; check::Bool = true) where {T} =
-    bunchkaufman!(copy_oftype(A, typeof(sqrt(one(T)))), rook; check = check)
+    bunchkaufman!(copy_oftype(A, typeof(sqrt(oneunit(T)))), rook; check = check)
 
 convert(::Type{BunchKaufman{T}}, B::BunchKaufman{T}) where {T} = B
 convert(::Type{BunchKaufman{T}}, B::BunchKaufman) where {T} =

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -32,6 +32,11 @@ struct Cholesky{T,S<:AbstractMatrix} <: Factorization{T}
     factors::S
     uplo::Char
     info::BlasInt
+
+    function Cholesky{T,S}(factors, uplo, info) where {T,S<:AbstractMatrix}
+        @assert !has_offset_axes(factors)
+        new(factors, uplo, info)
+    end
 end
 Cholesky(A::AbstractMatrix{T}, uplo::Symbol, info::BlasInt) where {T} =
     Cholesky{T,typeof(A)}(A, char_uplo(uplo), info)
@@ -45,6 +50,11 @@ struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
     rank::BlasInt
     tol::Real
     info::BlasInt
+
+    function CholeskyPivoted{T,S}(factors, uplo, piv, rank, tol, info) where {T,S<:AbstractMatrix}
+        @assert !has_offset_axes(factors)
+        new(factors, uplo, piv, rank, tol, info)
+    end
 end
 function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{BlasInt},
                             rank::BlasInt, tol::Real, info::BlasInt) where T
@@ -75,6 +85,7 @@ end
 
 ## Non BLAS/LAPACK element types (generic)
 function _chol!(A::AbstractMatrix, ::Type{UpperTriangular})
+    @assert !has_offset_axes(A)
     n = checksquare(A)
     @inbounds begin
         for k = 1:n
@@ -98,6 +109,7 @@ function _chol!(A::AbstractMatrix, ::Type{UpperTriangular})
     return UpperTriangular(A), convert(BlasInt, 0)
 end
 function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
+    @assert !has_offset_axes(A)
     n = checksquare(A)
     @inbounds begin
         for k = 1:n

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -52,7 +52,7 @@ function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{B
 end
 
 # make a copy that allow inplace Cholesky factorization
-@inline choltype(A) = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
+@inline choltype(A) = promote_type(typeof(sqrt(oneunit(eltype(A)))), Float32)
 @inline cholcopy(A) = copy_oftype(A, choltype(A))
 
 # _chol!. Internal methods for calling unpivoted Cholesky

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -169,6 +169,7 @@ julia> triu!(M, 1)
 ```
 """
 function triu!(M::AbstractMatrix, k::Integer)
+    @assert !has_offset_axes(M)
     m, n = size(M)
     if !(-m + 1 <= k <= n + 1)
         throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
@@ -213,6 +214,7 @@ julia> tril!(M, 2)
 ```
 """
 function tril!(M::AbstractMatrix, k::Integer)
+    @assert !has_offset_axes(M)
     m, n = size(M)
     if !(-m - 1 <= k <= n - 1)
         throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
@@ -236,6 +238,7 @@ tril(M::Matrix, k::Integer) = tril!(copy(M), k)
 Fill the band between diagonals `l` and `u` with the value `x`.
 """
 function fillband!(A::AbstractMatrix{T}, x, l, u) where T
+    @assert !has_offset_axes(A)
     m, n = size(A)
     xT = convert(T, x)
     for j in 1:n
@@ -271,7 +274,10 @@ julia> diagind(A,-1)
 2:4:6
 ```
 """
-diagind(A::AbstractMatrix, k::Integer=0) = diagind(size(A,1), size(A,2), k)
+function diagind(A::AbstractMatrix, k::Integer=0)
+    @assert !has_offset_axes(A)
+    diagind(size(A,1), size(A,2), k)
+end
 
 """
     diag(M, k::Integer=0)
@@ -378,6 +384,7 @@ julia> kron(A, B)
 ```
 """
 function kron(a::AbstractMatrix{T}, b::AbstractMatrix{S}) where {T,S}
+    @assert !has_offset_axes(a, b)
     R = Matrix{promote_op(*,T,S)}(undef, size(a,1)*size(b,1), size(a,2)*size(b,2))
     m = 1
     for j = 1:size(a,2), l = 1:size(b,2), i = 1:size(a,1)

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -186,6 +186,7 @@ _gradient(F::Vector, h::BitVector) = _gradient(F, Array(h))
 _gradient(F::BitVector, h::Vector) = _gradient(Array(F), h)
 _gradient(F::BitVector, h::BitVector) = _gradient(Array(F), Array(h))
 function _gradient(F::AbstractVector, h::Vector)
+    @assert !has_offset_axes(F)
     n = length(F)
     T = typeof(oneunit(eltype(F))/oneunit(eltype(h)))
     g = similar(F, T)
@@ -550,6 +551,7 @@ IndexStyle(::Type{<:RowVector}) = IndexLinear()
 
 # Generic behavior
 @inline function *(rowvec::RowVector, vec::AbstractVector)
+    @assert !has_offset_axes(rowvec, vec)
     if length(rowvec) != length(vec)
         throw(DimensionMismatch("A has dimensions $(size(rowvec)) but B has dimensions $(size(vec))"))
     end

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -160,11 +160,13 @@ end
     lmul!(D, copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag)), size(A)), A))
 
 function rmul!(A::AbstractMatrix, D::Diagonal)
+    @assert !has_offset_axes(A)
     A .= A .* transpose(D.diag)
     return A
 end
 
 function lmul!(D::Diagonal, B::AbstractMatrix)
+    @assert !has_offset_axes(B)
     B .= D.diag .* B
     return B
 end
@@ -304,6 +306,7 @@ function ldiv!(D::Diagonal{T}, v::AbstractVector{T}) where {T}
     v
 end
 function ldiv!(D::Diagonal{T}, V::AbstractMatrix{T}) where {T}
+    @assert !has_offset_axes(V)
     if size(V,1) != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $(size(V,1)) rows"))
     end
@@ -326,6 +329,7 @@ ldiv!(transD::Transpose{<:Any,<:Diagonal{T}}, B::AbstractVecOrMat{T}) where {T} 
     (D = transD.parent; ldiv!(D, B))
 
 function rdiv!(A::AbstractMatrix{T}, D::Diagonal{T}) where {T}
+    @assert !has_offset_axes(A)
     dd = D.diag
     m, n = size(A)
     if (k = length(dd)) ≠ n

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -73,18 +73,21 @@ end
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\)(F::Factorization{T}, B::VecOrMat{Complex{T}}) where T<:BlasReal
+    @assert !has_offset_axes(B)
     c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
     x = ldiv!(F, c2r)
     return reshape(copy(reinterpret(Complex{T}, copy(transpose(reshape(x, div(length(x), 2), 2))))), _ret_size(F, B))
 end
 
 function \(F::Factorization, B::AbstractVecOrMat)
+    @assert !has_offset_axes(B)
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
     BB = similar(B, TFB, size(B))
     copyto!(BB, B)
     ldiv!(F, BB)
 end
 function \(adjF::Adjoint{<:Any,<:Factorization}, B::AbstractVecOrMat)
+    @assert !has_offset_axes(B)
     F = adjF.parent
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
     BB = similar(B, TFB, size(B))
@@ -94,6 +97,7 @@ end
 
 # support the same 3-arg idiom as in our other in-place A_*_B functions:
 function ldiv!(Y::AbstractVecOrMat, A::Factorization, B::AbstractVecOrMat)
+    @assert !has_offset_axes(Y, B)
     m, n = size(A, 1), size(A, 2)
     if m > n
         ldiv!(A, B)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -19,8 +19,8 @@ function generic_lmul!(s::Number, X::AbstractArray)
 end
 
 function generic_mul!(C::AbstractArray, X::AbstractArray, s::Number)
-    if _length(C) != _length(X)
-        throw(DimensionMismatch("first array has length $(_length(C)) which does not match the length of the second, $(_length(X))."))
+    if length(C) != length(X)
+        throw(DimensionMismatch("first array has length $(length(C)) which does not match the length of the second, $(length(X))."))
     end
     for (IC, IX) in zip(eachindex(C), eachindex(X))
         @inbounds C[IC] = X[IX]*s
@@ -29,9 +29,9 @@ function generic_mul!(C::AbstractArray, X::AbstractArray, s::Number)
 end
 
 function generic_mul!(C::AbstractArray, s::Number, X::AbstractArray)
-    if _length(C) != _length(X)
-        throw(DimensionMismatch("first array has length $(_length(C)) which does not
-match the length of the second, $(_length(X))."))
+    if length(C) != length(X)
+        throw(DimensionMismatch("first array has length $(length(C)) which does not
+match the length of the second, $(length(X))."))
     end
     for (IC, IX) in zip(eachindex(C), eachindex(X))
         @inbounds C[IC] = s*X[IX]
@@ -300,7 +300,7 @@ function generic_norm2(x)
     (maxabs == 0 || isinf(maxabs)) && return maxabs
     (v, s) = iterate(x)::Tuple
     T = typeof(maxabs)
-    if isfinite(_length(x)*maxabs*maxabs) && maxabs*maxabs != 0 # Scaling not necessary
+    if isfinite(length(x)*maxabs*maxabs) && maxabs*maxabs != 0 # Scaling not necessary
         sum::promote_type(Float64, T) = norm_sqr(v)
         while true
             y = iterate(x, s)
@@ -333,7 +333,7 @@ function generic_normp(x, p)
         T = typeof(float(norm(v)))
     end
     spp::promote_type(Float64, T) = p
-    if -1 <= p <= 1 || (isfinite(_length(x)*maxabs^spp) && maxabs^spp != 0) # scaling not necessary
+    if -1 <= p <= 1 || (isfinite(length(x)*maxabs^spp) && maxabs^spp != 0) # scaling not necessary
         sum::promote_type(Float64, T) = norm(v)^spp
         while true
             y = iterate(x, s)
@@ -697,9 +697,9 @@ julia> dot([im; im], [1; 1])
 ```
 """
 function dot(x::AbstractArray, y::AbstractArray)
-    lx = _length(x)
-    if lx != _length(y)
-        throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(_length(y))."))
+    lx = length(x)
+    if lx != length(y)
+        throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(length(y))."))
     end
     if lx == 0
         return dot(zero(eltype(x)), zero(eltype(y)))
@@ -1131,9 +1131,9 @@ isdiag(x::Number) = true
 # BLAS-like in-place y = x*α+y function (see also the version in blas.jl
 #                                          for BlasFloat Arrays)
 function axpy!(α, x::AbstractArray, y::AbstractArray)
-    n = _length(x)
-    if n != _length(y)
-        throw(DimensionMismatch("x has length $n, but y has length $(_length(y))"))
+    n = length(x)
+    if n != length(y)
+        throw(DimensionMismatch("x has length $n, but y has length $(length(y))"))
     end
     for (IY, IX) in zip(eachindex(y), eachindex(x))
         @inbounds y[IY] += x[IX]*α
@@ -1142,8 +1142,8 @@ function axpy!(α, x::AbstractArray, y::AbstractArray)
 end
 
 function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractArray, ry::AbstractArray{<:Integer})
-    if _length(rx) != _length(ry)
-        throw(DimensionMismatch("rx has length $(_length(rx)), but ry has length $(_length(ry))"))
+    if length(rx) != length(ry)
+        throw(DimensionMismatch("rx has length $(length(rx)), but ry has length $(length(ry))"))
     elseif !checkindex(Bool, eachindex(IndexLinear(), x), rx)
         throw(BoundsError(x, rx))
     elseif !checkindex(Bool, eachindex(IndexLinear(), y), ry)
@@ -1156,8 +1156,8 @@ function axpy!(α, x::AbstractArray, rx::AbstractArray{<:Integer}, y::AbstractAr
 end
 
 function axpby!(α, x::AbstractArray, β, y::AbstractArray)
-    if _length(x) != _length(y)
-        throw(DimensionMismatch("x has length $(_length(x)), but y has length $(_length(y))"))
+    if length(x) != length(y)
+        throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
     for (IX, IY) in zip(eachindex(x), eachindex(y))
         @inbounds y[IY] = x[IX]*α + y[IY]*β

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -471,6 +471,7 @@ julia> norm(-2, Inf)
 
 # special cases of opnorm
 function opnorm1(A::AbstractMatrix{T}) where T
+    @assert !has_offset_axes(A)
     m, n = size(A)
     Tnorm = typeof(float(real(zero(T))))
     Tsum = promote_type(Float64, Tnorm)
@@ -488,6 +489,7 @@ function opnorm1(A::AbstractMatrix{T}) where T
 end
 
 function opnorm2(A::AbstractMatrix{T}) where T
+    @assert !has_offset_axes(A)
     m,n = size(A)
     if m == 1 || n == 1 return norm2(A) end
     Tnorm = typeof(float(real(zero(T))))
@@ -495,6 +497,7 @@ function opnorm2(A::AbstractMatrix{T}) where T
 end
 
 function opnormInf(A::AbstractMatrix{T}) where T
+    @assert !has_offset_axes(A)
     m,n = size(A)
     Tnorm = typeof(float(real(zero(T))))
     Tsum = promote_type(Float64, Tnorm)
@@ -851,6 +854,7 @@ true
 ```
 """
 function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
+    @assert !has_offset_axes(A, B)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -1010,6 +1014,7 @@ false
 ```
 """
 function istriu(A::AbstractMatrix, k::Integer = 0)
+    @assert !has_offset_axes(A)
     m, n = size(A)
     for j in 1:min(n, m + k - 1)
         for i in max(1, j - k + 1):m
@@ -1051,6 +1056,7 @@ false
 ```
 """
 function istril(A::AbstractMatrix, k::Integer = 0)
+    @assert !has_offset_axes(A)
     m, n = size(A)
     for j in max(1, k + 2):n
         for i in 1:min(j - k - 1, m)
@@ -1163,6 +1169,7 @@ end
 # Elementary reflection similar to LAPACK. The reflector is not Hermitian but
 # ensures that tridiagonalization of Hermitian matrices become real. See lawn72
 @inline function reflector!(x::AbstractVector)
+    @assert !has_offset_axes(x)
     n = length(x)
     @inbounds begin
         ξ1 = x[1]
@@ -1186,6 +1193,7 @@ end
 
 # apply reflector from left
 @inline function reflectorApply!(x::AbstractVector, τ::Number, A::StridedMatrix)
+    @assert !has_offset_axes(x)
     m, n = size(A)
     if length(x) != m
         throw(DimensionMismatch("reflector has length $(length(x)), which must match the first dimension of matrix A, $m"))

--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -327,6 +327,7 @@ function getindex(G::Givens, i::Integer, j::Integer)
 end
 
 function lmul!(G::Givens, A::AbstractVecOrMat)
+    @assert !has_offset_axes(A)
     m, n = size(A, 1), size(A, 2)
     if G.i2 > m
         throw(DimensionMismatch("column indices for rotation are outside the matrix"))
@@ -339,6 +340,7 @@ function lmul!(G::Givens, A::AbstractVecOrMat)
     return A
 end
 function rmul!(A::AbstractMatrix, adjG::Adjoint{<:Any,<:Givens})
+    @assert !has_offset_axes(A)
     G = adjG.parent
     m, n = size(A, 1), size(A, 2)
     if G.i2 > n

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -14,7 +14,7 @@ import ..LinearAlgebra: BlasFloat, BlasInt, LAPACKException,
 
 using ..LinearAlgebra: triu, tril, dot
 
-using Base: iszero
+using Base: iszero, has_offset_axes
 
 #Generic LAPACK error handlers
 """
@@ -120,6 +120,7 @@ for (gbtrf, gbtrs, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   AB( LDAB, * )
         function gbtrf!(kl::Integer, ku::Integer, m::Integer, AB::AbstractMatrix{$elty})
+            @assert !has_offset_axes(AB)
             chkstride1(AB)
             n    = size(AB, 2)
             mnmn = min(m, n)
@@ -143,6 +144,7 @@ for (gbtrf, gbtrs, elty) in
         function gbtrs!(trans::AbstractChar, kl::Integer, ku::Integer, m::Integer,
                         AB::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt},
                         B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(AB, B)
             chkstride1(AB, B, ipiv)
             chktrans(trans)
             info = Ref{BlasInt}()
@@ -221,6 +223,7 @@ for (gebal, gebak, elty, relty) in
         function gebak!(job::AbstractChar, side::AbstractChar,
                         ilo::BlasInt, ihi::BlasInt, scale::AbstractVector{$relty},
                         V::AbstractMatrix{$elty})
+            @assert !has_offset_axes(scale, V)
             chkstride1(scale, V)
             chkside(side)
             chkfinite(V) # balancing routines don't support NaNs and Infs
@@ -279,6 +282,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #  DOUBLE PRECISION   A( LDA, * ), D( * ), E( * ), TAUP( * ),
         #           TAUQ( * ), WORK( * )
         function gebrd!(A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             m, n  = size(A)
             k     = min(m, n)
@@ -312,6 +316,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function gelqf!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m     = BlasInt(size(A, 1))
             n     = BlasInt(size(A, 2))
@@ -342,6 +347,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function geqlf!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m     = BlasInt(size(A, 1))
             n     = BlasInt(size(A, 2))
@@ -373,6 +379,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #       INTEGER            JPVT( * )
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function geqp3!(A::AbstractMatrix{$elty}, jpvt::AbstractVector{BlasInt}, tau::AbstractVector{$elty})
+            @assert !has_offset_axes(A, jpvt, tau)
             chkstride1(A,jpvt,tau)
             m,n = size(A)
             if length(tau) != min(m,n)
@@ -420,6 +427,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         end
 
         function geqrt!(A::AbstractMatrix{$elty}, T::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, T)
             chkstride1(A)
             m, n = size(A)
             minmn = min(m, n)
@@ -444,6 +452,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         end
 
         function geqrt3!(A::AbstractMatrix{$elty}, T::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, T)
             chkstride1(A)
             chkstride1(T)
             m, n = size(A)
@@ -473,6 +482,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function geqrf!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m, n  = size(A)
             if length(tau) != min(m,n)
@@ -501,6 +511,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function gerqf!(A::AbstractMatrix{$elty},tau::AbstractVector{$elty})
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m, n  = size(A)
             if length(tau) != min(m,n)
@@ -530,6 +541,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * )
         function getrf!(A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             m, n = size(A)
             lda  = max(1,stride(A, 2))
@@ -756,6 +768,7 @@ for (tzrzf, ormrz, elty) in
          #       .. Array Arguments ..
          #       COMPLEX*16         A( LDA, * ), TAU( * ), WORK( * )
         function tzrzf!(A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             m, n = size(A)
             if n < m
@@ -792,6 +805,7 @@ for (tzrzf, ormrz, elty) in
         #       COMPLEX*16         A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormrz!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, tau, C)
@@ -857,6 +871,7 @@ for (gels, gesv, getrs, getri, elty) in
         #       CHARACTER          TRANS
         #       INTEGER            INFO, LDA, LDB, LWORK, M, N, NRHS
         function gels!(trans::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chktrans(trans)
             chkstride1(A, B)
             btrn  = trans == 'T'
@@ -901,6 +916,7 @@ for (gels, gesv, getrs, getri, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function gesv!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             n = checksquare(A)
             if size(B,1) != n
@@ -924,6 +940,7 @@ for (gels, gesv, getrs, getri, elty) in
         #      INTEGER            IPIV( * )
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function getrs!(trans::AbstractChar, A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chktrans(trans)
             chkstride1(A, B, ipiv)
             n = checksquare(A)
@@ -947,6 +964,7 @@ for (gels, gesv, getrs, getri, elty) in
         #      INTEGER            IPIV( * )
         #      DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function getri!(A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt})
+            @assert !has_offset_axes(A, ipiv)
             chkstride1(A, ipiv)
             n = checksquare(A)
             if n != length(ipiv)
@@ -1037,6 +1055,7 @@ for (gesvx, elty) in
         function gesvx!(fact::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         AF::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt}, equed::AbstractChar,
                         R::AbstractVector{$elty}, C::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, AF, ipiv, R, C, B)
             chktrans(trans)
             chkstride1(ipiv, R, C, B)
             n    = checksquare(A)
@@ -1106,6 +1125,7 @@ for (gesvx, elty, relty) in
         function gesvx!(fact::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         AF::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt}, equed::AbstractChar,
                         R::AbstractVector{$relty}, C::AbstractVector{$relty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, AF, ipiv, R, C, B)
             chktrans(trans)
             chkstride1(A, AF, ipiv, R, C, B)
             n   = checksquare(A)
@@ -1203,6 +1223,7 @@ for (gelsd, gelsy, elty) in
         #       INTEGER            IWORK( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), S( * ), WORK( * )
         function gelsd!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=-one($elty))
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             m, n  = size(A)
             if size(B, 1) != m
@@ -1245,6 +1266,7 @@ for (gelsd, gelsy, elty) in
         #       INTEGER            JPVT( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function gelsy!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=eps($elty))
+            @assert !has_offset_axes(A, B)
             chkstride1(A)
             m = size(A, 1)
             n = size(A, 2)
@@ -1296,6 +1318,7 @@ for (gelsd, gelsy, elty, relty) in
         #       DOUBLE PRECISION   RWORK( * ), S( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function gelsd!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=-one($relty))
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             m, n  = size(A)
             if size(B, 1) != m
@@ -1341,6 +1364,7 @@ for (gelsd, gelsy, elty, relty) in
         #       DOUBLE PRECISION   RWORK( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function gelsy!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=eps($relty))
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             m, n = size(A)
             nrhs = size(B, 2)
@@ -1414,6 +1438,7 @@ for (gglse, elty) in ((:dgglse_, :Float64),
         #      $                   WORK( * ), X( * )
         function gglse!(A::AbstractMatrix{$elty}, c::AbstractVector{$elty},
                         B::AbstractMatrix{$elty}, d::AbstractVector{$elty})
+            @assert !has_offset_axes(A, c, B, d)
             chkstride1(A, c, B, d)
             m, n = size(A)
             p = size(B, 1)
@@ -1530,6 +1555,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #      DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
         #                        VT( LDVT, * ), WORK( * )
         function gesdd!(job::AbstractChar, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             m, n   = size(A)
             minmn  = min(m, n)
@@ -1610,6 +1636,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #       DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
         #      $                   VT( LDVT, * ), WORK( * )
         function gesvd!(jobu::AbstractChar, jobvt::AbstractChar, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             m, n   = size(A)
             minmn  = min(m, n)
@@ -1678,6 +1705,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
         #      $                   U( LDU, * ), V( LDV, * ), WORK( * )
         function ggsvd!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             m, n = size(A)
             if size(B, 2) != n
@@ -1800,6 +1828,7 @@ for (f, elty) in ((:dggsvd3_, :Float64),
                   (:sggsvd3_, :Float32))
     @eval begin
         function ggsvd3!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             m, n = size(A)
             if size(B, 2) != n
@@ -1856,6 +1885,7 @@ for (f, elty, relty) in ((:zggsvd3_, :ComplexF64, :Float64),
                          (:cggsvd3_, :ComplexF32, :Float32))
     @eval begin
         function ggsvd3!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             m, n = size(A)
             if size(B, 2) != n
@@ -2021,6 +2051,7 @@ for (geevx, ggev, elty) in
         #      $                   B( LDB, * ), BETA( * ), VL( LDVL, * ),
         #      $                   VR( LDVR, * ), WORK( * )
         function ggev!(jobvl::AbstractChar, jobvr::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n, m = checksquare(A,B)
             if n != m
@@ -2167,6 +2198,7 @@ for (geevx, ggev, elty, relty) in
         #      $                   BETA( * ), VL( LDVL, * ), VR( LDVR, * ),
         #      $                   WORK( * )
         function ggev!(jobvl::AbstractChar, jobvr::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
@@ -2265,6 +2297,7 @@ for (laic1, elty) in
         #  DOUBLE PRECISION   W( J ), X( J )
         function laic1!(job::Integer, x::AbstractVector{$elty},
                         sest::$elty, w::AbstractVector{$elty}, gamma::$elty)
+            @assert !has_offset_axes(x, w)
             j = length(x)
             if j != length(w)
                 throw(DimensionMismatch("vectors must have same length, but length of x is $j and length of w is $(length(w))"))
@@ -2298,6 +2331,7 @@ for (laic1, elty, relty) in
        #  COMPLEX*16         W( J ), X( J )
         function laic1!(job::Integer, x::AbstractVector{$elty},
                         sest::$relty, w::AbstractVector{$elty}, gamma::$elty)
+            @assert !has_offset_axes(x, w)
             j = length(x)
             if j != length(w)
                 throw(DimensionMismatch("vectors must have same length, but length of x is $j and length of w is $(length(w))"))
@@ -2331,6 +2365,7 @@ for (gtsv, gttrf, gttrs, elty) in
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), DL( * ), DU( * )
         function gtsv!(dl::AbstractVector{$elty}, d::AbstractVector{$elty}, du::AbstractVector{$elty},
                        B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(dl, d, du, B)
             chkstride1(B, dl, d, du)
             n = length(d)
             if !(n >= length(dl) >= n - 1)
@@ -2361,6 +2396,7 @@ for (gtsv, gttrf, gttrs, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   D( * ), DL( * ), DU( * ), DU2( * )
         function gttrf!(dl::AbstractVector{$elty}, d::AbstractVector{$elty}, du::AbstractVector{$elty})
+            @assert !has_offset_axes(dl, d, du)
             chkstride1(dl,d,du)
             n    = length(d)
             if length(dl) != n - 1
@@ -2390,6 +2426,7 @@ for (gtsv, gttrf, gttrs, elty) in
         function gttrs!(trans::AbstractChar, dl::AbstractVector{$elty}, d::AbstractVector{$elty},
                         du::AbstractVector{$elty}, du2::AbstractVector{$elty}, ipiv::AbstractVector{BlasInt},
                         B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(dl, d, du, du2, ipiv, B)
             chktrans(trans)
             chkstride1(B, ipiv, dl, d, du, du2)
             n = length(d)
@@ -2459,6 +2496,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orglq!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             n = size(A, 2)
             m = min(n, size(A, 1))
@@ -2492,6 +2530,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgqr!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m = size(A, 1)
             n = min(m, size(A, 2))
@@ -2527,6 +2566,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgql!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m = size(A, 1)
             n = min(m, size(A, 2))
@@ -2562,6 +2602,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgrq!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
+            @assert !has_offset_axes(A, tau)
             chkstride1(A,tau)
             m, n = size(A)
             if n < m
@@ -2598,6 +2639,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormlq!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2644,6 +2686,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormqr!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2693,6 +2736,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormql!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2742,6 +2786,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormrq!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2780,6 +2825,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         end
 
         function gemqrt!(side::AbstractChar, trans::AbstractChar, V::AbstractMatrix{$elty}, T::AbstractMatrix{$elty}, C::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(V, T, C)
             chktrans(trans)
             chkside(side)
             chkstride1(V, T, C)
@@ -2930,6 +2976,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #     .. Array Arguments ..
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function posv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -2953,6 +3000,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * )
         function potrf!(uplo::AbstractChar, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             checksquare(A)
             chkuplo(uplo)
@@ -2978,6 +3026,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * )
         function potri!(uplo::AbstractChar, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             chkuplo(uplo)
             info = Ref{BlasInt}()
@@ -2996,6 +3045,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #     .. Array Arguments ..
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function potrs!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A, B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -3113,6 +3163,7 @@ for (ptsv, pttrf, elty, relty) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), E( * )
         function ptsv!(D::AbstractVector{$relty}, E::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(D, E, B)
             chkstride1(B, D, E)
             n = length(D)
             if length(E) != n - 1
@@ -3136,6 +3187,7 @@ for (ptsv, pttrf, elty, relty) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   D( * ), E( * )
         function pttrf!(D::AbstractVector{$relty}, E::AbstractVector{$elty})
+            @assert !has_offset_axes(D, E)
             chkstride1(D, E)
             n = length(D)
             if length(E) != n - 1
@@ -3179,6 +3231,7 @@ for (pttrs, elty, relty) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), E( * )
         function pttrs!(D::AbstractVector{$relty}, E::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(D, E, B)
             chkstride1(B, D, E)
             n = length(D)
             if length(E) != n - 1
@@ -3211,6 +3264,7 @@ for (pttrs, elty, relty) in
         #       DOUBLE PRECISION   D( * )
         #       COMPLEX*16         B( LDB, * ), E( * )
         function pttrs!(uplo::AbstractChar, D::AbstractVector{$relty}, E::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(D, E, B)
             chkstride1(B, D, E)
             chkuplo(uplo)
             n = length(D)
@@ -3276,6 +3330,7 @@ for (trtri, trtrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function trtrs!(uplo::AbstractChar, trans::AbstractChar, diag::AbstractChar,
                         A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chktrans(trans)
             chkdiag(diag)
             chkstride1(A)
@@ -3363,6 +3418,7 @@ for (trcon, trevc, trrfs, elty) in
         function trevc!(side::AbstractChar, howmny::AbstractChar, select::AbstractVector{BlasInt}, T::AbstractMatrix{$elty},
                         VL::AbstractMatrix{$elty} = similar(T),
                         VR::AbstractMatrix{$elty} = similar(T))
+            @assert !has_offset_axes(select, T, VL, VR)
             # Extract
             if side ∉ ['L','R','B']
                 throw(ArgumentError("side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
@@ -3422,6 +3478,7 @@ for (trcon, trevc, trrfs, elty) in
                 A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, X::AbstractVecOrMat{$elty},
                 Ferr::AbstractVector{$elty} = similar(B, $elty, size(B,2)),
                 Berr::AbstractVector{$elty} = similar(B, $elty, size(B,2)))
+            @assert !has_offset_axes(A, B, X, Ferr, Berr)
             chkstride1(A, B, X, Ferr, Berr)
             chktrans(trans)
             chkuplo(uplo)
@@ -3493,6 +3550,7 @@ for (trcon, trevc, trrfs, elty, relty) in
         function trevc!(side::AbstractChar, howmny::AbstractChar, select::AbstractVector{BlasInt}, T::AbstractMatrix{$elty},
                         VL::AbstractMatrix{$elty} = similar(T),
                         VR::AbstractMatrix{$elty} = similar(T))
+            @assert !has_offset_axes(select, T, VL, VR)
             # Extract
             n, mm = checksquare(T), size(VL, 2)
             ldt, ldvl, ldvr = stride(T, 2), stride(VL, 2), stride(VR, 2)
@@ -3552,6 +3610,7 @@ for (trcon, trevc, trrfs, elty, relty) in
                         A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, X::AbstractVecOrMat{$elty},
                         Ferr::AbstractVector{$relty} = similar(B, $relty, size(B,2)),
                         Berr::AbstractVector{$relty} = similar(B, $relty, size(B,2)))
+            @assert !has_offset_axes(A, B, X, Ferr, Berr)
             chkstride1(A, B, X, Ferr, Berr)
             chktrans(trans)
             chkuplo(uplo)
@@ -3626,6 +3685,7 @@ for (stev, stebz, stegr, stein, elty) in
      )
     @eval begin
         function stev!(job::AbstractChar, dv::AbstractVector{$elty}, ev::AbstractVector{$elty})
+            @assert !has_offset_axes(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
@@ -3647,6 +3707,7 @@ for (stev, stebz, stegr, stein, elty) in
         #*  in the half-open interval (VL, VU], or the IL-th through IU-th
         #*  eigenvalues.
         function stebz!(range::AbstractChar, order::AbstractChar, vl::$elty, vu::$elty, il::Integer, iu::Integer, abstol::Real, dv::AbstractVector{$elty}, ev::AbstractVector{$elty})
+            @assert !has_offset_axes(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
@@ -3677,6 +3738,7 @@ for (stev, stebz, stegr, stein, elty) in
         end
 
         function stegr!(jobz::AbstractChar, range::AbstractChar, dv::AbstractVector{$elty}, ev::AbstractVector{$elty}, vl::Real, vu::Real, il::Integer, iu::Integer)
+            @assert !has_offset_axes(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
@@ -3718,6 +3780,7 @@ for (stev, stebz, stegr, stein, elty) in
         end
 
         function stein!(dv::AbstractVector{$elty}, ev_in::AbstractVector{$elty}, w_in::AbstractVector{$elty}, iblock_in::AbstractVector{BlasInt}, isplit_in::AbstractVector{BlasInt})
+            @assert !has_offset_axes(dv, ev_in, w_in, iblock_in, isplit_in)
             chkstride1(dv, ev_in, w_in, iblock_in, isplit_in)
             n = length(dv)
             if length(ev_in) != n - 1
@@ -3857,6 +3920,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -3976,6 +4040,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function sytrs!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4007,6 +4072,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4097,6 +4163,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function sytrs_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4124,6 +4191,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
         function syconvf_rook!(uplo::AbstractChar, way::AbstractChar,
                                 A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt},
                                 e::AbstractVector{$elty} = Vector{$elty}(undef, length(ipiv)))
+            @assert !has_offset_axes(A, ipiv, e)
             # extract
             n = checksquare(A)
             lda = max(1, stride(A, 2))
@@ -4193,6 +4261,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function hesv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4310,6 +4379,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function hetrs!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             if n != size(B,1)
@@ -4339,6 +4409,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function hesv_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4426,6 +4497,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function hetrs_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                              ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             if n != size(B,1)
@@ -4456,6 +4528,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4576,6 +4649,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function sytrs!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4607,6 +4681,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4698,6 +4773,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function sytrs_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                              ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
+            @assert !has_offset_axes(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4725,6 +4801,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
         function syconvf_rook!(uplo::AbstractChar, way::AbstractChar,
                                 A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt},
                                 e::AbstractVector{$elty} = Vector{$elty}(undef, length(ipiv)))
+            @assert !has_offset_axes(A, ipiv, e)
             chkstride1(A, ipiv, e)
 
             # extract
@@ -5205,6 +5282,7 @@ for (bdsqr, relty, elty) in
     @eval begin
         function bdsqr!(uplo::AbstractChar, d::AbstractVector{$relty}, e_::AbstractVector{$relty},
                         Vt::AbstractMatrix{$elty}, U::AbstractMatrix{$elty}, C::AbstractMatrix{$elty})
+            @assert !has_offset_axes(d, e_, Vt, U, C)
             chkstride1(d, e_, Vt, U, C)
             # Extract number
             n = length(d)
@@ -5274,6 +5352,7 @@ for (bdsdc, elty) in
         #      DOUBLE PRECISION   D( * ), E( * ), Q( * ), U( LDU, * ),
         #     $                   VT( LDVT, * ), WORK( * )
         function bdsdc!(uplo::AbstractChar, compq::AbstractChar, d::AbstractVector{$elty}, e_::AbstractVector{$elty})
+            @assert !has_offset_axes(d, e_)
             chkstride1(d, e_)
             n, ldiq, ldq, ldu, ldvt = length(d), 1, 1, 1, 1
             chkuplo(uplo)
@@ -5468,6 +5547,7 @@ for (orghr, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orghr!(ilo::Integer, ihi::Integer, A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
+            @assert !has_offset_axes(A, tau)
             chkstride1(A, tau)
             n = checksquare(A)
             if n - length(tau) != 1
@@ -5518,6 +5598,7 @@ for (ormhr, elty) in
         function ormhr!(side::AbstractChar, trans::AbstractChar, ilo::Integer, ihi::Integer, A::AbstractMatrix{$elty},
             tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
 
+            @assert !has_offset_axes(A, tau, C)
             chkstride1(A, tau, C)
             n = checksquare(A)
             mC, nC = size(C, 1), size(C, 2)
@@ -5566,6 +5647,7 @@ for (gees, gges, elty) in
         #     DOUBLE PRECISION   A( LDA, * ), VS( LDVS, * ), WI( * ), WORK( * ),
         #    $                   WR( * )
         function gees!(jobvs::AbstractChar, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             n     = checksquare(A)
             sdim  = Vector{BlasInt}(undef, 1)
@@ -5659,6 +5741,7 @@ for (gees, gges, elty, relty) in
         #       DOUBLE PRECISION   RWORK( * )
         #       COMPLEX*16         A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
         function gees!(jobvs::AbstractChar, A::AbstractMatrix{$elty})
+            @assert !has_offset_axes(A)
             chkstride1(A)
             n     = checksquare(A)
             sort  = 'N'
@@ -6103,6 +6186,7 @@ for (fn, elty, relty) in ((:dtrsyl_, :Float64, :Float64),
     @eval begin
         function trsyl!(transa::AbstractChar, transb::AbstractChar, A::AbstractMatrix{$elty},
                         B::AbstractMatrix{$elty}, C::AbstractMatrix{$elty}, isgn::Int=1)
+            @assert !has_offset_axes(A, B, C)
             chkstride1(A, B, C)
             m, n = checksquare(A, B)
             lda = max(1, stride(A, 2))

--- a/stdlib/LinearAlgebra/src/ldlt.jl
+++ b/stdlib/LinearAlgebra/src/ldlt.jl
@@ -92,6 +92,7 @@ end
 factorize(S::SymTridiagonal) = ldlt(S)
 
 function ldiv!(S::LDLt{T,M}, B::AbstractVecOrMat{T}) where {T,M<:SymTridiagonal{T}}
+    @assert !has_offset_axes(B)
     n, nrhs = size(B, 1), size(B, 2)
     if size(S,1) != n
         throw(DimensionMismatch("Matrix has dimensions $(size(S)) but right hand side has first dimension $n"))

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -277,6 +277,7 @@ end
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\)(F::LQ{T}, B::VecOrMat{Complex{T}}) where T<:BlasReal
+    @assert !has_offset_axes(B)
     c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
     x = ldiv!(F, c2r)
     return reshape(copy(reinterpret(Complex{T}, copy(transpose(reshape(x, div(length(x), 2), 2))))),

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -262,6 +262,7 @@ size(A::LU)    = size(getfield(A, :factors))
 size(A::LU, i) = size(getfield(A, :factors), i)
 
 function ipiv2perm(v::AbstractVector{T}, maxi::Integer) where T
+    @assert !has_offset_axes(v)
     p = T[1:maxi;]
     @inbounds for i in 1:length(v)
         p[i], p[v[i]] = p[v[i]], p[i]
@@ -507,6 +508,7 @@ end
 
 # See dgtts2.f
 function ldiv!(A::LU{T,Tridiagonal{T,V}}, B::AbstractVecOrMat) where {T,V}
+    @assert !has_offset_axes(B)
     n = size(A,1)
     if n != size(B,1)
         throw(DimensionMismatch("matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
@@ -538,6 +540,7 @@ function ldiv!(A::LU{T,Tridiagonal{T,V}}, B::AbstractVecOrMat) where {T,V}
 end
 
 function ldiv!(transA::Transpose{<:Any,<:LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat) where {T,V}
+    @assert !has_offset_axes(B)
     A = transA.parent
     n = size(A,1)
     if n != size(B,1)
@@ -574,6 +577,7 @@ end
 
 # Ac_ldiv_B!(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat) where {T<:Real} = At_ldiv_B!(A,B)
 function ldiv!(adjA::Adjoint{<:Any,LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat) where {T,V}
+    @assert !has_offset_axes(B)
     A = adjA.parent
     n = size(A,1)
     if n != size(B,1)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -47,7 +47,7 @@ function (*)(A::StridedMatrix{T}, x::StridedVector{S}) where {T<:BlasFloat,S}
 end
 function (*)(A::AbstractMatrix{T}, x::AbstractVector{S}) where {T,S}
     TS = promote_op(matprod, T, S)
-    mul!(similar(x,TS,size(A,1)),A,x)
+    mul!(similar(x,TS,axes(A,1)),A,x)
 end
 
 # these will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
@@ -492,6 +492,7 @@ end
 #       strides != 1 cases
 
 function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::AbstractVector) where R
+    @assert !has_offset_axes(C, A, B)
     mB = length(B)
     mA, nA = lapack_size(tA, A)
     if mB != nA
@@ -578,6 +579,7 @@ end
 generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat) = _generic_matmatmul!(C, tA, tB, A, B)
 
 function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat{T}, B::AbstractVecOrMat{S}) where {T,S,R}
+    @assert !has_offset_axes(C, A, B)
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     if mB != nA
@@ -751,6 +753,7 @@ function matmul2x2(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,
 end
 
 function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+    @assert !has_offset_axes(C, A, B)
     if !(size(A) == size(B) == size(C) == (2,2))
         throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
     end
@@ -792,6 +795,7 @@ function matmul3x3(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,
 end
 
 function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
+    @assert !has_offset_axes(C, A, B)
     if !(size(A) == size(B) == size(C) == (3,3))
         throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
     end

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -438,7 +438,7 @@ for T in (:Symmetric, :Hermitian), op in (:*, :/)
 end
 
 function factorize(A::HermOrSym{T}) where T
-    TT = typeof(sqrt(one(T)))
+    TT = typeof(sqrt(oneunit(T)))
     if TT <: BlasFloat
         return bunchkaufman(A)
     else # fallback

--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -96,7 +96,7 @@ function transpose_f!(f, B::AbstractMatrix, A::AbstractMatrix)
     inds = axes(A)
     axes(B,1) == inds[2] && axes(B,2) == inds[1] || throw(DimensionMismatch(string(f)))
 
-    m, n = Base._length(inds[1]), Base._length(inds[2])
+    m, n = length(inds[1]), length(inds[2])
     if m*n<=4*transposebaselength
         @inbounds begin
             for j = inds[2]

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -1138,6 +1138,7 @@ end
 # replacing repeated references to A.data[j,j] with [Ajj = A.data[j,j] and references to Ajj]
 # does not significantly impact performance as of Dec 2015
 function naivesub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
+    @assert !has_offset_axes(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1152,6 +1153,7 @@ function naivesub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
     x
 end
 function naivesub!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector = b)
+    @assert !has_offset_axes(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1165,6 +1167,7 @@ function naivesub!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector 
     x
 end
 function naivesub!(A::LowerTriangular, b::AbstractVector, x::AbstractVector = b)
+    @assert !has_offset_axes(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1179,6 +1182,7 @@ function naivesub!(A::LowerTriangular, b::AbstractVector, x::AbstractVector = b)
     x
 end
 function naivesub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = b)
+    @assert !has_offset_axes(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1194,6 +1198,7 @@ end
 # in the following transpose and conjugate transpose naive substitution variants,
 # accumulating in z rather than b[j] significantly improves performance as of Dec 2015
 function ldiv!(transA::Transpose{<:Any,<:LowerTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1212,6 +1217,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:LowerTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(transA::Transpose{<:Any,<:UnitLowerTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1229,6 +1235,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:UnitLowerTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(transA::Transpose{<:Any,<:UpperTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1247,6 +1254,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:UpperTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(transA::Transpose{<:Any,<:UnitUpperTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1264,6 +1272,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:UnitUpperTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:LowerTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1282,6 +1291,7 @@ end
 ldiv!(adjA::Adjoint{<:Any,<:LowerTriangular}, b::AbstractVector) = ldiv!(adjA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:UnitLowerTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1299,6 +1309,7 @@ end
 ldiv!(adjA::Adjoint{<:Any,<:UnitLowerTriangular}, b::AbstractVector) = ldiv!(adjA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:UpperTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1317,6 +1328,7 @@ end
 ldiv!(adjA::Adjoint{<:Any,<:UpperTriangular}, b::AbstractVector) = ldiv!(adjA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:UnitUpperTriangular}, b::AbstractVector, x::AbstractVector)
+    @assert !has_offset_axes(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1783,12 +1795,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Multiplication with triangle to the left and hence rhs cannot be transposed.
     @eval begin
         function *(A::AbstractTriangular, B::$mat)
+            @assert !has_offset_axes(B)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             lmul!(convert(AbstractArray{TAB}, A), BB)
         end
         function *(adjA::Adjoint{<:Any,<:AbstractTriangular}, B::$mat)
+            @assert !has_offset_axes(B)
             A = adjA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1796,6 +1810,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             lmul!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function *(transA::Transpose{<:Any,<:AbstractTriangular}, B::$mat)
+            @assert !has_offset_axes(B)
             A = transA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1806,12 +1821,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
     @eval begin
         function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
+            @assert !has_offset_axes(B)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             ldiv!(convert(AbstractArray{TAB}, A), BB)
         end
         function \(adjA::Adjoint{<:Any,<:Union{UnitUpperTriangular,UnitLowerTriangular}}, B::$mat)
+            @assert !has_offset_axes(B)
             A = adjA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1819,6 +1836,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             ldiv!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function \(transA::Transpose{<:Any,<:Union{UnitUpperTriangular,UnitLowerTriangular}}, B::$mat)
+            @assert !has_offset_axes(B)
             A = transA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1829,12 +1847,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
     @eval begin
         function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
+            @assert !has_offset_axes(B)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             ldiv!(convert(AbstractArray{TAB}, A), BB)
         end
         function \(adjA::Adjoint{<:Any,<:Union{UpperTriangular,LowerTriangular}}, B::$mat)
+            @assert !has_offset_axes(B)
             A = adjA.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
@@ -1842,6 +1862,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             ldiv!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function \(transA::Transpose{<:Any,<:Union{UpperTriangular,LowerTriangular}}, B::$mat)
+            @assert !has_offset_axes(B)
             A = transA.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
@@ -1852,12 +1873,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
     @eval begin
         function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
+            @assert !has_offset_axes(A)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
             rdiv!(AA, convert(AbstractArray{TAB}, B))
         end
         function /(A::$mat, adjB::Adjoint{<:Any,<:Union{UnitUpperTriangular, UnitLowerTriangular}})
+            @assert !has_offset_axes(A)
             B = adjB.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
@@ -1865,6 +1888,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             rdiv!(AA, adjoint(convert(AbstractArray{TAB}, B)))
         end
         function /(A::$mat, transB::Transpose{<:Any,<:Union{UnitUpperTriangular, UnitLowerTriangular}})
+            @assert !has_offset_axes(A)
             B = transB.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
@@ -1875,12 +1899,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
     @eval begin
         function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
+            @assert !has_offset_axes(A)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
             rdiv!(AA, convert(AbstractArray{TAB}, B))
         end
         function /(A::$mat, adjB::Adjoint{<:Any,<:Union{UpperTriangular,LowerTriangular}})
+            @assert !has_offset_axes(A)
             B = adjB.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
@@ -1888,6 +1914,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             rdiv!(AA, adjoint(convert(AbstractArray{TAB}, B)))
         end
         function /(A::$mat, transB::Transpose{<:Any,<:Union{UpperTriangular,LowerTriangular}})
+            @assert !has_offset_axes(A)
             B = transB.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
@@ -1899,12 +1926,14 @@ end
 ### Multiplication with triangle to the right and hence lhs cannot be transposed.
 # Only for AbstractMatrix, hence outside the above loop.
 function *(A::AbstractMatrix, B::AbstractTriangular)
+    @assert !has_offset_axes(A)
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
     AA = similar(A, TAB, size(A))
     copyto!(AA, A)
     rmul!(AA, convert(AbstractArray{TAB}, B))
 end
 function *(A::AbstractMatrix, adjB::Adjoint{<:Any,<:AbstractTriangular})
+    @assert !has_offset_axes(A)
     B = adjB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
     AA = similar(A, TAB, size(A))
@@ -1912,6 +1941,7 @@ function *(A::AbstractMatrix, adjB::Adjoint{<:Any,<:AbstractTriangular})
     rmul!(AA, adjoint(convert(AbstractArray{TAB}, B)))
 end
 function *(A::AbstractMatrix, transB::Transpose{<:Any,<:AbstractTriangular})
+    @assert !has_offset_axes(A)
     B = transB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
     AA = similar(A, TAB, size(A))
@@ -2227,6 +2257,7 @@ end
 # Repeatedly compute the square roots of A so that in the end its
 # eigenvalues are close enough to the positive real line
 function invsquaring(A0::UpperTriangular, theta)
+    @assert !has_offset_axes(theta)
     # assumes theta is in ascending order
     maxsqrt = 100
     tmax = size(theta, 1)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -314,6 +314,7 @@ end
 #    Linear Algebra and its Applications 212-213 (1994), pp.413-414
 #    doi:10.1016/0024-3795(94)90414-6
 function inv_usmani(a::V, b::V, c::V) where {T,V<:AbstractVector{T}}
+    @assert !has_offset_axes(a, b, c)
     n = length(b)
     θ = zeros(T, n+1) #principal minors of A
     θ[1] = 1
@@ -344,6 +345,7 @@ end
 #Implements the determinant using principal minors
 #Inputs and reference are as above for inv_usmani()
 function det_usmani(a::V, b::V, c::V) where {T,V<:AbstractVector{T}}
+    @assert !has_offset_axes(a, b, c)
     n = length(b)
     θa = one(T)
     if n == 0
@@ -391,6 +393,7 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     du::V    # sup-diagonal
     du2::V   # supsup-diagonal for pivoting in LU
     function Tridiagonal{T}(dl::V, d::V, du::V) where {T,V<:AbstractVector{T}}
+        @assert !has_offset_axes(dl, d, du)
         n = length(d)
         if (length(dl) != n-1 || length(du) != n-1)
             throw(ArgumentError(string("cannot construct Tridiagonal from incompatible ",
@@ -401,6 +404,8 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     end
     # constructor used in lu!
     function Tridiagonal{T,V}(dl::V, d::V, du::V, du2::V) where {T,V<:AbstractVector{T}}
+        @assert !has_offset_axes(dl, d, du, du2)
+        # length checks?
         new{T,V}(dl, d, du, du2)
     end
 end

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -50,6 +50,7 @@ const I = UniformScaling(true)
 
 eltype(::Type{UniformScaling{T}}) where {T} = T
 ndims(J::UniformScaling) = 2
+Base.has_offset_axes(::UniformScaling) = false
 getindex(J::UniformScaling, i::Integer,j::Integer) = ifelse(i==j,J.λ,zero(J.λ))
 
 function show(io::IO, J::UniformScaling)
@@ -172,6 +173,7 @@ Broadcast.broadcasted(::typeof(/), J::UniformScaling,x::Number) = UniformScaling
 ## equality comparison with UniformScaling
 ==(J::UniformScaling, A::AbstractMatrix) = A == J
 function ==(A::AbstractMatrix, J::UniformScaling)
+    @assert !has_offset_axes(A)
     size(A, 1) == size(A, 2) || return false
     iszero(J.λ) && return iszero(A)
     isone(J.λ) && return isone(A)
@@ -204,6 +206,7 @@ end
 isapprox(A::AbstractMatrix, J::UniformScaling; kwargs...) = isapprox(J, A; kwargs...)
 
 function copyto!(A::AbstractMatrix, J::UniformScaling)
+    @assert !has_offset_axes(A)
     size(A,1)==size(A,2) || throw(DimensionMismatch("a UniformScaling can only be copied to a square matrix"))
     fill!(A, 0)
     λ = J.λ
@@ -240,6 +243,7 @@ for (f,dim,name) in ((:hcat,1,"rows"), (:vcat,2,"cols"))
             n = 0
             for a in A
                 if !isa(a, UniformScaling)
+                    @assert !has_offset_axes(a)
                     na = size(a,$dim)
                     n > 0 && n != na &&
                         throw(DimensionMismatch(string("number of ", $name,
@@ -255,6 +259,7 @@ end
 
 
 function hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractVecOrMat,UniformScaling}...)
+    @assert !has_offset_axes(A...)
     nr = length(rows)
     sum(rows) == length(A) || throw(ArgumentError("mismatch between row sizes and number of arguments"))
     n = zeros(Int, length(A))

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -10,7 +10,7 @@ using .DSFMT
 using Base.GMP.MPZ
 using Base.GMP: Limb
 
-using Base: BitInteger, BitInteger_types, BitUnsigned
+using Base: BitInteger, BitInteger_types, BitUnsigned, has_offset_axes
 
 import Base: copymutable, copy, copy!, ==, hash, convert
 using Serialization

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -85,6 +85,7 @@ end
 # (Note that this is different from the problem of finding a random
 #  size-m subset of A where m is fixed!)
 function randsubseq!(r::AbstractRNG, S::AbstractArray, A::AbstractArray, p::Real)
+    @assert !has_offset_axes(S, A)
     0 <= p <= 1 || throw(ArgumentError("probability $p not in [0,1]"))
     n = length(A)
     p == 1 && return copyto!(resize!(S, n), A)
@@ -179,6 +180,7 @@ julia> shuffle!(rng, Vector(1:16))
 ```
 """
 function shuffle!(r::AbstractRNG, a::AbstractArray)
+    @assert !has_offset_axes(a)
     n = length(a)
     @assert n <= Int64(2)^52
     mask = nextpow2(n) - 1

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -11,7 +11,7 @@ module Serialization
 
 import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
 import Core: svec, SimpleVector
-using Base: unaliascopy, unwrap_unionall
+using Base: unaliascopy, unwrap_unionall, has_offset_axes
 using Core.IR
 
 export serialize, deserialize, AbstractSerializer, Serializer
@@ -230,6 +230,7 @@ function serialize(s::AbstractSerializer, x::Symbol)
 end
 
 function serialize_array_data(s::IO, a)
+    @assert !has_offset_axes(a)
     isempty(a) && return 0
     if eltype(a) === Bool
         last = a[1]

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -7,7 +7,8 @@ Support for sparse arrays. Provides `AbstractSparseArray` and subtypes.
 """
 module SparseArrays
 
-using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail
+using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
+    has_offset_axes
 using Base.Sort: Forward
 using LinearAlgebra
 

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -237,6 +237,7 @@ end
 ## solvers
 function fwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
 # forward substitution for CSC matrices
+    @assert !has_offset_axes(A, B)
     nrowB, ncolB  = size(B, 1), size(B, 2)
     ncol = LinearAlgebra.checksquare(A)
     if nrowB != ncol
@@ -282,6 +283,7 @@ end
 
 function bwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
 # backward substitution for CSC matrices
+    @assert !has_offset_axes(A, B)
     nrowB, ncolB = size(B, 1), size(B, 2)
     ncol = LinearAlgebra.checksquare(A)
     if nrowB != ncol
@@ -920,6 +922,7 @@ function lmul!(b::Number, A::SparseMatrixCSC)
 end
 
 function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
+    @assert !has_offset_axes(A, B)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -943,6 +946,7 @@ for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
     @eval begin
         function \(xformA::($xformtype){<:Any,<:SparseMatrixCSC}, B::AbstractVecOrMat)
             A = xformA.parent
+            @assert !has_offset_axes(A, B)
             m, n = size(A)
             if m == n
                 if istril(A)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -371,6 +371,7 @@ SparseMatrixCSC(M::Matrix) = sparse(M)
 SparseMatrixCSC(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
+    @assert !has_offset_axes(M)
     I = findall(x -> x != 0, M)
     eltypeTiI = Ti[i[1] for i in I]
     eltypeTiJ = Ti[i[2] for i in I]
@@ -449,6 +450,7 @@ sparse_IJ_sorted!(I,J,V::AbstractVector{Bool},m,n) = sparse_IJ_sorted!(I,J,V,m,n
 function sparse_IJ_sorted!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
                            V::AbstractVector,
                            m::Integer, n::Integer, combine::Function) where Ti<:Integer
+    @assert !has_offset_axes(I, J, V)
     m = m < 0 ? 0 : m
     n = n < 0 ? 0 : n
     if isempty(V); return spzeros(eltype(V),Ti,m,n); end
@@ -520,6 +522,7 @@ julia> sparse(Is, Js, Vs)
 ```
 """
 function sparse(I::AbstractVector{Ti}, J::AbstractVector{Ti}, V::AbstractVector{Tv}, m::Integer, n::Integer, combine) where {Tv,Ti<:Integer}
+    @assert !has_offset_axes(I, J, V)
     coolen = length(I)
     if length(J) != coolen || length(V) != coolen
         throw(ArgumentError(string("the first three arguments' lengths must match, ",
@@ -613,6 +616,7 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
         csrrowptr::Vector{Ti}, csrcolval::Vector{Ti}, csrnzval::Vector{Tv},
         csccolptr::Vector{Ti}, cscrowval::Vector{Ti}, cscnzval::Vector{Tv}) where {Tv,Ti<:Integer}
 
+    @assert !has_offset_axes(I, J, V)
     # Compute the CSR form's row counts and store them shifted forward by one in csrrowptr
     fill!(csrrowptr, Ti(0))
     coolen = length(I)
@@ -943,7 +947,8 @@ column-permutation argument `q`.
 """
 function _checkargs_sourcecompatperms_permute!(A::SparseMatrixCSC,
         p::AbstractVector{<:Integer}, q::AbstractVector{<:Integer})
-     if length(q) != A.n
+    @assert !has_offset_axes(p, q)
+    if length(q) != A.n
          throw(DimensionMismatch(string("the length of column-permutation argument `q`, ",
              "`length(q) (= $(length(q)))`, must match source argument `A`'s column ",
              "count, `A.n (= $(A.n))`")))
@@ -968,6 +973,7 @@ function _checkargs_permutationsvalid_permute!(
 end
 function _ispermutationvalid_permute!(perm::AbstractVector{<:Integer},
         checkspace::Vector{<:Integer})
+    @assert !has_offset_axes(perm)
     n = length(perm)
     checkspace[1:n] .= 0
     for k in perm
@@ -1665,6 +1671,7 @@ end
 
 # General mapreducedim
 function _mapreducerows!(f, op, R::AbstractArray, A::SparseMatrixCSC{T}) where T
+    @assert !has_offset_axes(A, R)
     colptr = A.colptr
     rowval = A.rowval
     nzval = A.nzval
@@ -1680,6 +1687,7 @@ function _mapreducerows!(f, op, R::AbstractArray, A::SparseMatrixCSC{T}) where T
 end
 
 function _mapreducecols!(f, op, R::AbstractArray, A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+    @assert !has_offset_axes(A, R)
     colptr = A.colptr
     rowval = A.rowval
     nzval = A.nzval
@@ -1699,6 +1707,7 @@ function _mapreducecols!(f, op, R::AbstractArray, A::SparseMatrixCSC{Tv,Ti}) whe
 end
 
 function Base._mapreducedim!(f, op, R::AbstractArray, A::SparseMatrixCSC{T}) where T
+    @assert !has_offset_axes(A, R)
     lsiz = Base.check_reducedims(R,A)
     isempty(A) && return R
 
@@ -1749,6 +1758,7 @@ end
 # Specialized mapreducedim for + cols to avoid allocating a
 # temporary array when f(0) == 0
 function _mapreducecols!(f, op::typeof(+), R::AbstractArray, A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+    @assert !has_offset_axes(A, R)
     nzval = A.nzval
     m, n = size(A)
     if length(nzval) == m*n
@@ -1814,6 +1824,7 @@ function _findz(A::SparseMatrixCSC{Tv,Ti}, rows=1:A.m, cols=1:A.n) where {Tv,Ti}
 end
 
 function _findr(op, A, region, Tv)
+    @assert !has_offset_axes(A)
     Ti = eltype(keys(A))
     i1 = first(keys(A))
     N = nnz(A)
@@ -1920,6 +1931,7 @@ getindex(A::SparseMatrixCSC, i, ::Colon)       = getindex(A, i, 1:size(A, 2))
 getindex(A::SparseMatrixCSC, ::Colon, i)       = getindex(A, 1:size(A, 1), i)
 
 function getindex_cols(A::SparseMatrixCSC{Tv,Ti}, J::AbstractVector) where {Tv,Ti}
+    @assert !has_offset_axes(A, J)
     # for indexing whole columns
     (m, n) = size(A)
     nJ = length(J)
@@ -1956,6 +1968,7 @@ getindex_traverse_col(::AbstractUnitRange, lo::Int, hi::Int) = lo:hi
 getindex_traverse_col(I::StepRange, lo::Int, hi::Int) = step(I) > 0 ? (lo:1:hi) : (hi:-1:lo)
 
 function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractRange, J::AbstractVector) where {Tv,Ti<:Integer}
+    @assert !has_offset_axes(A, I, J)
     # Ranges for indexing rows
     (m, n) = size(A)
     # whole columns:
@@ -2003,6 +2016,7 @@ function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractRange, J::AbstractVector
 end
 
 function getindex_I_sorted(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector) where {Tv,Ti}
+    @assert !has_offset_axes(A, I, J)
     # Sorted vectors for indexing rows.
     # Similar to getindex_general but without the transpose trick.
     (m, n) = size(A)
@@ -2023,6 +2037,7 @@ function getindex_I_sorted(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::Abst
 end
 
 function getindex_I_sorted_bsearch_A(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector) where {Tv,Ti}
+    @assert !has_offset_axes(A, I, J)
     nI = length(I)
     nJ = length(J)
 
@@ -2082,6 +2097,7 @@ function getindex_I_sorted_bsearch_A(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVecto
 end
 
 function getindex_I_sorted_linear(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector) where {Tv,Ti}
+    @assert !has_offset_axes(A, I, J)
     nI = length(I)
     nJ = length(J)
 
@@ -2141,6 +2157,7 @@ function getindex_I_sorted_linear(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, 
 end
 
 function getindex_I_sorted_bsearch_I(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector) where {Tv,Ti}
+    @assert !has_offset_axes(A, I, J)
     nI = length(I)
     nJ = length(J)
 
@@ -2242,6 +2259,7 @@ function permute_rows!(S::SparseMatrixCSC{Tv,Ti}, pI::Vector{Int}) where {Tv,Ti}
 end
 
 function getindex_general(A::SparseMatrixCSC, I::AbstractVector, J::AbstractVector)
+    @assert !has_offset_axes(A, I, J)
     pI = sortperm(I)
     @inbounds Is = I[pI]
     permute_rows!(getindex_I_sorted(A, Is, J), pI)
@@ -2249,6 +2267,7 @@ end
 
 # the general case:
 function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector) where {Tv,Ti}
+    @assert !has_offset_axes(A, I, J)
     (m, n) = size(A)
 
     if !isempty(J)
@@ -2273,6 +2292,7 @@ function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVecto
 end
 
 function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractArray) where {Tv,Ti}
+    @assert !has_offset_axes(A, I)
     szA = size(A)
     nA = szA[1]*szA[2]
     colptrA = A.colptr
@@ -2375,6 +2395,7 @@ j in J, assigns zero to A[i,j] if A[i,j] is a presently-stored entry, and otherw
 """
 function _spsetz_setindex!(A::SparseMatrixCSC,
         I::Union{Integer, AbstractVector{<:Integer}}, J::Union{Integer, AbstractVector{<:Integer}})
+    @assert !has_offset_axes(A, I, J)
     lengthI = length(I)
     for j in J
         coljAfirstk = A.colptr[j]
@@ -2411,6 +2432,7 @@ assigns x to A[i,j] if A[i,j] is not presently stored.
 """
 function _spsetnz_setindex!(A::SparseMatrixCSC{Tv}, x::Tv,
         I::Union{Integer, AbstractVector{<:Integer}}, J::Union{Integer, AbstractVector{<:Integer}}) where Tv
+    @assert !has_offset_axes(A, I, J)
     m, n = size(A)
     lenI = length(I)
 
@@ -2521,6 +2543,7 @@ _to_same_csc(::SparseMatrixCSC{Tv, Ti}, V::AbstractVector, I...) where {Tv,Ti} =
 
 setindex!(A::SparseMatrixCSC{Tv}, B::AbstractVecOrMat, I::Integer, J::Integer) where {Tv} = setindex!(A, convert(Tv, B), I, J)
 function setindex!(A::SparseMatrixCSC{Tv,Ti}, V::AbstractVecOrMat, Ix::Union{Integer, AbstractVector{<:Integer}, Colon}, Jx::Union{Integer, AbstractVector{<:Integer}, Colon}) where {Tv,Ti<:Integer}
+    @assert !has_offset_axes(A, V, Ix, Jx)
     (I, J) = Base.ensure_indexable(to_indices(A, (Ix, Jx)))
     checkbounds(A, I, J)
     B = _to_same_csc(A, V, I, J)
@@ -2654,6 +2677,7 @@ setindex!(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{<:Integer}, J::Abstra
 setindex!(A::Matrix, x::SparseMatrixCSC, I::AbstractVector{Bool}, J::AbstractVector{<:Integer}) = setindex!(A, Array(x), findall(I), J)
 
 function setindex!(A::SparseMatrixCSC, x::AbstractArray, I::AbstractMatrix{Bool})
+    @assert !has_offset_axes(A, x, I)
     checkbounds(A, I)
     n = sum(I)
     (n == 0) && (return A)
@@ -2754,6 +2778,7 @@ function setindex!(A::SparseMatrixCSC, x::AbstractArray, I::AbstractMatrix{Bool}
 end
 
 function setindex!(A::SparseMatrixCSC, x::AbstractArray, Ix::AbstractVector{<:Integer})
+    @assert !has_offset_axes(A, x, Ix)
     (I,) = Base.ensure_indexable(to_indices(A, (Ix,)))
     # We check bounds after sorting I
     n = length(I)
@@ -2924,6 +2949,7 @@ julia> Base.SparseArrays.dropstored!(A, [1, 2], [1, 1])
 """
 function dropstored!(A::SparseMatrixCSC,
         I::AbstractVector{<:Integer}, J::AbstractVector{<:Integer})
+    @assert !has_offset_axes(A, I, J)
     m, n = size(A)
     nnzA = nnz(A)
     (nnzA == 0) && (return A)

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -72,7 +72,7 @@ function mean(f::Base.Callable, itr)
     end
     return total/count
 end
-mean(f::Base.Callable, A::AbstractArray) = sum(f, A) / Base._length(A)
+mean(f::Base.Callable, A::AbstractArray) = sum(f, A) / length(A)
 
 """
     mean!(r, v)
@@ -98,7 +98,7 @@ julia> mean!([1. 1.], v)
 """
 function mean!(R::AbstractArray, A::AbstractArray)
     sum!(R, A; init=true)
-    x = max(1, Base._length(R)) // Base._length(A)
+    x = max(1, length(R)) // length(A)
     R .= R .* x
     return R
 end
@@ -128,7 +128,7 @@ julia> mean(A, dims=2)
 mean(A::AbstractArray; dims=:) = _mean(A, dims)
 
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
-_mean(A::AbstractArray, ::Colon) = sum(A) / Base._length(A)
+_mean(A::AbstractArray, ::Colon) = sum(A) / length(A)
 
 function mean(r::AbstractRange{<:Real})
     isempty(r) && throw(ArgumentError("mean of an empty range is undefined"))
@@ -199,7 +199,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::Abstr
     isempty(A) && return R
 
     if Base.has_fast_linear_indexing(A) && lsiz > 16 && !has_offset_axes(R, means)
-        nslices = div(Base._length(A), lsiz)
+        nslices = div(length(A), lsiz)
         ibase = first(LinearIndices(A))-1
         for i = 1:nslices
             @inbounds R[i] = centralize_sumabs2(A, means[i], ibase+1, ibase+lsiz)
@@ -235,7 +235,7 @@ function varm!(R::AbstractArray{S}, A::AbstractArray, m::AbstractArray; correcte
     if isempty(A)
         fill!(R, convert(S, NaN))
     else
-        rn = div(Base._length(A), Base._length(R)) - Int(corrected)
+        rn = div(length(A), length(R)) - Int(corrected)
         centralize_sumabs2!(R, A, m)
         R .= R .* (1 // rn)
     end
@@ -264,7 +264,7 @@ _varm(A::AbstractArray{T}, m, corrected::Bool, region) where {T} =
 varm(A::AbstractArray, m; corrected::Bool=true) = _varm(A, m, corrected, :)
 
 function _varm(A::AbstractArray{T}, m, corrected::Bool, ::Colon) where T
-    n = Base._length(A)
+    n = length(A)
     n == 0 && return typeof((abs2(zero(T)) + abs2(zero(T)))/2)(NaN)
     return centralize_sumabs2(A, m) / (n - Int(corrected))
 end
@@ -395,7 +395,7 @@ stdm(iterable, m; corrected::Bool=true) =
 _conj(x::AbstractArray{<:Real}) = x
 _conj(x::AbstractArray) = conj(x)
 
-_getnobs(x::AbstractVector, vardim::Int) = Base._length(x)
+_getnobs(x::AbstractVector, vardim::Int) = length(x)
 _getnobs(x::AbstractMatrix, vardim::Int) = size(x, vardim)
 
 function _getnobs(x::AbstractVecOrMat, y::AbstractVecOrMat, vardim::Int)
@@ -423,7 +423,7 @@ unscaled_covzm(x::AbstractMatrix, y::AbstractMatrix, vardim::Int) =
 
 # covzm (with centered data)
 
-covzm(x::AbstractVector; corrected::Bool=true) = unscaled_covzm(x) / (Base._length(x) - Int(corrected))
+covzm(x::AbstractVector; corrected::Bool=true) = unscaled_covzm(x) / (length(x) - Int(corrected))
 function covzm(x::AbstractMatrix, vardim::Int=1; corrected::Bool=true)
     C = unscaled_covzm(x, vardim)
     T = promote_type(typeof(first(C) / 1), eltype(C))
@@ -433,7 +433,7 @@ function covzm(x::AbstractMatrix, vardim::Int=1; corrected::Bool=true)
     return A
 end
 covzm(x::AbstractVector, y::AbstractVector; corrected::Bool=true) =
-    unscaled_covzm(x, y) / (Base._length(x) - Int(corrected))
+    unscaled_covzm(x, y) / (length(x) - Int(corrected))
 function covzm(x::AbstractVecOrMat, y::AbstractVecOrMat, vardim::Int=1; corrected::Bool=true)
     C = unscaled_covzm(x, y, vardim)
     T = promote_type(typeof(first(C) / 1), eltype(C))
@@ -694,7 +694,7 @@ function median!(v::AbstractVector)
     eltype(v)>:Missing && any(ismissing, v) && return missing
     (eltype(v)<:AbstractFloat || eltype(v)>:AbstractFloat) && any(isnan, v) && return NaN
     inds = axes(v, 1)
-    n = Base._length(inds)
+    n = length(inds)
     mid = div(first(inds)+last(inds),2)
     if isodd(n)
         return middle(partialsort!(v,mid))
@@ -751,7 +751,7 @@ median(v::AbstractArray; dims=:) = _median(v, dims)
 
 _median(v::AbstractArray, dims) = mapslices(median!, v, dims = dims)
 
-_median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(undef, Base._length(v)), v))
+_median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(undef, length(v)), v))
 
 # for now, use the R/S definition of quantile; may want variants later
 # see ?quantile in R -- this is type 7

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -208,7 +208,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::Abstr
     indsAt, indsRt = Base.safe_tail(axes(A)), Base.safe_tail(axes(R)) # handle d=1 manually
     keep, Idefault = Broadcast.shapeindexer(indsRt)
     if Base.reducedim1(R, A)
-        i1 = first(Base.indices1(R))
+        i1 = first(Base.axes1(R))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
             r = R[i1,IR]

--- a/stdlib/SuiteSparse/src/SuiteSparse.jl
+++ b/stdlib/SuiteSparse/src/SuiteSparse.jl
@@ -11,14 +11,14 @@ import LinearAlgebra: ldiv!, rdiv!
 
 # Convert from 1-based to 0-based indices
 function decrement!(A::AbstractArray{T}) where T<:Integer
-    for i in 1:length(A); A[i] -= oneunit(T) end
+    for i in eachindex(A); A[i] -= oneunit(T) end
     A
 end
 decrement(A::AbstractArray{<:Integer}) = decrement!(copy(A))
 
 # Convert from 0-based to 1-based indices
 function increment!(A::AbstractArray{T}) where T<:Integer
-    for i in 1:length(A); A[i] += oneunit(T) end
+    for i in eachindex(A); A[i] += oneunit(T) end
     A
 end
 increment(A::AbstractArray{<:Integer}) = increment!(copy(A))

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -3,7 +3,8 @@
 module CHOLMOD
 
 import Base: (*), convert, copy, eltype, getindex, getproperty, show, size,
-             IndexStyle, IndexLinear, IndexCartesian, adjoint
+             IndexStyle, IndexLinear, IndexCartesian, adjoint, axes
+using Base: has_offset_axes
 
 using LinearAlgebra
 import LinearAlgebra: (\),
@@ -1040,6 +1041,7 @@ Base.copyto!(dest::AbstractArray{T,2}, D::Dense{T}) where {T<:VTypes} = _copy!(d
 Base.copyto!(dest::AbstractArray, D::Dense) = _copy!(dest, D)
 
 function _copy!(dest::AbstractArray, D::Dense)
+    @assert !has_offset_axes(dest)
     s = unsafe_load(pointer(D))
     n = s.nrow*s.ncol
     n <= length(dest) || throw(BoundsError(dest, n))
@@ -1237,6 +1239,7 @@ function size(F::Factor, i::Integer)
     return 1
 end
 size(F::Factor) = (size(F, 1), size(F, 2))
+axes(A::Union{Dense,Sparse,Factor}) = map(Base.OneTo, size(A))
 
 IndexStyle(::Dense) = IndexLinear()
 

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -3,6 +3,7 @@
 module SPQR
 
 import Base: \
+using Base: has_offset_axes
 using LinearAlgebra
 
 # ordering options */
@@ -124,6 +125,7 @@ function Base.size(F::QRSparse, i::Integer)
         throw(ArgumentError("second argument must be positive"))
     end
 end
+Base.axes(F::QRSparse) = map(Base.OneTo, size(F))
 
 struct QRSparseQ{Tv<:CHOLMOD.VTypes,Ti<:Integer} <: LinearAlgebra.AbstractQ{Tv}
     factors::SparseMatrixCSC{Tv,Ti}
@@ -131,6 +133,7 @@ struct QRSparseQ{Tv<:CHOLMOD.VTypes,Ti<:Integer} <: LinearAlgebra.AbstractQ{Tv}
 end
 
 Base.size(Q::QRSparseQ) = (size(Q.factors, 1), size(Q.factors, 1))
+Base.axes(Q::QRSparseQ) = map(Base.OneTo, size(Q))
 
 # From SPQR manual p. 6
 _default_tol(A::SparseMatrixCSC) =
@@ -346,6 +349,7 @@ function (\)(F::QRSparse{T}, B::VecOrMat{Complex{T}}) where T<:LinearAlgebra.Bla
 # |z2|z4|      ->       |y1|y2|y3|y4|     ->      |x2|y2|     ->    |x2|y2|x4|y4|
 #                                                 |x3|y3|
 #                                                 |x4|y4|
+    @assert !has_offset_axes(F, B)
     c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
     x = F\c2r
 

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -72,9 +72,8 @@ parenttype(A::OffsetArray) = parenttype(typeof(A))
 
 Base.parent(A::OffsetArray) = A.parent
 
-errmsg(A) = error("size not supported for arrays with indices $(axes(A)); see https://docs.julialang.org/en/latest/devdocs/offset-arrays/")
-Base.size(A::OffsetArray) = errmsg(A)
-Base.size(A::OffsetArray, d) = errmsg(A)
+Base.size(A::OffsetArray) = size(A.parent)
+Base.size(A::OffsetArray, d) = size(A.parent, d)
 Base.eachindex(::IndexCartesian, A::OffsetArray) = CartesianIndices(axes(A))
 Base.eachindex(::IndexLinear, A::OffsetVector) = axes(A, 1)
 

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -78,14 +78,14 @@ Base.size(A::OffsetArray, d) = errmsg(A)
 Base.eachindex(::IndexCartesian, A::OffsetArray) = CartesianIndices(axes(A))
 Base.eachindex(::IndexLinear, A::OffsetVector) = axes(A, 1)
 
-# Implementations of indices and indices1. Since bounds-checking is
+# Implementations of indices and axes1. Since bounds-checking is
 # performance-critical and relies on indices, these are usually worth
 # optimizing thoroughly.
 @inline Base.axes(A::OffsetArray, d) = 1 <= d <= length(A.offsets) ? Base.Slice(axes(parent(A))[d] .+ A.offsets[d]) : Base.Slice(1:1)
 @inline Base.axes(A::OffsetArray) = _indices(axes(parent(A)), A.offsets)  # would rather use ntuple, but see #15276
 @inline _indices(inds, offsets) = (Base.Slice(inds[1] .+ offsets[1]), _indices(tail(inds), tail(offsets))...)
 _indices(::Tuple{}, ::Tuple{}) = ()
-Base.indices1(A::OffsetArray{T,0}) where {T} = Base.Slice(1:1)  # we only need to specialize this one
+Base.axes1(A::OffsetArray{T,0}) where {T} = Base.Slice(1:1)  # we only need to specialize this one
 
 const OffsetAxis = Union{Integer, UnitRange, Base.Slice{<:UnitRange}}
 function Base.similar(A::OffsetArray, T::Type, dims::Dims)

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -169,7 +169,7 @@ _offset(out, ::Tuple{}, ::Tuple{}) = out
 
 indsoffset(r::AbstractRange) = first(r) - 1
 indsoffset(i::Integer) = 0
-indslength(r::AbstractRange) = Base._length(r)
+indslength(r::AbstractRange) = length(r)
 indslength(i::Integer) = i
 
 

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -70,4 +70,16 @@ end
     end
 end
 
+@testset "issue #27951" begin
+    a = UInt8[1 3; 2 4]
+    s = view(a, [1,2], :)
+    mktemp() do path, io
+        write(io, s)
+        seek(io, 0)
+        b = Vector{UInt8}(undef, 4)
+        @test readbytes!(io, b) == 4
+        @test b == 0x01:0x04
+    end
+end
+
 @test Base.open_flags(read=false, write=true, append=false) == (read=false, write=true, create=true, truncate=true, append=false)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -15,15 +15,15 @@ v0 = rand(4)
 v = OffsetArray(v0, (-3,))
 h = OffsetArray([-1,1,-2,2,0], (-3,))
 @test axes(v) == (-2:1,)
-@test_throws ErrorException size(v)
-@test_throws ErrorException size(v, 1)
+@test size(v) == (4,)
+@test size(v, 1) == 4
 
 A0 = [1 3; 2 4]
 A = OffsetArray(A0, (-1,2))                   # IndexLinear
 S = OffsetArray(view(A0, 1:2, 1:2), (-1,2))   # IndexCartesian
 @test axes(A) == axes(S) == (0:1, 3:4)
-@test_throws ErrorException size(A)
-@test_throws ErrorException size(A, 1)
+@test size(A) == (2,2)
+@test size(A, 1) == 2
 
 # Scalar indexing
 @test A[0,3] == A[1] == A[0,3,1] == S[0,3] == S[1] == S[0,3,1] == 1


### PR DESCRIPTION
This is a start at "taking off the training wheels" on [custom indexing](https://julialang.org/blog/2017/04/offset-arrays) and allow packages like [OffsetArrays](https://github.com/JuliaArrays/OffsetArrays.jl) to support `size`, `length`, and `@inbounds`.

So far this is almost exclusively documentation. The bigger part of the change will be to make Base safe for this change in policy. That means that for any function that calls `size` or `length`, we either need to generalize it or call `assert_oneindex(A)` (new to this PR). Overwhelmingly, the main place we'll need to add this is the `linalg` and `sparse` code.

I didn't add `assert_oneindex` back in the 0.5 days because I hoped we might soon have traits and could have written `cholfact(A::AbstractMatrix::OneIndexing)`. But at this point, we just need to get this done manually.

Before doing the big task, let's bikeshed the name and discuss any other issues folks can think of.
