### PR TITLE
More robust iteration over Vectors

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -642,7 +642,7 @@ end
 ## Iteration ##
 start(A::Array) = 1
 next(a::Array,i) = (@_propagate_inbounds_meta; (a[i],i+1))
-done(a::Array,i) = (@_inline_meta; i == length(a)+1)
+done(a::Array,i) = (@_inline_meta; i >= length(a)+1)
 
 ## Indexing: getindex ##
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2424,6 +2424,25 @@ end
     @inferred hash([1,2,3])
 end
 
+function f27079()
+    X = rand(5)
+    for x in X
+        resize!(X, 0)
+    end
+    length(X)
+end
+function g27079(X)
+    r = 0
+    @inbounds for x in X
+        r += x
+    end
+    r
+end
+@testset "iteration over resized vector" begin
+    @test f27079() == 0
+    @test occursin("vector.body", sprint(code_llvm, g27079, Tuple{Vector{Int}}))
+end
+
 @testset "indices-related shape promotion errors" begin
     @test_throws DimensionMismatch Base.promote_shape((2,), (3,))
     @test_throws DimensionMismatch Base.promote_shape((2, 3), (2, 4))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -5,7 +5,7 @@ isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using .Main.TestHelpers.OAs
 using SparseArrays
 
-using Random, LinearAlgebra, InteractiveUtils
+using Random, LinearAlgebra
 
 @testset "basics" begin
     @test length([1, 2, 3]) == 3
@@ -2431,16 +2431,8 @@ function f27079()
     end
     length(X)
 end
-function g27079(X)
-    r = 0
-    @inbounds for x in X
-        r += x
-    end
-    r
-end
 @testset "iteration over resized vector" begin
     @test f27079() == 0
-    @test occursin("vector.body", sprint(code_llvm, g27079, Tuple{Vector{Int}}))
 end
 
 @testset "indices-related shape promotion errors" begin

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -5,7 +5,7 @@ isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using .Main.TestHelpers.OAs
 using SparseArrays
 
-using Random, LinearAlgebra
+using Random, LinearAlgebra, InteractiveUtils
 
 @testset "basics" begin
     @test length([1, 2, 3]) == 3

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -2,7 +2,7 @@
 
 module TestBoundsCheck
 
-using Test, Random
+using Test, Random, InteractiveUtils
 
 @enum BCOption bc_default bc_on bc_off
 bc_opt = BCOption(Base.JLOptions().check_bounds)
@@ -238,5 +238,18 @@ Base.getindex(X::BadVector20469, i::Int) = X.data[i-1]
 if bc_opt != bc_off
     @test_throws BoundsError BadVector20469([1,2,3])[:]
 end
+
+# Ensure iteration over arrays is vectorizable with boundschecks off
+function g27079(X)
+    r = 0
+    @inbounds for x in X
+        r += x
+    end
+    r
+end
+if bc_opt == bc_default || bc_opt == bc_off
+    @test occursin("vector.body", sprint(code_llvm, g27079, Tuple{Vector{Int}}))
+end
+
 
 end


### PR DESCRIPTION
Currently, if a vector is resized in the midst of iteration, then `done` might "miss" the end of iteration. This trivially changes the definition to catch such a case. I am not sure what guarantees we make about mutating iterables during iteration, but this seems simple and easy to support.  Note, though, that it is somewhat tricky: until #13866 we used `i > length(a)`, but that foils vectorization due to the `typemax` case. This definition seems to get the best of both worlds. For a definition like `f` below, this new definition just requires one extra `add i64` operation in the preamble (before the loop). Everything else is identical to master.

```julia
function f(A)
    r = 0
    @inbounds for x in A
        r += x
    end
    r
end
```

Motivated by https://stackoverflow.com/questions/50297791/julia-boundserror-when-deleting-items-of-a-list-while-iterating-over-it