### PR TITLE
Fix missing gc root in struct allocation

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -739,6 +739,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
     if (type->instance != NULL) return type->instance;
     size_t nf = jl_datatype_nfields(type);
     jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
+    JL_GC_PUSH1(&jv);
     for (size_t i = 0; i < na; i++) {
         jl_value_t *ft = jl_field_type(type, i);
         if (!jl_isa(args[i], ft))
@@ -757,6 +758,7 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args,
             }
         }
     }
+    JL_GC_POP();
     return jv;
 }
 


### PR DESCRIPTION
ClangSA says:
```
/home/keno/julia/src/datatype.c:729:22: note: Started tracking value here
    jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./julia_internal.h:285:6: note: expanded from macro 'jl_gc_alloc'
     (jl_gc_alloc)(ptls, sz, ty))
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/datatype.c:730:24: note: Assuming 'i' is < 'na'
    for (size_t i = 0; i < na; i++) {
                       ^~~~~~
/home/keno/julia/src/datatype.c:730:5: note: Loop condition is true. Entering loop body
    for (size_t i = 0; i < na; i++) {
    ^
/home/keno/julia/src/datatype.c:732:14: note: Value may have been GCed here
        if (!jl_isa(args[i], ft))
             ^~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/datatype.c:732:13: note: Assuming the condition is false
        if (!jl_isa(args[i], ft))
            ^~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/datatype.c:732:9: note: Taking false branch
        if (!jl_isa(args[i], ft))
        ^
/home/keno/julia/src/datatype.c:734:9: note: Argument value may have been GCed
        jl_set_nth_field(jv, i, args[i]);
        ^                ~~
```
I concur.