### PR TITLE
fix parsing of `a.:b`

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1240,7 +1240,10 @@
                     ((eqv? (peek-token s) ':)
                      (begin
                        (take-token s)
-                       `(|.| ,ex (quote ,(parse-atom s)))))
+                       (if (or (eqv? (peek-token s) #\newline)
+                               (ts:space? s)) ;; uses side effect of previous peek-token
+                           (error "space not allowed after \":\" used for quoting"))
+                       `(|.| ,ex (quote ,(parse-atom s #f)))))
                     ((eq? (peek-token s) '$)
                      (take-token s)
                      (let ((dollarex (parse-atom s)))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1362,6 +1362,10 @@ end
          Expr(:call, :-, Expr(:call, Expr(:->, :x, Expr(:block, LineNumberNode(1,:none), true)),
                               :X)))
 
+@test_throws ParseError Meta.parse("a.: b")
+@test Meta.parse("a.:end") == Expr(:., :a, QuoteNode(:end))
+@test Meta.parse("a.:catch") == Expr(:., :a, QuoteNode(:catch))
+
 # issue #25994
 @test Meta.parse("[a\nfor a in b]") == Expr(:comprehension, Expr(:generator, :a, Expr(:(=), :a, :b)))
 


### PR DESCRIPTION
- disallow space after `:`, as in other uses of `:` for quoting
- allow same symbols after `:` as in other cases

Part of #26507
