### PR TITLE
Deprecate using && and || within at-dot expressions

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -853,7 +853,7 @@ function __dot__(x::Expr)
         if x.head == :&& || x.head == :||
             Base.depwarn("""
                 using $(x.head) expressions in @. is deprecated; in the future it will
-                become elementwise. Break the expression into smaller parts instead.""", ())
+                become elementwise. Break the expression into smaller parts instead.""", nothing)
         end
         head = string(x.head)
         if last(head) == '=' && first(head) != '.'

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -850,6 +850,11 @@ function __dot__(x::Expr)
            Meta.isexpr(x.args[1], :call) # function or macro definition
         Expr(x.head, x.args[1], dotargs[2])
     else
+        if x.head == :&& || x.head == :||
+            Base.depwarn("""
+                using $(x.head) expressions in @. is deprecated; in the future it will
+                become elementwise. Break the expression into smaller parts instead.""", ())
+        end
         head = string(x.head)
         if last(head) == '=' && first(head) != '.'
             Expr(Symbol('.',head), dotargs...)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -82,11 +82,12 @@ function depwarn(msg, funcsym)
         _id=(frame,funcsym),
         _group=:depwarn,
         caller=caller,
-        maxlog=funcsym === () ? nothing : 1
+        maxlog=funcsym === nothing ? nothing : 1
     )
     nothing
 end
 
+firstcaller(bt::Vector, ::Nothing) = Ptr{Cvoid}(0), StackTraces.UNKNOWN
 firstcaller(bt::Vector, funcsym::Symbol) = firstcaller(bt, (funcsym,))
 function firstcaller(bt::Vector, funcsyms)
     # Identify the calling line

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -82,7 +82,7 @@ function depwarn(msg, funcsym)
         _id=(frame,funcsym),
         _group=:depwarn,
         caller=caller,
-        maxlog=1
+        maxlog=funcsym === () ? nothing : 1
     )
     nothing
 end


### PR DESCRIPTION
Giving us space to allow lowering this to `.&&` and `.||` in the future. Ref #5187.