### PR TITLE
Fix `sincos` for reals that are not AbstractFloats

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -198,8 +198,18 @@ function sincos(x::T) where T<:Union{Float32, Float64}
     end
 end
 
-sincos(x::T) where {T <: Union{Integer, Rational, Irrational}} = sincos(float(x))
+function sincos(v::Real)
+    vf = float(v)
+
+    if isa(vf, AbstractFloat)
+        sincos(vf)  # any subtype of AbstractFloat must implement sincos
+    else
+        return (sin(vf), cos(vf))
+    end
+end
+
 sincos(x) = (sin(x), cos(x))
+
 
 
 # There's no need to write specialized kernels, as inlining takes care of remo-

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -197,8 +197,9 @@ function sincos(x::T) where T<:Union{Float32, Float64}
         return -co, si
     end
 end
-sincos(x::T) where {T <: Union{Integer, Rational}} = sincos(float(x))
-sincos(x::Real) = (sin(x), cos(x))
+
+sincos(x::T) where {T <: Union{Integer, Rational, Irrational}} = sincos(float(x))
+sincos(x) = (sin(x), cos(x))
 
 
 # There's no need to write specialized kernels, as inlining takes care of remo-

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -197,7 +197,6 @@ function sincos(x::T) where T<:Union{Float32, Float64}
         return -co, si
     end
 end
-<<<<<<< HEAD
 
 function sincos(v::Real)
     vf = float(v)
@@ -211,10 +210,6 @@ end
 
 sincos(x) = (sin(x), cos(x))
 
-=======
-sincos(x::T) where {T <: Union{Integer, Rational}} = sincos(float(x))
-sincos(x::Real) = (sin(x), cos(x))
->>>>>>> ccf40b32b... Separate sincos for integer and rational
 
 
 # There's no need to write specialized kernels, as inlining takes care of remo-

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -198,16 +198,6 @@ function sincos(x::T) where T<:Union{Float32, Float64}
     end
 end
 
-function sincos(v::Real)
-    vf = float(v)
-
-    if isa(vf, AbstractFloat)
-        sincos(vf)  # any subtype of AbstractFloat must implement sincos
-    else
-        return (sin(vf), cos(vf))
-    end
-end
-
 _sincos(x::AbstractFloat) = sincos(x)
 _sincos(x) = (sin(x), cos(x))
 

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -197,7 +197,9 @@ function sincos(x::T) where T<:Union{Float32, Float64}
         return -co, si
     end
 end
-sincos(x::Real) = sincos(float(x))
+sincos(x::T) where {T <: Union{Integer, Rational}} = sincos(float(x))
+sincos(x::Real) = (sin(x), cos(x))
+
 
 # There's no need to write specialized kernels, as inlining takes care of remo-
 # ving superfluous calculations.

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -197,6 +197,7 @@ function sincos(x::T) where T<:Union{Float32, Float64}
         return -co, si
     end
 end
+<<<<<<< HEAD
 
 function sincos(v::Real)
     vf = float(v)
@@ -210,6 +211,10 @@ end
 
 sincos(x) = (sin(x), cos(x))
 
+=======
+sincos(x::T) where {T <: Union{Integer, Rational}} = sincos(float(x))
+sincos(x::Real) = (sin(x), cos(x))
+>>>>>>> ccf40b32b... Separate sincos for integer and rational
 
 
 # There's no need to write specialized kernels, as inlining takes care of remo-

--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -208,7 +208,10 @@ function sincos(v::Real)
     end
 end
 
-sincos(x) = (sin(x), cos(x))
+_sincos(x::AbstractFloat) = sincos(x)
+_sincos(x) = (sin(x), cos(x))
+
+sincos(x) = _sincos(float(x))
 
 
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -892,7 +892,8 @@ convert(::Type{FloatWrapper}, x::Int) = FloatWrapper(float(x))
     @test sincos(x) == (sin(x), cos(x))
 
     z = Complex(x, y)
-    z2 = exp(z)
 
-    @test isa(z2, Complex)
+    @test isa(exp(z), Complex)
+    @test isa(sin(z), Complex)
+    @test isa(cos(z), Complex)
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -868,13 +868,13 @@ struct FloatWrapper <: Real
     x::Float64
 end
 
-import Base: +, -, *, /, ^, sin, cos, exp, convert, isfinite
+import Base: +, -, *, /, ^, sin, cos, exp, sinh, cosh, convert, isfinite, float, promote_rule
 
 for op in (:+, :-, :*, :/, :^)
     @eval $op(x::FloatWrapper, y::FloatWrapper) = FloatWrapper($op(x.x, y.x))
 end
 
-for op in (:sin, :cos, :exp)
+for op in (:sin, :cos, :exp, :sinh, :cosh, :-)
     @eval $op(x::FloatWrapper) = FloatWrapper($op(x.x))
 end
 
@@ -883,6 +883,9 @@ for op in (:isfinite,)
 end
 
 convert(::Type{FloatWrapper}, x::Int) = FloatWrapper(float(x))
+promote_rule(::Type{FloatWrapper}, ::Type{Int64}) = FloatWrapper
+
+float(x::FloatWrapper) = x
 
 @testset "exp(Complex(a, b)) for a and b of non-standard real type" begin
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -868,26 +868,19 @@ struct FloatWrapper <: Real
     x::Float64
 end
 
