### PR TITLE
make Symmetric/Hermitian recursive 

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -265,11 +265,11 @@ function copytri!(A::AbstractMatrix, uplo::Char, conjugate::Bool=false)
     n = checksquare(A)
     if uplo == 'U'
         for i = 1:(n-1), j = (i+1):n
-            A[j,i] = conjugate ? conj(A[i,j]) : A[i,j]
+            A[j,i] = conjugate ? adjoint(A[i,j]) : transpose(A[i,j])
         end
     elseif uplo == 'L'
         for i = 1:(n-1), j = (i+1):n
-            A[i,j] = conjugate ? conj(A[j,i]) : A[j,i]
+            A[i,j] = conjugate ? adjoint(A[j,i]) : transpose(A[j,i])
         end
     else
         throw(ArgumentError("uplo argument must be 'U' (upper) or 'L' (lower), got $uplo"))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -45,8 +45,27 @@ function Symmetric(A::AbstractMatrix, uplo::Symbol=:U)
     symmetric_type(typeof(A))(A, char_uplo(uplo))
 end
 
+"""
+    symmetric(A, uplo=:U)
+
+Construct a symmetric view of `A`. If `A` is a matrix, `uplo` controls whether the upper
+(if `uplo = :U`) or lower (if `uplo = :L`) triangle of `A` is used to implicitly fill the
+other one. If `A` is a `Number`, it is returned as is.
+
+If a symmetric view of a matrix is to be constructed of which the elements are neither
+matrices nor numbers, an appropriate method of `symmetric` has to be implemented. In that
+case, `symmetric_type` has to be implemented, too.
+"""
 symmetric(A::AbstractMatrix, uplo::Symbol) = Symmetric(A, uplo)
 symmetric(A::Number, ::Symbol) = A
+
+"""
+    symmetric_type(T::Type)
+
+The type of the object returned by `symmetric(::T, ::Symbol)`. For matrices, this is an
+appropriately typed `Symmetric`, for `Number`s, it is the original type. If `symmetric` is
+implemented for a custom type, so should be `symmetric_type`, and vice versa.
+"""
 function symmetric_type(::Type{T}) where {S,T<:AbstractMatrix{S}}
     Symmetric{Union{S,promote_op(transpose, S),symmetric_type(S)},T}
 end
@@ -96,8 +115,28 @@ function Hermitian(A::AbstractMatrix, uplo::Symbol=:U)
     hermitian_type(typeof(A))(A, char_uplo(uplo))
 end
 
+"""
+    hermitian(A, uplo=:U)
+
+Construct a hermitian view of `A`. If `A` is a matrix, `uplo` controls whether the upper
+(if `uplo = :U`) or lower (if `uplo = :L`) triangle of `A` is used to implicitly fill the
+other one. If `A` is a `Number`, its real part is returned converted back to the input
+type.
+
+If a hermitian view of a matrix is to be constructed of which the elements are neither
+matrices nor numbers, an appropriate method of `hermitian` has to be implemented. In that
+case, `hermitian_type` has to be implemented, too.
+"""
 hermitian(A::AbstractMatrix, uplo::Symbol) = Hermitian(A, uplo)
 hermitian(A::Number, ::Symbol) = convert(typeof(A), real(A))
+
+"""
+    hermitian_type(T::Type)
+
+The type of the object returned by `hermitian(::T, ::Symbol)`. For matrices, this is an
+appropriately typed `Hermitian`, for `Number`s, it is the original type. If `hermitian` is
+implemented for a custom type, so should be `hermitian_type`, and vice versa.
+"""
 function hermitian_type(::Type{T}) where {S,T<:AbstractMatrix{S}}
     Hermitian{Union{S,promote_op(adjoint, S),hermitian_type(S)},T}
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -487,4 +487,26 @@ end
     end
 end
 
+@testset "#25625 recursive transposition" begin
+    A = Matrix{Matrix{Int}}(uninitialized, 2, 2)
+    A[1,1] = [1 2; 2 3]
+    A[1,2] = [4 5 6; 7 8 9]
+    A[2,2] = hcat([1 2; 3 4])
+    S = Symmetric(A)
+    @test S[1,1] == A[1,1]
+    @test S[1,2] == transpose(S[2,1]) == A[1,2]
+    @test S[2,2] == Symmetric(A[2,2])
+    @test S == transpose(S) == Matrix(S) == Matrix(transpose(S)) == transpose(Matrix(S))
+
+    B = Matrix{Matrix{Complex{Int}}}(uninitialized, 2, 2)
+    B[1,1] = [1 2+im; 2-im 3]
+    B[1,2] = [4 5+1im 6-2im; 7+3im 8-4im 9+5im]
+    B[2,2] = hcat([1+1im 2+2im; 3-3im 4-2im])
+    H = Hermitian(B)
+    @test H[1,1] == B[1,1]
+    @test H[1,2] == adjoint(H[2,1]) == B[1,2]
+    @test H[2,2] == Hermitian(B[2,2])
+    @test H == adjoint(H) == Matrix(H) == Matrix(adjoint(H)) == adjoint(Matrix(H))
+end
+
 end # module TestSymmetric


### PR DESCRIPTION
Testing the waters here. I have no clue what a `Symmetric(::Matrix{Matrix})` might be used for in practice, but I'd say the additional tests look like we'd want them to pass. The alternative would be to make `a::Symmetric` obey `a == permutedims(a)` and `a::Hermitian` obey `a == conj(permutedims(a))`, where especially the latter looks extremely artificial.

(I admit to having used `promote_op` here but that's what `Transpose`/`Adjoint` do and I'm afraid I have to be consistent with those...)

Fixes JuliaLang/LinearAlgebra.jl#497.

~Note: This is on top of JuliaLang/julia#25687 because it triggered the bug fixed therein.~