### PR TITLE
Add optimized implementations of reduce([hv]cat, A)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1188,6 +1188,9 @@ typed_hcat(::Type{T}, X::Number...) where {T} = hvcat_fill(Matrix{T}(undef, 1,le
 vcat(V::AbstractVector...) = typed_vcat(promote_eltype(V...), V...)
 vcat(V::AbstractVector{T}...) where {T} = typed_vcat(T, V...)
 
+# FIXME: this alias would better be Union{AbstractVector{T}, Tuple{Vararg{T}}}
+# and method signatures should do AbstractVecOrTuple{<:T} when they want covariance,
+# but that solution currently fails (see #27188 and #27224)
 AbstractVecOrTuple{T} = Union{AbstractVector{<:T}, Tuple{Vararg{T}}}
 
 function _typed_vcat(::Type{T}, V::AbstractVecOrTuple{AbstractVector}) where T

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1188,7 +1188,9 @@ typed_hcat(::Type{T}, X::Number...) where {T} = hvcat_fill(Matrix{T}(undef, 1,le
 vcat(V::AbstractVector...) = typed_vcat(promote_eltype(V...), V...)
 vcat(V::AbstractVector{T}...) where {T} = typed_vcat(T, V...)
 
-function typed_vcat(::Type{T}, V::AbstractVector...) where T
+AbstractVecOrTuple{T} = Union{AbstractVector{<:T}, Tuple{Vararg{T}}}
+
+function _typed_vcat(::Type{T}, V::AbstractVecOrTuple{AbstractVector}) where T
     n::Int = 0
     for Vk in V
         n += length(Vk)
@@ -1204,10 +1206,12 @@ function typed_vcat(::Type{T}, V::AbstractVector...) where T
     a
 end
 
+typed_hcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_hcat(T, A)
+
 hcat(A::AbstractVecOrMat...) = typed_hcat(promote_eltype(A...), A...)
 hcat(A::AbstractVecOrMat{T}...) where {T} = typed_hcat(T, A...)
 
-function typed_hcat(::Type{T}, A::AbstractVecOrMat...) where T
+function _typed_hcat(::Type{T}, A::AbstractVecOrTuple{AbstractVecOrMat}) where T
     nargs = length(A)
     nrows = size(A[1], 1)
     ncols = 0
@@ -1244,7 +1248,7 @@ end
 vcat(A::AbstractVecOrMat...) = typed_vcat(promote_eltype(A...), A...)
 vcat(A::AbstractVecOrMat{T}...) where {T} = typed_vcat(T, A...)
 
-function typed_vcat(::Type{T}, A::AbstractVecOrMat...) where T
+function _typed_vcat(::Type{T}, A::AbstractVecOrTuple{AbstractVecOrMat}) where T
     nargs = length(A)
     nrows = sum(a->size(a, 1), A)::Int
     ncols = size(A[1], 2)
@@ -1263,6 +1267,14 @@ function typed_vcat(::Type{T}, A::AbstractVecOrMat...) where T
     end
     return B
 end
+
+typed_vcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_vcat(T, A)
+
+reduce(::typeof(vcat), A::AbstractVector{<:AbstractVecOrMat}) =
+    _typed_vcat(mapreduce(eltype, promote_type, A), A)
+
+reduce(::typeof(hcat), A::AbstractVector{<:AbstractVecOrMat}) =
+    _typed_hcat(mapreduce(eltype, promote_type, A), A)
 
 ## cat: general case
 

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -559,6 +559,8 @@ similar(S::SharedArray) = similar(S.s, eltype(S), size(S))
 reduce(f, S::SharedArray) =
     mapreduce(fetch, f, Any[ @spawnat p reduce(f, S.loc_subarr_1d) for p in procs(S) ])
 
+reduce(::typeof(vcat), S::SharedVector) = invoke(reduce, Tuple{Any,SharedArray}, vcat, S)
+reduce(::typeof(hcat), S::SharedVector) = invoke(reduce, Tuple{Any,SharedArray}, hcat, S)
 
 function map!(f, S::SharedArray, Q::SharedArray)
     if (S !== Q) && (procs(S) != procs(Q) || localindices(S) != localindices(Q))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -398,3 +398,20 @@ test18695(r) = sum( t^2 for t in r )
 @test prod(Char[]) == ""
 @test prod(Char['a']) == "a"
 @test prod(Char['a','b']) == "ab"
+
+@testset "optimized reduce(vcat/hcat, A) for arrays" begin
+    for args in ([1:2], [[1, 2]], [1:2, 3:4], [[3, 4, 5], 1:2], [1:2, [3.5, 4.5]],
+                 [[1 2], [3 4; 5 6]], [reshape([1, 2], 2, 1), 3:4])
+        X = reduce(vcat, args)
+        Y = vcat(args...)
+        @test X == Y
+        @test typeof(X) === typeof(Y)
+    end
+    for args in ([1:2], [[1, 2]], [1:2, 3:4], [[3, 4, 5], 1:3], [1:2, [3.5, 4.5]],
+                 [[1 2; 3 4], [5 6; 7 8]], [1:2, [5 6; 7 8]], [[5 6; 7 8], [1, 2]])
+        X = reduce(hcat, args)
+        Y = hcat(args...)
+        @test X == Y
+        @test typeof(X) === typeof(Y)
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/21672.

This implements the minimal fix for `AbstractVector{<:Union{AbstractVector,AbstractMatrix}}`. It doesn't cover the case of `Vector{Any}` list of vectors or matrices, which could be useful to support given that it is not uncommon to store expensive objects like arrays in `Vector{Any}` lists. For example, it appears that JSON.jl returns such objects. This could be done by passing `mapreduce(typeof, typejoin, A)` to an internal function which can then dispatch on the argument type, with a fallback on the normal `reduce` method. But it's more complex and can introduce ambiguities.