### PR TITLE
Fix missing ::Char annotation on `category_abbrev`

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -305,7 +305,7 @@ function category_code(c::Char)
 end
 
 # more human-readable representations of the category code
-function category_abbrev(c)
+function category_abbrev(c::Char)
     ismalformed(c) && return "Ma"
     c ≤ '\U10ffff' || return "In"
     unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), c))


### PR DESCRIPTION
Just something I noticed looking over this code, seems good to do to ensure
that we can change the implementation of this function in 1.x if we want to introduce
AbstractChar.