### PR TITLE
add a `merge` method for `Pairs` of `NamedTuple` to speed up keyword splatting

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -226,6 +226,8 @@ end
 
 merge(a::NamedTuple{()}, b::NamedTuple) = b
 
+merge(a::NamedTuple, b::Iterators.Pairs{<:Any,<:Any,<:Any,<:NamedTuple}) = merge(a, b.data)
+
 """
     merge(a::NamedTuple, iterable)
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -162,6 +162,10 @@ Array{T}(::Missing, d...) where {T} = fill!(Array{T}(uninitialized, d...), missi
 
 include("abstractdict.jl")
 
+include("iterators.jl")
+using .Iterators: zip, enumerate
+using .Iterators: Flatten, product  # for generators
+
 include("namedtuple.jl")
 
 # numeric operations
@@ -207,9 +211,6 @@ include("some.jl")
 
 include("dict.jl")
 include("set.jl")
-include("iterators.jl")
-using .Iterators: zip, enumerate
-using .Iterators: Flatten, product  # for generators
 
 include("char.jl")
 include("strings/basic.jl")


### PR DESCRIPTION
Fixes #9551. Well, that was also fixed by #24795, but this re-fixes it.
