### PR TITLE
Indirect checking for return_type through an extra function

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -704,7 +704,7 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
             return ret
         end
         return Any
-    elseif f === return_type
+    elseif is_return_type(f)
         rt_rt = return_type_tfunc(argtypes, vtypes, sv)
         if rt_rt !== NOT_FOUND
             return rt_rt
@@ -755,7 +755,7 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
     t = pure_eval_call(f, argtypes, atype, sv)
     t !== false && return t
 
-    if istopfunction(f, :typejoin) || f === return_type
+    if istopfunction(f, :typejoin) || is_return_type(f)
         return Type # don't try to infer these function edges directly -- it won't actually come up with anything useful
     end
 

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -32,6 +32,7 @@ include("options.jl")
 
 # core operations & types
 function return_type end # promotion.jl expects this to exist
+is_return_type(@Core.nospecialize(f)) = f === return_type
 include("promotion.jl")
 include("tuple.jl")
 include("pair.jl")

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -847,7 +847,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
         sv.params.inlining || continue
 
         # Special case inliners for regular functions
-        if late_inline_special_case!(ir, idx, stmt, atypes, f, ft) || f === return_type
+        if late_inline_special_case!(ir, idx, stmt, atypes, f, ft) || is_return_type(f)
             continue
         end
 
@@ -1061,7 +1061,7 @@ function late_inline_special_case!(ir::IRCode, idx::Int, stmt::Expr, atypes::Vec
         subtype_call = Expr(:call, GlobalRef(Core, :(<:)), stmt.args[3], stmt.args[2])
         ir[SSAValue(idx)] = subtype_call
         return true
-    elseif f === return_type
+    elseif is_return_type(f)
         if isconstType(typ)
             ir[SSAValue(idx)] = quoted(typ.parameters[1])
             return true

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -20,7 +20,7 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, spvals::S
         if head === :call
             f = argextype(ea[1], src, spvals)
             f = isa(f, Const) ? f.val : isType(f) ? f.parameters[1] : return false
-            f === return_type && return true
+            is_return_type(f) && return true
             contains_is(_PURE_BUILTINS, f) && return true
             contains_is(_PURE_OR_ERROR_BUILTINS, f) || return false
             rt === Bottom && return false


### PR DESCRIPTION
Compiler.return_type is a bit of an odd beast because we basically treat
it like a built-in, but it's defined in the compiler. When working on
inference, it can be useful to load a second copy of inference with
the new changes (e.g. to test changes before the changes are capable
of running correctly on all input). This works quite well, but was
causing problems with return type, because Base's notion of
return_type and the second inference copy's notion of return_type
were different. This patch adds a simple `is_return_type(f)` predicate
that we can overload in our second inference copy in order to make it
recognize both `Core.Compiler.return_type` and `return_type` (from
the second copy's perspective as the return_type builtin).

@jrevels this fixes that weird non-inference of matvec we saw yesterday