### PR TITLE
fix early return in emit_builtin_call

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2592,9 +2592,9 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
                                         !isboxed ? tbaa_arraybuf : tbaa_ptrarraybuf,
                                         data_owner, 0);
                         }
-                        *ret = ary;
-                        return true;
                     }
+                    *ret = ary;
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/25983

```
using BenchmarkTools
struct foo end
V=Vector{foo}(1000_000);

@btime map(identity, V);
  295.159 μs (2 allocations: 96 bytes)

 f(::foo)=foo();
 VV=similar(V);

@btime VV .= f.(V);
  26.156 ns (0 allocations: 0 bytes)
```