### PR TITLE
`replace` - collection of chars. fix #25741

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -392,9 +392,12 @@ _replace(io, repl::Function, str, r, pattern) =
 
 replace(str::String, pat_repl::Pair{Char}; count::Integer=typemax(Int)) =
     replace(str, equalto(first(pat_repl)) => last(pat_repl); count=count)
-replace(str::String, pat_repl::Pair{<:Union{Tuple{Vararg{Char}},AbstractVector{Char},Set{Char}}};
+
+replace(str::String, pat_repl::Pair{<:Union{Tuple{Vararg{Char}},
+                                            AbstractVector{Char},Set{Char}}};
         count::Integer=typemax(Int)) =
-    replace(str, occursin(first(pat_repl)) => last(pat_repl), count)
+    replace(str, occursin(first(pat_repl)) => last(pat_repl), count=count)
+
 function replace(str::String, pat_repl::Pair; count::Integer=typemax(Int))
     pattern, repl = pat_repl
     count == 0 && return str

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -258,6 +258,9 @@ end
         @test replace(s, 'a' => 'z', count=typemax(Int)) == "zzz"
         @test replace(s, 'a' => 'z')    == "zzz"
     end
+
+    # Issue 25741
+    @test replace("abc", ['a', 'd'] => 'A') == "Abc"
 end
 
 @testset "chomp/chop" begin


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/25741.

In the call `replace("", ['q'] =>"A")` the method dispatches to the wrong implementation, because no keyword-argument was used.