### PR TITLE
fix and generalize comprehension lowering

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -347,9 +347,9 @@ function _jl_spawn(file, argv, cmd::Cmd, stdio)
     loop = eventloop()
     handles = Tuple{Cint, UInt}[ # assuming little-endian layout
         let h = rawhandle(io)
-            h === C_NULL    && return (0x00, UInt(0))
-            h isa OS_HANDLE && return (0x02, UInt(cconvert(@static(Sys.iswindows() ? Ptr{Cvoid} : Cint), h)))
-            h isa Ptr{Cvoid} && return (0x04, UInt(h))
+            h === C_NULL     ? (0x00, UInt(0)) :
+            h isa OS_HANDLE  ? (0x02, UInt(cconvert(@static(Sys.iswindows() ? Ptr{Cvoid} : Cint), h))) :
+            h isa Ptr{Cvoid} ? (0x04, UInt(h)) :
             error("invalid spawn handle $h from $io")
         end
         for io in stdio]

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2314,56 +2314,59 @@
                (let ((ranges (cddr (caddr e))))
                  (if (any (lambda (x) (eq? x ':)) ranges)
                      (error "comprehension syntax with `:` ranges has been removed"))
-                 (and (every (lambda (x) (and (pair? x) (eq? (car x) '=)
-                                              (pair? (caddr x))
-                                              (eq? (car (caddr x)) 'call)
-                                              (eq? (cadr (caddr x)) ':)))
+                 (and (every (lambda (x) (and (pair? x) (eq? (car x) '=)))
                              ranges)
                       ;; TODO: this is a hack to lower simple comprehensions to loops very
                       ;; early, to greatly reduce the # of functions and load on the compiler
                       (lower-comprehension (cadr e) (cadr (caddr e)) ranges))))
           `(call (top collect) ,(cadr e) ,(caddr e)))))))
 
-(define (lower-comprehension atype expr ranges)
-  (let ((result    (make-ssavalue))
-        (ri        (gensy))
+(define (lower-comprehension ty expr itrs)
+  (let ((result    (gensy))
+        (idx       (gensy))
         (oneresult (make-ssavalue))
-        (lengths   (map (lambda (x) (make-ssavalue)) ranges))
-        (states    (map (lambda (x) (gensy)) ranges))
-        (rv        (map (lambda (x) (make-ssavalue)) ranges)))
+        (prod      (make-ssavalue))
+        (isz       (make-ssavalue))
+        (szunk     (make-ssavalue))
+        (iv        (map (lambda (x) (make-ssavalue)) itrs)))
 
-    ;; construct loops to cycle over all dimensions of an n-d comprehension
-    (define (construct-loops ranges rv states lengths)
-      (if (null? ranges)
+    ;; construct loops over all iterators
+    (define (construct-loops itrs iv)
+      (if (null? itrs)
           `(block (= ,oneresult ,expr)
                   (inbounds true)
-                  (call (top setindex!) ,result ,oneresult ,ri)
+                  (if ,szunk
+                      (call (top push!) ,result ,oneresult)
+                      (call (top setindex!) ,result ,oneresult ,idx))
                   (inbounds pop)
-                  (= ,ri (call (top add_int) ,ri 1)))
-          `(block
-            (= ,(car states) (call (top start) ,(car rv)))
-            (while (call (top not_int) (call (core typeassert) (call (top done) ,(car rv) ,(car states)) (core Bool)))
-                   (scope-block
-                   (block
-                    (= (tuple ,(cadr (car ranges)) ,(car states))
-                       (call (top next) ,(car rv) ,(car states)))
-                    ;; *** either this or force all for loop vars local
-                    ,.(map (lambda (r) `(local ,r))
-                           (lhs-vars (cadr (car ranges))))
-                    ,(construct-loops (cdr ranges) (cdr rv) (cdr states) (cdr lengths))))))))
+                  (= ,idx (call (top add_int) ,idx 1)))
+          `(for (= ,(cadr (car itrs)) ,(car iv))
+                (block
+                 ;; TODO: remove when all loop vars are local in 1.0
+                 ,.(map (lambda (v) `(local ,v))
+                        (lhs-vars (cadr (car itrs))))
+                 ,(construct-loops (cdr itrs) (cdr iv))))))
 
