### PR TITLE
add membership test methods to tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -352,6 +352,7 @@ end
 
 in(x, t::Tuple{}) = false
 in(x, t::Tuple  ) = x == t[1] || in(x, tail(t))
+in(x, t::Any16  ) = any(y -> y == x, t)
 
 ## functions ##
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -350,6 +350,9 @@ function isless(t1::Any16, t2::Any16)
     return n1 < n2
 end
 
+in(x, t::Tuple{}) = false
+in(x, t::Tuple  ) = x == t[1] || in(x, tail(t))
+
 ## functions ##
 
 isempty(x::Tuple{}) = true

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -350,9 +350,9 @@ function isless(t1::Any16, t2::Any16)
     return n1 < n2
 end
 
-in(x, t::Tuple{}) = false
-in(x, t::Tuple  ) = x == t[1] || in(x, tail(t))
-in(x, t::Any16  ) = any(y -> y == x, t)
+#in(x, t::Tuple{}) = false
+#in(x, t::Tuple  ) = x == t[1] || in(x, tail(t))
+#in(x, t::Any16  ) = any(y -> y == x, t)
 
 ## functions ##
 

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -350,9 +350,18 @@ function isless(t1::Any16, t2::Any16)
     return n1 < n2
 end
 
-#in(x, t::Tuple{}) = false
-#in(x, t::Tuple  ) = x == t[1] || in(x, tail(t))
-#in(x, t::Any16  ) = any(y -> y == x, t)
+in(x, t::Any16) = any(y -> y == x, t)
+# specialized methods for short tuples
+in(x, t::Tuple{}) = false
+function in(x, t::Tuple)
+    found = x == t[1]
+    if ismissing(found)
+        # propagate missingness
+        return missing | in(x, tail(t))
+    else
+        return found || in(x, tail(t))
+    end
+end
 
 ## functions ##
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -426,3 +426,14 @@ end
     @test findnext(isequal(1), (2, 3), 1) === nothing
     @test findprev(isequal(1), (2, 3), 2) === nothing
 end
+
+@testset "membership" begin
+    @test !(42 in ())
+    @test 42 in (2, 42, 57)
+    @test !(0 in (1:1000...,))
+    @test 57 in (missing, 42, 57)
+    @test ismissing(10 in (missing, 42, 57))
+    @test ismissing(missing in (2, 42, 57))
+    @test ismissing(missing in (missing, 42, 57))
+    @test ismissing(0 in (1:1000...,missing))
+end


### PR DESCRIPTION
This makes membership test much faster (~4.5x) for tuples. The benchmark suggests using `|` instead of `||` may make it even faster but I'm not sure whether it is always good even for long tuples. So I chose `||` in this pull request.

```
foo(x) = x ∈ (2, 42, 57)
bar(x) = (x == 2) || (x == 42) || (x == 57)
baz(x) = (x == 2) |  (x == 42) |  (x == 57)

#= master [aed88141e7]
julia> srand(1234); x = rand(1:100, 1000);

julia> @benchmark count(foo, x)
┌ Warning: `indmin` is deprecated, use `argmin` instead.
│   caller = minimum at trials.jl:112 [inlined]
└ @ Core trials.jl:112
┌ Warning: `indmax` is deprecated, use `argmax` instead.
│   caller = maximum at trials.jl:117 [inlined]
└ @ Core trials.jl:117
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     3.864 μs (0.00% GC)
  median time:      3.922 μs (0.00% GC)
  mean time:        4.295 μs (0.00% GC)
  maximum time:     22.867 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     8

julia> @benchmark count(bar, x)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     861.852 ns (0.00% GC)
  median time:      872.656 ns (0.00% GC)
  mean time:        920.294 ns (0.00% GC)
  maximum time:     4.779 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     61

julia> @benchmark count(baz, x)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     213.888 ns (0.00% GC)
  median time:      215.625 ns (0.00% GC)
  mean time:        234.152 ns (0.00% GC)
  maximum time:     1.822 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     525
=#

#= this branch [2ac76495de]
julia> srand(1234); x = rand(1:100, 1000);

julia> @benchmark count(foo, x)
┌ Warning: `indmin` is deprecated, use `argmin` instead.
│   caller = minimum at trials.jl:112 [inlined]
└ @ Core trials.jl:112
┌ Warning: `indmax` is deprecated, use `argmax` instead.
│   caller = maximum at trials.jl:117 [inlined]
└ @ Core trials.jl:117
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     858.190 ns (0.00% GC)
  median time:      874.857 ns (0.00% GC)
  mean time:        962.535 ns (0.00% GC)
  maximum time:     7.657 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     63

julia> @code_llvm foo(2)

; Function foo
; Location: /Users/kenta/vendor/julia/test.jl:1
define i8 @julia_foo_62439(i64) {
top:
; Function in; {
; Location: tuple.jl:348
  switch i64 %0, label %L24 [
    i64 2, label %L34
    i64 42, label %L34
    i64 57, label %L34
  ]

L34:                                              ; preds = %top, %top, %top, %L24
  %"#temp#2.0" = phi i8 [ 1, %top ], [ 0, %L24 ], [ 1, %top ], [ 1, %top ]
;}
  ret i8 %"#temp#2.0"

L24:                                              ; preds = %top
; Function in; {
; Location: tuple.jl:348
; Function in; {
; Location: tuple.jl:348
; Function in; {
; Location: tuple.jl:348
  br label %L34
;}}}
}
=#
```