### PR TITLE
WIP: Use constant propagation instead of Val in linalg

### DIFF
--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -1236,7 +1236,7 @@ function factorize(A::StridedMatrix{T}) where T
         end
         return lufact(A)
     end
-    qrfact(A, Val(true))
+    qrfact(A, :colnorm)
 end
 
 ## Moore-Penrose pseudoinverse

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -881,7 +881,7 @@ function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
         end
         return lufact(A) \ B
     end
-    return qrfact(A,Val(true)) \ B
+    return qrfact(A, :colnorm) \ B
 end
 
 (\)(a::AbstractVector, b::AbstractArray) = pinv(a) * b

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -19,7 +19,7 @@ function lufact!(A::StridedMatrix{T}; pivot = :rowmax) where T<:BlasFloat
         lpt = LAPACK.getrf!(A)
         return LU{T,typeof(A)}(lpt[1], lpt[2], lpt[3])
     else
-        throw(ArgumentError("only `row` and `none` are supported as `pivot` argument but you supplied `$pivot`"))
+        throw(ArgumentError("only `rowmax` and `none` are supported as `pivot` argument but you supplied `$pivot`"))
     end
 end
 function lufact!(A::HermOrSym, pivot = :rowmax)
@@ -72,7 +72,7 @@ function generic_lufact!(A::StridedMatrix{T}, pivot = :rowmax) where {T}
 
     # Check arguments
     if pivot != :rowmax && pivot != :none
-        throw(ArgumentError("only `row` and `none` are supported as `pivot` argument but you supplied `$pivot`"))
+        throw(ArgumentError("only `rowmax` and `none` are supported as `pivot` argument but you supplied `$pivot`"))
     end
 
     # Initialize variables


### PR DESCRIPTION
This is my first attempt to remove the uses of `Val` in the linear algebra code and instead rely on constant propagation. Currently, I think I have to use too make tricks to make inference work here so it would be great if @vtjnash could take a look. E.g. I'd like to get rid of [these definitions](https://github.com/JuliaLang/julia/compare/anj/novals?expand=1#diff-e36f5ee433c689229ccc916a11434d1dR196) and [this `@inline` annotations](https://github.com/JuliaLang/julia/compare/anj/novals?expand=1#diff-e36f5ee433c689229ccc916a11434d1dR314).