### PR TITLE
Support separate payloads for RemoteCallbacks

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -261,6 +261,7 @@ The keyword arguments are:
   * `refspecs=AbstractString[]`: determines properties of the fetch.
   * `credentials=nothing`: provides credentials and/or settings when authenticating against
     a private `remote`.
+  * `callbacks=Callbacks()`: user provided callbacks and payloads.
 
 Equivalent to `git fetch [<remoteurl>|<repo>] [<refspecs>]`.
 """
@@ -315,6 +316,7 @@ The keyword arguments are:
      overwriting the remote branch.
   * `credentials=nothing`: provides credentials and/or settings when authenticating against
      a private `remote`.
+  * `callbacks=Callbacks()`: user provided callbacks and payloads.
 
 Equivalent to `git push [<remoteurl>|<repo>] [<refspecs>]`.
 """
@@ -535,6 +537,7 @@ The keyword arguments are:
     the remote - it will be assumed to already exist.
   * `credentials::Creds=nothing`: provides credentials and/or settings when authenticating
     against a private repository.
+  * `callbacks::Callbacks=Callbacks()`: user provided callbacks and payloads.
 
 Equivalent to `git clone [-b <branch>] [--bare] <repo_url> <repo_path>`.
 

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -259,33 +259,37 @@ The keyword arguments are:
   * `remoteurl::AbstractString=""`: the URL of `remote`. If not specified,
     will be assumed based on the given name of `remote`.
   * `refspecs=AbstractString[]`: determines properties of the fetch.
-  * `payload=CredentialPayload()`: provides credentials and/or settings when authenticating
-    against a private `remote`.
+  * `credentials=nothing`: provides credentials and/or settings when authenticating against
+    a private `remote`.
 
 Equivalent to `git fetch [<remoteurl>|<repo>] [<refspecs>]`.
 """
 function fetch(repo::GitRepo; remote::AbstractString="origin",
                remoteurl::AbstractString="",
                refspecs::Vector{<:AbstractString}=AbstractString[],
-               payload::Union{CredentialPayload, AbstractCredential, CachedCredentials, Nothing}=CredentialPayload())
-    p = reset!(deprecate_nullable_creds(:fetch, "repo", payload), GitConfig(repo))
+               payload::Creds=nothing,
+               credentials::Creds=payload)
+    deprecate_payload_keyword(:fetch, "repo", payload)
+    p = reset!(CredentialPayload(credentials), GitConfig(repo))
+
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
     else
         GitRemoteAnon(repo, remoteurl)
     end
     result = try
-        fo = FetchOptions(callbacks=RemoteCallbacks(credentials=credentials_cb(), payload=p))
-        fetch(rmt, refspecs, msg="from $(url(rmt))", options = fo)
+        remote_callbacks = RemoteCallbacks(credentials=credentials_cb(), payload=p)
+        fo = FetchOptions(callbacks=remote_callbacks)
+        fetch(rmt, refspecs, msg="from $(url(rmt))", options=fo)
     catch err
         if isa(err, GitError) && err.code == Error.EAUTH
-            reject(payload)
+            reject(p)
         end
         rethrow()
     finally
         close(rmt)
     end
-    approve(payload)
+    approve(p)
     return result
 end
 
@@ -300,8 +304,8 @@ The keyword arguments are:
   * `refspecs=AbstractString[]`: determines properties of the push.
   * `force::Bool=false`: determines if the push will be a force push,
      overwriting the remote branch.
-  * `payload=CredentialPayload()`: provides credentials and/or settings when authenticating
-    against a private `remote`.
+  * `credentials=nothing`: provides credentials and/or settings when authenticating against
+     a private `remote`.
 
 Equivalent to `git push [<remoteurl>|<repo>] [<refspecs>]`.
 """
@@ -309,25 +313,29 @@ function push(repo::GitRepo; remote::AbstractString="origin",
               remoteurl::AbstractString="",
               refspecs::Vector{<:AbstractString}=AbstractString[],
               force::Bool=false,
-              payload::Union{CredentialPayload, AbstractCredential, CachedCredentials, Nothing}=CredentialPayload())
-    p = reset!(deprecate_nullable_creds(:push, "repo", payload), GitConfig(repo))
+              payload::Creds=nothing,
+              credentials::Creds=payload)
+    deprecate_payload_keyword(:push, "repo", payload)
+    p = reset!(CredentialPayload(credentials), GitConfig(repo))
+
     rmt = if isempty(remoteurl)
         get(GitRemote, repo, remote)
     else
         GitRemoteAnon(repo, remoteurl)
     end
     result = try
