### PR TITLE
Bump Pkg

### DIFF
--- a/stdlib/Pkg/src/GraphType.jl
+++ b/stdlib/Pkg/src/GraphType.jl
@@ -932,7 +932,7 @@ function check_constraints(graph::Graph)
             err_msg = "Resolve failed to satisfy requirements for package $(id(p0)):\n"
         end
         err_msg *= sprint(showlog, rlog, pkgs[p0])
-        throw(ResolverError(err_msg))
+        throw(ResolverError(chomp(err_msg)))
     end
     return true
 end
@@ -1002,7 +1002,7 @@ function propagate_constraints!(graph::Graph, sources::Set{Int} = Set{Int}(); lo
                         err_msg = "Resolve failed to satisfy requirements for package $(id(p1)):\n"
                     end
                     err_msg *= sprint(showlog, rlog, pkgs[p1])
-                    throw(ResolverError(err_msg))
+                    throw(ResolverError(chomp(err_msg)))
                 end
             end
         end

--- a/stdlib/Pkg/src/Operations.jl
+++ b/stdlib/Pkg/src/Operations.jl
@@ -243,10 +243,12 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Require
 
     for uuid in uuids
         uuid == uuid_julia && continue
-        uuid_to_name[uuid] = registered_name(ctx.env, uuid)
-        info = manifest_info(ctx.env, uuid)
-        info ≡ nothing && continue
-        uuid_to_name[UUID(info["uuid"])] = info["name"]
+        if !haskey(uuid_to_name, uuid)
+            uuid_to_name[uuid] = registered_name(ctx.env, uuid)
+            info = manifest_info(ctx.env, uuid)
+            info ≡ nothing && continue
+            uuid_to_name[UUID(info["uuid"])] = info["name"]
+        end
     end
 
     return Graph(all_versions, all_deps, all_compat, uuid_to_name, reqs, fixed, #=verbose=# ctx.graph_verbose)

--- a/stdlib/Pkg/src/Operations.jl
+++ b/stdlib/Pkg/src/Operations.jl
@@ -779,7 +779,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         write_env(localctx, display_diff = false)
         will_resolve && build_versions(localctx, new)
         sep = Sys.iswindows() ? ';' : ':'
-        withenv(f, "JULIA_LOAD_PATH" => "$tmpdir$sep$(Types.stdlib_dir())")
+        withenv(f, "JULIA_LOAD_PATH" => "@$sep$tmpdir$sep$(Types.stdlib_dir())")
     end
 end
 

--- a/stdlib/Pkg/src/Pkg2/types.jl
+++ b/stdlib/Pkg/src/Pkg2/types.jl
@@ -28,6 +28,11 @@ function Base.convert(::Type{VersionRange}, a::VersionInterval)
     lb = VersionBound(lower.major, lower.minor, lower.patch)
 
     vb = UInt32[upper.major, upper.minor, upper.patch]
+    # Consider e.g. "0.1.0 0.1.0+" to be the same as VerionRange("0.1.0")
+    # by making the "+" bump the patch version
+    if typeof(upper.build) == Tuple{String} && vb[3] != typemax(UInt32)
+        vb[3] += 1
+    end
     i = 3
     while i > 0 && vb[i] == 0
         pop!(vb)

--- a/stdlib/Pkg/src/REPLMode.jl
+++ b/stdlib/Pkg/src/REPLMode.jl
@@ -6,8 +6,8 @@ using UUIDs
 import REPL
 import REPL: LineEdit, REPLCompletions
 
-import ..devdir, ..API
-using ..Types, ..Display, ..Operations
+import ..devdir
+using ..Types, ..Display, ..Operations, ..API
 
 ############
 # Commands #
@@ -236,8 +236,8 @@ function do_cmd(repl::REPL.AbstractREPL, input::String; do_rethrow=false)
         if do_rethrow
             rethrow(err)
         end
-        if err isa CommandError
-            Base.display_error(repl.t.err_stream, ErrorException(err.msg), Ptr{Nothing}[])
+        if err isa CommandError || err isa ResolverError
+            Base.display_error(repl.t.err_stream, ErrorException(sprint(showerror, err)), Ptr{Nothing}[])
         else
             Base.display_error(repl.t.err_stream, err, Base.catch_backtrace())
         end

--- a/stdlib/Pkg/src/Types.jl
+++ b/stdlib/Pkg/src/Types.jl
@@ -355,6 +355,7 @@ struct CommandError <: Exception
     msg::String
 end
 cmderror(msg::String...) = throw(CommandError(join(msg)))
+Base.show(io::IO, err::CommandError) = print(io, err.msg)
 
 
 ###############

--- a/stdlib/Pkg/src/generate.jl
+++ b/stdlib/Pkg/src/generate.jl
@@ -47,10 +47,10 @@ function project(pkg::String, dir::String)
     genfile(pkg, dir, "Project.toml") do io
         print(io,
             """
+            authors = $authorstr
             name = "$pkg"
             uuid = "$(UUIDs.uuid1())"
             version = "0.1.0"
-            authors = $authorstr
 
             [deps]
             """

--- a/stdlib/Pkg/test/test_packages/BigProject/Project.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/Project.toml
@@ -1,4 +1,4 @@
-author = "Some One"
+authors = ["Some One <someone@email.com>"]
 name = "BigProject"
 uuid = "da7e1942-2519-11e8-2822-f5508ce758f0"
 version = "0.1.0"

--- a/stdlib/Pkg/test/test_packages/BigProject/SubModule/Project.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/SubModule/Project.toml
@@ -1,6 +1,6 @@
+authors = ["Some One <someone@email.com>"]
 name = "SubModule"
 uuid = "0d404dc8-25d6-11e8-300e-11c8e584fb95"
 version = "0.1.0"
-author = ["Some One"]
 
 [deps]

--- a/stdlib/Pkg/test/test_packages/BigProject/SubModule2/Project.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/SubModule2/Project.toml
@@ -1,6 +1,6 @@
+authors = ["Some One <someone@email.com>"]
 name = "SubModule2"
 uuid = "2d3cad7e-26b9-11e8-3e8d-a543003d541d"
 version = "0.1.0"
-author = ["Some One"]
 
 [deps]

--- a/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/Manifest.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/Manifest.toml
@@ -1,0 +1,8 @@
+[[Example]]
+deps = ["Test"]
+git-tree-sha1 = "8eb7b4d4ca487caade9ba3e85932e28ce6d6e1f8"
+uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
+version = "0.5.1"
+
+[[Test]]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/Project.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/Project.toml
@@ -1,0 +1,7 @@
+authors = ["Some One <someone@email.com>"]
+name = "LibFoo"
+uuid = "22d9ad80-6275-11e8-2737-a9b3d0e63aa9"
+version = "0.1.0"
+
+[deps]
+Example = "7876af07-990d-54b4-ab0e-23690620f79a"

--- a/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/src/LibFoo.jl
+++ b/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/src/LibFoo.jl
@@ -1,0 +1,5 @@
+module LibFoo
+
+greet() = print("Hello World!")
+
+end # module

--- a/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/test/runtests.jl
+++ b/stdlib/Pkg/test/test_packages/BigProject/test/LibFoo.jl/test/runtests.jl
@@ -1,0 +1,4 @@
+using LibFoo
+using Test
+
+@test 1 == 1

--- a/stdlib/Pkg/test/test_packages/BigProject/test/runtests.jl
+++ b/stdlib/Pkg/test/test_packages/BigProject/test/runtests.jl
@@ -4,3 +4,8 @@ using Example
 using BigProject
 
 @test BigProject.f() == 1
+
+# #306 Pkg.jl
+cd("LibFoo.jl") do
+    run(`$(Base.julia_cmd()) test/runtests.jl`)
+end


### PR DESCRIPTION
Some bugfixes:
* Allow using current env when testing: https://github.com/JuliaLang/Pkg.jl/issues/306
* ~Throw error when a package fails to build: https://github.com/JuliaLang/Pkg.jl/issues/297~
* Fixes adding packages with REQUIRE files that specified version bounds as e.g. `0.1.0 0.1.0+`. https://github.com/JuliaLang/Pkg.jl/issues/293
* Fix a problem when the stdlib finder for old packages errors when encountering files with weird permissions. https://github.com/JuliaLang/Pkg.jl/issues/314
* CommandError didn't print properly due to no `show` error being defined
* Fixed a bug that made fixed packages (checked out packages) not have their name in the resolver backtrace. https://github.com/JuliaLang/Pkg.jl/issues/293


Other changes:
* Only updates the registry on the first add of the session. Updating on every add was too much and it is always possible to just use `update`.
* No longer show the backtrace from a resolver error when using the Pkg REPL.