### PR TITLE
clean out stdlib doc folder before creating it

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -23,11 +23,12 @@ cp_q(src, dest) = isfile(dest) || cp(src, dest)
 # make links for stdlib package docs, this is needed until #522 in Documenter.jl is finished
 const STDLIB_DOCS = []
 const STDLIB_DIR = joinpath(@__DIR__, "..", "stdlib")
-for dir in readdir(STDLIB_DIR)
-    sourcefile = joinpath(STDLIB_DIR, dir, "docs", "src", "index.md")
-    if isfile(sourcefile)
-        cd(joinpath(@__DIR__, "src")) do
-            isdir("stdlib") || mkdir("stdlib")
+cd(joinpath(@__DIR__, "src")) do
+    Base.rm("stdlib"; recursive=true, force=true)
+    mkdir("stdlib")
+    for dir in readdir(STDLIB_DIR)
+        sourcefile = joinpath(STDLIB_DIR, dir, "docs", "src", "index.md")
+        if isfile(sourcefile)
             targetfile = joinpath("stdlib", dir * ".md")
             push!(STDLIB_DOCS, (stdlib = Symbol(dir), targetfile = targetfile))
             if Sys.iswindows()


### PR DESCRIPTION
Should fix some problems people have had when moving between old and recent branches since https://github.com/JuliaLang/julia/pull/24461.
Ref: https://github.com/JuliaDocs/Documenter.jl/issues/636, I know @ararslan and @kshyatt had the same issue.

