### PR TITLE
RFC: For `readdlm`, change default value of `comments` argument to `false`

### DIFF
--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -179,7 +179,7 @@ readdlm(input, dlm::Char, eol::Char; opts...) =
     readdlm_auto(input, dlm, Float64, eol, true; opts...)
 
 """
-    readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, skipblanks=true, use_mmap, quotes=true, dims, comments=true, comment_char='#')
+    readdlm(source, delim::Char, T::Type, eol::Char; header=false, skipstart=0, skipblanks=true, use_mmap, quotes=true, dims, comments=false, comment_char='#')
 
 Read a matrix from the source where each line (separated by `eol`) gives one row, with
 elements separated by the given delimiter. The source can be a text file, stream or byte
@@ -442,7 +442,7 @@ end
 function readdlm_string(sbuff::String, dlm::Char, T::Type, eol::Char, auto::Bool, optsd::Dict)
     ign_empty = (dlm == invalid_dlm(Char))
     quotes = get(optsd, :quotes, true)
-    comments = get(optsd, :comments, true)
+    comments = get(optsd, :comments, false)
     comment_char = get(optsd, :comment_char, '#')
     dims = get(optsd, :dims, nothing)
 

--- a/stdlib/DelimitedFiles/test/runtests.jl
+++ b/stdlib/DelimitedFiles/test/runtests.jl
@@ -120,12 +120,18 @@ isequaldlm(m1, m2, t) = isequal(m1, m2) && (eltype(m1) == eltype(m2) == t)
 end
 
 @testset "comments" begin
-    @test isequaldlm(readdlm(IOBuffer("#this is comment\n1,2,3\n#one more comment\n4,5,6"), ','), [1. 2. 3.;4. 5. 6.], Float64)
-    @test isequaldlm(readdlm(IOBuffer("#this is \n#comment\n1,2,3\n#one more \n#comment\n4,5,6"), ','), [1. 2. 3.;4. 5. 6.], Float64)
-    @test isequaldlm(readdlm(IOBuffer("1,2,#3\n4,5,6"), ','), [1. 2. "";4. 5. 6.], Any)
-    @test isequaldlm(readdlm(IOBuffer("1#,2,3\n4,5,6"), ','), [1. "" "";4. 5. 6.], Any)
+    @test isequaldlm(readdlm(IOBuffer("#this is comment\n1,2,3\n#one more comment\n4,5,6"), ',', comments=true), [1. 2. 3.;4. 5. 6.], Float64)
+    @test isequaldlm(readdlm(IOBuffer("#this is \n#comment\n1,2,3\n#one more \n#comment\n4,5,6"), ',', comments=true), [1. 2. 3.;4. 5. 6.], Float64)
+    @test isequaldlm(readdlm(IOBuffer("1,2,#3\n4,5,6"), ',', comments=true), [1. 2. "";4. 5. 6.], Any)
+    @test isequaldlm(readdlm(IOBuffer("1#,2,3\n4,5,6"), ',', comments=true), [1. "" "";4. 5. 6.], Any)
+    @test isequaldlm(readdlm(IOBuffer("1,2,\"#3\"\n4,5,6"), ',', comments=true), [1. 2. "#3";4. 5. 6.], Any)
+    @test isequaldlm(readdlm(IOBuffer("1,2,3\n #with leading whitespace\n4,5,6"), ',', comments=true), [1. 2. 3.;" " "" "";4. 5. 6.], Any)
+end
+
+@testset "without comments" begin
+    @test isequaldlm(readdlm(IOBuffer("1,2,#3\n4,5,6"), ','), [1. 2. "#3";4. 5. 6.], Any)
+    @test isequaldlm(readdlm(IOBuffer("1#,2,3\n4,5,6"), ','), ["1#" 2. 3.;4. 5. 6.], Any)
     @test isequaldlm(readdlm(IOBuffer("1,2,\"#3\"\n4,5,6"), ','), [1. 2. "#3";4. 5. 6.], Any)
-    @test isequaldlm(readdlm(IOBuffer("1,2,3\n #with leading whitespace\n4,5,6"), ','), [1. 2. 3.;" " "" "";4. 5. 6.], Any)
 end
 
 @testset "skipstart" begin
@@ -235,7 +241,7 @@ end
 end
 
 # fix #13179 parsing unicode lines with default delmiters
-@test isequaldlm(readdlm(IOBuffer("# Should ignore this π\n1\tα\n2\tβ\n")), Any[1 "α"; 2 "β"], Any)
+@test isequaldlm(readdlm(IOBuffer("# Should ignore this π\n1\tα\n2\tβ\n"), comments=true), Any[1 "α"; 2 "β"], Any)
 
 # BigInt parser
 let data = "1 2 3"


### PR DESCRIPTION
The default behavior of interpreting an unquoted `#` as the beginning of a comment is arguably unintuitive -- I suspect the vast majority of delimited files do not contain comments, and that, more often than not, this default behavior of `readdlm` will cause bugs in people's code. For example, I didn't know about this behavior until I noticed strings in a CSV getting truncated in places where a `#` appeared.

Changing the default value to `false` was mentioned in #9529, but as far as I can tell a PR was never submitted.