### PR TITLE
several iterator trait fixes

### DIFF
--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -401,7 +401,8 @@ end
 
 # pass-through iterator traits to the iterable
 # on which the mapping function is being applied
-IteratorSize(itr::AsyncGenerator) = SizeUnknown()
+IteratorSize(::Type{AsyncGenerator}) = SizeUnknown()
+IteratorEltype(::Type{AsyncGenerator}) = EltypeUnknown()
 size(itr::AsyncGenerator) = size(itr.collector.enumerator)
 length(itr::AsyncGenerator) = length(itr.collector.enumerator)
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -176,6 +176,7 @@ function next(ebo::ExponentialBackOff, state)
 end
 done(ebo::ExponentialBackOff, state) = state[1]<1
 length(ebo::ExponentialBackOff) = ebo.n
+eltype(::Type{ExponentialBackOff}) = Float64
 
 """
     retry(f::Function;  delays=ExponentialBackOff(), check=nothing) -> Function

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -533,6 +533,7 @@ lastindex(v::SimpleVector) = length(v)
 start(v::SimpleVector) = 1
 next(v::SimpleVector,i) = (v[i],i+1)
 done(v::SimpleVector,i) = (length(v) < i)
+eltype(::Type{SimpleVector}) = Any
 keys(v::SimpleVector) = OneTo(length(v))
 isempty(v::SimpleVector) = (length(v) == 0)
 axes(v::SimpleVector) = (OneTo(length(v)),)

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -47,6 +47,11 @@ function next(g::Generator, s)
     g.f(v), s2
 end
 
+length(g::Generator) = length(g.iter)
+size(g::Generator) = size(g.iter)
+axes(g::Generator) = axes(g.iter)
+ndims(g::Generator) = ndims(g.iter)
+
 
 ## iterator traits
 
@@ -85,6 +90,13 @@ Base.HasLength()
 IteratorSize(x) = IteratorSize(typeof(x))
 IteratorSize(::Type) = HasLength()  # HasLength is the default
 
+IteratorSize(::Type{<:AbstractArray{<:Any,N}})  where {N} = HasShape{N}()
+IteratorSize(::Type{Generator{I,F}}) where {I,F} = IteratorSize(I)
+
+IteratorSize(::Type{Any}) = SizeUnknown()
+
+haslength(iter) = IteratorSize(iter) isa Union{HasShape, HasLength}
+
 abstract type IteratorEltype end
 struct EltypeUnknown <: IteratorEltype end
 struct HasEltype <: IteratorEltype end
@@ -111,13 +123,6 @@ Base.HasEltype()
 IteratorEltype(x) = IteratorEltype(typeof(x))
 IteratorEltype(::Type) = HasEltype()  # HasEltype is the default
 
-IteratorSize(::Type{<:AbstractArray{<:Any,N}})  where {N} = HasShape{N}()
-IteratorSize(::Type{Generator{I,F}}) where {I,F} = IteratorSize(I)
-length(g::Generator) = length(g.iter)
-size(g::Generator) = size(g.iter)
-axes(g::Generator) = axes(g.iter)
-ndims(g::Generator) = ndims(g.iter)
-
 IteratorEltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
 
-haslength(iter) = IteratorSize(iter) isa Union{HasShape, HasLength}
+IteratorEltype(::Type{Any}) = EltypeUnknown()

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -1503,6 +1503,6 @@ function Base.showarg(io::IO, r::Iterators.Pairs{<:CartesianIndex, <:Any, <:Any,
     print(io, "pairs(::$T)")
 end
 
-function Base.showarg(io::IO, r::Iterators.Pairs{<:CartesianIndex, <:Any, <:Any, <:AbstractVector}, toplevel)
+function Base.showarg(io::IO, r::Iterators.Pairs{<:CartesianIndex, <:Any, <:Any, T}, toplevel) where T<:AbstractVector
     print(io, "pairs(IndexCartesian(), ::$T)")
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -690,6 +690,7 @@ isempty(m::MethodList) = isempty(m.ms)
 start(m::MethodList) = start(m.ms)
 done(m::MethodList, s) = done(m.ms, s)
 next(m::MethodList, s) = next(m.ms, s)
+eltype(::Type{MethodList}) = Method
 
 function MethodList(mt::Core.MethodTable)
     ms = Method[]

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -35,6 +35,7 @@ start(R::ReshapedArrayIterator) = start(R.iter)
     ReshapedIndex(item), inext
 end
 length(R::ReshapedArrayIterator) = length(R.iter)
+eltype(::Type{<:ReshapedArrayIterator{I}}) where {I} = @isdefined(I) ? ReshapedIndex{eltype(I)} : Any
 
 """
     reshape(A, dims...) -> R

--- a/base/show.jl
+++ b/base/show.jl
@@ -1935,7 +1935,7 @@ function showarg(io::IO, r::ReinterpretArray{T}, toplevel) where {T}
 end
 
 # pretty printing for Iterators.Pairs
-function Base.showarg(io::IO, r::Iterators.Pairs{<:Integer, <:Any, <:Any, <:AbstractArray}, toplevel)
+function Base.showarg(io::IO, r::Iterators.Pairs{<:Integer, <:Any, <:Any, T}, toplevel) where T<:AbstractArray
     print(io, "pairs(IndexLinear(), ::$T)")
 end
 

--- a/base/task.jl
+++ b/base/task.jl
@@ -37,6 +37,7 @@ isempty(c::CompositeException) = isempty(c.exceptions)
 start(c::CompositeException) = start(c.exceptions)
 next(c::CompositeException, state) = next(c.exceptions, state)
 done(c::CompositeException, state) = done(c.exceptions, state)
