### PR TITLE
Get rid of the tricks to avoid overflow in the AbstractUnitRange iterator

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -467,12 +467,13 @@ end
 
 iterate(r::StepRangeLen{T}, i=1) where {T} = i > length(r) ? nothing : (unsafe_getindex(r, i), i+1)
 
+iterate(r::AbstractUnitRange) = isless(last(r), first(r)) ? nothing : (first(r), first(r))
+
 function iterate(r::AbstractUnitRange{T}, i) where {T}
-    i == oftype(i, r.stop) + oneunit(T) && return nothing
-    (convert(T, i), i + oneunit(T))
+    i == last(r) && return nothing
+    next = convert(T, i + oneunit(T))
+    (next, next)
 end
-iterate(r::AbstractUnitRange{T}) where {T} = iterate(r, oftype(r.start + oneunit(T), r.start))
-iterate(r::OneTo{T}) where {T} = iterate(r, oneunit(T))
 
 # some special cases to favor default Int type to avoid overflow
 let smallint = (Int === Int64 ?
@@ -483,11 +484,6 @@ let smallint = (Int === Int64 ?
         (isempty(r) | (i == oftype(i, r.stop) + r.step)) && return nothing
         (i % T, i + r.step)
     end
-    function iterate(r::AbstractUnitRange{T}, i=convert(Int, r.start)) where {T<:smallint}
-        i == oftype(i, r.stop) + 1 && return nothing
-        (i % T, i + 1)
-    end
-    iterate(r::OneTo{T}) where {T<:smallint} = iterate(r, 1)
 end
 
 ## indexing

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -418,12 +418,19 @@ end
     end
     @test s == 2
 
-    # loops covering the full range of smaller integer types
+    # loops covering the full range of integers
     s = 0
     for i = typemin(UInt8):typemax(UInt8)
         s += 1
     end
     @test s == 256
+
+    s = 0
+    for i = typemin(UInt):typemax(UInt)
+        i == 10 && break
+        s += 1
+    end
+    @test s == 10
 
     s = 0
     for i = typemin(UInt8):one(UInt8):typemax(UInt8)


### PR DESCRIPTION
Thanks to the new iterator protocol we can now iterate over a unit range in the number type of its elements, without having to worry about overflow :). Fixes #26586.

Previously iterating over say `typemin(Int8) : typemax(Int8)` was done by using an `Int` internally which was converted to an `Int8` each iteration. Now we can just iterate with `Int8`.

Something similar can probably be done for `StepRange`, but that would  be another pr.