### PR TITLE
fix color attribute in TTY and TTYTerminal to be more IOContext-like

### DIFF
--- a/base/repl/Terminals.jl
+++ b/base/repl/Terminals.jl
@@ -168,7 +168,10 @@ else
 end
 
 # use cached value of have_color
-Base.get(::TTYTerminal, k::Symbol, default) = k === :color ? Base.have_color : default
+Base.in(key_value::Pair, t::TTYTerminal) = in(key_value, pipe_writer(t))
+Base.haskey(t::TTYTerminal, key) = haskey(pipe_writer(t), key)
+Base.getindex(t::TTYTerminal, key) = getindex(pipe_writer(t), key)
+Base.get(t::TTYTerminal, key, default) = get(pipe_writer(t), key, default)
 
 Base.peek(t::TTYTerminal) = Base.peek(t.in_stream)
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -403,7 +403,10 @@ function displaysize(io::TTY)
     return h, w
 end
 
-get(::TTY, k::Symbol, default) = k === :color ? have_color : default
+in(key_value::Pair{Symbol,Bool}, ::TTY) = key_value.first === :color && key_value.second === have_color
+haskey(::TTY, key::Symbol) = key === :color
+getindex(::TTY, key::Symbol) = key === :color ? have_color : throw(KeyError(key))
+get(::TTY, key::Symbol, default) = key === :color ? have_color : default
 
 ### Libuv callbacks ###
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -611,6 +611,16 @@ let buf_color = IOBuffer()
     @test expected_str == String(take!(buf_color))
 end
 
+if STDOUT isa Base.TTY
+    @test haskey(STDOUT, :color) == true
+    @test haskey(STDOUT, :bar) == false
+    @test (:color=>Base.have_color) in STDOUT
+    @test (:color=>!Base.have_color) ∉ STDOUT
+    @test STDOUT[:color] == get(STDOUT, :color, nothing) == Base.have_color
+    @test get(STDOUT, :bar, nothing) === nothing
+    @test_throws KeyError STDOUT[:bar]
+end
+
 let
     global c_18711 = 0
     buf = IOContext(IOBuffer(), :hascontext => true)

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -725,10 +725,17 @@ let ends_with_semicolon = Base.REPL.ends_with_semicolon
 end
 
 # PR #20794, TTYTerminal with other kinds of streams
-let term = Base.Terminals.TTYTerminal("dumb",IOBuffer("1+2\n"),IOBuffer(),IOBuffer())
+let term = Base.Terminals.TTYTerminal("dumb",IOBuffer("1+2\n"),IOContext(IOBuffer(),:foo=>true),IOBuffer())
     r = Base.REPL.BasicREPL(term)
     REPL.run_repl(r)
-    @test String(take!(term.out_stream)) == "julia> 3\n\njulia> \n"
+    @test String(take!(term.out_stream.io)) == "julia> 3\n\njulia> \n"
+    @test haskey(term, :foo) == true
+    @test haskey(term, :bar) == false
+    @test (:foo=>true) in term
+    @test (:foo=>false) ∉ term
+    @test term[:foo] == get(term, :foo, nothing) == true
+    @test get(term, :bar, nothing) === nothing
+    @test_throws KeyError term[:bar]
 end
 
 


### PR DESCRIPTION
This PR is a small bugfix to #25067, which added a `:color` attribute to `TTY` (and `TTYTerminal`) via a `get` method that fetches `Base.have_color`.  In order to act like `IOContext`, they also need `getindex`, `in`, and `haskey`, which are added in this PR with tests.