### PR TITLE
Doc conflict in juxtaposition multiplication and Float32

### DIFF
--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -671,11 +671,19 @@ where syntactic conflicts arise:
     `0` multiplied by the variable `xff`.
   * The floating-point literal expression `1e10` could be interpreted as the numeric literal `1` multiplied
     by the variable `e10`, and similarly with the equivalent `E` form.
+  * The 32-bit floating-point literal expression `1.5f22` could be interpreted as the numeric literal
+    `1.5` multiplied by the variable `f22`.
 
-In both cases, we resolve the ambiguity in favor of interpretation as numeric literals:
+In all cases, we resolve the ambiguity in favor of interpretation as numeric literals:
 
   * Expressions starting with `0x` are always hexadecimal literals.
   * Expressions starting with a numeric literal followed by `e` or `E` are always floating-point literals.
+  * Expressions starting with a numeric literal followed by `f` are always 32-bit floating-point literals.
+
+Unlike `E`, which is equivalent to `e` in numeric literals for historical reasons, `F` is just another
+letter and does not behave like `f` in numeric literals. Hence, expressions starting with a numeric literal
+followed by `F` are interpreted as the numerical literal multiplied by a variable, which means that, for
+example, `1.5F22` is equal to `1.5 * F22`.
 
 ## Literal zero and one
 


### PR DESCRIPTION
The documentation was extended by clearly stating the syntax conflict between the juxtaposition multiplication and `Float32` literals written in engineering notation, such as `1.5f22`.

We had a problem when implementing SGP4 algorithm because we have a lot of variables named `f11, f12, f22, etc.` and constants named `F400, F300, etc.` (do not ask me why, this dates back to Fortran IV probably). Then, we are using juxtaposition multiplication in constants and variables like:

```julia
f32 = 1.4f11 + 1.5F400 # Just an example, it is not the real equation...
```

which we were hoping to be equal to `1.4*f11 + 1.5*F400`. It took sometime to figure out the problem :)