### PR TITLE
Some corrections to findn

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -359,6 +359,9 @@ This section lists changes that do not have deprecation warnings.
     trait; see its documentation for details. Types which support subtraction (operator
     `-`) must now implement `widen` for hashing to work inside heterogeneous arrays.
 
+  * `findn(x::AbstractVector)` now return a 1-tuple with the vector of indices, to be
+    consistent with higher order arrays ([#25365]).
+
 Library improvements
 --------------------
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -1800,50 +1800,6 @@ end
 find(x::Bool) = x ? [1] : Vector{Int}()
 find(testf::Function, x::Number) = !testf(x) ? Vector{Int}() : [1]
 
-findn(A::AbstractVector) = find(A)
-
-"""
-    findn(A)
-
-Return a vector of indices for each dimension giving the locations of the non-zeros in `A`
-(determined by `A[i]!=0`).
-If there are no non-zero elements of `A`, return a 2-tuple of empty arrays.
-
-# Examples
-```jldoctest
-julia> A = [1 2 0; 0 0 3; 0 4 0]
-3×3 Array{Int64,2}:
- 1  2  0
- 0  0  3
- 0  4  0
-
-julia> findn(A)
-([1, 1, 3, 2], [1, 2, 2, 3])
-
-julia> A = zeros(2,2)
-2×2 Array{Float64,2}:
- 0.0  0.0
- 0.0  0.0
-
-julia> findn(A)
-(Int64[], Int64[])
-```
-"""
-function findn(A::AbstractMatrix)
-    nnzA = count(t -> t != 0, A)
-    I = similar(A, Int, nnzA)
-    J = similar(A, Int, nnzA)
-    cnt = 1
-    for j=axes(A,2), i=axes(A,1)
-        if A[i,j] != 0
-            I[cnt] = i
-            J[cnt] = j
-            cnt += 1
-        end
-    end
-    return (I, J)
-end
-
 """
     findnz(A)
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -689,13 +689,39 @@ end
 # small helper function since we cannot use a closure in a generated function
 _countnz(x) = x != 0
 
+"""
+    findn(A)
+
+Return one vector for each dimension containing indices giving the
+locations of the non-zeros in `A` (determined by `A[i] != 0`).
+
+# Examples
+```jldoctest
+julia> A = [1 2 0; 0 0 3; 0 4 0]
+3×3 Array{Int64,2}:
+ 1  2  0
+ 0  0  3
+ 0  4  0
+
+julia> findn(A)
+([1, 1, 3, 2], [1, 2, 2, 3])
+
+julia> A = [0 0; 0 0]
+2×2 Array{Int64,2}:
+ 0  0
+ 0  0
+
+julia> findn(A)
+(Int64[], Int64[])
+```
+"""
 @generated function findn(A::AbstractArray{T,N}) where {T,N}
     quote
         nnzA = count(_countnz, A)
         @nexprs $N d->(I_d = Vector{Int}(uninitialized, nnzA))
         k = 1
         @nloops $N i A begin
-            @inbounds if (@nref $N A i) != zero(T)
+            @inbounds if (@nref $N A i) != 0
                 @nexprs $N d->(I_d[k] = i_d)
                 k += 1
             end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -481,6 +481,8 @@ end
         z[a[1][i],a[2][i],a[3][i]] = 10
     end
     @test isequal(a,findn(z))
+
+    @test findn([1, 0, 2]) == ([1, 3], )
 end
 
 @testset "findmin findmax indmin indmax" begin


### PR DESCRIPTION
Fixes this oversight from #23812
```
julia> findn(rand(2))
┌ Warning: In the future `find(A)` will only work on boolean collections. Use `find(x->x!=0, A)` instead.
│   caller = findn(::Array{Float64,1}) at array.jl:1803
└ @ Base array.jl:1803
2-element Array{Int64,1}:
 1
 2
```
and adjust the docs for `findn` (fix #25343).

Two other things I noticed:
- It is a bit incosistent that `findn` return a tuple for all cases except for vectors. Should we also apply
```diff
diff --git a/base/array.jl b/base/array.jl
index d482e18..e1a8ce4 100644
--- a/base/array.jl
+++ b/base/array.jl
@@ -1800,7 +1800,7 @@ end
 find(x::Bool) = x ? [1] : Vector{Int}()
 find(testf::Function, x::Number) = !testf(x) ? Vector{Int}() : [1]
 
-findn(A::AbstractVector) = find(x -> x != 0, A)
+findn(A::AbstractVector) = (find(x -> x != 0, A), )
 
 """
     findn(A)
```

- Are the methods here in `base/array.jl` for vectors and matrices needed, or should we simply remove them in favor of https://github.com/JuliaLang/julia/blob/a70504f5db92c7b4995b3b67fa7ece399a0147c2/base/multidimensional.jl#L692-L705 (which for some simple test cases seems to be more efficient.)