### PR TITLE
make active_repl global again

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -386,6 +386,7 @@ const REPL_MODULE_REF = Ref{Module}()
 
 # run the requested sort of evaluation loop on stdio
 function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
+    global active_repl
     if interactive && isassigned(REPL_MODULE_REF)
         invokelatest(REPL_MODULE_REF[]) do REPL
             term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")


### PR DESCRIPTION
Removed (maybe by accident) in https://github.com/JuliaLang/julia/pull/25753, cc @vtjnash.

Almost all new REPL modes do something like:

```
if isdefined(Base, :active_repl)
    init_my_repl(Base.active_repl)
else
```

which is now broken.