### PR TITLE
reuse wrapper functions rather than ccalling directly to jl_array_del_*/jl_array_grow_*

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -941,7 +941,7 @@ julia> a[1:6]
 function resize!(a::Vector, nl::Integer)
     l = length(a)
     if nl > l
-        ccall(:jl_array_grow_end, Cvoid, (Any, UInt), a, nl-l)
+        _growend!(a, nl-l)
     elseif nl != l
         if nl < 0
             throw(ArgumentError("new length must be ≥ 0"))

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -369,14 +369,14 @@ function append_any(xs...)
     for x in xs
         for y in x
             if i > l
-                ccall(:jl_array_grow_end, Cvoid, (Any, UInt), out, 16)
+                _growend!(out, 16)
                 l += 16
             end
             Core.arrayset(true, out, y, i)
             i += 1
         end
     end
-    ccall(:jl_array_del_end, Cvoid, (Any, UInt), out, l-i+1)
+    _deleteend!(out, l-i+1)
     out
 end
 
@@ -764,4 +764,3 @@ ismissing(::Missing) = true
 
 function popfirst! end
 function peek end
-


### PR DESCRIPTION
There might've been a reason that these wrappers weren't being reused - apologies if that's the case and I missed something.

If I can assume that Base code reliably uses these wrappers as the entry point to `jl_array_del_*`/`jl_array_grow_*`,  Cassette's metadata propagation framework doesn't have to [do as much foreigncall interception](https://github.com/jrevels/Cassette.jl/issues/24#issuecomment-377338488) (it redirects certain array primitives called on `Cassette.Box{<:Array}` values). That might not be a tenable assumption though...