### PR TITLE
move diff back to Base

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1468,6 +1468,8 @@ end
 @deprecate(matchall(r::Regex, s::AbstractString; overlap::Bool = false),
            collect(m.match for m in eachmatch(r, s, overlap = overlap)))
 
+@deprecate diff(A::AbstractMatrix) diff(A, 1)
+
 # PR 26194
 export assert
 function assert(x)

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -370,6 +370,7 @@ export
     conj!,
     copy!,
     copyto!,
+    diff,
     cumprod,
     cumprod!,
     cumsum,

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1087,6 +1087,44 @@ function _accumulate1!(op, B, v1, A::AbstractVector, dim::Integer)
     return B
 end
 
+diff(a::AbstractVector) = [ a[i+1] - a[i] for i=1:length(a)-1 ]
+
+"""
+    diff(A::AbstractVector)
+    diff(A::AbstractMatrix, dim::Integer)
+
+Finite difference operator of matrix or vector `A`. If `A` is a matrix,
+specify the dimension over which to operate with the `dim` argument.
+
+# Examples
+```jldoctest
+julia> a = [2 4; 6 16]
+2×2 Array{Int64,2}:
+ 2   4
+ 6  16
+
+julia> diff(a,2)
+2×1 Array{Int64,2}:
+  2
+ 10
+
+julia> diff(vec(a))
+3-element Array{Int64,1}:
+  4
+ -2
+ 12
+```
+"""
+function diff(A::AbstractMatrix, dim::Integer)
+    if dim == 1
+        [A[i+1,j] - A[i,j] for i=1:size(A,1)-1, j=1:size(A,2)]
+    elseif dim == 2
+        [A[i,j+1] - A[i,j] for i=1:size(A,1), j=1:size(A,2)-1]
+    else
+        throw(ArgumentError("dimension dim must be 1 or 2, got $dim"))
+    end
+end
+
 ### from abstractarray.jl
 
 # In the common case where we have two views into the same parent, aliasing checks

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -739,7 +739,6 @@ end
     @deprecate_stdlib diag        LinearAlgebra true
     @deprecate_stdlib diagind     LinearAlgebra true
     @deprecate_stdlib diagm       LinearAlgebra true
-    @deprecate_stdlib diff        LinearAlgebra true
     @deprecate_stdlib dot         LinearAlgebra true
     @deprecate_stdlib eig         LinearAlgebra true
     @deprecate_stdlib eigfact!    LinearAlgebra true

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -144,7 +144,7 @@ Base.cumprod
 Base.cumprod!
 Base.cumsum
 Base.cumsum!
-LinearAlgebra.diff
+Base.diff
 Base.repeat
 Base.rot180
 Base.rotl90

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -77,7 +77,6 @@ export
     diag,
     diagind,
     diagm,
-    diff,
     dot,
     eig,
     eigfact,

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -333,8 +333,6 @@ end
 
 @deprecate chol!(x::Number, uplo) chol(x) false
 
