### PR TITLE
optimize the python version of abs2 in the microbenchmarks

### DIFF
--- a/test/perf/micro/perf.py
+++ b/test/perf/micro/perf.py
@@ -64,7 +64,7 @@ def randmatmul(n):
 ## mandelbrot ##
 
 def abs2(z):
-    return real(z)*real(z) +  imag(z)*imag(z)
+    return z.real*z.real +  z.imag*z.imag
 
 def mandel(z):
     maxiter = 80


### PR DESCRIPTION
the Python version of abs2 introduced as part of fixing #24097 is very inefficient because it uses numpy.real and numpy.imag on builtin python complex numbers.
This PR changes the function to use complex.real and complex.imag methods instead, resulting in a significant speedup (explaining most of the Python-specific slowdown brought about by introducing the function in the first place).