### PR TITLE
Make LU factorization work for more types

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -125,7 +125,7 @@ function lu(A::Union{AbstractMatrix{T}, AbstractMatrix{Complex{T}}},
     lu!(copy(A), pivot)
 end
 
-luop(x) = (x*x + x*x) / (x*x + x*x)
+rationalop(x) = (x*x + x*x) / (x*x + x*x)
 
 # for all other types we must promote to a type which is stable under division
 """
@@ -193,15 +193,14 @@ true
 ```
 """
 function lu(A::AbstractMatrix{T}, pivot::Union{Val{false}, Val{true}}) where T
-    S = typeof(zero(T)/one(T))
+    S = promote_op(rationalop, T)
     AA = similar(A, S)
     copyto!(AA, A)
     lu!(AA, pivot)
 end
 # We can't assume an ordered field so we first try without pivoting
 function lu(A::AbstractMatrix{T}) where T
-    S = typeof(zero(T)/one(T))
-    S = promote_op(luop, T)
+    S = promote_op(rationalop, T)
     AA = similar(A, S)
     copyto!(AA, A)
     F = lu!(AA, Val(false))

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -125,6 +125,8 @@ function lu(A::Union{AbstractMatrix{T}, AbstractMatrix{Complex{T}}},
     lu!(copy(A), pivot)
 end
 
+luop(x) = (x*x + x*x) / (x*x + x*x)
+
 # for all other types we must promote to a type which is stable under division
 """
     lu(A, pivot=Val(true)) -> F::LU
@@ -199,6 +201,7 @@ end
 # We can't assume an ordered field so we first try without pivoting
 function lu(A::AbstractMatrix{T}) where T
     S = typeof(zero(T)/one(T))
+    S = promote_op(luop, T)
     AA = similar(A, S)
     copyto!(AA, A)
     F = lu!(AA, Val(false))

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -329,12 +329,12 @@ module TrickyArithmetic
     Base.promote_rule(T::Type{<:Union{A,B,C}}, ::Type{D{NT,DT}}) where {NT,DT} = D{promote_type(NT,T),DT}
     Base.promote_rule(::Type{D{NS,DS}}, ::Type{D{NT,DT}}) where {NS,DS,NT,DT} = D{promote_type(NS,NT),promote_type(DS,DT)}
 end
-@testset "lufact with type whose sum is another type" begin
+@testset "lu with type whose sum is another type" begin
     A = TrickyArithmetic.A[1 2; 3 4]
     ElT = TrickyArithmetic.D{TrickyArithmetic.C,TrickyArithmetic.C}
-    B = @inferred lufact(A)
+    B = @inferred lu(A)
     @test B isa LinearAlgebra.LU{ElT,Matrix{ElT}}
-    C = @inferred lufact(A, Val(false))
+    C = @inferred lu(A, Val(false))
     @test C isa LinearAlgebra.LU{ElT,Matrix{ElT}}
 end
 

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -301,6 +301,7 @@ module TrickyArithmetic
         d::DT
     end
     Base.zero(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = zero(NT) / one(DT)
+    Base.one(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = one(NT) / one(DT)
     Base.convert(::Type{D{NT, DT}}, a::Union{A, B, C}) where {NT, DT} = NT(a) / one(DT)
     #Base.convert(::Type{D{NT, DT}}, a::D) where {NT, DT} = NT(a.n) / DT(a.d)
 

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -271,71 +271,14 @@ end
     @test allnames == ["L", "P", "U", "factors", "info", "ipiv", "p"]
 end
 
-module TrickyArithmetic
-    struct A
-        x::Int
-    end
-    A(a::A) = a
-    Base.convert(::Type{A}, i::Int) = A(i)
-    Base.zero(::Union{A, Type{A}}) = A(0)
-    Base.one(::Union{A, Type{A}}) = A(1)
-    struct B
-        x::Int
-    end
-    struct C
-        x::Int
-    end
-    C(a::A) = C(a.x)
-    Base.zero(::Union{C, Type{C}}) = C(0)
-    Base.one(::Union{C, Type{C}}) = C(1)
+include("trickyarithmetic.jl")
 
-    Base.:(*)(x::Int, a::A) = B(x*a.x)
-    Base.:(*)(a::A, x::Int) = B(a.x*x)
-    Base.:(*)(a::Union{A,B}, b::Union{A,B}) = B(a.x*b.x)
-    Base.:(*)(a::Union{A,B,C}, b::Union{A,B,C}) = C(a.x*b.x)
-    Base.:(+)(a::Union{A,B,C}, b::Union{A,B,C}) = C(a.x+b.x)
-    Base.:(-)(a::Union{A,B,C}, b::Union{A,B,C}) = C(a.x-b.x)
-
-    struct D{NT, DT}
-        n::NT
-        d::DT
-    end
-    Base.zero(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = zero(NT) / one(DT)
-    Base.one(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = one(NT) / one(DT)
-    Base.convert(::Type{D{NT, DT}}, a::Union{A, B, C}) where {NT, DT} = NT(a) / one(DT)
-    #Base.convert(::Type{D{NT, DT}}, a::D) where {NT, DT} = NT(a.n) / DT(a.d)
-
-    Base.:(*)(a::D, b::D) = (a.n*b.n) / (a.d*b.d)
-    Base.:(*)(a::D, b::Union{A,B,C}) = (a.n * b) / a.d
-    Base.:(*)(a::Union{A,B,C}, b::D) = b * a
-    Base.inv(a::Union{A,B,C}) = A(1) / a
-    Base.inv(a::D) = a.d / a.n
-    Base.:(/)(a::Union{A,B,C}, b::Union{A,B,C}) = D(a, b)
-    Base.:(/)(a::D, b::Union{A,B,C}) = a.n / (a.d*b)
-    Base.:(/)(a::Union{A,B,C}, b::D) = (a*b.d) / b.n
-    Base.:(+)(a::Union{A,B,C}, b::D) = (a*b.d+b.n) / b.d
-    Base.:(+)(a::D, b::Union{A,B,C}) = b + a
-    Base.:(+)(a::D, b::D) = (a.n*b.d+a.d*b.n) / (a.d*b.d)
-    Base.:(-)(a::Union{A,B,C}) = typeof(a)(a.x)
-    Base.:(-)(a::D) = (-a.n) / a.d
-    Base.:(-)(a::Union{A,B,C,D}, b::Union{A,B,C,D}) = a + (-b)
-
-    Base.promote_rule(::Type{A}, ::Type{B}) = B
-    Base.promote_rule(::Type{B}, ::Type{A}) = B
-    Base.promote_rule(::Type{A}, ::Type{C}) = C
-    Base.promote_rule(::Type{C}, ::Type{A}) = C
-    Base.promote_rule(::Type{B}, ::Type{C}) = C
-    Base.promote_rule(::Type{C}, ::Type{B}) = C
-    Base.promote_rule(::Type{D{NT,DT}}, T::Type{<:Union{A,B,C}}) where {NT,DT} = D{promote_type(NT,T),DT}
-    Base.promote_rule(T::Type{<:Union{A,B,C}}, ::Type{D{NT,DT}}) where {NT,DT} = D{promote_type(NT,T),DT}
-    Base.promote_rule(::Type{D{NS,DS}}, ::Type{D{NT,DT}}) where {NS,DS,NT,DT} = D{promote_type(NS,NT),promote_type(DS,DT)}
-end
 @testset "lu with type whose sum is another type" begin
     A = TrickyArithmetic.A[1 2; 3 4]
     ElT = TrickyArithmetic.D{TrickyArithmetic.C,TrickyArithmetic.C}
-    B = @inferred lu(A)
+    B = lu(A)
     @test B isa LinearAlgebra.LU{ElT,Matrix{ElT}}
-    C = @inferred lu(A, Val(false))
+    C = lu(A, Val(false))
     @test C isa LinearAlgebra.LU{ElT,Matrix{ElT}}
 end
 

--- a/stdlib/LinearAlgebra/test/trickyarithmetic.jl
+++ b/stdlib/LinearAlgebra/test/trickyarithmetic.jl
@@ -1,0 +1,59 @@
+module TrickyArithmetic
+    struct A
+        x::Int
+    end
+    A(a::A) = a
+    Base.convert(::Type{A}, i::Int) = A(i)
+    Base.zero(::Union{A, Type{A}}) = A(0)
+    Base.one(::Union{A, Type{A}}) = A(1)
+    struct B
+        x::Int
+    end
+    struct C
+        x::Int
+    end
+    C(a::A) = C(a.x)
+    Base.zero(::Union{C, Type{C}}) = C(0)
+    Base.one(::Union{C, Type{C}}) = C(1)
+
+    Base.:(*)(x::Int, a::A) = B(x*a.x)
+    Base.:(*)(a::A, x::Int) = B(a.x*x)
+    Base.:(*)(a::Union{A,B}, b::Union{A,B}) = B(a.x*b.x)
+    Base.:(*)(a::Union{A,B,C}, b::Union{A,B,C}) = C(a.x*b.x)
+    Base.:(+)(a::Union{A,B,C}, b::Union{A,B,C}) = C(a.x+b.x)
+    Base.:(-)(a::Union{A,B,C}, b::Union{A,B,C}) = C(a.x-b.x)
+
+    struct D{NT, DT}
+        n::NT
+        d::DT
+    end
+    Base.zero(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = zero(NT) / one(DT)
+    Base.one(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = one(NT) / one(DT)
+    Base.convert(::Type{D{NT, DT}}, a::Union{A, B, C}) where {NT, DT} = NT(a) / one(DT)
+    #Base.convert(::Type{D{NT, DT}}, a::D) where {NT, DT} = NT(a.n) / DT(a.d)
+
+    Base.:(*)(a::D, b::D) = (a.n*b.n) / (a.d*b.d)
+    Base.:(*)(a::D, b::Union{A,B,C}) = (a.n * b) / a.d
+    Base.:(*)(a::Union{A,B,C}, b::D) = b * a
+    Base.inv(a::Union{A,B,C}) = A(1) / a
+    Base.inv(a::D) = a.d / a.n
+    Base.:(/)(a::Union{A,B,C}, b::Union{A,B,C}) = D(a, b)
+    Base.:(/)(a::D, b::Union{A,B,C}) = a.n / (a.d*b)
+    Base.:(/)(a::Union{A,B,C,D}, b::D) = a * inv(b)
+    Base.:(+)(a::Union{A,B,C}, b::D) = (a*b.d+b.n) / b.d
+    Base.:(+)(a::D, b::Union{A,B,C}) = b + a
+    Base.:(+)(a::D, b::D) = (a.n*b.d+a.d*b.n) / (a.d*b.d)
+    Base.:(-)(a::Union{A,B,C}) = typeof(a)(a.x)
+    Base.:(-)(a::D) = (-a.n) / a.d
+    Base.:(-)(a::Union{A,B,C,D}, b::Union{A,B,C,D}) = a + (-b)
+
+    Base.promote_rule(::Type{A}, ::Type{B}) = B
+    Base.promote_rule(::Type{B}, ::Type{A}) = B
+    Base.promote_rule(::Type{A}, ::Type{C}) = C
+    Base.promote_rule(::Type{C}, ::Type{A}) = C
+    Base.promote_rule(::Type{B}, ::Type{C}) = C
+    Base.promote_rule(::Type{C}, ::Type{B}) = C
+    Base.promote_rule(::Type{D{NT,DT}}, T::Type{<:Union{A,B,C}}) where {NT,DT} = D{promote_type(NT,T),DT}
+    Base.promote_rule(T::Type{<:Union{A,B,C}}, ::Type{D{NT,DT}}) where {NT,DT} = D{promote_type(NT,T),DT}
+    Base.promote_rule(::Type{D{NS,DS}}, ::Type{D{NT,DT}}) where {NS,DS,NT,DT} = D{promote_type(NS,NT),promote_type(DS,DT)}
+end

--- a/stdlib/LinearAlgebra/test/trickyarithmetic.jl
+++ b/stdlib/LinearAlgebra/test/trickyarithmetic.jl
@@ -27,6 +27,7 @@ module TrickyArithmetic
         n::NT
         d::DT
     end
+    D{NT, DT}(d::D{NT, DT}) where {NT, DT} = d # called by oneunit
     Base.zero(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = zero(NT) / one(DT)
     Base.one(::Union{D{NT, DT}, Type{D{NT, DT}}}) where {NT, DT} = one(NT) / one(DT)
     Base.convert(::Type{D{NT, DT}}, a::Union{A, B, C}) where {NT, DT} = NT(a) / one(DT)


### PR DESCRIPTION
When determining the element type need, `lufact` does the following
https://github.com/JuliaLang/julia/blob/1a870b466d83068fad9f280cc1f8e65a108cb6bc/stdlib/LinearAlgebra/src/lu.jl#L180
However LU factorization also multiplies elements of type `T` together and sum them together.
If the type `T` is not invariant under multiplication and/or addition, `lufact` does work, see https://github.com/JuliaAlgebra/MultivariatePolynomials.jl/issues/69.
Note the strong similary between this PR and https://github.com/JuliaLang/julia/pull/18218 which did a similar change but to matrix multiplication.