### PR TITLE
Allow `jl_set_const` to overwrite const global (with warning).

### DIFF
--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1160,7 +1160,7 @@ static void add_intrinsic(jl_module_t *inm, const char *name, enum intrinsic f)
 {
     jl_value_t *i = jl_permbox32(jl_intrinsic_type, (int32_t)f);
     jl_sym_t *sym = jl_symbol(name);
-    jl_set_const(inm, sym, i);
+    jl_define_const(inm, sym, i);
     jl_module_export(inm, sym);
 }
 
@@ -1179,7 +1179,7 @@ void jl_init_intrinsic_functions(void)
 {
     jl_module_t *inm = jl_new_module(jl_symbol("Intrinsics"));
     inm->parent = jl_core_module;
-    jl_set_const(jl_core_module, jl_symbol("Intrinsics"), (jl_value_t*)inm);
+    jl_define_const(jl_core_module, jl_symbol("Intrinsics"), (jl_value_t*)inm);
     jl_mk_builtin_func(jl_intrinsic_type, "IntrinsicFunction", jl_f_intrinsic_call);
 
 #define ADD_I(name, nargs) add_intrinsic(inm, #name, name);
@@ -1193,7 +1193,7 @@ void jl_init_intrinsic_functions(void)
 
 static void add_builtin(const char *name, jl_value_t *v)
 {
-    jl_set_const(jl_core_module, jl_symbol(name), v);
+    jl_define_const(jl_core_module, jl_symbol(name), v);
 }
 
 jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b)

--- a/src/gf.c
+++ b/src/gf.c
@@ -208,7 +208,7 @@ void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr
     jl_sym_t *sname = jl_symbol(name);
     if (dt == NULL) {
         jl_value_t *f = jl_new_generic_function_with_supertype(sname, jl_core_module, jl_builtin_type, 0);
-        jl_set_const(jl_core_module, sname, f);
+        jl_define_const(jl_core_module, sname, f);
         dt = (jl_datatype_t*)jl_typeof(f);
     }
     jl_method_instance_t *li = jl_new_method_instance_uninit();
@@ -2302,7 +2302,7 @@ jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_
     JL_GC_PUSH1(&ftype);
     ftype->name->mt->name = name;
     jl_gc_wb(ftype->name->mt, name);
-    jl_set_const(module, tname, (jl_value_t*)ftype);
+    jl_define_const(module, tname, (jl_value_t*)ftype);
     jl_value_t *f = jl_new_struct(ftype);
     ftype->instance = f; jl_gc_wb(ftype, f);
     JL_GC_POP();

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -616,7 +616,7 @@ JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv)
         if (args == NULL) {
             args = jl_alloc_vec_any(0);
             JL_GC_PUSH1(&args);
-            jl_set_const(jl_core_module, jl_symbol("ARGS"), (jl_value_t*)args);
+            jl_define_const(jl_core_module, jl_symbol("ARGS"), (jl_value_t*)args);
             JL_GC_POP();
         }
         assert(jl_array_len(args) == 0);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1325,9 +1325,11 @@ JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
+// Set val on global var. NOTE: var must not be a const variable.
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT,
                                 jl_sym_t *var,
                                 jl_value_t *val JL_ROOTED_ARGUMENT);
+// Define a new const global variable. NOTE: var must not already exist.
 JL_DLLEXPORT void jl_define_const(jl_module_t *m JL_ROOTING_ARGUMENT,
                                jl_sym_t *var,
                                jl_value_t *val JL_ROOTED_ARGUMENT);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1331,8 +1331,8 @@ JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT,
                                 jl_value_t *val JL_ROOTED_ARGUMENT);
 // Define a new const global variable. NOTE: var must not already exist.
 JL_DLLEXPORT void jl_define_const(jl_module_t *m JL_ROOTING_ARGUMENT,
-                               jl_sym_t *var,
-                               jl_value_t *val JL_ROOTED_ARGUMENT);
+                                  jl_sym_t *var,
+                                  jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
 JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b);
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1328,7 +1328,7 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT,
                                 jl_sym_t *var,
                                 jl_value_t *val JL_ROOTED_ARGUMENT);
-JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT,
+JL_DLLEXPORT void jl_define_const(jl_module_t *m JL_ROOTING_ARGUMENT,
                                jl_sym_t *var,
                                jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);

--- a/src/module.c
+++ b/src/module.c
@@ -481,14 +481,29 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 
 JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
-    jl_checked_assignment(jl_get_binding_wr(m, var, 1), val);
+    jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
+    if (!bp->constp) {
+        bp->value = val;
+        jl_gc_wb(m, val);
+    } else {
+        jl_errorf("Cannot create global %s; it is already a global const. To "
+                  "change its value, use jl_checked_assignment",
+                  jl_symbol_name(bp->name));
+    }
 }
 
 JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    jl_checked_assignment(bp, val);
-    bp->constp = 1;
+    if (!bp->constp) {
+        bp->value = val;
+        bp->constp = 1;
+        jl_gc_wb(m, val);
+    } else {
+        jl_errorf("Cannot create const %s; it is already a global const. To "
+                  "change its value, use jl_checked_assignment",
+                  jl_symbol_name(bp->name));
+    }
 }
 
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)

--- a/src/module.c
+++ b/src/module.c
@@ -481,21 +481,14 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 
 JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
-    jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    if (!bp->constp) {
-        bp->value = val;
-        jl_gc_wb(m, val);
-    }
+    jl_checked_assignment(jl_get_binding_wr(m, var, 1), val);
 }
 
 JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    if (!bp->constp) {
-        bp->value = val;
-        bp->constp = 1;
-        jl_gc_wb(m, val);
-    }
+    jl_checked_assignment(bp, val);
+    bp->constp = 1;
 }
 
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)

--- a/src/module.c
+++ b/src/module.c
@@ -482,26 +482,18 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
 JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    if (!bp->constp) {
-        bp->value = val;
-        jl_gc_wb(m, val);
-    } else {
-        jl_errorf("Can't modify global const %s; consider jl_checked_assignment"
-                  "to change its value.", jl_symbol_name(bp->name));
-    }
+    assert(!bp->constp && "Can't modify const; consider jl_checked_assignment");
+    bp->value = val;
+    jl_gc_wb(m, val);
 }
 
 JL_DLLEXPORT void jl_define_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    if (!bp) {
-        bp->value = val;
-        bp->constp = 1;
-        jl_gc_wb(m, val);
-    } else {
-        jl_errorf("Cannot create const %s; variable already exists.",
-                  jl_symbol_name(bp->name));
-    }
+    assert(!bp && "Can't create new const; var already exists.");
+    bp->value = val;
+    bp->constp = 1;
+    jl_gc_wb(m, val);
 }
 
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var)

--- a/src/module.c
+++ b/src/module.c
@@ -489,8 +489,11 @@ JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 
 JL_DLLEXPORT void jl_define_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
-    jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
+    // Assert that it doesn't already exist.
+    jl_binding_t *bp = jl_get_binding(m, var);
     assert(!bp && "Can't create new const; var already exists.");
+    // Create it.
+    bp = jl_get_binding_wr(m, var, 1);
     bp->value = val;
     bp->constp = 1;
     jl_gc_wb(m, val);

--- a/src/module.c
+++ b/src/module.c
@@ -41,7 +41,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
         jl_module_using(m, jl_core_module);
     }
     // export own name, so "using Foo" makes "Foo" itself visible
-    jl_set_const(m, name, (jl_value_t*)m);
+    jl_define_const(m, name, (jl_value_t*)m);
     jl_module_export(m, name);
     JL_GC_POP();
     return m;
@@ -486,22 +486,20 @@ JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
         bp->value = val;
         jl_gc_wb(m, val);
     } else {
-        jl_errorf("Cannot create global %s; it is already a global const. To "
-                  "change its value, use jl_checked_assignment",
-                  jl_symbol_name(bp->name));
+        jl_errorf("Can't modify global const %s; consider jl_checked_assignment"
+                  "to change its value.", jl_symbol_name(bp->name));
     }
 }
 
-JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+JL_DLLEXPORT void jl_define_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
-    if (!bp->constp) {
+    if (!bp) {
         bp->value = val;
         bp->constp = 1;
         jl_gc_wb(m, val);
     } else {
-        jl_errorf("Cannot create const %s; it is already a global const. To "
-                  "change its value, use jl_checked_assignment",
+        jl_errorf("Cannot create const %s; variable already exists.",
                   jl_symbol_name(bp->name));
     }
 }

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -64,7 +64,7 @@ JL_DLLEXPORT jl_module_t *jl_new_main_module(void)
     ptls->current_module = jl_main_module;
 
     jl_core_module->parent = jl_main_module;
-    jl_set_const(jl_main_module, jl_symbol("Core"),
+    jl_define_const(jl_main_module, jl_symbol("Core"),
                  (jl_value_t*)jl_core_module);
     jl_set_global(jl_core_module, jl_symbol("Main"),
                   (jl_value_t*)jl_main_module);

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -173,7 +173,7 @@ function deserialize_global_from_main(s::ClusterSerializer, sym)
     sym_isconst = deserialize(s)
     v = deserialize(s)
     if sym_isconst
-        ccall(:jl_set_const, Cvoid, (Any, Any, Any), Main, sym, v)
+        ccall(:jl_define_const, Cvoid, (Any, Any, Any), Main, sym, v)
     else
         ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, sym, v)
     end

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1010,7 +1010,7 @@ function deserialize_typename(s::AbstractSerializer, number)
                     tn, tn.module, super, parameters, names, types,
                     abstr, mutabl, ninitialized)
         tn.wrapper = ndt.name.wrapper
-        ccall(:jl_set_const, Cvoid, (Any, Any, Any), tn.module, tn.name, tn.wrapper)
+        ccall(:jl_define_const, Cvoid, (Any, Any, Any), tn.module, tn.name, tn.wrapper)
         ty = tn.wrapper
         if has_instance && !isdefined(ty, :instance)
             # use setfield! directly to avoid `fieldtype` lowering expecting to see a Singleton object already on ty

--- a/test/module.jl
+++ b/test/module.jl
@@ -1,0 +1,46 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+using Base.Test
+
+# Test c api globals assignment
+ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testGlobal1), 10)
+@test 10 == Base.testGlobal1
+
+ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Core), Ref(:testConst1), "Hello World")
+@test "Hello World" == Core.testConst1
+
+# Test c api globals re-assignment
+ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testGlobal2), 1)
+ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testGlobal2), 2)
+@test 2 == Base.testGlobal2
+ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testGlobal2), "hi")
+@test "hi" == Base.testGlobal2
+
+# Okay to turn a non-const into a const.
+ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testGlobalConst), "global")
+ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testGlobalConst), "const")
+@test "const" == Base.testGlobalConst
+
+# Can't overwrite a const with a value of a new type.
+ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testConst2), 10)
+ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testConst2), "hi")
+@test Base.testConst2 == 10
+
+# *Can* overwrite a const only if it's the same type.
+ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testConst3), "initial")
+ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testConst3), "modified")
+@test_broken "modified" == Base.testConst3
+
+ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
+        Ref(Base), Ref(:testConst3), "modified again")
+@test_broken "modified again" == Base.testConst3

--- a/test/module.jl
+++ b/test/module.jl
@@ -34,15 +34,11 @@ ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
              (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst2), "hi")
 @test Base.testConst2 == 10
 
-# *Can* overwrite a const only if it's the same type.
+# Can't overwrite a const even if it's the same type.
 ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testConst3), "initial")
-@test_warn "redefining constant testConst3" ccall(:jl_set_const, Void,
-         (Ref{Module},Ref{Symbol},Any), Ref(Base),
-         Ref(:testConst3), "modified")
-@test "modified" == Base.testConst3
+@test_throws ErrorException ccall(:jl_set_const, Void,
+         (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst3), "modified")
 
