### PR TITLE
prohibit reserved-word module names

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1561,6 +1561,8 @@
         (let* ((name (parse-unary-prefix s))
                (loc  (line-number-node s))
                (body (parse-block s (lambda (s) (parse-docstring s parse-eq)))))
+          (if (reserved-word? name)
+              (error (string "invalid module name \"" name "\"")))
           (expect-end s word)
           (list 'module (if (eq? word 'module) 'true 'false) name
                 `(block ,loc ,@(cdr body)))))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1366,3 +1366,6 @@ end
 
 # issue #25994
 @test Meta.parse("[a\nfor a in b]") == Expr(:comprehension, Expr(:generator, :a, Expr(:(=), :a, :b)))
+
+# Module name cannot be a reserved word.
+@test_throws ParseError Meta.parse("module module end")


### PR DESCRIPTION
I'm a little bit surprised that this is not prohibited:
```
julia> module module end
Main.module

```

while this is prohibited:
```
julia> function function end
ERROR: syntax: invalid name "function"

```

This change makes it consistent.