### PR TITLE
preserve sign of NaN in conversions to and from BigFloat

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -97,7 +97,7 @@ widen(::Type{BigFloat}) = BigFloat
 BigFloat(x::BigFloat) = x
 
 # convert to BigFloat
-for (fJ, fC) in ((:si,:Clong), (:ui,:Culong), (:d,:Float64))
+for (fJ, fC) in ((:si,:Clong), (:ui,:Culong))
     @eval begin
         function BigFloat(x::($fC))
             z = BigFloat()
@@ -105,6 +105,16 @@ for (fJ, fC) in ((:si,:Clong), (:ui,:Culong), (:d,:Float64))
             return z
         end
     end
+end
+
+function BigFloat(x::Float64)
+    z = BigFloat()
+    ccall((:mpfr_set_d, :libmpfr), Int32, (Ref{BigFloat}, Float64, Int32), z, x, ROUNDING_MODE[])
+    if isnan(x) && signbit(x) != signbit(z)
+        # for some reason doing mpfr_neg in-place doesn't work here
+        return -z
+    end
+    return z
 end
 
 function BigFloat(x::BigInt)
@@ -247,19 +257,22 @@ function (::Type{T})(x::BigFloat) where T<:Integer
 end
 
 ## BigFloat -> AbstractFloat
+
+_cpynansgn(x::AbstractFloat, y::BigFloat) = isnan(x) && signbit(x) != signbit(y) ? -x : x
+
 Float64(x::BigFloat) =
-    ccall((:mpfr_get_d,:libmpfr), Float64, (Ref{BigFloat}, Int32), x, ROUNDING_MODE[])
+    _cpynansgn(ccall((:mpfr_get_d,:libmpfr), Float64, (Ref{BigFloat}, Int32), x, ROUNDING_MODE[]), x)
 Float32(x::BigFloat) =
-    ccall((:mpfr_get_flt,:libmpfr), Float32, (Ref{BigFloat}, Int32), x, ROUNDING_MODE[])
+    _cpynansgn(ccall((:mpfr_get_flt,:libmpfr), Float32, (Ref{BigFloat}, Int32), x, ROUNDING_MODE[]), x)
 # TODO: avoid double rounding
-Float16(x::BigFloat) = convert(Float16, convert(Float32, x))
+Float16(x::BigFloat) = Float16(Float32(x))
 
 Float64(x::BigFloat, r::RoundingMode) =
-    ccall((:mpfr_get_d,:libmpfr), Float64, (Ref{BigFloat}, Int32), x, to_mpfr(r))
+    _cpynansgn(ccall((:mpfr_get_d,:libmpfr), Float64, (Ref{BigFloat}, Int32), x, to_mpfr(r)), x)
 Float32(x::BigFloat, r::RoundingMode) =
-    ccall((:mpfr_get_flt,:libmpfr), Float32, (Ref{BigFloat}, Int32), x, to_mpfr(r))
+    _cpynansgn(ccall((:mpfr_get_flt,:libmpfr), Float32, (Ref{BigFloat}, Int32), x, to_mpfr(r)), x)
 # TODO: avoid double rounding
-Float16(x::BigFloat, r::RoundingMode) = convert(Float16, Float32(x, r))
+Float16(x::BigFloat, r::RoundingMode) = Float16(Float32(x, r))
 
 promote_rule(::Type{BigFloat}, ::Type{<:Real}) = BigFloat
 promote_rule(::Type{BigInt}, ::Type{<:AbstractFloat}) = BigFloat

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -353,6 +353,7 @@ end
     y = BigFloat(-1)
     @test copysign(x, y) == y
     @test copysign(y, x) == x
+    @test copysign(1.0, BigFloat(NaN)) == 1.0
 end
 @testset "isfinite / isinf / isnan" begin
     x = BigFloat(Inf)
@@ -380,6 +381,9 @@ end
     @test typeof(convert(BigFloat, parse(BigInt,"9223372036854775808"))) == BigFloat
     @test convert(AbstractFloat, parse(BigInt,"9223372036854775808")) == parse(BigFloat,"9223372036854775808")
     @test typeof(convert(AbstractFloat, parse(BigInt,"9223372036854775808"))) == BigFloat
+
+    @test signbit(BigFloat(NaN)) == 0
+    @test signbit(BigFloat(-NaN)) == 1
 end
 @testset "convert from BigFloat" begin
     @test convert(Float64, BigFloat(0.5)) == 0.5
@@ -388,6 +392,9 @@ end
     @test convert(Bool, BigFloat(0.0)) == false
     @test convert(Bool, BigFloat(1.0)) == true
     @test_throws InexactError convert(Bool, BigFloat(0.1))
+
+    @test signbit(Float64(BigFloat(NaN))) == 0
+    @test signbit(Float64(-BigFloat(NaN))) == 1
 end
 @testset "exponent, frexp, significand" begin
     x = BigFloat(0)


### PR DESCRIPTION
Looking at #5290 led me to finding various issues with the sign bit of NaN, which, let's be honest, is basically what most issues boil down to.

I don't know if this really matters, but our other floating point conversions preserve the sign of NaN so I figure these should too. Currently we get e.g.:

```
julia> signbit(big(NaN))  # ok
false

julia> signbit(Float64(big(NaN)))  # not ok
true

julia> copysign(1.0, big(NaN))  # not ok
-1.0

julia> signbit(big(-NaN))  # not ok
false
```

Maybe this is a bug in MPFR; not sure.