### PR TITLE
inference: re-architect entry points for more clarity

### DIFF
--- a/base/compiler/bootstrap.jl
+++ b/base/compiler/bootstrap.jl
@@ -5,7 +5,7 @@
 # especially try to make sure any recursive and leaf functions have concrete signatures,
 # since we won't be able to specialize & infer them at runtime
 
-let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, optimize, run_passes],
+let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, run_passes],
     world = ccall(:jl_get_world_counter, UInt, ())
     for x in T_FFUNC_VAL
         push!(fs, x[3])
@@ -27,7 +27,7 @@ let fs = Any[typeinf_ext, typeinf, typeinf_edge, pure_eval_call, optimize, run_p
                     typ[i] = typ[i].ub
                 end
             end
-            typeinf_type(m[3], Tuple{typ...}, m[2], true, Params(world))
+            typeinf_type(m[3], Tuple{typ...}, m[2], Params(world))
         end
     end
 end

--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -9,7 +9,7 @@ mutable struct InferenceResult
                        # on the InferenceResult, so that the optimizer can use this info
                        # later during inlining.
     result # ::Type, or InferenceState if WIP
-    src::Union{CodeInfo, Nothing} # if inferred copy is available
+    src #::Union{CodeInfo, OptimizationState, Nothing} # if inferred copy is available
     function InferenceResult(linfo::MethodInstance)
         if isdefined(linfo, :inferred_const)
             result = Const(linfo.inferred_const)

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -30,15 +30,11 @@ mutable struct InferenceState
     # ssavalue sparsity and restart info
     ssavalue_uses::Vector{BitSet}
 
-    backedges::Vector{Tuple{InferenceState, LineNum}} # call-graph backedges connecting from callee to caller
+    cycle_backedges::Vector{Tuple{InferenceState, LineNum}} # call-graph backedges connecting from callee to caller
     callers_in_cycle::Vector{InferenceState}
     parent::Union{Nothing, InferenceState}
 
-    const_api::Bool
-    const_ret::Bool
-
     # TODO: move these to InferenceResult / Params?
-    optimize::Bool
     cached::Bool
     limited::Bool
     inferred::Bool
@@ -46,7 +42,7 @@ mutable struct InferenceState
 
     # src is assumed to be a newly-allocated CodeInfo, that can be modified in-place to contain intermediate results
     function InferenceState(result::InferenceResult, src::CodeInfo,
-                            optimize::Bool, cached::Bool, params::Params)
+                            cached::Bool, params::Params)
         linfo = result.linfo
         code = src.code::Array{Any,1}
         toplevel = !isa(linfo.def, Method)
@@ -105,26 +101,22 @@ mutable struct InferenceState
             Union{}, W, 1, n,
             cur_hand, handler_at, n_handlers,
             ssavalue_uses,
-            Vector{Tuple{InferenceState,LineNum}}(), # backedges
+            Vector{Tuple{InferenceState,LineNum}}(), # cycle_backedges
             Vector{InferenceState}(), # callers_in_cycle
             #=parent=#nothing,
-            false, false, optimize, cached, false, false, false)
+            cached, false, false, false)
         result.result = frame
         cached && push!(params.cache, result)
         return frame
     end
 end
 
-function InferenceState(linfo::MethodInstance, optimize::Bool, cached::Bool, params::Params)
-    return InferenceState(InferenceResult(linfo), optimize, cached, params)
-end
-
-function InferenceState(result::InferenceResult, optimize::Bool, cached::Bool, params::Params)
+function InferenceState(result::InferenceResult, cached::Bool, params::Params)
     # prepare an InferenceState object for inferring lambda
     src = retrieve_code_info(result.linfo)
     src === nothing && return nothing
     validate_code_in_debug_mode(result.linfo, src, "lowered")
-    return InferenceState(result, src, optimize, cached, params)
+    return InferenceState(result, src, cached, params)
 end
 
 function spvals_from_meth_instance(linfo::MethodInstance)
@@ -204,10 +196,10 @@ function record_ssa_assign(ssa_id::Int, @nospecialize(new), frame::InferenceStat
     nothing
 end
 
-function add_backedge!(frame::InferenceState, caller::InferenceState, currpc::Int)
+function add_cycle_backedge!(frame::InferenceState, caller::InferenceState, currpc::Int)
     update_valid_age!(frame, caller)
     backedge = (caller, currpc)
-    contains_is(frame.backedges, backedge) || push!(frame.backedges, backedge)
+    contains_is(frame.cycle_backedges, backedge) || push!(frame.cycle_backedges, backedge)
     return frame
 end
 

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -7,7 +7,7 @@
 mutable struct OptimizationState
     linfo::MethodInstance
     result_vargs::Vector{Any}
-    backedges::Vector{Any}
+    calledges::Vector{Any}
     src::CodeInfo
     mod::Module
     nargs::Int
@@ -15,6 +15,7 @@ mutable struct OptimizationState
     max_valid::UInt
     params::Params
     sp::SimpleVector # static parameters
+    const_api::Bool
     function OptimizationState(frame::InferenceState)
         s_edges = frame.stmt_edges[1]
         if s_edges === ()
@@ -26,7 +27,7 @@ mutable struct OptimizationState
                    s_edges::Vector{Any},
                    src, frame.mod, frame.nargs,
                    frame.min_valid, frame.max_valid,
-                   frame.params, frame.sp)
+                   frame.params, frame.sp, false)
     end
     function OptimizationState(linfo::MethodInstance, src::CodeInfo,
                                params::Params)
@@ -56,8 +57,8 @@ mutable struct OptimizationState
                    s_edges::Vector{Any},
                    src, inmodule, nargs,
                    min_world(linfo), max_world(linfo),
-                   params, spvals_from_meth_instance(linfo))
-    end
+                   params, spvals_from_meth_instance(linfo), false)
+        end
 end
 
 function OptimizationState(linfo::MethodInstance, params::Params)
@@ -65,6 +66,34 @@ function OptimizationState(linfo::MethodInstance, params::Params)
     src === nothing && return nothing
     return OptimizationState(linfo, src, params)
 end
+
+
+#############
+# constants #
+#############
+
+# The slot has uses that are not statically dominated by any assignment
+# This is implied by `SLOT_USEDUNDEF`.
+# If this is not set, all the uses are (statically) dominated by the defs.
+# In particular, if a slot has `AssignedOnce && !StaticUndef`, it is an SSA.
+const SLOT_STATICUNDEF  = 1
+const SLOT_ASSIGNEDONCE = 16 # slot is assigned to only once
+const SLOT_USEDUNDEF    = 32 # slot has uses that might raise UndefVarError
+# const SLOT_CALLED      = 64
+
+const IR_FLAG_INBOUNDS = 0x01
+
+# known affect-free calls (also effect-free)
+const _PURE_BUILTINS = Any[tuple, svec, fieldtype, apply_type, ===, isa, typeof, UnionAll, nfields]
+
+# known effect-free calls (might not be affect-free)
+const _PURE_BUILTINS_VOLATILE = Any[getfield, arrayref, isdefined, Core.sizeof]
+
+const TOP_TUPLE = GlobalRef(Core, :tuple)
+
+#########
+# logic #
+#########
 
 _topmod(sv::OptimizationState) = _topmod(sv.mod)
 
@@ -82,55 +111,12 @@ update_valid_age!(li::MethodInstance, sv::OptimizationState) = update_valid_age!
 
 function add_backedge!(li::MethodInstance, caller::OptimizationState)
     isa(caller.linfo.def, Method) || return # don't add backedges to toplevel exprs
-    push!(caller.backedges, li)
+    push!(caller.calledges, li)
     update_valid_age!(li, caller)
     nothing
 end
 
-###########
-# structs #
-###########
-
-struct InvokeData
-    mt::Core.MethodTable
-    entry::Core.TypeMapEntry
-    types0
-    fexpr
-    texpr
-end
-
-#############
-# constants #
-#############
-
-# The slot has uses that are not statically dominated by any assignment
-# This is implied by `SLOT_USEDUNDEF`.
-# If this is not set, all the uses are (statically) dominated by the defs.
-# In particular, if a slot has `AssignedOnce && !StaticUndef`, it is an SSA.
-const SLOT_STATICUNDEF  = 1
-
-const SLOT_ASSIGNEDONCE = 16 # slot is assigned to only once
-
-const SLOT_USEDUNDEF    = 32 # slot has uses that might raise UndefVarError
-
-# const SLOT_CALLED      = 64
-
-const IR_FLAG_INBOUNDS = 0x01
-
-
-# known affect-free calls (also effect-free)
-const _PURE_BUILTINS = Any[tuple, svec, fieldtype, apply_type, ===, isa, typeof, UnionAll, nfields]
-
-# known effect-free calls (might not be affect-free)
-const _PURE_BUILTINS_VOLATILE = Any[getfield, arrayref, isdefined, Core.sizeof]
-
-const TOP_TUPLE = GlobalRef(Core, :tuple)
-
-#########
-# logic #
-#########
-
-function isinlineable(m::Method, me::InferenceState, bonus::Int=0)
+function isinlineable(m::Method, me::OptimizationState, bonus::Int=0)
     # compute the cost (size) of inlining this code
     inlineable = false
     cost_threshold = me.params.inline_cost_threshold
@@ -153,49 +139,31 @@ function isinlineable(m::Method, me::InferenceState, bonus::Int=0)
     return inlineable
 end
 
-# converge the optimization work
-function optimize(me::InferenceState)
-    # annotate fulltree with type information
-    type_annotate!(me)
+# run the optimization work
+function optimize(opt::OptimizationState, @nospecialize(result))
+    def = opt.linfo.def
+    nargs = Int(opt.nargs) - 1
+    @timeit "optimizer" ir = run_passes(opt.src, nargs, opt)
+    force_noinline = any(x -> isexpr(x, :meta) && x.args[1] == :noinline, ir.meta)
+    replace_code_newstyle!(opt.src, ir, nargs)
 
-    # run optimization passes on fulltree
-    force_noinline = true
-    def = me.linfo.def
-    if me.limited && me.cached && me.parent !== nothing
-        # a top parent will be cached still, but not this intermediate work
-        me.cached = false
-        me.linfo.inInference = false
-    elseif me.optimize
-        opt = OptimizationState(me)
-        nargs = Int(opt.nargs) - 1
-        @timeit "optimizer" ir = run_passes(opt.src, nargs, opt)
-        force_noinline = any(x->isexpr(x, :meta) && x.args[1] == :noinline, ir.meta)
-        replace_code_newstyle!(opt.src, ir, nargs)
-        me.min_valid = opt.min_valid
-        me.max_valid = opt.max_valid
-    end
-
-    # convert all type information into the form consumed by the code-generator
-    widen_all_consts!(me.src)
-
-    # compute inlining and other related properties
-    me.const_ret = (isa(me.bestguess, Const) || isconstType(me.bestguess))
-    if me.const_ret
+    # compute inlining and other related optimizations
+    if (isa(result, Const) || isconstType(result))
         proven_pure = false
         # must be proven pure to use const_api; otherwise we might skip throwing errors
         # (issue #20704)
         # TODO: Improve this analysis; if a function is marked @pure we should really
         # only care about certain errors (e.g. method errors and type errors).
