### PR TITLE
Fix LaTeX output for Markdown tables.

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -161,7 +161,7 @@ function latex(io::IO, md::Table)
             end
             println(io, " \\\\")
             if i == 1
-                println("\\hline")
+                println(io, "\\hline")
             end
         end
     end

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -296,6 +296,14 @@ Some **bolded**
 - list2
 """
 @test latex(book) == "\\section{Title}\nSome discussion\n\n\\begin{quote}\nA quote\n\n\\end{quote}\n\\subsection{Section \\emph{important}}\nSome \\textbf{bolded}\n\n\\begin{itemize}\n\\item list1\n\n\n\\item list2\n\n\\end{itemize}\n"
+table = md"""
+ a | b
+---|---
+ 1 | 2
+"""
+@test latex(table) ==
+    "\\begin{tabular}\n{r | r}\na & b \\\\\n\\hline\n1 & 2 \\\\\n\\end{tabular}\n"
+
 # mime output
 let out =
     """


### PR DESCRIPTION
The `\hline` was printed to `STDOUT`.

Also added a test.