### PR TITLE
Add support for _italics_ using underscores to the Markdown parser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -182,6 +182,9 @@ Language changes
   * `=>` now has its own precedence level, giving it strictly higher precedence than
     `=` and `,` ([#25391]).
 
+  * Underscores for `_italics_` and `__bold__` are now supported by the Base Markdown
+    parser. ([#25564])
+
 Breaking changes
 ----------------
 

--- a/base/markdown/Common/Common.jl
+++ b/base/markdown/Common/Common.jl
@@ -7,5 +7,5 @@ include("inline.jl")
                 paragraph,
 
                 linebreak, escapes, inline_code,
-                asterisk_bold, asterisk_italic, image, footnote_link, link, autolink]
+                asterisk_bold, underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]
 

--- a/base/markdown/Common/inline.jl
+++ b/base/markdown/Common/inline.jl
@@ -14,6 +14,12 @@ function asterisk_italic(stream::IO, md::MD)
     return result === nothing ? nothing : Italic(parseinline(result, md))
 end
 
+@trigger '_' ->
+function underscore_italic(stream::IO, md::MD)
+    result = parse_inline_wrapper(stream, "_")
+    return result === nothing ? nothing : Italic(parseinline(result, md))
+end
+
 mutable struct Bold
     text
 end
@@ -21,6 +27,12 @@ end
 @trigger '*' ->
 function asterisk_bold(stream::IO, md::MD)
     result = parse_inline_wrapper(stream, "**")
+    return result === nothing ? nothing : Bold(parseinline(result, md))
+end
+
+@trigger '_' ->
+function underscore_bold(stream::IO, md::MD)
+    result = parse_inline_wrapper(stream, "__")
     return result === nothing ? nothing : Bold(parseinline(result, md))
 end
 

--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -62,5 +62,5 @@ end
                 github_table, github_paragraph,
 
                 linebreak, escapes, en_dash, inline_code, asterisk_bold,
-                asterisk_italic, image, footnote_link, link, autolink]
+                underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]
 

--- a/base/markdown/Julia/Julia.jl
+++ b/base/markdown/Julia/Julia.jl
@@ -11,5 +11,5 @@ include("interp.jl")
                blockquote, admonition, footnote, github_table, horizontalrule, setextheader, paragraph,
 
                linebreak, escapes, tex, interp, en_dash, inline_code,
-               asterisk_bold, asterisk_italic, image, footnote_link, link, autolink]
+               asterisk_bold, underscore_bold, asterisk_italic, underscore_italic, image, footnote_link, link, autolink]
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -10,6 +10,9 @@ import Base: show
 
 @test md"foo" == MD(Paragraph("foo"))
 @test md"foo *bar* baz" == MD(Paragraph(["foo ", Italic("bar"), " baz"]))
+@test md"foo _bar_ baz" == MD(Paragraph(["foo ", Italic("bar"), " baz"]))
+@test md"foo **bar** baz" == MD(Paragraph(["foo ", Bold("bar"), " baz"]))
+@test md"foo __bar__ baz" == MD(Paragraph(["foo ", Bold("bar"), " baz"]))
 @test md"""foo
 bar""" == MD(Paragraph(["foo bar"]))
 @test md"""foo\


### PR DESCRIPTION
Julia's base Markdown parser currently parses `*italics*` but not `_italics_`.

This pull request adds support for italics via underscores, as used on GitHub, Discourse, and Slack as specified in the [original](https://daringfireball.net/projects/markdown/syntax) Markdown spec. Asterisks also continue to work.

Thanks to @c42f for help with this PR!