### PR TITLE
hack to avoid perm error when rm:ing temp dir on windows

### DIFF
--- a/stdlib/Pkg/test/pkg.jl
+++ b/stdlib/Pkg/test/pkg.jl
@@ -40,7 +40,10 @@ function temp_pkg_dir(fn::Function, tmp_dir=joinpath(tempdir(), randstring()),
             end
             fn()
         finally
-            remove_tmp_dir && rm(tmp_dir, recursive=true)
+            if remove_tmp_dir
+                Sys.iswindows() && GC.gc() # to make sure handles are closed on Windows
+                rm(tmp_dir, recursive=true)
+            end
         end
     end
 end


### PR DESCRIPTION
Avoids the failure seen here: https://ci.appveyor.com/project/JuliaLang/julia/build/1.0.26225/job/vtwv10ff4l8n7i2e, see https://github.com/JuliaLang/julia/pull/26854.