### PR TITLE
Rename pure to unsafe_pure and remove unnecessary/improper uses

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -32,7 +32,7 @@ julia> .![true false true]
 """
 function !(x::Bool)
     ## We need a better heuristic to detect this automatically
-    @_pure_meta
+    @_unsafe_pure_meta
     return not_int(x)
 end
 

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -134,7 +134,7 @@ BroadcastStyle(a::AbstractArrayStyle, ::Style{Tuple})    = a
 BroadcastStyle(::A, ::A) where A<:ArrayStyle             = A()
 BroadcastStyle(::ArrayStyle, ::ArrayStyle)               = Unknown()
 BroadcastStyle(::A, ::A) where A<:AbstractArrayStyle     = A()
-Base.@pure function BroadcastStyle(a::A, b::B) where {A<:AbstractArrayStyle{M},B<:AbstractArrayStyle{N}} where {M,N}
+Base.@unsafe_pure function BroadcastStyle(a::A, b::B) where {A<:AbstractArrayStyle{M},B<:AbstractArrayStyle{N}} where {M,N}
     if Base.typename(A).wrapper == Base.typename(B).wrapper
         return A(_max(Val(M),Val(N)))
     end

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -721,11 +721,11 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
         rty = abstract_call(<:, fargs, argtypes, vtypes, sv)
         return rty
     elseif length(argtypes) == 2 && isa(argtypes[2], Const) && isa(argtypes[2].val, SimpleVector) && istopfunction(f, :length)
-        # mark length(::SimpleVector) as @pure
+        # mark length(::SimpleVector) as pure
         return Const(length(argtypes[2].val))
     elseif length(argtypes) == 3 && isa(argtypes[2], Const) && isa(argtypes[3], Const) &&
             isa(argtypes[2].val, SimpleVector) && isa(argtypes[3].val, Int) && istopfunction(f, :getindex)
-        # mark getindex(::SimpleVector, i::Int) as @pure
+        # mark getindex(::SimpleVector, i::Int) as pure
         svecval = argtypes[2].val::SimpleVector
         idx = argtypes[3].val::Int
         if 1 <= idx <= length(svecval) && isassigned(svecval, idx)

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -167,7 +167,7 @@ function optimize(opt::OptimizationState, @nospecialize(result))
         proven_pure = false
         # must be proven pure to use const_api; otherwise we might skip throwing errors
         # (issue #20704)
-        # TODO: Improve this analysis; if a function is marked @pure we should really
+        # TODO: Improve this analysis; if a function is marked @unsafe_pure we should really
         # only care about certain errors (e.g. method errors and type errors).
         if length(ir.stmts) < 10
             proven_pure = true

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -8,7 +8,7 @@
 # The type of a value might be constant
 struct Const
     val
-    actual::Bool  # if true, we obtained `val` by actually calling a @pure function
+    actual::Bool  # if true, we obtained `val` by actually calling a @unsafe_pure function
     Const(@nospecialize(v)) = new(v, false)
     Const(@nospecialize(v), a::Bool) = new(v, a)
 end

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -695,7 +695,7 @@ julia> f(Val(true))
 struct Val{x}
 end
 
-Val(x) = (@_unsafe_pure_meta; Val{x}())
+Val(x) = Val{x}()
 
 """
     invokelatest(f, args...; kwargs...)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -172,11 +172,10 @@ end
 argtail(x, rest...) = rest
 tail(x::Tuple) = argtail(x...)
 
-<<<<<<< HEAD
-tuple_type_head(T::Type) = (@_pure_meta; fieldtype(T::Type{<:Tuple}, 1))
+tuple_type_head(T::Type) = (@_unsafe_pure_meta; fieldtype(T::Type{<:Tuple}, 1))
 
 function tuple_type_tail(T::Type)
-    @_pure_meta
+    @_unsafe_pure_meta
     if isa(T, UnionAll)
         return UnionAll(T.var, tuple_type_tail(T.body))
     elseif isa(T, Union)
