### PR TITLE
improve sizeof and repr documentation

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -335,9 +335,11 @@ reinterpret(::Type{Unsigned}, x::Float16) = reinterpret(UInt16,x)
 reinterpret(::Type{Signed}, x::Float16) = reinterpret(Int16,x)
 
 """
-    sizeof(T)
+    sizeof(T::DataType)
+    sizeof(obj)
 
-Size, in bytes, of the canonical binary representation of the given DataType `T`, if any.
+Size, in bytes, of the canonical binary representation of the given `DataType` `T`, if any.
+Size, in bytes, of object `obj` if it is not `DataType`.
 
 # Examples
 ```jldoctest
@@ -346,9 +348,15 @@ julia> sizeof(Float32)
 
 julia> sizeof(ComplexF64)
 16
+
+julia> sizeof(1.0)
+8
+
+julia> sizeof([1.0:10.0;])
+80
 ```
 
-If `T` does not have a specific size, an error is thrown.
+If `DataType` `T` does not have a specific size, an error is thrown.
 
 ```jldoctest
 julia> sizeof(AbstractArray)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -141,6 +141,22 @@ See also: [`getindex`](@ref), [`start`](@ref), [`done`](@ref),
 start(s::AbstractString) = 1
 done(s::AbstractString, i::Integer) = i > ncodeunits(s)
 eltype(::Type{<:AbstractString}) = Char # some string types may use another AbstractChar
+
+"""
+    sizeof(str::AbstractString)
+
+Size, in bytes, of the string `s`. Equal to the number of code units in `s` multiplied by
+the size, in bytes, of one code unit in `s`.
+
+# Examples
+```jldoctest
+julia> sizeof("")
+0
+
+julia> sizeof("∀")
+3
+```
+"""
 sizeof(s::AbstractString) = ncodeunits(s) * sizeof(codeunit(s))
 firstindex(s::AbstractString) = 1
 lastindex(s::AbstractString) = thisind(s, ncodeunits(s))

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -170,7 +170,7 @@ The optional keyword argument `context` can be set to an `IO` or [`IOContext`](@
 object whose attributes are used for the I/O stream passed to `show`.
 
 Note that `repr(x)` is usually similar to how the value of `x` would
-be entered in Julia.  See also [`repr("text/plain", x)`](@ref) to instead
+be entered in Julia.  See also [`repr(MIME("text/plain"), x)`](@ref) to instead
 return a "pretty-printed" version of `x` designed more for human consumption,
 equivalent to the REPL display of `x`.
 
@@ -181,6 +181,12 @@ julia> repr(1)
 
 julia> repr(zeros(3))
 "[0.0, 0.0, 0.0]"
+
+julia> repr(big(1/3))
+"3.33333333333333314829616256247390992939472198486328125e-01"
+
+julia> repr(big(1/3), context=:compact => true)
+"3.33333e-01"
 
 ```
 """


### PR DESCRIPTION
Changes:
* `sizeof` for general object (not `DataType`) and `AbstractString`;
* `repr` did not give example of `context` keyword argument and had a broken link to `repr` using `MIME`.
