### PR TITLE
.julia to launch julia

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ If you need to build Julia on a machine without internet access, use `make -C de
 
 Once it is built, you can run the `julia` executable after you enter your julia directory and run
     ./julia
+**Note:** `./julia` works only in Unix.
 i.e. you can run it using its full path in the directory created above (the `julia` directory). To run julia from anywhere you can:
 - add an alias (in `bash`: `echo "alias julia='/path/to/install/folder/bin/julia'" >> ~/.bashrc && source ~/.bashrc`), or
 - add a soft link to the `julia` executable in the `julia` directory to `/usr/local/bin` (or any suitable directory already in your path), or

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Once it is built, you can run the `julia` executable using its full path in the 
 
 Now you should be able to run Julia like this:
 
-    julia
+    ./julia
 
 If everything works correctly, you will see a Julia banner and an interactive prompt into which you can enter expressions for evaluation. (Errors related to libraries might be caused by old, incompatible libraries sitting around in your PATH. In this case, try moving the `julia` directory earlier in the PATH).
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ If you need to build Julia on a machine without internet access, use `make -C de
 
 **Note:** The build process will fail badly if any of the build directory's parent directories have spaces or other shell meta-characters such as `$` or `:` in their names (this is due to a limitation in GNU make).
 
-Once it is built, you can run the `julia` executable using its full path in the directory created above (the `julia` directory). To run julia from anywhere you can:
+Once it is built, you can run the `julia` executable after you enter your julia directory and run
+    ./julia
+Also you can run it using its full path in the directory created above (the `julia` directory). To run julia from anywhere you can:
 - add an alias (in `bash`: `echo "alias julia='/path/to/install/folder/bin/julia'" >> ~/.bashrc && source ~/.bashrc`), or
 - add a soft link to the `julia` executable in the `julia` directory to `/usr/local/bin` (or any suitable directory already in your path), or
 
@@ -112,7 +114,7 @@ Once it is built, you can run the `julia` executable using its full path in the 
 
 Now you should be able to run Julia like this:
 
-    ./julia
+    julia
 
 If everything works correctly, you will see a Julia banner and an interactive prompt into which you can enter expressions for evaluation. (Errors related to libraries might be caused by old, incompatible libraries sitting around in your PATH. In this case, try moving the `julia` directory earlier in the PATH).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you need to build Julia on a machine without internet access, use `make -C de
 
 Once it is built, you can run the `julia` executable after you enter your julia directory and run
     ./julia
-Also you can run it using its full path in the directory created above (the `julia` directory). To run julia from anywhere you can:
+i.e. you can run it using its full path in the directory created above (the `julia` directory). To run julia from anywhere you can:
 - add an alias (in `bash`: `echo "alias julia='/path/to/install/folder/bin/julia'" >> ~/.bashrc && source ~/.bashrc`), or
 - add a soft link to the `julia` executable in the `julia` directory to `/usr/local/bin` (or any suitable directory already in your path), or
 


### PR DESCRIPTION
I witnessed that to launch julia in my set up, whether through source code or the other way round, I need to run "./julia" and not "julia" simply. If in case its system dependent or its possible to launch using "julia" then please let me know. I suppose that then both the options should be mentioned in the doc.
Thank you.