### PR TITLE
codegen: use compiler trampoline closing over method-instance

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -367,7 +367,7 @@ function optimize(me::InferenceState)
 
         if proven_pure && !coverage_enabled()
             # use constant calling convention
-            # Do not emit `jlcall_api == 2` if coverage is enabled
+            # Do not emit `jl_fptr_const_return` if coverage is enabled
             # so that we don't need to add coverage support
             # to the `jl_call_method_internal` fast path
             # Still set pure flag to make sure `inference` tests pass
@@ -438,7 +438,7 @@ function finish(me::InferenceState)
         end
 
         # don't store inferred code if we've decided to interpret this function
-        if !already_inferred && me.linfo.jlcall_api != 4
+        if !already_inferred && invoke_api(me.linfo) != 4
             const_flags = (me.const_ret) << 1 | me.const_api
             if me.const_ret
                 if isa(me.bestguess, Const)
@@ -1320,7 +1320,7 @@ function inlineable(@nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector
     isa(linfo, MethodInstance) || return invoke_NF(argexprs0, e.typ, atypes0, sv,
                                                    atype_unlimited, invoke_data)
     linfo = linfo::MethodInstance
-    if linfo.jlcall_api == 2
+    if invoke_api(linfo) == 2
         # in this case function can be inlined to a constant
         add_backedge!(linfo, sv)
         return inline_as_constant(linfo.inferred_const, argexprs, sv, invoke_data)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -164,7 +164,7 @@ function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
             # so need to check whether the code itself is also inferred
             if min_world(linfo) <= params.world <= max_world(linfo)
                 inf = linfo.inferred
-                if linfo.jlcall_api == 2
+                if invoke_api(linfo) == 2
                     method = linfo.def::Method
                     tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
                     tree.code = Any[ Expr(:return, quoted(linfo.inferred_const)) ]

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -88,6 +88,10 @@ end
 # MethodInstance/CodeInfo #
 ###########################
 
+function invoke_api(li::MethodInstance)
+    return ccall(:jl_invoke_api, Cint, (Any,), li)
+end
+
 function get_staged(li::MethodInstance)
     try
         # user code might throw errors – ignore them

--- a/src/ast.c
+++ b/src/ast.c
@@ -993,7 +993,7 @@ static jl_value_t *jl_invoke_julia_macro(jl_array_t *args, jl_module_t *inmodule
             // unreachable
         }
         *ctx = mfunc->def.method->module;
-        result = jl_call_method_internal(mfunc, margs, nargs);
+        result = mfunc->invoke(mfunc, margs, nargs);
     }
     JL_CATCH {
         if (jl_loaderror_type == NULL) {

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1179,13 +1179,13 @@ static void add_builtin(const char *name, jl_value_t *v)
     jl_set_const(jl_core_module, jl_symbol(name), v);
 }
 
-jl_fptr_t jl_get_builtin_fptr(jl_value_t *b)
+jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b)
 {
     assert(jl_isa(b, (jl_value_t*)jl_builtin_type));
-    return jl_gf_mtable(b)->cache.leaf->func.linfo->fptr;
+    return jl_gf_mtable(b)->cache.leaf->func.linfo->specptr.fptr1;
 }
 
