### PR TITLE
make -O1 a bit more useful by disabling more optimization passes

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -111,8 +111,13 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
 #if defined(JL_MSAN_ENABLED)
     PM->add(llvm::createMemorySanitizerPass(true));
 #endif
-    if (opt_level == 0) {
+    if (opt_level < 2) {
         PM->add(createCFGSimplificationPass()); // Clean up disgusting code
+        if (opt_level == 1) {
+            PM->add(createSROAPass());                 // Break up aggregate allocas
+            PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
+            PM->add(createEarlyCSEPass());
+        }
 #if JL_LLVM_VERSION < 50000
         PM->add(createBarrierNoopPass());
         PM->add(createLowerExcHandlersPass());


### PR DESCRIPTION
Here are some really simple benchmarks. The first in each pair is intended to test compiler performance, the second run-time performance:

```
a = Any[1,2,3];
b = rand(2000, 2000);
f = x->2x

# default -O2:

julia> @time map(x->2x, a);
  0.070061 seconds (34.49 k allocations: 2.088 MiB)

julia> @btime map(f, b);
  5.943 ms (3 allocations: 30.52 MiB)

# -O0:

julia> @time map(x->2x, a);
  0.046827 seconds (34.62 k allocations: 2.113 MiB)

julia> @btime map(f, b);
  39.607 ms (3 allocations: 30.52 MiB)

# old -O1:

julia> @time map(x->2x, a);
  0.067364 seconds (34.61 k allocations: 2.079 MiB)

julia> @btime map(f, b);
  5.928 ms (3 allocations: 30.52 MiB)

# new -O1:

julia> @time map(x->2x, a);
  0.057817 seconds (34.48 k allocations: 2.099 MiB)

julia> @btime map(f, b);
  5.968 ms (3 allocations: 30.52 MiB)
```

The basic story is simple: `-O0` cuts down compile time a lot, but generated code performance is terrible. The existing `-O1` option (which just switches to fast isel) doesn't help compile time much. The new `-O1` option proposed here gets similar run-time performance to `-O2` but with significantly less compile time. Of course I don't expect the same results in all cases, but I feel this -O1 is closer to the optimal frontier in compile-time vs. run-time performance. Basically, you get big gains from just SROA (which @Keno has told me the LLVM folks now recommend over mem2reg).