### PR TITLE
faster Profile.print

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -83,7 +83,7 @@ If the StackFrame has function and line information, we consider two of them the
 they share the same function/line information.
 =#
 function ==(a::StackFrame, b::StackFrame)
-    a.line == b.line && a.from_c == b.from_c && a.func == b.func && a.file == b.file && a.inlined == b.inlined
+    return a.line == b.line && a.from_c == b.from_c && a.func == b.func && a.file == b.file && a.inlined == b.inlined # excluding linfo and pointer
 end
 
 function hash(frame::StackFrame, h::UInt)
@@ -93,6 +93,7 @@ function hash(frame::StackFrame, h::UInt)
     h = hash(frame.func, h)
     h = hash(frame.from_c, h)
     h = hash(frame.inlined, h)
+    return h
 end
 
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -242,14 +242,17 @@ function callers end
 
 function callers(funcname::String, bt::Vector, lidict::LineInfoFlatDict; filename = nothing, linerange = nothing)
     if filename === nothing && linerange === nothing
-        return callersf(li -> li.func == funcname, bt, lidict)
+        return callersf(li -> String(li.func) == funcname,
+            bt, lidict)
     end
     filename === nothing && throw(ArgumentError("if supplying linerange, you must also supply the filename"))
+    filename = String(filename)
     if linerange === nothing
-        return callersf(li -> li.func == funcname && li.file == filename, bt, lidict)
+        return callersf(li -> String(li.func) == funcname && String(li.file) == filename,
+            bt, lidict)
     else
-        return callersf(li -> li.func == funcname && li.file == filename &&
-            in(li.line, linerange), bt, lidict)
+        return callersf(li -> String(li.func) == funcname && String(li.file) == filename && in(li.line, linerange),
+            bt, lidict)
     end
 end
 

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -8,8 +8,6 @@ Profiling support, main entry point is the [`@profile`](@ref) macro.
 module Profile
 
 import Base.StackTraces: lookup, UNKNOWN, show_spec_linfo, StackFrame
-using Base: iszero
-using Printf: @sprintf
 
 export @profile
 