@@ -187,31 +186,6 @@ function tuple_type_tail(T::Type)
             return T
         end
         return Tuple{argtail(T.parameters...)...}
-=======
-# TODO: a better / more infer-able definition would pehaps be
-#   tuple_type_head(T::Type) = fieldtype(T::Type{<:Tuple}, 1)
-tuple_type_head(T::UnionAll) = (@_unsafe_pure_meta; UnionAll(T.var, tuple_type_head(T.body)))
-function tuple_type_head(T::Union)
-    @_unsafe_pure_meta
-    return Union{tuple_type_head(T.a), tuple_type_head(T.b)}
-end
-function tuple_type_head(T::DataType)
-    @_unsafe_pure_meta
-    T.name === Tuple.name || throw(MethodError(tuple_type_head, (T,)))
-    return unwrapva(T.parameters[1])
-end
-
-tuple_type_tail(T::UnionAll) = (@_unsafe_pure_meta; UnionAll(T.var, tuple_type_tail(T.body)))
-function tuple_type_tail(T::Union)
-    @_unsafe_pure_meta
-    return Union{tuple_type_tail(T.a), tuple_type_tail(T.b)}
-end
-function tuple_type_tail(T::DataType)
-    @_unsafe_pure_meta
-    T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))
-    if isvatuple(T) && length(T.parameters) == 1
-        return T
->>>>>>> Rename bootstrap version of unsafe_pure
     end
 end
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -217,6 +217,8 @@ macro unsafe_pure(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :pure) : ex)
 end
 
+@eval const $(Symbol("@pure")) = $(Symbol("@unsafe_pure"))
+
 """
     @propagate_inbounds
 

--- a/base/expr.jl
+++ b/base/expr.jl
@@ -213,7 +213,7 @@ mutable global state.
 Use with caution, incorrect `@pure` annotation of a function may introduce
 hard to identify bugs. Double check for calls to generic functions.
 """
-macro pure(ex)
+macro unsafe_pure(ex)
     esc(isa(ex, Expr) ? pushmeta!(ex, :pure) : ex)
 end
 

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -29,7 +29,7 @@ AbstractFloat(x::AbstractIrrational) = Float64(x)
 Float16(x::AbstractIrrational) = Float16(Float32(x))
 Complex{T}(x::AbstractIrrational) where {T<:Real} = Complex{T}(T(x))
 
-@pure function Rational{T}(x::AbstractIrrational) where T<:Integer
+@unsafe_pure function Rational{T}(x::AbstractIrrational) where T<:Integer
     o = precision(BigFloat)
     p = 256
     while true
@@ -45,7 +45,7 @@ Complex{T}(x::AbstractIrrational) where {T<:Real} = Complex{T}(T(x))
 end
 (::Type{Rational{BigInt}})(x::AbstractIrrational) = throw(ArgumentError("Cannot convert an AbstractIrrational to a Rational{BigInt}: use rationalize(Rational{BigInt}, x) instead"))
 
-@pure function (t::Type{T})(x::AbstractIrrational, r::RoundingMode) where T<:Union{Float32,Float64}
+@unsafe_pure function (t::Type{T})(x::AbstractIrrational, r::RoundingMode) where T<:Union{Float32,Float64}
     setprecision(BigFloat, 256) do
         T(BigFloat(x), r)
     end
@@ -87,11 +87,11 @@ end
 <=(x::AbstractFloat, y::AbstractIrrational) = x < y
 
 # Irrational vs Rational
-@pure function rationalize(::Type{T}, x::AbstractIrrational; tol::Real=0) where T
+@unsafe_pure function rationalize(::Type{T}, x::AbstractIrrational; tol::Real=0) where T
     return rationalize(T, big(x), tol=tol)
 end
-@pure function lessrational(rx::Rational{<:Integer}, x::AbstractIrrational)
-    # an @pure version of `<` for determining if the rationalization of
+@unsafe_pure function lessrational(rx::Rational{<:Integer}, x::AbstractIrrational)
+    # an @unsafe_pure version of `<` for determining if the rationalization of
     # an irrational number required rounding up or down
     return rx < big(x)
 end

