### PR TITLE
RFC: Improved (?) tab completion for symbols

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -422,6 +422,21 @@ function afterusing(string::String, startpos::Int)
     return contains(str[fr:end], r"^\b(using|import)\s*((\w+[.])*\w+\s*,\s*)*$")
 end
 
+function complete_symbols(comps, symbol_dict)
+    newcomps = []
+    for c in comps
+        smb = get(symbol_dict, c, c)
+        scomps, positions = completions(smb, 1)
+        (smb in  scomps) || push!(newcomps, smb)
+        if !isempty(scomps)
+            for s in scomps
+                push!(newcomps, s)
+            end
+         end
+    end
+    return newcomps
+end
+
 function bslash_completions(string, pos)
     slashpos = coalesce(findprev(equalto('\\'), string, pos), 0)
     if (coalesce(findprev(occursin(bslash_separators), string, pos), 0) < slashpos &&
@@ -440,10 +455,12 @@ function bslash_completions(string, pos)
         # Julian completions as only latex / emoji symbols contain the leading \
         if startswith(s, "\\:") # emoji
             emoji_names = Iterators.filter(k -> startswith(k, s), keys(emoji_symbols))
-            return (true, (sort!(collect(emoji_names)), slashpos:pos, true))
+            comps = complete_symbols(sort(collect(emoji_names)), emoji_symbols)
+            return (true, (comps, slashpos:pos, true))
         else # latex
             latex_names = Iterators.filter(k -> startswith(k, s), keys(latex_symbols))
-            return (true, (sort!(collect(latex_names)), slashpos:pos, true))
+            comps = complete_symbols(sort(collect(latex_names)), latex_symbols)
+            return (true, (comps, slashpos:pos, true))
         end
     end
     return (false, (String[], 0:-1, false))


### PR DESCRIPTION
This changes the REPL to show latex and emoji symbols as tab completions and complete names starting with that symbol as well:

![symb_repl](https://user-images.githubusercontent.com/430863/37362959-661331a4-26ff-11e8-98a8-a9ca2096641e.png)

This a very initial to implementation to get some feedback whether this is a good idea at all.  See some discussion at: https://github.com/JuliaLang/IJulia.jl/pull/634