### PR TITLE
simplify rand(::UnitRange) a bit

### DIFF
--- a/base/random/RNGs.jl
+++ b/base/random/RNGs.jl
@@ -4,7 +4,7 @@
 
 # SamplerUnion(Union{X,Y,...}) == Union{SamplerType{X},SamplerType{Y},...}
 SamplerUnion(U::Union) = Union{map(T->SamplerType{T}, Base.uniontypes(U))...}
-const SamplerBoolBitInteger = SamplerUnion(Union{Bool, Base.BitInteger})
+const SamplerBoolBitInteger = SamplerUnion(Union{Bool, BitInteger})
 
 if Sys.iswindows()
     struct RandomDevice <: AbstractRNG
@@ -30,7 +30,7 @@ else # !windows
 end # os-test
 
 # NOTE: this can't be put within the if-else block above
-for T in (Bool, Base.BitInteger_types...)
+for T in (Bool, BitInteger_types...)
     if Sys.iswindows()
         @eval function rand!(rd::RandomDevice, A::Array{$T}, ::SamplerType{$T})
             ccall((:SystemFunction036, :Advapi32), stdcall, UInt8, (Ptr{Void}, UInt32),
@@ -403,7 +403,7 @@ function rand!(r::MersenneTwister, A::Array{UInt128}, ::SamplerType{UInt128})
     A
 end
 
-for T in Base.BitInteger_types
+for T in BitInteger_types
     T === UInt128 && continue
     @eval function rand!(r::MersenneTwister, A::Array{$T}, ::SamplerType{$T})
         n = length(A)
@@ -451,7 +451,7 @@ function rand(rng::MersenneTwister,
     x % T + first(r)
 end
 
-for T in (Bool, Base.BitInteger_types...) # eval because of ambiguity otherwise
+for T in (Bool, BitInteger_types...) # eval because of ambiguity otherwise
     @eval Sampler(rng::MersenneTwister, r::UnitRange{$T}, ::Val{1}) =
         SamplerTrivial(r)
 end

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -4,6 +4,7 @@ module Random
 
 using Base.dSFMT
 using Base.GMP: Limb, MPZ
+using Base: BitInteger, BitInteger_types
 import Base: copymutable, copy, copy!, ==, hash
 
 export srand,

--- a/test/random.jl
+++ b/test/random.jl
@@ -103,9 +103,9 @@ if sizeof(Int32) < sizeof(Int)
     @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(UInt64,1:k)).u for k in 13 .+ Int64(2).^(32:62)])
     @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(Int64,1:k)).u for k in 13 .+ Int64(2).^(32:61)])
 
-    @test Base.Random.maxmultiplemix(0x000100000000) === 0xffffffffffffffff
-    @test Base.Random.maxmultiplemix(0x0000FFFFFFFF) === 0x00000000fffffffe
-    @test Base.Random.maxmultiplemix(0x000000000000) === 0xffffffffffffffff
+    @test Base.Random._maxmultiple(0x000100000000) === 0xffffffffffffffff
+    @test Base.Random._maxmultiple(0x0000FFFFFFFF) === 0x00000000fffffffe
+    @test Base.Random._maxmultiple(0x000000000000) === 0xffffffffffffffff
 end
 
 # BigInt specific


### PR DESCRIPTION
This supersedes most of the non-obsolete part of #9324.
This is essentially code reorganization (with one deleted `@eval`! :smiley: ).
I have subsequent work on this code, I will probably open another PR branched off of this one.