### PR TITLE
Add methods propagating missing for string functions 

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -102,7 +102,7 @@ max(::Any,     ::Missing) = missing
 # Rounding and related functions
 for f in (:(ceil), :(floor), :(round), :(trunc))
     @eval begin
-        ($f)(::Missing, digits::Integer=0, base::Integer=0) = missing
+        ($f)(::Missing, digits::Integer=0; base::Integer=0) = missing
         ($f)(::Type{>:Missing}, ::Missing) = missing
         ($f)(::Type{T}, ::Missing) where {T} =
             throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
@@ -112,6 +112,52 @@ for f in (:(ceil), :(floor), :(round), :(trunc))
         ($f)(::Type{T}, x::Rational{Bool}) where {T>:Missing} = $f(nonmissingtype(T), x)
     end
 end
+
+# String functions
+repeat(::Missing, ::Integer) = missing
+repeat(::AbstractString, ::Missing) = missing
+repeat(::Missing, ::Missing) = missing
+^(::AbstractString, ::Missing) = missing
+
+occursin(::Missing, ::AbstractString; offset::Integer=0) = missing
+occursin(::Union{AbstractChar,AbstractString,Regex}, ::Missing; offset::Integer=0) = missing
+occursin(::Missing, ::Missing; offset::Integer=0) = missing
+
+replace(::Missing, ::Pair; count::Integer=0) = missing
+
+chop(::Missing; head::Integer = 0, tail::Integer = 1) = missing
+
+escape_string(::Missing) = missing
+unescape_string(::Missing) = missing
+escape_string(::Missing, ::AbstractString) = missing
+
+for f in (:strip, :lstrip, :rstrip)
+    @eval begin
+        $f(::Missing) = missing
+        $f(::Missing, ::Chars) = missing
+    end
+end
+
+for f in (:startswith, :endswith)
+    @eval begin
+        $f(::Missing, ::Union{AbstractString,Chars}) = missing
+        $f(::AbstractString, ::Missing) = missing
+        $f(::Missing, ::Missing) = missing
+    end
+end
+
+for f in (:uppercase, :lowercase, :titlecase, :uppercasefirst, :lowercasefirst,
+          :isuppercase, :islowercase, :chomp, :textwidth)
+    @eval begin
+        $f(::Missing) = missing
+    end
+end
+
+parse(::Missing; base::Integer=0) = missing
+parse(::Type{>:Missing}, ::Missing; base::Integer=0) = missing
+parse(::Type{T}, ::Missing) where {T} =
+    throw(MissingException("cannot parse a missing value to type $T: use Union{$T, Missing} instead"))
+parse(::Type{T}, x::Any; kwargs...) where {T>:Missing} = parse(nonmissingtype(T), x; kwargs...)
 
 # to avoid ambiguity warnings
 (^)(::Missing, ::Integer) = missing

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -377,6 +377,7 @@ julia> thisind("αβγdef", 10)
 
 julia> thisind("αβγdef", 20)
 20
+```
 """
 thisind(s::AbstractString, i::Integer) = thisind(s, Int(i))
 

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -95,7 +95,8 @@ Find the first occurrence of `pattern` in `string`. Equivalent to
 
 # Examples
 ```jldoctest
-julia> findfirst("z", "Hello to the world") # returns nothing, but not printed in the REPL
+julia> findfirst("z", "Hello to the world") === nothing
+true
 
 julia> findfirst("Julia", "JuliaLang")
 1:5

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -49,9 +49,6 @@ endswith(str::AbstractString, chars::Chars) = !isempty(str) && last(str) in char
 startswith(a::String, b::String) = sizeof(a) ≥ sizeof(b) &&
     ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, sizeof(b)) == 0
 
-startswith(a::Vector{UInt8}, b::Vector{UInt8}) = length(a) ≥ length(b) &&
-    ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, length(b)) == 0
-
 # TODO: fast endswith
 
 """

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -190,11 +190,63 @@ end
     for f in rounding_functions
         @test ismissing(f(missing))
         @test ismissing(f(missing, 1))
-        @test ismissing(f(missing, 1, 1))
+        @test ismissing(f(missing, 1, base=10))
         @test ismissing(f(Union{Int, Missing}, missing))
         @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
     end
+end
+
+@testset "string functions" begin
+    @test repeat("a", missing) === missing
+    @test repeat(missing, 2) === missing
+    @test repeat(missing, missing) === missing
+    @test "a"^missing === missing
+    @test missing^2 === missing
+    @test missing^missing === missing
+
+    @test occursin(missing, "a") === missing
+    @test occursin("a", missing) === missing
+    @test occursin('a', missing) === missing
+    @test occursin(r"a", missing) === missing
+    @test occursin(missing, missing) === missing
+
+    @test replace(missing, 'a'=>'b') === missing
+    @test replace(missing, "a"=>"b") === missing
+    @test replace(missing, ['a','c']=>'b') === missing
+    @test replace(missing, 'a'=>uppercase) === missing
+    @test replace(missing, r"a"=>"b") === missing
+    @test replace(missing, 'a'=>'b', count=5) === missing
+
+    @test chop(missing) === missing
+    @test chop(missing, head=1, tail=1) === missing
+
+    @test escape_string(missing) === missing
+    @test unescape_string(missing) === missing
+    @test escape_string(missing, "a") === missing
+
+    for f in (strip, lstrip, rstrip)
+        @test f(missing) === missing
+    end
+
+    for f in (startswith, endswith)
+        @test f(missing, "a") === missing
+        @test f(missing, 'a') === missing
+        @test f(missing, ['a', 'b']) === missing
+        @test f("a", missing) === missing
+        @test f(missing, missing) === missing
+    end
+
+    for f in (uppercase, lowercase, titlecase, uppercasefirst, lowercasefirst,
+              isuppercase, islowercase, chomp, textwidth)
+      @test f(missing) === missing
+    end
+
+    @test parse(Union{Int, Missing}, missing) === missing
+    @test parse(Union{Int, Missing}, "1") === 1
+    @test parse(Union{Int, Missing}, missing, base=10) === missing
+    @test parse(Union{Int, Missing}, "1", base=10) === 1
+    @test_throws MissingException parse(Int, missing)
 end
 
 @testset "printing" begin


### PR DESCRIPTION
The first commit fixes a few details in docs and removes `startswith(::Vector{UInt8}, ::Vector{UInt8})`, which is the only `startswith` method accepting vectors and is not documented nor used anywhere.

The second commit adds methods propagating `missing` to string functions. This has been mentioned before [here](https://discourse.julialang.org/t/count-number-of-substrings-in-dataframe-column/9036) and [here](https://discourse.julialang.org/t/operations-on-missing-values/9785). I have only implemented methods where propagating missing sounds the most natural and useful: basically, for functions which treat strings as scalars and return a string or a scalar. This is consistent with implementing basic math functions and operators, and with the fact that strings are considered as scalars in some situations (e.g. `broadcast`).

I have omitted (at least) the following functions, because either they are only useful when operating directly on character or indices (which will fail for `missing` anyway) or because they return arrays: `isascii`, `ascii` and `isvalid`; `length`, `codeunits`, `ncodeunits`, `nextind`, `prevind`, `thisind`, `first` and `last`; `string` and `repr`; `reverse`; `split` and `rsplit`. Some cases are unclear, but it's easy to add more later if that turns out to be useful.