### PR TITLE
Bikeshed log message format

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -485,13 +485,13 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
             level < Warn  ? :cyan :
             level < Error ? :yellow : :red
     buf = IOBuffer()
-    print_with_color(color, buf, first(levelstr), "- ", bold=true)
+    print_with_color(color, buf, levelstr, ": ", bold=true)
     msglines = split(string(message), '\n')
     for i in 1:length(msglines)-1
         println(buf, msglines[i])
         print_with_color(color, buf, "|  ", bold=true)
     end
-    println(buf, msglines[end], " -", levelstr, ":", _module, ":", basename(filepath), ":", line)
+    println(buf, msglines[end], " - at ", _module, ":", basename(filepath), ":", line)
     for (key,val) in pairs(kwargs)
         print_with_color(color, buf, "|  ", bold=true)
         println(buf, key, " = ", val)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -249,20 +249,20 @@ end
     # Simple
     @test genmsg(Info, "msg", Main, "some/path.jl", 101) ==
     """
-    I- msg -Info:Main:path.jl:101
+    Info: msg - at Main:path.jl:101
     """
 
     # Multiline message
     @test genmsg(Warn, "line1\nline2", Main, "some/path.jl", 101) ==
     """
-    W- line1
-    |  line2 -Warn:Main:path.jl:101
+    Warn: line1
+    |  line2 - at Main:path.jl:101
     """
 
     # Keywords
     @test genmsg(Error, "msg", Base, "other.jl", 101, a=1, b="asdf") ==
     """
-    E- msg -Error:Base:other.jl:101
+    Error: msg - at Base:other.jl:101
     |  a = 1
     |  b = asdf
     """


### PR DESCRIPTION
See the diff in the test file to see how I changed the messages.

I made the full log level first, as just one letter might be confusing if your terminal doesn't support colour. I then removed it from the end as it was redundant and might have obscured the location information. I added `at` to match stack trace printing.

I think this is a bit clearer and fits better with other Julia output. Thoughts?