### PR TITLE
Build: update Make.inc to include a check for ICC

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -751,7 +751,6 @@ FC += -Wa,-q
 AS += -q
 endif
 endif
-endif
 
 JULIA_CPU_TARGET ?= native
 

--- a/Make.inc
+++ b/Make.inc
@@ -730,9 +730,11 @@ endif
 
 # Set MARCH-specific flags
 ifneq ($(MARCH),)
+ifneq ($(USEICC),1)	  
 CC += -march=$(MARCH)
 CXX += -march=$(MARCH)
 FC += -march=$(MARCH)
+endif
 JULIA_CPU_TARGET ?= $(MARCH)
 ifeq ($(OS),Darwin)
 # on Darwin, the standalone `as` program doesn't know
@@ -747,6 +749,7 @@ CXX += -Wa,-q
 endif
 FC += -Wa,-q
 AS += -q
+endif
 endif
 endif
 

--- a/Make.inc
+++ b/Make.inc
@@ -730,7 +730,7 @@ endif
 
 # Set MARCH-specific flags
 ifneq ($(MARCH),)
-ifneq ($(USEICC),1)	  
+ifneq ($(USEICC),1)
 CC += -march=$(MARCH)
 CXX += -march=$(MARCH)
 FC += -march=$(MARCH)


### PR DESCRIPTION
Do not add `-march=<arch>` when using Intel Compilers, as this reduces the optimization level. Fixes #24946