### PR TITLE
Restore functionality to ^C

### DIFF
--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -2026,19 +2026,16 @@ AnyDict(
     "^W" => (s,o...)->edit_werase(s),
     # Meta D
     "\ed" => (s,o...)->edit_delete_next_word(s),
-    "^C" => function (s,o...)
-        if isempty(s)
-            try # raise the debugger if present
-                ccall(:jl_raise_debugger, Int, ())
-            end
-            cancel_beep(s)
-            refresh_line(s)
-            print(terminal(s), "^C\n\n")
-            transition(s, :reset)
-            refresh_line(s)
-        else
-            edit_clear(s)
+    "^C" => (s,o...)->begin
+        try # raise the debugger if present
+            ccall(:jl_raise_debugger, Int, ())
         end
+        cancel_beep(s)
+        move_input_end(s)
+        refresh_line(s)
+        print(terminal(s), "^C\n\n")
+        transition(s, :reset)
+        refresh_line(s)
     end,
     "^Z" => (s,o...)->(return :suspend),
     # Right Arrow

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -732,14 +732,12 @@ function mode_keymap(julia_prompt::Prompt)
         end
     end,
     "^C" => function (s,o...)
-        if isempty(s)
-            print(LineEdit.terminal(s), "^C\n\n")
-            transition(s, julia_prompt)
-            transition(s, :reset)
-            LineEdit.refresh_line(s)
-        else
-            LineEdit.edit_clear(s)
-        end
+        LineEdit.move_input_end(s)
+        LineEdit.refresh_line(s)
+        print(LineEdit.terminal(s), "^C\n\n")
+        transition(s, julia_prompt)
+        transition(s, :reset)
+        LineEdit.refresh_line(s)
     end)
 end
 


### PR DESCRIPTION
Restores the functionality that pressing ^C keeps the buffer in the terminal, as well as not requiring you to press ^C twice to go back to the default prompt from a custom prompt.

Reverts "REPL: change ^C to "Clear" input area if not already empty"