### PR TITLE
Some preparatory work for enforcing subtype invariants for phi nodes

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -499,6 +499,8 @@ function maybe_widen_conditional(vt)
             vt = Const(false)
         elseif vt.elsetype === Bottom
             vt = Const(true)
+        else
+            vt = Bool
         end
     end
     vt
@@ -580,6 +582,7 @@ function type_annotate!(sv::InferenceState)
         if gt[j] === NOT_FOUND
             gt[j] = Union{}
         end
+        gt[j] = maybe_widen_conditional(gt[j])
     end
 
     # compute the required type for each slot

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -410,7 +410,7 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, topmod::Module, idx:
             argexprs′ = copy(argexprs)
             for i = 1:length(metharg.parameters)
                 a, m = atype.parameters[i], metharg.parameters[i]
-                isa(argexprs[i], SSAValue) || continue
+                (isa(argexprs[i], SSAValue) || isa(argexprs[i], Argument)) || continue
                 if !(a <: m)
                     argexprs′[i] = insert_node_here!(compact, PiNode(argexprs′[i], m),
                                                      m, line)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -648,9 +648,12 @@ function getindex(view::TypesView, idx)
 end
 
 function getindex(view::TypesView, idx::NewSSAValue)
-    @assert isa(view.ir, IncrementalCompact)
-    compact = view.ir
-    compact.new_new_nodes[idx.id].typ
+    if isa(view.ir, IncrementalCompact)
+        compact = view.ir
+        compact.new_new_nodes[idx.id].typ
+    else
+        view.ir.new_nodes[idx.id].typ
+    end
 end
 
 function process_phinode_values(old_values::Vector{Any}, late_fixup::Vector{Int},

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -101,7 +101,7 @@ function compute_value_for_use(ir::IRCode, domtree::DomTree, allblocks, du, phin
     end
 end
 
-function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSAValue=#), pi_callback=(pi,idx)->false)
+function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSAValue=#), pi_callback=(@nospecialize(pi),@nospecialize(idx))->false)
     while true
         if isa(defssa, OldSSAValue) && already_inserted(compact, defssa)
             rename = compact.ssa_rename[defssa.id]
@@ -137,7 +137,7 @@ function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSA
 end
 
 function simple_walk_constraint(compact, defidx, typeconstraint = types(compact)[defidx])
-    callback = (pi, _)->(isa(pi, PiNode) && (typeconstraint = typeintersect(typeconstraint, pi.typ)); false)
+    callback = (@nospecialize(pi), _)->(isa(pi, PiNode) && (typeconstraint = typeintersect(typeconstraint, pi.typ)); false)
     def = simple_walk(compact, defidx, callback)
     def, typeconstraint
 end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -101,7 +101,7 @@ function compute_value_for_use(ir::IRCode, domtree::DomTree, allblocks, du, phin
     end
 end
 
-function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSAValue=#), pi_callback=(pi,idx)->nothing)
+function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSAValue=#), pi_callback=(pi,idx)->false)
     while true
         if isa(defssa, OldSSAValue) && already_inserted(compact, defssa)
             rename = compact.ssa_rename[defssa.id]
@@ -113,7 +113,9 @@ function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSA
         end
         def = compact[defssa]
         if isa(def, PiNode)
-            pi_callback(def, defssa)
+            if pi_callback(def, defssa)
+                return defssa
+            end
             if isa(def.val, SSAValue)
                 if isa(defssa, OldSSAValue) && !already_inserted(compact, defssa)
                     defssa = OldSSAValue(def.val.id)
@@ -135,7 +137,7 @@ function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSA
 end
 
 function simple_walk_constraint(compact, defidx, typeconstraint = types(compact)[defidx])
-    callback = (pi, _)->isa(pi, PiNode) && (typeconstraint = typeintersect(typeconstraint, pi.typ))
+    callback = (pi, _)->(isa(pi, PiNode) && (typeconstraint = typeintersect(typeconstraint, pi.typ)); false)
     def = simple_walk(compact, defidx, callback)
     def, typeconstraint
 end
@@ -448,7 +450,7 @@ function perform_lifting!(compact::IncrementalCompact,
                 end
                 lifted_val = lifted_val.x
                 if isa(lifted_val, Union{NewSSAValue, SSAValue, OldSSAValue})
-                    lifted_val = simple_walk(compact, lifted_val)
+                    lifted_val = simple_walk(compact, lifted_val, (_a, _b)->true)
                 end
                 push!(new_node.values, lifted_val)
             elseif isa(val, Union{NewSSAValue, SSAValue, OldSSAValue}) && val in keys(reverse_mapping)
@@ -542,7 +544,7 @@ function getfield_elim_pass!(ir::IRCode, domtree)
             for (pidx, preserved_arg) in enumerate(old_preserves)
                 intermediaries = IdSet()
                 isa(preserved_arg, SSAValue) || continue
-                def = simple_walk(compact, preserved_arg, (pi, ssa)->push!(intermediaries, ssa.id))
+                def = simple_walk(compact, preserved_arg, (pi, ssa)->(push!(intermediaries, ssa.id); false))
                 isa(def, SSAValue) || continue
                 defidx = def.id
                 def = compact[defidx]
@@ -592,7 +594,7 @@ function getfield_elim_pass!(ir::IRCode, domtree)
         if struct_typ.mutable
             isa(def, SSAValue) || continue
             intermediaries = IdSet()
-            def = simple_walk(compact, def, (pi, ssa)->push!(intermediaries, ssa.id))
+            def = simple_walk(compact, def, (pi, ssa)->(push!(intermediaries, ssa.id); false))
             # Mutable stuff here
             isa(def, SSAValue) || continue
             mid, defuse = get!(defuses, def.id, (IdSet{Int}(), SSADefUse()))

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -86,15 +86,15 @@ struct UndefToken
 end
 const undef_token = UndefToken()
 
-function new_to_regular(@nospecialize(stmt))
+function new_to_regular(@nospecialize(stmt), new_offset::Int)
     if isa(stmt, NewSSAValue)
-        return SSAValue(stmt.id)
+        return SSAValue(stmt.id + new_offset)
     end
     urs = userefs(stmt)
     for op in urs
         val = op[]
         if isa(val, NewSSAValue)
-            op[] = SSAValue(val.id)
+            op[] = SSAValue(val.id + new_offset)
         end
     end
     return urs[]
@@ -113,7 +113,7 @@ function fixup_slot!(ir::IRCode, ci::CodeInfo, idx::Int, slot::Int, @nospecializ
     if isa(stmt, SlotNumber)
         return ssa
     elseif isa(stmt, TypedSlot)
-        return NewSSAValue(insert_node!(ir, idx, stmt.typ, PiNode(ssa, stmt.typ)).id)
+        return NewSSAValue(insert_node!(ir, idx, stmt.typ, PiNode(ssa, stmt.typ)).id - length(ir.stmts))
     end
 end
 
@@ -494,7 +494,7 @@ function recompute_type(node::Union{PhiNode, PhiCNode}, ci::CodeInfo, ir::IRCode
         end
         @assert !isa(typ, MaybeUndef)
         while isa(typ, DelayedTyp)
-            typ = ir.new_nodes[typ.phi.id - length(ir.stmts)].typ
+            typ = types(ir)[typ.phi::NewSSAValue]
         end
         new_typ = tmerge(new_typ, was_maybe_undef ? MaybeUndef(typ) : typ)
     end
@@ -522,7 +522,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
     end
 
     phi_slots = Vector{Int}[Vector{Int}() for _ = 1:length(ir.cfg.blocks)]
-    phi_nodes = Vector{Pair{Int,PhiNode}}[Vector{Pair{Int,PhiNode}}() for _ = 1:length(cfg.blocks)]
+    phi_nodes = Vector{Pair{NewSSAValue,PhiNode}}[Vector{Pair{NewSSAValue,PhiNode}}() for _ = 1:length(cfg.blocks)]
     phi_ssas = SSAValue[]
     phicnodes = IdDict{Int, Vector{Tuple{SlotNumber, NewSSAValue, PhiCNode}}}()
     for (_, exc) in catch_entry_blocks
@@ -560,7 +560,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 # Create a PhiC node in the catch entry block and
                 # an upsilon node in the corresponding enter block
                 node = PhiCNode(Any[])
-                phic_ssa = NewSSAValue(insert_node!(ir, first_insert_for_bb(code, cfg, li), Union{}, node).id)
+                phic_ssa = NewSSAValue(insert_node!(ir, first_insert_for_bb(code, cfg, li), Union{}, node).id - length(ir.stmts))
                 push!(phicnodes[li], (SlotNumber(idx), phic_ssa, node))
                 # Inform IDF that we now have a def in the catch block
                 if !(li in live.def_bbs)
@@ -572,8 +572,8 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
         for block in phiblocks
             push!(phi_slots[block], idx)
             node = PhiNode()
-            ssa = insert_node!(ir, first_insert_for_bb(code, cfg, block), Union{}, node)
-            push!(phi_nodes[block], ssa.id=>node)
+            ssa = NewSSAValue(insert_node!(ir, first_insert_for_bb(code, cfg, block), Union{}, node).id - length(ir.stmts))
+            push!(phi_nodes[block], ssa=>node)
         end
         push!(left, idx)
     end
@@ -624,19 +624,18 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 push!(node.values, incoming_val)
             end
             # TODO: Remove the next line, it shouldn't be necessary
-            push!(type_refine_phi, ssaval)
+            push!(type_refine_phi, ssaval.id)
             if isa(incoming_val, NewSSAValue)
-                push!(type_refine_phi, ssaval)
+                push!(type_refine_phi, ssaval.id)
             end
             typ = incoming_val == undef_token ? MaybeUndef(Union{}) : typ_for_val(incoming_val, ci)
-            new_node_id = ssaval - length(ir.stmts)
-            old_entry = ir.new_nodes[new_node_id]
+            old_entry = ir.new_nodes[ssaval.id]
             if isa(typ, DelayedTyp)
-                push!(type_refine_phi, ssaval)
+                push!(type_refine_phi, ssaval.id)
             end
             new_typ = isa(typ, DelayedTyp) ? Union{} : tmerge(old_entry.typ, typ)
-            ir.new_nodes[new_node_id] = NewNode(old_entry.pos, old_entry.attach_after, new_typ, node, old_entry.line)
-            incoming_vals[slot] = NewSSAValue(ssaval)
+            ir.new_nodes[ssaval.id] = NewNode(old_entry.pos, old_entry.attach_after, new_typ, node, old_entry.line)
+            incoming_vals[slot] = ssaval
         end
         (item in visited) && continue
         # Record phi_C nodes if necessary
@@ -654,7 +653,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 typ = ivalundef ? MaybeUndef(Union{}) : ci.slottypes[slot_id(slot)]
                 push!(node.values,
                     NewSSAValue(insert_node!(ir, first_insert_for_bb(code, cfg, item)+1,
-                                 typ, unode).id))
+                                 typ, unode).id - length(ir.stmts)))
             end
         end
         push!(visited, item)
@@ -694,7 +693,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                                 typ = MaybeUndef(Union{})
                             end
                             push!(phicnodes[exc][cidx][3].values,
-                                NewSSAValue(insert_node!(ir, idx, typ, node, true).id))
+                                NewSSAValue(insert_node!(ir, idx, typ, node, true).id - length(ir.stmts)))
                         end
                     end
                 end
@@ -717,12 +716,12 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
     # Convert into IRCode form
     new_code = ir.stmts
     ssavalmap = Any[SSAValue(-1) for _ in 1:(length(ci.ssavaluetypes)+1)]
-    types = Any[Any for _ in 1:length(new_code)]
+    result_types = Any[Any for _ in 1:length(new_code)]
     # Detect statement positions for assignments and construct array
     for (idx, stmt) in Iterators.enumerate(code)
         if isexpr(stmt, :(=)) && isa(stmt.args[1], SSAValue)
             ssavalmap[stmt.args[1].id + 1] = SSAValue(idx)
-            types[idx] = ci.ssavaluetypes[stmt.args[1].id + 1]
+            result_types[idx] = ci.ssavaluetypes[stmt.args[1].id + 1]
             stmt = stmt.args[2]
             if isa(stmt, PhiNode)
                 edges = Any[edge == 0 ? 0 : block_for_inst(cfg, edge) for edge in stmt.edges]
@@ -746,13 +745,13 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
             new_typ = Union{}
             # TODO: This could just be the ones that depend on other phis
             push!(type_refine_phi, ssa.id)
-            new_idx = ssa.id - length(ir.stmts)
+            new_idx = ssa.id
             node = ir.new_nodes[new_idx]
             for i = 1:length(node.node.values)
                 orig_typ = typ = typ_for_val(node.node.values[i], ci)
                 @assert !isa(typ, MaybeUndef)
                 while isa(typ, DelayedTyp)
-                    typ = ir.new_nodes[typ.phi.id - length(ir.stmts)].typ
+                    typ = types(ir)[typ.phi::NewSSAValue]
                 end
                 new_typ = tmerge(new_typ, typ)
             end
@@ -765,8 +764,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
     changed = true
     while changed
         changed = false
-        for phi in type_refine_phi
-            new_idx = phi - length(ir.stmts)
+        for new_idx in type_refine_phi
             node = ir.new_nodes[new_idx]
             new_typ = recompute_type(node.node, ci, ir)
             if !(node.typ ⊑ new_typ) || !(new_typ ⊑ node.typ)
@@ -775,19 +773,19 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
             end
         end
     end
-    types = Any[isa(types[i], DelayedTyp) ? ir.new_nodes[types[i].phi.id - length(ir.stmts)].typ : types[i] for i in 1:length(types)]
+    result_types = Any[isa(result_types[i], DelayedTyp) ? types(ir)[result_types[i].phi::NewSSAValue] : result_types[i] for i in 1:length(result_types)]
     new_nodes = NewNode[let node = ir.new_nodes[i]
-            typ = isa(node.typ, DelayedTyp) ? ir.new_nodes[node.typ.phi.id - length(ir.stmts)].typ : node.typ
+            typ = isa(node.typ, DelayedTyp) ? types(ir)[node.typ.phi::NewSSAValue] : node.typ
             NewNode(node.pos, node.attach_after, typ, node.node, node.line)
         end for i in 1:length(ir.new_nodes)]
     # Renumber SSA values
-    new_code = Any[new_to_regular(renumber_ssa!(new_code[i], ssavalmap)) for i in 1:length(new_code)]
+    new_code = Any[new_to_regular(renumber_ssa!(new_code[i], ssavalmap), length(ir.stmts)) for i in 1:length(new_code)]
     new_nodes = NewNode[let node = new_nodes[i]
             NewNode(node.pos, node.attach_after, node.typ,
-            new_to_regular(renumber_ssa!(node.node, ssavalmap)),
+            new_to_regular(renumber_ssa!(node.node, ssavalmap), length(ir.stmts)),
             node.line)
         end for i in 1:length(new_nodes)]
-    ir = IRCode(ir, new_code, types, ir.lines, ir.flags, ir.cfg, new_nodes)
+    ir = IRCode(ir, new_code, result_types, ir.lines, ir.flags, ir.cfg, new_nodes)
     @timeit "domsort" ir = domsort_ssa!(ir, domtree)
     return ir
 end


### PR DESCRIPTION
We currently have a check disabled in the verifier (https://github.com/JuliaLang/julia/blob/master/base/compiler/ssair/verify.jl#L89-L96), which didn't seem to cause problems in practice and as a result wasn't addressed before the new optimizer was turned on. However, @vtjnash requested that this invariant hold and it would be good to have it to catch errors in the optimizer. This is a bunch of cleanup work and bugfixes that gets most of the way there, but not quite (for completeness slot2ssa needs to insert additional PiNode). However, @JeffBezanson is also currently doing a bunch of work on that function, so before we both rewrite it in incompatible ways, I figured I'd get this prep work in and revisit the overall issue once things have settled down a bit more.