### PR TITLE
REPL: simplify some interfaces

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -982,6 +982,7 @@ export
 # misc
     atexit,
     atreplinit,
+    initREPL,
     clipboard,
     exit,
     ntuple,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -440,6 +440,7 @@ include("repl/Terminals.jl")
 include("repl/LineEdit.jl")
 include("repl/REPLCompletions.jl")
 include("repl/REPL.jl")
+using .REPL: initREPL
 
 # deprecated functions
 include("deprecated.jl")

--- a/doc/src/manual/interacting-with-julia.md
+++ b/doc/src/manual/interacting-with-julia.md
@@ -214,11 +214,7 @@ const mykeys = Dict{Any,Any}(
     "\e[B" => (s,o...)->(LineEdit.edit_move_up(s) || LineEdit.history_next(s, LineEdit.mode(s).hist))
 )
 
-function customize_keys(repl)
-    repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)
-end
-
-atreplinit(customize_keys)
+initREPL(extra_keymap = mykeys)
 ```
 
 Users should refer to `LineEdit.jl` to discover the available actions on key input.


### PR DESCRIPTION

This is an attempt to simplify a bit some REPL code, which looks quite general but sometimes it's not clear if it needs to be (so I may totally miss some intended use cases). For example, the function `LineEdit.prompt!` was accepting both `prompt::ModalInterface` and `s::MIState` and a terminal as arguments. I agree that it's good practice to write functions parameterized with a minimal set of specific arguments, but the problem here is that the arguments are coupled: `s` had a field `s.m::ModalInterface`, so this raise the question: what happens if `prompt != s.m` ? So now this function takes a single `repl` argument and gets the information it needs from it, and similarly for `run_interface`. Here are the other changes:

- the different name for `ModalInterface` objects was confusing ("prompt", "m", "interface"...), and I couldn't find how the fact that `ModalInterface <: TextInterface` was used, so I unwrapped this type by defining `const ModalInterface = Vector{TextInterface}`, and called such objects `modes`.
- in a `repl::LineEditREPL` object, there were two copies of modes, namely `repl.interface` and `repl.mistate.interface`, so I kept only one, renamed to `repl.modes`
- there was `LineEditREPL.hascolor` (set on the command line) and `LineEditREPL.options.hascolor` (set in ".juliarc.jl"), so I renamed the latter `usecolor` to try to disambiguate (they could probably be merged eventually)
- I would really like the users to not need to resort to `atreplinit` containing something like `repl.interface = REPL.setup_interface(repl; extra_repl_keymap = mykeys)`; I removed the redundant keyword args from this function (can be set in `REPL.Options`), and exported a function `initREPL` which can be called from ".juliarc.jl" directly like:
```julia
initREPL(extra_keymap = mykeys, usecolor = true)
```

I have a follow up plan to simplify a bit how one specifies `extra_keyamp` in ".juliarc.jl", but it's not ready.