### PR TITLE
Strip the CartesianIndex wrapper from the ind2sub deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1138,13 +1138,13 @@ workspace() = error("`workspace()` is discontinued, consider Revise.jl for an al
 @deprecate_moved unsafe_get "Nullables"
 
 # sub2ind and ind2sub deprecation (PR #24715)
-@deprecate ind2sub(A::AbstractArray, ind) CartesianIndices(A)[ind]
-@deprecate ind2sub(::Tuple{}, ind::Integer) CartesianIndices()[ind]
-@deprecate ind2sub(dims::Tuple{Vararg{Integer,N}} where N, ind::Integer) CartesianIndices(dims)[ind]
-@deprecate ind2sub(inds::Tuple{Base.OneTo}, ind::Integer) CartesianIndices(inds)[ind]
-@deprecate ind2sub(inds::Tuple{AbstractUnitRange}, ind::Integer) CartesianIndices(inds)[ind]
-@deprecate ind2sub(inds::Tuple{Vararg{AbstractUnitRange,N}} where N, ind::Integer) CartesianIndices(inds)[ind]
-@deprecate ind2sub(inds::Union{DimsInteger{N},Indices{N}}  where N, ind::AbstractVector{<:Integer}) CartesianIndices(inds)[ind]
+@deprecate ind2sub(A::AbstractArray, ind) Tuple(CartesianIndices(A)[ind])
+@deprecate ind2sub(::Tuple{}, ind::Integer) Tuple(CartesianIndices()[ind])
+@deprecate ind2sub(dims::Tuple{Vararg{Integer,N}} where N, ind::Integer) Tuple(CartesianIndices(dims)[ind])
+@deprecate ind2sub(inds::Tuple{Base.OneTo}, ind::Integer) Tuple(CartesianIndices(inds)[ind])
+@deprecate ind2sub(inds::Tuple{AbstractUnitRange}, ind::Integer) Tuple(CartesianIndices(inds)[ind])
+@deprecate ind2sub(inds::Tuple{Vararg{AbstractUnitRange,N}} where N, ind::Integer) Tuple(CartesianIndices(inds)[ind])
+@deprecate ind2sub(inds::Union{DimsInteger{N},Indices{N}}  where N, ind::AbstractVector{<:Integer}) Tuple(CartesianIndices(inds)[ind])
 
 @deprecate sub2ind(A::AbstractArray, I...) LinearIndices(A)[I...]
 @deprecate sub2ind(dims::Tuple{}) LinearIndices(dims)[]

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1138,13 +1138,35 @@ workspace() = error("`workspace()` is discontinued, consider Revise.jl for an al
 @deprecate_moved unsafe_get "Nullables"
 
 # sub2ind and ind2sub deprecation (PR #24715)
-@deprecate ind2sub(A::AbstractArray, ind) Tuple(CartesianIndices(A)[ind])
-@deprecate ind2sub(::Tuple{}, ind::Integer) Tuple(CartesianIndices()[ind])
-@deprecate ind2sub(dims::Tuple{Vararg{Integer,N}} where N, ind::Integer) Tuple(CartesianIndices(dims)[ind])
-@deprecate ind2sub(inds::Tuple{Base.OneTo}, ind::Integer) Tuple(CartesianIndices(inds)[ind])
-@deprecate ind2sub(inds::Tuple{AbstractUnitRange}, ind::Integer) Tuple(CartesianIndices(inds)[ind])
-@deprecate ind2sub(inds::Tuple{Vararg{AbstractUnitRange,N}} where N, ind::Integer) Tuple(CartesianIndices(inds)[ind])
-@deprecate ind2sub(inds::Union{DimsInteger{N},Indices{N}}  where N, ind::AbstractVector{<:Integer}) Tuple(CartesianIndices(inds)[ind])
+_ind2sub_depwarn(x, y) = "`ind2sub($x, $y)` is deprecated, use `Tuple(CartesianIndices($x)[$y])` for a direct replacement. In many cases, the conversion to `Tuple` is not necessary."
+function ind2sub(A::AbstractArray, ind)
+    depwarn(_ind2sub_depwarn("A", "ind"), :ind2sub)
+    Tuple(CartesianIndices(A)[ind])
+end
+function ind2sub(::Tuple{}, ind::Integer)
+    depwarn(_ind2sub_depwarn("()", "ind"), :ind2sub)
+    Tuple(CartesianIndices(())[ind])
+end
+function ind2sub(dims::Tuple{Vararg{Integer,N}} where N, ind::Integer)
+    depwarn(_ind2sub_depwarn("dims", "ind"), :ind2sub)
+    Tuple(CartesianIndices(dims)[ind])
+end
+function ind2sub(inds::Tuple{Base.OneTo}, ind::Integer)
+    depwarn(_ind2sub_depwarn("inds", "ind"), :ind2sub)
+    Tuple(CartesianIndices(inds)[ind])
+end
+function ind2sub(inds::Tuple{AbstractUnitRange}, ind::Integer)
+    depwarn(_ind2sub_depwarn("inds", "ind"), :ind2sub)
+    Tuple(CartesianIndices(inds)[ind])
+end
+function ind2sub(inds::Tuple{Vararg{AbstractUnitRange,N}} where N, ind::Integer)
+    depwarn(_ind2sub_depwarn("inds", "ind"), :ind2sub)
+    Tuple(CartesianIndices(inds)[ind])
+end
+function ind2sub(inds::Union{DimsInteger{N},Indices{N}}  where N, ind::AbstractVector{<:Integer})
+    depwarn(_ind2sub_depwarn("inds", "ind"), :ind2sub)
+    Tuple(CartesianIndices(inds)[ind])
+end
 
 @deprecate sub2ind(A::AbstractArray, I...) LinearIndices(A)[I...]
 @deprecate sub2ind(dims::Tuple{}) LinearIndices(dims)[]


### PR DESCRIPTION
In the warning message it might be better to encourage people to use the `CartesianIndex` directly, but the current version of the deprecation will break code (ref https://github.com/JuliaCI/BaseBenchmarks.jl/pull/155#issuecomment-352887693). Is it worth going through the whole custom-depwarn function business, or is this sufficient?

