### PR TITLE
call `realpath` on `/etc/alternatives/editor` so we can tell which editor it is

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -16,7 +16,7 @@ function editor()
     if Sys.iswindows() || Sys.isapple()
         default_editor = "open"
     elseif isfile("/etc/alternatives/editor")
-        default_editor = "/etc/alternatives/editor"
+        default_editor = realpath("/etc/alternatives/editor")
     else
         default_editor = "emacs"
     end


### PR DESCRIPTION
On my system `editor()` and `edit()` use `/etc/alternatives/editor`. Currently that makes us think the editor name is `editor`, based on the filename. That prevents us from knowing how to pass the line number. This fixes it by calling `readlink` to see which editor is actually referenced.