### PR TITLE
Deprecate defaulting to scalar in broadcast (take 2)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -914,6 +914,12 @@ Deprecated or removed
   * `map` on dictionaries previously operated on `key=>value` pairs. This behavior is deprecated,
     and in the future `map` will operate only on values ([#5794]).
 
+  * Previously, broadcast defaulted to treating its arguments as scalars if they were not
+    arrays. This behavior is deprecated, and in the future `broadcast` will default to
+    iterating over all its arguments. Wrap arguments you wish to be treated as scalars with
+    `Ref()` or a 1-tuple. Package developers can choose to allow a non-iterable type `T` to
+    always behave as a scalar by implementing `broadcastable(x::T) = Ref(x)` ([#26212]).
+
   * Automatically broadcasted `+` and `-` for `array + scalar`, `scalar - array`, and so-on have
     been deprecated due to inconsistency with linear algebra. Use `.+` and `.-` for these operations
     instead ([#22880], [#22932]).

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -386,11 +386,31 @@ end
     broadcastable(x)
 
 Return either `x` or an object like `x` such that it supports `axes` and indexing.
+
+If `x` supports iteration, the returned value should have the same `axes` and indexing behaviors as [`collect(x)`](@ref).
+
+# Examples
+```jldoctest
+julia> broadcastable([1,2,3]) # like `identity` since arrays already support axes and indexing
+3-element Array{Int64,1}:
+ 1
+ 2
+ 3
+
+julia> broadcastable(Int) # Types don't support axes, indexing, or iteration but are commonly used as scalars
+Base.RefValue{Type{Int64}}(Int64)
+
+julia> broadcastable("hello") # Strings break convention of matching iteration and act like a scalar instead
+Base.RefValue{String}("hello")
+```
 """
 broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing}) = Ref(x)
 broadcastable(x::Ptr) = Ref{Ptr}(x) # Cannot use Ref(::Ptr) until ambiguous deprecation goes through
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::AbstractArray) = x
+# In the future, default to collecting arguments. TODO: uncomment once deprecations are removed
+# broadcastable(x) = BroadcastStyle(typeof(x)) isa Unknown ? collect(x) : x
+# broadcastable(::Union{AbstractDict, NamedTuple}) = error("intentionally unimplemented to allow development in 1.x")
 
 """
     broadcast!(f, dest, As...)
@@ -511,17 +531,23 @@ combine_eltypes(f, A, As...) =
 """
     broadcast(f, As...)
 
-Broadcasts the arrays, tuples, `Ref`s and/or scalars `As` to a
-container of the appropriate type and dimensions. In this context, anything
-that is not a subtype of `AbstractArray`, `Ref` (except for `Ptr`s) or `Tuple`
-is considered a scalar. The resulting container is established by
-the following rules:
+Broadcast the function `f` over the arrays, tuples, collections, `Ref`s and/or scalars `As`.
 
- - If all the arguments are scalars, it returns a scalar.
- - If the arguments are tuples and zero or more scalars, it returns a tuple.
- - If the arguments contain at least one array or `Ref`, it returns an array
-   (expanding singleton dimensions), and treats `Ref`s as 0-dimensional arrays,
-   and tuples as 1-dimensional arrays.
+Broadcasting applies the function `f` over the elements of the container arguments and the
+scalars themselves in `As`. Singleton and missing dimensions are expanded to match the
+extents of the other arguments by virtually repeating the value. By default, only a limited
+number of types are considered scalars, including `Number`s, `String`s, `Symbol`s, `Type`s,
+`Function`s and some common singletons like `missing` and `nothing`. All other arguments are
+iterated over or indexed into elementwise.
+
+The resulting container type is established by the following rules:
+
+ - If all the arguments are scalars or zero-dimensional arrays, it returns an unwrapped scalar.
+ - If at least one argument is a tuple and all others are scalars or zero-dimensional arrays,
+   it returns a tuple.
+ - All other combinations of arguments default to returning an `Array`, but
+   custom container types can define their own implementation and promotion-like
+   rules to customize the result when they appear as arguments.
 
 A special syntax exists for broadcasting: `f.(args...)` is equivalent to
 `broadcast(f, args...)`, and nested `f.(g.(args...))` calls are fused into a

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -687,6 +687,21 @@ end
 # After deprecation is removed, enable the @testset "indexing by Bool values" in test/arrayops.jl
 # Also un-comment the new definition in base/indices.jl
 
+# Broadcast no longer defaults to treating its arguments as scalar (#)
+@noinline function Broadcast.broadcastable(x)
+    if Base.Broadcast.BroadcastStyle(typeof(x)) isa Broadcast.Unknown
+        depwarn("""
+            broadcast will default to iterating over its arguments in the future. Wrap arguments of
+            type `x::$(typeof(x))` with `Ref(x)` to ensure they broadcast as "scalar" elements.
+            """, (:broadcast, :broadcast!))
+        return Ref{typeof(x)}(x)
+    else
+        return x
+    end
+end
+@eval Base.Broadcast Base.@deprecate_binding Scalar DefaultArrayStyle{0} false
+# After deprecation is removed, enable the fallback broadcastable definitions in base/broadcast.jl
+
 # deprecate BitArray{...}(shape...) constructors to BitArray{...}(undef, shape...) equivalents
 @deprecate BitArray{N}(dims::Vararg{Int,N}) where {N}   BitArray{N}(undef, dims)
 @deprecate BitArray(dims::NTuple{N,Int}) where {N}      BitArray(undef, dims...)

--- a/base/range.jl
+++ b/base/range.jl
@@ -514,7 +514,7 @@ function _getindex_hiprec(r::StepRangeLen, i::Integer)  # without rounding by T
 end
 
 function unsafe_getindex(r::LinRange, i::Integer)
-    lerpi.(i-1, r.lendiv, r.start, r.stop)
+    lerpi(i-1, r.lendiv, r.start, r.stop)
 end
 
 function lerpi(j::Integer, d::Integer, a::T, b::T) where T

--- a/base/version.jl
+++ b/base/version.jl
@@ -67,6 +67,8 @@ function print(io::IO, v::VersionNumber)
 end
 show(io::IO, v::VersionNumber) = print(io, "v\"", v, "\"")
 
+Broadcast.broadcastable(v::VersionNumber) = Ref(v)
+
 const VERSION_REGEX = r"^
     v?                                      # prefix        (optional)
     (\d+)                                   # major         (required)

--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -97,3 +97,6 @@ end
 # AbstractArray{TimeType}, AbstractArray{TimeType}
 (-)(x::OrdinalRange{T}, y::OrdinalRange{T}) where {T<:TimeType} = Vector(x) - Vector(y)
 (-)(x::AbstractRange{T}, y::AbstractRange{T}) where {T<:TimeType} = Vector(x) - Vector(y)
+
+# Allow dates and times to broadcast as unwrapped scalars
+Base.Broadcast.broadcastable(x::AbstractTime) = Ref(x)

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -376,6 +376,7 @@ function Base.show(io::IO, df::DateFormat)
     end
     print(io, '"')
 end
+Base.Broadcast.broadcastable(x::DateFormat) = Ref(x)
 
 """
     dateformat"Y-m-d H:M:S"

--- a/stdlib/Pkg3/src/Operations.jl
+++ b/stdlib/Pkg3/src/Operations.jl
@@ -657,7 +657,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
     need_to_resolve = false
 
     if Types.is_project(localctx.env, pkg)
-        delete!.(localctx.env.project, ["name", "uuid", "version"])
+        foreach(k->delete!(localctx.env.project, k), ("name", "uuid", "version"))
         localctx.env.project["deps"][pkg.name] = string(pkg.uuid)
         localctx.env.manifest[pkg.name] = [Dict(
             "deps" => mainctx.env.project["deps"],

--- a/stdlib/Pkg3/src/Types.jl
+++ b/stdlib/Pkg3/src/Types.jl
@@ -482,7 +482,7 @@ mutable struct EnvCache
         git = ispath(joinpath(project_dir, ".git")) ? LibGit2.GitRepo(project_dir) : nothing
 
         project = read_project(project_file)
-        if any(haskey.(project, ["name", "uuid", "version"]))
+        if any(k->haskey(project, k), ("name", "uuid", "version"))
             project_package = PackageSpec(
                 get(project, "name", ""),
                 UUID(get(project, "uuid", 0)),

--- a/stdlib/Pkg3/src/resolve/FieldValues.jl
+++ b/stdlib/Pkg3/src/resolve/FieldValues.jl
@@ -105,4 +105,7 @@ function secondmax(f::Field, msk::BitVector = trues(length(f)))
     return m2 - m
 end
 
+# Support broadcasting like a scalar by default
+Base.Broadcast.broadcastable(a::FieldValue) = Ref(a)
+
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -408,8 +408,8 @@ end
 
 # Ref as 0-dimensional array for broadcast
 @test (-).(C_NULL, C_NULL)::UInt == 0
-@test (+).(1, Ref(2)) == fill(3)
-@test (+).(Ref(1), Ref(2)) == fill(3)
+@test (+).(1, Ref(2)) == 3
+@test (+).(Ref(1), Ref(2)) == 3
 @test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) == [[1,1], [2,2]]
 
 # Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722),
@@ -545,7 +545,7 @@ end
 # Test that broadcast treats type arguments as scalars, i.e. containertype yields Any,
 # even for subtypes of abstract array. (https://github.com/JuliaStats/DataArrays.jl/issues/229)
 @testset "treat type arguments as scalars, DataArrays issue 229" begin
-    @test Broadcast.combine_styles(AbstractArray) == Broadcast.Scalar()
+    @test Broadcast.combine_styles(AbstractArray) == Broadcast.Unknown()
     @test broadcast(==, [1], AbstractArray) == BitArray([false])
     @test broadcast(==, 1, AbstractArray) == false
 end
@@ -574,7 +574,7 @@ end
     @test broadcast(foo, "x", [1, 2, 3]) == ["hello", "hello", "hello"]
 
     @test isequal(
-        [Set([1]), Set([2])] .∪ Set([3]),
+        [Set([1]), Set([2])] .∪ Ref(Set([3])),
         [Set([1, 3]), Set([2, 3])])
 end
 


### PR DESCRIPTION
This PR replaces #26212.  The end result is the same, but I like this implementation much better.

This PR consists of two commits — both pass tests locally and I'd like to keep them separate. The first commit changes the default behavior of broadcast to collect its arguments instead of treating them as scalars. Broadcast now calls a special helper function, `broadcastable`, on each argument. It ensures that the arguments support indexing and have a shape, or otherwise have defined a custom `BroadcastStyle`.  The second commit layers on top a deprecation mechanism that makes this — almost entirely — non-breaking.

I believe this to be a compromise that will fix #18618 once deprecations are removed. Note that I kept all the types that are currently tested to behave as scalars as specializing `broadcastable` to return something that supports both indexing and `axes`, or otherwise has its own `BroadcastStyle` and internal implementation.

This also changes the behavior of broadcast such that if it ever wants to return a 0-dimensional array, it'll just "unwrap" that 0-dimensional array and return the contents instead.

Reasons I like this approach better than #26212:

* We're going to be requiring folks to explicitly wrap things in a `Ref` to make them broadcast as scalars.  In #26212, adding a `Ref` to an otherwise scalar expression would result in a 0-dimensional array as a result.  Yes, I generally have a very strong aversion to these kinds of auto-wrapping/unwrapping, but in this case I believe it is warranted and ends up with fewer special cases.  0-dimensional arrays and "scalar" types are treated identically as far as broadcast is concerned.
* Having an explicit `broadcastable` psuedo-conversion method makes it easier for other code to "work-around" broadcast and know how it'll behave.  Call `broadcastable` on a thing and then you'll be able to know what `broadcast` is going to do on the basis of its `axes`.  No digging around in `BroadcastStyle`s or other internals — this one function makes sure that iterables and everything else can just work.  (This isn't quite true, yet, as `Ref` isn't fully conforming with the iterable and `axes` spec, but I'd like to implement that separately.)
* It's so much simpler to not need to worry about `Broadcast.Scalar()` styles.