### PR TITLE
[NewOptimizer] Refactor phinode codegen

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -2107,9 +2107,9 @@ static void union_alloca_type(jl_uniontype_t *ut,
             counter);
 }
 
-static Value *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool &allunbox, size_t &min_align)
+static AllocaInst *try_emit_union_alloca(jl_codectx_t &ctx, jl_uniontype_t *ut, bool &allunbox, size_t &min_align, size_t &nbytes)
 {
-    size_t nbytes, align;
+    size_t align;
     union_alloca_type(ut, allunbox, nbytes, align, min_align);
     if (nbytes > 0) {
         // at least some of the values can live on the stack


### PR DESCRIPTION
Turns out the old approach we used didn't work, because it was possible
for the processing of one phi node to clobber the operands of another (e.g.
in a loop where one phi node depends on another). Fix this by using two
buffers. This isn't great, but hopefully LLVM should do ok at it. If
not, we can fix LLVM or try to be smarter.