### PR TITLE
Update Pkg3

### DIFF
--- a/stdlib/Pkg3/.travis.yml
+++ b/stdlib/Pkg3/.travis.yml
@@ -13,6 +13,10 @@ notifications:
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
 
+branches:
+  only:
+    - master
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Pkg3"); Pkg.test("Pkg3"; coverage=true)'

--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -321,7 +321,7 @@ Let’s say we found a bug in `JSON` that we want to fix. We can get the full gi
 pkg> develop JSON
     Cloning package from https://github.com/JuliaIO/JSON.jl.git
   Resolving package versions...
-   Updating "~/.julia/environments/v0.7/Project.toml"
+   Updating "~/Documents/HelloWorld/Project.toml"
  [682c06a0] + JSON v0.17.1+ [~/.julia/dev/JSON]
 ...
 ```

--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -113,59 +113,62 @@ we plan to make libraries first-class entities directly installed and upgraded
 by the package manager.
 
 **Registry:** a source tree with a standard layout recording metadata about a
-registered set of packages, tagged verions of them which are available, and
-which versions of different packages are compatible or incompatible with each
-other. A registry is indexed by package name and UUID, including, providing the
-following information:
+registered set of packages, the tagged versions of them which are available, and
+which versions of packages are compatible or incompatible with each other. A
+registry is indexed by package name and UUID, and has a directory for each
+registered package providing the following metadata about it:
 
-- a set of packages and metadata about each:
   - name – e.g. `DataFrames`
   - UUID – e.g. `a93c6f00-e57d-5684-b7b6-d8193f3e46c0`
   - authors – e.g. `Jane Q. Developer <jane@example.com>`
   - license – e.g. MIT, BSD3, or GPLv2
-  - repository location – e.g. `https://github.com/JuliaData/DataFrames.jl.git`
+  - repository – e.g. `https://github.com/JuliaData/DataFrames.jl.git`
   - description – a block of text summarizing the functionality of a package
   - keywords – e.g. `data`, `tabular`, `analysis`, `statistics`
-- a set of registered versions for each package with:
-  - semantic version number – e.g. `v1.2.3`
-  - git tree SHA-1 hash – e.g. `7ffb18ea3245ef98e368b02b81e8a86543a11103`
-  - a map from names to UUIDs of dependencies
-  - versions of other packages which each version is compatible with
+  - versions – a list of all registered version tags
 
-Each registered package has its own directory and per-version metadata like
-dependencies and compatiblity is stored in a compressed but human-readable
+For each registered version of a package, the following information is provided:
+
+  - its semantic version number – e.g. `v1.2.3`
+  - its git tree SHA-1 hash – e.g. `7ffb18ea3245ef98e368b02b81e8a86543a11103`
+  - a map from names to UUIDs of dependencies
+  - which versions of other packages it is compatible/incompatible with
+
+Dependencies and compatiblity are stored in a compressed but human-readable
 format using ranges of package verions.
 
-**Depot:** directory where various package-related resources live, including:
+**Depot:** a directory on a system where various package-related resources live,
+including:
 
-  - `registries`: clones of registries
-  - `packages`: installed package versions
-  - `environments`: shared named environments
+  - `environments`: shared named environments (e.g. `v0.7`, `devtools`)
   - `clones`: bare clones of package repositories
-  - `compiled`: cached compiled package code
-  - `logs`: logs of REPL history and manifest usage
+  - `compiled`: cached compiled package images (`.ji` files)
+  - `config`: global configuration files (e.g. `startup.jl`)
   - `dev`: default directory for package development
-  - `config`: global configuration files
+  - `logs`: log files (e.g. `manifest_usage.toml`, `repl_history.jl`)
+  - `packages`: installed package versions
+  - `registries`: clones of registries (e.g. `Uncurated`)
 
-**Load path:** a stack of environments, which are where package identities,
+**Load path:** a stack of environments where package identities, their
 dependencies, and entry-points are searched for. The load path is controlled in
-Julia by the `LOAD_PATH` global variable, which is populated at startup based on
+Julia by the `LOAD_PATH` global variable which is populated at startup based on
 the value of the `JULIA_LOAD_PATH` environment variable. The first entry is your
 primary environment, often the current project, while later entries provide
-additional packages one may want to use from the REPL or the top-level of a
-script.
+additional packages one may want to use from the REPL or top-level scripts.
 
