### PR TITLE
correct nextind/prevind/thisind for SubString{String}

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -102,6 +102,7 @@ end
 
 thisind(s::String, i::Int) = _thisind_str(s, i)
 
+# s should be String or SubString{String}
 function _thisind_str(s, i::Int)
     i == 0 && return 0
     n = ncodeunits(s)
@@ -122,6 +123,7 @@ end
 
 nextind(s::String, i::Int) = _nextind_str(s, i)
 
+# s should be String or SubString{String}
 function _nextind_str(s, i::Int)
     i == 0 && return 1
     n = ncodeunits(s)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -98,9 +98,11 @@ function ==(a::String, b::String)
     al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
 end
 
-## thisind, prevind, nextind ##
+## thisind, nextind ##
 
-function thisind(s::String, i::Int)
+thisind(s::String, i::Int) = _thisind_str(s, i)
+
+function _thisind_str(s, i::Int)
     i == 0 && return 0
     n = ncodeunits(s)
     i == n + 1 && return i
@@ -118,7 +120,9 @@ function thisind(s::String, i::Int)
     return i
 end
 
-function nextind(s::String, i::Int)
+nextind(s::String, i::Int) = _nextind_str(s, i)
+
+function _nextind_str(s, i::Int)
     i == 0 && return 1
     n = ncodeunits(s)
     @boundscheck between(i, 1, n) || throw(BoundsError(s, i))

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -79,26 +79,8 @@ function isvalid(s::SubString, i::Integer)
     @inbounds return ib && isvalid(s.string, s.offset + i)
 end
 
-function thisind(s::SubString, i::Int)
-    @boundscheck 0 ≤ i ≤ ncodeunits(s)+1 || throw(BoundsError(s, i))
-    @inbounds return thisind(s.string, s.offset + i) - s.offset
-end
-function nextind(s::SubString, i::Int, n::Int)
-    @boundscheck 0 ≤ i < ncodeunits(s)+1 || throw(BoundsError(s, i))
-    @inbounds return nextind(s.string, s.offset + i, n) - s.offset
-end
-function nextind(s::SubString, i::Int)
-    @boundscheck 0 ≤ i < ncodeunits(s)+1 || throw(BoundsError(s, i))
-    @inbounds return nextind(s.string, s.offset + i) - s.offset
-end
-function prevind(s::SubString, i::Int, n::Int)
-    @boundscheck 0 < i ≤ ncodeunits(s)+1 || throw(BoundsError(s, i))
-    @inbounds return prevind(s.string, s.offset + i, n) - s.offset
-end
-function prevind(s::SubString, i::Int)
-    @boundscheck 0 < i ≤ ncodeunits(s)+1 || throw(BoundsError(s, i))
-    @inbounds return prevind(s.string, s.offset + i) - s.offset
-end
+thisind(s::SubString{String}, i::Int) = _thisind_str(s, i)
+nextind(s::SubString{String}, i::Int) = _nextind_str(s, i)
 
 function cmp(a::SubString{String}, b::SubString{String})
     na = sizeof(a)

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -188,6 +188,43 @@ let s = "lorem ipsum", sdict = Dict(
     end
 end
 
+# proper nextind/prevind/thisind for SubString{String}
+let rng = MersenneTwister(1), strs = ["∀∃∀"*String(rand(rng, UInt8, 40))*"∀∃∀",
+                                      String(rand(rng, UInt8, 50))]
+    for s in strs
+        a = 0
+        while !done(s, a)
+            a = nextind(s, a)
+            b = a - 1
+            while !done(s, b)
+                ss = SubString(s, a:b)
+                s2 = s[a:b]
+                @test ncodeunits(ss) == ncodeunits(s2)
+                for i in 0:ncodeunits(ss)+1
+                    @test thisind(ss, i) == thisind(s2, i)
+                end
+                for i in 0:ncodeunits(ss)
+                    @test nextind(ss, i) == nextind(s2, i)
+                    for j in 0:ncodeunits(ss)+5
+                        if j > 0 || isvalid(ss, i)
+                            @test nextind(ss, i, j) == nextind(s2, i, j)
+                        end
+                    end
+                end
+                for i in 1:ncodeunits(ss)+1
+                    @test prevind(ss, i) == prevind(s2, i)
+                    for j in 0:ncodeunits(ss)+5
+                        if j > 0 || isvalid(ss, i)
+                            @test prevind(ss, i, j) == prevind(s2, i, j)
+                        end
+                    end
+                end
+                b = nextind(s, b)
+            end
+        end
+    end
+end
+
 # for isvalid(SubString{String})
 let s = "Σx + βz - 2"
     for i in -1:ncodeunits(s)+2


### PR DESCRIPTION
An attempt to correct incorrect behavior reported in #25478.

Also fixes those two problems:
```
julia> s = "∀∃∀"
"∀∃∀"

julia> ss = SubString(s, 4, 4)
"∃"

julia> thisind(ss, 0)
-2

julia> prevind(ss, 1)
-2
```

In general I want `SubString` to behave identically to `String` created using `getindex` with the same range.

It seems that it is enough to remove all methods from *substring.jl* and extend signatures in *string.jl*, but I am still checking corner cases, so it is WIP still (but hopefully CI will pass).