### PR TITLE
Markdown: store if list is loose or not in the List

### DIFF
--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -250,8 +250,9 @@ end
 mutable struct List
     items::Vector{Any}
     ordered::Int # `-1` is unordered, `>= 0` is ordered.
+    loose::Bool # TODO: Renderer's should use this field
 
-    List(x::AbstractVector, b::Integer) = new(x, b)
+    List(x::AbstractVector, b::Integer) = new(x, b, false)
     List(x::AbstractVector) = new(x, -1)
     List(b::Integer) = new(Any[], b)
 end
@@ -302,7 +303,6 @@ function list(stream::IO, block::MD)
                     println(buffer)
                 end
             else
-                newline = false
                 if startswith(stream, " "^indent)
                     # Indented text that is part of the current list item.
                     print(buffer, readline(stream, keep=true))
@@ -314,11 +314,13 @@ function list(stream::IO, block::MD)
                         break
                     else
                         # Start of a new list item.
+                        newline && (list.loose = true)
                         count += 1
                         count > 1 && pushitem!(list, buffer)
                         print(buffer, readline(stream, keep=true))
                     end
                 end
+                newline = false
             end
         end
         count == length(list.items) || pushitem!(list, buffer)

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -304,6 +304,7 @@ function list(stream::IO, block::MD)
                 end
             else
                 if startswith(stream, " "^indent)
+                    newline && (list.loose = true)
                     # Indented text that is part of the current list item.
                     print(buffer, readline(stream, keep=true))
                 else

--- a/stdlib/Markdown/src/Common/block.jl
+++ b/stdlib/Markdown/src/Common/block.jl
@@ -250,13 +250,11 @@ end
 mutable struct List
     items::Vector{Any}
     ordered::Int # `-1` is unordered, `>= 0` is ordered.
-    loose::Bool # TODO: Renderer's should use this field
-
-    List(x::AbstractVector, b::Integer) = new(x, b, false)
-    List(x::AbstractVector) = new(x, -1)
-    List(b::Integer) = new(Any[], b)
+    loose::Bool # TODO: Renderers should use this field
 end
-
+List(x::AbstractVector, b::Integer) = List(x, b, false)
+List(x::AbstractVector) = List(x, -1)
+List(b::Integer) = List(Any[], b)
 List(xs...) = List(vcat(xs...))
 
 isordered(list::List) = list.ordered >= 0

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1096,3 +1096,23 @@ let
     md.meta[:foo] = 42
     @test !haskey(md′.meta, :foo)
 end
+
+let
+    v = Markdown.md"""
+        foo
+
+        - 1
+        - 2
+
+        - 3
+
+
+        - 1
+        - 2
+
+        bar
+        """
+
+    @test v.content[2].loose
+    @test !v.content[3].loose
+end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1111,8 +1111,22 @@ let
         - 2
 
         bar
+
+        - 1
+
+          2
+        - 4
+
+        buz
+
+        - 1
+        - 2
+          3
+        - 4
         """
 
     @test v.content[2].loose
     @test !v.content[3].loose
+    @test v.content[5].loose
+    @test !v.content[7].loose
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1098,33 +1098,7 @@ let
 end
 
 let
-    v = Markdown.md"""
-        foo
-
-        - 1
-        - 2
-
-        - 3
-
-
-        - 1
-        - 2
-
-        bar
-
-        - 1
-
-          2
-        - 4
-
-        buz
-
-        - 1
-        - 2
-          3
-        - 4
-        """
-
+    v = Markdown.parse("foo\n\n- 1\n- 2\n\n- 3\n\n\n- 1\n- 2\n\nbar\n\n- 1\n\n  2\n- 4\n\nbuz\n\n- 1\n- 2\n  3\n- 4\n")
     @test v.content[2].loose
     @test !v.content[3].loose
     @test v.content[5].loose


### PR DESCRIPTION
Punt on updating the renders in base but do it for the Documenter HTML renderer: https://github.com/JuliaDocs/Documenter.jl/pull/685