### PR TITLE
rm newline from end of Markdown text/plain output

### DIFF
--- a/stdlib/Markdown/src/GitHub/table.jl
+++ b/stdlib/Markdown/src/GitHub/table.jl
@@ -142,11 +142,11 @@ function term(io::IO, md::Table, columns)
     padcells!(cells, md.align, len = ansi_length)
     for i = 1:length(cells)
         join(io, cells[i], " ")
-        println(io)
         if i == 1
-            join(io, ["–"^ansi_length(cells[i][j]) for j = 1:length(cells[1])], " ")
             println(io)
+            join(io, ["–"^ansi_length(cells[i][j]) for j = 1:length(cells[1])], " ")
         end
+        i < length(cells) && println(io)
     end
 end
 

--- a/stdlib/Markdown/src/IPython/IPython.jl
+++ b/stdlib/Markdown/src/IPython/IPython.jl
@@ -31,5 +31,5 @@ latex(io::IO, tex::LaTeX) =
 latexinline(io::IO, tex::LaTeX) =
     print(io, '$', tex.formula, '$')
 
-term(io::IO, tex::LaTeX, cols) = printstyled(io, tex.formula, '\n', color=:magenta)
+term(io::IO, tex::LaTeX, cols) = printstyled(io, tex.formula, color=:magenta)
 terminline(io::IO, tex::LaTeX) = printstyled(io, tex.formula, color=:magenta)

--- a/stdlib/Markdown/src/render/terminal/formatting.jl
+++ b/stdlib/Markdown/src/render/terminal/formatting.jl
@@ -35,12 +35,11 @@ wrapped_lines(io::IO, f::Function, args...; width = 80, i = 0) =
 
 function print_wrapped(io::IO, s...; width = 80, pre = "", i = 0)
     lines = wrapped_lines(io, s..., width = width, i = i)
-    println(io, lines[1])
+    print(io, lines[1])
     for line in lines[2:end]
-        println(io, pre, line)
+        print(io, '\n', pre, line)
     end
     length(lines), length(pre) + ansi_length(lines[end])
 end
 
 print_wrapped(f::Function, io::IO, args...; kws...) = print_wrapped(io, f, args...; kws...)
-

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -9,7 +9,7 @@ function term(io::IO, content::Vector, cols)
     isempty(content) && return
     for md in content[1:end-1]
         term(io, md, cols)
-        println(io)
+        print(io, '\n', '\n')
     end
     term(io, content[end], cols)
 end
@@ -17,16 +17,18 @@ end
 term(io::IO, md::MD, columns = cols(io)) = term(io, md.content, columns)
 
 function term(io::IO, md::Paragraph, columns)
-    print(io, " "^margin)
-    print_wrapped(io, width = columns-2margin, pre = " "^margin) do io
+    print(io, ' '^margin)
+    print_wrapped(io, width = columns-2margin, pre = ' '^margin) do io
         terminline(io, md.content)
     end
 end
 
 function term(io::IO, md::BlockQuote, columns)
     s = sprint(term, md.content, columns - 10; context=io)
-    for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "│", line)
+    lines = split(rstrip(s), '\n')
+    print(io, ' '^margin, '│', lines[1])
+    for i = 2:length(lines)
+        print(io, '\n', ' '^margin, '│', lines[i])
     end
 end
 
@@ -42,47 +44,52 @@ function term(io::IO, md::Admonition, columns)
     elseif lowercase(md.title) == "tip"
         col = :green
     end
-    printstyled(io, " "^margin, "│ "; color=col, bold=true)
+    printstyled(io, ' '^margin, "│ "; color=col, bold=true)
     printstyled(io, isempty(md.title) ? md.category : md.title; color=col, bold=true)
-    printstyled(io, "\n", " "^margin, "│", "\n"; color=col, bold=true)
+    printstyled(io, '\n', ' '^margin, '│', '\n'; color=col, bold=true)
     s = sprint(term, md.content, columns - 10; context=io)
-    for line in split(rstrip(s), "\n")
-        printstyled(io, " "^margin, "│"; color=col, bold=true)
-        println(io, line)
+    lines = split(rstrip(s), '\n')
+    for i in eachindex(lines)
+        printstyled(io, ' '^margin, '│'; color=col, bold=true)
+        print(io, lines[i])
+        i < lastindex(lines) && println(io)
     end
 end
 
 function term(io::IO, f::Footnote, columns)
-    print(io, " "^margin, "│ ")
+    print(io, ' '^margin, "│ ")
     printstyled(io, "[^$(f.id)]", bold=true)
-    println(io, "\n", " "^margin, "│")
+    println(io, '\n', ' '^margin, '│')
     s = sprint(term, f.text, columns - 10; context=io)
-    for line in split(rstrip(s), "\n")
-        println(io, " "^margin, "│", line)
+    lines = split(rstrip(s), '\n')
+    for i in eachindex(lines)
+        print(io, ' '^margin, '│', lines[i])
+        i < lastindex(lines) && println(io)
     end
 end
 
 function term(io::IO, md::List, columns)
     for (i, point) in enumerate(md.items)
