### PR TITLE
Adjustable tolerance for nullspace

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1310,9 +1310,13 @@ end
 ## Basis for null space
 
 """
-    nullspace(M)
+    nullspace(M[, tol::Real])
 
-Basis for nullspace of `M`.
+Computes a basis for the nullspace of `M` by including the singular
+vectors of A whose singular have magnitude are greater than `tol*σ₁`,
+where `σ₁` is `A`'s largest singular values. By default, the value of
+`tol` is the largest dimension of `A` multiplied by the [`eps`](@ref)
+of the [`eltype`](@ref) of `A`.
 
 # Examples
 ```jldoctest
@@ -1327,16 +1331,22 @@ julia> nullspace(M)
  0.0
  0.0
  1.0
+
+julia> nullspace(M, 2)
+3×3 Array{Float64,2}:
+ 0.0  1.0  0.0
+ 1.0  0.0  0.0
+ 0.0  0.0  1.0
 ```
 """
-function nullspace(A::StridedMatrix{T}) where T
+function nullspace(A::StridedMatrix, tol::Real = max(size(A)...)*eps(real(float(one(eltype(A))))))
     m, n = size(A)
     (m == 0 || n == 0) && return Matrix{T}(I, n, n)
     SVD = svdfact(A, full = true)
-    indstart = sum(SVD.S .> max(m,n)*maximum(SVD.S)*eps(eltype(SVD.S))) + 1
-    return copy(SVD.Vt[indstart:end,:]')
+    indstart = sum(SVD.S .> SVD.S[1]*tol) + 1
+    return copy(SVD.Vt[indstart:end,:]')    
 end
-nullspace(a::StridedVector) = nullspace(reshape(a, length(a), 1))
+nullspace(a::StridedVector, tol::Real = min(size(A)...)*eps(real(float(one(eltype(A)))))) = nullspace(reshape(a, length(a), 1), tol)
 
 """
     cond(M, p::Real=2)

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1342,7 +1342,7 @@ julia> nullspace(M, 2)
 function nullspace(A::StridedMatrix, tol::Real = max(size(A)...)*eps(real(float(one(eltype(A))))))
     m, n = size(A)
     (m == 0 || n == 0) && return Matrix{T}(I, n, n)
-    SVD = svdfact(A, full = true)
+    SVD = svdfact(A)
     indstart = sum(SVD.S .> SVD.S[1]*tol) + 1
     return copy(SVD.Vt[indstart:end,:]')
 end

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1344,7 +1344,7 @@ function nullspace(A::StridedMatrix, tol::Real = max(size(A)...)*eps(real(float(
     (m == 0 || n == 0) && return Matrix{T}(I, n, n)
     SVD = svdfact(A, full = true)
     indstart = sum(SVD.S .> SVD.S[1]*tol) + 1
-    return copy(SVD.Vt[indstart:end,:]')    
+    return copy(SVD.Vt[indstart:end,:]')
 end
 nullspace(a::StridedVector, tol::Real = min(size(A)...)*eps(real(float(one(eltype(A)))))) = nullspace(reshape(a, length(a), 1), tol)
 

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1342,11 +1342,11 @@ julia> nullspace(M, 2)
 function nullspace(A::StridedMatrix, tol::Real = min(size(A)...)*eps(real(float(one(eltype(A))))))
     m, n = size(A)
     (m == 0 || n == 0) && return Matrix{T}(I, n, n)
-    SVD = svdfact(A)
+    SVD = svdfact(A, full=true)
     indstart = sum(SVD.S .> SVD.S[1]*tol) + 1
     return copy(SVD.Vt[indstart:end,:]')
 end
-nullspace(a::StridedVector, tol::Real = min(size(A)...)*eps(real(float(one(eltype(A)))))) = nullspace(reshape(a, length(a), 1), tol)
+nullspace(a::StridedVector, tol::Real = min(size(a)...)*eps(real(float(one(eltype(a)))))) = nullspace(reshape(a, length(a), 1), tol)
 
 """
     cond(M, p::Real=2)

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1315,7 +1315,7 @@ end
 Computes a basis for the nullspace of `M` by including the singular
 vectors of A whose singular have magnitude are greater than `tol*σ₁`,
 where `σ₁` is `A`'s largest singular values. By default, the value of
-`tol` is the largest dimension of `A` multiplied by the [`eps`](@ref)
+`tol` is the smallest dimension of `A` multiplied by the [`eps`](@ref)
 of the [`eltype`](@ref) of `A`.
 
 # Examples
@@ -1339,7 +1339,7 @@ julia> nullspace(M, 2)
  0.0  0.0  1.0
 ```
 """
-function nullspace(A::StridedMatrix, tol::Real = max(size(A)...)*eps(real(float(one(eltype(A))))))
+function nullspace(A::StridedMatrix, tol::Real = min(size(A)...)*eps(real(float(one(eltype(A))))))
     m, n = size(A)
     (m == 0 || n == 0) && return Matrix{T}(I, n, n)
     SVD = svdfact(A)

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -72,7 +72,9 @@ bimg  = randn(n,2)/2
                 @test norm(a[:,1:n1]'a15null,Inf) ≈ zero(eltya) atol=300ε
                 @test norm(a15null'a[:,1:n1],Inf) ≈ zero(eltya) atol=400ε
                 @test size(nullspace(b), 2) == 0
+                @test size(nullspace(b, 100*eps(eltyb)), 2) == 0
                 @test nullspace(zeros(eltya,n)) == Matrix(I, 1, 1)
+                @test nullspace(zeros(eltya,n), 0.1) == Matrix(I, 1, 1)
             end
         end
     end # for eltyb

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -72,7 +72,7 @@ bimg  = randn(n,2)/2
                 @test norm(a[:,1:n1]'a15null,Inf) ≈ zero(eltya) atol=300ε
                 @test norm(a15null'a[:,1:n1],Inf) ≈ zero(eltya) atol=400ε
                 @test size(nullspace(b), 2) == 0
-                @test size(nullspace(b, 100*eps(eltyb)), 2) == 0
+                @test size(nullspace(b, 100*εb), 2) == 0
                 @test nullspace(zeros(eltya,n)) == Matrix(I, 1, 1)
                 @test nullspace(zeros(eltya,n), 0.1) == Matrix(I, 1, 1)
             end


### PR DESCRIPTION
Allow an optional `Tol` argument, like in `rank`.

I kept the original behavior, whose tolerance is `max(m,n)*eps*max(svdvals)`. This is different than `rank`, which uses `min(m,n)*eps*max(svdvals)`. Not sure which is best, but they should at least match.