### PR TITLE
Fix compiler warning and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,24 +177,31 @@ CORE_SRCS := $(addprefix $(JULIAHOME)/, \
 		base/boot.jl \
 		base/docs/core.jl \
 		base/abstractarray.jl \
-		base/array.jl \
-		base/bool.jl \
 		base/abstractdict.jl \
+		base/array.jl \
+		base/bitarray.jl \
+		base/bitset.jl \
+		base/bool.jl \
+		base/ctypes.jl \
 		base/error.jl \
 		base/essentials.jl \
-		base/generator.jl \
 		base/expr.jl \
+		base/generator.jl \
 		base/hashing.jl \
 		base/int.jl \
-		base/bitset.jl \
+		base/indices.jl \
+		base/iterators.jl \
+		base/namedtuple.jl \
 		base/number.jl \
 		base/operators.jl \
 		base/options.jl \
+		base/pair.jl \
 		base/pointer.jl \
 		base/promotion.jl \
 		base/range.jl \
 		base/reduce.jl \
 		base/reflection.jl \
+		base/traits.jl \
 		base/tuple.jl)
 COMPILER_SRCS = $(sort $(shell find $(JULIAHOME)/base/compiler -name \*.jl))
 BASE_SRCS := $(sort $(shell find $(JULIAHOME)/base -name \*.jl) $(shell find $(BUILDROOT)/base -name \*.jl))

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -113,14 +113,16 @@ function convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names}) where {name
     NamedTuple{names,T}(T(nt))
 end
 
-function Tuple(nt::NamedTuple{names}) where {names}
-    if @generated
-        return Expr(:tuple, Any[:(getfield(nt, $(QuoteNode(n)))) for n in names]...)
-    else
-        return tuple(nt...)
+if nameof(@__MODULE__) === :Base
+    function Tuple(nt::NamedTuple{names}) where {names}
+        if @generated
+            return Expr(:tuple, Any[:(getfield(nt, $(QuoteNode(n)))) for n in names]...)
+        else
+            return tuple(nt...)
+        end
     end
+    (::Type{T})(nt::NamedTuple) where {T <: Tuple} = convert(T, Tuple(nt))
 end
-(::Type{T})(nt::NamedTuple) where {T <: Tuple} = convert(T, Tuple(nt))
 
 function show(io::IO, t::NamedTuple)
     n = nfields(t)


### PR DESCRIPTION
Some accelerated `@generated` methods for converting `NamedTuple` to `Tuple` from #26025 are excluded from compiler compilation.

Also, the Makefile was quite stale in terms of tracking which files are used by the compiler compilation step. I added several and removed `hashing.jl` from the list. I'm surprised that no-one has had strange compilation problems recently.

Does anyone know why we have `hashing.jl` and `hashing2.jl`? I assumed one was safe/needed for the first compilation step and the second was evaluated for the final system image, but `hashing.jl` doesn't appear to be a dependency of the compiler.