### PR TITLE
Fix for UndefVarError(var=:arg_T2)

### DIFF
--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -1021,7 +1021,7 @@ function late_inline_special_case!(ir::IRCode, idx::Int, stmt::Expr, atypes::Vec
             ir[SSAValue(idx)] = quoted(stmt.typ.val)
             return true
         end
-        subtype_call = Expr(:call, GlobalRef(Core, :(<:)), arg_T2, arg_T1)
+        subtype_call = Expr(:call, GlobalRef(Core, :(<:)), stmt.args[3], stmt.args[2])
         subtype_call.typ = Bool
         ir[SSAValue(idx)] = subtype_call
         return true

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -23,3 +23,11 @@ let code = Any[
 
     Compiler.run_passes(ci, 1, Compiler.LineInfoNode[Compiler.NullLineInfo])
 end
+
+# test >:
+let
+
+f(a,b) = a >: b
+code_typed(f, Tuple{Any, Any})
+
+end


### PR DESCRIPTION
cc: @Keno @vtjnash 