### PR TITLE
disallow passing TypeVars to `<:`

### DIFF
--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -46,10 +46,10 @@ function get_argtypes(result::InferenceResult)
         for i = 1:laty
             atyp = atypes[i]
             if i == laty && isvarargtype(atyp)
-                atyp = unwrap_unionall(atyp).parameters[1]
+                atyp = unwrapva(atyp)
                 atail -= 1
             end
-            if isa(atyp, TypeVar)
+            while isa(atyp, TypeVar)
                 atyp = atyp.ub
             end
             if isa(atyp, DataType) && isdefined(atyp, :instance)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -436,13 +436,10 @@ end
 getfield_tfunc(@nospecialize(s00), @nospecialize(name), @nospecialize(inbounds)) =
     getfield_tfunc(s00, name)
 function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
-    if isa(s00, TypeVar)
-        s00 = s00.ub
-    end
     s = unwrap_unionall(s00)
     if isa(s, Union)
-        return tmerge(rewrap(getfield_tfunc(s.a, name),s00),
-                      rewrap(getfield_tfunc(s.b, name),s00))
+        return tmerge(getfield_tfunc(rewrap(s.a,s00), name),
+                      getfield_tfunc(rewrap(s.b,s00), name))
     elseif isa(s, Conditional)
         return Bottom # Bool has no fields
     elseif isa(s, Const) || isconstType(s)

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -66,8 +66,15 @@ function typesubtract(@nospecialize(a), @nospecialize(b))
     return a # TODO: improve this bound?
 end
 
+function tvar_extent(@nospecialize t)
+    while t isa TypeVar
+        t = t.ub
+    end
+    return t
+end
+
 function tuple_tail_elem(@nospecialize(init), ct)
-    return Vararg{widenconst(foldl((a, b) -> tmerge(a, unwrapva(b)), init, ct))}
+    return Vararg{widenconst(foldl((a, b) -> tmerge(a, tvar_extent(unwrapva(b))), init, ct))}
 end
 
 # t[n:end]

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -210,7 +210,7 @@ end
 isvatuple(t::DataType) = (n = length(t.parameters); n > 0 && isvarargtype(t.parameters[n]))
 function unwrapva(@nospecialize(t))
     t2 = unwrap_unionall(t)
-    isvarargtype(t2) ? t2.parameters[1] : t
+    isvarargtype(t2) ? rewrap_unionall(t2.parameters[1],t) : t
 end
 
 typename(a) = error("typename does not apply to this type")

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -409,8 +409,6 @@ JL_CALLABLE(jl_f_issubtype)
 {
     JL_NARGS(<:, 2, 2);
     jl_value_t *a = args[0], *b = args[1];
-    if (jl_is_typevar(a)) a = ((jl_tvar_t*)a)->ub; // TODO should we still allow this?
-    if (jl_is_typevar(b)) b = ((jl_tvar_t*)b)->ub;
     JL_TYPECHK(<:, type, a);
     JL_TYPECHK(<:, type, b);
     return (jl_subtype(a,b) ? jl_true : jl_false);

--- a/test/core.jl
+++ b/test/core.jl
@@ -24,6 +24,9 @@ f47(x::Vector{Vector{T}}) where {T} = 0
 @test_throws TypeError (Array{T} where T<:Vararg{Int})
 @test_throws TypeError (Array{T} where T<:Vararg{Int,2})
 
+@test_throws TypeError TypeVar(:T) <: Any
+@test_throws TypeError TypeVar(:T) >: Any
+
 # issue #12939
 module Issue12939
 abstract type Abs; end


### PR DESCRIPTION
TypeVars are not types and so should not be allowed here. We needed this early in 0.6 to ease the transition, but I believe we've by now fixed almost all of our type-slinging code to avoid invalid queries like these.

A more urgent reason to fix this came up recently on slack:

```
julia> struct Foo{T<:Number} <: AbstractArray{T<:Number,1}
       end

julia> supertype(Foo)
AbstractArray{true,1}
```

This is a natural thing to try to write. With this change you get an error instead.