### PR TITLE
Deprecate getindex(::Factorization, ::Symbol) in favor of dot overloading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -879,6 +879,10 @@ Deprecated or removed
 
   * `sub2ind` and `ind2sub` are deprecated in favor of using `CartesianIndices` and `LinearIndices` ([#24715]).
 
+  * `getindex(F::Factorizion, s::Symbol)` (usually seen as e.g. `F[:Q]`) is deprecated
+    in favor of dot overloading (`getproperty`) so factors should now be accessed as e.g.
+    `F.Q` instead of `F[:Q]` ([#25184]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -3466,6 +3466,15 @@ workspace() = error("workspace() is discontinued, check out Revise.jl for an alt
 @deprecate Ref(x::Ptr) Ref(x, 1)
 @deprecate Ref(x::Ref) x # or perhaps, `convert(Ref, x)`
 
+# PR #25184. Use getproperty instead of getindex for Factorizations
+function getindex(F::Factorization, s::Symbol)
+    depwarn("`F[:$s]` is deprecated, use `F.$s` instead.", :getindex)
+    return getproperty(F, s)
+end
+@eval Base.LinAlg begin
+    @deprecate getq(F::Factorization) F.Q
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/linalg/cholesky.jl
+++ b/base/linalg/cholesky.jl
@@ -285,7 +285,7 @@ end
 Compute the Cholesky factorization of a dense symmetric positive definite matrix `A`
 and return a `Cholesky` factorization. The matrix `A` can either be a [`Symmetric`](@ref) or [`Hermitian`](@ref)
 `StridedMatrix` or a *perfectly* symmetric or Hermitian `StridedMatrix`.
-The triangular Cholesky factor can be obtained from the factorization `F` with: `F[:L]` and `F[:U]`.
+The triangular Cholesky factor can be obtained from the factorization `F` with: `F.L` and `F.U`.
 The following functions are available for `Cholesky` objects: [`size`](@ref), [`\\`](@ref),
 [`inv`](@ref), [`det`](@ref), [`logdet`](@ref) and [`isposdef`](@ref).
 
@@ -305,19 +305,19 @@ U factor:
   ⋅   1.0   5.0
   ⋅    ⋅    3.0
 
-julia> C[:U]
+julia> C.U
 3×3 UpperTriangular{Float64,Array{Float64,2}}:
  2.0  6.0  -8.0
   ⋅   1.0   5.0
   ⋅    ⋅    3.0
 
-julia> C[:L]
+julia> C.L
 3×3 LowerTriangular{Float64,Array{Float64,2}}:
   2.0   ⋅    ⋅
   6.0  1.0   ⋅
  -8.0  5.0  3.0
 
-julia> C[:L] * C[:U] == A
+julia> C.L * C.U == A
 true
 ```
 """
@@ -332,7 +332,7 @@ cholfact(A::Union{StridedMatrix,RealHermSymComplexHerm{<:Real,<:StridedMatrix}},
 Compute the pivoted Cholesky factorization of a dense symmetric positive semi-definite matrix `A`
 and return a `CholeskyPivoted` factorization. The matrix `A` can either be a [`Symmetric`](@ref)
 or [`Hermitian`](@ref) `StridedMatrix` or a *perfectly* symmetric or Hermitian `StridedMatrix`.
-The triangular Cholesky factor can be obtained from the factorization `F` with: `F[:L]` and `F[:U]`.
+The triangular Cholesky factor can be obtained from the factorization `F` with: `F.L` and `F.U`.
 The following functions are available for `PivotedCholesky` objects:
 [`size`](@ref), [`\\`](@ref), [`inv`](@ref), [`det`](@ref), and [`rank`](@ref).
 The argument `tol` determines the tolerance for determining the rank.
@@ -361,14 +361,14 @@ CholeskyPivoted{T}(C::CholeskyPivoted) where {T} =
 Factorization{T}(C::CholeskyPivoted{T}) where {T} = C
 Factorization{T}(C::CholeskyPivoted) where {T} = CholeskyPivoted{T}(C)
 
-AbstractMatrix(C::Cholesky) = C.uplo == 'U' ? C[:U]'C[:U] : C[:L]*C[:L]'
+AbstractMatrix(C::Cholesky) = C.uplo == 'U' ? C.U'C.U : C.L*C.L'
 AbstractArray(C::Cholesky) = AbstractMatrix(C)
 Matrix(C::Cholesky) = Array(AbstractArray(C))
 Array(C::Cholesky) = Matrix(C)
 
 function AbstractMatrix(F::CholeskyPivoted)
-    ip = invperm(F[:p])
-    (F[:L] * F[:U])[ip,ip]
+    ip = invperm(F.p)
+    (F.L * F.U)[ip,ip]
 end
 AbstractArray(F::CholeskyPivoted) = AbstractMatrix(F)
 Matrix(F::CholeskyPivoted) = Array(AbstractArray(F))
@@ -380,25 +380,38 @@ copy(C::CholeskyPivoted) = CholeskyPivoted(copy(C.factors), C.uplo, C.piv, C.ran
 size(C::Union{Cholesky, CholeskyPivoted}) = size(C.factors)
 size(C::Union{Cholesky, CholeskyPivoted}, d::Integer) = size(C.factors, d)
 
-function getindex(C::Cholesky, d::Symbol)
-    d == :U && return UpperTriangular(Symbol(C.uplo) == d ? C.factors : adjoint(C.factors))
-    d == :L && return LowerTriangular(Symbol(C.uplo) == d ? C.factors : adjoint(C.factors))
-    d == :UL && return Symbol(C.uplo) == :U ? UpperTriangular(C.factors) : LowerTriangular(C.factors)
-    throw(KeyError(d))
+function getproperty(C::Cholesky, d::Symbol)
+    Cfactors = getfield(C, :factors)
+    Cuplo    = getfield(C, :uplo)
+    if d == :U
+        return UpperTriangular(Symbol(Cuplo) == d ? Cfactors : adjoint(Cfactors))
+    elseif d == :L
+        return LowerTriangular(Symbol(Cuplo) == d ? Cfactors : adjoint(Cfactors))
+    elseif d == :UL
+        return Symbol(Cuplo) == :U ? UpperTriangular(Cfactors) : LowerTriangular(Cfactors)
+    else
+        return getfield(C, d)
+    end
 end
-function getindex(C::CholeskyPivoted{T}, d::Symbol) where T<:BlasFloat
-    d == :U && return UpperTriangular(Symbol(C.uplo) == d ? C.factors : adjoint(C.factors))
-    d == :L && return LowerTriangular(Symbol(C.uplo) == d ? C.factors : adjoint(C.factors))
-    d == :p && return C.piv
-    if d == :P
+function getproperty(C::CholeskyPivoted{T}, d::Symbol) where T<:BlasFloat
+    Cfactors = getfield(C, :factors)
+    Cuplo    = getfield(C, :uplo)
+    if d == :U
+        return UpperTriangular(Symbol(Cuplo) == d ? Cfactors : adjoint(Cfactors))
+    elseif d == :L
+        return LowerTriangular(Symbol(Cuplo) == d ? Cfactors : adjoint(Cfactors))
+    elseif d == :p
+        return getfield(C, :piv)
+    elseif d == :P
         n = size(C, 1)
         P = zeros(T, n, n)
         for i = 1:n
-            P[C.piv[i],i] = one(T)
+            P[getfield(C, :piv)[i], i] = one(T)
         end
         return P
+    else
+        return getfield(C, d)
     end
-    throw(KeyError(d))
 end
 
 issuccess(C::Cholesky) = C.info == 0
@@ -406,7 +419,7 @@ issuccess(C::Cholesky) = C.info == 0
 function show(io::IO, mime::MIME{Symbol("text/plain")}, C::Cholesky{<:Any,<:AbstractMatrix})
     if issuccess(C)
         println(io, summary(C), "\n$(C.uplo) factor:")
-        show(io, mime, C[:UL])
+        show(io, mime, C.UL)
     else
         print(io, "Failed factorization of type $(typeof(C))")
     end
@@ -414,9 +427,9 @@ end
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, C::CholeskyPivoted{<:Any,<:AbstractMatrix})
     println(io, summary(C), "\n$(C.uplo) factor with rank $(rank(C)):")
-    show(io, mime, C.uplo == 'U' ? C[:U] : C[:L])
+    show(io, mime, C.uplo == 'U' ? C.U : C.L)
     println(io, "\npermutation:")
-    show(io, mime, C[:p])
+    show(io, mime, C.p)
 end
 
 ldiv!(C::Cholesky{T,<:AbstractMatrix}, B::StridedVecOrMat{T}) where {T<:BlasFloat} =
@@ -534,8 +547,8 @@ rank(C::CholeskyPivoted) = C.rank
 """
     lowrankupdate!(C::Cholesky, v::StridedVector) -> CC::Cholesky
 
-Update a Cholesky factorization `C` with the vector `v`. If `A = C[:U]'C[:U]` then
-`CC = cholfact(C[:U]'C[:U] + v*v')` but the computation of `CC` only uses `O(n^2)`
+Update a Cholesky factorization `C` with the vector `v`. If `A = C.U'C.U` then
+`CC = cholfact(C.U'C.U + v*v')` but the computation of `CC` only uses `O(n^2)`
 operations. The input factorization `C` is updated in place such that on exit `C == CC`.
 The vector `v` is destroyed during the computation.
 """
@@ -580,8 +593,8 @@ end
 """
     lowrankdowndate!(C::Cholesky, v::StridedVector) -> CC::Cholesky
 
-Downdate a Cholesky factorization `C` with the vector `v`. If `A = C[:U]'C[:U]` then
-`CC = cholfact(C[:U]'C[:U] - v*v')` but the computation of `CC` only uses `O(n^2)`
+Downdate a Cholesky factorization `C` with the vector `v`. If `A = C.U'C.U` then
+`CC = cholfact(C.U'C.U - v*v')` but the computation of `CC` only uses `O(n^2)`
 operations. The input factorization `C` is updated in place such that on exit `C == CC`.
 The vector `v` is destroyed during the computation.
 """
@@ -633,8 +646,8 @@ end
 """
     lowrankupdate(C::Cholesky, v::StridedVector) -> CC::Cholesky
 
-Update a Cholesky factorization `C` with the vector `v`. If `A = C[:U]'C[:U]`
-then `CC = cholfact(C[:U]'C[:U] + v*v')` but the computation of `CC` only uses
+Update a Cholesky factorization `C` with the vector `v`. If `A = C.U'C.U`
+then `CC = cholfact(C.U'C.U + v*v')` but the computation of `CC` only uses
 `O(n^2)` operations.
 """
 lowrankupdate(C::Cholesky, v::StridedVector) = lowrankupdate!(copy(C), copy(v))
@@ -642,8 +655,8 @@ lowrankupdate(C::Cholesky, v::StridedVector) = lowrankupdate!(copy(C), copy(v))
 """
     lowrankdowndate(C::Cholesky, v::StridedVector) -> CC::Cholesky
 
-Downdate a Cholesky factorization `C` with the vector `v`. If `A = C[:U]'C[:U]`
-then `CC = cholfact(C[:U]'C[:U] - v*v')` but the computation of `CC` only uses
+Downdate a Cholesky factorization `C` with the vector `v`. If `A = C.U'C.U`
+then `CC = cholfact(C.U'C.U - v*v')` but the computation of `CC` only uses
 `O(n^2)` operations.
 """
 lowrankdowndate(C::Cholesky, v::StridedVector) = lowrankdowndate!(copy(C), copy(v))

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -709,8 +709,8 @@ function sqrt(A::StridedMatrix{<:Real})
         return triu!(parent(sqrt(UpperTriangular(A))))
     else
         SchurF = schurfact(complex(A))
-        R = triu!(parent(sqrt(UpperTriangular(SchurF[:T])))) # unwrapping unnecessary?
-        return SchurF[:vectors] * R * SchurF[:vectors]'
+        R = triu!(parent(sqrt(UpperTriangular(SchurF.T)))) # unwrapping unnecessary?
+        return SchurF.vectors * R * SchurF.vectors'
     end
 end
 function sqrt(A::StridedMatrix{<:Complex})
@@ -723,8 +723,8 @@ function sqrt(A::StridedMatrix{<:Complex})
         return triu!(parent(sqrt(UpperTriangular(A))))
     else
         SchurF = schurfact(A)
-        R = triu!(parent(sqrt(UpperTriangular(SchurF[:T])))) # unwrapping unnecessary?
-        return SchurF[:vectors] * R * SchurF[:vectors]'
+        R = triu!(parent(sqrt(UpperTriangular(SchurF.T)))) # unwrapping unnecessary?
+        return SchurF.vectors * R * SchurF.vectors'
     end
 end
 

--- a/base/linalg/eigen.jl
+++ b/base/linalg/eigen.jl
@@ -20,13 +20,6 @@ end
 GeneralizedEigen(values::AbstractVector{V}, vectors::AbstractMatrix{T}) where {T,V} =
     GeneralizedEigen{T,V,typeof(vectors),typeof(values)}(values, vectors)
 
-
-function getindex(A::Union{Eigen,GeneralizedEigen}, d::Symbol)
-    d == :values && return A.values
-    d == :vectors && return A.vectors
-    throw(KeyError(d))
-end
-
 isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0, A.values)
 
 """
@@ -69,8 +62,8 @@ end
     eigfact(A; permute::Bool=true, scale::Bool=true) -> Eigen
 
 Computes the eigenvalue decomposition of `A`, returning an `Eigen` factorization object `F`
-which contains the eigenvalues in `F[:values]` and the eigenvectors in the columns of the
-matrix `F[:vectors]`. (The `k`th eigenvector can be obtained from the slice `F[:vectors][:, k]`.)
+which contains the eigenvalues in `F.values` and the eigenvectors in the columns of the
+matrix `F.vectors`. (The `k`th eigenvector can be obtained from the slice `F.vectors[:, k]`.)
 
 The following functions are available for `Eigen` objects: [`inv`](@ref), [`det`](@ref), and [`isposdef`](@ref).
 
@@ -84,13 +77,13 @@ make rows and columns more equal in norm. The default is `true` for both options
 julia> F = eigfact([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
 Base.LinAlg.Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}([1.0, 3.0, 18.0], [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0])
 
-julia> F[:values]
+julia> F.values
 3-element Array{Float64,1}:
   1.0
   3.0
  18.0
 
-julia> F[:vectors]
+julia> F.vectors
 3×3 Array{Float64,2}:
  1.0  0.0  0.0
  0.0  1.0  0.0
@@ -154,9 +147,9 @@ julia> eigvecs([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
 """
 eigvecs(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true) =
     eigvecs(eigfact(A, permute=permute, scale=scale))
-eigvecs(F::Union{Eigen{T,V,S,U}, GeneralizedEigen{T,V,S,U}}) where {T,V,S,U} = F[:vectors]::S
+eigvecs(F::Union{Eigen, GeneralizedEigen}) = F.vectors
 
-eigvals(F::Union{Eigen{T,V,S,U}, GeneralizedEigen{T,V,S,U}}) where {T,V,S,U} = F[:values]::U
+eigvals(F::Union{Eigen, GeneralizedEigen}) = F.values
 
 """
     eigvals!(A; permute::Bool=true, scale::Bool=true) -> values
@@ -352,8 +345,8 @@ end
 
 Computes the generalized eigenvalue decomposition of `A` and `B`, returning a
 `GeneralizedEigen` factorization object `F` which contains the generalized eigenvalues in
-`F[:values]` and the generalized eigenvectors in the columns of the matrix `F[:vectors]`.
-(The `k`th generalized eigenvector can be obtained from the slice `F[:vectors][:, k]`.)
+`F.values` and the generalized eigenvectors in the columns of the matrix `F.vectors`.
+(The `k`th generalized eigenvector can be obtained from the slice `F.vectors[:, k]`.)
 
 # Examples
 ```jldoctest
@@ -369,12 +362,12 @@ julia> B = [0 1; 1 0]
 
 julia> F = eigfact(A, B);
 
-julia> F[:values]
+julia> F.values
 2-element Array{Complex{Float64},1}:
  0.0 + 1.0im
  0.0 - 1.0im
 
-julia> F[:vectors]
+julia> F.vectors
 2×2 Array{Complex{Float64},2}:
   0.0-1.0im   0.0+1.0im
  -1.0-0.0im  -1.0+0.0im

--- a/base/linalg/linalg.jl
+++ b/base/linalg/linalg.jl
@@ -34,9 +34,10 @@ import Base: A_mul_Bt, At_ldiv_Bt, A_rdiv_Bc, At_ldiv_B, Ac_mul_Bc, A_mul_Bc, Ac
 import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, asec, asech,
     asin, asinh, atan, atanh, axes, big, broadcast, ceil, conj, convert, copy, copyto!, cos,
     cosh, cot, coth, csc, csch, eltype, exp, findmax, findmin, fill!, floor, getindex, hcat,
-    imag, inv, isapprox, isone, IndexStyle, kron, length, log, map, ndims, oneunit, parent,
-    power_by_squaring, print_matrix, promote_rule, real, round, sec, sech, setindex!, show,
-    similar, sin, sincos, sinh, size, sqrt, tan, tanh, transpose, trunc, typed_hcat, vec
+    getproperty, imag, inv, isapprox, isone, IndexStyle, kron, length, log, map, ndims,
+    oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
+    setindex!, show, similar, sin, sincos, sinh, size, sqrt, tan, tanh, transpose, trunc,
+    typed_hcat, vec
 using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_vcat
 # We use `_length` because of non-1 indices; releases after julia 0.5

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -130,14 +130,14 @@ The individual components of the factorization `F` can be accessed by indexing:
 
 | Component | Description                         |
 |:----------|:------------------------------------|
-| `F[:L]`   | `L` (lower triangular) part of `LU` |
-| `F[:U]`   | `U` (upper triangular) part of `LU` |
-| `F[:p]`   | (right) permutation `Vector`        |
-| `F[:P]`   | (right) permutation `Matrix`        |
+| `F.L`     | `L` (lower triangular) part of `LU` |
+| `F.U`     | `U` (upper triangular) part of `LU` |
+| `F.p`     | (right) permutation `Vector`        |
+| `F.P`     | (right) permutation `Matrix`        |
 
 The relationship between `F` and `A` is
 
-`F[:L]*F[:U] == A[F[:p], :]`
+`F.L*F.U == A[F.p, :]`
 
 `F` further supports the following functions:
 
@@ -169,7 +169,7 @@ U factor:
  4.0   3.0
  0.0  -1.5
 
-julia> F[:L] * F[:U] == A[F[:p], :]
+julia> F.L * F.U == A[F.p, :]
 true
 ```
 """
@@ -224,7 +224,7 @@ true
 """
 function lu(A::AbstractMatrix, pivot::Union{Val{false}, Val{true}} = Val(true))
     F = lufact(A, pivot)
-    F[:L], F[:U], F[:p]
+    F.L, F.U, F.p
 end
 
 function LU{T}(F::LU) where T
@@ -237,8 +237,8 @@ Factorization{T}(F::LU) where {T} = LU{T}(F)
 
 copy(A::LU{T,S}) where {T,S} = LU{T,S}(copy(A.factors), copy(A.ipiv), A.info)
 
-size(A::LU) = size(A.factors)
-size(A::LU,n) = size(A.factors,n)
+size(A::LU)    = size(getfield(A, :factors))
+size(A::LU, i) = size(getfield(A, :factors), i)
 
 function ipiv2perm(v::AbstractVector{T}, maxi::Integer) where T
     p = T[1:maxi;]
@@ -248,20 +248,20 @@ function ipiv2perm(v::AbstractVector{T}, maxi::Integer) where T
     return p
 end
 
-function getindex(F::LU{T,<:StridedMatrix}, d::Symbol) where T
+function getproperty(F::LU{T,<:StridedMatrix}, d::Symbol) where T
     m, n = size(F)
     if d == :L
-        L = tril!(F.factors[1:m, 1:min(m,n)])
+        L = tril!(getfield(F, :factors)[1:m, 1:min(m,n)])
         for i = 1:min(m,n); L[i,i] = one(T); end
         return L
     elseif d == :U
-        return triu!(F.factors[1:min(m,n), 1:n])
+        return triu!(getfield(F, :factors)[1:min(m,n), 1:n])
     elseif d == :p
-        return ipiv2perm(F.ipiv, m)
+        return ipiv2perm(getfield(F, :ipiv), m)
     elseif d == :P
-        return Matrix{T}(I, m, m)[:,invperm(F[:p])]
+        return Matrix{T}(I, m, m)[:,invperm(F.p)]
     else
-        throw(KeyError(d))
+        getfield(F, d)
     end
 end
 
@@ -270,9 +270,9 @@ issuccess(F::LU) = F.info == 0
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::LU)
     if issuccess(F)
         println(io, summary(F), "\nL factor:")
-        show(io, mime, F[:L])
+        show(io, mime, F.L)
         println(io, "\nU factor:")
-        show(io, mime, F[:U])
+        show(io, mime, F.U)
     else
         print(io, "Failed factorization of type $(typeof(F))")
     end
@@ -463,28 +463,28 @@ end
 
 factorize(A::Tridiagonal) = lufact(A)
 
-function getindex(F::LU{T,Tridiagonal{T,V}}, d::Symbol) where {T,V}
+function getproperty(F::LU{T,Tridiagonal{T,V}}, d::Symbol) where {T,V}
     m, n = size(F)
     if d == :L
-        L = Array(Bidiagonal(ones(T, n), F.factors.dl, d))
+        L = Array(Bidiagonal(ones(T, n), getfield(getfield(F, :factors), :dl), d))
         for i = 2:n
-            tmp = L[F.ipiv[i], 1:i - 1]
-            L[F.ipiv[i], 1:i - 1] = L[i, 1:i - 1]
+            tmp = L[getfield(F, :ipiv)[i], 1:i - 1]
+            L[getfield(F, :ipiv)[i], 1:i - 1] = L[i, 1:i - 1]
             L[i, 1:i - 1] = tmp
         end
         return L
     elseif d == :U
-        U = Array(Bidiagonal(F.factors.d, F.factors.du, d))
+        U = Array(Bidiagonal(getfield(getfield(F, :factors), :d), getfield(getfield(F, :factors), :du), d))
         for i = 1:n - 2
-            U[i,i + 2] = F.factors.du2[i]
+            U[i,i + 2] = getfield(getfield(F, :factors), :du2)[i]
         end
         return U
     elseif d == :p
-        return ipiv2perm(F.ipiv, m)
+        return ipiv2perm(getfield(F, :ipiv), m)
     elseif d == :P
-        return Matrix{T}(I, m, m)[:,invperm(F[:p])]
+        return Matrix{T}(I, m, m)[:,invperm(F.p)]
     end
-    throw(KeyError(d))
+    return getfield(F, d)
 end
 
 # See dgtts2.f
@@ -593,7 +593,7 @@ end
 /(B::AbstractMatrix,A::LU) = transpose(Transpose(A) \ Transpose(B))
 
 # Conversions
-AbstractMatrix(F::LU) = (F[:L] * F[:U])[invperm(F[:p]),:]
+AbstractMatrix(F::LU) = (F.L * F.U)[invperm(F.p),:]
 AbstractArray(F::LU) = AbstractMatrix(F)
 Matrix(F::LU) = Array(AbstractArray(F))
 Array(F::LU) = Matrix(F)

--- a/base/linalg/svd.jl
+++ b/base/linalg/svd.jl
@@ -27,7 +27,7 @@ julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
 
 julia> F = svdfact!(A);
 
-julia> F[:U] * Diagonal(F[:S]) * F[:Vt]
+julia> F.U * Diagonal(F.S) * F.Vt
 4×5 Array{Float64,2}:
  1.0  0.0  0.0  0.0  2.0
  0.0  0.0  3.0  0.0  0.0
@@ -64,8 +64,8 @@ end
 
 Compute the singular value decomposition (SVD) of `A` and return an `SVD` object.
 
-`U`, `S`, `V` and `Vt` can be obtained from the factorization `F` with `F[:U]`,
-`F[:S]`, `F[:V]` and `F[:Vt]`, such that `A = U * Diagonal(S) * Vt`.
+`U`, `S`, `V` and `Vt` can be obtained from the factorization `F` with `F.U`,
+`F.S`, `F.V` and `F.Vt`, such that `A = U * Diagonal(S) * Vt`.
 The algorithm produces `Vt` and hence `Vt` is more efficient to extract than `V`.
 The singular values in `S` are sorted in descending order.
 
@@ -84,7 +84,7 @@ julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
 
 julia> F = svdfact(A);
 
-julia> F[:U] * Diagonal(F[:S]) * F[:Vt]
+julia> F.U * Diagonal(F.S) * F.Vt
 4×5 Array{Float64,2}:
  1.0  0.0  0.0  0.0  2.0
  0.0  0.0  3.0  0.0  0.0
@@ -178,17 +178,11 @@ function svd(x::Number; full::Bool = false, thin::Union{Bool,Nothing} = nothing)
     return first.(svd(fill(x, 1, 1)))
 end
 
-function getindex(F::SVD, d::Symbol)
-    if d == :U
-        return F.U
-    elseif d == :S
-        return F.S
-    elseif d == :Vt
-        return F.Vt
-    elseif d == :V
-        return adjoint(F.Vt)
+function getproperty(F::SVD, d::Symbol)
+    if d == :V
+        return getfield(F, :Vt)'
     else
-        throw(KeyError(d))
+        return getfield(F, d)
     end
 end
 
@@ -249,7 +243,7 @@ julia> svdvals(A)
 """
 svdvals(A::AbstractMatrix{T}) where T = svdvals!(copy_oftype(A, eigtype(T)))
 svdvals(x::Number) = abs(x)
-svdvals(S::SVD{<:Any,T}) where {T} = (S[:S])::Vector{T}
+svdvals(S::SVD{<:Any,T}) where {T} = (S.S)::Vector{T}
 
 # SVD least squares
 function ldiv!(A::SVD{T}, B::StridedVecOrMat) where T
@@ -297,12 +291,12 @@ julia> B = [0. 1.; 1. 0.]
 
 julia> F = svdfact!(A, B);
 
-julia> F[:U]*F[:D1]*F[:R0]*F[:Q]'
+julia> F.U*F.D1*F.R0*F.Q'
 2×2 Array{Float64,2}:
  1.0   0.0
  0.0  -1.0
 
-julia> F[:V]*F[:D2]*F[:R0]*F[:Q]'
+julia> F.V*F.D2*F.R0*F.Q'
 2×2 Array{Float64,2}:
  0.0  1.0
  1.0  0.0
@@ -333,21 +327,21 @@ svdfact(A::StridedMatrix{T}, B::StridedMatrix{T}) where {T<:BlasFloat} = svdfact
     svdfact(A, B) -> GeneralizedSVD
 
 Compute the generalized SVD of `A` and `B`, returning a `GeneralizedSVD` factorization
-object `F`, such that `A = F[:U]*F[:D1]*F[:R0]*F[:Q]'` and `B = F[:V]*F[:D2]*F[:R0]*F[:Q]'`.
+object `F`, such that `A = F.U*F.D1*F.R0*F.Q'` and `B = F.V*F.D2*F.R0*F.Q'`.
 
 For an M-by-N matrix `A` and P-by-N matrix `B`,
 
-- `F[:U]` is a M-by-M orthogonal matrix,
-- `F[:V]` is a P-by-P orthogonal matrix,
-- `F[:Q]` is a N-by-N orthogonal matrix,
-- `F[:R0]` is a (K+L)-by-N matrix whose rightmost (K+L)-by-(K+L) block is
+- `U` is a M-by-M orthogonal matrix,
+- `V` is a P-by-P orthogonal matrix,
+- `Q` is a N-by-N orthogonal matrix,
+- `R0` is a (K+L)-by-N matrix whose rightmost (K+L)-by-(K+L) block is
            nonsingular upper block triangular,
-- `F[:D1]` is a M-by-(K+L) diagonal matrix with 1s in the first K entries,
-- `F[:D2]` is a P-by-(K+L) matrix whose top right L-by-L block is diagonal,
+- `D1` is a M-by-(K+L) diagonal matrix with 1s in the first K entries,
+- `D2` is a P-by-(K+L) matrix whose top right L-by-L block is diagonal,
 
 `K+L` is the effective numerical rank of the matrix `[A; B]`.
 
-The entries of `F[:D1]` and `F[:D2]` are related, as explained in the LAPACK
+The entries of `F.D1` and `F.D2` are related, as explained in the LAPACK
 documentation for the
 [generalized SVD](http://www.netlib.org/lapack/lug/node36.html) and the
 [xGGSVD3](http://www.netlib.org/lapack/explore-html/d6/db3/dggsvd3_8f.html)
@@ -367,12 +361,12 @@ julia> B = [0. 1.; 1. 0.]
 
 julia> F = svdfact(A, B);
 
-julia> F[:U]*F[:D1]*F[:R0]*F[:Q]'
+julia> F.U*F.D1*F.R0*F.Q'
 2×2 Array{Float64,2}:
  1.0   0.0
  0.0  -1.0
 
-julia> F[:V]*F[:D2]*F[:R0]*F[:Q]'
+julia> F.V*F.D2*F.R0*F.Q'
 2×2 Array{Float64,2}:
  0.0  1.0
  1.0  0.0
@@ -423,47 +417,47 @@ julia> V*D2*R0*Q'
 """
 function svd(A::AbstractMatrix, B::AbstractMatrix)
     F = svdfact(A, B)
-    F[:U], F[:V], F[:Q], F[:D1], F[:D2], F[:R0]
+    F.U, F.V, F.Q, F.D1, F.D2, F.R0
 end
 svd(x::Number, y::Number) = first.(svd(fill(x, 1, 1), fill(y, 1, 1)))
 
-function getindex(obj::GeneralizedSVD{T}, d::Symbol) where T
-    if d == :U
-        return obj.U
-    elseif d == :V
-        return obj.V
-    elseif d == :Q
-        return obj.Q
-    elseif d == :alpha || d == :a
-        return obj.a
-    elseif d == :beta || d == :b
-        return obj.b
+@inline function getproperty(F::GeneralizedSVD{T}, d::Symbol) where T
+    Fa = getfield(F, :a)
+    Fb = getfield(F, :b)
+    Fk = getfield(F, :k)
+    Fl = getfield(F, :l)
+    FU = getfield(F, :U)
+    FV = getfield(F, :V)
+    FQ = getfield(F, :Q)
+    FR = getfield(F, :R)
+    if d == :alpha
+        return Fa
+    elseif d == :beta
+        return Fb
     elseif d == :vals || d == :S
-        return obj.a[1:obj.k + obj.l] ./ obj.b[1:obj.k + obj.l]
+        return Fa[1:Fk + Fl] ./ Fb[1:Fk + Fl]
     elseif d == :D1
-        m = size(obj.U, 1)
-        if m - obj.k - obj.l >= 0
-            return [Matrix{T}(I, obj.k, obj.k)  zeros(T, obj.k, obj.l)                      ;
-                    zeros(T, obj.l, obj.k)      Diagonal(obj.a[obj.k + 1:obj.k + obj.l])    ;
-                    zeros(T, m - obj.k - obj.l, obj.k + obj.l)                              ]
+        m = size(FU, 1)
+        if m - Fk - Fl >= 0
+            return [Matrix{T}(I, Fk, Fk)  zeros(T, Fk, Fl)            ;
+                    zeros(T, Fl, Fk)      Diagonal(Fa[Fk + 1:Fk + Fl]);
+                    zeros(T, m - Fk - Fl, Fk + Fl)                    ]
         else
-            return [Matrix{T}(I, m, obj.k) [zeros(T, obj.k, m - obj.k); Diagonal(obj.a[obj.k + 1:m])] zeros(T, m, obj.k + obj.l - m)]
+            return [Matrix{T}(I, m, Fk) [zeros(T, Fk, m - Fk); Diagonal(Fa[Fk + 1:m])] zeros(T, m, Fk + Fl - m)]
         end
     elseif d == :D2
-        m = size(obj.U, 1)
-        p = size(obj.V, 1)
-        if m - obj.k - obj.l >= 0
-            return [zeros(T, obj.l, obj.k) Diagonal(obj.b[obj.k + 1:obj.k + obj.l]); zeros(T, p - obj.l, obj.k + obj.l)]
+        m = size(FU, 1)
+        p = size(FV, 1)
+        if m - Fk - Fl >= 0
+            return [zeros(T, Fl, Fk) Diagonal(Fb[Fk + 1:Fk + Fl]); zeros(T, p - Fl, Fk + Fl)]
         else
-            return [zeros(T, p, obj.k) [Diagonal(obj.b[obj.k + 1:m]); zeros(T, obj.k + p - m, m - obj.k)] [zeros(T, m - obj.k, obj.k + obj.l - m); Matrix{T}(I, obj.k + p - m, obj.k + obj.l - m)]]
+            return [zeros(T, p, Fk) [Diagonal(Fb[Fk + 1:m]); zeros(T, Fk + p - m, m - Fk)] [zeros(T, m - Fk, Fk + Fl - m); Matrix{T}(I, Fk + p - m, Fk + Fl - m)]]
         end
-    elseif d == :R
-        return obj.R
     elseif d == :R0
-        n = size(obj.Q, 1)
-        return [zeros(T, obj.k + obj.l, n - obj.k - obj.l) obj.R]
+        n = size(FQ, 1)
+        return [zeros(T, Fk + Fl, n - Fk - Fl) FR]
     else
-        throw(KeyError(d))
+        getfield(F, d)
     end
 end
 

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -214,7 +214,7 @@ eigmax(A::SymTridiagonal) = eigvals(A, size(A, 1):size(A, 1))[1]
 eigmin(A::SymTridiagonal) = eigvals(A, 1:1)[1]
 
 #Compute selected eigenvectors only corresponding to particular eigenvalues
-eigvecs(A::SymTridiagonal) = eigfact(A)[:vectors]
+eigvecs(A::SymTridiagonal) = eigfact(A).vectors
 
 """
     eigvecs(A::SymTridiagonal[, eigvals]) -> Matrix

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -554,9 +554,9 @@ bs = deepcopy(as)
 cs = collect(Distributed.pgenerate(x->(sleep(rand()*0.1); svdfact(x)), bs))
 svdas = map(svdfact, as)
 for i in 1:n
-    @test cs[i][:U] ≈ svdas[i][:U]
-    @test cs[i][:S] ≈ svdas[i][:S]
-    @test cs[i][:V] ≈ svdas[i][:V]
+    @test cs[i].U ≈ svdas[i].U
+    @test cs[i].S ≈ svdas[i].S
+    @test cs[i].V ≈ svdas[i].V
 end
 
 # Test that the default worker pool cycles through all workers

--- a/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
+++ b/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
@@ -280,7 +280,7 @@ julia> A = Diagonal(1:4);
 
 julia> s = svds(A, nsv = 2)[1];
 
-julia> s[:S]
+julia> s.S
 2-element Array{Float64,1}:
  4.0
  2.9999999999999996

--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -189,15 +189,15 @@ end
     S2 = svd(Array(A))
 
     ## singular values match:
-    @test S1[1][:S] ≈ S2[2][1:2]
+    @test S1[1].S ≈ S2[2][1:2]
     @testset "singular vectors" begin
         ## 1st left singular vector
-        s1_left = sign(S1[1][:U][3,1]) * S1[1][:U][:,1]
+        s1_left = sign(S1[1].U[3,1]) * S1[1].U[:,1]
         s2_left = sign(S2[1][3,1]) * S2[1][:,1]
         @test s1_left ≈ s2_left
 
         ## 1st right singular vector
-        s1_right = sign(S1[1][:V][3,1]) * S1[1][:V][:,1]
+        s1_right = sign(S1[1].V[3,1]) * S1[1].V[:,1]
         s2_right = sign(S2[3][3,1]) * S2[3][:,1]
         @test s1_right ≈ s2_right
     end
@@ -207,13 +207,13 @@ end
     @testset "singular values ordered correctly" begin
         B = sparse(Diagonal([1.0, 2.0, 34.0, 5.0, 6.0]))
         S3 = svds(B, ritzvec=false, nsv=2)
-        @test S3[1][:S] ≈ [34.0, 6.0]
+        @test S3[1].S ≈ [34.0, 6.0]
         S4 = svds(B, nsv=2)
-        @test S4[1][:S] ≈ [34.0, 6.0]
+        @test S4[1].S ≈ [34.0, 6.0]
     end
     @testset "passing guess for Krylov vectors" begin
         S1 = svds(A, nsv = 2, v0=rand(eltype(A),size(A,2)))
-        @test S1[1][:S] ≈ S2[2][1:2]
+        @test S1[1].S ≈ S2[2][1:2]
     end
 
     @test_throws ArgumentError svds(A,nsv=0)
@@ -231,15 +231,15 @@ end
         @testset "Number of singular values: $j" for j in 2:6
             # Default size of subspace
             F = svds(A, nsv = j, v0 = v0)
-            @test F[1][:U]'F[1][:U] ≈ Matrix(I, j, j)
-            @test F[1][:V]'F[1][:V] ≈ Matrix(I, j, j)
-            @test F[1][:S]          ≈ d[1:j]
+            @test F[1].U'F[1].U ≈ Matrix(I, j, j)
+            @test F[1].V'F[1].V ≈ Matrix(I, j, j)
+            @test F[1].S        ≈ d[1:j]
             for k in 3j:2:5j
                 # Custom size of subspace
                 F = svds(A, nsv = j, ncv = k, v0 = v0)
-                @test F[1][:U]'F[1][:U] ≈ Matrix(I, j, j)
-                @test F[1][:V]'F[1][:V] ≈ Matrix(I, j, j)
-                @test F[1][:S]          ≈ d[1:j]
+                @test F[1].U'F[1].U ≈ Matrix(I, j, j)
+                @test F[1].V'F[1].V ≈ Matrix(I, j, j)
+                @test F[1].S        ≈ d[1:j]
             end
         end
     end
@@ -251,21 +251,21 @@ end
     S2 = svd(Array(A))
 
     ## singular values match:
-    @test S1[1][:S] ≈ S2[2][1:2]
+    @test S1[1].S ≈ S2[2][1:2]
     @testset "singular vectors" begin
         ## left singular vectors
-        s1_left = abs.(S1[1][:U][:,1:2])
+        s1_left = abs.(S1[1].U[:,1:2])
         s2_left = abs.(S2[1][:,1:2])
         @test s1_left ≈ s2_left
 
         ## right singular vectors
-        s1_right = abs.(S1[1][:V][:,1:2])
+        s1_right = abs.(S1[1].V[:,1:2])
         s2_right = abs.(S2[3][:,1:2])
         @test s1_right ≈ s2_right
     end
     @testset "passing guess for Krylov vectors" begin
         S1 = svds(A, nsv = 2, v0=rand(eltype(A),size(A,2)))
-        @test S1[1][:S] ≈ S2[2][1:2]
+        @test S1[1].S ≈ S2[2][1:2]
     end
 
     @test_throws ArgumentError svds(A,nsv=0)

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -499,114 +499,114 @@ end
 
     @testset "cholfact, no permutation" begin
         Fs = cholfact(As, perm=[1:3;])
-        @test Fs[:p] == [1:3;]
-        @test sparse(Fs[:L]) ≈ Lf
+        @test Fs.p == [1:3;]
+        @test sparse(Fs.L) ≈ Lf
         @test sparse(Fs) ≈ As
         b = rand(3)
         @test Fs\b ≈ Af\b
-        @test Fs[:UP]\(Fs[:PtL]\b) ≈ Af\b
-        @test Fs[:L]\b ≈ Lf\b
-        @test Fs[:U]\b ≈ Lf'\b
-        @test Fs[:L]'\b ≈ Lf'\b
-        @test Fs[:U]'\b ≈ Lf\b
-        @test Fs[:PtL]\b ≈ Lf\b
-        @test Fs[:UP]\b ≈ Lf'\b
-        @test Fs[:PtL]'\b ≈ Lf'\b
-        @test Fs[:UP]'\b ≈ Lf\b
-        @test_throws CHOLMOD.CHOLMODException Fs[:D]
-        @test_throws CHOLMOD.CHOLMODException Fs[:LD]
-        @test_throws CHOLMOD.CHOLMODException Fs[:DU]
-        @test_throws CHOLMOD.CHOLMODException Fs[:PLD]
-        @test_throws CHOLMOD.CHOLMODException Fs[:DUPt]
+        @test Fs.UP\(Fs.PtL\b) ≈ Af\b
+        @test Fs.L\b ≈ Lf\b
+        @test Fs.U\b ≈ Lf'\b
+        @test Fs.L'\b ≈ Lf'\b
+        @test Fs.U'\b ≈ Lf\b
+        @test Fs.PtL\b ≈ Lf\b
+        @test Fs.UP\b ≈ Lf'\b
+        @test Fs.PtL'\b ≈ Lf'\b
+        @test Fs.UP'\b ≈ Lf\b
+        @test_throws CHOLMOD.CHOLMODException Fs.D
+        @test_throws CHOLMOD.CHOLMODException Fs.LD
+        @test_throws CHOLMOD.CHOLMODException Fs.DU
+        @test_throws CHOLMOD.CHOLMODException Fs.PLD
+        @test_throws CHOLMOD.CHOLMODException Fs.DUPt
     end
 
     @testset "cholfact, with permutation" begin
         Fs = cholfact(As, perm=p)
-        @test Fs[:p] == p
+        @test Fs.p == p
         Afp = Af[p,p]
-        Lfp = cholfact(Afp)[:L]
-        @test sparse(Fs[:L]) ≈ Lfp
+        Lfp = cholfact(Afp).L
+        @test sparse(Fs.L) ≈ Lfp
         @test sparse(Fs) ≈ As
         b = rand(3)
         @test Fs\b ≈ Af\b
-        @test Fs[:UP]\(Fs[:PtL]\b) ≈ Af\b
-        @test Fs[:L]\b ≈ Lfp\b
-        @test Fs[:U]'\b ≈ Lfp\b
-        @test Fs[:U]\b ≈ Lfp'\b
-        @test Fs[:L]'\b ≈ Lfp'\b
-        @test Fs[:PtL]\b ≈ Lfp\b[p]
-        @test Fs[:UP]\b ≈ (Lfp'\b)[p_inv]
-        @test Fs[:PtL]'\b ≈ (Lfp'\b)[p_inv]
-        @test Fs[:UP]'\b ≈ Lfp\b[p]
-        @test_throws CHOLMOD.CHOLMODException Fs[:PL]
-        @test_throws CHOLMOD.CHOLMODException Fs[:UPt]
-        @test_throws CHOLMOD.CHOLMODException Fs[:D]
-        @test_throws CHOLMOD.CHOLMODException Fs[:LD]
-        @test_throws CHOLMOD.CHOLMODException Fs[:DU]
-        @test_throws CHOLMOD.CHOLMODException Fs[:PLD]
-        @test_throws CHOLMOD.CHOLMODException Fs[:DUPt]
+        @test Fs.UP\(Fs.PtL\b) ≈ Af\b
+        @test Fs.L\b ≈ Lfp\b
+        @test Fs.U'\b ≈ Lfp\b
+        @test Fs.U\b ≈ Lfp'\b
+        @test Fs.L'\b ≈ Lfp'\b
+        @test Fs.PtL\b ≈ Lfp\b[p]
+        @test Fs.UP\b ≈ (Lfp'\b)[p_inv]
+        @test Fs.PtL'\b ≈ (Lfp'\b)[p_inv]
+        @test Fs.UP'\b ≈ Lfp\b[p]
+        @test_throws CHOLMOD.CHOLMODException Fs.PL
+        @test_throws CHOLMOD.CHOLMODException Fs.UPt
+        @test_throws CHOLMOD.CHOLMODException Fs.D
+        @test_throws CHOLMOD.CHOLMODException Fs.LD
+        @test_throws CHOLMOD.CHOLMODException Fs.DU
+        @test_throws CHOLMOD.CHOLMODException Fs.PLD
+        @test_throws CHOLMOD.CHOLMODException Fs.DUPt
     end
 
     @testset "ldltfact, no permutation" begin
         Fs = ldltfact(As, perm=[1:3;])
-        @test Fs[:p] == [1:3;]
-        @test sparse(Fs[:LD]) ≈ LDf
+        @test Fs.p == [1:3;]
+        @test sparse(Fs.LD) ≈ LDf
         @test sparse(Fs) ≈ As
         b = rand(3)
         @test Fs\b ≈ Af\b
-        @test Fs[:UP]\(Fs[:PtLD]\b) ≈ Af\b
-        @test Fs[:DUP]\(Fs[:PtL]\b) ≈ Af\b
-        @test Fs[:L]\b ≈ L_f\b
-        @test Fs[:U]\b ≈ L_f'\b
-        @test Fs[:L]'\b ≈ L_f'\b
-        @test Fs[:U]'\b ≈ L_f\b
-        @test Fs[:PtL]\b ≈ L_f\b
-        @test Fs[:UP]\b ≈ L_f'\b
-        @test Fs[:PtL]'\b ≈ L_f'\b
-        @test Fs[:UP]'\b ≈ L_f\b
-        @test Fs[:D]\b ≈ D_f\b
-        @test Fs[:D]'\b ≈ D_f\b
-        @test Fs[:LD]\b ≈ D_f\(L_f\b)
-        @test Fs[:DU]'\b ≈ D_f\(L_f\b)
-        @test Fs[:LD]'\b ≈ L_f'\(D_f\b)
-        @test Fs[:DU]\b ≈ L_f'\(D_f\b)
-        @test Fs[:PtLD]\b ≈ D_f\(L_f\b)
-        @test Fs[:DUP]'\b ≈ D_f\(L_f\b)
-        @test Fs[:PtLD]'\b ≈ L_f'\(D_f\b)
-        @test Fs[:DUP]\b ≈ L_f'\(D_f\b)
+        @test Fs.UP\(Fs.PtLD\b) ≈ Af\b
+        @test Fs.DUP\(Fs.PtL\b) ≈ Af\b
+        @test Fs.L\b ≈ L_f\b
+        @test Fs.U\b ≈ L_f'\b
+        @test Fs.L'\b ≈ L_f'\b
+        @test Fs.U'\b ≈ L_f\b
+        @test Fs.PtL\b ≈ L_f\b
+        @test Fs.UP\b ≈ L_f'\b
+        @test Fs.PtL'\b ≈ L_f'\b
+        @test Fs.UP'\b ≈ L_f\b
+        @test Fs.D\b ≈ D_f\b
+        @test Fs.D'\b ≈ D_f\b
+        @test Fs.LD\b ≈ D_f\(L_f\b)
+        @test Fs.DU'\b ≈ D_f\(L_f\b)
+        @test Fs.LD'\b ≈ L_f'\(D_f\b)
+        @test Fs.DU\b ≈ L_f'\(D_f\b)
+        @test Fs.PtLD\b ≈ D_f\(L_f\b)
+        @test Fs.DUP'\b ≈ D_f\(L_f\b)
+        @test Fs.PtLD'\b ≈ L_f'\(D_f\b)
+        @test Fs.DUP\b ≈ L_f'\(D_f\b)
     end
 
     @testset "ldltfact, with permutation" begin
         Fs = ldltfact(As, perm=p)
-        @test Fs[:p] == p
+        @test Fs.p == p
         @test sparse(Fs) ≈ As
         b = rand(3)
         Asp = As[p,p]
-        LDp = sparse(ldltfact(Asp, perm=[1,2,3])[:LD])
-        # LDp = sparse(Fs[:LD])
+        LDp = sparse(ldltfact(Asp, perm=[1,2,3]).LD)
+        # LDp = sparse(Fs.LD)
         Lp, dp = SuiteSparse.CHOLMOD.getLd!(copy(LDp))
         Dp = sparse(Diagonal(dp))
         @test Fs\b ≈ Af\b
-        @test Fs[:UP]\(Fs[:PtLD]\b) ≈ Af\b
-        @test Fs[:DUP]\(Fs[:PtL]\b) ≈ Af\b
-        @test Fs[:L]\b ≈ Lp\b
-        @test Fs[:U]\b ≈ Lp'\b
-        @test Fs[:L]'\b ≈ Lp'\b
-        @test Fs[:U]'\b ≈ Lp\b
-        @test Fs[:PtL]\b ≈ Lp\b[p]
-        @test Fs[:UP]\b ≈ (Lp'\b)[p_inv]
-        @test Fs[:PtL]'\b ≈ (Lp'\b)[p_inv]
-        @test Fs[:UP]'\b ≈ Lp\b[p]
-        @test Fs[:LD]\b ≈ Dp\(Lp\b)
-        @test Fs[:DU]'\b ≈ Dp\(Lp\b)
-        @test Fs[:LD]'\b ≈ Lp'\(Dp\b)
-        @test Fs[:DU]\b ≈ Lp'\(Dp\b)
-        @test Fs[:PtLD]\b ≈ Dp\(Lp\b[p])
-        @test Fs[:DUP]'\b ≈ Dp\(Lp\b[p])
-        @test Fs[:PtLD]'\b ≈ (Lp'\(Dp\b))[p_inv]
-        @test Fs[:DUP]\b ≈ (Lp'\(Dp\b))[p_inv]
-        @test_throws CHOLMOD.CHOLMODException Fs[:DUPt]
-        @test_throws CHOLMOD.CHOLMODException Fs[:PLD]
+        @test Fs.UP\(Fs.PtLD\b) ≈ Af\b
+        @test Fs.DUP\(Fs.PtL\b) ≈ Af\b
+        @test Fs.L\b ≈ Lp\b
+        @test Fs.U\b ≈ Lp'\b
+        @test Fs.L'\b ≈ Lp'\b
+        @test Fs.U'\b ≈ Lp\b
+        @test Fs.PtL\b ≈ Lp\b[p]
+        @test Fs.UP\b ≈ (Lp'\b)[p_inv]
+        @test Fs.PtL'\b ≈ (Lp'\b)[p_inv]
+        @test Fs.UP'\b ≈ Lp\b[p]
+        @test Fs.LD\b ≈ Dp\(Lp\b)
+        @test Fs.DU'\b ≈ Dp\(Lp\b)
+        @test Fs.LD'\b ≈ Lp'\(Dp\b)
+        @test Fs.DU\b ≈ Lp'\(Dp\b)
+        @test Fs.PtLD\b ≈ Dp\(Lp\b[p])
+        @test Fs.DUP'\b ≈ Dp\(Lp\b[p])
+        @test Fs.PtLD'\b ≈ (Lp'\(Dp\b))[p_inv]
+        @test Fs.DUP\b ≈ (Lp'\(Dp\b))[p_inv]
+        @test_throws CHOLMOD.CHOLMODException Fs.DUPt
+        @test_throws CHOLMOD.CHOLMODException Fs.PLD
     end
 
     @testset "Element promotion and type inference" begin
@@ -622,7 +622,7 @@ end
 gc()
 
 @testset "Issue 11747 - Wrong show method defined for FactorComponent" begin
-    v = cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10]))[:L]
+    v = cholfact(sparse(Float64[ 10 1 1 1; 1 10 0 0; 1 0 10 0; 1 0 0 10])).L
     for s in (sprint(show, MIME("text/plain"), v), sprint(show, v))
         @test contains(s, "method: simplicial")
         @test !contains(s, "#undef")

--- a/stdlib/SuiteSparse/test/spqr.jl
+++ b/stdlib/SuiteSparse/test/spqr.jl
@@ -8,7 +8,7 @@ using Base.LinAlg: mul!, Adjoint, Transpose
 m, n = 100, 10
 nn = 100
 
-@test size(qrfact(sprandn(m, n, 0.1))[:Q]) == (m, m)
+@test size(qrfact(sprandn(m, n, 0.1)).Q) == (m, m)
 
 @testset "element type of A: $eltyA" for eltyA in (Float64, Complex{Float64})
     if eltyA <: Real
@@ -25,21 +25,21 @@ nn = 100
     @test_throws ArgumentError size(F, 0)
 
     @testset "getindex" begin
-        @test istriu(F[:R])
-        @test isperm(F[:pcol])
-        @test isperm(F[:prow])
-        @test_throws KeyError F[:T]
+        @test istriu(F.R)
+        @test isperm(F.pcol)
+        @test isperm(F.prow)
+        @test_throws ErrorException F.T
     end
 
     @testset "apply Q" begin
-        Q = F[:Q]
+        Q = F.Q
         Imm = Matrix{Float64}(I, m, m)
         @test Q' * (Q*Imm) ≈ Imm
         @test (Imm*Q) * Q' ≈ Imm
 
         # test that Q'Pl*A*Pr = R
-        R0 = Q'*Array(A[F[:prow], F[:pcol]])
-        @test R0[1:n, :] ≈ F[:R]
+        R0 = Q'*Array(A[F.prow, F.pcol])
+        @test R0[1:n, :] ≈ F.R
         @test norm(R0[n + 1:end, :], 1) < 1e-12
 
         offsizeA = Matrix{Float64}(I, m+1, m+1)

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -20,8 +20,8 @@
             A = convert(SparseMatrixCSC{Tv,Ti}, A0)
             lua = lufact(A)
             @test nnz(lua) == 18
-            @test_throws KeyError lua[:Z]
-            L,U,p,q,Rs = lua[:(:)]
+            @test_throws ErrorException lua.Z
+            L,U,p,q,Rs = lua.:(:)
             @test (Diagonal(Rs) * A)[p,q] ≈ L * U
 
             det(lua) ≈ det(Array(A))
@@ -78,7 +78,7 @@
             Ac = convert(SparseMatrixCSC{ComplexF64,Ti}, Ac0)
             x  = complex.(ones(size(Ac, 1)), ones(size(Ac,1)))
             lua = lufact(Ac)
-            L,U,p,q,Rs = lua[:(:)]
+            L,U,p,q,Rs = lua.:(:)
             @test (Diagonal(Rs) * Ac)[p,q] ≈ L * U
             b  = Ac*x
             @test Ac\b ≈ x
@@ -93,7 +93,7 @@
         for (m, n) in ((10,5), (5, 10))
             A = sparse([1:min(m,n); rand(1:m, 10)], [1:min(m,n); rand(1:n, 10)], elty == Float64 ? randn(min(m, n) + 10) : complex.(randn(min(m, n) + 10), randn(min(m, n) + 10)))
             F = lufact(A)
-            L, U, p, q, Rs = F[:(:)]
+            L, U, p, q, Rs = F.:(:)
             @test (Diagonal(Rs) * A)[p,q] ≈ L * U
         end
     end
@@ -121,10 +121,10 @@
 
         F = lufact(sparse(ones(Tin, 1, 1)))
         L = sparse(ones(Tout, 1, 1))
-        @test F[:p] == F[:q] == [1]
-        @test F[:Rs] == [1.0]
-        @test F[:L] == F[:U] == L
-        @test F[:(:)] == (L, L, [1], [1], [1.0])
+        @test F.p == F.q == [1]
+        @test F.Rs == [1.0]
+        @test F.L == F.U == L
+        @test F.:(:) == (L, L, [1], [1], [1.0])
     end
 
     @testset "BigFloat not supported" for T in (BigFloat, Complex{BigFloat})
@@ -152,7 +152,7 @@
         A = sparse(1.0I, 4, 4)
         A[1:2,1:2] = [-.01 -200; 200 .001]
         F = lufact(A)
-        @test F[:p] == [3 ; 4 ; 2 ; 1]
+        @test F.p == [3 ; 4 ; 2 ; 1]
     end
 
     @testset "Test that A[c|t]_ldiv_B!{T<:Complex}(X::StridedMatrix{T}, lu::UmfpackLU{Float64}, B::StridedMatrix{T}) works as expected." begin

--- a/test/linalg/bunchkaufman.jl
+++ b/test/linalg/bunchkaufman.jl
@@ -2,6 +2,7 @@
 
 using Test
 
+using Base: getproperty
 using Base.LinAlg: BlasComplex, BlasFloat, BlasReal, QRPivoted
 
 n = 10
@@ -60,14 +61,15 @@ bimg  = randn(n,2)/2
                 end
                 # Test extraction of factors
                 if eltya <: Real
-                    @test bc1[uplo]*bc1[:D]*bc1[uplo]' ≈ aher[bc1[:p], bc1[:p]]
-                    @test bc1[uplo]*bc1[:D]*bc1[uplo]' ≈ bc1[:P]*aher*bc1[:P]'
+                    @test getproperty(bc1, uplo)*bc1.D*getproperty(bc1, uplo)' ≈ aher[bc1.p, bc1.p]
+                    @test getproperty(bc1, uplo)*bc1.D*getproperty(bc1, uplo)' ≈ bc1.P*aher*bc1.P'
                 end
+
                 bc1 = bkfact(Symmetric(asym, uplo))
-                @test bc1[uplo]*bc1[:D]*Transpose(bc1[uplo]) ≈ asym[bc1[:p], bc1[:p]]
-                @test bc1[uplo]*bc1[:D]*Transpose(bc1[uplo]) ≈ bc1[:P]*asym*Transpose(bc1[:P])
-                @test_throws KeyError bc1[:Z]
-                @test_throws ArgumentError uplo == :L ? bc1[:U] : bc1[:L]
+                @test getproperty(bc1, uplo)*bc1.D*Transpose(getproperty(bc1, uplo)) ≈ asym[bc1.p, bc1.p]
+                @test getproperty(bc1, uplo)*bc1.D*Transpose(getproperty(bc1, uplo)) ≈ bc1.P*asym*Transpose(bc1.P)
+                @test_throws ErrorException bc1.Z
+                @test_throws ArgumentError uplo == :L ? bc1.U : bc1.L
             end
         end
 

--- a/test/linalg/cholesky.jl
+++ b/test/linalg/cholesky.jl
@@ -223,7 +223,7 @@ end
         F = cholfact(Hermitian(AcA, uplo))
         G = cholfact(Hermitian(BcB, uplo))
         @test Base.getproperty(LinAlg.lowrankupdate(F, v), uplo) ≈ Base.getproperty(G, uplo)
-        @test_throws DimensionMismatch LinAlg.lowrankupdate(F, ones(eltype($v), length($v)+1))
+        @test_throws DimensionMismatch LinAlg.lowrankupdate(F, ones(eltype(v), length(v)+1))
         @test Base.getproperty(LinAlg.lowrankdowndate(G, v), uplo) ≈ Base.getproperty(F, uplo)
         @test_throws DimensionMismatch LinAlg.lowrankdowndate(G, ones(eltype(v), length(v)+1))
     end

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -379,7 +379,7 @@ end
         @test exp(A5) ≈ eA5
 
         # Hessenberg
-        @test hessfact(A1)[:H] ≈ convert(Matrix{elty},
+        @test hessfact(A1).H ≈ convert(Matrix{elty},
                                                  [4.000000000000000  -1.414213562373094  -1.414213562373095
                                                   -1.414213562373095   4.999999999999996  -0.000000000000000
                                                   0  -0.000000000000002   3.000000000000000])
@@ -578,19 +578,19 @@ end
             @test all(z -> (0 < real(z) < π ||
                             abs(real(z)) < abstol && imag(z) >= 0 ||
                             abs(real(z) - π) < abstol && imag(z) <= 0),
-                      eigfact(acos(A))[:values])
+                      eigfact(acos(A)).values)
             @test all(z -> (-π/2 < real(z) < π/2 ||
                             abs(real(z) + π/2) < abstol && imag(z) >= 0 ||
                             abs(real(z) - π/2) < abstol && imag(z) <= 0),
-                      eigfact(asin(A))[:values])
+                      eigfact(asin(A)).values)
             @test all(z -> (-π < imag(z) < π && real(z) > 0 ||
                             0 <= imag(z) < π && abs(real(z)) < abstol ||
                             abs(imag(z) - π) < abstol && real(z) >= 0),
-                      eigfact(acosh(A))[:values])
+                      eigfact(acosh(A)).values)
             @test all(z -> (-π/2 < imag(z) < π/2 ||
                             abs(imag(z) + π/2) < abstol && real(z) <= 0 ||
                             abs(imag(z) - π/2) < abstol && real(z) <= 0),
-                      eigfact(asinh(A))[:values])
+                      eigfact(asinh(A)).values)
         end
     end
 end

--- a/test/linalg/diagonal.jl
+++ b/test/linalg/diagonal.jl
@@ -205,8 +205,8 @@ srand(1)
 
     @testset "Eigensystem" begin
         eigD = eigfact(D)
-        @test Diagonal(eigD[:values]) ≈ D
-        @test eigD[:vectors] == Matrix(I, size(D))
+        @test Diagonal(eigD.values) ≈ D
+        @test eigD.vectors == Matrix(I, size(D))
     end
 
     @testset "ldiv" begin
@@ -262,7 +262,7 @@ srand(1)
         U, s, V = svd(D)
         @test (U*Diagonal(s))*V' ≈ D
         @test svdvals(D) == s
-        @test svdfact(D)[:V] == V
+        @test svdfact(D).V == V
     end
 end
 
@@ -354,9 +354,9 @@ end
 
 @testset "multiplication of QR Q-factor and Diagonal (#16615 spot test)" begin
     D = Diagonal(randn(5))
-    Q = qrfact(randn(5, 5))[:Q]
+    Q = qrfact(randn(5, 5)).Q
     @test D * Q' == Array(D) * Q'
-    Q = qrfact(randn(5, 5), Val(true))[:Q]
+    Q = qrfact(randn(5, 5), Val(true)).Q
     @test_throws MethodError mul!(Q, D)
 end
 

--- a/test/linalg/eigen.jl
+++ b/test/linalg/eigen.jl
@@ -40,8 +40,8 @@ aimg  = randn(n,n)/2
             @test det(a) ≈ det(f)
             @test inv(a) ≈ inv(f)
             @test isposdef(a) == isposdef(f)
-            @test eigvals(f) === f[:values]
-            @test eigvecs(f) === f[:vectors]
+            @test eigvals(f) === f.values
+            @test eigvecs(f) === f.vectors
             @test Array(f) ≈ a
 
             num_fact = eigfact(one(eltya))
@@ -61,17 +61,17 @@ aimg  = randn(n,n)/2
                 a_sg = view(a, 1:n, n1+1:n2)
             end
             f = eigfact(asym_sg, a_sg'a_sg)
-            @test asym_sg*f[:vectors] ≈ (a_sg'a_sg*f[:vectors]) * Diagonal(f[:values])
-            @test f[:values] ≈ eigvals(asym_sg, a_sg'a_sg)
-            @test prod(f[:values]) ≈ prod(eigvals(asym_sg/(a_sg'a_sg))) atol=200ε
-            @test eigvecs(asym_sg, a_sg'a_sg) == f[:vectors]
-            @test eigvals(f) === f[:values]
-            @test eigvecs(f) === f[:vectors]
-            @test_throws KeyError f[:Z]
+            @test asym_sg*f.vectors ≈ (a_sg'a_sg*f.vectors) * Diagonal(f.values)
+            @test f.values ≈ eigvals(asym_sg, a_sg'a_sg)
+            @test prod(f.values) ≈ prod(eigvals(asym_sg/(a_sg'a_sg))) atol=200ε
+            @test eigvecs(asym_sg, a_sg'a_sg) == f.vectors
+            @test eigvals(f) === f.values
+            @test eigvecs(f) === f.vectors
+            @test_throws ErrorException f.Z
 
             d,v = eig(asym_sg, a_sg'a_sg)
-            @test d == f[:values]
-            @test v == f[:vectors]
+            @test d == f.values
+            @test v == f.vectors
         end
         @testset "Non-symmetric generalized eigenproblem" begin
             if isa(a, Array)
@@ -82,15 +82,15 @@ aimg  = randn(n,n)/2
                 a2_nsg = view(a, n1+1:n2, n1+1:n2)
             end
             f = eigfact(a1_nsg, a2_nsg)
-            @test a1_nsg*f[:vectors] ≈ (a2_nsg*f[:vectors]) * Diagonal(f[:values])
-            @test f[:values] ≈ eigvals(a1_nsg, a2_nsg)
-            @test prod(f[:values]) ≈ prod(eigvals(a1_nsg/a2_nsg)) atol=50000ε
-            @test eigvecs(a1_nsg, a2_nsg) == f[:vectors]
-            @test_throws KeyError f[:Z]
+            @test a1_nsg*f.vectors ≈ (a2_nsg*f.vectors) * Diagonal(f.values)
+            @test f.values ≈ eigvals(a1_nsg, a2_nsg)
+            @test prod(f.values) ≈ prod(eigvals(a1_nsg/a2_nsg)) atol=50000ε
+            @test eigvecs(a1_nsg, a2_nsg) == f.vectors
+            @test_throws ErrorException f.Z
 
             d,v = eig(a1_nsg, a2_nsg)
-            @test d == f[:values]
-            @test v == f[:vectors]
+            @test d == f.values
+            @test v == f.vectors
         end
     end
 end
@@ -109,7 +109,7 @@ end
 let aa = rand(200, 200)
     for a in (aa, view(aa, 1:n, 1:n))
         f = eigfact(a)
-        @test a ≈ f[:vectors] * Diagonal(f[:values]) / f[:vectors]
+        @test a ≈ f.vectors * Diagonal(f.values) / f.vectors
     end
 end
 

--- a/test/linalg/givens.jl
+++ b/test/linalg/givens.jl
@@ -35,7 +35,7 @@ using Base.LinAlg: mul!, Adjoint, Transpose
         G, _ = givens(one(elty),zero(elty),11,12)
         @test_throws DimensionMismatch mul!(G, A)
         @test_throws DimensionMismatch mul!(A, Adjoint(G))
-        @test abs.(A) ≈ abs.(hessfact(Ac)[:H])
+        @test abs.(A) ≈ abs.(hessfact(Ac).H)
         @test norm(R*Matrix{elty}(I, 10, 10)) ≈ one(elty)
 
         I10 = Matrix{elty}(I, 10, 10)

--- a/test/linalg/hessenberg.jl
+++ b/test/linalg/hessenberg.jl
@@ -19,15 +19,15 @@ let n = 10
 
         if eltya != BigFloat
             H = hessfact(A)
-            @test size(H[:Q], 1) == size(A, 1)
-            @test size(H[:Q], 2) == size(A, 2)
-            @test size(H[:Q]) == size(A)
-            @test_throws KeyError H[:Z]
+            @test size(H.Q, 1) == size(A, 1)
+            @test size(H.Q, 2) == size(A, 2)
+            @test size(H.Q) == size(A)
+            @test_throws ErrorException H.Z
             @test convert(Array, H) ≈ A
-            @test (H[:Q] * H[:H]) * H[:Q]' ≈ A
-            @test (H[:Q]' *A) * H[:Q] ≈ H[:H]
+            @test (H.Q * H.H) * H.Q' ≈ A
+            @test (H.Q' *A) * H.Q ≈ H.H
             #getindex for HessenbergQ
-            @test H[:Q][1,1] ≈ Array(H[:Q])[1,1]
+            @test H.Q[1,1] ≈ Array(H.Q)[1,1]
         end
     end
 end

--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -230,8 +230,8 @@ end
         A = rand(elty,10,10)
         Aw, Avl, Avr = LAPACK.geev!('N','V',copy(A))
         fA = eigfact(A)
-        @test fA[:values] ≈ Aw
-        @test fA[:vectors] ≈ Avr
+        @test fA.values  ≈ Aw
+        @test fA.vectors ≈ Avr
     end
 end
 

--- a/test/linalg/lq.jl
+++ b/test/linalg/lq.jl
@@ -53,7 +53,7 @@ rectangularQ(Q::LinAlg.LQPackedQ) = convert(Array, Q)
                     @test size(lqa,3) == 1
                     @test size(lqa.Q,3) == 1
                     @test_throws ErrorException lqa.Z
-                    @test Array(lqa') ≈ a'
+                    @test Array(adjoint(lqa)) ≈ a'
                     @test lqa * lqa' ≈ a * a'
                     @test lqa' * lqa ≈ a' * a
                     @test q*squareQ(q)' ≈ Matrix(I, n, n)

--- a/test/linalg/lu.jl
+++ b/test/linalg/lu.jl
@@ -51,9 +51,9 @@ dimg  = randn(n)/2
                                        -0.5     -0.5       0.1     1.0])
             F = eigfact(A, permute=false, scale=false)
             eig(A, permute=false, scale=false)
-            @test F[:vectors]*Diagonal(F[:values])/F[:vectors] ≈ A
+            @test F.vectors*Diagonal(F.values)/F.vectors ≈ A
             F = eigfact(A)
-            # @test norm(F[:vectors]*Diagonal(F[:values])/F[:vectors] - A) > 0.01
+            # @test norm(F.vectors*Diagonal(F.values)/F.vectors - A) > 0.01
         end
     end
     @testset "Singular LU" begin
@@ -64,8 +64,8 @@ dimg  = randn(n)/2
     κ  = cond(a,1)
     @testset "(Automatic) Square LU decomposition" begin
         lua   = factorize(a)
-        @test_throws KeyError lua[:Z]
-        l,u,p = lua[:L], lua[:U], lua[:p]
+        @test_throws ErrorException lua.Z
+        l,u,p = lua.L, lua.U, lua.p
         ll,ul,pl = lu(a)
         @test ll * ul ≈ a[pl,:]
         @test l*u ≈ a[p,:]
@@ -76,7 +76,7 @@ dimg  = randn(n)/2
             # test conversion of LU factorization's numerical type
             bft = eltya <: Real ? Base.LinAlg.LU{BigFloat} : Base.LinAlg.LU{Complex{BigFloat}}
             bflua = convert(bft, lua)
-            @test bflua[:L]*bflua[:U] ≈ big.(a)[p,:] rtol=ε
+            @test bflua.L*bflua.U ≈ big.(a)[p,:] rtol=ε
         end
         # compact printing
         lstring = sprint(show,l)
@@ -88,9 +88,9 @@ dimg  = randn(n)/2
         lud   = lufact(d)
         @test LinAlg.issuccess(lud)
         @test lufact(lud) == lud
-        @test_throws KeyError lud[:Z]
-        @test lud[:L]*lud[:U] ≈ lud[:P]*Array(d)
-        @test lud[:L]*lud[:U] ≈ Array(d)[lud[:p],:]
+        @test_throws ErrorException lud.Z
+        @test lud.L*lud.U ≈ lud.P*Array(d)
+        @test lud.L*lud.U ≈ Array(d)[lud.p,:]
         @test AbstractArray(lud) ≈ d
     end
     @testset for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
@@ -178,18 +178,18 @@ dimg  = randn(n)/2
         end
         @testset "Thin LU" begin
             lua   = @inferred lufact(a[:,1:n1])
-            @test lua[:L]*lua[:U] ≈ lua[:P]*a[:,1:n1]
+            @test lua.L*lua.U ≈ lua.P*a[:,1:n1]
         end
         @testset "Fat LU" begin
             lua   = lufact(a[1:n1,:])
-            @test lua[:L]*lua[:U] ≈ lua[:P]*a[1:n1,:]
+            @test lua.L*lua.U ≈ lua.P*a[1:n1,:]
         end
     end
 
     @testset "LU of Symmetric/Hermitian" begin
         for HS in (Hermitian(a'a), Symmetric(a'a))
             luhs = lufact(HS)
-            @test luhs[:L]*luhs[:U] ≈ luhs[:P]*Matrix(HS)
+            @test luhs.L*luhs.U ≈ luhs.P*Matrix(HS)
         end
     end
 end
@@ -210,7 +210,7 @@ end
     b = rand(1:10,n,2)
     @inferred lufact(a)
     lua   = factorize(a)
-    l,u,p = lua[:L], lua[:U], lua[:p]
+    l,u,p = lua.L, lua.U, lua.p
     @test l*u ≈ a[p,:]
     @test l[invperm(p),:]*u ≈ a
     @test a*inv(lua) ≈ Matrix(I, n, n)

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -39,8 +39,8 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
         @testset "QR decomposition of a Number" begin
             α = rand(eltyb)
             aα = fill(α, 1, 1)
-            @test qrfact(α)[:Q] * qrfact(α)[:R] ≈ qrfact(aα)[:Q] * qrfact(aα)[:R]
-            @test abs(qrfact(α)[:Q][1,1]) ≈ one(eltyb)
+            @test qrfact(α).Q * qrfact(α).R ≈ qrfact(aα).Q * qrfact(aα).R
+            @test abs(qrfact(α).Q[1,1]) ≈ one(eltyb)
         end
 
         for (a, b) in ((raw_a, raw_b),
@@ -49,8 +49,8 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
             @testset "QR decomposition (without pivoting)" begin
                 qra   = @inferred qrfact(a)
                 @inferred qr(a)
-                q, r  = qra[:Q], qra[:R]
-                @test_throws KeyError qra[:Z]
+                q, r  = qra.Q, qra.R
+                @test_throws ErrorException qra.Z
                 @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
                 @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)
                 @test q'*Matrix(1.0I, a_1, a_1)' ≈ adjoint(squareQ(q))
@@ -73,8 +73,8 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
             @testset "Thin QR decomposition (without pivoting)" begin
                 qra   = @inferred qrfact(a[:, 1:n1], Val(false))
                 @inferred qr(a[:, 1:n1], Val(false))
-                q,r   = qra[:Q], qra[:R]
-                @test_throws KeyError qra[:Z]
+                q,r   = qra.Q, qra.R
+                @test_throws ErrorException qra.Z
                 @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
                 @test q'*rectangularQ(q) ≈ Matrix(I, a_1, n1)
                 @test q*r ≈ a[:, 1:n1]
@@ -93,16 +93,16 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
                 @inferred qr(a, Val(true))
 
                 qrpa  = factorize(a[1:n1,:])
-                q,r = qrpa[:Q], qrpa[:R]
-                @test_throws KeyError qrpa[:Z]
-                p = qrpa[:p]
+                q,r = qrpa.Q, qrpa.R
+                @test_throws ErrorException qrpa.Z
+                p = qrpa.p
                 @test q'*squareQ(q) ≈ Matrix(I, n1, n1)
                 @test q*squareQ(q)' ≈ Matrix(I, n1, n1)
                 sq = size(q, 2);
                 @test (UpperTriangular(Matrix{eltya}(I, sq, sq))*q')*squareQ(q) ≈ Matrix(I, n1, n1)
                 @test q*r ≈ (isa(qrpa,QRPivoted) ? a[1:n1,p] : a[1:n1,:])
                 @test q*r[:,invperm(p)] ≈ a[1:n1,:]
-                @test q*r*Transpose(qrpa[:P]) ≈ a[1:n1,:]
+                @test q*r*Transpose(qrpa.P) ≈ a[1:n1,:]
                 @test a[1:n1,:]*(qrpa\b[1:n1]) ≈ b[1:n1] atol=5000ε
                 @test Array(qrpa) ≈ a[1:5,:]
                 @test_throws DimensionMismatch q*b[1:n1+1]
@@ -113,9 +113,9 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
             end
             @testset "(Automatic) Thin (pivoted) QR decomposition" begin
                 qrpa  = factorize(a[:,1:n1])
-                q,r = qrpa[:Q], qrpa[:R]
-                @test_throws KeyError qrpa[:Z]
-                p = qrpa[:p]
+                q,r = qrpa.Q, qrpa.R
+                @test_throws ErrorException qrpa.Z
+                p = qrpa.p
                 @test q'*squareQ(q) ≈ Matrix(I, a_1, a_1)
                 @test q*squareQ(q)' ≈ Matrix(I, a_1, a_1)
                 @test q*r ≈ a[:,p]
@@ -134,8 +134,8 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
             @testset "Matmul with QR factorizations" begin
                 a = raw_a
                 qrpa = factorize(a[:,1:n1])
-                q, r = qrpa[:Q], qrpa[:R]
-                @test mul!(adjoint(squareQ(q)), q) ≈ Matrix(I, n, n)
+                q, r = qrpa.Q, qrpa.R
+                @test mul!(squareQ(q)', q) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1),q)
                 @test mul!(squareQ(q), Adjoint(q)) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1), Adjoint(q))
@@ -144,8 +144,8 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
                 @test_throws DimensionMismatch Base.LinAlg.mul!(Adjoint(q), zeros(eltya,n1+1))
 
                 qra = qrfact(a[:,1:n1], Val(false))
-                q, r = qra[:Q], qra[:R]
-                @test mul!(adjoint(squareQ(q)), q) ≈ Matrix(I, n, n)
+                q, r = qra.Q, qra.R
+                @test mul!(squareQ(q)', q) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1),q)
                 @test mul!(squareQ(q), Adjoint(q)) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1),Adjoint(q))
@@ -167,7 +167,7 @@ end
 
 @testset "Issue 7304" begin
     A = [-√.5 -√.5; -√.5 √.5]
-    Q = rectangularQ(qrfact(A)[:Q])
+    Q = rectangularQ(qrfact(A).Q)
     @test vecnorm(A-Q) < eps()
 end
 

--- a/test/linalg/qr.jl
+++ b/test/linalg/qr.jl
@@ -135,7 +135,7 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
                 a = raw_a
                 qrpa = factorize(a[:,1:n1])
                 q, r = qrpa.Q, qrpa.R
-                @test mul!(squareQ(q)', q) ≈ Matrix(I, n, n)
+                @test mul!(adjoint(squareQ(q)), q) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1),q)
                 @test mul!(squareQ(q), Adjoint(q)) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1), Adjoint(q))
@@ -145,7 +145,7 @@ rectangularQ(Q::LinAlg.AbstractQ) = convert(Array, Q)
 
                 qra = qrfact(a[:,1:n1], Val(false))
                 q, r = qra.Q, qra.R
-                @test mul!(squareQ(q)', q) ≈ Matrix(I, n, n)
+                @test mul!(adjoint(squareQ(q)), q) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1),q)
                 @test mul!(squareQ(q), Adjoint(q)) ≈ Matrix(I, n, n)
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n+1),Adjoint(q))

--- a/test/linalg/rowvector.jl
+++ b/test/linalg/rowvector.jl
@@ -187,7 +187,7 @@ end
 end
 
 @testset "QR ambiguity methods" begin
-    qrmat = Base.LinAlg.getq(qrfact(Matrix(1.0I, 3, 3)))
+    qrmat = qrfact(Matrix(1.0I, 3, 3)).Q
     v = [2,3,4]
     rv = rvtranspose(v)
 

--- a/test/linalg/schur.jl
+++ b/test/linalg/schur.jl
@@ -27,12 +27,12 @@ aimg  = randn(n,n)/2
 
         d,v = eig(a)
         f   = schurfact(a)
-        @test f[:vectors]*f[:Schur]*f[:vectors]' ≈ a
-        @test sort(real(f[:values])) ≈ sort(real(d))
-        @test sort(imag(f[:values])) ≈ sort(imag(d))
-        @test istriu(f[:Schur]) || eltype(a)<:Real
+        @test f.vectors*f.Schur*f.vectors' ≈ a
+        @test sort(real(f.values)) ≈ sort(real(d))
+        @test sort(imag(f.values)) ≈ sort(imag(d))
+        @test istriu(f.Schur) || eltype(a)<:Real
         @test convert(Array, f) ≈ a
-        @test_throws KeyError f[:A]
+        @test_throws ErrorException f.A
 
         sch, vecs, vals = schur(UpperTriangular(triu(a)))
         @test vecs*sch*vecs' ≈ triu(a)
@@ -45,9 +45,9 @@ aimg  = randn(n,n)/2
         sch, vecs, vals = schur(Tridiagonal(a + transpose(a)))
         @test vecs*sch*vecs' ≈ Tridiagonal(a + transpose(a))
 
-        tstring = sprint(show,f[:T])
-        zstring = sprint(show,f[:Z])
-        vstring = sprint(show,f[:values])
+        tstring = sprint(show,f.T)
+        zstring = sprint(show,f.Z)
+        vstring = sprint(show,f.values)
         @test sprint(show,f) == "$(typeof(f)) with factors T and Z:\n$tstring\n$(zstring)\nand values:\n$vstring"
         @testset "Reorder Schur" begin
             # use asym for real schur to enforce tridiag structure
@@ -56,13 +56,13 @@ aimg  = randn(n,n)/2
             S = schurfact(ordschura)
             select = bitrand(n)
             O = ordschur(S, select)
-            sum(select) != 0 && @test S[:values][find(select)] ≈ O[:values][1:sum(select)]
-            @test O[:vectors]*O[:Schur]*O[:vectors]' ≈ ordschura
-            @test_throws KeyError f[:A]
+            sum(select) != 0 && @test S.values[find(select)] ≈ O.values[1:sum(select)]
+            @test O.vectors*O.Schur*O.vectors' ≈ ordschura
+            @test_throws ErrorException f.A
             Snew = Base.LinAlg.Schur(S.T, S.Z, S.values)
             SchurNew = ordschur!(copy(Snew), select)
-            @test O[:vectors] ≈ SchurNew[:vectors]
-            @test O[:Schur] ≈ SchurNew[:Schur]
+            @test O.vectors ≈ SchurNew.vectors
+            @test O.Schur ≈ SchurNew.Schur
         end
 
         if isa(a, Array)
@@ -74,37 +74,37 @@ aimg  = randn(n,n)/2
         end
         @testset "Generalized Schur" begin
             f = schurfact(a1_sf, a2_sf)
-            @test f[:Q]*f[:S]*f[:Z]' ≈ a1_sf
-            @test f[:Q]*f[:T]*f[:Z]' ≈ a2_sf
-            @test istriu(f[:S]) || eltype(a)<:Real
-            @test istriu(f[:T]) || eltype(a)<:Real
-            @test_throws KeyError f[:A]
+            @test f.Q*f.S*f.Z' ≈ a1_sf
+            @test f.Q*f.T*f.Z' ≈ a2_sf
+            @test istriu(f.S) || eltype(a)<:Real
+            @test istriu(f.T) || eltype(a)<:Real
+            @test_throws ErrorException f.A
         end
         @testset "Reorder Generalized Schur" begin
             NS = schurfact(a1_sf, a2_sf)
             # Currently just testing with selecting gen eig values < 1
-            select = abs2.(NS[:values]) .< 1
+            select = abs2.(NS.values) .< 1
             m = sum(select)
             S = ordschur(NS, select)
             # Make sure that the new factorization stil factors matrix
-            @test S[:Q]*S[:S]*S[:Z]' ≈ a1_sf
-            @test S[:Q]*S[:T]*S[:Z]' ≈ a2_sf
+            @test S.Q*S.S*S.Z' ≈ a1_sf
+            @test S.Q*S.T*S.Z' ≈ a2_sf
             # Make sure that we have sorted it correctly
-            @test NS[:values][find(select)] ≈ S[:values][1:m]
+            @test NS.values[find(select)] ≈ S.values[1:m]
 
             Snew = Base.LinAlg.GeneralizedSchur(NS.S, NS.T, NS.alpha, NS.beta, NS.Q, NS.Z)
             SchurNew = ordschur!(copy(Snew), select)
-            @test S[:Q] ≈ SchurNew[:Q]
-            @test S[:S] ≈ SchurNew[:S]
-            @test S[:T] ≈ SchurNew[:T]
-            @test S[:Z] ≈ SchurNew[:Z]
-            @test S[:alpha] ≈ SchurNew[:alpha]
-            @test S[:beta] ≈ SchurNew[:beta]
+            @test S.Q ≈ SchurNew.Q
+            @test S.S ≈ SchurNew.S
+            @test S.T ≈ SchurNew.T
+            @test S.Z ≈ SchurNew.Z
+            @test S.alpha ≈ SchurNew.alpha
+            @test S.beta  ≈ SchurNew.beta
             sS,sT,sQ,sZ = schur(a1_sf,a2_sf)
-            @test NS[:Q] ≈ sQ
-            @test NS[:T] ≈ sT
-            @test NS[:S] ≈ sS
-            @test NS[:Z] ≈ sZ
+            @test NS.Q ≈ sQ
+            @test NS.T ≈ sT
+            @test NS.S ≈ sS
+            @test NS.Z ≈ sZ
         end
     end
     @testset "0x0 matrix" for A in (zeros(eltya, 0, 0), view(rand(eltya, 2, 2), 1:0, 1:0))

--- a/test/linalg/special.jl
+++ b/test/linalg/special.jl
@@ -116,11 +116,11 @@ end
         atri = typ(a)
         b = rand(n,n)
         qrb = qrfact(b,Val(true))
-        @test *(atri, Adjoint(qrb[:Q])) ≈ Matrix(atri) * qrb[:Q]'
-        @test mul!(copy(atri), Adjoint(qrb[:Q])) ≈ Matrix(atri) * qrb[:Q]'
+        @test *(atri, Adjoint(qrb.Q)) ≈ Matrix(atri) * qrb.Q'
+        @test mul!(copy(atri), Adjoint(qrb.Q)) ≈ Matrix(atri) * qrb.Q'
         qrb = qrfact(b,Val(false))
-        @test *(atri, Adjoint(qrb[:Q])) ≈ Matrix(atri) * qrb[:Q]'
-        @test mul!(copy(atri), Adjoint(qrb[:Q])) ≈ Matrix(atri) * qrb[:Q]'
+        @test *(atri, Adjoint(qrb.Q)) ≈ Matrix(atri) * qrb.Q'
+        @test mul!(copy(atri), Adjoint(qrb.Q)) ≈ Matrix(atri) * qrb.Q'
     end
 end
 

--- a/test/linalg/svd.jl
+++ b/test/linalg/svd.jl
@@ -53,48 +53,48 @@ a2img  = randn(n,n)/2
 
         usv = svdfact(a)
         @testset "singular value decomposition" begin
-            @test usv[:S] === svdvals(usv)
-            @test usv[:U] * (Diagonal(usv[:S]) * usv[:Vt]) ≈ a
+            @test usv.S === svdvals(usv)
+            @test usv.U * (Diagonal(usv.S) * usv.Vt) ≈ a
             @test convert(Array, usv) ≈ a
-            @test adjoint(usv[:Vt]) ≈ usv[:V]
-            @test_throws KeyError usv[:Z]
+            @test usv.Vt' ≈ usv.V
+            @test_throws ErrorException usv.Z
             b = rand(eltya,n)
             @test usv\b ≈ a\b
 
             if eltya <: BlasFloat
                 svdz = svdfact!(ones(eltya,0,0))
-                @test svdz[:U] ≈ Matrix{eltya}(I, 0, 0)
-                @test svdz[:S] ≈ real(zeros(eltya,0))
-                @test svdz[:Vt] ≈ Matrix{eltya}(I, 0, 0)
+                @test svdz.U ≈ Matrix{eltya}(I, 0, 0)
+                @test svdz.S ≈ real(zeros(eltya,0))
+                @test svdz.Vt ≈ Matrix{eltya}(I, 0, 0)
             end
         end
         @testset "Generalized svd" begin
             a_svd = a[1:n1, :]
             gsvd = svdfact(a,a_svd)
-            @test gsvd[:U]*gsvd[:D1]*gsvd[:R]*gsvd[:Q]' ≈ a
-            @test gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' ≈ a_svd
-            @test adjoint(usv[:Vt]) ≈ usv[:V]
-            @test_throws KeyError usv[:Z]
-            @test_throws KeyError gsvd[:Z]
-            @test gsvd[:vals] ≈ svdvals(a,a_svd)
+            @test gsvd.U*gsvd.D1*gsvd.R*gsvd.Q' ≈ a
+            @test gsvd.V*gsvd.D2*gsvd.R*gsvd.Q' ≈ a_svd
+            @test usv.Vt' ≈ usv.V
+            @test_throws ErrorException usv.Z
+            @test_throws ErrorException gsvd.Z
+            @test gsvd.vals ≈ svdvals(a,a_svd)
             α = eltya == Int ? -1 : rand(eltya)
             β = svdfact(α)
-            @test β[:S] == [abs(α)]
+            @test β.S == [abs(α)]
             @test svdvals(α) == abs(α)
             u,v,q,d1,d2,r0 = svd(a,a_svd)
-            @test u ≈ gsvd[:U]
-            @test v ≈ gsvd[:V]
-            @test d1 ≈ gsvd[:D1]
-            @test d2 ≈ gsvd[:D2]
-            @test q ≈ gsvd[:Q]
-            @test gsvd[:a].^2 + gsvd[:b].^2 ≈ ones(eltya,length(gsvd[:a]))
+            @test u ≈ gsvd.U
+            @test v ≈ gsvd.V
+            @test d1 ≈ gsvd.D1
+            @test d2 ≈ gsvd.D2
+            @test q ≈ gsvd.Q
+            @test gsvd.a.^2 + gsvd.b.^2 ≈ ones(eltya,length(gsvd.a))
 
             #testing the other layout for D1 & D2
             b = rand(eltya,n,2*n)
             c = rand(eltya,n,2*n)
             gsvd = svdfact(b,c)
-            @test gsvd[:U]*gsvd[:D1]*gsvd[:R]*gsvd[:Q]' ≈ b
-            @test gsvd[:V]*gsvd[:D2]*gsvd[:R]*gsvd[:Q]' ≈ c
+            @test gsvd.U*gsvd.D1*gsvd.R*gsvd.Q' ≈ b
+            @test gsvd.V*gsvd.D2*gsvd.R*gsvd.Q' ≈ c
         end
     end
     if eltya <: Base.LinAlg.BlasReal

--- a/test/linalg/symmetric.jl
+++ b/test/linalg/symmetric.jl
@@ -220,9 +220,9 @@ end
                         @test asym*v[:,1] ≈ d[1]*v[:,1]
                         @test v*Diagonal(d)*Transpose(v) ≈ asym
                         @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
-                        @test abs.(eigfact(Symmetric(asym), 1:2)[:vectors]'v[:,1:2]) ≈ Matrix(I, 2, 2)
+                        @test abs.(eigfact(Symmetric(asym), 1:2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                         eig(Symmetric(asym), 1:2) # same result, but checks that method works
-                        @test abs.(eigfact(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2)[:vectors]'v[:,1:2]) ≈ Matrix(I, 2, 2)
+                        @test abs.(eigfact(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                         eig(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2) # same result, but checks that method works
                         @test eigvals(Symmetric(asym), 1:2) ≈ d[1:2]
                         @test eigvals(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2) ≈ d[1:2]
@@ -235,9 +235,9 @@ end
                     @test aherm*v[:,1] ≈ d[1]*v[:,1]
                     @test v*Diagonal(d)*v' ≈ aherm
                     @test isequal(eigvals(aherm[1]), eigvals(aherm[1:1,1:1]))
-                    @test abs.(eigfact(Hermitian(aherm), 1:2)[:vectors]'v[:,1:2]) ≈ Matrix(I, 2, 2)
+                    @test abs.(eigfact(Hermitian(aherm), 1:2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                     eig(Hermitian(aherm), 1:2) # same result, but checks that method works
-                    @test abs.(eigfact(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2)[:vectors]'v[:,1:2]) ≈ Matrix(I, 2, 2)
+                    @test abs.(eigfact(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                     eig(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2) # same result, but checks that method works
                     @test eigvals(Hermitian(aherm), 1:2) ≈ d[1:2]
                     @test eigvals(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2) ≈ d[1:2]

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -421,7 +421,7 @@ for eltya in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
         debug && println("\ntype of A: ", eltya, " type of b: ", eltyb, "\n")
 
         debug && println("Solve upper triangular system")
-        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+        Atri = UpperTriangular(lufact(A).U) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? Matrix(Atri)*ones(n, 2) : Matrix(Atri)*ones(n, 2))
         x = Matrix(Atri) \ b
 
@@ -449,7 +449,7 @@ for eltya in (Float32, Float64, ComplexF32, ComplexF64, BigFloat, Int)
         end
 
         debug && println("Solve lower triangular system")
-        Atri = UpperTriangular(lufact(A)[:U]) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
+        Atri = UpperTriangular(lufact(A).U) |> t -> eltya <: Complex && eltyb <: Real ? real(t) : t # Here the triangular matrix can't be too badly conditioned
         b = convert(Matrix{eltyb}, eltya <: Complex ? Matrix(Atri)*ones(n, 2) : Matrix(Atri)*ones(n, 2))
         x = Matrix(Atri)\b
 

--- a/test/linalg/tridiag.jl
+++ b/test/linalg/tridiag.jl
@@ -248,14 +248,14 @@ end
                     @testset "stegr! call with index range" begin
                         F = eigfact(SymTridiagonal(b, a),1:2)
                         fF = eigfact(Symmetric(Array(SymTridiagonal(b, a))),1:2)
-                        Test.test_approx_eq_modphase(F[:vectors], fF[:vectors])
-                        @test F[:values] ≈ fF[:values]
+                        Test.test_approx_eq_modphase(F.vectors, fF.vectors)
+                        @test F.values ≈ fF.values
                     end
                     @testset "stegr! call with value range" begin
                         F = eigfact(SymTridiagonal(b, a),0.0,1.0)
                         fF = eigfact(Symmetric(Array(SymTridiagonal(b, a))),0.0,1.0)
-                        Test.test_approx_eq_modphase(F[:vectors], fF[:vectors])
-                        @test F[:values] ≈ fF[:values]
+                        Test.test_approx_eq_modphase(F.vectors, fF.vectors)
+                        @test F.values ≈ fF.values
                     end
                     @testset "eigenvalues/eigenvectors of symmetric tridiagonal" begin
                         if elty === Float32 || elty === Float64


### PR DESCRIPTION
Now that we have dot overloading, it is possible to use that instead of the special `getindex` methods for `Factorization`s. Furthermore, with a little care in the `getproperty` methods, it is possible to make the constant propagation work such that `qr` and `lu` are now inferred even though they extract the factors from the `Factorization`.
```julia
julia> A = randn(3,3);

julia> F = lufact(A);

julia> F[:L]
3×3 Array{Float64,2}:
  1.0        0.0       0.0
 -0.368965   1.0       0.0
  0.414762  -0.531993  1.0
```
becomes
```julia
julia> F.L
3×3 Array{Float64,2}:
  1.0        0.0       0.0
 -0.368965   1.0       0.0
  0.414762  -0.531993  1.0
```

Fixes JuliaLang/LinearAlgebra.jl#493