### PR TITLE
RFC: rename `trace` to `tr`

### DIFF
--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -162,7 +162,7 @@ let
 
     @test d[1] ≈ 1. # largest eigenvalue should be 1.
     v = reshape(v,(50,50)) # reshape to matrix
-    v /= trace(v) # factor out arbitrary phase
+    v /= tr(v) # factor out arbitrary phase
     @test vecnorm(imag(v)) ≈ 0. # it should be real
     v = real(v)
     # @test vecnorm(v-v')/2 ≈ 0. # it should be Hermitian
@@ -173,7 +173,7 @@ let
     # Repeat with starting vector
     (d2,v2,nconv2,numiter2,numop2,resid2) = eigs(Phi,nev=1,which=:LM,v0=reshape(v,(2500,)))
     v2 = reshape(v2,(50,50))
-    v2 /= trace(v2)
+    v2 /= tr(v2)
     @test numiter2 < numiter
     @test v ≈ v2
 

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -5,7 +5,7 @@ DocTestSetup = :(using LinearAlgebra)
 ```
 
 In addition to (and as part of) its support for multi-dimensional arrays, Julia provides native implementations
-of many common and useful linear algebra operations. Basic operations, such as [`trace`](@ref), [`det`](@ref),
+of many common and useful linear algebra operations. Basic operations, such as [`tr`](@ref), [`det`](@ref),
 and [`inv`](@ref) are all supported:
 
 ```jldoctest
@@ -15,7 +15,7 @@ julia> A = [1 2 3; 4 1 6; 7 8 1]
  4  1  6
  7  8  1
 
-julia> trace(A)
+julia> tr(A)
 3
 
 julia> det(A)
@@ -371,7 +371,7 @@ LinearAlgebra.normalize!
 LinearAlgebra.normalize
 LinearAlgebra.cond
 LinearAlgebra.condskeel
-LinearAlgebra.trace
+LinearAlgebra.tr
 LinearAlgebra.det
 LinearAlgebra.logdet
 LinearAlgebra.logabsdet

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -140,7 +140,7 @@ export
     svdvals!,
     svdvals,
     sylvester,
-    trace,
+    tr,
     transpose,
     transpose!,
     transpose_type,

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -341,7 +341,7 @@ function diagm_container(kv::Pair{<:Integer,<:BitVector}...)
 end
 
 
-function trace(A::Matrix{T}) where T
+function tr(A::Matrix{T}) where T
     n = checksquare(A)
     t = zero(T)
     for i=1:n

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1258,3 +1258,5 @@ end
 @deprecate scale!(a::AbstractVector, B::AbstractMatrix)                    lmul!(Diagonal(a), B)
 @deprecate scale!(C::AbstractMatrix, A::AbstractMatrix, b::AbstractVector) mul!(C, A, Diagonal(b))
 @deprecate scale!(C::AbstractMatrix, a::AbstractVector, B::AbstractMatrix) mul!(C, Diagonal(a), B)
+
+Base.@deprecate_binding trace tr

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -382,7 +382,7 @@ function diag(D::Diagonal, k::Integer=0)
             "and at most $(size(D, 2)) for an $(size(D, 1))-by-$(size(D, 2)) matrix")))
     end
 end
-trace(D::Diagonal) = sum(D.diag)
+tr(D::Diagonal) = sum(D.diag)
 det(D::Diagonal) = prod(D.diag)
 logdet(D::Diagonal{<:Real}) = sum(log, D.diag)
 function logdet(D::Diagonal{<:Complex}) # make sure branch cut is correct

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -731,7 +731,7 @@ end
 rank(x::Number) = x == 0 ? 0 : 1
 
 """
-    trace(M)
+    tr(M)
 
 Matrix trace. Sums the diagonal elements of `M`.
 
@@ -742,15 +742,15 @@ julia> A = [1 2; 3 4]
  1  2
  3  4
 
-julia> trace(A)
+julia> tr(A)
 5
 ```
 """
