### PR TITLE
`occursin` doscstring correction

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -435,7 +435,7 @@ findprev(t::AbstractString, s::AbstractString, i::Integer) = _rsearch(s, t, i)
 """
     occursin(needle::Union{AbstractString,Regex,AbstractChar}, haystack::AbstractString)
 
-Determine whether the second argument is a substring of the first. If `needle`
+Determine whether the first argument is a substring of the second. If `needle`
 is a regular expression, checks whether `haystack` contains a match.
 
 # Examples


### PR DESCRIPTION
I think that `occursin` have a reversed order of argument w.r.t contains. this fixes the argument order in the docstring description to match examples and code.