### PR TITLE
fix/unify eigenvalue promotion

### DIFF
--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -98,8 +98,7 @@ julia> F[:vectors]
 ```
 """
 function eigfact(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true) where T
-    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
-    AA = copy_oftype(A, S)
+    AA = copy_oftype(A, eigtype(T))
     isdiag(AA) && return eigfact(Diagonal(AA), permute = permute, scale = scale)
     return eigfact!(AA, permute = permute, scale = scale)
 end
@@ -199,6 +198,9 @@ function eigvals!(A::StridedMatrix{<:BlasComplex}; permute::Bool=true, scale::Bo
     return LAPACK.geevx!(permute ? (scale ? 'B' : 'P') : (scale ? 'S' : 'N'), 'N', 'N', 'N', A)[2]
 end
 
+# promotion type to use for eigenvalues of a Matrix{T}
+eigtype(T) = (Base.@_pure_meta; promote_type(Float32, typeof(float(zero(T)/norm(one(T))))))
+
 """
     eigvals(A; permute::Bool=true, scale::Bool=true) -> values
 
@@ -223,12 +225,10 @@ julia> eigvals(diag_matrix)
  4.0
 ```
 """
-function eigvals(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true) where T
-    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
-    return eigvals!(copy_oftype(A, S), permute = permute, scale = scale)
-end
+eigvals(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true) where T =
+    eigvals!(copy_oftype(A, eigtype(T)), permute = permute, scale = scale)
 function eigvals(x::T; kwargs...) where T<:Number
-    val = convert(promote_type(Float32, typeof(one(T)/norm(one(T)))), x)
+    val = convert(eigtype(T), x)
     return imag(val) == 0 ? [real(val)] : [val]
 end
 
@@ -381,7 +381,7 @@ julia> F[:vectors]
 ```
 """
 function eigfact(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}) where {TA,TB}
-    S = promote_type(Float32, typeof(one(TA)/norm(one(TA))),TB)
+    S = promote_type(eigtype(TA),TB)
     return eigfact!(copy_oftype(A, S), copy_oftype(B, S))
 end
 
@@ -493,7 +493,7 @@ julia> eigvals(A,B)
 ```
 """
 function eigvals(A::AbstractMatrix{TA}, B::AbstractMatrix{TB}) where {TA,TB}
-    S = promote_type(Float32, typeof(one(TA)/norm(one(TA))),TB)
+    S = promote_type(eigtype(TA),TB)
     return eigvals!(copy_oftype(A, S), copy_oftype(B, S))
 end
 

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -199,7 +199,7 @@ function eigvals!(A::StridedMatrix{<:BlasComplex}; permute::Bool=true, scale::Bo
 end
 
 # promotion type to use for eigenvalues of a Matrix{T}
-eigtype(T) = promote_type(Float32, typeof(zero(T)/sqrt(one(T))))
+eigtype(T) = promote_type(Float32, typeof(zero(T)/sqrt(abs2(one(T)))))
 
 """
     eigvals(A; permute::Bool=true, scale::Bool=true) -> values

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -199,7 +199,7 @@ function eigvals!(A::StridedMatrix{<:BlasComplex}; permute::Bool=true, scale::Bo
 end
 
 # promotion type to use for eigenvalues of a Matrix{T}
-eigtype(T) = (Base.@_pure_meta; promote_type(Float32, typeof(float(zero(T)/norm(one(T))))))
+eigtype(T) = promote_type(Float32, typeof(zero(T)/sqrt(one(T))))
 
 """
     eigvals(A; permute::Bool=true, scale::Bool=true) -> values

--- a/base/linalg/hessenberg.jl
+++ b/base/linalg/hessenberg.jl
@@ -47,10 +47,8 @@ julia> F[:Q] * F[:H] * F[:Q]'
  4.0  3.0  2.0
 ```
 """
-function hessfact(A::StridedMatrix{T}) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    return hessfact!(copy_oftype(A, S))
-end
+hessfact(A::StridedMatrix{T}) where T =
+    hessfact!(copy_oftype(A, eigtype(T)))
 
 struct HessenbergQ{T,S<:AbstractMatrix} <: AbstractMatrix{T}
     factors::S

--- a/base/linalg/schur.jl
+++ b/base/linalg/schur.jl
@@ -65,10 +65,7 @@ julia> F[:vectors] * F[:Schur] * F[:vectors]'
 ```
 """
 schurfact(A::StridedMatrix{<:BlasFloat}) = schurfact!(copy(A))
