### PR TITLE
Move the definitions of eltype() and length() in the iteration demo

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -66,9 +66,6 @@ julia> struct Squares
 
 julia> Base.iterate(S::Squares, state=1) = state > S.count ? nothing : (state*state, state+1)
 
-julia> Base.eltype(::Type{Squares}) = Int # Note that this is defined for the type
-
-julia> Base.length(S::Squares) = S.count
 ```
 
 With only [`iterate`](@ref) definition, the `Squares` type is already pretty powerful.
@@ -104,7 +101,13 @@ There are a few more methods we can extend to give Julia more information about 
 collection.  We know that the elements in a `Squares` sequence will always be `Int`. By extending
 the [`eltype`](@ref) method, we can give that information to Julia and help it make more specialized
 code in the more complicated methods. We also know the number of elements in our sequence, so
-we can extend [`length`](@ref), too.
+we can extend [`length`](@ref), too:
+
+```jldoctest squaretype
+julia> Base.eltype(::Type{Squares}) = Int # Note that this is defined for the type
+
+julia> Base.length(S::Squares) = S.count
+```
 
 Now, when we ask Julia to [`collect`](@ref) all the elements into an array it can preallocate a `Vector{Int}`
 of the right size instead of blindly [`push!`](@ref)ing each element into a `Vector{Any}`:


### PR DESCRIPTION
Moves the definitions of eltype() and length() in the basic iteration demo closer to their occurrence in the text. Currently, the methods are defined in code a few paragraphs before they're mentioned in the text, which makes the example a bit harder to follow.

This also helps reinforce the story that iterate() is the *only* required method for iteration, while eltype() and length() are optional improvements.