### PR TITLE
remove type instability in LAPACK eig perf tests

### DIFF
--- a/test/perf/lapack/eig.jl
+++ b/test/perf/lapack/eig.jl
@@ -2,9 +2,8 @@
 
 # Real
 function realeigtest(n, iter)
+    local d, v
     A = rand(n,n)
-    d = Vector{eltype(A)}
-    v = similar(A)
     for i = 1:iter
         d,v = eig(A)
     end
@@ -13,10 +12,9 @@ end
 
 # Symmetric
 function symeigtest(n, iter)
+    local d, v
     A = rand(n,n)
     A = A + adjoint(A)
-    d = Vector{eltype(A)}
-    v = similar(A)
     for i = 1:iter
         d,v = eig(A)
     end
@@ -25,10 +23,9 @@ end
 
 # Hermitian
 function hermitianeigtest(n, iter)
-    A = rand(n,n) + im*rand(n,n)
+    local d, v
+    A = rand(ComplexF64, n, n)
     A = A + adjoint(A)
-    d = Vector{eltype(A)}
-    v = similar(A)
     for i = 1:iter
         d,v = eig(A)
     end


### PR DESCRIPTION
Noticed during 5332 work. Best!