### PR TITLE
Add ArrayHashingStyle trait for O(1) range hashing and use it only for Numbers

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1965,8 +1965,10 @@ function hash_range(r::AbstractRange, h::UInt)
 end
 
 function hash(a::AbstractArray{T}, h::UInt) where T
-    # O(1) hashing for types with regular step
-    if isa(a, AbstractRange) && isa(RangeStepStyle(a), RangeStepRegular)
+    # O(1) hashing for types with ArrayHashingDiff and RangeStepRegular traits
+    if isa(a, AbstractRange) &&
+       isa(ArrayHashingStyle(T), ArrayHashingDiff) &&
+       isa(RangeStepStyle(a), RangeStepRegular)
         return hash_range(a, h)
     end
 
@@ -1984,7 +1986,9 @@ function hash(a::AbstractArray{T}, h::UInt) where T
     # at the beginning of the array as such as long as they match this assumption
     # This needs to be done even for non-RangeStepRegular types since they may still be equal
     # to RangeStepRegular values (e.g. 1.0:3.0 == 1:3)
-    if isa(a, AbstractVector) && applicable(-, x2, x1)
+    if isa(a, AbstractVector) &&
+       isa(ArrayHashingStyle(x1), ArrayHashingDiff) &&
+       isa(ArrayHashingStyle(x2), ArrayHashingDiff)
         n = 1
         local step, laststep, laststate
         while true
@@ -2002,7 +2006,10 @@ function hash(a::AbstractArray{T}, h::UInt) where T
                 # If true, wraparound overflow happened
                 sign(step) == cmp(x2, x1) || break
             else
-                applicable(-, x2, x1) || break
+                if !isa(ArrayHashingStyle(x1), ArrayHashingDiff) ||
+                   !isa(ArrayHashingStyle(x2), ArrayHashingDiff)
+                    break
+                end
                 # widen() is here to ensure no overflow can happen
                 step = widen(x2) - widen(x1)
             end

--- a/base/traits.jl
+++ b/base/traits.jl
@@ -57,3 +57,32 @@ struct RangeStepRegular   <: RangeStepStyle end # range with regular step
 struct RangeStepIrregular <: RangeStepStyle end # range with rounding error
 
 RangeStepStyle(instance) = RangeStepStyle(typeof(instance))
+
+# trait for diff-based hashing, O(1) for ranges with regular step
+"""
+    ArrayHashingStyle(instance)
+    ArrayHashingStyle(T::Type)
+
+Indicate whether an instance or a type supports hashing an `AbstractArray`
+by computing the difference between subsequent elements (`ArrayHashingDiff`)
+or not (`ArrayHashingDefault`). This allows [`hash](@ref) to use an O(1)
+hashing algorithm for [`RangeStepRegular`](@ref RangeStepStyle) ranges,
+but requires `T` to implement [`widen`](@ref) in order to compute
+the difference without any risk of overflow (only needed for hashing
+heterogeneous arrays).
+
+Note that all types `S` and `T` for which `isequal(::S, ::T)` can return `true`
+are required to use the same `ArrayHashingStyle`: else, equal arrays containing
+such elements would not hash to the same value.
+
+By default, only `Number` types are assumed to be `ArrayHashingDiff`, and
+therefore need to implement `widen` to support arrays hashing in all cases.
+"""
+abstract type ArrayHashingStyle end
+struct ArrayHashingDefault <: RangeStepStyle end # range with regular step
+struct ArrayHashingDiff    <: RangeStepStyle end # range with rounding error
+
+ArrayHashingStyle(instance) = ArrayHashingStyle(typeof(instance))
+
+ArrayHashingStyle(::Type{<:Number}) = ArrayHashingDiff()
+ArrayHashingStyle(::Type) = ArrayHashingDefault()

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -63,7 +63,7 @@ let
                         @test findall(occursin(dr), dr) == [1:len;]
                         @test length([dr;]) == len
                         @test dr == dr1
-                        @test hash(dr) == hash(dr1)
+                        @test hash(dr) == hash(dr1) == hash(convert(Vector{Any}, dr1))
                     end
                     @test !isempty(reverse(dr))
                     @test length(reverse(dr)) == len
@@ -121,7 +121,7 @@ let
                         @test findall(occursin(dr), dr) == [1:len;]
                         @test length([dr;]) == len
                         @test dr == dr1
-                        @test hash(dr) == hash(dr1)
+                        @test hash(dr) == hash(dr1) == hash(convert(Vector{Any}, dr1))
                     end
                     @test !isempty(reverse(dr))
                     @test length(reverse(dr)) == len
@@ -181,7 +181,7 @@ let
                             @test findall(occursin(dr), dr) == [1:len;]
                             @test length([dr;]) == len
                             @test dr == dr1
-                            @test hash(dr) == hash(dr1)
+                            @test hash(dr) == hash(dr1) == hash(convert(Vector{Any}, dr1))
                         end
                         @test !isempty(reverse(dr))
                         @test length(reverse(dr)) == len
@@ -239,7 +239,7 @@ let
                             @test findall(occursin(dr), dr) == [1:len;]
                             @test length([dr;]) == len
                             @test dr == dr1
-                            @test hash(dr) == hash(dr1)
+                            @test hash(dr) == hash(dr1) == hash(convert(Vector{Any}, dr1))
                         end
                         @test !isempty(reverse(dr))
                         @test length(reverse(dr)) == len


### PR DESCRIPTION
O(1) range hashing requires `widen` to avoid overflows when hashing heterogeneous arrays. Since this requirement can be problematic, add an `ArrayHashingStyle` trait to opt-in for this behavior, and use it only for `Number`s by default. This assumes that `isequal(x::Number, y::T)` will only return true when T<:Number, or at least that counter-examples are rare enough that it's OK to requires these types to define the trait: else, `hash(::AbstractArray{T})` will be inconsistent with isequal across types.

Do not use O(1) hashing for `Dates` types, which fixes hashing heterogeneous arrays, and add corresponding tests.

See [previous discussion](https://github.com/JuliaLang/julia/pull/16401/#issuecomment-355210342). The new trait will probably not be used very often by external packages, but it sounds cleaner to define it than to special-case `Number` directly in the function. Again, it's annoying that this design is so complex, but at least this limits the burden of implementing `widen` to `Number` types, rather than requiring all types which support `-` to implement it.