### PR TITLE
fix spawn to work with AbstractPipe

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -458,6 +458,9 @@ function setup_stdio(stdio::Pipe, readable::Bool)
     return (io, false)
 end
 
+setup_stdio(stdio::AbstractPipe, readable::Bool) =
+    setup_stdio(readable ? pipe_reader(stdio) : pipe_writer(stdio), readable)
+
 function setup_stdio(stdio::IOStream, readable::Bool)
     io = Filesystem.File(RawFD(fd(stdio)))
     return (io, false)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -223,6 +223,13 @@ end
 # issue #6310
 @test read(pipeline(`$echocmd "2+2"`, `$exename --startup-file=no`), String) == "4\n"
 
+# setup_stdio for AbstractPipe
+let out = Pipe(), proc = spawn(pipeline(`$echocmd "Hello World"`, stdout=IOContext(out,STDOUT)))
+    close(out.in)
+    @test read(out, String) == "Hello World\n"
+    @test success(proc)
+end
+
 # issue #5904
 @test run(pipeline(ignorestatus(falsecmd), truecmd)) === nothing
 
@@ -520,4 +527,3 @@ let p = spawn(`$sleepcmd 100`)
     # Should not throw if already dead
     kill(p)
 end
-


### PR DESCRIPTION
In JuliaLang/IJulia.jl#604, I noticed that `spawn` does not work for `AbstractPipe` (e.g. `IOContext`), due to a missing method for `Base.setup_stdio`, fixed here.