### PR TITLE
binomial should throw OverflowError instead of InexactError

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -900,7 +900,7 @@ function binomial(n::T, k::T) where T<:Integer
     rr = 2
     while rr <= k
         xt = div(widemul(x, nn), rr)
-        x = xt
+        x = xt % T
         x == xt || throw(OverflowError("binomial($n0, $k0) overflows"))
         rr += 1
         nn += 1

--- a/test/combinatorics.jl
+++ b/test/combinatorics.jl
@@ -13,7 +13,7 @@
     @test binomial(Int32(34), Int32(15)) == binomial(BigInt(34), BigInt(15)) == 1855967520
     @test binomial(Int64(67), Int64(29)) == binomial(BigInt(67), BigInt(29)) == 7886597962249166160
     @test binomial(Int128(131), Int128(62)) == binomial(BigInt(131), BigInt(62)) == 157311720980559117816198361912717812000
-    @test_throws InexactError binomial(Int64(67), Int64(30))
+    @test_throws OverflowError binomial(Int64(67), Int64(30))
 end
 
 @testset "permutations" begin


### PR DESCRIPTION
Fixes #25494