### PR TITLE
Fixes for logging during bootstrap

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -490,7 +490,7 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
     end
     buf = IOBuffer()
     iob = IOContext(buf, logger.stream)
-    levelstr = string(level)
+    levelstr = level == Warn ? "Warning" : string(level)
     msglines = split(chomp(string(message)), '\n')
     println(iob, "┌ ", levelstr, ": ", msglines[1])
     for i in 2:length(msglines)

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -481,37 +481,23 @@ min_enabled_level(logger::SimpleLogger) = logger.min_level
 
 function handle_message(logger::SimpleLogger, level, message, _module, group, id,
                         filepath, line; maxlog=nothing, kwargs...)
-    # TODO: Factor out more complex things here into a separate logger in
-    # stdlib: in particular maxlog support + colorization.
     if maxlog != nothing && maxlog isa Integer
         remaining = get!(logger.message_limits, id, maxlog)
         logger.message_limits[id] = remaining - 1
         remaining > 0 || return
     end
-    levelstr, color = level < Info  ? ("Debug", Base.debug_color()) :
-                      level < Warn  ? ("Info", Base.info_color()) :
-                      level < Error ? ("Warning", Base.warn_color()) :
-                                      ("Error", Base.error_color())
     buf = IOBuffer()
     iob = IOContext(buf, logger.stream)
+    levelstr = string(level)
     msglines = split(chomp(string(message)), '\n')
-    if length(msglines) + length(kwargs) == 1
-        print_with_color(color, iob, "[ ", levelstr, ": ", bold=true)
-        print(iob, msglines[1], " ")
-    else
-        print_with_color(color, iob, "┌ ", levelstr, ": ", bold=true)
-        println(iob, msglines[1])
-        for i in 2:length(msglines)
-            print_with_color(color, iob, "│ ", bold=true)
-            println(iob, msglines[i])
-        end
-        for (key,val) in pairs(kwargs)
-            print_with_color(color, iob, "│ ", bold=true)
-            println(iob, "  ", key, " = ", val)
-        end
-        print_with_color(color, iob, "└ ", bold=true)
+    println(iob, "┌ ", levelstr, ": ", msglines[1])
+    for i in 2:length(msglines)
+        println(iob, "│ ", msglines[i])
     end
-    print_with_color(:light_black, iob, "@ ", _module, " ", basename(filepath), ":", line, "\n")
+    for (key,val) in pairs(kwargs)
+        println(iob, "│   ", key, " = ", val)
+    end
+    println(iob, "└ @ ", _module, " ", filepath, ":", line)
     write(logger.stream, take!(buf))
     nothing
 end

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -479,6 +479,8 @@ shouldlog(logger::SimpleLogger, level, _module, group, id) =
 
 min_enabled_level(logger::SimpleLogger) = logger.min_level
 
+catch_exceptions(logger::SimpleLogger) = false
+
 function handle_message(logger::SimpleLogger, level, message, _module, group, id,
                         filepath, line; maxlog=nothing, kwargs...)
     if maxlog != nothing && maxlog isa Integer

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -378,7 +378,7 @@ end
 
 LogState(logger) = LogState(LogLevel(min_enabled_level(logger)), logger)
 
-_global_logstate = LogState(NullLogger()) # See __init__
+_global_logstate = LogState(NullLogger())
 
 function current_logstate()
     logstate = current_task().logstate

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -253,6 +253,7 @@ include("arrayshow.jl")
 # Logging
 include("logging.jl")
 using .CoreLogging
+global_logger(SimpleLogger(Core.STDERR, CoreLogging.Info))
 
 # multidimensional arrays
 include("cartesian.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -250,11 +250,6 @@ include("regex.jl")
 include("show.jl")
 include("arrayshow.jl")
 
-# Logging
-include("logging.jl")
-using .CoreLogging
-global_logger(SimpleLogger(Core.STDERR, CoreLogging.Info))
-
 # multidimensional arrays
 include("cartesian.jl")
 using .Cartesian
@@ -313,6 +308,11 @@ include("task.jl")
 include("lock.jl")
 include("threads.jl")
 include("weakkeydict.jl")
+
+# Logging
+include("logging.jl")
+using .CoreLogging
+global_logger(SimpleLogger(Core.STDERR, CoreLogging.Info))
 
 # To limit dependency on rand functionality (implemented in the Random
 # module), Crand is used in file.jl, and could be used in error.jl

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -2,7 +2,7 @@
 
 using Base.CoreLogging
 import Base.CoreLogging: BelowMinLevel, Debug, Info, Warn, Error,
-    handle_message, shouldlog, min_enabled_level
+    handle_message, shouldlog, min_enabled_level, catch_exceptions
 
 import Test: collect_test_logs, TestLogger
 using Base.Printf: @sprintf
@@ -231,6 +231,7 @@ end
     @test shouldlog(logger, Info, Base, :group, :asdf) === true
     handle_message(logger, Info, "msg", Base, :group, :asdf, "somefile", 1, maxlog=2)
     @test shouldlog(logger, Info, Base, :group, :asdf) === false
+    @test catch_exceptions(logger) === false
 
     # Log formatting
     function genmsg(level, message, _module, filepath, line; kws...)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -252,7 +252,7 @@ end
     # Multiline message
     @test genmsg(Warn, "line1\nline2", Main, "some/path.jl", 101) ==
     """
-    ┌ Warn: line1
+    ┌ Warning: line1
     │ line2
     └ @ Main some/path.jl:101
     """

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -238,26 +238,22 @@ end
         logger = SimpleLogger(io, Debug)
         handle_message(logger, level, message, _module, :group, :id,
                        filepath, line; kws...)
-        s = String(take!(io))
-        # Remove the small amount of color, as `Base.print_with_color` can't be
-        # simply controlled.
-        s = replace(s, r"^\e\[1m\e\[..m(.*)\e\[39m\e\[22m"m => s"\1")
-        # println(s)
-        s
+        String(take!(io))
     end
 
     # Simple
     @test genmsg(Info, "msg", Main, "some/path.jl", 101) ==
     """
-    [ Info: msg @ Main path.jl:101
+    ┌ Info: msg
+    └ @ Main some/path.jl:101
     """
 
     # Multiline message
     @test genmsg(Warn, "line1\nline2", Main, "some/path.jl", 101) ==
     """
-    ┌ Warning: line1
+    ┌ Warn: line1
     │ line2
-    └ @ Main path.jl:101
+    └ @ Main some/path.jl:101
     """
 
     # Keywords


### PR DESCRIPTION
Here's some fixes to make logging reliable while building the sysimg.

* Install `SimpleLogger` during sysimg build instead of `NullLogger` so that build warnings will be reported - see https://github.com/JuliaLang/julia/pull/25699#issuecomment-359747830
* For now, move the inclusion of `logging.jl` later in the sysimg, as it requires `current_task()` to be defined. With extra effort this could be defined further up but this seems simplest for now.
* Use simpler formatting for `SimpleLogger` so it can be relied on earlier during bootstrap (don't rely on color printing or path manipulation).  User friendly formatting is now provided by `ConsoleLogger` instead.
* Don't catch logging exceptions inside `SimpleLogger`; let them propagate out as obvious errors instead.