### PR TITLE
Add back MPFR version check for test

### DIFF
--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -880,8 +880,10 @@ end
 end
 
 # issue #22758
-setprecision(2_000_000) do
-    @test abs(sin(big(pi)/6) - 0.5) < ldexp(big(1.0),-1_999_000)
+if MPFR.version() > v"3.1.5" || "r11590" in MPFR.patches()
+    setprecision(2_000_000) do
+        @test abs(sin(big(pi)/6) - 0.5) < ldexp(big(1.0),-1_999_000)
+    end
 end
 
 @testset "show BigFloat" begin


### PR DESCRIPTION
We do not require MPFR 3.1.6, yet tests fail before that version.

See https://github.com/JuliaLang/julia/pull/24924/files/165c8356de6fb8c7ae1efaf33513997498524a5d#r161325447