### PR TITLE
fix getindex(::HermOrSym, i, j) when i == j

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -171,20 +171,20 @@ size(A::HermOrSym, d) = size(A.data, d)
 size(A::HermOrSym) = size(A.data)
 @inline function getindex(A::Symmetric, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
-    @inbounds if (A.uplo == 'U') == (i < j)
-        return A.data[i, j]
-    elseif i == j
+    @inbounds if i == j
         return symmetric(A.data[i, j], Symbol(A.uplo))::symmetric_type(eltype(A.data))
+    elseif (A.uplo == 'U') == (i < j)
+        return A.data[i, j]
     else
         return transpose(A.data[j, i])
     end
 end
 @inline function getindex(A::Hermitian, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
-    @inbounds if (A.uplo == 'U') == (i < j)
-        return A.data[i, j]
-    elseif i == j
+    @inbounds if i == j
         return hermitian(A.data[i, j], Symbol(A.uplo))::hermitian_type(eltype(A.data))
+    elseif (A.uplo == 'U') == (i < j)
+        return A.data[i, j]
     else
         return adjoint(A.data[j, i])
     end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -491,22 +491,34 @@ end
     A = Matrix{Matrix{Int}}(uninitialized, 2, 2)
     A[1,1] = [1 2; 2 3]
     A[1,2] = [4 5 6; 7 8 9]
-    A[2,2] = hcat([1 2; 3 4])
-    S = Symmetric(A)
-    @test S[1,1] == A[1,1]
-    @test S[1,2] == transpose(S[2,1]) == A[1,2]
-    @test S[2,2] == Symmetric(A[2,2])
-    @test S == transpose(S) == Matrix(S) == Matrix(transpose(S)) == transpose(Matrix(S))
+    A[2,1] = [4 7; 5 8; 6 9]
+    A[2,2] = [1 2; 3 4]
+    for uplo in (:U, :L)
+        S = Symmetric(A, uplo)
+        @test S[1,1] == A[1,1]
+        @test S[1,2] == transpose(S[2,1]) == A[1,2]
+        @test S[2,2] == Symmetric(A[2,2], uplo)
+        @test S == transpose(S) == Matrix(S) == Matrix(transpose(S)) == transpose(Matrix(S))
+    end
 
     B = Matrix{Matrix{Complex{Int}}}(uninitialized, 2, 2)
     B[1,1] = [1 2+im; 2-im 3]
     B[1,2] = [4 5+1im 6-2im; 7+3im 8-4im 9+5im]
-    B[2,2] = hcat([1+1im 2+2im; 3-3im 4-2im])
-    H = Hermitian(B)
-    @test H[1,1] == B[1,1]
-    @test H[1,2] == adjoint(H[2,1]) == B[1,2]
-    @test H[2,2] == Hermitian(B[2,2])
-    @test H == adjoint(H) == Matrix(H) == Matrix(adjoint(H)) == adjoint(Matrix(H))
+    B[2,1] = [4 7-3im; 5-1im 8+4im; 6+2im 9-5im]
+    B[2,2] = [1+1im 2+2im; 3-3im 4-2im]
+    for uplo in (:U, :L)
+        H = Hermitian(B, uplo)
+        @test H[1,1] == Hermitian(B[1,1], uplo)
+        @test H[1,2] == adjoint(H[2,1]) == B[1,2]
+        @test H[2,1] == adjoint(H[1,2]) == B[2,1]
+        @test H[2,2] == Hermitian(B[2,2], uplo)
+        @test H == adjoint(H) == Matrix(H) == Matrix(adjoint(H)) == adjoint(Matrix(H))
+    end
+end
+
+@testset "getindex of diagonal element (#25972)" begin
+    A = rand(ComplexF64, 2, 2)
+    @test Hermitian(A, :U)[1,1] == Hermitian(A, :L)[1,1] == real(A[1,1])
 end
 
 end # module TestSymmetric


### PR DESCRIPTION
Fixes `getindex` for `Hermitian` and `Symmetric` wrappers. Specifically we were wrong in the following cases when `uplo == :L` and `i == j`: `getindex(::Hermitian{<:Complex}, i, j)`, `getindex(::Hermitian{<:AbstractMatrix}, i, j)` and `getindex(::Symmetric{<:AbstractMatrix}, i, j)`