### PR TITLE
exclude delimiter by default in `readuntil`; rename `chomp` option to `keep`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -196,6 +196,9 @@ Breaking changes
 
 This section lists changes that do not have deprecation warnings.
 
+  * `readuntil` now does *not* include the delimiter in its result, matching the
+    behavior of `readline`. Pass `keep=true` to get the old behavior ([#25633]).
+
   * `getindex(s::String, r::UnitRange{Int})` now throws `UnicodeError` if `last(r)`
     is not a valid index into `s` ([#22572]).
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -236,7 +236,7 @@ parse_input_line(s::AbstractString) = parse_input_line(String(s))
 function parse_input_line(io::IO)
     s = ""
     while !eof(io)
-        s *= readline(io, chomp=false)
+        s *= readline(io, keep=true)
         e = parse_input_line(s)
         if !(isa(e,Expr) && e.head === :incomplete)
             return e

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -459,7 +459,7 @@ end
 
 @deprecate read(cmd::AbstractCmd, stdin::Redirectable) read(pipeline(stdin, cmd))
 @deprecate readstring(cmd::AbstractCmd, stdin::Redirectable) readstring(pipeline(stdin, cmd))
-@deprecate eachline(cmd::AbstractCmd, stdin; chomp::Bool=true) eachline(pipeline(stdin, cmd), chomp=chomp)
+@deprecate eachline(cmd::AbstractCmd, stdin; kw...) eachline(pipeline(stdin, cmd), kw...)
 
 @deprecate showall(x)     show(x)
 @deprecate showall(io, x) show(IOContext(io, :limit => false), x)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -444,26 +444,30 @@ function findfirst(delim::EqualTo{UInt8}, buf::GenericIOBuffer)
     return nothing
 end
 
-function readuntil(io::GenericIOBuffer, delim::UInt8)
+function readuntil(io::GenericIOBuffer, delim::UInt8; keep::Bool=false)
     lb = 70
     A = StringVector(lb)
-    n = 0
+    nread = 0
+    nout = 0
     data = io.data
     for i = io.ptr : io.size
-        n += 1
-        if n > lb
-            lb = n*2
-            resize!(A, lb)
-        end
         @inbounds b = data[i]
-        @inbounds A[n] = b
+        nread += 1
+        if keep || b != delim
+            nout += 1
+            if nout > lb
+                lb = nout*2
+                resize!(A, lb)
+            end
+            @inbounds A[nout] = b
+        end
         if b == delim
             break
         end
     end
-    io.ptr += n
-    if lb != n
-        resize!(A, n)
+    io.ptr += nread
+    if lb != nout
+        resize!(A, nout)
     end
     A
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -357,13 +357,13 @@ end
 take!(s::IOStream) =
     ccall(:jl_take_buffer, Vector{UInt8}, (Ptr{Cvoid},), s.ios)
 
-function readuntil(s::IOStream, delim::UInt8)
-    ccall(:jl_readuntil, Array{UInt8,1}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 0, 0)
+function readuntil(s::IOStream, delim::UInt8; keep::Bool=false)
+    ccall(:jl_readuntil, Array{UInt8,1}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 0, !keep)
 end
 
 # like readuntil, above, but returns a String without requiring a copy
-function readuntil_string(s::IOStream, delim::UInt8)
-    ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 1, false)
+function readuntil_string(s::IOStream, delim::UInt8, keep::Bool)
+    ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 1, !keep)
 end
 
 function readline(s::IOStream; chomp=nothing, keep::Bool=false)
@@ -371,7 +371,7 @@ function readline(s::IOStream; chomp=nothing, keep::Bool=false)
         keep = !chomp
         depwarn("The `chomp=$chomp` argument to `readline` is deprecated in favor of `keep=$keep`.", :readline)
     end
-    ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, !keep)
+    ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, keep ? 0 : 2)
 end
 
 function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -366,8 +366,12 @@ function readuntil_string(s::IOStream, delim::UInt8)
     ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, delim, 1, false)
 end
 
