### PR TITLE
Promote Sockets page header to a h1

### DIFF
--- a/stdlib/Sockets/docs/src/index.md
+++ b/stdlib/Sockets/docs/src/index.md
@@ -1,4 +1,4 @@
-## Sockets
+# Sockets
 
 ```@docs
 Sockets.connect(::TCPSocket, ::Integer)


### PR DESCRIPTION
Currently the "Sockets" page shows up as a dash in the manual's navbar since Documenter is unable to figure out the page title.