-function schurfact(A::StridedMatrix{T}) where T
-    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
-    return schurfact!(copy_oftype(A, S))
-end
+schurfact(A::StridedMatrix{T}) where T = schurfact!(copy_oftype(A, eigtype(T)))
 
 function getindex(F::Schur, d::Symbol)
     if d == :T || d == :Schur
@@ -215,7 +212,7 @@ generalized eigenvalues of `A` and `B` can be obtained with `F[:alpha]./F[:beta]
 """
 schurfact(A::StridedMatrix{T},B::StridedMatrix{T}) where {T<:BlasFloat} = schurfact!(copy(A),copy(B))
 function schurfact(A::StridedMatrix{TA}, B::StridedMatrix{TB}) where {TA,TB}
-    S = promote_type(Float32, typeof(one(TA)/norm(one(TA))), TB)
+    S = promote_type(eigtype(TA), TB)
     return schurfact!(copy_oftype(A, S), copy_oftype(B, S))
 end
 

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -100,8 +100,7 @@ function svdfact(A::StridedVecOrMat{T}; full::Bool = false, thin::Union{Bool,Voi
             "e.g. `svdfact(A; full = $(!thin))`."), :svdfact)
         full::Bool = !thin
     end
-    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
-    svdfact!(copy_oftype(A, S), full = full)
+    svdfact!(copy_oftype(A, eigtype(T)), full = full)
 end
 function svdfact(x::Number; full::Bool = false, thin::Union{Bool,Void} = nothing)
     # DEPRECATION TODO: remove deprecated thin argument and associated logic after 0.7
@@ -248,10 +247,7 @@ julia> svdvals(A)
  0.0
 ```
 """
-function svdvals(A::AbstractMatrix{T}) where T
-    S = promote_type(Float32, typeof(one(T)/norm(one(T))))
-    svdvals!(copy_oftype(A, S))
-end
+svdvals(A::AbstractMatrix{T}) where T = svdvals!(copy_oftype(A, eigtype(T)))
 svdvals(x::Number) = abs(x)
 svdvals(S::SVD{<:Any,T}) where {T} = (S[:S])::Vector{T}
 
@@ -383,7 +379,7 @@ julia> F[:V]*F[:D2]*F[:R0]*F[:Q]'
 ```
 """
 function svdfact(A::StridedMatrix{TA}, B::StridedMatrix{TB}) where {TA,TB}
-    S = promote_type(Float32, typeof(one(TA)/norm(one(TA))),TB)
+    S = promote_type(eigtype(TA),TB)
     return svdfact!(copy_oftype(A, S), copy_oftype(B, S))
 end
 # This method can be heavily optimized but it is probably not critical
