### PR TITLE
Revert "reserve syntax that could be used for computed field types"

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -862,16 +862,6 @@
                  (if (not (symbol? v))
                      (error (string "field name \"" (deparse v) "\" is not a symbol"))))
                field-names)
-     (for-each (lambda (t)
-                 (if (expr-contains-p (lambda (e)
-                                        (and (pair? e) (eq? (car e) 'call)
-                                             (expr-contains-p (lambda (a) (memq a params))
-                                                              e)))
-                                      t)
-                     (error (string "unsupported field type expression \""
-                                    (deparse t)
-                                    "\""))))
-               field-types)
      `(block
        (scope-block
         (block


### PR DESCRIPTION
See #26816

This reverts commit a6f6b5bd392ab87e21b5c0aa75e2f88e54038732.