### PR TITLE
add a deprecate_stdlib macro that binds to the right functions

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -131,21 +131,28 @@ macro deprecate_binding(old, new, export_old=true, dep_message=nothing)
          Expr(:call, :deprecate, __module__, Expr(:quote, old)))
 end
 
-macro deprecate_moved(old, new, export_old=true, default_package=false)
-    eold = esc(old)
+macro deprecate_stdlib(old, mod, export_old=true)
+    dep_message = """: it has been moved to the standard library package `$mod`.
+                        Add a `using $mod` to your imports."""
+    new = GlobalRef(Base.root_module(Base, mod), old)
     return Expr(:toplevel,
-         default_package ? :(function $eold(args...; kwargs...)
-                                 error($eold, " has been moved to the standard library package ", $new, ".\n",
-                                       "Restart Julia and then run `using ", $new, "` to load it.")
-                             end) :
-                           :(function $eold(args...; kwargs...)
-                                 error($eold, " has been moved to the package ", $new, ".jl.\n",
-                                       "Run `Pkg.add(\"", $new, "\")` to install it, restart Julia,\n",
-                                       "and then run `using ", $new, "` to load it.")
-                             end),
-         export_old ? Expr(:export, eold) : nothing,
-         Expr(:call, :deprecate, __module__, Expr(:quote, old), 2))
+         export_old ? Expr(:export, esc(old)) : nothing,
+         Expr(:const, Expr(:(=), esc(Symbol(string("_dep_message_",old))), esc(dep_message))),
+         Expr(:const, Expr(:(=), esc(old), esc(new))),
+         Expr(:call, :deprecate, __module__, Expr(:quote, old)))
 end
+
+macro deprecate_moved(old, new, export_old=true)
+    eold = esc(old)
+    emsg = string(old, " has been moved to the package ", new, ".jl.\n",
+        "Run `Pkg.add(\"", new, "\")` to install it, restart Julia,\n",
+        "and then run `using ", new, "` to load it.")
+    return Expr(:toplevel,
+        :($eold(args...; kwargs...) = error($emsg)),
+        export_old ? Expr(:export, eold) : nothing,
+        Expr(:call, :deprecate, __module__, Expr(:quote, old), 2))
+end
+
 
 # BEGIN 0.6 deprecations
 
@@ -301,75 +308,6 @@ end
 deprecate(Base, :DSP, 2)
 using .DSP
 export conv, conv2, deconv, filt, filt!, xcorr
-
-@deprecate_moved SharedArray "SharedArrays" true true
-
-@eval @deprecate_moved $(Symbol("@profile")) "Profile" true true
-
-@deprecate_moved readdlm  "DelimitedFiles" true true
-@deprecate_moved writedlm "DelimitedFiles" true true
-@deprecate_moved readcsv  "DelimitedFiles" true true
-@deprecate_moved writecsv "DelimitedFiles" true true
-
-@deprecate_moved base64encode "Base64" true true
-@deprecate_moved base64decode "Base64" true true
-@deprecate_moved Base64EncodePipe "Base64" true true
-@deprecate_moved Base64DecodePipe "Base64" true true
-
-@deprecate_moved poll_fd "FileWatching" true true
-@deprecate_moved poll_file "FileWatching" true true
-@deprecate_moved PollingFileWatcher "FileWatching" true true
-@deprecate_moved watch_file "FileWatching" true true
-@deprecate_moved FileMonitor "FileWatching" true true
-
-@eval @deprecate_moved $(Symbol("@spawn")) "Distributed" true true
-@eval @deprecate_moved $(Symbol("@spawnat")) "Distributed" true true
-@eval @deprecate_moved $(Symbol("@fetch")) "Distributed" true true
-@eval @deprecate_moved $(Symbol("@fetchfrom")) "Distributed" true true
-@eval @deprecate_moved $(Symbol("@everywhere")) "Distributed" true true
-@eval @deprecate_moved $(Symbol("@parallel")) "Distributed" true true
-
-@deprecate_moved addprocs "Distributed" true true
-@deprecate_moved CachingPool "Distributed" true true
-@deprecate_moved clear! "Distributed" true true
-@deprecate_moved ClusterManager "Distributed" true true
-@deprecate_moved default_worker_pool "Distributed" true true
-@deprecate_moved init_worker "Distributed" true true
-@deprecate_moved interrupt "Distributed" true true
-@deprecate_moved launch "Distributed" true true
-@deprecate_moved manage "Distributed" true true
-@deprecate_moved myid "Distributed" true true
-@deprecate_moved nprocs "Distributed" true true
-@deprecate_moved nworkers "Distributed" true true
-@deprecate_moved pmap "Distributed" true true
-@deprecate_moved procs "Distributed" true true
-@deprecate_moved remote "Distributed" true true
-@deprecate_moved remotecall "Distributed" true true
-@deprecate_moved remotecall_fetch "Distributed" true true
-@deprecate_moved remotecall_wait "Distributed" true true
-@deprecate_moved remote_do "Distributed" true true
-@deprecate_moved rmprocs "Distributed" true true
-@deprecate_moved workers "Distributed" true true
-@deprecate_moved WorkerPool "Distributed" true true
-@deprecate_moved RemoteChannel "Distributed" true true
-@deprecate_moved Future "Distributed" true true
-@deprecate_moved WorkerConfig "Distributed" true true
-@deprecate_moved RemoteException "Distributed" true true
-@deprecate_moved ProcessExitedException "Distributed" true true
-
-
-@deprecate_moved crc32c "CRC32c" true true
-
-@deprecate_moved DateTime "Dates" true true
-@deprecate_moved DateFormat "Dates" true true
-@eval @deprecate_moved $(Symbol("@dateformat_str")) "Dates" true true
-@deprecate_moved now "Dates" true true
-
-@deprecate_moved eigs "IterativeEigensolvers" true true
-@deprecate_moved svds "IterativeEigensolvers" true true
-
-@eval @deprecate_moved $(Symbol("@printf")) "Printf" true true
-@eval @deprecate_moved $(Symbol("@sprintf")) "Printf" true true
 
 # PR #21709
 @deprecate cov(x::AbstractVector, corrected::Bool) cov(x, corrected=corrected)
