### PR TITLE
fix :typeinfo with tuple elements (closes #25042)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -491,14 +491,18 @@ function show_delim_array(io::IO, itr, op, delim, cl, delim_one, i1=1, n=typemax
         recur_io = IOContext(io, :SHOWN_SET => itr)
         state = start(itr)
         first = true
+        i0 = i1-1
         while i1 > 1 && !done(itr, state)
             _, state = next(itr, state)
             i1 -= 1
         end
         if !done(itr, state)
+            typeinfo = get(io, :typeinfo, Any)
             while true
                 x, state = next(itr, state)
-                show(recur_io, x)
+                show(IOContext(recur_io, :typeinfo =>
+                               typeinfo <: Tuple ? typeinfo.parameters[i1+i0] : typeinfo),
+                     x)
                 i1 += 1
                 if done(itr, state) || i1 > n
                     delim_one && first && print(io, delim)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1035,6 +1035,9 @@ end
     @test showstr([[Float16(1)]]) == "Array{Float16,1}[[1.0]]"
     @test replstr(Real[Float16(1)]) == "1-element Array{Real,1}:\n Float16(1.0)"
     @test replstr(Array{Real}[Real[1]]) == "1-element Array{Array{Real,N} where N,1}:\n [1]"
+    # printing tuples (Issue #25042)
+    @test replstr(fill((Int64(1), zeros(Float16, 3)), 1)) ==
+                 "1-element Array{Tuple{Int64,Array{Float16,1}},1}:\n (1, [0.0, 0.0, 0.0])"
     @testset "nested Any eltype" begin
         x = Any[Any[Any[1]]]
         # The element of x (i.e. x[1]) has an eltype which can't be deduced


### PR DESCRIPTION
This example proves that it was nice to keep as `@assert` in the the `:typeinfo` code (in the `typeinfo_prefix` function), rather than ignoring unexpected inconsistencies, as this would have led to have:
```julia
julia> fill((1, zeros(Float16, 3)), 3)
3-element Array{Tuple{Int64,Array{Float16,1}},1}:
 (1, Float16[0.0, 0.0, 0.0])
 (1, Float16[0.0, 0.0, 0.0])
 (1, Float16[0.0, 0.0, 0.0])
```
whereas with this fix we get
```julia
julia> fill((1, zeros(Float16, 3)), 3)
3-element Array{Tuple{Int64,Array{Float16,1}},1}:
 (1, [0.0, 0.0, 0.0])
 (1, [0.0, 0.0, 0.0])
 (1, [0.0, 0.0, 0.0])
```
