### PR TITLE
Introduce an `AbstractDateTime` type

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -94,13 +94,15 @@ machine instant. `Time`, `DateTime` and `Date` are subtypes of `TimeType`.
 """
 abstract type TimeType <: AbstractTime end
 
+abstract type AbstractDateTime <: TimeType end
+
 """
     DateTime
 
 `DateTime` wraps a `UTInstant{Millisecond}` and interprets it according to the proleptic
 Gregorian calendar.
 """
-struct DateTime <: TimeType
+struct DateTime <: AbstractDateTime
     instant::UTInstant{Millisecond}
     DateTime(instant::UTInstant{Millisecond}) = new(instant)
 end


### PR DESCRIPTION
By having both `DateTime` and `ZonedDateTime` from TimeZones.jl subtype an
`AbstractDateTime` we should be able to write more general code without needing to use a
`Union{DateTime, ZonedDateTime}` or operate on the `TimeType` (which is too general).