### PR TITLE
Don't move Exprs during inlining

### DIFF
--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -493,7 +493,7 @@ function batch_inline!(todo::Vector{Any}, ir::IRCode, linetable::Vector{LineInfo
                 # At the moment we will allow globalrefs in argument position, turn those into ssa values
                 for aidx in 1:length(argexprs)
                     aexpr = argexprs[aidx]
-                    if isa(aexpr, GlobalRef)
+                    if isa(aexpr, GlobalRef) || isa(aexpr, Expr)
                         argexprs[aidx] = insert_node_here!(compact, aexpr, compact_exprtype(compact, aexpr), compact.result_lines[idx])
                     end
                 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -6155,3 +6155,18 @@ struct T27269{X, Y <: Vector{X}}
     v::Vector{Y}
 end
 @test T27269([[1]]) isa T27269{Int, Vector{Int}}
+
+# issue #27368
+struct Combinator27368
+    op
+    args::Vector{Any}
+    Combinator27368(op, args...) =
+        new(op, collect(Any, args))
+end
+field27368(name) =
+    Combinator27368(field27368, name)
+translate27368(name::Symbol) =
+    translate27368(Val{name})
+translate27368(::Type{Val{name}}) where {name} =
+    field27368(name)
+@test isa(translate27368(:name), Combinator27368)


### PR DESCRIPTION
E.g. `Expr(:static_parameter)` can throw, so, like GlobalRefs, it needs
to be maintained before the body of the inlined function in order to not
affect behavior. This was caught by the verifier in #27368, because it
checks that such exprs are not moved into phi values.

Fixes #27368