### PR TITLE
Add late union splitting for builtins

### DIFF
--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -26,6 +26,10 @@ struct Params
     # when inferring a call to _apply
     MAX_APPLY_UNION_ENUM::Int
 
+    # the maximum number of union-tuples to swap / expand
+    # for the benefit of codegen
+    MAX_UNION_CODGEN_EXPAND::Int
+
     # parameters limiting large types
     MAX_TUPLETYPE_LEN::Int
 
@@ -43,10 +47,11 @@ struct Params
                     tupletype_len::Int = 15,
                     tuple_splat::Int = 16,
                     union_splitting::Int = 4,
-                    apply_union_enum::Int = 8)
+                    apply_union_enum::Int = 8,
+                    union_codegen_expand::Int = 9)
         return new(Vector{InferenceResult}(),
                    world, inlining, true, false, inline_cost_threshold, inline_nonleaf_penalty,
                    inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum,
-                   tupletype_len, tuple_splat)
+                   union_codegen_expand, tupletype_len, tuple_splat)
     end
 end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -18,7 +18,7 @@ NTuple
 length(t::Tuple) = nfields(t)
 endof(t::Tuple) = length(t)
 size(t::Tuple, d) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
-@eval getindex(t::Tuple, i::Int) = getfield(t, i, $(Expr(:boundscheck)))
+@eval getindex(t::Tuple, i::Int) = (@_inline_meta; getfield(t, i, $(Expr(:boundscheck))))
 @eval getindex(t::Tuple, i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...,)
 getindex(t::Tuple, b::AbstractArray{Bool,1}) = length(b) == length(t) ? getindex(t, findall(b)) : throw(BoundsError(t, b))
@@ -55,7 +55,7 @@ end
 
 # this allows partial evaluation of bounded sequences of next() calls on tuples,
 # while reducing to plain next() for arbitrary iterables.
-indexed_next(t::Tuple, i::Int, state) = (t[i], i+1)
+indexed_next(t::Tuple, i::Int, state) = (@_inline_meta; (t[i], i+1))
 indexed_next(a::Array, i::Int, state) = (a[i], i+1)
 indexed_next(I, i, state) = done(I,state) ? throw(BoundsError(I, i)) : next(I, state)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -5945,3 +5945,15 @@ void24363 = A24363(nothing)
 f24363(a) = a.x
 @test f24363(int24363) === 65535
 @test f24363(void24363) === nothing
+
+# issue #25663
+@noinline foo25663() = rand(Bool) ? 2 : nothing
+@inline baz25663(x) = x ? (foo(), 1) : nothing
+function bar25663(arg)
+    x = baz25663(arg)
+    x === nothing && return 0
+    a, b = x
+    a === nothing && return 1
+    return a
+end
+@test @allocated(bar(true)) == 0


### PR DESCRIPTION
The case in #25663 presents a problem for codegen, because it contains
a bunch of builtins with union arguments which codegen doesn't like
very much at the moment. This takes the approach of rewriting
`Tuple{Union{A,B}, Int}` to `Union{Tuple{A, Int}, Tuple{B, Int}}`
and union splitting any builtins operating on these late in the
optimization pipeline to make them more amenable to codegen.

The resulting code is extremely ugly, but it does solve the
problem, so good enough for now?

Fixes #25663 (though not the general case where the union contains
non-isbits elements)