### PR TITLE
[NewOptimizer] Fix bug in getfield elim pass

### DIFF
--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -11,3 +11,22 @@ end
 function abstract_eval_ssavalue(s::SSAValue, src::IncrementalCompact)
     return types(src)[s]
 end
+
+function compact_exprtype(compact::IncrementalCompact, @nospecialize(value))
+    if isa(value, Union{SSAValue, OldSSAValue})
+        return types(compact)[value]
+    elseif isa(value, Argument)
+        return compact.ir.argtypes[value.n]
+    end
+    return exprtype(value, compact.ir, compact.ir.mod)
+end
+
+is_tuple_call(ir::IRCode, @nospecialize(def)) = isa(def, Expr) && is_known_call(def, tuple, ir, ir.mod)
+is_tuple_call(compact::IncrementalCompact, @nospecialize(def)) = isa(def, Expr) && is_known_call(def, tuple, compact)
+function is_known_call(e::Expr, @nospecialize(func), src::IncrementalCompact)
+    if e.head !== :call
+        return false
+    end
+    f = compact_exprtype(src, e.args[1])
+    return isa(f, Const) && f.val === func
+end


### PR DESCRIPTION
We were looking at the pre-compacted IR rather than the compacted
one, causing errors. We need to clean all this up once we rip out
the old optimizer code, but for now, let's get this correct.