### PR TITLE
deprecate `lexcmp`, `lexless`; define `cmp` in terms of `isless`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1556,13 +1556,16 @@ function isequal(A::AbstractArray, B::AbstractArray)
     return true
 end
 
-function lexcmp(A::AbstractArray, B::AbstractArray)
+function cmp(A::AbstractArray, B::AbstractArray)
     for (a, b) in zip(A, B)
-        res = lexcmp(a, b)
-        res == 0 || return res
+        if !isequal(a, b)
+            return isless(a, b) ? -1 : 1
+        end
     end
     return cmp(length(A), length(B))
 end
+
+isless(A::AbstractArray, B::AbstractArray) = cmp(A, B) < 0
 
 function (==)(A::AbstractArray, B::AbstractArray)
     if axes(A) != axes(B)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1309,8 +1309,8 @@ end
 
 _memcmp(a, b, len) = ccall(:memcmp, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), a, b, len) % Int
 
-# use memcmp for lexcmp on byte arrays
-function lexcmp(a::Array{UInt8,1}, b::Array{UInt8,1})
+# use memcmp for cmp on byte arrays
+function cmp(a::Array{UInt8,1}, b::Array{UInt8,1})
     c = _memcmp(a, b, min(length(a),length(b)))
     return c < 0 ? -1 : c > 0 ? +1 : cmp(length(a),length(b))
 end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -938,12 +938,6 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
 end
 atanh(z::Complex) = atanh(float(z))
 
-function lexcmp(a::Complex, b::Complex)
-    c = cmp(real(a), real(b))
-    c == 0 || return c
-    cmp(imag(a), imag(b))
-end
-
 #Rounding complex numbers
 #Requires two different RoundingModes for the real and imaginary components
 """

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -3806,6 +3806,14 @@ end
     @deprecate getq(F::Factorization) F.Q
 end
 
+# issue #5290
+@deprecate lexcmp(x::AbstractArray, y::AbstractArray) cmp(x, y)
+@deprecate lexcmp(x::Real, y::Real)                   cmp(isless, x, y)
+@deprecate lexcmp(x::Complex, y::Complex)             cmp((real(x),imag(x)), (real(y),imag(y)))
+@deprecate lexcmp(x, y)                               cmp(x, y)
+
+@deprecate lexless isless
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -804,8 +804,6 @@ export
     isimmutable,
     isless,
     ifelse,
-    lexless,
-    lexcmp,
     object_id,
     sizeof,
 

--- a/base/float.jl
+++ b/base/float.jl
@@ -460,22 +460,6 @@ for op in (:<, :<=, :isless)
     @eval ($op)(a::Float16, b::Float16) = ($op)(Float32(a), Float32(b))
 end
 
-function cmp(x::AbstractFloat, y::AbstractFloat)
-    isnan(x) && throw(DomainError(x, "`x` cannot be NaN."))
-    isnan(y) && throw(DomainError(y, "`y` cannot be NaN."))
-    ifelse(x<y, -1, ifelse(x>y, 1, 0))
-end
-
-function cmp(x::Real, y::AbstractFloat)
-    isnan(y) && throw(DomainError(y, "`y` cannot be NaN."))
-    ifelse(x<y, -1, ifelse(x>y, 1, 0))
-end
-
-function cmp(x::AbstractFloat, y::Real)
-    isnan(x) && throw(DomainError(x, "`x` cannot be NaN."))
-    ifelse(x<y, -1, ifelse(x>y, 1, 0))
-end
-
 # Exact Float (Tf) vs Integer (Ti) comparisons
 # Assumes:
 # - typemax(Ti) == 2^n-1

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -492,7 +492,7 @@ cmp(x::BigInt, y::CulongMax) = MPZ.cmp_ui(x, y)
 cmp(x::BigInt, y::Integer) = cmp(x, big(y))
 cmp(x::Integer, y::BigInt) = -cmp(y, x)
 
-cmp(x::BigInt, y::CdoubleMax) = isnan(y) ? throw(DomainError(y, "`y` cannot be NaN.")) : MPZ.cmp_d(x, y)
+cmp(x::BigInt, y::CdoubleMax) = isnan(y) ? -1 : MPZ.cmp_d(x, y)
 cmp(x::CdoubleMax, y::BigInt) = -cmp(y, x)
 
 isqrt(x::BigInt) = MPZ.sqrt(x)

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -676,23 +676,23 @@ end
 >(x::BigFloat, y::BigFloat) = ccall((:mpfr_greater_p, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigFloat}), x, y) != 0
 
 function cmp(x::BigFloat, y::BigInt)
-    isnan(x) && throw(DomainError(x, "`x` cannot be NaN."))
+    isnan(x) && return 1
     ccall((:mpfr_cmp_z, :libmpfr), Int32, (Ref{BigFloat}, Ref{BigInt}), x, y)
 end
 function cmp(x::BigFloat, y::ClongMax)
-    isnan(x) && throw(DomainError(x, "`x` cannot be NaN."))
+    isnan(x) && return 1
     ccall((:mpfr_cmp_si, :libmpfr), Int32, (Ref{BigFloat}, Clong), x, y)
 end
 function cmp(x::BigFloat, y::CulongMax)
-    isnan(x) && throw(DomainError(x, "`x` cannot be NaN."))
+    isnan(x) && return 1
     ccall((:mpfr_cmp_ui, :libmpfr), Int32, (Ref{BigFloat}, Culong), x, y)
 end
 cmp(x::BigFloat, y::Integer) = cmp(x,big(y))
 cmp(x::Integer, y::BigFloat) = -cmp(y,x)
 
 function cmp(x::BigFloat, y::CdoubleMax)
-    isnan(x) && throw(DomainError(x, "`x` cannot be NaN."))
-    isnan(y) && throw(DomainError(y, "`y` cannot be NaN."))
+    isnan(x) && return isnan(y) ? 0 : 1
+    isnan(y) && return -1
     ccall((:mpfr_cmp_d, :libmpfr), Int32, (Ref{BigFloat}, Cdouble), x, y)
 end
 cmp(x::CdoubleMax, y::BigFloat) = -cmp(y,x)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -300,7 +300,6 @@ const ≥ = >=
 # this definition allows Number types to implement < instead of isless,
 # which is more idiomatic:
 isless(x::Real, y::Real) = x<y
-lexcmp(x::Real, y::Real) = isless(x,y) ? -1 : ifelse(isless(y,x), 1, 0)
 
 """
     ifelse(condition::Bool, x, y)
