### PR TITLE
make fallback hash a constant instead of based on object id

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -14,6 +14,8 @@ Base.cconvert(::Type{T}, x::Enum{T2}) where {T<:Integer,T2<:Integer} = T(x)
 Base.write(io::IO, x::Enum{T}) where {T<:Integer} = write(io, T(x))
 Base.read(io::IO, ::Type{T}) where {T<:Enum} = T(read(io, Enums.basetype(T)))
 
+Base.hash(x::Enum, h::UInt) = Base.hash_by_id(x, h)
+
 # generate code to test whether expr is in the given set of values
 function membershiptest(expr, values)
     lo, hi = extrema(values)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -64,6 +64,9 @@ Collections should generally implement `==` by calling `==` recursively on all c
 
 New numeric types should implement this function for two arguments of the new type, and
 handle comparison to other types via promotion rules where possible.
+
+If a type that implements `==` will be used in sets or as dictionary keys, it should also
+implement [`hash`](@ref).
 """
 ==(x, y) = x === y
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1509,3 +1509,16 @@ The following examples may help you interpret expressions marked as containing n
         field `data::Array{T}`. But `Array` needs the dimension `N`, too, to be a concrete type.
       * Suggestion: use concrete types like `Array{T,3}` or `Array{T,N}`, where `N` is now a parameter
         of `ArrayContainer`
+
+## Define `hash` for custom types used as dictionary keys
+
+The default `hash` function returns a constant `0` value, causing `Dict`s and `Set`s to perform
+linear-time (instead of near-constant-time) lookup. This allows these collections to work
+correctly by default for arbitrary new definitions of `==`, but can cause performance problems.
+If you encounter this problem, simply add an appropriate method for `Base.hash(x::MyType, h::UInt)`.
+If the built-in equality function `===` already has the desired behavior for your type, this
+definition can be used:
+
+```julia
+Base.hash(x::MyType, h::UInt) = Base.hash_by_id(x, h)
+```

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -332,6 +332,23 @@ Base.show(io::IO, ::Alpha) = print(io,"α")
     @test endswith(str, "α => 1")
 end
 
+mutable struct Foo12198
+    x
+end
+Base.:(==)(x::Foo12198, y::Foo12198) = x.x == y.x
+@testset "issue #12198" begin
+    a = [Foo12198(1), Foo12198(1)]
+    @test length(unique(a)) == 1
+    a = [Foo12198(1), Foo12198(2)]
+    @test length(unique(a)) == 2
+    d = Dict()
+    d[Foo12198(1)] = 1
+    @test haskey(d, Foo12198(1))
+    d[Foo12198(1)] = 2
+    @test length(d) == 1
+    @test d[Foo12198(1)] == 2
+end
+
 @testset "issue #2540" begin
     d = Dict{Any,Any}(Dict(x => 1 for x in ['a', 'b', 'c']))
     @test d == Dict('a'=>1, 'b'=>1, 'c'=> 1)


### PR DESCRIPTION
This implements the idea in https://github.com/JuliaLang/julia/issues/12198#issuecomment-358158092 --- make `hash` correct by default, with dicts and sets doing linear lookup for types without `hash` methods. This can be supported fairly well just by avoiding growing Dict storage excessively in this case.

Fixes #12198.