+eltype(::Type{CompositeException}) = Any
 
 function showerror(io::IO, ex::CompositeException)
     if !isempty(ex)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -39,14 +39,14 @@ start(t::Tuple) = 1
 done(t::Tuple, i::Int) = (length(t) < i)
 next(t::Tuple, i::Int) = (t[i], i+1)
 
-keys(t::Tuple) = 1:length(t)
+keys(t::Tuple) = OneTo(length(t))
 
 prevind(t::Tuple, i::Integer) = Int(i)-1
 nextind(t::Tuple, i::Integer) = Int(i)+1
 
 function keys(t::Tuple, t2::Tuple...)
     @_inline_meta
-    1:_maxlength(t, t2...)
+    OneTo(_maxlength(t, t2...))
 end
 _maxlength(t::Tuple) = length(t)
 function _maxlength(t::Tuple, t2::Tuple, t3::Tuple...)

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -42,8 +42,7 @@ mutable struct WorkerConfig
 
     function WorkerConfig()
         wc = new()
-        for n in 1:length(WorkerConfig.types)
-            T = eltype(fieldtype(WorkerConfig, n))
+        for n in 1:fieldcount(WorkerConfig)
             setfield!(wc, n, nothing)
         end
         wc

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1314,11 +1314,10 @@ end
 
 @testset "eachindexvalue" begin
     A14 = [11 13; 12 14]
-    R = CartesianIndices(axes(A14))
     @test [a for (a,b) in pairs(IndexLinear(),    A14)] == [1,2,3,4]
-    @test [a for (a,b) in pairs(IndexCartesian(), A14)] == vec(Array(R))
+    @test [a for (a,b) in pairs(IndexCartesian(), A14)] == Array(CartesianIndices(axes(A14)))
     @test [b for (a,b) in pairs(IndexLinear(),    A14)] == [11,12,13,14]
-    @test [b for (a,b) in pairs(IndexCartesian(), A14)] == [11,12,13,14]
+    @test [b for (a,b) in pairs(IndexCartesian(), A14)] == A14
 end
 
 @testset "reverse" begin

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -490,6 +490,10 @@ end
         @test String(take!(io)) == "pairs(::Array{$Int,1})"
         Base.showarg(io, pairs((a=1, b=2)), true)
         @test String(take!(io)) == "pairs(::NamedTuple)"
+        Base.showarg(io, pairs(IndexLinear(), zeros(3,3)), true)
+        @test String(take!(io)) == "pairs(IndexLinear(), ::Array{Float64,2})"
+        Base.showarg(io, pairs(IndexCartesian(), zeros(3)), true)
+        @test String(take!(io)) == "pairs(IndexCartesian(), ::Array{Float64,1})"
     end
 end
 

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -66,7 +66,9 @@ end
 # ----
 let s = "hello"
     _, st = next(s, start(s))
-    @test collect(rest(s, st)) == ['e','l','l','o']
+    c = collect(rest(s, st))
+    @test c == ['e','l','l','o']
+    @test c isa Vector{Char}
 end
 
 @test_throws MethodError collect(rest(countfrom(1), 5))
@@ -414,6 +416,9 @@ let s = "Monkey 🙈🙊🙊"
     @test tf(1) == "M|o|n|k|e|y| |🙈|🙊|🙊"
 end
 
+@test Base.IteratorEltype(partition([1,2,3,4], 2)) == Base.HasEltype()
+@test Base.IteratorEltype(partition((2x for x in 1:3), 2)) == Base.EltypeUnknown()
+
 # take and friends with arbitrary integers (#19214)
 for T in (UInt8, UInt16, UInt32, UInt64, UInt128, Int8, Int16, Int128, BigInt)
     @test length(take(1:6, T(3))) == 3
@@ -450,10 +455,11 @@ end
         @test length(d) == length(A)
         @test keys(d) == keys(A)
         @test values(d) == A
-        @test Base.IteratorSize(d) == Base.HasLength()
+        @test Base.IteratorSize(d) == Base.IteratorSize(A)
         @test Base.IteratorEltype(d) == Base.HasEltype()
+        @test Base.IteratorSize(pairs([1 2;3 4])) isa Base.HasShape{2}
         @test isempty(d) || haskey(d, first(keys(d)))
-        @test collect(v for (k, v) in d) == vec(collect(A))
+        @test collect(v for (k, v) in d) == collect(A)
         if A isa NamedTuple
             K = isempty(d) ? Union{} : Symbol
             V = isempty(d) ? Union{} : Float64

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -164,8 +164,8 @@ end
     @test_throws BoundsError next((5,6,7), 0)
     @test_throws BoundsError next((), 1)
 
-    @test eachindex((2,5,"foo")) === 1:3
-    @test eachindex((2,5,"foo"), (1,2,5,7)) === 1:4
+    @test eachindex((2,5,"foo")) === Base.OneTo(3)
+    @test eachindex((2,5,"foo"), (1,2,5,7)) === Base.OneTo(4)
 end
 
 


### PR DESCRIPTION
Some bug fixes split out from #26852.

- `IteratorSize` was defined wrong for `AsyncGenerator`. It also needed `IteratorEltype`.
- Add `eltype` for some iterators that were missing it.
- `IteratorSize` for `Pairs` was unintentionally always `HasLength`
- `Pairs` assumes its inner iterators have eltype defined, so it's always `HasEltype`
- `eltype` of `Rest` didn't work
- Handle `EltypeUnknown` in `IteratorSize` of `Flatten`
- add `IteratorEltype` for `PartitionIterator`
- a couple `showarg` methods for `Pairs` were missing a static parameter

One strange case here is that `size` of `Pairs` is defined in terms of the index iterator, and the indices of a tuple are a range. A range has a `size`, but tuples don't. I hacked around this to force `IteratorSize(pairs(::Tuple))` to be `HasLength`; not sure what else to do.