### PR TITLE
[NewOptimizer] Make stmt_effect_free less aggressive

### DIFF
--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -1,7 +1,57 @@
+"""
+Determine whether a statement is side-effect-free, i.e. may be removed if it has no uses.
+"""
 function stmt_effect_free(@nospecialize(stmt), src, mod::Module)
     isa(stmt, Union{PiNode, PhiNode}) && return true
     isa(stmt, Union{ReturnNode, GotoNode, GotoIfNot}) && return false
-    return effect_free(stmt, src, mod, true)
+    isa(stmt, GlobalRef) && return isdefined(stmt.mod, stmt.name)
+    (isa(stmt, Symbol) || isa(stmt, SSAValue) || isa(stmt, Argument)) && return true
+    isa(stmt, Slot) && return false # Slots shouldn't occur in the IR at this point, but let's be defensive here
+    if isa(stmt, Expr)
+        e = stmt::Expr
+        head = e.head
+        is_meta_expr_head(head) && return true
+        if head === :static_parameter
+            # if we aren't certain enough about the type, it might be an UndefVarError at runtime
+            return isa(e.typ, Const) || issingletontype(widenconst(e.typ))
+        end
+        (e.typ === Bottom) && return false
+        ea = e.args
+        if head === :call
+            f = exprtype(ea[1], src, mod)
+            if isa(f, Const)
+                f = f.val
+            elseif isType(f)
+                f = f.parameters[1]
+            else
+                return false
+            end
+            f === return_type && return true
+            # TODO: This needs significant refinement
+            contains_is(_PURE_BUILTINS, f) || return false
+            return builtin_nothrow(f, Any[exprtype(ea[i], src, mod) for i = 2:length(ea)])
+        elseif head === :new
+            a = ea[1]
+            typ = exprtype(a, src, mod)
+            # `Expr(:new)` of unknown type could raise arbitrary TypeError.
+            typ, isexact = instanceof_tfunc(typ)
+            isexact || return false
+            isconcretedispatch(typ) || return false
+            typ = typ::DataType
+            fieldcount(typ) >= length(ea) - 1 || return false
+            for fld_idx in 1:(length(ea) - 1)
+                eT = exprtype(ea[fld_idx + 1], src, mod)
+                fT = fieldtype(typ, fld_idx)
+                eT ⊑ fT || return false
+            end
+            return true
+        elseif head === :isdefined || head === :the_exception || head === :copyast
+            return true
+        else
+            return false
+        end
+    end
+    return true
 end
 
 function abstract_eval_ssavalue(s::SSAValue, src::IRCode)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -433,6 +433,75 @@ function const_datatype_getfield_tfunc(sv, fld)
     return nothing
 end
 
