### PR TITLE
make IndexValue type act more like an AbstractDict

### DIFF
--- a/doc/src/stdlib/collections.md
+++ b/doc/src/stdlib/collections.md
@@ -187,6 +187,7 @@ for the key `x`).  Multiple arguments to `D[...]` are converted to tuples; for e
 Base.Dict
 Base.ObjectIdDict
 Base.WeakKeyDict
+Base.ImmutableDict
 Base.haskey
 Base.get(::Any, ::Any, ::Any)
 Base.get
@@ -219,6 +220,8 @@ Partially implemented by:
   * [`EnvDict`](@ref Base.EnvDict)
   * [`Array`](@ref)
   * [`BitArray`](@ref)
+  * [`ImmutableDict`](@ref Base.ImmutableDict)
+  * [`Iterators.IndexValue`](@ref)
 
 ## Set-Like Collections
 
@@ -271,4 +274,5 @@ Fully implemented by:
 
 ```@docs
 Base.Pair
+Iterators.IndexValue
 ```

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -430,6 +430,50 @@ end
     @test eltype(arr) == Int
 end
 
+@testset "IndexValue type" begin
+    for A in ([4.0 5.0 6.0],
+              [],
+              (4.0, 5.0, 6.0),
+              (a=4.0, b=5.0, c=6.0),
+              (),
+              NamedTuple(),
+             )
+        d = pairs(A)
+        @test d === pairs(d)
+        @test isempty(d) == isempty(A)
+        @test length(d) == length(A)
+        @test keys(d) == keys(A)
+        @test values(d) == A
+        @test Base.iteratorsize(d) == Base.HasLength()
+        @test Base.iteratoreltype(d) == Base.HasEltype()
+        @test isempty(d) || haskey(d, first(keys(d)))
+        @test collect(v for (k, v) in d) == vec(collect(A))
+        if A isa NamedTuple
+            K = isempty(d) ? Union{} : Symbol
+            V = isempty(d) ? Union{} : Float64
+            @test isempty(d) || haskey(d, :a)
+            @test !haskey(d, :abc)
+            @test !haskey(d, 1)
+        elseif A isa Tuple
+            K = Int
+            V = isempty(d) ? Union{} : Float64
+        else
+            K = A isa AbstractVector ? Int : CartesianIndex{2}
+            V = isempty(d) ? Any : Float64
+            @test get(A, 4, "not found") === "not found"
+            if !isempty(A)
+                @test get(A, 2, "not found") === 5.0
+                @test getindex(d, 3) === 6.0
+                @test setindex!(d, 9, 3) === d
+                @test A[3] === 9.0
+            end
+        end
+        @test keytype(d) == K
+        @test valtype(d) == V
+        @test eltype(d) == Pair{K, V}
+    end
+end
+
 @testset "reverse iterators" begin
     squash(A) = reshape(A, length(A))
     Z = Array{Int,0}(uninitialized); Z[] = 17 # zero-dimensional test case


### PR DESCRIPTION
Since this type acts like an AbstractDict container under iteration,
it should also be reasonable to make it also act like an AbstractDict
under other common operations (such as calling `pairs` and `getindex`)
by adding those methods to it here.