### PR TITLE
Replace "labelled" with "labeled" in documentation

### DIFF
--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -76,7 +76,7 @@ element type. `dims` is either an integer (for a 1d array) or a tuple of the arr
 `own` optionally specifies whether Julia should take ownership of the memory,
 calling `free` on the pointer when the array is no longer referenced.
 
-This function is labelled "unsafe" because it will crash if `pointer` is not
+This function is labeled "unsafe" because it will crash if `pointer` is not
 a valid memory address to data of the requested length.
 """
 function unsafe_wrap(::Union{Type{Array},Type{Array{T}},Type{Array{T,N}}},

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -37,7 +37,7 @@ Copy a string from the address of a C-style (NUL-terminated) string encoded as U
 (The pointer can be safely freed afterwards.) If `length` is specified
 (the length of the data in bytes), the string does not have to be NUL-terminated.
 
-This function is labelled "unsafe" because it will crash if `p` is not
+This function is labeled "unsafe" because it will crash if `p` is not
 a valid memory address to data of the requested length.
 """
 function unsafe_string(p::Union{Ptr{UInt8},Ptr{Int8}}, len::Integer)


### PR DESCRIPTION
"labeled" is the more common spelling, and less likely to be
interpreted as a misspelling at first glance.

https://books.google.com/ngrams/graph?content=labeled%2Flabelled&corpus=15