### PR TITLE
Improve parse: type inference and handling Complex

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -213,7 +213,8 @@ function tryparse(::Type{T}, s::AbstractString; base::Union{Nothing,Integer} = n
 end
 
 function parse(::Type{T}, s::AbstractString; base::Union{Nothing,Integer} = nothing) where {T<:Integer}
-    tryparse_internal(T, s, firstindex(s), lastindex(s), base===nothing ? 0 : check_valid_base(base), true)
+    convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s),
+                                 base===nothing ? 0 : check_valid_base(base), true))
 end
 
 ## string to float functions ##
@@ -322,7 +323,7 @@ function tryparse_internal(::Type{Complex{T}}, s::Union{String,SubString{String}
 end
 
 # the ±1 indexing above for ascii chars is specific to String, so convert:
-tryparse_internal(T::Type{<:Complex}, s::AbstractString, i::Int, e::Int, raise::Bool) =
+tryparse_internal(T::Type{Complex{S}}, s::AbstractString, i::Int, e::Int, raise::Bool) where S<:Real =
     tryparse_internal(T, String(s), i, e, raise)
 
 # fallback methods for tryparse_internal
@@ -339,4 +340,7 @@ tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, rais
     tryparse_internal(T, s, startpos, endpos, 10, raise)
 
 parse(::Type{T}, s::AbstractString) where T<:Union{Real,Complex} =
-    tryparse_internal(T, s, firstindex(s), lastindex(s), true)
+    convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s), true))
+
+tryparse(T::Type{Complex{S}}, s::AbstractString) where S<:Real =
+    convert(Union{T, Nothing}, tryparse_internal(T, s, firstindex(s), lastindex(s), false))

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -340,7 +340,7 @@ tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, rais
     tryparse_internal(T, s, startpos, endpos, 10, raise)
 
 parse(::Type{T}, s::AbstractString) where T<:Union{Real,Complex} =
-    convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s), true))
+    tryparse_internal(T, s, firstindex(s), lastindex(s), true)::T
 
 tryparse(T::Type{Complex{S}}, s::AbstractString) where S<:Real =
-    convert(Union{T, Nothing}, tryparse_internal(T, s, firstindex(s), lastindex(s), false))
+    tryparse_internal(T, s, firstindex(s), lastindex(s), false)::Union{T, Nothing}

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -302,7 +302,9 @@ function tryparse_internal(::Type{Complex{T}}, s::Union{String,SubString{String}
             x === nothing && return nothing
             return Complex{T}(zero(x),x)
         else # purely real
-            return Complex{T}(tryparse_internal(T, s, i, e, raise))
+            x = tryparse_internal(T, s, i, e, raise)
+            x === nothing && return nothing
+            return Complex{T}(x)
         end
     end
 
@@ -340,7 +342,7 @@ tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::Int, rais
     tryparse_internal(T, s, startpos, endpos, 10, raise)
 
 parse(::Type{T}, s::AbstractString) where T<:Union{Real,Complex} =
-    tryparse_internal(T, s, firstindex(s), lastindex(s), true)::T
+    convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s), true))
 
 tryparse(T::Type{Complex{S}}, s::AbstractString) where S<:Real =
-    tryparse_internal(T, s, firstindex(s), lastindex(s), false)::Union{T, Nothing}
+    tryparse_internal(T, s, firstindex(s), lastindex(s), false)

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -262,3 +262,15 @@ end
 # only allow certain characters after interpolated vars (#25231)
 @test Meta.parse("\"\$x෴  \"",raise=false) == Expr(:error, "interpolated variable \$x ends with invalid character \"෴\"; use \"\$(x)\" instead.")
 @test Base.incomplete_tag(Meta.parse("\"\$foo", raise=false)) == :string
+
+@testset "parse and tryparse type inference" begin
+    @inferred parse(Int, "12")
+    @inferred parse(Float64, "12")
+    @inferred parse(Complex{Int}, "12")
+    @test eltype([parse(Int, s, 16) for s in String[]]) == Int
+    @test eltype([parse(Float64, s) for s in String[]]) == Float64
+    @test eltype([parse(Complex{Int}, s) for s in String[]]) == Complex{Int}
+    @test eltype([tryparse(Int, s, 16) for s in String[]]) == Union{Nothing, Int}
+    @test eltype([tryparse(Float64, s) for s in String[]]) == Union{Nothing, Float64}
+    @test eltype([tryparse(Complex{Int}, s) for s in String[]]) == Union{Nothing, Complex{Int}}
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -260,7 +260,7 @@ end
 end
 
 @testset "issue #10307" begin
-    @test typeof(map(x -> parse(Int16, x), AbstractString[])) == Vector{Union{Int16, Nothing}}
+    @test typeof(map(x -> parse(Int16, x), AbstractString[])) == Vector{Int16}
 
     for T in [Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Int128, UInt128]
         for i in [typemax(T), typemin(T)]


### PR DESCRIPTION
Those are the issues this PR aims to fix in `parse` and `tryparse`:

* Type inference of `parse` result, e.g. on current master we have:
```
julia> @inferred parse(Int, "12")
ERROR: return type Int64 does not match inferred return type Union{Nothing, Int64}
Stacktrace:
 [1] error(::String) at .\error.jl:33
 [2] top-level scope

julia> @inferred parse(Complex{Int}, "12")
ERROR: return type Complex{Int64} does not match inferred return type Any
Stacktrace:
 [1] error(::String) at .\error.jl:33
 [2] top-level scope
```
now an appropriate type should be inferred.

* stack overflow at attempt to convert to `Complex` on current master:
```
julia> parse(Complex, "12")
ERROR: StackOverflowError:
```
now `MethodError` will be thrown

* `tryparse` for `Complex{T}` is missing:
```
julia> tryparse(Complex{Int}, "12")
ERROR: MethodError: no method matching tryparse(::Type{Complex{Int64}}, ::String)
Closest candidates are:
  tryparse(::Type{T<:Integer}, ::AbstractString) where T<:Integer at parse.jl:212
  tryparse(::Type{T<:Integer}, ::AbstractString, ::Integer) where T<:Integer at parse.jl:210
  tryparse(::Type{Float64}, ::String) at parse.jl:226
  ...
```
now it is defined.