### PR TITLE
Fix a Distributed GC test.

### DIFF
--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -196,7 +196,7 @@ remotecall_fetch(f25847, id_other, f)
 
 finalize(f)
 yield() # flush gc msgs
-@test false == remotecall_fetch(chk_rrid->haskey(Distributed.PGRP.refs, chk_rrid), id_other, rrid)
+@test false == remotecall_fetch(chk_rrid->(yield(); haskey(Distributed.PGRP.refs, chk_rrid)), id_other, rrid)
 
 
 # Distributed GC tests for RemoteChannels


### PR DESCRIPTION
This addresses https://github.com/JuliaLang/julia/pull/26360#issuecomment-371345214 . The fix ensures that a distributed gc "del msg" received by the remote worker is executed (by explicitly yielding) before we check for it.

This is already being done in other similar checks, For example at https://github.com/JuliaLang/julia/blob/a702539ae78ddd38ca56cb8dd48e055b8cf663b8/stdlib/Distributed/test/distributed_exec.jl#L113-L114 and https://github.com/JuliaLang/julia/blob/a702539ae78ddd38ca56cb8dd48e055b8cf663b8/stdlib/Distributed/test/distributed_exec.jl#L123-L124 but was missed out here.