-function readline(s::IOStream; chomp::Bool=true)
-    ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, chomp)
+function readline(s::IOStream; chomp=nothing, keep::Bool=false)
+    if chomp !== nothing
+        keep = !chomp
+        depwarn("The `chomp=$chomp` argument to `readline` is deprecated in favor of `keep=$keep`.", :readline)
+    end
+    ccall(:jl_readuntil, Ref{String}, (Ptr{Cvoid}, UInt8, UInt8, UInt8), s.ios, '\n', 1, !keep)
 end
 
 function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1051,7 +1051,7 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
     rm(output, force=true)   # Remove file if it exists
     code_object = """
         while !eof(STDIN)
-            code = chop(readuntil(STDIN, '\\0'))
+            code = readuntil(STDIN, '\\0')
             eval(Main, Meta.parse(code))
         end
         """

--- a/base/markdown/Common/block.jl
+++ b/base/markdown/Common/block.jl
@@ -108,7 +108,7 @@ function indentcode(stream::IO, block::MD)
         buffer = IOBuffer()
         while !eof(stream)
             if startswith(stream, "    ") || startswith(stream, "\t")
-                write(buffer, readline(stream, chomp=false))
+                write(buffer, readline(stream, keep=true))
             elseif blankline(stream)
                 write(buffer, '\n')
             else
@@ -139,10 +139,10 @@ function footnote(stream::IO, block::MD)
         else
             ref = match(regex, str).captures[1]
             buffer = IOBuffer()
-            write(buffer, readline(stream, chomp=false))
+            write(buffer, readline(stream, keep=true))
             while !eof(stream)
                 if startswith(stream, "    ")
-                    write(buffer, readline(stream, chomp=false))
+                    write(buffer, readline(stream, keep=true))
                 elseif blankline(stream)
                     write(buffer, '\n')
                 else
@@ -174,7 +174,7 @@ function blockquote(stream::IO, block::MD)
         empty = true
         while eatindent(stream) && startswith(stream, '>')
             startswith(stream, " ")
-            write(buffer, readline(stream, chomp=false))
+            write(buffer, readline(stream, keep=true))
             empty = false
         end
         empty && return false
@@ -229,7 +229,7 @@ function admonition(stream::IO, block::MD)
         buffer = IOBuffer()
         while !eof(stream)
             if startswith(stream, "    ")
-                write(buffer, readline(stream, chomp=false))
+                write(buffer, readline(stream, keep=true))
             elseif blankline(stream)
                 write(buffer, '\n')
             else
@@ -305,7 +305,7 @@ function list(stream::IO, block::MD)
                 newline = false
                 if startswith(stream, " "^indent)
                     # Indented text that is part of the current list item.
-                    print(buffer, readline(stream, chomp=false))
+                    print(buffer, readline(stream, keep=true))
                 else
                     matched = startswith(stream, regex)
                     if isempty(matched)
@@ -316,7 +316,7 @@ function list(stream::IO, block::MD)
                         # Start of a new list item.
                         count += 1
                         count > 1 && pushitem!(list, buffer)
-                        print(buffer, readline(stream, chomp=false))
+                        print(buffer, readline(stream, keep=true))
                     end
                 end
             end

--- a/base/markdown/GitHub/GitHub.jl
+++ b/base/markdown/GitHub/GitHub.jl
@@ -30,7 +30,7 @@ function fencedcode(stream::IO, block::MD)
                     seek(stream, line_start)
                 end
             end
-            write(buffer, readline(stream, chomp=false))
+            write(buffer, readline(stream, keep=true))
         end
         return false
     end

--- a/base/pkg/entry.jl
+++ b/base/pkg/entry.jl
@@ -635,8 +635,8 @@ function build!(pkgs::Vector, errs::Dict, seen::Set=Set())
     mktemp() do errfile, f
         build!(pkgs, seen, errfile)
         while !eof(f)
-            pkg = chop(readuntil(f, '\0'))
-            err = chop(readuntil(f, '\0'))
+            pkg = readuntil(f, '\0')
+            err = readuntil(f, '\0')
             errs[pkg] = err
         end
     end

