### PR TITLE
fix arguments to MethodError calls in base

### DIFF
--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -230,8 +230,8 @@ end
 *(transD::Transpose{<:Any,<:Diagonal}, transB::Transpose{<:Any,<:Diagonal}) =
     (D = transD.parent; B = transB.parent; Diagonal(transpose.(D.diag) .* transpose.(B.diag)))
 
-mul!(A::Diagonal, B::Diagonal) = throw(MethodError(mul!, Tuple{Diagonal,Diagonal}))
-mul!(A::QRPackedQ, D::Diagonal) = throw(MethodError(mul!, Tuple{Diagonal,Diagonal}))
+mul!(A::Diagonal, B::Diagonal) = throw(MethodError(mul!, (A, B)))
+mul!(A::QRPackedQ, D::Diagonal) = throw(MethodError(mul!, (A, D)))
 mul!(A::QRPackedQ, B::Adjoint{<:Any,<:Diagonal}) = throw(MethodError(mul!, (A, B)))
 mul!(A::QRPackedQ, B::Transpose{<:Any,<:Diagonal}) = throw(MethodError(mul!, (A, B)))
 mul!(A::Adjoint{<:Any,<:QRPackedQ}, B::Diagonal) = throw(MethodError(mul!, (A, B)))
@@ -243,10 +243,8 @@ mul!(A::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:Diagonal}) = throw(MethodE
 mul!(A::Adjoint{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Diagonal}) = throw(MethodError(mul!, (A, B)))
 mul!(A::Transpose{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:Diagonal}) = throw(MethodError(mul!, (A, B)))
 mul!(A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Diagonal}) = throw(MethodError(mul!, (A, B)))
-mul!(transA::Transpose{<:Any,<:Diagonal}, B::Diagonal) =
-    throw(MethodError(mul!, Tuple{Transpose{<:Any,<:Diagonal},Diagonal}))
-mul!(adjA::Adjoint{<:Any,<:Diagonal}, B::Diagonal) =
-    throw(MethodError(mul!, Tuple{Adjoint{<:Any,<:Diagonal},Diagonal}))
+mul!(A::Transpose{<:Any,<:Diagonal}, B::Diagonal) = throw(MethodError(mul!, (A, B)))
+mul!(A::Adjoint{<:Any,<:Diagonal}, B::Diagonal) = throw(MethodError(mul!, (A, B)))
 mul!(A::Diagonal, B::AbstractMatrix)  = scale!(A.diag, B)
 mul!(adjA::Adjoint{<:Any,<:Diagonal}, B::AbstractMatrix) = (A = adjA.parent; scale!(conj(A.diag),B))
 mul!(transA::Transpose{<:Any,<:Diagonal}, B::AbstractMatrix) = (A = transA.parent; scale!(A.diag,B))

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -82,7 +82,7 @@ I.e. the value returned by `codeunit(s, i)` is of the type returned by
 See also: [`ncodeunits`](@ref), [`checkbounds`](@ref)
 """
 @propagate_inbounds codeunit(s::AbstractString, i::Integer) = typeof(i) === Int ?
-    throw(MethodError(codeunit, Tuple{typeof(s),Int})) : codeunit(s, Int(i))
+    throw(MethodError(codeunit, (s, i))) : codeunit(s, Int(i))
 
 """
     isvalid(s::AbstractString, i::Integer) -> Bool
@@ -119,7 +119,7 @@ Stacktrace:
 ```
 """
 @propagate_inbounds isvalid(s::AbstractString, i::Integer) = typeof(i) === Int ?
-    throw(MethodError(isvalid, Tuple{typeof(s),Int})) : isvalid(s, Int(i))
+    throw(MethodError(isvalid, (s, i))) : isvalid(s, Int(i))
 
 """
     next(s::AbstractString, i::Integer) -> Tuple{Char, Int}
@@ -134,7 +134,7 @@ See also: [`getindex`](@ref), [`start`](@ref), [`done`](@ref),
 [`checkbounds`](@ref)
 """
 @propagate_inbounds next(s::AbstractString, i::Integer) = typeof(i) === Int ?
-    throw(MethodError(next, Tuple{typeof(s),Int})) : next(s, Int(i))
+    throw(MethodError(next, (s, i))) : next(s, Int(i))
 
 ## basic generic definitions ##
 


### PR DESCRIPTION
Compare, e.g.,
```
julia> throw(MethodError(mul!, Tuple{Diagonal,Diagonal}))
ERROR: ┌ Error: Error showing method candidates, aborted
│   exception = MethodError(length, (Tuple{Diagonal,Diagonal},), 0x000000000000636e)
└ @ Base replutil.jl:418
MethodError: no method matching mul!(::Diagonal, ::Diagonal)
```
to
```
julia> throw(MethodError(mul!, (Diagonal([1]), Diagonal([2]))))
ERROR: MethodError: no method matching mul!(::Diagonal{Int64,Array{Int64,1}}, ::Diagonal{Int64,Array{Int64,1}})
Closest candidates are:
  mul!(::Diagonal, ::Diagonal) at linalg/diagonal.jl:233
  mul!(::AbstractArray{T,2} where T, ::Diagonal) at linalg/diagonal.jl:253
  mul!(::AbstractArray{T,2} where T, ::Diagonal, ::Transpose{#s520,#s519} where #s519<:(Union{AbstractArray{T,1}, AbstractArray{T,2}} where T) where #s520) at linalg/diagonal.jl:271
```
Best!