### PR TITLE
Add lbinomial function based on lbeta

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -352,6 +352,7 @@ export
 # specfun
     beta,
     lbeta,
+    lbinomial,
 
 # arrays
     axes,

--- a/base/math.jl
+++ b/base/math.jl
@@ -13,7 +13,7 @@ export sin, cos, sincos, tan, sinh, cosh, tanh, asin, acos, atan,
        cbrt, sqrt, significand,
        lgamma, hypot, gamma, lfact, max, min, minmax, ldexp, frexp,
        clamp, clamp!, modf, ^, mod2pi, rem2pi,
-       beta, lbeta, @evalpoly
+       beta, lbeta, lbinomial, @evalpoly
 
 import .Base: log, exp, sin, cos, tan, sinh, cosh, tanh, asin,
              acos, atan, asinh, acosh, atanh, sqrt, log2, log10,

--- a/base/special/gamma.jl
+++ b/base/special/gamma.jl
@@ -155,3 +155,25 @@ Natural logarithm of the absolute value of the [`beta`](@ref)
 function ``\\log(|\\operatorname{B}(x,y)|)``.
 """
 lbeta(x::Number, w::Number) = lgamma(x)+lgamma(w)-lgamma(x+w)
+
+"""
+    lbinomial(n, k) = log(abs(binomial(n, k)))
+
+Accurate natural logarithm of the absolute value of the [`binomial`](@ref)
+coefficient `binomial(n, k)` for large `n` and `k` near `n/2`.
+"""
+function lbinomial(n::T, k::T) where {T<:Integer}
+    S = float(T)
+    (k < 0) && return typemin(S)
+    if n < 0
+       n = -n + k - 1
+    end
+    k > n && return typemin(S)
+    (k == 0 || k == n) && return zero(S)
+    (k == 1) && return log(abs(n))
+    if k > (n>>1)
+       k = n - k
+    end
+    -log1p(n) - lbeta(n - k + one(T), k + one(T))
+end
+lbinomial(n::Integer, k::Integer) = lbinomial(promote(n, k)...)

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -178,6 +178,7 @@ Base.Math.lgamma
 Base.Math.lfact
 Base.Math.beta
 Base.Math.lbeta
+Base.Math.lbinomial
 Base.ndigits
 Base.widemul
 Base.Math.@evalpoly

--- a/test/math.jl
+++ b/test/math.jl
@@ -443,6 +443,20 @@ end
           0.00169495384841964531409376316336552555952269360134349446910im)
 end
 
+@testset "lbinomial" begin
+    lbfixed(n) = k -> lbinomial(n, k)
+    blbfixed(n) = k -> log(binomial(BigInt(n), BigInt(k)))
+    @test lbinomial(10, -1) == -Inf
+    @test lbinomial(10, 11) == -Inf
+    @test lbinomial(10,  0) == 0.0
+    @test lbinomial(10, 10) == 0.0
+
+    @test lbinomial(10,  1)    ≈ log(10)
+    @test lbinomial(-6, 10)    ≈ log(binomial(-6, 10))
+    @test lbinomial(-6, 11)    ≈ log(abs(binomial(-6, 11)))
+    @test lbfixed(200).(0:200) ≈ blbfixed(200).(0:200)
+end
+
 # useful test functions for relative error, which differ from isapprox (≈)
 # in that relerrc separately looks at the real and imaginary parts
 relerr(z, x) = z == x ? 0.0 : abs(z - x) / abs(x)


### PR DESCRIPTION
This implementation of `lbinomial` uses the fact that `binomial(n,k) = 1/( (n+1) * B(n - k + 1, k + 1) )`. I have added tests for some simple cases, and then also comparing for very large `n` with `binomial(::BigInt, ::BigInt)`.

The main motivation is evaluating `log(binomial(n,k))` for large `n` with `k` near `n/2` without approximating with Poisson:

```julia
julia> log(binomial(70, 25)) # OK
43.311504703669215

julia> log(binomial(70, 26)) # :(
ERROR: InexactError()
Stacktrace:
 [1] binomial(::Int64, ::Int64) at ./intfuncs.jl:810

julia> log(binomial(BigInt(70), BigInt(26))) # OK, if you can afford it
4.386007065541805521142055198415251198714576775237582336220765505130378175238536e+01

julia> ans - lbinomial(70, 26) # Close enough?
-8.056495743460440321531836165841374176637792344948696218247614638531207882439305e-15
```

In R, this function is available as `lchoose(n, k)` and is a builtin.