### PR TITLE
Bump Documenter and DocStringExtensions

### DIFF
--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
-Compat 0.39.0 0.39.0+
-DocStringExtensions 0.4.1 0.4.1+
-Documenter 0.12.4 0.12.4+
+Compat 0.46.0 0.46.0+
+DocStringExtensions 0.4.2 0.4.2+
+Documenter 0.13.0 0.13.0+


### PR DESCRIPTION
To fix the deprecation warnings and timeouts due to the documentation build. Cheers to @fredrikekre and @KristofferC for the fixes!

Requires JuliaLang/METADATA.jl#12933