### PR TITLE
Add Array{T,N}(nothing/missing, dims) convenience constructors

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1313,7 +1313,41 @@ julia> Vector{Float64}(uninitialized, 3)
  6.90966e-310
 ```
 """
-Vector{T}(uninitialized, n)
+Vector{T}(::Uninitialized, n)
+
+"""
+    Vector{T}(nothing, m)
+
+Construct a [`Vector{T}`](@ref) of length `m`, initialized with
+[`nothing`](@ref) entries. Element type `T` must be able to hold
+these values, i.e. `Void <: T`.
+
+# Examples
+```jldoctest
+julia> Vector{Union{Void, String}}(nothing, 2)
+2-element Array{Union{Void, String},1}:
+ nothing
+ nothing
+```
+"""
+Vector{T}(::Void, n)
+
+"""
+    Vector{T}(missing, m)
+
+Construct a [`Vector{T}`](@ref) of length `m`, initialized with
+[`missing`](@ref) entries. Element type `T` must be able to hold
+these values, i.e. `Missing <: T`.
+
+# Examples
+```jldoctest
+julia> Vector{Union{Missing, String}}(missing, 2)
+2-element Array{Union{Missing, String},1}:
+ missing
+ missing
+```
+"""
+Vector{T}(::Missing, n)
 
 """
     Matrix{T}(uninitialized, m, n)
@@ -1328,7 +1362,41 @@ julia> Matrix{Float64}(uninitialized, 2, 3)
  6.93517e-310  6.93517e-310  1.29396e-320
 ```
 """
-Matrix{T}(uninitialized, m, n)
+Matrix{T}(::Uninitialized, m, n)
+
+"""
+    Matrix{T}(nothing, m, n)
+
+Construct a [`Matrix{T}`](@ref) of size `m`×`n`, initialized with
+[`nothing`](@ref) entries. Element type `T` must be able to hold
+these values, i.e. `Void <: T`.
+
+# Examples
+```jldoctest
+julia> Matrix{Union{Void, String}}(nothing, 2, 3)
+2×3 Array{Union{Void, String},2}:
+ nothing  nothing  nothing
+ nothing  nothing  nothing
+```
+"""
+Matrix{T}(::Void, m, n)
+
+"""
+    Matrix{T}(missing, m, n)
+
+Construct a [`Matrix{T}`](@ref) of size `m`×`n`, initialized with
+[`missing`](@ref) entries. Element type `T` must be able to hold
+these values, i.e. `Missing <: T`.
+
+# Examples
+```jldoctest
+julia> Matrix{Union{Missing, String}}(missing, 2, 3)
+2×3 Array{Union{Missing, String},2}:
+ missing  missing  missing
+ missing  missing  missing
+```
+"""
+Matrix{T}(::Missing, m, n)
 
 """
     Array{T}(uninitialized, dims)
@@ -1354,7 +1422,54 @@ julia> B = Array{Float64}(uninitialized, 2) # N determined by the input
  0.0
 ```
 """
-Array{T,N}(uninitialized, dims)
+Array{T,N}(::Uninitialized, dims)
+
+"""
+    Array{T}(nothing, dims)
+    Array{T,N}(nothing, dims)
+
+Construct an `N`-dimensional [`Array`](@ref) containing elements of type `T`,
+initialized with [`nothing`](@ref) entries. Element type `T` must be able
+to hold these values, i.e. `Void <: T`.
+
+# Examples
+```jldoctest
+julia> Array{Union{Void, String}}(nothing, 2)
+2-element Array{Union{Void, String},1}:
+ nothing
+ nothing
+
+julia> Array{Union{Void, Int}}(nothing, 2, 3)
+2×3 Array{Union{Void, Int64},2}:
+ nothing  nothing  nothing
+ nothing  nothing  nothing
+```
+"""
+Array{T,N}(::Void, dims)
+
+
+"""
+    Array{T}(missing, dims)
+    Array{T,N}(missing, dims)
+
+Construct an `N`-dimensional [`Array`](@ref) containing elements of type `T`,
+initialized with [`missing`](@ref) entries. Element type `T` must be able
+to hold these values, i.e. `Missing <: T`.
+
+# Examples
+```jldoctest
+julia> Array{Union{Missing, String}}(missing, 2)
+2-element Array{Union{Missing, String},1}:
+ missing
+ missing
+
+julia> Array{Union{Missing, Int}}(missing, 2, 3)
+2×3 Array{Union{Missing, Int64},2}:
+ missing  missing  missing
+ missing  missing  missing
+```
+"""
+Array{T,N}(::Missing, dims)
 
 """
     Uninitialized

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -146,6 +146,13 @@ Matrix(::Uninitialized, m::Integer, n::Integer) = Matrix{Any}(uninitialized, Int
 # empty vector constructor
 Vector() = Vector{Any}(uninitialized, 0)
 
+# Array constructors for nothing and missing
+# type and dimensionality specified
+Array{T,N}(::Void, d...) where {T,N} = fill!(Array{T,N}(uninitialized, d...), nothing)
+Array{T,N}(::Missing, d...) where {T,N} = fill!(Array{T,N}(uninitialized, d...), missing)
+# type but not dimensionality specified
+Array{T}(::Void, d...) where {T} = fill!(Array{T}(uninitialized, d...), nothing)
+Array{T}(::Missing, d...) where {T} = fill!(Array{T}(uninitialized, d...), missing)
 
 include("abstractdict.jl")
 

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -244,12 +244,12 @@ This kind of array uses an efficient memory storage equivalent to an `Array{T}`
 holding the actual values combined with an `Array{UInt8}` indicating the type
 of the entry (i.e. whether it is `Missing` or `T`).
 
-Uninitialized arrays allowing for missing values can be constructed with the
-standard syntax. By default, arrays with an [`isbits`](@ref) element type are
-filled with `missing` values
+Arrays allowing for missing values can be constructed with the standard syntax.
+Use `Array{Union{Missing, T}}(missing, dims)` to create arrays filled with
+missing values:
 ```jldoctest
