### PR TITLE
Change output of dump(T)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1595,8 +1595,6 @@ end
 const DUMP_DEFAULT_MAXDEPTH = 8
 # For abstract types, use _dumptype only if it's a form that will be called
 # interactively.
-dump(io::IO, x::DataType; maxdepth=DUMP_DEFAULT_MAXDEPTH) = ((x.abstract ? dumptype : dump)(io, x, maxdepth, ""); println(io))
-
 dump(io::IO, arg; maxdepth=DUMP_DEFAULT_MAXDEPTH) = (dump(io, arg, maxdepth, ""); println(io))
 
 """

--- a/test/show.jl
+++ b/test/show.jl
@@ -750,20 +750,13 @@ end
 let repr = sprint(dump, Int64)
     @test repr == "Int64 <: Signed\n"
 end
-# Make sure a `TypeVar` in a `Union` doesn't break subtype dump.
-BreakDump17529{T} = Union{T, Nothing}
-# make sure dependent parameters are represented correctly
-VectorVI{I, VI<:AbstractVector{I}} = Vector{VI}
 let repr = sprint(dump, Any)
-    @test length(repr) > 100000
-    @test ismatch(r"^Any\n  [^ \t\n]", repr)
+    @test length(repr) == 4
+    @test ismatch(r"^Any\n", repr)
     @test endswith(repr, '\n')
-    @test contains(repr, "     Base.Vector{T} = Array{T,1}\n")
-    @test contains(repr, ".VectorVI{I, VI<:AbstractArray{I,1}} = Array{VI,1}\n")
-    @test !contains(repr, "Core.Vector{T}")
 end
 let repr = sprint(dump, Integer)
-    @test contains(repr, "UInt128")
+    @test contains(repr, "Integer <: Real")
     @test !contains(repr, "Any")
 end
 let repr = sprint(dump, Union{Integer, Float32})


### PR DESCRIPTION
Fixes #24812

This commit removes the specialized function for DataType. The following is the behavior after this patch

```julia
./julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.7.0-DEV.3187 (2017-12-26 16:45 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 1a6e34bb1b* (0 days old master)
|__/                   |  x86_64-apple-darwin17.3.0

julia> dump(AbstractString)
AbstractString <: Any

julia> dump(Number)
Number <: Any

julia> dump(Int64)
Int64 <: Signed

julia> struct MyStruct
                  x
                  y
              end

julia> dump(MyStruct)
MyStruct <: Any
  x::Any
  y::Any

julia> struct MyTypedStruct
                  x::String
                  y::Int
              end

julia> dump(MyTypedStruct)
MyTypedStruct <: Any
  x::String
  y::Int64

julia> dump(MyTypedStruct("Hello", 1))
MyTypedStruct
  x: String "Hello"
  y: Int64 1
```