### PR TITLE
Fix == on AbstractDict to use three-valued logic for values

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -19,7 +19,7 @@ haskey(d::AbstractDict, k) = in(k, keys(d))
 function in(p::Pair, a::AbstractDict, valcmp=(==))
     v = get(a,p[1],secret_table_token)
     if v !== secret_table_token
-        valcmp(v, p[2]) && return true
+        return valcmp(v, p[2])
     end
     return false
 end
@@ -467,13 +467,17 @@ function ==(l::AbstractDict, r::AbstractDict)
     if isa(l,IdDict) != isa(r,IdDict)
         return false
     end
-    if length(l) != length(r) return false end
+    length(l) != length(r) && return false
+    anymissing = false
     for pair in l
-        if !in(pair, r, ==)
+        isin = in(pair, r, ==)
+        if ismissing(isin)
+            anymissing = true
+        elseif !isin
             return false
         end
     end
-    true
+    return anymissing ? missing : true
 end
 
 const hasha_seed = UInt === UInt64 ? 0x6d35bb51952d5539 : 0x952d5539

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -44,22 +44,32 @@ end
     d2 = Dict(Set([2]) => 33, Set([3]) => 22)
     @test hash(d1) != hash(d2)
 end
-@testset "isequal" begin
-    @test  isequal(Set(), Set())
-    @test !isequal(Set(), Set([1]))
-    @test  isequal(Set{Any}(Any[1,2]), Set{Int}([1,2]))
-    @test !isequal(Set{Any}(Any[1,2]), Set{Int}([1,2,3]))
-    # Comparison of unrelated types seems rather inconsistent
-    @test  isequal(Set{Int}(), Set{AbstractString}())
-    @test !isequal(Set{Int}(), Set{AbstractString}([""]))
-    @test !isequal(Set{AbstractString}(), Set{Int}([0]))
-    @test !isequal(Set{Int}([1]), Set{AbstractString}())
-    @test  isequal(Set{Any}([1,2,3]), Set{Int}([1,2,3]))
-    @test  isequal(Set{Int}([1,2,3]), Set{Any}([1,2,3]))
-    @test !isequal(Set{Any}([1,2,3]), Set{Int}([1,2,3,4]))
-    @test !isequal(Set{Int}([1,2,3]), Set{Any}([1,2,3,4]))
-    @test !isequal(Set{Any}([1,2,3,4]), Set{Int}([1,2,3]))
-    @test !isequal(Set{Int}([1,2,3,4]), Set{Any}([1,2,3]))
+
+@testset "equality" for eq in (isequal, ==)
+    @test  eq(Set(), Set())
+    @test !eq(Set(), Set([1]))
+    @test  eq(Set{Any}(Any[1,2]), Set{Int}([1,2]))
+    @test !eq(Set{Any}(Any[1,2]), Set{Int}([1,2,3]))
+
+    # Comparison of unrelated types
+    @test  eq(Set{Int}(), Set{AbstractString}())
+    @test !eq(Set{Int}(), Set{AbstractString}([""]))
+    @test !eq(Set{AbstractString}(), Set{Int}([0]))
+    @test !eq(Set{Int}([1]), Set{AbstractString}())
+    @test  eq(Set{Any}([1,2,3]), Set{Int}([1,2,3]))
+    @test  eq(Set{Int}([1,2,3]), Set{Any}([1,2,3]))
+    @test !eq(Set{Any}([1,2,3]), Set{Int}([1,2,3,4]))
+    @test !eq(Set{Int}([1,2,3]), Set{Any}([1,2,3,4]))
+    @test !eq(Set{Any}([1,2,3,4]), Set{Int}([1,2,3]))
+    @test !eq(Set{Int}([1,2,3,4]), Set{Any}([1,2,3]))
+
+    # Special cases
+    @test  eq(Set([-0.0]), Set([-0.0]))
+    @test !eq(Set([0.0]), Set([-0.0]))
+    @test  eq(Set([NaN]), Set([NaN]))
+    @test !eq(Set([NaN]), Set([1.0]))
+    @test  eq(Set([missing]), Set([missing]))
+    @test !eq(Set([missing]), Set([1]))
 end
 
 @testset "hash and == for Set/BitSet" begin


### PR DESCRIPTION
For consistency with other collections like AbstractArray. Do not apply 3VL on the keys, since key comparisons are always done via `isequal`: `-0.0` and `0.0` are considered. Add tests checking this for `Dict` and `Set`.

Also remove comments which do not make sense since the API has been validated for 1.0, and isn't as inconsistent as they make it sound.

----

Spotted at https://github.com/JuliaLang/julia/issues/25551#issuecomment-357755506. Actually, we could choose to apply 3VL also for the keys, even if `isequal` is used, by special-casing `missing`. This would be more consistent with the behavior of `==` everywhere else, but less consistent with the fact that `-0.0` and `0.0` are considered as different keys. Also since `d[missing]` must allow retrieving the value associated with the key `missing`, it sounds logical to consider it as equal to itself.