### PR TITLE
Revert "Deprecate ismatch(r, s) in favor of contains(s, r)"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1010,8 +1010,6 @@ Deprecated or removed
     `findlast`/`findprev` respectively, in combination with the new `equalto` and `occursin`
     predicates for some methods ([#24673]
 
-  * `ismatch(regex, str)` has been deprecated in favor of `contains(str, regex)` ([#24673]).
-
   * `matchall` has been deprecated in favor of `collect(m.match for m in eachmatch(r, s))` ([#26071]).
 
   * `similar(::Associative)` has been deprecated in favor of `empty(::Associative)`, and

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1240,7 +1240,7 @@ end
 @deprecate rsearchindex(s::AbstractString, c::Char) findlast(equalto(c), s)
 @deprecate rsearchindex(s::AbstractString, c::Char, i::Integer) findprev(equalto(c), s, i)
 
-@deprecate ismatch(r::Regex, s::AbstractString) contains(s, r)
+@deprecate contains(s::AbstractString, r::Regex) ismatch(r, s)
 
 @deprecate findin(a, b) findall(occursin(b), a)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -459,6 +459,7 @@ export
     findmax!,
     findnext,
     findprev,
+    ismatch,
     occursin,
     match,
     searchsorted,

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -203,7 +203,7 @@ function strptime(fmt::AbstractString, timestr::AbstractString)
     @static if Sys.isapple()
         # if we didn't explicitly parse the weekday or year day, use mktime
         # to fill them in automatically.
-        if !contains(fmt, r"([^%]|^)%(a|A|j|w|Ow)")
+        if !ismatch(r"([^%]|^)%(a|A|j|w|Ow)", fmt)
             ccall(:mktime, Int, (Ref{TmStruct},), tm)
         end
     end

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -202,7 +202,7 @@ function url(m::Method)
     (m.file == :null || m.file == :string) && return ""
     file = string(m.file)
     line = m.line
-    line <= 0 || contains(file, r"In\[[0-9]+\]") && return ""
+    line <= 0 || ismatch(r"In\[[0-9]+\]", file) && return ""
     Sys.iswindows() && (file = replace(file, '\\' => '/'))
     libgit2_id = PkgId(UUID((0x76f85450_5226_5b5a,0x8eaa_529ad045b433)), "LibGit2")
     if inbase(M)

--- a/base/path.jl
+++ b/base/path.jl
@@ -78,7 +78,7 @@ end
 
 
 if Sys.iswindows()
-    isabspath(path::String) = contains(path, path_absolute_re)
+    isabspath(path::String) = ismatch(path_absolute_re, path)
 else
     isabspath(path::String) = startswith(path, '/')
 end
@@ -113,7 +113,7 @@ julia> isdirpath("/home/")
 true
 ```
 """
-isdirpath(path::String) = contains(splitdrive(path)[2], path_directory_re)
+isdirpath(path::String) = ismatch(path_directory_re, splitdrive(path)[2])
 
 """
     splitdir(path::AbstractString) -> (AbstractString, AbstractString)
@@ -218,9 +218,9 @@ function joinpath(a::String, b::String)
     B, b = splitdrive(b)
     !isempty(B) && A != B && return string(B,b)
     C = isempty(B) ? A : B
-    isempty(a)                              ? string(C,b) :
-    contains(a[end:end], path_separator_re) ? string(C,a,b) :
-                                              string(C,a,pathsep(a,b),b)
+    isempty(a)                             ? string(C,b) :
+    ismatch(path_separator_re, a[end:end]) ? string(C,a,b) :
+                                             string(C,a,pathsep(a,b),b)
 end
 joinpath(a::AbstractString, b::AbstractString) = joinpath(String(a), String(b))
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -141,19 +141,39 @@ function getindex(m::RegexMatch, name::Symbol)
 end
 getindex(m::RegexMatch, name::AbstractString) = m[Symbol(name)]
 
-function contains(s::AbstractString, r::Regex, offset::Integer=0)
+"""
+    ismatch(r::Regex, s::AbstractString) -> Bool
+
+Test whether a string contains a match of the given regular expression.
+
+# Examples
+```jldoctest
+julia> rx = r"a.a"
+r"a.a"
+
+julia> ismatch(rx, "aba")
+true
+
+julia> ismatch(rx, "abba")
+false
+
+julia> rx("aba")
+true
+```
+"""
+function ismatch(r::Regex, s::AbstractString, offset::Integer=0)
     compile(r)
     return PCRE.exec(r.regex, String(s), offset, r.match_options,
                      r.match_data)
 end
 
-function contains(s::SubString, r::Regex, offset::Integer=0)
+function ismatch(r::Regex, s::SubString, offset::Integer=0)
     compile(r)
     return PCRE.exec(r.regex, s, offset, r.match_options,
                      r.match_data)
 end
 
-(r::Regex)(s) = contains(s, r)
+(r::Regex)(s) = ismatch(r, s)
 
 """
     match(r::Regex, s::AbstractString[, idx::Integer[, addopts]])

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -426,28 +426,16 @@ julia> findprev("Julia", "JuliaLang", 6)
 findprev(t::AbstractString, s::AbstractString, i::Integer) = _rsearch(s, t, i)
 
 """
-    contains(haystack::AbstractString, needle::Union{AbstractString,Regex,Char})
+    contains(haystack::AbstractString, needle::Union{AbstractString,Char})
 
-Determine whether the second argument is a substring of the first. If `needle`
-is a regular expression, checks whether `haystack` contains a match.
+Determine whether the second argument is a substring of the first.
 
 # Examples
 ```jldoctest
 julia> contains("JuliaLang is pretty cool!", "Julia")
 true
-
-julia> contains("JuliaLang is pretty cool!", 'a')
-true
-
-julia> contains("aba", r"a.a")
-true
-
-julia> contains("abba", r"a.a")
-false
 ```
 """
-function contains end
-
 contains(haystack::AbstractString, needle::Union{AbstractString,Char}) =
     _searchindex(haystack, needle, firstindex(haystack)) != 0
 

--- a/base/version.jl
+++ b/base/version.jl
@@ -21,7 +21,7 @@ struct VersionNumber
             if ident isa Integer
                 ident >= 0 || throw(ArgumentError("invalid negative pre-release identifier: $ident"))
             else
-                if !contains(ident, r"^(?:|[0-9a-z-]*[a-z-][0-9a-z-]*)$"i) ||
+                if !ismatch(r"^(?:|[0-9a-z-]*[a-z-][0-9a-z-]*)$"i, ident) ||
                     isempty(ident) && !(length(pre)==1 && isempty(bld))
                     throw(ArgumentError("invalid pre-release identifier: $(repr(ident))"))
                 end
@@ -31,7 +31,7 @@ struct VersionNumber
             if ident isa Integer
                 ident >= 0 || throw(ArgumentError("invalid negative build identifier: $ident"))
             else
-                if !contains(ident, r"^(?:|[0-9a-z-]*[a-z-][0-9a-z-]*)$"i) ||
+                if !ismatch(r"^(?:|[0-9a-z-]*[a-z-][0-9a-z-]*)$"i, ident) ||
                     isempty(ident) && length(bld)!=1
                     throw(ArgumentError("invalid build identifier: $(repr(ident))"))
                 end
@@ -83,7 +83,7 @@ function split_idents(s::AbstractString)
     idents = split(s, '.')
     ntuple(length(idents)) do i
         ident = idents[i]
-        contains(ident, r"^\d+$") ? parse(UInt64, ident) : String(ident)
+        ismatch(r"^\d+$", ident) ? parse(UInt64, ident) : String(ident)
     end
 end
 

--- a/doc/src/base/strings.md
+++ b/doc/src/base/strings.md
@@ -24,6 +24,7 @@ Base.Docs.@text_str
 Base.isvalid(::Any)
 Base.isvalid(::Any, ::Any)
 Base.isvalid(::AbstractString, ::Integer)
+Base.ismatch
 Base.match
 Base.eachmatch
 Base.isless(::AbstractString, ::AbstractString)
@@ -35,7 +36,7 @@ Base.findfirst(::AbstractString, ::AbstractString)
 Base.findnext(::AbstractString, ::AbstractString, ::Integer)
 Base.findlast(::AbstractString, ::AbstractString)
 Base.findprev(::AbstractString, ::AbstractString, ::Integer)
-Base.contains
+Base.contains(::AbstractString, ::AbstractString)
 Base.reverse(::Union{String,SubString{String}})
 Base.replace(s::AbstractString, ::Pair)
 Base.split

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -606,17 +606,17 @@ julia> typeof(ans)
 Regex
 ```
 
-To check if a regex matches a string, use [`contains`](@ref):
+To check if a regex matches a string, use [`ismatch`](@ref):
 
 ```jldoctest
-julia> contains("not a comment", r"^\s*(?:#|$)")
+julia> ismatch(r"^\s*(?:#|$)", "not a comment")
 false
 
-julia> contains("# a comment", r"^\s*(?:#|$)")
+julia> ismatch(r"^\s*(?:#|$)", "# a comment")
 true
 ```
 
-As one can see here, [`contains`](@ref) simply returns true or false, indicating whether the
+As one can see here, [`ismatch`](@ref) simply returns true or false, indicating whether the
 given regex matches the string or not. Commonly, however, one wants to know not just whether a
 string matched, but also *how* it matched. To capture this information about a match, use the
 [`match`](@ref) function instead:

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -15,7 +15,7 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
     end
 end
 @test length(filter(dlls) do dl
-        return contains(basename(dl), Regex("^libjulia(?:.*)\\.$(Libdl.dlext)(?:\\..+)?\$"))
+        return ismatch(Regex("^libjulia(?:.*)\\.$(Libdl.dlext)(?:\\..+)?\$"), basename(dl))
     end) == 1 # look for something libjulia-like (but only one)
 
 # library handle pointer must not be NULL

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -125,7 +125,7 @@ function check()
     blas = vendor()
     if blas == :openblas || blas == :openblas64
         openblas_config = openblas_get_config()
-        openblas64 = contains(openblas_config, r".*USE64BITINT.*")
+        openblas64 = ismatch(r".*USE64BITINT.*", openblas_config)
         if Base.USE_BLAS64 != openblas64
             if !openblas64
                 @error """

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -54,7 +54,7 @@ getindex(J::UniformScaling, i::Integer,j::Integer) = ifelse(i==j,J.λ,zero(J.λ)
 
 function show(io::IO, J::UniformScaling)
     s = "$(J.λ)"
-    if contains(s, r"\w+\s*[\+\-]\s*\w+")
+    if ismatch(r"\w+\s*[\+\-]\s*\w+", s)
         s = "($s)"
     end
     print(io, "$(typeof(J))\n$s*I")

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -211,11 +211,11 @@ function admonition(stream::IO, block::MD)
             let untitled = r"^([a-z]+)$",          # !!! <CATEGORY_NAME>
                 titled   = r"^([a-z]+) \"(.*)\"$", # !!! <CATEGORY_NAME> "<TITLE>"
                 line     = strip(readline(stream))
-                if contains(line, untitled)
+                if ismatch(untitled, line)
                     m = match(untitled, line)
                     # When no title is provided we use CATEGORY_NAME, capitalising it.
                     m.captures[1], ucfirst(m.captures[1])
-                elseif contains(line, titled)
+                elseif ismatch(titled, line)
                     m = match(titled, line)
                     # To have a blank TITLE provide an explicit empty string as TITLE.
                     m.captures[1], m.captures[2]
@@ -270,10 +270,10 @@ function list(stream::IO, block::MD)
         indent = isempty(bullet) ? (return false) : length(bullet)
         # Calculate the starting number and regex to use for bullet matching.
         initial, regex =
-            if contains(bullet, BULLETS)
+            if ismatch(BULLETS, bullet)
                 # An unordered list. Use `-1` to flag the list as unordered.
                 -1, BULLETS
-            elseif contains(bullet, r"^ {0,3}\d+(\.|\))( |$)")
+            elseif ismatch(r"^ {0,3}\d+(\.|\))( |$)", bullet)
                 # An ordered list. Either with `1. ` or `1) ` style numbering.
                 r = contains(bullet, ".") ? r"^ {0,3}(\d+)\.( |$)" : r"^ {0,3}(\d+)\)( |$)"
                 Base.parse(Int, match(r, bullet).captures[1]), r

--- a/stdlib/Markdown/src/Common/inline.jl
+++ b/stdlib/Markdown/src/Common/inline.jl
@@ -152,7 +152,7 @@ function _is_mailto(s::AbstractString)
     length(s) < 6 && return false
     # slicing strings is a bit risky, but this equality check is safe
     lowercase(s[1:6]) == "mailto:" || return false
-    return contains(s[6:end], _email_regex)
+    return ismatch(_email_regex, s[6:end])
 end
 
 # –––––––––––

--- a/stdlib/Markdown/src/render/rst.jl
+++ b/stdlib/Markdown/src/render/rst.jl
@@ -115,7 +115,7 @@ rstinline(io::IO, md::Vector) = !isempty(md) && rstinline(io, md...)
 # rstinline(io::IO, md::Image) = rstinline(io, ".. image:: ", md.url)
 
 function rstinline(io::IO, md::Link)
-    if contains(md.url, r":(func|obj|ref|exc|class|const|data):`\.*")
+    if ismatch(r":(func|obj|ref|exc|class|const|data):`\.*", md.url)
         rstinline(io, md.url)
     else
         rstinline(io, "`", md.text, " <", md.url, ">`_")

--- a/stdlib/Pkg/src/read.jl
+++ b/stdlib/Pkg/src/read.jl
@@ -20,7 +20,7 @@ function available(names=readdir("METADATA"))
         versdir = joinpath("METADATA", pkg, "versions")
         isdir(versdir) || continue
         for ver in readdir(versdir)
-            contains(ver, Base.VERSION_REGEX) || continue
+            ismatch(Base.VERSION_REGEX, ver) || continue
             isfile(versdir, ver, "sha1") || continue
             haskey(pkgs,pkg) || (pkgs[pkg] = Dict{VersionNumber,Available}())
             pkgs[pkg][VersionNumber(ver)] = Available(
@@ -41,7 +41,7 @@ function latest(names=readdir("METADATA"))
         isdir(versdir) || continue
         pkgversions = VersionNumber[]
         for ver in readdir(versdir)
-            contains(ver, Base.VERSION_REGEX) || continue
+            ismatch(Base.VERSION_REGEX, ver) || continue
             isfile(versdir, ver, "sha1") || continue
             push!(pkgversions, VersionNumber(ver))
         end
@@ -116,7 +116,7 @@ function ispinned(prepo::LibGit2.GitRepo)
     LibGit2.isattached(prepo) || return false
     br = LibGit2.branch(prepo)
     # note: regex is based on the naming scheme used in Entry.pin()
-    return contains(br, r"^pinned\.[0-9a-f]{8}\.tmp$")
+    return ismatch(r"^pinned\.[0-9a-f]{8}\.tmp$", br)
 end
 
 function installed_version(pkg::AbstractString, prepo::LibGit2.GitRepo, avail::Dict=available(pkg))

--- a/stdlib/Pkg/src/reqs.jl
+++ b/stdlib/Pkg/src/reqs.jl
@@ -27,7 +27,7 @@ struct Requirement <: Line
         end
         isempty(fields) && throw(PkgError("invalid requires entry: $content"))
         package = popfirst!(fields)
-        all(field->contains(field, Base.VERSION_REGEX), fields) ||
+        all(field->ismatch(Base.VERSION_REGEX, field), fields) ||
             throw(PkgError("invalid requires entry for $package: $content"))
         versions = map(VersionNumber, fields)
         issorted(versions) || throw(PkgError("invalid requires entry for $package: $content"))
@@ -59,7 +59,7 @@ function read(readable::Vector{<:AbstractString})
     lines = Line[]
     for line in readable
         line = chomp(line)
-        push!(lines, contains(line, r"^\s*(?:#|$)") ? Comment(line) : Requirement(line))
+        push!(lines, ismatch(r"^\s*(?:#|$)", line) ? Comment(line) : Requirement(line))
     end
     return lines
 end
@@ -67,7 +67,7 @@ end
 function read(readable::Union{IO,Base.AbstractCmd})
     lines = Line[]
     for line in eachline(readable)
-        push!(lines, contains(line, r"^\s*(?:#|$)") ? Comment(line) : Requirement(line))
+        push!(lines, ismatch(r"^\s*(?:#|$)", line) ? Comment(line) : Requirement(line))
     end
     return lines
 end

--- a/stdlib/Pkg/test/pkg.jl
+++ b/stdlib/Pkg/test/pkg.jl
@@ -522,9 +522,9 @@ temp_pkg_dir() do
         logs,_ = Test.collect_test_logs() do
             Pkg.update("ColorTypes")
         end
-        @test any(contains(l, (:info,r"Upgrading ColorTypes: v0\.2\.2 => v\d+\.\d+\.\d+")) for l in logs)
-        @test any(contains(l, (:info,r"Upgrading Compat: v0\.7\.18 => v\d+\.\d+\.\d+")) for l in logs)
-        @test !any(contains(l, (:info,r"Upgrading Colors")) for l in logs)
+        @test any(ismatch((:info,r"Upgrading ColorTypes: v0\.2\.2 => v\d+\.\d+\.\d+"), l) for l in logs)
+        @test any(ismatch((:info,r"Upgrading Compat: v0\.7\.18 => v\d+\.\d+\.\d+"), l) for l in logs)
+        @test !any(ismatch((:info,r"Upgrading Colors"),l) for l in logs)
 
         @test Pkg.installed("Colors") == v"0.6.4"
 
@@ -546,8 +546,8 @@ temp_pkg_dir() do
 
         Pkg.add(package)
         msg = read(ignorestatus(`$(Base.julia_cmd()) --startup-file=no -e
-            "redirect_stderr(stdout); using Logging; global_logger(SimpleLogger(stdout)); using Example; import Pkg; Pkg.update(\"$package\")"`), String)
-        @test contains(msg, Regex("- $package.*Restart Julia to use the updated versions","s"))
+            "redirect_stderr(STDOUT); using Logging; global_logger(SimpleLogger(STDOUT)); using Example; Pkg.update(\"$package\")"`), String)
+        @test ismatch(Regex("- $package.*Restart Julia to use the updated versions","s"), msg)
     end
 
     # Verify that the --startup-file flag is respected by Pkg.build / Pkg.test

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -126,7 +126,7 @@ function complete_keyword(s::Union{String,SubString{String}})
 end
 
 function complete_path(path::AbstractString, pos; use_envpath=false)
-    if Base.Sys.isunix() && contains(path, r"^~(?:/|$)")
+    if Base.Sys.isunix() && ismatch(r"^~(?:/|$)", path)
         # if the path is just "~", don't consider the expanded username as a prefix
         if path == "~"
             dir, prefix = homedir(), ""
@@ -419,7 +419,7 @@ function afterusing(string::String, startpos::Int)
     r = findfirst(r"\s(gnisu|tropmi)\b", rstr)
     isempty(r) && return false
     fr = reverseind(str, last(r))
-    return contains(str[fr:end], r"^\b(using|import)\s*((\w+[.])*\w+\s*,\s*)*$")
+    return ismatch(r"^\b(using|import)\s*((\w+[.])*\w+\s*,\s*)*$", str[fr:end])
 end
 
 function bslash_completions(string, pos)

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -842,23 +842,22 @@ for keys = [altkeys, merge(altkeys...)],
 
             # Check the history file
             history = read(histfile, String)
-            @test contains(history,
-                           r"""
-                           ^\#\ time:\ .*\n
-                            \#\ mode:\ julia\n
-                            \t1\ \+\ 1;\n
-                            \#\ time:\ .*\n
-                            \#\ mode:\ julia\n
-                            \tmulti=2;\n
-                            \tline=2;\n
-                            \#\ time:\ .*\n
-                            \#\ mode:\ julia\n
-                            \tmulti=3;\n
-                            \tline=1;\n
-                            \#\ time:\ .*\n
-                            \#\ mode:\ julia\n
-                            \t1\ \*\ 1;\n$
-                           """xm)
+            @test ismatch(r"""
+                          ^\#\ time:\ .*\n
+                           \#\ mode:\ julia\n
+                           \t1\ \+\ 1;\n
+                           \#\ time:\ .*\n
+                           \#\ mode:\ julia\n
+                           \tmulti=2;\n
+                           \tline=2;\n
+                           \#\ time:\ .*\n
+                           \#\ mode:\ julia\n
+                           \tmulti=3;\n
+                           \tline=1;\n
+                           \#\ time:\ .*\n
+                           \#\ mode:\ julia\n
+                           \t1\ \*\ 1;\n$
+                          """xm, history)
         end
     finally
         rm(histfile, force=true)

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -523,10 +523,10 @@ end
 
 # Test for warning messages (deprecated)
 
-contains_warn(output, s::AbstractString) = contains(output, s)
-contains_warn(output, s::Regex) = contains(output, s)
-contains_warn(output, s::Function) = s(output)
-contains_warn(output, S::Union{AbstractArray,Tuple}) = all(s -> contains_warn(output, s), S)
+ismatch_warn(s::AbstractString, output) = contains(output, s)
+ismatch_warn(s::Regex, output) = ismatch(s, output)
+ismatch_warn(s::Function, output) = s(output)
+ismatch_warn(S::Union{AbstractArray,Tuple}, output) = all(s -> ismatch_warn(s, output), S)
 
 """
     @test_warn msg expr
@@ -548,7 +548,7 @@ macro test_warn(msg, expr)
                         $(esc(expr))
                     end
                 end
-                @test contains_warn(read(fname, String), $(esc(msg)))
+                @test ismatch_warn($(esc(msg)), read(fname, String))
                 ret
             finally
                 rm(fname, force=true)

--- a/stdlib/Test/src/logging.jl
+++ b/stdlib/Test/src/logging.jl
@@ -3,7 +3,7 @@
 using Logging
 import Logging: Info,
     shouldlog, handle_message, min_enabled_level, catch_exceptions
-import Base: contains
+import Base: ismatch
 
 #-------------------------------------------------------------------------------
 # Log records
@@ -113,7 +113,7 @@ corresponding to the arguments to passed to `AbstractLogger` via the
 Elements which are present will be matched pairwise with the log record fields
 using `==` by default, with the special cases that `Symbol`s may be used for
 the standard log levels, and `Regex`s in the pattern will match string or
-Symbol fields using `contains`.
+Symbol fields using `ismatch`.
 
 # Examples
 
@@ -181,9 +181,9 @@ function match_logs(f, patterns...; match_mode::Symbol=:all, kwargs...)
     logs,value = collect_test_logs(f; kwargs...)
     if match_mode == :all
         didmatch = length(logs) == length(patterns) &&
-            all(contains(l,p) for (p,l) in zip(patterns, logs))
+            all(ismatch(p,l) for (p,l) in zip(patterns, logs))
     elseif match_mode == :any
-        didmatch = all(any(contains(l,p) for l in logs) for p in patterns)
+        didmatch = all(any(ismatch(p,l) for l in logs) for p in patterns)
     end
     didmatch,logs,value
 end
@@ -201,15 +201,15 @@ function parse_level(level::Symbol)
     end
 end
 
-logfield_contains(a, b) = a == b
-logfield_contains(a, r::Regex) = contains(a, r)
-logfield_contains(a::Symbol, r::Regex) = contains(String(a), r)
-logfield_contains(a::LogLevel, b::Symbol) = a == parse_level(b)
-logfield_contains(a, b::Ignored) = true
+logfield_ismatch(a, b) = a == b
+logfield_ismatch(r::Regex, b) = ismatch(r, b)
+logfield_ismatch(r::Regex, b::Symbol) = ismatch(r, String(b))
+logfield_ismatch(a::Symbol, b::LogLevel) = parse_level(a) == b
+logfield_ismatch(a::Ignored, b) = true
 
-function contains(r::LogRecord, pattern::Tuple)
+function ismatch(pattern::Tuple, r::LogRecord)
     stdfields = (r.level, r.message, r._module, r.group, r.id, r.file, r.line)
-    all(logfield_contains(f, p) for (f, p) in zip(stdfields[1:length(pattern)], pattern))
+    all(logfield_ismatch(p,f) for (p,f) in zip(pattern, stdfields[1:length(pattern)]))
 end
 
 """

--- a/test/compile.jl
+++ b/test/compile.jl
@@ -458,7 +458,7 @@ let dir = mktempdir()
         let fname = tempname()
             try
                 @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
-                @test contains(read(fname, String), Regex("Replacing module `$Test_module`"))
+                @test ismatch(Regex("Replacing module `$Test_module`"), read(fname, String))
             finally
                 rm(fname, force=true)
             end
@@ -470,7 +470,7 @@ let dir = mktempdir()
             try
                 @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
                 # e.g `@test_nowarn`
-                @test Test.contains_warn(read(fname, String), r"^(?!.)"s)
+                @test Test.ismatch_warn(r"^(?!.)"s, read(fname, String))
             finally
                 rm(fname, force=true)
             end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -318,8 +318,8 @@ let err_str,
     err_str = @except_str randn(1)() MethodError
     @test contains(err_str, "MethodError: objects of type Array{Float64,1} are not callable")
 end
-@test repr("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 0 methods)"
-@test contains(repr("text/plain", getfield(Base, Symbol("@doc"))), r"^@doc \(macro with \d+ method[s]?\)$")
+@test stringmime("text/plain", FunctionLike()) == "(::$(curmod_prefix)FunctionLike) (generic function with 0 methods)"
+@test ismatch(r"^@doc \(macro with \d+ method[s]?\)$", stringmime("text/plain", getfield(Base, Symbol("@doc"))))
 
 method_defs_lineno = @__LINE__() + 1
 Base.Symbol() = throw(ErrorException("1"))

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -75,7 +75,7 @@ let e = Meta.lower(@__MODULE__, quote
         end
     end)
     @test (e::Expr).head === :error
-    @test contains(e.args[1], r"label \"#\d+#a\" referenced but not defined")
+    @test ismatch(r"label \"#\d+#a\" referenced but not defined", e.args[1])
 end
 
 function goto_test5_3()

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -59,7 +59,7 @@ end
     @test record.file == Base.source_path()
     @test record.line == kwargs[:real_line]
     @test record.id isa Symbol
-    @test contains(String(record.id), r"^.*logging_[[:xdigit:]]{8}$")
+    @test ismatch(r"^.*logging_[[:xdigit:]]{8}$", String(record.id))
 
     # User-defined metadata
     @test kwargs[:bar_val] === bar_val
@@ -69,13 +69,13 @@ end
 
     # Keyword values accessible from message block
     record2 = logs[2]
-    @test contains(record2, (Info,"test2"))
+    @test ismatch((Info,"test2"), record2)
     kwargs = record2.kwargs
     @test kwargs[:value_in_msg_block] === 1000.0
 
     # Splatting of keywords
     record3 = logs[3]
-    @test contains(record3, (Info,"test3"))
+    @test ismatch((Info,"test3"), record3)
     kwargs = record3.kwargs
     @test sort(collect(keys(kwargs))) == [:a, :b]
     @test kwargs[:a] === 1

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -27,8 +27,8 @@ function test_code_reflection(freflect, f, types, tester)
 end
 
 function test_code_reflections(tester, freflect)
-    test_code_reflection(freflect, contains,
-                         Tuple{AbstractString, Regex}, tester) # abstract type
+    test_code_reflection(freflect, ismatch,
+                         Tuple{Regex, AbstractString}, tester) # abstract type
     test_code_reflection(freflect, +, Tuple{Int, Int}, tester) # leaftype signature
     test_code_reflection(freflect, +,
                          Tuple{Array{Float32}, Array{Float32}}, tester) # incomplete types
@@ -339,12 +339,12 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
         for i in 1:length(src.slotnames)
             name = src.slotnames[i]
             if name in dupnames
-                if name in must_used_vars && contains(str, Regex("_$i\\b"))
+                if name in must_used_vars && ismatch(Regex("_$i\\b"), str)
                     must_used_checked[name] = true
                     global used_dup_var_tested15714 = true
                 end
             else
-                @test !contains(str, Regex("_$i\\b"))
+                @test !ismatch(Regex("_$i\\b"), str)
                 if name in must_used_vars
                     global used_unique_var_tested15714 = true
                 end
@@ -363,7 +363,7 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
     # Use the variable names that we know should be present in the optimized AST
     for i in 2:length(src.slotnames)
         name = src.slotnames[i]
-        if name in must_used_vars && contains(str, Regex("_$i\\b"))
+        if name in must_used_vars && ismatch(Regex("_$i\\b"), str)
             must_used_checked[name] = true
         end
     end

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -31,7 +31,7 @@ show(buf, r"")
 @test read(buf, String) == "r\"\""
 
 # see #10994, #11447: PCRE2 allows NUL chars in the pattern
-@test contains("a\0b", Regex("^a\0b\$"))
+@test ismatch(Regex("^a\0b\$"), "a\0b")
 
 # regex match / search string must be a String
 @test_throws ArgumentError match(r"test", GenericString("this is a test"))

--- a/test/show.jl
+++ b/test/show.jl
@@ -432,7 +432,7 @@ let a = Expr(:quote,Expr(:$,:x8d003))
 end
 
 # issue #9865
-@test contains(replstr(Set(1:100)), r"^Set\(\[.+….+\]\)$")
+@test ismatch(r"^Set\(\[.+….+\]\)$", replstr(Set(1:100)))
 
 # issue #11413
 @test string(:(*{1, 2})) == "*{1, 2}"
@@ -788,7 +788,7 @@ let repr = sprint(dump, Int64)
 end
 let repr = sprint(dump, Any)
     @test length(repr) == 4
-    @test contains(repr, r"^Any\n")
+    @test ismatch(r"^Any\n", repr)
     @test endswith(repr, '\n')
 end
 let repr = sprint(dump, Integer)

--- a/test/strings/types.jl
+++ b/test/strings/types.jl
@@ -154,8 +154,8 @@ end
 @test parse(Float32, SubString("10",1,1)) === 1.0f0
 
 # issue #5870
-@test !contains(SubString("",1,0), Regex("aa"))
-@test contains(SubString("",1,0), Regex(""))
+@test !ismatch(Regex("aa"), SubString("",1,0))
+@test ismatch(Regex(""), SubString("",1,0))
 
 # isvalid, length, prevind, nextind for SubString{String}
 let s = "lorem ipsum", sdict = Dict(


### PR DESCRIPTION
This reverts commit 6ca43fc9cfb399143a74fd6c24fd5bae1a323954.

Fixes(?) #25584

Every time I have changed code from `ismatch(r, s)` to `contains(s, r)` it feels a bit odd.