### PR TITLE
Distributed: worker to supply a port_hint in the known range

### DIFF
--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -207,7 +207,8 @@ function start_worker(out::IO, cookie_in::Nullable{AbstractString})
     init_worker(cookie)
     interface = IPv4(LPROC.bind_addr)
     if LPROC.bind_port == 0
-        (port, sock) = listenany(interface, UInt16(0))
+        port_hint = 9000 + (getpid() % 1000)
+        (port, sock) = listenany(interface, UInt16(port_hint))
         LPROC.bind_port = port
     else
         sock = listen(interface, LPROC.bind_port)


### PR DESCRIPTION
This PR addresses https://github.com/JuliaLang/julia/issues/24722 for 0.7

A worker now provides a port_hint to `listenany` in the range 9000-9999 instead of listening on a port in the ephemeral port range (which appeared to be blocked on some clusters).  