### PR TITLE
Random: always use SamplerRangeFast for MersenneTwister

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -539,8 +539,8 @@ end
 
 #### from a range
 
-for T in BitInteger_types # eval because of ambiguity otherwise
-    @eval Sampler(rng::MersenneTwister, r::UnitRange{$T}, ::Val{1}) =
+for T in BitInteger_types, R=(1, Inf) # eval because of ambiguity otherwise
+    @eval Sampler(rng::MersenneTwister, r::UnitRange{$T}, ::Val{$R}) =
         SamplerRangeFast(r)
 end
 

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -53,10 +53,10 @@ number generator, see [Random Numbers](@ref).
 # Examples
 ```jldoctest
 julia> srand(0); randstring()
-"Qgt7sUOP"
+"0IPrGg0J"
 
 julia> randstring(MersenneTwister(0), 'a':'z', 6)
-"oevnou"
+"aszvqk"
 
 julia> randstring("ACGT")
 "TATCGGTC"


### PR DESCRIPTION
This is a "breaking" change concerning the numbers generated in a call like `rand(1:3, 10)`. It may be too late for 0.7, but on the other hand the resistance to change may be too high in a later release for such non-essential efficiency improvements.

To generate a random value in `1:3`, there are 2 distinct steps:
1) create a `Sampler` object, which involves one-time computations
2) use this sampler to generate a bunch of numbers
  
As the number of generated random values increases, the cost of step 1) becomes negligible (amortization).

We currently have two `Sampler` types with different compromises on the costs of both steps:
- `SamplerRangeInt` (`SRI`) which is more costly at 1), but is more efficient at using as few entropy bits as possible, in step 2)
- `SamplerRangeFast` (`SRF`) which is cheap at 1), but wastes more entropy bits (depending on the length of the range)

By default, an RNG will use `SRI`. `MersenneTwister` uses:
- `SRF` for scalar calls, like `rand(1:3)`: `MersenneTwister` is fast enough at generating entropy that wasting some bits is preferable in this case
- `SRI` for array calls, like `rand(1:3, 10)`: this was the the original method, and was not updated when `SRF` was introduced, as the status-quo was/is faster in some cases.

I propose now to use `SRF` in all cases for `MersenneTwister`, for more uniformity (e.g. `srand(0); [rand(1:10), rand(1:10)]` will give the same result as `srand(0); rand(1:10, 2)`), and for efficiency, as "most (e.g. 90%) of the time" this will give improved speed.

For a given length of array, the speed of the `SRI` method doesn't vary much with the length `L` of the range, unlike with `SRF`:
- if `L<=2^n` with `L` close to `2^n`, `SRF` can be between 2 and 3 times as fast as `SRI`
- if `L = k + 2^n` with `k>0` "small", `SRF` is slower than `SRI` by a small margin, e.g. 10%. As `k` grows, `SRF` gets faster, and becomes again faster than `SRI` e.g. when `k ≈ (2^n)/10` (which means that `SRF` is slightly slower than `SRI` for 10 percent of input ranges of length between `2^n+1` and `2^(n+1)`).

I lack time now to do advanced performance analysis and graphics, but here is a representative benchmark session (assume the range is `$`-escaped):
```julia
julia> a = zeros(Int, 1000)

# master: SamplerRangeInt

julia> @btime rand!($a, 1:2^30)
  15.184 μs (0 allocations: 0 bytes)

julia> @btime rand!($a, 1:2^30+1)
  15.165 μs (0 allocations: 0 bytes)

julia> @btime rand!($a, 1:2^30+2^26)
  15.176 μs (0 allocations: 0 bytes)

julia> @btime rand!($a, 1:2^30+2^27)
  15.166 μs (0 allocations: 0 bytes)

julia> @btime rand!($a, 1:2^30+2^29)
  15.687 μs (0 allocations: 0 bytes)

# PR: SamplerRangeFast

julia> @btime rand!($a, 1:2^30)
  6.117 μs (0 allocations: 0 bytes)

julia> @btime rand!($a, 1:2^30+1)
  16.535 μs (0 allocations: 0 bytes)

julia> @btime rand!($a, 1:2^30+2^26) # still slower than SRI
  15.699 μs (0 allocations: 0 bytes) 

julia> @btime rand!($a, 1:2^30+2^27)
  14.334 μs (0 allocations: 0 bytes) # faster than SRI again

julia> @btime rand!($a, 1:2^30+2^29)
  9.599 μs (0 allocations: 0 bytes) # significantly faster than SRI
```

