### PR TITLE
RFC: rename DenseArray to AbstractStridedArray

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -689,6 +689,8 @@ Deprecated or removed
   * `expand(ex)` and `expand(module, ex)` have been deprecated in favor of
     `Meta.lower(module, ex)` ([#22064], [#24278]).
 
+  * The `DenseArray` abstract type has been deprecated in favor of `AbstractStridedArray` ([#26013]).
+
   * `ones(A::AbstractArray[, opts...])` and `zeros(A::AbstractArray[, opts...])` methods
     have been deprecated. For `zeros(A)`, consider `zero(A)`. For `ones(A)` or `zeros(A)`,
     consider `ones(size(A))`, `zeros(size(A))`, `fill(v, size(A))` for `v` an appropriate

--- a/base/array.jl
+++ b/base/array.jl
@@ -60,8 +60,8 @@ a mathematical matrix. Alias for [`Array{T,2}`](@ref).
 const Matrix{T} = Array{T,2}
 const VecOrMat{T} = Union{Vector{T}, Matrix{T}}
 
-const DenseVector{T} = DenseArray{T,1}
-const DenseMatrix{T} = DenseArray{T,2}
+const DenseVector{T} = AbstractStridedArray{T,1}
+const DenseMatrix{T} = AbstractStridedArray{T,2}
 const DenseVecOrMat{T} = Union{DenseVector{T}, DenseMatrix{T}}
 
 ## Basic functions ##

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -5,7 +5,7 @@
 # notes: bits are stored in contiguous chunks
 #        unused bits must always be set to 0
 """
-    BitArray{N} <: DenseArray{Bool, N}
+    BitArray{N} <: AbstractStridedArray{Bool, N}
 
 Space-efficient `N`-dimensional boolean array, which stores one bit per boolean value.
 """
@@ -1181,8 +1181,8 @@ for f in (:&, :|, :xor)
             Fc[end] &= _msk_end(F)
             return F
         end
-        broadcast(::typeof($f), A::DenseArray{Bool}, B::BitArray) = broadcast($f, BitArray(A), B)
-        broadcast(::typeof($f), B::BitArray, A::DenseArray{Bool}) = broadcast($f, B, BitArray(A))
+        broadcast(::typeof($f), A::AbstractStridedArray{Bool}, B::BitArray) = broadcast($f, BitArray(A), B)
+        broadcast(::typeof($f), B::BitArray, A::AbstractStridedArray{Bool}) = broadcast($f, B, BitArray(A))
     end
 end
 

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -50,9 +50,9 @@
 #const nothing = Nothing()
 
 #abstract type AbstractArray{T,N} end
-#abstract type DenseArray{T,N} <: AbstractArray{T,N} end
+#abstract type AbstractStridedArray{T,N} <: AbstractArray{T,N} end
 
-#mutable struct Array{T,N} <: DenseArray{T,N}
+#mutable struct Array{T,N} <: AbstractStridedArray{T,N}
 #end
 
 #mutable struct Module
@@ -123,7 +123,7 @@ export
     # key types
     Any, DataType, Vararg, ANY, NTuple,
     Tuple, Type, UnionAll, TypeVar, Union, Nothing, Cvoid,
-    AbstractArray, DenseArray, NamedTuple,
+    AbstractArray, AbstractStridedArray, NamedTuple,
     # special objects
     Function, Method,
     Module, Symbol, Task, Array, Uninitialized, uninitialized, WeakRef, VecElement,

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1350,6 +1350,9 @@ end
 
 @deprecate which(s::Symbol) which(Main, s)
 
+# PR #26013
+@deprecate_binding DenseArray AbstractStridedArray
+
 @deprecate IOBuffer(data::AbstractVector{UInt8}, read::Bool, write::Bool=false, maxsize::Integer=typemax(Int)) IOBuffer(data, read=read, write=write, maxsize=maxsize)
 @deprecate IOBuffer(read::Bool, write::Bool) IOBuffer(read=read, write=write)
 @deprecate IOBuffer(maxsize::Integer) IOBuffer(read=true, write=true, maxsize=maxsize)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -217,17 +217,17 @@ include("strings/basic.jl")
 include("strings/string.jl")
 
 # Definition of StridedArray
-StridedReshapedArray{T,N,A<:Union{DenseArray,FastContiguousSubArray}} = ReshapedArray{T,N,A}
-StridedReinterpretArray{T,N,A<:Union{DenseArray,FastContiguousSubArray}} = ReinterpretArray{T,N,S,A} where S
-StridedArray{T,N,A<:Union{DenseArray,StridedReshapedArray},
+StridedReshapedArray{T,N,A<:Union{AbstractStridedArray,FastContiguousSubArray}} = ReshapedArray{T,N,A}
+StridedReinterpretArray{T,N,A<:Union{AbstractStridedArray,FastContiguousSubArray}} = ReinterpretArray{T,N,S,A} where S
+StridedArray{T,N,A<:Union{AbstractStridedArray,StridedReshapedArray},
     I<:Tuple{Vararg{Union{RangeIndex, AbstractCartesianIndex}}}} =
-    Union{DenseArray{T,N}, SubArray{T,N,A,I}, StridedReshapedArray{T,N}, StridedReinterpretArray{T,N,A}}
-StridedVector{T,A<:Union{DenseArray,StridedReshapedArray},
+    Union{AbstractStridedArray{T,N}, SubArray{T,N,A,I}, StridedReshapedArray{T,N}, StridedReinterpretArray{T,N,A}}
+StridedVector{T,A<:Union{AbstractStridedArray,StridedReshapedArray},
     I<:Tuple{Vararg{Union{RangeIndex, AbstractCartesianIndex}}}} =
-    Union{DenseArray{T,1}, SubArray{T,1,A,I}, StridedReshapedArray{T,1}, StridedReinterpretArray{T,1,A}}
-StridedMatrix{T,A<:Union{DenseArray,StridedReshapedArray},
+    Union{AbstractStridedArray{T,1}, SubArray{T,1,A,I}, StridedReshapedArray{T,1}, StridedReinterpretArray{T,1,A}}
+StridedMatrix{T,A<:Union{AbstractStridedArray,StridedReshapedArray},
     I<:Tuple{Vararg{Union{RangeIndex, AbstractCartesianIndex}}}} =
-    Union{DenseArray{T,2}, SubArray{T,2,A,I}, StridedReshapedArray{T,2}, StridedReinterpretArray{T,2,A}}
+    Union{AbstractStridedArray{T,2}, SubArray{T,2,A,I}, StridedReshapedArray{T,2}, StridedReinterpretArray{T,2,A}}
 StridedVecOrMat{T} = Union{StridedVector{T}, StridedMatrix{T}}
 
 # For OS specific stuff

--- a/doc/src/devdocs/types.md
+++ b/doc/src/devdocs/types.md
@@ -99,7 +99,7 @@ UnionAll
       name: Symbol N
       lb: Core.TypeofBottom Union{}
       ub: Any
-    body: Array{T,N} <: DenseArray{T,N}
+    body: Array{T,N} <: AbstractStridedArray{T,N}
 ```
 
 This indicates that `Array` actually names a `UnionAll` type. There is one `UnionAll` type for
@@ -185,7 +185,7 @@ TypeName
         name: Symbol N
         lb: Core.TypeofBottom Union{}
         ub: Any
-      body: Array{T,N} <: DenseArray{T,N}
+      body: Array{T,N} <: AbstractStridedArray{T,N}
   cache: SimpleVector
     ...
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -697,7 +697,7 @@ object returned by *integer* indexing (`A[1, ..., 1]`, when `A` is not empty) an
 the length of the tuple returned by [`size`](@ref). For more details on defining custom
 `AbstractArray` implementations, see the [array interface guide in the interfaces chapter](@ref man-interface-array).
 
-`DenseArray` is an abstract subtype of `AbstractArray` intended to include all arrays that are
+`AbstractStridedArray` is an abstract subtype of `AbstractArray` intended to include all arrays that are
 laid out at regular offsets in memory, and which can therefore be passed to external C and Fortran
 functions expecting this memory layout. Subtypes should provide a [`strides(A)`](@ref) method
 that returns a tuple of "strides" for each dimension; a provided [`stride(A,k)`](@ref) method accesses
@@ -707,7 +707,7 @@ method [`Base.unsafe_convert(Ptr{T}, A)`](@ref) is provided, the memory layout s
 in the same way to these strides. More concrete examples can be found within the [interface guide
 for strided arrays](@ref man-interface-strided-arrays).
 
-The [`Array`](@ref) type is a specific instance of `DenseArray` where elements are stored in column-major
+The [`Array`](@ref) type is a specific instance of `AbstractStridedArray` where elements are stored in column-major
 order (see additional notes in [Performance Tips](@ref man-performance-tips)). [`Vector`](@ref) and [`Matrix`](@ref) are aliases for
 the 1-d and 2-d cases. Specific operations such as scalar indexing, assignment, and a few other
 basic storage-specific operations are all that have to be implemented for [`Array`](@ref), so

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1268,7 +1268,7 @@ void jl_init_primitives(void)
     add_builtin("Task", (jl_value_t*)jl_task_type);
 
     add_builtin("AbstractArray", (jl_value_t*)jl_abstractarray_type);
-    add_builtin("DenseArray", (jl_value_t*)jl_densearray_type);
+    add_builtin("AbstractStridedArray", (jl_value_t*)jl_densearray_type);
     add_builtin("Array", (jl_value_t*)jl_array_type);
 
     add_builtin("Expr", (jl_value_t*)jl_expr_type);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1933,7 +1933,7 @@ void jl_init_types(void)
 
     tv = jl_svec2(tvar("T"), tvar("N"));
     jl_densearray_type = (jl_unionall_t*)
-        jl_new_abstracttype((jl_value_t*)jl_symbol("DenseArray"), core,
+        jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractStridedArray"), core,
                             (jl_datatype_t*)jl_apply_type((jl_value_t*)jl_abstractarray_type, jl_svec_data(tv), 2),
                             tv)->name->wrapper;
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -201,7 +201,7 @@ julia> LinearAlgebra.stride1(B)
 """
 stride1(x) = stride(x,1)
 stride1(x::Array) = 1
-stride1(x::DenseArray) = stride(x, 1)::Int
+stride1(x::AbstractStridedArray) = stride(x, 1)::Int
 
 @inline chkstride1(A...) = _chkstride1(true, A...)
 @noinline _chkstride1(ok::Bool) = ok || error("matrix does not have contiguous columns")

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -319,21 +319,21 @@ for (fname, elty) in ((:cblas_zdotu_sub,:ComplexF64),
     end
 end
 
-function dot(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasReal
+function dot(DX::Union{AbstractStridedArray{T},AbstractVector{T}}, DY::Union{AbstractStridedArray{T},AbstractVector{T}}) where T<:BlasReal
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     end
     GC.@preserve DX DY dot(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
-function dotc(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasComplex
+function dotc(DX::Union{AbstractStridedArray{T},AbstractVector{T}}, DY::Union{AbstractStridedArray{T},AbstractVector{T}}) where T<:BlasComplex
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
     end
     GC.@preserve DX DY dotc(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
-function dotu(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasComplex
+function dotu(DX::Union{AbstractStridedArray{T},AbstractVector{T}}, DY::Union{AbstractStridedArray{T},AbstractVector{T}}) where T<:BlasComplex
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -372,7 +372,7 @@ for (fname, elty, ret_type) in ((:dnrm2_,:Float64,:Float64),
         end
     end
 end
-nrm2(x::Union{AbstractVector,DenseArray}) = GC.@preserve x nrm2(length(x), pointer(x), stride1(x))
+nrm2(x::Union{AbstractVector,AbstractStridedArray}) = GC.@preserve x nrm2(length(x), pointer(x), stride1(x))
 
 ## asum
 
@@ -405,7 +405,7 @@ for (fname, elty, ret_type) in ((:dasum_,:Float64,:Float64),
         end
     end
 end
-asum(x::Union{AbstractVector,DenseArray}) = GC.@preserve x asum(length(x), pointer(x), stride1(x))
+asum(x::Union{AbstractVector,AbstractStridedArray}) = GC.@preserve x asum(length(x), pointer(x), stride1(x))
 
 ## axpy
 
@@ -449,7 +449,7 @@ for (fname, elty) in ((:daxpy_,:Float64),
         end
     end
 end
-function axpy!(alpha::Number, x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where T<:BlasFloat
+function axpy!(alpha::Number, x::Union{AbstractStridedArray{T},StridedVector{T}}, y::Union{AbstractStridedArray{T},StridedVector{T}}) where T<:BlasFloat
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
@@ -513,7 +513,7 @@ for (fname, elty) in ((:daxpby_,:Float64), (:saxpby_,:Float32),
     end
 end
 
-function axpby!(alpha::Number, x::Union{DenseArray{T},AbstractVector{T}}, beta::Number, y::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasFloat
+function axpby!(alpha::Number, x::Union{AbstractStridedArray{T},AbstractVector{T}}, beta::Number, y::Union{AbstractStridedArray{T},AbstractVector{T}}) where T<:BlasFloat
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
@@ -534,7 +534,7 @@ for (fname, elty) in ((:idamax_,:Float64),
         end
     end
 end
-iamax(dx::Union{AbstractVector,DenseArray}) = GC.@preserve dx iamax(length(dx), pointer(dx), stride1(dx))
+iamax(dx::Union{AbstractVector,AbstractStridedArray}) = GC.@preserve dx iamax(length(dx), pointer(dx), stride1(dx))
 
 # Level 2
 ## mv

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -116,7 +116,7 @@ isposdef(x::Number) = imag(x)==0 && real(x) > 0
 # a tuple containing 1 and a cumulative product of the first N-1 sizes
 # this definition is also used for StridedReshapedArray and StridedReinterpretedArray
 # which have the same memory storage as Array
-function stride(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}, i::Int)
+function stride(a::Union{AbstractStridedArray,StridedReshapedArray,StridedReinterpretArray}, i::Int)
     if i > ndims(a)
         return length(a)
     end
@@ -126,7 +126,7 @@ function stride(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray
     end
     return s
 end
-strides(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}) = size_to_strides(1, size(a)...)
+strides(a::Union{AbstractStridedArray,StridedReshapedArray,StridedReinterpretArray}) = size_to_strides(1, size(a)...)
 
 function norm(x::StridedVector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}) where {T<:BlasFloat,TI<:Integer}
     if minimum(rx) < 1 || maximum(rx) > length(x)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -6,8 +6,8 @@ matprod(x, y) = x*y + x*y
 
 # Dot products
 
-vecdot(x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where {T<:BlasReal} = BLAS.dot(x, y)
-vecdot(x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where {T<:BlasComplex} = BLAS.dotc(x, y)
+vecdot(x::Union{AbstractStridedArray{T},StridedVector{T}}, y::Union{AbstractStridedArray{T},StridedVector{T}}) where {T<:BlasReal} = BLAS.dot(x, y)
+vecdot(x::Union{AbstractStridedArray{T},StridedVector{T}}, y::Union{AbstractStridedArray{T},StridedVector{T}}) where {T<:BlasComplex} = BLAS.dotc(x, y)
 
 function dot(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector{T}, ry::Union{UnitRange{TI},AbstractRange{TI}}) where {T<:BlasReal,TI<:Integer}
     if length(rx) != length(ry)

--- a/stdlib/LinearAlgebra/test/lq.jl
+++ b/stdlib/LinearAlgebra/test/lq.jl
@@ -80,7 +80,7 @@ rectangularQ(Q::LinearAlgebra.LQPackedQ) = convert(Array, Q)
                     @test_throws DimensionMismatch q*b[1:n1 + 1]
                     @test_throws DimensionMismatch adjoint(q) * Matrix{eltya}(uninitialized,n+2,n+2)
                     @test_throws DimensionMismatch Matrix{eltyb}(uninitialized,n+2,n+2)*q
-                    if isa(a, DenseArray) && isa(b, DenseArray)
+                    if isa(a, AbstractStridedArray) && isa(b, AbstractStridedArray)
                         # use this to test 2nd branch in mult code
                         pad_a = vcat(I, a)
                         pad_b = hcat(I, b)

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -361,7 +361,7 @@ end
 ##### Array : internal functions
 
 # internal array-like type to circumevent the lack of flexibility with reinterpret
-struct UnsafeView{T} <: DenseArray{T,1}
+struct UnsafeView{T} <: AbstractStridedArray{T,1}
     ptr::Ptr{T}
     len::Int
 end

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -20,7 +20,7 @@ import Base.Filesystem: JL_O_CREAT, JL_O_RDWR, S_IRUSR, S_IWUSR
 
 export SharedArray, SharedVector, SharedMatrix, sdata, indexpids, localindices
 
-mutable struct SharedArray{T,N} <: DenseArray{T,N}
+mutable struct SharedArray{T,N} <: AbstractStridedArray{T,N}
     id::RRID
     dims::NTuple{N,Int}
     pids::Vector{Int}
@@ -476,7 +476,7 @@ end
 
 function show(io::IO, S::SharedArray)
     if length(S.s) > 0
-        invoke(show, Tuple{IO,DenseArray}, io, S)
+        invoke(show, Tuple{IO,AbstractStridedArray}, io, S)
     else
         show(io, remotecall_fetch(sharr->sharr.s, S.pids[1], S))
     end
@@ -484,7 +484,7 @@ end
 
 function show(io::IO, mime::MIME"text/plain", S::SharedArray)
     if length(S.s) > 0
-        invoke(show, Tuple{IO,MIME"text/plain",DenseArray}, io, MIME"text/plain"(), S)
+        invoke(show, Tuple{IO,MIME"text/plain",AbstractStridedArray}, io, MIME"text/plain"(), S)
     else
         # retrieve from the first worker mapping the array.
         println(io, summary(S), ":")

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1822,7 +1822,7 @@ end
 ###
 ### IndexCartesian workout
 ###
-struct LinSlowMatrix{T} <: DenseArray{T,2}
+struct LinSlowMatrix{T} <: AbstractStridedArray{T,2}
     data::Matrix{T}
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -884,7 +884,7 @@ end
 @test sprint(show, Main) == "Main"
 
 @test sprint(Base.show_supertypes, Int64) == "Int64 <: Signed <: Integer <: Real <: Number <: Any"
-@test sprint(Base.show_supertypes, Vector{String}) == "Array{String,1} <: DenseArray{String,1} <: AbstractArray{String,1} <: Any"
+@test sprint(Base.show_supertypes, Vector{String}) == "Array{String,1} <: AbstractStridedArray{String,1} <: AbstractArray{String,1} <: Any"
 
 # static_show
 

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -567,7 +567,7 @@ end
 # issue #18034
 # ensure that it is possible to create an isbits, IndexLinear view of an immutable Array
 let
-    struct ImmutableTestArray{T, N} <: Base.DenseArray{T, N}
+    struct ImmutableTestArray{T, N} <: Base.AbstractStridedArray{T, N}
     end
     Base.size(::Union{ImmutableTestArray, Type{ImmutableTestArray}}) = (0, 0)
     Base.IndexStyle(::Union{ImmutableTestArray, Type{ImmutableTestArray}}) = Base.IndexLinear()


### PR DESCRIPTION
Some of us had discussed on the triage call that the DenseArray name doesn't really convey what it means very well.  This is a shot in the dark at finding a better name for it.  I think the most compelling example is in the documentation changes here:

> `AbstractStridedArray` is an abstract subtype of `AbstractArray` intended to include all arrays that are laid out at regular offsets in memory, and which can therefore be passed to external C and Fortran functions expecting this memory layout.