### PR TITLE
fix #25433, make `grow_to!` more inferrable

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -583,8 +583,15 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
 end
 
 function grow_to!(dest, itr)
-    out = grow_to!(empty(dest, Union{}), itr, start(itr))
-    return isempty(out) ? dest : out
+    st = start(itr)
+    if done(itr, st)
+        return dest
+    else
+        v1, st = next(itr, st)
+        dest2 = empty(dest, typeof(v1))
+        push!(dest2, v1)
+        return grow_to!(dest2, itr, st)
+    end
 end
 
 function grow_to!(dest, itr, st)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -36,6 +36,9 @@ end
 @test isa(map(Integer, Any[1, 2]), Vector{Int})
 @test isa(map(Integer, Any[]), Vector{Integer})
 
+# issue #25433
+@test @inferred(collect(v for v in [1] if v > 0)) isa Vector{Int}
+
 # filter -- array.jl
 @test isequal(filter(x->(x>1), [0 1 2 3 2 1 0]), [2, 3, 2])
 # TODO: @test_throws isequal(filter(x->x+1, [0 1 2 3 2 1 0]), [2, 3, 2])


### PR DESCRIPTION
Not sure why it was implemented the way it was (even though I'm pretty sure I'm the one who wrote it...)

With the existing implementation, grow_to! started with a `Collection{Union{}}` even though that object could never actually be returned --- in the empty case, the `dest` argument is returned.