### PR TITLE
intfuncs: short-circuit gcd

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -79,8 +79,18 @@ lcm(a::Integer, b::Integer) = lcm(promote(a,b)...)
 gcd(a::Integer, b::Integer...) = gcd(a, gcd(b...))
 lcm(a::Integer, b::Integer...) = lcm(a, lcm(b...))
 
-gcd(abc::AbstractArray{<:Integer}) = reduce(gcd,abc)
 lcm(abc::AbstractArray{<:Integer}) = reduce(lcm,abc)
+
+function gcd(abc::AbstractArray{<:Integer})
+    a = zero(eltype(abc))
+    for b in abc
+        a = gcd(a,b)
+        if a == 1
+            return a
+        end
+    end
+    return a
+end
 
 # return (gcd(a,b),x,y) such that ax+by == gcd(a,b)
 """

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -79,7 +79,7 @@ lcm(a::Integer, b::Integer) = lcm(promote(a,b)...)
 gcd(a::Integer, b::Integer...) = gcd(a, gcd(b...))
 lcm(a::Integer, b::Integer...) = lcm(a, lcm(b...))
 
-lcm(abc::AbstractArray{<:Integer}) = reduce(lcm,abc)
+lcm(abc::AbstractArray{<:Integer}) = reduce(lcm,one(eltype(abc)),abc)
 
 function gcd(abc::AbstractArray{<:Integer})
     a = zero(eltype(abc))

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -43,7 +43,7 @@ end
         @test gcd(T[0, 15]) === T(15)
         @test gcd(T[3,-15]) === T(3)
         @test gcd(T[-3,-15]) === T(3)
-        @test gcd(T(0, 0)) === T(0)
+        @test gcd(T[0, 0]) === T(0)
 
         @test gcd(T[2, 4, 6]) === T(2)
         @test gcd(T[2, 4, 3, 5]) === T(1)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -35,6 +35,20 @@
         @test_throws OverflowError lcm(typemin(T), typemin(T))
     end
 end
+@testset "gcd for arrays" begin
+    for T in (Int32, Int64)
+        @test gcd(T[]) === T(0)
+        @test gcd(T[3, 5]) === T(1)
+        @test gcd(T[3, 15]) === T(3)
+        @test gcd(T[0, 15]) === T(15)
+        @test gcd(T[3,-15]) === T(3)
+        @test gcd(T[-3,-15]) === T(3)
+        @test gcd(T(0, 0)) === T(0)
+
+        @test gcd(T[2, 4, 6]) === T(2)
+        @test gcd(T[2, 4, 3, 5]) === T(1)
+    end
+end
 @testset "gcdx" begin
     @test gcdx(5, 12) == (1, 5, -2)
     @test gcdx(5, -12) == (1, 5, 2)

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -35,7 +35,7 @@
         @test_throws OverflowError lcm(typemin(T), typemin(T))
     end
 end
-@testset "gcd for arrays" begin
+@testset "gcd/lcm for arrays" begin
     for T in (Int32, Int64)
         @test gcd(T[]) === T(0)
         @test gcd(T[3, 5]) === T(1)
@@ -47,6 +47,17 @@ end
 
         @test gcd(T[2, 4, 6]) === T(2)
         @test gcd(T[2, 4, 3, 5]) === T(1)
+
+        @test lcm(T[]) === T(1)
+        @test lcm(T[2]) === T(2)
+        @test lcm(T[2, 3]) === T(6)
+        @test lcm(T[4, 6]) === T(12)
+        @test lcm(T[3, 0]) === T(0)
+        @test lcm(T[0, 0]) === T(0)
+        @test lcm(T[4, -6]) === T(12)
+        @test lcm(T[-4, -6]) === T(12)
+
+        @test lcm(T[2, 4, 6]) === T(12)
     end
 end
 @testset "gcdx" begin


### PR DESCRIPTION
When one argument to gcd is equal to 1, the result is fixed and there is no need to compute the rest.

This makes an enormous difference on random vectors of integers:

    julia> A = BigInt.(rand(Int, 2<<22));

    julia> gcd(A); @time gcd(A)
      0.404063 seconds (16.78 M allocations: 448.000 MiB)
    1

    julia> _gcd(A) = (res=zero(eltype(A)); for a in A; res=gcd(res,a); if res == 1 return res; end; end; return res)
    _gcd (generic function with 1 method)

    julia> _gcd(A); @time _gcd(A)
      0.000028 seconds (38 allocations: 1.086 KiB)
    1

but that's probably not a fair representation of real-world impact, as no such improvement is to be expected unless we reach 1 very quickly. A random vector will do that in very few iterations.