### PR TITLE
Various doctests for array stuff [ci skip]

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1380,6 +1380,27 @@ end
     reverse!(v [, start=1 [, stop=length(v) ]]) -> v
 
 In-place version of [`reverse`](@ref).
+
+# Examples
+```jldoctest
+julia> A = collect(1:5)
+5-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+ 5
+
+julia> reverse!(A);
+
+julia> A
+5-element Array{Int64,1}:
+ 5
+ 4
+ 3
+ 2
+ 1
+```
 """
 function reverse!(v::AbstractVector, s=first(linearindices(v)), n=last(linearindices(v)))
     liv = linearindices(v)

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -118,6 +118,32 @@ end
 
 Permute the dimensions of the matrix `m`, by flipping the elements across the diagonal of
 the matrix. Differs from [`transpose`](@ref) in that the operation is not recursive.
+
+# Examples
+```jldoctest
+julia> a = [1 2; 3 4];
+
+julia> b = [5 6; 7 8];
+
+julia> c = [9 10; 11 12];
+
+julia> d = [13 14; 15 16];
+
+julia> X = [[a] [b]; [c] [d]]
+2×2 Array{Array{Int64,2},2}:
+ [1 2; 3 4]     [5 6; 7 8]
+ [9 10; 11 12]  [13 14; 15 16]
+
+julia> permutedims(X)
+2×2 Array{Array{Int64,2},2}:
+ [1 2; 3 4]  [9 10; 11 12]
+ [5 6; 7 8]  [13 14; 15 16]
+
+julia> transpose(X)
+2×2 Array{Array{Int64,2},2}:
+ [1 3; 2 4]  [9 11; 10 12]
+ [5 7; 6 8]  [13 15; 14 16]
+```
 """
 permutedims(A::AbstractMatrix) = permutedims(A, (2,1))
 
@@ -125,6 +151,31 @@ permutedims(A::AbstractMatrix) = permutedims(A, (2,1))
     permutedims(v::AbstractVector)
 
 Reshape vector `v` into a `1 × length(v)` row matrix.
+ Differs from [`transpose`](@ref) in that the operation is not recursive.
+
+# Examples
+```jldoctest
+julia> permutedims(v)
+1×4 Array{Int64,2}:
+ 1  2  3  4
+
+julia> a = [1 2; 3 4];
+
+julia> b = [5 6; 7 8];
+
+julia> V = [[a]; [b]]
+2-element Array{Array{Int64,2},1}:
+ [1 2; 3 4]
+ [5 6; 7 8]
+
+julia> permutedims(V)
+1×2 Array{Array{Int64,2},2}:
+ [1 2; 3 4]  [5 6; 7 8]
+
+julia> transpose(V)
+1×2 Transpose{Transpose{Int64,Array{Int64,2}},Array{Array{Int64,2},1}}:
+ [1 3; 2 4]  [5 7; 6 8]
+```
 """
 permutedims(v::AbstractVector) = reshape(v, (1, length(v)))
 

--- a/base/sparse/abstractsparse.jl
+++ b/base/sparse/abstractsparse.jl
@@ -9,6 +9,20 @@ const AbstractSparseMatrix{Tv,Ti} = AbstractSparseArray{Tv,Ti,2}
     issparse(S)
 
 Returns `true` if `S` is sparse, and `false` otherwise.
+
+# Examples
+```jldoctest
+julia> sv = sparsevec([1, 4], [2.3, 2.2], 10)
+10-element SparseVector{Float64,Int64} with 2 stored entries:
+  [1 ]  =  2.3
+  [4 ]  =  2.2
+
+julia> issparse(sv)
+true
+
+julia> issparse(Array(sv))
+false
+```
 """
 issparse(A::AbstractArray) = false
 issparse(S::AbstractSparseArray) = true


### PR DESCRIPTION
tried to highlight the difference between `permutedims` and `transpose`

only did one example for `reverse!` because the other args are shown well in `reverse`