### PR TITLE
check worker process type while getting bind address

### DIFF
--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1045,6 +1045,9 @@ function disable_nagle(sock)
     end
 end
 
+wp_bind_addr(p::LocalProcess) = p.bind_addr
+wp_bind_addr(p) = p.config.bind_addr
+
 function check_same_host(pids)
     if myid() != 1
         return remotecall_fetch(check_same_host, 1, pids)
@@ -1055,8 +1058,8 @@ function check_same_host(pids)
         if all(p -> (p==1) || (isa(map_pid_wrkr[p].manager, LocalManager)), pids)
             return true
         else
-            first_bind_addr = notnothing(map_pid_wrkr[pids[1]].config.bind_addr)
-            return all(p -> (p != 1) && (notnothing(map_pid_wrkr[p].config.bind_addr) == first_bind_addr), pids[2:end])
+            first_bind_addr = notnothing(wp_bind_addr(map_pid_wrkr[pids[1]]))
+            return all(p -> notnothing(wp_bind_addr(map_pid_wrkr[p])) == first_bind_addr, pids[2:end])
         end
     end
 end


### PR DESCRIPTION
check worker process type and get bind address differently depending on whether it is a `LocalProcess` or `Worker`

fixes #26699 