### PR TITLE
[RFC] Quote filenames in erros

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -280,7 +280,7 @@ function open(fname::AbstractString;
         append = append,
     )
     s = IOStream(string("<file ",fname,">"))
-    systemerror("opening file \"$fname\"",
+    systemerror("opening file $(repr(fname))",
                 ccall(:ios_file, Ptr{Cvoid},
                       (Ptr{UInt8}, Cstring, Cint, Cint, Cint, Cint),
                       s.ios, fname, flags.read, flags.write, flags.create, flags.truncate) == C_NULL)

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -280,7 +280,7 @@ function open(fname::AbstractString;
         append = append,
     )
     s = IOStream(string("<file ",fname,">"))
-    systemerror("opening file $fname",
+    systemerror("opening file \"$fname\"",
                 ccall(:ios_file, Ptr{Cvoid},
                       (Ptr{UInt8}, Cstring, Cint, Cint, Cint, Cint),
                       s.ios, fname, flags.read, flags.write, flags.create, flags.truncate) == C_NULL)

--- a/test/file.jl
+++ b/test/file.jl
@@ -215,6 +215,15 @@ close(s)
 # This section tests temporary file and directory creation.           #
 #######################################################################
 
+@testset "quoting filenames" begin
+    try
+        open("foo bar")
+    catch e
+        isa(e, SystemError) || rethrow(e)
+        @test sprint(showerror, e) == "SystemError: opening file \"foo bar\": No such file or directory"
+    end
+end
+
 my_tempdir = tempdir()
 @test isdir(my_tempdir) == true
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -217,10 +217,12 @@ close(s)
 
 @testset "quoting filenames" begin
     try
-        open("foo bar")
+        open("this file is not expected to exist")
+        false
     catch e
         isa(e, SystemError) || rethrow(e)
-        @test sprint(showerror, e) == "SystemError: opening file \"foo bar\": No such file or directory"
+        @test sprint(showerror, e) == "SystemError: opening file \"this file is not expected to exist\": No such file or directory"
+        true
     end
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -216,7 +216,7 @@ close(s)
 #######################################################################
 
 @testset "quoting filenames" begin
-    try
+    @test try
         open("this file is not expected to exist")
         false
     catch e


### PR DESCRIPTION
Hi,

This PR fixes the issue #26643

I've just quote filenames when a `systemerror` happens.

Regards