### PR TITLE
Add show methods for Transpose and Adjoint of Factorizations

### DIFF
--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -53,6 +53,23 @@ Base.hash(F::Factorization, h::UInt) = mapreduce(f -> hash(getfield(F, f)), hash
 Base.:(==)(  F::T, G::T) where {T<:Factorization} = all(f -> getfield(F, f) == getfield(G, f), 1:nfields(F))
 Base.isequal(F::T, G::T) where {T<:Factorization} = all(f -> isequal(getfield(F, f), getfield(G, f)), 1:nfields(F))::Bool
 
+function Base.show(io::IO, x::Adjoint{<:Any,<:Factorization})
+    print(io, "Adjoint of ")
+    show(io, parent(x))
+end
+function Base.show(io::IO, x::Transpose{<:Any,<:Factorization})
+    print(io, "Transpose of ")
+    show(io, parent(x))
+end
+function Base.show(io::IO, ::MIME"text/plain", x::Adjoint{<:Any,<:Factorization})
+    print(io, "Adjoint of ")
+    show(io, MIME"text/plain"(), parent(x))
+end
+function Base.show(io::IO, ::MIME"text/plain", x::Transpose{<:Any,<:Factorization})
+    print(io, "Transpose of ")
+    show(io, MIME"text/plain"(), parent(x))
+end
+
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\)(F::Factorization{T}, B::VecOrMat{Complex{T}}) where T<:BlasReal

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -460,4 +460,14 @@ end
     @test B == A .* A'
 end
 
+@testset "test show methods for $t of Factorizations" for t in (Adjoint, Transpose)
+    A = randn(4, 4)
+    F = lu(A)
+    Fop = t(F)
+    @test "LinearAlgebra."*sprint(show, Fop) ==
+                  "$t of "*sprint(show, parent(Fop))
+    @test "LinearAlgebra."*sprint((io, t) -> show(io, MIME"text/plain"(), t), Fop) ==
+                  "$t of "*sprint((io, t) -> show(io, MIME"text/plain"(), t), parent(Fop))
+end
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
Fixes #27438. E.g. 
```julia
julia> lu(randn(3,3))'
Adjoint of LU{Float64,Array{Float64,2}}
L factor:
3×3 Array{Float64,2}:
  1.0       0.0       0.0
  0.16632   1.0       0.0
 -0.440947  0.799311  1.0
U factor:
3×3 Array{Float64,2}:
 0.817598  -1.60659   0.971571
 0.0       -2.20857   0.846662
 0.0        0.0      -1.75832
```