### PR TITLE
Simplify zip take 2

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -261,144 +261,87 @@ get(f::Base.Callable, collection::Pairs, key) = get(f, v.data, key)
 
 # zip
 
-abstract type AbstractZipIterator end
-
 zip_iteratorsize(a, b) = and_iteratorsize(a,b) # as `and_iteratorsize` but inherit `Union{HasLength,IsInfinite}` of the shorter iterator
 zip_iteratorsize(::HasLength, ::IsInfinite) = HasLength()
 zip_iteratorsize(::HasShape, ::IsInfinite) = HasLength()
 zip_iteratorsize(a::IsInfinite, b) = zip_iteratorsize(b,a)
 zip_iteratorsize(a::IsInfinite, b::IsInfinite) = IsInfinite()
 
-
-struct Zip1{I} <: AbstractZipIterator
-    a::I
+abstract type AbstractZipIterator end
+struct Zip1{A} <: AbstractZipIterator
+    a::A
 end
-zip(a) = Zip1(a)
+struct Zip{A,B<:AbstractZipIterator} <: AbstractZipIterator
+    a::A
+    b::B
+end
 length(z::Zip1) = length(z.a)
+length(z::Zip) = _min_length(z.a, z.b, IteratorSize(z.a), IteratorSize(z.b))
 size(z::Zip1) = size(z.a)
+size(z::Zip) = promote_shape(size(z.a), size(z.b))
 axes(z::Zip1) = axes(z.a)
-eltype(::Type{Zip1{I}}) where {I} = Tuple{eltype(I)}
-@propagate_inbounds function iterate(z::Zip1, state...)
-    n = iterate(z.a, state...)
-    n === nothing && return n
-    return ((n[1],), n[2])
-end
-@inline isdone(z::Zip1, state...) = isdone(z.a, state...)
+axes(z::Zip) = promote_shape(axes(z.a), axes(z.b))
+eltype(::Type{Zip1{A}}) where {A} = Tuple{eltype(A)}
+eltype(::Type{Zip{A,B}}) where {A,B} = tuple_type_cons(eltype(A), eltype(B))
+IteratorSize(::Type{Zip1{A}}) where {A} = IteratorSize(A)
+IteratorSize(::Type{Zip{A,B}}) where {A,B} = zip_iteratorsize(IteratorSize(A),IteratorSize(B))
+IteratorEltype(::Type{Zip1{A}}) where {A} = IteratorEltype(A)
+IteratorEltype(::Type{Zip{A,B}}) where {A,B} = and_iteratoreltype(IteratorEltype(A),IteratorEltype(B))
+reverse(z::Zip1) = Zip1(reverse(z.a))
+reverse(z::Zip) = Zip(reverse(z.a), reverse(z.b))
+@inline isdone(z::Zip1) = isdone(z.a)
+@inline isdone(z::Zip1, s) = isdone(z.a, first(s))
+@inline isdone(z::Zip) = isdone(z.a) | isdone(z.b)
+@inline isdone(z::Zip, s) = isdone(z.a, first(s)) | isdone(z.b, tail(s))
 
-IteratorSize(::Type{Zip1{I}}) where {I} = IteratorSize(I)
-IteratorEltype(::Type{Zip1{I}}) where {I} = IteratorEltype(I)
-
-struct Zip2{I1, I2} <: AbstractZipIterator
-    a::I1
-    b::I2
-end
-zip(a, b) = Zip2(a, b)
-length(z::Zip2) = _min_length(z.a, z.b, IteratorSize(z.a), IteratorSize(z.b))
-size(z::Zip2) = promote_shape(size(z.a), size(z.b))
-axes(z::Zip2) = promote_shape(axes(z.a), axes(z.b))
-eltype(::Type{Zip2{I1,I2}}) where {I1,I2} = Tuple{eltype(I1), eltype(I2)}
-@inline isdone(z::Zip2) = isdone(z.a) | isdone(z.b)
-@inline isdone(z::Zip2, (sa, sb)::Tuple{Any, Any}) = isdone(z.a, sa) | isdone(z.b, sb)
-function zip_iterate(a, b, sta, stb) # the states are either Tuple{} or Tuple{Any}
-    da, db = isdone(a), isdone(b)
-    da === true && return nothing
-    db === true && return nothing
-    if da === missing
-       ya = iterate(a, sta...)
-       ya === nothing && return nothing
+# sa′ and sb′ are optional state arguments for z.a and z.b
+@propagate_inbounds function zip_iterate(z::Zip, sa′::Tuple, sb′::Tuple)
+    done = isdone(z.a)
+    done === true && return nothing
+    if done === missing
+        a, sa = @something iterate(z.a, sa′...)
     end
-    if db === missing
-       yb = iterate(b, stb...)
-       yb === nothing && return nothing
+    b, sb = @something iterate(z.b, sb′...)
+    if done === false
+        a, sa = @something iterate(z.a, sa′...)
     end
