### PR TITLE
RFC: Simpler array hashing

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2081,11 +2081,11 @@ function hash(A::AbstractArray, h::UInt)
     i = last(I)
     v1 = A[i]
     h = hash(i=>v1, h)
-    i = findprev(x->!isequal(x, v1), A, i)
+    i = let v1=v1; findprev(x->!isequal(x, v1), A, i); end
     i === nothing && return h
     v2 = A[i]
     h = hash(i=>v2, h)
-    i = findprev(x->!isequal(x, v1) && !isequal(x, v2), A, i)
+    i = let v1=v1, v2=v2; findprev(x->!isequal(x, v1) && !isequal(x, v2), A, i); end
     i === nothing && return h
     h = hash(i=>A[i], h)
 
@@ -2096,7 +2096,7 @@ function hash(A::AbstractArray, h::UInt)
     # an evenly divisible size).
     J = vec(I) # Reshape the (potentially cartesian) keys to more efficiently compute the linear skips
     j = LinearIndices(I)[i]
-    fibskip = prevfibskip = 1
+    fibskip = prevfibskip = oneunit(j)
     while j > fibskip
         j -= fibskip
         h = hash(A[J[j]], h)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2111,7 +2111,7 @@ function hash(A::AbstractArray, h::UInt)
         # entirely-distinct 8000-element array will have ~75% of its elements hashed,
         # with every other element hashed in the first half of the array. At the same
         # time, hashing a `typemax(Int64)`-length Float64 range takes about a second.
-        if mod(n, 4096) == 0
+        if rem(n, 4096) == 0
             fibskip, prevfibskip = fibskip + prevfibskip, fibskip
         end
 

--- a/stdlib/Dates/test/ranges.jl
+++ b/stdlib/Dates/test/ranges.jl
@@ -578,4 +578,8 @@ a = Dates.Time(23, 1, 1)
 @test !(π in Date(2017, 01, 01):Dates.Day(1):Date(2017, 01, 05))
 @test !("a" in Date(2017, 01, 01):Dates.Day(1):Date(2017, 01, 05))
 
+@test hash(Any[Date("2018-1-03"), Date("2018-1-04"), Date("2018-1-05")]) ==
+      hash([Date("2018-1-03"), Date("2018-1-04"), Date("2018-1-05")]) ==
+      hash(Date("2018-1-03"):Day(1):Date("2018-1-05"))
+
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2440,7 +2440,7 @@ struct totally_not_five26034 end
 Base.isequal(::totally_not_five26034, x)=isequal(5,x);
 Base.isequal(x, ::totally_not_five26034)=isequal(5,x);
 Base.isequal(::totally_not_five26034, ::totally_not_five26034)=true;
-Base.hash(::totally_not_five26034, h::UInt64)=hash(5, h);
+Base.hash(::totally_not_five26034, h::UInt)=hash(5, h);
 import Base.==
 ==(::totally_not_five26034, x)= (5==x);
 ==(x,::totally_not_five26034)= (5==x);

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2435,6 +2435,25 @@ end
     @test hash([1,2,[3]]) != hash([1,2,[3,4]])
 end
 
+# Ensure we can hash strange custom structs — and they hash the same in arrays
+struct totally_not_five26034 end
+Base.isequal(::totally_not_five26034, x)=isequal(5,x);
+Base.isequal(x, ::totally_not_five26034)=isequal(5,x);
+Base.isequal(::totally_not_five26034, ::totally_not_five26034)=true;
+Base.hash(::totally_not_five26034, h::UInt64)=hash(5, h);
+import Base.==
+==(::totally_not_five26034, x)= (5==x);
+==(x,::totally_not_five26034)= (5==x);
+==(::totally_not_five26034,::totally_not_five26034)=true;
+@testset "issue #26034" begin
+    n5 = totally_not_five26034()
+    @test hash(n5) == hash(5)
+    @test isequal([4,n5,6], [4,5,6])
+    @test isequal(hash([4,n5,6]), hash([4,5,6]))
+    @test isequal(hash(Any[4,n5,6]), hash(Union{Int, totally_not_five26034}[4,5,6]))
+    @test isequal(hash([n5,4,n5,6]), hash([n5,4,5,6]))
+end
+
 function f27079()
     X = rand(5)
     for x in X

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2424,7 +2424,15 @@ end
 end
 
 @testset "inference hash array 22740" begin
-    @inferred hash([1,2,3])
+    @test @inferred(hash([1,2,3])) == @inferred(hash(1:3))
+end
+
+@testset "hashing arrays of arrays" begin
+    # issues #27865 and #26011
+    @test hash([["asd"], ["asd"], ["asad"]]) == hash(Any[["asd"], ["asd"], ["asad"]])
+    @test hash([["asd"], ["asd"], ["asad"]]) != hash([["asd"], ["asd"], ["asadq"]])
+    @test hash([1,2,[3]]) == hash([1,2,Any[3]]) == hash([1,2,Int8[3]]) == hash([1,2,BigInt[3]]) == hash([1,2,[3.0]])
+    @test hash([1,2,[3]]) != hash([1,2,[3,4]])
 end
 
 function f27079()


### PR DESCRIPTION
This is a straw-man implementation of a simpler array hashing scheme.  It's very basic and has room for further optimizations, but it's intention is to provide a starting point as an alternative to JuliaLang/julia#25822.  In short: This hashes the size of the array and then the first three distinct elements and their linear indices and then the last three distinct elements and their linear distance from the end of the array.

The exact scheme here is open to bikeshedding -- we could use more or less distinct elements.  I use "distinct elements" as a way of ensuring that all relatively empty sparse arrays don't hash similarly, and I hash elements at both the beginning and end of the array because they're the simplest to get to and final elements will be the "most expensive" to discover that they differ if we have to fall back to an equality check. The most complicated part is keeping track of what you hashed in order to prevent running through the entire array twice (once forwards and once backwards). 