### PR TITLE
Make UniformScaling correct for matrices of matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -188,6 +188,9 @@ broadcast(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...
 
 ### linear algebra
 
+(-)(A::Adjoint)   = Adjoint(  -A.parent)
+(-)(A::Transpose) = Transpose(-A.parent)
+
 ## multiplication *
 
 # Adjoint/Transpose-vector * vector

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -243,10 +243,14 @@ adjoint(B::Bidiagonal) = Adjoint(B)
 transpose(B::Bidiagonal) = Transpose(B)
 adjoint(B::Bidiagonal{<:Real}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
 transpose(B::Bidiagonal{<:Number}) = Bidiagonal(B.dv, B.ev, B.uplo == 'U' ? :L : :U)
-Base.copy(aB::Adjoint{<:Any,<:Bidiagonal}) =
-    (B = aB.parent; Bidiagonal(map(x -> copy.(adjoint.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U))
-Base.copy(tB::Transpose{<:Any,<:Bidiagonal}) =
-    (B = tB.parent; Bidiagonal(map(x -> copy.(transpose.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U))
+function Base.copy(aB::Adjoint{<:Any,<:Bidiagonal})
+    B = aB.parent
+    return Bidiagonal(map(x -> copy.(adjoint.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U)
+end
+function Base.copy(tB::Transpose{<:Any,<:Bidiagonal})
+    B = tB.parent
+    return Bidiagonal(map(x -> copy.(transpose.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U)
+end
 
 istriu(M::Bidiagonal) = M.uplo == 'U' || iszero(M.ev)
 istril(M::Bidiagonal) = M.uplo == 'L' || iszero(M.ev)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -94,83 +94,39 @@ ishermitian(J::UniformScaling) = isreal(J.λ)
 (-)(J1::UniformScaling, J2::UniformScaling) = UniformScaling(J1.λ-J2.λ)
 (-)(B::BitArray{2}, J::UniformScaling)      = Array(B) - J
 (-)(J::UniformScaling, B::BitArray{2})      = J - Array(B)
+(-)(A::AbstractMatrix, J::UniformScaling)   = A + (-J)
 
+# Unit{Lower/Upper}Triangular matrices become {Lower/Upper}Triangular under
+# addition with a UniformScaling
 for (t1, t2) in ((:UnitUpperTriangular, :UpperTriangular),
                  (:UnitLowerTriangular, :LowerTriangular))
-    for op in (:+,:-)
-        @eval begin
-            ($op)(UL::$t2, J::UniformScaling) = ($t2)(($op)(UL.data, J))
-
-            function ($op)(UL::$t1, J::UniformScaling)
-                ULnew = copy_oftype(UL.data, Base._return_type($op, Tuple{eltype(UL), typeof(J.λ)}))
-                for i = 1:size(ULnew, 1)
-                    ULnew[i,i] = ($op)(1, J.λ)
-                end
-                return ($t2)(ULnew)
+    @eval begin
+        function (+)(UL::$t1, J::UniformScaling)
+            ULnew = copy_oftype(UL.data, Base._return_type(+, Tuple{eltype(UL), typeof(J)}))
+            for i in axes(ULnew, 1)
+                ULnew[i,i] = one(ULnew[i,i]) + J
             end
+            return ($t2)(ULnew)
         end
     end
-end
-
-function (-)(J::UniformScaling, UL::Union{UpperTriangular,UnitUpperTriangular})
-    ULnew = similar(parent(UL), Base._return_type(-, Tuple{typeof(J.λ), eltype(UL)}))
-    n = size(ULnew, 1)
-    ULold = UL.data
-    for j = 1:n
-        for i = 1:j - 1
-            ULnew[i,j] = -ULold[i,j]
-        end
-        if isa(UL, UnitUpperTriangular)
-            ULnew[j,j] = J.λ - 1
-        else
-            ULnew[j,j] = J.λ - ULold[j,j]
-        end
-    end
-    return UpperTriangular(ULnew)
-end
-function (-)(J::UniformScaling, UL::Union{LowerTriangular,UnitLowerTriangular})
-    ULnew = similar(parent(UL), Base._return_type(-, Tuple{typeof(J.λ), eltype(UL)}))
-    n = size(ULnew, 1)
-    ULold = UL.data
-    for j = 1:n
-        if isa(UL, UnitLowerTriangular)
-            ULnew[j,j] = J.λ - 1
-        else
-            ULnew[j,j] = J.λ - ULold[j,j]
-        end
-        for i = j + 1:n
-            ULnew[i,j] = -ULold[i,j]
-        end
-    end
-    return LowerTriangular(ULnew)
 end
 
 function (+)(A::AbstractMatrix, J::UniformScaling)
-    n = checksquare(A)
-    B = similar(A, Base._return_type(+, Tuple{eltype(A), typeof(J.λ)}))
-    copyto!(B,A)
-    @inbounds for i = 1:n
-        B[i,i] += J.λ
+    checksquare(A)
+    B = copy_oftype(A, Base._return_type(+, Tuple{eltype(A), typeof(J)}))
+    @inbounds for i in axes(A, 1)
+        B[i,i] += J
     end
-    B
+    return B
 end
 
-function (-)(A::AbstractMatrix, J::UniformScaling)
-    n = checksquare(A)
-    B = similar(A, Base._return_type(-, Tuple{eltype(A), typeof(J.λ)}))
-    copyto!(B, A)
-    @inbounds for i = 1:n
-        B[i,i] -= J.λ
-    end
-    B
-end
 function (-)(J::UniformScaling, A::AbstractMatrix)
-    n = checksquare(A)
-    B = convert(AbstractMatrix{Base._return_type(-, Tuple{typeof(J.λ), eltype(A)})}, -A)
-    @inbounds for j = 1:n
-        B[j,j] += J.λ
+    checksquare(A)
+    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, -A)
+    @inbounds for i in axes(A, 1)
+        B[i,i] += J
     end
-    B
+    return B
 end
 
 inv(J::UniformScaling) = UniformScaling(inv(J.λ))

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -251,4 +251,9 @@ end
     @test eltype(fill(Float16(1), 2, 2) + I) == Float16
 end
 
+@testset "test that UniformScaling is applied correctly for matrices of matrices" begin
+    LL = Bidiagonal(fill(0*I, 3), fill(1*I, 2), :L)
+    @test (I - LL')\[[0], [0], [1]] == (I - LL)'\[[0], [0], [1]] == fill([1], 3)
+end
+
 end # module TestUniformscaling


### PR DESCRIPTION
Make adjoint/transpose of a Bidiagonal a Bidiagonal

To clarify, most of the "correct" part here is that `J::UnitformScaling` is applied to the diagonal elements in `+` instead of applying `J.λ`.