### PR TITLE
Rename IndexValue -> Pairs, print it better

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -30,9 +30,10 @@ function in(p, a::AbstractDict)
              function if you are looking for a key or value respectively.""")
 end
 
-function summary(t::AbstractDict)
+function summary(io::IO, t::AbstractDict)
     n = length(t)
-    return string(typeof(t), " with ", n, (n==1 ? " entry" : " entries"))
+    showarg(io, t, true)
+    print(io, " with ", n, (n==1 ? " entry" : " entries"))
 end
 
 struct KeySet{K, T <: AbstractDict{K}} <: AbstractSet{K}

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -153,15 +153,15 @@ end
 @inline done(r::Reverse{<:Enumerate}, state) = state[1] < 1
 
 """
-    Iterators.IndexValue(values, keys) <: AbstractDict{eltype(keys), eltype(values)}
+    Iterators.Pairs(values, keys) <: AbstractDict{eltype(keys), eltype(values)}
 
 Transforms an indexable container into an Dictionary-view of the same data.
 Modifying the key-space of the underlying data may invalidate this object.
 """
-struct IndexValue{K, V, I, A} <: AbstractDict{K, V}
+struct Pairs{K, V, I, A} <: AbstractDict{K, V}
     data::A
     itr::I
-    IndexValue(data::A, itr::I) where {A, I} = new{eltype(I), eltype(A), I, A}(data, itr)
+    Pairs(data::A, itr::I) where {A, I} = new{eltype(I), eltype(A), I, A}(data, itr)
 end
 
 """
