### PR TITLE
Fix NamedTuple fallback constructor

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -522,7 +522,8 @@ function NamedTuple{names,T}(args::T) where {names, T <: Tuple}
             arrayset(false, flds, getfield(args, i), i)
             i = add_int(i, 1)
         end
-        ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), NT, fields, N)::NT
+        ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), NT,
+              ccall(:jl_array_ptr, Ptr{Cvoid}, (Any,), flds), toUInt32(N))::NT
     end
 end
 

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -106,10 +106,10 @@ isempty(::NamedTuple) = false
 promote_typejoin(::Type{NamedTuple{n, S}}, ::Type{NamedTuple{n, T}}) where {n, S, T} =
     NamedTuple{n, promote_typejoin(S, T)}
 
-convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names,T}) where {names,T} = nt
+convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names,T}) where {names,T<:Tuple} = nt
 convert(::Type{NamedTuple{names}}, nt::NamedTuple{names}) where {names} = nt
 
-function convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names}) where {names,T}
+function convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names}) where {names,T<:Tuple}
     NamedTuple{names,T}(T(nt))
 end
 


### PR DESCRIPTION
Fix a typo that breaks things if inference decides it needs NamedTuples during inference.