### PR TITLE
download cert.pem from deps-getall, fixes #24903

### DIFF
--- a/deps/libgit2.mk
+++ b/deps/libgit2.mk
@@ -120,7 +120,7 @@ clean-libgit2:
 	-rm $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled
 	-$(MAKE) -C $(BUILDDIR)/$(LIBGIT2_SRC_DIR) clean
 
-get-libgit2: $(LIBGIT2_SRC_FILE)
+get-libgit2: $(LIBGIT2_SRC_FILE) $(build_datarootdir)/julia/cert.pem
 extract-libgit2: $(SRCCACHE)/$(LIBGIT2_SRC_DIR)/source-extracted
 configure-libgit2: $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-configured
 compile-libgit2: $(BUILDDIR)/$(LIBGIT2_SRC_DIR)/build-compiled


### PR DESCRIPTION
Fixes #24903.

It would be good to create a test for this, but I'm not sure the best way to do it.  Do the CI tests build julia from scratch every time, or are some dependencies cached?