### PR TITLE
RFC: Support state from old iteration protocol in Iterators.Rest

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -495,6 +495,8 @@ end
 
 @propagate_inbounds iterate(i::Rest, st=i.st) = iterate(i.itr, st)
 isdone(i::Rest, st...) = isdone(i.itr, st...)
+@propagate_inbounds iterate(i::Rest{I,S}, st::S=i.st) where {I,S<:Base.LegacyIterationCompat{I}} =
+    done(i.itr, st) ? nothing : next(i.itr, st)
 
 eltype(::Type{<:Rest{I}}) where {I} = eltype(I)
 IteratorEltype(::Type{<:Rest{I}}) where {I} = IteratorEltype(I)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -70,6 +70,8 @@ let s = "hello"
     @test c == ['e','l','l','o']
     @test c isa Vector{Char}
 end
+# rest with state from old iteration protocol
+@test collect(rest(1:6, start(1:6))) == collect(1:6)
 
 @test_throws MethodError collect(rest(countfrom(1), 5))
 


### PR DESCRIPTION
The new iteration protocol breaks code still using the old one and then passing the state to `rest`, e.g. something like
```julia
itr = 1:6
st = start(itr)
while !done(itr, st )
    global st
    v, st = next(itr, st)
    if v > 2 # imagine a meaningful check here
        break
    end
end
collect(Iterators.rest(itr, st))
```
gives
```
ERROR: MethodError: no method matching +(::Base.LegacyIterationCompat{UnitRange{Int64},Int64,Int64}, ::Int64)
```
This is a simple fix for that.

I would have liked to implement a special `rest(::I, ::S) where {I,S<:Base.LegacyIterationCompat{I}}` instead of a custom `iterate`, but I couldn't figure out how that could work.