### PR TITLE
Travis: download moreutils from the release tarball

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_install:
         export JULIA_TEST_MAXRSS_MB=600;
         TESTSTORUN="all --skip linalg/triangular subarray"; fi # TODO: re enable these if possible without timing out
     - echo "override JULIA_CPU_TARGET=generic;native" >> Make.user
-    - git clone -q git://git.kitenet.net/moreutils
+    - git clone -q git://git.joeyh.name/moreutils
 script:
     - echo BUILDOPTS=$BUILDOPTS
     - export BUILDOPTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,8 @@ before_install:
         export JULIA_TEST_MAXRSS_MB=600;
         TESTSTORUN="all --skip linalg/triangular subarray"; fi # TODO: re enable these if possible without timing out
     - echo "override JULIA_CPU_TARGET=generic;native" >> Make.user
-    - git clone -q git://git.joeyh.name/moreutils
+    - wget http://http.debian.net/debian/pool/main/m/moreutils/moreutils_0.62.orig.tar.xz
+    - tar -xJvf moreutils_0.62.orig.tar.xz && mv moreutils-0.62 moreutils
 script:
     - echo BUILDOPTS=$BUILDOPTS
     - export BUILDOPTS


### PR DESCRIPTION
The old `kitenet.net` domain is down.  Checking on wayback, its pages had been throwing 302 redirects to this new domain.