-static void add_builtin_func(const char *name, jl_fptr_t fptr)
+static void add_builtin_func(const char *name, jl_fptr_args_t fptr)
 {
     jl_mk_builtin_func(NULL, name, fptr);
 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -37,8 +37,9 @@ JL_DLLEXPORT size_t jl_get_tls_world_age(void)
 
 JL_DLLEXPORT jl_value_t *jl_invoke(jl_method_instance_t *meth, jl_value_t **args, uint32_t nargs)
 {
-    if (meth->jlcall_api) {
-        return jl_call_method_internal(meth, args, nargs);
+    jl_callptr_t fptr = meth->invoke;
+    if (fptr != jl_fptr_trampoline) {
+        return fptr(meth, args, nargs);
     }
     else {
         // if this hasn't been inferred (compiled) yet,
@@ -202,7 +203,7 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *typ
 // ----- MethodInstance specialization instantiation ----- //
 
 JL_DLLEXPORT jl_method_t *jl_new_method_uninit(void);
-void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr)
+void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr)
 {
     jl_sym_t *sname = jl_symbol(name);
     if (dt == NULL) {
@@ -211,8 +212,8 @@ void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr)
         dt = (jl_datatype_t*)jl_typeof(f);
     }
     jl_method_instance_t *li = jl_new_method_instance_uninit();
-    li->fptr = fptr;
-    li->jlcall_api = JL_API_GENERIC;
+    li->invoke = jl_fptr_args;
+    li->specptr.fptr1 = fptr;
     li->specTypes = (jl_value_t*)jl_anytuple_type;
     li->min_world = 1;
     li->max_world = ~(size_t)0;
@@ -414,20 +415,22 @@ JL_DLLEXPORT jl_method_instance_t* jl_set_method_inferred(
 
     // changing rettype changes the llvm signature,
     // so clear all of the llvm state at the same time
+    li->invoke = jl_fptr_trampoline;
     li->functionObjectsDecls.functionObject = NULL;
     li->functionObjectsDecls.specFunctionObject = NULL;
     li->rettype = rettype;
     jl_gc_wb(li, rettype);
     li->inferred = inferred;
     jl_gc_wb(li, inferred);
-    if (const_flags & 1) {
-        assert(const_flags & 2);
-        li->jlcall_api = JL_API_CONST;
-    }
     if (const_flags & 2) {
         li->inferred_const = inferred_const;
         jl_gc_wb(li, inferred_const);
     }
+    if (const_flags & 1) {
+        assert(const_flags & 2);
+        li->invoke = jl_fptr_const_return;
+    }
+    li->specptr.fptr = NULL;
     JL_GC_POP();
     return li;
 }
@@ -1736,66 +1739,135 @@ JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int
     return ml_matches(mt->defs, 0, types, lim, include_ambiguous, world, min_valid, max_valid);
 }
 
-jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **pli, size_t world)
+jl_callptr_t jl_compile_method_internal(jl_method_instance_t **pli, size_t world)
 {
     jl_method_instance_t *li = *pli;
-    if (li->jlcall_api == JL_API_CONST)
-        return li->functionObjectsDecls;
-    if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF ||
-        jl_options.compile_enabled == JL_OPTIONS_COMPILE_MIN) {
+    jl_callptr_t fptr = li->invoke;
+    if (fptr != jl_fptr_trampoline)
+        return fptr;
+
+   if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF ||
+            jl_options.compile_enabled == JL_OPTIONS_COMPILE_MIN) {
         // copy fptr from the template method definition
         jl_method_t *def = li->def.method;
         if (jl_is_method(def) && def->unspecialized) {
-            if (def->unspecialized->jlcall_api == JL_API_CONST) {
+            jl_method_instance_t *unspec = def->unspecialized;
+            if (unspec->invoke != jl_fptr_trampoline) {
                 li->functionObjectsDecls.functionObject = NULL;
                 li->functionObjectsDecls.specFunctionObject = NULL;
-                li->inferred = def->unspecialized->inferred;
-                jl_gc_wb(li, li->inferred);
-                li->inferred_const = def->unspecialized->inferred_const;
+                li->specptr = unspec->specptr;
+                li->inferred = unspec->inferred;
+                if (li->inferred)
+                    jl_gc_wb(li, li->inferred);
+                li->inferred_const = unspec->inferred_const;
                 if (li->inferred_const)
                     jl_gc_wb(li, li->inferred_const);
-                li->jlcall_api = JL_API_CONST;
-                return li->functionObjectsDecls;
-            }
-            if (def->unspecialized->fptr) {
-                li->functionObjectsDecls.functionObject = NULL;
-                li->functionObjectsDecls.specFunctionObject = NULL;
-                li->jlcall_api = def->unspecialized->jlcall_api;
-                li->fptr = def->unspecialized->fptr;
-                return li->functionObjectsDecls;
+                li->invoke = unspec->invoke;
+                return fptr;
             }
         }
-        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF &&
-            jl_is_method(li->def.method)) {
-            jl_code_info_t *src = jl_code_for_interpreter(li);
-            if (!jl_code_requires_compiler(src)) {
-                li->inferred = (jl_value_t*)src;
-                jl_gc_wb(li, src);
-                li->functionObjectsDecls.functionObject = NULL;
-                li->functionObjectsDecls.specFunctionObject = NULL;
-                li->fptr = (jl_fptr_t)&jl_interpret_call;
-                li->jlcall_api = JL_API_INTERPRETED;
-                return li->functionObjectsDecls;
-            }
+        jl_code_info_t *src = jl_code_for_interpreter(li);
+        if (!jl_code_requires_compiler(src)) {
+            li->inferred = (jl_value_t*)src;
+            jl_gc_wb(li, src);
+            li->functionObjectsDecls.functionObject = NULL;
+            li->functionObjectsDecls.specFunctionObject = NULL;
+            li->invoke = jl_fptr_interpret_call;
+            return jl_fptr_interpret_call;
+        }
+        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF) {
+            jl_printf(JL_STDERR, "code missing for ");
+            jl_static_show(JL_STDERR, (jl_value_t*)li);
+            jl_printf(JL_STDERR, " : sysimg may not have been built with --compile=all\n");
         }
     }
-    jl_llvm_functions_t decls = li->functionObjectsDecls;
-    if (decls.functionObject != NULL || li->jlcall_api == JL_API_CONST)
-        return decls;
 
-    jl_code_info_t *src = NULL;
-    if (jl_is_method(li->def.method) && !jl_is_rettype_inferred(li) &&
-             jl_symbol_name(li->def.method->name)[0] != '@') {
-        // don't bother with typeinf on macros or toplevel thunks
-        // but try to infer everything else
-        src = jl_type_infer(pli, world, 0);
-        li = *pli;
+    jl_llvm_functions_t decls = li->functionObjectsDecls;
+    if (decls.functionObject == NULL) {
+        // if we don't have decls already, try to generate it now
+        jl_code_info_t *src = NULL;
+        if (jl_is_method(li->def.method) && !jl_is_rettype_inferred(li) &&
+                 jl_symbol_name(li->def.method->name)[0] != '@') {
+            // don't bother with typeinf on macros or toplevel thunks
+            // but try to infer everything else
+            src = jl_type_infer(pli, world, 0);
+            li = *pli;
+        }
+
+        // check again, because jl_type_infer may have changed li or compiled it
+        fptr = li->invoke;
+        if (fptr != jl_fptr_trampoline)
+            return fptr;
+        decls = li->functionObjectsDecls;
+        if (decls.functionObject == NULL) {
+            decls = jl_compile_linfo(pli, src, world, &jl_default_cgparams);
+            li = *pli;
+        }
+
+        // check again, of course
+        fptr = li->invoke;
+        if (fptr != jl_fptr_trampoline)
+            return fptr;
+
+        // if it's not inferred (inference failed / disabled), try to just use the unspecialized fptr
+        if (!li->inferred) {
+            if (jl_is_method(li->def.method) && li->def.method->unspecialized) {
+                jl_method_instance_t *unspec = li->def.method->unspecialized;
+                fptr = unspec->invoke;
+                if (fptr != jl_fptr_trampoline) {
+                    li->specptr = unspec->specptr;
+                    li->inferred_const = unspec->inferred_const;
+                    if (li->inferred_const)
+                        jl_gc_wb(li, li->inferred_const);
+                    li->invoke = fptr;
+                    return fptr;
+                }
+            }
+        }
     }
-    // check again, because jl_type_infer may have changed li or compiled it
-    decls = li->functionObjectsDecls;
-    if (decls.functionObject != NULL || li->jlcall_api == JL_API_CONST)
-        return decls;
-    return jl_compile_linfo(&li, src, world, &jl_default_cgparams);
+
+    // ask codegen to make the fptr
+    fptr = jl_generate_fptr(pli, decls, world);
+    return fptr;
+}
+
+JL_DLLEXPORT jl_value_t *jl_fptr_trampoline(jl_method_instance_t *m, jl_value_t **args, uint32_t nargs)
+{
+    size_t world = jl_get_ptls_states()->world_age;
+    jl_callptr_t fptr = jl_compile_method_internal(&m, world);
+    return fptr(m, args, nargs);
+}
+
+JL_DLLEXPORT jl_value_t *jl_fptr_const_return(jl_method_instance_t *m, jl_value_t **args, uint32_t nargs)
+{
+    return m->inferred_const;
+}
+
+JL_DLLEXPORT jl_value_t *jl_fptr_args(jl_method_instance_t *m, jl_value_t **args, uint32_t nargs)
+{
+    return m->specptr.fptr1(args[0], &args[1], nargs - 1);
+}
+
+JL_DLLEXPORT jl_value_t *jl_fptr_sparam(jl_method_instance_t *m, jl_value_t **args, uint32_t nargs)
+{
+    return m->specptr.fptr3(m->sparam_vals, args[0], &args[1], nargs - 1);
+}
+
+// Return the index of the invoke api, if known
+JL_DLLEXPORT int32_t jl_invoke_api(jl_method_instance_t *mi)
+{
+    jl_callptr_t f = mi->invoke;
+    if (f == &jl_fptr_trampoline)
+        return 0;
+    if (f == &jl_fptr_args)
+        return 1;
+    if (f == &jl_fptr_const_return)
+        return 2;
+    if (f == &jl_fptr_sparam)
+        return 3;
+    if (f == &jl_fptr_interpret_call)
+        return 4;
+    return -1;
 }
 
 // compile-time method lookup
