### PR TITLE
Add license headers to files without them

### DIFF
--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 ###########
 # generic #
 ###########

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 """
 Gives a reinterpreted view (of element type T) of the underlying array (of element type S).
 If the size of `T` differs from the size of `S`, the array will be compressed/expanded in

--- a/base/special/exp10.jl
+++ b/base/special/exp10.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 #  Method
 #  1. Argument reduction: Reduce x to an r so that |r| <= 0.5*log10(2). Given x,
 #     find r and integer k such that

--- a/contrib/add_license_to_files.jl
+++ b/contrib/add_license_to_files.jl
@@ -18,6 +18,7 @@ const rootdirs = [
     "../contrib",
     "../examples",
     "../src",
+    "../stdlib",
     "../test",
 ]
 
@@ -35,7 +36,6 @@ const skipfiles = [
     "../base/special/trig.jl",
     "../base/special/exp.jl",
     "../base/special/rem_pio2.jl",
-    "../base/linalg/givens.jl",
     #
     "../src/abi_llvm.cpp",
     "../src/abi_ppc64le.cpp",
@@ -63,11 +63,11 @@ const skipfiles = [
 ]
 
 const ext_prefix = Dict([
-(".jl", "# "),
-(".sh", "# "),
-(".h", "\/\/ "),
-(".c", "\/\/ "),
-(".cpp", "\/\/ "),
+    (".jl", "# "),
+    (".sh", "# "),
+    (".h", "// "),
+    (".c", "// "),
+    (".cpp", "// "),
 ])
 
 const new_license = "This file is a part of Julia. License is MIT: https://julialang.org/license"
@@ -136,7 +136,7 @@ function add_license_line!(unprocessed::Vector, src::AbstractString, new_license
             if ext in keys(ext_prefix)
                 prefix = ext_prefix[ext]
                 f = open(path, "r")
-                lines = readlines(f, chomp=false)
+                lines = readlines(f, keep=true)
                 close(f)
                 isempty(lines) && (push!(unprocessed, path); continue)
                 isempty(old_license) || check_lines!(path, lines, old_license, prefix, true)

--- a/examples/clustermanager/simple/UnixDomainCM.jl
+++ b/examples/clustermanager/simple/UnixDomainCM.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Distributed
 import Distributed: launch, manage, connect, exit
 

--- a/examples/clustermanager/simple/test_simple.jl
+++ b/examples/clustermanager/simple/test_simple.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Distributed
 cmanpath = joinpath(@__DIR__, "UnixDomainCM.jl")
 include(cmanpath)

--- a/examples/embedding/LocalModule.jl
+++ b/examples/embedding/LocalModule.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__()
 module LocalModule
 

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -1,4 +1,5 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
+
 // This LLVM pass verifies invariants required for correct GC root placement.
 // See the devdocs for a description of these invariants.
 

--- a/src/support/analyzer_annotations.h
+++ b/src/support/analyzer_annotations.h
@@ -1,3 +1,5 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
 #ifdef __clang_analyzer__
 
 #define JL_PROPAGATES_ROOT __attribute__((annotate("julia_propagates_root")))

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -1,3 +1,4 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
 __precompile__(true)
 

--- a/stdlib/CRC32c/test/runtests.jl
+++ b/stdlib/CRC32c/test/runtests.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Test, Random
 using CRC32c
 

--- a/stdlib/Dates/src/deprecated.jl
+++ b/stdlib/Dates/src/deprecated.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # 0.7 deprecations
 
 import Base.colon

--- a/stdlib/Dates/test/adjusters.jl
+++ b/stdlib/Dates/test/adjusters.jl
@@ -1,4 +1,4 @@
-#This file is a part of Julia. License is MIT: https://julialang.org/license
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
 module AdjustersTest
 

--- a/stdlib/Dates/test/runtests.jl
+++ b/stdlib/Dates/test/runtests.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module DateTests
 
 for file in readlines(joinpath(@__DIR__, "testgroups"))

--- a/stdlib/LibGit2/src/deprecated.jl
+++ b/stdlib/LibGit2/src/deprecated.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # BEGIN 0.7 deprecations
 
 # PR #22062

--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 """
     GitCredential
 

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module LibGit2Tests
 
 import LibGit2

--- a/stdlib/LibGit2/test/online.jl
+++ b/stdlib/LibGit2/test/online.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module LibGit2OnlineTests
 
 using Test

