### PR TITLE
updates documentation for `Test.finish`

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -819,6 +819,18 @@ Do any final processing necessary for the given testset. This is called by the
 `@testset` infrastructure after a test block executes. One common use for this
 function is to record the testset to the parent's results list, using
 `get_testset`.
+
+Custom `AbstractTestSet` should call `record` on their parent (if there is one)
+to add themselves to the tree of test results. This might be implemented as:
+
+```
+if get_testset_depth() != 0
+    # Attach this test set to the parent test set
+    parent_ts = get_testset()
+    record(parent_ts, self)
+    return self
+end
+```
 """
 function finish end
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -816,14 +816,13 @@ function record end
     finish(ts::AbstractTestSet)
 
 Do any final processing necessary for the given testset. This is called by the
-`@testset` infrastructure after a test block executes. One common use for this
-function is to record the testset to the parent's results list, using
-`get_testset`.
+`@testset` infrastructure after a test block executes.
 
-Custom `AbstractTestSet` should call `record` on their parent (if there is one)
-to add themselves to the tree of test results. This might be implemented as:
+Custom `AbstractTestSet` subtypes should call `record` on their parent (if there
+is one) to add themselves to the tree of test results. This might be implemented
+as:
 
-```
+```julia
 if get_testset_depth() != 0
     # Attach this test set to the parent test set
     parent_ts = get_testset()


### PR DESCRIPTION
remind custom testset implementers to add themselves to their parent's results when they `finish`

Making sure that custom testsets add themselves to their parent is required so we can wrap the tests in a higher-level testset, as [TestReports.jl](https://github.com/oxinabox/TestReports.jl) does.

@oxinabox @c42f