### PR TITLE
don't double-count data shared by multiple arrays in `summarysize`

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -100,11 +100,16 @@ end
 
 function (ss::SummarySize)(obj::Array)
     haskey(ss.seen, obj) ? (return 0) : (ss.seen[obj] = true)
-    size::Int = Core.sizeof(obj)
-    # TODO: add size of jl_array_t
-    if !isbits(eltype(obj)) && !isempty(obj)
-        push!(ss.frontier_x, obj)
-        push!(ss.frontier_i, 1)
+    headersize = 4*sizeof(Int) + 8 + max(0, ndims(obj)-2)*sizeof(Int)
+    size::Int = headersize
+    datakey = unsafe_convert(Ptr{Cvoid}, obj)
+    if !haskey(ss.seen, datakey)
+        ss.seen[datakey] = true
+        size += Core.sizeof(obj)
+        if !isbits(eltype(obj)) && !isempty(obj)
+            push!(ss.frontier_x, obj)
+            push!(ss.frontier_i, 1)
+        end
     end
     return size
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -194,6 +194,14 @@ let R = Ref{Any}(nothing), depth = 10^6
     @test summarysize(R) == (depth + 4) * sizeof(Ptr)
 end
 
+# issue #25367 - summarysize with reshaped arrays
+let A = zeros(1000), B = reshape(A, (1,1000))
+    @test summarysize((A,B)) < 2 * sizeof(A)
+
+    # check that object header is accounted for
+    @test summarysize(A) > sizeof(A)
+end
+
 module _test_varinfo_
 export x
 x = 1.0


### PR DESCRIPTION
also count Array object header size

fixes #25367