### PR TITLE
implement `sizeof` for `SubArray`

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -57,6 +57,8 @@ size(V::SubArray) = (@_inline_meta; map(n->Int(unsafe_length(n)), axes(V)))
 
 similar(V::SubArray, T::Type, dims::Dims) = similar(V.parent, T, dims)
 
+sizeof(V::SubArray) = length(V) * sizeof(eltype(V))
+
 """
     parent(A)
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -583,3 +583,7 @@ let
     s = view(reshape(1:6, 2, 3), 1:2, 1:2)
     @test @inferred(s[2,2,1]) === 4
 end
+
+@test sizeof(view(zeros(UInt8, 10), 1:4)) == 4
+@test sizeof(view(zeros(UInt8, 10), 1:3)) == 3
+@test sizeof(view(zeros(Float64, 10, 10), 1:3, 2:6)) == 120


### PR DESCRIPTION
This surprised me. Is there any reason not to have this method?
Found while working on #25241.