### PR TITLE
RFC: remove rule requiring Number types to implement specific promotions

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -745,6 +745,8 @@ end
 for op in (:+, :-, :*, :&, :|, :xor)
     @eval function $op(a::Integer, b::Integer)
         T = promote_typeof(a, b)
-        return $op(a % T, b % T)
+        aT, bT = a % T, b % T
+        not_sametype((a, b), (aT, bT))
+        return $op(aT, bT)
     end
 end

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -275,25 +275,6 @@ end
 
 ## promotions in arithmetic, etc. ##
 
-# Because of the promoting fallback definitions for Number, we need
-# a special case for undefined promote_rule on numeric types.
-# Otherwise, typejoin(T,S) is called (returning Number) so no conversion
-# happens, and +(promote(x,y)...) is called again, causing a stack
-# overflow.
-function promote_result(::Type{T},::Type{S},::Type{Bottom},::Type{Bottom}) where {T<:Number,S<:Number}
-    @_inline_meta
-    promote_to_supertype(T, S, typejoin(T,S))
-end
-
-# promote numeric types T and S to typejoin(T,S) if T<:S or S<:T
-# for example this makes promote_type(Integer,Real) == Real without
-# promoting arbitrary pairs of numeric types to Number.
-promote_to_supertype(::Type{T}, ::Type{T}, ::Type{T}) where {T<:Number}           = T
-promote_to_supertype(::Type{T}, ::Type{S}, ::Type{T}) where {T<:Number,S<:Number} = T
-promote_to_supertype(::Type{T}, ::Type{S}, ::Type{S}) where {T<:Number,S<:Number} = S
-promote_to_supertype(::Type{T}, ::Type{S}, ::Type) where {T<:Number,S<:Number} =
-    error("no promotion exists for ", T, " and ", S)
-
 promote() = ()
 promote(x) = (x,)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -1720,7 +1720,7 @@ mutable struct SIQ{A,B} <: Number
 end
 import Base: promote_rule
 promote_rule(A::Type{SIQ{T,T2}},B::Type{SIQ{S,S2}}) where {T,T2,S,S2} = SIQ{promote_type(T,S)}
-@test_throws ErrorException promote_type(SIQ{Int},SIQ{Float64})
+@test promote_type(SIQ{Int},SIQ{Float64}) == SIQ
 f4731(x::T...) where {T} = ""
 f4731(x...) = 0
 g4731() = f4731()

--- a/test/int.jl
+++ b/test/int.jl
@@ -280,3 +280,10 @@ end
     @test_throws ArgumentError big"1_0_0_0_"
     @test_throws ArgumentError big"_1_0_0_0"
 end
+
+# issue #26779
+struct MyInt26779 <: Integer
+    x::Int
+end
+@test promote_type(MyInt26779, Int) == Integer
+@test_throws ErrorException MyInt26779(1) + 1


### PR DESCRIPTION
We used this to prevent stack overflows from `+(x::Number, y::Number) = +(promote(x,y)...)`, but now `promote` itself checks that types changed, which is sufficient to avoid the problem.

fixes #26779 