### PR TITLE
union-splitting optimizations

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -2363,7 +2363,11 @@ end
 
 # Check if the use is still valid.
 # The code that invalidate this use is responsible for adding new def(s) if any.
-check_valid(def::ValueDef, changes::IdDict) = !haskey(changes, def.stmts=>def.stmtidx)
+function check_valid(def::ValueDef, changes::IdDict)
+    haskey(changes, def.stmts=>def.stmtidx) && return false
+    isdefined(def, :assign) && haskey(changes, def.assign) && return false
+    return true
+end
 
 
 function remove_invalid!(info::ValueInfo, changes::IdDict)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -3338,7 +3338,7 @@ function split_disjoint_assign!(ctx::AllocOptContext, info, key)
                         end
                     end
                     if !@isdefined slot_var
-                        slot_var = quoted(false)
+                        slot_var = false
                     end
                     let v = get(alltypes, Any, false)
                         if v !== false && (!isconcretedispatch(T) || !haskey(alltypes, T))
@@ -3347,7 +3347,9 @@ function split_disjoint_assign!(ctx::AllocOptContext, info, key)
                             new_ex = :($new_slot_var = $slot_var)
                             push!(exprs, new_ex)
                             add_def(ctx.infomap, new_slot_var, ValueDef(new_ex, exprs, length(exprs)))
