### PR TITLE
RFC: improve usability of custom log levels

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -114,15 +114,16 @@ const Warn          = LogLevel(    1000)
 const Error         = LogLevel(    2000)
 const AboveMaxLevel = LogLevel( 1000001)
 
+const LogLevelNames = Dict(
+    BelowMinLevel  => "BelowMinLevel",
+    Debug          => "Debug",
+    Info           => "Info",
+    Warn           => "Warn",
+    Error          => "Error",
+    AboveMaxLevel  => "AboveMaxLevel")
+
 function show(io::IO, level::LogLevel)
-    if     level == BelowMinLevel  print(io, "BelowMinLevel")
-    elseif level == Debug          print(io, "Debug")
-    elseif level == Info           print(io, "Info")
-    elseif level == Warn           print(io, "Warn")
-    elseif level == Error          print(io, "Error")
-    elseif level == AboveMaxLevel  print(io, "AboveMaxLevel")
-    else                           print(io, "LogLevel($(level.level))")
-    end
+    print(io, get(LogLevelNames, level, "LogLevel($(level.level))"))
 end
 
 

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -297,8 +297,8 @@ function logmsg_code(_module, file, line, level, message, exs...)
     quote
         level = $level
         std_level = convert(LogLevel, level)
-        if std_level >= getindex(_min_enabled_level)
-            logstate = current_logstate()
+        if std_level >= getindex($_min_enabled_level)
+            logstate = $current_logstate()
             if std_level >= logstate.min_enabled_level
                 logger = logstate.logger
                 _module = $_module
@@ -306,17 +306,17 @@ function logmsg_code(_module, file, line, level, message, exs...)
                 group = $group
                 # Second chance at an early bail-out, based on arbitrary
                 # logger-specific logic.
-                if shouldlog(logger, level, _module, group, id)
+                if $shouldlog(logger, level, _module, group, id)
                     file = $file
                     line = $line
                     try
                         msg = $(esc(message))
-                        handle_message(logger, level, msg, _module, group, id, file, line; $(kwargs...))
+                        $handle_message(logger, level, msg, _module, group, id, file, line; $(kwargs...))
                     catch err
-                        if !catch_exceptions(logger)
+                        if !$catch_exceptions(logger)
                             rethrow(err)
                         end
-                        logging_error(logger, level, _module, group, id, file, line, err)
+                        $logging_error(logger, level, _module, group, id, file, line, err)
                     end
                 end
             end


### PR DESCRIPTION
Ref https://github.com/JuliaLang/julia/pull/26005#issuecomment-366363362
RFC, will add tests if deemed acceptable.

Makes it possible to define custom log levels:

```julia
using Logging

import Base.CoreLogging: @_sourceinfo, logmsg_code, Error, LogLevelNames
const ICE = Error+1000
macro ice(message, exs...)
    logmsg_code((@_sourceinfo)..., :ICE, message, exs...)
end
LogLevelNames[ICE] = "Internal compiler error"

@ice "k"
```

Performance hit of looking up the log level name in a dict is about 2.5% (could probably do something fancier if this is too much):
```
julia> with_logger(Logging.ConsoleLogger(DevNull)) do
           @btime @info 42
       end
  15.058 μs (74 allocations: 2.72 KiB)

julia> using Revise

julia> Revise.track(Base)

julia> with_logger(Logging.ConsoleLogger(DevNull)) do
           @btime @info 42
       end
  15.464 μs (82 allocations: 3.05 KiB)
```