### PR TITLE
Add AbstractComplex type

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1,14 +1,22 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-    Complex{T<:Real} <: Number
+    AbstractComplex <: Number
+
+Abstract supertype for complex numbers.
+"""
+abstract type AbstractComplex <: Number
+end
+
+"""
+    Complex{T<:Real} <: AbstractComplex
 
 Complex number type with real and imaginary part of type `T`.
 
 `ComplexF16`, `ComplexF32` and `ComplexF64` are aliases for
 `Complex{Float16}`, `Complex{Float32}` and `Complex{Float64}` respectively.
 """
-struct Complex{T<:Real} <: Number
+struct Complex{T<:Real} <: AbstractComplex
     re::T
     im::T
 end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -5,8 +5,7 @@
 
 Abstract supertype for complex numbers.
 """
-abstract type AbstractComplex <: Number
-end
+abstract type AbstractComplex <: Number end
 
 """
     Complex{T<:Real} <: AbstractComplex

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -13,6 +13,7 @@ export
 
 # Types
     AbstractChannel,
+    AbstractComplex,
     AbstractIrrational,
     AbstractMatrix,
     AbstractRange,


### PR DESCRIPTION
Allows for other complex number types, e.g. PolarComplex representations or Duals for Wirtinger derivatives.