### PR TITLE
clarify that eps(T) is dimensionless

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -761,7 +761,8 @@ realmax() = realmax(Float64)
 
 Return the *machine epsilon* of the floating point type `T` (`T = Float64` by
 default). This is defined as the gap between 1 and the next largest value representable by
-`T`, and is equivalent to `eps(one(T))`.
+`typeof(one(T))`, and is equivalent to `eps(one(T))`.  (Since `eps(T)` is a
+bound on the *relative error* of `T`, it is a "dimensionless" quantity like [`one`](@ref).)
 
 ```jldoctest
 julia> eps()


### PR DESCRIPTION
Although the previous docs implied this by saying it is equivalent to `eps(one(T))`, they weren't as clear as they could have been.

See also ajkeller34/Unitful.jl#121