### PR TITLE
Define factorize(Adjoint) to make e.g. inv(Adjoint) work (in most cases)

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1222,6 +1222,8 @@ function factorize(A::StridedMatrix{T}) where T
     end
     qrfact(A, Val(true))
 end
+factorize(A::Adjoint)   =   adjoint(factorize(parent(A)))
+factorize(A::Transpose) = transpose(factorize(parent(A)))
 
 ## Moore-Penrose pseudoinverse
 

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -847,4 +847,19 @@ end
     end
 end
 
+@testset "inverse of Adjoint" begin
+    A = randn(n, n)
+
+    @test inv(A')*A'                     ≈ I
+    @test inv(transpose(A))*transpose(A) ≈ I
+
+    B = complex.(A, randn(n, n))
+    B = B + transpose(B)
+
+    # The following two cases fail because ldiv!(F::Adjoint/Transpose{BunchKaufman},b)
+    # isn't implemented yet
+    @test_broken inv(B')*B'                     ≈ I
+    @test_broken inv(transpose(B))*transpose(B) ≈ I
+end
+
 end # module TestDense


### PR DESCRIPTION
Fixes JuliaLang/julia#26299. It will still fail for complex symmetric matrices and it will require a few more definitions to handle that (relatively rare) case so I've added a `@test_broken` for now.