### PR TITLE
Fix error in cglobal expressions created by macro with escaped literals

### DIFF
--- a/src/ccalltest.c
+++ b/src/ccalltest.c
@@ -978,3 +978,6 @@ JL_DLLEXPORT int threadcall_args(int a, int b) {
 JL_DLLEXPORT void c_exit_finalizer(void* v) {
     printf("c_exit_finalizer: %d, %u", *(int*)v, (unsigned)((uintptr_t)v & (uintptr_t)1));
 }
+
+// global variable for cglobal testing
+JL_DLLEXPORT const int global_var = 1;

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -286,7 +286,7 @@
    m parent-scope inarg))
 
 (define (resolve-expansion-vars- e env m parent-scope inarg)
-  (cond ((or (eq? e 'true) (eq? e 'false) (eq? e 'end) (eq? e 'ccall))
+  (cond ((or (eq? e 'true) (eq? e 'false) (eq? e 'end) (eq? e 'ccall) (eq? e 'cglobal))
          e)
         ((symbol? e)
          (let ((a (assq e env)))

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1321,7 +1321,7 @@ end
 #   test that the first argument to cglobal is recognized as a tuple literal even through
 #   macro expansion
 macro cglobal26297(sym)
-    :(cglobal(($(esc(sym)), "libccalltest"), Cint))
+    :(cglobal(($(esc(sym)), libccalltest), Cint))
 end
 cglobal26297() = @cglobal26297(:global_var)
 @test cglobal26297() != C_NULL

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1316,3 +1316,12 @@ function caller22734(ptr)
     ccall(ptr, Float64, (Ref{Abstract22734},), obj)
 end
 @test caller22734(ptr22734) === 32.0
+
+# 26297#issuecomment-371165725
+#   test that the first argument to cglobal is recognized as a tuple literal even through
+#   macro expansion
+macro cglobal26297(sym)
+    :(cglobal(($(esc(sym)), "libccalltest"), Cint))
+end
+cglobal26297() = @cglobal26297(:global_var)
+@test cglobal26297() != C_NULL


### PR DESCRIPTION
In [#26297 (#issuecomment-371165725)](https://github.com/JuliaLang/julia/issues/26297#issuecomment-371165725), I made reference to a problem with `cglobal` expressions created by macros — as PyCall uses — on master. This PR is a [naive] attempt at fixing that issue (which I think ends up being distinct from the original error being reported in #26297).

**I don't actually know lisp** so this is mostly just guessing, but some time spent with git grep and combinations of `@code_lowered` and `Meta.expand()`, I maybe lucked in to a solution. 

With this (plus a _lot_ of patience — see #26357) I was actually able to get a PyPlot window to show on master!

Before:
```julia
julia> @code_typed cglobal26297()
CodeInfo(:(begin
      Core.SSAValue(0) = (Core.tuple)(:global_var, "libccalltest")::Tuple{Symbol,String}
      Core.SSAValue(1) = (Main.cglobal)(Core.SSAValue(0), Main.Cint)::Ptr{Int32}
      return Core.SSAValue(1)
  end)) => Ptr{Int32}
```

After:
```julia
julia> @code_typed cglobal26297()
CodeInfo(:(begin 
        return (Main.cglobal)((Core.tuple)(:global_var, "libccalltest")::Tuple{Symbol,String}, Main.Cint)::Ptr{Int32}
    end))=>Ptr{Int32}
```