### PR TITLE
RFC: curry underscore arguments to create anonymous functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ Julia v1.7 Release Notes
 
 New language features
 ---------------------
+* An underscore `_` as a function argument, e.g. `f(_, y)`, is now shorthand
+  for the "curried" anonymous function `x -> f(x, y)` ([#24990]).
 
 Language changes
 ----------------

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -285,6 +285,35 @@ get(()->time(), dict, key)
 The call to [`time`](@ref) is delayed by wrapping it in a 0-argument anonymous function
 that is called only when the requested key is absent from `dict`.
 
+As a shorthand to create simple anonymous functions from other functions, if you pass an underscore
+`_` as a function *argument* it automatically constructs an anonymous function where `_` is
+the *parameter*.  For example, the expression `f(_,y)` is equivalent to `x -> f(x,y)`.  This
+includes infix functions like `_ + 1` (equivalent to `x -> x + 1`), indexing
+([`getindex`](@ref)) `_[i]` (equivalent to `x -> x[i]`), and
+field access `_.a` (equivalent to `x -> x.a`).   (This is called [partial application](https://en.wikipedia.org/wiki/Partial_application) of a function, and
+is sometimes informally referred to by the related term "[currying](https://en.wikipedia.org/wiki/Currying)".)
+For example, the following code averages the second element of each array in a collection, by
+passing the anonymous function `_[2]` (equivalent to `x -> x[2]`) as the first argument
+to [`mean`](@ref):
+
+```jldoctest
+julia> mean(_[2], [ [1,3,4], [1,2,5], [3,1,2], [4,4,4] ])
+2.5
+```
+
+More generally, if `_` is passed multiple times to the *same* function call,
+then each appearance of `_` is converted into a *different* argument of the
+anonymous function, in the order they appear.  For example, `f(_,y,_)` is
+equivalent to `(x,z) -> f(x,y,z)`.
+
+The `_` construction only applies to a *single* function call,
+not to nested function calls: `f(g(_))` is equivalent to `f(x -> g(x))`, not
+to `x -> f(g(x))`.  For example, the expression `2*_ + 1`, or
+equivalently the nested call `(+)((*)(2,_), 1)`, only converts `2*_`
+into a function, so the whole expression becomes `(x->2*x) + 1`, which
+will give an error because no method is defined to add `+ 1` to a function.
+Similarly, `f(g(_),_)` is converted into `y -> f(x -> g(x), y)`.
+
 ## Tuples
 
 Julia has a built-in data structure called a *tuple* that is closely related to function

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -294,11 +294,11 @@ field access `_.a` (equivalent to `x -> x.a`).   (This is called [partial applic
 is sometimes informally referred to by the related term "[currying](https://en.wikipedia.org/wiki/Currying)".)
 For example, the following code averages the second element of each array in a collection, by
 passing the anonymous function `_[2]` (equivalent to `x -> x[2]`) as the first argument
-to [`mean`](@ref):
+to [`sum`](@ref):
 
 ```jldoctest
-julia> mean(_[2], [ [1,3,4], [1,2,5], [3,1,2], [4,4,4] ])
-2.5
+julia> sum(_[2], [ [1,3,4], [1,2,5], [3,1,2], [4,4,4] ])
+10
 ```
 
 More generally, if `_` is passed multiple times to the *same* function call,

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1826,6 +1826,26 @@
                                  (call (top broadcasted) (top identity) ,e)))))))
 
 
