### PR TITLE
A better default dataids(::AbstractArray)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1529,7 +1529,14 @@ parts can specialize this method to return the concatenation of the `dataids` of
 their component parts.  A typical definition for an array that wraps a parent is
 `Base.dataids(C::CustomArray) = dataids(C.parent)`.
 """
-dataids(A::AbstractArray) = (UInt(pointer_from_objref(A)),)
+function dataids(A::AbstractArray)
+    @inline
+    ids = _splatmap(dataids, ntuple(i -> getfield(A, i), Val(nfields(A))))
+    if !isimmutable(A)
+        ids = (UInt(pointer_from_objref(A)), ids...)
+    end
+    return ids
+end
 dataids(A::Array) = (UInt(pointer(A)),)
 dataids(::AbstractRange) = ()
 dataids(x) = ()

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1547,8 +1547,9 @@ dataids(x) = ()
 
 # While dictionaries aren't typically involved in aliasing detection, some arrays
 # (like DefaultArray) do use dictionaries as a backing element for their data.
-# Defining this ensures those fields are appropriately involved in aliasing decisions.
-dataids(dict::AbstractDict) = (UInt(pointer_from_objref(dict)),)
+# Defining this ensures those fields are involved in aliasing decisions.
+dataids(dict::Dict) = (UInt(pointer_from_objref(dict)),)
+dataids(dict::AbstractDict) = (UInt(objectid(dict)),)
 
 ## get (getindex with a default value) ##
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1529,7 +1529,7 @@ parts can specialize this method to return the concatenation of the `dataids` of
 their component parts.  A typical definition for an array that wraps a parent is
 `Base.dataids(C::CustomArray) = dataids(C.parent)`.
 """
-dataids(A::AbstractArray) = (UInt(objectid(A)),)
+dataids(A::AbstractArray) = (UInt(pointer_from_objref(A)),)
 dataids(A::Array) = (UInt(pointer(A)),)
 dataids(::AbstractRange) = ()
 dataids(x) = ()

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1522,11 +1522,19 @@ _isdisjoint(as::Tuple, bs::Tuple) = !(as[1] in bs) && _isdisjoint(tail(as), bs)
 """
     Base.dataids(A::AbstractArray)
 
-Return a tuple of `UInt`s that represent the mutable data segments of an array.
+Return a tuple of `UInt`s that identify the mutable data segments of an array.
 
+These values are used to determine if two arrays might share memory with [`Base.mightalias`](@ref).
 The default implementation recursively combines the `dataids` of all fields of the struct.
-Custom arrays only need to implement a custom `dataids` method if they depend upon non-array
-fields to define their contents and are immutable.
+
+Custom arrays only need to implement a custom `dataids` method if:
+
+* they wish to ignore some fields (with non-empty `dataids`) in aliasing considerations;
+    for example this can be the case if an array is used to store intentionally-shared
+    metadata or other data that is not mutated by `setindex!`
+
+* or they depend upon non-array fields (with empty `dataids`) to define their indexable
+    contents that they wish to include in aliasing considerations.
 """
 function dataids(A::AbstractArray)
     @inline

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1545,11 +1545,6 @@ dataids(A::Array) = (UInt(pointer(A)),)
 dataids(::AbstractRange) = ()
 dataids(x) = ()
 
