### PR TITLE
Remove argument restriction on dims2string and inds2string (#26799)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1836,8 +1836,8 @@ end
 ## `summary` for AbstractArrays
 # sizes such as 0-dimensional, 4-dimensional, 2x3
 dims2string(d) = isempty(d) ? "0-dimensional" :
-                       length(d) == 1 ? "$(d[1])-element" :
-                       join(map(string,d), '×')
+                 length(d) == 1 ? "$(d[1])-element" :
+                 join(map(string,d), '×')
 
 inds2string(inds) = join(map(string,inds), '×')
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1835,11 +1835,11 @@ end
 
 ## `summary` for AbstractArrays
 # sizes such as 0-dimensional, 4-dimensional, 2x3
-dims2string(d::Dims) = isempty(d) ? "0-dimensional" :
+dims2string(d) = isempty(d) ? "0-dimensional" :
                        length(d) == 1 ? "$(d[1])-element" :
                        join(map(string,d), '×')
 
-inds2string(inds::Indices) = join(map(string,inds), '×')
+inds2string(inds) = join(map(string,inds), '×')
 
 # anything array-like gets summarized e.g. 10-element Array{Int64,1}
 summary(io::IO, a::AbstractArray) = summary(io, a, axes(a))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1189,3 +1189,10 @@ end
     @test repr("text/plain", context=:compact=>true) == "\"text/plain\""
     @test repr(MIME("text/plain"), context=:compact=>true) == "MIME type text/plain"
 end
+
+@testset "BigInt summary #26799" begin
+    @test Base.dims2string(tuple(BigInt(10))) == "10-element"
+    @test Base.inds2string(tuple(BigInt(10))) == "10"
+    @test summary(BigInt(1):BigInt(10)) == "10-element UnitRange{BigInt}"
+    @test summary(Base.OneTo(BigInt(10))) == "10-element Base.OneTo{BigInt}"
+end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1190,7 +1190,7 @@ end
     @test repr(MIME("text/plain"), context=:compact=>true) == "MIME type text/plain"
 end
 
-@testset "BigInt summary #26799" begin
+@testset "#26799 BigInt summary" begin
     @test Base.dims2string(tuple(BigInt(10))) == "10-element"
     @test Base.inds2string(tuple(BigInt(10))) == "10"
     @test summary(BigInt(1):BigInt(10)) == "10-element UnitRange{BigInt}"


### PR DESCRIPTION
This removes the restriction on argument type to `dims2string` and `inds2string`, resolving issue #26799 to fix `summary(::UnitRange{BigInt})`.