### PR TITLE
fixed two links and added example

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -1,4 +1,4 @@
-# [Functions](@id man-functions)
+# [Functions](https://docs.julialang.org/en/stable/manual/functions/)
 
 In Julia, a function is an object that maps a tuple of argument values to a return value. Julia
 functions are not pure mathematical functions, in the sense that functions can alter and be affected
@@ -143,7 +143,7 @@ julia> +(1,2,3)
 
 The infix form is exactly equivalent to the function application form -- in fact the former is
 parsed to produce the function call internally. This also means that you can assign and pass around
-operators such as [`+`](@ref) and [`*`](@ref) just like you would with other function values:
+operators such as [`+()`](@ref) and [`*()`](@ref) just like you would with other function values:
 
 ```jldoctest
 julia> f = +;
@@ -158,20 +158,21 @@ Under the name `f`, the function does not support infix notation, however.
 
 A few special expressions correspond to calls to functions with non-obvious names. These are:
 
-| Expression        | Calls                   |
-|:----------------- |:----------------------- |
-| `[A B C ...]`     | [`hcat`](@ref)          |
-| `[A; B; C; ...]`  | [`vcat`](@ref)          |
-| `[A B; C D; ...]` | [`hvcat`](@ref)         |
-| `A'`              | [`adjoint`](@ref)       |
-| `A.'`             | [`transpose`](@ref)     |
-| `1:n`             | [`colon`](@ref)         |
-| `A[i]`            | [`getindex`](@ref)      |
-| `A[i] = x`        | [`setindex!`](@ref)     |
-| `A.n`             | [`getproperty`](@ref Base.getproperty) |
-| `A.n = x`         | [`setproperty!`](@ref Base.setproperty!) |
+| Expression        | Calls                  |
+|:----------------- |:---------------------- |
+| `[A B C ...]`     | [`hcat()`](@ref)       |
+| `[A; B; C; ...]`  | [`vcat()`](@ref)       |
+| `[A B; C D; ...]` | [`hvcat()`](@ref)      |
+| `A'`              | [`ctranspose()`](@ref) |
+| `A.'`             | [`transpose()`](@ref)  |
+| `1:n`             | [`colon()`](@ref)      |
+| `A[i]`            | [`getindex()`](@ref)   |
+| `A[i]=x`          | [`setindex!()`](@ref)  |
 
