### PR TITLE
improve UInt-type of octal literals. fix #25216

### DIFF
--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -136,6 +136,12 @@ julia> 0x123456789abcdef
 
 julia> typeof(ans)
 UInt64
+
+julia> 0x11112222333344445555666677778888
+0x11112222333344445555666677778888
+
+julia> typeof(ans)
+UInt128
 ```
 
 This behavior is based on the observation that when one uses unsigned hex literals for integer
@@ -154,11 +160,36 @@ julia> 0b10
 julia> typeof(ans)
 UInt8
 
-julia> 0o10
+julia> 0o010
 0x08
 
 julia> typeof(ans)
 UInt8
+
+julia> 0x00000000000000001111222233334444
+0x00000000000000001111222233334444
+
+julia> typeof(ans)
+UInt128
+```
+
+As for hexadecimal literals, binary and octal literals produce unsigned integer types. The size
+of the binary data item is the minimal needed size, if the leading digit of the literal is not
+`0`. In the case of leading zeros, the size is determined by the minimal needed size for a
+literal, which has the same length but leading digit `1`. That allows the user to control
+the size
+Values, which cannot be stored in `UInt128` cannot be written as such literals.
+
+Binary, octal, and hexadecimal literals may be signed by a `-` immediately preceding the
+unsigned literal. They produce an unsigned integer of the same size as the unsigned literal
+would do, with the two's complement of the value:
+
+```jldoctest
+julia> -0x2
+0xfe
+
+julia> -0x0002
+0xfffe
 ```
 
 The minimum and maximum representable values of primitive numeric types such as integers are given

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -136,6 +136,12 @@ julia> 0x123456789abcdef
 
 julia> typeof(ans)
 UInt64
