### PR TITLE
Remove isempty(::Missing) definition

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -70,7 +70,7 @@ for f in (:(!), :(~), :(+), :(-), :(identity), :(zero), :(one), :(oneunit),
           :(exp), :(exp2), :(expm1), :(log), :(log10), :(log1p),
           :(log2), :(Math.exponent), :(sqrt), :(Math.gamma), :(Math.lgamma),
           :(iseven), :(ispow2), :(isfinite), :(isinf), :(isodd),
-          :(isinteger), :(isreal), :(isnan), :(isempty),
+          :(isinteger), :(isreal), :(isnan),
           :(iszero), :(transpose), :(adjoint), :(float), :(conj))
     @eval $(f)(::Missing) = missing
 end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -150,7 +150,7 @@ Base.one(::Type{Unit}) = 1
                             identity, zero, one, oneunit,
                             iseven, isodd, ispow2,
                             isfinite, isinf, isnan, iszero,
-                            isinteger, isreal, isempty, transpose, adjoint, float]
+                            isinteger, isreal, transpose, adjoint, float]
 
     # All elementary functions return missing when evaluating missing
     for f in elementary_functions


### PR DESCRIPTION
This is the only definition for `missing` with a non-scalar function, apart from `transpose` and `adjoint` which are needed since they are called recursively on array entries. There does not appear to be a clear use case for this definition.

Cc: @quinnj (who added this definition in the Missings.jl initial commit), @ararslan