### PR TITLE
fix error handling in printf.jl

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -641,6 +641,7 @@ function gen_s(flags::String, width::Int, precision::Int, c::Char)
     #
     # flags:
     #  (-): left justify
+    #  (#): use `show`/`repr` instead of `print`/`string`
     #
     @gensym x
     blk = Expr(:block)
@@ -683,6 +684,9 @@ end
 function gen_p(flags::String, width::Int, precision::Int, c::Char)
     # print pointer:
     #  [p]: the only option
+    #
+    # flags:
+    #  (-): left justify
     #
     @gensym x
     blk = Expr(:block)
@@ -1183,7 +1187,7 @@ function _printf(macroname, io, fmt, args)
           quote
              G = $(esc(x))
              if length(G) != $(length(sym_args))
-                throw(ArgumentError($macroname,": wrong number of arguments (",length(G),") should be (",$(length(sym_args)),")"))
+                 throw(ArgumentError(string($macroname,": wrong number of arguments (",length(G),") should be (",$(length(sym_args)),")")))
              end
           end
        )


### PR DESCRIPTION
Resolves the following wrong behaviour (found in v0.7 and also in v0.6):

```
julia> using Printf

julia> @printf "%d%d%d" 1:2...
ERROR: MethodError: no method matching ArgumentError(::String, ::String, ::Int64, ::String, ::Int64, ::String)
Closest candidates are:
  ArgumentError(::AbstractString) at boot.jl:257
  ArgumentError(::Any) at boot.jl:257
Stacktrace:
 [1] top-level scope at printf.jl:1189
```

After change it looks like:
```
julia> @sprintf "%d%d%d" 1:2...
ERROR: ArgumentError: @sprintf: wrong number of arguments (2) should be (3)
```