### PR TITLE
WIP: Direct binding deprecation warnings to logging system

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -450,6 +450,12 @@ show(@nospecialize a) = show(STDOUT, a)
 print(@nospecialize a...) = print(STDOUT, a...)
 println(@nospecialize a...) = println(STDOUT, a...)
 
+# Unspecialized closure
+struct DeferredCall
+    args::Array{Any,1}
+end
+(d::DeferredCall)() = ccall(:jl_apply_generic, Any, (Ptr{Any}, UInt32), ccall(:jl_array_ptr, Ptr{Any}, (Any,), d.args), UInt32(Intrinsics.arraylen(d.args)))
+
 struct GeneratedFunctionStub
     gen
     argnames::Array{Any,1}

--- a/src/ast.c
+++ b/src/ast.c
@@ -206,7 +206,7 @@ value_t fl_julia_logmsg(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     for (int i = 0; i < kwargs_len; ++i) {
         jl_array_ptr_set(kwargs, i, scm_to_julia(fl_ctx, arg_kwargs[i], NULL));
     }
-    jl_log(numval(arg_level), NULL, group, id, file, line, (jl_value_t*)kwargs, msg);
+    jl_log(numval(arg_level), NULL, group, id, file, line, (jl_value_t*)kwargs, 0, msg);
     JL_GC_POP();
     return fl_ctx->T;
 }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1743,20 +1743,9 @@ extern "C" void jl_write_malloc_log(void)
 
 // --- constant determination ---
 
-static void show_source_loc(jl_codectx_t &ctx, JL_STREAM *out)
-{
-    jl_printf(out, "in %s at %s", ctx.name, ctx.file.str().c_str());
-}
-
-extern "C" void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b);
-
 static void cg_bdw(jl_codectx_t &ctx, jl_binding_t *b)
 {
-    jl_binding_deprecation_warning(ctx.module, b);
-    if (b->deprecated == 1 && jl_options.depwarn) {
-        show_source_loc(ctx, JL_STDERR);
-        jl_printf(JL_STDERR, "\n");
-    }
+    jl_binding_deprecation_warning(b, ctx.module);
 }
 
 static jl_value_t *static_apply_type(jl_codectx_t &ctx, const jl_cgval_t *args, size_t nargs)

--- a/src/init.c
+++ b/src/init.c
@@ -831,6 +831,7 @@ void jl_get_builtin_hooks(void)
     jl_methoderror_type = (jl_datatype_t*)core("MethodError");
     jl_loaderror_type = (jl_datatype_t*)core("LoadError");
     jl_initerror_type = (jl_datatype_t*)core("InitError");
+    jl_deferredcall_type = (jl_datatype_t*)core("DeferredCall");
 }
 
 void jl_get_builtins(void)

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -112,6 +112,7 @@ jl_unionall_t *jl_pointer_type;
 jl_typename_t *jl_pointer_typename;
 jl_datatype_t *jl_void_type;
 jl_datatype_t *jl_voidpointer_type;
+jl_datatype_t *jl_deferredcall_type=NULL;
 jl_typename_t *jl_namedtuple_typename;
 jl_unionall_t *jl_namedtuple_type;
 jl_value_t *jl_an_empty_vec_any=NULL;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -705,7 +705,6 @@ size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize, bt_context_t *ct
 #endif
 JL_DLLEXPORT void jl_get_backtrace(jl_array_t **bt, jl_array_t **bt2);
 JL_DLLEXPORT jl_value_t *jl_apply_with_saved_exception_state(jl_value_t **args, uint32_t nargs, int drop_exceptions);
-jl_task_t *jl_apply_in_new_task(jl_value_t **args, uint32_t nargs);
 void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_t *bt_size);
 JL_DLLEXPORT void jl_raise_debugger(void);
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -140,6 +140,8 @@ STATIC_INLINE uint32_t jl_int32hash_fast(uint32_t a)
 extern jl_methtable_t *jl_type_type_mt;
 JL_DLLEXPORT extern size_t jl_world_counter;
 
+extern jl_datatype_t *jl_deferredcall_type;
+
 typedef void (*tracer_cb)(jl_value_t *tracee);
 void jl_call_tracer(tracer_cb callback, jl_value_t *tracee);
 
@@ -703,6 +705,7 @@ size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize, bt_context_t *ct
 #endif
 JL_DLLEXPORT void jl_get_backtrace(jl_array_t **bt, jl_array_t **bt2);
 JL_DLLEXPORT jl_value_t *jl_apply_with_saved_exception_state(jl_value_t **args, uint32_t nargs, int drop_exceptions);
+jl_task_t *jl_apply_in_new_task(jl_value_t **args, uint32_t nargs);
 void jl_critical_error(int sig, bt_context_t *context, uintptr_t *bt_data, size_t *bt_size);
 JL_DLLEXPORT void jl_raise_debugger(void);
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline);
@@ -979,6 +982,7 @@ STATIC_INLINE void *jl_get_frame_addr(void)
 JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
 JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n);
 void jl_depwarn(const char *msg, jl_value_t *sym);
+void jl_binding_deprecation_warning(jl_binding_t *b, jl_module_t* from_module);
 
 // Log `msg` to the current logger by calling CoreLogging.logmsg_shim() on the
 // julia side. If any of module, group, id, file or line are NULL, these will
@@ -986,7 +990,7 @@ void jl_depwarn(const char *msg, jl_value_t *sym);
 // of keyword arguments will be passed.
 void jl_log(int level, jl_value_t *module, jl_value_t *group, jl_value_t *id,
             jl_value_t *file, jl_value_t *line, jl_value_t *kwargs,
-            jl_value_t *msg);
+            int async, jl_value_t *msg);
 
 int isabspath(const char *in);
 


### PR DESCRIPTION
This is a first attempt to direct the output of `jl_binding_deprecation_warning` to the logging system. This is a bit of a challenge as this depwarn may be generated from contexts where calling back into julia isn't allowed. I don't yet know what these contexts are and when they are active. @vtjnash suggested working around this by emitting the warning from a different task which is what I've done here.

This approach works, but I'm not really satisfied with the current implementation because
1. It's non intuitive. I really expect and want warnings to be synchronous by default.
2. It's fragile because the C code has to reproduce the handling of the task list which is normally only done in julia code. This is kind of ok for the simple `Workqueue` variable, but to make it work with `@sync` blocks becomes quite nasty (it would require allocating an ObjectIdDict from the C side, and inserting into it.  All of which is defined in julia which we're supposed to not be calling into from this context.)
3. Due to the above, `@sync` blocks don't work so you can't collect async logs using `with_logger()`.
4. Warnings can be lost if julia exits before the warning tasks get a chance to execute.

I've got some ideas on what to try next
* make the call appear synchronous by running the task immediately with `jl_switchto`. This won't work if we're inside a finalizer or function generator, but maybe that's ok.
* If someone could list the various circumstances under which the runtime C code can't call into julia that would be immensely helpful. I think @vtjnash mentioned that sometimes streams can't be flushed. I also ran into problems naively calling these warnings synchronously from within C functions called from inference.  And it's clear that finalizers are severely constrained.

Advice appreciated - anything done here will be reused to convert the rest of the user visible logging from the C code to the logging system.
  