@@ -342,35 +341,12 @@ Stacktrace:
 cmp(x, y) = isless(x, y) ? -1 : ifelse(isless(y, x), 1, 0)
 
 """
-    lexcmp(x, y)
+    cmp(<, x, y)
 
-Compare `x` and `y` lexicographically and return -1, 0, or 1 depending on whether `x` is
-less than, equal to, or greater than `y`, respectively. This function should be defined for
-lexicographically comparable types, and `lexless` will call `lexcmp` by default.
-
-# Examples
-```jldoctest
-julia> lexcmp("abc", "abd")
--1
-
-julia> lexcmp("abc", "abc")
-0
-```
+Return -1, 0, or 1 depending on whether `x` is less than, equal to, or greater than `y`,
+respectively. The first argument specifies a less-than comparison function to use.
 """
-lexcmp(x, y) = cmp(x, y)
-
-"""
-    lexless(x, y)
-
-Determine whether `x` is lexicographically less than `y`.
-
-# Examples
-```jldoctest
-julia> lexless("abc", "abd")
-true
-```
-"""
-lexless(x, y) = lexcmp(x,y) < 0
+cmp(<, x, y) = (x < y) ? -1 : ifelse(y < x, 1, 0)
 
 # cmp returns -1, 0, +1 indicating ordering
 cmp(x::Integer, y::Integer) = ifelse(isless(x, y), -1, ifelse(isless(y, x), 1, 0))

--- a/base/ordering.jl
+++ b/base/ordering.jl
@@ -5,9 +5,9 @@ module Order
 ## notions of element ordering ##
 
 export # not exported by Base
-    Ordering, Forward, Reverse, Lexicographic,
+    Ordering, Forward, Reverse,
     By, Lt, Perm,
-    ReverseOrdering, ForwardOrdering, LexicographicOrdering,
+    ReverseOrdering, ForwardOrdering,
     DirectOrdering,
     lt, ord, ordtype
 
