### PR TITLE
fix typo in Base.digits

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1343,6 +1343,8 @@ end
 @deprecate countlines(x, eol) countlines(x, eol = eol)
 @deprecate PipeBuffer(data, maxsize) PipeBuffer(data, maxsize = maxsize)
 @deprecate unsafe_wrap(T, pointer, dims, own) unsafe_wrap(T, pointer, dims, own = own)
+@deprecate digits(n, base, pad) digits(n, base = base, pad = pad)
+@deprecate digits(T, n, base, pad) digits(T, n, base = base, pad = pad)
 
 @deprecate print_with_color(color, args...; kwargs...) printstyled(args...; kwargs..., color=color)
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -786,7 +786,7 @@ julia> digits(10, base = 2, pad = 6)
  0
 ```
 """
-digits(n::Integer; base = base::Integer = 10, pad = pad::Integer = 1) =
+digits(n::Integer; base::Integer = 10, pad::Integer = 1) =
     digits(typeof(base), n, base = base, pad = pad)
 
 function digits(T::Type{<:Integer}, n::Integer; base::Integer = 10, pad::Integer = 1)


### PR DESCRIPTION
Also adds deprecations for digits forgotten by [#25647](https://github.com/JuliaLang/julia/pull/25647/)