### PR TITLE
doctestsetup for stdlib

### DIFF
--- a/stdlib/Base64/docs/src/index.md
+++ b/stdlib/Base64/docs/src/index.md
@@ -1,9 +1,17 @@
 # Base64
 
+```@meta
+DocTestSetup = :(using Base64)
+```
+
 ```@docs
 Base64.Base64EncodePipe
 Base64.base64encode
 Base64.Base64DecodePipe
 Base64.base64decode
 Base64.stringmime
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -1,5 +1,9 @@
 # [Dates and Time](@id stdlib-dates)
 
+```@meta
+DocTestSetup = :(using Dates)
+```
+
 Functionality to handle time and dates is defined in the standard library module `Dates`.
 You'll need to import the module using `import Dates` and prefix each
 function call with an explicit `Dates.`, e.g. `Dates.dayofweek(dt)`. Alternatively, you can write
@@ -192,3 +196,7 @@ Months of the Year:
 | `October`   | `Oct` | 10          |
 | `November`  | `Nov` | 11          |
 | `December`  | `Dec` | 12          |
+
+```@meta
+DocTestSetup = nothing
+```

--- a/stdlib/DelimitedFiles/docs/src/index.md
+++ b/stdlib/DelimitedFiles/docs/src/index.md
@@ -1,5 +1,9 @@
 # Delimited Files
 
+```@meta
+DocTestSetup = :(using DelimitedFiles)
+```
+
 ```@docs
 DelimitedFiles.readdlm(::Any, ::Char, ::Type, ::Char)
 DelimitedFiles.readdlm(::Any, ::Char, ::Char)
@@ -8,4 +12,8 @@ DelimitedFiles.readdlm(::Any, ::Char)
 DelimitedFiles.readdlm(::Any, ::Type)
 DelimitedFiles.readdlm(::Any)
 DelimitedFiles.writedlm
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Distributed/docs/src/index.md
+++ b/stdlib/Distributed/docs/src/index.md
@@ -1,5 +1,9 @@
 # Distributed Computing
 
+```@meta
+DocTestSetup = :(using Distributed)
+```
+
 ```@docs
 Distributed.addprocs
 Distributed.nprocs
@@ -66,4 +70,8 @@ Distributed.connect(::ClusterManager, ::Int, ::WorkerConfig)
 Distributed.init_worker
 Distributed.start_worker
 Distributed.process_messages
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -1,5 +1,9 @@
 # Interactive Utilities
 
+```@meta
+DocTestSetup = :(using InteractiveUtils)
+```
+
 ```@docs
 InteractiveUtils.apropos
 InteractiveUtils.varinfo
@@ -22,4 +26,8 @@ InteractiveUtils.code_llvm
 InteractiveUtils.@code_llvm
 InteractiveUtils.code_native
 InteractiveUtils.@code_native
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/IterativeEigensolvers/docs/src/index.md
+++ b/stdlib/IterativeEigensolvers/docs/src/index.md
@@ -1,5 +1,9 @@
 # [Iterative Eigensolvers](@id lib-itereigen)
 