-import Base: +, -, *, /, ^, sin, cos, exp, sinh, cosh, convert, isfinite, float, promote_rule
+import Base: +, -, *, /, ^, sin, cos, exp, convert, isfinite
 
 for op in (:+, :-, :*, :/, :^)
-    @eval $op(x::FloatWrapper, y::FloatWrapper) = FloatWrapper($op(x.x, y.x))
+    @eval $op(x::FloatWrapper, y::FloatWrapper) = $op(x.x, y.x)
 end
 
-for op in (:sin, :cos, :exp, :sinh, :cosh, :-)
-    @eval $op(x::FloatWrapper) = FloatWrapper($op(x.x))
-end
-
-for op in (:isfinite,)
+for op in (:sin, :cos, :exp, :isfinite)
     @eval $op(x::FloatWrapper) = $op(x.x)
 end
 
 convert(::Type{FloatWrapper}, x::Int) = FloatWrapper(float(x))
-promote_rule(::Type{FloatWrapper}, ::Type{Int}) = FloatWrapper
 
-float(x::FloatWrapper) = x
-
-@testset "exp(Complex(a, b)) for a and b of non-standard real type #25292" begin
+@testset "exp(Complex(a, b)) for a and b of non-standard real type" begin
 
     x = FloatWrapper(3.1)
     y = FloatWrapper(4.1)

--- a/test/math.jl
+++ b/test/math.jl
@@ -862,3 +862,33 @@ end
         @test isnan_type(T, acos(T(NaN)))
     end
 end
+
+# Define simple wrapper of a Float type:
+struct FloatWrapper <: Real
+    x::Float64
+end
+
+import Base: +, -, *, /, ^, sin, cos, exp, convert, isfinite
+
+for op in (:+, :-, :*, :/, :^)
+    @eval $op(x::FloatWrapper, y::FloatWrapper) = $op(x.x, y.x)
+end
+
+for op in (:sin, :cos, :exp, :isfinite)
+    @eval $op(x::FloatWrapper) = $op(x.x)
+end
+
+convert(::Type{FloatWrapper}, x::Int) = FloatWrapper(float(x))
+
+@testset "exp(Complex(a, b)) for a and b of non-standard real type" begin
+
+    x = FloatWrapper(3.1)
+    y = FloatWrapper(4.1)
+
+    @test sincos(x) == (sin(x), cos(x))
+
+    z = Complex(x, y)
+    z2 = exp(z)
+
+    @test isa(z2, Complex)
+end

--- a/test/math.jl
+++ b/test/math.jl
@@ -871,10 +871,14 @@ end
 import Base: +, -, *, /, ^, sin, cos, exp, convert, isfinite
 
 for op in (:+, :-, :*, :/, :^)
-    @eval $op(x::FloatWrapper, y::FloatWrapper) = $op(x.x, y.x)
+    @eval $op(x::FloatWrapper, y::FloatWrapper) = FloatWrapper($op(x.x, y.x))
 end
 
-for op in (:sin, :cos, :exp, :isfinite)
+for op in (:sin, :cos, :exp)
+    @eval $op(x::FloatWrapper) = FloatWrapper($op(x.x))
+end
+
+for op in (:isfinite,)
     @eval $op(x::FloatWrapper) = $op(x.x)
 end
 

--- a/test/math.jl
+++ b/test/math.jl
@@ -883,11 +883,11 @@ for op in (:isfinite,)
 end
 
 convert(::Type{FloatWrapper}, x::Int) = FloatWrapper(float(x))
-promote_rule(::Type{FloatWrapper}, ::Type{Int64}) = FloatWrapper
+promote_rule(::Type{FloatWrapper}, ::Type{Int}) = FloatWrapper
 
 float(x::FloatWrapper) = x
 
-@testset "exp(Complex(a, b)) for a and b of non-standard real type" begin
+@testset "exp(Complex(a, b)) for a and b of non-standard real type #25292" begin
 
     x = FloatWrapper(3.1)
     y = FloatWrapper(4.1)

--- a/test/show.jl
+++ b/test/show.jl
@@ -590,9 +590,9 @@ let repr = sprint(show, "text/html", methods(f16580))
 end
 
 if isempty(Base.GIT_VERSION_INFO.commit)
-    @test contains(Base.url(first(methods(sin))),"https://github.com/JuliaLang/julia/tree/v$VERSION/base/missing.jl#L")
+    @test contains(Base.url(which(sin, (Float64,))), "https://github.com/JuliaLang/julia/tree/v$VERSION/base/special/trig.jl#L")
 else
-    @test contains(Base.url(first(methods(sin))),"https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/missing.jl#L")
+    @test contains(Base.url(which(sin, (Float64,))), "https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/special/trig.jl#L")
 end
 
 # print_matrix should be able to handle small and large objects easily, test by


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/22095.

This PR adds a generic fallback for `sincos`.
This allows `exp(a + im*b)` to work correctly when the type of `a` and `b` is a non-standard subtype of `Real` (e.g. `ArbFloat` or `Interval`). 

There is a test provided with the simplest such non-standard type.

[Note that this -- EDIT: that is, `exp(a + im*b)` -- worked in Julia 0.6, but does not work in current master, so this is in fact a bug fix for a regression and not a new feature.]