### PR TITLE
guard against chance singularity in a sparse linalg test

### DIFF
--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1672,8 +1672,8 @@ end
 
 @testset "sparse matrix cond" begin
     local A = sparse(reshape([1.0], 1, 1))
-    Ac = sprandn(20, 20,.5) + im* sprandn(20, 20,.5)
-    Ar = sprandn(20, 20,.5)
+    Ac = sprandn(20, 20,.5) + im*sprandn(20, 20,.5)
+    Ar = sprandn(20, 20,.5) + eps()*I
     @test cond(A, 1) == 1.0
     # For a discussion of the tolerance, see #14778
     if Base.USE_GPL_LIBS


### PR DESCRIPTION
Modify a sparse linalg test to guard against chance singularity causing test failure. Failure identified by @vtjnash in https://ci.appveyor.com/project/JuliaLang/julia/build/1.0.22640/job/prc1vdmu7xdix9r3. Best!