### PR TITLE
[NewOptimizer] Hook up printing, print linetable

### DIFF
--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -151,7 +151,7 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, linetab
     @timeit "domtree 1" domtree = construct_domtree(cfg)
     ir = let code = Any[nothing for _ = 1:length(code)]
              argtypes = ci.slottypes[1:(nargs+1)]
-            IRCode(code, Any[], lines, flags, cfg, argtypes, mod, meta)
+            IRCode(code, Any[], lines, flags, cfg, linetable, argtypes, mod, meta)
         end
     @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs)
     return ir

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -249,7 +249,7 @@ function inflate_ir(ci::CodeInfo)
             code[i] = stmt
         end
     end
-    ir = IRCode(code, copy(ci.ssavaluetypes), copy(ci.codelocs), copy(ci.ssaflags), cfg, copy(ci.slottypes), ci.linetable[1].mod, Any[])
+    ir = IRCode(code, copy(ci.ssavaluetypes), copy(ci.codelocs), copy(ci.ssaflags), cfg, ci.linetable, copy(ci.slottypes), ci.linetable[1].mod, Any[])
     return ir
 end
 

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -4,6 +4,8 @@ IOContext(io::IO, KV::Pair) = IOContext(io, Base.Pair(KV[1], KV[2]))
 length(s::String) = Base.length(s)
 ^(s::String, i::Int) = Base.:^(s, i)
 end
+isexpr(e::Expr, s::Symbol) = e.head === s
+isexpr(@nospecialize(e), s::Symbol) = false
 
 function Base.show(io::IO, cfg::CFG)
     foreach(pairs(cfg.blocks)) do (idx, block)
@@ -11,21 +13,12 @@ function Base.show(io::IO, cfg::CFG)
     end
 end
 
-function print_ssa(io::IO, val)
-    if isa(val, SSAValue)
-        Base.print(io, "%$(val.id)")
-    elseif isa(val, Argument)
-        Base.print(io, "%%$(val.n)")
-    else
-        try
-            Base.print(io, val)
-        catch
-            Base.print(io, "<error printing>")
-        end
-    end
-end
+print_ssa(io::IO, val::SSAValue, argnames) = Base.print(io, "%$(val.id)")
+print_ssa(io::IO, val::Argument, argnames) = Base.print(io, isempty(argnames) ? "%%$(val.n)" : "%%$(argnames[val.n])")
+print_ssa(io::IO, val::GlobalRef, argnames) = Base.print(io, val)
+print_ssa(io::IO, @nospecialize(val), argnames) = Base.show(io, val)
 
-function print_node(io::IO, idx, stmt, used, maxsize; color = true, print_typ=true)
+function print_node(io::IO, idx, stmt, used, argnames, maxsize; color = true, print_typ=true)
     if idx in used
         pad = " "^(maxsize-length(string(idx)))
         Base.print(io, "%$idx $pad= ")
