### PR TITLE
Fix missing gc root in compile-all

### DIFF
--- a/src/precompile.c
+++ b/src/precompile.c
@@ -191,7 +191,7 @@ static void _compile_all_union(jl_value_t *sig)
     JL_GC_PUSH2(&p, &methsig);
     int idx_ctr = 0, incr = 0;
     while (!incr) {
-        jl_svec_t *p = jl_alloc_svec_uninit(l);
+        p = jl_alloc_svec_uninit(l);
         for (i = 0, idx_ctr = 0, incr = 1; i < l; i++) {
             jl_value_t *ty = jl_svecref(sigbody->parameters, i);
             if (jl_is_uniontype(ty)) {


### PR DESCRIPTION
```
/home/keno/julia/src/precompile.c:191:5: note: GC frame changed here
    JL_GC_PUSH2(&p, &methsig);
    ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/precompile.c:193:5: note: Loop condition is true. Entering loop body
    while (!incr) {
    ^
/home/keno/julia/src/precompile.c:194:24: note: Started tracking value here
        jl_svec_t *p = jl_alloc_svec_uninit(l);
                       ^~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/precompile.c:195:9: note: Loop condition is true. Entering loop body
        for (i = 0, idx_ctr = 0, incr = 1; i < l; i++) {
        ^
/home/keno/julia/src/precompile.c:197:13: note: Taking false branch
            if (jl_is_uniontype(ty)) {
            ^
/home/keno/julia/src/precompile.c:195:9: note: Loop condition is false. Execution continues on line 217
        for (i = 0, idx_ctr = 0, incr = 1; i < l; i++) {
        ^
/home/keno/julia/src/precompile.c:217:32: note: Passing non-rooted value as argument to function that may GC
        methsig = (jl_value_t*)jl_apply_tuple_type(p);
                               ^                   ~
```
Essentially the same bug as #25123