### PR TITLE
make `b"..."` give a `CodeUnits` of the string

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -860,7 +860,7 @@ function decode_dec(d::Integer)
     return Int32(pt), Int32(pt), neg
 end
 
-function decode_hex(d::Integer, symbols::Array{UInt8,1})
+function decode_hex(d::Integer, symbols::AbstractArray{UInt8,1})
     neg, x = handlenegative(d)
     @handle_zero x
     pt = i = (sizeof(x)<<1)-(leading_zeros(x)>>2)
@@ -1034,10 +1034,10 @@ ini_HEX(x::Real, n::Int) = ini_hex(x,n,HEX_symbols)
 ini_hex(x::Real) = ini_hex(x,hex_symbols)
 ini_HEX(x::Real) = ini_hex(x,HEX_symbols)
 
-ini_hex(x::Real, n::Int, symbols::Array{UInt8,1}) = ini_hex(float(x), n, symbols)
-ini_hex(x::Real, symbols::Array{UInt8,1}) = ini_hex(float(x), symbols)
+ini_hex(x::Real, n::Int, symbols::AbstractArray{UInt8,1}) = ini_hex(float(x), n, symbols)
+ini_hex(x::Real, symbols::AbstractArray{UInt8,1}) = ini_hex(float(x), symbols)
 
-function ini_hex(x::SmallFloatingPoint, n::Int, symbols::Array{UInt8,1})
+function ini_hex(x::SmallFloatingPoint, n::Int, symbols::AbstractArray{UInt8,1})
     x = Float64(x)
     if x == 0.0
         ccall(:memset, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Csize_t), DIGITS, '0', n)
@@ -1062,7 +1062,7 @@ function ini_hex(x::SmallFloatingPoint, n::Int, symbols::Array{UInt8,1})
     end
 end
 
-function ini_hex(x::SmallFloatingPoint, symbols::Array{UInt8,1})
+function ini_hex(x::SmallFloatingPoint, symbols::AbstractArray{UInt8,1})
     x = Float64(x)
     if x == 0.0
         ccall(:memset, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Csize_t), DIGITS, '0', 1)

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -374,7 +374,7 @@ function unescape_string(io, s::AbstractString)
 end
 
 macro b_str(s)
-    v = Vector{UInt8}(codeunits(unescape_string(s)))
+    v = codeunits(unescape_string(s))
     QuoteNode(v)
 end
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -190,7 +190,7 @@ end
 # pr #11554
 let a,
     io = IOBuffer(SubString("***αhelloworldω***", 4, 16)),
-    io2 = IOBuffer(b"goodnightmoon", true, true)
+    io2 = IOBuffer(Vector{UInt8}(b"goodnightmoon"), true, true)
 
     @test read(io, Char) == 'α'
     @test_throws ArgumentError write(io,"!")

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -334,3 +334,12 @@ end
         @test_throws ArgumentError hex2bytes(b"0123456789abcdefABCDEFGH")
     end
 end
+
+# b"" should be immutable
+let testb() = b"0123"
+    b = testb()
+    @test eltype(b) === UInt8
+    @test b isa AbstractVector
+    @test_throws ErrorException b[4] = '4'
+    @test testb() == UInt8['0','1','2','3']
+end


### PR DESCRIPTION
Before it was mutable but returned the same vector every time, which could cause problems.