### PR TITLE
fix off-by-1 in stacktrace lookup code

### DIFF
--- a/base/stacktraces.jl
+++ b/base/stacktraces.jl
@@ -138,7 +138,7 @@ function lookup(ip::Base.InterpreterIP)
         file = empty_sym
         line = 0
     end
-    i = max(ip.stmt, 1)
+    i = max(ip.stmt+1, 1)  # ip.stmt is 0-indexed
     if i > length(codeinfo.codelocs) || codeinfo.codelocs[i] == 0
         return [StackFrame(func, file, line, ip.code, false, false, 0)]
     end

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -145,3 +145,15 @@ trace = StackTracesTestMod.unfiltered_stacktrace()
 
 trace = StackTracesTestMod.filtered_stacktrace()
 @test !occursin("filtered_stacktrace", string(trace))
+
+let bt, topline = @__LINE__
+try
+    let x = 1
+        y = 2x
+        z = 2z-1
+    end
+catch
+    bt = stacktrace(catch_backtrace())
+end
+@test bt[1].line == topline+4
+end


### PR DESCRIPTION
Probably caused by #27452.