### PR TITLE
Append collection of paths split from JULIA_DEPOT_PATH environ to DEPOT_PATH array

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -46,7 +46,7 @@ const DEPOT_PATH = String[]
 function init_depot_path(BINDIR = Sys.BINDIR)
     if haskey(ENV, "JULIA_DEPOT_PATH")
         depots = split(ENV["JULIA_DEPOT_PATH"], Sys.iswindows() ? ';' : ':')
-        push!(empty!(DEPOT_PATH), map(expanduser, depots))
+        append!(empty!(DEPOT_PATH), map(expanduser, depots))
     else
         push!(DEPOT_PATH, joinpath(homedir(), ".julia"))
     end


### PR DESCRIPTION
Without this, I receive the following error when trying to change Pkg3's package directory in the same way that I have configured Pkg2 using the `JULIA_PKGDIR` environment variable.

```bash
$ export JULIA_DEPOT_PATH="/cluster/path/julia_pkgdir"
$ julia
fatal: error thrown and no exception handler available.
InitError(mod=:Base, error=MethodError(f=typeof(Base.convert)(), args=(String, Array{Base.SubString{String}, (1,)}[Base.SubString{String}(string="/cluster/path/julia_pkgdir", offset=0, ncodeunits=53)]), world=0x0000000000006989))
rec_backtrace at /cluster/path/julia/src/stackwalk.c:94
record_backtrace at /cluster/path/julia/src/task.c:246
jl_throw at /cluster/path/julia/src/task.c:577
jl_method_error_bare at /cluster/path/julia/src/gf.c:1587
jl_method_error at /cluster/path/julia/src/gf.c:1605
jl_lookup_generic_ at /cluster/path/julia/src/gf.c:2071 [inlined]
jl_apply_generic at /cluster/path/julia/src/gf.c:2091
push! at ./array.jl:794
jl_call_fptr_internal at /cluster/path/julia/src/julia_internal.h:383 [inlined]
jl_call_method_internal at /cluster/path/julia/src/julia_internal.h:402 [inlined]
jl_apply_generic at /cluster/path/julia/src/gf.c:2094
init_depot_path at ./initdefs.jl:49
jl_call_fptr_internal at /cluster/path/julia/src/julia_internal.h:383 [inlined]
jl_call_method_internal at /cluster/path/julia/src/julia_internal.h:402 [inlined]
jl_apply_generic at /cluster/path/julia/src/gf.c:2094
init_depot_path at ./initdefs.jl:47 [inlined]
__init__ at ./sysimg.jl:495
jlcall___init___16085 at /cluster/path/julia/usr/lib/julia/sys.so (unknown line)
jl_call_fptr_internal at /cluster/path/julia/src/julia_internal.h:383 [inlined]
jl_call_method_internal at /cluster/path/julia/src/julia_internal.h:402 [inlined]
jl_apply_generic at /cluster/path/julia/src/gf.c:2094
jl_apply at /cluster/path/julia/src/julia.h:1527 [inlined]
jl_module_run_initializer at /cluster/path/julia/src/toplevel.c:90
_julia_init at /cluster/path/julia/src/init.c:810
julia_init__threading at /cluster/path/julia/src/task.c:302
main at /cluster/path/julia/ui/repl.c:232
__libc_start_main at /lib64/libc.so.6 (unknown line)
_start at julia (unknown line)

$ env -u JULIA_DEPOT_PATH julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.7.0-DEV.4421 (2018-02-28 13:22 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit 1da3190* (0 days old master)
|__/                   |  x86_64-redhat-linux-gnu

julia> versioninfo()
Julia Version 0.7.0-DEV.4421
Commit 1da3190* (2018-02-28 13:22 UTC)
Platform Info:
  OS: Linux (x86_64-redhat-linux-gnu)
  CPU: Intel(R) Xeon(R) CPU E5-2680 v3 @ 2.50GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-3.9.1 (ORCJIT, haswell)
Environment:
  JULIA_PKGDIR = /cluster/path/julia_pkgdir
```

(I made minor edits to the backtrace to replaces specific paths with generic paths to avoid sharing identifying information.)