### PR TITLE
RFC: Logging: enable configuration via ENV

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -298,14 +298,13 @@ function logmsg_code(_module, file, line, level, message, exs...)
         level = $level
         std_level = convert(LogLevel, level)
         if std_level >= getindex(_min_enabled_level)
-            logstate = current_logstate()
-            if std_level >= logstate.min_enabled_level
-                logger = logstate.logger
-                _module = $_module
+            group = $group
+            _module = $_module
+            logger = current_logger_for_env(std_level, group, _module)
+            if !(logger === nothing)
                 id = $id
-                group = $group
-                # Second chance at an early bail-out, based on arbitrary
-                # logger-specific logic.
+                # Second chance at an early bail-out (before computing the message),
+                # based on arbitrary logger-specific logic.
                 if shouldlog(logger, level, _module, group, id)
                     file = $file
                     line = $line
@@ -313,9 +312,6 @@ function logmsg_code(_module, file, line, level, message, exs...)
                         msg = $(esc(message))
                         handle_message(logger, level, msg, _module, group, id, file, line; $(kwargs...))
                     catch err
-                        if !catch_exceptions(logger)
-                            rethrow(err)
-                        end
                         logging_error(logger, level, _module, group, id, file, line, err)
                     end
                 end
@@ -327,7 +323,10 @@ end
 
 # Report an error in log message creation (or in the logger itself).
 @noinline function logging_error(logger, level, _module, group, id,
-                                 filepath, line, err)
+                                 filepath, line, @nospecialize(err))
+    if !catch_exceptions(logger)
+        rethrow(err)
+    end
     try
         msg = "Exception while generating log record in module $_module at $filepath:$line"
         handle_message(logger, Error, msg, _module, :logevent_error, id, filepath, line; exception=(err,catch_backtrace()))
@@ -369,7 +368,16 @@ LogState(logger) = LogState(LogLevel(min_enabled_level(logger)), logger)
 
 function current_logstate()
     logstate = current_task().logstate
-    (logstate != nothing ? logstate : _global_logstate)::LogState
+    return (logstate !== nothing ? logstate : _global_logstate)::LogState
+end
+
+# helper function to get the current logger, if enabled for the specified message type
+@noinline function current_logger_for_env(std_level::LogLevel, group, _module)
+    logstate = current_logstate()
+    if std_level >= logstate.min_enabled_level || env_override_minlevel(group, _module)
+        return logstate.logger
+    end
+    return nothing
 end
 
 function with_logstate(f::Function, logstate)