@@ -26,9 +26,6 @@ const DirectOrdering = Union{ForwardOrdering,ReverseOrdering{ForwardOrdering}}
 const Forward = ForwardOrdering()
 const Reverse = ReverseOrdering(Forward)
 
-struct LexicographicOrdering <: Ordering end
-const Lexicographic = LexicographicOrdering()
-
 struct By{T} <: Ordering
     by::T
 end
@@ -46,16 +43,11 @@ lt(o::ForwardOrdering,       a, b) = isless(a,b)
 lt(o::ReverseOrdering,       a, b) = lt(o.fwd,b,a)
 lt(o::By,                    a, b) = isless(o.by(a),o.by(b))
 lt(o::Lt,                    a, b) = o.lt(a,b)
-lt(o::LexicographicOrdering, a, b) = lexcmp(a,b) < 0
 
 Base.@propagate_inbounds function lt(p::Perm, a::Integer, b::Integer)
     da = p.data[a]
     db = p.data[b]
     lt(p.order, da, db) | (!lt(p.order, db, da) & (a < b))
-end
-Base.@propagate_inbounds function lt(p::Perm{LexicographicOrdering}, a::Integer, b::Integer)
-    c = lexcmp(p.data[a], p.data[b])
-    c != 0 ? c < 0 : a < b
 end
 
 ordtype(o::ReverseOrdering, vs::AbstractArray) = ordtype(o.fwd, vs)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -285,8 +285,12 @@ end
 for rel in (:<,:<=,:cmp)
     for (Tx,Ty) in ((Rational,AbstractFloat), (AbstractFloat,Rational))
         @eval function ($rel)(x::$Tx, y::$Ty)
