### PR TITLE
fix #26589, make impossible tuple conversions give a MethodError

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -223,6 +223,7 @@ end
 typename(union::UnionAll) = typename(union.body)
 
 convert(::Type{T}, x::T) where {T<:Tuple{Any, Vararg{Any}}} = x
+convert(::Type{Tuple{}}, x::Tuple{Any, Vararg{Any}}) = throw(MethodError(convert, (Tuple{}, x)))
 convert(::Type{T}, x::Tuple{Any, Vararg{Any}}) where {T<:Tuple} =
     (convert(tuple_type_head(T), x[1]), convert(tuple_type_tail(T), tail(x))...)
 

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -9,11 +9,6 @@ struct BitPerm_19352
     BitPerm_19352(xs::Vararg{Any,8}) = BitPerm(map(UInt8, xs))
 end
 
-# #17198
-@test_throws BoundsError convert(Tuple{Int}, (1.0, 2.0, 3.0))
-# #21238
-@test_throws MethodError convert(Tuple{Int, Int, Int}, (1, 2))
-
 @testset "conversion and construction" begin
     @test convert(Tuple, ()) === ()
     @test convert(Tuple, (1, 2)) === (1, 2)
@@ -41,17 +36,23 @@ end
     @test convert(NTuple{3, Int}, (1.0, 2, 0x3)) === (1, 2, 3)
     @test convert(Tuple{Int, Int, Float64}, (1.0, 2, 0x3)) === (1, 2, 3.0)
 
-    # TODO: seems like these all should throw BoundsError?
     @test_throws MethodError convert(Tuple{Int}, ())
+    @test_throws MethodError convert(Tuple{Any}, ())
     @test_throws MethodError convert(Tuple{Int, Vararg{Int}}, ())
-    @test_throws BoundsError convert(Tuple{}, (1, 2, 3))
-    @test_throws BoundsError convert(Tuple{}, (1.0, 2, 3))
+    @test_throws MethodError convert(Tuple{}, (1, 2, 3))
+    @test_throws MethodError convert(Tuple{}, (1.0, 2, 3))
     @test_throws MethodError convert(NTuple{3, Int}, ())
     @test_throws MethodError convert(NTuple{3, Int}, (1, 2))
-    @test_throws BoundsError convert(NTuple{3, Int}, (1, 2, 3, 4))
+    @test_throws MethodError convert(NTuple{3, Int}, (1, 2, 3, 4))
     @test_throws MethodError convert(Tuple{Int, Int, Float64}, ())
     @test_throws MethodError convert(Tuple{Int, Int, Float64}, (1, 2))
-    @test_throws BoundsError convert(Tuple{Int, Int, Float64}, (1, 2, 3, 4))
+    @test_throws MethodError convert(Tuple{Int, Int, Float64}, (1, 2, 3, 4))
+    # #17198
+    @test_throws MethodError convert(Tuple{Int}, (1.0, 2.0, 3.0))
+    # #21238
+    @test_throws MethodError convert(Tuple{Int, Int, Int}, (1, 2))
+    # issue #26589
+    @test_throws MethodError convert(NTuple{4}, (1.0,2.0,3.0,4.0,5.0))
 
     # PR #15516
     @test Tuple{Char,Char}("za") === ('z','a')


### PR DESCRIPTION
A comment in the tests suggests giving BoundsErrors here, but in general missing/impossible conversions give MethodErrors (for there being no conversion defined), so I prefer that.