@@ -962,33 +900,6 @@ end
 # issue #24822
 @deprecate_binding Display AbstractDisplay
 
-# PR #24874
-@deprecate_moved rand! "Random" true true
-@deprecate_moved srand "Random" true true
-@deprecate_moved AbstractRNG "Random" true true
-@deprecate_moved randcycle  "Random" true true
-@deprecate_moved randcycle!  "Random" true true
-@deprecate_moved randperm  "Random" true true
-@deprecate_moved randperm! "Random" true true
-@deprecate_moved shuffle  "Random" true true
-@deprecate_moved shuffle! "Random" true true
-@deprecate_moved randsubseq "Random" true true
-@deprecate_moved randsubseq! "Random" true true
-@deprecate_moved randstring "Random" true true
-@deprecate_moved MersenneTwister  "Random" true true
-@deprecate_moved RandomDevice  "Random" true true
-@deprecate_moved randn! "Random" true true
-@deprecate_moved randexp "Random" true true
-@deprecate_moved randexp! "Random" true true
-@deprecate_moved bitrand "Random" true true
-@deprecate_moved randjump "Random" true true
-@deprecate_moved GLOBAL_RNG "Random" false true
-
-@deprecate_moved serialize "Serialization" true true
-@deprecate_moved deserialize "Serialization" true true
-@deprecate_moved AbstractSerializer "Serialization" true true
-@deprecate_moved SerializationState "Serialization" true true
-
 # 24595
 @deprecate falses(A::AbstractArray) falses(size(A))
 @deprecate trues(A::AbstractArray) trues(size(A))
@@ -1237,183 +1148,6 @@ end
 # issue #24804
 @deprecate_moved sum_kbn "KahanSummation"
 @deprecate_moved cumsum_kbn "KahanSummation"
