### PR TITLE
make setindex!(v::RowVector, ...) return v rather than v's parent

### DIFF
--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -158,7 +158,7 @@ IndexStyle(::RowVector) = IndexLinear()
 IndexStyle(::Type{<:RowVector}) = IndexLinear()
 
 @propagate_inbounds getindex(rowvec::RowVector, i::Int) = transpose(rowvec.vec[i])
-@propagate_inbounds setindex!(rowvec::RowVector, v, i::Int) = setindex!(rowvec.vec, transpose(v), i)
+@propagate_inbounds setindex!(rowvec::RowVector, v, i::Int) = (setindex!(rowvec.vec, transpose(v), i); rowvec)
 
 # Keep a RowVector where appropriate
 @propagate_inbounds getindex(rowvec::RowVector, ::Colon, i::Int) = transpose.(rowvec.vec[i:i])

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -298,7 +298,7 @@ end
     @test rv[CartesianIndex()] == 2
     rv[CartesianIndex(1)] = 1
     @test rv[CartesianIndex(1)] == 1
-    
+
     # setindex!(v::RowVector, ...) should return v rather than v's parent
     @test setindex!(RowVector([1, 2, 3]), 4, 1)::RowVector == [4 2 3]
 end

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -298,4 +298,7 @@ end
     @test rv[CartesianIndex()] == 2
     rv[CartesianIndex(1)] = 1
     @test rv[CartesianIndex(1)] == 1
+    
+    # setindex!(v::RowVector, ...) should return v rather than v's parent
+    @test setindex!(RowVector([1, 2, 3]), 4, 1)::RowVector == [4 2 3]
 end


### PR DESCRIPTION
This pull request makes `setindex!(v::RowVector, ...)` return `v` rather than `v`'s parent. Present behavior:
```julia
julia> setindex!(RowVector([1,2,3]), 4, 1)
3-element Array{Int64,1}:
 4
 2
 3
```
Behavior with this pull request:
```julia
julia> setindex!(RowVector([1,2,3]), 4, 1)
1×3 RowVector{Int64,Array{Int64,1}}:
 4  2  3
```
Tiny bugfix noticed while working on linear algebra jazz things. Best!