### PR TITLE
fix `using A.B` and `using A: B` warnings

### DIFF
--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -34,9 +34,8 @@ for more information.
 """
 module Dates
 
-import ..Base: ==, div, fld, mod, rem, gcd, lcm, +, -, *, /, %
-import ..Base.broadcast
-using Base.Printf.@sprintf
+import Base: ==, div, fld, mod, rem, gcd, lcm, +, -, *, /, %, broadcast
+using Printf: @sprintf
 
 using Base.Iterators
 

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -1,8 +1,9 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Serialization: serialize_cycle, deserialize_cycle, writetag,
-                     __deserialized_types__, serialize_typename, deserialize_typename,
+                     serialize_typename, deserialize_typename,
                      TYPENAME_TAG, reset_state, serialize_type
+using Serialization.__deserialized_types__
 
 import Serialization: object_number, lookup_object_number, remember_object
 

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -10,7 +10,7 @@ export @printf, @sprintf
 using Base.Printf: _printf, is_str_expr, fix_dec, DIGITS, print_fixed, decode_dec, decode_hex,
                    ini_hex, ini_HEX, print_exp_a, decode_0ct, decode_HEX, ini_dec, print_exp_e,
                    decode_oct, _limit
-using Unicode.textwidth
+using Unicode: textwidth
 
 """
     @printf([io::IOStream], "%Fmt", args...)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -9,7 +9,7 @@ module Profile
 
 import Base.StackTraces: lookup, UNKNOWN, show_spec_linfo
 using Base: iszero
-using Base.Printf.@sprintf
+using Printf: @sprintf
 
 export @profile
 

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -17,7 +17,7 @@ using Serialization: serialize_cycle_header, serialize_type, writetag, UNDEFREF_
 import Serialization: serialize, deserialize
 import Distributed: RRID, procs
 import Base.Filesystem: JL_O_CREAT, JL_O_RDWR, S_IRUSR, S_IWUSR
-using Base.Printf.@sprintf
+using Printf: @sprintf
 
 export SharedArray, SharedVector, SharedMatrix, sdata, indexpids, localindices
 

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -11,7 +11,7 @@ import LinearAlgebra: (\),
                  issuccess, issymmetric, ldltfact, ldltfact!, logdet
 
 using SparseArrays
-using Base.Printf.@printf
+using Printf: @printf
 
 import Libdl
 


### PR DESCRIPTION
fix `using A.B` and `using A: B` warnings in `Dates`, `Printf`, `Profile`, `SharedArrays`, `SuiteSparse` and `Distributed` stdlibs. The warnings are not visible when these stdlibs are
`required` in `sysimg.jl`.