### PR TITLE
fix hashing of Rational{<:Integer} (fixes #25814)

### DIFF
--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -155,7 +155,7 @@ function hash(x::Rational{<:BitInteger64}, h::UInt)
         den >>= pow
         pow = -pow
         if den == 1 && abs(num) < 9007199254740992
-            return hash(ldexp(Float64(num),pow))
+            return hash(ldexp(Float64(num),pow),h)
         end
     end
     h = hash_integer(den, h)

--- a/test/hashing.jl
+++ b/test/hashing.jl
@@ -34,6 +34,7 @@ for T = types[2:end],
     x = vals,
     a = coerce(T, x)
     @test hash(a,zero(UInt)) == invoke(hash, Tuple{Real, UInt}, a, zero(UInt))
+    @test hash(a,one(UInt)) == invoke(hash, Tuple{Real, UInt}, a, one(UInt))
 end
 
 for T = types,


### PR DESCRIPTION
Fix for #25814, attempted via Github's web interface.