### PR TITLE
 WIP: [NewOptimizer] Rewrite inlining pass for new optimizer

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -837,7 +837,8 @@ function abstract_eval_global(M::Module, s::Symbol)
 end
 
 function abstract_eval_ssavalue(s::SSAValue, src::CodeInfo)
-    typ = src.ssavaluetypes[s.id + 1]
+    new_style_ir = src.codelocs !== nothing
+    typ = src.ssavaluetypes[new_style_ir ? s.id : (s.id + 1)]
     if typ === NOT_FOUND
         return Bottom
     end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -263,7 +263,7 @@ function isinlineable(m::Method, src::CodeInfo, mod::Module, params::Params, bon
     return inlineable
 end
 
-const enable_new_optimizer = RefValue(false)
+const enable_new_optimizer = RefValue(true)
 
 # converge the optimization work
 function optimize(me::InferenceState)

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -12,8 +12,10 @@ include("compiler/ssair/domtree.jl")
 include("compiler/ssair/slot2ssa.jl")
 include("compiler/ssair/queries.jl")
 include("compiler/ssair/passes.jl")
+include("compiler/ssair/inlining2.jl")
 include("compiler/ssair/verify.jl")
 include("compiler/ssair/legacy.jl")
+
 
 macro show(s)
     # return :(println($(QuoteNode(s)), " = ", $(esc(s))))
@@ -88,55 +90,61 @@ function normalize(@nospecialize(stmt), meta::Vector{Any}, table::Vector{LineInf
     return stmt
 end
 
-function run_passes(ci::CodeInfo, nargs::Int, linetable::Vector{LineInfoNode})
+function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, linetable::Vector{LineInfoNode})
     mod = linetable[1].mod
-    ci.code = copy(ci.code)
     # Go through and add an unreachable node after every
     # Union{} call. Then reindex labels.
     idx = 1
-    while idx <= length(ci.code)
-        stmt = ci.code[idx]
+    while idx <= length(code)
+        stmt = code[idx]
         if isexpr(stmt, :(=))
             stmt = stmt.args[2]
         end
         if isa(stmt, Expr) && stmt.typ === Union{}
-            if !(idx < length(ci.code) && isexpr(ci.code[idx+1], :unreachable))
-                insert!(ci.code, idx + 1, ReturnNode())
+            if !(idx < length(code) && isexpr(code[idx+1], :unreachable))
+                insert!(code, idx + 1, ReturnNode())
                 idx += 1
             end
         end
         idx += 1
     end
-    reindex_labels!(ci.code)
+    reindex_labels!(code)
     meta = Any[]
-    lines = fill(0, length(ci.code))
+    lines = fill(0, length(code))
     let loc = RefValue(1)
-        for i = 1:length(ci.code)
-            stmt = ci.code[i]
+        for i = 1:length(code)
+            stmt = code[i]
             stmt = normalize(stmt, meta, linetable, loc)
-            ci.code[i] = stmt
+            code[i] = stmt
             if !(stmt === nothing)
                 lines[i] = loc[]
             end
         end
     end
-    ci.code = strip_trailing_junk!(ci.code, lines)
-    cfg = compute_basic_blocks(ci.code)
-    defuse_insts = scan_slot_def_use(nargs, ci)
-    domtree = construct_domtree(cfg)
-    ir = let code = Any[nothing for _ = 1:length(ci.code)]
+    code = strip_trailing_junk!(code, lines)
+    cfg = compute_basic_blocks(code)
+    defuse_insts = scan_slot_def_use(nargs, ci, code)
+    @timeit "domtree 1" domtree = construct_domtree(cfg)
+    ir = let code = Any[nothing for _ = 1:length(code)]
              argtypes = ci.slottypes[1:(nargs+1)]
             IRCode(code, lines, cfg, argtypes, mod, meta)
         end
-    ir = construct_ssa!(ci, ir, domtree, defuse_insts, nargs)
+    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs)
+    return ir
+end
+
+function run_passes(ci::CodeInfo, nargs::Int, linetable::Vector{LineInfoNode}, sv::OptimizationState)
+    ir = just_construct_ssa(ci, copy(ci.code), nargs, linetable)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
-    domtree = construct_domtree(ir.cfg)
-    ir = compact!(ir)
-    verify_ir(ir)
-    ir = getfield_elim_pass!(ir, domtree)
-    ir = compact!(ir)
-    ir = type_lift_pass!(ir)
-    ir = compact!(ir)
-    verify_ir(ir)
+    @timeit "compact 1" ir = compact!(ir)
+    @timeit "verify 1" verify_ir(ir)
+    @timeit "Inlining" ir = ssa_inlining_pass!(ir, nothing, linetable, sv)
+    @timeit "verify 2" verify_ir(ir)
+    @timeit "domtree 2" domtree = construct_domtree(ir.cfg)
+    @timeit "SROA" ir = getfield_elim_pass!(ir, domtree)
+    @timeit "compact 2" ir = compact!(ir)
+    @timeit "type lift" ir = type_lift_pass!(ir)
+    @timeit "compact 3" ir = compact!(ir)
+    @timeit "verify 3" verify_ir(ir)
     return ir
 end

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -544,12 +544,15 @@ function assemble_inline_todo!(ir, domtree, linetable, sv)
             ast = copy_exprargs(src.code)
         end
 
-        topline = LineInfoNode(method.module, method.name, method.file, method.line, 0)
-        inline_linetable = [topline]
-
-        push!(ast, LabelNode(length(ast) + 1))
-        ir2 = just_construct_ssa(src, ast, na-1, inline_linetable)
-        verify_ir(ir2)
+        if src.codelocs === nothing
+            topline = LineInfoNode(method.module, method.name, method.file, method.line, 0)
+            inline_linetable = [topline]
+            push!(ast, LabelNode(length(ast) + 1))
+            ir2 = just_construct_ssa(src, ast, na-1, inline_linetable)
+        else
+            ir2, inline_linetable = inflate_ir(src), src.linetable
+        end
+        #verify_ir(ir2)
 
         push!(todo, (idx, (isva, isinvoke, isapply, na), method, Any[methsp...], inline_linetable, ir2, linear_inline_eligible(ir2)))
     end

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -1,0 +1,648 @@
+function ssa_inlining_pass!(ir::IRCode, domtree, linetable, sv::OptimizationState)
+    # Go through the function, perfoming simple ininlingin (e.g. replacing call by constants
+    # and analyzing legality of inlining).
+    todo = assemble_inline_todo!(ir, domtree, linetable, sv)
+    isempty(todo) && return ir
+    # Do the actual inlining for every call we identified
+    return batch_inline!(todo, ir, domtree, linetable, sv)
+end
+
+function batch_inline!(todo, ir, domtree, linetable, sv)
+    # Compute the new CFG first (modulo statement ranges, which will be computed below)
+    new_cfg_blocks = BasicBlock[]
+    inserted_block_ranges = UnitRange{Int}[]
+    todo_bbs = Tuple{Int, Int}[]
+    first_bb = 0
+    bb_rename = zeros(Int, length(ir.cfg.blocks))
+    split_targets = IdSet{Int}()
+    merged_orig_blocks = IdSet{Int}()
+    for (idx, _a, _b, _c, _d, ir2, lie) in todo
+        # A linear inline does not modify the CFG
+        lie && continue
+        # Figure out if we need to split the BB
+        need_split_before = false
+        need_split = true
+        block = block_for_inst(ir.cfg, idx)
+        last_block_idx = last(ir.cfg.blocks[block].stmts)
+
+        if !isempty(ir2.cfg.blocks[1].preds)
+            need_split_before = true
+        end
+
+        if first_bb != block
+            new_range = first_bb+1:block
+            bb_rename[new_range] = (1:length(new_range)) .+ length(new_cfg_blocks)
+            append!(new_cfg_blocks, map(copy, ir.cfg.blocks[new_range]))
+            push!(merged_orig_blocks, last(new_range))
+        end
+        first_bb = block
+        if false # TODO: ((idx+1) == last_block_idx && isa(ir[SSAValue(last_block_idx)], GotoNode))
+            need_split = false
+            post_bb_id = -ir[SSAValue(last_block_idx)].label
+        else
+            post_bb_id = length(new_cfg_blocks) + length(ir2.cfg.blocks) + (need_split_before ? 1 : 0)
+            need_split = true #!(idx == last_block_idx)
+        end
+
+        if !need_split
+            delete!(merged_orig_blocks, last(new_range))
+        end
+
+        push!(todo_bbs, (length(new_cfg_blocks) - 1 + (need_split_before ? 1 : 0), post_bb_id))
+
+        delete!(split_targets, length(new_cfg_blocks))
+        orig_succs = copy(new_cfg_blocks[end].succs)
+        empty!(new_cfg_blocks[end].succs)
+        if need_split_before
+            bb_rename_range = (1:length(ir2.cfg.blocks)) .+ length(new_cfg_blocks)
+            push!(new_cfg_blocks[end].succs, length(new_cfg_blocks)+1)
+            append!(new_cfg_blocks, ir2.cfg.blocks)
+        else
+            # Merge the last block that was already there with the first block we're adding
+            bb_rename_range = (1:length(ir2.cfg.blocks)) .+ (length(new_cfg_blocks) - 1)
+            append!(new_cfg_blocks[end].succs, ir2.cfg.blocks[1].succs)
+            append!(new_cfg_blocks, ir2.cfg.blocks[2:end])
+        end
+        if need_split
+            push!(new_cfg_blocks, BasicBlock(ir.cfg.blocks[block].stmts,
+                Int[], orig_succs))
+            push!(split_targets, length(new_cfg_blocks))
+        end
+        new_block_range = (length(new_cfg_blocks)-length(ir2.cfg.blocks)+1):length(new_cfg_blocks)
+        push!(inserted_block_ranges, new_block_range)
+
+        # Fixup the edges of the newely added blocks
+        for (old_block, new_block) in enumerate(bb_rename_range)
+            if old_block != 1 || need_split_before
+                p = new_cfg_blocks[new_block].preds
+                map!(p, p) do old_pred_block
+                    bb_rename_range[old_pred_block]
+                end
+            end
+            if new_block != last(new_block_range)
+                s = new_cfg_blocks[new_block].succs
+                map!(s, s) do old_succ_block
+                    bb_rename_range[old_succ_block]
+                end
+            end
+        end
+
+        if need_split_before
+            push!(new_cfg_blocks[first(bb_rename_range)].preds, first(bb_rename_range)-1)
+        end
+
+        for (old_block, new_block) in enumerate(bb_rename_range)
+            if (length(new_cfg_blocks[new_block].succs) == 0)
+                terminator_idx = last(ir2.cfg.blocks[old_block].stmts)
+                terminator = ir2[SSAValue(terminator_idx)]
+                if isa(terminator, ReturnNode) && isdefined(terminator, :val)
+                    push!(new_cfg_blocks[new_block].succs, post_bb_id)
+                    if need_split
+                        push!(new_cfg_blocks[post_bb_id].preds, new_block)
+                    end
+                end
+            end
+        end
+    end
+    new_range = first_bb+1:length(ir.cfg.blocks)
+    bb_rename[new_range] = (1:length(new_range)) .+ length(new_cfg_blocks)
+    append!(new_cfg_blocks, ir.cfg.blocks[new_range])
+
+    # Rename edges original bbs
+    for (orig_bb, bb) in pairs(bb_rename)
+        p, s = new_cfg_blocks[bb].preds, new_cfg_blocks[bb].succs
+        map!(p, p) do pred_bb
+            pred_bb == length(bb_rename) && return length(new_cfg_blocks)
+            bb_rename[pred_bb+1]-1
+        end
+        if !(orig_bb in merged_orig_blocks)
+            map!(s, s) do succ_bb
+                bb_rename[succ_bb]
+            end
+        end
+    end
+
+    for bb in collect(split_targets)
+        s = new_cfg_blocks[bb].succs
+        map!(s, s) do succ_bb
+            bb_rename[succ_bb]
+        end
+    end
+
+    # Rename any annotated original bb references
+    for bb in 1:length(new_cfg_blocks)
+        s = new_cfg_blocks[bb].succs
+        map!(s, s) do succ_bb
+            succ_bb < 0 ? bb_rename[-succ_bb] : succ_bb
+        end
+    end
+
+    compact = IncrementalCompact(ir)
+    compact.result_bbs = new_cfg_blocks
+    nnewnodes = length(compact.result) + sum(todo) do (_a, _b, _c, _d, _e, ir2, _f)
+        length(ir2.stmts) + length(ir2.new_nodes)
+    end
+    resize!(compact, nnewnodes)
+    (inline_idx, (isva, isinvoke, na), method, spvals, inline_linetable, inline_ir, lie) = popfirst!(todo)
+    for (idx, stmt) in compact
+        if compact.idx-1 == inline_idx
+            # Ok, do the inlining here
+            inline_cfg = inline_ir.cfg
+            linetable_offset = length(linetable)
+            # Append the linetable of the inlined function to our line table
+            for entry in inline_linetable
+                push!(linetable, LineInfoNode(entry.mod, entry.method, entry.file, entry.line, compact.result_lines[idx]))
+            end
+            # If the iterator already moved on to the next basic block,
+            # temorarily re-open in again.
+            refinish = false
+            if compact.result_idx == first(compact.result_bbs[compact.active_result_bb].stmts)
+                compact.active_result_bb -= 1
+                refinish = true
+            end
+            argexprs = copy(stmt.args)
+            if isinvoke
+                argexpr0 = argexprs[2]
+                argexprs = argexprs[4:end]
+                pushfirst!(argexprs, argexpr0)
+            end
+            if isva
+                vararg = mk_tuplecall!(compact, argexprs[na:end], compact.result_lines[idx])
+                argexprs = Any[argexprs[1:(na - 1)]..., vararg]
+            end
+            # At the moment we will allow globalrefs in argument position, turn those into ssa values
+            for (aidx, aexpr) in pairs(argexprs)
+                if isa(aexpr, GlobalRef)
+                    argexprs[aidx] = insert_node_here!(compact, aexpr, compact_exprtype(compact, aexpr), compact.result_lines[idx])
+                end
+            end
+            # Special case inlining that maintains the current basic block if there's only one BB in the target
+            if lie
+                terminator = inline_ir[SSAValue(last(inline_cfg.blocks[1].stmts))]
+                compact[idx] = nothing
+                inline_compact = IncrementalCompact(compact, inline_ir, compact.result_idx)
+                for (idx′, stmt′) in inline_compact
+                    # This dance is done to maintain accurate usage counts in the
+                    # face of rename_arguments! mutating in place - should figure out
+                    # something better eventually.
+                    inline_compact[idx′] = nothing
+                    stmt′ = ssa_substitute!(stmt′, argexprs, method.sig, spvals)
+                    compact.result_lines[idx′] += linetable_offset
+                    if isa(stmt′, ReturnNode)
+                        isa(stmt′.val, SSAValue) && (compact.used_ssas[stmt′.val.id] += 1)
+                        compact.ssa_rename[compact.idx-1] = stmt′.val
+                        stmt′ = nothing
+                    end
+                    inline_compact[idx′] = stmt′
+                end
+                just_fixup!(inline_compact)
+                compact.result_idx = inline_compact.result_idx
+                refinish && finish_current_bb!(compact)
+            else
+                bb_offset, post_bb_id = popfirst!(todo_bbs)
+                # This implements the need_split_before flag above
+                need_split_before = !isempty(inline_ir.cfg.blocks[1].preds)
+                if need_split_before
+                    finish_current_bb!(compact)
+                end
+                pn = PhiNode()
+                compact[idx] = nothing
+                inline_compact = IncrementalCompact(compact, inline_ir, compact.result_idx)
+                for (idx′, stmt′) in inline_compact
+                    inline_compact[idx′] = nothing
+                    stmt′ = ssa_substitute!(stmt′, argexprs, method.sig, spvals)
+                    compact.result_lines[idx′] += linetable_offset
+                    if isa(stmt′, ReturnNode)
+                        if isdefined(stmt′, :val)
+                            push!(pn.edges, inline_compact.active_result_bb-1)
+                            push!(pn.values, stmt′.val)
+                            stmt′ = GotoNode(post_bb_id)
+                        end
+                    elseif isa(stmt′, GotoNode)
+                        stmt′ = GotoNode(stmt′.label + bb_offset)
+                    elseif isa(stmt′, GotoIfNot)
+                        stmt′ = GotoIfNot(stmt′.cond, stmt′.dest + bb_offset)
+                    elseif isa(stmt′, PhiNode)
+                        stmt′ = PhiNode(Any[edge+bb_offset for edge in stmt′.edges], stmt′.values)
+                    end
+                    inline_compact[idx′] = stmt′
+                end
+                just_fixup!(inline_compact)
+                compact.result_idx = inline_compact.result_idx
+                compact.active_result_bb = inline_compact.active_result_bb
+                for i = 1:length(pn.values)
+                    isassigned(pn.values, i) || continue
+                    if isa(pn.values[i], SSAValue)
+                        compact.used_ssas[pn.values[i].id] += 1
+                    end
+                end
+                if length(pn.edges) == 1
+                    compact.ssa_rename[compact.idx-1] = pn.values[1]
+                else
+                    pn_ssa = insert_node_here!(compact, pn, stmt.typ, compact.result_lines[idx])
+                    compact.ssa_rename[compact.idx-1] = pn_ssa
+                end
+                refinish && finish_current_bb!(compact)
+            end
+            if !isempty(todo)
+                (inline_idx, (isva, isinvoke, na), method, spvals, inline_linetable, inline_ir, lie) = popfirst!(todo)
+            else
+                inline_idx = -1
+            end
+        elseif isa(stmt, GotoNode)
+            compact[idx] = GotoNode(bb_rename[stmt.label])
+        elseif isa(stmt, GotoIfNot)
+            compact[idx] = GotoIfNot(stmt.cond, bb_rename[stmt.dest])
+        elseif isa(stmt, PhiNode)
+            compact[idx] = PhiNode(Any[edge == length(bb_rename) ? length(new_cfg_blocks) : bb_rename[edge+1]-1 for edge in stmt.edges], stmt.values)
+        end
+    end
+
+    ir = finish(compact)
+end
+
+function assemble_inline_todo!(ir, domtree, linetable, sv)
+    todo = Tuple{Int, Tuple{Bool, Bool, Int}, Method, Vector{Any}, Vector{LineInfoNode}, IRCode, Bool}[]
+    for (idx, stmt) in pairs(ir.stmts)
+        isexpr(stmt, :call) || continue
+        eargs = stmt.args
+        isempty(eargs) && continue
+        arg1 = eargs[1]
+
+        ft = exprtype(arg1, ir, ir.mod)
+        if isa(ft, Const)
+            f = ft.val
+        elseif isa(ft, Conditional)
+            f = nothing
+            ft = Bool
+        else
+            f = nothing
+            if !(isconcretetype(ft) || (widenconst(ft) <: Type)) || has_free_typevars(ft)
+                # TODO: this is really aggressive at preventing inlining of closures. maybe drop `isconcretetype` requirement?
+                continue
+            end
+        end
+
+        atypes = Vector{Any}(undef, length(stmt.args))
+        atypes[1] = ft
+        ok = true
+        for i = 2:length(stmt.args)
+            a = exprtype(stmt.args[i], ir, ir.mod)
+            (a === Bottom || isvarargtype(a)) && (ok = false; break)
+            atypes[i] = a
+        end
+        ok || continue
+
+        # Check if we match any of the early inliners
+        res = early_inline_special_case(ir, f, ft, stmt, atypes)
+        if res !== nothing
+            ir.stmts[idx] = res[1]
+            continue
+        end
+
+        if f !== Core.invoke && (isa(f, IntrinsicFunction) || ft ⊑ IntrinsicFunction || isa(f, Builtin) || ft ⊑ Builtin)
+            # No inlining for builtins (other than what's handled in the early inliner)
+            continue
+        end
+
+        # Handle invoke
+        invoke_data = nothing
+        if f === Core.invoke && length(atypes) >= 3
+            res = compute_invoke_data(atypes, stmt.args, sv)
+            res === nothing && continue
+            (f, ft, atypes, argexprs, invoke_data) = res
+        end
+        isinvoke = invoke_data !== nothing
+
+        atype_unlimited = argtypes_to_type(atypes)
+
+        # In :invoke, make sure that the arguments we're passing are a subtype of the
+        # signature we're invoking.
+        (invoke_data === nothing || atype_unlimited <: invoke_data.types0) || continue
+
+        # TODO: Bail out here if inlining is disabled
+
+        # Special case inliners for regular functions
+        if late_inline_special_case!(ir, idx, stmt, atypes, f, ft, _topmod(ir.mod))
+            continue
+        end
+
+        # Compute the limited type if necessary
+        if length(atype_unlimited.parameters) - 1 > sv.params.MAX_TUPLETYPE_LEN
+            atype = limit_tuple_type(atype_unlimited, sv.params)
+        else
+            atype = atype_unlimited
+        end
+
+        # Ok, now figure out what method to call
+        if invoke_data === nothing
+            min_valid = UInt[typemin(UInt)]
+            max_valid = UInt[typemax(UInt)]
+            meth = _methods_by_ftype(atype, 1, sv.params.world, min_valid, max_valid)
+            if meth === false || length(meth) != 1
+                # TODO: Turn into :invoke
+                continue
+            end
+            meth = meth[1]::SimpleVector
+            metharg = meth[1]::Type
+            methsp = meth[2]::SimpleVector
+            method = meth[3]::Method
+        else
+            method = invoke_data.entry.func
+            (metharg, methsp) = ccall(:jl_type_intersection_with_env, Any, (Any, Any),
+                                    atype_unlimited, method.sig)::SimpleVector
+            methsp = methsp::SimpleVector
+        end
+
+        methsig = method.sig
+        if !(atype <: metharg)
+            # TODO: Turn this call into :invoke
+            continue
+        end
+
+        # Check whether this call just evaluates to a constant
+        if isa(f, widenconst(ft)) && !isdefined(method, :generator) && method.pure &&
+                isa(stmt.typ, Const) && stmt.typ.actual && is_inlineable_constant(stmt.typ.val)
+            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+            continue
+        end
+
+        # Check that we habe the correct number of arguments
+        na = Int(method.nargs)
+        npassedargs = length(stmt.args)
+        isinvoke && (npassedargs -= 2)
+        if na != npassedargs && !(na > 0 && method.isva)
+            # we have a method match only because an earlier
+            # inference step shortened our call args list, even
+            # though we have too many arguments to actually
+            # call this function
+            continue
+        end
+
+        # Bail out if any static parameters are left as TypeVar
+        ok = true
+        for i = 1:length(methsp)
+            isa(methsp[i], TypeVar) && (ok = false; break)
+        end
+        ok || continue
+
+        # Find the linfo for this methods (Generated functions are expanded here if necessary)
+        linfo = code_for_method(method, metharg, methsp, sv.params.world, true) # Union{Nothing, MethodInstance}
+        if !isa(linfo, MethodInstance)
+            # TODO: Turn into invoke
+            continue
+        end
+
+        if linfo.jlcall_api == 2
+            # in this case function can be inlined to a constant
+            add_backedge!(linfo, sv)
+            ir[SSAValue(idx)] = linfo.inferred_const
+            continue
+        end
+
+        # Handle vararg functions
+        isva = na > 0 && method.isva
+        if isva
+            @assert length(atypes) >= na - 1
+            va_type = tuple_tfunc(Tuple{Any[widenconst(exprtype(x, ir, ir.mod)) for x in stmt.args[na:end]]...})
+            atypes = Any[atypes[1:(na - 1)]..., va_type]
+        end
+
+        # Go see if we already have a pre-inferred result
+        res = find_inferred!(ir, idx, linfo, atypes, sv)
+        res === nothing && continue
+
+        (rettype, inferred) = res
+
+        # TODO: Inline as :invoke
+        inferred !== nothing || continue
+
+        src_inferred = ccall(:jl_ast_flag_inferred, Bool, (Any,), inferred)
+        src_inlineable = ccall(:jl_ast_flag_inlineable, Bool, (Any,), inferred)
+
+        # TODO: Inline as :invoke
+        (src_inferred && src_inlineable) || continue
+
+        # At this point we're committedd to performing the inlining, add the backedge
+        add_backedge!(linfo, sv)
+
+        if isa(inferred, CodeInfo)
+            src = inferred
+            ast = copy_exprargs(inferred.code)
+        else
+            src = ccall(:jl_uncompress_ast, Any, (Any, Any), method, inferred::Vector{UInt8})::CodeInfo
+            # TODO: It seems like PhiNodes are shared between compressed codeinfos, making this copy necessary
+            ast = copy_exprargs(src.code)
+        end
+
+        topline = LineInfoNode(method.module, method.name, method.file, method.line, 0)
+        inline_linetable = [topline]
+
+        push!(ast, LabelNode(length(ast) + 1))
+        ir2 = just_construct_ssa(src, ast, na-1, inline_linetable)
+        verify_ir(ir2)
+
+
+        push!(todo, (idx, (isva, isinvoke, na), method, Any[methsp...], inline_linetable, ir2, linear_inline_eligible(ir2)))
+    end
+    todo
+end
+
+function mk_tuplecall!(compact, args, line_idx)
+    e = Expr(:call, TOP_TUPLE, args...)
+    e.typ = tuple_tfunc(Tuple{Any[widenconst(compact_exprtype(compact, x)) for x in args]...})
+    return insert_node_here!(compact, e, e.typ, line_idx)
+end
+
+function linear_inline_eligible(ir)
+    length(ir.cfg.blocks) == 1 || return false
+    terminator = ir[SSAValue(last(ir.cfg.blocks[1].stmts))]
+    isa(terminator, ReturnNode) || return false
+    isdefined(terminator, :val) || return false
+    return true
+end
+
+function compute_invoke_data(atypes, argexprs, sv)
+    ft = widenconst(atypes[2])
+    invoke_tt = widenconst(atypes[3])
+    if !(isconcretetype(ft) || ft <: Type) || !isType(invoke_tt) ||
+            has_free_typevars(invoke_tt) || has_free_typevars(ft) || (ft <: Builtin)
+        # TODO: this is really aggressive at preventing inlining of closures. maybe drop `isconcretetype` requirement?
+        return nothing
+    end
+    if !(isa(invoke_tt.parameters[1], Type) &&
+            invoke_tt.parameters[1] <: Tuple)
+        return nothing
+    end
+    invoke_tt = invoke_tt.parameters[1]
+    invoke_types = rewrap_unionall(Tuple{ft, unwrap_unionall(invoke_tt).parameters...}, invoke_tt)
+    invoke_entry = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt),
+                            invoke_types, sv.params.world)
+    invoke_entry === nothing && return nothing
+    invoke_data = InvokeData(ft.name.mt, invoke_entry,
+                             invoke_types, nothing, nothing)
+    atype0 = atypes[2]
+    argexpr0 = argexprs[2]
+    atypes = atypes[4:end]
+    argexprs = argexprs[4:end]
+    pushfirst!(atypes, atype0)
+    pushfirst!(argexprs, argexpr0)
+    f = isdefined(ft, :instance) ? ft.instance : nothing
+    (f, ft, atypes, argexprs, invoke_data)
+end
+
+function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector{Any})
+    if (f === typeassert || ft ⊑ typeof(typeassert)) && length(atypes) == 3
+        # typeassert(x::S, T) => x, when S<:T
+        a3 = atypes[3]
+        if (isType(a3) && !has_free_typevars(a3) && atypes[2] ⊑ a3.parameters[1]) ||
+            (isa(a3, Const) && isa(a3.val, Type) && atypes[2] ⊑ a3.val)
+            return (e.args[2],)
+        end
+    end
+    topmod = _topmod(ir.mod)
+    # special-case inliners for known pure functions that compute types
+    if true #sv.params.inlining
+        if isa(e.typ, Const) # || isconstType(e.typ)
+            val = e.typ.val
+            if (f === apply_type || f === fieldtype || f === typeof || f === (===) ||
+                f === Core.sizeof || f === isdefined ||
+                istopfunction(topmod, f, :typejoin) ||
+                istopfunction(topmod, f, :isbits) ||
+                istopfunction(topmod, f, :promote_type) ||
+                (f === Core.kwfunc && length(atypes) == 2) ||
+                (is_inlineable_constant(val) &&
+                 (contains_is(_PURE_BUILTINS, f) ||
+                  (f === getfield && effect_free(e, ir, ir.mod, false)) ||
+                  (isa(f, IntrinsicFunction) && is_pure_intrinsic_optim(f)))))
+                return (quoted(val),)
+            end
+        end
+    end
+
+    return nothing
+end
+
+function late_inline_special_case!(ir::IRCode, idx::Int, stmt::Expr, atypes::Vector{Any}, @nospecialize(f), @nospecialize(ft), topmod::Module)
+    if length(atypes) == 3 && istopfunction(topmod, f, :!==)
+        # special-case inliner for !== that precedes _methods_by_ftype union splitting
+        # and that works, even though inference generally avoids inferring the `!==` Method
+        if isa(stmt.typ, Const)
+            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+            return true
+        end
+        cmp_call = Expr(:call, GlobalRef(Core, :(===)), stmt.args[2], stmt.args[3])
+        cmp_call.typ = Bool
+        cmp_call_ssa = insert_node!(ir, idx, Bool, cmp_call)
+        not_call = Expr(:call, GlobalRef(Core.Intrinsics, :not_int), cmp_call_ssa)
+        not_call.typ = Bool
+        ir[SSAValue(idx)] = not_call
+        return true
+    elseif length(atypes) == 3 && istopfunction(topmod, f, :(>:))
+        # special-case inliner for issupertype
+        # that works, even though inference generally avoids inferring the `>:` Method
+        if isa(stmt.typ, Const)
+            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+            return true
+        end
+        subtype_call = Expr(:call, GlobalRef(Core, :(<:)), arg_T2, arg_T1)
+        subtype_call.typ = Bool
+        ir[SSAValue(idx)] = subtype_call
+        return true
+    elseif f === return_type
+        if isconstType(stmt.typ)
+            ir[SSAValue(idx)] = quoted(stmt.typ.parameters[1])
+            return true
+        elseif isa(stmt.typ, Const)
+            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+            return true
+        end
+    end
+    return false
+end
+
+function ssa_substitute!(val, arg_replacements, spsig, spvals)
+    if isa(val, Argument)
+        return arg_replacements[val.n]
+    end
+    if isa(val, Expr)
+        e = val::Expr
+        head = e.head
+        if head === :static_parameter
+            return quoted(spvals[e.args[1]])
+        elseif head === :foreigncall
+            @assert !isa(spsig, UnionAll) || !isempty(spvals)
+            for i = 1:length(e.args)
+                if i == 2
+                    e.args[2] = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), e.args[2], spsig, spvals)
+                elseif i == 3
+                    argtuple = Any[
+                        ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), argt, spsig, spvals)
+                        for argt
+                        in e.args[3] ]
+                    e.args[3] = svec(argtuple...)
+                end
+            end
+    #=
+        elseif head === :boundscheck
+            if boundscheck === :propagate
+                return e
+            elseif boundscheck === :off
+                return false
+            else
+                return true
+            end
+    =#
+        end
+    end
+    urs = userefs(val)
+    urs === () && return val
+    for op in urs
+        op[] = ssa_substitute!(op[], arg_replacements, spsig, spvals)
+    end
+    urs[]
+end
+
+function find_inferred!(ir, idx, linfo, atypes, sv)
+    # see if the method has a InferenceResult in the current cache
+    # or an existing inferred code info store in `.inferred`
+    haveconst = false
+    for i in 1:length(atypes)
+        a = atypes[i]
+        if isa(a, Const) && !isdefined(typeof(a.val), :instance) && !(isa(a.val, Type) && issingletontype(a.val))
+            # have new information from argtypes that wasn't available from the signature
+            haveconst = true
+            break
+        end
+    end
+    if haveconst
+        inf_result = cache_lookup(linfo, atypes, sv.params.cache) # Union{Nothing, InferenceResult}
+    else
+        inf_result = nothing
+    end
+    if isa(inf_result, InferenceResult) && isa(inf_result.src, CodeInfo)
+        linfo = inf_result.linfo
+        result = inf_result.result
+        if (inf_result.src::CodeInfo).pure
+            if isa(result, Const)
+                inferred_const = result.val
+            elseif isconstType(result)
+                inferred_const = result.parameters[1]
+            end
+            if @isdefined(inferred_const) && is_inlineable_constant(inferred_const)
+                add_backedge!(linfo, sv)
+                ir[SSAValue(idx)] = quoted(inferred_const)
+                return nothing
+            end
+        end
+        inferred = inf_result.src
+        rettype = widenconst(result)
+    elseif isdefined(linfo, :inferred)
+        inferred = linfo.inferred
+        rettype = linfo.rettype
+    else
+        rettype = Any
+        inferred = nothing
+    end
+    return (rettype, inferred)
+end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -522,6 +522,7 @@ function finish_current_bb!(compact, old_result_idx=compact.result_idx)
     # If this was the last statement in the BB and we decided to skip it, insert a
     # dummy `nothing` node, to prevent changing the structure of the CFG
     if compact.result_idx == first(bb.stmts)
