### PR TITLE
make code_warntype and co work with unlowered form of getproperty and setproperty!

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -431,6 +431,12 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
         elseif ex0.head == :call
             return Expr(:call, fcn, esc(ex0.args[1]),
                         Expr(:call, typesof, map(esc, ex0.args[2:end])...))
+        elseif ex0.head == :(.)
+            return Expr(:call, fcn, :getproperty,
+                        Expr(:call, typesof, map(esc, ex0.args)...))
+        elseif ex0.head == :(=) && length(ex0.args) == 2 && ex0.args[1].head == :(.)
+            return Expr(:call, fcn, :(setproperty!),
+                        Expr(:call, typesof, map(esc, [ex0.args[1].args..., ex0.args[2]])...))
         end
     end
     if isa(ex0, Expr) && ex0.head == :macrocall # Make @edit @time 1+2 edit the macro by using the types of the *expressions*

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -97,6 +97,15 @@ has_unused() = (a = rand(5))
 @test !warntype_hastag(has_unused, Tuple{}, tag)
 @test warntype_hastag(has_unused, Tuple{}, "<optimized out>")
 
+# Make sure getproperty and setproperty! works with warntype
+struct T1234321
+    t::Int
+end
+Base.getproperty(t::T1234321, ::Symbol) = "foo"
+@test (@code_typed T1234321(1).f).second == String
+Base.setproperty!(t::T1234321, ::Symbol, ::Symbol) = "foo"
+@test (@code_typed T1234321(1).f = :foo).second == String
+
 module ImportIntrinsics15819
 # Make sure changing the lookup path of an intrinsic doesn't break
 # the heuristic for type instability warning.


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/25193

```jl
julia> struct T end

julia> Base.getproperty(t::T,s::Symbol)="blah"

julia> @code_lowered T().test
CodeInfo(:(begin
      nothing
      return "blah"
  end))
```