### PR TITLE
Add skipmissing() to skip missing values

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -886,6 +886,7 @@ export
 # missing values
     ismissing,
     missing,
+    skipmissing,
 
 # time
     sleep,

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -296,6 +296,46 @@ since type constructors fall back to convert methods.
 Stacktrace:
 [...]
 ```
+## Skipping Missing Values
+
+Since `missing` values propagate with standard mathematical operators, reduction
+functions return `missing` when called on arrays which contain missing values:
+```doctest
+julia> sum([1, missing])
+missing
+
+```
+
+In this situation, use the [`skipmissing`](@ref) function to skip missing values:
+```doctest
+julia> sum(skipmissing([1, missing]))
+1
+
+```
+
+This convenience function returns an iterator which filters out `missing` values
+efficiently. It can therefore be used with any function which supports iterators:
+```doctest
+julia> maximum(skipmissing([3, missing, 2, 1]))
+3
+
+julia> mean(skipmissing([3, missing, 2, 1]))
+2.0
+
+julia> mapreduce(sqrt, +, skipmissing([3, missing, 2, 1]))
+4.146264369941973
+
+```
+
+Use [`collect`](@ref) to extract non-`missing` values and store them in an array:
+```doctest
+julia> collect(skipmissing([3, missing, 2, 1]))
+3-element Array{Int64,1}:
+ 3
+ 2
+ 1
+
+```
 
 ## Logical Operations on Arrays
 

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -15,8 +15,8 @@ The behavior of `missing` values follows one basic rule: `missing`
 values *propagate* automatically when passed to standard operators and functions,
 in particular mathematical functions. Uncertainty about the value of one of the operands
 induces uncertainty about the result. In practice, this means an operation involving
-a `missing` value generally returns `missing`:
-```doctest
+a `missing` value generally returns `missing`
+```jldoctest
 julia> missing + 1
 missing
 
@@ -25,7 +25,6 @@ missing
 
 julia> abs(missing)
 missing
-
 ```
 
 As `missing` is a normal Julia object, this propagation rule only works
@@ -42,8 +41,8 @@ throws a `MethodError`, just like for any other type.
 
 Standard equality and comparison operators follow the propagation rule presented
 above: if any of the operands is `missing`, the result is `missing`.
-Here are a few examples:
-```doctest
+Here are a few examples
+```jldoctest
 julia> missing == 1
 missing
 
@@ -55,7 +54,6 @@ missing
 
 julia> 2 >= missing
 missing
-
 ```
 
 In particular, note that `missing == missing` returns `missing`, so `==` cannot
@@ -65,8 +63,8 @@ use [`ismissing(x)`](@ref).
 Special comparison operators [`isequal`](@ref) and [`===`](@ref) are exceptions
 to the propagation rule: they always return a `Bool` value, even in the presence
 of `missing` values, considering `missing` as equal to `missing` and as different
-from any other value. They can therefore be used to test whether a value is `missing`:
-```doctest
+from any other value. They can therefore be used to test whether a value is `missing`
+```jldoctest
 julia> missing === 1
 false
 
@@ -78,14 +76,12 @@ true
 
 julia> isequal(missing, missing)
 true
-
 ```
 
 The [`isless`](@ref) operator is another exception: `missing` is considered
 as greater than any other value. This operator is used by [`sort`](@ref),
 which therefore places `missing` values after all other values.
-
-```doctest
+```jldoctest
 julia> isless(1, missing)
 true
 
@@ -94,7 +90,6 @@ false
 
 julia> isless(missing, missing)
 false
-
 ```
 
 ## Logical operators
@@ -111,8 +106,8 @@ via concrete examples.
 Let us illustrate this principle with the logical "or" operator [`|`](@ref).
 Following the rules of boolean logic, if one of the operands is `true`,
 the value of the other operand does not have an influence on the result,
-which will always be `true`:
-```doctest
+which will always be `true`
+```jldoctest
 julia> true | true
 true
 
@@ -121,7 +116,6 @@ true
 
 julia> false | true
 true
-
 ```
 
 Based on this observation, we can conclude that if one of the operands is `true`
@@ -129,20 +123,19 @@ and the other `missing`, we know that the result is `true` in spite of the
 uncertainty about the actual value of one of the operands. If we had
 been able to observe the actual value of the second operand, it could only be
 `true` or `false`, and in both cases the result would be `true`. Therefore,
-in this particular case, missingness does *not* propagate:
-```doctest
+in this particular case, missingness does *not* propagate
+```jldoctest
 julia> true | missing
 true
 
 julia> missing | true
 true
-
 ```
 
 On the contrary, if one of the operands is `false`, the result could be either
 `true` or `false` depending on the value of the other operand. Therefore,
-if that operand is `missing`, the result has to be `missing` too:
-```doctest
+if that operand is `missing`, the result has to be `missing` too
+```jldoctest
 julia> false | true
 true
 
@@ -157,14 +150,13 @@ missing
 
 julia> missing | false
 missing
-
 ```
 
 The behavior of the logical "and" operator [`&`](@ref) is similar to that of the
 `|` operator, with the difference that missingness does not propagate when
 one of the operands is `false`. For example, when that is the case of the first
