### PR TITLE
clean some SparseArrays from base docs

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -801,39 +801,31 @@ range to efficiently index into the array with indices specified for every dimen
 other iterables, including strings and dictionaries, return an iterator object
 supporting arbitrary index types (e.g. unevenly spaced or non-integer indices).
 
-Example for a sparse 2-d array:
-
-```jldoctest
-julia> A = sparse([1, 1, 2], [1, 3, 1], [1, 2, -5])
-2×3 SparseMatrixCSC{Int64,Int64} with 3 stored entries:
-  [1, 1]  =  1
-  [2, 1]  =  -5
-  [1, 3]  =  2
-
-julia> for iter in eachindex(A)
-           @show iter.I[1], iter.I[2]
-           @show A[iter]
-       end
-(iter.I[1], iter.I[2]) = (1, 1)
-A[iter] = 1
-(iter.I[1], iter.I[2]) = (2, 1)
-A[iter] = -5
-(iter.I[1], iter.I[2]) = (1, 2)
-A[iter] = 0
-(iter.I[1], iter.I[2]) = (2, 2)
-A[iter] = 0
-(iter.I[1], iter.I[2]) = (1, 3)
-A[iter] = 2
-(iter.I[1], iter.I[2]) = (2, 3)
-A[iter] = 0
-```
-
 If you supply more than one `AbstractArray` argument, `eachindex` will create an
 iterable object that is fast for all arguments (a `UnitRange`
 if all inputs have fast linear indexing, a [`CartesianIndices`](@ref)
 otherwise).
 If the arrays have different sizes and/or dimensionalities, `eachindex` will return an
 iterable that spans the largest range along each dimension.
+
+# Examples
+```jldoctest
+julia> A = [1 2; 3 4];
+
+julia> for i in eachindex(A) # linear indexing
+           println(i)
+       end
+1
+2
+3
+4
+
+julia> for i in eachindex(view(A, 1:2, 1:1)) # Cartesian indexing
+           println(i)
+       end
+CartesianIndex(1, 1)
+CartesianIndex(2, 1)
+```
 """
 eachindex(A::AbstractArray) = (@_inline_meta(); eachindex(IndexStyle(A), A))
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -106,35 +106,14 @@ julia> convert(Rational{Int64}, x)
 6004799503160661//18014398509481984
 ```
 
-If `T` is a collection type and `x` a collection, the result of `convert(T, x)` may alias
-`x`.
+If `T` is a collection type and `x` a collection, the result of
+`convert(T, x)` may alias all or part of `x`.
 ```jldoctest
-julia> x = Int[1,2,3];
+julia> x = Int[1, 2, 3];
 
 julia> y = convert(Vector{Int}, x);
 
 julia> y === x
-true
-```
-Similarly, if `T` is a composite type and `x` a related instance, the result of
-`convert(T, x)` may alias part or all of `x`.
-```jldoctest
-julia> x = sparse(1.0I, 5, 5);
-
-julia> typeof(x)
-SparseMatrixCSC{Float64,Int64}
-
-julia> y = convert(SparseMatrixCSC{Float64,Int64}, x);
-
-julia> z = convert(SparseMatrixCSC{Float32,Int64}, y);
-
-julia> y === x
-true
-
-julia> z === x
-false
-
-julia> z.colptr === x.colptr
 true
 ```
 """

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1004,21 +1004,19 @@ See also [`accumulate`](@ref).
 
 # Examples
 ``jldoctest
-julia> x = SparseVector(7, [1, 3, 5], [2., 4., 5.]);
+julia> x = [1, 0, 2, 0, 3];
 
-julia> y = zeros(7);
+julia> y = [0, 0, 0, 0, 0];
 
 julia> accumulate!(+, y, x);
 
 julia> y
-7-element Array{Float64,1}:
-  2.0
-  2.0
-  6.0
-  6.0
- 11.0
- 11.0
- 11.0
+5-element Array{Int64,1}:
+ 1
+ 1
+ 3
+ 3
+ 6
 ```
 """
 function accumulate!(op::Op, y, x::AbstractVector) where Op

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -105,11 +105,11 @@ Get the name of field `i` of a `DataType`.
 
 # Examples
 ```jldoctest
-julia> fieldname(SparseMatrixCSC, 1)
-:m
+julia> fieldname(Rational, 1)
+:num
 
-julia> fieldname(SparseMatrixCSC, 5)
-:nzval
+julia> fieldname(Rational, 2)
+:den
 ```
 """
 function fieldname(t::DataType, i::Integer)

--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -17,7 +17,8 @@ allows you to combine these styles of indexing: for example, a 3d array `A3` can
 For `Array`s, linear indexing appeals to the underlying storage format: an array is laid out as
 a contiguous block of memory, and hence the linear index is just the offset (+1) of the corresponding
 entry relative to the beginning of the array.  However, this is not true for many other `AbstractArray`
-types: examples include [`SparseMatrixCSC`](@ref), arrays that require some kind of
+types: examples include [`SparseMatrixCSC`](@ref) from the `SparseArrays` standard library
+module, arrays that require some kind of
 computation (such as interpolation), and the type under discussion here, `SubArray`.
 For these types, the underlying information is more naturally described in terms of
 cartesian indices.

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -250,8 +250,8 @@ arrays are simple: just define `getindex(A::ArrayType, i::Int)`.  When the array
 indexed with a multidimensional set of indices, the fallback `getindex(A::AbstractArray, I...)()`
 efficiently converts the indices into one linear index and then calls the above method. `IndexCartesian()`
 arrays, on the other hand, require methods to be defined for each supported dimensionality with
-`ndims(A)` `Int` indices. For example, the built-in [`SparseMatrixCSC`](@ref) type only
-supports two dimensions, so it just defines
+`ndims(A)` `Int` indices. For example, [`SparseMatrixCSC`](@ref) from the `SparseArrays` standard
+library module, only supports two dimensions, so it just defines
 `getindex(A::SparseMatrixCSC, i::Int, j::Int)`. The same holds for `setindex!`.
 
 Returning to the sequence of squares from above, we could instead define it as a subtype of an

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -86,23 +86,12 @@ help?> @time
 
   See also @timev, @timed, @elapsed, and @allocated.
 
-help?> AbstractString
-search: AbstractString AbstractSparseMatrix AbstractSparseVector AbstractSet
+help?> Int32
+search: Int32 UInt32
 
-  No documentation found.
+  Int32 <: Signed
 
-  Summary
-  ≡≡≡≡≡≡≡≡≡
-
-  abstract type AbstractString <: Any
-
-  Subtypes
-  ≡≡≡≡≡≡≡≡≡≡
-
-  Base.SubstitutionString
-  String
-  SubString
-  Test.GenericString
+  32-bit signed integer type.
 ```
 
 Help mode can be exited by pressing backspace at the beginning of the line.


### PR DESCRIPTION
Remove some sparse related stuff from base docs, with the aim to decouple even more and make base doctest work without `SparseArrays`.