### PR TITLE
change RandomDevice(unlimited::Bool) to RandomDevice(; unlimited::Bool)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -956,6 +956,9 @@ Deprecated or removed
 
   * The module `Random.dSFMT` is renamed `Random.DSFMT` ([#25567]).
 
+  * `Random.RandomDevice(unlimited::Bool)` (on non-Windows systems) is deprecated in favor of
+    `Random.RandomDevice(; unlimited=unlimited)` ([#25668]).
+
   * The generic implementations of `strides(::AbstractArray)` and `stride(::AbstractArray, ::Int)`
      have been deprecated. Subtypes of `AbstractArray` that implement the newly introduced strided
      array interface should define their own `strides` method ([#25321]).

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -22,7 +22,7 @@ else # !windows
         file::IOStream
         unlimited::Bool
 
-        RandomDevice(unlimited::Bool=true) =
+        RandomDevice(; unlimited::Bool=true) =
             new(open(unlimited ? "/dev/urandom" : "/dev/random"), unlimited)
     end
 
@@ -34,7 +34,7 @@ else # !windows
     end
     function deserialize(s::AbstractSerializer, t::Type{RandomDevice})
         unlimited = deserialize(s)
-        return RandomDevice(unlimited)
+        return RandomDevice(unlimited=unlimited)
     end
 
 end # os-test

--- a/stdlib/Random/src/deprecated.jl
+++ b/stdlib/Random/src/deprecated.jl
@@ -22,3 +22,6 @@ end
 # PR #25429
 @deprecate rand(r::AbstractRNG, dims::Dims) rand(r, Float64, dims)
 @deprecate rand(                dims::Dims) rand(Float64, dims)
+
+# PR #25668
+@deprecate RandomDevice(unlimited::Bool) RandomDevice(; unlimited=unlimited)


### PR DESCRIPTION
Making `unlimited` a keyword argument is mainly for 2 reasons:
1) it seems better that the argument(s) of an RNG constructor match those of `srand` (cf. `srand` docstring), i.e. that the positional argument(s) specify a seed.
1) it is available only on non-Windows systems, and is not a functionality that is obviously expected, so it feels more "right" to name it (i.e. what `RandomDevice(false)` does is not guessable).