### PR TITLE
RFC: deprecate per-module definition of `eval(module, expr)`

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -74,7 +74,7 @@ macro enum(T, syms...)
     typename = T
     if isa(T, Expr) && T.head == :(::) && length(T.args) == 2 && isa(T.args[1], Symbol)
         typename = T.args[1]
-        basetype = eval(__module__, T.args[2])
+        basetype = Core.eval(__module__, T.args[2])
         if !isa(basetype, DataType) || !(basetype <: Integer) || !isbitstype(basetype)
             throw(ArgumentError("invalid base type for Enum $typename, $T=::$basetype; base type must be an integer primitive type"))
         end
@@ -98,7 +98,7 @@ macro enum(T, syms...)
         elseif isa(s, Expr) &&
                (s.head == :(=) || s.head == :kw) &&
                length(s.args) == 2 && isa(s.args[1], Symbol)
-            i = eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
+            i = Core.eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
             if !isa(i, Integer)
                 throw(ArgumentError("invalid value for Enum $typename, $s=$i; values must be integers"))
             end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -313,7 +313,6 @@ getptls() = ccall(:jl_get_ptls_states, Ptr{Cvoid}, ())
 
 include(m::Module, fname::String) = ccall(:jl_load_, Any, (Any, Any), m, fname)
 
-eval(@nospecialize(e)) = eval(Main, e)
 eval(m::Module, @nospecialize(e)) = ccall(:jl_toplevel_eval_in, Any, (Any, Any), m, e)
 
 kwfunc(@nospecialize(f)) = ccall(:jl_get_keyword_sorter, Any, (Any,), f)

--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -76,7 +76,7 @@ meta(m::Module) = isdefined(m, META) ? getfield(m, META) : IdDict()
 
 function initmeta(m::Module)
     if !isdefined(m, META)
-        eval(m, :(const $META = $(IdDict())))
+        Core.eval(m, :(const $META = $(IdDict())))
         push!(modules, m)
     end
     nothing
@@ -374,7 +374,7 @@ function moduledoc(__source__, __module__, meta, def, def′)
     docex = Expr(:call, doc!, name, bindingexpr(name),
         docexpr(__source__, name, lazy_iterpolate(meta), metadata(__source__, __module__, name, true)))
     if def === nothing
-        esc(:($eval($name, $(quot(docex)))))
+        esc(:(Core.eval($name, $(quot(docex)))))
     else
         def = unblock(def)
         block = def.args[3].args
@@ -580,7 +580,7 @@ function loaddocs(docs)
         data = Dict(:path => string(file), :linenumber => line)
         doc = docstr(str, data)
         docstring = docm(LineNumberNode(line, file), mod, doc, ex, false) # expand the real @doc macro now
-        eval(mod, Expr(:macrocall, unescape, nothing, docstring))
+        Core.eval(mod, Expr(:macrocall, unescape, nothing, docstring))
     end
     empty!(docs)
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -129,10 +129,10 @@ Evaluate an expression with values interpolated into it using `eval`.
 If two arguments are provided, the first is the module to evaluate in.
 """
 macro eval(ex)
-    :(eval($__module__, $(Expr(:quote,ex))))
+    :(Core.eval($__module__, $(Expr(:quote,ex))))
 end
 macro eval(mod, ex)
-    :(eval($(esc(mod)), $(Expr(:quote,ex))))
+    :(Core.eval($(esc(mod)), $(Expr(:quote,ex))))
 end
 
 argtail(x, rest...) = rest

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -151,11 +151,9 @@ end
 ## misc syntax ##
 
 """
-    eval([m::Module], expr::Expr)
+    Core.eval(m::Module, expr)
 
-Evaluate an expression in the given module and return the result. Every `Module` (except
-those defined with `baremodule`) has its own 1-argument definition of `eval`, which
-evaluates expressions in that module.
+Evaluate an expression in the given module and return the result.
 """
 Core.eval
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1080,9 +1080,8 @@ end
 """
     Base.include([m::Module,] path::AbstractString)
 
