### PR TITLE
add AbstractVecOrMat fallback for vcat

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1174,10 +1174,10 @@ function typed_hcat(::Type{T}, A::AbstractVecOrMat...) where T
     return B
 end
 
-vcat(A::AbstractMatrix...) = typed_vcat(promote_eltype(A...), A...)
-vcat(A::AbstractMatrix{T}...) where {T} = typed_vcat(T, A...)
+vcat(A::AbstractVecOrMat...) = typed_vcat(promote_eltype(A...), A...)
+vcat(A::AbstractVecOrMat{T}...) where {T} = typed_vcat(T, A...)
 
-function typed_vcat(::Type{T}, A::AbstractMatrix...) where T
+function typed_vcat(::Type{T}, A::AbstractVecOrMat...) where T
     nargs = length(A)
     nrows = sum(a->size(a, 1), A)::Int
     ncols = size(A[1], 2)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -876,3 +876,9 @@ end
     @test CartesianIndices(fill(1., 2, 3)) == CartesianIndices((2,3))
     @test LinearIndices((2,3)) == [1 3 5; 2 4 6]
 end
+
+@testset "issue #25770" begin
+    @test vcat(1:3, fill(1, (2,1))) == vcat([1:3;], fill(1, (2,1))) == reshape([1,2,3,1,1], 5,1)
+    @test hcat(1:2, fill(1, (2,1))) == hcat([1:2;], fill(1, (2,1))) == reshape([1,2,1,1],2,2)
+    @test [(1:3) (4:6); fill(1, (3,2))] == reshape([1,2,3,1,1,1,4,5,6,1,1,1], 6,2)
+end


### PR DESCRIPTION
Fixes #25770, which was due to a missing fallback accidentally calling the `UniformScaling` method.