### PR TITLE
make Adjoint/Transpose behave like typical constructors

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2224,10 +2224,10 @@ end
     @deprecate A_mul_Bt(A::AbstractMatrix, B::AbstractTriangular)  (*)(A, transpose(B))
 end
 for (f, op, transform) in (
-        (:A_mul_Bc, :*, :Adjoint),
-        (:A_mul_Bt, :*, :Transpose),
-        (:A_rdiv_Bc, :/, :Adjoint),
-        (:A_rdiv_Bt, :/, :Transpose))
+        (:A_mul_Bc, :*, :adjoint),
+        (:A_mul_Bt, :*, :transpose),
+        (:A_rdiv_Bc, :/, :adjoint),
+        (:A_rdiv_Bt, :/, :transpose))
     @eval Base.LinAlg begin
         @deprecate $f(A::LowerTriangular, B::UpperTriangular)       ($op)(A, ($transform)(B))
         @deprecate $f(A::LowerTriangular, B::UnitUpperTriangular)   ($op)(A, ($transform)(B))
@@ -2236,10 +2236,10 @@ for (f, op, transform) in (
     end
 end
 for (f, op, transform) in (
-        (:Ac_mul_B, :*, :Adjoint),
-        (:At_mul_B, :*, :Transpose),
-        (:Ac_ldiv_B, :\, :Adjoint),
-        (:At_ldiv_B, :\, :Transpose))
+        (:Ac_mul_B, :*, :adjoint),
+        (:At_mul_B, :*, :transpose),
+        (:Ac_ldiv_B, :\, :adjoint),
+        (:At_ldiv_B, :\, :transpose))
     @eval Base.LinAlg begin
         @deprecate ($f)(A::UpperTriangular, B::LowerTriangular)     ($op)(($transform)(A), B)
         @deprecate ($f)(A::UnitUpperTriangular, B::LowerTriangular) ($op)(($transform)(A), B)

