### PR TITLE
Fix typo in split docstring

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -242,7 +242,7 @@ end
     split(str::AbstractString, dlm; limit::Integer=0, keepempty::Bool=true)
     split(str::AbstractString; limit::Integer=0, keepempty::Bool=false)
 
-Split `str` into an array of substrings on occurences of the delimiter `dlm`.  `dlm`
+Split `str` into an array of substrings on occurrences of the delimiter(s) `dlm`.  `dlm`
 can be any of the formats allowed by [`findnext`](@ref)'s first argument (i.e. as a
 string, regular expression or a function), or as a single character or collection of
 characters.


### PR DESCRIPTION
Spotted at https://github.com/JuliaLang/julia/pull/27252.