### PR TITLE
Use lowered form in logging macro

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -297,7 +297,7 @@ function logmsg_code(_module, file, line, level, message, exs...)
     quote
         level = $level
         std_level = convert(LogLevel, level)
-        if std_level >= _min_enabled_level[]
+        if std_level >= getindex(_min_enabled_level)
             logstate = current_logstate()
             if std_level >= logstate.min_enabled_level
                 logger = logstate.logger

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -267,4 +267,12 @@ end
     """
 end
 
+# Issue #26273
+let m = Module(:Bare26273i, false)
+    eval(m, :(import Base: @error))
+    @test_logs (:error, "Hello") eval(m, quote
+        @error "Hello"
+    end)
+end
+
 end


### PR DESCRIPTION
Macro hygiene sees pre-lowered forms, and as a result does not apply
to syntactic forms like []. Use an explicit `getindex` to get the
proper hygiene behavior.

Fixes #26273