### PR TITLE
RFC: required keyword arguments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,9 @@ New language features
   * Values for `Enum`s can now be specified inside of a `begin` block when using the
     `@enum` macro ([#25424]).
 
+  * Keyword arguments can be required: if a default value is omitted, then an
+    exception is thrown if the caller does not assign the keyword a value ([#5111]).
+
 Language changes
 ----------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,7 +45,7 @@ New language features
     `@enum` macro ([#25424]).
 
   * Keyword arguments can be required: if a default value is omitted, then an
-    exception is thrown if the caller does not assign the keyword a value ([#5111]).
+    exception is thrown if the caller does not assign the keyword a value ([#25830]).
 
 Language changes
 ----------------

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -139,6 +139,7 @@ export
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
+    UnassignedKeyword,
     # AST representation
     Expr, GotoNode, LabelNode, LineNumberNode, QuoteNode,
     GlobalRef, NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot,
@@ -252,6 +253,9 @@ end
 
 struct ArgumentError <: Exception
     msg::AbstractString
+end
+struct UnassignedKeyword <: Exception
+    var::Symbol
 end
 
 struct MethodError <: Exception

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -139,7 +139,7 @@ export
     InterruptException, InexactError, OutOfMemoryError, ReadOnlyMemoryError,
     OverflowError, StackOverflowError, SegmentationFault, UndefRefError, UndefVarError,
     TypeError, ArgumentError, MethodError, AssertionError, LoadError, InitError,
-    UnassignedKeyword,
+    UndefKeywordError,
     # AST representation
     Expr, GotoNode, LabelNode, LineNumberNode, QuoteNode,
     GlobalRef, NewvarNode, SSAValue, Slot, SlotNumber, TypedSlot,
@@ -254,7 +254,7 @@ end
 struct ArgumentError <: Exception
     msg::AbstractString
 end
-struct UnassignedKeyword <: Exception
+struct UndefKeywordError <: Exception
     var::Symbol
 end
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1020,11 +1020,11 @@ A symbol in the current scope is not defined.
 UndefVarError
 
 """
-    UnassignedKeyword(var::Symbol)
+    UndefKeywordError(var::Symbol)
 
 The required keyword argument `var` was not assigned in a function call.
 """
-UnassignedKeyword
+UndefKeywordError
 
 """
     OverflowError(msg)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1020,6 +1020,13 @@ A symbol in the current scope is not defined.
 UndefVarError
 
 """
+    UnassignedKeyword(var::Symbol)
+
+The required keyword argument `var` was not assigned in a function call.
+"""
+UnassignedKeyword
+
+"""
     OverflowError(msg)
 
 The result of an expression is too large for the specified type and will cause a wraparound.

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -134,8 +134,8 @@ showerror(io::IO, ex::ArgumentError) = print(io, "ArgumentError: $(ex.msg)")
 showerror(io::IO, ex::AssertionError) = print(io, "AssertionError: $(ex.msg)")
 showerror(io::IO, ex::OverflowError) = print(io, "OverflowError: $(ex.msg)")
 
-showerror(io::IO, ex::UnassignedKeyword) =
-    print(io, "UnassignedKeyword: keyword argument $(ex.var) not assigned")
+showerror(io::IO, ex::UndefKeywordError) =
+    print(io, "UndefKeywordError: keyword argument $(ex.var) not assigned")
 
 function showerror(io::IO, ex::UndefVarError)
     if ex.var in [:UTF16String, :UTF32String, :WString, :utf16, :utf32, :wstring, :RepString]

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -134,6 +134,9 @@ showerror(io::IO, ex::ArgumentError) = print(io, "ArgumentError: $(ex.msg)")
 showerror(io::IO, ex::AssertionError) = print(io, "AssertionError: $(ex.msg)")
 showerror(io::IO, ex::OverflowError) = print(io, "OverflowError: $(ex.msg)")
 
+showerror(io::IO, ex::UnassignedKeyword) =
+    print(io, "UnassignedKeyword: keyword argument $(ex.var) not assigned")
+
 function showerror(io::IO, ex::UndefVarError)
     if ex.var in [:UTF16String, :UTF32String, :WString, :utf16, :utf32, :wstring, :RepString]
         return showerror(io, ErrorException("""

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -298,7 +298,7 @@ Base.ParseError
 Core.StackOverflowError
 Base.SystemError
 Core.TypeError
-Core.UnassignedKeyword
+Core.UndefKeywordError
 Core.UndefRefError
 Core.UndefVarError
 Base.InitError

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -298,6 +298,7 @@ Base.ParseError
 Core.StackOverflowError
 Base.SystemError
 Core.TypeError
+Core.UnassignedKeyword
 Core.UndefRefError
 Core.UndefVarError
 Base.InitError

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -519,14 +519,14 @@ end
 ```
 
 If a keyword argument is not assigned a default value in the method definition,
-then it is *required*: an [`UnassignedKeyword`](@ref) exception will be thrown
+then it is *required*: an [`UndefKeywordError`](@ref) exception will be thrown
 if the caller does not assign it a value:
 ```julia
 function f(x; y)
     ###
 end
 f(3, y=5) # ok, y is assigned
-f(3)      # throws UnassignedKeyword(:y)
+f(3)      # throws UndefKeywordError(:y)
 ```
 
 Inside `f`, `kwargs` will be a named tuple. Named tuples (as well as dictionaries) can be passed as

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -518,6 +518,17 @@ function f(x; y=0, kwargs...)
 end
 ```
 
+If a keyword argument is not assigned a default value in the method definition,
+then it is *required*: an [`UnassignedKeyword`](@ref) exception will be thrown
+if the caller does not assign it a value:
+```julia
+function f(x; y)
+    ###
+end
+f(3, y=5) # ok, y is assigned
+f(3)      # throws UnassignedKeyword(:y)
+```
+
 Inside `f`, `kwargs` will be a named tuple. Named tuples (as well as dictionaries) can be passed as
 keyword arguments using a semicolon in a call, e.g. `f(x, z=1; kwargs...)`.
 

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -650,7 +650,7 @@
 ; replace unassigned kw args with assignment to throw() call (forcing the caller to assign the keyword)
 (define (throw-unassigned-kw-args argl)
   (define (throw-unassigned argname)
-    `(call (core throw) (call (core UnassignedKeyword) (inert ,argname))))
+    `(call (core throw) (call (core UndefKeywordError) (inert ,argname))))
   (if (has-parameters? argl)
       (cons (cons 'parameters
                   (map (lambda (x)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -644,12 +644,8 @@
     (if (pair? invalid)
         (if (and (pair? (car invalid)) (eq? 'parameters (caar invalid)))
             (error "more than one semicolon in argument list")
-            (cond ((symbol? (car invalid))
-                   (error (string "keyword argument \"" (car invalid) "\" needs a default value")))
-                  (else
-                   (error (string "invalid keyword argument syntax \""
-                                  (deparse (car invalid))
-                                  "\" (expected assignment)"))))))))
+            (error (string "invalid keyword argument syntax \""
+                           (deparse (car invalid)) "\""))))))
 
 ; replace unassigned kw args with assignment to throw() call (forcing the caller to assign the keyword)
 (define (throw-unassigned-kw-args argl)

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -312,11 +312,11 @@ end
 @testset "required keyword arguments" begin
     f(x; y, z=3) = x + 2y + 3z
     @test f(1, y=2) === 14 === f(10, y=2, z=0)
-    @test_throws UnassignedKeyword f(1)
-    @test_throws UnassignedKeyword f(1, z=2)
+    @test_throws UndefKeywordError f(1)
+    @test_throws UndefKeywordError f(1, z=2)
     g(x; y::Int, z=3) = x + 2y + 3z
     @test g(1, y=2) === 14 === g(10, y=2, z=0)
     @test_throws TypeError g(1, y=2.3)
-    @test_throws UnassignedKeyword g(1)
-    @test_throws UnassignedKeyword g(1, z=2)
+    @test_throws UndefKeywordError g(1)
+    @test_throws UndefKeywordError g(1, z=2)
 end

--- a/test/keywordargs.jl
+++ b/test/keywordargs.jl
@@ -308,3 +308,15 @@ end
                 ((1, 3, 5, 6, 7),
                  (a = 2, b = 4, c = 8, d = 9, f = 10))
 end
+
+@testset "required keyword arguments" begin
+    f(x; y, z=3) = x + 2y + 3z
+    @test f(1, y=2) === 14 === f(10, y=2, z=0)
+    @test_throws UnassignedKeyword f(1)
+    @test_throws UnassignedKeyword f(1, z=2)
+    g(x; y::Int, z=3) = x + 2y + 3z
+    @test g(1, y=2) === 14 === g(10, y=2, z=0)
+    @test_throws TypeError g(1, y=2.3)
+    @test_throws UnassignedKeyword g(1)
+    @test_throws UnassignedKeyword g(1, z=2)
+end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -500,10 +500,6 @@ let m_error, error_out, filename = Base.source_path()
     error_out = sprint(showerror, m_error)
     @test startswith(error_out, "ArgumentError: invalid type for argument number 1 in method definition for method_c6 at $filename:")
 
-    m_error = try @eval method_c6(A; B) = 3; catch e; e; end
-    error_out = sprint(showerror, m_error)
-    @test error_out == "syntax: keyword argument \"B\" needs a default value"
-
     # issue #20614
     m_error = try @eval foo(types::NTuple{N}, values::Vararg{Any,N}, c) where {N} = nothing; catch e; e; end
     error_out = sprint(showerror, m_error)


### PR DESCRIPTION
This PR implements required keyword arguments (closes #5111):
```jl
f(; x) = ...
```
is sugar for
```jl
f(; x=throw(UndefKeywordError(:x))) = ...
```