### PR TITLE
REPL: change ^U to delete left part of the line

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -2023,16 +2023,19 @@ AnyDict(
     "^W" => (s,o...)->edit_werase(s),
     # Meta D
     "\ed" => (s,o...)->edit_delete_next_word(s),
-    "^C" => (s,o...)->begin
-        try # raise the debugger if present
-            ccall(:jl_raise_debugger, Int, ())
+    "^C" => function (s,o...)
+        if isempty(s)
+            try # raise the debugger if present
+                ccall(:jl_raise_debugger, Int, ())
+            end
+            cancel_beep(s)
+            refresh_line(s)
+            print(terminal(s), "^C\n\n")
+            transition(s, :reset)
+            refresh_line(s)
+        else
+            edit_clear(s)
         end
-        cancel_beep(s)
-        move_input_end(s)
-        refresh_line(s)
-        print(terminal(s), "^C\n\n")
-        transition(s, :reset)
-        refresh_line(s)
     end,
     "^Z" => (s,o...)->(return :suspend),
     # Right Arrow

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -732,12 +732,14 @@ function mode_keymap(julia_prompt::Prompt)
         end
     end,
     "^C" => function (s,o...)
-        LineEdit.move_input_end(s)
-        LineEdit.refresh_line(s)
-        print(LineEdit.terminal(s), "^C\n\n")
-        transition(s, julia_prompt)
-        transition(s, :reset)
-        LineEdit.refresh_line(s)
+        if isempty(s)
+            print(LineEdit.terminal(s), "^C\n\n")
+            transition(s, julia_prompt)
+            transition(s, :reset)
+            LineEdit.refresh_line(s)
+        else
+            LineEdit.edit_clear(s)
+        end
     end)
 end
 

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -649,6 +649,18 @@ end
     LineEdit.edit_delete_next_word(s)
     s.key_repeats = 0
     @test s.kill_ring[end] == "B  C"
+
+    # edit_kill_line_backwards
+    LineEdit.edit_clear(s)
+    edit_insert(s, "begin\n  a=1\n  b=2")
+    LineEdit.edit_kill_line_backwards(s)
+    @test s.kill_ring[end] == "  b=2"
+    s.key_repeats = 1
+    LineEdit.edit_kill_line_backwards(s)
+    @test s.kill_ring[end] == "\n  b=2"
+    LineEdit.edit_kill_line_backwards(s)
+    @test s.kill_ring[end] == "  a=1\n  b=2"
+    s.key_repeats = 0
 end
 
 @testset "undo" begin
@@ -694,6 +706,10 @@ end
     LineEdit.move_line_start(s)
     LineEdit.edit_kill_line(s)
     LineEdit.edit_kill_line(s) # no effect
+    @test edit!(edit_undo!) == "one two three"
+
+    LineEdit.move_line_end(s)
+    @test edit!(LineEdit.edit_kill_line_backwards) == ""
     @test edit!(edit_undo!) == "one two three"
 
     LineEdit.move_line_start(s)


### PR DESCRIPTION
In all REPLs I know, ^U is bound to deleting the lines from point leftwards to the begining of line, so I propose to do just this in the Julia one. To clear the input area (which was bound to ^U), I would think of ^C, which is what IPython does, but it's bound to the "julia debugger" currently, which does seem to be enabled only on windows... does anyone use it, and can we reclaim this binding for clearing the input area?