### PR TITLE
Regex documentation with julia-repl

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -67,8 +67,9 @@ end
 """
     @r_str -> Regex
 
-Construct a regex, such as `r"^[a-z]*\$"`. The regex also accepts one or more flags, listed
-after the ending quote, to change its behaviour:
+Construct a regex, such as `r"^[a-z]*\$"`, without interpolation and unescaping (except for
+quotation mark `"` which still has to be escaped). The regex also accepts one or more flags,
+listed after the ending quote, to change its behaviour:
 
 - `i` enables case-insensitive matching
 - `m` treats the `^` and `\$` tokens as matching the start and end of individual lines, as

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -832,6 +832,27 @@ julia> match(r"a+.*b+.*?d$"ism, "Goodbye,\nOh, angry,\nBad world\n")
 RegexMatch("angry,\nBad world")
 ```
 
+The `r"..."` literal is constructed without interpolation and unescaping (except for
+quotation mark `"` which still has to be escaped). Here is an example
+showing the difference from standard string literals:
+
+```julia-repl
+julia> x = 10
+10
+
+julia> r"$x"
+r"$x"
+
+julia> "$x"
+"10"
+
+julia> r"\x"
+r"\x"
+
+julia> "\x"
+ERROR: syntax: invalid escape sequence
+```
+
 Triple-quoted regex strings, of the form `r"""..."""`, are also supported (and may be convenient
 for regular expressions containing quotation marks or newlines).
 


### PR DESCRIPTION
Documenting regex with `julia-repl` to avoid Documenter.jl exception.