-    ;; Evaluate the comprehension
-    `(block
-      ,.(map (lambda (v) `(local ,v)) states)
-      (local ,ri)
-      ,.(map (lambda (v r) `(= ,v ,(caddr r))) rv ranges)
-      ,.(map (lambda (v r) `(= ,v (call (top length) ,r))) lengths rv)
-      (scope-block
-       (block
-        (= ,result (call (curly Array ,atype ,(length lengths)) undef ,@lengths))
-        (= ,ri 1)
-        ,(construct-loops (reverse ranges) (reverse rv) states (reverse lengths))
-        ,result)))))
+    (let ((overall-itr (if (length= itrs 1) (car iv) prod)))
+      `(scope-block
+        (block
+         (local ,result) (local ,idx)
+         ,.(map (lambda (v r) `(= ,v ,(caddr r))) iv itrs)
+         ,.(if (length= itrs 1)
+               '()
+               `((= ,prod (call (top product) ,@iv))))
+         (= ,isz (call (top IteratorSize) ,overall-itr))
+         (= ,szunk (call (core isa) ,isz (top SizeUnknown)))
+         (if ,szunk
+             (= ,result (call (curly (core Array) ,ty 1) (core undef) 0))
+             (if (call (core isa) ,isz (top HasShape))
+                 (= ,result (call (top similar) (curly (core Array) ,ty) (call (top axes) ,overall-itr)))
+                 (= ,result (call (curly (core Array) ,ty 1) (core undef) (call (core Int)
+                                                                                (|::| (call (top length) ,overall-itr)
+                                                                                 (core Integer)))))))
+         (= ,idx (call (top first) (call (top LinearIndices) ,result)))
+         ,(construct-loops (reverse itrs) (reverse iv))
+         ,result)))))
 
 (define (lhs-vars e)
   (cond ((symbol? e) (list e))

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -195,7 +195,7 @@ broadcast(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...
 *(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)
 function *(u::TransposeAbsVec, v::AbstractVector)
     @boundscheck length(u) == length(v) || throw(DimensionMismatch())
-    return sum(@inbounds(return u[k]*v[k]) for k in 1:length(u))
+    return sum(@inbounds(u[k]*v[k]) for k in 1:length(u))
 end
 # vector * Adjoint/Transpose-vector
 *(u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, u, v)

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -545,7 +545,7 @@ IndexStyle(::Type{<:RowVector}) = IndexLinear()
     if length(rowvec) != length(vec)
         throw(DimensionMismatch("A has dimensions $(size(rowvec)) but B has dimensions $(size(vec))"))
     end
-    sum(@inbounds(return rowvec[i]*vec[i]) for i = 1:length(vec))
+    sum(@inbounds(rowvec[i]*vec[i]) for i = 1:length(vec))
 end
 @inline *(rowvec::RowVector, mat::AbstractMatrix) = rvtranspose(transpose(mat) * rvtranspose(rowvec))
 *(::RowVector, ::RowVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -220,3 +220,10 @@ end
 let (:)(a,b) = (i for i in Base.:(:)(1,10) if i%2==0)
     @test Int8[ i for i = 1:2 ] == [2,4,6,8,10]
 end
+
+# comprehensions with `return`
+let f() = [ return 2 for i=1:2 ],
+    g() = Int[return 2 for i=1:2 ]
+    @test f() == [2, 2]
+    @test g() == [2, 2]
+end

--- a/test/functional.jl
+++ b/test/functional.jl
@@ -208,3 +208,15 @@ end
     @test Core.Compiler.return_type(collect, Tuple{typeof(x+y for x in Real[], y in Real[])}) <: Matrix
     @test Core.Compiler.return_type(collect, Tuple{typeof(x for x in Union{Bool,String}[])}) <: Array
 end
+
+let x = rand(2,2)
+    (:)(a,b) = x
+    @test Float64[ i for i = 1:2 ] == x
+    @test Float64[ i+j for i = 1:2, j = 1:2 ] == cat(4,
+                                                     cat(3, x[1].+x, x[2].+x),
+                                                     cat(3, x[3].+x, x[4].+x))
+end
+
+let (:)(a,b) = (i for i in Base.:(:)(1,10) if i%2==0)
+    @test Int8[ i for i = 1:2 ] == [2,4,6,8,10]
+end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1432,3 +1432,9 @@ catch e
     @test e isa LoadError
     @test e.error isa MethodError
 end
+
+@test Meta.lower(@__MODULE__, :(if true; break; end for i = 1:1)) == Expr(:error, "break or continue outside loop")
+@test Meta.lower(@__MODULE__, :([if true; break; end for i = 1:1])) == Expr(:error, "break or continue outside loop")
+@test Meta.lower(@__MODULE__, :(Int[if true; break; end for i = 1:1])) == Expr(:error, "break or continue outside loop")
+@test Meta.lower(@__MODULE__, :([if true; continue; end for i = 1:1])) == Expr(:error, "break or continue outside loop")
+@test Meta.lower(@__MODULE__, :(Int[if true; continue; end for i = 1:1])) == Expr(:error, "break or continue outside loop")


### PR DESCRIPTION
Ever since we changed how comprehensions (and higher-order functions generally) work in v0.5, there has been a special case in lowering for comprehensions of the form `T[a for b in c:d, ...]`. This greatly reduces the number of types and specializations the compiler has to deal with, consequently helping compiler performance and code size. It also speeds up small comprehensions by force-inlining everything. Unfortunately that lowering is technically incorrect, since it makes assumptions about what `:` does (the problem is worse ever since #26074 allowed local definitions of `:`, although uses of that will be quite rare).

This fixes the problem by correctly handling any comprehension of the form `T[a for b in c, ...]`, eliminating the need for compiler performance tweaks like those in #26897. I see definite improvements in compile times and code size from this.

Of course the lowering for this is a bit nasty, since the whole behavior needs to be conditioned on `IteratorSize`. In the best case all of that will be optimized out, but in the worst case the loop will be slower. However, that is arguably better handled by more general outlining to move the loop to a separately-specialized function only when needed.

@nanosoldier `runbenchmarks(ALL, vs = ":master")`
