### PR TITLE
Fix missing GC root in setting ARGS

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -607,10 +607,13 @@ JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv)
         assert(jl_array_len(args) == 0);
         jl_array_grow_end(args, argc);
         int i;
+        jl_value_t *s = NULL;
+        JL_GC_PUSH1(&s);
         for (i=0; i < argc; i++) {
-            jl_value_t *s = (jl_value_t*)jl_cstr_to_string(argv[i]);
+            s = (jl_value_t*)jl_cstr_to_string(argv[i]);
             jl_arrayset(args, s, i);
         }
+        JL_GC_POP();
     }
 }
 


### PR DESCRIPTION
```
/home/keno/julia/src/jloptions.c:611:42: note: Started tracking value here
            jl_value_t *s = (jl_value_t*)jl_cstr_to_string(argv[i]);
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/jloptions.c:612:13: note: Passing non-rooted value as argument to function that may GC
            jl_arrayset(args, s, i);
            ^                 ~
```
Fairly straightforward. We could instead make arrayset root its arguments, but the only other caller of this
function doesn't need it, so let's do it here.