### PR TITLE
Fix `join((), ", ")`

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -234,7 +234,6 @@ function join(io::IO, strings, delim, last)
         print(io, str)
     end
 end
-
 function join(io::IO, strings, delim)
     a = Iterators.Stateful(strings)
     for str in a
@@ -243,6 +242,9 @@ function join(io::IO, strings, delim)
     end
 end
 join(io::IO, strings) = join(io, strings, "")
+# Hack around https://github.com/JuliaLang/julia/issues/26871
+join(io::IO, strings::Tuple{}, delim) = nothing
+join(io::IO, strings::Tuple{}, delim, last) = nothing
 
 join(strings) = sprint(join, strings)
 join(strings, delim) = sprint(join, strings, delim)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -202,7 +202,7 @@ Base.getindex(::V26163, ::Int) = 0
     @test reshape(z, 1) == v == [0]
     @test reshape(z, 1, 1) == reshape(v, 1, 1) == fill(0, 1, 1)
     @test occursin("1-element reshape", summary(reshape(z, 1)))
-    @test_broken occursin("0-dimensional reshape", summary(reshape(v, ())))
+    @test occursin("0-dimensional reshape", summary(reshape(v, ())))
 end
 
 @test reshape(1:5, (5,)) === 1:5

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -145,7 +145,7 @@
 end
 @testset "join()" begin
     @test join([]) == join([],",") == ""
-    @test_broken join(()) == join((),",") == ""
+    @test join(()) == join((),",") == ""
     @test join(["a"],"?") == "a"
     @test join("HELLO",'-') == "H-E-L-L-O"
     @test join(1:5, ", ", " and ") == "1, 2, 3, 4 and 5"

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -151,6 +151,9 @@ end
     @test join(1:5, ", ", " and ") == "1, 2, 3, 4 and 5"
     @test join(["apples", "bananas", "pineapples"], ", ", " and ") == "apples, bananas and pineapples"
     @test_throws MethodError join(1, 2, 3, 4)
+    @test join(()) == ""
+    @test join((), ", ") == ""
+    @test join((), ", ", ", and ") == ""
 end
 
 # issue #9178 `join` calls `done()` twice on the iterables


### PR DESCRIPTION
This is simply a hack to avoid working with an `Iterators.Stateful(())`, which has problems when trying to stably infer the return type of the error function `next((), _)`. Punts https://github.com/JuliaLang/julia/issues/26871 to just using `Stateful` itself.

Note that `join((), …)` frequently pops up when displaying sizes or axes of a zero-dimensional array.