### PR TITLE
RFC: Change indexin sentinel to `nothing`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2188,9 +2188,9 @@ julia> indexin(b,a)
  3
 ```
 """
-function indexin(a::AbstractArray, b::AbstractArray)
+function indexin(a, b::AbstractArray)
     bdict = Dict(zip(b, 1:length(b)))
-    [get(bdict, i, 0) for i in a]
+    map(i -> get(bdict, i, 0), a)
 end
 
 function _findin(a, b)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2168,11 +2168,11 @@ array contains 0 wherever `a` is not a member of `b`.
 
 # Examples
 ```jldoctest
-julia> a = ['a', 'b', 'c', 'b', 'd', 'a'];
+julia> a = ['a', 'b', 'c', 'b', 'd', 'a']
 
-julia> b = ['a','b','c'];
+julia> b = ['a', 'b', 'c']
 
-julia> indexin(a,b)
+julia> indexin(a, b)
 6-element Array{Int64,1}:
  1
  2
@@ -2181,7 +2181,7 @@ julia> indexin(a,b)
  0
  1
 
-julia> indexin(b,a)
+julia> indexin(b, a)
 3-element Array{Int64,1}:
  6
  4

--- a/base/array.jl
+++ b/base/array.jl
@@ -2162,9 +2162,9 @@ indmin(a) = findmin(a)[2]
 """
     indexin(a, b)
 
-Return a vector containing the highest index in `b` for
-each value in `a` that is a member of `b` . The output
-vector contains 0 wherever `a` is not a member of `b`.
+Return an array containing the highest index in `b` for
+each value in `a` that is a member of `b`. The output
+array contains 0 wherever `a` is not a member of `b`.
 
 # Examples
 ```jldoctest

--- a/base/array.jl
+++ b/base/array.jl
@@ -2164,7 +2164,7 @@ indmin(a) = findmin(a)[2]
 
 Return an array containing the highest index in `b` for
 each value in `a` that is a member of `b`. The output
-array contains 0 wherever `a` is not a member of `b`.
+array contains `nothing` wherever `a` is not a member of `b`.
 
 # Examples
 ```jldoctest
@@ -2173,24 +2173,27 @@ julia> a = ['a', 'b', 'c', 'b', 'd', 'a']
 julia> b = ['a', 'b', 'c']
 
 julia> indexin(a, b)
-6-element Array{Int64,1}:
+6-element Array{Union{Nothing, Int64},1}:
  1
  2
  3
  2
- 0
+  nothing
  1
 
 julia> indexin(b, a)
-3-element Array{Int64,1}:
+3-element Array{Union{Nothing, Int64},1}:
  6
  4
  3
 ```
 """
 function indexin(a, b::AbstractArray)
-    bdict = Dict(zip(b, 1:length(b)))
-    map(i -> get(bdict, i, 0), a)
+    indexes = keys(b)
+    bdict = Dict(zip(b, indexes))
+    return Union{eltype(indexes), Nothing}[
+        get(bdict, i, nothing) for i in a
+    ]
 end
 
 function _findin(a, b)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1394,13 +1394,13 @@ end
 @test i7197() == (2,2)
 
 # PR #8622 and general indexin tests
-@test indexin([1,3,5,7], [5,4,3]) == [0,3,1,0]
-@test indexin([1 3; 5 7], [5 4; 3 2]) == [0 2; 1 0]
-@test indexin((2 * x + 1 for x in 0:3), [5,4,3,5,6]) == [0,3,4,0]
-@test indexin(6, [1,3,6,6,2]) == 4
+@test indexin([1,3,5,7], [5,4,3]) == [nothing,3,1,nothing]
+@test indexin([1 3; 5 7], [5 4; 3 2]) == [nothing CartesianIndex(2, 1); CartesianIndex(1, 1) nothing]
+@test indexin((2 * x + 1 for x in 0:3), [5,4,3,5,6]) == [nothing,3,4,nothing]
+@test indexin(6, [1,3,6,6,2]) == fill(4, ())
 @test indexin([6], [1,3,6,6,2]) == [4]
-@test indexin(3, 2:5) == 2
-@test indexin(3.0, 2:5) == 2
+@test indexin([3], 2:5) == [2]
+@test indexin([3.0], 2:5) == [2]
 
 #6828 - size of specific dimensions
 let a = Array{Float64}(uninitialized, 10)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1396,6 +1396,11 @@ end
 # PR #8622 and general indexin tests
 @test indexin([1,3,5,7], [5,4,3]) == [0,3,1,0]
 @test indexin([1 3; 5 7], [5 4; 3 2]) == [0 2; 1 0]
+@test indexin((2 * x + 1 for x in 0:3), [5,4,3,5,6]) == [0,3,4,0]
+@test indexin(6, [1,3,6,6,2]) == 4
+@test indexin([6], [1,3,6,6,2]) == [4]
+@test indexin(3, 2:5) == 2
+@test indexin(3.0, 2:5) == 2
 
 #6828 - size of specific dimensions
 let a = Array{Float64}(uninitialized, 10)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1393,13 +1393,9 @@ function i7197()
 end
 @test i7197() == (2,2)
 
-# PR #8622 and general indexin test
-function pr8622()
-    x=[1,3,5,7]
-    y=[5,4,3]
-    return indexin(x,y)
-end
-@test pr8622() == [0,3,1,0]
+# PR #8622 and general indexin tests
+@test indexin([1,3,5,7], [5,4,3]) == [0,3,1,0]
+@test indexin([1 3; 5 7], [5 4; 3 2]) == [0 2; 1 0]
 
 #6828 - size of specific dimensions
 let a = Array{Float64}(uninitialized, 10)


### PR DESCRIPTION
This changes `indexin`'s sentinel to `nothing`, following https://github.com/JuliaLang/julia/pull/25472#issuecomment-359179267.  Also includes the improvements in #23845 (which this pull request now supercedes).

~~At the moment, inference seems to be broken for this, as the first example in the doctest results in `Array{Any,1}`, hence the WIP title.~~