### PR TITLE
throw ArgumentError instead of trying to create zero(T)//zero(T)

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -127,7 +127,7 @@ function rationalize(::Type{T}, x::AbstractFloat, tol::Real) where T<:Integer
     if tol < 0
         throw(ArgumentError("negative tolerance $tol"))
     end
-    isnan(x) && return zero(T)//zero(T)
+    isnan(x) && return T(x)//one(T)
     isinf(x) && return (x < 0 ? -one(T) : one(T))//zero(T)
 
     p,  q  = (x < 0 ? -one(T) : one(T)), zero(T)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -30,6 +30,8 @@ using Test
     @test @inferred(rationalize(Int, 3.0, 0.0)) === 3//1
     @test @inferred(rationalize(Int, 3.0, 0)) === 3//1
     @test_throws ArgumentError rationalize(Int, big(3.0), -1.)
+    # issue 26823
+    @test_throws InexactError rationalize(Int, NaN)
 
     for a = -5:5, b = -5:5
         if a == b == 0; continue; end


### PR DESCRIPTION
Before, trying to rationalize a NaN tried to create a 0//0:
```
rationalize(Int64, NaN, 1e-16)
ERROR: ArgumentError: invalid rational: zero(Int64)//zero(Int64)
Stacktrace:
 [1] Type at ./rational.jl:13 [inlined]
 [2] Type at ./rational.jl:18 [inlined]
 [3] // at ./rational.jl:40 [inlined]
 [4] rationalize(::Type{Int64}, ::Float64, ::Float64) at ./rational.jl:130
 [5] top-level scope
```

After, it fails with a clearer error message:
```
ERROR: ArgumentError: received NaN, not allowed for integer-related types
Stacktrace:
 [1] rationalize(::Type{Int64}, ::Float64, ::Float64) at ./rational.jl:130
 [2] top-level scope
```

cf. issue #26823
