### PR TITLE
Documentation - Change complete_me (inner constructor helper function) to complete_me!

### DIFF
--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -262,7 +262,7 @@ You can pass incomplete objects to other functions from inner constructors to de
 ```jldoctest
 julia> mutable struct Lazy
            xx
-           Lazy(v) = complete_me(new(), v)
+           Lazy(v) = complete_me!(new(), v)
        end
 ```
 

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -266,7 +266,7 @@ julia> mutable struct Lazy
        end
 ```
 
-As with incomplete objects returned from constructors, if `complete_me` or any of its callees
+As with incomplete objects returned from constructors, if `complete_me!` or any of its callees
 try to access the `xx` field of the `Lazy` object before it has been initialized, an error will
 be thrown immediately.
 


### PR DESCRIPTION
To be consistent with Julia style guidelines change _complete_me_ to _complete_me!_ as it alters at least one of its mutable arguments.

Although the “!” requirement is arguably less stringent on inner constructor completion functions, as they will never be called directly, only indirectly upon creation of a struct instance, the “!” should still be appended to the function name for code reading clarity.

As discussed here:

https://discourse.julialang.org/t/a-question-of-style-should-inner-constructor-completion-functions-end-with/8948