### PR TITLE
missing @inbounds in copyto!

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -753,7 +753,7 @@ function copyto!(B::AbstractVecOrMat{R}, ir_dest::AbstractRange{Int}, jr_dest::A
     for jsrc in jr_src
         idest = first(ir_dest)
         for isrc in ir_src
-            B[idest,jdest] = A[isrc,jsrc]
+            @inbounds B[idest,jdest] = A[isrc,jsrc]
             idest += step(ir_dest)
         end
         jdest += step(jr_dest)


### PR DESCRIPTION
It seemed like this line should have an `@inbounds` call since the previous code already called `checkbounds`.