### PR TITLE
REPL: Optionize a bunch of global variables

### DIFF
--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -246,6 +246,18 @@ end
 mutable struct Options
     hascolor::Bool
     extra_keymap::Union{Dict,Vector{<:Dict}}
+    # controls the presumed tab width of code pasted into the REPL.
+    # Must satisfy `0 < tabwidth <= 16`.
+    tabwidth::Int
+    # Maximum number of entries in the kill ring queue.
+    # Beyond this number, oldest entries are discarded first.
+    kill_ring_max::Int
+    region_animation_duration::Float64
+    beep_duration::Float64
+    beep_blink::Float64
+    beep_maxduration::Float64
+    beep_colors::Vector{String}
+    beep_use_current::Bool
     backspace_align::Bool
     backspace_adjust::Bool
     confirm_exit::Bool # ^D must be repeated to confirm exit
@@ -254,9 +266,23 @@ end
 Options(;
         hascolor = true,
         extra_keymap = AnyDict[],
+        tabwidth = 8,
+        kill_ring_max = 100,
+        region_animation_duration = 0.2,
+        beep_duration = 0.2, beep_blink = 0.2, beep_maxduration = 1.0,
+        beep_colors = ["\e[90m"], # gray (text_colors not yet available)
+        beep_use_current = true,
         backspace_align = true, backspace_adjust = backspace_align,
         confirm_exit = false) =
-            Options(hascolor, extra_keymap, backspace_align, backspace_adjust, confirm_exit)
+            Options(hascolor, extra_keymap, tabwidth,
+                    kill_ring_max, region_animation_duration,
+                    beep_duration, beep_blink, beep_maxduration,
+                    beep_colors, beep_use_current,
+                    backspace_align, backspace_adjust, confirm_exit)
+
+# for use by REPLs not having an options field
+const GlobalOptions = Options()
+
 
 ## LineEditREPL ##
 

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -7,7 +7,7 @@ isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__),
 using Main.TestHelpers
 
 # no need to have animation in tests
-LineEdit.REGION_ANIMATION_DURATION[] = 0.001
+Base.REPL.GlobalOptions.region_animation_duration=0.001
 
 ## helper functions
 


### PR DESCRIPTION
This moves global variables serving as options predating the `REPL.Option` type into fields of it.