### PR TITLE
docstringify comments, readable variable names

### DIFF
--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -222,11 +222,16 @@ function printMenu(out, m::AbstractMenu, cursor::Int; init::Bool=false)
     buf = IOBuffer()
    
     lines = m.pagesize-1
+    
+    if init
+        m.pageoffset = 0
+    else
+        # Move the cursor to the beginning of where it should print
+        print(buf, "\x1b[999D\x1b[$(lines)A")
+    end
+    
     firstline = m.pageoffset+1
     lastline = m.pagesize+m.pageoffset
-    
-    # Move the cursor to the beginning of where it should print
-    !init && print(buf, "\x1b[999D\x1b[$(lines)A")
     
     for i in firstline:lastline
         # clearline

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -80,7 +80,7 @@ options(m::AbstractMenu) = error("unimplemented")
     writeLine(buf::IOBuffer, m::AbstractMenu, idx::Int, cur::Bool)
 
 Write the option at index `idx` to the buffer. If cursor is `true` display the cursor.
-""" 
+"""
 function writeLine(buf::IOBuffer, m::AbstractMenu, idx::Int, cur::Bool)
     error("unimplemented")
 end

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -56,7 +56,7 @@ abstract type AbstractMenu end
 """
     pick(m::AbstractMenu, cursor::Int)
 
-Defines what happens when a user presses the Enter key while the menu is open. 
+Defines what happens when a user presses the Enter key while the menu is open.
 If `true` is returned, `request()` will exit.
 """
 pick(m::AbstractMenu, cursor::Int) = error("unimplemented")
@@ -126,7 +126,7 @@ function request(term::REPL.Terminals.TTYTerminal, m::AbstractMenu)
 
     raw_mode_enabled = enableRawMode(term)
     raw_mode_enabled && print(term.out_stream, "\x1b[?25l") # hide the cursor
-    
+
     lastoption = length(options(m))
     try
         while true
@@ -222,28 +222,28 @@ end
 """
     printMenu(out, m::AbstractMenu, cursor::Int; init::Bool=false)
 
-Display the state of a menu. 
+Display the state of a menu.
 """
 function printMenu(out, m::AbstractMenu, cursor::Int; init::Bool=false)
     CONFIG[:supress_output] && return
 
     buf = IOBuffer()
-   
+
     lines = m.pagesize-1
-    
+
     if init
         m.pageoffset = 0
     else
         # Move the cursor to the beginning of where it should print
         print(buf, "\x1b[999D\x1b[$(lines)A")
     end
-    
+
     firstline = m.pageoffset+1
     lastline = m.pagesize+m.pageoffset
-    
+
     for i in firstline:lastline
         # clearline
-        print(buf, "\x1b[2K") 
+        print(buf, "\x1b[2K")
 
         if i == firstline && m.pageoffset > 0
             print(buf, CONFIG[:up_arrow])

--- a/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
+++ b/stdlib/REPL/src/TerminalMenus/AbstractMenu.jl
@@ -55,6 +55,7 @@ abstract type AbstractMenu end
 
 """
     pick(m::AbstractMenu, cursor::Int)
+
 Defines what happens when a user presses the Enter key while the menu is open. 
 If `true` is returned, `request()` will exit.
 """
@@ -62,19 +63,22 @@ pick(m::AbstractMenu, cursor::Int) = error("unimplemented")
 
 """
     cancel(m::AbstractMenu)
+
 Define what happens when a user cancels ('q' or ctrl-c) a menu.
 `request()` will always exit after calling this function.
 """
 cancel(m::AbstractMenu) = error("unimplemented")
 
 """
-    options(m::AbstractMenu) 
+    options(m::AbstractMenu)
+
 Return a list of strings to be displayed as options in the current page.
 """
 options(m::AbstractMenu) = error("unimplemented")
 
 """
     writeLine(buf::IOBuffer, m::AbstractMenu, idx::Int, cur::Bool)
+
 Write the option at index `idx` to the buffer. If cursor is `true` display the cursor.
 """ 
 function writeLine(buf::IOBuffer, m::AbstractMenu, idx::Int, cur::Bool)
@@ -88,12 +92,14 @@ end
 
 """
     header(m::AbstractMenu)
+
 Displays the header above the menu when it is rendered to the screen.
 """
 header(m::AbstractMenu) = ""
 
 """
     keypress(m::AbstractMenu, i::UInt32)
+
 Send any non-standard keypress event to this function.
 If `true` is returned, `request()` will exit.
 """
@@ -104,6 +110,7 @@ keypress(m::AbstractMenu, i::UInt32) = false
 
 """
     request(m::AbstractMenu)
+
 Display the menu and enter interactive mode. Returns `m.selected` which
 varies based on menu type.
 """
@@ -214,6 +221,7 @@ end
 
 """
     printMenu(out, m::AbstractMenu, cursor::Int; init::Bool=false)
+
 Display the state of a menu. 
 """
 function printMenu(out, m::AbstractMenu, cursor::Int; init::Bool=false)


### PR DESCRIPTION
 `m.pageoffset = 0` is the default for the implemented menus. If a menu needs to start at a different offset, it should be able to.

**edit:**
[nick-paul/TerminalMenus.jl#3](https://github.com/nick-paul/TerminalMenus.jl/pull/3)
Perhaps this should be changed to move the cursor to the last known position.

