### PR TITLE
 Move findnz to SparseArrays module

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1995,44 +1995,6 @@ findall(testf::Function, x::Number) = !testf(x) ? Vector{Int}() : [1]
 findall(p::OccursIn, x::Number) = x in p.x ? Vector{Int}() : [1]
 
 """
-    findnz(A)
-
-Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the non-zero
-values in matrix `A`, and `V` is a vector of the non-zero values.
-
-# Examples
-```jldoctest
-julia> A = [1 2 0; 0 0 3; 0 4 0]
-3×3 Array{Int64,2}:
- 1  2  0
- 0  0  3
- 0  4  0
-
-julia> findnz(A)
-([1, 1, 3, 2], [1, 2, 2, 3], [1, 2, 4, 3])
-```
-"""
-function findnz(A::AbstractMatrix{T}) where T
-    nnzA = count(t -> t != 0, A)
-    I = zeros(Int, nnzA)
-    J = zeros(Int, nnzA)
-    NZs = Vector{T}(uninitialized, nnzA)
-    cnt = 1
-    if nnzA > 0
-        for j=axes(A,2), i=axes(A,1)
-            Aij = A[i,j]
-            if Aij != 0
-                I[cnt] = i
-                J[cnt] = j
-                NZs[cnt] = Aij
-                cnt += 1
-            end
-        end
-    end
-    return (I, J, NZs)
-end
-
-"""
     findmax(itr) -> (x, index)
 
 Return the maximum element of the collection `itr` and its index. If there are multiple

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1634,21 +1634,6 @@ end
 # For performance
 findall(::typeof(!iszero), B::BitArray) = findall(B)
 
-function findnz(B::BitMatrix)
-    nnzB = count(B)
-    I = Vector{Int}(uninitialized, nnzB)
-    J = Vector{Int}(uninitialized, nnzB)
-    cnt = 1
-    for j = 1:size(B,2), i = 1:size(B,1)
-        if B[i,j]
-            I[cnt] = i
-            J[cnt] = j
-            cnt += 1
-        end
-    end
-    return I, J, trues(length(I))
-end
-
 ## Reductions ##
 
 sum(A::BitArray, region) = reducedim(+, A, region)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1249,6 +1249,7 @@ end
 @deprecate_moved rowvals    "SparseArrays" true true
 @deprecate_moved nzrange    "SparseArrays" true true
 @deprecate_moved nnz        "SparseArrays" true true
+@deprecate_moved findnz     "SparseArrays" true true
 ## functions that were exported from Base.SparseArrays but not from Base
 @deprecate_moved droptol!   "SparseArrays" false true
 ## deprecated functions that are moved to stdlib/SparseArrays/src/deprecated.jl

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -470,7 +470,6 @@ export
     findmax!,
     findnext,
     findprev,
-    findnz,
     occursin,
     match,
     matchall,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -123,7 +123,6 @@ Base.circshift!
 Base.circcopy!
 Base.findall(::Any)
 Base.findall(::Function, ::Any)
-Base.findnz
 Base.findfirst(::Any)
 Base.findfirst(::Function, ::Any)
 Base.findlast(::Any)

--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -204,6 +204,7 @@ SparseArrays.sparse
 SparseArrays.sparsevec
 SparseArrays.issparse
 SparseArrays.nnz
+SparseArrays.findnz
 SparseArrays.spzeros
 SparseArrays.spdiagm
 SparseArrays.blkdiag

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -24,7 +24,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     sin, sinc, sind, sinh, sinpi, squeeze, start, sum, summary, tan,
     tand, tanh, trunc, abs, abs2,
     broadcast, ceil, complex, conj, convert, copy, copyto!, adjoint,
-    exp, expm1, findall, findmax, findmin, findnz, float, getindex,
+    exp, expm1, findall, findmax, findmin, float, getindex,
     vcat, hcat, hvcat, cat, imag, indmax, kron, length, log, log1p, max, min,
     maximum, minimum, one, promote_eltype, real, reshape, rot180,
     rotl90, rotr90, round, setindex!, similar, size, transpose,
@@ -35,7 +35,7 @@ using Random: defaultRNG, AbstractRNG, randsubseq, randsubseq!
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
     SparseMatrixCSC, SparseVector, blkdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
-    sprand, sprandn, spzeros, nnz, permute
+    sprand, sprandn, spzeros, nnz, permute, findnz
 
 include("abstractsparse.jl")
 include("sparsematrix.jl")

--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -63,3 +63,56 @@ function findprev(f::typeof(!iszero), v::AbstractSparseArray, i::Integer)
     end
     return j
 end
+
+"""
+    findnz(A)
+
+Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the non-zero
+values in matrix `A`, and `V` is a vector of the non-zero values.
+
+# Examples
+```jldoctest
+julia> A = [1 2 0; 0 0 3; 0 4 0]
+3×3 Array{Int64,2}:
+ 1  2  0
+ 0  0  3
+ 0  4  0
+
+julia> findnz(A)
+([1, 1, 3, 2], [1, 2, 2, 3], [1, 2, 4, 3])
+```
+"""
+function findnz(A::AbstractMatrix{T}) where T
+    nnzA = count(t -> t != 0, A)
+    I = zeros(Int, nnzA)
+    J = zeros(Int, nnzA)
+    NZs = Vector{T}(uninitialized, nnzA)
+    cnt = 1
+    if nnzA > 0
+        for j=axes(A,2), i=axes(A,1)
+            Aij = A[i,j]
+            if Aij != 0
+                I[cnt] = i
+                J[cnt] = j
+                NZs[cnt] = Aij
+                cnt += 1
+            end
+        end
+    end
+    return (I, J, NZs)
+end
+
+function findnz(B::BitMatrix)
+    nnzB = count(B)
+    I = Vector{Int}(uninitialized, nnzB)
+    J = Vector{Int}(uninitialized, nnzB)
+    cnt = 1
+    for j = 1:size(B,2), i = 1:size(B,1)
+        if B[i,j]
+            I[cnt] = i
+            J[cnt] = j
+            cnt += 1
+        end
+    end
+    return I, J, trues(length(I))
+end

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -2,7 +2,7 @@
 
 ### Common definitions
 
-import Base: sort, findall, findnz
+import Base: sort, findall
 import LinearAlgebra: promote_to_array_type, promote_to_arrays_
 
 ### The SparseVector

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -716,19 +716,9 @@ function findnz(x::SparseVector{Tv,Ti}) where {Tv,Ti}
     nzind = x.nzind
     nzval = x.nzval
 
-    count = 1
     @inbounds for i = 1 : numnz
-        if nzval[i] != 0
-            I[count] = nzind[i]
-            V[count] = nzval[i]
-            count += 1
-        end
-    end
-
-    count -= 1
-    if numnz != count
-        deleteat!(I, (count+1):numnz)
-        deleteat!(V, (count+1):numnz)
+        I[i] = nzind[i]
+        V[i] = nzval[i]
     end
 
     return (I, V)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2204,3 +2204,8 @@ end
     v[1] = 2
     @test A[1,1] == 2
 end
+
+@testset "findnz on non-sparse arrays" begin
+    @test findnz([0 1; 0 2]) == ([1, 2], [2, 2], [1, 2])
+    @test findnz(BitArray([false true; false true])) == ([1, 2], [2, 2], trues(2))
+end

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -277,7 +277,7 @@ end
     @test findnz(spv_x1) == (findall(!iszero, x1_full), filter(x->x!=0, x1_full))
     let xc = SparseVector(8, [2, 3, 5], [1.25, 0, -0.75]), fc = Array(xc)
         @test findall(!iszero, xc) == findall(!iszero, fc)
-        @test findnz(xc) == ([2, 5], [1.25, -0.75])
+        @test findnz(xc) == ([2, 3, 5], [1.25, 0, -0.75])
     end
 end
 ### Array manipulation

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -4,7 +4,7 @@ module UMFPACK
 
 export UmfpackLU
 
-import Base: (\), findnz, getproperty, show, size
+import Base: (\), getproperty, show, size
 using LinearAlgebra
 import LinearAlgebra: Factorization, det, lufact, ldiv!
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1108,10 +1108,9 @@ timesofar("datamove")
     b1 = bitrand(n1, n2)
     @check_bit_operation findall(b1) Vector{CartesianIndex{2}}
     @check_bit_operation findall(!iszero, b1) Vector{CartesianIndex{2}}
-    @check_bit_operation findnz(b1) Tuple{Vector{Int}, Vector{Int}, BitArray}
 end
 
-timesofar("nnz&find")
+timesofar("find")
 
 @testset "Findnext/findprev" begin
     b1 = trues(v1)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -363,10 +363,6 @@ pmax, ipmax = findmax(parent(A))
 z = OffsetArray([0 0; 2 0; 0 0; 0 0], (-3,-1))
 I = findall(!iszero, z)
 @test I == [CartesianIndex(-1, 0)]
-I,J,N = findnz(z)
-@test I == [-1]
-@test J == [0]
-@test N == [2]
 @test findall(!iszero,h) == [-2:1;]
 @test findall(x->x>0, h) == [-1,1]
 @test findall(x->x<0, h) == [-2,0]


### PR DESCRIPTION
Its definition (return stored entries) only makes sense in the context of sparse arrays. Closes https://github.com/JuliaLang/julia/issues/24910. Part of #10593.


The first commit should be kept separate, it fixes an inconsistency spotted at https://github.com/JuliaLang/julia/issues/24910#issuecomment-357887466.