### PR TITLE
Bump Pkg3

### DIFF
--- a/stdlib/Pkg3/docs/src/index.md
+++ b/stdlib/Pkg3/docs/src/index.md
@@ -133,36 +133,36 @@ which versions of packages are compatible or incompatible with each other. A
 registry is indexed by package name and UUID, and has a directory for each
 registered package providing the following metadata about it:
 
-  - name – e.g. `DataFrames`
-  - UUID – e.g. `a93c6f00-e57d-5684-b7b6-d8193f3e46c0`
-  - authors – e.g. `Jane Q. Developer <jane@example.com>`
-  - license – e.g. MIT, BSD3, or GPLv2
-  - repository – e.g. `https://github.com/JuliaData/DataFrames.jl.git`
-  - description – a block of text summarizing the functionality of a package
-  - keywords – e.g. `data`, `tabular`, `analysis`, `statistics`
-  - versions – a list of all registered version tags
+- name – e.g. `DataFrames`
+- UUID – e.g. `a93c6f00-e57d-5684-b7b6-d8193f3e46c0`
+- authors – e.g. `Jane Q. Developer <jane@example.com>`
+- license – e.g. MIT, BSD3, or GPLv2
+- repository – e.g. `https://github.com/JuliaData/DataFrames.jl.git`
+- description – a block of text summarizing the functionality of a package
+- keywords – e.g. `data`, `tabular`, `analysis`, `statistics`
+- versions – a list of all registered version tags
 
 For each registered version of a package, the following information is provided:
 
-  - its semantic version number – e.g. `v1.2.3`
-  - its git tree SHA-1 hash – e.g. `7ffb18ea3245ef98e368b02b81e8a86543a11103`
-  - a map from names to UUIDs of dependencies
-  - which versions of other packages it is compatible/incompatible with
+- its semantic version number – e.g. `v1.2.3`
+- its git tree SHA-1 hash – e.g. `7ffb18ea3245ef98e368b02b81e8a86543a11103`
+- a map from names to UUIDs of dependencies
+- which versions of other packages it is compatible/incompatible with
 
-Dependencies and compatiblity are stored in a compressed but human-readable
-format using ranges of package verions.
+Dependencies and compatibility are stored in a compressed but human-readable
+format using ranges of package versions.
 
 **Depot:** a directory on a system where various package-related resources live,
 including:
 
-  - `environments`: shared named environments (e.g. `v0.7`, `devtools`)
-  - `clones`: bare clones of package repositories
-  - `compiled`: cached compiled package images (`.ji` files)
-  - `config`: global configuration files (e.g. `startup.jl`)
-  - `dev`: default directory for package development
-  - `logs`: log files (e.g. `manifest_usage.toml`, `repl_history.jl`)
-  - `packages`: installed package versions
-  - `registries`: clones of registries (e.g. `Uncurated`)
+- `environments`: shared named environments (e.g. `v0.7`, `devtools`)
+- `clones`: bare clones of package repositories
+- `compiled`: cached compiled package images (`.ji` files)
+- `config`: global configuration files (e.g. `startup.jl`)
+- `dev`: default directory for package development
+- `logs`: log files (e.g. `manifest_usage.toml`, `repl_history.jl`)
+- `packages`: installed package versions
+- `registries`: clones of registries (e.g. `Uncurated`)
 
 **Load path:** a stack of environments where package identities, their
 dependencies, and entry-points are searched for. The load path is controlled in
@@ -185,17 +185,25 @@ global configuration data is saved. Later entries in the depot path are treated
 as read-only and are appropriate for registries, packages, etc. installed and
 managed by system administrators.
 
-
 ## Getting Started
 
