### PR TITLE
Remove redundant bounds check in mul! with sparse matrices

### DIFF
--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -39,9 +39,9 @@ function mul!(C::StridedVecOrMat, A::SparseMatrixCSC, B::StridedVecOrMat, α::Nu
         β != 0 ? rmul!(C, β) : fill!(C, zero(eltype(C)))
     end
     for k = 1:size(C, 2)
-        for col = 1:A.n
+        @inbounds for col = 1:A.n
             αxj = α*B[col,k]
-            @inbounds for j = A.colptr[col]:(A.colptr[col + 1] - 1)
+            for j = A.colptr[col]:(A.colptr[col + 1] - 1)
                 C[rv[j], k] += nzv[j]*αxj
             end
         end
@@ -64,9 +64,9 @@ function mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::Str
         β != 0 ? rmul!(C, β) : fill!(C, zero(eltype(C)))
     end
     for k = 1:size(C, 2)
-        for col = 1:A.n
+        @inbounds for col = 1:A.n
             tmp = zero(eltype(C))
-            @inbounds for j = A.colptr[col]:(A.colptr[col + 1] - 1)
+            for j = A.colptr[col]:(A.colptr[col + 1] - 1)
                 tmp += adjoint(nzv[j])*B[rv[j],k]
             end
             C[col,k] += α*tmp
@@ -90,9 +90,9 @@ function mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:SparseMatrixCSC}, B:
         β != 0 ? rmul!(C, β) : fill!(C, zero(eltype(C)))
     end
     for k = 1:size(C, 2)
-        for col = 1:A.n
+        @inbounds for col = 1:A.n
             tmp = zero(eltype(C))
-            @inbounds for j = A.colptr[col]:(A.colptr[col + 1] - 1)
+            for j = A.colptr[col]:(A.colptr[col + 1] - 1)
                 tmp += transpose(nzv[j])*B[rv[j],k]
             end
             C[col,k] += α*tmp


### PR DESCRIPTION
There's performance to be gained in sparse mat-vec products for very sparse matrices by moving the `@inbounds` one block up. We can probably do this cause the dimensions of `B` and `C` have already been checked.

Some results:

```julia
function bench(n = 1_000, k = 5)
    # Tridiagonal matrix
    A = spdiagm(-1 => fill(-1.0, n-1), 0 => fill(2.0, n), 1 => fill(-1.1, n-1))
    B = ones(n, k)
    C1 = similar(B)
    C2 = similar(B)

    mul!(C1, A, B, 1.0, 0.0)
    my_mul!(C2, A, B, 1.0, 0.0)

    @assert C1 == C2

    mul!(C1, A', B, 1.0, 0.0)
    my_mul!(C2, A', B, 1.0, 0.0)

    @assert C1 == C2

    A1 = @benchmark mul!($C1, $A, $B, 1.0, 0.0)
    A2 = @benchmark my_mul!($C1, $A, $B, 1.0, 0.0)

    Aᵀ1 = @benchmark mul!($C1, $(A'), $B, 1.0, 0.0)
    Aᵀ2 = @benchmark my_mul!($C1, $(A'), $B, 1.0, 0.0)

    A1, A2, Aᵀ1, Aᵀ2
end
```

| `n`     | `k` | old A * x | new A * x | old A' * x | new A' * x |
|---------|-----|-------------|-------------|--------------|--------------|
| 1_000  | 5   | 22μs        | 17μs        | 21μs         | 18μs         |
| 10_000  | 5   | 222μs       | 175μs       | 207μs        | 182μs        |
| 100_000 | 5   | 2395μs      | 1933μs      | 2385μs       | 2078μs       |