### PR TITLE
WIP: turn on specialization spoofing mechanism in the compiler

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -189,7 +189,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
     cyclei = 0
     infstate = sv
     edgecycle = false
-    checked_method = method_for_inference_heuristics(method, sig, sparams, sv.params.world)
+    checked_method = method_for_specialization_heuristics(method, sig, sparams, sv.params.world)
     while !(infstate === nothing)
         infstate = infstate::InferenceState
         if infstate.linfo.specTypes == sig
@@ -199,7 +199,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
             edgecycle = true
             break
         end
-        working_method = method_for_inference_heuristics(infstate.src, infstate.linfo.def)
+        working_method = method_for_specialization_heuristics(infstate.src, infstate.linfo.def)
         if checked_method === working_method
             if topmost === nothing
                 # inspect the parent of this edge,
@@ -209,7 +209,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
                 for parent in infstate.callers_in_cycle
                     # check in the cycle list first
                     # all items in here are mutual parents of all others
-                    parent_method = method_for_inference_heuristics(parent.src, parent.linfo.def)
+                    parent_method = method_for_specialization_heuristics(parent.src, parent.linfo.def)
                     if parent_method === checked_method
                         topmost = infstate
                         edgecycle = true
@@ -220,7 +220,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
                     # then check the parent link
                     if topmost === nothing && parent !== nothing
                         parent = parent::InferenceState
-                        parent_method = method_for_inference_heuristics(parent.src, parent.linfo.def)
+                        parent_method = method_for_specialization_heuristics(parent.src, parent.linfo.def)
                         if parent.cached && parent_method === checked_method
                             topmost = infstate
                             edgecycle = true

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -217,6 +217,10 @@ function is_specializable_vararg_slot(@nospecialize(arg), sv::InferenceState)
             isa(sv.vararg_type_container, DataType))
 end
 
+function method_for_specialization_heuristics(sv::InferenceState)
+    return method_for_specialization_heuristics(sv.src, (sv.linfo.specTypes, sv.linfo.def))
+end
+
 function print_callstack(sv::InferenceState)
     while sv !== nothing
         print(sv.linfo)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -168,7 +168,7 @@ function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
                     method = linfo.def::Method
                     tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
                     tree.code = Any[ Expr(:return, quoted(linfo.inferred_const)) ]
-                    tree.signature_for_inference_heuristics = nothing
+                    tree.signature_for_specialization_heuristics = nothing
                     tree.slotnames = Any[ COMPILER_TEMP_SYM for i = 1:method.nargs ]
                     tree.slotflags = UInt8[ 0 for i = 1:method.nargs ]
                     tree.slottypes = nothing

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -151,9 +151,9 @@ function method_for_specialization_heuristics(cinfo, default)
         if isa(sig, SimpleVector) && length(sig) == 3
             methods = _methods(sig[1], sig[2], -1, sig[3])
             if length(methods) == 1
-                _, _, m = methods[]
-                if isa(m, Method)
-                    return m
+                spoofed_sig, _, spoofed_method = methods[]
+                if isa(spoofed_method, Method)
+                    return spoofed_sig, spoofed_method
                 end
             end
         end
