### PR TITLE
fix accumulated bugs with stdlib initialization

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -46,7 +46,7 @@ const DEPOT_PATH = String[]
 function init_depot_path(BINDIR = Sys.BINDIR)
     if haskey(ENV, "JULIA_DEPOT_PATH")
         depots = split(ENV["JULIA_DEPOT_PATH"], Sys.iswindows() ? ';' : ':')
-        push!(empty!(DEPOT_PATH), map(expanduser, depots))
+        append!(empty!(DEPOT_PATH), map(expanduser, depots))
     else
         push!(DEPOT_PATH, joinpath(homedir(), ".julia"))
     end
@@ -80,6 +80,7 @@ function show(io::IO, env::NamedEnv)
 end
 
 function parse_env(env::Union{String,SubString{String}})
+    isempty(env) && return Any[]
     env == "@" && return CurrentEnv()
     env == "@!" && return CurrentEnv(create=true)
     if env[1] == '@'
@@ -106,7 +107,7 @@ function parse_load_path(str::String)
     envs = Any[split(str, Sys.iswindows() ? ';' : ':');]
     for (i, env) in enumerate(envs)
         if '|' in env
-            envs[i] = [parse_env(e) for e in split(env, '|')]
+            envs[i] = Any[parse_env(e) for e in split(env, '|')]
         else
             envs[i] = parse_env(env)
         end
@@ -120,17 +121,6 @@ function init_load_path(BINDIR = Sys.BINDIR)
     vers = "v$(VERSION.major).$(VERSION.minor)"
     push!(LOAD_PATH, abspath(BINDIR, "..", "local", "share", "julia", "site", vers))
     push!(LOAD_PATH, abspath(BINDIR, "..", "share", "julia", "site", vers))
-end
-
-function early_init()
-    Sys._early_init()
-    # make sure OpenBLAS does not set CPU affinity (#1070, #9639)
-    ENV["OPENBLAS_MAIN_FREE"] = get(ENV, "OPENBLAS_MAIN_FREE",
-                                get(ENV, "GOTOBLAS_MAIN_FREE", "1"))
-    if Sys.CPU_CORES > 8 && !("OPENBLAS_NUM_THREADS" in keys(ENV)) && !("OMP_NUM_THREADS" in keys(ENV))
-        # Prevent openblas from starting too many threads, unless/until specifically requested
-        ENV["OPENBLAS_NUM_THREADS"] = 8
-    end
 end
 
 const atexit_hooks = []

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -367,8 +367,6 @@ end
 
 LogState(logger) = LogState(LogLevel(min_enabled_level(logger)), logger)
 
-_global_logstate = LogState(NullLogger())
-
 function current_logstate()
     logstate = current_task().logstate
     (logstate != nothing ? logstate : _global_logstate)::LogState
@@ -492,5 +490,7 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
     write(logger.stream, take!(buf))
     nothing
 end
+
+_global_logstate = LogState(SimpleLogger(Core.stderr, CoreLogging.Info))
 
 end # CoreLogging

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -27,14 +27,13 @@ export BINDIR,
 
 import ..Base: show
 
+global BINDIR = ccall(:jl_get_julia_bindir, Any, ())
 """
     Sys.BINDIR
 
 A string containing the full path to the directory containing the `julia` executable.
 """
-BINDIR = ccall(:jl_get_julia_bindir, Any, ())
-
-_early_init() = global BINDIR = ccall(:jl_get_julia_bindir, Any, ())
+:BINDIR
 
 # helper to avoid triggering precompile warnings
 
@@ -78,12 +77,21 @@ Standard word size on the current machine, in bits.
 const WORD_SIZE = Core.sizeof(Int) * 8
 
 function __init__()
