### PR TITLE
Comment on byte order for `read` and `write`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -170,13 +170,15 @@ You can write multiple values with the same `write` call. i.e. the following are
 # Examples
 Consistent serialization:
 ```jldoctest
-julia> open("/tmp/test.bin","w") do f
+julia> fname = tempname(); # random temporary filename
+
+julia> open(fname,"w") do f
            # Make sure we write 64bit integer in little-endian byte order
            write(f,htol(Int64(42)))
        end
 8
 
-julia> open("/tmp/test.bin","r") do f
+julia> open(fname,"r") do f
            # Convert back to host byte order and host integer type
            Int(ltoh(read(f,Int64)))
        end

--- a/base/io.jl
+++ b/base/io.jl
@@ -171,7 +171,7 @@ You can write multiple values with the same `write` call. i.e. the following are
 Consistent serialization:
 ```jldoctest
 julia> open("/tmp/test.bin","w") do f
-           # Make sure we write 64bit integer in Network (big-endian) byte order
+           # Make sure we write 64bit integer in little-endian byte order
            write(f,htol(Int64(42)))
        end
 8

--- a/base/io.jl
+++ b/base/io.jl
@@ -128,7 +128,7 @@ function eof end
 
 Read a single value of type `T` from `io`, in canonical binary representation.
 
-Note that Julia does not convert the endianess for you. Use [`ntoh`](@ref) or 
+Note that Julia does not convert the endianness for you. Use [`ntoh`](@ref) or 
 [`ltoh`](@ref) for this purpose. 
 
     read(io::IO, String)

--- a/base/io.jl
+++ b/base/io.jl
@@ -128,8 +128,8 @@ function eof end
 
 Read a single value of type `T` from `io`, in canonical binary representation.
 
-Note that Julia does not convert the endianness for you. Use [`ntoh`](@ref) or 
-[`ltoh`](@ref) for this purpose. 
+Note that Julia does not convert the endianness for you. Use [`ntoh`](@ref) or
+[`ltoh`](@ref) for this purpose.
 
     read(io::IO, String)
 
@@ -158,9 +158,9 @@ Write the canonical binary representation of a value to the given I/O stream or 
 Return the number of bytes written into the stream. See also [`print`](@ref) to
 write a text representation (with an encoding that may depend upon `io`).
 
-The endianness of the written value depends on the endianness of the host system. Use 
-[`hton`](@ref) when writing and [`ntoh`](@ref) when reading to get results that are 
-consistent across plattforms. 
+The endianness of the written value depends on the endianness of the host system. Use
+[`hton`](@ref) when writing and [`ntoh`](@ref) when reading to get results that are
+consistent across plattforms.
 
 You can write multiple values with the same `write` call. i.e. the following are equivalent:
 
@@ -183,7 +183,7 @@ julia> open("/tmp/test.bin","r") do f
 42
 ```
 
-Merging write calls: 
+Merging write calls:
 ```jldoctest
 julia> io = IOBuffer();
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -158,9 +158,9 @@ Write the canonical binary representation of a value to the given I/O stream or 
 Return the number of bytes written into the stream. See also [`print`](@ref) to
 write a text representation (with an encoding that may depend upon `io`).
 
-The endianness of the written value depends on the endianness of the host system. Use
-[`hton`](@ref) when writing and [`ntoh`](@ref) when reading to get results that are
-consistent across plattforms.
+The endianness of the written value depends on the endianness of the host system.
+Convert to/from a fixed endianness when writing/reading (e.g. using  [`htol`](@ref) and
+[`ltoh`](@ref)) to get results that are consistent across plattforms.
 
 You can write multiple values with the same `write` call. i.e. the following are equivalent:
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -128,6 +128,9 @@ function eof end
 
 Read a single value of type `T` from `io`, in canonical binary representation.
 
+Note that Julia does not convert the endianess for you. Use [`ntoh`](@ref) or 
+[`ltoh`](@ref) for this purpose. 
+
     read(io::IO, String)
 
 Read the entirety of `io`, as a `String`.
@@ -152,8 +155,12 @@ read(stream, t)
     write(filename::AbstractString, x)
 
 Write the canonical binary representation of a value to the given I/O stream or file.
-Return the number of bytes written into the stream.   See also [`print`](@ref) to
+Return the number of bytes written into the stream. See also [`print`](@ref) to
 write a text representation (with an encoding that may depend upon `io`).
+
+The endianness of the written value depends on the endianness of the host system. Use 
+[`hton`](@ref) when writing and [`ntoh`](@ref) when reading to get results that are 
+consistent across plattforms. 
 
 You can write multiple values with the same `write` call. i.e. the following are equivalent:
 
@@ -161,6 +168,22 @@ You can write multiple values with the same `write` call. i.e. the following are
     write(io, x) + write(io, y...)
 
 # Examples
+Consistent serialization:
+```jldoctest
+julia> open("/tmp/test.bin","w") do f
+           # Make sure we write 64bit integer in Network (big-endian) byte order
+           write(f,hton(Int64(42)))
+       end
+8
+
+julia> open("/tmp/test.bin","r") do f
+           # Convert back to host byte order and host integer type
+           Int(ntoh(read(f,Int64)))
+       end
+42
+```
+
+Merging write calls: 
 ```jldoctest
 julia> io = IOBuffer();
 

--- a/base/io.jl
+++ b/base/io.jl
@@ -172,13 +172,13 @@ Consistent serialization:
 ```jldoctest
 julia> open("/tmp/test.bin","w") do f
            # Make sure we write 64bit integer in Network (big-endian) byte order
-           write(f,hton(Int64(42)))
+           write(f,htol(Int64(42)))
        end
 8
 
 julia> open("/tmp/test.bin","r") do f
            # Convert back to host byte order and host integer type
-           Int(ntoh(read(f,Int64)))
+           Int(ltoh(read(f,Int64)))
        end
 42
 ```

--- a/base/io.jl
+++ b/base/io.jl
@@ -160,7 +160,7 @@ write a text representation (with an encoding that may depend upon `io`).
 
 The endianness of the written value depends on the endianness of the host system.
 Convert to/from a fixed endianness when writing/reading (e.g. using  [`htol`](@ref) and
-[`ltoh`](@ref)) to get results that are consistent across plattforms.
+[`ltoh`](@ref)) to get results that are consistent across platforms.
 
 You can write multiple values with the same `write` call. i.e. the following are equivalent:
 


### PR DESCRIPTION
Currently, the documentation says `read` and `write` work with the "canonical binary representation" of the value to be written, but it is frustratingly impossible to find out whether the "canonical" part includes specifying an endianness. It doesn't for all I know, but I'm still not 100% sure. This addition to the documentation should clarify things, I hope. 