### PR TITLE
Change keyword arguments back to regular NamedTuples

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -196,6 +196,11 @@ Breaking changes
 
 This section lists changes that do not have deprecation warnings.
 
+  * Keyword arguments are now `NamedTuple`s. This is a breaking change because iterating
+    `NamedTuple`s produces values only, whereas previously iteration over keyword arguments
+    inside of functions produced name, value pairs. The `pairs` function can be used to
+    extract both names and values. ([#24795])
+
   * `readuntil` now does *not* include the delimiter in its result, matching the
     behavior of `readline`. Pass `keep=true` to get the old behavior ([#25633]).
 
@@ -1221,6 +1226,7 @@ Command-line option changes
 [#24785]: https://github.com/JuliaLang/julia/issues/24785
 [#24786]: https://github.com/JuliaLang/julia/issues/24786
 [#24794]: https://github.com/JuliaLang/julia/issues/24794
+[#24795]: https://github.com/JuliaLang/julia/issues/24795
 [#24805]: https://github.com/JuliaLang/julia/issues/24805
 [#24808]: https://github.com/JuliaLang/julia/issues/24808
 [#24831]: https://github.com/JuliaLang/julia/issues/24831

--- a/base/interactiveutil.jl
+++ b/base/interactiveutil.jl
@@ -420,7 +420,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
             return quote
                 local arg1 = $(esc(args[1]))
                 $(fcn)(Core.kwfunc(arg1),
-                       Tuple{Any, Core.Typeof(arg1),
+                       Tuple{NamedTuple, Core.Typeof(arg1),
                              $(typesof)($(map(esc, args[2:end])...)).parameters...})
             end
         elseif ex0.head == :call

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -75,7 +75,7 @@ function arg_decl_parts(m::Method)
 end
 
 function kwarg_decl(m::Method, kwtype::DataType)
-    sig = rewrap_unionall(Tuple{kwtype, Any, unwrap_unionall(m.sig).parameters...}, m.sig)
+    sig = rewrap_unionall(Tuple{kwtype, NamedTuple, unwrap_unionall(m.sig).parameters...}, m.sig)
     kwli = ccall(:jl_methtable_lookup, Any, (Any, Any, UInt), kwtype.name.mt, sig, typemax(UInt))
     if kwli !== nothing
         kwli = kwli::Method

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -478,7 +478,7 @@
             ,(let (;; call mangled(vals..., [rest_kw,] pargs..., [vararg]...)
                    (ret `(return (call ,mangled
                                        ,@(if ordered-defaults keynames vals)
-                                       ,@(if (null? restkw) '() `((call (top pairs) (call (core NamedTuple)))))
+                                       ,@(if (null? restkw) '() `((call (core NamedTuple))))
                                        ,@(map arg-name pargl)
                                        ,@(if (null? vararg) '()
                                              (list `(... ,(arg-name (car vararg)))))))))
@@ -513,13 +513,13 @@
           `((|::|
              ;; if there are optional positional args, we need to be able to reference the function name
              ,(if (any kwarg? pargl) (gensy) UNUSED)
-             (call (core kwftype) ,ftype)) ,kw ,@pargl ,@vararg)
+             (call (core kwftype) ,ftype)) (:: ,kw (core NamedTuple)) ,@pargl ,@vararg)
           `(block
             ,(scopenest
               keynames
               (map (lambda (v dflt)
                      (let* ((k     (decl-var v))
-                            (rval0 `(call (top getindex) ,kw (inert ,k)))
+                            (rval0 `(call (top getfield) ,kw (quote ,k)))
                             ;; note: if the "declared" type of a KW arg includes something
                             ;; from keyword-sparams then don't assert it here, since those
                             ;; static parameters don't have values yet. instead, the type
@@ -548,11 +548,10 @@
                             ,dflt)))
                    vars vals)
               `(block
-                (= ,rkw (call (top pairs)
-                              ,(if (null? keynames)
-                                   kw
-                                   `(call (top structdiff) ,kw (curly (core NamedTuple)
-                                                                      (tuple ,@(map quotify keynames)))))))
+                (= ,rkw ,(if (null? keynames)
+                             kw
+                             `(call (top structdiff) ,kw (curly (core NamedTuple)
+                                                                (tuple ,@(map quotify keynames))))))
                 ,@(if (null? restkw)
                       `((if (call (top isempty) ,rkw)
                             (null)

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -483,8 +483,8 @@ const valid_opts = [:header, :has_header, :use_mmap, :quotes, :comments, :dims, 
 const valid_opt_types = [Bool, Bool, Bool, Bool, Bool, NTuple{2,Integer}, Char, Integer, Bool]
 
 function val_opts(opts)
-    d = Dict{Symbol, Union{Bool, NTuple{2, Integer}, Char, Integer}}()
-    for (opt_name, opt_val) in opts
+    d = Dict{Symbol,Union{Bool,NTuple{2,Integer},Char,Integer}}()
+    for (opt_name, opt_val) in pairs(opts)
         in(opt_name, valid_opts) ||
             throw(ArgumentError("unknown option $opt_name"))
         opt_typ = valid_opt_types[findfirst(equalto(opt_name), valid_opts)::Int]

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -370,7 +370,7 @@ function addprocs(manager::ClusterManager; kwargs...)
 end
 
 function addprocs_locked(manager::ClusterManager; kwargs...)
-    params = merge(default_addprocs_params(), AnyDict(kwargs))
+    params = merge(default_addprocs_params(), AnyDict(pairs(kwargs)))
     topology(Symbol(params[:topology]))
 
     if PGRP.topology != :all_to_all

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -103,7 +103,7 @@ f25130()
 testlogs = testlogger.logs
 @test length(testlogs) == 2
 @test testlogs[1].id != testlogs[2].id
-@test testlogs[1].kwargs[:caller].func == Symbol("top-level scope")
+@test testlogs[1].kwargs.caller.func == Symbol("top-level scope")
 @test all(l.message == "f25130 message" for l in testlogs)
 global_logger(prev_logger)
 

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -116,11 +116,11 @@ error_out3 = String(take!(buf))
 
 c7line = @__LINE__() + 1
 method_c7(a, b; kargs...) = a
-Base.show_method_candidates(buf, MethodError(method_c7, (1, 1)), pairs((x = 1, y = 2)))
+Base.show_method_candidates(buf, MethodError(method_c7, (1, 1)), (x = 1, y = 2))
 @test String(take!(buf)) == "\nClosest candidates are:\n  method_c7(::Any, ::Any; kargs...)$cfile$c7line"
 c8line = @__LINE__() + 1
 method_c8(a, b; y=1, w=1) = a
-Base.show_method_candidates(buf, MethodError(method_c8, (1, 1)), pairs((x = 1, y = 2, z = 1, w = 1)))
+Base.show_method_candidates(buf, MethodError(method_c8, (1, 1)), (x = 1, y = 2, z = 1, w = 1))
 @test String(take!(buf)) == "\nClosest candidates are:\n  method_c8(::Any, ::Any; y, w)$cfile$c8line got unsupported keyword arguments \"x\", \"z\""
 
 let no_kwsorter_match, e
@@ -134,7 +134,7 @@ ac15639line = @__LINE__
 addConstraint_15639(c::Int32) = c
 addConstraint_15639(c::Int64; uncset=nothing) = addConstraint_15639(Int32(c), uncset=uncset)
 
-Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), pairs((uncset = nothing,)))
+Base.show_method_candidates(buf, MethodError(addConstraint_15639, (Int32(1),)), (uncset = nothing,))
 @test String(take!(buf)) == "\nClosest candidates are:\n  addConstraint_15639(::Int32)$cfile$(ac15639line + 1) got unsupported keyword argument \"uncset\"\n  addConstraint_15639(!Matched::Int64; uncset)$cfile$(ac15639line + 2)"
 
 macro except_str(expr, err_type)
@@ -487,7 +487,7 @@ foo_9965(x::Int) = 2x
     end
     @test typeof(ex) == MethodError
     io = IOBuffer()
-    Base.show_method_candidates(io, ex, pairs((w = true,)))
+    Base.show_method_candidates(io, ex, (w = true,))
     @test contains(String(take!(io)), "got unsupported keyword argument \"w\"")
 end
 

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -188,7 +188,7 @@ function test4974(;kwargs...)
     end
 end
 
-@test test4974(a=1) == (2, pairs((a=1,)))
+@test test4974(a=1) == (2, (a=1,))
 
 @testset "issue #7704, computed keywords" begin
     @test kwf1(1; :tens => 2) == 21
@@ -300,11 +300,11 @@ end
         counter += 1
         return counter
     end
-    f(args...; kws...) = (args, values(kws))
+    f(args...; kws...) = (args, kws)
     @test f(get_next(), a=get_next(), get_next(),
             b=get_next(), get_next(),
             [get_next(), get_next()]...; c=get_next(),
             (d = get_next(), f = get_next())...) ==
-                ((1, 3, 5, 6, 7),
+                ((1,3,5,6,7),
                  (a = 2, b = 4, c = 8, d = 9, f = 10))
 end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -839,7 +839,7 @@ let f = function (x; kw...)
     g = function (x; a = 2)
             return (x, a)
         end
-    @test f(1) == (1, pairs(NamedTuple()))
+    @test f(1) == (1, NamedTuple())
     @test g(1) == (1, 2)
 end
 


### PR DESCRIPTION
Ref discussion in #25675. This reverts "undo breaking change to kwargs iteration order" (#25290) and makes keyword arguments regular ol' `NamedTuple`s again. This is breaking, since `NamedTuple`s iterate values rather than pairs (which motivated #25290) and so iteration of keyword arguments will be broken. Users who want the `(name, value)` iteration will need to use `pairs`.