### PR TITLE
Two improvements to replace()

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -583,6 +583,7 @@ _copy_oftype(x::AbstractSet{T}, ::Type{T}) where {T} = copy(x)
 
 For each pair `old=>new` in `old_new`, replace all occurrences
 of `old` in collection `A` by `new`.
+Equality is determined using [`isequal`](@ref).
 If `count` is specified, then replace at most `count` occurrences in total.
 See also [`replace`](@ref replace(A, old_new::Pair...)).
 
@@ -604,7 +605,7 @@ replace!(A, old_new::Pair...; count::Integer=typemax(Int)) = _replace!(A, count,
 function _replace!(A, count::Integer, old_new::Tuple{Vararg{Pair}})
     @inline function new(x)
         for o_n in old_new
-            first(o_n) == x && return last(o_n)
+            isequal(first(o_n), x) && return last(o_n)
         end
         return x # no replace
     end
@@ -671,6 +672,7 @@ end
 
 Return a copy of collection `A` where, for each pair `old=>new` in `old_new`,
 all occurrences of `old` are replaced by `new`.
+Equality is determined using [`isequal`](@ref).
 If `count` is specified, then replace at most `count` occurrences in total.
 See also [`replace!`](@ref).
 
@@ -699,6 +701,7 @@ promote_valuetype(x::Pair{K, V}, y::Pair...) where {K, V} =
 
 Return a copy of collection `A` where all occurrences `x` for which
 `pred(x)` is true are replaced by `new`.
+If `count` is specified, then replace at most `count` occurrences in total.
 
 # Examples
 ```jldoctest
@@ -719,6 +722,8 @@ end
     replace(new::Function, A; [count::Integer])
 
 Return a copy of `A` where each value `x` in `A` is replaced by `new(x)`
+If `count` is specified, then replace at most `count` values in total
+(replacements being defined as `new(x) !== x`).
 
 # Examples
 ```jldoctest

--- a/base/set.jl
+++ b/base/set.jl
@@ -564,6 +564,16 @@ convert(::Type{T}, s::AbstractSet) where {T<:AbstractSet} = T(s)
 
 ## replace/replace! ##
 
+# TODO: use copy!, which is currently unavailable from here since it is defined in Future
+_copy_oftype(x, ::Type{T}) where {T} = copyto!(similar(x, T), x)
+# TODO: use similar() once deprecation is removed and it preserves keys
+_copy_oftype(x::AbstractDict, ::Type{T}) where {T} = merge!(empty(x, T), x)
+_copy_oftype(x::AbstractSet, ::Type{T}) where {T} = union!(empty(x, T), x)
+
+_copy_oftype(x::AbstractArray{T}, ::Type{T}) where {T} = copy(x)
+_copy_oftype(x::AbstractDict{K,V}, ::Type{Pair{K,V}}) where {K,V} = copy(x)
+_copy_oftype(x::AbstractSet{T}, ::Type{T}) where {T} = copy(x)
+
 # to make replace/replace! work for a new container type Cont, only
 # replace!(new::Callable, A::Cont; count::Integer=typemax(Int))
 # has to be implemented
@@ -589,9 +599,9 @@ julia> replace!(Set([1, 2, 3]), 1=>0)
 Set([0, 2, 3])
 ```
 """
-replace!(A, old_new::Pair...; count::Integer=typemax(Int)) = _replace!(A, eltype(A), count, old_new)
+replace!(A, old_new::Pair...; count::Integer=typemax(Int)) = _replace!(A, count, old_new)
 
-function _replace!(A, ::Type{K}, count::Integer, old_new::Tuple{Vararg{Pair}}) where K
+function _replace!(A, count::Integer, old_new::Tuple{Vararg{Pair}})
     @inline function new(x)
         for o_n in old_new
             first(o_n) == x && return last(o_n)
@@ -674,8 +684,15 @@ julia> replace([1, 2, 1, 3], 1=>0, 2=>4, count=2)
  3
 ```
 """
-replace(A, old_new::Pair...; count::Integer=typemax(Int)) =
-    _replace!(copy(A), eltype(A), count, old_new)
+function replace(A, old_new::Pair...; count::Integer=typemax(Int))
+    V = promote_valuetype(old_new...)
+    T = promote_type(eltype(A), V)
+    _replace!(_copy_oftype(A, T), count, old_new)
+end
+
+promote_valuetype(x::Pair{K, V}) where {K, V} = V
+promote_valuetype(x::Pair{K, V}, y::Pair...) where {K, V} =
+    promote_type(V, promote_valuetype(y...))
 
 """
     replace(pred::Function, A, new; [count::Integer])
@@ -693,8 +710,10 @@ julia> replace(isodd, [1, 2, 3, 1], 0, count=2)
  1
 ```
 """
-replace(pred::Callable, A, new; count::Integer=typemax(Int)) =
-    replace!(pred, copy(A), new, count=count)
+function replace(pred::Callable, A, new; count::Integer=typemax(Int))
+    T = promote_type(eltype(A), typeof(new))
+    replace!(pred, _copy_oftype(A, T), new, count=count)
+end
 
 """
     replace(new::Function, A; [count::Integer])

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -547,6 +547,10 @@ end
     @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
     x = @inferred replace(x -> x > 1, [1, 2], missing)
     @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
+
+    # test that isequal is used
+    @test replace([NaN, 1.0], NaN=>0.0) == [0.0, 1.0]
+    @test replace([1, missing], missing=>0) == [1, 0]
 end
 
 @testset "⊆, ⊊, ⊈, ⊇, ⊋, ⊉, <, <=, issetequal" begin

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -536,6 +536,17 @@ end
 
     # avoid recursive call issue #25384
     @test_throws MethodError replace!("")
+
+    # test eltype promotion
+    x = @inferred replace([1, 2], 2=>2.5)
+    @test x == [1, 2.5] && x isa Vector{Float64}
+    x = @inferred replace(x -> x > 1, [1, 2], 2.5)
+    @test x == [1, 2.5] && x isa Vector{Float64}
+
+    x = @inferred replace([1, 2], 2=>missing)
+    @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
+    x = @inferred replace(x -> x > 1, [1, 2], missing)
+    @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
 end
 
 @testset "⊆, ⊊, ⊈, ⊇, ⊋, ⊉, <, <=, issetequal" begin


### PR DESCRIPTION
The first commit uses promotion to choose the element type of the array returned by `replace` so that it can hold both the original elements and the replacement(s). This is useful in particular to replace missing values or to replace integer values with non-integer ones.

The second commit changes `replace` to use `isequal` rather than `==`. This allows replacing `NaN` and `missing`, and it's already what happens with dicts and sets.