### PR TITLE
Deprecate a couple more find(next|prev) methods, and remove ::Integer on `start`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1511,7 +1511,7 @@ julia> findnext(A, 3)
 0
 ```
 """
-function findnext(A, start::Integer)
+function findnext(A, start)
     l = endof(A)
     i = start
     warned = false
@@ -1571,7 +1571,7 @@ julia> findnext(isodd, A, 2)
 0
 ```
 """
-function findnext(testf::Function, A, start::Integer)
+function findnext(testf::Function, A, start)
     l = endof(A)
     i = start
     while i <= l
@@ -1627,7 +1627,7 @@ julia> findprev(A,1)
 0
 ```
 """
-function findprev(A, start::Integer)
+function findprev(A, start)
     i = start
     warned = false
     while i >= 1
@@ -1686,7 +1686,7 @@ julia> findprev(isodd, A, 3)
 2
 ```
 """
-function findprev(testf::Function, A, start::Integer)
+function findprev(testf::Function, A, start)
     i = start
     while i >= 1
         testf(A[i]) && return i

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1463,7 +1463,7 @@ function unsafe_bitfindnext(Bc::Vector{UInt64}, start::Integer)
 end
 
 # returns the index of the next non-zero element, or 0 if all zeros
-function findnext(B::BitArray, start::Integer)
+function findnext(B::BitArray, start)
     start > 0 || throw(BoundsError(B, start))
     start > length(B) && return 0
     unsafe_bitfindnext(B.chunks, start)
@@ -1472,7 +1472,7 @@ end
 #findfirst(B::BitArray) = findnext(B, 1)  ## defined in array.jl
 
 # aux function: same as findnext(~B, start), but performed without temporaries
-function findnextnot(B::BitArray, start::Integer)
+function findnextnot(B::BitArray, start)
     start > 0 || throw(BoundsError(B, start))
     start > length(B) && return 0
 
@@ -1503,16 +1503,8 @@ function findnextnot(B::BitArray, start::Integer)
 end
 findfirstnot(B::BitArray) = findnextnot(B,1)
 
-# returns the index of the first matching element
-function findnext(B::BitArray, v, start::Integer)
-    v == false && return findnextnot(B, start)
-    v == true && return findnext(B, start)
-    return 0
-end
-#findfirst(B::BitArray, v) = findnext(B, 1, v)  ## defined in array.jl
-
 # returns the index of the first element for which the function returns true
-function findnext(testf::Function, B::BitArray, start::Integer)
+function findnext(testf::Function, B::BitArray, start)
     f0::Bool = testf(false)
     f1::Bool = testf(true)
     !f0 && f1 && return findnext(B, start)
@@ -1544,7 +1536,7 @@ function unsafe_bitfindprev(Bc::Vector{UInt64}, start::Integer)
 end
 
 # returns the index of the previous non-zero element, or 0 if all zeros
-function findprev(B::BitArray, start::Integer)
+function findprev(B::BitArray, start)
     start > 0 || return 0
     start > length(B) && throw(BoundsError(B, start))
     unsafe_bitfindprev(B.chunks, start)
@@ -1574,16 +1566,8 @@ function findprevnot(B::BitArray, start::Integer)
 end
 findlastnot(B::BitArray) = findprevnot(B, length(B))
 
-# returns the index of the previous matching element
-function findprev(B::BitArray, v, start::Integer)
-    v == false && return findprevnot(B, start)
-    v == true && return findprev(B, start)
-    return 0
-end
-#findlast(B::BitArray, v) = findprev(B, 1, v)  ## defined in array.jl
-
 # returns the index of the previous element for which the function returns true
-function findprev(testf::Function, B::BitArray, start::Integer)
+function findprev(testf::Function, B::BitArray, start)
     f0::Bool = testf(false)
     f1::Bool = testf(true)
     !f0 && f1 && return findprev(B, start)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1269,11 +1269,13 @@ end
 # (2) base/linalg/qr.jl
 # (3) base/linalg/lq.jl
 
-@deprecate find(x::Number)            find(!iszero, x)
-@deprecate findnext(A, v, i::Integer) findnext(equalto(v), A, i)
-@deprecate findfirst(A, v)            findfirst(equalto(v), A)
-@deprecate findprev(A, v, i::Integer) findprev(equalto(v), A, i)
-@deprecate findlast(A, v)             findlast(equalto(v), A)
+@deprecate find(x::Number)             find(!iszero, x)
+@deprecate findnext(A, v, i)           findnext(equalto(v), A, i)
+@deprecate findfirst(A, v)             findfirst(equalto(v), A)
+@deprecate findprev(A, v, i)           findprev(equalto(v), A, i)
+@deprecate findlast(A, v)              findlast(equalto(v), A)
+@deprecate findnext(A::BitArray, v, i) findnext(equalto(v), A, i)
+@deprecate findprev(A::BitArray, v, i) findprev(equalto(v), A, i)
 # also remove deprecation warnings in find* functions in array.jl, sparse/sparsematrix.jl,
 # and sparse/sparsevector.jl.
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -266,7 +266,7 @@ matchall(re::Regex, str::SubString, overlap::Bool=false) =
     matchall(re, String(str), overlap)
 
 # TODO: return only start index and update deprecation
-function findnext(re::Regex, str::Union{String,SubString}, idx::Integer)
+function findnext(re::Regex, str::Union{String,SubString}, idx)
     if idx > nextind(str,endof(str))
         throw(BoundsError())
     end
@@ -275,7 +275,7 @@ function findnext(re::Regex, str::Union{String,SubString}, idx::Integer)
     PCRE.exec(re.regex, str, idx-1, opts, re.match_data) ?
         ((Int(re.ovec[1])+1):prevind(str,Int(re.ovec[2])+1)) : (0:-1)
 end
-findnext(r::Regex, s::AbstractString, idx::Integer) = throw(ArgumentError(
+findnext(r::Regex, s::AbstractString, idx) = throw(ArgumentError(
     "regex search is only available for the String type; use String(s) to convert"
 ))
 findfirst(r::Regex, s::AbstractString) = findnext(r,s,start(s))

--- a/base/sparse/abstractsparse.jl
+++ b/base/sparse/abstractsparse.jl
@@ -48,7 +48,7 @@ end
 _sparse_findnextnz(v::AbstractSparseArray, i::Integer) = (I = find(!iszero, v); n = searchsortedfirst(I, i); n<=length(I) ? I[n] : zero(indtype(v)))
 _sparse_findprevnz(v::AbstractSparseArray, i::Integer) = (I = find(!iszero, v); n = searchsortedlast(I, i);  !iszero(n)   ? I[n] : zero(indtype(v)))
 
-function findnext(f::typeof(!iszero), v::AbstractSparseArray, i::Integer)
+function findnext(f::typeof(!iszero), v::AbstractSparseArray, i)
     j = _sparse_findnextnz(v, i)
     while !iszero(j) && !f(v[j])
         j = _sparse_findnextnz(v, j+1)
@@ -56,7 +56,7 @@ function findnext(f::typeof(!iszero), v::AbstractSparseArray, i::Integer)
     return j
 end
 
-function findprev(f::typeof(!iszero), v::AbstractSparseArray, i::Integer)
+function findprev(f::typeof(!iszero), v::AbstractSparseArray, i)
     j = _sparse_findprevnz(v, i)
     while !iszero(j) && !f(v[j])
         j = _sparse_findprevnz(v, j-1)

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-function findnext(pred::EqualTo{Char}, s::String, i::Integer)
+function findnext(pred::EqualTo{Char}, s::String, i)
     if i < 1 || i > sizeof(s)
         i == sizeof(s) + 1 && return 0
         throw(BoundsError(s, i))
@@ -17,7 +17,7 @@ end
 
 findfirst(pred::EqualTo{<:Union{Int8,UInt8}}, a::ByteArray) = _search(a, pred.x)
 
-findnext(pred::EqualTo{<:Union{Int8,UInt8}}, a::ByteArray, i::Integer) =
+findnext(pred::EqualTo{<:Union{Int8,UInt8}}, a::ByteArray, i) =
     _search(a, pred.x, i)
 
 function _search(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = 1)
@@ -41,7 +41,7 @@ function _search(a::ByteArray, b::Char, i::Integer = 1)
     end
 end
 
-function findprev(pred::EqualTo{Char}, s::String, i::Integer)
+function findprev(pred::EqualTo{Char}, s::String, i)
     c = pred.x
     c ≤ '\x7f' && return _rsearch(s, c % UInt8, i)
     b = first_utf8_byte(c)
@@ -54,7 +54,7 @@ end
 
 findlast(pred::EqualTo{<:Union{Int8,UInt8}}, a::ByteArray) = _rsearch(a, pred.x)
 
-findprev(pred::EqualTo{<:Union{Int8,UInt8}}, a::ByteArray, i::Integer) =
+findprev(pred::EqualTo{<:Union{Int8,UInt8}}, a::ByteArray, i) =
     _rsearch(a, pred.x, i)
 
 function _rsearch(a::Union{String,ByteArray}, b::Union{Int8,UInt8}, i::Integer = sizeof(a))
@@ -98,7 +98,7 @@ findfirst(pattern::AbstractString, string::AbstractString) =
     findnext(pattern, string, start(string))
 
 # AbstractString implementation of the generic findnext interface
-function findnext(testf::Function, s::AbstractString, i::Integer)
+function findnext(testf::Function, s::AbstractString, i)
     z = ncodeunits(s) + 1
     1 ≤ i ≤ z || throw(BoundsError(s, i))
     @inbounds i == z || isvalid(s, i) || string_index_err(s, i)
@@ -260,7 +260,7 @@ julia> findnext("Julia", "JuliaLang", 2)
 1:5
 ```
 """
-findnext(t::AbstractString, s::AbstractString, i::Integer) = _search(s, t, i)
+findnext(t::AbstractString, s::AbstractString, i) = _search(s, t, i)
 
 """
     findlast(pattern::AbstractString, string::AbstractString)
@@ -282,7 +282,7 @@ findlast(pattern::AbstractString, string::AbstractString) =
     findprev(pattern, string, endof(string))
 
 # AbstractString implementation of the generic findprev interface
-function findprev(testf::Function, s::AbstractString, i::Integer)
+function findprev(testf::Function, s::AbstractString, i)
     if i < 1
         return i == 0 ? 0 : throw(BoundsError(s, i))
     end
@@ -445,7 +445,7 @@ julia> findprev("Julia", "JuliaLang", 6)
 1:5
 ```
 """
-findprev(t::AbstractString, s::AbstractString, i::Integer) = _rsearch(s, t, i)
+findprev(t::AbstractString, s::AbstractString, i) = _rsearch(s, t, i)
 
 """
     contains(haystack::AbstractString, needle::Union{AbstractString,Regex,Char})


### PR DESCRIPTION
This deprecates a couple of more methods as part of #23812.  It's a small standalone PR to help minimize conflicts between multiple big PRs.