### PR TITLE
fix undefined variable in chol(::Number) deprecation

### DIFF
--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1414,7 +1414,7 @@ export eigfact!
 # deprecate chol[!] to cholesky[!] with getproperty
 @deprecate(chol(A::RealHermSymComplexHerm), cholesky(A).U)
 @deprecate(chol(A::AbstractMatrix), cholesky(A).U)
-@deprecate(chol(x::Number, args...), sqrt(A))
+@deprecate(chol(x::Number, args...), sqrt(x))
 @deprecate(chol(J::UniformScaling), UniformScaling(sqrt(J.λ)))
 @deprecate(chol!(A::RealHermSymComplexHerm{<:Real,<:StridedMatrix}), cholesky!(A).U, false)
 @deprecate(chol!(A::StridedMatrix), cholesky!(A).U, false)


### PR DESCRIPTION
`chol(::Number)` currently fails because the deprecation uses the wrong variable name (`A` instead of `x`)