### PR TITLE
Clarification of repeated keyword argument rule

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -539,7 +539,9 @@ at runtime.
 The nature of keyword arguments makes it possible to specify the same argument more than once.
 For example, in the call `plot(x, y; options..., width=2)` it is possible that the `options` structure
 also contains a value for `width`. In such a case the rightmost occurrence takes precedence; in
-this example, `width` is certain to have the value `2`.
+this example, `width` is certain to have the value `2`. However, it is not allowed to pass the same
+keyword argument more than once using assignment expression. For example `plot(x, y, width=2, width=3)`
+throws a syntax error.
 
 ## Evaluation Scope of Default Values
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -539,9 +539,9 @@ at runtime.
 The nature of keyword arguments makes it possible to specify the same argument more than once.
 For example, in the call `plot(x, y; options..., width=2)` it is possible that the `options` structure
 also contains a value for `width`. In such a case the rightmost occurrence takes precedence; in
-this example, `width` is certain to have the value `2`. However, it is not allowed to pass the same
-keyword argument more than once using assignment expression. For example `plot(x, y, width=2, width=3)`
-throws a syntax error.
+this example, `width` is certain to have the value `2`. However, explicitly specifying the same keyword
+argument multiple times, for example `plot(x, y, width=2, width=3)`, is not allowed and results in
+a syntax error.
 
 ## Evaluation Scope of Default Values
 


### PR DESCRIPTION
Currently the Julia Manual states that repeating the same keyword argument is allowed, but it is not the case for calls using assignment expressions:

```
julia> f(;x=1) = x
f (generic function with 1 method)

julia> f(x=1,x=2)
ERROR: syntax: keyword argument "x" repeated in call to "f"
```