@@ -396,6 +404,44 @@ disabled.
 """
 function disable_logging(level::LogLevel)
     _min_enabled_level[] = level + 1
+end
+
+let _debug_groups = Symbol[],
+    _debug_str::String = ""
+global function env_override_minlevel(group, _module)
+    debug = get(ENV, "JULIA_DEBUG", "")
+    if !(debug === _debug_str)
+        _debug_str = debug
+        empty!(_debug_groups)
+        for g in split(debug, ',')
+            isempty(g) && continue
+            if g == "all"
+                empty!(_debug_groups)
+                push!(_debug_groups, :all)
+                break
+            end
+            push!(_debug_groups, Symbol(g))
+        end
+    end
+    if isempty(_debug_groups)
+        return false
+    end
+    if _debug_groups[1] == :all
+        return true
+    end
+    if isa(group, Symbol) && group in _debug_groups
+        return true
+    end
+    if isa(_module, Module)
+        if nameof(_module) in _debug_groups
+            return true
+        end
+        if nameof(Base.moduleroot(_module)) in _debug_groups
+            return true
+        end
+    end
+    return false
+end
 end
 
 
@@ -483,7 +529,7 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
     for i in 2:length(msglines)
         println(iob, "│ ", msglines[i])
     end
-    for (key,val) in pairs(kwargs)
+    for (key, val) in kwargs
         println(iob, "│   ", key, " = ", val)
     end
     println(iob, "└ @ ", _module, " ", filepath, ":", line)


### PR DESCRIPTION
This restores the functionality we had previously to set JULIA_DEBUG_LOADING=1 to activate logging;
now the equivalent would be to set JULIA_DEBUG=loading. But with the new infrastructure, this is also
generalized to allow filtering on any key (module, root-module, or filename), or "all".
This sits between the global disable (which still provides a fast-path to skip everything),
and the default min-level for a logger (which will be overridden by the environment variable).

This also tries to move a bit more work into non-inlined helper functions,
rather than inlining that code directly, to slightly reduce the size of
the emitted code.

As a possible future improvement, we could allow specifying specific
levels (such as `loading=MaxLevel` or `all=Debug`), to provide even more
fine-grained control.

I know this needs-docs, but Logging doesn't currently appear to have any, so I have nowhere to put them :(

fix #25549

```
$ JULIA_DEBUG=loading ./usr/bin/julia -e 'using Colors'
┌ Debug: Rejecting cache file /home/vtjnash/.julia/compiled/v0.7/Colors.ji because module InteractiveUtils [b77e0a4c-d291-57a0-90e8-8db25a27a240] is already loaded and incompatible.
└ @ Base loading.jl:1344
┌ Debug: Recompiling stale cache file /home/vtjnash/.julia/compiled/v0.7/Colors.ji for module Colors
└ @ Base loading.jl:1190
┌ Debug: Rejecting cache file /home/vtjnash/.julia/compiled/v0.7/FixedPointNumbers.ji because module InteractiveUtils [b77e0a4c-d291-57a0-90e8-8db25a27a240] is already loaded and incompatible.
└ @ Base loading.jl:1344
┌ Debug: Recompiling stale cache file /home/vtjnash/.julia/compiled/v0.7/FixedPointNumbers.ji for module FixedPointNumbers
└ @ Base loading.jl:1190
┌ Debug: Rejecting cache file /home/vtjnash/.julia/compiled/v0.7/ColorTypes.ji because module InteractiveUtils [b77e0a4c-d291-57a0-90e8-8db25a27a240] is already loaded and incompatible.
└ @ Base loading.jl:1344
┌ Debug: Recompiling stale cache file /home/vtjnash/.julia/compiled/v0.7/ColorTypes.ji for module ColorTypes
└ @ Base loading.jl:1190
┌ Debug: Rejecting cache file /home/vtjnash/.julia/compiled/v0.7/Compat/GSFW.ji because module InteractiveUtils [b77e0a4c-d291-57a0-90e8-8db25a27a240] is already loaded and incompatible.
└ @ Base loading.jl:1344
┌ Debug: Recompiling stale cache file /home/vtjnash/.julia/compiled/v0.7/Compat/GSFW.ji for module Compat
└ @ Base loading.jl:1190
┌ Warning: `names(m, all)` is deprecated, use `names(m, all=all)` instead.
│   caller = top-level scope
└ @ Core :0
┌ Debug: Rejecting cache file /home/vtjnash/.julia/compiled/v0.7/Reexport.ji because module InteractiveUtils [b77e0a4c-d291-57a0-90e8-8db25a27a240] is already loaded and incompatible.
└ @ Base loading.jl:1344
┌ Debug: Recompiling stale cache file /home/vtjnash/.julia/compiled/v0.7/Reexport.ji for module Reexport
└ @ Base loading.jl:1190
WARNING: importing deprecated binding Base.@sprintf into Colors.
WARNING: Base.@sprintf is deprecated: it has been moved to the standard library package `Printf`.
Add `using Printf` to your imports.
  likely near /home/vtjnash/.julia/v0.7/Colors/src/utilities.jl:12
WARNING: Base.@sprintf is deprecated: it has been moved to the standard library package `Printf`.
Add `using Printf` to your imports.
  likely near /home/vtjnash/.julia/v0.7/Colors/src/utilities.jl:24
```