### PR TITLE
Add Fortran docs for character* and hidden arguments

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -426,6 +426,35 @@ checks and is only meant to improve readability of the call.
     ```
 
 !!! note
+    For Fortran functions taking variable length strings of type `character(len=*)` the string lengths
+    are provided as *hidden arguments*. Type and position of these arguments in the list are compiler
+    specific, where compiler vendors usually default to using `Csize_t` as type and append the hidden
+    arguments at the end of the argument list. While this behaviour is fixed for some compilers (GNU),
+    others *optionally* permit placing hidden arguments directly after the character argument (Intel,PGI). 
+    For example, Fortran subroutines of the form
+
+    ```fortran
+    subroutine test(str1, str2)
+    character(len=*) :: str1,str2
+    ```
+
+    can be called via the following Julia code, where the lengths are appended
+
+    ```julia
+    str1 = "example1"
+    str2 = "example2"
+    ccall(:test, Void, (Ptr{UInt8}, Ptr{UInt8}, Csize_t, Csize_t), 
+                        str1, str2, length(str1), length(str2))
+    ```
+    
+!!! warning    
+    Fortran compilers *may* also add other hidden arguments for pointers, assumed-shape (`:`)
+    and assumed-size (`*`) arrays. Such behaviour can be avoided by using `ISO_C_BINDING` and
+    including `bind(c)` in the defintion of the subroutine, which is strongly recommended for
+    interoperable code. In this case there will be no hidden arguments, at the cost of some
+    language features (e.g. only `character(len=1)` will be permitted to pass strings).
+
+!!! note
     A C function declared to return `Cvoid` will return the value `nothing` in Julia.
 
 ### Struct Type correspondences

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -441,10 +441,10 @@ checks and is only meant to improve readability of the call.
     can be called via the following Julia code, where the lengths are appended
 
     ```julia
-    str1 = "example1"
-    str2 = "example2"
+    str1 = "foo"
+    str2 = "bar"
     ccall(:test, Void, (Ptr{UInt8}, Ptr{UInt8}, Csize_t, Csize_t), 
-                        str1, str2, length(str1), length(str2))
+                        str1, str2, sizeof(str1), sizeof(str2))
     ```
     
 !!! warning    

--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -430,7 +430,7 @@ checks and is only meant to improve readability of the call.
     are provided as *hidden arguments*. Type and position of these arguments in the list are compiler
     specific, where compiler vendors usually default to using `Csize_t` as type and append the hidden
     arguments at the end of the argument list. While this behaviour is fixed for some compilers (GNU),
-    others *optionally* permit placing hidden arguments directly after the character argument (Intel,PGI). 
+    others *optionally* permit placing hidden arguments directly after the character argument (Intel,PGI).
     For example, Fortran subroutines of the form
 
     ```fortran
@@ -443,11 +443,11 @@ checks and is only meant to improve readability of the call.
     ```julia
     str1 = "foo"
     str2 = "bar"
-    ccall(:test, Void, (Ptr{UInt8}, Ptr{UInt8}, Csize_t, Csize_t), 
+    ccall(:test, Void, (Ptr{UInt8}, Ptr{UInt8}, Csize_t, Csize_t),
                         str1, str2, sizeof(str1), sizeof(str2))
     ```
-    
-!!! warning    
+
+!!! warning
     Fortran compilers *may* also add other hidden arguments for pointers, assumed-shape (`:`)
     and assumed-size (`*`) arrays. Such behaviour can be avoided by using `ISO_C_BINDING` and
     including `bind(c)` in the defintion of the subroutine, which is strongly recommended for


### PR DESCRIPTION
Since the Fortran part of the guide is still somewhat improvable, I have added a section for variable length strings, explaining hidden arguments and interoperability.

Fortran interfaces contain (partially compiler specific) "hidden arguments" when passing variable length strings and other stuff (see docs). These are invisible to Fortran users, but need to be passed from other languages. Usually one would preferably use ISO_C_BINDING, but in case one cannot or does not want to modify the Fortran lib, this is tricky to figure out.