### PR TITLE
Add umlauts to latex_symbols

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -108,6 +108,14 @@ const latex_symbols = Dict(
     "\\to" => "→",
     "\\euler" => "ℯ",
 
+    # Accented characters missing from unicode.xml
+    "\\\"a" => "ä",
+    "\\\"o" => "ö",
+    "\\\"u" => "ü",
+    "\\\"A" => "Ä",
+    "\\\"O" => "Ö",
+    "\\\"U" => "Ü",
+
     # Superscripts
     "\\^0" => "⁰",
     "\\^1" => "¹",

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -234,6 +234,14 @@ let s = "α\\alpha"
     @test length(c) == 1
 end
 
+# test umlaut completion (not in original W3C symbol list)
+let s = "\\\"a"
+    c, r = test_bslashcomplete(s)
+    @test c[1] == "ä"
+    @test r == 1:length(s)
+    @test length(c) == 1
+end
+
 # test emoji symbol completions
 let s = "\\:koala:"
     c, r = test_bslashcomplete(s)


### PR DESCRIPTION
This adds umlauts (ä, ö, ü, and upper case letters) to the list of latex
symbols recognized by the REPL with tab completion. The LaTeX symbols
are e.g. '\"a' (which matches what *actual* LaTeX uses).

These probably should have been in the W3C symbol mapping file
(unicode.xml), but apparently they are not. This omission is rather
glaring, considering that e.g. \ss => ß and \aa => å *are* defined in
unicode.xml.