### PR TITLE
Special case BitSet union! (fix performance)

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -28,6 +28,9 @@ very large integers), use [`Set`](@ref) instead.
 """
 BitSet(itr) = union!(BitSet(), itr)
 
+# Special implementation for BitSet, which lacks a fast `length` method.
+union!(s::BitSet, itr) = foldl(push!, s, itr)
+
 @inline intoffset(s::BitSet) = s.offset << 6
 
 eltype(::Type{BitSet}) = Int


### PR DESCRIPTION
In #26054, I generalized `Set`'s union! method to apply to AbstractSet.
Set's union! method tries to optimize common cases where the number of
possible values of the set type are small. However, to do this, it repeatedly
calls the set's length method. This is bad for `BitSet` for two reasons:
1. Its `length` method is O(N) in the number of elements.
2. The check isn't actually useful, since the eltype of `BitSet` is always
    Int and it's impossible to have a BitSet that already contains all integers.

This simply special cases `union!` on BitSet to use the same implementation it did previously.