-**Depot path:** a stack of depot locations, where code loading and the package
-manager looks for registries, installed packages, named environments, repo
-clones, chached compiled packages, and configuration files. The depot path is
-controlled by the Julia `DEPOT_PATH` global variable, which is populated at
-startup based on the value of the `JULIA_DEPOT_PATH` global variable. The first
-entry is the user depot and should be user-writable. The user depot is where
-registries are cloned, where new package versions are installed, where named
-environments are created and updated, where package repos are cloned, where new
-compiled package cache files are saved, where log files are written, where
-development packages are checked out by default, and where global configuration
-data is saved.
+**Depot path:** a stack of depot locations where the package manager, as well as
+Julia's code loading mechanisms, look for registries, installed packages, named
+environments, repo clones, cached compiled package images, and configuration
+files. The depot path is controlled by the Julia `DEPOT_PATH` global variable
+which is populated at startup based on the value of the `JULIA_DEPOT_PATH`
+environment variable. The first entry is the “user depot” and should be writable
+by and owned by the current user. The user depot is where: registries are
+cloned, new package versions are installed, named environments are created and
+updated, package repos are cloned, new compiled package image files are saved,
+log files are written, development packages are checked out by default, and
+global configuration data is saved. Later entries in the depot path are treated
+as read-only and are appropriate for registries, packages, etc. installed and
+managed by system administrators.
 
 
 ## Getting Started

--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -18,11 +18,11 @@ is designed around “environments”: independent sets of packages that can be
 local to an individual project or shared and selected by name. The exact set of
 packages and versions in an environment is captured in a _manifest file_ which
 can be checked into a project repository and tracked in version control,
-significantly improving reproducibility of projects. If you've ever tried to run
-code you haven't used in a while only to find that you can’t get anything to
+significantly improving reproducibility of projects. If you’ve ever tried to run
+code you haven’t used in a while only to find that you can’t get anything to
 work because you’ve updated or uninstalled some of the packages your project was
-using, you'll understand the motivation for this approach. In Pkg3, since each
-project maintains its own independent set of package versions, you'll never have
+using, you’ll understand the motivation for this approach. In Pkg3, since each
+project maintains its own independent set of package versions, you’ll never have
 this problem again. Moreover, if you check out a project on a new system, you
 can simply materialize the environment described by its manifest file and
 immediately be up and running with a known-good set of dependencies.
@@ -30,7 +30,7 @@ immediately be up and running with a known-good set of dependencies.
 Since environments are managed and updated independently from each other,
 “dependency hell” is significantly alleviated in Pkg3. If you want to use the
 latest and greatest `DataFrames` in a new project but you’re stuck on an older
-version in a different project, that's no problem – since they have separate
+version in a different project, that’s no problem – since they have separate
 environments they can just use different versions, which are both installed at
 the same time in different locations on your system. The location of each
 package version is canonical, so when environments use the same versions of
@@ -38,11 +38,11 @@ packages, they can share installations, avoiding unnecessary duplication of the
 package. Old package versions that are no longer used by any environments are
 periodically automatically “garbage collected” by the package manager.
 
-Pkg3's approach to local environments may be familiar to people who have used
-Python's `virtualenv` or Ruby's `bundler`. In Julia, instead of hacking the
-language's code loading mechanisms to support environments, we have the benefit
+Pkg3’s approach to local environments may be familiar to people who have used
+Python’s `virtualenv` or Ruby’s `bundler`. In Julia, instead of hacking the
+language’s code loading mechanisms to support environments, we have the benefit
 that Julia natively understands Pkg3 environments. In addition, Julia
-environments are "stackable": you can overlay one environment with another and
+environments are “stackable”: you can overlay one environment with another and
 thereby have access to additional packages outside of the primary project
 environment. The overlay of environments is controlled by the `LOAD_PATH`
 global, which specifies the stack of environments that are searched for
@@ -61,7 +61,7 @@ tag a `v1.2.3+hotfix` version in your internal private registry and get it to
 your developers and ops teams quickly and easily without having to wait for an
 upstream patch to be accepted and published. Once the upstream fix is accepted,
 just upgrade your dependency to the new official `v1.2.4` version which includes
-the fix and you're back on an official upstream version of the dependency.
+the fix and you’re back on an official upstream version of the dependency.
 
 ## Glossary
 
