### PR TITLE
Fix missing gc root in generator expansion

### DIFF
--- a/src/method.c
+++ b/src/method.c
@@ -325,7 +325,7 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
         ptls->world_age = def->min_world;
 
         // invoke code generator
-        jl_value_t *ex = jl_call_staged(linfo->def.method, generator, linfo->sparam_vals, jl_svec_data(tt->parameters), jl_nparams(tt));
+        ex = jl_call_staged(linfo->def.method, generator, linfo->sparam_vals, jl_svec_data(tt->parameters), jl_nparams(tt));
 
         if (jl_is_code_info(ex)) {
             func = (jl_code_info_t*)ex;


### PR DESCRIPTION
ClangSA complains:
```
/home/keno/julia/src/method.c:334:37: note: Passing non-rooted value as argument to function that may GC
            func = (jl_code_info_t*)jl_expand((jl_value_t*)ex, linfo->def.method->module);
                                    ^         ~~~~~~~~~~~~~~~
```
But why you ask, `ex` is pushed into a gc frame earlier in the function. Well, because of C scoping rules,
that's a different `ex` than the one that gets assigned.