### PR TITLE
Fix `has_bottom_parameter` for `TypeVar` with `Union{}` upper bound

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1176,7 +1176,7 @@ function has_bottom_parameter(t::Type)
 end
 has_bottom_parameter(t::UnionAll) = has_bottom_parameter(unwrap_unionall(t))
 has_bottom_parameter(t::Union) = has_bottom_parameter(t.a) & has_bottom_parameter(t.b)
-has_bottom_parameter(t::TypeVar) = has_bottom_parameter(t.ub)
+has_bottom_parameter(t::TypeVar) = t.ub == Bottom || has_bottom_parameter(t.ub)
 has_bottom_parameter(::Any) = false
 
 min_world(m::Method) = reinterpret(UInt, m.min_world)

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -297,4 +297,8 @@ end
     end
 end
 
+@testset "has_bottom_parameter with Union{} in tvar bound" begin
+    @test Base.has_bottom_parameter(Ref{<:Union{}})
+end
+
 nothing # don't return a module from the remote include


### PR DESCRIPTION
I was hitting a case where `detect_ambiguities` errored because of this.

We still have
```julia
julia> Base.has_bottom_parameter(Union{})
ERROR: type TypeofBottom has no field parameters
```
Should that rather be `false`? Or `true`?