### PR TITLE
refactor Base._start to be more modular

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -168,7 +168,7 @@ end
 display_error(er, bt) = display_error(STDERR, er, bt)
 display_error(er) = display_error(er, [])
 
-function eval_user_input(@nospecialize(ast), show_value)
+function eval_user_input(@nospecialize(ast), show_value::Bool)
     errcount, lasterr, bt = 0, (), nothing
     while true
         try
@@ -176,7 +176,7 @@ function eval_user_input(@nospecialize(ast), show_value)
                 print(color_normal)
             end
             if errcount > 0
-                display_error(lasterr,bt)
+                invokelatest(display_error, lasterr, bt)
                 errcount, lasterr = 0, ()
             else
                 ast = Meta.lower(Main, ast)
@@ -187,7 +187,7 @@ function eval_user_input(@nospecialize(ast), show_value)
                         print(answer_color())
                     end
                     try
-                        eval(Main, Expr(:body, Expr(:return, Expr(:call, display, QuoteNode(value)))))
+                        invokelatest(display, value)
                     catch err
                         println(STDERR, "Evaluation succeeded, but an error occurred while showing value of type ", typeof(value), ":")
                         rethrow(err)
@@ -208,18 +208,11 @@ function eval_user_input(@nospecialize(ast), show_value)
             bt = catch_backtrace()
         end
     end
-    isa(STDIN,TTY) && println()
+    isa(STDIN, TTY) && println()
+    nothing
 end
 
 function parse_input_line(s::String; filename::String="none", depwarn=true)