@@ -165,10 +165,10 @@ function method_for_specialization_heuristics(method::Method, @nospecialize(sig)
     if isdefined(method, :generator) && method.generator.expand_early
         method_instance = code_for_method(method, sig, sparams, world, false)
         if isa(method_instance, MethodInstance)
-            return method_for_specialization_heuristics(get_staged(method_instance), method)
+            return method_for_specialization_heuristics(get_staged(method_instance), (sig, method))
         end
     end
-    return method
+    return (sig, method)
 end
 
 function exprtype(@nospecialize(x), src::CodeInfo, mod::Module)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -144,10 +144,10 @@ end
 
 # TODO: Use these functions instead of directly manipulating
 # the "actual" method for appropriate places in inference (see #24676)
-function method_for_inference_heuristics(cinfo, default)
+function method_for_specialization_heuristics(cinfo, default)
     if isa(cinfo, CodeInfo)
         # appropriate format for `sig` is svec(ftype, argtypes, world)
-        sig = cinfo.signature_for_inference_heuristics
+        sig = cinfo.signature_for_specialization_heuristics
         if isa(sig, SimpleVector) && length(sig) == 3
             methods = _methods(sig[1], sig[2], -1, sig[3])
             if length(methods) == 1
@@ -161,11 +161,11 @@ function method_for_inference_heuristics(cinfo, default)
     return default
 end
 
-function method_for_inference_heuristics(method::Method, @nospecialize(sig), sparams, world)
+function method_for_specialization_heuristics(method::Method, @nospecialize(sig), sparams, world)
     if isdefined(method, :generator) && method.generator.expand_early
         method_instance = code_for_method(method, sig, sparams, world, false)
         if isa(method_instance, MethodInstance)
-            return method_for_inference_heuristics(get_staged(method_instance), method)
+            return method_for_specialization_heuristics(get_staged(method_instance), method)
         end
     end
     return method

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2048,7 +2048,7 @@ void jl_init_types(void)
                         jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(10,
                             "code",
-                            "signature_for_inference_heuristics",
+                            "signature_for_specialization_heuristics",
                             "slottypes",
                             "ssavaluetypes",
                             "slotflags",

--- a/src/julia.h
+++ b/src/julia.h
@@ -229,7 +229,7 @@ typedef struct _jl_llvm_functions_t {
 // This type describes a single function body
 typedef struct _jl_code_info_t {
     jl_array_t *code;  // Any array of statements
-    jl_value_t *signature_for_inference_heuristics; // optional method used during inference
+    jl_value_t *signature_for_specialization_heuristics; // optional method used during inference
     jl_value_t *slottypes; // types of variable slots (or `nothing`)
     jl_value_t *ssavaluetypes;  // types of ssa values (or count of them)
     jl_array_t *slotflags;  // local var bit flags

--- a/src/method.c
+++ b/src/method.c
@@ -187,7 +187,7 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
                 jl_array_del_end(meta, na - ins);
         }
     }
-    li->signature_for_inference_heuristics = jl_nothing;
+    li->signature_for_specialization_heuristics = jl_nothing;
     jl_array_t *vinfo = (jl_array_t*)jl_exprarg(ast, 1);
     jl_array_t *vis = (jl_array_t*)jl_array_ptr_ref(vinfo, 0);
     size_t nslots = jl_array_len(vis);
@@ -256,7 +256,7 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
         (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t),
                                        jl_code_info_type);
     src->code = NULL;
-    src->signature_for_inference_heuristics = NULL;
+    src->signature_for_specialization_heuristics = NULL;
     src->slotnames = NULL;
     src->slotflags = NULL;
     src->slottypes = NULL;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -576,7 +576,7 @@ static jl_code_info_t *expr_to_code_info(jl_value_t *expr)
     jl_gc_wb(src, src->slotflags);
     src->ssavaluetypes = jl_box_long(0);
     jl_gc_wb(src, src->ssavaluetypes);
-    src->signature_for_inference_heuristics = jl_nothing;
+    src->signature_for_specialization_heuristics = jl_nothing;
 
     JL_GC_POP();
     return src;

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1342,7 +1342,7 @@ end
 
 function f24852_gen_cinfo_inflated(X, Y, f, x, y)
     method, code_info = f24852_kernel_cinfo(x, y)
-    code_info.signature_for_inference_heuristics = Core.Compiler.svec(f, (x, y), typemax(UInt))
+    code_info.signature_for_specialization_heuristics = Core.Compiler.svec(f, (x, y), typemax(UInt))
     return code_info
 end
 
@@ -1391,7 +1391,7 @@ result = f24852_kernel(x, y)
 @test result === f24852_early_uninflated(x, y)
 @test result === f24852_early_inflated(x, y)
 
-# TODO: test that `expand_early = true` + inflated `signature_for_inference_heuristics`
+# TODO: test that `expand_early = true` + inflated `signature_for_specialization_heuristics`
 # can be used to tighten up some inference result.
 
 # Test that Conditional doesn't get widened to Bool too quickly


### PR DESCRIPTION
Follow-up to #24852. Intends to close #24676.

The intention of this PR is to rewrite relevant parts of the compiler to respect the `signature_for_specialization_heuristics` `CodeInfo` field. I've started off with some very naive changes to `abstract_call_method` that are probably incorrect...