### PR TITLE
Fix for #25847 (leaking Futures) 

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -180,6 +180,25 @@ testval = remotecall_fetch(wid2, fstore) do x
 end
 @test testval == 1
 
+# Issue number #25847
+@everywhere function f25847(ref)
+    fetch(ref)
+    return true
+end
+
+f = remotecall_wait(identity, id_other, ones(10))
+rrid = Distributed.RRID(f.whence, f.id)
+remotecall_fetch(f25847, id_other, f)
+@test BitSet([id_me]) == remotecall_fetch(()->Distributed.PGRP.refs[rrid].clientset, id_other)
+
+remotecall_fetch(f25847, id_other, f)
+@test BitSet([id_me]) == remotecall_fetch(()->Distributed.PGRP.refs[rrid].clientset, id_other)
+
+finalize(f)
+yield() # flush gc msgs
+@test false == remotecall_fetch(chk_rrid->haskey(Distributed.PGRP.refs, chk_rrid), id_other, rrid)
+
+
 # Distributed GC tests for RemoteChannels
 function test_remoteref_dgc(id)
     rr = RemoteChannel(id)


### PR DESCRIPTION
This fixes a leak of Futures when unfetched Futures are repeatedly serialized to the node with the reference store.

Closes https://github.com/JuliaLang/julia/issues/25847