### PR TITLE
Deprecate using reserved words as field names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -214,6 +214,9 @@ Language changes
 
   * `…` (`\dots`) and `⁝` (`\tricolon`) are now parsed as binary operators ([#26262]).
 
+  * Using reserved names as a field (e.g. `foo.function`) is deprecated; quote
+    the field name if needed (e.g. `foo.:function`) ([#?????]).
+
 Breaking changes
 ----------------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -214,8 +214,8 @@ Language changes
 
   * `…` (`\dots`) and `⁝` (`\tricolon`) are now parsed as binary operators ([#26262]).
 
-  * Using reserved names as a field (e.g. `foo.function`) is deprecated; quote
-    the field name if needed (e.g. `foo.:function`) ([#?????]).
+  * Using reserved words as a field (e.g. `foo.function`) is deprecated; quote
+    the field name if needed (e.g. `foo.:function`) ([#26622]).
 
 Breaking changes
 ----------------


### PR DESCRIPTION
This is a part of #26507, and deprecates using keywords as a field name (e.g. `foo.function`).