### PR TITLE
Minimal infrastructure support for ThreadSanitizer

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -492,7 +492,7 @@ ifeq ($(USE_LIBCPP),1)
 $(error USE_LIBCPP only supported with clang. Try setting USE_LIBCPP=0)
 endif
 ifeq ($(SANITIZE),1)
-$(error Address Sanitizer only supported with clang. Try setting SANITIZE=0)
+$(error Sanitizers are only supported with clang. Try setting SANITIZE=0)
 endif
 CC := $(CROSS_COMPILE)gcc
 CXX := $(CROSS_COMPILE)g++
@@ -539,7 +539,7 @@ ifeq ($(USE_LIBCPP),1)
 $(error USE_LIBCPP only supported with clang. Try setting USE_LIBCPP=0)
 endif
 ifeq ($(SANITIZE),1)
-$(error Address Sanitizer only supported with clang. Try setting SANITIZE=0)
+$(error Sanitizers only supported with clang. Try setting SANITIZE=0)
 endif
 CC  := icc
 CXX := icpc
@@ -670,17 +670,27 @@ endif
 endif
 
 ifeq ($(SANITIZE),1)
+SANITIZE_OPTS :=
+SANITIZE_LDFLAGS :=
 ifeq ($(SANITIZE_MEMORY),1)
-SANITIZE_OPTS := -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer
-SANITIZE_LDFLAGS := $(SANITIZE_OPTS)
-else
-SANITIZE_OPTS := -fsanitize=address -mllvm -asan-stack=0
-SANITIZE_LDFLAGS := -fsanitize=address
+SANITIZE_OPTS += -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer
+SANITIZE_LDFLAGS += $(SANITIZE_OPTS)
+endif
+ifeq ($(SANITIZE_ADDRESS),1)
+SANITIZE_OPTS += -fsanitize=address -mllvm -asan-stack=0
+SANITIZE_LDFLAGS += -fsanitize=address
+endif
+ifeq ($(SANITIZE_THREAD),1)
+SANITIZE_OPTS += -fsanitize=thread
+SANITIZE_LDFLAGS += -fsanitize=thread
+endif
+ifeq ($(SANITIZE_OPTS),)
+$(error SANITIZE=1, but no sanitizer selected, set either SANITIZE_MEMORY, SANITIZE_THREAD, or SANITIZE_ADDRESS)
 endif
 JCXXFLAGS += $(SANITIZE_OPTS)
 JCFLAGS += $(SANITIZE_OPTS)
 JLDFLAGS += $(SANITIZE_LDFLAGS)
-endif
+endif # SANITIZE
 
 TAR := $(shell which gtar 2>/dev/null || which tar 2>/dev/null)
 TAR_TEST := $(shell $(TAR) --help 2>&1  | egrep 'bsdtar|strip-components')

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -410,6 +410,7 @@ $(eval $(call LLVM_PATCH,llvm-8.0-D66657-codegen-degenerate)) # remove for 10.0
 $(eval $(call LLVM_PATCH,llvm-8.0-D71495-vectorize-freduce)) # remove for 10.0
 $(eval $(call LLVM_PATCH,llvm-8.0-D75072-SCEV-add-type))
 $(eval $(call LLVM_PATCH,llvm-8.0-D65174-limit-merge-stores)) # remove for 10.0
+$(eval $(call LLVM_PATCH,llvm-julia-tsan-custom-as))
 endif # LLVM_VER 8.0
 
 ifeq ($(LLVM_VER_SHORT),9.0)
@@ -427,6 +428,7 @@ $(eval $(call LLVM_PATCH,llvm-D75072-SCEV-add-type))
 $(eval $(call LLVM_PATCH,llvm-9.0-D65174-limit-merge-stores)) # remove for 10.0
 $(eval $(call LLVM_PATCH,llvm9-D71443-PPC-MC-redef-symbol)) # remove for 10.0
 $(eval $(call LLVM_PATCH,llvm-9.0-D78196)) # remove for 11.0
+$(eval $(call LLVM_PATCH,llvm-julia-tsan-custom-as))
 endif # LLVM_VER 9.0
 
 ifeq ($(LLVM_VER_SHORT),10.0)
@@ -441,6 +443,7 @@ $(eval $(call LLVM_PATCH,llvm7-revert-D44485))
 $(eval $(call LLVM_PATCH,llvm-D75072-SCEV-add-type))
 $(eval $(call LLVM_PATCH,llvm-10.0-PPC_SELECT_CC)) # delete for LLVM 11
 $(eval $(call LLVM_PATCH,llvm-10.0-PPC-LI-Elimination)) # delete for LLVM 11
+$(eval $(call LLVM_PATCH,llvm-julia-tsan-custom-as))
 endif # LLVM_VER 10.0
 
 # Add a JL prefix to the version map. DO NOT REMOVE

