### PR TITLE
Configure git to always use LF line endings in the working directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+* text=auto eol=lf
 # treat patches as files that should not be modified
 *.patch -text


### PR DESCRIPTION
If I understand git correctly, then this patch means that a) git will try to automatically detect whether a file is a text file (the default in any case) and then b) for all text files always use LF line endings in the working directory, even on Windows, even if there is a global setting ``core.eol crlf`` configured.

Hopefully this patch would change nothing on Mac and Linux systems. On Windows, it does mean that if I do a ``git clone``, everything will be checked out with LF line endings, which is good, because the build fails otherwise :)

This enables the following scenario: one can clone julia and use git from a Windows environment that uses the default git configuration for line endings. And then one can compile julia in WSL. And all of that works in the ``/mnt/c`` locations. Being able to use git from the Windows environment is nice in this case because one can e.g. use the built in git in VS Code.

Someone with more git foo should carefully think this patch through, though, before it gets merged, I'm not really an expert on this.

EDIT: Oh, and I do think that [this](https://github.com/JuliaLang/julia/blob/master/README.windows.md#line-endings) section could be removed if this patch here gets merged.