### PR TITLE
precompile: skip small functions

### DIFF
--- a/src/precompile.c
+++ b/src/precompile.c
@@ -311,7 +311,12 @@ static int precompile_enq_specialization_(jl_typemap_entry_t *l, void *closure)
 {
     if (jl_is_method_instance(l->func.value) &&
             l->func.linfo->functionObjectsDecls.functionObject == NULL &&
-            l->func.linfo->jlcall_api != JL_API_CONST)
+            l->func.linfo->jlcall_api != JL_API_CONST &&
+            (l->func.linfo->fptr ||
+             (l->func.linfo->inferred &&
+              l->func.linfo->inferred != jl_nothing &&
+              jl_ast_flag_inferred((jl_array_t*)l->func.linfo->inferred) &&
+              !jl_ast_flag_inlineable((jl_array_t*)l->func.linfo->inferred))))
         jl_array_ptr_1d_push((jl_array_t*)closure, (jl_value_t*)l->sig);
     return 1;
 }


### PR DESCRIPTION
These are likely to never be called directly, and would be quick to compile if they happened to be. In v0.6, I used to be manually excluding many of these from the sysimg; this is just a more general.

before
2565541888  maximum resident set size # 2.5 GB

after
1980424192  maximum resident set size # 2.0 GB

(build time and .ji size are also about proportionally (~25%) improved)