### PR TITLE
make sure module is not omitted when printing a type as `getfield(Mod, `

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -473,7 +473,7 @@ function show_type_name(io::IO, tn::Core.TypeName)
     # Print module prefix unless type is visible from module passed to IOContext
     # If :module is not set, default to Main. nothing can be used to force printing prefix
     from = get(io, :module, Main)
-    if isdefined(tn, :module) && (from === nothing || !isvisible(sym, tn.module, from))
+    if isdefined(tn, :module) && (hidden || from === nothing || !isvisible(sym, tn.module, from))
         show(io, tn.module)
         if !hidden
             print(io, ".")

--- a/test/show.jl
+++ b/test/show.jl
@@ -574,6 +574,8 @@ function f13127()
 end
 @test startswith(f13127(), "getfield($(@__MODULE__), Symbol(\"")
 
+@test startswith(sprint(show, typeof(x->x), context = :module=>@__MODULE__), "getfield($(@__MODULE__), Symbol(\"")
+
 #test methodshow.jl functions
 @test Base.inbase(Base)
 @test !Base.inbase(LinearAlgebra)


### PR DESCRIPTION
If you type `typeof(x->x)` at the prompt, you get `getfield(, ...)` due to the `:module` IOContext. This fixes it to always print the module name in this context.

fixes #25031