### PR TITLE
Broadcast performance: fix type stability

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -798,7 +798,7 @@ preprocess_args(dest, args::Tuple{}) = ()
 @inline function copyto!(dest::AbstractArray, bc::Broadcasted{Nothing})
     axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
     # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
-    if bc.f === identity && bc.args isa Tuple{<:AbstractArray} # only a single input argument to broadcast!
+    if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
         A = bc.args[1]
         if axes(dest) == axes(A)
             return copyto!(dest, A)


### PR DESCRIPTION
Remove a needless construction of a covariant typevar within a tuple. Tuples already are covariant.

Before:
```julia
julia> xset= 10:15
10:15

julia> yset= 12:14
12:14

julia> f(x,y) = sqrt( x^2 + y^2 )
f (generic function with 1 method)

julia> function loop3(xset, yset)
           m = Matrix{Float64}(undef, 3, length(xset)*length(yset))
           i = 1
           @inbounds for x in xset, y in yset
               m[:,i] .= (Float64(x), Float64(y), f(x,y))
               i += 1
           end
           m
       end
loop3 (generic function with 1 method)

julia> using BenchmarkTools

julia> @benchmark loop3($xset, $yset)
BenchmarkTools.Trial:
  memory estimate:  5.59 KiB
  allocs estimate:  109
  --------------
  minimum time:     9.634 μs (0.00% GC)
  median time:      10.504 μs (0.00% GC)
  mean time:        16.472 μs (32.25% GC)
  maximum time:     43.241 ms (99.95% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

After:
```julia
julia> @benchmark loop3($xset, $yset)
BenchmarkTools.Trial:
  memory estimate:  544 bytes
  allocs estimate:  1
  --------------
  minimum time:     186.732 ns (0.00% GC)
  median time:      193.974 ns (0.00% GC)
  mean time:        217.001 ns (6.63% GC)
  maximum time:     69.051 μs (99.42% GC)
  --------------
  samples:          10000
  evals/sample:     616
```