### PR TITLE
Fix backpropagation of conditionals when the type is later widened

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -307,7 +307,7 @@ function typeinf_work(frame::InferenceState)
                 hd = stmt.head
                 if hd === :gotoifnot
                     condt = abstract_eval(stmt.args[1], s[pc], frame)
-                    condval = isa(condt, Const) ? condt.val : nothing
+                    condval = maybe_extract_const_bool(condt)
                     l = stmt.args[2]::Int
                     changes = changes::VarTable
                     # constant conditions

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -111,6 +111,14 @@ function issubconditional(a::Conditional, b::Conditional)
     return false
 end
 
+maybe_extract_const_bool(c::Const) = isa(c.val, Bool) ? c.val : nothing
+function maybe_extract_const_bool(c::Conditional)
+    (c.vtype === Bottom && !(c.elsetype === Bottom)) && return false
+    (c.elsetype === Bottom && !(c.vtype === Bottom)) && return true
+    nothing
+end
+maybe_extract_const_bool(c) = nothing
+
 function ⊑(@nospecialize(a), @nospecialize(b))
     (a === NOT_FOUND || b === Any) && return true
     (a === Any || b === NOT_FOUND) && return false
@@ -119,6 +127,8 @@ function ⊑(@nospecialize(a), @nospecialize(b))
     if isa(a, Conditional)
         if isa(b, Conditional)
             return issubconditional(a, b)
+        elseif isa(b, Const) && isa(b.val, Bool)
+            return maybe_extract_const_bool(a) === b.val
         end
         a = Bool
     elseif isa(b, Conditional)


### PR DESCRIPTION
Consider the following example:
```
f() = (1, 1)
f(s) = i == 1 ? (1, 2) : nothing
function foo()
    next = f()
    while next !== nothing
        next = f(Core.getfield(next, 2))
    end
end
```

This was causing unnecessary allocations, because inference failed
to inform codegen that the reference to `next` inside the loop was
guaranteed not to be `Nothing`. Ironically if `f()` could also have
returned nothing, inference was able to figure this out, thanks to
pass the result of the comparison was inferred as `Const(true)`,
and on the second pass as `Conditional(next, Tuple{Int, Int},
Const(nothing))`, the tmerge of which is `Bool`. Fix that by
implementing Jameson's suggestion in #25261, and instead infering
the first pass as `Conditional(next, Tuple{Int, Int}, Union{})`.
To make this work we also adjust the lattice relation to have
`Conditional(next, T, Union{}) ⊑ Const(true)`. The result is that
the result of the comparison does not get widened to `Bool` as
quickly, retaining the type information on `next` and allowing
codegen to emit efficient code.