### PR TITLE
Resolve mul!(::Matrix, ::Diagonal, ::Adjoint) ambiguity

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -272,6 +272,9 @@ mul!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= A.diag .* in
 mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= adjoint.(A.parent.diag) .* in
 mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= transpose.(A.parent.diag) .* in
 
+mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:AbstractMatrix}) = out .= A.diag .* in
+mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:AbstractMatrix}) = out .= A.diag .* in
+
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose
 *(A::Diagonal, transB::Transpose{<:Any,<:RealHermSymComplexSym}) = A * transB.parent

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -271,6 +271,8 @@ mul!(out::AbstractVector, A::Transpose{<:Any,<:Diagonal}, in::AbstractVector) = 
 mul!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= A.diag .* in
 mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= adjoint.(A.parent.diag) .* in
 mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= transpose.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Adjoint{<:Any, <:AbstractMatrix}) = out .= adjoint.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Transpose{<:Any,<:AbstractMatrix}) = out .= transpose.(A.parent.diag) .* in
 
 mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:AbstractMatrix}) = out .= A.diag .* in
 mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:AbstractMatrix}) = out .= A.diag .* in

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -180,6 +180,14 @@ srand(1)
         @test (r = Matrix(D) * UU' ; mul!(UUU, D, adjoint(UU)) ≈ r ≈ UUU)
         @test (r = Matrix(D) * transpose(UU) ; mul!(UUU, D, transpose(UU)) ≈ r ≈ UUU)
 
+        # Performance specialisations / ambiguity checks for A*_mul_B*!
+        # Using non-lazy adjoint/transpose (so it's actually A_mul_B*!):
+        @test (r = Matrix(D') * UU' ; mul!(UUU, adjoint(D), adjoint(UU)) ≈ r ≈ UUU)
+        @test (r = Matrix(transpose(D)) * transpose(UU) ; mul!(UUU, transpose(D), transpose(UU)) ≈ r ≈ UUU)
+        # Using lazy Adjoint/Transpose:
+        @test (r = Matrix(D') * UU' ; mul!(UUU, Adjoint(D), adjoint(UU)) ≈ r ≈ UUU)
+        @test (r = Matrix(transpose(D)) * Transpose(UU) ; mul!(UUU, transpose(D), transpose(UU)) ≈ r ≈ UUU)
+
         # make sure that mul!(A, {Adj|Trans}(B)) works with B as a Diagonal
         VV = Array(D)
         DD = copy(D)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -176,6 +176,10 @@ srand(1)
         @test (r = Matrix(D)' * UU  ; mul!(UUU, adjoint(D), UU) ≈ r ≈ UUU)
         @test (r = transpose(Matrix(D)) * UU ; mul!(UUU, transpose(D), UU) ≈ r ≈ UUU)
 
+        # Performance specialisations / ambiguity checks for A_mul_B*!
+        @test (r = Matrix(D) * UU' ; mul!(UUU, D, adjoint(UU)) ≈ r ≈ UUU)
+        @test (r = Matrix(D) * transpose(UU) ; mul!(UUU, D, transpose(UU)) ≈ r ≈ UUU)
+
         # make sure that mul!(A, {Adj|Trans}(B)) works with B as a Diagonal
         VV = Array(D)
         DD = copy(D)


### PR DESCRIPTION
It looks like there is an ambiguity problem with `mul!(::Matrix, ::Diagonal, ::Adjoint)` and `mul!(::Matrix, ::Diagonal, ::Transpose)` in Julia 0.7-alpha.  I made a patch to fix it.

Here is how to reproduce the error in Julia 0.7-alpha:

```julia
julia> using LinearAlgebra

julia> A = Diagonal([100, 200, 300])
3×3 Diagonal{Int64,Array{Int64,1}}:
 100    ⋅    ⋅
   ⋅  200    ⋅
   ⋅    ⋅  300

julia> B = reshape(collect(1:9), (3, 3))
3×3 Array{Int64,2}:
 1  4  7
 2  5  8
 3  6  9

julia> Y = zeros(3, 3)
3×3 Array{Float64,2}:
 0.0  0.0  0.0
 0.0  0.0  0.0
 0.0  0.0  0.0

julia> mul!(Y, A, B')
ERROR: MethodError: LinearAlgebra.mul!(::Array{Float64,2}, ::Diagonal{Int64,Array{Int64,1}}, ::Adjoint{Int64,Array{Int64,2}}
) is ambiguous. Candidates:
  mul!(out::AbstractArray{T,2} where T, A::Diagonal, in::AbstractArray{T,2} where T) in LinearAlgebra at /buildworker/worker
/package_linux64/build/usr/share/julia/stdlib/v0.7/LinearAlgebra/src/diagonal.jl:271
  mul!(C::AbstractArray{T,2} where T, A::Union{AbstractArray{T,1}, AbstractArray{T,2}} where T, adjB::Adjoint{#s624,#s623} w
here #s623<:(Union{AbstractArray{T,1}, AbstractArray{T,2}} where T) where #s624) in LinearAlgebra at /buildworker/worker/pac
kage_linux64/build/usr/share/julia/stdlib/v0.7/LinearAlgebra/src/matmul.jl:306
Possible fix, define
  mul!(::AbstractArray{T,2} where T, ::Diagonal, ::Adjoint{#s624,#s623} where #s623<:(Union{AbstractArray{T,1}, AbstractArra
y{T,2}} where T) where #s624)

julia> mul!(Y, A, transpose(B)) 
ERROR: MethodError: LinearAlgebra.mul!(::Array{Float64,2}, ::Diagonal{Int64,Array{Int64,1}}, ::Transpose{Int64,Array{Int64,2}}) is ambiguous. Candidates:
  mul!(out::AbstractArray{T,2} where T, A::Diagonal, in::AbstractArray{T,2} where T) in LinearAlgebra at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/LinearAlgebra/src/diagonal.jl:271 
  mul!(C::AbstractArray{T,2} where T, A::Union{AbstractArray{T,1}, AbstractArray{T,2}} where T, transB::Transpose{#s624,#s623} where #s623<:(Union{AbstractArray{T,1}, AbstractArray{T,2}} where T) where #s624) in LinearAlgebra at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v0.7/LinearAlgebra/src/matmul.jl:251
Possible fix, define 
  mul!(::AbstractArray{T,2} where T, ::Diagonal, ::Transpose{#s624,#s623} where #s623<:(Union{AbstractArray{T,1}, AbstractArray{T,2}} where T) where #s624)
```

Defining the following method (added in this PR) resolves the ambiguity:

```julia
julia> LinearAlgebra.mul!(out::AbstractMatrix, A::Diagonal, 
                          in::Adjoint{T, <: AbstractMatrix{T}}) where T =
           out .= A.diag .* in
       
julia> mul!(Y, A, B')
3×3 Array{Float64,2}:
  100.0   200.0   300.0
  800.0  1000.0  1200.0
 2100.0  2400.0  2700.0

julia> LinearAlgebra.mul!(out::AbstractMatrix, A::Diagonal,
                          in::Transpose{T, <: AbstractMatrix{T}}) where T =
           out .= A.diag .* in
       
julia> mul!(Y, A, transpose(B))
3×3 Array{Float64,2}:
  100.0   200.0   300.0
  800.0  1000.0  1200.0
 2100.0  2400.0  2700.0

julia> versioninfo()
Julia Version 0.7.0-alpha.4
Commit 1538bced17 (2018-05-31 20:57 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.0 (ORCJIT, broadwell)
```