### PR TITLE
slightly rewrite the OurRational example

### DIFF
--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -406,8 +406,10 @@ defining sophisticated behavior is typically quite simple.
 ## Case Study: Rational
 
 Perhaps the best way to tie all these pieces together is to present a real world example of a
-parametric composite type and its constructor methods. To that end, here is the (slightly modified) beginning of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl),
-which implements Julia's [Rational Numbers](@ref):
+parametric composite type and its constructor methods. To that end, we implement our own rational number type
+`OurRational`, similar to Julia's built-in [`Rational`](@ref) type, defined in
+[`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl):
+
 
 ```jldoctest rational
 julia> struct OurRational{T<:Integer} <: Real
@@ -433,27 +435,27 @@ OurRational
 julia> OurRational(n::Integer) = OurRational(n,one(n))
 OurRational
 
-julia> //(n::Integer, d::Integer) = OurRational(n,d)
-// (generic function with 1 method)
+julia> ⊘(n::Integer, d::Integer) = OurRational(n,d)
+⊘ (generic function with 1 method)
 
-julia> //(x::OurRational, y::Integer) = x.num // (x.den*y)
-// (generic function with 2 methods)
+julia> ⊘(x::OurRational, y::Integer) = x.num ⊘ (x.den*y)
+⊘ (generic function with 2 methods)
 
-julia> //(x::Integer, y::OurRational) = (x*y.den) // y.num
-// (generic function with 3 methods)
+julia> ⊘(x::Integer, y::OurRational) = (x*y.den) ⊘ y.num
+⊘ (generic function with 3 methods)
 
-julia> //(x::Complex, y::Real) = complex(real(x)//y, imag(x)//y)
-// (generic function with 4 methods)
+julia> ⊘(x::Complex, y::Real) = complex(real(x) ⊘ y, imag(x) ⊘ y)
+⊘ (generic function with 4 methods)
 
-julia> //(x::Real, y::Complex) = x*y'//real(y*y')
-// (generic function with 5 methods)
+julia> ⊘(x::Real, y::Complex) = (x*y') ⊘ real(y*y')
+⊘ (generic function with 5 methods)
 
-julia> function //(x::Complex, y::Complex)
+julia> function ⊘(x::Complex, y::Complex)
            xy = x*y'
            yy = real(y*y')
-           complex(real(xy)//yy, imag(xy)//yy)
+           complex(real(xy) ⊘ yy, imag(xy) ⊘ yy)
        end
-// (generic function with 6 methods)
+⊘ (generic function with 6 methods)
 ```
 
 The first line -- `struct OurRational{T<:Integer} <: Real` -- declares that `OurRational` takes one
@@ -477,29 +479,30 @@ have different types: it promotes them to a common type and then delegates const
 outer constructor for arguments of matching type. The third outer constructor turns integer values
 into rationals by supplying a value of `1` as the denominator.
 
-Following the outer constructor definitions, we have a number of methods for the [`//`](@ref)
-operator, which provides a syntax for writing rationals. Before these definitions, [`//`](@ref)
+Following the outer constructor definitions, we defined a number of methods for the `⊘`
+operator, which provides a syntax for writing rationals (e.g. `1 ⊘ 2`). Julia's `Rational`
+type uses the [`//`](@ref) operator for this purpose. Before these definitions, `⊘`
 is a completely undefined operator with only syntax and no meaning. Afterwards, it behaves just
 as described in [Rational Numbers](@ref) -- its entire behavior is defined in these few lines.
-The first and most basic definition just makes `a//b` construct a `OurRational` by applying the
-`OurRational` constructor to `a` and `b` when they are integers. When one of the operands of [`//`](@ref)
+The first and most basic definition just makes `a ⊘ b` construct a `OurRational` by applying the
+`OurRational` constructor to `a` and `b` when they are integers. When one of the operands of `⊘`
 is already a rational number, we construct a new rational for the resulting ratio slightly differently;
 this behavior is actually identical to division of a rational with an integer.
 Finally, applying
-[`//`](@ref) to complex integral values creates an instance of `Complex{OurRational}` -- a complex
+`⊘` to complex integral values creates an instance of `Complex{OurRational}` -- a complex
 number whose real and imaginary parts are rationals:
 
 ```jldoctest rational
-julia> ans = (1 + 2im)//(1 - 2im);
+julia> z = (1 + 2im) ⊘ (1 - 2im);
 
-julia> typeof(ans)
+julia> typeof(z)
 Complex{OurRational{Int64}}
 
-julia> ans <: Complex{OurRational}
+julia> typeof(z) <: Complex{OurRational}
 false
 ```
 
-Thus, although the [`//`](@ref) operator usually returns an instance of `OurRational`, if either
+Thus, although the [`⊘`](@ref) operator usually returns an instance of `OurRational`, if either
 of its arguments are complex integers, it will return an instance of `Complex{OurRational}` instead.
 The interested reader should consider perusing the rest of [`rational.jl`](https://github.com/JuliaLang/julia/blob/master/base/rational.jl):
 it is short, self-contained, and implements an entire basic Julia type.


### PR DESCRIPTION
PR for https://github.com/JuliaLang/julia/issues/20296#issuecomment-275951608

Slightly rewrite the `OurRational` example, in particular don't use `//` without importing, instead define our own infix operator.

fix #20296