### PR TITLE
`retry` should support the check function proposed in the docstring

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -218,7 +218,8 @@ function retry(f::Function;  delays=ExponentialBackOff(), check=nothing)
             catch e
                 done(delays, state) && rethrow(e)
                 if check !== nothing
-                    state, retry_or_not = check(state, e)
+                    result = check(state, e)
+                    state, retry_or_not = length(result) == 2 ? result : (state, result)
                     retry_or_not || rethrow(e)
                 end
             end

--- a/test/error.jl
+++ b/test/error.jl
@@ -66,6 +66,11 @@ end
     @test ex.msg == "foo"
     @test c[1] == 1
 
+    # Test example in docstring where the check function doesn't return the state.
+    c = [0]
+    @test retry(foo_error, check=(s,e)->e.msg == "foo")(c,1) == 7
+    @test c[1] == 2
+
     # Functions with keyword arguments
     foo_kwargs(x; y=5) = x + y
     @test retry(foo_kwargs)(3) == 8


### PR DESCRIPTION
The `retry` docstring currently only proposes check functions that returns a bool, but these would result in a `BoundsError` because the `retry` function expects the `check` function to return the state and retry bool. This change supports both options, using the initial state when only 1 value is returned.

NOTE: If folks don't want to support returning just a bool then we should update the docstring.