### PR TITLE
Deprecate module_name in favor of nameof(::Module)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -965,8 +965,8 @@ Deprecated or removed
   * `findin(a, b)` has been deprecated in favor of `findall(occursin(b), a)` ([#24673]).
 
   * `module_name` has been deprecated in favor of a new, general `nameof` function. Similarly,
-    the unexported `Base.function_name` has been deprecated in favor of a `nameof` method
-    ([#25622]).
+    the unexported `Base.function_name` and `Base.datatype_name` have been deprecated in favor
+    of `nameof` methods ([#25622]).
 
   * The module `Random.dSFMT` is renamed `Random.DSFMT` ([#25567]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -964,7 +964,9 @@ Deprecated or removed
 
   * `findin(a, b)` has been deprecated in favor of `findall(occursin(b), a)` ([#24673]).
 
-  * `module_name` has been deprecated in favor of a new, general `nameof` function ([#25622]).
+  * `module_name` has been deprecated in favor of a new, general `nameof` function. Similarly,
+    the unexported `Base.function_name` has been deprecated in favor of a `nameof` method
+    ([#25622]).
 
   * The module `Random.dSFMT` is renamed `Random.DSFMT` ([#25567]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -964,6 +964,8 @@ Deprecated or removed
 
   * `findin(a, b)` has been deprecated in favor of `findall(occursin(b), a)` ([#24673]).
 
+  * `module_name` has been deprecated in favor of a new, general `nameof` function ([#25622]).
+
   * The module `Random.dSFMT` is renamed `Random.DSFMT` ([#25567]).
 
   * `Random.RandomDevice(unlimited::Bool)` (on non-Windows systems) is deprecated in favor of
@@ -1239,5 +1241,6 @@ Command-line option changes
 [#25532]: https://github.com/JuliaLang/julia/issues/25532
 [#25545]: https://github.com/JuliaLang/julia/issues/25545
 [#25616]: https://github.com/JuliaLang/julia/issues/25616
+[#25622]: https://github.com/JuliaLang/julia/issues/25622
 [#25634]: https://github.com/JuliaLang/julia/issues/25634
 [#25654]: https://github.com/JuliaLang/julia/issues/25654

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -14,7 +14,7 @@ AbstractArray
 convert(::Type{T}, a::T) where {T<:AbstractArray} = a
 convert(::Type{T}, a::AbstractArray) where {T<:AbstractArray} = T(a)
 
-if module_name(@__MODULE__) === :Base  # avoid method overwrite
+if nameof(@__MODULE__) === :Base  # avoid method overwrite
 # catch undefined constructors before the deprecation kicks in
 # TODO: remove when deprecation is removed
 function (::Type{T})(arg) where {T<:AbstractArray}

--- a/base/array.jl
+++ b/base/array.jl
@@ -411,7 +411,7 @@ promote_rule(a::Type{Array{T,n}}, b::Type{Array{S,n}}) where {T,n,S} = el_same(p
 
 ## Constructors ##
 
-if module_name(@__MODULE__) === :Base  # avoid method overwrite
+if nameof(@__MODULE__) === :Base  # avoid method overwrite
 # constructors should make copies
 Array{T,N}(x::AbstractArray{S,N})         where {T,N,S} = copyto!(Array{T,N}(uninitialized, size(x)), x)
 AbstractArray{T,N}(A::AbstractArray{S,N}) where {T,N,S} = copyto!(similar(A,T), A)

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -498,7 +498,7 @@ end
 reinterpret(::Type{Bool}, B::BitArray, dims::NTuple{N,Int}) where {N} = reinterpret(B, dims)
 reinterpret(B::BitArray, dims::NTuple{N,Int}) where {N} = reshape(B, dims)
 
-if module_name(@__MODULE__) === :Base  # avoid method overwrite
+if nameof(@__MODULE__) === :Base  # avoid method overwrite
 (::Type{T})(x::T) where {T<:BitArray} = copy(x)
 end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1626,6 +1626,7 @@ export readandwrite
 
 # PR #25622
 @deprecate module_name(m::Module) nameof(m)
+@deprecate function_name(f::Function) nameof(f) false
 
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1624,6 +1624,9 @@ export readandwrite
 @deprecate function_module(f::Function) parentmodule(f) false
 @deprecate function_module(f, t) parentmodule(f, t) false
 
+# PR #25622
+@deprecate module_name(m::Module) nameof(m)
+
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1627,6 +1627,8 @@ export readandwrite
 # PR #25622
 @deprecate module_name(m::Module) nameof(m)
 @deprecate function_name(f::Function) nameof(f) false
+@deprecate datatype_name(t::DataType) nameof(t) false
+@deprecate datatype_name(t::UnionAll) nameof(t) false
 
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -457,22 +457,22 @@ end
 
 uncurly(ex) = isexpr(ex, :curly) ? ex.args[1] : ex
 
-namify(x) = nameof(x, isexpr(x, :macro))
+namify(x) = astname(x, isexpr(x, :macro))
 
-function nameof(x::Expr, ismacro)
+function astname(x::Expr, ismacro)
     if isexpr(x, :.)
         ismacro ? macroname(x) : x
     # Call overloading, e.g. `(a::A)(b) = b` or `function (a::A)(b) b end` should document `A(b)`
     elseif (isexpr(x, :function) || isexpr(x, :(=))) && isexpr(x.args[1], :call) && isexpr(x.args[1].args[1], :(::))
-        return nameof(x.args[1].args[1].args[2], ismacro)
+        return astname(x.args[1].args[1].args[2], ismacro)
     else
         n = isexpr(x, (:module, :struct)) ? 2 : 1
-        nameof(x.args[n], ismacro)
+        astname(x.args[n], ismacro)
     end
 end
-nameof(q::QuoteNode, ismacro) = nameof(q.value, ismacro)
-nameof(s::Symbol, ismacro)    = ismacro ? macroname(s) : s
-nameof(other, ismacro)        = other
+astname(q::QuoteNode, ismacro) = astname(q.value, ismacro)
+astname(s::Symbol, ismacro)    = ismacro ? macroname(s) : s
+astname(other, ismacro)        = other
 
 macroname(s::Symbol) = Symbol('@', s)
 macroname(x::Expr)   = Expr(x.head, x.args[1], macroname(x.args[end].value))

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -9,7 +9,7 @@ struct Binding
     function Binding(m::Module, v::Symbol)
         # Normalise the binding module for module symbols so that:
         #   Binding(Base, :Base) === Binding(Main, :Base)
-        m = module_name(m) === v ? parentmodule(m) : m
+        m = nameof(m) === v ? parentmodule(m) : m
         new(Base.binding_module(m, v), v)
     end
 end
@@ -42,5 +42,5 @@ end
 aliasof(b::Binding)     = defined(b) ? (a = aliasof(resolve(b), b); defined(a) ? a : b) : b
 aliasof(d::DataType, b) = Binding(d.name.module, d.name.name)
 aliasof(λ::Function, b) = (m = typeof(λ).name.mt; Binding(m.module, m.name))
-aliasof(m::Module,   b) = Binding(m, module_name(m))
+aliasof(m::Module,   b) = Binding(m, nameof(m))
 aliasof(other,       b) = b

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -792,7 +792,7 @@ export
     hasmethod,
     methods,
     methodswith,
-    module_name,
+    nameof,
     parentmodule,
     names,
     varinfo,

--- a/base/int.jl
+++ b/base/int.jl
@@ -450,7 +450,7 @@ end
 # @doc isn't available when running in Core at this point.
 # Tuple syntax for documention two function signatures at the same time
 # doesn't work either at this point.
-if module_name(@__MODULE__) === :Base
+if nameof(@__MODULE__) === :Base
     for fname in (:mod, :rem)
         @eval @doc ("""
             rem(x::Integer, T::Type{<:Integer}) -> T

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -202,7 +202,7 @@ end
 
 function PkgId(m::Module)
     uuid = UUID(ccall(:jl_module_uuid, NTuple{2, UInt64}, (Any,), m))
-    name = String(module_name(m))
+    name = String(nameof(m))
     UInt128(uuid) == 0 && return PkgId(name)
     return PkgId(uuid, name)
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-if module_name(@__MODULE__) === :Base
+if nameof(@__MODULE__) === :Base
 
 """
     NamedTuple{names,T}(args::Tuple)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -143,9 +143,10 @@ fieldnames(t::UnionAll) = fieldnames(unwrap_unionall(t))
 fieldnames(t::Type{<:Tuple}) = Int[n for n in 1:fieldcount(t)]
 
 """
-    Base.datatype_name(t) -> Symbol
+    nameof(t::DataType) -> Symbol
 
-Get the name of a (potentially UnionAll-wrapped) `DataType` (without its parent module) as a symbol.
+Get the name of a (potentially `UnionAll`-wrapped) `DataType` (without its parent module)
+as a symbol.
 
 # Examples
 ```jldoctest
@@ -155,12 +156,12 @@ julia> module Foo
        end
 Foo
 
-julia> Base.datatype_name(Foo.S{T} where T)
+julia> nameof(Foo.S{T} where T)
 :S
 ```
 """
-datatype_name(t::DataType) = t.name.name
-datatype_name(t::UnionAll) = datatype_name(unwrap_unionall(t))
+nameof(t::DataType) = t.name.name
+nameof(t::UnionAll) = nameof(unwrap_unionall(t))
 
 """
     parentmodule(t::DataType) -> Module

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -3,17 +3,17 @@
 # name and module reflection
 
 """
-    module_name(m::Module) -> Symbol
+    nameof(m::Module) -> Symbol
 
 Get the name of a `Module` as a `Symbol`.
 
 # Examples
 ```jldoctest
-julia> module_name(Base)
+julia> nameof(Base)
 :Base
 ```
 """
-module_name(m::Module) = ccall(:jl_module_name, Ref{Symbol}, (Any,), m)
+nameof(m::Module) = ccall(:jl_module_name, Ref{Symbol}, (Any,), m)
 
 """
     parentmodule(m::Module) -> Module
@@ -56,7 +56,7 @@ julia> fullname(Main)
 ```
 """
 function fullname(m::Module)
-    mn = module_name(m)
+    mn = nameof(m)
     if m === Main || m === Base || m === Core
         return (mn,)
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1017,11 +1017,11 @@ end
 
 # function reflection
 """
-    Base.function_name(f::Function) -> Symbol
+    nameof(f::Function) -> Symbol
 
 Get the name of a generic `Function` as a symbol, or `:anonymous`.
 """
-function_name(f::Function) = typeof(f).name.mt.name
+nameof(f::Function) = typeof(f).name.mt.name
 
 functionloc(m::Core.MethodInstance) = functionloc(m.def)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -584,7 +584,7 @@ end
 
 function show(io::IO, m::Module)
     if is_root_module(m)
-        print(io, module_name(m))
+        print(io, nameof(m))
     else
         print(io, join(fullname(m),"."))
     end
@@ -1730,7 +1730,7 @@ function dumpsubtypes(io::IO, x::DataType, m::Module, n::Int, indent)
             t = getfield(m, s)
             if t === x || t === m
                 continue
-            elseif isa(t, Module) && module_name(t) === s && parentmodule(t) === m
+            elseif isa(t, Module) && nameof(t) === s && parentmodule(t) === m
                 # recurse into primary module bindings
                 dumpsubtypes(io, x, t, n, indent)
             elseif isa(t, UnionAll) && directsubtype(t::UnionAll, x)

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -318,7 +318,7 @@ function from(frame::StackFrame, m::Module)
     if finfo isa Core.MethodInstance
         frame_m = finfo.def
         isa(frame_m, Method) && (frame_m = frame_m.module)
-        result = module_name(frame_m) === module_name(m)
+        result = nameof(frame_m) === nameof(m)
     end
 
     return result

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -212,7 +212,7 @@ fill_to_length(t::Tuple{}, val, ::Val{2}) = (val, val)
 
 # only define these in Base, to avoid overwriting the constructors
 # NOTE: this means this constructor must be avoided in Core.Compiler!
-if module_name(@__MODULE__) === :Base
+if nameof(@__MODULE__) === :Base
 
 (::Type{T})(x::Tuple) where {T<:Tuple} = convert(T, x)  # still use `convert` for tuples
 

--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
 Compat 0.46.0 0.46.0+
-DocStringExtensions 0.4.2 0.4.2+
+DocStringExtensions 0.4.3 0.4.3+
 Documenter 0.13.0 0.13.0+

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -332,7 +332,7 @@ Base.AsyncCondition(::Function)
 ## Reflection
 
 ```@docs
-Base.module_name
+Base.nameof(::Module)
 Base.parentmodule
 Base.@__MODULE__
 Base.fullname

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -152,7 +152,7 @@ Base.isimmutable
 Base.isabstracttype
 Base.isprimitivetype
 Base.isstructtype
-Base.datatype_name
+Base.nameof(::DataType)
 Base.fieldnames
 Base.fieldname
 ```

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -339,7 +339,7 @@ Base.fullname
 Base.names
 Core.nfields
 Base.isconst
-Base.function_name
+Base.nameof(::Function)
 Base.functionloc(::Any, ::Any)
 Base.functionloc(::Method)
 Base.@functionloc

--- a/examples/typetree.jl
+++ b/examples/typetree.jl
@@ -79,7 +79,7 @@ function store_all_from(m::Module)
             t = getfield(m, s)
             if isa(t, Type) && t !== Union{}
                 store_type(Binding(m, s), t)
-            elseif isa(t, Module) && module_name(t) === s && parentmodule(t) === m && t !== m
+            elseif isa(t, Module) && nameof(t) === s && parentmodule(t) === m && t !== m
                 store_all_from(t)
             end
         end

--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -16,7 +16,7 @@ function character_codes(directives::SimpleVector)
     return letters
 end
 
-genvar(t::DataType) = Symbol(lowercase(string(Base.datatype_name(t))))
+genvar(t::DataType) = Symbol(lowercase(string(nameof(t))))
 
 """
     tryparsenext_core(str::AbstractString, pos::Int, len::Int, df::DateFormat, raise=false)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -219,7 +219,7 @@ const COMMAND_GROUPS =
 
 const COMMAND_GROUP = Dict(command=>group for (group, commands) in COMMAND_GROUPS for command in commands)
 command_group(command::Symbol) = get(COMMAND_GROUP, command, :nogroup)
-command_group(command::Function) = command_group(Base.function_name(command))
+command_group(command::Function) = command_group(Base.nameof(command))
 
 # return true if command should keep active a region
 function preserve_active(command::Symbol)

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -219,7 +219,7 @@ const COMMAND_GROUPS =
 
 const COMMAND_GROUP = Dict(command=>group for (group, commands) in COMMAND_GROUPS for command in commands)
 command_group(command::Symbol) = get(COMMAND_GROUP, command, :nogroup)
-command_group(command::Function) = command_group(Base.nameof(command))
+command_group(command::Function) = command_group(nameof(command))
 
 # return true if command should keep active a region
 function preserve_active(command::Symbol)

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -72,7 +72,7 @@ function complete_symbol(sym, ffunc)
         # We will exclude the results that the user does not want, as well
         # as excluding Main.Main.Main, etc., because that's most likely not what
         # the user wants
-        p = s->(!Base.isdeprecated(mod, s) && s != module_name(mod) && ffunc(mod, s))
+        p = s->(!Base.isdeprecated(mod, s) && s != nameof(mod) && ffunc(mod, s))
         # Looking for a binding in a module
         if mod == context_module
             # Also look in modules we got through `using`

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -363,7 +363,7 @@ function serialize_mod_names(s::AbstractSerializer, m::Module)
         serialize(s, Symbol(key.name))
     else
         serialize_mod_names(s, p)
-        serialize(s, module_name(m))
+        serialize(s, nameof(m))
     end
 end
 

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1288,7 +1288,7 @@ function detect_ambiguities(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && f !== mod && parentmodule(f) === mod && module_name(f) === n
+            if recursive && isa(f, Module) && f !== mod && parentmodule(f) === mod && nameof(f) === n
                 subambs = detect_ambiguities(f,
                     imported=imported, recursive=recursive, ambiguous_bottom=ambiguous_bottom)
                 union!(ambs, subambs)
@@ -1329,7 +1329,7 @@ function detect_unbound_args(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && parentmodule(f) === mod && module_name(f) === n
+            if recursive && isa(f, Module) && parentmodule(f) === mod && nameof(f) === n
                 subambs = detect_unbound_args(f, imported=imported, recursive=recursive)
                 union!(ambs, subambs)
             elseif isa(f, DataType) && isdefined(f.name, :mt)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2549,7 +2549,7 @@ function allsubtypes!(m::Module, x::DataType, sts::Set)
             t = getfield(m, s)
             if isa(t, Type) && t <: x && t != Union{}
                 push!(sts, t)
-            elseif isa(t, Module) && t !== m && module_name(t) === s && parentmodule(t) === m
+            elseif isa(t, Module) && t !== m && nameof(t) === s && parentmodule(t) === m
                 allsubtypes!(t, x, sts)
             end
         end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -230,7 +230,7 @@ module TestModSub9475
     let
         @test Base.binding_module(@__MODULE__, :a9475) == @__MODULE__
         @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
-        @test Base.module_name(@__MODULE__) == :TestModSub9475
+        @test Base.nameof(@__MODULE__) == :TestModSub9475
         @test Base.fullname(@__MODULE__) == (curmod_name..., :TestMod7648, :TestModSub9475)
         @test Base.parentmodule(@__MODULE__) == TestMod7648
     end
@@ -241,7 +241,7 @@ using .TestModSub9475
 let
     @test Base.binding_module(@__MODULE__, :d7648) == @__MODULE__
     @test Base.binding_module(@__MODULE__, :a9475) == TestModSub9475
-    @test Base.module_name(@__MODULE__) == :TestMod7648
+    @test Base.nameof(@__MODULE__) == :TestMod7648
     @test Base.parentmodule(@__MODULE__) == curmod
 end
 end # module TestMod7648

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -273,7 +273,7 @@ let
     @test parentmodule(foo9475, (Any,)) == TestMod7648.TestModSub9475
     @test parentmodule(foo9475) == TestMod7648.TestModSub9475
     @test parentmodule(Foo7648) == TestMod7648
-    @test Base.datatype_name(Foo7648) == :Foo7648
+    @test nameof(Foo7648) == :Foo7648
     @test basename(functionloc(foo7648, (Any,))[1]) == "reflection.jl"
     @test first(methods(TestMod7648.TestModSub9475.foo7648)) == @which foo7648(5)
     @test TestMod7648 == @which foo7648

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -266,7 +266,7 @@ let
     using .TestMod7648
     @test Base.binding_module(@__MODULE__, :a9475) == TestMod7648.TestModSub9475
     @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
-    @test Base.function_name(foo7648) == :foo7648
+    @test nameof(foo7648) == :foo7648
     @test parentmodule(foo7648, (Any,)) == TestMod7648
     @test parentmodule(foo7648) == TestMod7648
     @test parentmodule(foo7648_nomethods) == TestMod7648


### PR DESCRIPTION
As suggested by @Sacha0 and @martinholters in #25436.

This deprecates `module_name(::Module)` in favor of ~~`Symbol(::Module)`~~ `nameof(::Module)`. ~~This is technically breaking, since currently the `Symbol` constructor on modules falls back to `Symbol(string(::Module))`, which uses the entire module hierarchy (e.g. `LinAlg` -> `Symbol("Base.LinAlg")`), and with this PR it would be the top name only (e.g. `LinAlg` -> `:LinAlg`). The current behavior will still be available as `Symbol(join(fullname(m), '.'))`.~~

If this is accepted, I think we should also fold `function_name` and `datatype_name` into `Symbol` constructors.

~~(I'm actually not super convinced that I like this, but I figured it's worth exploring.)~~