### PR TITLE
[RFC] Fix issue when Enum doesn't display UInt8 correctly.

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -162,7 +162,12 @@ macro enum(T, syms...)
             Base.show_datatype(io, t)
             print(io, ":")
             for (sym, i) in $vals
-                print(io, "\n", sym, " = ", i)
+                print(io, "\n", sym, " = ")
+                if (isa(i, UInt8))
+                  show(io, i)
+                else
+                  print(io, i)
+                end
             end
         end
     end

--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -163,11 +163,7 @@ macro enum(T, syms...)
             print(io, ":")
             for (sym, i) in $vals
                 print(io, "\n", sym, " = ")
-                if (isa(i, UInt8))
-                  show(io, i)
-                else
-                  print(io, i)
-                end
+                show(io, i)
             end
         end
     end

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -156,6 +156,9 @@ let b = IOBuffer()
     @test deserialize(b) === apple
 end
 
+@enum UI8::UInt8 ten=0x0A thr=0x03 sevn=0x07
+@test repr("text/plain", UI8) == "Enum $(string(UI8)):\nten = 0x0a\nthr = 0x03\nsevn = 0x07"
+
 # test block form
 @enum BritishFood begin
     blackpudding = 1
@@ -163,6 +166,3 @@ end
     haggis       = 4
 end
 @test Int(haggis) == 4
-
-@enum UI8::UInt8 ten=0x0A thr=0x03 sevn=0x07
-@test repr("text/plain", UI8) == "Enum $(string(UI8)):\nten = 0x0a\nthr = 0x03\nsevn = 0x07"

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -138,10 +138,6 @@ end
 @test repr(apple) == "apple::$(string(Fruit)) = 0"
 @test string(apple) == "apple"
 
-@enum UI8::UInt8 ten=0x0A el=0x03 t=0x07
-
-@test repr("text/plain", UI8) == "Enum $(string(UI8)):\nten = 0x0a\nel = 0x03\nt = 0x07"
-
 @test repr("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
 @test repr("text/plain", orange) == "orange::$(curmod_prefix)Fruit = 1"
 let io = IOBuffer()
@@ -167,3 +163,6 @@ end
     haggis       = 4
 end
 @test Int(haggis) == 4
+
+@enum UI8::UInt8 ten=0x0A thr=0x03 sevn=0x07
+@test repr("text/plain", UI8) == "Enum $(string(UI8)):\nten = 0x0a\nthr = 0x03\nsevn = 0x07"

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -138,6 +138,10 @@ end
 @test repr(apple) == "apple::$(string(Fruit)) = 0"
 @test string(apple) == "apple"
 
+@enum UI8::UInt8 ten=0x0A el=0x03 t=0x07
+
+@test repr("text/plain", UI8) == "Enum $(string(UI8)):\nten = 0x0a\nel = 0x03\nt = 0x07"
+
 @test repr("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
 @test repr("text/plain", orange) == "orange::$(curmod_prefix)Fruit = 1"
 let io = IOBuffer()


### PR DESCRIPTION
Hi,

This PR solves the issue #27025 

As suggested, I've changed the call `print` to `show` when the enum type is `UInt8`.

Regards