### PR TITLE
Simplify SparseMatrix setindex!

### DIFF
--- a/stdlib/SparseArrays/src/deprecated.jl
+++ b/stdlib/SparseArrays/src/deprecated.jl
@@ -223,7 +223,7 @@ import Base: asyncmap
 @deprecate asyncmap(f, s::AbstractSparseArray...; kwargs...) sparse(asyncmap(f, map(Array, s)...; kwargs...))
 
 # PR 26347: implicit scalar broadcasting within setindex!
-@deprecate setindex!(A::SparseMatrixCSC{<:Any,<:Any}, x, i::Union{Integer, AbstractVector{<:Integer}, Colon}, j::Union{Integer, AbstractVector{<:Integer}, Colon}) (A[i, :] .= x; A)
+@deprecate setindex!(A::SparseMatrixCSC{<:Any,<:Any}, x, i::Union{Integer, AbstractVector{<:Integer}, Colon}, j::Union{Integer, AbstractVector{<:Integer}, Colon}) (A[i, j] .= x; A)
 
 #25395 keywords unlocked
 @deprecate dropzeros(x, trim)     dropzeros(x, trim = trim)

--- a/stdlib/SparseArrays/src/deprecated.jl
+++ b/stdlib/SparseArrays/src/deprecated.jl
@@ -223,13 +223,7 @@ import Base: asyncmap
 @deprecate asyncmap(f, s::AbstractSparseArray...; kwargs...) sparse(asyncmap(f, map(Array, s)...; kwargs...))
 
 # PR 26347: implicit scalar broadcasting within setindex!
-@deprecate setindex!(A::SparseMatrixCSC, x::Number, i::Integer, J::AbstractVector{<:Integer}) (A[i, J] .= x; A)
-@deprecate setindex!(A::SparseMatrixCSC, x::Number, I::AbstractVector{<:Integer}, j::Integer) (A[I, j] .= x; A)
-@deprecate setindex!(A::SparseMatrixCSC, x, ::Colon)          fill!(A, x)
-@deprecate setindex!(A::SparseMatrixCSC, x, ::Colon, ::Colon) fill!(A, x)
-@deprecate setindex!(A::SparseMatrixCSC, x, ::Colon, j::Union{Integer, AbstractVector}) (A[:, j] .= x; A)
-@deprecate setindex!(A::SparseMatrixCSC, x, i::Union{Integer, AbstractVector}, ::Colon) (A[i, :] .= x; A)
-@deprecate setindex!(A::SparseMatrixCSC, x::Number, I::AbstractVector{<:Integer}, J::AbstractVector{<:Integer}) (A[I, J] .= x; A)
+@deprecate setindex!(A::SparseMatrixCSC{<:Any,<:Any}, x, i::Union{Integer, AbstractVector{<:Integer}, Colon}, j::Union{Integer, AbstractVector{<:Integer}, Colon}) (A[i, :] .= x; A)
 
 #25395 keywords unlocked
 @deprecate dropzeros(x, trim)     dropzeros(x, trim = trim)


### PR DESCRIPTION
Fix #27013, and add a whole slew of tests. `methods(setindex!, Tuple{SparseMatrixCSC, Vararg{Any}})` goes from a hodgepodge of 26 methods that were tough to reason about to just 6 methods: scalar, logical linear indexing, linear indexing with a vector, linear indexing with a matrix, generic nonscalar indexing, and a disambiguation method. This is much easier to reason about, and fixes a handful of bugs.