-
-# PR #25249: SparseArrays to stdlib
-## the Base.SparseArrays module itself and exported types are deprecated in base/sysimg.jl
-## functions that were re-exported from Base
-@deprecate_moved nonzeros   "SparseArrays" true true
-@deprecate_moved permute    "SparseArrays" true true
-@deprecate_moved blkdiag    "SparseArrays" true true
-@deprecate_moved dropzeros  "SparseArrays" true true
-@deprecate_moved dropzeros! "SparseArrays" true true
-@deprecate_moved issparse   "SparseArrays" true true
-@deprecate_moved sparse     "SparseArrays" true true
-@deprecate_moved sparsevec  "SparseArrays" true true
-@deprecate_moved spdiagm    "SparseArrays" true true
-@deprecate_moved sprand     "SparseArrays" true true
-@deprecate_moved sprandn    "SparseArrays" true true
-@deprecate_moved spzeros    "SparseArrays" true true
-@deprecate_moved rowvals    "SparseArrays" true true
-@deprecate_moved nzrange    "SparseArrays" true true
-@deprecate_moved nnz        "SparseArrays" true true
-@deprecate_moved findnz     "SparseArrays" true true
-## functions that were exported from Base.SparseArrays but not from Base
-@deprecate_moved droptol!   "SparseArrays" false true
-## deprecated functions that are moved to stdlib/SparseArrays/src/deprecated.jl
-@deprecate_moved spones     "SparseArrays" true true
-@deprecate_moved speye      "SparseArrays" true true
-
-# PR #25571: LinearAlgebra to stdlib
-## the LinearAlgebra module itself is deprecated base/sysimg.jl
-
-## functions that were re-exported from Base
-@deprecate_moved bkfact!     "LinearAlgebra" true true
-@deprecate_moved bkfact      "LinearAlgebra" true true
-@deprecate_moved chol        "LinearAlgebra" true true
-@deprecate_moved cholfact!   "LinearAlgebra" true true
-@deprecate_moved cholfact    "LinearAlgebra" true true
-@deprecate_moved cond        "LinearAlgebra" true true
-@deprecate_moved condskeel   "LinearAlgebra" true true
-@deprecate_moved cross       "LinearAlgebra" true true
-@deprecate_moved adjoint!    "LinearAlgebra" true true
-# @deprecate_moved adjoint     "LinearAlgebra" true true
-@deprecate_moved det         "LinearAlgebra" true true
-@deprecate_moved diag        "LinearAlgebra" true true
-@deprecate_moved diagind     "LinearAlgebra" true true
-@deprecate_moved diagm       "LinearAlgebra" true true
-@deprecate_moved diff        "LinearAlgebra" true true
-@deprecate_moved dot         "LinearAlgebra" true true
-@deprecate_moved eig         "LinearAlgebra" true true
-@deprecate_moved eigfact!    "LinearAlgebra" true true
-@deprecate_moved eigfact     "LinearAlgebra" true true
-@deprecate_moved eigmax      "LinearAlgebra" true true
-@deprecate_moved eigmin      "LinearAlgebra" true true
-@deprecate_moved eigvals     "LinearAlgebra" true true
-@deprecate_moved eigvals!    "LinearAlgebra" true true
-@deprecate_moved eigvecs     "LinearAlgebra" true true
-@deprecate_moved factorize   "LinearAlgebra" true true
-@deprecate_moved givens      "LinearAlgebra" true true
-@deprecate_moved hessfact!   "LinearAlgebra" true true
-@deprecate_moved hessfact    "LinearAlgebra" true true
-@deprecate_moved isdiag      "LinearAlgebra" true true
-@deprecate_moved ishermitian "LinearAlgebra" true true
-@deprecate_moved isposdef!   "LinearAlgebra" true true
-@deprecate_moved isposdef    "LinearAlgebra" true true
-@deprecate_moved issymmetric "LinearAlgebra" true true
-@deprecate_moved istril      "LinearAlgebra" true true
-@deprecate_moved istriu      "LinearAlgebra" true true
-# @deprecate_moved kron        "LinearAlgebra" true true
-@deprecate_moved ldltfact    "LinearAlgebra" true true
-@deprecate_moved ldltfact!   "LinearAlgebra" true true
-@deprecate_moved linreg      "LinearAlgebra" true true
-@deprecate_moved logabsdet   "LinearAlgebra" true true
-@deprecate_moved logdet      "LinearAlgebra" true true
-@deprecate_moved lu          "LinearAlgebra" true true
-@deprecate_moved lufact!     "LinearAlgebra" true true
-@deprecate_moved lufact      "LinearAlgebra" true true
-@deprecate_moved lyap        "LinearAlgebra" true true
-@deprecate_moved norm        "LinearAlgebra" true true
-@deprecate_moved normalize   "LinearAlgebra" true true
-@deprecate_moved normalize!  "LinearAlgebra" true true
-@deprecate_moved nullspace   "LinearAlgebra" true true
-@deprecate_moved ordschur!   "LinearAlgebra" true true
-@deprecate_moved ordschur    "LinearAlgebra" true true
-@deprecate_moved peakflops   "LinearAlgebra" true true
-@deprecate_moved pinv        "LinearAlgebra" true true
-@deprecate_moved qr          "LinearAlgebra" true true
-@deprecate_moved qrfact!     "LinearAlgebra" true true
-@deprecate_moved qrfact      "LinearAlgebra" true true
-@deprecate_moved lq          "LinearAlgebra" true true
-@deprecate_moved lqfact!     "LinearAlgebra" true true
-@deprecate_moved lqfact      "LinearAlgebra" true true
-@deprecate_moved rank        "LinearAlgebra" true true
-@deprecate_moved scale!      "LinearAlgebra" true true
-@deprecate_moved schur       "LinearAlgebra" true true
-@deprecate_moved schurfact!  "LinearAlgebra" true true
-@deprecate_moved schurfact   "LinearAlgebra" true true
-@deprecate_moved svd         "LinearAlgebra" true true
-@deprecate_moved svdfact!    "LinearAlgebra" true true
-@deprecate_moved svdfact     "LinearAlgebra" true true
-@deprecate_moved svdvals!    "LinearAlgebra" true true
-@deprecate_moved svdvals     "LinearAlgebra" true true
-@deprecate_moved sylvester   "LinearAlgebra" true true
-@deprecate_moved trace       "LinearAlgebra" true true
-@deprecate_moved transpose!  "LinearAlgebra" true true
-# @deprecate_moved transpose   "LinearAlgebra" true true
-@deprecate_moved tril!       "LinearAlgebra" true true
-@deprecate_moved tril        "LinearAlgebra" true true
-@deprecate_moved triu!       "LinearAlgebra" true true
-@deprecate_moved triu        "LinearAlgebra" true true
-@deprecate_moved vecdot      "LinearAlgebra" true true
-@deprecate_moved vecnorm     "LinearAlgebra" true true
-# @deprecate_moved ⋅           "LinearAlgebra" true true
-# @deprecate_moved ×           "LinearAlgebra" true true
-
-## types that were re-exported from Base
-@deprecate_moved Diagonal        "LinearAlgebra" true true
-@deprecate_moved Bidiagonal      "LinearAlgebra" true true
-@deprecate_moved Tridiagonal     "LinearAlgebra" true true
-@deprecate_moved SymTridiagonal  "LinearAlgebra" true true
-@deprecate_moved UpperTriangular "LinearAlgebra" true true
-@deprecate_moved LowerTriangular "LinearAlgebra" true true
-@deprecate_moved Symmetric       "LinearAlgebra" true true
-@deprecate_moved Hermitian       "LinearAlgebra" true true
-@deprecate_moved Factorization   "LinearAlgebra" true true
-@deprecate_moved UniformScaling  "LinearAlgebra" true true
-@deprecate_moved Adjoint         "LinearAlgebra" true true
-@deprecate_moved Transpose       "LinearAlgebra" true true
-
-## functions that were exported from Base.LinAlg but not from Base
-@deprecate_moved axpy!           "LinearAlgebra" false true
-@deprecate_moved axpby!          "LinearAlgebra" false true
-@deprecate_moved copy_transpose! "LinearAlgebra" false true
-@deprecate_moved issuccess       "LinearAlgebra" false true
-@deprecate_moved transpose_type  "LinearAlgebra" false true
-@deprecate_moved A_mul_B!        "LinearAlgebra" false true
-@deprecate_moved A_mul_Bt!       "LinearAlgebra" false true
-@deprecate_moved At_mul_B!       "LinearAlgebra" false true
-@deprecate_moved At_mul_Bt!      "LinearAlgebra" false true
-@deprecate_moved A_mul_Bc!       "LinearAlgebra" false true
-@deprecate_moved Ac_mul_B!       "LinearAlgebra" false true
-@deprecate_moved Ac_mul_Bc!      "LinearAlgebra" false true
-@deprecate_moved A_ldiv_B!       "LinearAlgebra" false true
-@deprecate_moved At_ldiv_B!      "LinearAlgebra" false true
-@deprecate_moved Ac_ldiv_B!      "LinearAlgebra" false true
-
-## types that were exported from Base.LinAlg but not from Base
-@deprecate_moved BunchKaufman     "LinearAlgebra" false true
-@deprecate_moved Cholesky         "LinearAlgebra" false true
-@deprecate_moved CholeskyPivoted  "LinearAlgebra" false true
-@deprecate_moved Eigen            "LinearAlgebra" false true
-@deprecate_moved GeneralizedEigen "LinearAlgebra" false true
-@deprecate_moved GeneralizedSVD   "LinearAlgebra" false true
-@deprecate_moved GeneralizedSchur "LinearAlgebra" false true
-@deprecate_moved Hessenberg       "LinearAlgebra" false true
-@deprecate_moved LU               "LinearAlgebra" false true
-@deprecate_moved LDLt             "LinearAlgebra" false true
-@deprecate_moved QR               "LinearAlgebra" false true
-@deprecate_moved QRPivoted        "LinearAlgebra" false true
-@deprecate_moved LQ               "LinearAlgebra" false true
-@deprecate_moved Schur            "LinearAlgebra" false true
-@deprecate_moved SVD              "LinearAlgebra" false true
-
-## deprecated functions that are moved to stdlib/LinearAlgebra/src/deprecated.jl
-@deprecate_moved eye        "LinearAlgebra" true true
-@deprecate_moved sqrtm      "LinearAlgebra" true true
-@deprecate_moved expm       "LinearAlgebra" true true
-@deprecate_moved expm!      "LinearAlgebra" true true
-@deprecate_moved logm       "LinearAlgebra" true true
-@deprecate_moved gradient   "LinearAlgebra" true true
-@deprecate_moved ConjArray  "LinearAlgebra" true true
-@deprecate_moved ConjVector "LinearAlgebra" true true
-@deprecate_moved ConjMatrix "LinearAlgebra" true true
-@deprecate_moved RowVector  "LinearAlgebra" true true
-
-
-# PR #25021
-@deprecate_moved normalize_string "Unicode" true true
-@deprecate_moved graphemes "Unicode" true true
-@deprecate_moved is_assigned_char "Unicode" true true
 
 @deprecate isalnum(c::Char) isalpha(c) || isnumeric(c)
 @deprecate isgraph(c::Char) isprint(c) && !isspace(c)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -549,6 +549,9 @@ Base.require(Base, :REPL)
     @deprecate_binding(SparseVector, root_module(Base, :SparseArrays).SparseVector, true,
         ", run `using SparseArrays` to load sparse array functionality")
 