+```@meta
+DocTestSetup = :(using IterativeEigensolvers)
+```
+
 Julia provides bindings to [ARPACK](http://www.caam.rice.edu/software/ARPACK/), which
 can be used to perform iterative solutions for eigensystems (using [`eigs`](@ref))
 or singular value decompositions (using [`svds`](@ref)).
@@ -206,4 +210,8 @@ julia> λ
 IterativeEigensolvers.eigs(::Any)
 IterativeEigensolvers.eigs(::Any, ::Any)
 IterativeEigensolvers.svds
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/LibGit2/docs/index.md
+++ b/stdlib/LibGit2/docs/index.md
@@ -1,5 +1,9 @@
 # LibGit2
 
+```@meta
+DocTestSetup = :(using LibGit2)
+```
+
 The LibGit2 module provides bindings to [libgit2](https://libgit2.github.com/), a portable C library that
 implements core functionality for the [Git](https://git-scm.com/) version control system.
 These bindings are currently used to power Julia's package manager.
@@ -157,4 +161,8 @@ LibGit2.CachedCredentials
 LibGit2.CredentialPayload
 LibGit2.approve
 LibGit2.reject
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -1,5 +1,9 @@
 # Linear Algebra
 
+```@meta
+DocTestSetup = :(using LinearAlgebra)
+```
+
 In addition to (and as part of) its support for multi-dimensional arrays, Julia provides native implementations
 of many common and useful linear algebra operations. Basic operations, such as [`trace`](@ref), [`det`](@ref),
 and [`inv`](@ref) are all supported:
@@ -619,4 +623,8 @@ LinearAlgebra.LAPACK.trexc!
 LinearAlgebra.LAPACK.trsen!
 LinearAlgebra.LAPACK.tgsen!
 LinearAlgebra.LAPACK.trsyl!
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Mmap/docs/src/index.md
+++ b/stdlib/Mmap/docs/src/index.md
@@ -1,7 +1,15 @@
 # Memory-mapped I/O
 
+```@meta
+DocTestSetup = :(using Mmap)
+```
+
 ```@docs
 Mmap.Anonymous
 Mmap.mmap
 Mmap.sync!
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -26,8 +26,6 @@ for use in [`Mmap.mmap`](@ref Mmap.mmap). Used by `SharedArray` for creating sha
 
 # Examples
 ```jldoctest
-julia> using Mmap
-
 julia> anon = Mmap.Anonymous();
 
 julia> isreadable(anon)
@@ -263,8 +261,6 @@ the byte representation is different.
 
 # Examples
 ```jldoctest
-julia> using Mmap
-
 julia> io = open("mmap.bin", "w+");
 
 julia> B = Mmap.mmap(io, BitArray, (25,30000));

--- a/stdlib/Pkg/docs/src/index.md
+++ b/stdlib/Pkg/docs/src/index.md
@@ -1,5 +1,9 @@
 # Package Manager Functions
 
+```@meta
+DocTestSetup = :(using Pkg)
+```
+
 All package manager functions are defined in the `Pkg` module. None of the `Pkg` module's functions
 are exported; to use them, you'll need to prefix each function call with an explicit `Pkg.`, e.g.
 [`Pkg.status()`](@ref) or [`Pkg.dir()`](@ref).
@@ -27,4 +31,8 @@ Pkg.free
 Pkg.build
 Pkg.test
 Pkg.dependents
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Printf/docs/src/index.md
+++ b/stdlib/Printf/docs/src/index.md
@@ -1,6 +1,14 @@
 # Printf
 
+```@meta
+DocTestSetup = :(using Printf)
+```
+
 ```@docs
 Printf.@printf
 Printf.@sprintf
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -1,5 +1,9 @@
 # Random Numbers
 
+```@meta
+DocTestSetup = :(using Random)
+```
+
 Random number generation in Julia uses the [Mersenne Twister library](http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/SFMT/#dSFMT)
 via `MersenneTwister` objects. Julia has a global RNG, which is used by default. Other RNG types
 can be plugged in by inheriting the `AbstractRNG` type; they can then be used to have multiple
@@ -40,4 +44,8 @@ Random.randcycle
 Random.randcycle!
 Random.shuffle
 Random.shuffle!
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -1,5 +1,9 @@
 # Sparse Arrays
 
+```@meta
+DocTestSetup = :(using SparseArrays)
+```
+
 Julia has support for sparse vectors and [sparse matrices](https://en.wikipedia.org/wiki/Sparse_matrix)
 in the `SparseArrays` stdlib module. Sparse arrays are arrays that contain enough zeros
 that storing them in a special data structure leads to savings in space and execution time,
@@ -217,4 +221,8 @@ SparseArrays.dropzeros!
 SparseArrays.dropzeros
 SparseArrays.permute
 permute!{Tv, Ti, Tp <: Integer, Tq <: Integer}(::SparseMatrixCSC{Tv,Ti}, ::SparseMatrixCSC{Tv,Ti}, ::AbstractArray{Tp,1}, ::AbstractArray{Tq,1})
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -1,9 +1,7 @@
 # Unit Testing
 
 ```@meta
-DocTestSetup = quote
-    using Test
-end
+DocTestSetup = :(using Test)
 ```
 
 ## Testing Base Julia

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1200,8 +1200,6 @@ Returns the result of `f(x)` if the types match,
 and an `Error` `Result` if it finds different types.
 
 ```jldoctest
-julia> using Test
-
 julia> f(a,b,c) = b > 1 ? 1 : 1.0
 f (generic function with 1 method)
 

--- a/stdlib/UUIDs/docs/src/index.md
+++ b/stdlib/UUIDs/docs/src/index.md
@@ -1,7 +1,15 @@
 # UUIDs
 
+```@meta
+DocTestSetup = :(using UUIDs)
+```
+
 ```@docs
 UUIDs.uuid1
 UUIDs.uuid4
 UUIDs.uuid_version
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Unicode/docs/src/index.md
+++ b/stdlib/Unicode/docs/src/index.md
@@ -1,7 +1,15 @@
 # Unicode
 
+```@meta
+DocTestSetup = :(using Unicode)
+```
+
 ```@docs
 Unicode.isassigned
 Unicode.normalize
 Unicode.graphemes
+```
+
+```@meta
+DocTestSetup = nothing
 ```

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -43,8 +43,6 @@ For example, NFKC corresponds to the options `compose=true, compat=true, stable=
 
 # Examples
 ```jldoctest
-julia> using Unicode
-
 julia> "μ" == Unicode.normalize("µ", compat=true) #LHS: Unicode U+03bc, RHS: Unicode U+00b5
 true
 
@@ -66,8 +64,6 @@ Returns `true` if the given char or integer is an assigned Unicode code point.
 
 # Examples
 ```jldoctest
-julia> using Unicode
-
 julia> Unicode.isassigned(101)
 true
 


### PR DESCRIPTION
Add
````
```@meta
DocTestSetup = :(using $STDLIB)
```
````
to all stdlib docs. Without this running `make -C doc doctest` prints thousands of deprecations warnings and makes my computer sad. This is the same pattern as packages uses, so will be needed even if the code here moves to another repo.