### PR TITLE
Make gesvx test depend on condition number of test matrix to avoid intermittent test errors.

### DIFF
--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -538,7 +538,7 @@ end
         C = copy(A)
         D = copy(B)
         X, rcond, f, b, r = LAPACK.gesvx!(C,D)
-        @test X ≈ A\B
+        @test X ≈ A\B rtol=inv(rcond)*eps(real(elty))
     end
 end
 


### PR DESCRIPTION
Should get rid of the test error reported in https://github.com/JuliaLang/julia/pull/24902#issuecomment-348823541