### PR TITLE
RFC: Make LinearIndices consistent with linearindices for vectors

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -249,8 +249,9 @@ module IteratorsMD
         convert(Tuple{Vararg{UnitRange{Int}}}, R)
 
     # AbstractArray implementation
+    Base.axes(iter::CartesianIndices{N,R}) where {N,R} = iter.indices
     Base.IndexStyle(::Type{CartesianIndices{N,R}}) where {N,R} = IndexCartesian()
-    @inline Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R} = CartesianIndex(first.(iter.indices) .- 1 .+ I)
+    @inline Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R} = CartesianIndex(I)
 
     ndims(R::CartesianIndices) = ndims(typeof(R))
     ndims(::Type{CartesianIndices{N}}) where {N} = N
@@ -418,6 +419,7 @@ module IteratorsMD
         @inbounds result = reshape(1:prod(dims), dims)[(I .- first.(iter.indices) .+ 1)...]
         return result
     end
+    @inline Base.getindex(iter::LinearIndices{1,R}, i::Int) where {R} = i
 end  # IteratorsMD
 
 

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -251,7 +251,10 @@ module IteratorsMD
     # AbstractArray implementation
     Base.axes(iter::CartesianIndices{N,R}) where {N,R} = iter.indices
     Base.IndexStyle(::Type{CartesianIndices{N,R}}) where {N,R} = IndexCartesian()
-    @inline Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R} = CartesianIndex(I)
+    @inline function Base.getindex(iter::CartesianIndices{N,R}, I::Vararg{Int, N}) where {N,R}
+        @boundscheck checkbounds(iter, I...)
+        CartesianIndex(I)
+    end
 
     ndims(R::CartesianIndices) = ndims(typeof(R))
     ndims(::Type{CartesianIndices{N}}) where {N} = N

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -410,16 +410,13 @@ module IteratorsMD
     LinearIndices(A::AbstractArray) = LinearIndices(CartesianIndices(A))
 
     # AbstractArray implementation
-    Base.IndexStyle(::Type{LinearIndices{N,R}}) where {N,R} = IndexCartesian()
+    Base.IndexStyle(::Type{LinearIndices{N,R}}) where {N,R} = IndexLinear()
     Base.axes(iter::LinearIndices{N,R}) where {N,R} = iter.indices
     Base.size(iter::LinearIndices{N,R}) where {N,R} = length.(iter.indices)
-    @inline function Base.getindex(iter::LinearIndices{N,R}, I::Vararg{Int, N}) where {N,R}
-        dims = length.(iter.indices)
-        #without the inbounds, this is slower than Base._sub2ind(iter.indices, I...)
-        @inbounds result = reshape(1:prod(dims), dims)[(I .- first.(iter.indices) .+ 1)...]
-        return result
+    function Base.getindex(iter::LinearIndices{N,R}, i::Int) where {N,R}
+        @boundscheck checkbounds(iter, i)
+        i
     end
-    @inline Base.getindex(iter::LinearIndices{1,R}, i::Int) where {R} = i
 end  # IteratorsMD
 
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -178,7 +178,7 @@ end
             @test CartesianIndices((1:4,1:3,1:2))[l] == CartesianIndex(i,j,k)
             @test LinearIndices((0:3,3:5,-101:-100))[i-1,j+2,k-102] == l
             @test LinearIndices((0:3,3:5,-101:-100))[l] == l
-            @test CartesianIndices((0:3,3:5,-101:-100))[i,j,k] == CartesianIndex(i-1, j+2, k-102)
+            @test CartesianIndices((0:3,3:5,-101:-100))[i,j,k] == CartesianIndex(i,j,k)
             @test CartesianIndices((0:3,3:5,-101:-100))[l] == CartesianIndex(i-1, j+2, k-102)
         end
 
@@ -862,10 +862,8 @@ end
     yrng = 1:5
     CR = CartesianIndices((xrng,yrng))
 
-    for (i,i_idx) in enumerate(xrng)
-        for (j,j_idx) in enumerate(yrng)
-            @test CR[i,j] == CartesianIndex(i_idx,j_idx)
-        end
+    for i in xrng, j in yrng
+        @test CR[i,j] == CartesianIndex(i,j)
     end
 
     for i_lin in linearindices(CR)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -176,10 +176,15 @@ end
             @test LinearIndices((1:4,1:3,1:2))[l] == l
             @test CartesianIndices((1:4,1:3,1:2))[i,j,k] == CartesianIndex(i,j,k)
             @test CartesianIndices((1:4,1:3,1:2))[l] == CartesianIndex(i,j,k)
