### PR TITLE
Rework replace and replace!

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -682,6 +682,14 @@ Return a copy of collection `A` where, for each pair `old=>new` in `old_new`,
 all occurrences of `old` are replaced by `new`.
 Equality is determined using [`isequal`](@ref).
 If `count` is specified, then replace at most `count` occurrences in total.
+
+The element type of the result is chosen using promotion (see [`promote_type`](@ref))
+based on the element type of `A` and on the types of the `new` values in pairs.
+If `count` is omitted and the element type of `A` is a `Union`, the element type
+of the result will not include singleton types which are replaced with values of
+a different type: for example, `Union{T,Missing}` will become `T` if `missing` is
+replaced.
+
 See also [`replace!`](@ref).
 
 # Examples
@@ -692,6 +700,11 @@ julia> replace([1, 2, 1, 3], 1=>0, 2=>4, count=2)
  4
  1
  3
+
+julia> replace([1, missing], missing=>0)
+2-element Array{Int64,1}:
+ 1
+ 0
 ```
 """
 function replace(A, old_new::Pair...; count::Union{Integer,Nothing}=nothing)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -548,6 +548,15 @@ end
     x = @inferred replace(x -> x > 1, [1, 2], missing)
     @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
 
+    x = @inferred replace([1, missing], missing=>2)
+    @test x == [1, 2] && x isa Vector{Int}
+    x = @inferred replace([1, missing], missing=>2, count=1)
+    @test x == [1, 2] && x isa Vector{Union{Int, Missing}}
+    x = @inferred replace([1, missing], missing=>missing)
+    @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
+    x = @inferred replace([1, missing], missing=>2, 1=>missing)
+    @test isequal(x, [missing, 2]) && x isa Vector{Union{Int, Missing}}
+
     # test that isequal is used
     @test replace([NaN, 1.0], NaN=>0.0) == [0.0, 1.0]
     @test replace([1, missing], missing=>0) == [1, 0]


### PR DESCRIPTION
Introduce a new `replace!(new::Callable, res::T, A::T, count::Union{Nothing,Int})` method which custom types can implement to support all replace and replace! methods automatically, instead of the current `replace!(new::Callable, A::T, count::Int)`. This offers several advantages:
- For arrays, instead of copying the input and then replace elements, we can do the copy and replace operations at the same time, which is quite faster for arrays when `count=nothing`.
- For dicts and sets, copying up-front is still faster as long as most original elements are preserved, but for `replace`, we can apply replacements directly instead of storing a them in a temporary vector.
- When the LHS of a pair contains a singleton type, we can subtract it from the element type
of the result, e.g. `Union{T,Missing}` becomes `T`.

Also simplify the dispatch logic by removing the internal _replace! method in favor of replace!.


Benchmarks indicate that this PR significantly improves performance for arrays (except for `Int8`, for which it's stable), but not so much for sets (except for `Int8`, which are faster for some reason). So the specialized code for sets/dicts when origin and destination are different might not be worth adding.
```julia
A = rand(Int, 10_000);
B = rand(1:10, 10_000);
C = rand(Int8, 10_000);
@btime replace(A, 1 => 0);
@btime replace(B, 1 => 0);
@btime replace(C, 1 => Int8(0));
@btime replace(A, 1 => 0, count=500);
@btime replace(B, 1 => 0, count=500);
@btime replace(C, 1 => Int8(0), count=500);

sA = Set(A);
sB = Set(B);
sC = Set(C);
@btime replace(x -> ifelse(isodd(x), x-1, x), sA);
@btime replace(x -> ifelse(isodd(x), x-1, x), sB);
@btime replace(x -> ifelse(isodd(x), x-1, x), sC);

# Before
julia> @btime replace(A, 1 => 0);
  27.696 μs (3 allocations: 78.23 KiB)

julia> @btime replace(B, 1 => 0);
  36.078 μs (3 allocations: 78.23 KiB)

julia> @btime replace(C, 1 => Int8(0));
  17.438 μs (2 allocations: 9.97 KiB)

julia> @btime replace(A, 1 => 0, count=500);
  27.600 μs (4 allocations: 78.25 KiB)

julia> @btime replace(B, 1 => 0, count=500);
  20.220 μs (4 allocations: 78.25 KiB)

julia> @btime replace(C, 1 => Int8(0), count=500);
  17.422 μs (3 allocations: 9.98 KiB)

julia> @btime replace(x -> ifelse(isodd(x), x-1, x), sA);
  645.355 μs (4889 allocations: 477.13 KiB)

julia> @btime replace(x -> ifelse(isodd(x), x-1, x), sB);
  22.788 μs (18 allocations: 144.81 KiB)

julia> @btime replace(x -> ifelse(isodd(x), x-1, x), sC);
  22.137 μs (207 allocations: 8.22 KiB)

# After
julia> @btime replace(A, 1 => 0);
  16.180 μs (3 allocations: 78.23 KiB)

julia> @btime replace(B, 1 => 0);
  23.398 μs (3 allocations: 78.23 KiB)

julia> @btime replace(C, 1 => Int8(0));
  16.410 μs (2 allocations: 9.97 KiB)

julia> @btime replace(A, 1 => 0, count=500);
  17.062 μs (4 allocations: 78.25 KiB)

julia> @btime replace(B, 1 => 0, count=500);
  15.328 μs (4 allocations: 78.25 KiB)

julia> @btime replace(C, 1 => Int8(0), count=500);
  18.733 μs (3 allocations: 9.98 KiB)

julia> @btime replace(x -> ifelse(isodd(x), x-1, x), sA);
  633.428 μs (4798 allocations: 219.25 KiB)

julia> @btime replace(x -> ifelse(isodd(x), x-1, x), sB);
  22.580 μs (12 allocations: 144.47 KiB)

julia> @btime replace(x -> ifelse(isodd(x), x-1, x), sC);
  10.096 μs (69 allocations: 3.45 KiB)
```