### PR TITLE
In union splitting also check type of first argument

### DIFF
--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -361,7 +361,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, topmod::Module, idx:
         @assert !isa(metharg, UnionAll)
         cond = true
         @assert length(atype.parameters) == length(metharg.parameters)
-        for i in 2:length(atype.parameters)
+        for i in 1:length(atype.parameters)
             a, m = atype.parameters[i], metharg.parameters[i]
             # If this is always true, we don't need to check for it
             a <: m && continue
@@ -382,7 +382,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, topmod::Module, idx:
         argexprs′ = argexprs
         if !isa(case, ConstantCase)
             argexprs′ = copy(argexprs)
-            for i = 2:length(metharg.parameters)
+            for i = 1:length(metharg.parameters)
                 a, m = atype.parameters[i], metharg.parameters[i]
                 isa(argexprs[i], SSAValue) || continue
                 if !(a <: m)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6117,3 +6117,13 @@ function f27181()
     invoke(A27181(C27181).typ, Tuple{Any}, nothing)
 end
 @test f27181() == C27181(nothing)
+
+# Issue #27204
+struct Foo27204{T}
+end
+(::Foo27204{Int})() = 1
+(::Foo27204{Float64})() = 2
+@noinline f27204(x) = x ? Foo27204{Int}() : Foo27204{Float64}()
+foo27204(x) = f27204(x)()
+@test foo27204(true) == 1
+@test foo27204(false) == 2


### PR DESCRIPTION
I had mistakenly assumed that when we got to unionsplitting the first
type could not be one of the union types we were splitting on. However,
this assumption is incorrect for parameterized types (e.g.
Union{Type{Float64}, Type{BigFloat}} as in #27204). The fix is relatively
simple and consists of also checking the function argument during union
splitting.

Fixes #27204.