### PR TITLE
Use propagate_inbounds in AbstractArray iterator

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -832,6 +832,7 @@ zero(x::AbstractArray{T}) where {T} = fill!(similar(x), zero(T))
 # own, IndexCartesian's CartesianIndices is more complicated and requires explicit
 # inlining.
 function iterate(A::AbstractArray, state=(eachindex(A),))
+    @_propagate_inbounds_meta
     y = iterate(state...)
     y === nothing && return nothing
     A[y[1]], (state[1], tail(y)...)


### PR DESCRIPTION
I'm sure this was removed accidentally at some point.

```julia
julia> function simple_sum(V)
         s = 0.0
         @fastmath @inbounds for x in V
           s += x
         end
         s
       end

# Current master
julia> @btime simple_sum(v) setup = (v = rand(500))
  51.872 ns (0 allocations: 0 bytes)
251.22882057537214

# Current master
julia> @btime simple_sum(v) setup = (v = view(rand(500, 20), :, 1))
  553.941 ns (0 allocations: 0 bytes)
244.35868876917397

# This pr
julia> @btime simple_sum(v) setup = (v = view(rand(500, 20), :, 1))
  52.354 ns (0 allocations: 0 bytes)
254.29673869300711
```