### PR TITLE
Make map() and broadcast() faster for Union{T, Missing/Nothing} element types

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -573,12 +573,11 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
     i = offs
     while !done(itr, st)
         el, st = next(itr, st)
-        S = typeof(el)
-        if S === T || S <: T
+        if el isa T || typeof(el) === T
             @inbounds dest[i] = el::T
             i += 1
         else
-            R = promote_typejoin(T, S)
+            R = promote_typejoin(T, typeof(el))
             new = similar(dest, R)
             copyto!(new,1, dest,1, i-1)
             @inbounds new[i] = el

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -500,14 +500,13 @@ end
             @nexprs $nargs i->(@inbounds val_i = _broadcast_getindex(A_i, I_i))
             # call the function
             V = @ncall $nargs f val
-            S = typeof(V)
             # store the result
-            if S <: eltype(B)
+            if V isa eltype(B)
                 @inbounds B[I] = V
             else
                 # This element type doesn't fit in B. Allocate a new B with wider eltype,
                 # copy over old values, and continue
-                newB = Base.similar(B, promote_typejoin(eltype(B), S))
+                newB = Base.similar(B, promote_typejoin(eltype(B), typeof(V)))
                 for II in Iterators.take(iter, count)
                     newB[II] = B[II]
                 end


### PR DESCRIPTION
Storing `typeof(el)`/`eltype(B)` in a variable in the hot part of the loop kills performance because despite being inferred as equal to `Union{Type{T}, Type{Missing/Nothing}}`, it is marked as ::Any. Only using `typeof`/`eltype` when `isa` fails works around the problem and makes `map/broadcast(x->x, ::Vector{Union{Int, Missing}})` about 10 times faster.

Fixes https://github.com/JuliaLang/julia/issues/25799.

Before this PR:
```julia
using BenchmarkTools
x = rand(Int, 100_000);
y = convert(Vector{Union{Int,Missing}}, x);
z = copy(y); z[2] = missing;

julia> @btime map(identity, x);
  102.686 μs (3 allocations: 781.34 KiB)

julia> @btime map(identity, y);
  606.995 μs (4 allocations: 781.36 KiB)

julia> @btime map(identity, z);
  7.245 ms (7 allocations: 1.62 MiB)

# Use x->x rather than identity to avoid fast path
julia> @btime broadcast(x->x, x);
  108.737 μs (14 allocations: 781.95 KiB)

julia> @btime broadcast(x->x, y);
  1.225 ms (49 allocations: 783.25 KiB)

julia> @btime broadcast(x->x, z);
  7.318 ms (52 allocations: 1.62 MiB)
```

After this PR:
```julia
julia> @btime map(identity, x);
  104.782 μs (3 allocations: 781.34 KiB)

julia> @btime map(identity, y);
  505.128 μs (4 allocations: 781.36 KiB)

julia> @btime map(identity, z);
  623.634 μs (7 allocations: 1.62 MiB)

julia> @btime broadcast(x->x, x);
  102.317 μs (14 allocations: 781.95 KiB)

julia> @btime broadcast(x->x, y);
  607.368 μs (49 allocations: 783.25 KiB)

julia> @btime broadcast(x->x, z);
  703.995 μs (52 allocations: 1.62 MiB)
```

I will add these benchmarks to BaseBenchmarks to ensure we don't regress. EDIT: see https://github.com/JuliaCI/BaseBenchmarks.jl/pull/176.

EDIT: FWIW, `DataArray` takes 11ms with `map` in the benchmarks above, but only 300μs with `broadcast`. R (with C implementation) takes about 400μs (measured with `x^2` since there's no vectorized identity operation, but timings are similar to `identity` in Julia). So we're not far.