### PR TITLE
Remove `-i` flag being passed to `bash` for shell mode commands

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -129,9 +129,7 @@ function repl_cmd(cmd, out)
             else
                 shell_escape_cmd = "($(shell_escape_posixly(cmd))) && true"
             end
-            cmd = `$shell`
-            isa(STDIN, TTY) && (cmd = `$cmd -i`)
-            cmd = `$cmd -c $shell_escape_cmd`
+            cmd = `$shell -c $shell_escape_cmd`
         end
         run(ignorestatus(cmd))
     end


### PR DESCRIPTION
I do not see the benefit of passing `-i` to `bash` for shell mode commands; it reads in things like `.bash_profile` on some systems, and in general doesn't seem to be the right move for the quick one-off commands that shell mode is intended for.  I am unable to find a program that suffers when run without the `-i` flag (and if it is really needed, running `;bash` should give quick and easy access to those kinds of commands).

Fixes https://github.com/JuliaLang/julia/issues/24736
Fixes https://github.com/JuliaLang/julia/issues/17332