### PR TITLE
clarification in maxintfloat docs

### DIFF
--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -19,7 +19,7 @@ signbit(x::Float16) = signbit(bitcast(Int16, x))
 """
     maxintfloat(T=Float64)
 
-The largest consecutive integer representable by the given floating-point type `T`
+The largest consecutive integer that is exactly represented in the given floating-point type `T`
 (which defaults to `Float64`).
 
 That is, `maxintfloat` returns the smallest positive integer `n` such that `n+1`
@@ -33,7 +33,7 @@ maxintfloat(x::T) where {T<:AbstractFloat} = maxintfloat(T)
 """
     maxintfloat(T, S)
 
-The largest consecutive integer representable by the given floating-point type `T` that
+The largest consecutive integer representable in the given floating-point type `T` that
 also does not exceed the maximum integer representable by the integer type `S`.  Equivalently,
 it is the minimum of `maxintfloat(T)` and [`typemax(S)`](@ref).
 """

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -23,7 +23,7 @@ The largest consecutive integer that is exactly represented in the given floatin
 (which defaults to `Float64`).
 
 That is, `maxintfloat` returns the smallest positive integer `n` such that `n+1`
-is *not* exactly representable in the type `T`.  
+is *not* exactly representable in the type `T`.
 """
 maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -17,9 +17,13 @@ signbit(x::Float32) = signbit(bitcast(Int32, x))
 signbit(x::Float16) = signbit(bitcast(Int16, x))
 
 """
-    maxintfloat(T)
+    maxintfloat(T=Float64)
 
-The largest integer losslessly representable by the given floating-point DataType `T`.
+The largest consecutive integer representable by the given floating-point type `T`
+(which defaults to `Float64`).
+
+That is, `maxintfloat` returns the smallest positive integer `n` such that `n+1`
+is *not* exactly representable in the type `T`.  
 """
 maxintfloat(::Type{Float64}) = 9007199254740992.
 maxintfloat(::Type{Float32}) = Float32(16777216.)
@@ -29,8 +33,9 @@ maxintfloat(x::T) where {T<:AbstractFloat} = maxintfloat(T)
 """
     maxintfloat(T, S)
 
-The largest integer losslessly representable by the given floating-point DataType `T` that
-also does not exceed the maximum integer representable by the integer DataType `S`.
+The largest consecutive integer representable by the given floating-point type `T` that
+also does not exceed the maximum integer representable by the integer type `S`.  Equivalently,
+it is the minimum of `maxintfloat(T)` and [`typemax(S)`](@ref).
 """
 maxintfloat(::Type{S}, ::Type{T}) where {S<:AbstractFloat, T<:Integer} = min(maxintfloat(S), S(typemax(T)))
 maxintfloat() = maxintfloat(Float64)


### PR DESCRIPTION
The old phrasing of the largest "losslessly" representable integer is not correct.  (`2.0^1000` is an integer and is exactly represented by `Float64`, for example.)

I think what was meant here is the largest *consecutive* integer that is exactly represented.