### PR TITLE
Speed up dictionary merging with combiner function

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -215,13 +215,38 @@ Dict{Int64,Int64} with 3 entries:
   1 => 0
 ```
 """
-function merge!(combine::Function, d::AbstractDict, others::AbstractDict...)
+function merge!(combine::F, d::AbstractDict, others::AbstractDict...) where F<:Function
     for other in others
-        for (k,v) in other
-            d[k] = haskey(d, k) ? combine(d[k], v) : v
+        for kv in other
+            merge_kv!(combine, d, kv.first, kv.second)
         end
     end
     return d
+end
+
+"""
+    merge_kv!(combine, d::AbstractDict, k, v)
+
+Update d[k] = combine(d[k],v) is the key is present, and otherwise set d[k]=combine(v).
+
+# Examples
+```jldoctest
+julia> d1 = Dict(1 => 2, 3 => 4);
+
+julia> merge_kv!(+, d1, 2, 5);
+
+julia> merge_kv!(+, d1, 2, 6);
+
+julia> d1
+Dict{Int64,Int64} with 3 entries:
+  2 => 11
+  3 => 4
+  1 => 2
+```
+"""
+@inline function merge_kv!(combine::F, d::AbstractDict, k, v) where F<:Function
+    d[k] = haskey(d, k) ? combine(d[k], v) : combine(v)
+    d
 end
 
 """

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -399,6 +399,27 @@ function setindex!(h::Dict{K,V}, v0, key::K) where V where K
     return h
 end
 
+function merge_kv!(combine::F, h::Dict{K,V}, k, v) where {F<:Function,K,V}
+    key = convert(K, k)
+    if !isequal(key, k)
+        throw(ArgumentError("$(k) is not a valid key for type $K"))
+    end
+
+    index = ht_keyindex2!(h, key)
+
+    if index > 0
+        h.age += 1
+        @inbounds vold = h.vals[index]
+        @inbounds h.keys[index] = key
+        @inbounds h.vals[index] = convert(V,combine(vold,v))
+    else
+        @inbounds _setindex!(h, convert(V,combine(v)), key, -index)
+    end    
+
+    return h
+end
+
+
 """
     get!(collection, key, default)
 


### PR DESCRIPTION
This defines an API for updating a single element via combiner function (with only one instead of 2-3 hash evaluations), and uses this to also speed up merging. This will need some bike-shedding. My favorite non-breaking API would be `merge!(+, dst, "some string"=>1)` for counters. Unfortunately this can allocate for the pair in certain conditions, and I failed to find a reliable way to force the inliner to avoid this allocation. My favorite API would be `merge!(+, dst, "some_string", 1)` but this collides with the current `merge!` if keys and values are themselves dictionaries. Hence, `merge_kv!(combine, dst, key, value)`.

Somewhat related is [https://github.com/JuliaLang/julia/issues/24454](https://github.com/JuliaLang/julia/issues/24454), which would allow an abstract way of updating a value with only a single index-search.

Please, anyone propose a better name / API or declare that the overhead for `Pair` formation of non-isbits is acceptable or likely to go away soon in the compiler evolution.

For benchmarking I used the following (this PR implements the `kv` version with the associated speedups):

```
function pair_merge!(combine::F, h::Dict{K,V}, kv::Pair) where {F<:Function, K,V}
    key = convert(K, kv.first)
    if !isequal(key, kv.first)
        throw(ArgumentError("$(kv.first) is not a valid key for type $K"))
    end

    index = Base.ht_keyindex2!(h, key)

    if index > 0
        h.age += 1
        @inbounds vold = h.vals[index]
        @inbounds h.keys[index] = key
        @inbounds h.vals[index] = convert(V,combine(vold,kv.second))
    else
        @inbounds Base._setindex!(h, convert(V,combine(kv.second)), key, -index)
    end    

    return h
end

@inbounds function pairkv_merge!(combine::F, h::Dict{K,V}, kv::Pair) where {F<:Function, K,V}
    kv_merge!(combine,h,kv.first,kv.second)
end


function kv_merge!(combine::F, h::Dict{K,V}, k,v) where {F<:Function, K,V}
    key = convert(K, k)
    if !isequal(key, k)
        throw(ArgumentError("$(k) is not a valid key for type $K"))
    end

    index = Base.ht_keyindex2!(h, key)

    if index > 0
        h.age += 1
        @inbounds vold = h.vals[index]
        @inbounds h.keys[index] = key
        @inbounds h.vals[index] = convert(V,combine(vold,v))
    else
        @inbounds Base._setindex!(h, convert(V,combine(v)), key, -index)
    end    

    return h
