### PR TITLE
Add an easy way to emit assertions in the optimizer

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -246,6 +246,9 @@ struct UndefRefError       <: Exception end
 struct UndefVarError <: Exception
     var::Symbol
 end
+struct AssertEgalError     <: Exception
+    label::Symbol
+end
 struct InterruptException <: Exception end
 struct DomainError <: Exception
     val

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -274,7 +274,8 @@ function is_relevant_expr(e::Expr)
     return e.head in (:call, :invoke, :new, :(=), :(&),
                       :gc_preserve_begin, :gc_preserve_end,
                       :foreigncall, :isdefined, :copyast,
-                      :undefcheck, :throw_undef_if_not)
+                      :undefcheck, :throw_undef_if_not,
+                      :assert_egal)
 end
 
 function setindex!(x::UseRef, @nospecialize(v))

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -28,7 +28,8 @@ const VALID_EXPR_HEADS = IdDict{Any,Any}(
     :gc_preserve_begin => 0:typemax(Int),
     :gc_preserve_end => 0:typemax(Int),
     :thunk => 1:1,
-    :throw_undef_if_not => 2:2
+    :throw_undef_if_not => 2:2,
+    :assert_egal => 2:2
 )
 
 # @enum isn't defined yet, otherwise I'd use it for this

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -148,6 +148,10 @@ function showerror(io::IO, ex::UndefVarError)
     print(io, "UndefVarError: $(ex.var) not defined")
 end
 
+function showerror(io::IO, ex::Core.AssertEgalError)
+    print(io, "AssertEgalError: An internal compiler error occurred: $(ex.label)")
+end
+
 function showerror(io::IO, ex::InexactError)
     print(io, "InexactError: ", ex.func, '(', ex.T, ", ", ex.val, ')')
 end

--- a/src/ast.c
+++ b/src/ast.c
@@ -67,7 +67,7 @@ jl_sym_t *macrocall_sym; jl_sym_t *colon_sym;
 jl_sym_t *hygienicscope_sym;
 jl_sym_t *escape_sym;
 jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
-jl_sym_t *throw_undef_if_not_sym;
+jl_sym_t *throw_undef_if_not_sym; jl_sym_t *assert_egal_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -392,6 +392,7 @@ void jl_init_frontend(void)
     generated_sym = jl_symbol("generated");
     generated_only_sym = jl_symbol("generated_only");
     throw_undef_if_not_sym = jl_symbol("throw_undef_if_not");
+    assert_egal_sym = jl_symbol("assert_egal");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/init.c
+++ b/src/init.c
@@ -858,6 +858,7 @@ void jl_get_builtin_hooks(void)
     jl_diverror_exception  = jl_new_struct_uninit((jl_datatype_t*)core("DivideError"));
     jl_undefref_exception  = jl_new_struct_uninit((jl_datatype_t*)core("UndefRefError"));
     jl_undefvarerror_type  = (jl_datatype_t*)core("UndefVarError");
+    jl_assertegalerror_type = (jl_datatype_t*)core("AssertEgalError");
     jl_interrupt_exception = jl_new_struct_uninit((jl_datatype_t*)core("InterruptException"));
     jl_boundserror_type    = (jl_datatype_t*)core("BoundsError");
     jl_memory_exception    = jl_new_struct_uninit((jl_datatype_t*)core("OutOfMemoryError"));

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -111,6 +111,7 @@ jl_datatype_t *jl_methoderror_type;
 jl_datatype_t *jl_loaderror_type;
 jl_datatype_t *jl_initerror_type;
 jl_datatype_t *jl_undefvarerror_type;
+jl_datatype_t *jl_assertegalerror_type;
 jl_datatype_t *jl_lineinfonode_type;
 jl_unionall_t *jl_ref_type;
 jl_unionall_t *jl_pointer_type;

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3837,7 +3837,7 @@ f(x) = yt(x)
                s))
 
             ;; metadata expressions
-            ((line meta inbounds simdloop gc_preserve_end)
+            ((line meta inbounds simdloop gc_preserve_end assert_egal)
              (let ((have-ret? (and (pair? code) (pair? (car code)) (eq? (caar code) 'return))))
                (cond ((eq? (car e) 'line)
                       (set! current-loc e)

--- a/src/julia.h
+++ b/src/julia.h
@@ -562,6 +562,7 @@ extern JL_DLLEXPORT jl_datatype_t *jl_initerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_typeerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_methoderror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_undefvarerror_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_assertegalerror_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_lineinfonode_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_stackovf_exception JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_memory_exception JL_GLOBALLY_ROOTED;
@@ -1390,6 +1391,7 @@ JL_DLLEXPORT void JL_NORETURN jl_type_error_rt(const char *fname,
                                                jl_value_t *ty,
                                                jl_value_t *got JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var);
+JL_DLLEXPORT void JL_NORETURN jl_assert_egal_error(jl_sym_t *var);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v,
                                               jl_value_t *t JL_MAYBE_UNROOTED);
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error_v(jl_value_t *v,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -972,6 +972,7 @@ extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *generated_sym;
 extern jl_sym_t *generated_only_sym;
 extern jl_sym_t *throw_undef_if_not_sym;
+extern jl_sym_t *assert_egal_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -134,6 +134,11 @@ JL_DLLEXPORT void JL_NORETURN jl_undefined_var_error(jl_sym_t *var)
     jl_throw(jl_new_struct(jl_undefvarerror_type, var));
 }
 
+JL_DLLEXPORT void JL_NORETURN jl_assert_egal_error(jl_sym_t *label)
+{
+    jl_throw(jl_new_struct(jl_assertegalerror_type, label));
+}
+
 JL_DLLEXPORT void JL_NORETURN jl_bounds_error(jl_value_t *v, jl_value_t *t)
 {
     JL_GC_PUSH2(&v, &t); // root arguments so the caller doesn't need to

--- a/test/core.jl
+++ b/test/core.jl
@@ -6072,3 +6072,10 @@ end
 @test !Base.isvatuple(Tuple{Float64,Vararg{Int,1}})
 @test !Base.isvatuple(Tuple{T,Vararg{Int,2}} where T)
 @test !Base.isvatuple(Tuple{Int,Int,Vararg{Int,2}})
+
+# :assert_egal mechanism
+@eval f_assert_egal() = $(Expr(:assert_egal, 1, true, false))
+@eval g_assert_egal(x) = ($(Expr(:assert_egal, QuoteNode(Symbol("Important Property")), :x, true)); x)
+@test_throws(Core.AssertEgalError(Symbol("Assertion #1")), f_assert_egal())
+@test g_assert_egal(true) === true
+@test_throws(Core.AssertEgalError(Symbol("Important Property")), g_assert_egal(false))


### PR DESCRIPTION
A common situation when working on the compiler is that a pass wants
to replace one value with another that is egal (but constant or otherwise
cheaper to compute). To facilitate debugging such situations, this
commit adds an `:assert_egal` expression that compares its two argument
values and throws an appropriate error if they are not egal. The use case
is simple: The optimizer simply generates both code paths as well as an
inline `:assert_egal`. Then you run the test suite and get a report of
all the places that would have been miscompiles if the optimization had
been active. Another useful thing to do is to dump all IR to a file with
an increasing counter for the label argument in order to match up failing
assertions with the corresponding IR pieces. This is a relatively simple
mechanism, but seems quite useful to debug optimizer problems.