### PR TITLE
Backport for 27072

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -85,12 +85,7 @@ end
 size(a::Array, d) = arraysize(a, d)
 size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
-size(a::Array) = (@_inline_meta; _size((), a))
-_size(out::NTuple{N}, A::Array{_,N}) where {_,N} = out
-function _size(out::NTuple{M}, A::Array{_,N}) where _ where M where N
-    @_inline_meta
-    _size((out..., size(A,M+1)), A)
-end
+size(a::Array{<:Any,N}) where {N} = (@_inline_meta; ntuple(M -> size(a, M), Val{N}))
 
 asize_from(a::Array, n) = n > ndims(a) ? () : (arraysize(a,n), asize_from(a, n+1)...)
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2132,3 +2132,13 @@ Base.:(==)(a::T11053, b::T11053) = a.a == b.a
     @test_throws BoundsError zeros(2,3,0)[2,3]
     @test_throws BoundsError checkbounds(zeros(2,3,0), 2, 3)
 end
+
+# issue #27072
+function type_testB27072(B::StridedArray)
+    return typeof(similar(B, size(B)))
+end
+@testset "issue 27072: manually added, non-backported test" begin
+    bb_inp = reshape(eye(2^8), fill(2,16)...);
+    @test typeof(similar(bb_inp, size(bb_inp))) === Array{Float64,16}
+    @test type_testB27072(bb_inp) === Array{Float64,16}
+end


### PR DESCRIPTION
This is a PR into @ararslan's backports branch to fix #27072 on release-0.6.  It's a minimal cherry-pick of  4f1b479, which includes a number of much larger refactors.  I've manually added a commit to ensure this fixes the behavior we saw in #27072.