### PR TITLE
fix remaining doctest failures and enable doctests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -154,5 +154,5 @@ script:
         rm -f julia/deps/scratch/libgit2-*/CMakeFiles/CMakeOutput.log
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg
-after_success:
+    # build the docs and run the doctests
     - cd julia && make -C doc deploy

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -36,11 +36,11 @@ may be useful. See the manual chapter on [arrays with custom indices](@ref man-c
 ```jldoctest
 julia> A = fill(1, (2,3,4));
 
+julia> size(A)
+(2, 3, 4)
+
 julia> size(A, 2)
 3
-
-julia> size(A, 3, 2)
-(4, 3)
 ```
 """
 size(t::AbstractArray{T,N}, d) where {T,N} = d <= N ? size(t)[d] : 1

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -115,7 +115,7 @@ julia> A = [1 2 3 4; 5 6 7 8]
  5  6  7  8
 
 julia> selectdim(A, 2, 3)
-2-element view(::Array{Int64,2}, Base.OneTo(2), 3) with eltype Int64:
+2-element view(::Array{Int64,2}, :, 3) with eltype Int64:
  3
  7
 ```

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -600,7 +600,7 @@ Base.@propagate_inbounds _getindex(args::Tuple{}, I) = ()
 @inline _broadcast_getindex_evalf(f::Tf, args::Vararg{Any,N}) where {Tf,N} = f(args...)  # not propagate_inbounds
 
 """
-    broadcastable(x)
+    Broadcast.broadcastable(x)
 
 Return either `x` or an object like `x` such that it supports `axes`, indexing, and its type supports `ndims`.
 
@@ -614,16 +614,16 @@ Further, if `x` defines its own [`BroadcastStyle`](@ref), then it must define it
 
 # Examples
 ```jldoctest
-julia> broadcastable([1,2,3]) # like `identity` since arrays already support axes and indexing
+julia> Broadcast.broadcastable([1,2,3]) # like `identity` since arrays already support axes and indexing
 3-element Array{Int64,1}:
  1
  2
  3
 
-julia> broadcastable(Int) # Types don't support axes, indexing, or iteration but are commonly used as scalars
+julia> Broadcast.broadcastable(Int) # Types don't support axes, indexing, or iteration but are commonly used as scalars
 Base.RefValue{Type{Int64}}(Int64)
 
-julia> broadcastable("hello") # Strings break convention of matching iteration and act like a scalar instead
+julia> Broadcast.broadcastable("hello") # Strings break convention of matching iteration and act like a scalar instead
 Base.RefValue{String}("hello")
 ```
 """

--- a/base/floatfuncs.jl
+++ b/base/floatfuncs.jl
@@ -108,7 +108,7 @@ julia> round(357.913; sigdigits=4, base=2)
     julia> x < 115//100
     true
 
-    julia> round(x, 1)
+    julia> round(x, digits=1)
     1.2
     ```
 

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -331,9 +331,9 @@ from cartesian to linear indexing:
 ```jldoctest
 julia> linear = LinearIndices((1:3, 1:2))
 LinearIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 1:3×1:2:
-    1  4
-    2  5
-    3  6
+ 1  4
+ 2  5
+ 3  6
 
 julia> linear[1,2]
 4

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -433,7 +433,7 @@ An iterator that yields the same elements as `iter`, but starting at the given `
 # Examples
 ```jldoctest
 julia> collect(Iterators.rest([1,2,3,4], 2))
-3-element Array{Any,1}:
+3-element Array{Int64,1}:
  2
  3
  4

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -202,7 +202,7 @@ module IteratorsMD
 
     ```jldoctest
     julia> cartesian = CartesianIndices((1:3, 1:2))
-    3×2 CartesianIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}}:
+    CartesianIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}} with indices 1:3×1:2:
      CartesianIndex(1, 1)  CartesianIndex(1, 2)
      CartesianIndex(2, 1)  CartesianIndex(2, 2)
      CartesianIndex(3, 1)  CartesianIndex(3, 2)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -214,7 +214,7 @@ isconst(m::Module, s::Symbol) =
 Tests whether variable `s` is defined in the current scope.
 
 # Examples
-```jldoctest
+```julia-repl
 julia> function f()
            println(@isdefined x)
            x = 3

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -84,12 +84,11 @@ julia> reshape(A, 2, :)
  1  3  5  7   9  11  13  15
  2  4  6  8  10  12  14  16
 
- julia> reshape(1:6, 2, 3)
- 2×3 reshape(::UnitRange{Int64}, 2, 3) with eltype Int64:
-  1  3  5
-  2  4  6
+julia> reshape(1:6, 2, 3)
+2×3 reshape(::UnitRange{Int64}, 2, 3) with eltype Int64:
+ 1  3  5
+ 2  4  6
 ```
-
 """
 reshape
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1727,6 +1727,7 @@ end
     dump(x; maxdepth=$DUMP_DEFAULT_MAXDEPTH)
 
 Show every part of the representation of a value.
+The depth of the output is truncated at `maxdepth`.
 
 # Examples
 ```jldoctest
@@ -1743,32 +1744,11 @@ MyStruct
   y: Tuple{Int64,Int64}
     1: Int64 2
     2: Int64 3
-```
-Nested data structures are truncated at `maxdepth`.
-```jldoctest
-julia> struct DeeplyNested
-           xs::Vector{DeeplyNested}
-       end;
 
-julia> x = DeeplyNested([]);
-
-julia> push!(x.xs, x);
-
-julia> dump(x)
-DeeplyNested
-  xs: Array{DeeplyNested}((1,))
-    1: DeeplyNested
-      xs: Array{DeeplyNested}((1,))
-        1: DeeplyNested
-          xs: Array{DeeplyNested}((1,))
-            1: DeeplyNested
-              xs: Array{DeeplyNested}((1,))
-                1: DeeplyNested
-
-julia> dump(x, maxdepth=2)
-DeeplyNested
-  xs: Array{DeeplyNested}((1,))
-    1: DeeplyNested
+julia> dump(x; maxdepth = 1)
+MyStruct
+  x: Int64 1
+  y: Tuple{Int64,Int64}
 ```
 """
 dump(arg; maxdepth=DUMP_DEFAULT_MAXDEPTH) = dump(IOContext(stdout::IO, :limit => true), arg; maxdepth=maxdepth)

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -357,9 +357,6 @@ return `i`.
 
 # Examples
 ```jldoctest
-julia> thisind("αβγdef", -5)
--5
-
 julia> thisind("αβγdef", 1)
 1
 
@@ -374,9 +371,6 @@ julia> thisind("αβγdef", 9)
 
 julia> thisind("αβγdef", 10)
 10
-
-julia> thisind("αβγdef", 20)
-20
 ```
 """
 thisind(s::AbstractString, i::Integer) = thisind(s, Int(i))

--- a/base/views.jl
+++ b/base/views.jl
@@ -197,7 +197,7 @@ julia> A = zeros(3, 3);
 
 julia> @views for row in 1:3
            b = A[row, :]
-           b[:] = row
+           b[:] .= row
        end
 
 julia> A

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -69,5 +69,5 @@ check: deps
 # The deploy target should only be called in Travis builds
 deploy: deps
 	@echo "Deploying HTML documentation."
-	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy doctest
 	@echo "Build & deploy of docs finished."

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -1,3 +1,9 @@
+if "deploy" in ARGS
+    # Only deploy docs from 64bit Linux to avoid committing multiple versions of the same
+    # docs from different workers.
+    (Sys.ARCH === :x86_64 && Sys.KERNEL === :Linux) || exit()
+end
+
 # Install dependencies needed to build the documentation.
 ENV["JULIA_PKGDIR"] = joinpath(@__DIR__, "deps")
 using Pkg
@@ -165,20 +171,15 @@ makedocs(
     html_canonical = ("deploy" in ARGS) ? "https://docs.julialang.org/en/stable/" : nothing,
 )
 
-if "deploy" in ARGS
-    # Only deploy docs from 64bit Linux to avoid committing multiple versions of the same
-    # docs from different workers.
-    (Sys.ARCH === :x86_64 && Sys.KERNEL === :Linux) || return
 
-    # Since the `.travis.yml` config specifies `language: cpp` and not `language: julia` we
-    # need to manually set the version of Julia that we are deploying the docs from.
-    ENV["TRAVIS_JULIA_VERSION"] = "nightly"
+# Since the `.travis.yml` config specifies `language: cpp` and not `language: julia` we
+# need to manually set the version of Julia that we are deploying the docs from.
+ENV["TRAVIS_JULIA_VERSION"] = "nightly"
 
-    deploydocs(
-        repo = "github.com/JuliaLang/julia.git",
-        target = "_build/html/en",
-        dirname = "en",
-        deps = nothing,
-        make = nothing,
-    )
-end
+deploydocs(
+    repo = "github.com/JuliaLang/julia.git",
+    target = "_build/html/en",
+    dirname = "en",
+    deps = nothing,
+    make = nothing,
+)

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -392,14 +392,15 @@ julia> x = collect(reshape(1:9, 3, 3))
  2  5  8
  3  6  9
 
-julia> x[1:2, 2:3] = -1
--1
+julia> x[3, 3] = -9;
+
+julia> x[1:2, 1:2] = [-1 -4; -2 -5];
 
 julia> x
 3×3 Array{Int64,2}:
- 1  -1  -1
- 2  -1  -1
- 3   6   9
+ -1  -4   7
+ -2  -5   8
+  3   6  -9
 ```
 
 ### [Supported index types](@id man-supported-index-types)

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -556,7 +556,7 @@ Base.BroadcastStyle(::Type{<:ArrayAndChar}) = Broadcast.ArrayStyle{ArrayAndChar}
 ```
 
 This means we must also define a corresponding `broadcast_similar` method:
-```jldoctest
+```jldoctest ArrayAndChar; filter = r"(^find_aac \(generic function with 5 methods\)$|^$)"
 function Base.broadcast_similar(::Broadcast.ArrayStyle{ArrayAndChar}, ::Type{ElType}, inds, bc) where ElType
     # Scan the inputs for the ArrayAndChar:
     A = find_aac(bc)
@@ -570,6 +570,8 @@ find_aac(args::Tuple) = find_aac(find_aac(args[1]), Base.tail(args))
 find_aac(x) = x
 find_aac(a::ArrayAndChar, rest) = a
 find_aac(::Any, rest) = find_aac(rest)
+# output
+
 ```
 
 From these definitions, one obtains the following behavior:

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -621,8 +621,8 @@ julia> A = Matrix(2.7182818*I, 2, 2)
 
 julia> log(A)
 2×2 Array{Float64,2}:
-  1.0  0.0
- -0.0  1.0
+ 1.0  0.0
+ 0.0  1.0
 ```
 """
 function log(A::StridedMatrix)

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -35,7 +35,7 @@ A = ones(Int, 4, 4)
 v = ones(100)
 @info "Some variables"  A  s=sum(v)
 
-# Output
+# output
 ┌ Info: Some variables
 │   A =
 │    4×4 Array{Int64,2}:

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -341,11 +341,11 @@ The `@test_broken f(args...) key=val...` form works as for the `@test` macro.
 ```jldoctest
 julia> @test_broken 1 == 2
 Test Broken
-Expression: 1 == 2
+  Expression: 1 == 2
 
 julia> @test_broken 1 == 2 atol=0.1
 Test Broken
-Expression: ==(1, 2, atol=0.1)
+  Expression: ==(1, 2, atol=0.1)
 ```
 """
 macro test_broken(ex, kws...)

--- a/stdlib/UUIDs/src/UUIDs.jl
+++ b/stdlib/UUIDs/src/UUIDs.jl
@@ -36,7 +36,7 @@ according to section 4.5 of the RFC.
 julia> rng = MersenneTwister(1234);
 
 julia> uuid1(rng)
-fcbd9b64-1bc2-11e8-1f13-43a2532b2fa8
+UUID("cfc395e8-590f-11e8-1f13-43a2532b2fa8")
 ```
 """
 function uuid1(rng::AbstractRNG=Random.GLOBAL_RNG)
@@ -73,7 +73,7 @@ as specified by RFC 4122.
 julia> rng = MersenneTwister(1234);
 
 julia> uuid4(rng)
-196f2941-2d58-45ba-9f13-43a2532b2fa8
+UUID("196f2941-2d58-45ba-9f13-43a2532b2fa8")
 ```
 """
 function uuid4(rng::AbstractRNG=Random.GLOBAL_RNG)


### PR DESCRIPTION
This fixes all remaining doc(test) failures, and enables doctests on Travis Linux 64-bit (fix #19528). On my machine this changes the time for the doc build from ~2 to ~5 minutes, but I think it is well worth it, because, as you can see from the diff, we keep deprecating our own manual.

~ATM this includes #26973 and #26993, the relevant changes to review here is 3c29c7bc126f56a7d5f76dc451af0f3e776f39c2 + 14f08c1736357512fa3baea39f87a0f75ebed7b8~