-        if length(me.src.code) < 10
+        if length(opt.src.code) < 10
             proven_pure = true
-            for i in 1:length(me.src.code)
-                if !statement_effect_free(me.src.code[i], me, me.src.ssavaluetypes[i])
+            for i in 1:length(opt.src.code)
+                if !statement_effect_free(opt.src.code[i], opt, opt.src.ssavaluetypes[i])
                     proven_pure = false
                     break
                 end
             end
             if proven_pure
-                for fl in me.src.slotflags
+                for fl in opt.src.slotflags
                     if (fl & SLOT_USEDUNDEF) != 0
                         proven_pure = false
                         break
@@ -204,7 +172,7 @@ function optimize(me::InferenceState)
             end
         end
         if proven_pure
-            me.src.pure = true
+            opt.src.pure = true
         end
 
         if proven_pure && !coverage_enabled()
@@ -214,10 +182,10 @@ function optimize(me::InferenceState)
             # to the `jl_call_method_internal` fast path
             # Still set pure flag to make sure `inference` tests pass
             # and to possibly enable more optimization in the future
-            if !(isa(me.bestguess, Const) && !is_inlineable_constant(me.bestguess.val))
-                me.const_api = true
+            if !(isa(result, Const) && !is_inlineable_constant(result.val))
+                opt.const_api = true
             end
-            force_noinline || (me.src.inlineable = true)
+            force_noinline || (opt.src.inlineable = true)
         end
     end
 
@@ -225,7 +193,7 @@ function optimize(me::InferenceState)
     if !force_noinline
         # don't keep ASTs for functions specialized on a Union argument
         # TODO: this helps avoid a type-system bug mis-computing sparams during intersection
-        sig = unwrap_unionall(me.linfo.specTypes)
+        sig = unwrap_unionall(opt.linfo.specTypes)
         if isa(sig, DataType) && sig.name === Tuple.name
             for P in sig.parameters
                 P = unwrap_unionall(P)
@@ -239,339 +207,20 @@ function optimize(me::InferenceState)
         end
     end
     if force_noinline
-        me.src.inlineable = false
-    elseif !me.src.inlineable && isa(def, Method)
+        opt.src.inlineable = false
+    elseif !opt.src.inlineable && isa(def, Method)
         bonus = 0
-        if me.bestguess ⊑ Tuple && !isbitstype(widenconst(me.bestguess))
-            bonus = me.params.inline_tupleret_bonus
+        if result ⊑ Tuple && !isbitstype(widenconst(result))
+            bonus = opt.params.inline_tupleret_bonus
         end
-        me.src.inlineable = isinlineable(def, me, bonus)
-    end
-    me.src.inferred = true
-    if me.optimize && !(me.limited && me.parent !== nothing)
-        validate_code_in_debug_mode(me.linfo, me.src, "optimized")
+        opt.src.inlineable = isinlineable(def, opt, bonus)
     end
     nothing
 end
 
-# inference completed on `me`
-# update the MethodInstance and notify the edges
-function finish(me::InferenceState)
-    if me.cached
-        toplevel = !isa(me.linfo.def, Method)
-        if !toplevel
-            min_valid = me.min_valid
-            max_valid = me.max_valid
-        else
-            min_valid = UInt(0)
-            max_valid = UInt(0)
-        end
 
