### PR TITLE
consistently allow `@reserved_word` macro calls

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2382,7 +2382,7 @@
             (let ((startloc  (line-number-node s))
                   (head (if (eq? (peek-token s) '|.|)
                             (begin (take-token s) '__dot__)
-                            (parse-unary-prefix s))))
+                            (parse-atom s #f))))
               (peek-token s)
               (if (ts:space? s)
                   (maybe-docstring

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1378,3 +1378,8 @@ end
 @test Meta.lower(@__MODULE__, :(global true)) == Expr(:error, "invalid identifier name \"true\"")
 @test Meta.lower(@__MODULE__, :(let ccall end)) == Expr(:error, "invalid identifier name \"ccall\"")
 @test Meta.lower(@__MODULE__, :(cglobal = 0)) == Expr(:error, "invalid assignment location \"cglobal\"")
+
+# issue #26507
+@test Meta.parse("@try x") == Expr(:macrocall, Symbol("@try"), LineNumberNode(1,:none), :x)
+@test Meta.parse("@catch x") == Expr(:macrocall, Symbol("@catch"), LineNumberNode(1,:none), :x)
+@test Meta.parse("@\$x") == Expr(:macrocall, Symbol("@\$"), LineNumberNode(1,:none), :x)


### PR DESCRIPTION
A few packages are using macros like `@struct`, `@function`, `@return`, etc. and I see no reason to disallow it. This makes the situation consistent by allowing all reserved words. It basically makes `@` "quoting" in the same way that `:` and `a.` are. Macro and function *definitions* continue to disallow all reserved words, so our behavior is at least consistent there (the workaround is to use e.g. `@eval macro $(:function)(...)`).

part of #26507 
