### PR TITLE
fix type intersection for invalidation during method insertion to handle typevars properly

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1283,6 +1283,7 @@ for (fun, mode) in [(:+, 1), (:-, 1), (:*, 0), (:min, 2), (:max, 2)]
     end
     @eval begin
         map(::typeof($fun), x::AbstractSparseVector, y::AbstractSparseVector) = _binarymap($fun, x, y, $mode)
+        map(::typeof($fun), x::SparseVector, y::SparseVector) = _binarymap($fun, x, y, $mode)
         broadcast(::typeof($fun), x::AbstractSparseVector, y::AbstractSparseVector) = _bcast_binary_map($fun, x, y, $mode)
         broadcast(::typeof($fun), x::SparseVector, y::SparseVector) = _bcast_binary_map($fun, x, y, $mode)
     end

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1602,8 +1602,8 @@ end
 
 abstract type AbstractT27351 end
 struct T27351 <: AbstractT27351 end
-for i in 1:15
-    @eval f27351(::Val{$i}, ::AbstractT27351, ::AbstractT27351) = $i
+for i27351 in 1:15
+    @eval f27351(::Val{$i27351}, ::AbstractT27351, ::AbstractT27351) = $i27351
 end
 f27351(::T, ::T27351, ::T27351) where {T} = 16
 @test_throws MethodError f27351(Val(1), T27351(), T27351())

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1597,3 +1597,13 @@ end
 @test Core.Compiler.return_type(Core.apply_type, Tuple{Type{Union},Any,Int}) == Union{}
 @test Core.Compiler.return_type(Core.apply_type, Tuple{Any}) == Type
 @test Core.Compiler.return_type(Core.apply_type, Tuple{Any,Any}) == Type
+
+# PR 27351, make sure optimized type intersection for method invalidation handles typevars
+
+abstract type AbstractT27351 end
+struct T27351 <: AbstractT27351 end
+for i in 1:15
+    @eval f27351(::Val{$i}, ::AbstractT27351, ::AbstractT27351) = $i
+end
+f27351(::T, ::T27351, ::T27351) where {T} = 16
+@test_throws MethodError f27351(Val(1), T27351(), T27351())


### PR DESCRIPTION
I still need to add a test, but fixes https://github.com/jrevels/Cassette.jl/issues/44 and thus resolves a bunch of the world age problems that I thought we'd need #27073 to fix. With this fix, we might not need #27073 to block an initial Cassette release (though eventually we should still probably refactor the world age mechanism such that #27073 is correctly implementable). 

We should probably backport this once it's ready.

All credit to @vtjnash as usual.