### PR TITLE
Remove unused angle_restrict_symm function left over from #18330.

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -728,19 +728,6 @@ end
 @inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)
 @inline literal_pow(::typeof(^), x::Float16, ::Val{p}) where {p} = Float16(literal_pow(^,Float32(x),Val(p)))
 
-function angle_restrict_symm(theta)
-    P1 = 4 * 7.8539812564849853515625e-01
-    P2 = 4 * 3.7748947079307981766760e-08
-    P3 = 4 * 2.6951514290790594840552e-15
-
-    y = 2*floor(theta/(2*pi))
-    r = ((theta - y*P1) - y*P2) - y*P3
-    if (r > pi)
-        r -= (2*pi)
-    end
-    return r
-end
-
 ## rem2pi-related calculations ##
 
 function add22condh(xh::Float64, xl::Float64, yh::Float64, yl::Float64)


### PR DESCRIPTION
This function could have been removed in #18330 when the new complex `lgamma` version was added, as `angle_restrict_symm` was *only* used here, not exported, and not tested either.