@@ -1859,7 +1931,7 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
     jl_code_info_t *src = NULL;
     if (!jl_is_rettype_inferred(li))
         src = jl_type_infer(&li, world, 0);
-    if (li->jlcall_api != JL_API_CONST) {
+    if (li->invoke != jl_fptr_const_return) {
         if (jl_options.outputo || jl_options.outputbc || jl_options.outputunoptbc) {
             // If we are saving LLVM or native code, generate the LLVM IR so that it'll
             // be included in the saved LLVM module.
@@ -1870,12 +1942,7 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
             // don't bother generating anything since it won't be saved.
             // Otherwise (this branch), assuming we are at runtime (normal JIT) and
             // we should generate the native code.
-            jl_ptls_t ptls = jl_get_ptls_states();
-            size_t last_age = ptls->world_age;
-            ptls->world_age = world;
-            jl_generic_fptr_t fptr;
-            jl_compile_method_internal(&fptr, li);
-            ptls->world_age = last_age;
+            (void)jl_compile_method_internal(&li, world);
         }
     }
     return 1;
@@ -2097,7 +2164,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
     jl_method_instance_t *mfunc = jl_lookup_generic_(args, nargs,
                                                      jl_int32hash_fast(jl_return_address()),
                                                      jl_get_ptls_states()->world_age);
-    jl_value_t *res = jl_call_method_internal(mfunc, args, nargs);
+    jl_value_t *res = mfunc->invoke(mfunc, args, nargs);
     return verify_type(res);
 }
 
@@ -2178,7 +2245,7 @@ jl_value_t *jl_gf_invoke(jl_value_t *types0, jl_value_t **args, size_t nargs)
         JL_UNLOCK(&method->writelock);
     }
     JL_GC_POP();
