### PR TITLE
performance tweak in reverse(::String)

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -130,7 +130,7 @@ julia> join(reverse(collect(graphemes("ax̂e")))) # reverses graphemes
 ```
 """
 function reverse(s::Union{String,SubString{String}})::String
-    sprint() do io
+    sprint(sizehint=sizeof(s)) do io
         i, j = firstindex(s), lastindex(s)
         while i ≤ j
             c, j = s[j], prevind(s, j)


### PR DESCRIPTION
No reason not to pass a `sizehint` in this function since we know the exact number of bytes required.