### PR TITLE
lower top-level statements so that the front-end knows their values are unused

### DIFF
--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -94,12 +94,14 @@
 
 (define *in-expand* #f)
 
+(define (toplevel-only-expr? e)
+  (and (pair? e)
+       (or (memq (car e) '(toplevel line module import importall using export
+                                    error incomplete))
+           (and (eq? (car e) 'global) (every symbol? (cdr e))))))
+
 (define (expand-toplevel-expr e)
-  (cond ((or (atom? e)
-             (and (pair? e)
-                  (or (memq (car e) '(toplevel line module import importall using export
-                                               error incomplete))
-                      (and (eq? (car e) 'global) (every symbol? (cdr e))))))
+  (cond ((or (atom? e) (toplevel-only-expr? e))
          (if (underscore-symbol? e)
              (syntax-deprecation "underscores as an rvalue" "" #f))
          e)
@@ -206,6 +208,11 @@
 (define (jl-expand-to-thunk expr)
   (parser-wrap (lambda ()
                  (expand-toplevel-expr expr))))
+
+(define (jl-expand-to-thunk-stmt expr)
+  (jl-expand-to-thunk (if (toplevel-only-expr? expr)
+                          expr
+                          `(block ,expr (null)))))
 
 ; run whole frontend on a string. useful for testing.
 (define (fe str)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1450,6 +1450,7 @@ JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
 JL_DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
                                              char *filename, jl_module_t *inmodule);
 JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr, jl_module_t *inmodule);
+JL_DLLEXPORT jl_value_t *jl_expand_stmt(jl_value_t *expr, jl_module_t *inmodule);
 JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str);
 
 // external libraries

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -228,7 +228,7 @@ jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex)
         for (int i = 0; i < jl_array_len(exprs); i++) {
             // process toplevel form
             ptls->world_age = jl_world_counter;
-            form = jl_expand(jl_array_ptr_ref(exprs, i), newm);
+            form = jl_expand_stmt(jl_array_ptr_ref(exprs, i), newm);
             ptls->world_age = jl_world_counter;
             (void)jl_toplevel_eval_flex(newm, form, 1, 1);
         }

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -209,6 +209,18 @@ end
     # #6080
     @test_deprecated r"Syntax `&argument`.*is deprecated" Meta.lower(@__MODULE__, :(ccall(:a, Cvoid, (Cint,), &x)))
 
+    @test_logs eval(:(module DotEqualsDep
+        a=[1,2]
+        a.=3
+        0
+        end))
+    @test_logs include_string(@__MODULE__, """
+        a=[1,2]
+        a.=3
+        0""")
+    @test_deprecated include_string(@__MODULE__, """
+        a=[1,2]
+        a.=3""")
 end
 
 module LogTest


### PR DESCRIPTION
Fixes most false positives in the deprecation for using the value of `.=`; see https://github.com/JuliaLang/julia/pull/26088#issuecomment-369653334

This could also be useful in other ways in the future.