-    return jl_call_method_internal(mfunc, args, nargs);
+    return mfunc->invoke(mfunc, args, nargs);
 }
 
 JL_DLLEXPORT jl_value_t *jl_get_invoke_lambda(jl_methtable_t *mt,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2082,7 +2082,7 @@ void jl_init_types(void)
     jl_method_instance_type =
         jl_new_datatype(jl_symbol("MethodInstance"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(16,
+                        jl_perm_symsvec(15,
                             "def",
                             "specTypes",
                             "rettype",
@@ -2093,12 +2093,11 @@ void jl_init_types(void)
                             "min_world",
                             "max_world",
                             "inInference",
-                            "jlcall_api",
                             "",
-                            "fptr",
-                            "unspecialized_ducttape",
+                            "invoke",
+                            "specptr",
                             "", ""),
-                        jl_svec(16,
+                        jl_svec(15,
                             jl_new_struct(jl_uniontype_type, jl_method_type, jl_module_type),
                             jl_any_type,
                             jl_any_type,
@@ -2109,7 +2108,6 @@ void jl_init_types(void)
                             jl_long_type,
                             jl_long_type,
                             jl_bool_type,
-                            jl_uint8_type,
                             jl_bool_type,
                             jl_any_type, // void*
                             jl_any_type, // void*
@@ -2194,10 +2192,10 @@ void jl_init_types(void)
 #endif
     jl_svecset(jl_methtable_type->types, 8, jl_int32_type); // uint32_t
     jl_svecset(jl_method_type->types, 10, jl_method_instance_type);
+    jl_svecset(jl_method_instance_type->types, 11, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 13, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 14, jl_voidpointer_type);
-    jl_svecset(jl_method_instance_type->types, 15, jl_voidpointer_type);
 
     jl_compute_field_offsets(jl_datatype_type);
     jl_compute_field_offsets(jl_typename_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -201,36 +201,34 @@ union jl_typemap_t {
     struct _jl_value_t *unknown; // nothing
 };
 
-// calling conventions for externally-callable julia entry points.
-// this is used to set jlcall_api fields
-typedef enum {
-    JL_API_NOT_SET = 0,
-    JL_API_GENERIC = 1,         // (function, args ptr, arg count)
-    JL_API_CONST = 2,           // result is a constant value, no function pointer
-    JL_API_WITH_PARAMETERS = 3, // (svec of static parameter values, function, args ptr, arg count)
-    JL_API_INTERPRETED = 4,     // jl_interpret_call(method_instance, func and args ptr, arg count + 1, svec of sparam_vals)
-} jl_callingconv_t;
+typedef jl_value_t *(jl_call_t)(struct _jl_method_instance_t*, jl_value_t**, uint32_t);
+typedef jl_call_t *jl_callptr_t;
 
-// "jlcall" calling convention signatures.
-// This defines the default ABI used by compiled julia functions.
-typedef jl_value_t *(*jl_fptr_t)(jl_value_t*, jl_value_t**, uint32_t); // JL_API_GENERIC
-typedef jl_value_t *(*jl_fptr_sparam_t)(jl_svec_t*, jl_value_t*, jl_value_t**, uint32_t); // JL_API_WITH_PARAMETERS
-typedef jl_value_t *(*jl_fptr_linfo_t)(struct _jl_method_instance_t*, jl_value_t**, uint32_t, jl_svec_t*); // JL_API_INTERPRETED
+// "speccall" calling convention signatures.
+// This describes some of the special ABI used by compiled julia functions.
+JL_DLLEXPORT extern jl_call_t jl_fptr_trampoline;
 
-JL_EXTENSION typedef struct {
-    union {
-        jl_fptr_t fptr;
-        jl_fptr_t fptr1;
-        // constant fptr2;
-        jl_fptr_sparam_t fptr3;
-        jl_fptr_linfo_t fptr4;
-    };
-    uint8_t jlcall_api;
-} jl_generic_fptr_t;
+JL_DLLEXPORT extern jl_call_t jl_fptr_args;
+typedef jl_value_t *(*jl_fptr_args_t)(jl_value_t*, jl_value_t**, uint32_t);
+
+JL_DLLEXPORT extern jl_call_t jl_fptr_const_return;
+
+JL_DLLEXPORT extern jl_call_t jl_fptr_sparam;
+typedef jl_value_t *(*jl_fptr_sparam_t)(jl_svec_t*, jl_value_t*, jl_value_t**, uint32_t);
+
+JL_DLLEXPORT extern jl_call_t jl_fptr_interpret_call;
+typedef jl_value_t *(*jl_fptr_interpret_t)(struct _jl_method_instance_t*, jl_value_t*, jl_value_t**, uint32_t, jl_svec_t*);
+
+JL_EXTENSION typedef union {
+    void* fptr;
+    jl_fptr_args_t fptr1;
+    jl_fptr_sparam_t fptr3;
+    jl_fptr_interpret_t fptr4;
+} jl_generic_specptr_t;
 
 typedef struct _jl_llvm_functions_t {
-    const char *functionObject;     // jlcall llvm Function name
-    const char *specFunctionObject; // specialized llvm Function name
+    const char *functionObject;         // jl_callptr_t llvm Function name
+    const char *specFunctionObject;     // specialized llvm Function name (on sig+rettype)
 } jl_llvm_functions_t;
 
 // This type describes a single function body
@@ -301,15 +299,14 @@ typedef struct _jl_method_instance_t {
     jl_value_t *rettype; // return type for fptr
     jl_svec_t *sparam_vals; // static parameter values, indexed by def.method->sparam_syms
     jl_array_t *backedges;
-    jl_value_t *inferred;  // inferred jl_code_info_t, or value of the function if jlcall_api == JL_API_CONST, or null
+    jl_value_t *inferred;  // inferred jl_code_info_t, or jl_nothing, or null
     jl_value_t *inferred_const; // inferred constant return value, or null
     size_t min_world;
     size_t max_world;
     uint8_t inInference; // flags to tell if inference is running on this function
-    uint8_t jlcall_api;
     uint8_t compile_traced; // if set will notify callback if this linfo is compiled
-    jl_fptr_t fptr; // jlcall entry point with api specified by jlcall_api
-    jl_fptr_t unspecialized_ducttape; // if template can't be compiled due to intrinsics, an un-inferred fptr may get stored here, jlcall_api = JL_API_GENERIC
+    jl_callptr_t invoke; // jlcall entry point
+    jl_generic_specptr_t specptr;
 
     // names of declarations in the JIT,
     // suitable for referencing in LLVM IR
@@ -1522,6 +1519,7 @@ STATIC_INLINE int jl_vinfo_usedundef(uint8_t vi)
 
 JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs);
 JL_DLLEXPORT jl_value_t *jl_invoke(jl_method_instance_t *meth, jl_value_t **args, uint32_t nargs);
+JL_DLLEXPORT int32_t jl_invoke_api(jl_method_instance_t *mi);
 
 STATIC_INLINE
 jl_value_t *jl_apply(jl_value_t **args, uint32_t nargs)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -321,86 +321,19 @@ jl_svec_t *jl_perm_symsvec(size_t n, ...);
 
 jl_value_t *jl_gc_realloc_string(jl_value_t *s, size_t sz);
 
-jl_code_info_t *jl_type_infer(jl_method_instance_t **li JL_ROOTS_TEMPORARILY, size_t world, int force);
-jl_generic_fptr_t jl_generate_fptr(jl_method_instance_t *li, const char *F, size_t world);
+jl_code_info_t *jl_type_infer(jl_method_instance_t **pli JL_ROOTS_TEMPORARILY, size_t world, int force);
+jl_callptr_t jl_generate_fptr(jl_method_instance_t **pli, jl_llvm_functions_t decls, size_t world);
 jl_llvm_functions_t jl_compile_linfo(
         jl_method_instance_t **pli,
         jl_code_info_t *src JL_MAYBE_UNROOTED,
         size_t world,
         const jl_cgparams_t *params);
-jl_llvm_functions_t jl_compile_for_dispatch(jl_method_instance_t **li, size_t world);
+jl_callptr_t jl_compile_method_internal(jl_method_instance_t **pmeth, size_t world);
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
-jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs);
 jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *lam);
 int jl_code_requires_compiler(jl_code_info_t *src);
 jl_code_info_t *jl_new_code_info_from_ast(jl_expr_t *ast);
 JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
-
-STATIC_INLINE jl_value_t *jl_compile_method_internal(jl_generic_fptr_t *fptr,
-                                                     jl_method_instance_t *meth)
-{
-    if (meth->jlcall_api == JL_API_CONST)
-        return jl_assume(meth->inferred_const);
-    fptr->fptr = meth->fptr;
-    fptr->jlcall_api = meth->jlcall_api;
-    if (__unlikely(fptr->fptr == NULL || fptr->jlcall_api == 0)) {
-        size_t world = jl_get_ptls_states()->world_age;
-        // first see if it likely needs to be compiled
-        const char *F = meth->functionObjectsDecls.functionObject;
-        if (!F) // ask codegen to try to turn it into llvm code
-            F = jl_compile_for_dispatch(&meth, world).functionObject;
-        if (meth->jlcall_api == JL_API_CONST)
-            return jl_assume(meth->inferred_const);
-        // if it hasn't been inferred, try using the unspecialized meth cache instead
-        if (!meth->inferred) {
-            fptr->fptr = meth->unspecialized_ducttape;
-            fptr->jlcall_api = JL_API_GENERIC;
-            if (!fptr->fptr) {
-                if (jl_is_method(meth->def.method) && meth->def.method->unspecialized) {
-                    fptr->fptr = meth->def.method->unspecialized->fptr;
-                    fptr->jlcall_api = meth->def.method->unspecialized->jlcall_api;
-                    if (fptr->jlcall_api == 2) {
-                        return jl_assume(meth->def.method->unspecialized->inferred_const);
-                    }
-                }
-            }
-        }
-        if (!fptr->fptr || fptr->jlcall_api == 0) {
-            // ask codegen to make the fptr
-            *fptr = jl_generate_fptr(meth, F, world);
-            if (fptr->jlcall_api == JL_API_CONST)
-                return jl_assume(meth->inferred_const);
-        }
-    }
-    return NULL;
-}
-
-STATIC_INLINE jl_value_t *jl_call_fptr_internal(const jl_generic_fptr_t *fptr,
-                                                jl_method_instance_t *meth,
-                                                jl_value_t **args, uint32_t nargs)
-{
-    if (fptr->jlcall_api == JL_API_GENERIC)
-        return fptr->fptr1(args[0], &args[1], nargs-1);
-    else if (fptr->jlcall_api == JL_API_CONST)
-        return meth->inferred;
-    else if (fptr->jlcall_api == JL_API_WITH_PARAMETERS)
-        return fptr->fptr3(meth->sparam_vals, args[0], &args[1], nargs-1);
-    else if (fptr->jlcall_api == JL_API_INTERPRETED)
-        return fptr->fptr4(meth, &args[0], nargs, meth->sparam_vals);
-    else
-        abort();
-}
-
-// invoke (compiling if necessary) the jlcall function pointer for a method
-STATIC_INLINE jl_value_t *jl_call_method_internal(jl_method_instance_t *meth, jl_value_t **args, uint32_t nargs)
-{
-    jl_generic_fptr_t fptr;
-    jl_value_t *v = jl_compile_method_internal(&fptr, meth);
-    if (v)
-        return v;
-    (void)jl_assume(fptr.jlcall_api != JL_API_CONST);
-    return jl_call_fptr_internal(&fptr, meth, args, nargs);
-}
 
 jl_value_t *jl_argtype_with_function(jl_function_t *f, jl_value_t *types);
 
@@ -458,7 +391,7 @@ void jl_install_default_signal_handlers(void);
 void restore_signals(void);
 void jl_install_thread_signal_handler(jl_ptls_t ptls);
 
-jl_fptr_t jl_get_builtin_fptr(jl_value_t *b);
+jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b);
 
 extern uv_loop_t *jl_io_loop;
 void jl_uv_flush(uv_stream_t *stream);
@@ -477,7 +410,7 @@ int jl_has_concrete_subtype(jl_value_t *typ) JL_NOTSAFEPOINT;
 jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np) JL_ALWAYS_LEAFTYPE;
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p) JL_ALWAYS_LEAFTYPE;
 JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
-void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_t fptr) JL_GC_DISABLED;
+void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
 jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty);
 jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
 int jl_subtype_matching(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
@@ -631,7 +564,6 @@ JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char*
 void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *sysimg_data, size_t sysimg_len);
 int32_t jl_get_llvm_gv(jl_value_t *p);
 int32_t jl_assign_functionID(const char *fname);
