### PR TITLE
implement getfield overloading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,13 +19,13 @@ New language features
     iterated using `pairs(kw)`. `kw` can no longer contain multiple entries for the same
     argument name ([#4916]).
 
- * Custom infix operators can now be defined by appending Unicode
-   combining marks, primes, and sub/superscripts to other operators.
-   For example, `+̂ₐ″` is parsed as an infix operator with the same
-   precedence as `+` ([#22089]).
+  * Custom infix operators can now be defined by appending Unicode
+    combining marks, primes, and sub/superscripts to other operators.
+    For example, `+̂ₐ″` is parsed as an infix operator with the same
+    precedence as `+` ([#22089]).
 
- * The macro call syntax `@macroname[args]` is now available and is parsed
-   as `@macroname([args])` ([#23519]).
+  * The macro call syntax `@macroname[args]` is now available and is parsed
+    as `@macroname([args])` ([#23519]).
 
   * The construct `if @generated ...; else ...; end` can be used to provide both
     `@generated` and normal implementations of part of a function. Surrounding code
@@ -34,6 +34,9 @@ New language features
   * The `missing` singleton object (of type `Missing`) has been added to represent
     missing values ([#24653]). It propagates through standard operators and mathematical functions,
     and implements three-valued logic, similar to SQLs `NULL` and R's `NA`.
+
+  * Field access via dot-syntax can now be overloaded by adding methods to
+    `Base.getproperty` and `Base.setproperty!` ([#1974]).
 
 Language changes
 ----------------

--- a/base/array.jl
+++ b/base/array.jl
@@ -95,6 +95,12 @@ import Core: arraysize, arrayset, arrayref
 vect() = Vector{Any}()
 vect(X::T...) where {T} = T[ X[i] for i = 1:length(X) ]
 
+"""
+    vect(X...)
+
+Create a Vector with element type computed from the promote_typeof of the argument,
+containing the argument list.
+"""
 function vect(X...)
     T = promote_typeof(X...)
     #T[ X[i] for i=1:length(X) ]

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -153,6 +153,9 @@ export
     # constants
     nothing, Main
 
+const getproperty = getfield
+const setproperty! = setfield!
+
 abstract type Number end
 abstract type Real     <: Number end
 abstract type AbstractFloat <: Real end

--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -1,8 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-Main.Core.eval(Main.Core, :(baremodule Inference
+getfield(getfield(Main, :Core), :eval)(getfield(Main, :Core), :(baremodule Inference
 using Core.Intrinsics
 import Core: print, println, show, write, unsafe_write, STDOUT, STDERR
+
+const getproperty = getfield
+const setproperty! = setfield!
 
 ccall(:jl_set_istopmod, Void, (Any, Bool), Inference, false)
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1236,8 +1236,8 @@ tuple
 """
     getfield(value, name::Symbol)
 
-Extract a named field from a `value` of composite type. The syntax `a.b` calls
-`getfield(a, :b)`.
+Extract a named field from a `value` of composite type.
+See also [`getproperty`](@ref Base.getproperty).
 
 # Examples
 ```jldoctest
@@ -1256,8 +1256,9 @@ getfield
 """
     setfield!(value, name::Symbol, x)
 
-Assign `x` to a named field in `value` of composite type. The syntax `a.b = c` calls
-`setfield!(a, :b, c)`. `value` must be mutable.
+Assign `x` to a named field in `value` of composite type.
+The `value` must be mutable and `x` must be a subtype of `fieldtype(typeof(value), name)`.
+See also [`setproperty!`](@ref Base.setproperty!).
 
 # Examples
 ```jldoctest
@@ -1767,5 +1768,27 @@ Tuple
 The base library of Julia.
 """
 kw"Base"
+
+"""
+    typeassert(x, type)
+
+Throw a TypeError unless `x isa type`.
+The syntax `x::type` calls this function.
+"""
+typeassert
+
+"""
+    getproperty(value, name::Symbol)
+
+The syntax `a.b` calls `getproperty(a, :b)`.
+"""
+Base.getproperty
+
+"""
+    setproperty!(value, name::Symbol, x)
+
+The syntax `a.b = c` calls `setproperty!(a, :b, c)`.
+"""
+Base.setproperty!
 
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -898,6 +898,8 @@ export
 
 # types
     convert,
+    # getproperty,
+    # setproperty!,
     fieldoffset,
     fieldname,
     fieldnames,

--- a/base/libgit2/gitcredential.jl
+++ b/base/libgit2/gitcredential.jl
@@ -116,7 +116,7 @@ function Base.read!(io::IO, cred::GitCredential)
             # https://git-scm.com/docs/git-credential#git-credential-codeurlcode
             copy!(cred, parse(GitCredential, value))
         else
-            setfield!(cred, Symbol(key), String(value))
+            Base.setproperty!(cred, Symbol(key), String(value))
         end
     end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -146,7 +146,7 @@ function show_default(io::IO, @nospecialize(x))
                 if !isdefined(x, f)
                     print(io, undef_ref_str)
                 else
-                    show(recur_io, getfield(x, f))
+                    show(recur_io, getfield(x, i))
                 end
                 if i < nf
                     print(io, ", ")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -5,6 +5,16 @@ baremodule Base
 using Core.Intrinsics
 ccall(:jl_set_istopmod, Void, (Any, Bool), Base, true)
 
+getproperty(x, f::Symbol) = getfield(x, f)
+setproperty!(x, f::Symbol, v) = setfield!(x, f, convert(fieldtype(typeof(x), f), v))
+
+# Try to help prevent users from shooting them-selves in the foot
+# with ambiguities by defining a few common and critical operations
+getproperty(x::Module, f::Symbol) = getfield(x, f)
+setproperty!(x::Module, f::Symbol, v) = setfield!(x, f, v)
+getproperty(x::Type, f::Symbol) = getfield(x, f)
+setproperty!(x::Type, f::Symbol, v) = setfield!(x, f, v)
+
 function include(mod::Module, path::AbstractString)
     local result
     if INCLUDE_STATE === 1

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -10,6 +10,7 @@ setproperty!(x, f::Symbol, v) = setfield!(x, f, convert(fieldtype(typeof(x), f),
 
 # Try to help prevent users from shooting them-selves in the foot
 # with ambiguities by defining a few common and critical operations
+# (and these don't need the extra convert code)
 getproperty(x::Module, f::Symbol) = getfield(x, f)
 setproperty!(x::Module, f::Symbol, v) = setfield!(x, f, v)
 getproperty(x::Type, f::Symbol) = getfield(x, f)

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -158,16 +158,18 @@ Under the name `f`, the function does not support infix notation, however.
 
 A few special expressions correspond to calls to functions with non-obvious names. These are:
 
-| Expression        | Calls                  |
-|:----------------- |:---------------------- |
-| `[A B C ...]`     | [`hcat`](@ref)       |
-| `[A; B; C; ...]`  | [`vcat`](@ref)       |
-| `[A B; C D; ...]` | [`hvcat`](@ref)      |
-| `A'`              | [`adjoint`](@ref) |
-| `A.'`             | [`transpose`](@ref)  |
-| `1:n`             | [`colon`](@ref)      |
-| `A[i]`            | [`getindex`](@ref)   |
-| `A[i]=x`          | [`setindex!`](@ref)  |
+| Expression        | Calls                   |
+|:----------------- |:----------------------- |
+| `[A B C ...]`     | [`hcat`](@ref)          |
+| `[A; B; C; ...]`  | [`vcat`](@ref)          |
+| `[A B; C D; ...]` | [`hvcat`](@ref)         |
+| `A'`              | [`adjoint`](@ref)       |
+| `A.'`             | [`transpose`](@ref)     |
+| `1:n`             | [`colon`](@ref)         |
+| `A[i]`            | [`getindex`](@ref)      |
+| `A[i] = x`        | [`setindex!`](@ref)     |
+| `A.n`             | [`getproperty`](@ref Base.getproperty) |
+| `A.n = x`         | [`setproperty!`](@ref Base.setproperty!) |
 
 ## [Anonymous Functions](@id man-anonymous-functions)
 

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -119,6 +119,7 @@ Base.cat
 Base.vcat
 Base.hcat
 Base.hvcat
+Base.vect
 Base.flipdim
 Base.circshift
 Base.circshift!

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -115,6 +115,7 @@ Base.isless
 Base.ifelse
 Base.lexcmp
 Base.lexless
+Core.typeassert
 Core.typeof
 Core.tuple
 Base.ntuple
@@ -124,6 +125,10 @@ Base.finalizer
 Base.finalize
 Base.copy
 Base.deepcopy
+Base.getproperty
+Base.setproperty!
+Core.getfield
+Core.setfield!
 Core.isdefined
 Base.@isdefined
 Base.convert
@@ -133,7 +138,7 @@ Base.widen
 Base.identity
 ```
 
-## Dealing with Types
+## Properties of Types
 
 ```@docs
 Base.supertype
@@ -150,8 +155,6 @@ Base.eps(::Type{<:AbstractFloat})
 Base.eps(::AbstractFloat)
 Base.promote_type
 Base.promote_rule
-Core.getfield
-Core.setfield!
 Base.fieldoffset
 Core.fieldtype
 Base.isimmutable

--- a/doc/src/stdlib/punctuation.md
+++ b/doc/src/stdlib/punctuation.md
@@ -2,11 +2,11 @@
 
 Extended documentation for mathematical symbols & functions is [here](@ref math-ops).
 
-| symbol      | meaning                                                                                     |
-|:----------- |:------------------------------------------------------------------------------------------- |
+| symbol      | meaning                                                                                                                                         |
+|:----------- |:----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `@m`        | invoke macro `m`; followed by space-separated expressions                                   |
-| `!`         | prefix "not" operator                                                                       |
-| `a!( )`     | at the end of a function name, `!` indicates that a function modifies its argument(s)       |
+| `!`         | prefix "not" (logical negation) operator                                                    |
+| `a!( )`     | at the end of a function name, `!` is used as a convention to indicate that a function modifies its argument(s) |
 | `#`         | begin single line comment                                                                   |
 | `#=`        | begin multi-line comment (these are nestable)                                               |
 | `=#`        | end multi-line comment                                                                      |
@@ -23,23 +23,23 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | `~`         | bitwise not operator                                                                        |
 | `\`         | backslash operator                                                                          |
 | `'`         | complex transpose operator Aᴴ                                                               |
-| `a[]`       | array indexing                                                                              |
-| `[,]`       | vertical concatenation                                                                      |
-| `[;]`       | also vertical concatenation                                                                 |
-| `[    ]`    | with space-separated expressions, horizontal concatenation                                  |
+| `a[]`       | array indexing (calling [`getindex`](@ref) or [`setindex!`](@ref))                          |
+| `[,]`       | vector literal constructor (calling [`vect`](@ref Base.vect))                               |
+| `[;]`       | vertical concatenation (calling [`vcat`](@ref) or [`hvcat`](@ref))                          |
+| `[    ]`    | with space-separated expressions, horizontal concatenation (calling [`hcat`](@ref) or [`hvcat`](@ref)) |
 | `T{ }`      | parametric type instantiation                                                               |
 | `;`         | statement separator                                                                         |
 | `,`         | separate function arguments or tuple components                                             |
-| `?`         | 3-argument conditional operator (conditional ? if_true : if_false)                          |
+| `?`         | 3-argument conditional operator (used like: `conditional ? if_true : if_false`)             |
 | `""`        | delimit string literals                                                                     |
 | `''`        | delimit character literals                                                                  |
 | ``` ` ` ``` | delimit external process (command) specifications                                           |
-| `...`       | splice arguments into a function call or declare a varargs function or type                 |
-| `.`         | access named fields in objects/modules, also prefixes elementwise operator/function calls   |
-| `a:b`       | range a, a+1, a+2, ..., b                                                                   |
-| `a:s:b`     | range a, a+s, a+2s, ..., b                                                                  |
-| `:`         | index an entire dimension (1:end)                                                           |
-| `::`        | type annotation, depending on context                                                       |
+| `...`       | splice arguments into a function call or declare a varargs function                         |
+| `.`         | access named fields in objects/modules (calling [`getproperty`](@ref Base.getproperty) or [`setproperty!`](@ref Base.setproperty!)), also prefixes elementwise function calls (calling [`broadcast`](@ref)) |
+| `a:b`       | range a, a+1, a+2, ..., b (calling [`colon`](@ref))                                         |
+| `a:s:b`     | range a, a+s, a+2s, ..., b (also calling [`colon`](@ref))                                   |
+| `:`         | index an entire dimension (1:endof), see [`Colon`](@ref))                                   |
+| `::`        | type annotation or [`typeassert`](@ref), depending on context                               |
 | `:( )`      | quoted expression                                                                           |
 | `:a`        | symbol a                                                                                    |
 | `<:`        | [`subtype operator`](@ref <:)                                                               |

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1752,7 +1752,7 @@
     (if (and (pair? e) (eq? (car e) '|.|))
         (let ((f (cadr e)) (x (caddr e)))
           (cond ((or (eq? (car x) 'quote) (eq? (car x) 'inert) (eq? (car x) '$))
-                 `(call (core getfield) ,f ,x))
+                 `(call (top getproperty) ,f ,x))
                 ((eq? (car x) 'tuple)
                  (make-fuse f (cdr x)))
                 (else
@@ -2039,10 +2039,12 @@
                 ,.(if (eq? aa a)   '() `((= ,aa ,(expand-forms a))))
                 ,.(if (eq? bb b)   '() `((= ,bb ,(expand-forms b))))
                 ,.(if (eq? rr rhs) '() `((= ,rr ,(expand-forms rhs))))
-                (call (core setfield!) ,aa ,bb
-                      (call (top convert)
-                            (call (core fieldtype) (call (core typeof) ,aa) ,bb)
-                            ,rr))
+                (call (top setproperty!) ,aa ,bb
+                      (if (call (top ===) (top setproperty!) (core setfield!))
+                          (call (top convert)
+                                (call (core fieldtype) (call (core typeof) ,aa) ,bb)
+                                ,rr)
+                          ,rr))
                 (unnecessary ,rr)))))
          ((tuple)
           ;; multiple assignment

--- a/src/method.c
+++ b/src/method.c
@@ -41,60 +41,7 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
             // ignore these
         }
         else {
-            size_t nargs = jl_expr_nargs(e);
-            if (e->head == call_sym && nargs > 0) {
-                jl_value_t *fe = jl_exprarg(e, 0);
-                if (jl_is_globalref(fe) && jl_binding_resolved_p(jl_globalref_mod(fe), jl_globalref_name(fe))) {
-                    // look at some known called functions
-                    jl_binding_t *b = jl_get_binding(jl_globalref_mod(fe), jl_globalref_name(fe));
-                    jl_value_t *f = b && b->constp ? b->value : NULL;
-                    if (f == jl_builtin_getfield && nargs == 3 &&
-                        jl_is_quotenode(jl_exprarg(e, 2)) && module != NULL) {
-                        // replace getfield(module_expr, :sym) with GlobalRef
-                        jl_value_t *s = jl_fieldref(jl_exprarg(e, 2), 0);
-                        if (jl_is_symbol(s)) {
-                            jl_value_t *me = jl_exprarg(e, 1);
-                            jl_module_t *me_mod = NULL;
-                            jl_sym_t *me_sym = NULL;
-                            if (jl_is_globalref(me)) {
-                                me_mod = jl_globalref_mod(me);
-                                me_sym = jl_globalref_name(me);
-                            }
-                            else if (jl_is_symbol(me) && jl_binding_resolved_p(module, (jl_sym_t*)me)) {
-                                me_mod = module;
-                                me_sym = (jl_sym_t*)me;
-                            }
-                            if (me_mod && me_sym) {
-                                jl_binding_t *b = jl_get_binding(me_mod, me_sym);
-                                if (b && b->constp) {
-                                    jl_value_t *m = b->value;
-                                    if (m && jl_is_module(m)) {
-                                        return jl_module_globalref((jl_module_t*)m, (jl_sym_t*)s);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    else if (f == jl_builtin_tuple) {
-                        size_t j;
-                        for (j = 1; j < nargs; j++) {
-                            if (!jl_is_quotenode(jl_exprarg(e,j)))
-                                break;
-                        }
-                        if (j == nargs) {
-                            jl_value_t *val = NULL;
-                            JL_TRY {
-                                val = jl_interpret_toplevel_expr_in(module, (jl_value_t*)e, NULL, sparam_vals);
-                            }
-                            JL_CATCH {
-                            }
-                            if (val)
-                                return val;
-                        }
-                    }
-                }
-            }
-            size_t i = 0;
+            size_t i = 0, nargs = jl_array_len(e->args);
             if (e->head == foreigncall_sym) {
                 JL_NARGSV(ccall method definition, 5); // (fptr, rt, at, cc, narg)
                 jl_value_t *rt = jl_exprarg(e, 1);
@@ -138,6 +85,58 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
             for (; i < nargs; i++) {
                 // TODO: this should be making a copy, not mutating the source
                 jl_exprargset(e, i, resolve_globals(jl_exprarg(e, i), module, sparam_vals, binding_effects));
+            }
+            if (e->head == call_sym && jl_expr_nargs(e) == 3 &&
+                    jl_is_globalref(jl_exprarg(e, 0)) &&
+                    jl_is_globalref(jl_exprarg(e, 1)) &&
+                    jl_is_quotenode(jl_exprarg(e, 2))) {
+                // replace module_expr.sym with GlobalRef(module, sym)
+                // for expressions pattern-matching to `getproperty(module_expr, :sym)` in a top-module
+                // (this is expected to help inference performance)
+                // TODO: this was broken by linear-IR
+                jl_value_t *s = jl_fieldref(jl_exprarg(e, 2), 0);
+                jl_value_t *me = jl_exprarg(e, 1);
+                jl_value_t *fe = jl_exprarg(e, 0);
+                jl_module_t *fe_mod = jl_globalref_mod(fe);
+                jl_sym_t *fe_sym = jl_globalref_name(fe);
+                jl_module_t *me_mod = jl_globalref_mod(me);
+                jl_sym_t *me_sym = jl_globalref_name(me);
+                if (fe_mod->istopmod && !strcmp(jl_symbol_name(fe_sym), "getproperty") && jl_is_symbol(s)) {
+                    if (jl_binding_resolved_p(me_mod, me_sym)) {
+                        jl_binding_t *b = jl_get_binding(me_mod, me_sym);
+                        if (b && b->constp && b->value && jl_is_module(b->value)) {
+                            return jl_module_globalref((jl_module_t*)b->value, (jl_sym_t*)s);
+                        }
+                    }
+                }
+            }
+            if (e->head == call_sym && nargs > 0 &&
+                    jl_is_globalref(jl_exprarg(e, 0))) {
+                // TODO: this hack should be deleted once llvmcall is fixed
+                jl_value_t *fe = jl_exprarg(e, 0);
+                jl_module_t *fe_mod = jl_globalref_mod(fe);
+                jl_sym_t *fe_sym = jl_globalref_name(fe);
+                if (jl_binding_resolved_p(fe_mod, fe_sym)) {
+                    // look at some known called functions
+                    jl_binding_t *b = jl_get_binding(fe_mod, fe_sym);
+                    if (b && b->constp && b->value == jl_builtin_tuple) {
+                        size_t j;
+                        for (j = 1; j < nargs; j++) {
+                            if (!jl_is_quotenode(jl_exprarg(e, j)))
+                                break;
+                        }
+                        if (j == nargs) {
+                            jl_value_t *val = NULL;
+                            JL_TRY {
+                                val = jl_interpret_toplevel_expr_in(module, (jl_value_t*)e, NULL, sparam_vals);
+                            }
+                            JL_CATCH {
+                            }
+                            if (val)
+                                return val;
+                        }
+                    }
+                }
             }
         }
     }

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -473,7 +473,7 @@ function launch_n_additional_processes(manager, frompid, fromconfig, cnt, launch
 
             wconfig = WorkerConfig()
             for x in [:host, :tunnel, :sshflags, :exeflags, :exename, :enable_threaded_blas]
-                setfield!(wconfig, x, getfield(fromconfig, x))
+                Base.setproperty!(wconfig, x, Base.getproperty(fromconfig, x))
             end
             wconfig.bind_addr = bind_addr
             wconfig.port = port

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -505,14 +505,14 @@ test_typed_ast_printing(g15714, Tuple{Vector{Float32}},
 @test used_dup_var_tested15714
 @test used_unique_var_tested15714
 
-let li = typeof(getfield).name.mt.cache.func::Core.MethodInstance,
+let li = typeof(fieldtype).name.mt.cache.func::Core.MethodInstance,
     lrepr = string(li),
     mrepr = string(li.def),
     lmime = stringmime("text/plain", li),
     mmime = stringmime("text/plain", li.def)
 
-    @test lrepr == lmime == "MethodInstance for getfield(...)"
-    @test mrepr == mmime == "getfield(...) in Core"
+    @test lrepr == lmime == "MethodInstance for fieldtype(...)"
+    @test mrepr == mmime == "fieldtype(...) in Core"
 end
 
 

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -109,10 +109,10 @@ let src = Meta.lower(Main, quote let x = 1 end end).args[1]::CodeInfo,
     repr = string(sf)
     @test repr == "Toplevel MethodInstance thunk at b:3"
 end
-let li = typeof(getfield).name.mt.cache.func::Core.MethodInstance,
+let li = typeof(fieldtype).name.mt.cache.func::Core.MethodInstance,
     sf = StackFrame(:a, :b, 3, li, false, false, 0),
     repr = string(sf)
-    @test repr == "getfield(...) at b:3"
+    @test repr == "fieldtype(...) at b:3"
 end
 
 let ctestptr = cglobal((:ctest, "libccalltest")),

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -90,7 +90,7 @@ const _llvmtypes = Dict{DataType, String}(
     """
     return quote
         Base.@_inline_meta
-        Base.llvmcall($exp, Vec{$N, $T}, Tuple{Vec{$N, $T}, Vec{$N, $T}}, x, y)
+        Core.getfield(Base, :llvmcall)($exp, Vec{$N, $T}, Tuple{Vec{$N, $T}, Vec{$N, $T}}, x, y)
     end
 end
 


### PR DESCRIPTION
New functions `Base.getproperty` and `Base.setproperty!` can be overloaded to change the behavior of `x.f` and `x.f = v`, respectively. It seemed like about time to turn this on. (Also it means I get to close another 4-digit issue.)

fix #16226 (close #16195)
fix #1974

TODO:
 - [x] Docs & News
 - [x] Nanosoldier run