### PR TITLE
Document NamedTuple

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -1,5 +1,52 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    NamedTuple
+
+`NamedTuple`s are, as their name suggests, named [`Tuple`](@ref)s. That is, they're a
+tuple-like collection of values, where each entry has a unique name, represented as a
+`Symbol`. Like `Tuple`s, `NamedTuple`s are immutable; neither the names nor the values
+can be modified in place after construction.
+
+Accessing the value associated with a name in a named tuple can be done using field
+access syntax, e.g. `x.a`, or using [`getindex`](@ref), e.g. `x[:a]`. A tuple of the
+names can be obtained using [`keys`](@ref), and a tuple of the values can be obtained
+using [`values`](@ref).
+
+!!! note
+    Iteration over `NamedTuple`s produces the *values* without the names. (See example
+    below.) To iterate over the name-value pairs, use the [`pairs`](@ref) function.
+
+# Examples
+```jldoctest
+julia> x = (a=1, b=2)
+(a = 1, b = 2)
+
+julia> x.a
+1
+
+julia> x[:a]
+1
+
+julia> keys(x)
+(:a, :b)
+
+julia> values(x)
+(1, 2)
+
+julia> collect(x)
+2-element Array{Int64,1}:
+ 1
+ 2
+
+julia> collect(pairs(x))
+2-element Array{Pair{Symbol,Int64},1}:
+ :a => 1
+ :b => 2
+```
+"""
+Core.NamedTuple
+
 if nameof(@__MODULE__) === :Base
 
 """

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -191,6 +191,7 @@ Core.Union
 Union{}
 Core.UnionAll
 Core.Tuple
+Core.NamedTuple
 Base.Val
 Core.Vararg
 Core.Nothing

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -48,6 +48,7 @@ Fully implemented by:
   * `AbstractString`
   * [`Set`](@ref)
   * [`Pair`](@ref)
+  * [`NamedTuple`](@ref)
 
 ## General Collections
 
@@ -70,6 +71,7 @@ Fully implemented by:
   * [`WeakKeyDict`](@ref)
   * `AbstractString`
   * [`Set`](@ref)
+  * [`NamedTuple`](@ref)
 
 ## Iterable Collections
 
@@ -163,6 +165,7 @@ Partially implemented by:
   * [`Dict`](@ref)
   * [`IdDict`](@ref)
   * [`WeakKeyDict`](@ref)
+  * [`NamedTuple`](@ref)
 
 ## Dictionaries
 


### PR DESCRIPTION
Turns out there was no documentation for this type. This adds a docstring and includes references to it in the documentation.