### PR TITLE
add rand(::Tuple)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ Standard library changes
   * `Base.tail` now works on named tuples ([#29595]).
   * `randperm` and `randcycle` now use the type of their argument to determine the element type of
     the returned array ([#29670]).
+  * A new method `rand(::Tuple)` implements sampling from the values of a tuple ([#25278]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -217,6 +217,8 @@ rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 #### scalars
 
 rand(rng::AbstractRNG, X)                                      = rand(rng, Sampler(rng, X, Val(1)))
+# this is needed to disambiguate
+rand(rng::AbstractRNG, X::Dims)                                = rand(rng, Sampler(rng, X, Val(1)))
 rand(rng::AbstractRNG=GLOBAL_RNG, ::Type{X}=Float64) where {X} = rand(rng, Sampler(rng, X, Val(1)))
 
 rand(X)                   = rand(GLOBAL_RNG, X)
@@ -249,9 +251,6 @@ rand(                X, d::Integer, dims::Integer...) = rand(X, Dims((d, dims...
 # rand(r, ()) would match both this method and rand(r, dims::Dims)
 # moreover, a call like rand(r, NotImplementedType()) would be an infinite loop
 
-# this is needed to disambiguate
-rand(r::AbstractRNG, dims::Dims) = error("rand(rng, dims) is discontinued; try rand(rng, Float64, dims)")
-
 rand(r::AbstractRNG, ::Type{X}, dims::Dims) where {X} = rand!(r, Array{X}(undef, dims), X)
 rand(                ::Type{X}, dims::Dims) where {X} = rand(GLOBAL_RNG, X, dims)
 
@@ -283,7 +282,7 @@ include("misc.jl")
 Pick a random element or array of random elements from the set of values specified by `S`;
 `S` can be
 
-* an indexable collection (for example `1:n` or `['x','y','z']`),
+* an indexable collection (for example `1:9` or `('x', "y", :z)`),
 * an `AbstractDict` or `AbstractSet` object,
 * a string (considered as a collection of characters), or
 * a type: the set of values to pick from is then equivalent to `typemin(S):typemax(S)` for

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -702,3 +702,14 @@ end
     a = rand(Int, 1)
     @test shuffle(a) == a
 end
+
+@testset "rand(::Tuple)" begin
+    for x in (0x1, 1)
+        @test rand((x,)) == 0x1
+        @test rand((x, 2)) ∈ 1:2
+        @test rand((x, 2, 3)) ∈ 1:3
+        @test rand((x, 2, 3, 4)) ∈ 1:4
+        @test rand((x, 2, 3, 4, 5)) ∈ 1:5
+        @test rand((x, 2, 3, 4, 6)) ∈ 1:6
+    end
+end

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 import LinearAlgebra: checksquare
+using Random: rand!
 
 ## sparse matrix multiplication
 
@@ -929,12 +930,6 @@ function opnormestinv(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A))
 
     S = zeros(T <: Real ? Int : Ti, n, t)
 
-    function _rand_pm1!(v)
-        for i in eachindex(v)
-            v[i] = rand()<0.5 ? 1 : -1
-        end
-    end
-
     function _any_abs_eq(v,n::Int)
         for vv in v
             if abs(vv)==n
@@ -949,7 +944,7 @@ function opnormestinv(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A))
     X[1:n,1] .= 1
     for j = 2:t
         while true
-            _rand_pm1!(view(X,1:n,j))
+            rand!(view(X,1:n,j), (-1, 1))
             yaux = X[1:n,j]' * X[1:n,1:j-1]
             if !_any_abs_eq(yaux,n)
                 break
@@ -1010,7 +1005,7 @@ function opnormestinv(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A))
                         end
                     end
                     if repeated
-                        _rand_pm1!(view(S,1:n,j))
+                        rand!(view(S,1:n,j), (-1, 1))
                     else
                         break
                     end


### PR DESCRIPTION
PR based on #24874, only 2 new commits here.

Knowing the length a compile time gives a big advantage to something like `rand(('a', 'b'))` over `rand(['a', 'b'])` (many times faster). This PR implements optimizations for tuples up to length 4, but it could easily be extended. The second commit here shows a use case for this, and I also need that occasionally in my programs. 

But this raise one question: what to do for `rand((1, 2, 3))`. Currently, this calls the array contructor. So it would be a bit inconsistent to have `rand(::Tuple)` give a scalar except when the tuple is of type `Dims`. I see few possiblities about this:
+ live with this small gotcha
+ make `Dims` a dedicated types, instead of an alias for tuples of `Int`. This is a big change, unlikely to happen for 1.0. But I guess most of the time you get a `Dims` object by calling `size` on an array, so it doesn't seem to be a no-go in usability.
+ if we go with #24912, we could have either `rand(Array, (1, 2, 3))` or `rand(1, 2, 3)` for the construction of an array, i.e. if the size is specified as a tuple, you get to give `Array` as a parameter. 
+ wait and see if the array versions of `rand` are disabled, in favor of a `Vector` constructor (with a `Rand` iterator).
+ changing `rand` to require specifying the type of generated value (currently `Float64` is the default) (EDITED)

Thoughts?