### PR TITLE
Simplify iteration over ranges in general

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -117,7 +117,7 @@ convert(::Type{T}, r::AbstractRange) where {T<:AbstractRange} = r isa T ? r : T(
 ## ordinal ranges
 
 abstract type OrdinalRange{T,S} <: AbstractRange{T} end
-abstract type AbstractUnitRange{T} <: OrdinalRange{T,Int} end
+abstract type AbstractUnitRange{T} <: OrdinalRange{T,T} end
 
 struct StepRange{T,S} <: OrdinalRange{T,S}
     start::T
@@ -374,7 +374,7 @@ julia> step(range(2.5, stop=10.9, length=85))
 ```
 """
 step(r::StepRange) = r.step
-step(r::AbstractUnitRange) = 1
+step(r::AbstractUnitRange{T}) where{T} = oneunit(T)
 step(r::StepRangeLen{T}) where {T} = T(r.step)
 step(r::LinRange) = (last(r)-first(r))/r.lendiv
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -450,13 +450,11 @@ copy(r::AbstractRange) = r
 
 ## iteration
 
-function iterate(r::LinRange, i::Int=1)
+function iterate(r::Union{LinRange,StepRangeLen}, i::Int=1)
     @_inline_meta
     length(r) < i && return nothing
-    unsafe_getindex(r, i), i+1
+    unsafe_getindex(r, i), i + 1
 end
-
-iterate(r::StepRangeLen{T}, i=1) where {T} = i > length(r) ? nothing : (unsafe_getindex(r, i), i+1)
 
 iterate(r::OrdinalRange) = isempty(r) ? nothing : (first(r), first(r))
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -467,13 +467,6 @@ function iterate(r::OrdinalRange{T}, i) where {T}
     (next, next)
 end
 
-# In the case of floats we might not land exactly on the boundary due to rounding errors
-function iterate(r::StepRange{T}, i) where {T<:AbstractFloat}
-    next = convert(T, i + step(r))
-    ((next < min(r.start, r.stop)) | (next > max(r.start, r.stop))) && return nothing
-    (next, next)
-end
-
 ## indexing
 
 function getindex(v::UnitRange{T}, i::Integer) where T

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -438,6 +438,13 @@ end
     end
     @test s == 256
 
+    s = 0
+    for i = typemin(UInt):1:typemax(UInt)
+        i == 10 && break
+        s += 1
+    end
+    @test s == 10
+
     # loops past typemax(Int)
     n = 0
     s = Int128(0)


### PR DESCRIPTION
This complements #27147 with a bit of refactoring of `StepRange`.

- The step type of `AbstractUnitRange` is now identical to the element type
- ~For `StepRange{<:AbstractFloat}`: assume that we cannot land on the boundary of the range exactly~. Assume we can land on the boundary of the range exactly, so that we can always iterate over the full range inclusive without overflows.
- `LinRange` and `StepRangeLen` iteration was identical, so they're now combined.

Also fixes a bug where one cannot iterate as follows:

```
s = 0
for i = typemin(Int) : 1 : typemax(Int)
  i == typemin(Int) + 10 && break
  s += 1
endx
@assert s == 10
```