### PR TITLE
fix count argument of replace!

### DIFF
--- a/test/sets.jl
+++ b/test/sets.jl
@@ -482,9 +482,12 @@ end
         @test replace!(x->maybe(2x, iseven(x)), a) === a
         @test a == [1, 4, 3, 1]
         @test replace(a, 1=>0) == [0, 4, 3, 0]
-        @test replace(a, 1=>0, count=1) == [0, 4, 3, 1]
+        for count = (1, 0x1, big(1))
+            @test replace(a, 1=>0, count=count) == [0, 4, 3, 1]
+        end
         @test replace!(a, 1=>2) === a
         @test a == [2, 4, 3, 2]
+        @test replace!(x->2x, a, count=0x2) == [4, 8, 3, 2]
 
         d = Dict(1=>2, 3=>4)
         @test replace(x->x.first > 2, d, 0=>0) == Dict(1=>2, 0=>0)
@@ -493,24 +496,30 @@ end
         @test replace(d, (3=>8)=>(0=>0)) == Dict(1=>2, 0=>0)
         @test replace!(d, (3=>8)=>(2=>2)) === d
         @test d == Dict(1=>2, 2=>2)
-        @test replace(x->x.second == 2, d, 0=>0, count=1) in [Dict(1=>2, 0=>0),
-                                                              Dict(2=>2, 0=>0)]
-
+        for count = (1, 0x1, big(1))
+            @test replace(x->x.second == 2, d, 0=>0, count=count) in [Dict(1=>2, 0=>0),
+                                                                      Dict(2=>2, 0=>0)]
+        end
         s = Set([1, 2, 3])
         @test replace(x->maybe(2x, x>1), s) == Set([1, 4, 6])
-        @test replace(x->maybe(2x, x>1), s, count=1) in [Set([1, 4, 3]), Set([1, 2, 6])]
+        for count = (1, 0x1, big(1))
+            @test replace(x->maybe(2x, x>1), s, count=count) in [Set([1, 4, 3]), Set([1, 2, 6])]
+        end
         @test replace(s, 1=>4) == Set([2, 3, 4])
         @test replace!(s, 1=>2) === s
         @test s == Set([2, 3])
+        @test replace!(x->2x, s, count=0x1) in [Set([4, 3]), Set([2, 6])]
 
-        @test replace([1, 2], 1=>0, 2=>0, count=0) == [1, 2] # count=0 --> no replacements
+        for count = (0, 0x0, big(0))
+            @test replace([1, 2], 1=>0, 2=>0, count=count) == [1, 2] # count=0 --> no replacements
+        end
     end
     # test collisions with AbstractSet/AbstractDict
     @test replace!(x->2x, Set([3, 6])) == Set([6, 12])
     @test replace!(x->2x, Set([1:20;])) == Set([2:2:40;])
     @test replace!(kv -> (2kv[1] => kv[2]), Dict(1=>2, 2=>4, 4=>8, 8=>16)) == Dict(2=>2, 4=>4, 8=>8, 16=>16)
-    # test Some(nothing)
 
+    # test Some(nothing)
     a = [1, 2, nothing, 4]
     @test replace(x -> x === nothing ? 0 : Some(nothing), a) == [nothing, nothing, 0, nothing]
     @test replace(x -> x === nothing ? 0 : nothing, a) == [1, 2, 0, 4]


### PR DESCRIPTION
`replace!` had one stack-overflow problem reported in #25384.
Its fix #25386 made a method-overwrite, tentatively fixed in #25422.
But `replace!` also didn't handle non-Int count arguments as
expected (because there is no dispatch on keyword arguments).
This fixes the root problem and adds tests for non-Int count.