### PR TITLE
[RFC] Treat stdlib packages more like normal packages

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1255,8 +1255,13 @@ deprecate(Base, :DSP, 2)
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
 
+@deprecate_binding Test nothing true ", run `using Test` instead"
+
 @deprecate_moved SharedArray "SharedArrays" true true
 
+@deprecate_binding Mmap nothing true ", run `using Mmap` instead"
+
+@deprecate_binding Profile nothing true ", run `using Profile` instead"
 @eval @deprecate_moved $(Symbol("@profile")) "Profile" true true
 
 @deprecate_moved base64encode "Base64" true true
@@ -1277,6 +1282,7 @@ export conv, conv2, deconv, filt, filt!, xcorr
 @eval @deprecate_moved $(Symbol("@everywhere")) "Distributed" true true
 @eval @deprecate_moved $(Symbol("@parallel")) "Distributed" true true
 
+@deprecate_binding Distributed nothing true ", run `using Distributed` instead"
 @deprecate_moved addprocs "Distributed" true true
 @deprecate_moved CachingPool "Distributed" true true
 @deprecate_moved clear! "Distributed" true true
@@ -1308,6 +1314,7 @@ export conv, conv2, deconv, filt, filt!, xcorr
 
 @deprecate_moved crc32c "CRC32c" true true
 
+@deprecate_binding Dates nothing true ", run `using Dates` instead"
 @deprecate_moved DateTime "Dates" true true
 @deprecate_moved DateFormat "Dates" true true
 @eval @deprecate_moved $(Symbol("@dateformat_str")) "Dates" true true

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -66,7 +66,7 @@ function init_load_path(BINDIR = Sys.BINDIR)
     end
     push!(LOAD_PATH, abspath(BINDIR, "..", "local", "share", "julia", "site", vers))
     push!(LOAD_PATH, abspath(BINDIR, "..", "share", "julia", "site", vers))
-    #push!(LOAD_CACHE_PATH, abspath(BINDIR, "..", "lib", "julia")) #TODO: add a builtin location?
+    push!(LOAD_CACHE_PATH, abspath(BINDIR, "..", "share", "julia", "lib", vers))
 end
 
 function early_init()

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -85,6 +85,9 @@ custom METADATA setup.
 init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRANCH) = Dir.init(meta,branch)
 
 function __init__()
+    if haskey(ENV, "JULIA_SKIP_PKGCACHE") && ENV["JULIA_SKIP_PKGCACHE"] == "1"
+	return
+    end
     vers = "v$(VERSION.major).$(VERSION.minor)"
     pushfirst!(Base.LOAD_CACHE_PATH, abspath(Dir._pkgroot(), "lib", vers))
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -487,14 +487,6 @@ using Base
 # Ensure this file is also tracked
 pushfirst!(Base._included_files, (@__MODULE__, joinpath(@__DIR__, "sysimg.jl")))
 
-# @eval Base begin
-#     @deprecate_binding Test root_module(:Test) true ", run `using Test` instead"
-#     @deprecate_binding Mmap root_module(:Mmap) true ", run `using Mmap` instead"
-#     @deprecate_binding Profile root_module(:Profile) true ", run `using Profile` instead"
-#     @deprecate_binding Dates root_module(:Dates) true ", run `using Dates` instead"
-#     @deprecate_binding Distributed root_module(:Distributed) true ", run `using Distributed` instead"
-# end
-
 empty!(LOAD_PATH)
 
 Base.isfile("userimg.jl") && Base.include(Main, "userimg.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -487,30 +487,13 @@ using Base
 # Ensure this file is also tracked
 pushfirst!(Base._included_files, (@__MODULE__, joinpath(@__DIR__, "sysimg.jl")))
 
-# load some stdlib packages but don't put their names in Main
-Base.require(:Base64)
-Base.require(:CRC32c)
-Base.require(:Dates)
-Base.require(:DelimitedFiles)
-Base.require(:FileWatching)
-Base.require(:Logging)
-Base.require(:IterativeEigensolvers)
-Base.require(:Mmap)
-Base.require(:Profile)
-Base.require(:SharedArrays)
-Base.require(:SuiteSparse)
-Base.require(:Test)
-Base.require(:Unicode)
-Base.require(:Distributed)
-Base.require(:Printf)
-
-@eval Base begin
-    @deprecate_binding Test root_module(:Test) true ", run `using Test` instead"
-    @deprecate_binding Mmap root_module(:Mmap) true ", run `using Mmap` instead"
-    @deprecate_binding Profile root_module(:Profile) true ", run `using Profile` instead"
-    @deprecate_binding Dates root_module(:Dates) true ", run `using Dates` instead"
-    @deprecate_binding Distributed root_module(:Distributed) true ", run `using Distributed` instead"
-end
+# @eval Base begin
+#     @deprecate_binding Test root_module(:Test) true ", run `using Test` instead"
+#     @deprecate_binding Mmap root_module(:Mmap) true ", run `using Mmap` instead"
+#     @deprecate_binding Profile root_module(:Profile) true ", run `using Profile` instead"
+#     @deprecate_binding Dates root_module(:Dates) true ", run `using Dates` instead"
+#     @deprecate_binding Distributed root_module(:Distributed) true ", run `using Distributed` instead"
+# end
 
 empty!(LOAD_PATH)
 

--- a/contrib/stdlib_cache.jl
+++ b/contrib/stdlib_cache.jl
@@ -1,0 +1,30 @@
+#!/usr/bin/env julia
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# Builds a cache for all stdlib packages and installs that alongside Julia.
+
+@assert length(ARGS) == 2
+pkgdir = ARGS[1]
+cachedir = ARGS[2]
+
+let cache_path = Base.LOAD_CACHE_PATH
+    empty!(cache_path)
+    push!(cache_path, cachedir)
+end
+
+let load_path = Base.LOAD_PATH
+    empty!(load_path)
+    push!(load_path, pkgdir)
+end
+
+for pkg in readdir(pkgdir)
+    @info "Building cache for $pkg"
+    mfile = joinpath(pkgdir, pkg, "src", string(pkg, ".jl"))
+    if isfile(mfile)
+        # We can't use Base.compilecache since we don't know the order of dependencies
+        Base.require(Symbol(pkg))
+    else
+        @info "Directory $pkg doesn't have a $mfile. Skipping."
+        continue
+    end
+end

--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -2,6 +2,7 @@
 
 using IterativeEigensolvers
 using Test
+using SuiteSparse
 
 @testset "eigs" begin
     srand(1234)

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -2,6 +2,7 @@
 
 using Base.LinAlg: mul!, ldiv!, rdiv!, Adjoint, Transpose
 using Base.Printf.@printf
+using SuiteSparse
 
 @testset "issparse" begin
     @test issparse(sparse(ones(5,5)))


### PR DESCRIPTION
This PR has the goal to allow Pkg3 to eventually manage and update stdlib packages.
In order to achieve that goal we can no longer bake the stdlib packages into the sysimage
so I had to revert #24843. The major downside to this is that it increases the load time of
stdlib packages since they are now cached as normal packages. The major upside is that stdlib
packages are now treated as normal packages and the sysimage is faster to build.

I would like to solict comments on the `Makefile` and `contrib/stdlib_cache.jl`.
(I had to add an option to tell Pkg2 to not resolve packages in order to achieve reproducible builds)

This is part of my exploration for how to get Pkg3 into Base.