### PR TITLE
DO NOT MERGE! NFC for testing 0.6 Windows EPERM on AV

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -1,5 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
-
+# alex wuz here
 ## floating point traits ##
 
 """


### PR DESCRIPTION
Sorry for using AppVeyor for this, but I don't have access to Windows locally and building from scratch on AppVeyor from my fork would time out the build since there's no cache. FreeBSD CI has been skipped and I'll cancel Travis and Circle manually to avoid adding to those queues unnecessarily.

Basically, the deal is that we keep getting a permissions error (`EPERM`) from `unlink` when running the distributed tests on 64-bit Windows. This has been happening on my backports branch for 0.6.3, but the error was first seen on #26897, which initially targeted `release-0.6` rather than `aa/backports-0.6.3`. That PR didn't touch anything filesystem-related, which suggests that the issue may already exist on the release branch. Thus I'm opening this PR against the release branch to test that theory.

The change here is non-functional, but seriously, **do not merge this**.