### PR TITLE
Fix specialized select_value codegen

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -813,6 +813,15 @@ static jl_cgval_t emit_select_value(jl_codectx_t &ctx, jl_value_t **args, size_t
                 emit_unbox(ctx, llt1, x, t1));
     }
     else {
+        // type inference may know something we don't, in which case it may
+        // be illegal for us to convert to rt_hint. Check first if either
+        // of the types have empty intersection with the result type,
+        // in which case, we may use the other one.
+        if (jl_type_intersection(t1, rt_hint) == jl_bottom_type) {
+            return y;
+        } else if (jl_type_intersection(t2, rt_hint) == jl_bottom_type) {
+            return x;
+        }
         // if they aren't the same type, consider using the expr type
         // to instantiate a union-split optimization
         x = convert_julia_type(ctx, x, rt_hint);


### PR DESCRIPTION
When inference sees something like:

```
select_value(true, 1::Int, 1.0::Float64)
```

it knows that the condition is constant and can thus
conclude that the result is of `Int` type. Generally,
we would fold this away in inlining. However, if
inlining is disabled for whatever reason. We can end up with

```
select_value(true, 1::Int, 1.0::Float64)::Int
```

in codegen. After the recent enhancements to select_value and
without this patch, this would cause an unconditional trap
to be generated as it tried to convert 1.0 to `Int`. This patch
instead makes sure that the branches of the select have non-empty
intersection with the annotated result type before attempting the
conversion, thus preventing this case from crashing.