### PR TITLE
deprecate `yieldto`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1518,6 +1518,9 @@ end
 @deprecate showcompact(io, x) show(IOContext(io, :compact => true), x)
 @deprecate sprint(::typeof(showcompact), args...) sprint(show, args...; context=:compact => true)
 
+@deprecate yieldto(t::Task)    (schedule(t); yield())
+@deprecate yieldto(t::Task, x) (schedule(t,x); yield())
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -689,7 +689,6 @@ export
     trylock,
     unlock,
     yield,
-    yieldto,
     wait,
     timedwait,
     asyncmap,

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -6,7 +6,6 @@ Base.current_task
 Base.istaskdone
 Base.istaskstarted
 Base.yield
-Base.yieldto
 Base.task_local_storage(::Any)
 Base.task_local_storage(::Any, ::Any)
 Base.task_local_storage(::Function, ::Any, ::Any)

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -233,7 +233,7 @@ end
     # test for finalizers trying to yield leading to failed attempts to context switch
     garbage_finalizer((x) -> (run[] += 1; sleep(1)))
     garbage_finalizer((x) -> (run[] += 1; yield()))
-    garbage_finalizer((x) -> (run[] += 1; yieldto(@task () -> ())))
+    garbage_finalizer((x) -> (run[] += 1; schedule(@task () -> ()); yield()))
     t = @task begin
         GC.enable(true)
         GC.gc()

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -52,7 +52,7 @@ end
 
 let ct = current_task()
     # After a task switch, there should be nothing in catch_backtrace
-    yieldto(@task yieldto(ct))
+    Base._yieldto(@task Base._yieldto(ct))
     @test catch_backtrace() == StackFrame[]
 
     @noinline bad_function() = throw(UndefVarError(:nonexistent))

--- a/test/test_sourcepath.jl
+++ b/test/test_sourcepath.jl
@@ -4,14 +4,14 @@
 path = Base.source_path()::String # this variable is leaked to the source script
 @test endswith(path, joinpath("test","test_sourcepath.jl"))
 @test let ct = current_task()
-    yieldto(@task yieldto(ct, Base.source_path()))
+    Base._yieldto(@task Base._yieldto(ct, Base.source_path()))
 end == path
 @test let ct = current_task()
-    yieldto(@task schedule(ct, Base.source_path()))
+    Base._yieldto(@task schedule(ct, Base.source_path()))
 end == path
 @test let ct = current_task(), t = @task Base.source_path()
     schedule(ct)
-    yieldto(t)
+    Base._yieldto(t)
     fetch(t)
 end == path
 @test isabspath(@__FILE__)


### PR DESCRIPTION
The upcoming threading runtime (#22631) will not be able to support this function, since selecting tasks to run can and must only be done by the scheduler.