### PR TITLE
Depwarn caller fix

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -96,7 +96,7 @@ function firstcaller(bt::Vector, funcsyms)
     for frame in bt
         lkups = StackTraces.lookup(frame)
         for outer lkup in lkups
-            if lkup == StackTraces.UNKNOWN
+            if lkup == StackTraces.UNKNOWN || lkup.from_c
                 continue
             end
             if found

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -413,13 +413,14 @@ exists for the current task.
 
     global_logger(logger)
 
-Set the global logger to `logger`.
+Set the global logger to `logger`, and return the previous global logger.
 """
 global_logger() = _global_logstate.logger
 
 function global_logger(logger::AbstractLogger)
+    prev = _global_logstate.logger
     global _global_logstate = LogState(logger)
-    logger
+    prev
 end
 
 """

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -1,4 +1,5 @@
 using Test
+using Logging
 
 module DeprecationTests # to test @deprecate
     f() = true
@@ -81,3 +82,20 @@ depwarn24658() = Base.firstcaller(backtrace(), :_func_not_found_)
     # issue #24658
     @test eval(:(if true; f24658(); end)) == (Ptr{Void}(0),StackTraces.UNKNOWN)
 end
+
+# issue #25130
+f25130() = Base.depwarn("f25130 message", :f25130)
+# The following test is for the depwarn behavior of expressions evaluated at
+# top-level, so we can't use the usual `collect_test_logs()` / `with_logger()`
+testlogger = Test.TestLogger()
+prev_logger = global_logger(testlogger)
+# Each call at top level should be distinct. This won't be true if they're
+# attributed to internal C frames (including generic dispatch machinery)
+f25130()
+f25130()
+testlogs = testlogger.logs
+@test length(testlogs) == 2
+@test testlogs[1].id != testlogs[2].id
+@test testlogs[1].kwargs.caller.func == Symbol("top-level scope")
+@test all(l.message == "f25130 message" for l in testlogs)
+global_logger(prev_logger)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -121,21 +121,6 @@ end
         end
     end
 
-    @testset "Log filtering, global logger" begin
-        old_logger = global_logger()
-        logs = let
-            logger = TestLogger(min_level=Warn)
-            global_logger(logger)
-            @info "b"
-            @warn "c"
-            logger.logs
-        end
-        global_logger(old_logger)
-
-        @test length(logs) == 1
-        @test ismatch((Warn , "c"), logs[1])
-    end
-
     @testset "Log level filtering - global flag" begin
         # Test utility: Log once at each standard level
         function log_each_level()
@@ -190,6 +175,19 @@ end
     )
 end
 
+
+#-------------------------------------------------------------------------------
+@testset "Logger installation and access" begin
+    @testset "Global logger" begin
+        logger1 = global_logger()
+        logger2 = TestLogger()
+        # global_logger() returns the previously installed logger
+        @test logger1 === global_logger(logger2)
+        # current logger looks up global logger by default.
+        @test current_logger() === logger2
+        global_logger(logger1) # Restore global logger
+    end
+end
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
This fixes the core problem of #25130, namely that on occasion - and especially at top level scope - the internal dispatch or interpreter machinery was being blamed as the caller of a deprecated function.

Along the way I also noticed what was arguably a bug in `global_logger(logger)`, so that's also fixed to more usefully return the old logger rather than the replacement.