### PR TITLE
documentation.md: list all available admonition types

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -881,9 +881,8 @@ cannot span multiple rows or columns of the table.
 
 #### Admonitions
 
-Specially formatted blocks with titles such as "Notes", "Warning", or "Tips" are known as admonitions
-and are used when some part of a document needs special attention. They can be defined using the
-following `!!!` syntax:
+Specially formatted blocks, known as admonitions, can be used to highlight particular remarks.
+They can be defined using the following `!!!` syntax:
 
 ```
 !!! note
@@ -897,11 +896,12 @@ following `!!!` syntax:
     This warning admonition has a custom title: `"Beware!"`.
 ```
 
-If no title text is specified after the admonition type in double quotes,
-then the title used will be the title of the block, i.e. `"Note"` in the case of the `note` admonition.
+The type of the admonition can be any word, but some types produce special styling,
+namely (in order of decreasing severity): `danger`, `warning`, `info`/`note`, and `tip`.
 
-The full list of natively supported admonition types (which render into distinct colored boxes) can be seen
-[here](https://github.com/JuliaLang/julia/blob/c6f056b79/stdlib/Markdown/src/render/terminal/render.jl#L35-L43)
+A custom title for the box can be provided as a string (in double quotes) after the admonition type.
+If no title text is specified after the admonition type, then the title used will be the type of the block,
+i.e. `"Note"` in the case of the `note` admonition.
 
 Admonitions, like most other toplevel elements, can contain other toplevel elements.
 

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -897,9 +897,13 @@ following `!!!` syntax:
     This warning admonition has a custom title: `"Beware!"`.
 ```
 
-Admonitions, like most other toplevel elements, can contain other toplevel elements. When no title
-text, specified after the admonition type in double quotes, is included then the title used will
-be the type of the block, i.e. `"Note"` in the case of the `note` admonition.
+If no title text is specified after the admonition type in double quotes,
+then the title used will be the title of the block, i.e. `"Note"` in the case of the `note` admonition.
+
+The full list of natively supported admonition types (which render into distinct colored boxes) can be seen
+[here](https://github.com/JuliaLang/julia/blob/c6f056b79/stdlib/Markdown/src/render/terminal/render.jl#L35-L43)
+
+Admonitions, like most other toplevel elements, can contain other toplevel elements.
 
 ## Markdown Syntax Extensions
 

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -32,6 +32,7 @@ end
 
 function term(io::IO, md::Admonition, columns)
     col = :default
+    # If the types below are modified, the page manual/documentation.md must be updated accordingly.
     if lowercase(md.title) == "danger"
         col = Base.error_color()
     elseif lowercase(md.title) == "warning"


### PR DESCRIPTION
I'd like some help regarding how to link to a source file. Ideally we'd link to the Markdown module's documentation, but it's [currently empty](https://github.com/JuliaLang/julia/blob/master/stdlib/Markdown/docs/src/index.md) :/