### PR TITLE
show module or binding name when using deprecated using syntax

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -647,9 +647,10 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
                     u = (jl_module_t*)jl_eval_global_var(import, name);
                 if (jl_is_module(u)) {
                     if (from) {
-                        jl_depwarn("`using A: B` will only be allowed for single bindings, not modules. Use "
-                                   "`using A.B` instead",
-                                   (jl_value_t*)jl_symbol("using"));
+                        char str [256];
+                        snprintf(str, sizeof(str), "`using A: B` will only be allowed for single bindings, not modules. Use "
+                                                   "`using A.B` instead to use the module `%s`", jl_symbol_name(u->name));
+                        jl_depwarn(str, (jl_value_t*)jl_symbol("using"));
                     }
                     jl_module_using(m, u);
                     if (m == jl_main_module && name == NULL) {
@@ -660,9 +661,10 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
                 }
                 else {
                     if (!from) {
-                        jl_depwarn("`using A.B` will only be allowed for modules, not single bindings. Use "
-                                   "`using A: B` instead",
-                                   (jl_value_t*)jl_symbol("using"));
+                        char str [256];
+                        snprintf(str, sizeof(str), "`using A.B` will only be allowed for modules, not single bindings. Use "
+                                                   "`using A: B` instead to use the binding `%s`", jl_symbol_name(name));
+                        jl_depwarn(str, (jl_value_t*)jl_symbol("using"));
                     }
                     jl_module_t *replacement = deprecation_replacement_module(import, name);
                     if (replacement)


### PR DESCRIPTION
Since the line info is usually useless, this might at least help a bit in locating where the problem is.

```jl
julia> using Base: LibGit2
┌ Warning: `using A: B` will only be allowed for single bindings, not modules. Use `using A.B` instead to use the module `LibGit2`
│   caller = ip:0x0
└ @ Core :-1

julia> using Base.LoadError
┌ Warning: `using A.B` will only be allowed for modules, not single bindings. Use `using A: B` instead to use the binding `LoadError`
│   caller = ip:0x0
└ @ Core :-1
```