### PR TITLE
Make printing of UnitLower/UpperTriangular similar to the non-Unit versions

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -53,6 +53,8 @@ export
     Symmetric,
     LowerTriangular,
     UpperTriangular,
+    UnitLowerTriangular,
+    UnitUpperTriangular,
     Diagonal,
     UniformScaling,
 

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -218,13 +218,14 @@ end
 
 
 ## structured matrix methods ##
-function Base.replace_in_print_matrix(A::UpperTriangular,i::Integer,j::Integer,s::AbstractString)
-    i<=j ? s : Base.replace_with_centered_mark(s)
+function Base.replace_in_print_matrix(A::Union{UpperTriangular,UnitUpperTriangular},
+                                      i::Integer, j::Integer, s::AbstractString)
+    return i <= j ? s : Base.replace_with_centered_mark(s)
 end
-function Base.replace_in_print_matrix(A::LowerTriangular,i::Integer,j::Integer,s::AbstractString)
-    i>=j ? s : Base.replace_with_centered_mark(s)
+function Base.replace_in_print_matrix(A::Union{LowerTriangular,UnitLowerTriangular},
+                                      i::Integer, j::Integer, s::AbstractString)
+    return i >= j ? s : Base.replace_with_centered_mark(s)
 end
-
 
 istril(A::LowerTriangular) = true
 istril(A::UnitLowerTriangular) = true

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -538,4 +538,15 @@ end
     end
 end
 
+@testset "special printing of Lower/UpperTriangular" begin
+    @test sprint(show, MIME"text/plain"(), LowerTriangular(2ones(Int64,3,3))) ==
+        "3×3 LinearAlgebra.LowerTriangular{Int64,Array{Int64,2}}:\n 2  ⋅  ⋅\n 2  2  ⋅\n 2  2  2"
+    @test sprint(show, MIME"text/plain"(), UnitLowerTriangular(2ones(Int64,3,3))) ==
+        "3×3 LinearAlgebra.UnitLowerTriangular{Int64,Array{Int64,2}}:\n 1  ⋅  ⋅\n 2  1  ⋅\n 2  2  1"
+    @test sprint(show, MIME"text/plain"(), UpperTriangular(2ones(Int64,3,3))) ==
+        "3×3 LinearAlgebra.UpperTriangular{Int64,Array{Int64,2}}:\n 2  2  2\n ⋅  2  2\n ⋅  ⋅  2"
+    @test sprint(show, MIME"text/plain"(), UnitUpperTriangular(2ones(Int64,3,3))) ==
+        "3×3 LinearAlgebra.UnitUpperTriangular{Int64,Array{Int64,2}}:\n 1  2  2\n ⋅  1  2\n ⋅  ⋅  1"
+end
+
 end # module TestTriangular


### PR DESCRIPTION
and export the Unit types. I.e.
```julia
julia> using LinearAlgebra

julia> UnitLowerTriangular(2ones(Int,3,3))
3×3 UnitLowerTriangular{Int64,Array{Int64,2}}:
 1  ⋅  ⋅
 2  1  ⋅
 2  2  1
```