### PR TITLE
improve doc strings for bswap, muladd, continue

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -523,7 +523,7 @@ kw"break"
 """
     continue
 
-Skip the rest of the current loop, then carries on looping.
+Skip the rest of the current loop iteration.
 
 # Examples
 ```jldoctest

--- a/base/int.jl
+++ b/base/int.jl
@@ -320,15 +320,15 @@ xor(x::T, y::T) where {T<:BitInteger} = xor_int(x, y)
 """
     bswap(n)
 
-Byte-swap an integer. Flip the bits of its binary representation.
+Reverse the byte order of `n`.
 
 # Examples
 ```jldoctest
-julia> a = bswap(4)
-288230376151711744
+julia> a = bswap(0x10203040)
+0x40302010
 
 julia> bswap(a)
-4
+0x10203040
 
 julia> string(1, base = 2)
 "1"

--- a/base/math.jl
+++ b/base/math.jl
@@ -929,9 +929,10 @@ mod2pi(x) = rem2pi(x,RoundDown)
 """
     muladd(x, y, z)
 
-Combined multiply-add, computes `x*y+z` allowing the add and multiply to be contracted with
-each other or ones from other `muladd` and `@fastmath` to form `fma`
-if the transformation can improve performance.
+Combined multiply-add: computes `x*y+z`, but allowing the add and multiply to be merged
+with each other or with surrounding operations for performance.
+For example, this may be implemented as an [`fma`](@ref) if the hardware supports it
+efficiently.
 The result can be different on different machines and can also be different on the same machine
 due to constant propagation or other optimizations.
 See [`fma`](@ref).


### PR DESCRIPTION
A couple sub-optimal docstrings I've noticed.

bswap: doesn't operate on bits, and "flip" might mean inverting

continue: says it skips the "loop", but it actually only skips one iteration

muladd: I just found this a bit hard to read.