### PR TITLE
Revert "Add patch to MPFR version (#23287)"

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -27,11 +27,8 @@ import Base.Math.lgamma_r
 
 import Base.FastMath.sincos_fast
 
-function version()
-    version = unsafe_string(ccall((:mpfr_get_version,:libmpfr), Ptr{Cchar}, ()))
-    build = replace(unsafe_string(ccall((:mpfr_get_patches,:libmpfr), Ptr{Cchar}, ())), ' ', '.')
-    isempty(build) ? VersionNumber(version) : VersionNumber(version * '+' * build)
-end
+version() = VersionNumber(unsafe_string(ccall((:mpfr_get_version,:libmpfr), Ptr{Cchar}, ())))
+patches() = split(unsafe_string(ccall((:mpfr_get_patches,:libmpfr), Ptr{Cchar}, ())),' ')
 
 function __init__()
     try

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -865,7 +865,7 @@ end
     end
 end
 # issue #22758
-if MPFR.version() > v"3.1.5" || "r11590" in MPFR.version().build
+if MPFR.version() > v"3.1.5" || "r11590" in MPFR.patches()
     setprecision(2_000_000) do
         @test abs(sin(big(pi)/6) - 0.5) < ldexp(big(1.0),-1_999_000)
     end


### PR DESCRIPTION
This reverts commit 8f5f981a094e1f85290e8d394337a181a849bccf.

1. The function is not unnecessary
2. The patch field of VersionNumber is not what this is meant for

    Note that the function name is `patches` not `patch` and it is

    > a null-terminated string containing the ids of the patches
    > applied to the MPFR library (contents of the PATCHES file),
    > separated by spaces

    As defined by the MPFR doc.

In particular, it may not be a valid version string and must not be part of it.