### PR TITLE
fix typo in retry check doc string

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -233,8 +233,8 @@ current state and the `Exception`.
 retry(f, delays=fill(5.0, 3))
 retry(f, delays=rand(5:10, 2))
 retry(f, delays=Base.ExponentialBackOff(n=3, first_delay=5, max_delay=1000))
-retry(http_get, check=(s,e)->e.status == "503")(url)
-retry(read, check=(s,e)->isa(e, IOError))(io, 128; all=false)
+retry(http_get, check=(s,e)->(s,e.status == "503"))(url)
+retry(read, check=(s,e)->(s,isa(e, UVError)))(io, 128; all=false)
 ```
 """
 function retry(f::Function;  delays=ExponentialBackOff(), check=nothing)


### PR DESCRIPTION
fixes #25351

The retry check function is expected to return a tuple of state and boolean