### PR TITLE
Pkg3: fix adding and developing from url in Windows

### DIFF
--- a/stdlib/Pkg/src/REPLMode.jl
+++ b/stdlib/Pkg/src/REPLMode.jl
@@ -8,7 +8,7 @@ using UUIDs
 import REPL
 import REPL: LineEdit, REPLCompletions
 
-import ..devdir
+import ..devdir, ..Types.isdir_windows_workaround
 using ..Types, ..Display, ..Operations, ..API
 
 ############
@@ -142,7 +142,7 @@ end
 
 function parse_package(word::AbstractString; context=nothing)::PackageSpec
     word = replace(word, "~" => homedir())
-    if context in (CMD_ADD, CMD_DEVELOP) && isdir(word)
+    if context in (CMD_ADD, CMD_DEVELOP) && isdir_windows_workaround(word)
         pkg = PackageSpec()
         pkg.repo = Types.GitRepo(abspath(word))
         return pkg

--- a/stdlib/Pkg/test/pkg.jl
+++ b/stdlib/Pkg/test/pkg.jl
@@ -192,6 +192,11 @@ temp_pkg_dir() do project_path
     end
 end
 
+
+@testset "parse package url win" begin
+    @test typeof(Pkg.REPLMode.parse_package("https://github.com/abc/ABC.jl"; context=Pkg.REPLMode.CMD_ADD)) == PackageSpec
+end
+
 include("repl.jl")
 
 end # module


### PR DESCRIPTION
Windows throws on `isdir` with url-like inputs.