### PR TITLE
Faster conversion from `NamedTuple` to `Tuple`

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -113,6 +113,15 @@ function convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names}) where {name
     NamedTuple{names,T}(T(nt))
 end
 
+function Tuple(nt::NamedTuple{names}) where {names}
+    if @generated
+        return Expr(:tuple, Any[:(getfield(nt, $(QuoteNode(n)))) for n in names]...)
+    else
+        return tuple(nt...)
+    end
+end
+(::Type{T})(nt::NamedTuple) where {T <: Tuple} = convert(T, Tuple(nt))
+
 function show(io::IO, t::NamedTuple)
     n = nfields(t)
     for i = 1:n


### PR DESCRIPTION
The previous fallback was a generic iterator construction of a `Tuple` which was all kinds of slow... and affected many things like `isequal` and `isless` on named tuples.

Amusingly, this stuff would be simpler if `NamedTuple` were just a `struct` and we used `getproperty` overloading...