### PR TITLE
Deprecate broadcast_(get|set)index in favor of broadcasted (get|set)index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -711,6 +711,9 @@ Deprecated or removed
     using the broadcasted assignment syntax `A[I...] .= x` or `fill!(view(A, I...), x)`
     ([#26347]).
 
+  * `broadcast_getindex(A, I...)` and `broadcast_setindex!(A, v, I...)` are deprecated in
+    favor of `getindex.((A,), I...)` and `setindex!.((A,), v, I...)`, respectively ([#27075]).
+
   * `LinAlg.fillslots!` has been renamed `LinAlg.fillstored!` ([#25030]).
 
   * `fill!(A::Diagonal, x)` and `fill!(A::AbstractTriangular, x)` have been deprecated

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1631,6 +1631,10 @@ end
 @deprecate showcompact(io, x) show(IOContext(io, :compact => true), x)
 @deprecate sprint(::typeof(showcompact), args...) sprint(show, args...; context=:compact => true)
 
+# PR 27075
+@deprecate broadcast_getindex(A, I...)      getindex.((A,), I...)
+@deprecate broadcast_setindex!(A, v, I...)  setindex!.((A,), v, I...)
+
 @deprecate isupper isuppercase
 @deprecate islower islowercase
 @deprecate ucfirst uppercasefirst

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -357,8 +357,6 @@ export
     axes,
     broadcast!,
     broadcast,
-    broadcast_getindex,
-    broadcast_setindex!,
     cat,
     checkbounds,
     checkindex,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -59,8 +59,6 @@ to operate on arrays, you should use `sin.(a)` to vectorize via `broadcast`.
 Base.broadcast
 Base.Broadcast.broadcast!
 Base.@__dot__
-Base.Broadcast.broadcast_getindex
-Base.Broadcast.broadcast_setindex!
 ```
 
 For specializing broadcast on custom types, see

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -654,8 +654,7 @@ julia> broadcast(+, a, b)
 [Dotted operators](@ref man-dot-operators) such as `.+` and `.*` are equivalent
 to `broadcast` calls (except that they fuse, as described below). There is also a
 [`broadcast!`](@ref) function to specify an explicit destination (which can also
-be accessed in a fusing fashion by `.=` assignment), and functions [`broadcast_getindex`](@ref)
-and [`broadcast_setindex!`](@ref) that broadcast the indices before indexing. Moreover, `f.(args...)`
+be accessed in a fusing fashion by `.=` assignment). Moreover, `f.(args...)`
 is equivalent to `broadcast(f, args...)`, providing a convenient syntax to broadcast any function
 ([dot syntax](@ref man-vectorized)). Nested "dot calls" `f.(...)` (including calls to `.+` etcetera)
 [automatically fuse](@ref man-dot-operators) into a single `broadcast` call.

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -120,22 +120,22 @@ for arr in (identity, as_sub)
     @test arr(BitArray([true false])) .^ arr([0, 3]) == [true true; true false]
 
     M = arr([11 12; 21 22])
-    @test broadcast_getindex(M, [2 1; 1 2], arr([1, 2])) == [21 11; 12 22]
-    @test_throws BoundsError broadcast_getindex(M, [2 1; 1 2], arr([1, -1]))
-    @test_throws BoundsError broadcast_getindex(M, [2 1; 1 2], arr([1, 2]), [2])
-    @test broadcast_getindex(M, [2 1; 1 2],arr([2, 1]), [1]) == [22 12; 11 21]
+    @test getindex.((M,), [2 1; 1 2], arr([1, 2])) == [21 11; 12 22]
+    @test_throws BoundsError getindex.((M,), [2 1; 1 2], arr([1, -1]))
+    @test_throws BoundsError getindex.((M,), [2 1; 1 2], arr([1, 2]), [2])
+    @test getindex.((M,), [2 1; 1 2],arr([2, 1]), [1]) == [22 12; 11 21]
 
     A = arr(zeros(2,2))
-    broadcast_setindex!(A, arr([21 11; 12 22]), [2 1; 1 2], arr([1, 2]))
+    setindex!.((A,), arr([21 11; 12 22]), [2 1; 1 2], arr([1, 2]))
     @test A == M
-    broadcast_setindex!(A, 5, [1,2], [2 2])
+    setindex!.((A,), 5, [1,2], [2 2])
     @test A == [11 5; 21 5]
-    broadcast_setindex!(A, 7, [1,2], [1 2])
+    setindex!.((A,), 7, [1,2], [1 2])
     @test A == fill(7, 2, 2)
     A = arr(zeros(3,3))
-    broadcast_setindex!(A, 10:12, 1:3, 1:3)
+    setindex!.((A,), 10:12, 1:3, 1:3)
     @test A == [10 0 0; 0 11 0; 0 0 12]
-    @test_throws BoundsError broadcast_setindex!(A, 7, [1,-1], [1 2])
+    @test_throws BoundsError setindex!.((A,), 7, [1,-1], [1 2])
 
     for f in ((==), (<) , (!=), (<=))
         bittest(f, arr([1 0; 0 1]), arr([1, 4]))


### PR DESCRIPTION
Here's another simple deprecation I'd like to sneak in.

The performance here is comparable in my few quick tests, and only two packages used either of these functions -- both in situations where they would have gained much more by participating in dot-fusion.

```julia
julia> A = rand(5000,5000);
julia> @benchmark broadcast_getindex($A, 1:5000, 1:5000)
BenchmarkTools.Trial:
  memory estimate:  39.14 KiB
  allocs estimate:  2
  --------------
  minimum time:     34.535 μs (0.00% GC)
  median time:      35.510 μs (0.00% GC)
  mean time:        36.835 μs (1.72% GC)
  maximum time:     2.742 ms (97.61% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark getindex.(($A,), 1:5000, 1:5000)
BenchmarkTools.Trial:
  memory estimate:  39.14 KiB
  allocs estimate:  2
  --------------
  minimum time:     31.564 μs (0.00% GC)
  median time:      32.596 μs (0.00% GC)
  mean time:        35.887 μs (2.17% GC)
  maximum time:     3.604 ms (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark broadcast_setindex!($A, 1:5000, 1:5000, 1:5000)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     32.503 μs (0.00% GC)
  median time:      33.403 μs (0.00% GC)
  mean time:        33.432 μs (0.00% GC)
  maximum time:     136.444 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark setindex!.(($A,), 1:5000, 1:5000, 1:5000)
BenchmarkTools.Trial:
  memory estimate:  39.14 KiB
  allocs estimate:  2
  --------------
  minimum time:     35.955 μs (0.00% GC)
  median time:      37.788 μs (0.00% GC)
  mean time:        39.442 μs (2.17% GC)
  maximum time:     642.989 μs (80.10% GC)
  --------------
  samples:          10000
  evals/sample:     1
```