### PR TITLE
WIP: deprecate iteration on bare `Associative`, introduce `PairIterator`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -738,6 +738,10 @@ Deprecated or removed
   * The `sum_kbn` and `cumsum_kbn` functions have been moved to the
     [KahanSummation](https://github.com/JuliaMath/KahanSummation.jl) package ([#24869]).
 
+  * Iteration (`next`, `eltype`, `in`, `map`, etc) on `Associative`s has been deprecated.
+    Explicitly nominate `pairs(dict)`, `values(dict)` or `keys(dict)` as appropriate
+    ([#25013]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -107,7 +107,7 @@ function deepcopy_internal(x::Dict, stackdict::ObjectIdDict)
 
     dest = empty(x)
     stackdict[x] = dest
-    for (k, v) in x
+    for (k, v) in pairs(x)
         dest[deepcopy_internal(k, stackdict)] = deepcopy_internal(v, stackdict)
     end
     dest

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2186,6 +2186,11 @@ end
 @deprecate_moved sum_kbn "KahanSummation"
 @deprecate_moved cumsum_kbn "KahanSummation"
 
+# PR #25013
+@deprecate eltype(A::Type{Associative{K,V}}) where {K,V} pairtype(A)
+@deprecate next(a::Associative, i) next(pairs(a), i)
+#@deprecate Base.in(p::Pair, a::Associative, valcmp = (==)) Base.in(p, PairIterator(a), valcmp)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -43,7 +43,7 @@ function show(io::IO, t::Associative{K,V}) where V where K
         if !show_circular(io, t)
             first = true
             n = 0
-            for pair in t
+            for pair in pairs(t)
                 first || print(io, ',')
                 first = false
                 show(recur_io, pair)
@@ -139,9 +139,12 @@ Dict(ps::Pair{K}...)             where {K}   = Dict{K,Any}(ps)
 Dict(ps::(Pair{K,V} where K)...) where {V}   = Dict{Any,V}(ps)
 Dict(ps::Pair...)                            = Dict{Any,Any}(ps)
 
+pair_or_eltype(x) = eltype(x)
+pair_or_eltype(x::Associative) = pairtype(x)
+
 function Dict(kv)
     try
-        associative_with_eltype((K, V) -> Dict{K, V}, kv, eltype(kv))
+        associative_with_eltype((K, V) -> Dict{K, V}, kv, pair_or_eltype(kv))
     catch e
         if !applicable(start, kv) || !all(x->isa(x,Union{Tuple,Pair}),kv)
             throw(ArgumentError("Dict(kv): kv needs to be an iterator of tuples or pairs"))
@@ -193,7 +196,7 @@ empty(a::Associative, ::Type{K}, ::Type{V}) where {K, V} = Dict{K, V}()
 # conversion between Dict types
 function convert(::Type{Dict{K,V}},d::Associative) where V where K
     h = Dict{K,V}()
-    for (k,v) in d
+    for (k,v) in pairs(d)
         ck = convert(K,k)
         if !haskey(h,ck)
             h[ck] = convert(V,v)
@@ -711,8 +714,8 @@ function start(t::Dict)
     return i
 end
 done(t::Dict, i) = i > length(t.vals)
-@propagate_inbounds function next(t::Dict{K,V}, i) where {K,V}
-    return (Pair{K,V}(t.keys[i],t.vals[i]), skip_deleted(t,i+1))
+@propagate_inbounds function next(t::PairIterator{Dict{K,V}}, i) where {K,V}
+    return (Pair{K,V}(t.dict.keys[i],t.dict.vals[i]), skip_deleted(t.dict,i+1))
 end
 
 isempty(t::Dict) = (t.count == 0)
@@ -756,11 +759,11 @@ ImmutableDict
 ImmutableDict(KV::Pair{K,V}) where {K,V} = ImmutableDict{K,V}(KV[1], KV[2])
 ImmutableDict(t::ImmutableDict{K,V}, KV::Pair) where {K,V} = ImmutableDict{K,V}(t, KV[1], KV[2])
 
-function in(key_value::Pair, dict::ImmutableDict, valcmp=(==))
+function in(key_value::Pair, dict::PairIterator{<:ImmutableDict}, valcmp=(==))
     key, value = key_value
     while isdefined(dict, :parent)
-        if dict.key == key
-            valcmp(value, dict.value) && return true
+        if dict.dict.key == key
+            valcmp(value, dict.dict.value) && return true
         end
         dict = dict.parent
     end
@@ -792,7 +795,7 @@ end
 
 # this actually defines reverse iteration (e.g. it should not be used for merge/copy/filter type operations)
 start(t::ImmutableDict) = t
-next(::ImmutableDict{K,V}, t) where {K,V} = (Pair{K,V}(t.key, t.value), t.parent)
+next(::PairIterator{ImmutableDict{K,V}}, t) where {K,V} = (Pair{K,V}(t.key, t.value), t.parent)
 done(::ImmutableDict, t) = !isdefined(t, :parent)
 length(t::ImmutableDict) = count(x->true, t)
 isempty(t::ImmutableDict) = done(t, start(t))

--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -139,7 +139,7 @@ repl_corrections(s) = repl_corrections(STDOUT, s)
 const symbols_latex = Dict{String,String}()
 function symbol_latex(s::String)
     if isempty(symbols_latex)
-        for (k,v) in Base.REPLCompletions.latex_symbols
+        for (k,v) in pairs(Base.REPLCompletions.latex_symbols)
             symbols_latex[v] = k
         end
     end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -82,6 +82,7 @@ export
     ObjectIdDict,
     OrdinalRange,
     Pair,
+    PairIterator,
     PartialQuickSort,
     PermutedDimsArray,
     QuickSort,

--- a/base/inference.jl
+++ b/base/inference.jl
@@ -5686,7 +5686,7 @@ function remove_redundant_temp_vars!(src::CodeInfo, nargs::Int, sa::ObjectIdDict
     slottypes = src.slottypes
     ssavaluetypes = src.ssavaluetypes
     repls = ObjectIdDict()
-    for (v, init) in sa
+    for (v, init) in pairs(sa)
         repl = get_replacement(sa, v, init, nargs, slottypes, ssavaluetypes)
         compare = isa(repl, TypedSlot) ? normslot(repl) : repl
         if compare !== v

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -314,13 +314,13 @@ function versioninfo(io::IO=STDOUT; verbose::Bool=false, packages::Bool=false)
     println(io, "  LLVM: libLLVM-",libllvm_version," (", Sys.JIT, ", ", Sys.cpu_name, ")")
 
     println(io, "Environment:")
-    for (k,v) in ENV
+    for (k,v) in pairs(ENV)
         if ismatch(r"JULIA", String(k))
             println(io, "  $(k) = $(v)")
         end
     end
     if verbose
-        for (k,v) in ENV
+        for (k,v) in pairs(ENV)
             if ismatch(r"PATH|FLAG|^TERM$|HOME", String(k))
                 println(io, "  $(k) = $(v)")
             end

--- a/base/process.jl
+++ b/base/process.jl
@@ -208,7 +208,7 @@ end
 byteenv(env::AbstractArray{<:AbstractString}) =
     String[cstr(x) for x in env]
 byteenv(env::Associative) =
-    String[cstr(string(k)*"="*string(v)) for (k,v) in env]
+    String[cstr(string(k)*"="*string(v)) for (k,v) in pairs(env)]
 byteenv(env::Void) = nothing
 byteenv(env::Union{AbstractVector{Pair{T}}, Tuple{Vararg{Pair{T}}}}) where {T<:AbstractString} =
     String[cstr(k*"="*string(v)) for (k,v) in env]

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1233,7 +1233,7 @@ end
 
 function normalize_keys(keymap::Dict)
     ret = Dict{Any,Any}()
-    for (k,v) in keymap
+    for (k,v) in pairs(keymap)
         normalized = normalize_key(k)
         if haskey(ret,normalized)
             error("""Multiple spellings of a key in a single keymap
@@ -1396,7 +1396,7 @@ function postprocess!(dict::Dict)
     if haskey(dict, wildcard)
         add_specialisations(dict, dict, 1)
     end
-    for (k,v) in dict
+    for (k,v) in pairs(dict)
         k == wildcard && continue
         postprocess!(v)
     end
@@ -2179,7 +2179,7 @@ function reset_state(s::PromptState)
 end
 
 function reset_state(s::MIState)
-    for (mode, state) in s.mode_state
+    for (mode, state) in pairs(s.mode_state)
         reset_state(state)
     end
 end

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -432,7 +432,7 @@ end
 
 function mode_idx(hist::REPLHistoryProvider, mode)
     c = :julia
-    for (k,v) in hist.mode_mapping
+    for (k,v) in pairs(hist.mode_mapping)
         isequal(v, mode) && (c = k)
     end
     return c

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -59,7 +59,7 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
         vs = Vector{AbstractString}(uninitialized, min(rows, length(t)))
         keylen = 0
         vallen = 0
-        for (i, (k, v)) in enumerate(t)
+        for (i, (k, v)) in enumerate(pairs(t))
             i > rows && break
             ks[i] = sprint(0, show, k, env=recur_io)
             vs[i] = sprint(0, show, v, env=recur_io)
@@ -73,7 +73,7 @@ function show(io::IO, ::MIME"text/plain", t::Associative{K,V}) where {K,V}
         rows = cols = typemax(Int)
     end
 
-    for (i, (k, v)) in enumerate(t)
+    for (i, (k, v)) in enumerate(pairs(t))
         print(io, "\n  ")
         i == rows < length(t) && (print(io, rpad("⋮", keylen), " => ⋮"); break)
 

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -345,7 +345,7 @@ end
 function serialize(s::AbstractSerializer, d::Dict)
     serialize_cycle_header(s, d) && return
     write(s.io, Int32(length(d)))
-    for (k,v) in d
+    for (k,v) in pairs(d)
         serialize(s, k)
         serialize(s, v)
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -94,7 +94,7 @@ pipe_writer(io::IOContext) = io.io
 lock(io::IOContext) = lock(io.io)
 unlock(io::IOContext) = unlock(io.io)
 
-in(key_value::Pair, io::IOContext) = in(key_value, io.dict, ===)
+in(key_value::Pair, io::IOContext) = in(key_value, pairs(io.dict), ===)
 in(key_value::Pair, io::IO) = false
 haskey(io::IOContext, key) = haskey(io.dict, key)
 haskey(io::IO, key) = false
@@ -108,7 +108,7 @@ displaysize(io::IOContext) = haskey(io, :displaysize) ? io[:displaysize] : displ
 show_circular(io::IO, @nospecialize(x)) = false
 function show_circular(io::IOContext, @nospecialize(x))
     d = 1
-    for (k, v) in io.dict
+    for (k, v) in pairs(io.dict)
         if k === :SHOWN_SET
             if v === x
                 print(io, "#= circular reference @-$d =#")
@@ -215,7 +215,7 @@ end
 has_typevar(@nospecialize(t), v::TypeVar) = ccall(:jl_has_typevar, Cint, (Any, Any), t, v)!=0
 
 function io_has_tvar_name(io::IOContext, name::Symbol, @nospecialize(x))
-    for (key, val) in io.dict
+    for (key, val) in pairs(io.dict)
         if key === :unionall_env && val isa TypeVar && val.name === name && has_typevar(x, val)
             return true
         end

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -244,7 +244,7 @@ function sparsevec(dict::Associative{Ti,Tv}) where {Tv,Ti<:Integer}
 
     cnt = 0
     len = zero(Ti)
-    for (k, v) in dict
+    for (k, v) in pairs(dict)
         k >= 1 || throw(ArgumentError("index must be positive."))
         if k > len
             len = k
@@ -265,7 +265,7 @@ function sparsevec(dict::Associative{Ti,Tv}, len::Integer) where {Tv,Ti<:Integer
 
     cnt = 0
     maxk = convert(Ti, len)
-    for (k, v) in dict
+    for (k, v) in pairs(dict)
         1 <= k <= maxk || throw(ArgumentError("an index (key) is out of bound."))
         cnt += 1
         @inbounds nzind[cnt] = k

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -73,7 +73,7 @@ empty(d::WeakKeyDict, ::Type{K}, ::Type{V}) where {K, V} = WeakKeyDict{K, V}()
 # conversion between Dict types
 function convert(::Type{WeakKeyDict{K,V}},d::Associative) where V where K
     h = WeakKeyDict{K,V}()
-    for (k,v) in d
+    for (k,v) in pairs(d)
         ck = convert(K,k)
         if !haskey(h,ck)
             h[ck] = convert(V,v)
@@ -132,9 +132,9 @@ function start(t::WeakKeyDict{K,V}) where V where K
     return (start(t.ht), gc_token)
 end
 done(t::WeakKeyDict, i) = done(t.ht, i[1])
-function next(t::WeakKeyDict{K,V}, i)  where V where K
+function next(t::PairIterator{WeakKeyDict{K,V}}, i)  where V where K
     gc_token = i[2]
-    wkv, i = next(t.ht, i[1])
+    wkv, i = next(PairIterator(t.dict.ht), i[1])
     kv = Pair{K,V}(wkv[1].value::K, wkv[2])
     return (kv, (i, gc_token))
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1420,14 +1420,14 @@ struct GenericDict{K,V} <: Associative{K,V}
     s::Associative{K,V}
 end
 
-for (G, A) in ((GenericSet, AbstractSet),
-               (GenericDict, Associative))
+for (G, I, A) in ((GenericSet, GenericSet, AbstractSet),
+               (GenericDict, PairIterator{<:GenericSet}, Associative))
     @eval begin
         Base.convert(::Type{$G}, s::$A) = $G(s)
         Base.done(s::$G, state) = done(s.s, state)
-        Base.next(s::$G, state) = next(s.s, state)
+        Base.next(s::$I, state) = next(s.s, state)
     end
-    for f in (:eltype, :isempty, :length, :start)
+    for f in (:isempty, :length, :start)
         @eval begin
             Base.$f(s::$G) = $f(s.s)
         end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -77,13 +77,13 @@ end
     h["a","b","c"] = 4
     @test h["a","b","c"] == h[("a","b","c")] == 4
 
-    @testset "eltype, keytype and valtype" begin
-        @test eltype(h) == Pair{Any,Any}
+    @testset "pairtype, keytype and valtype" begin
+        @test pairtype(h) == Pair{Any,Any}
         @test keytype(h) == Any
         @test valtype(h) == Any
 
         td = Dict{AbstractString,Float64}()
-        @test eltype(td) == Pair{AbstractString,Float64}
+        @test pairtype(td) == Pair{AbstractString,Float64}
         @test keytype(td) == AbstractString
         @test valtype(td) == Float64
         @test keytype(Dict{AbstractString,Float64}) === AbstractString
@@ -421,7 +421,7 @@ end
     d = @inferred ObjectIdDict(Pair(1,1), Pair(2,2), Pair(3,3))
     @test isa(d, ObjectIdDict)
     @test d == ObjectIdDict(1=>1, 2=>2, 3=>3)
-    @test eltype(d) == Pair{Any,Any}
+    @test pairtype(d) == Pair{Any,Any}
 end
 
 @testset "Issue #7944" begin
@@ -435,7 +435,8 @@ end
 @testset "iteration" begin
     d = Dict('a'=>1, 'b'=>1, 'c'=> 3)
     @test [d[k] for k in keys(d)] == [d[k] for k in eachindex(d)] ==
-          [v for (k, v) in d] == [d[x[1]] for (i, x) in enumerate(d)]
+          [v for (k, v) in pairs(d)] == [d[x[1]] for (i, x) in enumerate(d)] ==
+          [v for v in values(d)]
 end
 
 @testset "generators, similar" begin
@@ -496,19 +497,19 @@ import Base.ImmutableDict
     @test collect(d1) == [Pair(k1, v1)]
     @test collect(d4) == reverse([Pair(k1, v1), Pair(k2, v2), Pair(k1, v2), Pair(k2, v1)])
     @test d1 == ImmutableDict(d, k1 => v1)
-    @test !((k1 => v2) in d2)
-    @test (k1 => v2) in d3
-    @test (k1 => v1) in d4
-    @test (k1 => v2) in d4
-    @test in(k2 => "value2", d4, ===)
-    @test in(k2 => v2, d4, ===)
-    @test in(k2 => NaN, dnan, isequal)
-    @test in(k2 => NaN, dnan, ===)
-    @test !in(k2 => NaN, dnan, ==)
-    @test !in(k2 => 1, dnum, ===)
-    @test in(k2 => 1.0, dnum, ===)
-    @test !in(k2 => 1, dnum, <)
-    @test in(k2 => 0, dnum, <)
+    @test !((k1 => v2) in pairs(d2))
+    @test (k1 => v2) in pairs(d3)
+    @test (k1 => v1) in pairs(d4)
+    @test (k1 => v2) in pairs(d4)
+    @test in(k2 => "value2", pairs(d4), ===)
+    @test in(k2 => v2, pairs(d4), ===)
+    @test in(k2 => NaN, pairs(dnan), isequal)
+    @test in(k2 => NaN, pairs(dnan), ===)
+    @test !in(k2 => NaN, pairs(dnan), ==)
+    @test !in(k2 => 1, pairs(dnum), ===)
+    @test in(k2 => 1.0, pairs(dnum), ===)
+    @test !in(k2 => 1, pairs(dnum), <)
+    @test in(k2 => 0, pairs(dnum), <)
     @test get(d1, "key1", :default) === v1
     @test get(d4, "key1", :default) === v2
     @test get(d4, "foo", :default) === :default

--- a/test/env.jl
+++ b/test/env.jl
@@ -37,7 +37,7 @@ end
     k1, k2 = "__test__", "__test1__"
     withenv(k1=>k1, k2=>k2) do
         b_k1, b_k2 = false, false
-        for (k, v) in ENV
+        for (k, v) in pairs(ENV)
             if k==k1
                 b_k1=true
             elseif k==k2
@@ -66,7 +66,7 @@ end
 @test withenv(Dict{Any,Any}()...) do; true; end
 
 # Test for #18141
-for (k, v) in ENV
+for (k, v) in pairs(ENV)
     if length(v) > 0
         @test v[end] != '\0'
     end


### PR DESCRIPTION
This is WIP towards modifying the iteration scheme for `Associative`. There have been some discussions about whether dictionaries should iterate key-value pairs, or just plain values (like arrays). For my part, I feel the latter makes most sense for operations like `map` (preserves keys), `reduce` (such as `sum(dict)`), and so-on, where you are using the dictionary as an indexed collection of *data*. Dictionary iteration has been discussed in multiple places - using values was floated by me at #24019, and iteration of dictionary-types is treated pretty extensively at #22194 (named tuples, which iterate values). There, Jeff's opening post contains this observation:

> There are different perspectives on dict-like types: sometimes they are more like relations, containing pairs, sometimes they are primarily collections of keys, and sometimes they are primarily collections of values. Iteration cannot do all of these at once; indeed, iteration has little to do with the concept of "keys".

With that in mind, in this PR the iteration protocol on `Associative` has been deprecated. A new `PairIterator` is introduced, and created by `pairs(dict)`. Users should use `pairs(dict)` or `values(dict)` (or `keys(dict)`) to explicitly specify iteration results, like so:

```julia
for k,v in pairs(dict)
    ...
end

for v in values(dict)
    ...
end

for k in keys(dict)
    ...
end
```
The `in` predicate also requires specifying `pairs`, `values` or `keys`. This PR doesn't yet fully deal with `filter` and `map` on dictionaries (and `pairs`/`values`/`keys` thereof), but arguably users will want to choose to `map` or `filter` with or without knowing about the key. At some point, it's probably also worth discussing how the deque protocol (`push!`, etc) interacts with iteration and the iterator types.

This PR also leaves open the possibility of reintroducing an iteration protocol for dictionaries at a later date. Comments very welcome. I will also note that v1.0 is coming up quickly, and we can iterate on this rapidly if we do decide to merge.