### PR TITLE
RFC: introduce check macro that can be disabled with a flag

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -1168,6 +1168,7 @@ export
     @polly,
 
     @assert,
+    @check,
     @__dot__,
     @enum,
     @label,

--- a/base/options.jl
+++ b/base/options.jl
@@ -21,6 +21,7 @@ struct JLOptions
     opt_level::Int8
     debug_level::Int8
     check_bounds::Int8
+    julia_debug::Int8
     depwarn::Int8
     warn_overwrite::Int8
     can_inline::Int8

--- a/base/pkg/pkg.jl
+++ b/base/pkg/pkg.jl
@@ -86,7 +86,7 @@ init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRANCH) = Di
 
 function __init__()
     vers = "v$(VERSION.major).$(VERSION.minor)"
-    pushfirst!(Base.LOAD_CACHE_PATH, abspath(Dir._pkgroot(), "lib", vers))
+    pushfirst!(Base.LOAD_CACHE_PATH, abspath(Dir._pkgroot(), "lib", Base.JLOptions().julia_debug == 1 ? "debug" : ""), vers)
 end
 
 """

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -501,6 +501,14 @@ function __init__()
     init_threadcall()
 end
 
+macro check(x)
+    if JLOptions().julia_debug == 1
+        return :($(esc(x)))
+    else
+        return nothing
+    end
+end
+
 INCLUDE_STATE = 3 # include = include_relative
 
 end # baremodule Base

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -152,6 +152,10 @@ Control whether inlining is permitted (overrides functions declared as @inline)
 Emit bounds checks always or never (ignoring declarations)
 
 .TP
+--debug={yes|no}
+Enable the @check macro and always emit bounds checks
+
+.TP
 --math-mode={ieee|user}
 Always use IEEE semantics for math (ignoring declarations),
 or adhere to declarations in source code

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -50,6 +50,11 @@ jl_options_t jl_options = { 0,    // quiet
                             1,    // debug_level [release build]
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
+#ifdef JL_DEBUG_BUILD
+                            1, // julia debug mode [debug build]
+#else
+                            0, // julia debug mode [release build]
+#endif
                             JL_OPTIONS_DEPWARN_ON,    // deprecation warning
                             0,    // method overwrite warning
                             1,    // can_inline
@@ -118,6 +123,7 @@ static const char opts[]  =
 #endif
     " --inline={yes|no}         Control whether inlining is permitted, including overriding @inline declarations\n"
     " --check-bounds={yes|no}   Emit bounds checks always or never (ignoring declarations)\n"
+    " --debug={yes|no}          Enable the @check macro and always emit bounds checks\n"
 #ifdef USE_POLLY
     " --polly={yes|no}          Enable or disable the polyhedral optimizer Polly (overrides @polly declaration)\n"
 #endif
@@ -151,6 +157,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_code_coverage,
            opt_track_allocation,
            opt_check_bounds,
+           opt_julia_debug,
            opt_output_jit_bc,
            opt_output_unopt_bc,
            opt_output_bc,
@@ -200,6 +207,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "track-allocation",optional_argument, 0, opt_track_allocation },
         { "optimize",        optional_argument, 0, 'O' },
         { "check-bounds",    required_argument, 0, opt_check_bounds },
+        { "debug",           required_argument, 0, opt_julia_debug },
         { "output-bc",       required_argument, 0, opt_output_bc },
         { "output-unopt-bc", required_argument, 0, opt_output_unopt_bc },
         { "output-jit-bc",   required_argument, 0, opt_output_jit_bc },
@@ -488,6 +496,16 @@ restart_switch:
                 jl_options.check_bounds = JL_OPTIONS_CHECK_BOUNDS_OFF;
             else
                 jl_errorf("julia: invalid argument to --check-bounds={yes|no} (%s)", optarg);
+            break;
+        case opt_julia_debug:
+            if (!strcmp(optarg,"yes")) {
+                jl_options.check_bounds = 1;
+                jl_options.check_bounds = JL_OPTIONS_CHECK_BOUNDS_ON;
+            }
+            else if (!strcmp(optarg,"no"))
+                jl_options.check_bounds = 0;
+            else
+                jl_errorf("julia: invalid argument to --debug={yes|no} (%s)", optarg);
             break;
         case opt_output_bc:
             jl_options.outputbc = optarg;

--- a/src/julia.h
+++ b/src/julia.h
@@ -1716,6 +1716,7 @@ typedef struct {
     int8_t malloc_log;
     int8_t opt_level;
     int8_t debug_level;
+    int8_t julia_debug;
     int8_t check_bounds;
     int8_t depwarn;
     int8_t warn_overwrite;


### PR DESCRIPTION
TLDR: for triage: Add docs to `@assert` that the block might not be executed, so don't e.g. use it for needed side effects?

It is common for packages to roll their own way of enabling a debug mode. This is typically done using a global const `DEBUG = true / false` which one has to edit in the source file to set. Another option is to use an ENV variable and start julia with package precompilation disabled. These are non ideal because manually editing files is awkward and doesn't really scale when you want to run multiple packages in debug mode and then swap back to release mode, and disabling package precompilation increases load time every time you want to debug.

In https://github.com/JuliaLang/julia/issues/10614 a suggestion was made for a `@check` macro completely disables a code block when not running in debug mode / alt. only enables it when running in "optimize" mode. This PR introduces a `--debug` flag that enables the `@check` macro (i.e. code in a `@check block is then not removed). Furthermore, running with `--debug` changes the precompilation path (adds a `debug` directory) so that it works with packages that enables precompilation.

The macro is currently not usable in base because any result of it will be cached into the sysimg. For it to work in Base, we probably need a second debug sysimg that is chosen based on the `--debug` flag.

Note that `@check` is not really intended for debug logging (the logging macros already work for that) but for situations where verifying certain properties might be too expensive to do normally. Such an example might be to check that the input to `searchsorted` actually is sorted.

This PR is mostly to spur some discussion if this is something we want, if this type of implementation makes sense, etc. It is not aimed at 1.0 but one thing we need to decide for 1.0 is if to instead repurpose the current `@assert` macro to be what `@check` is in this PR. There is currently no way to remove `@assert` but if we want to use `@assert` for this in 1.1 we need to document that `@assert`s can be removed. Therefore, putting the triage label on it. 
