### PR TITLE
safer vector<->string conversions, fixing #24388

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1555,8 +1555,19 @@ export hex2num
 @deprecate ctranspose adjoint
 @deprecate ctranspose! adjoint!
 
-@deprecate convert(::Type{Vector{UInt8}}, s::AbstractString)  Vector{UInt8}(s)
-@deprecate convert(::Type{Array{UInt8}}, s::AbstractString)   Vector{UInt8}(s)
+function convert(::Union{Type{Vector{UInt8}}, Type{Array{UInt8}}}, s::AbstractString)
+    depwarn("Strings can no longer be `convert`ed to byte arrays. Use `unsafe_wrap` or `codeunits` instead.", :Type)
+    unsafe_wrap(Vector{UInt8}, String(s))
+end
+function (::Type{Vector{UInt8}})(s::String)
+    depwarn("Vector{UInt8}(s::String) will copy data in the future. To avoid copying, use `unsafe_wrap` or `codeunits` instead.", :Type)
+    unsafe_wrap(Vector{UInt8}, s)
+end
+function (::Type{Array{UInt8}})(s::String)
+    depwarn("Array{UInt8}(s::String) will copy data in the future. To avoid copying, use `unsafe_wrap` or `codeunits` instead.", :Type)
+    unsafe_wrap(Vector{UInt8}, s)
+end
+
 @deprecate convert(::Type{Vector{Char}}, s::AbstractString)   Vector{Char}(s)
 @deprecate convert(::Type{Symbol}, s::AbstractString)         Symbol(s)
 @deprecate convert(::Type{String}, s::Symbol)                 String(s)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -686,6 +686,7 @@ export
     chomp,
     chop,
     codeunit,
+    codeunits,
     dec,
     digits,
     digits!,

--- a/base/io.jl
+++ b/base/io.jl
@@ -706,7 +706,7 @@ function readuntil(io::IO, target::AbstractString)
     # decide how we can index target
     if target isa String
         # convert String to a utf8-byte-iterator