end

function _kv_merge!(combine::F, d::AbstractDict, others::AbstractDict...) where F<:Function
    for other in others
        for kv in other            
            kv_merge!(combine, d, kv.first, kv.second)
        end
    end
    return d
end


function _pair_merge!(combine::F, d::AbstractDict, others::AbstractDict...) where F<:Function
    for other in others
        for kv in other            
            pair_merge!(combine, d, kv)
        end
    end
    return d
end

function _pairkv_merge!(combine::F, d::AbstractDict, others::AbstractDict...) where F<:Function
    for other in others
        for kv in other            
            pairkv_merge!(combine, d, kv)
        end
    end
    return d
end

using BenchmarkTools

begin 
dst=Dict(rand()=>rand() for i=1:10_000); 
src1=Dict(rand()=>rand() for i=1:10_000); 
src2=Dict(rand(UInt32)=>rand(Int8) for i=1:10_000); 
src3=Dict{Any,Any}(BigInt(rand(Int32))=>rand() for i=1:10_000);
merge!(+,dst,src1); merge!(+,dst, src2); merge!(+,dst,src3);
dst_s=Dict("key$(rand(Int32))"=>rand() for i=1:10_000);
 src_s=Dict("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA$(rand(Int32))"=>rand() for i=1:10_000);
merge!(+,dst_s,src_s);
dst_tup=Dict(ntuple(i->rand(),20)=>rand() for i=1:10_000);
src_tup=Dict(ntuple(i->rand(),20)=>rand() for i=1:10_000);
merge!(+,dst_tup,src_tup);
end;

begin 
println("base times [Float, Float-Int, Float-Any, String-String, 20xFloat]");
@btime merge!(+,dst,src1);
@btime merge!(+,dst,src2);
@btime merge!(+,dst,src3);
@btime merge!(+,dst_s,src_s);
@btime merge!(+,dst_tup,src_tup);

println("pair times")
@btime _pair_merge!(+,dst,src1);
@btime _pair_merge!(+,dst,src2);
@btime _pair_merge!(+,dst,src3);
@btime _pair_merge!(+,dst_s,src_s);
@btime _pair_merge!(+,dst_tup,src_tup);

println("kv times")
@btime _kv_merge!(+,dst,src1);
@btime _kv_merge!(+,dst,src2);
@btime _kv_merge!(+,dst,src3);
@btime _kv_merge!(+,dst_s,src_s);
@btime _kv_merge!(+,dst_tup,src_tup);

println("pairkv times")
@btime _pairkv_merge!(+,dst,src1);
@btime _pairkv_merge!(+,dst,src2);
@btime _pairkv_merge!(+,dst,src3);
@btime _pairkv_merge!(+,dst,src3);
@btime _pairkv_merge!(+,dst_tup,src_tup);
end;
```
with output (before PR):
```
base times [Float, Float-Int, Float-Any, String-String, 20xFloat]
  518.098 ��s (0 allocations: 0 bytes)
  618.896 ��s (0 allocations: 0 bytes)
  6.326 ms (50330 allocations: 786.41 KiB)
  1.656 ms (0 allocations: 0 bytes)
  6.618 ms (0 allocations: 0 bytes)
pair times
  329.324 ��s (0 allocations: 0 bytes)
  454.825 ��s (0 allocations: 0 bytes)
  5.240 ms (59922 allocations: 1.07 MiB)
  1.093 ms (10000 allocations: 312.50 KiB)
  2.900 ms (0 allocations: 0 bytes)
kv times
  316.915 ��s (0 allocations: 0 bytes)
  428.034 ��s (0 allocations: 0 bytes)
  1.456 ms (0 allocations: 0 bytes)
  893.439 ��s (0 allocations: 0 bytes)
  2.956 ms (0 allocations: 0 bytes)
pairkv times
  316.300 ��s (0 allocations: 0 bytes)
  431.073 ��s (0 allocations: 0 bytes)
  1.697 ms (10000 allocations: 312.50 KiB)
  1.675 ms (10000 allocations: 312.50 KiB)
  2.939 ms (0 allocations: 0 bytes)
```