### PR TITLE
normalize paths passed to include

### DIFF
--- a/base/grisu/grisu.jl
+++ b/base/grisu/grisu.jl
@@ -17,12 +17,12 @@ function __init__()
     Threads.resize_nthreads!(DIGITSs)
 end
 
-include(joinpath("grisu", "float.jl"))
-include(joinpath("grisu", "fastshortest.jl"))
-include(joinpath("grisu", "fastprecision.jl"))
-include(joinpath("grisu", "fastfixed.jl"))
-include(joinpath("grisu", "bignums.jl"))
-include(joinpath("grisu", "bignum.jl"))
+include("grisu/float.jl")
+include("grisu/fastshortest.jl")
+include("grisu/fastprecision.jl")
+include("grisu/fastfixed.jl")
+include("grisu/bignums.jl")
+include("grisu/bignum.jl")
 
 const BIGNUMS = [Bignums.Bignum(),Bignums.Bignum(),Bignums.Bignum(),Bignums.Bignum()]
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -771,10 +771,10 @@ function _include_dependency(mod::Module, _path::AbstractString)
     if prev === nothing
         path = abspath(_path)
     else
-        path = joinpath(dirname(prev), _path)
+        path = normpath(joinpath(dirname(prev), _path))
     end
     if _track_dependencies[]
-        push!(_require_dependencies, (mod, normpath(path), mtime(path)))
+        push!(_require_dependencies, (mod, path, mtime(path)))
     end
     return path, prev
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -968,12 +968,12 @@ cbrt(a::Float16) = Float16(cbrt(Float32(a)))
 sincos(a::Float16) = Float16.(sincos(Float32(a)))
 
 # More special functions
-include(joinpath("special", "exp.jl"))
-include(joinpath("special", "exp10.jl"))
-include(joinpath("special", "hyperbolic.jl"))
-include(joinpath("special", "trig.jl"))
-include(joinpath("special", "gamma.jl"))
-include(joinpath("special", "rem_pio2.jl"))
-include(joinpath("special", "log.jl"))
+include("special/exp.jl")
+include("special/exp10.jl")
+include("special/hyperbolic.jl")
+include("special/trig.jl")
+include("special/gamma.jl")
+include("special/rem_pio2.jl")
+include("special/log.jl")
 
 end # module

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -53,7 +53,7 @@ let SOURCE_PATH = ""
     global _include
     function _include(mod::Module, path)
         prev = SOURCE_PATH
-        path = joinpath(dirname(prev), path)
+        path = normpath(joinpath(dirname(prev), path))
         push!(_included_files, (mod, abspath(path)))
         SOURCE_PATH = path
         result = Core.include(mod, path)

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1395,7 +1395,7 @@ let
         @test_throws(ErrorException("could not open file $(joinpath(@__DIR__, "testfile2"))"),
                      include("testfile2"))
         @test_throws(ErrorException("could not open file $(joinpath(@__DIR__, "2", "testfile"))"),
-                     include(joinpath("2", "testfile")))
+                     include("2/testfile"))
         @test include(tmp_file) == 58.32
         @test remotecall_fetch(include, proc[1], joinpath("2", "testfile")) == 55.32 + proc[1] * 3
     finally

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -10,19 +10,19 @@ module Markdown
 import Base: show, ==, with_output_color
 using Base64: stringmime
 
-include(joinpath("parse", "config.jl"))
-include(joinpath("parse", "util.jl"))
-include(joinpath("parse", "parse.jl"))
+include("parse/config.jl")
+include("parse/util.jl")
+include("parse/parse.jl")
 
-include(joinpath("Common", "Common.jl"))
-include(joinpath("GitHub", "GitHub.jl"))
-include(joinpath("IPython", "IPython.jl"))
-include(joinpath("Julia", "Julia.jl"))
+include("Common/Common.jl")
+include("GitHub/GitHub.jl")
+include("IPython/IPython.jl")
+include("Julia/Julia.jl")
 
-include(joinpath("render", "plain.jl"))
-include(joinpath("render", "html.jl"))
-include(joinpath("render", "latex.jl"))
-include(joinpath("render", "rst.jl"))
+include("render/plain.jl")
+include("render/html.jl")
+include("render/latex.jl")
+include("render/rst.jl")
 
 include(joinpath("render", "terminal", "render.jl"))
 

--- a/stdlib/Pkg/src/resolve.jl
+++ b/stdlib/Pkg/src/resolve.jl
@@ -4,9 +4,9 @@ module Resolve
 
 import Pkg
 
-include(joinpath("resolve", "versionweight.jl"))
-include(joinpath("resolve", "interface.jl"))
-include(joinpath("resolve", "maxsum.jl"))
+include("resolve/versionweight.jl")
+include("resolve/interface.jl")
+include("resolve/maxsum.jl")
 
 using ..Types, ..Query, .PkgToMaxSumInterface, .MaxSum
 import ..PkgError

--- a/stdlib/Pkg3/src/Resolve.jl
+++ b/stdlib/Pkg3/src/Resolve.jl
@@ -2,8 +2,8 @@
 
 module Resolve
 
-include(joinpath("resolve", "VersionWeights.jl"))
-include(joinpath("resolve", "MaxSum.jl"))
+include("resolve/VersionWeights.jl")
+include("resolve/MaxSum.jl")
 
 using ..Types, ..GraphType, ..Resolve.MaxSum
 import ..Types: uuid_julia

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -507,6 +507,9 @@ end
     end
 end
 
+# normalization of paths by include (#26424)
+@test_throws ErrorException("could not open file $(joinpath(@__DIR__, "notarealfile.jl"))") include("./notarealfile.jl")
+
 ## cleanup after tests ##
 
 for env in keys(envs)


### PR DESCRIPTION
This PR fixes #26424, calling `normpath` on paths passed to `include`.

Rationale: it allows people to `include("foo/bar.jl")` without sacrificing readability of errors etc. on Windows, as also discussed in #21395.

In the name of eating our own dogfood, I also used this to simplify many of the `include` calls in Base (using `"foo/bar.jl"` instead of `joinpath`).