### PR TITLE
Make Refs fully container-like

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -97,7 +97,6 @@ DefaultArrayStyle{M}(::Val{N}) where {N,M} = DefaultArrayStyle{N}()
 const DefaultVectorStyle = DefaultArrayStyle{1}
 const DefaultMatrixStyle = DefaultArrayStyle{2}
 BroadcastStyle(::Type{<:AbstractArray{T,N}}) where {T,N} = DefaultArrayStyle{N}()
-BroadcastStyle(::Type{<:Ref}) = DefaultArrayStyle{0}()
 BroadcastStyle(::Type{T}) where {T} = DefaultArrayStyle{ndims(T)}()
 
 # `ArrayConflict` is an internal type signaling that two or more different `AbstractArrayStyle`
@@ -204,7 +203,6 @@ Base.similar(bc::Broadcasted{ArrayConflict}, ::Type{Bool}) =
 ## Computing the result's axes. Most types probably won't need to specialize this.
 broadcast_axes() = ()
 broadcast_axes(A::Tuple) = (OneTo(length(A)),)
-broadcast_axes(A::Ref) = ()
 @inline broadcast_axes(A) = axes(A)
 """
     Base.broadcast_axes(A)

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -35,6 +35,14 @@ end
 
 eltype(x::Type{<:Ref{T}}) where {T} = @isdefined(T) ? T : Any
 convert(::Type{Ref{T}}, x::Ref{T}) where {T} = x
+size(x::Ref) = ()
+axes(x::Ref) = ()
+length(x::Ref) = 1
+ndims(x::Ref) = 0
+ndims(::Type{<:Ref}) = 0
+iterate(r::Ref) = (r[], nothing)
+iterate(r::Ref, s) = nothing
+IteratorSize(::Type{<:Ref}) = HasShape{0}()
 
 # create Ref objects for general object conversion
 unsafe_convert(::Type{Ref{T}}, x::Ref{T}) where {T} = unsafe_convert(Ptr{T}, x)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6051,6 +6051,9 @@ g25907b(x) = x[1]::Complex
 
 #issue #26363
 @test eltype(Ref(Float64(1))) === Float64
+@test ndims(Ref(1)) === 0
+@test collect(Ref(1)) == [v for v in Ref(1)] == fill(1)
+@test axes(Ref(1)) === size(Ref(1)) === ()
 
 # issue #23206
 g1_23206(::Tuple{Type{Int}, T}) where T = 0


### PR DESCRIPTION
Give them iteration and all the associated behaviors surrounding iteration and indexing.