### PR TITLE
[RFC] Print nothing in the REPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -146,7 +146,7 @@ function print_response(errio::IO, @nospecialize(val), bt, show_value::Bool, hav
                 Base.invokelatest(Base.display_error, errio, val, bt)
                 iserr, lasterr = false, ()
             else
-                if val !== nothing && show_value
+                if show_value
                     try
                         if specialdisplay === nothing
                             Base.invokelatest(display, val)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -180,7 +180,7 @@ fake_repl() do stdin_write, stdout_read, repl
                 @test contains(s, "shell> ")
             end
             s = readuntil(stdout_read, "\n", keep=true)
-            @test s == "\e[0m\n" # the child has exited
+            @test s == "\e[0mnothing\n" # the child has exited
         finally
             redirect_stdout(old_stdout)
         end


### PR DESCRIPTION
Now that more functions, e.g. the `find`* family return `nothing` it does not make sense to hide it.
It is also better to be transparent with the return value.

Before:
```julia
julia> nothing

julia> findfirst(x -> x==4, [1,2,3])

julia> coalesce(nothing)
```

After:
```julia
julia> nothing
nothing

julia> findfirst(x -> x==4, [1,2,3])
nothing

julia> coalesce(nothing)
nothing
```

One thing that is a little bit annoying:
```julia
julia> print("hello")
hellonothing
```

But I guess thats why we have `;` supress output? And really that case is not different from something like:
```julia
julia> foo() = (print("hello"); return 2);

julia> foo()
hello2
```

Edit: Also this is not very nice
```julia
julia> using Random
nothing
```