### PR TITLE
Fix a warning in codegen when building with Clang

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5895,7 +5895,7 @@ static std::unique_ptr<Module> emit_function(
                 mallocVisitLine(ctx, props.file, props.line);
             }
         }
-        if (cursor + 1 < jl_array_len(stmts) && jl_is_labelnode(jl_array_ptr_ref(stmts, cursor+1)))
+        if ((size_t)cursor + 1 < jl_array_len(stmts) && jl_is_labelnode(jl_array_ptr_ref(stmts, cursor+1)))
             come_from_bb[cursor+1] = ctx.builder.GetInsertBlock();
         find_next_stmt(cursor + 1);
     }


### PR DESCRIPTION
The `cursor` variable is an `int` but is compared against the result of `jl_array_len`, which is a `size_t`. This causes Clang to emit a warning. To fix it we can simply cast `cursor` to a `size_t`.