### PR TITLE
fix intersection with empty tuples (fix #25801)

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -109,7 +109,8 @@ Maintain order with arrays.
 """
 intersect!(s::AbstractSet, itrs...) = foldl(intersect!, s, itrs)
 intersect!(s::AbstractSet, s2::AbstractSet) = filter!(_in(s2), s)
-intersect!(s::AbstractSet, itr) = intersect!(s, union!(emptymutable(s), itr))
+intersect!(s::AbstractSet, itr) =
+    intersect!(s, union!(emptymutable(s, eltype(itr)), itr))
 
 """
     setdiff(s, itrs...)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -221,6 +221,13 @@ end
     # intersect must uniquify
     @test intersect([1, 2, 1]) == intersect!([1, 2, 1]) == [1, 2]
     @test intersect([1, 2, 1], [2, 2]) == intersect!([1, 2, 1], [2, 2]) == [2]
+
+    # issue #25801
+    x = () ∩ (:something,)
+    y = () ∩ (42,)
+    @test isempty(x)
+    @test isempty(y)
+    @test eltype(x) == eltype(y) == Union{}
 end
 
 @testset "setdiff" begin


### PR DESCRIPTION
E.g. `() ∩ (42,)` was erroring out.