### PR TITLE
add the ability to rename identifiers in `deprecate_stdlib`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -131,10 +131,11 @@ macro deprecate_binding(old, new, export_old=true, dep_message=:nothing, constan
          Expr(:call, :deprecate, __module__, Expr(:quote, old)))
 end
 
-macro deprecate_stdlib(old, mod, export_old=true)
-    dep_message = """: it has been moved to the standard library package `$mod`.
+macro deprecate_stdlib(old, mod, export_old=true, newname=old)
+    rename = old === newname ? "" : " as `$newname`"
+    dep_message = """: it has been moved to the standard library package `$mod`$rename.
                         Add `using $mod` to your imports."""
-    new = GlobalRef(Base.root_module(Base, mod), old)
+    new = GlobalRef(Base.root_module(Base, mod), newname)
     return Expr(:toplevel,
          export_old ? Expr(:export, esc(old)) : nothing,
          Expr(:const, Expr(:(=), esc(Symbol(string("_dep_message_",old))), esc(dep_message))),

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -711,7 +711,7 @@ end
     ## functions that were re-exported from Base
     @deprecate_stdlib nonzeros   SparseArrays true
     @deprecate_stdlib permute    SparseArrays true
-    @deprecate_stdlib blkdiag    SparseArrays true
+    @deprecate_stdlib blkdiag    SparseArrays true blockdiag
     @deprecate_stdlib dropzeros  SparseArrays true
     @deprecate_stdlib dropzeros! SparseArrays true
     @deprecate_stdlib issparse   SparseArrays true


### PR DESCRIPTION
use this to fix warning about `blkdiag` in build