### PR TITLE
Additional Documenter updates

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -165,6 +165,7 @@ makedocs(
     analytics = "UA-28835595-6",
     pages     = PAGES,
     html_prettyurls = ("deploy" in ARGS),
+    html_canonical = ("deploy" in ARGS) ? "https://docs.julialang.org/en/stable/" : nothing,
 )
 
 if "deploy" in ARGS

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -153,7 +153,7 @@ end
 makedocs(
     build     = joinpath(pwd(), "_build/html/en"),
     modules   = [Base, Core, BuildSysImg, [Base.root_module(stdlib.stdlib) for stdlib in STDLIB_DOCS]...],
-    clean     = false,
+    clean     = true,
     doctest   = "doctest" in ARGS,
     linkcheck = "linkcheck" in ARGS,
     linkcheck_ignore = ["https://bugs.kde.org/show_bug.cgi?id=136779"], # fails to load from nanosoldier?


### PR DESCRIPTION
This follows up on #25617 with some non-critical changes.

* Enables [canonical links elements](https://en.wikipedia.org/wiki/Canonical_link_element) for the doc builds which point to "stable" docs.
* Cleans up the build directory before building another set of docs. Currently we actually deploy two HTML files to [gh-pages](https://github.com/JuliaLang/julia/tree/gh-pages/en/latest/base) for each `.md` page (e.g. `base/file/index.html` and `base/file.html`). This, I believe, is because during the build phase the docs also get built (with the "local" settings) and the `doc/_build/` directory does not get cleaned up when `make -C doc deploy` gets called at the end of the build.
