### PR TITLE
fix iterator test for shape of 1-argument product

### DIFF
--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -272,7 +272,7 @@ let iters = (1:2,
              )
     for method in [size, length, ndims, eltype]
         for i = 1:length(iters)
-            args = iters[i]
+            args = (iters[i],)
             @test method(product(args...)) == method(collect(product(args...)))
             for j = 1:length(iters)
                 args = iters[i], iters[j]


### PR DESCRIPTION
Since the subsequent tests are for 2 and 3 arguments, it looks like this one was intended to be for one argument.