### PR TITLE
deprecate `quit`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1377,6 +1377,8 @@ export readandwrite
 # PR #25196
 @deprecate_binding ObjectIdDict IdDict{Any,Any}
 
+@deprecate quit() exit()
+
 # PR #25654
 @deprecate indmin argmin
 @deprecate indmax argmax

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -818,7 +818,6 @@ export
     clipboard,
     exit,
     ntuple,
-    quit,
 
 # IP address stuff
     @ip_str,

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -21,22 +21,12 @@ const ARGS = String[]
 """
     exit(code=0)
 
-Quit the program with an exit code. The default exit code is zero, indicating that the
-program completed successfully (see also [`quit`](@ref)). In an interactive session,
-`exit()` can be called with the keyboard shorcut `^D`.
-
+Stop the program with an exit code. The default exit code is zero, indicating that the
+program completed successfully. In an interactive session, `exit()` can be called with
+the keyboard shortcut `^D`.
 """
 exit(n) = ccall(:jl_exit, Cvoid, (Int32,), n)
 exit() = exit(0)
-
-"""
-    quit()
-
-Quit the program indicating successful completion. This function is equivalent to
-`exit(0)` (see [`exit`](@ref)). In an interactive session, `quit()` can be called
-with the keyboard shorcut `^D`.
-"""
-quit() = exit()
 
 const roottask = current_task()
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -19,7 +19,6 @@ Some general notes:
 
 ```@docs
 Base.exit
-Base.quit
 Base.atexit
 Base.isinteractive
 Base.varinfo

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -139,7 +139,7 @@ function check()
                     Please rebuild Julia with USE_BLAS64=1"""
             end
             println("Quitting.")
-            quit()
+            exit()
         end
     elseif blas == :mkl
         if Base.USE_BLAS64

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -666,18 +666,18 @@ let exename = Base.julia_cmd()
                 # valgrind banner here, not just the prompt.
                 @test output == "julia> "
             end
-            write(master,"1\nquit()\n")
+            write(master,"1\nexit()\n")
 
             wait(p)
             output = readuntil(master,' ',keep=true)
-            @test output == "1\r\nquit()\r\n1\r\n\r\njulia> "
+            @test output == "1\r\nexit()\r\n1\r\n\r\njulia> "
             @test bytesavailable(master) == 0
         end
     end
 
     # Test stream mode
     p = open(`$exename --startup-file=no -q`, "r+")
-    write(p, "1\nquit()\n")
+    write(p, "1\nexit()\n")
     @test read(p, String) == "1\n"
 end # let exename
 


### PR DESCRIPTION
This is a silly function.

Could be added back as repl-only if we want to accommodate guesses that `quit()` is the way to quit the repl.