### PR TITLE
Enable PCRE UTF-8 validity string checks

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -4,8 +4,8 @@
 
 include("pcre.jl")
 
-const DEFAULT_COMPILER_OPTS = PCRE.UTF | PCRE.NO_UTF_CHECK | PCRE.ALT_BSUX
-const DEFAULT_MATCH_OPTS = PCRE.NO_UTF_CHECK
+const DEFAULT_COMPILER_OPTS = PCRE.UTF | PCRE.ALT_BSUX
+const DEFAULT_MATCH_OPTS = zero(UInt32)
 
 mutable struct Regex
     pattern::String

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -49,3 +49,19 @@ end
 
 # Proper unicode handling
 @test  match(r"∀∀", "∀x∀∀∀").match == "∀∀"
+
+@test_throws ErrorException match(r"a", "\xe2\x88") # 1 byte missing at end
+@test_throws ErrorException match(r"a", "\xe2\x08\x80") # byte 2 top bits not 0x80
+@test_throws ErrorException match(r"a", "\xf8\x89\x89\x80\x80") # 5-byte character is not allowed (RFC 3629)
+@test_throws ErrorException match(r"a", "\xf4\x9f\xbf\xbf") # code points greater than 0x10ffff are not defined
+@test_throws ErrorException match(r"a", "\Udfff") # code points 0xd800-0xdfff are not defined
+@test_throws ErrorException match(r"a", "\xc0\x80") #  overlong 2-byte sequence
+@test_throws ErrorException match(r"a", "\xff") # illegal byte (0xfe or 0xff)
+
+@test_throws ErrorException Regex("\xe2\x88") # 1 byte missing at end
+@test_throws ErrorException Regex("\xe2\x08\x80") # byte 2 top bits not 0x80
+@test_throws ErrorException Regex("\xf8\x89\x89\x80\x80") # 5-byte character is not allowed (RFC 3629)
+@test_throws ErrorException Regex("\xf4\x9f\xbf\xbf") # code points greater than 0x10ffff are not defined
+@test_throws ErrorException Regex("\Udfff") # code points 0xd800-0xdfff are not defined
+@test_throws ErrorException Regex("\xc0\x80") #  overlong 2-byte sequence
+@test_throws ErrorException Regex("\xff") # illegal byte (0xfe or 0xff)


### PR DESCRIPTION
Strings are no guaranteed to contain valid UTF-8, and PCRE documentation says that the behavior is undefined in that case. See [Discourse post](https://discourse.julialang.org/t/flaw-in-regex-support-for-string/9667).

This is WIP for two reasons:
- ~`match(r"a", "\U11000")` is supposed to fail according to [the docs](https://www.pcre.org/current/doc/html/pcre2unicode.html) (look for `PCRE2_ERROR_UTF8_ERR14`), but it doesn't. Am I missing something?~ EDIT: turns out this was a typo in the PCRE docs, one zero was missing.
- For an obscure reason, `r"\xff"` does not throw an error even though `Regex("\xff")` and `@r_str("\xff")` do. This means that the UTF-8 validity check does not work in the most common cases.

Given that regexes are often written as literals, it could make sense for performance to check them ourselves at compile time in `r_str`, and keep track of that in the object to disable the PCRE check. But that optimization isn't breaking, so it can be applied later.