### PR TITLE
RFC: disallow `return` inside generator and comprehension expressions

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -347,9 +347,9 @@ function _jl_spawn(file, argv, cmd::Cmd, stdio)
     loop = eventloop()
     handles = Tuple{Cint, UInt}[ # assuming little-endian layout
         let h = rawhandle(io)
-            h === C_NULL    && return (0x00, UInt(0))
-            h isa OS_HANDLE && return (0x02, UInt(cconvert(@static(Sys.iswindows() ? Ptr{Cvoid} : Cint), h)))
-            h isa Ptr{Cvoid} && return (0x04, UInt(h))
+            h === C_NULL     ? (0x00, UInt(0)) :
+            h isa OS_HANDLE  ? (0x02, UInt(cconvert(@static(Sys.iswindows() ? Ptr{Cvoid} : Cint), h))) :
+            h isa Ptr{Cvoid} ? (0x04, UInt(h)) :
             error("invalid spawn handle $h from $io")
         end
         for io in stdio]

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1610,6 +1610,11 @@
                         (call (top not_int) (call (core typeassert) (call (top done) ,coll ,state) (core Bool)))
                         ,body))))))))
 
+(define (check-generator-expr e)
+  (if (expr-contains-p return? e (lambda (x) (not (function-def? x))))
+      (error "\"return\" not allowed inside a generator expression")
+      #t))
+
 ;; wrap `expr` in a function appropriate for consuming values from given ranges
 (define (func-for-generator-ranges expr range-exprs flat outervars)
   (let* ((vars    (map cadr range-exprs))
@@ -1639,6 +1644,7 @@
                                                                                outervars)))
                               ,expr))
                           (else expr))))
+          (check-generator-expr expr)
           `(-> ,argname (block ,@splat ,expr))))))
 
 (define (expand-generator e flat outervars)
@@ -2321,6 +2327,7 @@
                              ranges)
                       ;; TODO: this is a hack to lower simple comprehensions to loops very
                       ;; early, to greatly reduce the # of functions and load on the compiler
+                      (check-generator-expr (caddr e))
                       (lower-comprehension (cadr e) (cadr (caddr e)) ranges))))
           `(call (top collect) ,(cadr e) ,(caddr e)))))))
 

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -195,7 +195,7 @@ broadcast(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...
 *(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)
 function *(u::TransposeAbsVec, v::AbstractVector)
     @boundscheck length(u) == length(v) || throw(DimensionMismatch())
-    return sum(@inbounds(return u[k]*v[k]) for k in 1:length(u))
+    return sum(@inbounds(u[k]*v[k]) for k in 1:length(u))
 end
 # vector * Adjoint/Transpose-vector
 *(u::AbstractVector, v::AdjOrTransAbsVec) = broadcast(*, u, v)

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -545,7 +545,7 @@ IndexStyle(::Type{<:RowVector}) = IndexLinear()
     if length(rowvec) != length(vec)
         throw(DimensionMismatch("A has dimensions $(size(rowvec)) but B has dimensions $(size(vec))"))
     end
-    sum(@inbounds(return rowvec[i]*vec[i]) for i = 1:length(vec))
+    sum(@inbounds(rowvec[i]*vec[i]) for i = 1:length(vec))
 end
 @inline *(rowvec::RowVector, mat::AbstractMatrix) = rvtranspose(transpose(mat) * rvtranspose(rowvec))
 *(::RowVector, ::RowVector) = throw(DimensionMismatch("Cannot multiply two transposed vectors"))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1432,3 +1432,9 @@ catch e
     @test e isa LoadError
     @test e.error isa MethodError
 end
+
+@test Meta.lower(@__MODULE__, :(return 0 for i = 1:2)) == Expr(:error, "\"return\" not allowed inside a generator expression")
+@test Meta.lower(@__MODULE__, :([ return 0 for i = 1:2 ])) == Expr(:error, "\"return\" not allowed inside a generator expression")
+@test Meta.lower(@__MODULE__, :(Int[ return 0 for i = 1:2 ])) == Expr(:error, "\"return\" not allowed inside a generator expression")
+@test [ (()->return 42) for i = 1:1 ][1]() == 42
+@test Function[ (()->return 42) for i = 1:1 ][1]() == 42


### PR DESCRIPTION
This allows us to avoid defining whether a generator expression is wrapped in a function, and avoids possible confusion about where the `return` will actually return from (since it's not lexically obvious that the generator expression is nested inside a function). Alternatively, we could decide that a generator officially introduces a nested function, and fix this case in the special alternate comprehension lowering.

ref #27023
