### PR TITLE
log when a worker begins a testset to improve debuggability when workers hang in CI

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -15,6 +15,7 @@ function runtests(name, path, isolate=true; seed=nothing)
             m = Main
         end
         @eval(m, using Test, Random)
+        println("running testset ", name, "...")
         ex = quote
             @timed @testset $"$name" begin
                 # srand(nothing) will fail


### PR DESCRIPTION
The upside of this is that it's now easy to see what all workers were last working on in the event that CI kills the build due to a timeout (maybe I'm missing something, though, and there's another way to easily derive this from the current logs). The downside is that it makes the logs a bit uglier otherwise. 

Here's a slice of the test output after this change:

```
⋮
Dates/conversions             (59) |     3.79 |   0.04 |  1.2 |      40.33 |   238.11
      From worker 46:   running testset Libdl...
      From worker 59:   running testset Logging...
Dates/rounding                (18) |     6.48 |   0.04 |  0.7 |      70.29 |   257.09
      From worker 18:   running testset Markdown...
Dates/types                   (26) |     6.99 |   0.07 |  0.9 |      58.65 |   241.59
      From worker 26:   running testset Mmap...
Libdl                         (46) |     1.37 |   0.04 |  2.8 |      25.06 |   221.79
      From worker 46:   running testset Printf...
rational                      (33) |    28.28 |   0.97 |  3.4 |     605.28 |   246.05
Future                        (60) |     3.31 |   0.03 |  1.0 |      50.03 |   238.12
⋮
```

I know we have nifty new logging stuff in Base these days, but I'm not up to date with it yet. Assuming this change is even desirable, let me know if I should be using something other than `println`.
