### PR TITLE
Fix documentation warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -725,9 +725,9 @@ Deprecated or removed
   * `slicedim(A, d, i)` has been deprecated in favor of `copy(selectdim(A, d, i))`. The new
     `selectdim` function now always returns a view into `A`; in many cases the `copy` is
     not necessary. Previously, `slicedim` on a vector `V` over dimension `d=1` and scalar
-	index `i` would return the just selected element (unless `V` was a `BitVector`). This
-	has now been made consistent: `selectdim` now always returns a view into the original
-	array, with a zero-dimensional view in this specific case ([#26009]).
+    index `i` would return the just selected element (unless `V` was a `BitVector`). This
+    has now been made consistent: `selectdim` now always returns a view into the original
+    array, with a zero-dimensional view in this specific case ([#26009]).
 
   * `whos` has been renamed `varinfo`, and now returns a markdown table instead of printing
     output ([#12131]).

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -30,8 +30,7 @@ Base.trues
 Base.falses
 Base.fill
 Base.fill!
-Base.similar(::AbstractArray)
-Base.similar(::Any, ::Tuple)
+Base.similar
 ```
 
 ## Basic functions

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -316,6 +316,7 @@ Base.AsyncCondition(::Function)
 ```@docs
 Base.nameof(::Module)
 Base.parentmodule
+Base.moduleroot
 Base.@__MODULE__
 Base.fullname
 Base.names

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -122,12 +122,11 @@ Base.Rounding.RoundNearestTiesUp
 Base.Rounding.RoundToZero
 Base.Rounding.RoundUp
 Base.Rounding.RoundDown
-Base.round{T <: AbstractFloat, MR, MI}(::Complex{T}, ::RoundingMode{MR}, ::RoundingMode{MI})
+Base.round(::Complex{<: AbstractFloat}, ::RoundingMode, ::RoundingMode)
 Base.ceil
 Base.floor
 Base.trunc
 Base.unsafe_trunc
-Base.signif
 Base.min
 Base.max
 Base.minmax

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -58,7 +58,7 @@ Lazy adjoint (conjugate transposition) (also postfix `'`).
 Note that `adjoint` is applied recursively to elements.
 
 This operation is intended for linear algebra usage - for general data manipulation see
-[`permutedims`](@ref).
+[`permutedims`](@ref Base.permutedims).
 
 # Examples
 ```jldoctest
@@ -83,7 +83,7 @@ but not always, yields `Transpose(A)`, where `Transpose` is a lazy transpose wra
 that this operation is recursive.
 
 This operation is intended for linear algebra usage - for general data manipulation see
-[`permutedims`](@ref), which is non-recursive.
+[`permutedims`](@ref Base.permutedims), which is non-recursive.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -153,7 +153,7 @@ Eagerly evaluate the lazy matrix transpose/adjoint.
 Note that the transposition is applied recursively to elements.
 
 This operation is intended for linear algebra usage - for general data manipulation see
-[`permutedims`](@ref), which is non-recursive.
+[`Base.permutedims`](@ref), which is non-recursive.
 
 # Examples
 ```jldoctest

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -131,7 +131,7 @@ There are three logger types provided by the library.  [`ConsoleLogger`](@ref)
 is the default logger you see when starting the REPL.  It displays events in a
 readable text format and tries to give simple but user friendly control over
 formatting and filtering.  [`NullLogger`](@ref) is a convenient way to drop all
-messages where necessary; it is the logging equivalent of the [`DevNull`](@ref)
+messages where necessary; it is the logging equivalent of the [`devnull`](@ref)
 stream.  [`SimpleLogger`](@ref) is a very simplistic text formatting logger,
 mainly useful for debugging the logging system itself.
 
@@ -147,15 +147,15 @@ messages that will be discarded:
    [`disable_logging`](@ref)).  This is a crude but extremely cheap global
    setting.
 2. The current logger state is looked up and the message level checked against the
-   logger's cached minimum level, as found by calling [`min_enabled_level`](@ref).
+   logger's cached minimum level, as found by calling [`Logging.min_enabled_level`](@ref).
    This behavior can be overridden via environment variables (more on this later).
-3. The [`shouldlog`](@ref) function is called with the current logger, taking
+3. The [`Logging.shouldlog`](@ref) function is called with the current logger, taking
    some minimal information (level, module, group, id) which can be computed
    statically.  Most usefully, `shouldlog` is passed an event `id` which can be
    used to discard events early based on a cached predicate.
 
 If all these checks pass, the message and key--value pairs are evaluated in full
-and passed to the current logger via the [`handle_message`](@ref) function.
+and passed to the current logger via the [`Logging.handle_message`](@ref) function.
 `handle_message()` may perform additional filtering as required and display the
 event to the screen, save it to a file, etc.
 
@@ -163,7 +163,7 @@ Exceptions that occur while generating the log event are captured and logged
 by default.  This prevents individual broken events from crashing the
 application, which is helpful when enabling little-used debug events in a
 production system.  This behavior can be customized per logger type by
-extending [`catch_exceptions`](@ref).
+extending [`Logging.catch_exceptions`](@ref).
 
 ## Testing log events
 
@@ -208,13 +208,13 @@ Logging.LogLevel
 Event processing is controlled by overriding functions associated with
 `AbstractLogger`:
 
-| Methods to implement          |                        | Brief description                        |
-|:----------------------------- |:---------------------- |:---------------------------------------- |
-| [`handle_message`](@ref)      |                        | Handle a log event                       |
-| [`shouldlog`](@ref)           |                        | Early filtering of events                |
-| [`min_enabled_level`](@ref)   |                        | Lower bound for log level of accepted events |
-| **Optional methods**          | **Default definition** | **Brief description**                    |
-| [`catch_exceptions`](@ref)    | `true`                 | Catch exceptions during event evaluation |
+| Methods to implement                |                        | Brief description                        |
+|:----------------------------------- |:---------------------- |:---------------------------------------- |
+| [`Logging.handle_message`](@ref)    |                        | Handle a log event                       |
+| [`Logging.shouldlog`](@ref)         |                        | Early filtering of events                |
+| [`Logging.min_enabled_level`](@ref) |                        | Lower bound for log level of accepted events |
+| **Optional methods**                | **Default definition** | **Brief description**                    |
+| [`Logging.catch_exceptions`](@ref)  | `true`                 | Catch exceptions during event evaluation |
 
 
 ```@docs


### PR DESCRIPTION
This fixes almost all remaining warnings when generating the documenation. It is mostly fixes to broken links. Also changes some tabs -> spaces in NEWS.md that trips up the markdown parser.