### PR TITLE
Fix `push!` signature for `EnvDict`.

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2641,6 +2641,9 @@ end
 @deprecate lpad(s, n::Integer, p) lpad(string(s), n, string(p))
 @deprecate rpad(s, n::Integer, p) rpad(string(s), n, string(p))
 
+# PR #25011
+@deprecate push!(env::EnvDict, k::AbstractString, v) push!(env, k=>v)
+
 # issue #24868
 @deprecate sprint(size::Integer, f::Function, args...; env=nothing) sprint(f, args...; context=env, sizehint=size)
 

--- a/base/env.jl
+++ b/base/env.jl
@@ -81,7 +81,7 @@ pop!(::EnvDict, k::AbstractString) = (v = ENV[k]; _unsetenv(k); v)
 pop!(::EnvDict, k::AbstractString, def) = haskey(ENV,k) ? pop!(ENV,k) : def
 delete!(::EnvDict, k::AbstractString) = (_unsetenv(k); ENV)
 setindex!(::EnvDict, v, k::AbstractString) = _setenv(k,string(v))
-push!(::EnvDict, k::AbstractString, v) = setindex!(ENV, v, k)
+push!(::EnvDict, kv::Pair{<:AbstractString}) = setindex!(ENV, kv.second, kv.first)
 
 if Sys.iswindows()
     start(hash::EnvDict) = (pos = ccall(:GetEnvironmentStringsW,stdcall,Ptr{UInt16},()); (pos,pos))

--- a/test/env.jl
+++ b/test/env.jl
@@ -73,3 +73,11 @@ for (k, v) in ENV
         @test v[end] != '\0'
     end
 end
+
+@testset "push" begin
+    @test !haskey(ENV, "testing_envdict")
+    push!(ENV, "testing_envdict" => "tested")
+    @test haskey(ENV, "testing_envdict")
+    @test ENV["testing_envdict"] == "tested"
+    delete!(ENV, "testing_envdict")
+end


### PR DESCRIPTION
New style is to `push!` pairs onto `Associatives`. This one must have been missed.