### PR TITLE
rename SparseMatrixCSC to SparseMatrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -645,21 +645,21 @@ Deprecated or removed
 
   * `full` has been deprecated in favor of more specific, better defined alternatives.
     On structured matrices `A`, consider instead `Matrix(A)`, `Array(A)`,
-    `SparseMatrixCSC(A)`, or `sparse(A)`. On sparse arrays `S`, consider instead
+    `SparseMatrix(A)`, or `sparse(A)`. On sparse arrays `S`, consider instead
     `Vector(S)`, `Matrix(S)`, or `Array(S)` as appropriate. On factorizations `F`,
     consider instead `Matrix(F)`, `Array(F)`, `AbstractMatrix(F)`, or `AbstractArray(F)`.
     On implicit orthogonal factors `Q`, consider instead `Matrix(Q)` or `Array(Q)`; for
     implicit orthogonal factors that can be recovered in square or truncated form,
     see the deprecation message for square recovery instructions. On `Symmetric`,
     `Hermitian`, or `AbstractTriangular` matrices `A`, consider instead `Matrix(S)`,
-    `Array(S)`, `SparseMatrixCSC(S)`, or `sparse(S)`. On `Symmetric` matrices `A`
+    `Array(S)`, `SparseMatrix(S)`, or `sparse(S)`. On `Symmetric` matrices `A`
     particularly, consider instead `LinAlg.copytri!(copy(parent(A)), A.uplo)`. On
     `Hermitian` matrices `A` particularly, consider instead
     `LinAlg.copytri!(copy(parent(A)), A.uplo, true)`. On `UpperTriangular` matrices `A`
     particularly, consider instead `triu!(copy(parent(A)))`. On `LowerTriangular` matrices
     `A` particularly, consider instead `tril!(copy(parent(A)))` ([#24250]).
 
-  * `speye` has been deprecated in favor of `I`, `sparse`, and `SparseMatrixCSC`
+  * `speye` has been deprecated in favor of `I`, `sparse`, and `SparseMatrix`
     constructor methods ([#24356]).
 
   * Calling `union` with no arguments is deprecated; construct an empty set with an appropriate
@@ -690,7 +690,7 @@ Deprecated or removed
 
   * `diagm(x::Number)` has been deprecated in favor of `fill(x, 1, 1)` ([#24047]).
 
-  * `diagm(A::SparseMatrixCSC)` has been deprecated in favor of
+  * `diagm(A::SparseMatrix)` has been deprecated in favor of
     `spdiagm(sparsevec(A))` ([#23341]).
 
   * `diagm(A::BitMatrix)` has been deprecated, use `diagm(0 => vec(A))` or
@@ -809,6 +809,8 @@ Deprecated or removed
     has been renamed to `indices` without deprecation ([#25088]).
 
   * `Associative` has been deprecated in favor of `AbstractDict` ([#25012]).
+
+  * `SparseMatrixCSC` has been renamed `SparseMatrix` ([#25151]).
 
   * `Nullable{T}` has been deprecated and moved to the Nullables package ([#23642]).
     Use `Union{T, Void}` instead, or `Union{Some{T}, Void}` if `nothing` is a possible value
@@ -1248,7 +1250,7 @@ Library improvements
 
   * `map[!]` and `broadcast[!]` now have dedicated methods for sparse/structured
     vectors/matrices. Specifically, `map[!]` and `broadcast[!]` over combinations including
-    one or more `SparseVector`, `SparseMatrixCSC`, `Diagonal`, `Bidiagonal`, `Tridiagonal`,
+    one or more `SparseVector`, `SparseMatrix`, `Diagonal`, `Bidiagonal`, `Tridiagonal`,
     or `SymTridiagonal`, and any number of `broadcast` scalars, `Vector`s, or `Matrix`s,
     now efficiently yield `SparseVector`s or `SparseMatrix`s as appropriate ([#19239],
     [#19371], [#19518], [#19438], [#19690], [#19724], [#19926], [#19934], [#20009]).

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -799,7 +799,7 @@ Example for a sparse 2-d array:
 
 ```jldoctest
 julia> A = sparse([1, 1, 2], [1, 3, 1], [1, 2, -5])
-2×3 SparseMatrixCSC{Int64,Int64} with 3 stored entries:
+2×3 SparseMatrix{Int64,Int64} with 3 stored entries:
   [1, 1]  =  1
   [2, 1]  =  -5
   [1, 3]  =  2

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -65,7 +65,7 @@ The `N` parameter is the dimensionality, which can be handy for AbstractArray ty
 that only support specific dimensionalities:
 
     struct SparseMatrixStyle <: Broadcast.AbstractArrayStyle{2} end
-    Base.BroadcastStyle(::Type{<:SparseMatrixCSC}) = SparseMatrixStyle()
+    Base.BroadcastStyle(::Type{<:SparseMatrix}) = SparseMatrixStyle()
 
 For AbstractArray types that support arbitrary dimensionality, `N` can be set to `Any`:
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -122,11 +122,11 @@ Similarly, if `T` is a composite type and `x` a related instance, the result of
 julia> x = sparse(1.0I, 5, 5);
 
 julia> typeof(x)
-SparseMatrixCSC{Float64,Int64}
+SparseMatrix{Float64,Int64}
 
-julia> y = convert(SparseMatrixCSC{Float64,Int64}, x);
+julia> y = convert(SparseMatrix{Float64,Int64}, x);
 
-julia> z = convert(SparseMatrixCSC{Float32,Int64}, y);
+julia> z = convert(SparseMatrix{Float32,Int64}, y);
 
 julia> y === x
 true

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1231,7 +1231,7 @@ export
     AbstractSparseArray,
     AbstractSparseMatrix,
     AbstractSparseVector,
-    SparseMatrixCSC,
+    SparseMatrix,
     SparseVector,
     issparse,
     sparse,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -119,10 +119,10 @@ Get the name of field `i` of a `DataType`.
 
 # Examples
 ```jldoctest
-julia> fieldname(SparseMatrixCSC, 1)
+julia> fieldname(SparseMatrix, 1)
 :m
 
-julia> fieldname(SparseMatrixCSC, 5)
+julia> fieldname(SparseMatrix, 5)
 :nzval
 ```
 """

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -5,32 +5,32 @@ import Base.LinAlg: checksquare
 
 ## sparse matrix multiplication
 
-*(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
+*(A::SparseMatrix{TvA,TiA}, B::SparseMatrix{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
     *(sppromote(A, B)...)
-*(A::SparseMatrixCSC{TvA,TiA}, transB::Transpose{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(A::SparseMatrix{TvA,TiA}, transB::Transpose{<:Any,<:SparseMatrix{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (B = transB.parent; (pA, pB) = sppromote(A, B); *(pA, Transpose(pB)))
-*(A::SparseMatrixCSC{TvA,TiA}, adjB::Adjoint{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(A::SparseMatrix{TvA,TiA}, adjB::Adjoint{<:Any,<:SparseMatrix{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (B = adjB.parent; (pA, pB) = sppromote(A, B); *(pA, Adjoint(pB)))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TvA,TiA}}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
+*(transA::Transpose{<:Any,<:SparseMatrix{TvA,TiA}}, B::SparseMatrix{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
     (A = transA.parent; (pA, pB) = sppromote(A, B); *(Transpose(pA), pB))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TvA,TiA}}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
+*(adjA::Adjoint{<:Any,<:SparseMatrix{TvA,TiA}}, B::SparseMatrix{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
     (A = adjA.parent; (pA, pB) = sppromote(A, B); *(Adjoint(pA), pB))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TvA,TiA}}, transB::Transpose{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(transA::Transpose{<:Any,<:SparseMatrix{TvA,TiA}}, transB::Transpose{<:Any,<:SparseMatrix{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (A = transA.parent; B = transB.parent; (pA, pB) = sppromote(A, B); *(Transpose(pA), Transpose(pB)))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TvA,TiA}}, adjB::Adjoint{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(adjA::Adjoint{<:Any,<:SparseMatrix{TvA,TiA}}, adjB::Adjoint{<:Any,<:SparseMatrix{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (A = adjA.parent; B = adjB.parent; (pA, pB) = sppromote(A, B); *(Adjoint(pA), Adjoint(pB)))
 
-function sppromote(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
+function sppromote(A::SparseMatrix{TvA,TiA}, B::SparseMatrix{TvB,TiB}) where {TvA,TiA,TvB,TiB}
     Tv = promote_type(TvA, TvB)
     Ti = promote_type(TiA, TiB)
-    A  = convert(SparseMatrixCSC{Tv,Ti}, A)
-    B  = convert(SparseMatrixCSC{Tv,Ti}, B)
+    A  = convert(SparseMatrix{Tv,Ti}, A)
+    B  = convert(SparseMatrix{Tv,Ti}, B)
     A, B
 end
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 
-function mul!(α::Number, A::SparseMatrixCSC, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
+function mul!(α::Number, A::SparseMatrix, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
     A.n == size(B, 1) || throw(DimensionMismatch())
     A.m == size(C, 1) || throw(DimensionMismatch())
     size(B, 2) == size(C, 2) || throw(DimensionMismatch())
@@ -49,12 +49,12 @@ function mul!(α::Number, A::SparseMatrixCSC, B::StridedVecOrMat, β::Number, C:
     end
     C
 end
-*(A::SparseMatrixCSC{TA,S}, x::StridedVector{Tx}) where {TA,S,Tx} =
+*(A::SparseMatrix{TA,S}, x::StridedVector{Tx}) where {TA,S,Tx} =
     (T = promote_type(TA, Tx); mul!(one(T), A, x, zero(T), similar(x, T, A.m)))
-*(A::SparseMatrixCSC{TA,S}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
+*(A::SparseMatrix{TA,S}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
     (T = promote_type(TA, Tx); mul!(one(T), A, B, zero(T), similar(B, T, (A.m, size(B, 2)))))
 
-function mul!(α::Number, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
+function mul!(α::Number, adjA::Adjoint{<:Any,<:SparseMatrix}, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
     A = adjA.parent
     A.n == size(C, 1) || throw(DimensionMismatch())
     A.m == size(B, 1) || throw(DimensionMismatch())
@@ -75,12 +75,12 @@ function mul!(α::Number, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::StridedVecO
     end
     C
 end
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
+*(adjA::Adjoint{<:Any,<:SparseMatrix{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
     (A = adjA.parent; T = promote_type(TA, Tx); mul!(one(T), Adjoint(A), x, zero(T), similar(x, T, A.n)))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
+*(adjA::Adjoint{<:Any,<:SparseMatrix{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
     (A = adjA.parent; T = promote_type(TA, Tx); mul!(one(T), Adjoint(A), B, zero(T), similar(B, T, (A.n, size(B, 2)))))
 
-function mul!(α::Number, transA::Transpose{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
+function mul!(α::Number, transA::Transpose{<:Any,<:SparseMatrix}, B::StridedVecOrMat, β::Number, C::StridedVecOrMat)
     A = transA.parent
     A.n == size(C, 1) || throw(DimensionMismatch())
     A.m == size(B, 1) || throw(DimensionMismatch())
@@ -101,21 +101,21 @@ function mul!(α::Number, transA::Transpose{<:Any,<:SparseMatrixCSC}, B::Strided
     end
     C
 end
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
+*(transA::Transpose{<:Any,<:SparseMatrix{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
     (A = transA.parent; T = promote_type(TA, Tx); mul!(one(T), Transpose(A), x, zero(T), similar(x, T, A.n)))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
+*(transA::Transpose{<:Any,<:SparseMatrix{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
     (A = transA.parent; T = promote_type(TA, Tx); mul!(one(T), Transpose(A), B, zero(T), similar(B, T, (A.n, size(B, 2)))))
 
 # For compatibility with dense multiplication API. Should be deleted when dense multiplication
 # API is updated to follow BLAS API.
-mul!(C::StridedVecOrMat, A::SparseMatrixCSC, B::StridedVecOrMat) =
+mul!(C::StridedVecOrMat, A::SparseMatrix, B::StridedVecOrMat) =
     mul!(one(eltype(B)), A, B, zero(eltype(C)), C)
-mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat) =
+mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:SparseMatrix}, B::StridedVecOrMat) =
     (A = adjA.parent; mul!(one(eltype(B)), Adjoint(A), B, zero(eltype(C)), C))
-mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat) =
+mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:SparseMatrix}, B::StridedVecOrMat) =
     (A = transA.parent; mul!(one(eltype(B)), Transpose(A), B, zero(eltype(C)), C))
 
-function (*)(X::StridedMatrix{TX}, A::SparseMatrixCSC{TvA,TiA}) where {TX,TvA,TiA}
+function (*)(X::StridedMatrix{TX}, A::SparseMatrix{TvA,TiA}) where {TX,TvA,TiA}
     mX, nX = size(X)
     nX == A.m || throw(DimensionMismatch())
     Y = zeros(promote_type(TX,TvA), mX, A.n)
@@ -127,11 +127,11 @@ function (*)(X::StridedMatrix{TX}, A::SparseMatrixCSC{TvA,TiA}) where {TX,TvA,Ti
     Y
 end
 
-function (*)(D::Diagonal, A::SparseMatrixCSC)
+function (*)(D::Diagonal, A::SparseMatrix)
     T = Base.promote_op(*, eltype(D), eltype(A))
     scale!(LinAlg.copy_oftype(A, T), D.diag, A)
 end
-function (*)(A::SparseMatrixCSC, D::Diagonal)
+function (*)(A::SparseMatrix, D::Diagonal)
     T = Base.promote_op(*, eltype(D), eltype(A))
     scale!(LinAlg.copy_oftype(A, T), A, D.diag)
 end
@@ -139,21 +139,21 @@ end
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
 
-(*)(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(A,B)
-*(A::SparseMatrixCSC{Tv,Ti}, transB::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} =
+(*)(A::SparseMatrix{Tv,Ti}, B::SparseMatrix{Tv,Ti}) where {Tv,Ti} = spmatmul(A,B)
+*(A::SparseMatrix{Tv,Ti}, transB::Transpose{<:Any,<:SparseMatrix{Tv,Ti}}) where {Tv,Ti} =
     (B = transB.parent; spmatmul(A, transpose(B)))
-*(A::SparseMatrixCSC{Tv,Ti}, adjB::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} =
+*(A::SparseMatrix{Tv,Ti}, adjB::Adjoint{<:Any,<:SparseMatrix{Tv,Ti}}) where {Tv,Ti} =
     (B = adjB.parent; spmatmul(A, adjoint(B)))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} =
+*(transA::Transpose{<:Any,<:SparseMatrix{Tv,Ti}}, B::SparseMatrix{Tv,Ti}) where {Tv,Ti} =
     (A = transA.parent; spmatmul(tranpsose(A), B))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} =
+*(adjA::Adjoint{<:Any,<:SparseMatrix{Tv,Ti}}, B::SparseMatrix{Tv,Ti}) where {Tv,Ti} =
     (A = adjA.parent; spmatmul(adjoint(A), B))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}, transB::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} =
+*(transA::Transpose{<:Any,<:SparseMatrix{Tv,Ti}}, transB::Transpose{<:Any,<:SparseMatrix{Tv,Ti}}) where {Tv,Ti} =
     (A = transA.parent; B = transB.parent; spmatmul(transpose(A), transpose(B)))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}, adjB::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} =
+*(adjA::Adjoint{<:Any,<:SparseMatrix{Tv,Ti}}, adjB::Adjoint{<:Any,<:SparseMatrix{Tv,Ti}}) where {Tv,Ti} =
     (A = adjA.parent; B = adjB.parent; spmatmul(adjoint(A), adjoint(B)))
 
-function spmatmul(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
+function spmatmul(A::SparseMatrix{Tv,Ti}, B::SparseMatrix{Tv,Ti};
                   sortindices::Symbol = :sortcols) where {Tv,Ti}
     mA, nA = size(A)
     mB, nB = size(B)
@@ -205,13 +205,13 @@ function spmatmul(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
     deleteat!(nzvalC, colptrC[end]:length(nzvalC))
 
     # The Gustavson algorithm does not guarantee the product to have sorted row indices.
-    Cunsorted = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
-    C = SparseArrays.sortSparseMatrixCSC!(Cunsorted, sortindices=sortindices)
+    Cunsorted = SparseMatrix(mA, nB, colptrC, rowvalC, nzvalC)
+    C = SparseArrays.sortSparseMatrix!(Cunsorted, sortindices=sortindices)
     return C
 end
 
 ## solvers
-function fwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
+function fwdTriSolve!(A::SparseMatrixUnion, B::AbstractVecOrMat)
 # forward substitution for CSC matrices
     nrowB, ncolB  = size(B, 1), size(B, 2)
     ncol = LinAlg.checksquare(A)
@@ -256,7 +256,7 @@ function fwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
     B
 end
 
-function bwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
+function bwdTriSolve!(A::SparseMatrixUnion, B::AbstractVecOrMat)
 # backward substitution for CSC matrices
     nrowB, ncolB = size(B, 1), size(B, 2)
     ncol = LinAlg.checksquare(A)
@@ -301,16 +301,16 @@ function bwdTriSolve!(A::SparseMatrixCSCUnion, B::AbstractVecOrMat)
     B
 end
 
-ldiv!(L::LowerTriangular{T,<:SparseMatrixCSCUnion{T}}, B::StridedVecOrMat) where {T} = fwdTriSolve!(L.data, B)
-ldiv!(U::UpperTriangular{T,<:SparseMatrixCSCUnion{T}}, B::StridedVecOrMat) where {T} = bwdTriSolve!(U.data, B)
+ldiv!(L::LowerTriangular{T,<:SparseMatrixUnion{T}}, B::StridedVecOrMat) where {T} = fwdTriSolve!(L.data, B)
+ldiv!(U::UpperTriangular{T,<:SparseMatrixUnion{T}}, B::StridedVecOrMat) where {T} = bwdTriSolve!(U.data, B)
 
-(\)(L::LowerTriangular{T,<:SparseMatrixCSCUnion{T}}, B::SparseMatrixCSC) where {T} = ldiv!(L, Array(B))
-(\)(U::UpperTriangular{T,<:SparseMatrixCSCUnion{T}}, B::SparseMatrixCSC) where {T} = ldiv!(U, Array(B))
-\(A::Transpose{<:Real,<:Hermitian{<:Real,<:SparseMatrixCSC}}, B::Vector) = A.parent \ B
-\(A::Transpose{<:Complex,<:Hermitian{<:Complex,<:SparseMatrixCSC}}, B::Vector) = transpose(A.parent) \ B
-\(A::Transpose{<:Number,<:Symmetric{<:Number,<:SparseMatrixCSC}}, B::Vector) = A.parent \ B
+(\)(L::LowerTriangular{T,<:SparseMatrixUnion{T}}, B::SparseMatrix) where {T} = ldiv!(L, Array(B))
+(\)(U::UpperTriangular{T,<:SparseMatrixUnion{T}}, B::SparseMatrix) where {T} = ldiv!(U, Array(B))
+\(A::Transpose{<:Real,<:Hermitian{<:Real,<:SparseMatrix}}, B::Vector) = A.parent \ B
+\(A::Transpose{<:Complex,<:Hermitian{<:Complex,<:SparseMatrix}}, B::Vector) = transpose(A.parent) \ B
+\(A::Transpose{<:Number,<:Symmetric{<:Number,<:SparseMatrix}}, B::Vector) = A.parent \ B
 
-function rdiv!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T
+function rdiv!(A::SparseMatrix{T}, D::Diagonal{T}) where T
     dd = D.diag
     if (k = length(dd)) ≠ A.n
         throw(DimensionMismatch("size(A, 2)=$(A.n) should be size(D, 1)=$k"))
@@ -328,14 +328,14 @@ function rdiv!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T
     A
 end
 
-rdiv!(A::SparseMatrixCSC{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
+rdiv!(A::SparseMatrix{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
     (D = adjD.parent; rdiv!(A, conj(D)))
-rdiv!(A::SparseMatrixCSC{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
+rdiv!(A::SparseMatrix{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
     (D = transD.parent; rdiv!(A, D))
 
 ## triu, tril
 
-function triu(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
+function triu(S::SparseMatrix{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     m,n = size(S)
     if !(-m + 1 <= k <= n + 1)
         throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
@@ -355,7 +355,7 @@ function triu(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     end
     rowval = Vector{Ti}(uninitialized, nnz)
     nzval = Vector{Tv}(uninitialized, nnz)
-    A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
+    A = SparseMatrix(m, n, colptr, rowval, nzval)
     for col = max(k+1,1) : n
         c1 = S.colptr[col]
         for c2 = A.colptr[col] : A.colptr[col+1]-1
@@ -367,7 +367,7 @@ function triu(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     A
 end
 
-function tril(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
+function tril(S::SparseMatrix{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     m,n = size(S)
     if !(-m - 1 <= k <= n - 1)
         throw(ArgumentError(string("the requested diagonal, $k, must be at least ",
@@ -389,7 +389,7 @@ function tril(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     end
     rowval = Vector{Ti}(uninitialized, nnz)
     nzval = Vector{Tv}(uninitialized, nnz)
-    A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
+    A = SparseMatrix(m, n, colptr, rowval, nzval)
     for col = 1 : min(n, m+k)
         c1 = S.colptr[col+1]-1
         l2 = A.colptr[col+1]-1
@@ -404,9 +404,9 @@ end
 
 ## diff
 
-function sparse_diff1(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+function sparse_diff1(S::SparseMatrix{Tv,Ti}) where {Tv,Ti}
     m,n = size(S)
-    m > 1 || return SparseMatrixCSC(0, n, ones(Ti,n+1), Ti[], Tv[])
+    m > 1 || return SparseMatrix(0, n, ones(Ti,n+1), Ti[], Tv[])
     colptr = Vector{Ti}(uninitialized, n+1)
     numnz = 2 * nnz(S) # upper bound; will shrink later
     rowval = Vector{Ti}(uninitialized, numnz)
@@ -441,10 +441,10 @@ function sparse_diff1(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     end
     deleteat!(rowval, numnz+1:length(rowval))
     deleteat!(nzval, numnz+1:length(nzval))
-    return SparseMatrixCSC(m-1, n, colptr, rowval, nzval)
+    return SparseMatrix(m-1, n, colptr, rowval, nzval)
 end
 
-function sparse_diff2(a::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+function sparse_diff2(a::SparseMatrix{Tv,Ti}) where {Tv,Ti}
     m,n = size(a)
     colptr = Vector{Ti}(uninitialized, max(n,1))
     numnz = 2 * nnz(a) # upper bound; will shrink later
@@ -460,7 +460,7 @@ function sparse_diff2(a::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     ptrS = 1
     colptr[1] = 1
 
-    n == 0 && return SparseMatrixCSC(m, n, colptr, rowval, nzval)
+    n == 0 && return SparseMatrix(m, n, colptr, rowval, nzval)
 
     startA = colptr_a[1]
     stopA = colptr_a[2]
@@ -530,15 +530,15 @@ function sparse_diff2(a::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     end
     deleteat!(rowval, ptrS:length(rowval))
     deleteat!(nzval, ptrS:length(nzval))
-    return SparseMatrixCSC(m, n-1, colptr, rowval, nzval)
+    return SparseMatrix(m, n-1, colptr, rowval, nzval)
 end
 
-diff(a::SparseMatrixCSC, dim::Integer)= dim==1 ? sparse_diff1(a) : sparse_diff2(a)
+diff(a::SparseMatrix, dim::Integer)= dim==1 ? sparse_diff1(a) : sparse_diff2(a)
 
 ## norm and rank
-vecnorm(A::SparseMatrixCSC, p::Real=2) = vecnorm(view(A.nzval, 1:nnz(A)), p)
+vecnorm(A::SparseMatrix, p::Real=2) = vecnorm(view(A.nzval, 1:nnz(A)), p)
 
-function norm(A::SparseMatrixCSC,p::Real=2)
+function norm(A::SparseMatrix,p::Real=2)
     m, n = size(A)
     if m == 0 || n == 0 || isempty(A)
         return float(real(zero(eltype(A))))
@@ -574,7 +574,7 @@ end
 # TODO rank
 
 # cond
-function cond(A::SparseMatrixCSC, p::Real=2)
+function cond(A::SparseMatrix, p::Real=2)
     if p == 1
         normAinv = normestinv(A)
         normA = norm(A, 1)
@@ -590,7 +590,7 @@ function cond(A::SparseMatrixCSC, p::Real=2)
     end
 end
 
-function normestinv(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)))) where T
+function normestinv(A::SparseMatrix{T}, t::Integer = min(2,maximum(size(A)))) where T
     maxiter = 5
     # Check the input
     n = checksquare(A)
@@ -763,7 +763,7 @@ end
 
 # kron
 
-function kron(a::SparseMatrixCSC{Tv,Ti}, b::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+function kron(a::SparseMatrix{Tv,Ti}, b::SparseMatrix{Tv,Ti}) where {Tv,Ti}
     numnzA = nnz(a)
     numnzB = nnz(b)
 
@@ -815,19 +815,19 @@ function kron(a::SparseMatrixCSC{Tv,Ti}, b::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti
             end
         end
     end
-    SparseMatrixCSC(m, n, colptr, rowval, nzval)
+    SparseMatrix(m, n, colptr, rowval, nzval)
 end
 
-function kron(A::SparseMatrixCSC{Tv1,Ti1}, B::SparseMatrixCSC{Tv2,Ti2}) where {Tv1,Ti1,Tv2,Ti2}
+function kron(A::SparseMatrix{Tv1,Ti1}, B::SparseMatrix{Tv2,Ti2}) where {Tv1,Ti1,Tv2,Ti2}
     Tv_res = promote_type(Tv1, Tv2)
     Ti_res = promote_type(Ti1, Ti2)
-    A = convert(SparseMatrixCSC{Tv_res,Ti_res}, A)
-    B = convert(SparseMatrixCSC{Tv_res,Ti_res}, B)
+    A = convert(SparseMatrix{Tv_res,Ti_res}, A)
+    B = convert(SparseMatrix{Tv_res,Ti_res}, B)
     return kron(A,B)
 end
 
-kron(A::SparseMatrixCSC, B::VecOrMat) = kron(A, sparse(B))
-kron(A::VecOrMat, B::SparseMatrixCSC) = kron(sparse(A), B)
+kron(A::SparseMatrix, B::VecOrMat) = kron(A, sparse(B))
+kron(A::VecOrMat, B::SparseMatrix) = kron(sparse(A), B)
 
 function kron(x::SparseVector{Tv,Ti},y::SparseVector{Tv,Ti}) where {Tv,Ti}
     nnzx = nnz(x)
@@ -856,14 +856,14 @@ kron(x::AbstractVector, y::SparseVector{Tv,Ti}) where {Tv,Ti} = kron(sparse(x), 
 
 ## det, inv, cond
 
-inv(A::SparseMatrixCSC) = error("The inverse of a sparse matrix can often be dense and can cause the computer to run out of memory. If you are sure you have enough memory, please convert your matrix to a dense matrix.")
+inv(A::SparseMatrix) = error("The inverse of a sparse matrix can often be dense and can cause the computer to run out of memory. If you are sure you have enough memory, please convert your matrix to a dense matrix.")
 
 # TODO
 
 ## scale methods
 
 # Copy colptr and rowval from one sparse matrix to another
-function copyinds!(C::SparseMatrixCSC, A::SparseMatrixCSC)
+function copyinds!(C::SparseMatrix, A::SparseMatrix)
     if C.colptr !== A.colptr
         resize!(C.colptr, length(A.colptr))
         copyto!(C.colptr, A.colptr)
@@ -875,7 +875,7 @@ function copyinds!(C::SparseMatrixCSC, A::SparseMatrixCSC)
 end
 
 # multiply by diagonal matrix as vector
-function scale!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Vector)
+function scale!(C::SparseMatrix, A::SparseMatrix, b::Vector)
     m, n = size(A)
     (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
     copyinds!(C, A)
@@ -888,7 +888,7 @@ function scale!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Vector)
     C
 end
 
-function scale!(C::SparseMatrixCSC, b::Vector, A::SparseMatrixCSC)
+function scale!(C::SparseMatrix, b::Vector, A::SparseMatrix)
     m, n = size(A)
     (m==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
     copyinds!(C, A)
@@ -902,7 +902,7 @@ function scale!(C::SparseMatrixCSC, b::Vector, A::SparseMatrixCSC)
     C
 end
 
-function scale!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Number)
+function scale!(C::SparseMatrix, A::SparseMatrix, b::Number)
     size(A)==size(C) || throw(DimensionMismatch())
     copyinds!(C, A)
     resize!(C.nzval, length(A.nzval))
@@ -910,7 +910,7 @@ function scale!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Number)
     C
 end
 
-function scale!(C::SparseMatrixCSC, b::Number, A::SparseMatrixCSC)
+function scale!(C::SparseMatrix, b::Number, A::SparseMatrix)
     size(A)==size(C) || throw(DimensionMismatch())
     copyinds!(C, A)
     resize!(C.nzval, length(A.nzval))
@@ -918,10 +918,10 @@ function scale!(C::SparseMatrixCSC, b::Number, A::SparseMatrixCSC)
     C
 end
 
-scale!(A::SparseMatrixCSC, b::Number) = (scale!(A.nzval, b); A)
-scale!(b::Number, A::SparseMatrixCSC) = (scale!(b, A.nzval); A)
+scale!(A::SparseMatrix, b::Number) = (scale!(A.nzval, b); A)
+scale!(b::Number, A::SparseMatrix) = (scale!(b, A.nzval); A)
 
-function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
+function \(A::SparseMatrix, B::AbstractVecOrMat)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -943,7 +943,7 @@ function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
 end
 for xform in (:Adjoint, :Transpose)
     @eval begin
-        function \(xformA::($xform){<:Any,<:SparseMatrixCSC}, B::AbstractVecOrMat)
+        function \(xformA::($xform){<:Any,<:SparseMatrix}, B::AbstractVecOrMat)
             A = xformA.parent
             m, n = size(A)
             if m == n
@@ -967,7 +967,7 @@ for xform in (:Adjoint, :Transpose)
     end
 end
 
-function factorize(A::SparseMatrixCSC)
+function factorize(A::SparseMatrix)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -988,7 +988,7 @@ function factorize(A::SparseMatrixCSC)
     end
 end
 
-# function factorize(A::Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}) where Ti
+# function factorize(A::Symmetric{Float64,SparseMatrix{Float64,Ti}}) where Ti
 #     F = cholfact(A)
 #     if LinAlg.issuccess(F)
 #         return F
@@ -997,7 +997,7 @@ end
 #         return F
 #     end
 # end
-function factorize(A::LinAlg.RealHermSymComplexHerm{Float64,<:SparseMatrixCSC})
+function factorize(A::LinAlg.RealHermSymComplexHerm{Float64,<:SparseMatrix})
     F = cholfact(A)
     if LinAlg.issuccess(F)
         return F
@@ -1007,11 +1007,11 @@ function factorize(A::LinAlg.RealHermSymComplexHerm{Float64,<:SparseMatrixCSC})
     end
 end
 
-chol(A::SparseMatrixCSC) = error("Use cholfact() instead of chol() for sparse matrices.")
-lu(A::SparseMatrixCSC) = error("Use lufact() instead of lu() for sparse matrices.")
-eig(A::SparseMatrixCSC) = error("Use IterativeEigensolvers.eigs() instead of eig() for sparse matrices.")
+chol(A::SparseMatrix) = error("Use cholfact() instead of chol() for sparse matrices.")
+lu(A::SparseMatrix) = error("Use lufact() instead of lu() for sparse matrices.")
+eig(A::SparseMatrix) = error("Use IterativeEigensolvers.eigs() instead of eig() for sparse matrices.")
 
-function Base.cov(X::SparseMatrixCSC, vardim::Int=1; corrected::Bool=true)
+function Base.cov(X::SparseMatrix, vardim::Int=1; corrected::Bool=true)
     a, b = size(X)
     n, p = vardim == 1 ? (a, b) : (b, a)
 

--- a/base/sparse/sparse.jl
+++ b/base/sparse/sparse.jl
@@ -30,7 +30,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     triu, vec, permute!, map, map!
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
-    SparseMatrixCSC, SparseVector, blkdiag, droptol!, dropzeros!, dropzeros,
+    SparseMatrix, SparseVector, blkdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
     sprand, sprandn, spzeros, nnz, permute
 

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -17,7 +17,7 @@ allows you to combine these styles of indexing: for example, a 3d array `A3` can
 For `Array`s, linear indexing appeals to the underlying storage format: an array is laid out as
 a contiguous block of memory, and hence the linear index is just the offset (+1) of the corresponding
 entry relative to the beginning of the array.  However, this is not true for many other `AbstractArray`
-types: examples include [`SparseMatrixCSC`](@ref), arrays that require some kind of
+types: examples include [`SparseMatrix`](@ref), arrays that require some kind of
 computation (such as interpolation), and the type under discussion here, `SubArray`.
 For these types, the underlying information is more naturally described in terms of
 cartesian indices.

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -707,12 +707,12 @@ in space and execution time, compared to dense arrays.
 ### [Compressed Sparse Column (CSC) Sparse Matrix Storage](@id man-csc)
 
 In Julia, sparse matrices are stored in the [Compressed Sparse Column (CSC) format](https://en.wikipedia.org/wiki/Sparse_matrix#Compressed_sparse_column_.28CSC_or_CCS.29).
-Julia sparse matrices have the type [`SparseMatrixCSC{Tv,Ti}`](@ref), where `Tv` is the
+Julia sparse matrices have the type [`SparseMatrix{Tv,Ti}`](@ref), where `Tv` is the
 type of the stored values, and `Ti` is the integer type for storing column pointers and
-row indices. The internal representation of `SparseMatrixCSC` is as follows:
+row indices. The internal representation of `SparseMatrix` is as follows:
 
 ```julia
-struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
+struct SparseMatrix{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows
     n::Int                  # Number of columns
     colptr::Vector{Ti}      # Column i is in colptr[i]:(colptr[i+1]-1)
@@ -732,10 +732,10 @@ for performance, and to avoid expensive operations.
 
 If you have data in CSC format from a different application or library, and wish to import it
 in Julia, make sure that you use 1-based indexing. The row indices in every column need to be
-sorted. If your `SparseMatrixCSC` object contains unsorted row indices, one quick way to sort
+sorted. If your `SparseMatrix` object contains unsorted row indices, one quick way to sort
 them is by doing a double transpose.
 
-In some applications, it is convenient to store explicit zero values in a `SparseMatrixCSC`. These
+In some applications, it is convenient to store explicit zero values in a `SparseMatrix`. These
 *are* accepted by functions in `Base` (but there is no guarantee that they will be preserved in
 mutating operations). Such explicitly stored zeros are treated as structural nonzeros by many
 routines. The [`nnz`](@ref) function returns the number of elements explicitly stored in the
@@ -746,13 +746,13 @@ remove stored zeros from the sparse matrix.
 
 ```jldoctest
 julia> A = sparse([1, 2, 3], [1, 2, 3], [0, 2, 0])
-3×3 SparseMatrixCSC{Int64,Int64} with 3 stored entries:
+3×3 SparseMatrix{Int64,Int64} with 3 stored entries:
   [1, 1]  =  0
   [2, 2]  =  2
   [3, 3]  =  0
 
 julia> dropzeros(A)
-3×3 SparseMatrixCSC{Int64,Int64} with 1 stored entry:
+3×3 SparseMatrix{Int64,Int64} with 1 stored entry:
   [2, 2]  =  2
 ```
 
@@ -771,7 +771,7 @@ struct SparseVector{Tv,Ti<:Integer} <: AbstractSparseVector{Tv,Ti}
 end
 ```
 
-As for [`SparseMatrixCSC`](@ref), the `SparseVector` type can also contain explicitly
+As for [`SparseMatrix`](@ref), the `SparseVector` type can also contain explicitly
 stored zeros. (See [Sparse Matrix Storage](@ref man-csc).).
 
 ### Sparse Vector and Matrix Constructors
@@ -798,7 +798,7 @@ such that `R[I[k]] = V[k]`.
 julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
 julia> S = sparse(I,J,V)
-5×18 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
+5×18 SparseMatrix{Int64,Int64} with 4 stored entries:
   [1 ,  4]  =  1
   [4 ,  7]  =  2
   [5 ,  9]  =  3
@@ -839,7 +839,7 @@ the [`sparse`](@ref) function:
 
 ```jldoctest
 julia> sparse(Matrix(1.0I, 5, 5))
-5×5 SparseMatrixCSC{Float64,Int64} with 5 stored entries:
+5×5 SparseMatrix{Float64,Int64} with 5 stored entries:
   [1, 1]  =  1.0
   [2, 2]  =  1.0
   [3, 3]  =  1.0

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -250,9 +250,9 @@ arrays are simple: just define `getindex(A::ArrayType, i::Int)`.  When the array
 indexed with a multidimensional set of indices, the fallback `getindex(A::AbstractArray, I...)()`
 efficiently converts the indices into one linear index and then calls the above method. `IndexCartesian()`
 arrays, on the other hand, require methods to be defined for each supported dimensionality with
-`ndims(A)` `Int` indices. For example, the built-in [`SparseMatrixCSC`](@ref) type only
+`ndims(A)` `Int` indices. For example, the built-in [`SparseMatrix`](@ref) type only
 supports two dimensions, so it just defines
-`getindex(A::SparseMatrixCSC, i::Int, j::Int)`. The same holds for `setindex!`.
+`getindex(A::SparseMatrix, i::Int, j::Int)`. The same holds for `setindex!`.
 
 Returning to the sequence of squares from above, we could instead define it as a subtype of an
 `AbstractArray{Int, 1}`:
@@ -572,7 +572,7 @@ subtype `AbstractArrayStyle`. For example, the sparse array code has the followi
 struct SparseVecStyle <: Broadcast.AbstractArrayStyle{1} end
 struct SparseMatStyle <: Broadcast.AbstractArrayStyle{2} end
 Base.BroadcastStyle(::Type{<:SparseVector}) = SparseVecStyle()
-Base.BroadcastStyle(::Type{<:SparseMatrixCSC}) = SparseMatStyle()
+Base.BroadcastStyle(::Type{<:SparseMatrix}) = SparseMatStyle()
 ```
 
 Whenever you subtype `AbstractArrayStyle`, you also need to define rules for combining

--- a/doc/src/stdlib/arrays.md
+++ b/doc/src/stdlib/arrays.md
@@ -196,7 +196,7 @@ The following functions are specific to sparse arrays.
 
 ```@docs
 Base.SparseArrays.SparseVector
-Base.SparseArrays.SparseMatrixCSC
+Base.SparseArrays.SparseMatrix
 Base.SparseArrays.sparse
 Base.SparseArrays.sparsevec
 Base.SparseArrays.issparse
@@ -208,10 +208,10 @@ Base.SparseArrays.sprandn
 Base.SparseArrays.nonzeros
 Base.SparseArrays.rowvals
 Base.SparseArrays.nzrange
-Base.SparseArrays.dropzeros!(::SparseMatrixCSC, ::Bool)
-Base.SparseArrays.dropzeros(::SparseMatrixCSC, ::Bool)
+Base.SparseArrays.dropzeros!(::SparseMatrix, ::Bool)
+Base.SparseArrays.dropzeros(::SparseMatrix, ::Bool)
 Base.SparseArrays.dropzeros!(::SparseVector, ::Bool)
 Base.SparseArrays.dropzeros(::SparseVector, ::Bool)
 Base.SparseArrays.permute
-Base.permute!{Tv, Ti, Tp <: Integer, Tq <: Integer}(::SparseMatrixCSC{Tv,Ti}, ::SparseMatrixCSC{Tv,Ti}, ::AbstractArray{Tp,1}, ::AbstractArray{Tq,1})
+Base.permute!{Tv, Ti, Tp <: Integer, Tq <: Integer}(::SparseMatrix{Tv,Ti}, ::SparseMatrix{Tv,Ti}, ::AbstractArray{Tp,1}, ::AbstractArray{Tq,1})
 ```

--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -22,11 +22,11 @@ using Test
             b = breal
         end
         a_evs = eigvals(Array(a))
-        a     = convert(SparseMatrixCSC{elty}, a)
+        a     = convert(SparseMatrix{elty}, a)
         asym  = a' + a                  # symmetric indefinite
         apd   = a'*a                    # symmetric positive-definite
 
-        b     = convert(SparseMatrixCSC{elty}, b)
+        b     = convert(SparseMatrix{elty}, b)
         bsym  = b' + b
         bpd   = b'*b
 

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -105,7 +105,7 @@ mutable struct UmfpackLU{Tv<:UMFVTypes,Ti<:UMFITypes} <: Factorization{Tv}
 end
 
 """
-    lufact(A::SparseMatrixCSC) -> F::UmfpackLU
+    lufact(A::SparseMatrix) -> F::UmfpackLU
 
 Compute the LU factorization of a sparse matrix `A`.
 
@@ -135,12 +135,12 @@ The relation between `F` and `A` is
 - [`det`](@ref)
 
 !!! note
-    `lufact(A::SparseMatrixCSC)` uses the UMFPACK library that is part of
+    `lufact(A::SparseMatrix)` uses the UMFPACK library that is part of
     SuiteSparse. As this library only supports sparse matrices with [`Float64`](@ref) or
     `ComplexF64` elements, `lufact` converts `A` into a copy that is of type
-    `SparseMatrixCSC{Float64}` or `SparseMatrixCSC{ComplexF64}` as appropriate.
+    `SparseMatrix{Float64}` or `SparseMatrix{ComplexF64}` as appropriate.
 """
-function lufact(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes})
+function lufact(S::SparseMatrix{<:UMFVTypes,<:UMFITypes})
     zerobased = S.colptr[1] == 0
     res = UmfpackLU(C_NULL, C_NULL, S.m, S.n,
                     zerobased ? copy(S.colptr) : decrement(S.colptr),
@@ -149,16 +149,16 @@ function lufact(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes})
     finalizer(umfpack_free_symbolic, res)
     umfpack_numeric!(res)
 end
-lufact(A::SparseMatrixCSC{<:Union{Float16,Float32},Ti}) where {Ti<:UMFITypes} =
-    lufact(convert(SparseMatrixCSC{Float64,Ti}, A))
-lufact(A::SparseMatrixCSC{<:Union{ComplexF16,ComplexF32},Ti}) where {Ti<:UMFITypes} =
-    lufact(convert(SparseMatrixCSC{ComplexF64,Ti}, A))
-lufact(A::Union{SparseMatrixCSC{T},SparseMatrixCSC{Complex{T}}}) where {T<:AbstractFloat} =
+lufact(A::SparseMatrix{<:Union{Float16,Float32},Ti}) where {Ti<:UMFITypes} =
+    lufact(convert(SparseMatrix{Float64,Ti}, A))
+lufact(A::SparseMatrix{<:Union{ComplexF16,ComplexF32},Ti}) where {Ti<:UMFITypes} =
+    lufact(convert(SparseMatrix{ComplexF64,Ti}, A))
+lufact(A::Union{SparseMatrix{T},SparseMatrix{Complex{T}}}) where {T<:AbstractFloat} =
     throw(ArgumentError(string("matrix type ", typeof(A), "not supported. ",
-    "Try lufact(convert(SparseMatrixCSC{Float64/ComplexF64,Int}, A)) for ",
+    "Try lufact(convert(SparseMatrix{Float64/ComplexF64,Int}, A)) for ",
     "sparse floating point LU using UMFPACK or lufact(Array(A)) for generic ",
     "dense LU.")))
-lufact(A::SparseMatrixCSC) = lufact(float(A))
+lufact(A::SparseMatrix) = lufact(float(A))
 
 
 size(F::UmfpackLU) = (F.m, F.n)
@@ -345,8 +345,8 @@ for itype in UmfpackIndexTypes
                         Up,Ui,Ux,
                         P, Q, C_NULL,
                         0, Rs, lu.numeric)
-            (transpose(SparseMatrixCSC(min(n_row, n_col), n_row, increment!(Lp), increment!(Lj), Lx)),
-             SparseMatrixCSC(min(n_row, n_col), n_col, increment!(Up), increment!(Ui), Ux),
+            (transpose(SparseMatrix(min(n_row, n_col), n_row, increment!(Lp), increment!(Lj), Lx)),
+             SparseMatrix(min(n_row, n_col), n_col, increment!(Up), increment!(Ui), Ux),
              increment!(P), increment!(Q), Rs)
         end
         function umf_extract(lu::UmfpackLU{ComplexF64,$itype})
@@ -372,8 +372,8 @@ for itype in UmfpackIndexTypes
                         Up,Ui,Ux,Uz,
                         P, Q, C_NULL, C_NULL,
                         0, Rs, lu.numeric)
-            (transpose(SparseMatrixCSC(min(n_row, n_col), n_row, increment!(Lp), increment!(Lj), complex.(Lx, Lz))),
-             SparseMatrixCSC(min(n_row, n_col), n_col, increment!(Up), increment!(Ui), complex.(Ux, Uz)),
+            (transpose(SparseMatrix(min(n_row, n_col), n_row, increment!(Lp), increment!(Lj), complex.(Lx, Lz))),
+             SparseMatrix(min(n_row, n_col), n_col, increment!(Up), increment!(Ui), complex.(Ux, Uz)),
              increment!(P), increment!(Q), Rs)
         end
     end

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -162,11 +162,11 @@ end
 @testset "Issue 9160" begin
     local A, B
     A = sprand(10, 10, 0.1)
-    A = convert(SparseMatrixCSC{Float64,CHOLMOD.SuiteSparse_long}, A)
+    A = convert(SparseMatrix{Float64,CHOLMOD.SuiteSparse_long}, A)
     cmA = CHOLMOD.Sparse(A)
 
     B = sprand(10, 10, 0.1)
-    B = convert(SparseMatrixCSC{Float64,CHOLMOD.SuiteSparse_long}, B)
+    B = convert(SparseMatrix{Float64,CHOLMOD.SuiteSparse_long}, B)
     cmB = CHOLMOD.Sparse(B)
 
     # Ac_mul_B
@@ -342,11 +342,11 @@ end
     end #Construct Hermitian matrix properly
     @test CHOLMOD.sparse(CHOLMOD.Sparse(Hermitian(A1, :L))) == Hermitian(A1, :L)
     @test CHOLMOD.sparse(CHOLMOD.Sparse(Hermitian(A1, :U))) == Hermitian(A1, :U)
-    @test_throws ArgumentError convert(SparseMatrixCSC{elty,Int}, A1pdSparse)
+    @test_throws ArgumentError convert(SparseMatrix{elty,Int}, A1pdSparse)
     if elty <: Real
-        @test_throws ArgumentError convert(Symmetric{Float64,SparseMatrixCSC{Float64,Int}}, A1Sparse)
+        @test_throws ArgumentError convert(Symmetric{Float64,SparseMatrix{Float64,Int}}, A1Sparse)
     else
-        @test_throws ArgumentError convert(Hermitian{Complex{Float64},SparseMatrixCSC{Complex{Float64},Int}}, A1Sparse)
+        @test_throws ArgumentError convert(Hermitian{Complex{Float64},SparseMatrix{Complex{Float64},Int}}, A1Sparse)
     end
     @test copy(A1Sparse) == A1Sparse
     @test size(A1Sparse, 3) == 1
@@ -698,7 +698,7 @@ end
     @test F2\b ≈ ones(m + n)
 end
 
-@testset "Test that imaginary parts in Hermitian{T,SparseMatrixCSC{T}} are ignored" begin
+@testset "Test that imaginary parts in Hermitian{T,SparseMatrix{T}} are ignored" begin
     A = sparse([1,2,3,4,1], [1,2,3,4,2], [complex(2.0,1),2,2,2,1])
     Fs = cholfact(Hermitian(A))
     Fd = cholfact(Hermitian(Array(A)))
@@ -722,7 +722,7 @@ end
     end
 end
 
-@testset "Check that Symmetric{SparseMatrixCSC} can be constructed from CHOLMOD.Sparse" begin
+@testset "Check that Symmetric{SparseMatrix} can be constructed from CHOLMOD.Sparse" begin
     Int === Int32 && srand(124)
     A = sprandn(10, 10, 0.1)
     B = CHOLMOD.Sparse(A)
@@ -731,15 +731,15 @@ end
     o = fieldoffset(CHOLMOD.C_Sparse{eltype(C)}, find(fieldnames(CHOLMOD.C_Sparse{eltype(C)}) .== :stype)[1])
     for uplo in (1, -1)
         unsafe_store!(Ptr{Int8}(pointer(C)), uplo, Int(o) + 1)
-        @test convert(Symmetric{Float64,SparseMatrixCSC{Float64,Int}}, C) == Symmetric(A'A)
+        @test convert(Symmetric{Float64,SparseMatrix{Float64,Int}}, C) == Symmetric(A'A)
     end
 end
 
 @testset "Check inputs to Sparse. Related to #20024" for A_ in (
-    SparseMatrixCSC(2, 2, [1, 2], CHOLMOD.SuiteSparse_long[], Float64[]),
-    SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1], Float64[]),
-    SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[], Float64[1.0]),
-    SparseMatrixCSC(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1], Float64[1.0]))
+    SparseMatrix(2, 2, [1, 2], CHOLMOD.SuiteSparse_long[], Float64[]),
+    SparseMatrix(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1], Float64[]),
+    SparseMatrix(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[], Float64[1.0]),
+    SparseMatrix(2, 2, [1, 2, 3], CHOLMOD.SuiteSparse_long[1], Float64[1.0]))
     @test_throws ArgumentError CHOLMOD.Sparse(size(A_)..., A_.colptr .- 1, A_.rowval .- 1, A_.nzval)
     @test_throws ArgumentError CHOLMOD.Sparse(A_)
 end
@@ -755,7 +755,7 @@ end
 end
 
 @testset "Test sparse low rank update for cholesky decomposion" begin
-    A = SparseMatrixCSC{Float64,CHOLMOD.SuiteSparse_long}(10, 5, [1,3,6,8,10,13], [6,7,1,2,9,3,5,1,7,6,7,9],
+    A = SparseMatrix{Float64,CHOLMOD.SuiteSparse_long}(10, 5, [1,3,6,8,10,13], [6,7,1,2,9,3,5,1,7,6,7,9],
         [-0.138843, 2.99571, -0.556814, 0.669704, -1.39252, 1.33814,
         1.02371, -0.502384, 1.10686, 0.262229, -1.6935, 0.525239])
     AtA = A'*A

--- a/stdlib/SuiteSparse/test/spqr.jl
+++ b/stdlib/SuiteSparse/test/spqr.jl
@@ -66,7 +66,7 @@ nn = 100
     end
 
     # Make sure that conversion to Sparse doesn't use SuiteSparse's symmetric flag
-    @test qrfact(SparseMatrixCSC{eltyA}(I, 5, 5)) \ ones(eltyA, 5) == ones(5)
+    @test qrfact(SparseMatrix{eltyA}(I, 5, 5)) \ ones(eltyA, 5) == ones(5)
 end
 
 @testset "basic solution of rank deficient ls" begin

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -17,7 +17,7 @@
     @testset "Core functionality for $Tv elements" for Tv in (Float64, ComplexF64)
         # We might be able to support two index sizes one day
         for Ti in Base.uniontypes(SuiteSparse.UMFPACK.UMFITypes)
-            A = convert(SparseMatrixCSC{Tv,Ti}, A0)
+            A = convert(SparseMatrix{Tv,Ti}, A0)
             lua = lufact(A)
             @test nnz(lua) == 18
             @test_throws KeyError lua[:Z]
@@ -75,7 +75,7 @@
     @testset "More tests for complex cases" begin
         Ac0 = complex.(A0,A0)
         for Ti in Base.uniontypes(SuiteSparse.UMFPACK.UMFITypes)
-            Ac = convert(SparseMatrixCSC{ComplexF64,Ti}, Ac0)
+            Ac = convert(SparseMatrix{ComplexF64,Ti}, Ac0)
             x  = complex.(ones(size(Ac, 1)), ones(size(Ac,1)))
             lua = lufact(Ac)
             L,U,p,q,Rs = lua[:(:)]

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -75,7 +75,7 @@ vals = Any[
     [], [1], [2], [1, 1], [1, 2], [1, 3], [2, 2], [1, 2, 2], [1, 3, 3],
     zeros(2, 2), spzeros(2, 2), Matrix(1.0I, 2, 2), sparse(1.0I, 2, 2),
     sparse(ones(2, 2)), ones(2, 2), sparse([0 0; 1 0]), [0 0; 1 0],
-    [-0. 0; -0. 0.], SparseMatrixCSC(2, 2, [1, 3, 3], [1, 2], [-0., -0.])
+    [-0. 0; -0. 0.], SparseMatrix(2, 2, [1, 3, 3], [1, 2], [-0., -0.])
 ]
 
 for a in vals, b in vals
@@ -88,7 +88,7 @@ end
 
 @test hash([1,2]) == hash(view([1,2,3,4],1:2))
 
-# test explicit zeros in SparseMatrixCSC
+# test explicit zeros in SparseMatrix
 x = sprand(10, 10, 0.5)
 x[1] = 1
 x.nzval[1] = 0

--- a/test/linalg/bidiag.jl
+++ b/test/linalg/bidiag.jl
@@ -82,8 +82,8 @@ srand(1)
         @test similar(ubd).uplo == ubd.uplo
         @test isa(similar(ubd, Int), Bidiagonal{Int})
         @test similar(ubd, Int).uplo == ubd.uplo
-        @test isa(similar(ubd, (3, 2)), SparseMatrixCSC)
-        @test isa(similar(ubd, Int, (3, 2)), SparseMatrixCSC{Int})
+        @test isa(similar(ubd, (3, 2)), SparseMatrix)
+        @test isa(similar(ubd, Int, (3, 2)), SparseMatrix{Int})
     end
 
     @testset "show" begin

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -240,8 +240,8 @@ srand(1)
     @testset "similar" begin
         @test isa(similar(D), Diagonal{elty})
         @test isa(similar(D, Int), Diagonal{Int})
-        @test isa(similar(D, (3,2)), SparseMatrixCSC{elty})
-        @test isa(similar(D, Int, (3,2)), SparseMatrixCSC{Int})
+        @test isa(similar(D, (3,2)), SparseMatrix{elty})
+        @test isa(similar(D, Int, (3,2)), SparseMatrix{Int})
     end
 
     # Issue number 10036

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -457,10 +457,10 @@ end
         symsparsemat = SymType(sparsemat)
         @test isa(similar(symsparsemat), typeof(symsparsemat))
         @test similar(symsparsemat).uplo == symsparsemat.uplo
-        @test isa(similar(symsparsemat, Float32), SymType{Float32,<:SparseMatrixCSC{Float32}})
+        @test isa(similar(symsparsemat, Float32), SymType{Float32,<:SparseMatrix{Float32}})
         @test similar(symsparsemat, Float32).uplo == symsparsemat.uplo
         @test isa(similar(symsparsemat, (n, n)), typeof(sparsemat))
-        @test isa(similar(symsparsemat, Float32, (n, n)), SparseMatrixCSC{Float32})
+        @test isa(similar(symsparsemat, Float32, (n, n)), SparseMatrix{Float32})
     end
 end
 

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -527,8 +527,8 @@ end
     for TriType in (UpperTriangular, LowerTriangular, UnitUpperTriangular, UnitLowerTriangular)
         trisparsemat = TriType(sparsemat)
         @test isa(similar(trisparsemat), typeof(trisparsemat))
-        @test isa(similar(trisparsemat, Float32), TriType{Float32,<:SparseMatrixCSC{Float32}})
+        @test isa(similar(trisparsemat, Float32), TriType{Float32,<:SparseMatrix{Float32}})
         @test isa(similar(trisparsemat, (n, n)), typeof(sparsemat))
-        @test isa(similar(trisparsemat, Float32, (n, n)), SparseMatrixCSC{Float32})
+        @test isa(similar(trisparsemat, Float32, (n, n)), SparseMatrix{Float32})
     end
 end

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -128,8 +128,8 @@ end
             end
             @test isa(similar(A), mat_type{elty})
             @test isa(similar(A, Int), mat_type{Int})
-            @test isa(similar(A, (3, 2)), SparseMatrixCSC)
-            @test isa(similar(A, Int, (3, 2)), SparseMatrixCSC{Int})
+            @test isa(similar(A, (3, 2)), SparseMatrix)
+            @test isa(similar(A, Int, (3, 2)), SparseMatrix{Int})
             @test size(A, 3) == 1
             @test size(A, 1) == n
             @test size(A) == (n, n)
@@ -297,8 +297,8 @@ end
                     @testset "similar" begin
                         @test isa(similar(Ts), SymTridiagonal{elty})
                         @test isa(similar(Ts, Int), SymTridiagonal{Int})
-                        @test isa(similar(Ts, (3, 2)), SparseMatrixCSC)
-                        @test isa(similar(Ts, Int, (3, 2)), SparseMatrixCSC{Int})
+                        @test isa(similar(Ts, (3, 2)), SparseMatrix)
+                        @test isa(similar(Ts, Int, (3, 2)), SparseMatrix{Int})
                     end
 
                     @test first(logabsdet(Tldlt)) ≈ first(logabsdet(Fs))

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -171,7 +171,7 @@ end
     @test_throws ArgumentError vcat(I)
     @test_throws ArgumentError [I; I]
     @test_throws ArgumentError [I I; I]
-    for T in (Matrix, SparseMatrixCSC)
+    for T in (Matrix, SparseMatrix)
         A = T(rand(3,4))
         B = T(rand(3,3))
         @test (hcat(A, 2I))::T == hcat(A, Matrix(2I, 3, 3))

--- a/test/perf/sparse/getindex.jl
+++ b/test/perf/sparse/getindex.jl
@@ -42,7 +42,7 @@ function sparse_getindex_perf()
     ## using uint32 (works up to 10^9)
     uus = []
     for u in us
-        push!(uus, SparseMatrixCSC(u.m, u.n, map(UInt32,u.colptr), map(UInt32,u.rowval), u.nzval))
+        push!(uus, SparseMatrix(u.m, u.n, map(UInt32,u.colptr), map(UInt32,u.rowval), u.nzval))
     end
 
     # test performance with matrices in us, uus and ts for

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -8,13 +8,13 @@ using Base.Printf.@printf
     @test !issparse(ones(5,5))
 end
 
-@testset "iszero specialization for SparseMatrixCSC" begin
+@testset "iszero specialization for SparseMatrix" begin
     @test !iszero(sparse(I, 3, 3))                  # test failure
     @test iszero(spzeros(3, 3))                     # test success with no stored entries
     @test iszero(setindex!(sparse(I, 3, 3), 0, :))  # test success with stored zeros
-    @test iszero(SparseMatrixCSC(2, 2, [1,2,3], [1,2], [0,0,1])) # test success with nonzeros beyond data range
+    @test iszero(SparseMatrix(2, 2, [1,2,3], [1,2], [0,0,1])) # test success with nonzeros beyond data range
 end
-@testset "isone specialization for SparseMatrixCSC" begin
+@testset "isone specialization for SparseMatrix" begin
     @test isone(sparse(I, 3, 3))    # test success
     @test !isone(sparse(I, 3, 4))   # test failure for non-square matrix
     @test !isone(spzeros(3, 3))     # test failure for too few stored entries
@@ -34,38 +34,38 @@ end
     @test_throws ArgumentError sparse([1,2,3], [1,2,3], [1,2,3], 1, 0)
     @test_throws ArgumentError sparse([1,2,4], [1,2,3], [1,2,3], 3, 3)
     @test_throws ArgumentError sparse([1,2,3], [1,2,4], [1,2,3], 3, 3)
-    @test isequal(sparse(Int[], Int[], Int[], 0, 0), SparseMatrixCSC(0, 0, Int[1], Int[], Int[]))
+    @test isequal(sparse(Int[], Int[], Int[], 0, 0), SparseMatrix(0, 0, Int[1], Int[], Int[]))
     @test sparse(Any[1,2,3], Any[1,2,3], Any[1,1,1]) == sparse([1,2,3], [1,2,3], [1,1,1])
     @test sparse(Any[1,2,3], Any[1,2,3], Any[1,1,1], 5, 4) == sparse([1,2,3], [1,2,3], [1,1,1], 5, 4)
 end
 
-@testset "SparseMatrixCSC construction from UniformScaling" begin
-    @test_throws ArgumentError SparseMatrixCSC(I, -1, 3)
-    @test_throws ArgumentError SparseMatrixCSC(I, 3, -1)
-    @test SparseMatrixCSC(2I, 3, 3)::SparseMatrixCSC{Int,Int} == Matrix(2I, 3, 3)
-    @test SparseMatrixCSC(2I, 3, 4)::SparseMatrixCSC{Int,Int} == Matrix(2I, 3, 4)
-    @test SparseMatrixCSC(2I, 4, 3)::SparseMatrixCSC{Int,Int} == Matrix(2I, 4, 3)
-    @test SparseMatrixCSC(2.0I, 3, 3)::SparseMatrixCSC{Float64,Int} == Matrix(2I, 3, 3)
-    @test SparseMatrixCSC{Real}(2I, 3, 3)::SparseMatrixCSC{Real,Int} == Matrix(2I, 3, 3)
-    @test SparseMatrixCSC{Float64}(2I, 3, 3)::SparseMatrixCSC{Float64,Int} == Matrix(2I, 3, 3)
-    @test SparseMatrixCSC{Float64,Int32}(2I, 3, 3)::SparseMatrixCSC{Float64,Int32} == Matrix(2I, 3, 3)
-    @test SparseMatrixCSC{Float64,Int32}(0I, 3, 3)::SparseMatrixCSC{Float64,Int32} == Matrix(0I, 3, 3)
+@testset "SparseMatrix construction from UniformScaling" begin
+    @test_throws ArgumentError SparseMatrix(I, -1, 3)
+    @test_throws ArgumentError SparseMatrix(I, 3, -1)
+    @test SparseMatrix(2I, 3, 3)::SparseMatrix{Int,Int} == Matrix(2I, 3, 3)
+    @test SparseMatrix(2I, 3, 4)::SparseMatrix{Int,Int} == Matrix(2I, 3, 4)
+    @test SparseMatrix(2I, 4, 3)::SparseMatrix{Int,Int} == Matrix(2I, 4, 3)
+    @test SparseMatrix(2.0I, 3, 3)::SparseMatrix{Float64,Int} == Matrix(2I, 3, 3)
+    @test SparseMatrix{Real}(2I, 3, 3)::SparseMatrix{Real,Int} == Matrix(2I, 3, 3)
+    @test SparseMatrix{Float64}(2I, 3, 3)::SparseMatrix{Float64,Int} == Matrix(2I, 3, 3)
+    @test SparseMatrix{Float64,Int32}(2I, 3, 3)::SparseMatrix{Float64,Int32} == Matrix(2I, 3, 3)
+    @test SparseMatrix{Float64,Int32}(0I, 3, 3)::SparseMatrix{Float64,Int32} == Matrix(0I, 3, 3)
 end
 @testset "sparse(S::UniformScaling, shape...) convenience constructors" begin
-    # we exercise these methods only lightly as these methods call the SparseMatrixCSC
+    # we exercise these methods only lightly as these methods call the SparseMatrix
     # constructor methods well-exercised by the immediately preceding testset
-    @test sparse(2I, 3, 4)::SparseMatrixCSC{Int,Int} == Matrix(2I, 3, 4)
-    @test sparse(2I, (3, 4))::SparseMatrixCSC{Int,Int} == Matrix(2I, 3, 4)
+    @test sparse(2I, 3, 4)::SparseMatrix{Int,Int} == Matrix(2I, 3, 4)
+    @test sparse(2I, (3, 4))::SparseMatrix{Int,Int} == Matrix(2I, 3, 4)
 end
 
-se33 = SparseMatrixCSC{Float64}(I, 3, 3)
+se33 = SparseMatrix{Float64}(I, 3, 3)
 do33 = ones(3)
 
 @testset "sparse binary operations" begin
     @test isequal(se33 * se33, se33)
 
-    @test Array(se33 + convert(SparseMatrixCSC{Float32,Int32}, se33)) == Matrix(2I, 3, 3)
-    @test Array(se33 * convert(SparseMatrixCSC{Float32,Int32}, se33)) == Matrix(I, 3, 3)
+    @test Array(se33 + convert(SparseMatrix{Float32,Int32}, se33)) == Matrix(2I, 3, 3)
+    @test Array(se33 * convert(SparseMatrix{Float32,Int32}, se33)) == Matrix(I, 3, 3)
 
     @testset "shape checks for sparse elementwise binary operations equivalent to map" begin
         sqrfloatmat, colfloatmat = sprand(4, 4, 0.5), sprand(4, 1, 0.5)
@@ -90,7 +90,7 @@ end
 
     @testset "vertical concatenation" begin
         @test all([se33; se33] == sparse([1, 4, 2, 5, 3, 6], [1, 1, 2, 2, 3, 3], ones(6)))
-        se33_32bit = convert(SparseMatrixCSC{Float32,Int32}, se33)
+        se33_32bit = convert(SparseMatrix{Float32,Int32}, se33)
         @test all([se33; se33_32bit] == sparse([1, 4, 2, 5, 3, 6], [1, 1, 2, 2, 3, 3], ones(6)))
         @test length(([sp33; 0I]).nzval) == 3
     end
@@ -396,7 +396,7 @@ end
     @test Array(conj!(copy(cA))) == conj(Array(cA))
 end
 
-@testset "SparseMatrixCSC [c]transpose[!] and permute[!]" begin
+@testset "SparseMatrix [c]transpose[!] and permute[!]" begin
     smalldim = 5
     largedim = 10
     nzprob = 0.4
@@ -530,7 +530,7 @@ end
 end
 
 @testset "what used to be issue #5386" begin
-    K,J,V = findnz(SparseMatrixCSC(2,1,[1,3],[1,2],[1.0,0.0]))
+    K,J,V = findnz(SparseMatrix(2,1,[1,3],[1,2],[1.0,0.0]))
     @test length(K) == length(J) == length(V) == 2
 end
 
@@ -612,7 +612,7 @@ end
     # Test representatives of remaining vectorized-nonbroadcast unary functions
     @test ceil.(Int, Afull) == Array(ceil.(Int, A))
     @test floor.(Int, Afull) == Array(floor.(Int, A))
-    # Tests of real, imag, abs, and abs2 for SparseMatrixCSC{Int,X}s previously elsewhere
+    # Tests of real, imag, abs, and abs2 for SparseMatrix{Int,X}s previously elsewhere
     for T in (Int, Float16, Float32, Float64, BigInt, BigFloat)
         R = rand(T[1:100;], 2, 2)
         I = rand(T[1:100;], 2, 2)
@@ -714,8 +714,8 @@ end
     end
 
     # workaround issue #7197: comment out let-block
-    #let S = SparseMatrixCSC(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])
-    S1290 = SparseMatrixCSC(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])
+    #let S = SparseMatrix(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])
+    S1290 = SparseMatrix(3, 3, UInt8[1,1,1,1], UInt8[], Int64[])
         S1290[1,1] = 1
         S1290[5] = 2
         S1290[end] = 3
@@ -728,7 +728,7 @@ end
         r1 = S1290[[5,9]]
         r2 = S1290[[1 2;5 9]]
         @test isa(r1, SparseVector{Int64,UInt8})
-        @test isa(r2, SparseMatrixCSC{Int64,UInt8})
+        @test isa(r2, SparseMatrix{Int64,UInt8})
     # end
 end
 
@@ -769,7 +769,7 @@ end
     @test nnz(a) == 19
     @test count(!iszero, a) == 0
 
-    # Zero-assignment behavior of setindex!(A, B::SparseMatrixCSC, I, J)
+    # Zero-assignment behavior of setindex!(A, B::SparseMatrix, I, J)
     a = copy(b)
     a[1:2,:] = spzeros(2, 10)
     @test nnz(a) == 19
@@ -1180,7 +1180,7 @@ end
     @test size(rotl90(a)) == (5,3)
 end
 
-function test_getindex_algs(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector, J::AbstractVector, alg::Int) where {Tv,Ti}
+function test_getindex_algs(A::SparseMatrix{Tv,Ti}, I::AbstractVector, J::AbstractVector, alg::Int) where {Tv,Ti}
     # Sorted vectors for indexing rows.
     # Similar to getindex_general but without the transpose trick.
     (m, n) = size(A)
@@ -1306,7 +1306,7 @@ end
 
 @testset "explicit zeros" begin
     if Base.USE_GPL_LIBS
-        a = SparseMatrixCSC(2, 2, [1, 3, 5], [1, 2, 1, 2], [1.0, 0.0, 0.0, 1.0])
+        a = SparseMatrix(2, 2, [1, 3, 5], [1, 2, 1, 2], [1.0, 0.0, 0.0, 1.0])
         @test lufact(a)\[2.0, 3.0] ≈ [2.0, 3.0]
         @test cholfact(a)\[2.0, 3.0] ≈ [2.0, 3.0]
     end
@@ -1379,9 +1379,9 @@ end
     @test sparse([1:5;], [1:5;], 1) == sparse(1.0I, 5, 5)
 end
 
-@testset "one(A::SparseMatrixCSC)" begin
+@testset "one(A::SparseMatrix)" begin
     @test_throws DimensionMismatch one(sparse([1 1 1; 1 1 1]))
-    @test one(sparse([1 1; 1 1]))::SparseMatrixCSC == [1 0; 0 1]
+    @test one(sparse([1 1; 1 1]))::SparseMatrix == [1 0; 0 1]
 end
 
 @testset "istriu/istril" begin
@@ -1399,7 +1399,7 @@ end
         triu(sprand(10, 10, 0.2))
     end
     @test Base.droptol!(A, 0.01).colptr == [1,1,1,2,2,3,4,6,6,7,9]
-    @test isequal(Base.droptol!(sparse([1], [1], [1]), 1), SparseMatrixCSC(1, 1, Int[1, 1], Int[], Int[]))
+    @test isequal(Base.droptol!(sparse([1], [1], [1]), 1), SparseMatrix(1, 1, Int[1, 1], Int[], Int[]))
 end
 
 @testset "dropzeros[!]" begin
@@ -1455,11 +1455,11 @@ end
     @test spdiagm(0 => ones(2),  1 => ones(2)) == [1.0 1.0 0.0; 0.0 1.0 1.0; 0.0 0.0 0.0]
 
     for (x, y) in ((rand(5), rand(4)),(sparse(rand(5)), sparse(rand(4))))
-        @test spdiagm(-1 => x)::SparseMatrixCSC         == diagm(-1 => x)
-        @test spdiagm( 0 => x)::SparseMatrixCSC         == diagm( 0 => x) == sparse(Diagonal(x))
-        @test spdiagm(-1 => x)::SparseMatrixCSC         == diagm(-1 => x)
-        @test spdiagm(0 => x, -1 => y)::SparseMatrixCSC == diagm(0 => x, -1 => y)
-        @test spdiagm(0 => x,  1 => y)::SparseMatrixCSC == diagm(0 => x,  1 => y)
+        @test spdiagm(-1 => x)::SparseMatrix         == diagm(-1 => x)
+        @test spdiagm( 0 => x)::SparseMatrix         == diagm( 0 => x) == sparse(Diagonal(x))
+        @test spdiagm(-1 => x)::SparseMatrix         == diagm(-1 => x)
+        @test spdiagm(0 => x, -1 => y)::SparseMatrix == diagm(0 => x, -1 => y)
+        @test spdiagm(0 => x,  1 => y)::SparseMatrix == diagm(0 => x,  1 => y)
     end
     # promotion
     @test spdiagm(0 => [1,2], 1 => [3.5], -1 => [4+5im]) == [1 3.5; 4+5im 2]
@@ -1570,7 +1570,7 @@ end
     colptr = [1, 5, 9, 13, 13, 17]
     rowval = [1, 2, 3, 5, 1, 2, 3, 5, 1, 2, 3, 5, 1, 2, 3, 5]
     nzval = [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0]
-    A = SparseMatrixCSC(m, n, colptr, rowval, nzval)
+    A = SparseMatrix(m, n, colptr, rowval, nzval)
     @test issymmetric(A) == true
     A.nzval[end - 3]  = 2.0
     @test issymmetric(A) == false
@@ -1628,16 +1628,16 @@ end
     B12118 = sparse([1,2,4,5],   [1,2,3,5],   [2,1,-1,-2])
 
     @test A12118 + B12118 == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], [3,3,3,-1,4,3])
-    @test typeof(A12118 + B12118) == SparseMatrixCSC{Int,Int}
+    @test typeof(A12118 + B12118) == SparseMatrix{Int,Int}
 
     @test A12118 - B12118 == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], [-1,1,3,1,4,7])
-    @test typeof(A12118 - B12118) == SparseMatrixCSC{Int,Int}
+    @test typeof(A12118 - B12118) == SparseMatrix{Int,Int}
 
     @test max.(A12118, B12118) == sparse([1,2,3,4,5], [1,2,3,4,5], [2,2,3,4,5])
-    @test typeof(max.(A12118, B12118)) == SparseMatrixCSC{Int,Int}
+    @test typeof(max.(A12118, B12118)) == SparseMatrix{Int,Int}
 
     @test min.(A12118, B12118) == sparse([1,2,4,5], [1,2,3,5], [1,1,-1,-2])
-    @test typeof(min.(A12118, B12118)) == SparseMatrixCSC{Int,Int}
+    @test typeof(min.(A12118, B12118)) == SparseMatrix{Int,Int}
 end
 
 @testset "sparse matrix norms" begin
@@ -1717,19 +1717,19 @@ end
     B13024 = sparse([1,2,4,5],   [1,2,3,5],   fill(true,4))
 
     @test broadcast(&, A13024, B13024) == sparse([1,2,5], [1,2,5], fill(true,3))
-    @test typeof(broadcast(&, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(&, A13024, B13024)) == SparseMatrix{Bool,Int}
 
     @test broadcast(|, A13024, B13024) == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], fill(true,6))
-    @test typeof(broadcast(|, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(|, A13024, B13024)) == SparseMatrix{Bool,Int}
 
     @test broadcast(⊻, A13024, B13024) == sparse([3,4,4], [3,3,4], fill(true,3), 5, 5)
-    @test typeof(broadcast(⊻, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(⊻, A13024, B13024)) == SparseMatrix{Bool,Int}
 
     @test broadcast(max, A13024, B13024) == sparse([1,2,3,4,4,5], [1,2,3,3,4,5], fill(true,6))
-    @test typeof(broadcast(max, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(max, A13024, B13024)) == SparseMatrix{Bool,Int}
 
     @test broadcast(min, A13024, B13024) == sparse([1,2,5], [1,2,5], fill(true,3))
-    @test typeof(broadcast(min, A13024, B13024)) == SparseMatrixCSC{Bool,Int}
+    @test typeof(broadcast(min, A13024, B13024)) == SparseMatrix{Bool,Int}
 
     for op in (+, -)
         @test op(A13024, B13024) == op(Array(A13024), Array(B13024))
@@ -1759,9 +1759,9 @@ end
     A = A*A.'
     @test !Base.USE_GPL_LIBS || abs(det(factorize(Symmetric(A)))) ≈ abs(det(factorize(Array(A))))
     @test factorize(triu(A)) == triu(A)
-    @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrixCSC{Float64, Int}})
+    @test isa(factorize(triu(A)), UpperTriangular{Float64, SparseMatrix{Float64, Int}})
     @test factorize(tril(A)) == tril(A)
-    @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrixCSC{Float64, Int}})
+    @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrix{Float64, Int}})
     @test !Base.USE_GPL_LIBS || factorize(A[:, 1:4])\ones(size(A, 1)) ≈ Array(A[:, 1:4])\ones(size(A, 1))
     @test_throws ErrorException chol(A)
     @test_throws ErrorException lu(A)
@@ -1853,21 +1853,21 @@ end
 
 # Test temporary fix for issue #16548 in PR #16979. Somewhat brittle. Expect to remove with `\` revisions.
 @testset "issue #16548" begin
-    ms = methods(\, (SparseMatrixCSC, AbstractVecOrMat)).ms
+    ms = methods(\, (SparseMatrix, AbstractVecOrMat)).ms
     @test all(m -> m.module == Base.SparseArrays, ms)
 end
 
-@testset "row indexing a SparseMatrixCSC with non-Int integer type" begin
+@testset "row indexing a SparseMatrix with non-Int integer type" begin
     local A = sparse(UInt32[1,2,3], UInt32[1,2,3], [1.0,2.0,3.0])
     @test A[1,1:3] == A[1,:] == [1,0,0]
 end
 
-# Check that `broadcast` methods specialized for unary operations over `SparseMatrixCSC`s
+# Check that `broadcast` methods specialized for unary operations over `SparseMatrix`s
 # are called. (Issue #18705.) EDIT: #19239 unified broadcast over a single sparse matrix,
 # eliminating the former operation classes.
 @testset "issue #18705" begin
     S = sparse(Diagonal(collect(1.0:5.0)))
-    @test isa(sin.(S), SparseMatrixCSC)
+    @test isa(sin.(S), SparseMatrix)
 end
 
 @testset "issue #19225" begin
@@ -1906,15 +1906,15 @@ end
 end
 
 # Check that `broadcast` methods specialized for unary operations over
-# `SparseMatrixCSC`s determine a reasonable return type.
+# `SparseMatrix`s determine a reasonable return type.
 @testset "issue #18974" begin
     S = sparse(Diagonal(collect(Int64(1):Int64(4))))
     @test eltype(sin.(S)) == Float64
 end
 
-# Check calling of unary minus method specialized for SparseMatrixCSCs
+# Check calling of unary minus method specialized for SparseMatrixs
 @testset "issue #19503" begin
-    @test which(-, (SparseMatrixCSC,)).module == Base.SparseArrays
+    @test which(-, (SparseMatrix,)).module == Base.SparseArrays
 end
 
 @testset "issue #14398" begin
@@ -1951,47 +1951,47 @@ end
 @testset "show" begin
     io = IOBuffer()
     show(io, MIME"text/plain"(), sparse(Int64[1], Int64[1], [1.0]))
-    @test String(take!(io)) == "1×1 SparseMatrixCSC{Float64,Int64} with 1 stored entry:\n  [1, 1]  =  1.0"
+    @test String(take!(io)) == "1×1 SparseMatrix{Float64,Int64} with 1 stored entry:\n  [1, 1]  =  1.0"
     show(io, MIME"text/plain"(), spzeros(Float32, Int64, 2, 2))
-    @test String(take!(io)) == "2×2 SparseMatrixCSC{Float32,Int64} with 0 stored entries"
+    @test String(take!(io)) == "2×2 SparseMatrix{Float32,Int64} with 0 stored entries"
 
     ioc = IOContext(io, :displaysize => (5, 80), :limit => true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1], Int64[1], [1.0]))
-    @test String(take!(io)) == "1×1 SparseMatrixCSC{Float64,Int64} with 1 stored entry:\n  [1, 1]  =  1.0"
+    @test String(take!(io)) == "1×1 SparseMatrix{Float64,Int64} with 1 stored entry:\n  [1, 1]  =  1.0"
     show(ioc, MIME"text/plain"(), sparse(Int64[1, 1], Int64[1, 2], [1.0, 2.0]))
-    @test String(take!(io)) == "1×2 SparseMatrixCSC{Float64,Int64} with 2 stored entries:\n  ⋮"
+    @test String(take!(io)) == "1×2 SparseMatrix{Float64,Int64} with 2 stored entries:\n  ⋮"
 
     # even number of rows
     ioc = IOContext(io, :displaysize => (8, 80), :limit => true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4], Int64[1,1,2,2], [1.0,2.0,3.0,4.0]))
-    @test String(take!(io)) == string("4×2 SparseMatrixCSC{Float64,Int64} with 4 stored entries:\n  [1, 1]",
+    @test String(take!(io)) == string("4×2 SparseMatrix{Float64,Int64} with 4 stored entries:\n  [1, 1]",
                                       "  =  1.0\n  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0")
 
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5], Int64[1,1,2,2,3], [1.0,2.0,3.0,4.0,5.0]))
-    @test String(take!(io)) ==  string("5×3 SparseMatrixCSC{Float64,Int64} with 5 stored entries:\n  [1, 1]",
+    @test String(take!(io)) ==  string("5×3 SparseMatrix{Float64,Int64} with 5 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  ⋮\n  [5, 3]  =  5.0")
 
     show(ioc, MIME"text/plain"(), sparse(ones(5,3)))
-    @test String(take!(io)) ==  string("5×3 SparseMatrixCSC{Float64,$Int} with 15 stored entries:\n  [1, 1]",
+    @test String(take!(io)) ==  string("5×3 SparseMatrix{Float64,$Int} with 15 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  ⋮\n  [5, 3]  =  1.0")
 
     # odd number of rows
     ioc = IOContext(io, :displaysize => (9, 80), :limit => true)
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5], Int64[1,1,2,2,3], [1.0,2.0,3.0,4.0,5.0]))
-    @test String(take!(io)) == string("5×3 SparseMatrixCSC{Float64,Int64} with 5 stored entries:\n  [1, 1]",
+    @test String(take!(io)) == string("5×3 SparseMatrix{Float64,Int64} with 5 stored entries:\n  [1, 1]",
                                       "  =  1.0\n  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0")
 
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5,6], Int64[1,1,2,2,3,3], [1.0,2.0,3.0,4.0,5.0,6.0]))
-    @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,Int64} with 6 stored entries:\n  [1, 1]",
+    @test String(take!(io)) ==  string("6×3 SparseMatrix{Float64,Int64} with 6 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  [2, 1]  =  2.0\n  ⋮\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")
 
     show(ioc, MIME"text/plain"(), sparse(ones(6,3)))
-    @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,$Int} with 18 stored entries:\n  [1, 1]",
+    @test String(take!(io)) ==  string("6×3 SparseMatrix{Float64,$Int} with 18 stored entries:\n  [1, 1]",
                                        "  =  1.0\n  [2, 1]  =  1.0\n  ⋮\n  [5, 3]  =  1.0\n  [6, 3]  =  1.0")
 
     ioc = IOContext(io, :displaysize => (9, 80))
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5,6], Int64[1,1,2,2,3,3], [1.0,2.0,3.0,4.0,5.0,6.0]))
-    @test String(take!(io)) ==  string("6×3 SparseMatrixCSC{Float64,Int64} with 6 stored entries:\n  [1, 1]  =  1.0\n",
+    @test String(take!(io)) ==  string("6×3 SparseMatrix{Float64,Int64} with 6 stored entries:\n  [1, 1]  =  1.0\n",
         "  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")
 end
 
@@ -2001,10 +2001,10 @@ end
     rowval = [1,2,3]
     nzval1  = ones(0)
     nzval2  = ones(3)
-    A = SparseMatrixCSC(n, n, colptr, rowval, nzval1)
+    A = SparseMatrix(n, n, colptr, rowval, nzval1)
     @test nnz(A) == n
     @test_throws BoundsError A[n,n]
-    A = SparseMatrixCSC(n, n, colptr, rowval, nzval2)
+    A = SparseMatrix(n, n, colptr, rowval, nzval2)
     @test nnz(A) == n
     @test A      == Matrix(I, n, n)
 end
@@ -2089,14 +2089,14 @@ end
 @testset "similar with type conversion" begin
     local A = sparse(1.0I, 5, 5)
     @test size(similar(A, ComplexF64, Int)) == (5, 5)
-    @test typeof(similar(A, ComplexF64, Int)) == SparseMatrixCSC{ComplexF64, Int}
+    @test typeof(similar(A, ComplexF64, Int)) == SparseMatrix{ComplexF64, Int}
     @test size(similar(A, ComplexF64, Int8)) == (5, 5)
-    @test typeof(similar(A, ComplexF64, Int8)) == SparseMatrixCSC{ComplexF64, Int8}
+    @test typeof(similar(A, ComplexF64, Int8)) == SparseMatrix{ComplexF64, Int8}
     @test similar(A, ComplexF64,(6, 6)) == spzeros(ComplexF64, 6, 6)
     @test convert(Matrix, A) == Array(A) # lolwut, are you lost, test?
 end
 
-@testset "similar for SparseMatrixCSC" begin
+@testset "similar for SparseMatrix" begin
     local A = sparse(1.0I, 5, 5)
     # test similar without specifications (preserves stored-entry structure)
     simA = similar(A)
@@ -2107,14 +2107,14 @@ end
     @test length(simA.nzval) == length(A.nzval)
     # test similar with entry type specification (preserves stored-entry structure)
     simA = similar(A, Float32)
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(A.colptr)}
+    @test typeof(simA) == SparseMatrix{Float32,eltype(A.colptr)}
     @test size(simA) == size(A)
     @test simA.colptr == A.colptr
     @test simA.rowval == A.rowval
     @test length(simA.nzval) == length(A.nzval)
     # test similar with entry and index type specification (preserves stored-entry structure)
     simA = similar(A, Float32, Int8)
-    @test typeof(simA) == SparseMatrixCSC{Float32,Int8}
+    @test typeof(simA) == SparseMatrix{Float32,Int8}
     @test size(simA) == size(A)
     @test simA.colptr == A.colptr
     @test simA.rowval == A.rowval
@@ -2128,14 +2128,14 @@ end
     @test length(simA.nzval) == length(A.nzval)
     # test similar with entry type and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(A.colptr)}
+    @test typeof(simA) == SparseMatrix{Float32,eltype(A.colptr)}
     @test size(simA) == (6,6)
     @test simA.colptr == ones(eltype(A.colptr), 6+1)
     @test length(simA.rowval) == length(A.rowval)
     @test length(simA.nzval) == length(A.nzval)
     # test similar with entry type, index type, and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, Int8, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32, Int8}
+    @test typeof(simA) == SparseMatrix{Float32, Int8}
     @test size(simA) == (6,6)
     @test simA.colptr == ones(eltype(A.colptr), 6+1)
     @test length(simA.rowval) == length(A.rowval)
@@ -2165,10 +2165,10 @@ end
 
 @testset "count specializations" begin
     # count should throw for sparse arrays for which zero(eltype) does not exist
-    @test_throws MethodError count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Any[true, true]))
+    @test_throws MethodError count(SparseMatrix(2, 2, Int[1, 2, 3], Int[1, 2], Any[true, true]))
     @test_throws MethodError count(SparseVector(2, Int[1], Any[true]))
     # count should run only over S.nzval[1:nnz(S)], not S.nzval in full
-    @test count(SparseMatrixCSC(2, 2, Int[1, 2, 3], Int[1, 2], Bool[true, true, true])) == 2
+    @test count(SparseMatrix(2, 2, Int[1, 2, 3], Int[1, 2], Bool[true, true, true])) == 2
 end
 
 # #20711

--- a/test/sparse/sparsevector.jl
+++ b/test/sparse/sparsevector.jl
@@ -194,7 +194,7 @@ end
         let x = convert(SparseVector{Float64,UInt32},sprandn(100,0.5))
             I = rand(1:length(x), 20,1)
             r = x[I]
-            @test isa(r, SparseMatrixCSC{Float64,UInt32})
+            @test isa(r, SparseMatrix{Float64,UInt32})
             @test all(!iszero, nonzeros(r))
             @test Array(r) == Array(x)[I]
         end
@@ -415,12 +415,12 @@ end
         @test isa(xc, SparseVector{Float32,Int})
         @test exact_equal(xc, xf32)
 
-        xm = convert(SparseMatrixCSC, x)
-        @test isa(xm, SparseMatrixCSC{Float64,Int})
+        xm = convert(SparseMatrix, x)
+        @test isa(xm, SparseMatrix{Float64,Int})
         @test Array(xm) == reshape(xf, 8, 1)
 
-        xm = convert(SparseMatrixCSC{Float32}, x)
-        @test isa(xm, SparseMatrixCSC{Float32,Int})
+        xm = convert(SparseMatrix{Float32}, x)
+        @test isa(xm, SparseMatrix{Float32,Int})
         @test Array(xm) == reshape(convert(Vector{Float32}, xf), 8, 1)
     end
 end
@@ -435,7 +435,7 @@ end
         end
 
         H = hcat(A...)
-        @test isa(H, SparseMatrixCSC{Float64,Int})
+        @test isa(H, SparseMatrix{Float64,Int})
         @test size(H) == (m, n)
         @test nnz(H) == tnnz
         Hr = zeros(m, n)
@@ -924,8 +924,8 @@ end
 
         sprmat = sprand(m, m, 0.2)
         sparsefloatmat = I + sprmat/(2m)
-        sparsecomplexmat = I + SparseMatrixCSC(m, m, sprmat.colptr, sprmat.rowval, complex.(sprmat.nzval, sprmat.nzval)/(4m))
-        sparseintmat = 10m*I + SparseMatrixCSC(m, m, sprmat.colptr, sprmat.rowval, round.(Int, sprmat.nzval*10))
+        sparsecomplexmat = I + SparseMatrix(m, m, sprmat.colptr, sprmat.rowval, complex.(sprmat.nzval, sprmat.nzval)/(4m))
+        sparseintmat = 10m*I + SparseMatrix(m, m, sprmat.colptr, sprmat.rowval, round.(Int, sprmat.nzval*10))
 
         denseintmat = I*10m + rand(1:m, m, m)
         densefloatmat = I + randn(m, m)/(2m)
@@ -941,7 +941,7 @@ end
                                     eltypemat in floattypes ? (densefloatmat, sparsefloatmat) :
                                     eltypemat in complextypes && (densecomplexmat, sparsecomplexmat)
             densemat = convert(Matrix{eltypemat}, densemat)
-            sparsemat = convert(SparseMatrixCSC{eltypemat}, sparsemat)
+            sparsemat = convert(SparseMatrix{eltypemat}, sparsemat)
             trimats = (LowerTriangular(densemat), UpperTriangular(densemat),
                        LowerTriangular(sparsemat), UpperTriangular(sparsemat) )
             unittrimats = (Base.LinAlg.UnitLowerTriangular(densemat), Base.LinAlg.UnitUpperTriangular(densemat),
@@ -1072,7 +1072,7 @@ end
 # but if that's done, then modifications to one or the other will cause
 # an inconsistent state:
 sv = sparse(1:10)
-sm = convert(SparseMatrixCSC, sv)
+sm = convert(SparseMatrix, sv)
 sv[1] = 0
 @test Array(sm)[2:end] == collect(2:10)
 
@@ -1080,8 +1080,8 @@ sv[1] = 0
 @test sparsevec([1,2,3],[0,0,0]) == [0,0,0]
 
 @testset "stored zero semantics" begin
-    # Compare stored zero semantics between SparseVector and SparseMatrixCSC
-    let S = SparseMatrixCSC(10,1,[1,6],[1,3,5,6,7],[0,1,2,0,3]), x = SparseVector(10,[1,3,5,6,7],[0,1,2,0,3])
+    # Compare stored zero semantics between SparseVector and SparseMatrix
+    let S = SparseMatrix(10,1,[1,6],[1,3,5,6,7],[0,1,2,0,3]), x = SparseVector(10,[1,3,5,6,7],[0,1,2,0,3])
         @test nnz(S) == nnz(x) == 5
         for I = (:, 1:10, collect(1:10))
             @test S[I,1] == S[I] == x[I] == x
@@ -1130,7 +1130,7 @@ end
 @testset "fill!" begin
     for Tv in [Float32, Float64, Int64, Int32, ComplexF64]
         for Ti in [Int16, Int32, Int64, BigInt]
-            sptypes = (SparseMatrixCSC{Tv, Ti}, SparseVector{Tv, Ti})
+            sptypes = (SparseMatrix{Tv, Ti}, SparseVector{Tv, Ti})
             sizes = [(3, 4), (3,)]
             for (siz, Sp) in zip(sizes, sptypes)
                 arr = rand(Tv, siz...)
@@ -1227,21 +1227,21 @@ end
     @test similar(A, Float32, Int8, 6) == similar(A, Float32, Int8, (6,))
     # test similar with Dims{2} specification (preserves storage space only, not stored-entry structure)
     simA = similar(A, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{eltype(A.nzval),eltype(A.nzind)}
+    @test typeof(simA) == SparseMatrix{eltype(A.nzval),eltype(A.nzind)}
     @test size(simA) == (6,6)
     @test simA.colptr == ones(eltype(A.nzind), 6+1)
     @test length(simA.rowval) == length(A.nzind)
     @test length(simA.nzval) == length(A.nzval)
     # test similar with entry type and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32,eltype(A.nzind)}
+    @test typeof(simA) == SparseMatrix{Float32,eltype(A.nzind)}
     @test size(simA) == (6,6)
     @test simA.colptr == ones(eltype(A.nzind), 6+1)
     @test length(simA.rowval) == length(A.nzind)
     @test length(simA.nzval) == length(A.nzval)
     # test similar with entry type, index type, and Dims{2} specification (preserves storage space only)
     simA = similar(A, Float32, Int8, (6,6))
-    @test typeof(simA) == SparseMatrixCSC{Float32, Int8}
+    @test typeof(simA) == SparseMatrix{Float32, Int8}
     @test size(simA) == (6,6)
     @test simA.colptr == ones(eltype(A.nzind), 6+1)
     @test length(simA.rowval) == length(A.nzind)


### PR DESCRIPTION
Makes the constructor much friendlier to type (`SparseMatrix(I, 3, 3)` etc...)

CC @ViralBShah and @Sacha0 who previously discussed this.