### PR TITLE
Support method deletion

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1084,6 +1084,21 @@ function isambiguous(m1::Method, m2::Method; ambiguous_bottom::Bool=false)
 end
 
 """
+    delete_method(m::Method)
+
+Make method `m` uncallable and force recompilation of any methods that use(d) it.
+"""
+function delete_method(m::Method)
+    ccall(:jl_method_table_disable, Void, (Any, Any), MethodTable(m), m)
+end
+
+function MethodTable(m::Method)
+    ft = ccall(:jl_first_argument_datatype, Any, (Any,), m.sig)
+    ft == C_NULL && error("Method ", m, " does not correspond to a function type")
+    (ft::DataType).name.mt
+end
+
+"""
     has_bottom_parameter(t) -> Bool
 
 Determine whether `t` is a Type for which one or more of its parameters is `Union{}`.

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4523,7 +4523,7 @@ static Function *jl_cfunction_object(jl_function_t *ff, jl_value_t *declrt, jl_t
     // check the cache
     jl_typemap_entry_t *sf = NULL;
     if (jl_cfunction_list.unknown != jl_nothing) {
-        sf = jl_typemap_assoc_by_type(jl_cfunction_list, (jl_tupletype_t*)cfunc_sig, NULL, /*subtype*/0, /*offs*/0, /*world*/1);
+        sf = jl_typemap_assoc_by_type(jl_cfunction_list, (jl_tupletype_t*)cfunc_sig, NULL, /*subtype*/0, /*offs*/0, /*world*/1, /*max_world_mask*/0);
         if (sf) {
             jl_value_t *v = sf->func.value;
             if (v) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -2585,18 +2585,31 @@ static void jl_update_backref_list(jl_value_t *old, jl_value_t *_new, size_t sta
 
 // repeatedly look up older methods until we come to one that existed
 // at the time this module was serialized
-static jl_method_t *jl_lookup_method_worldset(jl_methtable_t *mt, jl_datatype_t *sig, arraylist_t *dependent_worlds)
+static jl_method_t *jl_lookup_method_worldset(jl_methtable_t *mt, jl_datatype_t *sig, arraylist_t *dependent_worlds, size_t *max_world)
 {
     size_t world = jl_world_counter;
+    jl_typemap_entry_t *entry;
     jl_method_t *_new;
     while (1) {
-        _new = (jl_method_t*)jl_methtable_lookup(mt, sig, world);
-        if (!(_new && jl_is_method(_new)))
-            return NULL; // the method wasn't found, probably because it was disabled
+        entry = jl_typemap_assoc_by_type(
+            mt->defs, sig, NULL, /*subtype*/0, /*offs*/0, world, /*max_world_mask*/0);
+        if (!entry)
+            break;
+        _new = (jl_method_t*)entry->func.value;
         world = lowerbound_dependent_world_set(_new->min_world, dependent_worlds);
-        if (world == _new->min_world)
+        if (world == _new->min_world) {
+            *max_world = entry->max_world;
             return _new;
+        }
     }
+    // If we failed to find a method (perhaps due to method deletion),
+    // grab anything
+    entry = jl_typemap_assoc_by_type(
+        mt->defs, sig, NULL, /*subtype*/0, /*offs*/0, /*world*/jl_world_counter, /*max_world_mask*/(~(size_t)0) >> 1);
+    assert(entry);
+    assert(entry->max_world != ~(size_t)0);
+    *max_world = entry->max_world;
+    return (jl_method_t*)entry->func.value;
 }
 
 static jl_method_t *jl_recache_method(jl_method_t *m, size_t start, arraylist_t *dependent_worlds)
@@ -2604,10 +2617,9 @@ static jl_method_t *jl_recache_method(jl_method_t *m, size_t start, arraylist_t 
     jl_datatype_t *sig = (jl_datatype_t*)m->sig;
     jl_datatype_t *ftype = jl_first_argument_datatype((jl_value_t*)sig);
     jl_methtable_t *mt = ftype->name->mt;
+    size_t max_world = 0;
     jl_set_typeof(m, (void*)(intptr_t)0x30); // invalidate the old value to help catch errors
-    jl_method_t *_new = jl_lookup_method_worldset(mt, sig, dependent_worlds);
-    if (!_new)
-        return NULL;
+    jl_method_t *_new = jl_lookup_method_worldset(mt, sig, dependent_worlds, &max_world);
     jl_update_backref_list((jl_value_t*)m, (jl_value_t*)_new, start);
     return _new;
 }
@@ -2618,10 +2630,8 @@ static jl_method_instance_t *jl_recache_method_instance(jl_method_instance_t *li
     assert(jl_is_datatype(sig) || jl_is_unionall(sig));
     jl_datatype_t *ftype = jl_first_argument_datatype((jl_value_t*)sig);
     jl_methtable_t *mt = ftype->name->mt;
-    jl_method_t *m = jl_lookup_method_worldset(mt, sig, dependent_worlds);
-    if (!m)
-        return NULL;
-
+    size_t max_world = 0;
+    jl_method_t *m = jl_lookup_method_worldset(mt, sig, dependent_worlds, &max_world);
     jl_datatype_t *argtypes = (jl_datatype_t*)li->specTypes;
     jl_set_typeof(li, (void*)(intptr_t)0x40); // invalidate the old value to help catch errors
     jl_svec_t *env = jl_emptysvec;
@@ -2630,6 +2640,7 @@ static jl_method_instance_t *jl_recache_method_instance(jl_method_instance_t *li
     if (ti == jl_bottom_type)
         env = jl_emptysvec; // the intersection may fail now if the type system had made an incorrect subtype env in the past
     jl_method_instance_t *_new = jl_specializations_get_linfo(m, (jl_value_t*)argtypes, env, jl_world_counter);
+    _new->max_world = max_world;
     jl_update_backref_list((jl_value_t*)li, (jl_value_t*)_new, start);
     return _new;
 }
@@ -2653,12 +2664,10 @@ static void jl_recache_other(arraylist_t *dependent_worlds)
         else {
             abort();
         }
-        if (_new) {
-            if (loc)
-                *loc = _new;
-            if (offs > 0)
-                backref_list.items[offs] = _new;
-        }
+        if (loc)
+            *loc = _new;
+        if (offs > 0)
+            backref_list.items[offs] = _new;
     }
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -927,7 +927,7 @@ jl_typemap_entry_t *jl_typemap_insert(union jl_typemap_t *cache, jl_value_t *par
 
 jl_typemap_entry_t *jl_typemap_assoc_by_type(
         union jl_typemap_t ml_or_cache, jl_tupletype_t *types, jl_svec_t **penv,
-        int8_t subtype, int8_t offs, size_t world);
+        int8_t subtype, int8_t offs, size_t world, size_t max_world_mask);
 jl_typemap_entry_t *jl_typemap_level_assoc_exact(jl_typemap_level_t *cache, jl_value_t **args, size_t n, int8_t offs, size_t world);
 jl_typemap_entry_t *jl_typemap_entry_assoc_exact(jl_typemap_entry_t *mn, jl_value_t **args, size_t n, size_t world);
 STATIC_INLINE jl_typemap_entry_t *jl_typemap_assoc_exact(union jl_typemap_t ml_or_cache, jl_value_t **args, size_t n, int8_t offs, size_t world)


### PR DESCRIPTION
This is thanks to a fortuitously-timed trip to Boston and @vtjnash kindly spending a Sunday afternoon guiding me through this. I used it heavily today (with a local branch of Revise), and after I fixed one or two bugs I seemed to be running out of ways to break Julia :smile:.

Technically this doesn't delete the method, it simply sets `max_world` to be too small to run in the future. The most subtle part of this is that you have to recompute ambiguities, because if you delete an ambiguity-resolving method you might suddenly need to start throwing `MethodError`s as appropriate. A naive computation of the new ambiguities is `O(N^2)` in the number of methods; we found we could rebuild the entire method table for `convert` (>700 methods) in ~30ms, so even the naive approach would probably have been workable. Nevertheless, we decided to limit it to those that intersect with the signature that's being deleted, so it's `O(n^2)` where `n` is the number that intersect. For most cases this should be pretty cheap.