-## [Anonymous Functions](@id man-anonymous-functions)
+These functions are included in the `Base.Operators` module even though they do not have operator-like
+names.
+
+## [Anonymous Functions](https://docs.julialang.org/en/stable/manual/functions/#man-anonymous-functions-1)
 
 Functions in Julia are [first-class objects](https://en.wikipedia.org/wiki/First-class_citizen):
 they can be assigned to variables, and called using the standard function call syntax from the
@@ -181,12 +182,12 @@ syntaxes:
 
 ```jldoctest
 julia> x -> x^2 + 2x - 1
-#1 (generic function with 1 method)
+(::#1) (generic function with 1 method)
 
 julia> function (x)
            x^2 + 2x - 1
        end
-#3 (generic function with 1 method)
+(::#3) (generic function with 1 method)
 ```
 
 This creates a function taking one argument `x` and returning the value of the polynomial `x^2 +
@@ -194,7 +195,7 @@ This creates a function taking one argument `x` and returning the value of the p
 name based on consecutive numbering.
 
 The primary use for anonymous functions is passing them to functions which take other functions
-as arguments. A classic example is [`map`](@ref), which applies a function to each value of
+as arguments. A classic example is [`map()`](@ref), which applies a function to each value of
 an array and returns a new array containing the resulting values:
 
 ```jldoctest
@@ -205,10 +206,10 @@ julia> map(round, [1.2,3.5,1.7])
  2.0
 ```
 
-This is fine if a named function effecting the transform already exists to pass as the first argument
-to [`map`](@ref). Often, however, a ready-to-use, named function does not exist. In these
-situations, the anonymous function construct allows easy creation of a single-use function object
-without needing a name:
+This is fine if a named function effecting the transform one wants already exists to pass as the
+first argument to [`map()`](@ref). Often, however, a ready-to-use, named function does not exist.
+In these situations, the anonymous function construct allows easy creation of a single-use function
+object without needing a name:
 
 ```jldoctest
 julia> map(x -> x^2 + 2x - 1, [1,3,-1])
@@ -219,51 +220,19 @@ julia> map(x -> x^2 + 2x - 1, [1,3,-1])
 ```
 
 An anonymous function accepting multiple arguments can be written using the syntax `(x,y,z)->2x+y-z`.
+
+```jldoctest
+# anonymous function for two arguments bound to identifier add
+add = (x,y) -> x+y
+# calls function add
+add(3,4) # => 7
+```
+
 A zero-argument anonymous function is written as `()->3`. The idea of a function with no arguments
 may seem strange, but is useful for "delaying" a computation. In this usage, a block of code is
-wrapped in a zero-argument function, which is later invoked by calling it as `f`.
+wrapped in a zero-argument function, which is later invoked by calling it as `f()`.
 
-## Tuples
 
-Julia has a built-in data structure called a *tuple* that is closely related to function
-arguments and return values.
-A tuple is a fixed-length container that can hold any values, but cannot be modified
-(it is *immutable*).
-Tuples are constructed with commas and parentheses, and can be accessed via indexing:
-
-```jldoctest
-julia> (1, 1+1)
-(1, 2)
-
-julia> (1,)
-(1,)
-
-julia> x = (0.0, "hello", 6*7)
-(0.0, "hello", 42)
-
-julia> x[2]
-"hello"
-```
-
-Notice that a length-1 tuple must be written with a comma, `(1,)`, since `(1)` would just
-be a parenthesized value.
-`()` represents the empty (length-0) tuple.
-
-## Named Tuples
-
-The components of tuples can optionally be named, in which case a *named tuple* is
-constructed:
-
-```jldoctest
-julia> x = (a=1, b=1+1)
-(a = 1, b = 2)
-
-julia> x.a
-1
-```
-
-Named tuples are very similar to tuples, except that fields can additionally be accessed by name
-using dot syntax (`x.a`).
 
 ## Multiple Return Values
 
@@ -311,25 +280,6 @@ end
 
 This has the exact same effect as the previous definition of `foo`.
 
-## Argument destructuring
-
-The destructuring feature can also be used within a function argument.
-If a function argument name is written as a tuple (e.g. `(x, y)`) instead of just
-a symbol, then an assignment `(x, y) = argument` will be inserted for you:
-
-```julia
-julia> minmax(x, y) = (y < x) ? (y, x) : (x, y)
-
-julia> range((min, max)) = max - min
-
-julia> range(minmax(10, 2))
-8
-```
-
-Notice the extra set of parentheses in the definition of `range`.
-Without those, `range` would be a two-argument function, and this example would
-not work.
-
 ## Varargs Functions
 
 It is often convenient to be able to write functions taking an arbitrary number of arguments.
@@ -364,7 +314,7 @@ In all these cases, `x` is bound to a tuple of the trailing values passed to `ba
 It is possible to constrain the number of values passed as a variable argument; this will be discussed
 later in [Parametrically-constrained Varargs methods](@ref).
 
-On the flip side, it is often handy to "splat" the values contained in an iterable collection
+On the flip side, it is often handy to "splice" the values contained in an iterable collection
 into a function call as individual arguments. To do this, one also uses `...` but in the function
 call instead:
 
@@ -393,7 +343,7 @@ julia> bar(x...)
 (1, 2, (3, 4))
 ```
 
-Furthermore, the iterable object splatted into a function call need not be a tuple:
+Furthermore, the iterable object spliced into a function call need not be a tuple:
 
 ```jldoctest barfunc
 julia> x = [3,4]
@@ -415,7 +365,7 @@ julia> bar(x...)
 (1, 2, (3, 4))
 ```
 
-Also, the function that arguments are splatted into need not be a varargs function (although it
+Also, the function that arguments are spliced into need not be a varargs function (although it
 often is):
 
 ```jldoctest
@@ -441,7 +391,7 @@ Closest candidates are:
   baz(::Any, ::Any) at none:1
 ```
 
-As you can see, if the wrong number of elements are in the splatted container, then the function
+As you can see, if the wrong number of elements are in the spliced container, then the function
 call will fail, just as it would if too many arguments were given explicitly.
 
 ## Optional Arguments
@@ -452,7 +402,7 @@ interprets a string as a number in some base. The `base` argument defaults to `1
 can be expressed concisely as:
 
 ```julia
-function parse(T, num, base=10)
+function parse(type, num, base=10)
     ###
 end
 ```
@@ -506,7 +456,7 @@ prior keyword arguments.
 The types of keyword arguments can be made explicit as follows:
 
 ```julia
-function f(;x::Int=1)
+function f(;x::Int64=1)
     ###
 end
 ```
@@ -519,12 +469,14 @@ function f(x; y=0, kwargs...)
 end
 ```
 
-Inside `f`, `kwargs` will be a named tuple. Named tuples (as well as dictionaries) can be passed as
-keyword arguments using a semicolon in a call, e.g. `f(x, z=1; kwargs...)`.
+Inside `f`, `kwargs` will be a collection of `(key,value)` tuples, where each `key` is a symbol.
+Such collections can be passed as keyword arguments using a semicolon in a call, e.g. `f(x, z=1; kwargs...)`.
+Dictionaries can also be used for this purpose.
 
-One can also pass `key => value` expressions after a semicolon. For example, `plot(x, y; :width => 2)`
-is equivalent to `plot(x, y, width=2)`. This is useful in situations where the keyword name is computed
-at runtime.
+One can also pass `(key,value)` tuples, or any iterable expression (such as a `=>` pair) that
+can be assigned to such a tuple, explicitly after a semicolon. For example, `plot(x, y; (:width,2))`
+and `plot(x, y; :width => 2)` are equivalent to `plot(x, y, width=2)`. This is useful in situations
+where the keyword name is computed at runtime.
 
 The nature of keyword arguments makes it possible to specify the same argument more than once.
 For example, in the call `plot(x, y; options..., width=2)` it is possible that the `options` structure
@@ -533,8 +485,9 @@ this example, `width` is certain to have the value `2`.
 
 ## Evaluation Scope of Default Values
 
-When optional and keyword argument default expressions are evaluated, only *previous* arguments are in
-scope.
+Optional and keyword arguments differ slightly in how their default values are evaluated. When
+optional argument default expressions are evaluated, only *previous* arguments are in scope. In
+contrast, *all* the arguments are in scope when keyword arguments default expressions are evaluated.
 For example, given this definition:
 
 ```julia
@@ -543,13 +496,17 @@ function f(x, a=b, b=1)
 end
 ```
 
-the `b` in `a=b` refers to a `b` in an outer scope, not the subsequent argument `b`.
+the `b` in `a=b` refers to a `b` in an outer scope, not the subsequent argument `b`. However,
+if `a` and `b` were keyword arguments instead, then both would be created in the same scope and
+the `b` in `a=b` would refer to the subsequent argument `b` (shadowing any `b` in an outer scope),
+which would result in an undefined variable error (since the default expressions are evaluated
+left-to-right, and `b` has not been assigned yet).
 
 ## Do-Block Syntax for Function Arguments
 
 Passing functions as arguments to other functions is a powerful technique, but the syntax for
 it is not always convenient. Such calls are especially awkward to write when the function argument
-requires multiple lines. As an example, consider calling [`map`](@ref) on a function with several
+requires multiple lines. As an example, consider calling [`map()`](@ref) on a function with several
 cases:
 
 ```julia
@@ -580,16 +537,16 @@ end
 ```
 
 The `do x` syntax creates an anonymous function with argument `x` and passes it as the first argument
-to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function, and a
+to [`map()`](@ref). Similarly, `do a,b` would create a two-argument anonymous function, and a
 plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 
-How these arguments are initialized depends on the "outer" function; here, [`map`](@ref) will
+How these arguments are initialized depends on the "outer" function; here, [`map()`](@ref) will
 sequentially set `x` to `A`, `B`, `C`, calling the anonymous function on each, just as would happen
 in the syntax `map(func, [A, B, C])`.
 
 This syntax makes it easier to use functions to effectively extend the language, since calls look
-like normal code blocks. There are many possible uses quite different from [`map`](@ref), such
-as managing system state. For example, there is a version of [`open`](@ref) that runs code ensuring
+like normal code blocks. There are many possible uses quite different from [`map()`](@ref), such
+as managing system state. For example, there is a version of [`open()`](@ref) that runs code ensuring
 that the opened file is eventually closed:
 
 ```julia
@@ -611,8 +568,8 @@ function open(f::Function, args...)
 end
 ```
 
-Here, [`open`](@ref) first opens the file for writing and then passes the resulting output stream
-to the anonymous function you defined in the `do ... end` block. After your function exits, [`open`](@ref)
+Here, [`open()`](@ref) first opens the file for writing and then passes the resulting output stream
+to the anonymous function you defined in the `do ... end` block. After your function exits, [`open()`](@ref)
 will make sure that the stream is properly closed, regardless of whether your function exited
 normally or threw an exception. (The `try/finally` construct will be described in [Control Flow](@ref).)
 
@@ -640,9 +597,9 @@ julia> A = [1.0, 2.0, 3.0]
 
 julia> sin.(A)
 3-element Array{Float64,1}:
- 0.8414709848078965
- 0.9092974268256817
- 0.1411200080598672
+ 0.841471
+ 0.909297
+ 0.14112
 ```
 
 Of course, you can omit the dot if you write a specialized "vector" method of `f`, e.g. via `f(A::AbstractArray) = map(f, A)`,
@@ -665,9 +622,9 @@ julia> B = [4.0, 5.0, 6.0];
 
 julia> f.(pi, A)
 3-element Array{Float64,1}:
- 13.42477796076938
- 17.42477796076938
- 21.42477796076938
+ 13.4248
+ 17.4248
+ 21.4248
 
 julia> f.(A, B)
 3-element Array{Float64,1}:
@@ -688,7 +645,7 @@ loops cannot be merged because of the intervening `sort` function.
 
 Finally, the maximum efficiency is typically achieved when the output array of a vectorized operation
 is *pre-allocated*, so that repeated calls do not allocate new arrays over and over again for
-the results (see [Pre-allocating outputs](@ref)). A convenient syntax for this is `X .= ...`, which
+the results ([Pre-allocating outputs](@ref):). A convenient syntax for this is `X .= ...`, which
 is equivalent to `broadcast!(identity, X, ...)` except that, as above, the `broadcast!` loop is
 fused with any nested "dot" calls. For example, `X .= sin.(Y)` is equivalent to `broadcast!(sin, X, Y)`,
 overwriting `X` with `sin.(Y)` in-place. If the left-hand side is an array-indexing expression,
@@ -707,10 +664,10 @@ julia> X = similar(Y); # pre-allocate output array
 
 julia> @. X = sin(cos(Y)) # equivalent to X .= sin.(cos.(Y))
 4-element Array{Float64,1}:
-  0.5143952585235492
- -0.4042391538522658
- -0.8360218615377305
- -0.6080830096407656
+  0.514395
+ -0.404239
+ -0.836022
+ -0.608083
 ```
 
 Binary (or unary) operators like `.+` are handled with the same mechanism:


### PR DESCRIPTION
I fixed two broken links in manual page **functions.md** and added a example for multiple arguments (lambda) functions. for issue #25543