### PR TITLE
do not look in Pkg.dir and project files when creating the sysimg

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -115,8 +115,10 @@ function parse_load_path(str::String)
 end
 
 function init_load_path(BINDIR = Sys.BINDIR)
-    load_path = get(ENV, "JULIA_LOAD_PATH", "@|@v#.#.#|@v#.#|@v#|@default|@!v#.#")
-    append!(empty!(LOAD_PATH), parse_load_path(load_path))
+    if !Base.creating_sysimg
+        load_path = get(ENV, "JULIA_LOAD_PATH", "@|@v#.#.#|@v#.#|@v#|@default|@!v#.#")
+        append!(empty!(LOAD_PATH), parse_load_path(load_path))
+    end
     vers = "v$(VERSION.major).$(VERSION.minor)"
     push!(LOAD_PATH, abspath(BINDIR, "..", "local", "share", "julia", "site", vers))
     push!(LOAD_PATH, abspath(BINDIR, "..", "share", "julia", "site", vers))

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -456,6 +456,7 @@ include("loading.jl")
 # misc useful functions & macros
 include("util.jl")
 
+creating_sysimg = true
 # set up depot & load paths to be able to find stdlib packages
 let BINDIR = ccall(:jl_get_julia_bindir, Any, ())
     init_depot_path(BINDIR)
@@ -894,12 +895,15 @@ end
 end
 end
 
-empty!(DEPOT_PATH)
+@eval Base creating_sysimg = false
+
 empty!(LOAD_PATH)
+Base.init_load_path() # want to be able to find external packages in userimg.jl
 
 let
 tot_time_userimg = @elapsed (Base.isfile("userimg.jl") && Base.include(Main, "userimg.jl"))
 tot_time_precompile = Base.is_primary_base_module ? (@elapsed Base.include(Base, "precompile.jl")) : 0.0
+
 
 tot_time_base = (Base.end_base_include - Base.start_base_include) * 10.0^(-9)
 tot_time = tot_time_base + Base.tot_time_stdlib[] + tot_time_userimg + tot_time_precompile
@@ -913,3 +917,6 @@ print("Userimg: ──── "); Base.time_print(tot_time_userimg       * 10^9);
 end
 print("Precompile: ─ "); Base.time_print(tot_time_precompile    * 10^9); print(" "); showcompact((tot_time_precompile    / tot_time) * 100); println("%")
 end
+
+empty!(LOAD_PATH)
+empty!(DEPOT_PATH)

--- a/stdlib/Pkg/src/Pkg.jl
+++ b/stdlib/Pkg/src/Pkg.jl
@@ -87,8 +87,10 @@ custom METADATA setup.
 init(meta::AbstractString=DEFAULT_META, branch::AbstractString=META_BRANCH) = Dir.init(meta,branch)
 
 function __init__()
-    vers = "v$(VERSION.major).$(VERSION.minor)"
-    push!(Base.LOAD_PATH, dir)
+    if !Base.creating_sysimg
+        vers = "v$(VERSION.major).$(VERSION.minor)"
+        push!(Base.LOAD_PATH, dir)
+    end
 end
 
 """


### PR DESCRIPTION
Can someone explain why the `LOAD_PATH` is emptied *before* including the `userimg.jl`? How are you supposed to load anything there in that case? I reinitialize the `LOAD_PATH` in this PR so you can actually put something like `Base.require(Main, :Crayons)` there. Also, moved emptying the `DEPOT_PATH`.

@StefanKarpinski 