--- a/deps/patches/llvm-julia-tsan-custom-as.patch
+++ b/deps/patches/llvm-julia-tsan-custom-as.patch
@@ -1,0 +1,28 @@
+From bd41be423127b8946daea805290ad2eb19e66be4 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Sat, 19 May 2018 11:56:55 -0400
+Subject: [PATCH] [TSAN] Allow for custom address spaces
+
+Julia uses addressspaces for GC and we want these to be sanitized as well.
+---
+ lib/Transforms/Instrumentation/ThreadSanitizer.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/lib/Transforms/Instrumentation/ThreadSanitizer.cpp b/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+index ec6904486e1..9d673353f43 100644
+--- a/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
++++ b/lib/Transforms/Instrumentation/ThreadSanitizer.cpp
+@@ -296,7 +296,9 @@ static bool shouldInstrumentReadWriteFromAddress(const Module *M, Value *Addr) {
+   // with them.
+   if (Addr) {
+     Type *PtrTy = cast<PointerType>(Addr->getType()->getScalarType());
+-    if (PtrTy->getPointerAddressSpace() != 0)
++    auto AS = PtrTy->getPointerAddressSpace();
++    // Allow for custom addresspaces
++    if (AS != 0 && AS < 10)
+       return false;
+   }
+ 
+-- 
+2.17.0
+

--- a/doc/src/devdocs/sanitizers.md
+++ b/doc/src/devdocs/sanitizers.md
@@ -11,10 +11,13 @@ An easy solution is to have an dedicated build folder for providing a matching t
 with `BUILD_LLVM_CLANG=1`. You can then refer to this toolchain from another build
 folder by specifying `USECLANG=1` while overriding the `CC` and `CXX` variables.
 
+To use one of of the sanitizers set `SANITIZE=1` and then the appropriate flag for the sanitizer you
+want to use.
+
 ## Address Sanitizer (ASAN)
 
 For detecting or debugging memory bugs, you can use Clang's [address sanitizer (ASAN)](http://clang.llvm.org/docs/AddressSanitizer.html).
-By compiling with `SANITIZE=1` you enable ASAN for the Julia compiler and its generated code.
+By compiling with `SANITIZE_ADDRESS=1` you enable ASAN for the Julia compiler and its generated code.
 In addition, you can specify `LLVM_SANITIZE=1` to sanitize the LLVM library as well. Note that
 these options incur a high performance and memory cost. For example, using ASAN for Julia and
 LLVM makes `testall1` takes 8-10 times as long while using 20 times as much memory (this can be
@@ -31,3 +34,8 @@ the future.
 
 For detecting use of uninitialized memory, you can use Clang's [memory sanitizer (MSAN)](http://clang.llvm.org/docs/MemorySanitizer.html)
 by compiling with `SANITIZE_MEMORY=1`.
+
+## Thread Sanitizer (TSAN)
+
+For debugging data-races and other threading related issues you can use Clang's [thread sanitizer (TSAN)](https://clang.llvm.org/docs/ThreadSanitizer.html)
+by compiling with `SANITIZE_THREAD=1`.

--- a/src/aotcompile.cpp
+++ b/src/aotcompile.cpp
@@ -2,7 +2,6 @@
 
 #include "llvm-version.h"
 #include "platform.h"
-#include "options.h"
 
 // target support
 #include <llvm/ADT/Triple.h>
@@ -23,6 +22,9 @@
 #include <llvm/Transforms/Vectorize.h>
 #if defined(JL_ASAN_ENABLED)
 #include <llvm/Transforms/Instrumentation/AddressSanitizer.h>
+#endif
+#if defined(JL_TSAN_ENABLED)
+#include <llvm/Transforms/Instrumentation/ThreadSanitizer.h>
 #endif
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
@@ -624,6 +626,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         }
         PM->add(createMemCpyOptPass());
         PM->add(createAlwaysInlinerLegacyPass()); // Respect always_inline
+        PM->add(createLowerSimdLoopPass()); // Annotate loop marked with "loopinfo" as LLVM parallel loop
         if (lower_intrinsics) {
             PM->add(createBarrierNoopPass());
             PM->add(createLowerExcHandlersPass());
@@ -641,6 +644,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
 #endif
 #if defined(JL_MSAN_ENABLED)
         PM->add(createMemorySanitizerPass(true));
+#endif
+#if defined(JL_TSAN_ENABLED)
+        PM->add(createThreadSanitizerLegacyPassPass());
 #endif
         return;
     }
@@ -763,6 +769,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
 #endif
 #if defined(JL_MSAN_ENABLED)
     PM->add(createMemorySanitizerPass(true));
+#endif
+#if defined(JL_TSAN_ENABLED)
+    PM->add(createThreadSanitizerLegacyPassPass());
 #endif
 }
 

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -2,7 +2,6 @@
 
 #include "llvm-version.h"
 #include "platform.h"
-#include "options.h"
 
 #include <llvm/ExecutionEngine/SectionMemoryManager.h>
 #include "julia.h"

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2,7 +2,6 @@
 
 #include "llvm-version.h"
 #include "platform.h"
-#include "options.h"
 #if defined(_OS_WINDOWS_)
 // use ELF because RuntimeDyld COFF i686 support didn't exist
 // use ELF because RuntimeDyld COFF X86_64 doesn't seem to work (fails to generate function pointers)?
