### PR TITLE
fix unicode completion in square brackets

### DIFF
--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -462,9 +462,9 @@ function dict_identifier_key(str,tag)
         isa(obj, Array) && return (nothing, nothing, nothing)
     end
     begin_of_key = first(search(str, r"\S", nextind(str, end_of_identifier) + 1)) # 1 for [
-    begin_of_key==0 && return (true, nothing, nothing)
+    begin_of_key==0 && return (nothing, nothing, nothing)
     partial_key = str[begin_of_key:end]
-    (isa(obj, AbstractDict) && length(obj) < 1e6) || return (true, nothing, nothing)
+    (isa(obj, AbstractDict) && length(obj) < 1e6) || return (nothing, nothing, nothing)
     return (obj, partial_key, begin_of_key)
 end
 


### PR DESCRIPTION
This fixes #24705, but I don't know anything of the REPL code so I am not sure this is the way to go.

To me, the name `dict_identifier_key` seems to indicate that it should only return non-trivial values `identifier, partial_key, loc` when the object in front of the square brackets is a `Dict`. Currently, only `Array` objects were special cased to return `nothing, nothing, nothing`, whereas all other objects returned `true,nothing,nothing`. I don't see the point of the `true` value, since this is then only used in `completions` where it means that for any object which is not a dict (or an array), followed by `[`, effectively all completions are disabled.