### PR TITLE
Add Fix1 (partial application).

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -814,11 +814,28 @@ julia> filter(!isalpha, str)
 !(f::Function) = (x...)->!f(x...)
 
 """
+    Fix1(f, x)
+
+A type representing a partially-applied version of the two-argument function
+`f`, with the first argument fixed to the value "x". In other words,
+`Fix1(f, x)` behaves similarly to `y->f(x, y)`.
+"""
+struct Fix1{F,T} <: Function
+    f::F
+    x::T
+
+    Fix1(f::F, x::T) where {F,T} = new{F,T}(f, x)
+    Fix1(f::Type{F}, x::T) where {F,T} = new{Type{F},T}(f, x)
+end
+
+(f::Fix1)(y) = f.f(f.x, y)
+
+"""
     Fix2(f, x)
 
-A type representing a partially-applied version of function `f`, with the second
-argument fixed to the value "x".
-In other words, `Fix2(f, x)` behaves similarly to `y->f(y, x)`.
+A type representing a partially-applied version of the two-argument function
+`f`, with the second argument fixed to the value "x". In other words,
+`Fix2(f, x)` behaves similarly to `y->f(y, x)`.
 """
 struct Fix2{F,T} <: Function
     f::F

--- a/test/operators.jl
+++ b/test/operators.jl
@@ -181,3 +181,12 @@ end
 
     @test fldmod1(4.0, 3) == fldmod1(4, 3)
 end
+
+@testset "Fix12" begin
+    x = 9
+    y = 7.0
+    fx = Base.Fix1(/, x)
+    fy = Base.Fix2(/, y)
+    @test fx(y) == x / y
+    @test fy(x) == x / y
+end


### PR DESCRIPTION
Also add some trivial tests, and clarify that this is for two-argument functions in the docstrings.

This is a follow-up to 71fbc70ef9c3d4a7fee24d9835a42034170be97f, my understanding is that this was [planned](https://github.com/JuliaLang/julia/pull/26436#issuecomment-373490587). See also [forum discussion](https://discourse.julialang.org/t/fix1-analogue-of-base-fix2/10161/).