-function trace(A::AbstractMatrix)
+function tr(A::AbstractMatrix)
     checksquare(A)
     sum(diag(A))
 end
-trace(x::Number) = x
+tr(x::Number) = x
 
 #kron(a::AbstractVector, b::AbstractVector)
 #kron(a::AbstractMatrix{T}, b::AbstractMatrix{S}) where {T,S}

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -323,7 +323,7 @@ Base.copy(A::Adjoint{<:Any,<:Symmetric}) =
 Base.collect(A::Transpose{<:Any,<:Hermitian}) =
     Hermitian(copy(transpose(A.parent.data)), ifelse(A.parent.uplo == 'U', :L, :U))
 
-trace(A::Hermitian) = real(trace(A.data))
+tr(A::Hermitian) = real(tr(A.data))
 
 Base.conj(A::HermOrSym) = typeof(A)(conj(A.data), A.uplo)
 Base.conj!(A::HermOrSym) = typeof(A)(conj!(A.data), A.uplo)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -67,7 +67,7 @@ srand(1)
             @test op(D)==op(DM)
         end
 
-        for func in (det, trace)
+        for func in (det, tr)
             @test func(D) ≈ func(DM) atol=n^2*eps(relty)*(1+(elty<:Complex))
         end
         if relty <: BlasFloat

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -162,7 +162,7 @@ end
 @test_throws DimensionMismatch cross(fill(1,3), fill(1,4))
 @test_throws DimensionMismatch cross(fill(1,2), fill(1,3))
 
-@test trace(Bidiagonal(fill(1,5),fill(0,4),:U)) == 5
+@test tr(Bidiagonal(fill(1,5),fill(0,4),:U)) == 5
 
 
 @testset "array and subarray" begin
@@ -222,7 +222,7 @@ end
 @testset "ops on Numbers" begin
     @testset for elty in [Float32,Float64,ComplexF32,ComplexF64]
         a = rand(elty)
-        @test trace(a)         == a
+        @test tr(a)            == a
         @test rank(zero(elty)) == 0
         @test rank(one(elty))  == 1
         @test !isfinite(cond(zero(elty)))

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -156,9 +156,9 @@ end
         end
 
         @testset "linalg unary ops" begin
-            @testset "trace" begin
-                @test trace(asym) == trace(Symmetric(asym))
-                @test trace(aherm) == trace(Hermitian(aherm))
+            @testset "tr" begin
+                @test tr(asym) == tr(Symmetric(asym))
+                @test tr(aherm) == tr(Hermitian(aherm))
             end
 
             @testset "isposdef[!]" begin

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -13,7 +13,7 @@ using LinearAlgebra
 
 import Base: +, -, *, \, /, &, |, xor, ==
 import LinearAlgebra: mul!, ldiv!, rdiv!, chol, adjoint!, diag, dot, eig,
-    issymmetric, istril, istriu, lu, trace, transpose!, tril!, triu!,
+    issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!,
     vecnorm, cond, diagm, factorize, ishermitian, norm, lmul!, rmul!, tril, triu
 
 import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3360,7 +3360,7 @@ function diag(A::SparseMatrixCSC{Tv,Ti}, d::Integer=0) where {Tv,Ti}
     return SparseVector{Tv,Ti}(l, ind, val)
 end
 
-function trace(A::SparseMatrixCSC{Tv}) where Tv
+function tr(A::SparseMatrixCSC{Tv}) where Tv
     n = checksquare(A)
     s = zero(Tv)
     for i in 1:n

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1445,8 +1445,8 @@ end
 end
 
 @testset "trace" begin
-    @test_throws DimensionMismatch trace(spzeros(5,6))
-    @test trace(sparse(1.0I, 5, 5)) == 5
+    @test_throws DimensionMismatch tr(spzeros(5,6))
+    @test tr(sparse(1.0I, 5, 5)) == 5
 end
 
 @testset "spdiagm" begin


### PR DESCRIPTION
In math this is always written as `tr(A)`, and `trace` could potentially mean other things.