### PR TITLE
More doctests and wording fixes for IO stuff

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -33,10 +33,24 @@ buffer_writes(x::IO, bufsize=SZ_UNBUFFERED_IO) = x
 """
     isopen(object) -> Bool
 
-Determine whether an object - such as a stream, timer, or mmap -- is not yet closed. Once an
-object is closed, it will never produce a new event. However, a closed stream may still have
-data to read in its buffer, use [`eof`](@ref) to check for the ability to read data.
+Determine whether an object - such as a stream, timer, or [`mmap`](@ref Mmap.mmap)
+-- is not yet closed. Once an object is closed, it will never produce a new event.
+However, since a closed stream may still have data to read in its buffer,
+use [`eof`](@ref) to check for the ability to read data.
 Use the `FileWatching` package to be notified when a stream might be writable or readable.
+
+# Examples
+```jldoctest
+julia> io = open("my_file.txt", "w+");
+
+julia> isopen(io)
+true
+
+julia> close(io)
+
+julia> isopen(io)
+false
+```
 """
 function isopen end
 

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -172,7 +172,29 @@ end
 """
     showerror(io, e)
 
-Show a descriptive representation of an exception object.
+Show a descriptive representation of an exception object `e`.
+This method is used to display the exception after a call to [`throw`](@ref).
+
+# Examples
+```jldoctest
+julia> struct MyException <: Exception
+           msg::AbstractString
+       end
+
+julia> function Base.showerror(io::IO, err::MyException)
+           print(io, "MyException: ")
+           print(io, err.msg)
+       end
+
+julia> err = MyException("test exception")
+MyException("test exception")
+
+julia> sprint(showerror, err)
+"MyException: test exception"
+
+julia> throw(MyException("test exception"))
+ERROR: MyException: test exception
+```
 """
 showerror(io::IO, ex) = show(io, ex)
 


### PR DESCRIPTION
Just did a super simple example of extending `showerror`. I can add more if people want.