### PR TITLE
build: enhance usage of libwhich path resolution to respect SONAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Building Julia requires that the following software be installed:
 - **[perl]**                    — preprocessing of header files of libraries.
 - **[wget]**, **[curl]**, or **[fetch]** (FreeBSD) — to automatically download external libraries.
 - **[m4]**                      — needed to build GMP.
+- **[awk]**                     - helper tool for Makefiles.
 - **[patch]**                   — for modifying source code.
 - **[cmake]** (>= 3.4.3)        — needed to build `libgit2`.
 - **[pkg-config]**              - needed to build `libgit2` correctly, especially for proxy support.

--- a/base/Makefile
+++ b/base/Makefile
@@ -130,6 +130,14 @@ resolve_path += && \
 	$1_wd=`dirname "$${$1}"`; $1=$${$1_}; \
 	if [ -z "`echo $${$1} | grep '^/'`" ]; then $1=$${$1_wd}/$${$1}; fi; \
 	fi
+else
+# try to use the SO_NAME (if the named file exists)
+resolve_path += && \
+	$1_=`objdump -p "$${$1}" | awk '/SONAME/ {print $$2}'` && \
+	if [ -n "$${$1_}" ]; then \
+	$1_=$$(dirname "$${$1}")/$${$1_}; \
+	if [ -e "$${$1_}" ]; then $1=$${$1_}; fi; \
+	fi
 endif
 
 ## debug code: `make resolve-path P=<path to test>`
@@ -201,12 +209,12 @@ symlink_system_libraries: $(SYMLINK_SYSTEM_LIBRARIES)
 .PHONY: $(BUILDDIR)/build_h.jl.phony $(BUILDDIR)/version_git.jl.phony clean all symlink_*
 
 clean:
-	rm -f $(BUILDDIR)/pcre_h.jl
-	rm -f $(BUILDDIR)/errno_h.jl
-	rm -f $(BUILDDIR)/build_h.jl
-	rm -f $(BUILDDIR)/build_h.jl.phony
-	rm -f $(BUILDDIR)/fenv_constants.jl # To be removed
-	rm -f $(BUILDDIR)/uv_constants.jl
-	rm -f $(BUILDDIR)/file_constants.jl
-	rm -f $(BUILDDIR)/version_git.jl
-	rm -f $(BUILDDIR)/version_git.jl.phony
+	-rm -f $(BUILDDIR)/pcre_h.jl
+	-rm -f $(BUILDDIR)/errno_h.jl
+	-rm -f $(BUILDDIR)/build_h.jl
+	-rm -f $(BUILDDIR)/build_h.jl.phony
+	-rm -f $(BUILDDIR)/uv_constants.jl
+	-rm -f $(BUILDDIR)/file_constants.jl
+	-rm -f $(BUILDDIR)/version_git.jl
+	-rm -f $(BUILDDIR)/version_git.jl.phony
+	-rm -f $(build_private_libdir)/lib*.$(SHLIB_EXT)*


### PR DESCRIPTION
If the SONAME is available, it directly names the file we want to link to, so use that instead.