### PR TITLE
Deprecate {Linear,Cartesian}Indices(inds...) constructors

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1510,6 +1510,12 @@ end
 # Issue #26248
 @deprecate conj(x) x
 
+# Remove ambiguous CartesianIndices and LinearIndices constructors that are ambiguous between an axis and an array (#26448)
+@eval IteratorsMD @deprecate CartesianIndices(inds::Vararg{AbstractUnitRange{Int},N}) where {N} CartesianIndices(inds)
+@eval IteratorsMD @deprecate CartesianIndices(inds::Vararg{AbstractUnitRange{<:Integer},N}) where {N} CartesianIndices(inds)
+@eval IteratorsMD @deprecate LinearIndices(inds::Vararg{AbstractUnitRange{Int},N}) where {N} LinearIndices(inds)
+@eval IteratorsMD @deprecate LinearIndices(inds::Vararg{AbstractUnitRange{<:Integer},N}) where {N} LinearIndices(inds)
+
 # rename uninitialized
 @deprecate_binding uninitialized undef
 @deprecate_binding Uninitialized UndefInitializer

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -220,12 +220,8 @@ module IteratorsMD
     CartesianIndices(::Tuple{}) = CartesianIndices{0,typeof(())}(())
     CartesianIndices(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} =
         CartesianIndices{N,typeof(inds)}(inds)
-    CartesianIndices(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
-        CartesianIndices(inds)
     CartesianIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N} =
         CartesianIndices(map(r->convert(AbstractUnitRange{Int}, r), inds))
-    CartesianIndices(inds::Vararg{AbstractUnitRange{<:Integer},N}) where {N} =
-        CartesianIndices(inds)
 
     CartesianIndices(index::CartesianIndex) = CartesianIndices(index.I)
     CartesianIndices(sz::NTuple{N,<:Integer}) where {N} = CartesianIndices(map(Base.OneTo, sz))
@@ -406,9 +402,7 @@ module IteratorsMD
     LinearIndices(inds::CartesianIndices{N,R}) where {N,R} = LinearIndices{N,R}(inds.indices)
     LinearIndices(::Tuple{}) = LinearIndices(CartesianIndices(()))
     LinearIndices(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} = LinearIndices(CartesianIndices(inds))
-    LinearIndices(inds::Vararg{AbstractUnitRange{Int},N}) where {N} = LinearIndices(CartesianIndices(inds))
     LinearIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N} = LinearIndices(CartesianIndices(inds))
-    LinearIndices(inds::Vararg{AbstractUnitRange{<:Integer},N}) where {N} = LinearIndices(CartesianIndices(inds))
     LinearIndices(index::CartesianIndex) = LinearIndices(CartesianIndices(index))
     LinearIndices(sz::NTuple{N,<:Integer}) where {N} = LinearIndices(CartesianIndices(sz))
     LinearIndices(inds::NTuple{N,Union{<:Integer,AbstractUnitRange{<:Integer}}}) where {N} = LinearIndices(CartesianIndices(inds))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -116,13 +116,15 @@ end
 
 @testset "index conversion" begin
     @testset "0-dimensional" begin
-        @test LinearIndices()[1] == 1
-        @test_throws BoundsError LinearIndices()[2]
-        @test LinearIndices()[1,1] == 1
-        @test LinearIndices()[] == 1
-        @test size(LinearIndices()) == ()
-        @test CartesianIndices()[1] == CartesianIndex()
-        @test_throws BoundsError CartesianIndices()[2]
+        for i in ((), fill(0))
+            @test LinearIndices(i)[1] == 1
+            @test_throws BoundsError LinearIndices(i)[2]
+            @test LinearIndices(i)[1,1] == 1
+            @test LinearIndices(i)[] == 1
+            @test size(LinearIndices(i)) == ()
+            @test CartesianIndices(i)[1] == CartesianIndex()
+            @test_throws BoundsError CartesianIndices(i)[2]
+        end
     end
 
     @testset "1-dimensional" begin
@@ -149,8 +151,8 @@ end
             k += 1
             @test linear[i,j] == linear[k] == k
             @test cartesian[k] == CartesianIndex(i,j)
-            @test LinearIndices(0:3,3:5)[i-1,j+2] == k
-            @test CartesianIndices(0:3,3:5)[k] == CartesianIndex(i-1,j+2)
+            @test LinearIndices((0:3,3:5))[i-1,j+2] == k
+            @test CartesianIndices((0:3,3:5))[k] == CartesianIndex(i-1,j+2)
         end
         @test linear[linear] == linear
         @test linear[vec(linear)] == vec(linear)
