### PR TITLE
set GLIBCXX_USE_C99 for g++ to avoit std::to_string failures

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -387,7 +387,7 @@ CXX := $(CROSS_COMPILE)g++
 JCFLAGS := -std=gnu99 -pipe $(fPIC) -fno-strict-aliasing -D_FILE_OFFSET_BITS=64
 # AArch64 needs this flag to generate the .eh_frame used by libunwind
 JCPPFLAGS := -fasynchronous-unwind-tables
-JCXXFLAGS := -pipe $(fPIC) -fno-rtti
+JCXXFLAGS :=  -D_GLIBCXX_USE_C99 -pipe $(fPIC) -fno-rtti
 ifneq ($(OS), WINNT)
 # Do not enable on windows to avoid warnings from libuv.
 JCXXFLAGS += -pedantic


### PR DESCRIPTION
The build failed for me on anubis with:

```
g++ -m64 -I/data/vchuravy/julia/usr/include     -fPIC -fvisibility-inlines-hidden -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers -pedantic -Wno-long-long -Wno-maybe-uninitialized -Wdelete-non-virtual-dtor -Wno-comment -Werror=date-time -std=c++1y -ffunction-sections -fdata-sectio
ns -O2 -g   -fno-exceptions -fno-rtti -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-fasynchronous-unwind-tables -DJULIA_HAS_IFUNC_SUPPORT=1 -DJULIA_ENABLE_THREADING -DJULIA_NUM_THREADS=1 -pipe -fPIC -fno-r
tti -pedantic -D_FILE_OFFSET_BITS=64 -O3 -ggdb2 -falign-functions -momit-leaf-frame-pointer -D_GNU_SOURCE -I. -I/data/vchu
ravy/julia/src -I/data/vchuravy/julia/src/flisp -I/data/vchuravy/julia/src/support -I/data/vchuravy/julia/usr/include -I/d
ata/vchuravy/julia/usr/include -DLIBRARY_EXPORTS -I/data/vchuravy/julia/deps/valgrind -Wall -Wno-strict-aliasing -fno-omit
-frame-pointer -fvisibility=hidden -fno-common -Wpointer-arith -Wundef -DJL_BUILD_ARCH='"x86_64"' -DJL_BUILD_UNAME='"Linux
"' -I/data/vchuravy/julia/usr/include -DLLVM_SHLIB "-DJL_SYSTEM_IMAGE_PATH=\"../lib/julia/sys.so\""  -c /data/vchuravy/jul
ia/src/codegen.cpp -o codegen.o
In file included from /data/vchuravy/julia/src/intrinsics.cpp:7:0,
                 from /data/vchuravy/julia/src/codegen.cpp:1890:
                 /data/vchuravy/julia/src/ccall.cpp: In function ‘bool runtime_sym_gvs(const char*, const char*, MT&&, llvm::GlobalVariable*&, llvm::GlobalVariable*&, void**)’:
                 /data/vchuravy/julia/src/ccall.cpp:110:17: error: ‘to_string’ is not a member of ‘std’
                          name += std::to_string(globalUnique++);
                                           ^
```

My GCC version is:

```
vchuravy@anubis:/data/vchuravy/julia$ gcc --version
gcc (Ubuntu 5.5.0-1ubuntu2) 5.4.1 20171010
```

Solution taken from https://stackoverflow.com/a/34352742/1237861

Since the offending change is from 2016, this might also be a missconfiguration
on my part.