-operand:
-```doctest
+operand
+```jldoctest
 julia> false & false
 false
 
@@ -173,12 +165,11 @@ false
 
 julia> false & missing
 false
-
 ```
 
 On the other hand, missingness propagates when one of the operands is `true`,
-for example the first one:
-```doctest
+for example the first one
+```jldoctest
 julia> true & true
 true
 
@@ -187,7 +178,6 @@ false
 
 julia> true & missing
 missing
-
 ```
 
 Finally, the "exclusive or" logical operator [`xor`](@ref) always propagates
@@ -202,20 +192,19 @@ Control flow operators including [`if`](@ref), [`while`](@ref) and the
 do not allow for missing values. This is because of the uncertainty about whether
 the actual value would be `true` or `false` if we could observe it,
 which implies that we do not know how the program should behave. A `TypeError`
-is thrown as soon as a `missing` value is encountered in this context:
-```doctest
+is thrown as soon as a `missing` value is encountered in this context
+```jldoctest
 julia> if missing
            println("here")
        end
 ERROR: TypeError: non-boolean (Missing) used in boolean context
-
 ```
 
 For the same reason, contrary to logical operators presented above,
 the short-circuiting boolean operators [`&&`](@ref) and [`||`](@ref) do not
 allow for `missing` values in situations where the value of the operand
-determines whether the next operand is evaluated or not. For example:
-```doctest
+determines whether the next operand is evaluated or not. For example
+```jldoctest
 julia> missing || false
 ERROR: TypeError: non-boolean (Missing) used in boolean context
 
@@ -224,31 +213,28 @@ ERROR: TypeError: non-boolean (Missing) used in boolean context
 
 julia> true && missing && false
 ERROR: TypeError: non-boolean (Missing) used in boolean context
-
 ```
 
 On the other hand, no error is thrown when the result can be determined without
 the `missing` values. This is the case when the code short-circuits
 before evaluating the `missing` operand, and when the `missing` operand is the
-last one:
-```doctest
+last one
+```jldoctest
 julia> true && missing
 missing
 
 julia> false && missing
 false
-
 ```
 
 ## Arrays With Missing Values
 
-Arrays containing missing values can be created like other arrays:
-```doctest
+Arrays containing missing values can be created like other arrays
+```jldoctest
 julia> [1, missing]
 2-element Array{Union{Missing, Int64},1}:
  1
   missing
-
 ```
 
 As this example shows, the element type of such arrays is `Union{Missing, T}`,
@@ -260,20 +246,19 @@ of the entry (i.e. whether it is `Missing` or `T`).
 
 Uninitialized arrays allowing for missing values can be constructed with the
 standard syntax. By default, arrays with an [`isbits`](@ref) element type are
-filled with `missing` values:
-```doctest
+filled with `missing` values
+```jldoctest
 julia> Array{Union{Missing, Int}}(uninitialized, 2, 3)
 2×3 Array{Union{Missing, Int64},2}:
  missing  missing  missing
  missing  missing  missing
-
 ```
 
 An array allowing for `missing` values but which does not contain any such value
 can be converted back to an array which does not allow for missing values using
 [`convert`](@ref). If the array contains `missing` values, a `MethodError` is thrown
-during conversion:
-```doctest
+during conversion
+```jldoctest
 julia> x = Union{Missing, String}["a", "b"]
 2-element Array{Union{Missing, String},1}:
  "a"
@@ -294,28 +279,26 @@ ERROR: MethodError: Cannot `convert` an object of type Missing to an object of t
 This may have arisen from a call to the constructor String(...),
 since type constructors fall back to convert methods.
 Stacktrace:
-[...]
+[...
 ```
 ## Skipping Missing Values
 
 Since `missing` values propagate with standard mathematical operators, reduction
-functions return `missing` when called on arrays which contain missing values:
-```doctest
+functions return `missing` when called on arrays which contain missing values
+```jldoctest
 julia> sum([1, missing])
 missing
-
 ```
 
-In this situation, use the [`skipmissing`](@ref) function to skip missing values:
-```doctest
+In this situation, use the [`skipmissing`](@ref) function to skip missing values
+```jldoctest
 julia> sum(skipmissing([1, missing]))
 1
-
 ```
 
 This convenience function returns an iterator which filters out `missing` values
-efficiently. It can therefore be used with any function which supports iterators:
-```doctest
+efficiently. It can therefore be used with any function which supports iterators
+```jldoctest
 julia> maximum(skipmissing([3, missing, 2, 1]))
 3
 
@@ -324,17 +307,15 @@ julia> mean(skipmissing([3, missing, 2, 1]))
 
 julia> mapreduce(sqrt, +, skipmissing([3, missing, 2, 1]))
 4.146264369941973
-
 ```
 
-Use [`collect`](@ref) to extract non-`missing` values and store them in an array:
-```doctest
+Use [`collect`](@ref) to extract non-`missing` values and store them in an array
+```jldoctest
 julia> collect(skipmissing([3, missing, 2, 1]))
 3-element Array{Int64,1}:
  3
  2
  1
-
 ```
 
 ## Logical Operations on Arrays
