### PR TITLE
separate `isbitstype(::Type)` from `isbits`

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -75,7 +75,7 @@ macro enum(T, syms...)
     if isa(T, Expr) && T.head == :(::) && length(T.args) == 2 && isa(T.args[1], Symbol)
         typename = T.args[1]
         basetype = eval(__module__, T.args[2])
-        if !isa(basetype, DataType) || !(basetype <: Integer) || !isbits(basetype)
+        if !isa(basetype, DataType) || !(basetype <: Integer) || !isbitstype(basetype)
             throw(ArgumentError("invalid base type for Enum $typename, $T=::$basetype; base type must be an integer primitive type"))
         end
     elseif !isa(T, Symbol)

--- a/base/arraymath.jl
+++ b/base/arraymath.jl
@@ -94,7 +94,7 @@ function reverse(A::Array{T}; dims::Integer) where T
             end
         end
     else
-        if isbits(T) && M>200
+        if isbitstype(T) && M>200
             for i = 1:sd
                 ri = sd+1-i
                 for j=0:stride:(N-stride)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -396,7 +396,7 @@ function optimize(me::InferenceState)
         me.src.inlineable = false
     elseif !me.src.inlineable && isa(def, Method)
         bonus = 0
-        if me.bestguess ⊑ Tuple && !isbits(widenconst(me.bestguess))
+        if me.bestguess ⊑ Tuple && !isbitstype(widenconst(me.bestguess))
             bonus = me.params.inline_tupleret_bonus
         end
         me.src.inlineable = isinlineable(def, me.src, me.mod, me.params, bonus)
@@ -706,7 +706,7 @@ end
 # since codegen optimizations of functions like `is` will depend on knowing it
 function widen_slot_type(@nospecialize(ty), untypedload::Bool)
     if isa(ty, DataType)
-        if untypedload || isbits(ty) || isdefined(ty, :instance)
+        if untypedload || isbitstype(ty) || isdefined(ty, :instance)
             return ty
         end
     elseif isa(ty, Union)
