### PR TITLE
Remove Adjoint|Transpose(::UniformScaling) definition

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -64,9 +64,7 @@ copy(J::UniformScaling) = UniformScaling(J.λ)
 conj(J::UniformScaling) = UniformScaling(conj(J.λ))
 
 transpose(J::UniformScaling) = J
-Transpose(S::UniformScaling) = transpose(S)
 adjoint(J::UniformScaling) = UniformScaling(conj(J.λ))
-Adjoint(S::UniformScaling) = adjoint(S)
 
 one(::Type{UniformScaling{T}}) where {T} = UniformScaling(one(T))
 one(J::UniformScaling{T}) where {T} = one(UniformScaling{T})


### PR DESCRIPTION
Reading https://github.com/JuliaLang/julia/pull/25461, it looks like that the consensus was that `Adjoint` and `Transpose` have to add an extra layer of indirection by wrapping the given object.  However, `Adjoint(::UniformScaling)` and `Transpose(::UniformScaling)` "eagerly execute" adjoint and transpose:

https://github.com/JuliaLang/julia/blob/91d2071f0776ceb4c53bc95277ba967aaa0a5608/stdlib/LinearAlgebra/src/uniformscaling.jl#L66-L69

(FYI: those are the added in commit https://github.com/JuliaLang/julia/commit/e80697dfc5cf4748f50b727361c40d781149341a#diff-2053e27c93f0362bfb456f36c77bb232 during https://github.com/JuliaLang/julia/pull/24969.)

If `Adjoint(::UniformScaling)` and `Transpose(::UniformScaling)` are just unnoticed during https://github.com/JuliaLang/julia/pull/25461, I suggest simply removing those lines (hence this PR).  When I test `stdlib/LinearAlgebra` locally, those definitions were not necessary.

Note that, even though `Adjoint{T, UniformScaling{T}}` can be constructed with this PR, I'm not sure if it is necessary to add a special handling.  Since `Adjoint <: AbstractMatrix` but not `UniformScaling <: AbstractMatrix`, an object of type `Adjoint{T, UniformScaling{T}}` is not well-defined; for example, after this PR, typing `Adjoint(I)` in REPL shows error from `Base.show` as would happen with other meaningless combinations like `Adjoint("str")`.