### PR TITLE
move `peakflops` to InteractiveUtils

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -738,7 +738,6 @@ Base.require(Base, :Markdown)
     @deprecate_stdlib nullspace   LinearAlgebra true
     @deprecate_stdlib ordschur!   LinearAlgebra true
     @deprecate_stdlib ordschur    LinearAlgebra true
-    @deprecate_stdlib peakflops   LinearAlgebra true
     @deprecate_stdlib pinv        LinearAlgebra true
     @deprecate_stdlib qr          LinearAlgebra true
     @deprecate_stdlib qrfact!     LinearAlgebra true
@@ -845,6 +844,7 @@ Base.require(Base, :Markdown)
     @deprecate_stdlib methodswith   InteractiveUtils true
     @deprecate_stdlib varinfo       InteractiveUtils true
     @deprecate_stdlib versioninfo   InteractiveUtils true
+    @deprecate_stdlib peakflops     InteractiveUtils true
     @eval @deprecate_stdlib $(Symbol("@which"))         InteractiveUtils true
     @eval @deprecate_stdlib $(Symbol("@edit"))          InteractiveUtils true
     @eval @deprecate_stdlib $(Symbol("@less"))          InteractiveUtils true

--- a/stdlib/InteractiveUtils/Project.toml
+++ b/stdlib/InteractiveUtils/Project.toml
@@ -4,3 +4,4 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pkg = "fe1c5a76-5840-53d2-82f9-288dd83ce2ce"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -5,8 +5,8 @@ __precompile__(true)
 module InteractiveUtils
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
-    versioninfo, subtypes, @which, @edit, @less, @functionloc, @code_warntype, @code_typed,
-    @code_lowered, @code_llvm, @code_native
+    versioninfo, subtypes, peakflops, @which, @edit, @less, @functionloc, @code_warntype,
+    @code_typed, @code_lowered, @code_llvm, @code_native
 
 import Base.Docs.apropos
 
@@ -14,6 +14,7 @@ using Base: unwrap_unionall, rewrap_unionall, isdeprecated, Bottom, show_expr_ty
     to_tuple_type, signature_type, format_bytes
 
 using Markdown
+using LinearAlgebra  # for peakflops
 import Pkg
 
 include("editless.jl")
@@ -322,6 +323,39 @@ function dumpsubtypes(io::IO, x::DataType, m::Module, n::Int, indent)
         end
     end
     nothing
+end
+
+const Distributed_modref = Ref{Module}()
+
+"""
+    peakflops(n::Integer=2000; parallel::Bool=false)
+
+`peakflops` computes the peak flop rate of the computer by using double precision
+[`gemm!`](@ref LinearAlgebra.BLAS.gemm!). By default, if no arguments are specified, it
+multiplies a matrix of size `n x n`, where `n = 2000`. If the underlying BLAS is using
+multiple threads, higher flop rates are realized. The number of BLAS threads can be set with
+[`BLAS.set_num_threads(n)`](@ref).
+
+If the keyword argument `parallel` is set to `true`, `peakflops` is run in parallel on all
+the worker processors. The flop rate of the entire parallel computer is returned. When
+running in parallel, only 1 BLAS thread is used. The argument `n` still refers to the size
+of the problem that is solved on each processor.
+"""
+function peakflops(n::Integer=2000; parallel::Bool=false)
+    a = fill(1.,100,100)
+    t = @elapsed a2 = a*a
+    a = fill(1.,n,n)
+    t = @elapsed a2 = a*a
+    @assert a2[1,1] == n
+    if parallel
+        if !isassigned(Distributed_modref)
+            Distributed_modref[] = Base.require(Base, :Distributed)
+        end
+        Dist = Distributed_modref[]
+        sum(Dist.pmap(peakflops, fill(n, Dist.nworkers())))
+    else
+        2*Float64(n)^3 / t
+    end
 end
 
 @deprecate methodswith(typ, supertypes) methodswith(typ, supertypes = supertypes)

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -123,7 +123,6 @@ export
     nullspace,
     ordschur!,
     ordschur,
-    peakflops,
     pinv,
     qr,
     qrfact!,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1183,29 +1183,6 @@ function linreg(x::AbstractVector, y::AbstractVector)
     return (a, b)
 end
 
-"""
-    peakflops(n::Integer=2000; parallel::Bool=false)
-
-`peakflops` computes the peak flop rate of the computer by using double precision
-[`gemm!`](@ref LinearAlgebra.BLAS.gemm!). By default, if no arguments are specified, it
-multiplies a matrix of size `n x n`, where `n = 2000`. If the underlying BLAS is using
-multiple threads, higher flop rates are realized. The number of BLAS threads can be set with
-[`BLAS.set_num_threads(n)`](@ref).
-
-If the keyword argument `parallel` is set to `true`, `peakflops` is run in parallel on all
-the worker processors. The flop rate of the entire parallel computer is returned. When
-running in parallel, only 1 BLAS thread is used. The argument `n` still refers to the size
-of the problem that is solved on each processor.
-"""
-function peakflops(n::Integer=2000; parallel::Bool=false)
-    a = fill(1.,100,100)
-    t = @elapsed a2 = a*a
-    a = fill(1.,n,n)
-    t = @elapsed a2 = a*a
-    @assert a2[1,1] == n
-    parallel ? sum(pmap(peakflops, [ n for i in 1:nworkers()])) : (2*Float64(n)^3/t)
-end
-
 # BLAS-like in-place y = x*α+y function (see also the version in blas.jl
 #                                          for BlasFloat Arrays)
 function axpy!(α, x::AbstractArray, y::AbstractArray)


### PR DESCRIPTION
Also fixes the deprecations in its implementation.