### PR TITLE
misc fixes that error's the doc build on --depwarn=error

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -20,7 +20,7 @@ representable in a given `AbstractChar` type.
 Internally, an `AbstractChar` type may use a variety of encodings.  Conversion
 via `codepoint(char)` will not reveal this encoding because it always returns the
 Unicode value of the character. `print(io, c)` of any `c::AbstractChar`
-produces an encoding determined by `io` (UTF-8 for all built-in [`IO`](@ref)
+produces an encoding determined by `io` (UTF-8 for all built-in `IO`
 types), via conversion to `Char` if necessary.
 
 `write(io, c)`, in contrast, may emit an encoding depending on

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -416,7 +416,7 @@ julia> i = 1
 
 julia> while i < 5
            println(i)
-           i += 1
+           global i += 1
        end
 1
 2

--- a/base/io.jl
+++ b/base/io.jl
@@ -33,7 +33,7 @@ buffer_writes(x::IO, bufsize=SZ_UNBUFFERED_IO) = x
 """
     isopen(object) -> Bool
 
-Determine whether an object - such as a stream, timer, or [`mmap`](@ref Mmap.mmap)
+Determine whether an object - such as a stream or timer
 -- is not yet closed. Once an object is closed, it will never produce a new event.
 However, since a closed stream may still have data to read in its buffer,
 use [`eof`](@ref) to check for the ability to read data.

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -91,8 +91,7 @@ Find the first occurrence of `pattern` in `string`. Equivalent to
 
 # Examples
 ```jldoctest
-julia> findfirst("z", "Hello to the world")
-0:-1
+julia> findfirst("z", "Hello to the world") # returns nothing, but not printed in the REPL
 
 julia> findfirst("Julia", "JuliaLang")
 1:5

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -147,7 +147,7 @@ for stdlib in STDLIB_DOCS
 end
 
 makedocs(
-    build     = joinpath(pwd(), "_build/html/en"),
+    build     = joinpath(@__DIR__, "_build/html/en"),
     modules   = [Base, Core, BuildSysImg, [Base.root_module(Base, stdlib.stdlib) for stdlib in STDLIB_DOCS]...],
     clean     = true,
     doctest   = "doctest" in ARGS,

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -245,7 +245,6 @@ Base.withenv
 Base.pipeline(::Any, ::Any, ::Any, ::Any...)
 Base.pipeline(::Base.AbstractCmd)
 Base.Libc.gethostname
-Base.getipaddr
 Base.Libc.getpid
 Base.Libc.time()
 Base.time_ns
@@ -291,7 +290,6 @@ Base.MissingException
 Core.OutOfMemoryError
 Core.ReadOnlyMemoryError
 Core.OverflowError
-Base.ParseError
 Core.StackOverflowError
 Base.SystemError
 Core.TypeError
@@ -336,6 +334,7 @@ Meta.lower
 Meta.@lower
 Meta.parse(::AbstractString, ::Int)
 Meta.parse(::AbstractString)
+Meta.ParseError
 Base.macroexpand
 Base.@macroexpand
 Base.@macroexpand1

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -203,8 +203,8 @@ Base.keys
 Base.values
 Base.pairs
 Base.merge
-Base.merge!(::Associative, ::Associative...)
-Base.merge!(::Function, ::Associative, ::Associative...)
+Base.merge!(::AbstractDict, ::AbstractDict...)
+Base.merge!(::Function, ::AbstractDict, ::AbstractDict...)
 Base.sizehint!
 Base.keytype
 Base.valtype

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -113,14 +113,13 @@ julia> Meta.lower(@__MODULE__, :(f() = 1) )
 
 Inspecting the lowered form for functions requires selection of the specific method to display,
 because generic functions may have many methods with different type signatures. For this purpose,
-method-specific code-lowering is available using [`code_lowered(f::Function, (Argtypes...))`](@ref),
-and the type-inferred form is available using [`code_typed(f::Function, (Argtypes...))`](@ref).
-[`code_warntype(f::Function, (Argtypes...))`](@ref) adds highlighting to the output of [`code_typed`](@ref)
-(see [`@code_warntype`](@ref)).
+method-specific code-lowering is available using [`code_lowered`](@ref),
+and the type-inferred form is available using [`code_typed`](@ref).
+[`code_warntype`](@ref) adds highlighting to the output of [`code_typed`](@ref).
 
 Closer to the machine, the LLVM intermediate representation of a function may be printed using
-by [`code_llvm(f::Function, (Argtypes...))`](@ref), and finally the compiled machine code is available
-using [`code_native(f::Function, (Argtypes...))`](@ref) (this will trigger JIT compilation/code
+by [`code_llvm`](@ref), and finally the compiled machine code is available
+using [`code_native`](@ref) (this will trigger JIT compilation/code
 generation for any function which has not previously been called).
 
 For convenience, there are macro versions of the above functions which take standard function
@@ -137,4 +136,5 @@ top:
 }
 ```
 
-(likewise `@code_typed`, `@code_warntype`, `@code_lowered`, and `@code_native`)
+See [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code_warntype`](@ref),
+[`@code_llvm`](@ref), and [`@code_native`](@ref).

--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -12,7 +12,7 @@ Please read the [release notes](NEWS.md) to see what has changed since the last 
 ## Manual
 
   * [Introduction](@ref man-introduction)
-  * [Getting Started](@ref)
+  * [Getting Started](@ref man-getting-started)
   * [Variables](@ref)
   * [Integers and Floating-Point Numbers](@ref)
   * [Mathematical Operations and Elementary Functions](@ref)

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -561,7 +561,7 @@ below all interrupt the normal flow of control.
 | [`RemoteException`](@ref)     |
 | [`MethodError`](@ref)         |
 | [`OverflowError`](@ref)       |
-| [`ParseError`](@ref)          |
+| [`Meta.ParseError`](@ref)     |
 | [`SystemError`](@ref)         |
 | [`TypeError`](@ref)           |
 | [`UndefRefError`](@ref)       |

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -97,7 +97,7 @@ respect to the working directory. If `$JULIA_PKGDIR` is not set, then
 $HOME/.julia
 ```
 
-Then the repository location [`Pkg.dir`](@ref) for a given Julia version is
+Then the repository location `Pkg.dir` for a given Julia version is
 
 ```
 $JULIA_PKGDIR/v$(VERSION.major).$(VERSION.minor)
@@ -128,7 +128,7 @@ $HOME/.julia_history
 ### `JULIA_PKGRESOLVE_ACCURACY`
 
 A positive `Int` that determines how much time the max-sum subroutine
-`MaxSum.maxsum()` of the package dependency resolver [`Base.Pkg.resolve`](@ref)
+`MaxSum.maxsum()` of the package dependency resolver `Pkg.resolve`
 will devote to attempting satisfying constraints before giving up: this value is
 by default `1`, and larger values correspond to larger amounts of time.
 
@@ -164,7 +164,7 @@ exists, or `emacs` otherwise.
 !!! note
 
     `$JULIA_EDITOR` is *not* used in the determination of the editor for
-    [`Base.Pkg.edit`](@ref): this function checks `$VISUAL` and `$EDITOR` alone.
+    `Pkg.edit`: this function checks `$VISUAL` and `$EDITOR` alone.
 
 ## Parallelization
 

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# [Getting Started](@id man-getting-started)
 
 Julia installation is straightforward, whether using precompiled binaries or compiling from source.
 Download and install Julia by following the instructions at [https://julialang.org/downloads/](https://julialang.org/downloads/).

--- a/doc/src/manual/index.md
+++ b/doc/src/manual/index.md
@@ -1,7 +1,7 @@
 # The Julia Manual
 
   * [Introduction](@ref man-introduction)
-  * [Getting Started](@ref)
+  * [Getting Started](@ref man-getting-started)
   * [Variables](@ref)
   * [Integers and Floating-Point Numbers](@ref)
   * [Mathematical Operations and Elementary Functions](@ref)

--- a/doc/src/manual/unicode-input.md
+++ b/doc/src/manual/unicode-input.md
@@ -19,7 +19,7 @@ the symbol).
 #
 # Generate a table containing all LaTeX and Emoji tab completions available in the REPL.
 #
-import REPL
+import REPL, Markdown
 const NBSP = '\u00A0'
 
 function tab_completions(symbols...)


### PR DESCRIPTION
Almost fixes the doc build with `--depwarn=error` and `strict = true`.