### PR TITLE
Deprecate module querying functions to parentmodule methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -952,8 +952,8 @@ Deprecated or removed
      have been deprecated. Subtypes of `AbstractArray` that implement the newly introduced strided
      array interface should define their own `strides` method ([#25321]).
 
-  * `module_parent` and `Base.datatype_module` have been deprecated in favor of `parentmodule`
-    ([#TODO]).
+  * `module_parent`, `Base.datatype_module`, and `Base.function_module` have been deprecated
+    in favor of `parentmodule` ([#TODO]).
 
   * `rand(t::Tuple{Vararg{Int}})` is deprecated in favor of `rand(Float64, t)` or `rand(t...)`;
     `rand(::Tuple)` will have another meaning in the future ([#25429], [#25278]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -952,6 +952,8 @@ Deprecated or removed
      have been deprecated. Subtypes of `AbstractArray` that implement the newly introduced strided
      array interface should define their own `strides` method ([#25321]).
 
+  * `module_parent` has been deprecated in favor of `parentmodule` ([#TODO]).
+
   * `rand(t::Tuple{Vararg{Int}})` is deprecated in favor of `rand(Float64, t)` or `rand(t...)`;
     `rand(::Tuple)` will have another meaning in the future ([#25429], [#25278]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -952,7 +952,8 @@ Deprecated or removed
      have been deprecated. Subtypes of `AbstractArray` that implement the newly introduced strided
      array interface should define their own `strides` method ([#25321]).
 
-  * `module_parent` has been deprecated in favor of `parentmodule` ([#TODO]).
+  * `module_parent` and `Base.datatype_module` have been deprecated in favor of `parentmodule`
+    ([#TODO]).
 
   * `rand(t::Tuple{Vararg{Int}})` is deprecated in favor of `rand(Float64, t)` or `rand(t...)`;
     `rand(::Tuple)` will have another meaning in the future ([#25429], [#25278]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2816,7 +2816,11 @@ function readandwrite(cmds::AbstractCmd)
 end
 export readandwrite
 
-@deprecate module_parent parentmodule
+@deprecate module_parent(m::Module) parentmodule(m)
+@deprecate datatype_module(t::DataType) parentmodule(t) false
+@deprecate datatype_module(t::UnionAll) parentmodule(t) false
+@deprecate Base.function_module(f::Function) parentmodule(f)
+@deprecate Base.function_module(f, t) parentmodule(f, t)
 
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2816,6 +2816,8 @@ function readandwrite(cmds::AbstractCmd)
 end
 export readandwrite
 
+@deprecate module_parent parentmodule
+
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -2819,8 +2819,8 @@ export readandwrite
 @deprecate module_parent(m::Module) parentmodule(m)
 @deprecate datatype_module(t::DataType) parentmodule(t) false
 @deprecate datatype_module(t::UnionAll) parentmodule(t) false
-@deprecate Base.function_module(f::Function) parentmodule(f)
-@deprecate Base.function_module(f, t) parentmodule(f, t)
+@deprecate function_module(f::Function) parentmodule(f) false
+@deprecate function_module(f, t) parentmodule(f, t) false
 
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}

--- a/base/docs/bindings.jl
+++ b/base/docs/bindings.jl
@@ -9,7 +9,7 @@ struct Binding
     function Binding(m::Module, v::Symbol)
         # Normalise the binding module for module symbols so that:
         #   Binding(Base, :Base) === Binding(Main, :Base)
-        m = module_name(m) === v ? module_parent(m) : m
+        m = module_name(m) === v ? parentmodule(m) : m
         new(Base.binding_module(m, v), v)
     end
 end

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -889,7 +889,7 @@ export
     methods,
     methodswith,
     module_name,
-    module_parent,
+    parentmodule,
     names,
     varinfo,
     versioninfo,

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -6,8 +6,8 @@ Methods for working with Iterators.
 module Iterators
 
 # small dance to make this work from Base or Intrinsics
-import ..@__MODULE__, ..module_parent
-const Base = module_parent(@__MODULE__)
+import ..@__MODULE__, ..parentmodule
+const Base = parentmodule(@__MODULE__)
 using .Base:
     @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
     tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -126,7 +126,7 @@ function _include_from_serialized(path::String, depmods::Vector{Any})
             if isdefined(M, Base.Docs.META)
                 push!(Base.Docs.modules, M)
             end
-            if module_parent(M) === M
+            if parentmodule(M) === M
                 register_root_module(module_name(M), M)
             end
         end

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -191,7 +191,7 @@ function inbase(m::Module)
     if m == Base
         true
     else
-        parent = module_parent(m)
+        parent = parentmodule(m)
         parent === m ? false : inbase(parent)
     end
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -16,20 +16,20 @@ julia> module_name(Base.LinAlg)
 module_name(m::Module) = ccall(:jl_module_name, Ref{Symbol}, (Any,), m)
 
 """
-    module_parent(m::Module) -> Module
+    parentmodule(m::Module) -> Module
 
 Get a module's enclosing `Module`. `Main` is its own parent.
 
 # Examples
 ```jldoctest
-julia> module_parent(Main)
+julia> parentmodule(Main)
 Main
 
-julia> module_parent(Base.LinAlg.BLAS)
+julia> parentmodule(Base.LinAlg.BLAS)
 Base.LinAlg
 ```
 """
-module_parent(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
+parentmodule(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
 
 """
     @__MODULE__ -> Module
@@ -60,7 +60,7 @@ function fullname(m::Module)
     if m === Main || m === Base || m === Core
         return (mn,)
     end
-    mp = module_parent(m)
+    mp = parentmodule(m)
     if mp === m
         return (mn,)
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -983,19 +983,19 @@ function functionloc(@nospecialize(f))
 end
 
 """
-    Base.function_module(f::Function) -> Module
+    parentmodule(f::Function) -> Module
 
 Determine the module containing the (first) definition of a generic
 function.
 """
-function_module(f::Function) = parentmodule(typeof(f))
+parentmodule(f::Function) = parentmodule(typeof(f))
 
 """
-    Base.function_module(f::Function, types) -> Module
+    parentmodule(f::Function, types) -> Module
 
 Determine the module containing a given definition of a generic function.
 """
-function function_module(@nospecialize(f), @nospecialize(types))
+function parentmodule(@nospecialize(f), @nospecialize(types))
     m = methods(f, types)
     if isempty(m)
         error("no matching methods")

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -163,9 +163,9 @@ datatype_name(t::DataType) = t.name.name
 datatype_name(t::UnionAll) = datatype_name(unwrap_unionall(t))
 
 """
-    Base.datatype_module(t::DataType) -> Module
+    parentmodule(t::DataType) -> Module
 
-Determine the module containing the definition of a (potentially UnionAll-wrapped) `DataType`.
+Determine the module containing the definition of a (potentially `UnionAll`-wrapped) `DataType`.
 
 # Examples
 ```jldoctest
@@ -174,15 +174,15 @@ julia> module Foo
        end
 Foo
 
-julia> Base.datatype_module(Int)
+julia> parentmodule(Int)
 Core
 
-julia> Base.datatype_module(Foo.Int)
+julia> parentmodule(Foo.Int)
 Foo
 ```
 """
-datatype_module(t::DataType) = t.name.module
-datatype_module(t::UnionAll) = datatype_module(unwrap_unionall(t))
+parentmodule(t::DataType) = t.name.module
+parentmodule(t::UnionAll) = parentmodule(unwrap_unionall(t))
 
 """
     isconst(m::Module, s::Symbol) -> Bool
@@ -988,7 +988,7 @@ end
 Determine the module containing the (first) definition of a generic
 function.
 """
-function_module(f::Function) = datatype_module(typeof(f))
+function_module(f::Function) = parentmodule(typeof(f))
 
 """
     Base.function_module(f::Function, types) -> Module

--- a/base/serialize.jl
+++ b/base/serialize.jl
@@ -357,7 +357,7 @@ function serialize_mod_names(s::AbstractSerializer, m::Module)
     if Base.is_root_module(m)
         serialize(s, Base.root_module_key(m))
     else
-        serialize_mod_names(s, module_parent(m))
+        serialize_mod_names(s, parentmodule(m))
         serialize(s, module_name(m))
     end
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -197,7 +197,7 @@ function is_exported_from_stdlib(name::Symbol, mod::Module)
     !isdefined(mod, name) && return false
     orig = getfield(mod, name)
     while !(mod === Base || mod === Core)
-        parent = module_parent(mod)
+        parent = parentmodule(mod)
         if mod === Main || mod === parent || parent === Main
             return false
         end
@@ -1574,7 +1574,7 @@ function dumpsubtypes(io::IO, x::DataType, m::Module, n::Int, indent)
             t = getfield(m, s)
             if t === x || t === m
                 continue
-            elseif isa(t, Module) && module_name(t) === s && module_parent(t) === m
+            elseif isa(t, Module) && module_name(t) === s && parentmodule(t) === m
                 # recurse into primary module bindings
                 dumpsubtypes(io, x, t, n, indent)
             elseif isa(t, UnionAll) && directsubtype(t::UnionAll, x)

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -133,7 +133,7 @@ function (ss::SummarySize)(obj::Module)
     for binding in names(obj, true)
         if isdefined(obj, binding) && !isdeprecated(obj, binding)
             value = getfield(obj, binding)
-            if !isa(value, Module) || module_parent(value) === obj
+            if !isa(value, Module) || parentmodule(value) === obj
                 size += ss(value)::Int
                 if isa(value, UnionAll)
                     value = unwrap_unionall(value)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -309,7 +309,7 @@ Base.AsyncCondition(::Function)
 
 ```@docs
 Base.module_name
-Base.module_parent
+Base.parentmodule
 Base.@__MODULE__
 Base.fullname
 Base.names

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -318,7 +318,6 @@ Base.fieldnames
 Base.fieldname
 Base.fieldcount
 Base.propertynames
-Base.datatype_module
 Base.datatype_name
 Base.isconst
 Base.function_name

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -321,8 +321,6 @@ Base.propertynames
 Base.datatype_name
 Base.isconst
 Base.function_name
-Base.function_module(::Function)
-Base.function_module(::Any, ::Any)
 Base.functionloc(::Any, ::Any)
 Base.functionloc(::Method)
 Base.@functionloc

--- a/examples/typetree.jl
+++ b/examples/typetree.jl
@@ -79,7 +79,7 @@ function store_all_from(m::Module)
             t = getfield(m, s)
             if isa(t, Type) && t !== Union{}
                 store_type(Binding(m, s), t)
-            elseif isa(t, Module) && module_name(t) === s && module_parent(t) === m && t !== m
+            elseif isa(t, Module) && module_name(t) === s && parentmodule(t) === m && t !== m
                 store_all_from(t)
             end
         end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1314,7 +1314,7 @@ function detect_ambiguities(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && f !== mod && module_parent(f) === mod && module_name(f) === n
+            if recursive && isa(f, Module) && f !== mod && parentmodule(f) === mod && module_name(f) === n
                 subambs = detect_ambiguities(f,
                     imported=imported, recursive=recursive, ambiguous_bottom=ambiguous_bottom)
                 union!(ambs, subambs)
@@ -1355,7 +1355,7 @@ function detect_unbound_args(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && module_parent(f) === mod && module_name(f) === n
+            if recursive && isa(f, Module) && parentmodule(f) === mod && module_name(f) === n
                 subambs = detect_unbound_args(f, imported=imported, recursive=recursive)
                 union!(ambs, subambs)
             elseif isa(f, DataType) && isdefined(f.name, :mt)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2548,7 +2548,7 @@ function allsubtypes!(m::Module, x::DataType, sts::Set)
             t = getfield(m, s)
             if isa(t, Type) && t <: x && t != Union{}
                 push!(sts, t)
-            elseif isa(t, Module) && t !== m && module_name(t) === s && module_parent(t) === m
+            elseif isa(t, Module) && t !== m && module_name(t) === s && parentmodule(t) === m
                 allsubtypes!(t, x, sts)
             end
         end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -237,7 +237,7 @@ module TestModSub9475
         @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
         @test Base.module_name(@__MODULE__) == :TestModSub9475
         @test Base.fullname(@__MODULE__) == (curmod_name..., :TestMod7648, :TestModSub9475)
-        @test Base.module_parent(@__MODULE__) == TestMod7648
+        @test Base.parentmodule(@__MODULE__) == TestMod7648
     end
 end # module TestModSub9475
 
@@ -247,7 +247,7 @@ let
     @test Base.binding_module(@__MODULE__, :d7648) == @__MODULE__
     @test Base.binding_module(@__MODULE__, :a9475) == TestModSub9475
     @test Base.module_name(@__MODULE__) == :TestMod7648
-    @test Base.module_parent(@__MODULE__) == curmod
+    @test Base.parentmodule(@__MODULE__) == curmod
 end
 end # module TestMod7648
 
@@ -580,10 +580,10 @@ function f15280(x) end
 
 # bug found in #16850, Base.url with backslashes on Windows
 function module_depth(from::Module, to::Module)
-    if from === to || module_parent(to) === to
+    if from === to || parentmodule(to) === to
         return 0
     else
-        return 1 + module_depth(from, module_parent(to))
+        return 1 + module_depth(from, parentmodule(to))
     end
 end
 function has_backslashes(mod::Module)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -277,7 +277,7 @@ let
     @test Base.function_module(foo7648_nomethods) == TestMod7648
     @test Base.function_module(foo9475, (Any,)) == TestMod7648.TestModSub9475
     @test Base.function_module(foo9475) == TestMod7648.TestModSub9475
-    @test Base.datatype_module(Foo7648) == TestMod7648
+    @test parentmodule(Foo7648) == TestMod7648
     @test Base.datatype_name(Foo7648) == :Foo7648
     @test basename(functionloc(foo7648, (Any,))[1]) == "reflection.jl"
     @test first(methods(TestMod7648.TestModSub9475.foo7648)) == @which foo7648(5)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -272,11 +272,11 @@ let
     @test Base.binding_module(@__MODULE__, :a9475) == TestMod7648.TestModSub9475
     @test Base.binding_module(@__MODULE__, :c7648) == TestMod7648
     @test Base.function_name(foo7648) == :foo7648
-    @test Base.function_module(foo7648, (Any,)) == TestMod7648
-    @test Base.function_module(foo7648) == TestMod7648
-    @test Base.function_module(foo7648_nomethods) == TestMod7648
-    @test Base.function_module(foo9475, (Any,)) == TestMod7648.TestModSub9475
-    @test Base.function_module(foo9475) == TestMod7648.TestModSub9475
+    @test parentmodule(foo7648, (Any,)) == TestMod7648
+    @test parentmodule(foo7648) == TestMod7648
+    @test parentmodule(foo7648_nomethods) == TestMod7648
+    @test parentmodule(foo9475, (Any,)) == TestMod7648.TestModSub9475
+    @test parentmodule(foo9475) == TestMod7648.TestModSub9475
     @test parentmodule(Foo7648) == TestMod7648
     @test Base.datatype_name(Foo7648) == :Foo7648
     @test basename(functionloc(foo7648, (Any,))[1]) == "reflection.jl"


### PR DESCRIPTION
This PR adds a function `parentmodule` and deprecates `module_parent`, `Base.datatype_module`, and `Base.function_module` in favor of `parentmodule` methods. I find that this has a nice symmetry with the changes made in #25622.