--- a/base/namedtuple.jl
+++ b/base/namedtuple.jl
@@ -190,14 +190,14 @@ function map(f, nt::NamedTuple{names}, nts::NamedTuple...) where names
 end
 
 # a version of `in` for the older world these generated functions run in
-@pure function sym_in(x::Symbol, itr::Tuple{Vararg{Symbol}})
+@unsafe_pure function sym_in(x::Symbol, itr::Tuple{Vararg{Symbol}})
     for y in itr
         y === x && return true
     end
     return false
 end
 
-@pure function merge_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+@unsafe_pure function merge_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
     names = Symbol[an...]
     for n in bn
         if !sym_in(n, an)
@@ -207,7 +207,7 @@ end
     (names...,)
 end
 
-@pure function merge_types(names::Tuple{Vararg{Symbol}}, a::Type{<:NamedTuple}, b::Type{<:NamedTuple})
+@unsafe_pure function merge_types(names::Tuple{Vararg{Symbol}}, a::Type{<:NamedTuple}, b::Type{<:NamedTuple})
     bn = _nt_names(b)
     Tuple{Any[ fieldtype(sym_in(n, bn) ? b : a, n) for n in names ]...}
 end
@@ -274,7 +274,7 @@ haskey(nt::NamedTuple, key::Union{Integer, Symbol}) = isdefined(nt, key)
 get(nt::NamedTuple, key::Union{Integer, Symbol}, default) = haskey(nt, key) ? getfield(nt, key) : default
 get(f::Callable, nt::NamedTuple, key::Union{Integer, Symbol}) = haskey(nt, key) ? getfield(nt, key) : f()
 
-@pure function diff_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
+@unsafe_pure function diff_names(an::Tuple{Vararg{Symbol}}, bn::Tuple{Vararg{Symbol}})
     names = Symbol[]
     for n in an
         if !sym_in(n, bn)

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -41,12 +41,12 @@ Signed
 ```
 """
 function supertype(T::DataType)
-    @_pure_meta
+    @_unsafe_pure_meta
     T.super
 end
 
 function supertype(T::UnionAll)
-    @_pure_meta
+    @_unsafe_pure_meta
     UnionAll(T.var, supertype(T.body))
 end
 
@@ -151,11 +151,11 @@ isless(x::AbstractFloat, y::Real         ) = (!isnan(x) & (isnan(y) | signless(x
 
 
 function ==(T::Type, S::Type)
-    @_pure_meta
+    @_unsafe_pure_meta
     T<:S && S<:T
 end
 function !=(T::Type, S::Type)
-    @_pure_meta
+    @_unsafe_pure_meta
     !(T == S)
 end
 ==(T::TypeVar, S::Type) = false

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -9,11 +9,11 @@
 Return the closest common ancestor of `T` and `S`, i.e. the narrowest type from which
 they both inherit.
 """
-typejoin() = (@_pure_meta; Bottom)
-typejoin(@nospecialize(t)) = (@_pure_meta; t)
-typejoin(@nospecialize(t), ts...) = (@_pure_meta; typejoin(t, typejoin(ts...)))
+typejoin() = (@_unsafe_pure_meta; Bottom)
+typejoin(@nospecialize(t)) = (@_unsafe_pure_meta; t)
+typejoin(@nospecialize(t), ts...) = (@_unsafe_pure_meta; typejoin(t, typejoin(ts...)))
 function typejoin(@nospecialize(a), @nospecialize(b))
-    @_pure_meta
+    @_unsafe_pure_meta
     if a <: b
         return b
     elseif b <: a

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -275,7 +275,7 @@ Memory allocation minimum alignment for instances of this type.
 Can be called on any `isconcretetype`.
 """
 function datatype_alignment(dt::DataType)
-    @_pure_meta
+    @_unsafe_pure_meta
     dt.layout == C_NULL && throw(UndefRefError())
     alignment = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).alignment
     return Int(alignment & 0x1FF)
@@ -289,7 +289,7 @@ with no intervening padding bytes.
 Can be called on any `isconcretetype`.
 """
 function datatype_haspadding(dt::DataType)
-    @_pure_meta
+    @_unsafe_pure_meta
     dt.layout == C_NULL && throw(UndefRefError())
     alignment = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).alignment
     return (alignment >> 9) & 1 == 1
@@ -302,7 +302,7 @@ Return whether instances of this type can contain references to gc-managed memor
 Can be called on any `isconcretetype`.
 """
 function datatype_pointerfree(dt::DataType)
-    @_pure_meta
+    @_unsafe_pure_meta
     dt.layout == C_NULL && throw(UndefRefError())
     alignment = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).alignment
     return (alignment >> 10) & 0xFFFFF == 0
@@ -318,7 +318,7 @@ Can be called on any `isconcretetype`.
 See also [`Base.fieldoffset`](@ref).
 """
 function datatype_fielddesc_type(dt::DataType)
-    @_pure_meta
+    @_unsafe_pure_meta
     dt.layout == C_NULL && throw(UndefRefError())
     alignment = unsafe_load(convert(Ptr{DataTypeLayout}, dt.layout)).alignment
     return (alignment >> 30) & 3
@@ -340,7 +340,7 @@ julia> isimmutable([1,2])
 false
 ```
 """
-isimmutable(@nospecialize(x)) = (@_pure_meta; !typeof(x).mutable)
+isimmutable(@nospecialize(x)) = (@_unsafe_pure_meta; !typeof(x).mutable)
 
 """
     Base.isstructtype(T) -> Bool
