### PR TITLE
Fix `@isdefined` with new optimizer

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -834,8 +834,11 @@ function type_lift_pass!(ir::IRCode)
             # so lift all these nodes that have maybe undef values
             processed = IdDict{Int, Union{SSAValue, Bool}}()
             if !isa(val, SSAValue)
+                (isa(val, GlobalRef) || isexpr(val, :static_parameter)) && continue
                 if stmt.head === :undefcheck
                     ir.stmts[idx] = nothing
+                else
+                    ir.stmts[idx] = true
                 end
                 continue
             end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -214,7 +214,7 @@ isconst(m::Module, s::Symbol) =
 Tests whether variable `s` is defined in the current scope.
 
 # Examples
-```julia-repl
+```jldoctest
 julia> function f()
            println(@isdefined x)
            x = 3

--- a/test/core.jl
+++ b/test/core.jl
@@ -6089,3 +6089,17 @@ let A = [1], B = [], C = DelegateIterator([1]), D = DelegateIterator([]), E = An
     @test done(D, start(D))
     @test next(E, next(E, start(E))[2])[1] == "abc"
 end
+
+# Issue 27103
+function f27103()
+    a = @isdefined x
+    x = 3
+    b = @isdefined x
+    (a, b)
+end
+@test f27103() == (false, true)
+
+g27103() = @isdefined z27103
+@test g27103() == false
+z27103 = 1
+@test g27103() == true


### PR DESCRIPTION
The only values that are special for an `:isdefined` expression are SSAValues
(which are tracked through to phi nodes to see if they are defined), global
variables and static parameters (both of which have support in the interpreter
and codegen).

Fixes #27103.