### PR TITLE
Use binary gcd for Int8, UInt8, Int16, UInt16, Int32 and UInt32.

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -27,7 +27,7 @@ end
 
 # binary GCD (aka Stein's) algorithm
 # about 1.7x (2.1x) faster for random Int64s (Int128s)
-function gcd(a::T, b::T) where T<:Union{Int64,UInt64,Int128,UInt128}
+function gcd(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128}
     @noinline throw1(a, b) = throw(OverflowError("gcd($a, $b) overflows"))
     a == 0 && return abs(b)
     b == 0 && return abs(a)


### PR DESCRIPTION
For now, binary GCD is restricted for (U)Int(64, 128) but I think there are no reasons not to use it for (U)Int(8, 16, 32).
Binary GCD is faster even for them.
```julia
function bgcd(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128}
    a == 0 && return abs(b)
    b == 0 && return abs(a)
    za = trailing_zeros(a)
    zb = trailing_zeros(b)
    k = min(za, zb)
    u = unsigned(abs(a >> za))
    v = unsigned(abs(b >> zb))
    while u != v
        if u > v
            u, v = v, u
        end
        v -= u
        v >>= trailing_zeros(v)
    end
    r = u << k
    # T(r) would throw InexactError; we want OverflowError instead
    r > typemax(T) && throw(OverflowError())
    r % T
end

using Distributions

function calc_gcd(xs, n)
    for i = 1:n
        gcd(xs[1, i], xs[2, i]) # Euclidean algorithm
    end
end

function calc_bgcd(xs, n)
    for i = 1:n
        bgcd(xs[1, i], xs[2, i]) # Binary GCD algorithm
    end
end

function calcInt8()
    const s = 100
    const n = 10000000
    xs = Array{Int8}(rand(DiscreteUniform(1, s), 2, n))
    @time calc_bgcd(xs, n)
    @time calc_gcd(xs, n)
    @time calc_bgcd(xs, n)
    @time calc_gcd(xs, n)
end

function calcInt16()
    const s = 10000
    const n = 10000000
    xs = Array{Int16}(rand(DiscreteUniform(1, s), 2, n))
    @time calc_bgcd(xs, n)
    @time calc_gcd(xs, n)
    @time calc_bgcd(xs, n)
    @time calc_gcd(xs, n)
end

function calcInt32()
    const s = 10000000
    const n = 10000000
    xs = Array{Int32}(rand(DiscreteUniform(1, s), 2, n))
    @time calc_bgcd(xs, n)
    @time calc_gcd(xs, n)
    @time calc_bgcd(xs, n)
    @time calc_gcd(xs, n)
end

calcInt8()
calcInt8()
calcInt16()
calcInt16()
calcInt32()
calcInt32()
```

Results
```julia
julia> calcInt8()
  0.340335 seconds
  0.431797 seconds
  0.337438 seconds
  0.427935 seconds

julia> calcInt8()
  0.333049 seconds
  0.428666 seconds
  0.336461 seconds
  0.428213 seconds

julia> calcInt16()
  0.426914 seconds
  0.883527 seconds
  0.426431 seconds
  0.886137 seconds

julia> calcInt16()
  0.424130 seconds
  0.887899 seconds
  0.426719 seconds
  0.902378 seconds

julia> calcInt32()
  0.598807 seconds
  1.225969 seconds
  0.604063 seconds
  1.214246 seconds

julia> calcInt32()
  0.596746 seconds
  1.213162 seconds
  0.599760 seconds
  1.216061 seconds
```