-        # check if the existing me.linfo metadata is also sufficient to describe the current inference result
-        # to decide if it is worth caching it again (which would also clear any generated code)
-        already_inferred = !me.linfo.inInference
-        if isdefined(me.linfo, :inferred)
-            inf = me.linfo.inferred
-            if !isa(inf, CodeInfo) || (inf::CodeInfo).inferred
-                if min_world(me.linfo) == min_valid && max_world(me.linfo) == max_valid
-                    already_inferred = true
-                end
-            end
-        end
-
-        # don't store inferred code if we've decided to interpret this function
-        if !already_inferred && invoke_api(me.linfo) != 4
-            const_flags = (me.const_ret) << 1 | me.const_api
-            if me.const_ret
-                if isa(me.bestguess, Const)
-                    inferred_const = (me.bestguess::Const).val
-                else
-                    @assert isconstType(me.bestguess)
-                    inferred_const = me.bestguess.parameters[1]
-                end
-            else
-                inferred_const = nothing
-            end
-            if me.const_api
-                # use constant calling convention
-                inferred_result = nothing
-            else
-                inferred_result = me.src
-            end
-
-            if !toplevel
-                if !me.const_api
-                    def = me.linfo.def::Method
-                    keeptree = me.optimize &&
-                        (me.src.inlineable ||
-                         ccall(:jl_isa_compileable_sig, Int32, (Any, Any), me.linfo.specTypes, def) != 0)
-                    if keeptree
-                        # compress code for non-toplevel thunks
-                        inferred_result = ccall(:jl_compress_ast, Any, (Any, Any), def, inferred_result)
-                    else
-                        inferred_result = nothing
-                    end
-                end
-            end
-            cache = ccall(:jl_set_method_inferred, Ref{MethodInstance}, (Any, Any, Any, Any, Int32, UInt, UInt),
-                me.linfo, widenconst(me.bestguess), inferred_const, inferred_result,
-                const_flags, min_valid, max_valid)
-            if cache !== me.linfo
-                me.linfo.inInference = false
-                me.linfo = cache
-                me.result.linfo = cache
-            end
-        end
-        me.linfo.inInference = false
-    end
-
-    # finish updating the result struct
-    if me.src.inlineable
-        me.result.src = me.src # stash a copy of the code (for inlining)
-    end
-    me.result.result = me.bestguess # record type, and that wip is done and me.linfo can be used as a backedge
-
-    # update all of the callers with real backedges by traversing the temporary list of backedges
-    for (i, _) in me.backedges
-        add_backedge!(me.linfo, i)
-    end
-
-    # finalize and record the linfo result
-    me.inferred = true
-    nothing
-end
-
-maybe_widen_conditional(@nospecialize vt) = vt
-function maybe_widen_conditional(vt::Conditional)
-    if vt.vtype === Bottom
-        Const(false)
-    elseif vt.elsetype === Bottom
-        Const(true)
-    else
-        Bool
-    end
-end
-
-function annotate_slot_load!(e::Expr, vtypes::VarTable, sv::InferenceState, undefs::Array{Bool,1})
-    head = e.head
-    i0 = 1
-    if is_meta_expr_head(head) || head === :const
-        return
-    end
-    if head === :(=) || head === :method
-        i0 = 2
-    end
-    for i = i0:length(e.args)
-        subex = e.args[i]
-        if isa(subex, Expr)
-            annotate_slot_load!(subex, vtypes, sv, undefs)
-        elseif isa(subex, Slot)
-            e.args[i] = visit_slot_load!(subex, vtypes, sv, undefs)
-        end
-    end
-end
-
-function visit_slot_load!(sl::Slot, vtypes::VarTable, sv::InferenceState, undefs::Array{Bool,1})
-    id = slot_id(sl)
-    s = vtypes[id]
-    vt = maybe_widen_conditional(s.typ)
-    if s.undef
-        # find used-undef variables
-        undefs[id] = true
-    end
-    # add type annotations where needed
-    if !(sv.src.slottypes[id] ⊑ vt)
-        return TypedSlot(id, vt)
-    end
-    return sl
-end
-
-function record_slot_assign!(sv::InferenceState)
-    # look at all assignments to slots
-    # and union the set of types stored there
-    # to compute a lower bound on the storage required
-    states = sv.stmt_types
-    body = sv.src.code::Vector{Any}
-    slottypes = sv.src.slottypes::Vector{Any}
-    for i = 1:length(body)
-        expr = body[i]
-        st_i = states[i]
-        # find all reachable assignments to locals
-        if isa(st_i, VarTable) && isa(expr, Expr) && expr.head === :(=)
-            lhs = expr.args[1]
-            rhs = expr.args[2]
-            if isa(lhs, Slot)
-                vt = widenconst(sv.src.ssavaluetypes[i])
-                if vt !== Bottom
-                    id = slot_id(lhs)
-                    otherTy = slottypes[id]
-                    if otherTy === Bottom
-                        slottypes[id] = vt
-                    elseif otherTy === Any
-                        slottypes[id] = Any
-                    else
-                        slottypes[id] = tmerge(otherTy, vt)
-                    end
-                end
-            end
-        end
-    end
-end
-
-# annotate types of all symbols in AST
-function type_annotate!(sv::InferenceState)
-    # remove all unused ssa values
-    gt = sv.src.ssavaluetypes
-    for j = 1:length(gt)
-        if gt[j] === NOT_FOUND
-            gt[j] = Union{}
-        end
-        gt[j] = maybe_widen_conditional(gt[j])
-    end
-
-    # compute the required type for each slot
-    # to hold all of the items assigned into it
-    record_slot_assign!(sv)
-
-    # annotate variables load types
-    # remove dead code
-    # and compute which variables may be used undef
-    src = sv.src
-    states = sv.stmt_types
-    nargs = sv.nargs
-    nslots = length(states[1])
-    undefs = fill(false, nslots)
-    body = src.code::Array{Any,1}
-    nexpr = length(body)
-
-    # replace gotoifnot with its condition if the branch target is unreachable
-    for i = 1:nexpr
-        expr = body[i]
-        if isa(expr, Expr) && expr.head === :gotoifnot
-            tgt = expr.args[2]::Int
-            if !isa(states[tgt], VarTable)
-                body[i] = expr.args[1]
-            end
-        end
-    end
-
-    i = 1
-    oldidx = 0
-    changemap = fill(0, nexpr)
-
-    while i <= nexpr
-        oldidx += 1
-        st_i = states[i]
-        expr = body[i]
-        if isa(st_i, VarTable)
-            # st_i === ()  =>  unreached statement  (see issue #7836)
-            if isa(expr, Expr)
-                annotate_slot_load!(expr, st_i, sv, undefs)
-            elseif isa(expr, Slot)
-                body[i] = visit_slot_load!(expr, st_i, sv, undefs)
-            end
-        elseif sv.optimize
-            if isa(expr, Expr) && is_meta_expr(expr)
-                # keep any lexically scoped expressions
-            else
-                deleteat!(body, i)
-                deleteat!(states, i)
-                deleteat!(src.ssavaluetypes, i)
-                deleteat!(src.codelocs, i)
-                nexpr -= 1
-                if oldidx < length(changemap)
-                    changemap[oldidx+1] = -1
-                end
-                continue
-            end
-        end
-        i += 1
-    end
-
-    for i = 2:length(changemap)
-        changemap[i] += changemap[i-1]
-    end
-    if changemap[end] != 0
-        renumber_stuff!(body, changemap)
-    end
-
-    # finish marking used-undef variables
-    for j = 1:nslots
-        if undefs[j]
-            src.slotflags[j] |= SLOT_USEDUNDEF | SLOT_STATICUNDEF
-        end
-    end
-    nothing
-end
-
-# widen all Const elements in type annotations
-function _widen_all_consts!(e::Expr, untypedload::Vector{Bool}, slottypes::Vector{Any})
-    for i = 1:length(e.args)
-        x = e.args[i]
-        if isa(x, Expr)
-            _widen_all_consts!(x, untypedload, slottypes)
-        elseif isa(x, TypedSlot)
-            vt = widenconst(x.typ)
-            if !(vt === x.typ)
-                if slottypes[x.id] ⊑ vt
-                    x = SlotNumber(x.id)
-                    untypedload[x.id] = true
-                else
-                    x = TypedSlot(x.id, vt)
-                end
-                e.args[i] = x
-            end
-        elseif isa(x, PiNode)
-            e.args[i] = PiNode(x.val, widenconst(x.typ))
-        elseif isa(x, SlotNumber) && (i != 1 || e.head !== :(=))
-            untypedload[x.id] = true
-        end
-    end
-    nothing
-end
-
-function widen_all_consts!(src::CodeInfo)
-    for i = 1:length(src.ssavaluetypes)
-        src.ssavaluetypes[i] = widenconst(src.ssavaluetypes[i])
-    end
-    for i = 1:length(src.slottypes)
-        src.slottypes[i] = widenconst(src.slottypes[i])
-    end
-
-    nslots = length(src.slottypes)
-    untypedload = fill(false, nslots)
-    e = Expr(:body)
-    e.args = src.code
-    _widen_all_consts!(e, untypedload, src.slottypes)
-    for i = 1:nslots
-        src.slottypes[i] = widen_slot_type(src.slottypes[i], untypedload[i])
-    end
-    return src
-end
-
-# widen all slots to their optimal storage layout
-# we also need to preserve the type for any untyped load of a DataType
-# since codegen optimizations of functions like `is` will depend on knowing it
-function widen_slot_type(@nospecialize(ty), untypedload::Bool)
-    if isa(ty, DataType)
-        if untypedload || isbitstype(ty) || isdefined(ty, :instance)
-            return ty
-        end
-    elseif isa(ty, Union)
-        ty_a = widen_slot_type(ty.a, false)
-        ty_b = widen_slot_type(ty.b, false)
-        if ty_a !== Any || ty_b !== Any
-            # TODO: better optimized codegen for unions?
-            return ty
-        end
-    elseif isa(ty, UnionAll)
-        if untypedload
-            return ty
-        end
-    end
-    return Any
-end
-
+# NOTE: this dead code is left in place due to external consumers
+#   to allow them time to move this code elsewhere. It also has tests.
 # replace slots 1:na with argexprs, static params with spvals, and increment
 # other slots by offset.
 function substitute!(
@@ -658,6 +307,7 @@ function substitute!(
     return e
 end
 
+
 # whether `f` is pure for inference
 function is_pure_intrinsic_infer(f::IntrinsicFunction)
     return !(f === Intrinsics.pointerref || # this one is volatile
@@ -692,7 +342,7 @@ function is_pure_builtin(@nospecialize(f))
     end
 end
 
-function statement_effect_free(@nospecialize(e), me::InferenceState, @nospecialize(etype))
+function statement_effect_free(@nospecialize(e), me::OptimizationState, @nospecialize(etype))
     if isa(e, Expr)
         if e.head === :(=)
             return !isa(e.args[1], GlobalRef) && effect_free(e.args[2], me, false, etype)
@@ -804,16 +454,6 @@ function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile
         return false
     end
     return true
-end
-
-function countunionsplit(atypes)
-    nu = 1
-    for ti in atypes
-        if isa(ti, Union)
-            nu *= unionlen(ti::Union)
-        end
-    end
-    return nu
 end
 
 ## Computing the cost of a function body
@@ -962,27 +602,6 @@ function renumber_stuff!(body::Vector{Any}, changemap::Vector{Int})
             end
         end
     end
-end
-
-function return_type(@nospecialize(f), @nospecialize(t))
-    params = Params(ccall(:jl_get_tls_world_age, UInt, ()))
-    rt = Union{}
-    if isa(f, Builtin)
-        rt = builtin_tfunction(f, Any[t.parameters...], nothing, params)
-        if isa(rt, TypeVar)
-            rt = rt.ub
-        else
-            rt = widenconst(rt)
-        end
-    else
-        for m in _methods(f, t, -1, params.world)
-            ty = typeinf_type(m[3], m[1], m[2], true, params)
-            ty === nothing && return Any
-            rt = tmerge(rt, ty)
-            rt === Any && break
-        end
-    end
-    return rt
 end
 
 include("compiler/ssair/driver.jl")

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -219,95 +219,6 @@ function optimize(opt::OptimizationState, @nospecialize(result))
 end
 
 
-# NOTE: this dead code is left in place due to external consumers
-#   to allow them time to move this code elsewhere. It also has tests.
-# replace slots 1:na with argexprs, static params with spvals, and increment
-# other slots by offset.
-function substitute!(
-        @nospecialize(e), na::Int, argexprs::Vector{Any},
-        @nospecialize(spsig), spvals::Vector{Any},
-        offset::Int, boundscheck::Symbol)
-    if isa(e, Slot)
-        id = slot_id(e)
-        if 1 <= id <= na
-            ae = argexprs[id]
-            if isa(e, TypedSlot) && isa(ae, Slot)
-                return TypedSlot(ae.id, e.typ)
-            end
-            return ae
-        end
-        if isa(e, SlotNumber)
-            return SlotNumber(id + offset)
-        else
-            return TypedSlot(id + offset, e.typ)
-        end
-    end
-    if isa(e, NewvarNode)
-        return NewvarNode(substitute!(e.slot, na, argexprs, spsig, spvals, offset, boundscheck))
-    end
-    if isa(e, PhiNode)
-        values = Vector{Any}(undef, length(e.values))
-        for i = 1:length(values)
-            isassigned(e.values, i) || continue
-            values[i] = substitute!(e.values[i], na, argexprs, spsig,
-                spvals, offset, boundscheck)
-        end
-        return PhiNode(e.edges, values)
-    end
-    if isa(e, PiNode)
-        return PiNode(substitute!(e.val, na, argexprs, spsig, spvals, offset, boundscheck), e.typ)
-    end
-    if isa(e, Expr)
-        e = e::Expr
-        head = e.head
-        if head === :static_parameter
-            return quoted(spvals[e.args[1]])
-        elseif head === :cfunction
-            @assert !isa(spsig, UnionAll) || !isempty(spvals)
-            if !(e.args[2] isa QuoteNode) # very common no-op
-                e.args[2] = substitute!(e.args[2], na, argexprs, spsig, spvals, offset, boundscheck)
-            end
-            e.args[3] = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), e.args[3], spsig, spvals)
-            e.args[4] = svec(Any[
-                ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), argt, spsig, spvals)
-                for argt
-                in e.args[4] ]...)
-        elseif head === :foreigncall
-            @assert !isa(spsig, UnionAll) || !isempty(spvals)
-            for i = 1:length(e.args)
-                if i == 2
-                    e.args[2] = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), e.args[2], spsig, spvals)
-                elseif i == 3
-                    e.args[3] = svec(Any[
-                        ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), argt, spsig, spvals)
-                        for argt
-                        in e.args[3] ]...)
-                elseif i == 4
-                    @assert isa((e.args[4]::QuoteNode).value, Symbol)
-                elseif i == 5
-                    @assert isa(e.args[5], Int)
-                else
-                    e.args[i] = substitute!(e.args[i], na, argexprs, spsig, spvals, offset, boundscheck)
-                end
-            end
-        elseif head === :boundscheck
-            if boundscheck === :propagate
-                return e
-            elseif boundscheck === :off
-                return false
-            else
-                return true
-            end
-        elseif !is_meta_expr_head(head)
-            for i = 1:length(e.args)
-                e.args[i] = substitute!(e.args[i], na, argexprs, spsig, spvals, offset, boundscheck)
-            end
-        end
-    end
-    return e
-end
-
-
 # whether `f` is pure for inference
 function is_pure_intrinsic_infer(f::IntrinsicFunction)
     return !(f === Intrinsics.pointerref || # this one is volatile
@@ -466,7 +377,7 @@ isknowntype(@nospecialize T) = (T == Union{}) || isconcretetype(T)
 
 function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector, params::Params)
     head = ex.head
-    if is_meta_expr(ex) || head == :copyast # not sure if copyast is right
+    if is_meta_expr_head(head) || head == :copyast # not sure if copyast is right
         return 0
     end
     argcost = 0

--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -3,6 +3,7 @@
 struct Params
     cache::Vector{InferenceResult}
     world::UInt
+    global_cache::Bool
 
     # optimization
     inlining::Bool
@@ -35,20 +36,34 @@ struct Params
     MAX_TUPLE_SPLAT::Int
 
     # reasonable defaults
-    function Params(world::UInt;
+    global function CustomParams(world::UInt,
+                    ;
                     inlining::Bool = inlining_enabled(),
-                    inline_cost_threshold::Int = 100,
-                    inline_nonleaf_penalty::Int = 1000,
-                    inline_tupleret_bonus::Int = 400,
-                    max_methods::Int = 4,
-                    tupletype_len::Int = 15,
-                    tupletype_depth::Int = 3,
-                    tuple_splat::Int = 16,
-                    union_splitting::Int = 4,
-                    apply_union_enum::Int = 8)
+                    inline_cost_threshold::Int = DEFAULT_PARAMS.inline_cost_threshold,
+                    inline_nonleaf_penalty::Int = DEFAULT_PARAMS.inline_nonleaf_penalty,
+                    inline_tupleret_bonus::Int = DEFAULT_PARAMS.inline_tupleret_bonus,
+                    max_methods::Int = DEFAULT_PARAMS.MAX_METHODS,
+                    tupletype_len::Int = DEFAULT_PARAMS.MAX_TUPLETYPE_LEN,
+                    tupletype_depth::Int = DEFAULT_PARAMS.TUPLE_COMPLEXITY_LIMIT_DEPTH,
+                    tuple_splat::Int = DEFAULT_PARAMS.MAX_TUPLE_SPLAT,
+                    union_splitting::Int = DEFAULT_PARAMS.MAX_UNION_SPLITTING,
+                    apply_union_enum::Int = DEFAULT_PARAMS.MAX_APPLY_UNION_ENUM)
         return new(Vector{InferenceResult}(),
-                   world, inlining, true, false, inline_cost_threshold, inline_nonleaf_penalty,
+                   world, false,
+                   inlining, true, false, inline_cost_threshold, inline_nonleaf_penalty,
                    inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum,
                    tupletype_len, tupletype_depth, tuple_splat)
     end
+    function Params(world::UInt)
+        inlining = inlining_enabled()
+        return new(Vector{InferenceResult}(),
+                   world, true,
+                   #=inlining, ipo_constant_propagation, aggressive_constant_propagation, inline_cost_threshold, inline_nonleaf_penalty,=#
+                   inlining, true, false, 100, 1000,
+                   #=inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum=#
+                   400, 4, 4, 8,
+                   #=tupletype_len, tupletype_depth, tuple_splat=#
+                   15, 3, 16)
+    end
 end