@@ -225,7 +225,7 @@ Hello World!
 
 ### Adding packages to the project
 
-Let's say we want to use the standard library package `Random` and the registered package `JSON` in our project.
+Let’s say we want to use the standard library package `Random` and the registered package `JSON` in our project.
 We simply `add` these packages:
 
 ```
@@ -241,7 +241,7 @@ pkg> add Random JSON
  ...
 ```
 
-Both `Random` and `JSON` got added to the project's `Project.toml` file, and the resulting dependencies got added to the `Manifest.toml` file.
+Both `Random` and `JSON` got added to the project’s `Project.toml` file, and the resulting dependencies got added to the `Manifest.toml` file.
 The resolver has installed each package with the highest possible version, while still respecting the compatibility that each package enforce on its dependencies.
 
 We can now use both `Random` and `JSON` in our project. Changing `src/HelloWorld.jl` to
@@ -297,7 +297,7 @@ For unregistered packages we could have given a branch (or commit SHA) to track 
 
 ## Developing packages
 
-Let's say we found a bug in `JSON` that we want to fix. We can get the full git-repo using the `develop` command
+Let’s say we found a bug in `JSON` that we want to fix. We can get the full git-repo using the `develop` command
 
 ```
 pkg> develop JSON

--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -12,7 +12,57 @@ Pages = [
 
 ## Introduction
 
-Pkg3 is the package manager for Julia.
+Pkg3 is the standard package manager for Julia 1.0 and newer. Unlike traditional
+package managers, which install and manage a single global set of packages, Pkg3
+is designed around “environments”: independent sets of packages that can be
+local to an individual project or shared and selected by name. The exact set of
+packages and versions in an environment is captured in a _manifest file_ which
+can be checked into a project repository and tracked in version control,
+significantly improving reproducibility of projects. If you've ever tried to run
+code you haven't used in a while only to find that you can’t get anything to
+work because you’ve updated or uninstalled some of the packages your project was
+using, you'll understand the motivation for this approach. In Pkg3, since each
+project maintains its own independent set of package versions, you'll never have
+this problem again. Moreover, if you check out a project on a new system, you
+can simply materialize the environment described by its manifest file and
+immediately be up and running with a known-good set of dependencies.
+
+Since environments are managed and updated independently from each other,
+“dependency hell” is significantly alleviated in Pkg3. If you want to use the
+latest and greatest `DataFrames` in a new project but you’re stuck on an older
+version in a different project, that's no problem – since they have separate
+environments they can just use different versions, which are both installed at
+the same time in different locations on your system. The location of each
+package version is canonical, so when environments use the same versions of
+packages, they can share installations, avoiding unnecessary file system bloat.
+Old package versions that are no longer used by any environments are
+periodically automatically “garbage collected” by the package manager.
+
+Pkg3's approach to local environments may be familiar to people who have used
+Python's `virtualenv` or Ruby's `bundler`. In Julia, however, instead of hacking
+the language's code loading mechanisms to support environments, Julia natively
+understands them. In addition, Julia environments are "stackable": you can
+overlay one environment with another and thereby have access to additional
+packages outside of those that are part of a project. The overlay of
+environments is controlled by the `LOAD_PATH` global, which specifies the stack
+of environments that are searched for dependencies. This makes it easy to work
+on a project – whose environment will typically come first in your load path –
+while still having access to all your usual dev tools like profilers, debuggers,
+and so on. This is accomplished simply by an environment containing your dev
+tools in the load path.
+
+Last but not least, Pkg3 is designed to support federated package registries.
+This means that it allows multiple registries managed by different parties to
+interact seamlessly. In particular, this includes private registries which can
+live behind a corporate firewall. You can install and update your own packages
+from a private registry with exactly the same tools and workflows that you use
+to install and manage official Julia packages. If you urgently need to apply a
+hotfix for a public package that’s critical to your company’s product, you can
+tag a `v1.2.3+hotfix` version in your internal private registry and get it to
+your developers and ops teams quicly and easily without having to wait for an
+upstream patch to be accepted and published. Once the upstream fix is accepted,
+just upgrade your dependency to the new official `v1.2.4` version which includes
+the fix and you're back on an official upstream version of the dependency.
 
 ## Getting Started
 

--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -34,22 +34,21 @@ version in a different project, that's no problem – since they have separate
 environments they can just use different versions, which are both installed at
 the same time in different locations on your system. The location of each
 package version is canonical, so when environments use the same versions of
-packages, they can share installations, avoiding unnecessary file system bloat.
-Old package versions that are no longer used by any environments are
+packages, they can share installations, avoiding unnecessary duplication of the
+package. Old package versions that are no longer used by any environments are
 periodically automatically “garbage collected” by the package manager.
 
 Pkg3's approach to local environments may be familiar to people who have used
-Python's `virtualenv` or Ruby's `bundler`. In Julia, however, instead of hacking
-the language's code loading mechanisms to support environments, Julia natively
-understands them. In addition, Julia environments are "stackable": you can
-overlay one environment with another and thereby have access to additional
-packages outside of those that are part of a project. The overlay of
-environments is controlled by the `LOAD_PATH` global, which specifies the stack
-of environments that are searched for dependencies. This makes it easy to work
-on a project – whose environment will typically come first in your load path –
-while still having access to all your usual dev tools like profilers, debuggers,
-and so on. This is accomplished simply by an environment containing your dev
-tools in the load path.
+Python's `virtualenv` or Ruby's `bundler`. In Julia, instead of hacking the
+language's code loading mechanisms to support environments, we have the benefit
+that Julia natively understands Pkg3 environments. In addition, Julia
+environments are "stackable": you can overlay one environment with another and
+thereby have access to additional packages outside of the primary project
+environment. The overlay of environments is controlled by the `LOAD_PATH`
+global, which specifies the stack of environments that are searched for
+dependencies. This makes it easy to work on a project while still having access
+to all your usual dev tools like profilers, debuggers, and so on just by having
+an environment including these dev tools later in your load path.
 
 Last but not least, Pkg3 is designed to support federated package registries.
 This means that it allows multiple registries managed by different parties to
@@ -59,7 +58,7 @@ from a private registry with exactly the same tools and workflows that you use
 to install and manage official Julia packages. If you urgently need to apply a
 hotfix for a public package that’s critical to your company’s product, you can
 tag a `v1.2.3+hotfix` version in your internal private registry and get it to
-your developers and ops teams quicly and easily without having to wait for an
+your developers and ops teams quickly and easily without having to wait for an
 upstream patch to be accepted and published. Once the upstream fix is accepted,
 just upgrade your dependency to the new official `v1.2.4` version which includes
 the fix and you're back on an official upstream version of the dependency.
@@ -72,31 +71,31 @@ for the main body of Julia code, a `test` directory for testing the project,
 script and its outputs.
 
 - **Project file:** a file in the root directory of a project, named
-`Project.toml` (or `JuliaProject.toml`) describing metadata about the project,
-including its name, UUID (for packages), authors, license, and the names and
-UUIDs of packages and libraries that it depends on.
+  `Project.toml` (or `JuliaProject.toml`) describing metadata about the project,
+  including its name, UUID (for packages), authors, license, and the names and
+  UUIDs of packages and libraries that it depends on.
 
 - **Manifest file:** a file in the root directory of a project, named
-`Manifest.toml` (or `JuliaManifest.toml`) describing complete dependency graph
-and exact versions of each package and library used by a project.
+  `Manifest.toml` (or `JuliaManifest.toml`) describing a complete dependency graph
+  and exact versions of each package and library used by a project.
 
 **Environment:** the combination of the top-level name map provided by a project
 file combined with the dependency graph and package loction map provided by a
 manifest file. For more detail see the section on code loading.
 
 - **Explicit environment:** an environment in the form of an explicit project
-file and an optional corresponding manifest file together in a directory. If the
-manifest file is absent then the implied dependency graph and location maps are
-empty.
+  file and an optional corresponding manifest file together in a directory. If the
+  manifest file is absent then the implied dependency graph and location maps are
+  empty.
 
 - **Implicit environment:** an environment provided as a directory (without a
-project file or manifest file) containing packages with entry points of the form
-`X.jl`, `X.jl/src/X.jl` or `X/src/X.jl`. The top-level name map is implied by
-these entry points. The dependency graph is implied by the existence of project
-files inside of these package directories, e.g. `X.jl/Project.toml` or
-`X/Project.toml`. The dependencies of the `X` package are the dependencies in
-the corresponding project file if there is one. The location map is implied by
-the entry points themselves.
+  project file or manifest file) containing packages with entry points of the form
+  `X.jl`, `X.jl/src/X.jl` or `X/src/X.jl`. The top-level name map is implied by
+  these entry points. The dependency graph is implied by the existence of project
+  files inside of these package directories, e.g. `X.jl/Project.toml` or
+  `X/Project.toml`. The dependencies of the `X` package are the dependencies in
+  the corresponding project file if there is one. The location map is implied by
+  the entry points themselves.
 
 **Application:** a project which provides standalone functionality not intended
 to be reused by other Julia projects. For example a web application or a

--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -64,6 +64,111 @@ upstream patch to be accepted and published. Once the upstream fix is accepted,
 just upgrade your dependency to the new official `v1.2.4` version which includes
 the fix and you're back on an official upstream version of the dependency.
 
+## Glossary
+
+**Project:** a source tree with a standard layout, including a `src` directory
+for the main body of Julia code, a `test` directory for testing the project,
+`docs` for documentation files, and optionally a `build` directory for a build
+script and its outputs.
+
+- **Project file:** a file in the root directory of a project, named
+`Project.toml` (or `JuliaProject.toml`) describing metadata about the project,
+including its name, UUID (for packages), authors, license, and the names and
+UUIDs of packages and libraries that it depends on.
+
+- **Manifest file:** a file in the root directory of a project, named
+`Manifest.toml` (or `JuliaManifest.toml`) describing complete dependency graph
+and exact versions of each package and library used by a project.
+
+**Environment:** the combination of the top-level name map provided by a project
+file combined with the dependency graph and package loction map provided by a
+manifest file. For more detail see the section on code loading.
+
+- **Explicit environment:** an environment in the form of an explicit project
+file and an optional corresponding manifest file together in a directory. If the
+manifest file is absent then the implied dependency graph and location maps are
+empty.
+
+- **Implicit environment:** an environment provided as a directory (without a
+project file or manifest file) containing packages with entry points of the form
+`X.jl`, `X.jl/src/X.jl` or `X/src/X.jl`. The top-level name map is implied by
+these entry points. The dependency graph is implied by the existence of project
+files inside of these package directories, e.g. `X.jl/Project.toml` or
+`X/Project.toml`. The dependencies of the `X` package are the dependencies in
+the corresponding project file if there is one. The location map is implied by
+the entry points themselves.
+
+**Application:** a project which provides standalone functionality not intended
+to be reused by other Julia projects. For example a web application or a
+commmand-line utility.
+
+**Package:** a project which provides reusable functionality that can be used by
+other projects via `import X` or `using X`. A package will typically have a
+project file with a `uuid` entry giving its package UUID. This UUID is used to
+identify the package when other projects depend on it.
+
+**Library (future work):** a compiled binary dependency (not written in Julia)
+packaged to be used by a Julia project. These are currently typically built in-
+place by a `deps/build.jl` script in a project’s source tree, but in the future
+we plan to make libraries first-class entities directly installed and upgraded
+by the package manager.
+
+**Registry:** a source tree with a standard layout recording metadata about a
+registered set of packages, tagged verions of them which are available, and
+which versions of different packages are compatible or incompatible with each
+other. A registry is indexed by package name and UUID, including, providing the
+following information:
+
+- a set of packages and metadata about each:
+  - name – e.g. `DataFrames`
+  - UUID – e.g. `a93c6f00-e57d-5684-b7b6-d8193f3e46c0`
+  - authors – e.g. `Jane Q. Developer <jane@example.com>`
+  - license – e.g. MIT, BSD3, or GPLv2
+  - repository location – e.g. `https://github.com/JuliaData/DataFrames.jl.git`
+  - description – a block of text summarizing the functionality of a package
+  - keywords – e.g. `data`, `tabular`, `analysis`, `statistics`
+- a set of registered versions for each package with:
+  - semantic version number – e.g. `v1.2.3`
+  - git tree SHA-1 hash – e.g. `7ffb18ea3245ef98e368b02b81e8a86543a11103`
+  - a map from names to UUIDs of dependencies
+  - versions of other packages which each version is compatible with
+
+Each registered package has its own directory and per-version metadata like
+dependencies and compatiblity is stored in a compressed but human-readable
+format using ranges of package verions.
+
+**Depot:** directory where various package-related resources live, including:
+
+  - `registries`: clones of registries
+  - `packages`: installed package versions
+  - `environments`: shared named environments
+  - `clones`: bare clones of package repositories
+  - `compiled`: cached compiled package code
+  - `logs`: logs of REPL history and manifest usage
+  - `dev`: default directory for package development
+  - `config`: global configuration files
+
+**Load path:** a stack of environments, which are where package identities,
+dependencies, and entry-points are searched for. The load path is controlled in
+Julia by the `LOAD_PATH` global variable, which is populated at startup based on
+the value of the `JULIA_LOAD_PATH` environment variable. The first entry is your
+primary environment, often the current project, while later entries provide
+additional packages one may want to use from the REPL or the top-level of a
+script.
+
+**Depot path:** a stack of depot locations, where code loading and the package
+manager looks for registries, installed packages, named environments, repo
+clones, chached compiled packages, and configuration files. The depot path is
+controlled by the Julia `DEPOT_PATH` global variable, which is populated at
+startup based on the value of the `JULIA_DEPOT_PATH` global variable. The first
+entry is the user depot and should be user-writable. The user depot is where
+registries are cloned, where new package versions are installed, where named
+environments are created and updated, where package repos are cloned, where new
+compiled package cache files are saved, where log files are written, where
+development packages are checked out by default, and where global configuration
+data is saved.
+
+
 ## Getting Started
 
 The Pkg REPL-mode is entered using from the Julia REPL using the key `]`.

