### PR TITLE
make print_with_color emit starting and terminating ANSI sequences on each line

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -41,6 +41,7 @@ const disable_text_style = AnyDict(
     :hidden    => "\033[28m",
     :normal    => "",
     :default   => "",
+    :nothing   => "",
 )
 
 # Create a docstring with an automatically generated list

--- a/base/util.jl
+++ b/base/util.jl
@@ -328,18 +328,17 @@ function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args.
         else
             lines = split(str, '\n')
             first = true
-            iob = IOBuffer()
             for line in lines
-                first || print(iob, '\n')
+                first || print(buf, '\n')
                 first = false
                 isempty(line) && continue
-                iscolor && bold && print(iob, text_colors[:bold])
-                iscolor && print(iob, get(text_colors, color, color_normal))
-                print(iob, line)
-                iscolor && color != :nothing && print(iob, get(disable_text_style, color, text_colors[:default]))
-                iscolor && (bold || color == :bold) && print(iob, disable_text_style[:bold])
+                bold && color != :bold && print(buf, text_colors[:bold])
+                print(buf, get(text_colors, color, color_normal))
+                print(buf, line)
+                color != :nothing && print(buf, get(disable_text_style, color, text_colors[:default]))
+                bold && color != :bold && print(buf, disable_text_style[:bold])
             end
-            print(io, String(take!(iob)))
+            print(io, String(take!(buf)))
         end
     end
 end

--- a/base/util.jl
+++ b/base/util.jl
@@ -326,17 +326,18 @@ function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args.
         if !iscolor
             print(io, str)
         else
+            bold && color == :bold && (color = :nothing)
+            enable_ansi  = get(text_colors, color, text_colors[:default]) *
+                               (bold ? text_colors[:bold] : "")
+            disable_ansi = get(disable_text_style, color, text_colors[:default]) *
+                               (bold ? disable_text_style[:bold] : "")
             lines = split(str, '\n')
             first = true
             for line in lines
                 first || print(buf, '\n')
                 first = false
                 isempty(line) && continue
-                bold && color != :bold && print(buf, text_colors[:bold])
-                print(buf, get(text_colors, color, color_normal))
-                print(buf, line)
-                color != :nothing && print(buf, get(disable_text_style, color, text_colors[:default]))
-                bold && color != :bold && print(buf, disable_text_style[:bold])
+                print(buf, enable_ansi, line, disable_ansi)
             end
             print(io, String(take!(buf)))
         end

--- a/base/util.jl
+++ b/base/util.jl
@@ -329,11 +329,10 @@ function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args.
             bold && color == :bold && (color = :nothing)
             enable_ansi  = get(text_colors, color, text_colors[:default]) *
                                (bold ? text_colors[:bold] : "")
-            disable_ansi = get(disable_text_style, color, text_colors[:default]) *
-                               (bold ? disable_text_style[:bold] : "")
-            lines = split(str, '\n')
+            disable_ansi = (bold ? disable_text_style[:bold] : "") *
+                               get(disable_text_style, color, text_colors[:default])
             first = true
-            for line in lines
+            for line in split(str, '\n')
                 first || print(buf, '\n')
                 first = false
                 isempty(line) && continue

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -472,6 +472,14 @@ let buf_color = IOBuffer()
     @test expected_str == String(take!(buf_color))
 end
 
+# Test that `print_with_color` on multiline input prints the ANSI codes
+# on each line
+let buf_color = IOBuffer()
+    str = "Two\nlines"
+    print_with_color(:red, IOContext(buf_color, :color=>true), str; bold=true)
+    @test String(take!(buf_color)) == "\e[1m\e[31mTwo\e[39m\e[22m\n\e[1m\e[31mlines\e[39m\e[22m"
+end
+
 if STDOUT isa Base.TTY
     @test haskey(STDOUT, :color) == true
     @test haskey(STDOUT, :bar) == false

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -477,7 +477,7 @@ end
 let buf_color = IOBuffer()
     str = "Two\nlines"
     print_with_color(:red, IOContext(buf_color, :color=>true), str; bold=true)
-    @test String(take!(buf_color)) == "\e[1m\e[31mTwo\e[39m\e[22m\n\e[1m\e[31mlines\e[39m\e[22m"
+    @test String(take!(buf_color)) == "\e[31m\e[1mTwo\e[22m\e[39m\n\e[31m\e[1mlines\e[22m\e[39m"
 end
 
 if STDOUT isa Base.TTY
@@ -508,7 +508,7 @@ let buf = IOBuffer()
 
     # Check that boldness is turned off
     print_with_color(:red, buf_color, "foo"; bold = true)
-    @test String(take!(buf)) == "\e[1m\e[31mfoo\e[39m\e[22m"
+    @test String(take!(buf)) == "\e[31m\e[1mfoo\e[22m\e[39m"
 end
 
 abstract type DA_19281{T, N} <: AbstractArray{T, N} end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -12,8 +12,8 @@ Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, 1, "")))
 @test String(take!(buf)) == "\nClosest candidates are:\n  method_c1(!Matched::Float64, !Matched::AbstractString...)$cfile$c1line"
 @test length(methods(method_c1)) <= 3 # because of '...' in candidate printing
 Base.show_method_candidates(IOContext(buf, :color => true), Base.MethodError(method_c1,(1, 1, "")))
-@test String(take!(buf)) == "\e[0m\nClosest candidates are:\n  method_c1(\e[91m::Float64\e[39m, \e[91m::AbstractString...\e[39m)$cfile$c1line"
 
+@test String(take!(buf)) == "\n\e[0mClosest candidates are:\n\e[0m  method_c1(\e[91m::Float64\e[39m, \e[91m::AbstractString...\e[39m)$cfile$c1line"
 Base.show_method_candidates(buf, Base.MethodError(method_c1,(1, "", "")))
 @test String(take!(buf)) == "\nClosest candidates are:\n  method_c1(!Matched::Float64, ::AbstractString...)$cfile$c1line"
 


### PR DESCRIPTION
This is useful if you for example want to print something before each line of colored text.

For example:

```
function boxify(io, str)
	lines = split(str, '\n')
	for (i, line) in enumerate(lines)
		i == 1 || print(io, '\n')
		if length(lines) == 1
			print(io, "[ ")
		elseif i == 1
			print(io, "┌ ")
		elseif i == length(lines)
			print(io, "└ ")
		else
			print(io, "│ ")
		end
		print(io, line)
	end
end

str = """
This is a string
that has many lines
we will print it
in color"""

io = IOBuffer(); print_with_color(:red, IOContext(io, :color => true), str)
str_colored = String(take!(io));
boxify(STDOUT, str_colored)
```

Before this PR this will show

<img width="266" alt="screen shot 2017-12-27 at 23 53 31" src="https://user-images.githubusercontent.com/1282691/34395837-0d942122-eb64-11e7-9747-304ba6686851.png">

now it shows:

<img width="256" alt="screen shot 2017-12-27 at 23 52 55" src="https://user-images.githubusercontent.com/1282691/34395835-0b80e0c8-eb64-11e7-8ae5-4cd9e928bad7.png">