+const DEFAULT_PARAMS = Params(UInt(0))

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -1,5 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+struct InvokeData
+    mt::Core.MethodTable
+    entry::Core.TypeMapEntry
+    types0
+end
+
 struct InliningTodo
     idx::Int # The statement to replace
     # Properties of the call - these determine how arguments
@@ -984,10 +990,9 @@ function compute_invoke_data(@nospecialize(atypes), argexprs::Vector{Any}, sv::O
     invoke_tt = invoke_tt.parameters[1]
     invoke_types = rewrap_unionall(Tuple{ft, unwrap_unionall(invoke_tt).parameters...}, invoke_tt)
     invoke_entry = ccall(:jl_gf_invoke_lookup, Any, (Any, UInt),
-                            invoke_types, sv.params.world)
+                         invoke_types, sv.params.world)
     invoke_entry === nothing && return nothing
-    invoke_data = InvokeData(mt, invoke_entry,
-                             invoke_types, nothing, nothing)
+    invoke_data = InvokeData(mt, invoke_entry, invoke_types)
     atype0 = atypes[2]
     argexpr0 = argexprs[2]
     atypes = atypes[4:end]

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -18,7 +18,8 @@ print_ssa(io::IO, val::Argument, argnames) = Base.print(io, isempty(argnames) ? 
 print_ssa(io::IO, val::GlobalRef, argnames) = Base.print(io, val)
 print_ssa(io::IO, @nospecialize(val), argnames) = Base.show(io, val)
 
-function print_node(io::IO, idx, stmt, used, argnames, maxsize; color = true, print_typ=true)
+
+function print_node(io::IO, idx::Int, @nospecialize(stmt), used, argnames, maxsize; color = true, print_typ=true)
     if idx in used
         pad = " "^(maxsize-length(string(idx)))
         Base.print(io, "%$idx $pad= ")
@@ -91,17 +92,17 @@ function print_node(io::IO, idx, stmt, used, argnames, maxsize; color = true, pr
     end
 end
 
-function compute_inlining_depth(linetable, iline)
+function compute_inlining_depth(linetable, iline::Int)
     depth = 0
     while iline != 0
         linetable[iline].inlined_at == 0 && break
         depth += 1
         iline = linetable[iline].inlined_at
     end
-    depth
+    return depth
 end
 
-function should_print_ssa_type(node)
+function should_print_ssa_type(@nospecialize node)
     if isa(node, Expr)
         return !(node.head in (:gc_preserve_begin, :gc_preserve_end))
     end
@@ -109,16 +110,17 @@ function should_print_ssa_type(node)
            !isa(node, GotoNode) && !isa(node, ReturnNode)
 end
 
-function default_expr_type_printer(io, typ)
+function default_expr_type_printer(io::IO, @nospecialize typ)
     typ_str = try
         string(typ)
     catch
         "<error_printing>"
     end
     Base.printstyled(io, "::$(typ_str)", color=:cyan)
+    nothing
 end
 
-function compute_loc_stack(code, line)
+function compute_loc_stack(code::IRCode, line::Int)
     stack = []
     line === 0 && return stack
     inlined_at = code.linetable[line].inlined_at
@@ -132,6 +134,7 @@ function compute_loc_stack(code, line)
         reverse!(stack)
     end
     push!(stack, line)
+    return stack
 end
 
 """
@@ -274,7 +277,7 @@ function compute_ir_line_annotations(code::IRCode)
         last_line = line
         (lineno != 0) && (last_lineno = lineno)
     end
-    (loc_annotations, loc_methods, loc_lineno)
+    return (loc_annotations, loc_methods, loc_lineno)
 end
 
 Base.show(io::IO, code::IRCode) = show_ir(io, code)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -2,11 +2,193 @@
 
 const COMPILER_TEMP_SYM = Symbol("#temp#")
 
+# build (and start inferring) the inference frame for the linfo
+function typeinf(result::InferenceResult, cached::Bool, params::Params)
+    frame = InferenceState(result, cached, params)
+    frame === nothing && return false
+    cached && (result.linfo.inInference = true)
+    return typeinf(frame)
+end
+
+function typeinf(frame::InferenceState)
+    cached = frame.cached
+    typeinf_nocycle(frame) || return false # frame is now part of a higher cycle
+    # with no active ip's, frame is done
+    frames = frame.callers_in_cycle
+    isempty(frames) && push!(frames, frame)
+    for caller in frames
+        @assert !(caller.dont_work_on_me)
+        caller.dont_work_on_me = true
+    end
+    for caller in frames
+        finish(caller)
+    end
+    # collect results for the new expanded frame
+    results = InferenceResult[ frames[i].result for i in 1:length(frames) ]
+    # empty!(frames)
+    min_valid = frame.min_valid
+    max_valid = frame.max_valid
+    if cached || frame.parent !== nothing
+        for caller in results
+            opt = caller.src
+            if opt isa OptimizationState
+                optimize(opt, caller.result)
+                finish(opt.src)
+                # finish updating the result struct
+                validate_code_in_debug_mode(opt.linfo, opt.src, "optimized")
+                if opt.const_api
+                    if caller.result isa Const
+                        caller.src = caller.result
+                    else
+                        @assert isconstType(caller.result)
+                        caller.src = Const(caller.result.parameters[1])
+                    end
+                elseif opt.src.inferred
+                    caller.src = opt.src::CodeInfo # stash a copy of the code (for inlining)
+                else
+                    caller.src = nothing
+                end
+                if min_valid < opt.min_valid
+                    min_valid = opt.min_valid
+                end
+                if max_valid > opt.max_valid
+                    max_valid = opt.max_valid
+                end
+            end
+        end
+        if cached
+            for caller in results
+                cache_result(caller, min_valid, max_valid)
+            end
+        end
+    end
+    # if we aren't cached, we don't need this edge
+    # but our caller might, so let's just make it anyways
+    for caller in frames
+        finalize_backedges(caller)
+    end
+    if max_valid == typemax(UInt)
+        for caller in frames
+            store_backedges(caller)
+        end
+    end
+    return true
+end
+
+# inference completed on `me`
+# update the MethodInstance and notify the edges
+function cache_result(result::InferenceResult, min_valid::UInt, max_valid::UInt)
+    def = result.linfo.def
+    toplevel = !isa(result.linfo.def, Method)
+    if toplevel
+        min_valid = UInt(0)
+        max_valid = UInt(0)
+    end
+
+    # check if the existing linfo metadata is also sufficient to describe the current inference result
+    # to decide if it is worth caching it again (which would also clear any generated code)
+    already_inferred = !result.linfo.inInference
+    if isdefined(result.linfo, :inferred)
+        inf = result.linfo.inferred
+        if !isa(inf, CodeInfo) || (inf::CodeInfo).inferred
+            if min_world(result.linfo) == min_valid && max_world(result.linfo) == max_valid
+                already_inferred = true
+            end
+        end
+    end
+
+    # don't store inferred code if we've decided to interpret this function
+    if !already_inferred && invoke_api(result.linfo) != 4
+        inferred_result = result.src
+        if inferred_result isa Const
+            # use constant calling convention
+            inferred_const = (result.src::Const).val
+            const_flags = 0x3
+        else
+            if isa(result.result, Const)
+                inferred_const = (result.result::Const).val
+                const_flags = 0x2
+            elseif isconstType(result.result)
+                inferred_const = result.result.parameters[1]
+                const_flags = 0x2
+            else
+                inferred_const = nothing
+                const_flags = 0x00
+            end
+            if !toplevel && inferred_result isa CodeInfo
+                cache_the_tree = result.src.inferred &&
+                    (result.src.inlineable ||
+                     ccall(:jl_isa_compileable_sig, Int32, (Any, Any), result.linfo.specTypes, def) != 0)
+                if cache_the_tree
+                    # compress code for non-toplevel thunks
+                    inferred_result = ccall(:jl_compress_ast, Any, (Any, Any), def, inferred_result)
+                else
+                    inferred_result = nothing
+                end
+            end
+        end
+        if !isa(inferred_result, Union{CodeInfo, Vector{UInt8}})
+            inferred_result = nothing
+        end
+        cache = ccall(:jl_set_method_inferred, Ref{MethodInstance}, (Any, Any, Any, Any, Int32, UInt, UInt),
+            result.linfo, widenconst(result.result), inferred_const, inferred_result,
+            const_flags, min_valid, max_valid)
+        if cache !== result.linfo
+            result.linfo.inInference = false
+            result.linfo = cache
+        end
+    end
+    result.linfo.inInference = false
+    nothing
+end
+
+function finish(me::InferenceState)
+    # prepare to run optimization passes on fulltree
+    if me.limited && me.cached && me.parent !== nothing
+        # a top parent will be cached still, but not this intermediate work
+        # we can throw everything else away now
+        me.cached = false
+        me.linfo.inInference = false
+        me.src.inlineable = false
+    else
+        # annotate fulltree with type information
+        type_annotate!(me)
+        run_optimizer = (me.cached || me.parent !== nothing)
+        if run_optimizer
+            # construct the optimizer for later use, if we're building this IR to cache it
+            # (otherwise, we'll run the optimization passes later, outside of inference)
+            opt = OptimizationState(me)
+            me.result.src = opt
+        end
+    end
+    me.result.result = me.bestguess
+    nothing
+end
+
+function finish(src::CodeInfo)
+    # convert all type information into the form consumed by the cache for inlining and code-generation
+    widen_all_consts!(src)
+    src.inferred = true
+    nothing
+end
+
+function finalize_backedges(me::InferenceState)
+    # update all of the (cycle) callers with real backedges
+    # by traversing the temporary list of backedges
+    for (i, _) in me.cycle_backedges
+        add_backedge!(me.linfo, i)
+    end
+
+    # finalize and record the linfo result
+    me.inferred = true
+    nothing
+end
+
 # add the real backedges
-function finalize_backedges(frame::InferenceState)
+function store_backedges(frame::InferenceState)
     toplevel = !isa(frame.linfo.def, Method)
-    if !toplevel && (frame.cached || frame.parent !== nothing) && frame.max_valid == typemax(UInt)
-        caller = frame.linfo
+    if !toplevel && (frame.cached || frame.parent !== nothing)
+        caller = frame.result.linfo
         for edges in frame.stmt_edges
             i = 1
             while i <= length(edges)
@@ -23,6 +205,245 @@ function finalize_backedges(frame::InferenceState)
             end
         end
     end
+end
+
+# widen all Const elements in type annotations
+function _widen_all_consts!(e::Expr, untypedload::Vector{Bool}, slottypes::Vector{Any})
+    for i = 1:length(e.args)
+        x = e.args[i]
+        if isa(x, Expr)
+            _widen_all_consts!(x, untypedload, slottypes)
+        elseif isa(x, TypedSlot)
+            vt = widenconst(x.typ)
+            if !(vt === x.typ)
+                if slottypes[x.id] ⊑ vt
+                    x = SlotNumber(x.id)
+                    untypedload[x.id] = true
+                else
+                    x = TypedSlot(x.id, vt)
+                end
+                e.args[i] = x
+            end
+        elseif isa(x, PiNode)
+            e.args[i] = PiNode(x.val, widenconst(x.typ))
+        elseif isa(x, SlotNumber) && (i != 1 || e.head !== :(=))
+            untypedload[x.id] = true
+        end
+    end
+    nothing
+end
+
+function widen_all_consts!(src::CodeInfo)
+    for i = 1:length(src.ssavaluetypes)
+        src.ssavaluetypes[i] = widenconst(src.ssavaluetypes[i])
+    end
+    for i = 1:length(src.slottypes)
+        src.slottypes[i] = widenconst(src.slottypes[i])
+    end
+
+    nslots = length(src.slottypes)
+    untypedload = fill(false, nslots)
+    e = Expr(:body)
+    e.args = src.code
+    _widen_all_consts!(e, untypedload, src.slottypes)
+    for i = 1:nslots
+        src.slottypes[i] = widen_slot_type(src.slottypes[i], untypedload[i])
+    end
+    return src
+end
+
+# widen all slots to their optimal storage layout
+# we also need to preserve the type for any untyped load of a DataType
+# since codegen optimizations of functions like `is` will depend on knowing it
+function widen_slot_type(@nospecialize(ty), untypedload::Bool)
+    if isa(ty, DataType)
+        if untypedload || isbitstype(ty) || isdefined(ty, :instance)
+            return ty
+        end
+    elseif isa(ty, Union)
+        ty_a = widen_slot_type(ty.a, false)
+        ty_b = widen_slot_type(ty.b, false)
+        if ty_a !== Any || ty_b !== Any
+            # TODO: better optimized codegen for unions?
+            return ty
+        end
+    elseif isa(ty, UnionAll)
+        if untypedload
+            return ty
+        end
+    end
+    return Any
+end
+
+maybe_widen_conditional(@nospecialize vt) = vt
+function maybe_widen_conditional(vt::Conditional)
+    if vt.vtype === Bottom
+        return Const(false)
+    elseif vt.elsetype === Bottom
+        return Const(true)
+    else
+        return Bool
+    end
+end
+
+function annotate_slot_load!(e::Expr, vtypes::VarTable, sv::InferenceState, undefs::Array{Bool,1})
+    head = e.head
+    i0 = 1
+    if is_meta_expr_head(head) || head === :const
+        return
+    end
+    if head === :(=) || head === :method
+        i0 = 2
+    end
+    for i = i0:length(e.args)
+        subex = e.args[i]
+        if isa(subex, Expr)
+            annotate_slot_load!(subex, vtypes, sv, undefs)
+        elseif isa(subex, Slot)
+            e.args[i] = visit_slot_load!(subex, vtypes, sv, undefs)
+        end
+    end
+end
+
+function visit_slot_load!(sl::Slot, vtypes::VarTable, sv::InferenceState, undefs::Array{Bool,1})
+    id = slot_id(sl)
+    s = vtypes[id]
+    vt = maybe_widen_conditional(s.typ)
+    if s.undef
+        # find used-undef variables
+        undefs[id] = true
+    end
+    # add type annotations where needed
+    if !(sv.src.slottypes[id] ⊑ vt)
+        return TypedSlot(id, vt)
+    end
+    return sl
+end
+
+function record_slot_assign!(sv::InferenceState)
+    # look at all assignments to slots
+    # and union the set of types stored there
+    # to compute a lower bound on the storage required
+    states = sv.stmt_types
+    body = sv.src.code::Vector{Any}
+    slottypes = sv.src.slottypes::Vector{Any}
+    for i = 1:length(body)
+        expr = body[i]
+        st_i = states[i]
+        # find all reachable assignments to locals
+        if isa(st_i, VarTable) && isa(expr, Expr) && expr.head === :(=)
+            lhs = expr.args[1]
+            rhs = expr.args[2]
+            if isa(lhs, Slot)
+                vt = widenconst(sv.src.ssavaluetypes[i])
+                if vt !== Bottom
+                    id = slot_id(lhs)
+                    otherTy = slottypes[id]
+                    if otherTy === Bottom
+                        slottypes[id] = vt
+                    elseif otherTy === Any
+                        slottypes[id] = Any
+                    else
+                        slottypes[id] = tmerge(otherTy, vt)
+                    end
+                end
+            end
+        end
+    end
+end
+
+# annotate types of all symbols in AST
+function type_annotate!(sv::InferenceState)
+    # delete dead statements only if we're building this IR to cache it
+    # (otherwise, we'll run the optimization passes later, outside of inference)
+    run_optimizer = (sv.cached || sv.parent !== nothing)
+
+    # remove all unused ssa values
+    gt = sv.src.ssavaluetypes
+    for j = 1:length(gt)
+        if gt[j] === NOT_FOUND
+            gt[j] = Union{}
+        end
+        gt[j] = maybe_widen_conditional(gt[j])
+    end
+
+    # compute the required type for each slot
+    # to hold all of the items assigned into it
+    record_slot_assign!(sv)
+
+    # annotate variables load types
+    # remove dead code optimization
+    # and compute which variables may be used undef
+    src = sv.src
+    states = sv.stmt_types
+    nargs = sv.nargs
+    nslots = length(states[1])
+    undefs = fill(false, nslots)
+    body = src.code::Array{Any,1}
+    nexpr = length(body)
+
+    # replace gotoifnot with its condition if the branch target is unreachable
+    for i = 1:nexpr
+        expr = body[i]
+        if isa(expr, Expr) && expr.head === :gotoifnot
+            tgt = expr.args[2]::Int
+            if !isa(states[tgt], VarTable)
+                body[i] = expr.args[1]
+            end
+        end
+    end
+
+    i = 1
+    oldidx = 0
+    changemap = fill(0, nexpr)
+
+    while i <= nexpr
+        oldidx += 1
+        st_i = states[i]
+        expr = body[i]
+        if isa(st_i, VarTable)
+            # st_i === ()  =>  unreached statement  (see issue #7836)
+            if isa(expr, Expr)
+                annotate_slot_load!(expr, st_i, sv, undefs)
+            elseif isa(expr, Slot)
+                body[i] = visit_slot_load!(expr, st_i, sv, undefs)
+            end
+        else
+            if isa(expr, Expr) && is_meta_expr(expr)
+                # keep any lexically scoped expressions
+            elseif run_optimizer
+                deleteat!(body, i)
+                deleteat!(states, i)
+                deleteat!(src.ssavaluetypes, i)
+                deleteat!(src.codelocs, i)
+                nexpr -= 1
+                if oldidx < length(changemap)
+                    changemap[oldidx + 1] = -1
+                end
+                continue
+            else
+                body[i] = Const(expr) # annotate that this statement actually is dead
+            end
+        end
+        i += 1
+    end
+
+    if run_optimizer
+        for i = 2:length(changemap)
+            changemap[i] += changemap[i - 1]
+        end
+        if changemap[end] != 0
+            renumber_stuff!(body, changemap)
+        end
+    end
+
+    # finish marking used-undef variables
+    for j = 1:nslots
+        if undefs[j]
+            src.slotflags[j] |= SLOT_USEDUNDEF | SLOT_STATICUNDEF
+        end
+    end
+    nothing
 end
 
 # at the end, all items in b's cycle
@@ -50,7 +471,7 @@ function merge_call_chain!(parent::InferenceState, ancestor::InferenceState, chi
     # and merge all of the callers into ancestor.callers_in_cycle
     # and ensure that walking the parent list will get the same result (DAG) from everywhere
     while true
-        add_backedge!(child, parent, parent.currpc)
+        add_cycle_backedge!(child, parent, parent.currpc)
         union_caller_cycle!(ancestor, child)
         child = parent
         parent = child.parent
@@ -87,16 +508,6 @@ function resolve_call_cycle!(linfo::MethodInstance, parent::InferenceState)
     return false
 end
 
-# build (and start inferring) the inference frame for the linfo
-function typeinf_frame(linfo::MethodInstance,
-                       optimize::Bool, cached::Bool, params::Params)
-    frame = InferenceState(linfo, optimize, cached, params)
-    frame === nothing && return nothing
-    cached && (linfo.inInference = true)
-    typeinf(frame)
-    return frame
-end
-
 # compute (and cache) an inferred AST and return the current best estimate of the result type
 function typeinf_edge(method::Method, @nospecialize(atypes), sparams::SimpleVector, caller::InferenceState)
     code = code_for_method(method, atypes, sparams, caller.params.world)
@@ -125,7 +536,8 @@ function typeinf_edge(method::Method, @nospecialize(atypes), sparams::SimpleVect
     if frame === false
         # completely new
         code.inInference = true
-        frame = InferenceState(code, #=optimize=#true, #=cached=#true, caller.params) # always optimize and cache edge targets
+        result = InferenceResult(code)
+        frame = InferenceState(result, #=cached=#true, caller.params) # always use the cache for edge targets
         if frame === nothing
             # can't get the source for this, so we know nothing
             code.inInference = false
@@ -148,17 +560,28 @@ end
 #### entry points for inferring a MethodInstance given a type signature ####
 
 # compute an inferred AST and return type
-function typeinf_code(method::Method, @nospecialize(atypes), sparams::SimpleVector,
-                      optimize::Bool, cached::Bool, params::Params)
+function typeinf_code(method::Method, @nospecialize(atypes), sparams::SimpleVector, run_optimizer::Bool, params::Params)
     code = code_for_method(method, atypes, sparams, params.world)
-    code === nothing && return (nothing, nothing, Any)
-    return typeinf_code(code::MethodInstance, optimize, cached, params)
+    code === nothing && return (nothing, Any)
+    ccall(:jl_typeinf_begin, Cvoid, ())
+    result = InferenceResult(code)
+    frame = InferenceState(result, false, params)
+    frame === nothing && return (nothing, Any)
+    if typeinf(frame) && run_optimizer
+        opt = OptimizationState(frame)
+        optimize(opt, result.result)
+        opt.src.inferred = true
+    end
+    ccall(:jl_typeinf_end, Cvoid, ())
+    frame.inferred || return (nothing, Any)
+    return (frame.src, widenconst(result.result))
 end
-function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
-                      params::Params)
+
+# compute (and cache) an inferred AST and return type
+function typeinf_ext(linfo::MethodInstance, params::Params)
     for i = 1:2 # test-and-lock-and-test
         i == 2 && ccall(:jl_typeinf_begin, Cvoid, ())
-        if cached && isdefined(linfo, :inferred)
+        if isdefined(linfo, :inferred)
             # see if this code already exists in the cache
             # staged functions make this hard since they have two "inferred" conditions,
             # so need to check whether the code itself is also inferred
@@ -180,28 +603,33 @@ function typeinf_code(linfo::MethodInstance, optimize::Bool, cached::Bool,
                     tree.pure = true
                     tree.inlineable = true
                     i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
-                    return svec(linfo, tree, linfo.rettype)
+                    return svec(linfo, tree)
                 elseif isa(inf, CodeInfo)
                     if inf.inferred
                         i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
-                        return svec(linfo, inf, linfo.rettype)
+                        return svec(linfo, inf)
+                    end
+                elseif isa(inf, Vector{UInt8})
+                    inf = uncompressed_ast(linfo.def::Method, inf)
+                    if inf.inferred
+                        i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
+                        return svec(linfo, inf)
                     end
                 end
             end
         end
     end
-    frame = typeinf_frame(linfo, optimize, cached, params)
+    linfo.inInference = true
+    frame = InferenceState(InferenceResult(linfo), #=cached=#true, params)
+    frame === nothing && return svec(nothing, nothing)
+    typeinf(frame)
     ccall(:jl_typeinf_end, Cvoid, ())
-    frame === nothing && return svec(nothing, nothing, Any)
-    frame = frame::InferenceState
-    frame.inferred || return svec(nothing, nothing, Any)
-    frame.cached || return svec(nothing, frame.src, widenconst(frame.bestguess))
-    return svec(frame.linfo, frame.src, widenconst(frame.bestguess))
+    frame.src.inferred || return svec(nothing, nothing)
+    return svec(frame.result.linfo, frame.src)
 end
 
 # compute (and cache) an inferred AST and return the inferred return type
-function typeinf_type(method::Method, @nospecialize(atypes), sparams::SimpleVector,
-                      cached::Bool, params::Params)
+function typeinf_type(method::Method, @nospecialize(atypes), sparams::SimpleVector, params::Params)
     if contains_is(unwrap_unionall(atypes).parameters, Union{})
         return Union{}
     end
@@ -210,7 +638,7 @@ function typeinf_type(method::Method, @nospecialize(atypes), sparams::SimpleVect
     code = code::MethodInstance
     for i = 1:2 # test-and-lock-and-test
         i == 2 && ccall(:jl_typeinf_begin, Cvoid, ())
-        if cached && isdefined(code, :inferred)
+        if isdefined(code, :inferred)
             # see if this rettype already exists in the cache
             # staged functions make this hard since they have two "inferred" conditions,
             # so need to check whether the code itself is also inferred
@@ -221,270 +649,50 @@ function typeinf_type(method::Method, @nospecialize(atypes), sparams::SimpleVect
             end
         end
     end
-    frame = typeinf_frame(code, cached, cached, params)
+    frame = InferenceResult(code)
+    typeinf(frame, true, params)
     ccall(:jl_typeinf_end, Cvoid, ())
-    frame === nothing && return nothing
-    frame = frame::InferenceState
-    frame.inferred || return nothing
-    return widenconst(frame.bestguess)
+    frame.result isa InferenceState && return nothing
+    return widenconst(frame.result)
 end
 
 @timeit function typeinf_ext(linfo::MethodInstance, world::UInt)
     if isa(linfo.def, Method)
         # method lambda - infer this specialization via the method cache
-        return typeinf_code(linfo, true, true, Params(world))
+        return typeinf_ext(linfo, Params(world))
     else
         # toplevel lambda - infer directly
         ccall(:jl_typeinf_begin, Cvoid, ())
         result = InferenceResult(linfo)
         frame = InferenceState(result, linfo.inferred::CodeInfo,
-                               true, true, Params(world))
+                               #=cached=#true, Params(world))
         typeinf(frame)
         ccall(:jl_typeinf_end, Cvoid, ())
         @assert frame.inferred # TODO: deal with this better
         @assert frame.linfo === linfo
         linfo.rettype = widenconst(frame.bestguess)
-        return svec(linfo, frame.src, linfo.rettype)
+        return svec(linfo, frame.src)
     end
 end
 
-#### do the work of inference ####
 
-function typeinf_work(frame::InferenceState)
-    @assert !frame.inferred
-    frame.dont_work_on_me = true # mark that this function is currently on the stack
-    W = frame.ip
-    s = frame.stmt_types
-    n = frame.nstmts
-    while frame.pc´´ <= n
-        # make progress on the active ip set
-        local pc::Int = frame.pc´´ # current program-counter
-        while true # inner loop optimizes the common case where it can run straight from pc to pc + 1
-            #print(pc,": ",s[pc],"\n")
-            local pc´::Int = pc + 1 # next program-counter (after executing instruction)
-            if pc == frame.pc´´
-                # need to update pc´´ to point at the new lowest instruction in W
-                min_pc = _bits_findnext(W.bits, pc + 1)
-                frame.pc´´ = min_pc == -1 ? n + 1 : min_pc
-            end
-            delete!(W, pc)
-            frame.currpc = pc
-            frame.cur_hand = frame.handler_at[pc]
-            frame.stmt_edges[pc] === () || empty!(frame.stmt_edges[pc])
-            stmt = frame.src.code[pc]
-            changes = s[pc]::VarTable
-            t = nothing
-
-            hd = isa(stmt, Expr) ? stmt.head : nothing
-
-            if isa(stmt, NewvarNode)
-                sn = slot_id(stmt.slot)
-                changes[sn] = VarState(Bottom, true)
-            elseif isa(stmt, GotoNode)
-                pc´ = (stmt::GotoNode).label
-            elseif hd === :gotoifnot
-                condt = abstract_eval(stmt.args[1], s[pc], frame)
-                if condt === Bottom
-                    break
-                end
-                condval = maybe_extract_const_bool(condt)
-                l = stmt.args[2]::Int
-                # constant conditions
-                if condval === true
-                elseif condval === false
-                    pc´ = l
-                else
-                    # general case
-                    frame.handler_at[l] = frame.cur_hand
-                    changes_else = changes
-                    if isa(condt, Conditional)
-                        if condt.elsetype !== Any && condt.elsetype !== changes[slot_id(condt.var)]
-                            changes_else = StateUpdate(condt.var, VarState(condt.elsetype, false), changes_else)
-                        end
-                        if condt.vtype !== Any && condt.vtype !== changes[slot_id(condt.var)]
-                            changes = StateUpdate(condt.var, VarState(condt.vtype, false), changes)
-                        end
-                    end
-                    newstate_else = stupdate!(s[l], changes_else)
-                    if newstate_else !== false
-                        # add else branch to active IP list
-                        if l < frame.pc´´
-                            frame.pc´´ = l
-                        end
-                        push!(W, l)
-                        s[l] = newstate_else
-                    end
-                end
-            elseif hd === :return
-                pc´ = n + 1
-                rt = abstract_eval(stmt.args[1], s[pc], frame)
-                if !isa(rt, Const) && !isa(rt, Type)
-                    # only propagate information we know we can store
-                    # and is valid inter-procedurally
-                    rt = widenconst(rt)
-                end
-                if tchanged(rt, frame.bestguess)
-                    # new (wider) return type for frame
-                    frame.bestguess = tmerge(frame.bestguess, rt)
-                    for (caller, caller_pc) in frame.backedges
-                        # notify backedges of updated type information
-                        if caller.stmt_types[caller_pc] !== ()
-                            if caller_pc < caller.pc´´
-                                caller.pc´´ = caller_pc
-                            end
-                            push!(caller.ip, caller_pc)
-                        end
-                    end
-                end
-            elseif hd === :enter
-                l = stmt.args[1]::Int
-                frame.cur_hand = (l, frame.cur_hand)
-                # propagate type info to exception handler
-                l = frame.cur_hand[1]
-                old = s[l]
-                new = s[pc]::Array{Any,1}
-                newstate_catch = stupdate!(old, new)
-                if newstate_catch !== false
-                    if l < frame.pc´´
-                        frame.pc´´ = l
-                    end
-                    push!(W, l)
-                    s[l] = newstate_catch
-                end
-                typeassert(s[l], VarTable)
-                frame.handler_at[l] = frame.cur_hand
-            elseif hd === :leave
-                for i = 1:((stmt.args[1])::Int)
-                    frame.cur_hand = frame.cur_hand[2]
-                end
-            else
-                if hd === :(=)
-                    t = abstract_eval(stmt.args[2], changes, frame)
-                    t === Bottom && break
-                    frame.src.ssavaluetypes[pc] = t
-                    lhs = stmt.args[1]
-                    if isa(lhs, Slot)
-                        changes = StateUpdate(lhs, VarState(t, false), changes)
-                    end
-                elseif hd === :method
-                    fname = stmt.args[1]
-                    if isa(fname, Slot)
-                        changes = StateUpdate(fname, VarState(Any, false), changes)
-                    end
-                elseif hd === :inbounds || hd === :meta || hd === :simdloop
-                else
-                    t = abstract_eval(stmt, changes, frame)
-                    t === Bottom && break
-                    if !isempty(frame.ssavalue_uses[pc])
-                        record_ssa_assign(pc, t, frame)
-                    else
-                        frame.src.ssavaluetypes[pc] = t
-                    end
-                end
-                if frame.cur_hand !== () && isa(changes, StateUpdate)
-                    # propagate new type info to exception handler
-                    # the handling for Expr(:enter) propagates all changes from before the try/catch
-                    # so this only needs to propagate any changes
-                    l = frame.cur_hand[1]
-                    if stupdate1!(s[l]::VarTable, changes::StateUpdate) !== false
-                        if l < frame.pc´´
-                            frame.pc´´ = l
-                        end
-                        push!(W, l)
-                    end
-                end
-            end
-
-            if t === nothing
-                # mark other reached expressions as `Any` to indicate they don't throw
-                frame.src.ssavaluetypes[pc] = Any
-            end
-
-            pc´ > n && break # can't proceed with the fast-path fall-through
-            frame.handler_at[pc´] = frame.cur_hand
-            newstate = stupdate!(s[pc´], changes)
-            if isa(stmt, GotoNode) && frame.pc´´ < pc´
-                # if we are processing a goto node anyways,
-                # (such as a terminator for a loop, if-else, or try block),
-                # consider whether we should jump to an older backedge first,
-                # to try to traverse the statements in approximate dominator order
-                if newstate !== false
-                    s[pc´] = newstate
-                end
-                push!(W, pc´)
-                pc = frame.pc´´
-            elseif newstate !== false
-                s[pc´] = newstate
-                pc = pc´
-            elseif pc´ in W
-                pc = pc´
-            else
-                break
-            end
+function return_type(@nospecialize(f), @nospecialize(t))
+    params = Params(ccall(:jl_get_tls_world_age, UInt, ()))
+    rt = Union{}
+    if isa(f, Builtin)
+        rt = builtin_tfunction(f, Any[t.parameters...], nothing, params)
+        if isa(rt, TypeVar)
+            rt = rt.ub
+        else
+            rt = widenconst(rt)
+        end
+    else
+        for m in _methods(f, t, -1, params.world)
+            ty = typeinf_type(m[3], m[1], m[2], params)
+            ty === nothing && return Any
+            rt = tmerge(rt, ty)
+            rt === Any && break
         end
     end
-    frame.dont_work_on_me = false
-end
-
-function typeinf(frame::InferenceState)
-    typeinf_work(frame)
-
-    # If the current frame is part of a cycle, solve the cycle before finishing
-    no_active_ips_in_callers = false
-    while !no_active_ips_in_callers
-        no_active_ips_in_callers = true
-        for caller in frame.callers_in_cycle
-            caller.dont_work_on_me && return
-            if caller.pc´´ <= caller.nstmts # equivalent to `isempty(caller.ip)`
-                # Note that `typeinf_work(caller)` can potentially modify the other frames
-                # `frame.callers_in_cycle`, which is why making incremental progress requires the
-                # outer while loop.
-                typeinf_work(caller)
-                no_active_ips_in_callers = false
-            end
-            if caller.min_valid < frame.min_valid
-                caller.min_valid = frame.min_valid
-            end
-            if caller.max_valid > frame.max_valid
-                caller.max_valid = frame.max_valid
-            end
-        end
-    end
-
-    # with no active ip's, type inference on frame is done
-
-    if isempty(frame.callers_in_cycle)
-        @assert !(frame.dont_work_on_me)
-        frame.dont_work_on_me = true
-        optimize(frame)
-        finish(frame)
-        finalize_backedges(frame)
-    else # frame is in frame.callers_in_cycle
-        for caller in frame.callers_in_cycle
-            @assert !(caller.dont_work_on_me)
-            caller.dont_work_on_me = true
-        end
-        # complete the computation of the src optimizations
-        for caller in frame.callers_in_cycle
-            optimize(caller)
-            if frame.min_valid < caller.min_valid
-                frame.min_valid = caller.min_valid
-            end
-            if frame.max_valid > caller.max_valid
-                frame.max_valid = caller.max_valid
-            end
-        end
-        # update and store in the global cache
-        for caller in frame.callers_in_cycle
-            caller.min_valid = frame.min_valid
-        end
-        for caller in frame.callers_in_cycle
-            finish(caller)
-        end
-        for caller in frame.callers_in_cycle
-            finalize_backedges(caller)
-        end
-    end
-
-    nothing
+    return rt
 end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -409,7 +409,7 @@ function type_annotate!(sv::InferenceState)
                 body[i] = visit_slot_load!(expr, st_i, sv, undefs)
             end
         else
-            if isa(expr, Expr) && is_meta_expr(expr)
+            if isa(expr, Expr) && is_meta_expr_head(expr.head)
                 # keep any lexically scoped expressions
             elseif run_optimizer
                 deleteat!(body, i)

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -10,8 +10,7 @@ function rewrap(@nospecialize(t), @nospecialize(u))
     return rewrap_unionall(t, u)
 end
 
-const _TYPE_NAME = Type.body.name
-isType(@nospecialize t) = isa(t, DataType) && (t::DataType).name === _TYPE_NAME
+isType(@nospecialize t) = isa(t, DataType) && t.name === _TYPE_NAME
 
 # true if Type{T} is inlineable as constant T
 # requires that T is a singleton, s.t. T == S implies T === S
@@ -27,19 +26,9 @@ function issingletontype(@nospecialize t)
     iskindtype(typeof(t)) || return true # non-types are always compared by egal in the type system
     isconcretetype(t) && return true # these are also interned and pointer comparable
     if isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
-        return all(p -> issingletontype(p), t.parameters)
+        return all(@nospecialize(p) -> issingletontype(p), t.parameters)
     end
     return false
-end
-
-iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
-isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
-
-# equivalent to isdispatchtuple(Tuple{v}) || v == Union{}
-# and is thus perhaps most similar to the old (pre-1.0) `isleaftype` query
-function isdispatchelem(@nospecialize v)
-    return (v === Bottom) || (v === typeof(Bottom)) ||
-        isconcretedispatch(v) || (isType(v) && !has_free_typevars(v))
 end
 
 argtypes_to_type(argtypes::Array{Any,1}) = Tuple{anymap(widenconst, argtypes)...}
@@ -59,8 +48,6 @@ function valid_tparam(@nospecialize(x))
     end
     return isa(x, Symbol) || isbitstype(typeof(x))
 end
-
-has_free_typevars(@nospecialize(t)) = ccall(:jl_has_free_typevars, Cint, (Any,), t) != 0
 
 # return an upper-bound on type `a` with type `b` removed
 # such that `return <: a` && `Union{return, b} == Union{a, b}`
@@ -96,7 +83,19 @@ _typename(union::UnionAll) = _typename(union.body)
 _typename(a::DataType) = Const(a.name)
 
 function tuple_tail_elem(@nospecialize(init), ct)
-    return Vararg{widenconst(foldl((a, b) -> tmerge(a, tvar_extent(unwrapva(b))), init, ct))}
+    # FIXME: this is broken: it violates subtyping relations and creates invalid types with free typevars
+    tmerge_maybe_vararg(@nospecialize(a), @nospecialize(b)) = tmerge(a, tvar_extent(unwrapva(b)))
+    return Vararg{widenconst(foldl(tmerge_maybe_vararg, init, ct))}
+end
+
+function countunionsplit(atypes)
+    nu = 1
+    for ti in atypes
+        if isa(ti, Union)
+            nu *= unionlen(ti::Union)
+        end
+    end
+    return nu
 end
 
 # take a Tuple where one or more parameters are Unions

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -53,7 +53,6 @@ end
 # Meta expression head, these generally can't be deleted even when they are
 # in a dead branch but can be ignored when analyzing uses/liveness.
 is_meta_expr_head(head::Symbol) = (head === :inbounds || head === :boundscheck || head === :meta || head === :simdloop)
-is_meta_expr(ex::Expr) = is_meta_expr_head(ex.head)
 
 sym_isless(a::Symbol, b::Symbol) = ccall(:strcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}), a, b) < 0
 
@@ -74,7 +73,6 @@ end
 # count occurrences up to n+1
 function occurs_more(@nospecialize(e), pred, n)
     if isa(e,Expr)
-        e = e::Expr
         head = e.head
         is_meta_expr_head(head) && return 0
         c = 0

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -170,4 +170,91 @@ function parse(str::AbstractString; raise::Bool=true, depwarn::Bool=true)
     return ex
 end
 
+# replace slots 1:na with argexprs, static params with spvals, and increment
+# other slots by offset.
+function substitute!(
+        @nospecialize(e), na::Int, argexprs::Vector{Any},
+        @nospecialize(spsig), spvals::Vector{Any},
+        offset::Int, boundscheck::Symbol)
+    if isa(e, Core.Slot)
+        id = e.id::Int
+        if 1 <= id <= na
+            ae = argexprs[id]
+            if isa(e, Core.TypedSlot) && isa(ae, Core.Slot)
+                return Core.TypedSlot(ae.id, e.typ)
+            end
+            return ae
+        end
+        if isa(e, Core.SlotNumber)
+            return Core.SlotNumber(id + offset)
+        else
+            return Core.TypedSlot(id + offset, e.typ)
+        end
+    end
+    if isa(e, Core.NewvarNode)
+        return Core.NewvarNode(substitute!(e.slot, na, argexprs, spsig, spvals, offset, boundscheck))
+    end
+    if isa(e, Core.PhiNode)
+        values = Vector{Any}(undef, length(e.values))
+        for i = 1:length(values)
+            isassigned(e.values, i) || continue
+            values[i] = substitute!(e.values[i], na, argexprs, spsig,
+                spvals, offset, boundscheck)
+        end
+        return Core.PhiNode(e.edges, values)
+    end
+    if isa(e, Core.PiNode)
+        return Core.PiNode(substitute!(e.val, na, argexprs, spsig, spvals, offset, boundscheck), e.typ)
+    end
+    if isa(e, Expr)
+        head = e.head
+        if head === :static_parameter
+            return QuoteNode(spvals[e.args[1]])
+        elseif head === :cfunction
+            @assert !isa(spsig, UnionAll) || !isempty(spvals)
+            if !(e.args[2] isa QuoteNode) # very common no-op
+                e.args[2] = substitute!(e.args[2], na, argexprs, spsig, spvals, offset, boundscheck)
+            end
+            e.args[3] = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), e.args[3], spsig, spvals)
+            e.args[4] = svec(Any[
+                ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), argt, spsig, spvals)
+                for argt
+                in e.args[4] ]...)
+        elseif head === :foreigncall
+            @assert !isa(spsig, UnionAll) || !isempty(spvals)
+            for i = 1:length(e.args)
+                if i == 2
+                    e.args[2] = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), e.args[2], spsig, spvals)
+                elseif i == 3
+                    e.args[3] = svec(Any[
+                        ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), argt, spsig, spvals)
+                        for argt
+                        in e.args[3] ]...)
+                elseif i == 4
+                    @assert isa((e.args[4]::QuoteNode).value, Symbol)
+                elseif i == 5
+                    @assert isa(e.args[5], Int)
+                else
+                    e.args[i] = substitute!(e.args[i], na, argexprs, spsig, spvals, offset, boundscheck)
+                end
+            end
+        elseif head === :boundscheck
+            if boundscheck === :propagate
+                return e
+            elseif boundscheck === :off
+                return false
+            else
+                return true
+            end
+        elseif !is_meta_expr_head(head)
+            for i = 1:length(e.args)
+                e.args[i] = substitute!(e.args[i], na, argexprs, spsig, spvals, offset, boundscheck)
+            end
+        end
+    end
+    return e
+end
+
+is_meta_expr_head(head::Symbol) = (head === :inbounds || head === :boundscheck || head === :meta || head === :simdloop)
+
 end # module

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -390,6 +390,18 @@ and has no subtypes (or supertypes) which could appear in a call.
 """
 isdispatchtuple(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isdispatchtuple)
 
+iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
+isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
+has_free_typevars(@nospecialize(t)) = ccall(:jl_has_free_typevars, Cint, (Any,), t) != 0
+
+# equivalent to isa(v, Type) && isdispatchtuple(Tuple{v}) || v === Union{}
+# and is thus perhaps most similar to the old (pre-1.0) `isleaftype` query
+const _TYPE_NAME = Type.body.name
+function isdispatchelem(@nospecialize v)
+    return (v === Bottom) || (v === typeof(Bottom)) || isconcretedispatch(v) ||
+        (isa(v, DataType) && v.name === _TYPE_NAME && !has_free_typevars(v)) # isType(v)
+end
+
 """
     isconcretetype(T)
 
@@ -842,9 +854,9 @@ function code_typed(@nospecialize(f), @nospecialize(types=Tuple); optimize=true)
     params = Core.Compiler.Params(world)
     for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
-        (_, code, ty) = Core.Compiler.typeinf_code(meth, x[1], x[2], optimize, optimize, params)
+        (code, ty) = Core.Compiler.typeinf_code(meth, x[1], x[2], optimize, params)
         code === nothing && error("inference not successful") # inference disabled?
-        push!(asts, uncompressed_ast(meth, code) => ty)
+        push!(asts, code => ty)
     end
     return asts
 end
@@ -860,7 +872,7 @@ function return_types(@nospecialize(f), @nospecialize(types=Tuple))
     params = Core.Compiler.Params(world)
     for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
-        ty = Core.Compiler.typeinf_type(meth, x[1], x[2], true, params)
+        ty = Core.Compiler.typeinf_type(meth, x[1], x[2], params)
         ty === nothing && error("inference not successful") # inference disabled?
         push!(rt, ty)
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -912,7 +912,7 @@ function show_expr_type(io::IO, @nospecialize(ty), emph::Bool)
     elseif ty === Core.IntrinsicFunction
         print(io, "::I")
     else
-        if emph && (!isdispatchtuple(Tuple{ty}) || ty == Core.Box)
+        if emph && ty isa Type && (!isdispatchelem(ty) || ty == Core.Box)
             if ty isa Union && is_expected_union(ty)
                 emphasize(io, "::$ty", Base.warn_color()) # more mild user notification
             else

--- a/src/gf.c
+++ b/src/gf.c
@@ -271,17 +271,17 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli, size_t world, int forc
     ptls->world_age = jl_typeinf_world;
     li->inInference = 1;
     in_inference++;
-    jl_svec_t *linfo_src_rettype = (jl_svec_t*)jl_apply_with_saved_exception_state(fargs, 3, 0);
+    jl_svec_t *linfo_src = (jl_svec_t*)jl_apply_with_saved_exception_state(fargs, 3, 0);
     ptls->world_age = last_age;
     in_inference--;
     li->inInference = 0;
 
-    if (linfo_src_rettype &&
-            jl_is_svec(linfo_src_rettype) && jl_svec_len(linfo_src_rettype) == 3 &&
-            jl_is_method_instance(jl_svecref(linfo_src_rettype, 0)) &&
-            jl_is_code_info(jl_svecref(linfo_src_rettype, 1))) {
-        *pli = (jl_method_instance_t*)jl_svecref(linfo_src_rettype, 0);
-        src = (jl_code_info_t*)jl_svecref(linfo_src_rettype, 1);
+    if (linfo_src &&
+            jl_is_svec(linfo_src) && jl_svec_len(linfo_src) == 2 &&
+            jl_is_method_instance(jl_svecref(linfo_src, 0)) &&
+            jl_is_code_info(jl_svecref(linfo_src, 1))) {
+        *pli = (jl_method_instance_t*)jl_svecref(linfo_src, 0);
+        src = (jl_code_info_t*)jl_svecref(linfo_src, 1);
     }
     JL_GC_POP();
 #endif

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -2,19 +2,13 @@
 
 # displaying type warnings
 
-function code_warntype_legacy_ir(io::IO, src::Core.CodeInfo, rettype)
-    function slots_used(ci, slotnames)
-        used = falses(length(slotnames))
-        scan_exprs!(used, ci.code)
-        return used
-    end
-
-    function scan_exprs!(used, exprs)
+function code_warntype_legacy_ir(io::IO, src::Core.CodeInfo, @nospecialize(rettype))
+    function scan_expr_uses!(used, exprs::Vector{Any})
         for ex in exprs
             if isa(ex, Core.Slot)
                 used[ex.id] = true
             elseif isa(ex, Expr)
-                scan_exprs!(used, ex.args)
+                scan_expr_uses!(used, ex.args)
             end
         end
     end
@@ -22,7 +16,9 @@ function code_warntype_legacy_ir(io::IO, src::Core.CodeInfo, rettype)
     emph_io = IOContext(io, :TYPEEMPHASIZE => true)
     println(emph_io, "Variables:")
     slotnames = Base.sourceinfo_slotnames(src)
-    used_slotids = slots_used(src, slotnames)
+    # compute the set of ssa values that are used
+    used_slotids = falses(length(slotnames))
+    scan_expr_uses!(used_slotids, src.code)
     for i = 1:length(slotnames)
         if used_slotids[i]
             print(emph_io, "  ", slotnames[i])
@@ -44,8 +40,8 @@ function code_warntype_legacy_ir(io::IO, src::Core.CodeInfo, rettype)
     print(emph_io, '\n')
 end
 
-function warntype_type_printer(io, ty)
-    if ty !== Union{} && (!isdispatchtuple(Tuple{ty}) || ty == Core.Box)
+function warntype_type_printer(io::IO, @nospecialize(ty))
+    if ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
         if ty isa Union && Base.is_expected_union(ty)
             Base.emphasize(io, "::$ty", Base.warn_color()) # more mild user notification
         else
@@ -54,6 +50,7 @@ function warntype_type_printer(io, ty)
     else
         Base.printstyled(io, "::$ty", color=:cyan)
     end
+    nothing
 end
 
 """
@@ -71,21 +68,25 @@ in verbose mode, showing all available information (rather than applying
 the usual heuristics).
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
-function code_warntype(io::IO, f, @nospecialize(t); verbose_linetable=false)
+function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); verbose_linetable=false)
     for (src, rettype) in code_typed(f, t)
         if src.codelocs === nothing
             code_warntype_legacy_ir(io, src, rettype)
         else
