### PR TITLE
guard against LAPACK least squares solver test failure

### DIFF
--- a/test/linalg/lapack.jl
+++ b/test/linalg/lapack.jl
@@ -141,11 +141,11 @@ end
 
 @testset "gelsy, gelsd" begin
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
-        A = rand(elty,10,10)
-        B = rand(elty,10,10)
+        A = rand(elty, 10, 10)
+        B = rand(elty, 10, 10)
         C, j = LAPACK.gelsd!(copy(A),copy(B))
         D, k = LAPACK.gelsy!(copy(A),copy(B))
-        @test C ≈ D
+        @test C ≈ D rtol=eps(cond(A))
         @test_throws DimensionMismatch LAPACK.gelsd!(A,rand(elty,12,10))
         @test_throws DimensionMismatch LAPACK.gelsy!(A,rand(elty,12,10))
     end


### PR DESCRIPTION
Modify a LAPACK least squares solver test to guard against chance failure due to poor conditioning of the test matrices. Failure identified by @vtjnash in https://ci.appveyor.com/project/JuliaLang/julia/build/1.0.22839/job/gam4o5u92uhi6e5j. Best!

(Did I make the test matrices too well conditioned again, Andreas? 😉)