### PR TITLE
Deprecate variadic size(A, dim1, dim2, dims...) method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -768,6 +768,9 @@ Deprecated or removed
     `AbstractUnitRange`s are accepted as arguments.  Instead, convert the arguments before
     calling `ones` or `zeros` ([#26733]).
 
+  * The variadic `size(A, dim1, dim2, dims...)` method to return a tuple of multiple
+    dimension lengths of `A` has been deprecated ([#26862]).
+
   * The `Operators` module is deprecated. Instead, import required operators explicitly
     from `Base`, e.g. `import Base: +, -, *, /` ([#22251]).
 

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -24,11 +24,10 @@ end
 end
 
 """
-    size(A::AbstractArray, [dim...])
+    size(A::AbstractArray, [dim])
 
-Return a tuple containing the dimensions of `A`. Optionally you can specify the
-dimension(s) you want the length of, and get the length of that dimension, or a tuple of the
-lengths of dimensions you asked for.
+Return a tuple containing the dimensions of `A`. Optionally you can specify a
+dimension to just get the length of that dimension.
 
 Note that `size` may not be defined for arrays with non-standard indices, in which case [`axes`](@ref)
 may be useful. See the manual chapter on [arrays with custom indices](@ref man-custom-indices).
@@ -45,8 +44,6 @@ julia> size(A, 3, 2)
 ```
 """
 size(t::AbstractArray{T,N}, d) where {T,N} = d <= N ? size(t)[d] : 1
-size(x, d1::Integer, d2::Integer, dx::Vararg{Integer, N}) where {N} =
-    (size(x, d1), size(x, d2), ntuple(k->size(x, dx[k]), Val(N))...)
 
 """
     axes(A, d)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1586,6 +1586,9 @@ end
 @deprecate ones(::Type{T}, dims::NTuple{N, Any}) where {T, N}   ones(T, convert(Dims, dims))
 @deprecate ones(dims::Tuple)                                    ones(convert(Dims, dims))
 
+# Deprecate varargs size: PR #26862
+@deprecate size(x, d1::Integer, d2::Integer) (size(x, d1), size(x, d2))
+@deprecate size(x, d1::Integer, d2::Integer, dx::Integer...) map(dim->size(x, dim), (d1, d2, dx...))
 
 @deprecate showcompact(x) show(IOContext(stdout, :compact => true), x)
 @deprecate showcompact(io, x) show(IOContext(io, :compact => true), x)

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -732,8 +732,8 @@ A = TSlowNIndexes(rand(2,2))
 @test first(A) == A.data[1]
 
 @testset "#16381" begin
-    @inferred size(rand(3,2,1), 2, 1)
-    @inferred size(rand(3,2,1), 2, 1, 3)
+    @inferred size(rand(3,2,1))
+    @inferred size(rand(3,2,1), 2)
 
     @test @inferred(axes(rand(3,2)))    == (1:3,1:2)
     @test @inferred(axes(rand(3,2,1)))  == (1:3,1:2,1:1)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1478,15 +1478,14 @@ end
 let a = Array{Float64}(undef, 10)
     @test size(a) == (10,)
     @test size(a, 1) == 10
-    @test size(a,2,1) == (1,10)
+    @test (size(a,2), size(a,1)) == (1,10)
     aa = Array{Float64}(undef, 2,3)
     @test size(aa) == (2,3)
-    @test size(aa,4,3,2,1) == (1,1,3,2)
-    @test size(aa,1,2) == (2,3)
+    @test (size(aa,4), size(aa,3), size(aa,2), size(aa,1)) == (1,1,3,2)
     aaa = Array{Float64}(undef, 9,8,7,6,5,4,3,2,1)
-    @test size(aaa,1,1) == (9,9)
+    @test size(aaa,1) == 9
     @test size(aaa,4) == 6
-    @test size(aaa,9,8,7,6,5,4,3,2,19,8,7,6,5,4,3,2,1) == (1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,9)
+    @test size(aaa) == (9,8,7,6,5,4,3,2,1)
 
     #18459 Test Array{T, N} constructor
     b = Vector{Float64}(undef, 10)
@@ -2176,19 +2175,16 @@ end
     b = Vector{Float64}(undef, 10)
     @test size(a) == (10,)
     @test size(a, 1) == 10
-    @test size(a,2,1) == (1,10)
     @test size(a) == size(b)
     a = Array{Float64}(undef, 2,3)
     b = Matrix{Float64}(undef, 2,3)
     @test size(a) == (2,3)
-    @test size(a,4,3,2,1) == (1,1,3,2)
-    @test size(a,1,2) == (2,3)
+    @test (size(a, 1), size(a, 2), size(a, 3)) == (2,3,1)
     @test size(a) == size(b)
     a = Array{Float64}(undef, 9,8,7,6,5,4,3,2,1)
     b = Array{Float64,9}(undef, 9,8,7,6,5,4,3,2,1)
-    @test size(a,1,1) == (9,9)
     @test size(a,4) == 6
-    @test size(a,9,8,7,6,5,4,3,2,19,8,7,6,5,4,3,2,1) == (1,2,3,4,5,6,7,8,1,2,3,4,5,6,7,8,9)
+    @test size(a) == (9,8,7,6,5,4,3,2,1)
     @test size(a) == size(b)
 end
 


### PR DESCRIPTION
Resolves #26851.