### PR TITLE
fix terminal rendering of markdown tables

### DIFF
--- a/base/markdown/GitHub/table.jl
+++ b/base/markdown/GitHub/table.jl
@@ -138,7 +138,7 @@ function rst(io::IO, md::Table)
 end
 
 function term(io::IO, md::Table, columns)
-    cells = mapmap(terminline, md.rows)
+    cells = mapmap(x -> terminline_string(io, x), md.rows)
     padcells!(cells, md.align, len = ansi_length)
     for i = 1:length(cells)
         join(io, cells[i], " ")

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -1072,3 +1072,10 @@ let buf = IOBuffer()
     show(IOContext(buf, :color=>true), "text/plain", md"*emph*")
     @test String(take!(buf)) == "  \e[4memph\e[24m\n"
 end
+
+# table rendering with term #25213
+t = """
+    a   |   b
+    :-- | --:
+    1   |   2"""
+@test sprint(Markdown.term, Markdown.parse(t), 0) == "a b\n– –\n1 2\n"


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/25213

Regressed in https://github.com/JuliaLang/julia/pull/25067/commits/4b04cfe5bc2206bcdba93580078ec4d711c821bb cc @stevengj 

```
julia> varinfo(Main)
name                 size summary
–––––––––––––– –––––––––– –––––––
Base                      Module
Core                      Module
DelimitedFiles 92.050 KiB Module
Main                      Module
ans               0 bytes Nothing
```