@@ -349,7 +349,7 @@ Determine whether type `T` was declared as a struct type
 (i.e. using the `struct` or `mutable struct` keyword).
 """
 function isstructtype(@nospecialize(t::Type))
-    @_pure_meta
+    @_unsafe_pure_meta
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     isa(t, DataType) || return false
@@ -363,7 +363,7 @@ Determine whether type `T` was declared as a primitive type
 (i.e. using the `primitive` keyword).
 """
 function isprimitivetype(@nospecialize(t::Type))
-    @_pure_meta
+    @_unsafe_pure_meta
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     isa(t, DataType) || return false
@@ -391,14 +391,14 @@ julia> isbitstype(Complex)
 false
 ```
 """
-isbitstype(@nospecialize(t::Type)) = (@_pure_meta; isa(t, DataType) && t.isbitstype)
+isbitstype(@nospecialize(t::Type)) = (@_unsafe_pure_meta; isa(t, DataType) && t.isbitstype)
 
 """
     isbits(x)
 
 Return `true` if `x` is an instance of an `isbitstype` type.
 """
-isbits(@nospecialize x) = (@_pure_meta; typeof(x).isbitstype)
+isbits(@nospecialize x) = (@_unsafe_pure_meta; typeof(x).isbitstype)
 
 """
     isdispatchtuple(T)
@@ -407,7 +407,7 @@ Determine whether type `T` is a tuple "leaf type",
 meaning it could appear as a type signature in dispatch
 and has no subtypes (or supertypes) which could appear in a call.
 """
-isdispatchtuple(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isdispatchtuple)
+isdispatchtuple(@nospecialize(t)) = (@_unsafe_pure_meta; isa(t, DataType) && t.isdispatchtuple)
 
 iskindtype(@nospecialize t) = (t === DataType || t === UnionAll || t === Union || t === typeof(Bottom))
 isconcretedispatch(@nospecialize t) = isconcretetype(t) && !iskindtype(t)
@@ -448,7 +448,7 @@ julia> isconcretetype(Union{Int,String})
 false
 ```
 """
-isconcretetype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isconcretetype)
+isconcretetype(@nospecialize(t)) = (@_unsafe_pure_meta; isa(t, DataType) && t.isconcretetype)
 
 """
     Base.isabstracttype(T)
