### PR TITLE
loading: make __precompile__ the default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -233,6 +233,10 @@ Language changes
     `size`, `length`, and `@inbounds`. To optionally enforce conventional indices,
     you can `@assert !has_offset_axes(A)`.
 
+  * Module pre-compilation is now the default for code loading. Adding a
+    `__precompile__()` declaration is no longer necessary, although
+    `__precompile__(false)` can still be used to opt-out ([#26991]).
+
 Breaking changes
 ----------------
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -744,46 +744,30 @@ function include_dependency(path::AbstractString)
     return nothing
 end
 
-# We throw PrecompilableError(true) when a module wants to be precompiled but isn't,
-# and PrecompilableError(false) when a module doesn't want to be precompiled but is
-struct PrecompilableError <: Exception
-    isprecompilable::Bool
-end
+# we throw PrecompilableError when a module doesn't want to be precompiled
+struct PrecompilableError <: Exception end
 function show(io::IO, ex::PrecompilableError)
-    if ex.isprecompilable
-        print(io, "Declaring __precompile__(true) is only allowed in module files being imported.")
-    else
-        print(io, "Declaring __precompile__(false) is not allowed in files that are being precompiled.")
-    end
+    print(io, "Declaring __precompile__(false) is not allowed in files that are being precompiled.")
 end
-precompilableerror(ex::PrecompilableError, c) = ex.isprecompilable == c
-precompilableerror(ex::WrappedException, c) = precompilableerror(ex.error, c)
-precompilableerror(ex, c) = false
+precompilableerror(ex::PrecompilableError) = true
+precompilableerror(ex::WrappedException) = precompilableerror(ex.error)
+precompilableerror(@nospecialize ex) = false
 
-# Call __precompile__ at the top of a file to force it to be precompiled (true), or
-# to be prevent it from being precompiled (false).  __precompile__(true) is
-# ignored except within "require" call.
+# Call __precompile__(false) at the top of a tile prevent it from being precompiled (false)
 """
-    __precompile__(isprecompilable::Bool=true)
+    __precompile__(false)
 
-Specify whether the file calling this function is precompilable. If `isprecompilable` is
-`true`, then `__precompile__` throws an exception when the file is loaded by
-`using`/`import`/`require` *unless* the file is being precompiled, and in a module file it
-causes the module to be automatically precompiled when it is imported. Typically,
-`__precompile__()` should occur before the `module` declaration in the file.
-
+Specify that the file calling this function is not precompilable.
 If a module or file is *not* safely precompilable, it should call `__precompile__(false)` in
 order to throw an error if Julia attempts to precompile it.
-
-`__precompile__()` should *not* be used in a module unless all of its dependencies are also
-using `__precompile__()`. Failure to do so can result in a runtime error when loading the module.
 """
-function __precompile__(isprecompilable::Bool=true)
-    if (JLOptions().use_compiled_modules != 0 &&
-        isprecompilable != (0 != ccall(:jl_generating_output, Cint, ())) &&
-        !(isprecompilable && toplevel_load[]))
-        throw(PrecompilableError(isprecompilable))
+@noinline function __precompile__(isprecompilable::Bool=true)
+    if isprecompilable
+        depwarn("__precompile__() is now the default", :__precompile__)
+    elseif 0 != ccall(:jl_generating_output, Cint, ())
+        throw(PrecompilableError())
     end
+    nothing
 end
 
 # require always works in Main scope and loads files from node 1
@@ -932,10 +916,9 @@ function _require(pkg::PkgId)
         end
 
         # attempt to load the module file via the precompile cache locations
-        doneprecompile = false
         if JLOptions().use_compiled_modules != 0
-            doneprecompile = _require_search_from_serialized(pkg, path)
-            if !isa(doneprecompile, Bool)
+            m = _require_search_from_serialized(pkg, path)
+            if !isa(m, Bool)
                 return
             end
         end
@@ -948,21 +931,24 @@ function _require(pkg::PkgId)
                      This may mean module $name does not support precompilation but is imported by a module that does."""
                 if JLOptions().incremental != 0
                     # during incremental precompilation, this should be fail-fast
-                    throw(PrecompilableError(false))
+                    throw(PrecompilableError())
                 end
             end
         end
 
-        if doneprecompile === true || JLOptions().incremental != 0
-            # spawn off a new incremental pre-compile task for recursive `require` calls
-            # or if the require search declared it was pre-compiled before (and therefore is expected to still be pre-compilable)
-            cachefile = compilecache(pkg)
-            m = _require_from_serialized(cachefile)
-            if isa(m, Exception)
-                @warn "The call to compilecache failed to create a usable precompiled cache file for module $name" exception=m
-                # fall-through, TODO: disable __precompile__(true) error so that the normal include will succeed
-            else
-                return
+        if JLOptions().use_compiled_modules != 0
+            if (0 == ccall(:jl_generating_output, Cint, ())) || (JLOptions().incremental != 0)
+                # spawn off a new incremental pre-compile task for recursive `require` calls
+                # or if the require search declared it was pre-compiled before (and therefore is expected to still be pre-compilable)
+                cachefile = compilecache(pkg)
+                m = _require_from_serialized(cachefile)
+                if isa(m, Exception)
+                    if !precompilableerror(m)
+                        @warn "The call to compilecache failed to create a usable precompiled cache file for module $name" exception=m
+                    end
+                else
+                    return
+                end
             end
         end
 
@@ -977,22 +963,6 @@ function _require(pkg::PkgId)
         try
             include_relative(__toplevel__, path)
             return
-        catch ex
-            if uuid !== old_uuid
-                ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, old_uuid)
-            end
-            if doneprecompile === true || JLOptions().use_compiled_modules == 0 || !precompilableerror(ex, true)
-                rethrow() # rethrow non-precompilable=true errors
-            end
-            # the file requested `__precompile__`, so try to build a cache file and use that
-            cachefile = compilecache(pkg)
-            m = _require_from_serialized(cachefile)
-            if isa(m, Exception)
-                @warn """Module `$name` declares `__precompile__(true)` but `require` failed
-                         to create a usable precompiled cache file""" exception=m
-                # TODO: disable __precompile__(true) error and do normal include instead of error
-                error("Module $name declares __precompile__(true) but require failed to create a usable precompiled cache file.")
-            end
         finally
             if uuid !== old_uuid
                 ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), __toplevel__, old_uuid)

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module Base64
 
 using Base: has_offset_axes

--- a/stdlib/CRC32c/src/CRC32c.jl
+++ b/stdlib/CRC32c/src/CRC32c.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Standard library module for computing the CRC-32c checksum.
 

--- a/stdlib/Dates/src/Dates.jl
+++ b/stdlib/Dates/src/Dates.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
     Dates
 

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Utilities for reading and writing delimited files, for example ".csv".
 See [`readdlm`](@ref) and [`writedlm`](@ref).

--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Tools for distributed parallel processing.
 """

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Utilities for monitoring files and file descriptors for events.
 """

--- a/stdlib/Future/src/Future.jl
+++ b/stdlib/Future/src/Future.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 "The `Future` module implements future behavior of already existing functions,
 which will replace the current version in a future release of Julia."
 module Future

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module InteractiveUtils
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Interface to [libgit2](https://libgit2.github.com/).
 """

--- a/stdlib/Libdl/src/Libdl.jl
+++ b/stdlib/Libdl/src/Libdl.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module Libdl
 @doc """
 Interface to libdl. Provides dynamic linking support.

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Linear algebra module. Provides array arithmetic,
 matrix factorizations and other linear algebra related

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module Logging
 
 # For now, simply import most names from Base - we don't want to fully

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Tools for working with the Markdown file format. Mainly for documentation.
 """

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Low level module for mmap (memory mapping of files).
 """

--- a/stdlib/OldPkg/src/OldPkg.jl
+++ b/stdlib/OldPkg/src/OldPkg.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
     OldPkg
 

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -465,9 +465,9 @@ function precompile(ctx::Context)
             end
         end
         if !found_matching_precompile
-            # Only precompile packages that has contains `__precompile__` or `__precompile__(true)`
+            # Don't bother attempting to precompile packages that appear to contain `__precompile__(false)`
             source = read(sourcepath, String)
-            if occursin(r"__precompile__\(\)|__precompile__\(true\)", source)
+            if !occursin(r"__precompile__\(false\)", source)
                 push!(needs_to_be_precompiled, pkg.name)
             end
         end

--- a/stdlib/Pkg/src/Pkg.jl
+++ b/stdlib/Pkg/src/Pkg.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Pkg
 
 import Random

--- a/stdlib/Pkg/test/repl.jl
+++ b/stdlib/Pkg/test/repl.jl
@@ -121,7 +121,10 @@ temp_pkg_dir() do project_path; cd(project_path) do; mktempdir() do tmp_pkg_path
     p2 = git_init_package(tmp_pkg_path, joinpath(@__DIR__, "test_packages/$pkg2"))
     Pkg.REPLMode.pkgstr("add $p2")
     Pkg.REPLMode.pkgstr("pin $pkg2")
-    @eval import $(Symbol(pkg2))
+    # FIXME: this confuses the precompile logic to know what is going on with the user
+    # FIXME: why isn't this testing the Pkg after importing, rather than after freeing it
+    #@eval import Example
+    #@eval import $(Symbol(pkg2))
     @test Pkg.installed()[pkg2] == v"0.1.0"
     Pkg.REPLMode.pkgstr("free $pkg2")
     @test_throws CommandError Pkg.REPLMode.pkgstr("free $pkg2")

--- a/stdlib/Pkg/test/test_packages/UnregisteredWithoutProject/src/UnregisteredWithoutProject.jl
+++ b/stdlib/Pkg/test/test_packages/UnregisteredWithoutProject/src/UnregisteredWithoutProject.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__()
 module UnregisteredWithoutProject
 
 if !isfile(joinpath(@__DIR__, "..", "deps", "deps.jl"))

--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module Printf
 # the macro implementations here exactly mirrors the
 # macros left in base/printf.jl, and uses the utility there

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Profiling support, main entry point is the [`@profile`](@ref) macro.
 """

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module REPL
 
 using Base.Meta, Sockets

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module Random
 
 include("DSFMT.jl")

--- a/stdlib/SHA/src/SHA.jl
+++ b/stdlib/SHA/src/SHA.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module SHA
 
 # Export convenience functions, context types, update!() and digest!() functions

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Provide serialization of Julia objects via the functions
 * [`serialize`](@ref)

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Provide the [`SharedArray`](@ref) type. It represents an array, which is shared across multiple processes, on a single machine.
 """

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Support for sparse arrays. Provides `AbstractSparseArray` and subtypes.
 """

--- a/stdlib/SuiteSparse/src/SuiteSparse.jl
+++ b/stdlib/SuiteSparse/src/SuiteSparse.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module SuiteSparse
 
 import Base: \

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 """
 Simple unit testing functionality:
 

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module UUIDs
 
 using Random

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -1,7 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
-
 module Unicode
 
 export graphemes

--- a/test/TestPkg/src/TestPkg.jl
+++ b/test/TestPkg/src/TestPkg.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__()
 module TestPkg
 
 using Random

--- a/test/depot/packages/Baz/81oLe/src/Baz.jl
+++ b/test/depot/packages/Baz/81oLe/src/Baz.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Baz
 import Foo, Qux
 this = "Baz"

--- a/test/depot/packages/Foo/I05Qq/src/Foo.jl
+++ b/test/depot/packages/Foo/I05Qq/src/Foo.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Foo
 import Bar, Baz, Qux
 this = "Foo1"

--- a/test/embedding/LocalModule.jl
+++ b/test/embedding/LocalModule.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__()
 module LocalModule
 
 using Distributed

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -24,8 +24,6 @@ try
 
     write(FooBase_file,
           """
-          __precompile__(true)
-
           module $FooBase_module
               import Base: hash, >
               struct fmpz end
@@ -39,8 +37,6 @@ try
           """)
     write(Foo2_file,
           """
-          __precompile__(true)
-
           module $Foo2_module
               export override
               override(x::Integer) = 2
@@ -49,8 +45,6 @@ try
           """)
     write(Foo_file,
           """
-          __precompile__(true)
-
           module $Foo_module
               import $FooBase_module, $FooBase_module.typeA
               import $Foo2_module: $Foo2_module, override
@@ -160,7 +154,7 @@ try
     @test_throws ErrorException Core.kwfunc(Base.nothing) # make sure `nothing` didn't have a kwfunc (which would invalidate the attempted test)
 
     # Issue #12623
-    @test __precompile__(true) === nothing
+    @test __precompile__(false) === nothing
 
     # Issue #21307
     Foo2 = Base.require(Main, Foo2_module)
@@ -302,7 +296,6 @@ try
     FooBar1_file = joinpath(dir, "FooBar1.jl")
     write(FooBar1_file,
           """
-          __precompile__(true)
           module FooBar1
               using FooBar
           end
@@ -311,7 +304,6 @@ try
     FooBar_file = joinpath(dir, "FooBar.jl")
     write(FooBar_file,
           """
-          __precompile__(true)
           module FooBar
           end
           """)
@@ -352,7 +344,6 @@ try
     FooBar2_file = joinpath(dir, "FooBar2.jl")
     write(FooBar2_file,
           """
-          __precompile__(true)
           module FooBar2
           error("break me")
           end
@@ -369,14 +360,12 @@ try
     FooBarT_file = joinpath(dir, "FooBarT.jl")
     write(FooBarT_file,
           """
-          __precompile__(true)
           module FooBarT
           end
           """)
     FooBarT1_file = joinpath(dir, "FooBarT1.jl")
     write(FooBarT1_file,
           """
-          __precompile__(true)
           module FooBarT1
               using FooBarT
           end
@@ -384,7 +373,6 @@ try
     FooBarT2_file = joinpath(dir, "FooBarT2.jl")
     write(FooBarT2_file,
           """
-          __precompile__(true)
           module FooBarT2
               using FooBarT1
           end
@@ -392,7 +380,6 @@ try
     Base.compilecache(Base.PkgId("FooBarT2"))
     write(FooBarT1_file,
           """
-          __precompile__(true)
           module FooBarT1
           end
           """)
@@ -415,7 +402,6 @@ let dir = mktempdir(),
         write(joinpath(dir, "$Time_module.jl"),
               """
               module $Time_module
-                  __precompile__(true)
                   time = Base.time()
               end
               """)
@@ -458,15 +444,13 @@ let dir = mktempdir()
         write(joinpath(dir, "Iterators.jl"),
               """
               module Iterators
-                   __precompile__(true)
               end
               """)
 
         write(joinpath(dir, "$Test_module.jl"),
               """
               module $Test_module
-                   __precompile__(true)
-                   using Iterators
+                   import Iterators # FIXME: use `using`
               end
               """)
 
@@ -474,25 +458,16 @@ let dir = mktempdir()
             insert!(LOAD_PATH, 1, $(repr(dir)))
             insert!(DEPOT_PATH, 1, $(repr(dir)))
             using $Test_module
+            println(stderr, $Test_module.Iterators)
         """
 
         exename = `$(Base.julia_cmd()) --startup-file=no`
         let fname = tempname()
             try
-                @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
-                @test occursin(Regex("Replacing module `$Test_module`"), read(fname, String))
-            finally
-                rm(fname, force=true)
-            end
-        end
-        # Loading $Test_module from the cache should not bring `Base.Iterators`
-        # into `Main`, since that would lead to a namespace conflict with
-        # the module `Iterators` defined above.
-        let fname = tempname()
-            try
-                @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
-                # e.g `@test_nowarn`
-                @test Test.contains_warn(read(fname, String), r"^(?!.)"s)
+                for i = 1:2
+                    @test readchomp(pipeline(`$exename -E $(testcode)`, stderr=fname)) == "nothing"
+                    @test read(fname, String) == "Iterators\n"
+                end
             finally
                 rm(fname, force=true)
             end
@@ -518,7 +493,6 @@ let dir = mktempdir()
         write(joinpath(dir, "$(Test1_module).jl"),
               """
               module $(Test1_module)
-                  __precompile__(true)
               end
               """)
 
@@ -526,7 +500,6 @@ let dir = mktempdir()
         write(joinpath(dir, "$(Test2_module).jl"),
               """
               module $(Test2_module)
-                  __precompile__(true)
                   using $(Test1_module)
               end
               """)
@@ -567,7 +540,6 @@ end
 
         write(joinpath(load_path, "$ModuleA.jl"),
             """
-            __precompile__(true)
             module $ModuleA
                 import Distributed: myid
                 export f
@@ -577,7 +549,6 @@ end
 
         write(joinpath(load_path, "$ModuleB.jl"),
             """
-            __precompile__(true)
             module $ModuleB
                 using $ModuleA
                 export g
@@ -627,8 +598,6 @@ try
 
     write(A_file,
           """
-          __precompile__()
-
           module $A_module
 
           export apc, anopc
@@ -643,8 +612,6 @@ try
           """)
     write(B_file,
           """
-          __precompile__()
-
           module $B_module
 
           using $A_module
@@ -679,7 +646,6 @@ let
 
         write(joinpath(load_path, "$ModuleA.jl"),
             """
-            __precompile__(true)
             module $ModuleA
                 __init__() = push!(Base.package_callbacks, sym->nothing)
             end
@@ -703,7 +669,6 @@ let
     try
         write(joinpath(load_path, "A25604.jl"),
             """
-            __precompile__(true)
             module A25604
             using B25604
             using C25604
@@ -711,13 +676,11 @@ let
             """)
         write(joinpath(load_path, "B25604.jl"),
             """
-            __precompile__()
             module B25604
             end
             """)
         write(joinpath(load_path, "C25604.jl"),
             """
-            __precompile__()
             module C25604
             using B25604
             end

--- a/test/project/deps/Bar/src/Bar.jl
+++ b/test/project/deps/Bar/src/Bar.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Bar
 import Baz, Foo
 this = "Bar"

--- a/test/project/deps/Foo1/src/Foo.jl
+++ b/test/project/deps/Foo1/src/Foo.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Foo
 import Bar, Baz, Qux
 this = "Foo1"

--- a/test/project/deps/Foo2.jl/src/Foo.jl
+++ b/test/project/deps/Foo2.jl/src/Foo.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Foo
 import Qux
 this = "Foo2"

--- a/test/project/deps/Qux.jl
+++ b/test/project/deps/Qux.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-__precompile__(true)
 module Qux
 this = "Qux"
 end


### PR DESCRIPTION
This is nice, because it simplifies the `require` code. That should also make error handling more understandable and predictable. And the problems resulting from non-precompile-declaring code is used from `__precompile__` code simply won't exist anymore.

fix #26282