-int32_t jl_jlcall_api(const char *fname);
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns
 JL_DLLEXPORT jl_array_t *jl_idtable_rehash(jl_array_t *a, size_t newsz);
@@ -648,7 +580,7 @@ JL_DLLEXPORT void jl_method_instance_add_backedge(jl_method_instance_t *callee, 
 JL_DLLEXPORT void jl_method_table_add_backedge(jl_methtable_t *mt, jl_value_t *typ, jl_value_t *caller);
 
 uint32_t jl_module_next_counter(jl_module_t *m);
-void jl_fptr_to_llvm(jl_fptr_t fptr, jl_method_instance_t *lam, int specsig);
+void jl_fptr_to_llvm(void *fptr, jl_method_instance_t *lam, int spec_abi);
 jl_tupletype_t *arg_type_tuple(jl_value_t **args, size_t nargs);
 
 int jl_has_meta(jl_array_t *body, jl_sym_t *sym);

--- a/src/method.c
+++ b/src/method.c
@@ -235,9 +235,8 @@ JL_DLLEXPORT jl_method_instance_t *jl_new_method_instance_uninit(void)
     li->rettype = (jl_value_t*)jl_any_type;
     li->sparam_vals = jl_emptysvec;
     li->backedges = NULL;
-    li->fptr = NULL;
-    li->unspecialized_ducttape = NULL;
-    li->jlcall_api = 0;
+    li->invoke = jl_fptr_trampoline;
+    li->specptr.fptr = NULL;
     li->compile_traced = 0;
     li->functionObjectsDecls.functionObject = NULL;
     li->functionObjectsDecls.specFunctionObject = NULL;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -57,8 +57,7 @@ jl_array_t *jl_module_init_order;
 static htable_t fptr_to_id;
 // array of definitions for the predefined function pointers
 // (reverse of fptr_to_id)
-static const jl_fptr_t id_to_fptrs[] = {
-    NULL, NULL,
+static const jl_fptr_args_t id_to_fptrs[] = {
     jl_f_throw, jl_f_is, jl_f_typeof, jl_f_issubtype, jl_f_isa,
     jl_f_typeassert, jl_f__apply, jl_f__apply_pure, jl_f__apply_latest, jl_f_isdefined,
     jl_f_tuple, jl_f_svec, jl_f_intrinsic_call, jl_f_invoke_kwsorter,
@@ -99,8 +98,23 @@ enum RefTags {
     ConstDataRef,
     TagRef,
     SymbolRef,
-    BindingRef
+    BindingRef,
+    FunctionRef,
+    BuiltinFunctionRef
 };
+
+// calling conventions for internal entry points.
+// this is used to set the method-instance->invoke field
+typedef enum {
+    JL_API_TRAMPOLINE,
+    JL_API_BOXED,
+    JL_API_CONST,
+    JL_API_WITH_PARAMETERS,
+    JL_API_INTERPRETED,
+    JL_API_BUILTIN,
+    JL_API_MAX
+} jl_callingconv_t;
+
 
 // this supports up to 1 GB images and 16 RefTags
 // if a larger size is required, will need to add support for writing larger relocations in many cases below
@@ -190,25 +204,10 @@ static uintptr_t jl_fptr_id(void *fptr)
 {
     void **pbp = ptrhash_bp(&fptr_to_id, fptr);
     if (*pbp == HT_NOTFOUND || fptr == NULL)
-        return 1;
+        return 0;
     else
         return *(uintptr_t*)pbp;
 }
-
-int32_t jl_jlcall_api(const char *fname)
-{
-    // give the function an index in the constant lookup table
-    if (fname == NULL)
-        return 0;
-    if (!strncmp(fname, "japi3_", 6)) // jlcall abi 3 from JIT
-        return JL_API_WITH_PARAMETERS;
-    assert(!strncmp(fname, "japi1_", 6) ||  // jlcall abi 1 from JIT
-           !strncmp(fname, "jsys1_", 6) ||  // jlcall abi 1 from sysimg
-           !strncmp(fname, "jlcall_", 7) || // jlcall abi 1 from JIT wrapping a specsig method
-           !strncmp(fname, "jlsysw_", 7));  // jlcall abi 1 from sysimg wrapping a specsig method
-    return JL_API_GENERIC;
-}
-
 
 #define jl_serialize_value(s, v) jl_serialize_value_(s,(jl_value_t*)(v))
 static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v);
@@ -655,50 +654,63 @@ static void jl_write_values(jl_serializer_state *s)
             else if (jl_is_method_instance(v)) {
                 jl_method_instance_t *m = (jl_method_instance_t*)v;
                 jl_method_instance_t *newm = (jl_method_instance_t*)&s->s->buf[reloc_offset];
-                newm->fptr = NULL;
-                newm->unspecialized_ducttape = NULL;
-                if (jl_is_method(m->def.method)) {
-                    uintptr_t fptr_id = jl_fptr_id((void*)(uintptr_t)m->fptr);
-                    if (m->jlcall_api == JL_API_CONST) {
-                    }
-                    else if (fptr_id >= 2) {
-                        //write_int8(s->s, -li->jlcall_api);
-                        //write_uint16(s->s, fptr_id);
-                        newm->fptr = (jl_fptr_t)fptr_id;
-                        arraylist_push(&reinit_list, (void*)item);
-                        arraylist_push(&reinit_list, (void*)6);
-                    }
-                    else if (m->functionObjectsDecls.functionObject) {
-                        int jlcall_api = jl_jlcall_api(m->functionObjectsDecls.functionObject);
-                        assert(jlcall_api);
-                        newm->jlcall_api = jlcall_api;
-                        // save functionObject pointers
-                        int cfunc = jl_assign_functionID(m->functionObjectsDecls.specFunctionObject);
-                        int func = jl_assign_functionID(m->functionObjectsDecls.functionObject);
-                        assert(reloc_offset < INT32_MAX);
-                        if (cfunc != 0) {
-                            ios_ensureroom(s->fptr_record, cfunc * sizeof(void*));
-                            ios_seek(s->fptr_record, (cfunc - 1) * sizeof(void*));
-                            write_uint32(s->fptr_record, ~reloc_offset);
-#ifdef _P64
-                            write_padding(s->fptr_record, 4);
-#endif
-                        }
-                        if (func != 0) {
-                            ios_ensureroom(s->fptr_record, func * sizeof(void*));
-                            ios_seek(s->fptr_record, (func - 1) * sizeof(void*));
-                            write_uint32(s->fptr_record, reloc_offset);
-#ifdef _P64
-                            write_padding(s->fptr_record, 4);
-#endif
-                        }
-                    }
-                    else {
-                        newm->jlcall_api = 0;
-                    }
-                }
+
+                newm->invoke = NULL;
+                newm->specptr.fptr = NULL;
                 newm->functionObjectsDecls.functionObject = NULL;
                 newm->functionObjectsDecls.specFunctionObject = NULL;
+                uintptr_t fptr_id = JL_API_TRAMPOLINE;
+                uintptr_t specfptr_id = 0;
+                if (m->invoke == jl_fptr_const_return) {
+                    fptr_id = JL_API_CONST;
+                }
+                else {
+                    if (jl_is_method(m->def.method)) {
+                        specfptr_id = jl_fptr_id(m->specptr.fptr);
+                        const char *fname = m->functionObjectsDecls.functionObject;
+                        if (specfptr_id) { // found in the table of builtins
+                            assert(specfptr_id >= 2);
+                            fptr_id = JL_API_BUILTIN;
+                        }
+                        else if (fname) {
+                            assert(reloc_offset < INT32_MAX);
+                            if (!strcmp(fname, "jl_fptr_args")) {
+                                fptr_id = JL_API_BOXED;
+                            }
+                            else if (!strcmp(fname, "jl_fptr_sparam")) {
+                                fptr_id = JL_API_WITH_PARAMETERS;
+                            }
+                            else {
+                                int func = jl_assign_functionID(fname);
+                                assert(func > 0);
+                                ios_ensureroom(s->fptr_record, func * sizeof(void*));
+                                ios_seek(s->fptr_record, (func - 1) * sizeof(void*));
+                                write_uint32(s->fptr_record, ~reloc_offset);
+#ifdef _P64
+                                write_padding(s->fptr_record, 4);
+#endif
+                            }
+                            fname = m->functionObjectsDecls.specFunctionObject;
+                            if (fname) {
+                                int cfunc = jl_assign_functionID(fname);
+                                assert(cfunc > 0);
+                                ios_ensureroom(s->fptr_record, cfunc * sizeof(void*));
+                                ios_seek(s->fptr_record, (cfunc - 1) * sizeof(void*));
+                                write_uint32(s->fptr_record, reloc_offset);
+#ifdef _P64
+                                write_padding(s->fptr_record, 4);
+#endif
+                            }
+                        }
+                    }
+                }
+                newm->invoke = NULL; // relocation offset
+                arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_method_instance_t, invoke))); // relocation location
+                arraylist_push(&s->relocs_list, (void*)(((uintptr_t)FunctionRef << RELOC_TAG_OFFSET) + fptr_id)); // relocation target
+                if (specfptr_id >= 2) {
+                    arraylist_push(&s->relocs_list, (void*)(reloc_offset + offsetof(jl_method_instance_t, specptr.fptr))); // relocation location
+                    arraylist_push(&s->relocs_list, (void*)(((uintptr_t)BuiltinFunctionRef << RELOC_TAG_OFFSET) + specfptr_id - 2)); // relocation target
+                }
             }
             else if (jl_is_datatype(v)) {
                 jl_datatype_t *dt = (jl_datatype_t*)v;
@@ -814,9 +826,16 @@ static uintptr_t get_reloc_for_item(uintptr_t reloc_item, size_t reloc_offset)
         case BindingRef:
             assert(offset == 0 && "corrupt relocation offset");
             break;
+        case BuiltinFunctionRef:
+            assert(offset < sizeof(id_to_fptrs) / sizeof(*id_to_fptrs) && "unknown function pointer id");
+            break;
+        case FunctionRef:
+            assert(offset < JL_API_MAX && "unknown function pointer id");
+            break;
         case DataRef:
         default:
             assert("corrupt relocation item id");
+            abort();
         }
 #endif
         return reloc_item; // pre-composed relocation + offset