@@ -170,14 +172,14 @@ end
             @test LinearIndices((4,3,2))[l] == l
             @test CartesianIndices((4,3,2))[i,j,k] == CartesianIndex(i,j,k)
             @test CartesianIndices((4,3,2))[l] == CartesianIndex(i,j,k)
-            @test LinearIndices(1:4,1:3,1:2)[i,j,k] == l
-            @test LinearIndices(1:4,1:3,1:2)[l] == l
-            @test CartesianIndices(1:4,1:3,1:2)[i,j,k] == CartesianIndex(i,j,k)
-            @test CartesianIndices(1:4,1:3,1:2)[l] == CartesianIndex(i,j,k)
-            @test LinearIndices(0:3,3:5,-101:-100)[i-1,j+2,k-102] == l
-            @test LinearIndices(0:3,3:5,-101:-100)[l] == l
-            @test CartesianIndices(0:3,3:5,-101:-100)[i,j,k] == CartesianIndex(i-1, j+2, k-102)
-            @test CartesianIndices(0:3,3:5,-101:-100)[l] == CartesianIndex(i-1, j+2, k-102)
+            @test LinearIndices((1:4,1:3,1:2))[i,j,k] == l
+            @test LinearIndices((1:4,1:3,1:2))[l] == l
+            @test CartesianIndices((1:4,1:3,1:2))[i,j,k] == CartesianIndex(i,j,k)
+            @test CartesianIndices((1:4,1:3,1:2))[l] == CartesianIndex(i,j,k)
+            @test LinearIndices((0:3,3:5,-101:-100))[i-1,j+2,k-102] == l
+            @test LinearIndices((0:3,3:5,-101:-100))[l] == l
+            @test CartesianIndices((0:3,3:5,-101:-100))[i,j,k] == CartesianIndex(i-1, j+2, k-102)
+            @test CartesianIndices((0:3,3:5,-101:-100))[l] == CartesianIndex(i-1, j+2, k-102)
         end
 
         local A = reshape(Vector(1:9), (3,3))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1676,7 +1676,7 @@ end
     @test a[1,2] == 7
     @test 2*CartesianIndex{3}(1,2,3) == CartesianIndex{3}(2,4,6)
 
-    R = CartesianIndices(2:5, 3:5)
+    R = CartesianIndices((2:5, 3:5))
     @test eltype(R) <: CartesianIndex{2}
     @test eltype(typeof(R)) <: CartesianIndex{2}
     @test eltype(CartesianIndices{2}) <: CartesianIndex{2}
@@ -1701,8 +1701,8 @@ end
     @test @inferred(convert(NTuple{2,UnitRange}, R)) === (2:5, 3:5)
     @test @inferred(convert(Tuple{Vararg{UnitRange}}, R)) === (2:5, 3:5)
 
-    @test CartesianIndices((3:5,-7:7)) == CartesianIndices(3:5,-7:7)
-    @test CartesianIndices((3,-7:7)) == CartesianIndices(3:3,-7:7)
+    @test CartesianIndices((3:5,-7:7)) == CartesianIndex.(3:5, reshape(-7:7, 1, :))
+    @test CartesianIndices((3,-7:7)) == CartesianIndex.(3, reshape(-7:7, 1, :))
 end
 
 # All we really care about is that we have an optimized

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -115,23 +115,23 @@ function simd_cartesian_range!(indices, crng)
     indices
 end
 
-crng = CartesianIndices(2:4, 0:1, 1:1, 3:5)
+crng = CartesianIndices((2:4, 0:1, 1:1, 3:5))
 indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indices == vec(collect(crng))
 
-crng = CartesianIndices(-1:1, 1:3)
+crng = CartesianIndices((-1:1, 1:3))
 indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indices == vec(collect(crng))
 
-crng = CartesianIndices(-1:-1, 1:3)
+crng = CartesianIndices((-1:-1, 1:3))
 indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indices == vec(collect(crng))
 
-crng = CartesianIndices(2:4)
+crng = CartesianIndices((2:4,))
 indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indices == collect(crng)
 
-crng = CartesianIndices()
+crng = CartesianIndices(())
 indices = simd_cartesian_range!(Vector{eltype(crng)}(), crng)
 @test indices == vec(collect(crng))
 


### PR DESCRIPTION
Previously, there had been an ambiguity between `LinearIndices(-2:2)` and `LinearIndices(collect(-2:2))`, with the former treating the argument as axes directly and the latter asking the argument for its axes. This removes the constructors with varargs `(axes...)` in favor of an explicit tuple of sizes and/or axes.

No NEWS here since CartesianIndices and LinearIndices are both new in 0.7 — but I kept a deprecation for folks' continued development on 0.7.