### PR TITLE
Fixing bug in qsort example in docs

### DIFF
--- a/doc/src/manual/calling-c-and-fortran-code.md
+++ b/doc/src/manual/calling-c-and-fortran-code.md
@@ -934,7 +934,7 @@ function qsort(a::Vector{T}, cmp) where T
     # Here, `callback` isa Base.CFunction, which will be converted to Ptr{Cvoid}
     # (and protected against finalization) by the ccall
     ccall(:qsort, Cvoid, (Ptr{T}, Csize_t, Csize_t, Ptr{Cvoid}),
-        a, length(A), Base.elsize(A), callback)
+        a, length(a), Base.elsize(a), callback)
     # We could instead use:
     #    GC.@preserve callback begin
     #        use(Base.unsafe_convert(Ptr{Cvoid}, callback))


### PR DESCRIPTION
qsort example in `calling-c-and-fortran-code.md` has a bug. `A` is used in the code but the function arguments are `a`.