### PR TITLE
Add SuiteSparse symlinks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -129,9 +129,10 @@ script:
     # compile / install Julia
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - if [ `uname` = "Darwin" ]; then
-        for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do
+        for name in suitesparseconfig spqr umfpack colamd cholmod amd; do
             install -pm755 usr/lib/julia/lib${name}*.dylib* /tmp/julia/lib/julia/;
         done;
+        install -pm755 usr/lib/libsuitesparse_wrapper*.dylib* /tmp/julia/lib/julia/;
       fi
     - make $BUILDOPTS NO_GIT=1 build-stats
     - du -sk /tmp/julia/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ script:
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
     - if [ `uname` = "Darwin" ]; then
         for name in suitesparseconfig spqr umfpack colamd cholmod amd suitesparse_wrapper; do
-            install -pm755 usr/lib/lib${name}*.dylib* /tmp/julia/lib/julia/;
+            install -pm755 usr/lib/julia/lib${name}*.dylib* /tmp/julia/lib/julia/;
         done;
       fi
     - make $BUILDOPTS NO_GIT=1 build-stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,12 +128,6 @@ script:
           false; }
     # compile / install Julia
     - make $BUILDOPTS NO_GIT=1 prefix=/tmp/julia install | moreutils/ts -s "%.s"
-    - if [ `uname` = "Darwin" ]; then
-        for name in suitesparseconfig spqr umfpack colamd cholmod amd; do
-            install -pm755 usr/lib/julia/lib${name}*.dylib* /tmp/julia/lib/julia/;
-        done;
-        install -pm755 usr/lib/libsuitesparse_wrapper*.dylib* /tmp/julia/lib/julia/;
-      fi
     - make $BUILDOPTS NO_GIT=1 build-stats
     - du -sk /tmp/julia/*
     - ls -l /tmp/julia/lib

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ JL_LIBS := julia julia-debug
 JL_PRIVATE_LIBS-0 := libccalltest
 ifeq ($(USE_GPL_LIBS), 1)
 JL_PRIVATE_LIBS-0 += libsuitesparse_wrapper
+JL_PRIVATE_LIBS-$(USE_SYSTEM_SUITESPARSE) += libamd libcamd libccolamd libcholmod libcolamd libumfpack libspqr libsuitesparseconfig
 endif
 JL_PRIVATE_LIBS-$(USE_SYSTEM_PCRE) += libpcre2-8
 JL_PRIVATE_LIBS-$(USE_SYSTEM_DSFMT) += libdSFMT
@@ -246,12 +247,6 @@ endif
 JL_PRIVATE_LIBS-$(USE_SYSTEM_BLAS) += $(LIBBLASNAME)
 ifneq ($(LIBLAPACKNAME),$(LIBBLASNAME))
 JL_PRIVATE_LIBS-$(USE_SYSTEM_LAPACK) += $(LIBLAPACKNAME)
-endif
-
-ifeq ($(USE_GPL_LIBS), 1)
-ifeq ($(USE_SYSTEM_SUITESPARSE),0)
-JL_PRIVATE_LIBS-0 += libamd libcamd libccolamd libcholmod libcolamd libumfpack libspqr libsuitesparseconfig
-endif
 endif
 
 ifeq ($(OS),Darwin)

--- a/base/Makefile
+++ b/base/Makefile
@@ -163,7 +163,7 @@ endif
 endif
 endef
 
-# the following excludes: libuv.a, libutf8proc.a, suitesparse*
+# the following excludes: libuv.a, libutf8proc.a
 
 $(eval $(call symlink_system_library,$(LIBMNAME)))
 ifneq ($(USE_SYSTEM_LIBM),0)
@@ -185,6 +185,14 @@ $(eval $(call symlink_system_library,libmbedtls,MBEDTLS))
 $(eval $(call symlink_system_library,libssh2,LIBSSH2))
 $(eval $(call symlink_system_library,libcurl,CURL))
 $(eval $(call symlink_system_library,libgit2,LIBGIT2))
+$(eval $(call symlink_system_library,libamd,SUITESPARSE))
+$(eval $(call symlink_system_library,libcamd,SUITESPARSE))
+$(eval $(call symlink_system_library,libccolamd,SUITESPARSE))
+$(eval $(call symlink_system_library,libcholmod,SUITESPARSE))
+$(eval $(call symlink_system_library,libcolamd,SUITESPARSE))
+$(eval $(call symlink_system_library,libumfpack,SUITESPARSE))
+$(eval $(call symlink_system_library,libspqr,SUITESPARSE))
+$(eval $(call symlink_system_library,libsuitesparseconfig,SUITESPARSE))
 ifneq ($(DISABLE_LIBUNWIND),0)
 $(eval $(call symlink_system_library,libunwind,LIBUNWIND))
 endif

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -31,6 +31,8 @@ default:
 	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_private_libdir)/libamd.$(SHLIB_EXT)
 	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libcamd.$(SHLIB_EXT) $(build_private_libdir)/libcamd.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libccolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libccolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libccolamd.$(SHLIB_EXT) $(build_private_libdir)/libccolamd.$(SHLIB_EXT)
 	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_private_libdir)/libcolamd.$(SHLIB_EXT)
 	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcholmod.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd $(RPATH_ORIGIN)

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -13,7 +13,7 @@ ifeq ($(USE_SYSTEM_LAPACK),0)
 
 $(build_private_libdir)/libgfortblas.dylib:
 	mkdir -p $(build_private_libdir)
-	make -C ../deps/ @$
+	make -C ../deps/ $@
 
 default: $(build_private_libdir)/libgfortblas.dylib
 endif

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -13,7 +13,7 @@ ifeq ($(USE_SYSTEM_LAPACK),0)
 
 $(build_libdir)/libgfortblas.dylib:
 	mkdir -p $(build_libdir)
-	make -C ../deps/ $(build_libdir)/libgfortblas.dylib
+	make -C ../deps/ $(build_private_libdir)/libgfortblas.dylib
 
 default: $(build_libdir)/libgfortblas.dylib
 endif

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -29,6 +29,8 @@ default:
 	$(INSTALL_NAME_CMD)libsuitesparseconfig.$(SHLIB_EXT) $(build_private_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
 	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_private_libdir)/libamd.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libcamd.$(SHLIB_EXT) $(build_private_libdir)/libcamd.$(SHLIB_EXT)
 	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
 	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_private_libdir)/libcolamd.$(SHLIB_EXT)
 	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcholmod.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd $(RPATH_ORIGIN)

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -24,7 +24,7 @@ default:
 	mkdir -p $(build_private_libdir)
 	mkdir -p $(JULIAHOME)/deps/build/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/build/SuiteSparse-SYSTEM/lib && \
-	rm -f $(build_private_libdir)/lib{amd,cholmod,colamd,spqr,umfpack}.$(SHLIB_EXT)
+	rm -f $(build_private_libdir)/lib{amd,camd,cholmod,ccolamd,colamd,spqr,umfpack}.$(SHLIB_EXT)
 	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
 	$(INSTALL_NAME_CMD)libsuitesparseconfig.$(SHLIB_EXT) $(build_private_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
 	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)

--- a/contrib/repackage_system_suitesparse4.make
+++ b/contrib/repackage_system_suitesparse4.make
@@ -11,30 +11,30 @@ ifeq ($(OS),Darwin)
 ifeq ($(USE_SYSTEM_BLAS),1)
 ifeq ($(USE_SYSTEM_LAPACK),0)
 
-$(build_libdir)/libgfortblas.dylib:
-	mkdir -p $(build_libdir)
-	make -C ../deps/ $(build_private_libdir)/libgfortblas.dylib
+$(build_private_libdir)/libgfortblas.dylib:
+	mkdir -p $(build_private_libdir)
+	make -C ../deps/ @$
 
-default: $(build_libdir)/libgfortblas.dylib
+default: $(build_private_libdir)/libgfortblas.dylib
 endif
 endif
 endif
 
 default:
-	mkdir -p $(build_libdir)
+	mkdir -p $(build_private_libdir)
 	mkdir -p $(JULIAHOME)/deps/build/SuiteSparse-SYSTEM/lib
 	cd $(JULIAHOME)/deps/build/SuiteSparse-SYSTEM/lib && \
-	rm -f $(build_libdir)/lib{amd,cholmod,colamd,spqr,umfpack}.$(SHLIB_EXT)
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
-	$(INSTALL_NAME_CMD)libsuitesparseconfig.$(SHLIB_EXT) $(build_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
-	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_libdir)/libamd.$(SHLIB_EXT)
-	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
-	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_libdir)/libcolamd.$(SHLIB_EXT)
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcholmod.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd $(RPATH_ORIGIN)
-	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(build_libdir)/libcholmod.$(SHLIB_EXT)
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libumfpack.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
-	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(build_libdir)/libumfpack.$(SHLIB_EXT)
-	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libspqr.a $(NO_WHOLE_ARCHIVE) -o $(build_libdir)/libspqr.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
-	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_libdir)/libspqr.$(SHLIB_EXT)
+	rm -f $(build_private_libdir)/lib{amd,cholmod,colamd,spqr,umfpack}.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libsuitesparseconfig.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
+	$(INSTALL_NAME_CMD)libsuitesparseconfig.$(SHLIB_EXT) $(build_private_libdir)/libsuitesparseconfig.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libamd.$(SHLIB_EXT) $(LDFLAGS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libamd.$(SHLIB_EXT) $(build_private_libdir)/libamd.$(SHLIB_EXT)
+	$(CC) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcolamd.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcolamd.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libcolamd.$(SHLIB_EXT) $(build_private_libdir)/libcolamd.$(SHLIB_EXT)
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libcholmod.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libcholmod.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libcholmod.$(SHLIB_EXT) $(build_private_libdir)/libcholmod.$(SHLIB_EXT)
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libumfpack.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libumfpack.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libumfpack.$(SHLIB_EXT) $(build_private_libdir)/libumfpack.$(SHLIB_EXT)
+	$(CXX) -shared $(WHOLE_ARCHIVE) $(SS_LIB)/libspqr.a $(NO_WHOLE_ARCHIVE) -o $(build_private_libdir)/libspqr.$(SHLIB_EXT) $(LDFLAGS) $(LIBBLAS) -L$(build_private_libdir) -lsuitesparseconfig -lcolamd -lccolamd -lcamd -lamd -lcholmod $(RPATH_ORIGIN)
+	$(INSTALL_NAME_CMD)libspqr.$(SHLIB_EXT) $(build_private_libdir)/libspqr.$(SHLIB_EXT)
 


### PR DESCRIPTION
These symlinks are needed to load SuiteSparse dynamically, yet they were not created with `USE_SYSTEM_SUITEPARSE=1`. This affects distribution packages (see https://discourse.julialang.org/t/nightly-builds-from-copr-missing-a-dependency-on-fedora-centos-rhel-etc/9857).

@vtjnash I may well be missing something, since I don't understand why I excluded SuiteSparse from the list in the first place.

EDIT: the OS X failure looks real.