### PR TITLE
prevent fill! from inlining

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -217,6 +217,7 @@ copyto!(dest::Array{T}, src::Array{T}) where {T} = copyto!(dest, 1, src, 1, leng
 # N.B: The generic definition in multidimensional.jl covers, this, this is just here
 # for bootstrapping purposes.
 function fill!(dest::Array{T}, x) where T
+    @_noinline_meta
     xT = convert(T, x)
     for i in 1:length(dest)
         @inbounds dest[i] = xT
@@ -318,6 +319,7 @@ function fill!(a::Union{Array{UInt8}, Array{Int8}}, x::Integer)
 end
 
 function fill!(a::Array{T}, x) where T<:Union{Integer,AbstractFloat}
+    @_noinline_meta
     xT = convert(T, x)
     for i in eachindex(a)
         @inbounds a[i] = xT


### PR DESCRIPTION
Fixes https://discourse.julialang.org/t/performance-degradation-of-fill-in-latest-julia-0-7-dev/9648. Not sure why inlining this function is problematic though. It contains a loop though so perhaps it shouldn't really be inlined?