### PR TITLE
Throw cmderror for no-argument pkg> generate

### DIFF
--- a/stdlib/Pkg/src/REPLMode.jl
+++ b/stdlib/Pkg/src/REPLMode.jl
@@ -738,6 +738,7 @@ function do_init!(ctx::Context, tokens::Vector{Token})
 end
 
 function do_generate!(ctx::Context, tokens::Vector{Token})
+    isempty(tokens) && cmderror("`generate` requires a project name as an argument")
     local pkg
     while !isempty(tokens)
         token = popfirst!(tokens)


### PR DESCRIPTION
Calling `pkg> generate` without arguments on master / 0.7.0-alpha throws a somewhat unhelpful error at the moment:

```
(v0.7) pkg> generate
ERROR: UndefVarError: pkg not defined
Stacktrace:
 [1] do_generate!(::Pkg.Types.Context, ::Array{Union{Pkg.Types.VersionRange, String, Pkg.REPLMode.Command, Pkg.REPLMode.Option, Pkg.REPLMode.Rev},1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/Pkg/src/REPLMode.jl:751
 ...
```

This adds a `cmderror` call with a nicer error message:

```
(v0.7) pkg> generate
ERROR: `generate` requires a project name as an argument
```

I was also considering adding a `length(token) == 1` check, since right now additional tokens get silently ignored, but I wasn't sure about breaking the whole `while !isempty(); popfirst!` pattern.