### PR TITLE
Fix Vector'Diagonal (and Transpose as well) to avoid infinite recursion.

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -51,12 +51,8 @@ end
 # these will throw a DimensionMismatch unless B has 1 row (or 1 col for transposed case):
 *(a::AbstractVector, transB::Transpose{<:Any,<:AbstractMatrix}) =
     (B = transB.parent; *(reshape(a,length(a),1), transpose(B)))
-*(A::AbstractMatrix, transb::Transpose{<:Any,<:AbstractVector}) =
-    (b = transb.parent; *(A, transpose(reshape(b,length(b),1))))
 *(a::AbstractVector, adjB::Adjoint{<:Any,<:AbstractMatrix}) =
     (B = adjB.parent; *(reshape(a,length(a),1), adjoint(B)))
-*(A::AbstractMatrix, adjb::Adjoint{<:Any,<:AbstractVector}) =
-    (b = adjb.parent; *(A, adjoint(reshape(b,length(b),1))))
 (*)(a::AbstractVector, B::AbstractMatrix) = reshape(a,length(a),1)*B
 
 mul!(y::StridedVector{T}, A::StridedVecOrMat{T}, x::StridedVector{T}) where {T<:BlasFloat} = gemv!(y, 'N', A, x)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -433,4 +433,11 @@ end
     @test Diagonal(transpose([1, 2, 3])) == Diagonal([1 2 3])
 end
 
+@testset "Multiplication with Adjoint and Transpose vectors (#26863)" begin
+    x = rand(5)
+    D = Diagonal(rand(5))
+    @test x'*D*x == (x'*D)*x == (x'*Array(D))*x
+    @test Transpose(x)*D*x == (Transpose(x)*D)*x == (Transpose(x)*Array(D))*x
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
Also add optimized methods for x'D*y to avoid allocating temporary vector

Fixes JuliaLang/LinearAlgebra.jl#517