### PR TITLE
faster rand!(::MersenneTwister, ::UnitRange)

### DIFF
--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -105,7 +105,7 @@ Sampler(rng::AbstractRNG, sp::Sampler, ::Repetition) =
 Sampler(rng::AbstractRNG, X) = Sampler(rng, X, Val(Inf))
 Sampler(rng::AbstractRNG, ::Type{X}) where {X} = Sampler(rng, X, Val(Inf))
 
-#### pre-defined useful Sampler subtypes
+#### pre-defined useful Sampler types
 
 # default fall-back for types
 struct SamplerType{T} <: Sampler end
@@ -136,6 +136,38 @@ struct SamplerTag{T,S} <: Sampler
     data::S
     SamplerTag{T}(s::S) where {T,S} = new{T,S}(s)
 end
+
+
+#### helper samplers
+
+##### Adapter to generate a randome value in [0, n]
+
+struct LessThan{T<:Integer,S} <: Sampler
+    sup::T
+    s::S    # the scalar specification/sampler to feed to rand
+end
+
+function rand(rng::AbstractRNG, sp::LessThan)
+    while true
+        x = rand(rng, sp.s)
+        x <= sp.sup && return x
+    end
+end
+
+struct Masked{T<:Integer,S} <: Sampler
+    mask::T
+    s::S
+end
+
+rand(rng::AbstractRNG, sp::Masked) = rand(rng, sp.s) & sp.mask
+
+##### Uniform
+
+struct UniformT{T} <: Sampler end
+
+uniform(::Type{T}) where {T} = UniformT{T}()
+
+rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 
 
 ### machinery for generation with Sampler

--- a/test/random.jl
+++ b/test/random.jl
@@ -102,12 +102,13 @@ if sizeof(Int32) < sizeof(Int)
     local r = rand(Int32(-1):typemax(Int32))
     @test typeof(r) == Int32
     @test -1 <= r <= typemax(Int32)
-    @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(UInt64,1:k)).u for k in 13 .+ Int64(2).^(32:62)])
-    @test all([div(0x00010000000000000000,k)*k - 1 == Base.Random.RangeGenerator(map(Int64,1:k)).u for k in 13 .+ Int64(2).^(32:61)])
+    for U = (Int64, UInt64)
+        @test all(div(one(UInt128) << 52, k)*k - 1 == SamplerRangeInt(map(U, 1:k)).u
+                  for k in 13 .+ Int64(2).^(32:51))
+        @test all(div(one(UInt128) << 64, k)*k - 1 == SamplerRangeInt(map(U, 1:k)).u
+                  for k in 13 .+ Int64(2).^(52:62))
+    end
 
-    @test Base.Random._maxmultiple(0x000100000000) === 0xffffffffffffffff
-    @test Base.Random._maxmultiple(0x0000FFFFFFFF) === 0x00000000fffffffe
-    @test Base.Random._maxmultiple(0x000000000000) === 0xffffffffffffffff
 end
 
 # BigInt specific
@@ -224,8 +225,11 @@ guardsrand() do
     @test r == rand(map(UInt64, 97:122))
 end
 
-@test all([div(0x000100000000,k)*k - 1 == Base.Random.RangeGenerator(map(UInt64,1:k)).u for k in 13 .+ Int64(2).^(1:30)])
-@test all([div(0x000100000000,k)*k - 1 == Base.Random.RangeGenerator(map(Int64,1:k)).u for k in 13 .+ Int64(2).^(1:30)])
+for U in (Int64, UInt64)
+    @test all(div(one(UInt64) << 52, k)*k - 1 == SamplerRangeInt(map(U, 1:k)).u
+              for k in 13 .+ Int64(2).^(1:30))
+end
+
 
 import Base.Random: uuid1, uuid4, UUID, uuid_version
 


### PR DESCRIPTION
Ses commits message for details. The main performance improvement is for `[U]Int128`, e.g. `a = zeros(Int128, 1000); rand!(a, Int128(1):Int128(10))` sees a 3x speed-up. 
I plan also to unify further the 2 samplers for ranges, they look now very similar, but this wouldn't need to change the streams, so can be done in a non-breaking way later. 