### PR TITLE
widen `empty(::Set)` to `empty(::AbstractSet)`

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -27,7 +27,7 @@ function Set(g::Generator)
     return Set{T}(g)
 end
 
-empty(s::Set{T}, ::Type{U}=T) where {T,U} = Set{U}()
+empty(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 
 # return an empty set with eltype T, which is mutable (can be grown)
 # by default, a Set is returned

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -746,3 +746,14 @@ end
     @test pop!(d) == (3=>4)
     @test_throws ArgumentError pop!(d)
 end
+
+@testset "keys as a set" begin
+    d = Dict(1=>2, 3=>4)
+    @test keys(d) isa AbstractSet
+    @test empty(keys(d)) isa AbstractSet
+    let i = keys(d) ∩ Set([1,2])
+        @test i isa AbstractSet
+        @test i == Set([1])
+    end
+    @test map(string, keys(d)) == Set(["1","3"])
+end


### PR DESCRIPTION
This allows more operations e.g. on `KeySet` to work, like `map`. It also matches the other methods for `empty`, which apply to `AbstractDict` and `AbstractArray`.