### PR TITLE
remove unused Lisp procedures

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -313,13 +313,6 @@
                                               (eq? (car a) 'parameters))))
                         lst)))
 
-(define (llist-keywords lst)
-  (apply append
-         (map (lambda (a) (if (and (pair? a) (eq? (car a) 'parameters))
-                              (map arg-name (cdr a))
-                              '()))
-              lst)))
-
 ;; get just argument types
 (define (llist-types lst) (map arg-type lst))
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1875,13 +1875,6 @@
                                 (deparse (car vec)) t "\"")))
              (loop (cons (parse-eq* s) vec) outer))))))))
 
-(define (peek-non-newline-token s)
-  (let loop ((t (peek-token s)))
-    (if (newline? t)
-        (begin (take-token s)
-               (loop (peek-token s)))
-        t)))
-
 (define (expect-space-before s t)
   (if (not (ts:space? s))
       (error (string "expected space before \"" t "\""))))

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -264,10 +264,6 @@
             `(,@head (curly Vararg ,(cadr las)))
             `(,@head ,las)))))
 
-(define (hidden-name? s)
-  (and (symbol? s)
-       (eqv? (string.char (string s) 0) #\#)))
-
 (define (replace-vars e renames)
   (cond ((symbol? e)      (lookup e renames e))
         ((or (not (pair? e)) (quoted? e))  e)
@@ -760,17 +756,6 @@
                                             (call (core fieldtype) ,tn (quote ,fld))
                                             ,val))
                                    (list-head field-names (length args)) args)))))))))
-
-;; insert a statement after line number node
-(define (prepend-stmt stmt body)
-  (if (and (pair? body) (eq? (car body) 'block))
-      (cond ((atom? (cdr body))
-             `(block ,stmt (null)))
-            ((linenum? (cadr body))
-             `(block ,(cadr body) ,stmt ,@(cddr body)))
-            (else
-             `(block ,stmt ,@(cdr body))))
-      body))
 
 ;; insert item at start of arglist
 (define (arglist-unshift sig item)


### PR DESCRIPTION
Systematic word counting suggests these procedures are no longer used in Julia. I think it is safe to remove them since they are only used internally.