-            @test LinearIndices((0:3,3:5,-101:-100))[i-1,j+2,k-102] == l
+        end
+
+        l = 0
+        for k = -101:-100, j = 3:5, i = 0:3
+            l += 1
+            @test LinearIndices((0:3,3:5,-101:-100))[i,j,k] == l
             @test LinearIndices((0:3,3:5,-101:-100))[l] == l
             @test CartesianIndices((0:3,3:5,-101:-100))[i,j,k] == CartesianIndex(i,j,k)
-            @test CartesianIndices((0:3,3:5,-101:-100))[l] == CartesianIndex(i-1, j+2, k-102)
+            @test CartesianIndices((0:3,3:5,-101:-100))[l] == CartesianIndex(i,j,k)
         end
 
         local A = reshape(Vector(1:9), (3,3))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1680,7 +1680,7 @@ end
     @test eltype(R) <: CartesianIndex{2}
     @test eltype(typeof(R)) <: CartesianIndex{2}
     @test eltype(CartesianIndices{2}) <: CartesianIndex{2}
-    indices = Array(R)
+    indices = collect(R)
     @test indices[1] == CartesianIndex{2}(2,3)
     @test indices[2] == CartesianIndex{2}(3,3)
     @test indices[4] == CartesianIndex{2}(5,3)
@@ -1701,8 +1701,8 @@ end
     @test @inferred(convert(NTuple{2,UnitRange}, R)) === (2:5, 3:5)
     @test @inferred(convert(Tuple{Vararg{UnitRange}}, R)) === (2:5, 3:5)
 
-    @test CartesianIndices((3:5,-7:7)) == CartesianIndex.(3:5, reshape(-7:7, 1, :))
-    @test CartesianIndices((3,-7:7)) == CartesianIndex.(3, reshape(-7:7, 1, :))
+    @test collect(CartesianIndices((3:5,-7:7))) == CartesianIndex.(3:5, reshape(-7:7, 1, :))
+    @test collect(CartesianIndices((3,-7:7))) == CartesianIndex.(3, reshape(-7:7, 1, :))
 end
 
 # All we really care about is that we have an optimized


### PR DESCRIPTION
Change `LinearIndices(x::AbstractVector)` to use the same indices as `axes(x, 1)`. This is consistent with `linearindices(x)` and allows indexing into `x`.
Change `CartesianIndices` to use custom axes so that it works with indices returned by `LinearIndices` for vectors.

This matches the description of linear indices in [the manual](https://docs.julialang.org/en/latest/devdocs/offset-arrays/#Linear-indexing-(linearindices)-1), and should allow deprecating `linearindices` in favor of `LinearIndices` if we want. See https://github.com/JuliaLang/julia/issues/25901#issuecomment-377232502.

If we want this PR, docstrings could be improved to be more explicit.

Before:
```julia
julia> include("test/TestHelpers.jl");

julia> x = TestHelpers.OAs.OffsetArray(1:3, (3,))
Main.TestHelpers.OAs.OffsetArray{Int64,1,UnitRange{Int64}} with indices 4:6:
 1
 2
 3

julia> linearindices(x)
4:6

julia> LinearIndices(x)
LinearIndices{1,Tuple{UnitRange{Int64}}} with indices 4:6:
 1
 2
 3

julia> CartesianIndices(x)
3-element CartesianIndices{1,Tuple{UnitRange{Int64}}}:
 CartesianIndex(4,)
 CartesianIndex(5,)
 CartesianIndex(6,)

julia> y = TestHelpers.OAs.OffsetArray([1 2; 3 4], (3, 2))
Main.TestHelpers.OAs.OffsetArray{Int64,2,Array{Int64,2}} with indices 4:5×3:4:
 1  2
 3  4

julia> linearindices(y)
Base.OneTo(4)

julia> LinearIndices(y)
LinearIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 4:5×3:4:
 1  3
 2  4

julia> CartesianIndices(y)
2×2 CartesianIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}}:
 CartesianIndex(4, 3)  CartesianIndex(4, 4)
 CartesianIndex(5, 3)  CartesianIndex(5, 4)

```

After:
```julia
julia> LinearIndices(x)
LinearIndices{1,Tuple{UnitRange{Int64}}} with indices 4:6:
 4
 5
 6

julia> CartesianIndices(x)
CartesianIndices{1,Tuple{UnitRange{Int64}}} with indices 4:6:
 CartesianIndex(4,)
 CartesianIndex(5,)
 CartesianIndex(6,)

julia> LinearIndices(y)
LinearIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 4:5×3:4:
 1  3
 2  4

julia> CartesianIndices(y)
CartesianIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 4:5×3:4:
 CartesianIndex(4, 3)  CartesianIndex(4, 4)
 CartesianIndex(5, 3)  CartesianIndex(5, 4)
```