### PR TITLE
Apply a forgotten patch to LLVM >3.9

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# treat patches as files that should not be modified
+*.patch -text

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -484,6 +484,7 @@ $(eval $(call LLVM_PATCH,llvm-D32208-coerce-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D32623-GVN-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D33129-scevexpander-non-integral)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-Yet-another-fix))
+$(eval $(call LLVM_PATCH,llvm-NVPTX-addrspaces)) # NVPTX
 $(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-loadcse-addrspace_4.0))
 ifeq ($(BUILD_LLVM_CLANG),1)
@@ -496,6 +497,7 @@ $(eval $(call LLVM_PATCH,llvm-3.9.0_D27296-libssp))
 $(eval $(call LLVM_PATCH,llvm-D27629-AArch64-large_model_4.0))
 $(eval $(call LLVM_PATCH,llvm-loadcse-addrspace_5.0))
 $(eval $(call LLVM_PATCH,llvm-D34078-vectorize-fdiv))
+$(eval $(call LLVM_PATCH,llvm-5.0-NVPTX-addrspaces)) # NVPTX
 $(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-D38765-gvn_5.0)) # Remove for 6.0
 endif # LLVM_VER

--- a/deps/patches/llvm-5.0-NVPTX-addrspaces.patch
+++ b/deps/patches/llvm-5.0-NVPTX-addrspaces.patch
@@ -1,0 +1,30 @@
+diff -ru llvm-5.0.0.orig/lib/Target/NVPTX/NVPTXISelLowering.cpp llvm-5.0.0/lib/Target/NVPTX/NVPTXISelLowering.cpp
+--- llvm-5.0.0.orig/lib/Target/NVPTX/NVPTXISelLowering.cpp	2017-07-12 22:49:21.000000000 +0200
++++ llvm-5.0.0/lib/Target/NVPTX/NVPTXISelLowering.cpp	2018-01-13 09:08:17.275987874 +0100
+@@ -1235,6 +1235,14 @@
+   }
+ }
+ 
++bool NVPTXTargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
++                                              unsigned DestAS) const {
++  assert(SrcAS != DestAS && "Expected different address spaces!");
++
++  return (SrcAS  == ADDRESS_SPACE_GENERIC || SrcAS  > ADDRESS_SPACE_LOCAL) &&
++         (DestAS == ADDRESS_SPACE_GENERIC || DestAS > ADDRESS_SPACE_LOCAL);
++}
++
+ SDValue
+ NVPTXTargetLowering::LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const {
+   SDLoc dl(Op);
+diff -ru llvm-5.0.0.orig/lib/Target/NVPTX/NVPTXISelLowering.h llvm-5.0.0/lib/Target/NVPTX/NVPTXISelLowering.h
+--- llvm-5.0.0.orig/lib/Target/NVPTX/NVPTXISelLowering.h	2018-01-13 09:07:48.839643576 +0100
++++ llvm-5.0.0/lib/Target/NVPTX/NVPTXISelLowering.h	2018-01-13 09:06:18.658551692 +0100
+@@ -443,6 +443,8 @@
+                                const NVPTXSubtarget &STI);
+   SDValue LowerOperation(SDValue Op, SelectionDAG &DAG) const override;
+ 
++  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override;
++
+   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
+ 
+   const char *getTargetNodeName(unsigned Opcode) const override;


### PR DESCRIPTION
More specifically, https://github.com/JuliaLang/julia/pull/23611 for making the NVPTX back-end ignore Julia's address spaces.
Tested with LLVM 4.0.1 and 5.0.0

This also adds a `.gitattributes` file to fully preserve patch contents, because apparently the target file contains CRLF line endings that otherwise get stripped from the patch by git.

cc @iblis17
