### PR TITLE
export `getproperty`, `setproperty!`, and `propertynames`

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -720,13 +720,13 @@ export
 
 # types
     convert,
-    # getproperty,
-    # setproperty!,
+    getproperty,
+    setproperty!,
     fieldoffset,
     fieldname,
     fieldnames,
     fieldcount,
-    # propertynames,
+    propertynames,
     isabstracttype,
     isbitstype,
     isprimitivetype,


### PR DESCRIPTION
fixes #27120

These already have documentation. Improving the docs is not alpha-blocking.