### PR TITLE
remove special lowering for and deprecate .'

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -3098,7 +3098,7 @@ end
     *(rowvec::RowVector, A::AbstractTriangular) = rvtranspose(transpose(A) * rvtranspose(rowvec))
     *(rowvec::RowVector, transA::Transpose{<:Any,<:AbstractTriangular}) = rvtranspose(transA.parent * rvtranspose(rowvec))
     *(A::AbstractTriangular, transrowvec::Transpose{<:Any,<:RowVector}) = A * rvtranspose(transrowvec.parent)
-    *(transA::Transpose{<:Any,<:AbstractTriangular}, transrowvec::Transpose{<:Any,<:RowVector}) = transA.parent.' * rvtranspose(transrowvec.parent)
+    *(transA::Transpose{<:Any,<:AbstractTriangular}, transrowvec::Transpose{<:Any,<:RowVector}) = transA * rvtranspose(transrowvec.parent)
     *(rowvec::RowVector, adjA::Adjoint{<:Any,<:AbstractTriangular}) = rvadjoint(adjA.parent * rvadjoint(rowvec))
     *(A::AbstractTriangular, adjrowvec::Adjoint{<:Any,<:RowVector}) = A * rvadjoint(adjrowvec.parent)
     *(adjA::Adjoint{<:Any,<:AbstractTriangular}, adjrowvec::Adjoint{<:Any,<:RowVector}) = adjA.parent' * rvadjoint(adjrowvec.parent)

--- a/base/linalg/bitarray.jl
+++ b/base/linalg/bitarray.jl
@@ -123,7 +123,7 @@ end
 
 ## Structure query functions
 
