### PR TITLE
Deprecate map(f, ::AbstractSet)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -959,6 +959,9 @@ Deprecated or removed
   * `map` on dictionaries previously operated on `key=>value` pairs. This behavior is deprecated,
     and in the future `map` will operate only on values ([#5794]).
 
+  * `map` on sets previously returned a `Set`, possibly changing the order or number of elements. This
+    behavior is deprecated and in the future `map` will preserve order and number of elements ([#26980]).
+
   * Previously, broadcast defaulted to treating its arguments as scalars if they were not
     arrays. This behavior is deprecated, and in the future `broadcast` will default to
     iterating over all its arguments. Wrap arguments you wish to be treated as scalars with

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1980,7 +1980,7 @@ function map!(f::F, dest::AbstractArray, A::AbstractArray) where F
 end
 
 # map on collections
-map(f, A::Union{AbstractArray,AbstractSet}) = collect_similar(A, Generator(f,A))
+map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
 # default to returning an Array for `map` on general iterators
 """

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -576,6 +576,8 @@ import .Iterators.enumerate
 
 # issue #5794
 @deprecate map(f, d::T) where {T<:AbstractDict}  T( f(p) for p in pairs(d) )
+# issue #26359 - map over sets
+@deprecate map(f, s::AbstractSet)  Set( f(v) for v in s )
 
 # issue #17086
 @deprecate isleaftype isconcretetype

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -609,7 +609,7 @@ let b = ['0':'9';'A':'Z';'a':'z']
             if eltype(c) == Char
                 @test issubset(s, c)
             else # UInt8
-                @test issubset(s, map(Char, c))
+                @test issubset(s, Set(Char(v) for v in c))
             end
         end
     end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -926,7 +926,7 @@ end
         @test i isa AbstractSet
         @test i == Set([1])
     end
-    @test map(string, keys(d)) == Set(["1","3"])
+    @test Set(string(k) for k in keys(d)) == Set(["1","3"])
 end
 
 @testset "find" begin


### PR DESCRIPTION
`map` on sets previously returned a `Set`, possibly changing the order or number of elements. This
behavior is deprecated and in the future `map` will preserve order and number of elements.

Fixes #26359.