### PR TITLE
deprecate lu/eig/schur/svd/lq in favor of *fact counterparts and factorization destructuring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1040,6 +1040,46 @@ Deprecated or removed
     (`S, T, Q, Z, α, β = schurfact(A, B)`) or as a `GeneralizedSchur` object
     (`schurf = schurfact(A, B)`) ([#26997]).
 
+  * `svd(A::Abstractarray; thin=true)` has been deprecated in favor of
+    `svdfact(A; full=false)`. Note that the `thin` keyword and its replacement
+    `full` have opposite meanings. Additionally, whereas `svd` returns a
+    tuple of arrays `(U, S, V)` such that `A ≈ U*Diagonal(S)*V'`, `svdfact` returns
+    an `SVD` object that nominally provides `U, S, Vt` such that `A ≈ U*Diagonal(S)*Vt`.
+    So for a direct replacement,
+    use `((U, S, Vt) = svdfact(A[; full=...]); (U, S, copy(Vt')))`. But going forward,
+    consider using the direct result of `svdfact(A[; full=...])` instead,
+    either destructured into its components (`U, S, Vt = svdfact(A[; full=...])`)
+    or as an `SVD` object (`svdf = svdfact(A[; full=...])`) ([#26997]).
+
+  * `svd(x::Number; thin=true)` has been deprecated in favor of
+    `svdfact(x; full=false)`. Note that the `thin` keyword and its replacement
+    `full` have opposite meanings. Additionally, whereas `svd(x::Number[; thin=...])`
+    returns a tuple of numbers `(u, s, v)` such that `x ≈ u*s*conj(v)`,
+    `svdfact(x::Number[; full=...])` returns
+    an `SVD` object that nominally provides `u, s, vt` such that `x ≈ u*Diagonal(s)*conj(vt)`.
+    So for a direct replacement,
+    use `((u, s, vt) = first.((svdfact(x[; full=...]...,)); (u, s, conj(vt)))`.
+    But going forward,
+    consider using the direct result of `svdfact(x[; full=...])` instead,
+    either destructured into its components (`U, S, Vt = svdfact(A[; full=...])`)
+    or as an `SVD` object (`svdf = svdfact(x[; full=...])`) ([#26997]).
+
+  * `svd(A::Abstractarray, B::AbstractArray)` has been deprecated in favor of
+    `svdfact(A, B)`. Whereas the former returns a tuple of arrays,
+    the latter returns a `GeneralizedSVD` object. So for a direct replacement,
+    use `(svdfact(A, B)...,)`. But going forward,
+    consider using the direct result of `svdfact(A, B)` instead,
+    either destructured into its components (`U, V, Q, D1, D2, R0 = svdfact(A, B)`)
+    or as a `GeneralizedSVD` object (`gsvdf = svdfact(A, B)`) ([#26997]).
+
+  * `svd(x::Number, y::Number)` has been deprecated in favor of
+    `svdfact(x, y)`. Whereas the former returns a tuple of numbers,
+    the latter returns a `GeneralizedSVD` object. So for a direct replacement,
+    use `first.((svdfact(x, y)...,))`. But going forward,
+    consider using the direct result of `svdfact(x, ys)` instead,
+    either destructured into its components (`U, V, Q, D1, D2, R0 = svdfact(x, y)`)
+    or as a `GeneralizedSVD` object (`gsvdf = svdfact(x, y)`) ([#26997]).
+
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -997,6 +997,18 @@ Deprecated or removed
 
   * `gradient` is deprecated and will be removed in the next release ([#23816]).
 
+  * `lu(A::AbstractMatrix[, pivot])` has been deprecated in favor of `lufact(A[, pivot])`.
+    Whereas `lu(A[, pivot])` returns a tuple of arrays, `lufact(A[, pivot])` returns an `LU` object.
+    So for a direct replacement, use `(lufact(A[, pivot])...,)`. But going forward, consider using
+    the direct result of `lufact(A[, pivot])` instead, either destructured into its components
+    (`l, u, p = lufact(A[, pivot])`) or as an `LU` object (`lup = lufact(A)`) ([#26997]).
+
+  * `lu(x::Number)` has been deprecated in favor of `lufact(x::Number)`.
+    Whereas `lu(x::Number)` returns a tuple of numbers, `lufact(x::Number)` returns a tuple of arrays
+    for consistency with other `lufact` methods. So for a direct replacement, use `first.((lufact(x)...,))`.
+    But going forward, consider using the direct result of `lufact(x)` instead, either destructured
+    into its components (`l, u, p = lufact(x)`) or as an `LU` object (`lup = lufact(x)`) ([#26997]).
+
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1009,6 +1009,22 @@ Deprecated or removed
     But going forward, consider using the direct result of `lufact(x)` instead, either destructured
     into its components (`l, u, p = lufact(x)`) or as an `LU` object (`lup = lufact(x)`) ([#26997]).
 
+  * `eig(A[, args...])` has been deprecated in favor of `eigfact(A[, args...])`.
+    Whereas the former returns a tuple of arrays, the latter returns an `Eigen` object.
+    So for a direct replacement, use `(eigfact(A[, args...])...,)`.
+    But going forward, consider using the direct result of
+    `eigfact(A[, args...])` instead, either destructured into its components
+    (`vals, vecs = eigfact(A[, args...])`) or as an `Eigen` object
+    (`eigf = eigfact(A[, args...])`) ([#26997]).
+
+  * `eig(A::AbstractMatrix, B::AbstractMatrix)` and `eig(A::Number, B::Number)`
+    have been deprecated in favor of `eigfact(A, B)`. Whereas the former each return
+    a tuple of arrays, the latter returns a `GeneralizedEigen` object. So for a direct
+    replacement, use `(eigfact(A, B)...,)`. But going forward, consider using the
+    direct result of `eigfact(A, B)` instead, either destructured into its components
+    (`vals, vecs = eigfact(A, B)`), or as a
+    `GeneralizedEigen` object (`eigf = eigfact(A, B)`) ([#26997]).
+
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1025,6 +1025,21 @@ Deprecated or removed
     (`vals, vecs = eigfact(A, B)`), or as a
     `GeneralizedEigen` object (`eigf = eigfact(A, B)`) ([#26997]).
 
+  * `schur(A::AbstractMatrix)` has been deprecated in favor of `schurfact(A)`.
+    Whereas the former returns a tuple of arrays, the latter returns a `Schur` object.
+    So for a direct replacement, use `(schurfact(A)...,)`. But going forward, consider
+    using the direct result of `schurfact(A)` instead, either destructured into
+    its components (`T, Z, λ = schurfact(A)`) or as a `Schur` object
+    (`schurf = schurfact(A)`) ([#26997]).
+
+  * `schur(A::StridedMatrix, B::StridedMatrix)` has been deprecated in favor of
+    `schurfact(A, B)`. Whereas the former returns a tuple of arrays, the latter
+    returns a `GeneralizedSchur` object. So for a direct replacement, use
+    `(schurfact(A, B)...,)`. But going forward, consider using the direct result
+    of `schurfact(A, B)` instead, either destructured into its components
+    (`S, T, Q, Z, α, β = schurfact(A, B)`) or as a `GeneralizedSchur` object
+    (`schurf = schurfact(A, B)`) ([#26997]).
+
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1080,6 +1080,15 @@ Deprecated or removed
     either destructured into its components (`U, V, Q, D1, D2, R0 = svdfact(x, y)`)
     or as a `GeneralizedSVD` object (`gsvdf = svdfact(x, y)`) ([#26997]).
 
+  * `lq(A; thin=true)` has been deprecated in favor of `lqfact(A)`.
+     Whereas `lq(A; thin=true)` returns a tuple of arrays, `lqfact` returns
+     an `LQ` object. So for a direct replacement of `lqfact(A; thin=true)`,
+     use `(F = lqfact(A); (F.L, Array(F.Q)))`, and for `lqfact(A; thin=false)`
+     use `(F = lqfact(A); k = size(F.Q.factors, 2); (F.L, lmul!(F.Q, Matrix{eltype(F.Q)}(I, k, k))))`.
+     But going forward, consider using the direct result of `lqfact(A)` instead,
+     either destructured into its components (`L, Q = lqfact(A)`)
+     or as an `LQ` object (`lqf = lqfact(A)`) ([#26997]).
+
   * The timing functions `tic`, `toc`, and `toq` are deprecated in favor of `@time` and `@elapsed`
     ([#17046]).
 

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -66,7 +66,7 @@ may trip up Julia users accustomed to MATLAB:
     parentheses may be required (e.g., to select elements of `A` equal to 1 or 2 use `(A .== 1) .| (A .== 2)`).
   * In Julia, the elements of a collection can be passed as arguments to a function using the splat
     operator `...`, as in `xs=[1,2]; f(xs...)`.
-  * Julia's [`svd`](@ref) returns singular values as a vector instead of as a dense diagonal matrix.
+  * Julia's [`svdfact`](@ref) returns singular values as a vector instead of as a dense diagonal matrix.
   * In Julia, `...` is not used to continue lines of code. Instead, incomplete expressions automatically
     continue onto the next line.
   * In both Julia and MATLAB, the variable `ans` is set to the value of the last expression issued

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -457,7 +457,7 @@ we could compute the singular values of several large random matrices in paralle
 ```julia-repl
 julia> M = Matrix{Float64}[rand(1000,1000) for i = 1:10];
 
-julia> pmap(svd, M);
+julia> pmap(svdvals, M);
 ```
 
 Julia's [`pmap`](@ref) is designed for the case where each function call does a large amount
@@ -486,7 +486,7 @@ As an example, consider computing the singular values of matrices of different s
 ```julia-repl
 julia> M = Matrix{Float64}[rand(800,800), rand(600,600), rand(800,800), rand(600,600)];
 
-julia> pmap(svd, M);
+julia> pmap(svdvals, M);
 ```
 
 If one process handles both 800×800 matrices and another handles both 600×600 matrices, we will

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -544,7 +544,7 @@ function norm(A)
     if isa(A, Vector)
         return sqrt(real(dot(A,A)))
     elseif isa(A, Matrix)
-        return maximum(svd(A)[2])
+        return maximum(svdvals(A))
     else
         error("norm: invalid argument")
     end
@@ -555,7 +555,7 @@ This can be written more concisely and efficiently as:
 
 ```julia
 norm(x::Vector) = sqrt(real(dot(x,x)))
-norm(A::Matrix) = maximum(svd(A)[2])
+norm(A::Matrix) = maximum(svdvals(A))
 ```
 
 ## Write "type-stable" functions

--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -186,7 +186,7 @@ end
 @testset "real svds" begin
     A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], [2.0, -1.0, 6.1, 7.0, 1.5])
     S1 = svds(A, nsv = 2)
-    S2 = svd(Array(A))
+    S2 = (F = svdfact(Array(A)); (F.U, F.S, F.V))
 
     ## singular values match:
     @test S1[1].S ≈ S2[2][1:2]
@@ -248,7 +248,7 @@ end
 @testset "complex svds" begin
     A = sparse([1, 1, 2, 3, 4], [2, 1, 1, 3, 1], exp.(im*[2.0:2:10;]), 5, 4)
     S1 = svds(A, nsv = 2)
-    S2 = svd(Array(A))
+    S2 = (F = svdfact(Array(A)); (F.U, F.S, F.V))
 
     ## singular values match:
     @test S1[1].S ≈ S2[2][1:2]

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -345,7 +345,6 @@ LinearAlgebra.hessfact
 LinearAlgebra.hessfact!
 LinearAlgebra.schurfact
 LinearAlgebra.schurfact!
-LinearAlgebra.schur
 LinearAlgebra.ordschur
 LinearAlgebra.ordschur!
 LinearAlgebra.svdfact

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -311,7 +311,6 @@ LinearAlgebra.Hermitian
 LinearAlgebra.LowerTriangular
 LinearAlgebra.UpperTriangular
 LinearAlgebra.UniformScaling
-LinearAlgebra.lu
 LinearAlgebra.lufact
 LinearAlgebra.lufact!
 LinearAlgebra.chol

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -331,7 +331,6 @@ LinearAlgebra.QRCompactWY
 LinearAlgebra.QRPivoted
 LinearAlgebra.lqfact!
 LinearAlgebra.lqfact
-LinearAlgebra.lq
 LinearAlgebra.bkfact
 LinearAlgebra.bkfact!
 LinearAlgebra.eigvals

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -198,16 +198,16 @@ Legend:
 
 ### Matrix factorizations
 
-| Matrix type               | LAPACK | [`eigfact`](@ref) | [`eigvals`](@ref) | [`eigvecs`](@ref) | [`svd`](@ref) | [`svdvals`](@ref) |
-|:------------------------- |:------ |:----------------- |:----------------- |:----------------- |:------------- |:----------------- |
-| [`Symmetric`](@ref)       | SY     |                   | ARI               |                   |               |                   |
-| [`Hermitian`](@ref)       | HE     |                   | ARI               |                   |               |                   |
-| [`UpperTriangular`](@ref) | TR     | A                 | A                 | A                 |               |                   |
-| [`LowerTriangular`](@ref) | TR     | A                 | A                 | A                 |               |                   |
-| [`SymTridiagonal`](@ref)  | ST     | A                 | ARI               | AV                |               |                   |
-| [`Tridiagonal`](@ref)     | GT     |                   |                   |                   |               |                   |
-| [`Bidiagonal`](@ref)      | BD     |                   |                   |                   | A             | A                 |
-| [`Diagonal`](@ref)        | DI     |                   | A                 |                   |               |                   |
+| Matrix type               | LAPACK | [`eigfact`](@ref) | [`eigvals`](@ref) | [`eigvecs`](@ref) | [`svdfact`](@ref) | [`svdvals`](@ref) |
+|:------------------------- |:------ |:----------------- |:----------------- |:----------------- |:----------------- |:----------------- |
+| [`Symmetric`](@ref)       | SY     |                   | ARI               |                   |                   |                   |
+| [`Hermitian`](@ref)       | HE     |                   | ARI               |                   |                   |                   |
+| [`UpperTriangular`](@ref) | TR     | A                 | A                 | A                 |                   |                   |
+| [`LowerTriangular`](@ref) | TR     | A                 | A                 | A                 |                   |                   |
+| [`SymTridiagonal`](@ref)  | ST     | A                 | ARI               | AV                |                   |                   |
+| [`Tridiagonal`](@ref)     | GT     |                   |                   |                   |                   |                   |
+| [`Bidiagonal`](@ref)      | BD     |                   |                   |                   | A                 | A                 |
+| [`Diagonal`](@ref)        | DI     |                   | A                 |                   |                   |                   |
 
 Legend:
 
@@ -349,7 +349,6 @@ LinearAlgebra.ordschur
 LinearAlgebra.ordschur!
 LinearAlgebra.svdfact
 LinearAlgebra.svdfact!
-LinearAlgebra.svd
 LinearAlgebra.svdvals
 LinearAlgebra.svdvals!
 LinearAlgebra.Givens

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -198,16 +198,16 @@ Legend:
 
 ### Matrix factorizations
 
-| Matrix type               | LAPACK | [`eig`](@ref) | [`eigvals`](@ref) | [`eigvecs`](@ref) | [`svd`](@ref) | [`svdvals`](@ref) |
-|:------------------------- |:------ |:------------- |:----------------- |:----------------- |:------------- |:----------------- |
-| [`Symmetric`](@ref)       | SY     |               | ARI               |                   |               |                   |
-| [`Hermitian`](@ref)       | HE     |               | ARI               |                   |               |                   |
-| [`UpperTriangular`](@ref) | TR     | A             | A                 | A                 |               |                   |
-| [`LowerTriangular`](@ref) | TR     | A             | A                 | A                 |               |                   |
-| [`SymTridiagonal`](@ref)  | ST     | A             | ARI               | AV                |               |                   |
-| [`Tridiagonal`](@ref)     | GT     |               |                   |                   |               |                   |
-| [`Bidiagonal`](@ref)      | BD     |               |                   |                   | A             | A                 |
-| [`Diagonal`](@ref)        | DI     |               | A                 |                   |               |                   |
+| Matrix type               | LAPACK | [`eigfact`](@ref) | [`eigvals`](@ref) | [`eigvecs`](@ref) | [`svd`](@ref) | [`svdvals`](@ref) |
+|:------------------------- |:------ |:----------------- |:----------------- |:----------------- |:------------- |:----------------- |
+| [`Symmetric`](@ref)       | SY     |                   | ARI               |                   |               |                   |
+| [`Hermitian`](@ref)       | HE     |                   | ARI               |                   |               |                   |
+| [`UpperTriangular`](@ref) | TR     | A                 | A                 | A                 |               |                   |
+| [`LowerTriangular`](@ref) | TR     | A                 | A                 | A                 |               |                   |
+| [`SymTridiagonal`](@ref)  | ST     | A                 | ARI               | AV                |               |                   |
+| [`Tridiagonal`](@ref)     | GT     |                   |                   |                   |               |                   |
+| [`Bidiagonal`](@ref)      | BD     |                   |                   |                   | A             | A                 |
+| [`Diagonal`](@ref)        | DI     |                   | A                 |                   |               |                   |
 
 Legend:
 
@@ -334,7 +334,6 @@ LinearAlgebra.lqfact
 LinearAlgebra.lq
 LinearAlgebra.bkfact
 LinearAlgebra.bkfact!
-LinearAlgebra.eig
 LinearAlgebra.eigvals
 LinearAlgebra.eigvals!
 LinearAlgebra.eigmax

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -111,7 +111,6 @@ export
     lowrankdowndate!,
     lowrankupdate,
     lowrankupdate!,
-    lu,
     lufact,
     lufact!,
     lyap,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -133,7 +133,6 @@ export
     rdiv!,
     schurfact!,
     schurfact,
-    svd,
     svdfact!,
     svdfact,
     svdvals!,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -131,7 +131,6 @@ export
     lqfact,
     rank,
     rdiv!,
-    schur,
     schurfact!,
     schurfact,
     svd,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -80,7 +80,6 @@ export
     diagind,
     diagm,
     dot,
-    eig,
     eigfact,
     eigfact!,
     eigmax,

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -126,7 +126,6 @@ export
     qr,
     qrfact!,
     qrfact,
-    lq,
     lqfact!,
     lqfact,
     rank,

--- a/stdlib/LinearAlgebra/src/bitarray.jl
+++ b/stdlib/LinearAlgebra/src/bitarray.jl
@@ -87,7 +87,7 @@ end
 
 ## norm and rank
 
-svd(A::BitMatrix) = svd(float(A))
+svdfact(A::BitMatrix) = svdfact(float(A))
 qr(A::BitMatrix) = qr(float(A))
 
 ## kron

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -418,7 +418,7 @@ function schurpow(A::AbstractMatrix, p)
             retmat = retmat * powm!(UpperTriangular(float.(A)), real(p - floor(p)))
         end
     else
-        S,Q,d = schur(complex(A))
+        S,Q,d = schurfact(complex(A))
         # Integer part
         R = S ^ floor(p)
         # Real part
@@ -605,7 +605,7 @@ matrix function is returned whenever possible.
 If `A` is symmetric or Hermitian, its eigendecomposition ([`eigfact`](@ref)) is
 used, if `A` is triangular an improved version of the inverse scaling and squaring method is
 employed (see [^AH12] and [^AHR13]). For general matrices, the complex Schur form
-([`schur`](@ref)) is computed and the triangular algorithm is used on the
+([`schurfact`](@ref)) is computed and the triangular algorithm is used on the
 triangular factor.
 
 [^AH12]: Awad H. Al-Mohy and Nicholas J. Higham, "Improved inverse  scaling and squaring algorithms for the matrix logarithm", SIAM Journal on Scientific Computing, 34(4), 2012, C153-C169. [doi:10.1137/110852553](https://doi.org/10.1137/110852553)
@@ -662,7 +662,7 @@ that is the unique matrix ``X`` with eigenvalues having positive real part such 
 
 If `A` is symmetric or Hermitian, its eigendecomposition ([`eigfact`](@ref)) is
 used to compute the square root. Otherwise, the square root is determined by means of the
-Björck-Hammarling method [^BH83], which computes the complex Schur form ([`schur`](@ref))
+Björck-Hammarling method [^BH83], which computes the complex Schur form ([`schurfact`](@ref))
 and then the complex square root of the triangular factor.
 
 [^BH83]:
@@ -1409,8 +1409,8 @@ julia> A*X + X*B + C
 ```
 """
 function sylvester(A::StridedMatrix{T},B::StridedMatrix{T},C::StridedMatrix{T}) where T<:BlasFloat
-    RA, QA = schur(A)
-    RB, QB = schur(B)
+    RA, QA = schurfact(A)
+    RB, QB = schurfact(B)
 
     D = -(adjoint(QA) * (C*QB))
     Y, scale = LAPACK.trsyl!('N','N', RA, RB, D)
@@ -1453,7 +1453,7 @@ julia> A*X + X*A' + B
 ```
 """
 function lyap(A::StridedMatrix{T}, C::StridedMatrix{T}) where {T<:BlasFloat}
-    R, Q = schur(A)
+    R, Q = schurfact(A)
 
     D = -(adjoint(Q) * (C*Q))
     Y, scale = LAPACK.trsyl!('N', T <: Complex ? 'C' : 'T', R, R, D)

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1418,3 +1418,19 @@ end
 svd(A::BitMatrix) = _simpledepsvd(float(A))
 svd(D::Diagonal{<:Number}) = _simpledepsvd(D)
 svd(A::AbstractTriangular) = _simpledepsvd(copyto!(similar(parent(A)), A))
+
+# deprecate lq(...) in favor of lqfact(...) and factorization destructuring
+export lq
+function lq(A::Union{Number,AbstractMatrix}; full::Bool = false, thin::Union{Bool,Nothing} = nothing)
+    depwarn(string("`lq(A; thin=true)` has been deprecated in favor of `lqfact(A)`. ",
+        "Whereas `lq(A; thin=true)` returns a tuple of arrays, `lqfact` returns ",
+        "an `LQ` object. So for a direct replacement of `lqfact(A; thin=true)`, ",
+        "use `(F = lqfact(A); (F.L, Array(F.Q)))`, and for `lqfact(A; thin=false)` ",
+        "use `(F = lqfact(A); k = size(F.Q.factors, 2); (F.L, lmul!(F.Q, Matrix{eltype(F.Q)}(I, k, k))))`. ",
+        "But going forward, consider using the direct result of `lqfact(A)` instead, ",
+        "either destructured into its components (`L, Q = lqfact(A)`) ",
+        "or as an `LQ` object (`lqf = lqfact(A)`)."), :lq)
+    F = lqfact(A)
+    retQ = !full ? Array(F.Q) : (k = size(F.Q.factors, 2); lmul!(F.Q, Matrix{eltype(F.Q)}(I, k, k)))
+    return F.L, retQ
+end

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1282,3 +1282,43 @@ function lu(x::Number)
         "`LU` object (`lup = lufact(x)`)."), :lu)
     return first.((lufact(x)...,))
 end
+
+# deprecate eig(...) in favor of eigfact and factorization destructuring
+export eig
+function eig(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)
+    depwarn(string("`eig(A[, permute, scale])` has been deprecated in favor of ",
+        "`eigfact(A[, permute, scale])`. Whereas `eig(A[, permute, scale])` ",
+        "returns a tuple of arrays, `eigfact(A[, permute, scale])` returns ",
+        "an `Eigen` object. So for a direct replacement, use ",
+        "`(eigfact(A[, permute, scale])...,)`. But going forward, consider ",
+        "using the direct result of `eigfact(A[, permute, scale])` instead, ",
+        "either destructured into its components ",
+        "(`vals, vecs = eigfact(A[, permute, scale])`) ",
+        "or as an `Eigen` object (`eigf = eigfact(A[, permute, scale])`)."), :eig)
+    return (eigfact(A, permute=permute, scale=scale)...,)
+end
+function eig(A::AbstractMatrix, args...)
+    depwarn(string("`eig(A, args...)` has been deprecated in favor of ",
+        "`eigfact(A, args...)`. Whereas `eig(A, args....)` ",
+        "returns a tuple of arrays, `eigfact(A, args...)` returns ",
+        "an `Eigen` object. So for a direct replacement, use ",
+        "`(eigfact(A, args...)...,)`. But going forward, consider ",
+        "using the direct result of `eigfact(A, args...)` instead, ",
+        "either destructured into its components ",
+        "(`vals, vecs = eigfact(A, args...)`) ",
+        "or as an `Eigen` object (`eigf = eigfact(A, args...)`)."), :eig)
+    return (eigfact(A, args...)...,)
+end
+eig(A::AbstractMatrix, B::AbstractMatrix) = _geneig(A, B)
+eig(A::Number, B::Number) = _geneig(A, B)
+function _geneig(A, B)
+    depwarn(string("`eig(A::AbstractMatrix, B::AbstractMatrix)` and ",
+    "`eig(A::Number, B::Number)` have been deprecated in favor of ",
+    "`eigfact(A, B)`. Whereas the former each return a tuple of arrays, ",
+    "the latter returns a `GeneralizedEigen` object. So for a direct ",
+    "replacement, use `(eigfact(A, B)...,)`. But going forward, consider ",
+    "using the direct result of `eigfact(A, B)` instead, either ",
+    "destructured into its components (`vals, vecs = eigfact(A, B)`), ",
+    "or as a `GeneralizedEigen` object (`eigf = eigfact(A, B)`)."), :eig)
+    return (eigfact(A, B)...,)
+end

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1322,3 +1322,26 @@ function _geneig(A, B)
     "or as a `GeneralizedEigen` object (`eigf = eigfact(A, B)`)."), :eig)
     return (eigfact(A, B)...,)
 end
+
+# deprecate schur(...) in favor of schurfact(...) and factorization destructuring
+export schur
+function schur(A::Union{StridedMatrix,Symmetric,Hermitian,UpperTriangular,LowerTriangular,Tridiagonal})
+    depwarn(string("`schur(A::AbstractMatrix)` has been deprecated in favor of ",
+        "`schurfact(A)`. Whereas the former returns a tuple of arrays, the ",
+        "latter returns a `Schur` object. So for a direct replacement, ",
+        "use `(schurfact(A)...,)`. But going forward, consider using ",
+        "the direct result of `schurfact(A)` instead, either destructured ",
+        "into its components (`T, Z, λ = schurfact(A)`) or as a `Schur` ",
+        "object (`schurf = schurfact(A)`)."), :schur)
+    return (schurfact(A)...,)
+end
+function schur(A::StridedMatrix, B::StridedMatrix)
+    depwarn(string("`schur(A::StridedMatrix, B::StridedMatrix)` has been ",
+        "deprecated in favor of `schurfact(A, B)`. Whereas the former returns ",
+        "a tuple of arrays, the latter returns a `GeneralizedSchur` object. ",
+        "So for a direct replacement, use `(schurfact(A, B)...,)`. But going ",
+        "forward, consider using the direct result of `schurfact(A, B)` instead, ",
+        "either destructured into its components (`S, T, Q, Z, α, β = schurfact(A, B)`) ",
+        " or as a `GeneralizedSchur` object (`schurf = schurfact(A, B)`)."), :schur)
+    return (schurfact(A, B)...,)
+end

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1260,3 +1260,25 @@ end
 @deprecate scale!(C::AbstractMatrix, a::AbstractVector, B::AbstractMatrix) mul!(C, Diagonal(a), B)
 
 Base.@deprecate_binding trace tr
+
+# deprecate lu(...) in favor of lufact and factorization destructuring
+export lu
+function lu(A::AbstractMatrix, pivot::Union{Val{false}, Val{true}} = Val(true))
+    depwarn(string("`lu(A[, pivot])` has been deprecated in favor of ",
+        "`lufact(A[, pivot])`. Whereas `lu(A[, pivot])` returns a tuple of arrays, ",
+        "`lufact(A[, pivot])` returns an `LU` object. So for a direct replacement, ",
+        "use `(lufact(A[, pivot])...,)`. But going forward, consider using the direct ",
+        "result of `lufact(A[, pivot])` instead, either destructured into its components ",
+        "(`l, u, p = lufact(A[, pivot])`) or as an `LU` object (`lup = lufact(A)`)."), :lu)
+    return (lufact(A, pivot)...,)
+end
+function lu(x::Number)
+    depwarn(string("`lu(x::Number)` has been deprecated in favor of `lufact(x::Number)`. ",
+        "Whereas `lu(x::Number)` returns a tuple of numbers, `lufact(x::Number)` ",
+        "returns a tuple of arrays for consistency with other `lufact` methods. ",
+        "So for a direct replacement, use `first.((lufact(x)...,))`. But going ",
+        "forward, consider using the direct result of `lufact(x)` instead, either ",
+        "destructured into its components (`l, u, p = lufact(x)`) or as an ",
+        "`LU` object (`lup = lufact(x)`)."), :lu)
+    return first.((lufact(x)...,))
+end

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1345,3 +1345,76 @@ function schur(A::StridedMatrix, B::StridedMatrix)
         " or as a `GeneralizedSchur` object (`schurf = schurfact(A, B)`)."), :schur)
     return (schurfact(A, B)...,)
 end
+
+# deprecate svd(...) in favor of svdfact(...) and factorization destructuring
+export svd
+function svd(A::AbstractArray; full::Bool = false, thin::Union{Bool,Nothing} = nothing)
+    depwarn(string("`svd(A::Abstractarray; thin=true)` has been deprecated ",
+        "in favor of `svdfact(A; full=false)`. Note that the `thin` keyword ",
+        "and its replacement `full` have opposite meanings. Additionally, whereas ",
+        "`svd` returns a tuple of arrays `(U, S, V)` such that `A ≈ U*Diagonal(S)*V'`, ",
+        "`svdfact` returns an `SVD` object that nominally provides `U, S, Vt` ",
+        "such that `A ≈ U*Diagonal(S)*Vt`. So for a direct replacement, use ",
+        "`((U, S, Vt) = svdfact(A[; full=...]); (U, S, copy(Vt')))`. But going forward, ",
+        "consider using the direct result of `svdfact(A[; full=...])` instead, ",
+        "either destructured into its components (`U, S, Vt = svdfact(A[; full=...])`) ",
+        "or as an `SVD` object (`svdf = svdfact(A[; full=...])`)."), :svd)
+    F = svdfact(A, full = (thin != nothing ? !thin : full))
+    return F.U, F.S, copy(F.Vt')
+end
+function svd(x::Number; full::Bool = false, thin::Union{Bool,Nothing} = nothing)
+    depwarn(string("`svd(x::Number; thin=true)` has been deprecated ",
+        "in favor of `svdfact(x; full=false)`. Note that the `thin` keyword ",
+        "and its replacement `full` have opposite meanings. Additionally, whereas ",
+        "`svd(x::Number[; thin=...])` returns a tuple of numbers `(u, s, v)` ",
+        " such that `x ≈ u*s*conj(v)`, `svdfact(x::Number[; full=...])` returns ",
+        "an `SVD` object that nominally provides `u, s, vt` such that ",
+        "`x ≈ u*s*vt`. So for a direct replacement, use ",
+        "`((u, s, vt) = first.((svdfact(A[; full=...])...,)); (u, s, conj(vt)))`. ",
+        "But going forward, ",
+        "consider using the direct result of `svdfact(A[; full=...])` instead, ",
+        "either destructured into its components (`u, s, vt = svdfact(A[; full=...])`) ",
+        "or as an `SVD` object (`svdf = svdfact(A[; full=...])`)."), :svd)
+    u, s, v = first.((svdfact(x)...,))
+    return u, s, conj(vt)
+end
+
+function svd(A::AbstractMatrix, B::AbstractMatrix)
+    depwarn(string("`svd(A::Abstractarray, B::AbstractArray)` has been deprecated ",
+        "in favor of `svdfact(A, B)`. Whereas the former returns a tuple of arrays, ",
+        "the latter returns a `GeneralizedSVD` object. So for a direct replacement, ",
+        "use `(svdfact(A, B)...,)`. But going forward, ",
+        "consider using the direct result of `svdfact(A, B)` instead, ",
+        "either destructured into its components ",
+        "(`U, V, Q, D1, D2, R0 = svdfact(A, B)`) ",
+        "or as a `GeneralizedSVD` object (`gsvdf = svdfact(A, B)`)."), :svd)
+    return (svdfact(A, B)...,)
+end
+function svd(x::Number, y::Number)
+    depwarn(string("`svd(x::Number, y::Number)` has been deprecated ",
+        "in favor of `svdfact(x, y)`. Whereas the former returns a tuple of numbers, ",
+        "the latter returns a `GeneralizedSVD` object. So for a direct replacement, ",
+        "use `first.((svdfact(x, y)...,))`. But going forward, ",
+        "consider using the direct result of `svdfact(x, y)` instead, ",
+        "either destructured into its components ",
+        "(`U, V, Q, D1, D2, R0 = svdfact(x, y)`) ",
+        "or as a `GeneralizedSVD` object (`gsvdf = svdfact(x, y)`)."), :svd)
+    return first.((svdfact(x, y)...,))
+end
+
+@inline function _simpledepsvd(A)
+    depwarn(string("`svd(A)` has been deprecated ",
+        "in favor of `svdfact(A)`. Whereas `svd` ",
+        "returns a tuple of arrays `(U, S, V)` such that `A ≈ U*Diagonal(S)*V'`, ",
+        "`svdfact` returns an `SVD` object that nominally provides `U, S, Vt` ",
+        "such that `A ≈ U*Diagonal(S)*Vt`. So for a direct replacement, use ",
+        "`((U, S, Vt) = svdfact(A); (U, S, copy(Vt')))`. But going forward, ",
+        "consider using the direct result of `svdfact(A)` instead, ",
+        "either destructured into its components (`U, S, Vt = svdfact(A)`) ",
+        "or as an `SVD` object (`svdf = svdfact(A)`)."), :svd)
+    U, S, Vt = svdfact(A)
+    return U, S, copy(Vt')
+end
+svd(A::BitMatrix) = _simpledepsvd(float(A))
+svd(D::Diagonal{<:Number}) = _simpledepsvd(D)
+svd(A::AbstractTriangular) = _simpledepsvd(copyto!(similar(parent(A)), A))

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -455,18 +455,18 @@ end
 #Singular system
 svdvals(D::Diagonal{<:Number}) = sort!(abs.(D.diag), rev = true)
 svdvals(D::Diagonal) = [svdvals(v) for v in D.diag]
-function svd(D::Diagonal{<:Number})
+function svdfact(D::Diagonal{<:Number})
     S   = abs.(D.diag)
     piv = sortperm(S, rev = true)
     U   = Diagonal(D.diag ./ S)
     Up  = hcat([U[:,i] for i = 1:length(D.diag)][piv]...)
     V   = Diagonal(fill!(similar(D.diag), one(eltype(D.diag))))
     Vp  = hcat([V[:,i] for i = 1:length(D.diag)][piv]...)
-    return (Up, S[piv], Vp)
+    return SVD(Up, S[piv], copy(Vp'))
 end
 function svdfact(D::Diagonal)
-    U, s, V = svd(D)
-    SVD(U, s, copy(V'))
+    U, s, Vt = svdfact(D)
+    return SVD(U, s, Vt)
 end
 
 # dismabiguation methods: * of Diagonal and Adj/Trans AbsVec

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2156,7 +2156,7 @@ function log(A0::UpperTriangular{T}) where T<:BlasFloat
         R[i,i+1] = i / sqrt((2 * i)^2 - 1)
         R[i+1,i] = R[i,i+1]
     end
-    x,V = eig(R)
+    x,V = eigfact(R)
     w = Vector{Float64}(undef, m)
     for i = 1:m
         x[i] = (x[i] + 1) / 2

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2435,7 +2435,7 @@ end
 eigfact(A::AbstractTriangular) = Eigen(eigvals(A), eigvecs(A))
 
 # Generic singular systems
-for func in (:svd, :svdfact, :svdfact!, :svdvals)
+for func in (:svdfact, :svdfact!, :svdvals)
     @eval begin
         ($func)(A::AbstractTriangular) = ($func)(copyto!(similar(parent(A)), A))
     end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -231,8 +231,8 @@ srand(1)
 
         @testset "Eigensystems" begin
             if relty <: AbstractFloat
-                d1, v1 = eig(T)
-                d2, v2 = eig(map(elty<:Complex ? ComplexF64 : Float64,Tfull))
+                d1, v1 = eigfact(T)
+                d2, v2 = eigfact(map(elty<:Complex ? ComplexF64 : Float64,Tfull))
                 @test (uplo == :U ? d1 : reverse(d1)) ≈ d2
                 if elty <: Real
                     test_approx_eq_modphase(v1, uplo == :U ? v2 : v2[:,n:-1:1])

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -244,8 +244,8 @@ srand(1)
             if (elty <: BlasReal)
                 @test AbstractArray(svdfact(T)) ≈ AbstractArray(svdfact!(copy(Tfull)))
                 @test svdvals(Tfull) ≈ svdvals(T)
-                u1, d1, v1 = svd(Tfull)
-                u2, d2, v2 = svd(T)
+                u1, d1, v1 = (F = svdfact(Tfull); (F.U, F.S, copy(F.Vt')))
+                u2, d2, v2 = (F = svdfact(T); (F.U, F.S, copy(F.Vt')))
                 @test d1 ≈ d2
                 if elty <: Real
                     test_approx_eq_modphase(u1, u2)
@@ -253,7 +253,7 @@ srand(1)
                 end
                 @test 0 ≈ vecnorm(u2*Diagonal(d2)*v2'-Tfull) atol=n*max(n^2*eps(relty),vecnorm(u1*Diagonal(d1)*v1'-Tfull))
                 @inferred svdvals(T)
-                @inferred svd(T)
+                @inferred svdfact(T)
             end
         end
 

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -262,7 +262,7 @@ srand(1)
     end
 
     @testset "svd (#11120/#11247)" begin
-        U, s, V = svd(D)
+        U, s, V = (F = svdfact(D); (F.U, F.S, F.V))
         @test (U*Diagonal(s))*V' ≈ D
         @test svdvals(D) == s
         @test svdfact(D).V == V

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -28,12 +28,12 @@ aimg  = randn(n,n)/2
 
         α = rand(eltya)
         β = rand(eltya)
-        eab = eig(α,β)
+        eab = (eigfact(α,β)...,)
         @test eab[1] == eigvals(fill(α,1,1),fill(β,1,1))
         @test eab[2] == eigvecs(fill(α,1,1),fill(β,1,1))
 
         @testset "non-symmetric eigen decomposition" begin
-            d, v = eig(a)
+            d, v = eigfact(a)
             for i in 1:size(a,2)
                 @test a*v[:,i] ≈ d[i]*v[:,i]
             end
@@ -70,7 +70,7 @@ aimg  = randn(n,n)/2
             @test eigvecs(f) === f.vectors
             @test_throws ErrorException f.Z
 
-            d,v = eig(asym_sg, a_sg'a_sg)
+            d,v = eigfact(asym_sg, a_sg'a_sg)
             @test d == f.values
             @test v == f.vectors
         end
@@ -89,7 +89,7 @@ aimg  = randn(n,n)/2
             @test eigvecs(a1_nsg, a2_nsg) == f.vectors
             @test_throws ErrorException f.Z
 
-            d,v = eig(a1_nsg, a2_nsg)
+            d,v = eigfact(a1_nsg, a2_nsg)
             @test d == f.values
             @test v == f.vectors
         end
@@ -98,11 +98,11 @@ end
 
 @testset "eigenvalue computations with NaNs" begin
     for eltya in (NaN16, NaN32, NaN)
-        @test_throws(ArgumentError, eig(fill(eltya, 1, 1)))
-        @test_throws(ArgumentError, eig(fill(eltya, 2, 2)))
+        @test_throws(ArgumentError, eigfact(fill(eltya, 1, 1)))
+        @test_throws(ArgumentError, eigfact(fill(eltya, 2, 2)))
         test_matrix = rand(typeof(eltya),3,3)
         test_matrix[2,2] = eltya
-        @test_throws(ArgumentError, eig(test_matrix))
+        @test_throws(ArgumentError, eigfact(test_matrix))
     end
 end
 

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -165,7 +165,7 @@ end
 @testset "gesvd, ggsvd" begin
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         A = rand(elty,10,5)
-        U,S,V = svd(A)
+        U,S,V = (F = svdfact(A); (F.U, F.S, F.V))
         lU,lS,lVt = LAPACK.gesvd!('S','S',A)
         @test U ≈ lU
         @test S ≈ lS

--- a/stdlib/LinearAlgebra/test/lapack.jl
+++ b/stdlib/LinearAlgebra/test/lapack.jl
@@ -590,7 +590,7 @@ end
         for job in ('N', 'E', 'V', 'B')
             for c in ('V', 'N')
                 A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])
-                T,Q,d = schur(A)
+                T,Q,d = schurfact(A)
                 s, sep = LinearAlgebra.LAPACK.trsen!(job,c,Array{LinearAlgebra.BlasInt}([0,1,0,0]),T,Q)[4:5]
                 @test d[1] ≈ T[2,2]
                 @test d[2] ≈ T[1,1]
@@ -616,7 +616,7 @@ end
     @testset for elty in (Float32, Float64, ComplexF32, ComplexF64)
         for c in ('V', 'N')
             A = convert(Matrix{elty}, [7 2 2 1; 1 5 2 0; 0 3 9 4; 1 1 1 4])
-            T,Q,d = schur(A)
+            T,Q,d = schurfact(A)
             LinearAlgebra.LAPACK.trexc!(c,LinearAlgebra.BlasInt(1),LinearAlgebra.BlasInt(2),T,Q)
             @test d[1] ≈ T[2,2]
             @test d[2] ≈ T[1,1]

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -42,7 +42,7 @@ dimg  = randn(n)/2
     if eltya <: BlasFloat
         @testset "LU factorization for Number" begin
             num = rand(eltya)
-            @test lu(num) == (one(eltya),num,1)
+            @test (lufact(num)...,) == (hcat(one(eltya)), hcat(num), [1])
             @test convert(Array, lufact(num)) ≈ eltya[num]
         end
         @testset "Balancing in eigenvector calculations" begin
@@ -67,7 +67,7 @@ dimg  = randn(n)/2
         lua   = factorize(a)
         @test_throws ErrorException lua.Z
         l,u,p = lua.L, lua.U, lua.p
-        ll,ul,pl = lu(a)
+        ll,ul,pl = lufact(a)
         @test ll * ul ≈ a[pl,:]
         @test l*u ≈ a[p,:]
         @test (l*u)[invperm(p),:] ≈ a

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -51,7 +51,7 @@ dimg  = randn(n)/2
                                        -eps(real(one(eltya)))/4  eps(real(one(eltya)))/2  -1.0     0;
                                        -0.5     -0.5       0.1     1.0])
             F = eigfact(A, permute=false, scale=false)
-            eig(A, permute=false, scale=false)
+            (eigfact(A, permute=false, scale=false)...,)
             @test F.vectors*Diagonal(F.values)/F.vectors ≈ A
             F = eigfact(A)
             # @test norm(F.vectors*Diagonal(F.values)/F.vectors - A) > 0.01

--- a/stdlib/LinearAlgebra/test/schur.jl
+++ b/stdlib/LinearAlgebra/test/schur.jl
@@ -35,15 +35,15 @@ aimg  = randn(n,n)/2
         @test convert(Array, f) ≈ a
         @test_throws ErrorException f.A
 
-        sch, vecs, vals = schur(UpperTriangular(triu(a)))
+        sch, vecs, vals = schurfact(UpperTriangular(triu(a)))
         @test vecs*sch*vecs' ≈ triu(a)
-        sch, vecs, vals = schur(LowerTriangular(tril(a)))
+        sch, vecs, vals = schurfact(LowerTriangular(tril(a)))
         @test vecs*sch*vecs' ≈ tril(a)
-        sch, vecs, vals = schur(Hermitian(asym))
+        sch, vecs, vals = schurfact(Hermitian(asym))
         @test vecs*sch*vecs' ≈ asym
-        sch, vecs, vals = schur(Symmetric(a + transpose(a)))
+        sch, vecs, vals = schurfact(Symmetric(a + transpose(a)))
         @test vecs*sch*vecs' ≈ a + transpose(a)
-        sch, vecs, vals = schur(Tridiagonal(a + transpose(a)))
+        sch, vecs, vals = schurfact(Tridiagonal(a + transpose(a)))
         @test vecs*sch*vecs' ≈ Tridiagonal(a + transpose(a))
 
         tstring = sprint((t, s) -> show(t, "text/plain", s), f.T)
@@ -111,7 +111,7 @@ aimg  = randn(n,n)/2
             @test S.Z ≈ SchurNew.Z
             @test S.alpha ≈ SchurNew.alpha
             @test S.beta  ≈ SchurNew.beta
-            sS,sT,sQ,sZ = schur(a1_sf,a2_sf)
+            sS,sT,sQ,sZ = schurfact(a1_sf,a2_sf)
             @test NS.Q ≈ sQ
             @test NS.T ≈ sT
             @test NS.S ≈ sS
@@ -119,7 +119,7 @@ aimg  = randn(n,n)/2
         end
     end
     @testset "0x0 matrix" for A in (zeros(eltya, 0, 0), view(rand(eltya, 2, 2), 1:0, 1:0))
-        T, Z, λ = LinearAlgebra.schur(A)
+        T, Z, λ = LinearAlgebra.schurfact(A)
         @test T == A
         @test Z == A
         @test λ == zeros(0)

--- a/stdlib/LinearAlgebra/test/schur.jl
+++ b/stdlib/LinearAlgebra/test/schur.jl
@@ -26,7 +26,7 @@ aimg  = randn(n,n)/2
                             view(apd, 1:n, 1:n)))
         ε = εa = eps(abs(float(one(eltya))))
 
-        d,v = eig(a)
+        d,v = eigfact(a)
         f   = schurfact(a)
         @test f.vectors*f.Schur*f.vectors' ≈ a
         @test sort(real(f.values)) ≈ sort(real(d))

--- a/stdlib/LinearAlgebra/test/svd.jl
+++ b/stdlib/LinearAlgebra/test/svd.jl
@@ -82,7 +82,7 @@ a2img  = randn(n,n)/2
             β = svdfact(α)
             @test β.S == [abs(α)]
             @test svdvals(α) == abs(α)
-            u,v,q,d1,d2,r0 = svd(a,a_svd)
+            u,v,q,d1,d2,r0 = svdfact(a,a_svd)
             @test u ≈ gsvd.U
             @test v ≈ gsvd.V
             @test d1 ≈ gsvd.D1
@@ -103,10 +103,8 @@ a2img  = randn(n,n)/2
             x, y = randn(eltya, 2)
             @test svdfact(x)    == svdfact(fill(x, 1, 1))
             @test svdvals(x)    == first(svdvals(fill(x, 1, 1)))
-            @test svd(x)        == first.(svd(fill(x, 1, 1)))
             @test svdfact(x, y) == svdfact(fill(x, 1, 1), fill(y, 1, 1))
             @test svdvals(x, y) ≈  first(svdvals(fill(x, 1, 1), fill(y, 1, 1)))
-            @test svd(x, y)     == first.(svd(fill(x, 1, 1), fill(y, 1, 1)))
         end
     end
     if eltya != Int

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -218,14 +218,14 @@ end
 
                 @testset "symmetric eigendecomposition" begin
                     if eltya <: Real # the eigenvalues are only real and ordered for Hermitian matrices
-                        d, v = eig(asym)
+                        d, v = eigfact(asym)
                         @test asym*v[:,1] ≈ d[1]*v[:,1]
                         @test v*Diagonal(d)*transpose(v) ≈ asym
                         @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
                         @test abs.(eigfact(Symmetric(asym), 1:2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
-                        eig(Symmetric(asym), 1:2) # same result, but checks that method works
+                        (eigfact(Symmetric(asym), 1:2)...,) # same result, but checks that method works
                         @test abs.(eigfact(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
-                        eig(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2) # same result, but checks that method works
+                        (eigfact(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2)...,) # same result, but checks that method works
                         @test eigvals(Symmetric(asym), 1:2) ≈ d[1:2]
                         @test eigvals(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2) ≈ d[1:2]
                         # eigfact doesn't support Symmetric{Complex}
@@ -233,14 +233,14 @@ end
                         @test eigvecs(Symmetric(asym)) ≈ eigvecs(asym)
                     end
 
-                    d, v = eig(aherm)
+                    d, v = eigfact(aherm)
                     @test aherm*v[:,1] ≈ d[1]*v[:,1]
                     @test v*Diagonal(d)*v' ≈ aherm
                     @test isequal(eigvals(aherm[1]), eigvals(aherm[1:1,1:1]))
                     @test abs.(eigfact(Hermitian(aherm), 1:2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
-                    eig(Hermitian(aherm), 1:2) # same result, but checks that method works
+                    (eigfact(Hermitian(aherm), 1:2)...,) # same result, but checks that method works
                     @test abs.(eigfact(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
-                    eig(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2) # same result, but checks that method works
+                    (eigfact(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2)...,) # same result, but checks that method works
                     @test eigvals(Hermitian(aherm), 1:2) ≈ d[1:2]
                     @test eigvals(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2) ≈ d[1:2]
                     @test Matrix(eigfact(aherm)) ≈ aherm
@@ -365,7 +365,7 @@ end
 end
 
 @testset "Issues #8057 and #8058. f=$f, A=$A" for f in
-        (eigfact, eigvals, eig),
+        (eigfact, eigvals, eigfact),
             A in (Symmetric([0 1; 1 0]), Hermitian([0 im; -im 0]))
     @test_throws ArgumentError f(A, 3, 2)
     @test_throws ArgumentError f(A, 1:4)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -249,7 +249,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
 
         # eigenproblems
         if !(elty1 in (BigFloat, Complex{BigFloat})) # Not handled yet
-            vals, vecs = eig(A1)
+            vals, vecs = eigfact(A1)
             if (t1 == UpperTriangular || t1 == LowerTriangular) && elty1 != Int # Cannot really handle degenerate eigen space and Int matrices will probably have repeated eigenvalues.
                 @test vecs*diagm(0 => vals)/vecs ≈ A1 atol=sqrt(eps(float(real(one(vals[1])))))*(norm(A1,Inf)*n)^2
             end

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -264,7 +264,6 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         end
 
         if !(elty1 in (BigFloat, Complex{BigFloat})) # Not implemented yet
-            svd(A1)
             svdfact(A1)
             elty1 <: BlasFloat && svdfact!(copy(A1))
             svdvals(A1)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -243,7 +243,7 @@ end
                         w, iblock, isplit = LAPACK.stebz!('V', 'B', -infinity, infinity, 0, 0, zero, b, a)
                         evecs = LAPACK.stein!(b, a, w)
 
-                        (e, v) = eig(SymTridiagonal(b, a))
+                        (e, v) = eigfact(SymTridiagonal(b, a))
                         @test e ≈ w
                         test_approx_eq_vecs(v, evecs)
                     end
@@ -266,10 +266,10 @@ end
                     end
                     @testset "eigenvalues/eigenvectors of symmetric tridiagonal" begin
                         if elty === Float32 || elty === Float64
-                            DT, VT = @inferred eig(A)
-                            @inferred eig(A, 2:4)
-                            @inferred eig(A, 1.0, 2.0)
-                            D, Vecs = eig(fA)
+                            DT, VT = @inferred eigfact(A)
+                            @inferred eigfact(A, 2:4)
+                            @inferred eigfact(A, 1.0, 2.0)
+                            D, Vecs = eigfact(fA)
                             @test DT ≈ D
                             @test abs.(VT'Vecs) ≈ Matrix(elty(1)I, n, n)
                             test_approx_eq_modphase(eigvecs(A), eigvecs(fA))

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1009,7 +1009,6 @@ function factorize(A::LinearAlgebra.RealHermSymComplexHerm{Float64,<:SparseMatri
 end
 
 chol(A::SparseMatrixCSC) = error("Use cholfact() instead of chol() for sparse matrices.")
-lu(A::SparseMatrixCSC) = error("Use lufact() instead of lu() for sparse matrices.")
 eig(A::SparseMatrixCSC) = error("Use IterativeEigensolvers.eigs() instead of eig() for sparse matrices.")
 
 function Base.cov(X::SparseMatrixCSC; dims::Int=1, corrected::Bool=true)

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1009,7 +1009,6 @@ function factorize(A::LinearAlgebra.RealHermSymComplexHerm{Float64,<:SparseMatri
 end
 
 chol(A::SparseMatrixCSC) = error("Use cholfact() instead of chol() for sparse matrices.")
-eig(A::SparseMatrixCSC) = error("Use IterativeEigensolvers.eigs() instead of eig() for sparse matrices.")
 
 function Base.cov(X::SparseMatrixCSC; dims::Int=1, corrected::Bool=true)
     vardim = dims

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1780,7 +1780,6 @@ end
     C, b = A[:, 1:4], fill(1., size(A, 1))
     @test !Base.USE_GPL_LIBS || factorize(C)\b ≈ Array(C)\b
     @test_throws ErrorException chol(A)
-    @test_throws ErrorException lu(A)
     @test_throws ErrorException eig(A)
     @test_throws ErrorException inv(A)
 end

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1780,7 +1780,6 @@ end
     C, b = A[:, 1:4], fill(1., size(A, 1))
     @test !Base.USE_GPL_LIBS || factorize(C)\b ≈ Array(C)\b
     @test_throws ErrorException chol(A)
-    @test_throws ErrorException eig(A)
     @test_throws ErrorException inv(A)
 end
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1466,7 +1466,7 @@ timesofar("cat")
     @check_bit_operation diff(b1, dims=2) Matrix{Int}
 
     b1 = bitrand(n1, n1)
-    @check_bit_operation svd(b1)
+    @check_bit_operation svdfact(b1)
     @check_bit_operation qr(b1)
 
     b1 = bitrand(v1)


### PR DESCRIPTION
(Rewritten with updates:) This pull request concerns JuliaLang/LinearAlgebra.jl#322 and JuliaLang/julia#25187, deprecating `lu`, `eig`, `schur`, `svd`, and `lq` to `*fact` counterparts and factorization destructuring.

Other, slightly different and/or trickier targets for similar deprecation:`chol` and `qr`. Best!