### PR TITLE
Bump Pkg3

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -515,8 +515,8 @@ end
 
 function explicit_manifest_deps_get(manifest_file::String, where::UUID, name::String)::Union{Bool,UUID}
     open(manifest_file) do io
+        uuid = deps = nothing
         state = :other
-        uuid = deps = path = nothing
         for line in eachline(io)
             if contains(line, re_array_of_tables)
                 uuid == where && break
@@ -525,8 +525,6 @@ function explicit_manifest_deps_get(manifest_file::String, where::UUID, name::St
             elseif state == :stanza
                 if (m = match(re_uuid_to_string, line)) != nothing
                     uuid = UUID(m.captures[1])
-                elseif (m = match(re_path_to_string, line)) != nothing
-                    path = String(m.captures[1])
                 elseif (m = match(re_deps_to_any, line)) != nothing
                     deps = String(m.captures[1])
                 elseif contains(line, re_subsection_deps)
@@ -541,15 +539,7 @@ function explicit_manifest_deps_get(manifest_file::String, where::UUID, name::St
             end
         end
         uuid == where || return false
-        if deps == nothing
-            (state == :deps || path == nothing) && return true
-            path = abspath(dirname(manifest_file), path)
-            project_file = env_project_file(path)
-            project_file isa String &&
-                return explicit_project_deps_get(project_file, name)
-            pkg = identify_package(name)
-            return pkg == nothing || pkg.uuid
-        end
+        deps == nothing && return true
         # TODO: handle inline table syntax
         if deps[1] != '[' || deps[end] != ']'
             @warn "Unexpected TOML deps format:\n$deps"

--- a/stdlib/Pkg3/src/API.jl
+++ b/stdlib/Pkg3/src/API.jl
@@ -334,7 +334,7 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     uuids = UUID[]
     _get_deps!(ctx, pkgs, uuids)
     length(uuids) == 0 && (@info("no packages to build"); return)
-    Pkg3.Operations.build_versions(ctx, uuids)
+    Pkg3.Operations.build_versions(ctx, uuids; do_resolve=true)
 end
 
 init() = init(Context())

--- a/stdlib/Pkg3/src/API.jl
+++ b/stdlib/Pkg3/src/API.jl
@@ -337,9 +337,11 @@ function build(ctx::Context, pkgs::Vector{PackageSpec}; kwargs...)
     Pkg3.Operations.build_versions(ctx, uuids)
 end
 
-function init(path::String)
+init() = init(Context())
+init(path::String) = init(Context(), path)
+function init(ctx::Context, path::String=pwd())
     print_first_command_header()
-    ctx = Context(env = EnvCache(joinpath(path, "Project.toml")))
+    Context!(ctx; env = EnvCache(joinpath(path, "Project.toml")))
     Pkg3.Operations.init(ctx)
 end
 

--- a/stdlib/Pkg3/src/API.jl
+++ b/stdlib/Pkg3/src/API.jl
@@ -301,7 +301,7 @@ end
 
 function _get_deps!(ctx::Context, pkgs::Vector{PackageSpec}, uuids::Vector{UUID})
     for pkg in pkgs
-        pkg.uuid in ctx.stdlib_uuids && continue
+        pkg.uuid in keys(ctx.stdlibs) && continue
         info = manifest_info(ctx.env, pkg.uuid)
         pkg.uuid in uuids && continue
         push!(uuids, pkg.uuid)

--- a/stdlib/Pkg3/src/REPLMode.jl
+++ b/stdlib/Pkg3/src/REPLMode.jl
@@ -233,7 +233,7 @@ function do_cmd!(tokens::Vector{Token}, repl)
     end
     # Using invokelatest to hide the functions from inference.
     # Otherwise it would try to infer everything here.
-    cmd.kind == CMD_INIT     ? Base.invokelatest(    do_init!, tokens) :
+    cmd.kind == CMD_INIT     ? Base.invokelatest(    do_init!, ctx, tokens) :
     cmd.kind == CMD_HELP     ? Base.invokelatest(    do_help!, ctx, tokens, repl) :
     cmd.kind == CMD_RM       ? Base.invokelatest(      do_rm!, ctx, tokens) :
     cmd.kind == CMD_ADD      ? Base.invokelatest(     do_add!, ctx, tokens) :

--- a/stdlib/Pkg3/src/Types.jl
+++ b/stdlib/Pkg3/src/Types.jl
@@ -898,18 +898,18 @@ end
 # Context #
 ###########
 function gather_stdlib_uuids()
-    stdlib_uuids = UUID[]
+    stdlibs = Dict{UUID, String}()
     stdlib_dir = joinpath(Sys.BINDIR, "..", "share", "julia", "site", "v$(VERSION.major).$(VERSION.minor)")
     for stdlib in readdir(stdlib_dir)
         projfile = joinpath(stdlib_dir, stdlib, "Project.toml")
         if isfile(projfile)
             proj = TOML.parsefile(joinpath(stdlib_dir, stdlib, "Project.toml"))
             if haskey(proj, "uuid")
-                push!(stdlib_uuids, UUID(proj["uuid"]))
+                stdlibs[UUID(proj["uuid"])] = stdlib
             end
         end
     end
-    return stdlib_uuids
+    return stdlibs
 end
 
 # ENV variables to set some of these defaults?
@@ -919,7 +919,7 @@ Base.@kwdef mutable struct Context
     use_libgit2_for_all_downloads::Bool = false
     num_concurrent_downloads::Int = 8
     graph_verbose::Bool = false
-    stdlib_uuids::Vector{UUID} = gather_stdlib_uuids()
+    stdlibs::Dict{UUID,String} = gather_stdlib_uuids()
 end
 
 function Context!(ctx::Context; kwargs...)

--- a/stdlib/Pkg3/src/Types.jl
+++ b/stdlib/Pkg3/src/Types.jl
@@ -432,7 +432,7 @@ const default_envs = [
     "default",
 ]
 
-struct EnvCache
+mutable struct EnvCache
     # environment info:
     env::Union{Nothing,String,AbstractEnv}
     git::Union{Nothing,LibGit2.GitRepo}
@@ -928,7 +928,7 @@ function Context!(ctx::Context; kwargs...)
     end
 end
 
-function write_env(ctx::Context)
+function write_env(ctx::Context; no_output=false)
     env = ctx.env
     # load old environment for comparison
     old_env = EnvCache(env.env)
@@ -936,8 +936,8 @@ function write_env(ctx::Context)
     project = deepcopy(env.project)
     isempty(project["deps"]) && delete!(project, "deps")
     if !isempty(project) || ispath(env.project_file)
-        @info "Updating $(pathrepr(env, env.project_file))"
-        Pkg3.Display.print_project_diff(old_env, env)
+        no_output || @info "Updating $(pathrepr(env, env.project_file))"
+        no_output || Pkg3.Display.print_project_diff(old_env, env)
         if !ctx.preview
             mkpath(dirname(env.project_file))
             open(env.project_file, "w") do io
@@ -947,8 +947,8 @@ function write_env(ctx::Context)
     end
     # update the manifest file
     if !isempty(env.manifest) || ispath(env.manifest_file)
-        @info "Updating $(pathrepr(env, env.manifest_file))"
-        Pkg3.Display.print_manifest_diff(old_env, env)
+        no_output || @info "Updating $(pathrepr(env, env.manifest_file))"
+        no_output || Pkg3.Display.print_manifest_diff(old_env, env)
         manifest = deepcopy(env.manifest)
         uniques = sort!(collect(keys(manifest)), by=lowercase)
         filter!(name->length(manifest[name]) == 1, uniques)

--- a/test/project/Manifest.toml
+++ b/test/project/Manifest.toml
@@ -12,6 +12,9 @@ path = "deps/Foo2.jl"
 [[Bar]]
 uuid = "2a550a13-6bab-4a91-a4ee-dff34d6b99d0"
 path = "deps/Bar"
+    [Bar.deps]
+    Baz = "6801f525-dc68-44e8-a4e8-cabd286279e7"
+    Foo = "6f418443-bd2e-4783-b551-cdbac608adf2"
 
 [[Baz]]
 uuid = "6801f525-dc68-44e8-a4e8-cabd286279e7"
@@ -21,6 +24,5 @@ git-tree-sha1 = "efc7e24c53d6a328011975294a2c75fed2f9800a"
     Qux = "b5ec9b9c-e354-47fd-b367-a348bdc8f909"
 
 [[Qux]]
-deps = []
 uuid = "b5ec9b9c-e354-47fd-b367-a348bdc8f909"
 path = "deps/Qux.jl"

--- a/test/project/deps/Bar/Project.toml
+++ b/test/project/deps/Bar/Project.toml
@@ -1,6 +1,0 @@
-name = "Bar"
-uuid = "2a550a13-6bab-4a91-a4ee-dff34d6b99d0"
-
-[deps]
-Baz = "6801f525-dc68-44e8-a4e8-cabd286279e7"
-Foo = "6f418443-bd2e-4783-b551-cdbac608adf2"


### PR DESCRIPTION
* Fixes a problem with `init` in the REPL, fixes https://github.com/JuliaLang/Pkg3.jl/issues/149.
* Tweak the way packages are being built (and tested), fixes https://github.com/JuliaLang/Pkg3.jl/issues/152. As a consequence, #26139 is not needed, and is therefore reverted.
* Fixes loading of checked out packages that uses stdlibs, for example`pkg> checkout Revise` -> `julia> using Revise`.