-# While dictionaries aren't typically involved in aliasing detection, some arrays
-# (like DefaultArray) do use dictionaries as a backing element for their data.
-# Defining this ensures those fields are involved in aliasing decisions.
-dataids(dict::AbstractDict) = (UInt(objectid(dict)),)
-
 ## get (getindex with a default value) ##
 
 RangeVecIntList{A<:AbstractVector{Int}} = Union{Tuple{Vararg{Union{AbstractRange, AbstractVector{Int}}}},

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1524,10 +1524,9 @@ _isdisjoint(as::Tuple, bs::Tuple) = !(as[1] in bs) && _isdisjoint(tail(as), bs)
 
 Return a tuple of `UInt`s that represent the mutable data segments of an array.
 
-Custom arrays that would like to opt-in to aliasing detection of their component
-parts can specialize this method to return the concatenation of the `dataids` of
-their component parts.  A typical definition for an array that wraps a parent is
-`Base.dataids(C::CustomArray) = dataids(C.parent)`.
+The default implementation recursively combines the `dataids` of all fields of the struct.
+Custom arrays only need to implement a custom `dataids` method if they depend upon non-array
+fields to define their contents and are immutable.
 """
 function dataids(A::AbstractArray)
     @inline

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1546,6 +1546,11 @@ dataids(A::Array) = (UInt(pointer(A)),)
 dataids(::AbstractRange) = ()
 dataids(x) = ()
 
+# While dictionaries aren't typically involved in aliasing detection, some arrays
+# (like DefaultArray) do use dictionaries as a backing element for their data.
+# Defining this ensures those fields are appropriately involved in aliasing decisions.
+dataids(dict::AbstractDict) = (UInt(pointer_from_objref(dict)),)
+
 ## get (getindex with a default value) ##
 
 RangeVecIntList{A<:AbstractVector{Int}} = Union{Tuple{Vararg{Union{AbstractRange, AbstractVector{Int}}}},

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1548,7 +1548,6 @@ dataids(x) = ()
 # While dictionaries aren't typically involved in aliasing detection, some arrays
 # (like DefaultArray) do use dictionaries as a backing element for their data.
 # Defining this ensures those fields are involved in aliasing decisions.
-dataids(dict::Dict) = (UInt(pointer_from_objref(dict)),)
 dataids(dict::AbstractDict) = (UInt(objectid(dict)),)
 
 ## get (getindex with a default value) ##

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -790,6 +790,7 @@ LogicalIndex{Int}(mask::AbstractArray) = LogicalIndex{Int, typeof(mask)}(mask)
 size(L::LogicalIndex) = (L.sum,)
 length(L::LogicalIndex) = L.sum
 collect(L::LogicalIndex) = [i for i in L]
+unaliascopy(L::TL) where {TL <: LogicalIndex} = TL(unaliascopy(L.mask))
 show(io::IO, r::LogicalIndex) = print(io,collect(r))
 print_array(io::IO, X::LogicalIndex) = print_array(io, collect(X))
 # Iteration over LogicalIndex is very performance-critical, but it also must

--- a/base/permuteddimsarray.jl
+++ b/base/permuteddimsarray.jl
@@ -252,6 +252,10 @@ function _copy!(P::PermutedDimsArray{T,N,perm}, src) where {T,N,perm}
     return P
 end
 
+function Base.unaliascopy(P::PermutedDimsArray)::typeof(P)
+    return (typeof(P))(Base.unaliascopy(P.parent))
+end
+
 @noinline function _permutedims!(P::PermutedDimsArray, src, R1::CartesianIndices{0}, R2, R3, ds, dp)
     ip, is = axes(src, dp), axes(src, ds)
     for jo in first(ip):8:last(ip), io in first(is):8:last(is)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -591,6 +591,8 @@ similar(M::Tridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = sim
 # Operations on Tridiagonal matrices
 copyto!(dest::Tridiagonal, src::Tridiagonal) = (copyto!(dest.dl, src.dl); copyto!(dest.d, src.d); copyto!(dest.du, src.du); dest)
 
+Base.dataids(A::Tridiagonal) = (Base.dataids(A.dl), Base.dataids(A.d), Base.dataids(A.du))
+
 #Elementary operations
 for func in (:conj, :copy, :real, :imag)
     @eval function ($func)(M::Tridiagonal)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -1309,6 +1309,59 @@ end
     end
 end
 
+# Ensure dataids are inferrable for custom arrays
+struct M0 <: AbstractArray{Int,2} end
+struct M1{T} <: AbstractArray{Int,2}
+    x::T
+end
+struct M2{T,S} <: AbstractArray{Int,2}
+    x::T
+    y::S
+end
+struct M10{A,B,C,D,E,F,G,H,I,J} <: AbstractArray{Int,2}
+    a::A
+    b::B
+    c::C
+    d::D
+    e::E
+    f::F
+    g::G
+    h::H
+    i::I
+    j::J
+end
+
+@testset "dataids" begin
+    @test @inferred(Base.dataids(M0())) === ()
+    @test @inferred(Base.dataids(M1(1))) === ()
+    @test @inferred(Base.dataids(M1(1:10))) === ()
+    @test @inferred(Base.dataids(M10(1,2,3,4,5,6,7,8,9,0))) === ()
+
+    @test @inferred(Base.dataids(M1(M1([1])))) != Base.dataids(M1(M1([1])))
+    @test @inferred(Base.dataids(M1(M2([1],2)))) != Base.dataids(M1(M2([1],2)))
+    @test @inferred(Base.dataids(M1(M2([1],[2])))) != Base.dataids(M1(M2([1],[2])))
+    @test @inferred(Base.dataids(M10([1],[2],[3],[4],[5],[6],[7],[8],[9],[0]))) != Base.dataids(M10([1],[2],[3],[4],[5],[6],[7],[8],[9],[0]))
+
+    x = [1]
+    y = [1]
+    mx = M1(x)
+    mxx = M2(x,x)
+    mxy = M2(x,y)
+    @test @inferred(Base.mightalias(mx,mx))
+    @test @inferred(Base.mightalias(mx,mxx))
+    @test @inferred(Base.mightalias(mx,mxy))
+    @test @inferred(Base.mightalias(mxx,x))
+    @test @inferred(Base.mightalias(x,mxy))
+    @test !@inferred(Base.mightalias(mx, y))
+    @test !@inferred(Base.mightalias(mxx, y))
+    @test !@inferred(Base.mightalias(mxx, [1]))
+    @test !@inferred(Base.mightalias(mxy, 1:10))
+    @test !@inferred(Base.mightalias(mxy, M0()))
+    @test !@inferred(Base.mightalias(mxy, [1]))
+    @test !@inferred(Base.mightalias(mxy, M1(1:10)))
+    @test !@inferred(Base.mightalias(mxy, M1([1])))
+end
+
 @testset "Base.rest" begin
     a = reshape(1:4, 2, 2)'
     @test Base.rest(a) == a[:]


### PR DESCRIPTION
~~I was previously calling `objectid` -- I should have been using `pointer_from_objref`.  The former is a hash, the latter is much quicker and easier to compute.~~

This PR now implements a more robust default `dataids` definition that attempts to dynamically dig into custom array struct fields.  This started as the simpler optimization struck above; that was split off and merged separately at https://github.com/JuliaLang/julia/pull/29854.