### PR TITLE
typeinfo: more resilience for user-defined types

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -476,7 +476,10 @@ end
 # X not constrained, can be any iterable (cf. show_vector)
 function typeinfo_prefix(io::IO, X)
     typeinfo = get(io, :typeinfo, Any)::Type
-    @assert X isa typeinfo "$(typeof(X)) is not a subtype of $typeinfo"
+    if !(X isa typeinfo)
+        @assert typeinfo.name.module ∉ (Base, Core) "$(typeof(X)) is not a subtype of $typeinfo"
+        typeinfo = Any # no error for user-defined types
+    end
     # what the context already knows about the eltype of X:
     eltype_ctx = typeinfo_eltype(typeinfo)
     eltype_X = eltype(X)


### PR DESCRIPTION
Currently, if a user-defined collection-like type doesn't handle
the typeinfo property, an assertion is thrown in some circumstances.
This strictness is here lifted up, and maintained only for types
defined in Core/Base.