### PR TITLE
LibGit2: allow using a void ptr for payload and add git_transfer_progress struct

### DIFF
--- a/stdlib/LibGit2/docs/index.md
+++ b/stdlib/LibGit2/docs/index.md
@@ -41,6 +41,7 @@ LibGit2.GitShortHash
 LibGit2.GitSignature
 LibGit2.GitStatus
 LibGit2.GitTag
+LibGit2.GitTransferProgress
 LibGit2.GitTree
 LibGit2.IndexEntry
 LibGit2.IndexTime


### PR DESCRIPTION
I want to be able to send in an arbitrary pointer for the payload but the current constructor has too tight types.

Also adds the `git_transfer_progress` struct https://libgit2.github.com/libgit2/#HEAD/type/git_transfer_progress.
Useful if one wants to print some progress bar when cloning.

cc @keno 