### PR TITLE
Fix bunch kaufman type stability

### DIFF
--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -3896,7 +3896,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
             chkuplo(uplo)
             ipiv  = similar(A, BlasInt, n)
             if n == 0
-                return A, ipiv
+                return A, ipiv, zero(BlasInt)
             end
             work  = Vector{$elty}(uninitialized, 1)
             lwork = BlasInt(-1)
@@ -4046,7 +4046,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
             chkuplo(uplo)
             ipiv  = similar(A, BlasInt, n)
             if n == 0
-                return A, ipiv
+                return A, ipiv, zero(BlasInt)
             end
             work  = Vector{$elty}(uninitialized, 1)
             lwork = BlasInt(-1)
@@ -4496,7 +4496,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
             chkuplo(uplo)
             ipiv = similar(A, BlasInt, n)
             if n == 0
-                return A, ipiv
+                return A, ipiv, zero(BlasInt)
             end
             work  = Vector{$elty}(uninitialized, 1)
             lwork = BlasInt(-1)
@@ -4647,7 +4647,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
             chkuplo(uplo)
             ipiv = similar(A, BlasInt, n)
             if n == 0
-                return A, ipiv
+                return A, ipiv, zero(BlasInt)
             end
             work  = Vector{$elty}(uninitialized, 1)
             lwork = BlasInt(-1)

--- a/stdlib/LinearAlgebra/test/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/test/bunchkaufman.jl
@@ -140,5 +140,6 @@ end
 
 @test_throws DomainError logdet(bkfact([-1 -1; -1 1]))
 @test logabsdet(bkfact([8 4; 4 2]))[1] == -Inf
+@test isa(bkfact(Symmetric(ones(0,0))), BunchKaufman) # 0x0 matrix
 
 end # module TestBunchKaufman

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -361,7 +361,7 @@ end
         B,ipiv = LAPACK.sytrf!('U',B)
         @test triu(inv(A)) ≈ triu(LAPACK.sytri!('U',B,ipiv)) rtol=eps(cond(A))
         @test_throws DimensionMismatch LAPACK.sytrs!('U',B,ipiv,rand(elty,11,5))
-        @test LAPACK.sytrf!('U',zeros(elty,0,0)) == (zeros(elty,0,0),zeros(BlasInt,0))
+        @test LAPACK.sytrf!('U',zeros(elty,0,0)) == (zeros(elty,0,0),zeros(BlasInt,0),zero(BlasInt))
     end
 
     # Rook-pivoting variants
@@ -372,7 +372,7 @@ end
         B,ipiv = LAPACK.sytrf_rook!('U', B)
         @test triu(inv(A)) ≈ triu(LAPACK.sytri_rook!('U', B, ipiv)) rtol=eps(cond(A))
         @test_throws DimensionMismatch LAPACK.sytrs_rook!('U', B, ipiv, rand(elty, 11, 5))
-        @test LAPACK.sytrf_rook!('U',zeros(elty, 0, 0)) == (zeros(elty, 0, 0),zeros(BlasInt, 0))
+        @test LAPACK.sytrf_rook!('U',zeros(elty, 0, 0)) == (zeros(elty, 0, 0),zeros(BlasInt, 0),zero(BlasInt))
         A = rand(elty, 10, 10)
         A = A + transpose(A) #symmetric!
         b = rand(elty, 10)


### PR DESCRIPTION
The `info` code was missing in the case `n = 0`.

```
using LinearAlgebra
A = rand(10, 10)
A += A' + 10 * I
@benchmark bkfact!(S) setup = (S = Symmetric($A, :U))
```

Now: 2.026 μs (5 allocations: 5.39 KiB)
Earlier: 3.419 μs (8 allocations: 5.48 KiB)