### PR TITLE
RFC: Deprecate implicit scalar broadcasting in setindex!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -697,6 +697,18 @@ Deprecated or removed
     `Matrix{Int}(undef, (2, 4))`, and `Array{Float32,3}(11, 13, 17)` is now
     `Array{Float32,3}(undef, 11, 13, 17)` ([#24781]).
 
+  * Previously `setindex!(A, x, I...)` (and the syntax `A[I...] = x`) supported two
+    different modes of operation when supplied with a set of non-scalar indices `I`
+    (e.g., at least one index is an `AbstractArray`) depending upon the value of `x`
+    on the right hand side. If `x` is an `AbstractArray`, its _contents_ are copied
+    elementwise into the locations in `A` selected by `I` and it must have the same
+    number of elements as `I` selects locations. Otherwise, if `x` is not an
+    `AbstractArray`, then its _value_ is implicitly broadcast to all locations to
+    all locations in `A` selected by `I`. This latter behavior—implicitly broadcasting
+    "scalar"-like values across many locations—is now deprecated in favor of explicitly
+    using the broadcasted assignment syntax `A[I...] .= x` or `fill!(view(A, I...), x)`
+    ([#26347]).
+
   * `LinAlg.fillslots!` has been renamed `LinAlg.fillstored!` ([#25030]).
 
   * `fill!(A::Diagonal, x)` and `fill!(A::AbstractTriangular, x)` have been deprecated

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -363,10 +363,6 @@ _rshps(shp, shp_i, sz, i, ::Tuple{}) =
 _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
     "($n) cannot be less than number of dimensions of input ($N)"))
 
-# We need special handling when repeating arrays of arrays
-cat_fill!(R, X, inds) = (R[inds...] = X)
-cat_fill!(R, X::AbstractArray, inds) = fill!(view(R, inds...), X)
-
 @noinline function _repeat(A::AbstractArray, inner, outer)
     shape, inner_shape = rep_shapes(A, inner, outer)
 
@@ -385,7 +381,7 @@ cat_fill!(R, X::AbstractArray, inds) = fill!(view(R, inds...), X)
                 n = inner[i]
                 inner_indices[i] = (1:n) .+ ((c[i] - 1) * n)
             end
-            cat_fill!(R, A[c], inner_indices)
+            fill!(view(R, inner_indices...), A[c])
         end
     end
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -706,29 +706,6 @@ function setindex! end
 @eval setindex!(A::Array{T}, x, i1::Int, i2::Int, I::Int...) where {T} =
     (@_inline_meta; arrayset($(Expr(:boundscheck)), A, convert(T,x)::T, i1, i2, I...))
 
-# These are redundant with the abstract fallbacks but needed for bootstrap
-function setindex!(A::Array, x, I::AbstractVector{Int})
-    @_propagate_inbounds_meta
-    I′ = unalias(A, I)
-    for i in I′
-        A[i] = x
-    end
-    return A
-end
-function setindex!(A::Array, X::AbstractArray, I::AbstractVector{Int})
-    @_propagate_inbounds_meta
-    @boundscheck setindex_shape_check(X, length(I))
-    X′ = unalias(A, X)
-    I′ = unalias(A, I)
-    count = 1
-    for i in I′
-        @inbounds x = X′[count]
-        A[i] = x
-        count += 1
-    end
-    return A
-end
-
 # Faster contiguous setindex! with copyto!
 function setindex!(A::Array{T}, X::Array{T}, I::UnitRange{Int}) where T
     @_inline_meta
@@ -749,9 +726,6 @@ function setindex!(A::Array{T}, X::Array{T}, c::Colon) where T
     end
     return A
 end
-
-setindex!(A::Array, x::Number, ::Colon) = fill!(A, x)
-setindex!(A::Array{T, N}, x::Number, ::Vararg{Colon, N}) where {T, N} = fill!(A, x)
 
 # efficiently grow an array
 

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -114,12 +114,16 @@ end
 @inline function _growend0!(b::Bits, nchunks::Int)
     len = length(b)
     _growend!(b, nchunks)
-    @inbounds b[len+1:end] = CHK0 # resize! gives dirty memory
+    for i in len+1:length(b)
+        @inbounds b[i] = CHK0 # resize! gives dirty memory
+    end
 end
 
 @inline function _growbeg0!(b::Bits, nchunks::Int)
     _growbeg!(b, nchunks)
-    @inbounds b[1:nchunks] = CHK0
+    for i in 1:nchunks
+        @inbounds b[i] = CHK0
+    end
 end
 
 function _matched_map!(f, s1::BitSet, s2::BitSet)

--- a/base/char.jl
+++ b/base/char.jl
@@ -215,7 +215,10 @@ widen(::Type{T}) where {T<:AbstractChar} = T
 print(io::IO, c::Char) = (write(io, c); nothing)
 print(io::IO, c::AbstractChar) = print(io, Char(c)) # fallback: convert to output UTF-8
 
-const hex_chars = UInt8['0':'9';'a':'z']
+const hex_chars = UInt8['0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i',
+                        'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r',
+                        's', 't', 'u', 'v', 'w', 'x', 'y', 'z']
 
 function show_invalid(io::IO, c::Char)
     write(io, 0x27)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -578,7 +578,9 @@ function resize!(compact::IncrementalCompact, nnewnodes)
     resize!(compact.result_lines, nnewnodes)
     resize!(compact.result_flags, nnewnodes)
     resize!(compact.used_ssas, nnewnodes)
-    compact.used_ssas[(old_length+1):nnewnodes] = 0
+    for i in (old_length+1):nnewnodes
+        compact.used_ssas[i] = 0
+    end
     nothing
 end
 

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -377,8 +377,8 @@ function domsort_ssa!(ir::IRCode, domtree::DomTree)
         end
         old_inst_range = ir.cfg.blocks[bb].stmts
         inst_range = (bb_start_off+1):(bb_start_off+length(old_inst_range))
-        inst_rename[old_inst_range] = Any[SSAValue(x) for x in inst_range]
         for (nidx, idx) in zip(inst_range, old_inst_range)
+            inst_rename[idx] = SSAValue(nidx)
             stmt = ir.stmts[idx]
             if isa(stmt, PhiNode)
                 result_stmts[nidx] = rename_phinode_edges(stmt, bb, result_order, bb_rename)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1491,6 +1491,27 @@ function slicedim(A::AbstractVector, d::Integer, i::Number)
     end
 end
 
+# PR #26347: Deprecate implicit scalar broadcasting in setindex!
+_axes(::Ref) = ()
+_axes(x) = axes(x)
+function deprecate_scalar_setindex_broadcast_message(v, I...)
+    value = (_axes(Base.Broadcast.broadcastable(v)) == () ? "x" : "(x,)")
+    "using `A[I...] = x` to implicitly broadcast `x` across many locations is deprecated. Use `A[I...] .= $value` instead."
+end
+deprecate_scalar_setindex_broadcast_message(v, ::Colon, ::Vararg{Colon}) =
+    "using `A[:] = x` to implicitly broadcast `x` across many locations is deprecated. Use `fill!(A, x)` instead."
+
+function _iterable(v, I...)
+    depwarn(deprecate_scalar_setindex_broadcast_message(v, I...), :setindex!)
+    Iterators.repeated(v)
+end
+function setindex!(B::BitArray, x, I0::Union{Colon,UnitRange{Int}}, I::Union{Int,UnitRange{Int},Colon}...)
+    depwarn(deprecate_scalar_setindex_broadcast_message(x, I0, I...), :setindex!)
+    B[I0, I...] .= (x,)
+    B
+end
+
+
 # PR #26283
 @deprecate contains(haystack, needle) occursin(needle, haystack)
 @deprecate contains(s::AbstractString, r::Regex, offset::Integer) occursin(r, s, offset=offset)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -117,7 +117,7 @@ function IOBuffer(;
         append=flags.append,
         truncate=flags.truncate,
         maxsize=maxsize)
-    buf.data[:] = 0
+    fill!(buf.data, 0)
     return buf
 end
 
@@ -246,7 +246,7 @@ function truncate(io::GenericIOBuffer, n::Integer)
     if n > length(io.data)
         resize!(io.data, n)
     end
-    io.data[io.size+1:n] = 0
+    io.data[io.size+1:n] .= 0
     io.size = n
     io.ptr = min(io.ptr, n+1)
     ismarked(io) && io.mark > n && unmark(io)

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -158,7 +158,7 @@ mutable struct _FDWatcher
                 if fdnum > length(FDWatchers)
                     old_len = length(FDWatchers)
                     resize!(FDWatchers, fdnum)
-                    FDWatchers[(old_len + 1):fdnum] = nothing
+                    FDWatchers[(old_len + 1):fdnum] .= nothing
                 elseif FDWatchers[fdnum] !== nothing
                     this = FDWatchers[fdnum]::_FDWatcher
                     this.refcount = (this.refcount[1] + Int(readable), this.refcount[2] + Int(writable))

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1297,7 +1297,7 @@ function pinv(A::StridedMatrix{T}, tol::Real) where T
     Sinv        = zeros(Stype, length(SVD.S))
     index       = SVD.S .> tol*maximum(SVD.S)
     Sinv[index] = one(Stype) ./ SVD.S[index]
-    Sinv[findall(.!isfinite.(Sinv))] = zero(Stype)
+    Sinv[findall(.!isfinite.(Sinv))] .= zero(Stype)
     return SVD.Vt' * (Diagonal(Sinv) * SVD.U')
 end
 function pinv(A::StridedMatrix{T}) where T

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -774,7 +774,7 @@ function ldiv!(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real) where T<:BlasF
     end
     ar = abs(A.factors[1])
     if ar == 0
-        B[1:nA, :] = 0
+        B[1:nA, :] .= 0
         return B, 0
     end
     rnk = 1
@@ -795,7 +795,7 @@ function ldiv!(A::QRPivoted{T}, B::StridedMatrix{T}, rcond::Real) where T<:BlasF
     end
     C, τ = LAPACK.tzrzf!(A.factors[1:rnk,:])
     ldiv!(UpperTriangular(C[1:rnk,1:rnk]),view(lmul!(adjoint(A.Q), view(B, 1:mA, 1:nrhs)), 1:rnk, 1:nrhs))
-    B[rnk+1:end,:] = zero(T)
+    B[rnk+1:end,:] .= zero(T)
     LAPACK.ormrz!('L', eltype(B)<:Complex ? 'C' : 'T', C, τ, view(B,1:nA,1:nrhs))
     B[1:nA,:] = view(B, 1:nA, :)[invperm(A.p),:]
     return B, rnk
@@ -832,7 +832,7 @@ function ldiv!(A::QR{T}, B::StridedMatrix{T}) where T
         end
         LinearAlgebra.ldiv!(UpperTriangular(view(R, :, 1:minmn)), view(B, 1:minmn, :))
         if n > m # Apply elementary transformation to solution
-            B[m + 1:mB,1:nB] = zero(T)
+            B[m + 1:mB,1:nB] .= zero(T)
             for j = 1:nB
                 for k = 1:m
                     vBj = B[k,j]

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -378,7 +378,14 @@ chol(J::UniformScaling, args...) = ((C, info) = _chol!(J, nothing); @assertposde
 
 
 ## Matrix construction from UniformScaling
-Matrix{T}(s::UniformScaling, dims::Dims{2}) where {T} = setindex!(Base.zeros(T, dims), T(s.λ), diagind(dims...))
+function Matrix{T}(s::UniformScaling, dims::Dims{2}) where {T}
+    A = zeros(T, dims)
+    v = T(s.λ)
+    for i in diagind(dims...)
+        @inbounds A[i] = v
+    end
+    return A
+end
 Matrix{T}(s::UniformScaling, m::Integer, n::Integer) where {T} = Matrix{T}(s, Dims((m, n)))
 Matrix(s::UniformScaling, m::Integer, n::Integer) = Matrix(s, Dims((m, n)))
 Matrix(s::UniformScaling, dims::Dims{2}) = Matrix{eltype(s)}(s, dims)

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -340,7 +340,7 @@ end
     dim=2
     S=zeros(Complex,dim,dim)
     T=zeros(Complex,dim,dim)
-    T[:] = 1
+    fill!(T, 1)
     z = 2.5 + 1.5im
     S[1] = z
     @test S*T == [z z; 0 0]

--- a/stdlib/Pkg3/src/GraphType.jl
+++ b/stdlib/Pkg3/src/GraphType.jl
@@ -1266,7 +1266,7 @@ function build_eq_classes_soft1!(graph::Graph, p0::Int)
 
     # disable the other versions by introducing additional constraints
     fill!(gconstr0, false)
-    gconstr0[repr_vers] = true
+    gconstr0[repr_vers] .= true
 
     return
 end

--- a/stdlib/SHA/src/sha3.jl
+++ b/stdlib/SHA/src/sha3.jl
@@ -61,7 +61,7 @@ function digest!(context::T) where {T<:SHA3_CTX}
         # Begin padding with a 0x06
         context.buffer[usedspace+1] = 0x06
         # Fill with zeros up until the last byte
-        context.buffer[usedspace+2:end-1] = 0x00
+        context.buffer[usedspace+2:end-1] .= 0x00
         # Finish it off with a 0x80
         context.buffer[end] = 0x80
     else

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -34,7 +34,7 @@ function check_pids_all(S::SharedArray)
             parentindices(D.loc_subarr_1d)[1]
         end
         @test all(sdata(S)[idxes_in_p] .== p)
-        pidtested[idxes_in_p] = true
+        pidtested[idxes_in_p] .= true
     end
     @test all(pidtested)
 end
@@ -124,7 +124,7 @@ finalize(S)
 
 # Creating a new file
 fn2 = tempname()
-S = SharedArray{Int,2}(fn2, sz, init=D->D[localindices(D)] = myid())
+S = SharedArray{Int,2}(fn2, sz, init=D->(for i in localindices(D); D[i] = myid(); end))
 @test S == filedata
 filedata2 = similar(Atrue)
 read!(fn2, filedata2)
@@ -134,7 +134,7 @@ finalize(S)
 # Appending to a file
 fn3 = tempname()
 write(fn3, fill(0x1, 4))
-S = SharedArray{UInt8}(fn3, sz, 4, mode="a+", init=D->D[localindices(D)]=0x02)
+S = SharedArray{UInt8}(fn3, sz, 4, mode="a+", init=D->(for i in localindices(D); D[i] = 0x02; end))
 len = prod(sz)+4
 @test filesize(fn3) == len
 filedata = Vector{UInt8}(undef, len)
@@ -190,25 +190,25 @@ s = copy(sdata(d))
 ds = deepcopy(d)
 @test ds == d
 pids_d = procs(d)
-remotecall_fetch(setindex!, pids_d[findfirst(id->(id != myid()), pids_d)::Int], d, 1.0, 1:10)
+@everywhere bcast_setindex!(S, v, I) = (for i in I; S[i] = v; end; S)
+remotecall_fetch(bcast_setindex!, pids_d[findfirst(id->(id != myid()), pids_d)::Int], d, 1.0, 1:10)
 @test ds != d
 @test s != d
 copyto!(d, s)
-@everywhere setid!(A) = A[localindices(A)] = myid()
+@everywhere setid!(A) = (for i in localindices(A); A[i] = myid(); end; A)
 @everywhere procs(ds) setid!($ds)
 @test d == s
 @test ds != s
 @test first(ds) == first(procs(ds))
 @test last(ds)  ==  last(procs(ds))
 
-
 # SharedArray as an array
 # Since the data in d will depend on the nprocs, just test that these operations work
 a = d[1:5]
 @test_throws BoundsError d[-1:5]
 a = d[1,1,1:3:end]
-d[2:4] = 7
-d[5,1:2:4,8] = 19
+d[2:4] .= 7
+d[5,1:2:4,8] .= 19
 
 AA = rand(4,2)
 A = @inferred(convert(SharedArray, AA))

--- a/stdlib/SparseArrays/src/deprecated.jl
+++ b/stdlib/SparseArrays/src/deprecated.jl
@@ -222,6 +222,15 @@ end
 import Base: asyncmap
 @deprecate asyncmap(f, s::AbstractSparseArray...; kwargs...) sparse(asyncmap(f, map(Array, s)...; kwargs...))
 
+# PR 26347: implicit scalar broadcasting within setindex!
+@deprecate setindex!(A::SparseMatrixCSC, x::Number, i::Integer, J::AbstractVector{<:Integer}) (A[i, J] .= x; A)
+@deprecate setindex!(A::SparseMatrixCSC, x::Number, I::AbstractVector{<:Integer}, j::Integer) (A[I, j] .= x; A)
+@deprecate setindex!(A::SparseMatrixCSC, x, ::Colon)          fill!(A, x)
+@deprecate setindex!(A::SparseMatrixCSC, x, ::Colon, ::Colon) fill!(A, x)
+@deprecate setindex!(A::SparseMatrixCSC, x, ::Colon, j::Union{Integer, AbstractVector}) (A[:, j] .= x; A)
+@deprecate setindex!(A::SparseMatrixCSC, x, i::Union{Integer, AbstractVector}, ::Colon) (A[i, :] .= x; A)
+@deprecate setindex!(A::SparseMatrixCSC, x::Number, I::AbstractVector{<:Integer}, J::AbstractVector{<:Integer}) (A[I, J] .= x; A)
+
 #25395 keywords unlocked
 @deprecate dropzeros(x, trim)     dropzeros(x, trim = trim)
 @deprecate dropzeros!(x, trim)    dropzeros!(x, trim = trim)

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -618,7 +618,7 @@ function normestinv(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A))))
 
     # Generate the block matrix
     X = Matrix{Ti}(undef, n, t)
-    X[1:n,1] = 1
+    X[1:n,1] .= 1
     for j = 2:t
         while true
             _rand_pm1!(view(X,1:n,j))

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1799,7 +1799,7 @@ function _densifyfirstnztoend!(x::SparseVector)
         nzi = x.nzind[oldpos]
         nzv = x.nzval[oldpos]
         newpos = nzi - x.nzind[1] + 1
-        newpos < nextpos && (x.nzval[newpos+1:nextpos] = 0)
+        newpos < nextpos && (x.nzval[newpos+1:nextpos] .= 0)
         newpos == oldpos && break
         x.nzval[newpos] = nzv
         nextpos = newpos - 1
@@ -1821,12 +1821,12 @@ function _densifystarttolastnz!(x::SparseVector)
     @inbounds for oldpos in oldnnz:-1:1
         nzi = x.nzind[oldpos]
         nzv = x.nzval[oldpos]
-        nzi < nextpos && (x.nzval[nzi+1:nextpos] = 0)
+        nzi < nextpos && (x.nzval[nzi+1:nextpos] .= 0)
         nzi == oldpos && (nextpos = 0; break)
         x.nzval[nzi] = nzv
         nextpos = nzi - 1
     end
-    nextpos > 0 && (x.nzval[1:nextpos] = 0)
+    nextpos > 0 && (x.nzval[1:nextpos] .= 0)
     # finally update lengthened nzinds
     x.nzind[1:newnnz] = 1:newnnz
     x

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -208,7 +208,7 @@ end
         let x = sprand(10, 10, 0.5)
             I = rand(1:size(x, 2), 10)
             bI = falses(size(x, 2))
-            bI[I] = true
+            bI[I] .= true
             r = x[1,bI]
             @test isa(r, SparseVector{Float64,Int})
             @test all(!iszero, nonzeros(r))
@@ -218,7 +218,7 @@ end
         let x = sprand(10, 0.5)
             I = rand(1:length(x), 5)
             bI = falses(length(x))
-            bI[I] = true
+            bI[I] .= true
             r = x[bI]
             @test isa(r, SparseVector{Float64,Int})
             @test all(!iszero, nonzeros(r))
@@ -1045,9 +1045,12 @@ end
             struczerosv = findall(x -> x == 0, v)
             poszerosinds = unique(rand(struczerosv, targetnumposzeros))
             negzerosinds = unique(rand(struczerosv, targetnumnegzeros))
-            vposzeros = setindex!(copy(v), 2, poszerosinds)
-            vnegzeros = setindex!(copy(v), -2, negzerosinds)
-            vbothsigns = setindex!(copy(vposzeros), -2, negzerosinds)
+            vposzeros = copy(v)
+            vposzeros[poszerosinds] .= 2
+            vnegzeros = copy(v)
+            vnegzeros[negzerosinds] .= -2
+            vbothsigns = copy(vposzeros)
+            vbothsigns[negzerosinds] .= -2
             map!(x -> x == 2 ? 0.0 : x, vposzeros.nzval, vposzeros.nzval)
             map!(x -> x == -2 ? -0.0 : x, vnegzeros.nzval, vnegzeros.nzval)
             map!(x -> x == 2 ? 0.0 : x == -2 ? -0.0 : x, vbothsigns.nzval, vbothsigns.nzval)
@@ -1067,7 +1070,7 @@ end
         end
         # original dropzeros! test
         xdrop = sparsevec(1:7, [3., 2., -1., 1., -2., -3., 3.], 7)
-        xdrop.nzval[[2, 4, 6]] = 0.0
+        xdrop.nzval[[2, 4, 6]] .= 0.0
         SparseArrays.dropzeros!(xdrop)
         @test exact_equal(xdrop, SparseVector(7, [1, 3, 5, 7], [3, -1., -2., 3.]))
     end

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -381,7 +381,7 @@ function _ldiv_basic(F::QRSparse, B::StridedVecOrMat)
     LinearAlgebra.lmul!(adjoint(F.Q), X0)
 
     # Zero out to get basic solution
-    X[rnk + 1:end, :] = 0
+    X[rnk + 1:end, :] .= 0
 
     # Solve R*X = B
     LinearAlgebra.ldiv!(UpperTriangular(view(F.R, Base.OneTo(rnk), Base.OneTo(rnk))),

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -54,13 +54,13 @@ using Random, LinearAlgebra
     b = copy(a')
     @test a[1,1] == 1. && a[1,2] == 2. && a[2,1] == 3. && a[2,2] == 4.
     @test b[1,1] == 1. && b[2,1] == 2. && b[1,2] == 3. && b[2,2] == 4.
-    a[[1 2 3 4]] = 0
+    a[[1 2 3 4]] .= 0
     @test a == zeros(2,2)
-    a[[1 2], [1 2]] = 1
+    a[[1 2], [1 2]] .= 1
     @test a == fill(1.,2,2)
-    a[[1 2], 1] = 0
+    a[[1 2], 1] .= 0
     @test a[1,1] == 0. && a[1,2] == 1. && a[2,1] == 0. && a[2,2] == 1.
-    a[:, [1 2]] = 2
+    a[:, [1 2]] .= 2
     @test a == fill(2.,2,2)
 
     a = Array{Float64}(undef, 2, 2, 2, 2, 2)
@@ -301,7 +301,7 @@ end
     @test B == [0 0 1 0 0; 11 12 13 14 15; 0 0 3 0 0; 0 0 4 0 0]
     B[[3,1],[2,4]] = [21 22; 23 24]
     @test B == [0 23 1 24 0; 11 12 13 14 15; 0 21 3 22 0; 0 0 4 0 0]
-    B[4,[2,3]] = 7
+    B[4,[2,3]] .= 7
     @test B == [0 23 1 24 0; 11 12 13 14 15; 0 21 3 22 0; 0 7 7 0 0]
 
     @test isequal(reshape(reshape(1:27, 3, 3, 3), Val(2))[1,:], [1,  4,  7,  10,  13,  16,  19,  22,  25])
@@ -916,7 +916,7 @@ end
     @test_throws BoundsError [1:5;][[true,false,true,false]]
     @test_throws BoundsError [1:5;][[true,false,true,false,true,false]]
     a = [1:5;]
-    a[[true,false,true,false,true]] = 6
+    a[[true,false,true,false,true]] .= 6
     @test a == [6,2,6,4,6]
     a[[true,false,true,false,true]] = [7,8,9]
     @test a == [7,2,8,4,9]
@@ -933,7 +933,7 @@ end
     @test A == [1 1 1 1 1; 2 1 3 4 1; 1 1 1 1 1]
     @test_throws DimensionMismatch A[[true,false,true], 5] = [19]
     @test_throws DimensionMismatch A[[true,false,true], 5] = 19:21
-    A[[true,false,true], 5] = 7
+    A[[true,false,true], 5] .= 7
     @test A == [1 1 1 1 7; 2 1 3 4 1; 1 1 1 1 7]
 
     B = cat(3, 1, 2, 3)
@@ -1050,7 +1050,7 @@ end
     end
     a = [1,3,5]
     b = [1 3]
-    a[b] = 8
+    a[b] .= 8
     @test a == [8,3,8]
 end
 
@@ -1642,7 +1642,7 @@ end
         @test a[1,CartesianIndex{2}(3,4)] == -2
         a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] = -3
         @test a[CartesianIndex{1}(2),3,CartesianIndex{1}(3)] == -3
-        a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3] = -4
+        a[[CartesianIndex(1,3),CartesianIndex(2,4)],3:3] .= -4
         @test a[1,3,3] == -4
         @test a[2,4,3] == -4
     end
@@ -1983,7 +1983,7 @@ copyto!(S, A)
 
 # issue #13250
 x13250 = zeros(3)
-x13250[UInt(1):UInt(2)] = 1.0
+x13250[UInt(1):UInt(2)] .= 1.0
 @test x13250[1] == 1.0
 @test x13250[2] == 1.0
 @test x13250[3] == 0.0
@@ -2323,7 +2323,7 @@ Float64(x::F21666) = Float64(x.x)
     # test that cumsum uses more stable algorithm
     # for types with unknown/rounding arithmetic
     # we make v pretty large, because stable algorithm may have a large base case
-    v = zeros(300); v[1] = 2; v[200:end] = eps(Float32)
+    v = zeros(300); v[1] = 2; v[200:end] .= eps(Float32)
 
     f_rounds = Float64.(cumsum(F21666{Base.ArithmeticRounds}.(v)))
     f_unknown = Float64.(cumsum(F21666{Base.ArithmeticUnknown}.(v)))

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -12,6 +12,7 @@ tc(r1,r2) = false
 
 bitcheck(b::BitArray) = Test._check_bitarray_consistency(b)
 bitcheck(x) = true
+bcast_setindex!(b, x, I...) = (b[I...] .= x; b)
 
 function check_bitop_call(ret_type, func, args...; kwargs...)
     r1 = func(args...; kwargs...)
@@ -156,7 +157,7 @@ timesofar("conversions")
         b1 = bitrand(v1)
         @test_throws BoundsError resize!(b1, -1)
         @check_bit_operation resize!(b1, v1 ÷ 2) BitVector
-        gr(b) = (resize!(b, v1)[(v1÷2):end] = 1; b)
+        gr(b) = (resize!(b, v1)[(v1÷2):end] .= 1; b)
         @check_bit_operation gr(b1) BitVector
     end
 
@@ -251,39 +252,41 @@ timesofar("constructors")
 
         for j in [1, 63, 64, 65, 127, 128, 129, 191, 192, 193, l-1]
             x = rand(Bool)
-            @check_bit_operation setindex!(b1, x, 1:j) T
+            @check_bit_operation fill!(b1, x) T
+            rand!(b1)
+            @check_bit_operation bcast_setindex!(b1, x, 1:j)
             b2 = bitrand(j)
             for bb in (b2, view(b2, 1:j), view(Array{Any}(b2), :))
                 @check_bit_operation setindex!(b1, bb, 1:j) T
             end
             x = rand(Bool)
-            @check_bit_operation setindex!(b1, x, j+1:l) T
+            @check_bit_operation bcast_setindex!(b1, x, j+1:l) T
             b2 = bitrand(l-j)
             @check_bit_operation setindex!(b1, b2, j+1:l) T
         end
         for j in [1, 63, 64, 65, 127, 128, 129, div(l,2)]
             m1 = j:(l-j)
             x = rand(Bool)
-            @check_bit_operation setindex!(b1, x, m1) T
+            @check_bit_operation bcast_setindex!(b1, x, m1) T
             b2 = bitrand(length(m1))
             @check_bit_operation setindex!(b1, b2, m1) T
         end
         x = rand(Bool)
-        @check_bit_operation setindex!(b1, x, 1:100) T
+        @check_bit_operation bcast_setindex!(b1, x, 1:100) T
         b2 = bitrand(100)
         @check_bit_operation setindex!(b1, b2, 1:100) T
 
         y = rand(0.0:1.0)
-        @check_bit_operation setindex!(b1, y, 1:100) T
+        @check_bit_operation bcast_setindex!(b1, y, 1:100) T
 
         t1 = findall(bitrand(l))
         x = rand(Bool)
-        @check_bit_operation setindex!(b1, x, t1) T
+        @check_bit_operation bcast_setindex!(b1, x, t1) T
         b2 = bitrand(length(t1))
         @check_bit_operation setindex!(b1, b2, t1) T
 
         y = rand(0.0:1.0)
-        @check_bit_operation setindex!(b1, y, t1) T
+        @check_bit_operation bcast_setindex!(b1, y, t1) T
     end
 
     @testset "multidimensional" begin
@@ -405,8 +408,16 @@ timesofar("constructors")
 
         for (b2, k1, k2) in Channel(gen_setindex_data)
             # println(typeof(b2), " ", typeof(k1), " ", typeof(k2)) # uncomment to debug
-            for bb in ((b2 isa AbstractArray) ? (b2, view(b2, :), view(Array{Any}(b2), :)) : (b2,))
-                @check_bit_operation setindex!(b1, bb, k1, k2) BitMatrix
+            if b2 isa AbstractArray
+                for bb in (b2, view(b2, :), view(Array{Any}(b2), :))
+                    @check_bit_operation setindex!(b1, bb, k1, k2) BitMatrix
+                end
+            else
+                if k1 isa Integer && k2 isa Integer
+                    @check_bit_operation setindex!(b1, b2, k1, k2) BitMatrix
+                else
+                    @check_bit_operation bcast_setindex!(b1, b2, k1, k2) BitMatrix
+                end
             end
         end
 
@@ -415,7 +426,7 @@ timesofar("constructors")
         @check_bit_operation setindex!(b1, b2, m1, 1:m2) BitMatrix
         x = rand(Bool)
         b2 = bitrand(1, m2, 1)
-        @check_bit_operation setindex!(b1, x, m1, 1:m2, 1)  BitMatrix
+        @check_bit_operation bcast_setindex!(b1, x, m1, 1:m2, 1)  BitMatrix
         @check_bit_operation setindex!(b1, b2, m1, 1:m2, 1) BitMatrix
 
         b1 = bitrand(s1, s2, s3, s4)
@@ -461,7 +472,11 @@ timesofar("constructors")
 
         for (b2, k1, k2, k3, k4) in Channel(gen_setindex_data4)
             # println(typeof(b2), " ", typeof(k1), " ", typeof(k2), " ", typeof(k3), " ", typeof(k4)) # uncomment to debug
-            @check_bit_operation setindex!(b1, b2, k1, k2, k3, k4) BitArray{4}
+            if b2 isa Bool
+                @check_bit_operation bcast_setindex!(b1, b2, k1, k2, k3, k4) BitArray{4}
+            else
+                @check_bit_operation setindex!(b1, b2, k1, k2, k3, k4) BitArray{4}
+            end
         end
 
         for p1 = [rand(1:v1) 1 63 64 65 191 192 193]
@@ -489,7 +504,7 @@ timesofar("constructors")
 
         b1 = bitrand(n1, n2)
         t1 = bitrand(n1, n2)
-        @check_bit_operation setindex!(b1, true, t1) BitMatrix
+        @check_bit_operation bcast_setindex!(b1, true, t1) BitMatrix
 
         t1 = bitrand(n1, n2)
         b2 = bitrand(count(t1))

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -61,7 +61,7 @@ end
         RA = CartesianIndices(axes(A))
         copyto!(B, CartesianIndices((5:7,2:3)), A, RA)
         @test B[5:7,2:3] == A
-        B[5:7,2:3] = 0
+        B[5:7,2:3] .= 0
         @test all(x->x==0, B)
     end
 end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -354,7 +354,7 @@ sA = view(A, 2:2, 1:5, :)
 @test size(sA) == (1, 5, 8)
 @test axes(sA) === (Base.OneTo(1), Base.OneTo(5), Base.OneTo(8))
 @test sA[1, 2, 1:8][:] == [5:15:120;]
-sA[2:5:end] = -1
+sA[2:5:end] .= -1
 @test all(sA[2:5:end] .== -1)
 @test all(A[5:15:120] .== -1)
 @test @inferred(strides(sA)) == (1,3,15)
@@ -363,10 +363,12 @@ sA[2:5:end] = -1
 test_bounds(sA)
 sA = view(A, 1:3, 1:5, 5)
 @test Base.parentdims(sA) == [1:2;]
-sA[1:3,1:5] = -2
+sA[1:3,1:5] .= -2
 @test all(A[:,:,5] .== -2)
-sA[:] = -3
+fill!(sA, -3)
 @test all(A[:,:,5] .== -3)
+sA[:] .= 4
+@test all(A[:,:,5] .== 4)
 @test @inferred(strides(sA)) == (1,3)
 test_bounds(sA)
 sA = view(A, 1:3, 3:3, 2:5)
@@ -413,7 +415,7 @@ sA = view(A, 2, :, 1:8)
 @test sA[2, 1:8][:] == [5:15:120;]
 @test sA[:,1] == [2:3:14;]
 @test sA[2:5:end] == [5:15:110;]
-sA[2:5:end] = -1
+sA[2:5:end] .= -1
 @test all(sA[2:5:end] .== -1)
 @test all(A[5:15:120] .== -1)
 test_bounds(sA)
@@ -441,7 +443,7 @@ A = rand(2, 2, 3)
 msk = fill(true, 2, 2)
 msk[2,1] = false
 sA = view(A, :, :, 1)
-sA[msk] = 1.0
+sA[msk] .= 1.0
 @test sA[msk] == fill(1, count(msk))
 
 # bounds checking upon construction; see #4044, #10296
@@ -531,7 +533,7 @@ end
     @test x[1:3] isa SubArray
     @test x[2] === 11
     @test Dict((1:3) => 4)[1:3] === 4
-    x[1:2] = 0
+    x[1:2] .= 0
     @test x == [0,0,19,4]
     x[1:2] .= 5:6
     @test x == [5,6,19,4]


### PR DESCRIPTION
The current `setindex!` function (the `A[i] = b` syntax) does three very different operations:
* Given an index `i` that refers to only one location (scalar indexing), `A[i] = b` modifies `A` in that location to hold `b`.
* Given an index `I` that refers to more than one location (non-scalar indexing), `A[I] = b` can mean one of two things:
    * If `b` is an AbstractArray (multi-value), assign the values it contains to those locations `I` in `A`. That is, essentially, `[A[i] = bᵢ for (i, bᵢ) in zip(I, b)]`.
    * If `b` is not an AbstractArray (scalar-value), then broadcast its value to every location selected by `I` in `A`.

These two different behaviors in the non-scalar indexing case basically make using this function in a generic way impossible.  If you want to _always_ set the value `b` to many indices of `A`, you _cannot_ use this syntax because `b` might happen to be an array in some cases, radically changing the meaning of the expression.  You need to manually iterate over the indices, using scalar setindex methods.  But we now also have the new `broadcast!` syntax, `A[I] .= B`, which uses the usual broadcasting semantics to determine how `B` should fill into the values of `A`.

This PR deprecates the implicit broadcasting of scalar values in non-scalar indexing in favor of an explicit `.=` broadcast syntax, leaving multi-value non-scalar indexing intact.  This is the _exact opposite_ of PR #24368.

There are still a few things left to do here, making this still a WIP:

* [-] ~~Make `setindex_shape_check` more stringent~~ To be done in a separate PR. Or maybe not.
* [x] Examine cases where the deprecation message — as suggested — did not work and try to find less-verbose alternatives than an explicit for loop. Edit: This is much improved now that `.= nothing` works.
* [x] Re-implement the old `setindex!` methods as either `fill!` or `broadcast!` specializations (or both — having broadcast fall back to fill for `Scalar()` styles)
* [x] Check performance