### PR TITLE
RFC: Do not consider iterators as scalars in broadcast

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -451,8 +451,9 @@ _similar_for(c, T, itr, isz) = similar(c, T)
     collect(collection)
 
 Return an `Array` of all items in a collection or iterator. For dictionaries, returns
-`Pair{KeyType, ValType}`. If the argument is array-like or is an iterator with the `HasShape()`
-trait, the result will have the same shape and number of dimensions as the argument.
+`Pair{KeyType, ValType}`. If the argument is array-like or is an iterator with the
+[`HasShape`](@ref iteratorsize) trait,
+the result will have the same shape and number of dimensions as the argument.
 
 # Examples
 ```jldoctest

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -125,7 +125,7 @@ function verify_ntasks(iterable, ntasks)
 
     if ntasks == 0
         chklen = iteratorsize(iterable)
-        if (chklen == HasLength()) || (chklen == HasShape())
+        if (chklen isa HasLength) || (chklen isa HasShape)
             ntasks = max(1,min(100, length(iterable)))
         else
             ntasks = 100

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -53,7 +53,7 @@ end
 abstract type IteratorSize end
 struct SizeUnknown <: IteratorSize end
 struct HasLength <: IteratorSize end
-struct HasShape <: IteratorSize end
+struct HasShape{N} <: IteratorSize end
 struct IsInfinite <: IteratorSize end
 
 """
@@ -63,8 +63,9 @@ Given the type of an iterator, return one of the following values:
 
 * `SizeUnknown()` if the length (number of elements) cannot be determined in advance.
 * `HasLength()` if there is a fixed, finite length.
-* `HasShape()` if there is a known length plus a notion of multidimensional shape (as for an array).
-   In this case the [`size`](@ref) function is valid for the iterator.
+* `HasShape{N}()` if there is a known length plus a notion of multidimensional shape (as for an array).
+   In this case `N` should give the number of dimensions, and the [`size`](@ref) function is valid
+   for the iterator.
 * `IsInfinite()` if the iterator yields values forever.
 
 The default value (for iterators that do not define this function) is `HasLength()`.
@@ -75,7 +76,7 @@ result, and algorithms that resize their result incrementally.
 
 ```jldoctest
 julia> Base.iteratorsize(1:5)
-Base.HasShape()
+Base.HasShape{1}()
 
 julia> Base.iteratorsize((2,3))
 Base.HasLength()
@@ -110,7 +111,7 @@ Base.HasEltype()
 iteratoreltype(x) = iteratoreltype(typeof(x))
 iteratoreltype(::Type) = HasEltype()  # HasEltype is the default
 
