### PR TITLE
Update printing for length and size method error

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -227,6 +227,10 @@ function showerror(io::IO, ex::MethodError)
         end
         print(io, ")")
     end
+    if f_is_function && ( name == :length || name == :size )
+        print(io, "\nYou may consider implementing additional iterator methods",
+                  "\nsuch as a specialized `length` or `size`.")
+    end
     if ft <: AbstractArray
         print(io, "\nUse square brackets [] for indexing an Array.")
     end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -227,10 +227,10 @@ function showerror(io::IO, ex::MethodError)
         end
         print(io, ")")
     end
-    if applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasLength()
+    if f_is_function && applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasLength() && !method_exists(ex.f, arg_types)
         print(io, "\nYou may consider implementing an additional",
                   "\nspecialized iterator method called `length`.")
-    elseif applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasShape()
+    elseif f_is_function && applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasShape() && !method_exists(ex.f, arg_types)
         print(io, "\nYou may consider implementing additional specialized iterator methods",
                   "\nsuch as a `length` and `size`.")
     end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -227,9 +227,12 @@ function showerror(io::IO, ex::MethodError)
         end
         print(io, ")")
     end
-    if f_is_function && ( name == :length || name == :size )
-        print(io, "\nYou may consider implementing additional iterator methods",
-                  "\nsuch as a specialized `length` or `size`.")
+    if applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasLength()
+        print(io, "\nYou may consider implementing an additional",
+                  "\nspecialized iterator method called `length`.")
+    elseif applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasShape()
+        print(io, "\nYou may consider implementing additional specialized iterator methods",
+                  "\nsuch as a `length` and `size`.")
     end
     if ft <: AbstractArray
         print(io, "\nUse square brackets [] for indexing an Array.")

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -229,11 +229,9 @@ function showerror(io::IO, ex::MethodError)
     end
     if f_is_function && applicable(start, ex.args) && !method_exists(f, arg_types)
         if Base.iteratorsize(ex.args) == Base.HasLength()
-            print(io, "\nYou may consider implementing an additional",
-                      "\nspecialized iterator method called `length`.")
+            print(io, "\nYou may consider implementing the `length` method.")
         elseif Base.iteratorsize(ex.args) == Base.HasShape()
-            print(io, "\nYou may consider implementing additional",
-                      "\nspecialized iterator methods such as `length` and `size`.")
+            print(io, "\nYou may consider implementing the `length` and `size` methods.")
         end
     end
     if ft <: AbstractArray

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -230,10 +230,10 @@ function showerror(io::IO, ex::MethodError)
     if f_is_function && applicable(start, ex.args) && !method_exists(f, arg_types)
         if Base.iteratorsize(ex.args) == Base.HasLength()
             print(io, "\nYou may consider implementing an additional",
-                  "\nspecialized iterator method called `length`.")
+                      "\nspecialized iterator method called `length`.")
         elseif Base.iteratorsize(ex.args) == Base.HasShape()
-            print(io, "\nYou may consider implementing additional specialized iterator methods",
-                  "\nsuch as a `length` and `size`.")
+            print(io, "\nYou may consider implementing additional",
+                      "\nspecialized iterator methods such as `length` and `size`.")
         end
     end
     if ft <: AbstractArray

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -227,12 +227,14 @@ function showerror(io::IO, ex::MethodError)
         end
         print(io, ")")
     end
-    if f_is_function && applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasLength() && !method_exists(ex.f, arg_types)
-        print(io, "\nYou may consider implementing an additional",
+    if f_is_function && applicable(start, ex.args) && !method_exists(ex.f, arg_types)
+        if Base.iteratorsize(ex.args) == Base.HasLength()
+            print(io, "\nYou may consider implementing an additional",
                   "\nspecialized iterator method called `length`.")
-    elseif f_is_function && applicable(start, ex.args) && Base.iteratorsize(ex.args) == Base.HasShape() && !method_exists(ex.f, arg_types)
-        print(io, "\nYou may consider implementing additional specialized iterator methods",
+        elseif Base.iteratorsize(ex.args) == Base.HasShape()
+            print(io, "\nYou may consider implementing additional specialized iterator methods",
                   "\nsuch as a `length` and `size`.")
+        end
     end
     if ft <: AbstractArray
         print(io, "\nUse square brackets [] for indexing an Array.")

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -227,7 +227,7 @@ function showerror(io::IO, ex::MethodError)
         end
         print(io, ")")
     end
-    if f_is_function && applicable(start, ex.args) && !method_exists(ex.f, arg_types)
+    if f_is_function && applicable(start, ex.args) && !method_exists(f, arg_types)
         if Base.iteratorsize(ex.args) == Base.HasLength()
             print(io, "\nYou may consider implementing an additional",
                   "\nspecialized iterator method called `length`.")

--- a/test/embedding/embedding-test.jl
+++ b/test/embedding/embedding-test.jl
@@ -17,7 +17,7 @@ end
     close(err.in)
     out_task = @async readlines(out)
     err = read(err, String)
-    @test err == "MethodError: no method matching this_function_has_no_methods()\n"
+    @test contains(err, "MethodError: no method matching this_function_has_no_methods()")
     @test success(p)
     lines = fetch(out_task)
     @test length(lines) == 10


### PR DESCRIPTION
Fixes #25232 

This commit adds special printing that hints that the user might be missing some of the additional iterator methods such as `length` and `size`.