### PR TITLE
fix printing of pairs containing array (fix #25466)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -577,12 +577,16 @@ function show(io::IO, p::Pair)
     iocompact = IOContext(io, :compact => get(io, :compact, true))
     has_tight_type(p) || return show_default(iocompact, p)
 
+    typeinfo = get(io, :typeinfo, Any)
+    typeinfos = typeinfo <: Pair && p isa typeinfo ?
+        (fieldtype(typeinfo, 1), fieldtype(typeinfo, 2)) : (Any, Any)
+
     isdelimited(iocompact, p.first) || print(io, "(")
-    show(iocompact, p.first)
+    show(IOContext(iocompact, :typeinfo => typeinfos[1]), p.first)
     isdelimited(iocompact, p.first) || print(io, ")")
     print(io, compact ? "=>" : " => ")
     isdelimited(iocompact, p.second) || print(io, "(")
-    show(iocompact, p.second)
+    show(IOContext(iocompact, :typeinfo => typeinfos[2]), p.second)
     isdelimited(iocompact, p.second) || print(io, ")")
     nothing
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1158,6 +1158,9 @@ end
 
     # issue #25857
     @test repr([(1,),(1,2),(1,2,3)]) == "Tuple{$Int,Vararg{$Int,N} where N}[(1,), (1, 2), (1, 2, 3)]"
+
+    # issues #25466 & #26256
+    @test replstr([:A => [1]]) == "1-element Array{Pair{Symbol,Array{$Int,1}},1}:\n :A => [1]"
 end
 
 @testset "#14684: `display` should print associative types in full" begin


### PR DESCRIPTION
E.g `[:A => rand(2)]`.

Fixes #25466.