### PR TITLE
adding rand for rational types

### DIFF
--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -153,6 +153,14 @@ rand_generic(r::AbstractRNG, ::Type{Int64})  = rand(r, UInt64) % Int64
 rand(r::AbstractRNG, ::SamplerType{Complex{T}}) where {T<:Real} =
     complex(rand(r, T), rand(r, T))
 
+### random rationals
+
+rand(r::AbstractRNG, ::SamplerType{Rational{T}}) where {T<:Integer} =
+    Rational(rand(r, T), rand(r, T))
+
+rand(r::AbstractRNG, ::SamplerType{Rational}) =
+    Rational(rand(r, Int), rand(r, Int)) # allows rand(Rational) to work
+
 ### random characters
 
 # returns a random valid Unicode scalar value (i.e. 0 - 0xd7ff, 0xe000 - # 0x10ffff)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -32,6 +32,10 @@ end
 
 @test rand(MersenneTwister(0)) == 0.8236475079774124
 @test rand(MersenneTwister(42)) == 0.5331830160438613
+
+@test rand(MersenneTwister(42), Rational{Int32}) == -368374157//235696739
+@test rand(MersenneTwister(42), Rational) == 5590813852184710015//3569577920569690638
+
 # Try a seed larger than 2^32
 @test rand(MersenneTwister(5294967296)) == 0.3498809918210497
 


### PR DESCRIPTION
Adding support for random generation of rational types

Now ```rand(Rational)``` and ```rand(Rational{T})``` where ```T <: Integer``` work.