### PR TITLE
remove reload

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -3388,7 +3388,8 @@ end
 @deprecate indices(a, d) axes(a, d)
 
 # PR #25046
-export workspace
+export reload, workspace
+reload(name::AbstractString) = error("reload($(repr(name))) is discontinued, check out Revise.jl for an alternative workflow")
 workspace() = error("workspace() is discontinued, check out Revise.jl for an alternative workflow")
 
 # Issue #12902

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -953,7 +953,6 @@ export
     evalfile,
     include_string,
     include_dependency,
-    reload,
 
 # RTS internals
     finalizer,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -288,23 +288,6 @@ function __precompile__(isprecompilable::Bool=true)
     end
 end
 
-"""
-    reload(name::AbstractString)
-
-Force reloading of a package, even if it has been loaded before. This is intended for use
-during package development as code is modified.
-"""
-function reload(name::AbstractString)
-    if contains(name, Filesystem.path_separator) || contains(name, ".")
-        # for reload("path/file.jl") just ask for include instead
-        error("use `include` instead of `reload` to load source files")
-    else
-        # reload("Package") is ok
-        unreference_module(Symbol(name))
-        require(Symbol(name))
-    end
-end
-
 # require always works in Main scope and loads files from node 1
 const toplevel_load = Ref(true)
 

--- a/doc/src/manual/workflow-tips.md
+++ b/doc/src/manual/workflow-tips.md
@@ -29,11 +29,7 @@ line. A common pattern includes the following elements:
     import Tmp
     ```
 
-    and includes tests for the contents of `Tmp`. The value of using `import` versus `using` is that
-    you can call `reload("Tmp")` instead of having to restart the REPL when your definitions change.
-    Of course, the cost is the need to prepend `Tmp.` to uses of names defined in your module. (You
-    can lower that cost by keeping your module name short.)
-
+    and includes tests for the contents of `Tmp`.
     Alternatively, you can wrap the contents of your test file in a module, as
 
     ```
@@ -49,12 +45,6 @@ line. A common pattern includes the following elements:
     `Tmp.` everywhere. The disadvantage is that code can no longer be selectively copied to the REPL
     without some tweaking.
   * **Lather. Rinse. Repeat.** Explore ideas at the `julia` command prompt. Save good ideas in `tst.jl`.
-    Occasionally restart the REPL, issuing
-
-    ```julia
-    reload("Tmp")
-    include("tst.jl")
-    ```
 
 ### Simplify initialization
 

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -33,7 +33,6 @@ Base.less(::Any)
 Base.@less
 Base.clipboard(::Any)
 Base.clipboard()
-Base.reload
 Base.require
 Base.compilecache
 Base.__precompile__

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -321,25 +321,6 @@ try
     fb_uuid1 = Base.module_uuid(FooBar1)
     @test fb_uuid != fb_uuid1
 
-    reload("FooBar")
-    @test fb_uuid != Base.module_uuid(root_module(:FooBar))
-    @test fb_uuid1 == Base.module_uuid(FooBar1)
-    fb_uuid = Base.module_uuid(root_module(:FooBar))
-    @test isfile(joinpath(dir2, "FooBar.ji"))
-    @test Base.stale_cachefile(FooBar_file, joinpath(dir, "FooBar.ji")) === true
-    @test Base.stale_cachefile(FooBar1_file, joinpath(dir2, "FooBar1.ji")) isa Vector
-    @test Base.stale_cachefile(FooBar_file, joinpath(dir2, "FooBar.ji")) isa Vector
-
-    reload("FooBar1")
-    @test fb_uuid == Base.module_uuid(root_module(:FooBar))
-    @test fb_uuid1 != Base.module_uuid(root_module(:FooBar1))
-
-    @test isfile(joinpath(dir2, "FooBar.ji"))
-    @test isfile(joinpath(dir2, "FooBar1.ji"))
-    @test Base.stale_cachefile(FooBar_file, joinpath(dir, "FooBar.ji")) === true
-    @test Base.stale_cachefile(FooBar_file, joinpath(dir2, "FooBar.ji")) isa Vector
-    @test Base.stale_cachefile(FooBar1_file, joinpath(dir2, "FooBar1.ji")) isa Vector
-
     # test checksum
     open(joinpath(dir2, "FooBar1.ji"), "a") do f
         write(f, 0x076cac96) # append 4 random bytes
@@ -545,21 +526,6 @@ let dir = mktempdir()
         splice!(Base.LOAD_CACHE_PATH, 1)
         splice!(LOAD_PATH, 1)
         rm(dir, recursive=true)
-    end
-end
-
-let module_name = string("a",randstring())
-    mktempdir() do path
-        unshift!(LOAD_PATH, path)
-        file_name = joinpath(path, string(module_name, ".jl"))
-        sleep(2)
-        touch(file_name)
-        code = """module $(module_name)\nend\n"""
-        write(file_name, code)
-        reload(module_name)
-        @test isa(root_module(Symbol(module_name)), Module)
-        @test shift!(LOAD_PATH) == path
-        rm(file_name)
     end
 end
 


### PR DESCRIPTION
Send `reload` the way of the dodo – and `workspace`. Now that Revise is the way to do this sort of thing, perhaps we should get rid of `reload` as well. Both `require` and `reload` are soon going to need to pass in a context module in order to determine what the meaning of the `name` argument means, so this is going to have to change API in any case. See also #25046, #25166.