### PR TITLE
Explicit transform for eigs - bugfix generalized eigenvalue problems

### DIFF
--- a/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
+++ b/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
@@ -69,7 +69,7 @@ eigs(A, B; kwargs...) = _eigs(A, B; kwargs...)
 function _eigs(A, B;
                nev::Integer=6, ncv::Integer=max(20,2*nev+1), which=:LM,
                tol=0.0, maxiter::Integer=300, sigma=nothing, v0::Vector=zeros(eltype(A),(0,)),
-               ritzvec::Bool=true, explicittransform=nothing)
+               ritzvec::Bool=true, explicittransform::Union{Bool, Nothing}=nothing)
     n = checksquare(A)
 
     eigval_postprocess = false; # If we need to shift-and-invert eigvals as postprocessing

--- a/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
+++ b/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
@@ -69,8 +69,10 @@ eigs(A, B; kwargs...) = _eigs(A, B; kwargs...)
 function _eigs(A, B;
                nev::Integer=6, ncv::Integer=max(20,2*nev+1), which=:LM,
                tol=0.0, maxiter::Integer=300, sigma=nothing, v0::Vector=zeros(eltype(A),(0,)),
-               ritzvec::Bool=true)
+               ritzvec::Bool=true, explicittransform=:AUTO)
     n = checksquare(A)
+
+    eigval_postprocess = false; # If we need to shift-and-invert eigvals as postprocessing
 
     T = eltype(A)
     iscmplx = T <: Complex
