### PR TITLE
Set `JULIA_PKGDIR` before Julia ever starts up when building docs

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,6 +7,7 @@ SRCDIR           := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
 JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
+export JULIA_PKGDIR := $(call cygpath_w,$(abspath $(SRCDIR)/deps))
 
 .PHONY: help clean cleanall html pdf linkcheck doctest doctest-fix check deps deploy
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,7 +7,7 @@ SRCDIR           := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
 JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
-export JULIA_PKGDIR := $(call cygpath_w,$(abspath $(SRCDIR)/deps))
+export JULIA_PKGDIR := $(abspath $(SRCDIR)/deps)
 
 .PHONY: help clean cleanall html pdf linkcheck doctest doctest-fix check deps deploy
 

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -1,5 +1,3 @@
-# Install dependencies needed to build the documentation.
-ENV["JULIA_PKGDIR"] = joinpath(@__DIR__, "deps")
 using Pkg
 Pkg.init()
 cp(joinpath(@__DIR__, "REQUIRE"), Pkg.dir("REQUIRE"); force = true)


### PR DESCRIPTION
Attempting to set `ENV["JULIA_PKGDIR"]` from within Julia doesn't work,
as the `LOAD_CACHE_PATH` is initialized within an `__init__()` function
within `Pkg`, causing compile cache files to be saved to the default
location (within the user's `$HOME`) rather than the override location.
This change ensures that the docs pkg environment is properly confined.