### PR TITLE
make `tempname` on windows match unix behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -385,6 +385,9 @@ This section lists changes that do not have deprecation warnings.
       to get the old behavior (only "space" characters are considered as
       word separators), use the keyword `wordsep=isspace`.
 
+  * The `tempname` function used to create a file on Windows but not on other
+    platforms. It now never creates a file ([#9053]).
+
 Library improvements
 --------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2782,6 +2782,13 @@ end
 @deprecate findn(x::AbstractMatrix) (I = find(!iszero, x); (getindex.(I, 1), getindex.(I, 2)))
 @deprecate findn(a::AbstractArray{T, N}) where {T, N} (I = find(!iszero, x); ntuple(i -> getindex.(I, i), N))
 
+# issue #9053
+if Sys.iswindows()
+function Filesystem.tempname(uunique::UInt32)
+    error("`tempname(::UInt32)` is discontinued.")
+end
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/file.jl
+++ b/base/file.jl
@@ -265,9 +265,9 @@ function tempdir()
     resize!(temppath,lentemppath)
     return transcode(String, temppath)
 end
-tempname(uunique::UInt32=UInt32(0)) = tempname(tempdir(), uunique)
+
 const temp_prefix = cwstring("jl_")
-function tempname(temppath::AbstractString,uunique::UInt32)
+function _win_tempname(temppath::AbstractString, uunique::UInt32)
     tempp = cwstring(temppath)
     tname = Vector{UInt16}(uninitialized, 32767)
     uunique = ccall(:GetTempFileNameW,stdcall,UInt32,(Ptr{UInt16},Ptr{UInt16},UInt32,Ptr{UInt16}), tempp,temp_prefix,uunique,tname)
@@ -280,7 +280,7 @@ function tempname(temppath::AbstractString,uunique::UInt32)
 end
 
 function mktemp(parent=tempdir())
-    filename = tempname(parent, UInt32(0))
+    filename = _win_tempname(parent, UInt32(0))
     return (filename, Base.open(filename, "r+"))
 end
 
@@ -290,12 +290,27 @@ function mktempdir(parent=tempdir())
         if (seed & typemax(UInt16)) == 0
             seed += 1
         end
-        filename = tempname(parent, seed)
+        filename = _win_tempname(parent, seed)
         ret = ccall(:_wmkdir, Int32, (Ptr{UInt16},), cwstring(filename))
         if ret == 0
             return filename
         end
         systemerror(:mktempdir, Libc.errno()!=Libc.EEXIST)
+        seed += 1
+    end
+end
+
+function tempname()
+    parent = tempdir()
+    seed::UInt32 = rand(UInt32)
+    while true
+        if (seed & typemax(UInt16)) == 0
+            seed += 1
+        end
+        filename = _win_tempname(parent, seed)
+        if !ispath(filename)
+            return filename
+        end
         seed += 1
     end
 end
@@ -343,7 +358,14 @@ tempdir()
 """
     tempname()
 
-Generate a unique temporary file path.
+Generate a temporary file path. This function only returns a path; no file is
+created. The path is likely to be unique, but this cannot be guaranteed.
+
+!!! warning
+
+    This can lead to race conditions if another process obtains the same
+    file name and creates the file before you are able to.
+    Using [`mktemp()`](@ref) is recommended instead.
 """
 tempname()
 

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -633,19 +633,13 @@ function build!(pkgs::Vector, seen::Set, errfile::AbstractString)
 end
 
 function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
-    errfile = tempname()
-    touch(errfile)  # create empty file
-    try
+    mktemp() do errfile, f
         build!(pkgs, seen, errfile)
-        open(errfile, "r") do f
-            while !eof(f)
-                pkg = deserialize(f)
-                err = deserialize(f)
-                errs[pkg] = err
-            end
+        while !eof(f)
+            pkg = deserialize(f)
+            err = deserialize(f)
+            errs[pkg] = err
         end
-    finally
-        isfile(errfile) && Base.rm(errfile)
     end
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -218,10 +218,10 @@ close(s)
 my_tempdir = tempdir()
 @test isdir(my_tempdir) == true
 
-path = tempname()
-# Issue #9053.
-@test ispath(path) == Sys.iswindows()
-ispath(path) && rm(path)
+let path = tempname()
+    # issue #9053
+    @test !ispath(path)
+end
 
 (p, f) = mktemp()
 print(f, "Here is some text")

--- a/test/replcompletions.jl
+++ b/test/replcompletions.jl
@@ -776,6 +776,7 @@ end
 
 if Sys.iswindows()
     tmp = tempname()
+    touch(tmp)
     path = dirname(tmp)
     file = basename(tmp)
     temp_name = basename(path)


### PR DESCRIPTION
Here is a possible fix to #9053. From re-reading the thread I decided the following:

- While `tempname` is not recommended, it has uses and it would be annoying for us to remove it.
- We could potentially change (and/or rename) the function to make it create (but not open) the file, which would be safer, but it's not clear that all use cases want the file to exist.

So this PR does the following:

- Change `tempname` on windows not to create the file, like unix. According to the docs it *is* possible to call `GetTempFileNameW` such that it doesn't create the file.
- Add a warning to the docs.
- Deprecate (with an error) `tempname(::UInt32)` because it's just weird.
- Change a use of `tempname` in Pkg to `mktemp`