-            print(io, "Body"); warntype_type_printer(io, rettype); println(io);
+            print(io, "Body")
+            warntype_type_printer(io, rettype)
+            println(io)
             # TODO: static parameter values
             ir = Core.Compiler.inflate_ir(src, Core.svec())
             Base.IRShow.show_ir(io, ir, warntype_type_printer;
-                                argnames=Base.sourceinfo_slotnames(src), verbose_linetable=verbose_linetable)
+                                argnames = Base.sourceinfo_slotnames(src),
+                                verbose_linetable = verbose_linetable)
         end
     end
     nothing
 end
-code_warntype(f, @nospecialize(t); kwargs...) = code_warntype(stdout, f, t; kwargs...)
+code_warntype(@nospecialize(f), @nospecialize(t); kwargs...) =
+    code_warntype(stdout, f, t; kwargs...)
 
 import Base.CodegenParams
 

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -321,7 +321,7 @@ function get_type_call(expr::Expr)
     m = first(mt)
     # Typeinference
     params = Core.Compiler.Params(world)
-    return_type = Core.Compiler.typeinf_type(m[3], m[1], m[2], true, params)
+    return_type = Core.Compiler.typeinf_type(m[3], m[1], m[2], params)
     return_type === nothing && return (Any, false)
     return (return_type, true)
 end

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1106,8 +1106,7 @@ function test_const_return(@nospecialize(f), @nospecialize(t), @nospecialize(val
         if isa(ex, LineNumberNode)
             continue
         elseif isa(ex, Expr)
-            ex = ex::Expr
-            if Core.Compiler.is_meta_expr(ex)
+            if Core.Compiler.is_meta_expr_head(ex.head)
                 continue
             elseif ex.head === :return
                 # multiple returns
@@ -1370,7 +1369,7 @@ function f24852_kernel_cinfo(fsig::Type)
     isdefined(method, :source) || return (nothing, :(f(x, y)))
     code_info = Base.uncompressed_ast(method)
     body = Expr(:block, code_info.code...)
-    Base.Core.Compiler.substitute!(body, 0, Any[], sig, Any[spvals...], 1, :propagate)
+    Meta.substitute!(body, 0, Any[], sig, Any[spvals...], 1, :propagate)
     if startswith(String(method.name), "f24852")
         for a in body.args
             if a isa Expr && a.head == :(=)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # tests for Core.Compiler correctness and precision
-import Core.Compiler: Const, Conditional, ⊑, isdispatchelem
+import Core.Compiler: Const, Conditional, ⊑
+isdispatchelem(@nospecialize x) = !isa(x, Type) || Core.Compiler.isdispatchelem(x)
 
 using Random, Core.IR
 using InteractiveUtils: code_llvm
@@ -252,7 +253,7 @@ end
 end
 let ast12474 = code_typed(f12474, Tuple{Float64})
     @test isdispatchelem(ast12474[1][2])
-    @test all(x -> isdispatchelem(Core.Compiler.typesubtract(x, Nothing)), ast12474[1][1].slottypes)
+    @test all(x -> x isa Const || isdispatchelem(Core.Compiler.typesubtract(x, Nothing)), ast12474[1][1].slottypes)
 end
 
 
@@ -538,7 +539,7 @@ for (codetype, all_ssa) in Any[
         (code_typed(g19348, (typeof((1, 2.0)),))[1], true)]
     # make sure none of the slottypes are left as Core.Compiler.Const objects
     code = codetype[1]
-    @test all(x->isa(x, Type), code.slottypes)
+    @test all(x -> isa(x, Type) || isa(x, Const), code.slottypes)
     local notconst(@nospecialize(other)) = true
     notconst(slot::TypedSlot) = @test isa(slot.typ, Type)
     function notconst(expr::Expr)
@@ -550,7 +551,9 @@ for (codetype, all_ssa) in Any[
     for i = 1:length(code.code)
         e = code.code[i]
         notconst(e)
-        @test isa(code.ssavaluetypes[i], Type)
+        typ = code.ssavaluetypes[i]
+        typ isa Core.Compiler.MaybeUndef && (typ = typ.typ)
+        @test isa(typ, Type) || isa(typ, Const) || isa(typ, Conditional) || typ
     end
     test_inferred_static(codetype, all_ssa)
 end
@@ -1132,7 +1135,7 @@ function find_call(code::Core.CodeInfo, @nospecialize(func), narg)
                     farg = typeof(getfield(farg.mod, farg.name))
                 end
             elseif isa(farg, Core.SSAValue)
-                farg = code.ssavaluetypes[farg.id]
+                farg = Core.Compiler.widenconst(code.ssavaluetypes[farg.id])
             else
                 farg = typeof(farg)
             end

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -493,7 +493,7 @@ else
     @test h16850 === nothing
 end
 
-# PR #18888: code_typed shouldn't cache if not optimizing
+# PR #18888: code_typed shouldn't cache, return_types should
 let
     world = typemax(UInt)
     f18888() = return nothing
@@ -507,6 +507,10 @@ let
     @test !isdefined(code, :inferred)
 
     code_typed(f18888, Tuple{}; optimize=true)
+    code = Core.Compiler.code_for_method(m, Tuple{ft}, Core.svec(), world, true)
+    @test !isdefined(code, :inferred)
+
+    Base.return_types(f18888, Tuple{})
     code = Core.Compiler.code_for_method(m, Tuple{ft}, Core.svec(), world, true)
     @test isdefined(code, :inferred)
 end

--- a/test/staged.jl
+++ b/test/staged.jl
@@ -244,7 +244,7 @@ f22440kernel(::Type{T}) where {T<:AbstractFloat} = zero(T)
     sig, spvals, method = Base._methods_by_ftype(Tuple{typeof(f22440kernel),y}, -1, typemax(UInt))[1]
     code_info = Base.uncompressed_ast(method)
     body = Expr(:block, code_info.code...)
-    Base.Core.Compiler.substitute!(body, 0, Any[], sig, Any[spvals...], 0, :propagate)
+    Meta.substitute!(body, 0, Any[], sig, Any[spvals...], 0, :propagate)
     return code_info
 end
 


### PR DESCRIPTION
The main functional changes are:
 - More nearly separates the optimization steps from the inference loop
   (still some interleaving, due to wanting to cache work results eagerly)
 - Doesn't run `widen_all_const` on the IR before returning to the user
   during reflection (e.g. code-typed). This allows the user to run
   additional passes on it outside of Julia codegen,
   or simply to better see what inference knows.
 - There's now a flag in `Compiler.Params` for whether the global
   inference cache is applicable and should be used (read / write).
   Although this flag is currently not respected, however.