### PR TITLE
don't allow promoting `Some{T}` and `Some{S}`

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -35,6 +35,8 @@ end
 promote_rule(::Type{Union{Nothing, Missing}}, ::Type{Any}) = Any
 promote_rule(::Type{Union{Nothing, Missing}}, ::Type{T}) where {T} =
     Union{Nothing, Missing, T}
+promote_rule(::Type{Union{Nothing, Missing, S}}, ::Type{T}) where {T,S} =
+    Union{Nothing, Missing, promote_type(T, S)}
 
 convert(::Type{Union{T, Missing}}, x) where {T} = convert(T, x)
 # To fix ambiguities

--- a/base/some.jl
+++ b/base/some.jl
@@ -12,7 +12,7 @@ struct Some{T}
     value::T
 end
 
-promote_rule(::Type{Some{S}}, ::Type{Some{T}}) where {S,T} = Some{promote_type(S, T)}
+promote_rule(::Type{Some{T}}, ::Type{Some{S}}) where {T, S<:T} = Some{T}
 promote_rule(::Type{Some{T}}, ::Type{Nothing}) where {T} = Union{Some{T}, Nothing}
 
 convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -286,6 +286,7 @@ end
         pop!(need_to_handle_undef_sparam, which(Base.convert, Tuple{Type{Union{Missing, T}} where T, Any}))
         pop!(need_to_handle_undef_sparam, which(Base.promote_rule, Tuple{Type{Union{Nothing, S}} where S, Type{T} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.promote_rule, Tuple{Type{Union{Missing, S}} where S, Type{T} where T}))
+        pop!(need_to_handle_undef_sparam, which(Base.promote_rule, Tuple{Type{Union{Missing, Nothing, S}} where S, Type{T} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.zero, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.one, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.oneunit, Tuple{Type{Union{Missing, T}} where T}))

--- a/test/some.jl
+++ b/test/some.jl
@@ -2,7 +2,9 @@
 
 ## promote()
 
-@test promote_type(Some{Int}, Some{Float64}) === Some{Float64}
+@test promote_type(Some{Int}, Some{Float64}) == Some
+@test promote_type(Some{Int}, Some{Real}) == Some{Real}
+@test promote_type(Some{Int}, Nothing) == Union{Some{Int},Nothing}
 
 ## convert()
 
@@ -75,6 +77,15 @@ for v in (nothing, missing)
     @test coalesce(v, nothing) === nothing
     @test coalesce(v, missing, v) === v
     @test coalesce(v, nothing, v) === v
+
+    # issue #26927
+    a = [missing, nothing, Some(nothing), Some(missing)]
+    @test a isa Vector{Union{Missing, Nothing, Some}}
+    @test a[1] === missing && a[2] === nothing && a[3] === Some(nothing) && a[4] === Some(missing)
+    b = [ "replacement", "replacement", nothing, missing ]
+    @test b isa Vector{Union{Missing, Nothing, String}}
+    # the original operation from the issue, though it was not the source of the problem
+    @test all(coalesce.(a, "replacement") .=== b)
 end
 
 # notnothing()


### PR DESCRIPTION
Currently, `[Some(1), Some(2.0)]` gives a `Vector{Some{Float64}}`. That doesn't seem right to me; `Some(1)` is not itself a number but a wrapper whose purpose is to convey the presence of a value, and then get unwrapped. So I think we should leave values inside them alone in promotion. Changing that fixes the error reported in #26927.

I also added a promotion rule that allows entering the array `["", "", nothing, missing]`, which previously led to the same ambiguity error.