### PR TITLE
Implement broadcasting for `AbstractDict` and `NamedTuple`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -596,6 +596,10 @@ Library improvements
     like other `AbstractDict` subtypes and its constructors mirror the
     ones of `Dict`. ([#25210])
 
+  * `broadcast` and `broadcast!` now work with dictionaries and named tuples, matching up
+    the indices as appropriate and broadcasting over scalars, `Ref`s, and arrays/tuples
+    containing a single element. ([#??])
+
   * `IOBuffer` can take the `sizehint` keyword argument to suggest a capacity of
     the buffer ([#25944]).
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -180,6 +180,28 @@ function grow_to!(dest::AbstractDict{K,V}, itr, st) where V where K
     return dest
 end
 
+"""
+    Dict{K,V}(uninitialized, keys)
+
+Construct a `Dict` with unitialized values of type `V` with the provided unique set of
+`keys`.
+
+# Examples
+
+```
+julia> Dict{Int, Float64}(uninitialized, [1, 2, 3])
+Dict{Int64,Float64} with 3 entries:
+  2 => 6.90966e-310
+  3 => 6.90966e-310
+  1 => 6.90966e-310
+```
+"""
+function Dict{K,V}(::Uninitialized, inds::KeySet{<:Dict{K}}) where {K, V}
+    d = inds.dict
+    n = length(d.keys)
+    Dict{K,V}(copy(d.slots), copy(d.keys), Vector{V}(uninitialized, n), d.ndel, d.count, d.age, d.idxfloor, d.maxprobe)
+end
+
 empty(a::AbstractDict, ::Type{K}, ::Type{V}) where {K, V} = Dict{K, V}()
 
 hashindex(key, sz) = (((hash(key)%Int) & (sz-1)) + 1)::Int

--- a/base/set.jl
+++ b/base/set.jl
@@ -790,3 +790,11 @@ function _replace!(new::Callable, A::AbstractArray, count::Int)
         c == count && break
     end
 end
+
+# Construct uninitialized dictionary using the keys from/via a `Set`
+Dict{K, V}(::Uninitialized, inds) where {K, V} = Dict{K, V}(uninitialized, Set{K}(inds))
+function Dict{K,V}(::Uninitialized, inds::Set{K}) where {K, V}
+    d = inds.dict
+    n = length(d.keys)
+    Dict{K,V}(copy(d.slots), copy(d.keys), Vector{V}(uninitialized, n), d.ndel, d.count, d.age, d.idxfloor, d.maxprobe)
+end

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -655,8 +655,9 @@ is equivalent to `broadcast(f, args...)`, providing a convenient syntax to broad
 [automatically fuse](@ref man-dot-operators) into a single `broadcast` call.
 
 Additionally, [`broadcast`](@ref) is not limited to arrays (see the function documentation),
-it also handles tuples and treats any argument that is not an array, tuple or [`Ref`](@ref)
-(except for [`Ptr`](@ref)) as a "scalar".
+it also handles tuples, named tuples and dictionaries, and treats any argument that is not
+an array, tuple, named tuple, dictionary or [`Ref`](@ref) (except for [`Ptr`](@ref)) as a
+"scalar".
 
 ```jldoctest
 julia> convert.(Float32, [1, 2])
@@ -674,6 +675,14 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
  "1. First"
  "2. Second"
  "3. Third"
+
+julia> (a = 1, b = 2) .* 2
+(a = 2, b = 4)
+
+julia> Dict(1 => 1, 2 => 2) .+ [10, 20]
+Dict{Int64,Int64} with 2 entries:
+  2 => 22
+  1 => 11
 ```
 
 ### Implementation


### PR DESCRIPTION
This is an implementation of `broadcast` and `broadcast!` over the indices of both `AbstractDict`s and `NamedTuple`s. The current behavior is to treat these types as a scalar for the purpose of broadcasting. I feel it would be quite useful to allow users to broadcast over the values in these containers - I know I'd use it, at least.

I followed the semantic that for 1D containers the job of `broadcast` is to match up the indices of the containers (and broadcast the scalars) and apply the given function to the resulting values. Here, dictionaries cannot be broadcast with matrices or higher-dimensional arrays, but if the keys of a vector or tuple happen to be the same as the keys of a dictionary than that's OK.

There are a few things I just "made up" such as the new precedence orders between dictionaries <--> arrays / tuples / named tuples; comments welcome.

There are a few things that could be improved (in this PR or later):
 * Friendlier support for dictionary types other than `Dict`.
 * Make `NamedTuple` broadcasting faster (I currently observe type inference issues with the constant propagation of the field names).

I'm pinging triage to consider this now as v1.0 users may rely on the broadcast-as-a-scalar behavior of dictionaries and named tuples and it should thus be considered a *breaking* change for v1.x.

I'll also note that there have been discussions around `AbstractDict` and how they `map` and iterate. Note that this acts on dictionary values and not key-value pairs like the current implementation of `map`. On that note, I have been considering that `map` has something to do with iteration and `broadcast` has something (a bit more complex) to do with indexing (and the relationship between iteration and indexing is currently different for dictionaries as compared to arrays, tuples, and named tuples).

A few small examples:
```julia
julia> Dict(1 => 10, 2 => 20) .* 2
Dict{Int64,Int64} with 2 entries:
  2 => 40
  1 => 20

julia> (a=1, b=2) .+ (b=2, a=1)
(a = 2, b = 4)

julia> sum.((a=[1,2,3], b=[4,5,6]))
(a = 6, b = 15)
```
The third one could be considered summing the columns of a "table", or perhaps the groups of a container returned by some kind of `groupby` function.

Closes #25904. CC @timholy since you have obviously put a *lot* of effort into our broadcast design.