### PR TITLE
distinguish `{x y}` and `{x y;}` in parser, as with `[ ]`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -604,7 +604,7 @@ const expr_calls  = Dict(:call => ('(',')'), :calldecl => ('(',')'),
                          :ref => ('[',']'), :curly => ('{','}'), :(.) => ('(',')'))
 const expr_parens = Dict(:tuple=>('(',')'), :vcat=>('[',']'),
                          :hcat =>('[',']'), :row =>('[',']'), :vect=>('[',']'),
-                         :braces=>('{','}'), :bracescat=>('{','}'))
+                         :braces=>('{','}'), :bracescat=>('{','}'), :braceshcat=>('{','}'))
 
 ## AST decoding helpers ##
 
@@ -1006,7 +1006,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         op, cl = expr_parens[head]
         if head === :vcat || head === :bracescat
             sep = "; "
-        elseif head === :hcat || head === :row
+        elseif head === :hcat || head === :row || head === :braceshcat
             sep = " "
         else
             sep = ", "
@@ -1016,7 +1016,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         if nargs == 1
             if head === :tuple
                 print(io, ',')
-            elseif head === :vcat
+            elseif head === :vcat || head === :bracescat
                 print(io, ';')
             end
         end

--- a/src/ast.scm
+++ b/src/ast.scm
@@ -85,6 +85,7 @@
                 ((row)        (deparse-arglist (cdr e) " "))
                 ((braces)     (string #\{ (deparse-arglist (cdr e) ", ") #\}))
                 ((bracescat)  (string #\{ (deparse-arglist (cdr e) "; ") #\}))
+                ((braceshcat) (string #\{ (deparse-arglist (cdr e) " ") #\}))
                 ((const)  (string "const " (deparse (cadr e))))
                 ((global local)
                  (string (car e) " " (string.join (map deparse (cdr e)) ", ")))

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2284,7 +2284,7 @@
                      '(braces)
                      (case (car vex)
                        ((vect) `(braces ,@(cdr vex)))
-                       ((hcat) `(bracescat (row ,@(cdr vex))))
+                       ((hcat) `(braceshcat ,@(cdr vex)))
                        ((comprehension) `(braces ,@(cdr vex)))
                        (else   `(bracescat ,@(cdr vex))))))))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -444,7 +444,7 @@ end
 @test Meta.parse("A=>B") == Expr(:call, :(=>), :A, :B)
 
 @test Meta.parse("{1,2,3}") == Expr(:braces, 1, 2, 3)
-@test Meta.parse("{1 2 3 4}") == Expr(:bracescat, Expr(:row, 1, 2, 3, 4))
+@test Meta.parse("{1 2 3 4}") == Expr(:braceshcat, 1, 2, 3, 4)
 @test Meta.parse("{1 2; 3 4}") == Expr(:bracescat, Expr(:row, 1, 2), Expr(:row, 3, 4))
 @test Meta.parse("{x for x in 1:10}") == Expr(:braces, :(x for x in 1:10))
 @test Meta.parse("{x=>y for (x,y) in zip([1,2,3],[4,5,6])}") == Expr(:braces, :(x=>y for (x,y) in zip([1,2,3],[4,5,6])))


### PR DESCRIPTION
This is syntax that's parsed but unused. Reading the tea leaves on JuliaLang/LinearAlgebra.jl#450 it seems we'll want to keep the distinction between `[x y]` and `[x y;]`, so the same should be available for `{ }` (to the extent we can parse it).

Parses `{x y}` as `(braceshcat x y)`, to match `[x y]` and `hcat`. Parses `{x y;}` as `(bracescat (row x y))` to match `[x y;]` and `vcat`.

Alternatively, we could make concatenation with `{ }` a parse error until there's an actual use for it.
