### PR TITLE
Re-enable strict=true for doc generation

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -162,6 +162,22 @@ julia> length([1 2; 3 4])
 4
 ```
 """
+length
+
+"""
+    length(A::AbstractArray)
+
+Return the number of elements in the array, defaults to `prod(size(A))`.
+
+# Examples
+```jldoctest
+julia> length([1, 2, 3, 4])
+4
+
+julia> length([1 2; 3 4])
+4
+```
+"""
 length(t::AbstractArray) = (@_inline_meta; prod(size(t)))
 _length(A::AbstractArray) = (@_inline_meta; prod(map(unsafe_length, axes(A)))) # circumvent missing size
 _length(A) = (@_inline_meta; length(A))

--- a/base/array.jl
+++ b/base/array.jl
@@ -231,6 +231,8 @@ Create a shallow copy of `x`: the outer structure is copied, but not all interna
 For example, copying an array produces a new array with identically-same elements as the
 original.
 """
+copy
+
 copy(a::T) where {T<:Array} = ccall(:jl_array_copy, Ref{T}, (Any,), a)
 
 # reshaping to same # of dimensions

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -154,7 +154,7 @@ makedocs(
     doctest   = ("doctest-fix" in ARGS) ? (:fix) : ("doctest" in ARGS),
     linkcheck = "linkcheck" in ARGS,
     linkcheck_ignore = ["https://bugs.kde.org/show_bug.cgi?id=136779"], # fails to load from nanosoldier?
-    strict    = false,
+    strict    = true,
     checkdocs = :none,
     format    = "pdf" in ARGS ? :latex : :html,
     sitename  = "The Julia Language",

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -157,7 +157,7 @@ Base.invperm
 Base.isperm
 Base.permute!(::Any, ::AbstractVector)
 Base.invpermute!
-Base.reverse
+Base.reverse(::AbstractVector; kwargs...)
 Base.reverseind
 Base.reverse!
 ```

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -127,7 +127,6 @@ Base.last
 Base.step
 Base.collect(::Any)
 Base.collect(::Type, ::Any)
-Base.issubset(::Any, ::Any)
 Base.filter
 Base.filter!
 Base.replace(::Any, ::Pair...)

--- a/stdlib/LinearAlgebra/src/transpose.jl
+++ b/stdlib/LinearAlgebra/src/transpose.jl
@@ -153,7 +153,7 @@ Eagerly evaluate the lazy matrix transpose/adjoint.
 Note that the transposition is applied recursively to elements.
 
 This operation is intended for linear algebra usage - for general data manipulation see
-[`Base.permutedims`](@ref), which is non-recursive.
+[`permutedims`](@ref Base.permutedims), which is non-recursive.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
We have had this turned off since 87913c6c6f518fd8c54002ca437d1fd8de8854f3 which is bad because we introduce new doc-bugs every week.

I have finally managed to track down the last errors and this PR should now pass with `strict=true`. 🎉 

~ATM this also includes #26973. Relevant change to review here is 33b1014918e89deaa01a3eaee35d38dec51bde46 + 714e3386cb32716487e7706d497f1e3daccd0c0c.~