### PR TITLE
Don't accidentally put GlobalRefs into a PhiNode

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -259,6 +259,11 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
                 if isa(leaf, OldSSAValue) && isa(lifted, SSAValue)
                     lifted = OldSSAValue(lifted.id)
                 end
+                if isa(lifted, GlobalRef) || isa(lifted, Expr)
+                    lifted = insert_node!(compact, leaf, compact_exprtype(compact, lifted), lifted)
+                    def.args[1+field] = lifted
+                    (isa(leaf, SSAValue) && (leaf.id < compact.result_idx)) && push!(compact.late_fixup, leaf.id)
+                end
                 lifted_leaves[leaf_key] = RefValue{Any}(lifted)
                 continue
             elseif isexpr(def, :new)
@@ -292,6 +297,11 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
                 lifted = def.args[1+field]
                 if isa(leaf, OldSSAValue) && isa(lifted, SSAValue)
                     lifted = OldSSAValue(lifted.id)
+                end
+                if isa(lifted, GlobalRef) || isa(lifted, Expr)
+                    lifted = insert_node!(compact, leaf, compact_exprtype(compact, lifted), lifted)
+                    def.args[1+field] = lifted
+                    (isa(leaf, SSAValue) && (leaf.id < compact.result_idx)) && push!(compact.late_fixup, leaf.id)
                 end
                 lifted_leaves[leaf_key] = RefValue{Any}(lifted)
                 continue

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -372,7 +372,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
             print_sep = true
         end
         floop = true
-        while !isempty(new_nodes_perm) && new_nodes[peek(new_nodes_perm)].pos == idx
+        while !isempty(new_nodes_perm) && new_nodes[Iterators.peek(new_nodes_perm)].pos == idx
             node_idx = popfirst!(new_nodes_perm)
             new_node = new_nodes[node_idx]
             node_idx += length(code.stmts)

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -94,6 +94,9 @@ function verify_ir(ir::IRCode)
                         #"""
                         #error()
                     end
+                elseif isa(val, GlobalRef) || isa(val, Expr)
+                    @verify_error "GlobalRefs and Exprs are not allowed as PhiNode values"
+                    error()
                 end
                 check_op(ir, domtree, val, edge, last(ir.cfg.blocks[stmt.edges[i]].stmts)+1)
             end

--- a/test/core.jl
+++ b/test/core.jl
@@ -6138,3 +6138,14 @@ foo27204(x) = f27204(x)()
 end
 g27209(x) = f27209(x ? nothing : 1.0)
 @test g27209(true) == true
+
+# Issue 27240
+@inline function foo27240()
+    if rand(Bool)
+        return foo_nonexistant_27240
+    else
+        return bar_nonexistant_27240
+    end
+end
+bar27240() = foo27240()
+@test_throws UndefVarError bar27240()

--- a/test/show.jl
+++ b/test/show.jl
@@ -1236,8 +1236,7 @@ function f_line()
    nothing
 end
 h_line() = f_line()
-@test compute_annotations(h_line, Tuple{}) == """
+@test startswith(compute_annotations(h_line, Tuple{}), """
     │╻╷ f_line
     ││╻  g_line
-    ││╻  g_line
-    │"""
+    ││╻  g_line""")


### PR DESCRIPTION
GlobalRefs (and Expr(:static_parameter)) are not legal to be moved
into PhiNodes because they may have side effects (throw an undefined
variable error), so they must remain at the place where they occurred
in the code.

Fixes #27240