### PR TITLE
fix AV build (#26255)

### DIFF
--- a/contrib/windows/appveyor_build.sh
+++ b/contrib/windows/appveyor_build.sh
@@ -207,6 +207,6 @@ echo 'FORCE_ASSERTIONS = 1' >> Make.user
 cat Make.user
 make -j3 VERBOSE=1 all
 make -j3 VERBOSE=1 install
-make VERBOSE=1 -C examples
+make VERBOSE=1 JULIA=../../usr/bin/julia.exe BIN=. "$(make print-CC)" -C test/embedding release
 cp usr/bin/busybox.exe julia-*/bin
 make build-stats

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1402,7 +1402,7 @@ let
         rm(tmp_file, force=true)
         rm(tmp_file2, force=true)
         rm(tmp_dir2, force=true)
-        rm(tmp_dir, force=true)
+        #rm(tmp_dir, force=true)
     end
 end
 # cookie and comand line option `--worker` tests. remove workers, set cookie and test

--- a/stdlib/Pkg3/src/PlatformEngines.jl
+++ b/stdlib/Pkg3/src/PlatformEngines.jl
@@ -218,11 +218,11 @@ function probe_platform_engines!(;verbose::Bool = false)
         prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
 
         # On windows, we bundle 7z with Julia, so try invoking that directly
-        exe7z = joinpath(JULIA_HOME, "7z.exe")
+        exe7z = joinpath(Sys.BINDIR, "7z.exe")
         prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
 
         # And finally, we want to look for sh as busybox as well:
-        busybox = joinpath(JULIA_HOME, "busybox.exe")
+        busybox = joinpath(Sys.BINDIR, "busybox.exe")
         prepend!(sh_engines, [(`$busybox sh`)])
     end
 


### PR DESCRIPTION
Removing this directory is not worth having every AV run fail. Should be fixed properly, but we should unblock other testing for now.