### PR TITLE
documented function return type declaration #25718

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -125,8 +125,8 @@ There are three possible points of return from this function, returning the valu
 expressions, depending on the values of `x` and `y`. The `return` on the last line could be omitted
 since it is the last expression.
 
-A return type can also be specified in the function declaration using the `::` operator. This forces
-the function to always return the specified type.
+A return type can also be specified in the function declaration using the `::` operator. This converts
+the return value to the specified type.
 
 ```jldoctest
 function g(x,y)::Int8
@@ -134,7 +134,7 @@ function g(x,y)::Int8
 end
 ```
 
-Evaluating this function will always return an `Int8` regardless of the types of `x` and `y`.
+This function will always return an `Int8` regardless of the types of `x` and `y`. 
 See [Type Declarations](@ref) for more on return types.
 
 ## Operators Are Functions

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -125,6 +125,18 @@ There are three possible points of return from this function, returning the valu
 expressions, depending on the values of `x` and `y`. The `return` on the last line could be omitted
 since it is the last expression.
 
+A return type can also be specified in the function declaration using the `::` operator. This forces
+the function to always return the specified type.
+
+```jldoctest
+function g(x,y)::Int8
+    return x * y
+end
+```
+
+Evaluating this function will always return an `Int8` regardless of the types of `x` and `y`.
+See [Type Declarations](@ref) for more on return types.
+
 ## Operators Are Functions
 
 In Julia, most operators are just functions with support for special syntax. (The exceptions are


### PR DESCRIPTION
The Function section of the documentation now mentions return types with a helpful link to the Type Declaration section.