### PR TITLE
Define copy for Char

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -76,6 +76,7 @@ getindex(c::Char, i::Integer) = i == 1 ? c : throw(BoundsError())
 getindex(c::Char, I::Integer...) = all(x -> x == 1, I) ? c : throw(BoundsError())
 first(c::Char) = c
 last(c::Char) = c
+copy(c::Char) = c  # some code treats characters as collection-like
 eltype(::Type{Char}) = Char
 
 start(c::Char) = false

--- a/test/char.jl
+++ b/test/char.jl
@@ -106,6 +106,11 @@ let
         @test last(x) == x
     end
 
+    #copy(c::Char) = c
+    for x in testarrays
+        @test copy(x) == x
+    end
+
     #eltype(c::Char) = Char
     for x in testarrays
         @test eltype(x) == Char


### PR DESCRIPTION
I suggest to define `copy` for `Char`. Otherwise operations like `'a'^1` throw an error.