### PR TITLE
add dump method for Ptr

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1651,6 +1651,7 @@ dump(io::IOContext, x::Module, n::Int, indent) = print(io, "Module ", x)
 dump(io::IOContext, x::String, n::Int, indent) = (print(io, "String "); show(io, x))
 dump(io::IOContext, x::Symbol, n::Int, indent) = print(io, typeof(x), " ", x)
 dump(io::IOContext, x::Union,  n::Int, indent) = print(io, x)
+dump(io::IOContext, x::Ptr,    n::Int, indent) = print(io, x)
 
 function dump_elts(io::IOContext, x::Array, n::Int, indent, i0, i1)
     for i in i0:i1

--- a/test/show.jl
+++ b/test/show.jl
@@ -802,6 +802,9 @@ end
 let repr = sprint(dump, Union{Integer, Float32})
     @test repr == "Union{Integer, Float32}\n" || repr == "Union{Float32, Integer}\n"
 end
+let repr = sprint(dump, Ptr{UInt8}(UInt(1)))
+    @test repr == "Ptr{UInt8} @$(repr(UInt(1)))"
+end
 let repr = sprint(dump, Core.svec())
     @test repr == "empty SimpleVector\n"
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -803,7 +803,7 @@ let repr = sprint(dump, Union{Integer, Float32})
     @test repr == "Union{Integer, Float32}\n" || repr == "Union{Float32, Integer}\n"
 end
 let repr = sprint(dump, Ptr{UInt8}(UInt(1)))
-    @test repr == "Ptr{UInt8} @$(repr(UInt(1)))"
+    @test repr == "Ptr{UInt8} @$(Base.repr(UInt(1)))"
 end
 let repr = sprint(dump, Core.svec())
     @test repr == "empty SimpleVector\n"

--- a/test/show.jl
+++ b/test/show.jl
@@ -803,7 +803,7 @@ let repr = sprint(dump, Union{Integer, Float32})
     @test repr == "Union{Integer, Float32}\n" || repr == "Union{Float32, Integer}\n"
 end
 let repr = sprint(dump, Ptr{UInt8}(UInt(1)))
-    @test repr == "Ptr{UInt8} @$(Base.repr(UInt(1)))"
+    @test repr == "Ptr{UInt8} @$(Base.repr(UInt(1)))\n"
 end
 let repr = sprint(dump, Core.svec())
     @test repr == "empty SimpleVector\n"


### PR DESCRIPTION
Currently `dump(x::Ptr)` will print the type of the pointer twice, e.g.

```Ptr{Nothing} Ptr{Nothing} @0x0000000120f1d2d0```

This was because the catchall `dump` method first printed `typeof(x)`, then `x` itself, and the `print` method for `Ptr` also prints the type first. This PR adds an overload so that the pointer type is only printed once.

```Ptr{Nothing} @0x0000000120f1d2d0```

I believe `dump` is not really exercised in tests right now but I could add some?