### PR TITLE
ensure more iterators stay type-stable

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -672,11 +672,11 @@ _oidd_nextind(a, i) = reinterpret(Int, ccall(:jl_eqtable_nextind, Csize_t, (Any,
 
 start(d::IdDict) = _oidd_nextind(d.ht, 0)
 done(d::IdDict, i) = (i == -1)
-next(d::IdDict{K,V}, i) where {K, V} = (Pair{K,V}(d.ht[i+1], d.ht[i+2]), _oidd_nextind(d.ht, i+2))
+next(d::IdDict{K, V}, i) where {K, V} = (Pair{K, V}(d.ht[i + 1]::K, d.ht[i + 2]::V), _oidd_nextind(d.ht, i + 2))
 
 length(d::IdDict) = d.count
 
-copy(d::IdDict) = IdDict(d)
+copy(d::IdDict) = typeof(d)(d)
 
 get!(d::IdDict{K,V}, @nospecialize(key), @nospecialize(default)) where {K, V} = (d[key] = get(d, key, default))::V
 
@@ -689,14 +689,14 @@ mutable struct IdSet{T} <: AbstractSet{T}
     dict::IdDict{T,Nothing}
 
     IdSet{T}() where {T} = new(IdDict{T,Nothing}())
-    IdSet{T}(s::IdSet{T}) where {T} = new(IdDict{T,Nothing}(s.dict))
+    IdSet{T}(s::IdSet{T}) where {T} = new(copy(s.dict))
 end
 
 IdSet{T}(itr) where {T} = union!(IdSet{T}(), itr)
 IdSet() = IdSet{Any}()
 
-copy(s::IdSet{T}) where {T} = IdSet{T}(s)
-copymutable(s::IdSet{T}) where {T} = IdSet{T}(s)
+copymutable(s::IdSet) = typeof(s)(s)
+copy(s::IdSet) = typeof(s)(s)
 
 isempty(s::IdSet) = isempty(s.dict)
 length(s::IdSet)  = length(s.dict)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -319,11 +319,14 @@ function typeinf_work(frame::InferenceState)
                     else
                         # general case
                         frame.handler_at[l] = frame.cur_hand
+                        changes_else = changes
                         if isa(condt, Conditional)
-                            changes_else = StateUpdate(condt.var, VarState(condt.elsetype, false), changes)
-                            changes = StateUpdate(condt.var, VarState(condt.vtype, false), changes)
-                        else
-                            changes_else = changes
+                            if condt.elsetype !== Any && condt.elsetype !== changes[slot_id(condt.var)]
+                                changes_else = StateUpdate(condt.var, VarState(condt.elsetype, false), changes_else)
+                            end
+                            if condt.vtype !== Any && condt.vtype !== changes[slot_id(condt.var)]
+                                changes = StateUpdate(condt.var, VarState(condt.vtype, false), changes)
+                            end
                         end
                         newstate_else = stupdate!(s[l], changes_else)
                         if newstate_else !== false

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -226,10 +226,10 @@ length(v::Pairs)  = length(v.itr)
 axes(v::Pairs) = axes(v.itr)
 size(v::Pairs)    = size(v.itr)
 @inline start(v::Pairs) = start(v.itr)
-@propagate_inbounds function next(v::Pairs, state)
+@propagate_inbounds function next(v::Pairs{K, V}, state) where {K, V}
     indx, n = next(v.itr, state)
     item = v.data[indx]
-    return (Pair(indx, item), n)
+    return (Pair{K, V}(indx, item), n)
 end
 @inline done(v::Pairs, state) = done(v.itr, state)
 

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -28,18 +28,27 @@ foo
 7
 ```
 """
-struct Pair{A,B}
+struct Pair{A, B}
     first::A
     second::B
+    function Pair{A, B}(@nospecialize(a), @nospecialize(b)) where {A, B}
+        @_inline_meta
+        # if we didn't inline this, it's probably because the callsite was actually dynamic
+        # to avoid potentially compiling many copies of this, we mark the arguments with `@nospecialize`
+        # but also mark the whole function with `@inline` to ensure we will inline it whenever possible
+        # (even if `convert(::Type{A}, a::A)` for some reason was expensive)
+        return new(a, b)
+    end
 end
+Pair(a::A, b::B) where {A, B} = Pair{A, B}(a, b)
 const => = Pair
 
 start(p::Pair) = 1
 done(p::Pair, i) = i>2
-next(p::Pair, i) = (getfield(p,i), i+1)
-eltype(p::Type{Pair{A,B}}) where {A,B} = Union{A,B}
+next(p::Pair, i) = (getfield(p, i), i+1)
+eltype(p::Type{Pair{A, B}}) where {A, B} = Union{A, B}
 
-indexed_next(p::Pair, i::Int, state) = (getfield(p,i), i+1)
+indexed_next(p::Pair, i::Int, state) = (getfield(p, i), i+1)
 
 hash(p::Pair, h::UInt) = hash(p.second, hash(p.first, h))
 


### PR DESCRIPTION
This is a frequent performance trap. Perhaps because Tuple/NamedTuple/Pair/default-constructor usage is so much easier than `@nospecialize`. Dunno what else to do but fix them manually.