### PR TITLE
Fix deprecation warning from LinearAlgebra.trace in sysimg

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -804,7 +804,7 @@ end
     @deprecate_stdlib svdvals!    LinearAlgebra true
     @deprecate_stdlib svdvals     LinearAlgebra true
     @deprecate_stdlib sylvester   LinearAlgebra true
-    @deprecate_stdlib trace       LinearAlgebra true
+    @deprecate_stdlib trace       LinearAlgebra true tr
     @deprecate_stdlib transpose!  LinearAlgebra true
     # @deprecate_stdlib transpose   LinearAlgebra true
     @deprecate_stdlib tril!       LinearAlgebra true


### PR DESCRIPTION
`trace` was renamed to `tr` in #26365 but the deprecation in sysimg was not updated, causing a warning when building Julia.