### PR TITLE
fix deprecations of \cdot and \times

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -797,8 +797,8 @@ end
     @deprecate_stdlib triu        LinearAlgebra true
     @deprecate_stdlib vecdot      LinearAlgebra true
     @deprecate_stdlib vecnorm     LinearAlgebra true
-    # @deprecate_stdlib ⋅           LinearAlgebra true
-    # @deprecate_stdlib ×           LinearAlgebra true
+    @deprecate_stdlib $(:⋅)       LinearAlgebra true
+    @deprecate_stdlib $(:×)       LinearAlgebra true
 
     ## types that were re-exported from Base
     @deprecate_stdlib Diagonal        LinearAlgebra true


### PR DESCRIPTION
Turn
```julia
julia> v = [1, 2]; v ⋅ v
ERROR: UndefVarError: ⋅ not defined
```
into
```julia
julia> v = [1, 2]; v ⋅ v
WARNING: Base.⋅ is deprecated: it has been moved to the standard library package `LinearAlgebra`.
Add `using LinearAlgebra` to your imports.
 in module Main
5
```

I am surprised no one ran into this until now, are people not using nice infix operators? :disappointed: 