### PR TITLE
Make random test less likely to fail

### DIFF
--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -120,7 +120,9 @@ end
 for T in [UInt32, UInt64, UInt128, Int128]
     local r, s
     s = big(typemax(T)-1000) : big(typemax(T)) + 10000
-    @test rand(s) != rand(s)
+    # s is a 11001-length array
+    @test rand(s) isa BigInt
+    @test sum(rand(s, 1000) .== rand(s, 1000)) <= 20
     @test big(typemax(T)-1000) <= rand(s) <= big(typemax(T)) + 10000
     r = rand(s, 1, 2)
     @test size(r) == (1, 2)


### PR DESCRIPTION
Previously, one of Random's tests was checking `rand(s) != rand(s)`, where `s` was a 11001-length range.  This is expected to have a one-in-11001 chance of failure, and indeed it has caused at least one CI failure. This changes it to something much less likely to spuriously fail -- if I have my probabilities right here I think it'd be on the order of 10^-20.