### PR TITLE
Fix varinfo() when module contains missing

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -742,7 +742,7 @@ function varinfo(m::Module=Main, pattern::Regex=r"")
     rows =
         Any[ let value = getfield(m, v)
                  Any[string(v),
-                     (value ∈ (Base, Main, Core) ? "" : format_bytes(summarysize(value))),
+                     (any(x -> x === value, (Base, Main, Core)) ? "" : format_bytes(summarysize(value))),
                      summary(value)]
              end
              for v in sort!(names(m)) if isdefined(m, v) && ismatch(pattern, string(v)) ]

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -767,3 +767,9 @@ end
 
 # PR #23664, make sure names don't get added to the default `Main` workspace
 @test readlines(`$(Base.julia_cmd()) --startup-file=no -e 'foreach(println, names(Main))'`) == ["Base","Core","Main"]
+
+# PR #24997: test that `varinfo` doesn't fail when encountering `missing`
+module A
+    export missing
+    varinfo(A)
+end


### PR DESCRIPTION
Checks for object equality should not have used `in`, which propagates missing values. What is intended here is really `===`.