### PR TITLE
Preserve CallInst metadata in LateLowerGCFrame pass.

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1749,7 +1749,14 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                                    old_attrs.getFnAttributes());
                 NewCall->setAttributes(attr);
 #endif
-                NewCall->setDebugLoc(CI->getDebugLoc());
+#if JL_LLVM_VERSION >= 40000
+                NewCall->copyMetadata(CI);
+#else
+                SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
+                CI->getAllMetadata(MDs);
+                for (auto MD : MDs)
+                    NewCall->setMetadata(MD.first, MD.second);
+#endif
                 CI->replaceAllUsesWith(NewCall);
                 UpdatePtrNumbering(CI, NewCall, S);
             } else if (CI->getNumArgOperands() == CI->getNumOperands()) {
@@ -1759,6 +1766,14 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
             } else {
                 CallInst *NewCall = CallInst::Create(CI, None, CI);
                 NewCall->takeName(CI);
+#if JL_LLVM_VERSION >= 40000
+                NewCall->copyMetadata(CI);
+#else
+                SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
+                CI->getAllMetadata(MDs);
+                for (auto MD : MDs)
+                    NewCall->setMetadata(MD.first, MD.second);
+#endif
                 CI->replaceAllUsesWith(NewCall);
                 UpdatePtrNumbering(CI, NewCall, S);
             }


### PR DESCRIPTION
I was experimenting with `!range` metadata on NVPTX intrinsics, and noticed it got dropped after our GC frame lowering pass (the same happens with other metadata).