### PR TITLE
Use predicate function in `lstrip` etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -688,6 +688,8 @@ Library improvements
   * `Sys.which()` provides a cross-platform method to find executable files, similar to
     the Unix `which` command. ([#26559])
 
+  * `lstrip`, `rstrip` and `strip` now correctly handle unicode whitespace ([#27211]), and accept a predicate function to determine which characters should be removed ([#27232])
+
 Compiler/Runtime improvements
 -----------------------------
 
@@ -1560,3 +1562,5 @@ Command-line option changes
 [#26670]: https://github.com/JuliaLang/julia/issues/26670
 [#26775]: https://github.com/JuliaLang/julia/issues/26775
 [#26932]: https://github.com/JuliaLang/julia/issues/26932
+[#27211]: https://github.com/JuliaLang/julia/issues/27211
+[#27232]: https://github.com/JuliaLang/julia/issues/27232

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1679,6 +1679,10 @@ end
 
 @eval @deprecate $(Symbol("@schedule")) $(Symbol("@async"))
 
+@deprecate lstrip(str::AbstractString, chars::Chars) lstrip(in(chars), str)
+@deprecate rstrip(str::AbstractString, chars::Chars) rstrip(in(chars), str)
+@deprecate strip(str::AbstractString, chars::Chars) strip(in(chars), str)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -932,7 +932,7 @@ function _prettify_bigfloat(s::String)::String
     if !occursin('.', mantissa)
         mantissa = string(mantissa, '.')
     end
-    mantissa = rstrip(mantissa, '0')
+    mantissa = rstrip(isequal('0'), mantissa)
     if endswith(mantissa, '.')
         mantissa = string(mantissa, '0')
     end

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -116,13 +116,20 @@ end
 const _default_delims = [' ','\t','\n','\v','\f','\r']
 
 """
-    lstrip(s::AbstractString[, chars::Chars])
+    lstrip(s::AbstractString)
+    lstrip(f, s::AbstractString)
+    lstrip(s::AbstractString, chars::Chars)
 
-Return `s` with any leading whitespace and delimiters removed.
-The default delimiters to remove are `' '`, `\\t`, `\\n`, `\\v`,
-`\\f`, and `\\r`.
-If `chars` (a character, or vector or set of characters) is provided,
-instead remove characters contained in it.
+Remove leading characters from `s`.
+
+The default behaviour is to remove leading whitespace and delimiters: any characters for
+which [`isspace`](@ref) is `true`.
+
+If a predicate `f` is provided, then remove any leading characters `c` such that `f(c)` is
+`true`.
+
+If `chars` (a character, or vector or set of characters) is provided, instead remove
+leading characters contained in `chars`.
 
 # Examples
 ```jldoctest
@@ -133,22 +140,32 @@ julia> lstrip(a)
 "March"
 ```
 """
-function lstrip(s::AbstractString, chars::Chars=_default_delims)
+function lstrip(f, s::AbstractString)
     e = lastindex(s)
     for (i, c) in pairs(s)
-        !(c in chars) && return SubString(s, i, e)
+        !f(c) && return SubString(s, i, e)
     end
     SubString(s, e+1, e)
 end
+lstrip(s::AbstractString) = lstrip(isspace, f)
+lstrip(s::AbstractString, chars::Chars) = lstrip(c -> c in chars, s)
+
 
 """
-    rstrip(s::AbstractString[, chars::Chars])
+    rstrip(s::AbstractString)
+    rstrip(f, s::AbstractString)
+    rstrip(s::AbstractString, chars::Chars)
 
-Return `s` with any trailing whitespace and delimiters removed.
-The default delimiters to remove are `' '`, `\\t`, `\\n`, `\\v`,
-`\\f`, and `\\r`.
-If `chars` (a character, or vector or set of characters) is provided,
-instead remove characters contained in it.
+Remove trailing characters from `s`.
+
+The default behaviour is to remove trailing whitespace and delimiters: any characters for
+which [`isspace`](@ref) is `true`.
+
+If a predicate `f` is provided, then remove any trailing characters `c` such that `f(c)`
+is `true`.
+
+If `chars` (a character, or vector or set of characters) is provided, instead remove
+trailing characters contained in `chars`.
 
 # Examples
 ```jldoctest
@@ -159,28 +176,44 @@ julia> rstrip(a)
 "March"
 ```
 """
-function rstrip(s::AbstractString, chars::Chars=_default_delims)
+function rstrip(f, s::AbstractString)
     for (i, c) in Iterators.reverse(pairs(s))
-        c in chars || return SubString(s, 1, i)
+        f(c) || return SubString(s, 1, i)
     end
     SubString(s, 1, 0)
 end
+rstrip(s::AbstractString) = rstrip(isspace, f)
+rstrip(s::AbstractString, chars::Chars) = rstrip(c -> c in chars, s)
 
 """
-    strip(s::AbstractString, [chars::Chars])
+    strip(s::AbstractString)
+    strip(f, s::AbstractString)
+    strip(s::AbstractString, chars::Chars)
 
-Return `s` with any leading and trailing whitespace removed.
-If `chars` (a character, or vector or set of characters) is provided,
-instead remove characters contained in it.
+Remove leading and trailing characters from `s`.
+
+The default behaviour is to remove leading or trailing whitespace and delimiters: any
+characters for which [`isspace`](@ref) is `true`.
+
+If a predicate `f` is provided, then remove any leading or trailing characters `c` such
+that `f(c)` is `true`.
+
+If `chars` (a character, or vector or set of characters) is provided, instead remove
+leading or trailing characters contained in `chars`.
 
 # Examples
 ```jldoctest
 julia> strip("{3, 5}\\n", ['{', '}', '\\n'])
 "3, 5"
 ```
+
+# See also
+- [`lstrip`](@ref)
+- [`rstrip`](@ref)
 """
-strip(s::AbstractString) = lstrip(rstrip(s))
-strip(s::AbstractString, chars::Chars) = lstrip(rstrip(s, chars), chars)
+strip(f, s::AbstractString) = lstrip(f, rstrip(f, s))
+strip(s::AbstractString) = strip(isspace, f)
+strip(s::AbstractString, chars::Chars) = strip(c -> c in chars, s)
 
 ## string padding functions ##
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -148,7 +148,7 @@ function lstrip(f, s::AbstractString)
     SubString(s, e+1, e)
 end
 lstrip(s::AbstractString) = lstrip(isspace, f)
-lstrip(s::AbstractString, chars::Chars) = lstrip(c -> c in chars, s)
+lstrip(s::AbstractString, chars::Chars) = lstrip(in(chars), s)
 
 
 """
@@ -183,7 +183,7 @@ function rstrip(f, s::AbstractString)
     SubString(s, 1, 0)
 end
 rstrip(s::AbstractString) = rstrip(isspace, f)
-rstrip(s::AbstractString, chars::Chars) = rstrip(c -> c in chars, s)
+rstrip(s::AbstractString, chars::Chars) = rstrip(in(chars), s)
 
 """
     strip(s::AbstractString)
@@ -213,7 +213,7 @@ julia> strip("{3, 5}\\n", ['{', '}', '\\n'])
 """
 strip(f, s::AbstractString) = lstrip(f, rstrip(f, s))
 strip(s::AbstractString) = strip(isspace, f)
-strip(s::AbstractString, chars::Chars) = strip(c -> c in chars, s)
+strip(s::AbstractString, chars::Chars) = strip(in(chars), s)
 
 ## string padding functions ##
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -147,7 +147,7 @@ function lstrip(f, s::AbstractString)
     end
     SubString(s, e+1, e)
 end
-lstrip(s::AbstractString) = lstrip(isspace, f)
+lstrip(s::AbstractString) = lstrip(isspace, s)
 lstrip(s::AbstractString, chars::Chars) = lstrip(in(chars), s)
 
 
@@ -182,7 +182,7 @@ function rstrip(f, s::AbstractString)
     end
     SubString(s, 1, 0)
 end
-rstrip(s::AbstractString) = rstrip(isspace, f)
+rstrip(s::AbstractString) = rstrip(isspace, s)
 rstrip(s::AbstractString, chars::Chars) = rstrip(in(chars), s)
 
 """
@@ -212,7 +212,7 @@ julia> strip("{3, 5}\\n", ['{', '}', '\\n'])
 - [`rstrip`](@ref)
 """
 strip(f, s::AbstractString) = lstrip(f, rstrip(f, s))
-strip(s::AbstractString) = strip(isspace, f)
+strip(s::AbstractString) = strip(isspace, s)
 strip(s::AbstractString, chars::Chars) = strip(in(chars), s)
 
 ## string padding functions ##

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -116,20 +116,12 @@ end
 const _default_delims = [' ','\t','\n','\v','\f','\r']
 
 """
-    lstrip(s::AbstractString)
-    lstrip(f, s::AbstractString)
-    lstrip(s::AbstractString, chars::Chars)
+    lstrip(f, str::AbstractString)
+    lstrip(str::AbstractString)
 
-Remove leading characters from `s`.
+Remove any leading characters from `str` for which the predicate `f` is true.
 
-The default behaviour is to remove leading whitespace and delimiters: any characters for
-which [`isspace`](@ref) is `true`.
-
-If a predicate `f` is provided, then remove any leading characters `c` such that `f(c)` is
-`true`.
-
-If `chars` (a character, or vector or set of characters) is provided, instead remove
-leading characters contained in `chars`.
+The default predicate is [`isspace`](@ref), that is remove leading whitespace and delimiters.
 
 # Examples
 ```jldoctest
@@ -139,6 +131,10 @@ julia> a = lpad("March", 20)
 julia> lstrip(a)
 "March"
 ```
+
+# See also
+- [`rstrip`](@ref)
+- [`strip`](@ref)
 """
 function lstrip(f, s::AbstractString)
     e = lastindex(s)
@@ -148,24 +144,15 @@ function lstrip(f, s::AbstractString)
     SubString(s, e+1, e)
 end
 lstrip(s::AbstractString) = lstrip(isspace, s)
-lstrip(s::AbstractString, chars::Chars) = lstrip(in(chars), s)
 
 
 """
-    rstrip(s::AbstractString)
-    rstrip(f, s::AbstractString)
-    rstrip(s::AbstractString, chars::Chars)
+    rstrip(f, str::AbstractString)
+    rstrip(str::AbstractString)
 
-Remove trailing characters from `s`.
+Remove any trailing characters from `str` for which the predicate `f` is true.
 
-The default behaviour is to remove trailing whitespace and delimiters: any characters for
-which [`isspace`](@ref) is `true`.
-
-If a predicate `f` is provided, then remove any trailing characters `c` such that `f(c)`
-is `true`.
-
-If `chars` (a character, or vector or set of characters) is provided, instead remove
-trailing characters contained in `chars`.
+The default predicate is [`isspace`](@ref), that is remove trailing whitespace and delimiters.
 
 # Examples
 ```jldoctest
@@ -175,6 +162,10 @@ julia> a = rpad("March", 20)
 julia> rstrip(a)
 "March"
 ```
+
+# See also
+- [`lstrip`](@ref)
+- [`strip`](@ref)
 """
 function rstrip(f, s::AbstractString)
     for (i, c) in Iterators.reverse(pairs(s))
@@ -183,23 +174,14 @@ function rstrip(f, s::AbstractString)
     SubString(s, 1, 0)
 end
 rstrip(s::AbstractString) = rstrip(isspace, s)
-rstrip(s::AbstractString, chars::Chars) = rstrip(in(chars), s)
 
 """
-    strip(s::AbstractString)
-    strip(f, s::AbstractString)
-    strip(s::AbstractString, chars::Chars)
+    strip(f, str::AbstractString)
+    strip(str::AbstractString)
 
-Remove leading and trailing characters from `s`.
+Remove any leading or trailing characters from `str` for which the predicate `f` is true.
 
-The default behaviour is to remove leading or trailing whitespace and delimiters: any
-characters for which [`isspace`](@ref) is `true`.
-
-If a predicate `f` is provided, then remove any leading or trailing characters `c` such
-that `f(c)` is `true`.
-
-If `chars` (a character, or vector or set of characters) is provided, instead remove
-leading or trailing characters contained in `chars`.
+The default predicate is [`isspace`](@ref), that is remove trailing whitespace and delimiters.
 
 # Examples
 ```jldoctest
@@ -213,7 +195,6 @@ julia> strip("{3, 5}\\n", ['{', '}', '\\n'])
 """
 strip(f, s::AbstractString) = lstrip(f, rstrip(f, s))
 strip(s::AbstractString) = strip(isspace, s)
-strip(s::AbstractString, chars::Chars) = strip(in(chars), s)
 
 ## string padding functions ##
 

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -47,7 +47,7 @@ function Base.string(t::Time)
     mii = lpad(mi, 2, "0")
     ss = lpad(s, 2, "0")
     nss = tons(Millisecond(t)) + tons(Microsecond(t)) + tons(Nanosecond(t))
-    ns = nss == 0 ? "" : rstrip(@sprintf("%.9f", nss / 1e+9)[2:end], '0')
+    ns = nss == 0 ? "" : rstrip(isequal('0'), @sprintf("%.9f", nss / 1e+9)[2:end])
     return "$hh:$mii:$ss$ns"
 end
 

--- a/stdlib/Markdown/src/GitHub/GitHub.jl
+++ b/stdlib/Markdown/src/GitHub/GitHub.jl
@@ -9,7 +9,7 @@ function fencedcode(stream::IO, block::MD)
         skip(stream, -1)
         ch = read(stream, Char)
         trailing = strip(readline(stream))
-        flavor = lstrip(trailing, ch)
+        flavor = lstrip(isequal(ch), trailing)
         n = 3 + length(trailing) - length(flavor)
 
         # inline code block

--- a/stdlib/Pkg/ext/TOML/src/parser.jl
+++ b/stdlib/Pkg/ext/TOML/src/parser.jl
@@ -392,7 +392,7 @@ function numdatetime(p::Parser, st::Int)
         elseif !isnull(decimal) && !isnull(exponent)
             "$(prefix)."*get(decimal,"")*"E"*get(exponent,"")
         end
-        input = lstrip(input, '+')
+        input = lstrip(isequal('+'), input)
         try
             SOME(Base.parse(isfloat ? Float64 : Int, input))
         catch

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -326,7 +326,7 @@ function get_type_call(expr::Expr)
     return (return_type, true)
 end
 
-# Returns the return type. example: get_type(:(Base.strip("", ' ')), Main) returns (String, true)
+# Returns the return type. example: get_type(:(Base.strip(isequal(' '), "")), Main) returns (String, true)
 function try_get_type(sym::Expr, fn::Module)
     val, found = get_value(sym, fn)
     found && return Base.typesof(val).parameters[1], found

--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -53,7 +53,7 @@ isfile(fname) || download("http://mirror.math.ku.edu/tex-archive/macros/latex/co
 const latex_strings = Set(values(REPL.REPLCompletions.latex_symbols))
 open(fname) do f
     for L in eachline(f)
-        x = map(s -> rstrip(s, [' ','\t','\n']),
+        x = map(s -> rstrip(in([' ','\t','\n']), s),
                 split(replace(L, r"[{}\"]+" => "\t"), "\t"))
         c = Char(parse(Int, x[2], base = 16))
         if (Base.is_id_char(c) || Base.isoperator(Symbol(c))) &&

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -50,6 +50,7 @@ end
     @test strip("  ") == ""
     @test strip("   ") == ""
     @test strip("\t  hi   \n") == "hi"
+    @test strip(" \u2009 hi \u2009 ") == "hi"
     @test strip("foobarfoo", ['f','o']) == "bar"
     @test strip("foobarfoo", ('f','o')) == "bar"
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -51,8 +51,8 @@ end
     @test strip("   ") == ""
     @test strip("\t  hi   \n") == "hi"
     @test strip(" \u2009 hi \u2009 ") == "hi"
-    @test strip("foobarfoo", ['f','o']) == "bar"
-    @test strip("foobarfoo", ('f','o')) == "bar"
+    @test strip(in(['f','o']), "foobarfoo") == "bar"
+    @test strip(in(('f','o')), "foobarfoo") == "bar"
 
     for s in ("", " ", " abc", "abc ", "  abc  "),
         f in (lstrip, rstrip, strip)


### PR DESCRIPTION
Fixes #27211. Should be non-breaking.