### PR TITLE
Rename nb_available to bytesavailable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -690,6 +690,8 @@ Deprecated or removed
 
   * `read(::IO, ::Ref)` is now a method of `read!`, since it mutates its `Ref` argument ([#21592]).
 
+  * `nb_available` is now `bytesavailable` ([#25634]).
+
   * `Bidiagonal` constructors now use a `Symbol` (`:U` or `:L`) for the upper/lower
     argument, instead of a `Bool` or a `Char` ([#22703]).
 
@@ -1222,3 +1224,4 @@ Command-line option changes
 [#25532]: https://github.com/JuliaLang/julia/issues/25532
 [#25545]: https://github.com/JuliaLang/julia/issues/25545
 [#25616]: https://github.com/JuliaLang/julia/issues/25616
+[#25634]: https://github.com/JuliaLang/julia/issues/25634

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1583,6 +1583,8 @@ end
 @deprecate gc_enable GC.enable
 @eval @deprecate $(Symbol("@gc_preserve")) GC.$(Symbol("@preserve")) false
 
+@deprecate nb_available bytesavailable
+
 # issue #9053
 if Sys.iswindows()
 function Filesystem.tempname(uunique::UInt32)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -855,7 +855,7 @@ export
     listenany,
     ltoh,
     mark,
-    nb_available,
+    bytesavailable,
     ntoh,
     open,
     pipeline,

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -40,7 +40,7 @@ export File,
 
 import Base:
     UVError, _sizeof_uv_fs, check_open, close, eof, eventloop, fd, isopen,
-    nb_available, position, read, read!, readavailable, seek, seekend, show,
+    bytesavailable, position, read, read!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, transcode, uv_error, uvhandle,
     uvtype, write
 using Base: coalesce
@@ -179,12 +179,12 @@ function unsafe_read(f::File, p::Ptr{UInt8}, nel::UInt)
     nothing
 end
 
-nb_available(f::File) = max(0, filesize(f) - position(f)) # position can be > filesize
+bytesavailable(f::File) = max(0, filesize(f) - position(f)) # position can be > filesize
 
-eof(f::File) = nb_available(f) == 0
+eof(f::File) = bytesavailable(f) == 0
 
 function readbytes!(f::File, b::Array{UInt8}, nb=length(b))
-    nr = min(nb, nb_available(f))
+    nr = min(nb, bytesavailable(f))
     if length(b) < nr
         resize!(b, nr)
     end
@@ -193,9 +193,9 @@ function readbytes!(f::File, b::Array{UInt8}, nb=length(b))
     uv_error("read",ret)
     return ret
 end
-read(io::File) = read!(io, Base.StringVector(nb_available(io)))
+read(io::File) = read!(io, Base.StringVector(bytesavailable(io)))
 readavailable(io::File) = read(io)
-read(io::File, nb::Integer) = read!(io, Base.StringVector(min(nb, nb_available(io))))
+read(io::File, nb::Integer) = read!(io, Base.StringVector(min(nb, bytesavailable(io))))
 
 const SEEK_SET = Int32(0)
 const SEEK_CUR = Int32(1)

--- a/base/io.jl
+++ b/base/io.jl
@@ -65,7 +65,7 @@ function wait_connected end
 function wait_readnb end
 function wait_readbyte end
 function wait_close end
-function nb_available end
+function bytesavailable end
 
 """
     readavailable(stream)
@@ -243,7 +243,7 @@ wait_readbyte(io::AbstractPipe, byte::UInt8) = wait_readbyte(pipe_reader(io), by
 wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)); wait_close(pipe_reader(io)))
 
 """
-    nb_available(io)
+    bytesavailable(io)
 
 Return the number of bytes available for reading before a read from this stream or buffer will block.
 
@@ -251,11 +251,11 @@ Return the number of bytes available for reading before a read from this stream 
 ```jldoctest
 julia> io = IOBuffer("JuliaLang is a GitHub organization");
 
-julia> nb_available(io)
+julia> bytesavailable(io)
 34
 ```
 """
-nb_available(io::AbstractPipe) = nb_available(pipe_reader(io))
+bytesavailable(io::AbstractPipe) = bytesavailable(pipe_reader(io))
 
 """
     eof(stream) -> Bool

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -147,7 +147,7 @@ show(io::IO, b::GenericIOBuffer) = print(io, "IOBuffer(data=UInt8[...], ",
 
 function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
-    avail = nb_available(from)
+    avail = bytesavailable(from)
     adv = min(avail, nb)
     GC.@preserve from unsafe_copyto!(p, pointer(from.data, from.ptr), adv)
     from.ptr += adv
@@ -200,8 +200,8 @@ iswritable(io::GenericIOBuffer) = io.writable
 
 # TODO: GenericIOBuffer is not iterable, so doesn't really have a length.
 # This should maybe be sizeof() instead.
-#length(io::GenericIOBuffer) = (io.seekable ? io.size : nb_available(io))
-nb_available(io::GenericIOBuffer) = io.size - io.ptr + 1
+#length(io::GenericIOBuffer) = (io.seekable ? io.size : bytesavailable(io))
+bytesavailable(io::GenericIOBuffer) = io.size - io.ptr + 1
 position(io::GenericIOBuffer) = io.ptr-1
 
 function skip(io::GenericIOBuffer, n::Integer)
@@ -251,10 +251,10 @@ function compact(io::GenericIOBuffer)
     if ismarked(io) && io.mark < io.ptr
         if io.mark == 0 return end
         ptr = io.mark
-        bytes_to_move = nb_available(io) + (io.ptr-io.mark)
+        bytes_to_move = bytesavailable(io) + (io.ptr-io.mark)
     else
         ptr = io.ptr
-        bytes_to_move = nb_available(io)
+        bytes_to_move = bytesavailable(io)
     end
     copyto!(io.data, 1, io.data, ptr, bytes_to_move)
     io.size -= ptr - 1
@@ -305,7 +305,7 @@ eof(io::GenericIOBuffer) = (io.ptr-1 == io.size)
     nothing
 end
 
-isopen(io::GenericIOBuffer) = io.readable || io.writable || io.seekable || nb_available(io) > 0
+isopen(io::GenericIOBuffer) = io.readable || io.writable || io.seekable || bytesavailable(io) > 0
 
 """
     take!(b::IOBuffer)
@@ -330,7 +330,7 @@ function take!(io::GenericIOBuffer)
         nbytes = io.size
         data = copyto!(StringVector(nbytes), 1, io.data, 1, nbytes)
     else
-        nbytes = nb_available(io)
+        nbytes = bytesavailable(io)
         data = read!(io,StringVector(nbytes))
     end
     if io.writable
@@ -351,7 +351,7 @@ function take!(io::IOBuffer)
         end
         resize!(data,io.size)
     else
-        nbytes = nb_available(io)
+        nbytes = bytesavailable(io)
         a = StringVector(nbytes)
         data = read!(io, a)
     end
@@ -367,7 +367,7 @@ function write(to::GenericIOBuffer, from::GenericIOBuffer)
         from.ptr = from.size + 1
         return 0
     end
-    written::Int = write_sub(to, from.data, from.ptr, nb_available(from))
+    written::Int = write_sub(to, from.data, from.ptr, bytesavailable(from))
     from.ptr += written
     return written
 end
@@ -415,20 +415,20 @@ end
 
 readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb=length(b)) = readbytes!(io, b, Int(nb))
 function readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb::Int)
-    nr = min(nb, nb_available(io))
+    nr = min(nb, bytesavailable(io))
     if length(b) < nr
         resize!(b, nr)
     end
     read_sub(io, b, 1, nr)
     return nr
 end
-read(io::GenericIOBuffer) = read!(io,StringVector(nb_available(io)))
+read(io::GenericIOBuffer) = read!(io,StringVector(bytesavailable(io)))
 readavailable(io::GenericIOBuffer) = read(io)
-read(io::GenericIOBuffer, nb::Integer) = read!(io,StringVector(min(nb, nb_available(io))))
+read(io::GenericIOBuffer, nb::Integer) = read!(io,StringVector(min(nb, bytesavailable(io))))
 
 function findfirst(delim::EqualTo{UInt8}, buf::IOBuffer)
     p = pointer(buf.data, buf.ptr)
-    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim.x,nb_available(buf))
+    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim.x,bytesavailable(buf))
     q == C_NULL && return nothing
     return Int(q-p+1)
 end
@@ -472,10 +472,10 @@ end
 function _crc32c(io::IOBuffer, nb::Integer, crc::UInt32=0x00000000)
     nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0"))
     io.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
-    n = min(nb, nb_available(io))
+    n = min(nb, bytesavailable(io))
     n == 0 && return crc
     crc = GC.@preserve io unsafe_crc32c(pointer(io.data, io.ptr), n, crc)
     io.ptr += n
     return crc
 end
-_crc32c(io::IOBuffer, crc::UInt32=0x00000000) = _crc32c(io, nb_available(io), crc)
+_crc32c(io::IOBuffer, crc::UInt32=0x00000000) = _crc32c(io, bytesavailable(io), crc)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -326,9 +326,9 @@ function unsafe_write(s::IOStream, p::Ptr{UInt8}, nb::UInt)
 end
 
 # num bytes available without blocking
-nb_available(s::IOStream) = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
+bytesavailable(s::IOStream) = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
 
-readavailable(s::IOStream) = read!(s, Vector{UInt8}(uninitialized, nb_available(s)))
+readavailable(s::IOStream) = read!(s, Vector{UInt8}(uninitialized, bytesavailable(s)))
 
 function read(s::IOStream, ::Type{UInt8})
     b = ccall(:ios_getc, Cint, (Ptr{Cvoid},), s.ios)

--- a/base/repl/REPL.jl
+++ b/base/repl/REPL.jl
@@ -888,7 +888,7 @@ function setup_interface(
             sbuffer = LineEdit.buffer(s)
             curspos = position(sbuffer)
             seek(sbuffer, 0)
-            shouldeval = (nb_available(sbuffer) == curspos && findfirst(equalto(UInt8('\n')), sbuffer) === nothing)
+            shouldeval = (bytesavailable(sbuffer) == curspos && findfirst(equalto(UInt8('\n')), sbuffer) === nothing)
             seek(sbuffer, curspos)
             if curspos == 0
                 # if pasting at the beginning, strip leading whitespace

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -326,7 +326,7 @@ function TCPServer(; delay=true)
     return tcp
 end
 
-isreadable(io::TCPSocket) = isopen(io) || nb_available(io) > 0
+isreadable(io::TCPSocket) = isopen(io) || bytesavailable(io) > 0
 iswritable(io::TCPSocket) = isopen(io) && io.status != StatusClosing
 
 ## VARIOUS METHODS TO BE MOVED TO BETTER LOCATION

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -43,16 +43,16 @@ function stream_wait(x, c...) # for x::LibuvObject
     end
 end
 
-nb_available(s::LibuvStream) = nb_available(s.buffer)
+bytesavailable(s::LibuvStream) = bytesavailable(s.buffer)
 
 function eof(s::LibuvStream)
     if isopen(s) # fast path
-        nb_available(s) > 0 && return false
+        bytesavailable(s) > 0 && return false
     else
-        return nb_available(s) <= 0
+        return bytesavailable(s) <= 0
     end
     wait_readnb(s,1)
-    return !isopen(s) && nb_available(s) <= 0
+    return !isopen(s) && bytesavailable(s) <= 0
 end
 
 # Limit our default maximum read and buffer size,
@@ -205,12 +205,12 @@ show(io::IO, stream::LibuvServer) = print(io, typeof(stream), "(",
 show(io::IO, stream::LibuvStream) = print(io, typeof(stream), "(",
     _fd(stream), " ",
     uv_status_string(stream), ", ",
-    nb_available(stream.buffer)," bytes waiting)")
+    bytesavailable(stream.buffer)," bytes waiting)")
 
 # Shared LibuvStream object interface
 
 function isreadable(io::LibuvStream)
-    nb_available(io) > 0 && return true
+    bytesavailable(io) > 0 && return true
     isopen(io) || return false
     return ccall(:uv_is_readable, Cint, (Ptr{Cvoid},), io.handle) != 0
 end
@@ -292,14 +292,14 @@ end
 
 function wait_readnb(x::LibuvStream, nb::Int)
     if isopen(x) # fast path
-        nb_available(x.buffer) >= nb && return
+        bytesavailable(x.buffer) >= nb && return
     else
         return
     end
     oldthrottle = x.throttle
     preserve_handle(x)
     try
-        while isopen(x) && nb_available(x.buffer) < nb
+        while isopen(x) && bytesavailable(x.buffer) < nb
             x.throttle = max(nb, x.throttle)
             start_reading(x) # ensure we are reading
             wait(x.readnotify)
@@ -536,8 +536,8 @@ function uv_readcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid})
         # 3) we have an alternate buffer that has reached its limit.
         if stream.status == StatusPaused ||
            (stream.status == StatusActive &&
-            ((nb_available(stream.buffer) >= stream.throttle) ||
-             (nb_available(stream.buffer) >= stream.buffer.maxsize)))
+            ((bytesavailable(stream.buffer) >= stream.throttle) ||
+             (bytesavailable(stream.buffer) >= stream.buffer.maxsize)))
             # save cycles by stopping kernel notifications from arriving
             ccall(:uv_read_stop, Cint, (Ptr{Cvoid},), stream)
             stream.status = StatusOpen
@@ -606,7 +606,7 @@ show(io::IO, stream::Pipe) = print(io,
     uv_status_string(stream.in), " => ",
     _fd(stream.out), " ",
     uv_status_string(stream.out), ", ",
-    nb_available(stream), " bytes waiting)")
+    bytesavailable(stream), " bytes waiting)")
 
 
 ## Functions for PipeEndpoint and PipeServer ##
@@ -763,7 +763,7 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
     @assert sbuf.seekable == false
     @assert sbuf.maxsize >= nb
 
-    if nb_available(sbuf) >= nb
+    if bytesavailable(sbuf) >= nb
         return readbytes!(sbuf, a, nb)
     end
 
@@ -779,7 +779,7 @@ function readbytes!(s::LibuvStream, a::Vector{UInt8}, nb::Int)
             write(newbuf, sbuf)
             wait_readnb(s, Int(nb))
             compact(newbuf)
-            return nb_available(newbuf)
+            return bytesavailable(newbuf)
         finally
             s.buffer = sbuf
             if !isempty(s.readnotify.waitq)
@@ -800,7 +800,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
     @assert sbuf.seekable == false
     @assert sbuf.maxsize >= nb
 
-    if nb_available(sbuf) >= nb
+    if bytesavailable(sbuf) >= nb
         return unsafe_read(sbuf, p, nb)
     end
 
@@ -815,7 +815,7 @@ function unsafe_read(s::LibuvStream, p::Ptr{UInt8}, nb::UInt)
             s.buffer = newbuf
             write(newbuf, sbuf)
             wait_readnb(s, Int(nb))
-            nb == nb_available(newbuf) || throw(EOFError())
+            nb == bytesavailable(newbuf) || throw(EOFError())
         finally
             s.buffer = sbuf
             if !isempty(s.readnotify.waitq)
@@ -910,7 +910,7 @@ function unsafe_write(s::LibuvStream, p::Ptr{UInt8}, n::UInt)
     end
 
     buf = s.sendbuf
-    totb = nb_available(buf) + n
+    totb = bytesavailable(buf) + n
     if totb < buf.maxsize
         nb = unsafe_write(buf, p, n)
     else
@@ -927,7 +927,7 @@ end
 function flush(s::LibuvStream)
     if s.sendbuf !== nothing
         buf = s.sendbuf
-        if nb_available(buf) > 0
+        if bytesavailable(buf) > 0
             arr = take!(buf)        # Array of UInt8s
             uv_write(s, arr)
             return
@@ -944,7 +944,7 @@ buffer_writes(s::LibuvStream, bufsize) = (s.sendbuf=PipeBuffer(bufsize); s)
 function write(s::LibuvStream, b::UInt8)
     if s.sendbuf !== nothing
         buf = s.sendbuf
-        if nb_available(buf) + 1 < buf.maxsize
+        if bytesavailable(buf) + 1 < buf.maxsize
             return write(buf, b)
         end
     end
@@ -1239,18 +1239,18 @@ uvfinalize(s::BufferStream) = nothing
 
 read(s::BufferStream, ::Type{UInt8}) = (wait_readnb(s, 1); read(s.buffer, UInt8))
 unsafe_read(s::BufferStream, a::Ptr{UInt8}, nb::UInt) = (wait_readnb(s, Int(nb)); unsafe_read(s.buffer, a, nb))
-nb_available(s::BufferStream) = nb_available(s.buffer)
+bytesavailable(s::BufferStream) = bytesavailable(s.buffer)
 
 isreadable(s::BufferStream) = s.buffer.readable
 iswritable(s::BufferStream) = s.buffer.writable
 
 function wait_readnb(s::BufferStream, nb::Int)
-    while isopen(s) && nb_available(s.buffer) < nb
+    while isopen(s) && bytesavailable(s.buffer) < nb
         wait(s.r_c)
     end
 end
 
-show(io::IO, s::BufferStream) = print(io,"BufferStream() bytes waiting:",nb_available(s.buffer),", isopen:", s.is_open)
+show(io::IO, s::BufferStream) = print(io,"BufferStream() bytes waiting:",bytesavailable(s.buffer),", isopen:", s.is_open)
 
 function wait_readbyte(s::BufferStream, c::UInt8)
     while isopen(s) && findfirst(equalto(c), s.buffer) === nothing
@@ -1271,7 +1271,7 @@ end
 
 function eof(s::BufferStream)
     wait_readnb(s, 1)
-    return !isopen(s) && nb_available(s)<=0
+    return !isopen(s) && bytesavailable(s)<=0
 end
 
 # If buffer_writes is called, it will delay notifying waiters till a flush is called.

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -137,7 +137,7 @@ Base.getsockname
 Base.getpeername
 Base.IPv4
 Base.IPv6
-Base.nb_available
+Base.bytesavailable
 Base.accept
 Base.listenany
 Base.bind

--- a/stdlib/Base64/src/buffer.jl
+++ b/stdlib/Base64/src/buffer.jl
@@ -30,7 +30,7 @@ function read_to_buffer(io::IO, buffer::Buffer)
     copyto!(buffer.data, 1, buffer.data, offset, buffer.size)
     buffer.ptr = pointer(buffer.data) + buffer.size
     if !eof(io)
-        n = min(nb_available(io), capacity(buffer) - buffer.size)
+        n = min(bytesavailable(io), capacity(buffer) - buffer.size)
         unsafe_read(io, buffer.ptr + buffer.size, n)
         buffer.size += n
     end

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -749,7 +749,7 @@ function writedlm(io::IO, a::AbstractMatrix, dlm; opts...)
             writedlm_cell(pb, a[i, j], dlm, quotes)
             j == lastc ? write(pb,'\n') : print(pb,dlm)
         end
-        (nb_available(pb) > (16*1024)) && write(io, take!(pb))
+        (bytesavailable(pb) > (16*1024)) && write(io, take!(pb))
     end
     write(io, take!(pb))
     nothing
@@ -783,7 +783,7 @@ function writedlm(io::IO, itr, dlm; opts...)
     pb = PipeBuffer()
     for row in itr
         writedlm_row(pb, row, dlm, quotes)
-        (nb_available(pb) > (16*1024)) && write(io, take!(pb))
+        (bytesavailable(pb) > (16*1024)) && write(io, take!(pb))
     end
     write(io, take!(pb))
     nothing

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -2,7 +2,7 @@
 
 using Random
 
-ioslength(io::IOBuffer) = (io.seekable ? io.size : nb_available(io))
+ioslength(io::IOBuffer) = (io.seekable ? io.size : bytesavailable(io))
 
 bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
 
@@ -232,8 +232,8 @@ let bstream = BufferStream()
     @test isopen(bstream)
     @test isreadable(bstream)
     @test iswritable(bstream)
-    @test nb_available(bstream) == 0
-    @test sprint(show, bstream) == "BufferStream() bytes waiting:$(nb_available(bstream.buffer)), isopen:true"
+    @test bytesavailable(bstream) == 0
+    @test sprint(show, bstream) == "BufferStream() bytes waiting:$(bytesavailable(bstream.buffer)), isopen:true"
     a = rand(UInt8,10)
     write(bstream,a)
     @test !eof(bstream)
@@ -243,13 +243,13 @@ let bstream = BufferStream()
     b = read(bstream,UInt8)
     @test a[2] == b
     c = zeros(UInt8,8)
-    @test nb_available(bstream) == 8
+    @test bytesavailable(bstream) == 8
     @test !eof(bstream)
     read!(bstream,c)
     @test c == a[3:10]
     @test close(bstream) === nothing
     @test eof(bstream)
-    @test nb_available(bstream) == 0
+    @test bytesavailable(bstream) == 0
 end
 
 @test flush(IOBuffer()) === nothing # should be a no-op

--- a/test/lineedit.jl
+++ b/test/lineedit.jl
@@ -332,7 +332,7 @@ let buf = IOBuffer()
     LineEdit.edit_move_left(buf)
     @test position(buf) == 0
     LineEdit.edit_move_right(buf)
-    @test nb_available(buf) == 0
+    @test bytesavailable(buf) == 0
     LineEdit.edit_backspace(buf, false, false)
     @test content(buf) == "a"
 end

--- a/test/repl.jl
+++ b/test/repl.jl
@@ -664,7 +664,7 @@ let exename = Base.julia_cmd()
             wait(p)
             output = readuntil(master,' ')
             @test output == "1\r\nquit()\r\n1\r\n\r\njulia> "
-            @test nb_available(master) == 0
+            @test bytesavailable(master) == 0
         end
     end
 

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -348,7 +348,7 @@ end
     P = Pipe()
     Base.link_pipe(P)
     write(P, "hello")
-    @test nb_available(P) == 0
+    @test bytesavailable(P) == 0
     @test !eof(P)
     @test read(P, Char) === 'h'
     @test !eof(P)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -337,13 +337,13 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(STDOUT, " 1\t", r
         @test !isopen(out)
     end
     wait(ready) # wait for writer task to be ready before using `out`
-    @test nb_available(out) == 0
+    @test bytesavailable(out) == 0
     @test endswith(readuntil(out, '1'), '1')
     @test Char(read(out, UInt8)) == '\t'
     c = UInt8[0]
     @test c == read!(out, c)
     Base.wait_readnb(out, 1)
-    @test nb_available(out) > 0
+    @test bytesavailable(out) > 0
     ln1 = readline(out)
     ln2 = readline(out)
     desc = read(out, String)
@@ -352,7 +352,7 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(STDOUT, " 1\t", r
     @test !isopen(out)
     @test infd != Base._fd(out.in) == Base.INVALID_OS_HANDLE
     @test outfd != Base._fd(out.out) == Base.INVALID_OS_HANDLE
-    @test nb_available(out) == 0
+    @test bytesavailable(out) == 0
     @test c == UInt8['w']
     @test lstrip(ln2) == "1\thello"
     @test ln1 == "orld"


### PR DESCRIPTION
`nb_available` is odd in that the prefix `nb_` is pretty non-descriptive. Thus this PR renames the function to `bytesavailable`, which I think is more descriptive. Indeed, I find the following example from the diff especially pleasant:
```julia
eof(f::File) = bytesavailable(f) == 0
```
How do you know it's EOF? There are no bytes available. :slightly_smiling_face: 