### PR TITLE
Enable logging after exit with atexit hook.

### DIFF
--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -54,6 +54,12 @@ include("ConsoleLogger.jl")
 
 function __init__()
     global_logger(ConsoleLogger(stderr))
+    atexit() do
+        logger = global_logger()
+        if isa(logger, ConsoleLogger)
+            global_logger(ConsoleLogger(Core.stderr, min_enabled_level(logger)))
+        end
+    end
 end
 
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -529,3 +529,10 @@ end
 let s = "   \$abc   "
     @test s[Base.shell_parse(s)[2]] == "abc"
 end
+
+# Logging macros should not output to finalized streams (#26687)
+let
+    cmd = `$(Base.julia_cmd()) -e 'finalizer(x->@info(x), "Hello")'`
+    output = readchomp(pipeline(cmd, stderr=catcmd))
+    @test occursin("Info: Hello", output)
+end


### PR DESCRIPTION
Fixes #26687

Only replaces a ConsoleLogger (which calls displaysize from #26687), but doesn't === because the user might have replaced it to control eg. the logging level.