### PR TITLE
Remove dead RPATH cleanup branch from Makefile

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -210,7 +210,6 @@ build_private_libdir := $(build_libdir)/julia
 # Calculate relative paths to libdir, private_libdir, datarootdir, and sysconfdir
 build_libdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(build_bindir) $(build_libdir))
 libdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(libdir))
-build_private_libdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(build_bindir) $(build_private_libdir))
 private_libdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(private_libdir))
 datarootdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(datarootdir))
 docdir_rel := $(shell $(JULIAHOME)/contrib/relative_path.sh $(bindir) $(docdir))

--- a/Makefile
+++ b/Makefile
@@ -349,24 +349,6 @@ endif
 	mkdir -p $(DESTDIR)$(datarootdir)/appdata/
 	$(INSTALL_F) $(JULIAHOME)/contrib/julia.appdata.xml $(DESTDIR)$(datarootdir)/appdata/
 
-	# Update RPATH entries and JL_SYSTEM_IMAGE_PATH if $(private_libdir_rel) != $(build_private_libdir_rel)
-ifneq ($(private_libdir_rel),$(build_private_libdir_rel))
-ifeq ($(OS), Darwin)
-	for julia in $(DESTDIR)$(bindir)/julia* ; do \
-		install_name_tool -rpath @executable_path/$(build_private_libdir_rel) @executable_path/$(private_libdir_rel) $$julia; \
-		install_name_tool -add_rpath @executable_path/$(build_libdir_rel) @executable_path/$(libdir_rel) $$julia; \
-	done
-else ifneq (,$(findstring $(OS),Linux FreeBSD))
-	for julia in $(DESTDIR)$(bindir)/julia* ; do \
-		patchelf --set-rpath '$$ORIGIN/$(private_libdir_rel):$$ORIGIN/$(libdir_rel)' $$julia; \
-	done
-endif
-
-	# Overwrite JL_SYSTEM_IMAGE_PATH in julia library
-	$(call stringreplace,$(DESTDIR)$(libdir)/libjulia.$(SHLIB_EXT),sys.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys.$(SHLIB_EXT))
-	$(call stringreplace,$(DESTDIR)$(libdir)/libjulia-debug.$(SHLIB_EXT),sys-debug.$(SHLIB_EXT)$$,$(private_libdir_rel)/sys-debug.$(SHLIB_EXT))
-endif
-
 	mkdir -p $(DESTDIR)$(sysconfdir)
 	cp -R $(build_sysconfdir)/julia $(DESTDIR)$(sysconfdir)/
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -106,8 +106,8 @@ DEBUGFLAGS += $(FLAGS)
 SHIPFLAGS += $(FLAGS)
 
 # if not absolute, then relative to the directory of the julia executable
-SHIPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys.$(SHLIB_EXT)\""
-DEBUGFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(build_private_libdir_rel)/sys-debug.$(SHLIB_EXT)\""
+SHIPFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(private_libdir_rel)/sys.$(SHLIB_EXT)\""
+DEBUGFLAGS += "-DJL_SYSTEM_IMAGE_PATH=\"$(private_libdir_rel)/sys-debug.$(SHLIB_EXT)\""
 
 FLISP_EXECUTABLE_debug := $(BUILDDIR)/flisp/flisp-debug
 FLISP_EXECUTABLE_release := $(BUILDDIR)/flisp/flisp


### PR DESCRIPTION
While looking into https://github.com/JuliaLang/julia/issues/26830, I realized that `private_libdir_rel` and `build_private_libdir_rel` cannot be different. They'll both be either `../lib/julia` or `../lib/$(MULTIARCH)/julia` so the branch below is dead. It is also unnecessary to have both so I've deleted one of the variables from `Make.inc`.

cc: @nalimilan @staticfloat 