### PR TITLE
Fix two annoying warnings

### DIFF
--- a/stdlib/Pkg/src/Pkg.jl
+++ b/stdlib/Pkg/src/Pkg.jl
@@ -14,7 +14,7 @@ Please see the manual section on packages for more information.
 module Pkg
 
 export Dir, Types, Reqs, Cache, Read, Query, Resolve, Write, Entry
-export dir, init, rm, add, available, installed, status, clone, checkout,
+export dir, init, add, available, installed, status, clone, checkout,
        update, resolve, test, build, free, pin, PkgError, setprotocol!
 
 const DEFAULT_META = "https://github.com/JuliaLang/METADATA.jl"

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -3,6 +3,7 @@
 module REPL
 
 using Base.Meta
+import InteractiveUtils
 
 export
     AbstractREPL,
@@ -980,7 +981,7 @@ function setup_interface(
             if n <= 0 || n > length(linfos) || startswith(linfos[n][1], "./REPL")
                 @goto writeback
             end
-            Base.edit(linfos[n][1], linfos[n][2])
+            InteractiveUtils.edit(linfos[n][1], linfos[n][2])
             LineEdit.refresh_line(s)
             return
             @label writeback


### PR DESCRIPTION
Fixes:
```
julia> using <TAB>WARNING: both Pkg and Base export "rm"; uses of it in module Main must be qualified
julia> using
```

and

```
julia> error()
ERROR: 
Stacktrace:
 [1] error() at ./error.jl:42
 [2] top-level scope

julia> 1<Ctrl+Q>WARNING: Base.edit is deprecated: it has been moved to the standard library package `InteractiveUtils`.
Add `using InteractiveUtils` to your imports.
 in module Base
WARNING: Base.edit is deprecated: it has been moved to the standard library package `InteractiveUtils`.
Add `using InteractiveUtils` to your imports.
 in module REPL
in #59 at /home/fredrik/julia-master/usr/share/julia/site/v0.7/REPL/src/REPL.jl
```