@@ -5785,6 +5784,12 @@ static std::pair<std::unique_ptr<Module>, jl_llvm_functions_t>
 
 #ifdef JL_DEBUG_BUILD
     f->addFnAttr(Attribute::StackProtectStrong);
+#endif
+
+#ifdef JL_TSAN_ENABLED
+    // TODO: enable this only when a argument like `-race` is passed to Julia
+    //       add a macro for no_sanitize_thread
+    f->addFnAttr(llvm::Attribute::SanitizeThread);
 #endif
 
     // add the optimization level specified for this module, if any

--- a/src/dlload.c
+++ b/src/dlload.c
@@ -110,7 +110,7 @@ JL_DLLEXPORT void *jl_dlopen(const char *filename, unsigned flags)
 #ifdef RTLD_NOLOAD
                   | JL_RTLD(flags, NOLOAD)
 #endif
-#if defined(RTLD_DEEPBIND) && !defined(JL_ASAN_ENABLED)
+#if defined(RTLD_DEEPBIND) && !(defined(JL_ASAN_ENABLED) || defined(JL_TSAN_ENABLED) || defined(JL_MSAN_ENABLED))
                   | JL_RTLD(flags, DEEPBIND)
 #endif
 #ifdef RTLD_FIRST

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -4,7 +4,6 @@
 
 #include "llvm-version.h"
 #include "platform.h"
-#include "options.h"
 
 #include <llvm/Transforms/Utils/Cloning.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>

--- a/src/julia.expmap
+++ b/src/julia.expmap
@@ -1,6 +1,8 @@
 {
   global:
     __asan*;
+    __tsan*;
+    pthread*;
     __stack_chk_guard;
     asprintf;
     bitvector_*;

--- a/src/julia.h
+++ b/src/julia.h
@@ -65,6 +65,23 @@
 #  define JL_THREAD_LOCAL
 #endif
 
+// Duplicated from options.h
+#if defined(__has_feature) // Clang flavor
+#if __has_feature(address_sanitizer)
+#define JL_ASAN_ENABLED
+#endif
+#if __has_feature(memory_sanitizer)
+#define JL_MSAN_ENABLED
+#endif
+#if __has_feature(thread_sanitizer)
+#define JL_TSAN_ENABLED
+#endif
+#else // GCC flavor
+#if defined(__SANITIZE_ADDRESS__)
+#define JL_ASAN_ENABLED
+#endif
+#endif // __has_feature
+
 #define container_of(ptr, type, member) \
     ((type *) ((char *)(ptr) - offsetof(type, member)))
 
@@ -1787,6 +1804,10 @@ typedef struct _jl_task_t {
     size_t bufsz; // actual sizeof stkbuf
     unsigned int copy_stack:31; // sizeof stack for copybuf
     unsigned int started:1;
+
+#if defined(JL_TSAN_ENABLED)
+    void *tsan_state;
+#endif
 
     // current exception handler
     jl_handler_t *eh;

--- a/src/options.h
+++ b/src/options.h
@@ -154,24 +154,19 @@
 
 // sanitizer defaults ---------------------------------------------------------
 
-// XXX: these macros are duplicated from julia_internal.h
-#if defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define JL_ASAN_ENABLED
-#endif
-#elif defined(__SANITIZE_ADDRESS__)
-#define JL_ASAN_ENABLED
-#endif
-#if defined(__has_feature)
-#if __has_feature(memory_sanitizer)
-#define JL_MSAN_ENABLED
-#endif
+#ifndef JULIA_H
+#error "Must be included after julia.h"
 #endif
 
 // Automatically enable MEMDEBUG and KEEP_BODIES for the sanitizers
 #if defined(JL_ASAN_ENABLED) || defined(JL_MSAN_ENABLED)
 #define MEMDEBUG
 #define KEEP_BODIES
+#endif
+
+// TSAN doesn't like COPY_STACKS
+#if defined(JL_TSAN_ENABLED) && defined(COPY_STACKS)
+#undef COPY_STACKS
 #endif
 
 // Memory sanitizer needs TLS, which llvm only supports for the small memory model


### PR DESCRIPTION
Inspired by the current progress on partr, I started looking into what
it takes to have a race detector like Go. This PR is the minimal change
necessary for people to build with thread-sanitizer enabled.

The big open question is how to move forward with this and how to enable
something as simplisitics as `go -race` for multi-threaded Julia code.

Current build requirements:
 - Clang (preferably build with `BUILD_LLVM_CLANG=1`)
 - add `-fsanitize=thread` and `-DJL_TSAN_ENABLED=1` to `JCFLAGS` and co.

I am open for ideas to enable better integration. I was thinking that our
options are:

1. Have a `julia-san` similar to `julia-debug` that has TSAN enabled
2. Pretend `tsan` is a cpu-feature and enable it in the sysimage behind
   a feature flag, e.g. `julia -race` would load the sanitized version
   of the sysimage. The main challenge here is that the executing binary
   needs to have setup code for TSAN, so we couldn't use that from a
   non-sanitized Julia
3. Go has special treatment in TSAN, and similarily instead off using the
   C/C++ TSAN we could build our own and hook that up correctly