### PR TITLE
remove functions `readme ` and `license` to decouple Markdown from Pkg

### DIFF
--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -23,16 +23,10 @@ include(joinpath("render", "rst.jl"))
 
 include(joinpath("render", "terminal", "render.jl"))
 
-export readme, license, @md_str, @doc_str
+export @md_str, @doc_str
 
 parse(markdown::AbstractString; flavor = julia) = parse(IOBuffer(markdown), flavor = flavor)
 parse_file(file::AbstractString; flavor = julia) = parse(read(file, String), flavor = flavor)
-
-readme(pkg::AbstractString; flavor = github) = parse_file(Pkg.dir(pkg, "README.md"), flavor = flavor)
-readme(pkg::Module; flavor = github) = readme(string(pkg), flavor = flavor)
-
-license(pkg::AbstractString; flavor = github) = parse_file(Pkg.dir(pkg, "LICENSE.md"), flavor = flavor)
-license(pkg::Module; flavor = github) = license(string(pkg), flavor = flavor)
 
 function mdexpr(s, flavor = :julia)
     md = parse(s, flavor = Symbol(flavor))


### PR DESCRIPTION
These are not used anywhere in Base, as far as I can see, and they seem quite out of place here. Simply deleting them seems to be easiest. 