### PR TITLE
reserve syntax that could be used for computed field types

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -862,6 +862,16 @@
                  (if (not (symbol? v))
                      (error (string "field name \"" (deparse v) "\" is not a symbol"))))
                field-names)
+     (for-each (lambda (t)
+                 (if (expr-contains-p (lambda (e)
+                                        (and (pair? e) (eq? (car e) 'call)
+                                             (expr-contains-p (lambda (a) (memq a params))
+                                                              e)))
+                                      t)
+                     (error (string "unsupported field type expression \""
+                                    (deparse t)
+                                    "\""))))
+               field-types)
      `(block
        (scope-block
         (block


### PR DESCRIPTION
This will allows us to implement #18466 in a non-breaking way. Example:

```
julia> struct Foo{T}
           x::T
           y::eltype(T)
       end
ERROR: syntax: unsupported field type expression "eltype(T)"
```

Specifically, this disallows call expressions containing type parameters.