### PR TITLE
Correct replacement for read(io, type, dims)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -708,7 +708,7 @@ Deprecated or removed
     in favor of `replace(s::AbstractString, pat => r; [count])` ([#25165]).
     Moreover, `count` cannot be negative anymore (use `typemax(Int)` instead ([#22325]).
 
-  * `read(io, type, dims)` is deprecated to `read!(io, Array{type}(dims))` ([#21450]).
+  * `read(io, type, dims)` is deprecated to `read!(io, Array{type}(uninitialized, dims))` ([#21450]).
 
   * `read(::IO, ::Ref)` is now a method of `read!`, since it mutates its `Ref` argument ([#21592]).
 


### PR DESCRIPTION
It says

> `read(io, type, dims)` is deprecated to `read!(io, Array{type}(dims))`

but in turn `Array{type}(dims)` is deprecated to `Array{type}(uninitialized, dims)`. Fix to inform users about the correct replacement.