-Evaluate the contents of the input source file in the global scope of module `m`, or,
-for the one argument call, in the global scope of the `Base` module.
-Note that every `Module` (except those defined with `baremodule`) has its own 1-argument
+Evaluate the contents of the input source file in the global scope of module `m`.
+Every module (except those defined with `baremodule`) has its own 1-argument
 definition of `include`, which evaluates the file in that module.
 Returns the result of the last evaluated expression of the input file. During including,
 a task-local include path is set to the directory containing the file. Nested calls to
@@ -1092,34 +1091,19 @@ interactively, or to combine files in packages that are broken into multiple sou
 Base.include # defined in sysimg.jl
 
 """
-    include(path::AbstractString)
-
-Evaluate the contents of the input source file into the global scope of the containing module.
-Every `Module` (except those defined with `baremodule`) has its own 1-argument
-definition of `include`, which evaluates the file in that module.
-Returns the result of the last evaluated expression of the input file. During including, a task-local include
-path is set to the directory containing the file. Nested calls to `include` will search
-relative to that path. This function is typically used to load source
-interactively, or to combine files in packages that are broken into multiple source files.
-
-Use [`Base.include`](@ref) to evaluate a file into another module.
-"""
-MainInclude.include # defined in sysimg.jl
-
-"""
     evalfile(path::AbstractString, args::Vector{String}=String[])
 
 Load the file using [`Base.include`](@ref), evaluate all expressions,
 and return the value of the last one.
 """
 function evalfile(path::AbstractString, args::Vector{String}=String[])
-    return eval(Module(:__anon__),
-                Expr(:toplevel,
-                     :(const ARGS = $args),
-                     :(eval(x) = $(Expr(:core, :eval))(__anon__, x)),
-                     :(eval(m, x) = $(Expr(:core, :eval))(m, x)),
-                     :(include(x) = $(Expr(:top, :include))(__anon__, x)),
-                     :(include($path))))
+    return Core.eval(Module(:__anon__),
+        Expr(:toplevel,
+             :(const ARGS = $args),
+             :(eval(x) = $(Expr(:core, :eval))(__anon__, x)),
+             :(@deprecate eval(m, x) Core.eval(m, x)),
+             :(include(x) = $(Expr(:top, :include))(__anon__, x)),
+             :(include($path))))
 end
 evalfile(path::AbstractString, args::Vector) = evalfile(path, String[args...])
 
