### PR TITLE
Inference for splatting numbers (and more)

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -376,11 +376,10 @@ end
 
 # simulate iteration protocol on container type up to fixpoint
 function abstract_iteration(@nospecialize(itertype), vtypes::VarTable, sv::InferenceState)
-    tm = _topmod(sv)
-    if !isdefined(tm, :iterate) || !isconst(tm, :iterate)
+    if !isdefined(Main, :Base) || !isdefined(Main.Base, :iterate) || !isconst(Main.Base, :iterate)
         return Any[Vararg{Any}]
     end
-    iteratef = getfield(tm, :iterate)
+    iteratef = getfield(Main.Base, :iterate)
     stateordonet = abstract_call(iteratef, (), Any[Const(iteratef), itertype], vtypes, sv)
     # Return Bottom if this is not an iterator.
     # WARNING: Changes to the iteration protocol must be reflected here,

--- a/base/number.jl
+++ b/base/number.jl
@@ -233,7 +233,8 @@ julia> widemul(Float32(3.), 4.)
 """
 widemul(x::Number, y::Number) = widen(x)*widen(y)
 
-iterate(x::Number, done = false) = done ? nothing : (x, true)
+iterate(x::Number) = (x, nothing)
+iterate(x::Number, ::Any) = nothing
 isempty(x::Number) = false
 in(x::Number, y::Number) = x == y
 

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1720,3 +1720,4 @@ Base.iterate(i::Iterator27434, ::Val{1}) = i.y, Val(2)
 Base.iterate(i::Iterator27434, ::Val{2}) = i.z, Val(3)
 Base.iterate(::Iterator27434, ::Any) = nothing
 @test @inferred splat27434(Iterator27434(1, 2, 3)) == (1, 2, 3)
+@test Core.Compiler.return_type(splat27434, Tuple{typeof(Iterators.repeated(1))}) == Union{}

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1707,3 +1707,16 @@ function h27316()
     return x
 end
 @test Tuple{Tuple{Vector{Int}}} <: Base.return_types(h27316, Tuple{})[1] == Union{Vector{Int}, Tuple{Any}} # we may be able to improve this bound in the future
+
+# PR 27434, inference when splatting iterators with type-based state
+splat27434(x) = (x...,)
+struct Iterator27434
+    x::Int
+    y::Int
+    z::Int
+end
+Base.iterate(i::Iterator27434) = i.x, Val(1)
+Base.iterate(i::Iterator27434, ::Val{1}) = i.y, Val(2)
+Base.iterate(i::Iterator27434, ::Val{2}) = i.z, Val(3)
+Base.iterate(::Iterator27434, ::Any) = nothing
+@test @inferred splat27434(Iterator27434(1, 2, 3)) == (1, 2, 3)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6235,3 +6235,8 @@ function f27597(y)
 end
 @test f27597([1]) == [1]
 @test f27597([]) == 1:0
+
+# issue #22291
+wrap22291(ind) = (ind...,)
+@test @inferred(wrap22291(1)) == (1,)
+@test @inferred(wrap22291((1, 2))) == (1, 2)


### PR DESCRIPTION
Fixes #22291, closes #22292 (from where I've taken the tests).

But even more:
```julia
julia> using LinearAlgebra; foo(x) = (x...,); @code_warntype foo(qr(rand(3,3))) # master
Body::Tuple{Vararg{Union{Array{Float64,2}, LinearAlgebra.QRCompactWYQ{Float64,Array{Float64,2}}},N} where N}
1 1 ─ %1 = Core._apply(Core.tuple, %%x)::Tuple{Vararg{Union{Array{Float64,2}, LinearAlgebra.QRCompactWYQ{Float64,Array{Float64,2}}},N} where N}
  └──      return %1  

julia> using LinearAlgebra; foo(x) = (x...,); @code_warntype foo(qr(rand(3,3))) # this PR
Body::Tuple{LinearAlgebra.QRCompactWYQ{Float64,Array{Float64,2}},Array{Float64,2}}
1 1 ─ %1 = Core._apply(Core.tuple, %%x)::Tuple{LinearAlgebra.QRCompactWYQ{Float64,Array{Float64,2}},Array{Float64,2}}                   │
  └──      return %1 
```
