### PR TITLE
fix #25172, make `HTML` constructors consistent

### DIFF
--- a/base/docs/utils.jl
+++ b/base/docs/utils.jl
@@ -26,7 +26,7 @@ end
 function HTML(xs...)
     HTML() do io
         for x in xs
-            show(io, MIME"text/html"(), x)
+            print(io, x)
         end
     end
 end

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1003,6 +1003,9 @@ end
 @test hash(Text("docstring1")) ≠ hash(Text("docstring2"))
 @test hash(Text("docstring")) ≠ hash(HTML("docstring"))
 
+# issue #25172
+@test repr(MIME"text/html"(), HTML("a","b")) == "ab"
+
 # issue 21016
 module I21016
 


### PR DESCRIPTION
I'm not totally sure what's going on here, but based on the doc string it looks like `HTML` is intended to wrap content already formatted as HTML, so I'd call the vararg constructor behavior a bug.