### PR TITLE
Switch Float16 LLVM representation from `i16` to `half`

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -323,7 +323,7 @@ const llvmtypes = IdDict{Any,String}(
     Int32 => "i32", UInt32 => "i32",
     Int64 => "i64", UInt64 => "i64",
     Int128 => "i128", UInt128 => "i128",
-    Float16 => "i16", # half
+    Float16 => "half",
     Float32 => "float",
     Float64 => "double",
 )

--- a/base/math.jl
+++ b/base/math.jl
@@ -723,6 +723,8 @@ end
     end
     z
 end
+@inline ^(x::Float16, y::Float16) = Float16(Float32(x)^Float32(y))
+
 @inline ^(x::Float64, y::Integer) = ccall("llvm.pow.f64", llvmcall, Float64, (Float64, Float64), x, Float64(y))
 @inline ^(x::Float32, y::Integer) = ccall("llvm.pow.f32", llvmcall, Float32, (Float32, Float32), x, Float32(y))
 @inline ^(x::Float16, y::Integer) = Float16(Float32(x) ^ y)

--- a/base/rtlib/RTLIB.jl
+++ b/base/rtlib/RTLIB.jl
@@ -38,7 +38,7 @@ function truncsfhf2(x::Float32)
 end
 register(truncsfhf2, Float16, Tuple{Float32}, "__truncsfhf2")
 register(truncsfhf2, Float16, Tuple{Float32}, "__gnu_f2h_ieee")
- 
+
 # Extend
 function extendhfsf2(x::Float16)
     local ival::UInt32 = reinterpret(UInt16, val)

--- a/base/rtlib/RTLIB.jl
+++ b/base/rtlib/RTLIB.jl
@@ -1,0 +1,129 @@
+module RTLIB
+
+
+# We would like to use `@ccallable` here,
+# but building the sysimage fails, so we use a bootstrapped version.
+function register(f, rtype, argt, name)
+    ccall(:jl_extern_c, Nothing, (Any, Any, Any, Cstring),
+          f, rtype, argt, name)
+end
+
+# Trunc
+function truncdfhf2(x::Float64)
+    return Float16(Float32(x))
+end
+register(truncdfhf2, Float16, Tuple{Float64}, "__truncdfhf2")
+
+function truncsfhf2(x::Float32)
+    f = reinterpret(UInt32, val)
+    if isnan(val)
+        t = 0x8000 ⊻ (0x8000 & ((f >> 0x10) % UInt16))
+        return reinterpret(Float16, t ⊻ ((f >> 0xd) % UInt16))
+    end
+    i = (f >> 23) & 0x1ff + 1
+    sh = shifttable[i]
+    f &= 0x007fffff
+    h::UInt16 = basetable[i] + (f >> sh)
+    # round
+    # NOTE: we maybe should ignore NaNs here, but the payload is
+    # getting truncated anyway so "rounding" it might not matter
+    nextbit = (f >> (sh-1)) & 1
+    if nextbit != 0
+        # Round halfway to even or check lower bits
+        if h&1 == 1 || (f & ((1<<(sh-1))-1)) != 0
+            h += 1
+        end
+    end
+    reinterpret(Float16, h)
+end
+register(truncsfhf2, Float16, Tuple{Float32}, "__truncsfhf2")
+register(truncsfhf2, Float16, Tuple{Float32}, "__gnu_f2h_ieee")
+ 
+# Extend
+function extendhfsf2(x::Float16)
+    local ival::UInt32 = reinterpret(UInt16, val)
+    local sign::UInt32 = (ival & 0x8000) >> 15
+    local exp::UInt32  = (ival & 0x7c00) >> 10
+    local sig::UInt32  = (ival & 0x3ff) >> 0
+    local ret::UInt32
+
+    if exp == 0
+        if sig == 0
+            sign = sign << 31
+            ret = sign | exp | sig
+        else
+            n_bit = 1
+            bit = 0x0200
+            while (bit & sig) == 0
+                n_bit = n_bit + 1
+                bit = bit >> 1
+            end
+            sign = sign << 31
+            exp = (-14 - n_bit + 127) << 23
+            sig = ((sig & (~bit)) << n_bit) << (23 - 10)
+            ret = sign | exp | sig
+        end
+    elseif exp == 0x1f
+        if sig == 0  # Inf
+            if sign == 0
+                ret = 0x7f800000
+            else
+                ret = 0xff800000
+            end
+        else  # NaN
+            ret = 0x7fc00000 | (sign<<31) | (sig<<(23-10))
+        end
+    else
+        sign = sign << 31
+        exp  = (exp - 15 + 127) << 23
+        sig  = sig << (23 - 10)
+        ret = sign | exp | sig
+    end
+    return reinterpret(Float32, ret)
+end
+register(extendhfsf2, Float32, Tuple{Float16}, "__extendhfsf2")
+register(extendhfsf2, Float32, Tuple{Float16}, "__gnu_h2f_ieee")
+
+function extendhfdf2(x::Float16)
+    return return Float32(Float16)
+end
+register(extendhfdf2, Float64, Tuple{Float16}, "__extendhfdf2")
+
+# Float32 -> Float16 algorithm from:
+#   "Fast Half Float Conversion" by Jeroen van der Zijp
+#   ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf
+
+const basetable = Vector{UInt16}(uninitialized, 512)
+const shifttable = Vector{UInt8}(uninitialized, 512)
+
+for i = 0:255
+    e = i - 127
+    if e < -24  # Very small numbers map to zero
+        basetable[i|0x000+1] = 0x0000
+        basetable[i|0x100+1] = 0x8000
+        shifttable[i|0x000+1] = 24
+        shifttable[i|0x100+1] = 24
+    elseif e < -14  # Small numbers map to denorms
+        basetable[i|0x000+1] = (0x0400>>(-e-14))
+        basetable[i|0x100+1] = (0x0400>>(-e-14)) | 0x8000
+        shifttable[i|0x000+1] = -e-1
+        shifttable[i|0x100+1] = -e-1
+    elseif e <= 15  # Normal numbers just lose precision
+        basetable[i|0x000+1] = ((e+15)<<10)
+        basetable[i|0x100+1] = ((e+15)<<10) | 0x8000
+        shifttable[i|0x000+1] = 13
+        shifttable[i|0x100+1] = 13
+    elseif e < 128  # Large numbers map to Infinity
+        basetable[i|0x000+1] = 0x7C00
+        basetable[i|0x100+1] = 0xFC00
+        shifttable[i|0x000+1] = 24
+        shifttable[i|0x100+1] = 24
+    else  # Infinity and NaN's stay Infinity and NaN's
+        basetable[i|0x000+1] = 0x7C00
+        basetable[i|0x100+1] = 0xFC00
+        shifttable[i|0x000+1] = 13
+        shifttable[i|0x100+1] = 13
+    end
+end
+
+end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -186,6 +186,8 @@ include("namedtuple.jl")
 include("hashing.jl")
 include("rounding.jl")
 using .Rounding
