### PR TITLE
some small fixes to `jl_log`

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -361,7 +361,7 @@ end
 
 # Log a message. Called from the julia C code; kwargs is in the format
 # Any[key1,val1, ...] for simplicity in construction on the C side.
-function logmsg_thunk(level, message, _module, group, id, file, line, kwargs)
+function logmsg_shim(level, message, _module, group, id, file, line, kwargs)
     real_kws = Any[(kwargs[i],kwargs[i+1]) for i in 1:2:length(kwargs)]
     @logmsg(convert(LogLevel, level), message,
             _module=_module, _id=id, _group=group,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -981,7 +981,7 @@ JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
 JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n);
 void jl_depwarn(const char *msg, jl_value_t *sym);
 
-// Log `msg` to the current logger by calling CoreLogging.logmsg_thunk() on the
+// Log `msg` to the current logger by calling CoreLogging.logmsg_shim() on the
 // julia side. If any of module, group, id, file or line are NULL, these will
 // be passed to the julia side as `nothing`.  If `kwargs` is NULL an empty set
 // of keyword arguments will be passed.

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1039,32 +1039,32 @@ void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
     if (!logmsg_func && jl_base_module) {
         jl_value_t *corelogging = jl_get_global(jl_base_module, jl_symbol("CoreLogging"));
         if (corelogging && jl_is_module(corelogging)) {
-            logmsg_func = jl_get_global((jl_module_t*)corelogging, jl_symbol("logmsg_thunk"));
+            logmsg_func = jl_get_global((jl_module_t*)corelogging, jl_symbol("logmsg_shim"));
         }
     }
     if (!logmsg_func) {
         ios_t str_;
         ios_mem(&str_, 300);
         uv_stream_t* str = (uv_stream_t*)&str_;
-        if (jl_is_string(file)) {
-            jl_uv_puts(str, jl_string_data(file), jl_string_len(file));
-        }
-        else {
-            jl_static_show(str, file);
-        }
-        jl_printf(str, ":");
-        jl_static_show(str, line);
-        jl_printf(str, " - ");
         if (jl_is_string(msg)) {
             jl_uv_puts(str, jl_string_data(msg), jl_string_len(msg));
         }
-        else {
-            jl_static_show(str, msg);
+        else if (jl_is_symbol(msg)) {
+            jl_printf(str, "%s", jl_symbol_name((jl_sym_t*)msg));
         }
+        jl_printf(str, "\n@ ");
+        if (jl_is_string(file)) {
+            jl_uv_puts(str, jl_string_data(file), jl_string_len(file));
+        }
+        else if (jl_is_symbol(file)) {
+            jl_printf(str, "%s", jl_symbol_name((jl_sym_t*)file));
+        }
+        jl_printf(str, ":");
+        jl_static_show(str, line);
         jl_safe_printf("%s [Fallback logging]: %.*s\n",
-                       level < JL_LOGLEVEL_INFO ? "DEBUG" :
-                       level < JL_LOGLEVEL_WARN ? "INFO" :
-                       level < JL_LOGLEVEL_ERROR ? "WARNING" : "ERROR",
+                       level < JL_LOGLEVEL_INFO ? "Debug" :
+                       level < JL_LOGLEVEL_WARN ? "Info" :
+                       level < JL_LOGLEVEL_ERROR ? "Warning" : "Error",
                        (int)str_.size, str_.buf);
         ios_close(&str_);
         return;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -231,6 +231,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
     jl_parse_opts(&argc, (char***)&argv);
     julia_init(jl_options.image_file_specified ? JL_IMAGE_CWD : JL_IMAGE_JULIA_HOME);
     if (lisp_prompt) {
+        jl_get_ptls_states()->world_age = jl_get_world_counter();
         jl_lisp_prompt();
         return 0;
     }


### PR DESCRIPTION
- synchronize printing format of fallback logging
- make new logging work under `--lisp`

Also rename `logmsg_thunk` to `logmsg_shim`. I'd say it's more of a shim than a thunk :)