### PR TITLE
Remove outdated reference to embedding Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,4 +10,3 @@ release: # default target
 JULIA:=$(call spawn,$(JULIA_EXECUTABLE))
 BIN:=$(BUILDDIR)/embedding
 CC:=$(CC)
-include $(SRCDIR)/embedding/Makefile


### PR DESCRIPTION
The file moved from examples/embedding to test/embedding in #26123 but updates to the examples Makefile where erroneously omitted.

Ref https://github.com/JuliaLang/julia/pull/26123#issuecomment-368414200.