-        print(io, " "^2margin, isordered(md) ? "$(i + md.ordered - 1). " : "•  ")
-        print_wrapped(io, width = columns-(4margin+2), pre = " "^(2margin+2),
+        print(io, ' '^2margin, isordered(md) ? "$(i + md.ordered - 1). " : "•  ")
+        print_wrapped(io, width = columns-(4margin+2), pre = ' '^(2margin+2),
                           i = 2margin+2) do io
             term(io, point, columns - 10)
         end
+        i < lastindex(md.items) && print(io, '\n', '\n')
     end
 end
 
 function _term_header(io::IO, md, char, columns)
     text = terminline_string(io, md.text)
     with_output_color(:bold, io) do io
-        print(io, " "^(margin))
+        print(io, ' '^margin)
         line_no, lastline_width = print_wrapped(io, text,
                                                 width=columns - 4margin; pre=" ")
         line_width = min(1 + lastline_width, columns)
         if line_no > 1
             line_width = max(line_width, div(columns, 3))
         end
-        char != ' ' && println(io, " "^(margin), string(char) ^ line_width)
+        char != ' ' && print(io, '\n', ' '^(margin), char^line_width)
     end
 end
 
@@ -96,19 +103,18 @@ end
 
 function term(io::IO, md::Code, columns)
     with_output_color(:cyan, io) do io
-        for line in lines(md.code)
-            print(io, " "^margin)
-            println(io, line)
+        L = lines(md.code)
+        for i in eachindex(L)
+            print(io, ' '^margin, L[i])
+            i < lastindex(L) && println(io)
         end
     end
 end
 
-function term(io::IO, br::LineBreak, columns)
-   println(io)
-end
+term(io::IO, br::LineBreak, columns) = nothing # line breaks already printed between subsequent elements
 
 function term(io::IO, br::HorizontalRule, columns)
-   println(io, " " ^ margin, "─" ^ (columns - 2margin))
+   print(io, ' '^margin, '─'^(columns - 2margin))
 end
 
 term(io::IO, x, _) = show(io, MIME"text/plain"(), x)
@@ -126,7 +132,7 @@ function terminline(io::IO, content::Vector)
 end
 
 function terminline(io::IO, md::AbstractString)
-    print(io, replace(md, r"[\s\t\n]+" => " "))
+    print(io, replace(md, r"[\s\t\n]+" => ' '))
 end
 
 function terminline(io::IO, md::Bold)

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -226,11 +226,11 @@ World""" |> plain == "Hello\n\n---\n\nWorld\n"
 # Terminal (markdown) output
 
 # multiple whitespace is ignored
-@test sprint(term, md"a  b") == "  a b\n"
-@test sprint(term, md"[x](https://julialang.org)") == "  x (https://julialang.org)\n"
-@test sprint(term, md"[x](@ref)") == "  x\n"
-@test sprint(term, md"[x](@ref something)") == "  x\n"
-@test sprint(term, md"![x](https://julialang.org)") == "  (Image: x)\n"
+@test sprint(term, md"a  b") == "  a b"
+@test sprint(term, md"[x](https://julialang.org)") == "  x (https://julialang.org)"
+@test sprint(term, md"[x](@ref)") == "  x"
+@test sprint(term, md"[x](@ref something)") == "  x"
+@test sprint(term, md"![x](https://julialang.org)") == "  (Image: x)"
 
 # enumeration is normalized
 let doc = Markdown.parse(
@@ -312,7 +312,7 @@ table = md"""
 # mime output
 let out =
     @test sprint(show, "text/plain", book) ==
-        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •    list1\n      \n    •    list2\n      \n"
+        "  Title\n  ≡≡≡≡≡≡≡\n\n  Some discussion\n\n  │  A quote\n\n  Section important\n  ===================\n\n  Some bolded\n\n    •    list1\n\n    •    list2"
     @test sprint(show, "text/markdown", book) ==
         """
         # Title
@@ -1073,11 +1073,11 @@ end
 let buf = IOBuffer()
     @test typeof(sprint(Markdown.term, Markdown.parse(" "))) == String
     show(buf, "text/plain", md"*emph*")
-    @test String(take!(buf)) == "  emph\n"
+    @test String(take!(buf)) == "  emph"
     show(buf, "text/markdown", md"*emph*")
     @test String(take!(buf)) == "*emph*\n"
     show(IOContext(buf, :color=>true), "text/plain", md"*emph*")
-    @test String(take!(buf)) == "  \e[4memph\e[24m\n"
+    @test String(take!(buf)) == "  \e[4memph\e[24m"
 end
 
 # table rendering with term #25213
@@ -1085,7 +1085,7 @@ t = """
     a   |   b
     :-- | --:
     1   |   2"""
-@test sprint(Markdown.term, Markdown.parse(t), 0) == "a b\n– –\n1 2\n"
+@test sprint(Markdown.term, Markdown.parse(t), 0) == "a b\n– –\n1 2"
 
 # test Base.copy
 let

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -32,7 +32,7 @@ docstring_startswith(d1::DocStr, d2) = docstring_startswith(parsedoc(d1), d2)
 
 @doc "Doc abstract type"
 abstract type C74685{T,N} <: AbstractArray{T,N} end
-@test repr("text/plain", Docs.doc(C74685))=="  Doc abstract type\n"
+@test repr("text/plain", Docs.doc(C74685))=="  Doc abstract type"
 @test string(Docs.doc(C74685))=="Doc abstract type\n"
 
 macro macro_doctest() end


### PR DESCRIPTION
Fixes #27102.

Since I was going through Markdown/render.jl line by line, I also made a few other small cleanups, primarily replacing single-character strings with chars.