### PR TITLE
Make sparse scale!, *, and / on columns fast and add tests

### DIFF
--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -1475,14 +1475,14 @@ end
 
 # scale
 
-scale!(x::AbstractSparseVector, a::Real) = (scale!(nonzeros(x), a); x)
-scale!(x::AbstractSparseVector, a::Complex) = (scale!(nonzeros(x), a); x)
-scale!(a::Real, x::AbstractSparseVector) = (scale!(nonzeros(x), a); x)
-scale!(a::Complex, x::AbstractSparseVector) = (scale!(nonzeros(x), a); x)
+scale!(x::SparseVectorUnion, a::Real)    = (scale!(nonzeros(x), a); x)
+scale!(x::SparseVectorUnion, a::Complex) = (scale!(nonzeros(x), a); x)
+scale!(a::Real, x::SparseVectorUnion)    = (scale!(nonzeros(x), a); x)
+scale!(a::Complex, x::SparseVectorUnion) = (scale!(nonzeros(x), a); x)
 
-(*)(x::AbstractSparseVector, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) * a)
-(*)(a::Number, x::AbstractSparseVector) = SparseVector(length(x), copy(nonzeroinds(x)), a * nonzeros(x))
-(/)(x::AbstractSparseVector, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) / a)
+(*)(x::SparseVectorUnion, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) * a)
+(*)(a::Number, x::SparseVectorUnion) = SparseVector(length(x), copy(nonzeroinds(x)), a * nonzeros(x))
+(/)(x::SparseVectorUnion, a::Number) = SparseVector(length(x), copy(nonzeroinds(x)), nonzeros(x) / a)
 
 # dot
 function dot(x::StridedVector{Tx}, y::SparseVectorUnion{Ty}) where {Tx<:Number,Ty<:Number}


### PR DESCRIPTION
In theory, this restricts the signatures since it excludes sparse vectors that are not `SparseVector`s but I'm not aware of any such vectors and would expect such vectors to have custom definitions anyway.