### PR TITLE
Bump tuple inference length cutoff from 16 to 32

### DIFF
--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -28,7 +28,6 @@ struct Params
     MAX_APPLY_UNION_ENUM::Int
 
     # parameters limiting large (tuple) types
-    MAX_TUPLETYPE_LEN::Int
     TUPLE_COMPLEXITY_LIMIT_DEPTH::Int
 
     # when attempting to inlining _apply, abort the optimization if the tuple
@@ -43,7 +42,6 @@ struct Params
                     inline_nonleaf_penalty::Int = DEFAULT_PARAMS.inline_nonleaf_penalty,
                     inline_tupleret_bonus::Int = DEFAULT_PARAMS.inline_tupleret_bonus,
                     max_methods::Int = DEFAULT_PARAMS.MAX_METHODS,
-                    tupletype_len::Int = DEFAULT_PARAMS.MAX_TUPLETYPE_LEN,
                     tupletype_depth::Int = DEFAULT_PARAMS.TUPLE_COMPLEXITY_LIMIT_DEPTH,
                     tuple_splat::Int = DEFAULT_PARAMS.MAX_TUPLE_SPLAT,
                     union_splitting::Int = DEFAULT_PARAMS.MAX_UNION_SPLITTING,
@@ -52,7 +50,7 @@ struct Params
                    world, false,
                    inlining, true, false, inline_cost_threshold, inline_nonleaf_penalty,
                    inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum,
-                   tupletype_len, tupletype_depth, tuple_splat)
+                   tupletype_depth, tuple_splat)
     end
     function Params(world::UInt)
         inlining = inlining_enabled()
@@ -62,8 +60,8 @@ struct Params
                    inlining, true, false, 100, 1000,
                    #=inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum=#
                    400, 4, 4, 8,
-                   #=tupletype_len, tupletype_depth, tuple_splat=#
-                   31, 3, 32)
+                   #=tupletype_depth, tuple_splat=#
+                   3, 32)
     end
 end
 const DEFAULT_PARAMS = Params(UInt(0))

--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -63,7 +63,7 @@ struct Params
                    #=inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum=#
                    400, 4, 4, 8,
                    #=tupletype_len, tupletype_depth, tuple_splat=#
-                   15, 3, 16)
+                   31, 3, 32)
     end
 end
 const DEFAULT_PARAMS = Params(UInt(0))

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -843,7 +843,7 @@ add_tfunc(apply_type, 1, INT_INF, apply_type_tfunc, 10)
 
 function invoke_tfunc(@nospecialize(ft), @nospecialize(types), @nospecialize(argtype), sv::InferenceState)
     argument_mt(ft) === nothing && return Any
-    argtype = typeintersect(types, limit_tuple_type(argtype, sv.params))
+    argtype = typeintersect(types, argtype)
     if argtype === Bottom
         return Bottom
     end

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -11,21 +11,6 @@ const MAX_INLINE_CONST_SIZE = 256
 # limitation heuristics #
 #########################
 
-limit_tuple_type(@nospecialize(t), params::Params) = limit_tuple_type_n(t, params.MAX_TUPLETYPE_LEN)
-
-function limit_tuple_type_n(@nospecialize(t), lim::Int)
-    if isa(t, UnionAll)
-        return UnionAll(t.var, limit_tuple_type_n(t.body, lim))
-    end
-    p = t.parameters
-    n = length(p)
-    if n > lim
-        tail = reduce(typejoin, Bottom, Any[p[lim:(n-1)]..., unwrapva(p[n])])
-        return Tuple{p[1:(lim-1)]..., Vararg{tail}}
-    end
-    return t
-end
-
 # limit the complexity of type `t` to be simpler than the comparison type `compare`
 # no new values may be introduced, so the parameter `source` encodes the set of all values already present
 # the outermost tuple type is permitted to have up to `allowed_tuplelen` parameters

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1030,7 +1030,7 @@ function count_specializations(method::Method)
     return n::Int
 end
 
-# demonstrate that inference can complete without waiting for MAX_TUPLETYPE_LEN or MAX_TYPE_DEPTH
+# demonstrate that inference can complete without waiting for MAX_TYPE_DEPTH
 copy_dims_out(out) = ()
 copy_dims_out(out, dim::Int, tail...) =  copy_dims_out((out..., dim), tail...)
 copy_dims_out(out, dim::Colon, tail...) = copy_dims_out((out..., dim), tail...)


### PR DESCRIPTION
 * ~~Bumps `tupletype_len` to `31`~~ Removes `tupletype_len` entirely.
 * Bumps `tuple_splat` to `32`
 * ~~Similarly for the types `Any16` -> `Any32` and `All16` -> `All32`.~~

For context, I feel this would be useful for working with heterogenously typed data as tuples and named tuples. In particular, for v0.7/v1.0, simple containers such as `Vector{NamedTuple{...}}` could be versatile, performant containers for tables and data (similarly for named tuples of arrays, etc), and at times the existing limits (where practically speaking its `14` elements being the biggest size that gives "full run-time speed") felt a bit limiting (e.g. a table with 15-30 columns doesn't seem particularly unreasonable, though for very large numbers I admit that switching to a more dynamic data structure might be preferable).

Incidentally, this might help with things like arrays with 15+ dimensions and so-on (#20163) (cc @Jutho). Having `30` dimensions as the maximum with fully-inferred code seems a somewhat reasonable cutoff number to me, giving ~1 billion elements for a 2x2x2x... sized array, as in #20163.

Of course, I'm more than a bit ignorant of what other impacts this may have internally for the compiler (compile time speed will obviously be slower in some situations) but I thought this might be worthwhile floating for inclusion in v0.7.