### PR TITLE
Fix incorrect function name in deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1318,7 +1318,7 @@ export readandwrite
 # PR 25458
 @deprecate endof(a) lastindex(a)
 function firstindex(a)
-    depwarn("if appropriate you should implement `firstindex` for type $(typeof(a)), which might just return 1", :beginof)
+    depwarn("if appropriate you should implement `firstindex` for type $(typeof(a)), which might just return 1", :firstindex)
     1
 end
 


### PR DESCRIPTION
Appears to be a leftover from the name change during discussion in #25458.