### PR TITLE
Fix inferability of skipmissing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -176,10 +176,15 @@ end
 IteratorSize(::Type{<:SkipMissing}) = SizeUnknown()
 IteratorEltype(::Type{SkipMissing{T}}) where {T} = IteratorEltype(T)
 eltype(::Type{SkipMissing{T}}) where {T} = nonmissingtype(eltype(T))
+
 function Base.iterate(itr::SkipMissing, state...)
     y = iterate(itr.x, state...)
-    while y !== nothing && y[1] isa Missing
-        y = iterate(itr.x, y[2])
+    y === nothing && return nothing
+    item, state = y
+    while item === missing
+        y = iterate(itr.x, state)
+        y === nothing && return nothing
+        item, state = y
     end
-    y
+    item, state
 end


### PR DESCRIPTION
The current implementation of this function was not inferable.
Simplify the implementation such that the compiler can figure out
that its element type is never `missing`. Fixes #27196.