### PR TITLE
Use count instead of sum in rank...

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -726,7 +726,7 @@ julia> rank(diagm(0 => [1, 0.001, 2]), 0.00001)
 """
 function rank(A::AbstractMatrix, tol::Real = min(size(A)...)*eps(real(float(one(eltype(A))))))
     s = svdvals(A)
-    sum(x -> x > tol*s[1], s)
+    count(x -> x > tol*s[1], s)
 end
 rank(x::Number) = x == 0 ? 0 : 1
 

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -238,6 +238,7 @@ end
     @test !issymmetric(NaN)
 end
 
+@test rank(fill(0, 0, 0)) == 0
 @test rank([1.0 0.0; 0.0 0.9],0.95) == 1
 @test qr(big.([0 1; 0 0]))[2] == [0 1; 0 0]
 


### PR DESCRIPTION
...to handle the case where the vector of singular values is empty.

Fixes JuliaLang/LinearAlgebra.jl#511