### PR TITLE
optimizer: lower inline cost threshold

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -82,7 +82,6 @@
 #mutable struct Expr
 #    head::Symbol
 #    args::Array{Any,1}
-#    typ::Any
 #end
 
 #struct LineNumberNode

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -341,7 +341,7 @@ function precise_container_type(@nospecialize(arg), @nospecialize(typ), vtypes::
     if isa(arg, Expr) && arg.head === :call && (abstract_evals_to_constant(arg.args[1], svec, vtypes, sv) ||
                                                 abstract_evals_to_constant(arg.args[1], tuple, vtypes, sv))
         aa = arg.args
-        result = Any[ (isa(aa[j],Expr) ? aa[j].typ : abstract_eval(aa[j],vtypes,sv)) for j=2:length(aa) ]
+        result = Any[ abstract_eval(aa[j],vtypes,sv) for j=2:length(aa) ]
         if _any(isvarargtype, result)
             return Any[Vararg{Any}]
         end
@@ -898,7 +898,6 @@ function abstract_eval(@nospecialize(e), vtypes::VarTable, sv::InferenceState)
         # replace singleton types with their equivalent Const object
         t = Const(t.instance)
     end
-    e.typ = t
     return t
 end
 

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -788,6 +788,21 @@ function abstract_eval_cfunction(e::Expr, vtypes::VarTable, sv::InferenceState)
     nothing
 end
 
+# convert an inferred static parameter value to the inferred type of a static_parameter expression
+function sparam_type(@nospecialize(val))
+    if isa(val, TypeVar)
+        if Any <: val.ub
+            # static param bound to typevar
+            # if the tvar is not known to refer to anything more specific than Any,
+            # the static param might actually be an integer, symbol, etc.
+            return Any
+        else
+            return UnionAll(val, Type{val})
+        end
+    end
+    return AbstractEvalConstant(val)
+end
+
 function abstract_eval(@nospecialize(e), vtypes::VarTable, sv::InferenceState)
     if isa(e, QuoteNode)
         return AbstractEvalConstant((e::QuoteNode).value)
@@ -834,18 +849,7 @@ function abstract_eval(@nospecialize(e), vtypes::VarTable, sv::InferenceState)
         n = e.args[1]
         t = Any
         if 1 <= n <= length(sv.sp)
-            val = sv.sp[n]
-            if isa(val, TypeVar)
-                if Any <: val.ub
-                    # static param bound to typevar
-                    # if the tvar is not known to refer to anything more specific than Any,
-                    # the static param might actually be an integer, symbol, etc.
-                else
-                    t = UnionAll(val, Type{val})
-                end
-            else
-                t = AbstractEvalConstant(val)
-            end
+            t = sparam_type(sv.sp[n])
         end
     elseif e.head === :method
         t = (length(e.args) == 1) ? Any : Nothing

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -186,7 +186,7 @@ function optimize(me::InferenceState)
         # (issue #20704)
         # TODO: Improve this analysis; if a function is marked @pure we should really
         # only care about certain errors (e.g. method errors and type errors).
-        if length(me.src.code) < 10
+        if length(me.src.code) < 100
             proven_pure = true
             for i in 1:length(me.src.code)
                 if !statement_effect_free(me.src.code[i], me, me.src.ssavaluetypes[i])

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -66,8 +66,6 @@ function OptimizationState(linfo::MethodInstance, params::Params)
     return OptimizationState(linfo, src, params)
 end
 
-include("compiler/ssair/driver.jl")
-
 _topmod(sv::OptimizationState) = _topmod(sv.mod)
 
 function update_valid_age!(min_valid::UInt, max_valid::UInt, sv::OptimizationState)
@@ -343,17 +341,15 @@ function finish(me::InferenceState)
     nothing
 end
 
-function maybe_widen_conditional(vt)
-    if isa(vt, Conditional)
-        if vt.vtype === Bottom
-            vt = Const(false)
-        elseif vt.elsetype === Bottom
-            vt = Const(true)
-        else
-            vt = Bool
-        end
+maybe_widen_conditional(@nospecialize vt) = vt
+function maybe_widen_conditional(vt::Conditional)
+    if vt.vtype === Bottom
+        Const(false)
+    elseif vt.elsetype === Bottom
+        Const(true)
+    else
+        Bool
     end
-    vt
 end
 
 function annotate_slot_load!(e::Expr, vtypes::VarTable, sv::InferenceState, undefs::Array{Bool,1})
@@ -988,3 +984,5 @@ function return_type(@nospecialize(f), @nospecialize(t))
     end
     return rt
 end
+
+include("compiler/ssair/driver.jl")

--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -37,7 +37,7 @@ struct Params
     # reasonable defaults
     function Params(world::UInt;
                     inlining::Bool = inlining_enabled(),
-                    inline_cost_threshold::Int = 100,
+                    inline_cost_threshold::Int = 75,
                     inline_nonleaf_penalty::Int = 1000,
                     inline_tupleret_bonus::Int = 400,
                     max_methods::Int = 4,

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -57,11 +57,7 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, spvals:
     oldidx = 1
     changemap = fill(0, length(code))
     while idx <= length(code)
-        stmt = code[idx]
-        if isexpr(stmt, :(=))
-            stmt = stmt.args[2]
-        end
-        if isa(stmt, Expr) && stmt.typ === Union{}
+        if code[idx] isa Expr && ci.ssavaluetypes[idx] === Union{}
             if !(idx < length(code) && isexpr(code[idx+1], :unreachable))
                 insert!(code, idx + 1, ReturnNode())
                 insert!(ci.codelocs, idx + 1, ci.codelocs[idx])
@@ -115,7 +111,7 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, spvals:
              argtypes = ci.slottypes[1:(nargs+1)]
             IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), argtypes, meta, spvals)
         end
