### PR TITLE
Document {last,first}index(A, d) methods

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -172,7 +172,7 @@ _length(A) = (@_inline_meta; length(A))
     lastindex(collection) -> Integer
     lastindex(collection, d) -> Integer
 
-Return the last index of `collection`, optionally constrained to be within dimension `d`.
+Return the last index of `collection`. If `d` is given, return the last index of `collection` along dimension `d`.
 
 The syntaxes `A[end]` and `A[end, end]` lower to `A[lastindex(A)]` and
 `A[lastindex(A, 1), lastindex(A, 2)]`, respectively.
@@ -193,7 +193,7 @@ lastindex(a::AbstractArray, d) = (@_inline_meta; last(axes(a, d)))
     firstindex(collection) -> Integer
     firstindex(collection, d) -> Integer
 
-Return the first index of `collection`, optionally constrained to be within dimension `d`.
+Return the first index of `collection`. If `d` is given, return the first index of `collection` along dimension `d`.
 
 # Examples
 ```jldoctest

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -170,31 +170,42 @@ _length(A) = (@_inline_meta; length(A))
 
 """
     lastindex(collection) -> Integer
+    lastindex(collection, d) -> Integer
 
-Return the last index of the collection.
+Return the last index of `collection`, optionally constrained to be within dimension `d`.
+
+The syntaxes `A[end]` and `A[end, end]` lower to `A[lastindex(A)]` and
+`A[lastindex(A, 1), lastindex(A, 2)]`, respectively.
 
 # Examples
 ```jldoctest
 julia> lastindex([1,2,4])
 3
+
+julia> lastindex(rand(3,4,5), 2)
+4
 ```
 """
 lastindex(a::AbstractArray) = (@_inline_meta; last(linearindices(a)))
-lastindex(a::AbstractArray, n) = (@_inline_meta; last(axes(a, n)))
+lastindex(a::AbstractArray, d) = (@_inline_meta; last(axes(a, d)))
 
 """
     firstindex(collection) -> Integer
+    firstindex(collection, d) -> Integer
 
-Return the first index of the collection.
+Return the first index of `collection`, optionally constrained to be within dimension `d`.
 
 # Examples
 ```jldoctest
 julia> firstindex([1,2,4])
 1
+
+julia> firstindex(rand(3,4,5), 2)
+1
 ```
 """
 firstindex(a::AbstractArray) = (@_inline_meta; first(linearindices(a)))
-firstindex(a::AbstractArray, n) = (@_inline_meta; first(axes(a, n)))
+firstindex(a::AbstractArray, d) = (@_inline_meta; first(axes(a, d)))
 
 first(a::AbstractArray) = a[first(eachindex(a))]
 


### PR DESCRIPTION
As noted in https://github.com/JuliaLang/julia/pull/25763#issuecomment-370779238.

I didn't constrain `d::Integer` because it's similarly unconstrained in `axes`.