### PR TITLE
fix method overwrites during build

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -208,8 +208,6 @@ macro _noinline_meta()
     Expr(:meta, :noinline)
 end
 
-function postfixapostrophize end
-
 struct BoundsError <: Exception
     a::Any
     i::Any

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -739,8 +739,8 @@ fldmod1(x::T, y::T) where {T<:Real} = (fld1(x,y), mod1(x,y))
 # efficient version for integers
 fldmod1(x::T, y::T) where {T<:Integer} = (fld1(x,y), mod1(x,y))
 
-# postfix apostophre
-Core.postfixapostrophize(x) = Adjoint(x)
+# postfix apostrophe
+apostrophe(x) = Adjoint(x)
 
 """
     adjoint(A)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1089,13 +1089,8 @@ end
 Make method `m` uncallable and force recompilation of any methods that use(d) it.
 """
 function delete_method(m::Method)
-    ccall(:jl_method_table_disable, Cvoid, (Any, Any), MethodTable(m), m)
-end
-
-function MethodTable(m::Method)
-    ft = ccall(:jl_first_argument_datatype, Any, (Any,), m.sig)
-    ft == C_NULL && error("Method ", m, " does not correspond to a function type")
-    (ft::DataType).name.mt
+    ft = ccall(:jl_first_argument_datatype, Any, (Any,), m.sig) # should not be NULL
+    ccall(:jl_method_table_disable, Cvoid, (Any, Any), (ft::DataType).name.mt, m)
 end
 
 """

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2378,7 +2378,7 @@
                      ,.(apply append rows)))
             `(call (top typed_vcat) ,t ,@a)))))
 
-   '|'|  (lambda (e) (expand-forms `(call (core postfixapostrophize) ,(cadr e))))
+   '|'|  (lambda (e) (expand-forms `(call (top apostrophe) ,(cadr e))))
    '|.'| (lambda (e) (begin (deprecation-message (string "The syntax `.'` for transposition is deprecated, "
                                              "and the special lowering of `.'` in multiplication "
                                              "(`*`), left-division (`\\`), and right-division (`/`) "


### PR DESCRIPTION
Some recent changes added method overwrite warnings to the build, which is bad. This fixes them.