-    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs)
+    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs, spvals)
     return ir
 end
 

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -577,8 +577,9 @@ function singleton_type(@nospecialize(ft))
     return nothing
 end
 
-function analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data,
-                         stmttyp)
+function analyze_method!(idx::Int, @nospecialize(f), @nospecialize(ft), @nospecialize(metharg), methsp::SimpleVector,
+                         method::Method, stmt::Expr, atypes::Vector{Any}, sv::OptimizationState, @nospecialize(atype_unlimited),
+                         isinvoke::Bool, isapply::Bool, invoke_data::Union{InvokeData,Nothing}, @nospecialize(stmttyp))
     methsig = method.sig
 
     # Check whether this call just evaluates to a constant

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -368,7 +368,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
         if length(pn.edges) == 1
             return_value = pn.values[1]
         else
-            return_value = insert_node_here!(compact, pn, stmt.typ, compact.result_lines[idx])
+            return_value = insert_node_here!(compact, pn, compact_exprtype(compact, SSAValue(idx)), compact.result_lines[idx])
         end
     end
     return_value
@@ -397,7 +397,6 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int,
             a <: m && continue
             # Generate isa check
             isa_expr = Expr(:call, isa, argexprs[i], m)
-            isa_expr.typ = Bool
             ssa = insert_node_here!(compact, isa_expr, Bool, line)
             if cond === true
                 cond = ssa
