### PR TITLE
Change indexin() to return first rather than last matching index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -426,6 +426,8 @@ This section lists changes that do not have deprecation warnings.
   * The `fieldnames` and `propertynames` functions now return a tuple rather than
     an array ([#25725]).
 
+  * `indexin` now returns the first rather than the last matching index ([#25998]).
+
 Library improvements
 --------------------
 
@@ -1297,3 +1299,4 @@ Command-line option changes
 [#25655]: https://github.com/JuliaLang/julia/issues/25655
 [#25725]: https://github.com/JuliaLang/julia/issues/25725
 [#25745]: https://github.com/JuliaLang/julia/issues/25745
+[#25998]: https://github.com/JuliaLang/julia/issues/25998

--- a/base/array.jl
+++ b/base/array.jl
@@ -2139,7 +2139,7 @@ argmin(a) = findmin(a)[2]
 """
     indexin(a, b)
 
-Return an array containing the highest index in `b` for
+Return an array containing the first index in `b` for
 each value in `a` that is a member of `b`. The output
 array contains `nothing` wherever `a` is not a member of `b`.
 
@@ -2160,15 +2160,18 @@ julia> indexin(a, b)
 
 julia> indexin(b, a)
 3-element Array{Union{Nothing, Int64},1}:
- 6
- 4
+ 1
+ 2
  3
 ```
 """
 function indexin(a, b::AbstractArray)
-    indexes = keys(b)
-    bdict = Dict(zip(b, indexes))
-    return Union{eltype(indexes), Nothing}[
+    inds = keys(b)
+    bdict = Dict{eltype(b),eltype(inds)}()
+    for (val, ind) in zip(b, inds)
+        get!(bdict, val, ind)
+    end
+    return Union{eltype(inds), Nothing}[
         get(bdict, i, nothing) for i in a
     ]
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1415,9 +1415,9 @@ end
 # PR #8622 and general indexin tests
 @test indexin([1,3,5,7], [5,4,3]) == [nothing,3,1,nothing]
 @test indexin([1 3; 5 7], [5 4; 3 2]) == [nothing CartesianIndex(2, 1); CartesianIndex(1, 1) nothing]
-@test indexin((2 * x + 1 for x in 0:3), [5,4,3,5,6]) == [nothing,3,4,nothing]
-@test indexin(6, [1,3,6,6,2]) == fill(4, ())
-@test indexin([6], [1,3,6,6,2]) == [4]
+@test indexin((2 * x + 1 for x in 0:3), [5,4,3,5,6]) == [nothing,3,1,nothing]
+@test indexin(6, [1,3,6,6,2]) == fill(3, ())
+@test indexin([6], [1,3,6,6,2]) == [3]
 @test indexin([3], 2:5) == [2]
 @test indexin([3.0], 2:5) == [2]
 


### PR DESCRIPTION
That's more natural, and consistent with MATLAB's `ismember` and R's `match`.
See discussion at https://github.com/JuliaLang/julia/pull/25662#issuecomment-359255176.

If desired, breakage could be avoided by adding an optional argument to choose between the first and the last one. We would print a deprecation by default unless the argument is passed explicitly.