-issymmetric(A::BitMatrix) = size(A, 1)==size(A, 2) && count(!iszero, A - A.')==0
+issymmetric(A::BitMatrix) = size(A, 1)==size(A, 2) && count(!iszero, A - transpose(A))==0
 ishermitian(A::BitMatrix) = issymmetric(A)
 
 function nonzero_chunks(chunks::Vector{UInt64}, pos0::Int, pos1::Int)

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -555,9 +555,9 @@ for (fname, elty) in ((:dgemv_,:Float64),
             if trans == 'N' && (length(X) != n || length(Y) != m)
                 throw(DimensionMismatch("A has dimensions $(size(A)), X has length $(length(X)) and Y has length $(length(Y))"))
             elseif trans == 'C' && (length(X) != m || length(Y) != n)
-                throw(DimensionMismatch("A' has dimensions $n, $m, X has length $(length(X)) and Y has length $(length(Y))"))
+                throw(DimensionMismatch("the adjoint of A has dimensions $n, $m, X has length $(length(X)) and Y has length $(length(Y))"))
             elseif trans == 'T' && (length(X) != m || length(Y) != n)
-                throw(DimensionMismatch("A.' has dimensions $n, $m, X has length $(length(X)) and Y has length $(length(Y))"))
+                throw(DimensionMismatch("the transpose of A has dimensions $n, $m, X has length $(length(X)) and Y has length $(length(Y))"))
             end
             ccall((@blasfunc($fname), libblas), Void,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
@@ -994,7 +994,7 @@ end
 """
     syr!(uplo, alpha, x, A)
 
-Rank-1 update of the symmetric matrix `A` with vector `x` as `alpha*x*x.' + A`.
+Rank-1 update of the symmetric matrix `A` with vector `x` as `alpha*x*Transpose(x) + A`.
 [`uplo`](@ref stdlib-blas-uplo) controls which triangle of `A` is updated. Returns `A`.
 """
 function syr! end
@@ -1228,7 +1228,7 @@ end
 """
     syrk!(uplo, trans, alpha, A, beta, C)
 
-Rank-k update of the symmetric matrix `C` as `alpha*A*A.' + beta*C` or `alpha*A.'*A +
+Rank-k update of the symmetric matrix `C` as `alpha*A*Transpose(A) + beta*C` or `alpha*Transpose(A)*A +
 beta*C` according to [`trans`](@ref stdlib-blas-trans).
 Only the [`uplo`](@ref stdlib-blas-uplo) triangle of `C` is used. Returns `C`.
 """
@@ -1239,7 +1239,7 @@ function syrk! end
 
 Returns either the upper triangle or the lower triangle of `A`,
 according to [`uplo`](@ref stdlib-blas-uplo),
-of `alpha*A*A.'` or `alpha*A.'*A`,
+of `alpha*A*Transpose(A)` or `alpha*Transpose(A)*A`,
 according to [`trans`](@ref stdlib-blas-trans).
 """
 function syrk end

--- a/base/linalg/bunchkaufman.jl
+++ b/base/linalg/bunchkaufman.jl
@@ -118,7 +118,7 @@ end
     getindex(B::BunchKaufman, d::Symbol)
 
 Extract the factors of the Bunch-Kaufman factorization `B`. The factorization can take the
-two forms `L*D*L'` or `U*D*U'` (or `.'` in the complex symmetric case) where `L` is a
+two forms `L*D*L'` or `U*D*U'` (or `L*D*Transpose(L)` in the complex symmetric case) where `L` is a
 `UnitLowerTriangular` matrix, `U` is a `UnitUpperTriangular`, and `D` is a block diagonal
 symmetric or Hermitian matrix with 1x1 or 2x2 blocks. The argument `d` can be
 - `:D`: the block diagonal matrix
@@ -153,7 +153,7 @@ permutation:
  3
  2
 
-julia> F[:L]*F[:D]*F[:L].' - A[F[:p], F[:p]]
+julia> F[:L]*F[:D]*F[:L]' - A[F[:p], F[:p]]
 3×3 Array{Float64,2}:
  0.0  0.0  0.0
  0.0  0.0  0.0
@@ -161,7 +161,7 @@ julia> F[:L]*F[:D]*F[:L].' - A[F[:p], F[:p]]
 
 julia> F = bkfact(Symmetric(A));
 
-julia> F[:U]*F[:D]*F[:U].' - F[:P]*A*F[:P]'
+julia> F[:U]*F[:D]*F[:U]' - F[:P]*A*F[:P]'
 3×3 Array{Float64,2}:
  0.0  0.0  0.0
  0.0  0.0  0.0
@@ -192,13 +192,13 @@ function getindex(B::BunchKaufman{T}, d::Symbol) where {T<:BlasFloat}
             if B.uplo == 'L'
                 return UnitLowerTriangular(LUD)
             else
-                throw(ArgumentError("factorization is U*D*U.' but you requested L"))
+                throw(ArgumentError("factorization is U*D*Transpose(U) but you requested L"))
             end
         else # :U
             if B.uplo == 'U'
                 return UnitUpperTriangular(LUD)
             else
-                throw(ArgumentError("factorization is L*D*L.' but you requested U"))
+                throw(ArgumentError("factorization is L*D*Transpose(L) but you requested U"))
             end
         end
     else

--- a/base/linalg/givens.jl
+++ b/base/linalg/givens.jl
@@ -3,7 +3,7 @@
 
 abstract type AbstractRotation{T} end
 
-transpose(R::AbstractRotation) = error("transpose not implemented for $(typeof(R)). Consider using conjugate transpose (') instead of transpose (.').")
+transpose(R::AbstractRotation) = error("transpose not implemented for $(typeof(R)). Consider using adjoint instead of transpose.")
 
 function *(R::AbstractRotation{T}, A::AbstractVecOrMat{S}) where {T,S}
     TS = typeof(zero(T)*zero(S) + zero(T)*zero(S))

--- a/base/linalg/lapack.jl
+++ b/base/linalg/lapack.jl
@@ -972,7 +972,7 @@ end
 """
     gels!(trans, A, B) -> (F, B, ssr)
 
-Solves the linear equation `A * X = B`, `A.' * X =B`, or `A' * X = B` using
+Solves the linear equation `A * X = B`, `Transpose(A) * X = B`, or `Adjoint(A) * X = B` using
 a QR or LQ factorization. Modifies the matrix/vector `B` in place with the
 solution. `A` is overwritten with its `QR` or `LQ` factorization. `trans`
 may be one of `N` (no modification), `T` (transpose), or `C` (conjugate
@@ -994,7 +994,7 @@ gesv!(A::StridedMatrix, B::StridedVecOrMat)
 """
     getrs!(trans, A, ipiv, B)
 
-Solves the linear equation `A * X = B`, `A.' * X =B`, or `A' * X = B` for
+Solves the linear equation `A * X = B`, `Transpose(A) * X = B`, or `Adjoint(A) * X = B` for
 square `A`. Modifies the matrix/vector `B` in place with the solution. `A`
 is the `LU` factorization from `getrf!`, with `ipiv` the pivoting
 information. `trans` may be one of `N` (no modification), `T` (transpose),
@@ -1155,8 +1155,8 @@ end
 """
     gesvx!(fact, trans, A, AF, ipiv, equed, R, C, B) -> (X, equed, R, C, B, rcond, ferr, berr, work)
 
-Solves the linear equation `A * X = B` (`trans = N`), `A.' * X =B`
-(`trans = T`), or `A' * X = B` (`trans = C`) using the `LU` factorization
+Solves the linear equation `A * X = B` (`trans = N`), `Transpose(A) * X = B`
+(`trans = T`), or `Adjoint(A) * X = B` (`trans = C`) using the `LU` factorization
 of `A`. `fact` may be `E`, in which case `A` will be equilibrated and copied
 to `AF`; `F`, in which case `AF` and `ipiv` from a previous `LU` factorization
 are inputs; or `N`, in which case `A` will be copied to `AF` and then
@@ -2436,8 +2436,8 @@ gttrf!(dl::StridedVector, d::StridedVector, du::StridedVector)
 """
     gttrs!(trans, dl, d, du, du2, ipiv, B)
 
-Solves the equation `A * X = B` (`trans = N`), `A.' * X = B` (`trans = T`),
-or `A' * X = B` (`trans = C`) using the `LU` factorization computed by
+Solves the equation `A * X = B` (`trans = N`), `Transpose(A) * X = B` (`trans = T`),
+or `Adjoint(A) * X = B` (`trans = C`) using the `LU` factorization computed by
 `gttrf!`. `B` is overwritten with the solution `X`.
 """
 gttrs!(trans::Char, dl::StridedVector, d::StridedVector, du::StridedVector, du2::StridedVector,
@@ -2866,7 +2866,7 @@ orgrq!(A::StridedMatrix, tau::StridedVector, k::Integer = length(tau))
 """
     ormlq!(side, trans, A, tau, C)
 
-Computes `Q * C` (`trans = N`), `Q.' * C` (`trans = T`), `Q' * C`
+Computes `Q * C` (`trans = N`), `Transpose(Q) * C` (`trans = T`), `Adjoint(Q) * C`
 (`trans = C`) for `side = L` or the equivalent right-sided multiplication
 for `side = R` using `Q` from a `LQ` factorization of `A` computed using
 `gelqf!`. `C` is overwritten.
@@ -2876,7 +2876,7 @@ ormlq!(side::Char, trans::Char, A::StridedMatrix, tau::StridedVector, C::Strided
 """
     ormqr!(side, trans, A, tau, C)
 
-Computes `Q * C` (`trans = N`), `Q.' * C` (`trans = T`), `Q' * C`
+Computes `Q * C` (`trans = N`), `Transpose(Q) * C` (`trans = T`), `Adjoint(Q) * C`
 (`trans = C`) for `side = L` or the equivalent right-sided multiplication
 for `side = R` using `Q` from a `QR` factorization of `A` computed using
 `geqrf!`. `C` is overwritten.
@@ -2886,7 +2886,7 @@ ormqr!(side::Char, trans::Char, A::StridedMatrix, tau::StridedVector, C::Strided
 """
     ormql!(side, trans, A, tau, C)
 
-Computes `Q * C` (`trans = N`), `Q.' * C` (`trans = T`), `Q' * C`
+Computes `Q * C` (`trans = N`), `Transpose(Q) * C` (`trans = T`), `Adjoint(Q) * C`
 (`trans = C`) for `side = L` or the equivalent right-sided multiplication
 for `side = R` using `Q` from a `QL` factorization of `A` computed using
 `geqlf!`. `C` is overwritten.
@@ -2896,7 +2896,7 @@ ormql!(side::Char, trans::Char, A::StridedMatrix, tau::StridedVector, C::Strided
 """
     ormrq!(side, trans, A, tau, C)
 
-Computes `Q * C` (`trans = N`), `Q.' * C` (`trans = T`), `Q' * C`
+Computes `Q * C` (`trans = N`), `Transpose(Q) * C` (`trans = T`), `Adjoint(Q) * C`
 (`trans = C`) for `side = L` or the equivalent right-sided multiplication
 for `side = R` using `Q` from a `RQ` factorization of `A` computed using
 `gerqf!`. `C` is overwritten.
@@ -2906,7 +2906,7 @@ ormrq!(side::Char, trans::Char, A::StridedMatrix, tau::StridedVector, C::Strided
 """
     gemqrt!(side, trans, V, T, C)
 
-Computes `Q * C` (`trans = N`), `Q.' * C` (`trans = T`), `Q' * C`
+Computes `Q * C` (`trans = N`), `Transpose(Q) * C` (`trans = T`), `Adjoint(Q) * C`
 (`trans = C`) for `side = L` or the equivalent right-sided multiplication
 for `side = R` using `Q` from a `QR` factorization of `A` computed using
 `geqrt!`. `C` is overwritten.
@@ -3306,8 +3306,8 @@ trtri!(uplo::Char, diag::Char, A::StridedMatrix)
 """
     trtrs!(uplo, trans, diag, A, B)
 
-Solves `A * X = B` (`trans = N`), `A.' * X = B` (`trans = T`), or
-`A' * X = B` (`trans = C`) for (upper if `uplo = U`, lower if `uplo = L`)
+Solves `A * X = B` (`trans = N`), `Transpose(A) * X = B` (`trans = T`), or
+`Adjoint(A) * X = B` (`trans = C`) for (upper if `uplo = U`, lower if `uplo = L`)
 triangular matrix `A`. If `diag = N`, `A` has non-unit diagonal elements.
 If `diag = U`, all diagonal elements of `A` are one. `B` is overwritten
 with the solution `X`.
@@ -3601,7 +3601,7 @@ trevc!(side::Char, howmny::Char, select::StridedVector{BlasInt}, T::StridedMatri
     trrfs!(uplo, trans, diag, A, B, X, Ferr, Berr) -> (Ferr, Berr)
 
 Estimates the error in the solution to `A * X = B` (`trans = N`),
-`A.' * X = B` (`trans = T`), `A' * X = B` (`trans = C`) for `side = L`,
+`Transpose(A) * X = B` (`trans = T`), `Adjoint(A) * X = B` (`trans = C`) for `side = L`,
 or the equivalent equations a right-handed `side = R` `X * A` after
 computing `X` using `trtrs!`. If `uplo = U`, `A` is upper triangular.
 If `uplo = L`, `A` is lower triangular. If `diag = N`, `A` has non-unit

--- a/base/linalg/lq.jl
+++ b/base/linalg/lq.jl
@@ -37,7 +37,7 @@ lqfact(x::Number) = lqfact(fill(x,1,1))
 
 Perform an LQ factorization of `A` such that `A = L*Q`. The default (`full = false`)
 computes a factorization with possibly-rectangular `L` and `Q`, commonly the "thin"
-factorization. The LQ factorization is the QR factorization of `A.'`. If the explicit,
+factorization. The LQ factorization is the QR factorization of `Transpose(A)`. If the explicit,
 full/square form of `Q` is requested via `full = true`, `L` is not extended with zeros.
 
 !!! note

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -590,7 +590,7 @@ function ldiv!(adjA::Adjoint{<:Any,LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat)
     return B
 end
 
-/(B::AbstractMatrix,A::LU) = \(Transpose(A),Transpose(B)).'
+/(B::AbstractMatrix,A::LU) = transpose(Transpose(A) \ Transpose(B))
 
 # Conversions
 convert(::Type{AbstractMatrix}, F::LU) = (F[:L] * F[:U])[invperm(F[:p]),:]

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -475,7 +475,7 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
                 s = zero(A[aoffs + 1]*B[1] + A[aoffs + 1]*B[1])
             end
             for i = 1:nA
-                s += A[aoffs+i].'B[i]
+                s += Transpose(A[aoffs+i]) * B[i]
             end
             C[k] = s
         end
@@ -629,7 +629,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     z2 = zero(A[i, 1]*B[j, 1] + A[i, 1]*B[j, 1])
                     Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
-                        Ctmp += A[i, k]*B[j, k].'
+                        Ctmp += A[i, k] * Transpose(B[j, k])
                     end
                     C[i,j] = Ctmp
                 end
@@ -649,7 +649,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     z2 = zero(A[1, i]*B[1, j] + A[1, i]*B[1, j])
                     Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
-                        Ctmp += A[k, i].'B[k, j]
+                        Ctmp += Transpose(A[k, i]) * B[k, j]
                     end
                     C[i,j] = Ctmp
                 end
@@ -658,7 +658,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
                     Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
-                        Ctmp += A[k, i].'B[j, k].'
+                        Ctmp += Transpose(A[k, i]) * Transpose(B[j, k])
                     end
                     C[i,j] = Ctmp
                 end
@@ -667,7 +667,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
                     Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
-                        Ctmp += A[k, i].'B[j, k]'
+                        Ctmp += Transpose(A[k, i]) * Adjoint(B[j, k])
                     end
                     C[i,j] = Ctmp
                 end
@@ -687,7 +687,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
                     z2 = zero(A[1, i]*B[j, 1] + A[1, i]*B[j, 1])
                     Ctmp = convert(promote_type(R, typeof(z2)), z2)
                     for k = 1:nA
-                        Ctmp += A[k, i]'B[j, k].'
+                        Ctmp += Adjoint(A[k, i]) * Transpose(B[j, k])
                     end
                     C[i,j] = Ctmp
                 end

--- a/base/linalg/rowvector.jl
+++ b/base/linalg/rowvector.jl
@@ -5,13 +5,12 @@
 
 A lazy-view wrapper of an [`AbstractVector`](@ref), which turns a length-`n` vector into a `1×n`
 shaped row vector and represents the transpose of a vector (the elements are also transposed
-recursively). This type is usually constructed (and unwrapped) via the [`transpose`](@ref)
-function or `.'` operator (or related [`adjoint`](@ref) or `'` operator).
+recursively).
 
 By convention, a vector can be multiplied by a matrix on its left (`A * v`) whereas a row
-vector can be multiplied by a matrix on its right (such that `v.' * A = (A.' * v).'`). It
+vector can be multiplied by a matrix on its right (such that `RowVector(v) * A = RowVector(Transpose(A) * v)`). It
 differs from a `1×n`-sized matrix by the facts that its transpose returns a vector and the
-inner product `v1.' * v2` returns a scalar, but will otherwise behave similarly.
+inner product `RowVector(v1) * v2` returns a scalar, but will otherwise behave similarly.
 
 # Examples
 ```jldoctest
@@ -26,21 +25,17 @@ julia> RowVector(a)
 1×4 RowVector{Int64,Array{Int64,1}}:
  1  2  3  4
 
-julia> a.'
-1×4 RowVector{Int64,Array{Int64,1}}:
- 1  2  3  4
-
-julia> a.'[3]
+julia> RowVector(a)[3]
 3
 
-julia> a.'[1,3]
+julia> RowVector(a)[1,3]
 3
 
-julia> a.'[3,1]
+julia> RowVector(a)[3,1]
 ERROR: BoundsError: attempt to access 1×4 RowVector{Int64,Array{Int64,1}} at index [3, 1]
 [...]
 
-julia> a.'*a
+julia> RowVector(a)*a
 30
 
 julia> B = [1 2; 3 4; 5 6; 7 8]
@@ -50,7 +45,7 @@ julia> B = [1 2; 3 4; 5 6; 7 8]
  5  6
  7  8
 
-julia> a.'*B
+julia> RowVector(a)*B
 1×2 RowVector{Int64,Array{Int64,1}}:
  50  60
 ```
@@ -148,7 +143,7 @@ Return a [`ConjArray`](@ref) lazy view of the input, where each element is conju
 
 # Examples
 ```jldoctest
-julia> v = [1+im, 1-im].'
+julia> v = RowVector([1+im, 1-im])
 1×2 RowVector{Complex{Int64},Array{Complex{Int64},1}}:
  1+1im  1-1im
 
@@ -214,7 +209,7 @@ IndexStyle(::Type{<:RowVector}) = IndexLinear()
     end
     sum(@inbounds(return rowvec[i]*vec[i]) for i = 1:length(vec))
 end
-@inline *(rowvec::RowVector, mat::AbstractMatrix) = rvtranspose(mat.' * rvtranspose(rowvec))
+@inline *(rowvec::RowVector, mat::AbstractMatrix) = rvtranspose(Transpose(mat) * rvtranspose(rowvec))
 *(::RowVector, ::RowVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))
 @inline *(vec::AbstractVector, rowvec::RowVector) = vec .* rowvec
 *(vec::AbstractVector, rowvec::AbstractVector) = throw(DimensionMismatch("Cannot multiply two vectors"))
@@ -238,7 +233,7 @@ end
 *(transvec::Transpose{<:Any,<:AbstractVector}, transrowvec::Transpose{<:Any,<:RowVector}) =
     transpose(transvec.parent)*rvtranspose(transrowvec.parent)
 *(transmat::Transpose{<:Any,<:AbstractMatrix}, transrowvec::Transpose{<:Any,<:RowVector}) =
-    (transmat.parent).' * rvtranspose(transrowvec.parent)
+    transmat * rvtranspose(transrowvec.parent)
 
 *(::Transpose{<:Any,<:RowVector}, ::AbstractVector) =
     throw(DimensionMismatch("Cannot multiply two vectors"))

--- a/base/linalg/symmetric.jl
+++ b/base/linalg/symmetric.jl
@@ -38,7 +38,7 @@ julia> Slower = Symmetric(A, :L)
  2  0  3  0  4
 ```
 
-Note that `Supper` will not be equal to `Slower` unless `A` is itself symmetric (e.g. if `A == A.'`).
+Note that `Supper` will not be equal to `Slower` unless `A` is itself symmetric (e.g. if `A == Transpose(A)`).
 """
 Symmetric(A::AbstractMatrix, uplo::Symbol=:U) = (checksquare(A); Symmetric{eltype(A),typeof(A)}(A, char_uplo(uplo)))
 
@@ -261,13 +261,13 @@ end
 
 function tril(A::Symmetric, k::Integer=0)
     if A.uplo == 'U' && k <= 0
-        return tril!(A.data.',k)
+        return tril!(transpose(A.data),k)
     elseif A.uplo == 'U' && k > 0
-        return tril!(A.data.',-1) + tril!(triu(A.data),k)
+        return tril!(transpose(A.data),-1) + tril!(triu(A.data),k)
     elseif A.uplo == 'L' && k <= 0
         return tril(A.data,k)
     else
-        return tril(A.data,-1) + tril!(triu!(A.data.'),k)
+        return tril(A.data,-1) + tril!(triu!(transpose(A.data)),k)
     end
 end
 
@@ -287,11 +287,11 @@ function triu(A::Symmetric, k::Integer=0)
     if A.uplo == 'U' && k >= 0
         return triu(A.data,k)
     elseif A.uplo == 'U' && k < 0
-        return triu(A.data,1) + triu!(tril!(A.data.'),k)
+        return triu(A.data,1) + triu!(tril!(transpose(A.data)),k)
     elseif A.uplo == 'L' && k >= 0
-        return triu!(A.data.',k)
+        return triu!(transpose(A.data),k)
     else
-        return triu!(A.data.',1) + triu!(tril(A.data),k)
+        return triu!(transpose(A.data),1) + triu!(tril(A.data),k)
     end
 end
 

--- a/base/linalg/transpose.jl
+++ b/base/linalg/transpose.jl
@@ -147,7 +147,7 @@ end
 """
     transpose(A::AbstractMatrix)
 
-The transposition operator (`.'`). Note that the transposition is applied recursively to
+Eager matrix transpose. Note that the transposition is applied recursively to
 elements.
 
 This operation is intended for linear algebra usage - for general data manipulation see

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -795,9 +795,9 @@ function mul!(transA::Transpose{<:Any,<:UpperTriangular}, B::StridedVecOrMat)
     end
     for j = 1:n
         for i = m:-1:1
-            Bij = A.data[i,i].'B[i,j]
+            Bij = Transpose(A.data[i,i]) * B[i,j]
             for k = 1:i - 1
-                Bij += A.data[k,i].'B[k,j]
+                Bij += Transpose(A.data[k,i]) * B[k,j]
             end
             B[i,j] = Bij
         end
@@ -814,7 +814,7 @@ function mul!(transA::Transpose{<:Any,<:UnitUpperTriangular}, B::StridedVecOrMat
         for i = m:-1:1
             Bij = B[i,j]
             for k = 1:i - 1
-                Bij += A.data[k,i].'B[k,j]
+                Bij += Transpose(A.data[k,i]) * B[k,j]
             end
             B[i,j] = Bij
         end
@@ -830,9 +830,9 @@ function mul!(transA::Transpose{<:Any,<:LowerTriangular}, B::StridedVecOrMat)
     end
     for j = 1:n
         for i = 1:m
-            Bij = A.data[i,i].'B[i,j]
+            Bij = Transpose(A.data[i,i]) * B[i,j]
             for k = i + 1:m
-                Bij += A.data[k,i].'B[k,j]
+                Bij += Transpose(A.data[k,i]) * B[k,j]
             end
             B[i,j] = Bij
         end
@@ -849,7 +849,7 @@ function mul!(transA::Transpose{<:Any,<:UnitLowerTriangular}, B::StridedVecOrMat
         for i = 1:m
             Bij = B[i,j]
             for k = i + 1:m
-                Bij += A.data[k,i].'B[k,j]
+                Bij += Transpose(A.data[k,i]) * B[k,j]
             end
             B[i,j] = Bij
         end
@@ -1001,9 +1001,9 @@ function mul!(A::StridedMatrix, transB::Transpose{<:Any,<:UpperTriangular})
     end
     for i = 1:m
         for j = 1:n
-            Aij = A[i,j]*B.data[j,j].'
+            Aij = A[i,j] * Transpose(B.data[j,j])
             for k = j + 1:n
-                Aij += A[i,k]*B.data[j,k].'
+                Aij += A[i,k] * Transpose(B.data[j,k])
             end
             A[i,j] = Aij
         end
@@ -1020,7 +1020,7 @@ function mul!(A::StridedMatrix, transB::Transpose{<:Any,<:UnitUpperTriangular})
         for j = 1:n
             Aij = A[i,j]
             for k = j + 1:n
-                Aij += A[i,k]*B.data[j,k].'
+                Aij += A[i,k] * Transpose(B.data[j,k])
             end
             A[i,j] = Aij
         end
@@ -1036,9 +1036,9 @@ function mul!(A::StridedMatrix, transB::Transpose{<:Any,<:LowerTriangular})
     end
     for i = 1:m
         for j = n:-1:1
-            Aij = A[i,j]*B.data[j,j].'
+            Aij = A[i,j] * Transpose(B.data[j,j])
             for k = 1:j - 1
-                Aij += A[i,k]*B.data[j,k].'
+                Aij += A[i,k] * Transpose(B.data[j,k])
             end
             A[i,j] = Aij
         end
@@ -1055,7 +1055,7 @@ function mul!(A::StridedMatrix, transB::Transpose{<:Any,<:UnitLowerTriangular})
         for j = n:-1:1
             Aij = A[i,j]
             for k = 1:j - 1
-                Aij += A[i,k]*B.data[j,k].'
+                Aij += A[i,k] * Transpose(B.data[j,k])
             end
             A[i,j] = Aij
         end
@@ -1398,9 +1398,9 @@ function rdiv!(A::StridedMatrix, transB::Transpose{<:Any,<:UpperTriangular})
         for j = n:-1:1
             Aij = A[i,j]
             for k = j + 1:n
-                Aij -= A[i,k]*B.data[j,k].'
+                Aij -= A[i,k] * Transpose(B.data[j,k])
             end
-            A[i,j] = Aij/B.data[j,j].'
+            A[i,j] = Aij / Transpose(B.data[j,j])
         end
     end
     A
@@ -1415,7 +1415,7 @@ function rdiv!(A::StridedMatrix, transB::Transpose{<:Any,<:UnitUpperTriangular})
         for j = n:-1:1
             Aij = A[i,j]
             for k = j + 1:n
-                Aij -= A[i,k]*B.data[j,k].'
+                Aij -= A[i,k] * Transpose(B.data[j,k])
             end
             A[i,j] = Aij
         end
@@ -1433,9 +1433,9 @@ function rdiv!(A::StridedMatrix, transB::Transpose{<:Any,<:LowerTriangular})
         for j = 1:n
             Aij = A[i,j]
             for k = 1:j - 1
-                Aij -= A[i,k]*B.data[j,k].'
+                Aij -= A[i,k] * Transpose(B.data[j,k])
             end
-            A[i,j] = Aij/B.data[j,j].'
+            A[i,j] = Aij / Transpose(B.data[j,j])
         end
     end
     A
@@ -1450,7 +1450,7 @@ function rdiv!(A::StridedMatrix, transB::Transpose{<:Any,<:UnitLowerTriangular})
         for j = 1:n
             Aij = A[i,j]
             for k = 1:j - 1
-                Aij -= A[i,k]*B.data[j,k].'
+                Aij -= A[i,k] * Transpose(B.data[j,k])
             end
             A[i,j] = Aij
         end
@@ -1928,7 +1928,7 @@ function powm!(A0::UpperTriangular{<:BlasFloat}, p::Real)
     scale!(S, normA0^p)
     return S
 end
-powm(A::LowerTriangular, p::Real) = powm(A.', p::Real).'
+powm(A::LowerTriangular, p::Real) = transpose(powm(transpose(A), p::Real))
 
 # Complex matrix logarithm for the upper triangular factor, see:
 #   Al-Mohy and Higham, "Improved inverse  scaling and squaring algorithms for
@@ -2112,7 +2112,7 @@ function log(A0::UpperTriangular{T}) where T<:BlasFloat
 
     return UpperTriangular(Y)
 end
-log(A::LowerTriangular) = log(A.').'
+log(A::LowerTriangular) = transpose(log(transpose(A)))
 
 # Auxiliary functions for matrix logarithm and matrix power
 
@@ -2320,8 +2320,8 @@ function sqrt(A::UnitUpperTriangular{T}) where T
     end
     return UnitUpperTriangular(R)
 end
-sqrt(A::LowerTriangular) = sqrt(A.').'
-sqrt(A::UnitLowerTriangular) = sqrt(A.').'
+sqrt(A::LowerTriangular) = transpose(sqrt(transpose(A)))
+sqrt(A::UnitLowerTriangular) = transpose(sqrt(transpose(A)))
 
 # Generic eigensystems
 eigvals(A::AbstractTriangular) = diag(A)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1525,17 +1525,8 @@
                       ,(expand-forms (cadr b)))
                `(call ,(aref ops 1) #;Ac_mul_B ,(expand-forms (cadr a))
                       ,(expand-forms b))))
-          ((trans? a)
-           (if (trans? b)
-               `(call ,(aref ops 2) #;At_mul_Bt ,(expand-forms (cadr a))
-                      ,(expand-forms (cadr b)))
-               `(call ,(aref ops 3) #;At_mul_B ,(expand-forms (cadr a))
-                      ,(expand-forms b))))
           ((ctrans? b)
-           `(call ,(aref ops 4) #;A_mul_Bc ,(expand-forms a)
-                  ,(expand-forms (cadr b))))
-          ((trans? b)
-           `(call ,(aref ops 5) #;A_mul_Bt ,(expand-forms a)
+           `(call ,(aref ops 2) #;A_mul_Bc ,(expand-forms a)
                   ,(expand-forms (cadr b))))
           (else
            `(call ,(cadr e) ,(expand-forms a) ,(expand-forms b))))))
@@ -2223,15 +2214,15 @@
                  ((and (eq? f '*) (length= e 4))
                   (expand-transposed-op
                    e
-                   #(Ac_mul_Bc Ac_mul_B At_mul_Bt At_mul_B A_mul_Bc A_mul_Bt)))
+                   #(Ac_mul_Bc Ac_mul_B A_mul_Bc)))
                  ((and (eq? f '/) (length= e 4))
                   (expand-transposed-op
                    e
-                   #(Ac_rdiv_Bc Ac_rdiv_B At_rdiv_Bt At_rdiv_B A_rdiv_Bc A_rdiv_Bt)))
+                   #(Ac_rdiv_Bc Ac_rdiv_B A_rdiv_Bc)))
                  ((and (eq? f '\\) (length= e 4))
                   (expand-transposed-op
                    e
-                   #(Ac_ldiv_Bc Ac_ldiv_B At_ldiv_Bt At_ldiv_B A_ldiv_Bc A_ldiv_Bt)))
+                   #(Ac_ldiv_Bc Ac_ldiv_B A_ldiv_Bc)))
                  (else
                   (map expand-forms e))))
          (map expand-forms e)))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2395,7 +2395,38 @@
             `(call (top typed_vcat) ,t ,@a)))))
 
    '|'|  (lambda (e) (expand-forms `(call adjoint ,(cadr e))))
-   '|.'| (lambda (e) (expand-forms `(call transpose ,(cadr e))))
+   '|.'| (lambda (e) (begin (deprecation-message (string "The syntax `.'` for transposition is deprecated, "
+                                             "and the special lowering of `.'` in multiplication "
+                                             "(`*`), left-division (`\\`), and right-division (`/`) "
+                                             "operations, for example `A.'*B` lowering to `At_mul_B(A, B)`, "
+                                             "`A\\B.'` lowering to `A_ldiv_Bt(A, B)`, and `A.'/B.'` "
+                                             "lowering to `At_rdiv_Bt(A, B)`, has been removed "
+                                             "in favor of a lazy `Transpose` wrapper type and "
+                                             "dispatch on that type. Two rewrites for `A.'` for "
+                                             "matrix `A` exist: eager or materializing `transpose(A)`, "
+                                             "which constructs a freshly allocated matrix of `A`'s type "
+                                             "and containing the transpose of `A`, and lazy "
+                                             "`Transpose(A)`, which wraps `A` in a `Transpose` "
+                                             "view type. Which rewrite is appropriate depends on "
+                                             "context: If `A.'` appears in a multiplication, "
+                                             "left-division, or right-division operation that "
+                                             "was formerly specially lowered to an `A_mul_B`-like "
+                                             "call, then the lazy `Tranpose(A)` is the correct "
+                                             "replacement and will result in dispatch to a method "
+                                             "equivalent to the former `A_mul_B`-like call. For "
+                                             "example, `A.'*B`, formerly yielding `At_mul_B(A, B)`, "
+                                             "should be rewritten `Transpose(A)*B`, which will "
+                                             "dispatch to a method equivalent to the former "
+                                             "`At_mul_B(A, B)` method. If `A.'` appears outside "
+                                             "such an operation, then `transpose(A)` is the "
+                                             "correct rewrite. For vector `A`, `A.'` already "
+                                             "transposed lazily to a `RowVector`, so `Transpose(A)`. "
+                                             "which now yields a `Transpose`-wrapped vector "
+                                             "behaviorally equivalent to the former `RowVector` "
+                                             "is always the correct rewrite for vectors. For "
+                                             "more information, see issue #5332 on Julia's "
+                                             "issue tracker on GitHub." #\newline))
+                            (return (expand-forms `(call transpose ,(cadr e))))))
 
    'generator
    (lambda (e)

--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -88,9 +88,9 @@ using Test
             @test_throws DimensionMismatch eigs(a, v0=zeros(elty,n+2))
             @test_throws ArgumentError eigs(a, v0=zeros(Int,n))
             if elty == Float64
-                @test_throws ArgumentError eigs(a+a.',which=:SI)
-                @test_throws ArgumentError eigs(a+a.',which=:LI)
-                @test_throws ArgumentError eigs(a,sigma=rand(ComplexF32))
+                @test_throws ArgumentError eigs(a + transpose(a), which=:SI)
+                @test_throws ArgumentError eigs(a + transpose(a), which=:LI)
+                @test_throws ArgumentError eigs(a, sigma = rand(ComplexF32))
             end
         end
     end

--- a/stdlib/SuiteSparse/src/umfpack_h.jl
+++ b/stdlib/SuiteSparse/src/umfpack_h.jl
@@ -4,20 +4,20 @@
 
 ## Type of solve
 const UMFPACK_A     =  0     # Ax=b
-const UMFPACK_At    =  1     # A'x=b
-const UMFPACK_Aat   =  2     # A.'x=b
-const UMFPACK_Pt_L  =  3     # P'Lx=b
+const UMFPACK_At    =  1     # Adjoint(A)x=b
+const UMFPACK_Aat   =  2     # Transpose(A)x=b
+const UMFPACK_Pt_L  =  3     # Adjoint(P)Lx=b
 const UMFPACK_L     =  4     # Lx=b
-const UMFPACK_Lt_P  =  5     # L'Px=b
-const UMFPACK_Lat_P =  6     # L.'Px=b
-const UMFPACK_Lt    =  7     # L'x=b
-const UMFPACK_Lat   =  8     # L.'x=b
-const UMFPACK_U_Qt  =  9     # UQ'x=b
+const UMFPACK_Lt_P  =  5     # Adjoint(L)Px=b
+const UMFPACK_Lat_P =  6     # Transpose(L)Px=b
+const UMFPACK_Lt    =  7     # Adjoint(L)x=b
+const UMFPACK_Lat   =  8     # Transpose(L)x=b
+const UMFPACK_U_Qt  =  9     # U*Adjoint(Q)x=b
 const UMFPACK_U     =  10    # Ux=b
-const UMFPACK_Q_Ut  =  11    # QU'x=b
-const UMFPACK_Q_Uat =  12    # QU.'x=b
-const UMFPACK_Ut    =  13    # U'x=b
-const UMFPACK_Uat   =  14    # U.'x=b
+const UMFPACK_Q_Ut  =  11    # Q*Adjoint(U)x=b
+const UMFPACK_Q_Uat =  12    # Q*Transpose(U)x=b
+const UMFPACK_Ut    =  13    # Adjoint(U)x=b
+const UMFPACK_Uat   =  14    # Transpose(U)x=b
 
 ## Sizes of Control and Info arrays for returning information from solver
 const UMFPACK_INFO = 90

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -391,7 +391,7 @@ end
     @test_throws DimensionMismatch F\CHOLMOD.Sparse(sparse(ones(elty, 4)))
     @test F'\ones(elty, 5) ≈ Array(A1pd)'\ones(5)
     @test F'\sparse(ones(elty, 5)) ≈ Array(A1pd)'\ones(5)
-    @test F.'\ones(elty, 5) ≈ conj(A1pd)'\ones(elty, 5)
+    @test Transpose(F)\ones(elty, 5) ≈ conj(A1pd)'\ones(elty, 5)
     @test logdet(F) ≈ logdet(Array(A1pd))
     @test det(F) == exp(logdet(F))
     let # to test supernodal, we must use a larger matrix
@@ -706,8 +706,8 @@ end
     @test Fs\ones(4) ≈ Fd\ones(4)
 end
 
-@testset "\\ '\\ and .'\\" begin
-    # Test that \ and '\ and .'\ work for Symmetric and Hermitian. This is just
+@testset "\\ '\\ and Transpose(...)\\" begin
+    # Test that \ and '\ and Transpose(...)\ work for Symmetric and Hermitian. This is just
     # a dispatch exercise so it doesn't matter that the complex matrix has
     # zero imaginary parts
     Apre = sprandn(10, 10, 0.2) - I
@@ -718,7 +718,7 @@ end
         x = ones(10)
         b = A*x
         @test x ≈ A\b
-        @test A.'\b ≈ A'\b
+        @test Transpose(A)\b ≈ A'\b
     end
 end
 

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -55,17 +55,17 @@
             @test y ≈ x
 
             @test A'*x ≈ b
-            x = lua.'\b
+            x = Transpose(lua) \ b
             @test x ≈ float([1:5;])
 
-            @test A.'*x ≈ b
+            @test Transpose(A) * x ≈ b
             x = SuiteSparse.ldiv!(Transpose(lua), complex.(b))
             @test x ≈ float([1:5;])
             y = similar(x)
             SuiteSparse.ldiv!(y, Transpose(lua), complex.(b))
             @test y ≈ x
 
-            @test A.'*x ≈ b
+            @test Transpose(A) * x ≈ b
 
             # Element promotion and type inference
             @inferred lua\ones(Int, size(A, 2))
@@ -84,8 +84,8 @@
             @test Ac\b ≈ x
             b  = Ac'*x
             @test Ac'\b ≈ x
-            b  = Ac.'*x
-            @test Ac.'\b ≈ x
+            b  = Transpose(Ac)*x
+            @test Transpose(Ac)\b ≈ x
         end
     end
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -610,7 +610,7 @@ let A, B, C, D
     C = unique(B, 1)
     @test sortrows(C) == sortrows(A)
     @test unique(B, 2) == B
-    @test unique(B.', 2).' == C
+    @test transpose(unique(transpose(B), 2)) == C
 
     # Along third dimension
     D = cat(3, B, B)
@@ -1342,14 +1342,14 @@ end
 @test size([]') == (1,0)
 
 # issue #6996
-@test Any[ 1 2; 3 4 ]' == Any[ 1 2; 3 4 ].'
+@test adjoint(Any[ 1 2; 3 4 ]) == transpose(Any[ 1 2; 3 4 ])
 
 # map with promotion (issue #6541)
 @test map(join, ["z", "я"]) == ["z", "я"]
 
 # Handle block matrices
 let A = [randn(2, 2) for i = 1:2, j = 1:2]
-    @test issymmetric(A.'A)
+    @test issymmetric(Transpose(A)*A)
 end
 let A = [complex.(randn(2, 2), randn(2, 2)) for i = 1:2, j = 1:2]
     @test ishermitian(A'A)

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1390,7 +1390,7 @@ timesofar("cat")
     end
 
     b1 = bitrand(n1,n1)
-    b1 .|= b1.'
+    b1 .|= transpose(b1)
     @check_bit_operation issymmetric(b1) Bool
     @check_bit_operation ishermitian(b1) Bool
 

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -163,21 +163,21 @@ srand(1)
             condT = cond(map(ComplexF64,Tfull))
             promty = typeof((zero(relty)*zero(relty) + zero(relty)*zero(relty))/one(relty))
             if relty != BigFloat
-                x = T.'\c.'
-                tx = Tfull.' \ c.'
+                x = Transpose(T)\Transpose(c)
+                tx = Transpose(Tfull) \ Transpose(c)
                 elty <: AbstractFloat && @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
-                @test_throws DimensionMismatch T.'\b.'
-                x = T'\c.'
-                tx = Tfull' \ c.'
+                @test_throws DimensionMismatch Transpose(T)\Transpose(b)
+                x = T'\transpose(c)
+                tx = Tfull'\transpose(c)
                 @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
-                @test_throws DimensionMismatch T'\b.'
-                x = T\c.'
-                tx = Tfull\c.'
+                @test_throws DimensionMismatch T'\transpose(b)
+                x = T\Transpose(c)
+                tx = Tfull\Transpose(c)
                 @test norm(x-tx,Inf) <= 4*condT*max(eps()*norm(tx,Inf), eps(promty)*norm(x,Inf))
-                @test_throws DimensionMismatch T\b.'
+                @test_throws DimensionMismatch T\Transpose(b)
             end
             @test_throws DimensionMismatch T \ ones(elty,n+1,2)
-            @test_throws DimensionMismatch T.' \ ones(elty,n+1,2)
+            @test_throws DimensionMismatch Transpose(T) \ ones(elty,n+1,2)
             @test_throws DimensionMismatch T' \ ones(elty,n+1,2)
 
             let bb = b, cc = c

--- a/test/linalg/blas.jl
+++ b/test/linalg/blas.jl
@@ -14,10 +14,10 @@ srand(100)
         end
         U = convert(Array{elty, 2}, U)
         V = convert(Array{elty, 2}, V)
-        @test tril(LinAlg.BLAS.syr2k('L','N',U,V)) ≈ tril(U*V.' + V*U.')
-        @test triu(LinAlg.BLAS.syr2k('U','N',U,V)) ≈ triu(U*V.' + V*U.')
-        @test tril(LinAlg.BLAS.syr2k('L','T',U,V)) ≈ tril(U.'*V + V.'*U)
-        @test triu(LinAlg.BLAS.syr2k('U','T',U,V)) ≈ triu(U.'*V + V.'*U)
+        @test tril(LinAlg.BLAS.syr2k('L','N',U,V)) ≈ tril(U*Transpose(V) + V*Transpose(U))
+        @test triu(LinAlg.BLAS.syr2k('U','N',U,V)) ≈ triu(U*Transpose(V) + V*Transpose(U))
+        @test tril(LinAlg.BLAS.syr2k('L','T',U,V)) ≈ tril(Transpose(U)*V + Transpose(V)*U)
+        @test triu(LinAlg.BLAS.syr2k('U','T',U,V)) ≈ triu(Transpose(U)*V + Transpose(V)*U)
     end
 
     if elty in (ComplexF32, ComplexF64)
@@ -134,9 +134,9 @@ srand(100)
             @test_throws DimensionMismatch BLAS.ger!(α,ones(elty,n+1),y,copy(A))
 
             A = rand(elty,n,n)
-            A = A + A.'
+            A = A + transpose(A)
             @test issymmetric(A)
-            @test triu(BLAS.syr!('U',α,x,copy(A))) ≈ triu(A + α*x*x.')
+            @test triu(BLAS.syr!('U',α,x,copy(A))) ≈ triu(A + α*x*Transpose(x))
             @test_throws DimensionMismatch BLAS.syr!('U',α,ones(elty,n+1),copy(A))
 
             if elty <: Complex
@@ -163,8 +163,8 @@ srand(100)
         @testset "symmetric/Hermitian multiplication" begin
             x = rand(elty,n)
             A = rand(elty,n,n)
-            Aherm = A + A'
-            Asymm = A + A.'
+            Aherm = A + adjoint(A)
+            Asymm = A + transpose(A)
             @testset "symv and hemv" begin
                 @test BLAS.symv('U',Asymm,x) ≈ Asymm*x
                 @test_throws DimensionMismatch BLAS.symv!('U',one(elty),Asymm,x,one(elty),ones(elty,n+1))
@@ -313,10 +313,10 @@ end
 
 @testset "syr for eltype $elty" for elty in (Float32, Float64, Complex{Float32}, Complex{Float64})
     A = rand(elty, 5, 5)
-    @test triu(A[1,:] * A[1,:].') ≈ BLAS.syr!('U', one(elty), A[1,:], zeros(elty, 5, 5))
-    @test tril(A[1,:] * A[1,:].') ≈ BLAS.syr!('L', one(elty), A[1,:], zeros(elty, 5, 5))
-    @test triu(A[1,:] * A[1,:].') ≈ BLAS.syr!('U', one(elty), view(A, 1, :), zeros(elty, 5, 5))
-    @test tril(A[1,:] * A[1,:].') ≈ BLAS.syr!('L', one(elty), view(A, 1, :), zeros(elty, 5, 5))
+    @test triu(A[1,:] * Transpose(A[1,:])) ≈ BLAS.syr!('U', one(elty), A[1,:], zeros(elty, 5, 5))
+    @test tril(A[1,:] * Transpose(A[1,:])) ≈ BLAS.syr!('L', one(elty), A[1,:], zeros(elty, 5, 5))
+    @test triu(A[1,:] * Transpose(A[1,:])) ≈ BLAS.syr!('U', one(elty), view(A, 1, :), zeros(elty, 5, 5))
+    @test tril(A[1,:] * Transpose(A[1,:])) ≈ BLAS.syr!('L', one(elty), view(A, 1, :), zeros(elty, 5, 5))
 end
 
 @testset "her for eltype $elty" for elty in (Complex{Float32}, Complex{Float64})

--- a/test/linalg/bunchkaufman.jl
+++ b/test/linalg/bunchkaufman.jl
@@ -22,9 +22,9 @@ bimg  = randn(n,2)/2
 @testset "$eltya argument A" for eltya in (Float32, Float64, ComplexF32, ComplexF64, Int)
     a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
     a2 = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(a2real, a2img) : a2real)
-    asym = a.'+ a                  # symmetric indefinite
-    aher = a' + a                  # Hermitian indefinite
-    apd  = a' * a                  # Positive-definite
+    asym = transpose(a) + a                  # symmetric indefinite
+    aher = adjoint(a) + a                  # Hermitian indefinite
+    apd  = adjoint(a) * a                  # Positive-definite
     for (a, a2, aher, apd) in ((a, a2, aher, apd),
                                (view(a, 1:n, 1:n),
                                 view(a2, 1:n, 1:n),
@@ -46,11 +46,11 @@ bimg  = randn(n,2)/2
             end
             @test inv(bc1)*aher ≈ Matrix(I, n, n)
             @testset for rook in (false, true)
-                @test inv(bkfact(Symmetric(a.' + a, uplo), rook))*(a.' + a) ≈ Matrix(I, n, n)
+                @test inv(bkfact(Symmetric(transpose(a) + a, uplo), rook))*(transpose(a) + a) ≈ Matrix(I, n, n)
                 if eltya <: BlasFloat
                     # test also bkfact! without explicit type tag
                     # no bkfact! method for Int ... yet
-                    @test inv(bkfact!(a.' + a, rook))*(a.' + a) ≈ Matrix(I, n, n)
+                    @test inv(bkfact!(transpose(a) + a, rook))*(transpose(a) + a) ≈ Matrix(I, n, n)
                 end
                 @test size(bc1) == size(bc1.LD)
                 @test size(bc1, 1) == size(bc1.LD, 1)
@@ -64,8 +64,8 @@ bimg  = randn(n,2)/2
                     @test bc1[uplo]*bc1[:D]*bc1[uplo]' ≈ bc1[:P]*aher*bc1[:P]'
                 end
                 bc1 = bkfact(Symmetric(asym, uplo))
-                @test bc1[uplo]*bc1[:D]*bc1[uplo].' ≈ asym[bc1[:p], bc1[:p]]
-                @test bc1[uplo]*bc1[:D]*bc1[uplo].' ≈ bc1[:P]*asym*bc1[:P].'
+                @test bc1[uplo]*bc1[:D]*Transpose(bc1[uplo]) ≈ asym[bc1[:p], bc1[:p]]
+                @test bc1[uplo]*bc1[:D]*Transpose(bc1[uplo]) ≈ bc1[:P]*asym*Transpose(bc1[:P])
                 @test_throws KeyError bc1[:Z]
                 @test_throws ArgumentError uplo == :L ? bc1[:U] : bc1[:L]
             end

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -89,7 +89,7 @@ srand(1)
             @test D*v ≈ DM*v atol=n*eps(relty)*(1+(elty<:Complex))
             @test D*U ≈ DM*U atol=n^2*eps(relty)*(1+(elty<:Complex))
 
-            @test U.'*D ≈ U.'*Array(D)
+            @test Transpose(U)*D ≈ Transpose(U)*Array(D)
             @test U'*D ≈ U'*Array(D)
 
             if relty != BigFloat
@@ -147,15 +147,15 @@ srand(1)
                 b = rand(elty,n,n)
                 b = sparse(b)
                 @test mul!(copy(D), copy(b)) ≈ Array(D)*Array(b)
-                @test mul!(Transpose(copy(D)), copy(b)) ≈ Array(D).'*Array(b)
+                @test mul!(Transpose(copy(D)), copy(b)) ≈ Transpose(Array(D))*Array(b)
                 @test mul!(Adjoint(copy(D)), copy(b)) ≈ Array(D)'*Array(b)
             end
         end
 
         #a few missing mults
         bd = Bidiagonal(D2)
-        @test D*D2.' ≈ Array(D)*Array(D2).'
-        @test D2*D.' ≈ Array(D2)*Array(D).'
+        @test D*Transpose(D2) ≈ Array(D)*Transpose(Array(D2))
+        @test D2*Transpose(D) ≈ Array(D2)*Transpose(Array(D))
         @test D2*D' ≈ Array(D2)*Array(D)'
 
         #division of two Diagonals
@@ -166,12 +166,12 @@ srand(1)
         vvv = similar(vv)
         @test (r = Matrix(D) * vv   ; mul!(vvv, D, vv)  ≈ r ≈ vvv)
         @test (r = Matrix(D)' * vv  ; mul!(vvv, Adjoint(D), vv) ≈ r ≈ vvv)
-        @test (r = Matrix(D).' * vv ; mul!(vvv, Transpose(D), vv) ≈ r ≈ vvv)
+        @test (r = Transpose(Matrix(D)) * vv ; mul!(vvv, Transpose(D), vv) ≈ r ≈ vvv)
 
         UUU = similar(UU)
         @test (r = Matrix(D) * UU   ; mul!(UUU, D, UU) ≈ r ≈ UUU)
         @test (r = Matrix(D)' * UU  ; mul!(UUU, Adjoint(D), UU) ≈ r ≈ UUU)
-        @test (r = Matrix(D).' * UU ; mul!(UUU, Transpose(D), UU) ≈ r ≈ UUU)
+        @test (r = Transpose(Matrix(D)) * UU ; mul!(UUU, Transpose(D), UU) ≈ r ≈ UUU)
 
         # make sure that mul!(A, {Adj|Trans}(B)) works with B as a Diagonal
         VV = Array(D)
@@ -179,7 +179,7 @@ srand(1)
         r  = VV * Matrix(D)
         @test Array(mul!(VV, DD)) ≈ r ≈ Array(D)*Array(D)
         DD = copy(D)
-        r  = VV * (Array(D).')
+        r  = VV * Transpose(Array(D))
         @test Array(mul!(VV, Transpose(DD))) ≈ r
         DD = copy(D)
         r  = VV * (Array(D)')
@@ -228,7 +228,7 @@ srand(1)
         end
         # Translates to Ac/t_mul_B, which is specialized after issue 21286
         @test(D' * vv == conj(D) * vv)
-        @test(D.' * vv == D * vv)
+        @test(Transpose(D) * vv == D * vv)
     end
 
     #logdet
@@ -339,9 +339,9 @@ end
         D = Diagonal(randn(5))
         @test T*D   == Array(T)*Array(D)
         @test T'D   == Array(T)'*Array(D)
-        @test T.'D  == Array(T).'*Array(D)
+        @test Transpose(T)*D  == Transpose(Array(T))*Array(D)
         @test D*T'  == Array(D)*Array(T)'
-        @test D*T.' == Array(D)*Array(T).'
+        @test D*Transpose(T) == Array(D)*Transpose(Array(T))
         @test D*T   == Array(D)*Array(T)
     end
 end
@@ -364,16 +364,16 @@ end
     D = Diagonal([[1 2; 3 4], [1 2; 3 4]])
     Dherm = Diagonal([[1 1+im; 1-im 1], [1 1+im; 1-im 1]])
     Dsym = Diagonal([[1 1+im; 1+im 1], [1 1+im; 1+im 1]])
-    @test D' == Diagonal([[1 3; 2 4], [1 3; 2 4]])
-    @test D.' == Diagonal([[1 3; 2 4], [1 3; 2 4]])
-    @test Dherm' == Dherm
-    @test Dherm.' == Diagonal([[1 1-im; 1+im 1], [1 1-im; 1+im 1]])
-    @test Dsym' == Diagonal([[1 1-im; 1-im 1], [1 1-im; 1-im 1]])
-    @test Dsym.' == Dsym
+    @test adjoint(D) == Diagonal([[1 3; 2 4], [1 3; 2 4]])
+    @test transpose(D) == Diagonal([[1 3; 2 4], [1 3; 2 4]])
+    @test adjoint(Dherm) == Dherm
+    @test transpose(Dherm) == Diagonal([[1 1-im; 1+im 1], [1 1-im; 1+im 1]])
+    @test adjoint(Dsym) == Diagonal([[1 1-im; 1-im 1], [1 1-im; 1-im 1]])
+    @test transpose(Dsym) == Dsym
 
     v = [[1, 2], [3, 4]]
     @test Dherm' * v == Dherm * v
-    @test D.' * v == [[7, 10], [15, 22]]
+    @test Transpose(D) * v == [[7, 10], [15, 22]]
 
     @test issymmetric(D) == false
     @test issymmetric(Dherm) == false

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -352,7 +352,7 @@ end
 @testset "sytri, sytrs, and sytrf" begin
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         A = rand(elty,10,10)
-        A = A + A.' #symmetric!
+        A = A + transpose(A) #symmetric!
         B = copy(A)
         B,ipiv = LAPACK.sytrf!('U',B)
         @test triu(inv(A)) ≈ triu(LAPACK.sytri!('U',B,ipiv)) rtol=eps(cond(A))
@@ -363,14 +363,14 @@ end
     # Rook-pivoting variants
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         A = rand(elty, 10, 10)
-        A = A + A.' #symmetric!
+        A = A + transpose(A) #symmetric!
         B = copy(A)
         B,ipiv = LAPACK.sytrf_rook!('U', B)
         @test triu(inv(A)) ≈ triu(LAPACK.sytri_rook!('U', B, ipiv)) rtol=eps(cond(A))
         @test_throws DimensionMismatch LAPACK.sytrs_rook!('U', B, ipiv, rand(elty, 11, 5))
         @test LAPACK.sytrf_rook!('U',zeros(elty, 0, 0)) == (zeros(elty, 0, 0),zeros(BlasInt, 0))
         A = rand(elty, 10, 10)
-        A = A + A.' #symmetric!
+        A = A + transpose(A) #symmetric!
         b = rand(elty, 10)
         c = A \ b
         cnd = cond(A)
@@ -436,7 +436,7 @@ end
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         srand(123)
         A = rand(elty,10,10)
-        A = A + A.' #symmetric!
+        A = A + transpose(A) #symmetric!
         b = rand(elty,10)
         c = A \ b
         b,A = LAPACK.sysv!('U',A,b)
@@ -512,9 +512,9 @@ end
         A = rand(elty,10,10)/100
         A += real(diagm(0 => 10*real(rand(elty,10))))
         if elty <: Complex
-            A = A + A'
+            A = A + adjoint(A)
         else
-            A = A + A.'
+            A = A + transpose(A)
         end
         B = rand(elty,10,10)
         D = copy(A)

--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -73,10 +73,10 @@ rectangularQ(Q::LinAlg.LQPackedQ) = convert(Array, Q)
                         @test Matrix{eltyb}(I, n, n)*q ≈ convert(AbstractMatrix{tab},q)
                     end
                     @test q*b ≈ squareQ(q)*b atol=100ε
-                    @test q.'*b ≈ squareQ(q).'*b atol=100ε
+                    @test Transpose(q)*b ≈ Transpose(squareQ(q))*b atol=100ε
                     @test q'*b ≈ squareQ(q)'*b atol=100ε
                     @test a*q ≈ a*squareQ(q) atol=100ε
-                    @test a*q.' ≈ a*squareQ(q).' atol=100ε
+                    @test a*Transpose(q) ≈ a*Transpose(squareQ(q)) atol=100ε
                     @test a*q' ≈ a*squareQ(q)' atol=100ε
                     @test a'*q ≈ a'*squareQ(q) atol=100ε
                     @test a'*q' ≈ a'*squareQ(q)' atol=100ε
@@ -88,7 +88,7 @@ rectangularQ(Q::LinAlg.LQPackedQ) = convert(Array, Q)
                         pad_a = vcat(I, a)
                         pad_b = hcat(I, b)
                         @test pad_a*q ≈ pad_a*squareQ(q) atol=100ε
-                        @test q.'*pad_b ≈ squareQ(q).'*pad_b atol=100ε
+                        @test Transpose(q)*pad_b ≈ Transpose(squareQ(q))*pad_b atol=100ε
                         @test q'*pad_b ≈ squareQ(q)'*pad_b atol=100ε
                     end
                 end

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -110,8 +110,8 @@ dimg  = randn(n)/2
                     @test norm(a*(lua\cc) - cc, 1) < ε*κ*n # cc is a vector
                     @test norm(a'*(lua'\cc) - cc, 1) < ε*κ*n # cc is a vector
                     @test AbstractArray(lua) ≈ a
-                    @test norm(a.'*(lua.'\bb) - bb,1) < ε*κ*n*2 # Two because the right hand side has two columns
-                    @test norm(a.'*(lua.'\cc) - cc,1) < ε*κ*n
+                    @test norm(Transpose(a)*(Transpose(lua)\bb) - bb,1) < ε*κ*n*2 # Two because the right hand side has two columns
+                    @test norm(Transpose(a)*(Transpose(lua)\cc) - cc,1) < ε*κ*n
                 end
 
                 # Test whether Ax_ldiv_B!(y, LU, x) indeed overwrites y
@@ -127,8 +127,8 @@ dimg  = randn(n)/2
 
                 ldiv!(b_dest, Transpose(lua), b)
                 ldiv!(c_dest, Transpose(lua), c)
-                @test norm(b_dest - lua.' \ b, 1) < ε*κ*2n
-                @test norm(c_dest - lua.' \ c, 1) < ε*κ*n
+                @test norm(b_dest - Transpose(lua) \ b, 1) < ε*κ*2n
+                @test norm(c_dest - Transpose(lua) \ c, 1) < ε*κ*n
 
                 ldiv!(b_dest, Adjoint(lua), b)
                 ldiv!(c_dest, Adjoint(lua), c)
@@ -144,16 +144,16 @@ dimg  = randn(n)/2
             lud   = factorize(d)
             f = zeros(eltyb, n+1)
             @test_throws DimensionMismatch lud\f
-            @test_throws DimensionMismatch lud.'\f
+            @test_throws DimensionMismatch Transpose(lud)\f
             @test_throws DimensionMismatch lud'\f
             @test_throws DimensionMismatch Base.LinAlg.ldiv!(Transpose(lud), f)
             let Bs = copy(b)
                 for bb in (Bs, view(Bs, 1:n, 1))
                     @test norm(d*(lud\bb) - bb, 1) < ε*κd*n*2 # Two because the right hand side has two columns
                     if eltya <: Real
-                        @test norm((lud.'\bb) - Array(d.')\bb, 1) < ε*κd*n*2 # Two because the right hand side has two columns
+                        @test norm((Transpose(lud)\bb) - Array(transpose(d))\bb, 1) < ε*κd*n*2 # Two because the right hand side has two columns
                         if eltya != Int && eltyb != Int
-                            @test norm(Base.LinAlg.ldiv!(Transpose(lud), copy(bb)) - Array(d.')\bb, 1) < ε*κd*n*2
+                            @test norm(Base.LinAlg.ldiv!(Transpose(lud), copy(bb)) - Array(transpose(d))\bb, 1) < ε*κd*n*2
                         end
                     end
                     if eltya <: Complex
@@ -164,7 +164,7 @@ dimg  = randn(n)/2
             if eltya <: BlasFloat && eltyb <: BlasFloat
                 e = rand(eltyb,n,n)
                 @test norm(e/lud - e/d,1) < ε*κ*n^2
-                @test norm((lud.'\e') - Array(d.')\e',1) < ε*κd*n^2
+                @test norm((Transpose(lud)\e') - Array(transpose(d))\e',1) < ε*κd*n^2
                 #test singular
                 du = rand(eltya,n-1)
                 dl = rand(eltya,n-1)

--- a/test/linalg/matmul.jl
+++ b/test/linalg/matmul.jl
@@ -100,7 +100,7 @@ end
         @test mul!(C, Transpose(A), B) == A'*B
         @test mul!(C, A, Transpose(B)) == A*B'
         @test mul!(C, Transpose(A), Transpose(B)) == A'*B'
-        @test Base.LinAlg.mul!(C, Adjoint(A), Transpose(B)) == A'*B.'
+        @test Base.LinAlg.mul!(C, Adjoint(A), Transpose(B)) == A'*Transpose(B)
 
         #test DimensionMismatch for generic_matmatmul
         @test_throws DimensionMismatch Base.LinAlg.mul!(C, Adjoint(A), Transpose(ones(Int,4,4)))
@@ -137,9 +137,9 @@ end
     BB = rand(Float64,6,6)
     CC = zeros(Float64,6,6)
     for A in (copy(AA), view(AA, 1:6, 1:6)), B in (copy(BB), view(BB, 1:6, 1:6)), C in (copy(CC), view(CC, 1:6, 1:6))
-        @test Base.LinAlg.mul!(C, Transpose(A), Transpose(B)) == A.'*B.'
-        @test Base.LinAlg.mul!(C, A, Adjoint(B)) == A*B.'
-        @test Base.LinAlg.mul!(C, Adjoint(A), B) == A.'*B
+        @test Base.LinAlg.mul!(C, Transpose(A), Transpose(B)) == Transpose(A)*Transpose(B)
+        @test Base.LinAlg.mul!(C, A, Adjoint(B)) == A*Transpose(B)
+        @test Base.LinAlg.mul!(C, Adjoint(A), B) == Transpose(A)*B
     end
 end
 
@@ -222,7 +222,7 @@ end
     @test_throws BoundsError dot(x, 1:4, y, 1:4)
     @test_throws BoundsError dot(x, 1:3, y, 2:4)
     @test dot(x, 1:2,y, 1:2) == convert(elty, 12.5)
-    @test x.'*y == convert(elty, 29.0)
+    @test Transpose(x)*y == convert(elty, 29.0)
     @test_throws MethodError dot(rand(elty, 2, 2), randn(elty, 2, 2))
     X = convert(Vector{Matrix{elty}},[reshape(1:4, 2, 2), ones(2, 2)])
     res = convert(Matrix{elty}, [7.0 13.0; 13.0 27.0])
@@ -276,7 +276,7 @@ end
     @test_throws DimensionMismatch Base.LinAlg.gemm_wrapper!(I10x10,'N','N', I0x0, I0x0)
 
     A = rand(elty,3,3)
-    @test Base.LinAlg.matmul3x3('T','N',A, Matrix{elty}(I, 3, 3)) == A.'
+    @test Base.LinAlg.matmul3x3('T','N',A, Matrix{elty}(I, 3, 3)) == transpose(A)
 end
 
 @testset "#13593, #13488" begin

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -102,7 +102,7 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
                 @test (UpperTriangular(Matrix{eltya}(I, sq, sq))*q')*squareQ(q) ≈ Matrix(I, n1, n1)
                 @test q*r ≈ (isa(qrpa,QRPivoted) ? a[1:n1,p] : a[1:n1,:])
                 @test q*r[:,invperm(p)] ≈ a[1:n1,:]
-                @test q*r*qrpa[:P].' ≈ a[1:n1,:]
+                @test q*r*Transpose(qrpa[:P]) ≈ a[1:n1,:]
                 @test a[1:n1,:]*(qrpa\b[1:n1]) ≈ b[1:n1] atol=5000ε
                 @test Array(qrpa) ≈ a[1:5,:]
                 @test_throws DimensionMismatch q*b[1:n1+1]

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -40,10 +40,10 @@ aimg  = randn(n,n)/2
         @test vecs*sch*vecs' ≈ tril(a)
         sch, vecs, vals = schur(Hermitian(asym))
         @test vecs*sch*vecs' ≈ asym
-        sch, vecs, vals = schur(Symmetric(a+a.'))
-        @test vecs*sch*vecs' ≈ a + a.'
-        sch, vecs, vals = schur(Tridiagonal(a+a.'))
-        @test vecs*sch*vecs' ≈ Tridiagonal(a + a.')
+        sch, vecs, vals = schur(Symmetric(a + transpose(a)))
+        @test vecs*sch*vecs' ≈ a + transpose(a)
+        sch, vecs, vals = schur(Tridiagonal(a + transpose(a)))
+        @test vecs*sch*vecs' ≈ Tridiagonal(a + transpose(a))
 
         tstring = sprint(show,f[:T])
         zstring = sprint(show,f[:Z])

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -20,7 +20,7 @@ end
 
     A1 = randn(4,4)
     A3 = A1 * A1'
-    A4 = A1 + A1.'
+    A4 = A1 + transpose(A1)
     @test exp(A4) ≈ exp(Symmetric(A4))
     @test log(A3) ≈ log(Symmetric(A3))
     @test log(A3) ≈ log(Hermitian(A3))
@@ -32,10 +32,10 @@ end
     aimg  = randn(n,n)/2
     @testset for eltya in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
         a = eltya == Int ? rand(1:7, n, n) : convert(Matrix{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
-        asym = a.'+a                 # symmetric indefinite
-        aherm = a'+a                 # Hermitian indefinite
+        asym = transpose(a)+a                 # symmetric indefinite
+        aherm = adjoint(a)+a                 # Hermitian indefinite
         apos  = a'*a                 # Hermitian positive definite
-        aposs = apos + apos.'        # Symmetric positive definite
+        aposs = apos + transpose(apos)        # Symmetric positive definite
         ε = εa = eps(abs(float(one(eltya))))
 
         x = randn(n)
@@ -218,7 +218,7 @@ end
                     if eltya <: Real # the eigenvalues are only real and ordered for Hermitian matrices
                         d, v = eig(asym)
                         @test asym*v[:,1] ≈ d[1]*v[:,1]
-                        @test v*Diagonal(d)*v.' ≈ asym
+                        @test v*Diagonal(d)*Transpose(v) ≈ asym
                         @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
                         @test abs.(eigfact(Symmetric(asym), 1:2)[:vectors]'v[:,1:2]) ≈ Matrix(I, 2, 2)
                         eig(Symmetric(asym), 1:2) # same result, but checks that method works
@@ -289,9 +289,9 @@ end
         @testset "linalg binary ops" begin
             @testset "mat * vec" begin
                 @test Symmetric(asym)*x+y ≈ asym*x+y
-                # testing fallbacks for Transpose-vector * SymHerm.'
-                xadj = x.'
-                @test xadj * Symmetric(asym).' ≈ xadj * asym
+                # testing fallbacks for Transpose-vector * Transpose(SymHerm)
+                xadj = Transpose(x)
+                @test xadj * Transpose(Symmetric(asym)) ≈ xadj * asym
                 @test x' * Symmetric(asym) ≈ x' * asym
 
                 @test Hermitian(aherm)*x+y ≈ aherm*x+y
@@ -318,13 +318,13 @@ end
                 @test C ≈ a*asym
 
                 tri_b = UpperTriangular(triu(b))
-                @test Array(Hermitian(aherm).' * tri_b) ≈ aherm.' * Array(tri_b)
-                @test Array(tri_b * Hermitian(aherm).') ≈ Array(tri_b) * aherm.'
+                @test Array(Transpose(Hermitian(aherm)) * tri_b) ≈ Transpose(aherm) * Array(tri_b)
+                @test Array(tri_b * Transpose(Hermitian(aherm))) ≈ Array(tri_b) * Transpose(aherm)
                 @test Array(Hermitian(aherm)' * tri_b) ≈ aherm' * Array(tri_b)
                 @test Array(tri_b * Hermitian(aherm)') ≈ Array(tri_b) * aherm'
 
-                @test Array(Symmetric(asym).' * tri_b) ≈ asym.' * Array(tri_b)
-                @test Array(tri_b * Symmetric(asym).') ≈ Array(tri_b) * asym.'
+                @test Array(Transpose(Symmetric(asym)) * tri_b) ≈ Transpose(asym) * Array(tri_b)
+                @test Array(tri_b * Transpose(Symmetric(asym))) ≈ Array(tri_b) * Transpose(asym)
                 @test Array(Symmetric(asym)' * tri_b) ≈ asym' * Array(tri_b)
                 @test Array(tri_b * Symmetric(asym)') ≈ Array(tri_b) * asym'
             end

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -133,14 +133,14 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         # [c]transpose[!] (test views as well, see issue #14317)
         let vrange = 1:n-1, viewA1 = t1(view(A1.data, vrange, vrange))
             # transpose
-            @test A1.' == Matrix(A1).'
-            @test viewA1.' == Matrix(viewA1).'
+            @test transpose(A1) == transpose(Matrix(A1))
+            @test transpose(viewA1) == transpose(Matrix(viewA1))
             # adjoint
             @test A1' == Matrix(A1)'
             @test viewA1' == Matrix(viewA1)'
             # transpose!
-            @test transpose!(copy(A1)) == A1.'
-            @test transpose!(t1(view(copy(A1).data, vrange, vrange))) == viewA1.'
+            @test transpose!(copy(A1)) == transpose(A1)
+            @test transpose!(t1(view(copy(A1).data, vrange, vrange))) == transpose(viewA1)
             # adjoint!
             @test adjoint!(copy(A1)) == A1'
             @test adjoint!(t1(view(copy(A1).data, vrange, vrange))) == viewA1'
@@ -166,15 +166,15 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             B = similar(A1)
             copyto!(B, A1)
             @test B == A1
-            B = similar(A1.')
-            copyto!(B, A1.')
-            @test B == A1.'
+            B = similar(transpose(A1))
+            copyto!(B, transpose(A1))
+            @test B == transpose(A1)
             B = similar(viewA1)
             copyto!(B, viewA1)
             @test B == viewA1
-            B = similar(viewA1.')
-            copyto!(B, viewA1.')
-            @test B == viewA1.'
+            B = similar(transpose(viewA1))
+            copyto!(B, transpose(viewA1))
+            @test B == transpose(viewA1)
         end
 
         #exp/log
@@ -292,22 +292,22 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
 
                 # Triangular-Triangualar multiplication and division
                 @test A1*A2 ≈ Matrix(A1)*Matrix(A2)
-                @test A1.'A2 ≈ Matrix(A1).'Matrix(A2)
+                @test Transpose(A1)*A2 ≈ Transpose(Matrix(A1))*Matrix(A2)
                 @test A1'A2 ≈ Matrix(A1)'Matrix(A2)
-                @test A1*A2.' ≈ Matrix(A1)*Matrix(A2).'
+                @test A1*Transpose(A2) ≈ Matrix(A1)*Transpose(Matrix(A2))
                 @test A1*A2' ≈ Matrix(A1)*Matrix(A2)'
-                @test A1.'A2.' ≈ Matrix(A1).'Matrix(A2).'
+                @test Transpose(A1)*Transpose(A2) ≈ Transpose(Matrix(A1))*Transpose(Matrix(A2))
                 @test A1'A2' ≈ Matrix(A1)'Matrix(A2)'
                 @test A1/A2 ≈ Matrix(A1)/Matrix(A2)
                 @test A1\A2 ≈ Matrix(A1)\Matrix(A2)
                 offsizeA = Matrix{Float64}(I, n+1, n+1)
                 @test_throws DimensionMismatch offsizeA / A2
-                @test_throws DimensionMismatch offsizeA / A2.'
+                @test_throws DimensionMismatch offsizeA / Transpose(A2)
                 @test_throws DimensionMismatch offsizeA / A2'
                 @test_throws DimensionMismatch offsizeA * A2
-                @test_throws DimensionMismatch offsizeA * A2.'
+                @test_throws DimensionMismatch offsizeA * Transpose(A2)
                 @test_throws DimensionMismatch offsizeA * A2'
-                @test_throws DimensionMismatch A2.' * offsizeA
+                @test_throws DimensionMismatch Transpose(A2) * offsizeA
                 @test_throws DimensionMismatch A2'  * offsizeA
                 @test_throws DimensionMismatch A2   * offsizeA
             end
@@ -326,35 +326,35 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             # Triangular-dense Matrix/vector multiplication
             @test A1*B[:,1] ≈ Matrix(A1)*B[:,1]
             @test A1*B ≈ Matrix(A1)*B
-            @test A1.'B[:,1] ≈ Matrix(A1).'B[:,1]
+            @test Transpose(A1)*B[:,1] ≈ Transpose(Matrix(A1))*B[:,1]
             @test A1'B[:,1] ≈ Matrix(A1)'B[:,1]
-            @test A1.'B ≈ Matrix(A1).'B
+            @test Transpose(A1)*B ≈ Transpose(Matrix(A1))*B
             @test A1'B ≈ Matrix(A1)'B
-            @test A1*B.' ≈ Matrix(A1)*B.'
+            @test A1*Transpose(B) ≈ Matrix(A1)*Transpose(B)
             @test A1*B' ≈ Matrix(A1)*B'
             @test B*A1 ≈ B*Matrix(A1)
-            @test B[:,1].'A1 ≈ B[:,1].'Matrix(A1)
+            @test Transpose(B[:,1])*A1 ≈ Transpose(B[:,1])*Matrix(A1)
             @test B[:,1]'A1 ≈ B[:,1]'Matrix(A1)
-            @test B.'A1 ≈ B.'Matrix(A1)
+            @test Transpose(B)*A1 ≈ Transpose(B)*Matrix(A1)
             @test B'A1 ≈ B'Matrix(A1)
-            @test B*A1.' ≈ B*Matrix(A1).'
+            @test B*Transpose(A1) ≈ B*Transpose(Matrix(A1))
             @test B*A1' ≈ B*Matrix(A1)'
-            @test B[:,1].'A1.' ≈ B[:,1].'Matrix(A1).'
+            @test Transpose(B[:,1])*Transpose(A1) ≈ Transpose(B[:,1])*Transpose(Matrix(A1))
             @test B[:,1]'A1' ≈ B[:,1]'Matrix(A1)'
-            @test B.'A1.' ≈ B.'Matrix(A1).'
+            @test Transpose(B)*Transpose(A1) ≈ Transpose(B)*Transpose(Matrix(A1))
             @test B'A1' ≈ B'Matrix(A1)'
 
             if eltyB == elty1
                 @test mul!(similar(B),A1,B)  ≈ A1*B
                 @test mul!(similar(B), A1, Adjoint(B)) ≈ A1*B'
-                @test mul!(similar(B), A1, Transpose(B)) ≈ A1*B.'
+                @test mul!(similar(B), A1, Transpose(B)) ≈ A1*Transpose(B)
                 @test mul!(similar(B), Adjoint(A1), B) ≈ A1'*B
-                @test mul!(similar(B), Transpose(A1), B) ≈ A1.'*B
+                @test mul!(similar(B), Transpose(A1), B) ≈ Transpose(A1)*B
                 # test also vector methods
                 B1 = vec(B[1,:])
                 @test mul!(similar(B1),A1,B1)  ≈ A1*B1
                 @test mul!(similar(B1), Adjoint(A1), B1) ≈ A1'*B1
-                @test mul!(similar(B1), Transpose(A1), B1) ≈ A1.'*B1
+                @test mul!(similar(B1), Transpose(A1), B1) ≈ Transpose(A1)*B1
             end
             #error handling
             @test_throws DimensionMismatch mul!(A1, ones(eltyB,n+1))
@@ -367,26 +367,26 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
             # ... and division
             @test A1\B[:,1] ≈ Matrix(A1)\B[:,1]
             @test A1\B ≈ Matrix(A1)\B
-            @test A1.'\B[:,1] ≈ Matrix(A1).'\B[:,1]
+            @test Transpose(A1)\B[:,1] ≈ Transpose(Matrix(A1))\B[:,1]
             @test A1'\B[:,1] ≈ Matrix(A1)'\B[:,1]
-            @test A1.'\B ≈ Matrix(A1).'\B
+            @test Transpose(A1)\B ≈ Transpose(Matrix(A1))\B
             @test A1'\B ≈ Matrix(A1)'\B
-            @test A1\B.' ≈ Matrix(A1)\B.'
+            @test A1\Transpose(B) ≈ Matrix(A1)\Transpose(B)
             @test A1\B' ≈ Matrix(A1)\B'
-            @test A1.'\B.' ≈ Matrix(A1).'\B.'
+            @test Transpose(A1)\Transpose(B) ≈ Transpose(Matrix(A1))\Transpose(B)
             @test A1'\B' ≈ Matrix(A1)'\B'
             @test_throws DimensionMismatch A1\ones(elty1,n+2)
             @test_throws DimensionMismatch A1'\ones(elty1,n+2)
-            @test_throws DimensionMismatch A1.'\ones(elty1,n+2)
+            @test_throws DimensionMismatch Transpose(A1)\ones(elty1,n+2)
             if t1 == UpperTriangular || t1 == LowerTriangular
                 @test_throws Base.LinAlg.SingularException naivesub!(t1(zeros(elty1,n,n)),ones(eltyB,n))
             end
             @test B/A1 ≈ B/Matrix(A1)
-            @test B/A1.' ≈ B/Matrix(A1).'
+            @test B/Transpose(A1) ≈ B/Transpose(Matrix(A1))
             @test B/A1' ≈ B/Matrix(A1)'
-            @test B.'/A1 ≈ B.'/Matrix(A1)
+            @test Transpose(B)/A1 ≈ Transpose(B)/Matrix(A1)
             @test B'/A1 ≈ B'/Matrix(A1)
-            @test B.'/A1.' ≈ B.'/Matrix(A1).'
+            @test Transpose(B)/Transpose(A1) ≈ Transpose(B)/Transpose(Matrix(A1))
             @test B'/A1' ≈ B'/Matrix(A1)'
 
             # Error bounds

--- a/test/math.jl
+++ b/test/math.jl
@@ -296,7 +296,7 @@ end
 
 @testset "test abstractarray trig functions" begin
     TAA = rand(2,2)
-    TAA = (TAA + TAA.')/2.
+    TAA = (TAA + transpose(TAA))/2.
     STAA = Symmetric(TAA)
     @test Array(atanh.(STAA)) == atanh.(TAA)
     @test Array(asinh.(STAA)) == asinh.(TAA)

--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -126,8 +126,8 @@ function randmatstat(t)
         d = randn(n,n)
         P = [a b c d]
         Q = [a b; c d]
-        v[i] = trace((P.'*P)^4)
-        w[i] = trace((Q.'*Q)^4)
+        v[i] = trace((Transpose(P)*P)^4)
+        w[i] = trace((Transpose(Q)*Q)^4)
     end
     return (std(v)/mean(v), std(w)/mean(w))
 end

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -163,7 +163,7 @@ end
         am = sprand(1, 20, 0.2)
         av = squeeze(am, 1)
         @test ndims(av) == 1
-        @test all(av.'.==am)
+        @test all(transpose(av) .== am)
     end
 end
 
@@ -196,73 +196,73 @@ end
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(mul!(similar(b), a, b) - Array(a)*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
         @test (maximum(abs.(mul!(similar(c), a, c) - Array(a)*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
-        @test (maximum(abs.(mul!(similar(b), Transpose(a), b) - Array(a).'*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
-        @test (maximum(abs.(mul!(similar(c), Transpose(a), c) - Array(a).'*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
+        @test (maximum(abs.(mul!(similar(b), Transpose(a), b) - Transpose(Array(a))*b)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
+        @test (maximum(abs.(mul!(similar(c), Transpose(a), c) - Transpose(Array(a))*c)) < 100*eps()) # for compatibility with present matmul API. Should go away eventually.
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
         @test (maximum(abs.((a'*c + d) - (Array(a)'*c + d))) < 1000*eps())
-        @test (maximum(abs.((α*a.'*c + β*d) - (α*Array(a).'*c + β*d))) < 1000*eps())
-        @test (maximum(abs.((a.'*c + d) - (Array(a).'*c + d))) < 1000*eps())
+        @test (maximum(abs.((α*Transpose(a)*c + β*d) - (α*Transpose(Array(a))*c + β*d))) < 1000*eps())
+        @test (maximum(abs.((Transpose(a)*c + d) - (Transpose(Array(a))*c + d))) < 1000*eps())
         c = randn(6) + im*randn(6)
-        @test_throws DimensionMismatch α*a.'*c + β*c
-        @test_throws DimensionMismatch α*a.'*ones(5) + β*c
+        @test_throws DimensionMismatch α*Transpose(a)*c + β*c
+        @test_throws DimensionMismatch α*Transpose(a)*ones(5) + β*c
 
         a = I + 0.1*sprandn(5, 5, 0.2) + 0.1*im*sprandn(5, 5, 0.2)
         b = randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         a = I + tril(0.1*sprandn(5, 5, 0.2))
         b = randn(5,3) + im*randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         a = I + tril(0.1*sprandn(5, 5, 0.2) + 0.1*im*sprandn(5, 5, 0.2))
         b = randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         a = I + triu(0.1*sprandn(5, 5, 0.2))
         b = randn(5,3) + im*randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         a = I + triu(0.1*sprandn(5, 5, 0.2) + 0.1*im*sprandn(5, 5, 0.2))
         b = randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         a = I + triu(0.1*sprandn(5, 5, 0.2))
         b = randn(5,3) + im*randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         # UpperTriangular/LowerTriangular solve
         a = UpperTriangular(I + triu(0.1*sprandn(5, 5, 0.2)))
@@ -282,18 +282,18 @@ end
         b = randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
 
         b = randn(5,3) + im*randn(5,3)
         @test (maximum(abs.(a*b - Array(a)*b)) < 100*eps())
         @test (maximum(abs.(a'b - Array(a)'b)) < 100*eps())
-        @test (maximum(abs.(a.'b - Array(a).'b)) < 100*eps())
+        @test (maximum(abs.(Transpose(a)*b - Transpose(Array(a))*b)) < 100*eps())
         @test (maximum(abs.(a\b - Array(a)\b)) < 1000*eps())
         @test (maximum(abs.(a'\b - Array(a')\b)) < 1000*eps())
-        @test (maximum(abs.(a.'\b - Array(a.')\b)) < 1000*eps())
+        @test (maximum(abs.(Transpose(a)\b - Array(transpose(a))\b)) < 1000*eps())
     end
     end
 end
@@ -1747,16 +1747,16 @@ end
     srand(123)
     local A
     A = sparse(Diagonal(rand(5))) + sprandn(5, 5, 0.2) + im*sprandn(5, 5, 0.2)
-    A = A + A'
+    A = A + adjoint(A)
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(Array(A))))
     A = sparse(Diagonal(rand(5))) + sprandn(5, 5, 0.2) + im*sprandn(5, 5, 0.2)
     A = A*A'
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Hermitian(A)))) ≈ abs(det(factorize(Array(A))))
     A = sparse(Diagonal(rand(5))) + sprandn(5, 5, 0.2)
-    A = A + A.'
+    A = A + transpose(A)
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(Array(A))))
     A = sparse(Diagonal(rand(5))) + sprandn(5, 5, 0.2)
-    A = A*A.'
+    A = A*Transpose(A)
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(Array(A))))
     @test factorize(triu(A)) == triu(A)
     @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrixCSC{Float64, Int}})

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -874,7 +874,7 @@ end
             xf = Array(x)
             x2f = Array(x2)
             @test SparseArrays.densemv(A, x; trans='N') ≈ Af * xf
-            @test SparseArrays.densemv(A, x2; trans='T') ≈ Af.' * x2f
+            @test SparseArrays.densemv(A, x2; trans='T') ≈ Transpose(Af) * x2f
             @test SparseArrays.densemv(A, x2; trans='C') ≈ Af'x2f
             @test_throws ArgumentError SparseArrays.densemv(A, x; trans='D')
         end
@@ -909,7 +909,7 @@ end
 
             y = *(Transpose(A), x2)
             @test isa(y, SparseVector{ComplexF64,Int})
-            @test Array(y) ≈ Af.' * x2f
+            @test Array(y) ≈ Transpose(Af) * x2f
 
             y = *(Adjoint(A), x2)
             @test isa(y, SparseVector{ComplexF64,Int})


### PR DESCRIPTION
This pull request is the next step towards JuliaLang/LinearAlgebra.jl#57 after JuliaLang/julia#24969 and JuliaLang/julia#25083, completing items 8-12 in JuliaLang/julia#24969's OP's task list. Specifically, this pull request:

1. Rewrites all remaining uses of `.'` in base, test, and stdlib as appropriate.
2. Removes the special lowering for `.'` in multiplication, left-division, and right-division expressions.
3. Deprecates `.'`.

Notes:

1. ~This pull request is based on JuliaLang/julia#25083, from which the first twenty commits come. Only the last five commits belong to this pull request. I will rebase those commits out once JuliaLang/julia#25083 merges.~ Rebased out.
2. I deprecated `.'` in `src/julia-syntax.scm`. Whether that's the best way to go about this deprecation (or instead, e.g., lower `.'` to some, e.g., `depwarn_transpose` function defined in `base/deprecated.jl`) I do not know, and would appreciate input from someone better versed in these things than I :).
3. I plan to write a news entry for these changes as part of a large, single news item on the JuliaLang/LinearAlgebra.jl#57 (in a later pull request).

Thanks and best!