### PR TITLE
speed up isequal and == for small tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -266,11 +266,19 @@ function _isequal(t1::Any16, t2::Any16)
     return true
 end
 
-function ==(t1::Tuple, t2::Tuple)
-    if length(t1) != length(t2)
+==(t1::Tuple, t2::Tuple) = (length(t1) == length(t2)) && _eq(t1, t2, false)
+_eq(t1::Tuple{}, t2::Tuple{}, anymissing) = anymissing ? missing : true
+function _eq(t1::Tuple, t2::Tuple, anymissing)
+    eq = t1[1] == t2[1]
+    if ismissing(eq)
+        return _eq(tail(t1), tail(t2), true)
+    elseif !eq
         return false
+    else
+        return _eq(tail(t1), tail(t2), anymissing)
     end
-    anymissing = false
+end
+function _eq(t1::Any16, t2::Any16, anymissing)
     for i = 1:length(t1)
         eq = (t1[i] == t2[i])
         if ismissing(eq)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -253,10 +253,11 @@ end
 
 ## comparison ##
 
-function isequal(t1::Tuple, t2::Tuple)
-    if length(t1) != length(t2)
-        return false
-    end
+isequal(t1::Tuple, t2::Tuple) = (length(t1) == length(t2)) && _isequal(t1, t2)
+_isequal(t1::Tuple{}, t2::Tuple{}) = true
+_isequal(t1::Tuple{Any}, t2::Tuple{Any}) = isequal(t1[1], t2[1])
+_isequal(t1::Tuple, t2::Tuple) = isequal(t1[1], t2[1]) && _isequal(tail(t1), tail(t2))
+function _isequal(t1::Any16, t2::Any16)
     for i = 1:length(t1)
         if !isequal(t1[i], t2[i])
             return false

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -270,12 +270,10 @@ end
 _eq(t1::Tuple{}, t2::Tuple{}, anymissing) = anymissing ? missing : true
 function _eq(t1::Tuple, t2::Tuple, anymissing)
     eq = t1[1] == t2[1]
-    if ismissing(eq)
-        return _eq(tail(t1), tail(t2), true)
-    elseif !eq
+    if eq === false
         return false
     else
-        return _eq(tail(t1), tail(t2), anymissing)
+        return _eq(tail(t1), tail(t2), anymissing | ismissing(eq))
     end
 end
 function _eq(t1::Any16, t2::Any16, anymissing)

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -260,11 +260,22 @@ end
     @test ismissing((missing, 2) == (1, missing))
     @test !((missing, 1) == (missing, 2))
 
+    longtuple = (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
+    @test ismissing((longtuple...,17,missing) == (longtuple...,17,18))
+    @test ismissing((longtuple...,missing,18) == (longtuple...,17,18))
+    @test !((longtuple...,17,missing) == (longtuple...,-17,18))
+    @test !((longtuple...,missing,18) == (longtuple...,17,-18))
+
     @test ismissing((1, missing) != (1, missing))
     @test ismissing(("a", missing) != ("a", missing))
     @test ismissing((missing,) != (missing,))
     @test ismissing((missing, 2) != (1, missing))
     @test (missing, 1) != (missing, 2)
+
+    @test ismissing((longtuple...,17,missing) != (longtuple...,17,18))
+    @test ismissing((longtuple...,missing,18) != (longtuple...,17,18))
+    @test (longtuple...,17,missing) != (longtuple...,-17,18)
+    @test (longtuple...,missing,18) != (longtuple...,17,-18)
 end
 
 @testset "< and isless on tuples" begin


### PR DESCRIPTION
Currently, `isequal` for inhomogeneous tuples allocates because it loops over the elements, so that the compiler cannot infer the type of the variables in the loop. This switches to a lisp style recursive definition for small tuples, in similar spirit to how `map` etc are implemented. The difference can be significant:

Before:
```julia
julia> @benchmark isequal((3,5.),(3,5))
BenchmarkTools.Trial: 
  memory estimate:  80 bytes
  allocs estimate:  3
  --------------
  minimum time:     46.539 ns (0.00% GC)
  median time:      51.482 ns (0.00% GC)
  mean time:        63.057 ns (12.80% GC)
  maximum time:     36.090 μs (99.81% GC)
  --------------
  samples:          10000
  evals/sample:     979
```
After:
```julia
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.649 ns (0.00% GC)
  median time:      1.896 ns (0.00% GC)
  mean time:        1.926 ns (0.00% GC)
  maximum time:     37.677 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1000
```

I would like to do the same for `==`, but don't fully understand the current implementation with `missing`. It seems to me that, with the current implementation, if `missing` appears in the first slot of one or both of the two tuples (or all slots before its appearance are equal in both tuples) then `missing` is returned. However, if there are non-equal values before the `missing` is encountered, than `false` is returned. Is this the desired behaviour?