### PR TITLE
add StringIndexError documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -230,7 +230,7 @@ This section lists changes that do not have deprecation warnings.
   * `countlines` now always counts the last non-empty line even if it does not
     end with EOL, matching the behavior of `eachline` and `readlines` ([#25845]).
 
-  * `getindex(s::String, r::UnitRange{Int})` now throws `UnicodeError` if `last(r)`
+  * `getindex(s::String, r::UnitRange{Int})` now throws `StringIndexError` if `last(r)`
     is not a valid index into `s` ([#22572]).
 
   * `ntuple(f, n::Integer)` throws `ArgumentError` if `n` is negative.

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -1,5 +1,10 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    StringIndexError(str, i)
+
+An error occurred when trying to access `str` at index `i` that is not valid.
+"""
 struct StringIndexError <: Exception
     string::AbstractString
     index::Integer

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -295,6 +295,7 @@ Core.TypeError
 Core.UndefKeywordError
 Core.UndefRefError
 Core.UndefVarError
+Base.StringIndexError
 Base.InitError
 Base.retry
 Base.ExponentialBackOff

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -584,7 +584,7 @@ below all interrupt the normal flow of control.
 | [`TypeError`](@ref)           |
 | [`UndefRefError`](@ref)       |
 | [`UndefVarError`](@ref)       |
-| `UnicodeError`                |
+| [`StringIndexError`](@ref)    |
 
 For example, the [`sqrt`](@ref) function throws a [`DomainError`](@ref) if applied to a negative
 real value:


### PR DESCRIPTION
`StringIndexError` replaced `UnicodeError` in strings. This PR updates documentation to reflect this change.