-        push_opts = PushOptions(callbacks=RemoteCallbacks(credentials=credentials_cb(), payload=p))
+        remote_callbacks = RemoteCallbacks(credentials=credentials_cb(), payload=p)
+        push_opts = PushOptions(callbacks=remote_callbacks)
         push(rmt, refspecs, force=force, options=push_opts)
     catch err
         if isa(err, GitError) && err.code == Error.EAUTH
-            reject(payload)
+            reject(p)
         end
         rethrow()
     finally
         close(rmt)
     end
-    approve(payload)
+    approve(p)
     return result
 end
 
@@ -507,8 +515,8 @@ The keyword arguments are:
   * `remote_cb::Ptr{Cvoid}=C_NULL`: a callback which will be used to create the remote
     before it is cloned. If `C_NULL` (the default), no attempt will be made to create
     the remote - it will be assumed to already exist.
-  * `payload::CredentialPayload=CredentialPayload()`: provides credentials and/or settings
-    when authenticating against a private repository.
+  * `credentials::Creds=nothing`: provides credentials and/or settings when authenticating
+    against a private repository.
 
 Equivalent to `git clone [-b <branch>] [--bare] <repo_url> <repo_path>`.
 
@@ -525,12 +533,16 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
                branch::AbstractString="",
                isbare::Bool = false,
                remote_cb::Ptr{Cvoid} = C_NULL,
-               payload::Union{CredentialPayload, AbstractCredential, CachedCredentials, Nothing}=CredentialPayload())
+               payload::Creds=nothing,
+               credentials::Creds=payload)
+    deprecate_payload_keyword(:clone, "repo_url, repo_path", payload)
+    p = reset!(CredentialPayload(credentials))
+
     # setup clone options
     lbranch = Base.cconvert(Cstring, branch)
     GC.@preserve lbranch begin
