### PR TITLE
New way to fetch and set RefValues field.

### DIFF
--- a/base/refvalue.jl
+++ b/base/refvalue.jl
@@ -29,3 +29,6 @@ unsafe_convert(::Type{Ptr{Cvoid}}, b::RefValue{T}) where {T} = convert(Ptr{Cvoid
 
 getindex(b::RefValue) = b.x
 setindex!(b::RefValue, x) = (b.x = x; b)
+
+(b::RefValue)() = b.x
+(b::RefValue)(x) = (b.x = x; b)


### PR DESCRIPTION
This PR adds a new way to fetch and set RefValues fields:

```julia
julia> a = Ref(1)
Base.RefValue{Int64}(1)

# current way of fetching data
julia> a[]
1

# current way of setting data
julia> a[] = 2
2

# my proposal for fetching data
julia> a()
2

# proposal for setting data
julia> a(3)
3
```

IMO this makes it more convenient to work with RefValues, specially for setting the field. I only added the new way to fetch data to be consistent with the new way to set it.