+function try_compute_fieldidx(@nospecialize(typ), @nospecialize(field))
+    if isa(field, Symbol)
+        field = fieldindex(typ, field, false)
+        field == 0 && return nothing
+    elseif isa(field, Integer)
+        (1 <= field <= fieldcount(typ)) || return nothing
+    else
+        return nothing
+    end
+    return field
+end
+
+function getfield_nothrow(argtypes::Vector{Any})
+    2 <= length(argtypes) <= 3 || return false
+    length(argtypes) == 2 && return getfield_nothrow(argtypes[1], argtypes[2], Const(true))
+    return getfield_nothrow(argtypes[1], argtypes[2], argtypes[3])
+end
+function getfield_nothrow(@nospecialize(s00), @nospecialize(name), @nospecialize(inbounds))
+    bounds_check_disabled = isa(inbounds, Const) && inbounds.val === false
+    # If we don't have invounds and don't know the field, don't even bother
+    if !bounds_check_disabled
+        isa(name, Const) || return false
+    end
+
+    # If we have s00 being a const, we can potentially refine our type-based analysis above
+    if isa(s00, Const) || isconstType(s00)
+        if !isa(s00, Const)
+            sv = s00.parameters[1]
+        else
+            sv = s00.val
+        end
+        if isa(name, Const)
+            (isa(sv, Module) && isa(name.val, Symbol)) || return false
+            (isa(name.val, Symbol) || isa(name.val, Int)) || return false
+            return isdefined(sv, name.val)
+        end
+        if bounds_check_disabled && !isa(sv, Module)
+            # If bounds checking is disabled and all fields are assigned,
+            # we may assume that we don't throw
+            for i = 1:fieldcount(typeof(sv))
+                isdefined(sv, i) || return false
+            end
+            return true
+        end
+        return false
+    end
+
+    s = unwrap_unionall(widenconst(s00))
+    if isa(s, Union)
+        return getfield_nothrow(rewrap(s.a, s00), name, inbounds) &&
+            getfield_nothrow(rewrap(s.b, s00), name, inbounds)
+    elseif isa(s, DataType)
+        # Can't say anything about abstract types
+        s.abstract && return false
+        # If all fields are always initialized, and bounds check is disabled, we can assume
+        # we don't throw
+        if bounds_check_disabled && !isvatuple(s) && s.name !== NamedTuple.body.body.name && fieldcount(s) == s.ninitialized
+            return true
+        end
+        # Else we need to know what the field is
+        isa(name, Const) || return false
+        field = try_compute_fieldidx(s, name.val)
+        field === nothing && return false
+        field <= s.ninitialized && return true
+    end
+
+    return false
+end
+
 getfield_tfunc(@nospecialize(s00), @nospecialize(name), @nospecialize(inbounds)) =
     getfield_tfunc(s00, name)
 function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
@@ -768,6 +837,44 @@ function tuple_tfunc(@nospecialize(argtype))
         return t
     end
     return argtype
+end
+
+function array_builtin_common_nothrow(argtypes, first_idx_idx)
+    length(argtypes) >= 4 || return false
+    (argtypes[0] ⊑ Bool && argtypes[1] ⊑ Array) || return false
+    for i = first_idx_idx:length(argtypes)
+        argtypes[i] ⊑ Int || return false
+    end
+    # If we have @inbounds (first argument is false), we're allowed to assume we don't throw
+    (isa(argtypes[0], Const) && !argtypes[0].val) && return true
+    # Else we can't really say anything here
+    # TODO: In the future we may be able to track the shapes of arrays though
+    # inference.
+    return false
+end
+
+# Query whether the given builtin is guaranteed not to throw given the argtypes
+function builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1})
+    (f === tuple || f === svec) && return true
+    if f === arrayset
+        array_builtin_common_nothrow(argtypes, 4) || return true
+        # Additionally check element type compatibility
+        a = widenconst(argtypes[2])
+        # Check that we can determine the element type
+        (isa(a, DataType) && isa(a.parameters[1], Type)) || return false
+        # Check that the element type is compatible with the element we're assigning
+        (argtypes[3] ⊑ a.parameters[1]::Type) || return false
+        return true
+    elseif f === arrayref
+        return array_builtin_common_nothrow(argtypes, 3)
+    elseif f === Core._expr
+        return length(argtypes) >= 1 && argtypes[1] ⊑ Symbol
+    elseif f === invoke
+        return false
+    elseif f === getfield
+        return getfield_nothrow(argtypes)
+    end
+    return false
 end
 
 function builtin_tfunction(@nospecialize(f), argtypes::Array{Any,1},


### PR DESCRIPTION
Previously, the new optimizer used the pre-existing `effect_free` function
to determine whether it is safe to remove an unreferenced statement. However,
this function ignores many builtin's error cases, causing them to be
removed when that is not legal to do (because that would potentially remove
an exception that would otherwise be thrown). Start fixing this, by
introducing a version of the function that is correct for a subset of
intresting functions. We will likely need to expand this when we look
at the benchmarks, but this should be correct for now.