### PR TITLE
fix tab completion in reverse search in REPL (fixes #26176)

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -1680,7 +1680,9 @@ function complete_line(s::SearchState, repeats)
         prev_pos = position(s)
         push_undo(s)
         edit_splice!(s, prev_pos-sizeof(partial) => prev_pos, completions[1])
+        return true
     end
+    false
 end
 
 function accept_result(s, p)


### PR DESCRIPTION
Tiny commit to fix  #26176  "Tab completion in reverse search is broken". The error disappears with the fix, and things like Unicode tab completion work in reverse-i-search mode now. 