### PR TITLE
Attach backtraces explicitly in error logging

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -175,11 +175,8 @@ There's also some key value pairs which have conventional meaning:
   * `maxlog=integer` should be used as a hint to the backend that the message
     should be displayed no more than `maxlog` times.
   * `exception=ex` should be used to transport an exception with a log message,
-    often used with `@error`. `AbstractLoggers` should assume that the
-    associated backtrace can be obtained from `catch_backtrace()`. If the log
-    message is emitted outside the catch block which generated `ex`, an
-    associated backtrace `bt` may be attached explicitly using
-    `exception=(ex,bt)`.
+    often used with `@error`. An associated backtrace `bt` may be attached
+    using the tuple `exception=(ex,bt)`.
 
 # Examples
 

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -602,7 +602,7 @@ function build(pkg::AbstractString, build_file::AbstractString, errfile::Abstrac
                 @error \"""
                     ------------------------------------------------------------
                     # Build failed for \$pkg
-                    \""" exception=err
+                    \""" exception=err,catch_backtrace()
                 serialize(f, pkg)
                 serialize(f, err)
             end
@@ -679,7 +679,7 @@ function updatehook!(pkgs::Vector, errs::Dict, seen::Set=Set())
                 @error """
                     ------------------------------------------------------------
                     # Update hook failed for $pkg
-                    """ exception=err
+                    """ exception=err,catch_backtrace()
                 errs[pkg] = err
             end
         end
@@ -739,7 +739,7 @@ function test!(pkg::AbstractString,
                 @error """
                     ------------------------------------------------------------
                     # Testing failed for $pkg
-                    """ exception=err
+                    """ exception=err,catch_backtrace()
                 push!(errs,pkg)
             end
         end

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -2317,7 +2317,7 @@ function prompt!(term::TextTerminal, prompt::ModalInterface, s::MIState = init_s
             try
                 status = fcn(s, kdata)
             catch e
-                @error "Error in the keymap" exception=e
+                @error "Error in the keymap" exception=e,catch_backtrace()
                 # try to cleanup and get `s` back to its original state before returning
                 transition(s, :reset)
                 transition(s, old_state)

--- a/base/replutil.jl
+++ b/base/replutil.jl
@@ -415,7 +415,7 @@ function showerror(io::IO, ex::MethodError)
     try
         show_method_candidates(io, ex, kwargs)
     catch ex
-        @error "Error showing method candidates, aborted" exception=ex
+        @error "Error showing method candidates, aborted" exception=ex,catch_backtrace()
     end
 end
 

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1074,7 +1074,7 @@ function terminate_all_workers()
             try
                 rmprocs(workers(); waitfor=5.0)
             catch _ex2
-                @error "Unable to terminate all workers" exception=_ex2
+                @error "Unable to terminate all workers" exception=_ex2,catch_backtrace()
             end
         end
     end

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -89,7 +89,7 @@ function deliver_result(sock::IO, msg, oid, value)
     catch e
         # terminate connection in case of serialization error
         # otherwise the reading end would hang
-        @error "Fatal error on process $(myid())" exception=e
+        @error "Fatal error on process $(myid())" exception=e,catch_backtrace()
         wid = worker_id_from_socket(sock)
         close(sock)
         if myid()==1
@@ -210,7 +210,7 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
             # If unhandleable error occurred talking to pid 1, exit
             if wpid == 1
                 if isopen(w_stream)
-                    @error "Fatal error on process $(myid())" exception=e
+                    @error "Fatal error on process $(myid())" exception=e,catch_backtrace()
                 end
                 exit(1)
             end
@@ -341,7 +341,7 @@ function connect_to_peer(manager::ClusterManager, rpid::Int, wconfig::WorkerConf
         send_connection_hdr(w, true)
         send_msg_now(w, MsgHeader(), IdentifySocketMsg(myid()))
     catch e
-        @error "Error on $(myid()) while connecting to peer $rpid, exiting" exception=e
+        @error "Error on $(myid()) while connecting to peer $rpid, exiting" exception=e,catch_backtrace()
         exit(1)
     end
 end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -48,7 +48,7 @@ function showvalue(io, e::Tuple{Exception,Any})
     ex,bt = e
     showerror(io, ex, bt; backtrace = bt!=nothing)
 end
-showvalue(io, ex::Exception) = showvalue(io, (ex,catch_backtrace()))
+showvalue(io, ex::Exception) = showerror(io, ex)
 
 function default_logcolor(level)
     level < Info  ? Base.debug_color() :

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -165,7 +165,7 @@ function __init__()
         end
 
     catch ex
-        @error "Error during initialization of module CHOLMOD" exception=ex
+        @error "Error during initialization of module CHOLMOD" exception=ex,catch_backtrace()
     end
 end
 


### PR DESCRIPTION
To avoid ambiguity and confusion, do not assume that `catch_backtrace()`
is the backtrace associated with a logged exception. Instead, always
attach the backtrace explicitly.

I think this is the best way to address @JeffBezanson's comment at https://github.com/JuliaLang/julia/pull/25370#discussion_r160065706. I believe #19979 can be fixed, but that won't address the potential for ambiguity in not attaching the backtrace explicitly. I'm not thrilled about the extra boilerplate, but it might be best for now.