### PR TITLE
Propage inbounds through `broadcast!`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -625,12 +625,12 @@ const NonleafHandlingTypes = Union{DefaultArrayStyle,ArrayConflict,VectorStyle,M
         return broadcast_nonleaf(f, s, ElType, inds, As...)
     end
     dest = broadcast_similar(f, s, ElType, inds, As...)
-    broadcast!(f, dest, As...)
+    @inbounds broadcast!(f, dest, As...)
 end
 
 @inline function broadcast(f, s::BroadcastStyle, ::Type{ElType}, inds::Indices, As...) where ElType
     dest = broadcast_similar(f, s, ElType, inds, As...)
-    broadcast!(f, dest, As...)
+    @inbounds broadcast!(f, dest, As...)
 end
 
 # When ElType is not concrete, use narrowing. Use the first element of each input to determine


### PR DESCRIPTION
I noticed we had a `@boundscheck` in `_broadcast!` that was never eliminated. The first commit adds the necessary `@propagate_inbounds` annotations so that users may actually remove that boundscheck when calling `broadcast!`, if they chose. The second commit makes `broadcast` call the `@inbounds` for the `broadcast!` step (I'm assuming that's safe??).

This only has a very minor impact, `@btime` tells me around the 1%-2% level for a length-3 `Vector` for `broadcast!` (and probably negligible for larger arrays and when allocating via `broadcast`). But I saw the inconsistency and decided to investigate, so here it is.