@@ -842,6 +861,31 @@ static inline uintptr_t get_item_for_reloc(jl_serializer_state *s, uintptr_t bas
         return (uintptr_t)deser_sym.items[offset];
     case BindingRef:
         return jl_buff_tag | GC_OLD_MARKED;
+    case BuiltinFunctionRef:
+        assert(offset < sizeof(id_to_fptrs) / sizeof(*id_to_fptrs) && "unknown function pointer ID");
+        return (uintptr_t)id_to_fptrs[offset];
+    case FunctionRef:
+        switch ((jl_callingconv_t)offset) {
+        case JL_API_BOXED:
+            if (sysimg_fptrs.base)
+                return (uintptr_t)jl_fptr_args;
+            JL_FALLTHROUGH;
+        case JL_API_WITH_PARAMETERS:
+            if (sysimg_fptrs.base)
+                return (uintptr_t)jl_fptr_sparam;
+            JL_FALLTHROUGH;
+        case JL_API_TRAMPOLINE:
+            return (uintptr_t)jl_fptr_trampoline;
+        case JL_API_CONST:
+            return (uintptr_t)jl_fptr_const_return;
+        case JL_API_INTERPRETED:
+            return (uintptr_t)jl_fptr_interpret_call;
+        case JL_API_BUILTIN:
+            return (uintptr_t)jl_fptr_args;
+        case JL_API_MAX:
+        //default:
+            assert("corrupt relocation item id");
+        }
     }
     abort();
 }
