### PR TITLE
make overlong Chars `!isvalid`; throw error on `UInt32` of overlong Char

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -1,12 +1,12 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-struct MalformedCharError <: Exception
+struct InvalidCharError <: Exception
     char::Char
 end
 struct CodePointError <: Exception
     code::Integer
 end
-@noinline malformed_char(c::Char) = throw(MalformedCharError(c))
+@noinline invalid_char(c::Char) = throw(InvalidCharError(c))
 @noinline code_point_err(u::UInt32) = throw(CodePointError(u))
 
 function ismalformed(c::Char)
@@ -17,20 +17,32 @@ function ismalformed(c::Char)
     (((u & 0x00c0c0c0) ⊻ 0x00808080) >> t0 != 0)
 end
 
+@inline is_overlong_enc(u::UInt32) = (u >> 24 == 0xc0) | (u >> 24 == 0xc1) | (u >> 21 == 0x0704) | (u >> 20 == 0x0f08)
+
 function isoverlong(c::Char)
     u = reinterpret(UInt32, c)
-    (u >> 24 == 0xc0) | (u >> 21 == 0x0704) | (u >> 20 == 0x0f08)
+    is_overlong_enc(u)
 end
 
 function UInt32(c::Char)
     # TODO: use optimized inline LLVM
     u = reinterpret(UInt32, c)
-    u < 0x80000000 && return reinterpret(UInt32, u >> 24)
+    u < 0x80000000 && return u >> 24
     l1 = leading_ones(u)
     t0 = trailing_zeros(u) & 56
     (l1 == 1) | (8l1 + t0 > 32) |
-    (((u & 0x00c0c0c0) ⊻ 0x00808080) >> t0 != 0) &&
-        malformed_char(c)::Union{}
+    ((((u & 0x00c0c0c0) ⊻ 0x00808080) >> t0 != 0) | is_overlong_enc(u)) &&
+        invalid_char(c)::Union{}
+    u &= 0xffffffff >> l1
+    u >>= t0
+    (u & 0x0000007f >> 0) | (u & 0x00007f00 >> 2) |
+    (u & 0x007f0000 >> 4) | (u & 0x7f000000 >> 6)
+end
+
+function decode_overlong(c::Char)
+    u = reinterpret(UInt32, c)
+    l1 = leading_ones(u)
+    t0 = trailing_zeros(u) & 56
     u &= 0xffffffff >> l1
     u >>= t0
     (u & 0x0000007f >> 0) | (u & 0x00007f00 >> 2) |
@@ -145,8 +157,13 @@ function show(io::IO, ::MIME"text/plain", c::Char)
     show(io, c)
     if !ismalformed(c)
         print(io, ": ")
-        isoverlong(c) && print(io, "[overlong] ")
-        u = UInt32(c)
+        if isoverlong(c)
+            print(io, "[overlong] ")
+            u = decode_overlong(c)
+            c = Char(u)
+        else
+            u = UInt32(c)
+        end
         h = hex(u, u ≤ 0xffff ? 4 : 6)
         print(io, (isascii(c) ? "ASCII/" : ""), "Unicode U+", h)
     else

--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -4,7 +4,7 @@
 module Unicode
 
 import Base: show, ==, hash, string, Symbol, isless, length, eltype, start,
-             next, done, convert, isvalid, MalformedCharError, ismalformed
+             next, done, convert, isvalid, ismalformed, isoverlong
 
 # whether codepoints are valid Unicode scalar values, i.e. 0-0xd7ff, 0xe000-0x10ffff
 
@@ -43,7 +43,7 @@ true
 """
 isvalid(T,value)
 
-isvalid(c::Char) = !ismalformed(c) & ((c ≤ '\ud7ff') | ('\ue000' ≤ c) & (c ≤ '\U10ffff'))
+isvalid(c::Char) = !ismalformed(c) & !isoverlong(c) & ((c ≤ '\ud7ff') | ('\ue000' ≤ c) & (c ≤ '\U10ffff'))
 isvalid(::Type{Char}, c::Unsigned) = ((c ≤  0xd7ff ) | ( 0xe000  ≤ c) & (c ≤  0x10ffff ))
 isvalid(::Type{Char}, c::Integer)  = isvalid(Char, Unsigned(c))
 isvalid(::Type{Char}, c::Char)     = isvalid(c)

--- a/test/char.jl
+++ b/test/char.jl
@@ -221,7 +221,11 @@ end
 end
 
 function test_overlong(c::Char, n::Integer, rep::String)
-    @test Int(c) == n
+    if isvalid(c)
+        @test Int(c) == n
+    else
+        @test_throws Base.InvalidCharError UInt32(c)
+    end
     @test sprint(show, c) == rep
 end
 

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -362,6 +362,7 @@ end
             ("\udc00\ud800", false),
         )
         @test isvalid(String, val) == pass == isvalid(String(val))
+        @test isvalid(val[1]) == pass
     end
 
     # Issue #11203
@@ -435,6 +436,17 @@ end
     end
     # Check seven-byte sequences, should be invalid
     @test isvalid(String, UInt8[0xfe, 0x80, 0x80, 0x80, 0x80, 0x80]) == false
+
+    # invalid Chars
+    @test  isvalid('a')
+    @test  isvalid('柒')
+    @test !isvalid("\xff"[1])
+    @test !isvalid("\xc0\x80"[1])
+    @test !isvalid("\xf0\x80\x80\x80"[1])
+    @test !isvalid('\ud800')
+    @test  isvalid('\ud7ff')
+    @test !isvalid('\udfff')
+    @test  isvalid('\ue000')
 end
 
 @testset "NULL pointers are handled consistently by String" begin


### PR DESCRIPTION
This takes care of most of #25452.

- Handle an extra case of overlong encoding.
- Make `isvalid(::Char)` return false on overlongs.
- Make `UInt32(::Char)` throw an error on overlongs.
