### PR TITLE
decouple kwargs performance improvement from API changes

### DIFF
--- a/base/coreimg.jl
+++ b/base/coreimg.jl
@@ -57,6 +57,7 @@ include("reduce.jl")
 include("bitarray.jl")
 include("bitset.jl")
 include("abstractdict.jl")
+include("iterators.jl")
 include("namedtuple.jl")
 
 # core docsystem

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -425,7 +425,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
             return quote
                 local arg1 = $(esc(args[1]))
                 $(fcn)(Core.kwfunc(arg1),
-                       Tuple{NamedTuple, Core.Typeof(arg1),
+                       Tuple{Any, Core.Typeof(arg1),
                              $(typesof)($(map(esc, args[2:end])...)).parameters...})
             end
         elseif ex0.head == :call

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -5,15 +5,20 @@ Methods for working with Iterators.
 """
 module Iterators
 
-import Base:
+# small dance to make this work from Base or Intrinsics
+import ..@__MODULE__, ..module_parent
+const Base = module_parent(@__MODULE__)
+using .Base:
+    @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
+    tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,
+    IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds, Generator, AbstractRange
+
+import .Base:
     start, done, next, first, last,
     isempty, length, size, axes, ndims,
     eltype, iteratorsize, iteratoreltype,
     haskey, keys, values, pairs,
     getindex, setindex!, get
-
-using Base: tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,
-            IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds, Generator, AbstractRange
 
 export enumerate, zip, rest, countfrom, take, drop, cycle, repeated, product, flatten, partition
 
@@ -222,7 +227,7 @@ size(v::IndexValue)    = size(v.itr)
 @propagate_inbounds function next(v::IndexValue, state)
     indx, n = next(v.itr, state)
     item = v.data[indx]
-    (indx => item), n
+    return (Pair(indx, item), n)
 end
 @inline done(v::IndexValue, state) = done(v.itr, state)
 

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -75,7 +75,7 @@ function arg_decl_parts(m::Method)
 end
 
 function kwarg_decl(m::Method, kwtype::DataType)
-    sig = rewrap_unionall(Tuple{kwtype, NamedTuple, unwrap_unionall(m.sig).parameters...}, m.sig)
+    sig = rewrap_unionall(Tuple{kwtype, Any, unwrap_unionall(m.sig).parameters...}, m.sig)
     kwli = ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), kwtype.name.mt, sig, typemax(UInt))
     if kwli !== nothing
         kwli = kwli::Method

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -322,7 +322,7 @@ function showerror(io::IO, ex::MethodError)
     ft = typeof(f)
     name = ft.name.mt.name
     f_is_function = false
-    kwargs = NamedTuple()
+    kwargs = ()
     if startswith(string(ft.name.name), "#kw#")
         f = ex.args[2]
         ft = typeof(f)
@@ -372,7 +372,7 @@ function showerror(io::IO, ex::MethodError)
         end
         if !isempty(kwargs)
             print(io, "; ")
-            for (i, (k, v)) in enumerate(pairs(kwargs))
+            for (i, (k, v)) in enumerate(kwargs)
                 print(io, k, "=")
                 show(IOContext(io, :limit => true), v)
                 i == length(kwargs) || print(io, ", ")
@@ -452,7 +452,7 @@ function showerror_nostdio(err, msg::AbstractString)
     ccall(:jl_printf, Cint, (Ptr{Cvoid},Cstring), stderr_stream, "\n")
 end
 
-function show_method_candidates(io::IO, ex::MethodError, kwargs::NamedTuple = NamedTuple())
+function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=())
     is_arg_types = isa(ex.args, DataType)
     arg_types = is_arg_types ? ex.args : typesof(ex.args...)
     arg_types_param = Any[arg_types.parameters...]
@@ -583,7 +583,7 @@ function show_method_candidates(io::IO, ex::MethodError, kwargs::NamedTuple = Na
                 if !isempty(kwargs)
                     unexpected = Symbol[]
                     if isempty(kwords) || !(any(endswith(string(kword), "...") for kword in kwords))
-                        for (k, v) in pairs(kwargs)
+                        for (k, v) in kwargs
                             if !(k in kwords)
                                 push!(unexpected, k)
                             end

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -483,8 +483,8 @@ const valid_opts = [:header, :has_header, :use_mmap, :quotes, :comments, :dims, 
 const valid_opt_types = [Bool, Bool, Bool, Bool, Bool, NTuple{2,Integer}, Char, Integer, Bool]
 
 function val_opts(opts)
-    d = Dict{Symbol,Union{Bool,NTuple{2,Integer},Char,Integer}}()
-    for (opt_name, opt_val) in pairs(opts)
+    d = Dict{Symbol, Union{Bool, NTuple{2, Integer}, Char, Integer}}()
+    for (opt_name, opt_val) in opts
         in(opt_name, valid_opts) ||
             throw(ArgumentError("unknown option $opt_name"))
         opt_typ = valid_opt_types[findfirst(equalto(opt_name), valid_opts)]

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -369,7 +369,7 @@ function addprocs(manager::ClusterManager; kwargs...)
 end
 
 function addprocs_locked(manager::ClusterManager; kwargs...)
-    params = merge(default_addprocs_params(), AnyDict(pairs(kwargs)))
+    params = merge(default_addprocs_params(), AnyDict(kwargs))
     topology(Symbol(params[:topology]))
 
     if PGRP.topology != :all_to_all

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -101,7 +101,7 @@ f25130()
 testlogs = testlogger.logs
 @test length(testlogs) == 2
 @test testlogs[1].id != testlogs[2].id
-@test testlogs[1].kwargs.caller.func == Symbol("top-level scope")
+@test testlogs[1].kwargs[:caller].func == Symbol("top-level scope")
 @test all(l.message == "f25130 message" for l in testlogs)
 global_logger(prev_logger)
 

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -188,7 +188,7 @@ function test4974(;kwargs...)
     end
 end
 
-@test test4974(a=1) == (2, (a=1,))
+@test test4974(a=1) == (2, pairs((a=1,)))
 
 @testset "issue #7704, computed keywords" begin
     @test kwf1(1; :tens => 2) == 21
@@ -300,11 +300,11 @@ end
         counter += 1
         return counter
     end
-    f(args...; kws...) = (args, kws)
+    f(args...; kws...) = (args, values(kws))
     @test f(get_next(), a=get_next(), get_next(),
             b=get_next(), get_next(),
             [get_next(), get_next()]...; c=get_next(),
             (d = get_next(), f = get_next())...) ==
-                ((1,3,5,6,7),
+                ((1, 3, 5, 6, 7),
                  (a = 2, b = 4, c = 8, d = 9, f = 10))
 end

--- a/test/replutil.jl
+++ b/test/replutil.jl
@@ -114,18 +114,18 @@ error_out3 = String(take!(buf))
 
 c7line = @__LINE__() + 1
 method_c7(a, b; kargs...) = a
-Base.show_method_candidates(buf, MethodError(method_c7, (1, 1)), (x = 1, y = 2))
+Base.show_method_candidates(buf, MethodError(method_c7, (1, 1)), pairs((x = 1, y = 2)))
 @test String(take!(buf)) == "\nClosest candidates are:\n  method_c7(::Any, ::Any; kargs...)$cfile$c7line"
 c8line = @__LINE__() + 1
 method_c8(a, b; y=1, w=1) = a
-Base.show_method_candidates(buf, MethodError(method_c8, (1, 1)), (x = 1, y = 2, z = 1, w = 1))
+Base.show_method_candidates(buf, MethodError(method_c8, (1, 1)), pairs((x = 1, y = 2, z = 1, w = 1)))
 @test String(take!(buf)) == "\nClosest candidates are:\n  method_c8(::Any, ::Any; y, w)$cfile$c8line got unsupported keyword arguments \"x\", \"z\""
 
 ac15639line = @__LINE__
 addConstraint_15639(c::Int32) = c
 addConstraint_15639(c::Int64; uncset=nothing) = addConstraint_15639(Int32(c), uncset=uncset)
 
-Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), (uncset = nothing,))
+Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), pairs((uncset = nothing,)))
 @test String(take!(buf)) == "\nClosest candidates are:\n  addConstraint_15639(::Int32)$cfile$(ac15639line + 1) got unsupported keyword argument \"uncset\"\n  addConstraint_15639(!Matched::Int64; uncset)$cfile$(ac15639line + 2)"
 
 macro except_str(expr, err_type)
@@ -499,7 +499,7 @@ foo_9965(x::Int) = 2x
     end
     @test typeof(ex) == MethodError
     io = IOBuffer()
-    Base.show_method_candidates(io, ex, (w = true,))
+    Base.show_method_candidates(io, ex, pairs((w = true,)))
     @test contains(String(take!(io)), "got unsupported keyword argument \"w\"")
 end
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -837,7 +837,7 @@ let f = function (x; kw...)
     g = function (x; a = 2)
             return (x, a)
         end
-    @test f(1) == (1, NamedTuple())
+    @test f(1) == (1, pairs(NamedTuple()))
     @test g(1) == (1, 2)
 end
 


### PR DESCRIPTION
This undoes the breaking API change introduced by #24795 (fixing #25177), while keeping the performance / inference improvement. This lets us develop the kwargs API independent of Core.NT, for example, to provide proper deprecations for future changes, specific error messages, and work towards possible future development of NT (for example, implementing it as just another normal type in Julia, rather than requiring a special cases in the runtime).