### PR TITLE
optimize and fix map/broadcast over Adjoint/Transpose vectors, take 2

### DIFF
--- a/test/linalg/adjtrans.jl
+++ b/test/linalg/adjtrans.jl
@@ -338,6 +338,16 @@ end
     # trinary broadcast over wrapped vectors with concrete scalar eltype and numbers
     @test broadcast(+, Adjoint(vec), 1, Adjoint(vec))::Adjoint{Complex{Int},Vector{Complex{Int}}} == avec + avec .+ 1
     @test broadcast(+, Transpose(vec), 1, Transpose(vec))::Transpose{Complex{Int},Vector{Complex{Int}}} == tvec + tvec .+ 1
+    @test broadcast(+, Adjoint(vec), 1im, Adjoint(vec))::Adjoint{Complex{Int},Vector{Complex{Int}}} == avec + avec .+ 1im
+    @test broadcast(+, Transpose(vec), 1im, Transpose(vec))::Transpose{Complex{Int},Vector{Complex{Int}}} == tvec + tvec .+ 1im
+    # ascertain inference friendliness, ref. https://github.com/JuliaLang/julia/pull/25083#issuecomment-353031641
+    sparsevec = SparseVector([1.0, 2.0, 3.0])
+    @test map(-, Adjoint(sparsevec), Adjoint(sparsevec)) isa Adjoint{Float64,SparseVector{Float64,Int}}
+    @test map(-, Transpose(sparsevec), Transpose(sparsevec)) isa Transpose{Float64,SparseVector{Float64,Int}}
+    @test broadcast(-, Adjoint(sparsevec), Adjoint(sparsevec)) isa Adjoint{Float64,SparseVector{Float64,Int}}
+    @test broadcast(-, Transpose(sparsevec), Transpose(sparsevec)) isa Transpose{Float64,SparseVector{Float64,Int}}
+    @test broadcast(+, Adjoint(sparsevec), 1.0, Adjoint(sparsevec)) isa Adjoint{Float64,SparseVector{Float64,Int}}
+    @test broadcast(+, Transpose(sparsevec), 1.0, Transpose(sparsevec)) isa Transpose{Float64,SparseVector{Float64,Int}}
 end
 
 @testset "Adjoint/Transpose-wrapped vector multiplication" begin


### PR DESCRIPTION
Second take on JuliaLang/julia#25219: This pull request implements the optimization @timholy suggested in https://github.com/JuliaLang/julia/pull/25083#discussion_r157302172 (hence closes JuliaLang/LinearAlgebra.jl#492) and fixes the inference issue @martinholters caught in https://github.com/JuliaLang/julia/pull/25083#issuecomment-353031641. This version addresses the linalg/dense test failures discovered in JuliaLang/julia#25219 as well, and adds a couple direct tests for that issue to linalg/adjtrans. Thanks and best!