### PR TITLE
also backport sover patch to LLVM 4.0

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -461,7 +461,7 @@ $(eval $(call LLVM_PATCH,llvm-D33179))
 $(eval $(call LLVM_PATCH,llvm-PR29010-i386-xmm)) # Remove for 4.0
 $(eval $(call LLVM_PATCH,llvm-3.9.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-D37939-Mem2Reg-Also-handle-memcpy))
-$(eval $(call LLVM_PATCH,llvm-D31524-sovers_4.0)) # Remove for 4.0
+$(eval $(call LLVM_PATCH,llvm-D31524-sovers_4.0)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D42262-jumpthreading-not-i1))
 $(eval $(call LLVM_PATCH,llvm-3.9-c_api_nullptr))
 ifeq ($(BUILD_LLVM_CLANG),1)
@@ -490,6 +490,7 @@ $(eval $(call LLVM_PATCH,llvm-Yet-another-fix))
 $(eval $(call LLVM_PATCH,llvm-NVPTX-addrspaces)) # NVPTX
 $(eval $(call LLVM_PATCH,llvm-4.0.0-D37576-NVPTX-sm_70)) # NVPTX, Remove for 6.0
 $(eval $(call LLVM_PATCH,llvm-loadcse-addrspace_4.0))
+$(eval $(call LLVM_PATCH,llvm-D31524-sovers_4.0)) # Remove for 5.0
 $(eval $(call LLVM_PATCH,llvm-D42262-jumpthreading-not-i1))
 ifeq ($(BUILD_LLVM_CLANG),1)
 $(eval $(call LLVM_PATCH,compiler_rt-3.9-glibc_2.25.90)) # Remove for 5.0


### PR DESCRIPTION
noticed that the patch for #25597 also needed to be applied to LLVM 4.0