### PR TITLE
fix use of srand in docs (moved to stdlib/Random)

### DIFF
--- a/doc/src/devdocs/subarrays.md
+++ b/doc/src/devdocs/subarrays.md
@@ -36,7 +36,7 @@ cartesian, rather than linear, indexing.
 Consider making 2d slices of a 3d array:
 
 ```@meta
-DocTestSetup = :(srand(1234))
+DocTestSetup = :(import Random; Random.srand(1234))
 ```
 ```jldoctest subarray
 julia> A = rand(2,3,4);

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -614,7 +614,8 @@ type:
 
 ```@meta
 DocTestSetup = quote
-    srand(1234)
+    import Random
+    Random.srand(1234)
 end
 ```
 


### PR DESCRIPTION
This is not enough to have `make doctest` pass, but removes at least an early interruption.