### PR TITLE
Teach at-dot about chained comparisons

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -838,7 +838,8 @@ function __dot__(x::Expr)
     if x.head == :call && dottable(x.args[1])
         Expr(:., dotargs[1], Expr(:tuple, dotargs[2:end]...))
     elseif x.head == :comparison
-        Expr(:comparison, (iseven(i) && dottable(arg) ? Symbol('.', arg) : arg for (i, arg) in pairs(dotargs))...)
+        Expr(:comparison, (iseven(i) && dottable(arg) && arg isa Symbol ? Symbol('.', arg) : arg
+                               for (i, arg) in pairs(dotargs))...)
     elseif x.head == :$
         x.args[1]
     elseif x.head == :let # don't add dots to `let x=...` assignments

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -838,8 +838,8 @@ function __dot__(x::Expr)
     if x.head == :call && dottable(x.args[1])
         Expr(:., dotargs[1], Expr(:tuple, dotargs[2:end]...))
     elseif x.head == :comparison
-        Expr(:comparison, (iseven(i) && dottable(arg) && arg isa Symbol ? Symbol('.', arg) : arg
-                               for (i, arg) in pairs(dotargs))...)
+        Expr(:comparison, (iseven(i) && dottable(arg) && arg isa Symbol && isoperator(arg) ?
+                               Symbol('.', arg) : arg for (i, arg) in pairs(dotargs))...)
     elseif x.head == :$
         x.args[1]
     elseif x.head == :let # don't add dots to `let x=...` assignments

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -837,6 +837,8 @@ function __dot__(x::Expr)
     dotargs = map(__dot__, x.args)
     if x.head == :call && dottable(x.args[1])
         Expr(:., dotargs[1], Expr(:tuple, dotargs[2:end]...))
+    elseif x.head == :comparison
+        Expr(:comparison, (isodd(i) ? arg : Symbol('.', arg) for (i, arg) in pairs(dotargs))...)
     elseif x.head == :$
         x.args[1]
     elseif x.head == :let # don't add dots to `let x=...` assignments

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -838,7 +838,7 @@ function __dot__(x::Expr)
     if x.head == :call && dottable(x.args[1])
         Expr(:., dotargs[1], Expr(:tuple, dotargs[2:end]...))
     elseif x.head == :comparison
-        Expr(:comparison, (isodd(i) ? arg : Symbol('.', arg) for (i, arg) in pairs(dotargs))...)
+        Expr(:comparison, (iseven(i) && dottable(arg) ? Symbol('.', arg) : arg for (i, arg) in pairs(dotargs))...)
     elseif x.head == :$
         x.args[1]
     elseif x.head == :let # don't add dots to `let x=...` assignments

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -276,7 +276,7 @@ end
 
 # Issue #23622: @. with chained comparisons
 let x = [1,2,3]
-    @test (1 .< x .< 3) == @.(1 < x < 3) == [false, true, false]
+    @test (1 .< x .< 3) == @.(1 < x < 3) == (@. 1 .< x .< 3) == [false, true, false]
     @test (x .=== 1:3 .=== [1,2,3]) == @.(x === 1:3 === [1,2,3]) == [true, true, true]
 end
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -274,6 +274,12 @@ let x = [1,2,3]
     @test f(x) == [1,4,9]
 end
 
+# Issue #23622: @. with chained comparisons
+let x = [1,2,3]
+    @test (1 .< x .< 3) == @.(1 < x < 3) == [false, true, false]
+    @test (x .=== 1:3 .=== [1,2,3]) == @.(x === 1:3 === [1,2,3]) == [true, true, true]
+end
+
 # PR #17510: Fused in-place assignment
 let x = [1:4;], y = x
     y .= 2:5


### PR DESCRIPTION
Fixes #23622. `@. 1 < A < 2` now works as expected.