@@ -940,6 +984,8 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
     // make these NULL now so we skip trying to restore GlobalVariable pointers later
     sysimg_gvars_base = NULL;
     sysimg_fptrs.base = NULL;
+    if (fvars.base == NULL)
+        return;
     int sysimg_fvars_max = s->fptr_record->size / sizeof(void*);
     size_t i;
     uintptr_t base = (uintptr_t)&s->s->buf[0];
@@ -949,36 +995,35 @@ static void jl_update_all_fptrs(jl_serializer_state *s)
         uintptr_t val = (uintptr_t)&linfos[i];
         uint32_t offset = load_uint32(&val);
         if (offset != 0) {
-            int cfunc = 0;
+            int specfunc = 1;
             if (offset & ((uintptr_t)1 << (8 * sizeof(uint32_t) - 1))) {
-                // if high bit is set, this is cfunc, not func
-                cfunc = 1;
+                // if high bit is set, this is the func wrapper, not the specfunc
+                specfunc = 0;
                 offset = ~offset;
             }
             jl_method_instance_t *li = (jl_method_instance_t*)(base + offset);
-            if (fvars.base == NULL) {
-                li->jlcall_api = 0;
+            uintptr_t base = (uintptr_t)fvars.base;
+            assert(jl_is_method(li->def.method) && li->invoke != jl_fptr_const_return);
+            assert(specfunc ? li->invoke != jl_fptr_trampoline : li->invoke == jl_fptr_trampoline);
+            linfos[i] = li;
+            int32_t offset = fvars.offsets[i];
+            for (; clone_idx < fvars.nclones; clone_idx++) {
+                uint32_t idx = fvars.clone_idxs[clone_idx] & jl_sysimg_val_mask;
+                if (idx < i)
+                    continue;
+                if (idx == i)
+                    offset = fvars.clone_offsets[clone_idx];
+                break;
             }
-            else {
-                uintptr_t base = (uintptr_t)fvars.base;
-                assert(jl_is_method(li->def.method) && li->jlcall_api && li->jlcall_api != JL_API_CONST);
-                linfos[i] = li;
-                int32_t offset = fvars.offsets[i];
-                for (; clone_idx < fvars.nclones; clone_idx++) {
-                    uint32_t idx = fvars.clone_idxs[clone_idx] & jl_sysimg_val_mask;
-                    if (idx < i)
-                        continue;
-                    if (idx == i)
-                        offset = fvars.clone_offsets[clone_idx];
-                    break;
-                }
-                jl_fptr_to_llvm((jl_fptr_t)(base + offset), li, cfunc);
-            }
+            void *fptr = (void*)(base + offset);
+            if (specfunc)
+                li->specptr.fptr = fptr;
+            else
+                li->invoke = (jl_callptr_t)fptr;
+            jl_fptr_to_llvm(fptr, li, specfunc);
         }
     }
