### PR TITLE
Adjust claims about the power of `parse(Complex...)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -465,6 +465,7 @@ Library improvements
     ([#21973]).
 
   * `parse(Complex{T}, string)` can parse complex numbers in common formats ([#24713]).
+    However, this does not include formats commonly output by Fortran programs.
 
   * The function `rand` can now pick up random elements from strings, associatives
     and sets ([#22228], [#21960], [#18155], [#22224]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -464,8 +464,7 @@ Library improvements
   * The function `randn` now accepts complex arguments (`Complex{T <: AbstractFloat}`)
     ([#21973]).
 
-  * `parse(Complex{T}, string)` can parse complex numbers in common formats ([#24713]).
-    However, this does not include formats commonly output by Fortran programs.
+  * `parse(Complex{T}, string)` can parse complex numbers in some common formats ([#24713]).
 
   * The function `rand` can now pick up random elements from strings, associatives
     and sets ([#22228], [#21960], [#18155], [#22224]).


### PR DESCRIPTION
The statement

> `parse(Complex{T}, string)` can parse complex numbers in common formats

is a bit exaggerating. Arguably one of the more common complex number output formats is that used by Fortran, which is of the form "(real, imag)". The current implementation of `parse` fails to parse this:
```
julia> parse(Complex{Float64}, "(1.0, 2.0)")
ERROR: ArgumentError: cannot parse "(1.0, 2.0)" as Float64
```
On version 0.7.0-DEV.3712.