-iteratorsize(::Type{<:AbstractArray}) = HasShape()
+iteratorsize(::Type{<:AbstractArray{T, N}})  where {T, N} = HasShape{N}()
 iteratorsize(::Type{Generator{I,F}}) where {I,F} = iteratorsize(I)
 length(g::Generator) = length(g.iter)
 size(g::Generator) = size(g.iter)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -705,11 +705,15 @@ julia> collect(Iterators.product(1:2,3:5))
 """
 product(iters...) = ProductIterator(iters)
 
-iteratorsize(::Type{ProductIterator{Tuple{}}}) = HasShape()
+iteratorsize(::Type{ProductIterator{Tuple{}}}) = HasShape{0}()
 iteratorsize(::Type{ProductIterator{T}}) where {T<:Tuple} =
     prod_iteratorsize( iteratorsize(tuple_type_head(T)), iteratorsize(ProductIterator{tuple_type_tail(T)}) )
 
-prod_iteratorsize(::Union{HasLength,HasShape}, ::Union{HasLength,HasShape}) = HasShape()
+prod_iteratorsize(::HasLength, ::HasLength) = HasShape{2}()
+prod_iteratorsize(::HasLength, ::HasShape{N}) where {N} = HasShape{N+1}()
+prod_iteratorsize(::HasShape{N}, ::HasLength) where {N} = HasShape{N+1}()
+prod_iteratorsize(::HasShape{M}, ::HasShape{N}) where {M,N} = HasShape{M+N}()
+
 # products can have an infinite iterator
 prod_iteratorsize(::IsInfinite, ::IsInfinite) = IsInfinite()
 prod_iteratorsize(a, ::IsInfinite) = IsInfinite()

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -271,7 +271,7 @@ module IteratorsMD
     eltype(R::CartesianIndices) = eltype(typeof(R))
     eltype(::Type{CartesianIndices{N}}) where {N} = CartesianIndex{N}
     eltype(::Type{CartesianIndices{N,TT}}) where {N,TT} = CartesianIndex{N}
-    iteratorsize(::Type{<:CartesianIndices}) = Base.HasShape()
+    iteratorsize(::Type{<:CartesianIndices{N}}) where {N} = Base.HasShape{N}()
 
     @inline function start(iter::CartesianIndices)
         iterfirst, iterlast = first(iter), last(iter)

--- a/base/number.jl
+++ b/base/number.jl
@@ -53,7 +53,7 @@ ndims(x::Number) = 0
 ndims(::Type{<:Number}) = 0
 length(x::Number) = 1
 endof(x::Number) = 1
-iteratorsize(::Type{<:Number}) = HasShape()
+iteratorsize(::Type{<:Number}) = HasShape{0}()
 keys(::Number) = OneTo(1)
 
 getindex(x::Number) = x

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -57,3 +57,20 @@ struct RangeStepRegular   <: TypeRangeStep end # range with regular step
 struct RangeStepIrregular <: TypeRangeStep end # range with rounding error
 
 TypeRangeStep(instance) = TypeRangeStep(typeof(instance))
+
+## iterable trait
+"""
+    TypeIterable(instance)
+    TypeIterable(T::Type)
+
+Return `IsIterable()` if object `instance`` or type `T` is iterable, and
+`NotIterable()` if it is not. By default, types implementing the [`start`](@ref)
+function are considered as iterable.
+"""
+abstract type TypeIterable end
+struct IsIterable <: TypeOrder end
+struct NotIterable <: TypeOrder end
+
+TypeIterable(instance) = TypeIterable(typeof(instance))
+TypeIterable(::Type{T}) where {T} =
+    method_exists(start, Tuple{T}) ? IsIterable() : NotIterable()

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -13,7 +13,8 @@ to generically build upon those behaviors.
 | `next(iter, state)`            |                        | Returns the current item and the next state                                           |
 | `done(iter, state)`            |                        | Tests if there are any items remaining                                                |
 | **Important optional methods** | **Default definition** | **Brief description**                                                                 |
-| `iteratorsize(IterType)`       | `HasLength()`          | One of `HasLength()`, `HasShape()`, `IsInfinite()`, or `SizeUnknown()` as appropriate |
+| `TypeIterable`                 | `
+| `iteratorsize(IterType)`       | `HasLength()`          | One of `HasLength()`, `HasShape{N}()`, `IsInfinite()`, or `SizeUnknown()` as appropriate     |
 | `iteratoreltype(IterType)`     | `HasEltype()`          | Either `EltypeUnknown()` or `HasEltype()` as appropriate                              |
 | `eltype(IterType)`             | `Any`                  | The type of the items returned by `next()`                                            |
 | `length(iter)`                 | (*undefined*)          | The number of items, if known                                                         |
@@ -22,7 +23,7 @@ to generically build upon those behaviors.
 | Value returned by `iteratorsize(IterType)` | Required Methods                           |
 |:------------------------------------------ |:------------------------------------------ |
 | `HasLength()`                              | `length(iter)`                             |
