### PR TITLE
Documenter updates for 0.6.3

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -901,8 +901,8 @@ julia> deleteat!([6, 5, 4, 3, 2, 1], [true, false, true, false, true, false])
 julia> deleteat!([6, 5, 4, 3, 2, 1], (2, 2))
 ERROR: ArgumentError: indices must be unique and sorted
 Stacktrace:
- [1] _deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:926
- [2] deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:913
+ [1] _deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:921
+ [2] deleteat!(::Array{Int64,1}, ::Tuple{Int64,Int64}) at ./array.jl:908
 ```
 """
 deleteat!(a::Vector, inds) = _deleteat!(a, inds)

--- a/doc/REQUIRE
+++ b/doc/REQUIRE
@@ -1,3 +1,3 @@
-Compat 0.25.2 0.25.2+
-DocStringExtensions 0.3.3 0.3.3+
-Documenter 0.11.1 0.11.1+
+Compat 0.62.1 0.62.1+
+DocStringExtensions 0.4.4 0.4.4+
+Documenter 0.18.0 0.18.0+

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -116,9 +116,9 @@ const PAGES = [
 ]
 
 makedocs(
-    build     = joinpath(pwd(), "_build/html/en"),
+    build     = joinpath(@__DIR__, "_build/html/en"),
     modules   = [Base, Core, BuildSysImg],
-    clean     = false,
+    clean     = true,
     doctest   = "doctest" in ARGS,
     linkcheck = "linkcheck" in ARGS,
     linkcheck_ignore = ["https://bugs.kde.org/show_bug.cgi?id=136779"], # fails to load from nanosoldier?
@@ -130,6 +130,8 @@ makedocs(
     analytics = "UA-28835595-6",
     pages     = PAGES,
     html_prettyurls = ("deploy" in ARGS),
+    html_canonical = ("deploy" in ARGS) ? "https://docs.julialang.org/en/stable/" : nothing,
+    assets = ["assets/julia-manual.css"],
 )
 
 if "deploy" in ARGS

--- a/doc/src/assets/julia-manual.css
+++ b/doc/src/assets/julia-manual.css
@@ -1,0 +1,3 @@
+nav.toc h1 {
+    display: none;
+}


### PR DESCRIPTION
@ararslan: Following up on https://github.com/JuliaLang/julia/pull/26915#issuecomment-391152102 Backports a few of the changes that I think are relevant.
 
* Bump Documenter and deps.
* Canonical URLs and build cleanup. (#25623)
* Hide "The Julia Language" in navbar. (#27146)
* Fix a doctest in `base/array.jl`

Maybe @fredrikekre has some thoughts on this as well.