### PR TITLE
Revert "Use multi-line format in `at-show` (#22253)"

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -539,9 +539,8 @@ Show an expression and result, returning the result.
 macro show(exs...)
     blk = Expr(:block)
     for ex in exs
-        push!(blk.args, :(print($(sprint(show_unquoted,ex)*" = "))))
-        push!(blk.args, :(show(STDOUT, "text/plain", begin value=$(esc(ex)) end)))
-        push!(blk.args, :(println()))
+        push!(blk.args, :(println($(sprint(show_unquoted,ex)*" = "),
+                                  repr(begin value=$(esc(ex)) end))))
     end
     isempty(exs) || push!(blk.args, :value)
     return blk

--- a/test/show.jl
+++ b/test/show.jl
@@ -919,7 +919,7 @@ let fname = tempname()
                 @show zeros(2, 2)
             end
         end
-        @test read(fname, String) == "zeros(2, 2) = 2×2 Array{Float64,2}:\n 0.0  0.0\n 0.0  0.0\n"
+        @test read(fname, String) == "zeros(2, 2) = [0.0 0.0; 0.0 0.0]\n"
     finally
         rm(fname, force=true)
     end


### PR DESCRIPTION
This reverts commit fe2d49fb1e8304f5330812e54ade982bd5a38307.

The change in #22253 essentially broke the round-trippable-ness of using `at-show` with arrays. It was decided that the change should simply be reverted.

Fixes #25848.