### PR TITLE
Deprecate showcompact()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1093,7 +1093,11 @@ Deprecated or removed
   * `DevNull`, `STDIN`, `STDOUT`, and `STDERR` have been renamed to `devnull`, `stdin`, `stdout`,
     and `stderr`, respectively ([#25786]).
 
-  * `wait` and `fetch` on `Task` now resemble the interface of `Future`
+  * `wait` and `fetch` on `Task` now resemble the interface of `Future`.
+
+  * `showcompact(io, x...)` has been deprecated in favor of
+    `show(IOContext(io, :compact => true), x...)` ([#26080]).
+    Use `sprint(show, x..., context=:compact => true)` instead of `sprint(showcompact, x...)`.
 
 Command-line option changes
 ---------------------------
@@ -1391,4 +1395,5 @@ Command-line option changes
 [#25998]: https://github.com/JuliaLang/julia/issues/25998
 [#26009]: https://github.com/JuliaLang/julia/issues/26009
 [#26071]: https://github.com/JuliaLang/julia/issues/26071
+[#26080]: https://github.com/JuliaLang/julia/issues/26080
 [#26149]: https://github.com/JuliaLang/julia/issues/26149

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -150,7 +150,7 @@ macro enum(T, syms...)
                 print(io, x)
             else
                 print(io, x, "::")
-                showcompact(io, typeof(x))
+                show(IOContext(io, :compact => true), typeof(x))
                 print(io, " = ", $basetype(x))
             end
         end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1495,6 +1495,10 @@ end
 # Issue #26248
 @deprecate conj(x) x
 
+@deprecate showcompact(x) show(IOContext(stdout, :compact => true), x)
+@deprecate showcompact(io, x) show(IOContext(io, :compact => true), x)
+@deprecate sprint(::typeof(showcompact), args...) sprint(show, args...; context=:compact => true)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -619,7 +619,6 @@ export
     println,
     printstyled,
     show,
-    showcompact,
     showerror,
     sprint,
     summary,

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -154,7 +154,8 @@ big(::Type{<:AbstractIrrational}) = BigFloat
 
 # align along = for nice Array printing
 function alignment(io::IO, x::AbstractIrrational)
-    m = match(r"^(.*?)(=.*)$", sprint(showcompact, x, context=io, sizehint=0))
-    m === nothing ? (length(sprint(showcompact, x, context=io, sizehint=0)), 0) :
+    ctx = IOContext(io, :compact=>true)
+    m = match(r"^(.*?)(=.*)$", sprint(show, x, context=ctx, sizehint=0))
+    m === nothing ? (length(sprint(show, x, context=ctx, sizehint=0)), 0) :
     (length(m.captures[1]), length(m.captures[2]))
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -205,8 +205,8 @@ IOContext(io::IO, context::IO) = IOContext(unwrapcontext(io)[1], unwrapcontext(c
 Create an `IOContext` that wraps a given stream, adding the specified `key=>value` pairs to
 the properties of that stream (note that `io` can itself be an `IOContext`).
 
- - use `(key => value) in dict` to see if this particular combination is in the properties set
- - use `get(dict, key, default)` to retrieve the most recent value for a particular key
+ - use `(key => value) in io` to see if this particular combination is in the properties set
+ - use `get(io, key, default)` to retrieve the most recent value for a particular key
 
 The following properties are in common use:
 
@@ -1944,41 +1944,6 @@ end
 function Base.showarg(io::IO, r::Iterators.Pairs{<:Any, <:Any, I, D}, toplevel) where {D, I}
     print(io, "Iterators.Pairs(::$D, ::$I)")
 end
-
-"""
-    showcompact(x)
-    showcompact(io::IO, x)
-
-Show a compact representation of a value to `io`. If `io` is not specified, the
-default is to print to [`stdout`](@ref).
-
-This is used for printing array elements without repeating type information (which would
-be redundant with that printed once for the whole array), and without line breaks inside
-the representation of an element.
-
-To offer a compact representation different from its standard one, a custom type should
-test `get(io, :compact, false)` in its normal [`show`](@ref) method.
-
-# Examples
-```jldoctest
-julia> A = [1. 2.; 3. 4]
-2×2 Array{Float64,2}:
- 1.0  2.0
- 3.0  4.0
-
-julia> showcompact(A)
-[1.0 2.0; 3.0 4.0]
-```
-"""
-showcompact(x) = showcompact(stdout, x)
-function showcompact(io::IO, x)
-    if get(io, :compact, false)
-        show(io, x)
-    else
-        show(IOContext(io, :compact => true), x)
-    end
-end
-
 
 # printing BitArrays
 

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -73,6 +73,9 @@ println(io::IO, xs...) = print(io, xs..., '\n')
 
 Call the given function with an I/O stream and the supplied extra arguments.
 Everything written to this I/O stream is returned as a string.
+`context` can be either an [`IOContext`](@ref) whose properties will be used,
+or a `Pair` specifying a property and its value. `sizehint` suggests the capacity
+of the buffer (in bytes).
 
 The optional keyword argument `context` can be set to `:key=>value` pair
 or an `IO` or [`IOContext`](@ref) object whose attributes are used for the I/O
@@ -81,8 +84,11 @@ to allocate for the buffer used to write the string.
 
 # Examples
 ```jldoctest
-julia> sprint(showcompact, 66.66666)
+julia> sprint(show, 66.66666; context=:compact => true)
 "66.6667"
+
+julia> sprint(showerror, BoundsError([1], 100))
+"BoundsError: attempt to access 1-element Array{Int64,1} at index [100]"
 ```
 """
 function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -942,12 +942,12 @@ tot_time = tot_time_base + Base.tot_time_stdlib[] + tot_time_userimg + tot_time_
 
 println("Sysimage built. Summary:")
 print("Total ─────── "); Base.time_print(tot_time               * 10^9); print(" \n");
-print("Base: ─────── "); Base.time_print(tot_time_base          * 10^9); print(" "); showcompact((tot_time_base          / tot_time) * 100); println("%")
-print("Stdlibs: ──── "); Base.time_print(Base.tot_time_stdlib[] * 10^9); print(" "); showcompact((Base.tot_time_stdlib[] / tot_time) * 100); println("%")
+print("Base: ─────── "); Base.time_print(tot_time_base          * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_base          / tot_time) * 100); println("%")
+print("Stdlibs: ──── "); Base.time_print(Base.tot_time_stdlib[] * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (Base.tot_time_stdlib[] / tot_time) * 100); println("%")
 if isfile("userimg.jl")
-print("Userimg: ──── "); Base.time_print(tot_time_userimg       * 10^9); print(" "); showcompact((tot_time_userimg       / tot_time) * 100); println("%")
+print("Userimg: ──── "); Base.time_print(tot_time_userimg       * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_userimg       / tot_time) * 100); println("%")
 end
-print("Precompile: ─ "); Base.time_print(tot_time_precompile    * 10^9); print(" "); showcompact((tot_time_precompile    / tot_time) * 100); println("%")
+print("Precompile: ─ "); Base.time_print(tot_time_precompile    * 10^9); print(" "); show(IOContext(stdout, :compact=>true), (tot_time_precompile    / tot_time) * 100); println("%")
 end
 
 empty!(LOAD_PATH)

--- a/doc/src/base/io-network.md
+++ b/doc/src/base/io-network.md
@@ -55,7 +55,6 @@ Base.IOContext(::IO, ::IOContext)
 
 ```@docs
 Base.show(::Any)
-Base.showcompact
 Base.summary
 Base.print
 Base.println

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -100,12 +100,15 @@ Note that `a` is written to [`stdout`](@ref) by the [`write`](@ref) function and
 value is `1` (since `0x61` is one byte).
 
 For text I/O, use the [`print`](@ref) or [`show`](@ref) methods, depending on your needs (see
-the Julia Base reference for a detailed discussion of the difference between the two):
+the documentation for these two methods for a detailed discussion of the difference between them):
 
 ```jldoctest
 julia> print(stdout, 0x61)
 97
 ```
+
+See [Custom pretty-printing](@ref man-custom-pretty-printing) for more information on how to
+implement display methods for custom types.
 
 ## IO Output Contextual Properties
 

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -111,8 +111,9 @@ julia> print(stdout, 0x61)
 
 Sometimes IO output can benefit from the ability to pass contextual information into show methods.
 The [`IOContext`](@ref) object provides this framework for associating arbitrary metadata with an IO object.
-For example, [`showcompact`](@ref) adds a hinting parameter to the IO object that the invoked show method
-should print a shorter output (if applicable).
+For example, `:compact => true` adds a hinting parameter to the IO object that the invoked show method
+should print a shorter output (if applicable). See the [`IOContext`](@ref) documentation for a list
+of common properties.
 
 ## Working with Files
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1187,7 +1187,7 @@ Closest candidates are:
   supertype(!Matched::UnionAll) at operators.jl:47
 ```
 
-## Custom pretty-printing
+## [Custom pretty-printing](@id man-custom-pretty-printing)
 
 Often, one wants to customize how instances of a type are displayed.  This is accomplished by
 overloading the [`show`](@ref) function.  For example, suppose we define a type to represent
@@ -1320,6 +1320,37 @@ julia> :($a + 2)
 julia> :($a == 2)
 :(3.0 * exp(4.0im) == 2)
 ```
+
+In some cases, it is useful to adjust the behavior of `show` methods depending
+on the context. This can be achieved via the [`IOContext`](@ref) type, which allows
+passing contextual properties together with a wrapped IO stream.
+For example, we can build a shorter representation in our `show` method
+when the `:compact` property is set to `true`, falling back to the long
+representation if the property is `false` or absent:
+```jldoctest polartype
+julia> function Base.show(io::IO, z::Polar)
+           if get(io, :compact, false)
+               print(io, z.r, "ℯ", z.Θ, "im")
+           else
+               print(io, z.r, " * exp(", z.Θ, "im)")
+           end
+       end
+```
+
+This new compact representation will be used when the passed IO stream is an `IOContext`
+object with the `:compact` property set. In particular, this is the case when printing
+arrays with multiple columns (where horizontal space is limited):
+```jldoctest polartype
+julia> show(IOContext(stdout, :compact=>true), Polar(3, 4.0))
+3.0ℯ4.0im
+
+julia> [Polar(3, 4.0) Polar(4.0,5.3)]
+1×2 Array{Polar{Float64},2}:
+ 3.0ℯ4.0im  4.0ℯ5.3im
+```
+
+See the [`IOContext`](@ref) documentation for a list of common properties which can be used
+to adjust printing.
 
 ## "Value types"
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -11,8 +11,8 @@ for T in (Int64, Float64)
     @test complex(Complex{T}) == Complex{T}
 end
 
-#showcompact
-@test sprint(showcompact, complex(1, 0)) == "1+0im"
+#show
+@test sprint(show, complex(1, 0), context=:compact => true) == "1+0im"
 @test sprint(show, complex(true, true)) == "Complex(true,true)"
 
 @testset "arithmetic" begin

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -350,7 +350,7 @@ end
 @testset "Issue #15739" begin # Compact REPL printouts of an `AbstractDict` use brackets when appropriate
     d = Dict((1=>2) => (3=>45), (3=>10) => (10=>11))
     buf = IOBuffer()
-    showcompact(buf, d)
+    show(IOContext(buf, :compact => true), d)
 
     # Check explicitly for the expected strings, since the CPU bitness effects
     # dictionary ordering.

--- a/test/float16.jl
+++ b/test/float16.jl
@@ -108,7 +108,7 @@ end
     @test NaN16 != NaN16
     @test isequal(NaN16, NaN16)
     @test repr(NaN16) == "NaN16"
-    @test sprint(showcompact, NaN16) == "NaN"
+    @test sprint(show, NaN16, context=:compact => true) == "NaN"
 
     @test isinf(Inf16)
     @test isinf(-Inf16)
@@ -120,7 +120,7 @@ end
     @test -Inf16 < Inf16
     @test isequal(Inf16, Inf16)
     @test repr(Inf16) == "Inf16"
-    @test sprint(showcompact, Inf16) == "Inf"
+    @test sprint(show, Inf16, context=:compact => true) == "Inf"
 
     @test isnan(reinterpret(Float16,0x7c01))
     @test !isinf(reinterpret(Float16,0x7c01))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -197,7 +197,7 @@ end
 
 @testset "printing" begin
     @test sprint(show, missing) == "missing"
-    @test sprint(showcompact, missing) == "missing"
+    @test sprint(show, missing, context=:compact => true) == "missing"
     @test sprint(show, [missing]) == "$Missing[missing]"
     @test sprint(show, [1 missing]) == "$(Union{Int, Missing})[1 missing]"
     b = IOBuffer()

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -895,7 +895,7 @@ end
         ends::String="",
         starts::String="")
         sx = sprint(show, x)
-        scx = sprint(showcompact, x)
+        scx = sprint(show, x, context=:compact => true)
         strx = string(x)
         @test sx == strx
         @test length(scx) < 20
@@ -915,8 +915,8 @@ end
     test_show_bigfloat(big"-2.3457645687563543266576889678956787e-10000", starts="-2.345", ends="e-10000")
 
     for to_string in [string,
-        x->sprint(show, x),
-        x->sprint(showcompact,x)]
+                      x->sprint(show, x),
+                      x->sprint(show, x, context=:compact => true)]
         @test to_string(big"0.0") == "0.0"
         @test to_string(big"-0.0") == "-0.0"
         @test to_string(big"1.0") == "1.0"

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -410,14 +410,14 @@ end
     @test repr(-NaN) == "NaN"
     @test repr(Float64(pi)) == "3.141592653589793"
     # issue 6608
-    @test sprint(showcompact, 666666.6) == "6.66667e5"
-    @test sprint(showcompact, 666666.049) == "666666.0"
-    @test sprint(showcompact, 666665.951) == "666666.0"
-    @test sprint(showcompact, 66.66666) == "66.6667"
-    @test sprint(showcompact, -666666.6) == "-6.66667e5"
-    @test sprint(showcompact, -666666.049) == "-666666.0"
-    @test sprint(showcompact, -666665.951) == "-666666.0"
-    @test sprint(showcompact, -66.66666) == "-66.6667"
+    @test sprint(show, 666666.6, context=:compact => true) == "6.66667e5"
+    @test sprint(show, 666666.049, context=:compact => true) == "666666.0"
+    @test sprint(show, 666665.951, context=:compact => true) == "666666.0"
+    @test sprint(show, 66.66666, context=:compact => true) == "66.6667"
+    @test sprint(show, -666666.6, context=:compact => true) == "-6.66667e5"
+    @test sprint(show, -666666.049, context=:compact => true) == "-666666.0"
+    @test sprint(show, -666665.951, context=:compact => true) == "-666666.0"
+    @test sprint(show, -66.66666, context=:compact => true) == "-66.6667"
 
     @test repr(1.0f0) == "1.0f0"
     @test repr(-1.0f0) == "-1.0f0"
@@ -2564,7 +2564,7 @@ end
                             (-T(Inf), "-Inf")]
                 @assert x isa T
                 @test string(x) == sx
-                @test sprint(io -> show(IOContext(io, :compact => true), x)) == sx
+                @test sprint(show, x, context=:compact => true) == sx
                 @test sprint(print, x) == sx
             end
         end

--- a/test/show.jl
+++ b/test/show.jl
@@ -747,16 +747,6 @@ end
 @test !contains(repr(fill(1.,10,10)), "\u2026")
 @test contains(sprint((io, x) -> show(IOContext(io, :limit => true), x), fill(1.,30,30)), "\u2026")
 
-# showcompact() also sets :multiline=>false (#16817)
-let io = IOBuffer(),
-    x = [1, 2]
-
-    showcompact(io, x)
-    @test String(take!(io)) == "[1, 2]"
-    showcompact(IOContext(io, :compact => true), x)
-    @test String(take!(io)) == "[1, 2]"
-end
-
 let io = IOBuffer()
     ioc = IOContext(io, :limit => true)
     @test sprint(show, ioc) == "IOContext($(sprint(show, ioc.io)))"


### PR DESCRIPTION
There is no obvious reason to provide a special function for the `:compact` `IOContext` property
but not for other properties. `showcompact` used to be useful to print a single-line representation of an array at the REPL, but now `show` does the same thing. So it should only be needed for collections to print their elements when implementing `show`, and for tests (most of the changes here).

Also improve a few docstrings.