### PR TITLE
Simplify zip iterator and improve performance in certain cases

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -677,10 +677,8 @@ function grow_to!(dest, itr, st)
 end
 
 ## Iteration ##
-function iterate(A::Array, i=1)
-    @_propagate_inbounds_meta
-    i >= length(A) + 1 ? nothing : (A[i], i+1)
-end
+
+iterate(A::Array, i=1) = (i % UInt) - 1 < length(A) ? (@inbounds A[i], i + 1) : nothing
 
 ## Indexing: getindex ##
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -946,10 +946,9 @@ function length(itr::PartitionIterator)
 end
 
 function iterate(itr::PartitionIterator{<:Vector}, state=1)
-    iterate(itr.c, state) === nothing && return nothing
-    l = state
-    r = min(state + itr.n-1, length(itr.c))
-    return view(itr.c, l:r), r + 1
+    state > length(itr.c) && return nothing
+    r = min(state + itr.n - 1, length(itr.c))
+    return view(itr.c, state:r), r + 1
 end
 
 struct IterationCutShort; end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -555,7 +555,8 @@ mutable struct CharStr <: AbstractString
     chars::Vector{Char}
     CharStr(x) = new(collect(x))
 end
-Base.iterate(x::CharStr, i::Integer=1) = iterate(x.chars, i)
+Base.iterate(x::CharStr) = iterate(x.chars)
+Base.iterate(x::CharStr, state::Int) = iterate(x.chars, state)
 Base.lastindex(x::CharStr) = lastindex(x.chars)
 @testset "cmp without UTF-8 indexing" begin
     # Simple case, with just ANSI Latin 1 characters


### PR DESCRIPTION
This is a separate pr built on top of #27386. It removes the `Zip2` struct, since what used to be `Zip1` is already returning a 1-tuple and hence is a base case (turns out @StefanKarpinski was right in the comments here: https://github.com/JuliaLang/julia/commit/eaf5a959cb30e64e6b3b5fca525d892320d2fbda, but maybe only after `Zip1` was updated.)

Further it fixes a bug in `isdone` where the tail of the zip iterator was never checked (https://github.com/JuliaLang/julia/blob/master/base/iterators.jl#L373). Should still add a test for this.

I've built this on top of #27386 to show that we now finally get fully optimized code in some cases -- note the lack of `@inbounds`:

```julia
$ ./julia
> using BenchmarkTools
> function f(v)
     s = 0
     for (i, w) = zip(LinearIndices(v), v)
       s += i * w
     end
     s
   end
> @benchmark f(v) setup = (v = rand(Int, 1000))
```

On current master:

```
  median time:      546.735 ns (0.00% GC)
```

On this branch:

```
  median time:      245.483 ns (0.00% GC)
```

This is now on par with writing `for (i, w) = enumerate(v)` _and_ with the handwritten loop

```
@inbounds for i = 1 : length(v)
  s += i * v[i]
end
```