### PR TITLE
Bump required MPFR version to 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Julia uses the following external libraries, which are automatically downloaded 
 - **[ARPACK]**               — collection of subroutines designed to solve large, sparse eigenvalue problems.
 - **[PCRE]** (>= 10.00)      — Perl-compatible regular expressions library.
 - **[GMP]** (>= 5.0)         — GNU multiple precision arithmetic library, needed for `BigInt` support.
-- **[MPFR]** (>= 3.0)        — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
+- **[MPFR]** (>= 4.0)        — GNU multiple precision floating point library, needed for arbitrary precision floating point (`BigFloat`) support.
 - **[libgit2]** (>= 0.23)    — Git linkable library, used by Julia's package manager.
 - **[curl]** (>= 7.50)       — libcurl provides download and proxy support for Julia's package manager.
 - **[libssh2]** (>= 1.7)     — library for SSH transport, used by libgit2 for packages with SSH remotes.


### PR DESCRIPTION
Needed since https://github.com/JuliaLang/julia/pull/26773 for `mpfr_roundeven`.