### PR TITLE
adjust ownership heuristics for methods in `summarysize`

### DIFF
--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -21,8 +21,8 @@ Compute the amount of memory used by all unique objects reachable from the argum
   fields, even if those fields would normally be excluded.
 """
 function summarysize(obj;
-                     exclude = Union{DataType, TypeName, Method},
-                     chargeall = Union{TypeMapEntry, Core.MethodInstance})
+                     exclude = Union{DataType, TypeName, Core.MethodInstance},
+                     chargeall = Union{TypeMapEntry, Method})
     @nospecialize obj exclude chargeall
     ss = SummarySize(IdDict(), Any[], Int[], exclude, chargeall)
     size::Int = ss(obj)


### PR DESCRIPTION
This failure has happened a couple times recently:

```
Expression: summarysize(Core) > summarysize(Core.Compiler) + Base.summarysize(Core.Intrinsics) > Core.sizeof(Core)
   Evaluated: 63948885 > 63965935 > 16
```

This is one of those somewhat-silly tests, but I also noticed this at the prompt:

```
name                   size summary
–––––––––––––––– –––––––––– –––––––
Base                        Module 
Core                        Module 
InteractiveUtils 47.218 MiB Module 
Main                        Module 
Markdown         48.431 MiB Module 
```

Digging into it, the cause seems to be traversing `MethodInstance` objects referenced from `Method.roots` arrays, which makes us charge very large call graphs of code to almost any non-trivial method. The size estimates calm down if we only look at Methods and not MethodInstances. With this change:

```
julia> summarysize(Core)
16040463

julia> summarysize(Core.Compiler)
15424889

julia> summarysize(Core.Intrinsics)
356

name                    size summary
–––––––––––––––– ––––––––––– –––––––
Base                         Module 
Core                         Module 
InteractiveUtils 145.636 KiB Module 
Main                         Module 
Markdown         461.094 KiB Module 
```

@vtjnash Do you think this is likely to be more accurate, or too optimistic?