### PR TITLE
Audit iterator traits to make sure they're always called on types

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -401,7 +401,7 @@ end
 
 # pass-through iterator traits to the iterable
 # on which the mapping function is being applied
-IteratorSize(itr::AsyncGenerator) = IteratorSize(itr.collector.enumerator)
+IteratorSize(itr::AsyncGenerator) = SizeUnknown()
 size(itr::AsyncGenerator) = size(itr.collector.enumerator)
 length(itr::AsyncGenerator) = length(itr.collector.enumerator)
 

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -53,8 +53,6 @@ function copy!(dest::BitSet, src::BitSet)
     dest
 end
 
-eltype(s::BitSet) = Int
-
 sizehint!(s::BitSet, n::Integer) = (sizehint!(s.bits, (n+63) >> 6); s)
 
 function _bits_getindex(b::Bits, n::Int, offset::Int)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -72,11 +72,11 @@ reverse(itr) = Reverse(itr)
 struct Reverse{T}
     itr::T
 end
-eltype(r::Reverse) = eltype(r.itr)
+eltype(::Type{Reverse{T}}) where {T} = eltype(T)
 length(r::Reverse) = length(r.itr)
 size(r::Reverse) = size(r.itr)
-IteratorSize(r::Reverse) = IteratorSize(r.itr)
-IteratorEltype(r::Reverse) = IteratorEltype(r.itr)
+IteratorSize(::Type{Reverse{T}}) where {T} = IteratorSize(T)
+IteratorEltype(::Type{Reverse{T}}) where {T} = IteratorEltype(T)
 last(r::Reverse) = first(r.itr) # the first shall be last
 first(r::Reverse) = last(r.itr) # and the last shall be first
 
@@ -748,9 +748,10 @@ function IteratorEltype(::Type{ProductIterator{T}}) where {T<:Tuple}
     IteratorEltype(I) == EltypeUnknown() ? EltypeUnknown() : IteratorEltype(P)
 end
 
-eltype(P::ProductIterator) = _prod_eltype(P.iterators)
-_prod_eltype(::Tuple{}) = Tuple{}
-_prod_eltype(t::Tuple) = Base.tuple_type_cons(eltype(t[1]),_prod_eltype(tail(t)))
+eltype(::Type{<:ProductIterator{I}}) where {I} = _prod_eltype(I)
+_prod_eltype(::Type{Tuple{}}) = Tuple{}
+_prod_eltype(::Type{I}) where {I<:Tuple} =
+    Base.tuple_type_cons(eltype(tuple_type_head(I)),_prod_eltype(tuple_type_tail(I)))
 
 start(::ProductIterator{Tuple{}}) = false
 next(::ProductIterator{Tuple{}}, state) = (), true

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -166,7 +166,7 @@ struct SkipMissing{T}
 end
 IteratorSize(::Type{<:SkipMissing}) = SizeUnknown()
 IteratorEltype(::Type{SkipMissing{T}}) where {T} = IteratorEltype(T)
-eltype(itr::SkipMissing) = nonmissingtype(eltype(itr.x))
+eltype(::Type{SkipMissing{T}}) where {T} = nonmissingtype(eltype(T))
 # Fallback implementation for general iterables: we cannot access a value twice,
 # so after finding the next non-missing element in start() or next(), we have to
 # pass it in the iterator state, which introduces a type instability since the value

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -89,7 +89,7 @@ module IteratorsMD
 
     # indexing
     getindex(index::CartesianIndex, i::Integer) = index.I[i]
-    eltype(index::CartesianIndex) = eltype(index.I)
+    eltype(::Type{T}) where {T<:CartesianIndex} = eltype(fieldtype(T, :I))
 
     # access to index tuple
     Tuple(index::CartesianIndex) = index.I
@@ -272,7 +272,6 @@ module IteratorsMD
         CartesianIndices(axsA)
     end
 
-    eltype(R::CartesianIndices) = eltype(typeof(R))
     eltype(::Type{CartesianIndices{N}}) where {N} = CartesianIndex{N}
     eltype(::Type{CartesianIndices{N,TT}}) where {N,TT} = CartesianIndex{N}
     IteratorSize(::Type{<:CartesianIndices{N}}) where {N} = Base.HasShape{N}()

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -37,7 +37,7 @@ const => = Pair
 start(p::Pair) = 1
 done(p::Pair, i) = i>2
 next(p::Pair, i) = (getfield(p,i), i+1)
-eltype(p::Pair{A,B}) where {A,B} = Union{A,B}
+eltype(p::Type{Pair{A,B}}) where {A,B} = Union{A,B}
 
 indexed_next(p::Pair, i::Int, state) = (getfield(p,i), i+1)
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -820,9 +820,10 @@ wait(x::ProcessChain) = for p in x.processes; wait(p); end
 show(io::IO, p::Process) = print(io, "Process(", p.cmd, ", ", process_status(p), ")")
 
 # allow the elements of the Cmd to be accessed as an array or iterator
-for f in (:length, :endof, :start, :keys, :eltype, :first, :last)
+for f in (:length, :endof, :start, :keys, :first, :last)
     @eval $f(cmd::Cmd) = $f(cmd.exec)
 end
+eltype(::Type{Cmd}) = eltype(fieldtype(Cmd, :exec))
 for f in (:next, :done, :getindex)
     @eval $f(cmd::Cmd, i) = $f(cmd.exec, i)
 end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -35,7 +35,6 @@ end
 
 parent(a::ReinterpretArray) = a.parent
 
-eltype(a::ReinterpretArray{T}) where {T} = T
 function size(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     psize = size(a.parent)
     size1 = div(psize[1]*sizeof(S), sizeof(T))

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -95,7 +95,7 @@ const BitFloatType = Union{Type{Float16},Type{Float32},Type{Float64}}
 
 abstract type Sampler{E} end
 
-Base.eltype(::Sampler{E}) where {E} = E
+Base.eltype(::Type{Sampler{E}}) where {E} = E
 
 # temporarily for BaseBenchmarks
 RangeGenerator(x) = Sampler(GLOBAL_RNG, x)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1451,7 +1451,7 @@ for (G, A) in ((GenericSet, AbstractSet),
         Base.done(s::$G, state) = done(s.s, state)
         Base.next(s::$G, state) = next(s.s, state)
     end
-    for f in (:eltype, :isempty, :length, :start)
+    for f in (:isempty, :length, :start)
         @eval begin
             Base.$f(s::$G) = $f(s.s)
         end


### PR DESCRIPTION
The iterator wrappers assume that eltype is called on the type of
the wrapped iterator, not the value itself, so all objects that
implement these traits need to do so. Audit all of them in base
and make sure that's the case.