### PR TITLE
stop calling `supertype` in type trait functions

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -138,8 +138,7 @@ julia> ndims(A)
 ```
 """
 ndims(::AbstractArray{T,N}) where {T,N} = N
-ndims(::Type{AbstractArray{T,N}}) where {T,N} = N
-ndims(::Type{T}) where {T<:AbstractArray} = ndims(supertype(T))
+ndims(::Type{<:AbstractArray{T,N}}) where {T,N} = N
 
 """
     length(collection) -> Integer

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -242,9 +242,8 @@ julia> keytype(Dict(Int32(1) => "foo"))
 Int32
 ```
 """
-keytype(::Type{AbstractDict{K,V}}) where {K,V} = K
+keytype(::Type{<:AbstractDict{K,V}}) where {K,V} = K
 keytype(a::AbstractDict) = keytype(typeof(a))
-keytype(::Type{A}) where {A<:AbstractDict} = keytype(supertype(A))
 
 """
     valtype(type)
@@ -257,8 +256,7 @@ julia> valtype(Dict(Int32(1) => "foo"))
 String
 ```
 """
-valtype(::Type{AbstractDict{K,V}}) where {K,V} = V
-valtype(::Type{A}) where {A<:AbstractDict} = valtype(supertype(A))
+valtype(::Type{<:AbstractDict{K,V}}) where {K,V} = V
 valtype(a::AbstractDict) = valtype(typeof(a))
 
 """
@@ -447,7 +445,19 @@ function filter(f, d::AbstractDict)
     return df
 end
 
-eltype(::Type{AbstractDict{K,V}}) where {K,V} = Pair{K,V}
+function eltype(::Type{<:AbstractDict{K,V}}) where {K,V}
+    if @isdefined(K)
+        if @isdefined(V)
+            return Pair{K,V}
+        else
+            return Pair{K}
+        end
+    elseif @isdefined(V)
+        return Pair{k,V} where k
+    else
+        return Pair
+    end
+end
 
 function isequal(l::AbstractDict, r::AbstractDict)
     l === r && return true

--- a/base/array.jl
+++ b/base/array.jl
@@ -87,7 +87,6 @@ UInt8
 eltype(::Type) = Any
 eltype(::Type{Any}) = Any
 eltype(::Type{Bottom}) = throw(ArgumentError("Union{} does not have elements"))
-eltype(t::DataType) = eltype(supertype(t))
 eltype(x) = eltype(typeof(x))
 
 import Core: arraysize, arrayset, arrayref

--- a/base/set.jl
+++ b/base/set.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-eltype(::Type{AbstractSet{T}}) where {T} = T
+eltype(::Type{<:AbstractSet{T}}) where {T} = @isdefined(T) ? T : Any
 
 mutable struct Set{T} <: AbstractSet{T}
     dict::Dict{T,Nothing}

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -4,7 +4,7 @@
 
 abstract type Factorization{T} end
 
-eltype(::Type{Factorization{T}}) where {T} = T
+eltype(::Type{<:Factorization{T}}) where {T} = T
 size(F::Adjoint{<:Any,<:Factorization}) = reverse(size(parent(F)))
 size(F::Transpose{<:Any,<:Factorization}) = reverse(size(parent(F)))
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -95,7 +95,7 @@ const BitFloatType = Union{Type{Float16},Type{Float32},Type{Float64}}
 
 abstract type Sampler{E} end
 
-Base.eltype(::Type{Sampler{E}}) where {E} = E
+Base.eltype(::Type{<:Sampler{E}}) where {E} = E
 
 # temporarily for BaseBenchmarks
 RangeGenerator(x) = Sampler(GLOBAL_RNG, x)


### PR DESCRIPTION
These cases should now use "triangular" dispatch instead.

Also improve `eltype` of `AbstractDict` while we're at it.