### PR TITLE
RNG: delete rand_ui* functions in favor of multi-dispatch

### DIFF
--- a/base/random/misc.jl
+++ b/base/random/misc.jl
@@ -147,7 +147,7 @@ randsubseq(A::AbstractArray, p::Real) = randsubseq(GLOBAL_RNG, A, p)
 @inline function rand_lt(r::AbstractRNG, n::Int, mask::Int=nextpow2(n)-1)
     # this duplicates the functionality of rand(1:n), to optimize this special case
     while true
-        x = (rand_ui52_raw(r) % Int) & mask
+        x = rand(r, UInt52Raw(Int)) & mask
         x < n && return x
     end
 end

--- a/base/random/normal.jl
+++ b/base/random/normal.jl
@@ -35,7 +35,7 @@ julia> randn(rng, Complex64, (2, 3))
 """
 @inline function randn(rng::AbstractRNG=GLOBAL_RNG)
     @inbounds begin
-        r = rand_ui52(rng)
+        r = rand(rng, UInt52())
         rabs = Int64(r>>1) # One bit for the sign
         idx = rabs & 0xFF
         x = ifelse(r % Bool, -rabs, rabs)*wi[idx+1]
@@ -95,7 +95,7 @@ julia> randexp(rng, 3, 3)
 """
 function randexp(rng::AbstractRNG=GLOBAL_RNG)
     @inbounds begin
-        ri = rand_ui52(rng)
+        ri = rand(rng, UInt52())
         idx = ri & 0xFF
         x = ri*we[idx+1]
         ri < ke[idx+1] && return x # 98.9% of the time we return here 1st try

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -25,6 +25,43 @@ export srand,
 
 abstract type AbstractRNG end
 
+### integers
+
+# we define types which encode the generation of a specific number of bits
+# the "raw" version means that the unused bits are not zeroed
+
+abstract type UniformBits{T<:BitInteger} end
+
+struct UInt10{T}    <: UniformBits{T} end
+struct UInt10Raw{T} <: UniformBits{T} end
+
+struct UInt23{T}    <: UniformBits{T} end
+struct UInt23Raw{T} <: UniformBits{T} end
+
+struct UInt52{T}    <: UniformBits{T} end
+struct UInt52Raw{T} <: UniformBits{T} end
+
+struct UInt104{T}    <: UniformBits{T} end
+struct UInt104Raw{T} <: UniformBits{T} end
+
+struct UInt2x52{T}    <: UniformBits{T} end
+struct UInt2x52Raw{T} <: UniformBits{T} end
+
+uint_sup(::Type{<:Union{UInt10,UInt10Raw}}) = UInt16
+uint_sup(::Type{<:Union{UInt23,UInt23Raw}}) = UInt32
+uint_sup(::Type{<:Union{UInt52,UInt52Raw}}) = UInt64
+uint_sup(::Type{<:Union{UInt104,UInt104Raw}}) = UInt128
+uint_sup(::Type{<:Union{UInt2x52,UInt2x52Raw}}) = UInt128
+
+for UI = (:UInt10, :UInt10Raw, :UInt23, :UInt23Raw, :UInt52, :UInt52Raw,
+          :UInt104, :UInt104Raw, :UInt2x52, :UInt2x52Raw)
+    @eval begin
+        $UI(::Type{T}=uint_sup($UI)) where {T} = $UI{T}()
+        # useful for defining rand generically:
+        uint_default(::$UI) = $UI{uint_sup($UI)}()
+    end
+end
+
 ### floats
 
 abstract type FloatInterval{T<:AbstractFloat} end

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -4,7 +4,7 @@ module Random
 
 using Base.dSFMT
 using Base.GMP: Limb, MPZ
-using Base: BitInteger, BitInteger_types
+using Base: BitInteger, BitInteger_types, BitUnsigned
 import Base: copymutable, copy, copy!, ==, hash
 
 export srand,

--- a/test/random.jl
+++ b/test/random.jl
@@ -3,6 +3,8 @@
 isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using Main.TestHelpers.OAs
 
+using Base.Random: Sampler, SamplerRangeFast, SamplerRangeInt
+
 # Issue #6573
 guardsrand(0) do
     rand()
@@ -646,4 +648,11 @@ struct RandomStruct23964 end
 @testset "error message when rand not defined for a type" begin
     @test_throws ArgumentError rand(nothing)
     @test_throws ArgumentError rand(RandomStruct23964())
+end
+
+@testset "rand(::$RNG, ::UnitRange{$T}" for RNG ∈ (MersenneTwister(), RandomDevice()),
+                                                 T ∈ (Int32, UInt32, Int64, Int128, UInt128)
+    RNG isa MersenneTwister && srand(RNG, rand(UInt128)) # for reproducibility
+    r = T(1):T(108)
+    @test rand(RNG, SamplerRangeFast(r)) ∈ r
 end


### PR DESCRIPTION
* we add a first RNG trait, `rng_native_52()`, which selects a native
  primitive, between `UInt64` and `Float64`. This is still experimental,
  but it already allows a little bit of code simplification;
* we also rename the `rand_generic` functions to rand; the `Sampler`
  framework plus traits should make them un-necessary