### PR TITLE
remove `using DelimitedFiles` from default juliarc

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1262,6 +1262,11 @@ export conv, conv2, deconv, filt, filt!, xcorr
 
 @eval @deprecate_moved $(Symbol("@profile")) "Profile" true true
 
+@deprecate_moved readdlm  "DelimitedFiles" true true
+@deprecate_moved writedlm "DelimitedFiles" true true
+@deprecate_moved readcsv  "DelimitedFiles" true true
+@deprecate_moved writecsv "DelimitedFiles" true true
+
 @deprecate_moved base64encode "Base64" true true
 @deprecate_moved base64decode "Base64" true true
 @deprecate_moved Base64EncodePipe "Base64" true true

--- a/etc/juliarc.jl
+++ b/etc/juliarc.jl
@@ -1,4 +1,2 @@
 # This file should contain site-specific commands to be executed on Julia startup
 # Users may store their own personal commands in the user home directory `homedir()`, in a file named `.juliarc.jl`
-
-using DelimitedFiles


### PR DESCRIPTION
Now that we have quite a few stdlib packages, it seems odd for this to be the only one loaded by default in the repl.