### PR TITLE
Finish breaking the decompositions: deprecate chol and chol!

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -313,7 +313,6 @@ LinearAlgebra.UpperTriangular
 LinearAlgebra.UniformScaling
 LinearAlgebra.lu
 LinearAlgebra.lu!
-LinearAlgebra.chol
 LinearAlgebra.cholesky
 LinearAlgebra.cholesky!
 LinearAlgebra.lowrankupdate

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -317,12 +317,13 @@ size(C::Union{Cholesky, CholeskyPivoted}, d::Integer) = size(C.factors, d)
 function getproperty(C::Cholesky, d::Symbol)
     Cfactors = getfield(C, :factors)
     Cuplo    = getfield(C, :uplo)
+    info     = getfield(C, :info)
     if d == :U
-        return UpperTriangular(Symbol(Cuplo) == d ? Cfactors : copy(Cfactors'))
+        return @assertposdef UpperTriangular(Symbol(Cuplo) == d ? Cfactors : copy(Cfactors')) info
     elseif d == :L
-        return LowerTriangular(Symbol(Cuplo) == d ? Cfactors : copy(Cfactors'))
+        return @assertposdef LowerTriangular(Symbol(Cuplo) == d ? Cfactors : copy(Cfactors')) info
     elseif d == :UL
-        return Symbol(Cuplo) == :U ? UpperTriangular(Cfactors) : LowerTriangular(Cfactors)
+        return @assertposdef (Symbol(Cuplo) == :U ? UpperTriangular(Cfactors) : LowerTriangular(Cfactors)) info
     else
         return getfield(C, d)
     end
@@ -334,12 +335,16 @@ function getproperty(C::CholeskyPivoted{T}, d::Symbol) where T<:BlasFloat
     Cfactors = getfield(C, :factors)
     Cuplo    = getfield(C, :uplo)
     if d == :U
+        chkfullrank(C)
         return UpperTriangular(Symbol(Cuplo) == d ? Cfactors : copy(Cfactors'))
     elseif d == :L
+        chkfullrank(C)
         return LowerTriangular(Symbol(Cuplo) == d ? Cfactors : copy(Cfactors'))
     elseif d == :p
+        chkfullrank(C)
         return getfield(C, :piv)
     elseif d == :P
+        chkfullrank(C)
         n = size(C, 1)
         P = zeros(T, n, n)
         for i = 1:n

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -53,7 +53,7 @@ function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{B
 end
 
 # make a copy that allow inplace Cholesky factorization
-@inline choltype(A) = promote_type(typeof(chol(one(eltype(A)))), Float32)
+@inline choltype(A) = promote_type(typeof(sqrt(one(eltype(A)))), Float32)
 @inline cholcopy(A) = copy_oftype(A, choltype(A))
 
 # _chol!. Internal methods for calling unpivoted Cholesky
@@ -144,62 +144,7 @@ function chol!(A::StridedMatrix)
     @assertposdef C info
 end
 
-
-
-# chol. Non-destructive methods for computing Cholesky factor of a real symmetric or
-# Hermitian matrix. Promotes elements to a type that is stable under square roots.
-function chol(A::RealHermSymComplexHerm)
-    AA = similar(A, choltype(A), size(A))
-    if A.uplo == 'U'
-        copyto!(AA, A.data)
-    else
-        adjoint!(AA, A.data)
-    end
-    chol!(Hermitian(AA, :U))
-end
-
 ## for StridedMatrices, check that matrix is symmetric/Hermitian
-"""
-    chol(A) -> U
-
-Compute the Cholesky factorization of a positive definite matrix `A`
-and return the [`UpperTriangular`](@ref) matrix `U` such that `A = U'U`.
-
-# Examples
-```jldoctest
-julia> A = [1. 2.; 2. 50.]
-2×2 Array{Float64,2}:
- 1.0   2.0
- 2.0  50.0
-
-julia> U = chol(A)
-2×2 UpperTriangular{Float64,Array{Float64,2}}:
- 1.0  2.0
-  ⋅   6.78233
-
-julia> U'U
-2×2 Array{Float64,2}:
- 1.0   2.0
- 2.0  50.0
-```
-"""
-chol(A::AbstractMatrix) = chol!(cholcopy(A))
-
-## Numbers
-"""
-    chol(x::Number) -> y
-
-Compute the square root of a non-negative number `x`.
-
-# Examples
-```jldoctest
-julia> chol(16)
-4.0
-```
-"""
-chol(x::Number, args...) = ((C, info) = _chol!(x, nothing); @assertposdef C info)
-
-
 
 # cholesky!. Destructive methods for computing Cholesky factorization of real symmetric
 # or Hermitian matrix

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -4,7 +4,7 @@
 # Cholesky Factorization #
 ##########################
 
-# The dispatch structure in the chol!, chol, cholesky, and cholesky! methods is a bit
+# The dispatch structure in the chol!, cholesky, and cholesky! methods is a bit
 # complicated and some explanation is therefore provided in the following
 #
 # In the methods below, LAPACK is called when possible, i.e. StridedMatrices with Float32,
@@ -20,7 +20,7 @@
 
 # The internal structure is as follows
 # - _chol! returns the factor and info without checking positive definiteness
-# - chol/chol! returns the factor and checks for positive definiteness
+# - chol! returns the factor and checks for positive definiteness
 # - cholesky/cholesky! returns Cholesky without checking positive definiteness
 
 # FixMe? The dispatch below seems overly complicated. One simplification could be to

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -4,7 +4,7 @@
 # Cholesky Factorization #
 ##########################
 
-# The dispatch structure in the chol!, cholesky, and cholesky! methods is a bit
+# The dispatch structure in the cholesky, and cholesky! methods is a bit
 # complicated and some explanation is therefore provided in the following
 #
 # In the methods below, LAPACK is called when possible, i.e. StridedMatrices with Float32,
@@ -20,7 +20,6 @@
 
 # The internal structure is as follows
 # - _chol! returns the factor and info without checking positive definiteness
-# - chol! returns the factor and checks for positive definiteness
 # - cholesky/cholesky! returns Cholesky without checking positive definiteness
 
 # FixMe? The dispatch below seems overly complicated. One simplification could be to
@@ -130,18 +129,6 @@ function _chol!(x::Number, uplo)
     rxr = sqrt(abs(rx))
     rval =  convert(promote_type(typeof(x), typeof(rxr)), rxr)
     rx == abs(x) ? (rval, convert(BlasInt, 0)) : (rval, convert(BlasInt, 1))
-end
-
-# chol!. Destructive methods for computing Cholesky factor of real symmetric or Hermitian
-# matrix
-function chol!(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix})
-    C, info = _chol!(A.uplo == 'U' ? A.data : LinearAlgebra.copytri!(A.data, 'L', true), UpperTriangular)
-    @assertposdef C info
-end
-function chol!(A::StridedMatrix)
-    checksquare(A)
-    C, info = _chol!(A)
-    @assertposdef C info
 end
 
 ## for StridedMatrices, check that matrix is symmetric/Hermitian

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -8,12 +8,12 @@ using Base: @deprecate, depwarn
 
 # PR #22188
 export cholfact, cholfact!
-@deprecate cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}}) cholfact!(Hermitian(A, uplo), Val(false))
-@deprecate cholfact!(A::StridedMatrix, uplo::Symbol) cholfact!(Hermitian(A, uplo))
-@deprecate cholfact(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}}) cholfact(Hermitian(A, uplo), Val(false))
-@deprecate cholfact(A::StridedMatrix, uplo::Symbol) cholfact(Hermitian(A, uplo))
-@deprecate cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{true}}; tol = 0.0) cholfact!(Hermitian(A, uplo), Val(true), tol = tol)
-@deprecate cholfact(A::StridedMatrix, uplo::Symbol, ::Type{Val{true}}; tol = 0.0) cholfact(Hermitian(A, uplo), Val(true), tol = tol)
+@deprecate cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}}) cholesky!(Hermitian(A, uplo), Val(false))
+@deprecate cholfact!(A::StridedMatrix, uplo::Symbol) cholesky!(Hermitian(A, uplo))
+@deprecate cholfact(A::StridedMatrix, uplo::Symbol, ::Type{Val{false}}) cholesky(Hermitian(A, uplo), Val(false))
+@deprecate cholfact(A::StridedMatrix, uplo::Symbol) cholesky(Hermitian(A, uplo))
+@deprecate cholfact!(A::StridedMatrix, uplo::Symbol, ::Type{Val{true}}; tol = 0.0) cholesky!(Hermitian(A, uplo), Val(true), tol = tol)
+@deprecate cholfact(A::StridedMatrix, uplo::Symbol, ::Type{Val{true}}; tol = 0.0) cholesky(Hermitian(A, uplo), Val(true), tol = tol)
 
 # PR #22245
 @deprecate isposdef(A::AbstractMatrix, UL::Symbol) isposdef(Hermitian(A, UL))
@@ -23,31 +23,31 @@ export cholfact, cholfact!
 export bkfact, bkfact!
 function bkfact(A::StridedMatrix, uplo::Symbol, symmetric::Bool = issymmetric(A), rook::Bool = false)
     depwarn(string("`bkfact` with uplo and symmetric arguments is deprecated, ",
-        "use `bkfact($(symmetric ? "Symmetric(" : "Hermitian(")A, :$uplo))` instead."),
+        "use `bunchkaufman($(symmetric ? "Symmetric(" : "Hermitian(")A, :$uplo))` instead."),
         :bkfact)
-    return bkfact(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
+    return bunchkaufman(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
 end
 function bkfact!(A::StridedMatrix, uplo::Symbol, symmetric::Bool = issymmetric(A), rook::Bool = false)
     depwarn(string("`bkfact!` with uplo and symmetric arguments is deprecated, ",
-        "use `bkfact!($(symmetric ? "Symmetric(" : "Hermitian(")A, :$uplo))` instead."),
+        "use `bunchkaufman!($(symmetric ? "Symmetric(" : "Hermitian(")A, :$uplo))` instead."),
         :bkfact!)
-    return bkfact!(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
+    return bunchkaufman!(symmetric ? Symmetric(A, uplo) : Hermitian(A, uplo), rook)
 end
 
 export lufact!
 @deprecate sqrtm(A::UpperTriangular{T},::Type{Val{realmatrix}}) where {T,realmatrix} sqrtm(A, Val(realmatrix))
-@deprecate lufact(A::AbstractMatrix, ::Type{Val{false}}) lufact(A, Val(false))
-@deprecate lufact(A::AbstractMatrix, ::Type{Val{true}}) lufact(A, Val(true))
-@deprecate lufact!(A::AbstractMatrix, ::Type{Val{false}}) lufact!(A, Val(false))
-@deprecate lufact!(A::AbstractMatrix, ::Type{Val{true}}) lufact!(A, Val(true))
-@deprecate qrfact(A::AbstractMatrix, ::Type{Val{false}}) qrfact(A, Val(false))
-@deprecate qrfact(A::AbstractMatrix, ::Type{Val{true}}) qrfact(A, Val(true))
-@deprecate qrfact!(A::AbstractMatrix, ::Type{Val{false}}) qrfact!(A, Val(false))
-@deprecate qrfact!(A::AbstractMatrix, ::Type{Val{true}}) qrfact!(A, Val(true))
-@deprecate cholfact(A::AbstractMatrix, ::Type{Val{false}}) cholfact(A, Val(false))
-@deprecate cholfact(A::AbstractMatrix, ::Type{Val{true}}; tol = 0.0) cholfact(A, Val(true); tol = tol)
-@deprecate cholfact!(A::AbstractMatrix, ::Type{Val{false}}) cholfact!(A, Val(false))
-@deprecate cholfact!(A::AbstractMatrix, ::Type{Val{true}}; tol = 0.0) cholfact!(A, Val(true); tol = tol)
+@deprecate lufact(A::AbstractMatrix, ::Type{Val{false}}) lu(A, Val(false))
+@deprecate lufact(A::AbstractMatrix, ::Type{Val{true}}) lu(A, Val(true))
+@deprecate lufact!(A::AbstractMatrix, ::Type{Val{false}}) lu!(A, Val(false))
+@deprecate lufact!(A::AbstractMatrix, ::Type{Val{true}}) lu!(A, Val(true))
+@deprecate qrfact(A::AbstractMatrix, ::Type{Val{false}}) qr(A, Val(false))
+@deprecate qrfact(A::AbstractMatrix, ::Type{Val{true}}) qr(A, Val(true))
+@deprecate qrfact!(A::AbstractMatrix, ::Type{Val{false}}) qr!(A, Val(false))
+@deprecate qrfact!(A::AbstractMatrix, ::Type{Val{true}}) qr!(A, Val(true))
+@deprecate cholfact(A::AbstractMatrix, ::Type{Val{false}}) cholesky(A, Val(false))
+@deprecate cholfact(A::AbstractMatrix, ::Type{Val{true}}; tol = 0.0) cholesky(A, Val(true); tol = tol)
+@deprecate cholfact!(A::AbstractMatrix, ::Type{Val{false}}) cholesky!(A, Val(false))
+@deprecate cholfact!(A::AbstractMatrix, ::Type{Val{true}}; tol = 0.0) cholesky!(A, Val(true); tol = tol)
 
 # PR #22703
 @deprecate Bidiagonal(dv::AbstractVector, ev::AbstractVector, isupper::Bool) Bidiagonal(dv, ev, ifelse(isupper, :U, :L))

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1411,11 +1411,13 @@ export eigfact!
 @deprecate(cholfact!(A::RealHermSymComplexHerm{<:Real}, ::Val{true}; tol = 0.0), cholesky!(A, Val(true); tol=tol))
 @deprecate(cholfact!(A::StridedMatrix, ::Val{true}; tol = 0.0), cholesky!(A, Val(true); tol=tol))
 
-# deprecate chol to cholesky with getproperty
+# deprecate chol[!] to cholesky[!] with getproperty
 @deprecate(chol(A::RealHermSymComplexHerm), cholesky(A).U)
 @deprecate(chol(A::AbstractMatrix), cholesky(A).U)
 @deprecate(chol(x::Number, args...), sqrt(A))
 @deprecate(chol(J::UniformScaling), UniformScaling(sqrt(J.λ)))
+@deprecate(chol!(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix}), cholesky!(A).U, false)
+@deprecate(chol!(A::StridedMatrix), cholesky!(A).U, false)
 
 # deprecate eig in favor of eigen and destructuring via iteration
 # deprecate eig(...) in favor of eigfact and factorization destructuring

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1415,6 +1415,7 @@ export eigfact!
 @deprecate(chol(A::RealHermSymComplexHerm), cholesky(A).U)
 @deprecate(chol(A::AbstractMatrix), cholesky(A).U)
 @deprecate(chol(x::Number, args...), sqrt(A))
+@deprecate(chol(J::UniformScaling), UniformScaling(sqrt(J.λ)))
 
 # deprecate eig in favor of eigen and destructuring via iteration
 # deprecate eig(...) in favor of eigfact and factorization destructuring

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -333,7 +333,7 @@ end
 # (3) stdlib/LinearAlgebra/src/lq.jl
 
 
-@deprecate chol!(x::Number, uplo) chol(x) false
+@deprecate chol!(x::Number, uplo) sqrt(x) false
 
 ### deprecations for lazier, less jazzy linalg transition in the next several blocks ###
 
@@ -1410,6 +1410,11 @@ export eigfact!
 @deprecate(cholfact!(A::RealHermSymComplexHerm{<:BlasReal,<:StridedMatrix}, ::Val{true}; tol = 0.0), cholesky!(A, Val(true); tol=tol))
 @deprecate(cholfact!(A::RealHermSymComplexHerm{<:Real}, ::Val{true}; tol = 0.0), cholesky!(A, Val(true); tol=tol))
 @deprecate(cholfact!(A::StridedMatrix, ::Val{true}; tol = 0.0), cholesky!(A, Val(true); tol=tol))
+
+# deprecate chol to cholesky with getproperty
+@deprecate(chol(A::RealHermSymComplexHerm), cholesky(A).U)
+@deprecate(chol(A::AbstractMatrix), cholesky(A).U)
+@deprecate(chol(x::Number, args...), sqrt(A))
 
 # deprecate eig in favor of eigen and destructuring via iteration
 # deprecate eig(...) in favor of eigfact and factorization destructuring

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -353,30 +353,6 @@ function hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractVecOrMat,UniformScalin
     return hvcat(rows, promote_to_arrays(n,1, promote_to_array_type(A), A...)...)
 end
 
-
-## Cholesky
-function _chol!(J::UniformScaling, uplo)
-    c, info = _chol!(J.λ, uplo)
-    UniformScaling(c), info
-end
-
-chol!(J::UniformScaling, uplo) = ((J, info) = _chol!(J, uplo); @assertposdef J info)
-
-"""
-    chol(J::UniformScaling) -> C
-
-Compute the square root of a non-negative UniformScaling `J`.
-
-# Examples
-```jldoctest
-julia> chol(16I)
-UniformScaling{Float64}
-4.0*I
-```
-"""
-chol(J::UniformScaling, args...) = ((C, info) = _chol!(J, nothing); @assertposdef C info)
-
-
 ## Matrix construction from UniformScaling
 function Matrix{T}(s::UniformScaling, dims::Dims{2}) where {T}
     A = zeros(T, dims)

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -64,7 +64,6 @@ end
 
         @testset "throw for non-square input" begin
             A = rand(eltya, 2, 3)
-            @test_throws DimensionMismatch LinearAlgebra.chol!(A)
             @test_throws DimensionMismatch cholesky(A)
             @test_throws DimensionMismatch cholesky!(A)
         end
@@ -87,7 +86,6 @@ end
 
         apos = apd[1,1]
         @test all(x -> x ≈ √apos, cholesky(apos).factors)
-        @test_throws PosDefException cholesky(-one(eltya))
 
         # Test cholesky with Symmetric/Hermitian upper/lower
         apds  = Symmetric(apd)
@@ -263,7 +261,6 @@ end
     for A in (R, C)
         @test !LinearAlgebra.issuccess(cholesky(A))
         @test !LinearAlgebra.issuccess(cholesky!(copy(A)))
-        @test_throws PosDefException LinearAlgebra.chol!(copy(A))
     end
 end
 

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -20,7 +20,7 @@ end
 function factor_recreation_tests(a_U, a_L)
     c_U = cholesky(a_U)
     c_L = cholesky(a_L)
-    cl  = chol(a_L)
+    cl  = c_L.U
     ls = c_L.L
     @test Array(c_U) ≈ Array(c_L) ≈ a_U
     @test ls*ls' ≈ a_U
@@ -56,7 +56,6 @@ end
         # Test of symmetric pos. def. strided matrix
         apd  = a'*a
         @inferred cholesky(apd)
-        @inferred chol(apd)
         capd  = factorize(apd)
         r     = capd.U
         κ     = cond(apd, 1) #condition number
@@ -65,7 +64,6 @@ end
 
         @testset "throw for non-square input" begin
             A = rand(eltya, 2, 3)
-            @test_throws DimensionMismatch chol(A)
             @test_throws DimensionMismatch LinearAlgebra.chol!(A)
             @test_throws DimensionMismatch cholesky(A)
             @test_throws DimensionMismatch cholesky!(A)
@@ -87,9 +85,9 @@ end
         @test LinearAlgebra.issuccess(capd)
         @inferred(logdet(capd))
 
-        apos = apd[1,1]            # test chol(x::Number), needs x>0
+        apos = apd[1,1]
         @test all(x -> x ≈ √apos, cholesky(apos).factors)
-        @test_throws PosDefException chol(-one(eltya))
+        @test_throws PosDefException cholesky(-one(eltya))
 
         # Test cholesky with Symmetric/Hermitian upper/lower
         apds  = Symmetric(apd)
@@ -116,9 +114,9 @@ end
             @test sprint((t, s) -> show(t, "text/plain", s), capdh) == "$(typeof(capdh))\nU factor:\n$ulstring"
         end
 
-        # test chol of 2x2 Strang matrix
+        # test cholesky of 2x2 Strang matrix
         S = Matrix{eltya}(SymTridiagonal([2, 2], [-1]))
-        @test Matrix(chol(S)) ≈ [2 -1; 0 sqrt(eltya(3))] / sqrt(eltya(2))
+        @test Matrix(cholesky(S).U) ≈ [2 -1; 0 sqrt(eltya(3))] / sqrt(eltya(2))
 
         # test extraction of factor and re-creating original matrix
         if eltya <: Real
@@ -265,7 +263,6 @@ end
     for A in (R, C)
         @test !LinearAlgebra.issuccess(cholesky(A))
         @test !LinearAlgebra.issuccess(cholesky!(copy(A)))
-        @test_throws PosDefException chol(A)
         @test_throws PosDefException LinearAlgebra.chol!(copy(A))
     end
 end

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -26,7 +26,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
                         (UnitLowerTriangular, :L))
 
         # Construct test matrix
-        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo1 == :U ? t : copy(t')))
+        A1 = t1(elty1 == Int ? rand(1:7, n, n) : convert(Matrix{elty1}, (elty1 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo1 == :U ? t : copy(t')))
 
 
         debug && println("elty1: $elty1, A1: $t1")
@@ -278,7 +278,7 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
 
                 debug && println("elty1: $elty1, A1: $t1, elty2: $elty2")
 
-                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> chol(t't) |> t -> uplo2 == :U ? t : copy(t')))
+                A2 = t2(elty2 == Int ? rand(1:7, n, n) : convert(Matrix{elty2}, (elty2 <: Complex ? complex.(randn(n, n), randn(n, n)) : randn(n, n)) |> t -> cholesky(t't).U |> t -> uplo2 == :U ? t : copy(t')))
 
                 # Convert
                 if elty1 <: Real && !(elty2 <: Integer)

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -192,14 +192,6 @@ end
     end
 end
 
-@testset "chol" begin
-    for T in (Float64, ComplexF32, BigFloat, Int)
-        λ = T(4)
-        @test chol(λ*I) ≈ √λ*I
-        @test_throws LinearAlgebra.PosDefException chol(-λ*I)
-    end
-end
-
 @testset "Matrix/Array construction from UniformScaling" begin
     I2_33 = [2 0 0; 0 2 0; 0 0 2]
     I2_34 = [2 0 0 0; 0 2 0 0; 0 0 2 0]

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1008,5 +1008,4 @@ function factorize(A::LinearAlgebra.RealHermSymComplexHerm{Float64,<:SparseMatri
     end
 end
 
-chol(A::SparseMatrixCSC) = error("Use cholesky() instead of chol() for sparse matrices.")
 eigen(A::SparseMatrixCSC) = error("Use IterativeEigensolvers.eigs() instead of eigen() for sparse matrices.")

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1778,7 +1778,6 @@ end
     @test isa(factorize(tril(A)), LowerTriangular{Float64, SparseMatrixCSC{Float64, Int}})
     C, b = A[:, 1:4], fill(1., size(A, 1))
     @test !Base.USE_GPL_LIBS || factorize(C)\b ≈ Array(C)\b
-    @test_throws ErrorException chol(A)
     @test_throws ErrorException eigen(A)
     @test_throws ErrorException inv(A)
 end


### PR DESCRIPTION
This branch simply rebases @fredrikekre's work on top of the work done in #27212.

There was a slight question about what to do with the `chol(::Number)` and `chol(::UniformScaling)` methods since we can't construct `Cholesky`s for those — I believe that using `sqrt` is just fine here and cannot construct a case where this simplification would change any existing support.