@@ -345,8 +326,8 @@ the [`==`](@ref) operator return `missing` whenever the result cannot be
 determined without knowing the actual value of the `missing` entry. In practice,
 this means that `missing` is returned if all non-missing values of the compared
 arrays are equal, but one or both arrays contain missing values (possibly at
-different positions):
-```doctest
+different positions)
+```jldoctest
 julia> [1, missing] == [2, missing]
 false
 
@@ -355,23 +336,21 @@ missing
 
 julia> [1, 2, missing] == [1, missing, 2]
 missing
-
 ```
 
 As for single values, use [`isequal`](@ref) to treat `missing` values as equal
-to other `missing` values but different from non-missing values:
-```doctest
+to other `missing` values but different from non-missing values
+```jldoctest
 julia> isequal([1, missing], [1, missing])
 true
 
 julia> isequal([1, 2, missing], [1, missing, 2])
 false
-
 ```
 
 Functions [`any`](@ref) and [`all`](@ref) also follow the rules of
-three-valued logic, returning `missing` when the result cannot be determined:
-```doctest
+three-valued logic, returning `missing` when the result cannot be determined
+```jldoctest
 julia> all([true, missing])
 missing
 
@@ -383,5 +362,4 @@ true
 
 julia> any([false, missing])
 missing
-
 ```

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -183,7 +183,9 @@ For users coming to Julia from R, these are some noteworthy differences:
   * Julia does not support the `NULL` type. The closest equivalent is [`nothing`](@ref), but it
     behaves like a scalar value rather than like a list. Use `x == nothing` instead of `is.null(x)`.
   * In Julia, missing values are represented by the [`missing`](@ref) object rather than by `NA`.
-    Use [`ismissing(x)`](@ref) instead of `isna(x)`.
+    Use [`ismissing(x)`](@ref) instead of `isna(x)`. The [`skipmissing`](@ref) function is generally
+    used instead of `na.rm=TRUE` (though in some particular cases functions take a `skipmissing`
+    argument).
   * Julia lacks the equivalent of R's `assign` or `get`.
   * In Julia, `return` does not require parentheses.
   * In R, an idiomatic way to remove unwanted values is to use logical indexing, like in the expression

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -226,6 +226,7 @@ Base.unsafe_get
 Base.Missing
 Base.missing
 Base.ismissing
+Base.skipmissing
 ```
 
 ## System

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -287,6 +287,7 @@ end
         pop!(need_to_handle_undef_sparam, which(Base.zero, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.one, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.oneunit, Tuple{Type{Union{Missing, T}} where T}))
+        pop!(need_to_handle_undef_sparam, which(Base.nonmissingtype, Tuple{Type{Union{Missing, T}} where T}))
         @test need_to_handle_undef_sparam == Set()
     end
 end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -4,6 +4,12 @@
     @test sprint(showerror, MissingException("test")) == "MissingException: test"
 end
 
+@testset "nonmissingtype" begin
+    @test Base.nonmissingtype(Union{Int, Missing}) == Int
+    @test Base.nonmissingtype(Any) == Any
+    @test Base.nonmissingtype(Missing) == Union{}
+end
+
 @testset "convert" begin
     @test convert(Union{Int, Missing}, 1) === 1
     @test convert(Union{Int, Missing}, 1.0) === 1
@@ -245,4 +251,36 @@ end
     @test float(Union{Int, Missing}[1]) isa Vector{Union{Float64, Missing}}
     @test isequal(float([missing]), [missing])
     @test float([missing]) isa Vector{Missing}
+end
+
+@testset "skipmissing" begin
+    x = skipmissing([1, 2, missing, 4])
+    @test eltype(x) === Int
+    @test collect(x) == [1, 2, 4]
+    @test collect(x) isa Vector{Int}
+
+    x = skipmissing([1  2; missing 4])
+    @test eltype(x) === Int
+    @test collect(x) == [1, 2, 4]
+    @test collect(x) isa Vector{Int}
+
+    x = collect(skipmissing([missing]))
+    @test eltype(x) === Union{}
+    @test isempty(collect(x))
+    @test collect(x) isa Vector{Union{}}
+
+    x = collect(skipmissing(Union{Int, Missing}[]))
+    @test eltype(x) === Int
+    @test isempty(collect(x))
+    @test collect(x) isa Vector{Int}
+
+    x = skipmissing([missing, missing, 1, 2, missing, 4, missing, missing])
+    @test eltype(x) === Int
+    @test collect(x) == [1, 2, 4]
+    @test collect(x) isa Vector{Int}
+
+    x = skipmissing(v for v in [missing, 1, missing, 2, 4])
+    @test eltype(x) === Any
+    @test collect(x) == [1, 2, 4]
+    @test collect(x) isa Vector{Int}
 end


### PR DESCRIPTION
Currently defined in Missings.jl. See design discussion at https://github.com/JuliaData/Missings.jl/issues/53.

We should be able to get rid of the specialized `AbstractArray` methods once the compiler handles `Union`s more efficiently, but benchmarking shows that it currently makes a dramatic difference.