### PR TITLE
[RFC] Making working with LLVM a bit more convinient

### DIFF
--- a/deps/llvm-options.mk
+++ b/deps/llvm-options.mk
@@ -1,5 +1,9 @@
-ifeq ($(LLVM_DEBUG),1)
+ifneq ($(LLVM_DEBUG),0)
+ifeq  ($(LLVM_DEBUG),1)
 LLVM_BUILDTYPE := Debug
+else
+LLVM_BUILDTYPE := RelWithDebInfo
+endif
 else
 LLVM_BUILDTYPE := Release
 endif

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -84,11 +84,16 @@ endif # OS == WINNT
 else
 LLVM_FLAGS += --disable-assertions
 endif # LLVM_ASSERTIONS
-ifeq ($(LLVM_DEBUG), 1)
-LLVM_FLAGS += --disable-optimized --enable-debug-symbols --enable-keep-symbols
+ifneq ($(LLVM_DEBUG), 0)
+LLVM_FLAGS += --enable-debug-symbols --enable-keep-symbols
 ifeq ($(OS), WINNT)
 LLVM_CXXFLAGS += -Wa,-mbig-obj
 endif # OS == WINNT
+ifeq ($(LLVM_DEBUG), 1)
+LLVM_FLAGS += --disable-optimized
+else #RelWithDebInfo
+LLVM_FLAGS += --enable-optimized
+endif
 else
 LLVM_FLAGS += --enable-optimized
 endif # LLVM_DEBUG

--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -50,9 +50,8 @@ development version of LLVM.
 
 ## Passing options to LLVM
 
-You can pass options to LLVM using *debug* builds of Julia. To create a debug build, run `make debug`.
-The resulting executable is `usr/bin/julia-debug`. You can pass LLVM options to this executable
-via the environment variable `JULIA_LLVM_ARGS`. Here are example settings using `bash` syntax:
+You can pass LLVM options to via the environment variable `JULIA_LLVM_ARGS`.
+Here are example settings using `bash` syntax:
 
   * `export JULIA_LLVM_ARGS = -print-after-all` dumps IR after each pass.
   * `export JULIA_LLVM_ARGS = -debug-only=loop-vectorize` dumps LLVM `DEBUG(...)` diagnostics for

--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -48,16 +48,22 @@ LLVM_VER = 3.5.0
 Besides the LLVM release numerals, you can also use `LLVM_VER = svn` to bulid against the latest
 development version of LLVM.
 
+You can also specify to build a debug version of LLVM, by setting either `LLVM_DEBUG = 1` or
+`LLVM_DEBUG = Release` in your `Make.user` file. The former will be a fully unoptimized build
+of LLVM and the latter will produce an optimized build of LLVM. Depending on your needs the
+latter will suffice and it quite a bit faster. If you use `LLVM_DEBUG = Release` you will also
+want to set `LLVM_ASSERTIONS = 1` to enable diagonstics for different passes. Only `LLVM_DEBUG = 1`
+implies that option by default.
+
 ## Passing options to LLVM
 
-You can pass LLVM options to via the environment variable `JULIA_LLVM_ARGS`.
+You can pass options to LLVM via the environment variable `JULIA_LLVM_ARGS`.
 Here are example settings using `bash` syntax:
 
   * `export JULIA_LLVM_ARGS = -print-after-all` dumps IR after each pass.
   * `export JULIA_LLVM_ARGS = -debug-only=loop-vectorize` dumps LLVM `DEBUG(...)` diagnostics for
-    loop vectorizer *if* you built Julia with `LLVM_ASSERTIONS=1`. Otherwise you will get warnings
-    about "Unknown command line argument". Counter-intuitively, building Julia with `LLVM_DEBUG=1`
-    is *not* enough to dump `DEBUG` diagnostics from a pass.
+    loop vectorizer. If you get warnings about "Unknown command line argument", rebuild LLVM with
+    `LLVM_ASSERTIONS = 1`.
 
 ## Debugging LLVM transformations in isolation
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -314,12 +314,6 @@ event listener for just-in-time (JIT) profiling.
 
 Arguments to be passed to the LLVM backend.
 
-!!! note
-
-    This environment variable has an effect only if Julia was compiled with
-    `JL_DEBUG_BUILD` set — in particular, the `julia-debug` executable is always
-    compiled with this build variable.
-
 ### `JULIA_DEBUG_LOADING`
 
 If set, then Julia prints detailed information about the cache in the loading

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7271,9 +7271,7 @@ extern "C" void *jl_init_llvm(void)
     const char *const argv_copyprop[] = {"", "-disable-copyprop"}; // llvm bug 21743
     cl::ParseCommandLineOptions(sizeof(argv_copyprop)/sizeof(argv_copyprop[0]), argv_copyprop, "disable-copyprop\n");
 #endif
-#if defined(JL_DEBUG_BUILD) || defined(USE_POLLY)
     cl::ParseEnvironmentOptions("Julia", "JULIA_LLVM_ARGS");
-#endif
 
     jl_page_size = jl_getpagesize();
     imaging_mode = jl_generating_output();


### PR DESCRIPTION
These are two changes that I have been carrying around locally for a while.

1. Allow `JULIA_LLVM_ARGS` in non-debug builds. Since debug builds and release builds
   differ sometimes, it can be quite useful to also pass them to release builds.

2. Make `LLVM_DEBUG` a three value flag:
   1. `LLVM_DEBUG=0` implies LLVM_CMAKE_BUILDTYPE=Release
   2. `LLVM_DEBUG=1` implies LLVM_CMAKE_BUILDTYPE=Debug
   3. `LLVM_DEBUG=Release` implies LLVM_CMAKE_BUILDTYPE=RelWithDebInfo
   The last option is quite helpful since it gives one most of the information,
   but is not as slow as a full debug build. (One generally wants to pair that with `LLVM_ASSERTIONS=1`)

Also `LLVM_ASSERTIONS=1` is no longer necessary for debug builds since `3.9` when using cmake.