+; Convert f(_,y) into x -> f(x,y) etcetera.  That is, an _ in e is changed into the
+; argument of an anonymous function.  Multiple underscores are turned into
+; multiple anonymous-function args.  2 arg-functions are turned into Fix1 or Fix2 calls.
+(define (curry-underscore e)
+  (expand-forms
+   (let ((oldargs (cddr e)))
+     (if (and (length= oldargs 2) (not (any kwarg? oldargs))) ; 2-arg case lowers to Fix1 or Fix2
+         (if (eq? '_ (car oldargs))
+             (if (eq? '_ (cadr oldargs))
+                 (cadr e) ; f(_,_) becomes f
+                 `(call (top Fix2) ,(cadr e) ,(cadr oldargs)))
+             `(call (top Fix1) ,(cadr e) ,(car oldargs)))
+         (let* ((args '()) ; n-arg case just becomes anon func
+                (enew (map (lambda (y) (if (eq? '_ y)
+                                           (let ((x (gensy)))
+                                             (set! args (cons x args))
+                                             x)
+                                           y)) e)))
+           `(-> (tuple ,@(reverse args)) ,enew))))))
+
 (define (expand-where body var)
   (let* ((bounds (analyze-typevar var))
          (v  (car bounds)))
@@ -2227,6 +2247,8 @@
                  ;; "(.op)(...)"
                  ((and (length= f 2) (eq? (car f) '|.|))
                   (expand-fuse-broadcast '() `(|.| ,(cadr f) (tuple ,@(cddr e)))))
+                 ((memq '_ (cddr e))
+                  (curry-underscore e))
                  ((eq? f 'ccall)
                   (if (not (length> e 4)) (error "too few arguments to ccall"))
                   (let* ((cconv (cadddr e))
@@ -2265,12 +2287,15 @@
                           (let ((x (car a)))
                             (if (and (length= x 2)
                                      (eq? (car x) '...))
-                                (if (null? run)
-                                    (list* (cadr x)
-                                           (tuple-wrap (cdr a) '()))
-                                    (list* `(call (core tuple) ,.(reverse run))
-                                           (cadr x)
-                                           (tuple-wrap (cdr a) '())))
+                                (begin
+                                  (if (eq? (cadr x) '_) ; _... is not currently allowed (meaning TBD)
+                                      (error (string "invalid underscore argument \"" (deparse x) "\"")))
+                                  (if (null? run)
+                                      (list* (cadr x)
+                                             (tuple-wrap (cdr a) '()))
+                                      (list* `(call (core tuple) ,.(reverse run))
+                                             (cadr x)
+                                             (tuple-wrap (cdr a) '()))))
                                 (tuple-wrap (cdr a) (cons x run))))))
                     (expand-forms
                      `(call (core _apply_iterate) (top iterate) ,f ,@(tuple-wrap argl '())))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1828,23 +1828,16 @@
 
 ; Convert f(_,y) into x -> f(x,y) etcetera.  That is, an _ in e is changed into the
 ; argument of an anonymous function.  Multiple underscores are turned into
-; multiple anonymous-function args.  2 arg-functions are turned into Fix1 or Fix2 calls.
+; multiple anonymous-function args.
 (define (curry-underscore e)
   (expand-forms
-   (let ((oldargs (cddr e)))
-     (if (and (length= oldargs 2) (not (any kwarg? oldargs))) ; 2-arg case lowers to Fix1 or Fix2
-         (if (eq? '_ (car oldargs))
-             (if (eq? '_ (cadr oldargs))
-                 (cadr e) ; f(_,_) becomes f
-                 `(call (top Fix2) ,(cadr e) ,(cadr oldargs)))
-             `(call (top Fix1) ,(cadr e) ,(car oldargs)))
-         (let* ((args '()) ; n-arg case just becomes anon func
-                (enew (map (lambda (y) (if (eq? '_ y)
-                                           (let ((x (gensy)))
-                                             (set! args (cons x args))
-                                             x)
-                                           y)) e)))
-           `(-> (tuple ,@(reverse args)) ,enew))))))
+   (let* ((args '()) ; n-arg case just becomes anon func
+          (enew (map (lambda (y) (if (eq? '_ y)
+                                     (let ((x (gensy)))
+                                       (set! args (cons x args))
+                                       x)
+                                     y)) e)))
+     `(-> (tuple ,@(reverse args)) ,enew))))
 
 (define (expand-where body var)
   (let* ((bounds (analyze-typevar var))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1226,6 +1226,26 @@ end
 # issue #9972
 @test Meta.lower(@__MODULE__, :(f(;3))) == Expr(:error, "invalid keyword argument syntax \"3\"")
 
+@testset "underscore currying" begin
+    @test div(4, _) isa Base.Fix1{typeof(div)}
+    @test div(_, 3) isa Base.Fix2{typeof(div)}
+    @test div(_, _) === div
+    @test div(_, 3)(13) === 4
+    @test (_+1)(3) === 4
+    @test (_.re)(5+6im) === 5
+    @test (_[2])([7,8,9]) === 8
+    @test div.(10,_)([1,2,3,4]) == [10,5,3,2]
+    @test (_ .+ 1)([1,2,3,4]) == [2,3,4,5]
+    @test (_ // _)(3,4) === 3//4
+    let _round(x,d; kws...) = round(x; digits=d, kws...) # test a 2-arg func with keywords
+        @test _round(_, 2, base=10)(pi) == 3.14
+        @test _round(_, 2, base=2)(pi) === _round(_, _, base=2)(pi, 2) == 3.25
+    end
+    @test split(_)("a b") == ["a","b"]
+    @test split(_, limit=2)("a b c") == ["a","b c"]
+    @test Meta.lower(@__MODULE__, :(f(_...))) == Expr(:error, "invalid underscore argument \"_...\"")
+end
+
 # issue #25055, make sure quote makes new Exprs
 function f25055()
     x = quote end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1227,15 +1227,12 @@ end
 @test Meta.lower(@__MODULE__, :(f(;3))) == Expr(:error, "invalid keyword argument syntax \"3\"")
 
 @testset "underscore currying" begin
-    @test div(4, _) isa Base.Fix1{typeof(div)}
-    @test div(_, 3) isa Base.Fix2{typeof(div)}
-    @test div(_, _) === div
     @test div(_, 3)(13) === 4
     @test (_+1)(3) === 4
     @test (_.re)(5+6im) === 5
     @test (_[2])([7,8,9]) === 8
-    @test div.(10,_)([1,2,3,4]) == [10,5,3,2]
-    @test (_ .+ 1)([1,2,3,4]) == [2,3,4,5]
+    @test_broken div.(10,_)([1,2,3,4]) == [10,5,3,2]
+    @test_broken (_ .+ 1)([1,2,3,4]) == [2,3,4,5]
     @test (_ // _)(3,4) === 3//4
     let _round(x,d; kws...) = round(x; digits=d, kws...) # test a 2-arg func with keywords
         @test _round(_, 2, base=10)(pi) == 3.14


### PR DESCRIPTION
This PR addresses JuliaLang/julia#554, JuliaLang/julia#5571, and JuliaLang/julia#22710 by "currying" underscores in function calls like `f(_,y)` into anonymous function expressions `x -> f(x,y)`.  (Note that `_.foo` works and turns into `x -> x.foo` since it is equivalent to a `getfield` call, and `_[i]` works and turns into `x -> x[i]`, since it is equivalent to a `getindex(_,i)` call.)

This will help us get rid of functions like `equalto` (#23812) or `occursin` (#24967), is useful for "destructuring" as discussed in JuliaLang/julia#22710, and should generally be convenient in lots of cases to avoid having to explicitly do `x -> f(x,y)`.

Some simplifying design decisions that I made:

* The currying is "tight", i.e. it only converts the immediately surrounding function call into a lambda, [as suggested by](https://github.com/JuliaLang/julia/issues/22710#issuecomment-314259250) @JeffBezanson (and [as in Scala](https://www.scala-lang.org/files/archive/spec/2.11/06-expressions.html#placeholder-syntax-for-anonymous-functions)).   So, e.g. `f(g(_,y))` is equivalent to `f(x -> g(x,y))`.   (Note that something like `find(!(_ in c), y)` will work fine, because the `!` operator works on functions; you can also use `_ ∉ c`.)  Any other rule seems hard to make comprehensible and consistent.

* ~~Only a single underscore is allowed.  `f(_,_)` throws an error: this case seems ambiguous to me (do you want `x -> f(x,x)` or `x,y -> f(x,y)`?), so it seemed better to punt on this for now.  We can always add a meaning for multiple underscores later.~~ Similar to Scala, multiple underscores are converted into multiple arguments in the order they appear.  e.g. `f(_,y,_)` is equivalent to `(x,z) -> f(x,y,z)`.  See [rationale below](https://github.com/JuliaLang/julia/pull/24990#issuecomment-350879561).

The implementation is pretty trivial.  If people are in favor, I will add
- [x] Tests
- [x] Documentation
- [ ] Fix interaction with broadcasting `f.(x, _)`
- [ ] Fix interaction with keyword arguments `f(x; y=_)`
- [ ] Support chained comparisons, e.g. `3 ≤ _ ≤ 10`, since they parse as a single expression?