### PR TITLE
fix vec and diag for RowVector

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -37,6 +37,7 @@ See also [`reshape`](@ref).
 """
 vec(a::AbstractArray) = reshape(a,_length(a))
 vec(a::AbstractVector) = a
+vec(a::RowVector) = a.vec
 
 _sub(::Tuple{}, ::Tuple{}) = ()
 _sub(t::Tuple, ::Tuple{}) = t

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -306,7 +306,7 @@ julia> diag(A,1)
  6
 ```
 """
-diag(A::AbstractMatrix, k::Integer=0) = A[diagind(A,k)]
+diag(A::AbstractMatrix, k::Integer=0) = vec(A[diagind(A,k)])
 
 """
     diagm(kv::Pair{<:Integer,<:AbstractVector}...)


### PR DESCRIPTION
I propose to fix two issues with `RowVector`.

1. `vec` on `RowVector` can be made more efficient by defining a specialized method
2. currently `diag` on `RowVector` returns `RowVector` and it should return a `Vector`; in this PR this is fixed

The reason for fixing `diag` is the following situation:
```
julia> [2 2; 2 2] / [2]
ERROR: StackOverflowError:
```
whereas it should be `[1.0 1.0; 1.0 1.0]` as it is the result of `reshape([2], 1, 1) \ [2 2; 2 2]`.

Additionally (I have not touched this because it is probably intentional - if not I propose to fix it):
```
@propagate_inbounds getindex(rowvec::RowVector, i) = transpose(rowvec.vec[i])
```
which means that indexing into `RowVector` by a vector produces `RowVector`. This is inconsistent with the general behavior that indexing into e.g. `Matrix` by a vector produces `Vector`, e.g.
```
reshape([1,2], 1, 2)[[1]]
```
is a `Vector`, but
```
[1,2]'[[1]]
```
is a `RowVector`.