### PR TITLE
[release-0.6] Backport "Explicitly add `-lpthread` when building curl"

### DIFF
--- a/deps/curl.mk
+++ b/deps/curl.mk
@@ -10,6 +10,12 @@ endif
 
 CURL_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
 
+# On older Linuces (those that use OpenSSL < 1.1) we include `libpthread` explicitly.
+# It doesn't hurt to include it explicitly elsewhere, so we do so.
+ifeq ($(OS),Linux)
+CURL_LDFLAGS += -lpthread
+endif
+
 $(SRCDIR)/srccache/curl-$(CURL_VER).tar.bz2: | $(SRCDIR)/srccache
 	$(JLDOWNLOAD) $@ https://curl.haxx.se/download/curl-$(CURL_VER).tar.bz2
 


### PR DESCRIPTION
This is a backport of PR #24261 to the release-0.6 branch. I observed a pthread-related failure when building curl on release-0.6 on the buildbots, so I figured this patch might be necessary.