@@ -466,7 +466,7 @@ false
 ```
 """
 function isabstracttype(@nospecialize(t))
-    @_pure_meta
+    @_unsafe_pure_meta
     t = unwrap_unionall(t)
     # TODO: what to do for `Union`?
     return isa(t, DataType) && t.abstract
@@ -493,7 +493,7 @@ Any
 ```
 """
 function parameter_upper_bound(t::UnionAll, idx)
-    @_pure_meta
+    @_unsafe_pure_meta
     return rewrap_unionall((unwrap_unionall(t)::DataType).parameters[idx], t)
 end
 
@@ -503,7 +503,7 @@ end
 Compute a type that contains the intersection of `T` and `S`. Usually this will be the
 smallest such type or one close to it.
 """
-typeintersect(@nospecialize(a),@nospecialize(b)) = (@_pure_meta; ccall(:jl_type_intersection, Any, (Any,Any), a, b))
+typeintersect(@nospecialize(a),@nospecialize(b)) = (@_unsafe_pure_meta; ccall(:jl_type_intersection, Any, (Any,Any), a, b))
 
 """
     fieldoffset(type, i)
@@ -530,7 +530,7 @@ julia> structinfo(Base.Filesystem.StatStruct)
  (0x0000000000000058, :ctime, Float64)
 ```
 """
