### PR TITLE
Pkg: fix precompile function

### DIFF
--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -454,6 +454,7 @@ function precompile(ctx::Context)
     code = join(["import " * pkg for pkg in needs_to_be_precompiled], '\n') * "\nexit(0)"
     for (i, pkg) in enumerate(needs_to_be_precompiled)
         code = """
+            import OldPkg
             empty!(Base.DEPOT_PATH)
             append!(Base.DEPOT_PATH, $(repr(map(abspath, DEPOT_PATH))))
             empty!(Base.DL_LOAD_PATH)


### PR DESCRIPTION
OldPkg puts OldPkg.dir into the LOAD_PATH which thus means OldPkg needs to be imported

Not sure how worth it is to write a test case for this since OldPkg will be gone in not too long anyway.