--- a/stdlib/Pkg3/src/API.jl
+++ b/stdlib/Pkg3/src/API.jl
@@ -74,7 +74,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
     else
         for reg in registries()
             if isdir(joinpath(reg, ".git"))
-                regpath = pathrepr(reg)
+                regpath = pathrepr(ctx, reg)
                 printpkgstyle(ctx, :Updating, "registry at ", regpath)
                 LibGit2.with(LibGit2.GitRepo, reg) do repo
                     if LibGit2.isdirty(repo)

--- a/stdlib/Pkg3/src/Operations.jl
+++ b/stdlib/Pkg3/src/Operations.jl
@@ -377,6 +377,7 @@ end
 
 const refspecs = ["+refs/*:refs/remotes/cache/*"]
 function install_git(
+    ctx::Context,
     uuid::UUID,
     name::String,
     hash::SHA1,
@@ -403,8 +404,7 @@ function install_git(
         LibGit2.fetch(repo, remoteurl=url, refspecs=refspecs)
     end
     tree = try
-        with(LibGit2.GitObject, repo, git_hash) do g
-        end
+        LibGit2.GitObject(repo, git_hash)
     catch err
         err isa LibGit2.GitError && err.code == LibGit2.Error.ENOTFOUND || rethrow(err)
         error("$name: git object $(string(hash)) could not be found")
@@ -417,7 +417,7 @@ function install_git(
         target_directory = Base.unsafe_convert(Cstring, version_path)
     )
     LibGit2.checkout_tree(repo, tree, options=opts)
-    close(repo); close(tree); close(opts); close(git_hash)
+    close(repo); close(tree)
     return
 end
 
@@ -493,7 +493,7 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec})::Vector{UUID}
     for (pkg, path) in missed_packages
         uuid = pkg.uuid
         if !ctx.preview
