### PR TITLE
In shell mode, auto-expand directories so `~` works.

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -34,6 +34,9 @@ function repl_cmd(cmd, out)
     shell = shell_split(get(ENV, "JULIA_SHELL", get(ENV, "SHELL", "/bin/sh")))
     shell_name = Base.basename(shell[1])
 
+    # Immediately expand all arguments, so that typing e.g. ~/bin/foo works.
+    cmd.exec .= expanduser.(cmd.exec)
+
     if isempty(cmd.exec)
         throw(ArgumentError("no cmd to execute"))
     elseif cmd.exec[1] == "cd"


### PR DESCRIPTION
If we're going to allow tab-completion with `~` in shell mode, we should allow `cd()` to work with it as well.  I would argue that _all_ commands should use `expanduser()` but this PR only does so for `;cd` at the moment.

Closes https://github.com/JuliaLang/julia/issues/22181