### PR TITLE
Fix std(::AbstractArray{<:AbstractFloat})

### DIFF
--- a/base/statistics.jl
+++ b/base/statistics.jl
@@ -296,7 +296,7 @@ _std(A::AbstractArray{<:AbstractFloat}, corrected::Bool, mean, dims) =
     sqrt!(var(A; corrected=corrected, mean=mean, dims=dims))
 
 _std(A::AbstractArray{<:AbstractFloat}, corrected::Bool, mean, ::Colon) =
-    sqrt!(var(A; corrected=corrected, mean=mean))
+    sqrt.(var(A; corrected=corrected, mean=mean))
 
 std(iterable; corrected::Bool=true, mean=nothing) =
     sqrt(var(iterable, corrected=corrected, mean=mean))

--- a/test/statistics.jl
+++ b/test/statistics.jl
@@ -155,6 +155,17 @@ end
     @test std([1,2,3]; mean=0) ≈ sqrt(7.0)
     @test std([1,2,3]; mean=0, corrected=false) ≈ sqrt(14.0/3)
 
+    @test stdm([1.0,2,3], 2) ≈ 1.
+    @test std([1.0,2,3]) ≈ 1.
+    @test std([1.0,2,3]; corrected=false) ≈ sqrt(2.0/3)
+    @test std([1.0,2,3]; mean=0) ≈ sqrt(7.0)
+    @test std([1.0,2,3]; mean=0, corrected=false) ≈ sqrt(14.0/3)
+
+    @test std([1.0,2,3]; dims=1)[] ≈ 1.
+    @test std([1.0,2,3]; dims=1, corrected=false)[] ≈ sqrt(2.0/3)
+    @test std([1.0,2,3]; dims=1, mean=[0])[] ≈ sqrt(7.0)
+    @test std([1.0,2,3]; dims=1, mean=[0], corrected=false)[] ≈ sqrt(14.0/3)
+
     @test stdm((1,2,3), 2) ≈ 1.
     @test std((1,2,3)) ≈ 1.
     @test std((1,2,3); corrected=false) ≈ sqrt(2.0/3)
@@ -409,9 +420,8 @@ end
 
 @testset "Issue #17153 and PR #17154" begin
     a = rand(10,10)
-    b = deepcopy(a)
+    b = copy(a)
     x = median(a, dims=1)
-
     @test b == a
     x = median(a, dims=2)
     @test b == a


### PR DESCRIPTION
Issue #25989 accidentally broke `std(rand(10))`.  This fixes it.