### PR TITLE
remove extra `.` at end of binding deprecation message

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -123,7 +123,7 @@ end
 deprecate(m::Module, s::Symbol, flag=1) = ccall(:jl_deprecate_binding, Cvoid, (Any, Any, Cint), m, s, flag)
 
 macro deprecate_binding(old, new, export_old=true, dep_message=nothing)
-    dep_message == nothing && (dep_message = ", use $new instead")
+    dep_message == nothing && (dep_message = ", use $new instead.")
     return Expr(:toplevel,
          export_old ? Expr(:export, esc(old)) : nothing,
          Expr(:const, Expr(:(=), esc(Symbol(string("_dep_message_",old))), esc(dep_message))),
@@ -133,7 +133,7 @@ end
 
 macro deprecate_stdlib(old, mod, export_old=true)
     dep_message = """: it has been moved to the standard library package `$mod`.
-                        Add a `using $mod` to your imports."""
+                        Add `using $mod` to your imports."""
     new = GlobalRef(Base.root_module(Base, mod), old)
     return Expr(:toplevel,
          export_old ? Expr(:export, esc(old)) : nothing,

--- a/src/module.c
+++ b/src/module.c
@@ -526,23 +526,26 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b)
                       jl_symbol_name(b->owner->name), jl_symbol_name(b->name));
             dep_message_binding = jl_get_dep_message_binding(b->owner, b);
         }
-        else
+        else {
             jl_printf(JL_STDERR, "%s is deprecated", jl_symbol_name(b->name));
+        }
 
         if (dep_message_binding && dep_message_binding->value) {
             if (jl_isa(dep_message_binding->value, (jl_value_t*)jl_string_type)) {
                 jl_uv_puts(JL_STDERR, jl_string_data(dep_message_binding->value),
                     jl_string_len(dep_message_binding->value));
-            } else {
+            }
+            else {
                 jl_static_show(JL_STDERR, dep_message_binding->value);
             }
-        } else {
+        }
+        else {
             jl_value_t *v = b->value;
             if (v) {
                 if (jl_is_type(v) || jl_is_module(v)) {
                     jl_printf(JL_STDERR, ", use ");
                     jl_static_show(JL_STDERR, v);
-                    jl_printf(JL_STDERR, " instead");
+                    jl_printf(JL_STDERR, " instead.");
                 }
                 else {
                     jl_methtable_t *mt = jl_gf_mtable(v);
@@ -554,12 +557,12 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b)
                             jl_printf(JL_STDERR, ".");
                         }
                         jl_printf(JL_STDERR, "%s", jl_symbol_name(mt->name));
-                        jl_printf(JL_STDERR, " instead");
+                        jl_printf(JL_STDERR, " instead.");
                     }
                 }
             }
         }
-        jl_printf(JL_STDERR, ".\n");
+        jl_printf(JL_STDERR, "\n");
 
         if (jl_options.depwarn != JL_OPTIONS_DEPWARN_ERROR) {
             if (jl_lineno == 0) {


### PR DESCRIPTION
This has been annoying me. Example:

```
WARNING: Base.subtypes is deprecated: it has been moved to the standard library package `InteractiveUtils`.
Add a `using InteractiveUtils` to your imports..
```