### PR TITLE
Add missing GC preserve in String hash

### DIFF
--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -176,6 +176,6 @@ const memhash_seed = UInt === UInt64 ? 0x71e729fd56419c81 : 0x56419c81
 function hash(s::Union{String,SubString{String}}, h::UInt)
     h += memhash_seed
     # note: use pointer(s) here (see #6058).
-    ccall(memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), pointer(s), sizeof(s), h % UInt32) + h
+    GC.@preserve s ccall(memhash, UInt, (Ptr{UInt8}, Csize_t, UInt32), pointer(s), sizeof(s), h % UInt32) + h
 end
 hash(s::AbstractString, h::UInt) = hash(String(s), h)


### PR DESCRIPTION
Probably doesn't actually make a difference in practice, but the preserve is technically required because of the `pointer` call.