### PR TITLE
Improve inference of `collect` with unstable eltype

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -543,7 +543,7 @@ else
 end
 
 _array_for(::Type{T}, itr, ::HasLength) where {T} = Vector{T}(undef, Int(length(itr)::Integer))
-_array_for(::Type{T}, itr, ::HasShape) where {T} = similar(Array{T}, axes(itr))::Array{T}
+_array_for(::Type{T}, itr, ::HasShape{N}) where {T,N} = similar(Array{T,N}, axes(itr))
 
 function collect(itr::Generator)
     isz = IteratorSize(itr.iter)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -125,19 +125,20 @@ Compute a type that contains both `T` and `S`, which could be
 either a parent of both types, or a `Union` if appropriate.
 Falls back to [`typejoin`](@ref).
 """
-promote_typejoin(@nospecialize(a), @nospecialize(b)) = typejoin(a, b)
-promote_typejoin(::Type{Nothing}, ::Type{T}) where {T} =
+promote_typejoin(@nospecialize(a), @nospecialize(b)) = _promote_typejoin(a, b)::Type
+_promote_typejoin(@nospecialize(a), @nospecialize(b)) = typejoin(a, b)
+_promote_typejoin(::Type{Nothing}, ::Type{T}) where {T} =
     isconcretetype(T) || T === Union{} ? Union{T, Nothing} : Any
-promote_typejoin(::Type{T}, ::Type{Nothing}) where {T} =
+_promote_typejoin(::Type{T}, ::Type{Nothing}) where {T} =
     isconcretetype(T) || T === Union{} ? Union{T, Nothing} : Any
-promote_typejoin(::Type{Missing}, ::Type{T}) where {T} =
+_promote_typejoin(::Type{Missing}, ::Type{T}) where {T} =
     isconcretetype(T) || T === Union{} ? Union{T, Missing} : Any
-promote_typejoin(::Type{T}, ::Type{Missing}) where {T} =
+_promote_typejoin(::Type{T}, ::Type{Missing}) where {T} =
     isconcretetype(T) || T === Union{} ? Union{T, Missing} : Any
-promote_typejoin(::Type{Nothing}, ::Type{Missing}) = Union{Nothing, Missing}
-promote_typejoin(::Type{Missing}, ::Type{Nothing}) = Union{Nothing, Missing}
-promote_typejoin(::Type{Nothing}, ::Type{Nothing}) = Nothing
-promote_typejoin(::Type{Missing}, ::Type{Missing}) = Missing
+_promote_typejoin(::Type{Nothing}, ::Type{Missing}) = Union{Nothing, Missing}
+_promote_typejoin(::Type{Missing}, ::Type{Nothing}) = Union{Nothing, Missing}
+_promote_typejoin(::Type{Nothing}, ::Type{Nothing}) = Nothing
+_promote_typejoin(::Type{Missing}, ::Type{Missing}) = Missing
 
 # Returns length, isfixed
 function full_va_len(p)

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -201,3 +201,10 @@ end
     res = map(f, y)
     @test res isa Vector{Union{Bool, T}}
 end
+
+@testset "inference of collect with unstable eltype" begin
+    @test Core.Compiler.return_type(collect, Tuple{typeof(2x for x in Real[])}) <: Vector
+    @test Core.Compiler.return_type(collect, Tuple{typeof(x+y for x in Real[] for y in Real[])}) <: Vector
+    @test Core.Compiler.return_type(collect, Tuple{typeof(x+y for x in Real[], y in Real[])}) <: Matrix
+    @test Core.Compiler.return_type(collect, Tuple{typeof(x for x in Union{Bool,String}[])}) <: Array
+end


### PR DESCRIPTION
As `promote_typejoin(::Any, ::Any)` is inferred as `Any`, inference of `similar(dest, promote_typejoin(T, S))` is very vague as the second parameter could not only be the new element type, but also e.g. new size. A simple type-assertion improves the situation.

Example:
Before:
```julia
julia> Core.Compiler.return_type(collect, Tuple{typeof(2x for x in Real[])})
AbstractArray
```
After:
```julia
julia> Core.Compiler.return_type(collect, Tuple{typeof(2x for x in Real[])})
Array{_1,1} where _1
```