### PR TITLE
Deprecate flipbits! in favor of dot-broadcasting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -977,6 +977,9 @@ Deprecated or removed
     been deprecated due to inconsistency with linear algebra. Use `.+` and `.-` for these operations
     instead ([#22880], [#22932]).
 
+  * `flipbits!(B)` is deprecated in favor of using in-place broadcast to negate each element:
+    `B .= .!B` ([#27067]).
+
   * `isleaftype` is deprecated in favor of the simpler predicates `isconcretetype` and `isdispatchtuple`.
     Concrete types are those that might equal `typeof(x)` for some `x`;
     `isleaftype` included some types for which this is not true. Those are now categorized more precisely

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1062,36 +1062,6 @@ function (-)(B::BitArray)
     return A
 end
 
-"""
-    flipbits!(B::BitArray{N}) -> BitArray{N}
-
-Performs a bitwise not operation on `B`. See [`~`](@ref).
-
-# Examples
-```jldoctest
-julia> A = trues(2,2)
-2×2 BitArray{2}:
- true  true
- true  true
-
-julia> flipbits!(A)
-2×2 BitArray{2}:
- false  false
- false  false
-```
-"""
-function flipbits!(B::BitArray)
-    Bc = B.chunks
-    @inbounds if !isempty(Bc)
-        for i = 1:length(Bc)
-            Bc[i] = ~Bc[i]
-        end
-        Bc[end] &= _msk_end(B)
-    end
-    return B
-end
-
-
 ## Binary arithmetic operators ##
 
 for f in (:+, :-)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1644,6 +1644,9 @@ function search(buf::IOBuffer, delim::UInt8)
     return Int(q-p+1)
 end
 
+# Issue #27067
+@deprecate flipbits!(B::BitArray) B .= .!B
+
 @deprecate linearindices(x::AbstractArray) LinearIndices(x)
 
 # PR #26647

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -469,7 +469,6 @@ export
 
 # bitarrays
     falses,
-    flipbits!,
     trues,
 
 # dequeues

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -160,13 +160,3 @@ Base.reverse(::AbstractVector; kwargs...)
 Base.reverseind
 Base.reverse!
 ```
-
-## BitArrays
-
-[`BitArray`](@ref)s are space-efficient "packed" boolean arrays, which store one bit per boolean value.
-They can be used similarly to `Array{Bool}` arrays (which store one byte per boolean value),
-and can be converted to/from the latter via `Array(bitarray)` and `BitArray(array)`, respectively.
-
-```@docs
-Base.flipbits!
-```

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -722,6 +722,10 @@ indirectly.  By putting the [`@views`](@ref) macro in front of an expression or
 block of code, any `array[...]` slice in that expression will be converted to
 create a `SubArray` view instead.
 
+[`BitArray`](@ref)s are space-efficient "packed" boolean arrays, which store one bit per boolean value.
+They can be used similarly to `Array{Bool}` arrays (which store one byte per boolean value),
+and can be converted to/from the latter via `Array(bitarray)` and `BitArray(array)`, respectively.
+
 A "strided" array is stored in memory with elements laid out in regular offsets such that
 an instance with a supported `isbits` element type can be passed to
 external C and Fortran functions that expect this memory layout. Strided arrays

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -779,7 +779,8 @@ timesofar("dequeue")
     @testset "flipbits!" begin
         b1 = bitrand(n1, n2)
         i1 = Array(b1)
-        @test flipbits!(b1) == .~i1
+        b1 .= .!b1
+        @test b1 == .~i1
         @test bitcheck(b1)
     end
 end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -776,7 +776,7 @@ timesofar("dequeue")
     @check_bit_operation (-)(b0)  Vector{Int}
     @check_bit_operation broadcast(sign, b0) BitVector
 
-    @testset "flipbits!" begin
+    @testset "in-place .!" begin
         b1 = bitrand(n1, n2)
         i1 = Array(b1)
         b1 .= .!b1


### PR DESCRIPTION
Seems like we no longer need this function:

```julia
julia> B = bitrand(100,1000);

julia> @benchmark flipbits!($B)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     87.996 ns (0.00% GC)
  median time:      88.474 ns (0.00% GC)
  mean time:        88.596 ns (0.00% GC)
  maximum time:     118.378 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     960

julia> @benchmark $B .= .!$B
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     88.060 ns (0.00% GC)
  median time:      88.202 ns (0.00% GC)
  mean time:        88.314 ns (0.00% GC)
  maximum time:     137.057 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     960
```