### PR TITLE
Re-enable BB simplification pass

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -181,14 +181,14 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     PM->add(createAllocOptPass());
 #endif
     PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
+    // Now that SROA has cleaned up for front-end mess, a lot of control flow should
+    // be more evident - try to clean it up.
+    PM->add(createCFGSimplificationPass());    // Merge & remove BBs
     if (dump_native)
         PM->add(createMultiVersioningPass());
     PM->add(createSROAPass());                 // Break up aggregate allocas
     PM->add(createInstructionCombiningPass()); // Cleanup for scalarrepl.
     PM->add(createJumpThreadingPass());        // Thread jumps.
-    // NOTE: CFG simp passes after this point seem to hurt native codegen.
-    // See issue #6112. Should be re-evaluated when we switch to MCJIT.
-    //PM->add(createCFGSimplificationPass());    // Merge & remove BBs
     PM->add(createInstructionCombiningPass()); // Combine silly seq's
 
     //PM->add(createCFGSimplificationPass());    // Merge & remove BBs


### PR DESCRIPTION
This was originally disabled in the 0.2 days because it caused performance regressions with the legacy JIT. However, thing have moved on quite a bit, the legacy JIT is no more and we now have phi nodes in the frontend. The latter is important because this pass is necessary to fold simple conditionals `foo() ? 1 : 2` expressed as phi nodes, but a lot of these opportunities are not visible until after SROA, where we had previously disabled all instances of this pass. Let's try enabling this again and see what happens. 