### PR TITLE
Restore cfunction special case in inlining

### DIFF
--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -1054,6 +1054,13 @@ function ssa_substitute_op!(@nospecialize(val), arg_replacements::Vector{Any},
         head = e.head
         if head === :static_parameter
             return quoted(spvals[e.args[1]])
+        elseif head === :cfunction
+            @assert !isa(spsig, UnionAll) || !isempty(spvals)
+            e.args[3] = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), e.args[3], spsig, spvals)
+            e.args[4] = svec(Any[
+                ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), argt, spsig, spvals)
+                for argt
+                in e.args[4] ]...)
         elseif head === :foreigncall
             @assert !isa(spsig, UnionAll) || !isempty(spvals)
             for i = 1:length(e.args)

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1436,7 +1436,7 @@ end
 
 # issue #27178 (cfunction special case in inlining)
 mutable struct CallThisFunc27178{FCN_TYPE}
-  fcn::FCN_TYPE
+    fcn::FCN_TYPE
 end
 
 callback27178(cb::CTF) where CTF<:CallThisFunc27178 = nothing

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1433,3 +1433,13 @@ function callthis_26607(args)
 end
 @test callthis_26607(Int64(0)) === nothing
 @test callthis_26607(Int32(0)) === nothing
+
+# issue #27178 (cfunction special case in inlining)
+mutable struct CallThisFunc27178{FCN_TYPE}
+  fcn::FCN_TYPE
+end
+
+callback27178(cb::CTF) where CTF<:CallThisFunc27178 = nothing
+@inline make_cfunc27178(cbi::CI) where CI = @cfunction(callback27178, Cvoid, (Ref{CI},))
+get_c_func(fcn::FCN_TYPE) where {FCN_TYPE<:Function} = return make_cfunc27178(CallThisFunc27178(fcn))
+@test isa(get_c_func(sin), Ptr)


### PR DESCRIPTION
As far as I'm concerned this entire mechanism (storing raw DataTypes in the AST)
is a hack and we should come up with something better at some point, but until
then, but back the hack and add a test for the feature. Fixes #27178.