### PR TITLE
change skipchars(io, predicate) to skipchars(predicate, io)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -692,6 +692,9 @@ Deprecated or removed
 
   * `nb_available` is now `bytesavailable` ([#25634]).
 
+  * `skipchars(io::IO, predicate; linecomment=nothing)` is deprecated in favor of
+    `skipchars(predicate, io::IO; linecomment=nothing)` ([#25667]).
+
   * `Bidiagonal` constructors now use a `Symbol` (`:U` or `:L`) for the upper/lower
     argument, instead of a `Bool` or a `Char` ([#22703]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1592,6 +1592,10 @@ end
 
 @deprecate nb_available bytesavailable
 
+@deprecate skipchars(io::IO, predicate; linecomment=nothing) skipchars(predicate, io, linecomment=linecomment)
+# this method is to avoid ambiguity, delete at the same time as deprecation of skipchars above:
+skipchars(::IO, ::IO; linecomment=nothing) = throw(ArgumentError("the first argument of `skipchars` must be callable"))
+
 # issue #9053
 if Sys.iswindows()
 function Filesystem.tempname(uunique::UInt32)

--- a/base/io.jl
+++ b/base/io.jl
@@ -912,7 +912,7 @@ Commit all currently buffered writes to the given stream.
 flush(io::IO) = nothing
 
 """
-    skipchars(io::IO, predicate; linecomment=nothing)
+    skipchars(predicate, io::IO; linecomment=nothing)
 
 Advance the stream `io` such that the next-read character will be the first remaining for
 which `predicate` returns `false`. If the keyword argument `linecomment` is specified, all
@@ -923,19 +923,19 @@ characters from that character until the start of the next line are ignored.
 julia> buf = IOBuffer("    text")
 IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=8, maxsize=Inf, ptr=1, mark=-1)
 
-julia> skipchars(buf, isspace)
+julia> skipchars(isspace, buf)
 IOBuffer(data=UInt8[...], readable=true, writable=false, seekable=true, append=false, size=8, maxsize=Inf, ptr=5, mark=-1)
 
 julia> String(readavailable(buf))
 "text"
 ```
 """
-function skipchars(io::IO, pred; linecomment=nothing)
+function skipchars(predicate, io::IO; linecomment=nothing)
     while !eof(io)
         c = read(io, Char)
         if c === linecomment
             readline(io)
-        elseif !pred(c)
+        elseif !predicate(c)
             skip(io, -codelen(c))
             break
         end

--- a/base/repl/LineEdit.jl
+++ b/base/repl/LineEdit.jl
@@ -1037,7 +1037,7 @@ end
 
 function edit_replace_word_right(buf::IOBuffer, replace::Function)
     # put the cursor at the beginning of the next word
-    skipchars(buf, is_non_word_char)
+    skipchars(is_non_word_char, buf)
     b = position(buf)
     char_move_word_right(buf)
     e = position(buf)

--- a/test/iobuffer.jl
+++ b/test/iobuffer.jl
@@ -262,25 +262,25 @@ end
 # skipchars
 let
     io = IOBuffer("")
-    @test eof(skipchars(io, isspace))
+    @test eof(skipchars(isspace, io))
 
     io = IOBuffer("   ")
-    @test eof(skipchars(io, isspace))
+    @test eof(skipchars(isspace, io))
 
     io = IOBuffer("#    \n     ")
-    @test eof(skipchars(io, isspace, linecomment='#'))
+    @test eof(skipchars(isspace, io, linecomment='#'))
 
     io = IOBuffer("      text")
-    skipchars(io, isspace)
+    skipchars(isspace, io)
     @test String(readavailable(io)) == "text"
 
     io = IOBuffer("   # comment \n    text")
-    skipchars(io, isspace, linecomment='#')
+    skipchars(isspace, io, linecomment='#')
     @test String(readavailable(io)) == "text"
 
     for char in ['@','߷','࿊','𐋺']
         io = IOBuffer("alphabeticalstuff$char")
-        @test !eof(skipchars(io, isalpha))
+        @test !eof(skipchars(isalpha, io))
         @test read(io, Char) == char
     end
 end

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -10,31 +10,31 @@ mktemp() do path, file
     end
 
     # test it doesn't error on eof
-    @test eof(skipchars(file, isspace))
+    @test eof(skipchars(isspace, file))
 
     # test it correctly skips
     append_to_file("    ")
-    @test eof(skipchars(file, isspace))
+    @test eof(skipchars(isspace, file))
 
     # test it correctly detects comment lines
     append_to_file("#    \n   ")
-    @test eof(skipchars(file, isspace, linecomment='#'))
+    @test eof(skipchars(isspace, file, linecomment='#'))
 
     # test it stops at the appropriate time
     append_to_file("   not a space")
-    @test !eof(skipchars(file, isspace))
+    @test !eof(skipchars(isspace, file))
     @test read(file, Char) == 'n'
 
     # test it correctly ignores the contents of comment lines
     append_to_file("  #not a space \n   not a space")
-    @test !eof(skipchars(file, isspace, linecomment='#'))
+    @test !eof(skipchars(isspace, file, linecomment='#'))
     @test read(file, Char) == 'n'
 
     # test it correctly handles unicode
     for (byte,char) in zip(1:4, ('@','߷','࿊','𐋺'))
         append_to_file("abcdef$char")
         @test Base.codelen(char) == byte
-        @test !eof(skipchars(file, isalpha))
+        @test !eof(skipchars(isalpha, file))
         @test read(file, Char) == char
     end
 end


### PR DESCRIPTION
This is to be consistent with our style guide.

Cf. https://docs.julialang.org/en/latest/manual/style-guide/#Write-functions-with-argument-ordering-similar-to-Julia's-Base-1