+        length(compact.result) < old_result_idx && resize!(compact, old_result_idx)
         compact.result[old_result_idx] = nothing
         compact.result_types[old_result_idx] = Nothing
         compact.result_lines[old_result_idx] = 0

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -136,8 +136,8 @@ struct IRCode
     mod::Module
     meta::Vector{Any}
 
-    function IRCode(stmts::Vector{Any}, lines::Vector{Int}, cfg::CFG, argtypes::Vector{Any}, mod::Module, meta::Vector{Any})
-        return new(stmts, Any[], lines, argtypes, cfg, NewNode[], mod, meta)
+    function IRCode(stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int}, cfg::CFG, argtypes::Vector{Any}, mod::Module, meta::Vector{Any})
+        return new(stmts, types, lines, argtypes, cfg, NewNode[], mod, meta)
     end
     function IRCode(ir::IRCode, stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int}, cfg::CFG, new_nodes::Vector{NewNode})
         return new(stmts, types, lines, ir.argtypes, cfg, new_nodes, ir.mod, ir.meta)

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -210,3 +210,79 @@ function replace_code!(ci::CodeInfo, code::IRCode, nargs::Int, linetable::Vector
     ci.code = new_code
     return ci
 end
+
+function inflate_ir(ci::CodeInfo)
+    code = copy_exprargs(ci.code)
+    for i = 1:length(code)
+        if isa(code[i], Expr)
+            code[i] = normalize_expr(code[i])
+        end
+    end
+    cfg = compute_basic_blocks(code)
+    for i = 1:length(code)
+        stmt = code[i]
+        urs = userefs(stmt)
+        if urs !== ()
+            for op in urs
+                val = op[]
+                if isa(val, SlotNumber)
+                    op[] = Argument(val.id)
+                end
+            end
+            stmt = urs[]
+        end
+        # Translate statement edges to bb_edges
+        if isa(stmt, GotoNode)
+            code[i] = GotoNode(block_for_inst(cfg, stmt.label))
+        elseif isa(stmt, GotoIfNot)
+            code[i] = GotoIfNot(stmt.cond, block_for_inst(cfg, stmt.dest))
+        elseif isa(stmt, PhiNode)
+            code[i] = PhiNode(Any[block_for_inst(cfg, edge) for edge in stmt.edges], stmt.values)
+        else
+            code[i] = stmt
+        end
+    end
+    ir = IRCode(code, copy(ci.ssavaluetypes), copy(ci.codelocs), cfg, copy(ci.slottypes), ci.linetable[1].mod, Any[])
+end
+
+function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs, linetable)
+    @assert isempty(ir.new_nodes)
+    # All but the first `nargs` slots will now be unused
+    resize!(ci.slottypes, nargs+1)
+    resize!(ci.slotnames, nargs+1)
+    resize!(ci.slotflags, nargs+1)
+    ci.code = ir.stmts
+    ci.codelocs = ir.lines
+    ci.linetable = linetable
+    ci.ssavaluetypes = ir.types
+    # Translate BB Edges to statement edges
+    # (and undo normalization for now)
+    for i = 1:length(ci.code)
+        stmt = ci.code[i]
+        urs = userefs(stmt)
+        if urs !== ()
+            for op in urs
+                val = op[]
+                if isa(val, Argument)
+                    op[] = SlotNumber(val.n)
+                end
+            end
+            stmt = urs[]
+        end
+        if isa(stmt, GotoNode)
+            ci.code[i] = GotoNode(first(ir.cfg.blocks[stmt.label].stmts))
+        elseif isa(stmt, GotoIfNot)
+            ci.code[i] = Expr(:gotoifnot, stmt.cond, first(ir.cfg.blocks[stmt.dest].stmts))
+        elseif isa(stmt, PhiNode)
+            ci.code[i] = PhiNode(Any[last(ir.cfg.blocks[edge].stmts) for edge in stmt.edges], stmt.values)
+        elseif isa(stmt, ReturnNode)
+            if isdefined(stmt, :val)
+                ci.code[i] = Expr(:return, stmt.val)
+            else
+                ci.code[i] = Expr(:unreachable)
+            end
+        else
+            ci.code[i] = stmt
+        end
+    end
+end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -226,7 +226,7 @@ function typeinf_type(method::Method, @nospecialize(atypes), sparams::SimpleVect
     return widenconst(frame.bestguess)
 end
 
-function typeinf_ext(linfo::MethodInstance, world::UInt)
+@timeit function typeinf_ext(linfo::MethodInstance, world::UInt)
     if isa(linfo.def, Method)
         # method lambda - infer this specialization via the method cache
         return typeinf_code(linfo, true, true, Params(world))

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -176,6 +176,8 @@ function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
                     tree.inferred = true
                     tree.pure = true
                     tree.inlineable = true
+                    tree.codelocs = nothing
+                    tree.linetable = nothing
                     i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
                     return svec(linfo, tree, linfo.rettype)
                 elseif isa(inf, CodeInfo)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -4,6 +4,14 @@
 # generic #
 ###########
 
+if !isdefined(@__MODULE__, Symbol("@timeit"))
+    # This is designed to allow inserting timers when loading a second copy
+    # of inference for performing performance experiments.
+    macro timeit(args...)
+        esc(args[end])
+    end
+end
+
 # avoid cycle due to over-specializing `any` when used by inference
 function _any(@nospecialize(f), a)
     for x in a

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -55,7 +55,7 @@ end
 InvalidCodeError(kind::AbstractString) = InvalidCodeError(kind, nothing)
 
 function validate_code_in_debug_mode(linfo::MethodInstance, src::CodeInfo, kind::String)
-    if JLOptions().debug_level == 2
+    #=if JLOptions().debug_level == 2
         # this is a debug build of julia, so let's validate linfo
         errors = validate_code(linfo, src)
         if !isempty(errors)
@@ -69,7 +69,7 @@ function validate_code_in_debug_mode(linfo::MethodInstance, src::CodeInfo, kind:
                 end
             end
         end
-    end
+    end=#
 end
 
 """

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -40,6 +40,14 @@ copy(e::Expr) = (n = Expr(e.head);
 # copy parts of an AST that the compiler mutates
 copy_exprs(x::Expr) = copy(x)
 copy_exprs(@nospecialize(x)) = x
+function copy_exprs(x::PhiNode)
+    new_values = Vector{Any}(undef, length(x.values))
+    for i = 1:length(x.edges)
+        isassigned(x.values, i) || continue
+        new_values[i] = copy_exprs(x.values[i])
+    end
+    PhiNode(copy(x.edges), new_values)
+end
 copy_exprargs(x::Array{Any,1}) = Any[copy_exprs(a) for a in x]
 
 ==(x::Expr, y::Expr) = x.head === y.head && isequal(x.args, y.args)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -12,7 +12,7 @@ using .Base:
     @inline, Pair, AbstractDict, IndexLinear, IndexCartesian, IndexStyle, AbstractVector, Vector,
     tail, tuple_type_head, tuple_type_tail, tuple_type_cons, SizeUnknown, HasLength, HasShape,
     IsInfinite, EltypeUnknown, HasEltype, OneTo, @propagate_inbounds, Generator, AbstractRange,
-    linearindices, (:), |, +, -, !==, !
+    linearindices, (:), |, +, -, !==, !, <=, <
 
 import .Base:
     start, done, next, first, last,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6098,7 +6098,11 @@ static std::unique_ptr<Module> emit_function(
                     if (!RTindex) {
                         assert(new_union.isboxed && new_union.Vboxed && "convert_julia_type failed");
                         RTindex = compute_tindex_unboxed(ctx, new_union, phiType);
-                        RTindex = ctx.builder.CreateOr(RTindex, ConstantInt::get(T_int8, 0x80));
+                        if (PhiAlloca) {
+                            // If PhiAlloca is not set, this is a ghost union, the recipient of which
+                            // is often not prepared to handle a boxed representation of the ghost.
+                            RTindex = ctx.builder.CreateOr(RTindex, ConstantInt::get(T_int8, 0x80));
+                        }
                         new_union.TIndex = RTindex;
                     }
                     V = new_union.Vboxed ? new_union.Vboxed : ConstantPointerNull::get(cast<PointerType>(T_prjlvalue));

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -557,6 +557,7 @@ public:
     Value *world_age_field = NULL;
 
     bool debug_enabled = false;
+    bool new_style_ir = false;
     const jl_cgparams_t *params = NULL;
 
     jl_codectx_t(LLVMContext &llvmctx)
@@ -1808,6 +1809,8 @@ static jl_value_t *static_eval(jl_codectx_t &ctx, jl_value_t *ex, int sparams=tr
         return NULL;
     if (jl_is_ssavalue(ex)) {
         ssize_t idx = ((jl_ssavalue_t*)ex)->id;
+        if (ctx.new_style_ir)
+            idx -= 1;
         assert(idx >= 0);
         if (ctx.ssavalue_assigned.at(idx)) {
             return ctx.SAvalues.at(idx).constant;
@@ -3463,11 +3466,8 @@ static void emit_vi_assignment_unboxed(jl_codectx_t &ctx, jl_varinfo_t &vi, Valu
     }
 }
 
-static void emit_phinode_assign(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
+static void emit_phinode_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
 {
-    ssize_t idx = ((jl_ssavalue_t*)l)->id;
-    assert(idx >= 0);
-    assert(!ctx.ssavalue_assigned.at(idx));
     jl_value_t *ssavalue_types = (jl_value_t*)ctx.source->ssavaluetypes;
     assert(jl_is_array(ssavalue_types));
     jl_array_t *edges = (jl_array_t*)jl_fieldref_noalloc(r, 0);
@@ -3545,71 +3545,78 @@ static void emit_phinode_assign(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
     return;
 }
 
+static void emit_ssaval_assign(jl_codectx_t &ctx, ssize_t idx, jl_value_t *r)
+{
+    assert(!ctx.ssavalue_assigned.at(idx));
+    if (jl_is_phinode(r)) {
+        return emit_phinode_assign(ctx, idx, r);
+    }
+    jl_cgval_t slot = emit_expr(ctx, r); // slot could be a jl_value_t (unboxed) or jl_value_t* (ispointer)
+    if (slot.isboxed || slot.TIndex) {
+        // see if inference suggested a different type for the ssavalue than the expression
+        // e.g. sometimes the information is inconsistent after inlining getfield on a Tuple
+        jl_value_t *ssavalue_types = (jl_value_t*)ctx.source->ssavaluetypes;
+        if (jl_is_array(ssavalue_types)) {
+            jl_value_t *declType = jl_array_ptr_ref(ssavalue_types, idx);
+            if (declType != slot.typ) {
+                slot = update_julia_type(ctx, slot, declType);
+            }
+        }
+    }
+    if (!slot.isboxed && !slot.isimmutable) {
+        // emit a copy of values stored in mutable slots
+        Value *dest;
+        jl_value_t *jt = slot.typ;
+        if (jl_is_uniontype(jt)) {
+            assert(slot.TIndex && "Unboxed union must have a type-index.");
+            bool allunbox;
+            size_t min_align;
+            dest = try_emit_union_alloca(ctx, ((jl_uniontype_t*)jt), allunbox, min_align);
+            Value *isboxed = NULL;
+            if (slot.isboxed || slot.Vboxed != nullptr) {
+                isboxed = ctx.builder.CreateICmpNE(
+                        ctx.builder.CreateAnd(slot.TIndex, ConstantInt::get(T_int8, 0x80)),
+                        ConstantInt::get(T_int8, 0));
+            }
+            if (dest)
+                emit_unionmove(ctx, dest, slot, isboxed, false, NULL);
+            if (isboxed) {
+                Value *box = slot.Vboxed ? slot.Vboxed : V_null;
+                if (dest) // might be all ghost values
+                    dest = ctx.builder.CreateSelect(isboxed,
+                        decay_derived(box),
+                        emit_bitcast(ctx, decay_derived(dest), box->getType()));
+                else
+                    dest = box;
+            }
+            else {
+                assert(allunbox && "Failed to allocate correct union-type storage.");
+            }
+            Value *box = slot.Vboxed;
+            slot = mark_julia_slot(dest, slot.typ, slot.TIndex, tbaa_stack);
+            slot.Vboxed = box;
+        }
+        else {
+            bool isboxed;
+            Type *vtype = julia_type_to_llvm(slot.typ, &isboxed);
+            assert(!isboxed);
+            dest = emit_static_alloca(ctx, vtype);
+            emit_unbox(ctx, vtype, slot, slot.typ, dest);
+            slot = mark_julia_slot(dest, slot.typ, NULL, tbaa_stack);
+        }
+    }
+    ctx.SAvalues.at(idx) = slot; // now SAvalues[idx] contains the SAvalue
+    ctx.ssavalue_assigned.at(idx) = true;
+}
+
 static void emit_assignment(jl_codectx_t &ctx, jl_value_t *l, jl_value_t *r)
 {
     if (jl_is_ssavalue(l)) {
-        if (jl_is_phinode(r)) {
-            return emit_phinode_assign(ctx, l, r);
-        }
         ssize_t idx = ((jl_ssavalue_t*)l)->id;
+        if (ctx.new_style_ir)
+            idx -= 1;
         assert(idx >= 0);
-        assert(!ctx.ssavalue_assigned.at(idx));
-        jl_cgval_t slot = emit_expr(ctx, r); // slot could be a jl_value_t (unboxed) or jl_value_t* (ispointer)
-        if (slot.isboxed || slot.TIndex) {
-            // see if inference suggested a different type for the ssavalue than the expression
-            // e.g. sometimes the information is inconsistent after inlining getfield on a Tuple
-            jl_value_t *ssavalue_types = (jl_value_t*)ctx.source->ssavaluetypes;
-            if (jl_is_array(ssavalue_types)) {
-                jl_value_t *declType = jl_array_ptr_ref(ssavalue_types, idx);
-                if (declType != slot.typ) {
-                    slot = update_julia_type(ctx, slot, declType);
-                }
-            }
-        }
-        if (!slot.isboxed && !slot.isimmutable) {
-            // emit a copy of values stored in mutable slots
-            Value *dest;
-            jl_value_t *jt = slot.typ;
-            if (jl_is_uniontype(jt)) {
-                assert(slot.TIndex && "Unboxed union must have a type-index.");
-                bool allunbox;
-                size_t min_align;
-                dest = try_emit_union_alloca(ctx, ((jl_uniontype_t*)jt), allunbox, min_align);
-                Value *isboxed = NULL;
-                if (slot.isboxed || slot.Vboxed != nullptr) {
-                    isboxed = ctx.builder.CreateICmpNE(
-                            ctx.builder.CreateAnd(slot.TIndex, ConstantInt::get(T_int8, 0x80)),
-                            ConstantInt::get(T_int8, 0));
-                }
-                if (dest)
-                    emit_unionmove(ctx, dest, slot, isboxed, false, NULL);
-                if (isboxed) {
-                    Value *box = slot.Vboxed ? slot.Vboxed : V_null;
-                    if (dest) // might be all ghost values
-                        dest = ctx.builder.CreateSelect(isboxed,
-                            decay_derived(box),
-                            emit_bitcast(ctx, decay_derived(dest), box->getType()));
-                    else
-                        dest = box;
-                }
-                else {
-                    assert(allunbox && "Failed to allocate correct union-type storage.");
-                }
-                Value *box = slot.Vboxed;
-                slot = mark_julia_slot(dest, slot.typ, slot.TIndex, tbaa_stack);
-                slot.Vboxed = box;
-            }
-            else {
-                bool isboxed;
-                Type *vtype = julia_type_to_llvm(slot.typ, &isboxed);
-                assert(!isboxed);
-                dest = emit_static_alloca(ctx, vtype);
-                emit_unbox(ctx, vtype, slot, slot.typ, dest);
-                slot = mark_julia_slot(dest, slot.typ, NULL, tbaa_stack);
-            }
-        }
-        ctx.SAvalues.at(idx) = slot; // now SAvalues[idx] contains the SAvalue
-        ctx.ssavalue_assigned.at(idx) = true;
+        emit_ssaval_assign(ctx, idx, r);
         return;
     }
 
@@ -3731,7 +3738,7 @@ static Value *emit_condition(jl_codectx_t &ctx, jl_value_t *cond, const std::str
     return emit_condition(ctx, emit_expr(ctx, cond), msg);
 }
 
-static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr)
+static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
 {
     if (jl_is_ssavalue(expr))
         return; // value not used, no point in attempting codegen for it
@@ -3759,7 +3766,10 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr)
         return;
     }
     if (!jl_is_expr(expr)) {
-        (void)emit_expr(ctx, expr);
+        if (ssaval_result != -1)
+            emit_ssaval_assign(ctx, ssaval_result, expr);
+        else
+            emit_expr(ctx, expr);
         return;
     }
     jl_expr_t *ex = (jl_expr_t*)expr;
@@ -3781,7 +3791,10 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr)
             Value *world = ctx.builder.CreateLoad(prepare_global(jlgetworld_global));
             ctx.builder.CreateStore(world, ctx.world_age_field);
         }
-        (void)emit_expr(ctx, expr);
+        if (ssaval_result != -1)
+            emit_ssaval_assign(ctx, ssaval_result, expr);
+        else
+            emit_expr(ctx, expr);
     }
 }
 
@@ -3796,6 +3809,8 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr)
     }
     if (jl_is_ssavalue(expr)) {
         ssize_t idx = ((jl_ssavalue_t*)expr)->id;
+        if (ctx.new_style_ir)
+            idx -= 1;
         assert(idx >= 0);
         if (!ctx.ssavalue_assigned.at(idx)) {
             ctx.ssavalue_assigned.at(idx) = true; // (assignment, not comparison test)
@@ -4979,6 +4994,8 @@ static std::unique_ptr<Module> emit_function(
     jl_array_t *stmts = ctx.code;
     size_t stmtslen = jl_array_dim0(stmts);
 
+    ctx.new_style_ir = src->codelocs != jl_nothing;
+
     // step 1b. unpack debug information
     int coverage_mode = jl_options.code_coverage;
     int malloc_log_mode = jl_options.malloc_log;
@@ -5688,6 +5705,14 @@ static std::unique_ptr<Module> emit_function(
     // `loc_changed` is false.
     bool linear_codegen = true;
     auto find_next_stmt = [&] (int seq_next) {
+        // new style ir is always in dominance order
+        if (ctx.new_style_ir) {
+            if (cursor + 1 == (int)stmtslen)
+                cursor = -1;
+            else
+                cursor = cursor + 1;
+            return;
+        }
         // `seq_next` is the next statement we want to emit
         // i.e. if it exists, it's the next one following control flow and
         // should be emitted into the current insert point.
@@ -5761,6 +5786,47 @@ static std::unique_ptr<Module> emit_function(
     std::map<size_t, BasicBlock*> come_from_bb;
     come_from_bb[0] = ctx.builder.GetInsertBlock();
 
+    // First go through and collect all branch targets, so we know where to
+    // split basic blocks.
+    std::set<int> branch_targets;
+    if (ctx.new_style_ir) {
+        for (size_t i = 0; i < stmtslen; ++i) {
+            jl_value_t *stmt = jl_array_ptr_ref(stmts, i);
+            if (jl_is_expr(stmt)) {
+                if (((jl_expr_t*)stmt)->head == goto_ifnot_sym) {
+                    int dest = jl_unbox_long(jl_array_ptr_ref(((jl_expr_t*)stmt)->args, 1));
+                    branch_targets.insert(dest);
+                    // The next 1-indexed statement
+                    branch_targets.insert(i + 2);
+                } else if (((jl_expr_t*)stmt)->head == return_sym) {
+                    // We don't do dead branch elimination before codegen
+                    // so we need to make sure to start a BB after any
+                    // return node, even if they aren't otherwise branch
+                    // targets.
+                    if (i + 2 <= stmtslen)
+                        branch_targets.insert(i + 2);
+                } else if (((jl_expr_t*)stmt)->head == unreachable_sym) {
+                    if (i + 2 <= stmtslen)
+                        branch_targets.insert(i + 2);
+                }
+            } else if (jl_is_gotonode(stmt)) {
+                int dest = jl_gotonode_label(stmt);
+                branch_targets.insert(dest);
+                if (i + 2 <= stmtslen)
+                    branch_targets.insert(i + 2);
+            }
+        }
+    }
+
+    std::map<int, BasicBlock*> BB;
+    if (ctx.new_style_ir) {
+        for (int label : branch_targets) {
+            BasicBlock *bb = BasicBlock::Create(jl_LLVMContext,
+                "L" + std::to_string(label), f);
+            BB[label] = bb;
+        }
+    }
+
     // Handle the implicit first line number node.
     if (ctx.debug_enabled)
         ctx.builder.SetCurrentDebugLocation(topdebugloc);
@@ -5777,6 +5843,13 @@ static std::unique_ptr<Module> emit_function(
         }
         jl_value_t *stmt = jl_array_ptr_ref(stmts, cursor);
         jl_expr_t *expr = jl_is_expr(stmt) ? (jl_expr_t*)stmt : nullptr;
+        if (ctx.new_style_ir && branch_targets.count(cursor+1)) {
+            come_from_bb[cursor] = ctx.builder.GetInsertBlock();
+            BasicBlock *NewBB = BB[cursor+1];
+            if (!ctx.builder.GetInsertBlock()->getTerminator())
+                ctx.builder.CreateBr(NewBB);
+            ctx.builder.SetInsertPoint(NewBB);
+        }
         if (jl_is_labelnode(stmt)) {
             // Label node
             int lname = jl_labelnode_label(stmt);
@@ -5887,7 +5960,12 @@ static std::unique_ptr<Module> emit_function(
         if (jl_is_gotonode(stmt)) {
             int lname = jl_gotonode_label(stmt);
             come_from_bb[cursor+1] = ctx.builder.GetInsertBlock();
-            handle_label(lname, true);
+            if (ctx.new_style_ir) {
+                ctx.builder.CreateBr(BB[lname]);
+                find_next_stmt(-1);
+            } else {
+                handle_label(lname, true);
+            }
             continue;
         }
         if (expr && expr->head == goto_ifnot_sym) {
@@ -5895,18 +5973,25 @@ static std::unique_ptr<Module> emit_function(
             jl_value_t *cond = args[0];
             int lname = jl_unbox_long(args[1]);
             Value *isfalse = emit_condition(ctx, cond, "if");
-            come_from_bb[cursor+1] = ctx.builder.GetInsertBlock();
             if (do_malloc_log(props.in_user_code) && props.line != -1)
                 mallocVisitLine(ctx, props.file, props.line);
-            bool next_is_label = jl_is_labelnode(jl_array_ptr_ref(stmts, cursor+1));
-            BasicBlock *ifnot = handle_label(lname, false);
-            BasicBlock *ifso = next_is_label ? handle_label(cursor+2, false) : BasicBlock::Create(jl_LLVMContext, "if", f);
-            // Any branches treated as constant in type inference should be
-            // eliminated before running
-            ctx.builder.CreateCondBr(isfalse, ifnot, ifso);
-            if (!next_is_label)
-                ctx.builder.SetInsertPoint(ifso);
-            find_next_stmt(next_is_label ? -1 : cursor+1);
+            come_from_bb[cursor+1] = ctx.builder.GetInsertBlock();
+            if (ctx.new_style_ir) {
+                BasicBlock *ifnot = BB[lname];
+                BasicBlock *ifso = BB[cursor+2];
+                ctx.builder.CreateCondBr(isfalse, ifnot, ifso);
+                find_next_stmt(-1);
+            } else {
+                bool next_is_label = jl_is_labelnode(jl_array_ptr_ref(stmts, cursor+1));
+                BasicBlock *ifnot = handle_label(lname, false);
+                BasicBlock *ifso = (next_is_label || ctx.new_style_ir) ? handle_label(cursor+2, false) : BasicBlock::Create(jl_LLVMContext, "if", f);
+                // Any branches treated as constant in type inference should be
+                // eliminated before running
+                ctx.builder.CreateCondBr(isfalse, ifnot, ifso);
+                if (!next_is_label && !ctx.new_style_ir)
+                    ctx.builder.SetInsertPoint(ifso);
+                find_next_stmt(next_is_label ? -1 : cursor+1);
+            }
             continue;
         }
         else if (expr && expr->head == enter_sym) {
@@ -5919,7 +6004,11 @@ static std::unique_ptr<Module> emit_function(
             sj->setCanReturnTwice();
             Value *isz = ctx.builder.CreateICmpEQ(sj, ConstantInt::get(T_int32, 0));
             BasicBlock *tryblk = BasicBlock::Create(jl_LLVMContext, "try", f);
-            BasicBlock *handlr = handle_label(lname, false);
+            BasicBlock *handlr = NULL;
+            if (ctx.new_style_ir)
+                handlr = BB[lname];
+            else
+                handlr = handle_label(lname, false);
 #ifdef _OS_WINDOWS_
             BasicBlock *cond_resetstkoflw_blk = BasicBlock::Create(jl_LLVMContext, "cond_resetstkoflw", f);
             BasicBlock *resetstkoflw_blk = BasicBlock::Create(jl_LLVMContext, "resetstkoflw", f);
@@ -5938,13 +6027,15 @@ static std::unique_ptr<Module> emit_function(
             ctx.builder.SetInsertPoint(tryblk);
         }
         else {
-            emit_stmtpos(ctx, stmt);
+            emit_stmtpos(ctx, stmt, ctx.new_style_ir ? cursor : -1);
             if (do_malloc_log(props.in_user_code) && props.line != -1) {
                 mallocVisitLine(ctx, props.file, props.line);
             }
         }
-        if ((size_t)cursor + 1 < jl_array_len(stmts) && jl_is_labelnode(jl_array_ptr_ref(stmts, cursor+1)))
-            come_from_bb[cursor+1] = ctx.builder.GetInsertBlock();
+        if (!ctx.new_style_ir) {
+            if ((size_t)cursor + 1 < jl_array_len(stmts) && jl_is_labelnode(jl_array_ptr_ref(stmts, cursor+1)))
+                come_from_bb[cursor+1] = ctx.builder.GetInsertBlock();
+        }
         find_next_stmt(cursor + 1);
     }
     ctx.builder.SetCurrentDebugLocation(noDbg);
@@ -5952,8 +6043,10 @@ static std::unique_ptr<Module> emit_function(
 
     // We don't visit empty labels, but they can still be implicit terminators,
     // just add them to the list
-    for (auto &pair : labels)
-        come_from_bb[pair.first] = pair.second;
+    if (!ctx.new_style_ir) {
+        for (auto &pair : labels)
+            come_from_bb[pair.first] = pair.second;
+    }
 
     // Codegen Phi nodes
     std::map<BasicBlock *, BasicBlock*> BB_rewrite_map;
@@ -5993,6 +6086,8 @@ static std::unique_ptr<Module> emit_function(
             jl_cgval_t val;
             if (!value || jl_is_ssavalue(value)) {
                 ssize_t idx = value ? ((jl_ssavalue_t*)value)->id : 0;
+                if (ctx.new_style_ir)
+                    idx -= 1;
                 if (!value || !ctx.ssavalue_assigned.at(idx)) {
                     Value *RTindex = TindexN ? UndefValue::get(T_int8) : NULL;
                      if (VN) { // otherwise, it's all-unboxed

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2010,29 +2010,36 @@ void jl_init_types(void)
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(10,
+                        jl_perm_symsvec(12,
                             "code",
+                            "codelocs",
                             "signature_for_inference_heuristics",
                             "slottypes",
                             "ssavaluetypes",
+                            "linetable",
                             "slotflags",
                             "slotnames",
                             "inferred",
                             "inlineable",
                             "propagate_inbounds",
                             "pure"),
-                        jl_svec(10,
+                        jl_svec(12,
                             jl_array_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
                             jl_array_uint8_type,
+                            // Note: The following fields have special serialization.
+                            // If you change them, you'll have to adjust the
+                            // serializer
                             jl_array_any_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 10);
+                        0, 1, 12);
 
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,

--- a/src/julia.h
+++ b/src/julia.h
@@ -236,9 +236,11 @@ typedef struct _jl_llvm_functions_t {
 // This type describes a single function body
 typedef struct _jl_code_info_t {
     jl_array_t *code;  // Any array of statements
+    jl_value_t *codelocs; // Int array of indicies into the line table
     jl_value_t *signature_for_inference_heuristics; // optional method used during inference
     jl_value_t *slottypes; // types of variable slots (or `nothing`)
     jl_value_t *ssavaluetypes;  // types of ssa values (or count of them)
+    jl_value_t *linetable; // Table of locations
     jl_array_t *slotflags;  // local var bit flags
     jl_array_t *slotnames; // names of local variables
     uint8_t inferred;

--- a/src/method.c
+++ b/src/method.c
@@ -201,6 +201,9 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
     jl_gc_wb(li, li->slotflags);
     li->ssavaluetypes = jl_box_long(nssavalue);
     jl_gc_wb(li, li->ssavaluetypes);
+    li->linetable = jl_nothing;
+    li->codelocs = jl_nothing;
+
     // Flags that need to be copied to slotflags
     const uint8_t vinfo_mask = 16 | 32 | 64;
     int i;
@@ -261,6 +264,8 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
     src->slotflags = NULL;
     src->slottypes = NULL;
     src->ssavaluetypes = NULL;
+    src->codelocs = jl_nothing;
+    src->linetable = jl_nothing;
     src->inferred = 0;
     src->pure = 0;
     src->inlineable = 0;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -594,6 +594,8 @@ static jl_code_info_t *expr_to_code_info(jl_value_t *expr)
     src->ssavaluetypes = jl_box_long(0);
     jl_gc_wb(src, src->ssavaluetypes);
     src->signature_for_inference_heuristics = jl_nothing;
+    src->codelocs = jl_nothing;
+    src->linetable = jl_nothing;
 
     JL_GC_POP();
     return src;


### PR DESCRIPTION
Now that the optimizer is complete, we need to start looking at latency.
The biggest problem at the moment is that we keep converting back and
forth to the legacy IR format. In order to cease doing so, we need to
move the other parts of the optimizer that still operate on the old
data structure to operate on the new ones instead. This PR does so
for inlining.

Current status: Passes tests modulo not doing boundscheck elision yet.