### PR TITLE
RFC: Deprecate findfirst on I/O buffers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1038,7 +1038,10 @@ Deprecated or removed
 
   * `search` and `rsearch` have been deprecated in favor of `findfirst`/`findnext` and
     `findlast`/`findprev` respectively, in combination with curried `isequal` and `in`
-    predicates for some methods ([#24673]
+    predicates for some methods ([#24673]).
+
+  * `search(buf::IOBuffer, delim::UInt8)` has been deprecated in favor of either `occursin(delim, buf)`
+    (to test containment) or `readuntil(buf, delim)` (to read data up to `delim`) ([#26600]).
 
   * `ismatch(regex, str)` has been deprecated in favor of `contains(str, regex)` ([#24673]).
 
@@ -1430,3 +1433,4 @@ Command-line option changes
 [#26286]: https://github.com/JuliaLang/julia/issues/26286
 [#26436]: https://github.com/JuliaLang/julia/issues/26436
 [#26442]: https://github.com/JuliaLang/julia/issues/26442
+[#26600]: https://github.com/JuliaLang/julia/issues/26600

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1227,9 +1227,6 @@ end
 @deprecate search(s::AbstractString, t::AbstractString, i::Integer) coalesce(findnext(t, s, i), 0:-1)
 @deprecate search(s::AbstractString, t::AbstractString) coalesce(findfirst(t, s), 0:-1)
 
-@deprecate search(buf::IOBuffer, delim::UInt8) coalesce(findfirst(isequal(delim), buf), 0)
-@deprecate search(buf::Base.GenericIOBuffer, delim::UInt8) coalesce(findfirst(isequal(delim), buf), 0)
-
 @deprecate rsearch(s::AbstractString, c::Union{Tuple{Vararg{Char}},AbstractVector{Char},Set{Char}}, i::Integer) coalesce(findprev(in(c), s, i), 0)
 @deprecate rsearch(s::AbstractString, c::Union{Tuple{Vararg{Char}},AbstractVector{Char},Set{Char}}) coalesce(findlast(in(c), s), 0)
 @deprecate rsearch(s::AbstractString, t::AbstractString, i::Integer) coalesce(findprev(t, s, i), 0:-1)
@@ -1564,6 +1561,14 @@ end
 @deprecate islower islowercase
 @deprecate ucfirst uppercasefirst
 @deprecate lcfirst lowercasefirst
+
+function search(buf::IOBuffer, delim::UInt8)
+    Base.depwarn("search(buf::IOBuffer, delim::UInt8) is deprecated: use occursin(delim, buf) or readuntil(buf, delim) instead", :search)
+    p = pointer(buf.data, buf.ptr)
+    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim,bytesavailable(buf))
+    q == C_NULL && return nothing
+    return Int(q-p+1)
+end
 
 # END 0.7 deprecations
 

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -435,22 +435,19 @@ read(io::GenericIOBuffer) = read!(io,StringVector(bytesavailable(io)))
 readavailable(io::GenericIOBuffer) = read(io)
 read(io::GenericIOBuffer, nb::Integer) = read!(io,StringVector(min(nb, bytesavailable(io))))
 
-function findfirst(delim::Fix2{<:Union{typeof(isequal),typeof(==)},UInt8}, buf::IOBuffer)
+function occursin(delim::UInt8, buf::IOBuffer)
     p = pointer(buf.data, buf.ptr)
-    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim.x,bytesavailable(buf))
-    q == C_NULL && return nothing
-    return Int(q-p+1)
+    q = GC.@preserve buf ccall(:memchr,Ptr{UInt8},(Ptr{UInt8},Int32,Csize_t),p,delim,bytesavailable(buf))
+    return q != C_NULL
 end
 
-function findfirst(isdelim::Fix2{<:Union{typeof(isequal),typeof(==)},UInt8}, buf::GenericIOBuffer)
+function occursin(delim::UInt8, buf::GenericIOBuffer)
     data = buf.data
     for i = buf.ptr:buf.size
         @inbounds b = data[i]
-        if isdelim(b)
-            return i - buf.ptr + 1
-        end
+        b == delim && return true
     end
-    return nothing
+    return false
 end
 
 function readuntil(io::GenericIOBuffer, delim::UInt8; keep::Bool=false)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -267,13 +267,13 @@ end
 
 function wait_readbyte(x::LibuvStream, c::UInt8)
     if isopen(x) # fast path
-        findfirst(isequal(c), x.buffer) !== nothing && return
+        occursin(c, x.buffer) && return
     else
         return
     end
     preserve_handle(x)
     try
-        while isopen(x) && coalesce(findfirst(isequal(c), x.buffer), 0) <= 0
+        while isopen(x) && !occursin(c, x.buffer)
             start_reading(x) # ensure we are reading
             wait(x.readnotify)
         end
@@ -1074,7 +1074,7 @@ end
 show(io::IO, s::BufferStream) = print(io,"BufferStream() bytes waiting:",bytesavailable(s.buffer),", isopen:", s.is_open)
 
 function wait_readbyte(s::BufferStream, c::UInt8)
-    while isopen(s) && findfirst(isequal(c), s.buffer) === nothing
+    while isopen(s) && !occursin(c, s.buffer)
         wait(s.r_c)
     end
 end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -893,7 +893,7 @@ function setup_interface(
             sbuffer = LineEdit.buffer(s)
             curspos = position(sbuffer)
             seek(sbuffer, 0)
-            shouldeval = (bytesavailable(sbuffer) == curspos && findfirst(isequal(UInt8('\n')), sbuffer) === nothing)
+            shouldeval = (bytesavailable(sbuffer) == curspos && !occursin(UInt8('\n'), sbuffer))
             seek(sbuffer, curspos)
             if curspos == 0
                 # if pasting at the beginning, strip leading whitespace


### PR DESCRIPTION
These two methods are exceptions in the API as we generally do not support `find*` for non-indexable collections. `occursin` and `readuntil` are replacements for most typical cases (but not all).

Possible counter-arguments to this change:
- `IOBuffer` is special since even if it's not indexable, it supports `position`: it could make sense to look for the position of `delim`
- the deprecation does not cover the case where you really want to know the position of `delim`