-    # (expr, pos) = Meta.parse(s, 1)
-    # (ex, pos) = ccall(:jl_parse_string, Any,
-    #                   (Ptr{UInt8},Csize_t,Int32,Int32),
-    #                   s, sizeof(s), pos-1, 1)
-    # if ex!==()
-    #     throw(Meta.ParseError("extra input after end of expression"))
-    # end
-    # expr
     # For now, assume all parser warnings are depwarns
     ex = with_logger(depwarn ? current_logger() : NullLogger()) do
         ccall(:jl_parse_input_line, Any, (Ptr{UInt8}, Csize_t, Ptr{UInt8}, Csize_t),
@@ -259,10 +252,10 @@ function incomplete_tag(ex::Expr)
     return :other
 end
 
-# try to include() a file, ignoring if not found
-try_include(mod::Module, path::AbstractString) = isfile(path) && include(mod, path)
+# call include() on a file, ignoring if not found
+include_ifexists(mod::Module, path::AbstractString) = isfile(path) && include(mod, path)
 
-function process_options(opts::JLOptions)
+function exec_options(opts)
     if !isempty(ARGS)
         idxs = findall(x -> x == "--", ARGS)
         length(idxs) > 0 && deleteat!(ARGS, idxs[1])
@@ -270,8 +263,8 @@ function process_options(opts::JLOptions)
     quiet                 = (opts.quiet != 0)
     startup               = (opts.startupfile != 2)
     history_file          = (opts.historyfile != 0)
-    color_set             = (opts.color != 0)
-    global have_color     = (opts.color == 1)
+    color_set             = (opts.color != 0) # --color!=auto
+    global have_color     = (opts.color == 1) # --color=on
     global is_interactive = (opts.isinteractive != 0)
 
     # pre-process command line argument list
@@ -334,7 +327,17 @@ function process_options(opts::JLOptions)
         include(Main, PROGRAM_FILE)
     end
     repl |= is_interactive
-    return (quiet, repl, startup, color_set, history_file)
+    if repl
+        interactiveinput = isa(STDIN, TTY)
+        if interactiveinput
+            global is_interactive = true
+            banner = (opts.banner != 0) # --banner!=no
+        else
+            banner = (opts.banner == 1) # --banner=yes
+        end
+        run_main_repl(interactiveinput, quiet, banner, history_file, color_set)
+    end
+    nothing
 end
 
 function load_juliarc()
@@ -343,9 +346,9 @@ function load_juliarc()
     if !isempty(Base.SYSCONFDIR) && isfile(joinpath(Sys.BINDIR, Base.SYSCONFDIR, "julia", "juliarc.jl"))
         include(Main, abspath(Sys.BINDIR, Base.SYSCONFDIR, "julia", "juliarc.jl"))
     else
-        try_include(Main, abspath(Sys.BINDIR, "..", "etc", "julia", "juliarc.jl"))
+        include_ifexists(Main, abspath(Sys.BINDIR, "..", "etc", "julia", "juliarc.jl"))
     end
-    try_include(Main, abspath(homedir(), ".juliarc.jl"))
+    include_ifexists(Main, abspath(homedir(), ".juliarc.jl"))
     nothing
 end
 
@@ -376,71 +379,69 @@ _atreplinit(repl) = invokelatest(__atreplinit, repl)
 # The REPL stdlib hooks into Base using this Ref
 const REPL_MODULE_REF = Ref{Module}()
 
+# run the requested sort of evaluation loop on stdio
+function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
+    if interactive && isassigned(REPL_MODULE_REF)
+        invokelatest(REPL_MODULE_REF[]) do REPL
+            term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
+            term = REPL.Terminals.TTYTerminal(term_env, STDIN, STDOUT, STDERR)
+            color_set || (global have_color = REPL.Terminals.hascolor(term))
+            banner && REPL.banner(term, term)
+            if term.term_type == "dumb"
+                active_repl = REPL.BasicREPL(term)
+                quiet || @warn "Terminal not fully functional"
+            else
+                active_repl = REPL.LineEditREPL(term, have_color, true)
+                active_repl.history_file = history_file
+            end
+            # Make sure any displays pushed in .juliarc.jl ends up above the
+            # REPLDisplay
+            pushdisplay(REPL.REPLDisplay(active_repl))
+            _atreplinit(active_repl)
+            REPL.run_repl(active_repl, backend->(global active_repl_backend = backend))
+        end
+    else
+        # otherwise provide a simple fallback
+        if interactive && !quiet
+            @warn "REPL provider not available: using basic fallback"
+        end
+        banner && Base.banner()
+        let input = STDIN
+            if isa(input, File) || isa(input, IOStream)
+                # for files, we can slurp in the whole thing at once
+                ex = parse_input_line(read(input, String))
+                if Meta.isexpr(ex, :toplevel)
+                    # if we get back a list of statements, eval them sequentially
+                    # as if we had parsed them sequentially
+                    for stmt in ex.args
+                        eval_user_input(stmt, true)
+                    end
+                    body = ex.args
+                else
+                    eval_user_input(ex, true)
+                end
+            else
+                while isopen(input) || !eof(input)
+                    if interactive
+                        print("julia> ")
+                        flush(STDOUT)
+                    end
+                    eval_user_input(parse_input_line(input), true)
+                end
+            end
+        end
+    end
+    nothing
+end
+
 function _start()
-    repl_stdlib_loaded = isassigned(REPL_MODULE_REF)
     empty!(ARGS)
     append!(ARGS, Core.ARGS)
-    opts = JLOptions()
     @eval Main using Base.MainInclude
     try
-        (quiet,repl,startup,color_set,history_file) = process_options(opts)
-        banner = opts.banner == 1
-
-        global active_repl
-        global active_repl_backend
-        if repl
-            if !isa(STDIN,TTY)
-                global is_interactive |= !isa(STDIN, Union{File, IOStream})
-                banner |= opts.banner != 0 && is_interactive
-                color_set || (global have_color = false)
-            else
-                if !repl_stdlib_loaded
-                    error("REPL standard library not loaded, cannot start a REPL.")
-                end
-                term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
-                term = REPL_MODULE_REF[].Terminals.TTYTerminal(term_env, STDIN, STDOUT, STDERR)
-                global is_interactive = true
-                banner |= opts.banner != 0
-                color_set || (global have_color = REPL_MODULE_REF[].Terminals.hascolor(term))
-                banner && REPL_MODULE_REF[].banner(term,term)
-                if term.term_type == "dumb"
-                    active_repl = REPL_MODULE_REF[].BasicREPL(term)
-                    quiet || @warn "Terminal not fully functional"
-                else
-                    active_repl = REPL_MODULE_REF[].LineEditREPL(term, have_color, true)
-                    active_repl.history_file = history_file
-                end
-                # Make sure any displays pushed in .juliarc.jl ends up above the
-                # REPLDisplay
-                pushdisplay(REPL_MODULE_REF[].REPLDisplay(active_repl))
-            end
-        else
-            banner |= opts.banner != 0 && is_interactive
-        end
-
-        if repl
-            if !isa(STDIN,TTY)
-                # note: currently IOStream is used for file STDIN
-                if isa(STDIN,File) || isa(STDIN,IOStream)
-                    # reading from a file, behave like include
-                    eval(Main,parse_input_line(read(STDIN, String)))
-                else
-                    # otherwise behave repl-like
-                    while !eof(STDIN)
-                        eval_user_input(parse_input_line(STDIN), true)
-                    end
-                end
-            else
-                if !repl_stdlib_loaded
-                    error("REPL standard library not loaded")
-                end
-                _atreplinit(active_repl)
-                REPL_MODULE_REF[].run_repl(active_repl, backend->(global active_repl_backend = backend))
-            end
-        end
+        exec_options(JLOptions())
     catch err
-        eval(Main, Expr(:body, Expr(:return, Expr(:call, Base.display_error,
-                                                  QuoteNode(err), catch_backtrace()))))
+        invokelatest(display_error, err, catch_backtrace())
         exit(1)
     end
     if is_interactive && have_color

--- a/base/precompile.jl
+++ b/base/precompile.jl
@@ -285,7 +285,7 @@ precompile(Tuple{getfield(Base, Symbol("#kw##spawn")), Array{Any, 1}, typeof(Bas
 precompile(Tuple{typeof(Core.Compiler.isbits), Tuple{Tuple{String}, Tuple{String}, Tuple{String}}})
 precompile(Tuple{typeof(Base.cmd_gen), Tuple{Tuple{String}, Tuple{String}, Tuple{String}}})
 precompile(Tuple{typeof(Base.append!), Array{String, 1}, Array{Any, 1}})
-precompile(Tuple{typeof(Base.process_options), Base.JLOptions})
+precompile(Tuple{typeof(Base.exec_options), Base.JLOptions})
 precompile(Tuple{typeof(Base.close), Base.IOStream})
 precompile(Tuple{typeof(Base._atexit)})
 precompile(Tuple{getfield(Base, Symbol("#kw##notify")), Array{Any, 1}, typeof(Base.notify), Base.Condition, Nothing})

--- a/doc/man/julia.1
+++ b/doc/man/julia.1
@@ -108,11 +108,11 @@ Run processes on hosts listed in <file>
 Interactive mode; REPL runs and isinteractive() is true
 
 .TP
---banner={yes|no}
+--banner={yes|no|auto}
 Enable or disable startup banner
 
 .TP
---color={yes|no}
+--color={yes|no|auto}
 Enable or disable color text
 
 .TP

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -117,8 +117,8 @@ julia [switches] -- [programfile] [args...]
 
  -i                        Interactive mode; REPL runs and isinteractive() is true
  -q, --quiet               Quiet startup: no banner, suppress REPL warnings
- --banner={yes|no}         Enable or disable startup banner
- --color={yes|no}          Enable or disable color text
+ --banner={yes|no|auto}    Enable or disable startup banner
+ --color={yes|no|auto}     Enable or disable color text
  --history-file={yes|no}   Load or save history
 
  --depwarn={yes|no|error}  Enable or disable syntax and method deprecation warnings ("error" turns warnings into errors)

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -98,8 +98,8 @@ static const char opts[]  =
     // interactive options
     " -i                        Interactive mode; REPL runs and isinteractive() is true\n"
     " -q, --quiet               Quiet startup: no banner, suppress REPL warnings\n"
-    " --banner={yes|no}         Enable or disable startup banner\n"
-    " --color={yes|no}          Enable or disable color text\n"
+    " --banner={yes|no|auto}    Enable or disable startup banner\n"
+    " --color={yes|no|auto}     Enable or disable color text\n"
     " --history-file={yes|no}   Load or save history\n\n"
 
     // error and warning options
@@ -343,12 +343,14 @@ restart_switch:
                 jl_options.banner = 0;
             break;
         case opt_banner: // banner
-            if (!strcmp(optarg,"yes"))
+            if (!strcmp(optarg, "yes"))
                 jl_options.banner = 1;
-            else if (!strcmp(optarg,"no"))
+            else if (!strcmp(optarg, "no"))
                 jl_options.banner = 0;
+            else if (!strcmp(optarg, "auto"))
+                jl_options.banner = -1;
             else
-                jl_errorf("julia: invalid argument to --banner={yes|no} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --banner={yes|no|auto} (%s)", optarg);
             break;
         case opt_use_precompiled:
             jl_printf(JL_STDOUT, "WARNING: julia --precompiled option is deprecated, use --sysimage-native-code instead.\n");
@@ -398,12 +400,14 @@ restart_switch:
                 jl_error("julia: failed to allocate memory");
             break;
         case opt_color:
-            if (!strcmp(optarg,"yes"))
+            if (!strcmp(optarg, "yes"))
                 jl_options.color = JL_OPTIONS_COLOR_ON;
-            else if (!strcmp(optarg,"no"))
+            else if (!strcmp(optarg, "no"))
                 jl_options.color = JL_OPTIONS_COLOR_OFF;
+            else if (!strcmp(optarg, "auto"))
+                jl_options.color = JL_OPTIONS_COLOR_AUTO;
             else
-                jl_errorf("julia: invalid argument to --color={yes|no} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --color={yes|no|auto} (%s)", optarg);
             break;
         case opt_history_file:
             if (!strcmp(optarg,"yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1779,6 +1779,7 @@ JL_DLLEXPORT int jl_generating_output(void);
 #define JL_OPTIONS_COMPILE_ALL 2
 #define JL_OPTIONS_COMPILE_MIN 3
 
+#define JL_OPTIONS_COLOR_AUTO 0
 #define JL_OPTIONS_COLOR_ON 1
 #define JL_OPTIONS_COLOR_OFF 2
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -157,23 +157,32 @@ fake_repl() do stdin_write, stdout_read, repl
     # issue #10120
     # ensure that command quoting works correctly
     let s, old_stdout = STDOUT
+        write(stdin_write, ";")
+        readuntil(stdout_read, "shell> ")
+        Base.print_shell_escaped(stdin_write, Base.julia_cmd().exec..., special=Base.shell_special)
+        write(stdin_write, """ -e "println(\\"HI\\")\"""")
+        readuntil(stdout_read, ")\"")
         proc_stdout_read, proc_stdout = redirect_stdout()
         get_stdout = @async read(proc_stdout_read, String)
         try
-            write(stdin_write, ";")
-            readuntil(stdout_read, "shell> ")
-            Base.print_shell_escaped(stdin_write, Base.julia_cmd().exec..., special=Base.shell_special)
-            write(stdin_write, """ -e "println(\\"HI\\")"\n""")
-            while true
+            write(stdin_write, '\n')
+            s = readuntil(stdout_read, "\n", keep=true)
+            if s == "\n"
+                # if shell width is precisely the text width,
+                # we may print some extra characters to fix the cursor state
                 s = readuntil(stdout_read, "\n", keep=true)
-                s == "\e[0m\n" && break # the child has exited
-                @test contains(s, "shell> ") # check for the echo of the prompt
+                @test contains(s, "shell> ")
+                s = readuntil(stdout_read, "\n", keep=true)
+                @test s == "\r\r\n"
+            else
+                @test contains(s, "shell> ")
             end
+            s = readuntil(stdout_read, "\n", keep=true)
+            @test s == "\e[0m\n" # the child has exited
         finally
             redirect_stdout(old_stdout)
         end
         close(proc_stdout)
-        @test contains(wait(get_stdout), "HI\n")
         @test wait(get_stdout) == "HI\n"
     end
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -209,6 +209,7 @@ let r, t, sock
     close(sock)
     @test wait(t)
 end
+
 # issue #4535
 exename = Base.julia_cmd()
 if valgrind_off
@@ -221,9 +222,6 @@ if valgrind_off
     @test read(out, String) == "Hello World\n"
     @test success(proc)
 end
-
-# issue #6310
-@test read(pipeline(`$echocmd "2+2"`, `$exename --startup-file=no`), String) == "4\n"
 
 # setup_stdio for AbstractPipe
 let out = Pipe(), proc = spawn(pipeline(`$echocmd "Hello World"`, stdout=IOContext(out,STDOUT)))


### PR DESCRIPTION
try to make this more reusable and have better separation of concerns:
 - allow late loading of the REPL module
 - respect user options more carefully (such as --banner=yes)
 - process_options was also mostly about changing global state, so rename to exec_options instead of returning some values
 - don't fail in the REPL module is not available - just fall back to the basic stream-repl
 - be more clear about how `isa` is being used to affect behavior