### PR TITLE
Deprecate `assert` function.

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -386,7 +386,7 @@ function abstract_apply(@nospecialize(aft), fargs::Vector{Any}, aargtypes::Vecto
     end
     res = Union{}
     nargs = length(fargs)
-    assert(nargs == length(aargtypes))
+    @assert nargs == length(aargtypes)
     splitunions = 1 < countunionsplit(aargtypes) <= sv.params.MAX_APPLY_UNION_ENUM
     ctypes = Any[Any[aft]]
     for i = 1:nargs

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1468,6 +1468,13 @@ end
 @deprecate(matchall(r::Regex, s::AbstractString; overlap::Bool = false),
            collect(m.match for m in eachmatch(r, s, overlap = overlap)))
 
+# PR 26194
+export assert
+function assert(x)
+    depwarn("`assert` is deprecated, use `@assert` instead.", :assert)
+    @assert x ""
+end
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/error.jl
+++ b/base/error.jl
@@ -105,23 +105,8 @@ Raises a `SystemError` for `errno` with the descriptive string `sysfunc` if `ift
 """
 systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), extrainfo)) : nothing
 
-## assertion functions and macros ##
+## assertion macro ##
 
-
-"""
-    assert(cond)
-
-Throw an [`AssertionError`](@ref) if `cond` is `false`.
-Also available as the macro [`@assert`](@ref).
-
-!!! warning
-    An assert might be disabled at various optimization levels.
-    Assert should therefore only be used as a debugging tool
-    and not used for authentication verification (e.g. verifying passwords),
-    nor should side effects needed for the function to work correctly
-    be used inside of asserts.
-"""
-assert(x) = x ? nothing : throw(AssertionError())
 
 """
     @assert cond [text]
@@ -132,7 +117,7 @@ Message `text` is optionally displayed upon assertion failure.
 !!! warning
     An assert might be disabled at various optimization levels.
     Assert should therefore only be used as a debugging tool
-    and not used for authentication verification (e.g. verifying passwords),
+    and not used for authentication verification (e.g., verifying passwords),
     nor should side effects needed for the function to work correctly
     be used inside of asserts.
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -716,7 +716,6 @@ export
     time_ns,
 
 # errors
-    assert,
     backtrace,
     catch_backtrace,
     error,

--- a/base/file.jl
+++ b/base/file.jl
@@ -634,7 +634,7 @@ function readlink(path::AbstractString)
         if ret < 0
             ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
             uv_error("readlink", ret)
-            assert(false)
+            @assert false
         end
         tgt = unsafe_string(ccall(:jl_uv_fs_t_ptr, Ptr{Cchar}, (Ptr{Cvoid},), req))
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)

--- a/base/show.jl
+++ b/base/show.jl
@@ -168,7 +168,7 @@ struct IOContext{IO_t <: IO} <: AbstractPipe
     dict::ImmutableDict{Symbol, Any}
 
     function IOContext{IO_t}(io::IO_t, dict::ImmutableDict{Symbol, Any}) where IO_t<:IO
-        assert(!(IO_t <: IOContext))
+        @assert !(IO_t <: IOContext) "Cannot create `IOContext` from another `IOContext`."
         return new(io, dict)
     end
 end

--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -133,7 +133,7 @@ function lookup(ip::Base.InterpreterIP)
         # interpreted top-level expression with no CodeInfo
         return [StackFrame(top_level_scope_sym, empty_sym, 0, nothing, false, false, 0)]
     else
-        assert(ip.code isa Core.CodeInfo)
+        @assert ip.code isa Core.CodeInfo
         codeinfo = ip.code
         func = top_level_scope_sym
         file = empty_sym

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -476,7 +476,7 @@ macro view(ex)
         if Meta.isexpr(ex, :ref)
             ex = Expr(:call, view, ex.args...)
         else # ex replaced by let ...; foo[...]; end
-            assert(Meta.isexpr(ex, :let) && Meta.isexpr(ex.args[2], :ref))
+            @assert Meta.isexpr(ex, :let) && Meta.isexpr(ex.args[2], :ref)
             ex.args[2] = Expr(:call, view, ex.args[2].args...)
         end
         Expr(:&&, true, esc(ex))

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -274,7 +274,6 @@ Core.throw
 Base.rethrow
 Base.backtrace
 Base.catch_backtrace
-Base.assert
 Base.@assert
 Base.ArgumentError
 Base.AssertionError

--- a/examples/clustermanager/0mq/ZMQCM.jl
+++ b/examples/clustermanager/0mq/ZMQCM.jl
@@ -140,7 +140,7 @@ function recv_data()
     try
         #println("On $(manager.zid_self) waiting to recv message")
         zid = parse(Int,String(ZMQ.recv(manager.sub)))
-        assert(zid == manager.zid_self)
+        @assert zid == manager.zid_self
 
         from_zid = parse(Int,String(ZMQ.recv(manager.sub)))
         mtype = String(ZMQ.recv(manager.sub))
@@ -279,4 +279,3 @@ function print_worker_stdout(io, pid)
         println("      From worker $(pid):\t$line")
     end
 end
-

--- a/examples/clustermanager/simple/test_simple.jl
+++ b/examples/clustermanager/simple/test_simple.jl
@@ -5,9 +5,9 @@ cmanpath = joinpath(@__DIR__, "UnixDomainCM.jl")
 include(cmanpath)
 
 npids = addprocs(UnixDomainCM(2))
-assert(length(npids) == 2)
+@assert length(npids) == 2
 test_pids = [remotecall_fetch(myid, x) for x in npids]
-assert(npids == test_pids)
+@assert npids == test_pids
 rmprocs(npids; waitfor=1.0)
 
 exit(0)

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -324,9 +324,9 @@ function init_worker(cookie::AbstractString, manager::ClusterManager=DefaultClus
     cluster_manager = manager
 
     # Since our pid has yet to be set, ensure no RemoteChannel / Future  have been created or addprocs() called.
-    assert(nprocs() <= 1)
-    assert(isempty(PGRP.refs))
-    assert(isempty(client_refs))
+    @assert nprocs() <= 1
+    @assert isempty(PGRP.refs)
+    @assert isempty(client_refs)
 
     # System is started in head node mode, cleanup related entries
     empty!(PGRP.workers)
@@ -493,7 +493,7 @@ end
 
 function create_worker(manager, wconfig)
     # only node 1 can add new nodes, since nobody else has the full list of address:port
-    assert(LPROC.id == 1)
+    @assert LPROC.id == 1
 
     # initiate a connect. Does not wait for connection completion in case of TCP.
     w = Worker()
@@ -650,8 +650,8 @@ Set the passed cookie as the cluster cookie, then returns it.
 """
 function cluster_cookie(cookie)
     # The cookie must be an ASCII string with length <=  HDR_COOKIE_LEN
-    assert(isascii(cookie))
-    assert(length(cookie) <= HDR_COOKIE_LEN)
+    @assert isascii(cookie)
+    @assert length(cookie) <= HDR_COOKIE_LEN
 
     cookie = rpad(cookie, HDR_COOKIE_LEN)
 
@@ -685,7 +685,7 @@ function topology(t)
         Base.depwarn("The topology :master_slave is deprecated, use :master_worker instead.", :topology)
         t = :master_worker
     end
-    assert(t in [:all_to_all, :master_worker, :custom])
+    @assert t in [:all_to_all, :master_worker, :custom]
     if (PGRP.topology==t) || ((myid()==1) && (nprocs()==1)) || (myid() > 1)
         PGRP.topology = t
     else
@@ -1004,7 +1004,7 @@ end
 
 
 function interrupt(pid::Integer)
-    assert(myid() == 1)
+    @assert myid() == 1
     w = map_pid_wrkr[pid]
     if isa(w, Worker)
         manage(w.manager, w.id, w.config, :interrupt)
@@ -1026,7 +1026,7 @@ Interrupt the current executing task on the specified workers. This is equivalen
 pressing Ctrl-C on the local machine. If no arguments are given, all workers are interrupted.
 """
 function interrupt(pids::AbstractVector=workers())
-    assert(myid() == 1)
+    @assert myid() == 1
     @sync begin
         for pid in pids
             @async interrupt(pid)
@@ -1120,7 +1120,7 @@ function init_parallel()
     global LPROC
     LPROC.id = 1
     cluster_cookie(randstring(HDR_COOKIE_LEN))
-    assert(isempty(PGRP.workers))
+    @assert isempty(PGRP.workers)
     register_worker(LPROC)
 end
 

--- a/stdlib/Distributed/src/messages.jl
+++ b/stdlib/Distributed/src/messages.jl
@@ -92,7 +92,7 @@ for (idx, tname) in enumerate(msgtypes)
     end
 end
 
-let msg_cases = :(assert(false))
+let msg_cases = :(@assert false)
     for i = length(msgtypes):-1:1
         mti = msgtypes[i]
         msg_cases = :(if idx == $i

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -61,7 +61,7 @@ for p in procs(d)
     idxl = last(idxes_in_p)
     d[idxf] = Float64(idxf)
     rv = remotecall_fetch(p, d,idxf,idxl) do D,idxf,idxl
-        assert(D[idxf] == Float64(idxf))
+        @assert D[idxf] == Float64(idxf)
         D[idxl] = Float64(idxl)
         D[idxl]
     end

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1760,7 +1760,7 @@ function diag(F::Factor{Tv}) where Tv
         xv = f.x
         for j in 1:f.n
             jj = unsafe_load(c0, j) + 1
-            assert(unsafe_load(r0, jj) == j - 1)
+            @assert unsafe_load(r0, jj) == j - 1
             res[j] = unsafe_load(xv, jj)
         end
     end

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -101,7 +101,7 @@ using Distributed
     cs = [Channel(N) for i in 1:5]
     tf2 = () -> begin
         if N > 0
-            foreach(c->assert(take!(c)==2), cs)
+            foreach(c->(@assert take!(c)==2), cs)
         end
         yield()
         error("foo")
@@ -145,7 +145,7 @@ using Distributed
 
     # channeled_tasks
     for T in [Any, Int]
-        chnls, tasks = Base.channeled_tasks(2, (c1,c2)->(assert(take!(c1)==1); put!(c2,2)); ctypes=[T,T], csizes=[N,N])
+        chnls, tasks = Base.channeled_tasks(2, (c1,c2)->(@assert take!(c1)==1; put!(c2,2)); ctypes=[T,T], csizes=[N,N])
         put!(chnls[1], 1)
         @test take!(chnls[2]) == 2
         @test_throws InvalidStateException wait(chnls[1])
@@ -156,7 +156,7 @@ using Distributed
 
         f=Future()
         tf4 = (c1,c2) -> begin
-            assert(take!(c1)==1)
+            @assert take!(c1)==1
             wait(f)
         end
 
@@ -181,7 +181,7 @@ using Distributed
 
     # channel
     tf6 = c -> begin
-        assert(take!(c)==2)
+        @assert take!(c)==2
         error("foo")
     end
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -2,21 +2,6 @@
 
 # Tests that do not really go anywhere else
 
-# test assert() method
-@test_throws AssertionError assert(false)
-let res = assert(true)
-    @test res === nothing
-end
-let
-    try
-        assert(false)
-        error("unexpected")
-    catch ex
-        @test isa(ex, AssertionError)
-        @test isempty(ex.msg)
-    end
-end
-
 # test @assert macro
 @test_throws AssertionError (@assert 1 == 2)
 @test_throws AssertionError (@assert false)


### PR DESCRIPTION
Addresses #8856. Tests pass locally for me. ~The deprecation warning message is currently mangled.~ The warning looks like:
```
julia> assert(true)
┌ Warning: `assert` is deprecated, use `@assert` instead.
│   caller = top-level scope
└ @ Core :0
```