-        target = Vector{UInt8}(target)
+        target = codeunits(target)
     #elseif applicable(codeunit, target)
     #   TODO: a more general version of above optimization
     #         would be to permit accessing any string via codeunit

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -27,7 +27,7 @@ function GenericIOBuffer(data::T, readable::Bool, writable::Bool, seekable::Bool
 end
 
 # allocate Vector{UInt8}s for IOBuffer storage that can efficiently become Strings
-StringVector(n::Integer) = Vector{UInt8}(_string_n(n))
+StringVector(n::Integer) = unsafe_wrap(Vector{UInt8}, _string_n(n))
 
 # IOBuffers behave like Files. They are typically readable and writable. They are seekable. (They can be appendable).
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -64,12 +64,12 @@ elseif Sys.isapple()
             break
         end
         # Hack to compensate for inability to create a string from a subarray with no allocations.
-        Vector{UInt8}(path_basename) == casepreserved_basename && return true
+        codeunits(path_basename) == casepreserved_basename && return true
 
         # If there is no match, it's possible that the file does exist but HFS+
         # performed unicode normalization. See  https://developer.apple.com/library/mac/qa/qa1235/_index.html.
         isascii(path_basename) && return false
-        Vector{UInt8}(Unicode.normalize(path_basename, :NFD)) == casepreserved_basename
+        codeunits(Unicode.normalize(path_basename, :NFD)) == casepreserved_basename
     end
 else
     # Generic fallback that performs a slow directory listing.

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -657,7 +657,7 @@ function edit_splice!(s, r::Region=region(s), ins::AbstractString = ""; rigid_ma
     elseif buf.mark >= B
         buf.mark += sizeof(ins) - B + A
     end
-    ret = splice!(buf.data, A+1:B, Vector{UInt8}(ins)) # position(), etc, are 0-indexed
+    ret = splice!(buf.data, A+1:B, codeunits(String(ins))) # position(), etc, are 0-indexed
     buf.size = buf.size + sizeof(ins) - B + A
     adjust_pos && seek(buf, position(buf) + sizeof(ins))
     String(ret)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -283,7 +283,7 @@ function showerror(io::IO, ex::ErrorException)
     print(io, ex.msg)
     if ex.msg == "type String has no field data"
         println(io)
-        print(io, "Use `Vector{UInt8}(str)` instead.")
+        print(io, "Use `codeunits(str)` instead.")
     end
 end
 showerror(io::IO, ex::KeyError) = print(io, "KeyError: key $(repr(ex.key)) not found")

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -188,8 +188,8 @@ julia> String(take!(io))
 "Haho"
 ```
 """
-IOBuffer(str::String) = IOBuffer(Vector{UInt8}(str))
-IOBuffer(s::SubString{String}) = IOBuffer(view(Vector{UInt8}(s.string), s.offset + 1 : s.offset + sizeof(s)))
+IOBuffer(str::String) = IOBuffer(unsafe_wrap(Vector{UInt8}, str))
+IOBuffer(s::SubString{String}) = IOBuffer(view(unsafe_wrap(Vector{UInt8}, s.string), s.offset + 1 : s.offset + sizeof(s)))
 
 # join is implemented using IO
 
@@ -373,7 +373,10 @@ function unescape_string(io, s::AbstractString)
     end
 end
 
-macro b_str(s); :(Vector{UInt8}($(unescape_string(s)))); end
+macro b_str(s)
+    v = Vector{UInt8}(codeunits(unescape_string(s)))
+    QuoteNode(v)
+end
 
 """
     @raw_str -> String

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -31,7 +31,7 @@ function search(a::ByteArray, b::Char, i::Integer = 1)
     if isascii(b)
         search(a,UInt8(b),i)
     else
-        search(a,Vector{UInt8}(string(b)),i).start
+        search(a,unsafe_wrap(Vector{UInt8},string(b)),i).start
     end
 end
 
@@ -62,7 +62,7 @@ function rsearch(a::ByteArray, b::Char, i::Integer = length(a))
     if isascii(b)
         rsearch(a,UInt8(b),i)
     else
-        rsearch(a,Vector{UInt8}(string(b)),i).start
+        rsearch(a,unsafe_wrap(Vector{UInt8},string(b)),i).start
     end
 end
 

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -147,7 +147,7 @@ function _search_bloom_mask(c)
 end
 
 _nthbyte(s::String, i) = codeunit(s, i)
-_nthbyte(a::ByteArray, i) = a[i]
+_nthbyte(a::Union{AbstractVector{UInt8},AbstractVector{Int8}}, i) = a[i]
 
 function _searchindex(s::Union{String,ByteArray}, t::Union{String,ByteArray}, i)
     n = sizeof(t)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -60,7 +60,11 @@ This representation is often appropriate for passing strings to C.
 String(s::AbstractString) = print_to_string(s)
 String(s::Symbol) = unsafe_string(unsafe_convert(Ptr{UInt8}, s))
 
-(::Type{Vector{UInt8}})(s::String) = ccall(:jl_string_to_array, Ref{Vector{UInt8}}, (Any,), s)
+unsafe_wrap(::Type{Vector{UInt8}}, s::String) = ccall(:jl_string_to_array, Ref{Vector{UInt8}}, (Any,), s)
+
+(::Type{Vector{UInt8}})(s::CodeUnits{UInt8,String}) = copyto!(Vector{UInt8}(uninitialized, length(s)), s)
+
+String(s::CodeUnits{UInt8,String}) = s.s
 
 ## low-level functions ##
 

--- a/base/strings/strings.jl
+++ b/base/strings/strings.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 include("strings/substring.jl")
-include("strings/basic.jl")
 include("strings/search.jl")
 include("strings/unicode.jl")
 include("strings/util.jl")

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -155,3 +155,5 @@ function reverse(s::Union{String,SubString{String}})::String
         end
     end
 end
+
+getindex(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, r)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -475,24 +475,29 @@ julia> hex2bytes(a)
 """
 function hex2bytes end
 
-hex2bytes(s::AbstractString) = hex2bytes(Vector{UInt8}(String(s)))
-hex2bytes(s::AbstractVector{UInt8}) = hex2bytes!(Vector{UInt8}(uninitialized, length(s) >> 1), s)
+hex2bytes(s::AbstractString) = hex2bytes(String(s))
+hex2bytes(s::Union{String,AbstractVector{UInt8}}) = hex2bytes!(Vector{UInt8}(uninitialized, length(s) >> 1), s)
+
+_firstbyteidx(s::String) = 1
+_firstbyteidx(s::AbstractVector{UInt8}) = first(eachindex(s))
+_lastbyteidx(s::String) = sizeof(s)
+_lastbyteidx(s::AbstractVector{UInt8}) = endof(s)
 
 """
-    hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
+    hex2bytes!(d::AbstractVector{UInt8}, s::Union{String,AbstractVector{UInt8}})
 
 Convert an array `s` of bytes representing a hexadecimal string to its binary
 representation, similar to [`hex2bytes`](@ref) except that the output is written in-place
 in `d`.   The length of `s` must be exactly twice the length of `d`.
 """
-function hex2bytes!(d::AbstractVector{UInt8}, s::AbstractVector{UInt8})
-    if 2length(d) != length(s)
-        isodd(length(s)) && throw(ArgumentError("input hex array must have even length"))
+function hex2bytes!(d::AbstractVector{UInt8}, s::Union{String,AbstractVector{UInt8}})
+    if 2length(d) != sizeof(s)
+        isodd(sizeof(s)) && throw(ArgumentError("input hex array must have even length"))
         throw(ArgumentError("output array must be half length of input array"))
     end
     j = first(eachindex(d)) - 1
-    for i = first(eachindex(s)):2:endof(s)
-        @inbounds d[j += 1] = number_from_hex(s[i]) << 4 + number_from_hex(s[i+1])
+    for i = _firstbyteidx(s):2:_lastbyteidx(s)
+        @inbounds d[j += 1] = number_from_hex(_nthbyte(s,i)) << 4 + number_from_hex(_nthbyte(s,i+1))
     end
     return d
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -183,9 +183,6 @@ macro MIME_str(s)
     :(MIME{$(Expr(:quote, Symbol(s)))})
 end
 
-include("char.jl")
-include("strings/string.jl")
-
 # SIMD loops
 include("simdloop.jl")
 using .SimdLoop
@@ -211,6 +208,10 @@ include("set.jl")
 include("iterators.jl")
 using .Iterators: zip, enumerate
 using .Iterators: Flatten, product  # for generators
+
+include("char.jl")
+include("strings/basic.jl")
+include("strings/string.jl")
 
 # Definition of StridedArray
 StridedReshapedArray{T,N,A<:Union{DenseArray,FastContiguousSubArray}} = ReshapedArray{T,N,A}

--- a/doc/src/stdlib/strings.md
+++ b/doc/src/stdlib/strings.md
@@ -15,6 +15,7 @@ Base.transcode
 Base.unsafe_string
 Base.ncodeunits(::AbstractString)
 Base.codeunit
+Base.codeunits
 Base.ascii
 Base.@r_str
 Base.@raw_str

--- a/src/array.c
+++ b/src/array.c
@@ -441,6 +441,11 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
         if (jl_is_string(o)) {
             a->flags.isshared = 1;
             *(size_t*)o = jl_array_len(a);
+            a->nrows = 0;
+#ifdef STORE_ARRAY_LEN
+            a->length = 0;
+#endif
+            a->maxsize = 0;
             return o;
         }
     }

--- a/test/char.jl
+++ b/test/char.jl
@@ -201,7 +201,7 @@ end
 @testset "read incomplete character at end of stream or file" begin
     local file = tempname()
     local iob = IOBuffer([0xf0])
-    local bytes(c::Char) = Vector{UInt8}(string(c))
+    local bytes(c::Char) = codeunits(string(c))
     @test bytes(read(iob, Char)) == [0xf0]
     @test eof(iob)
     try

--- a/test/core.jl
+++ b/test/core.jl
@@ -4114,7 +4114,7 @@ b = "aaa"
 c = [0x2, 0x1, 0x3]
 
 @test check_nul(a)
-@test check_nul(Vector{UInt8}(b))
+@test check_nul(unsafe_wrap(Vector{UInt8},b))
 @test check_nul(c)
 d = [0x2, 0x1, 0x3]
 @test check_nul(d)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -394,7 +394,7 @@ end
 
 let s = "abcα🐨\0x\0"
     for T in (UInt8, UInt16, UInt32, Int32)
-        @test transcode(T, s) == transcode(T, Vector{UInt8}(s))
+        @test transcode(T, s) == transcode(T, codeunits(s))
         @test transcode(String, transcode(T, s)) == s
     end
 end

--- a/test/random.jl
+++ b/test/random.jl
@@ -613,7 +613,7 @@ let b = ['0':'9';'A':'Z';'a':'z']
         @test length(randstring(rng...)) == 8
         @test length(randstring(rng..., 20)) == 20
         @test issubset(randstring(rng...), b)
-        for c = ['a':'z', "qwèrtï", Set(Vector{UInt8}("gcat"))],
+        for c = ['a':'z', "qwèrtï", Set(codeunits("gcat"))],
                 len = [8, 20]
             s = len == 8 ? randstring(rng..., c) : randstring(rng..., c, len)
             @test length(s) == len

--- a/test/read.jl
+++ b/test/read.jl
@@ -165,7 +165,7 @@ for (name, f) in l
         @test readuntil(io(t), s) == m
         @test readuntil(io(t), SubString(s, start(s), endof(s))) == m
         @test readuntil(io(t), GenericString(s)) == m
-        @test readuntil(io(t), Vector{UInt8}(s)) == Vector{UInt8}(m)
+        @test readuntil(io(t), unsafe_wrap(Vector{UInt8},s)) == unsafe_wrap(Vector{UInt8},m)
         @test readuntil(io(t), collect(s)::Vector{Char}) == Vector{Char}(m)
     end
     cleanup()
@@ -223,7 +223,7 @@ for (name, f) in l
 
 
         verbose && println("$name read...")
-        @test read(io()) == Vector{UInt8}(text)
+        @test read(io()) == unsafe_wrap(Vector{UInt8},text)
 
         @test read(io()) == read(filename)
 
@@ -331,7 +331,7 @@ for (name, f) in l
     @test read("$filename.to", String) == text
 
     verbose && println("$name write(::IOBuffer, ...)")
-    to = IOBuffer(copy(Vector{UInt8}(text)), false, true)
+    to = IOBuffer(Vector{UInt8}(codeunits(text)), false, true)
     write(to, io())
     @test String(take!(to)) == text
 
@@ -400,14 +400,14 @@ test_read_nbyte()
 
 
 let s = "qwerty"
-    @test read(IOBuffer(s)) == Vector{UInt8}(s)
-    @test read(IOBuffer(s), 10) == Vector{UInt8}(s)
-    @test read(IOBuffer(s), 1) == Vector{UInt8}(s)[1:1]
+    @test read(IOBuffer(s)) == codeunits(s)
+    @test read(IOBuffer(s), 10) == codeunits(s)
+    @test read(IOBuffer(s), 1) == codeunits(s)[1:1]
 
     # Test growing output array
     x = UInt8[]
     n = readbytes!(IOBuffer(s), x, 10)
-    @test x == Vector{UInt8}(s)
+    @test x == codeunits(s)
     @test n == length(x)
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -206,7 +206,7 @@ struct tstStringType <: AbstractString
     data::Array{UInt8,1}
 end
 @testset "AbstractString functions" begin
-    tstr = tstStringType(Vector{UInt8}("12"))
+    tstr = tstStringType(unsafe_wrap(Vector{UInt8},"12"))
     @test_throws MethodError ncodeunits(tstr)
     @test_throws MethodError codeunit(tstr)
     @test_throws MethodError codeunit(tstr, 1)
@@ -697,7 +697,7 @@ end
     end
 end
 
-@test Vector{UInt8}("\xcc\xdd\xee\xff\x80") == [0xcc,0xdd,0xee,0xff,0x80]
+@test unsafe_wrap(Vector{UInt8},"\xcc\xdd\xee\xff\x80") == [0xcc,0xdd,0xee,0xff,0x80]
 
 @test next("a", 1)[2] == 2
 @test nextind("a", 1) == 2
@@ -794,3 +794,19 @@ end
 @test nextind("\xf8\x9f\x98\x84", 1) == 2
 @test next("\xf8\x9f\x98\x84z", 1)[2] == 2
 @test nextind("\xf8\x9f\x98\x84z", 1) == 2
+
+# codeunit vectors
+
+let s = "∀x∃y", u = codeunits(s)
+    @test u isa Base.CodeUnits{UInt8,String}
+    @test length(u) == ncodeunits(s) == 8
+    @test sizeof(u) == sizeof(s)
+    @test eltype(u) === UInt8
+    @test size(u) == (length(u),)
+    @test strides(u) == (1,)
+    @test u[1] == 0xe2
+    @test u[2] == 0x88
+    @test u[8] == 0x79
+    @test_throws ErrorException (u[1] = 0x00)
+    @test collect(u) == b"∀x∃y"
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -810,3 +810,11 @@ let s = "∀x∃y", u = codeunits(s)
     @test_throws ErrorException (u[1] = 0x00)
     @test collect(u) == b"∀x∃y"
 end
+
+# issue #24388
+let v = unsafe_wrap(Vector{UInt8}, "abc")
+    s = String(v)
+    @test_throws BoundsError v[1]
+    push!(v, UInt8('x'))
+    @test s == "abc"
+end


### PR DESCRIPTION
I tried a couple things here. First, I decided that we will still want *some* way to wrap a String as a Vector in-place, so I made that a method of `unsafe_wrap` as suggested by @vtjnash. But then, there are many uses that just want to access the bytes of a string and don't do anything unsafe. To handle that I added a ~~`StringBytes`~~ `CodeUnits` AbstractVector type that exposes the bytes of a `String` as an immutable UInt8 vector.

My questions are (1) do we want `CodeUnits` and should it be exported, and (2) what should the existing functions be deprecated to? I feel the majority of uses will want `CodeUnits`, but that isn't an accurate deprecation since it doesn't return a `Vector{UInt8}`.
  