### PR TITLE
add bytes2hex(io, a) method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -478,6 +478,9 @@ Library improvements
   * `Char` is now a subtype of `AbstractChar`, and most of the functions that
     take character arguments now accept any `AbstractChar` ([#26286]).
 
+  * `bytes2hex` now accepts an optional `io` argument to output to a hexadecimal stream
+    without allocating a `String` first ([#27121]).
+
   * `String(array)` now accepts an arbitrary `AbstractVector{UInt8}`. For `Vector`
     inputs, it "steals" the memory buffer, leaving them with an empty buffer which
     is guaranteed not to be shared with the `String` object. For other types of vectors

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -91,10 +91,11 @@ struct SHA1
     end
 end
 SHA1(s::AbstractString) = SHA1(hex2bytes(s))
-string(hash::SHA1) = bytes2hex(hash.bytes)
-print(io::IO, hash::SHA1) = print(io, string(hash))
 
-show(io::IO, hash::SHA1) = print(io, "SHA1(\"", string(hash), "\")")
+string(hash::SHA1) = bytes2hex(hash.bytes)
+print(io::IO, hash::SHA1) = bytes2hex(io, hash.bytes)
+show(io::IO, hash::SHA1) = print(io, "SHA1(\"", hash, "\")")
+
 isless(a::SHA1, b::SHA1) = lexless(a.bytes, b.bytes)
 hash(a::SHA1, h::UInt) = hash((SHA1, a.bytes), h)
 ==(a::SHA1, b::SHA1) = a.bytes == b.bytes

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -547,10 +547,13 @@ end
     throw(ArgumentError("byte is not an ASCII hexadecimal digit"))
 
 """
-    bytes2hex(bin_arr::Array{UInt8, 1}) -> String
+    bytes2hex(a::AbstractArray{UInt8}) -> String
+    bytes2hex(io::IO, a::AbstractArray{UInt8})
 
-Convert an array of bytes to its hexadecimal representation.
-All characters are in lower-case.
+Convert an array `a` of bytes to its hexadecimal string representation, either
+returning a `String` via `bytes2hex(a)` or writing the string to an `io` stream
+via `bytes2hex(io, a)`.  The hexadecimal characters are all lowercase.
+
 # Examples
 ```jldoctest
 julia> a = string(12345, base = 16)
@@ -565,8 +568,10 @@ julia> bytes2hex(b)
 "3039"
 ```
 """
+function bytes2hex end
+
 function bytes2hex(a::AbstractArray{UInt8})
-    b = Vector{UInt8}(undef, 2*length(a))
+    b = Base.StringVector(2*length(a))
     i = 0
     for x in a
         b[i += 1] = hex_chars[1 + x >> 4]
@@ -574,6 +579,11 @@ function bytes2hex(a::AbstractArray{UInt8})
     end
     return String(b)
 end
+
+bytes2hex(io::IO, a::AbstractArray{UInt8}) =
+    for x in a
+        print(io, Char(hex_chars[1 + x >> 4]), Char(hex_chars[1 + x & 0xf]))
+    end
 
 # check for pure ASCII-ness
 

--- a/base/uuid.jl
+++ b/base/uuid.jl
@@ -50,8 +50,7 @@ let groupings = [36:-1:25; 23:-1:20; 18:-1:15; 13:-1:10; 8:-1:1]
         u = u.value
         a = Base.StringVector(36)
         for i in groupings
-            d = u & 0xf
-            a[i] = '0' + d + 39*(d > 9)
+            a[i] = hex_chars[1 + u & 0xf]
             u >>= 4
         end
         a[24] = a[19] = a[14] = a[9] = '-'

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -96,7 +96,7 @@ end
 let uuidstr = "ab"^4 * "-" * "ab"^2 * "-" * "ab"^2 * "-" * "ab"^2 * "-" * "ab"^6
     uuid = UUID(uuidstr)
     @test uuid == eval(Meta.parse(repr(uuid))) # check show method
-    @test string(uuid) == uuidstr
+    @test string(uuid) == uuidstr == sprint(print, uuid)
     @test "check $uuid" == "check $uuidstr"
 end
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -324,7 +324,7 @@ end
     bin_val = hex2bytes(hex_str)
 
     @test div(length(hex_str), 2) == length(bin_val)
-    @test hex_str == bytes2hex(bin_val)
+    @test hex_str == bytes2hex(bin_val) == sprint(bytes2hex, bin_val)
 
     bin_val = hex2bytes("07bf")
     @test bin_val[1] == 7


### PR DESCRIPTION
Fixes #27036.

I don't *really* care about allocating an extra string when calling `print` on an `SHA1` object, but I can easily imagine cases where you might be writing a long block of hexadecimal text to a file and then it would be mildly annoying to be forced to allocate an extra string.

Actually, the old code allocated *two* extra strings rather than one, because it wasn't using `StringVector`.  #27036 also mentioned UUID printing, but this doesn't go through `bytes2hex` so I left it as allocating an extra string (I doubt it's a big deal in practice) but I did slightly clean up the code to use the same `hex_chars` array as `bytes2hex`.