### PR TITLE
Markdown terminal render: use box horizontal marker for admonitions, and color them depending on their title

### DIFF
--- a/base/markdown/render/terminal/render.jl
+++ b/base/markdown/render/terminal/render.jl
@@ -26,27 +26,38 @@ end
 function term(io::IO, md::BlockQuote, columns)
     s = sprint(term, md.content, columns - 10; context=io)
     for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "|", line)
+        println(io, " "^margin, "│", line)
     end
 end
 
 function term(io::IO, md::Admonition, columns)
-    print(io, " "^margin, "| ")
-    print_with_color(:bold, io, isempty(md.title) ? md.category : md.title)
-    println(io, "\n", " "^margin, "|")
+    col = :default
+    if lowercase(md.title) == "danger"
+        col = Base.error_color()
+    elseif lowercase(md.title) == "warning"
+        col = Base.warn_color()
+    elseif lowercase(md.title) in ("info", "note")
+        col = Base.info_color()
+    elseif lowercase(md.title) == "tip"
+        col = :green
+    end
+    print_with_color(col, io, " "^margin, "│ "; bold = true)
+    print_with_color(col, io, isempty(md.title) ? md.category : md.title; bold = true)
+    print_with_color(col, io, "\n", " "^margin, "│", "\n"; bold = true)
     s = sprint(term, md.content, columns - 10; context=io)
     for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "|", line)
+        print_with_color(col, io, " "^margin, "│"; bold = true)
+        println(io, line)
     end
 end
 
 function term(io::IO, f::Footnote, columns)
-    print(io, " "^margin, "| ")
+    print(io, " "^margin, "│ ")
     print_with_color(:bold, io, "[^$(f.id)]")
-    println(io, "\n", " "^margin, "|")
+    println(io, "\n", " "^margin, "│")
     s = sprint(term, f.text, columns - 10; context=io)
     for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "|", line)
+        println(io, " "^margin, "│", line)
     end
 end
 

--- a/test/markdown.jl
+++ b/test/markdown.jl
@@ -312,7 +312,7 @@ table = md"""
 # mime output
 let out =
     @test sprint(show, "text/plain", book) ==
-        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  |  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •    list1\n      \n    •    list2\n      \n"
+        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •    list1\n      \n    •    list2\n      \n"
     @test sprint(show, "text/markdown", book) ==
         """
         # Title


### PR DESCRIPTION
(Also box-characters for footnotes and block quotes)

Previously:

![screen shot 2018-01-18 at 15 29 09](https://user-images.githubusercontent.com/1282691/35102820-57c68f9e-fc64-11e7-815c-1c4600a7677b.png)

PR:

![screen shot 2018-01-18 at 15 25 49](https://user-images.githubusercontent.com/1282691/35102795-4a9452ac-fc64-11e7-9134-7e57e8daf80d.png)

