### PR TITLE
Add `only` function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -436,6 +436,9 @@ Library improvements
     defined, linear-algebra function `transpose`. Similarly,
     `permutedims(v::AbstractVector)` will create a row matrix ([#24839]).
 
+  * New function `only(x)` returns the one-and-only element of a collection `x`, and throws
+    an error if `x` contains zero or multiple elements.
+
 Compiler/Runtime improvements
 -----------------------------
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -813,6 +813,7 @@ export
 
     enumerate,  # re-exported from Iterators
     zip,
+    only,
 
 # object identity and equality
     copy,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -193,7 +193,7 @@ end
 include("dict.jl")
 include("set.jl")
 include("iterators.jl")
-using .Iterators: zip, enumerate
+using .Iterators: zip, enumerate, only
 using .Iterators: Flatten, product  # for generators
 
 # Definition of StridedArray

--- a/doc/src/stdlib/iterators.md
+++ b/doc/src/stdlib/iterators.md
@@ -14,4 +14,5 @@ Base.Iterators.flatten
 Base.Iterators.partition
 Base.Iterators.filter
 Base.Iterators.reverse
+Base.Iterators.only
 ```

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -447,3 +447,25 @@ end
         @test Iterators.reverse(Iterators.reverse(t)) === t
     end
 end
+
+@testset "only" begin
+    @test only([3]) === 3
+    @test_throws ErrorException only([])
+    @test_throws ErrorException only([3, 2])
+
+    @test @inferred(only((3,))) === 3
+    @test_throws ErrorException only(())
+    @test_throws ErrorException only((3, 2))
+
+    @test only(Dict(1=>3)) === (1=>3)
+    @test_throws ErrorException only(Dict{Int,Int}())
+    @test_throws ErrorException only(Dict(1=>3, 2=>2))
+
+    @test only(Set([3])) === 3
+    @test_throws ErrorException only(Set(Int[]))
+    @test_throws ErrorException only(Set([3,2]))
+
+    @test @inferred(only((;a=1))) === 1
+    @test_throws ErrorException only(NamedTuple())
+    @test_throws ErrorException only((a=3, b=2.0))
+end


### PR DESCRIPTION
The function `only(x)` returns the one-and-only element of a collection `x`, or else throws an error.

I discovered this little gem in LINQ (under the `IEnumerable` method `x.Single()`), and instantly fell in love. In particular, it's quite useful when you have e.g. filtered down some data and expect only one element, but it feels dirty to call `x[1]` or `first(x)` without at least checking that it has one (and only one) element. This little function lets you grab the element and make the assertion that it is the *only* element, all in a few characters.

(Note: this is currently a part of my *SplitApplyCombine.jl* experiment, which has strategies to deal with nested containers, but to me seems a much better fit for `Base` / `Base.Iterators`, which deals with... iteration...)