### PR TITLE
generate default outer ctors for more types with triangular constraints

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -39,7 +39,6 @@ end
 struct KeySet{K, T <: AbstractDict{K}} <: AbstractSet{K}
     dict::T
 end
-KeySet(dict::AbstractDict) = KeySet{keytype(dict), typeof(dict)}(dict)
 
 struct ValueIterator{T<:AbstractDict}
     dict::T

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -350,7 +350,6 @@ struct LinearIndices{N,R<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractArray{Int
 end
 
 LinearIndices(::Tuple{}) = LinearIndices{0,typeof(())}(())
-LinearIndices(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} = LinearIndices{N,typeof(inds)}(inds)
 LinearIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N} =
     LinearIndices(map(r->convert(AbstractUnitRange{Int}, r), inds))
 LinearIndices(sz::NTuple{N,<:Integer}) where {N} = LinearIndices(map(Base.OneTo, sz))

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -218,8 +218,6 @@ module IteratorsMD
     end
 
     CartesianIndices(::Tuple{}) = CartesianIndices{0,typeof(())}(())
-    CartesianIndices(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} =
-        CartesianIndices{N,typeof(inds)}(inds)
     CartesianIndices(inds::NTuple{N,AbstractUnitRange{<:Integer}}) where {N} =
         CartesianIndices(map(r->convert(AbstractUnitRange{Int}, r), inds))
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -45,7 +45,8 @@ julia> Diagonal(V)
  ⋅  2
 ```
 """
-Diagonal(V::AbstractVector{T}) where {T} = Diagonal{T,typeof(V)}(V)
+Diagonal(V::AbstractVector)
+
 Diagonal{T}(V::AbstractVector{T}) where {T} = Diagonal{T,typeof(V)}(V)
 Diagonal{T}(V::AbstractVector) where {T} = Diagonal{T}(convert(AbstractVector{T}, V))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -6149,3 +6149,9 @@ g27209(x) = f27209(x ? nothing : 1.0)
 end
 bar27240() = foo27240()
 @test_throws UndefVarError bar27240()
+
+# issue #27269
+struct T27269{X, Y <: Vector{X}}
+    v::Vector{Y}
+end
+@test T27269([[1]]) isa T27269{Int, Vector{Int}}


### PR DESCRIPTION
Previously, we required all type parameters to occur in field types in order to generate a default outer constructor. Now, it is sufficient for all parameters to be reachable via field types, or via the bounds of reachable parameters.

I thought this rule might be too fiddly, but it seems to work really well with examples in Base and stdlib. A few explicit constructors can simply be deleted.

fixes #27269