### PR TITLE
MersenneTwister: more efficient integer generation with caching

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -7,25 +7,38 @@
 # they are also used elsewhere where Int128/UInt128 support is separated out,
 # such as in hashing2.jl
 
-const BitSigned64_types      = (Int8, Int16, Int32, Int64)
-const BitUnsigned64_types    = (UInt8, UInt16, UInt32, UInt64)
+const BitSigned32_types      = (Int8, Int16, Int32)
+const BitUnsigned32_types    = (UInt8, UInt16, UInt32)
+const BitInteger32_types     = (BitSigned32_types..., BitUnsigned32_types...)
+
+const BitSigned64_types      = (BitSigned32_types..., Int64)
+const BitUnsigned64_types    = (BitUnsigned32_types..., UInt64)
 const BitInteger64_types     = (BitSigned64_types..., BitUnsigned64_types...)
+
 const BitSigned_types        = (BitSigned64_types..., Int128)
 const BitUnsigned_types      = (BitUnsigned64_types..., UInt128)
 const BitInteger_types       = (BitSigned_types..., BitUnsigned_types...)
+
 const BitSignedSmall_types   = Int === Int64 ? ( Int8,  Int16,  Int32) : ( Int8,  Int16)
 const BitUnsignedSmall_types = Int === Int64 ? (UInt8, UInt16, UInt32) : (UInt8, UInt16)
 const BitIntegerSmall_types  = (BitSignedSmall_types..., BitUnsignedSmall_types...)
 
+const BitSigned32      = Union{BitSigned32_types...}
+const BitUnsigned32    = Union{BitUnsigned32_types...}
+const BitInteger32     = Union{BitInteger32_types...}
+
 const BitSigned64      = Union{BitSigned64_types...}
 const BitUnsigned64    = Union{BitUnsigned64_types...}
 const BitInteger64     = Union{BitInteger64_types...}
+
 const BitSigned        = Union{BitSigned_types...}
 const BitUnsigned      = Union{BitUnsigned_types...}
 const BitInteger       = Union{BitInteger_types...}
+
 const BitSignedSmall   = Union{BitSignedSmall_types...}
 const BitUnsignedSmall = Union{BitUnsignedSmall_types...}
 const BitIntegerSmall  = Union{BitIntegerSmall_types...}
+
 const BitSigned64T     = Union{Type{Int8}, Type{Int16}, Type{Int32}, Type{Int64}}
 const BitUnsigned64T   = Union{Type{UInt8}, Type{UInt16}, Type{UInt32}, Type{UInt64}}
 


### PR DESCRIPTION
This is the last "performance" PR I wanted in 1.0. It depends on the PR on which it is based off of for getting better performance. But the gains are less significative than when I first implemented it some 3 years ago. Hence RFC, to discuss the trade-off.
The idea is that, as `MersenneTwister` is natively efficient to randomize an array, we can store an array of integers as a `MersenneTwister` field and randomize it; each time a random integer is requested, we give one of the cached values. This is exactly like we do already for `Float64` values. So do we want `MersenneTwister` to be heavier by some kB for better performance? I don't see any drawback, but I'm not sure. I played a little bit with the size of the cache, the "best" one so far is 10kB, with speed-ups as follows on my machine (`Int==Int64`):
+ `Int8` -> +20%
+ `Int16` -> +15%
+ `Int32` -> +20%
+ `Int64` -> +60%
+ `Int128` -> +30%

This is WIP: MersenneTwister is untouched, the new algorithm is used when instanciating a helper RNG like `r = IntCached{625}(MersenneTwister()); rand(r, Int)`, where `625` is the size of the cache in terms of `UInt128` integers. It will be very fast to remove the WIP if we decide so.