### PR TITLE
Correct pointer(::AbstractArray, i) to use strides, deprecate elsize(::AbstractArray)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -122,7 +122,13 @@ prevind(::AbstractArray, i::Integer) = Int(i)-1
 nextind(::AbstractArray, i::Integer) = Int(i)+1
 
 eltype(::Type{<:AbstractArray{E}}) where {E} = @isdefined(E) ? E : Any
-elsize(::AbstractArray{T}) where {T} = sizeof(T)
+
+"""
+    Base.elsize(::Type{<:CustomArray})
+
+Return the distance (in bytes) between two successive elements with stride 1.
+"""
+elsize(a::AbstractArray) = elsize(typeof(a))
 
 """
     ndims(A::AbstractArray) -> Integer
@@ -270,6 +276,8 @@ stride(A::AbstractArray, k::Integer) = strides(A)[k]
 size_to_strides(s, d) = (s,)
 size_to_strides(s) = ()
 
+strides(a::DenseArray) = size_to_strides(1, size(a)...)
+stride(a::DenseArray, k::Integer) = ifelse(k == 1, 1, k == 2 ? size(a, 1) : strides(a)[k])
 
 function isassigned(a::AbstractArray, i::Int...)
     try

--- a/base/array.jl
+++ b/base/array.jl
@@ -136,7 +136,7 @@ function bitsunionsize(u::Union)
 end
 
 length(a::Array) = arraylen(a)
-elsize(a::Array{T}) where {T} = isbits(T) ? sizeof(T) : (isbitsunion(T) ? bitsunionsize(T) : sizeof(Ptr))
+elsize(::Type{<:Array{T}}) where {T} = isbits(T) ? sizeof(T) : (isbitsunion(T) ? bitsunionsize(T) : sizeof(Ptr))
 sizeof(a::Array) = Core.sizeof(a)
 
 function isassigned(a::Array, i::Int...)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1165,6 +1165,17 @@ end
 
 @deprecate substrides(s, parent, dim, I::Tuple) substrides(parent, strides(parent), I)
 
+# Issue #26072 Also remove default Base.eltype implementation
+function elsize(t::Type{<:AbstractArray{T}}) where T
+    depwarn("""
+    `Base.elsize(::Type{<:AbstractArray})` is deprecated for general arrays.
+    Specialize `Base.elsize(::Type{<:$(t.name)})` for that has the appropriate
+    representation in memory such that it represents the distance between a unit-stride.
+    Warning: inappropriately implementing this method may lead to incorrect results or segfaults.
+    """, :elsize)
+    sizeof(T)
+end
+
 @deprecate lexcmp(x::AbstractArray, y::AbstractArray) cmp(x, y)
 @deprecate lexcmp(x::Real, y::Real)                   cmp(isless, x, y)
 @deprecate lexcmp(x::Complex, y::Complex)             cmp((real(x),imag(x)), (real(y),imag(y)))

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -44,6 +44,13 @@ function size(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
 end
 
 unsafe_convert(::Type{Ptr{T}}, a::ReinterpretArray{T,N,S} where N) where {T,S} = Ptr{T}(unsafe_convert(Ptr{S},a.parent))
+function strides(a::ReinterpretArray{T,<:Any,S}) where {T,S}
+    pstrides = strides(a.parent)
+    (pstrides[1], _muldiv(sizeof(S), sizeof(T), tail(pstrides))...)
+end
+_muldiv(num,den,::Tuple{}) = ()
+_muldiv(num,den,t::Tuple) = (div(t[1]*num, den), _muldiv(num, den, tail(t))...)
+elsize(::Type{<:ReinterpretArray{T}}) where {T} = sizeof(T)
 
 @inline @propagate_inbounds getindex(a::ReinterpretArray{T,0}) where {T} = reinterpret(T, a.parent[])
 @inline @propagate_inbounds getindex(a::ReinterpretArray) = a[1]

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -179,6 +179,8 @@ IndexStyle(::Type{<:ReshapedArrayLF}) = IndexLinear()
 parent(A::ReshapedArray) = A.parent
 parentindices(A::ReshapedArray) = map(s->1:s, size(parent(A)))
 reinterpret(::Type{T}, A::ReshapedArray, dims::Dims) where {T} = reinterpret(T, parent(A), dims)
+strides(a::ReshapedArray{<:Any,<:Any,<:Union{DenseArray,FastContiguousSubArray}}) = size_to_strides(1, size(a)...)
+elsize(::Type{<:ReshapedArray{<:Any,<:Any,P}}) where {P} = elsize(P)
 
 @inline ind2sub_rs(::Tuple{}, i::Int) = i
 @inline ind2sub_rs(strds, i) = _ind2sub_rs(strds, i - 1)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -644,6 +644,7 @@ length(s::CodeUnits) = ncodeunits(s.s)
 sizeof(s::CodeUnits{T}) where {T} = ncodeunits(s.s) * sizeof(T)
 size(s::CodeUnits) = (length(s),)
 strides(s::CodeUnits) = (1,)
+elsize(s::CodeUnits{T}) where {T} = sizeof(T)
 @propagate_inbounds getindex(s::CodeUnits, i::Int) = codeunit(s.s, i)
 IndexStyle(::Type{<:CodeUnits}) = IndexLinear()
 start(s::CodeUnits) = 1

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -273,6 +273,9 @@ compute_stride1(s, inds, I::Tuple{AbstractRange, Vararg{Any}}) = s*step(I[1])
 compute_stride1(s, inds, I::Tuple{Slice, Vararg{Any}}) = s
 compute_stride1(s, inds, I::Tuple{Any, Vararg{Any}}) = throw(ArgumentError("invalid strided index type $(typeof(I[1]))"))
 
+# And elsize determines the scaling of those strides
+elsize(::Type{<:SubArray{<:Any,<:Any,P}}) where {P} = elsize(P)
+
 iscontiguous(A::SubArray) = iscontiguous(typeof(A))
 iscontiguous(::Type{<:SubArray}) = false
 iscontiguous(::Type{<:FastContiguousSubArray}) = true

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -112,22 +112,6 @@ true
 isposdef(A::AbstractMatrix) = ishermitian(A) && isposdef(cholfact(Hermitian(A)))
 isposdef(x::Number) = imag(x)==0 && real(x) > 0
 
-# the definition of strides for Array{T,N} is tuple() if N = 0, otherwise it is
-# a tuple containing 1 and a cumulative product of the first N-1 sizes
-# this definition is also used for StridedReshapedArray and StridedReinterpretedArray
-# which have the same memory storage as Array
-function stride(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}, i::Int)
-    if i > ndims(a)
-        return length(a)
-    end
-    s = 1
-    for n = 1:(i-1)
-        s *= size(a, n)
-    end
-    return s
-end
-strides(a::Union{DenseArray,StridedReshapedArray,StridedReinterpretArray}) = size_to_strides(1, size(a)...)
-
 function norm(x::StridedVector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}) where {T<:BlasFloat,TI<:Integer}
     if minimum(rx) < 1 || maximum(rx) > length(x)
         throw(BoundsError(x, rx))

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -371,6 +371,8 @@ Base.getindex(a::UnsafeView, i::Int) = unsafe_load(a.ptr, i)
 Base.setindex!(a::UnsafeView, x, i::Int) = unsafe_store!(a.ptr, x, i)
 Base.pointer(a::UnsafeView) = a.ptr
 Base.size(a::UnsafeView) = (a.len,)
+Base.strides(a::UnsafeView) = (1,)
+Base.elsize(a::UnsafeView{T}) where {T} = sizeof(T)
 
 # this is essentially equivalent to rand!(r, ::AbstractArray{Float64}, I) above, but due to
 # optimizations which can't be done currently when working with pointers, we have to re-order


### PR DESCRIPTION
Previously, `pointer` was erroneously calculating memory offsets based upon `linearindices` instead of `strides` and `Base.elsize`.  This corrects it.  This is a bug-fix for StridedArrays that did not have contiguous strides, and arrays that do not specialize `strides` will see the same behavior but with a deprecation warning that the fallback `strides` implementation (that assumes contiguous strides) is deprecated.

Edit: I've now also deprecated the fallback `elsize` instead of coercing `Array`'s definition onto everyone.