### PR TITLE
mpfr: speed improvements

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -36,6 +36,7 @@ function __init__()
     catch ex
         Base.showerror_nostdio(ex, "WARNING: Error during initialization of module MPFR")
     end
+    nothing
 end
 
 const ROUNDING_MODE = RefValue{Cint}(0)

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -313,11 +313,6 @@ function serialize(s::AbstractSerializer, n::BigInt)
     serialize(s, string(n, base = 62))
 end
 
-function serialize(s::AbstractSerializer, n::BigFloat)
-    serialize_type(s, BigFloat)
-    serialize(s, string(n))
-end
-
 function serialize(s::AbstractSerializer, ex::Expr)
     serialize_cycle(s, ex) && return
     l = length(ex.args)
@@ -1183,8 +1178,6 @@ function deserialize(s::AbstractSerializer, T::Type{Dict{K,V}}) where {K,V}
     end
     return t
 end
-
-deserialize(s::AbstractSerializer, ::Type{BigFloat}) = parse(BigFloat, deserialize(s))
 
 deserialize(s::AbstractSerializer, ::Type{BigInt}) = parse(BigInt, deserialize(s), base = 62)
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -137,15 +137,16 @@ const REF_OBJECT_TAG       = Int32(o0+13)
 const FULL_GLOBALREF_TAG   = Int32(o0+14)
 const HEADER_TAG           = Int32(o0+15)
 
-writetag(s::IO, tag) = write(s, UInt8(tag))
+writetag(s::IO, tag) = (write(s, UInt8(tag)); nothing)
 
 function write_as_tag(s::IO, tag)
     tag < VALUE_TAGS && write(s, UInt8(0))
     write(s, UInt8(tag))
+    nothing
 end
 
 # cycle handling
-function serialize_cycle(s::AbstractSerializer, x)
+function serialize_cycle(s::AbstractSerializer, @nospecialize(x))
     offs = get(s.table, x, -1)::Int
     if offs != -1
         if offs <= typemax(UInt16)
@@ -225,6 +226,7 @@ function serialize(s::AbstractSerializer, x::Symbol)
         write(s.io, Int32(len))
     end
     unsafe_write(s.io, pname, len)
+    nothing
 end
 
 function serialize_array_data(s::IO, a)
@@ -290,6 +292,7 @@ function serialize(s::AbstractSerializer, ss::String)
         write(s.io, Int64(len))
     end
     write(s.io, ss)
+    nothing
 end
 
 function serialize(s::AbstractSerializer, ss::SubString{String})
@@ -546,6 +549,7 @@ function serialize_type_data(s, t::DataType)
             end
         end
     end
+    nothing
 end
 
 function serialize(s::AbstractSerializer, t::DataType)
@@ -575,6 +579,7 @@ function serialize(s::AbstractSerializer, n::Int32)
         writetag(s.io, INT32_TAG)
         write(s.io, n)
     end
+    nothing
 end
 
 function serialize(s::AbstractSerializer, n::Int64)
@@ -587,6 +592,7 @@ function serialize(s::AbstractSerializer, n::Int64)
         writetag(s.io, INT64_TAG)
         write(s.io, n)
     end
+    nothing
 end
 
 serialize(s::AbstractSerializer, ::Type{Bottom}) = write_as_tag(s.io, BOTTOM_TAG)
@@ -636,6 +642,7 @@ function serialize_any(s::AbstractSerializer, @nospecialize(x))
             end
         end
     end
+    nothing
 end
 
 """

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -853,11 +853,17 @@ end
 @test_throws ArgumentError parse(BigFloat, "1\0")
 
 @testset "serialization (issue #12386)" begin
-    b = IOBuffer()
-    x = 2.1 * big(pi)
-    serialize(b, x)
-    seekstart(b)
-    @test deserialize(b) == x
+    b = PipeBuffer()
+    let x = setprecision(53) do
+            return 2.1 * big(pi)
+        end
+        serialize(b, x)
+        @test deserialize(b) == x
+    end
+    let x = BigFloat(Inf, 46)
+        serialize(b, x)
+        @test deserialize(b) == x == BigFloat(Inf, 2)
+    end
 end
 @test isnan(sqrt(BigFloat(NaN)))
 

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -142,6 +142,9 @@ try
 
               g() = override(1.0)
               Test.@test g() === 2.0 # compile this
+
+              const abigfloat_f() = big"12.34"
+              const abigfloat_x = big"43.21"
           end
           """)
     @test_throws ErrorException Core.kwfunc(Base.nothing) # make sure `nothing` didn't have a kwfunc (which would invalidate the attempted test)
@@ -164,6 +167,10 @@ try
         @test Foo.override(1.0e0) == Float64('a')
         @test Foo.override(1.0f0) == 'b'
         @test Foo.override(UInt(1)) == 2
+
+        # Issue #15722
+        @test Foo.abigfloat_f()::BigFloat == big"12.34"
+        @test (Foo.abigfloat_x::BigFloat + 21) == big"64.21"
     end
 
     cachedir = joinpath(dir, "compiled", "v$(VERSION.major).$(VERSION.minor)")


### PR DESCRIPTION
Unlike GMP / BigInt, the MPFR / BigFloat library exposes an interface for external allocation:
http://www.mpfr.org/mpfr-current/mpfr.html#Custom-Interface

Using that allows us to use our fast memory-pool gc, and avoid adding finalizers and use the slow malloc/free functions, and allows us to better track memory pressure.

```julia
function benchwork(x, y)
    for i in 1:100000000
          x += y
     end
     return x
end
@time benchwork(big"0.0", big"23.0")
```
```
 12.923691 seconds (200.00 M allocations: 8.196 GiB, 31.56% gc time)
  5.469907 seconds (200.00 M allocations: 10.431 GiB, 6.15% gc time)
```
(`@profile` now indicates that this is now about equal parts mpfr time and allocation-related time)