### PR TITLE
Check vector length in cross()

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -109,8 +109,12 @@ julia> cross(a,b)
  0
 ```
 """
-cross(a::AbstractVector, b::AbstractVector) =
+function cross(a::AbstractVector, b::AbstractVector)
+    if !(length(a) == length(b) == 3)
+        throw(DimensionMismatch("cross product is only defined for vectors of length 3"))
+    end
     [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]]
+end
 
 """
     triu(M)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -113,7 +113,9 @@ function cross(a::AbstractVector, b::AbstractVector)
     if !(length(a) == length(b) == 3)
         throw(DimensionMismatch("cross product is only defined for vectors of length 3"))
     end
-    @inbounds [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]]
+    a1, a2, a3 = a
+    b1, b2, b3 = b
+    [a2*b3-a3*b2, a3*b1-a1*b3, a1*b2-a2*b1]
 end
 
 """

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -113,7 +113,7 @@ function cross(a::AbstractVector, b::AbstractVector)
     if !(length(a) == length(b) == 3)
         throw(DimensionMismatch("cross product is only defined for vectors of length 3"))
     end
-    [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]]
+    @inbounds [a[2]*b[3]-a[3]*b[2], a[3]*b[1]-a[1]*b[3], a[1]*b[2]-a[2]*b[1]]
 end
 
 """

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -159,6 +159,8 @@ end
 @test !issymmetric(fill(1,5,3))
 @test !ishermitian(fill(1,5,3))
 @test (x = fill(1,3); cross(x,x) == zeros(3))
+@test_throws DimensionMismatch cross(fill(1,3), fill(1,4))
+@test_throws DimensionMismatch cross(fill(1,2), fill(1,3))
 
 @test trace(Bidiagonal(fill(1,5),fill(0,4),:U)) == 5
 


### PR DESCRIPTION
`cross` conceptually assumes the vectors are each of length three, but previously this has not been checked.  (This code is essentially unchanged since it was introduced in e673b1c8061b6486589d299cf5deff41b76f1fc6.)  This is technically breaking, but I can't imagine anybody should have been passing vectors of length > 3 here, so I think it's safe to merge without deprecation warning.