### PR TITLE
add missing import to SuiteSparse lufact deprecation

### DIFF
--- a/stdlib/SuiteSparse/src/deprecated.jl
+++ b/stdlib/SuiteSparse/src/deprecated.jl
@@ -49,6 +49,7 @@ end
 
 # deprecate lufact to lu
 @eval SuiteSparse.UMFPACK begin
+    import LinearAlgebra: lufact
     @deprecate(lufact(A::SparseMatrixCSC), lu(A))
     @deprecate(lufact(S::SparseMatrixCSC{<:UMFVTypes,<:UMFITypes}), lu(S))
     @deprecate(lufact(A::SparseMatrixCSC{<:Union{Float16,Float32},Ti}) where {Ti<:UMFITypes}, lu(A))


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#528:
```
julia> import LinearAlgebra: lufact

julia> using SparseArrays

julia> S = sparse([1, 2, 1, 2, 3, 4, 3, 4], [1, 1, 2, 2, 3, 3, 4, 4], [0.000800802+0.0im, 2.98977e-5+0.0im, 2.98977e-5+0.0im, 0.0016016+0.0im, 0.000728054+0.0im, 0.000115496+0.0im, 0.000115496+0.0im,  0.000680672+0.0im], 4, 4);

julia> lufact(S)
┌ Warning: `lufact(S::SparseMatrixCSC{<:UMFVTypes, <:UMFITypes})` is deprecated, use `lu(S)` instead.
│   caller = top-level scope
└ @ Core :0
UMFPACK LU Factorization of a (4, 4) sparse matrix
Ptr{Nothing} @0x00007fd571d64800
```
cc @PetrKryslUCSD. Best!