### PR TITLE
Improve reinterpret

### DIFF
--- a/base/atomics.jl
+++ b/base/atomics.jl
@@ -337,7 +337,7 @@ inttype(::Type{Float32}) = Int32
 inttype(::Type{Float64}) = Int64
 
 
-alignment(::Type{T}) where {T} = ccall(:jl_alignment, Cint, (Csize_t,), sizeof(T))
+gc_alignment(::Type{T}) where {T} = ccall(:jl_alignment, Cint, (Csize_t,), sizeof(T))
 
 # All atomic operations have acquire and/or release semantics, depending on
 # whether the load or store values. Most of the time, this is what one wants
@@ -350,13 +350,13 @@ for typ in atomictypes
     @eval getindex(x::Atomic{$typ}) =
         llvmcall($"""
                  %ptr = inttoptr i$WORD_SIZE %0 to $lt*
-                 %rv = load atomic $rt %ptr acquire, align $(alignment(typ))
+                 %rv = load atomic $rt %ptr acquire, align $(gc_alignment(typ))
                  ret $lt %rv
                  """, $typ, Tuple{Ptr{$typ}}, unsafe_convert(Ptr{$typ}, x))
     @eval setindex!(x::Atomic{$typ}, v::$typ) =
         llvmcall($"""
                  %ptr = inttoptr i$WORD_SIZE %0 to $lt*
-                 store atomic $lt %1, $lt* %ptr release, align $(alignment(typ))
+                 store atomic $lt %1, $lt* %ptr release, align $(gc_alignment(typ))
                  ret void
                  """, Cvoid, Tuple{Ptr{$typ}, $typ}, unsafe_convert(Ptr{$typ}, x), v)
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -812,6 +812,8 @@ end
 function is_pure_intrinsic_infer(f::IntrinsicFunction)
     return !(f === Intrinsics.pointerref || # this one is volatile
              f === Intrinsics.pointerset || # this one is never effect-free
+             f === Intrinsics.tbaa_pointerref || # same as pointerref
+             f === Intrinsics.tbaa_pointerset || # same as pointerset
              f === Intrinsics.llvmcall ||   # this one is never effect-free
              f === Intrinsics.arraylen ||   # this one is volatile
              f === Intrinsics.sqrt_llvm ||  # this one may differ at runtime (by a few ulps)
@@ -822,6 +824,8 @@ end
 function is_pure_intrinsic_optim(f::IntrinsicFunction)
     return !(f === Intrinsics.pointerref || # this one is volatile
              f === Intrinsics.pointerset || # this one is never effect-free
+             f === Intrinsics.tbaa_pointerref || # same as pointerref
+             f === Intrinsics.tbaa_pointerset || # same as pointerset
              f === Intrinsics.llvmcall ||   # this one is never effect-free
              f === Intrinsics.arraylen ||   # this one is volatile
              f === Intrinsics.checked_sdiv_int ||  # these may throw errors

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1031,6 +1031,9 @@ mutable struct Stateful{T, VS}
     # A bit awkward right now, but adapted to the new iteration protocol
     nextvalstate::Union{VS, Nothing}
     taken::Int
+    @inline function Stateful{<:Any, Any}(itr::T) where {T}
+        new{T, Any}(itr, iterate(itr), 0)
+    end
     @inline function Stateful(itr::T) where {T}
         VS = approx_iter_type(T)
         new{T, VS}(itr, iterate(itr)::VS, 0)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -7,6 +7,8 @@ the first dimension.
 """
 struct ReinterpretArray{T,N,S,A<:AbstractArray{S, N}} <: AbstractArray{T, N}
     parent::A
+    readable::Bool
+    writable::Bool
     global reinterpret
     function reinterpret(::Type{T}, a::A) where {T,N,S,A<:AbstractArray{S, N}}
         function throwbits(::Type{S}, ::Type{T}, ::Type{U}) where {S,T,U}
@@ -31,9 +33,31 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S, N}} <: AbstractArray{T, N}
             dim = size(a)[1]
             rem(dim*sizeof(S),sizeof(T)) == 0 || thrownonint(S, T, dim)
         end
-        new{T, N, S, A}(a)
+        readable = array_subpadding(T, S)
+        writable = array_subpadding(S, T)
+        new{T, N, S, A}(a, readable, writable)
     end
 end
+
+function check_readable(a::ReinterpretArray{T, N, S} where N) where {T,S}
+    # See comment in check_writable
+    if !a.readable && !array_subpadding(T, S)
+        throw(PaddingError(T, S))
+    end
+end
+
+function check_writable(a::ReinterpretArray{T, N, S} where N) where {T,S}
+    # `array_subpadding` is relatively expensive (compared to a simple arrayref),
+    # so it is cached in the array. However, it is computable at compile time if,
+    # inference has the types available. By using this form of the check, we can
+    # get the best of both worlds for the success case. If the types were not
+    # available to inference, we simply need to check the field (relatively cheap)
+    # and if they were we should be able to fold this check away entirely.
+    if !a.writable && !array_subpadding(S, T)
+        throw(PaddingError(T, S))
+    end
+end
+
 
 parent(a::ReinterpretArray) = a.parent
 dataids(a::ReinterpretArray) = dataids(a.parent)
@@ -51,6 +75,7 @@ unsafe_convert(::Type{Ptr{T}}, a::ReinterpretArray{T,N,S} where N) where {T,S} =
 @inline @propagate_inbounds getindex(a::ReinterpretArray) = a[1]
 
 @inline @propagate_inbounds function getindex(a::ReinterpretArray{T,N,S}, inds::Vararg{Int, N}) where {T,N,S}
+    check_readable(a)
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
         return reinterpret(T, a.parent[inds...])
@@ -85,6 +110,7 @@ end
 @inline @propagate_inbounds setindex!(a::ReinterpretArray, v) = (a[1] = v)
 
 @inline @propagate_inbounds function setindex!(a::ReinterpretArray{T,N,S}, v, inds::Vararg{Int, N}) where {T,N,S}
+    check_writable(a)
     v = convert(T, v)::T
     # Make sure to match the scalar reinterpret if that is applicable
     if sizeof(T) == sizeof(S) && (fieldcount(T) + fieldcount(S)) == 0
@@ -135,4 +161,98 @@ end
         end
     end
     return a
+end
+
+# Padding
+struct Padding
+    offset::Int
+    size::Int
+end
+function intersect(p1::Padding, p2::Padding)
+    start = max(p1.offset, p2.offset)
+    stop = min(p1.offset + p1.size, p2.offset + p2.size)
+    Padding(start, max(0, stop-start))
+end
+
+struct PaddingError
+    S::Type
+    T::Type
+end
+
+function showerror(io::IO, p::PaddingError)
+    print(io, "Padding of type $(p.S) is not compatible with type $(p.T).")
+end
+
+"""
+    CyclePadding(padding, total_size)
+
+Cylces an iterator of `Padding` structs, restarting the padding at `total_size`.
+E.g. if `padding` is all the padding in a struct and `total_size` is the total
+aligned size of that array, `CyclePadding` will correspond to the padding in an
+infinite vector of such structs.
+"""
+struct CyclePadding{P}
+    padding::P
+    total_size::Int
+end
+eltype(::Type{<:CyclePadding}) = Padding
+IteratorSize(::Type{<:CyclePadding}) = IsInfinite()
+isempty(cp::CyclePadding) = isempty(cp.padding)
+function iterate(cp::CyclePadding)
+    y = iterate(cp.padding)
+    y === nothing && return nothing
+    y[1], (0, y[2])
+end
+function iterate(cp::CyclePadding, state::Tuple)
+    y = iterate(cp.padding, tail(state)...)
+    y === nothing && return iterate(cp, (state[1]+cp.total_size,))
+    Padding(y[1].offset+state[1], y[1].size), (state[1], tail(y)...)
+end
+
+"""
+    Compute the location of padding in a type.
+"""
+function padding(T)
+    padding = Padding[]
+    last_end::Int = 0
+    for i = 1:fieldcount(T)
+        offset = fieldoffset(T, i)
+        fT = fieldtype(T, i)
+        if offset != last_end
+            push!(padding, Padding(offset, offset-last_end))
+        end
+        last_end = offset + sizeof(fT)
+    end
+    padding
+end
+
+function CyclePadding(T::DataType)
+    a, s = datatype_alignment(T), sizeof(T)
+    as = s + (a - (s % a)) % a
+    pad = padding(T)
+    s != as && push!(pad, Padding(s, as - s))
+    CyclePadding(pad, as)
+end
+
+using .Iterators: Stateful
+@pure function array_subpadding(S, T)
+    checked_size = 0
+    lcm_size = lcm(sizeof(S), sizeof(T))
+    s, t = Stateful{<:Any, Any}(CyclePadding(S)),
+           Stateful{<:Any, Any}(CyclePadding(T))
+    isempty(t) && return true
+    isempty(s) && return false
+    while checked_size < lcm_size
+        # Take padding in T
+        pad = popfirst!(t)
+        # See if there's corresponding padding in S
+        while true
+            ps = peek(s)
+            ps.offset > pad.offset && return false
+            intersect(ps, pad) == pad && break
+            popfirst!(s)
+        end
+        checked_size = pad.offset + pad.size
+    end
+    return true
 end

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -137,8 +137,6 @@ include("array.jl")
 include("abstractarray.jl")
 include("subarray.jl")
 include("views.jl")
-include("reinterpretarray.jl")
-
 
 # ## dims-type-converting Array constructors for convenience
 # type and dimensionality specified, accepting dims as series of Integers
@@ -205,6 +203,7 @@ include("reduce.jl")
 
 ## core structures
 include("reshapedarray.jl")
+include("reinterpretarray.jl")
 include("bitarray.jl")
 include("bitset.jl")
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -193,7 +193,7 @@ $(BUILDDIR)/debuginfo.o $(BUILDDIR)/debuginfo.dbg.obj: \
 	$(addprefix $(SRCDIR)/,debuginfo.h processor.h)
 $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)/processor.h
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h
-$(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
+$(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c $(SRCDIR)/intrinsics.h
 $(BUILDDIR)/staticdata.o $(BUILDDIR)/staticdata.dbg.obj: $(SRCDIR)/processor.h
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h

--- a/src/intrinsics.h
+++ b/src/intrinsics.h
@@ -91,6 +91,8 @@
     /*  pointer access */ \
     ADD_I(pointerref, 3) \
     ADD_I(pointerset, 4) \
+    ADD_I(tbaa_pointerref, 4) \
+    ADD_I(tbaa_pointerset, 5) \
     /* c interface */ \
     ADD_I(cglobal, 2) \
     ALIAS(llvmcall, llvmcall) \

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -700,6 +700,8 @@ unsigned jl_intrinsic_nargs(int f);
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);
 JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
+JL_DLLEXPORT jl_value_t *jl_tbaa_pointerref(jl_value_t *t, jl_value_t *p, jl_value_t *i, jl_value_t *align);
+JL_DLLEXPORT jl_value_t *jl_tbaa_pointerset(jl_value_t *t, jl_value_t *p, jl_value_t *x, jl_value_t *align, jl_value_t *i);
 JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty);
 JL_DLLEXPORT jl_value_t *jl_cglobal_auto(jl_value_t *v);
 

--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -75,6 +75,33 @@ JL_DLLEXPORT jl_value_t *jl_pointerset(jl_value_t *p, jl_value_t *x, jl_value_t 
     return p;
 }
 
+static void check_tbaa_type(jl_value_t *t)
+{
+    // For now, we only allow array types with concrete element types
+    if (!jl_is_array_type(t))
+        jl_error("tbaa_pointer(set/ref): Type argument must be an array type");
+
+    jl_value_t *array_eltype = jl_tparam0(t);
+    if ((!jl_isbits(array_eltype) && !jl_is_structtype(array_eltype)) ||
+         jl_is_array_type(array_eltype) || !jl_is_concrete_type(array_eltype))
+        jl_error("tbaa_pointer(set/ref): TBAA array element type must be isbits or a structtype"
+                 ", not an array and concrete");
+}
+
+JL_DLLEXPORT jl_value_t *jl_tbaa_pointerref(jl_value_t *t, jl_value_t *p, jl_value_t *i, jl_value_t *align)
+{
+    JL_TYPECHK(tbaa_pointerref, type, t);
+    check_tbaa_type(t);
+    return jl_pointerref(p, i, align);
+}
+
+JL_DLLEXPORT jl_value_t *jl_tbaa_pointerset(jl_value_t *t, jl_value_t *p, jl_value_t *x, jl_value_t *i, jl_value_t *align)
+{
+    JL_TYPECHK(tbaa_pointerset, type, t);
+    check_tbaa_type(t);
+    return jl_pointerset(x, p, i, align);
+}
+
 JL_DLLEXPORT jl_value_t *jl_cglobal(jl_value_t *v, jl_value_t *ty)
 {
     JL_TYPECHK(cglobal, type, ty);

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -11,7 +11,8 @@ B = Complex{Int64}[5+6im, 7+8im, 9+10im]
 @test reinterpret(NTuple{3, Int64}, B) == [(5,6,7),(8,9,10)]
 
 # setindex
-let Ac = copy(A), Bc = copy(B)
+for (Ac, Bc) in zip((copy(A), GenericArray(copy(A))),
+                    (copy(B), GenericArray(copy(B))))
     reinterpret(Complex{Int64}, Ac)[2] = -1 - 2im
     @test Ac == [1, 2, -1, -2]
     reinterpret(NTuple{3, Int64}, Bc)[2] = (4,5,6)
@@ -26,7 +27,8 @@ let Ac = copy(A), Bc = copy(B)
 end
 
 # same-size reinterpret where one of the types is non-primitive
-let a = NTuple{4,UInt8}[(0x01,0x02,0x03,0x04)]
+for a = (NTuple{4,UInt8}[(0x01,0x02,0x03,0x04)],
+         GenericArray(NTuple{4,UInt8}[(0x01,0x02,0x03,0x04)]))
     @test reinterpret(Float32, a)[1] == reinterpret(Float32, 0x04030201)
     reinterpret(Float32, a)[1] = 2.0
     @test reinterpret(Float32, a)[1] == 2.0

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -49,3 +49,22 @@ let A = collect(reshape(1:20, 5, 4))
     @test view(R, :, :) isa StridedArray
     @test reshape(R, :) isa StridedArray
 end
+
+# Error on reinterprets that would expose padding
+struct S1
+    a::Int8
+    b::Int64
+end
+
+struct S2
+    a::Int16
+    b::Int64
+end
+
+A1 = S1[S1(0, 0)]
+A2 = S2[S2(0, 0)]
+@test reinterpret(S1, A2)[1] == S1(0, 0)
+@test_throws Base.PaddingError (reinterpret(S1, A2)[1] = S2(1, 2))
+@test_throws Base.PaddingError reinterpret(S2, A1)[1]
+reinterpret(S2, A1)[1] = S2(1, 2)
+@test A1[1] == S1(1, 2)


### PR DESCRIPTION
This fixes two issues with reinterpret. As always, the commit messages have details.

The first commit fixes #25908, by making the problematic reinterprets an error. We can choose more lax semantics at a later point, but this seems like the right behavior for 1.0.
The second fixes #25014 by adding a special case for `reinterpret(T, ::Array)`. We should also investigate why LLVM stopped being able to optimize this, but that's for another time.