### PR TITLE
[release-0.6] some compiler performance improvements

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -40,7 +40,7 @@ copy(e::Expr) = (n = Expr(e.head);
 # copy parts of an AST that the compiler mutates
 copy_exprs(x::Expr) = copy(x)
 copy_exprs(x::ANY) = x
-copy_exprargs(x::Array{Any,1}) = Any[copy_exprs(a) for a in x]
+copy_exprargs(x::Array{Any,1}) = Any[copy_exprs(x[i]) for i in 1:length(x)]
 
 ==(x::Expr, y::Expr) = x.head === y.head && isequal(x.args, y.args)
 ==(x::QuoteNode, y::QuoteNode) = isequal(x.value, y.value)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -232,7 +232,7 @@ false
 """
 isbits(t::DataType) = (@_pure_meta; !t.mutable & (t.layout != C_NULL) && datatype_pointerfree(t))
 isbits(t::Type) = (@_pure_meta; false)
-isbits(x) = (@_pure_meta; isbits(typeof(x)))
+isbits(x::ANY) = (@_pure_meta; isbits(typeof(x)))
 
 """
     isleaftype(T)


### PR DESCRIPTION
Mostly due to avoiding specialization of closures in comprehensions in the compiler itself. Most of these changes are already on master, or not worth applying due to code being in flux.

Sysimg build time and size on release-0.6:
```
real	3m4.122s
user	3m1.152s
-rw-rw-r-- 1 jeff jeff  2291415 Apr 24 18:56 inference.ji
-rwxrwxr-x 1 jeff jeff 39370374 Apr 24 18:59 sys.so
```

and on this branch:
```
real	2m59.307s
user	2m56.835s
-rw-rw-r-- 1 jeff jeff  2237103 Apr 24 18:52 inference.ji
-rwxrwxr-x 1 jeff jeff 38218607 Apr 24 18:55 sys.so
```

I think I've seen more improvement in some package precompile times, but it's hard to tell since there is a lot of variability (probably #25900).