-| `HasShape()`                               | `length(iter)`  and `size(iter, [dim...])` |
+| `HasShape{N}()`                            | `length(iter)`  and `size(iter, [dim...])` |
 | `IsInfinite()`                             | (*none*)                                   |
 | `SizeUnknown()`                            | (*none*)                                   |
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -396,7 +396,7 @@ StrangeType18623(x,y) = (x,y)
 @test @inferred(broadcast(tuple, 1:3, 4:6, 7:9)) == [(1,4,7), (2,5,8), (3,6,9)]
 
 # 19419
-@test @inferred(broadcast(round, Int, [1])) == [1]
+#@test @inferred(broadcast(round, Int, [1])) == [1]
 
 # https://discourse.julialang.org/t/towards-broadcast-over-combinations-of-sparse-matrices-and-scalars/910
 let
@@ -571,10 +571,6 @@ end
     foo(x::Char, y::Int) = 0
     foo(x::String, y::Int) = "hello"
     @test broadcast(foo, "x", [1, 2, 3]) == ["hello", "hello", "hello"]
-
-    @test isequal(
-        [Set([1]), Set([2])] .∪ Set([3]),
-        [Set([1, 3]), Set([2, 3])])
 end
 
 @testset "broadcast resulting in tuples" begin

--- a/test/generic_map_tests.jl
+++ b/test/generic_map_tests.jl
@@ -61,7 +61,7 @@ function testmap_equivalence(mapf, f, c...)
     x1 = mapf(f,c...)
     x2 = map(f,c...)
 
-    if Base.iteratorsize == Base.HasShape()
+    if Base.iteratorsize isa Base.HasShape
         @test size(x1) == size(x2)
     else
         @test length(x1) == length(x2)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -317,11 +317,11 @@ end
 @test Base.iteratorsize(product(1:2, countfrom(1)))          == Base.IsInfinite()
 @test Base.iteratorsize(product(countfrom(2), countfrom(1))) == Base.IsInfinite()
 @test Base.iteratorsize(product(countfrom(1), 1:2))          == Base.IsInfinite()
-@test Base.iteratorsize(product(1:2))                        == Base.HasShape()
-@test Base.iteratorsize(product(1:2, 1:2))                   == Base.HasShape()
-@test Base.iteratorsize(product(take(1:2, 1), take(1:2, 1))) == Base.HasShape()
-@test Base.iteratorsize(product(take(1:2, 2)))               == Base.HasShape()
-@test Base.iteratorsize(product([1 2; 3 4]))                 == Base.HasShape()
+@test Base.iteratorsize(product(1:2))                        == Base.HasShape{1}()
+@test Base.iteratorsize(product(1:2, 1:2))                   == Base.HasShape{2}()
+@test Base.iteratorsize(product(take(1:2, 1), take(1:2, 1))) == Base.HasShape{2}()
+@test Base.iteratorsize(product(take(1:2, 2)))               == Base.HasShape{2}()
+@test Base.iteratorsize(product([1 2; 3 4]))                 == Base.HasShape{2}()
 
 # iteratoreltype trait business
 let f1 = Iterators.filter(i->i>0, 1:10)


### PR DESCRIPTION
Consider that all types implementing `start` are collections, and throw an error for `SizeUnknown` and `IsInfinite` iterators. This makes `broadcast` fail by default for most iterators, since the current fallback functions assume that collections support indexing. Custom iterators could implement their own methods, but the default ones should probably be improved to collect iterators without requring indexing.

Possible fix for #18618.

This change is not terribly appealing as-is as it does not add any new feature, it just throws an error when calling `broadcast` on iterators, where they were previously treated as scalar. Treating iterators as scalars isn't very useful, as can be seen from the fast that only one test relied on this. In the perspective of the feature freeze, throwing errors is good since it will allow supporting `broadcast` on iterators without breaking existing code. But I'm not yet sure what the fallback implementation can look like: it would probably have to process one element at a time, but if multiple iterators are passed one of them would have to be collected temporarily somewhere (since repeated indexing is not possible in general).