--- a/base/linalg/bidiag.jl
+++ b/base/linalg/bidiag.jl
@@ -252,9 +252,9 @@ transpose(B::Bidiagonal) = Transpose(B)
 adjoint(B::Bidiagonal{<:Real}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
 transpose(B::Bidiagonal{<:Number}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
 Base.copy(aB::Adjoint{<:Any,<:Bidiagonal}) =
-    (B = aB.parent; Bidiagonal(map(x -> copy.(Adjoint.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U))
+    (B = aB.parent; Bidiagonal(map(x -> copy.(adjoint.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U))
 Base.copy(tB::Transpose{<:Any,<:Bidiagonal}) =
-    (B = tB.parent; Bidiagonal(map(x -> copy.(Transpose.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U))
+    (B = tB.parent; Bidiagonal(map(x -> copy.(transpose.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U))
 
 istriu(M::Bidiagonal) = M.uplo == 'U' || iszero(M.ev)
 istril(M::Bidiagonal) = M.uplo == 'L' || iszero(M.ev)

--- a/base/linalg/diagonal.jl
+++ b/base/linalg/diagonal.jl
@@ -188,7 +188,7 @@ function mul!(D::Diagonal, B::UnitUpperTriangular)
     UpperTriangular(B.data)
 end
 
-*(D::Adjoint{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(Adjoint.(D.parent.diag) .* B.diag)
+*(D::Adjoint{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(adjoint.(D.parent.diag) .* B.diag)
 *(A::Adjoint{<:Any,<:AbstractTriangular}, D::Diagonal) = mul!(copy(A), D)
 function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = adjA.parent
@@ -197,7 +197,7 @@ function *(adjA::Adjoint{<:Any,<:AbstractMatrix}, D::Diagonal)
     mul!(Ac, D)
 end
 
-*(D::Transpose{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(Transpose.(D.parent.diag) .* B.diag)
+*(D::Transpose{<:Any,<:Diagonal}, B::Diagonal) = Diagonal(transpose.(D.parent.diag) .* B.diag)
 *(A::Transpose{<:Any,<:AbstractTriangular}, D::Diagonal) = mul!(copy(A), D)
 function *(transA::Transpose{<:Any,<:AbstractMatrix}, D::Diagonal)
     A = transA.parent
@@ -206,7 +206,7 @@ function *(transA::Transpose{<:Any,<:AbstractMatrix}, D::Diagonal)
     mul!(At, D)
 end
 
-*(D::Diagonal, B::Adjoint{<:Any,<:Diagonal}) = Diagonal(D.diag .* Adjoint.(B.parent.diag))
+*(D::Diagonal, B::Adjoint{<:Any,<:Diagonal}) = Diagonal(D.diag .* adjoint.(B.parent.diag))
 *(D::Diagonal, B::Adjoint{<:Any,<:AbstractTriangular}) = mul!(D, collect(B))
 *(D::Diagonal, adjQ::Adjoint{<:Any,<:Union{QRCompactWYQ,QRPackedQ}}) = (Q = adjQ.parent; mul!(Array(D), adjoint(Q)))
 function *(D::Diagonal, adjA::Adjoint{<:Any,<:AbstractMatrix})
@@ -216,7 +216,7 @@ function *(D::Diagonal, adjA::Adjoint{<:Any,<:AbstractMatrix})
     mul!(D, Ac)
 end
 
-*(D::Diagonal, B::Transpose{<:Any,<:Diagonal}) = Diagonal(D.diag .* Transpose.(B.parent.diag))
+*(D::Diagonal, B::Transpose{<:Any,<:Diagonal}) = Diagonal(D.diag .* transpose.(B.parent.diag))
 *(D::Diagonal, B::Transpose{<:Any,<:AbstractTriangular}) = mul!(D, copy(B))
 function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
     A = transA.parent
@@ -226,9 +226,9 @@ function *(D::Diagonal, transA::Transpose{<:Any,<:AbstractMatrix})
 end
 
 *(D::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:Diagonal}) =
-    Diagonal(Adjoint.(D.parent.diag) .* Adjoint.(B.parent.diag))
+    Diagonal(adjoint.(D.parent.diag) .* adjoint.(B.parent.diag))
 *(D::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Diagonal}) =
-    Diagonal(Transpose.(D.parent.diag) .* Transpose.(B.parent.diag))
+    Diagonal(transpose.(D.parent.diag) .* transpose.(B.parent.diag))
 
 mul!(A::Diagonal, B::Diagonal) = throw(MethodError(mul!, (A, B)))
 mul!(A::QRPackedQ, D::Diagonal) = throw(MethodError(mul!, (A, D)))
@@ -254,12 +254,12 @@ mul!(A::AbstractMatrix, transB::Transpose{<:Any,<:Diagonal}) = (B = transB.paren
 
 # Get ambiguous method if try to unify AbstractVector/AbstractMatrix here using AbstractVecOrMat
 mul!(out::AbstractVector, A::Diagonal, in::AbstractVector) = out .= A.diag .* in
-mul!(out::AbstractVector, A::Adjoint{<:Any,<:Diagonal}, in::AbstractVector) = out .= Adjoint.(A.parent.diag) .* in
-mul!(out::AbstractVector, A::Transpose{<:Any,<:Diagonal}, in::AbstractVector) = out .= Transpose.(A.parent.diag) .* in
+mul!(out::AbstractVector, A::Adjoint{<:Any,<:Diagonal}, in::AbstractVector) = out .= adjoint.(A.parent.diag) .* in
+mul!(out::AbstractVector, A::Transpose{<:Any,<:Diagonal}, in::AbstractVector) = out .= transpose.(A.parent.diag) .* in
 
 mul!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= A.diag .* in
-mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= Adjoint.(A.parent.diag) .* in
-mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= Transpose.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= adjoint.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= transpose.(A.parent.diag) .* in
 
 mul!(C::AbstractMatrix, A::Diagonal, B::Adjoint{<:Any,<:AbstractVecOrMat}) = mul!(C, A, copy(B))
 mul!(C::AbstractMatrix, A::Diagonal, B::Transpose{<:Any,<:AbstractVecOrMat}) = mul!(C, A, copy(B))
@@ -281,8 +281,8 @@ mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:Abs
 *(adjD::Adjoint{<:Any,<:Diagonal}, adjA::Adjoint{<:Any,<:RealHermSymComplexHerm}) = adjD * adjA.parent
 mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:RealHermSymComplexHerm}) = mul!(C, A, B.parent)
 mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:RealHermSymComplexSym}) = mul!(C, A, B.parent)
-mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:RealHermSymComplexSym}) = C .= Adjoint.(A.parent.diag) .* B
-mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:RealHermSymComplexHerm}) = C .= Transpose.(A.parent.diag) .* B
+mul!(C::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, B::Adjoint{<:Any,<:RealHermSymComplexSym}) = C .= adjoint.(A.parent.diag) .* B
+mul!(C::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, B::Transpose{<:Any,<:RealHermSymComplexHerm}) = C .= transpose.(A.parent.diag) .* B
 
 
 (/)(Da::Diagonal, Db::Diagonal) = Diagonal(Da.diag ./ Db.diag)

--- a/base/linalg/generic.jl
+++ b/base/linalg/generic.jl
@@ -823,9 +823,9 @@ function inv(A::AbstractMatrix{T}) where T
     ldiv!(factorize(convert(AbstractMatrix{S}, A)), dest)
 end
 
-pinv(v::AbstractVector{T}, tol::Real = real(zero(T))) where {T<:Real} = _vectorpinv(Transpose, v, tol)
-pinv(v::AbstractVector{T}, tol::Real = real(zero(T))) where {T<:Complex} = _vectorpinv(Adjoint, v, tol)
-pinv(v::AbstractVector{T}, tol::Real = real(zero(T))) where {T} = _vectorpinv(Adjoint, v, tol)
+pinv(v::AbstractVector{T}, tol::Real = real(zero(T))) where {T<:Real} = _vectorpinv(transpose, v, tol)
+pinv(v::AbstractVector{T}, tol::Real = real(zero(T))) where {T<:Complex} = _vectorpinv(adjoint, v, tol)
+pinv(v::AbstractVector{T}, tol::Real = real(zero(T))) where {T} = _vectorpinv(adjoint, v, tol)
 function _vectorpinv(dualfn::Tf, v::AbstractVector{Tv}, tol) where {Tv,Tf}
     res = dualfn(similar(v, typeof(zero(Tv) / (abs2(one(Tv)) + abs2(one(Tv))))))
     den = sum(abs2, v)

--- a/base/linalg/lu.jl
+++ b/base/linalg/lu.jl
@@ -584,7 +584,7 @@ function ldiv!(adjA::Adjoint{<:Any,LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat)
     return B
 end
 
-/(B::AbstractMatrix, A::LU) = copy(Transpose(transpose(A) \ transpose(B)))
+/(B::AbstractMatrix, A::LU) = copy(transpose(transpose(A) \ transpose(B)))
 
 # Conversions
 AbstractMatrix(F::LU) = (F.L * F.U)[invperm(F.p),:]

--- a/base/linalg/triangular.jl
+++ b/base/linalg/triangular.jl
@@ -1553,46 +1553,46 @@ for (f1, f2) in ((:*, :mul!), (:\, :ldiv!))
     end
 end
 
-for (ipop, op, xform) in (
-        (:mul!, :*, :Adjoint),
-        (:mul!, :*, :Transpose),
-        (:ldiv!, :\, :Adjoint),
-        (:ldiv!, :\, :Transpose))
+for (ipop, op, xformtype, xformop) in (
+        (:mul!, :*, :Adjoint, :adjoint),
+        (:mul!, :*, :Transpose, :transpose),
+        (:ldiv!, :\, :Adjoint, :adjoint),
+        (:ldiv!, :\, :Transpose, :transpose))
     @eval begin
-        function ($op)(xformA::($xform){<:Any,<:UpperTriangular}, B::LowerTriangular)
+        function ($op)(xformA::($xformtype){<:Any,<:UpperTriangular}, B::LowerTriangular)
             A = xformA.parent
-            TAB = typeof(($op)($xform(zero(eltype(A))), zero(eltype(B))) +
-                         ($op)($xform(zero(eltype(A))), zero(eltype(B))))
+            TAB = typeof(($op)($xformop(zero(eltype(A))), zero(eltype(B))) +
+                         ($op)($xformop(zero(eltype(A))), zero(eltype(B))))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
-            return LowerTriangular(($ipop)($xform(convert(AbstractMatrix{TAB}, A)), BB))
+            return LowerTriangular(($ipop)($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
 
-        function ($op)(xformA::($xform){<:Any,<:UnitUpperTriangular}, B::LowerTriangular)
+        function ($op)(xformA::($xformtype){<:Any,<:UnitUpperTriangular}, B::LowerTriangular)
             A = xformA.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
-            return LowerTriangular($ipop($xform(convert(AbstractMatrix{TAB}, A)), BB))
+            return LowerTriangular($ipop($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
 
-        function ($op)(xformA::($xform){<:Any,<:LowerTriangular}, B::UpperTriangular)
+        function ($op)(xformA::($xformtype){<:Any,<:LowerTriangular}, B::UpperTriangular)
             A = xformA.parent
-            TAB = typeof(($op)($xform(zero(eltype(A))), zero(eltype(B))) +
-                         ($op)($xform(zero(eltype(A))), zero(eltype(B))))
+            TAB = typeof(($op)($xformop(zero(eltype(A))), zero(eltype(B))) +
+                         ($op)($xformop(zero(eltype(A))), zero(eltype(B))))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
-            return UpperTriangular($ipop($xform(convert(AbstractMatrix{TAB}, A)), BB))
+            return UpperTriangular($ipop($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
 
-        function ($op)(xformA::($xform){<:Any,<:UnitLowerTriangular}, B::UpperTriangular)
+        function ($op)(xformA::($xformtype){<:Any,<:UnitLowerTriangular}, B::UpperTriangular)
             A = xformA.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
-            return UpperTriangular($ipop($xform(convert(AbstractMatrix{TAB}, A)), BB))
+            return UpperTriangular($ipop($xformop(convert(AbstractMatrix{TAB}, A)), BB))
         end
     end
 end
@@ -1626,46 +1626,46 @@ function (/)(A::UpperTriangular, B::UnitUpperTriangular)
     return UpperTriangular(rdiv!(AA, convert(AbstractMatrix{TAB}, B)))
 end
 
-for (ipop, op, xform) in (
-        (:mul!, :*, :Adjoint),
-        (:mul!, :*, :Transpose),
-        (:rdiv!, :/, :Adjoint),
-        (:rdiv!, :/, :Transpose))
+for (ipop, op, xformtype, xformop) in (
+        (:mul!, :*, :Adjoint, :adjoint),
+        (:mul!, :*, :Transpose, :transpose),
+        (:rdiv!, :/, :Adjoint, :adjoint),
+        (:rdiv!, :/, :Transpose, :transpose))
     @eval begin
-        function ($op)(A::LowerTriangular, xformB::($xform){<:Any,<:UpperTriangular})
+        function ($op)(A::LowerTriangular, xformB::($xformtype){<:Any,<:UpperTriangular})
             B = xformB.parent
-            TAB = typeof(($op)(zero(eltype(A)), $xform(zero(eltype(B)))) +
-                         ($op)(zero(eltype(A)), $xform(zero(eltype(B)))))
+            TAB = typeof(($op)(zero(eltype(A)), $xformop(zero(eltype(B)))) +
+                         ($op)(zero(eltype(A)), $xformop(zero(eltype(B)))))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
-            return LowerTriangular($ipop(AA, $xform(convert(AbstractMatrix{TAB}, B))))
+            return LowerTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
 
-        function ($op)(A::LowerTriangular, xformB::($xform){<:Any,<:UnitUpperTriangular})
+        function ($op)(A::LowerTriangular, xformB::($xformtype){<:Any,<:UnitUpperTriangular})
             B = xformB.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
-            return LowerTriangular($ipop(AA, $xform(convert(AbstractMatrix{TAB}, B))))
+            return LowerTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
 
-        function ($op)(A::UpperTriangular, xformB::($xform){<:Any,<:LowerTriangular})
+        function ($op)(A::UpperTriangular, xformB::($xformtype){<:Any,<:LowerTriangular})
             B = xformB.parent
-            TAB = typeof(($op)(zero(eltype(A)), $xform(zero(eltype(B)))) +
-                         ($op)(zero(eltype(A)), $xform(zero(eltype(B)))))
+            TAB = typeof(($op)(zero(eltype(A)), $xformop(zero(eltype(B)))) +
+                         ($op)(zero(eltype(A)), $xformop(zero(eltype(B)))))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
-            return UpperTriangular($ipop(AA, $xform(convert(AbstractMatrix{TAB}, B))))
+            return UpperTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
 
-        function ($op)(A::UpperTriangular, xformB::($xform){<:Any,<:UnitLowerTriangular})
+        function ($op)(A::UpperTriangular, xformB::($xformtype){<:Any,<:UnitLowerTriangular})
             B = xformB.parent
             TAB = typeof((*)(zero(eltype(A)), zero(eltype(B))) +
                          (*)(zero(eltype(A)), zero(eltype(B))))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
-            return UpperTriangular($ipop(AA, $xform(convert(AbstractMatrix{TAB}, B))))
+            return UpperTriangular($ipop(AA, $xformop(convert(AbstractMatrix{TAB}, B))))
         end
     end
 end

--- a/base/linalg/tridiag.jl
+++ b/base/linalg/tridiag.jl
@@ -130,8 +130,8 @@ broadcast(::typeof(ceil), ::Type{T}, M::SymTridiagonal) where {T<:Integer} = Sym
 transpose(S::SymTridiagonal) = S
 adjoint(S::SymTridiagonal{<:Real}) = S
 adjoint(S::SymTridiagonal) = Adjoint(S)
-Base.copy(S::Adjoint{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(Adjoint.(x)), (S.parent.dv, S.parent.ev))...)
-Base.copy(S::Transpose{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(Transpose.(x)), (S.parent.dv, S.parent.ev))...)
+Base.copy(S::Adjoint{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(adjoint.(x)), (S.parent.dv, S.parent.ev))...)
+Base.copy(S::Transpose{<:Any,<:SymTridiagonal}) = SymTridiagonal(map(x -> copy.(transpose.(x)), (S.parent.dv, S.parent.ev))...)
 
 function diag(M::SymTridiagonal, n::Integer=0)
     # every branch call similar(..., ::Int) to make sure the
@@ -526,8 +526,8 @@ adjoint(S::Tridiagonal) = Adjoint(S)
 transpose(S::Tridiagonal) = Transpose(S)
 adjoint(S::Tridiagonal{<:Real}) = Tridiagonal(S.du, S.d, S.dl)
 transpose(S::Tridiagonal{<:Number}) = Tridiagonal(S.du, S.d, S.dl)
-Base.copy(aS::Adjoint{<:Any,<:Tridiagonal}) = (S = aS.parent; Tridiagonal(map(x -> copy.(Adjoint.(x)), (S.du, S.d, S.dl))...))
-Base.copy(tS::Transpose{<:Any,<:Tridiagonal}) = (S = tS.parent; Tridiagonal(map(x -> copy.(Transpose.(x)), (S.du, S.d, S.dl))...))
+Base.copy(aS::Adjoint{<:Any,<:Tridiagonal}) = (S = aS.parent; Tridiagonal(map(x -> copy.(adjoint.(x)), (S.du, S.d, S.dl))...))
+Base.copy(tS::Transpose{<:Any,<:Tridiagonal}) = (S = tS.parent; Tridiagonal(map(x -> copy.(transpose.(x)), (S.du, S.d, S.dl))...))
 
 \(A::Adjoint{<:Any,<:Tridiagonal}, B::Adjoint{<:Any,<:StridedVecOrMat}) = copy(A) \ copy(B)
 

--- a/base/sparse/linalg.jl
+++ b/base/sparse/linalg.jl
@@ -934,27 +934,27 @@ function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
         return \(qrfact(A), B)
     end
 end
-for xform in (:Adjoint, :Transpose)
+for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
     @eval begin
-        function \(xformA::($xform){<:Any,<:SparseMatrixCSC}, B::AbstractVecOrMat)
+        function \(xformA::($xformtype){<:Any,<:SparseMatrixCSC}, B::AbstractVecOrMat)
             A = xformA.parent
             m, n = size(A)
             if m == n
                 if istril(A)
                     if istriu(A)
-                        return \($xform(Diagonal(Vector(diag(A)))), B)
+                        return \($xformop(Diagonal(Vector(diag(A)))), B)
                     else
-                        return \($xform(LowerTriangular(A)), B)
+                        return \($xformop(LowerTriangular(A)), B)
                     end
                 elseif istriu(A)
-                    return \($xform(UpperTriangular(A)), B)
+                    return \($xformop(UpperTriangular(A)), B)
                 end
                 if ishermitian(A)
-                    return \($xform(Hermitian(A)), B)
+                    return \($xformop(Hermitian(A)), B)
                 end
-                return \($xform(lufact(A)), B)
+                return \($xformop(lufact(A)), B)
             else
-                return \($xform(qrfact(A)), B)
+                return \($xformop(qrfact(A)), B)
             end
         end
     end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1306,7 +1306,7 @@ end
 
 # TODO
 
-@testset "Transpose" begin
+@testset "transpose" begin
     b1 = bitrand(v1)
     @check_bit_operation transpose(b1) Transpose{Bool,BitVector}
 

--- a/test/linalg/adjtrans.jl
+++ b/test/linalg/adjtrans.jl
@@ -62,23 +62,12 @@ end
     # the tests for the inner constructors exercise abstract scalar and concrete array eltype, forgoing here
 end
 
-@testset "Adjoint and Transpose of Numbers" begin
-    @test Adjoint(1) == 1
-    @test Adjoint(1.0) == 1.0
-    @test Adjoint(1im) == -1im
-    @test Adjoint(1.0im) == -1.0im
-    @test Transpose(1) == 1
-    @test Transpose(1.0) == 1.0
-    @test Transpose(1im) == 1im
-    @test Transpose(1.0im) == 1.0im
-end
-
-@testset "Adjoint and Transpose unwrapping" begin
+@testset "Adjoint and Transpose add additional layers to already-wrapped objects" begin
     intvec, intmat = [1, 2], [1 2; 3 4]
-    @test Adjoint(Adjoint(intvec)) === intvec
-    @test Adjoint(Adjoint(intmat)) === intmat
-    @test Transpose(Transpose(intvec)) === intvec
-    @test Transpose(Transpose(intmat)) === intmat
+    @test (A = Adjoint(Adjoint(intvec))::Adjoint{Int,Adjoint{Int,Vector{Int}}}; A.parent.parent === intvec)
+    @test (A = Adjoint(Adjoint(intmat))::Adjoint{Int,Adjoint{Int,Matrix{Int}}}; A.parent.parent === intmat)
+    @test (A = Transpose(Transpose(intvec))::Transpose{Int,Transpose{Int,Vector{Int}}}; A.parent.parent === intvec)
+    @test (A = Transpose(Transpose(intmat))::Transpose{Int,Transpose{Int,Matrix{Int}}}; A.parent.parent === intmat)
 end
 
 @testset "Adjoint and Transpose basic AbstractArray functionality" begin
@@ -439,6 +428,17 @@ end
         @test norm(Transpose(v), 1) ≈ 4
         @test norm(Transpose(v), Inf) ≈ 7
     end
+end
+
+@testset "adjoint and transpose of Numbers" begin
+    @test adjoint(1) == 1
+    @test adjoint(1.0) == 1.0
+    @test adjoint(1im) == -1im
+    @test adjoint(1.0im) == -1.0im
+    @test transpose(1) == 1
+    @test transpose(1.0) == 1.0
+    @test transpose(1im) == 1im
+    @test transpose(1.0im) == 1.0im
 end
 
 @testset "adjoint!(a, b) return a" begin

--- a/test/linalg/dense.jl
+++ b/test/linalg/dense.jl
@@ -790,7 +790,7 @@ end
 @testset "/ and \\ consistency with pinv for vectors" begin
     @testset "Tests for type $elty" for elty in (Float32, Float64, ComplexF32, ComplexF64)
         c = rand(elty, 5)
-        r = (elty <: Complex ? Adjoint : Transpose)(rand(elty, 5))
+        r = (elty <: Complex ? adjoint : transpose)(rand(elty, 5))
         cm = rand(elty, 5, 1)
         rm = rand(elty, 1, 5)
         @testset "inner prodcuts" begin


### PR DESCRIPTION
This pull request is the hopefully last set of functional changes in the JuliaLang/LinearAlgebra.jl#57 series (after JuliaLang/julia#24969, JuliaLang/julia#25083, JuliaLang/julia#25125, JuliaLang/julia#25148, JuliaLang/julia#25217, and JuliaLang/julia#25364).

Specifically, this pull request's first commit replaces some instances of `Adjoint`/`Transpose` with `adjoint`/`transpose` (namely those missed in JuliaLang/julia#25364 but caught by changes in the second commit), and its second commit makes `Adjoint`/`Transpose` behave like typical constructors (instead of e.g. satisfying `Adjoint(Adjoint(A)) === A`). 

Unless I am forgetting something (please remind me if so!), after this pull request only news, docs, and cleanup remain for JuliaLang/LinearAlgebra.jl#57. Best!
