### PR TITLE
RFC: change signatures that help is showing [ci skip]

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -283,7 +283,7 @@ function doc(binding::Binding, sig::Type = Union{})
         result = getdoc(resolve(binding), sig)
         result === nothing || return result
     end
-    results, groups = DocStr[], MultiDoc[]
+    results, groups, sigs = DocStr[], MultiDoc[], Any[]
     # Lookup `binding` and `sig` for matches in all modules of the docsystem.
     for mod in modules
         dict = meta(mod)
@@ -291,7 +291,10 @@ function doc(binding::Binding, sig::Type = Union{})
             multidoc = dict[binding]
             push!(groups, multidoc)
             for msig in multidoc.order
-                sig <: msig && push!(results, multidoc.docs[msig])
+                if (isconcrete(sig) && sig <: msig) || (!isconcrete(sig) && msig <: sig) || sig == Union{}
+                    push!(sigs, msig)
+                    push!(results, multidoc.docs[msig])
+                end
             end
         end
     end
@@ -308,6 +311,15 @@ function doc(binding::Binding, sig::Type = Union{})
         if isempty(results)
             for group in groups, each in group.order
                 push!(results, group.docs[each])
+            end
+        elseif sig != Union{}
+            # If the signature is abstract, only show more specific methods
+            morespec = [x <: sig && x != Union{} for x in sigs]
+            if !any(morespec)
+                # If not any method is more specific that sig, show the most specific one
+                results = DocStr[results[first(sortperm(sigs, lt = (a,b) -> a <: b))]]
+            else
+                results = results[morespec]
             end
         end
         # Get parsed docs and concatenate them.


### PR DESCRIPTION
After looking at https://github.com/JuliaLang/julia/issues/20064 and experimenting a bit, I am a bit unhappy with what docstrings we show for different queries in help mode.

Here are some methods with docstrings to use a example:

```jl
"""
foobar
"""
function foobar end

"""
Number
"""
foobar(x::Number) = x

"""
Real
"""
foobar(x::Real) = x


"""
Int
"""
foobar(x::Int) = x


"""
Real, Int
"""
foobar(x::Real, y::Int) = x
```

## Master

### Example 1

```jl
help?> foobar(1)
  Number

  Real

  Int
```

Why would I want to see the docstrings for `Number` and `Real` for `foobar(1)`? None of these will be executed if I run `foobar(1)` and this means that we will always see fallback docstrings, like #20064 complains about:

```jl
help?> +(::Date, ::Time)
  +(x, y...)

  Addition operator. x+y+z+... calls this function with all arguments, i.e. +(x, y, z, ...).

  ..........

  dt::Date + t::Time -> DateTime

  The addition of a Date with a Time produces a DateTime. The hour, minute, second, and millisecond parts of the Time are used along with the year, month, and day of the Date to create the new DateTime.
  Non-zero microseconds or nanoseconds in the Time type will result in an InexactError being thrown.
```

The `+(x, y...)` docstring is fairly uninteresting if we specifically say that we are interested in `+(::Date, ::Time)`.

### Example 2

```jl
help?> foobar(::Real)
  Number

  Real
```

So if ask about the method `foobar` constrained to the type `::Real` then why do I get to read the docstring for `foobar(::Number)` which will never be called if I have an object `<: Real`? And why do I not get the docstring for `f(::Int)` which does match the query?

## PR

### Example 1

```jl
help?> foobar(1)
  Int

help?> foobar(2.0)
  Real

help?> foobar(2.0, 1)
  Real, Int
```

Alright, I get the docstring for the method that matches my (concrete) arguments. Nice.

### Example 2

```jl
help?> foobar(::Real)
  Real

  Int

help?> foobar(::Real, ::Real)
  Real, Int
```

Ok, I get the docstring(s) for the function(s) that is/are applicable to the constraints I put. Makes sense.

Trying the original example in #20064 

```
help?> +(::Date, ::Time)
  dt::Date + t::Time -> DateTime

  The addition of a Date with a Time produces a DateTime. The hour, minute, second, and millisecond parts of the Time are used along with the year, month, and day of the Date to create the new DateTime.
  Non-zero microseconds or nanoseconds in the Time type will result in an InexactError being thrown.
```

We no longer get the fallback `+(x, y...)`.

------------------------------

Does anyone else have opinions on the current way we select what docstrings to show?
