### PR TITLE
RFC: Mark Symbol as immutable

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -186,6 +186,8 @@ JL_DLLEXPORT int jl_egal(jl_value_t *a, jl_value_t *b)
     }
     if (dt->mutabl)
         return 0;
+    if (dt == jl_symbol_type)
+        return 0;
     size_t sz = jl_datatype_size(dt);
     if (sz == 0)
         return 1;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1818,7 +1818,7 @@ void jl_init_types(void)
     jl_sym_type->ditype = NULL;
     jl_sym_type->size = 0;
     jl_sym_type->abstract = 0;
-    jl_sym_type->mutabl = 1;
+    jl_sym_type->mutabl = 0;
     jl_sym_type->ninitialized = 0;
 
     jl_simplevector_type->name = jl_new_typename_in(jl_symbol("SimpleVector"), core);


### PR DESCRIPTION
Symbol is a bit odd. On the one hand it is comparable by identity like mutable
types, on the other hand, its identity is entirely determined by its "contents",
like an immutable type. The setting of the mutabl flag is thus a bit arbitrary.
However, while that is the system perspective, from the user perspective, setting it
to immutable seems clearer, since a user associates the symbol value with the symbol
rather than its identity, and that symbol value is immutable.

Brought up here: https://discourse.julialang.org/t/whats-so-mutable-about-symbol-s/8094
I don't care strongly about this though, up for debate.