### PR TITLE
Make Sys.which return nothing instead of throwing

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -346,8 +346,8 @@ isexecutable(path::AbstractString) = isexecutable(String(path))
     Sys.which(program_name::String)
 
 Given a program name, search the current `PATH` to find the first binary with
-the proper executable permissions that can be run, and return an absolute
-path. Raise `ErrorException` if no such program is available.  If a path with
+the proper executable permissions that can be run and return an absolute path
+to it, or return `nothing` if no such program is available. If a path with
 a directory in it is passed in for `program_name`, tests that exact path
 for executable permissions only (with `.exe` and `.com` extensions added on
 Windows platforms); no searching of `PATH` is performed.
@@ -401,8 +401,8 @@ function which(program_name::String)
         end
     end
 
-    # If we couldn't find anything, complain
-    error("$program_name not found")
+    # If we couldn't find anything, don't return anything
+    nothing
 end
 which(program_name::AbstractString) = which(String(program_name))
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -561,12 +561,12 @@ mktempdir() do dir
             @test Sys.which(foo_path) == realpath(foo_path)
 
             chmod(foo_path, 0o666)
-            @test_throws ErrorException Sys.which("foo")
-            @test_throws ErrorException Sys.which(foo_path)
+            @test Sys.which("foo") === nothing
+            @test Sys.which(foo_path) === nothing
         end
 
-        # Test that completely missing files also fail
-        @test_throws ErrorException Sys.which("this_is_not_a_command")
+        # Test that completely missing files also return nothing
+        @test Sys.which("this_is_not_a_command") === nothing
     end
 end
 


### PR DESCRIPTION
Currently `Sys.which("prog")` will throw an error if `prog` is not found or is found but is not executable. This changes the function to instead return `nothing` in those cases, thereby simplifying logic for situations such as hierarchically choosing an executable based on which in a list is present.

Fixes #27284.