### PR TITLE
RFC: move stringmime to Base64, rename reprmime -> repr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -180,8 +180,8 @@ Language changes
     backslashes and the end of the literal while 2n+1 backslashes followed by a quote encodes n
     backslashes followed by a quote character ([#22926]).
 
-  * `reprmime(mime, x)` has been renamed to `repr(mime, x)`, and along with `repr(x)` it
-    now also accepts zero or more `:symbol=>value` pairs specifying `IOContext` attributes.
+  * `reprmime(mime, x)` has been renamed to `repr(mime, x)`, and along with `repr(x)`
+    and `sprint` it now accepts an optional `context` keyword for `IOContext` attributes.
     `stringmime` has been moved to the Base64 stdlib package ([#25990]).
 
   * The syntax `(x...)` for constructing a tuple is deprecated; use `(x...,)` instead ([#24452]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@ New language features
 
   * Added `⟂` (`\perp`) operator with comparison precedence ([#24404]).
 
-  * The `missing` singleton object (of type `Missing`) has been added to (repr)esent
+  * The `missing` singleton object (of type `Missing`) has been added to represent
     missing values ([#24653]). It propagates through standard operators and mathematical functions,
     and implements three-valued logic, similar to SQLs `NULL` and R's `NA`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,7 @@ New language features
 
   * Added `⟂` (`\perp`) operator with comparison precedence ([#24404]).
 
-  * The `missing` singleton object (of type `Missing`) has been added to represent
+  * The `missing` singleton object (of type `Missing`) has been added to (repr)esent
     missing values ([#24653]). It propagates through standard operators and mathematical functions,
     and implements three-valued logic, similar to SQLs `NULL` and R's `NA`.
 
@@ -179,6 +179,10 @@ Language changes
     of backslashes precedes a quote character. Thus, 2n backslashes followed by a quote encodes n
     backslashes and the end of the literal while 2n+1 backslashes followed by a quote encodes n
     backslashes followed by a quote character ([#22926]).
+
+  * `reprmime(mime, x)` has been renamed to `repr(mime, x)`, and along with `repr(x)` it
+    now also accepts zero or more `:symbol=>value` pairs specifying `IOContext` attributes.
+    `stringmime` has been moved to the Base64 stdlib package ([#25990]).
 
   * The syntax `(x...)` for constructing a tuple is deprecated; use `(x...,)` instead ([#24452]).
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1364,6 +1364,8 @@ end
 @deprecate IOBuffer(read::Bool, write::Bool) IOBuffer(read=read, write=write)
 @deprecate IOBuffer(maxsize::Integer) IOBuffer(read=true, write=true, maxsize=maxsize)
 
+@deprecate reprmime(mime, x) repr(mime, x)
+
 # PR #23332
 @deprecate ^(x, p::Integer) Base.power_by_squaring(x,p)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -876,8 +876,6 @@ export
     istextmime,
     MIME,
     @MIME_str,
-    reprmime,
-    stringmime,
     mimewritable,
     popdisplay,
     pushdisplay,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1116,7 +1116,7 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
         begin
         import Pkg
         empty!(Base.LOAD_PATH)
-        append!(Base.LOAD_PATH, $(repr(LOAD_PATH, :module => nothing)))
+        append!(Base.LOAD_PATH, $(repr(LOAD_PATH, context=:module=>nothing)))
         empty!(Base.DEPOT_PATH)
         append!(Base.DEPOT_PATH, $(repr(DEPOT_PATH)))
         empty!(Base.LOAD_CACHE_PATH)

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -115,26 +115,22 @@ repr(m::MIME, x, context::Pair{Symbol}...) = istextmime(m) ? _textrepr(m, x, con
 repr(m::AbstractString, x, context::Pair{Symbol}...) = repr(MIME(m), x, context...)
 
 # strings are shown escaped for text/plain
-_textrepr(m::MIME, x) = sprint(show, m, x)
+_textrepr(m::MIME, x, context::Pair{Symbol}...) = String(__binrepr(m, x, context...))
 _textrepr(::MIME, x::AbstractString, context::Pair{Symbol}...) = x
-_textrepr(m::MIME"text/plain", x::AbstractString) =
-    sprint(show, m, x)
-function _textrepr(m::MIME"text/plain", x, context::Pair{Symbol}...)
-    s = IOBuffer()
-    show(IOContext(s, context...), m, x)
-    String(take!(s))
-end
+_textrepr(m::MIME"text/plain", x::AbstractString, context::Pair{Symbol}...) =
+    String(__binrepr(m, x, context...))
 
-function _binrepr(m::MIME, x)
+function __binrepr(m::MIME, x)
     s = IOBuffer()
     show(s, m, x)
     take!(s)
 end
-function _binrepr(m::MIME, x, context::Pair{Symbol}...)
+function __binrepr(m::MIME, x, context::Pair{Symbol}...)
     s = IOBuffer()
     show(IOContext(s, context...), m, x)
     take!(s)
 end
+_binrepr(m::MIME, x, context::Pair{Symbol}...) = __binrepr(m, x, context...)
 _binrepr(m::MIME, x::Vector{UInt8}, context::Pair{Symbol}...) = x
 
 # resolve method ambiguities with repr(x, context...):

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -120,14 +120,14 @@ _textrepr(m::MIME, x, context) = String(__binrepr(m, x, context))
 _textrepr(::MIME, x::AbstractString, context) = x
 _textrepr(m::MIME"text/plain", x::AbstractString, context) = String(__binrepr(m, x, context))
 
-function __binrepr(m::MIME, x, ::Nothing)
-    s = IOBuffer()
-    show(s, m, x)
-    take!(s)
-end
+
 function __binrepr(m::MIME, x, context)
-    s = IOBuffer(sizehint=sizehint)
-    show(IOContext(s, context), m, x)
+    s = IOBuffer()
+    if context === nothing
+        show(s, m, x)
+    else
+        show(IOContext(s, context), m, x)
+    end
     take!(s)
 end
 _binrepr(m::MIME, x, context) = __binrepr(m, x, context)

--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -3,7 +3,7 @@
 module Multimedia
 
 export AbstractDisplay, display, pushdisplay, popdisplay, displayable, redisplay,
-    MIME, @MIME_str, reprmime, stringmime, istextmime,
+    MIME, @MIME_str, istextmime,
     mimewritable, TextDisplay
 
 ###########################################################################
@@ -15,8 +15,7 @@ export AbstractDisplay, display, pushdisplay, popdisplay, displayable, redisplay
 # struct MIME{mime} end
 # macro MIME_str(s)
 import Base: MIME, @MIME_str
-import Base64
-import Base: show, print, string, convert
+import Base: show, print, string, convert, repr
 MIME(s) = MIME{Symbol(s)}()
 show(io::IO, ::MIME{mime}) where {mime} = print(io, "MIME type ", string(mime))
 print(io::IO, ::MIME{mime}) where {mime} = print(io, mime)
@@ -79,59 +78,73 @@ show(stream, mime, x)
 show(io::IO, m::AbstractString, x) = show(io, MIME(m), x)
 mimewritable(m::AbstractString, x) = mimewritable(MIME(m), x)
 
-verbose_show(io, m, x) = show(IOContext(io, :limit => false), m, x)
-
 """
-    reprmime(mime, x)
+    repr(mime, x, context::Pair{Symbol}...)
 
 Returns an `AbstractString` or `Vector{UInt8}` containing the representation of
-`x` in the requested `mime` type, as written by [`show`](@ref) (throwing a
+`x` in the requested `mime` type, as written by [`show(io, mime, x)`](@ref) (throwing a
 [`MethodError`](@ref) if no appropriate `show` is available). An `AbstractString` is
 returned for MIME types with textual representations (such as `"text/html"` or
 `"application/postscript"`), whereas binary data is returned as
 `Vector{UInt8}`. (The function `istextmime(mime)` returns whether or not Julia
 treats a given `mime` type as text.)
 
+If `context` pairs are given, the IO buffer used to capture `show` output
+is wrapped in an [`IOContext`](@ref) object with those context pairs.
+
 As a special case, if `x` is an `AbstractString` (for textual MIME types) or a
-`Vector{UInt8}` (for binary MIME types), the `reprmime` function assumes that
+`Vector{UInt8}` (for binary MIME types), the `repr` function assumes that
 `x` is already in the requested `mime` format and simply returns `x`. This
 special case does not apply to the `"text/plain"` MIME type. This is useful so
 that raw data can be passed to `display(m::MIME, x)`.
+
+In particular, `repr("text/plain", x)` is typically a "pretty-printed" version
+of `x` designed for human consumption.  See also [`repr(x)`](@ref) to instead
+return a string corresponding to [`show(x)`](@ref) that may be closer to how
+the value of `x` would be entered in Julia.
 
 # Examples
 ```jldoctest
 julia> A = [1 2; 3 4];
 
-julia> reprmime("text/plain", A)
+julia> repr("text/plain", A)
 "2×2 Array{Int64,2}:\\n 1  2\\n 3  4"
 ```
 """
-reprmime(m::MIME, x) = istextmime(m) ? _textreprmime(m, x) : _binreprmime(m, x)
+repr(m::MIME, x, context::Pair{Symbol}...) = istextmime(m) ? _textrepr(m, x, context...) : _binrepr(m, x, context...)
+repr(m::AbstractString, x, context::Pair{Symbol}...) = repr(MIME(m), x, context...)
 
 # strings are shown escaped for text/plain
-_textreprmime(m::MIME, x) = sprint(verbose_show, m, x)
-_textreprmime(::MIME, x::AbstractString) = x
-_textreprmime(m::MIME"text/plain", x::AbstractString) =
-    sprint(verbose_show, m, x)
-
-function _binreprmime(m::MIME, x)
+_textrepr(m::MIME, x) = sprint(show, m, x)
+_textrepr(::MIME, x::AbstractString, context::Pair{Symbol}...) = x
+_textrepr(m::MIME"text/plain", x::AbstractString) =
+    sprint(show, m, x)
+function _textrepr(m::MIME"text/plain", x, context::Pair{Symbol}...)
     s = IOBuffer()
-    verbose_show(s, m, x)
+    show(IOContext(s, context...), m, x)
+    String(take!(s))
+end
+
+function _binrepr(m::MIME, x)
+    s = IOBuffer()
+    show(s, m, x)
     take!(s)
 end
-_binreprmime(m::MIME, x::Vector{UInt8}) = x
+function _binrepr(m::MIME, x, context::Pair{Symbol}...)
+    s = IOBuffer()
+    show(IOContext(s, context...), m, x)
+    take!(s)
+end
+_binrepr(m::MIME, x::Vector{UInt8}, context::Pair{Symbol}...) = x
 
-"""
-    stringmime(mime, x)
+# resolve method ambiguities with repr(x, context...):
+repr(m::MIME, x::Pair{Symbol}, context::Pair{Symbol}...) = istextmime(m) ? _textrepr(m, x, context...) : _binrepr(m, x, context...)
+function repr(x::AbstractString, c::Pair{Symbol}, context::Pair{Symbol}...)
+    s = IOBuffer()
+    show(IOContext(s, c, context...), x)
+    String(take!(s))
+end
 
-Returns an `AbstractString` containing the representation of `x` in the
-requested `mime` type. This is similar to [`reprmime`](@ref) except
-that binary data is base64-encoded as an ASCII string.
-"""
-stringmime(m::MIME, x) = istextmime(m) ? reprmime(m, x) : _binstringmime(m, x)
-
-_binstringmime(m::MIME, x) = Base64.base64encode(verbose_show, m, x)
-_binstringmime(m::MIME, x::Vector{UInt8}) = Base64.base64encode(write, x)
 
 """
     istextmime(m::MIME)
@@ -149,11 +162,7 @@ false
 ```
 """
 istextmime(m::MIME) = startswith(string(m), "text/")
-
-# it is convenient to accept strings instead of ::MIME
 istextmime(m::AbstractString) = istextmime(MIME(m))
-reprmime(m::AbstractString, x) = reprmime(MIME(m), x)
-stringmime(m::AbstractString, x) = stringmime(MIME(m), x)
 
 for mime in ["application/atom+xml", "application/ecmascript",
              "application/javascript", "application/julia",
@@ -169,7 +178,7 @@ end
 # We have an abstract AbstractDisplay class that can be subclassed in order to
 # define new rich-display output devices.  A typical subclass should
 # overload display(d::AbstractDisplay, m::MIME, x) for supported MIME types m,
-# (typically using reprmime or stringmime to get the MIME
+# (typically using show, repr, ..., to get the MIME
 # representation of x) and should also overload display(d::AbstractDisplay, x)
 # to display x in whatever MIME type is preferred by the AbstractDisplay and
 # is writable by x.  display(..., x) should throw a MethodError if x

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -152,7 +152,12 @@ end
 
 Create a string from any value using the [`show`](@ref) function.
 If context pairs are given, the IO buffer used to capture `show` output
-is wrapped in an `IOContext` object with those context pairs.
+is wrapped in an [`IOContext`](@ref) object with those context pairs.
+
+In particular, `repr(x)` is usually similar to how the value of `x` would
+be entered in Julia.  See also [`repr("text/plain", x)`](@ref) to instead
+return a "pretty-printed" version of `x` designed more for human consumption,
+equivalent to the REPL display of `x`.
 
 # Examples
 ```jldoctest

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -69,10 +69,15 @@ println(io::IO, xs...) = print(io, xs..., '\n')
 ## conversion of general objects to strings ##
 
 """
-    sprint(f::Function, args...)
+    sprint(f::Function, args...; context=nothing, sizehint=0)
 
 Call the given function with an I/O stream and the supplied extra arguments.
 Everything written to this I/O stream is returned as a string.
+
+The optional keyword argument `context` can be set to `:key=>value` pair
+or an `IO` or [`IOContext`](@ref) object whose attributes are used for the I/O
+stream passed to `f`.  The optional `sizehint` is a suggersted (in bytes)
+to allocate for the buffer used to write the string.
 
 # Examples
 ```jldoctest
@@ -147,14 +152,14 @@ function print_quoted_literal(io, s::AbstractString)
 end
 
 """
-    repr(x)
-    repr(x, context::Pair{Symbol,<:Any}...)
+    repr(x; context=nothing)
 
 Create a string from any value using the [`show`](@ref) function.
-If context pairs are given, the IO buffer used to capture `show` output
-is wrapped in an [`IOContext`](@ref) object with those context pairs.
 
-In particular, `repr(x)` is usually similar to how the value of `x` would
+The optional keyword argument `context` can be set to an `IO` or [`IOContext`](@ref)
+object whose attributes are used for the I/O stream passed to `show`.
+
+Note that `repr(x)` is usually similar to how the value of `x` would
 be entered in Julia.  See also [`repr("text/plain", x)`](@ref) to instead
 return a "pretty-printed" version of `x` designed more for human consumption,
 equivalent to the REPL display of `x`.
@@ -169,17 +174,7 @@ julia> repr(zeros(3))
 
 ```
 """
-function repr(x)
-    s = IOBuffer()
-    show(s, x)
-    String(take!(s))
-end
-
-function repr(x, context::Pair{Symbol}...)
-    s = IOBuffer()
-    show(IOContext(s, context...), x)
-    String(take!(s))
-end
+repr(x; context=nothing) = sprint(show, x; context=context)
 
 # IOBuffer views of a (byte)string:
 

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -448,12 +448,6 @@ let BINDIR = ccall(:jl_get_julia_bindir, Any, ())
     init_load_path(BINDIR)
 end
 
-INCLUDE_STATE = 3 # include = include_relative
-
-import Base64
-
-INCLUDE_STATE = 2
-
 include("asyncmap.jl")
 
 include("multimedia.jl")
@@ -575,6 +569,7 @@ Base.require(Base, :Markdown)
     @deprecate_stdlib base64decode Base64 true
     @deprecate_stdlib Base64EncodePipe Base64 true
     @deprecate_stdlib Base64DecodePipe Base64 true
+    @deprecate_stdlib stringmime Base64 true
 
     @deprecate_stdlib poll_fd FileWatching true
     @deprecate_stdlib poll_file FileWatching true

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -94,8 +94,7 @@ Base.Multimedia.redisplay
 Base.Multimedia.displayable
 Base.show(::Any, ::Any, ::Any)
 Base.Multimedia.mimewritable
-Base.Multimedia.reprmime
-Base.Multimedia.stringmime
+Base.repr(::Any, ::Any)
 ```
 
 As mentioned above, one can also define new display backends. For example, a module that can display
@@ -105,8 +104,9 @@ types with PNG representations will automatically display the image using the mo
 In order to define a new display backend, one should first create a subtype `D` of the abstract
 class `AbstractDisplay`.  Then, for each MIME type (`mime` string) that can be displayed on `D`, one should
 define a function `display(d::D, ::MIME"mime", x) = ...` that displays `x` as that MIME type,
-usually by calling [`reprmime(mime, x)`](@ref).  A `MethodError` should be thrown if `x` cannot be displayed
-as that MIME type; this is automatic if one calls [`reprmime`](@ref). Finally, one should define a function
+usually by calling [`show(io, mime, x)`](@ref) or [`repr(io, mime, x)`](@ref).
+A `MethodError` should be thrown if `x` cannot be displayed
+as that MIME type; this is automatic if one calls `show` or `repr`. Finally, one should define a function
 `display(d::D, x)` that queries [`mimewritable(mime, x)`](@ref) for the `mime` types supported by `D`
 and displays the "best" one; a `MethodError` should be thrown if no supported MIME types are found
 for `x`.  Similarly, some subtypes may wish to override [`redisplay(d::D, ...)`](@ref Base.Multimedia.redisplay). (Again, one should

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -8,7 +8,7 @@ Base.:^(::AbstractString, ::Integer)
 Base.string
 Base.repeat(::AbstractString, ::Integer)
 Base.repeat(::Char, ::Integer)
-Base.repr
+Base.repr(::Any)
 Core.String(::AbstractString)
 Base.SubString
 Base.transcode

--- a/stdlib/Base64/docs/src/index.md
+++ b/stdlib/Base64/docs/src/index.md
@@ -5,4 +5,5 @@ Base64.Base64EncodePipe
 Base64.base64encode
 Base64.Base64DecodePipe
 Base64.base64decode
+Base64.stringmime
 ```

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -25,20 +25,20 @@ include("encode.jl")
 include("decode.jl")
 
 """
-    stringmime(mime, x, context::Pair{Symbol,<:Any}...)
+    stringmime(mime, x; context=nothing)
 
 Returns an `AbstractString` containing the representation of `x` in the
 requested `mime` type. This is similar to [`repr(mime, x)`](@ref) except
 that binary data is base64-encoded as an ASCII string.
 
-If `context` pairs are given, the IO buffer used to capture `show` output
-is wrapped in an [`IOContext`](@ref) object with those context pairs.
+The optional keyword argument `context` can be set to `:key=>value` pair
+or an `IO` or [`IOContext`](@ref) object whose attributes are used for the I/O
+stream passed to `show`.
 """
-stringmime(m::MIME, x, context::Pair{Symbol}...) = istextmime(m) ? repr(m, x, context...) : _binstringmime(m, x, context...)
-stringmime(m::AbstractString, x, context::Pair{Symbol}...) = stringmime(MIME(m), x, context...)
+stringmime(m::MIME, x; context=nothing) = istextmime(m) ? Base._textrepr(m, x, context) : _binstringmime(m, x, context)
+stringmime(m::AbstractString, x; context=nothing) = stringmime(MIME(m), x; context=context)
 
-_binstringmime(m::MIME, x) = Base64.base64encode(show, m, x)
-_binstringmime(m::MIME, x, context::Pair{Symbol}...) = Base64.base64encode(io -> show(IOContext(io, m, x, context...)))
-_binstringmime(m::MIME, x::Vector{UInt8}, context::Pair{Symbol}...) = Base64.base64encode(write, x)
+_binstringmime(m::MIME, x, context) = Base64.base64encode(show, m, x; context=IOContext)
+_binstringmime(m::MIME, x::Vector{UInt8}, context) = Base64.base64encode(write, x; context=context)
 
 end

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -35,7 +35,7 @@ The optional keyword argument `context` can be set to `:key=>value` pair
 or an `IO` or [`IOContext`](@ref) object whose attributes are used for the I/O
 stream passed to `show`.
 """
-stringmime(m::MIME, x; context=nothing) = istextmime(m) ? Base._textrepr(m, x, context) : _binstringmime(m, x, context)
+stringmime(m::MIME, x; context=nothing) = istextmime(m) ? Base.Multimedia._textrepr(m, x, context) : _binstringmime(m, x, context)
 stringmime(m::AbstractString, x; context=nothing) = stringmime(MIME(m), x; context=context)
 
 _binstringmime(m::MIME, x, context) = Base64.base64encode(show, m, x; context=IOContext)

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -8,7 +8,8 @@ export
     Base64EncodePipe,
     base64encode,
     Base64DecodePipe,
-    base64decode
+    base64decode,
+    stringmime
 
 # Base64EncodePipe is a pipe-like IO object, which converts into base64 data
 # sent to a stream. (You must close the pipe to complete the encode, separate
@@ -22,5 +23,22 @@ export
 include("buffer.jl")
 include("encode.jl")
 include("decode.jl")
+
+"""
+    stringmime(mime, x, context::Pair{Symbol,<:Any}...)
+
+Returns an `AbstractString` containing the representation of `x` in the
+requested `mime` type. This is similar to [`repr(mime, x)`](@ref) except
+that binary data is base64-encoded as an ASCII string.
+
+If `context` pairs are given, the IO buffer used to capture `show` output
+is wrapped in an [`IOContext`](@ref) object with those context pairs.
+"""
+stringmime(m::MIME, x, context::Pair{Symbol}...) = istextmime(m) ? repr(m, x, context...) : _binstringmime(m, x, context...)
+stringmime(m::AbstractString, x, context::Pair{Symbol}...) = stringmime(MIME(m), x, context...)
+
+_binstringmime(m::MIME, x) = Base64.base64encode(show, m, x)
+_binstringmime(m::MIME, x, context::Pair{Symbol}...) = Base64.base64encode(io -> show(IOContext(io, m, x, context...)))
+_binstringmime(m::MIME, x::Vector{UInt8}, context::Pair{Symbol}...) = Base64.base64encode(write, x)
 
 end

--- a/stdlib/Base64/src/encode.jl
+++ b/stdlib/Base64/src/encode.jl
@@ -183,8 +183,8 @@ function loadtriplet!(buffer::Buffer, ptr::Ptr{UInt8}, n::UInt)
 end
 
 """
-    base64encode(writefunc, args...)
-    base64encode(args...)
+    base64encode(writefunc, args...; context=nothing)
+    base64encode(args...; context=nothing)
 
 Given a [`write`](@ref)-like function `writefunc`, which takes an I/O stream as
 its first argument, `base64encode(writefunc, args...)` calls `writefunc` to
@@ -193,13 +193,21 @@ write `args...` to a base64-encoded string, and returns the string.
 converts its arguments into bytes using the standard [`write`](@ref) functions
 and returns the base64-encoded string.
 
+The optional keyword argument `context` can be set to `:key=>value` pair
+or an `IO` or [`IOContext`](@ref) object whose attributes are used for the I/O
+stream passed to `writefunc` or `write`.
+
 See also [`base64decode`](@ref).
 """
-function base64encode(f::Function, args...)
+function base64encode(f::Function, args...; context=nothing)
     s = IOBuffer()
     b = Base64EncodePipe(s)
-    f(b, args...)
+    if context === nothing
+        f(b, args...)
+    else
+        f(IOContext(b, context), args...)
+    end
     close(b)
     return String(take!(s))
 end
-base64encode(args...) = base64encode(write, args...)
+base64encode(args...; context=nothing) = base64encode(write, args...; context=context)

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -75,3 +75,11 @@ end
         @test hash(base64decode(base64encode(data))) == hash(data)
     end
 end
+
+@testset "stringmime" begin
+    @test stringmime("text/plain", [1 2;3 4]) == repr("text/plain", [1 2;3 4])
+    @test stringmime("text/html", "raw html data") == "raw html data"
+    @test stringmime("text/plain", "string") == "\"string\""
+    @test stringmime("image/png", UInt8[2,3,4,7]) == "AgMEBw=="
+    @test stringmime("text/plain", 3.141592653589793, :compact=>true) == "3.14159"
+end

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -5,7 +5,8 @@ import Base64:
     Base64EncodePipe,
     base64encode,
     Base64DecodePipe,
-    base64decode
+    base64decode,
+    stringmime
 
 const inputText = "Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure."
 const encodedMaxLine76 = """

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -82,5 +82,5 @@ end
     @test stringmime("text/html", "raw html data") == "raw html data"
     @test stringmime("text/plain", "string") == "\"string\""
     @test stringmime("image/png", UInt8[2,3,4,7]) == "AgMEBw=="
-    @test stringmime("text/plain", 3.141592653589793, :compact=>true) == "3.14159"
+    @test stringmime("text/plain", 3.141592653589793, context=:compact=>true) == "3.14159"
 end

--- a/stdlib/Markdown/Project.toml
+++ b/stdlib/Markdown/Project.toml
@@ -1,3 +1,5 @@
 name = "Markdown"
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -6,6 +6,7 @@ Tools for working with the Markdown file format. Mainly for documentation.
 module Markdown
 
 import Base: show, ==, with_output_color
+using Base64: stringmime
 
 include(joinpath("parse", "config.jl"))
 include(joinpath("parse", "util.jl"))

--- a/stdlib/Pkg/src/entry.jl
+++ b/stdlib/Pkg/src/entry.jl
@@ -585,7 +585,7 @@ function build(pkg::AbstractString, build_file::AbstractString, errfile::Abstrac
     code = """
         import Pkg
         empty!(Base.LOAD_PATH)
-        append!(Base.LOAD_PATH, $(repr(LOAD_PATH, :module => nothing)))
+        append!(Base.LOAD_PATH, $(repr(LOAD_PATH, context=:module=>nothing)))
         empty!(Base.DEPOT_PATH)
         append!(Base.DEPOT_PATH, $(repr(DEPOT_PATH)))
         empty!(Base.LOAD_CACHE_PATH)

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -67,7 +67,7 @@ When the cursor is at the beginning of the line, the prompt can be changed to a 
 julia> ? # upon typing ?, the prompt changes (in place) to: help?>
 
 help?> string
-search: string String stringmime Cstring Cwstring RevString randstring bytestring SubString
+search: string String Cstring Cwstring RevString randstring bytestring SubString
 
   string(xs...)
 
@@ -220,7 +220,7 @@ or type and then press the tab key to get a list all matches:
 
 ```julia-repl
 julia> stri[TAB]
-stride     strides     string      stringmime  strip
+stride     strides     string      strip
 
 julia> Stri[TAB]
 StridedArray    StridedMatrix    StridedVecOrMat  StridedVector    String

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -32,7 +32,7 @@ docstring_startswith(d1::DocStr, d2) = docstring_startswith(parsedoc(d1), d2)
 
 @doc "Doc abstract type"
 abstract type C74685{T,N} <: AbstractArray{T,N} end
-@test stringmime("text/plain", Docs.doc(C74685))=="  Doc abstract type\n"
+@test repr("text/plain", Docs.doc(C74685))=="  Doc abstract type\n"
 @test string(Docs.doc(C74685))=="Doc abstract type\n"
 
 macro macro_doctest() end
@@ -559,7 +559,7 @@ REPL.docsearch(haystack::LazyHelp, needle) = REPL.docsearch(haystack.text, needl
 end
 
 let d = @doc(I15424.LazyHelp)
-    @test stringmime("text/plain", d) == "LazyHelp\nLazyHelp(text)\n"
+    @test repr("text/plain", d) == "LazyHelp\nLazyHelp(text)\n"
 end
 
 # Issue #13385.

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -137,8 +137,8 @@ end
 @test repr(apple) == "apple::$(string(Fruit)) = 0"
 @test string(apple) == "apple"
 
-@test reprmime("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
-@test reprmime("text/plain", orange) == "orange::$(curmod_prefix)Fruit = 1"
+@test repr("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
+@test repr("text/plain", orange) == "orange::$(curmod_prefix)Fruit = 1"
 let io = IOBuffer()
     ioc = IOContext(io, :compact=>false)
     show(io, Fruit)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -318,8 +318,8 @@ let err_str,
     err_str = @except_str randn(1)() MethodError
     @test contains(err_str, "MethodError: objects of type Array{Float64,1} are not callable")
 end
-@test stringmime("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 0 methods)"
-@test contains(stringmime("text/plain", getfield(Base, Symbol("@doc"))), r"^@doc \(macro with \d+ method[s]?\)$")
+@test repr("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 0 methods)"
+@test contains(repr("text/plain", getfield(Base, Symbol("@doc"))), r"^@doc \(macro with \d+ method[s]?\)$")
 
 method_defs_lineno = @__LINE__() + 1
 Base.Symbol() = throw(ErrorException("1"))
@@ -356,8 +356,8 @@ let err_str,
                      "@doc(__source__::LineNumberNode, __module__::Module, x...) in Core at boot.jl:")
     @test startswith(sprint(show, which(FunctionLike(), Tuple{})),
                      "(::$(curmod_prefix)FunctionLike)() in $curmod_str at $sp:$(method_defs_lineno + 7)")
-    @test stringmime("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 1 method)"
-    @test stringmime("text/plain", Core.arraysize) == "arraysize (built-in function)"
+    @test repr("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 1 method)"
+    @test repr("text/plain", Core.arraysize) == "arraysize (built-in function)"
 
     err_str = @except_stackframe Symbol() ErrorException
     @test err_str == "Symbol() at $sn:$(method_defs_lineno + 0)"

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -384,7 +384,7 @@ if Sys.iswindows()
     end
 end
 
-let optstring = stringmime(MIME("text/plain"), Base.JLOptions())
+let optstring = repr("text/plain", Base.JLOptions())
     @test startswith(optstring, "JLOptions(\n")
     @test !contains(optstring, "Ptr")
     @test endswith(optstring, "\n)")

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -903,22 +903,22 @@ end
     @test i == 7
 end
 
-@testset "stringmime/repr" begin
-    # stringmime/show should display the range nicely
+@testset "repr" begin
+    # repr/show should display the range nicely
     # to test print_range in range.jl
-    replstrmime(x) = sprint((io,x) -> show(IOContext(io, :limit => true, :displaysize => (24, 80)), MIME("text/plain"), x), x)
-    @test replstrmime(1:4) == "1:4"
-    @test stringmime("text/plain", 1:4) == "1:4"
-    @test stringmime("text/plain", range(1, stop=5, length=7)) == "1.0:0.6666666666666666:5.0"
-    @test stringmime("text/plain", LinRange{Float64}(1,5,7)) == "7-element LinRange{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
+    replrepr(x) = repr("text/plain", x; context=IOContext(STDOUT, :limit=>true, :displaysize=>(24, 80)))
+    @test replrepr(1:4) == "1:4"
+    @test repr("text/plain", 1:4) == "1:4"
+    @test repr("text/plain", range(1, stop=5, length=7)) == "1.0:0.6666666666666666:5.0"
+    @test repr("text/plain", LinRange{Float64}(1,5,7)) == "7-element LinRange{Float64}:\n 1.0,1.66667,2.33333,3.0,3.66667,4.33333,5.0"
     @test repr(range(1, stop=5, length=7)) == "1.0:0.6666666666666666:5.0"
     @test repr(LinRange{Float64}(1,5,7)) == "range(1.0, stop=5.0, length=7)"
-    @test replstrmime(0:100.) == "0.0:1.0:100.0"
+    @test replrepr(0:100.) == "0.0:1.0:100.0"
     # next is to test a very large range, which should be fast because print_range
     # only examines spacing of the left and right edges of the range, sufficient
     # to cover the designated screen size.
-    @test replstrmime(range(0, stop=100, length=10000)) == "0.0:0.010001000100010001:100.0"
-    @test replstrmime(LinRange{Float64}(0,100, 10000)) == "10000-element LinRange{Float64}:\n 0.0,0.010001,0.020002,0.030003,0.040004,…,99.95,99.96,99.97,99.98,99.99,100.0"
+    @test replrepr(range(0, stop=100, length=10000)) == "0.0:0.010001000100010001:100.0"
+    @test replrepr(LinRange{Float64}(0,100, 10000)) == "10000-element LinRange{Float64}:\n 0.0,0.010001,0.020002,0.030003,0.040004,…,99.95,99.96,99.97,99.98,99.99,100.0"
 
     @test sprint(show, UnitRange(1, 2)) == "1:2"
     @test sprint(show, StepRange(1, 2, 5)) == "1:2:5"

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -329,7 +329,7 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
         must_used_checked[sym] = false
     end
     for str in (sprint(code_warntype, f, types),
-                stringmime("text/plain", src))
+                repr("text/plain", src))
         for var in must_used_vars
             @test contains(str, string(var))
         end
@@ -381,8 +381,8 @@ test_typed_ast_printing(g15714, Tuple{Vector{Float32}},
 let li = typeof(fieldtype).name.mt.cache.func::Core.MethodInstance,
     lrepr = string(li),
     mrepr = string(li.def),
-    lmime = stringmime("text/plain", li),
-    mmime = stringmime("text/plain", li.def)
+    lmime = repr("text/plain", li),
+    mmime = repr("text/plain", li.def)
 
     @test lrepr == lmime == "MethodInstance for fieldtype(...)"
     @test mrepr == mmime == "fieldtype(...) in Core"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1156,3 +1156,14 @@ end
         @test contains(str, "(intrinsic function")
     end
 end
+
+@testset "repr(mime, x)" begin
+    @test repr("text/plain", UInt8[1 2;3 4]) == "2×2 Array{UInt8,2}:\n 0x01  0x02\n 0x03  0x04"
+    @test repr("text/html", "raw html data") == "raw html data"
+    @test repr("text/plain", "string") == "\"string\""
+    @test repr("image/png", UInt8[2,3,4,7]) == UInt8[2,3,4,7]
+    @test repr("text/plain", 3.141592653589793) == "3.141592653589793"
+    @test repr("text/plain", 3.141592653589793, :compact=>true) == "3.14159"
+    @test repr("text/plain", :compact=>true) == "\"text/plain\""
+    @test repr(MIME("text/plain"), :compact=>true) == ":compact => true"
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1164,6 +1164,6 @@ end
     @test repr("image/png", UInt8[2,3,4,7]) == UInt8[2,3,4,7]
     @test repr("text/plain", 3.141592653589793) == "3.141592653589793"
     @test repr("text/plain", 3.141592653589793, :compact=>true) == "3.14159"
-    @test repr("text/plain", :compact=>true) == "\"text/plain\""
-    @test repr(MIME("text/plain"), :compact=>true) == ":compact => true"
+    @test repr("text/plain", context=:compact=>true) == "\"text/plain\""
+    @test repr(MIME("text/plain"), context=:compact=>true) == "MIME type text/plain"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1163,7 +1163,7 @@ end
     @test repr("text/plain", "string") == "\"string\""
     @test repr("image/png", UInt8[2,3,4,7]) == UInt8[2,3,4,7]
     @test repr("text/plain", 3.141592653589793) == "3.141592653589793"
-    @test repr("text/plain", 3.141592653589793, :compact=>true) == "3.14159"
+    @test repr("text/plain", 3.141592653589793, context=:compact=>true) == "3.14159"
     @test repr("text/plain", context=:compact=>true) == "\"text/plain\""
     @test repr(MIME("text/plain"), context=:compact=>true) == "MIME type text/plain"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -850,7 +850,7 @@ test_repr("a.:(begin
 @test repr(Tuple{Float32, Float32, Float32}) == "Tuple{Float32,Float32,Float32}"
 
 # Test that REPL/mime display of invalid UTF-8 data doesn't throw an exception:
-@test isa(stringmime("text/plain", String(UInt8[0x00:0xff;])), String)
+@test isa(repr("text/plain", String(UInt8[0x00:0xff;])), String)
 
 # don't use julia-specific `f` in Float32 printing (PR #18053)
 @test sprint(print, 1f-7) == "1.0e-7"
@@ -1036,10 +1036,10 @@ end
     anonfn_type_repr = "getfield($modname, Symbol(\"$(typeof(anonfn).name.name)\"))"
     @test repr(typeof(anonfn)) == anonfn_type_repr
     @test repr(anonfn) == anonfn_type_repr * "()"
-    @test stringmime("text/plain", anonfn) == "$(typeof(anonfn).name.mt.name) (generic function with 1 method)"
+    @test repr("text/plain", anonfn) == "$(typeof(anonfn).name.mt.name) (generic function with 1 method)"
     mkclosure = x->y->x+y
     clo = mkclosure(10)
-    @test stringmime("text/plain", clo) == "$(typeof(clo).name.mt.name) (generic function with 1 method)"
+    @test repr("text/plain", clo) == "$(typeof(clo).name.mt.name) (generic function with 1 method)"
     @test repr(UnionAll) == "UnionAll"
 end
 


### PR DESCRIPTION
This PR makes three main changes:

* It renames `reprmime(mime, x)` to `repr(mime, x)`, analogous to how we merged `writemime` and `show`.

* It moves `stringmime` to the `Base64` package, since the *only* reason to use this function rather than `repr` is if you want base64 encoding for binary MIME types.

* It adds optional ~~`context::Pair{Symbol}...` arguments~~ `context` keywords to `repr` to `repr(mime, x)` and `stringmime`, similar to c418a1004b8b6fd0a9648f04329d45e37143b96c and `sprint`.

~~One slight wrinkle is that there is an ambiguity for `repr(mime::Union{MIME,AbstractString}, p::Pair{Symbol})`: are you asking for `repr(mime)` using the context `p`, or `repr(p)` using the MIME type `mime`?  I opted to resolve this as `repr(p)` for `mime::MIME` and `repr(mime)` for `mime::AbstractString`.~~

To do:
- [x] Tests of the new context arguments
- [x] NEWS