### PR TITLE
BitArrays should not be DenseArrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -263,7 +263,7 @@ This section lists changes that do not have deprecation warnings.
     respectively ([#22718], [#22925], [#23035], [#23154]).
 
   * The immediate supertype of `BitArray` is now simply `AbstractArray`. `BitArray` is no longer
-    considered a subtype of `DenseArray` and `StridedArray` ([#25857]).
+    considered a subtype of `DenseArray` and `StridedArray` ([#25858]).
 
   * When called with an argument that contains `NaN` elements, `findmin` and `findmax` now return the
     first `NaN` found and its corresponding index. Previously, `NaN` elements were ignored.

--- a/NEWS.md
+++ b/NEWS.md
@@ -262,6 +262,9 @@ This section lists changes that do not have deprecation warnings.
     `Tridiagonal{T,V<:AbstractVector{T}}` and `SymTridiagonal{T,V<:AbstractVector{T}}`
     respectively ([#22718], [#22925], [#23035], [#23154]).
 
+  * The immediate supertype of `BitArray` is now simply `AbstractArray`. `BitArray` is no longer
+    considered a subtype of `DenseArray` and `StridedArray` ([#25857]).
+
   * When called with an argument that contains `NaN` elements, `findmin` and `findmax` now return the
     first `NaN` found and its corresponding index. Previously, `NaN` elements were ignored.
     The new behavior matches that of `min`, `max`, `minimum`, and `maximum`.

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -9,7 +9,7 @@
 
 Space-efficient `N`-dimensional boolean array, which stores one bit per boolean value.
 """
-mutable struct BitArray{N} <: DenseArray{Bool, N}
+mutable struct BitArray{N} <: AbstractArray{Bool, N}
     chunks::Vector{UInt64}
     len::Int
     dims::NTuple{N,Int}
@@ -656,6 +656,9 @@ indexoffset(::Colon) = 0
     f0 = indexoffset(I0)+1
     fill_chunks!(B.chunks, y, f0, l0)
     return B
+end
+@propagate_inbounds function setindex!(B::BitArray, X::AbstractArray, J0::Union{Colon,UnitRange{Int}})
+    _setindex!(IndexStyle(B), B, X, to_indices(B, (J0,))[1])
 end
 
 # logical indexing

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1491,3 +1491,11 @@ end
 end
 
 timesofar("I/O")
+
+@testset "not strided" begin
+    @test_throws ErrorException pointer(trues(1))
+    @test_throws ErrorException pointer(trues(1),1)
+    b = falses(3)
+    b[:] = view(trues(10), [1,3,7])
+    @test b == trues(3)
+end


### PR DESCRIPTION
BitArray has previously been subtype of DenseArray, making it defined as a StridedArray. However - BitArrays do not and can not support the `pointer` function. As such, they can never be passed to a C function in the same manner that all other StridedArrays can.

This patch makes `BitArray <: AbstractArray`. Surprisingly little breaks in our test set, but this is indeed massively breaking.  Notably, most of the other changes required here were actually long-standing bugs that this change simply happened to uncover.