### PR TITLE
Fix zero() error in 'missing' test

### DIFF
--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1135,14 +1135,19 @@ end
 A = sparse(["a", "b"])
 @test_throws MethodError findmin(A, 1)
 
-# Support the case, when user defined `zero` and `isless` for non-numerical type
-#
-Base.zero(::Type{T}) where T<:AbstractString = ""
-for (tup, rval, rind) in [((1,), ["a"], [1])]
+# Support the case when user defined `zero` and `isless` for non-numerical type
+struct CustomType
+    x::String
+end
+Base.zero(::Type{CustomType}) = CustomType("")
+Base.isless(x::CustomType, y::CustomType) = isless(x.x, y.x)
+A = sparse([CustomType("a"), CustomType("b")])
+
+for (tup, rval, rind) in [((1,), [CustomType("a")], [1])]
     @test isequal(findmin(A, tup), (rval, rind))
 end
 
-for (tup, rval, rind) in [((1,), ["b"], [2])]
+for (tup, rval, rind) in [((1,), [CustomType("b")], [2])]
     @test isequal(findmax(A, tup), (rval, rind))
 end
 


### PR DESCRIPTION
The 'sparse' test defined zero(::String), which triggered a failure
when it was run on before the 'missing' test on the same worker.

Fixes https://github.com/JuliaLang/julia/issues/24949.