### PR TITLE
Fix dot-evaluation fast path

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -36,7 +36,7 @@ jl_sym_t *top_sym;     jl_sym_t *colons_sym;
 jl_sym_t *line_sym;    jl_sym_t *jl_incomplete_sym;
 jl_sym_t *goto_sym;    jl_sym_t *goto_ifnot_sym;
 jl_sym_t *label_sym;   jl_sym_t *return_sym;
-jl_sym_t *unreachable_sym;
+jl_sym_t *unreachable_sym; jl_sym_t *tuple_sym;
 jl_sym_t *lambda_sym;  jl_sym_t *assign_sym;
 jl_sym_t *body_sym;    jl_sym_t *globalref_sym;
 jl_sym_t *method_sym;  jl_sym_t *core_sym;
@@ -338,6 +338,7 @@ void jl_init_frontend(void)
     label_sym = jl_symbol("label");
     return_sym = jl_symbol("return");
     unreachable_sym = jl_symbol("unreachable");
+    tuple_sym = jl_symbol("tuple");
     lambda_sym = jl_symbol("lambda");
     module_sym = jl_symbol("module");
     export_sym = jl_symbol("export");

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -945,7 +945,7 @@ extern jl_sym_t *export_sym;  extern jl_sym_t *import_sym;
 extern jl_sym_t *importall_sym; extern jl_sym_t *using_sym;
 extern jl_sym_t *goto_sym;    extern jl_sym_t *goto_ifnot_sym;
 extern jl_sym_t *label_sym;   extern jl_sym_t *return_sym;
-extern jl_sym_t *unreachable_sym;
+extern jl_sym_t *unreachable_sym; extern jl_sym_t *tuple_sym;
 extern jl_sym_t *lambda_sym;  extern jl_sym_t *assign_sym;
 extern jl_sym_t *method_sym;  extern jl_sym_t *slot_sym;
 extern jl_sym_t *enter_sym;   extern jl_sym_t *leave_sym;

--- a/test/core.jl
+++ b/test/core.jl
@@ -6037,3 +6037,8 @@ g1_23206(::Tuple{Type{Int}, T}) where T = 0
 g2_23206(::Tuple{Type{Int}}) = 1
 @test_throws MethodError g1_23206(tuple(Int, 2))
 @test_throws MethodError g2_23206(tuple(Int, 2))
+
+# issue #26739
+let x26739 = Int[1]
+    @test eval(:(identity.($x26739))) == x26739
+end


### PR DESCRIPTION
Broadcast calls like `sin.(x)` are parsed to

    Expr(:(.), :sin, Expr(:tuple, :x))

before lowering. As a result, they got caught in the
top-level interpreters fast path for lowering calls
like that to getfield/getproperty, causing #26739.

Fixes #26739