### PR TITLE
Fix #27494, element type of Diagonal{T} when zero(T) is not a T

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -2,7 +2,7 @@
 
 ## Diagonal matrices
 
-struct Diagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
+struct Diagonal{T,V<:AbstractVector} <: AbstractMatrix{T}
     diag::V
 end
 """
@@ -47,6 +47,11 @@ julia> Diagonal(V)
 """
 Diagonal(V::AbstractVector)
 
+Diagonal(diag::V) where {S,V<:AbstractVector{S}} = Diagonal{promote_type(S, typeof(zero(S))),V}(diag)
+
+# `zero` is generally not defined for AbstractMatrix, so:
+Diagonal(diag::V) where {S<:AbstractMatrix,V<:AbstractVector{S}} = Diagonal{S,V}(diag)
+
 Diagonal{T}(V::AbstractVector{T}) where {T} = Diagonal{T,typeof(V)}(V)
 Diagonal{T}(V::AbstractVector) where {T} = Diagonal{T}(convert(AbstractVector{T}, V))
 
@@ -74,10 +79,10 @@ function size(D::Diagonal,d::Integer)
     return d<=2 ? length(D.diag) : 1
 end
 
-@inline function getindex(D::Diagonal, i::Int, j::Int)
+@inline function getindex(D::Diagonal{T}, i::Int, j::Int) where {T}
     @boundscheck checkbounds(D, i, j)
     if i == j
-        @inbounds r = D.diag[i]
+        @inbounds r = T(D.diag[i])
     else
         r = diagzero(D, i, j)
     end

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -440,4 +440,22 @@ end
     @test Transpose(x)*D*x == (Transpose(x)*D)*x == (Transpose(x)*Array(D))*x
 end
 
+struct Foo27494 end
+struct Bar27494
+    iszero::Bool
+end
+Bar27494(::Foo27494) = Bar27494(false)
+Base.zero(::Type{Foo27494}) = Bar27494(true)
+Base.zero(::Type{Bar27494}) = Bar27494(true)
+Base.promote_rule(::Type{Foo27494}, ::Type{Bar27494}) = Bar27494
+
+@testset "typeof(zero(T)) != T (#27494)" begin
+    D = Diagonal([Foo27494(), Foo27494()])
+    @test eltype(D) == Bar27494
+    @test (@inferred D[1, 1]) === Bar27494(false)
+    @test (@inferred D[1, 2]) === Bar27494(true)
+    @test (@inferred D[2, 1]) === Bar27494(true)
+    @test (@inferred D[2, 2]) === Bar27494(false)
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#1451.

The existence of the `AbstractMatrix` element type specialization (basically using the old behavior in this case) is less than ideal, but I still think this is an improvement.