### PR TITLE
Change Type{Ref{T}} to Type{<:Ref{T}}

### DIFF
--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -33,14 +33,14 @@ end
 
 ### General Methods for Ref{T} type
 
-eltype(x::Type{Ref{T}}) where {T} = T
-convert(::Type{Ref{T}}, x::Ref{T}) where {T} = x
+eltype(x::Type{<:Ref{T}}) where {T} = T
+convert(::Type{<:Ref{T}}, x::Ref{T}) where {T} = x
 
 # create Ref objects for general object conversion
-unsafe_convert(::Type{Ref{T}}, x::Ref{T}) where {T} = unsafe_convert(Ptr{T}, x)
-unsafe_convert(::Type{Ref{T}}, x) where {T} = unsafe_convert(Ptr{T}, x)
+unsafe_convert(::Type{<:Ref{T}}, x::Ref{T}) where {T} = unsafe_convert(Ptr{T}, x)
+unsafe_convert(::Type{<:Ref{T}}, x) where {T} = unsafe_convert(Ptr{T}, x)
 
-convert(::Type{Ref{T}}, x) where {T} = RefValue{T}(x)
+convert(::Type{<:Ref{T}}, x) where {T} = RefValue{T}(x)
 
 ### Methods for a Ref object that is backed by an array at index i
 struct RefArray{T,A<:AbstractArray{T},R} <: Ref{T}
@@ -51,7 +51,7 @@ struct RefArray{T,A<:AbstractArray{T},R} <: Ref{T}
 end
 RefArray(x::AbstractArray{T}, i::Int, roots::Any) where {T} = RefArray{T,typeof(x),Any}(x, i, roots)
 RefArray(x::AbstractArray{T}, i::Int=1, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, i, nothing)
-convert(::Type{Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
+convert(::Type{<:Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
 
 function unsafe_convert(P::Type{Ptr{T}}, b::RefArray{T}) where T
     if datatype_pointerfree(RefValue{T})

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -33,14 +33,14 @@ end
 
 ### General Methods for Ref{T} type
 
-eltype(x::Type{<:Ref{T}}) where {T} = T
-convert(::Type{<:Ref{T}}, x::Ref{T}) where {T} = x
+eltype(x::Type{<:Ref{T}}) where {T} = @isdefined(T) ? T : Any
+convert(::Type{Ref{T}}, x::Ref{T}) where {T} = x
 
 # create Ref objects for general object conversion
-unsafe_convert(::Type{<:Ref{T}}, x::Ref{T}) where {T} = unsafe_convert(Ptr{T}, x)
-unsafe_convert(::Type{<:Ref{T}}, x) where {T} = unsafe_convert(Ptr{T}, x)
+unsafe_convert(::Type{Ref{T}}, x::Ref{T}) where {T} = unsafe_convert(Ptr{T}, x)
+unsafe_convert(::Type{Ref{T}}, x) where {T} = unsafe_convert(Ptr{T}, x)
 
-convert(::Type{<:Ref{T}}, x) where {T} = RefValue{T}(x)
+convert(::Type{Ref{T}}, x) where {T} = RefValue{T}(x)
 
 ### Methods for a Ref object that is backed by an array at index i
 struct RefArray{T,A<:AbstractArray{T},R} <: Ref{T}
@@ -51,7 +51,7 @@ struct RefArray{T,A<:AbstractArray{T},R} <: Ref{T}
 end
 RefArray(x::AbstractArray{T}, i::Int, roots::Any) where {T} = RefArray{T,typeof(x),Any}(x, i, roots)
 RefArray(x::AbstractArray{T}, i::Int=1, roots::Nothing=nothing) where {T} = RefArray{T,typeof(x),Nothing}(x, i, nothing)
-convert(::Type{<:Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
+convert(::Type{Ref{T}}, x::AbstractArray{T}) where {T} = RefArray(x, 1)
 
 function unsafe_convert(P::Type{Ptr{T}}, b::RefArray{T}) where T
     if datatype_pointerfree(RefValue{T})

--- a/test/core.jl
+++ b/test/core.jl
@@ -6010,3 +6010,6 @@ g25907a(x) = x[1]::Integer
 @test g25907a(Union{Int, UInt, Nothing}[1]) === 1
 g25907b(x) = x[1]::Complex
 @test g25907b(Union{Complex{Int}, Complex{UInt}, Nothing}[1im]) === 1im
+
+#issue #26363
+@test eltype(Ref(Float64(1))) === Float64


### PR DESCRIPTION
This addresses #26363 . The problem here was that Ref{T} is an abstract type. So:
```julia-repl
julia> Type{Base.RefValue{Float64}} <: Type{Ref{Float64}}
false
```