### PR TITLE
Add Julia port of cbrt from Openlibm.

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -286,25 +286,6 @@ for f in (:exp2, :expm1)
 end
 
 """
-    cbrt(x::Real)
-
-Return the cube root of `x`, i.e. ``x^{1/3}``. Negative values are accepted
-(returning the negative real root when ``x < 0``).
-
-The prefix operator `∛` is equivalent to `cbrt`.
-
-# Examples
-```jldoctest
-julia> cbrt(big(27))
-3.0
-
-julia> cbrt(big(-27))
--3.0
-```
-"""
-cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
-
-"""
     exp2(x)
 
 Compute the base 2 exponential of `x`, in other words ``2^x``.
@@ -1041,6 +1022,10 @@ Return the high word of `x` as a `UInt32`.
 @inline highword(x::Float64) = highword(reinterpret(UInt64, x))
 @inline highword(x::UInt64)  = (x >>> 32) % UInt32
 @inline highword(x::Float32) = reinterpret(UInt32, x)
+
+@inline fromhighword(::Type{Float64}, u::UInt32) = reinterpret(Float64, UInt64(u) << 32)
+@inline fromhighword(::Type{Float32}, u::UInt32) = reinterpret(Float32, u)
+
 
 """
     poshighword(x)

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -1,114 +1,149 @@
-# ====================================================
-# Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-#
-# Developed at SunPro, a Sun Microsystems, Inc. business.
-# Permission to use, copy, modify, and distribute this
-# software is freely granted, provided that this notice
-# is preserved.
-# ====================================================
-#
-# Optimized by Bruce D. Evans.
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# s_cbrT.c -- float version of s_cbrt.c.
-# Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
-# Debugged and optimized by Bruce D. Evans.
+# Float32/Float64 based on C implementations from FDLIBM (http://www.netlib.org/fdlibm/)
+# and FreeBSD:
+#
+## ====================================================
+## Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+##
+## Developed at SunPro, a Sun Microsystems, Inc. business.
+## Permission to use, copy, modify, and distribute this
+## software is freely granted, provided that this notice
+## is preserved.
+## ====================================================
+## Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+## Debugged and optimized by Bruce D. Evans.
 
+"""
+    cbrt(x::Real)
+
+Return the cube root of `x`, i.e. ``x^{1/3}``. Negative values are accepted
+(returning the negative real root when ``x < 0``).
+
+The prefix operator `∛` is equivalent to `cbrt`.
+
+# Examples
+```jldoctest
+julia> cbrt(big(27))
+3.0
+
+julia> cbrt(big(-27))
+-3.0
+```
+"""
 cbrt(x::Real) = cbrt(float(x))