-fieldoffset(x::DataType, idx::Integer) = (@_pure_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))
+fieldoffset(x::DataType, idx::Integer) = (@_unsafe_pure_meta; ccall(:jl_get_field_offset, Csize_t, (Any, Cint), x, idx))
 
 """
     fieldtype(T, name::Symbol | index::Int)
@@ -642,7 +642,7 @@ julia> instances(Color)
 function instances end
 
 function to_tuple_type(@nospecialize(t))
-    @_pure_meta
+    @_unsafe_pure_meta
     if isa(t,Tuple) || isa(t,AbstractArray) || isa(t,SimpleVector)
         t = Tuple{t...}
     end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -280,7 +280,7 @@ function CyclePadding(T::DataType)
 end
 
 using .Iterators: Stateful
-@pure function array_subpadding(S, T)
+@unsafe_pure function array_subpadding(S, T)
     checked_size = 0
     lcm_size = lcm(sizeof(S), sizeof(T))
     s, t = Stateful{<:Any, Any}(CyclePadding(S)),

--- a/base/set.jl
+++ b/base/set.jl
@@ -440,7 +440,7 @@ promote_valuetype(x::Pair{K, V}, y::Pair...) where {K, V} =
     promote_type(V, promote_valuetype(y...))
 
 # Subtract singleton types which are going to be replaced
-@pure issingletontype(T::DataType) = isdefined(T, :instance)
+@unsafe_pure issingletontype(T::DataType) = isdefined(T, :instance)
 issingletontype(::Type) = false
 function subtract_singletontype(::Type{T}, x::Pair{K}) where {T, K}
     if issingletontype(K)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -88,7 +88,7 @@ function eltype(t::Type{<:Tuple{Vararg{E}}}) where {E}
 end
 eltype(t::Type{<:Tuple}) = _compute_eltype(t)
 function _compute_eltype(t::Type{<:Tuple})
-    @_pure_meta
+    @_unsafe_pure_meta
     t isa Union && return promote_typejoin(eltype(t.a), eltype(t.b))
     t´ = unwrap_unionall(t)
     r = Union{}

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -15,7 +15,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
-using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
+using Base: hvcat_fill, iszero, IndexLinear, promote_op, promote_typeof,
     @propagate_inbounds, @unsafe_pure, reduce, typed_vcat, has_offset_axes
 using Base.Broadcast: Broadcasted
 

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -15,8 +15,8 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
-using Base: hvcat_fill, iszero, IndexLinear, promote_op, promote_typeof,
-    @propagate_inbounds, @pure, reduce, typed_vcat, has_offset_axes
+using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
+    @propagate_inbounds, @unsafe_pure, reduce, typed_vcat
 using Base.Broadcast: Broadcasted
 
 export

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -16,7 +16,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
 using Base: hvcat_fill, iszero, IndexLinear, _length, promote_op, promote_typeof,
-    @propagate_inbounds, @unsafe_pure, reduce, typed_vcat
+    @propagate_inbounds, @unsafe_pure, reduce, typed_vcat, has_offset_axes
 using Base.Broadcast: Broadcasted
 
 export

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -440,7 +440,7 @@ f18450() = ifelse(true, Tuple{Vararg{Int}}, Tuple{Vararg})
 @test !Core.Compiler.isconstType(Type{Tuple})
 
 # ensure pure attribute applies correctly to all signatures of fpure
-Base.@pure function fpure(a=rand(); b=rand())
+Base.@unsafe_pure function fpure(a=rand(); b=rand())
     # use the `rand` function since it is known to be `@inline`
     # but would be too big to inline
     return a + b + rand()
@@ -456,8 +456,8 @@ gpure(x::Irrational) = fpure(x)
 @test gpure() == gpure() == gpure()
 @test gpure(π) == gpure(π) == gpure(π)
 
-# Make sure @pure works for functions using the new syntax
-Base.@pure (fpure2(x::T) where T) = T
+# Make sure @unsafe_pure works for functions using the new syntax
+Base.@unsafe_pure (fpure2(x::T) where T) = T
 @test which(fpure2, (Int64,)).pure
 
 # issue #10880
@@ -755,7 +755,7 @@ f20267(x::T20267{T}, y::T) where (T) = f20267(Any[1][1], x.inds)
 
 # issue #20704
 f20704(::Int) = 1
-Base.@pure b20704(@nospecialize(x)) = f20704(x)
+Base.@unsafe_pure b20704(@nospecialize(x)) = f20704(x)
 @test b20704(42) === 1
 @test_throws MethodError b20704(42.0)
 
@@ -766,16 +766,16 @@ v20704() = Val{b20704(Any[1.0][1])}
 @test_throws MethodError v20704()
 @test Base.return_types(v20704, ()) == Any[Type{Val{1}}]
 
-Base.@pure g20704(::Int) = 1
+Base.@unsafe_pure g20704(::Int) = 1
 h20704(@nospecialize(x)) = g20704(x)
 @test g20704(1) === 1
 @test_throws MethodError h20704(1.2)
 
-Base.@pure c20704() = (f20704(1.0); 1)
+Base.@unsafe_pure c20704() = (f20704(1.0); 1)
 d20704() = c20704()
 @test_throws MethodError d20704()
 
-Base.@pure function a20704(x)
+Base.@unsafe_pure function a20704(x)
     rand()
     42
 end
@@ -1017,7 +1017,7 @@ typeargs = (Type{Int},Type{Int},Type{Int},Type{Int},Type{Int},Type{Int})
 
 # demonstrate that inference must converge
 # while doing constant propagation
-Base.@pure plus1(x) = x + 1
+Base.@unsafe_pure plus1(x) = x + 1
 f21933(x::Val{T}) where {T} = f(Val(plus1(T)))
 code_typed(f21933, (Val{1},))
 Base.return_types(f21933, (Val{1},))

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -19,7 +19,7 @@ Furlong{p}(v::Number) where {p} = Furlong{p,typeof(v)}(v)
 Furlong{p,T}(x::Furlong{p,S}) where {T,p,S} = Furlong{p,T}(T(x.val))
 
 Base.promote_type(::Type{Furlong{p,T}}, ::Type{Furlong{p,S}}) where {p,T,S} =
-    (Base.@_pure_meta; Furlong{p,promote_type(T,S)})
+    (Base.@_unsafe_pure_meta; Furlong{p,promote_type(T,S)})
 
 Base.one(x::Furlong{p,T}) where {p,T} = one(T)
 Base.one(::Type{Furlong{p,T}}) where {p,T} = one(T)


### PR DESCRIPTION
See dicussion here https://discourse.julialang.org/t/bug-in-doc-system-and-question-on-pure-in-docs-meaning-julia-1-0-is-close/11292

This should send a clear signal to beginners that this macro should be handled with care.

Since it is not exported, there is no deprecation and NEWS entry needed, right?