### PR TITLE
Fix test with libgit2 v0.26.0+

### DIFF
--- a/test/libgit2.jl
+++ b/test/libgit2.jl
@@ -1697,7 +1697,7 @@ mktempdir() do dir
                             deserialize(f)
                         end
                         @test err.code == LibGit2.Error.ERROR
-                        @test err.msg == "Invalid Content-Type: text/plain"
+                        @test lowercase(err.msg) == lowercase("Invalid Content-Type: text/plain")
                     end
                 finally
                     kill(pobj)


### PR DESCRIPTION
This fixes an error in tests when libgit2 version is equal or newer v0.26.0.

Closes #24453