### PR TITLE
add TODO from removed 0.6 deps to 0.7 deps

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -188,6 +188,8 @@ end
 
 # BEGIN 0.7 deprecations
 
+# TODO: remove warning for using `_` in parse_input_line in base/client.jl
+
 @deprecate issubtype (<:)
 
 @deprecate union() Set()
@@ -2907,8 +2909,6 @@ end
 
 @deprecate substrides(s, parent, dim, I::Tuple) substrides(parent, strides(parent), I)
 
-# END 0.7 deprecations
-
 @deprecate lexcmp(x::AbstractArray, y::AbstractArray) cmp(x, y)
 @deprecate lexcmp(x::Real, y::Real)                   cmp(isless, x, y)
 @deprecate lexcmp(x::Complex, y::Complex)             cmp((real(x),imag(x)), (real(y),imag(y)))
@@ -2972,6 +2972,7 @@ end
 
 
 # END 0.7 deprecations
+
 # BEGIN 1.0 deprecations
 
 # END 1.0 deprecations


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/pull/25312#pullrequestreview-87356875. Also remove a misplaced `# END 0.7 deprecations` heading and add a missing empty line between correctly located headings. Best!