### PR TITLE
fix showing shared arrays

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -415,7 +415,7 @@ _show_empty(io, X) = nothing # by default, we don't know this constructor
 
 # typeinfo aware (necessarily)
 function show(io::IO, X::AbstractArray)
-    @assert ndims(X) != 1
+    ndims(X) == 1 && return show_vector(io, X)
     prefix = typeinfo_prefix(io, X)
     io = IOContext(io, :typeinfo => eltype(X), :compact => true)
     isempty(X) ?
@@ -442,8 +442,6 @@ function show_vector(io::IO, v, opn='[', cls=']')
         show_delim_array(io, v, opn, ",", cls, false)
     end
 end
-
-show(io::IO, X::AbstractVector) = show_vector(io, X)
 
 
 ## Logic for displaying type information

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -299,3 +299,7 @@ end
 let s = convert(SharedArray, [1,2,3,4])
     @test pmap(i->length(s), 1:2) == [4,4]
 end
+
+let S = SharedArray([1,2,3])
+    @test sprint(show, S) == "[1, 2, 3]"
+end


### PR DESCRIPTION
Fixes #27045 

not sure if this is the best fix but should do the job.

The problem here was that SharedArray `invoke`s `show` in a way that AFAIU circumvents the normal dispatch.