### PR TITLE
enable the SLP Vectorizer optimization pass by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -664,6 +664,9 @@ Compiler/Runtime improvements
   * Inference now propagates constants inter-procedurally, and can compute
     various constants expressions at compile-time ([#24362]).
 
+  * The LLVM SLP Vectorizer optimization pass is now enabled at the default
+    optimization level.
+
 Deprecated or removed
 ---------------------
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -238,14 +238,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     PM->add(createLoopIdiomPass());
     PM->add(createLoopDeletionPass());          // Delete dead loops
     PM->add(createJumpThreadingPass());         // Thread jumps
-
-    if (opt_level >= 3) {
-        PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
-    }
-
+    PM->add(createSLPVectorizerPass());         // Vectorize straight-line code
     PM->add(createAggressiveDCEPass());         // Delete dead instructions
-    if (opt_level >= 3)
-        PM->add(createInstructionCombiningPass());   // Clean up after SLP loop vectorizer
+    PM->add(createInstructionCombiningPass());  // Clean up after SLP loop vectorizer
     PM->add(createLoopVectorizePass());         // Vectorize loops
     PM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
     // LowerPTLS removes an indirect call. As a result, it is likely to trigger


### PR DESCRIPTION
The justification for this is that it seems to pretty much negligble impact compilation time but has serious performance improvements for linear algebra and other operations with static arrays ( https://github.com/JuliaLang/julia/pull/26398#issuecomment-375628897)

## SLP Disabled:

Sysimg build time:  User time (seconds): 323.47

Running tests for StaticArrays
```
@testinf      |    3      3
  3.388018 seconds (4.51 M allocations: 303.673 MiB, 4.26% gc time)
SVector       |   53     53
  1.610420 seconds (946.33 k allocations: 54.435 MiB, 1.03% gc time)
MVector       |   52     52
  0.899716 seconds (366.94 k allocations: 20.813 MiB, 0.69% gc time)
SMatrix       |   68     68
  2.104827 seconds (1.26 M allocations: 71.847 MiB, 0.78% gc time)
MMatrix       |   71     71
  1.987582 seconds (754.25 k allocations: 43.105 MiB, 0.68% gc time)
SArray        |   92     92
  6.809774 seconds (4.14 M allocations: 226.083 MiB, 0.88% gc time)
MArray        |  101    101
  5.667526 seconds (2.80 M allocations: 148.517 MiB, 0.76% gc time)
FieldVector   |   27     27
  1.362807 seconds (693.47 k allocations: 40.276 MiB, 1.09% gc time)
Scalar        |    8      8
  3.657003 seconds (1.80 M allocations: 103.858 MiB, 2.87% gc time)
SUnitRange    |   10     10
  0.139713 seconds (30.73 k allocations: 1.809 MiB)
SizedArray    |   49       1     50
  2.333507 seconds (1.05 M allocations: 60.101 MiB, 1.03% gc time)
SDiagonal     |   71     71
 13.601758 seconds (13.72 M allocations: 720.386 MiB, 2.94% gc time)
Custom types  |    2      2
  0.068887 seconds (9.19 k allocations: 583.006 KiB)
Core definitions and constructors |   57     57
  1.817816 seconds (446.50 k allocations: 27.372 MiB, 0.46% gc time)
AbstractArray interface |   54     54
  3.961401 seconds (1.79 M allocations: 100.007 MiB, 1.16% gc time)
Indexing      |   73     73
  6.983536 seconds (3.72 M allocations: 211.556 MiB, 2.49% gc time)
Map, reduce, mapreduce, broadcast |   67     67
  9.380575 seconds (8.80 M allocations: 481.281 MiB, 1.86% gc time)
Array math    |  121    121
  3.541558 seconds (2.94 M allocations: 166.468 MiB, 1.89% gc time)
Broadcast sizes |   30     30
Broadcast     |   77      12     89
  8.707391 seconds (4.76 M allocations: 274.434 MiB, 1.17% gc time)
Linear algebra |   86     86
  7.220394 seconds (3.60 M allocations: 205.664 MiB, 1.42% gc time)
Matrix multiplication |   61       1     62
 28.005206 seconds (32.25 M allocations: 1.397 GiB, 4.13% gc time)
```

### SLP Enabled

Sysimg build time:  User time (seconds): 329.58

Running tests for StaticArrays
```
@testinf      |    3      3
  3.524660 seconds (4.51 M allocations: 304.837 MiB, 5.88% gc time)
SVector       |   53     53
  1.594506 seconds (947.30 k allocations: 54.376 MiB, 1.05% gc time)
MVector       |   52     52
  0.907068 seconds (367.29 k allocations: 20.782 MiB, 0.68% gc time)
SMatrix       |   68     68
  2.124502 seconds (1.26 M allocations: 71.770 MiB, 0.81% gc time)
MMatrix       |   71     71
  1.683213 seconds (754.89 k allocations: 43.175 MiB, 0.74% gc time)
SArray        |   92     92
  6.771967 seconds (4.15 M allocations: 225.854 MiB, 0.91% gc time)
MArray        |  101    101
  5.707790 seconds (2.80 M allocations: 148.675 MiB, 0.78% gc time)
FieldVector   |   27     27
  1.229272 seconds (694.42 k allocations: 40.199 MiB, 1.04% gc time)
Scalar        |    8      8
  3.683220 seconds (1.80 M allocations: 104.034 MiB, 2.84% gc time)
SUnitRange    |   10     10
  0.119789 seconds (30.79 k allocations: 1.793 MiB)
SizedArray    |   49       1     50
  2.187806 seconds (1.05 M allocations: 60.016 MiB, 0.97% gc time)
SDiagonal     |   71     71
 13.556212 seconds (13.73 M allocations: 720.349 MiB, 2.92% gc time)
Custom types  |    2      2
  0.064020 seconds (9.20 k allocations: 583.443 KiB)
Core definitions and constructors |   57     57
  1.797976 seconds (446.71 k allocations: 27.369 MiB, 0.52% gc time)
AbstractArray interface |   54     54
  3.770388 seconds (1.79 M allocations: 99.841 MiB, 1.12% gc time)
Indexing      |   73     73
  7.115772 seconds (3.73 M allocations: 211.120 MiB, 2.52% gc time)
Map, reduce, mapreduce, broadcast |   67     67
 10.392894 seconds (8.81 M allocations: 482.237 MiB, 1.76% gc time)
Array math    |  121    121
  3.884809 seconds (2.94 M allocations: 166.417 MiB, 1.86% gc time)
Broadcast sizes |   30     30
Broadcast     |   77      12     89
  9.460607 seconds (4.76 M allocations: 273.940 MiB, 1.15% gc time)
Linear algebra |   86     86
  7.504202 seconds (3.61 M allocations: 205.617 MiB, 1.40% gc time)
Matrix multiplication |   61       1     62
 28.755902 seconds (32.22 M allocations: 1.396 GiB, 4.07% gc time)
```