+
+julia> 0x11112222333344445555666677778888
+0x11112222333344445555666677778888
+
+julia> typeof(ans)
+UInt128
 ```
 
 This behavior is based on the observation that when one uses unsigned hex literals for integer
@@ -154,11 +160,36 @@ julia> 0b10
 julia> typeof(ans)
 UInt8
 
-julia> 0o10
+julia> 0o010
 0x08
 
 julia> typeof(ans)
 UInt8
+
+julia> 0x00000000000000001111222233334444
+0x00000000000000001111222233334444
+
+julia> typeof(ans)
+UInt128
+```
+
+As for hexadecimal literals, binary and octal literals produce unsigned integer types. The size
+of the binary data item is the minimal needed size, if the leading digit of the literal is not
+`0`. In the case of leading zeros, the size is determined by the minimal needed size for a
+literal, which has the same length but leading digit `1`. That allows the user to control
+the size 
+Values, which cannot be stored in `UInt128` cannot be written as such literals.
+
+Binary, octal, and hexadecimal literals may be signed by a `-` immediately preceding the
+unsigned literal. They produce an unsigned integer of the same size as the unsigned literal
+would do, with the two's complement of the value:
+
+```jldoctest
+julia> -0x2
+0xfe
+
+julia> -0x0002
+0xfffe
 ```
 
 The minimum and maximum representable values of primitive numeric types such as integers are given

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -424,8 +424,8 @@
       n))
 
 (define (sized-uint-literal n s b)
-  (let* ((i (if (eqv? (string.char s 0) #\-) 3 2))
-         (l (* (- (length s) i) b)))
+  (let* ((i (if (eqv? (string.char s 0) #\-) 4 3))
+         (l (+ (* (- (length s) i) b) 1)))
     (cond ((<= l 8)   (numchk n s) (uint8  n))
           ((<= l 16)  (numchk n s) (uint16 n))
           ((<= l 32)  (numchk n s) (uint32 n))

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1876,7 +1876,7 @@ end
     @test isa(0o2000000000000000000000000000000000000000000, UInt128)
     @test_throws Meta.ParseError Meta.parse("0o4000000000000000000000000000000000000000000")
 
-    @test String([0o110, 0o145, 0o154, 0o154, 0o157, 0o054, 0o040, 0o127, 0o157, 0o162, 0o154, 0o144, 0o041]) == "Hello World!"
+    @test String([0o110, 0o145, 0o154, 0o154, 0o157, 0o054, 0o040, 0o127, 0o157, 0o162, 0o154, 0o144, 0o041]) == "Hello, World!"
 
 end
 @testset "hexadecimal literals" begin

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1834,7 +1834,6 @@ end
     @test 0o100 == 0x40
     @test 0o1000 == 0x200
     @test 0o724 == 0x1d4
-    @test isa(0o377,UInt8)
     @test isa(0o00,UInt8)
     @test isa(0o000,UInt8)
     @test isa(0o00000,UInt16)
@@ -1860,6 +1859,25 @@ end
     @test_throws Meta.ParseError Meta.parse("0o4000000000000000000000000000000000000000000")
     # remove BigInt unsigned integer literals #11105
     @test_throws Meta.ParseError Meta.parse("0o11111111111111111111111111111111111111111111")
+    @test isa(0o077, UInt8)
+    @test isa(0o377, UInt8)
+    @test isa(0o400, UInt16)
+    @test isa(0o077777, UInt16)
+    @test isa(0o177777, UInt16)
+    @test isa(0o200000, UInt32)
+    @test isa(0o00000000000, UInt32)
+    @test isa(0o17777777777, UInt32)
+    @test isa(0o40000000000, UInt64)
+    @test isa(0o0000000000000000000000, UInt64)
+    @test isa(0o1000000000000000000000, UInt64)
+    @test isa(0o2000000000000000000000, UInt128)
+    @test isa(0o0000000000000000000000000000000000000000000, UInt128)
+    @test isa(0o1000000000000000000000000000000000000000000, UInt128)
+    @test isa(0o2000000000000000000000000000000000000000000, UInt128)
+    @test_throws Meta.ParseError Meta.parse("0o4000000000000000000000000000000000000000000")
+
+    @test String([0o110, 0o145, 0o154, 0o154, 0o157, 0o054, 0o040, 0o127, 0o157, 0o162, 0o154, 0o144, 0o041]) == "Hello World!"
+
 end
 @testset "hexadecimal literals" begin
     @test isa(0x00,UInt8)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1836,16 +1836,16 @@ end
     @test 0o724 == 0x1d4
     @test isa(0o377,UInt8)
     @test isa(0o00,UInt8)
-    @test isa(0o000,UInt16)
+    @test isa(0o000,UInt8)
     @test isa(0o00000,UInt16)
-    @test isa(0o000000,UInt32)
+    @test isa(0o000000,UInt16)
     @test isa(0o0000000000,UInt32)
-    @test isa(0o00000000000,UInt64)
+    @test isa(0o00000000000,UInt32)
     @test isa(0o000000000000000000000,UInt64)
-    @test isa(0o0000000000000000000000,UInt128)
+    @test isa(0o0000000000000000000000,UInt64)
     @test isa(0o000000000000000000000000000000000000000000,UInt128)
     # remove BigInt unsigned integer literals #11105
-    @test_throws Meta.ParseError Meta.parse("0o0000000000000000000000000000000000000000000")
+    @test_throws Meta.ParseError Meta.parse("0o00000000000000000000000000000000000000000000")
     @test isa(0o11,UInt8)
     @test isa(0o111,UInt8)
     @test isa(0o11111,UInt16)
@@ -1856,6 +1856,8 @@ end
     @test isa(0o1111111111111111111111,UInt64)
     @test isa(0o111111111111111111111111111111111111111111,UInt128)
     @test isa(0o1111111111111111111111111111111111111111111,UInt128)
+    @test isa(0o3777777777777777777777777777777777777777777,UInt128)
+    @test_throws Meta.ParseError Meta.parse("0o4000000000000000000000000000000000000000000")
     # remove BigInt unsigned integer literals #11105
     @test_throws Meta.ParseError Meta.parse("0o11111111111111111111111111111111111111111111")
 end


### PR DESCRIPTION
The minimal amount of bits required for the binary representation of a number literal with a leading zero, like `0abc` is the same as the minimal amount of bits required to store `1xyz`.
Here `xyz` is an arbitrary sequence of digits of the chosen base `b` ∈ {2,8,16}.
The behaviour is changed only if `b == 8` and resolves https://github.com/JuliaLang/julia/issues/25216