### PR TITLE
improve performance for Matrix -> SparseMatrix

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -376,6 +376,27 @@ function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
     eltypeTvV = convert(Vector{Tv}, V)
     return sparse_IJ_sorted!(eltypeTiI, eltypeTiJ, eltypeTvV, size(M)...)
 end
+function SparseMatrixCSC{Tv,Ti}(M::Matrix) where {Tv,Ti}
+    nz = count(!equalto(0), M)
+    colptr = zeros(Ti, size(M, 2) + 1)
+    nzval = Vector{Tv}(uninitialized, nz)
+    rowval = Vector{Ti}(uninitialized, nz)
+    colptr[1] = 1
+    cnt = 1
+    @inbounds for j in 1:size(M, 2)
+        for i in 1:size(M, 1)
+            v = M[i, j]
+            if v != 0
+                rowval[cnt] = i
+                nzval[cnt] = v
+                cnt += 1
+            end
+        end
+        colptr[j+1] = cnt
+    end
+    return SparseMatrixCSC(size(M, 1), size(M, 2), colptr, rowval, nzval)
+end
+
 # converting from SparseMatrixCSC to other matrix types
 function Matrix(S::SparseMatrixCSC{Tv}) where Tv
     # Handle cases where zero(Tv) is not defined but the array is dense.

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -377,7 +377,7 @@ function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
     return sparse_IJ_sorted!(eltypeTiI, eltypeTiJ, eltypeTvV, size(M)...)
 end
 function SparseMatrixCSC{Tv,Ti}(M::Matrix) where {Tv,Ti}
-    nz = count(!equalto(0), M)
+    nz = count(t -> t != 0, M)
     colptr = zeros(Ti, size(M, 2) + 1)
     nzval = Vector{Tv}(uninitialized, nz)
     rowval = Vector{Ti}(uninitialized, nz)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -376,7 +376,7 @@ function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
     eltypeTvV = convert(Vector{Tv}, V)
     return sparse_IJ_sorted!(eltypeTiI, eltypeTiJ, eltypeTvV, size(M)...)
 end
-function SparseMatrixCSC{Tv,Ti}(M::Matrix) where {Tv,Ti}
+function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}
     nz = count(t -> t != 0, M)
     colptr = zeros(Ti, size(M, 2) + 1)
     nzval = Vector{Tv}(uninitialized, nz)


### PR DESCRIPTION
Benchmark (`sparse2` is PR):

```
A1 = rand(3000, 3000)
A2 = Matrix(sprand(3000, 3000, 0.1))
A3 = Matrix(sprand(3000, 3000, 0.01))

@btime sparse(A1)
  114.613 ms (11 allocations: 206.04 MiB)
@btime sparse(A2)
  27.586 ms (11 allocations: 20.61 MiB)
@btime sparse(A3)
  14.071 ms (11 allocations: 2.09 MiB)

@btime sparse2(A1)
  61.808 ms (7 allocations: 137.35 MiB)
@btime sparse2(A2)
  22.060 ms (7 allocations: 13.73 MiB)
@btime sparse2(A3)
  11.622 ms (7 allocations: 1.39 MiB
```