@@ -1154,6 +1154,7 @@ function inlineable(@nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector
                 f === Core.sizeof || f === isdefined ||
                 istopfunction(topmod, f, :typejoin) ||
                 istopfunction(topmod, f, :isbits) ||
+                istopfunction(topmod, f, :isbitstype) ||
                 istopfunction(topmod, f, :promote_type) ||
                 (f === Core.kwfunc && length(argexprs) == 2) ||
                 (is_inlineable_constant(val) &&
@@ -3093,7 +3094,7 @@ function structinfo_new(ctx::AllocOptContext, ex::Expr, vt::DataType)
             si.defs[i] = ex.args[i + 1]
         else
             ft = fieldtype(vt, i)
-            if isbits(ft)
+            if isbitstype(ft)
                 ex = Expr(:new, ft)
                 ex.typ = ft
                 si.defs[i] = ex
@@ -3630,7 +3631,7 @@ function split_struct_alloc_single!(ctx::AllocOptContext, info, key, nf, has_pre
         if !@isdefined(fld_name)
             fld_name = :struct_field
         end
-        need_preserved_root = has_preserve && !isbits(field_typ)
+        need_preserved_root = has_preserve && !isbitstype(field_typ)
         local var_slot
         if !has_def
             # If there's no direct use of the field

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -636,6 +636,7 @@ function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(f
                 f === Core.sizeof || f === isdefined ||
                 istopfunction(topmod, f, :typejoin) ||
                 istopfunction(topmod, f, :isbits) ||
+                istopfunction(topmod, f, :isbitstype) ||
                 istopfunction(topmod, f, :promote_type) ||
                 (f === Core.kwfunc && length(atypes) == 2) ||
                 (is_inlineable_constant(val) &&

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -189,7 +189,7 @@ is_tuple_call(ir, def) = isa(def, Expr) && is_known_call(def, tuple, ir, ir.mod)
 
 function process_immutable_preserve(new_preserves::Vector{Any}, compact::IncrementalCompact, def::Expr)
     for arg in (isexpr(def, :new) ? def.args : def.args[2:end])
-        if !isbits(compact_exprtype(compact, arg))
+        if !isbitstype(compact_exprtype(compact, arg))
             push!(new_preserves, arg)
         end
     end
@@ -373,7 +373,7 @@ function getfield_elim_pass!(ir::IRCode, domtree::DomTree)
                 for stmt in du.uses
                     ir[SSAValue(stmt)] = compute_value_for_use(ir, domtree, allblocks, du, phinodes, fidx, stmt)
                 end
-                if !isbits(fieldtype(typ, fidx))
+                if !isbitstype(fieldtype(typ, fidx))
                     for (use, list) in preserve_uses
                         push!(list, compute_value_for_use(ir, domtree, allblocks, du, phinodes, fidx, use))
                     end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -261,7 +261,7 @@ function isdefined_tfunc(args...)
                 end
             elseif idx <= 0 || (!isvatuple(a1) && idx > fieldcount(a1))
                 return Const(false)
-            elseif !isvatuple(a1) && isbits(fieldtype(a1, idx))
+            elseif !isvatuple(a1) && isbitstype(fieldtype(a1, idx))
                 return Const(true)
             elseif isa(arg1, Const) && isimmutable((arg1::Const).val)
                 return Const(isdefined((arg1::Const).val, idx))

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -73,7 +73,7 @@ function is_derived_type(@nospecialize(t), @nospecialize(c), mindepth::Int)
         for p in cP
             is_derived_type(t, p, mindepth) && return true
         end
-        if isconcretetype(c) && isbits(c)
+        if isconcretetype(c) && isbitstype(c)
             # see if it was extracted from a fieldtype
             # however, only look through types that can be inlined
             # to ensure monotonicity of derivation

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -53,11 +53,11 @@ end
 function valid_tparam(@nospecialize(x))
     if isa(x, Tuple)
         for t in x
-            isa(t, Symbol) || isbits(typeof(t)) || return false
+            isa(t, Symbol) || isbitstype(typeof(t)) || return false
         end
         return true
     end
-    return isa(x, Symbol) || isbits(typeof(x))
+    return isa(x, Symbol) || isbitstype(typeof(x))
 end
 
 has_free_typevars(@nospecialize(t)) = ccall(:jl_has_free_typevars, Cint, (Any,), t) != 0

--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -54,7 +54,7 @@ end
 function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
     T = typeof(x)::DataType
     nf = nfields(x)
-    (isbits(T) || nf == 0) && return x
+    (isbitstype(T) || nf == 0) && return x
     if haskey(stackdict, x)
         return stackdict[x]
     end
@@ -79,7 +79,7 @@ function deepcopy_internal(x::Array, stackdict::IdDict)
 end
 
 function _deepcopy_array_t(@nospecialize(x), T, stackdict::IdDict)
-    if isbits(T)
+    if isbitstype(T)
         return (stackdict[x]=copy(x))
     end
     dest = similar(x)
@@ -87,7 +87,7 @@ function _deepcopy_array_t(@nospecialize(x), T, stackdict::IdDict)
     for i = 1:(length(x)::Int)
         if ccall(:jl_array_isassigned, Cint, (Any, Csize_t), x, i-1) != 0
             xi = ccall(:jl_arrayref, Any, (Any, Csize_t), x, i-1)
-            if !isbits(typeof(xi))
+            if !isbitstype(typeof(xi))
                 xi = deepcopy_internal(xi, stackdict)
             end
             ccall(:jl_arrayset, Cvoid, (Any, Any, Csize_t), dest, xi, i-1)
@@ -101,7 +101,7 @@ function deepcopy_internal(x::Union{Dict,IdDict}, stackdict::IdDict)
         return stackdict[x]::typeof(x)
     end
 
-    if isbits(eltype(x))
+    if isbitstype(eltype(x))
         return (stackdict[x] = copy(x))
     end
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1609,6 +1609,9 @@ end
 # To remove this deprecation, remove the `keep` argument from the function signatures as well as
 # the internal logic that deals with the renaming. These live in base/strings/util.jl.
 
+# when this is removed, `isbitstype(typeof(x))` can be replaced with `isbits(x)`
+@deprecate isbits(@nospecialize(t::Type)) isbitstype(t)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -731,6 +731,7 @@ export
     fieldcount,
     # propertynames,
     isabstracttype,
+    isbitstype,
     isprimitivetype,
     isstructtype,
     isconcretetype,

--- a/base/io.jl
+++ b/base/io.jl
@@ -518,7 +518,7 @@ write(s::IO, x::Bool) = write(s, UInt8(x))
 write(to::IO, p::Ptr) = write(to, convert(UInt, p))
 
 function write(s::IO, A::AbstractArray)
-    if !isbits(eltype(A))
+    if !isbitstype(eltype(A))
         depwarn("Calling `write` on non-isbits arrays is deprecated. Use a loop or `serialize` instead.", :write)
     end
     nb = 0
@@ -529,7 +529,7 @@ function write(s::IO, A::AbstractArray)
 end
 
 function write(s::IO, a::Array)
-    if isbits(eltype(a))
+    if isbitstype(eltype(a))
         return GC.@preserve a unsafe_write(s, pointer(a), sizeof(a))
     else
         depwarn("Calling `write` on non-isbits arrays is deprecated. Use a loop or `serialize` instead.", :write)
@@ -542,7 +542,7 @@ function write(s::IO, a::Array)
 end
 
 function write(s::IO, a::SubArray{T,N,<:Array}) where {T,N}
-    if !isbits(T)
+    if !isbitstype(T)
         return invoke(write, Tuple{IO, AbstractArray}, s, a)
     end
     elsz = sizeof(T)
@@ -605,7 +605,7 @@ function read!(s::IO, a::Array{UInt8})
 end
 
 function read!(s::IO, a::Array{T}) where T
-    if isbits(T)
+    if isbitstype(T)
         GC.@preserve a unsafe_read(s, pointer(a), sizeof(a))
     else
         for i in eachindex(a)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -171,7 +171,7 @@ function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
     end
-    if isbits(T) && isa(a,Array)
+    if isbitstype(T) && isa(a,Array)
         nb = UInt(nel * sizeof(T))
         GC.@preserve a unsafe_read(from, pointer(a, offs), nb)
     else

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -116,7 +116,7 @@ function _reducedim_init(f, op, fv, fop, A, region)
     if T !== Any && applicable(zero, T)
         x = f(zero(T))
         z = op(fv(x), fv(x))
-        Tr = typeof(z) == typeof(x) && !isbits(T) ? T : typeof(z)
+        Tr = typeof(z) == typeof(x) && !isbitstype(T) ? T : typeof(z)
     else
         z = fv(fop(f, A))
         Tr = typeof(z)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -352,11 +352,11 @@ function isprimitivetype(@nospecialize(t::Type))
 end
 
 """
-    isbits(T)
+    isbitstype(T)
 
 Return `true` if type `T` is a "plain data" type,
 meaning it is immutable and contains no references to other values,
-only `primitive` types and other `isbits` types.
+only `primitive` types and other `isbitstype` types.
 Typical examples are numeric types such as [`UInt8`](@ref),
 [`Float64`](@ref), and [`Complex{Float64}`](@ref).
 This category of types is significant since they are valid as type parameters,
@@ -365,14 +365,20 @@ and have a defined layout that is compatible with C.
 
 # Examples
 ```jldoctest
-julia> isbits(Complex{Float64})
+julia> isbitstype(Complex{Float64})
 true
 
-julia> isbits(Complex)
+julia> isbitstype(Complex)
 false
 ```
 """
-isbits(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && t.isbitstype)
+isbitstype(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && t.isbitstype)
+
+"""
+    isbits(x)
+
+Return `true` if `x` is an instance of an `isbitstype` type.
+"""
 isbits(@nospecialize x) = (@_pure_meta; typeof(x).isbitstype)
 
 """

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -83,7 +83,7 @@ if is_primary_base_module
         return RefArray(a) # effectively a no-op
     end
     function Ref{P}(a::Array{T}) where P<:Union{Ptr,Cwstring,Cstring} where T
-        if (!isbits(T) && T <: eltype(P))
+        if (!isbitstype(T) && T <: eltype(P))
             # this Array already has the right memory layout for the requested Ref
             return RefArray(a,1,false) # root something, so that this function is type-stable
         else

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -24,8 +24,8 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S, N}} <: AbstractArray{T, N}
                 The resulting array would have non-integral first dimension.
             """))
         end
-        isbits(T) || throwbits(S, T, T)
-        isbits(S) || throwbits(S, T, S)
+        isbitstype(T) || throwbits(S, T, T)
+        isbitstype(S) || throwbits(S, T, S)
         (N != 0 || sizeof(T) == sizeof(S)) || throwsize0(S, T)
         if N != 0 && sizeof(S) != sizeof(T)
             dim = size(a)[1]

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -45,7 +45,7 @@ function summarysize(obj;
         else
             nf = _nfields(x)
             ft = typeof(x).types
-            if !isbits(ft[i]) && isdefined(x, i)
+            if !isbitstype(ft[i]) && isdefined(x, i)
                 val = getfield(x, i)
             end
         end
@@ -108,7 +108,7 @@ function (ss::SummarySize)(obj::Array)
     if !haskey(ss.seen, datakey)
         ss.seen[datakey] = true
         size += Core.sizeof(obj)
-        if !isbits(eltype(obj)) && !isempty(obj)
+        if !isbitstype(eltype(obj)) && !isempty(obj)
             push!(ss.frontier_x, obj)
             push!(ss.frontier_i, 1)
         end

--- a/base/threadcall.jl
+++ b/base/threadcall.jl
@@ -68,7 +68,7 @@ function do_threadcall(fun_ptr::Ptr{Cvoid}, rettype::Type, argtypes::Vector, arg
     args_arr = Vector{UInt8}(undef, args_size)
     ptr = pointer(args_arr)
     for (T, x) in zip(argtypes, argvals)
-        isbits(T) || throw(ArgumentError("threadcall requires isbits argument types"))
+        isbitstype(T) || throw(ArgumentError("threadcall requires isbits argument types"))
         y = cconvert(T, x)
         push!(roots, y)
         unsafe_store!(convert(Ptr{T}, ptr), unsafe_convert(T, y)::T)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -146,6 +146,7 @@ Base.fieldname
 Base.sizeof(::Type)
 Base.isconcretetype
 Base.isbits
+Base.isbitstype
 Core.fieldtype
 Base.fieldcount
 Base.fieldoffset

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -126,7 +126,7 @@ function syms_2b_sent(s::ClusterSerializer, identifier)
     for sym in check_syms
         v = getfield(Main, sym)
 
-        if isbits(v)
+        if isbitstype(typeof(v))
             push!(lst, sym)
         else
             oid = objectid(v)
@@ -146,7 +146,7 @@ function serialize_global_from_main(s::ClusterSerializer, sym)
 
     oid = objectid(v)
     record_v = true
-    if isbits(v)
+    if isbitstype(typeof(v))
         record_v = false
     elseif !haskey(s.glbs_sent, oid)
         # set up a finalizer the first time this object is sent

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -526,7 +526,7 @@ function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat
     end
 
     tile_size = 0
-    if isbits(R) && isbits(T) && isbits(S) && (tA == 'N' || tB != 'N')
+    if isbitstype(R) && isbitstype(T) && isbitstype(S) && (tA == 'N' || tB != 'N')
         tile_size = floor(Int, sqrt(tilebufsize / max(sizeof(R), sizeof(S), sizeof(T))))
     end
     @inbounds begin

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -186,7 +186,7 @@ function mmap(io::IO,
               offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where {T,N}
     # check inputs
     isopen(io) || throw(ArgumentError("$io must be open to mmap"))
-    isbits(T)  || throw(ArgumentError("unable to mmap $T; must satisfy isbits(T) == true"))
+    isbitstype(T)  || throw(ArgumentError("unable to mmap $T; must satisfy isbitstype(T) == true"))
 
     len = prod(dims) * sizeof(T)
     len >= 0 || throw(ArgumentError("requested size must be ≥ 0, got $len"))

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -437,7 +437,7 @@ end
 # fills up A reinterpreted as an array of Float64 with n64 values
 function _rand!(r::MersenneTwister, A::Array{T}, n64::Int, I::FloatInterval_64) where T
     # n64 is the length in terms of `Float64` of the target
-    @assert sizeof(Float64)*n64 <= sizeof(T)*length(A) && isbits(T)
+    @assert sizeof(Float64)*n64 <= sizeof(T)*length(A) && isbitstype(T)
     GC.@preserve A rand!(r, UnsafeView{Float64}(pointer(A), n64), SamplerTrivial(I))
     A
 end

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -259,7 +259,7 @@ function serialize(s::AbstractSerializer, a::Array)
     else
         serialize(s, length(a))
     end
-    if isbits(elty)
+    if isbitstype(elty)
         serialize_array_data(s.io, a)
     else
         sizehint!(s.table, div(length(a),4))  # prepare for lots of pointers
@@ -918,7 +918,7 @@ function deserialize_array(s::AbstractSerializer)
         elty = UInt8
     end
     if isa(d1, Integer)
-        if elty !== Bool && isbits(elty)
+        if elty !== Bool && isbitstype(elty)
             a = Vector{elty}(undef, d1)
             s.table[slot] = a
             return read!(s.io, a)
@@ -927,7 +927,7 @@ function deserialize_array(s::AbstractSerializer)
     else
         dims = convert(Dims, d1)::Dims
     end
-    if isbits(elty)
+    if isbitstype(elty)
         n = prod(dims)::Int
         if elty === Bool && n > 0
             A = Array{Bool, length(dims)}(undef, dims)
@@ -1135,7 +1135,7 @@ function deserialize(s::AbstractSerializer, t::DataType)
     end
     if nf == 0
         return ccall(:jl_new_struct, Any, (Any,Any...), t)
-    elseif isbits(t)
+    elseif isbitstype(t)
         if nf == 1
             f1 = deserialize(s)
             return ccall(:jl_new_struct, Any, (Any,Any...), t, f1)

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -104,7 +104,7 @@ beginning of the file.
 SharedArray
 
 function SharedArray{T,N}(dims::Dims{N}; init=false, pids=Int[]) where {T,N}
-    isbits(T) || throw(ArgumentError("type of SharedArray elements must be bits types, got $(T)"))
+    isbitstype(T) || throw(ArgumentError("type of SharedArray elements must be bits types, got $(T)"))
 
     pids, onlocalhost = shared_pids(pids)
 
@@ -178,7 +178,7 @@ function SharedArray{T,N}(filename::AbstractString, dims::NTuple{N,Int}, offset:
     if !isabspath(filename)
         throw(ArgumentError("$filename is not an absolute path; try abspath(filename)?"))
     end
-    if !isbits(T)
+    if !isbitstype(T)
         throw(ArgumentError("type of SharedArray elements must be bits types, got $(T)"))
     end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -3350,7 +3350,7 @@ end
 @noinline throw_error() = error()
 foo11904(x::Int) = x
 @inline function foo11904(x::Nullable11904{S}) where S
-    if isbits(S)
+    if isbitstype(S)
         Nullable11904(foo11904(x.value), x.hasvalue)
     else
         throw_error()

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -22,7 +22,8 @@ end
 
 @enum Fruit apple orange kiwi
 @test typeof(Fruit) == DataType
-@test isbits(Fruit)
+@test isbitstype(Fruit)
+@test isbits(apple)
 @test typeof(apple) <: Fruit <: Enum
 @test Int(apple) == 0
 @test Int(orange) == 1

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -42,17 +42,21 @@ test_code_reflections(test_ast_reflection, code_typed)
 
 end # module ReflectionTest
 
-# isbits
+# isbits, isbitstype
 
-@test !isbits(Array{Int})
-@test isbits(Float32)
-@test isbits(Int)
-@test !isbits(AbstractString)
-@test isbits(Tuple{Int, Vararg{Int, 2}})
-@test !isbits(Tuple{Int, Vararg{Int}})
-@test !isbits(Tuple{Integer, Vararg{Int, 2}})
-@test isbits(Tuple{Int, Vararg{Any, 0}})
-@test isbits(Tuple{Vararg{Any, 0}})
+@test !isbitstype(Array{Int})
+@test isbitstype(Float32)
+@test isbitstype(Int)
+@test !isbitstype(AbstractString)
+@test isbitstype(Tuple{Int, Vararg{Int, 2}})
+@test !isbitstype(Tuple{Int, Vararg{Int}})
+@test !isbitstype(Tuple{Integer, Vararg{Int, 2}})
+@test isbitstype(Tuple{Int, Vararg{Any, 0}})
+@test isbitstype(Tuple{Vararg{Any, 0}})
+@test isbits(1)
+@test isbits((1,2))
+@test !isbits([1])
+@test isbits(nothing)
 
 # issue #16670
 @test isconcretetype(Int)


### PR DESCRIPTION
I believe this is the only remaining type predicate that conflates types and their instances. This change clarifies what `isbits(x)` means, and adds `isbitstype` to be consistent with `isconcretetype`, `isstructtype`, etc.