### PR TITLE
Let `less` return nothing instead of the `Process` object

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -100,11 +100,13 @@ if Sys.iswindows()
         pager = shell_split(get(ENV, "PAGER", "more"))
         g = pager[1] == "more" ? "" : "g"
         run(Cmd(`$pager +$(line)$(g) \"$file\"`, windows_verbatim = true))
+        nothing
     end
 else
     function less(file::AbstractString, line::Integer)
         pager = shell_split(get(ENV, "PAGER", "less"))
         run(`$pager +$(line)g $file`)
+        nothing
     end
 end
 


### PR DESCRIPTION
Before:
```julia
julia> @less @less @less # ...and quit opened less
Process(`less +70g usr/share/julia/site/v0.7/InteractiveUtils/src/macros.jl`, ProcessExited(0))

julia>
```
After:
```julia
julia> @less @less @less # ...and quit opened less

julia>
```
(This is consistent with `edit` which also returns `nothing`).

Neither `edit` nor `less` seem to be tested at all, and I don't know whether there is a good way to do so.