### PR TITLE
Avoid Julia warnings during the build

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -309,7 +309,7 @@ reducedim(op, A::AbstractArray, region) = mapreducedim(identity, op, A, region)
 
 ##### Specific reduction functions #####
 """
-    sum(A, dims)
+    sum(A::AbstractArray, dims)
 
 Sum elements of an array over the given dimensions.
 
@@ -330,7 +330,7 @@ julia> sum(A, 2)
  7
 ```
 """
-sum(A, dims)
+sum(A::AbstractArray, dims)
 
 """
     sum!(r, A)
@@ -357,7 +357,7 @@ julia> sum!([1 1], A)
 sum!(r, A)
 
 """
-    prod(A, dims)
+    prod(A::AbstractArray, dims)
 
 Multiply elements of an array over the given dimensions.
 
@@ -378,7 +378,7 @@ julia> prod(A, 2)
  12
 ```
 """
-prod(A, dims)
+prod(A::AbstractArray, dims)
 
 """
     prod!(r, A)

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -62,6 +62,7 @@ let groupings = [1:8; 10:13; 15:18; 20:23; 25:36]
 end
 
 let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
+    global string
     function string(u::UUID)
         u = u.value
         a = Base.StringVector(36)


### PR DESCRIPTION
Previously they were being silently hidden, but now that we show them during the build, it turns out there are a few places where we're emitting warnings.