-    global CPU_CORES =
-        haskey(ENV,"JULIA_CPU_CORES") ? parse(Int,ENV["JULIA_CPU_CORES"]) :
-                                        Int(ccall(:jl_cpu_cores, Int32, ()))
+    env_cores = get(ENV, "JULIA_CPU_CORES", "")
+    global CPU_CORES = if !isempty(env_cores)
+        env_cores = tryparse(Int, env_cores)
+        if !(env_cores isa Int && env_cores > 0)
+            Core.print(Core.stderr, "WARNING: couldn't parse `JULIA_CPU_CORES` environment variable. Defaulting Sys.CPU_CORES to 1.\n")
+            env_cores = 1
+        end
+        env_cores
+    else
+        Int(ccall(:jl_cpu_cores, Int32, ()))
+    end
     global SC_CLK_TCK = ccall(:jl_SC_CLK_TCK, Clong, ())
     global CPU_NAME = ccall(:jl_get_cpu_name, Ref{String}, ())
     global JIT = ccall(:jl_get_JIT, Ref{String}, ())
+    global BINDIR = ccall(:jl_get_julia_bindir, Any, ())
 end
 
 mutable struct UV_cpu_info_t

--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -10,10 +10,6 @@ function notify_fun(idx)
     return
 end
 
-function init_threadcall()
-    global c_notify_fun = cfunction(notify_fun, Cvoid, Tuple{Cint})
-end
-
 """
     @threadcall((cfunc, clib), rettype, (argtypes...), argvals...)
 
@@ -65,6 +61,7 @@ end
 function do_threadcall(wrapper::Function, rettype::Type, argtypes::Vector, argvals::Vector)
     # generate function pointer
     fun_ptr = cfunction(wrapper, Int, Tuple{Ptr{Cvoid}, Ptr{Cvoid}})
+    c_notify_fun = cfunction(notify_fun, Cvoid, Tuple{Cint})
 
     # cconvert, root and unsafe_convert arguments
     roots = Any[]

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -52,4 +52,8 @@ include("ConsoleLogger.jl")
 # 2. AbstractLogger message related functions:
 #  handle_message, shouldlog, min_enabled_level, catch_exceptions,
 
+function __init__()
+    global_logger(ConsoleLogger(stderr))
+end
+
 end

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -10,7 +10,7 @@ function writereadpipeline(input, exename)
         write(p.in, input)
         close(p.in)
     end
-    return read(p.out, String)
+    return (read(p.out, String), success(p))
 end
 
 # helper function for returning stderr and stdout
@@ -24,6 +24,52 @@ function readchomperrors(exename::Cmd)
     return (success(p), fetch(o), fetch(e))
 end
 
+
+let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
+    # tests for handling of ENV errors
+    let v = writereadpipeline("println(\"REPL: \", @which(less), @isdefined(InteractiveUtils))",
+                setenv(`$exename -i -E 'empty!(LOAD_PATH); @isdefined InteractiveUtils'`,
+                    "JULIA_LOAD_PATH"=>"", "JULIA_DEPOT_PATH"=>""))
+        @test v[1] == "false\nREPL: InteractiveUtilstrue\n"
+        @test v[2]
+    end
+    let v = writereadpipeline("println(\"REPL: \", InteractiveUtils)",
+                setenv(`$exename -i -e 'const InteractiveUtils = 3'`,
+                    "JULIA_LOAD_PATH"=>";;;:::", "JULIA_DEPOT_PATH"=>";;;:::"))
+        # TODO: ideally, `@which`, etc. would still work, but Julia can't handle `using $InterativeUtils`
+        @test v[1] == "REPL: 3\n"
+        @test v[2]
+    end
+    let v = readchomperrors(`$exename -i -e '
+            empty!(LOAD_PATH)
+            Base.unreference_module(Base.PkgId(Base.UUID(0xb77e0a4c_d291_57a0_90e8_8db25a27a240), "InteractiveUtils"))
+            '`)
+        # simulate not having a working version of InteractiveUtils,
+        # make sure this is a non-fatal error and the REPL still loads
+        @test v[1]
+        @test isempty(v[2])
+        @test startswith(v[3], """
+                         ┌ Warning: Failed to insert InteractiveUtils into module Main
+                         │   exception =
+                         │    ArgumentError: Module InteractiveUtils not found in current path.
+                         │    Run `Pkg.add("InteractiveUtils")` to install the InteractiveUtils package.
+                         │    Stacktrace:
+                         """)
+    end
+    for nc in ("0", "-2", "x", "2x", " ")
+        v = readchomperrors(setenv(`$exename -i -E 'Sys.CPU_CORES'`, "JULIA_CPU_CORES" => nc))
+        @test v[1]
+        @test v[2] == "1"
+        @test v[3] == "WARNING: couldn't parse `JULIA_CPU_CORES` environment variable. Defaulting Sys.CPU_CORES to 1."
+    end
+    real_cores = string(ccall(:jl_cpu_cores, Int32, ()))
+    for nc in ("1", " 1 ", " +1 ", " 0x1 ", "")
+        v = readchomperrors(setenv(`$exename -i -E 'Sys.CPU_CORES'`, "JULIA_CPU_CORES" => nc))
+        @test v[1]
+        @test v[2] == (isempty(nc) ? real_cores : "1")
+        @test isempty(v[3])
+    end
+end
 
 let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     # --version
@@ -173,19 +219,25 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
 
     # -g
     @test readchomp(`$exename -E "Base.JLOptions().debug_level" -g`) == "2"
-    let code = read(`$exename -g0 -i -e "code_llvm(stdout, +, (Int64, Int64), false, true); exit()"`, String)
+    let code = writereadpipeline("code_llvm(stdout, +, (Int64, Int64), false, true)", `$exename -g0`)
+        @test code[2]
+        code = code[1]
         @test contains(code, "llvm.module.flags")
         @test !contains(code, "llvm.dbg.cu")
         @test !contains(code, "int.jl")
         @test !contains(code, "Int64")
     end
-    let code = read(`$exename -g1 -i -e "code_llvm(stdout, +, (Int64, Int64), false, true); exit()"`, String)
+    let code = writereadpipeline("code_llvm(stdout, +, (Int64, Int64), false, true)", `$exename -g1`)
+        @test code[2]
+        code = code[1]
         @test contains(code, "llvm.module.flags")
         @test contains(code, "llvm.dbg.cu")
         @test contains(code, "int.jl")
         @test !contains(code, "Int64")
     end
-    let code = read(`$exename -g2 -i -e "code_llvm(stdout, +, (Int64, Int64), false, true); exit()"`, String)
+    let code = writereadpipeline("code_llvm(stdout, +, (Int64, Int64), false, true)", `$exename -g2`)
+        @test code[2]
+        code = code[1]
         @test contains(code, "llvm.module.flags")
         @test contains(code, "llvm.dbg.cu")
         @test contains(code, "int.jl")
@@ -486,11 +538,11 @@ end
 
 # issue #6310
 let exename = `$(Base.julia_cmd()) --startup-file=no`
-    @test writereadpipeline("2+2", exename) == "4\n"
-    @test writereadpipeline("2+2\n3+3\n4+4", exename) == "4\n6\n8\n"
-    @test writereadpipeline("", exename) == ""
-    @test writereadpipeline("print(2)", exename) == "2"
-    @test writereadpipeline("print(2)\nprint(3)", exename) == "23"
+    @test writereadpipeline("2+2", exename) == ("4\n", true)
+    @test writereadpipeline("2+2\n3+3\n4+4", exename) == ("4\n6\n8\n", true)
+    @test writereadpipeline("", exename) == ("", true)
+    @test writereadpipeline("print(2)", exename) == ("2", true)
+    @test writereadpipeline("print(2)\nprint(3)", exename) == ("23", true)
     let infile = tempname()
         touch(infile)
         try


### PR DESCRIPTION
These were making it hard to turn off certain stdlibs,
which in turn made it hard to test alternate configurations and compiler changes.