-        p = reset!(deprecate_nullable_creds(:clone, "repo_url, repo_path", payload))
-        fetch_opts = FetchOptions(callbacks = RemoteCallbacks(credentials=credentials_cb(), payload=p))
+        remote_callbacks = RemoteCallbacks(credentials=credentials_cb(), payload=p)
+        fetch_opts = FetchOptions(callbacks=remote_callbacks)
         clone_opts = CloneOptions(
                     bare = Cint(isbare),
                     checkout_branch = isempty(lbranch) ? Cstring(C_NULL) : Base.unsafe_convert(Cstring, lbranch),
@@ -541,12 +553,12 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
             clone(repo_url, repo_path, clone_opts)
         catch err
             if isa(err, GitError) && err.code == Error.EAUTH
-                reject(payload)
+                reject(p)
             end
             rethrow()
         end
     end
-    approve(payload)
+    approve(p)
     return repo
 end
 

--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -261,12 +261,8 @@ For addition details see the LibGit2 guide on
 """
 function credentials_callback(libgit2credptr::Ptr{Ptr{Cvoid}}, url_ptr::Cstring,
                               username_ptr::Cstring,
-                              allowed_types::Cuint, payload_ptr::Ptr{Cvoid})
+                              allowed_types::Cuint, p::CredentialPayload)
     err = Cint(0)
-
-    # get `CredentialPayload` object from payload pointer
-    @assert payload_ptr != C_NULL
-    p = unsafe_pointer_to_objref(payload_ptr)::CredentialPayload
 
     # Parse URL only during the first call to this function. Future calls will use the
     # information cached inside the payload.
@@ -340,6 +336,13 @@ function credentials_callback(libgit2credptr::Ptr{Ptr{Cvoid}}, url_ptr::Cstring,
     return err
 end
 
+function credentials_callback(libgit2credptr::Ptr{Ptr{Cvoid}}, url_ptr::Cstring,
+                              username_ptr::Cstring, allowed_types::Cuint,
+                              payloads::Dict)
+    p = payloads[:credentials]
+    credentials_callback(libgit2credptr, url_ptr, username_ptr, allowed_types, p)
+end
+
 function fetchhead_foreach_callback(ref_name::Cstring, remote_url::Cstring,
                         oid_ptr::Ptr{GitHash}, is_merge::Cuint, payload::Ptr{Cvoid})
     fhead_vec = unsafe_pointer_to_objref(payload)::Vector{FetchHead}
@@ -351,6 +354,6 @@ end
 "C function pointer for `mirror_callback`"
 mirror_cb() = cfunction(mirror_callback, Cint, Tuple{Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Cstring, Ptr{Cvoid}})
 "C function pointer for `credentials_callback`"
-credentials_cb() = cfunction(credentials_callback, Cint, Tuple{Ptr{Ptr{Cvoid}}, Cstring, Cstring, Cuint, Ptr{Cvoid}})
+credentials_cb() = cfunction(credentials_callback, Cint, Tuple{Ptr{Ptr{Cvoid}}, Cstring, Cstring, Cuint, Any})
 "C function pointer for `fetchhead_foreach_callback`"
 fetchhead_foreach_cb() = cfunction(fetchhead_foreach_callback, Cint, Tuple{Cstring, Cstring, Ptr{GitHash}, Cuint, Ptr{Cvoid}})

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -204,6 +204,26 @@ end
     payload::Ptr{Cvoid}
 end
 
+"""
+    LibGit2.Callbacks
+
+A dictionary which containing the callback name as the key and the value as a tuple of the
+callback function and payload.
+
+The `Callback` dictionary to construct `RemoteCallbacks` allows each callback to use a
+distinct payload. Each callback, when called, will receive `Dict` which will hold the
+callback's custom payload which can be accessed using the callback name.
+
+# Examples
+```julia
+julia> c = LibGit2.Callbacks(:credentials => (LibGit2.credentials_cb(), LibGit2.CredentialPayload()));
+
+julia> LibGit2.clone(url, callbacks=c);
+```
+
+See [`git_remote_callbacks`](https://libgit2.github.com/libgit2/#HEAD/type/git_remote_callbacks)
+for details on supported callbacks.
+"""
 const Callbacks = Dict{Symbol, Tuple{Ptr{Cvoid}, Any}}
 
 """

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1293,6 +1293,9 @@ function CredentialPayload(cache::CachedCredentials; kwargs...)
     CredentialPayload(nothing, cache; kwargs...)
 end
 
+CredentialPayload(p::CredentialPayload) = p
+
+
 """
     reset!(payload, [config]) -> CredentialPayload
 
@@ -1364,3 +1367,6 @@ function reject(p::CredentialPayload; shred::Bool=true)
     shred && securezero!(cred)
     nothing
 end
+
+# Useful for functions which can handle various kinds of credentials
+const Creds = Union{CredentialPayload, AbstractCredential, CachedCredentials, Nothing}

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -188,6 +188,22 @@ The fields represent:
     perfdata_payload::Ptr{Cvoid}
 end
 
+"""
+    LibGit2.TransferProgress
+
+Transfer progress information used by the `transfer_progress` remote callback.
+Matches the [`git_transfer_progress`](https://libgit2.github.com/libgit2/#HEAD/type/git_transfer_progress) struct.
+"""
+@kwdef struct TransferProgress
+    total_objects::Cuint
+    indexed_objects::Cuint
+    received_objects::Cuint
+    local_objects::Cuint
+    total_deltas::Cuint
+    indexed_deltas::Cuint
+    received_bytes::Csize_t
+end
+
 @kwdef struct RemoteCallbacksStruct
     version::Cuint                    = 1
     sideband_progress::Ptr{Cvoid}

--- a/stdlib/LibGit2/test/libgit2-helpers.jl
+++ b/stdlib/LibGit2/test/libgit2-helpers.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import LibGit2: AbstractCredential, UserPasswordCredential, SSHCredential,
-    CachedCredentials, CredentialPayload, Payload
+using LibGit2: AbstractCredential, UserPasswordCredential, SSHCredential,
+    CachedCredentials, CredentialPayload
 using Base: coalesce
 
 const DEFAULT_PAYLOAD = CredentialPayload(allow_ssh_agent=false, allow_git_helpers=false)

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -726,6 +726,11 @@ mktempdir() do dir
                 @test repo_str == "LibGit2.GitRepo($(sprint(show,LibGit2.path(repo))))"
             end
         end
+        @testset "credentials callback conflict" begin
+            callbacks = LibGit2.Callbacks(:credentials => (C_NULL, 0))
+            cred_payload = LibGit2.CredentialPayload()
+            @test_throws ArgumentError LibGit2.clone(cache_repo, test_repo, callbacks=callbacks, credentials=cred_payload)
+        end
     end
 
     @testset "Update cache repository" begin
@@ -1258,6 +1263,15 @@ mktempdir() do dir
             close(our_repo)
             close(up_repo)
         end
+
+        @testset "credentials callback conflict" begin
+            callbacks = LibGit2.Callbacks(:credentials => (C_NULL, 0))
+            cred_payload = LibGit2.CredentialPayload()
+
+            LibGit2.with(LibGit2.GitRepo(joinpath(dir, "Example.Push"))) do repo
+                @test_throws ArgumentError LibGit2.push(repo, callbacks=callbacks, credentials=cred_payload)
+            end
+        end
     end
 
     @testset "Fetch from cache repository" begin
@@ -1317,6 +1331,15 @@ mktempdir() do dir
                 @test fh_strs[2] == "Name: $(fh.name)"
                 @test fh_strs[3] == "URL: $(fh.url)"
                 @test fh_strs[5] == "Merged: $(fh.ismerge)"
+            end
+        end
+
+        @testset "credentials callback conflict" begin
+            callbacks = LibGit2.Callbacks(:credentials => (C_NULL, 0))
+            cred_payload = LibGit2.CredentialPayload()
+
+            LibGit2.with(LibGit2.GitRepo(test_repo)) do repo
+                @test_throws ArgumentError LibGit2.fetch(repo, callbacks=callbacks, credentials=cred_payload)
             end
         end
     end

--- a/stdlib/LibGit2/test/online.jl
+++ b/stdlib/LibGit2/test/online.jl
@@ -15,8 +15,8 @@ mktempdir() do dir
     @testset "Cloning repository" begin
         @testset "with 'https' protocol" begin
             repo_path = joinpath(dir, "Example1")
-            payload = LibGit2.CredentialPayload(allow_prompt=false, allow_git_helpers=false)
-            repo = LibGit2.clone(repo_url, repo_path, payload=payload)
+            c = LibGit2.CredentialPayload(allow_prompt=false, allow_git_helpers=false)
+            repo = LibGit2.clone(repo_url, repo_path, credentials=c)
             try
                 @test isdir(repo_path)
                 @test isdir(joinpath(repo_path, ".git"))
@@ -30,8 +30,8 @@ mktempdir() do dir
                 repo_path = joinpath(dir, "Example2")
                 # credentials are required because github tries to authenticate on unknown repo
                 cred = LibGit2.UserPasswordCredential("JeffBezanson", "hunter2") # make sure Jeff is using a good password :)
-                payload = LibGit2.CredentialPayload(cred, allow_prompt=false, allow_git_helpers=false)
-                LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
+                c = LibGit2.CredentialPayload(cred, allow_prompt=false, allow_git_helpers=false)
+                LibGit2.clone(repo_url*randstring(10), repo_path, credentials=c)
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)
@@ -44,8 +44,8 @@ mktempdir() do dir
                 repo_path = joinpath(dir, "Example3")
                 # credentials are required because github tries to authenticate on unknown repo
                 cred = LibGit2.UserPasswordCredential("","") # empty credentials cause authentication error
-                payload = LibGit2.CredentialPayload(cred, allow_prompt=false, allow_git_helpers=false)
-                LibGit2.clone(repo_url*randstring(10), repo_path, payload=payload)
+                c = LibGit2.CredentialPayload(cred, allow_prompt=false, allow_git_helpers=false)
+                LibGit2.clone(repo_url*randstring(10), repo_path, credentials=c)
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)

--- a/stdlib/Pkg/src/entry.jl
+++ b/stdlib/Pkg/src/entry.jl
@@ -435,7 +435,7 @@ function update(branch::AbstractString, upkgs::Set{String})
                         prev_sha = string(LibGit2.head_oid(repo))
                         success = true
                         try
-                            LibGit2.fetch(repo, payload=LibGit2.CredentialPayload(creds))
+                            LibGit2.fetch(repo, credentials=creds)
                             LibGit2.merge!(repo, fastforward=true)
                         catch err
                             cex = CapturedException(err, catch_backtrace())


### PR DESCRIPTION
Spin off of https://github.com/JuliaLang/julia/pull/26387. Support having separate payloads for each callback in `RemoteCallbacks`.  Specifically this change was made to support using the credential callback included in LibGit2.jl and the progress bar proposed in https://github.com/JuliaLang/Pkg3.jl/pull/177.

There is a little work yet to do including:
- [x] Documenting the new interface to `RemoteCallbacks` where tuples of callbacks/payloads are passed in
- [x] Tests