### PR TITLE
fix #19030, incorrectly copying mutable objects via IR in precompile

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -345,7 +345,9 @@ function optimize(me::InferenceState)
             # to the `jl_call_method_internal` fast path
             # Still set pure flag to make sure `inference` tests pass
             # and to possibly enable more optimization in the future
-            me.const_api = true
+            if !(isa(me.bestguess, Const) && !is_inlineable_constant(me.bestguess.val))
+                me.const_api = true
+            end
             force_noinline || (me.src.inlineable = true)
         end
     end
@@ -1092,7 +1094,7 @@ function inlineable(@nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector
                 istopfunction(topmod, f, :isbits) ||
                 istopfunction(topmod, f, :promote_type) ||
                 (f === Core.kwfunc && length(argexprs) == 2) ||
-                (isbits(val) && Core.sizeof(val) <= MAX_INLINE_CONST_SIZE &&
+                (is_inlineable_constant(val) &&
                  (contains_is(_PURE_BUILTINS, f) ||
                   (f === getfield && effect_free(e, sv.src, sv.mod, false)) ||
                   (isa(f, IntrinsicFunction) && is_pure_intrinsic_optim(f)))))
@@ -1222,7 +1224,7 @@ function inlineable(@nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector
             elseif isa(e.typ, Const)
                 return inline_as_constant(e.typ.val, argexprs, sv, invoke_data)
             end
-        elseif method.pure && isa(e.typ, Const) && e.typ.actual
+        elseif method.pure && isa(e.typ, Const) && e.typ.actual && is_inlineable_constant(e.typ.val)
             return inline_as_constant(e.typ.val, argexprs, sv, invoke_data)
         end
     end
@@ -1291,7 +1293,7 @@ function inlineable(@nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector
             elseif isconstType(result)
                 inferred_const = result.parameters[1]
             end
-            if @isdefined inferred_const
+            if @isdefined(inferred_const) && is_inlineable_constant(inferred_const)
                 add_backedge!(linfo, sv)
                 return inline_as_constant(inferred_const, argexprs, sv, invoke_data)
             end
@@ -2203,7 +2205,7 @@ function fold_constant_getfield_pass!(sv::OptimizationState)
         obj = exprtype(ex.args[2], sv.src, sv.mod)
         isa(obj, Const) || continue
         obj = obj.val
-        !typeof(obj).mutable || isa(obj, DataType) || continue
+        is_inlineable_constant(obj) || continue
         fld = ex.args[3]
         if isa(fld, Int)
             fld = fld
@@ -2690,7 +2692,7 @@ function propagate_const_def!(ctx::AllocOptContext, info, key)
         # We don't want to probagate this constant since this is a token.
         isa(defex, Expr) && defex.head === :gc_preserve_begin && return false
         v = exprtype(defex, ctx.sv.src, ctx.sv.mod)
-        isa(v, Const) || return false
+        (isa(v, Const) && is_inlineable_constant(v.val)) || return false
         v = v.val
         @isdefined(constv) && constv !== v && return false
         constv = v
@@ -2831,7 +2833,7 @@ function split_disjoint_assign!(ctx::AllocOptContext, info, key)
             end
         end
         ty = exprtype(usex, ctx.sv.src, ctx.sv.mod)
-        if isa(ty, Const)
+        if isa(ty, Const) && is_inlineable_constant(ty.val)
             replace_use_expr_with!(ctx, use, quoted(ty.val))
         elseif isa(ty, Conditional)
             exprs = []
@@ -3527,7 +3529,7 @@ function split_struct_alloc_single!(ctx::AllocOptContext, info, key, nf, has_pre
             # OK so no setfield
             # First check if the field was a constant
             cv = exprtype(orig_def, ctx.sv.src, ctx.sv.mod)
-            if isa(cv, Const)
+            if isa(cv, Const) && is_inlineable_constant(cv.val)
                 vars[i] = quoted(cv.val)
                 # Constants don't need to be preserved
                 continue

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -56,6 +56,11 @@ function quoted(@nospecialize(x))
     return is_self_quoting(x) ? x : QuoteNode(x)
 end
 
+function is_inlineable_constant(@nospecialize(x))
+    x isa Type && return true
+    return isbits(x) && Core.sizeof(x) <= MAX_INLINE_CONST_SIZE
+end
+
 # count occurrences up to n+1
 function occurs_more(@nospecialize(e), pred, n)
     if isa(e,Expr)


### PR DESCRIPTION
This consolidates checking for which constant values should be inlined into a single `is_inlineable_constant` function.