### PR TITLE
test-cmdlineargs: avoid dependence on posix programs

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -438,7 +438,7 @@ end
 function setup_stdio(stdio::PipeEndpoint, child_readable::Bool)
     if stdio.status == StatusInit
         rd, wr = link_pipe(!child_readable, child_readable)
-        open_pipe!(stdio, child_readable ? wr : rd)
+        open_pipe!(stdio, child_readable ? wr : rd, !child_readable, child_readable)
         return (child_readable ? rd : wr, true)
     end
     return (stdio, false)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -2,21 +2,28 @@
 
 import Libdl
 
-catcmd = `cat`
-echocmd = `echo`
-if Sys.iswindows()
-    busybox = joinpath(Sys.BINDIR, "busybox.exe")
-    havebb = try # use busybox-w32 on windows
-        success(`$busybox`)
-        true
-    catch
-        false
+# helper function for passing input to stdin
+# and returning the stdout result
+function writereadpipeline(input, exename)
+    p = open(exename, "w+")
+    @async begin
+        write(p.in, input)
+        close(p.in)
     end
-    if havebb
-        catcmd = `$busybox cat`
-        echocmd = `$busybox echo`
-    end
+    return read(p.out, String)
 end
+
+# helper function for returning stderr and stdout
+# from running a command (ignoring failure status)
+function readchomperrors(exename::Cmd)
+    out = Base.PipeEndpoint()
+    err = Base.PipeEndpoint()
+    p = spawn(exename, DevNull, out, err)
+    o = @async(readchomp(out))
+    e = @async(readchomp(err))
+    return (success(p), fetch(o), fetch(e))
+end
+
 
 let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     # --version
@@ -226,25 +233,11 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
 
         @test !success(`$exename -E "$code" --depwarn=error`)
 
-        let out  = Pipe(),
-            proc = spawn(pipeline(`$exename -E "$code" --depwarn=yes`, stderr=out)),
-            output = @async readchomp(out)
+        @test readchomperrors(`$exename -E "$code" --depwarn=yes`) ==
+            (true, "true", "WARNING: Foo.Deprecated is deprecated, use NotDeprecated instead.\n  likely near no file:5")
 
-            close(out.in)
-            wait(proc)
-            @test success(proc)
-            @test fetch(output) == "WARNING: Foo.Deprecated is deprecated, use NotDeprecated instead.\n  likely near no file:5"
-        end
-
-        let out  = Pipe(),
-            proc = spawn(pipeline(`$exename -E "$code" --depwarn=no`, stderr=out))
-            output = @async read(out, String)
-
-            wait(proc)
-            close(out.in)
-            @test success(proc)
-            @test fetch(output) == ""
-        end
+        @test readchomperrors(`$exename -E "$code" --depwarn=no`) ==
+            (true, "true", "")
     end
 
     # --inline
@@ -353,14 +346,14 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     @test readchomp(`$exename -e 'println(ARGS);' ''`) == "[\"\"]"
 
     # issue #12679
-    @test readchomp(pipeline(ignorestatus(`$exename --startup-file=no --compile=yes -ioo`),
-        stderr=catcmd)) == "ERROR: unknown option `-o`"
-    @test readchomp(pipeline(ignorestatus(`$exename --startup-file=no -p`),
-        stderr=catcmd)) == "ERROR: option `-p/--procs` is missing an argument"
-    @test readchomp(pipeline(ignorestatus(`$exename --startup-file=no --inline`),
-        stderr=catcmd)) == "ERROR: option `--inline` is missing an argument"
-    @test readchomp(pipeline(ignorestatus(`$exename --startup-file=no -e "@show ARGS" -now -- julia RUN.jl`),
-        stderr=catcmd)) == "ERROR: unknown option `-n`"
+    @test readchomperrors(`$exename --startup-file=no --compile=yes -ioo`) ==
+        (false, "", "ERROR: unknown option `-o`")
+    @test readchomperrors(`$exename --startup-file=no -p`) ==
+        (false, "", "ERROR: option `-p/--procs` is missing an argument")
+    @test readchomperrors(`$exename --startup-file=no --inline`) ==
+        (false, "", "ERROR: option `--inline` is missing an argument")
+    @test readchomperrors(`$exename --startup-file=no -e "@show ARGS" -now -- julia RUN.jl`) ==
+        (false, "", "ERROR: unknown option `-n`")
 
     # --compiled-modules={yes|no}
     @test readchomp(`$exename -E "Bool(Base.JLOptions().use_compiled_modules)"`) == "true"
@@ -439,8 +432,8 @@ end
 run(pipeline(DevNull, `$(joinpath(Sys.BINDIR, Base.julia_exename())) --lisp`, DevNull))
 
 # Test that `julia [some other option] --lisp` is disallowed
-@test_throws ErrorException run(pipeline(DevNull, pipeline(`$(joinpath(Sys.BINDIR,
-    Base.julia_exename())) -Cnative --lisp`, stderr=DevNull), DevNull))
+@test readchomperrors(`$(joinpath(Sys.BINDIR, Base.julia_exename())) -Cnative --lisp`) ==
+    (false, "", "ERROR: --lisp must be specified as the first argument")
 
 # --sysimage-native-code={yes|no}
 let exename = `$(Base.julia_cmd()) --startup-file=no`
@@ -452,8 +445,10 @@ end
 
 # backtrace contains type and line number info (esp. on windows #17179)
 for precomp in ("yes", "no")
-    bt = read(pipeline(ignorestatus(`$(Base.julia_cmd()) --startup-file=no --sysimage-native-code=$precomp
-        -E 'include("____nonexistent_file")'`), stderr=catcmd), String)
+    success, out, bt = readchomperrors(`$(Base.julia_cmd()) --startup-file=no --sysimage-native-code=$precomp
+        -E 'include("____nonexistent_file")'`)
+    @test !success
+    @test out == ""
     @test contains(bt, "include_relative(::Module, ::String) at $(joinpath(".", "loading.jl"))")
     lno = match(r"at \.[\/\\]loading\.jl:(\d+)", bt)
     @test length(lno.captures) == 1
@@ -489,11 +484,11 @@ end
 
 # issue #6310
 let exename = `$(Base.julia_cmd()) --startup-file=no`
-    @test read(pipeline(`$echocmd $"2+2"`, exename), String) == "4\n"
-    @test read(pipeline(`$echocmd $"2+2\n3+3\n4+4"`, exename), String) == "4\n6\n8\n"
-    @test read(pipeline(`$echocmd $""`, exename), String) == ""
-    @test read(pipeline(`$echocmd $"print(2)"`, exename), String) == "2"
-    @test read(pipeline(`$echocmd $"print(2)\nprint(3)"`, exename), String) == "23"
+    @test writereadpipeline("2+2", exename) == "4\n"
+    @test writereadpipeline("2+2\n3+3\n4+4", exename) == "4\n6\n8\n"
+    @test writereadpipeline("", exename) == ""
+    @test writereadpipeline("print(2)", exename) == "2"
+    @test writereadpipeline("print(2)\nprint(3)", exename) == "23"
     let infile = tempname()
         touch(infile)
         try


### PR DESCRIPTION
We can use some simple helper functions for the same result.
This avoids breakage for when a program like cygwin echo.exe
refuses to handle `\n` transparently