### PR TITLE
remove unnecessary locals

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -375,7 +375,6 @@ function _start()
         (quiet,repl,startup,color_set,history_file) = process_options(opts)
         banner = opts.banner == 1
 
-        local term
         global active_repl
         global active_repl_backend
         if repl

--- a/base/file.jl
+++ b/base/file.jl
@@ -514,8 +514,8 @@ function rename(src::AbstractString, dst::AbstractString)
 end
 
 function sendfile(src::AbstractString, dst::AbstractString)
-    local src_open = false
-    local dst_open = false
+    src_open = false
+    dst_open = false
     local src_file, dst_file
     try
         src_file = open(src, JL_O_RDONLY)

--- a/base/hashing.jl
+++ b/base/hashing.jl
@@ -25,7 +25,7 @@ hash(@nospecialize(x), h::UInt) = hash_uint(3h - object_id(x))
 ## core data hashing functions ##
 
 function hash_64_64(n::UInt64)
-    local a::UInt64 = n
+    a::UInt64 = n
     a = ~a + a << 21
     a =  a ⊻ a >> 24
     a =  a + a << 3 + a << 8
@@ -37,7 +37,7 @@ function hash_64_64(n::UInt64)
 end
 
 function hash_64_32(n::UInt64)
-    local a::UInt64 = n
+    a::UInt64 = n
     a = ~a + a << 18
     a =  a ⊻ a >> 31
     a =  a * 21
@@ -48,7 +48,7 @@ function hash_64_32(n::UInt64)
 end
 
 function hash_32_32(n::UInt32)
-    local a::UInt32 = n
+    a::UInt32 = n
     a = a + 0x7ed55d16 + a << 12
     a = a ⊻ 0xc761c23c ⊻ a >> 19
     a = a + 0x165667b1 + a << 5

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -284,8 +284,7 @@ function powermod(x::Integer, p::Integer, m::T) where T<:Integer
     b = oftype(m,mod(x,m))  # this also checks for divide by zero
 
     t = prevpow2(p)
-    local r::T
-    r = 1
+    r::T = 1
     while true
         if p >= t
             r = mod(widemul(r,b),m)

--- a/base/io.jl
+++ b/base/io.jl
@@ -191,7 +191,7 @@ to provide more efficient implementations:
 `unsafe_write(s::T, p::Ptr{UInt8}, n::UInt)`
 """
 function unsafe_write(s::IO, p::Ptr{UInt8}, n::UInt)
-    local written::Int = 0
+    written::Int = 0
     for i = 1:n
         written += write(s, unsafe_load(p, i))
     end
@@ -485,8 +485,7 @@ isreadonly(s) = isreadable(s) && !iswritable(s)
 
 write(io::IO, x) = throw(MethodError(write, (io, x)))
 function write(io::IO, x1, xs...)
-    local written::Int = 0
-    written += write(io, x1)
+    written::Int = write(io, x1)
     for x in xs
         written += write(io, x)
     end


### PR DESCRIPTION
This removes some unnecessary `local`s to avoid misleading implications. I think these `local`s are due to historical reasons.