### PR TITLE
fix #26310, give `import` warnings even if source and dest are the same

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -299,8 +299,6 @@ JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s)
 static void module_import_(jl_module_t *to, jl_module_t *from, jl_sym_t *s,
                            int explici)
 {
-    if (to == from)
-        return;
     jl_binding_t *b = jl_get_binding(from, s);
     if (b == NULL) {
         jl_printf(JL_STDERR,

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -589,3 +589,9 @@ end
 
 # PR #23664, make sure names don't get added to the default `Main` workspace
 @test readlines(`$(Base.julia_cmd()) --startup-file=no -e 'foreach(println, names(Main))'`) == ["Base","Core","Main"]
+
+# issue #26310
+@test_warn "could not import" eval(@__MODULE__, :(import .notdefined_26310__))
+@test_warn "could not import" eval(Main,        :(import ........notdefined_26310__))
+@test_nowarn eval(Main, :(import .Main))
+@test_nowarn eval(Main, :(import ....Main))


### PR DESCRIPTION
We had a special check to make `import` a no-op if the source and destination modules were the same, but there's not much point to that. Might as well do the same checks and warnings as usual even in that case.