### PR TITLE
Inbounds tuple iteration and reduction

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -40,7 +40,7 @@ mul_prod(x::SmallUnsigned,y::SmallUnsigned) = UInt(x) * UInt(y)
     if done(itr, i)
         return v0
     else
-        (x, i) = next(itr, i)
+        @inbounds (x, i) = next(itr, i)
         v = op(v0, f(x))
         while !done(itr, i)
             @inbounds (x, i) = next(itr, i)
@@ -71,7 +71,7 @@ function mapfoldl(f, op, itr)
     if done(itr, i)
         return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
     end
-    (x, i) = next(itr, i)
+    @inbounds (x, i) = next(itr, i)
     v0 = mapreduce_first(f, op, x)
     mapfoldl_impl(f, op, v0, itr, i)
 end
@@ -555,10 +555,10 @@ julia> extrema([9,pi,4.5])
 function extrema(itr)
     s = start(itr)
     done(itr, s) && throw(ArgumentError("collection must be non-empty"))
-    (v, s) = next(itr, s)
+    @inbounds (v, s) = next(itr, s)
     vmin = vmax = v
     while !done(itr, s)
-        (x, s) = next(itr, s)
+        @inbounds (x, s) = next(itr, s)
         vmax = max(x, vmax)
         vmin = min(x, vmin)
     end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -37,7 +37,7 @@ _setindex(v, i::Integer) = ()
 
 start(t::Tuple) = 1
 done(t::Tuple, i::Int) = (length(t) < i)
-next(t::Tuple, i::Int) = (t[i], i+1)
+next(t::Tuple, i::Int) = (@_propagate_inbounds_meta; (t[i], i+1))
 
 keys(t::Tuple) = 1:length(t)
 


### PR DESCRIPTION
I noticed `prod(length, (1,))` performed a bounds check, caused by the reduction not specifying `@inbounds` (which should be safe, because it is guarded by a call to `done`) and the tuple iteration functions not propagating it. Not sure about the correctness of this, so going for limited scope first.