-@deprecate diff(A::AbstractMatrix) diff(A, 1)
-
 ### deprecations for lazier, less jazzy linalg transition in the next several blocks ###
 
 # deprecate ConjArray

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -238,44 +238,6 @@ See also [`tril`](@ref).
 """
 tril!(M::AbstractMatrix) = tril!(M,0)
 
-diff(a::AbstractVector) = [ a[i+1] - a[i] for i=1:length(a)-1 ]
-
-"""
-    diff(A::AbstractVector)
-    diff(A::AbstractMatrix, dim::Integer)
-
-Finite difference operator of matrix or vector `A`. If `A` is a matrix,
-specify the dimension over which to operate with the `dim` argument.
-
-# Examples
-```jldoctest
-julia> a = [2 4; 6 16]
-2×2 Array{Int64,2}:
- 2   4
- 6  16
-
-julia> diff(a,2)
-2×1 Array{Int64,2}:
-  2
- 10
-
-julia> diff(vec(a))
-3-element Array{Int64,1}:
-  4
- -2
- 12
-```
-"""
-function diff(A::AbstractMatrix, dim::Integer)
-    if dim == 1
-        [A[i+1,j] - A[i,j] for i=1:size(A,1)-1, j=1:size(A,2)]
-    elseif dim == 2
-        [A[i,j+1] - A[i,j] for i=1:size(A,1), j=1:size(A,2)-1]
-    else
-        throw(ArgumentError("dimension dim must be 1 or 2, got $dim"))
-    end
-end
-
 diag(A::AbstractVector) = throw(ArgumentError("use diagm instead of diag to construct a diagonal matrix"))
 
 ###########################################################################################

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -89,21 +89,6 @@ n = 5 # should be odd
     end
 end
 
-@testset "diff" begin
-    # test diff, throw ArgumentError for invalid dimension argument
-    X = [3  9   5;
-         7  4   2;
-         2  1  10]
-    @test diff(X,1) == [4  -5 -3; -5  -3  8]
-    @test diff(X,2) == [6 -4; -3 -2; -1 9]
-    @test diff(view(X, 1:2, 1:2),1) == [4 -5]
-    @test diff(view(X, 1:2, 1:2),2) == reshape([6; -3], (2,1))
-    @test diff(view(X, 2:3, 2:3),1) == [-3 8]
-    @test diff(view(X, 2:3, 2:3),2) == reshape([-2; 9], (2,1))
-    @test_throws ArgumentError diff(X,3)
-    @test_throws ArgumentError diff(X,-1)
-end
-
 @testset "linrange" begin
     # make sure unequal input arrays throw an error
     x = [2; 5; 6]

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -12,7 +12,7 @@ using Base.Sort: Forward
 using LinearAlgebra
 
 import Base: +, -, *, \, /, &, |, xor, ==
-import LinearAlgebra: mul!, ldiv!, rdiv!, chol, adjoint!, diag, diff, dot, eig,
+import LinearAlgebra: mul!, ldiv!, rdiv!, chol, adjoint!, diag, dot, eig,
     issymmetric, istril, istriu, lu, trace, transpose!, tril!, triu!,
     vecnorm, cond, diagm, factorize, ishermitian, norm, lmul!, rmul!, tril, triu
 
@@ -28,7 +28,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     vcat, hcat, hvcat, cat, imag, argmax, kron, length, log, log1p, max, min,
     maximum, minimum, one, promote_eltype, real, reshape, rot180,
     rotl90, rotr90, round, setindex!, similar, size, transpose,
-    vec, permute!, map, map!, Array
+    vec, permute!, map, map!, Array, diff
 
 using Random: GLOBAL_RNG, AbstractRNG, randsubseq, randsubseq!
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2184,6 +2184,21 @@ end
     @test all(x -> x isa U, b)
 end
 
+@testset "diff" begin
+    # test diff, throw ArgumentError for invalid dimension argument
+    X = [3  9   5;
+         7  4   2;
+         2  1  10]
+    @test diff(X,1) == [4  -5 -3; -5  -3  8]
+    @test diff(X,2) == [6 -4; -3 -2; -1 9]
+    @test diff(view(X, 1:2, 1:2),1) == [4 -5]
+    @test diff(view(X, 1:2, 1:2),2) == reshape([6; -3], (2,1))
+    @test diff(view(X, 2:3, 2:3),1) == [-3 8]
+    @test diff(view(X, 2:3, 2:3),2) == reshape([-2; 9], (2,1))
+    @test_throws ArgumentError diff(X,3)
+    @test_throws ArgumentError diff(X,-1)
+end
+
 @testset "accumulate, accumulate!" begin
     @test accumulate(+, [1,2,3]) == [1, 3, 6]
     @test accumulate(min, [1 2; 3 4], dims=1) == [1 2; 1 2]


### PR DESCRIPTION
`diff` belong with `cumsum` and friends rather than in `LinearAlgebra`. Note that the docstring is already now included in `base/array.md` rather than in the `LinearAlgebra` docs.