### PR TITLE
Upgrade Documenter, and add make target to fix doctests

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -8,15 +8,16 @@ JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
 JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
 
-.PHONY: help clean cleanall html pdf linkcheck doctest check deps deploy
+.PHONY: help clean cleanall html pdf linkcheck doctest doctest-fix check deps deploy
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
-	@echo "  html      to make standalone HTML files"
-	@echo "  pdf       to make standalone PDF file"
-	@echo "  linkcheck to check all external links for integrity"
-	@echo "  doctest   to run all doctests embedded in the documentation"
-	@echo "  check     to run linkcheck and doctests"
+	@echo "  html        to make standalone HTML files"
+	@echo "  pdf         to make standalone PDF file"
+	@echo "  linkcheck   to check all external links for integrity"
+	@echo "  doctest     to run all doctests embedded in the documentation"
+	@echo "  doctest-fix to update all doctests embedded in the documentation"
+	@echo "  check       to run linkcheck and doctests"
 
 UnicodeData.txt:
 	$(JLDOWNLOAD) http://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt
@@ -54,6 +55,11 @@ doctest: deps
 	@echo "Running all embedded 'doctests'."
 	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- doctest
 	@echo "Checks finished."
+
+doctest-fix: deps
+	@echo "Updating all embedded 'doctests'."
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- doctest-fix
+	@echo "Update finished."
 
 check: deps
 	@echo "Running all embedded 'doctests' and checking external links."

--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
-Compat 0.56.0 0.56.0+
+Compat 0.58.0 0.58.0+
 DocStringExtensions 0.4.3 0.4.3+
-Documenter 0.14.0 0.14.0+
+Documenter 0.15.0 0.15.0+

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -150,7 +150,7 @@ makedocs(
     build     = joinpath(@__DIR__, "_build/html/en"),
     modules   = [Base, Core, BuildSysImg, [Base.root_module(Base, stdlib.stdlib) for stdlib in STDLIB_DOCS]...],
     clean     = true,
-    doctest   = "doctest" in ARGS,
+    doctest   = ("doctest-fix" in ARGS) ? (:fix) : ("doctest" in ARGS),
     linkcheck = "linkcheck" in ARGS,
     linkcheck_ignore = ["https://bugs.kde.org/show_bug.cgi?id=136779"], # fails to load from nanosoldier?
     strict    = false,


### PR DESCRIPTION
This upgrades Documenter to `v0.15.0` (https://github.com/JuliaDocs/Documenter.jl/releases/tag/v0.15.0).

In particular this release includes https://github.com/JuliaDocs/Documenter.jl/pull/656 which adds a `fix` flag to `makedocs` that will update all the outdated doctests. This is something I am pretty excited about -- you would be surprised how fast our docs get outdated! I added a new make target for running the fix in `doc/Makefile`, so running:
```
make -C doc doctest-fix
```
should now update all the doctests to the new output.

This is something we should do before every new release, to make sure docs are up to date. This is also very useful when doing other changes to the code -- instead of manually updating all the docstrings, it should in theory be enough to run `make -C doc doctest-fix` to update to the new output, see e.g. https://github.com/JuliaLang/julia/pull/20288