### PR TITLE
Fix adjoint/transpose triangular/vector multiplication

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2447,22 +2447,22 @@ end
 factorize(A::AbstractTriangular) = A
 
 # dismabiguation methods: *(AbstractTriangular, Adj/Trans of AbstractVector)
-*(A::AbstractTriangular, B::Adjoint{<:Any,<:AbstractVector}) = A * copy(B)
-*(A::AbstractTriangular, B::Transpose{<:Any,<:AbstractVector}) = A * copy(B)
+*(A::AbstractTriangular, B::Adjoint{<:Any,<:AbstractVector}) = adjoint(adjoint(B) * adjoint(A))
+*(A::AbstractTriangular, B::Transpose{<:Any,<:AbstractVector}) = transpose(transpose(B) * transpose(A))
 # dismabiguation methods: *(Adj/Trans of AbstractTriangular, Trans/Ajd of AbstractTriangular)
 *(A::Adjoint{<:Any,<:AbstractTriangular}, B::Transpose{<:Any,<:AbstractTriangular}) = copy(A) * B
 *(A::Transpose{<:Any,<:AbstractTriangular}, B::Adjoint{<:Any,<:AbstractTriangular}) = copy(A) * B
 # dismabiguation methods: *(Adj/Trans of AbstractTriangular, Adj/Trans of AbsVec or AbsMat)
-*(A::Adjoint{<:Any,<:AbstractTriangular}, B::Adjoint{<:Any,<:AbstractVector}) = A * copy(B)
+*(A::Adjoint{<:Any,<:AbstractTriangular}, B::Adjoint{<:Any,<:AbstractVector}) = adjoint(adjoint(B) * adjoint(A))
 *(A::Adjoint{<:Any,<:AbstractTriangular}, B::Transpose{<:Any,<:AbstractMatrix}) = A * copy(B)
-*(A::Adjoint{<:Any,<:AbstractTriangular}, B::Transpose{<:Any,<:AbstractVector}) = A * copy(B)
-*(A::Transpose{<:Any,<:AbstractTriangular}, B::Transpose{<:Any,<:AbstractVector}) = A * copy(B)
-*(A::Transpose{<:Any,<:AbstractTriangular}, B::Adjoint{<:Any,<:AbstractVector}) = A * copy(B)
+*(A::Adjoint{<:Any,<:AbstractTriangular}, B::Transpose{<:Any,<:AbstractVector}) = transpose(transpose(B) * transpose(A))
+*(A::Transpose{<:Any,<:AbstractTriangular}, B::Transpose{<:Any,<:AbstractVector}) = transpose(transpose(B) * transpose(A))
+*(A::Transpose{<:Any,<:AbstractTriangular}, B::Adjoint{<:Any,<:AbstractVector}) = adjoint(adjoint(B) * adjoint(A))
 *(A::Transpose{<:Any,<:AbstractTriangular}, B::Adjoint{<:Any,<:AbstractMatrix}) = A * copy(B)
 # dismabiguation methods: *(Adj/Trans of AbsVec or AbsMat, Adj/Trans of AbstractTriangular)
-*(A::Adjoint{<:Any,<:AbstractVector}, B::Transpose{<:Any,<:AbstractTriangular}) = copy(A) * B
+*(A::Adjoint{<:Any,<:AbstractVector}, B::Transpose{<:Any,<:AbstractTriangular}) = adjoint(adjoint(B) * adjoint(A))
 *(A::Adjoint{<:Any,<:AbstractMatrix}, B::Transpose{<:Any,<:AbstractTriangular}) = copy(A) * B
-*(A::Transpose{<:Any,<:AbstractVector}, B::Adjoint{<:Any,<:AbstractTriangular}) = copy(A) * B
+*(A::Transpose{<:Any,<:AbstractVector}, B::Adjoint{<:Any,<:AbstractTriangular}) = transpose(transpose(B) * transpose(A))
 *(A::Transpose{<:Any,<:AbstractMatrix}, B::Adjoint{<:Any,<:AbstractTriangular}) = copy(A) * B
 
 # disambiguation methods: /(Adjoint of AbsVec, <:AbstractTriangular)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -549,4 +549,29 @@ end
         r"3×3 (LinearAlgebra\.)?UnitUpperTriangular{Int64,Array{Int64,2}}:\n 1  2  2\n ⋅  1  2\n ⋅  ⋅  1")
 end
 
+@testset "adjoint/transpose triangular/vector multiplication" begin
+    for elty in (Float64, ComplexF64), trity in (UpperTriangular, LowerTriangular)
+        A1 = trity(rand(elty, 1, 1))
+        b1 = rand(elty, 1)
+        A4 = trity(rand(elty, 4, 4))
+        b4 = rand(elty, 4)
+        @test A1 * b1' ≈ Matrix(A1) * b1'
+        @test_throws DimensionMismatch A4 * b4'
+        @test A1 * transpose(b1) ≈ Matrix(A1) * transpose(b1)
+        @test_throws DimensionMismatch A4 * transpose(b4)
+        @test A1' * b1' ≈ Matrix(A1') * b1'
+        @test_throws DimensionMismatch A4' * b4'
+        @test A1' * transpose(b1) ≈  Matrix(A1') * transpose(b1)
+        @test_throws DimensionMismatch A4' * transpose(b4)
+        @test transpose(A1) * transpose(b1) ≈  Matrix(transpose(A1)) * transpose(b1)
+        @test_throws DimensionMismatch transpose(A4) * transpose(b4)
+        @test transpose(A1) * b1' ≈ Matrix(transpose(A1)) * b1'
+        @test_throws DimensionMismatch transpose(A4) * b4'
+        @test b1' * transpose(A1) ≈ b1' * Matrix(transpose(A1))
+        @test b4' * transpose(A4) ≈ b4' * Matrix(transpose(A4))
+        @test transpose(b1) * A1' ≈ transpose(b1) * Matrix(A1')
+        @test transpose(b4) * A4' ≈ transpose(b4) * Matrix(A4')
+    end
+end
+
 end # module TestTriangular


### PR DESCRIPTION
As `copy(::Adjoint{<:Any,<:AbstractVector}` is a no-op (and likewise for `Transpose`), the previous definitions ended in a stack overflow.