@@ -37,19 +30,19 @@ function print_node(io::IO, idx, stmt, used, maxsize; color = true, print_typ=tr
             e = stmt.edges[i]
             v = !isassigned(stmt.values, i) ? "#undef" :
                 sprint() do io′
-                    print_ssa(io′, stmt.values[i])
+                    print_ssa(io′, stmt.values[i], argnames)
                 end
             "$e => $v"
         end
         Base.print(io, "φ ", '(', join(args, ", "), ')')
     elseif isa(stmt, PhiCNode)
-        Base.print(io, "φᶜ ", '(', join(map(x->sprint(print_ssa, x), stmt.values), ", "), ')')
+        Base.print(io, "φᶜ ", '(', join(map(x->sprint(print_ssa, x, argnames), stmt.values), ", "), ')')
     elseif isa(stmt, PiNode)
         Base.print(io, "π (")
-        print_ssa(io, stmt.val)
+        print_ssa(io, stmt.val, argnames)
         Base.print(io, ", ")
         if color
-            Base.printstyled(io, stmt.typ, color=:red)
+            Base.printstyled(io, stmt.typ, color=:cyan)
         else
             Base.print(io, stmt.typ)
         end
@@ -57,7 +50,7 @@ function print_node(io::IO, idx, stmt, used, maxsize; color = true, print_typ=tr
     elseif isa(stmt, UpsilonNode)
         Base.print(io, "ϒ (")
         isdefined(stmt, :val) ?
-            print_ssa(io, stmt.val) :
+            print_ssa(io, stmt.val, argnames) :
             Base.print(io, "#undef")
         Base.print(io, ")")
     elseif isa(stmt, ReturnNode)
@@ -65,33 +58,236 @@ function print_node(io::IO, idx, stmt, used, maxsize; color = true, print_typ=tr
             Base.print(io, "unreachable")
         else
             Base.print(io, "return ")
-            print_ssa(io, stmt.val)
+            print_ssa(io, stmt.val, argnames)
         end
     elseif isa(stmt, GotoIfNot)
         Base.print(io, "goto ", stmt.dest, " if not ")
-        print_ssa(io, stmt.cond)
+        print_ssa(io, stmt.cond, argnames)
     elseif isexpr(stmt, :call)
-        print_ssa(io, stmt.args[1])
+        print_ssa(io, stmt.args[1], argnames)
         Base.print(io, "(")
-        Base.print(io, join(map(arg->sprint(io->print_ssa(io, arg)), stmt.args[2:end]), ", "))
+        Base.print(io, join(map(arg->sprint(io->print_ssa(io, arg, argnames)), stmt.args[2:end]), ", "))
+        Base.print(io, ")")
+        if print_typ && stmt.typ !== Any
+            Base.print(io, "::$(stmt.typ)")
+        end
+    elseif isexpr(stmt, :invoke)
+        print(io, "invoke ")
+        linfo = stmt.args[1]
+        print_ssa(io, stmt.args[2], argnames)
+        Base.print(io, "(")
+        sig = linfo.specTypes === Tuple ? () : Base.unwrap_unionall(linfo.specTypes).parameters
+        print_arg(i) = sprint() do io
+            print_ssa(io, stmt.args[2+i], argnames)
+            if (i + 1) <= length(sig)
+                print(io, "::$(sig[i+1])")
+            end
+        end
+        Base.print(io, join((print_arg(i) for i=1:(length(stmt.args)-2)), ", "))
         Base.print(io, ")")
         if print_typ && stmt.typ !== Any
             Base.print(io, "::$(stmt.typ)")
         end
     elseif isexpr(stmt, :new)
         Base.print(io, "new(")
-        Base.print(io, join(map(arg->sprint(io->print_ssa(io, arg)), stmt.args), ", "))
+        Base.print(io, join(String[arg->sprint(io->print_ssa(io, arg, argnames)) for arg in stmt.args]), ", ")
         Base.print(io, ")")
     else
         Base.print(io, stmt)
     end
 end
 
-function Base.show(io::IO, code::IRCode)
-    io = IOContext(io, :color=>true)
+function compute_inlining_depth(linetable, iline)
+    depth = 0
+    while iline != 0
+        linetable[iline].inlined_at == 0 && break
+        depth += 1
+        iline = linetable[iline].inlined_at
+    end
+    depth
+end
+
+function should_print_ssa_type(node)
+    if isa(node, Expr)
+        return !(node.head in (:gc_preserve_begin, :gc_preserve_end))
+    end
+    return !isa(node, PiNode)   && !isa(node, GotoIfNot) &&
+           !isa(node, GotoNode) && !isa(node, ReturnNode)
+end
+
+function default_expr_type_printer(io, typ)
+    typ_str = try
+        string(typ)
+    catch
+        "<error_printing>"
+    end
+    Base.printstyled(io, "::$(typ_str)", color=:cyan)
+end
+
+function compute_loc_stack(code, line)
+    stack = []
+    line === 0 && return stack
+    inlined_at = code.linetable[line].inlined_at
+    if inlined_at != 0
+        push!(stack, inlined_at)
+        entry = code.linetable[inlined_at]
+        while entry.inlined_at != 0
+            push!(stack, entry.inlined_at)
+            entry = code.linetable[entry.inlined_at]
+        end
+        reverse!(stack)
+    end
+    push!(stack, line)
+end
+
+"""
+    Compute line number annotations for an IRCode
+
+This functions compute three sets of annotations for each IR line. Take the following
+example (taken from `@code_typed sin(1.0)`):
+
+```
+    **                                                    ***         **********
+    35 6 ── %10  = :(Base.mul_float)(%%2, %%2)::Float64   │╻╷         sin_kernel
+       │    %11  = :(Base.mul_float)(%10, %10)::Float64   ││╻          *
+```
+
+The three annotations are indicated with `*`. The first one is the line number of the
+active function (printed once whenver the outer most line number changes). The second
+is the inlining indicator. The number of lines indicate the level of nesting, with a
+half-size line (╷) indicating the start of a scope and a full size line (│) indicating
+a continuing scope. The last annotation is the most complicated one. It is a heuristic
+way to print the name of the entered scope. What it attempts to do is print the outermost
+scope that hasn't been printed before. Let's work a number of examples to see the impacts
+and tradeoffs involved.
+
+```
+f() = leaf_function() # Delibarately not defined to end up in the IR verbatim
+g() = f()
+h() = g()
+top_function() = h()
+```
+
+After inlining, we end up with:
+```
+1 1 ─ %1 = :(Main.leaf_function)()::Any   │╻╷╷ h
+  └──      return %1                      │
+```
+
+We see that the only function printed is the outermost function. This certainly loses
+some information, but the idea is that the outermost function would have the most
+semantic meaning (in the context of the function we're looking at).
+
+On the other hand, let's see what happens when we redefine f:
+```
+function f()
+    leaf_function()
+    leaf_function()
+    leaf_function()
+end
+```
+
+We get:
+```
+1 1 ─      :(Main.leaf_function)()::Any   │╻╷╷ h
+  │        :(Main.leaf_function)()::Any   ││┃│  g
+  │   %3 = :(Main.leaf_function)()::Any   │││┃   f
+  └──      return %3                      │
+```
+
+Even though we were in the `f` scope since the first statement, it tooks us two statements
+to catch up and print the intermediate scopes. Which scope is printed is indicated both
+by the indentation of the method name and by an increased thickness of the appropriate
+line for the scope.
+"""
+function compute_ir_line_annotations(code::IRCode)
+    loc_annotations = String[]
+    loc_methods = String[]
+    loc_lineno = String[]
+    cur_group = 1
+    last_line = 0
+    last_lineno = 0
+    last_stack = []
+    last_printed_depth = 0
+    for idx in eachindex(code.stmts)
+        buf = IOBuffer()
+        line = code.lines[idx]
+        depth = compute_inlining_depth(code.linetable, line)
+        iline = line
+        lineno = 0
+        loc_method = ""
+        print(buf, "│")
+        if line !== 0
+            stack = compute_loc_stack(code, line)
+            lineno = code.linetable[stack[1]].line
+            x = min(length(last_stack), length(stack))
+            if length(stack) != 0
+                # Compute the last depth that was in common
+                first_mismatch = findfirst(i->last_stack[i] != stack[i], 1:x)
+                # If the first mismatch is the last stack frame, that might just
+                # be a line number mismatch in inner most frame. Ignore those
+                if length(last_stack) == length(stack) && first_mismatch == length(stack)
+                    last_entry, entry = code.linetable[last_stack[end]], code.linetable[stack[end]]
+                    if last_entry.method == entry.method && last_entry.file == entry.file
+                        first_mismatch = nothing
+                    end
+                end
+                last_depth = coalesce(first_mismatch, x+1)-1
+                if min(depth, last_depth) > last_printed_depth
+                    printing_depth = min(depth, last_printed_depth + 1)
+                    last_printed_depth = printing_depth
+                elseif length(stack) > length(last_stack) || first_mismatch != nothing
+                    printing_depth = min(depth, last_depth + 1)
+                    last_printed_depth = printing_depth
+                else
+                    printing_depth = 0
+                end
+                stole_one = false
+                if printing_depth != 0
+                    for _ in 1:(printing_depth-1)
+                        print(buf, "│")
+                    end
+                    if printing_depth <= last_depth-1 && first_mismatch === nothing
+                        print(buf, "┃")
+                        for _ in printing_depth+1:min(depth, last_depth)
+                            print(buf, "│")
+                        end
+                    else
+                        stole_one = true
+                        print(buf, "╻")
+                    end
+                else
+                    for _ in 1:min(depth, last_depth)
+                        print(buf, "│")
+                    end
+                end
+                print(buf, "╷"^max(0,depth-last_depth-stole_one))
+                if printing_depth != 0
+                    if length(stack) == printing_depth
+                        loc_method = String(code.linetable[line].method)
+                    else
+                        loc_method = String(code.linetable[stack[printing_depth+1]].method)
+                    end
+                end
+                loc_method = string(" "^printing_depth, loc_method)
+            end
+            last_stack = stack
+            entry = code.linetable[line]
+        end
+        push!(loc_annotations, String(take!(buf)))
+        push!(loc_lineno, (lineno != 0 && lineno != last_lineno) ? string(lineno) : "")
+        push!(loc_methods, loc_method)
+        last_line = line
+        (lineno != 0) && (last_lineno = lineno)
+    end
+    (loc_annotations, loc_methods, loc_lineno)
+end
+
+Base.show(io::IO, code::IRCode) = show_ir(io, code)
+function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_printer; argnames=Symbol[], verbose_linetable=false)
+    (lines, cols) = displaysize(io)
     used = IdSet{Int}()
-    Base.println(io, "Code")
-    foreach(stmt->scan_ssa_use!(used, stmt), code.stmts)
+    foreach(stmt->scan_ssa_use!(push!, used, stmt), code.stmts)
     cfg = code.cfg
     max_bb_idx_size = length(string(length(cfg.blocks)))
     bb_idx = 1
@@ -99,7 +295,7 @@ function Base.show(io::IO, code::IRCode)
         printstyled(io, :red, "ERROR: New node array has unset entry\n")
     end
     new_nodes = code.new_nodes[filter(i->isassigned(code.new_nodes, i), 1:length(code.new_nodes))]
-    foreach(nn -> scan_ssa_use!(used, nn.node), new_nodes)
+    foreach(nn -> scan_ssa_use!(push!, used, nn.node), new_nodes)
     perm = sortperm(new_nodes, by = x->x.pos)
     new_nodes_perm = Iterators.Stateful(perm)
 
@@ -109,6 +305,14 @@ function Base.show(io::IO, code::IRCode)
         maxused = maximum(used)
         maxsize = length(string(maxused))
     end
+    if !verbose_linetable
+        (loc_annotations, loc_methods, loc_lineno) = compute_ir_line_annotations(code)
+        max_loc_width = maximum(length(str) for str in loc_annotations)
+        max_lineno_width = maximum(length(str) for str in loc_lineno)
+        max_method_width = maximum(length(str) for str in loc_methods)
+    end
+    max_depth = maximum(line == 0 ? 1 : compute_inlining_depth(code.linetable, line) for line in code.lines)
+    last_stack = []
     for idx in eachindex(code.stmts)
         if !isassigned(code.stmts, idx)
             # This is invalid, but do something useful rather
@@ -117,17 +321,52 @@ function Base.show(io::IO, code::IRCode)
             continue
         end
         stmt = code.stmts[idx]
+        # Compute BB guard rail
         bbrange = cfg.blocks[bb_idx].stmts
         bbrange = bbrange.first:bbrange.last
         bb_pad = max_bb_idx_size - length(string(bb_idx))
         bb_start_str = string("$(bb_idx) ",length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄",  "─"^(bb_pad)," ")
-        if idx != last(bbrange)
-            if idx == first(bbrange)
-                Base.print(io, bb_start_str)
-            else
-                Base.print(io, "│  "," "^max_bb_idx_size)
-            end
+        bb_guard_rail_cont = string("│  "," "^max_bb_idx_size)
+        if idx == first(bbrange)
+            bb_guard_rail = bb_start_str
+        else
+            bb_guard_rail = bb_guard_rail_cont
         end
+        # Print linetable information
+        if verbose_linetable
+            stack = compute_loc_stack(code, code.lines[idx])
+            # We need to print any stack frames that did not exist in the last stack
+            ndepth = max(1, length(stack))
+            rail = string(" "^(max_depth+1-ndepth), "│"^ndepth)
+            start_column = cols - max_depth - 10
+            for (i, x) in enumerate(stack)
+                if i > length(last_stack) || last_stack[i] != x
+                    entry = code.linetable[x]
+                    printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
+                    print(io, bb_guard_rail)
+                    ssa_guard = " "^(maxsize+4+(i-1))
+                    entry_label = "$(ssa_guard)$(entry.method) at $(entry.file):$(entry.line) "
+                    hline = string("─"^(start_column-length(entry_label)-length(bb_guard_rail)+max_depth-i), "┐")
+                    printstyled(io, string(entry_label, hline), "\n"; color=:light_black)
+                    bb_guard_rail = bb_guard_rail_cont
+                end
+            end
+            printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
+            last_stack = stack
+        else
+            annotation = loc_annotations[idx]
+            loc_method = loc_methods[idx]
+            lineno = loc_lineno[idx]
+            # Print location information right aligned. If the line below is too long, it'll overwrite this,
+            # but that's what we want.
+            if get(io, :color, false)
+                method_start_column = cols - max_method_width - max_loc_width - 2
+                filler = " "^(max_loc_width-length(annotation))
+                printstyled(io, "\e[$(method_start_column)G$(annotation)$(filler)$(loc_method)\e[1G", color = :light_black)
+            end
+            printstyled(io, lineno, " "^(max_lineno_width-length(lineno)+1); color = :light_black)
+        end
+        idx != last(bbrange) && Base.print(io, bb_guard_rail)
         print_sep = false
         if idx == last(bbrange)
             print_sep = true
@@ -146,13 +385,11 @@ function Base.show(io::IO, code::IRCode)
             end
             print_sep = true
             floop = false
-            print_ssa_typ = !isa(new_node.node, PiNode) && node_idx in used
             Base.with_output_color(:yellow, io) do io′
-                print_node(io′, node_idx, new_node.node, used, maxsize; color = false,
-                    print_typ=!print_ssa_typ || (isa(new_node.node, Expr) && typ != new_node.node.typ))
+                print_node(io′, node_idx, new_node.node, used, argnames, maxsize; color = false, print_typ=false)
             end
-            if print_ssa_typ
-                Base.printstyled(io, "::$(new_node.typ)", color=:red)
+            if should_print_ssa_type(new_node.node) && node_idx in used
+                expr_type_printer(io, new_node.typ)
             end
             Base.println(io)
         end
@@ -174,21 +411,14 @@ function Base.show(io::IO, code::IRCode)
             continue
         end
         typ = code.types[idx]
-        print_ssa_typ = !isa(stmt, PiNode) && idx in used
         try
-            print_node(io, idx, stmt, used, maxsize,
-                print_typ=!print_ssa_typ || (isa(stmt, Expr) && typ != stmt.typ))
-        catch
+            print_node(io, idx, stmt, used, argnames, maxsize, print_typ=false)
+        catch e
             print(io, "<error printing>")
         end
-        if print_ssa_typ
-            typ_str = try
-                string(typ)
-            catch
-                "<error_printing>"
-            end
-            Base.printstyled(io, "::$(typ_str)", color=:red)
+        if should_print_ssa_type(stmt) && idx in used
+            expr_type_printer(io, typ)
         end
-        Base.println(io)
+        println(io)
     end
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1274,22 +1274,11 @@ julia> typeof(f(1,2,3))
 Int64
 
 julia> @code_warntype f(1,2,3)
-Variables:
-  a<optimized out>
-  b::Int64
-  c<optimized out>
-
-Body:
-  begin
-      # meta: location operators.jl > 279
-      # meta: location int.jl < 49
-      Core.SSAValue(2) = (Base.slt_int)(1, b::Int64)::Bool
-      # meta: pop locations (2)
-      unless Core.SSAValue(2) goto 7
-      return 1
-      7:
-      return 1.0
-  end::UNION{FLOAT64, INT64}
+Body::UNION{FLOAT64, INT64}
+1 1 ─ %1 = Base.slt_int(1, %%b)::Bool
+  └──      goto 3 if not %1
+  2 ─      return 1
+  3 ─      return 1.0
 
 julia> @inferred f(1,2,3)
 ERROR: return type Int64 does not match inferred return type Union{Float64, Int64}

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -340,8 +340,6 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
         for var in must_used_vars
             @test occursin(string(var), str)
         end
-        @test !occursin("::Any", str)
-        @test !occursin("::ANY", str)
         # Check that we are not printing the bare slot numbers
         for i in 1:length(src.slotnames)
             name = src.slotnames[i]

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -280,7 +280,7 @@ let a = Any[]
     @test occursin("x + x", string(code_lowered(f23168, (Vector{Any},Int))))
     @test occursin("2 * x", string(Base.uncompressed_ast(first(methods(f23168)))))
     @test occursin("2 * x", string(code_lowered(f23168, (Vector{Any},Int), generated=false)))
-    @test occursin("(Base.add_int)(x, x)", string(code_typed(f23168, (Vector{Any},Int))))
+    @test occursin("Base.add_int", string(code_typed(f23168, (Vector{Any},Int))))
 end
 
 # issue #18747


### PR DESCRIPTION
This hooks up printing for the new IR and teaches it to print the
linetable. In printing a linetable, I tried to strike a balance
between verboseness (I think the old printing and our printing of LLVM IR
is significantly too verbose). There's a description of the idea in
show.jl.

Screenshot:
![screen shot 2018-05-19 at 5 38 38 pm](https://user-images.githubusercontent.com/1291671/40273721-067eead4-5b94-11e8-8a49-d8c60e27cc1b.png)

Fixes #27149