### PR TITLE
remove legacy at-pure annotation from linalg/adjtrans

### DIFF
--- a/base/linalg/adjtrans.jl
+++ b/base/linalg/adjtrans.jl
@@ -23,7 +23,7 @@ struct Transpose{T,S} <: AbstractMatrix{T}
     end
 end
 
-@pure function checkeltype(::Type{Transform}, ::Type{ResultEltype}, ::Type{ParentEltype}) where {Transform, ResultEltype, ParentEltype}
+function checkeltype(::Type{Transform}, ::Type{ResultEltype}, ::Type{ParentEltype}) where {Transform, ResultEltype, ParentEltype}
     if ResultEltype !== transformtype(Transform, ParentEltype)
         error(string("Element type mismatch. Tried to create an `$Transform{$ResultEltype}` ",
             "from an object with eltype `$ParentEltype`, but the element type of the ",


### PR DESCRIPTION
This pull request removes the problematic legacy `@pure` annotation from linalg/adjtrans.jl. This branch passes the linalg, sparse, stdlib/IterativeEigensolvers, and stdlib/SuiteSparse test suites locally, so hopefully CI will also approve. Resolves JuliaLang/LinearAlgebra.jl#495 (no longer segfaults) and JuliaLang/julia#25271 (also no longer segfaults).  Also ref. https://github.com/JuliaLang/julia/pull/25268#issuecomment-353894158 and https://github.com/JuliaLang/julia/pull/25265#issuecomment-353990473. Best! :)