### PR TITLE
Fix operations on SparseArrays of Integer types other than Int

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1667,7 +1667,7 @@ function _mapreducecols!(f, op, R::AbstractArray, A::SparseMatrixCSC{Tv,Ti}) whe
         end
     end
     @inbounds for i = 1:m
-        R[i, 1] = _mapreducezeros(f, op, Tv, rownz[i], R[i, 1])
+        R[i, 1] = _mapreducezeros(f, op, Tv, Int(rownz[i]), R[i, 1])
     end
     R
 end

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2214,4 +2214,10 @@ end
     @test findnz(BitArray([false true; false true])) == ([1, 2], [2, 2], trues(2))
 end
 
+# #25943
+@testset "operations on Integer subtypes" begin
+    s = sparse(UInt8[1, 2, 3], UInt8[1, 2, 3], UInt8[1, 2, 3])
+    @test sum(s, 2) == reshape([1, 2, 3], 3, 1)
+end
+
 end # module


### PR DESCRIPTION
On current master, operations on `SparseArrays` of anything other than the system `Int` gives the following error

```julia
julia> using SparseArrays

julia> S = sparse(UInt8[1, 2, 3], UInt8[1, 2, 3], UInt8[1, 2, 3])
3×3 SparseMatrixCSC{UInt8,UInt8} with 3 stored entries:
  [1, 1]  =  0x01
  [2, 2]  =  0x02
  [3, 3]  =  0x03

julia> sum(S, 2)
ERROR: MethodError: no method matching _mapreducezeros(::typeof(identity), ::typeof(Base.add_sum), ::Type{UInt8}, ::UInt8, ::UInt64)
Closest candidates are:
  _mapreducezeros(::Any, ::Any, ::Type{T}, ::Int64, ::Any) where T at /Users/rohitvarkey/Code/julia/usr/share/julia/site/v0.7/SparseArrays/src/sparsematrix.jl:1590
  _mapreducezeros(::Any, ::typeof(+), ::Type{T}, ::Int64, ::Any) where T at /Users/rohitvarkey/Code/julia/usr/share/julia/site/v0.7/SparseArrays/src/sparsematrix.jl:1623
  _mapreducezeros(::Any, ::typeof(*), ::Type{T}, ::Int64, ::Any) where T at /Users/rohitvarkey/Code/julia/usr/share/julia/site/v0.7/SparseArrays/src/sparsematrix.jl:1625
Stacktrace:
 [1] _mapreducecols!(::typeof(identity), ::typeof(Base.add_sum), ::Array{UInt64,2}, ::SparseMatrixCSC{UInt8,UInt8}) at /Users/rohitvarkey/Code/julia/usr/share/julia/site/v0.7/SparseArrays/src/sparsematrix.jl:1670
 [2] _mapreducedim!(::typeof(identity), ::typeof(Base.add_sum), ::Array{UInt64,2}, ::SparseMatrixCSC{UInt8,UInt8}) at /Users/rohitvarkey/Code/julia/usr/share/julia/site/v0.7/SparseArrays/src/sparsematrix.jl:1687
 [3] mapreducedim! at ./reducedim.jl:240 [inlined]
 [4] mapreducedim at ./reducedim.jl:272 [inlined]
 [5] sum at ./reducedim.jl:612 [inlined]
 [6] sum(::SparseMatrixCSC{UInt8,UInt8}, ::Int64) at ./reducedim.jl:614
 [7] top-level scope

julia> versioninfo()
Julia Version 0.7.0-DEV.3743
Commit 8da832fb69* (2018-02-07 22:19 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin16.4.0)
  CPU: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, broadwell)
Environment:
```

This change fixes this error. `julia` built with commit gives me the following.

```julia
julia> using SparseArrays

julia> S = sparse(UInt8[1, 2, 3], UInt8[1, 2, 3], UInt8[1, 2, 3])
3×3 SparseMatrixCSC{UInt8,UInt8} with 3 stored entries:
  [1, 1]  =  0x01
  [2, 2]  =  0x02
  [3, 3]  =  0x03

julia> sum(S, 2)
3×1 Array{UInt64,2}:
 0x0000000000000001
 0x0000000000000002
 0x0000000000000003

julia> versioninfo()
Julia Version 0.7.0-DEV.3744
Commit 8a4f0c6e53* (2018-02-08 04:25 UTC)
Platform Info:
  OS: macOS (x86_64-apple-darwin16.4.0)
  CPU: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, broadwell)
Environment:
```