### PR TITLE
define show(::MersenneTwister)

### DIFF
--- a/stdlib/Future/src/Future.jl
+++ b/stdlib/Future/src/Future.jl
@@ -36,7 +36,10 @@ One such step corresponds to the generation of two `Float64` numbers.
 For each different value of `steps`, a large polynomial has to be generated internally.
 One is already pre-computed for `steps=big(10)^20`.
 """
-randjump(r::MersenneTwister, steps::Integer) =
-    Random._randjump(r, Random.DSFMT.calc_jump(steps))
+function randjump(r::MersenneTwister, steps::Integer)
+    j = Random._randjump(r, Random.DSFMT.calc_jump(steps))
+    j.adv_jump += 2*big(steps) # convert to BigInt to prevent overflow
+    j
+end
 
 end # module Future

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -17,7 +17,7 @@ using Base.GMP: Limb
 using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
 
 import Base: copymutable, copy, copy!, ==, hash, convert,
-             rand, randn
+             rand, randn, show
 
 export rand!, randn!,
        randexp, randexp!,

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -592,16 +592,16 @@ end
 @test_throws DomainError DSFMT.DSFMT_state(zeros(Int32, rand(0:DSFMT.JN32-1)))
 
 @test_throws DomainError MersenneTwister(zeros(UInt32, 1), DSFMT.DSFMT_state(),
-                                         zeros(Float64, 10), zeros(UInt128, MT_CACHE_I>>4), 0, 0)
+                                         zeros(Float64, 10), zeros(UInt128, MT_CACHE_I>>4), 0, 0, 0, 0, -1, -1, -1, -1)
 
 @test_throws DomainError MersenneTwister(zeros(UInt32, 1), DSFMT.DSFMT_state(),
-                                         zeros(Float64, MT_CACHE_F), zeros(UInt128, MT_CACHE_I>>4), -1, 0)
+                                         zeros(Float64, MT_CACHE_F), zeros(UInt128, MT_CACHE_I>>4), -1, 0, 0, 0, -1, -1, -1, -1)
 
 @test_throws DomainError MersenneTwister(zeros(UInt32, 1), DSFMT.DSFMT_state(),
-                                         zeros(Float64, MT_CACHE_F), zeros(UInt128, MT_CACHE_I>>3), 0, 0)
+                                         zeros(Float64, MT_CACHE_F), zeros(UInt128, MT_CACHE_I>>3), 0, 0, 0, 0, -1, -1, -1, -1)
 
 @test_throws DomainError MersenneTwister(zeros(UInt32, 1), DSFMT.DSFMT_state(),
-                                         zeros(Float64, MT_CACHE_F), zeros(UInt128, MT_CACHE_I>>4), 0, -1)
+                                         zeros(Float64, MT_CACHE_F), zeros(UInt128, MT_CACHE_I>>4), 0, -1, 0, 0, -1, -1, -1, -1)
 
 # seed is private to MersenneTwister
 let seed = rand(UInt32, 10)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -833,3 +833,28 @@ end
     end
     @test length(s) == n
 end
+
+@testset "show" begin
+    m = MersenneTwister(123)
+    @test string(m) == "MersenneTwister(123)"
+    Random.jump!(m, 2*big(10)^20)
+    @test string(m) == "MersenneTwister(123, (200000000000000000000, 0))"
+    @test m == MersenneTwister(123, (200000000000000000000, 0))
+    rand(m)
+    @test string(m) == "MersenneTwister(123, (200000000000000000000, 1002, 0, 1))"
+    @test m == MersenneTwister(123, (200000000000000000000, 1002, 0, 1))
+    rand(m, Int64)
+    @test string(m) == "MersenneTwister(123, (200000000000000000000, 2002, 0, 255, 1002, 0, 1, 1))"
+    @test m == MersenneTwister(123, (200000000000000000000, 2002, 0, 255, 1002, 0, 1, 1))
+
+    m = MersenneTwister(0x0ecfd77f89dcd508caa37a17ebb7556b)
+    @test string(m) == "MersenneTwister(0xecfd77f89dcd508caa37a17ebb7556b)"
+    rand(m, Int64)
+    @test string(m) == "MersenneTwister(0xecfd77f89dcd508caa37a17ebb7556b, (0, 2002, 1000, 254, 0, 0, 0, 1))"
+    @test m == MersenneTwister(0xecfd77f89dcd508caa37a17ebb7556b, (0, 2002, 1000, 254, 0, 0, 0, 1))
+
+    # test when floats advancing is done by initializing ints, and (few) floats are then generated
+    m = MersenneTwister(0); rand(m, Int64); rand(m)
+    @test string(m) == "MersenneTwister(0, (0, 2002, 1000, 255, 0, 0, 0, 1))"
+    @test m == MersenneTwister(0, (0, 2002, 1000, 255, 0, 0, 0, 1))
+end


### PR DESCRIPTION
I have been meaning to do this for a long time. I would say it's mostly useful because `srand` returns the RNG, so it happens at the REPL to be show a `MersenneTwister`, with loads of useless information:
```julia
julia> srand() # master
MersenneTwister(UInt32[0x0c7ad3d3, 0xa5925687, 0xc6ea340a, 0xabaa8392], Base.dSFMT.DSFMT_state(Int32[-1758623818, 1072978913, 994178365, 1073660380, -791860901, 1073515898, -549958670, 1072772648, 1411463369, 1073306694  …  -160292708, 1073238798, 320054219, 1073706379, -1551517119, 564778559, 1415871354, 1522268230, 382, 0]), [1.91962, 1.42752, 1.00802, 1.95107, 1.86132, 1.55257, 1.4849, 1.10529, 1.9795, 1.78886  …  1.13922, 1.99249, 1.29247, 1.76895, 1.25858, 1.77279, 1.29767, 1.65949, 1.73626, 1.38635], 382)

julia> srand() # PR
MersenneTwister RNG with seed 0xd4e8b116a747b4fc7dbf67862e68478a

julia> srand() # PR alternative 2
MersenneTwister(0xd4e8b116a747b4fc7dbf67862e68478a, ...)

julia> srand() # PR alternative 3
MersenneTwister(seed=0xd4e8b116a747b4fc7dbf67862e68478a)
```
Alternative 2 is a bit ugly, but without the dots, it mistakenly makes you think you can get an equal RNG with `MersenneTwister(0xd4e8b116a747b4fc7dbf67862e68478a)`, (same problem with alternative 3), and with the dots, it makes you think there is a multi-arg constructor, which is not the case.

I like to print the seed as an unsigned number, as it's just a field of bits, and the unsigned can be fed back as a seed later.

Suggestions welcome! 