### PR TITLE
Deprecate print_shortest

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -410,6 +410,9 @@ This section lists changes that do not have deprecation warnings.
       to get the old behavior (only "space" characters are considered as
       word separators), use the keyword `wordsep=isspace`.
 
+  * `writedlm` in the standard library module DelimitedFiles now writes numeric values
+    using `print` rather than `print_shortest` ([#25745]).
+
   * The `tempname` function used to create a file on Windows but not on other
     platforms. It now never creates a file ([#9053]).
 
@@ -1001,6 +1004,9 @@ Deprecated or removed
 
   * `Base.@gc_preserve` has been deprecated in favor of `GC.@preserve` ([#25616]).
 
+  * `print_shortest` has been discontinued, but is still available in the `Base.Grisu`
+    submodule ([#25745]).
+
   * `scale!` has been deprecated in favor of `mul!`, `lmul!`, and `rmul!` ([#25701], [#25812]).
 
   * `endof(a)` has been renamed to `lastindex(a)`, and the `end` keyword in indexing expressions now
@@ -1267,3 +1273,4 @@ Command-line option changes
 [#25634]: https://github.com/JuliaLang/julia/issues/25634
 [#25654]: https://github.com/JuliaLang/julia/issues/25654
 [#25655]: https://github.com/JuliaLang/julia/issues/25655
+[#25745]: https://github.com/JuliaLang/julia/issues/25745

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1331,6 +1331,9 @@ end
 # this method is to avoid ambiguity, delete at the same time as deprecation of skipchars above:
 skipchars(::IO, ::IO; linecomment=nothing) = throw(ArgumentError("the first argument of `skipchars` must be callable"))
 
+# Issue #25745
+@deprecate print_shortest Base.Grisu.print_shortest
+
 # issue #9053
 if Sys.iswindows()
 function Filesystem.tempname(uunique::UInt32)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -613,7 +613,6 @@ export
     oct,
     prevind,
     print,
-    print_shortest,
     println,
     printstyled,
     repeat,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -346,7 +346,6 @@ include("filesystem.jl")
 using .Filesystem
 include("process.jl")
 include("grisu/grisu.jl")
-import .Grisu.print_shortest
 include("methodshow.jl")
 
 # core math functions

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -730,7 +730,7 @@ function dlm_parse(dbuff::String, eol::D, dlm::D, qchar::D, cchar::D,
 end
 
 # todo: keyword argument for # of digits to print
-writedlm_cell(io::IO, elt::AbstractFloat, dlm, quotes) = print_shortest(io, elt)
+writedlm_cell(io::IO, elt::AbstractFloat, dlm, quotes) = print(io, elt)
 function writedlm_cell(io::IO, elt::AbstractString, dlm::T, quotes::Bool) where T
     if quotes && !isempty(elt) && (('"' in elt) || ('\n' in elt) || ((T <: Char) ? (dlm in elt) : contains(elt, dlm)))
         print(io, '"', replace(elt, r"\"" => "\"\""), '"')


### PR DESCRIPTION
This deprecates `print_shortest` to `Base.Grisu.print_shortest`.

The only place where `print_shortest` is used is in DelimitedFiles, when writing numeric values. This has been changed to `print`, which is technically a breaking change, though it more accurately represents the value being written.

Fixes #25745.