### PR TITLE
Deprecate some Array{Any} constructors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -465,6 +465,9 @@ Deprecated or removed
     `Matrix{Int}(uninitialized, (2, 4))`, and `Array{Float32,3}(11, 13, 17)` is now
     `Array{Float32,3}(uninitialized, 11, 13, 17)` ([#24781]).
 
+  * `Vector()`, `Vector(n)` and `Matrix(m,n)` have been deprecated in favor of `Vector{Any}()`,
+    `Vector{Any}(uninitialized, n)` and `Matrix{Any}(uninitialized, m,n)` ([#24974]).
+
   * `fill!(A::Diagonal, x)` and `fill!(A::AbstractTriangular, x)` have been deprecated
     in favor of `Base.LinAlg.fillslots!(A, x)` ([#24413]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1061,17 +1061,6 @@ end
 
 ## end of FloatRange
 
-@noinline zero_arg_matrix_constructor(prefix::String) =
-    depwarn("$prefix() is deprecated, use $prefix(uninitialized, 0, 0) instead.", :zero_arg_matrix_constructor)
-function Matrix{T}() where T
-    zero_arg_matrix_constructor("Matrix{T}")
-    return Matrix{T}(uninitialized, 0, 0)
-end
-function Matrix()
-    zero_arg_matrix_constructor("Matrix")
-    return Matrix(uninitialized, 0, 0)
-end
-
 for name in ("alnum", "alpha", "cntrl", "digit", "number", "graph",
              "lower", "print", "punct", "space", "upper", "xdigit")
     f = Symbol("is",name)
@@ -2055,8 +2044,11 @@ end
 @deprecate Array{T}(m::Integer, n::Integer) where {T}               Array{T}(uninitialized, m, n)
 @deprecate Array{T}(m::Integer, n::Integer, o::Integer) where {T}   Array{T}(uninitialized, m, n, o)
 @deprecate Array{T}(d::Integer...) where {T}                        Array{T}(uninitialized, d)
-@deprecate Vector(m::Integer)                                       Vector(uninitialized, m)
-@deprecate Matrix(m::Integer, n::Integer)                           Matrix(uninitialized, m, n)
+@deprecate Vector(m::Integer)                                       Vector{Any}(uninitialized, m)
+@deprecate Matrix(m::Integer, n::Integer)                           Matrix{Any}(uninitialized, m, n)
+
+# PR #24974
+@deprecate Vector() Vector{Any}()
 
 # deprecate IntSet to BitSet
 @deprecate_binding IntSet BitSet

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -140,12 +140,6 @@ Array{T}(::Uninitialized, m::Integer) where {T} = Array{T,1}(uninitialized, Int(
 Array{T}(::Uninitialized, m::Integer, n::Integer) where {T} = Array{T,2}(uninitialized, Int(m), Int(n))
 Array{T}(::Uninitialized, m::Integer, n::Integer, o::Integer) where {T} = Array{T,3}(uninitialized, Int(m), Int(n), Int(o))
 Array{T}(::Uninitialized, d::Integer...) where {T} = Array{T}(uninitialized, convert(Tuple{Vararg{Int}}, d))
-# dimensionality but not type specified, accepting dims as series of Integers
-Vector(::Uninitialized, m::Integer) = Vector{Any}(uninitialized, Int(m))
-Matrix(::Uninitialized, m::Integer, n::Integer) = Matrix{Any}(uninitialized, Int(m), Int(n))
-# empty vector constructor
-Vector() = Vector{Any}(uninitialized, 0)
-
 
 include("associative.jl")
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -297,32 +297,14 @@ end
 @testset "construction" begin
     @test typeof(Vector{Int}(uninitialized, 3)) == Vector{Int}
     @test typeof(Vector{Int}()) == Vector{Int}
-    @test typeof(Vector(uninitialized, 3)) == Vector{Any}
-    @test typeof(Vector()) == Vector{Any}
     @test typeof(Matrix{Int}(uninitialized, 2,3)) == Matrix{Int}
-    @test typeof(Matrix(uninitialized, 2,3)) == Matrix{Any}
 
     @test size(Vector{Int}(uninitialized, 3)) == (3,)
     @test size(Vector{Int}()) == (0,)
-    @test size(Vector(uninitialized, 3)) == (3,)
-    @test size(Vector()) == (0,)
     @test size(Matrix{Int}(uninitialized, 2,3)) == (2,3)
-    @test size(Matrix(uninitialized, 2,3)) == (2,3)
 
-    # TODO: will throw MethodError after 0.6 deprecations are deleted
-    dw = Base.JLOptions().depwarn
-    if dw == 2
-        @test_throws ErrorException Matrix{Int}()
-        @test_throws ErrorException Matrix()
-    elseif dw == 1
-        @test_warn "deprecated" Matrix{Int}()
-        @test_warn "deprecated" Matrix()
-    elseif dw == 0
-        @test size(Matrix{Int}()) == (0,0)
-        @test size(Matrix()) == (0,0)
-    else
-        error("unexpected depwarn value")
-    end
+    @test_throws MethodError Matrix()
+    @test_throws MethodError Matrix{Int}()
     @test_throws MethodError Array{Int,3}()
 end
 @testset "get" begin


### PR DESCRIPTION
Deprecate some `Array{Any}` constructors, specifically:
  - `Vector()` -> `Vector{Any}()`
  - `Vector(uninitialized, n)` -> `Vector{Any}(uninitialized, n)`
  - `Matrix(uninitialized, m, n)` -> `Matrix{Any}(uninitialized, m, n)`

Why?
 - It is better to be explicit about element type
 - We don't have any matching methods for higher order arrays
 - They were not used in Base at all (tests passes locally at least) which should be an indication that they are not needed and not very useful

I also removed the 0.6 deprecation for `Matrix()` and `Matrix{T}()` and the corresponding tests, because I didn't feel like fixing that deprecation.