### PR TITLE
Root dt during construction in interpreter

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -175,7 +175,7 @@ static void eval_primitivetype(jl_expr_t *ex, interpreter_state *s)
     jl_datatype_t *dt = NULL;
     jl_value_t *w = NULL;
     jl_module_t *modu = s->module;
-    JL_GC_PUSH4(&para, &super, &temp, &w);
+    JL_GC_PUSH5(&para, &super, &temp, &w, &dt);
     if (jl_is_globalref(name)) {
         modu = jl_globalref_mod(name);
         name = (jl_value_t*)jl_globalref_name(name);
@@ -228,7 +228,7 @@ static void eval_structtype(jl_expr_t *ex, interpreter_state *s)
     jl_datatype_t *dt = NULL;
     jl_value_t *w = NULL;
     jl_module_t *modu = s->module;
-    JL_GC_PUSH4(&para, &super, &temp, &w);
+    JL_GC_PUSH5(&para, &super, &temp, &w, &dt);
     if (jl_is_globalref(name)) {
         modu = jl_globalref_mod(name);
         name = (jl_value_t*)jl_globalref_name(name);


### PR DESCRIPTION
ClangSA was unhappy about this:
```
/home/keno/julia/src/interpreter.c:239:10: note: Started tracking value here
    dt = jl_new_datatype((jl_sym_t*)name, modu, NULL, (jl_svec_t*)para,
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/interpreter.c:244:23: note: Value may have been GCed here
    jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)name, 1);
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/interpreter.c:255:9: note: Argument value may have been GCed
        jl_set_datatype_super(dt, super);
        ^                     ~~
```
Talking to Jeff and Jameson, these are likely never seen in real code because leaf types are generally rooted
somehow and we don't like collecting them. However, it seems like there's no guarantee that this won't happen
(in contrived) situations, so let's put the root here to be safe.