### PR TITLE
loading tests: oops, delete temp file

### DIFF
--- a/test/loading.jl
+++ b/test/loading.jl
@@ -138,6 +138,7 @@ end
             @test that == false
         end
     end
+    rm(project_file)
 end
 
 ## functional testing of package identification, location & loading ##


### PR DESCRIPTION
Fix silly mistake: remember to delete the tempfile that the project file parsings tests create.