-    if da === false
-         ya = iterate(a, sta...)
-         ya === nothing && return nothing
-    end
-    if db === false
-         yb = iterate(b, stb...)
-         yb === nothing && return nothing
-    end
-    return (ya, yb)
-end
-let interleave(a, b) = ((a[1], b[1]), (a[2], b[2]))
-    global iterate
-    @propagate_inbounds function iterate(z::Zip2)
-        ys = zip_iterate(z.a, z.b, (), ())
-        ys === nothing && return nothing
-        return interleave(ys...)
-    end
-    @propagate_inbounds function iterate(z::Zip2, st::Tuple{Any, Any})
-        ys = zip_iterate(z.a, z.b, (st[1],), (st[2],))
-        ys === nothing && return nothing
-        return interleave(ys...)
-    end
+    (a, b...), (sa, sb...)
 end
 
-IteratorSize(::Type{Zip2{I1,I2}}) where {I1,I2} = zip_iteratorsize(IteratorSize(I1),IteratorSize(I2))
-IteratorEltype(::Type{Zip2{I1,I2}}) where {I1,I2} = and_iteratoreltype(IteratorEltype(I1),IteratorEltype(I2))
-
-struct Zip{I, Z<:AbstractZipIterator} <: AbstractZipIterator
-    a::I
-    z::Z
+# iterate(zip(a, b...)) -> (val_a, val_b...), (state_a, state_b...)
+@propagate_inbounds function iterate(z::Zip1)
+    a, sa = @something iterate(z.a)
+    (a,), (sa,)
 end
+@propagate_inbounds function iterate(z::Zip1, s::Tuple)
+    a, sa = @something iterate(z.a, first(s))
+    (a,), (sa,)
+end
+@propagate_inbounds iterate(z::Zip) = zip_iterate(z, (), ())
+@propagate_inbounds iterate(z::Zip, s::Tuple) = zip_iterate(z, (first(s),), (tail(s),))
 
 """
-    zip(iters...)
+    zip(a, b...)
 
-For a set of iterable objects, return an iterable of tuples, where the `i`th tuple contains
-the `i`th component of each input iterable.
+Run multiple iterators at the same time, until any of them is exhausted. The value type of
+the `zip` iterator is a tuple of values of its subiterators.
+
+Note: `zip` orders the calls to its subiterators in such a way that stateful iterators will
+not advance when another iterator finishes in the current iteration.
 
 # Examples
 ```jldoctest
-julia> a = 1:5
-1:5
-
-julia> b = ["e","d","b","c","a"]
-5-element Array{String,1}:
- "e"
- "d"
- "b"
- "c"
- "a"
-
-julia> c = zip(a,b)
-Base.Iterators.Zip2{UnitRange{Int64},Array{String,1}}(1:5, ["e", "d", "b", "c", "a"])
-
-julia> length(c)
-5
-
-julia> first(c)
-(1, "e")
+julia> collect(zip(1:5, "abcde"))
+5-element Array{Tuple{Int64,Char},1}:
+ (1, 'a')
+ (2, 'b')
+ (3, 'c')
+ (4, 'd')
+ (5, 'e')
 ```
 """
+zip(a) = Zip1(a)
 zip(a, b, c...) = Zip(a, zip(b, c...))
-length(z::Zip) = _min_length(z.a, z.z, IteratorSize(z.a), IteratorSize(z.z))
-size(z::Zip) = promote_shape(size(z.a), size(z.z))
-axes(z::Zip) = promote_shape(axes(z.a), axes(z.z))
-eltype(::Type{Zip{I,Z}}) where {I,Z} = tuple_type_cons(eltype(I), eltype(Z))
-@inline isdone(z::Zip) = isdone(z.a) | isdone(z.z)
-@inline isdone(z::Zip, (sa, sz)) = isdone(z.a, sa) | isdone(z.a, sz)
-let interleave(a, b) = ((a[1], b[1]...), (a[2], b[2]))
-    global iterate
-    @propagate_inbounds function iterate(z::Zip)
-        ys = zip_iterate(z.a, z.z, (), ())
-        ys === nothing && return nothing
-        return interleave(ys...)
-    end
-    @propagate_inbounds function iterate(z::Zip, st::Tuple{Any, Any})
-        ys = zip_iterate(z.a, z.z, (st[1],), (st[2],))
-        ys === nothing && return nothing
-        return interleave(ys...)
-    end
-end
-
-IteratorSize(::Type{Zip{I1,I2}}) where {I1,I2} = zip_iteratorsize(IteratorSize(I1),IteratorSize(I2))
-IteratorEltype(::Type{Zip{I1,I2}}) where {I1,I2} = and_iteratoreltype(IteratorEltype(I1),IteratorEltype(I2))
-
-reverse(z::Zip1) = Zip1(reverse(z.a))
-reverse(z::Zip2) = Zip2(reverse(z.a), reverse(z.b))
-reverse(z::Zip) = Zip(reverse(z.a), reverse(z.z))
 
 # filter
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -15,7 +15,7 @@ using .Base:
     LinearIndices, (:), |, +, -, !==, !, <=, <, missing
 
 import .Base:
-    first, last,
+    esc, first, last,
     isempty, length, size, axes, ndims,
     eltype, IteratorSize, IteratorEltype,
     haskey, keys, values, pairs,