@@ -115,10 +117,48 @@ function _eigs(A, B;
         which=:LM
     end
 
+    if (explicittransform==:AUTO)
+        # Try to automatically detect if it is good to carry out an explicittransform
+        if (isgeneral && (isshift  || which==:LM))
+            explicittransform = true
+        else
+            explicittransform = false
+        end
+    end
+
     if sigma !== nothing && !iscmplx && isa(sigma,Complex)
         throw(ArgumentError("complex shifts for real problems are not yet supported"))
     end
     sigma = isshift ? convert(T,sigma) : zero(T)
+
+    if (!explicittransform && isgeneral && !ishermitian(B))
+        @warn "B matrix not hermitian. Explicit transformation is generally needed unless B is definite. "
+    end
+    if (explicittransform==true && (which==:LM || which==:LR || which == :LI) && !isgeneral)
+        @warn "Explicit transformation with :L* for standard eigenvalue problems has no meaning. Changing to explicittransform=false."
+       explicittransform=false
+    end
+
+    sigma0=sigma; # Store for inverted shift-and-invert
+    if explicittransform
+        isgeneral=false
+        bmat="I"
+        sym=false # Explicit transform destroys symmetry in general
+        sigma=zero(T);
+        if (isshift) # Try to keep the original meaning of which & sigma
+            if (which == :LM)
+                which = :SM
+            elseif (which == :SM)
+                which = :LM
+            end
+            if (which == :LR)
+                which = :SR
+            elseif (which == :SR)
+                which = :LR
+            end
+        end
+
+    end
 
     if !isempty(v0)
         if length(v0) != n
@@ -155,16 +195,33 @@ function _eigs(A, B;
     end
 
     # Refer to ex-*.doc files in ARPACK/DOCUMENTS for calling sequence
-    matvecA!(y, x) = mul!(y, A, x)
-    if !isgeneral           # Standard problem
+    matvecA! = (y, x) -> mul!(y, A, x)
+    if !isgeneral || explicittransform      # Standard problem
         matvecB = x -> x
-        if !isshift         #    Regular mode
-            mode       = 1
-            solveSI = x->x
-        else                #    Shift-invert mode
-            mode       = 3
-            F = factorize(A - UniformScaling(sigma))
-            solveSI = x -> F \ x
+
+        if (!explicittransform)
+            if !isshift         #    Regular mode
+                mode       = 1
+                solveSI = x->x
+            else                #    Shift-invert mode
+                mode       = 3
+                F = factorize(A - UniformScaling(sigma))
+                solveSI = x -> F \ x
+            end
+        else
+            # doing explicit transformation to standard eigprob
+            if (which == :LM || which == :LI || which == :LR)
+                eigval_postprocess = false # No eigval postprocess necessary the operator is B^{-1}A
+                F = factorize(B);
+                matvecA! = (y,x) -> (y[:]= F \ (A*x))
+            else
+                eigval_postprocess = true
+                sigma = zero(T);
+                F = factorize(sigma0*B - A);
+                matvecA! = (y,x) -> (y[:]= F \ (B*x))
+            end
+            mode = 1;
+            solveSI = x -> x;
         end
     else                    # Generalized eigenproblem
         matvecB = x -> B * x
@@ -191,6 +248,11 @@ function _eigs(A, B;
     nev = length(output[1])
     nconv = output[ritzvec ? 3 : 2]
     nev ≤ nconv || @warn "Not all wanted Ritz pairs converged. Requested: $nev, converged: $nconv"
+
+    if (eigval_postprocess) # invert the shift-and-inverse
+       λ = sigma0 .- 1 ./output[1];
+       return (λ, output[2:end]...)
+    end
 
     return output
 end

--- a/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
+++ b/stdlib/IterativeEigensolvers/src/IterativeEigensolvers.jl
@@ -69,7 +69,7 @@ eigs(A, B; kwargs...) = _eigs(A, B; kwargs...)
 function _eigs(A, B;
                nev::Integer=6, ncv::Integer=max(20,2*nev+1), which=:LM,
                tol=0.0, maxiter::Integer=300, sigma=nothing, v0::Vector=zeros(eltype(A),(0,)),
-               ritzvec::Bool=true, explicittransform=:AUTO)
+               ritzvec::Bool=true, explicittransform=nothing)
     n = checksquare(A)
 
     eigval_postprocess = false; # If we need to shift-and-invert eigvals as postprocessing
@@ -117,7 +117,7 @@ function _eigs(A, B;
         which=:LM
     end
 
-    if (explicittransform==:AUTO)
+    if (explicittransform==nothing)
         # Try to automatically detect if it is good to carry out an explicittransform
         if (isgeneral && (isshift  || which==:LM))
             explicittransform = true

--- a/stdlib/IterativeEigensolvers/test/runtests.jl
+++ b/stdlib/IterativeEigensolvers/test/runtests.jl
@@ -101,7 +101,7 @@ using Test, LinearAlgebra, SparseArrays, Random
         k = 3
         A = randn(n,n); A = A'A
         B = randn(n,k); B = B*B'
-        @test sort(eigs(A, B, nev = k, sigma = 1.0)[1]) ≈ sort(eigvals(A, B)[1:k])
+        @test sort(eigs(A, B, nev = k, sigma = 1.0, explicittransform=false)[1]) ≈ sort(eigvals(A, B)[1:k])
     end
 end
 


### PR DESCRIPTION
Here is an attempt to resolve the bug in JuliaLang/LinearAlgebra.jl#488 (or rather the bug reported in the comments in JuliaLang/LinearAlgebra.jl#488). As pointed out in the issue discussion, `eigs` is currently broken for generalized eigenvalue problems unless `B` is positive or negative definite, e.g., it normally does not work for non-symmetric `B`. 

The code introduces an `explicittransform` kwarg which provides the possibility to do shift-and-invert in the julia code, or (as before) let ARPACK do it. If you do shift-and-invert in the julia code the problem does not occur. The `explicittransform` kwarg defaults to `:AUTO` which tries to determine if it is a good idea to let ARPACK do the shift-and-invert or do it in julia-code. This way the previous behaviour is accessible to any user using `explicittransform=false`.

I have tried to keep the code such that the meaning of `which` and `sigma` is independent if `explicittransform` is true or false, which created a bit more if-statements than one might expect, but the advantage is that you get consistent meaning like this: 
 ```julia
julia> A=sprandn(100,100,0.1); e1=eye(100,1); A=A+100*e1*e1';

julia> C=I+0.0001*sprandn(100,100,0.1);

julia> B=C*C';  # symm. pos. definite 

julia> λ1=eigs(A,B,explicittransform=false,sigma=1.0)[1]
6-element Array{Complex{Float64},1}:
 0.8853783560528526 - 0.2251061711212125im
 0.8853783560528526 + 0.2251061711212125im
 1.4198361576177376 + 0.0im               
 0.5786082353083483 - 0.5069352320198903im
 0.5786082353083483 + 0.5069352320198903im
 1.6872265416932886 + 0.0im               

julia> λ2=eigs(A,B,explicittransform=true,sigma=1.0)[1]
6-element Array{Complex{Float64},1}:
 0.8853783560528521 + 0.2251061711212136im
 0.8853783560528521 - 0.2251061711212136im
 1.4198361576177394 + 0.0im               
 0.5786082353083479 + 0.5069352320198891im
 0.5786082353083479 - 0.5069352320198891im
 1.6872265416932901 + 0.0im               
```

After hopefully some discussion on this here I can add it to the function description. 