### PR TITLE
Improve support for ranges with nonstandard Integers

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -6,10 +6,9 @@
 
 (:)(start::T, stop::T) where {T} = (:)(start, oftype(stop-start, 1), stop)
 
-# first promote start and stop, leaving step alone
+# promote start and stop, leaving step alone
 (:)(start::A, step, stop::C) where {A<:Real,C<:Real} =
     (:)(convert(promote_type(A,C),start), step, convert(promote_type(A,C),stop))
-(:)(start::T, step::Real, stop::T) where {T<:Real} = (:)(promote(start, step, stop)...)
 
 # AbstractFloat specializations
 (:)(a::T, b::T) where {T<:AbstractFloat} = (:)(a, T(1), b)

--- a/base/range.jl
+++ b/base/range.jl
@@ -143,7 +143,7 @@ function steprange_last(start::T, step, stop) where T
             last = steprange_last_empty(start, step, stop)
         else
             diff = stop - start
-            if T<:Signed && (diff > zero(diff)) != (stop > start)
+            if (diff > zero(diff)) != (stop > start)
                 # handle overflowed subtraction with unsigned rem
                 if diff > zero(diff)
                     remain = -convert(T, unsigned(-diff) % step)
@@ -400,8 +400,10 @@ function length(r::StepRange{T}) where T<:Union{Int,UInt,Int64,UInt64}
         return checked_add(convert(T, div(unsigned(r.stop - r.start), r.step)), one(T))
     elseif r.step < -1
         return checked_add(convert(T, div(unsigned(r.start - r.stop), -r.step)), one(T))
+    elseif r.step > 0
+        return checked_add(div(checked_sub(r.stop, r.start), r.step), one(T))
     else
-        checked_add(div(checked_sub(r.stop, r.start), r.step), one(T))
+        return checked_add(div(checked_sub(r.start, r.stop), -r.step), one(T))
     end
 end
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -374,7 +374,7 @@ julia> step(range(2.5, stop=10.9, length=85))
 ```
 """
 step(r::StepRange) = r.step
-step(r::AbstractUnitRange{T}) where{T} = oneunit(T)
+step(r::AbstractUnitRange{T}) where{T} = oneunit(T) - zero(T)
 step(r::StepRangeLen{T}) where {T} = T(r.step)
 step(r::LinRange) = (last(r)-first(r))/r.lendiv
 
@@ -388,8 +388,8 @@ function unsafe_length(r::StepRange)
     isempty(r) ? zero(n) : n
 end
 length(r::StepRange) = unsafe_length(r)
-unsafe_length(r::AbstractUnitRange) = Integer(last(r) - first(r) + 1)
-unsafe_length(r::OneTo) = r.stop
+unsafe_length(r::AbstractUnitRange) = Integer(last(r) - first(r) + step(r))
+unsafe_length(r::OneTo) = Integer(r.stop - zero(r.stop))
 length(r::AbstractUnitRange) = unsafe_length(r)
 length(r::OneTo) = unsafe_length(r)
 length(r::StepRangeLen) = r.len

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1325,10 +1325,8 @@ Base.convert(::Type{Int}, x::Displacement) = x.val
                 r1 = StepRange(Position(start), Displacement(step), Position(stop))
                 @test collect(r1) == Position.(start : step : stop)
 
-                @test_broken begin
-                    r2 = Position(start) : Displacement(step) : Position(stop)
-                    r1 === r2
-                end
+                r2 = Position(start) : Displacement(step) : Position(stop)
+                @test r1 === r2
             end
         end
     end

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1319,7 +1319,7 @@ Base.convert(::Type{Int}, x::Displacement) = x.val
         @test collect(Base.OneTo(Position(start))) == Position.(Base.OneTo(start))
     end
 
-    for step in [1, 2, 3]
+    for step in [-3, -2, -1, 1, 2, 3]
         for start in [-1, 0, 2]
             for stop in [start, start - 1, start + 2 * step, start + 2 * step + 1]
                 r1 = StepRange(Position(start), Displacement(step), Position(stop))
@@ -1333,3 +1333,23 @@ Base.convert(::Type{Int}, x::Displacement) = x.val
 end
 
 end # module NonStandardIntegerRangeTest
+
+@testset "Issue #26619" begin
+    @test length(UInt(100) : -1 : 1) === UInt(100)
+    @test collect(UInt(5) : -1 : 3) == [UInt(5), UInt(4), UInt(3)]
+
+    let r = UInt(5) : -2 : 2
+        @test r.start === UInt(5)
+        @test r.step === -2
+        @test r.stop === UInt(3)
+        @test collect(r) == [UInt(5), UInt(3)]
+    end
+
+    for step in [-3, -2, -1, 1, 2, 3]
+        for start in [0, 15]
+            for stop in [0, 15]
+                @test collect(UInt(start) : step : UInt(stop)) == start : step : stop
+            end
+        end
+    end
+end


### PR DESCRIPTION
See added `testset`. Makes it so that `UnitRange`, `OneTo`, and `StepRange` properly handle `Integer` subtypes (e.g. `Position <: Integer`) for which _differences_ are of a different type (say `Displacement <: Integer`). Note the `test_broken` for `a : b : c`. I can fix that too if there's support for this PR.

This kind of thing is pretty handy for e.g. `MathOptInterface`, where there's a `VariableIndex` `struct` that's basically a wrapper around an `Int`, and `VariableIndex` ranges would be very handy, but it doesn't really make sense to return a `VariableIndex` from `Base.:-(x::VariableIndex, y::VariableIndex)`.