### PR TITLE
rename topology master_slave to master_worker

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1332,7 +1332,7 @@ The keyword argument `topology` passed to `addprocs` is used to specify how the 
 connected to each other:
 
   * `:all_to_all`, the default: all workers are connected to each other.
-  * `:master_slave`: only the driver process, i.e. `pid` 1, has connections to the workers.
+  * `:master_worker`: only the driver process, i.e. `pid` 1, has connections to the workers.
   * `:custom`: the `launch` method of the cluster manager specifies the connection topology via the
     fields `ident` and `connect_idents` in `WorkerConfig`. A worker with a cluster-manager-provided
     identity `ident` will connect to all workers specified in `connect_idents`.

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -680,7 +680,11 @@ end
 const PGRP = ProcessGroup([])
 
 function topology(t)
-    assert(t in [:all_to_all, :master_slave, :custom])
+    if t == :master_slave
+        Base.depwarn("The topology :master_slave is deprecated, use :master_worker instead.", :topology)
+        t = :master_worker
+    end
+    assert(t in [:all_to_all, :master_worker, :custom])
     if (PGRP.topology==t) || ((myid()==1) && (nprocs()==1)) || (myid() > 1)
         PGRP.topology = t
     else

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -92,7 +92,7 @@ Keyword arguments:
 
     + `topology=:all_to_all`: All processes are connected to each other. The default.
 
-    + `topology=:master_slave`: Only the driver process, i.e. `pid` 1 connects to the
+    + `topology=:master_worker`: Only the driver process, i.e. `pid` 1 connects to the
       workers. The workers do not connect to each other.
 
     + `topology=:custom`: The `launch` method of the cluster manager specifies the

--- a/stdlib/Distributed/test/topology.jl
+++ b/stdlib/Distributed/test/topology.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-pids = addprocs_with_testenv(4; topology="master_slave")
+pids = addprocs_with_testenv(4; topology="master_worker")
 
 let p1 = pids[1], p2 = pids[2]
     @test_throws RemoteException remotecall_fetch(()->remotecall_fetch(myid, p2), p1)
@@ -117,7 +117,7 @@ while length(combinations) < 10
     end
 end
 
-# Initially only master-slave connections ought to be setup
+# Initially only master-worker connections ought to be setup
 expected_num_conns = 8
 let num_conns = sum(asyncmap(p->remotecall_fetch(count_connected_workers,p), workers()))
     @test num_conns == expected_num_conns


### PR DESCRIPTION
Everywhere else we are using the master/worker terminology.`