+    @deprecate_binding(SharedArray, root_module(Base, :SharedArrays).SharedArray, true,
+        ", run `using SharedArrays` to load shared array functionality")
+
     # PR #25571
     @deprecate_binding LinAlg root_module(Base, :LinearAlgebra) true ", run `using LinearAlgebra` instead"
     @deprecate_binding(I, root_module(Base, :LinearAlgebra).I, true,
@@ -559,6 +562,274 @@ Base.require(Base, :REPL)
     @deprecate_binding LineEdit        root_module(Base, :REPL).LineEdit        true ", use `REPL.LineEdit` instead"
     @deprecate_binding REPLCompletions root_module(Base, :REPL).REPLCompletions true ", use `REPL.REPLCompletions` instead"
     @deprecate_binding Terminals       root_module(Base, :REPL).Terminals       true ", use `REPL.Terminals` instead"
+
+    @deprecate_stdlib readdlm  DelimitedFiles true
+    @deprecate_stdlib writedlm DelimitedFiles true
+    @deprecate_stdlib readcsv  DelimitedFiles true
+    @deprecate_stdlib writecsv DelimitedFiles true
+
+    @eval @deprecate_stdlib $(Symbol("@profile")) Profile true
+
+    @deprecate_stdlib base64encode Base64 true
+    @deprecate_stdlib base64decode Base64 true
+    @deprecate_stdlib Base64EncodePipe Base64 true
+    @deprecate_stdlib Base64DecodePipe Base64 true
+
+    @deprecate_stdlib poll_fd FileWatching true
+    @deprecate_stdlib poll_file FileWatching true
+    @deprecate_stdlib PollingFileWatcher FileWatching true
+    @deprecate_stdlib watch_file FileWatching true
+    @deprecate_stdlib FileMonitor FileWatching true
+
+    @eval @deprecate_stdlib $(Symbol("@spawn")) Distributed true
+    @eval @deprecate_stdlib $(Symbol("@spawnat")) Distributed true
+    @eval @deprecate_stdlib $(Symbol("@fetch")) Distributed true
+    @eval @deprecate_stdlib $(Symbol("@fetchfrom")) Distributed true
+    @eval @deprecate_stdlib $(Symbol("@everywhere")) Distributed true
+    @eval @deprecate_stdlib $(Symbol("@parallel")) Distributed true
+
+    @deprecate_stdlib addprocs Distributed true
+    @deprecate_stdlib CachingPool Distributed true
+    @deprecate_stdlib clear! Distributed true
+    @deprecate_stdlib ClusterManager Distributed true
+    @deprecate_stdlib default_worker_pool Distributed true
+    @deprecate_stdlib init_worker Distributed true
+    @deprecate_stdlib interrupt Distributed true
+    @deprecate_stdlib launch Distributed true
+    @deprecate_stdlib manage Distributed true
+    @deprecate_stdlib myid Distributed true
+    @deprecate_stdlib nprocs Distributed true
+    @deprecate_stdlib nworkers Distributed true
+    @deprecate_stdlib pmap Distributed true
+    @deprecate_stdlib procs Distributed true
+    @deprecate_stdlib remote Distributed true
+    @deprecate_stdlib remotecall Distributed true
+    @deprecate_stdlib remotecall_fetch Distributed true
+    @deprecate_stdlib remotecall_wait Distributed true
+    @deprecate_stdlib remote_do Distributed true
+    @deprecate_stdlib rmprocs Distributed true
+    @deprecate_stdlib workers Distributed true
+    @deprecate_stdlib WorkerPool Distributed true
+    @deprecate_stdlib RemoteChannel Distributed true
+    @deprecate_stdlib Future Distributed true
+    @deprecate_stdlib WorkerConfig Distributed true
+    @deprecate_stdlib RemoteException Distributed true
+    @deprecate_stdlib ProcessExitedException Distributed true
+
+    @deprecate_stdlib crc32c CRC32c true
+
+    @deprecate_stdlib DateTime Dates true
+    @deprecate_stdlib DateFormat Dates true
+    @eval @deprecate_stdlib $(Symbol("@dateformat_str")) Dates true
+    @deprecate_stdlib now Dates true
+
+    @deprecate_stdlib eigs IterativeEigensolvers true
+    @deprecate_stdlib svds IterativeEigensolvers true
+
+    @eval @deprecate_stdlib $(Symbol("@printf")) Printf true
+    @eval @deprecate_stdlib $(Symbol("@sprintf")) Printf true
+
+    # PR #24874
+    @deprecate_stdlib rand! Random true
+    @deprecate_stdlib srand Random true
+    @deprecate_stdlib AbstractRNG Random true
+    @deprecate_stdlib randcycle  Random true
+    @deprecate_stdlib randcycle!  Random true
+    @deprecate_stdlib randperm  Random true
+    @deprecate_stdlib randperm! Random true
+    @deprecate_stdlib shuffle  Random true
+    @deprecate_stdlib shuffle! Random true
+    @deprecate_stdlib randsubseq Random true
+    @deprecate_stdlib randsubseq! Random true
+    @deprecate_stdlib randstring Random true
+    @deprecate_stdlib MersenneTwister  Random true
+    @deprecate_stdlib RandomDevice  Random true
+    @deprecate_stdlib randn! Random true
+    @deprecate_stdlib randexp Random true
+    @deprecate_stdlib randexp! Random true
+    @deprecate_stdlib bitrand Random true
+    @deprecate_stdlib randjump Random true
+    @deprecate_stdlib GLOBAL_RNG Random false
+
+    @deprecate_stdlib serialize Serialization true
+    @deprecate_stdlib deserialize Serialization true
+    @deprecate_stdlib AbstractSerializer Serialization true
+    @deprecate_stdlib SerializationState Serialization true
+
+    # PR #25249: SparseArrays to stdlib
+    ## the Base.SparseArrays module itself and exported types are deprecated in base/sysimg.jl
+    ## functions that were re-exported from Base
+    @deprecate_stdlib nonzeros   SparseArrays true
+    @deprecate_stdlib permute    SparseArrays true
+    @deprecate_stdlib blkdiag    SparseArrays true
+    @deprecate_stdlib dropzeros  SparseArrays true
+    @deprecate_stdlib dropzeros! SparseArrays true
+    @deprecate_stdlib issparse   SparseArrays true
+    @deprecate_stdlib sparse     SparseArrays true
+    @deprecate_stdlib sparsevec  SparseArrays true
+    @deprecate_stdlib spdiagm    SparseArrays true
+    @deprecate_stdlib sprand     SparseArrays true
+    @deprecate_stdlib sprandn    SparseArrays true
+    @deprecate_stdlib spzeros    SparseArrays true
+    @deprecate_stdlib rowvals    SparseArrays true
+    @deprecate_stdlib nzrange    SparseArrays true
+    @deprecate_stdlib nnz        SparseArrays true
+    @deprecate_stdlib findnz     SparseArrays true
+    ## functions that were exported from Base.SparseArrays but not from Base
+    @deprecate_stdlib droptol!   SparseArrays false
+    ## deprecated functions that are moved to stdlib/SparseArrays/src/deprecated.jl
+    @deprecate_stdlib spones     SparseArrays true
+    @deprecate_stdlib speye      SparseArrays true
+
+    # PR #25571: LinearAlgebra to stdlib
+    @deprecate_stdlib BLAS        LinearAlgebra true
+    ## functions that were re-exported from Base
+    @deprecate_stdlib bkfact!     LinearAlgebra true
+    @deprecate_stdlib bkfact      LinearAlgebra true
+    @deprecate_stdlib chol        LinearAlgebra true
+    @deprecate_stdlib cholfact!   LinearAlgebra true
+    @deprecate_stdlib cholfact    LinearAlgebra true
+    @deprecate_stdlib cond        LinearAlgebra true
+    @deprecate_stdlib condskeel   LinearAlgebra true
+    @deprecate_stdlib cross       LinearAlgebra true
+    @deprecate_stdlib adjoint!    LinearAlgebra true
+    # @deprecate_stdlib adjoint     LinearAlgebra true
+    @deprecate_stdlib det         LinearAlgebra true
+    @deprecate_stdlib diag        LinearAlgebra true
+    @deprecate_stdlib diagind     LinearAlgebra true
+    @deprecate_stdlib diagm       LinearAlgebra true
+    @deprecate_stdlib diff        LinearAlgebra true
+    @deprecate_stdlib dot         LinearAlgebra true
+    @deprecate_stdlib eig         LinearAlgebra true
+    @deprecate_stdlib eigfact!    LinearAlgebra true
+    @deprecate_stdlib eigfact     LinearAlgebra true
+    @deprecate_stdlib eigmax      LinearAlgebra true
+    @deprecate_stdlib eigmin      LinearAlgebra true
+    @deprecate_stdlib eigvals     LinearAlgebra true
+    @deprecate_stdlib eigvals!    LinearAlgebra true
+    @deprecate_stdlib eigvecs     LinearAlgebra true
+    @deprecate_stdlib factorize   LinearAlgebra true
+    @deprecate_stdlib givens      LinearAlgebra true
+    @deprecate_stdlib hessfact!   LinearAlgebra true
+    @deprecate_stdlib hessfact    LinearAlgebra true
+    @deprecate_stdlib isdiag      LinearAlgebra true
+    @deprecate_stdlib ishermitian LinearAlgebra true
+    @deprecate_stdlib isposdef!   LinearAlgebra true
+    @deprecate_stdlib isposdef    LinearAlgebra true
+    @deprecate_stdlib issymmetric LinearAlgebra true
+    @deprecate_stdlib istril      LinearAlgebra true
+    @deprecate_stdlib istriu      LinearAlgebra true
+    # @deprecate_stdlib kron        LinearAlgebra true
+    @deprecate_stdlib ldltfact    LinearAlgebra true
+    @deprecate_stdlib ldltfact!   LinearAlgebra true
+    @deprecate_stdlib linreg      LinearAlgebra true
+    @deprecate_stdlib logabsdet   LinearAlgebra true
+    @deprecate_stdlib logdet      LinearAlgebra true
+    @deprecate_stdlib lu          LinearAlgebra true
+    @deprecate_stdlib lufact!     LinearAlgebra true
+    @deprecate_stdlib lufact      LinearAlgebra true
+    @deprecate_stdlib lyap        LinearAlgebra true
+    @deprecate_stdlib norm        LinearAlgebra true
+    @deprecate_stdlib normalize   LinearAlgebra true
+    @deprecate_stdlib normalize!  LinearAlgebra true
+    @deprecate_stdlib nullspace   LinearAlgebra true
+    @deprecate_stdlib ordschur!   LinearAlgebra true
+    @deprecate_stdlib ordschur    LinearAlgebra true
+    @deprecate_stdlib peakflops   LinearAlgebra true
+    @deprecate_stdlib pinv        LinearAlgebra true
+    @deprecate_stdlib qr          LinearAlgebra true
+    @deprecate_stdlib qrfact!     LinearAlgebra true
+    @deprecate_stdlib qrfact      LinearAlgebra true
+    @deprecate_stdlib lq          LinearAlgebra true
+    @deprecate_stdlib lqfact!     LinearAlgebra true
+    @deprecate_stdlib lqfact      LinearAlgebra true
+    @deprecate_stdlib rank        LinearAlgebra true
+    @deprecate_stdlib scale!      LinearAlgebra true
+    @deprecate_stdlib schur       LinearAlgebra true
+    @deprecate_stdlib schurfact!  LinearAlgebra true
+    @deprecate_stdlib schurfact   LinearAlgebra true
+    @deprecate_stdlib svd         LinearAlgebra true
+    @deprecate_stdlib svdfact!    LinearAlgebra true
+    @deprecate_stdlib svdfact     LinearAlgebra true
+    @deprecate_stdlib svdvals!    LinearAlgebra true
+    @deprecate_stdlib svdvals     LinearAlgebra true
+    @deprecate_stdlib sylvester   LinearAlgebra true
+    @deprecate_stdlib trace       LinearAlgebra true
+    @deprecate_stdlib transpose!  LinearAlgebra true
+    # @deprecate_stdlib transpose   LinearAlgebra true
+    @deprecate_stdlib tril!       LinearAlgebra true
+    @deprecate_stdlib tril        LinearAlgebra true
+    @deprecate_stdlib triu!       LinearAlgebra true
+    @deprecate_stdlib triu        LinearAlgebra true
+    @deprecate_stdlib vecdot      LinearAlgebra true
+    @deprecate_stdlib vecnorm     LinearAlgebra true
+    # @deprecate_stdlib ⋅           LinearAlgebra true
+    # @deprecate_stdlib ×           LinearAlgebra true
+
+    ## types that were re-exported from Base
+    @deprecate_stdlib Diagonal        LinearAlgebra true
+    @deprecate_stdlib Bidiagonal      LinearAlgebra true
+    @deprecate_stdlib Tridiagonal     LinearAlgebra true
+    @deprecate_stdlib SymTridiagonal  LinearAlgebra true
+    @deprecate_stdlib UpperTriangular LinearAlgebra true
+    @deprecate_stdlib LowerTriangular LinearAlgebra true
+    @deprecate_stdlib Symmetric       LinearAlgebra true
+    @deprecate_stdlib Hermitian       LinearAlgebra true
+    @deprecate_stdlib Factorization   LinearAlgebra true
+    @deprecate_stdlib UniformScaling  LinearAlgebra true
+    @deprecate_stdlib Adjoint         LinearAlgebra true
+    @deprecate_stdlib Transpose       LinearAlgebra true
+
+    ## functions that were exported from Base.LinAlg but not from Base
+    @deprecate_stdlib axpy!           LinearAlgebra false
+    @deprecate_stdlib axpby!          LinearAlgebra false
+    @deprecate_stdlib copy_transpose! LinearAlgebra false
+    @deprecate_stdlib issuccess       LinearAlgebra false
+    @deprecate_stdlib transpose_type  LinearAlgebra false
+    @deprecate_stdlib A_mul_B!        LinearAlgebra false
+    @deprecate_stdlib A_mul_Bt!       LinearAlgebra false
+    @deprecate_stdlib At_mul_B!       LinearAlgebra false
+    @deprecate_stdlib At_mul_Bt!      LinearAlgebra false
+    @deprecate_stdlib A_mul_Bc!       LinearAlgebra false
+    @deprecate_stdlib Ac_mul_B!       LinearAlgebra false
+    @deprecate_stdlib Ac_mul_Bc!      LinearAlgebra false
+    @deprecate_stdlib A_ldiv_B!       LinearAlgebra false
+    @deprecate_stdlib At_ldiv_B!      LinearAlgebra false
+    @deprecate_stdlib Ac_ldiv_B!      LinearAlgebra false
+
+    ## types that were exported from Base.LinAlg but not from Base
+    @deprecate_stdlib BunchKaufman     LinearAlgebra false
+    @deprecate_stdlib Cholesky         LinearAlgebra false
+    @deprecate_stdlib CholeskyPivoted  LinearAlgebra false
+    @deprecate_stdlib Eigen            LinearAlgebra false
+    @deprecate_stdlib GeneralizedEigen LinearAlgebra false
+    @deprecate_stdlib GeneralizedSVD   LinearAlgebra false
+    @deprecate_stdlib GeneralizedSchur LinearAlgebra false
+    @deprecate_stdlib Hessenberg       LinearAlgebra false
+    @deprecate_stdlib LU               LinearAlgebra false
+    @deprecate_stdlib LDLt             LinearAlgebra false
+    @deprecate_stdlib QR               LinearAlgebra false
+    @deprecate_stdlib QRPivoted        LinearAlgebra false
+    @deprecate_stdlib LQ               LinearAlgebra false
+    @deprecate_stdlib Schur            LinearAlgebra false
+    @deprecate_stdlib SVD              LinearAlgebra false
+
+    ## deprecated functions that are moved to stdlib/LinearAlgebra/src/deprecated.jl
+    @deprecate_stdlib eye        LinearAlgebra true
+    @deprecate_stdlib sqrtm      LinearAlgebra true
+    @deprecate_stdlib expm       LinearAlgebra true
+    @deprecate_stdlib expm!      LinearAlgebra true
+    @deprecate_stdlib logm       LinearAlgebra true
+    @deprecate_stdlib gradient   LinearAlgebra true
+    @deprecate_stdlib ConjArray  LinearAlgebra true
+    @deprecate_stdlib ConjVector LinearAlgebra true
+    @deprecate_stdlib ConjMatrix LinearAlgebra true
+    @deprecate_stdlib RowVector  LinearAlgebra true
+
+    # PR #25021
+    @deprecate_stdlib normalize_string Unicode true
+    @deprecate_stdlib graphemes Unicode true
+    @deprecate_stdlib is_assigned_char Unicode true
 end
 
 empty!(DEPOT_PATH)


### PR DESCRIPTION
The long anticipated followup to #24843. Since we actually have the stdlib modules in the sysimage
we can deprecate correctly and still point to the right functions.

Turns
```julia
julia> readdlm("test.csv")
ERROR: Base.readdlm has been moved to the standard library package DelimitedFiles.
Restart Julia and then run `using DelimitedFiles` to load it.
Stacktrace:
 [1] error(::Function, ::String, ::String, ::String, ::String, ::String, ::String) at ./error.jl:42
 [2] #readdlm#829(::Base.Iterators.IndexValue{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::String, ::Vararg{String,N} where N) at ./deprecated.jl:138
 [3] readdlm(::String, ::Vararg{String,N} where N) at ./deprecated.jl:138
 [4] top-level scope

julia> using DelimitedFiles
WARNING: using DelimitedFiles.readdlm in module Main conflicts with an existing identifier.

julia> readdlm("test.csv")
ERROR: Base.readdlm has been moved to the standard library package DelimitedFiles.
Restart Julia and then run `using DelimitedFiles` to load it.
Stacktrace:
 [1] error(::Function, ::String, ::String, ::String, ::String, ::String, ::String) at ./error.jl:42
 [2] #readdlm#829(::Base.Iterators.IndexValue{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::String, ::Vararg{String,N} where N) at ./deprecated.jl:138
 [3] readdlm(::String, ::Vararg{String,N} where N) at ./deprecated.jl:138
 [4] top-level scope
```

into: 

```julia
julia> readdlm("test.csv")
┌ Warning: `readdlm`, has been moved to the standard library package `DelimitedFiles`.
│ Add a `using DelimitedFiles` to your imports.
│   caller = top-level scope
└ @ Core :0
ERROR: ArgumentError: Cannot open 'test.csv': not a file
```

This still leads to:

```julia
julia> readdlm("test.csv")
julia> using DelimitedFiles
WARNING: using DelimitedFiles.readdlm in module Main conflicts with an existing identifier.
```

- [x] Check if kwargs work
- [x] Deprecation warnings are printed multiple times