### PR TITLE
[RFC] Specialize setdiff! for sets

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -129,17 +129,6 @@ julia> setdiff([1,2,3], [3,4,5])
 setdiff(s::AbstractSet, itrs...) = setdiff!(copymutable(s), itrs...)
 setdiff(s) = union(s)
 
-function setdiff!(s::AbstractSet, itr::Set)
-    if length(s) > length(itr)
-        for x=itr
-            delete!(s, x)
-        end
-    else
-        foldl(delete!, s, itr)
-    end
-    s
-end
-
 """
     setdiff!(s, itrs...)
 

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -129,6 +129,17 @@ julia> setdiff([1,2,3], [3,4,5])
 setdiff(s::AbstractSet, itrs...) = setdiff!(copymutable(s), itrs...)
 setdiff(s) = union(s)
 
+function setdiff!(s::AbstractSet, itr::Set)
+    if length(s) > length(itr)
+        for x=itr
+            delete!(s, x)
+        end
+    else
+        foldl(delete!, s, itr)
+    end
+    s
+end
+
 """
     setdiff!(s, itrs...)
 

--- a/base/set.jl
+++ b/base/set.jl
@@ -294,6 +294,20 @@ function hash(s::AbstractSet, h::UInt)
     hash(hv, h)
 end
 
+function setdiff!(s::Set, itr::Set)
+    if length(s) < length(itr)
+        d = empty(s)
+        for x in s
+            if !(x in itr)
+                push!(d, x)
+            end
+        end
+        return d
+    else
+        return foldl(delete!, s, itr)
+    end
+end
+
 convert(::Type{T}, s::T) where {T<:AbstractSet} = s
 convert(::Type{T}, s::AbstractSet) where {T<:AbstractSet} = T(s)
 


### PR DESCRIPTION
Hi all,

This PR tries to solve the issue #25317. As pointed out there, the PR #23528 made `setdiff` as _slow_ as `setdiff!`. This is still a work in progress and I would like some feedback on what has been done so far.  

With the specialization, I got the following numbers

```Julia
julia> s1 = Set([1.0])
Set([1.0])

julia> s = Set(rand(1_000_000))
Set([0.955284, 0.397492, …, 0.00387804, 0.116504])

julia> @which setdiff!(s1, s)
setdiff!(s::Set, itr::Set) in Base at set.jl:298

julia> @time setdiff!(s1, s)
  0.059103 seconds (32.46 k allocations: 1.888 MiB)
Set([1.0])

julia> @time setdiff!(s1, s)
  0.000004 seconds (9 allocations: 656 bytes)
Set([1.0])
```
With the specialization, shouldn't the first call to `setdiff!` be as fast as the second one?