### PR TITLE
remove cmp for String and SubString{String} by memcmp

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -89,13 +89,6 @@ end
 
 ## comparison ##
 
-function cmp(a::String, b::String)
-    al, bl = sizeof(a), sizeof(b)
-    c = ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-              a, b, min(al,bl))
-    return c < 0 ? -1 : c > 0 ? +1 : cmp(al,bl)
-end
-
 function ==(a::String, b::String)
     al = sizeof(a)
     al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -82,14 +82,6 @@ end
 thisind(s::SubString{String}, i::Int) = _thisind_str(s, i)
 nextind(s::SubString{String}, i::Int) = _nextind_str(s, i)
 
-function cmp(a::SubString{String}, b::SubString{String})
-    na = sizeof(a)
-    nb = sizeof(b)
-    c = ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-              pointer(a), pointer(b), min(na, nb))
-    return c < 0 ? -1 : c > 0 ? +1 : cmp(na, nb)
-end
-
 # don't make unnecessary copies when passing substrings to C functions
 cconvert(::Type{Ptr{UInt8}}, s::SubString{String}) = s
 cconvert(::Type{Ptr{Int8}}, s::SubString{String}) = s

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -603,3 +603,17 @@ julia> ascii("abcdefgh")
 ```
 """
 ascii(x::AbstractString) = ascii(String(x))
+
+function cmp(a::Union{String, SubString{String}}, b::Union{String, SubString{String}})
+    a === b && return 0
+    al, bl = ncodeunits(a), ncodeunits(b)
+    al == 0 && return bl == 0 ? 0 : -1
+    bl == 0 && return 1
+    i = 0
+    @inbounds for outer i in 1:min(al, bl)
+        codeunit(a, i) ≠ codeunit(b, i) && break
+    end
+    @inbounds iv = min(thisind(a, i), thisind(b, i))
+    @inbounds c = cmp(a[iv], b[iv])
+    c == 0 ? cmp(al, bl) : c
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -23,6 +23,12 @@ using Random
     @test eltype(GenericString) == Char
     @test firstindex("abc") == 1
     @test cmp("ab","abc") == -1
+    @test cmp(String([0xc4, 0xfd, 0x27, 0x25]),
+              String([0xc4, 0xb0, 0xcf, 0x86])) == -1
+    @test cmp(SubString(String([0xc4, 0xfd, 0x27, 0x25])),
+              String([0xc4, 0xb0, 0xcf, 0x86])) == -1
+    @test cmp(SubString(String([0xc4, 0xfd, 0x27, 0x25])),
+              SubString(String([0xc4, 0xb0, 0xcf, 0x86]))) == -1
     @test typemin(String) === ""
     @test typemin("abc") === ""
     @test "abc" === "abc"


### PR DESCRIPTION
Fixes a bug in `cmp` for `String` and `SubString{String}` by removing specialized method using `memcmp`. Current behavior of `cmp` was inconsistent with the documentation and behavior of `cmp(::AbstractString, ::AbstractString)`. For instance:
```
julia> x1 = String([0xc4, 0xfd, 0x27, 0x25])
"\xc4\xfd'%"

julia> x2 = String([0xc4, 0xb0, 0xcf, 0x86])
"����"

julia> cmp(x1, x2)
1

julia> cmp(SubString(x1), x2)
-1

julia> cmp(SubString(x1), SubString(x2))
1

julia> cmp(x1[1], x2[1])
-1
```