### PR TITLE
Allow $(HOSTCC) to be set through environment variables

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -263,7 +263,7 @@ CROSS_COMPILE:=
 # delayed expansion of $(CC), since it won't be computed until later
 HOSTCC = $(CC)
 else
-HOSTCC := gcc
+HOSTCC ?= gcc
 OPENBLAS_DYNAMIC_ARCH := 1
 override CROSS_COMPILE:=$(XC_HOST)-
 ifneq (,$(findstring mingw,$(XC_HOST)))


### PR DESCRIPTION
In general, we should set hardcoded Makefile variables with `?=` so that the environment can override them without having to do silly things like `make HOSTCC=$HOSTCC`.