@@ -542,7 +538,7 @@ julia> svdvals(A, B)
 ```
 """
 function svdvals(A::StridedMatrix{TA}, B::StridedMatrix{TB}) where {TA,TB}
-    S = promote_type(Float32, typeof(one(TA)/norm(one(TA))), TB)
+    S = promote_type(eigtype(TA), TB)
     return svdvals!(copy_oftype(A, S), copy_oftype(B, S))
 end
 svdvals(x::Number, y::Number) = abs(x/y)

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -390,7 +390,7 @@ eigfact!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}) = Eigen(LAPACK.s
 
 function eigfact(A::RealHermSymComplexHerm)
     T = eltype(A)
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    S = eigtype(T)
     eigfact!(S != T ? convert(AbstractMatrix{S}, A) : copy(A))
 end
 
@@ -413,7 +413,7 @@ The `UnitRange` `irange` specifies indices of the sorted eigenvalues to search f
 """
 function eigfact(A::RealHermSymComplexHerm, irange::UnitRange)
     T = eltype(A)
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    S = eigtype(T)
     eigfact!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), irange)
 end
 
@@ -437,7 +437,7 @@ The following functions are available for `Eigen` objects: [`inv`](@ref), [`det`
 """
 function eigfact(A::RealHermSymComplexHerm, vl::Real, vh::Real)
     T = eltype(A)
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    S = eigtype(T)
     eigfact!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh)
 end
 
@@ -446,7 +446,7 @@ eigvals!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}) =
 
 function eigvals(A::RealHermSymComplexHerm)
     T = eltype(A)
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    S = eigtype(T)
     eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A))
 end
 
@@ -486,7 +486,7 @@ julia> eigvals(A)
 """
 function eigvals(A::RealHermSymComplexHerm, irange::UnitRange)
     T = eltype(A)
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    S = eigtype(T)
     eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), irange)
 end
 
@@ -525,7 +525,7 @@ julia> eigvals(A)
 """
 function eigvals(A::RealHermSymComplexHerm, vl::Real, vh::Real)
     T = eltype(A)
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
+    S = eigtype(T)
     eigvals!(S != T ? convert(AbstractMatrix{S}, A) : copy(A), vl, vh)
 end
 

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -184,44 +184,30 @@ end
 (\)(T::SymTridiagonal, B::StridedVecOrMat) = ldltfact(T)\B
 
 eigfact!(A::SymTridiagonal{<:BlasReal}) = Eigen(LAPACK.stegr!('V', A.dv, A.ev)...)
-function eigfact(A::SymTridiagonal{T}) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    eigfact!(copy_oftype(A, S))
-end
+eigfact(A::SymTridiagonal{T}) where T = eigfact!(copy_oftype(A, eigtype(T)))
 
 eigfact!(A::SymTridiagonal{<:BlasReal}, irange::UnitRange) =
     Eigen(LAPACK.stegr!('V', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)...)
-function eigfact(A::SymTridiagonal{T}, irange::UnitRange) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    return eigfact!(copy_oftype(A, S), irange)
-end
+eigfact(A::SymTridiagonal{T}, irange::UnitRange) where T =
+    eigfact!(copy_oftype(A, eigtype(T)), irange)
 
 eigfact!(A::SymTridiagonal{<:BlasReal}, vl::Real, vu::Real) =
     Eigen(LAPACK.stegr!('V', 'V', A.dv, A.ev, vl, vu, 0, 0)...)
-function eigfact(A::SymTridiagonal{T}, vl::Real, vu::Real) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    return eigfact!(copy_oftype(A, S), vl, vu)
-end
+eigfact(A::SymTridiagonal{T}, vl::Real, vu::Real) where T =
+    eigfact!(copy_oftype(A, eigtype(T)), vl, vu)
 
 eigvals!(A::SymTridiagonal{<:BlasReal}) = LAPACK.stev!('N', A.dv, A.ev)[1]
-function eigvals(A::SymTridiagonal{T}) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    return eigvals!(copy_oftype(A, S))
-end
+eigvals(A::SymTridiagonal{T}) where T = eigvals!(copy_oftype(A, eigtype(T)))
 
 eigvals!(A::SymTridiagonal{<:BlasReal}, irange::UnitRange) =
     LAPACK.stegr!('N', 'I', A.dv, A.ev, 0.0, 0.0, irange.start, irange.stop)[1]
-function eigvals(A::SymTridiagonal{T}, irange::UnitRange) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    return eigvals!(copy_oftype(A, S), irange)
-end
+eigvals(A::SymTridiagonal{T}, irange::UnitRange) where T =
+    eigvals!(copy_oftype(A, eigtype(T)), irange)
 
 eigvals!(A::SymTridiagonal{<:BlasReal}, vl::Real, vu::Real) =
     LAPACK.stegr!('N', 'V', A.dv, A.ev, vl, vu, 0, 0)[1]
-function eigvals(A::SymTridiagonal{T}, vl::Real, vu::Real) where T
-    S = promote_type(Float32, typeof(zero(T)/norm(one(T))))
-    return eigvals!(copy_oftype(A, S), vl, vu)
-end
+eigvals(A::SymTridiagonal{T}, vl::Real, vu::Real) where T =
+    eigvals!(copy_oftype(A, eigtype(T)), vl, vu)
 
 #Computes largest and smallest eigenvalue
 eigmax(A::SymTridiagonal) = eigvals(A, size(A, 1):size(A, 1))[1]

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -112,3 +112,11 @@ let aa = rand(200, 200)
         @test a ≈ f[:vectors] * Diagonal(f[:values]) / f[:vectors]
     end
 end
+
+@testset "rational promotion: issue #24935" begin
+    A = [1//2 0//1; 0//1 2//3]
+    for λ in (eigvals(A), @inferred(eigvals(Symmetric(A))))
+        @test λ isa Vector{Float64}
+        @test λ ≈ [0.5, 2/3]
+    end
+end


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#491.  Also unifies the promotion code to call a single `LinAlg.eigtype` function rather than copy-and-pasting the same `promote_type` call everywhere.