@@ -210,42 +210,42 @@ CartesianIndex(2, 2) e
 
 See also: [`IndexStyle`](@ref), [`axes`](@ref).
 """
-pairs(::IndexLinear,    A::AbstractArray) = IndexValue(A, linearindices(A))
-pairs(::IndexCartesian, A::AbstractArray) = IndexValue(A, CartesianIndices(axes(A)))
+pairs(::IndexLinear,    A::AbstractArray) = Pairs(A, linearindices(A))
+pairs(::IndexCartesian, A::AbstractArray) = Pairs(A, CartesianIndices(axes(A)))
 
 # preserve indexing capabilities for known indexable types
 # faster than zip(keys(a), values(a)) for arrays
 pairs(A::AbstractArray)  = pairs(IndexCartesian(), A)
 pairs(A::AbstractVector) = pairs(IndexLinear(), A)
-pairs(tuple::Tuple) = IndexValue(tuple, keys(tuple))
-pairs(nt::NamedTuple) = IndexValue(nt, keys(nt))
-# pairs(v::IndexValue) = v # listed for reference, but already defined from being an AbstractDict
+pairs(tuple::Tuple) = Pairs(tuple, keys(tuple))
+pairs(nt::NamedTuple) = Pairs(nt, keys(nt))
+# pairs(v::Pairs) = v # listed for reference, but already defined from being an AbstractDict
 
-length(v::IndexValue)  = length(v.itr)
-axes(v::IndexValue) = axes(v.itr)
-size(v::IndexValue)    = size(v.itr)
-@inline start(v::IndexValue) = start(v.itr)
-@propagate_inbounds function next(v::IndexValue, state)
+length(v::Pairs)  = length(v.itr)
+axes(v::Pairs) = axes(v.itr)
+size(v::Pairs)    = size(v.itr)
+@inline start(v::Pairs) = start(v.itr)
+@propagate_inbounds function next(v::Pairs, state)
     indx, n = next(v.itr, state)
     item = v.data[indx]
     return (Pair(indx, item), n)
 end
-@inline done(v::IndexValue, state) = done(v.itr, state)
+@inline done(v::Pairs, state) = done(v.itr, state)
 
-eltype(::Type{IndexValue{K, V}}) where {K, V} = Pair{K, V}
+eltype(::Type{Pairs{K, V}}) where {K, V} = Pair{K, V}
 
-IteratorSize(::Type{IndexValue{<:Any, <:Any, I}}) where {I} = IteratorSize(I)
-IteratorEltype(::Type{IndexValue{<:Any, <:Any, I}}) where {I} = IteratorEltype(I)
+IteratorSize(::Type{Pairs{<:Any, <:Any, I}}) where {I} = IteratorSize(I)
+IteratorEltype(::Type{Pairs{<:Any, <:Any, I}}) where {I} = IteratorEltype(I)
 
-reverse(v::IndexValue) = IndexValue(v.data, reverse(v.itr))
+reverse(v::Pairs) = Pairs(v.data, reverse(v.itr))
 
-haskey(v::IndexValue, key) = (key in v.itr)
-keys(v::IndexValue) = v.itr
-values(v::IndexValue) = v.data
-getindex(v::IndexValue, key) = v.data[key]
-setindex!(v::IndexValue, value, key) = (v.data[key] = value; v)
-get(v::IndexValue, key, default) = get(v.data, key, default)
-get(f::Base.Callable, collection::IndexValue, key) = get(f, v.data, key)
+haskey(v::Pairs, key) = (key in v.itr)
+keys(v::Pairs) = v.itr
+values(v::Pairs) = v.data
+getindex(v::Pairs, key) = v.data[key]
+setindex!(v::Pairs, value, key) = (v.data[key] = value; v)
+get(v::Pairs, key, default) = get(v.data, key, default)
+get(f::Base.Callable, collection::Pairs, key) = get(f, v.data, key)
 
 # zip
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1800,3 +1800,13 @@ end
     end
     return B
 end
+
+# Show for pairs() with Cartesian indicies. Needs to be here rather than show.jl for bootstrap order
+function Base.showarg(io::IO, r::Union{Iterators.Pairs{<:Integer, <:Any, <:Any, T} where T <: Union{AbstractVector, Tuple},
+                                       Iterators.Pairs{<:CartesianIndex, <:Any, <:Any, T} where T <: AbstractArray}, toplevel)
+    print(io, "pairs(::$T)")
+end
+
+function Base.showarg(io::IO, r::Iterators.Pairs{<:CartesianIndex, <:Any, <:Any, <:AbstractVector}, toplevel)
+    print(io, "pairs(IndexCartesian(), ::$T)")
+end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1934,6 +1934,19 @@ function showarg(io::IO, r::ReinterpretArray{T}, toplevel) where {T}
     print(io, ')')
 end
 
+# pretty printing for Iterators.Pairs
+function Base.showarg(io::IO, r::Iterators.Pairs{<:Integer, <:Any, <:Any, <:AbstractArray}, toplevel)
+    print(io, "pairs(IndexLinear(), ::$T)")
+end
+
+function Base.showarg(io::IO, r::Iterators.Pairs{Symbol, <:Any, <:Any, T}, toplevel) where {T <: NamedTuple}
+    print(io, "pairs(::NamedTuple)")
+end
+
+function Base.showarg(io::IO, r::Iterators.Pairs{<:Any, <:Any, I, D}, toplevel) where {D, I}
+    print(io, "Iterators.Pairs(::$D, ::$I)")
+end
+
 """
     showcompact(x)
     showcompact(io::IO, x)

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -228,7 +228,7 @@ Partially implemented by:
   * [`Array`](@ref)
   * [`BitArray`](@ref)
   * [`ImmutableDict`](@ref Base.ImmutableDict)
-  * [`Iterators.IndexValue`](@ref)
+  * [`Iterators.Pairs`](@ref)
 
 ## Set-Like Collections
 
@@ -279,5 +279,5 @@ Fully implemented by:
 
 ```@docs
 Base.Pair
-Iterators.IndexValue
+Iterators.Pairs
 ```

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -431,7 +431,7 @@ end
     @test eltype(arr) == Int
 end
 
-@testset "IndexValue type" begin
+@testset "Pairs type" begin
     for A in ([4.0 5.0 6.0],
               [],
               (4.0, 5.0, 6.0),


### PR DESCRIPTION
As discussed in #25711

Before:
```
julia> f(;kwargs...) = kwargs
f (generic function with 1 method)

julia> f(;a = 1, b = 2)
Base.Iterators.IndexValue{Symbol,Int64,Tuple{Symbol,Symbol},NamedTuple{(:a, :b),Tuple{Int64,Int64}}} with 2 entries:
  :a => 1
  :b => 2
```

After:
```
julia> f(;a = 1, b = 2)
pairs((a = 1, b = 2)) with 2 entries:
  :a => 1
  :b => 2
```