### PR TITLE
Fix JULIA_TESTFULL tests for SubArray

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -31,6 +31,8 @@ _Agen(A, i1) = [A[j1] for j1 in i1]
 _Agen(A, i1, i2) = [A[j1,j2] for j1 in i1, j2 in i2]
 _Agen(A, i1, i2, i3) = [A[j1,j2,j3] for j1 in i1, j2 in i2, j3 in i3]
 _Agen(A, i1, i2, i3, i4) = [A[j1,j2,j3,j4] for j1 in i1, j2 in i2, j3 in i3, j4 in i4]
+_Agen(A, i1, i2, i3, i4, i5) = [A[j1,j2,j3,j4,j5] for j1 in i1, j2 in i2, j3 in i3, j4 in i4, j5 in i5]
+_Agen(A, i1, i2, i3, i4, i5, i6) = [A[j1,j2,j3,j4,j5,j6] for j1 in i1, j2 in i2, j3 in i3, j4 in i4, j5 in i5, j6 in i6]
 
 function replace_colon(A::AbstractArray, I)
     Iout = Vector{Any}(undef, length(I))


### PR DESCRIPTION
We test a few higher dimensions than had been supported by the testsuite. This is a simple fix and is all that is required:

```
$ time JULIA_TESTFULL=1 make -C test subarray
make: Entering directory /home/mbauman/julia/test
    JULIA test/subarray
Test  (Worker) | Time (s) | GC (s) | GC % | Alloc (MB) | RSS (MB)
subarray   (1) |  3448.65 | 833.68 | 24.2 |  312818.37 |  8946.79

Test Summary: | Pass  Total
  Overall     |  219    219
    SUCCESS
make: Leaving directory /home/mbauman/julia/test

real    57m54.425s
user    57m19.639s
sys    0m27.468s
```