### PR TITLE
fix "Deprecated syntax `"begin" inside indexing expression`" warning.

### DIFF
--- a/stdlib/Dates/src/parse.jl
+++ b/stdlib/Dates/src/parse.jl
@@ -55,30 +55,28 @@ Return a 3-element tuple `(values, pos, num_parsed)`:
 
     vi = 1
     parsers = Expr[
-        begin
-            if directives[i] <: DatePart
-                name = value_names[vi]
-                val = Symbol(:val, name)
-                vi += 1
-                quote
-                    pos > len && @goto done
-                    $val, next_pos = tryparsenext(directives[$i], str, pos, len, locale)
-                    $val === nothing && @goto error
-                    $name = $val
-                    pos = next_pos
-                    num_parsed += 1
-                    directive_index += 1
-                end
-            else
-                quote
-                    pos > len && @goto done
-                    delim, next_pos = tryparsenext(directives[$i], str, pos, len, locale)
-                    delim === nothing && @goto error
-                    pos = next_pos
-                    directive_index += 1
-                end
+        (if directives[i] <: DatePart
+            name = value_names[vi]
+            val = Symbol(:val, name)
+            vi += 1
+            quote
+                pos > len && @goto done
+                $val, next_pos = tryparsenext(directives[$i], str, pos, len, locale)
+                $val === nothing && @goto error
+                $name = $val
+                pos = next_pos
+                num_parsed += 1
+                directive_index += 1
             end
-        end
+        else
+            quote
+                pos > len && @goto done
+                delim, next_pos = tryparsenext(directives[$i], str, pos, len, locale)
+                delim === nothing && @goto error
+                pos = next_pos
+                directive_index += 1
+            end
+        end)
         for i in 1:length(directives)
     ]
 


### PR DESCRIPTION
This warning is only printed if `Dates` is not `require`d in `sysimg.jl`.

Edit: https://github.com/JuliaLang/julia/pull/25699/files?w=1 for easier review.