### PR TITLE
better deprecation message for (+|-)(::Array, ::Number) deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -582,10 +582,10 @@ import .Iterators.enumerate
 @deprecate isabstract isabstracttype
 
 # PR #22932
-@deprecate +(a::Number, b::AbstractArray) broadcast(+, a, b)
-@deprecate +(a::AbstractArray, b::Number) broadcast(+, a, b)
-@deprecate -(a::Number, b::AbstractArray) broadcast(-, a, b)
-@deprecate -(a::AbstractArray, b::Number) broadcast(-, a, b)
+@deprecate +(a::Number, b::AbstractArray) a .+ b
+@deprecate +(a::AbstractArray, b::Number) a .+ b
+@deprecate -(a::Number, b::AbstractArray) a .- b
+@deprecate -(a::AbstractArray, b::Number) a .- b
 
 @deprecate(ind2sub(dims::NTuple{N,Integer}, idx::CartesianIndex{N}) where N, Tuple(idx))
 


### PR DESCRIPTION
Changes
```
julia> A + 1;
┌ Warning: `a::AbstractArray + b::Number` is deprecated, use `broadcast(+, a, b)` instead.
│   caller = top-level scope
└ @ Core :0
```
to
```
julia> A + 1;
┌ Warning: `a::AbstractArray + b::Number` is deprecated, use `a .+ b` instead.
│   caller = top-level scope
└ @ Core :0
```

which is a simpler change for users, and is more idiomatic.