### PR TITLE
keep non deprecated symbols when finding help completions, instead, filter out deprecated symbols

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -364,7 +364,7 @@ moduleusings(mod) = ccall(:jl_module_usings, Any, (Any,), mod)
 filtervalid(names) = filter(x->!ismatch(r"#", x), map(string, names))
 
 accessible(mod::Module) =
-    [filter!(s->Base.isdeprecated(mod, s), names(mod, true, true));
+    [filter!(s -> !Base.isdeprecated(mod, s), names(mod, true, true));
      map(names, moduleusings(mod))...;
      builtins] |> unique |> filtervalid
 

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1082,3 +1082,7 @@ catch e
 end
     @test ex.line == 2
 end
+
+struct t_docs_abc end
+@test "t_docs_abc" in Docs.accessible(@__MODULE__)
+


### PR DESCRIPTION
It seems https://github.com/JuliaLang/julia/issues/17140 missed a negation here causing all symbols that where **not** deprecated to be filtered out in the help completion search.

Example:

Setup:
```
julia> struct Foo end

julia> struct Foobar end
```

Before PR:

```
help?> Foo
search: floor pointer_from_objref ...
```

After PR:
```
help?> Foo
search: Foo Foobar floor ... 
```