### PR TITLE
Bump documenter version

### DIFF
--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
 Compat 0.62.1 0.62.1+
 DocStringExtensions 0.4.4 0.4.4+
-Documenter 0.16.1 0.16.1+
+Documenter 0.17.0 0.17.0+


### PR DESCRIPTION
Documenter 0.17.0 contains the fix for https://github.com/JuliaDocs/Documenter.jl/pull/699, which allows doc builds inside of git worktrees to actually finish.