### PR TITLE
Publish docs for Base.Iterators.Stateful

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -976,12 +976,13 @@ end
     Stateful(itr)
 
 There are several different ways to think about this iterator wrapper:
-    1. It provides a mutable wrapper around an iterator and
-       its iteration state.
-    2. It turns an iterator-like abstraction into a Channel-like
-       abstraction.
-    3. It's an iterator that mutates to become its own rest iterator
-       whenever an item is produced.
+
+1. It provides a mutable wrapper around an iterator and
+   its iteration state.
+2. It turns an iterator-like abstraction into a Channel-like
+   abstraction.
+3. It's an iterator that mutates to become its own rest iterator
+   whenever an item is produced.
 
 `Stateful` provides the regular iterator interface. Like other mutable iterators
 (e.g. `Channel`), if iteration is stopped early (e.g. by a `break` in a `for` loop),

--- a/doc/src/base/iterators.md
+++ b/doc/src/base/iterators.md
@@ -1,6 +1,7 @@
 # Iteration utilities
 
 ```@docs
+Base.Iterators.Stateful
 Base.Iterators.zip
 Base.Iterators.enumerate
 Base.Iterators.rest


### PR DESCRIPTION
Also changed the formatting for the list so it shows up nice in rendered markdown. Indenting causes it to be code-formatted, and the lack of a blank line causes it to not understand that it's a list.