### PR TITLE
Tune Stateful iterator

### DIFF
--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -495,13 +495,13 @@ end
 end
 
 @testset "Iterators.Stateful" begin
-    let a = Iterators.Stateful("abcdef")
+    let a = @inferred(Iterators.Stateful("abcdef"))
         @test !isempty(a)
         @test popfirst!(a) == 'a'
         @test collect(Iterators.take(a, 3)) == ['b','c','d']
         @test collect(a) == ['e', 'f']
     end
-    let a = Iterators.Stateful([1, 1, 1, 2, 3, 4])
+    let a = @inferred(Iterators.Stateful([1, 1, 1, 2, 3, 4]))
         for x in a; x == 1 || break; end
         @test Base.peek(a) == 3
         @test sum(a) == 7


### PR DESCRIPTION
This attempts to address some of the performance regressions observed
with the Stateful iterator #25736. It gets most of the way there,
but unfortunately still ends up allocating the `Stateful` iterator
object rather than propagating through the fields. Getting the rest
of the way there will require some compiler tweaks.