--- a/stdlib/LibGit2/test/runtests.jl
+++ b/stdlib/LibGit2/test/runtests.jl
@@ -1,2 +1,4 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 include("libgit2.jl")
 include("online.jl")

--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # givensAlgorithm functions are derived from LAPACK, see below
 
 abstract type AbstractRotation{T} end

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Logging
 
 import Logging: min_enabled_level, shouldlog, handle_message

--- a/stdlib/Pkg/test/runtests.jl
+++ b/stdlib/Pkg/test/runtests.jl
@@ -1,2 +1,4 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 include("pkg.jl")
 include("resolve.jl")

--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 ## Code for searching and viewing documentation
 
 using Markdown

--- a/stdlib/REPL/src/precompile.jl
+++ b/stdlib/REPL/src/precompile.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     precompile(Tuple{typeof(Base.__atreplinit), REPL.LineEditREPL})

--- a/stdlib/REPL/test/FakeTerminals.jl
+++ b/stdlib/REPL/test/FakeTerminals.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module FakeTerminals
 
 import REPL

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -1,4 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Test
 using REPL
 using Random

--- a/stdlib/REPL/test/runtests.jl
+++ b/stdlib/REPL/test/runtests.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module REPLTests
     include("repl.jl")
 end

--- a/stdlib/Serialization/src/precompile.jl
+++ b/stdlib/Serialization/src/precompile.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 precompile(Tuple{typeof(Serialization.write_as_tag), Base.TCPSocket, Int32})
 precompile(Tuple{typeof(Serialization.object_number), Core.TypeName})
 precompile(Tuple{typeof(Serialization.serialize_array_data), Base.TCPSocket, Array{Int64, 1}})

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module UUIDs
 
 using Random

--- a/stdlib/UUIDs/test/runtests.jl
+++ b/stdlib/UUIDs/test/runtests.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using UUIDs, Random
 
 u1 = uuid1()

--- a/test/depot/packages/9HkB/TCSb/src/Baz.jl
+++ b/test/depot/packages/9HkB/TCSb/src/Baz.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__(true)
 module Baz
 import Foo, Qux

--- a/test/depot/packages/SXm7/WLVn/src/Foo.jl
+++ b/test/depot/packages/SXm7/WLVn/src/Foo.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__(true)
 module Foo
 import Bar, Baz, Qux

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # Tests for deprecated functionality.
 #
 # These can't be run with --depwarn=error, so currently require special

--- a/test/llvmpasses/alloc-opt.jl
+++ b/test/llvmpasses/alloc-opt.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # RUN: julia --startup-file=no %s | opt -load libjulia.so -AllocOpt -LateLowerGCFrame -S - | FileCheck %s
 
 isz = sizeof(UInt) == 8 ? "i64" : "i32"

--- a/test/llvmpasses/alloc-opt2.jl
+++ b/test/llvmpasses/alloc-opt2.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # RUN: julia --startup-file=no %s | opt -load libjulia.so -AllocOpt -S - | FileCheck %s
 
 isz = sizeof(UInt) == 8 ? "i64" : "i32"

--- a/test/llvmpasses/safepoint_stress.jl
+++ b/test/llvmpasses/safepoint_stress.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # RUN: julia --startup-file=no %s | opt -load libjulia.so -LateLowerGCFrame -S - | FileCheck %s
 
 println("""

--- a/test/project/deps/Bar/src/Bar.jl
+++ b/test/project/deps/Bar/src/Bar.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__(true)
 module Bar
 import Baz, Foo

--- a/test/project/deps/Foo1/src/Foo.jl
+++ b/test/project/deps/Foo1/src/Foo.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__(true)
 module Foo
 import Bar, Baz, Qux

--- a/test/project/deps/Foo2.jl/src/Foo.jl
+++ b/test/project/deps/Foo2.jl/src/Foo.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__(true)
 module Foo
 import Qux

--- a/test/project/deps/Qux.jl
+++ b/test/project/deps/Qux.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__(true)
 module Qux
 this = "Qux"

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Test
 
 A = Int64[1, 2, 3, 4]

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 function args_morespecific(a, b)
     sp = (ccall(:jl_type_morespecific, Cint, (Any,Any), a, b) != 0)
     if sp  # make sure morespecific(a,b) implies !morespecific(b,a)


### PR DESCRIPTION
This consists of two commits: The first updates the license header script for 0.7 and the second is the result of running the script on the repo.

Fixes #25952.