### PR TITLE
expand `min`/`max` with `missing` to all types

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -77,15 +77,21 @@ for f in (:(Base.zero), :(Base.one), :(Base.oneunit))
 end
 
 # Binary operators/functions
-for f in (:(+), :(-), :(*), :(/), :(^),
-          :(div), :(mod), :(fld), :(rem), :(min), :(max))
+for f in (:(+), :(-), :(*), :(/), :(^), :(div), :(mod), :(fld), :(rem))
     @eval begin
         # Scalar with missing
         ($f)(::Missing, ::Missing) = missing
-        ($f)(d::Missing, x::Number) = missing
-        ($f)(d::Number, x::Missing) = missing
+        ($f)(::Missing, ::Number)  = missing
+        ($f)(::Number,  ::Missing) = missing
     end
 end
+
+min(::Missing, ::Missing) = missing
+min(::Missing, ::Any)     = missing
+min(::Any,     ::Missing) = missing
+max(::Missing, ::Missing) = missing
+max(::Missing, ::Any)     = missing
+max(::Any,     ::Missing) = missing
 
 # Rounding and related functions
 for f in (:(ceil), :(floor), :(round), :(trunc))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -77,6 +77,15 @@ end
         @test ismissing(f(1, missing))
         @test ismissing(f(missing, 1))
     end
+
+    @test ismissing(min(missing, missing))
+    @test ismissing(max(missing, missing))
+    for f in [min, max]
+        for arg in ["", "a", 1, -1.0, [2]]
+            @test ismissing(f(missing, arg))
+            @test ismissing(f(arg, missing))
+        end
+    end
 end
 
 @testset "bit operators" begin


### PR DESCRIPTION
`min` and `max` are normally defined using `isless`, which gives:

```
julia> min(missing, 1)
missing

julia> min(1, missing)
missing

julia> min(missing, "1")
"1"
```

That doesn't seem right, so I expanded the `min` and `max` methods for `Missing` to all types, not just `Number`. 
  