### PR TITLE
filter REPL backtraces on top-level scope instead of eval

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -139,6 +139,16 @@ function repl_cmd(cmd, out)
     nothing
 end
 
+function ip_matches_func(ip, func::Symbol)
+    for fr in StackTraces.lookup(ip)
+        if fr === StackTraces.UNKNOWN || fr.from_c
+            return false
+        end
+        fr.func === func && return true
+    end
+    return false
+end
+
 function display_error(io::IO, er, bt)
     if !isempty(bt)
         st = stacktrace(bt)
@@ -148,7 +158,7 @@ function display_error(io::IO, er, bt)
     end
     print_with_color(Base.error_color(), io, "ERROR: "; bold = true)
     # remove REPL-related frames from interactive printing
-    eval_ind = findlast(addr->Base.REPL.ip_matches_func(addr, :eval), bt)
+    eval_ind = findlast(addr->ip_matches_func(addr, Symbol("top-level scope")), bt)
     if eval_ind != 0
         bt = bt[1:eval_ind-1]
     end

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -165,7 +165,7 @@ precompile(Tuple{typeof(Base.show_circular), Base.IOContext{Base.GenericIOBuffer
 precompile(Tuple{typeof(Base.show_delim_array), Base.IOContext{Base.GenericIOBuffer{Array{UInt8, 1}}}, Tuple{}, Char, Char, Char, Bool, Int64, Int64})
 precompile(Tuple{typeof(Base.throw_boundserror), Array{Base.StackTraces.StackFrame, 1}, Tuple{Base.UnitRange{Int64}}})
 precompile(Tuple{typeof(Base.splice!), Array{Base.StackTraces.StackFrame, 1}, Base.UnitRange{Int64}, Array{Any, 1}})
-precompile(Tuple{typeof(Base.REPL.ip_matches_func), Ptr{Cvoid}, Symbol})
+precompile(Tuple{typeof(Base.ip_matches_func), Ptr{Cvoid}, Symbol})
 precompile(Tuple{typeof(Base.throw_boundserror), Array{Ptr{Cvoid}, 1}, Tuple{Base.UnitRange{Int64}}})
 precompile(Tuple{typeof(Base.unsafe_copyto!), Array{Ptr{Cvoid}, 1}, Int64, Array{Ptr{Cvoid}, 1}, Int64, Int64})
 precompile(Tuple{Type{Base.Channel{Any}}, Int64})

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -104,16 +104,6 @@ function start_repl_backend(repl_channel::Channel, response_channel::Channel)
     backend
 end
 
-function ip_matches_func(ip, func::Symbol)
-    for fr in StackTraces.lookup(ip)
-        if fr === StackTraces.UNKNOWN || fr.from_c
-            return false
-        end
-        fr.func === func && return true
-    end
-    return false
-end
-
 struct REPLDisplay{R<:AbstractREPL} <: AbstractDisplay
     repl::R
 end


### PR DESCRIPTION
Changes:

```jl
julia> error()
ERROR:
Stacktrace:
 [1] error() at ./error.jl:42
 [2] top-level scope
```

back to what it was on 0.6:

```jl
julia> error()
ERROR:
Stacktrace:
 [1] error() at ./error.jl:42
```

I'm not sure this is completely correct since I do not know exactly when the "top-level scope" frames appear.

cc @keno
