### PR TITLE
Fix undefined var error in reshape error

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -142,7 +142,7 @@ _reshape(parent::Array, dims::Dims) = reshape(parent, dims)
 # When reshaping Vector->Vector, don't wrap with a ReshapedArray
 function _reshape(v::AbstractVector, dims::Dims{1})
     len = dims[1]
-    len == length(v) || _throw_dmrs(n, "length", len)
+    len == length(v) || _throw_dmrs(_length(v), "length", len)
     v
 end
 # General reshape

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -87,6 +87,8 @@ using Main.TestHelpers.OAs
     @test a[2,1,2,2,1] == b[14]
     @test a[2,2,2,2,2] == b[end]
 
+    @test_throws DimensionMismatch reshape(1:3, 4)
+
     # issue #23107
     a = [1,2,3]
     @test typeof(a)(a) !== a


### PR DESCRIPTION
Before:

```
julia> reshape(1:3, 4)
ERROR: UndefVarError: n not defined
Stacktrace:
 [1] _reshape(::UnitRange{Int64}, ::Tuple{Int64}) at ./reshapedarray.jl:145
 [2] reshape at ./reshapedarray.jl:92 [inlined]
 [3] reshape(::UnitRange{Int64}, ::Int64) at ./reshapedarray.jl:95
 [4] top-level scope
```

After:

```
julia> reshape(1:3, 4)
ERROR: DimensionMismatch("parent has 3 elements, which is incompatible with length 4")
Stacktrace:
 [1] _throw_dmrs(::Int64, ::String, ::Int64) at ./reshapedarray.jl:156
 [2] _reshape at ./reshapedarray.jl:145 [inlined]
 [3] reshape at ./reshapedarray.jl:92 [inlined]
 [4] reshape(::UnitRange{Int64}, ::Int64) at ./reshapedarray.jl:95
 [5] top-level scope
```