### PR TITLE
README: fix coveralls image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Code coverage:
 
 [travis-img]: https://img.shields.io/travis/JuliaLang/julia/master.svg?label=Linux+/+macOS
 [appveyor-img]: https://img.shields.io/appveyor/ci/JuliaLang/julia/master.svg?label=Windows
-[coveralls-img]: https://img.shields.io/coveralls/c/github/JuliaLang/julia/master.svg?label=coveralls
+[coveralls-img]: https://img.shields.io/coveralls/github/JuliaLang/julia/master.svg?label=coveralls
 [codecov-img]: https://img.shields.io/codecov/c/github/JuliaLang/julia/master.svg?label=codecov
 
 ## The Julia Language


### PR DESCRIPTION
Follow-up of #24344 and #25419 (which fixed a copy-paste error in the former).