### PR TITLE
Sparsity-preserving outer products

### DIFF
--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -1128,7 +1128,7 @@ function copy(bc::Broadcasted{PromoteToSparse})
     if can_skip_sparsification(bcf.f, bcf.args...)
         return _copy(bcf.f, bcf.args...)
     elseif is_supported_sparse_broadcast(bcf.args...)
-        return broadcast(bcf.f, map(_sparsifystructured, bcf.args)...)
+        return _copy(bcf.f, map(_sparsifystructured, bcf.args)...)
     else
         return copy(convert(Broadcasted{Broadcast.DefaultArrayStyle{length(axes(bc))}}, bc))
     end

--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -831,7 +831,7 @@ function _outer(trans::Tf, x, y) where Tf
     nnzw = length(nzvalsw)
 
     nnzC = nnzx * nnzw
-    Tv = typeof(one(eltype(x)) * one(eltype(w)))
+    Tv = typeof(oneunit(eltype(x)) * oneunit(eltype(w)))
     Ti = promote_type(indtype(x), indtype(w))
     colptrC = zeros(Ti, nw + 1)
     rowvalC = Vector{Ti}(undef, nnzC)

--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -93,9 +93,8 @@ is_supported_sparse_broadcast(t::Union{Transpose, Adjoint}, rest...) = is_suppor
 is_supported_sparse_broadcast(x, rest...) = axes(x) === () && is_supported_sparse_broadcast(rest...)
 is_supported_sparse_broadcast(x::Ref, rest...) = is_supported_sparse_broadcast(rest...)
 
-is_specialcase_sparse_broadcast(f, rest...) = false
-is_specialcase_sparse_broadcast(::typeof(*), ::SparseVectorUnion,
-                                ::AdjOrTransSparseVectorUnion) = true
+can_skip_sparsification(f, rest...) = false
+can_skip_sparsification(::typeof(*), ::SparseVectorUnion, ::AdjOrTransSparseVectorUnion) = true
 
 # Dispatch on broadcast operations by number of arguments
 const Broadcasted0{Style<:Union{Nothing,BroadcastStyle},Axes,F} =
@@ -817,33 +816,32 @@ _finishempty!(C::SparseMatrixCSC) = (fill!(C.colptr, 1); C)
 
 # special case - vector outer product
 _copy(f::typeof(*), x::SparseVectorUnion, y::AdjOrTransSparseVectorUnion) = _outer(x, y)
-@inline _outer(x::SparseVectorUnion, y::Adjoint) = return _outer(conj, x, y)
-@inline _outer(x::SparseVectorUnion, y::Transpose) = return _outer(identity, x, y)
+@inline _outer(x::SparseVectorUnion, y::Adjoint) = return _outer(conj, x, parent(y))
+@inline _outer(x::SparseVectorUnion, y::Transpose) = return _outer(identity, x, parent(y))
 function _outer(trans::Tf, x, y) where Tf
-    w = parent(y)
     nx = length(x)
-    nw = length(w)
+    ny = length(y)
     rowvalx = nonzeroinds(x)
-    rowvalw = nonzeroinds(w)
+    rowvaly = nonzeroinds(y)
     nzvalsx = nonzeros(x)
-    nzvalsw = nonzeros(w)
+    nzvalsy = nonzeros(y)
     nnzx = length(nzvalsx)
-    nnzw = length(nzvalsw)
+    nnzy = length(nzvalsy)
 
-    nnzC = nnzx * nnzw
-    Tv = typeof(oneunit(eltype(x)) * oneunit(eltype(w)))
-    Ti = promote_type(indtype(x), indtype(w))
-    colptrC = zeros(Ti, nw + 1)
+    nnzC = nnzx * nnzy
+    Tv = typeof(oneunit(eltype(x)) * oneunit(eltype(y)))
+    Ti = promote_type(indtype(x), indtype(y))
+    colptrC = zeros(Ti, ny + 1)
     rowvalC = Vector{Ti}(undef, nnzC)
     nzvalsC = Vector{Tv}(undef, nnzC)
 
     idx = 0
     @inbounds colptrC[1] = 1
-    @inbounds for jj = 1:nnzw
-        wval = nzvalsw[jj]
-        iszero(wval) && continue
-        col = rowvalw[jj]
-        wval = trans(wval)
+    @inbounds for jj = 1:nnzy
+        yval = nzvalsy[jj]
+        iszero(yval) && continue
+        col = rowvaly[jj]
+        yval = trans(yval)
 
         for ii = 1:nnzx
             xval = nzvalsx[ii]
@@ -851,12 +849,12 @@ function _outer(trans::Tf, x, y) where Tf
             idx += 1
             colptrC[col+1] += 1
             rowvalC[idx] = rowvalx[ii]
-            nzvalsC[idx] = xval * wval
+            nzvalsC[idx] = xval * yval
         end
     end
     cumsum!(colptrC, colptrC)
 
-    return SparseMatrixCSC(nx, nw, colptrC, rowvalC, nzvalsC)
+    return SparseMatrixCSC(nx, ny, colptrC, rowvalC, nzvalsC)
 end
 
 # (9) _broadcast_zeropres!/_broadcast_notzeropres! for more than two (input) sparse vectors/matrices
