### PR TITLE
Avoid segfault when ptls->safepoint is NULL

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -161,7 +161,7 @@ JL_DLLEXPORT void (jl_cpu_wake)(void);
 
 // gc safepoint and gc states
 // This triggers a SegFault when we are in GC
-// Assign it to a variable to make sure the compiler emit the load
+// Assign it to a variable to make sure the compiler emits the load
 // and to avoid Clang warning for -Wunused-volatile-lvalue
 #define jl_gc_safepoint_(ptls) do {                     \
         jl_signal_fence();                              \

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -503,3 +503,11 @@ function test_thread_too_few_iters()
     @test !(true in found[nthreads():end])
 end
 test_thread_too_few_iters()
+
+
+function test_27020_SIGSEGV()
+    x = BigInt()
+    # We only care that this call does not throw a SIGSEGV, so no need to check return value
+    @threadcall((:__gmpz_init, :libgmp), Cvoid, (Ptr{BigInt}, ), Ref(x))
+end
+test_27020_SIGSEGV()


### PR DESCRIPTION
When using the snowflake connector through `PyCall`, we end up with a segfault due to `ptls->safepoint` being `NULL` when dereferenced via `maybe_collect`. This patch checks for nullness before dereferencing the pointer.

To reproduce:

1. Start with julia 0.6.x, python 3.4+ and PyCall installed to use the system python 3.4 (not Conda).
2. Install the snowflake connector: `sudo pip3 install --upgrade snowflake-connector-python`
3. In julia, run the following code:

```julia
julia> using PyCall
julia> @pyimport snowflake.connector as snowflake
julia> snowflake.connect(account="snowflake", user="foo", password="bar")
```

The values for `account`, `user` and `password` are not important, but all three must be present. At this point the snowflake connector attempts to connect to the snowflake server, and we get a segfault with the following stack trace:

```
#0  jl_unw_step (sp=0x7f48ddac2f10, ip=0x0, cursor=0x7f48ddac3020) at /buildworker/worker/package_linux64/build/src/stackwalk.c:318
318 /buildworker/worker/package_linux64/build/src/stackwalk.c: No such file or directory.
(gdb) bt
#0  jl_unw_step (sp=0x7f48ddac2f10, ip=0x0, cursor=0x7f48ddac3020) at /buildworker/worker/package_linux64/build/src/stackwalk.c:318
#1  jl_unw_stepn (cursor=cursor@entry=0x7f48ddac3020, ip=ip@entry=0x0, sp=sp@entry=0x0, maxsize=maxsize@entry=80000)
    at /buildworker/worker/package_linux64/build/src/stackwalk.c:47
#2  0x00007f48ed49285c in rec_backtrace_ctx (data=data@entry=0x0, maxsize=maxsize@entry=80000, context=context@entry=0x7f48ddac35c0)
    at /buildworker/worker/package_linux64/build/src/stackwalk.c:76
#3  0x00007f48ed4a1404 in jl_critical_error (bt_size=0x7f48ddac8db0, bt_data=0x0, context=0x7f48ddac35c0, sig=11)
    at /buildworker/worker/package_linux64/build/src/signal-handling.c:108
#4  sigdie_handler (sig=11, info=<optimized out>, context=0x7f48ddac35c0) at /buildworker/worker/package_linux64/build/src/signals-unix.c:180
#5  0x00007f48ed4a1937 in segv_handler (sig=11, info=0x7f48ddac36f0, context=0x7f48ddac35c0)
    at /buildworker/worker/package_linux64/build/src/signals-unix.c:264
#6  <signal handler called>
#7  0x00007f48ed49bc33 in maybe_collect (ptls=<optimized out>) at /buildworker/worker/package_linux64/build/src/gc.c:653
#8  jl_gc_counted_malloc (sz=24) at /buildworker/worker/package_linux64/build/src/gc.c:2182
#9  0x00007f48e18a5148 in __gmpz_init () from /opt/julia-0.6.2/bin/../lib/julia/libgmp.so
#10 0x00007f48cf921c7c in ffi_call_unix64 () from /usr/lib/x86_64-linux-gnu/libffi.so.6
#11 0x00007f48cf9215ac in ffi_call () from /usr/lib/x86_64-linux-gnu/libffi.so.6
#12 0x00007f48cc5bb26f in cdata_call (cd=0x7f48c8fb7990, args=<optimized out>, kwds=<optimized out>) at c/_cffi_backend.c:3025
#13 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#14 0x00007f48d0732f3d in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#15 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#16 0x00007f48d0738fa6 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#17 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#18 0x00007f48d068059d in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#19 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#20 0x00007f48d05f9bf9 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#21 0x00007f48d06a3636 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#22 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#23 0x00007f48d0732f3d in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#24 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#25 0x00007f48d07351b2 in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#26 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#27 0x00007f48d07351b2 in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#28 0x00007f48d07356cc in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#29 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#30 0x00007f48d07351b2 in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#31 0x00007f48d07356cc in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#32 0x00007f48d07356cc in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#33 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#34 0x00007f48d0739083 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#35 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#36 0x00007f48d0731704 in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#37 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#38 0x00007f48d0739083 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#39 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#40 0x00007f48d0731704 in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#41 0x00007f48d07356cc in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#42 0x00007f48d07356cc in PyEval_EvalFrameEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#43 0x00007f48d0738976 in PyEval_EvalCodeEx () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#44 0x00007f48d0738fa6 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#45 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#46 0x00007f48d068059d in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#47 0x00007f48d069a758 in PyObject_Call () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#48 0x00007f48d07109b7 in PyEval_CallObjectWithKeywords () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#49 0x00007f48d0777e32 in ?? () from /usr/lib/x86_64-linux-gnu/libpython3.4m.so
#50 0x00007f48ecdf1184 in start_thread (arg=0x7f48ddacb700) at pthread_create.c:312
#51 0x00007f48ecb1e37d in eventfd (count=-504087184, flags=-940641344) at ../sysdeps/unix/sysv/linux/eventfd.c:55
#52 0x0000000000000000 in ?? ()
```

The problem appears to be in `maybe_collect` where it calls `jl_gc_safepoint_(ptls)`, which is a macro that tries to dereference `ptls->safepoint`, which at this point is `NULL`.

I don't know why this value is `NULL`, but wrapping it in a nullcheck avoids the segfault and my code executes correctly after that.