### PR TITLE
Fix (lin)range with big arguments

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -256,8 +256,10 @@ end
 _range(start::T, ::Nothing, stop::T, len::Integer) where {T<:Real} = LinRange{T}(start, stop, len)
 _range(start::T, ::Nothing, stop::T, len::Integer) where {T} = LinRange{T}(start, stop, len)
 _range(start::T, ::Nothing, stop::T, len::Integer) where {T<:Integer} =
-    _linspace(Float64, start, stop, len, 1)
-## for Float16, Float32, and Float64 see twiceprecision.jl
+    _linspace(float(T), start, stop, len)
+## for Float16, Float32, and Float64 we hit twiceprecision.jl to lift to higher precision StepRangeLen
+# for all other types we fall back to a plain old LinRange
+_linspace(::Type{T}, start::Integer, stop::Integer, len::Integer) where T = LinRange{T}(start, stop, len)
 
 function show(io::IO, r::LinRange)
     print(io, "range(")

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -636,7 +636,8 @@ end
 
 # range for rational numbers, start = start_n/den, stop = stop_n/den
 # Note this returns a StepRangeLen
-function _linspace(::Type{T}, start_n::Integer, stop_n::Integer, len::Integer, den::Integer) where T
+_linspace(::Type{T}, start::Integer, stop::Integer, len::Integer) where {T<:IEEEFloat} = _linspace(T, start, stop, len, 1)
+function _linspace(::Type{T}, start_n::Integer, stop_n::Integer, len::Integer, den::Integer) where T<:IEEEFloat
     len < 2 && return _linspace1(T, start_n/den, stop_n/den, len)
     start_n == stop_n && return steprangelen_hp(T, (start_n, den), (zero(start_n), den), 0, len)
     tmin = -start_n/(Float64(stop_n) - Float64(start_n))
@@ -650,7 +651,7 @@ function _linspace(::Type{T}, start_n::Integer, stop_n::Integer, len::Integer, d
 end
 
 # For len < 2
-function _linspace1(::Type{T}, start, stop, len::Integer) where T
+function _linspace1(::Type{T}, start, stop, len::Integer) where T<:IEEEFloat
     len >= 0 || throw(ArgumentError("range($start, stop=$stop, length=$len): negative length"))
     if len <= 1
         len == 1 && (start == stop || throw(ArgumentError("range($start, stop=$stop, length=$len): endpoints differ")))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1224,3 +1224,11 @@ end
     @test_throws ArgumentError range(nothing, length=2)
     @test_throws ArgumentError range(1.0, step=0.25, stop=2.0, length=5)
 end
+
+@testset "issue #23300#issuecomment-371575548" begin
+    for (start, stop) in ((-5, 5), (-5.0, 5), (-5, 5.0), (-5.0, 5.0))
+        @test @inferred(range(big(start), stop=big(stop), length=11)) isa LinRange{BigFloat}
+        @test Float64.(@inferred(range(big(start), stop=big(stop), length=11))) == range(start, stop=stop, length=11)
+        @test Float64.(@inferred(map(exp, range(big(start), stop=big(stop), length=11)))) == map(exp, range(start, stop=stop, length=11))
+    end
+end


### PR DESCRIPTION
There are a lot of assumptions in twiceprecision.jl that require a Float16/32/64, but we were hitting those methods in some cases. This adds a fallback and ensures that the _linspace entry points are constrained appropriately. Also use `float(T)` (where `T<:Integer`) to ensure we construct a bigfloat range when appropriate.