### PR TITLE
Some adjustments for dimensionful numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -616,14 +616,12 @@ Deprecated or removed
     `Meta.lower(module, ex)` ([#22064, #24278]).
 
   * `ones(A::AbstractArray[, opts...])` and `zeros(A::AbstractArray[, opts...])` methods
-    have been deprecated. The general replacement is
-    `fill!(similar(A[, opts...]), {one(eltype(A)) | zero(eltype(A))})`,
-    though in most use cases simpler alternatives are better: For `zeros(A)`, consider
-    `zero(A)`. For `ones(A)` or `zeros(A)`, consider `fill(v, size(A))` for `v` an
-    appropriate one or zero, `fill!(copy(A), {one(eltype(A)) | zero(eltype(A))})`,
-    `ones(size(A))` or `zeros(size(A))`, or any of the preceding with different element type
-    and/or shape depending on `opts...`. For an algebraic multiplicative identity,
-    consider `one(A)` ([#24656]).
+    have been deprecated. For `zeros(A)`, consider `zero(A)`. For `ones(A)` or `zeros(A)`,
+    consider `ones(size(A))`, `zeros(size(A))`, `fill(v, size(A))` for `v` an appropriate
+    one or zero, `fill!(copy(A), {1|0})`, `fill!(similar(A), {1|0})`, or any of the preceding
+    with different element type and/or shape depending on `opts...`. Where strictly
+    necessary, consider `fill!(similar(A[, opts...]), {one(eltype(A)) | zero(eltype(A))})`.
+    For an algebraic multiplicative identity, consider `one(A)` ([#24656]).
 
   * The `Operators` module is deprecated. Instead, import required operators explicitly
     from `Base`, e.g. `import Base: +, -, *, /` ([#22251]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -616,11 +616,12 @@ Deprecated or removed
     `Meta.lower(module, ex)` ([#22064, #24278]).
 
   * `ones(A::AbstractArray[, opts...])` and `zeros(A::AbstractArray[, opts...])` methods
-    have been deprecated. The general replacement is `fill!(similar(A[, opts...]), {1|0})`,
+    have been deprecated. The general replacement is
+    `fill!(similar(A[, opts...]), {one(eltype(A)) | zero(eltype(A))})`,
     though in most use cases simpler alternatives are better: For `zeros(A)`, consider
     `zero(A)`. For `ones(A)` or `zeros(A)`, consider `fill(v, size(A))` for `v` an
-    appropriate one or zero, `fill!(copy(A), {1|0})`, `ones(size(A))` or
-    `zeros(size(A))`, or any of the preceding with different element type
+    appropriate one or zero, `fill!(copy(A), {one(eltype(A)) | zero(eltype(A))})`,
+    `ones(size(A))` or `zeros(size(A))`, or any of the preceding with different element type
     and/or shape depending on `opts...`. For an algebraic multiplicative identity,
     consider `one(A)` ([#24656]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1757,10 +1757,30 @@ function spdiagm(x, d, m::Integer, n::Integer)
 end
 
 # deprecate zeros(D::Diagonal[, opts...])
-@deprecate zeros(D::Diagonal)                         Diagonal(fill!(similar(D.diag), 0))
-@deprecate zeros(D::Diagonal, ::Type{T}) where {T}    Diagonal(fill!(similar(D.diag, T), 0))
-@deprecate zeros(D::Diagonal, ::Type{T}, dims::Dims) where {T}          fill!(similar(D, T, dims), 0)
-@deprecate zeros(D::Diagonal, ::Type{T}, dims::Integer...) where {T}    fill!(similar(D, T, dims), 0)
+function zeros(D::Diagonal)
+    depwarn(string("`zeros(D::Diagonal)` is deprecated, use ",
+        "`Diagonal(fill!(similar(D.diag), 0))` instead, or ",
+        "`Diagonal(fill!(similar(D.diag), zero(eltype(D.diag))))` where necessary."), :zeros)
+    return Diagonal(fill!(similar(D.diag), zero(eltype(D.diag))))
+end
+function zeros(D::Diagonal, ::Type{T}) where {T}
+    depwarn(string("`zeros(D::Diagonal, ::Type{T}) where T` is deprecated, use ",
+        "`Diagonal(fill!(similar(D.diag, T), 0))` instead, or ",
+        "`Diagonal(fill!(similar(D.diag, T), zero(T)))` where necessary."), :zeros)
+    return Diagonal(fill!(similar(D.diag, T), zero(T)))
+end
+function zeros(D::Diagonal, ::Type{T}, dims::Dims) where {T}
+    depwarn(string("`zeros(D::Diagonal, ::Type{T}, dims::Dims) where T` is deprecated, ",
+        "use `fill!(similar(D, T, dims), 0)` instead, or ",
+        "`fill!(similar(D, T, dims), zero(T))` where necessary."), :zeros)
+    return fill!(similar(D, T, dims), zero(T))
+end
+function zeros(D::Diagonal, ::Type{T}, dims::Integer...) where {T}
+    depwarn(string("`zeros(D::Diagonal, ::Type{T}, dims::Integer...) where T` is deprecated, ",
+        "use `fill!(similar(D, T, dims), 0)` instead, or ",
+        "`fill!(similar(D, T, dims), zero(T))` where necessary."), :zeros)
+    return fill!(similar(D, T, dims), zero(T))
+end
 
 # PR #23690
 # `SSHCredential` and `UserPasswordCredential` constructors using `prompt_if_incorrect`

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1767,14 +1767,56 @@ end
 # are deprecated in base/libgit2/types.jl.
 
 # deprecate ones/zeros methods accepting an array as first argument
-@deprecate ones(a::AbstractArray, ::Type{T}, dims::Tuple) where {T} fill!(similar(a, T, dims), one(T))
-@deprecate ones(a::AbstractArray, ::Type{T}, dims...) where {T}     fill!(similar(a, T, dims...), one(T))
-@deprecate ones(a::AbstractArray, ::Type{T}) where {T}              fill!(similar(a, T), one(T))
-@deprecate ones(a::AbstractArray)                                   fill!(similar(a), one(eltype(a)))
-@deprecate zeros(a::AbstractArray, ::Type{T}, dims::Tuple) where {T}  fill!(similar(a, T, dims), zero(T))
-@deprecate zeros(a::AbstractArray, ::Type{T}, dims...) where {T}      fill!(similar(a, T, dims...), zero(T))
-@deprecate zeros(a::AbstractArray, ::Type{T}) where {T}               fill!(similar(a, T), zero(T))
-@deprecate zeros(a::AbstractArray)                                    fill!(similar(a), zero(eltype(a)))
+function ones(a::AbstractArray, ::Type{T}, dims::Tuple) where {T}
+    depwarn(string("`ones(a::AbstractArray, ::Type{T}, dims::Tuple) where T` is ",
+        "deprecated, use `fill!(similar(a, T, dims), 1)` instead, or ",
+        "`fill!(similar(a, T, dims), one(T))` where necessary."), :ones)
+    return fill!(similar(a, T, dims), one(T))
+end
+function ones(a::AbstractArray, ::Type{T}, dims...) where {T}
+    depwarn(string("`ones(a::AbstractArray, ::Type{T}, dims...) where T` is ",
+        "deprecated, use `fill!(similar(a, T, dims...), 1)` instead, or ",
+        "`fill!(similar(a, T, dims...), one(T))` where necessary."), :ones)
+    return fill!(similar(a, T, dims...), one(T))
+end
+function ones(a::AbstractArray, ::Type{T}) where {T}
+    depwarn(string("`ones(a::AbstractArray, ::Type{T}) where T` is deprecated, ",
+        "use `fill!(similar(a, T), 1)` instead, or `fill!(similar(a, T), one(T))` ",
+        "where necessary."), :ones)
+    return fill!(similar(a, T), one(T))
+end
+function ones(a::AbstractArray)
+    depwarn(string("`ones(a::AbstractArray)` is deprecated, consider ",
+        "`fill(1, size(a))`, `fill!(copy(a), 1)`, or `fill!(similar(a), 1)`. Where ",
+        "necessary, use `fill!(similar(a), one(eltype(a)))`."), :ones)
+    return fill!(similar(a), one(eltype(a)))
+end
+
+function zeros(a::AbstractArray, ::Type{T}, dims::Tuple) where {T}
+    depwarn(string("`zeros(a::AbstractArray, ::Type{T}, dims::Tuple) where T` is ",
+        "deprecated, use `fill!(similar(a, T, dims), 0)` instead, or ",
+        "`fill!(similar(a, T, dims), zero(T))` where necessary."), :zeros)
+    return fill!(similar(a, T, dims), zero(T))
+end
+function zeros(a::AbstractArray, ::Type{T}, dims...) where {T}
+    depwarn(string("`zeros(a::AbstractArray, ::Type{T}, dims...) where T` is ",
+        "deprecated, use `fill!(similar(a, T, dims...), 0)` instead, or ",
+        "`fill!(similar(a, T, dims...), zero(T))` where necessary."), :zeros)
+    return fill!(similar(a, T, dims...), zero(T))
+end
+function zeros(a::AbstractArray, ::Type{T}) where {T}
+    depwarn(string("`zeros(a::AbstractArray, ::Type{T}) where T` is deprecated, ",
+        "use `fill!(similar(a, T), 0)` instead, or `fill!(similar(a, T), zero(T))` ",
+        "where necessary."), :zeros)
+    return fill!(similar(a, T), zero(T))
+end
+function zeros(a::AbstractArray)
+    depwarn(string("`zeros(a::AbstractArray)` is deprecated, consider `zero(a)`, ",
+        "`fill(0, size(a))`, `fill!(copy(a), 0)`, or ",
+        "`fill!(similar(a), 0)`. Where necessary, use ",
+        "`fill!(similar(a), zero(eltype(a)))`."), :zeros)
+    return fill!(similar(a), zero(eltype(a)))
+end
 
 # PR #23711
 @eval LibGit2 begin

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1767,14 +1767,14 @@ end
 # are deprecated in base/libgit2/types.jl.
 
 # deprecate ones/zeros methods accepting an array as first argument
-@deprecate ones(a::AbstractArray, ::Type{T}, dims::Tuple) where {T} fill!(similar(a, T, dims), 1)
-@deprecate ones(a::AbstractArray, ::Type{T}, dims...) where {T}     fill!(similar(a, T, dims...), 1)
-@deprecate ones(a::AbstractArray, ::Type{T}) where {T}              fill!(similar(a, T), 1)
-@deprecate ones(a::AbstractArray)                                   fill!(similar(a), 1)
-@deprecate zeros(a::AbstractArray, ::Type{T}, dims::Tuple) where {T}  fill!(similar(a, T, dims), 0)
-@deprecate zeros(a::AbstractArray, ::Type{T}, dims...) where {T}      fill!(similar(a, T, dims...), 0)
-@deprecate zeros(a::AbstractArray, ::Type{T}) where {T}               fill!(similar(a, T), 0)
-@deprecate zeros(a::AbstractArray)                                    fill!(similar(a), 0)
+@deprecate ones(a::AbstractArray, ::Type{T}, dims::Tuple) where {T} fill!(similar(a, T, dims), one(T))
+@deprecate ones(a::AbstractArray, ::Type{T}, dims...) where {T}     fill!(similar(a, T, dims...), one(T))
+@deprecate ones(a::AbstractArray, ::Type{T}) where {T}              fill!(similar(a, T), one(T))
+@deprecate ones(a::AbstractArray)                                   fill!(similar(a), one(eltype(a)))
+@deprecate zeros(a::AbstractArray, ::Type{T}, dims::Tuple) where {T}  fill!(similar(a, T, dims), zero(T))
+@deprecate zeros(a::AbstractArray, ::Type{T}, dims...) where {T}      fill!(similar(a, T, dims...), zero(T))
+@deprecate zeros(a::AbstractArray, ::Type{T}) where {T}               fill!(similar(a, T), zero(T))
+@deprecate zeros(a::AbstractArray)                                    fill!(similar(a), zero(eltype(a)))
 
 # PR #23711
 @eval LibGit2 begin

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -465,7 +465,7 @@ function svd(D::Diagonal{<:Number})
     piv = sortperm(S, rev = true)
     U   = Diagonal(D.diag ./ S)
     Up  = hcat([U[:,i] for i = 1:length(D.diag)][piv]...)
-    V   = Diagonal(fill!(similar(D.diag), 1))
+    V   = Diagonal(fill!(similar(D.diag), one(eltype(D.diag))))
     Vp  = hcat([V[:,i] for i = 1:length(D.diag)][piv]...)
     return (Up, S[piv], Vp)
 end

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -270,9 +270,9 @@ function tril!(M::SymTridiagonal, k::Integer=0)
         return Tridiagonal(M.ev,M.dv,copy(M.ev))
     elseif k == -1
         fill!(M.dv,0)
-        return Tridiagonal(M.ev,M.dv,fill!(similar(M.ev), 0))
+        return Tridiagonal(M.ev,M.dv,zero(M.ev))
     elseif k == 0
-        return Tridiagonal(M.ev,M.dv,fill!(similar(M.ev), 0))
+        return Tridiagonal(M.ev,M.dv,zero(M.ev))
     elseif k >= 1
         return Tridiagonal(M.ev,M.dv,copy(M.ev))
     end
@@ -289,9 +289,9 @@ function triu!(M::SymTridiagonal, k::Integer=0)
         return Tridiagonal(M.ev,M.dv,copy(M.ev))
     elseif k == 1
         fill!(M.dv,0)
-        return Tridiagonal(fill!(similar(M.ev), 0),M.dv,M.ev)
+        return Tridiagonal(zero(M.ev),M.dv,M.ev)
     elseif k == 0
-        return Tridiagonal(fill!(similar(M.ev), 0),M.dv,M.ev)
+        return Tridiagonal(zero(M.ev),M.dv,M.ev)
     elseif k <= -1
         return Tridiagonal(M.ev,M.dv,copy(M.ev))
     end


### PR DESCRIPTION
In an effort to restore compatibility of Unitful.jl with the nightly build, I noticed some of the tests started failing following PR #24656. In that PR, literal numbers `0` and `1` were used instead of `zero(T)` and `oneunit(T)`, causing issues for dimensionful numbers. This PR substitutes in `zero(T)` and `oneunit(T)` and updates NEWS.md with revised guidance (although the guidance is even more verbose than before...)

Cross-ref https://github.com/JuliaLang/julia/pull/24656#discussion_r156203978