### PR TITLE
Get rid of conversions in UnitRange iterator

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -452,9 +452,9 @@ start(r::StepRangeLen) = 1
 next(r::StepRangeLen{T}, i) where {T} = unsafe_getindex(r, i), i+1
 done(r::StepRangeLen, i) = i > length(r)
 
-start(r::UnitRange{T}) where {T} = oftype(r.start + oneunit(T), r.start)
-next(r::AbstractUnitRange{T}, i) where {T} = (convert(T, i), i + oneunit(T))
-done(r::AbstractUnitRange{T}, i) where {T} = i == oftype(i, r.stop) + oneunit(T)
+start(r::UnitRange{T}) where {T} = r.start
+next(r::AbstractUnitRange{T}, i) where {T} = (i, i + oneunit(T))
+done(r::AbstractUnitRange{T}, i) where {T} = i == r.stop + oneunit(T)
 
 start(r::OneTo{T}) where {T} = oneunit(T)
 


### PR DESCRIPTION
In some applications iteration over `UnitRange{Int32}` is way slower than a handwritten loop. For example:

```julia
function copy_via_iterator!(x::AbstractVector{Ti}, r::UnitRange{Ti}) where {Ti}
    @inbounds for (i, j) = enumerate(r)
        x[i] = j
    end

    x
end

function copy_via_loop!(x::AbstractVector{Ti}, r::UnitRange{Ti}) where {Ti}
    value = r.start
    @inbounds for i = 1 : length(r)
        x[i] = value
        value += one(Ti)
    end

    x
end

function bench(n = 5000)
    v = Vector{Int32}(undef, n)
    r = Int32(1) : Int32(n)

    @assert copy_via_loop!(similar(v), r) == copy_via_iterator!(similar(v), r)

    a = @benchmark copy_via_loop!($v, $r)
    b = @benchmark copy_via_iterator!($v, $r)

    a, b
end
```

Before: (Trial(203.847 ns), Trial(827.101 ns))
After this PR: Trial(204.140 ns), Trial(203.795 ns))

This PR makes the iterator equivalent to the code in `copy_via_loop!`. Maybe there's a good reason for the current implementation, but the tests will probably tell.

Apparently `copyto!` is even slower, but that seems to be related to indexing of `UnitRange{Int32}` with `Int64` integers and will be the next PR.