### PR TITLE
Change url scheme to https

### DIFF
--- a/deps/patchelf.mk
+++ b/deps/patchelf.mk
@@ -1,7 +1,7 @@
 ## patchelf ##
 
 $(SRCCACHE)/patchelf-$(PATCHELF_VER).tar.gz: | $(SRCCACHE)
-	$(JLDOWNLOAD) $@ http://nixos.org/releases/patchelf/patchelf-$(PATCHELF_VER)/patchelf-$(PATCHELF_VER).tar.gz
+	$(JLDOWNLOAD) $@ https://nixos.org/releases/patchelf/patchelf-$(PATCHELF_VER)/patchelf-$(PATCHELF_VER).tar.gz
 
 $(SRCCACHE)/patchelf-$(PATCHELF_VER)/source-extracted: $(SRCCACHE)/patchelf-$(PATCHELF_VER).tar.gz
 	$(JLCHECKSUM) $<


### PR DESCRIPTION
Similarly to #26757, update the url scheme for this download to use https instead of http (which has started to 301 redirect)