+cbrt(x::AbstractFloat) = x < 0 ? -(-x)^(1//3) : x^(1//3)
 
-const cbrt_B1_32 = 0x2a5119f2 # UInt32(709958130) # B1 = (127-127.0/3-0.03306235651)*2**23
-const cbrt_B1_64 = 0x2a9f7893 # UInt32(715094163) # B1 = (1023-1023/3-0.03306235651)*2**20
+"""
+    _approx_cbrt(x)
 
-const cbrt_B2_32 = 0x265119f2 # UInt32(642849266) # B2 = (127-127.0/3-24/3-0.03306235651)*2**23
-const cbrt_B2_64 = 0x297f7893 # UInt32(696219795) # B2 = (1023-1023/3-54/3-0.03306235651)*2**20
+Approximate `cbrt` to 5 bits precision
 
-cbrt_t(::Type{Float64}) = 1.8014398509481984e16# 2.0^54
-cbrt_t(::Type{Float32}) = 1.6777216f7 ## 2f0^24
+    cbrt(2^e * (1+m)) ≈ 2^(e÷3) * (1 + (e%3+m)÷3)
 
-cbrt_t_from_words(::Type{Float32}, high)   = reinterpret(Float32, (div(high & 0x7fffffff, 0x00000003))+cbrt_B2_32)
-cbrt_t_from_words_alt(::Type{Float32}, hx) = reinterpret(Float32, (div(hx, 0x00000003) + cbrt_B1_32))
+where:
+ - `e` is integral and >= 0
+ - `m` is real and in [0, 1),
+ - `÷` is integer division
+ - `%` is integer remainder
 
-cbrt_t_from_words(::Type{Float64}, high)   = reinterpret(Float64, UInt64((div(high & 0x7fffffff, 0x00000003)+cbrt_B2_64))<<32)
-cbrt_t_from_words_alt(::Type{Float64}, hx) = reinterpret(Float64, UInt64((div(hx, 0x00000003) + cbrt_B1_64))<<32)
+The RHS is always >= the LHS and has a maximum relative error of about 1 in 16.
+Adding a bias of -0.03306235651 to the `(e%3+m)÷3` term reduces the error to about 1 in
+32.
 
-function cbrt(x::Tf) where Tf <: Union{Float32, Float64}
-    # mathematically cbrt(x) is defined as the real number y such that y^3 == x
+With the IEEE floating point representation, for finite positive normal values, ordinary
+integer divison of the value in bits magically gives almost exactly the RHS of the above
+provided we first subtract the exponent bias and later add it back.  We do the
+subtraction virtually to keep e >= 0 so that ordinary integer division rounds towards
+minus infinity; this is also efficient. All operations can be done in 32-bit.
 
-    if isnan(x) || isinf(x)
+These implementations assume that NaNs, infinities and zeros have already been filtered.
+"""
+@inline function _approx_cbrt(x::T) where {T<:Union{Float32,Float64}}
+    # floor(UInt32, adj * exp2(k)) should be evaluated to 2 constants.
+    adj = exponent_bias(T)*2/3 - 0.03306235651
+    k = significand_bits(T) - (8*sizeof(T) - 32)
+
+    u = highword(x) & 0x7fff_ffff
+    if u >= Base.Math.highword(realmin(T))
+        v = div(u, UInt32(3)) + floor(UInt32, adj * exp2(k))
+    else
+        # subnormal
+        x *= maxintfloat(T)
+        adj -= exponent(maxintfloat(T))/3
+        u = highword(x) & 0x7fff_ffff
+        v = div(u, UInt32(3)) + floor(UInt32, adj * exp2(k))
+    end
+    return copysign(fromhighword(T, v), x)
+end
+
+@inline function _improve_cbrt(x::Float32, t::Float32)
+    # Newton iterations solving
+    #   t^2 - x/t == 0
+    # with update
+    #   t <- t*(t^3 + 2*x)/(2*t^3 + x)
+
+    # Use double precision so that its terms can be arranged for efficiency
+    # without causing overflow or underflow.
+    xx = Float64(x)
+    tt = Float64(t)
+
+    # 1st step: 16 bits accuracy
+    tt3 = tt^3
+    tt *= (2*xx + tt3)/(x + 2*tt3)
+
+    # 2nd step: 47 bits accuracy
+    tt3 = tt^3
+    tt *= (2*xx + tt3)/(x + 2*tt3)
+
+    return Float32(tt)
+end
+
+@inline function _improve_cbrt(x::Float64, t::Float64)
+    # cbrt to 23 bits:
+    #
+    #    cbrt(x) = t * cbrt(x / t^3) ~= t * P(t^3 / x)
+    #
+    # where P(r) is a polynomial of degree 4 that approximates 1/cbrt(r)
+    # to within 2^-23.5 when |r - 1| < 1/10.  The rough approximation
+    # has produced t such than |t/cbrt(x) - 1| ~< 1/32, and cubing this
+    # gives us bounds for r = t^3/x.
+
+    r = (t*t)*(t/x)
+    t *= (@horner(r, 1.87595182427177009643, -1.88497979543377169875, 1.621429720105354466140) +
+          r^3 * @horner(r, -0.758397934778766047437, 0.145996192886612446982))
+
+    # Round t away from zero to 23 bits (sloppily except for ensuring that
+    # the result is larger in magnitude than cbrt(x) but not much more than
+    # 2 23-bit ulps larger).  With rounding towards zero, the error bound
+    # would be ~5/6 instead of ~4/6.  With a maximum error of 2 23-bit ulps
+    # in the rounded t, the infinite-precision error in the Newton
+    # approximation barely affects third digit in the final error
+    # 0.667; the error in the rounded t can be up to about 3 23-bit ulps
+    # before the final error is larger than 0.667 ulps.
+
+    u = reinterpret(UInt64, t)
+    u = (u + 0x8000_0000) & UInt64(0xffff_ffff_c000_0000)
+    t = reinterpret(Float64, u)
+
+    # one step Newton iteration solving
+    #   t^3 - x == 0
+    # with update
+    #   t <- t + t * (x/t^2 - t) / (3*t)
+
+    # to 53 bits with error < 0.667 ulps
+    s = t*t             # t*t is exact
+    r = x/s             # error <= 0.5 ulps; |r| < |t|
+    w = t+t             # t+t is exact
+    r = (r - t)/(w + r) # r-t is exact; w+r ~= 3*t
+    t = muladd(t, r, t) # error <= 0.5 + 0.5/3 + epsilon
+    return t
+end
+
+function cbrt(x::Union{Float32,Float64})
+    if !isfinite(x) || iszero(x)
         return x
     end
-
-    # rough cbrt to 5 bits
-
-    #    cbrt(2**e*(1+m) ~= 2**(e/3)*(1+(e%3+m)/3)
-    # where e is integral and >= 0, m is real and in [0, 1), and "/" and
-    # "%" are integer division and modulus with rounding towards minus
-    # infinity.  The RHS is always >= the LHS and has a maximum relative
-    # error of about 1 in 16.  Adding a bias of -0.03306235651 to the
-    # (e%3+m)/3 term reduces the error to about 1 in 32. With the IEEE
-    # floating point representation, for finite positive normal values,
-    # ordinary integer divison of the value in bits magically gives
-    # almost exactly the RHS of the above provided we first subtract the
-    # exponent bias and later add it back.  We do the
-    # subtraction virtually to keep e >= 0 so that ordinary integer
-    # division rounds towards minus infinity; this is also efficient.
-
-    if x == zero(Tf)
-        return x # cbrt(+-0) is itself
-    elseif issubnormal(x) # zero or subnormal?
-        t = x*cbrt_t(Tf)
-        high = highword(t)
-        t = copysign(cbrt_t_from_words(Tf, high), x)
-    else
-        hw = poshighword(x)
-        t = copysign(cbrt_t_from_words_alt(Tf, hw), x)
-    end
-
-    if Tf == Float32
-        # First step Newton iteration (solving t*t-x/t == 0) to 16 bits.  In
-        # double precision so that its terms can be arranged for efficiency
-        # without causing overflow or underflow.
-
-        T = Float64(t)
-        r = T*T*T
-        T = T*(Float64(x) + x + r)/(x + r + r)
-
-        # Second step Newton iteration to 47 bits.  In double precision for
-        # efficiency and accuracy.
-        r = T*T*T
-        T = T*(Float64(x) + x + r)/(x + r + r)
-
-        return Float32(T)
-    elseif Tf == Float64
-        # New cbrt to 23 bits:
-        #    cbrt(x) = t*cbrt(x/t**3) ~= t*P(t**3/x)
-        # where P(r) is a polynomial of degree 4 that approximates 1/cbrt(r)
-        # to within 2**-23.5 when |r - 1| < 1/10.  The rough approximation
-        # has produced t such than |t/cbrt(x) - 1| ~< 1/32, and cubing this
-        # gives us bounds for r = t**3/x.
-
-        r = (t*t)*(t/x)
-        t = t*(@horner(r, 1.87595182427177009643, -1.88497979543377169875, 1.621429720105354466140) +
-            ((r*r)*r)*(@horner(r, -0.758397934778766047437, 0.145996192886612446982)))
-
-        # Round t away from zero to 23 bits (sloppily except for ensuring that
-        # the result is larger in magnitude than cbrt(x) but not much more than
-        # 2 23-bit ulps larger).  With rounding towards zero, the error bound
-        # would be ~5/6 instead of ~4/6.  With a maximum error of 2 23-bit ulps
-        # in the rounded t, the infinite-precision error in the Newton
-        # approximation barely affects third digit in the final error
-        # 0.667; the error in the rounded t can be up to about 3 23-bit ulps
-        # before the final error is larger than 0.667 ulps.
-
-        u = reinterpret(UInt64, t)
-        u = (u + 0x80000000) & UInt64(0xffffffffc0000000)
-        t = reinterpret(Float64, u)
-
-        # one step Newton iteration to 53 bits with error < 0.667 ulps
-        s = t*t             # t*t is exact
-        r = x/s             # error <= 0.5 ulps; |r| < |t|
-        w = t + t           # t+t is exact
-        r = (r - t)/(w + r) # r-t is exact; w+r ~= 3*t
-        t = muladd(t, r, t) # error <= 0.5 + 0.5/3 + epsilon
-        return t
-    end
+    t = _approx_cbrt(x)
+    return _improve_cbrt(x, t)
 end

--- a/base/special/cbrt.jl
+++ b/base/special/cbrt.jl
@@ -1,0 +1,114 @@
+# ====================================================
+# Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+#
+# Developed at SunPro, a Sun Microsystems, Inc. business.
+# Permission to use, copy, modify, and distribute this
+# software is freely granted, provided that this notice
+# is preserved.
+# ====================================================
+#
+# Optimized by Bruce D. Evans.
+
+# s_cbrT.c -- float version of s_cbrt.c.
+# Conversion to float by Ian Lance Taylor, Cygnus Support, ian@cygnus.com.
+# Debugged and optimized by Bruce D. Evans.
+
+cbrt(x::Real) = cbrt(float(x))
+
+const cbrt_B1_32 = 0x2a5119f2 # UInt32(709958130) # B1 = (127-127.0/3-0.03306235651)*2**23
+const cbrt_B1_64 = 0x2a9f7893 # UInt32(715094163) # B1 = (1023-1023/3-0.03306235651)*2**20
+
+const cbrt_B2_32 = 0x265119f2 # UInt32(642849266) # B2 = (127-127.0/3-24/3-0.03306235651)*2**23
+const cbrt_B2_64 = 0x297f7893 # UInt32(696219795) # B2 = (1023-1023/3-54/3-0.03306235651)*2**20
+
+cbrt_t(::Type{Float64}) = 1.8014398509481984e16# 2.0^54
+cbrt_t(::Type{Float32}) = 1.6777216f7 ## 2f0^24
+
+cbrt_t_from_words(::Type{Float32}, high)   = reinterpret(Float32, (div(high & 0x7fffffff, 0x00000003))+cbrt_B2_32)
+cbrt_t_from_words_alt(::Type{Float32}, hx) = reinterpret(Float32, (div(hx, 0x00000003) + cbrt_B1_32))
+
+cbrt_t_from_words(::Type{Float64}, high)   = reinterpret(Float64, UInt64((div(high & 0x7fffffff, 0x00000003)+cbrt_B2_64))<<32)
+cbrt_t_from_words_alt(::Type{Float64}, hx) = reinterpret(Float64, UInt64((div(hx, 0x00000003) + cbrt_B1_64))<<32)
+
+function cbrt(x::Tf) where Tf <: Union{Float32, Float64}
+    # mathematically cbrt(x) is defined as the real number y such that y^3 == x
+
+    if isnan(x) || isinf(x)
+        return x
+    end
+
+    # rough cbrt to 5 bits
+
+    #    cbrt(2**e*(1+m) ~= 2**(e/3)*(1+(e%3+m)/3)
+    # where e is integral and >= 0, m is real and in [0, 1), and "/" and
+    # "%" are integer division and modulus with rounding towards minus
+    # infinity.  The RHS is always >= the LHS and has a maximum relative
+    # error of about 1 in 16.  Adding a bias of -0.03306235651 to the
+    # (e%3+m)/3 term reduces the error to about 1 in 32. With the IEEE
+    # floating point representation, for finite positive normal values,
+    # ordinary integer divison of the value in bits magically gives
+    # almost exactly the RHS of the above provided we first subtract the
+    # exponent bias and later add it back.  We do the
+    # subtraction virtually to keep e >= 0 so that ordinary integer
+    # division rounds towards minus infinity; this is also efficient.
+
+    if x == zero(Tf)
+        return x # cbrt(+-0) is itself
+    elseif issubnormal(x) # zero or subnormal?
+        t = x*cbrt_t(Tf)
+        high = highword(t)
+        t = copysign(cbrt_t_from_words(Tf, high), x)
+    else
+        hw = poshighword(x)
+        t = copysign(cbrt_t_from_words_alt(Tf, hw), x)
+    end
+
+    if Tf == Float32
+        # First step Newton iteration (solving t*t-x/t == 0) to 16 bits.  In
+        # double precision so that its terms can be arranged for efficiency
+        # without causing overflow or underflow.
+
+        T = Float64(t)
+        r = T*T*T
+        T = T*(Float64(x) + x + r)/(x + r + r)
+
+        # Second step Newton iteration to 47 bits.  In double precision for
+        # efficiency and accuracy.
+        r = T*T*T
+        T = T*(Float64(x) + x + r)/(x + r + r)
+
+        return Float32(T)
+    elseif Tf == Float64
+        # New cbrt to 23 bits:
+        #    cbrt(x) = t*cbrt(x/t**3) ~= t*P(t**3/x)
+        # where P(r) is a polynomial of degree 4 that approximates 1/cbrt(r)
+        # to within 2**-23.5 when |r - 1| < 1/10.  The rough approximation
+        # has produced t such than |t/cbrt(x) - 1| ~< 1/32, and cubing this
+        # gives us bounds for r = t**3/x.
+
+        r = (t*t)*(t/x)
+        t = t*(@horner(r, 1.87595182427177009643, -1.88497979543377169875, 1.621429720105354466140) +
+            ((r*r)*r)*(@horner(r, -0.758397934778766047437, 0.145996192886612446982)))
+
+        # Round t away from zero to 23 bits (sloppily except for ensuring that
+        # the result is larger in magnitude than cbrt(x) but not much more than
+        # 2 23-bit ulps larger).  With rounding towards zero, the error bound
+        # would be ~5/6 instead of ~4/6.  With a maximum error of 2 23-bit ulps
+        # in the rounded t, the infinite-precision error in the Newton
+        # approximation barely affects third digit in the final error
+        # 0.667; the error in the rounded t can be up to about 3 23-bit ulps
+        # before the final error is larger than 0.667 ulps.
+
+        u = reinterpret(UInt64, t)
+        u = (u + 0x80000000) & UInt64(0xffffffffc0000000)
+        t = reinterpret(Float64, u)
+
+        # one step Newton iteration to 53 bits with error < 0.667 ulps
+        s = t*t             # t*t is exact
+        r = x/s             # error <= 0.5 ulps; |r| < |t|
+        w = t + t           # t+t is exact
+        r = (r - t)/(w + r) # r-t is exact; w+r ~= 3*t
+        t = muladd(t, r, t) # error <= 0.5 + 0.5/3 + epsilon
+        return t
+    end
+end

--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -44,23 +44,6 @@ const INV_2PI = UInt64[
     0x9afe_d7ec_47e3_5742,
     0x1580_cc11_bf1e_daea]
 
-"""
-    highword(x)
-
-Return the high word of `x` as a `UInt32`.
-"""
-@inline highword(x::UInt64) = unsafe_trunc(UInt32,x >> 32)
-@inline highword(x::Float64) = highword(reinterpret(UInt64, x))
-
-"""
-    poshighword(x)
-
-Return positive part of the high word of `x` as a `UInt32`.
-"""
-@inline poshighword(x::UInt64) = unsafe_trunc(UInt32,x >> 32)&0x7fffffff
-@inline poshighword(x::Float32) = reinterpret(UInt32, x)&0x7fffffff
-@inline poshighword(x::Float64) = poshighword(reinterpret(UInt64, x))
-
 @inline function cody_waite_2c_pio2(x::Float64, fn, n)
     pio2_1 = 1.57079632673412561417e+00
     pio2_1t = 6.07710050650619224932e-11

--- a/test/math.jl
+++ b/test/math.jl
@@ -953,6 +953,28 @@ float(x::FloatWrapper) = x
     @test isa(cos(z), Complex)
 end
 
+@testset "cbrt" begin
+    for T in (Float32, Float64)
+        @test cbrt(zero(T)) === zero(T)
+        @test cbrt(-zero(T)) === -zero(T)
+        @test cbrt(one(T)) === one(T)
+        @test cbrt(-one(T)) === -one(T)
+        @test cbrt(T(Inf)) === T(Inf)
+        @test cbrt(-T(Inf)) === -T(Inf)
+        @test isnan_type(T, cbrt(T(NaN)))
+        for x in (pcnfloat(nextfloat(nextfloat(zero(T))))...,
+                  pcnfloat(prevfloat(prevfloat(zero(T))))...,
+                  0.45, 0.6, 0.98,
+                  map(x->x^3, 1.0:1.0:1024.0)...,
+                  nextfloat(-T(Inf)), prevfloat(T(Inf)))
+            by = cbrt(big(T(x)))
+            @test cbrt(T(x)) ≈ by rtol=eps(T)
+            bym = cbrt(big(T(-x)))
+            @test cbrt(T(-x)) ≈ bym rtol=eps(T)
+        end
+    end
+end
+
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using .Main.TestHelpers: Furlong
 @test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)


