### PR TITLE
ensure promotion rules don't alter eltype values

### DIFF
--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -103,9 +103,6 @@ indexed_next(t::NamedTuple, i::Int, state) = (getfield(t, i), i+1)
 isempty(::NamedTuple{()}) = true
 isempty(::NamedTuple) = false
 
-promote_typejoin(::Type{NamedTuple{n, S}}, ::Type{NamedTuple{n, T}}) where {n, S, T} =
-    NamedTuple{n, promote_typejoin(S, T)}
-
 convert(::Type{NamedTuple{names,T}}, nt::NamedTuple{names,T}) where {names,T<:Tuple} = nt
 convert(::Type{NamedTuple{names}}, nt::NamedTuple{names}) where {names} = nt
 

--- a/test/namedtuple.jl
+++ b/test/namedtuple.jl
@@ -226,9 +226,9 @@ abstr_nt_22194_3()
 for T in (Nothing, Missing)
     x = [(a=1, b=T()), (a=1, b=2)]
     y = map(v -> (a=v.a, b=v.b), [(a=1, b=T()), (a=1, b=2)])
-    @test y isa Vector{NamedTuple{(:a,:b),Tuple{Int,Union{T,Int}}}}
+    @test y isa Vector{NamedTuple{(:a,:b), T} where T<:Tuple}
     @test isequal(x, y)
 end
 y = map(v -> (a=v.a, b=v.a + v.b), [(a=1, b=missing), (a=1, b=2)])
-@test y isa Vector{NamedTuple{(:a,:b),Tuple{Int,Union{Missing,Int}}}}
+@test y isa Vector{NamedTuple{(:a,:b), T} where T<:Tuple}
 @test isequal(y, [(a=1, b=missing), (a=1, b=3)])

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -189,11 +189,11 @@ end
     for T in (Nothing, Missing)
         x = [(1, T()), (1, 2)]
         y = map(v -> (v[1], v[2]), [(1, T()), (1, 2)])
-        @test y isa Vector{Tuple{Int,Union{T,Int}}}
+        @test y isa Vector{Tuple{Int, Any}}
         @test isequal(x, y)
     end
     y = map(v -> (v[1], v[1] + v[2]), [(1, missing), (1, 2)])
-    @test y isa Vector{Tuple{Int,Union{Missing,Int}}}
+    @test y isa Vector{Tuple{Int, Any}}
     @test isequal(y, [(1, missing), (1, 3)])
 end
 


### PR DESCRIPTION
This also helps to re-synchronize `cat` and `map` and restore v0.6 behavior. Since I don't think it's obvious if this type can be made efficient (aka fastest), I think it seems best to avoid changing this to a more complicated type.

Closes #25924