### PR TITLE
Remove (incorrect) C API fixes from llvm-api and patch LLVM instead

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -463,6 +463,7 @@ $(eval $(call LLVM_PATCH,llvm-3.9.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-D37939-Mem2Reg-Also-handle-memcpy))
 $(eval $(call LLVM_PATCH,llvm-D31524-sovers_4.0)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-D42262-jumpthreading-not-i1))
+$(eval $(call LLVM_PATCH,llvm-3.9-c_api_nullptr))
 ifeq ($(BUILD_LLVM_CLANG),1)
 $(eval $(call LLVM_PATCH,compiler_rt-3.9-glibc_2.25.90)) # Remove for 5.0
 endif

--- a/deps/patches/llvm-3.9-c_api_nullptr.patch
+++ b/deps/patches/llvm-3.9-c_api_nullptr.patch
@@ -1,11 +1,3 @@
-commit b1cfc87891b4cb41ec94457a0d42d8c1fd57faf6
-Author: whitequark <whitequark@whitequark.org>
-Date:   Sat Nov 12 03:38:23 2016 +0000
-
-    [C API] Fix several null pointer dereferences.
-    
-    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@286704 91177308-0d34-0410-b5e6-96231b3b80d8
-
 diff --git a/lib/IR/Core.cpp b/lib/IR/Core.cpp
 index 1cf17b1f311..a969e08cabc 100644
 --- a/lib/IR/Core.cpp

--- a/deps/patches/llvm-3.9-c_api_nullptr.patch
+++ b/deps/patches/llvm-3.9-c_api_nullptr.patch
@@ -1,0 +1,47 @@
+commit b1cfc87891b4cb41ec94457a0d42d8c1fd57faf6
+Author: whitequark <whitequark@whitequark.org>
+Date:   Sat Nov 12 03:38:23 2016 +0000
+
+    [C API] Fix several null pointer dereferences.
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@286704 91177308-0d34-0410-b5e6-96231b3b80d8
+
+diff --git a/lib/IR/Core.cpp b/lib/IR/Core.cpp
+index 1cf17b1f311..a969e08cabc 100644
+--- a/lib/IR/Core.cpp
++++ b/lib/IR/Core.cpp
+@@ -1842,12 +1842,16 @@ void LLVMAddAttributeAtIndex(LLVMValueRef F, LLVMAttributeIndex Idx,
+ 
+ unsigned LLVMGetAttributeCountAtIndex(LLVMValueRef F, LLVMAttributeIndex Idx) {
+   auto *ASN = AttributeSetNode::get(unwrap<Function>(F)->getAttributes(), Idx);
++  if (!ASN)
++    return 0;
+   return ASN->getNumAttributes();
+ }
+ 
+ void LLVMGetAttributesAtIndex(LLVMValueRef F, LLVMAttributeIndex Idx,
+                               LLVMAttributeRef *Attrs) {
+   auto *ASN = AttributeSetNode::get(unwrap<Function>(F)->getAttributes(), Idx);
++  if (!ASN)
++    return;
+   for (auto A: make_range(ASN->begin(), ASN->end()))
+     *Attrs++ = wrap(A);
+ }
+@@ -2173,6 +2177,8 @@ unsigned LLVMGetCallSiteAttributeCount(LLVMValueRef C,
+                                        LLVMAttributeIndex Idx) {
+   auto CS = CallSite(unwrap<Instruction>(C));
+   auto *ASN = AttributeSetNode::get(CS.getAttributes(), Idx);
++  if (!ASN)
++    return 0;
+   return ASN->getNumAttributes();
+ }
+ 
+@@ -2180,6 +2186,8 @@ void LLVMGetCallSiteAttributes(LLVMValueRef C, LLVMAttributeIndex Idx,
+                                LLVMAttributeRef *Attrs) {
+   auto CS = CallSite(unwrap<Instruction>(C));
+   auto *ASN = AttributeSetNode::get(CS.getAttributes(), Idx);
++  if (!ASN)
++    return;
+   for (auto A: make_range(ASN->begin(), ASN->end()))
+     *Attrs++ = wrap(A);
+ }

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -200,35 +200,6 @@ LLVMExtraCreateBasicBlockPass(const char *Name, jl_value_t *Callback)
 }
 
 
-// Bugfixes
-
-#if JL_LLVM_VERSION < 40000
-
-// D26392
-extern "C" JL_DLLEXPORT unsigned
-LLVMExtraGetAttributeCountAtIndex(LLVMValueRef F, LLVMAttributeIndex Idx)
-{
-    auto Fn = unwrap<Function>(F);
-    if (Fn->getAttributes().isEmpty())
-        return 0;
-    else
-        return LLVMGetAttributeCountAtIndex(F, Idx);
-}
-
-// D26392
-extern "C" JL_DLLEXPORT unsigned LLVMExtraGetCallSiteAttributeCount(
-        LLVMValueRef C, LLVMAttributeIndex Idx)
-{
-    CallSite CS(unwrap<Instruction>(C));
-    if (CS.getAttributes().isEmpty())
-        return 0;
-    else
-        return LLVMGetCallSiteAttributeCount(C, Idx);
-}
-
-#endif
-
-
 // Various missing functions
 
 extern "C" JL_DLLEXPORT unsigned int LLVMExtraGetDebugMDVersion()


### PR DESCRIPTION
This backports D26392 to LLVM 3.9, fixing nullpointer dereferences in the C API. `llvm-api.cpp` already contained a partial fix, but I was still running into issues with CUDAnative so decided to backport the proper fix instead.

ref https://github.com/JuliaGPU/CUDAnative.jl/pull/151 (triggers the additional nullptr deref)