### PR TITLE
fix conjugation of UniformScaling

### DIFF
--- a/base/linalg/uniformscaling.jl
+++ b/base/linalg/uniformscaling.jl
@@ -62,6 +62,8 @@ function show(io::IO, J::UniformScaling)
 end
 copy(J::UniformScaling) = UniformScaling(J.λ)
 
+conj(J::UniformScaling) = UniformScaling(conj(J.λ))
+
 transpose(J::UniformScaling) = J
 Transpose(S::UniformScaling) = transpose(S)
 adjoint(J::UniformScaling) = UniformScaling(conj(J.λ))

--- a/test/linalg/uniformscaling.jl
+++ b/test/linalg/uniformscaling.jl
@@ -21,6 +21,13 @@ srand(123)
     @test norm(UniformScaling(1+im)) ≈ sqrt(2)
 end
 
+@testset "conjugation of UniformScaling" begin
+    @test conj(UniformScaling(1))::UniformScaling{Int} == UniformScaling(1)
+    @test conj(UniformScaling(1.0))::UniformScaling{Float64} == UniformScaling(1.0)
+    @test conj(UniformScaling(1+1im))::UniformScaling{Complex{Int}} == UniformScaling(1-1im)
+    @test conj(UniformScaling(1.0+1.0im))::UniformScaling{Complex{Float64}} == UniformScaling(1.0-1.0im)
+end
+
 @testset "istriu, istril, issymmetric, ishermitian, isapprox" begin
     @test istriu(I)
     @test istril(I)


### PR DESCRIPTION
On master, `conj(J::UniformScaling)` hits the `conj` no-op fallback:
```julia
julia> conj(UniformScaling(1+1im))
UniformScaling{Complex{Int64}}
(1 + 1im)*I
```
With this pull request, `conj(J::UniformScaling)` conjugates the wrapped number:
```julia
julia> conj(UniformScaling(1+1im))
UniformScaling{Complex{Int64}}
(1 - 1im)*I
```
Best!