### PR TITLE
don't print a space in Union printing

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -385,8 +385,13 @@ end
 show(io::IO, ::Core.TypeofBottom) = print(io, "Union{}")
 
 function show(io::IO, x::Union)
-    print(io, "Union")
-    show_comma_array(io, uniontypes(x), '{', '}')
+    types = uniontypes(x)
+    print(io, "Union{")
+    for i in 1:length(types)
+        print(io, types[i])
+        i == length(types) || print(io, ',')
+    end
+    print(io, '}')
 end
 
 function print_without_params(@nospecialize(x))
@@ -702,7 +707,6 @@ function show_delim_array(io::IO, itr, op, delim, cl, delim_one, i1=1, n=typemax
     print(io, cl)
 end
 
-show_comma_array(io::IO, itr, o, c) = show_delim_array(io, itr, o, ',', c, false)
 show(io::IO, t::Tuple) = show_delim_array(io, t, '(', ',', ')', true)
 show(io::IO, v::SimpleVector) = show_delim_array(io, v, "svec(", ',', ')', false)
 

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -84,7 +84,7 @@ end
 let nt = merge(NamedTuple{(:a,:b),Tuple{Int32,Union{Int32,Nothing}}}((1,Int32(2))),
                NamedTuple{(:a,:c),Tuple{Union{Int8,Nothing},Float64}}((nothing,1.0)))
     @test typeof(nt) == NamedTuple{(:a,:b,:c),Tuple{Union{Int8,Nothing},Union{Int32,Nothing},Float64}}
-    @test repr(nt) == "NamedTuple{(:a, :b, :c),Tuple{Union{Nothing, Int8},Union{Nothing, Int32},Float64}}((nothing, 2, 1.0))"
+    @test repr(nt) == "NamedTuple{(:a, :b, :c),Tuple{Union{Nothing,Int8},Union{Nothing,Int32},Float64}}((nothing, 2, 1.0))"
 end
 
 @test merge(NamedTuple(), [:a=>1, :b=>2, :c=>3, :a=>4, :c=>5]) == (a=4, b=2, c=5)

--- a/test/show.jl
+++ b/test/show.jl
@@ -338,7 +338,7 @@ end
 @test sprint(show, :end) == ":end"
 
 # issue #12477
-@test sprint(show,  Union{Int64, Int32, Int16, Int8, Float64}) == "Union{Float64, Int16, Int32, Int64, Int8}"
+@test sprint(show,  Union{Int64, Int32, Int16, Int8, Float64}) == "Union{Float64,Int16,Int32,Int64,Int8}"
 
 # Function and array reference precedence
 @test_repr "([2] + 3)[1]"
@@ -782,7 +782,7 @@ let repr = sprint(dump, Integer)
     @test !contains(repr, "Any")
 end
 let repr = sprint(dump, Union{Integer, Float32})
-    @test repr == "Union{Integer, Float32}\n" || repr == "Union{Float32, Integer}\n"
+    @test repr == "Union{Integer,Float32}\n" || repr == "Union{Float32,Integer}\n"
 end
 let repr = sprint(dump, Core.svec())
     @test repr == "empty SimpleVector\n"


### PR DESCRIPTION
This:
```julia
julia> Union{Int,Missing}
Union{Missing,Int64}

julia> Vector{Union{Int,Missing}}(missing, 2)
2-element Array{Union{Missing,Int64},1}:
 missing
 missing
```
Instead of: 
```julia
julia> Union{Int,Missing}
Union{Missing, Int64}

julia> Vector{Union{Int,Missing}}(missing, 2)
2-element Array{Union{Missing, Int64},1}:
 missing
 missing
```
This is how `Tuple` is printed, thought it would be nice to be consistent:
```julia
julia> Tuple{Int,Missing}
Tuple{Int64,Missing}
```