### PR TITLE
Document performance issues for captured variables

### DIFF
--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -198,6 +198,14 @@ julia> map(tuple, (1/(i+j) for i=1:2, j=1:2), [1 3; 2 4])
  (0.333333, 2)  (0.25, 4)
 ```
 
+Generators are implemented via inner functions. As in other cases of
+inner functions in the language, variables from the enclosing scope can be 
+"captured" in the inner function.  For example, `sum(p[i] - q[i] for i=1:n)`
+captures the three variables `p`, `q` and `n` from the enclosing scope. 
+Captured variables can present performance challenges described in
+[performance tips](@ref man-performance-tips).
+
+
 Ranges in generators and comprehensions can depend on previous ranges by writing multiple `for`
 keywords:
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -199,9 +199,9 @@ julia> map(tuple, (1/(i+j) for i=1:2, j=1:2), [1 3; 2 4])
 ```
 
 Generators are implemented via inner functions. As in other cases of
-inner functions in the language, variables from the enclosing scope can be 
+inner functions in the language, variables from the enclosing scope can be
 "captured" in the inner function.  For example, `sum(p[i] - q[i] for i=1:n)`
-captures the three variables `p`, `q` and `n` from the enclosing scope. 
+captures the three variables `p`, `q` and `n` from the enclosing scope.
 Captured variables can present performance challenges described in
 [performance tips](@ref man-performance-tips).
 

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -654,6 +654,12 @@ normally or threw an exception. (The `try/finally` construct will be described i
 With the `do` block syntax, it helps to check the documentation or implementation to know how
 the arguments of the user function are initialized.
 
+A `do` block, like any other inner function, can "capture" variables from its
+enclosing scope. For example, the variable `data` in the above example of
+`open...do` is captured from the outer scope. Captured variables
+can create performance challenges as discussed in [performance tips](@ref man-performance-tips).
+
+
 ## [Dot Syntax for Vectorizing Functions](@id man-vectorized)
 
 In technical-computing languages, it is common to have "vectorized" versions of functions, which

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1510,7 +1510,7 @@ The following examples may help you interpret expressions marked as containing n
 
 ## [Performance of captured variable](@id man-performance-captured)
 
-Consider the following example that defines two inner functions:
+Consider the following example that defines an inner function:
 ```julia
 function abmult(r::Int)
     if r < 0
@@ -1581,7 +1581,7 @@ function abmult3(r::Int)
     return f
 end
 ```
-A `let` block creates a new variable `r` whose scope is only the
+The `let` block creates a new variable `r` whose scope is only the
 inner function. The second technique recovers full language performance
 in the presence of captured variables. Note that this is a rapidly
 evolving aspect of the compiler, and it is likely that future releases

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1511,16 +1511,16 @@ The following examples may help you interpret expressions marked as containing n
 ## [Performance of captured variable](@id man-performance-captured)
 
 Consider the following example that defines two inner functions:
-```
-    function abmult(r::Int)
-        if r >= 0
-            f = x -> x * r
-        else
-            r = -r
-            f = x -> x * r
-        end
-        return f
+```julia
+function abmult(r::Int)
+    if r >= 0
+        f = x -> x * r
+    else
+        r = -r
+        f = x -> x * r
     end
+    return f
+end
 ```
 
 Function `abmult` returns a function `f` that multiplies its argument by
@@ -1557,37 +1557,36 @@ then the following tips help ensure that their use is performant. First, if
 it is known that a captured variable does not change its type, then this can
 be declared explicitly with a type annotation (on the variable, not the
 right-hand side):
-```
-    function abmult(r0::Int)
-        r::Int = r0
-        if r >= 0
-            f = x -> x * r
-        else
-            r = -r
-            f = x -> x * r
-        end
-        return f
+```julia
+function abmult(r0::Int)
+    r::Int = r0
+    if r >= 0
+        f = x -> x * r
+    else
+        r = -r
+        f = x -> x * r
     end
+    return f
+end
 ```
 The type annotation partially recovers lost performance due to capturing because
 the parser can associate a concrete type to the object in the box.
 Second, if the captured variable does not need to be boxed (because it
 will not be reassigned after the closure is created), this can be indicated
 with `let` blocks as follows.
-```
-    function abmult3(r::Int)
-        f =
-            if r >= 0
-                let r = r
-                    x -> x * r
-                end
-            else
-                let r = -r
-                    x -> x * r
-                end
-            end
-        return f
+```julia
+function abmult3(r::Int)
+    f = if r >= 0
+        let r = r
+            x -> x * r
+        end
+    else
+        let r = -r
+            x -> x * r
+        end
     end
+    return f
+end
 ```
 Each `let` block creates a new variable `r` whose scope is only the
 inner function. The second technique recovers full language performance

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1542,14 +1542,14 @@ The discussion in the preceding paragraph referred to the "parser", that is, the
 of compilation that takes place when the module containing `abmult` is first loaded,
 as opposed to the later phase when it is first invoked. The parser does not "know" that
 `Int` is a fixed type, or that the statement `r = -r` tranforms an `Int` to another `Int`.
-The magic of type inference takes place in the later phase of compilation
+The magic of type inference takes place in the later phase of compilation.
 
 Thus, the parser does not know that `r` has a fixed type (`Int`)
 nor that `r` does not change value once the inner function is created.  Therefore,
 it must create a "box" (a heap allocation) for `r`, and furthermore, the
 box holds an object with an abstract type such as `Any`, which
-requires run-time type dispatch for each occurrence of `r`.  This can be 
-verified by applying `@code_warntype` to the above function.  Both the boxing 
+requires run-time type dispatch for each occurrence of `r`.  This can be
+verified by applying `@code_warntype` to the above function.  Both the boxing
 and the run-time type dispatch can cause loss of performance.
 
 If captured variables are used in a performance-critical section of the code,

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -263,7 +263,7 @@ julia> counter()
 ```
 
 See also the closures in the examples in the next two sections. A variable
-such `x` in the first example and `state` in the second that is inherited
+such as `x` in the first example and `state` in the second that is inherited
 from the enclosing scope by the inner function is sometimes called a
 *captured* variable. Captured variables can present performance challenges
 discussed in [performance tips](@ref man-performance-tips).

--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -262,7 +262,11 @@ julia> counter()
 2
 ```
 
-See also the closures in the examples in the next two sections.
+See also the closures in the examples in the next two sections. A variable
+such `x` in the first example and `state` in the second that is inherited
+from the enclosing scope by the inner function is sometimes called a
+*captured* variable. Captured variables can present performance challenges
+discussed in [performance tips](@ref man-performance-tips).
 
 The distinction between inheriting global scope and nesting local scope
 can lead to some slight differences between functions


### PR DESCRIPTION
These changes to the manual try to document the material
in issue #15276 about the performance of captured variables, since
it appears that this issue will not be "solved" before the release
of 1.0