### PR TITLE
[NewOptimizer] Backport reverse affinity changes from #26778

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -80,7 +80,7 @@ function Base.show(io::IO, code::IRCode)
     used = IdSet{Int}()
     Base.println(io, "Code")
     foreach(stmt->scan_ssa_use!(used, stmt), code.stmts)
-    foreach(((_a, _b, node, _d),) -> scan_ssa_use!(used, node), code.new_nodes)
+    foreach(nn -> scan_ssa_use!(used, nn.node), new_nodes)
     if isempty(used)
         maxsize = 0
     else
@@ -118,7 +118,7 @@ function Base.show(io::IO, code::IRCode)
         floop = true
         while !isempty(new_nodes_perm) && code.new_nodes[peek(new_nodes_perm)][1] == idx
             node_idx = popfirst!(new_nodes_perm)
-            _, reverse_affinity, typ, node, line = code.new_nodes[node_idx]
+            new_node = code.new_nodes[node_idx]
             node_idx += length(code.stmts)
             if print_sep
                 if floop
@@ -129,13 +129,13 @@ function Base.show(io::IO, code::IRCode)
             end
             print_sep = true
             floop = false
-            print_ssa_typ = !isa(node, PiNode) && node_idx in used
+            print_ssa_typ = !isa(new_node.node, PiNode) && node_idx in used
             Base.with_output_color(:yellow, io) do io′
-                print_node(io′, node_idx, node, used, maxsize; color = false,
-                    print_typ=!print_ssa_typ || (isa(node, Expr) && typ != node.typ))
+                print_node(io′, node_idx, new_node.node, used, maxsize; color = false,
+                    print_typ=!print_ssa_typ || (isa(new_node.node, Expr) && typ != new_node.node.typ))
             end
             if print_ssa_typ
-                Base.printstyled(io, "::$(typ)", color=:red)
+                Base.printstyled(io, "::$(new_node.typ)", color=:red)
             end
             Base.println(io)
         end

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -426,11 +426,15 @@ function domsort_ssa!(ir::IRCode, domtree::DomTree)
     end
     result_stmts = Any[renumber_ssa!(result_stmts[i], inst_rename, true) for i in 1:length(result_stmts)]
     cfg = CFG(new_bbs, Int[first(bb.stmts) for bb in new_bbs[2:end]])
-    new_new_nodes = NewNode[let (pos, reverse_affinity, typ, node, lno) = ir.new_nodes[i]
-            isa(node, PhiNode) && (node = rename_phinode_edges(node, 0, result_order, bb_rename))
-            node = renumber_ssa!(node, inst_rename, true)
-            (inst_rename[pos].id, reverse_affinity, typ, node, lno)
-        end for i in 1:length(ir.new_nodes)]
+    new_new_nodes = Vector{NewNode}(undef, length(ir.new_nodes))
+    for i = 1:length(ir.new_nodes)
+        entry = ir.new_nodes[i]
+        new_new_nodes[i] = NewNode(inst_rename[entry.pos].id, entry.attach_after, entry.typ,
+            renumber_ssa!(isa(entry.node, PhiNode) ?
+                rename_phinode_edges(entry.node, 0, result_order, bb_rename) : entry.node,
+                inst_rename, true),
+            entry.line)
+    end
     new_ir = IRCode(ir, result_stmts, result_types, result_ltable, result_flags, cfg, new_new_nodes)
     return new_ir
 end
@@ -602,12 +606,12 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
             end
             typ = incoming_val == undef_token ? MaybeUndef(Union{}) : typ_for_val(incoming_val, ci)
             new_node_id = ssaval - length(ir.stmts)
-            old_insert, reverse_affinity, old_typ, _, old_line = ir.new_nodes[new_node_id]
+            old_entry = ir.new_nodes[new_node_id]
             if isa(typ, DelayedTyp)
                 push!(type_refine_phi, ssaval)
             end
-            new_typ = isa(typ, DelayedTyp) ? Union{} : tmerge(old_typ, typ)
-            ir.new_nodes[new_node_id] = (old_insert, reverse_affinity, new_typ, node, old_line)
+            new_typ = isa(typ, DelayedTyp) ? Union{} : tmerge(old_entry.typ, typ)
+            ir.new_nodes[new_node_id] = NewNode(old_entry.pos, old_entry.attach_after, new_typ, node, old_entry.line)
             incoming_vals[slot] = NewSSAValue(ssaval)
         end
         (item in visited) && continue
@@ -666,7 +670,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                                 typ = MaybeUndef(Union{})
                             end
                             push!(phicnodes[exc][cidx][3].values,
-                                NewSSAValue(insert_node!(ir, idx+1, typ, node, true).id))
+                                NewSSAValue(insert_node!(ir, idx, typ, node, true).id))
                         end
                     end
                 end
@@ -717,16 +721,16 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
         for (_, ssa, node) in nodes
             new_typ = Union{}
             new_idx = ssa.id - length(ir.stmts)
-            old_insert, reverse_affinity, old_typ, _, old_line = ir.new_nodes[new_idx]
-            for i = 1:length(node.values)
-                orig_typ = typ = typ_for_val(node.values[i], ci)
+            node = ir.new_nodes[new_idx]
+            for i = 1:length(node.node.values)
+                orig_typ = typ = typ_for_val(node.node.values[i], ci)
                 @assert !isa(typ, MaybeUndef)
                 while isa(typ, DelayedTyp)
