### PR TITLE
RFC: Faster methods for tuple comparison and hash

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -289,12 +289,30 @@ function _eq(t1::Any16, t2::Any16, anymissing)
 end
 
 const tuplehash_seed = UInt === UInt64 ? 0x77cfa1eef01bca90 : 0xf01bca90
-hash( ::Tuple{}, h::UInt)        = h + tuplehash_seed
-hash(x::Tuple{Any,}, h::UInt)    = hash(x[1], hash((), h))
-hash(x::Tuple{Any,Any}, h::UInt) = hash(x[1], hash(x[2], hash((), h)))
-hash(x::Tuple, h::UInt)          = hash(x[1], hash(x[2], hash(tail(tail(x)), h)))
+hash(::Tuple{}, h::UInt) = h + tuplehash_seed
+hash(t::Tuple, h::UInt) = hash(t[1], hash(tail(t), h))
+function hash(t::Any16, h::UInt)
+    out = h + tuplehash_seed
+    for i = length(t):-1:1
+        out = hash(t[i], out)
+    end
+    return out
+end
 
+<(::Tuple{}, ::Tuple{}) = false
+<(::Tuple{}, ::Tuple) = true
+<(::Tuple, ::Tuple{}) = false
 function <(t1::Tuple, t2::Tuple)
+    a, b = t1[1], t2[1]
+    eq = (a == b)
+    if ismissing(eq)
+        return missing
+    elseif !eq
+        return a < b
+    end
+    return tail(t1) < tail(t2)
+end
+function <(t1::Any16, t2::Any16)
     n1, n2 = length(t1), length(t2)
     for i = 1:min(n1, n2)
         a, b = t1[i], t2[i]
@@ -308,7 +326,14 @@ function <(t1::Tuple, t2::Tuple)
     return n1 < n2
 end
 
+isless(::Tuple{}, ::Tuple{}) = false
+isless(::Tuple{}, ::Tuple) = true
+isless(::Tuple, ::Tuple{}) = false
 function isless(t1::Tuple, t2::Tuple)
+    a, b = t1[1], t2[1]
+    isless(a, b) || (isequal(a, b) && isless(tail(t1), tail(t2)))
+end
+function isless(t1::Any16, t2::Any16)
     n1, n2 = length(t1), length(t2)
     for i = 1:min(n1, n2)
         a, b = t1[i], t2[i]

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -233,7 +233,7 @@ end
     end
 end
 
-@testset "comparison" begin
+@testset "comparison and hash" begin
     @test isequal((), ())
     @test isequal((1,2,3), (1,2,3))
     @test !isequal((1,2,3), (1,2,4))
@@ -253,8 +253,33 @@ end
     @test isless((1,), (1,2))
     @test !isless((1,2), (1,2))
     @test !isless((2,1), (1,2))
-end
 
+    @test hash(()) === Base.tuplehash_seed
+    @test hash((1,)) === hash(1, Base.tuplehash_seed)
+    @test hash((1,2)) === hash(1, hash(2, Base.tuplehash_seed))
+
+    # Test Any16 methods
+    t = ntuple(identity, 16)
+    @test isequal((t...,1,2,3), (t...,1,2,3))
+    @test !isequal((t...,1,2,3), (t...,1,2,4))
+    @test !isequal((t...,1,2,3), (t...,1,2))
+
+    @test ==((t...,1,2,3), (t...,1,2,3))
+    @test !==((t...,1,2,3), (t...,1,2,4))
+    @test !==((t...,1,2,3), (t...,1,2))
+
+    @test (t...,1,2) < (t...,1,3)
+    @test (t...,1,) < (t...,1,2)
+    @test !((t...,1,2) < (t...,1,2))
+    @test (t...,2,1) > (t...,1,2)
+
+    @test isless((t...,1,2), (t...,1,3))
+    @test isless((t...,1,), (t...,1,2))
+    @test !isless((t...,1,2), (t...,1,2))
+    @test !isless((t...,2,1), (t...,1,2))
+
+    @test hash(t) === foldr(hash, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,(),UInt(0)])
+end
 
 @testset "functions" begin
     @test isempty(())


### PR DESCRIPTION
~~`isequal(::Tuple, ::Tuple)` previously used recursion, which got slow for tuples greater than size 14 (and if I understand correctly, this kind of recursion is not O(N) for very large tuples). Now it is fully unrolled generated code (when `if @generated`, otherwise it follows a `for` loop).~~

`isless(::Tuple, ::Tuple)` previously used a for loop in all cases, which is OK for the homogenous element types case but much slower otherwise. Now it is unrolled via recursion (for small tuples only). A similar approach is implemented for `<` and `hash`.

~~While some might see this as a bit "heavy", I think we need this kind of stuff for nice, generic, speedy operations on e.g. simple tables which are collections of `Tuples` and `NamedTuples`.~~ Recursion seems okay-ish at first but my limited understanding is that it won't always act O(N) for very large tuples.

Follow-up of #26025. What motivated both PR's was a slow `sortperm(::AbstractVector{<:NamedTuple})` and other operations you might want on sorted "table"-like data structures - @shashi, @JeffBezanson I'd be curious how the generic methods in `Base` for `sortperm` and `searchsorted` now compare to the (optimized) algorithms used in `IndexedTables`.

~~We might want to do something for `==` and `<` in the future for very similar reasons (FYI @nalimilan). Possibly also `hash`.~~ We might want to do something similar for `sum` and `prod`.