### PR TITLE
[Distributed] don't sidestep require logic

### DIFF
--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -74,7 +74,7 @@ function _require_callback(mod::Base.PkgId)
         @sync for p in procs()
             p == 1 && continue
             @async remotecall_wait(p) do
-                Base._require(mod)
+                Base.require(mod)
                 nothing
             end
         end

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -18,6 +18,23 @@ include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 addprocs_with_testenv(4)
 @test nprocs() == 5
 
+# distributed loading of packages
+
+# setup
+@everywhere begin
+    old_act_proj = Base.ACTIVE_PROJECT[]
+    pushfirst!(Base.LOAD_PATH, "@")
+    Base.ACTIVE_PROJECT[] = joinpath(Sys.BINDIR, "..", "share", "julia", "test", "TestPkg")
+end
+
+@everywhere using TestPkg
+@everywhere using TestPkg
+
+@everywhere begin
+    Base.ACTIVE_PROJECT[] = old_act_proj
+    popfirst!(Base.LOAD_PATH)
+end
+
 @everywhere using Test, Random, LinearAlgebra
 
 id_me = myid()


### PR DESCRIPTION
We were trying to be clever, but there is logic in `require` that we shouldn't sidestep.

fixes: #26805