### PR TITLE
Send all parser and lowering depwarns to the logging system

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -103,9 +103,7 @@ function helpmode(io::IO, line::AbstractString)
             # keyword such as `function` would throw a parse error due to the missing `end`.
             Symbol(line)
         else
-            x = Base.syntax_deprecation_warnings(false) do
-                Meta.parse(line, raise = false)
-            end
+            x = Meta.parse(line, raise = false, depwarn = false)
             # Retrieving docs for macros requires us to make a distinction between the text
             # `@macroname` and `@macroname()`. These both parse the same, but are used by
             # the docsystem to return different results. The first returns all documentation

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -269,10 +269,9 @@ function logmsg_code(_module, file, line, level, message, exs...)
             if k == :_id
                 # id may be overridden if you really want several log
                 # statements to share the same id (eg, several pertaining to
-                # the same progress step).
-                #
-                # TODO: Refine this - doing it as is, is probably a bad idea
-                # for consistency, and is hard to make unique between modules.
+                # the same progress step).  In those cases it may be wise to
+                # manually call log_record_id to get a unique id in the same
+                # format.
                 id = esc(v)
             elseif k == :_module
                 _module = esc(v)
@@ -358,6 +357,15 @@ end
         end
     end
     nothing
+end
+
+# Log a message. Called from the julia C code; kwargs is in the format
+# Any[key1,val1, ...] for simplicity in construction on the C side.
+function logmsg_thunk(level, message, _module, group, id, file, line, kwargs)
+    real_kws = Any[(kwargs[i],kwargs[i+1]) for i in 1:2:length(kwargs)]
+    @logmsg(convert(LogLevel, level), message,
+            _module=_module, _id=id, _group=group,
+            _file=file, _line=line, real_kws...)
 end
 
 # Global log limiting mechanism for super fast but inflexible global log

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -365,7 +365,7 @@ function logmsg_thunk(level, message, _module, group, id, file, line, kwargs)
     real_kws = Any[(kwargs[i],kwargs[i+1]) for i in 1:2:length(kwargs)]
     @logmsg(convert(LogLevel, level), message,
             _module=_module, _id=id, _group=group,
-            _file=file, _line=line, real_kws...)
+            _file=String(file), _line=line, real_kws...)
 end
 
 # Global log limiting mechanism for super fast but inflexible global log

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -5,6 +5,8 @@ Convenience functions for metaprogramming.
 """
 module Meta
 
+using ..CoreLogging
+
 export quot,
        isexpr,
        show_sexpr,
@@ -93,7 +95,7 @@ struct ParseError <: Exception
 end
 
 """
-    parse(str, start; greedy=true, raise=true)
+    parse(str, start; greedy=true, raise=true, depwarn=true)
 
 Parse the expression string and return an expression (which could later be passed to eval
 for execution). `start` is the index of the first character to start parsing. If `greedy` is
@@ -101,7 +103,8 @@ for execution). `start` is the index of the first character to start parsing. If
 stop as soon as it has parsed a valid expression. Incomplete but otherwise syntactically
 valid expressions will return `Expr(:incomplete, "(error message)")`. If `raise` is `true`
 (default), syntax errors other than incomplete expressions will raise an error. If `raise`
-is `false`, `parse` will return an expression that will raise an error upon evaluation.
+is `false`, `parse` will return an expression that will raise an error upon evaluation. If
+`depwarn` is `false`, deprecation warnings will be suppressed.
 
 ```jldoctest
 julia> Meta.parse("x = 3, y = 5", 7)
@@ -111,13 +114,17 @@ julia> Meta.parse("x = 3, y = 5", 5)
 (:((3, y) = 5), 13)
 ```
 """
-function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=true)
+function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=true,
+               depwarn::Bool=true)
     # pos is one based byte offset.
     # returns (expr, end_pos). expr is () in case of parse error.
     bstr = String(str)
-    ex, pos = ccall(:jl_parse_string, Any,
-                    (Ptr{UInt8}, Csize_t, Int32, Int32),
-                    bstr, sizeof(bstr), pos-1, greedy ? 1 : 0)
+    # For now, assume all parser warnings are depwarns
+    ex, pos = with_logger(depwarn ? current_logger() : NullLogger()) do
+        ccall(:jl_parse_string, Any,
+              (Ptr{UInt8}, Csize_t, Int32, Int32),
+              bstr, sizeof(bstr), pos-1, greedy ? 1 : 0)
+    end
     if raise && isa(ex,Expr) && ex.head === :error
         throw(ParseError(ex.args[1]))
     end
@@ -129,12 +136,13 @@ function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=tru
 end
 
 """