@@ -1127,7 +1125,7 @@ broadcast(f::Tf, A::SparseMatrixCSC, ::Type{T}) where {Tf,T} = broadcast(x -> f(
 
 function copy(bc::Broadcasted{PromoteToSparse})
     bcf = flatten(bc)
-    if is_specialcase_sparse_broadcast(bcf.f, bcf.args...)
+    if can_skip_sparsification(bcf.f, bcf.args...)
         return _copy(bcf.f, bcf.args...)
     elseif is_supported_sparse_broadcast(bcf.args...)
         return broadcast(bcf.f, map(_sparsifystructured, bcf.args)...)

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1198,6 +1198,9 @@ kron(x::SparseVector, A::SparseMatrixCSC) = kron(SparseMatrixCSC(x), A)
 kron(A::Union{SparseVector,SparseMatrixCSC}, B::VecOrMat) = kron(A, sparse(B))
 kron(A::VecOrMat, B::Union{SparseVector,SparseMatrixCSC}) = kron(sparse(A), B)
 
+# sparse outer product
+kron(A::SparseVectorUnion, B::AdjOrTransSparseVectorUnion) = A .* B
+
 ## det, inv, cond
 
 inv(A::SparseMatrixCSC) = error("The inverse of a sparse matrix can often be dense and can cause the computer to run out of memory. If you are sure you have enough memory, please convert your matrix to a dense matrix.")

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -58,6 +58,11 @@ function nonzeroinds(x::SparseColumnView)
     return y
 end
 
+indtype(x::SparseColumnView) = indtype(parent(x))
+function nnz(x::SparseColumnView)
+    rowidx, colidx = parentindices(x)
+    return length(nzrange(parent(x), colidx))
+end
 
 ## similar
 #

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -34,6 +34,7 @@ SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
 # union of such a view and a SparseVector so we define an alias for such a union as well
 const SparseColumnView{T}  = SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
 const SparseVectorUnion{T} = Union{SparseVector{T}, SparseColumnView{T}}
+const AdjOrTransSparseVectorUnion{T} = LinearAlgebra.AdjOrTrans{T, <:SparseVectorUnion{T}}
 
 ### Basic properties
 

--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -656,4 +656,19 @@ using SparseArrays.HigherOrderFns: SparseVecStyle
     @test occursin("no method matching _copy(::typeof(rand))", sprint(showerror, err))
 end
 
+@testset "Sparse outer product, for type $T and vector $op" for
+         op in (transpose, adjoint),
+         T in (Float64, ComplexF64)
+    m, n, p = 100, 250, 0.1
+    A = sprand(T, m, n, p)
+    a, b = view(A, :, 1), sprand(T, m, p)
+    av, bv = Vector(a), Vector(b)
+    v = @inferred a .* op(b)
+    w = @inferred b .* op(a)
+    @test issparse(v)
+    @test issparse(w)
+    @test v == av .* op(bv)
+    @test w == bv .* op(av)
+end
+
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -352,6 +352,7 @@ end
     for (m,n) in ((5,10), (13,8), (14,10))
         a = sprand(m, 5, 0.4); a_d = Matrix(a)
         b = sprand(n, 6, 0.3); b_d = Matrix(b)
+        v = view(a, :, 1); v_d = Vector(v)
         x = sprand(m, 0.4); x_d = Vector(x)
         y = sprand(n, 0.3); y_d = Vector(y)
         # mat ⊗ mat
@@ -370,6 +371,11 @@ end
         @test Array(kron(x, b)) == kron(x_d, b_d)
         @test Array(kron(x_d, b)) == kron(x_d, b_d)
         @test Array(kron(x, b_d)) == kron(x_d, b_d)
+        # vec ⊗ vec'
+        @test issparse(kron(v, y'))
+        @test issparse(kron(x, y'))
+        @test Array(kron(v, y')) == kron(v_d, y_d')
+        @test Array(kron(x, y')) == kron(x_d, y_d')
         # test different types
         z = convert(SparseVector{Float16, Int8}, y); z_d = Vector(z)
         @test Vector(kron(x, z)) == kron(x_d, z_d)


### PR DESCRIPTION
This PR adds sparsity-preserving outer products of sparse vectors and views into sparse matrices, implemented as methods of `kron` and `*`.

The motivation that caused me to dig into this is the desire to have fast/efficient quadratic matrix products. My specific case is to compute a very large sparse-dense-sparse product, but computation of the middle dense matrix can be parallelized as computations of single columns.

Some example code showing the impact:

```julia
using BenchmarkTools
using Test

m,n = (25_000, 100_000);  # dimensions of matrices
k = 1000;                 # column vector location to fill
A = sprand(m, n, 0.01);   # large, sparse operator
b = rand(n);              # column subset of dense matrix
B = sparse(collect(1:n), fill(k, n), b, n, n); # sparse representation

if true
    # outer products only
    @btime $b * $A[:, $k]';
    @btime $b * view($A, :, $k)';

    # quadratic matrix products which motivated
    C1 = @btime $A * $B * $A';
    C2 = @btime ($A * $b) * view($A, :, $k)';

    @test C1 == C2
end
```

On master (Version 0.7.0-DEV.2770, Commit 11d5a5345e):
```
  1.830 s (6 allocations: 1.86 GiB)
  1.953 s (2 allocations: 1.86 GiB)
  39.669 ms (190 allocations: 116.06 MiB)
  199.583 ms (4 allocations: 190.77 MiB)
Test Passed
```

This PR:
```
  4.948 ms (12 allocations: 40.48 MiB)
  4.938 ms (10 allocations: 40.47 MiB)
  36.562 ms (205 allocations: 116.23 MiB)
  3.570 ms (12 allocations: 4.12 MiB)
Test Passed
```

I've marked this as a work-in-progress because I'd welcome comments on how to potentially better integrate the new methods with existing code. The first commit could be thrown away / extracted to separate PR — it was just something I noticed while grapping with current code — ~and the tests still need to add a `Complex` case which exercises handling of the `RowVector{<:Any, ConjArray}` case~.