### PR TITLE
Replace all use of 'indexes' with 'indices'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -780,6 +780,10 @@ Deprecated or removed
   * The aliases `Complex32`, `Complex64` and `Complex128` have been deprecated in favor of `ComplexF16`,
     `ComplexF32` and `ComplexF64` respectively ([#24647]).
 
+  * `Base.parentindexes` and `SharedArrays.localindexes` have been renamed to `parentindices`
+    and `localindices`, respectively. Similarly, the `indexes` field in the `SubArray` type
+    has been renamed to `indices` without deprecation ([#25088]).
+
   * `Associative` has been deprecated in favor of `AbstractDict` ([#25012]).
 
   * `Nullable{T}` has been deprecated and moved to the Nullables package ([#23642]).
@@ -1766,3 +1770,4 @@ Command-line option changes
 [#24714]: https://github.com/JuliaLang/julia/issues/24714
 [#24869]: https://github.com/JuliaLang/julia/issues/24869
 [#25021]: https://github.com/JuliaLang/julia/issues/25021
+[#25088]: https://github.com/JuliaLang/julia/issues/25088

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1876,22 +1876,22 @@ function mapslices(f, A::AbstractArray, dims::AbstractVector)
     R[ridx...] = r1
 
     nidx = length(otherdims)
-    indexes = Iterators.drop(CartesianRange(itershape), 1)
-    inner_mapslices!(safe_for_reuse, indexes, nidx, idx, otherdims, ridx, Aslice, A, f, R)
+    indices = Iterators.drop(CartesianRange(itershape), 1)
+    inner_mapslices!(safe_for_reuse, indices, nidx, idx, otherdims, ridx, Aslice, A, f, R)
 end
 
-@noinline function inner_mapslices!(safe_for_reuse, indexes, nidx, idx, otherdims, ridx, Aslice, A, f, R)
+@noinline function inner_mapslices!(safe_for_reuse, indices, nidx, idx, otherdims, ridx, Aslice, A, f, R)
     if safe_for_reuse
         # when f returns an array, R[ridx...] = f(Aslice) line copies elements,
         # so we can reuse Aslice
-        for I in indexes # skip the first element, we already handled it
+        for I in indices # skip the first element, we already handled it
             replace_tuples!(nidx, idx, ridx, otherdims, I)
             _unsafe_getindex!(Aslice, A, idx...)
             R[ridx...] = f(Aslice)
         end
     else
         # we can't guarantee safety (#18524), so allocate new storage for each slice
-        for I in indexes
+        for I in indices
             replace_tuples!(nidx, idx, ridx, otherdims, I)
             R[ridx...] = f(A[idx...])
         end

--- a/base/array.jl
+++ b/base/array.jl
@@ -1683,7 +1683,7 @@ findlast(testf::Function, A) = findprev(testf, A, endof(A))
 """
     find(f::Function, A)
 
-Return a vector `I` of the linear indexes of `A` where `f(A[I])` returns `true`.
+Return a vector `I` of the linear indices of `A` where `f(A[I])` returns `true`.
 If there are no such elements of `A`, return an empty array.
 
 # Examples
@@ -1710,7 +1710,7 @@ julia> find(isodd, [2, 4])
 ```
 """
 function find(testf::Function, A)
-    # use a dynamic-length array to store the indexes, then copy to a non-padded
+    # use a dynamic-length array to store the indices, then copy to a non-padded
     # array for the return
     tmpI = Vector{Int}()
     inds = _index_remapper(A)
@@ -1775,7 +1775,7 @@ findn(A::AbstractVector) = find(A)
 """
     findn(A)
 
-Return a vector of indexes for each dimension giving the locations of the non-zeros in `A`
+Return a vector of indices for each dimension giving the locations of the non-zeros in `A`
 (determined by `A[i]!=0`).
 If there are no non-zero elements of `A`, return a 2-tuple of empty arrays.
 
@@ -1817,7 +1817,7 @@ end
 """
     findnz(A)
 
-Return a tuple `(I, J, V)` where `I` and `J` are the row and column indexes of the non-zero
+Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the non-zero
 values in matrix `A`, and `V` is a vector of the non-zero values.
 
 # Examples

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -313,7 +313,7 @@ function start(itr::AsyncCollector)
     itr.batch_size = verify_batch_size(itr.batch_size)
     if itr.batch_size !== nothing
         exec_func = batch -> begin
-            # extract indexes from the input tuple
+            # extract indices from the input tuple
             batch_idxs = map(x->x[1], batch)
 
             # and the args tuple....

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1263,7 +1263,7 @@ end
 
 function reverse!(B::BitVector)
     # Basic idea: each chunk is divided into two blocks of size k = n % 64, and
-    # h = 64 - k. Walk from either end (with indexes i and j) reversing chunks
+    # h = 64 - k. Walk from either end (with indices i and j) reversing chunks
     # and separately ORing their two blocks into place.
     #
     #           chunk 3                  chunk 2                  chunk 1

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -225,7 +225,7 @@ function convert(::Type{UpperTriangular}, A::Bidiagonal)
 end
 
 # Deprecate three-arg SubArray since the constructor doesn't need the dims tuple
-@deprecate SubArray(parent::AbstractArray, indexes::Tuple, dims::Tuple) SubArray(parent, indexes)
+@deprecate SubArray(parent::AbstractArray, indices::Tuple, dims::Tuple) SubArray(parent, indices)
 
 # Deprecate vectorized unary functions over sparse matrices in favor of compact broadcast syntax (#17265).
 for f in (:sind, :asind, :tand, :atand, :sinpi, :cosc, :ceil, :floor, :trunc,
@@ -3253,6 +3253,9 @@ end
 # PR #25057
 @deprecate indices(a) axes(a)
 @deprecate indices(a, d) axes(a, d)
+
+# Issue #12902
+@deprecate parentindexes parentindices
 
 @deprecate_moved Nullable "Nullables"
 @deprecate_moved NullException "Nullables"

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -96,7 +96,7 @@ mutable struct Dict{K,V} <: AbstractDict{K,V}
     ndel::Int
     count::Int
     age::UInt
-    idxfloor::Int  # an index <= the indexes of all used slots
+    idxfloor::Int  # an index <= the indices of all used slots
     maxprobe::Int
 
     function Dict{K,V}() where V where K

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -477,7 +477,7 @@ export
     nonzeros,
     ones,
     parent,
-    parentindexes,
+    parentindices,
     partialsort,
     partialsort!,
     partialsortperm,

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -752,7 +752,7 @@ bitstring(x::Union{Int128,UInt128})            = bin(reinterpret(UInt128,x),128)
 
 Return an array with element type `T` (default `Int`) of the digits of `n` in the given
 base, optionally padded with zeros to a specified size. More significant digits are at
-higher indexes, such that `n == sum([digits[k]*base^(k-1) for k=1:length(digits)])`.
+higher indices, such that `n == sum([digits[k]*base^(k-1) for k=1:length(digits)])`.
 
 # Examples
 ```jldoctest
@@ -796,7 +796,7 @@ hastypemax(::Type{T}) where {T} = applicable(typemax, T)
     digits!(array, n::Integer, base::Integer=10)
 
 Fills an array of the digits of `n` in the given base. More significant digits are at higher
-indexes. If the array length is insufficient, the least significant digits are filled up to
+indices. If the array length is insufficient, the least significant digits are filled up to
 the array length. If the array length is excessive, the excess portion is filled with zeros.
 
 # Examples

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -427,7 +427,7 @@ index_lengths() = ()
 @inline index_lengths(A::AbstractArray, rest...) = (length(A), index_lengths(rest...)...)
 @inline index_lengths(A::Slice, rest...) = (length(indices1(A)), index_lengths(rest...)...)
 
-# shape of array to create for getindex() with indexes I, dropping scalars
+# shape of array to create for getindex() with indices I, dropping scalars
 # returns a Tuple{Vararg{AbstractUnitRange}} of indices
 index_shape() = ()
 @inline index_shape(::Real, rest...) = index_shape(rest...)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -177,7 +177,7 @@ size(A::ReshapedArray) = A.dims
 similar(A::ReshapedArray, eltype::Type, dims::Dims) = similar(parent(A), eltype, dims)
 IndexStyle(::Type{<:ReshapedArrayLF}) = IndexLinear()
 parent(A::ReshapedArray) = A.parent
-parentindexes(A::ReshapedArray) = map(s->1:s, size(parent(A)))
+parentindices(A::ReshapedArray) = map(s->1:s, size(parent(A)))
 reinterpret(::Type{T}, A::ReshapedArray, dims::Dims) where {T} = reinterpret(T, parent(A), dims)
 
 @inline ind2sub_rs(::Tuple{}, i::Int) = i
@@ -193,9 +193,9 @@ end
     @inbounds ret = parent(A)[index]
     ret
 end
-@inline function getindex(A::ReshapedArray{T,N}, indexes::Vararg{Int,N}) where {T,N}
-    @boundscheck checkbounds(A, indexes...)
-    _unsafe_getindex(A, indexes...)
+@inline function getindex(A::ReshapedArray{T,N}, indices::Vararg{Int,N}) where {T,N}
+    @boundscheck checkbounds(A, indices...)
+    _unsafe_getindex(A, indices...)
 end
 @inline function getindex(A::ReshapedArray, index::ReshapedIndex)
     @boundscheck checkbounds(parent(A), index.parentindex)
@@ -203,8 +203,8 @@ end
     ret
 end
 
-@inline function _unsafe_getindex(A::ReshapedArray{T,N}, indexes::Vararg{Int,N}) where {T,N}
-    i = sub2ind(size(A), indexes...)
+@inline function _unsafe_getindex(A::ReshapedArray{T,N}, indices::Vararg{Int,N}) where {T,N}
+    i = sub2ind(size(A), indices...)
     I = ind2sub_rs(A.mi, i)
     _unsafe_getindex_rs(parent(A), I)
 end
@@ -216,9 +216,9 @@ _unsafe_getindex_rs(A, i::Integer) = (@inbounds ret = A[i]; ret)
     @inbounds parent(A)[index] = val
     val
 end
-@inline function setindex!(A::ReshapedArray{T,N}, val, indexes::Vararg{Int,N}) where {T,N}
-    @boundscheck checkbounds(A, indexes...)
-    _unsafe_setindex!(A, val, indexes...)
+@inline function setindex!(A::ReshapedArray{T,N}, val, indices::Vararg{Int,N}) where {T,N}
+    @boundscheck checkbounds(A, indices...)
+    _unsafe_setindex!(A, val, indices...)
 end
 @inline function setindex!(A::ReshapedArray, val, index::ReshapedIndex)
     @boundscheck checkbounds(parent(A), index.parentindex)
@@ -226,15 +226,15 @@ end
     val
 end
 
-@inline function _unsafe_setindex!(A::ReshapedArray{T,N}, val, indexes::Vararg{Int,N}) where {T,N}
-    @inbounds parent(A)[ind2sub_rs(A.mi, sub2ind(size(A), indexes...))...] = val
+@inline function _unsafe_setindex!(A::ReshapedArray{T,N}, val, indices::Vararg{Int,N}) where {T,N}
+    @inbounds parent(A)[ind2sub_rs(A.mi, sub2ind(size(A), indices...))...] = val
     val
 end
 
 # helpful error message for a common failure case
 const ReshapedRange{T,N,A<:AbstractRange} = ReshapedArray{T,N,A,Tuple{}}
 setindex!(A::ReshapedRange, val, index::Int) = _rs_setindex!_err()
-setindex!(A::ReshapedRange{T,N}, val, indexes::Vararg{Int,N}) where {T,N} = _rs_setindex!_err()
+setindex!(A::ReshapedRange{T,N}, val, indices::Vararg{Int,N}) where {T,N} = _rs_setindex!_err()
 setindex!(A::ReshapedRange, val, index::ReshapedIndex) = _rs_setindex!_err()
 
 @noinline _rs_setindex!_err() = error("indexed assignment fails for a reshaped range; consider calling collect")

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -274,16 +274,16 @@ end
 function trimmedsubarray(V::SubArray{T,N,A}) where {T,N,A<:Array}
     dest = Array{eltype(V)}(uninitialized, trimmedsize(V))
     copy!(dest, V)
-    _trimmedsubarray(dest, V, (), V.indexes...)
+    _trimmedsubarray(dest, V, (), V.indices...)
 end
 
-trimmedsize(V) = index_lengths(V.indexes...)
+trimmedsize(V) = index_lengths(V.indices...)
 
-function _trimmedsubarray(A, V::SubArray{T,N,P,I,LD}, newindexes) where {T,N,P,I,LD}
-    LD && return SubArray{T,N,P,I,LD}(A, newindexes, Base.compute_offset1(A, 1, newindexes), 1)
-    SubArray{T,N,P,I,LD}(A, newindexes, 0, 0)
+function _trimmedsubarray(A, V::SubArray{T,N,P,I,LD}, newindices) where {T,N,P,I,LD}
+    LD && return SubArray{T,N,P,I,LD}(A, newindices, Base.compute_offset1(A, 1, newindices), 1)
+    SubArray{T,N,P,I,LD}(A, newindices, 0, 0)
 end
-_trimmedsubarray(A, V, newindexes, index::ViewIndex, indexes...) = _trimmedsubarray(A, V, (newindexes..., trimmedindex(V.parent, length(newindexes)+1, index)), indexes...)
+_trimmedsubarray(A, V, newindices, index::ViewIndex, indices...) = _trimmedsubarray(A, V, (newindices..., trimmedindex(V.parent, length(newindices)+1, index)), indices...)
 
 trimmedindex(P, d, i::Real) = oftype(i, 1)
 trimmedindex(P, d, i::Colon) = i

--- a/base/show.jl
+++ b/base/show.jl
@@ -1700,7 +1700,7 @@ because of a definition similar to
     function Base.showarg(io::IO, v::SubArray, toplevel)
         print(io, "view(")
         showarg(io, parent(v), false)
-        print(io, ", ", join(v.indexes, ", "))
+        print(io, ", ", join(v.indices, ", "))
         print(io, ')')
         toplevel && print(io, " with eltype ", eltype(v))
     end
@@ -1728,7 +1728,7 @@ end
 function showarg(io::IO, v::SubArray, toplevel)
     print(io, "view(")
     showarg(io, parent(v), false)
-    showindices(io, v.indexes...)
+    showindices(io, v.indices...)
     print(io, ')')
     toplevel && print(io, " with eltype ", eltype(v))
 end

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -45,7 +45,7 @@ count(f, x::SparseVector) = count(f, x.nzval) + f(zero(eltype(x)))*(length(x) - 
 
 nonzeros(x::SparseVector) = x.nzval
 function nonzeros(x::SparseColumnView)
-    rowidx, colidx = parentindexes(x)
+    rowidx, colidx = parentindices(x)
     A = parent(x)
     @inbounds y = view(A.nzval, nzrange(A, colidx))
     return y
@@ -53,7 +53,7 @@ end
 
 nonzeroinds(x::SparseVector) = x.nzind
 function nonzeroinds(x::SparseColumnView)
-    rowidx, colidx = parentindexes(x)
+    rowidx, colidx = parentindices(x)
     A = parent(x)
     @inbounds y = view(A.rowval, nzrange(A, colidx))
     return y
@@ -105,7 +105,7 @@ LinAlg.fillstored!(x::SparseVector, y) = (fill!(x.nzval, y); x)
 ### Construction from lists of indices and values
 
 function _sparsevector!(I::Vector{<:Integer}, V::Vector, len::Integer)
-    # pre-condition: no duplicate indexes in I
+    # pre-condition: no duplicate indices in I
     if !isempty(I)
         p = sortperm(I)
         permute!(I, p)

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -75,7 +75,7 @@ Search for the first occurrence of the given characters within the given string.
 argument may be a single character, a vector or a set of characters, a string, or a regular
 expression (though regular expressions are only allowed on contiguous strings, such as ASCII
 or UTF-8 strings). The third argument optionally specifies a starting index. The return
-value is a range of indexes where the matching sequence is found, such that `s[search(s,x)] == x`:
+value is a range of indices where the matching sequence is found, such that `s[search(s,x)] == x`:
 
 `search(string, "substring")` = `start:end` such that `string[start:end] == "substring"`, or
 `0:-1` if unmatched.

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -528,7 +528,7 @@ end
 
 function sum(r::StepRangeLen)
     l = length(r)
-    # Compute the contribution of step over all indexes.
+    # Compute the contribution of step over all indices.
     # Indexes on opposite side of r.offset contribute with opposite sign,
     #    r.step * (sum(1:np) - sum(1:nn))
     np, nn = l - r.offset, r.offset - 1  # positive, negative

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -6,7 +6,7 @@ documents some of the design principles and implementation of `SubArray`s.
 ## Indexing: cartesian vs. linear indexing
 
 Broadly speaking, there are two main ways to access data in an array. The first, often called
-cartesian indexing, uses `N` indexes for an `N` -dimensional `AbstractArray`.  For example, a
+cartesian indexing, uses `N` indices for an `N` -dimensional `AbstractArray`.  For example, a
 matrix `A` (2-dimensional) can be indexed in cartesian style as `A[i,j]`.  The second indexing
 method, referred to as linear indexing, uses a single index even for higher-dimensional objects.
  For example, if `A = reshape(1:12, 3, 4)`, then the expression `A[5]` returns the value 5.  Julia
@@ -20,7 +20,7 @@ entry relative to the beginning of the array.  However, this is not true for man
 types: examples include [`SparseMatrixCSC`](@ref), arrays that require some kind of
 computation (such as interpolation), and the type under discussion here, `SubArray`.
 For these types, the underlying information is more naturally described in terms of
-cartesian indexes.
+cartesian indices.
 
 You can manually convert from a cartesian index to a linear index with `sub2ind`, and vice versa
 using `ind2sub`.  `getindex` and `setindex!` functions for `AbstractArray` types may include similar
@@ -74,7 +74,7 @@ The strategy adopted is first and foremost expressed in the definition of the ty
 ```julia
 struct SubArray{T,N,P,I,L} <: AbstractArray{T,N}
     parent::P
-    indexes::I
+    indices::I
     offset1::Int       # for linear indexing and pointer, only valid when L==true
     stride1::Int       # used only for linear indexing
     ...
@@ -93,7 +93,7 @@ Note in particular the tuple parameter, which stores the types of the indices us
 `S1`. Likewise,
 
 ```jldoctest subarray
-julia> S1.indexes
+julia> S1.indices
 (Base.Slice(Base.OneTo(2)), 1, 2:3)
 ```
 
@@ -108,23 +108,23 @@ of the parent array, whereas for `S2` one needs to apply them to the second and 
 approach to indexing would be to do the type-analysis at runtime:
 
 ```julia
-parentindexes = Vector{Any}()
-for thisindex in S.indexes
+parentindices = Vector{Any}()
+for thisindex in S.indices
     ...
     if isa(thisindex, Int)
-        # Don't consume one of the input indexes
-        push!(parentindexes, thisindex)
+        # Don't consume one of the input indices
+        push!(parentindices, thisindex)
     elseif isa(thisindex, AbstractVector)
         # Consume an input index
-        push!(parentindexes, thisindex[inputindex[j]])
+        push!(parentindices, thisindex[inputindex[j]])
         j += 1
     elseif isa(thisindex, AbstractMatrix)
         # Consume two input indices
-        push!(parentindexes, thisindex[inputindex[j], inputindex[j+1]])
+        push!(parentindices, thisindex[inputindex[j], inputindex[j+1]])
         j += 2
     elseif ...
 end
-S.parent[parentindexes...]
+S.parent[parentindices...]
 ```
 
 Unfortunately, this would be disastrous in terms of performance: each element access would allocate
@@ -136,7 +136,7 @@ number of input indices, and then it recurses on the remaining indices. In the c
 expands to
 
 ```julia
-Base.reindex(S1, S1.indexes, (i, j)) == (i, S1.indexes[2], S1.indexes[3][j])
+Base.reindex(S1, S1.indices, (i, j)) == (i, S1.indices[2], S1.indices[3][j])
 ```
 
 for any pair of indices `(i,j)` (except [`CartesianIndex`](@ref)s and arrays thereof, see below).
@@ -156,10 +156,10 @@ of the indices, and does not depend on values like the size of the parent array.
 a given set of indices supports fast linear indexing with the internal `Base.viewindexing` function:
 
 ```jldoctest subarray
-julia> Base.viewindexing(S1.indexes)
+julia> Base.viewindexing(S1.indices)
 IndexCartesian()
 
-julia> Base.viewindexing(S2.indexes)
+julia> Base.viewindexing(S2.indices)
 IndexLinear()
 ```
 
@@ -217,12 +217,12 @@ then `A[2:2:4,:]` does not have uniform stride, so we cannot guarantee efficient
     levels of indirection; they can simply re-compute the indices into the original parent array!
   * Hopefully by now it's fairly clear that supporting slices means that the dimensionality, given
     by the parameter `N`, is not necessarily equal to the dimensionality of the parent array or the
-    length of the `indexes` tuple.  Neither do user-supplied indices necessarily line up with entries
-    in the `indexes` tuple (e.g., the second user-supplied index might correspond to the third dimension
-    of the parent array, and the third element in the `indexes` tuple).
+    length of the `indices` tuple.  Neither do user-supplied indices necessarily line up with entries
+    in the `indices` tuple (e.g., the second user-supplied index might correspond to the third dimension
+    of the parent array, and the third element in the `indices` tuple).
 
     What might be less obvious is that the dimensionality of the stored parent array must be equal
-    to the number of effective indices in the `indexes` tuple. Some examples:
+    to the number of effective indices in the `indices` tuple. Some examples:
 
     ```julia
     A = reshape(1:35, 5, 7) # A 2d parent Array
@@ -230,7 +230,7 @@ then `A[2:2:4,:]` does not have uniform stride, so we cannot guarantee efficient
     S = view(A, :, :, 1:1)   # Appending extra indices is supported
     ```
 
-    Naively, you'd think you could just set `S.parent = A` and `S.indexes = (:,:,1:1)`, but supporting
+    Naively, you'd think you could just set `S.parent = A` and `S.indices = (:,:,1:1)`, but supporting
     this dramatically complicates the reindexing process, especially for views of views. Not only
     do you need to dispatch on the types of the stored indices, but you need to examine whether a
     given index is the final one and "merge" any remaining stored indices together. This is not an
@@ -244,18 +244,18 @@ then `A[2:2:4,:]` does not have uniform stride, so we cannot guarantee efficient
     `reindex` simply dispatches on the type of the stored indices in order to determine how many passed
     indices should be used and where they should go. But with `CartesianIndex`, there's no longer
     a one-to-one correspondence between the number of passed arguments and the number of dimensions
-    that they index into. If we return to the above example of `Base.reindex(S1, S1.indexes, (i, j))`,
+    that they index into. If we return to the above example of `Base.reindex(S1, S1.indices, (i, j))`,
     you can see that the expansion is incorrect for `i, j = CartesianIndex(), CartesianIndex(2,1)`.
     It should *skip* the `CartesianIndex()` entirely and return:
 
     ```julia
-    (CartesianIndex(2,1)[1], S1.indexes[2], S1.indexes[3][CartesianIndex(2,1)[2]])
+    (CartesianIndex(2,1)[1], S1.indices[2], S1.indices[3][CartesianIndex(2,1)[2]])
     ```
 
     Instead, though, we get:
 
     ```julia
-    (CartesianIndex(), S1.indexes[2], S1.indexes[3][CartesianIndex(2,1)])
+    (CartesianIndex(), S1.indices[2], S1.indices[3][CartesianIndex(2,1)])
     ```
 
     Doing this correctly would require *combined* dispatch on both the stored and passed indices across

--- a/doc/src/manual/methods.md
+++ b/doc/src/manual/methods.md
@@ -789,10 +789,10 @@ Closest candidates are:
 More usefully, it is possible to constrain varargs methods by a parameter. For example:
 
 ```julia
-function getindex(A::AbstractArray{T,N}, indexes::Vararg{Number,N}) where {T,N}
+function getindex(A::AbstractArray{T,N}, indices::Vararg{Number,N}) where {T,N}
 ```
 
-would be called only when the number of `indexes` matches the dimensionality of the array.
+would be called only when the number of `indices` matches the dimensionality of the array.
 
 When only the type of supplied arguments needs to be constrained `Vararg{T}` can be equivalently
 written as `T...`. For instance `f(x::Int...) = x` is a shorthand for `f(x::Vararg{Int}) = x`.

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -200,7 +200,7 @@ For users coming to Julia from R, these are some noteworthy differences:
   * In Julia, indexing of arrays, strings, etc. is 1-based not 0-based.
   * Julia's slice indexing includes the last element, unlike in Python. `a[2:3]` in Julia is `a[1:3]`
     in Python.
-  * Julia does not support negative indexes. In particular, the last element of a list or array is
+  * Julia does not support negative indices. In particular, the last element of a list or array is
     indexed with `end` in Julia, not `-1` as in Python.
   * Julia's `for`, `if`, `while`, etc. blocks are terminated by the `end` keyword. Indentation level
     is not significant as it is in Python.

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -525,7 +525,7 @@ end
 
 [`@async`](@ref) is similar to [`@spawn`](@ref), but only runs tasks on the local process. We
 use it to create a "feeder" task for each process. Each task picks the next index that needs to
-be computed, then waits for its process to finish, then repeats until we run out of indexes. Note
+be computed, then waits for its process to finish, then repeats until we run out of indices. Note
 that the feeder tasks do not begin to execute until the main task reaches the end of the [`@sync`](@ref)
 block, at which point it surrenders control and waits for all the local tasks to complete before
 returning from the function. The feeder tasks are able to share state via `nextidx` because
@@ -894,7 +894,7 @@ julia> addprocs(3)
 
 julia> @everywhere using SharedArrays
 
-julia> S = SharedArray{Int,2}((3,4), init = S -> S[localindexes(S)] = myid())
+julia> S = SharedArray{Int,2}((3,4), init = S -> S[localindices(S)] = myid())
 3×4 SharedArray{Int64,2}:
  2  2  3  4
  2  3  3  4
@@ -910,7 +910,7 @@ julia> S
  2  7  4  4
 ```
 
-[`SharedArrays.localindexes`](@ref) provides disjoint one-dimensional ranges of indexes, and is sometimes
+[`SharedArrays.localindices`](@ref) provides disjoint one-dimensional ranges of indices, and is sometimes
 convenient for splitting up tasks among processes. You can, of course, divide the work any way
 you wish:
 
@@ -950,7 +950,7 @@ into trouble: if `q[i,j,t]` is near the end of the block assigned to one worker 
 is near the beginning of the block assigned to another, it's very likely that `q[i,j,t]` will
 not be ready at the time it's needed for computing `q[i,j,t+1]`. In such cases, one is better
 off chunking the array manually. Let's split along the second dimension.
-Define a function that returns the `(irange, jrange)` indexes assigned to this worker:
+Define a function that returns the `(irange, jrange)` indices assigned to this worker:
 
 ```julia-repl
 julia> @everywhere function myrange(q::SharedArray)

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -101,7 +101,7 @@ Base.view
 Base.@view
 Base.@views
 Base.parent
-Base.parentindexes
+Base.parentindices
 Base.slicedim
 Base.reinterpret
 Base.reshape

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2424,15 +2424,15 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
 
     else if (f == jl_builtin_arrayref && nargs >= 3) {
         const jl_cgval_t &ary = argv[2];
-        bool indexes_ok = true;
+        bool indices_ok = true;
         for (size_t i = 3; i <= nargs; i++) {
             if (argv[i].typ != (jl_value_t*)jl_long_type) {
-                indexes_ok = false;
+                indices_ok = false;
                 break;
             }
         }
         jl_value_t *aty_dt = jl_unwrap_unionall(ary.typ);
-        if (jl_is_array_type(aty_dt) && indexes_ok) {
+        if (jl_is_array_type(aty_dt) && indices_ok) {
             jl_value_t *ety = jl_tparam0(aty_dt);
             jl_value_t *ndp = jl_tparam1(aty_dt);
             if (!jl_has_free_typevars(ety) && (jl_is_long(ndp) || nargs == 3)) {
@@ -2479,15 +2479,15 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
     else if (f == jl_builtin_arrayset && nargs >= 4) {
         const jl_cgval_t &ary = argv[2];
         const jl_cgval_t &val = argv[3];
-        bool indexes_ok = true;
+        bool indices_ok = true;
         for (size_t i = 4; i <= nargs; i++) {
             if (argv[i].typ != (jl_value_t*)jl_long_type) {
-                indexes_ok = false;
+                indices_ok = false;
                 break;
             }
         }
         jl_value_t *aty_dt = jl_unwrap_unionall(ary.typ);
-        if (jl_is_array_type(aty_dt) && indexes_ok) {
+        if (jl_is_array_type(aty_dt) && indices_ok) {
             jl_value_t *ety = jl_tparam0(aty_dt);
             jl_value_t *ndp = jl_tparam1(aty_dt);
             if (!jl_has_free_typevars(ety) && (jl_is_long(ndp) || nargs == 4)) {

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -115,10 +115,10 @@
                     (cdr ex))))))
 
 ;; go through indices and replace the `end` symbol
-;; a = array being indexed, i = list of indexes
+;; a = array being indexed, i = list of indices
 ;; returns (values index-list stmts) where stmts are statements that need
 ;; to execute first.
-(define (process-indexes a i)
+(define (process-indices a i)
   (let loop ((lst i)
              (n   1)
              (stmts '())
@@ -1561,7 +1561,7 @@
            (arr   (if reuse (make-ssavalue) a))
            (stmts (if reuse `((= ,arr ,a)) '())))
       (receive
-       (new-idxs stuff) (process-indexes arr idxs)
+       (new-idxs stuff) (process-indices arr idxs)
        `(block
          ,@(append stmts stuff)
          (call getindex ,arr ,@new-idxs))))))
@@ -2098,7 +2098,7 @@
                    (r    (if rrhs (make-ssavalue) rhs))
                    (rini (if rrhs `((= ,r ,(expand-forms rhs))) '())))
               (receive
-               (new-idxs stuff) (process-indexes arr idxs)
+               (new-idxs stuff) (process-indices arr idxs)
                `(block
                  ,@stmts
                  ,.(map expand-forms stuff)

--- a/src/julia.h
+++ b/src/julia.h
@@ -455,7 +455,7 @@ typedef struct _jl_typemap_entry_t {
 // one level in a TypeMap tree
 // indexed by key if it is a sublevel in an array
 struct jl_ordereddict_t {
-    jl_array_t *indexes; // Array{Int{8,16,32}}
+    jl_array_t *indices; // Array{Int{8,16,32}}
     jl_array_t *values; // Array{union jl_typemap_t}
 };
 typedef struct _jl_typemap_level_t {

--- a/stdlib/SharedArrays/docs/src/index.md
+++ b/stdlib/SharedArrays/docs/src/index.md
@@ -5,5 +5,5 @@ SharedArrays.SharedArray
 SharedArrays.procs(::SharedArray)
 SharedArrays.sdata
 SharedArrays.indexpids
-SharedArrays.localindexes
+SharedArrays.localindices
 ```

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -31,7 +31,7 @@ function check_pids_all(S::SharedArray)
     pidtested = falses(size(S))
     for p in procs(S)
         idxes_in_p = remotecall_fetch(p, S) do D
-            parentindexes(D.loc_subarr_1d)[1]
+            parentindices(D.loc_subarr_1d)[1]
         end
         @test all(sdata(S)[idxes_in_p] .== p)
         pidtested[idxes_in_p] = true
@@ -55,7 +55,7 @@ end
 d = SharedArrays.shmem_rand(dims)
 for p in procs(d)
     idxes_in_p = remotecall_fetch(p, d) do D
-        parentindexes(D.loc_subarr_1d)[1]
+        parentindices(D.loc_subarr_1d)[1]
     end
     idxf = first(idxes_in_p)
     idxl = last(idxes_in_p)
@@ -84,7 +84,7 @@ a = rand(dims)
 d = SharedArray{Int}(dims, init = D->fill!(D.loc_subarr_1d, myid()))
 for p in procs(d)
     idxes_in_p = remotecall_fetch(p, d) do D
-        parentindexes(D.loc_subarr_1d)[1]
+        parentindices(D.loc_subarr_1d)[1]
     end
     idxf = first(idxes_in_p)
     idxl = last(idxes_in_p)
@@ -124,7 +124,7 @@ finalize(S)
 
 # Creating a new file
 fn2 = tempname()
-S = SharedArray{Int,2}(fn2, sz, init=D->D[localindexes(D)] = myid())
+S = SharedArray{Int,2}(fn2, sz, init=D->D[localindices(D)] = myid())
 @test S == filedata
 filedata2 = similar(Atrue)
 read!(fn2, filedata2)
@@ -134,7 +134,7 @@ finalize(S)
 # Appending to a file
 fn3 = tempname()
 write(fn3, ones(UInt8, 4))
-S = SharedArray{UInt8}(fn3, sz, 4, mode="a+", init=D->D[localindexes(D)]=0x02)
+S = SharedArray{UInt8}(fn3, sz, 4, mode="a+", init=D->D[localindices(D)]=0x02)
 len = prod(sz)+4
 @test filesize(fn3) == len
 filedata = Vector{UInt8}(uninitialized, len)
@@ -194,7 +194,7 @@ remotecall_fetch(setindex!, pids_d[findfirst(id->(id != myid()), pids_d)], d, 1.
 @test ds != d
 @test s != d
 copy!(d, s)
-@everywhere setid!(A) = A[localindexes(A)] = myid()
+@everywhere setid!(A) = A[localindices(A)] = myid()
 @everywhere procs(ds) setid!($ds)
 @test d == s
 @test ds != s

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -629,7 +629,7 @@ mutable struct TSlowNIndexes{T,N} <: AbstractArray{T,N}
 end
 Base.IndexStyle(::Type{A}) where {A<:TSlowNIndexes} = Base.IndexCartesian()
 Base.size(A::TSlowNIndexes) = size(A.data)
-Base.getindex(A::TSlowNIndexes, index::Int...) = error("Must use $(ndims(A)) indexes")
+Base.getindex(A::TSlowNIndexes, index::Int...) = error("Must use $(ndims(A)) indices")
 Base.getindex(A::TSlowNIndexes{T,2}, i::Int, j::Int) where {T} = A.data[i,j]
 
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -104,7 +104,7 @@ end
         @test r[3,1] == 4
         @test r[Base.ReshapedIndex(CartesianIndex((1,2)))] == 3
         @test parent(reshape(r, (1,3))) === r.parent === s
-        @test parentindexes(r) == (1:1, 1:3)
+        @test parentindices(r) == (1:1, 1:3)
         @test reshape(r, (3,)) === r
         @test convert(Array{Int,1}, r) == [2,3,4]
         @test_throws MethodError convert(Array{Int,2}, r)
@@ -120,7 +120,7 @@ end
         @test r[3,1] == 5
         @test r[Base.ReshapedIndex(CartesianIndex((1,2)))] == 3
         @test parent(reshape(r, (1,3))) === r.parent === s
-        @test parentindexes(r) == (1:1, 1:3)
+        @test parentindices(r) == (1:1, 1:3)
         @test reshape(r, (3,)) === r
         @test convert(Array{Int,1}, r) == [2,3,5]
         @test_throws MethodError convert(Array{Int,2}, r)
@@ -1577,13 +1577,13 @@ end
     @test eltype(R) <: CartesianIndex{2}
     @test eltype(typeof(R)) <: CartesianIndex{2}
     @test eltype(CartesianRange{2}) <: CartesianIndex{2}
-    indexes = collect(R)
-    @test indexes[1] == CartesianIndex{2}(2,3)
-    @test indexes[2] == CartesianIndex{2}(3,3)
-    @test indexes[4] == CartesianIndex{2}(5,3)
-    @test indexes[5] == CartesianIndex{2}(2,4)
-    @test indexes[12] == CartesianIndex{2}(5,5)
-    @test length(indexes) == 12
+    indices = collect(R)
+    @test indices[1] == CartesianIndex{2}(2,3)
+    @test indices[2] == CartesianIndex{2}(3,3)
+    @test indices[4] == CartesianIndex{2}(5,3)
+    @test indices[5] == CartesianIndex{2}(2,4)
+    @test indices[12] == CartesianIndex{2}(5,5)
+    @test length(indices) == 12
     @test length(R) == 12
     @test ndims(R) == 2
     @test in(CartesianIndex((2,3)), R)

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -12,6 +12,6 @@ ex = Base.Cartesian.exprresolve(:(if 5 > 4; :x; else :y; end))
     @test convert(Int, CartesianIndex(42)) === 42
     @test convert(Float64, CartesianIndex(42)) === 42.0
     @test convert(Tuple, CartesianIndex(42, 1)) === (42, 1)
-    # can't convert higher-dimensional indexes to Int
+    # can't convert higher-dimensional indices to Int
     @test_throws MethodError convert(Int, CartesianIndex(42, 1))
 end

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -70,7 +70,7 @@ module MyArray15367
     end
 
     Base.size(A::MyArray) = size(A.data)
-    Base.getindex(A::MyArray, indexes...) = A.data[indexes...]
+    Base.getindex(A::MyArray, indices...) = A.data[indices...]
 
     A = MyArray(rand(4,5))
     b = rand(5)

--- a/test/show.jl
+++ b/test/show.jl
@@ -628,12 +628,12 @@ show_f1(x...) = [x...]
 show_f2(x::Vararg{Any}) = [x...]
 show_f3(x::Vararg) = [x...]
 show_f4(x::Vararg{Any,3}) = [x...]
-show_f5(A::AbstractArray{T, N}, indexes::Vararg{Int,N}) where {T, N} = [indexes...]
+show_f5(A::AbstractArray{T, N}, indices::Vararg{Int,N}) where {T, N} = [indices...]
 test_mt(show_f1, "show_f1(x...)")
 test_mt(show_f2, "show_f2(x...)")
 test_mt(show_f3, "show_f3(x...)")
 test_mt(show_f4, "show_f4(x::Vararg{Any,3})")
-test_mt(show_f5, "show_f5(A::AbstractArray{T,N}, indexes::Vararg{$Int,N})")
+test_mt(show_f5, "show_f5(A::AbstractArray{T,N}, indices::Vararg{$Int,N})")
 
 # Issue #15525, printing of vcat
 @test sprint(show, :([a;])) == ":([a;])"

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -108,32 +108,32 @@ end
 end
 
 # @simd with cartesian iteration
-function simd_cartesian_range!(indexes, crng)
+function simd_cartesian_range!(indices, crng)
     @simd for I in crng
-        push!(indexes, I)
+        push!(indices, I)
     end
-    indexes
+    indices
 end
 
 crng = CartesianRange(2:4, 0:1, 1:1, 3:5)
-indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
-@test indexes == vec(collect(crng))
+indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
+@test indices == vec(collect(crng))
 
 crng = CartesianRange(-1:1, 1:3)
-indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
-@test indexes == vec(collect(crng))
+indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
+@test indices == vec(collect(crng))
 
 crng = CartesianRange(-1:-1, 1:3)
-indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
-@test indexes == vec(collect(crng))
+indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
+@test indices == vec(collect(crng))
 
 crng = CartesianRange(2:4)
-indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
-@test indexes == collect(crng)
+indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
+@test indices == collect(crng)
 
 crng = CartesianRange()
-indexes = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
-@test indexes == vec(collect(crng))
+indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
+@test indices == vec(collect(crng))
 
 # @simd with array as "range"
 # issue #13869

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -67,10 +67,10 @@ splat3(A, 1:2, 1, 1:2)
 @test String(take!(stagediobuf)) == "(UnitRange{$intstr}, $intstr, UnitRange{$intstr})"
 
 B = view(A, 1:3, 2, 1:3)
-@generated function mygetindex(S::SubArray, indexes::Real...)
+@generated function mygetindex(S::SubArray, indices::Real...)
     T, N, A, I = S.parameters
-    if N != length(indexes)
-        error("Wrong number of indexes supplied")
+    if N != length(indices)
+        error("Wrong number of indices supplied")
     end
     Ip = I.parameters
     NP = length(Ip)
@@ -78,9 +78,9 @@ B = view(A, 1:3, 2, 1:3)
     j = 1
     for i = 1:NP
         if Ip[i] == Int
-            indexexprs[i] = :(S.indexes[$i])
+            indexexprs[i] = :(S.indices[$i])
         else
-            indexexprs[i] = :(S.indexes[$i][indexes[$j]])
+            indexexprs[i] = :(S.indices[$i][indices[$j]])
             j += 1
         end
     end


### PR DESCRIPTION
This changes all use of "indexes" as a noun to "indices," which is the proper pluralization of "index." Functions which use `indexes` as part of the name, e.g. `parentindexes` and `localindexes`, have been deprecated accordingly. The only possibly breaking change here is that field names that use `indexes` have been changed, so code that specifically tries to access such a field will break without a deprecation.

Fixes #12902.