### PR TITLE
Add `typemin` for `String`

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -98,6 +98,9 @@ function ==(a::String, b::String)
     al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
 end
 
+typemin(::Type{String}) = ""
+typemin(::String) = typemin(String)
+
 ## thisind, nextind ##
 
 thisind(s::String, i::Int) = _thisind_str(s, i)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -10,6 +10,8 @@ using Random
     @test eltype(GenericString) == Char
     @test firstindex("abc") == 1
     @test cmp("ab","abc") == -1
+    @test typemin(String) === ""
+    @test typemin("abc") === ""
     @test "abc" === "abc"
     @test "ab"  !== "abc"
     @test string("ab", 'c') === "abc"


### PR DESCRIPTION
There *is* a minimum according to `isless`, being `""`.

Note that we could do the same for other the similar types `SubString` and `Symbol`.

I also noted that we don't have `empty(::String)` (that isn't dealt with in this PR, but possibly could be desirable?).