### PR TITLE
Stop setting force_noinline for functions of union arguments

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1161,7 +1161,7 @@ function print_statement_costs(io::IO, @nospecialize(tt::Type);
         code === nothing && error("inference not successful") # inference disabled?
         empty!(cst)
         resize!(cst, length(code.code))
-        maxcost = Core.Compiler.statement_costs!(cst, code.code, code, Any[match.sparams...], params)
+        maxcost = Core.Compiler.statement_costs!(cst, code.code, code, Any[match.sparams...], false, params)
         nd = ndigits(maxcost)
         println(io, meth)
         IRShow.show_ir(io, code, (io, linestart, idx) -> (print(io, idx > 0 ? lpad(cst[idx], nd+1) : " "^(nd+1), " "); return ""))


### PR DESCRIPTION
The original motivation for setting force_noinline for functions
with union arguments seems to have been bugs in type intersection.
However, the type system has improved quite a bit and at least in
the test suites we don't seem to run into any issues. Thus, we can
stop setting force_noinline. Nevertheless, it still make since
to penalize functions with union arguments. Doing so encourages
union splits to happen at the call site, rather than having multiple
redundant union splits inside the function. However, for simple functions
of intrinsics and builtins it can make a lot of sense to inline
the union split signature.