### PR TITLE
disallow `ccall` and `cglobal` as variable names

### DIFF
--- a/src/ast.scm
+++ b/src/ast.scm
@@ -268,8 +268,11 @@
 (define (bad-formal-argument v)
   (error (string #\" (deparse v) #\" " is not a valid function argument name")))
 
+(define (valid-name? s)
+  (not (memq s '(true false ccall cglobal))))
+
 (define (arg-name v)
-  (cond ((and (symbol? v) (not (eq? v 'true)) (not (eq? v 'false)))
+  (cond ((and (symbol? v) (valid-name? v))
          v)
         ((not (pair? v))
          (bad-formal-argument v))

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -98,7 +98,8 @@
   (and (pair? e)
        (or (memq (car e) '(toplevel line module import importall using export
                                     error incomplete))
-           (and (eq? (car e) 'global) (every symbol? (cdr e))))))
+           (and (eq? (car e) 'global) (every symbol? (cdr e))
+                (every (lambda (x) (not (memq x '(true false)))) (cdr e))))))
 
 (define (expand-toplevel-expr e)
   (cond ((or (atom? e) (toplevel-only-expr? e))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1367,3 +1367,7 @@ end
 
 # Module name cannot be a reserved word.
 @test_throws ParseError Meta.parse("module module end")
+
+@test Meta.lower(@__MODULE__, :(global true)) == Expr(:error, "invalid identifier name \"true\"")
+@test Meta.lower(@__MODULE__, :(let ccall end)) == Expr(:error, "invalid identifier name \"ccall\"")
+@test Meta.lower(@__MODULE__, :(cglobal = 0)) == Expr(:error, "invalid assignment location \"cglobal\"")


### PR DESCRIPTION
These used to be normal identifiers but over time have become quasi-syntax. As a result you get behavior like this:

```
julia> ccall(x) = x
ccall (generic function with 1 method)

julia> ccall(2)
ERROR: syntax: too few arguments to ccall
```

This change prevents that from happening by disallowing assigning to or otherwise creating a variable with these names.