@@ -20,7 +18,7 @@ export @profile
 appended to an internal buffer of backtraces.
 """
 macro profile(ex)
-    quote
+    return quote
         try
             status = start_timer()
             if status < 0
@@ -146,6 +144,7 @@ end
 
 function print(io::IO, data::Vector{<:Unsigned}, lidict::LineInfoDict, fmt::ProfileFormat, format::Symbol)
     cols::Int = Base.displaysize(io)[2]
+    data = convert(Vector{UInt64}, data)
     if format == :tree
         tree(io, data, lidict, cols, fmt)
     elseif format == :flat
@@ -316,52 +315,38 @@ function fetch()
 end
 
 
-# Number of backtrace "steps" that are triggered by taking the backtrace, e.g., inside profile_bt
-# TODO: may be platform-specific?
-const btskip = 0
-
 ## Print as a flat list
 # Counts the number of times each line appears, at any nesting level
-function count_flat(data::Vector{T}) where T<:Unsigned
-    linecount = Dict{T,Int}()
-    toskip = btskip
+function count_flat(data::Vector{UInt64})
+    linecount = Dict{UInt64, Int}()
     for ip in data
-        if toskip > 0
-            toskip -= 1
-            continue
+        if ip != 0
+            linecount[ip] = get(linecount, ip, 0) + 1
         end
-        if ip == 0
-            toskip = btskip
-            continue
-        end
-        linecount[ip] = get(linecount, ip, 0)+1
     end
-    iplist = Vector{T}()
+    iplist = Vector{UInt64}()
     n = Vector{Int}()
-    for (k,v) in linecount
+    for (k, v) in linecount
         push!(iplist, k)
         push!(n, v)
     end
     return (iplist, n)
 end
 
-function parse_flat(iplist, n, lidict::LineInfoFlatDict, C::Bool)
+function parse_flat(iplist::Vector{UInt64}, n::Vector{Int}, lidict::LineInfoFlatDict, C::Bool)
     # Convert instruction pointers to names & line numbers
-    lilist = [lidict[ip] for ip in iplist]
+    lilist = StackFrame[lidict[ip] for ip in iplist]
     # Keep only the interpretable ones
     # The ones with no line number might appear multiple times in a single
     # backtrace, giving the wrong impression about the total number of backtraces.
     # Delete them too.
-    keep = .!Bool[x == UNKNOWN || x.line == 0 || (x.from_c && !C) for x in lilist]
+    keep = Bool[x != UNKNOWN && x.line != 0 && (C || !x.from_c) for x in lilist]
     n = n[keep]
     lilist = lilist[keep]
     return (lilist, n)
 end
 
-function flat(io::IO, data::Vector, lidict::LineInfoFlatDict, cols::Int, fmt::ProfileFormat)
-    if !fmt.C
-        data = purgeC(data, lidict)
-    end
+function flat(io::IO, data::Vector{UInt64}, lidict::LineInfoFlatDict, cols::Int, fmt::ProfileFormat)
     iplist, n = count_flat(data)
     if isempty(n)
         warning_empty()
@@ -372,7 +357,7 @@ function flat(io::IO, data::Vector, lidict::LineInfoFlatDict, cols::Int, fmt::Pr
     nothing
 end
 
-function flat(io::IO, data::Vector, lidict::LineInfoDict, cols::Int, fmt::ProfileFormat)
+function flat(io::IO, data::Vector{UInt64}, lidict::LineInfoDict, cols::Int, fmt::ProfileFormat)
     newdata, newdict = flatten(data, lidict)
     flat(io, newdata, newdict, cols, fmt)
     nothing
@@ -384,6 +369,8 @@ function print_flat(io::IO, lilist::Vector{StackFrame}, n::Vector{Int},
     lilist = lilist[p]
     n = n[p]
     if fmt.combine
+        # now that lilist is sorted by li,
+        # combine adjacent entries that are equivlent
         j = 1
         for i = 2:length(lilist)
             if lilist[i] == lilist[j]
@@ -440,27 +427,6 @@ function print_flat(io::IO, lilist::Vector{StackFrame}, n::Vector{Int},
 end
 
 ## A tree representation
-# Identify and counts repetitions of all unique backtraces
-function tree_aggregate(data::Vector{UInt64})
-    iz = findall(iszero, data)  # find the breaks between backtraces
-    treecount = Dict{Vector{UInt64},Int}()
-    istart = 1 + btskip
-    for iend in iz
-        tmp = data[iend - 1 : -1 : istart]
-        treecount[tmp] = get(treecount, tmp, 0) + 1
-        istart = iend + 1 + btskip
-    end
-    bt = Vector{Vector{UInt64}}()
-    counts = Vector{Int}()
-    for (k, v) in treecount
-        if !isempty(k)
-            push!(bt, k)
-            push!(counts, v)
-        end
-    end
-    return (bt, counts)
-end
-
 tree_format_linewidth(x::StackFrame) = ndigits(x.line) + 6
 
 function tree_format(lilist::Vector{StackFrame}, counts::Vector{Int}, level::Int, cols::Int)
@@ -512,108 +478,87 @@ function tree_format(lilist::Vector{StackFrame}, counts::Vector{Int}, level::Int
     return strs
 end
 
+# Construct a prefix trie of backtrace counts
+mutable struct StackFrameTree{T} # where T <: Union{UInt64, StackFrame}
+    frame::StackFrame
+    count::Int
+    down::Dict{T, StackFrameTree{T}}
+    StackFrameTree{T}() where {T} = new(UNKNOWN, 0, LEAF(T))
+end
+@eval LEAF(::Type{UInt64}) = $(Dict{UInt64, StackFrameTree{UInt64}}())
+@eval LEAF(::Type{StackFrame}) = $(Dict{StackFrame, StackFrameTree{StackFrame}}())
+
+# turn a list of backtraces into a tree (implicitly separated by NULL markers)
+function tree!(root::StackFrameTree{T}, all::Vector{UInt64}, lidict::Union{LineInfoFlatDict, LineInfoDict}, C::Bool) where {T}
+    parent = root
+    for i in length(all):-1:1
+        ip = all[i]
+        if ip == 0
+            parent = root
+            parent.count += 1
+        else
+            frames = lidict[ip]
+            nframes = (frames isa Vector ? length(frames) : 1)
+            for i = nframes:-1:1
+                frame = (frames isa Vector ? frames[i] : frames)
+                !C && frame.from_c && continue
+                key = (T === UInt64 ? ip : frame)
+                down = parent.down
+                if down === LEAF(T)
+                    down = Dict{T, StackFrameTree{T}}()
+                    parent.down = down
+                    parent = StackFrameTree{T}()
+                    parent.frame = frame
+                    down[key] = parent
+                else
+                    parent = get!(down, key) do
+                        return StackFrameTree{T}()
+                    end
+                    parent.frame = frame
+                end
+                parent.count += 1
+            end
+        end
+    end
+    return root
+end
+
 # Print a "branch" starting at a particular level. This gets called recursively.
-function tree(io::IO, bt::Vector{Vector{UInt64}}, counts::Vector{Int},
-        lidict::LineInfoFlatDict, level::Int, cols::Int, fmt::ProfileFormat, noisefloor::Int)
-    if level > fmt.maxdepth
-        return
-    end
-    # Organize backtraces into groups that are identical up to this level
-    if fmt.combine
-        # Combine based on the line information
-        d = Dict{StackFrame,Vector{Int}}()
-        for i = 1:length(bt)
-            ip = bt[i][level + 1]
-            key = lidict[ip]
-            indx = Base.ht_keyindex(d, key)
-            if haskey(d, key)
-                push!(d[key], i)
-            else
-                d[key] = [i]
-            end
-        end
-        # Generate counts
-        dlen = length(d)
-        lilist = Vector{StackFrame}(undef, dlen)
-        group = Vector{Vector{Int}}(undef, dlen)
-        n = Vector{Int}(undef, dlen)
-        i = 1
-        for (key, v) in d
-            lilist[i] = key
-            group[i] = v
-            n[i] = sum(counts[v])
-            i += 1
-        end
-    else
-        # Combine based on the instruction pointer
-        d = Dict{UInt64,Vector{Int}}()
-        for i = 1:length(bt)
-            key = bt[i][level+1]
-            if haskey(d, key)
-                push!(d[key], i)
-            else
-                d[key] = [i]
-            end
-        end
-        # Generate counts, and do the code lookup
-        dlen = length(d)
-        lilist = Vector{StackFrame}(undef, dlen)
-        group = Vector{Vector{Int}}(undef, dlen)
-        n = Vector{Int}(undef, dlen)
-        i = 1
-        for (key, v) in d
-            lilist[i] = lidict[key]
-            group[i] = v
-            n[i] = sum(counts[v])
-            i += 1
-        end
-    end
+function tree(io::IO, bt::StackFrameTree, level::Int, cols::Int, fmt::ProfileFormat, noisefloor::Int)
+    level > fmt.maxdepth && return
+    isempty(bt.down) && return
     # Order the line information
-    if length(lilist) > 1
-        p = liperm(lilist)
-        lilist = lilist[p]
-        group = group[p]
-        n = n[p]
-    end
+    nexts = collect(values(bt.down))
+    lilist = collect(frame.frame for frame in nexts)
+    counts = collect(frame.count for frame in nexts)
     # Generate the string for each line
-    strs = tree_format(lilist, n, level, cols)
+    strs = tree_format(lilist, counts, level, cols)
     # Recurse to the next level
-    len = Int[length(x) for x in bt]
-    for i = 1:length(lilist)
-        n[i] < fmt.mincount && continue
-        n[i] < noisefloor && continue
-        if !isempty(strs[i])
-            println(io, strs[i])
-        end
-        idx = group[i]
-        keep = len[idx] .> level+1
-        if any(keep)
-            idx = idx[keep]
-            tree(io, bt[idx], counts[idx], lidict, level + 1, cols, fmt, fmt.noisefloor > 0 ? floor(Int, fmt.noisefloor * sqrt(n[i])) : 0)
-        end
+    for i in liperm(lilist)
+        down = nexts[i]
+        count = down.count
+        count < fmt.mincount && continue
+        count < noisefloor && continue
+        str = strs[i]
+        println(io, isempty(str) ? "$count unknown stackframe" : str)
+        noisefloor_down = fmt.noisefloor > 0 ? floor(Int, fmt.noisefloor * sqrt(count)) : 0
+        tree(io, down, level + 1, cols, fmt, noisefloor_down)
     end
     nothing
 end
 
-function tree(io::IO, data::Vector{UInt64}, lidict::LineInfoFlatDict, cols::Int, fmt::ProfileFormat)
-    if !fmt.C
-        data = purgeC(data, lidict)
+function tree(io::IO, data::Vector{UInt64}, lidict::Union{LineInfoFlatDict, LineInfoDict}, cols::Int, fmt::ProfileFormat)
+    if fmt.combine
+        root = tree!(StackFrameTree{StackFrame}(), data, lidict, fmt.C)
+    else
+        root = tree!(StackFrameTree{UInt64}(), data, lidict, fmt.C)
     end
-    bt, counts = tree_aggregate(data)
-    if isempty(counts)
+    if isempty(root.down)
         warning_empty()
         return
     end
     level = 0
-    len = Int[length(x) for x in bt]
-    keep = len .> 0
-    tree(io, bt[keep], counts[keep], lidict, level, cols, fmt, 0)
-    nothing
-end
-
-function tree(io::IO, data::Vector, lidict::LineInfoDict, cols::Int, fmt::ProfileFormat)
-    newdata, newdict = flatten(data, lidict)
-    tree(io, newdata, newdict, cols, fmt)
+    tree(io, root, level, cols, fmt, 0)
     nothing
 end
 
@@ -662,26 +607,25 @@ truncto(str::Symbol, w::Int) = truncto(string(str), w)
 
 # Order alphabetically (file, function) and then by line number
 function liperm(lilist::Vector{StackFrame})
-    comb = Vector{String}(undef, length(lilist))
-    for i = 1:length(lilist)
-        li = lilist[i]
-        if li != UNKNOWN
-            comb[i] = @sprintf("%s:%s:%06d", li.file, li.func, li.line)
-        else
-            comb[i] = "zzz"
-        end
+    function lt(a::StackFrame, b::StackFrame)
+        a == UNKNOWN && return false
+        b == UNKNOWN && return true
+        fcmp = cmp(a.file, b.file)
+        fcmp < 0 && return true
+        fcmp > 0 && return false
+        fcmp = cmp(a.func, b.func)
+        fcmp < 0 && return true
+        fcmp > 0 && return false
+        fcmp = cmp(a.line, b.line)
+        fcmp < 0 && return true
+        return false
     end
-    return sortperm(comb)
+    return sortperm(lilist, lt = lt)
 end
 
 warning_empty() = @warn """
             There were no samples collected. Run your program longer (perhaps by
             running it multiple times), or adjust the delay between samples with
             `Profile.init()`."""
-
-function purgeC(data::Vector{UInt64}, lidict::LineInfoFlatDict)
-    keep = Bool[d == 0 || lidict[d].from_c == false for d in data]
-    return data[keep]
-end
 
 end # module

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1185,7 +1185,7 @@ function deserialize(s::AbstractSerializer, t::Type{Regex})
     pattern = deserialize(s)
     compile_options = deserialize(s)
     match_options = deserialize(s)
-    Regex(pattern, compile_options, match_options)
+    return Regex(pattern, compile_options, match_options)
 end
 
 ## StackTraces
@@ -1201,6 +1201,7 @@ function serialize(s::AbstractSerializer, frame::Base.StackTraces.StackFrame)
     write(s.io, frame.from_c)
     write(s.io, frame.inlined)
     write(s.io, frame.pointer)
+    nothing
 end
 
 function deserialize(s::AbstractSerializer, ::Type{Base.StackTraces.StackFrame})


### PR DESCRIPTION
In my tests, this was 5-15x faster at printing the output, mostly by avoiding using `Dict` or calling `hash` on `UInt64` objects a couple extra times (but also by using a less naive algorithm, which also happens to be less complicated in lines of code – even after adding some new optimizations and features – so yay!)