### PR TITLE
use empirically found threshold to speed up issubset by creating Set …

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -215,6 +215,16 @@ false
 ```
 """
 function issubset(l, r)
+
+    rlen = length(r)
+    #This threshold was empirically determined by repeatedly
+    #sampling using these two methods.
+    lenthresh = 70
+
+    if rlen > lenthresh && !isa(r, Set)
+       return issubset(l, Set(r))
+    end
+
     for elt in l
         if !in(elt, r)
             return false

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -221,7 +221,7 @@ function issubset(l, r)
     #sampling using these two methods.
     lenthresh = 70
 
-    if rlen > lenthresh && !isa(r, Set)
+    if rlen > lenthresh && !isa(r, AbstractSet)
        return issubset(l, Set(r))
     end
 


### PR DESCRIPTION
This plot shows the timing comparison between the hash-based `O(m + n)` issubset, vs the double for-loop `O(mn)` approach, where `m = length(n)` and `n = length(m)`.

This reveals a threshold size at which the constant-time lookup of the hashset overtakes the overhead imposed by creating that set. 

The x-axis shows the number of elements in the collection to check membership against (the right hand side). The y-axis shows time in seconds.

<img width="448" alt="issubsettiming5000" src="https://user-images.githubusercontent.com/11050562/36636649-4ae60ebe-1990-11e8-87f3-88400bf7b766.png">

It shows the necessity to use hashing for efficient performance. This addresses #24624.

Various timing experiments reveal the threshold size to be ~70. As shown:

<img width="403" alt="issubsettimingthreshold" src="https://user-images.githubusercontent.com/11050562/36636650-4af260e2-1990-11e8-8c65-9ae5cb2780a3.png">
