### PR TITLE
Guarantee inbounds iteration over Array{T}

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -677,10 +677,8 @@ function grow_to!(dest, itr, st)
 end
 
 ## Iteration ##
-function iterate(A::Array, i=1)
-    @_propagate_inbounds_meta
-    i >= length(A) + 1 ? nothing : (A[i], i+1)
-end
+
+iterate(A::Array, i=1) = (i % UInt) - 1 < length(A) ? (@inbounds A[i], i + 1) : nothing
 
 ## Indexing: getindex ##
 

--- a/base/array.jl
+++ b/base/array.jl
@@ -678,7 +678,7 @@ end
 
 ## Iteration ##
 
-iterate(A::Array, i=1) = (i % UInt) - 1 < length(A) ? (@inbounds A[i], i + 1) : nothing
+iterate(A::Array, i=1) = (@_inline_meta; (i % UInt) - 1 < length(A) ? (@inbounds A[i], i + 1) : nothing)
 
 ## Indexing: getindex ##
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -946,10 +946,9 @@ function length(itr::PartitionIterator)
 end
 
 function iterate(itr::PartitionIterator{<:Vector}, state=1)
-    iterate(itr.c, state) === nothing && return nothing
-    l = state
-    r = min(state + itr.n-1, length(itr.c))
-    return view(itr.c, l:r), r + 1
+    state > length(itr.c) && return nothing
+    r = min(state + itr.n - 1, length(itr.c))
+    return view(itr.c, state:r), r + 1
 end
 
 struct IterationCutShort; end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -555,7 +555,8 @@ mutable struct CharStr <: AbstractString
     chars::Vector{Char}
     CharStr(x) = new(collect(x))
 end
-Base.iterate(x::CharStr, state...) = iterate(x.chars, state...)
+Base.iterate(x::CharStr) = iterate(x.chars)
+Base.iterate(x::CharStr, i::Int) = iterate(x.chars, i)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
 @testset "cmp without UTF-8 indexing" begin
     # Simple case, with just ANSI Latin 1 characters

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -555,7 +555,7 @@ mutable struct CharStr <: AbstractString
     chars::Vector{Char}
     CharStr(x) = new(collect(x))
 end
-Base.iterate(x::CharStr, i::Integer=1) = iterate(x.chars, i)
+Base.iterate(x::CharStr, state...) = iterate(x.chars, state...)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
 @testset "cmp without UTF-8 indexing" begin
     # Simple case, with just ANSI Latin 1 characters


### PR DESCRIPTION
I think the new iteration protocol really shines in this PR :). Fixes #27384 and replaces #15291.

As an example, `extrema(itr)` is a generic function that applies to any iterator, and hence it cannot safely use `@inbounds`. Therefore currently:

```julia
julia> @benchmark extrema(v) setup = (v = rand(Int, 1000)) # 0.7.0-alpha.0
  median time:      1.132 μs (0.00% GC)
```

After this PR however, we don't need bounds checking and we can have SIMD and everything 🎉 :

```julia
julia> @benchmark extrema(v) setup = (v = rand(Int, 1000))
  median time:      391.347 ns (0.00% GC)
```

It preserves the new behaviour of #27079.