### PR TITLE
Add mapreduce_single function

### DIFF
--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -391,3 +391,8 @@ test18695(r) = sum( t^2 for t in r )
 # test neutral element not picked incorrectly for &, |
 @test @inferred(foldl(&, Int[1])) === 1
 @test_throws ArgumentError foldl(&, Int[])
+
+# prod on Chars
+@test prod(Char[]) == ""
+@test prod(Char['a']) == "a"
+@test prod(Char['a','b']) == "ab"

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -339,9 +339,10 @@ for region in Any[-1, 0, (-1, 2), [0, 1], (1,-2,3), [0 1;
 end
 
 # check type of result
-under_test = [UInt8, Int8, Int32, Int64, BigInt]
-@testset "type of sum(::Array{$T}" for T in under_test
+@testset "type of sum(::Array{$T}" for T in [UInt8, Int8, Int32, Int64, BigInt]
     result = sum(T[1 2 3; 4 5 6; 7 8 9], 2)
     @test result == hcat([6, 15, 24])
-    @test eltype(result) === typeof(Base.promote_sys_size_add(zero(T)))
+    @test eltype(result) === (T <: Base.SmallSigned ? Int :
+                              T <: Base.SmallUnsigned ? UInt :
+                              T)
 end


### PR DESCRIPTION
Since the demise of `r_promote` in #22825, there is now a type-instability in `mapreduce` if the operator does not give an element of the same type as the input. This arose during my implementation of Kahan summation using a reduction operator, see: https://github.com/JuliaMath/KahanSummation.jl/pull/7

This adds a `mapreduce_single` function which defines what the result should be in these cases.