@@ -438,7 +437,6 @@ function ir_inline_unionsplit!(compact::IncrementalCompact, idx::Int,
     # We're now in the fall through block, decide what to do
     if item.fully_covered
         e = Expr(:call, GlobalRef(Core, :throw), fatal_type_bound_error)
-        e.typ = Union{}
         insert_node_here!(compact, e, Union{}, line)
         insert_node_here!(compact, ReturnNode(), Union{}, line)
         finish_current_bb!(compact)
@@ -501,7 +499,7 @@ function batch_inline!(todo::Vector{Any}, ir::IRCode, linetable::Vector{LineInfo
                 end
                 if item.isinvoke
                     argexprs = rewrite_invoke_exprargs!((node, typ)->insert_node_here!(compact, node, typ, compact.result_lines[idx]),
-                                                arg->compact_exprtype(compact, arg), argexprs)
+                                                argexprs)
                 end
                 if isa(item, InliningTodo)
                     compact.ssa_rename[compact.idx-1] = ir_inline_item!(compact, idx, argexprs, linetable, item, boundscheck, state.todo_bbs)
@@ -549,24 +547,23 @@ function spec_lambda(@nospecialize(atype), sv::OptimizationState, @nospecialize(
     linfo
 end
 
-function rewrite_apply_exprargs!(inserter, exprtype, argexprs::Vector{Any})
+function rewrite_apply_exprargs!(inserter, typefunc, argexprs::Vector{Any})
     new_argexprs = Any[argexprs[2]]
     # Flatten all tuples
     for arg in argexprs[3:end]
-        tupT = exprtype(arg)
+        tupT = typefunc(arg)
         t = widenconst(tupT)
         for i = 1:length(t.parameters)
             # Insert a getfield call here
             new_call = Expr(:call, Core.getfield, arg, i)
-            new_call.typ = getfield_tfunc(tupT, Const(i))
-            push!(new_argexprs, inserter(new_call, new_call.typ))
+            push!(new_argexprs, inserter(new_call, getfield_tfunc(tupT, Const(i))))
         end
     end
     argexprs = new_argexprs
     return argexprs
 end
 
-function rewrite_invoke_exprargs!(inserter, exprtype, argexprs::Vector{Any})
+function rewrite_invoke_exprargs!(inserter, argexprs::Vector{Any})
     argexpr0 = argexprs[2]
     argexprs = argexprs[4:end]
     pushfirst!(argexprs, argexpr0)
@@ -580,13 +577,14 @@ function singleton_type(@nospecialize(ft))
     return nothing
 end
 
-function analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data)
+function analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data,
+                         stmttyp)
     methsig = method.sig
 
     # Check whether this call just evaluates to a constant
     if isa(f, widenconst(ft)) && !isdefined(method, :generator) && method.pure &&
-            isa(stmt.typ, Const) && stmt.typ.actual && is_inlineable_constant(stmt.typ.val)
-        return ConstantCase(quoted(stmt.typ.val), method, Any[methsp...], metharg)
+            isa(stmttyp, Const) && stmttyp.actual && is_inlineable_constant(stmttyp.val)
+        return ConstantCase(quoted(stmttyp.val), method, Any[methsp...], metharg)
     end
 
     # Check that we habe the correct number of arguments
@@ -708,7 +706,6 @@ function handle_single_case!(ir::IRCode, stmt::Expr, idx::Int, @nospecialize(cas
         if isinvoke
             stmt.args = rewrite_invoke_exprargs!(
                 (node, typ)->insert_node!(ir, idx, typ, node),
-                arg->exprtype(arg, ir, sv.sp),
                 stmt.args)
         end
         stmt.head = :invoke
@@ -731,23 +728,27 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
         isempty(eargs) && continue
         arg1 = eargs[1]
 
-        ft = exprtype(arg1, ir, sv.sp)
+        ft = argextype(arg1, ir, sv.sp)
         has_free_typevars(ft) && continue
         isa(ft, Conditional) && (ft = Bool)
         f = singleton_type(ft)
+        # TODO: llvmcall can contain other calls as arguments, so this code doesn't work on it
+        f === Core.Intrinsics.llvmcall && continue
+        f === Core.Intrinsics.cglobal && continue
 
         atypes = Vector{Any}(undef, length(stmt.args))
         atypes[1] = ft
         ok = true
         for i = 2:length(stmt.args)
-            a = exprtype(stmt.args[i], ir, sv.sp)
+            a = argextype(stmt.args[i], ir, sv.sp)
             (a === Bottom || isvarargtype(a)) && (ok = false; break)
             atypes[i] = a
         end
         ok || continue
 
         # Check if we match any of the early inliners
-        res = early_inline_special_case(ir, f, ft, stmt, atypes, sv)
+        calltype = ir.types[idx]
+        res = early_inline_special_case(ir, f, ft, stmt, atypes, sv, calltype)
         if res !== nothing
             ir.stmts[idx] = res
             continue
@@ -768,7 +769,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
         isapply = false
         if f === Core._apply
             new_atypes = Any[]
-            ft = exprtype(stmt.args[2], ir, sv.sp)
+            ft = argextype(stmt.args[2], ir, sv.sp)
             has_free_typevars(ft) && continue
             isa(ft, Conditional) && (ft = Bool)
             f = singleton_type(ft)
@@ -795,7 +796,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
                 # get a good method match). This pattern is used in the array code a bunch.
                 if isa(def, SSAValue) && is_tuple_call(ir, ir[def])
                     for tuparg in ir[def].args[2:end]
-                        push!(new_atypes, exprtype(tuparg, ir, sv.sp))
+                        push!(new_atypes, argextype(tuparg, ir, sv.sp))
                     end
                 elseif isa(def, Argument) && def.n === length(ir.argtypes) && !isempty(sv.result_vargs)
                     append!(new_atypes, sv.result_vargs)
@@ -811,7 +812,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
         # Independent of whether we can inline, the above analysis allows us to rewrite
         # this apply call to a regular call
         if isapply
-            stmt.args = rewrite_apply_exprargs!((node, typ)->insert_node!(ir, idx, typ, node), arg->exprtype(arg, ir, sv.sp), stmt.args)
+            stmt.args = rewrite_apply_exprargs!((node, typ)->insert_node!(ir, idx, typ, node), arg->argextype(arg, ir, sv.sp), stmt.args)
         end
 
         if f !== Core.invoke && (isa(f, IntrinsicFunction) || ft ⊑ IntrinsicFunction || isa(f, Builtin) || ft ⊑ Builtin)
@@ -855,7 +856,8 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
             (metharg, methsp) = ccall(:jl_type_intersection_with_env, Any, (Any, Any),
                                     atype_unlimited, method.sig)::SimpleVector
             methsp = methsp::SimpleVector
-            result = analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data)
+            result = analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data,
+                                     calltype)
             handle_single_case!(ir, stmt, idx, result, isinvoke, todo, sv)
             continue
         end
@@ -883,7 +885,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
                 fully_covered = false
                 continue
             end
-            case = analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, metharg, isinvoke, isapply, invoke_data)
+            case = analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, metharg, isinvoke, isapply, invoke_data, calltype)
             if case === nothing
                 fully_covered = false
                 continue
@@ -909,7 +911,8 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
                 for (i, match) in enumerate(meth)
                     (metharg, methsp, method) = (match[1]::Type, match[2]::SimpleVector, match[3]::Method)
                     metharg′ <: method.sig || continue
