### PR TITLE
Define round(::Type{>:Missing}, x) and similar functions

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -99,7 +99,11 @@ for f in (:(ceil), :(floor), :(round), :(trunc))
         ($f)(::Missing, digits::Integer=0, base::Integer=0) = missing
         ($f)(::Type{>:Missing}, ::Missing) = missing
         ($f)(::Type{T}, ::Missing) where {T} =
-            throw(MissingException("cannot convert a missing value to type $T"))
+            throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
+        ($f)(::Type{T}, x::Any) where {T>:Missing} = $f(nonmissingtype(T), x)
+        # to fix ambiguities
+        ($f)(::Type{T}, x::Rational) where {T>:Missing} = $f(nonmissingtype(T), x)
+        ($f)(::Type{T}, x::Rational{Bool}) where {T>:Missing} = $f(nonmissingtype(T), x)
     end
 end
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -180,6 +180,7 @@ end
         @test ismissing(f(missing, 1))
         @test ismissing(f(missing, 1, 1))
         @test ismissing(f(Union{Int, Missing}, missing))
+        @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
     end
 end


### PR DESCRIPTION
We currently define `round(::Type{>:Missing}, ::Missing)`, but not the corresponding method for non-missing inputs was missing, making it basically useless.