### PR TITLE
fix deprecation of IOContext after #24795

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1560,7 +1560,7 @@ import .LinAlg: diagm
 # PR #23271
 function IOContext(io::IO; kws...)
     depwarn("IOContext(io, k=v, ...) is deprecated, use IOContext(io, :k => v, ...) instead.", :IOContext)
-    IOContext(io, (k=>v for (k, v) in kws)...)
+    IOContext(io, (k=>v for (k, v) in pairs(kws))...)
 end
 
 @deprecate IOContext(io::IO, key, value) IOContext(io, key=>value)


### PR DESCRIPTION
```julia
julia> IOContext(IOBuffer(), limit=true)
WARNING: IOContext(io, k=v, ...) is deprecated, use IOContext(io, :k => v, ...) instead.
Stacktrace:
 [1] depwarn at ./deprecated.jl:68 [inlined]
 [2] #IOContext#855 at ./deprecated.jl:1562 [inlined]
 [3] (::getfield(Core, Symbol("#kw#Type")))(::NamedTuple{(:limit,),Tuple{Bool}}, ::Type{IOContext}, ::Base.GenericIOBuffer{Array{UInt8,1}}) at ./<missing>:0
 [4] top-level scope
 [5] eval(::Module, ::Expr) at ./repl/REPL.jl:3
 [6] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./repl/REPL.jl:69
 [7] macro expansion at ./repl/REPL.jl:100 [inlined]
 [8] (::getfield(Base.REPL, Symbol("##1#2")){Base.REPL.REPLBackend})() at ./event.jl:95
in expression starting at no file:0
ERROR: BoundsError: attempt to access true
  at index [2]
Stacktrace:
 [1] indexed_next at ./tuple.jl:60 [inlined]
 [2] #856 at ./<missing>:0 [inlined]
 [3] next(::Base.Generator{NamedTuple{(:limit,),Tuple{Bool}},getfield(Base, Symbol("##856#857"))}, ::Int64) at ./generator.jl:47
 [4] append_any(::Tuple{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Vararg{Any,N} where N) at ./essentials.jl:377
 [5] (::getfield(Core, Symbol("#kw#Type")))(::NamedTuple{(:limit,),Tuple{Bool}}, ::Type{IOContext}, ::Base.GenericIOBuffer{Array{UInt8,1}}) at ./<missing>:0
 [6] top-level scope
```