### PR TITLE
Fix hash(::AbstractArray) failure in when some types support - and others do not

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1994,6 +1994,7 @@ function hash(a::AbstractArray{T}, h::UInt) where T
                 # If true, wraparound overflow happened
                 sign(step) == cmp(x2, x1) || break
             else
+                applicable(-, x2, x1) || break
                 # widen() is here to ensure no overflow can happen
                 step = widen(x2) - widen(x1)
             end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -787,6 +787,7 @@ julia> widen(1.5f0)
 ```
 """
 widen(x::T) where {T} = convert(widen(T), x)
+widen(x::Type{T}) where {T} = throw(MethodError(widen, (T,)))
 
 # function pipelining
 

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -70,6 +70,8 @@ vals = Any[
     Any[Int8(127), Int8(-128), -383], 127:-255:-383,
     # Loss of precision with Float64
     Any[-2^53-1, 0.0, 2^53+1], [-2^53-1, 0, 2^53+1], (-2^53-1):2^53+1:(2^53+1),
+    # Some combinations of elements support -, others do not
+    [1, 2, "a"], [1, "a", 2], [1, 2, "a", 2], [1, 'a', 2],
     Set([1,2,3,4]),
     Set([1:10;]),                # these lead to different key orders
     Set([7,9,4,10,2,3,5,8,6,1]), #

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2400,6 +2400,9 @@ end
     @test typeof(widemul(UInt64(1),Int64(1))) == Int128
     @test typeof(widemul(Int128(1),UInt128(1))) == BigInt
     @test typeof(widemul(UInt128(1),Int128(1))) == BigInt
+
+    # Check that the widen() fallback doesn't trigger a StackOverflowError
+    @test_throws MethodError widen(String)
 end
 @testset ".//" begin
     @test [1,2,3] // 4 == [1//4, 2//4, 3//4]


### PR DESCRIPTION
The existing code (recently added by https://github.com/JuliaLang/julia/pull/16401) only checked that subtraction was supported for the first two elements, but not for subsequent elements, which is necessary for heterogeneous arrays.

Also fix a `StackOverflow` error due to the `widen` fallback calling itself recursively by throwing a `MethodError` manually.
