### PR TITLE
add lift function for working with missing values

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -705,6 +705,7 @@ export
     ismissing,
     missing,
     skipmissing,
+    lift,
 
 # time
     sleep,

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -218,3 +218,47 @@ end
     @inbounds v = itr.x[i]::eltype(itr)
     (v, _next_nonmissing_ind(itr.x, state))
 end
+
+"""
+    lift(f)
+    lift(f, x...; kw...)
+
+Lift function `f` so that it returns `missing` when any of its positional arguments
+is `missing`. Otherwise `f` is applied to its arguments.
+
+The form `lift(f)` returns an anonymous function that has lifted behavior.
+The form `lift(f, x...; kw...)` returns `missing` if any of `x` is `missing`
+and otherwise returns `f(x...; kw...)`.
+
+# Examples
+```jldoctest
+julia> g = lift(uppercase);
+
+julia> g("a")
+"A"
+
+julia> g(missing)
+missing
+
+julia> lift(parse, Int, "aa", base=16)
+170
+
+julia> lift(parse, missing, "aa", base=16)
+missing
+
+julia> lift(parse).(Int, ["1", "2", missing])
+3-element Array{Union{Missing, Int64},1}:
+ 1
+ 2
+  missing
+
+julia> lift.(parse, Int, ["a", "b", missing], base=16)
+3-element Array{Union{Missing, Int64},1}:
+ 10
+ 11
+   missing
+```
+"""
+lift(f::Function) = (x...; kw...) -> any(ismissing, x) ? missing : f(x...; kw...)
+lift(f::Function, x; kw...) = ismissing(x) ? missing : f(x; kw...)
+lift(f::Function, x...; kw...) = any(ismissing, x) ? missing : f(x...; kw...)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -222,6 +222,7 @@ Base.missing
 Base.coalesce
 Base.ismissing
 Base.skipmissing
+Base.lift
 ```
 
 ## System


### PR DESCRIPTION
Folows discussion in #26631 to add generic lifting method for any function.

The implementation lifts only over positional arguments. The three implemented methods follow results of benchmarking. In particular for a single positional argument it is faster not to call `any` function (at least currently). Also in `lift(f, x; kw...)` it is faster not to call `lift(f)` but directly perform the test. Some limitation is that in `lift(f)` approach we are not able to differentiate between single or multiple positional argument cases. Therefore `lift(f, x; kw...)` style will be faster for single positional argument case.

CC @nalimilan 