### PR TITLE
update `isassigned` for invalid Chars

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -329,7 +329,7 @@ julia> isassigned('\\x01')
 true
 ```
 """
-isassigned(c) = category_code(c) != UTF8PROC_CATEGORY_CN
+isassigned(c) = UTF8PROC_CATEGORY_CN < category_code(c) <= UTF8PROC_CATEGORY_CO
 
 ## libc character class predicates ##
 

--- a/stdlib/Unicode/test/runtests.jl
+++ b/stdlib/Unicode/test/runtests.jl
@@ -293,11 +293,16 @@ end
     @test_throws ArgumentError normalize("\u006e\u0303", compose=false, stripmark=true)
 end
 
-@testset "fastplus" begin
-    @test lowercase('A') == 'a'
-    @test uppercase('a') == 'A'
-
+@testset "isassigned" begin
+    @test isassigned('\x00')
     @test isassigned('A')
+    @test isassigned('α')
+    @test isassigned('柒')
+    @test !isassigned('\ufffe')
+    @test !isassigned('\uffff')
+    @test !isassigned("\xf4\x90\x80\x80"[1])
+    @test !isassigned("\xf7\xbf\xbf\xbf"[1])
+    @test !isassigned("\xff"[1])
 end
 
 @testset "isspace" begin


### PR DESCRIPTION
Needed to be updated for the category codes used for invalid characters.

I'm not sure what to do with category codes for invalid characters more generally; utf8proc returns `0` (unassigned) for anything invalid, and we return our own codes (since arguably something that's not even in the range of valid codepoints can't be in any category). So far I haven't found any official guidance on this.