### PR TITLE
fix fallback floating-point `isless` for `-NaN, NaN`

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -121,9 +121,9 @@ values such as `NaN`.
 """
 function isless end
 
-isless(x::AbstractFloat, y::AbstractFloat) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
-isless(x::Real,          y::AbstractFloat) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
-isless(x::AbstractFloat, y::Real         ) = (!isnan(x) & isnan(y)) | signless(x, y) | (x < y)
+isless(x::AbstractFloat, y::AbstractFloat) = (!isnan(x) & (isnan(y) | signless(x, y))) | (x < y)
+isless(x::Real,          y::AbstractFloat) = (!isnan(x) & (isnan(y) | signless(x, y))) | (x < y)
+isless(x::AbstractFloat, y::Real         ) = (!isnan(x) & (isnan(y) | signless(x, y))) | (x < y)
 
 
 function ==(T::Type, S::Type)

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -490,6 +490,13 @@ end
     # total ordering
     @test isless(big(-0.0), big(0.0))
     @test isless(big(1.0), big(NaN))
+    @test isless(big(Inf), big(NaN))
+    @test isless(big(Inf), -big(NaN))
+    @test !isless(big(NaN), big(NaN))
+    @test !isless(big(-NaN), big(NaN))
+    @test !isless(-big(NaN), big(NaN))
+    @test !isless(-big(NaN), big(1.0))
+    @test !isless(-big(NaN), 1.0)
 
     # cmp
     @test cmp(big(-0.0), big(0.0)) == 0

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -720,6 +720,8 @@ end
     @test !isless(+NaN,+Inf)
     @test !isless(+NaN,-NaN)
     @test !isless(+NaN,+NaN)
+    @test !isless(+NaN,1)
+    @test !isless(-NaN,1)
 
     @test  isequal(   0, 0.0)
     @test  isequal( 0.0,   0)


### PR DESCRIPTION
This was causing e.g. `isless(-big(NaN), big(NaN))` to disagree with `isless(-NaN, NaN)`.