### PR TITLE
Separate LibGit2.(count|map) from Base.(count|map)

### DIFF
--- a/stdlib/LibGit2/docs/src/index.md
+++ b/stdlib/LibGit2/docs/src/index.md
@@ -108,7 +108,7 @@ LibGit2.isorphan
 LibGit2.isset
 LibGit2.iszero
 LibGit2.lookup_branch
-LibGit2.map(::Function, ::LibGit2.GitRevWalker; ::LibGit2.GitHash, ::AbstractString, ::Cint, ::Bool)
+LibGit2.map
 LibGit2.mirror_callback
 LibGit2.mirror_cb
 LibGit2.message

--- a/stdlib/LibGit2/docs/src/index.md
+++ b/stdlib/LibGit2/docs/src/index.md
@@ -68,7 +68,7 @@ LibGit2.checkout!
 LibGit2.clone
 LibGit2.commit
 LibGit2.committer
-LibGit2.count(::Function, ::LibGit2.GitRevWalker; ::LibGit2.GitHash, ::Cint, ::Bool)
+LibGit2.count
 LibGit2.counthunks
 LibGit2.create_branch
 LibGit2.credentials_callback

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -727,7 +727,7 @@ function merge!(repo::GitRepo;
                 throw(GitError(Error.Merge, Error.ERROR,
                                "There is no fetch reference for this branch."))
             end
-            map(fh->GitAnnotated(repo,fh), fheads)
+            Base.map(fh->GitAnnotated(repo,fh), fheads)
         else # merge commitish
             [GitAnnotated(repo, committish)]
         end
@@ -785,7 +785,7 @@ function merge!(repo::GitRepo;
                merge_opts=merge_opts,
                checkout_opts=checkout_opts)
     finally
-        map(close, upst_anns)
+        Base.map(close, upst_anns)
     end
 end
 

--- a/stdlib/LibGit2/src/deprecated.jl
+++ b/stdlib/LibGit2/src/deprecated.jl
@@ -44,6 +44,8 @@ end
 @eval Base @deprecate count(rb::$(GitRebase)) $(LibGit2.count)(rb)
 @eval Base @deprecate count(tree::$(GitTree)) $(LibGit2.count)(tree)
 @eval Base @deprecate count(f::Function, walker::$(GitRevWalker); kwargs...) $(LibGit2.count)(f, walker; kwargs...)
+@eval Base @deprecate map(f::Function, bi::$(GitBranchIter)) $(LibGit2.map)(f, bi)
+@eval Base @deprecate map(f::Function, walker::$(GitRevWalker); kwargs...) $(LibGit2.map)(f, walker; kwargs...)
 
 # PR #24594
 @deprecate AbstractCredentials AbstractCredential false

--- a/stdlib/LibGit2/src/deprecated.jl
+++ b/stdlib/LibGit2/src/deprecated.jl
@@ -39,6 +39,11 @@ end
 
 @eval Base @deprecate merge!(repo::$(GitRepo), args...; kwargs...) $(LibGit2.merge!)(repo, args...; kwargs...)
 @eval Base @deprecate push!(w::$(GitRevWalker), arg) $(LibGit2.push!)(w, arg)
+@eval Base @deprecate count(diff::$(GitDiff)) $(LibGit2.count)(diff)
+@eval Base @deprecate count(idx::$(GitIndex)) $(LibGit2.count)(idx)
+@eval Base @deprecate count(rb::$(GitRebase)) $(LibGit2.count)(rb)
+@eval Base @deprecate count(tree::$(GitTree)) $(LibGit2.count)(tree)
+@eval Base @deprecate count(f::Function, walker::$(GitRevWalker); kwargs...) $(LibGit2.count)(f, walker; kwargs...)
 
 # PR #24594
 @deprecate AbstractCredentials AbstractCredential false

--- a/stdlib/LibGit2/src/diff.jl
+++ b/stdlib/LibGit2/src/diff.jl
@@ -106,7 +106,7 @@ function deletions(diff_stat::GitDiffStats)
     return ccall((:git_diff_stats_deletions, :libgit2), Csize_t, (Ptr{Cvoid},), diff_stat.ptr)
 end
 
-function Base.count(diff::GitDiff)
+function count(diff::GitDiff)
     return ccall((:git_diff_num_deltas, :libgit2), Cint, (Ptr{Cvoid},), diff.ptr)
 end
 

--- a/stdlib/LibGit2/src/index.jl
+++ b/stdlib/LibGit2/src/index.jl
@@ -163,7 +163,7 @@ function read!(repo::GitRepo, force::Bool = false)
     return
 end
 
-function Base.count(idx::GitIndex)
+function count(idx::GitIndex)
     return ccall((:git_index_entrycount, :libgit2), Csize_t, (Ptr{Cvoid},), idx.ptr)
 end
 

--- a/stdlib/LibGit2/src/merge.jl
+++ b/stdlib/LibGit2/src/merge.jl
@@ -81,7 +81,7 @@ Return two outputs, `analysis` and `preference`. `analysis` has several possible
 function merge_analysis(repo::GitRepo, anns::Vector{GitAnnotated})
     analysis = Ref{Cint}(0)
     preference = Ref{Cint}(0)
-    anns_ref = Ref(map(a->a.ptr, anns), 1)
+    anns_ref = Ref(Base.map(a->a.ptr, anns), 1)
     anns_size = Csize_t(length(anns))
     @check ccall((:git_merge_analysis, :libgit2), Cint,
                   (Ptr{Cint}, Ptr{Cint}, Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Csize_t),
@@ -144,7 +144,7 @@ function merge!(repo::GitRepo, anns::Vector{GitAnnotated};
     @check ccall((:git_merge, :libgit2), Cint,
                   (Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Csize_t,
                    Ptr{MergeOptions}, Ptr{CheckoutOptions}),
-                   repo.ptr, map(x->x.ptr, anns), anns_size,
+                   repo.ptr, Base.map(x->x.ptr, anns), anns_size,
                    Ref(merge_opts), Ref(checkout_opts))
     @info "Review and commit merged changes"
     return true

--- a/stdlib/LibGit2/src/rebase.jl
+++ b/stdlib/LibGit2/src/rebase.jl
@@ -12,7 +12,7 @@ function GitRebase(repo::GitRepo, branch::GitAnnotated, upstream::GitAnnotated;
     return GitRebase(repo, rebase_ptr_ptr[])
 end
 
-function Base.count(rb::GitRebase)
+function count(rb::GitRebase)
     return ccall((:git_rebase_operation_entrycount, :libgit2), Csize_t, (Ptr{Cvoid},), rb.ptr)
 end
 

--- a/stdlib/LibGit2/src/reference.jl
+++ b/stdlib/LibGit2/src/reference.jl
@@ -342,7 +342,7 @@ end
 
 Base.IteratorSize(::Type{GitBranchIter}) = Base.SizeUnknown()
 
-function Base.map(f::Function, bi::GitBranchIter)
+function map(f::Function, bi::GitBranchIter)
     res = nothing
     s = start(bi)
     while !done(bi, s)

--- a/stdlib/LibGit2/src/tree.jl
+++ b/stdlib/LibGit2/src/tree.jl
@@ -88,7 +88,7 @@ function entryid(te::GitTreeEntry)
     return oid
 end
 
-function Base.count(tree::GitTree)
+function count(tree::GitTree)
     return ccall((:git_tree_entrycount, :libgit2), Csize_t, (Ptr{Cvoid},), tree.ptr)
 end
 

--- a/stdlib/LibGit2/src/walker.jl
+++ b/stdlib/LibGit2/src/walker.jl
@@ -158,7 +158,7 @@ end
 the walk from that commit and moving forwards in time from it. Since the `GitHash` is unique to
 a commit, `cnt` will be `1`.
 """
-function Base.count(f::Function, walker::GitRevWalker;
+function count(f::Function, walker::GitRevWalker;
                   oid::GitHash=GitHash(),
                   by::Cint = Consts.SORT_NONE,
                   rev::Bool=false)

--- a/stdlib/LibGit2/src/walker.jl
+++ b/stdlib/LibGit2/src/walker.jl
@@ -105,7 +105,7 @@ end
 ```
 Here, `map` visits each commit using the `GitRevWalker` and finds its `GitHash`.
 """
-function Base.map(f::Function, walker::GitRevWalker;
+function map(f::Function, walker::GitRevWalker;
                   oid::GitHash=GitHash(),
                   range::AbstractString="",
                   by::Cint = Consts.SORT_NONE,

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -885,7 +885,7 @@ mktempdir() do dir
                         @test LibGit2.lookup_branch(repo, test_branch2, true) === nothing
                     end
                 end
-                branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
+                branches = LibGit2.map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
                 @test master_branch in branches
                 @test test_branch in branches
             end
@@ -1357,7 +1357,7 @@ mktempdir() do dir
                 @test tag2 in tags
 
                 # all tag in place
-                branches = map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
+                branches = LibGit2.map(b->LibGit2.shortname(b[1]), LibGit2.GitBranchIter(repo))
                 @test master_branch in branches
                 @test test_branch in branches
 

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -1018,7 +1018,7 @@ mktempdir() do dir
                 @test isa(tree, LibGit2.GitTree)
                 @test isa(LibGit2.GitObject(repo, "HEAD^{tree}"), LibGit2.GitTree)
                 @test LibGit2.Consts.OBJECT(typeof(tree)) == LibGit2.Consts.OBJ_TREE
-                @test count(tree) == 1
+                @test LibGit2.count(tree) == 1
 
                 # test showing the GitTree and its entries
                 tree_str = sprint(show, tree)
@@ -1077,7 +1077,7 @@ mktempdir() do dir
 
                 # test properties of the diff_tree
                 diff = LibGit2.diff_tree(repo, tree, "", cached=true)
-                @test count(diff) == 1
+                @test LibGit2.count(diff) == 1
                 @test_throws BoundsError diff[0]
                 @test_throws BoundsError diff[2]
                 @test LibGit2.Consts.DELTA_STATUS(diff[1].status) == LibGit2.Consts.DELTA_MODIFIED
@@ -1396,11 +1396,11 @@ mktempdir() do dir
                 end
                 # test with specified oid
                 LibGit2.with(LibGit2.GitRevWalker(repo)) do walker
-                    @test count((oid,repo)->(oid == commit_oid1), walker, oid=commit_oid1, by=LibGit2.Consts.SORT_TIME) == 1
+                    @test LibGit2.count((oid,repo)->(oid == commit_oid1), walker, oid=commit_oid1, by=LibGit2.Consts.SORT_TIME) == 1
                 end
                 # test without specified oid
                 LibGit2.with(LibGit2.GitRevWalker(repo)) do walker
-                    @test count((oid,repo)->(oid == commit_oid1), walker, by=LibGit2.Consts.SORT_TIME) == 1
+                    @test LibGit2.count((oid,repo)->(oid == commit_oid1), walker, by=LibGit2.Consts.SORT_TIME) == 1
                 end
             finally
                 close(repo)
@@ -1428,10 +1428,10 @@ mktempdir() do dir
 
                 LibGit2.remove!(repo, test_file)
                 LibGit2.read!(repo)
-                @test count(idx) == 0
+                @test LibGit2.count(idx) == 0
                 LibGit2.add!(repo, test_file)
                 LibGit2.update!(repo, test_file)
-                @test count(idx) == 1
+                @test LibGit2.count(idx) == 1
             end
 
             # check non-existent file status


### PR DESCRIPTION
This is already done for `LibGit2.merge!` (https://github.com/JuliaLang/julia/pull/24818) and `LibGit2.push!` (https://github.com/JuliaLang/julia/pull/24837). As an extra bonus this fixes some link problems in the doc generation.

~ATM this also includes #26971 since otherwise we don't run LibGit2 tests on CI, things passes locally so should be fine.~