### PR TITLE
Include LinearAlgebra module in micro benchmark

### DIFF
--- a/test/perf/micro/perf.jl
+++ b/test/perf/micro/perf.jl
@@ -1,5 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using LinearAlgebra
 using Test
 using Printf
 


### PR DESCRIPTION
I just noticed that many functions were recently moved to the LinearAlgebra module (#25571), but the inclusion of this module in perf.jl was missing in this transition.