### PR TITLE
rename `blkdiag` to `blockdiag`

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -211,7 +211,7 @@ SparseArrays.nnz
 SparseArrays.findnz
 SparseArrays.spzeros
 SparseArrays.spdiagm
-SparseArrays.blkdiag
+SparseArrays.blockdiag
 SparseArrays.sprand
 SparseArrays.sprandn
 SparseArrays.nonzeros

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -33,7 +33,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
 using Random: GLOBAL_RNG, AbstractRNG, randsubseq, randsubseq!
 
 export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
-    SparseMatrixCSC, SparseVector, blkdiag, droptol!, dropzeros!, dropzeros,
+    SparseMatrixCSC, SparseVector, blockdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
     sprand, sprandn, spzeros, nnz, permute, findnz
 

--- a/stdlib/SparseArrays/src/deprecated.jl
+++ b/stdlib/SparseArrays/src/deprecated.jl
@@ -227,6 +227,8 @@ import Base: asyncmap
 @deprecate dropzeros!(x, trim)    dropzeros!(x, trim = trim)
 @deprecate droptol!(A, tol, trim) droptol!(A, tol, trim = trim)
 
+Base.@deprecate_binding blkdiag blockdiag
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3103,13 +3103,13 @@ function hcat(X::SparseMatrixCSC...)
 end
 
 """
-    blkdiag(A...)
+    blockdiag(A...)
 
 Concatenate matrices block-diagonally. Currently only implemented for sparse matrices.
 
 # Examples
 ```jldoctest
-julia> blkdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
+julia> blockdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
 5×5 SparseMatrixCSC{Int64,Int64} with 5 stored entries:
   [1, 1]  =  2
   [2, 2]  =  2
@@ -3118,7 +3118,7 @@ julia> blkdiag(sparse(2I, 3, 3), sparse(4I, 2, 2))
   [5, 5]  =  4
 ```
 """
-function blkdiag(X::SparseMatrixCSC...)
+function blockdiag(X::SparseMatrixCSC...)
     num = length(X)
     mX = Int[ size(x, 1) for x in X ]
     nX = Int[ size(x, 2) for x in X ]

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -110,8 +110,8 @@ end
         @test length(([sp33 0I; 1I 0I]).nzval) == 6
     end
 
-    @testset "blkdiag concatenation" begin
-        @test blkdiag(se33, se33) == sparse(1:6,1:6,fill(1.,6))
+    @testset "blockdiag concatenation" begin
+        @test blockdiag(se33, se33) == sparse(1:6,1:6,fill(1.,6))
     end
 
     @testset "concatenation promotion" begin


### PR DESCRIPTION
This seems like a case of unnecessary abbreviation to me. Writing out the word only makes the name 28% longer, but much clearer.