### PR TITLE
[WIP] add world age bounds to CodeInfo

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -129,11 +129,11 @@ mutable struct InferenceState
 
         # TODO: we should be setting this correctly somewhere else
         if cached && !toplevel
-            src.min_world = min_world(linfo.def)
-            src.max_world = max_world(linfo.def)
+            set_min_world!(src, min_world(linfo.def))
+            set_max_world!(src, max_world(linfo.def))
         else
-            src.min_world = typemax(UInt)
-            src.max_world = typemin(UInt)
+            set_min_world!(src, typemax(UInt))
+            set_max_world!(src, typemin(UInt))
         end
         frame = new(
             params, result, linfo,
@@ -168,16 +168,16 @@ _topmod(sv::InferenceState) = _topmod(sv.mod)
 
 # work towards converging the valid age range for sv
 function update_valid_age!(min_valid::UInt, max_valid::UInt, sv::InferenceState)
-    sv.src.min_world = max(sv.src.min_world, min_valid)
-    sv.src.max_world = min(sv.src.max_world, max_valid)
+    set_min_world!(sv.src, max(min_world(sv.src), min_valid))
+    set_max_world!(sv.src, min(max_world(sv.src), max_valid))
     @assert(!isa(sv.linfo.def, Method) ||
             !sv.cached ||
-            sv.src.min_world <= sv.params.world <= sv.src.max_world,
+            min_world(sv.src) <= sv.params.world <= max_world(sv.src),
             "invalid age range update")
     nothing
 end
 
-update_valid_age!(edge::InferenceState, sv::InferenceState) = update_valid_age!(edge.src.min_world, edge.src.max_world, sv)
+update_valid_age!(edge::InferenceState, sv::InferenceState) = update_valid_age!(min_world(edge.src), max_world(edge.src), sv)
 update_valid_age!(li::MethodInstance, sv::InferenceState) = update_valid_age!(min_world(li), max_world(li), sv)
 
 function record_ssa_assign(ssa_id::Int, @nospecialize(new), frame::InferenceState)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -77,11 +77,11 @@ function newvar!(sv::OptimizationState, @nospecialize(typ))
 end
 
 function update_valid_age!(min_valid::UInt, max_valid::UInt, sv::OptimizationState)
-    sv.src.min_world = max(sv.src.min_world, min_valid)
-    sv.src.max_world = min(sv.src.max_world, max_valid)
+    set_min_world!(sv.src, max(min_world(sv.src), min_valid))
+    set_max_world!(sv.src, min(max_world(sv.src), max_valid))
     @assert(!isa(sv.linfo.def, Method) ||
-            (sv.src.min_world == typemax(UInt) && sv.src.max_world == typemin(UInt)) ||
-            sv.src.min_world <= sv.params.world <= sv.src.max_world,
+            (min_world(sv.src) == typemax(UInt) && max_world(sv.src) == typemin(UInt)) ||
+            min_world(sv.src) <= sv.params.world <= max_world(sv.src),
             "invalid age range update")
     nothing
 end
@@ -318,8 +318,8 @@ function optimize(me::InferenceState)
                 reindex_labels!(opt)
             end
         end
-        me.src.min_world = opt.src.min_world
-        me.src.max_world = opt.src.max_world
+        set_min_world!(me.src, min_world(opt.src))
+        set_max_world!(me.src, max_world(opt.src))
     end
 
     # convert all type information into the form consumed by the code-generator
@@ -407,8 +407,8 @@ function finish(me::InferenceState)
     if me.cached
         toplevel = !isa(me.linfo.def, Method)
         if !toplevel
-            min_valid = me.src.min_world
-            max_valid = me.src.max_world
+            min_valid = min_world(me.src)
+            max_valid = max_world(me.src)
         else
             min_valid = UInt(0)
             max_valid = UInt(0)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -92,9 +92,19 @@ function occurs_more(@nospecialize(e), pred, n)
     return 0
 end
 
-###########################
-# MethodInstance/CodeInfo #
-###########################
+##################################
+# Method/MethodInstance/CodeInfo #
+##################################
+
+min_world(m::Method) = reinterpret(UInt, m.min_world)
+max_world(m::Method) = typemax(UInt)
+min_world(m::MethodInstance) = reinterpret(UInt, m.min_world)
+max_world(m::MethodInstance) = reinterpret(UInt, m.max_world)
+min_world(c::CodeInfo) = reinterpret(UInt, c.min_world)
+max_world(c::CodeInfo) = reinterpret(UInt, c.max_world)
+
+set_min_world!(c::CodeInfo, w::UInt) = (sw = reinterpret(Int, w); c.min_world = sw; sw)
+set_max_world!(c::CodeInfo, w::UInt) = (sw = reinterpret(Int, w); c.max_world = sw; sw)
 
 function invoke_api(li::MethodInstance)
     return ccall(:jl_invoke_api, Cint, (Any,), li)

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -443,7 +443,7 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
                         end
                     end
                 end
-                if ex.world < min_world(method)
+                if ex.world < Core.Compiler.min_world(method)
                     print(iob, " (method too new to be called from this world context.)")
                 end
                 # TODO: indicate if it's in the wrong world

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1058,12 +1058,6 @@ has_bottom_parameter(t::Union) = has_bottom_parameter(t.a) & has_bottom_paramete
 has_bottom_parameter(t::TypeVar) = t.ub == Bottom || has_bottom_parameter(t.ub)
 has_bottom_parameter(::Any) = false
 
-min_world(m::Method) = reinterpret(UInt, m.min_world)
-max_world(m::Method) = typemax(UInt)
-min_world(m::Core.MethodInstance) = reinterpret(UInt, m.min_world)
-max_world(m::Core.MethodInstance) = reinterpret(UInt, m.max_world)
-
-
 """
     propertynames(x, private=false)
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1063,6 +1063,7 @@ max_world(m::Method) = typemax(UInt)
 min_world(m::Core.MethodInstance) = reinterpret(UInt, m.min_world)
 max_world(m::Core.MethodInstance) = reinterpret(UInt, m.max_world)
 
+
 """
     propertynames(x, private=false)
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2052,8 +2052,8 @@ void jl_init_types(void)
                             // If you change them, you'll have to adjust the
                             // serializer
                             jl_array_any_type,
-                            jl_ulong_type,
-                            jl_ulong_type,
+                            jl_long_type,
+                            jl_long_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2023,7 +2023,7 @@ void jl_init_types(void)
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(13,
+                        jl_perm_symsvec(15,
                             "code",
                             "codelocs",
                             "method_for_inference_limit_heuristics",
@@ -2033,11 +2033,13 @@ void jl_init_types(void)
                             "ssaflags",
                             "slotflags",
                             "slotnames",
+                            "min_world",
+                            "max_world",
                             "inferred",
                             "inlineable",
                             "propagate_inbounds",
                             "pure"),
-                        jl_svec(13,
+                        jl_svec(15,
                             jl_array_any_type,
                             jl_any_type,
                             jl_any_type,
@@ -2050,11 +2052,13 @@ void jl_init_types(void)
                             // If you change them, you'll have to adjust the
                             // serializer
                             jl_array_any_type,
+                            jl_ulong_type,
+                            jl_ulong_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 13);
+                        0, 1, 15);
 
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,

--- a/src/julia.h
+++ b/src/julia.h
@@ -247,6 +247,8 @@ typedef struct _jl_code_info_t {
         // 7 = has out-of-band info
     jl_array_t *slotflags;  // local var bit flags
     jl_array_t *slotnames; // names of local variables
+    size_t min_world;
+    size_t max_world;
     uint8_t inferred;
     uint8_t inlineable;
     uint8_t propagate_inbounds;

--- a/src/method.c
+++ b/src/method.c
@@ -312,6 +312,8 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
     src->codelocs = jl_nothing;
     src->linetable = jl_nothing;
     src->ssaflags = NULL;
+    src->min_world = 0;
+    src->max_world = 0;
     src->inferred = 0;
     src->pure = 0;
     src->inlineable = 0;
@@ -520,6 +522,8 @@ static void jl_method_set_source(jl_method_t *m, jl_code_info_t *src)
         jl_array_ptr_set(copy, i, st);
     }
     src = jl_copy_code_info(src);
+    src->min_world = m->min_world;
+    src->max_world = ~(size_t)0;
     src->code = copy;
     jl_gc_wb(src, copy);
     if (gen_only)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1303,8 +1303,8 @@ let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     @test opt.src.ssavaluetypes isa Vector{Any}
     @test !opt.src.inferred
     @test opt.mod === Base
-    @test opt.src.max_world === typemax(UInt)
-    @test opt.src.min_world === Core.Compiler.min_world(opt.linfo) > 2
+    @test Core.Compiler.max_world(opt.src) === typemax(UInt)
+    @test Core.Compiler.min_world(opt.src) === Core.Compiler.min_world(opt.linfo) > 2
     @test opt.nargs == 3
 end
 

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1303,8 +1303,8 @@ let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     @test opt.src.ssavaluetypes isa Vector{Any}
     @test !opt.src.inferred
     @test opt.mod === Base
-    @test opt.max_valid === typemax(UInt)
-    @test opt.min_valid === Core.Compiler.min_world(opt.linfo) > 2
+    @test opt.src.max_world === typemax(UInt)
+    @test opt.src.min_world === Core.Compiler.min_world(opt.linfo) > 2
     @test opt.nargs == 3
 end
 


### PR DESCRIPTION
This PR adds world age bounds to `CodeInfo`, so that downstream code returning `CodeInfo` from `@generated` functions (*cough* Cassette *cough*) can participate in world age validation without any hacks. 