### PR TITLE
increase MAX_INTERP_STATE_SIZE on armv7-l to 48

### DIFF
--- a/src/interpreter-stacktrace.c
+++ b/src/interpreter-stacktrace.c
@@ -257,7 +257,7 @@ asm(
 
 #elif defined(_CPU_ARM_)
 
-#define MAX_INTERP_STATE_SIZE 32
+#define MAX_INTERP_STATE_SIZE 48
 
 // Check that the interpreter state can fit
 static_assert(sizeof(interpreter_state) <= MAX_INTERP_STATE_SIZE,


### PR DESCRIPTION
fixes #26473
Build: https://build.julialang.org/#/builders/4/builds/803