### PR TITLE
fix some issues with `cmp` and `isless`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1548,7 +1548,7 @@ function isequal(A::AbstractArray, B::AbstractArray)
     return true
 end
 
-function cmp(A::AbstractArray, B::AbstractArray)
+function cmp(A::AbstractVector, B::AbstractVector)
     for (a, b) in zip(A, B)
         if !isequal(a, b)
             return isless(a, b) ? -1 : 1
@@ -1557,7 +1557,7 @@ function cmp(A::AbstractArray, B::AbstractArray)
     return cmp(length(A), length(B))
 end
 
-isless(A::AbstractArray, B::AbstractArray) = cmp(A, B) < 0
+isless(A::AbstractVector, B::AbstractVector) = cmp(A, B) < 0
 
 function (==)(A::AbstractArray, B::AbstractArray)
     if axes(A) != axes(B)

--- a/base/linalg/adjtrans.jl
+++ b/base/linalg/adjtrans.jl
@@ -116,6 +116,8 @@ similar(A::AdjOrTrans, ::Type{T}, dims::Dims{N}) where {T,N} = similar(A.parent,
 parent(A::AdjOrTrans) = A.parent
 vec(v::AdjOrTransAbsVec) = v.parent
 
+cmp(A::AdjOrTransAbsVec, B::AdjOrTransAbsVec) = cmp(parent(A), parent(B))
+isless(A::AdjOrTransAbsVec, B::AdjOrTransAbsVec) = isless(parent(A), parent(B))
 
 ### concatenation
 # preserve Adjoint/Transpose wrapper around vectors

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -223,11 +223,11 @@ one(::Union{T,Type{T}}) where {T<:AbstractString} = convert(T, "")
 """
     cmp(a::AbstractString, b::AbstractString) -> Int
 
-Compare two strings for equality. Return `0` if both strings have the same
-length and the character at each index is the same in both strings. Return `-1`
-if `a` is a substring of `b`, or if `a` comes before `b` in alphabetical order.
-Return `1` if `b` is a substring of `a`, or if `b` comes before `a` in
-alphabetical order (technically, lexicographical order by Unicode code points).
+Compare two strings. Return `0` if both strings have the same length and the character
+at each index is the same in both strings. Return `-1` if `a` is a prefix of `b`, or if
+`a` comes before `b` in alphabetical order. Return `1` if `b` is a prefix of `a`, or if
+`b` comes before `a` in alphabetical order (technically, lexicographical order by Unicode
+code points).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Some feel these methods should not exist, but while they exist they should at least implement an actual total order, so restricting to vectors for now.
 
Also fixes #25407