### PR TITLE
fix splatting for positional arguments in isequal, isapprox etc

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -404,7 +404,7 @@ function get_test_result(ex, source)
             isa(a, Expr) && a.head in (:kw, :parameters) && continue
 
             if isa(a, Expr) && a.head == :...
-                push!(escaped_args, Expr(:..., esc(a)))
+                push!(escaped_args, Expr(:..., esc(a.args[1])))
             else
                 push!(escaped_args, esc(a))
             end

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -837,3 +837,8 @@ h25835(;x=1,y=1) = x isa Int ? x*y : (rand(Bool) ? 1.0 : 1)
     @test @inferred(h25835(x=2,y=3)) == 6
     @test_throws ErrorException @inferred(h25835(x=1.0,y=1.0)) == 1
 end
+
+@testset "splatting in isapprox" begin
+    a = [1, 2, 3]
+    @test isapprox(identity.((a, a))...)
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/26579