### PR TITLE
Use promote_typejoin for Tuple and NamedTuple promotion

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -103,6 +103,9 @@ indexed_next(t::NamedTuple, i::Int, state) = (getfield(t, i), i+1)
 isempty(::NamedTuple{()}) = true
 isempty(::NamedTuple) = false
 
+promote_rule(::Type{NamedTuple{n, S}}, ::Type{NamedTuple{n, T}}) where {n, S, T} =
+    NamedTuple{n, promote_type(S, T)}
+
 promote_typejoin(::Type{NamedTuple{n, S}}, ::Type{NamedTuple{n, T}}) where {n, S, T} =
     NamedTuple{n, promote_typejoin(S, T)}
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -92,6 +92,7 @@ end
 
 # Not an actual promotion, just an improved typejoin
 promote_rule(::Type{S}, ::Type{T}) where {S<:Tuple, T<:Tuple} = promote_typejoin(S, T)
+promote_rule(::Type{NTuple{N,Any}}, ::Type{<:NTuple{N}}) where {N} = NTuple{N,Any}
 
 # version of tail that doesn't throw on empty tuples (used in array indexing)
 safe_tail(t::Tuple) = tail(t)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -88,6 +88,11 @@ function _compute_eltype(t::Type{<:Tuple})
     return r
 end
 
+# promotion
+
+# Not an actual promotion, just an improved typejoin
+promote_rule(::Type{S}, ::Type{T}) where {S<:Tuple, T<:Tuple} = promote_typejoin(S, T)
+
 # version of tail that doesn't throw on empty tuples (used in array indexing)
 safe_tail(t::Tuple) = tail(t)
 safe_tail(t::Tuple{}) = ()

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -222,9 +222,36 @@ abstr_nt_22194_3()
 @test findfirst(equalto(1), (a=2, b=3)) === nothing
 @test findlast(equalto(1), (a=2, b=3)) === nothing
 
+# Test promotion
+
+@test promote_type(NamedTuple{(:a,),Tuple{Int}},
+                   NamedTuple{(:a,),Tuple{Float64}}) ===
+    NamedTuple{(:a,),Tuple{Real}}
+@test promote_type(NamedTuple{(:a,:b),Tuple{Int,Float64}},
+                   NamedTuple{(:a,:b),Tuple{Float64,Int}}) ===
+    NamedTuple{(:a, :b),Tuple{Real, Real}}
+@test promote_type(NamedTuple{(:a,:b),Tuple{Int,String}},
+                   NamedTuple{(:a,:b),Tuple{Float64,Int}}) ===
+    NamedTuple{(:a,:b),Tuple{Real,Any}}
+
+for T in (Nothing, Missing)
+    @test promote_type(NamedTuple{(:a,),Tuple{Int}},
+                       NamedTuple{(:a,),Tuple{T}}) ===
+        NamedTuple{(:a,),Tuple{Union{T,Int}}}
+    @test promote_type(NamedTuple{(:a,:b),Tuple{Int,T}},
+                       NamedTuple{(:a,:b),Tuple{T,Float64}}) ===
+        NamedTuple{(:a, :b),Tuple{Union{T,Int}, Union{T,Float64}}}
+    @test promote_type(NamedTuple{(:a,),Tuple{Int}},
+                       NamedTuple{(:a,),Tuple{Float64}},
+                       NamedTuple{(:a,),Tuple{T}}) ===
+        NamedTuple{(:a,),Tuple{Union{Any,T}}}
+end
+
 # Test map with Nothing and Missing
 for T in (Nothing, Missing)
     x = [(a=1, b=T()), (a=1, b=2)]
+    @test x isa Vector{NamedTuple{(:a,:b),Tuple{Int,Union{T,Int}}}}
+
     y = map(v -> (a=v.a, b=v.b), [(a=1, b=T()), (a=1, b=2)])
     @test y isa Vector{NamedTuple{(:a,:b),Tuple{Int,Union{T,Int}}}}
     @test isequal(x, y)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -192,6 +192,9 @@ end
     @test promote_type(Tuple{Int,Float64}, Tuple{Float64,Int}) === Tuple{Real,Real}
     @test promote_type(Tuple{Int,String}, Tuple{Float64,Int}) === Tuple{Real,Any}
 
+    @test promote_type(Tuple{Any}, Tuple{Int}) === Tuple{Any}
+    @test promote_type(Tuple{Any,Any}, Tuple{Float64,Int}) === Tuple{Any,Any}
+
     for T in (Nothing, Missing)
         @test promote_type(Tuple{Int}, Tuple{T}) === Tuple{Union{T,Int}}
         @test promote_type(Tuple{Int,T}, Tuple{T,Float64}) ===

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -183,11 +183,28 @@ end
         typejoin(Int, Float64, Bool)
     @test eltype(Tuple{Int, Missing}) === Union{Missing, Int}
     @test eltype(Tuple{Int, Nothing}) === Union{Nothing, Int}
+    @test eltype(Tuple{Int, Float64, Missing}) === Any
+    @test eltype(Tuple{Int, Float64, Nothing}) === Any
+end
+
+@testset "promotion" begin
+    @test promote_type(Tuple{Int}, Tuple{Float64}) === Tuple{Real}
+    @test promote_type(Tuple{Int,Float64}, Tuple{Float64,Int}) === Tuple{Real,Real}
+    @test promote_type(Tuple{Int,String}, Tuple{Float64,Int}) === Tuple{Real,Any}
+
+    for T in (Nothing, Missing)
+        @test promote_type(Tuple{Int}, Tuple{T}) === Tuple{Union{T,Int}}
+        @test promote_type(Tuple{Int,T}, Tuple{T,Float64}) ===
+            Tuple{Union{T,Int},Union{T,Float64}}
+        @test promote_type(Tuple{Int}, Tuple{Float64}, Tuple{T}) === Tuple{Any}
+    end
 end
 
 @testset "map with Nothing and Missing" begin
     for T in (Nothing, Missing)
         x = [(1, T()), (1, 2)]
+        @test x isa Vector{Tuple{Int,Union{Int,T}}}
+
         y = map(v -> (v[1], v[2]), [(1, T()), (1, 2)])
         @test y isa Vector{Tuple{Int,Union{T,Int}}}
         @test isequal(x, y)


### PR DESCRIPTION
Even if we do not want to call `promote_type`  on the entries when promoting tuples (https://github.com/JuliaLang/julia/pull/25553#discussion_r163990979), we still have to use `promote_typejoin` so that e.g. `promote_type(Tuple{Int}, Tuple{Missing})` returns `Tuple{Union{Int,Missing}}`. In particular, this ensures array concatenation uses `Union{T,Missing/Nothing}` instead of `Any`, which is consistent with `map(identity, x)`.