### PR TITLE
Fix SparseVector broadcasting oddities

### DIFF
--- a/stdlib/SparseArrays/src/deprecated.jl
+++ b/stdlib/SparseArrays/src/deprecated.jl
@@ -229,6 +229,11 @@ import Base: asyncmap
 
 Base.@deprecate_binding blkdiag blockdiag
 
+@deprecate complex(x::AbstractSparseVector{<:Real}, y::AbstractSparseVector{<:Real}) complex.(x, y)
+@deprecate complex(x::AbstractVector{<:Real}, y::AbstractSparseVector{<:Real}) complex.(x, y)
+@deprecate complex(x::AbstractSparseVector{<:Real}, y::AbstractVector{<:Real}) complex.(x, y)
+
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/stdlib/SparseArrays/src/higherorderfns.jl
+++ b/stdlib/SparseArrays/src/higherorderfns.jl
@@ -163,12 +163,6 @@ end
     storedvals = Vector{entrytype}(undef, maxnnz)
     return SparseMatrixCSC(shape..., pointers, storedinds, storedvals)
 end
-# Ambiguity killers, TODO: nix conflicting specializations
-ambiguityfunnel(f::Tf, x, y) where {Tf} = _aresameshape(x, y) ? _noshapecheck_map(f, x, y) : _diffshape_broadcast(f, x, y)
-broadcast(::typeof(+), x::SparseVector, y::SparseVector) = ambiguityfunnel(+, x, y) # base/sparse/sparsevectors.jl:1266
-broadcast(::typeof(-), x::SparseVector, y::SparseVector) = ambiguityfunnel(-, x, y) # base/sparse/sparsevectors.jl:1266
-broadcast(::typeof(*), x::SparseVector, y::SparseVector) = ambiguityfunnel(*, x, y) # base/sparse/sparsevectors.jl:1266
-
 
 # (4) _map_zeropres!/_map_notzeropres! specialized for a single sparse vector/matrix
 "Stores only the nonzero entries of `map(f, Array(A))` in `C`."

--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -331,11 +331,6 @@ end
                 ((spargsl..., s, s, s, spargsr...), (dargsl..., s, s, s, dargsr...)), )
             # test broadcast entry point
             @test broadcast(*, sparseargs...) == sparse(broadcast(*, denseargs...))
-            if !isa(@inferred(broadcast(*, sparseargs...)), SparseMatrixCSC{elT})
-                @show map(typeof, sparseargs)
-                @show SparseMatrixCSC{elT}
-                @show typeof(broadcast(*, sparseargs...))
-            end
             @test isa(@inferred(broadcast(*, sparseargs...)), SparseMatrixCSC{elT})
             # test broadcast! entry point
             fX = broadcast(*, sparseargs...); X = sparse(fX)


### PR DESCRIPTION
Lots of SparseVector oddities fixed here, all by deleting code.  Previous behaviors that are now fixed include:

```julia
julia> spzeros(5) .* [1]
ERROR: DimensionMismatch("")
Stacktrace:
 [1] _binarymap(::typeof(*), ::SparseVector{Float64,Int64}, ::Array{Int64,1}, ::Int64) at /home/mbauman/julia-wip3/usr/share/julia/site/v0.7/SparseArrays/src/sparsevector.jl:1325
 [2] _vmul at /home/mbauman/julia-wip3/usr/share/julia/site/v0.7/SparseArrays/src/sparsevector.jl:1369 [inlined]
 [3] broadcast(::typeof(*), ::SparseVector{Float64,Int64}, ::Array{Int64,1}) at /home/mbauman/julia-wip3/usr/share/julia/site/v0.7/SparseArrays/src/sparsevector.jl:1388
 [4] top-level scope

julia> spzeros(5) .* ones(5)
5-element Array{Float64,1}:
 0.0
 0.0
 0.0
 0.0
 0.0

julia> spzeros(5) .* ones(5) .* 1 # this is correct, just demonstrating that the previous call is confusing
5-element SparseVector{Float64,Int64} with 0 stored entries
```

Those all now behave as you'd expect, returning a SparseVector in all cases.