### PR TITLE
Improve performance of eachindex(a, b). Fixes #25497

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -849,9 +849,14 @@ eachindex(::IndexLinear, A::AbstractArray) = linearindices(A)
 function eachindex(::IndexLinear, A::AbstractArray, B::AbstractArray...)
     @_inline_meta
     indsA = linearindices(A)
-    all(x->linearindices(x) == indsA, B) || throw_eachindex_mismatch(IndexLinear(), A, B...)
+    _all_match_first(linearindices, indsA, B...) || throw_eachindex_mismatch(IndexLinear(), A, B...)
     indsA
 end
+function _all_match_first(f::F, inds, A, B...) where F<:Function
+    @_inline_meta
+    (inds == f(A)) & _all_match_first(f, inds, B...)
+end
+_all_match_first(f::F, inds) where F<:Function = true
 
 isempty(a::AbstractArray) = (_length(a) == 0)
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -264,7 +264,7 @@ module IteratorsMD
 
     @inline function eachindex(::IndexCartesian, A::AbstractArray, B::AbstractArray...)
         axsA = axes(A)
-        all(x->axes(x) == axsA, B) || Base.throw_eachindex_mismatch(IndexCartesian(), A, B...)
+        Base._all_match_first(axes, axsA, B...) || Base.throw_eachindex_mismatch(IndexCartesian(), A, B...)
         CartesianIndices(axsA)
     end
 


### PR DESCRIPTION
On my machine this gets #25497 from ~8ns to ~3ns. Prior to #25108 it was around 2ns, but I don't think we can fully close the gap, except with `@inbounds` and putting the test inside `@boundscheck` (which technically, it's not).