### PR TITLE
Use promote_typejoin() to choose type parameters in Dict constructor

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -130,10 +130,8 @@ copy(d::Dict) = Dict(d)
 
 const AnyDict = Dict{Any,Any}
 
-Dict(ps::Pair{K,V}...)           where {K,V} = Dict{K,V}(ps)
-Dict(ps::Pair{K}...)             where {K}   = Dict{K,Any}(ps)
-Dict(ps::(Pair{K,V} where K)...) where {V}   = Dict{Any,V}(ps)
-Dict(ps::Pair...)                            = Dict{Any,Any}(ps)
+Dict(ps::Pair{K,V}...) where {K,V} = Dict{K,V}(ps)
+Dict(ps::Pair...)                  = Dict(ps)
 
 function Dict(kv)
     try

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -117,13 +117,13 @@ Falls back to [`typejoin`](@ref).
 promote_typejoin(@nospecialize(a), @nospecialize(b)) =
     (@_pure_meta; join_types(a, b, promote_typejoin))
 promote_typejoin(::Type{Nothing}, ::Type{T}) where {T} =
-    isconcretetype(T) ? Union{T, Nothing} : Any
+    isconcretetype(T) || T === Union{} ? Union{T, Nothing} : Any
 promote_typejoin(::Type{T}, ::Type{Nothing}) where {T} =
-    isconcretetype(T) ? Union{T, Nothing} : Any
+    isconcretetype(T) || T === Union{} ? Union{T, Nothing} : Any
 promote_typejoin(::Type{Missing}, ::Type{T}) where {T} =
-    isconcretetype(T) ? Union{T, Missing} : Any
+    isconcretetype(T) || T === Union{} ? Union{T, Missing} : Any
 promote_typejoin(::Type{T}, ::Type{Missing}) where {T} =
-    isconcretetype(T) ? Union{T, Missing} : Any
+    isconcretetype(T) || T === Union{} ? Union{T, Missing} : Any
 promote_typejoin(::Type{Nothing}, ::Type{Missing}) = Union{Nothing, Missing}
 promote_typejoin(::Type{Missing}, ::Type{Nothing}) = Union{Nothing, Missing}
 promote_typejoin(::Type{Nothing}, ::Type{Nothing}) = Nothing

--- a/test/core.jl
+++ b/test/core.jl
@@ -139,6 +139,8 @@ for T in (Nothing, Missing)
     @test Base.promote_typejoin(Int, String) === Any
     @test Base.promote_typejoin(Int, Union{Float64, T}) === Any
     @test Base.promote_typejoin(Int, Union{String, T}) === Any
+    @test Base.promote_typejoin(T, Union{}) === T
+    @test Base.promote_typejoin(Union{}, T) === T
 end
 
 @test promote_type(Bool,Bottom) === Bool

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -165,10 +165,12 @@ end
     @test Dict(1=>1, 2.0=>2) isa Dict{Real,Int}
     @test Dict(1=>1.0, 2.0=>2) isa Dict{Real,Real}
 
-    @test Dict(1=>1, 2=>missing) isa Dict{Int,Union{Int,Missing}}
-    @test Dict(1=>1, 2=>nothing) isa Dict{Int,Union{Int,Nothing}}
-    @test Dict(1=>1, missing=>2) isa Dict{Union{Int,Missing},Int}
-    @test Dict(1=>1, nothing=>2) isa Dict{Union{Int,Nothing},Int}
+    for T in (Nothing, Missing)
+        @test Dict(1=>1, 2=>T()) isa Dict{Int,Union{Int,T}}
+        @test Dict(1=>T(), 2=>2) isa Dict{Int,Union{Int,T}}
+        @test Dict(1=>1, T()=>2) isa Dict{Union{Int,T},Int}
+        @test Dict(T()=>1, 2=>2) isa Dict{Union{Int,T},Int}
+    end
 end
 
 @test_throws KeyError Dict("a"=>2)[Base.secret_table_token]

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -160,6 +160,17 @@ end
     @test d == Dict{Real,Real}(2.0=>3.0, 1=>2)
 end
 
+@testset "type of Dict constructed from varargs of Pairs" begin
+    @test Dict(1=>1, 2=>2.0) isa Dict{Int,Real}
+    @test Dict(1=>1, 2.0=>2) isa Dict{Real,Int}
+    @test Dict(1=>1.0, 2.0=>2) isa Dict{Real,Real}
+
+    @test Dict(1=>1, 2=>missing) isa Dict{Int,Union{Int,Missing}}
+    @test Dict(1=>1, 2=>nothing) isa Dict{Int,Union{Int,Nothing}}
+    @test Dict(1=>1, missing=>2) isa Dict{Union{Int,Missing},Int}
+    @test Dict(1=>1, nothing=>2) isa Dict{Union{Int,Nothing},Int}
+end
+
 @test_throws KeyError Dict("a"=>2)[Base.secret_table_token]
 
 @testset "issue #1821" begin


### PR DESCRIPTION
This is consistent with `Array`, `NamedTuple` and `Tuple` (via its `eltype` method), and therefore with the `Dict(::AbstractArray{<:Pair})` constructor.

Fixes https://github.com/JuliaLang/julia/issues/25551.