### PR TITLE
Give CircleCI steps names to improve readability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,53 +15,65 @@ jobs:
           JULIA_CPU_CORES: 4
           JULIA_TEST_MAXRSS_MB: 800
     steps: &steps
-      - run: | # install build dependencies
-          sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
-            time ccache bar &&
-          for prog in gcc g++ gfortran; do
-            sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
-          done
+      - run:
+          name: Install build dependencies
+          command: |
+            sudo apt-get install -y g++-4.8-multilib gfortran-4.8-multilib \
+              time ccache bar
+            for prog in gcc g++ gfortran; do
+              sudo ln -s /usr/bin/$prog-4.8 /usr/local/bin/$prog;
+            done
       - checkout # circle ci code checkout step
 # (FIXME: need to unset url."ssh://git@github.com".insteadOf or libgit2 tests fail)
-      - run: | # checkout merge commit, set versioning info and Make.user variables
-          git config --global --unset url."ssh://git@github.com".insteadOf &&
-          if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-            git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge &&
-            git checkout -qf FETCH_HEAD;
-          fi &&
-          make -C base version_git.jl.phony &&
-          echo "override ARCH = $ARCH" | tee -a Make.user &&
-          for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
-            echo "override $var = 1" | tee -a Make.user;
-          done &&
-          echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
+      - run:
+          name: Checkout merge commit, set versioning info and Make.user variables
+          command: |
+            git config --global --unset url."ssh://git@github.com".insteadOf
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+              git fetch origin +refs/pull/$(basename $CIRCLE_PULL_REQUEST)/merge
+              git checkout -qf FETCH_HEAD;
+            fi
+            make -C base version_git.jl.phony
+            echo "override ARCH = $ARCH" | tee -a Make.user
+            for var in FORCE_ASSERTIONS LLVM_ASSERTIONS USECCACHE NO_GIT; do
+              echo "override $var = 1" | tee -a Make.user;
+            done
+            echo "$ARCH $HOME $(date +%Y%W)" | tee /tmp/weeknumber
       - restore_cache: # silly to take a checksum of the tag file here instead of
           keys: # its contents but this is the only thing that works on circle
             - ccache-{{ arch }}-{{ checksum "/tmp/weeknumber" }}
-      - run: | # compile julia deps
-          contrib/download_cmake.sh &&
-          make -j3 -C deps || make
-      - run: | # build julia, output ccache stats when done
-          make -j3 all &&
-          make prefix=/tmp/julia install &&
-          ccache -s &&
-          make build-stats
-      - run: | # move source tree out of the way, run tests from install tree
-          cd .. &&
-          mv project julia-src &&
-          /tmp/julia/bin/julia -e 'versioninfo()' &&
-          /tmp/julia/bin/julia --sysimage-native-code=no -e 'true' &&
-          /tmp/julia/bin/julia-debug --sysimage-native-code=no -e 'true' &&
-          pushd /tmp/julia/share/julia/test &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30 &&
-          /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg &&
-          popd &&
-          mkdir /tmp/embedding-test &&
-          make check -C /tmp/julia/share/doc/julia/examples/embedding \
-            JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
-            "$(cd julia-src && make print-CC)" &&
-          mv julia-src project
-#      - run: cd project && make -C doc deploy
+      - run:
+          name: Compile Julia dependencies
+          command: |
+            contrib/download_cmake.sh
+            make -j3 -C deps || make
+      - run:
+          name: Build Julia, output ccache stats when done
+          command: |
+            make -j3 all
+            make prefix=/tmp/julia install
+            ccache -s
+            make build-stats
+      - run:
+          name: Move source tree out of the way, run tests from install tree
+          command: |
+            cd ..
+            mv project julia-src
+            /tmp/julia/bin/julia -e 'versioninfo()'
+            /tmp/julia/bin/julia --sysimage-native-code=no -e 'true'
+            /tmp/julia/bin/julia-debug --sysimage-native-code=no -e 'true'
+            pushd /tmp/julia/share/julia/test
+            /tmp/julia/bin/julia --check-bounds=yes runtests.jl all --skip socket | bar -i 30
+            /tmp/julia/bin/julia --check-bounds=yes runtests.jl libgit2-online download pkg
+            popd
+            mkdir /tmp/embedding-test
+            make check -C /tmp/julia/share/doc/julia/examples/embedding \
+              JULIA=/tmp/julia/bin/julia BIN=/tmp/embedding-test \
+              "$(cd julia-src && make print-CC)"
+            mv julia-src project
+#     - run:
+#         name: Deploy documentation
+#         command: cd project && make -C doc deploy
       - run:
           command: sudo dmesg
           when: on_fail


### PR DESCRIPTION
Also remove unnecessary `&&`s to conditionally run the next piece of the step; each Circle step runs in `/bin/bash -eo pipefail`. This further improves readability.

Cherry picked from #24408.

Note: FreeBSD skipped, AppVeyor attempted to skip but canceled instead, Travis canceled.