### PR TITLE
[RFC/WIP] Add a secondary location for a sysimage in $HOME/.julia/$VERSION/sys.so

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -26,6 +26,23 @@ JL_DLLEXPORT const char *jl_get_default_sysimg_path(void)
     return &system_image_path[1];
 }
 
+JL_DLLEXPORT char *jl_get_homedir_sysimg_path(void)
+{
+    size_t size = PATH_MAX;
+    char *homedir = (char*) malloc(size);
+    if (uv_os_homedir(homedir, &size) != 0) {
+        free(homedir);
+        jl_error("fatal error: path of home dir is to large.");
+    }
+    char *path = (char*) malloc(PATH_MAX);
+    int n = snprintf(path, PATH_MAX, "%s" PATHSEPSTRING "%s" PATHSEPSTRING "v%s" PATHSEPSTRING "%s%s", homedir, ".julia", JULIA_VERSION_STRING , "sys", shlib_ext);
+    if (n >= PATH_MAX || n < 0) {
+        jl_error("fatal error: Can't construct sysimage path");
+    }
+    free(homedir);
+    return path;
+}
+
 
 jl_options_t jl_options = { 0,    // quiet
                             -1,   // banner

--- a/src/julia.h
+++ b/src/julia.h
@@ -1368,6 +1368,7 @@ JL_DLLEXPORT void jl_init(void);
 JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
                                      const char *image_relative_path);
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
+JL_DLLEXPORT char *jl_get_homedir_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
 JL_DLLEXPORT void jl_atexit_hook(int status);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);


### PR DESCRIPTION
adds a secondary location for a userdefined sysimage, making it easier for users
to bake their own sysimages and use them. Furthermore this allows the update of
stdlib packages, through building a new sysimage that contains them.

This sidesteps the issue brought up in #25248, instead of removing all stdlib packages
from the sysimage, we can now rebuild the sysimage even if the other location is in a
write protected area.

I would greatly appreciate a style review since I bungled my way through the C string handling.

Currently this PR checks for the modify time of the sysimage in the bindir or homedir and uses
the newer one, trying to ensure that during development a potential stale userimage is not loaded.