### PR TITLE
specify eltype for Random.UniformBits (internal type)

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -72,6 +72,7 @@ for UI = (:UInt10, :UInt10Raw, :UInt23, :UInt23Raw, :UInt52, :UInt52Raw,
     end
 end
 
+Base.eltype(::Type{<:UniformBits{T}}) where {T} = T
 
 ### floats
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -657,3 +657,9 @@ end
     r = T(1):T(108)
     @test rand(RNG, SamplerRangeFast(r)) ∈ r
 end
+
+@testset "eltype for UniformBits" begin
+    @test eltype(Random.UInt52()) == UInt64
+    @test eltype(Random.UInt52(UInt128)) == UInt128
+    @test eltype(Random.UInt104()) == UInt128
+end


### PR DESCRIPTION
This is to allow not altering the `Random` code in #26852, and gives tighter array type for expressions like `rand(UInt52(), 2)`.