### PR TITLE
Open Julia in iTerm rather than Terminal if iTerm's installed

### DIFF
--- a/contrib/mac/app/startup.applescript
+++ b/contrib/mac/app/startup.applescript
@@ -1,5 +1,17 @@
+-- find out preferred terminal
+try
+	tell application "Finder" to get application file id "com.googlecode.iterm2"
+	set termapp to "iTerm2"
+on error
+	set termapp to "Terminal"
+end try
+
 set RootPath to POSIX path of (path to me)
-tell application id "com.apple.terminal"
-  do script ("exec '" & RootPath & "Contents/Resources/julia/bin/julia'")
-  activate
+set cmd to "exec '" & RootPath & "Contents/Resources/julia/bin/julia'"
+
+tell application termapp
+	activate
+	-- create a new window, to avoid typing into existing one 
+	tell application "System Events" to tell application termapp to keystroke "n" using command down
+	tell application "System Events" to tell application termapp to keystroke cmd & return
 end tell


### PR DESCRIPTION
When run, this script looks to see if iTerm is installed. If it is, it opens iTerm, creates a new window, and runs Julia. If it isn't, create a new window in Terminal and run Julia. 

This doesn't help someone who has previously installed iTerm but still prefers Terminal...

More testing on all possible permutations of Mac hardware, OS versions, and terminal apps would be nice; I've tried a few but have run out of Macs. 