### PR TITLE
Maybe fix `@edit`

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -3,6 +3,7 @@
 # editing and paging files
 
 import Base.shell_split
+using Base: find_source_file
 
 """
     editor()


### PR DESCRIPTION
Seems to have been missing a reference to the unexported `find_source_file` in `Base`, possibly a symptom of moving this to a standard library.

(not sure on the `using` vs `import` thing; we're not extending either of these methods here?).

Fixes #25803