### PR TITLE
Check whether all fields of a mutable struct are defined before SROA

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -696,6 +696,18 @@ function getfield_elim_pass!(ir::IRCode, domtree)
             push!(fielddefuse[field].defs, use)
         end
         ok || continue
+        # Check that the defexpr has defined values for all the fields
+        # we're accessing. In the future, we may want to relax this,
+        # but we should come up with semantics for well defined semantics
+        # for uninitialized fields first.
+        for (fidx, du) in pairs(fielddefuse)
+            isempty(du.uses) && continue
+            if fidx + 1 > length(defexpr.args)
+                ok = false
+                break
+            end
+        end
+        ok || continue
         preserve_uses = IdDict{Int, Vector{Any}}((idx=>Any[] for idx in IdSet{Int}(defuse.ccall_preserve_uses)))
         # Everything accounted for. Go field by field and perform idf
         for (fidx, du) in pairs(fielddefuse)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6170,3 +6170,16 @@ translate27368(name::Symbol) =
 translate27368(::Type{Val{name}}) where {name} =
     field27368(name)
 @test isa(translate27368(:name), Combinator27368)
+
+# issue #27365
+mutable struct foo27365
+    x::Float64
+    foo27365() = new()
+end
+
+function baz27365()
+    data = foo27365()
+    return data.x
+end
+
+@test isa(baz27365(), Float64)


### PR DESCRIPTION
For now, just bail out in this situation. There's a number of better
things we could do here. However, I want to avoid making #26764 worse
for now.

Fixes #27365