### PR TITLE
write multiple bytes of Char at once #27267

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -566,16 +566,18 @@ end
 
 function write(io::IO, c::Char)
     v = reinterpret(UInt32, c)
-    u = hton(v) # BIG-endian
-    p = unsafe_convert(Ptr{Cvoid}, Ref{UInt32}(u))
-    if      v & 0x000000FF != 0
-        unsafe_write(io, p, 4)
-    elseif  v & 0x0000FFFF != 0
-        unsafe_write(io, p, 3)
-    elseif  v & 0x00FFFFFF != 0
-        unsafe_write(io, p, 2)
-    else
-        unsafe_write(io, p, 1)
+    u = Ref{UInt32}(hton(v)) # BIG-endian
+    GC.@preserve u begin
+        p = unsafe_convert(Ptr{Cvoid}, u)
+        if      v & 0x000000FF != 0
+            unsafe_write(io, p, 4)
+        elseif  v & 0x0000FFFF != 0
+            unsafe_write(io, p, 3)
+        elseif  v & 0x00FFFFFF != 0
+            unsafe_write(io, p, 2)
+        else
+            unsafe_write(io, p, 1)
+        end
     end
 end
 # write(io, ::AbstractChar) is not defined: implementations

--- a/base/io.jl
+++ b/base/io.jl
@@ -569,15 +569,8 @@ function write(io::IO, c::Char)
     u = Ref{UInt32}(hton(v)) # BIG-endian
     GC.@preserve u begin
         p = unsafe_convert(Ptr{Cvoid}, u)
-        if      v & 0x000000FF != 0
-            unsafe_write(io, p, 4)
-        elseif  v & 0x0000FFFF != 0
-            unsafe_write(io, p, 3)
-        elseif  v & 0x00FFFFFF != 0
-            unsafe_write(io, p, 2)
-        else
-            unsafe_write(io, p, 1)
-        end
+        n = max(1, 4 - (trailing_zeros(v) >>> 3))
+        unsafe_write(io, p, n)
     end
 end
 # write(io, ::AbstractChar) is not defined: implementations


### PR DESCRIPTION
Fix #27267

`write()` function from 0.7.0-alpha:
```julia
function write(io::IO, c::Char) 
    # Let c == '한'
    # v == 0xed959c00
    #v = reinterpret(UInt32, c)
    
    # u = 0x009c95ed
    u = bswap(reinterpret(UInt32, c))
    
    # n |    1 |    2 |    3 |    4  
    #   | 0xed | 0x95 | 0x9c | 0x00
    n = 1
    while true
        # n == 1, write 0xed
        # n == 2, write 0x95
        # n == 3, write 0x9c
        write(io, u % UInt8)
        # return 3
        (u >>= 8) == 0 && return n
    n += 1
    end
end
```
```
julia> @time write(stdout, '한') == 3
���  0.000629 seconds (13 allocations: 400 bytes)
true

julia> @time write(stdout, '한') == 3
���  0.000445 seconds (10 allocations: 256 bytes)
true

julia> @time write(stdout, '한') == 3
���  0.000226 seconds (10 allocations: 256 bytes)
true

julia> @time write(stdout, '한') == 3
���  0.000305 seconds (10 allocations: 256 bytes)
true

julia> @time write(stdout, '한') == 3
���  0.000350 seconds (10 allocations: 256 bytes)
true

julia>
```

`write()` function from `alkorang/display`:
```julia
function write(io::IO, c::Char)
    # Let c == '한'
    # v == 0xed959c00
    v = reinterpret(UInt32, c)
    u = hton(v) # BIG-endian
    
    # p[0] | p[1] | p[2] | p[3]
    # 0xed | 0x95 | 0x9c | 0x00
    p = unsafe_convert(Ptr{Cvoid}, Ref{UInt32}(u))
    
    # Compare with v, not u
    if      v & 0x000000FF != 0
        unsafe_write(io, p, 4)
    elseif  v & 0x0000FFFF != 0
        # Write 0xed, 0x95, 0x9c at once, return 3
        unsafe_write(io, p, 3)
    elseif  v & 0x00FFFFFF != 0
        unsafe_write(io, p, 2)
    else
        unsafe_write(io, p, 1)
    end
end
```
```
julia> @time write(stdout, '한') == 3
한  0.000234 seconds (8 allocations: 320 bytes)
true

julia> @time write(stdout, '한') == 3
한  0.000253 seconds (5 allocations: 176 bytes)
true

julia> @time write(stdout, '한') == 3
한  0.000136 seconds (5 allocations: 176 bytes)
true

julia> @time write(stdout, '한') == 3
한  0.000183 seconds (5 allocations: 176 bytes)
true

julia> @time write(stdout, '한') == 3
한  0.000212 seconds (5 allocations: 176 bytes)
true

julia>
```

