### PR TITLE
[GCLowering] Fix phis of unions

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1846,6 +1846,11 @@ static void AddInPredLiveOuts(BasicBlock *BB, BitVector &LiveIn, State &S)
     while (!WorkList.empty()) {
         BB = &*WorkList.back();
         WorkList.pop_back();
+        // Nothing is live at function entry
+        if (BB == &S.F->getEntryBlock()) {
+            LiveIn.reset();
+            return;
+        }
         for (BasicBlock *Pred : predecessors(BB)) {
             if (!Visited.insert(Pred).second)
                 continue;
@@ -1860,6 +1865,8 @@ static void AddInPredLiveOuts(BasicBlock *BB, BitVector &LiveIn, State &S)
                 } else {
                     LiveIn &= S.LiveSets[LastSP];
                 }
+                if (LiveIn.empty()) // Just a compiler performance optimization
+                    return;
             }
         }
     }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1085,6 +1085,7 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                     // Known functions emitted in codegen that are not safepoints
                     if (callee == pointer_from_objref_func || callee == gc_preserve_begin_func ||
                         callee == gc_preserve_end_func || callee == typeof_func ||
+                        callee == ptls_getter ||
                         callee == write_barrier_func || callee->getName() == "memcmp") {
                         continue;
                     }


### PR DESCRIPTION
This fixes gc lowering for phis of the form:
```
%phi = phi {%jl_value_t addrspace(10)*, i8} [%aunion, %a], [%bunion, %b]
```
This kind of struct (used by the tagged union representation) has special support
in GC lowering. After optimization, these structs often survive quite far as a
struct (i.e. the destructuring of them is often elided). We simply need to extend
this support to the cases that handle phi and select nodes.

Fixes crashes with the new optimizer enabled noted in #26925