### PR TITLE
Update the resources required to build Julia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ By default you will be building the latest unstable version of Julia. However, m
 
 Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.)
 When compiled the first time, it will automatically download and build its [external dependencies](#required-build-tools-and-external-libraries).
-This takes a while, but only has to be done once. If the defaults in the build do not work for you, and you need to set specific make parameters, you can save them in `Make.user`. You can create the file at the root folder of the source if it does not exist. The build will automatically check for the existence of `Make.user` and use it if it exists.
-Building Julia requires 1.5GiB of disk space and approximately 700MiB of virtual memory.
+This takes a while, but only has to be done once. If the defaults in the build do not work for you, and you need to set specific make parameters, you can save them in `Make.user`, and place the file in the root of your Julia source. The build will automatically check for the existence of `Make.user` and use it if it exists.
+Building Julia requires 5GiB of disk space and approximately 2GiB of virtual memory.
 
 For builds of julia starting with 0.5.0-dev, you can create out-of-tree builds of Julia by specifying `make O=<build-directory> configure` on the command line. This will create a directory mirror, with all of the necessary Makefiles to build Julia, in the specified directory. These builds will share the source files in Julia and `deps/srccache`. Each out-of-tree build directory can have its own `Make.user` file to override the global `Make.user` file in the top-level folder.
 


### PR DESCRIPTION
Perhaps we need even more resources to build Julia. Is 2GiB memory sufficient, or should it be 4GiB?