### PR TITLE
[NewOptimizer] Fix codegen test

### DIFF
--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -76,6 +76,9 @@ end
 function test_jl_dump_compiles_toplevel_thunks()
     tfile = tempname()
     io = open(tfile, "w")
+    # Make sure to cause compilation of the eval function
+    # before calling it below.
+    Core.eval(Main, Any[:(nothing)][1])
     topthunk = Meta.lower(Main, :(for i in 1:10; end))
     ccall(:jl_dump_compiles, Cvoid, (Ptr{Cvoid},), io.handle)
     Core.eval(Main, topthunk)


### PR DESCRIPTION
With the new optimizer enabled, we compile a signature for eval(::Module, ::Any),
which throws off the codegen test. I'm not entirely sure why this is different,
from the old optimizer, but presumably the old optimizer compiled this singature
beforehand. To fix this, simply add another call to `eval` that forces this
signature to be compiled.