-                    typ = ir.new_nodes[typ.phi.id - length(ir.stmts)][3]
+                    typ = ir.new_nodes[typ.phi.id - length(ir.stmts)].typ
                 end
                 new_typ = tmerge(new_typ, typ)
             end
-            ir.new_nodes[new_idx] = (old_insert, reverse_affinity, new_typ, node, old_line)
+            ir.new_nodes[new_idx] = NewNode(node.pos, node.attach_after, new_typ, node.node, node.line)
         end
     end
     # This is a bit awkward, because it basically duplicates what type
@@ -737,16 +741,16 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
         changed = false
         for phi in type_refine_phi
             new_idx = phi - length(ir.stmts)
-            old_insert, reverse_affinity, old_typ, node, old_line = ir.new_nodes[new_idx]
+            node = ir.new_nodes[new_idx]
             new_typ = Union{}
-            for i = 1:length(node.values)
-                if !isassigned(node.values, i)
+            for i = 1:length(node.node.values)
+                if !isassigned(node.node.values, i)
                     if !isa(new_typ, MaybeUndef)
                         new_typ = MaybeUndef(new_typ)
                     end
                     continue
                 end
-                typ = typ_for_val(node.values[i], ci)
+                typ = typ_for_val(node.node.values[i], ci)
                 was_maybe_undef = false
                 if isa(typ, MaybeUndef)
                     typ = typ.typ
@@ -754,25 +758,27 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 end
                 @assert !isa(typ, MaybeUndef)
                 while isa(typ, DelayedTyp)
-                    typ = ir.new_nodes[typ.phi.id - length(ir.stmts)][3]
+                    typ = ir.new_nodes[typ.phi.id - length(ir.stmts)].typ
                 end
                 new_typ = tmerge(new_typ, was_maybe_undef ? MaybeUndef(typ) : typ)
             end
-            if !(old_typ ⊑ new_typ) || !(new_typ ⊑ old_typ)
-                ir.new_nodes[new_idx] = (old_insert, reverse_affinity, new_typ, node, old_line)
+            if !(node.typ ⊑ new_typ) || !(new_typ ⊑ node.typ)
+                ir.new_nodes[new_idx] = NewNode(node.pos, node.attach_after, new_typ, node.node, node.line)
                 changed = true
             end
         end
     end
-    types = Any[isa(types[i], DelayedTyp) ? ir.new_nodes[types[i].phi.id - length(ir.stmts)][2] : types[i] for i in 1:length(types)]
-    new_nodes = NewNode[let (pos, reverse_affinity, typ, node, line) = ir.new_nodes[i]
-            typ = isa(typ, DelayedTyp) ? ir.new_nodes[typ.phi.id - length(ir.stmts)][2] : typ
-            (pos, reverse_affinity, typ, node, line)
+    types = Any[isa(types[i], DelayedTyp) ? ir.new_nodes[types[i].phi.id - length(ir.stmts)].typ : types[i] for i in 1:length(types)]
+    new_nodes = NewNode[let node = ir.new_nodes[i]
+            typ = isa(node.typ, DelayedTyp) ? ir.new_nodes[node.typ.phi.id - length(ir.stmts)].typ : node.typ
+            NewNode(node.pos, node.attach_after, typ, node.node, node.line)
         end for i in 1:length(ir.new_nodes)]
     # Renumber SSA values
     new_code = Any[new_to_regular(renumber_ssa!(new_code[i], ssavalmap)) for i in 1:length(new_code)]
-    new_nodes = NewNode[let (pt, reverse_affinity, typ, stmt, line) = new_nodes[i]
-            (pt, reverse_affinity, typ, new_to_regular(renumber_ssa!(stmt, ssavalmap)), line)
+    new_nodes = NewNode[let node = new_nodes[i]
+            NewNode(node.pos, node.attach_after, node.typ,
+            new_to_regular(renumber_ssa!(node.node, ssavalmap)),
+            node.line)
         end for i in 1:length(new_nodes)]
     ir = IRCode(ir, new_code, types, ir.lines, ir.flags, ir.cfg, new_nodes)
     @timeit "domsort" ir = domsort_ssa!(ir, domtree)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -11,13 +11,13 @@ end
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int)
     if isa(op, SSAValue)
         if op.id > length(ir.stmts)
-            def_bb = block_for_inst(ir.cfg, ir.new_nodes[op.id - length(ir.stmts)][1])
+            def_bb = block_for_inst(ir.cfg, ir.new_nodes[op.id - length(ir.stmts)].pos)
         else
             def_bb = block_for_inst(ir.cfg, op.id)
         end
         if (def_bb == use_bb)
             if op.id > length(ir.stmts)
-                @assert ir.new_nodes[op.id - length(ir.stmts)][1] <= use_idx
+                @assert ir.new_nodes[op.id - length(ir.stmts)].pos <= use_idx
             else
                 @assert op.id < use_idx
             end


### PR DESCRIPTION
In #26778, I changed the way that the reverse affinity flag works
in order to support node insertion during compaction. In particular,
I had originally (for ease of implementation primarily) had that flag
simply change which BB an inserted node belongs to (i.e. if that flag
was set and there was a basic block boundary at the insertion site,
the new node would belong to the previous BB). In #26778, I changed
this to instead be a flag of whether to insert before or after a given
instruction. As it turns out, this change is also required for correctness.
Because domsorting can change the notion of "previous instruction" by
moving basic blocks, we had (in rare circumstances) instructions end
up in the wrong BB. Backporting those changes fixes that.