### PR TITLE
fix #26267, regression in `names` with `imported=false`

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -648,7 +648,7 @@ JL_DLLEXPORT jl_value_t *jl_module_names(jl_module_t *m, int all, int imported)
             int hidden = jl_symbol_name(b->name)[0]=='#';
             if ((b->exportp ||
                  (imported && b->imported) ||
-                 ((b->owner == m) && (all || m == jl_main_module))) &&
+                 (b->owner == m && !b->imported && (all || m == jl_main_module))) &&
                 (all || (!b->deprecated && !hidden))) {
                 jl_array_grow_end(a, 1);
                 //XXX: change to jl_arrayset if array storage allocation for Array{Symbols,1} changes:

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -738,3 +738,12 @@ typeparam(::Type{T}, a::AbstractArray{T}) where T = 2
 @test typeparam(Int, rand(Int, 2)) == 2
 
 end
+
+# issue #26267
+module M26267
+import Test
+foo(x) = x
+end
+@test !(:Test in names(M26267, all=true, imported=false))
+@test :Test in names(M26267, all=true, imported=true)
+@test :Test in names(M26267, all=false, imported=true)


### PR DESCRIPTION
This happened because all imports used to come "from" somewhere (`Main` if nowhere else). When we changed that for top-level modules, I added a new hacked-together code path for importing that forgot to set the `imported` flag.