-The Pkg REPL-mode is entered using from the Julia REPL using the key `]`.
+The Pkg REPL-mode is entered from the Julia REPL using the key `]`.
+
+```
+(v0.7) pkg>
+```
+
+The part inside the parenthesis of the prompt shows the name of the current project.
+Since we haven't created our own project yet, we are in the default project, located at `~/.julia/environments/v0.7`
+(or whatever version of Julia you happen to run).
+
 To return to the `julia>` prompt, either press backspace when the input line is empty or press Ctrl+C.
 Help is available by calling `pkg> help`.
 
 To generate files for a new project, use `pkg> generate`.
 
 ```
-pkg> generate HelloWorld
+(v0.7) pkg> generate HelloWorld
 ```
 
 This creates a new project `HelloWorld` with the following files (visualized with the external [`tree` command](https://linux.die.net/man/1/tree)):
@@ -244,10 +252,11 @@ Hello World!
 ### Adding packages to the project
 
 Let’s say we want to use the standard library package `Random` and the registered package `JSON` in our project.
-We simply `add` these packages:
+We simply `add` these packages (note how the prompt now shows the name of the newly generated project,
+since we are inside the `HelloWorld` project directory):
 
 ```
-pkg> add Random JSON
+(HelloWorld) pkg> add Random JSON
  Resolving package versions...
   Updating "~/Documents/HelloWorld/Project.toml"
  [682c06a0] + JSON v0.17.1
@@ -287,7 +296,7 @@ Sometimes we might want to use the very latest, unreleased version of a package,
 git repository. We can use e.g. the `master` branch of `JSON` by specifying the branch after a `#` when adding the package:
 
 ```
-pkg> add JSON#master
+(HelloWorld) pkg> add JSON#master
    Cloning package from https://github.com/JuliaIO/JSON.jl.git
  Resolving package versions...
   Updating "~/Documents/HelloWorld/Project.toml"
@@ -299,7 +308,7 @@ pkg> add JSON#master
 If we want to use a package that has not been registered in a registry, we can `add` its git repository url:
 
 ```
-pkg> add https://github.com/fredrikekre/ImportMacros.jl
+(HelloWorld) pkg> add https://github.com/fredrikekre/ImportMacros.jl
   Cloning package from https://github.com/fredrikekre/ImportMacros.jl
  Resolving package versions...
 Downloaded MacroTools ─ v0.4.0
@@ -315,10 +324,10 @@ For unregistered packages we could have given a branch (or commit SHA) to track 
 
 ## Developing packages
 
-Let’s say we found a bug in `JSON` that we want to fix. We can get the full git-repo using the `develop` command
+Let’s say we found a bug in one of our dependencies, e.g. `JSON` that we want to fix. We can get the full git-repo using the `develop` command
 
 ```
-pkg> develop JSON
+(HelloWorld) pkg> develop JSON
     Cloning package from https://github.com/JuliaIO/JSON.jl.git
   Resolving package versions...
    Updating "~/Documents/HelloWorld/Project.toml"
@@ -327,11 +336,11 @@ pkg> develop JSON
 ```
 
 By default, the package get cloned to the `~/.julia/dev` folder but can also be set by the `JULIA_PKG_DEVDIR` environment variable.
-When we have fixed the bug and checked that `JSON` now works correctly with out project, we can make a PR to the `JSON` repository.
-When a new release of `JSON` is made, we can go back to using the versioned `JSON` using the command `free` and `update` (see next section):
+When we have fixed the bug and checked that `JSON` now works correctly with our project, we can make a PR to the `JSON` repository.
+When the PR has been merged we can go over to track the master branch and finally, when a new release of `JSON` is made, we can go back to using the versioned `JSON` using the command `free` and `update` (see next section):
 
 ```
-pkg> free JSON
+(HelloWorld) pkg> free JSON
  Resolving package versions...
   Updating "~/Documents/HelloWorld/Project.toml"
  [682c06a0] ~ JSON v0.17.1+ #master ⇒ v0.17.1
@@ -341,20 +350,20 @@ pkg> free JSON
 
 It is also possible to give a local path as the argument to `develop` which will not clone anything but simply use that directory for the package.
 
-Developing a non registered package is done by giving the git-repo url as an argument to `develop`.
+Overriding the dependency path for a non registered package is done by giving the git-repo url as an argument to `develop`.
 
 ### Updating dependencies
 
 When new versions of packages the project is using  are released, it is a good idea to update. Simply calling `up` will try to update *all* the dependencies of the project. Sometimes this is not what you want. You can specify a subset of the dependencies to upgrade by giving them as arguments to `up`, e.g:
 
 ```
-pkg> up JSON
+(HelloWorld) pkg> up JSON
 ```
 
-The version of all other dependencies will stay the same. If you only want to update the minor version of packages, to reduce the risk that your project breaks, you can give the `--minor` flag, e.g:
+The version of all other direct dependencies will stay the same. If you only want to update the minor version of packages, to reduce the risk that your project breaks, you can give the `--minor` flag, e.g:
 
 ```
-pkg> up --minor JSON
+(HelloWorld) pkg> up --minor JSON
 ```
 
 Packages that track a branch are not updated when a minor upgrade is done.
@@ -363,7 +372,7 @@ Developed packages are never touched by the package manager.
 If you just want install the packages that are given by the current `Manifest.toml` use
 
 ```
-pkg> up --manifest --fixed
+(HelloWorld) pkg> up --manifest --fixed
 ```
 
 ### Preview mode
@@ -372,25 +381,24 @@ If you just want to see the effects of running a command, but not change your st
 For example:
 
 ```
-pkg> preview add Plot
+(HelloWorld) pkg> preview add Plots
 ```
 
 or
 
 ```
-pkg> preview up
+(HelloWorld) pkg> preview up
 ```
 
 will show you the effects adding `Plots`, or doing a full upgrade, respectively, would have on your project.
 However, nothing would be installed and your `Project.toml` and `Manfiest.toml` are untouched.
 
-
-### Using someone elses project.
+### Using someone elses project
 
 Simple clone their project using e.g. `git clone`, `cd` to the project directory and call
 
 ```
-pkg> up --manifest --fixed
+(SomeProject) pkg> up --manifest --fixed
 ```
 
 This will install the packages at the same state that the project you cloned was using.

--- a/stdlib/Pkg3/src/API.jl
+++ b/stdlib/Pkg3/src/API.jl
@@ -7,7 +7,7 @@ import Dates
 import LibGit2
 
 import ..depots, ..logdir, ..devdir, ..print_first_command_header
-import ..Operations, ..Display
+import ..Operations, ..Display, ..GitTools
 using ..Types, ..TOML
 
 
@@ -86,7 +86,7 @@ function up(ctx::Context, pkgs::Vector{PackageSpec};
                         return
                     end
                     branch = LibGit2.headname(repo)
-                    LibGit2.fetch(repo)
+                    GitTools.fetch(repo)
                     ff_succeeded = try
                         LibGit2.merge!(repo; branch="refs/remotes/origin/$branch", fastforward=true)
                     catch e

--- a/stdlib/Pkg3/src/GitTools.jl
+++ b/stdlib/Pkg3/src/GitTools.jl
@@ -1,0 +1,100 @@
+module GitTools
+
+using ..Pkg3
+import LibGit2
+using Printf
+
+Base.@kwdef mutable struct MiniProgressBar
+    max::Float64 = 1
+    header::String = ""
+    color::Symbol = :white
+    width::Int = 40
+    current::Float64 = 0.0
+    prev::Float64 = 0.0
+    has_shown::Bool = false
+end
+
+function showprogress(io::IO, p::MiniProgressBar)
+    perc = p.current / p.max * 100
+    prev_perc = p.prev / p.max * 100
+    # Bail early if we are not updating the progress bar,
+    # Saves printing to the terminal
+    if p.has_shown && !(perc - prev_perc > 0.1)
+        return
+    end
+    p.prev = p.current
+    p.has_shown = true
+    n_filled = ceil(Int, p.width * perc / 100)
+    n_left = p.width - n_filled
+    print(io, "    ")
+    printstyled(io, p.header, color=p.color, bold=true)
+    print(io, " [")
+    print(io, "="^n_filled, ">")
+    print(io, " "^n_left, "]  ", )
+    @printf io "%2.1f %%" perc
+    print(io, "\r")
+end
+
+function transfer_progress(progress::Ptr{LibGit2.TransferProgress}, p::Any)
+
+    progress = unsafe_load(progress)
+    @assert haskey(p, :transfer_progress)
+    bar = p[:transfer_progress]
+    @assert typeof(bar) == MiniProgressBar
+    if progress.total_deltas != 0
+        bar.header = "Resolving Deltas:"
+        bar.max = progress.total_deltas
+        bar.current = progress.indexed_deltas
+    else
+        bar.max = progress.total_objects
+        bar.current = progress.received_objects
+    end
+    showprogress(stdout, bar)
+    return Cint(0)
+end
+
+function clone(url, source_path; header=nothing, kwargs...)
+    Pkg3.Types.printpkgstyle(stdout, :Cloning, header == nothing ? "git-repo `$url`" : header)
+    transfer_payload = MiniProgressBar(header = "Fetching:", color = Base.info_color())
+    callbacks = LibGit2.Callbacks(
+        :transfer_progress => (
+            cfunction(transfer_progress, Cint, Tuple{Ptr{LibGit2.TransferProgress}, Any}),
+            transfer_payload,
+        )
+    )
+    print(stdout, "\e[?25l") # disable cursor
+    try
+        return LibGit2.clone(url, source_path; callbacks=callbacks, kwargs...)
+    catch e
+        rm(source_path; force=true, recursive=true)
+        rethrow(e)
+    finally
+        print(stdout, "\033[2K") # clear line
+        print(stdout, "\e[?25h") # put back cursor
+    end
+end
+
+function fetch(repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kwargs...)
+    if remoteurl === nothing
+        remoteurl = LibGit2.with(LibGit2.get(LibGit2.GitRemote, repo, "origin")) do remote
+            LibGit2.url(remote)
+        end
+    end
+    Pkg3.Types.printpkgstyle(stdout, :Updating, header == nothing ? "git-repo `$remoteurl`" : header)
+    transfer_payload = MiniProgressBar(header = "Fetching:", color = Base.info_color())
+    callbacks = LibGit2.Callbacks(
+        :transfer_progress => (
+            cfunction(transfer_progress, Cint, Tuple{Ptr{LibGit2.TransferProgress}, Any}),
+            transfer_payload,
+        )
+    )
+    print(stdout, "\e[?25l") # disable cursor
+    try
+        return LibGit2.fetch(repo; remoteurl=remoteurl, callbacks=callbacks, kwargs...)
+    finally
+        print(stdout, "\033[2K") # clear line
+        print(stdout, "\e[?25h") # put back cursor
+    end
+end
+
+end # module

--- a/stdlib/Pkg3/src/GitTools.jl
+++ b/stdlib/Pkg3/src/GitTools.jl
@@ -58,7 +58,7 @@ function clone(url, source_path; header=nothing, kwargs...)
     transfer_payload = MiniProgressBar(header = "Fetching:", color = Base.info_color())
     callbacks = LibGit2.Callbacks(
         :transfer_progress => (
-            cfunction(transfer_progress, Cint, Tuple{Ptr{LibGit2.TransferProgress}, Any}),
+            @cfunction(transfer_progress, Cint, (Ptr{LibGit2.TransferProgress}, Any)),
             transfer_payload,
         )
     )
@@ -84,7 +84,7 @@ function fetch(repo::LibGit2.GitRepo, remoteurl=nothing; header=nothing, kwargs.
     transfer_payload = MiniProgressBar(header = "Fetching:", color = Base.info_color())
     callbacks = LibGit2.Callbacks(
         :transfer_progress => (
-            cfunction(transfer_progress, Cint, Tuple{Ptr{LibGit2.TransferProgress}, Any}),
+            @cfunction(transfer_progress, Cint, (Ptr{LibGit2.TransferProgress}, Any)),
             transfer_payload,
         )
     )

--- a/stdlib/Pkg3/src/Pkg3.jl
+++ b/stdlib/Pkg3/src/Pkg3.jl
@@ -27,6 +27,7 @@ end
 # load snapshotted dependencies
 include("../ext/TOML/src/TOML.jl")
 
+include("GitTools.jl")
 include("PlatformEngines.jl")
 include("Types.jl")
 include("Display.jl")

--- a/stdlib/Pkg3/src/REPLMode.jl
+++ b/stdlib/Pkg3/src/REPLMode.jl
@@ -769,9 +769,9 @@ function complete_option(s, i1, i2)
 end
 
 function complete_package(s, i1, i2, lastcommand, project_opt)
-    if lastcommand in [CMD_STATUS, CMD_RM, CMD_UP, CMD_TEST, CMD_BUILD, CMD_FREE, CMD_PIN, CMD_CHECKOUT, CMD_DEVELOP]
+    if lastcommand in [CMD_STATUS, CMD_RM, CMD_UP, CMD_TEST, CMD_BUILD, CMD_FREE, CMD_PIN, CMD_CHECKOUT]
         return complete_installed_package(s, i1, i2, project_opt)
-    elseif lastcommand in [CMD_ADD]
+    elseif lastcommand in [CMD_ADD, CMD_DEVELOP]
         return complete_remote_package(s, i1, i2)
     end
     return String[], 0:-1, false

--- a/stdlib/Pkg3/src/REPLMode.jl
+++ b/stdlib/Pkg3/src/REPLMode.jl
@@ -849,9 +849,23 @@ function completions(full, index)
     end
 end
 
+function promptf()
+    env = EnvCache()
+    proj_dir = dirname(env.project_file)
+    if startswith(pwd(), proj_dir) && env.pkg != nothing && !isempty(env.pkg.name)
+        name = env.pkg.name
+    else
+        name = basename(proj_dir)
+    end
+    prefix = string("(", name, ") ")
+    return prefix * "pkg> "
+end
+
 # Set up the repl Pkg REPLMode
 function create_mode(repl, main)
-    pkg_mode = LineEdit.Prompt("pkg> ";
+
+
+    pkg_mode = LineEdit.Prompt(promptf;
         prompt_prefix = Base.text_colors[:blue],
         prompt_suffix = "",
         complete = PkgCompletionProvider(),

--- a/stdlib/Pkg3/src/Types.jl
+++ b/stdlib/Pkg3/src/Types.jl
@@ -9,7 +9,7 @@ using REPL.TerminalMenus
 
 using ..TOML
 import ..Pkg3
-import Pkg3: depots, logdir
+import Pkg3: GitTools, depots, logdir
 
 import Base: SHA1, AbstractEnv
 using SHA
@@ -623,6 +623,7 @@ function isdir_windows_workaround(path::String)
 end
 
 function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec})
+    creds = LibGit2.CachedCredentials()
     env = ctx.env
     for pkg in pkgs
         pkg.repo == nothing && continue
@@ -643,14 +644,12 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec})
             mkpath(clone_path)
             repo_path = joinpath(clone_path, string(hash(pkg.repo.url), "_full"))
             repo, just_cloned = ispath(repo_path) ? (LibGit2.GitRepo(repo_path), false) : begin
-                printpkgstyle(ctx, :Cloning, "package from $(pkg.repo.url)")
-                r = LibGit2.clone(pkg.repo.url, repo_path)
-                LibGit2.fetch(r, remoteurl=pkg.repo.url, refspecs=refspecs)
+                r = GitTools.clone(pkg.repo.url, repo_path)
+                GitTools.fetch(r, pkg.repo.url; refspecs=refspecs, credentials=creds)
                 r, true
             end
             if !just_cloned
-                printpkgstyle(ctx, :Updating, "repo from $(pkg.repo.url)")
-                LibGit2.fetch(repo, remoteurl=pkg.repo.url, refspecs=refspecs)
+                GitTools.fetch(repo, pkg.repo.url; refspecs=refspecs, credentials=creds)
             end
             close(repo)
 
@@ -682,6 +681,7 @@ function handle_repos_develop!(ctx::Context, pkgs::AbstractVector{PackageSpec})
 end
 
 function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec}; upgrade_or_add::Bool=true)
+    creds = LibGit2.CachedCredentials()
     env = ctx.env
     for pkg in pkgs
         pkg.repo == nothing && continue
@@ -691,16 +691,15 @@ function handle_repos_add!(ctx::Context, pkgs::AbstractVector{PackageSpec}; upgr
         mkpath(clones_dir)
         repo_path = joinpath(clones_dir, string(hash(pkg.repo.url)))
         repo, just_cloned = ispath(repo_path) ? (LibGit2.GitRepo(repo_path), false) : begin
-            printpkgstyle(ctx, :Cloning, "package from $(pkg.repo.url)")
-            r = LibGit2.clone(pkg.repo.url, repo_path, isbare=true)
-            LibGit2.fetch(r, remoteurl=pkg.repo.url, refspecs=refspecs)
+            r = GitTools.clone(pkg.repo.url, repo_path, isbare=true, credentials=creds)
+            GitTools.fetch(r, pkg.repo.url; refspecs=refspecs, credentials=creds)
             r, true
         end
         info = manifest_info(env, pkg.uuid)
         pinned = (info != nothing && get(info, "pinned", false))
-        if upgrade_or_add  && !pinned && !just_cloned
-            printpkgstyle(ctx, :Updating, "repo from $(pkg.repo.url)")
-            LibGit2.fetch(repo, remoteurl=pkg.repo.url, refspecs=refspecs)
+        if upgrade_or_add && !pinned && !just_cloned
+            rev = pkg.repo.rev
+            GitTools.fetch(repo, pkg.repo.url; refspecs=refspecs, credentials=creds)
         end
         if upgrade_or_add && !pinned
             rev = pkg.repo.rev
@@ -963,11 +962,11 @@ function registries(; clone_default=true)::Vector{String}
     if clone_default
         if !ispath(user_regs)
             mkpath(user_regs)
+            creds = LibGit2.CachedCredentials()
             printpkgstyle(stdout, :Cloning, "default registries into $user_regs")
             for (reg, url) in DEFAULT_REGISTRIES
-                printpkgstyle(stdout, :Cloning, "registry $reg from $(repr(url))")
                 path = joinpath(user_regs, reg)
-                repo = LibGit2.clone(url, path)
+                repo = GitTools.clone(url, path; header = "registry $reg from $(repr(url))", credentials = creds)
                 close(repo)
             end
         end


### PR DESCRIPTION
* Add credential handling to Pkg3's git functionality (thanks to @omus).
* Add a progress-bar for cloning repos, thanks @omus for the groundwork that made this feature possible (https://github.com/JuliaLang/julia/pull/26437):

![apr-04-2018 15-08-29](https://user-images.githubusercontent.com/1282691/38309370-32421ee0-381a-11e8-97bd-786fce21c313.gif)

* Show in the Pkg3 prompt the name of the current project (also shown in gif above). Some users have been a bit confused about what their current project is, this should make that more explicit.
