### PR TITLE
move `nprocs` and `myid` to Distributed

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1286,6 +1286,8 @@ export conv, conv2, deconv, filt, filt!, xcorr
 @deprecate_moved interrupt "Distributed" true true
 @deprecate_moved launch "Distributed" true true
 @deprecate_moved manage "Distributed" true true
+@deprecate_moved myid "Distributed" true true
+@deprecate_moved nprocs "Distributed" true true
 @deprecate_moved nworkers "Distributed" true true
 @deprecate_moved pmap "Distributed" true true
 @deprecate_moved procs "Distributed" true true

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1241,9 +1241,4 @@ export
     spzeros,
     rowvals,
     nzrange,
-    nnz,
-
-# Minimal set of Distributed exports - useful for a program to check if running
-# in distributed mode or not.
-    myid,
-    nprocs
+    nnz

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -291,9 +291,6 @@ end
 # require always works in Main scope and loads files from node 1
 const toplevel_load = Ref(true)
 
-myid() = isdefined(Main, :Distributed) ? invokelatest(Main.Distributed.myid) : 1
-nprocs() = isdefined(Main, :Distributed) ? invokelatest(Main.Distributed.nprocs) : 1
-
 """
     require(module::Symbol)
 
@@ -317,13 +314,6 @@ function require(mod::Symbol)
     if !root_module_exists(mod)
         _require(mod)
         # After successfully loading, notify downstream consumers
-        if toplevel_load[] && myid() == 1 && nprocs() > 1
-            # broadcast top-level import/using from node 1 (only)
-            @sync for p in invokelatest(Main.procs)
-                p == 1 && continue
-                @async invokelatest(Main.remotecall_wait, ()->(require(mod); nothing), p)
-            end
-        end
         for callback in package_callbacks
             invokelatest(callback, mod)
         end

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -368,17 +368,15 @@ end
 
 # TODO: make this bidirectional, so objects can be sent back via the same key
 const object_numbers = WeakKeyDict()
-const obj_number_salt = Ref(0)
-function object_number(@nospecialize(l))
+const obj_number_salt = Ref{UInt64}(0)
+function object_number(s::AbstractSerializer, @nospecialize(l))
     global obj_number_salt, object_numbers
     if haskey(object_numbers, l)
         return object_numbers[l]
     end
-    # a hash function that always gives the same number to the same
-    # object on the same machine, and is unique over all machines.
-    ln = obj_number_salt[]+(UInt64(myid())<<44)
-    obj_number_salt[] += 1
+    ln = obj_number_salt[]
     object_numbers[l] = ln
+    obj_number_salt[] += 1
     return ln::UInt64
 end
 
@@ -398,7 +396,7 @@ end
 function serialize(s::AbstractSerializer, meth::Method)
     serialize_cycle(s, meth) && return
     writetag(s.io, METHOD_TAG)
-    write(s.io, object_number(meth))
+    write(s.io, object_number(s, meth))
     serialize(s, meth.module)
     serialize(s, meth.name)
     serialize(s, meth.file)
@@ -476,7 +474,7 @@ end
 function serialize(s::AbstractSerializer, t::TypeName)
     serialize_cycle(s, t) && return
     writetag(s.io, TYPENAME_TAG)
-    write(s.io, object_number(t))
+    write(s.io, object_number(s, t))
     serialize_typename(s, t)
 end
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -509,7 +509,7 @@ Base.require(:Printf)
     @deprecate_binding Mmap root_module(:Mmap) true ", run `using Mmap` instead"
     @deprecate_binding Profile root_module(:Profile) true ", run `using Profile` instead"
     @deprecate_binding Dates root_module(:Dates) true ", run `using Dates` instead"
-#    @deprecate_binding Distributed root_module(:Distributed) true ", run `using Distributed` instead"
+    @deprecate_binding Distributed root_module(:Distributed) true ", run `using Distributed` instead"
 end
 
 empty!(LOAD_PATH)

--- a/doc/src/stdlib/.gitignore
+++ b/doc/src/stdlib/.gitignore
@@ -10,3 +10,4 @@ dates.md
 unicode.md
 iterativeeigensolvers.md
 printf.md
+distributed.md

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -25,6 +25,8 @@ export detect_ambiguities, detect_unbound_args
 export GenericString, GenericSet, GenericDict, GenericArray
 export guardsrand
 
+import Distributed: myid
+
 #-----------------------------------------------------------------------
 
 # Backtrace utility functions

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -23,7 +23,7 @@ export @testset
 export @inferred
 export detect_ambiguities, detect_unbound_args
 export GenericString, GenericSet, GenericDict, GenericArray
-export guardsrand
+export guardsrand, TestSetException
 
 import Distributed: myid
 

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -547,6 +547,7 @@ let
             """
             __precompile__(true)
             module $ModuleA
+                import Distributed: myid
                 export f
                 f() = myid()
             end


### PR DESCRIPTION
I was trying to fix the logic in #25119 while also optimising `myid` and `nprocs`
and I think it is better to fully deprecate them. 

@vtjnash mentioned to me that the usage of `object_number` is most likely incorrect,
but I do not understand the code well enough to attempt a fix, so I went with the minimal solution.

fixes #25077
fixes #25135

replaces #25119