-    parse(str; raise=true)
+    parse(str; raise=true, depwarn=true)
 
 Parse the expression string greedily, returning a single expression. An error is thrown if
 there are additional characters after the first expression. If `raise` is `true` (default),
 syntax errors will raise an error; otherwise, `parse` will return an expression that will
-raise an error upon evaluation.
+raise an error upon evaluation.  If `depwarn` is `false`, deprecation warnings will be
+suppressed.
 
 ```jldoctest
 julia> Meta.parse("x = 3")
@@ -152,8 +160,8 @@ julia> Meta.parse("1.0.2"; raise = false)
 :($(Expr(:error, "invalid numeric constant \"1.0.\"")))
 ```
 """
-function parse(str::AbstractString; raise::Bool=true)
-    ex, pos = parse(str, 1, greedy=true, raise=raise)
+function parse(str::AbstractString; raise::Bool=true, depwarn::Bool=true)
+    ex, pos = parse(str, 1, greedy=true, raise=raise, depwarn=depwarn)
     if isa(ex,Expr) && ex.head === :error
         return ex
     end

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -657,9 +657,7 @@ end
 LineEdit.reset_state(hist::REPLHistoryProvider) = history_reset_state(hist)
 
 function return_callback(s)
-    ast = Base.syntax_deprecation_warnings(false) do
-        Base.parse_input_line(String(take!(copy(LineEdit.buffer(s)))))
-    end
+    ast = Base.parse_input_line(String(take!(copy(LineEdit.buffer(s)))), depwarn=false)
     if  !isa(ast, Expr) || (ast.head != :continue && ast.head != :incomplete)
         return true
     else
@@ -932,9 +930,7 @@ function setup_interface(
                         continue
                     end
                 end
-                ast, pos = Base.syntax_deprecation_warnings(false) do
-                    Meta.parse(input, oldpos, raise=false)
-                end
+                ast, pos = Meta.parse(input, oldpos, raise=false, depwarn=false)
                 if (isa(ast, Expr) && (ast.head == :error || ast.head == :continue || ast.head == :incomplete)) ||
                         (done(input, pos) && !endswith(input, '\n'))
                     # remaining text is incomplete (an error, or parser ran to the end but didn't stop with a newline):

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -44,9 +44,7 @@ function complete_symbol(sym, ffunc)
         # Find module
         lookup_name, name = rsplit(sym, ".", limit=2)
 
-        ex = Base.syntax_deprecation_warnings(false) do
-            Meta.parse(lookup_name, raise=false)
-        end
+        ex = Meta.parse(lookup_name, raise=false, depwarn=false)
 
         b, found = get_value(ex, context_module)
         if found
@@ -481,9 +479,7 @@ end
 function completions(string, pos)
     # First parse everything up to the current position
     partial = string[1:pos]
-    inc_tag = Base.syntax_deprecation_warnings(false) do
-        Base.incomplete_tag(Meta.parse(partial, raise=false))
-    end
+    inc_tag = Base.incomplete_tag(Meta.parse(partial, raise=false, depwarn=false))
 
     # if completing a key in a Dict
     identifier, partial_key, loc = dict_identifier_key(partial,inc_tag)
@@ -529,9 +525,7 @@ function completions(string, pos)
 
     if inc_tag == :other && should_method_complete(partial)
         frange, method_name_end = find_start_brace(partial)
-        ex = Base.syntax_deprecation_warnings(false) do
-            Meta.parse(partial[frange] * ")", raise=false)
-        end
+        ex = Meta.parse(partial[frange] * ")", raise=false, depwarn=false)
         if isa(ex, Expr) && ex.head==:call
             return complete_methods(ex), start(frange):method_name_end, false
         end

--- a/src/ast.c
+++ b/src/ast.c
@@ -194,7 +194,8 @@ value_t fl_julia_logmsg(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     // Abuse scm_to_julia here to convert arguments.  This is meant for `Expr`s
     // but should be good enough provided we're only passing simple numbers,
     // symbols and strings.
-    jl_value_t *group=NULL, *id=NULL, *file=NULL, *line=NULL, *msg=NULL, *kwargs=NULL;
+    jl_value_t *group=NULL, *id=NULL, *file=NULL, *line=NULL, *msg=NULL;
+    jl_array_t *kwargs=NULL;
     JL_GC_PUSH6(&group, &id, &file, &line, &msg, &kwargs);
     group = scm_to_julia(fl_ctx, arg_group, NULL);
     id    = scm_to_julia(fl_ctx, arg_id, NULL);
@@ -203,10 +204,9 @@ value_t fl_julia_logmsg(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     msg   = scm_to_julia(fl_ctx, arg_msg, NULL);
     kwargs = jl_alloc_vec_any(kwargs_len);
     for (int i = 0; i < kwargs_len; ++i) {
-        jl_array_ptr_set((jl_array_t*)kwargs, i,
-                         scm_to_julia(fl_ctx, arg_kwargs[i], NULL));
+        jl_array_ptr_set(kwargs, i, scm_to_julia(fl_ctx, arg_kwargs[i], NULL));
     }
-    jl_log(numval(arg_level), jl_nothing, group, id, file, line, kwargs, msg);
+    jl_log(numval(arg_level), NULL, group, id, file, line, (jl_value_t*)kwargs, msg);
     JL_GC_POP();
     return fl_ctx->T;
 }

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -101,7 +101,7 @@
                                                error incomplete))
                       (and (eq? (car e) 'global) (every symbol? (cdr e))))))
          (if (underscore-symbol? e)
-             (syntax-deprecation #f "underscores as an rvalue" ""))
+             (syntax-deprecation "underscores as an rvalue" "" #f))
          e)
         (else
          (let ((last *in-expand*))
@@ -202,18 +202,6 @@
    (jl-parse-all (open-input-file filename) filename)
    (lambda (e) #f)))
 
-(define *depwarn* #t)
-(define (jl-parser-depwarn w)
-  (let ((prev *depwarn*))
-    (set! *depwarn* (eq? w #t))
-    prev))
-
-(define *deperror* #f)
-(define (jl-parser-deperror e)
-  (let ((prev *deperror*))
-    (set! *deperror* (eq? e #t))
-    prev))
-
 ; expand a piece of raw surface syntax to an executable thunk
 (define (jl-expand-to-thunk expr)
   (parser-wrap (lambda ()
@@ -229,3 +217,45 @@
            (newline)
            (prn e))
    (lambda () (profile s))))
+
+
+; --- logging ---
+; Utilities for logging messages from the frontend, in a way which can be
+; controlled from julia code.
+
+; Log a general deprecation message at line node location `lno`
+(define (deprecation-message msg lno)
+  (let* ((lf (extract-line-file lno)) (line (car lf)) (file (cadr lf)))
+    (frontend-depwarn msg file line)))
+
+; Log a syntax deprecation from line node location `lno`
+(define (syntax-deprecation what instead lno)
+  (let* ((lf (extract-line-file lno)) (line (car lf)) (file (cadr lf)))
+    (deprecation-message (format-syntax-deprecation what instead file line #f) lno)))
+
+; Extract line and file from a line number node, defaulting to (0, none)
+; respectively if lno is absent (`#f`) or doesn't contain a file
+(define (extract-line-file lno)
+  (cond ((or (not lno) (null? lno)) '(0 none))
+        ((not (eq? (car lno) 'line)) (error "lno is not a line number node"))
+        ((length= lno 2) `(,(cadr lno) none))
+        (else (cdr lno))))
+
+(define (format-syntax-deprecation what instead file line exactloc)
+  (string "Deprecated syntax `" what "`"
+          (if (or (= line 0) (eq? file 'none))
+            ""
+            (string (if exactloc " at " " around ") file ":" line))
+          "."
+          (if (equal? instead "") ""
+            (string #\newline "Use `" instead "` instead."))))
+
+; Corresponds to --depwarn 0="no", 1="yes", 2="error"
+(define *depwarn-opt* 1)
+
+; Emit deprecation warning via julia logging layer.
+(define (frontend-depwarn msg file line)
+  ; (display (string msg "; file = " file "; line = " line #\newline)))
+  (case *depwarn-opt*
+    (1 (julia-logmsg 1000 'depwarn (symbol (string file line)) file line msg))
+    (2 (error msg))))

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -50,7 +50,7 @@ jl_options_t jl_options = { 0,    // quiet
                             1,    // debug_level [release build]
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
-                            1,    // deprecation warning
+                            JL_OPTIONS_DEPWARN_ON,    // deprecation warning
                             0,    // method overwrite warning
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -249,8 +249,8 @@
         (if s
             (let ((newe (list (car e) (cadr e) (cadr (caddr e))))
                   (S (deparse `(quote ,s)))) ; #16295
-              (syntax-deprecation #f (string (deparse (cadr e)) ".(" S ")")
-                                  (string (deparse (cadr e)) "." S))
+              (syntax-deprecation (string (deparse (cadr e)) ".(" S ")")
+                                  (string (deparse (cadr e)) "." S) #f)
               newe)
             e))
       e))
@@ -816,9 +816,9 @@
                   (sig    (car temp))
                   (params (cdr temp)))
              (if (pair? params)
-                 (syntax-deprecation #f
-                                     (string "inner constructor " name "(...)" (linenode-string (function-body-lineno body)))
-                                     (deparse `(where (call (curly ,name ,@params) ...) ,@params))))
+                 (syntax-deprecation (string "inner constructor " name "(...)" )
+                                     (deparse `(where (call (curly ,name ,@params) ...) ,@params))
+                                     (function-body-lineno body)))
              `(function ,sig ,(ctor-body body params)))))))
 
 (define (function-body-lineno body)
@@ -1063,8 +1063,8 @@
                   (name    (deprecate-dotparen (if has-sp (cadr head) head)))
                   (op (let ((op_ (maybe-undotop name))) ; handle .op -> broadcast deprecation
                         (if op_
-                            (syntax-deprecation #f (string "function " (deparse name) "(...)")
-                                                (string "function Base.broadcast(::typeof(" (deparse op_) "), ...)")))
+                            (syntax-deprecation (string "function " (deparse name) "(...)")
+                                                (string "function Base.broadcast(::typeof(" (deparse op_) "), ...)") #f))
                         op_))
                   (name (if op '(|.| Base (inert broadcast)) name))
                   (annotations (map (lambda (a) `(meta nospecialize ,(arg-name a)))
@@ -1096,15 +1096,14 @@
                   (name    (if (or (decl? name) (and (pair? name) (eq? (car name) 'curly)))
                                #f name)))
              (if has-sp
-                 (syntax-deprecation #f
-                                     (string "parametric method syntax " (deparse (cadr e))
-                                             (linenode-string (function-body-lineno body)))
+                 (syntax-deprecation (string "parametric method syntax " (deparse (cadr e)))
                                      (deparse `(where (call ,(or name
                                                                  (cadr (cadr (cadr e))))
                                                             ,@(if (has-parameters? argl)
                                                                   (cons (car argl) (cddr argl))
                                                                   (cdr argl)))
-                                                      ,@raw-typevars))))
+                                                      ,@raw-typevars))
+                                     (function-body-lineno body)))
              (expand-forms
               (method-def-expr name sparams argl body rett))))
           (else
@@ -1154,11 +1153,11 @@
 (define (expand-let e)
   (if (length= e 2)
       (begin (deprecation-message (string "The form `Expr(:let, ex)` is deprecated. "
-                                          "Use `Expr(:let, Expr(:block), ex)` instead." #\newline))
+                                          "Use `Expr(:let, Expr(:block), ex)` instead." #\newline) #f)
              (return (expand-let `(let (block) ,(cadr e))))))
   (if (length> e 3)
       (begin (deprecation-message (string "The form `Expr(:let, ex, binds...)` is deprecated. "
-                                          "Use `Expr(:let, Expr(:block, binds...), ex)` instead." #\newline))
+                                          "Use `Expr(:let, Expr(:block, binds...), ex)` instead." #\newline) #f)
              (return (expand-let `(let (block ,@(cddr e)) ,(cadr e))))))
   (let ((ex    (caddr e))
         (binds (let-binds e)))
@@ -1618,7 +1617,7 @@
                 (block
                  ;; NOTE: enable this to force loop-local var
                  #;,@(map (lambda (v) `(local ,v)) (lhs-vars lhs))
-                 ,@(if (and (not outer?) (or *depwarn* *deperror*))
+                 ,@(if (not outer?)
                        (map (lambda (v) `(warn-if-existing ,v)) (lhs-vars lhs))
                        '())
                  ,(lower-tuple-assignment (list lhs state)
@@ -1906,7 +1905,7 @@
    'struct         expand-struct-def
    'type
    (lambda (e)
-     (syntax-deprecation #f ":type expression head" ":struct")
+     (syntax-deprecation ":type expression head" ":struct" #f)
      (expand-struct-def e))
    'try            expand-try
    ;; deprecated in 0.6
@@ -2000,9 +1999,9 @@
                  (b_  (caddr lhs))
                  (b   (if (and (length= b_ 2) (eq? (car b_) 'tuple))
                           (begin
-                            (syntax-deprecation #f
+                            (syntax-deprecation
                              (string (deparse a) ".(" (deparse (cadr b_)) ") = ...")
-                             (string "setfield!(" (deparse a) ", " (deparse (cadr b_)) ", ...)"))
+                             (string "setfield!(" (deparse a) ", " (deparse (cadr b_)) ", ...)") #f)
                             (cadr b_))
                           b_))
                  (rhs (caddr e)))
@@ -2108,7 +2107,7 @@
 
    'bitstype
    (lambda (e)
-     (syntax-deprecation #f "Expr(:bitstype, nbits, name)" "Expr(:primitive, name, nbits)")
+     (syntax-deprecation "Expr(:bitstype, nbits, name)" "Expr(:primitive, name, nbits)" #f)
      (expand-forms `(primitive ,(caddr e) ,(cadr e))))
    'primitive
    (lambda (e)
@@ -2224,7 +2223,7 @@
 
    '=>
    (lambda (e)
-     (syntax-deprecation #f "Expr(:(=>), ...)" "Expr(:call, :(=>), ...)")
+     (syntax-deprecation "Expr(:(=>), ...)" "Expr(:call, :(=>), ...)" #f)
      (expand-forms `(call => ,@(cdr e))))
 
    'braces    (lambda (e) (error "{ } vector syntax is discontinued"))
@@ -2409,7 +2408,7 @@
                                              "behaviorally equivalent to the former `RowVector` "
                                              "is always the correct rewrite for vectors. For "
                                              "more information, see issue #5332 on Julia's "
-                                             "issue tracker on GitHub." #\newline))
+                                             "issue tracker on GitHub." #\newline) #f)
                             (return (expand-forms `(call transpose ,(cadr e))))))
 
    'generator
@@ -2573,7 +2572,7 @@
            (filter
              (lambda (v)
                (if (memq v deprecated-env)
-                   (begin (syntax-deprecation #f (string "implicit assignment to global variable `" v "`") (string "global " v)) #f)
+                   (begin (syntax-deprecation (string "implicit assignment to global variable `" v "`") (string "global " v) #f) #f)
                    #t))
              (find-assigned-vars e env))))
 
@@ -3438,11 +3437,6 @@ f(x) = yt(x)
         (else (for-each linearize (cdr e))))
   e)
 
-(define (deprecation-message msg)
-  (if *deperror*
-      (error msg)
-      (io.write *stderr* msg)))
-
 (define (valid-ir-argument? e)
   (or (simple-atom? e) (symbol? e)
       (and (pair? e)
@@ -3612,12 +3606,11 @@ f(x) = yt(x)
                                (and (pair? e) (or (eq? (car e) 'outerref)
                                                   (eq? (car e) 'globalref))
                                     (underscore-symbol? (cadr e)))))
-                (syntax-deprecation #f (string "underscores as an rvalue" (linenode-string current-loc))
-                                    ""))
+                (syntax-deprecation "underscores as an rvalue" "" current-loc))
             (if (and (not *warn-all-loop-vars*) (has? deprecated-loop-vars e))
                 (begin (deprecation-message
-                        (string "Use of final value of loop variable \"" e "\"" (linenode-string current-loc) " "
-                                "is deprecated. In the future the variable will be local to the loop instead." #\newline))
+                        (string "Use of final value of loop variable `" e "`" (linenode-string current-loc) " "
+                                "is deprecated. In the future the variable will be local to the loop instead.") current-loc)
                        (del! deprecated-loop-vars e)))
             (cond (tail  (emit-return e1))
                   (value e1)
@@ -3633,9 +3626,10 @@ f(x) = yt(x)
                             (for-each (lambda (a)
                                         (if (and (length= a 2) (eq? (car a) '&))
                                             (deprecation-message
-                                             (string "Syntax \"&argument\"" (linenode-string current-loc)
-                                                     " is deprecated. Remove the \"&\" and use a \"Ref\" argument "
-                                                     "type instead." #\newline))))
+                                             (string "Syntax `&argument`" (linenode-string current-loc)
+                                                     " is deprecated. Remove the `&` and use a `Ref` argument "
+                                                     "type instead.")
+                                             current-loc)))
                                       (list-tail e 6))
                             ;; NOTE: 2nd to 5th arguments of ccall must be left in place
                             ;;       the 1st should be compiled if an atom.
@@ -3868,8 +3862,7 @@ f(x) = yt(x)
              (if (or (assq (cadr e) (car  (lam:vinfo lam)))
                      (assq (cadr e) (cadr (lam:vinfo lam))))
                  (begin
-                   (syntax-deprecation #f (string "`const` declaration on local variable" (linenode-string current-loc))
-                                       "")
+                   (syntax-deprecation "`const` declaration on local variable" "" current-loc)
                    '(null))
                  (emit e)))
             ((isdefined) (if tail (emit-return e) e))
@@ -3878,9 +3871,10 @@ f(x) = yt(x)
                      (not (or (assq (cadr e) (car  (lam:vinfo lam)))
                               (assq (cadr e) (cadr (lam:vinfo lam))))))
                  (deprecation-message
-                  (string "Loop variable \"" (cadr e) "\"" (linenode-string current-loc) " "
+                  (string "Loop variable `" (cadr e) "`" (linenode-string current-loc) " "
                           "overwrites a variable in an enclosing scope. "
-                          "In the future the variable will be local to the loop instead." #\newline))
+                          "In the future the variable will be local to the loop instead.")
+                  current-loc)
                  (put! deprecated-loop-vars (cadr e) #t))
              '(null))
             ((boundscheck) (if tail (emit-return e) e))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1389,7 +1389,6 @@ JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len,
                                              const char *filename, size_t filename_len);
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
                                          int pos0, int greedy);
-JL_DLLEXPORT int jl_parse_depwarn(int warn);
 JL_DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
                                              char *filename, jl_module_t *inmodule);
 JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr, jl_module_t *inmodule);
@@ -1775,6 +1774,13 @@ JL_DLLEXPORT int jl_generating_output(void);
 
 #define JL_OPTIONS_STARTUPFILE_ON 1
 #define JL_OPTIONS_STARTUPFILE_OFF 2
+
+#define JL_LOGLEVEL_BELOWMIN -1000001
+#define JL_LOGLEVEL_DEBUG    -1000
+#define JL_LOGLEVEL_INFO      0
+#define JL_LOGLEVEL_WARN      1000
+#define JL_LOGLEVEL_ERROR     2000
+#define JL_LOGLEVEL_ABOVEMAX  1000001
 
 #define JL_OPTIONS_DEPWARN_OFF 0
 #define JL_OPTIONS_DEPWARN_ON 1

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -983,9 +983,9 @@ void jl_depwarn(const char *msg, jl_value_t *sym);
 
 // Log `msg` to the current logger by calling CoreLogging.logmsg_thunk() on the
 // julia side.
-void jl_log(int level, jl_module_t *module, const char *group, const char *id,
-            const char *file, int line, jl_value_t **kwargs, int kwargs_len,
-            const char *msg);
+void jl_log(int level, jl_module_t *module, jl_value_t *group, jl_value_t *id,
+            jl_value_t *file, jl_value_t *line, jl_value_t *kwargs,
+            jl_value_t *msg);
 
 int isabspath(const char *in);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -982,8 +982,10 @@ JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n);
 void jl_depwarn(const char *msg, jl_value_t *sym);
 
 // Log `msg` to the current logger by calling CoreLogging.logmsg_thunk() on the
-// julia side.
-void jl_log(int level, jl_module_t *module, jl_value_t *group, jl_value_t *id,
+// julia side. If any of module, group, id, file or line are NULL, these will
+// be passed to the julia side as `nothing`.  If `kwargs` is NULL an empty set
+// of keyword arguments will be passed.
+void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
             jl_value_t *file, jl_value_t *line, jl_value_t *kwargs,
             jl_value_t *msg);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -981,6 +981,12 @@ JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
 JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n);
 void jl_depwarn(const char *msg, jl_value_t *sym);
 
+// Log `msg` to the current logger by calling CoreLogging.logmsg_thunk() on the
+// julia side.
+void jl_log(int level, jl_module_t *module, const char *group, const char *id,
+            const char *file, int line, jl_value_t **kwargs, int kwargs_len,
+            const char *msg);
+
 int isabspath(const char *in);
 
 extern jl_sym_t *call_sym;    extern jl_sym_t *invoke_sym;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1031,7 +1031,7 @@ JL_DLLEXPORT void jl_breakpoint(jl_value_t *v)
 
 // logging tools --------------------------------------------------------------
 
-void jl_log(int level, jl_module_t *module, jl_value_t *group, jl_value_t *id,
+void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
             jl_value_t *file, jl_value_t *line, jl_value_t *kwargs,
             jl_value_t *msg)
 {
@@ -1075,8 +1075,8 @@ void jl_log(int level, jl_module_t *module, jl_value_t *group, jl_value_t *id,
     args[0] = logmsg_func;
     args[1] = jl_box_long(level);
     args[2] = msg;
-    args[3] = (jl_value_t*)(module ? module : jl_core_module);
     // Would some of the jl_nothing here be better as `missing` instead?
+    args[3] = module ? module  : jl_nothing;
     args[4] = group  ? group   : jl_nothing;
     args[5] = id     ? id      : jl_nothing;
     args[6] = file   ? file    : jl_nothing;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1046,11 +1046,21 @@ void jl_log(int level, jl_module_t *module, jl_value_t *group, jl_value_t *id,
         ios_t str_;
         ios_mem(&str_, 300);
         uv_stream_t* str = (uv_stream_t*)&str_;
-        jl_static_show(str, file);
+        if (jl_is_string(file)) {
+            jl_uv_puts(str, jl_string_data(file), jl_string_len(file));
+        }
+        else {
+            jl_static_show(str, file);
+        }
         jl_printf(str, ":");
         jl_static_show(str, line);
         jl_printf(str, " - ");
-        jl_static_show(str, msg);
+        if (jl_is_string(msg)) {
+            jl_uv_puts(str, jl_string_data(msg), jl_string_len(msg));
+        }
+        else {
+            jl_static_show(str, msg);
+        }
         jl_safe_printf("%s [Fallback logging]: %.*s\n",
                        level < JL_LOGLEVEL_INFO ? "DEBUG" :
                        level < JL_LOGLEVEL_WARN ? "INFO" :

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -196,10 +196,8 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     @test !success(`$exename -E "exit(0)" --check-bounds=false`)
 
     # --depwarn
-    @test readchomp(`$exename --depwarn=no -E
-        "Base.syntax_deprecation_warnings(true)"`) == "false"
-    @test readchomp(`$exename --depwarn=yes -E
-        "Base.syntax_deprecation_warnings(false)"`) == "true"
+    @test readchomp(`$exename --depwarn=no  -E "Base.JLOptions().depwarn"`) == "0"
+    @test readchomp(`$exename --depwarn=yes -E "Base.JLOptions().depwarn"`) == "1"
     @test !success(`$exename --depwarn=false`)
     # test deprecated syntax
     @test !success(`$exename -e "foo (x::Int) = x * x" --depwarn=error`)

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -6,6 +6,8 @@
 using Test
 using Logging
 
+using Base: remove_linenums!
+
 module DeprecationTests # to test @deprecate
     f() = true
 
@@ -108,6 +110,113 @@ global_logger(prev_logger)
 
 #-------------------------------------------------------------------------------
 # BEGIN 0.7 deprecations
+
+@testset "parser syntax deprecations" begin
+    # Test empty logs for meta.parse depwarn argument.
+    @test_logs Meta.parse("1.+2", depwarn=false)
+
+    # #19089
+    @test (@test_deprecated Meta.parse("1.+2")) == :(1 .+ 2)
+
+    # #16356
+    @test (@test_deprecated Meta.parse("0xapi")) == :(0xa * pi)
+
+    # #22523 #22712
+    @test (@test_deprecated Meta.parse("a?b:c"))    == :(a ? b : c)
+    @test (@test_deprecated Meta.parse("a ?b:c"))   == :(a ? b : c)
+    @test (@test_deprecated Meta.parse("a ? b:c"))  == :(a ? b : c)
+    @test (@test_deprecated Meta.parse("a ? b :c")) == :(a ? b : c)
+    @test (@test_deprecated Meta.parse("?")) == Symbol("?")
+
+    # #13079
+    @test (@test_deprecated Meta.parse("1<<2*3")) == :(1<<(2*3))
+
+    # ([#19157], [#20418]).
+    @test remove_linenums!(@test_deprecated Meta.parse("immutable A; end")) ==
+          remove_linenums!(:(struct A; end))
+    @test remove_linenums!(@test_deprecated Meta.parse("type A; end")) ==
+          remove_linenums!(:(mutable struct A; end))
+    @test (@test_deprecated Meta.parse("abstract A")) == :(abstract type A end)
+    @test (@test_deprecated Meta.parse("bitstype 32 A")) == :(primitive type A 32 end)
+
+    # #20500
+    @test (@test_deprecated Meta.parse("typealias A B")) == Expr(:typealias, :A, :B)
+
+    # #19987
+    @test remove_linenums!(@test_deprecated Meta.parse("try ; catch f() ; end")) ==
+          remove_linenums!(:(try ; catch; f() ; end))
+
+    # #15524
+    # @test (@test_deprecated Meta.parse("for a=b f() end")) == :(for a=b; f() end)
+    @test_broken length(Test.collect_test_logs(()->Meta.parse("for a=b f() end"))[1]) > 0
+
+    # #23076
+    @test (@test_deprecated Meta.parse("[a,b;]")) == :([a;b])
+
+    # #24452
+    @test (@test_deprecated Meta.parse("(a...)")) == :((a...,))
+end
+
+
+@testset "lowering syntax deprecations" begin
+    # #16295
+    @test_deprecated Meta.lower(@__MODULE__, :(A.(:+)(a,b) = 1))
+
+    # #11310
+    @test_deprecated r"inner constructor" Meta.lower(@__MODULE__, :(struct A{T}; A() = new(); end))
+    @test_deprecated r"parametric method syntax" Meta.lower(@__MODULE__, :(f{T}(x::T) = 1))
+
+    # #17623
+    @test_deprecated r"Deprecated syntax `function .+(...)`" Meta.lower(@__MODULE__, :(function .+(a,b) ; end))
+
+    # #21774 (more uniform let expressions)
+    @test_deprecated Meta.lower(@__MODULE__, Expr(:let, :a))
+    @test_deprecated Meta.lower(@__MODULE__, Expr(:let, :a, :(a=1), :(b=1)))
+
+    # #23157 (Expression heads for types renamed)
+    @test_deprecated Meta.lower(@__MODULE__, Expr(:type, true, :A, Expr(:block)))
+    @test_deprecated Meta.lower(@__MODULE__, Expr(:bitstype, 32, :A))
+
+    # #15032
+    @test_deprecated Meta.lower(@__MODULE__, :(a.(b) = 1))
+
+    # #20610
+    @test_deprecated Meta.lower(@__MODULE__, Expr(:(=>), :a, :b))
+
+    # #5332
+    @test_deprecated Meta.lower(@__MODULE__, :(a.'))
+
+    # #19324
+    @test_deprecated r"implicit assignment to global" eval(
+           :(module M19324
+                 x=1
+                 for i=1:10
+                     x += i
+                 end
+             end))
+
+    # #24221
+    @test_deprecated r"underscores as an rvalue" Meta.lower(@__MODULE__, :(a=_))
+
+    # #22314
+    @test_deprecated r"Use of final value of loop variable `i`.*is deprecated. In the future the variable will be local to the loop instead." Meta.lower(@__MODULE__, :(
+        function f()
+            i=0
+            for i=1:10
+            end
+            i
+        end))
+    @test_deprecated r"Loop variable `i` overwrites a variable in an enclosing scope" eval(:(
+        module M22314
+            i=10
+            for i=1:10
+            end
+        end))
+
+    # #6080
+    @test_deprecated r"Syntax `&argument`.*is deprecated" Meta.lower(@__MODULE__, :(ccall(:a, Cvoid, (Cint,), &x)))
+
+end
 
 module LogTest
     function bar(io)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -953,7 +953,7 @@ for (line, expr) in Pair[
     "\"...\""      => "...",
     "r\"...\""     => Expr(:macrocall, Symbol("@r_str"), LineNumberNode(1, :none), "...")
     ]
-    @test Docs.helpmode(line) == Expr(:macrocall, Expr(:., Expr(:., :Base, QuoteNode(:Docs)), QuoteNode(Symbol("@repl"))), LineNumberNode(118, doc_util_path), STDOUT, expr)
+    @test Docs.helpmode(line) == Expr(:macrocall, Expr(:., Expr(:., :Base, QuoteNode(:Docs)), QuoteNode(Symbol("@repl"))), LineNumberNode(116, doc_util_path), STDOUT, expr)
     buf = IOBuffer()
     @test eval(Base, Docs.helpmode(buf, line)) isa Union{Base.Markdown.MD,Nothing}
 end
@@ -985,8 +985,8 @@ dynamic_test.x = "test 2"
 @test @doc(dynamic_test) == "test 2 Union{}"
 @test @doc(dynamic_test(::String)) == "test 2 Tuple{String}"
 
-@test Docs._repl(:(dynamic_test(1.0))) == Expr(:escape, Expr(:macrocall, Symbol("@doc"), LineNumberNode(207, doc_util_path), :(dynamic_test(::typeof(1.0)))))
-@test Docs._repl(:(dynamic_test(::String))) == Expr(:escape, Expr(:macrocall, Symbol("@doc"), LineNumberNode(207, doc_util_path), :(dynamic_test(::String))))
+@test Docs._repl(:(dynamic_test(1.0))) == Expr(:escape, Expr(:macrocall, Symbol("@doc"), LineNumberNode(205, doc_util_path), :(dynamic_test(::typeof(1.0)))))
+@test Docs._repl(:(dynamic_test(::String))) == Expr(:escape, Expr(:macrocall, Symbol("@doc"), LineNumberNode(205, doc_util_path), :(dynamic_test(::String))))
 
 
 # Equality testing


### PR DESCRIPTION
This change forwards all frontend depwarn messages through to the new logging system for consistency of formatting and dispatch.

User visible changes:
* Depwarn messages go to the logging system, rather than STDERR
* `Meta.parse()` is given a `depwarn` keyword (see below)

Some detail:

* Tests for all parser and lowering depwarns that I found.
* Ensure that syntax-deprecation, deprecation-message forwards to the logging system.  Split these into distinct functions for depwarns coming from the parser vs lowering, as these extract line number information in a different way.
* Remove jl_parse_depwarn(), replace flisp *depwarn* / *deperror* with simplified *depwarn-opt* handled in one place.
* Replace Base.syntax_deprecation_warnings() with Meta.parse(..., depwarn=false)
* Internal C functions jl_log() and jl_logf() for use when communicating log messages from C code.  These will need to be augmented with an async `jl_safe_log()` or something similar for safe printing from the C code, but that's another PR.