### PR TITLE
parsing Project files should swap state even if state == :deps

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -503,7 +503,8 @@ function explicit_project_deps_get(project_file::String, name::String)::Union{Bo
                 if (m = match(re_key_to_string, line)) != nothing
                     m.captures[1] == name && return UUID(m.captures[2])
                 end
-            elseif occursin(re_section, line)
+            end
+            if occursin(re_section, line)
                 state = occursin(re_section_deps, line) ? :deps : :other
             end
         end


### PR DESCRIPTION
Otherwise we get stuck in the `state == :deps` state forever.

Minimal erroring Project file:

```
[deps]
Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

[compatibility]
Example = "0.2.0"
```

```jl
julia> using Example
ERROR: ArgumentError: Malformed UUID string: "0.2.0"
Stacktrace:
 [1] Base.UUID(::SubString{String}) at ./uuid.jl:34
 [2] (::getfield(Base, Symbol("##664#665")){String,String})(::IOStream) at ./loading.jl:504
 [3] #open#304(::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::Function, ::getfield(Base, Symbol("##664#665")){String,String}, ::String) at ./iostream.jl:369
 [4] open at ./iostream.jl:367 [inlined]
 [5] explicit_project_deps_get(::String, ::String) at ./loading.jl:488
 [6] project_deps_get(::String, ::String) at ./loading.jl:332
 [7] identify_package(::String) at ./loading.jl:267
 [8] identify_package(::Base.PkgId, ::String) at ./loading.jl:256
 [9] identify_package(::Module, ::String) at ./loading.jl:251
 [10] require(::Module, ::Symbol) at ./loading.jl:865
```

Not sure how to best test, @StefanKarpinski probably knows better.