-                            add_use(ctx.infomap, slot_var, ValueUse(exprs, length(exprs)))
+                            if !isa(slot_var, Bool)
+                                add_use(ctx.infomap, slot_var, ValueUse(exprs, length(exprs)))
+                            end
                             new_test = newvar!(ctx.sv, Bool)
                             new_val = Expr(:call, GlobalRef(Core, :(===)), tag_var, v.id)
                             new_val.typ = Bool

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -841,7 +841,7 @@ function effect_free(@nospecialize(e), src::CodeInfo, mod::Module, allow_volatil
                         return false
                     elseif is_known_call(e, getfield, src, mod)
                         nargs = length(ea)
-                        (3 < nargs < 4) || return false
+                        (3 <= nargs <= 4) || return false
                         et = exprtype(e, src, mod)
                         # TODO: check ninitialized
                         if !isa(et, Const) && !isconstType(et)
@@ -1124,7 +1124,9 @@ function inlineable(@nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector
         invoke_tt = widenconst(atypes[3])
         if !(isconcretetype(ft) || ft <: Type) || !isType(invoke_tt) ||
                 has_free_typevars(invoke_tt) || has_free_typevars(ft) || (ft <: Builtin)
-            # TODO: this is really aggressive at preventing inlining of closures. maybe drop `isconcretetype` requirement?
+            # TODO: this can be rather aggressive at preventing inlining of closures
+            # XXX: this is wrong for `ft <: Type`, since we are failing to check that
+            #      the result doesn't have subtypes, or to do an intersection lookup
             return NOT_FOUND
         end
         if !(isa(invoke_tt.parameters[1], Type) &&
@@ -1787,8 +1789,7 @@ function inline_call(e::Expr, sv::OptimizationState, stmts::Vector{Any}, boundsc
         ft = Bool
     else
         f = nothing
-        if !(isconcretetype(ft) || (widenconst(ft) <: Type)) || has_free_typevars(ft)
-            # TODO: this is really aggressive at preventing inlining of closures. maybe drop `isconcretetype` requirement?
+        if has_free_typevars(ft)
             return e
         end
     end
@@ -1945,8 +1946,7 @@ function inline_call(e::Expr, sv::OptimizationState, stmts::Vector{Any}, boundsc
                 ft = Bool
             else
                 f = nothing
-                if !(isconcretetype(ft) || (widenconst(ft) <: Type)) || has_free_typevars(ft)
-                    # TODO: this is really aggressive at preventing inlining of closures. maybe drop `isconcretetype` requirement?
+                if has_free_typevars(ft)
                     return e
                 end
             end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -3375,7 +3375,6 @@ function split_disjoint_assign!(ctx::AllocOptContext, info, key)
                         end
                     end
                     # replace old expression with new and update metadata
-                    slot_var = quoted(23431)
                     replace_use_expr_with!(ctx, use, slot_var, false, isempty(exprs))
                     if !isempty(exprs)
                         old_expr = use.stmts[use.stmtidx]

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -24,13 +24,13 @@ function issingletontype(@nospecialize t)
 end
 
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
+isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
 
 # equivalent to isdispatchtuple(Tuple{v}) || v == Union{}
 # and is thus perhaps most similar to the old (pre-1.0) `isleaftype` query
 function isdispatchelem(@nospecialize v)
     return (v === Bottom) || (v === typeof(Bottom)) ||
-        (isconcretetype(v) && !iskindtype(v)) ||
-        (isType(v) && !has_free_typevars(v))
+        isconcretedispatch(v) || (isType(v) && !has_free_typevars(v))
 end
 
 argtypes_to_type(argtypes::Array{Any,1}) = Tuple{anymap(widenconst, argtypes)...}

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2060,17 +2060,17 @@ static Value *compute_box_tindex(jl_codectx_t &ctx, Value *datatype, jl_value_t 
     return tindex;
 }
 
-// get the runtime tindex value
+// get the runtime tindex value, assuming val is already converted to type typ if it has a TIndex
 static Value *compute_tindex_unboxed(jl_codectx_t &ctx, const jl_cgval_t &val, jl_value_t *typ)
 {
     if (val.typ == jl_bottom_type)
         return UndefValue::get(T_int8);
     if (val.constant)
         return ConstantInt::get(T_int8, get_box_tindex((jl_datatype_t*)jl_typeof(val.constant), typ));
-    if (val.isboxed)
-        return compute_box_tindex(ctx, emit_typeof_boxed(ctx, val), val.typ, typ);
-    assert(val.TIndex);
-    return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(T_int8, 0x7f));
+    if (val.TIndex)
+        return ctx.builder.CreateAnd(val.TIndex, ConstantInt::get(T_int8, 0x7f));
+    assert(val.isboxed);
+    return compute_box_tindex(ctx, emit_typeof_boxed(ctx, val), val.typ, typ);
 }
 
 /*

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -772,6 +772,133 @@ struct math_builder {
 static Value *emit_untyped_intrinsic(jl_codectx_t &ctx, intrinsic f, Value **argvalues, size_t nargs,
                                      jl_datatype_t **newtyp, jl_value_t *xtyp);
 
+
+// NOTE: this is the only intrinsic we allow for an input to be a runtime NULL
+// (or other undef value), as a means of building up a PHI node
+// the result is undef, however, if the NULL is selected
+static jl_cgval_t emit_select_value(jl_codectx_t &ctx, jl_value_t **args, size_t nargs, jl_value_t *rt_hint)
+{
+    if (nargs != 3)
+        jl_errorf("intrinsic #%d select_value: wrong number of arguments", select_value);
+    jl_cgval_t c = emit_expr(ctx, args[1]);
+    jl_cgval_t x = emit_expr(ctx, args[2]);
+    jl_cgval_t y = emit_expr(ctx, args[3]);
+
+    Value *isfalse = emit_condition(ctx, c, "select_value"); // emit the first argument
+    // emit X and Y arguments
+    jl_value_t *t1 = x.typ;
+    jl_value_t *t2 = y.typ;
+    // check the return value was valid
+    if (t1 == jl_bottom_type && t2 == jl_bottom_type)
+        return jl_cgval_t(); // undefined
+    if (t1 == jl_bottom_type)
+        return y;
+    if (t2 == jl_bottom_type)
+        return x;
+
+    Value *ifelse_result;
+    bool isboxed;
+    Type *llt1 = julia_type_to_llvm(t1, &isboxed);
+    if (t1 != t2)
+        isboxed = true;
+    if (!isboxed) {
+        if (type_is_ghost(llt1))
+            return x;
+        ifelse_result = ctx.builder.CreateSelect(isfalse,
+                emit_unbox(ctx, llt1, y, t1),
+                emit_unbox(ctx, llt1, x, t1));
+    }
+    else {
+        // if they aren't the same type, consider using the expr type
+        // to instantiate a union-split optimization
+        x = convert_julia_type(ctx, x, rt_hint);
+        y = convert_julia_type(ctx, y, rt_hint);
+        Value *x_tindex = x.TIndex;
+        Value *y_tindex = y.TIndex;
+        if (x_tindex || y_tindex) {
+            if (!x.isghost)
+                x = value_to_pointer(ctx, x);
+            if (!y.isghost)
+                y = value_to_pointer(ctx, y);
+            Value *x_vboxed = x.Vboxed;
+            Value *y_vboxed = y.Vboxed;
+            Value *x_ptr = (x.isghost ? NULL : data_pointer(ctx, x));
+            Value *y_ptr = (y.isghost ? NULL : data_pointer(ctx, y));
+            if (!x.isghost && x.constant)
+                x_vboxed = boxed(ctx, x);
+            if (!y.isghost && y.constant)
+                y_vboxed = boxed(ctx, y);
+            if (!x_ptr && !y_ptr) {
+                ifelse_result = NULL;
+            }
+            else if (!x_ptr) {
+                ifelse_result = y_ptr;
+            }
+            else if (!y_ptr) {
+                ifelse_result = x_ptr;
+            }
+            else {
+                x_ptr = decay_derived(x_ptr);
+                y_ptr = decay_derived(y_ptr);
+                if (x_ptr->getType() != y_ptr->getType())
+                    y_ptr = ctx.builder.CreateBitCast(y_ptr, x_ptr->getType());
+                ifelse_result = ctx.builder.CreateSelect(isfalse, y_ptr, x_ptr);
+            }
+            Value *tindex;
+            if (!x_tindex && x.constant) {
+                x_tindex = ConstantInt::get(T_int8, 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(x.constant), rt_hint));
+            }
+            if (!y_tindex && y.constant) {
+                y_tindex = ConstantInt::get(T_int8, 0x80 | get_box_tindex((jl_datatype_t*)jl_typeof(y.constant), rt_hint));
+            }
+            if (x_tindex && y_tindex) {
+                tindex = ctx.builder.CreateSelect(isfalse, y_tindex, x_tindex);
+            }
+            else {
+                PHINode *ret = PHINode::Create(T_int8, 2);
+                BasicBlock *post = BasicBlock::Create(jl_LLVMContext, "post", ctx.f);
+                BasicBlock *compute = BasicBlock::Create(jl_LLVMContext, "compute_tindex", ctx.f);
+                // compute tindex if we select the previously-boxed (and non-null) value
+                if (x_tindex) {
+                    assert(y.isboxed && y.V);
+                    ctx.builder.CreateCondBr(ctx.builder.CreateAnd(isfalse, ctx.builder.CreateIsNotNull(y.V)), compute, post);
+                    ret->addIncoming(x_tindex, ctx.builder.GetInsertBlock());
+                    ctx.builder.SetInsertPoint(compute);
+                    tindex = compute_tindex_unboxed(ctx, y, rt_hint);
+                }
+                else {
+                    assert(x.isboxed);
+                    ctx.builder.CreateCondBr(ctx.builder.CreateOr(isfalse, ctx.builder.CreateIsNull(x.V)), post, compute);
+                    ret->addIncoming(y_tindex, ctx.builder.GetInsertBlock());
+                    ctx.builder.SetInsertPoint(compute);
+                    tindex = compute_tindex_unboxed(ctx, x, rt_hint);
+                }
+                tindex = ctx.builder.CreateOr(tindex, ConstantInt::get(T_int8, 0x80));
+                ret->addIncoming(tindex, compute);
+                ctx.builder.CreateBr(post);
+                ctx.builder.SetInsertPoint(post);
+                ctx.builder.Insert(ret);
+                tindex = ret;
+            }
+            jl_cgval_t ret = mark_julia_slot(ifelse_result, rt_hint, tindex, tbaa_data);
+            ret.isimmutable = x.isimmutable && y.isimmutable;
+            if (x_vboxed || y_vboxed) {
+                if (!x_vboxed)
+                    x_vboxed = ConstantPointerNull::get(cast<PointerType>(y_vboxed->getType()));
+                if (!y_vboxed)
+                    y_vboxed = ConstantPointerNull::get(cast<PointerType>(x_vboxed->getType()));
+                ret.Vboxed = ctx.builder.CreateSelect(isfalse, y_vboxed, x_vboxed);
+            }
+            return ret;
+        }
+        ifelse_result = ctx.builder.CreateSelect(isfalse,
+                boxed(ctx, y),
+                boxed(ctx, x));
+    }
+    jl_value_t *jt = (t1 == t2 ? t1 : rt_hint);
+    return mark_julia_type(ctx, ifelse_result, isboxed, jt);
+}
+
 static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **args, size_t nargs)
 {
     assert(f < num_intrinsics);
@@ -822,42 +949,6 @@ static jl_cgval_t emit_intrinsic(jl_codectx_t &ctx, intrinsic f, jl_value_t **ar
         return generic_cast(ctx, f, generic_fptrunc, argv, false, false);
     case fpext:
         return generic_cast(ctx, f, generic_fpext, argv, false, false);
-
-    case select_value: {
-        Value *isfalse = emit_condition(ctx, argv[0], "select_value"); // emit the first argument
-        // emit X and Y arguments
-        const jl_cgval_t &x = argv[1];
-        const jl_cgval_t &y = argv[2];
-        jl_value_t *t1 = x.typ;
-        jl_value_t *t2 = y.typ;
-        // check the return value was valid
-        if (t1 == jl_bottom_type && t2 == jl_bottom_type)
-            return jl_cgval_t(); // undefined
-        if (t1 == jl_bottom_type)
-            return y;
-        if (t2 == jl_bottom_type)
-            return x;
-
-        Value *ifelse_result;
-        bool isboxed;
-        Type *llt1 = julia_type_to_llvm(t1, &isboxed);
-        if (t1 != t2)
-            isboxed = true;
-        if (!isboxed) {
-            if (type_is_ghost(llt1))
-                return x;
-            ifelse_result = ctx.builder.CreateSelect(isfalse,
-                    emit_unbox(ctx, llt1, y, t1),
-                    emit_unbox(ctx, llt1, x, t1));
-        }
-        else {
-            ifelse_result = ctx.builder.CreateSelect(isfalse,
-                    boxed(ctx, y),
-                    boxed(ctx, x));
-        }
-        jl_value_t *jt = (t1 == t2 ? t1 : (jl_value_t*)jl_any_type);
-        return mark_julia_type(ctx, ifelse_result, isboxed, jt);
-    }
 
     case not_int: {
         const jl_cgval_t &x = argv[0];

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -884,7 +884,7 @@ un_fintrinsic(sqrt_float,sqrt_llvm)
 
 JL_DLLEXPORT jl_value_t *jl_select_value(jl_value_t *isfalse, jl_value_t *a, jl_value_t *b)
 {
-    JL_TYPECHK(isfalse, bool, isfalse);
+    JL_TYPECHK(select_value, bool, isfalse);
     return (isfalse == jl_false ? b : a);
 }
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -76,7 +76,6 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
             Base.sigatomic_end()
             if iserr
                 put!(backend.response_channel, lasterr)
-                iserr, lasterr = false, ()
             else
                 backend.in_eval = true
                 value = eval(Main, ast)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # tests for Core.Compiler correctness and precision
-import Core.Compiler: Const, Conditional, ⊑
+import Core.Compiler: Const, Conditional, ⊑, isdispatchelem
 
 using Random
 using InteractiveUtils: code_llvm
@@ -210,8 +210,8 @@ end
 end
 let
     ast12474 = code_typed(f12474, Tuple{Float64})
-    @test isconcretetype(ast12474[1][2])
-    @test all(isconcretetype, ast12474[1][1].slottypes)
+    @test isdispatchelem(ast12474[1][2])
+    @test all(isdispatchelem, ast12474[1][1].slottypes)
 end
 
 
@@ -437,10 +437,10 @@ function is_typed_expr(e::Expr)
     return false
 end
 test_inferred_static(@nospecialize(other)) = true
-test_inferred_static(slot::TypedSlot) = @test isconcretetype(slot.typ)
+test_inferred_static(slot::TypedSlot) = @test isdispatchelem(slot.typ)
 function test_inferred_static(expr::Expr)
     if is_typed_expr(expr)
-        @test isconcretetype(expr.typ)
+        @test isdispatchelem(expr.typ)
     end
     for a in expr.args
         test_inferred_static(a)
@@ -448,10 +448,10 @@ function test_inferred_static(expr::Expr)
 end
 function test_inferred_static(arrow::Pair)
     code, rt = arrow
-    @test isconcretetype(rt)
+    @test isdispatchelem(rt)
     @test code.inferred
-    @test all(isconcretetype, code.slottypes)
-    @test all(isconcretetype, code.ssavaluetypes)
+    @test all(isdispatchelem, code.slottypes)
+    @test all(isdispatchelem, code.ssavaluetypes)
     for e in code.code
         test_inferred_static(e)
     end


### PR DESCRIPTION
This is needed to handle the IR structure emitted by the new proposed `iterate` protocol.