-@test_warn "redefining constant testConst3" ccall(:jl_set_global, Void,
-         (Ref{Module},Ref{Symbol},Any), Ref(Base),
-         Ref(:testConst3), "modified again")
-@test "modified again" == Base.testConst3
+@test_throws ErrorException ccall(:jl_set_global, Void,
+         (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst3), "modified")

--- a/test/module.jl
+++ b/test/module.jl
@@ -20,24 +20,27 @@ ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testGlobal2), "hi")  # Change type
 @test "hi" == Base.testGlobal2
 
+
+# TODO: How to test the assert statements?
+
 # Cannot define a new const when a variable already exists.
 ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testGlobalConst), "global")
-@test_throws ErrorException ccall(:jl_define_const, Void, (Ref{Module},Ref{Symbol},Any),
-                   Ref(Base), Ref(:testGlobalConst), "const")
+#@test_throws ErrorException ccall(:jl_define_const, Void, (Ref{Module},Ref{Symbol},Any),
+#                   Ref(Base), Ref(:testGlobalConst), "const")
 @test "global" == Base.testGlobalConst
 
 # Can't define a new const when a _const_ variable already exists.
 ccall(:jl_define_const, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testConst2), 10)
-@test_throws ErrorException ccall(:jl_define_const, Void,  # Same type
-             (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst2), 20)
-@test_throws ErrorException ccall(:jl_define_const, Void,  # Different type
-             (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst2), "hi")
+#@test_throws ErrorException ccall(:jl_define_const, Void,  # Same type
+#             (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst2), 20)
+#@test_throws ErrorException ccall(:jl_define_const, Void,  # Different type
+#             (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst2), "hi")
 @test Base.testConst2 == 10
 
 # jl_set_global can't change value of a const even if it's the same type.
 ccall(:jl_define_const, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testConst3), "initial")
-@test_throws ErrorException ccall(:jl_set_global, Void,
-         (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst3), "modified")
+#@test_throws ErrorException ccall(:jl_set_global, Void,
+#         (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst3), "modified")

--- a/test/module.jl
+++ b/test/module.jl
@@ -30,17 +30,19 @@ ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
 # Can't overwrite a const with a value of a new type.
 ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testConst2), 10)
-ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
-        Ref(Base), Ref(:testConst2), "hi")
+@test_throws ErrorException ccall(:jl_set_const, Void,
+             (Ref{Module},Ref{Symbol},Any), Ref(Base), Ref(:testConst2), "hi")
 @test Base.testConst2 == 10
 
 # *Can* overwrite a const only if it's the same type.
 ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
         Ref(Base), Ref(:testConst3), "initial")
-ccall(:jl_set_const, Void, (Ref{Module},Ref{Symbol},Any),
-        Ref(Base), Ref(:testConst3), "modified")
-@test_broken "modified" == Base.testConst3
+@test_warn "redefining constant testConst3" ccall(:jl_set_const, Void,
+         (Ref{Module},Ref{Symbol},Any), Ref(Base),
+         Ref(:testConst3), "modified")
+@test "modified" == Base.testConst3
 
-ccall(:jl_set_global, Void, (Ref{Module},Ref{Symbol},Any),
-        Ref(Base), Ref(:testConst3), "modified again")
-@test_broken "modified again" == Base.testConst3
+@test_warn "redefining constant testConst3" ccall(:jl_set_global, Void,
+         (Ref{Module},Ref{Symbol},Any), Ref(Base),
+         Ref(:testConst3), "modified again")
+@test "modified again" == Base.testConst3


### PR DESCRIPTION
Currently, `jl_set_const` (and `jl_set_global`) silently do
nothing if the binding is a `const` global variable. This does not match
the `julia` behavior, which is to allow redefining the const global
(with a Warning) as long as *the types are the same*.

I've added tests for those functions, and include two broken tests demonstrating the above.

I'm also going to push up a commit that changes those two functions to have the
same behavior as an assignment to a const global in julia, by simply delegating
to `jl_checked_assignment`.