-            install_git(pkg.uuid, pkg.name, hashes[uuid], urls[uuid], pkg.version::VersionNumber, path)
+            install_git(ctx, pkg.uuid, pkg.name, hashes[uuid], urls[uuid], pkg.version::VersionNumber, path)
         end
         vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
         @info "Installed $(rpad(pkg.name * " ", max_name + 2, "─")) $vstr"

--- a/stdlib/Pkg3/src/Operations.jl
+++ b/stdlib/Pkg3/src/Operations.jl
@@ -792,7 +792,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
     for (uuid, name, hash_or_path, build_file) in builds
         log_file = splitext(build_file)[1] * ".log"
         printpkgstyle(ctx, :Building,
-            rpad(name * " ", max_name + 1, "─"), "→ ", Types.pathrepr(log_file))
+            rpad(name * " ", max_name + 1, "─"), "→ ", Types.pathrepr(ctx, log_file))
 
         code = """
             empty!(Base.DEPOT_PATH)

--- a/stdlib/Pkg3/src/REPLMode.jl
+++ b/stdlib/Pkg3/src/REPLMode.jl
@@ -740,8 +740,10 @@ end
 pkgstr(str::String) = do_cmd(minirepl[], str; do_rethrow=true)
 
 # handle completions
-commands_sorted = sort!(collect(keys(cmds)))
-options_sorted = sort!(collect(keys(opts)))
+all_commands_sorted = sort!(collect(keys(cmds)))
+long_commands = filter(c -> length(c) > 2, all_commands_sorted)
+all_options_sorted = [length(opt) > 1 ? "--$opt" : "-$opt" for opt in sort!(collect(keys(opts)))]
+long_options = filter(c -> length(c) > 2, all_options_sorted)
 
 struct PkgCompletionProvider <: LineEdit.CompletionProvider end
 
@@ -753,28 +755,17 @@ function LineEdit.complete_line(c::PkgCompletionProvider, s)
 end
 
 function complete_command(s, i1, i2)
-    cmp = filter(cmd -> startswith(cmd, s), commands_sorted)
-    return cmp, i1:i2, length(cmp) == 1
+    # only show short form commands when no input is given at all
+    cmp = filter(cmd -> startswith(cmd, s), isempty(s) ? all_commands_sorted : long_commands)
+    return cmp, i1:i2, !isempty(cmp)
 end
 
 function complete_option(s, i1, i2)
-    dashes = 0
-    while !isempty(s) && first(s) == '-'
-        s = s[2:end]
-        dashes += 1
-    end
-
-    cmp = filter(cmd -> startswith(cmd, s), options_sorted)
-
-    isempty(cmp) && (return cmp, 0:-1, false)
-
-    cmp = string.('-'^(2-dashes), cmp)
-
-    if length(cmp) == 1
-        return cmp, i1+dashes:i2, true
-    else
-        return cmp, i1+dashes:i2, false
-    end
+    # only show short form options if only a dash is given
+    cmp = filter(cmd -> startswith(cmd, s), length(s) == 1 && first(s) == '-' ?
+                                                all_options_sorted :
+                                                long_options)
+    return cmp, i1:i2, !isempty(cmp)
 end
 
 function complete_package(s, i1, i2, lastcommand, project_opt)
@@ -783,19 +774,19 @@ function complete_package(s, i1, i2, lastcommand, project_opt)
     elseif lastcommand in [CMD_ADD]
         return complete_remote_package(s, i1, i2)
     end
-    return [], 0:-1, false
+    return String[], 0:-1, false
 end
 
 function complete_installed_package(s, i1, i2, project_opt)
     pkgs = project_opt ? API.installed(PKGMODE_PROJECT) : API.installed()
     pkgs = sort!(collect(keys(filter((p) -> p[2] != nothing, pkgs))))
     cmp = filter(cmd -> startswith(cmd, s), pkgs)
-    return cmp, i1:i2, length(cmp) == 1
+    return cmp, i1:i2, !isempty(cmp)
 end
 
 function complete_remote_package(s, i1, i2)
     cmp = filter(cmd -> startswith(cmd, s), collect_package_names())
-    return cmp, i1:i2, length(cmp) == 1
+    return cmp, i1:i2, !isempty(cmp)
 end
 
 function collect_package_names()
@@ -819,28 +810,36 @@ function completions(full, index)
     else
         to_complete = pre_words[end]
         offset = isempty(to_complete) ? index+1 : to_complete.offset+1
+
         if length(pre_words) == 1
             return complete_command(to_complete, offset, index)
         end
 
-        twocommands = false
+        # tokenize input, don't offer any completions for invalid commands
+        tokens = try
+            tokenize(join(pre_words[1:end-1], ' '))
+        catch
+            return String[], 0:-1, false
+        end
+
+        tokens = reverse!(tokens)
+
         lastcommand = nothing
         project_opt = true
-        # this should consume any words up to the current one
-        while length(pre_words) > 1
-            twocommands = false
-            word = popfirst!(pre_words)
-            (word == "preview" || word == "help") && (twocommands = true)
-            if !isempty(word) && haskey(cmds, word)
-                lastcommand = cmds[word]
+        for t in tokens
+            if t isa Command
+                lastcommand = t.kind
+                break
             end
-            if !isempty(word) && first(word) == '-' && haskey(opts, strip(word, '-'))
-                opts[strip(word, '-')] == OPT_PROJECT && (project_opt = true)
-                opts[strip(word, '-')] == OPT_MANIFEST && (project_opt = false)
+        end
+        for t in tokens
+            if t isa Option && t.kind in [OPT_PROJECT, OPT_MANIFEST]
+                project_opt = t.kind == OPT_PROJECT
+                break
             end
         end
 
-        if twocommands
+        if lastcommand in [CMD_HELP, CMD_PREVIEW]
             return complete_command(to_complete, offset, index)
         elseif !isempty(to_complete) && first(to_complete) == '-'
             return complete_option(to_complete, offset, index)

--- a/stdlib/Pkg3/src/Types.jl
+++ b/stdlib/Pkg3/src/Types.jl
@@ -1180,22 +1180,13 @@ function printpkgstyle(ctx::Context, cmd::Symbol, text::String...; kwargs...)
     printpkgstyle(stdout, cmd, text...; kwargs...)
 end
 
-# Give a short path string representation
-pathrepr(path::String, base::String=pwd()) = pathrepr(nothing, path, base)
 
 function pathrepr(ctx::Union{Nothing, Context}, path::String, base::String=pwd())
-    if ctx isa Context
-        project_path = abspath(dirname(ctx.env.project_file))
-        path = joinpath(project_path, path)
-        if startswith(path, project_path)
-            # Path in project
-            if startswith(base, project_path)
-                # We are in project
-                path = relpath(path, base)
-            else
-                path = relpath(path, project_path)
-            end
-        end
+    project_path = dirname(ctx.env.project_file)
+    path = joinpath(project_path, path)
+    if startswith(path, project_path) && startswith(base, project_path)
+        # We are in project and path is in project
+        path = relpath(path, base)
     end
     if !Sys.iswindows() && isabspath(path)
         home = joinpath(homedir(), "")

--- a/stdlib/Pkg3/test/pkg.jl
+++ b/stdlib/Pkg3/test/pkg.jl
@@ -16,7 +16,6 @@ include("utils.jl")
 const TEST_PKG = (name = "Example", uuid = UUID("7876af07-990d-54b4-ab0e-23690620f79a"))
 
 temp_pkg_dir() do project_path
-
     @testset "simple add and remove with preview" begin
         Pkg3.init(project_path)
         Pkg3.add(TEST_PKG.name; preview = true)
@@ -144,6 +143,14 @@ temp_pkg_dir() do project_path
     end
 
     Pkg3.rm(TEST_PKG.name)
+end
+
+temp_pkg_dir() do project_path
+    @testset "libgit2 downloads" begin
+        Pkg3.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
+        @test haskey(Pkg3.installed(), TEST_PKG.name)
+        Pkg3.rm(TEST_PKG.name)
+    end
 end
 
 include("repl.jl")

--- a/stdlib/Pkg3/test/repl.jl
+++ b/stdlib/Pkg3/test/repl.jl
@@ -86,7 +86,6 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
         Pkg3.REPLMode.pkgstr("add $p2#$c")
     end
 
-    # TODO cleanup
     mktempdir() do tmp_dev_dir
     withenv("JULIA_PKG_DEVDIR" => tmp_dev_dir) do
         pkg"develop Example"

--- a/stdlib/Pkg3/test/repl.jl
+++ b/stdlib/Pkg3/test/repl.jl
@@ -226,11 +226,18 @@ temp_pkg_dir() do project_path; cd(project_path) do
         c, r = test_complete("rm Exam")
         @test "Example" in c
         c, r = test_complete("add --man")
-        @test "manifest" in c
+        @test "--manifest" in c
         c, r = test_complete("rem")
         @test "remove" in c
         @test apply_completion("rm E") == "rm Example"
         @test apply_completion("add Exampl") == "add Example"
+
+        c, r = test_complete("preview r")
+        @test "remove" in c
+        c, r = test_complete("help r")
+        @test "remove" in c
+        @test !("rm" in c)
+
     finally
         popfirst!(LOAD_PATH)
     end


### PR DESCRIPTION
* Improves the autocompletion https://github.com/JuliaLang/Pkg3.jl/pull/215 (thanks @pfitzseb)
* Fixes and test a bug when falling back to using LibGit2 for package downloads (e.g. for GitLab repos).
* Fix a bug with how path printing was done when pwd is not in the path.
* Adds some glossary type of docs. 