### PR TITLE
Move scalar broadcast setindex_shape_check method to deprecated

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1494,6 +1494,7 @@ end
 # PR #26347: Deprecate implicit scalar broadcasting in setindex!
 _axes(::Ref) = ()
 _axes(x) = axes(x)
+setindex_shape_check(X::Base.Iterators.Repeated, I...) = nothing
 function deprecate_scalar_setindex_broadcast_message(v, I...)
     value = (_axes(Base.Broadcast.broadcastable(v)) == () ? "x" : "(x,)")
     "using `A[I...] = x` to implicitly broadcast `x` across many locations is deprecated. Use `A[I...] .= $value` instead."

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -155,7 +155,6 @@ function setindex_shape_check(X::AbstractArray{<:Any,2}, i::Integer, j::Integer)
         throw_setindex_mismatch(X, (i,j))
     end
 end
-setindex_shape_check(X, I...) = nothing # Non-arrays broadcast to all idxs
 
 # convert to a supported index type (array or Int)
 """

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -337,8 +337,8 @@ end
     @test findall(in([1, 2]), 2) == [1]
     @test findall(in([1, 2]), 3) == []
 
-    rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, UInt8, Vector{Int}, Int16, UnitRange{Int}})
-    @test length(rt) == 1 && rt[1] == Array{Int32, 3}
+    rt = Base.return_types(setindex!, Tuple{Array{Int32, 3}, Vector{UInt8}, Vector{Int}, Int16, UnitRange{Int}})
+    @test length(rt) == 1 && rt[1] === Array{Int32, 3}
 end
 @testset "construction" begin
     @test typeof(Vector{Int}(undef, 3)) == Vector{Int}


### PR DESCRIPTION
This will ensure its deletion after deprecations are removed.  Thanks to @mschauer who identified this in https://github.com/JuliaLang/julia/pull/26347#issuecomment-386147060.