### PR TITLE
Use yellow for unions with missing or nothing

### DIFF
--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -367,6 +367,8 @@ and type signature to `io` which defaults to `STDOUT`. The ASTs are annotated in
 as to cause "non-leaf" types to be emphasized (if color is available, displayed in red).
 This serves as a warning of potential type instability. Not all non-leaf types are particularly
 problematic for performance, so the results need to be used judiciously.
+In particular, unions containing either [`missing`](@ref) or [`nothing`](@ref) are displayed in yellow, since
+these are often intentional.
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
 function code_warntype(io::IO, f, @nospecialize(t))

--- a/base/show.jl
+++ b/base/show.jl
@@ -736,7 +736,7 @@ function show_expr_type(io::IO, @nospecialize(ty), emph::Bool)
     elseif ty === Core.IntrinsicFunction
         print(io, "::I")
     else
-        if emph && (!_isleaftype(ty) || ty == Core.Box) && !(ty == Union{})
+        if emph && (!_isleaftype(ty) || ty == Core.Box)
             if ty isa Union && is_expected_union(ty)
                 emphasize(io, "::$ty", Base.warn_color())
             else

--- a/base/show.jl
+++ b/base/show.jl
@@ -736,16 +736,22 @@ function show_expr_type(io::IO, @nospecialize(ty), emph::Bool)
     elseif ty === Core.IntrinsicFunction
         print(io, "::I")
     else
-        if emph && (!_isleaftype(ty) || ty == Core.Box)
-            emphasize(io, "::$ty")
+        if emph && (!_isleaftype(ty) || ty == Core.Box) && !(ty == Union{})
+            if ty isa Union && is_expected_union(ty)
+                emphasize(io, "::$ty", Base.warn_color())
+            else
+                emphasize(io, "::$ty")
+            end
         else
             print(io, "::$ty")
         end
     end
 end
 
-emphasize(io, str::AbstractString) = get(io, :color, false) ?
-    print_with_color(Base.error_color(), io, str; bold = true) :
+is_expected_union(u::Union) = u.a == Nothing || u.b == Nothing || u.a == Missing || u.b == Missing
+
+emphasize(io, str::AbstractString, col = Base.error_color()) = get(io, :color, false) ?
+    print_with_color(col, io, str; bold = true) :
     print(io, uppercase(str))
 
 show_linenumber(io::IO, line)       = print(io, "#= line ", line, " =#")

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1482,6 +1482,11 @@ effects of type instability.  This is particularly relevant in cases where fixin
 is difficult or impossible: for example, currently it's not possible to infer the return type
 of an anonymous function.  In such cases, the tips above (e.g., adding type annotations and/or
 breaking up functions) are your best tools to contain the "damage" from type instability.
+Also, note that even Julia Base has functions that are type unstable.
+For example, the function [`findfirst`](@ref) returns the index into an array where a key is found,
+or `nothing` if it is not found, a clear type instability. In order to make it easier to find the
+type instabilities that are likely to be important, `Union`s containing either `missing` or `nothing`
+are color highlighted in yellow, instead of red.
 
 The following examples may help you interpret expressions marked as containing non-leaf types:
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -97,7 +97,16 @@ has_unused() = (a = rand(5))
 @test !warntype_hastag(has_unused, Tuple{}, tag)
 @test warntype_hastag(has_unused, Tuple{}, "<optimized out>")
 
-# Make sure getproperty and setproperty! works with warntype
+# Make sure Union{} is not highlighted
+@test !warntype_hastag(error, Tuple{}, "UNION")
+
+# Make sure that "expected" unions are highlighted with warning color instead of error color
+iob = IOBuffer()
+code_warntype(IOContext(iob, :color => true), x -> (x > 1 ? "foo" : nothing), Tuple{Int64})
+str = String(take!(iob))
+@test contains(str, Base.text_colors[Base.warn_color()])
+
+# Make sure getproperty and setproperty! works with @code_... macros
 struct T1234321
     t::Int
 end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -97,9 +97,6 @@ has_unused() = (a = rand(5))
 @test !warntype_hastag(has_unused, Tuple{}, tag)
 @test warntype_hastag(has_unused, Tuple{}, "<optimized out>")
 
-# Make sure Union{} is not highlighted
-@test !warntype_hastag(error, Tuple{}, "UNION")
-
 # Make sure that "expected" unions are highlighted with warning color instead of error color
 iob = IOBuffer()
 code_warntype(IOContext(iob, :color => true), x -> (x > 1 ? "foo" : nothing), Tuple{Int64})


### PR DESCRIPTION
Since we are starting to use some "type instabilities" in Base and popular packages, it is a bit harsh to warn about these using bright red colors. Therefore, instead, use a milder yellow for Unions with `missing` or `nothing` since these unions are often intentional.

~~Also, remove highlighting of `Union{}` since these are not a problem.~~

Example screenshot:

![screen shot 2018-01-16 at 12 13 50](https://user-images.githubusercontent.com/1282691/34986141-be3eaa5e-fab6-11e7-93e1-c13ea8065e4b.png)
