### PR TITLE
Some logging printing improvements

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -69,6 +69,7 @@ have_color = false
 default_color_warn = :yellow
 default_color_error = :light_red
 default_color_info = :cyan
+default_color_debug = :blue
 default_color_input = :normal
 default_color_answer = :normal
 color_normal = text_colors[:normal]
@@ -83,6 +84,7 @@ end
 error_color() = repl_color("JULIA_ERROR_COLOR", default_color_error)
 warn_color()  = repl_color("JULIA_WARN_COLOR" , default_color_warn)
 info_color()  = repl_color("JULIA_INFO_COLOR" , default_color_info)
+debug_color()  = repl_color("JULIA_DEBUG_COLOR" , default_color_debug)
 
 input_color()  = text_colors[repl_color("JULIA_INPUT_COLOR", default_color_input)]
 answer_color() = text_colors[repl_color("JULIA_ANSWER_COLOR", default_color_answer)]

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -249,22 +249,24 @@ end
     # Simple
     @test genmsg(Info, "msg", Main, "some/path.jl", 101) ==
     """
-    I- msg -Info:Main:path.jl:101
+    [ Info: msg @ Main path.jl:101
     """
 
     # Multiline message
     @test genmsg(Warn, "line1\nline2", Main, "some/path.jl", 101) ==
     """
-    W- line1
-    |  line2 -Warn:Main:path.jl:101
+    ┌ Warning: line1
+    │ line2
+    └ @ Main path.jl:101
     """
 
     # Keywords
     @test genmsg(Error, "msg", Base, "other.jl", 101, a=1, b="asdf") ==
     """
-    E- msg -Error:Base:other.jl:101
-    |  a = 1
-    |  b = asdf
+    ┌ Error: msg
+    │   a = 1
+    │   b = asdf
+    └ @ Base other.jl:101
     """
 end
 


### PR DESCRIPTION
 - use user customizable colors in logging
 - nice box drawing chars
 - print line info after key value pairs
 - always put the line info on its own line for multiline messages
 - don't show the loglevel in the location info since it is already printed in the beginning of the message

![screenshot from 2017-12-15 16-10-47](https://user-images.githubusercontent.com/11698744/34048093-ac0f7cae-e1b2-11e7-9065-356c567b4c3b.png)

 - use showerror to print exceptions rather than their string representation
![screenshot from 2017-12-15 16-13-24](https://user-images.githubusercontent.com/11698744/34048158-f748083a-e1b2-11e7-9c91-fbd0ab1c1a41.png)
