### PR TITLE
Distributed : delete relative include test

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1356,25 +1356,6 @@ catch ex
     @test ex.captured.ex.exceptions[2].ex == UndefVarError(:DontExistOn1)
 end
 
-@test let
-    # creates a new worker in the same folder and tries to include file
-    tmp_file, temp_file_stream = mktemp()
-    close(temp_file_stream)
-    tmp_file = relpath(tmp_file, @__DIR__)
-    try
-        proc = addprocs_with_testenv(1)
-        include(tmp_file)
-        remotecall_fetch(include, proc[1], tmp_file)
-        rmprocs(proc)
-        rm(tmp_file)
-        return true
-    catch e
-        println(e)
-        rm(tmp_file, force=true)
-        return false
-    end
-end == true
-
 let
     # creates a new worker in a different folder and tries to include file
     tmp_dir = mktempdir()


### PR DESCRIPTION
I believe the include test with a relative path for both local and remote includes is not expected to work identically in all circumstances because, while the local include is relative to the path of the directory containing the current file, `include` on the worker process will be relative to its working dir.

This test used to work when runtests.jl and distributed_exec.jl were both in the same directory. Now that distributed_exec.jl has moved under stdlib, it errors.

I have deleted the test.