### PR TITLE
[RFC] rename module_parent to enclosingmodule

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -3775,6 +3775,9 @@ workspace() = error("`workspace()` is discontinued, consider Revise.jl for an al
 @deprecate_moved isnull "Nullables"
 @deprecate_moved unsafe_get "Nullables"
 
+# rename module_parent to enclosingmodule
+@deprecate module_parent(m::Module) enclosingmodule(m)
+
 # sub2ind and ind2sub deprecation (PR #24715)
 @deprecate ind2sub(A::AbstractArray, ind) CartesianIndices(A)[ind]
 @deprecate ind2sub(::Tuple{}, ind::Integer) CartesianIndices()[ind]

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -9,7 +9,7 @@ struct Binding
     function Binding(m::Module, v::Symbol)
         # Normalise the binding module for module symbols so that:
         #   Binding(Base, :Base) === Binding(Main, :Base)
-        m = module_name(m) === v ? module_parent(m) : m
+        m = module_name(m) === v ? enclosingmodule(m) : m
         new(Base.binding_module(m, v), v)
     end
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -901,7 +901,7 @@ export
     methods,
     methodswith,
     module_name,
-    module_parent,
+    enclosingmodule,
     names,
     varinfo,
     versioninfo,

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -6,8 +6,8 @@ Methods for working with Iterators.
 module Iterators
 
 # small dance to make this work from Base or Intrinsics
-import ..@__MODULE__, ..module_parent
-const Base = module_parent(@__MODULE__)
+import ..@__MODULE__, ..enclosingmodule
+const Base = enclosingmodule(@__MODULE__)
 using .Base:
     @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
     tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -126,7 +126,7 @@ function _include_from_serialized(path::String, depmods::Vector{Any})
             if isdefined(M, Base.Docs.META)
                 push!(Base.Docs.modules, M)
             end
-            if module_parent(M) === M
+            if enclosingmodule(M) === M
                 register_root_module(module_name(M), M)
             end
         end

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -191,7 +191,7 @@ function inbase(m::Module)
     if m == Base
         true
     else
-        parent = module_parent(m)
+        parent = enclosingmodule(m)
         parent === m ? false : inbase(parent)
     end
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -16,20 +16,20 @@ julia> module_name(Base.LinAlg)
 module_name(m::Module) = ccall(:jl_module_name, Ref{Symbol}, (Any,), m)
 
 """
-    module_parent(m::Module) -> Module
+    enclosingmodule(m::Module) -> Module
 
 Get a module's enclosing `Module`. `Main` is its own parent.
 
 # Examples
 ```jldoctest
-julia> module_parent(Main)
+julia> enclosingmodule(Main)
 Main
 
-julia> module_parent(Base.LinAlg.BLAS)
+julia> enclosingmodule(Base.LinAlg.BLAS)
 Base.LinAlg
 ```
 """
-module_parent(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
+enclosingmodule(m::Module) = ccall(:jl_enclosing_module, Ref{Module}, (Any,), m)
 
 """
     @__MODULE__ -> Module
@@ -60,7 +60,7 @@ function fullname(m::Module)
     if m === Main || m === Base || m === Core
         return (mn,)
     end
-    mp = module_parent(m)
+    mp = enclosingmodule(m)
     if mp === m
         if mn !== :Main
             return (mn,)

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -357,7 +357,7 @@ function serialize_mod_names(s::AbstractSerializer, m::Module)
     if Base.is_root_module(m)
         serialize(s, Base.root_module_key(m))
     else
-        serialize_mod_names(s, module_parent(m))
+        serialize_mod_names(s, enclosingmodule(m))
         serialize(s, module_name(m))
     end
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -175,7 +175,7 @@ function is_exported_from_stdlib(name::Symbol, mod::Module)
     !isdefined(mod, name) && return false
     orig = getfield(mod, name)
     while !(mod === Base || mod === Core)
-        parent = module_parent(mod)
+        parent = enclosingmodule(mod)
         if mod === Main || mod === parent || parent === Main
             return false
         end
@@ -1546,7 +1546,7 @@ function dumpsubtypes(io::IO, x::DataType, m::Module, n::Int, indent)
             t = getfield(m, s)
             if t === x || t === m
                 continue
-            elseif isa(t, Module) && module_name(t) === s && module_parent(t) === m
+            elseif isa(t, Module) && module_name(t) === s && enclosingmodule(t) === m
                 # recurse into primary module bindings
                 dumpsubtypes(io, x, t, n, indent)
             elseif isa(t, UnionAll) && directsubtype(t::UnionAll, x)

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -133,7 +133,7 @@ function (ss::SummarySize)(obj::Module)
     for binding in names(obj, true)
         if isdefined(obj, binding) && !isdeprecated(obj, binding)
             value = getfield(obj, binding)
-            if !isa(value, Module) || module_parent(value) === obj
+            if !isa(value, Module) || enclosingmodule(value) === obj
                 size += ss(value)::Int
                 if isa(value, UnionAll)
                     value = unwrap_unionall(value)

--- a/doc/src/stdlib/base.md
+++ b/doc/src/stdlib/base.md
@@ -311,7 +311,7 @@ Base.AsyncCondition(::Function)
 
 ```@docs
 Base.module_name
-Base.module_parent
+Base.enclosingmodule
 Base.@__MODULE__
 Base.fullname
 Base.names

--- a/src/module.c
+++ b/src/module.c
@@ -650,7 +650,7 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
 }
 
 JL_DLLEXPORT jl_sym_t *jl_module_name(jl_module_t *m) { return m->name; }
-JL_DLLEXPORT jl_module_t *jl_module_parent(jl_module_t *m) { return m->parent; }
+JL_DLLEXPORT jl_module_t *jl_enclosing_module(jl_module_t *m) { return m->parent; }
 JL_DLLEXPORT uint64_t jl_module_uuid(jl_module_t *m) { return m->uuid; }
 
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1291,7 +1291,7 @@ function detect_ambiguities(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && f !== mod && module_parent(f) === mod && module_name(f) === n
+            if recursive && isa(f, Module) && f !== mod && enclosingmodule(f) === mod && module_name(f) === n
                 subambs = detect_ambiguities(f,
                     imported=imported, recursive=recursive, ambiguous_bottom=ambiguous_bottom)
                 union!(ambs, subambs)
@@ -1332,7 +1332,7 @@ function detect_unbound_args(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && module_parent(f) === mod && module_name(f) === n
+            if recursive && isa(f, Module) && enclosingmodule(f) === mod && module_name(f) === n
                 subambs = detect_unbound_args(f, imported=imported, recursive=recursive)
                 union!(ambs, subambs)
             elseif isa(f, DataType) && isdefined(f.name, :mt)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2546,7 +2546,7 @@ function allsubtypes!(m::Module, x::DataType, sts::Set)
             t = getfield(m, s)
             if isa(t, Type) && t <: x && t != Union{}
                 push!(sts, t)
-            elseif isa(t, Module) && t !== m && module_name(t) === s && module_parent(t) === m
+            elseif isa(t, Module) && t !== m && module_name(t) === s && enclosingmodule(t) === m
                 allsubtypes!(t, x, sts)
             end
         end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -231,7 +231,7 @@ module TestModSub9475
         @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
         @test Base.module_name(@__MODULE__) == :TestModSub9475
         @test Base.fullname(@__MODULE__) == (curmod_name..., :TestMod7648, :TestModSub9475)
-        @test Base.module_parent(@__MODULE__) == TestMod7648
+        @test Base.enclosingmodule(@__MODULE__) == TestMod7648
     end
 end # module TestModSub9475
 
@@ -241,7 +241,7 @@ let
     @test Base.binding_module(@__MODULE__, :d7648) == @__MODULE__
     @test Base.binding_module(@__MODULE__, :a9475) == TestModSub9475
     @test Base.module_name(@__MODULE__) == :TestMod7648
-    @test Base.module_parent(@__MODULE__) == curmod
+    @test Base.enclosingmodule(@__MODULE__) == curmod
 end
 end # module TestMod7648
 
@@ -574,10 +574,10 @@ function f15280(x) end
 
 # bug found in #16850, Base.url with backslashes on Windows
 function module_depth(from::Module, to::Module)
-    if from === to || module_parent(to) === to
+    if from === to || enclosingmodule(to) === to
         return 0
     else
-        return 1 + module_depth(from, module_parent(to))
+        return 1 + module_depth(from, enclosingmodule(to))
     end
 end
 function has_backslashes(mod::Module)


### PR DESCRIPTION
Renaming `module_parent` to `enclosingmodule` came up in a slack conversation between @malmaud, @JeffBezanson, and myself. This pull request explores that change. Thoughts? Best!