+include("rtlib/RTLIB.jl")
+using .RTLIB
 include("float.jl")
 include("twiceprecision.jl")
 include("complex.jl")
@@ -247,10 +249,6 @@ include(string((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "version_git.jl")) # 
 
 include("osutils.jl")
 include("c.jl")
-
-# inlucde the runtime library
-include("rtlib/RTLIB.jl")
-using .RTLIB
 
 # Core I/O
 include("io.jl")

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -248,6 +248,10 @@ include(string((length(Core.ARGS)>=2 ? Core.ARGS[2] : ""), "version_git.jl")) # 
 include("osutils.jl")
 include("c.jl")
 
+# inlucde the runtime library
+include("rtlib/RTLIB.jl")
+using .RTLIB
+
 # Core I/O
 include("io.jl")
 include("iostream.jl")

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -507,6 +507,8 @@ static Type *bitstype_to_llvm(jl_value_t *bt)
         return T_int32;
     if (bt == (jl_value_t*)jl_int64_type)
         return T_int64;
+    if (bt == (jl_value_t*)jl_float16_type)
+        return T_float16;
     if (bt == (jl_value_t*)jl_float32_type)
         return T_float32;
     if (bt == (jl_value_t*)jl_float64_type)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -157,8 +157,6 @@ extern void _chkstk(void);
 #define __alignof__ __alignof
 #endif
 
-#define DISABLE_FLOAT16
-
 // llvm state
 JL_DLLEXPORT LLVMContext jl_LLVMContext;
 static bool nested_compile = false;

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -109,10 +109,8 @@ static Type *FLOATT(Type *t)
         return T_float64;
     if (nb == 32)
         return T_float32;
-#ifndef DISABLE_FLOAT16
     if (nb == 16)
         return T_float16;
-#endif
     if (nb == 128)
         return T_float128;
     return NULL;


### PR DESCRIPTION
This is a first step towards implementing the parts of #18927 and #18734
in the laziest most straight-forward possible.

1. Use LLVM's half type for Float16
2. Use LLVM intrinsics for basic operations on Float16
3. Provide fallbacks for methods missing in our current libc.

This foregoes the completnes aspect of #18927, while providing
a way forward to potentially extend this to `Float128`, and it doesn't add
additional dependencies like #18734.

Follow-up PR's could extend RTLIB to be more generic or to not use Base
(thus allowing it to be it's own shared library). There are other places
where `Float16` currently are eagerly converted to `Float32` so this is 
not an attempt at completness.

All the code paths are tested on x86 Linux and I am currently testing on ARM.
(There is a known PPC codegen issue, but I guess nobody but me cares about that).

@vtjnash is there anything I would need to do for `anticodegen`/LLVM free builds?

## Notes:
- Upstream LLVM PPC backend bug: https://bugs.llvm.org/show_bug.cgi?id=39865