### PR TITLE
bugfix for regex matches ending with non-ASCII

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -334,7 +334,7 @@ function next(itr::RegexMatchIterator, prev_match)
             offset = prev_match.offset
         end
     else
-        offset = prev_match.offset + lastindex(prev_match.match)
+        offset = prev_match.offset + ncodeunits(prev_match.match)
     end
 
     opts_nonempty = UInt32(PCRE.ANCHORED | PCRE.NOTEMPTY_ATSTART)

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -25,6 +25,14 @@ target = """71.163.72.113 - - [30/Jul/2014:16:40:55 -0700] "GET emptymind.org/th
 pat = r"""([\d\.]+) ([\w.-]+) ([\w.-]+) (\[.+\]) "([^"\r\n]*|[^"\r\n\[]*\[.+\][^"]+|[^"\r\n]+.[^"]+)" (\d{3}) (\d+|-) ("(?:[^"]|\")+)"? ("(?:[^"]|\")+)"?"""
 match(pat, target)
 
+# issue #26829
+@test map(m -> m.match, eachmatch(r"^$|\S", "ö")) == ["ö"]
+
+# issue #26199
+@test map(m -> m.match, eachmatch(r"(\p{L}+)", "Tú")) == ["Tú"]
+@test map(m -> m.match, eachmatch(r"(\p{L}+)", "Tú lees.")) == ["Tú", "lees"]
+@test map(m -> m.match, eachmatch(r"(\p{L}+)", "¿Cuál es tu pregunta?")) == ["Cuál", "es", "tu", "pregunta"]
+
 # Issue 9545 (32 bit)
 buf = PipeBuffer()
 show(buf, r"")


### PR DESCRIPTION
Fixes #26829, fixes #26199.

To backport to 0.6 (or earlier versions … this bug has been around for a while), replace `endof` with `sizeof` in the [corresponding line of `regex.jl`](https://github.com/JuliaLang/julia/blob/93168a68268a2023c0da5f14e75ccb807cc4fc35/base/regex.jl#L338).