### PR TITLE
For singleton types, make Const(T.instance) and T equivalent

### DIFF
--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -127,6 +127,9 @@ function ⊑(@nospecialize(a), @nospecialize(b))
         end
         return isa(a.val, widenconst(b))
     elseif isa(b, Const)
+        if isa(a, DataType) && isdefined(a, :instance)
+            return a.instance === b.val
+        end
         return a === Bottom
     elseif !(isa(a, Type) || isa(a, TypeVar)) ||
            !(isa(b, Type) || isa(b, TypeVar))

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1580,3 +1580,6 @@ function _g_ifelse_isa_()
     ifelse(isa(x, Nothing), 1, x)
 end
 @test Base.return_types(_g_ifelse_isa_, ()) == [Int]
+
+# Equivalence of Const(T.instance) and T for singleton types
+@test Const(nothing) ⊑ Nothing && Nothing ⊑ Const(nothing)


### PR DESCRIPTION
Both inference and the optimizer will readily change the latter to the former
in a number of places and it is important for the type lattice to consider
them equivalent in order for that operation to be not cause potential assertion
errors.