### PR TITLE
readuntil bugfix

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -232,7 +232,7 @@ readuntil(io::AbstractPipe, arg::UInt8; kw...) = readuntil(pipe_reader(io), arg;
 readuntil(io::AbstractPipe, arg::Char; kw...) = readuntil(pipe_reader(io), arg; kw...)
 readuntil(io::AbstractPipe, arg::AbstractString; kw...) = readuntil(pipe_reader(io), arg; kw...)
 readuntil(io::AbstractPipe, arg::AbstractVector; kw...) = readuntil(pipe_reader(io), arg; kw...)
-readuntil_indexable(io::AbstractPipe, target#=::Indexable{T}=#, out) = readuntil_indexable(pipe_reader(io), target, out)
+readuntil_vector!(io::AbstractPipe, target::AbstractVector, out) = readuntil_vector!(pipe_reader(io), target, out)
 
 readavailable(io::AbstractPipe) = readavailable(pipe_reader(io))
 
@@ -661,17 +661,31 @@ function readuntil(s::IO, delim::T; keep::Bool=false) where T
     return out
 end
 
-# requires that indices for target are small ordered integers bounded by firstindex and lastindex
+# requires that indices for target are the integer unit range from firstindex to lastindex
 # returns whether the delimiter was matched
-function readuntil_indexable(io::IO, target#=::Indexable{T}=#, out)
-    T = eltype(target)
-    isempty(target) && return true
+# uses the Knuth–Morris–Pratt_algorithm, with the first and second cache entries unrolled
+# For longer targets, the cache improves the big-O efficiency of scanning of sequences
+# with repeated patterns
+# Each cache entry tells us which index we should start the search at.
+# We assume this is unlikely, so we only lazy-initialize as much of the cache as we need to use
+# When we allocate the cache, we initialize it to 0 (and offset by the first index afterwards).
+# Suppose target is:
+#    Index:  1245689
+#    Value: "aδcaδcx"
+# We would set the cache to
+#    0 0 0 1 2 3 4 0
+# So after if we mismatch after the second aδc sequence,
+# we can immediately jump back to index 5 (4 + 1).
+function readuntil_vector!(io::IO, target::AbstractVector{T}, out) where {T}
     first = firstindex(target)
-    len = lastindex(target)
+    last = lastindex(target)
+    len = last - first + 1
+    if len < 1
+        return true
+    end
+    pos = 0 # array-offset
+    max_pos = 1 # array-offset in cache
     local cache # will be lazy initialized when needed
-    second = next(target, first)[2]
-    max_pos = second
-    pos = first
     while !eof(io)
         c = read(io, T)
         # Backtrack until the next target character matches what was found
@@ -681,37 +695,36 @@ function readuntil_indexable(io::IO, target#=::Indexable{T}=#, out)
             push!(out, c)
         end
         while true
-            c1, pos1 = next(target, pos)
+            c1 = target[pos + first]
             if c == c1
-                pos = pos1
+                pos += 1
                 break
-            elseif pos == first
+            elseif pos == 0
                 break
-            elseif pos == second
-                pos = first
+            elseif pos == 1
+                pos = 0
             else
                 # grow cache to contain up to `pos`
                 if !@isdefined(cache)
                     cache = zeros(Int, len)
                 end
                 while max_pos < pos
+                    ci = target[max_pos + first]
                     b = max_pos
-                    local max_pos1
-                    while b != first
-                        b = cache[b] + first
-                        cb, b1 = next(target, b)
-                        ci, max_pos1 = next(target, max_pos)
+                    max_pos += 1
+                    while b != 0
+                        b = cache[b]
+                        cb = target[b + first]
                         if ci == cb
-                            cache[max_pos1] = b1 - first
+                            cache[max_pos] = b + 1
                             break
                         end
                     end
-                    max_pos = max_pos1
                 end
-                pos = cache[pos] + first
+                pos = cache[pos]
             end
         end
-        done(target, pos) && return true
+        pos == len && return true
     end
     return false
 end
@@ -725,25 +738,16 @@ function readuntil(io::IO, target::AbstractString; keep::Bool=false)
         return readuntil_string(io, c % UInt8, keep)
     end
     # convert String to a utf8-byte-iterator
-    if target isa String || target isa SubString{String}
-        target = codeunits(target)
-    else
-        target = codeunits(String(target))
+    if !(target isa String) && !(target isa SubString{String})
+        target = String(target)
     end
-    out = StringVector(0)
-    found = readuntil_indexable(io, target, out)
-    if !keep && found
-        lo, lt = length(out), length(target)
-        if lt <= lo
-            resize!(out, lo - lt)
-        end
-    end
-    return String(out)
+    target = codeunits(target)::AbstractVector
+    return String(readuntil(io, target, keep=keep))
 end
 
 function readuntil(io::IO, target::AbstractVector{T}; keep::Bool=false) where T
     out = (T === UInt8 ? StringVector(0) : Vector{T}())
-    found = readuntil_indexable(io, target, out)
+    found = readuntil_vector!(io, target, out)
     if !keep && found
         lo, lt = length(out), length(target)
         if lt <= lo

--- a/base/io.jl
+++ b/base/io.jl
@@ -695,11 +695,16 @@ function readuntil_indexable(io::IO, target#=::Indexable{T}=#, out)
                     cache = zeros(Int, len)
                 end
                 while max_pos < pos
-                    b = cache[max_pos] + first
-                    cb, b1 = next(target, b)
-                    ci, max_pos1 = next(target, max_pos)
-                    if ci == cb
-                        cache[max_pos1] = b1 - first
+                    b = max_pos
+                    local max_pos1
+                    while b != first
+                        b = cache[b] + first
+                        cb, b1 = next(target, b)
+                        ci, max_pos1 = next(target, max_pos)
+                        if ci == cb
+                            cache[max_pos1] = b1 - first
+                            break
+                        end
                     end
                     max_pos = max_pos1
                 end

--- a/test/read.jl
+++ b/test/read.jl
@@ -161,7 +161,11 @@ for (name, f) in l
             ("αααβγ", "αβ", "αα", "αααβ"),
             ("αααβγ", "ααβ", "α", "αααβ"),
             ("αααβγ", "αγ", "αααβγ", "αααβγ"),
-            ("barbarbarians", "barbarian", "bar", "barbarbarian")]
+            ("barbarbarians", "barbarian", "bar", "barbarbarian"),
+            ("abcaabcaabcxl", "abcaabcx", "abca", "abcaabcaabcx"),
+            ("abbaabbaabbabbaax", "abbaabbabbaax", "abba", "abbaabbaabbabbaax"),
+            ("abbaabbabbaabbaabbabbaax", "abbaabbabbaax", "abbaabbabba", "abbaabbabbaabbaabbabbaax"),
+           ]
         local t, s, m, kept
         @test readuntil(io(t), s) == m
         @test readuntil(io(t), s, keep=true) == kept


### PR DESCRIPTION
Keno found a bug in the cache construction, and was complaining that this was misusing the iteration protocol. So this improve the function to be clearer about it's expectations by using simple integer index offsets rather than calling `next`, and restricting the type-signature to indicate that new restriction. Because we now have the `CodeUnits` view of a String, this also eliminates some duplicated code in the callers and optimizes the common case of `keep=false`.

replaces #25713