### PR TITLE
allow predicate functions to lstrip etc. and default to stripping unicode whitespace

### DIFF
--- a/base/shell.jl
+++ b/base/shell.jl
@@ -9,7 +9,7 @@ function rstrip_shell(s::AbstractString)
     c_old = nothing
     for (i, c) in Iterators.reverse(pairs(s))
         ((c == '\\') && c_old == ' ') && return SubString(s, 1, i+1)
-        c in _default_delims || return SubString(s, 1, i)
+        isspace(c) || return SubString(s, 1, i)
         c_old = c
     end
     SubString(s, 1, 0)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -134,16 +134,16 @@ function chomp(s::String)
     end
 end
 
-const _default_delims = [' ','\t','\n','\v','\f','\r']
-
 """
-    lstrip(s::AbstractString[, chars::Chars])
+    lstrip(str::AbstractString[, chars])
 
-Return `s` with any leading whitespace and delimiters removed.
-The default delimiters to remove are `' '`, `\\t`, `\\n`, `\\v`,
-`\\f`, and `\\r`.
-If `chars` (a character, or vector or set of characters) is provided,
-instead remove characters contained in it.
+Remove leading characters from `str`.
+
+The default behaviour is to remove leading whitespace and delimiters: see
+[`isspace`](@ref) for precise details.
+
+The optional `chars` argument specifies which characters to remove: it can be a single character,
+vector or set of characters, or a predicate function.
 
 # Examples
 ```jldoctest
@@ -154,22 +154,25 @@ julia> lstrip(a)
 "March"
 ```
 """
-function lstrip(s::AbstractString, chars::Chars=_default_delims)
+function lstrip(s::AbstractString, f=isspace)
     e = lastindex(s)
     for (i, c) in pairs(s)
-        !(c in chars) && return SubString(s, i, e)
+        !f(c) && return SubString(s, i, e)
     end
     SubString(s, e+1, e)
 end
+lstrip(s::AbstractString, chars::Chars) = lstrip(s, in(chars))
 
 """
-    rstrip(s::AbstractString[, chars::Chars])
+    rstrip(str::AbstractString[, chars])
 
-Return `s` with any trailing whitespace and delimiters removed.
-The default delimiters to remove are `' '`, `\\t`, `\\n`, `\\v`,
-`\\f`, and `\\r`.
-If `chars` (a character, or vector or set of characters) is provided,
-instead remove characters contained in it.
+Remove trailing characters from `str`.
+
+The default behaviour is to remove leading whitespace and delimiters: see
+[`isspace`](@ref) for precise details.
+
+The optional `chars` argument specifies which characters to remove: it can be a single character,
+vector or set of characters, or a predicate function.
 
 # Examples
 ```jldoctest
@@ -180,19 +183,24 @@ julia> rstrip(a)
 "March"
 ```
 """
-function rstrip(s::AbstractString, chars::Chars=_default_delims)
+function rstrip(s::AbstractString, f=isspace)
     for (i, c) in Iterators.reverse(pairs(s))
-        c in chars || return SubString(s, 1, i)
+        f(c) || return SubString(s, 1, i)
     end
     SubString(s, 1, 0)
 end
+rstrip(s::AbstractString, chars::Chars) = rstrip(s, in(chars))
 
 """
-    strip(s::AbstractString, [chars::Chars])
+    strip(str::AbstractString, [chars])
 
-Return `s` with any leading and trailing whitespace removed.
-If `chars` (a character, or vector or set of characters) is provided,
-instead remove characters contained in it.
+Remove leading and trailing characters from `str`.
+
+The default behaviour is to remove leading whitespace and delimiters: see
+[`isspace`](@ref) for precise details.
+
+The optional `chars` argument specifies which characters to remove: it can be a single character,
+vector or set of characters, or a predicate function.
 
 # Examples
 ```jldoctest
@@ -201,7 +209,7 @@ julia> strip("{3, 5}\\n", ['{', '}', '\\n'])
 ```
 """
 strip(s::AbstractString) = lstrip(rstrip(s))
-strip(s::AbstractString, chars::Chars) = lstrip(rstrip(s, chars), chars)
+strip(s::AbstractString, chars) = lstrip(rstrip(s, chars), chars)
 
 ## string padding functions ##
 

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -590,7 +590,7 @@ function dlm_parse(dbuff::String, eol::D, dlm::D, qchar::D, cchar::D,
             val,idx = iterate(dbuff, idx)
             if (is_eol = (Char(val) == Char(eol)))
                 is_dlm = is_comment = is_cr = is_quote = false
-            elseif (is_dlm = (is_default_dlm ? in(Char(val), _default_delims) : (Char(val) == Char(dlm))))
+            elseif (is_dlm = (is_default_dlm ? isspace(Char(val)) : (Char(val) == Char(dlm))))
                 is_comment = is_cr = is_quote = false
             elseif (is_quote = (Char(val) == Char(qchar)))
                 is_comment = is_cr = false

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -50,6 +50,7 @@ end
     @test strip("  ") == ""
     @test strip("   ") == ""
     @test strip("\t  hi   \n") == "hi"
+    @test strip(" \u2009 hi \u2009 ") == "hi"
     @test strip("foobarfoo", ['f','o']) == "bar"
     @test strip("foobarfoo", ('f','o')) == "bar"
 


### PR DESCRIPTION
This is similar to #27232, except that the predicate function is the second argument. It does not require any deprecations.

Fixes #27211.