### PR TITLE
remove REPLs dependence on Pkg

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -557,7 +557,8 @@ function completions(string, pos)
         # also search for packages
         s = string[startpos:pos]
         if dotpos <= startpos
-            for dir in [Pkg.dir(); LOAD_PATH; pwd()]
+            for dir in [LOAD_PATH; pwd()]
+                dir isa Function && (dir = dir())
                 dir isa AbstractString && isdir(dir) || continue
                 for pname in readdir(dir)
                     if pname[1] != '.' && pname != "METADATA" &&

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -204,14 +204,7 @@ function summarize(io::IO, T::DataType, binding)
 end
 
 function summarize(io::IO, m::Module, binding)
-    readme = Pkg.dir(string(m), "README.md")
-    if isfile(readme)
-        println(io, "Displaying the `README.md` for the module instead.\n")
-        println(io, "---\n")
-        println(io, read(readme, String))
-    else
-        println(io, "No docstring or `README.md` found for module `", m, "`.\n")
-    end
+    println(io, "No docstring found for module `", m, "`.\n")
 end
 
 function summarize(io::IO, ::T, binding) where T


### PR DESCRIPTION
The REPLCompletions dependence on Pkg.dir was not needed since this one exists in LOAD_PATH anyway.

Removes the "feature" of dumping the README of `Pkg.dir(Module)` when doing `help> Module`. I think that feature is not really needed and rarely works well. Just document your modules if you want to see docs about them.