### PR TITLE
Remove keyword argument performance tips

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -515,26 +515,6 @@ c = (b + 1.0f0)::Complex{T}
 does not hinder performance (but does not help either) since the compiler can determine the type of `c`
 at the time `k` is compiled.
 
-### Declare types of keyword arguments
-
-Keyword arguments can have declared types:
-
-```julia
-function with_keyword(x; name::Int = 1)
-    ...
-end
-```
-
-Functions are specialized on the types of keyword arguments, so these declarations will not affect
-performance of code inside the function. However, they will reduce the overhead of calls to the
-function that include keyword arguments.
-
-Functions with keyword arguments have near-zero overhead for call sites that pass only positional
-arguments.
-
-Passing dynamic lists of keyword arguments, as in `f(x; keywords...)`, can be slow and should
-be avoided in performance-sensitive code.
-
 ## Break functions into multiple definitions
 
 Writing a function as many small definitions allows the compiler to directly call the most applicable


### PR DESCRIPTION
Given the results of the newest keyword argument changes:

#24795 (comment)

Could this section be entirely erased from the performance tips?

https://docs.julialang.org/en/latest/manual/performance-tips/#Declare-types-of-keyword-arguments-1

