### PR TITLE
fix perf regression for bitrand

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -198,19 +198,18 @@ rand(rng::AbstractRNG, ::UniformT{T}) where {T} = rand(rng, T)
 
 #### scalars
 
-rand(rng::AbstractRNG, X) = rand(rng, Sampler(rng, X, Val(1)))
-rand(rng::AbstractRNG=GLOBAL_RNG, ::Type{X}=Float64) where {X} =
-    rand(rng, Sampler(rng, X, Val(1)))
+rand(rng::AbstractRNG, X)                                      = rand(rng, Sampler(rng, X, Val(1)))
+rand(rng::AbstractRNG=GLOBAL_RNG, ::Type{X}=Float64) where {X} = rand(rng, Sampler(rng, X, Val(1)))
 
-rand(X) = rand(GLOBAL_RNG, X)
+rand(X)                   = rand(GLOBAL_RNG, X)
 rand(::Type{X}) where {X} = rand(GLOBAL_RNG, X)
 
 #### arrays
 
-rand!(A::AbstractArray{T}, X) where {T} = rand!(GLOBAL_RNG, A, X)
+rand!(A::AbstractArray{T}, X) where {T}             = rand!(GLOBAL_RNG, A, X)
 rand!(A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(GLOBAL_RNG, A, X)
 
-rand!(rng::AbstractRNG, A::AbstractArray{T}, X) where {T} = rand!(rng, A, Sampler(rng, X))
+rand!(rng::AbstractRNG, A::AbstractArray{T}, X) where {T}             = rand!(rng, A, Sampler(rng, X))
 rand!(rng::AbstractRNG, A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(rng, A, Sampler(rng, X))
 
 function rand!(rng::AbstractRNG, A::AbstractArray{T}, sp::Sampler) where T

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -2,7 +2,7 @@
 
 ## rand!(::BitArray) && bitrand
 
-function rand!(rng::AbstractRNG, B::BitArray)
+function rand!(rng::AbstractRNG, B::BitArray, ::SamplerType{Bool})
     isempty(B) && return B
     Bc = B.chunks
     rand!(rng, Bc)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/26505

Before:

```
julia> @btime bitrand(10^6);
  2.726 ms (3 allocations: 122.23 KiB)
```

After:

```
julia> @btime bitrand(10^6);
  20.322 μs (3 allocations: 122.23 KiB)
```
Before, this dispatched to 

```
rand!(A::AbstractArray{T}, ::Type{X}=T) where {T,X} = rand!(GLOBAL_RNG, A, X)
```

and avoided the specialization for `rand!(rng::AbstractRNG, B::BitArray)`.  After a while we ended up at a loop that generates random `Bool`s for each element in `A`, which is bad.

*Generic methods, a blessing and a curse*

I guess there is some general advice emerging from this which is to build up your "dispatch-chain" as incrementally as possible so that you do not risk "skipping over" someone else's specialization.