### PR TITLE
add PipelineError to capture exit code

### DIFF
--- a/base/download.jl
+++ b/base/download.jl
@@ -11,7 +11,17 @@ if Sys.iswindows()
         client = "New-Object System.Net.Webclient"
         # in the following we escape ' with '' (see https://ss64.com/ps/syntax-esc.html)
         downloadfile = "($client).DownloadFile('$(replace(url, "'" => "''"))', '$(replace(filename, "'" => "''"))')"
-        run(`$ps -NoProfile -Command "$tls12; $downloadfile"`)
+        # PowerShell v3 or later is required for Tls12
+        try
+            run(`$ps -Version 3 -NoProfile -Command "$tls12; $downloadfile"`)
+        catch e
+            if e isa PipelineError{Process} && e.pipe.exitcode % Int32 == -393216
+                # appears to be "wrong version" exit code, based on
+                # https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-startup-tasks-common
+                error("Downloading files requires Windows Management Framework 3.0 or later.")
+            end
+            rethrow(e)
+        end
         filename
     end
 else


### PR DESCRIPTION
At the moment if a process fails and throws and error, there is no easy way to capture the exit code. The only other option is to run asynchronously and manually check (but then there is no easy way to throw an error...)