### PR TITLE
make `using A.B` only for modules, `using A: B` only for single bindings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -173,6 +173,9 @@ Language changes
     by a character that will never be an allowed identifier character (currently
     operators, space/control characters, or common punctuation characters) ([#25231]).
 
+  * The syntax `using A.B` can now only be used when `A.B` is a module, and the syntax
+    `using A: B` can only be used for adding single bindings ([#8000]).
+
 
 Breaking changes
 ----------------

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.Iterators.Enumerate
+using Base.Iterators: Enumerate
 
 """
     asyncmap(f, c...; ntasks=0, batch_size=nothing)

--- a/base/libgit2/libgit2.jl
+++ b/base/libgit2/libgit2.jl
@@ -7,7 +7,7 @@ module LibGit2
 
 import Base: ==
 using Base: coalesce, notnothing
-using Base.Printf.@printf
+using Base.Printf: @printf
 
 export with, GitRepo, GitConfig
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -25,7 +25,7 @@ using Base: sign_mask, exponent_mask, exponent_one,
 
 using Core.Intrinsics: sqrt_llvm
 
-using Base.IEEEFloat
+using Base: IEEEFloat
 
 @noinline function throw_complex_domainerror(f, x)
     throw(DomainError(x, string("$f will only return a complex result if called with a ",

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -7,7 +7,7 @@ import ..Reqs, ..Read, ..Query, ..Resolve, ..Cache, ..Write, ..Dir
 using ...LibGit2
 import ...Pkg.PkgError
 using ..Types
-using Base.Printf.@printf
+using Base.Printf: @printf
 
 macro recover(ex)
     quote

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module Printf
-using Base: Grisu, GMP
+using Base.Grisu
+using Base.GMP
 using Base.Unicode: lowercase, textwidth, isupper
 
 ### printf formatter generation ###

--- a/base/random/dSFMT.jl
+++ b/base/random/dSFMT.jl
@@ -3,7 +3,7 @@
 module dSFMT
 
 import Base: copy, copy!, ==, hash
-using Base.GMP: MPZ
+using Base.GMP.MPZ
 
 export DSFMT_state, dsfmt_get_min_array_size, dsfmt_get_idstring,
        dsfmt_init_gen_rand, dsfmt_init_by_array, dsfmt_gv_init_by_array,

--- a/base/random/random.jl
+++ b/base/random/random.jl
@@ -3,7 +3,8 @@
 module Random
 
 using Base.dSFMT
-using Base.GMP: Limb, MPZ
+using Base.GMP.MPZ
+using Base.GMP: Limb
 using Base: BitInteger, BitInteger_types, BitUnsigned, @gc_preserve
 
 import Base: copymutable, copy, copy!, ==, hash

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -2,7 +2,8 @@
 
 module Sort
 
-using Base: Order, Checked, copymutable, linearindices, IndexStyle, viewindexing, IndexLinear, _length
+using Base.Order, Base.Checked
+using Base: copymutable, linearindices, IndexStyle, viewindexing, IndexLinear, _length
 
 import
     Base.sort,

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -8,7 +8,7 @@ module StackTraces
 
 import Base: hash, ==, show
 import Base.Serializer: serialize, deserialize
-using Base.Printf.@printf
+using Base.Printf: @printf
 
 export StackTrace, StackFrame, stacktrace, catch_stacktrace
 

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -42,11 +42,13 @@ the system will search for it among variables exported by `Lib` and import it if
 This means that all uses of that global within the current module will resolve to the definition
 of that variable in `Lib`.
 
-The statement `using BigLib: thing1, thing2` is a syntactic shortcut for `using BigLib.thing1, BigLib.thing2`.
+The statement `using BigLib: thing1, thing2` brings just the identifiers `thing1` and `thing2`
+into scope from module `BigLib`. If these names refer to functions, adding methods to them
+will not be allowed (you may only "use" them, not extend them).
 
-The `import` keyword supports all the same syntax as `using`, but only operates on a single name
+The `import` keyword supports the same syntax as `using`, but only operates on a single name
 at a time. It does not add modules to be searched the way `using` does. `import` also differs
-from `using` in that functions must be imported using `import` to be extended with new methods.
+from `using` in that functions imported using `import` can be extended with new methods.
 
 In `MyModule` above we wanted to add a method to the standard `show` function, so we had to write
 `import Base.show`. Functions whose names are only visible via `using` cannot be extended.
@@ -79,7 +81,6 @@ functions into the current workspace:
 | Import Command                  | What is brought into scope                                                      | Available for method extension              |
 |:------------------------------- |:------------------------------------------------------------------------------- |:------------------------------------------- |
 | `using MyModule`                | All `export`ed names (`x` and `y`), `MyModule.x`, `MyModule.y` and `MyModule.p` | `MyModule.x`, `MyModule.y` and `MyModule.p` |
-| `using MyModule.x, MyModule.p`  | `x` and `p`                                                                     |                                             |
 | `using MyModule: x, p`          | `x` and `p`                                                                     |                                             |
 | `import MyModule`               | `MyModule.x`, `MyModule.y` and `MyModule.p`                                     | `MyModule.x`, `MyModule.y` and `MyModule.p` |
 | `import MyModule.x, MyModule.p` | `x` and `p`                                                                     | `x` and `p`                                 |

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -638,6 +638,11 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
                 if (name != NULL)
                     u = (jl_module_t*)jl_eval_global_var(import, name);
                 if (jl_is_module(u)) {
+                    if (from) {
+                        jl_depwarn("`using A: B` will only be allowed for single bindings, not modules. Use "
+                                   "`using A.B` instead",
+                                   (jl_value_t*)jl_symbol("using"));
+                    }
                     jl_module_using(m, u);
                     if (m == jl_main_module && name == NULL) {
                         // TODO: for now, `using A` in Main also creates an explicit binding for `A`
@@ -646,6 +651,11 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
                     }
                 }
                 else {
+                    if (!from) {
+                        jl_depwarn("`using A.B` will only be allowed for modules, not single bindings. Use "
+                                   "`using A: B` instead",
+                                   (jl_value_t*)jl_symbol("using"));
+                    }
                     jl_module_t *replacement = deprecation_replacement_module(import, name);
                     if (replacement)
                         jl_module_using(m, replacement);

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -7,7 +7,7 @@
 
     # based on deps/Suitesparse-4.0.2/UMFPACK/Demo/umfpack_di_demo.c
 
-    using SuiteSparse.increment!
+    using SuiteSparse: increment!
     using Base.LinAlg: Adjoint, Transpose
 
     A0 = sparse(increment!([0,4,1,1,2,2,0,1,2,3,4,4]),

--- a/test/linalg/triangular.jl
+++ b/test/linalg/triangular.jl
@@ -516,7 +516,7 @@ end
 
 # dimensional correctness:
 isdefined(Main, :TestHelpers) || @eval Main include("../TestHelpers.jl")
-using Main.TestHelpers.Furlong
+using Main.TestHelpers: Furlong
 let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
     @test sqrt(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
 end

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.llvmcall
+using Base: llvmcall
 
 #function add1234(x::Tuple{Int32,Int32,Int32,Int32})
 #    llvmcall("""%3 = add <4 x i32> %1, %0
@@ -48,7 +48,7 @@ end
 
 # Test whether llvmcall escapes the function name correctly
 baremodule PlusTest
-    using Base.llvmcall
+    using Base: llvmcall
     using Test
     using Base
 

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -5,7 +5,7 @@ import Base.CoreLogging: BelowMinLevel, Debug, Info, Warn, Error,
     handle_message, shouldlog, min_enabled_level
 
 import Test: collect_test_logs, TestLogger
-using Base.Printf.@sprintf
+using Base.Printf: @sprintf
 
 #-------------------------------------------------------------------------------
 @testset "Logging" begin

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -43,7 +43,7 @@ end
 @test foundfunc(h_inlined(), :g_inlined)
 @test foundfunc(h_noinlined(), :g_noinlined)
 
-using Base.pushmeta!, Base.popmeta!
+using Base: pushmeta!, popmeta!
 
 macro attach(val, ex)
     esc(_attach(val, ex))

--- a/test/random.jl
+++ b/test/random.jl
@@ -3,7 +3,8 @@
 isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
 using Main.TestHelpers.OAs
 
-using Base.Random: Sampler, SamplerRangeFast, SamplerRangeInt, dSFMT, MT_CACHE_F, MT_CACHE_I
+using Base.Random.dSFMT
+using Base.Random: Sampler, SamplerRangeFast, SamplerRangeInt, MT_CACHE_F, MT_CACHE_I
 
 @testset "Issue #6573" begin
     srand(0)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1198,7 +1198,7 @@ Base.isless(x, y::NotReal) = isless(x, y.val)
 @test colon(1, NotReal(1), 5) isa StepRange{Int,NotReal}
 
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using Main.TestHelpers.Furlong
+using Main.TestHelpers: Furlong
 @testset "dimensional correctness" begin
     @test length(collect(Furlong(2):Furlong(10))) == 9
     @test length(range(Furlong(2), 9)) == 9

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@
 
 using Test
 using Distributed
-using Base.Printf.@sprintf
+using Base.Printf: @sprintf
 
 include("choosetests.jl")
 include("testenv.jl")

--- a/test/sparse/sparse.jl
+++ b/test/sparse/sparse.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Base.LinAlg: mul!, ldiv!, rdiv!, Adjoint, Transpose
-using Base.Printf.@printf
+using Base.Printf: @printf
 
 @testset "issparse" begin
     @test issparse(sparse(ones(5,5)))

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.Printf.@sprintf
+using Base.Printf: @sprintf
 
 @generated function staged_t1(a,b)
     if a == Int

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -408,7 +408,7 @@ end
 
 # dimensional correctness
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using Main.TestHelpers.Furlong
+using Main.TestHelpers: Furlong
 @testset "Unitful elements" begin
     r = Furlong(1):Furlong(1):Furlong(2)
     a = collect(r)

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.Bottom
+using Base: Bottom
 using Test
 
 macro UnionAll(var, expr)


### PR DESCRIPTION
part of #8000