### PR TITLE
fix completions for packages that are lower in LOAD_PATH

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -582,7 +582,7 @@ function completions(string, pos)
         # also search for packages
         s = string[startpos:pos]
         if dotpos <= startpos
-            for dir in [LOAD_PATH; pwd(); Base.find_env(LOAD_PATH)]
+            for dir in [Base.load_path()..., pwd()]
                 dir isa Function && (dir = dir())
                 dir isa AbstractString || continue
                 if basename(dir) in Base.project_names && isfile(dir)


### PR DESCRIPTION
It is possible to load a package from an environment lower in LOAD_PATH in Main but REPL Completions didn't account for this (because I didn't know it when I wrote that code!).