### PR TITLE
Correct exponent_max to conform to IEEE754-2008

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -40,7 +40,7 @@ end
 """
     exponent_max(T)
 
-Maximum exponent a real floating point number of type `T` can have,
+Maximum value of [`exponent`](@ref) for a real floating point number of type `T`.
 for example 1023 for `Float64`. `exponent_max(T) + 1` is a possible value of
 the exponent field with bias, but it is used as sentinel value for `Inf` and `NaN`.
 """

--- a/base/math.jl
+++ b/base/math.jl
@@ -37,13 +37,28 @@ end
                                 "Complex(x)^y, or similar.")))
 end
 
+"""
+    exponent_max(T)
+
+Maximum exponent a real floating point number of type `T` can have,
+for example 1023 for `Float64`. `exponent_max(T) + 1` is a possible value of
+the exponent field with bias, but it is used as sentinel value for `Inf` and `NaN`.
+"""
+function exponent_max end
+
+"""
+    exponent_raw_max(T)
+
+The maximum value of the exponent field of floating point type `T` without bias,
+that is the maximum integer value representable by `exponent_bits(T)` bits.
+"""
+function exponent_raw_max end
+
 for T in (Float16, Float32, Float64)
     @eval significand_bits(::Type{$T}) = $(trailing_ones(significand_mask(T)))
     @eval exponent_bits(::Type{$T}) = $(sizeof(T)*8 - significand_bits(T) - 1)
     @eval exponent_bias(::Type{$T}) = $(Int(exponent_one(T) >> significand_bits(T)))
-    # maximum float exponent
-    @eval exponent_max(::Type{$T}) = $(Int(exponent_mask(T) >> significand_bits(T)) - exponent_bias(T))
-    # maximum float exponent without bias
+    @eval exponent_max(::Type{$T}) = $(Int(exponent_mask(T) >> significand_bits(T)) - exponent_bias(T) - 1)
     @eval exponent_raw_max(::Type{$T}) = $(Int(exponent_mask(T) >> significand_bits(T)))
 end
 

--- a/base/special/exp.jl
+++ b/base/special/exp.jl
@@ -116,7 +116,7 @@ function exp(x::T) where T<:Union{Float32,Float64}
         # scale back
         if k > -significand_bits(T)
             # multiply by 2.0 first to prevent overflow, which helps extends the range
-            k == exponent_max(T) && return y * T(2.0) * T(2.0)^(exponent_max(T) - 1)
+            k == exponent_max(T) + 1 && return y * T(2.0) * T(2.0)^exponent_max(T)
             twopk = reinterpret(T, rem(exponent_bias(T) + k, uinttype(T)) << significand_bits(T))
             return y*twopk
         else

--- a/base/special/exp10.jl
+++ b/base/special/exp10.jl
@@ -118,7 +118,7 @@ function exp10(x::T) where T<:Union{Float32,Float64}
         # scale back
         if k > -significand_bits(T)
             # multiply by 2.0 first to prevent overflow, extending the range
-            k == exponent_max(T) && return y * T(2.0) * T(2.0)^(exponent_max(T) - 1)
+            k == exponent_max(T) + 1 && return y * T(2.0) * T(2.0)^exponent_max(T)
             twopk = reinterpret(T, rem(exponent_bias(T) + k, uinttype(T)) << significand_bits(T))
             return y*twopk
         else


### PR DESCRIPTION
`exponent_max` was not giving the maximum exponent, but a sentinel value for `Inf` and `NaN` which is not a legal exponent. I found this error prone. Exponent exponent_max returns actual maximum exponent. As a by-product the code become somewhat more readable. ("if k is one bigger than the maximum exponent, first multiply y with 2 and then with the highest power of two representable...") I added internal docstrings to help the future readers.