### PR TITLE
make checkbounds(string, ...) return nothing or error

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -174,11 +174,11 @@ checkbounds(::Type{Bool}, s::AbstractString, i::Integer) =
 checkbounds(::Type{Bool}, s::AbstractString, r::AbstractRange{<:Integer}) =
     isempty(r) || (1 ≤ minimum(r) && maximum(r) ≤ ncodeunits(s))
 checkbounds(::Type{Bool}, s::AbstractString, I::AbstractArray{<:Real}) =
-    all(i -> checkbounds(s, i), I)
+    all(i -> checkbounds(Bool, s, i), I)
 checkbounds(::Type{Bool}, s::AbstractString, I::AbstractArray{<:Integer}) =
-    all(i -> checkbounds(s, i), I)
+    all(i -> checkbounds(Bool, s, i), I)
 checkbounds(s::AbstractString, I::Union{Integer,AbstractArray}) =
-    checkbounds(Bool, s, I) || throw(BoundsError(s, I))
+    checkbounds(Bool, s, I) ? nothing : throw(BoundsError(s, I))
 
 ## construction, conversion, promotion ##
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -113,9 +113,22 @@ end
     @test_throws BoundsError checkbounds("hello", 4:6)
     @test_throws BoundsError checkbounds("hello", [0:3;])
     @test_throws BoundsError checkbounds("hello", [4:6;])
-    @test checkbounds("hello", 2)
-    @test checkbounds("hello", 1:5)
-    @test checkbounds("hello", [1:5;])
+    @test checkbounds("hello", 1) === nothing
+    @test checkbounds("hello", 5) === nothing
+    @test checkbounds("hello", 1:3) === nothing
+    @test checkbounds("hello", 3:5) === nothing
+    @test checkbounds("hello", [1:3;]) === nothing
+    @test checkbounds("hello", [3:5;]) === nothing
+    @test checkbounds(Bool, "hello", 0) === false
+    @test checkbounds(Bool, "hello", 1) === true
+    @test checkbounds(Bool, "hello", 5) === true
+    @test checkbounds(Bool, "hello", 6) === false
+    @test checkbounds(Bool, "hello", 0:5) === false
+    @test checkbounds(Bool, "hello", 1:6) === false
+    @test checkbounds(Bool, "hello", 1:5) === true
+    @test checkbounds(Bool, "hello", [0:5;]) === false
+    @test checkbounds(Bool, "hello", [1:6;]) === false
+    @test checkbounds(Bool, "hello", [1:5;]) === true
 end
 
 @testset "issue #15624 (indexing with out of bounds empty range)" begin


### PR DESCRIPTION
fix #24840 all the way, already mostly fixed by #24999