### PR TITLE
Stop exporting isassigned() and normalize() from Unicode

### DIFF
--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -9,7 +9,7 @@ using Base.Unicode: normalize, graphemes, isassigned, textwidth, isvalid,
                     iscntrl, ispunct, isspace, isprint, isgraph,
                     lowercase, uppercase, titlecase, lcfirst, ucfirst
 
-export normalize, graphemes, isassigned, textwidth, isvalid,
+export graphemes, textwidth, isvalid,
        islower, isupper, isalpha, isdigit, isxdigit, isnumeric, isalnum,
        iscntrl, ispunct, isspace, isprint, isgraph,
        lowercase, uppercase, titlecase, lcfirst, ucfirst


### PR DESCRIPTION
Since these conflict with functions from Base, they cannot be called without the module name anyway, and they make it impossible to call the functions from Base once `using Unicode` has been called.

See https://github.com/JuliaLang/julia/pull/25021#issuecomment-351678924.