### PR TITLE
Fix call to Timer in create_expr_cache

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1161,7 +1161,7 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
         close(in)
     catch ex
         close(in)
-        process_running(io) && Timer(t -> kill(io), interval = 5.0) # wait a short time before killing the process to give it a chance to clean up on its own first
+        process_running(io) && Timer(t -> kill(io), 5.0) # wait a short time before killing the process to give it a chance to clean up on its own first
         rethrow(ex)
     end
     return io


### PR DESCRIPTION
Just got an error similar to
```julia
julia> Timer(t -> t, interval = 5.0)
ERROR: MethodError: no method matching Timer(::getfield(Main, Symbol("##3#4")); interval=5.0)
Closest candidates are:
  Timer(::Function, ::Real; interval) at event.jl:465
  Timer(::Any, ::Any) at deprecated.jl:53 got unsupported keyword argument "interval"
  Timer(::Any, ::Any, ::Any) at deprecated.jl:53 got unsupported keyword argument "interval"
  ...
```
during precompilation because of this. This should fix it but I don't really know how to test that code path.

I believe [this change](https://github.com/JuliaLang/julia/pull/25647/files#diff-a03d5ce5729a81495000698e643fce27R1107) is wrong so the PR effectively reverts it.

cc: @JeffBezanson 