@@ -23,6 +23,14 @@ import .Base:
     popfirst!, isdone, peek
 
 export enumerate, zip, rest, countfrom, take, drop, cycle, repeated, product, flatten, partition
+
+macro something(ex)
+    quote
+        result = $(esc(ex))
+        result === nothing && return nothing
+        result
+    end
+end
 
 tail_if_any(::Tuple{}) = ()
 tail_if_any(x::Tuple) = tail(x)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -490,13 +490,15 @@ for i in 1:6
 end
 
 # test @inferred
-function uninferrable_function(i)
-    q = [1, "1"]
-    return q[i]
-end
-
-@test_throws ErrorException @inferred(uninferrable_function(1))
-@test @inferred(identity(1)) == 1
+uninferrable_function(i) = (1, "1")[i]
+uninferrable_small_union(i) = (1, nothing)[i]
+@test_throws ErrorException (@inferred uninferrable_function(1))
+@test (@inferred identity(1)) == 1
+@test (@inferred Nothing uninferrable_small_union(1)) === 1
+@test (@inferred Nothing uninferrable_small_union(2)) === nothing
+@test_throws ErrorException (@inferred Missing uninferrable_small_union(1))
+@test_throws ErrorException (@inferred Missing uninferrable_small_union(2))
+@test_throws ArgumentError (@inferred nothing uninferrable_small_union(1))
 
 # Ensure @inferred only evaluates the arguments once
 inferred_test_global = 0
@@ -511,8 +513,8 @@ end
 struct SillyArray <: AbstractArray{Float64,1} end
 Base.getindex(a::SillyArray, i) = rand() > 0.5 ? 0 : false
 @testset "@inferred works with A[i] expressions" begin
-    @test @inferred((1:3)[2]) == 2
-    test_result = @test_throws ErrorException @inferred(SillyArray()[2])
+    @test (@inferred (1:3)[2]) == 2
+    test_result = @test_throws ErrorException (@inferred SillyArray()[2])
     @test occursin("Bool", test_result.value.msg)
 end
 # Issue #14928
@@ -521,16 +523,12 @@ end
 
 # Issue #17105
 # @inferred with kwargs
-function inferrable_kwtest(x; y=1)
-    2x
-end
-function uninferrable_kwtest(x; y=1)
-    2x+y
-end
-@test @inferred(inferrable_kwtest(1)) == 2
-@test @inferred(inferrable_kwtest(1; y=1)) == 2
-@test @inferred(uninferrable_kwtest(1)) == 3
-@test @inferred(uninferrable_kwtest(1; y=2)) == 4
+inferrable_kwtest(x; y=1) = 2x
+uninferrable_kwtest(x; y=1) = 2x+y
+@test (@inferred inferrable_kwtest(1)) == 2
+@test (@inferred inferrable_kwtest(1; y=1)) == 2
+@test (@inferred uninferrable_kwtest(1)) == 3
+@test (@inferred uninferrable_kwtest(1; y=2)) == 4
 
 @test_throws ErrorException @testset "$(error())" for i in 1:10
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -23,6 +23,11 @@ let z = zip(1:2, 3:4, 5:6)
     @test eltype(z) == Tuple{Int,Int,Int}
 end
 
+let z = zip(1:2, 2:3, 3:4, 4:5, 5:6, 6:7, 7:8, 8:9, 9:10, 10:11), (v,s) = iterate(z)
+    @inferred Nothing iterate(z)
+    @inferred Nothing iterate(z, s)
+end
+
 @test eltype(Iterators.filter(isodd, 1:5)) == Int
 
 # typed `collect`

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -533,9 +533,13 @@ end
     @test eltype(Iterators.Stateful("a")) == Char
     # Interaction of zip/Stateful
     let a = Iterators.Stateful("a"), b = ""
-	@test isempty(collect(zip(a,b)))
-	@test !isempty(a)
-	@test isempty(collect(zip(b,a)))
-	@test !isempty(a)
+        @test isempty(collect(zip(a,b)))
+        @test !isempty(a)
+        @test isempty(collect(zip(b,a)))
+        @test !isempty(a)
+    end
+    let z = zip(Iterators.Stateful("ab"), Iterators.Stateful("b"), Iterators.Stateful("c"))
+        v, s = iterate(z)
+        @test Base.isdone(z, s)
     end
 end


### PR DESCRIPTION
This pr:

1. Removes `Zip2` since `Zip1` is a valid base case
2. Fixes and adds a test for an `isdone` bug for the `Zip` iterator.
3. Flattens the state like the values: `iterate(zip(a, b, c))` returns `((val_a, val_b, val_c), (state_a, state_b, state_c))`.
4. Removes a call to `isdone(z.b)` in the iterate function, since that is handled by recursion already when calling `iterate(z.b, ...)`.
5. Adds a macro that @iamed2 suggested to "bail on nothing"; there's this three-liner pattern `y = produce(); y === nothing && return nothing; a, b = y` all over the place, which is `a, b = @something produce()` with the macro. Yet I suspect people wouldn't like this macro in base, at least not with this name. Suggestions?
6. Adds a note to the docs about stateful iterators & how they are not advanced when another iterator finishes in the current iteration.