### PR TITLE
precompile: support `@big_str` parsed integers

### DIFF
--- a/test/int.jl
+++ b/test/int.jl
@@ -107,8 +107,8 @@ end
     @test big"2"^100 == BigInt(2)^100
     @test isa(big"2", BigInt)
     @test big"1.0" == BigFloat(1.0)
-    @test_throws ArgumentError big"1.0.3"
-    @test_throws ArgumentError big"pi"
+    @test_throws LoadError Meta.@macroexpand big"1.0.3"
+    @test_throws LoadError Meta.@macroexpand big"pi"
 end
 
 @test round(UInt8, 123) == 123
@@ -287,8 +287,8 @@ end
 
 @testset "issue #21092" begin
     @test big"1_0_0_0" == BigInt(1000)
-    @test_throws ArgumentError big"1_0_0_0_"
-    @test_throws ArgumentError big"_1_0_0_0"
+    @test_throws LoadError Meta.@lower big"1_0_0_0_"
+    @test_throws LoadError Meta.@lower big"_1_0_0_0"
 end
 
 # issue #26779

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -145,6 +145,8 @@ try
 
               const abigfloat_f() = big"12.34"
               const abigfloat_x = big"43.21"
+              const abigint_f() = big"12_34"
+              #TODO: const abigint_x = big"43_21"
           end
           """)
     @test_throws ErrorException Core.kwfunc(Base.nothing) # make sure `nothing` didn't have a kwfunc (which would invalidate the attempted test)
@@ -171,6 +173,8 @@ try
         # Issue #15722
         @test Foo.abigfloat_f()::BigFloat == big"12.34"
         @test (Foo.abigfloat_x::BigFloat + 21) == big"64.21"
+        @test Foo.abigint_f()::BigInt == big(12_34)
+        #@test (Foo.abigint_x::BigInt + 21) == big(43_42)
     end
 
     cachedir = joinpath(dir, "compiled", "v$(VERSION.major).$(VERSION.minor)")


### PR DESCRIPTION
In support of #26991 (enable `__precompile__` flag by default), this ensures that parser-derived "big" numbers are restored completely at runtime, to remove that odd "gotcha".