-    if (fvars.base) {
-        jl_register_fptrs(sysimage_base, &fvars, linfos, sysimg_fvars_max);
-    }
+    jl_register_fptrs(sysimage_base, &fvars, linfos, sysimg_fvars_max);
 }
 
 
@@ -1093,14 +1138,6 @@ static void jl_reinit_item(jl_value_t *v, int how, arraylist_t *tracee_list)
                     b += 1;
                     nbindings -= 1;
                 }
-                break;
-            }
-            case 6: { // assign the real fptr for m
-                jl_method_instance_t *m = (jl_method_instance_t*)v;
-                uintptr_t fptr_id = (uintptr_t)m->fptr;
-                assert(fptr_id <= sizeof(id_to_fptrs) / sizeof(*id_to_fptrs) &&
-                       fptr_id >= 2 && "unknown function pointer ID");
-                m->fptr = id_to_fptrs[fptr_id];
                 break;
             }
             default:
@@ -1648,10 +1685,8 @@ static void jl_init_serializer2(int for_serialize)
     }
 
     if (for_serialize) {
-        i = 2;
-        while (id_to_fptrs[i] != NULL) {
-            ptrhash_put(&fptr_to_id, (void*)(uintptr_t)id_to_fptrs[i], (void*)i);
-            i += 1;
+        for (i = 0; id_to_fptrs[i] != NULL; i++) {
+            ptrhash_put(&fptr_to_id, (void*)(uintptr_t)id_to_fptrs[i], (void*)(i + 2));
         }
     }
 

--- a/src/threading.h
+++ b/src/threading.h
@@ -40,7 +40,7 @@ enum {
 typedef struct {
     uint8_t command;
     jl_method_instance_t *mfunc;
-    jl_generic_fptr_t fptr;
+    jl_callptr_t fptr;
     jl_value_t **args;
     uint32_t nargs;
     jl_value_t *ret;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -808,7 +808,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
             jl_type_infer(&li, world, 0);
         }
         jl_value_t *dummy_f_arg = NULL;
-        result = jl_call_method_internal(li, &dummy_f_arg, 1);
+        result = li->invoke(li, &dummy_f_arg, 1);
     }
     else {
         // use interpreter

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1031,9 +1031,9 @@ function test_const_return(@nospecialize(f), @nospecialize(t), @nospecialize(val
     # If coverage is not enabled, make the check strict by requiring constant ABI
     # Otherwise, check the typed AST to make sure we return a constant.
     if Base.JLOptions().code_coverage == 0
-        @test linfo.jlcall_api == 2
+        @test Core.Compiler.invoke_api(linfo) == 2
     end
-    if linfo.jlcall_api == 2
+    if Core.Compiler.invoke_api(linfo) == 2
         @test linfo.inferred_const == val
         return
     end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -274,9 +274,12 @@ for (f, t) in Any[(definitely_not_in_sysimg, Tuple{}),
     world = typemax(UInt)
     linfo = ccall(:jl_specializations_get_linfo, Ref{Core.MethodInstance}, (Any, Any, Any, UInt), meth, tt, env, world)
     params = Base.CodegenParams()
-    llvmf = ccall(:jl_get_llvmf_decl, Ptr{Cvoid}, (Any, UInt, Bool, Base.CodegenParams), linfo::Core.MethodInstance, world, true, params)
-    @test llvmf != C_NULL
-    @test ccall(:jl_get_llvm_fptr, Ptr{Cvoid}, (Ptr{Cvoid},), llvmf) != C_NULL
+    llvmf1 = ccall(:jl_get_llvmf_decl, Ptr{Cvoid}, (Any, UInt, Bool, Base.CodegenParams), linfo::Core.MethodInstance, world, true, params)
+    @test llvmf1 != C_NULL
+    llvmf2 = ccall(:jl_get_llvmf_decl, Ptr{Cvoid}, (Any, UInt, Bool, Base.CodegenParams), linfo::Core.MethodInstance, world, false, params)
+    @test llvmf2 != C_NULL
+    @test ccall(:jl_get_llvm_fptr, Ptr{Cvoid}, (Ptr{Cvoid},), llvmf1) != C_NULL
+    @test ccall(:jl_get_llvm_fptr, Ptr{Cvoid}, (Ptr{Cvoid},), llvmf2) != C_NULL
 end
 
 # issue #15714


### PR DESCRIPTION
Uses a trampoline to reduce the number of jump checks to happen during dynamic dispatch. It used to be done this way initially, but that got lost for awhile after the function-types PR. This brings back the ability to directly call a method without going through the dispatch helper function.

(over)estimated performance jump is pretty good for certain cases:  17.31 ns =>  13.82 ns

```julia
julia> @noinline f(a) = a
julia> g = []
julia> @noinline function unstable_no_alloc(n::Int)
                  for s = 1:n
                      f(g)
                  end
              end
@btime unstable_no_alloc(100_000)
```