### PR TITLE
Revert "enable the SLP Vectorizer optimization pass by default"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -666,9 +666,6 @@ Compiler/Runtime improvements
   * Inference now propagates constants inter-procedurally, and can compute
     various constants expressions at compile-time ([#24362]).
 
-  * The LLVM SLP Vectorizer optimization pass is now enabled at the default
-    optimization level.
-
 Deprecated or removed
 ---------------------
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -252,9 +252,14 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     PM->add(createLoopIdiomPass());
     PM->add(createLoopDeletionPass());          // Delete dead loops
     PM->add(createJumpThreadingPass());         // Thread jumps
-    PM->add(createSLPVectorizerPass());         // Vectorize straight-line code
+
+    if (opt_level >= 3) {
+        PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
+    }
+
     PM->add(createAggressiveDCEPass());         // Delete dead instructions
-    PM->add(createInstructionCombiningPass());  // Clean up after SLP loop vectorizer
+    if (opt_level >= 3)
+        PM->add(createInstructionCombiningPass());   // Clean up after SLP loop vectorizer
     PM->add(createLoopVectorizePass());         // Vectorize loops
     PM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
     // LowerPTLS removes an indirect call. As a result, it is likely to trigger


### PR DESCRIPTION
This reverts commit 32bcf5d8e547ca57e02536aca4354316364db8bb.

Temporary fix for #27032, a real fix is still needed