### PR TITLE
Corrected jl_type_infer when ENABLE_INFERENCE is not set

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -246,6 +246,8 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli, size_t world, int forc
     static int in_inference;
     if (in_inference > 2)
         return NULL;
+
+    jl_code_info_t *src = NULL;
 #ifdef ENABLE_INFERENCE
     jl_method_instance_t *li = *pli;
     if (li->inInference && !force)
@@ -273,7 +275,6 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli, size_t world, int forc
     in_inference--;
     li->inInference = 0;
 
-    jl_code_info_t *src = NULL;
     if (linfo_src_rettype &&
             jl_is_svec(linfo_src_rettype) && jl_svec_len(linfo_src_rettype) == 3 &&
             jl_is_method_instance(jl_svecref(linfo_src_rettype, 0)) &&


### PR DESCRIPTION
This corrects a bug whenever the debug flag `ENABLE_INFERENCE` is not set, by defining the return object `src` for the function `jl_type_infer`.