### PR TITLE
RFC: Allow inference of recursion on a decreasing integer type parameter

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -256,7 +256,7 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
         return type_more_complex(t, c.a, sources, depth, tupledepth, allowed_tuplelen) &&
                type_more_complex(t, c.b, sources, depth, tupledepth, allowed_tuplelen)
     elseif isa(t, Int) && isa(c, Int)
-        return t !== 1 # alternatively, could use !(0 <= t < c)
+        return t !== 1 && !(0 <= t < c) # alternatively, could use !(abs(t) <= abs(c) || abs(t) < n) for some n
     end
     # base case for data types
     if isa(t, DataType)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1418,3 +1418,8 @@ function h25579(g)
 end
 @test Base.return_types(h25579, (Base.RefValue{Union{Nothing, Int}},)) ==
         Any[Union{Type{Float64}, Type{Int}, Type{Nothing}}]
+
+f26172(v) = Val{length(Base.tail(ntuple(identity, v)))}() # Val(M-1)
+g26172(::Val{0}) = ()
+g26172(v) = (nothing, g26172(f26172(v))...)
+@test @inferred(g26172(Val(10))) === ntuple(_ -> nothing, 10)


### PR DESCRIPTION
This makes use of the alternative already mentioned by @vtjnash in the comment.

### Motivation
In https://github.com/JuliaArrays/StaticArrays.jl/pull/368, I have implemented an LU decomposition for StaticMatrices that recursively calls itself on sub-matrices. It works (almost) without `@generated` functions and allows for relatively clean code. Overall, I'm quite happy with the result---except that it doesn't work on 0.7. Well, it works *), but it cannot be inferred, which is bad news for StaticArrays. Slightly simplified, the problem is that `lu(::SArray{Tuple{6,6},Float64,2,36}` calls `lu(::SArray{Tuple{5,5},Float64,2,25}` calls `SArray{Tuple{4,4},Float64,2,16}` and so on, but that latter argument types are considered more complex, making inference bail out of the recursion. However, that coding style in probably recommendable, similar to working with tuples by recursively decomposing them. So it would be really nice to make inference work for it, which this PR achieves.

*) After applying a work-around for #26083.

### Drawback
If one writes a recursion where an integer type parameter is successively decremented to zero and starts it at 10000, inference will run into a stack overflow. Could be solved by putting an upper limit on `t` (or `c`) here, but it's a bit unclear what that should be.