### PR TITLE
Rename bytesavailable (née nb_available) to nbytesavailable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -690,7 +690,7 @@ Deprecated or removed
 
   * `read(::IO, ::Ref)` is now a method of `read!`, since it mutates its `Ref` argument ([#21592]).
 
-  * `nb_available` is now `bytesavailable` ([#25634]).
+  * `nb_available` is now `nbytesavailable` ([#25634]).
 
   * `skipchars(io::IO, predicate; linecomment=nothing)` is deprecated in favor of
     `skipchars(predicate, io::IO; linecomment=nothing)` ([#25667]).

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1589,7 +1589,7 @@ end
 @deprecate gc_enable GC.enable
 @eval @deprecate $(Symbol("@gc_preserve")) GC.$(Symbol("@preserve")) false
 
-@deprecate nb_available bytesavailable
+@deprecate nb_available nbytesavailable
 
 @deprecate skipchars(io::IO, predicate; linecomment=nothing) skipchars(predicate, io, linecomment=linecomment)
 # this method is to avoid ambiguity, delete at the same time as deprecation of skipchars above:

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -856,7 +856,7 @@ export
     listenany,
     ltoh,
     mark,
-    bytesavailable,
+    nbytesavailable,
     ntoh,
     open,
     pipeline,

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -40,7 +40,7 @@ export File,
 
 import Base:
     UVError, _sizeof_uv_fs, check_open, close, eof, eventloop, fd, isopen,
-    bytesavailable, position, read, read!, readavailable, seek, seekend, show,
+    nbytesavailable, position, read, read!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, transcode, uv_error, uvhandle,
     uvtype, write
 using Base: coalesce
@@ -179,12 +179,12 @@ function unsafe_read(f::File, p::Ptr{UInt8}, nel::UInt)
     nothing
 end
 
-bytesavailable(f::File) = max(0, filesize(f) - position(f)) # position can be > filesize
+nbytesavailable(f::File) = max(0, filesize(f) - position(f)) # position can be > filesize
 
-eof(f::File) = bytesavailable(f) == 0
+eof(f::File) = nbytesavailable(f) == 0
 
 function readbytes!(f::File, b::Array{UInt8}, nb=length(b))
-    nr = min(nb, bytesavailable(f))
+    nr = min(nb, nbytesavailable(f))
     if length(b) < nr
         resize!(b, nr)
     end
@@ -193,9 +193,9 @@ function readbytes!(f::File, b::Array{UInt8}, nb=length(b))
     uv_error("read",ret)
     return ret
 end
-read(io::File) = read!(io, Base.StringVector(bytesavailable(io)))
+read(io::File) = read!(io, Base.StringVector(nbytesavailable(io)))
 readavailable(io::File) = read(io)
-read(io::File, nb::Integer) = read!(io, Base.StringVector(min(nb, bytesavailable(io))))
+read(io::File, nb::Integer) = read!(io, Base.StringVector(min(nb, nbytesavailable(io))))
 
 const SEEK_SET = Int32(0)
 const SEEK_CUR = Int32(1)

--- a/base/io.jl
+++ b/base/io.jl
@@ -65,7 +65,7 @@ function wait_connected end
 function wait_readnb end
 function wait_readbyte end
 function wait_close end
-function bytesavailable end
+function nbytesavailable end
 
 """
     readavailable(stream)
@@ -243,7 +243,7 @@ wait_readbyte(io::AbstractPipe, byte::UInt8) = wait_readbyte(pipe_reader(io), by
 wait_close(io::AbstractPipe) = (wait_close(pipe_writer(io)); wait_close(pipe_reader(io)))
 
 """
-    bytesavailable(io)
+    nbytesavailable(io)
 
 Return the number of bytes available for reading before a read from this stream or buffer will block.
 
@@ -251,11 +251,11 @@ Return the number of bytes available for reading before a read from this stream 
 ```jldoctest
 julia> io = IOBuffer("JuliaLang is a GitHub organization");
 
-julia> bytesavailable(io)
+julia> nbytesavailable(io)
 34
 ```
 """
-bytesavailable(io::AbstractPipe) = bytesavailable(pipe_reader(io))
+nbytesavailable(io::AbstractPipe) = nbytesavailable(pipe_reader(io))
 
 """
     eof(stream) -> Bool

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -147,7 +147,7 @@ show(io::IO, b::GenericIOBuffer) = print(io, "IOBuffer(data=UInt8[...], ",
 
 function unsafe_read(from::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
-    avail = bytesavailable(from)
+    avail = nbytesavailable(from)
     adv = min(avail, nb)
     GC.@preserve from unsafe_copyto!(p, pointer(from.data, from.ptr), adv)
     from.ptr += adv
@@ -200,8 +200,8 @@ iswritable(io::GenericIOBuffer) = io.writable
 
 # TODO: GenericIOBuffer is not iterable, so doesn't really have a length.
 # This should maybe be sizeof() instead.
-#length(io::GenericIOBuffer) = (io.seekable ? io.size : bytesavailable(io))
-bytesavailable(io::GenericIOBuffer) = io.size - io.ptr + 1
+#length(io::GenericIOBuffer) = (io.seekable ? io.size : nbytesavailable(io))
+nbytesavailable(io::GenericIOBuffer) = io.size - io.ptr + 1
 position(io::GenericIOBuffer) = io.ptr-1
 
 function skip(io::GenericIOBuffer, n::Integer)
@@ -251,10 +251,10 @@ function compact(io::GenericIOBuffer)
     if ismarked(io) && io.mark < io.ptr
         if io.mark == 0 return end
         ptr = io.mark
-        bytes_to_move = bytesavailable(io) + (io.ptr-io.mark)
+        bytes_to_move = nbytesavailable(io) + (io.ptr-io.mark)
     else
         ptr = io.ptr
-        bytes_to_move = bytesavailable(io)
+        bytes_to_move = nbytesavailable(io)
     end
     copyto!(io.data, 1, io.data, ptr, bytes_to_move)
     io.size -= ptr - 1
@@ -305,7 +305,7 @@ eof(io::GenericIOBuffer) = (io.ptr-1 == io.size)
     nothing
 end
 
-isopen(io::GenericIOBuffer) = io.readable || io.writable || io.seekable || bytesavailable(io) > 0
+isopen(io::GenericIOBuffer) = io.readable || io.writable || io.seekable || nbytesavailable(io) > 0
 
 """
     take!(b::IOBuffer)
@@ -330,7 +330,7 @@ function take!(io::GenericIOBuffer)
         nbytes = io.size
         data = copyto!(StringVector(nbytes), 1, io.data, 1, nbytes)
     else
-        nbytes = bytesavailable(io)
+        nbytes = nbytesavailable(io)
         data = read!(io,StringVector(nbytes))
     end
     if io.writable
@@ -351,7 +351,7 @@ function take!(io::IOBuffer)
         end
         resize!(data,io.size)
     else
-        nbytes = bytesavailable(io)
+        nbytes = nbytesavailable(io)
         a = StringVector(nbytes)
         data = read!(io, a)
     end
@@ -367,7 +367,7 @@ function write(to::GenericIOBuffer, from::GenericIOBuffer)
         from.ptr = from.size + 1
         return 0
     end
-    written::Int = write_sub(to, from.data, from.ptr, bytesavailable(from))
+    written::Int = write_sub(to, from.data, from.ptr, nbytesavailable(from))
     from.ptr += written
     return written
 end
@@ -415,20 +415,20 @@ end
 
 readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb=length(b)) = readbytes!(io, b, Int(nb))
 function readbytes!(io::GenericIOBuffer, b::Array{UInt8}, nb::Int)
-    nr = min(nb, bytesavailable(io))
+    nr = min(nb, nbytesavailable(io))
     if length(b) < nr
         resize!(b, nr)
     end
     read_sub(io, b, 1, nr)
     return nr
 end
-read(io::GenericIOBuffer) = read!(io,StringVector(bytesavailable(io)))
+read(io::GenericIOBuffer) = read!(io,StringVector(nbytesavailable(io)))
 readavailable(io::GenericIOBuffer) = read(io)
-read(io::GenericIOBuffer, nb::Integer) = read!(io,StringVector(min(nb, bytesavailable(io))))
+read(io::GenericIOBuffer, nb::Integer) = read!(io,StringVector(min(nb, nbytesavailable(io))))
 
 function findfirst(delim::EqualTo{UInt8}, buf::IOBuffer)
     p = pointer(buf.data, buf.ptr)
-    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim.x,bytesavailable(buf))
+    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim.x,nbytesavailable(buf))
     q == C_NULL && return nothing
     return Int(q-p+1)
 end
@@ -472,10 +472,10 @@ end
 function _crc32c(io::IOBuffer, nb::Integer, crc::UInt32=0x00000000)
     nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0"))
     io.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
-    n = min(nb, bytesavailable(io))
+    n = min(nb, nbytesavailable(io))
     n == 0 && return crc
     crc = GC.@preserve io unsafe_crc32c(pointer(io.data, io.ptr), n, crc)
     io.ptr += n
     return crc
 end
-_crc32c(io::IOBuffer, crc::UInt32=0x00000000) = _crc32c(io, bytesavailable(io), crc)
+_crc32c(io::IOBuffer, crc::UInt32=0x00000000) = _crc32c(io, nbytesavailable(io), crc)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -326,9 +326,9 @@ function unsafe_write(s::IOStream, p::Ptr{UInt8}, nb::UInt)
 end
 
 # num bytes available without blocking
-bytesavailable(s::IOStream) = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
+nbytesavailable(s::IOStream) = ccall(:jl_nb_available, Int32, (Ptr{Cvoid},), s.ios)
 
-readavailable(s::IOStream) = read!(s, Vector{UInt8}(uninitialized, bytesavailable(s)))
+readavailable(s::IOStream) = read!(s, Vector{UInt8}(uninitialized, nbytesavailable(s)))
 
 function read(s::IOStream, ::Type{UInt8})
     b = ccall(:ios_getc, Cint, (Ptr{Cvoid},), s.ios)

--- a/base/socket.jl
+++ b/base/socket.jl
@@ -326,7 +326,7 @@ function TCPServer(; delay=true)
     return tcp
 end
 
-isreadable(io::TCPSocket) = isopen(io) || bytesavailable(io) > 0
+isreadable(io::TCPSocket) = isopen(io) || nbytesavailable(io) > 0
 iswritable(io::TCPSocket) = isopen(io) && io.status != StatusClosing
 
 ## VARIOUS METHODS TO BE MOVED TO BETTER LOCATION

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -137,7 +137,7 @@ Base.getsockname
 Base.getpeername
 Base.IPv4
 Base.IPv6
-Base.bytesavailable
+Base.nbytesavailable
 Base.accept
 Base.listenany
 Base.bind

--- a/stdlib/Base64/src/buffer.jl
+++ b/stdlib/Base64/src/buffer.jl
@@ -30,7 +30,7 @@ function read_to_buffer(io::IO, buffer::Buffer)
     copyto!(buffer.data, 1, buffer.data, offset, buffer.size)
     buffer.ptr = pointer(buffer.data) + buffer.size
     if !eof(io)
-        n = min(bytesavailable(io), capacity(buffer) - buffer.size)
+        n = min(nbytesavailable(io), capacity(buffer) - buffer.size)
         unsafe_read(io, buffer.ptr + buffer.size, n)
         buffer.size += n
     end

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -749,7 +749,7 @@ function writedlm(io::IO, a::AbstractMatrix, dlm; opts...)
             writedlm_cell(pb, a[i, j], dlm, quotes)
             j == lastc ? write(pb,'\n') : print(pb,dlm)
         end
-        (bytesavailable(pb) > (16*1024)) && write(io, take!(pb))
+        (nbytesavailable(pb) > (16*1024)) && write(io, take!(pb))
     end
     write(io, take!(pb))
     nothing
@@ -783,7 +783,7 @@ function writedlm(io::IO, itr, dlm; opts...)
     pb = PipeBuffer()
     for row in itr
         writedlm_row(pb, row, dlm, quotes)
-        (bytesavailable(pb) > (16*1024)) && write(io, take!(pb))
+        (nbytesavailable(pb) > (16*1024)) && write(io, take!(pb))
     end
     write(io, take!(pb))
     nothing

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -887,7 +887,7 @@ function setup_interface(
             sbuffer = LineEdit.buffer(s)
             curspos = position(sbuffer)
             seek(sbuffer, 0)
-            shouldeval = (bytesavailable(sbuffer) == curspos && findfirst(equalto(UInt8('\n')), sbuffer) === nothing)
+            shouldeval = (nbytesavailable(sbuffer) == curspos && findfirst(equalto(UInt8('\n')), sbuffer) === nothing)
             seek(sbuffer, curspos)
             if curspos == 0
                 # if pasting at the beginning, strip leading whitespace

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -338,7 +338,7 @@ let buf = IOBuffer()
     LineEdit.edit_move_left(buf)
     @test position(buf) == 0
     LineEdit.edit_move_right(buf)
-    @test bytesavailable(buf) == 0
+    @test nbytesavailable(buf) == 0
     LineEdit.edit_backspace(buf, false, false)
     @test content(buf) == "a"
 end

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -670,7 +670,7 @@ let exename = Base.julia_cmd()
             wait(p)
             output = readuntil(master,' ')
             @test output == "1\r\nquit()\r\n1\r\n\r\njulia> "
-            @test bytesavailable(master) == 0
+            @test nbytesavailable(master) == 0
         end
     end
 

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -2,7 +2,7 @@
 
 using Random
 
-ioslength(io::IOBuffer) = (io.seekable ? io.size : bytesavailable(io))
+ioslength(io::IOBuffer) = (io.seekable ? io.size : nbytesavailable(io))
 
 bufcontents(io::Base.GenericIOBuffer) = unsafe_string(pointer(io.data), io.size)
 
@@ -232,8 +232,8 @@ let bstream = BufferStream()
     @test isopen(bstream)
     @test isreadable(bstream)
     @test iswritable(bstream)
-    @test bytesavailable(bstream) == 0
-    @test sprint(show, bstream) == "BufferStream() bytes waiting:$(bytesavailable(bstream.buffer)), isopen:true"
+    @test nbytesavailable(bstream) == 0
+    @test sprint(show, bstream) == "BufferStream() bytes waiting:$(nbytesavailable(bstream.buffer)), isopen:true"
     a = rand(UInt8,10)
     write(bstream,a)
     @test !eof(bstream)
@@ -243,13 +243,13 @@ let bstream = BufferStream()
     b = read(bstream,UInt8)
     @test a[2] == b
     c = zeros(UInt8,8)
-    @test bytesavailable(bstream) == 8
+    @test nbytesavailable(bstream) == 8
     @test !eof(bstream)
     read!(bstream,c)
     @test c == a[3:10]
     @test close(bstream) === nothing
     @test eof(bstream)
-    @test bytesavailable(bstream) == 0
+    @test nbytesavailable(bstream) == 0
 end
 
 @test flush(IOBuffer()) === nothing # should be a no-op

--- a/test/socket.jl
+++ b/test/socket.jl
@@ -348,7 +348,7 @@ end
     P = Pipe()
     Base.link_pipe(P)
     write(P, "hello")
-    @test bytesavailable(P) == 0
+    @test nbytesavailable(P) == 0
     @test !eof(P)
     @test read(P, Char) === 'h'
     @test !eof(P)

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -337,13 +337,13 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(STDOUT, " 1\t", r
         @test !isopen(out)
     end
     wait(ready) # wait for writer task to be ready before using `out`
-    @test bytesavailable(out) == 0
+    @test nbytesavailable(out) == 0
     @test endswith(readuntil(out, '1'), '1')
     @test Char(read(out, UInt8)) == '\t'
     c = UInt8[0]
     @test c == read!(out, c)
     Base.wait_readnb(out, 1)
-    @test bytesavailable(out) > 0
+    @test nbytesavailable(out) > 0
     ln1 = readline(out)
     ln2 = readline(out)
     desc = read(out, String)
@@ -352,7 +352,7 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(STDOUT, " 1\t", r
     @test !isopen(out)
     @test infd != Base._fd(out.in) == Base.INVALID_OS_HANDLE
     @test outfd != Base._fd(out.out) == Base.INVALID_OS_HANDLE
-    @test bytesavailable(out) == 0
+    @test nbytesavailable(out) == 0
     @test c == UInt8['w']
     @test lstrip(ln2) == "1\thello"
     @test ln1 == "orld"


### PR DESCRIPTION
In #25634, `nb_available` was renamed to `bytesavailable`. However, [it was noted](https://github.com/JuliaLang/julia/pull/25634#issuecomment-359186767) that the `n` provided an important distinction, so this PR adds it for clarity, thus renaming `bytesavailable` to `nbytesavailable`.

This is technically a breaking change, code eagerly updated in the last few hours since #25634 was merged will get an `UndefVarError` from `bytesavailable`. I can add a defensive second deprecation if necessary.