### PR TITLE
Filter out non-directories from stdlibs in runtests/choosetests

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -3,7 +3,7 @@
 using Random, Sockets
 
 const STDLIB_DIR = joinpath(Sys.BINDIR, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)")
-const STDLIBS = readdir(STDLIB_DIR)
+const STDLIBS = filter(isdir, readdir(STDLIB_DIR))
 
 """
 

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -3,7 +3,7 @@
 using Random, Sockets
 
 const STDLIB_DIR = joinpath(Sys.BINDIR, "..", "share", "julia", "stdlib", "v$(VERSION.major).$(VERSION.minor)")
-const STDLIBS = filter(isdir, readdir(STDLIB_DIR))
+const STDLIBS = filter!(x -> isdir(joinpath(STDLIB_DIR, x)), readdir(STDLIB_DIR))
 
 """
 


### PR DESCRIPTION
Thanks to @KristofferC for pointing me directly to the troublesome line!

Should close #27467 