### PR TITLE
add issetequal and make hash/== generic for AbstractSet

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -362,6 +362,10 @@ This section lists changes that do not have deprecation warnings.
     trait; see its documentation for details. Types which support subtraction (operator
     `-`) must now implement `widen` for hashing to work inside heterogeneous arrays.
 
+  * `AbstractSet` objects are now considered equal by `==` and `isequal` if all of their
+    elements are equal ([#25368]). This has required changing the hashing algorithm
+    for `BitSet`.
+
   * `findn(x::AbstractVector)` now return a 1-tuple with the vector of indices, to be
     consistent with higher order arrays ([#25365]).
 

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -326,7 +326,7 @@ function _check0(a::Vector{UInt64}, b::Int, e::Int)
     true
 end
 
-function ==(s1::BitSet, s2::BitSet)
+function issetequal(s1::BitSet, s2::BitSet)
     # Swap so s1 has always the smallest offset
     if s1.offset > s2.offset
         s1, s2 = s2, s1
@@ -356,33 +356,9 @@ function ==(s1::BitSet, s2::BitSet)
     return true
 end
 
-issubset(a::BitSet, b::BitSet) = isequal(a, intersect(a,b))
-<(a::BitSet, b::BitSet) = (a<=b) && !isequal(a,b)
-<=(a::BitSet, b::BitSet) = issubset(a, b)
+⊆(a::BitSet, b::BitSet) = a == intersect(a,b)
+⊊(a::BitSet, b::BitSet) = a <= b && a != b
 
-const hashis_seed = UInt === UInt64 ? 0x88989f1fc7dea67d : 0xc7dea67d
-function hash(s::BitSet, h::UInt)
-    h ⊻= hashis_seed
-    bc = s.bits
-    i = 1
-    j = length(bc)
-
-    while j > 0 && bc[j] == CHK0
-        # Skip trailing empty bytes to prevent extra space from changing the hash
-        j -= 1
-    end
-    while i <= j && bc[i] == CHK0
-        # Skip leading empty bytes to prevent extra space from changing the hash
-        i += 1
-    end
-    i > j && return h # empty
-    h = hash(i+s.offset, h) # normalized offset
-    while j >= i
-        h = hash(bc[j], h)
-        j -= 1
-    end
-    h
-end
 
 minimum(s::BitSet) = first(s)
 maximum(s::BitSet) = last(s)

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -326,7 +326,7 @@ function _check0(a::Vector{UInt64}, b::Int, e::Int)
     true
 end
 
-function issetequal(s1::BitSet, s2::BitSet)
+function ==(s1::BitSet, s2::BitSet)
     # Swap so s1 has always the smallest offset
     if s1.offset > s2.offset
         s1, s2 = s2, s1
@@ -356,7 +356,7 @@ function issetequal(s1::BitSet, s2::BitSet)
     return true
 end
 
-⊆(a::BitSet, b::BitSet) = a == intersect(a,b)
+issubset(a::BitSet, b::BitSet) = a == intersect(a,b)
 ⊊(a::BitSet, b::BitSet) = a <= b && a != b
 
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -642,6 +642,7 @@ export
     intersect,
     isempty,
     issubset,
+    issetequal,
     keys,
     keytype,
     length,

--- a/base/set.jl
+++ b/base/set.jl
@@ -261,9 +261,9 @@ function symdiff!(s::AbstractSet, itr)
     s
 end
 
+==(l::AbstractSet, r::AbstractSet) = length(l) == length(r) && l ⊆ r
 # convenience functions for AbstractSet
-# (if needed, only their synonyms issetequal, ⊊ and ⊆ must be specialized)
-==(l::AbstractSet, r::AbstractSet) = issetequal(l, r)
+# (if needed, only their synonyms ⊊ and ⊆ must be specialized)
 <( l::AbstractSet, r::AbstractSet) = l ⊊ r
 <=(l::AbstractSet, r::AbstractSet) = l ⊆ r
 
@@ -284,7 +284,7 @@ julia> issubset([1, 2, 3], [1, 2])
 false
 ```
 """
-function ⊆(l, r)
+function issubset(l, r)
     for elt in l
         if !in(elt, r)
             return false
@@ -295,7 +295,7 @@ end
 # use the implementation below when it becoms as efficient
 # issubset(l, r) = all(_in(r), l)
 
-const issubset = ⊆
+const ⊆ = issubset
 
 """
     issetequal(a, b)
@@ -313,6 +313,7 @@ true
 ```
 """
 issetequal(l, r) = length(l) == length(r) && l ⊆ r
+issetequal(l::AbstractSet, r::AbstractSet) = l == r
 
 ⊊(l, r) = length(l) < length(r) && l ⊆ r
 ⊈(l, r) = !⊆(l, r)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -61,6 +61,15 @@ end
     @test !isequal(Set{Any}([1,2,3,4]), Set{Int}([1,2,3]))
     @test !isequal(Set{Int}([1,2,3,4]), Set{Any}([1,2,3]))
 end
+
+@testset "hash and == for Set/BitSet" begin
+    for s = (Set([1]), Set(1:10), Set(-100:7:100))
+        b = BitSet(s)
+        @test hash(s) == hash(b)
+        @test s == b
+    end
+end
+
 @testset "eltype, empty" begin
     s1 = empty(Set([1,"hello"]))
     @test isequal(s1, Set())
@@ -535,4 +544,41 @@ end
 
     # avoid recursive call issue #25384
     @test_throws MethodError replace!("")
+end
+
+@testset "⊆, ⊊, ⊈, ⊇, ⊋, ⊉, <, <=, issetequal" begin
+    a = [1, 2]
+    b = [2, 1, 3]
+    for C = (Tuple, identity, Set, BitSet)
+        A = C(a)
+        B = C(b)
+        @test A ⊆ B
+        @test A ⊊ B
+        @test !(A ⊈ B)
+        @test !(A ⊇ B)
+        @test !(A ⊋ B)
+        @test A ⊉ B
+        @test !(B ⊆ A)
+        @test !(B ⊊ A)
+        @test B ⊈ A
+        @test B ⊇ A
+        @test B ⊋ A
+        @test !(B ⊉ A)
+        @test !issetequal(A, B)
+        @test !issetequal(B, A)
+        if A isa AbstractSet && B isa AbstractSet
+            @test A <= B
+            @test A <  B
+            @test !(A >= B)
+            @test !(A >  B)
+            @test !(B <= A)
+            @test !(B <  A)
+            @test B >= A
+            @test B >  A
+        end
+        for D = (Tuple, identity, Set, BitSet)
+            @test issetequal(A, D(A))
+            @test !issetequal(A, D(B))
+        end
+    end
 end


### PR DESCRIPTION
This is a fix for #25318. It implements a generic `issetequal` binary predicate which tests whether two collections have the same elements. Moreover, it defines `==(::AbstractSet, ::AbstractSet)` and `hash(::AbstractSet)` generically so that two sets compare and hash equal. As noted in the issue, this makes `hash` significantly slower for `BitSet` (by about 6x, i.e. more or less as "slow" as for `Set`), but it's probably not a big deal.

In the current state, `issetequal`, `⊆`, and `⊊` are the "primary" functions, which are the ones to be specialized if needed, and `==`, `<=` and `<` are aliases for those. I chose so as it makes the implementation simpler: 
1. otherwise, `issetequal`, `⊆`, and `⊊` have to be defined both for generic collections and for `AbstractSet` 
2. the implementation of a particular set type could have to specialize both `==(::MySet, ::AbstractSet)` and `issetequal(::MySet, itr)` depending on whether the other argument is a set (and similarly for the other 2 functions). It seems simpler to only have to specialize one functions in all cases, (which can also share the same implementation whatever the second argument is, `AbstractSet` or not).

But it's possibly ugly for a set type to specialize `issetequal` instead of `==`.

Note that the generic implementation of `issetequal(a, b)` currently requires `length(a)` and `length(b)` to exist, but this could be lifted in the future. 