### PR TITLE
RFC: Deprecate first() and last() on empty ranges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -233,7 +233,7 @@ This section lists changes that do not have deprecation warnings.
 
   * The representation of `CartesianRange` has changed to a
     tuple-of-AbstractUnitRanges; the `start` and `stop` fields are no
-    longer present. Use `first(R)` and `last(R)` to obtain
+    longer present. Use `rangestart(R)` and `rangestop(R)` to obtain
     start/stop. ([#20974])
 
   * The `Diagonal`, `Bidiagonal`, `Tridiagonal` and `SymTridiagonal` type definitions have
@@ -897,6 +897,10 @@ Deprecated or removed
     in favor of dot overloading (`getproperty`) so factors should now be accessed as e.g.
     `F.Q` instead of `F[:Q]` ([#25184]).
 
+  * Calling `first` and `last` on empty ranges has been deprecated in favor of `rangestart`
+    and `rangestop` (respectively). An error will be thrown in the future, for consistency
+    with other `AbstractArray` types ([#25385]).
+
 Command-line option changes
 ---------------------------
 
@@ -1140,3 +1144,4 @@ Command-line option changes
 [#25168]: https://github.com/JuliaLang/julia/issues/25168
 [#25184]: https://github.com/JuliaLang/julia/issues/25184
 [#25231]: https://github.com/JuliaLang/julia/issues/25231
+[#25385]: https://github.com/JuliaLang/julia/issues/25385

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -156,7 +156,7 @@ function flipdim(A::AbstractArray, d::Integer)
         nnd += Int(length(inds[i])==1 || i==d)
     end
     indsd = inds[d]
-    sd = first(indsd)+last(indsd)
+    sd = rangestart(indsd)+rangestop(indsd)
     if nnd==nd
         # flip along the only non-singleton dimension
         for i in indsd

--- a/base/array.jl
+++ b/base/array.jl
@@ -551,7 +551,7 @@ function _collect(c, itr, ::EltypeUnknown, isz::Union{HasLength,HasShape})
 end
 
 function collect_to_with_first!(dest::AbstractArray, v1, itr, st)
-    i1 = first(linearindices(dest))
+    i1 = rangestart(linearindices(dest))
     dest[i1] = v1
     return collect_to!(dest, itr, i1+1, st)
 end
@@ -646,7 +646,7 @@ function getindex(A::Array, I::UnitRange{Int})
     lI = length(I)
     X = similar(A, lI)
     if lI > 0
-        unsafe_copyto!(X, 1, A, first(I), lI)
+        unsafe_copyto!(X, 1, A, rangestart(I), lI)
     end
     return X
 end
@@ -712,7 +712,7 @@ function setindex!(A::Array{T}, X::Array{T}, I::UnitRange{Int}) where T
     lI = length(I)
     @boundscheck setindex_shape_check(X, lI)
     if lI > 0
-        unsafe_copyto!(A, first(I), X, 1, lI)
+        unsafe_copyto!(A, rangestart(I), X, 1, lI)
     end
     return A
 end
@@ -817,7 +817,7 @@ function append!(a::Array{<:Any,1}, items::AbstractVector)
     itemindices = eachindex(items)
     n = length(itemindices)
     _growend!(a, n)
-    copyto!(a, length(a)-n+1, items, first(itemindices), n)
+    copyto!(a, length(a)-n+1, items, rangestart(itemindices), n)
     return a
 end
 
@@ -863,7 +863,7 @@ function prepend!(a::Array{<:Any,1}, items::AbstractVector)
     if a === items
         copyto!(a, 1, items, n+1, n)
     else
-        copyto!(a, 1, items, first(itemindices), n)
+        copyto!(a, 1, items, rangestart(itemindices), n)
     end
     return a
 end
@@ -1098,7 +1098,7 @@ deleteat!(a::Vector, i::Integer) = (_deleteat!(a, i, 1); a)
 
 function deleteat!(a::Vector, r::UnitRange{<:Integer})
     n = length(a)
-    isempty(r) || _deleteat!(a, first(r), length(r))
+    isempty(r) || _deleteat!(a, rangestart(r), length(r))
     return a
 end
 
@@ -1283,8 +1283,8 @@ function splice!(a::Vector, r::UnitRange{<:Integer}, ins=_default_splice)
     end
 
     n = length(a)
-    f = first(r)
-    l = last(r)
+    f = rangestart(r)
+    l = rangestop(r)
     d = length(r)
 
     if m < d
@@ -1367,22 +1367,24 @@ julia> reverse(A, 3, 5)
  3
 ```
 """
-function reverse(A::AbstractVector, s=first(linearindices(A)), n=last(linearindices(A)))
+function reverse(A::AbstractVector,
+                 s=rangestart(linearindices(A)),
+                 n=rangestop(linearindices(A)))
     B = similar(A)
-    for i = first(linearindices(A)):s-1
+    for i = rangestart(linearindices(A)):s-1
         B[i] = A[i]
     end
     for i = s:n
         B[i] = A[n+s-i]
     end
-    for i = n+1:last(linearindices(A))
+    for i = n+1:rangestop(linearindices(A))
         B[i] = A[i]
     end
     return B
 end
 function reverseind(a::AbstractVector, i::Integer)
     li = linearindices(a)
-    first(li) + last(li) - i
+    rangestart(li) + rangestop(li) - i
 end
 
 """
@@ -1411,12 +1413,14 @@ julia> A
  1
 ```
 """
-function reverse!(v::AbstractVector, s=first(linearindices(v)), n=last(linearindices(v)))
+function reverse!(v::AbstractVector,
+                  s=rangestart(linearindices(v)),
+                  n=rangestop(linearindices(v)))
     liv = linearindices(v)
     if n <= s  # empty case; ok
-    elseif !(first(liv) ≤ s ≤ last(liv))
+    elseif !(rangestart(liv) ≤ s ≤ rangestop(liv))
         throw(BoundsError(v, s))
-    elseif !(first(liv) ≤ n ≤ last(liv))
+    elseif !(rangestart(liv) ≤ n ≤ rangestop(liv))
         throw(BoundsError(v, n))
     end
     r = n
@@ -2209,7 +2213,7 @@ function filter!(f, a::AbstractVector)
         end
     end
 
-    deleteat!(a, i:last(idx))
+    deleteat!(a, i:rangestop(idx))
 
     return a
 end

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -140,7 +140,7 @@ julia> rotl90(a)
 function rotl90(A::AbstractMatrix)
     ind1, ind2 = axes(A)
     B = similar(A, (ind2,ind1))
-    n = first(ind2)+last(ind2)
+    n = rangestart(ind2)+rangestop(ind2)
     for i=axes(A,1), j=ind2
         B[n-j,i] = A[i,j]
     end
@@ -168,7 +168,7 @@ julia> rotr90(a)
 function rotr90(A::AbstractMatrix)
     ind1, ind2 = axes(A)
     B = similar(A, (ind2,ind1))
-    m = first(ind1)+last(ind1)
+    m = rangestart(ind1)+rangestop(ind1)
     for i=ind1, j=axes(A,2)
         B[j,m-i] = A[i,j]
     end
@@ -195,7 +195,8 @@ julia> rot180(a)
 function rot180(A::AbstractMatrix)
     B = similar(A)
     ind1, ind2 = axes(A,1), axes(A,2)
-    m, n = first(ind1)+last(ind1), first(ind2)+last(ind2)
+    m = rangestart(ind1)+rangestop(ind1)
+    n = rangestart(ind2)+rangestop(ind2)
     for j=ind2, i=ind1
         B[m-i,n-j] = A[i,j]
     end

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -96,7 +96,8 @@ is specified as string sep.
 function print_matrix_row(io::IO,
         X::AbstractVecOrMat, A::Vector,
         i::Integer, cols::AbstractVector, sep::AbstractString)
-    isempty(A) || first(axes(cols,1)) == 1 || throw(DimensionMismatch("indices of cols ($(axes(cols,1))) must start at 1"))
+    isempty(A) || rangestart(axes(cols,1)) == 1 ||
+        throw(DimensionMismatch("indices of cols ($(axes(cols,1))) must start at 1"))
     for k = 1:length(A)
         j = cols[k]
         if isassigned(X,Int(i),Int(j)) # isassigned accepts only `Int` indices
@@ -268,11 +269,11 @@ function show_nd(io::IO, a::AbstractArray, print_matrix::Function, label_slices:
                 ii = idxs[i]
                 ind = tailinds[i]
                 if length(ind) > 10
-                    if ii == ind[4] && all(d->idxs[d]==first(tailinds[d]),1:i-1)
+                    if ii == ind[4] && all(d->idxs[d]==rangestart(tailinds[d]),1:i-1)
                         for j=i+1:nd
                             szj = length(axes(a, j+2))
                             indj = tailinds[j]
-                            if szj>10 && first(indj)+2 < idxs[j] <= last(indj)-3
+                            if szj>10 && rangestart(indj)+2 < idxs[j] <= rangestop(indj)-3
                                 @goto skip
                             end
                         end
@@ -293,7 +294,7 @@ function show_nd(io::IO, a::AbstractArray, print_matrix::Function, label_slices:
         end
         slice = view(a, axes(a,1), axes(a,2), idxs...)
         print_matrix(io, slice)
-        print(io, idxs == map(last,tailinds) ? "" : "\n\n")
+        print(io, idxs == map(rangestop,tailinds) ? "" : "\n\n")
         @label skip
     end
 end
@@ -380,7 +381,7 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
         for i in rr
             for cr in (cr1, cr2)
                 for j in cr
-                    j > first(cr) && print(io, " ")
+                    j > rangestart(cr) && print(io, " ")
                     if !isassigned(X,i,j)
                         print(io, undef_ref_str)
                     else
@@ -388,14 +389,14 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
                         show(io, el)
                     end
                 end
-                if last(cr) == last(indc)
-                    i < last(indr) && print(io, "; ")
+                if rangestop(cr) == rangestop(indc)
+                    i < rangestop(indr) && print(io, "; ")
                 elseif cdots
                     print(io, " \u2026 ")
                 end
             end
         end
-        last(rr) != nr && rdots && print(io, "\u2026 ; ")
+        rangestop(rr) != nr && rdots && print(io, "\u2026 ; ")
     end
     print(io, "]")
 end

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -644,7 +644,8 @@ end
     return B
 end
 
-indexoffset(i) = rangestart(i)-1
+indexoffset(i::Integer) = i-1
+indexoffset(i::AbstractRange) = rangestart(i)-1
 indexoffset(::Colon) = 0
 
 @inline function setindex!(B::BitArray, x, J0::Union{Colon,UnitRange{Int}})
@@ -1000,8 +1001,12 @@ const _default_bit_splice = BitVector()
 
 function splice!(B::BitVector, r::Union{UnitRange{Int}, Integer}, ins::AbstractArray = _default_bit_splice)
     n = length(B)
-    i_f = rangestart(r)
-    i_l = rangestop(r)
+    if r isa Integer
+        i_f = i_l = r
+    else
+        i_f = rangestart(r)
+        i_l = rangestop(r)
+    end
 
     1 <= i_f <= n+1 || throw(BoundsError(B, i_f))
     i_l <= n || throw(BoundsError(B, n+1))

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -644,7 +644,7 @@ end
     return B
 end
 
-indexoffset(i) = first(i)-1
+indexoffset(i) = rangestart(i)-1
 indexoffset(::Colon) = 0
 
 @inline function setindex!(B::BitArray, x, J0::Union{Colon,UnitRange{Int}})
@@ -927,8 +927,8 @@ end
 
 function deleteat!(B::BitVector, r::UnitRange{Int})
     n = length(B)
-    i_f = first(r)
-    i_l = last(r)
+    i_f = rangestart(r)
+    i_l = rangestop(r)
     1 <= i_f || throw(BoundsError(B, i_f))
     i_l <= n || throw(BoundsError(B, n+1))
 
@@ -1000,8 +1000,8 @@ const _default_bit_splice = BitVector()
 
 function splice!(B::BitVector, r::Union{UnitRange{Int}, Integer}, ins::AbstractArray = _default_bit_splice)
     n = length(B)
-    i_f = first(r)
-    i_l = last(r)
+    i_f = rangestart(r)
+    i_l = rangestop(r)
 
     1 <= i_f <= n+1 || throw(BoundsError(B, i_f))
     i_l <= n || throw(BoundsError(B, n+1))
@@ -1013,7 +1013,7 @@ function splice!(B::BitVector, r::Union{UnitRange{Int}, Integer}, ins::AbstractA
         return BitVector()
     end
 
-    v = B[r]  # TODO: change to a copy if/when subscripting becomes an ArrayView
+    v = B[r]
 
     Bc = B.chunks
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -346,7 +346,7 @@ end
 @inline function shapeindexer(shape, indsA::Tuple)
     ind1 = indsA[1]
     keep, Idefault = shapeindexer(tail(shape), tail(indsA))
-    (shape[1] == ind1, keep...), (first(ind1), Idefault...)
+    (shape[1] == ind1, keep...), (rangestart(ind1), Idefault...)
 end
 
 # Equivalent to map(x->newindexer(shape, x), As) (but see #17126)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -468,6 +468,8 @@ export
     randsubseq!,
     randsubseq,
     range,
+    rangestart,
+    rangestop,
     reducedim,
     repmat,
     reshape,

--- a/base/float.jl
+++ b/base/float.jl
@@ -885,8 +885,8 @@ function float(A::AbstractArray{T}) where T
     convert(AbstractArray{typeof(float(zero(T)))}, A)
 end
 
-float(r::StepRange) = float(r.start):float(r.step):float(last(r))
-float(r::UnitRange) = float(r.start):float(last(r))
+float(r::StepRange) = float(r.start):float(r.step):float(rangestop(r))
+float(r::UnitRange) = float(r.start):float(rangestop(r))
 float(r::StepRangeLen{T}) where {T} =
     StepRangeLen{typeof(float(T(r.ref)))}(float(r.ref), float(r.step), length(r), r.offset)
 function float(r::LinSpace)
@@ -896,8 +896,8 @@ end
 # big, broadcast over arrays
 # TODO: do the definitions below primarily pertaining to integers belong in float.jl?
 function big end # no prior definitions of big in sysimg.jl, necessitating this
-broadcast(::typeof(big), r::UnitRange) = big(r.start):big(last(r))
-broadcast(::typeof(big), r::StepRange) = big(r.start):big(r.step):big(last(r))
+broadcast(::typeof(big), r::UnitRange) = big(r.start):big(rangestop(r))
+broadcast(::typeof(big), r::StepRange) = big(r.start):big(r.step):big(rangestop(r))
 broadcast(::typeof(big), r::StepRangeLen) = StepRangeLen(big(r.ref), big(r.step), length(r), r.offset)
 function broadcast(::typeof(big), r::LinSpace)
     LinSpace(big(r.start), big(r.stop), length(r))

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -238,12 +238,15 @@ end
 axes(S::Slice) = (S.indices,)
 unsafe_indices(S::Slice) = (S.indices,)
 indices1(S::Slice) = S.indices
+# TODO: remove?
 first(S::Slice) = first(S.indices)
 last(S::Slice) = last(S.indices)
+rangestart(S::Slice) = rangestart(S.indices)
+rangestop(S::Slice) = rangestop(S.indices)
 errmsg(A) = error("size not supported for arrays with indices $(axes(A)); see https://docs.julialang.org/en/latest/devdocs/offset-arrays/")
-size(S::Slice) = first(S.indices) == 1 ? (length(S.indices),) : errmsg(S)
-length(S::Slice) = first(S.indices) == 1 ? length(S.indices) : errmsg(S)
-unsafe_length(S::Slice) = first(S.indices) == 1 ? unsafe_length(S.indices) : errmsg(S)
+size(S::Slice) = rangestart(S.indices) == 1 ? (length(S.indices),) : errmsg(S)
+length(S::Slice) = rangestart(S.indices) == 1 ? length(S.indices) : errmsg(S)
+unsafe_length(S::Slice) = rangestart(S.indices) == 1 ? unsafe_length(S.indices) : errmsg(S)
 getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 show(io::IO, r::Slice) = print(io, "Base.Slice(", r.indices, ")")
 start(S::Slice) = start(S.indices)

--- a/base/linalg/blas.jl
+++ b/base/linalg/blas.jl
@@ -467,7 +467,7 @@ function axpy!(alpha::Number, x::Array{T}, rx::Union{UnitRange{Ti},AbstractRange
     if minimum(ry) < 1 || maximum(ry) > length(y)
         throw(ArgumentError("range out of bounds for y, of length $(length(y))"))
     end
-    Base.@gc_preserve x y axpy!(length(rx), convert(T, alpha), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    Base.@gc_preserve x y axpy!(length(rx), convert(T, alpha), pointer(x)+(rangestart(rx)-1)*sizeof(T), step(rx), pointer(y)+(rangestart(ry)-1)*sizeof(T), step(ry))
     y
 end
 
@@ -1534,9 +1534,9 @@ function copyto!(dest::Array{T}, rdest::Union{UnitRange{Ti},AbstractRange{Ti}},
         throw(DimensionMismatch("ranges must be of the same length"))
     end
     Base.@gc_preserve src dest BLAS.blascopy!(length(rsrc),
-                                              pointer(src) + (first(rsrc) - 1) * sizeof(T),
+                                              pointer(src) + (rangestart(rsrc) - 1) * sizeof(T),
                                               step(rsrc),
-                                              pointer(dest) + (first(rdest) - 1) * sizeof(T),
+                                              pointer(dest) + (rangestart(rdest) - 1) * sizeof(T),
                                               step(rdest))
     dest
 end

--- a/base/linalg/dense.jl
+++ b/base/linalg/dense.jl
@@ -146,7 +146,7 @@ function norm(x::StridedVector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}) w
     if minimum(rx) < 1 || maximum(rx) > length(x)
         throw(BoundsError(x, rx))
     end
-    Base.@gc_preserve x BLAS.nrm2(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx))
+    Base.@gc_preserve x BLAS.nrm2(length(rx), pointer(x)+(rangestart(rx)-1)*sizeof(T), step(rx))
 end
 
 vecnorm1(x::Union{Array{T},StridedVector{T}}) where {T<:BlasReal} =

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -946,7 +946,7 @@ function issymmetric(A::AbstractMatrix)
     if indsm != indsn
         return false
     end
-    for i = first(indsn):last(indsn), j = (i):last(indsn)
+    for i = rangestart(indsn):rangestop(indsn), j = (i):rangestop(indsn)
         if A[i,j] != transpose(A[j,i])
             return false
         end
@@ -985,7 +985,7 @@ function ishermitian(A::AbstractMatrix)
     if indsm != indsn
         return false
     end
-    for i = indsn, j = i:last(indsn)
+    for i = indsn, j = i:rangestop(indsn)
         if A[i,j] != adjoint(A[j,i])
             return false
         end

--- a/base/linalg/matmul.jl
+++ b/base/linalg/matmul.jl
@@ -51,7 +51,7 @@ function dot(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector
     if minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError(y, ry))
     end
-    Base.@gc_preserve x y BLAS.dot(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    Base.@gc_preserve x y BLAS.dot(length(rx), pointer(x)+(rangestart(rx)-1)*sizeof(T), step(rx), pointer(y)+(rangestart(ry)-1)*sizeof(T), step(ry))
 end
 
 function dot(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector{T}, ry::Union{UnitRange{TI},AbstractRange{TI}}) where {T<:BlasComplex,TI<:Integer}
@@ -64,7 +64,7 @@ function dot(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector
     if minimum(ry) < 1 || maximum(ry) > length(y)
         throw(BoundsError(y, ry))
     end
-    Base.@gc_preserve x y BLAS.dotc(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+    Base.@gc_preserve x y BLAS.dotc(length(rx), pointer(x)+(rangestart(rx)-1)*sizeof(T), step(rx), pointer(y)+(rangestart(ry)-1)*sizeof(T), step(ry))
 end
 
 *(transx::Transpose{<:Any,<:StridedVector{T}}, y::StridedVector{T}) where {T<:BlasComplex} =

--- a/base/linalg/transpose.jl
+++ b/base/linalg/transpose.jl
@@ -106,7 +106,7 @@ function transpose_f!(f, B::AbstractMatrix, A::AbstractMatrix)
             end
         end
     else
-        transposeblock!(f,B,A,m,n,first(inds[1])-1,first(inds[2])-1)
+        transposeblock!(f,B,A,m,n,rangestart(inds[1])-1,rangestart(inds[2])-1)
     end
     return B
 end
@@ -195,9 +195,9 @@ function copy_transpose!(B::AbstractVecOrMat, ir_dest::AbstractRange{Int}, jr_de
     end
     @boundscheck checkbounds(B, ir_dest, jr_dest)
     @boundscheck checkbounds(A, ir_src, jr_src)
-    idest = first(ir_dest)
+    idest = rangestart(ir_dest)
     for jsrc in jr_src
-        jdest = first(jr_dest)
+        jdest = rangestart(jr_dest)
         for isrc in ir_src
             B[idest,jdest] = A[isrc,jsrc]
             jdest += step(jr_dest)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -231,7 +231,7 @@ module IteratorsMD
     CartesianIndices(index::CartesianIndex) = CartesianIndices(index.I)
     CartesianIndices(sz::NTuple{N,<:Integer}) where {N} = CartesianIndices(map(Base.OneTo, sz))
     CartesianIndices(inds::NTuple{N,Union{<:Integer,AbstractUnitRange{<:Integer}}}) where {N} =
-        CartesianIndices(map(i->rangestart(i):rangestop(i), inds))
+        CartesianIndices(map(i-> i isa Integer ? (i:i) : (rangestart(i):rangestop(i)), inds))
 
     CartesianIndices(A::AbstractArray) = CartesianIndices(axes(A))
 

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -56,6 +56,8 @@ endof(p::Pair) = 2
 length(p::Pair) = 2
 first(p::Pair) = p.first
 last(p::Pair) = p.second
+rangestart(p::Pair) = p.first
+rangestop(p::Pair) = p.second
 
 convert(::Type{Pair{A,B}}, x::Pair{A,B}) where {A,B} = x
 function convert(::Type{Pair{A,B}}, x::Pair) where {A,B}

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -224,10 +224,10 @@ end
 
 @noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianIndices{0}, R2, R3, ds, dp)
     ip, is = axes(src, dp), axes(src, ds)
-    for jo in first(ip):8:last(ip), io in first(is):8:last(is)
+    for jo in rangestart(ip):8:rangestop(ip), io in rangestart(is):8:rangestop(is)
         for I3 in R3, I2 in R2
-            for j in jo:min(jo+7, last(ip))
-                for i in io:min(io+7, last(is))
+            for j in jo:min(jo+7, rangestop(ip))
+                for i in io:min(io+7, rangestop(is))
                     @inbounds P[i, I2, j, I3] = src[i, I2, j, I3]
                 end
             end
@@ -238,10 +238,10 @@ end
 
 @noinline function _permutedims!(P::PermutedDimsArray, src, R1, R2, R3, ds, dp)
     ip, is = axes(src, dp), axes(src, ds)
-    for jo in first(ip):8:last(ip), io in first(is):8:last(is)
+    for jo in rangestart(ip):8:rangestop(ip), io in rangestart(is):8:rangestop(is)
         for I3 in R3, I2 in R2
-            for j in jo:min(jo+7, last(ip))
-                for i in io:min(io+7, last(is))
+            for j in jo:min(jo+7, rangestop(ip))
+                for i in io:min(io+7, rangestop(is))
                     for I1 in R1
                         @inbounds P[I1, i, I2, j, I3] = src[I1, i, I2, j, I3]
                     end

--- a/base/random/RNGs.jl
+++ b/base/random/RNGs.jl
@@ -330,8 +330,8 @@ function rand!(r::MersenneTwister, A::AbstractArray{Float64},
     # for i=region
     #     @inbounds A[i] = rand(r, I[])
     # end
-    m = Base.checked_sub(first(region), 1)
-    n = last(region)
+    m = Base.checked_sub(rangestart(region), 1)
+    n = rangestop(region)
     while m < n
         s = mt_avail(r)
         if s == 0

--- a/base/range.jl
+++ b/base/range.jl
@@ -434,12 +434,10 @@ rangestart(r::OrdinalRange{T}) where {T} = convert(T, r.start)
 rangestart(r::OneTo{T}) where {T} = oneunit(T)
 rangestart(r::StepRangeLen) = unsafe_getindex(r, 1)
 rangestart(r::LinSpace) = r.start
-rangestart(a) = first(a)
 
 rangestop(r::OrdinalRange{T}) where {T} = convert(T, r.stop)
 rangestop(r::StepRangeLen) = unsafe_getindex(r, length(r))
 rangestop(r::LinSpace) = r.stop
-rangestop(a) = last(a)
 
 minimum(r::AbstractUnitRange) =
     isempty(r) ? throw(ArgumentError("range must be non-empty")) : rangestart(r)

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -281,13 +281,13 @@ function _mapreduce(f, op, ::IndexLinear, A::AbstractArray{T}) where T
         @inbounds a1 = A[i]
         @inbounds a2 = A[i+=1]
         s = op(f(a1), f(a2))
-        while i < last(inds)
+        while i < rangestop(inds)
             @inbounds Ai = A[i+=1]
             s = op(s, f(Ai))
         end
         return s
     else
-        return mapreduce_impl(f, op, A, first(inds), last(inds))
+        return mapreduce_impl(f, op, A, rangestart(inds), rangestop(inds))
     end
 end
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -204,7 +204,7 @@ function mapfirst!(f, R::AbstractArray, A::AbstractArray)
     t = []
     for i in 1:length(iR)
         iAi = iA[i]
-        push!(t, iAi == iR[i] ? iAi : first(iAi))
+        push!(t, iAi == iR[i] ? iAi : rangestart(iAi))
     end
     map!(f, R, view(A, t...))
 end
@@ -216,7 +216,7 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArray)
     if has_fast_linear_indexing(A) && lsiz > 16
         # use mapreduce_impl, which is probably better tuned to achieve higher performance
         nslices = div(_length(A), lsiz)
-        ibase = first(linearindices(A))-1
+        ibase = rangestart(linearindices(A))-1
         for i = 1:nslices
             @inbounds R[i] = op(R[i], mapreduce_impl(f, op, A, ibase+1, ibase+lsiz))
             ibase += lsiz
@@ -227,7 +227,7 @@ function _mapreducedim!(f, op, R::AbstractArray, A::AbstractArray)
     keep, Idefault = Broadcast.shapeindexer(indsAt, indsRt)
     if reducedim1(R, A)
         # keep the accumulator as a local variable when reducing along the first dimension
-        i1 = first(indices1(R))
+        i1 = rangestart(indices1(R))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
             r = R[i1,IR]
@@ -651,7 +651,7 @@ function findminmax!(f, Rval, Rind, A::AbstractArray{T,N}) where {T,N}
     k, kss = next(ks, start(ks))
     zi = zero(eltype(ks))
     if reducedim1(Rval, A)
-        i1 = first(indices1(Rval))
+        i1 = rangestart(indices1(Rval))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
             tmpRv = Rval[i1,IR]

--- a/base/repl/REPLCompletions.jl
+++ b/base/repl/REPLCompletions.jl
@@ -106,10 +106,10 @@ const sorted_keywords = [
 
 function complete_keyword(s::Union{String,SubString{String}})
     r = searchsorted(sorted_keywords, s)
-    i = first(r)
+    i = rangestart(r)
     n = length(sorted_keywords)
     while i <= n && startswith(sorted_keywords[i],s)
-        r = first(r):i
+        r = rangestart(r):i
         i += 1
     end
     sorted_keywords[r]
@@ -408,7 +408,7 @@ function afterusing(string::String, startpos::Int)
     rstr = reverse(str)
     r = search(rstr, r"\s(gnisu|tropmi)\b")
     isempty(r) && return false
-    fr = reverseind(str, last(r))
+    fr = reverseind(str, rangestop(r))
     return ismatch(r"^\b(using|import)\s*((\w+[.])*\w+\s*,\s*)*$", str[fr:end])
 end
 
@@ -635,10 +635,10 @@ function shell_completions(string, pos)
 
         return complete_path(prefix, pos, use_envpath=use_envpath)
     elseif isexpr(arg, :incomplete) || isexpr(arg, :error)
-        r = first(last_parse):prevind(last_parse, last(last_parse))
+        r = rangestart(last_parse):prevind(last_parse, rangestop(last_parse))
         partial = scs[r]
         ret, range = completions(partial, endof(partial))
-        range = range .+ (first(r) - 1)
+        range = range .+ (rangestart(r) - 1)
         return ret, range, true
     end
     return String[], 0:-1, false

--- a/base/set.jl
+++ b/base/set.jl
@@ -410,7 +410,7 @@ function _unique!(A::AbstractVector)
             A[i] = x
         end
     end
-    resize!(A, i - first(idxs) + 1)
+    resize!(A, i - rangestart(idxs) + 1)
 end
 
 # If A is grouped, so that each unique element is in a contiguous group, then we only
@@ -429,7 +429,7 @@ function _groupedunique!(A::AbstractVector)
             y = A[i] = x
         end
     end
-    resize!(A, i - first(idxs) + 1)
+    resize!(A, i - rangestart(idxs) + 1)
 end
 
 """

--- a/base/show.jl
+++ b/base/show.jl
@@ -458,7 +458,7 @@ function show(io::IO, src::CodeInfo)
 end
 
 function show_delim_array(io::IO, itr::Union{AbstractArray,SimpleVector}, op, delim, cl,
-                          delim_one, i1=first(linearindices(itr)), l=last(linearindices(itr)))
+                          delim_one, i1=rangestart(linearindices(itr)), l=rangestop(linearindices(itr)))
     print(io, op)
     if !show_circular(io, itr)
         recur_io = IOContext(io, :SHOWN_SET => itr)

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -76,7 +76,7 @@ function compile(x)
                             end
                         end
                         # Set index to last value just like a regular for loop would
-                        $var = rangestop($r)
+                        $var = $r isa AbstractRange ? rangestop($r) : $r
                     end
                 end
             end

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -76,7 +76,7 @@ function compile(x)
                             end
                         end
                         # Set index to last value just like a regular for loop would
-                        $var = last($r)
+                        $var = rangestop($r)
                     end
                 end
             end

--- a/base/sparse/sparsematrix.jl
+++ b/base/sparse/sparsematrix.jl
@@ -46,7 +46,7 @@ const SparseMatrixCSCView{Tv,Ti} =
 const SparseMatrixCSCUnion{Tv,Ti} = Union{SparseMatrixCSC{Tv,Ti}, SparseMatrixCSCView{Tv,Ti}}
 
 getcolptr(S::SparseMatrixCSC)     = S.colptr
-getcolptr(S::SparseMatrixCSCView) = view(S.parent.colptr, first(axes(S, 2)):(last(axes(S, 2)) + 1))
+getcolptr(S::SparseMatrixCSCView) = view(S.parent.colptr, rangestart(axes(S, 2)):(rangestop(axes(S, 2)) + 1))
 getrowval(S::SparseMatrixCSC)     = S.rowval
 getrowval(S::SparseMatrixCSCView) = S.parent.rowval
 getnzval( S::SparseMatrixCSC)     = S.nzval
@@ -1520,9 +1520,9 @@ function ==(A1::SparseMatrixCSC, A2::SparseMatrixCSC)
     m, n = size(A1)
     @inbounds for i = 1:n
         nz1,nz2 = nzrange(A1,i), nzrange(A2,i)
-        j1,j2 = first(nz1), first(nz2)
+        j1,j2 = rangestart(nz1), rangestart(nz2)
         # step through the rows of both matrices at once:
-        while j1 <= last(nz1) && j2 <= last(nz2)
+        while j1 <= rangestop(nz1) && j2 <= rangestop(nz2)
             r1,r2 = rows1[j1], rows2[j2]
             if r1==r2
                 vals1[j1]!=vals2[j2] && return false
@@ -1539,10 +1539,10 @@ function ==(A1::SparseMatrixCSC, A2::SparseMatrixCSC)
             end
         end
         # finish off any left-overs:
-        for j = j1:last(nz1)
+        for j = j1:rangestop(nz1)
             vals1[j]!=0 && return false
         end
-        for j = j2:last(nz2)
+        for j = j2:rangestop(nz2)
             vals2[j]!=0 && return false
         end
     end
@@ -1847,7 +1847,7 @@ indmax(A::SparseMatrixCSC) = findmax(A)[2]
 
 ## getindex
 function rangesearch(haystack::AbstractRange, needle)
-    (i,rem) = divrem(needle - first(haystack), step(haystack))
+    (i,rem) = divrem(needle - rangestart(haystack), step(haystack))
     (rem==0 && 1<=i+1<=length(haystack)) ? i+1 : 0
 end
 

--- a/base/sparse/sparsevector.jl
+++ b/base/sparse/sparsevector.jl
@@ -513,9 +513,9 @@ function getindex(x::SparseMatrixCSC, I::AbstractUnitRange, j::Integer)
     c1 = convert(Int, x.colptr[j])
     c2 = convert(Int, x.colptr[j+1]) - 1
     # Restrict to the selected rows
-    r1 = searchsortedfirst(x.rowval, first(I), c1, c2, Forward)
-    r2 = searchsortedlast(x.rowval, last(I), c1, c2, Forward)
-    SparseVector(length(I), [x.rowval[i] - first(I) + 1 for i = r1:r2], x.nzval[r1:r2])
+    r1 = searchsortedfirst(x.rowval, rangestart(I), c1, c2, Forward)
+    r2 = searchsortedlast(x.rowval, rangestop(I), c1, c2, Forward)
+    SparseVector(length(I), [x.rowval[i] - rangestart(I) + 1 for i = r1:r2], x.nzval[r1:r2])
 end
 
 # In the general case, we piggy back upon SparseMatrixCSC's optimized solution
@@ -613,8 +613,8 @@ function getindex(A::SparseMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
     rowvalB = Vector{Int}(uninitialized, nnzB)
     nzvalB = Vector{Tv}(uninitialized, nnzB)
 
-    rowstart,colstart = Base._ind2sub(szA, first(I))
-    rowend,colend = Base._ind2sub(szA, last(I))
+    rowstart,colstart = Base._ind2sub(szA, rangestart(I))
+    rowend,colend = Base._ind2sub(szA, rangestop(I))
 
     idxB = 1
     @inbounds for col in colstart:colend
@@ -623,7 +623,7 @@ function getindex(A::SparseMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
         for r in colptrA[col]:(colptrA[col+1]-1)
             rowA = rowvalA[r]
             if minrow <= rowA <= maxrow
-                rowvalB[idxB] = Base._sub2ind(szA, rowA, col) - first(I) + 1
+                rowvalB[idxB] = Base._sub2ind(szA, rowA, col) - rangestart(I) + 1
                 nzvalB[idxB] = nzvalA[r]
                 idxB += 1
             end
@@ -750,8 +750,8 @@ end
 function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractUnitRange) where {Tv,Ti}
     checkbounds(x, I)
     xlen = length(x)
-    i0 = first(I)
-    i1 = last(I)
+    i0 = rangestart(I)
+    i1 = rangestop(I)
 
     xnzind = nonzeroinds(x)
     xnzval = nonzeros(x)

--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -133,7 +133,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::Abstr
 
     if has_fast_linear_indexing(A) && lsiz > 16
         nslices = div(_length(A), lsiz)
-        ibase = first(linearindices(A))-1
+        ibase = rangestart(linearindices(A))-1
         for i = 1:nslices
             @inbounds R[i] = centralize_sumabs2(A, means[i], ibase+1, ibase+lsiz)
             ibase += lsiz
@@ -143,7 +143,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::Abstr
     indsAt, indsRt = safe_tail(axes(A)), safe_tail(axes(R)) # handle d=1 manually
     keep, Idefault = Broadcast.shapeindexer(indsAt, indsRt)
     if reducedim1(R, A)
-        i1 = first(indices1(R))
+        i1 = rangestart(indices1(R))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)
             r = R[i1,IR]
@@ -225,7 +225,7 @@ varm(iterable, m; corrected::Bool=true) =
 ## variances over ranges
 
 function varm(v::AbstractRange, m)
-    f  = first(v) - m
+    f  = rangestart(v) - m
     s  = step(v)
     l  = length(v)
     vv = f^2 * l / (l - 1) + f * s * l + s^2 * l * (2 * l - 1) / 6
@@ -602,7 +602,7 @@ function median!(v::AbstractVector)
     end
     inds = axes(v, 1)
     n = length(inds)
-    mid = div(first(inds)+last(inds),2)
+    mid = div(rangestart(inds)+rangestop(inds),2)
     if isodd(n)
         return middle(partialsort!(v,mid))
     else

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -217,11 +217,11 @@ function getindex_continued(s::String, i::Int, u::UInt32)
     return reinterpret(Char, u)
 end
 
-getindex(s::String, r::UnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
+getindex(s::String, r::UnitRange{<:Integer}) = s[Int(rangestart(r)):Int(rangestop(r))]
 
 function getindex(s::String, r::UnitRange{Int})
     isempty(r) && return ""
-    i, j = first(r), last(r)
+    i, j = rangestart(r), rangestop(r)
     @boundscheck begin
         checkbounds(s, r)
         @inbounds isvalid(s, i) || string_index_err(s, i)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -37,7 +37,7 @@ end
 
 SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
 SubString(s::AbstractString, i::Integer, j::Integer=endof(s)) = SubString(s, Int(i), Int(j))
-SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, first(r), last(r))
+SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, rangestart(r), rangestop(r))
 
 function SubString(s::SubString, i::Int, j::Int)
     @boundscheck i ≤ j && checkbounds(s, i:j)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -291,6 +291,8 @@ function _split(str::AbstractString, splitter, limit::Integer, keep_empty::Bool,
     i = start(str)
     n = endof(str)
     r = search(str,splitter,i)
+    # FIXME
+    r isa Integer && (r = r:r)
     if r != 0:-1
         j, k = rangestart(r), nextind(str,rangestop(r))
         while 0 < j <= n && length(strs) != limit-1
@@ -303,6 +305,8 @@ function _split(str::AbstractString, splitter, limit::Integer, keep_empty::Bool,
             (k <= j) && (k = nextind(str,j))
             r = search(str,splitter,k)
             r == 0:-1 && break
+            # FIXME
+            r isa Integer && (r = r:r)
             j, k = rangestart(r), nextind(str,rangestop(r))
         end
     end
@@ -352,6 +356,8 @@ function _rsplit(str::AbstractString, splitter, limit::Integer, keep_empty::Bool
     i = start(str)
     n = endof(str)
     r = rsearch(str,splitter)
+    # FIXME
+    r isa Integer && (r = r:r)
     j = rangestart(r)-1
     k = rangestop(r)
     while((0 <= j < n) && (length(strs) != limit-1))
@@ -361,6 +367,8 @@ function _rsplit(str::AbstractString, splitter, limit::Integer, keep_empty::Bool
         end
         (k <= j) && (j = prevind(str,j))
         r = rsearch(str,splitter,j)
+        # FIXME
+        r isa Integer && (r = r:r)
         j = rangestart(r)-1
         k = rangestop(r)
     end
@@ -381,7 +389,11 @@ function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
     e = endof(str)
     i = a = start(str)
     r = search(str,pattern,i)
-    j, k = rangestart(r), rangestop(r)
+    if r isa Integer
+        j = k = r
+    else
+        j, k = rangestart(r), rangestop(r)
+    end
     out = IOBuffer(StringVector(floor(Int, 1.2sizeof(str))), true, true)
     out.size = 0
     out.ptr = 1
@@ -398,6 +410,8 @@ function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
             i = k = nextind(str, k)
         end
         r = search(str,pattern,k)
+        # FIXME
+        r isa Integer && (r = r:r)
         r == 0:-1 || n == count && break
         j, k = rangestart(r), rangestop(r)
         n += 1

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -292,7 +292,7 @@ function _split(str::AbstractString, splitter, limit::Integer, keep_empty::Bool,
     n = endof(str)
     r = search(str,splitter,i)
     if r != 0:-1
-        j, k = first(r), nextind(str,last(r))
+        j, k = rangestart(r), nextind(str,rangestop(r))
         while 0 < j <= n && length(strs) != limit-1
             if i < k
                 if keep_empty || i < j
@@ -303,7 +303,7 @@ function _split(str::AbstractString, splitter, limit::Integer, keep_empty::Bool,
             (k <= j) && (k = nextind(str,j))
             r = search(str,splitter,k)
             r == 0:-1 && break
-            j, k = first(r), nextind(str,last(r))
+            j, k = rangestart(r), nextind(str,rangestop(r))
         end
     end
     if keep_empty || !done(str,i)
@@ -352,8 +352,8 @@ function _rsplit(str::AbstractString, splitter, limit::Integer, keep_empty::Bool
     i = start(str)
     n = endof(str)
     r = rsearch(str,splitter)
-    j = first(r)-1
-    k = last(r)
+    j = rangestart(r)-1
+    k = rangestop(r)
     while((0 <= j < n) && (length(strs) != limit-1))
         if i <= k
             (keep_empty || (k < n)) && pushfirst!(strs, SubString(str,k+1,n))
@@ -361,8 +361,8 @@ function _rsplit(str::AbstractString, splitter, limit::Integer, keep_empty::Bool
         end
         (k <= j) && (j = prevind(str,j))
         r = rsearch(str,splitter,j)
-        j = first(r)-1
-        k = last(r)
+        j = rangestart(r)-1
+        k = rangestop(r)
     end
     (keep_empty || (n > 0)) && pushfirst!(strs, SubString(str,1,n))
     return strs
@@ -371,7 +371,7 @@ end
 
 _replace(io, repl, str, r, pattern) = print(io, repl)
 _replace(io, repl::Function, str, r, pattern) =
-    print(io, repl(SubString(str, first(r), last(r))))
+    print(io, repl(SubString(str, rangestart(r), rangestop(r))))
 
 function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
     pattern, repl = pat_repl
@@ -381,7 +381,7 @@ function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
     e = endof(str)
     i = a = start(str)
     r = search(str,pattern,i)
-    j, k = first(r), last(r)
+    j, k = rangestart(r), rangestop(r)
     out = IOBuffer(StringVector(floor(Int, 1.2sizeof(str))), true, true)
     out.size = 0
     out.ptr = 1
@@ -399,7 +399,7 @@ function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
         end
         r = search(str,pattern,k)
         r == 0:-1 || n == count && break
-        j, k = first(r), last(r)
+        j, k = rangestart(r), rangestop(r)
         n += 1
     end
     write(out, SubString(str,i))
@@ -479,7 +479,7 @@ hex2bytes(s::AbstractString) = hex2bytes(String(s))
 hex2bytes(s::Union{String,AbstractVector{UInt8}}) = hex2bytes!(Vector{UInt8}(uninitialized, length(s) >> 1), s)
 
 _firstbyteidx(s::String) = 1
-_firstbyteidx(s::AbstractVector{UInt8}) = first(eachindex(s))
+_firstbyteidx(s::AbstractVector{UInt8}) = rangestart(eachindex(s))
 _lastbyteidx(s::String) = sizeof(s)
 _lastbyteidx(s::AbstractVector{UInt8}) = endof(s)
 
@@ -495,7 +495,7 @@ function hex2bytes!(d::AbstractVector{UInt8}, s::Union{String,AbstractVector{UIn
         isodd(sizeof(s)) && throw(ArgumentError("input hex array must have even length"))
         throw(ArgumentError("output array must be half length of input array"))
     end
-    j = first(eachindex(d)) - 1
+    j = rangestart(eachindex(d)) - 1
     for i = _firstbyteidx(s):2:_lastbyteidx(s)
         @inbounds d[j += 1] = number_from_hex(_nthbyte(s,i)) << 4 + number_from_hex(_nthbyte(s,i+1))
     end

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -289,14 +289,14 @@ end
 # The running sum is `f`; the cumulative stride product is `s`.
 # If the parent is a vector, then we offset the parent's own indices with parameters of I
 compute_offset1(parent::AbstractVector, stride1::Integer, I::Tuple{AbstractRange}) =
-    (@_inline_meta; first(I[1]) - first(indices1(I[1]))*stride1)
+    (@_inline_meta; rangestart(I[1]) - rangestart(indices1(I[1]))*stride1)
 # If the result is one-dimensional and it's a Colon, then linear
 # indexing uses the indices along the given dimension. Otherwise
 # linear indexing always starts with 1.
 compute_offset1(parent, stride1::Integer, I::Tuple) =
     (@_inline_meta; compute_offset1(parent, stride1, find_extended_dims(1, I...), find_extended_inds(I...), I))
 compute_offset1(parent, stride1::Integer, dims::Tuple{Int}, inds::Tuple{Slice}, I::Tuple) =
-    (@_inline_meta; compute_linindex(parent, I) - stride1*first(axes(parent, dims[1])))  # index-preserving case
+    (@_inline_meta; compute_linindex(parent, I) - stride1*rangestart(axes(parent, dims[1])))  # index-preserving case
 compute_offset1(parent, stride1::Integer, dims, inds, I::Tuple) =
     (@_inline_meta; compute_linindex(parent, I) - stride1)  # linear indexing starts with 1
 
@@ -307,12 +307,12 @@ function compute_linindex(parent, I::NTuple{N,Any}) where N
 end
 function compute_linindex(f, s, IP::Tuple, I::Tuple{ScalarIndex, Vararg{Any}})
     @_inline_meta
-    Δi = I[1]-first(IP[1])
+    Δi = I[1]-rangestart(IP[1])
     compute_linindex(f + Δi*s, s*unsafe_length(IP[1]), tail(IP), tail(I))
 end
 function compute_linindex(f, s, IP::Tuple, I::Tuple{Any, Vararg{Any}})
     @_inline_meta
-    Δi = first(I[1])-first(IP[1])
+    Δi = rangestart(I[1])-rangestart(IP[1])
     compute_linindex(f + Δi*s, s*unsafe_length(IP[1]), tail(IP), tail(I))
 end
 compute_linindex(f, s, IP::Tuple, I::Tuple{}) = f

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -458,9 +458,9 @@ end
 
 function getindex(r::StepRangeLen{T,<:TwicePrecision,<:TwicePrecision}, s::OrdinalRange{<:Integer}) where T
     @boundscheck checkbounds(r, s)
-    soffset = 1 + round(Int, (r.offset - first(s))/step(s))
+    soffset = 1 + round(Int, (r.offset - rangestart(s))/step(s))
     soffset = clamp(soffset, 1, length(s))
-    ioffset = first(s) + (soffset-1)*step(s)
+    ioffset = rangestart(s) + (soffset-1)*step(s)
     if step(s) == 1 || length(s) < 2
         newstep = r.step
     else
@@ -499,13 +499,13 @@ function _convertSRL(::Type{StepRangeLen{T,R,S}}, r::StepRangeLen{<:Integer}) wh
 end
 
 function _convertSRL(::Type{StepRangeLen{T,R,S}}, r::AbstractRange{<:Integer}) where {T,R,S}
-    StepRangeLen{T,R,S}(R(first(r)), S(step(r)), length(r))
+    StepRangeLen{T,R,S}(R(rangestart(r)), S(step(r)), length(r))
 end
 
 function _convertSRL(::Type{StepRangeLen{T,R,S}}, r::AbstractRange{U}) where {T,R,S,U}
     # if start and step have a rational approximation in the old type,
     # then we transfer that rational approximation to the new type
-    f, s = first(r), step(r)
+    f, s = rangestart(r), step(r)
     start_n, start_d = rat(f)
     step_n, step_d = rat(s)
     if start_d != 0 && step_d != 0 &&
@@ -526,7 +526,7 @@ function __convertSRL(::Type{StepRangeLen{T,R,S}}, r::StepRangeLen{U}) where {T,
     StepRangeLen{T,R,S}(R(r.ref), S(r.step), length(r), r.offset)
 end
 function __convertSRL(::Type{StepRangeLen{T,R,S}}, r::AbstractRange{U}) where {T,R,S,U}
-    StepRangeLen{T,R,S}(R(first(r)), S(step(r)), length(r))
+    StepRangeLen{T,R,S}(R(rangestart(r)), S(step(r)), length(r))
 end
 
 function sum(r::StepRangeLen)
@@ -654,7 +654,7 @@ function _linspace1(::Type{T}, start, stop, len::Integer) where T
     len >= 0 || throw(ArgumentError("linspace($start, $stop, $len): negative length"))
     if len <= 1
         len == 1 && (start == stop || throw(ArgumentError("linspace($start, $stop, $len): endpoints differ")))
-        # Ensure that first(r)==start and last(r)==stop even for len==0
+        # Ensure that rangestart(r)==start and rangestop(r)==stop even for len==0
         # The output type must be consistent with steprangelen_hp
         if T<:Union{Float32,Float16}
             return StepRangeLen{T}(Float64(start), Float64(start) - Float64(stop), len, 1)

--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -118,18 +118,18 @@ Note also that `similar(Array{Int}, (axes(A, 2),))` would allocate an `AbstractV
 ### Deprecations
 
 In generalizing Julia's code base, at least one deprecation was unavoidable: earlier versions
-of Julia defined `first(::Colon) = 1`, meaning that the first index along a dimension indexed
+of Julia defined `rangestart(::Colon) = 1`, meaning that the first index along a dimension indexed
 by `:` is 1. This definition can no longer be justified, so it was deprecated. There is no provided
 replacement, because the proper replacement depends on what you are doing and might need to know
-more about the array. However, it appears that many uses of `first(::Colon)` are really about
+more about the array. However, it appears that many uses of `rangestart(::Colon)` are really about
 computing an index offset; when that is the case, a candidate replacement is:
 
 ```julia
-indexoffset(r::AbstractVector) = first(r) - 1
+indexoffset(r::AbstractVector) = rangestart(r) - 1
 indexoffset(::Colon) = 0
 ```
 
-In other words, while `first(:)` does not itself make sense, in general you can say that the offset
+In other words, while `rangestart(:)` does not itself make sense, in general you can say that the offset
 associated with a colon-index is zero.
 
 ## Writing custom array types with non-1 indexing

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -518,7 +518,7 @@ you can convert a `UnitRange{Int}` `r` to a `UnitRange{BigInt}` with `big.(r)`; 
 of this method is approximately
 
 ```julia
-Broadcast.broadcast(::typeof(big), r::UnitRange) = big(first(r)):big(last(r))
+Broadcast.broadcast(::typeof(big), r::UnitRange) = big(rangestart(r)):big(rangestop(r))
 ```
 
 This exploits Julia's ability to dispatch on a particular function type. (This kind of

--- a/stdlib/Dates/src/ranges.jl
+++ b/stdlib/Dates/src/ranges.jl
@@ -27,7 +27,7 @@ Base.steprem(a::T, b::T, c) where {T<:TimeType} = b - (a + c * len(a, b, c))
 
 import Base.in
 function in(x::T, r::StepRange{T}) where T<:TimeType
-    n = len(first(r), x, step(r)) + 1
+    n = len(rangestart(r), x, step(r)) + 1
     n >= 1 && n <= length(r) && r[n] == x
 end
 
@@ -35,9 +35,9 @@ Base.start(r::StepRange{<:TimeType}) = 0
 Base.next(r::StepRange{<:TimeType}, i::Int) = (r.start + r.step*i, i + 1)
 Base.done(r::StepRange{<:TimeType,<:Period}, i::Integer) = length(r) <= i
 
-+(x::Period, r::AbstractRange{<:TimeType}) = (x + first(r)):step(r):(x + last(r))
++(x::Period, r::AbstractRange{<:TimeType}) = (x + rangestart(r)):step(r):(x + rangestop(r))
 +(r::AbstractRange{<:TimeType}, x::Period) = x + r
--(r::AbstractRange{<:TimeType}, x::Period) = (first(r)-x):step(r):(last(r)-x)
+-(r::AbstractRange{<:TimeType}, x::Period) = (rangestart(r)-x):step(r):(rangestop(r)-x)
 
 # Combinations of types and periods for which the range step is regular
 Base.TypeRangeStep(::Type{<:OrdinalRange{<:TimeType, <:FixedPeriod}}) =

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -20,8 +20,8 @@ let
                 @test len == 0
                 @test isa(len, Int64)
                 @test isempty(dr)
-                @test first(dr) == f1
-                @test last(dr) < f1
+                @test rangestart(dr) == f1
+                @test rangestop(dr) < f1
                 @test length([i for i in dr]) == 0
                 @test_throws ArgumentError minimum(dr)
                 @test_throws ArgumentError maximum(dr)
@@ -30,8 +30,8 @@ let
                 @test [dr;] == T[]
                 @test isempty(reverse(dr))
                 @test length(reverse(dr)) == 0
-                @test first(reverse(dr)) < f1
-                @test last(reverse(dr)) >= f1
+                @test rangestart(reverse(dr)) < f1
+                @test rangestop(reverse(dr)) >= f1
                 @test issorted(dr)
                 @test sortperm(dr) == 1:1:0
                 @test !(f1 in dr)
@@ -78,8 +78,8 @@ let
                 @test len == 0
                 @test isa(len, Int64)
                 @test isempty(dr)
-                @test first(dr) == l1
-                @test last(dr) > l1
+                @test rangestart(dr) == l1
+                @test rangestop(dr) > l1
                 @test length([i for i in dr]) == 0
                 @test_throws ArgumentError minimum(dr)
                 @test_throws ArgumentError maximum(dr)
@@ -88,8 +88,8 @@ let
                 @test [dr;] == T[]
                 @test isempty(reverse(dr))
                 @test length(reverse(dr)) == 0
-                @test first(reverse(dr)) > l1
-                @test last(reverse(dr)) <= l1
+                @test rangestart(reverse(dr)) > l1
+                @test rangestop(reverse(dr)) <= l1
                 @test issorted(dr)
                 @test sortperm(dr) == 1:1:0
                 @test !(l1 in dr)
@@ -138,8 +138,8 @@ let
                     @test len == 0
                     @test isa(len, Int64)
                     @test isempty(dr)
-                    @test first(dr) == f1
-                    @test last(dr) < f1
+                    @test rangestart(dr) == f1
+                    @test rangestop(dr) < f1
                     @test length([i for i in dr]) == 0
                     @test_throws ArgumentError minimum(dr)
                     @test_throws ArgumentError maximum(dr)
@@ -148,8 +148,8 @@ let
                     @test [dr;] == T[]
                     @test isempty(reverse(dr))
                     @test length(reverse(dr)) == 0
-                    @test first(reverse(dr)) < f1
-                    @test last(reverse(dr)) >= f1
+                    @test rangestart(reverse(dr)) < f1
+                    @test rangestop(reverse(dr)) >= f1
                     @test issorted(dr)
                     @test sortperm(dr) == 1:1:0
                     @test !(f1 in dr)
@@ -196,8 +196,8 @@ let
                     @test len == 0
                     @test isa(len, Int64)
                     @test isempty(dr)
-                    @test first(dr) == l1
-                    @test last(dr) > l1
+                    @test rangestart(dr) == l1
+                    @test rangestop(dr) > l1
                     @test length([i for i in dr]) == 0
                     @test_throws ArgumentError minimum(dr)
                     @test_throws ArgumentError maximum(dr)
@@ -206,8 +206,8 @@ let
                     @test [dr;] == T[]
                     @test isempty(reverse(dr))
                     @test length(reverse(dr)) == 0
-                    @test first(reverse(dr)) > l1
-                    @test last(reverse(dr)) <= l1
+                    @test rangestart(reverse(dr)) > l1
+                    @test rangestop(reverse(dr)) <= l1
                     @test issorted(dr)
                     @test sortperm(dr) == 1:1:0
                     @test !(l1 in dr)
@@ -288,19 +288,19 @@ dr20 = typemin(Dates.DateTime):Dates.Day(2):typemax(Dates.DateTime)
 
 drs = Any[dr, dr1, dr2, dr3, dr4, dr5, dr6, dr7, dr8, dr9, dr10,
           dr11, dr12, dr13, dr14, dr15, dr16, dr17, dr18, dr19, dr20]
-drs2 = map(x->Dates.Date(first(x)):step(x):Dates.Date(last(x)), drs)
+drs2 = map(x->Dates.Date(rangestart(x)):step(x):Dates.Date(rangestop(x)), drs)
 
 @test map(length, drs) == map(x->size(x)[1], drs)
-@test map(length, drs) == map(x->length(Dates.Date(first(x)):step(x):Dates.Date(last(x))), drs)
+@test map(length, drs) == map(x->length(Dates.Date(rangestart(x)):step(x):Dates.Date(rangestop(x))), drs)
 @test map(length, drs) == map(x->length(reverse(x)), drs)
 @test all(x->findin(x, x)==[1:length(x);], drs[1:4])
 @test isempty(dr2)
-@test all(x->reverse(x) == range(last(x), -step(x), length(x)), drs)
-@test all(x->minimum(x) == (step(x) < zero(step(x)) ? last(x) : first(x)), drs[4:end])
-@test all(x->maximum(x) == (step(x) < zero(step(x)) ? first(x) : last(x)), drs[4:end])
+@test all(x->reverse(x) == range(rangestop(x), -step(x), length(x)), drs)
+@test all(x->minimum(x) == (step(x) < zero(step(x)) ? rangestop(x) : rangestart(x)), drs[4:end])
+@test all(x->maximum(x) == (step(x) < zero(step(x)) ? rangestart(x) : rangestop(x)), drs[4:end])
 @test all(drs[1:3]) do dd
     for (i, d) in enumerate(dd)
-        @test d == (first(dd) + Dates.Day(i - 1))
+        @test d == (rangestart(dd) + Dates.Day(i - 1))
     end
     true
 end
@@ -373,12 +373,12 @@ drs = Any[dr, dr1, dr2, dr3, dr4, dr5, dr6, dr7, dr8, dr9, dr10,
 @test map(length, drs) == map(x->size(x)[1], drs)
 @test all(x->findin(x, x) == [1:length(x);], drs[1:4])
 @test isempty(dr2)
-@test all(x->reverse(x) == last(x): - step(x):first(x), drs)
-@test all(x->minimum(x) == (step(x) < zero(step(x)) ? last(x) : first(x)), drs[4:end])
-@test all(x->maximum(x) == (step(x) < zero(step(x)) ? first(x) : last(x)), drs[4:end])
+@test all(x->reverse(x) == rangestop(x): - step(x):rangestart(x), drs)
+@test all(x->minimum(x) == (step(x) < zero(step(x)) ? rangestop(x) : rangestart(x)), drs[4:end])
+@test all(x->maximum(x) == (step(x) < zero(step(x)) ? rangestart(x) : rangestop(x)), drs[4:end])
 @test all(drs[1:3]) do dd
     for (i, d) in enumerate(dd)
-        @test d == (first(dd) + Dates.Day(i - 1))
+        @test d == (rangestart(dd) + Dates.Day(i - 1))
     end
     true
 end
@@ -559,9 +559,9 @@ drs = Any[dr, dr1, dr2, dr3, dr8, dr9, dr10,
 @test map(length, drs) == map(x->size(x)[1], drs)
 @test all(x->findin(x, x) == [1:length(x);], drs[1:4])
 @test isempty(dr2)
-@test all(x->reverse(x) == last(x): - step(x):first(x), drs)
-@test all(x->minimum(x) == (step(x) < zero(step(x)) ? last(x) : first(x)), drs[4:end])
-@test all(x->maximum(x) == (step(x) < zero(step(x)) ? first(x) : last(x)), drs[4:end])
+@test all(x->reverse(x) == rangestop(x): - step(x):rangestart(x), drs)
+@test all(x->minimum(x) == (step(x) < zero(step(x)) ? rangestop(x) : rangestart(x)), drs[4:end])
+@test all(x->maximum(x) == (step(x) < zero(step(x)) ? rangestart(x) : rangestop(x)), drs[4:end])
 @test_throws MethodError dr .+ 1
 
 a = Dates.Time(23, 1, 1)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -4,6 +4,11 @@
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using Main.TestHelpers.OAs
 
+_start(x::Number) = x
+_stop(x::Number) = x
+_start(x::AbstractRange) = rangestart(x)
+_stop(x::AbstractRange) = rangestop(x)
+
 @testset "basics" begin
     @test length([1, 2, 3]) == 3
     @test count(!iszero, [1, 2, 3]) == 3
@@ -1125,7 +1130,7 @@ end
             a = [1:10;]
             acopy = copy(a)
             @test splice!(a, idx, repl) == acopy[idx]
-            @test a == [acopy[1:(first(idx)-1)]; repl; acopy[(last(idx)+1):end]]
+            @test a == [acopy[1:(_start(idx)-1)]; repl; acopy[(_stop(idx)+1):end]]
         end
     end
 end
@@ -1163,15 +1168,15 @@ end
                    8:9, 9:10, 6:9, 7:10]
         # integer indexing with AbstractArray
         a = [1:10;]; acopy = copy(a)
-        @test deleteat!(a, idx) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
+        @test deleteat!(a, idx) == [acopy[1:(_start(idx)-1)]; acopy[(_stop(idx)+1):end]]
 
         # integer indexing with non-AbstractArray iterable
         a = [1:10;]; acopy = copy(a)
-        @test deleteat!(a, (i for i in idx)) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
+        @test deleteat!(a, (i for i in idx)) == [acopy[1:(_start(idx)-1)]; acopy[(_stop(idx)+1):end]]
 
         # logical indexing
         a = [1:10;]; acopy = copy(a)
-        @test deleteat!(a, map(i -> i in idx, 1:length(a))) == [acopy[1:(first(idx)-1)]; acopy[(last(idx)+1):end]]
+        @test deleteat!(a, map(i -> i in idx, 1:length(a))) == [acopy[1:(_start(idx)-1)]; acopy[(_stop(idx)+1):end]]
     end
     a = [1:10;]
     @test deleteat!(a, 11:10) == [1:10;]

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -623,18 +623,18 @@ end
 @testset "linspace & ranges with very small endpoints for type $T" for T = (Float32, Float64)
     z = zero(T)
     u = eps(z)
-    @test first(linspace(u,u,0)) == u
-    @test last(linspace(u,u,0)) == u
-    @test first(linspace(-u,u,0)) == -u
-    @test last(linspace(-u,u,0)) == u
+    @test rangestart(linspace(u,u,0)) == u
+    @test rangestop(linspace(u,u,0)) == u
+    @test rangestart(linspace(-u,u,0)) == -u
+    @test rangestop(linspace(-u,u,0)) == u
     @test [linspace(-u,u,0);] == []
     @test [linspace(-u,-u,1);] == [-u]
     @test [linspace(-u,u,2);] == [-u,u]
     @test [linspace(-u,u,3);] == [-u,0,u]
-    @test first(linspace(-u,-u,0)) == -u
-    @test last(linspace(-u,-u,0)) == -u
-    @test first(linspace(u,-u,0)) == u
-    @test last(linspace(u,-u,0)) == -u
+    @test rangestart(linspace(-u,-u,0)) == -u
+    @test rangestop(linspace(-u,-u,0)) == -u
+    @test rangestart(linspace(u,-u,0)) == u
+    @test rangestop(linspace(u,-u,0)) == -u
     @test [linspace(u,-u,0);] == []
     @test [linspace(u,u,1);] == [u]
     @test [linspace(u,-u,2);] == [u,-u]

--- a/test/sorting.jl
+++ b/test/sorting.jl
@@ -105,6 +105,8 @@ end
 Base.length(r::ConstantRange) = r.len
 Base.getindex(r::ConstantRange, i::Int) = (1 <= i <= r.len || throw(BoundsError(r,i)); r.val)
 Base.step(r::ConstantRange) = 0
+Base.rangestart(r::ConstantRange) = r.val
+Base.rangestop(r::ConstantRange) = r.val
 
 @testset "searchsorted method with ranges which check for zero step range" begin
     r = ConstantRange(1, 5)


### PR DESCRIPTION
This will allow throwing an error, for consistency with other `AbstractArray`s.
Introduce the `rangestart` and `rangestop` functions instead.

Fixes #22354.

This is RFC because two issues need to be discussed (apart from missing docs and FIXME):
- It would be nice to use the new field overloading feature to write `r.start` and `r.stop` instead of adding `rangestart` and `rangestop` functions. I think this use for ranges has been considered when discussing the feature, but since that would be one of the first times it would be used in Base, I'd rather check that people support it before adopting that approach.
- It turns out that in a few cases it would be useful to have `rangestart` and `rangestop` accept integers and return them, just like `first` and `last` do. See the second commit to have a list of the few places where it's needed. Unfortunately, that doesn't play well with using field overloading, except if we are OK with things like `1.start` returning `1`.