### PR DESCRIPTION
<s>*A little note: some functions/methods such as, `issubnormal` and more should probably be in `Base.Math`, but for now I'm placing the methods that I use with the methods. When all the openlibm stuff is out of `Base.Math` I will reorganize this slightly. Focus is on getting the rest of the functions in there asap focusing only on correctness and performance. If this is not wanted, we can look at code organization (inside of the module mind you), but my time is limited these days.*</s>

I would love advice from @stevengj and @simonbyrne on good test values. I've basically grabbed some a bit out of thin air.

I'm doing some preliminary benchmarks, but of course nanosoldier  should receive benchmark suites for these functions.

*EDIT*
Some relative timings. The sampled values are
```
[   4.94066e-324
       9.88131e-324
       1.4822e-323 
      -1.4822e-323 
      -9.88131e-324
      -4.94066e-324
       0.45        
       0.6         
       0.98        
       1.0         
  157464.0         
       1.22504e6   
       4.096e6     
       9.6636e6    
       1.88211e7   
       3.24618e7   
       5.14788e7   
       7.67656e7   
       1.09215e8   
       1.49721e8   
       1.99177e8   
       2.58475e8   
       3.28509e8   
       4.10172e8   
       5.04358e8   
       6.1196e8    
       7.33871e8   
       8.70984e8   
       1.02419e9   
      -1.0         
 -157464.0         
      -1.22504e6   
      -4.096e6     
      -9.6636e6    
      -1.88211e7   
      -3.24618e7   
      -5.14788e7   
      -7.67656e7   
      -1.09215e8   
      -1.49721e8   
      -1.99177e8   
      -2.58475e8   
      -3.28509e8   
      -4.10172e8   
      -5.04358e8   
      -6.1196e8    
      -7.33871e8   
      -8.70984e8   
      -1.02419e9   
      -1.79769e308 
       1.79769e308]
```
But I've left out the x-values because it only made the plot worse to look at. It's in the same order as what you see above though.

**Float32**
![fl32](https://user-images.githubusercontent.com/8431156/35973468-d6882ba4-0cd5-11e8-9b98-81243a18957c.png)

**Float64**
![fl64](https://user-images.githubusercontent.com/8431156/35973473-dae9d9ea-0cd5-11e8-904e-f098ed8caf85.png)

So, I'm basically seeing either noise, or a 0.93 ratio (master/v0.6)