-julia> Array{Union{Missing, Int}}(uninitialized, 2, 3)
-2×3 Array{Union{Missing, Int64},2}:
+julia> Array{Union{Missing, String}}(missing, 2, 3)
+2×3 Array{Union{Missing, String},2}:
  missing  missing  missing
  missing  missing  missing
 ```

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -7,15 +7,19 @@ Core.AbstractArray
 Base.AbstractVector
 Base.AbstractMatrix
 Core.Array
-Core.Array(::Any)
-Core.Array(::Any, ::Any)
+Core.Array(::Uninitialized, ::Any)
+Core.Array(::Void, ::Any)
+Core.Array(::Missing, ::Any)
 Core.Uninitialized
 Core.uninitialized
 Base.Vector
-Base.Vector(::Any)
-Base.Vector(::Any, ::Any)
+Base.Vector(::Uninitialized, ::Any)
+Base.Vector(::Void, ::Any)
+Base.Vector(::Missing, ::Any)
 Base.Matrix
-Base.Matrix(::Any, ::Any, ::Any)
+Base.Matrix(::Uninitialized, ::Any, ::Any)
+Base.Matrix(::Void, ::Any, ::Any)
+Base.Matrix(::Missing, ::Any, ::Any)
 Base.getindex(::Type, ::Any...)
 Base.zeros
 Base.ones

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2079,6 +2079,25 @@ end
     @test size(a) == size(b)
 end
 
+@testset "type constructor Array{T, N}(nothing, d...) works (especially for N>3)" for T in (Int, String),
+                                                                                      U in (Void, Missing)
+    a = Array{Union{T, U}}(U(), 10)
+    b = Vector{Union{T, U}}(U(), 10)
+    @test size(a) == size(b) == (10,)
+    @test all(x -> x isa U, a)
+    @test all(x -> x isa U, b)
+    a = Array{Union{T, U}}(U(), 2,3)
+    b = Matrix{Union{T, U}}(U(), 2,3)
+    @test size(a) ==  size(b) == (2,3)
+    @test all(x -> x isa U, a)
+    @test all(x -> x isa U, b)
+    a = Array{Union{T, U}}(U(), 9,8,7,6,5,4,3,2,1)
+    b = Array{Union{T, U},9}(U(), 9,8,7,6,5,4,3,2,1)
+    @test size(a) ==  size(b) == (9,8,7,6,5,4,3,2,1)
+    @test all(x -> x isa U, a)
+    @test all(x -> x isa U, b)
+end
+
 @testset "accumulate, accumulate!" begin
     @test accumulate(+, [1,2,3]) == [1, 3, 6]
     @test accumulate(min, [1 2; 3 4], 1) == [1 2; 1 2]


### PR DESCRIPTION
These are shorthands for `fill!(Array{T,N}(uninitialized, dims), nothing/missing)`. In the future they could be optimized for `isbits` `Union` types in which nothing/missing is the first type of the `Union`, since such arrays are already filled with `nothing`/`missing`.

This implements solution 3. from https://github.com/JuliaLang/julia/issues/24939, which got broad support.

I haven't found a way to attach the new docstrings to the new methods rather than to the general docstring for the function/type, given that methods are generated using `@eval` with a loop. Anyway the docstrings describe both the `nothing` and the `missing` method, so that sounds unavoidable to limit duplication.