-                    case = analyze_method!(idx, f, ft, metharg′, methsp, method, stmt, atypes, sv, metharg′, isinvoke, isapply, invoke_data)
+                    case = analyze_method!(idx, f, ft, metharg′, methsp, method, stmt, atypes, sv, metharg′, isinvoke, isapply, invoke_data,
+                                           calltype)
                     if case !== nothing
                         found_any = true
                         push!(cases, Pair{Any,Any}(metharg′, case))
@@ -930,7 +933,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
             methsp = meth[1][2]::SimpleVector
             method = meth[1][3]::Method
             fully_covered = true
-            case = analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data)
+            case = analyze_method!(idx, f, ft, metharg, methsp, method, stmt, atypes, sv, atype_unlimited, isinvoke, isapply, invoke_data, calltype)
             case == nothing && continue
             push!(cases, Pair{Any,Any}(metharg, case))
         end
@@ -950,8 +953,8 @@ end
 
 function mk_tuplecall!(compact::IncrementalCompact, args::Vector{Any}, line_idx::Int)
     e = Expr(:call, TOP_TUPLE, args...)
-    e.typ = tuple_tfunc(Tuple{Any[widenconst(compact_exprtype(compact, args[i])) for i in 1:length(args)]...})
-    return insert_node_here!(compact, e, e.typ, line_idx)
+    etyp = tuple_tfunc(Tuple{Any[widenconst(compact_exprtype(compact, args[i])) for i in 1:length(args)]...})
+    return insert_node_here!(compact, e, etyp, line_idx)
 end
 
 function linear_inline_eligible(ir::IRCode)
@@ -994,7 +997,8 @@ function compute_invoke_data(@nospecialize(atypes), argexprs::Vector{Any}, sv::O
     return svec(f, ft, atypes, argexprs, invoke_data)
 end
 
-function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector{Any}, sv::OptimizationState)
+function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector{Any}, sv::OptimizationState,
+                                   @nospecialize(etype))
     if (f === typeassert || ft ⊑ typeof(typeassert)) && length(atypes) == 3
         # typeassert(x::S, T) => x, when S<:T
         a3 = atypes[3]