-            if isnan(x) || isnan(y)
-                $(rel == :cmp ? :(throw(DomainError((x,y), "Inputs cannot be NaN."))) :
+            if isnan(x)
+                $(rel == :cmp ? :(return isnan(y) ? 0 : 1) :
+                                :(return false))
+            end
+            if isnan(y)
+                $(rel == :cmp ? :(return -1) :
                                 :(return false))
             end
 

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -927,7 +927,7 @@ function sortrows(A::AbstractMatrix; kws...)
     for i in inds
         rows[i] = view(A, i, :)
     end
-    p = sortperm(rows; kws..., order=Lexicographic)
+    p = sortperm(rows; kws...)
     A[p,:]
 end
 
@@ -966,7 +966,7 @@ function sortcols(A::AbstractMatrix; kws...)
     for i in inds
         cols[i] = view(A, :, i)
     end
-    p = sortperm(cols; kws..., order=Lexicographic)
+    p = sortperm(cols; kws...)
     A[:,p]
 end
 

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -112,8 +112,6 @@ Core.isa
 Base.isequal
 Base.isless
 Base.ifelse
-Base.lexcmp
-Base.lexless
 Core.typeassert
 Core.typeof
 Core.tuple

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1033,27 +1033,27 @@ end
 end
 
 @testset "lexicographic comparison" begin
-    @test lexcmp([1.0], [1]) == 0
-    @test lexcmp([1], [1.0]) == 0
-    @test lexcmp([1, 1], [1, 1]) == 0
-    @test lexcmp([1, 1], [2, 1]) == -1
-    @test lexcmp([2, 1], [1, 1]) == 1
-    @test lexcmp([1, 1], [1, 2]) == -1
-    @test lexcmp([1, 2], [1, 1]) == 1
-    @test lexcmp([1], [1, 1]) == -1
-    @test lexcmp([1, 1], [1]) == 1
+    @test cmp([1.0], [1]) == 0
+    @test cmp([1], [1.0]) == 0
+    @test cmp([1, 1], [1, 1]) == 0
+    @test cmp([1, 1], [2, 1]) == -1
+    @test cmp([2, 1], [1, 1]) == 1
+    @test cmp([1, 1], [1, 2]) == -1
+    @test cmp([1, 2], [1, 1]) == 1
+    @test cmp([1], [1, 1]) == -1
+    @test cmp([1, 1], [1]) == 1
 end
 
 @testset "sort on arrays" begin
     local a = rand(3,3)
 
     asr = sortrows(a)
-    @test lexless(asr[1,:],asr[2,:])
-    @test lexless(asr[2,:],asr[3,:])
+    @test isless(asr[1,:],asr[2,:])
+    @test isless(asr[2,:],asr[3,:])
 
     asc = sortcols(a)
-    @test lexless(asc[:,1],asc[:,2])
-    @test lexless(asc[:,2],asc[:,3])
+    @test isless(asc[:,1],asc[:,2])
+    @test isless(asc[:,2],asc[:,3])
 
     # mutating functions
     o = ones(3, 4)
@@ -1062,12 +1062,12 @@ end
     @test o == ones(3, 4)
 
     asr = sortrows(a, rev=true)
-    @test lexless(asr[2,:],asr[1,:])
-    @test lexless(asr[3,:],asr[2,:])
+    @test isless(asr[2,:],asr[1,:])
+    @test isless(asr[3,:],asr[2,:])
 
     asc = sortcols(a, rev=true)
-    @test lexless(asc[:,2],asc[:,1])
-    @test lexless(asc[:,3],asc[:,2])
+    @test isless(asc[:,2],asc[:,1])
+    @test isless(asc[:,3],asc[:,2])
 
     as = sort(a, 1)
     @test issorted(as[:,1])

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -774,12 +774,6 @@ end
     @test isequal(atan(complex( NaN, NaN)),complex( NaN, NaN))
 end
 
-@testset "lexcmp" begin
-    @test lexcmp(1.0-1.0im, 1.0+0.0im) == -1
-    @test lexcmp(0.0+0.0im, 0.0+0.0im) == 0
-    @test lexcmp(1.0-1.0im, 0.0+0.0im) == 1
-end
-
 # misc.
 
 @test complex(1//2,1//3)^2 === complex(5//36, 1//3)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -313,7 +313,7 @@ for s in [map(first,V8); X8],
     ss = s[i:j]
     ss in X8 || push!(X8, ss)
 end
-sort!(X8, lt=lexless)
+sort!(X8, lt=isless)
 sort!(X8, by=length)
 
 I8 = [(s,map(UInt16,s)) for s in X8]

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -492,11 +492,11 @@ end
     @test isless(big(1.0), big(NaN))
 
     # cmp
-    @test cmp(big(-0.0), big(0.0)) == 0
-    @test cmp(big(0.0), big(-0.0)) == 0
-    @test_throws DomainError cmp(big(1.0), big(NaN))
-    @test_throws DomainError cmp(big(NaN), big(NaN))
-    @test_throws DomainError cmp(big(NaN), big(1.0))
+    @test cmp(big(-0.0), big(0.0)) == -1
+    @test cmp(big(0.0), big(-0.0)) == 1
+    @test cmp(big(1.0), big(NaN)) == -1
+    @test cmp(big(NaN), big(NaN)) == 0
+    @test cmp(big(NaN), big(1.0)) == 1
 end
 @testset "signbit" begin
     @test signbit(BigFloat(-1.0)) == 1

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -729,11 +729,11 @@ end
     @test  !isless(   0,-0.0)
 
     @test isless(-0.0, 0.0f0)
-    @test lexcmp(-0.0, 0.0f0) == -1
-    @test lexcmp(0.0, -0.0f0) == 1
-    @test lexcmp(NaN, 1) == 1
-    @test lexcmp(1, NaN) == -1
-    @test lexcmp(NaN, NaN) == 0
+    @test cmp(isless, -0.0, 0.0f0) == -1
+    @test cmp(isless, 0.0, -0.0f0) == 1
+    @test cmp(isless, NaN, 1) == 1
+    @test cmp(isless, 1, NaN) == -1
+    @test cmp(isless, NaN, NaN) == 0
 end
 @testset "Float vs Integer comparison" begin
     for x=-5:5, y=-5:5

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -82,7 +82,7 @@ import Base.<
 @test isequal(minmax(TO23094(2), TO23094(1))[1], TO23094(1))
 @test isequal(minmax(TO23094(2), TO23094(1))[2], TO23094(2))
 
-@test lexless('a','b')
+@test isless('a','b')
 
 @test 1 .!= 2
 @test 1 .== 1


### PR DESCRIPTION
Fixes #5290.