### PR TITLE
[WIP] Introduce AbstractSparseMatrixCSC into Type Hierarchy

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1253,6 +1253,7 @@ export
     SparseArrays,
     AbstractSparseArray,
     AbstractSparseMatrix,
+    AbstractSparseMatrixCSC,
     AbstractSparseVector,
     SparseMatrixCSC,
     SparseVector,

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -4,7 +4,7 @@ import Base.LinAlg: checksquare
 
 ## sparse matrix multiplication
 
-function (*)(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
+function (*)(A::AbstractSparseMatrixCSC{TvA,TiA}, B::AbstractSparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
     (*)(sppromote(A, B)...)
 end
 for f in (:A_mul_Bt, :A_mul_Bc,
@@ -17,7 +17,7 @@ for f in (:A_mul_Bt, :A_mul_Bc,
     end
 end
 
-function sppromote(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
+function sppromote(A::AbstractSparseMatrixCSC{TvA,TiA}, B::AbstractSparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
     Tv = promote_type(TvA, TvB)
     Ti = promote_type(TiA, TiB)
     A  = convert(SparseMatrixCSC{Tv,Ti}, A)
@@ -106,7 +106,7 @@ end
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
 
-(*)(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(A,B)
+(*)(A::AbstractSparseMatrixCSC{Tv,Ti}, B::AbstractSparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(A,B)
 for (f, opA, opB) in ((:A_mul_Bt, :identity, :transpose),
                       (:A_mul_Bc, :identity, :adjoint),
                       (:At_mul_B, :transpose, :identity),
@@ -120,7 +120,7 @@ for (f, opA, opB) in ((:A_mul_Bt, :identity, :transpose),
     end
 end
 
-function spmatmul(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
+function spmatmul(A::AbstractSparseMatrixCSC{Tv,Ti}, B::AbstractSparseMatrixCSC{Tv,Ti};
                   sortindices::Symbol = :sortcols) where {Tv,Ti}
     mA, nA = size(A)
     mB, nB = size(B)

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -29,7 +29,8 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     rotl90, rotr90, round, scale!, setindex!, similar, size, transpose, tril,
     triu, vec, permute!, map, map!
 
-export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
+export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseMatrixCSC,
+    AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm, spones,
     sprand, sprandn, spzeros, nnz, permute

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -6,12 +6,21 @@
 #      issorted(rowval[colptr[i]:(colptr[i+1]-1)]) == true
 
 """
+    AbstractSparseMatrixCSC{Tv,Ti} <: AbstractSparseMatrix{Tv,Ti}
+
+Supertype of all sparse matrices that store the data using
+[Compressed Sparse Column](@ref man-csc) format.  Concrete types must have all the fields
+of [`SparseMatrixCSC`](@ref) to be usable by external linear algebra libraries.
+"""
+abstract type AbstractSparseMatrixCSC{Tv,Ti} <: AbstractSparseMatrix{Tv,Ti}
+
+"""
     SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
 
 Matrix type for storing sparse matrices in the
 [Compressed Sparse Column](@ref man-csc) format.
 """
-struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
+struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrixCSC{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
     colptr::Vector{Ti}      # Column i is in colptr[i]:(colptr[i+1]-1)

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -12,7 +12,7 @@ Supertype of all sparse matrices that store the data using
 [Compressed Sparse Column](@ref man-csc) format.  Concrete types must have all the fields
 of [`SparseMatrixCSC`](@ref) to be usable by external linear algebra libraries.
 """
-abstract type AbstractSparseMatrixCSC{Tv,Ti} <: AbstractSparseMatrix{Tv,Ti}
+abstract type AbstractSparseMatrixCSC{Tv,Ti} <: AbstractSparseMatrix{Tv,Ti} end
 
 """
     SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -78,7 +78,7 @@ julia> nnz(A)
 3
 ```
 """
-nnz(S::SparseMatrixCSC)         = Int(S.colptr[S.n + 1] - 1)
+nnz(S::AbstractSparseMatrixCSC)         = Int(S.colptr[S.n + 1] - 1)
 count(pred, S::SparseMatrixCSC) = count(pred, view(S.nzval, 1:nnz(S))) + pred(zero(eltype(S)))*(prod(size(S)) - nnz(S))
 
 """

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1389,7 +1389,7 @@ cholfact!(F::Factor, A::Union{AbstractSparseMatrixCSC{T},
         Symmetric{T,Tcsc},
         Hermitian{Complex{T},TCcsc},
         Hermitian{T,Tcsc}};
-    shift = 0.0) where {T<:Real, 
+    shift = 0.0) where {T<:Real,
                   Tcsc<:AbstractSparseMatrixCSC{T,SuiteSparse_long},
                   TCcsc<:AbstractSparseMatrixCSC{Complex{T},SuiteSparse_long}} =
     cholfact!(F, Sparse(A); shift = shift)
@@ -1550,7 +1550,7 @@ ldltfact(A::Union{AbstractSparseMatrixCSC{T},AbstractSparseMatrixCSC{Complex{T}}
     Hermitian{T,Tcsc}};
     kws...) where {T<:Real,
       Tcsc<:AbstractSparseMatrixCSC{T,SuiteSparse_long},
-      TCcsc<:AbstractSparseMatrixCSC{Complex{T},SuiteSparse_long}} = 
+      TCcsc<:AbstractSparseMatrixCSC{Complex{T},SuiteSparse_long}} =
       ldltfact(Sparse(A); kws...)
 
 ## Rank updates
@@ -1710,7 +1710,7 @@ Ac_ldiv_B(L::Factor, B::SparseVecOrMat) = Ac_ldiv_B(L, Sparse(B))
 for f in (:\, :Ac_ldiv_B)
     @eval function ($f)(A::Union{Symmetric{Float64, Tcsc},
                           Hermitian{Float64,Tcsc},
-                          Hermitian{Complex{Float64}, TCcsc}}, 
+                          Hermitian{Complex{Float64}, TCcsc}},
                           B::StridedVecOrMat) where {
                       Tcsc<:AbstractSparseMatrixCSC{Float64,SuiteSparse_long},
                       TCcsc<:AbstractSparseMatrixCSC{Complex{Float64},SuiteSparse_long}}
@@ -1825,7 +1825,7 @@ end
     B::SparseVecOrMat{Float64,Ti}) where {
       Ti, Tcsc<:AbstractSparseMatrixCSC{Float64,Ti}} = sparse(Sparse(A)*Sparse(B))
 (*)(A::Hermitian{Complex{Float64},TCcsc},
-    B::SparseVecOrMat{Complex{Float64},Ti}) where {Ti, 
+    B::SparseVecOrMat{Complex{Float64},Ti}) where {Ti,
       TCcsc<:AbstractSparseMatrixCSC{Complex{Float64},Ti}} = sparse(Sparse(A)*Sparse(B))
 (*)(A::Hermitian{Float64,Tcsc},
     B::SparseVecOrMat{Float64,Ti}) where {Ti, Tcsc<:AbstractSparseMatrixCSC{Float64,Ti}} = sparse(Sparse(A)*Sparse(B))

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -251,7 +251,9 @@ struct C_SparseVoid <: SuiteSparseStruct
     packed::Cint
 end
 
-mutable struct Sparse{Tv<:VTypes} <: AbstractSparseMatrixCSC{Tv,SuiteSparse_long}
+# although this contains a SparseMatrixCSC via the C_SparseVoid struct, making
+# it an AbstractSparseMatrixCSC changes method specificity in undesirable ways
+mutable struct Sparse{Tv<:VTypes} <: AbstractSparseMatrix{Tv,SuiteSparse_long}
     p::Ptr{C_Sparse{Tv}}
     function Sparse{Tv}(p::Ptr{C_Sparse{Tv}}) where Tv<:VTypes
         if p == C_NULL
@@ -1482,7 +1484,7 @@ ldltfact!(F::Factor, A::Union{AbstractSparseMatrixCSC{T},
     AbstractSparseMatrixCSC{Complex{T}},
     Symmetric{T,Tcsc},
     Hermitian{Complex{T},TCcsc},
-    Hermitian{T,TCcsc}};
+    Hermitian{T,Tcsc}};
     shift = 0.0) where {T<:Real,
                 Tcsc<:AbstractSparseMatrixCSC{T,SuiteSparse_long},
                 TCcsc<:AbstractSparseMatrixCSC{Complex{T},SuiteSparse_long}} =
@@ -1720,7 +1722,7 @@ for f in (:\, :Ac_ldiv_B)
             if issuccess(F)
                 return ($f)(F, B)
             else
-                return ($f)(lufact(convert(AbstractSparseMatrixCSC{eltype(A), SuiteSparse_long}, A)), B)
+                return ($f)(lufact(convert(SparseMatrixCSC{eltype(A), SuiteSparse_long}, A)), B)
             end
         end
     end

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -21,7 +21,7 @@ const ORDERING_BESTAMD = Int32(9) # try COLAMD and AMD; pick best#
 # tried.  If there is a high fill-in with AMD then try METIS(A'A) and take
 # the best of AMD and METIS. METIS is not tried if it isn't installed.
 
-using ..SparseArrays: SparseMatrixCSC
+using ..SparseArrays: SparseMatrixCSC, AbstractSparseMatrixCSC
 using ..SuiteSparse.CHOLMOD
 using ..SuiteSparse.CHOLMOD: change_stype!, free!
 
@@ -132,10 +132,10 @@ end
 Base.size(Q::QRSparseQ) = (size(Q.factors, 1), size(Q.factors, 1))
 
 # From SPQR manual p. 6
-_default_tol(A::SparseMatrixCSC) =
+_default_tol(A::AbstractSparseMatrixCSC) =
     20*sum(size(A))*eps(real(eltype(A)))*maximum(norm(view(A, :, i))^2 for i in 1:size(A, 2))
 
-function Base.LinAlg.qrfact(A::SparseMatrixCSC{Tv}; tol = _default_tol(A)) where {Tv <: CHOLMOD.VTypes}
+function Base.LinAlg.qrfact(A::AbstractSparseMatrixCSC{Tv}; tol = _default_tol(A)) where {Tv <: CHOLMOD.VTypes}
     R     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
     E     = Ref{Ptr{CHOLMOD.SuiteSparse_long}}()
     H     = Ref{Ptr{CHOLMOD.C_Sparse{Tv}}}()
@@ -193,9 +193,9 @@ Column permutation:
  2
 ```
 """
-Base.LinAlg.qrfact(A::SparseMatrixCSC; tol = _default_tol(A)) = qrfact(A, Val{true}, tol = tol)
+Base.LinAlg.qrfact(A::AbstractSparseMatrixCSC; tol = _default_tol(A)) = qrfact(A, Val{true}, tol = tol)
 
-Base.LinAlg.qr(A::SparseMatrixCSC; tol = _default_tol(A)) = qr(A, Val{true}, tol = tol)
+Base.LinAlg.qr(A::AbstractSparseMatrixCSC; tol = _default_tol(A)) = qr(A, Val{true}, tol = tol)
 
 function Base.A_mul_B!(Q::QRSparseQ, A::StridedVecOrMat)
     if size(A, 1) != size(Q, 1)

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -104,7 +104,7 @@ mutable struct UmfpackLU{Tv<:UMFVTypes,Ti<:UMFITypes} <: Factorization{Tv}
 end
 
 """
-    lufact(A::SparseMatrixCSC) -> F::UmfpackLU
+    lufact(A::AbstractSparseMatrixCSC) -> F::UmfpackLU
 
 Compute the LU factorization of a sparse matrix `A`.
 
@@ -134,12 +134,12 @@ The relation between `F` and `A` is
 - [`det`](@ref)
 
 !!! note
-    `lufact(A::SparseMatrixCSC)` uses the UMFPACK library that is part of
+    `lufact(A::AbstractSparseMatrixCSC)` uses the UMFPACK library that is part of
     SuiteSparse. As this library only supports sparse matrices with [`Float64`](@ref) or
     `Complex128` elements, `lufact` converts `A` into a copy that is of type
     `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{Complex128}` as appropriate.
 """
-function lufact(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes})
+function lufact(S::AbstractSparseMatrixCSC{<:UMFVTypes,<:UMFITypes})
     zerobased = S.colptr[1] == 0
     res = UmfpackLU(C_NULL, C_NULL, S.m, S.n,
                     zerobased ? copy(S.colptr) : decrement(S.colptr),
@@ -148,16 +148,16 @@ function lufact(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes})
     finalizer(umfpack_free_symbolic, res)
     umfpack_numeric!(res)
 end
-lufact(A::SparseMatrixCSC{<:Union{Float16,Float32},Ti}) where {Ti<:UMFITypes} =
+lufact(A::AbstractSparseMatrixCSC{<:Union{Float16,Float32},Ti}) where {Ti<:UMFITypes} =
     lufact(convert(SparseMatrixCSC{Float64,Ti}, A))
-lufact(A::SparseMatrixCSC{<:Union{Complex32,Complex64},Ti}) where {Ti<:UMFITypes} =
+lufact(A::AbstractSparseMatrixCSC{<:Union{Complex32,Complex64},Ti}) where {Ti<:UMFITypes} =
     lufact(convert(SparseMatrixCSC{Complex128,Ti}, A))
-lufact(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) where {T<:AbstractFloat} =
+lufact(A::Union{AbstractSparseMatrixCSC{T},AbstractSparseMatrixCSC{Complex{T}}}) where {T<:AbstractFloat} =
     throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",
     "Try lufact(convert(SparseMatrixCSC{Float64/Complex128,Int}, A)) for ",
     "sparse floating point LU using UMFPACK or lufact(Array(A)) for generic ",
     "dense LU.")))
-lufact(A::SparseMatrixCSC) = lufact(float(A))
+lufact(A::AbstractSparseMatrixCSC) = lufact(float(A))
 
 
 size(F::UmfpackLU) = (F.m, F.n)

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -393,7 +393,7 @@ end
     @test_throws ArgumentError cholfact(A3, shift=1.0)
     @test_throws ArgumentError ldltfact(A3)
     @test_throws ArgumentError ldltfact(A3, shift=1.0)
- 
+
 
     @test_throws LinAlg.PosDefException cholfact(A1 + A1' - 2eigmax(Array(A1 + A1'))*I)\ones(size(A1, 1))
     @test_throws LinAlg.PosDefException cholfact(A1 + A1', shift=-2eigmax(Array(A1 + A1')))\ones(size(A1, 1))

--- a/stdlib/SuiteSparse/test/runtests.jl
+++ b/stdlib/SuiteSparse/test/runtests.jl
@@ -13,11 +13,11 @@ struct TestCSC{Tv,Ti} <: AbstractSparseMatrixCSC{Tv,Ti}
   rowval::Vector{Ti}
   nzval::Vector{Tv}
   # for simplicity, have an underlying matrix and alias the above arrays
-  _A::SparseMatrixCSC{Tv,Ti}  
+  _A::SparseMatrixCSC{Tv,Ti}
 end
 
 function TestCSC(A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
-  
+
   A2 = copy(A)
   return TestCSC{Tv,Ti}(A2.m, A2.n, A2.colptr, A2.rowval, A2.nzval, A2)
 end

--- a/stdlib/SuiteSparse/test/runtests.jl
+++ b/stdlib/SuiteSparse/test/runtests.jl
@@ -40,10 +40,11 @@ function transpose(A::TestCSC{Tv,Ti}) where {Tv,Ti}
   convert(TestCSC{Tv,Ti}, A2)
 end
 
+#=
 # TODO: implement in Base
 import Base:nnz
 nnz(A::TestCSC) = nnz(A._A)
-
+=#
 
 if Base.USE_GPL_LIBS
    include("umfpack.jl")

--- a/stdlib/SuiteSparse/test/runtests.jl
+++ b/stdlib/SuiteSparse/test/runtests.jl
@@ -3,6 +3,48 @@
 using Test
 using SuiteSparse
 
+
+# define types used for testing
+import Base: setindex!, getindex, size, transpose
+struct TestCSC{Tv,Ti} <: AbstractSparseMatrixCSC{Tv,Ti}
+  m::Int
+  n::Int
+  colptr::Vector{Ti}
+  rowval::Vector{Ti}
+  nzval::Vector{Tv}
+  # for simplicity, have an underlying matrix and alias the above arrays
+  _A::SparseMatrixCSC{Tv,Ti}  
+end
+
+function TestCSC(A::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+  
+  A2 = copy(A)
+  return TestCSC{Tv,Ti}(A2.m, A2.n, A2.colptr, A2.rowval, A2.nzval, A2)
+end
+
+function size(A::TestCSC)
+  return (A.m, A.n)
+end
+
+function setindex!(A::TestCSC, value, key...)
+  setindex!(A._A, value, key...)
+end
+
+function getindex(A::TestCSC, key...)
+  getindex(A._A, key...)
+end
+
+function transpose(A::TestCSC{Tv,Ti}) where {Tv,Ti}
+
+  A2 = transpose(A._A)
+  convert(TestCSC{Tv,Ti}, A2)
+end
+
+# TODO: implement in Base
+import Base:nnz
+nnz(A::TestCSC) = nnz(A._A)
+
+
 if Base.USE_GPL_LIBS
    include("umfpack.jl")
    include("cholmod.jl")

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -55,7 +55,6 @@
 
             @test A*x ≈ b
 
-            
             @test A2*x ≈ b
             z = complex.(b)
             x = SuiteSparse.A_ldiv_B!(lua2, z)


### PR DESCRIPTION
This PR introduces the minimal set of changes needed to let users define their own sparse matrix CSC types and retain access to the `SuiteSparse` libraries.

Specifically, it introduces an  `AbstractSparseMatrixCSC` type and modifies the `SuiteSparse` wrappers to accept it (rather than only `SparseMatrixCSC`).  This allows users to implement new sparse matrix types with their own indexing behavior (ref [#15579](https://github.com/JuliaLang/julia/pull/15579), [#22733](https://github.com/JuliaLang/julia/issues/22733), [#5424](https://github.com/JuliaLang/LinearAlgebra.jl/issues/60,), particularly [#9906](https://github.com/JuliaLang/julia/issues/9906), edit: added issue 9906).

I have updated the tests to make sure a sample `TestCSC <: AbstractSparseMatrixCSC` works, and they all pass.  For some reason, the `ambiguous` tests now cause julia to segfault,  and I'm not sure how to debug this.

 To reproduce, run

```julia
  cd ./test
  ../julia ./runtests.jl ambiguous
```
in the repo root directory.  The backtrace generated by the segfault is [here](https://gist.github.com/JaredCrean2/5f34544af666a4a8de91c3ff834a22a8#file-segfault) and running `julia-debug` under gdb produced [this](https://gist.github.com/JaredCrean2/5f34544af666a4a8de91c3ff834a22a8#file-debugging-backtrace).