--- a/base/process.jl
+++ b/base/process.jl
@@ -561,13 +561,17 @@ Run a command object asynchronously, returning the resulting `Process` object.
 spawn(cmds::AbstractCmd, args...; chain::Union{ProcessChain, Nothing}=nothing) =
     spawn(cmds, spawn_opts_swallow(args...)...; chain=chain)
 
-function eachline(cmd::AbstractCmd; chomp::Bool=true)
+function eachline(cmd::AbstractCmd; chomp=nothing, keep::Bool=false)
+    if chomp !== nothing
+        keep = !chomp
+        depwarn("The `chomp=$chomp` argument to `eachline` is deprecated in favor of `keep=$keep`.", :eachline)
+    end
     stdout = Pipe()
     processes = spawn(cmd, (DevNull,stdout,STDERR))
     close(stdout.in)
     out = stdout.out
     # implicitly close after reading lines, since we opened
-    return EachLine(out, chomp=chomp,
+    return EachLine(out, keep=keep,
         ondone=()->(close(out); success(processes) || pipeline_error(processes)))::EachLine
 end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -840,11 +840,11 @@ function readavailable(this::LibuvStream)
     return take!(buf)
 end
 
-function readuntil(this::LibuvStream, c::UInt8)
+function readuntil(this::LibuvStream, c::UInt8; keep::Bool=false)
     wait_readbyte(this, c)
     buf = this.buffer
     @assert buf.seekable == false
-    return readuntil(buf, c)
+    return readuntil(buf, c, keep=keep)
 end
 
 uv_write(s::LibuvStream, p::Vector{UInt8}) = uv_write(s, pointer(p), UInt(sizeof(p)))

--- a/base/util.jl
+++ b/base/util.jl
@@ -458,7 +458,7 @@ function prompt(message::AbstractString; default::AbstractString="", password::B
         uinput = getpass(msg)
     else
         print(msg)
-        uinput = readline(chomp=false)
+        uinput = readline(keep=true)
         isempty(uinput) && return nothing  # Encountered an EOF
         uinput = chomp(uinput)
     end

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1816,8 +1816,7 @@ function setup_search_keymap(hp)
         # Bracketed paste mode
         "\e[200~" => (s,data,c)-> begin
             ps = state(s, mode(s))
-            str = readuntil(ps.terminal, "\e[201~")
-            input = str[1:prevind(str, end-5)]
+            input = readuntil(ps.terminal, "\e[201~", keep=true)
             edit_insert(data.query_buffer, input); update_display_buffer(s, data)
         end,
         "*"       => (s,data,c)->(edit_insert(data.query_buffer, c); update_display_buffer(s, data))
@@ -1881,8 +1880,7 @@ end
 
 function bracketed_paste(s; tabwidth=options(s).tabwidth)
     ps = state(s, mode(s))
-    str = readuntil(ps.terminal, "\e[201~")
-    input = str[1:prevind(str, end-5)]
+    input = readuntil(ps.terminal, "\e[201~")
     input = replace(input, '\r' => '\n')
     if position(buffer(s)) == 0
         indent = Base.indentation(input; tabwidth=tabwidth)[1]

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -381,7 +381,7 @@ function refresh_multi_line(termbuf::TerminalBuffer, terminal::UnixTerminal, buf
     seek(buf, 0)
     moreinput = true # add a blank line if there is a trailing newline on the last line
     while moreinput
-        l = readline(buf, chomp=false)
+        l = readline(buf, keep=true)
         moreinput = endswith(l, "\n")
         # We need to deal with on-screen characters, so use textwidth to compute occupied columns
         llength = textwidth(l)

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -207,7 +207,7 @@ function run_frontend(repl::BasicREPL, backend::REPLBackendRef)
         interrupted = false
         while true
             try
-                line *= readline(repl.terminal, chomp=false)
+                line *= readline(repl.terminal, keep=true)
             catch e
                 if isa(e,InterruptException)
                     try # raise the debugger if present
@@ -378,7 +378,7 @@ An editor may have converted tabs to spaces at line """
 
 function hist_getline(file)
     while !eof(file)
-        line = readline(file, chomp=false)
+        line = readline(file, keep=true)
         isempty(line) && return line
         line[1] in "\r\n" || return line
     end
@@ -1112,7 +1112,7 @@ function run_frontend(repl::StreamREPL, backend::REPLBackendRef)
         if have_color
             print(repl.stream, input_color(repl))
         end
-        line = readline(repl.stream, chomp=false)
+        line = readline(repl.stream, keep=true)
         if !isempty(line)
             ast = Base.parse_input_line(line)
             if have_color

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -116,11 +116,11 @@ fake_repl() do stdin_write, stdout_read, repl
     #    write(stdin_write, ";")
     #    readuntil(stdout_read, "shell> ")
     #    write(stdin_write, "echo hello >/dev/null\n")
-    #    let s = readuntil(stdout_read, "\n")
+    #    let s = readuntil(stdout_read, "\n", keep=true)
     #        @test contains(s, "shell> ") # make sure we echoed the prompt
     #        @test contains(s, "echo hello >/dev/null") # make sure we echoed the input
     #    end
-    #    @test readuntil(stdout_read, "\n") == "\e[0m\n"
+    #    @test readuntil(stdout_read, "\n", keep=true) == "\e[0m\n"
     #end
 
     # issue #20771
@@ -147,7 +147,7 @@ fake_repl() do stdin_write, stdout_read, repl
     #            @test contains(s, "shell> ") # make sure we echoed the prompt
     #            @test contains(s, "echo \$123 >$tmp") # make sure we echoed the input
     #        end
-    #        @test readuntil(stdout_read, "\n") == "\e[0m\n"
+    #        @test readuntil(stdout_read, "\n", keep=true) == "\e[0m\n"
     #        @test read(tmp, String) == "123\n"
     #    finally
     #        rm(tmp, force=true)
@@ -165,7 +165,7 @@ fake_repl() do stdin_write, stdout_read, repl
             Base.print_shell_escaped(stdin_write, Base.julia_cmd().exec..., special=Base.shell_special)
             write(stdin_write, """ -e "println(\\"HI\\")"\n""")
             while true
-                s = readuntil(stdout_read, "\n")
+                s = readuntil(stdout_read, "\n", keep=true)
                 s == "\e[0m\n" && break # the child has exited
                 @test contains(s, "shell> ") # check for the echo of the prompt
             end
@@ -597,13 +597,13 @@ fake_repl() do stdin_write, stdout_read, repl
     sendrepl2("""\e[200~julia> begin\n           α=1\n           β=2\n       end\n\e[201~""")
     wait(c)
     readuntil(stdout_read, "begin")
-    @test readuntil(stdout_read, "end") == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
+    @test readuntil(stdout_read, "end", keep=true) == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
     # for incomplete input (`end` below is added after the end of bracket paste)
     sendrepl2("""\e[200~julia> begin\n           α=1\n           β=2\n\e[201~end""")
     wait(c)
     readuntil(stdout_read, "begin")
     readuntil(stdout_read, "begin")
-    @test readuntil(stdout_read, "end") == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
+    @test readuntil(stdout_read, "end", keep=true) == "\n\r\e[7C    α=1\n\r\e[7C    β=2\n\r\e[7Cend"
 
     # Close repl
     write(stdin_write, '\x04')
@@ -659,7 +659,7 @@ let exename = Base.julia_cmd()
             nENV = copy(ENV)
             nENV["TERM"] = "dumb"
             p = spawn(setenv(`$exename --startup-file=no -q`,nENV),slave,slave,slave)
-            output = readuntil(master,"julia> ")
+            output = readuntil(master,"julia> ",keep=true)
             if ccall(:jl_running_on_valgrind,Cint,()) == 0
                 # If --trace-children=yes is passed to valgrind, we will get a
                 # valgrind banner here, not just the prompt.
@@ -668,7 +668,7 @@ let exename = Base.julia_cmd()
             write(master,"1\nquit()\n")
 
             wait(p)
-            output = readuntil(master,' ')
+            output = readuntil(master,' ',keep=true)
             @test output == "1\r\nquit()\r\n1\r\n\r\njulia> "
             @test bytesavailable(master) == 0
         end
@@ -825,7 +825,7 @@ for keys = [altkeys, merge(altkeys...)],
             close(repl.interface.modes[1].hist.history_file)
 
             # Check that the correct prompt was displayed
-            output = readuntil(stdout_read, "1 * 1;")
+            output = readuntil(stdout_read, "1 * 1;", keep=true)
             @test !contains(LineEdit.prompt_string(altprompt), output)
             @test !contains("julia> ", output)
 

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -91,7 +91,7 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=10, debug::Bool
 
         try
             for (challenge, response) in challenges
-                write(out, readuntil(master, challenge))
+                write(out, readuntil(master, challenge, keep=true))
                 if !isopen(master)
                     error("Could not locate challenge: \"$challenge\". ",
                           format_output(out))

--- a/test/file.jl
+++ b/test/file.jl
@@ -252,7 +252,7 @@ end
 emptyfile = joinpath(dir, "empty")
 touch(emptyfile)
 emptyf = open(emptyfile)
-@test isempty(readlines(emptyf, chomp=false))
+@test isempty(readlines(emptyf, keep=true))
 close(emptyf)
 rm(emptyfile)
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -81,20 +81,20 @@ Base.compact(io)
 @test write(io,"pancakes\nwaffles\nblueberries\n") > 0
 @test readlines(io) == String["pancakes", "waffles", "blueberries"]
 write(io,"\n\r\n\n\r \n") > 0
-@test readlines(io, chomp=false) == String["\n", "\r\n", "\n", "\r \n"]
+@test readlines(io, keep=true) == String["\n", "\r\n", "\n", "\r \n"]
 write(io,"\n\r\n\n\r \n") > 0
-@test readlines(io, chomp=true) == String["", "", "", "\r "]
+@test readlines(io, keep=false) == String["", "", "", "\r "]
 @test write(io,"α\nβ\nγ\nδ") > 0
-@test readlines(io, chomp=false) == String["α\n","β\n","γ\n","δ"]
+@test readlines(io, keep=true) == String["α\n","β\n","γ\n","δ"]
 @test write(io,"α\nβ\nγ\nδ") > 0
-@test readlines(io, chomp=true) == String["α", "β", "γ", "δ"]
-@test readlines(IOBuffer(""), chomp=false) == []
-@test readlines(IOBuffer(""), chomp=true) == []
-@test readlines(IOBuffer("first\nsecond"), chomp=false) == String["first\n", "second"]
-@test readlines(IOBuffer("first\nsecond"), chomp=true) == String["first", "second"]
+@test readlines(io, keep=false) == String["α", "β", "γ", "δ"]
+@test readlines(IOBuffer(""), keep=true) == []
+@test readlines(IOBuffer(""), keep=false) == []
+@test readlines(IOBuffer("first\nsecond"), keep=true) == String["first\n", "second"]
+@test readlines(IOBuffer("first\nsecond"), keep=false) == String["first", "second"]
 
 let fname = tempname()
-    for dochomp in [true, false],
+    for dokeep in [true, false],
         endline in ["\n", "\r\n"],
         i in -5:5
 
@@ -102,8 +102,8 @@ let fname = tempname()
         open(fname, "w") do io
             write(io, ref)
         end
-        x = readlines(fname, chomp = dochomp)
-        if dochomp
+        x = readlines(fname, keep = dokeep)
+        if !dokeep
             ref = chomp(ref)
         end
         @test ref == x[1]
@@ -170,7 +170,7 @@ let io = IOBuffer("abcdef"),
     @test eof(io)
 end
 
-@test isempty(readlines(IOBuffer(), chomp=false))
+@test isempty(readlines(IOBuffer(), keep=true))
 
 # issue #8193
 let io=IOBuffer("asdf")

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -32,11 +32,11 @@ end
 let b = IOBuffer("foo\n")
     @test collect(EachLine(b)) == ["foo"]
     seek(b, 0)
-    @test collect(EachLine(b, chomp=false)) == ["foo\n"]
+    @test collect(EachLine(b, keep=true)) == ["foo\n"]
     seek(b, 0)
     @test collect(EachLine(b, ondone=()->0)) == ["foo"]
     seek(b, 0)
-    @test collect(EachLine(b, chomp=false, ondone=()->0)) == ["foo\n"]
+    @test collect(EachLine(b, keep=true, ondone=()->0)) == ["foo\n"]
 end
 
 # enumerate (issue #6284)

--- a/test/perf/shootout/revcomp.jl
+++ b/test/perf/shootout/revcomp.jl
@@ -43,7 +43,7 @@ function revcomp(infile="revcomp-input.txt")
     input = open(infile, "r")
     buff = UInt8[]
     while true
-        line = readuntil(input, UInt8('\n'))
+        line = readuntil(input, UInt8('\n'), keep=true)
         if isempty(line)
 #            print_buff(buff)
             return

--- a/test/read.jl
+++ b/test/read.jl
@@ -147,27 +147,32 @@ for (name, f) in l
     end
 
     verbose && println("$name readuntil...")
-    for (t, s, m) in [
-            ("a", "ab", "a"),
-            ("b", "ab", "b"),
-            ("α", "αγ", "α"),
-            ("ab", "abc", "ab"),
-            ("bc", "abc", "bc"),
-            ("αβ", "αβγ", "αβ"),
-            ("aaabc", "ab", "aaab"),
-            ("aaabc", "ac", "aaabc"),
-            ("aaabc", "aab", "aaab"),
-            ("aaabc", "aac", "aaabc"),
-            ("αααβγ", "αβ", "αααβ"),
-            ("αααβγ", "ααβ", "αααβ"),
-            ("αααβγ", "αγ", "αααβγ"),
-            ("barbarbarians", "barbarian", "barbarbarian")]
-        local t, s, m
+    for (t, s, m, kept) in [
+            ("a", "ab", "a", "a"),
+            ("b", "ab", "b", "b"),
+            ("α", "αγ", "α", "α"),
+            ("ab", "abc", "ab", "ab"),
+            ("bc", "abc", "bc", "bc"),
+            ("αβ", "αβγ", "αβ", "αβ"),
+            ("aaabc", "ab", "aa", "aaab"),
+            ("aaabc", "ac", "aaabc", "aaabc"),
+            ("aaabc", "aab", "a", "aaab"),
+            ("aaabc", "aac", "aaabc", "aaabc"),
+            ("αααβγ", "αβ", "αα", "αααβ"),
+            ("αααβγ", "ααβ", "α", "αααβ"),
+            ("αααβγ", "αγ", "αααβγ", "αααβγ"),
+            ("barbarbarians", "barbarian", "bar", "barbarbarian")]
+        local t, s, m, kept
         @test readuntil(io(t), s) == m
+        @test readuntil(io(t), s, keep=true) == kept
         @test readuntil(io(t), SubString(s, start(s), endof(s))) == m
+        @test readuntil(io(t), SubString(s, start(s), endof(s)), keep=true) == kept
         @test readuntil(io(t), GenericString(s)) == m
+        @test readuntil(io(t), GenericString(s), keep=true) == kept
         @test readuntil(io(t), unsafe_wrap(Vector{UInt8},s)) == unsafe_wrap(Vector{UInt8},m)
+        @test readuntil(io(t), unsafe_wrap(Vector{UInt8},s), keep=true) == unsafe_wrap(Vector{UInt8},kept)
         @test readuntil(io(t), collect(s)::Vector{Char}) == Vector{Char}(m)
+        @test readuntil(io(t), collect(s)::Vector{Char}, keep=true) == Vector{Char}(kept)
     end
     cleanup()
 
@@ -263,12 +268,14 @@ for (name, f) in l
 
 
         verbose && println("$name readuntil...")
-        @test readuntil(io(), '\n') == readuntil(IOBuffer(text),'\n')
-        @test readuntil(io(), '\n') == readuntil(filename,'\n')
-        @test readuntil(io(), "\n") == readuntil(IOBuffer(text),"\n")
-        @test readuntil(io(), "\n") == readuntil(filename,"\n")
-        @test readuntil(io(), ',')  == readuntil(IOBuffer(text),',')
-        @test readuntil(io(), ',')  == readuntil(filename,',')
+        for keep in [false, true]
+            @test readuntil(io(), '\n', keep=keep) == readuntil(IOBuffer(text),'\n', keep=keep)
+            @test readuntil(io(), '\n', keep=keep) == readuntil(filename,'\n', keep=keep)
+            @test readuntil(io(), "\n", keep=keep) == readuntil(IOBuffer(text),"\n", keep=keep)
+            @test readuntil(io(), "\n", keep=keep) == readuntil(filename,"\n", keep=keep)
+            @test readuntil(io(), ',', keep=keep)  == readuntil(IOBuffer(text),',', keep=keep)
+            @test readuntil(io(), ',', keep=keep)  == readuntil(filename,',', keep=keep)
+        end
 
         cleanup()
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -273,16 +273,16 @@ for (name, f) in l
         cleanup()
 
         verbose && println("$name readline...")
-        @test readline(io(), chomp=false) == readline(IOBuffer(text), chomp=false)
-        @test readline(io(), chomp=false) == readline(filename, chomp=false)
+        @test readline(io(), keep=true) == readline(IOBuffer(text), keep=true)
+        @test readline(io(), keep=true) == readline(filename, keep=true)
 
         verbose && println("$name readlines...")
-        @test readlines(io(), chomp=false) == readlines(IOBuffer(text), chomp=false)
-        @test readlines(io(), chomp=false) == readlines(filename, chomp=false)
+        @test readlines(io(), keep=true) == readlines(IOBuffer(text), keep=true)
+        @test readlines(io(), keep=true) == readlines(filename, keep=true)
         @test readlines(io()) == readlines(IOBuffer(text))
         @test readlines(io()) == readlines(filename)
-        @test collect(eachline(io(), chomp=false)) == collect(eachline(IOBuffer(text), chomp=false))
-        @test collect(eachline(io(), chomp=false)) == collect(eachline(filename, chomp=false))
+        @test collect(eachline(io(), keep=true)) == collect(eachline(IOBuffer(text), keep=true))
+        @test collect(eachline(io(), keep=true)) == collect(eachline(filename, keep=true))
         @test collect(eachline(io())) == collect(eachline(IOBuffer(text)))
         @test collect(@inferred(eachline(io()))) == collect(@inferred(eachline(filename))) #20351
 

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -371,7 +371,7 @@ end
     @test isopen(P) # without an active uv_reader, P shouldn't be closed yet
     @test !eof(P) # should already know this,
     @test isopen(P) #  so it still shouldn't have an active uv_reader
-    @test readuntil(P, 'w') == "llow"
+    @test readuntil(P, 'w') == "llo"
     Sys.iswindows() && wait(t)
     @test eof(P)
     @test !isopen(P) # eof test should have closed this by now

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -338,7 +338,7 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(STDOUT, " 1\t", r
     end
     wait(ready) # wait for writer task to be ready before using `out`
     @test bytesavailable(out) == 0
-    @test endswith(readuntil(out, '1'), '1')
+    @test endswith(readuntil(out, '1', keep=true), '1')
     @test Char(read(out, UInt8)) == '\t'
     c = UInt8[0]
     @test c == read!(out, c)


### PR DESCRIPTION
The first (less important) commit just renames the existing `chomp` argument to `readline` to `keep`, with the opposite meaning. The second commit adds the `keep` option to `readuntil`, and makes the function exclude the delimiter by default, to match `readline`.

Fixes #25633.
