### PR TITLE
disallow unrecognized escapes in unescape_string (part of #21284)

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -375,7 +375,9 @@ function unescape_string(io, s::AbstractString)
                           c == 'v' ? '\v' :
                           c == 'f' ? '\f' :
                           c == 'r' ? '\r' :
-                          c == 'e' ? '\e' : c)
+                          c == 'e' ? '\e' :
+                          (c == '\\' || c == '"') ? c :
+                          throw(ArgumentError("invalid escape sequence \\$c")))
             end
         else
             print(io, c)

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -18,6 +18,7 @@
         0x0000001c      '\x1c'      "\\x1c"
         0x0000001f      '\x1f'      "\\x1f"
         0x00000020      ' '         " "
+        0x00000022      '"'         "\\\""
         0x0000002f      '/'         "/"
         0x00000030      '0'         "0"
         0x00000039      '9'         "9"
@@ -26,6 +27,7 @@
         0x00000041      'A'         "A"
         0x0000005a      'Z'         "Z"
         0x0000005b      '['         "["
+        0x0000005c      '\\'         "\\\\"
         0x00000060      '`'         "`"
         0x00000061      'a'         "a"
         0x0000007a      'z'         "z"
@@ -169,6 +171,9 @@ join(myio, "", "", 1)
 @testset "unescape_string ArgumentErrors" begin
     @test_throws ArgumentError unescape_string(IOBuffer(), string('\\',"xZ"))
     @test_throws ArgumentError unescape_string(IOBuffer(), string('\\',"777"))
+    @test_throws ArgumentError unescape_string(IOBuffer(), string('\\',"U110000"))
+    @test_throws ArgumentError unescape_string(IOBuffer(), string('\\',"N"))
+    @test_throws ArgumentError unescape_string(IOBuffer(), string('\\',"m"))
 end
 @testset "#11659" begin
     # The indentation code was not correctly counting tab stops

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -75,7 +75,7 @@
             local str = string(ch, cx[j,2])
             @test str == unescape_string(escape_string(str))
         end
-        @test repr(ch) == "'$(isprint(ch) ? ch : st)'"
+        @test repr(ch) == "'$(isprint(ch) && ch != '\\' ? ch : st)'"
     end
 
     for i = 0:0x7f, p = ["","\0","x","xxx","\x7f","\uFF","\uFFF",


### PR DESCRIPTION
Throw an error when encountering unknown/unrecognized escape sequences in `unescape_string` (currently unrecognized single letter sequences like `\m`, `\j`, etc. are silently replaced by their corresponding character (m, j, ...) by `unescape_string`). 

This seems to have been the intention behind [test changes](https://github.com/JuliaLang/julia/pull/22800/files#diff-482397be0c5cfbbf2913ab68936cb49fL85) in #22800, and it will make fixing things like #27125 easier. 