### PR TITLE
eliminate unnecessary and misnamed Base._display function

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -298,7 +298,7 @@ function show_nd(io::IO, a::AbstractArray, print_matrix::Function, label_slices:
     end
 end
 
-# print_array: main helper functions for _display
+# print_array: main helper functions for show(io, text/plain, array)
 # typeinfo agnostic
 
 # 0-dimensional arrays
@@ -312,7 +312,7 @@ print_array(io::IO, X::AbstractArray) = show_nd(io, X, print_matrix, true)
 
 # typeinfo aware
 # implements: show(io::IO, ::MIME"text/plain", X::AbstractArray)
-function _display(io::IO, X::AbstractArray)
+function show(io::IO, ::MIME"text/plain", X::AbstractArray)
     # 0) compute new IOContext
     if !haskey(io, :compact) && length(axes(X, 2)) > 1
         io = IOContext(io, :compact => true)
@@ -344,8 +344,6 @@ function _display(io::IO, X::AbstractArray)
     # 2) show actual content
     print_array(io, X)
 end
-
-show(io::IO, ::MIME"text/plain", X::AbstractArray) = _display(io, X)
 
 ## printing with `show`
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -990,7 +990,7 @@ end
 @testset "Array printing with limited rows" begin
     arrstr = let buf = IOBuffer()
         function (A, rows)
-            Base._display(IOContext(buf, :displaysize => (rows, 80), :limit => true), A)
+            show(IOContext(buf, :displaysize => (rows, 80), :limit => true), "text/plain", A)
             String(take!(buf))
         end
     end
@@ -1139,4 +1139,3 @@ end
     show(buf, methods(f22798))
     @test contains(String(take!(buf)), "f22798(x::Integer, y)")
 end
-


### PR DESCRIPTION
PR #24651 introduced a function `Base._display` that is misnamed (because it is called by `show(io, text/plain, A)`, not necessarily `display`: https://github.com/JuliaLang/julia/pull/24651#discussion_r164275845), and is unnecessary because it is only called by `show(io, text/plain, X::AbstractArray) = _display(io, x)`.

This is a minimal PR that just eliminates the function.