### PR TITLE
strings/basic map/filter off-by-one error in sizehint

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -512,7 +512,7 @@ isascii(s::AbstractString) = all(isascii, s)
 ## string map, filter, has ##
 
 function map(f, s::AbstractString)
-    out = IOBuffer(StringVector(endof(s)), true, true)
+    out = IOBuffer(StringVector(sizeof(s)), true, true)
     truncate(out, 0)
     for c in s
         c′ = f(c)
@@ -525,7 +525,7 @@ function map(f, s::AbstractString)
 end
 
 function filter(f, s::AbstractString)
-    out = IOBuffer(StringVector(endof(s)), true, true)
+    out = IOBuffer(StringVector(sizeof(s)), true, true)
     truncate(out, 0)
     for c in s
         f(c) && write(out, c)


### PR DESCRIPTION
Output buffer size for map and filter is 1 short, if last character is not ascii.