### PR TITLE
codegen: incorrect computation of "not-unboxed"

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -5985,3 +5985,9 @@ end
 let a = Foo17149()
     @test a === a
 end
+
+# issue #25907
+g25907a(x) = x[1]::Integer
+@test g25907a(Union{Int, UInt, Nothing}[1]) === 1
+g25907b(x) = x[1]::Complex
+@test g25907b(Union{Complex{Int}, Complex{UInt}, Nothing}[1im]) === 1im


### PR DESCRIPTION
fix #25907