### PR TITLE
loading: top-level load w/ `path`, w/o `deps` or dep project file

### DIFF
--- a/test/project/Manifest.toml
+++ b/test/project/Manifest.toml
@@ -12,9 +12,6 @@ path = "deps/Foo2.jl"
 [[Bar]]
 uuid = "2a550a13-6bab-4a91-a4ee-dff34d6b99d0"
 path = "deps/Bar"
-    [Bar.deps]
-    Baz = "6801f525-dc68-44e8-a4e8-cabd286279e7"
-    Foo = "6f418443-bd2e-4783-b551-cdbac608adf2"
 
 [[Baz]]
 uuid = "6801f525-dc68-44e8-a4e8-cabd286279e7"

--- a/test/project/Manifest.toml
+++ b/test/project/Manifest.toml
@@ -24,5 +24,6 @@ git-tree-sha1 = "efc7e24c53d6a328011975294a2c75fed2f9800a"
     Qux = "b5ec9b9c-e354-47fd-b367-a348bdc8f909"
 
 [[Qux]]
+deps = []
 uuid = "b5ec9b9c-e354-47fd-b367-a348bdc8f909"
 path = "deps/Qux.jl"

--- a/test/project/deps/Bar/Project.toml
+++ b/test/project/deps/Bar/Project.toml
@@ -1,0 +1,6 @@
+name = "Bar"
+uuid = "2a550a13-6bab-4a91-a4ee-dff34d6b99d0"
+
+[deps]
+Baz = "6801f525-dc68-44e8-a4e8-cabd286279e7"
+Foo = "6f418443-bd2e-4783-b551-cdbac608adf2"


### PR DESCRIPTION
This allows a checked out package without a project file to load its
dependencies as top-level packages in the load path.

Also: modify tests to exercise new code paths added in first commit.