### PR TITLE
Fix trimming of SubArrays in unaliascopy

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -84,7 +84,7 @@ function unaliascopy(V::SubArray{T,N,A,I,LD}) where {T,N,A<:Array,I<:Tuple{Varar
 end
 # Transform indices to be "dense"
 _trimmedindex(i::Real) = oftype(i, 1)
-_trimmedindex(i::AbstractUnitRange) = i
+_trimmedindex(i::AbstractUnitRange) = oftype(i, OneTo(length(i)))
 _trimmedindex(i::AbstractArray) = oftype(i, reshape(linearindices(i), axes(i)))
 
 ## SubArray creation

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -588,9 +588,14 @@ end
 @test sizeof(view(zeros(UInt8, 10), 1:3)) == 3
 @test sizeof(view(zeros(Float64, 10, 10), 1:3, 2:6)) == 120
 
-
 # PR #25321
 # checks that issue in type inference is resolved
 A = rand(5,5,5,5)
 V = view(A, 1:1 ,:, 1:3, :)
 @test @inferred(strides(V)) == (1, 5, 25, 125)
+
+# Issue #26263 — ensure that unaliascopy properly trims the array
+A = rand(5,5,5,5)
+V = view(A, 2:5, :, 2:5, 1:2:5)
+@test @inferred(Base.unaliascopy(V)) == V == A[2:5, :, 2:5, 1:2:5]
+@test @inferred(sum(Base.unaliascopy(V))) == sum(V) == sum(A[2:5, :, 2:5, 1:2:5])


### PR DESCRIPTION
This fixes a bug in SubArray's unaliascopy "trimming" within unaliascopy