### PR TITLE
RFC: parse any string macro call as a doc string

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1267,3 +1267,9 @@ end
 
 # issue #25020
 @test_throws ParseError Meta.parse("using Colors()")
+
+let ex = Meta.parse("md\"x\"
+                     f(x) = x")
+    @test Meta.isexpr(ex, :macrocall)
+    @test ex.args[1] == Core.GlobalRef(Core, Symbol("@doc"))
+end


### PR DESCRIPTION
This allows any string macro to be used for writing doc strings. This makes the system extensible to e.g. `html" "`, and also makes the syntax more predictable --- anything string-like in an appropriate context is treated as a doc string.