@@ -1007,8 +1011,8 @@ function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(f
     end
     # special-case inliners for known pure functions that compute types
     if sv.params.inlining
-        if isa(e.typ, Const) # || isconstType(e.typ)
-            val = e.typ.val
+        if isa(etype, Const) # || isconstType(etype)
+            val = etype.val
             if (f === apply_type || f === fieldtype || f === typeof || f === (===) ||
                 f === Core.sizeof || f === isdefined ||
                 istopfunction(f, :typejoin) ||
@@ -1018,7 +1022,7 @@ function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(f
                 (f === Core.kwfunc && length(atypes) == 2) ||
                 (is_inlineable_constant(val) &&
                  (contains_is(_PURE_BUILTINS, f) ||
-                  (f === getfield && effect_free(e, ir, ir.spvals, false)) ||
+                  (f === getfield && effect_free(e, ir, ir.spvals, false, etype)) ||
                   (isa(f, IntrinsicFunction) && is_pure_intrinsic_optim(f)))))
                 return quoted(val)
             end
@@ -1029,37 +1033,35 @@ function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(f
 end
 
 function late_inline_special_case!(ir::IRCode, idx::Int, stmt::Expr, atypes::Vector{Any}, @nospecialize(f), @nospecialize(ft))
+    typ = ir.types[idx]
     if length(atypes) == 3 && istopfunction(f, :!==)
         # special-case inliner for !== that precedes _methods_by_ftype union splitting
         # and that works, even though inference generally avoids inferring the `!==` Method
-        if isa(stmt.typ, Const)
-            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+        if isa(typ, Const)
+            ir[SSAValue(idx)] = quoted(typ.val)
             return true
         end
         cmp_call = Expr(:call, GlobalRef(Core, :(===)), stmt.args[2], stmt.args[3])
-        cmp_call.typ = Bool
         cmp_call_ssa = insert_node!(ir, idx, Bool, cmp_call)
         not_call = Expr(:call, GlobalRef(Core.Intrinsics, :not_int), cmp_call_ssa)
-        not_call.typ = Bool
         ir[SSAValue(idx)] = not_call
         return true
     elseif length(atypes) == 3 && istopfunction(f, :(>:))
         # special-case inliner for issupertype
         # that works, even though inference generally avoids inferring the `>:` Method
-        if isa(stmt.typ, Const)
-            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+        if isa(typ, Const)
+            ir[SSAValue(idx)] = quoted(typ.val)
             return true
         end
         subtype_call = Expr(:call, GlobalRef(Core, :(<:)), stmt.args[3], stmt.args[2])
-        subtype_call.typ = Bool
         ir[SSAValue(idx)] = subtype_call
         return true
     elseif f === return_type
-        if isconstType(stmt.typ)
-            ir[SSAValue(idx)] = quoted(stmt.typ.parameters[1])
+        if isconstType(typ)
+            ir[SSAValue(idx)] = quoted(typ.parameters[1])
             return true
-        elseif isa(stmt.typ, Const)
-            ir[SSAValue(idx)] = quoted(stmt.typ.val)
+        elseif isa(typ, Const)
+            ir[SSAValue(idx)] = quoted(typ.val)
             return true
         end
     end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -868,7 +868,11 @@ end
 function maybe_erase_unused!(extra_worklist, compact, idx, callback = x->nothing)
     stmt = compact.result[idx]
     stmt === nothing && return false
-    effect_free = stmt_effect_free(stmt, compact, compact.ir.spvals)
+    if compact_exprtype(compact, SSAValue(idx)) === Bottom
+        effect_free = false
+    else
+        effect_free = stmt_effect_free(stmt, compact, compact.ir.spvals)
+    end
     if effect_free
         for ops in userefs(stmt)
             val = ops[]

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-function inflate_ir(ci::CodeInfo)
+function inflate_ir(ci::CodeInfo, spvals::SimpleVector)
     code = copy_exprargs(ci.code)
     for i = 1:length(code)
         if isa(code[i], Expr)
@@ -35,7 +35,7 @@ function inflate_ir(ci::CodeInfo)
     newslottypes = ci.inferred ? copy(ci.slottypes) : Any[ Any for i = 1:length(ci.slotnames) ]
     ssavaluetypes = ci.ssavaluetypes isa Vector{Any} ? copy(ci.ssavaluetypes) : Any[ Any for i = 1:ci.ssavaluetypes ]
     ir = IRCode(code, ssavaluetypes, copy(ci.codelocs), copy(ci.ssaflags), cfg, collect(LineInfoNode, ci.linetable),
-                newslottypes, ci.linetable[1].mod, Any[])
+                newslottypes, Any[], spvals)
     return ir
 end
 

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -271,7 +271,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
                 lifted_leaves[leaf_key] = RefValue{Any}(lifted)
                 continue
             elseif isexpr(def, :new)
-                typ = def.typ
+                typ = types(compact)[leaf]
                 if isa(typ, UnionAll)
                     typ = unwrap_unionall(typ)
                 end
@@ -555,11 +555,11 @@ function getfield_elim_pass!(ir::IRCode, domtree)
                     old_preserves[pidx] = nothing
                     continue
                 elseif isexpr(def, :new)
-                    typ = def.typ
+                    typ = widenconst(compact_exprtype(compact, SSAValue(defidx)))
                     if isa(typ, UnionAll)
                         typ = unwrap_unionall(typ)
                     end
-                    if !typ.mutable
+                    if typ isa DataType && !typ.mutable
                         process_immutable_preserve(new_preserves, compact, def)
                         old_preserves[pidx] = nothing
                         continue
@@ -576,7 +576,6 @@ function getfield_elim_pass!(ir::IRCode, domtree)
                 old_preserves = filter(ssa->ssa !== nothing, old_preserves)
                 new_expr = Expr(:foreigncall, stmt.args[1:(6+nccallargs-1)]...,
                     old_preserves..., new_preserves...)
-                new_expr.typ = stmt.typ
                 compact[idx] = new_expr
             end
             continue
@@ -674,7 +673,7 @@ function getfield_elim_pass!(ir::IRCode, domtree)
         # Find the type for this allocation
         defexpr = ir[SSAValue(idx)]
         isexpr(defexpr, :new) || continue
-        typ = defexpr.typ
+        typ = ir.types[idx]
         if isa(typ, UnionAll)
             typ = unwrap_unionall(typ)
         end
@@ -746,7 +745,6 @@ function getfield_elim_pass!(ir::IRCode, domtree)
             old_preserves = filter(ssa->!isa(ssa, SSAValue) || !(ssa.id in intermediaries), useexpr.args[(6+nccallargs):end])
             new_expr = Expr(:foreigncall, useexpr.args[1:(6+nccallargs-1)]...,
                 old_preserves..., new_preserves...)
-            new_expr.typ = useexpr.typ
             ir[SSAValue(use)] = new_expr
         end
     end

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -68,9 +68,6 @@ function print_node(io::IO, idx, stmt, used, argnames, maxsize; color = true, pr
         Base.print(io, "(")
         Base.print(io, join(map(arg->sprint(io->print_ssa(io, arg, argnames)), stmt.args[2:end]), ", "))
         Base.print(io, ")")
-        if print_typ && stmt.typ !== Any
-            Base.print(io, "::$(stmt.typ)")
-        end
     elseif isexpr(stmt, :invoke)
         print(io, "invoke ")
         linfo = stmt.args[1]
@@ -85,9 +82,6 @@ function print_node(io::IO, idx, stmt, used, argnames, maxsize; color = true, pr
         end
         Base.print(io, join((print_arg(i) for i=1:(length(stmt.args)-2)), ", "))
         Base.print(io, ")")
-        if print_typ && stmt.typ !== Any
-            Base.print(io, "::$(stmt.typ)")
-        end
     elseif isexpr(stmt, :new)
         Base.print(io, "new(")
         Base.print(io, join(String[sprint(io->print_ssa(io, arg, argnames)) for arg in stmt.args], ", "))

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -133,7 +133,7 @@ function retrieve_code_info(linfo::MethodInstance)
             c = copy_code_info(m.source)
         end
     end
-    return c
+    return c::CodeInfo
 end
 
 function code_for_method(method::Method, @nospecialize(atypes), sparams::SimpleVector, world::UInt, preexisting::Bool=false)
@@ -174,7 +174,9 @@ function method_for_inference_heuristics(method::Method, @nospecialize(sig), spa
     return nothing
 end
 
-function exprtype(@nospecialize(x), src, mod::Module)
+exprtype(@nospecialize(x), state) = exprtype(x, state.src, state.sp)
+
+function exprtype(@nospecialize(x), src, spvals::SimpleVector)
     if isa(x, Expr)
         return (x::Expr).typ
     elseif isa(x, SlotNumber)
@@ -185,8 +187,6 @@ function exprtype(@nospecialize(x), src, mod::Module)
         return abstract_eval_ssavalue(x::SSAValue, src)
     elseif isa(x, Argument)
         return isa(src, IncrementalCompact) ? src.ir.argtypes[x.n] : src.argtypes[x.n]
-    elseif isa(x, Symbol)
-        return abstract_eval_global(mod, x::Symbol)
     elseif isa(x, QuoteNode)
         return AbstractEvalConstant((x::QuoteNode).value)
     elseif isa(x, GlobalRef)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -37,11 +37,11 @@ anymap(f::Function, a::Array{Any,1}) = Any[ f(a[i]) for i in 1:length(a) ]
 
 _topmod(m::Module) = ccall(:jl_base_relative_to, Any, (Any,), m)::Module
 
-function istopfunction(topmod, @nospecialize(f), sym)
-    if isdefined(Main, :Base) && isdefined(Main.Base, sym) && isconst(Main.Base, sym) && f === getfield(Main.Base, sym)
-        return true
-    elseif isdefined(topmod, sym) && isconst(topmod, sym) && f === getfield(topmod, sym)
-        return true
+function istopfunction(@nospecialize(f), name::Symbol)
+    tn = typeof(f).name
+    if tn.mt.name === name
+        top = _topmod(tn.module)
+        return isdefined(top, name) && isconst(top, name) && f === getfield(top, name)
     end
     return false
 end

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -35,7 +35,6 @@ end
 function copy(e::Expr)
     n = Expr(e.head)
     n.args = copy_exprargs(e.args)
-    n.typ = e.typ
     return n
 end
 

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -80,7 +80,6 @@ Expr
     1: Symbol +
     2: Int64 1
     3: Int64 1
-  typ: Any
 ```
 
 `Expr` objects may also be nested:
@@ -324,8 +323,6 @@ Expr
         1: Symbol +
         2: Int64 1
         3: Int64 2
-      typ: Any
-  typ: Any
 ```
 
 As we have seen, such expressions support interpolation with `$`.
@@ -734,7 +731,6 @@ Expr
     3: String ") should equal b ("
     4: Symbol b
     5: String ")!"
-  typ: Any
 ```
 
 So now instead of getting a plain string in `msg_body`, the macro is receiving a full expression

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1004,7 +1004,6 @@ jl_expr_t *jl_exprn(jl_sym_t *head, size_t n)
                                             jl_expr_type);
     ex->head = head;
     ex->args = ar;
-    ex->etype = (jl_value_t*)jl_any_type;
     JL_GC_POP();
     return ex;
 }
@@ -1022,7 +1021,6 @@ JL_CALLABLE(jl_f__expr)
                                             jl_expr_type);
     ex->head = (jl_sym_t*)args[0];
     ex->args = ar;
-    ex->etype = (jl_value_t*)jl_any_type;
     JL_GC_POP();
     return (jl_value_t*)ex;
 }

--- a/src/dump.c
+++ b/src/dump.c
@@ -630,7 +630,6 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
             write_int32(s->s, l);
         }
         jl_serialize_value(s, e->head);
-        jl_serialize_value(s, e->etype);
         for (i = 0; i < l; i++) {
             jl_serialize_value(s, jl_exprarg(e, i));
         }
@@ -1488,8 +1487,6 @@ static jl_value_t *jl_deserialize_value_expr(jl_serializer_state *s, jl_value_t 
     jl_expr_t *e = jl_exprn((jl_sym_t*)jl_deserialize_value(s, NULL), len);
     if (usetable)
         backref_list.items[pos] = e;
-    e->etype = jl_deserialize_value(s, &e->etype);
-    jl_gc_wb(e, e->etype);
     jl_value_t **data = (jl_value_t**)(e->args->data);
     for (i = 0; i < len; i++) {
         data[i] = jl_deserialize_value(s, &data[i]);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1959,10 +1959,9 @@ void jl_init_types(void)
     jl_expr_type =
         jl_new_datatype(jl_symbol("Expr"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(3, "head", "args", "typ"),
-                        jl_svec(3, jl_sym_type, jl_array_any_type,
-                                 jl_any_type),
-                        0, 1, 3);
+                        jl_perm_symsvec(2, "head", "args"),
+                        jl_svec(2, jl_sym_type, jl_array_any_type),
+                        0, 1, 2);
 
     jl_module_type =
         jl_new_datatype(jl_symbol("Module"), core, jl_any_type, jl_emptysvec,

--- a/src/julia.h
+++ b/src/julia.h
@@ -506,7 +506,6 @@ typedef struct {
     JL_DATA_TYPE
     jl_sym_t *head;
     jl_array_t *args;
-    jl_value_t *etype;
 } jl_expr_t;
 
 // constants and type objects -------------------------------------------------

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -813,8 +813,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
                 n += jl_printf(out, ",%c", sep);
                 n += jl_static_show_x(out, jl_exprarg(e,i), depth);
             }
-            n += jl_printf(out, ")::");
-            n += jl_static_show_x(out, e->etype, depth);
+            n += jl_printf(out, ")");
         }
     }
     else if (jl_is_array_type(vt)) {

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -37,10 +37,10 @@ function code_warntype_legacy_ir(io::IO, src::Core.CodeInfo, rettype)
     print(emph_io, "\nBody:\n  ")
     body = Expr(:body)
     body.args = src.code
-    body.typ = rettype
     # Fix slot names and types in function body
     show_unquoted(IOContext(emph_io, :SOURCEINFO => src, :SOURCE_SLOTNAMES => slotnames),
                     body, 2)
+    print(emph_io, "::", rettype)
     print(emph_io, '\n')
 end
 
@@ -77,7 +77,8 @@ function code_warntype(io::IO, f, @nospecialize(t); verbose_linetable=false)
             code_warntype_legacy_ir(io, src, rettype)
         else
             print(io, "Body"); warntype_type_printer(io, rettype); println(io);
-            ir = Core.Compiler.inflate_ir(src)
+            # TODO: static parameter values
+            ir = Core.Compiler.inflate_ir(src, Core.svec())
             Base.IRShow.show_ir(io, ir, warntype_type_printer;
                                 argnames=Base.sourceinfo_slotnames(src), verbose_linetable=verbose_linetable)
         end

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -326,7 +326,6 @@ function serialize(s::AbstractSerializer, ex::Expr)
         write(s.io, Int32(l))
     end
     serialize(s, ex.head)
-    serialize(s, ex.typ)
     for a in ex.args
         serialize(s, a)
     end
@@ -964,9 +963,7 @@ function deserialize_expr(s::AbstractSerializer, len)
     e = Expr(:temp)
     resolve_ref_immediately(s, e)
     e.head = deserialize(s)::Symbol
-    ty = deserialize(s)
     e.args = Any[ deserialize(s) for i = 1:len ]
-    e.typ = ty
     e
 end
 

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -477,24 +477,25 @@ function is_typed_expr(e::Expr)
     end
     return false
 end
+is_typed_expr(@nospecialize other) = false
 test_inferred_static(@nospecialize(other)) = true
 test_inferred_static(slot::TypedSlot) = @test isdispatchelem(slot.typ)
 function test_inferred_static(expr::Expr)
-    if is_typed_expr(expr)
-        @test isdispatchelem(expr.typ)
-    end
     for a in expr.args
         test_inferred_static(a)
     end
 end
-function test_inferred_static(arrow::Pair)
+function test_inferred_static(arrow::Pair, all_ssa)
     code, rt = arrow
     @test isdispatchelem(rt)
     @test code.inferred
     @test all(isdispatchelem, code.slottypes)
-    @test all(isdispatchelem, code.ssavaluetypes)
-    for e in code.code
+    for i = 1:length(code.code)
+        e = code.code[i]
         test_inferred_static(e)
+        if all_ssa && is_typed_expr(e)
+            @test isdispatchelem(code.ssavaluetypes[i])
+        end
     end
 end
 
@@ -507,6 +508,7 @@ function f18679()
             return a[1]
         end
     end
+    error()
 end
 g18679(x::Tuple) = ()
 g18679() = g18679(any_undef_global::Union{Int, Tuple{}})
@@ -529,26 +531,28 @@ function g19348(x)
     return a + b + c[1]
 end
 
-for codetype in Any[
-        code_typed(f18679, ())[1],
-        code_typed(g18679, ())[1],
-        code_typed(h18679, ())[1],
-        code_typed(g19348, (typeof((1, 2.0)),))[1]]
+for (codetype, all_ssa) in Any[
+        (code_typed(f18679, ())[1], true),
+        (code_typed(g18679, ())[1], false),
+        (code_typed(h18679, ())[1], true),
+        (code_typed(g19348, (typeof((1, 2.0)),))[1], true)]
     # make sure none of the slottypes are left as Core.Compiler.Const objects
     code = codetype[1]
     @test all(x->isa(x, Type), code.slottypes)
     local notconst(@nospecialize(other)) = true
     notconst(slot::TypedSlot) = @test isa(slot.typ, Type)
     function notconst(expr::Expr)
-        @test isa(expr.typ, Type)
         for a in expr.args
             notconst(a)
         end
     end
-    for e in code.code
+    local i
+    for i = 1:length(code.code)
+        e = code.code[i]
         notconst(e)
+        @test isa(code.ssavaluetypes[i], Type)
     end
-    test_inferred_static(code)
+    test_inferred_static(codetype, all_ssa)
 end
 @test f18679() === ()
 @test_throws UndefVarError(:any_undef_global) g18679()
@@ -1549,12 +1553,15 @@ g26826(x) = getfield26826(x, :a, :b)
 # If this test is broken (especially if inference is getting a correct, but loose result,
 # like a Union) then it's potentially an indication that the optimizer isn't hitting the
 # InferenceResult cache properly for varargs methods.
-typed_code = Core.Compiler.code_typed(f26826, (Float64,))[1].first.code
+typed_code = Core.Compiler.code_typed(f26826, (Float64,))[1].first
 found_well_typed_getfield_call = false
-for stmt in typed_code
-    lhs = Meta.isexpr(stmt, :(=)) ? stmt.args[2] : stmt
-    if Meta.isexpr(lhs, :call) && lhs.args[1] == GlobalRef(Base, :getfield) && lhs.typ === Float64
-        global found_well_typed_getfield_call = true
+let i
+    for i = 1:length(typed_code.code)
+        stmt = typed_code.code[i]
+        rhs = Meta.isexpr(stmt, :(=)) ? stmt.args[2] : stmt
+        if Meta.isexpr(rhs, :call) && rhs.args[1] == GlobalRef(Base, :getfield) && typed_code.ssavaluetypes[i] === Float64
+            global found_well_typed_getfield_call = true
+        end
     end
 end
 

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -23,7 +23,6 @@ function test_inlined_symbols(func, argtypes)
     nl = length(src.slottypes)
     ast = Expr(:body)
     ast.args = src.code
-    ast.typ = rettype
     walk(ast) do e
         if isa(e, Core.Slot)
             @test 1 <= e.id <= nl

--- a/test/meta.jl
+++ b/test/meta.jl
@@ -177,7 +177,6 @@ let oldout = stdout
                 1: Symbol +
                 2: Symbol x
                 3: Symbol y
-              typ: Any
             """
     finally
         redirect_stdout(oldout)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -209,8 +209,6 @@ end
 # PR 13825
 let ex = :(a + b)
     @test string(ex) == "a + b"
-    ex.typ = Integer
-    @test string(ex) == "(a + b)::Integer"
 end
 foo13825(::Array{T, N}, ::Array, ::Vector) where {T, N} = nothing
 @test startswith(string(first(methods(foo13825))),

--- a/test/show.jl
+++ b/test/show.jl
@@ -779,7 +779,7 @@ end
 end
 
 let repr = sprint(dump, :(x = 1))
-    @test repr == "Expr\n  head: Symbol =\n  args: Array{Any}((2,))\n    1: Symbol x\n    2: $Int 1\n  typ: Any\n"
+    @test repr == "Expr\n  head: Symbol =\n  args: Array{Any}((2,))\n    1: Symbol x\n    2: $Int 1\n"
 end
 let repr = sprint(dump, Pair{String,Int64})
     @test repr == "Pair{String,Int64} <: Any\n  first::String\n  second::Int64\n"
@@ -1220,7 +1220,7 @@ end
 # Tests for code_typed linetable annotations
 function compute_annotations(f, types)
     src = code_typed(f, types)[1][1]
-    ir = Core.Compiler.inflate_ir(src)
+    ir = Core.Compiler.inflate_ir(src, Core.svec())
     la, lb, ll = Base.IRShow.compute_ir_line_annotations(ir)
     max_loc_method = maximum(length(s) for s in la)
     join((strip(string(a, " "^(max_loc_method-length(a)), b)) for (a, b) in zip(la, lb)), '\n')


### PR DESCRIPTION
It was probably too high.

I have a pet theory that since the new optimizer does a better job, there's no longer as much easy work for LLVM to do, resulting in more actual work being done (e.g. more than intended before).