@@ -1128,7 +1112,7 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
     code_object = """
         while !eof(stdin)
             code = readuntil(stdin, '\\0')
-            eval(Main, Meta.parse(code))
+            eval(Meta.parse(code))
         end
         """
     io = open(pipeline(detach(`$(julia_cmd()) -O0

--- a/base/osutils.jl
+++ b/base/osutils.jl
@@ -16,7 +16,7 @@ macro static(ex)
         @label loop
         hd = ex.head
         if hd ∈ (:if, :elseif, :&&, :||)
-            cond = eval(__module__, ex.args[1])
+            cond = Core.eval(__module__, ex.args[1])
             if xor(cond, hd === :||)
                 return esc(ex.args[2])
             elseif length(ex.args) == 3

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -63,15 +63,11 @@ let SOURCE_PATH = ""
 end
 INCLUDE_STATE = 1 # include = Core.include
 
-baremodule MainInclude
-export include
-include(fname::AbstractString) = Main.Base.include(Main, fname)
-end
-
 include("coreio.jl")
 
 eval(x) = Core.eval(Base, x)
-eval(m, x) = Core.eval(m, x)
+eval(m::Module, x) = Core.eval(m, x)
+
 VecElement{T}(arg) where {T} = VecElement{T}(convert(T, arg))
 convert(::Type{T}, arg)  where {T<:VecElement} = T(arg)
 convert(::Type{T}, arg::T) where {T<:VecElement} = arg
@@ -417,7 +413,6 @@ include("stacktraces.jl")
 using .StackTraces
 
 include("initdefs.jl")
-include("client.jl")
 
 # statistics
 include("statistics.jl")
@@ -449,6 +444,8 @@ include("deprecated.jl")
 
 # Some basic documentation
 include("docs/basedocs.jl")
+
+include("client.jl")
 
 # Documentation -- should always be included last in sysimg.
 include("docs/Docs.jl")

--- a/base/util.jl
+++ b/base/util.jl
@@ -296,6 +296,69 @@ end
 
 ## printing with color ##
 
+const text_colors = AnyDict(
+    :black         => "\033[30m",
+    :red           => "\033[31m",
+    :green         => "\033[32m",
+    :yellow        => "\033[33m",
+    :blue          => "\033[34m",
+    :magenta       => "\033[35m",
+    :cyan          => "\033[36m",
+    :white         => "\033[37m",
+    :light_black   => "\033[90m", # gray
+    :light_red     => "\033[91m",
+    :light_green   => "\033[92m",
+    :light_yellow  => "\033[93m",
+    :light_blue    => "\033[94m",
+    :light_magenta => "\033[95m",
+    :light_cyan    => "\033[96m",
+    :normal        => "\033[0m",
+    :default       => "\033[39m",
+    :bold          => "\033[1m",
+    :underline     => "\033[4m",
+    :blink         => "\033[5m",
+    :reverse       => "\033[7m",
+    :hidden        => "\033[8m",
+    :nothing       => "",
+)
+
+for i in 0:255
+    text_colors[i] = "\033[38;5;$(i)m"
+end
+
+const disable_text_style = AnyDict(
+    :bold      => "\033[22m",
+    :underline => "\033[24m",
+    :blink     => "\033[25m",
+    :reverse   => "\033[27m",
+    :hidden    => "\033[28m",
+    :normal    => "",
+    :default   => "",
+    :nothing   => "",
+)
+
+# Create a docstring with an automatically generated list
+# of colors.
+available_text_colors = collect(Iterators.filter(x -> !isa(x, Integer), keys(text_colors)))
+const possible_formatting_symbols = [:normal, :bold, :default]
+available_text_colors = cat(1,
+    sort!(intersect(available_text_colors, possible_formatting_symbols), rev=true),
+    sort!(setdiff(  available_text_colors, possible_formatting_symbols)))
+
+const available_text_colors_docstring =
+    string(join([string("`:", key,"`")
+                 for key in available_text_colors], ",\n", ", or \n"))
+
+"""Dictionary of color codes for the terminal.
+
+Available colors are: $available_text_colors_docstring as well as the integers 0 to 255 inclusive.
+
+The color `:default` will print text in the default color while the color `:normal`
+will print text with all text properties (like boldness) reset.
+Printing with the color `:nothing` will print the string without modifications.
+"""
+text_colors
+
 function with_output_color(f::Function, color::Union{Int, Symbol}, io::IO, args...; bold::Bool = false)
     buf = IOBuffer()
     iscolor = get(io, :color, false)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -205,6 +205,7 @@ Base.:(∘)
 
 ```@docs
 Core.eval
+Base.MainInclude.eval
 Base.@eval
 Base.evalfile
 Base.esc

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -145,7 +145,6 @@ baremodule Mod
 using Base
 
 eval(x) = Core.eval(Mod, x)
-eval(m,x) = Core.eval(m, x)
 include(p) = Base.include(Mod, p)
 
 ...

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -131,10 +131,15 @@
           (block
            ,loc
            (call (core eval) ,name ,x)))
-       (= (call eval m ,x)
-          (block
-           ,loc
-           (call (core eval) m ,x)))
+       (if (&& (call (top isdefined) (core Main) (quote Base))
+               (call (top isdefined) (top Base) (quote @deprecate)))
+           (call eval
+                 (quote
+                  (macrocall (top @deprecate)
+                             (line 0 none)
+                             (call eval m x)
+                             (call (|.| Core (quote eval)) m x)
+                             false))))
        (= (call include ,x)
           (block
            ,loc

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2211,7 +2211,7 @@ function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=ini
             @static if Sys.isunix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
             buf, ok, suspend = prompt!(terminal, m, s)
         end
-        eval(Main,
+        Core.eval(Main,
             Expr(:body,
                 Expr(:return,
                      Expr(:call,

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -82,10 +82,10 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
                 put!(backend.response_channel, lasterr)
             else
                 backend.in_eval = true
-                value = eval(Main, ast)
+                value = Core.eval(Main, ast)
                 backend.in_eval = false
                 # note: value wrapped carefully here to ensure it doesn't get passed through expand
-                eval(Main, Expr(:body, Expr(:(=), :ans, QuoteNode(value)), Expr(:return, nothing)))
+                Core.eval(Main, Expr(:body, Expr(:(=), :ans, QuoteNode(value)), Expr(:return, nothing)))
                 put!(backend.response_channel, (value, nothing))
             end
             break

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -910,5 +910,5 @@ for (line, expr) in Pair[
     ]
     #@test REPL._helpmode(line) == Expr(:macrocall, Expr(:., Expr(:., :Base, QuoteNode(:Docs)), QuoteNode(Symbol("@repl"))), LineNumberNode(119, doc_util_path), stdout, expr)
     buf = IOBuffer()
-    @test eval(Base, REPL._helpmode(buf, line)) isa Union{Markdown.MD,Nothing}
+    @test Base.eval(REPL._helpmode(buf, line)) isa Union{Markdown.MD,Nothing}
 end

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -82,7 +82,7 @@ let ex = quote
         test_dict_ℂ = Dict(1=>2)
     end
     ex.head = :toplevel
-    eval(Main, ex)
+    Core.eval(Main, ex)
 end
 
 function temp_pkg_dir_noinit(fn::Function)

--- a/stdlib/Serialization/test/runtests.jl
+++ b/stdlib/Serialization/test/runtests.jl
@@ -331,7 +331,7 @@ main_ex = quote
     end
 end
 # This needs to be run on `Main` since the serializer treats it differently.
-eval(Main, main_ex)
+Core.eval(Main, main_ex)
 
 # Task
 create_serialization_stream() do s # user-defined type array

--- a/test/examples.jl
+++ b/test/examples.jl
@@ -59,7 +59,7 @@ main_ex = quote
     end
     RemoteChannel(()->DictChannel(), 1)
 end
-dc = eval(Main, main_ex)
+dc = Core.eval(Main, main_ex)
 @test typeof(dc) == RemoteChannel{Main.DictChannel}
 
 @test isready(dc) == false

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -296,8 +296,8 @@ end
 
 # Issue #26273
 let m = Module(:Bare26273i, false)
-    eval(m, :(import Base: @error))
-    @test_logs (:error, "Hello") eval(m, quote
+    Core.eval(m, :(import Base: @error))
+    @test_logs (:error, "Hello") Core.eval(m, quote
         @error "Hello"
     end)
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -590,7 +590,7 @@ end
 @test readlines(`$(Base.julia_cmd()) --startup-file=no -e 'foreach(println, names(Main))'`) == ["Base","Core","Main"]
 
 # issue #26310
-@test_warn "could not import" eval(@__MODULE__, :(import .notdefined_26310__))
-@test_warn "could not import" eval(Main,        :(import ........notdefined_26310__))
-@test_nowarn eval(Main, :(import .Main))
-@test_nowarn eval(Main, :(import ....Main))
+@test_warn "could not import" Core.eval(@__MODULE__, :(import .notdefined_26310__))
+@test_warn "could not import" Core.eval(Main,        :(import ........notdefined_26310__))
+@test_nowarn Core.eval(Main, :(import .Main))
+@test_nowarn Core.eval(Main, :(import ....Main))

--- a/test/show.jl
+++ b/test/show.jl
@@ -541,7 +541,7 @@ let filename = tempname()
 
     # stdin is unavailable on the workers. Run test on master.
     @test occursin("WARNING: hello", read(filename, String))
-    ret = eval(Main, quote
+    ret = Core.eval(Main, quote
         remotecall_fetch(1, $filename) do fname
             open(fname) do f
                 redirect_stdin(f) do

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -31,7 +31,7 @@ let
         ex1 = Meta.parse(ex1); ex2 = Meta.parse(ex2)
         @test ex1.head === :call && (ex1.head === ex2.head)
         @test ex1.args[2] === 5 && ex2.args[2] === 5
-        @test eval(Main, undot(ex1.args[1])) === eval(Main, undot(ex2.args[1]))
+        @test Core.eval(Main, undot(ex1.args[1])) === Core.eval(Main, undot(ex2.args[1]))
         @test ex1.args[3] === :x && (ex1.args[3] === ex2.args[3])
     end
 end
@@ -581,7 +581,7 @@ let thismodule = @__MODULE__,
     ex = Meta.lower(thismodule, :(@M16096.iter))
     @test isa(ex, Expr)
     @test !isdefined(M16096, :foo16096)
-    local_foo16096 = eval(@__MODULE__, ex)
+    local_foo16096 = Core.eval(@__MODULE__, ex)
     @test local_foo16096(2.0) == 1
     @test !@isdefined foo16096
     @test !@isdefined it
@@ -927,7 +927,7 @@ macro m20729()
     return ex
 end
 
-@test_throws ErrorException eval(@__MODULE__, :(@m20729))
+@test_throws ErrorException Core.eval(@__MODULE__, :(@m20729))
 @test Meta.lower(@__MODULE__, :(@m20729)) == Expr(:error, "undefined reference in AST")
 
 macro err20000()
@@ -1217,7 +1217,7 @@ end
 @test Meta.parse("2e3_\"x\"") == Expr(:call, :*, 2e3, Expr(:macrocall, Symbol("@__str"), LineNumberNode(1, :none), "x"))
 
 # misplaced top-level expressions
-@test_throws ErrorException("syntax: \"\$\" expression outside quote") eval(@__MODULE__, Meta.parse("x->\$x"))
+@test_throws ErrorException("syntax: \"\$\" expression outside quote") Core.eval(@__MODULE__, Meta.parse("x->\$x"))
 @test Meta.lower(@__MODULE__, Expr(:$, :x)) == Expr(:error, "\"\$\" expression outside quote")
 @test Meta.lower(@__MODULE__, :(x->import Foo)) == Expr(:error, "\"import\" expression not at top level")
 @test Meta.lower(@__MODULE__, :(x->module Foo end)) == Expr(:error, "\"module\" expression not at top level")
@@ -1421,7 +1421,7 @@ end\""""
 end
 
 # issue #26739
-@test_throws ErrorException("syntax: invalid syntax \"sin.[1]\"") eval(@__MODULE__, :(sin.[1]))
+@test_throws ErrorException("syntax: invalid syntax \"sin.[1]\"") Core.eval(@__MODULE__, :(sin.[1]))
 
 # issue #26873
 f26873 = 0

--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -22,7 +22,7 @@ function runtests(name, path, isolate=true; seed=nothing)
                 include($"$path.jl")
             end
         end
-        res_and_time_data = eval(m, ex)
+        res_and_time_data = Core.eval(m, ex)
         rss = Sys.maxrss()
         #res_and_time_data[1] is the testset
         passes,fails,error,broken,c_passes,c_fails,c_errors,c_broken = Test.get_test_counts(res_and_time_data[1])

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -50,9 +50,12 @@ static int exec_program(char *program)
             if (errs) {
                 bt_data = (uintptr_t*)malloc(bt_size * sizeof(void*));
                 memcpy(bt_data, ptls->bt_data, bt_size * sizeof(void*));
-                jl_call2(jl_get_function(jl_base_module, "show"), errs, e);
-                jl_printf(JL_STDERR, "\n");
-                shown_err = 1;
+                jl_value_t *showf = jl_get_function(jl_base_module, "show");
+                if (showf != NULL) {
+                    jl_call2(showf, errs, e);
+                    jl_printf(JL_STDERR, "\n");
+                    shown_err = 1;
+                }
             }
         }
         JL_CATCH {


### PR DESCRIPTION
These definitions are silly, since they're identical in every module. Making it slightly less convenient to evaluate in a given module is also a good thing, since you should really think twice before doing that.

fixes #27093