### PR TITLE
split out TestHelpers into separate parts

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -7,8 +7,8 @@ using Test
 using Random, Serialization, Sockets
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-import .Main.TestHelpers: with_fake_pty
+isdefined(Main, :FakePTYs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FakePTYs.jl"))
+import .Main.FakePTYs: with_fake_pty
 
 function challenge_prompt(code::Expr, challenges; timeout::Integer=60, debug::Bool=true)
     input_code = tempname()

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -481,9 +481,8 @@ end
                   "$t of "*sprint((io, t) -> show(io, MIME"text/plain"(), t), parent(Fop))
 end
 
-const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 @testset "offset axes" begin
     s = Base.Slice(-3:3)'

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -519,8 +519,10 @@ end
 
 # dimensional correctness:
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
+using .Main.Furlongs
+LinearAlgebra.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
+
 let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
     @test sqrt(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
 end

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -8,10 +8,6 @@ import REPL.LineEdit: edit_insert, buffer, content, setmark, getmark, region
 include("FakeTerminals.jl")
 import .FakeTerminals.FakeTerminal
 
-const BASE_TEST_PATH = joinpath(@__DIR__, "..", "..", "..", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-import .Main.TestHelpers
-
 # no need to have animation in tests
 REPL.GlobalOptions.region_animation_duration=0.001
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -7,8 +7,8 @@ import REPL.LineEdit
 using Markdown
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-import .Main.TestHelpers
+isdefined(Main, :FakePTYs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FakePTYs.jl"))
+import .Main.FakePTYs: with_fake_pty
 
 # For curmod_*
 include(joinpath(BASE_TEST_PATH, "testenv.jl"))
@@ -719,7 +719,7 @@ ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 1)
 let exename = Base.julia_cmd()
     # Test REPL in dumb mode
     if !Sys.iswindows()
-        TestHelpers.with_fake_pty() do slave, master
+        with_fake_pty() do slave, master
             nENV = copy(ENV)
             nENV["TERM"] = "dumb"
             p = run(setenv(`$exename --startup-file=no -q`,nENV),slave,slave,slave,wait=false)

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -4,8 +4,8 @@ using Test, SparseArrays
 using Test: guardsrand
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
+using .Main.OffsetArrays
 
 using Random
 using Random.DSFMT

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -505,8 +505,8 @@ end
 
 # dimensional correctness
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
+using .Main.Furlongs
 
 Statistics.middle(x::Furlong{p}) where {p} = Furlong{p}(middle(x.val))
 Statistics.middle(x::Furlong{p}, y::Furlong{p}) where {p} = Furlong{p}(middle(x.val, y.val))

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ include $(JULIAHOME)/Make.inc
 TESTGROUPS = unicode strings compiler
 TESTS = all stdlib $(TESTGROUPS) \
         $(patsubst $(STDLIBDIR)/%/,%,$(dir $(wildcard $(STDLIBDIR)/*/.))) \
-		$(filter-out TestHelpers runtests testdefs, \
+		$(filter-out runtests testdefs, \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/*.jl))) \
 		$(foreach group,$(TESTGROUPS), \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/$(group)/*.jl)))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Array test
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 using SparseArrays
 
 using Random, LinearAlgebra

--- a/test/math.jl
+++ b/test/math.jl
@@ -956,8 +956,8 @@ float(x::FloatWrapper) = x
     @test isa(cos(z), Complex)
 end
 
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+using .Main.Furlongs
 @test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
 @test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
 @test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 using DelimitedFiles
 using Random
 using LinearAlgebra
 using Statistics
 
-const OAs_name = join(fullname(OAs), ".")
+const OAs_name = join(fullname(OffsetArrays), ".")
 
 let
 # Basics

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Dates, Random
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
+isdefined(Main, :PhysQuantities || @eval Main include("testhelpers/PhysQuantities.jl")
+using .Main.PhysQuantities
 
 # Compare precision in a manner sensitive to subnormals, which lose
 # precision compared to widening.
@@ -187,10 +188,10 @@ end
     @test isnan(Float64(x0/0))
     @test isnan(Float64(x0/0.0))
 
-    x = Base.TwicePrecision(Main.TestHelpers.PhysQuantity{1}(4.0))
-    @test x.hi*2 === Main.TestHelpers.PhysQuantity{1}(8.0)
+    x = Base.TwicePrecision(.PhysQuantity{1}(4.0))
+    @test x.hi*2 === PhysQuantity{1}(8.0)
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x*2   # not a MethodError for convert
-    @test x.hi/2 === Main.TestHelpers.PhysQuantity{1}(2.0)
+    @test x.hi/2 === PhysQuantity{1}(2.0)
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x/2
 end
 @testset "ranges" begin
@@ -1224,8 +1225,9 @@ Base.rem(x, y::NotReal) = rem(x, y.val)
 Base.isless(x, y::NotReal) = isless(x, y.val)
 @test (:)(1, NotReal(1), 5) isa StepRange{Int,NotReal}
 
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+using .Main.Furlongs
+
 @testset "dimensional correctness" begin
     @test length(Vector(Furlong(2):Furlong(10))) == 9
     @test length(range(Furlong(2), length=9)) == 9

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Random
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 # fold(l|r) & mapfold(l|r)
 @test foldl(+, Int64[]) === Int64(0) # In reference to issues #7465/#20144 (PR #20160)

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 A = Int64[1, 2, 3, 4]
 B = Complex{Int64}[5+6im, 7+8im, 9+10im]

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Set tests
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 @testset "Construction, collect" begin
     @test Set([1,2,3]) isa Set{Int}

--- a/test/testhelpers/FakePTYs.jl
+++ b/test/testhelpers/FakePTYs.jl
@@ -1,0 +1,39 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module FakePTYs
+
+function open_fake_pty()
+    @static if Sys.iswindows()
+        error("Unable to create a fake PTY in Windows")
+    end
+
+    O_RDWR = Base.Filesystem.JL_O_RDWR
+    O_NOCTTY = Base.Filesystem.JL_O_NOCTTY
+
+    fdm = ccall(:posix_openpt, Cint, (Cint,), O_RDWR|O_NOCTTY)
+    fdm == -1 && error("Failed to open PTY master")
+    rc = ccall(:grantpt, Cint, (Cint,), fdm)
+    rc != 0 && error("grantpt failed")
+    rc = ccall(:unlockpt, Cint, (Cint,), fdm)
+    rc != 0 && error("unlockpt")
+
+    fds = ccall(:open, Cint, (Ptr{UInt8}, Cint),
+        ccall(:ptsname, Ptr{UInt8}, (Cint,), fdm), O_RDWR|O_NOCTTY)
+
+    # slave
+    slave = RawFD(fds)
+    master = Base.TTY(RawFD(fdm); readable = true)
+    slave, master
+end
+
+function with_fake_pty(f)
+    slave, master = open_fake_pty()
+    try
+        f(slave, master)
+    finally
+        ccall(:close,Cint,(Cint,),slave) # XXX: this causes the kernel to throw away all unread data on the pty
+        close(master)
+    end
+end
+
+end

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -1,8 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module Furlongs
+
+export Furlong
+
 # Here we implement a minimal dimensionful type Furlong, which is used
-# to test dimensional correctness of various functions in Base.  Furlong
-# is exported by the TestHelpers module.
+# to test dimensional correctness of various functions in Base.
 
 # represents a quantity in furlongs^p
 struct Furlong{p,T<:Number} <: Number
@@ -34,8 +37,6 @@ canonical_p(p) = isinteger(p) ? Int(p) : Rational{Int}(p)
 Base.abs(x::Furlong{p}) where {p} = Furlong{p}(abs(x.val))
 @generated Base.abs2(x::Furlong{p}) where {p} = :(Furlong{$(canonical_p(2p))}(abs2(x.val)))
 @generated Base.inv(x::Furlong{p}) where {p} = :(Furlong{$(canonical_p(-p))}(inv(x.val)))
-import LinearAlgebra: sylvester
-sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 
 for f in (:isfinite, :isnan, :isreal, :isinf)
     @eval Base.$f(x::Furlong) = $f(x.val)
@@ -76,3 +77,5 @@ for op in (:rem, :mod)
     end
 end
 Base.sqrt(x::Furlong) = _div(sqrt(x.val), x, Val(2))
+
+end

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -1,52 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module TestHelpers
-
-using Serialization
-
-include("dimensionful.jl")
-export Furlong
-
-function open_fake_pty()
-    @static if Sys.iswindows()
-        error("Unable to create a fake PTY in Windows")
-    end
-
-    O_RDWR = Base.Filesystem.JL_O_RDWR
-    O_NOCTTY = Base.Filesystem.JL_O_NOCTTY
-
-    fdm = ccall(:posix_openpt, Cint, (Cint,), O_RDWR|O_NOCTTY)
-    fdm == -1 && error("Failed to open PTY master")
-    rc = ccall(:grantpt, Cint, (Cint,), fdm)
-    rc != 0 && error("grantpt failed")
-    rc = ccall(:unlockpt, Cint, (Cint,), fdm)
-    rc != 0 && error("unlockpt")
-
-    fds = ccall(:open, Cint, (Ptr{UInt8}, Cint),
-        ccall(:ptsname, Ptr{UInt8}, (Cint,), fdm), O_RDWR|O_NOCTTY)
-
-    # slave
-    slave = RawFD(fds)
-    master = Base.TTY(RawFD(fdm); readable = true)
-    slave, master
-end
-
-function with_fake_pty(f)
-    slave, master = open_fake_pty()
-    try
-        f(slave, master)
-    finally
-        ccall(:close,Cint,(Cint,),slave) # XXX: this causes the kernel to throw away all unread data on the pty
-        close(master)
-    end
-end
-
 # OffsetArrays (arrays with indexing that doesn't start at 1)
 
 # This test file is designed to exercise support for generic indexing,
 # even though offset arrays aren't implemented in Base.
 
-module OAs
+module OffsetArrays
 
 using Base: Indices, IndexCartesian, IndexLinear, tail
 
@@ -174,26 +133,5 @@ indslength(i::Integer) = i
 
 
 Base.resize!(A::OffsetVector, nl::Integer) = (resize!(A.parent, nl); A)
-
-end
-
-# Mimic a quantity with a physical unit that is not convertible to a real number
-struct PhysQuantity{n,T}   # n is like the exponent of the unit
-    val::T
-end
-PhysQuantity{n}(x::T) where {n,T} = PhysQuantity{n,T}(x)
-Base.zero(::Type{PhysQuantity{n,T}}) where {n,T} = PhysQuantity{n,T}(zero(T))
-Base.zero(x::PhysQuantity) = zero(typeof(x))
-Base.:+(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val + y.val)
-Base.:-(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val - y.val)
-Base.:*(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val*y)
-Base.:/(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val/y)
-Base.:*(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
-    PhysQuantity{n1+n2}(x.val*y.val)
-Base.:/(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
-    PhysQuantity{n1-n2}(x.val/y.val)
-Base.convert(::Type{PhysQuantity{0,T}}, x::Int) where T = PhysQuantity{0}(convert(T, x))
-Base.convert(::Type{P}, ::Int) where P<:PhysQuantity =
-    error("Int is incommensurate with PhysQuantity")
 
 end

--- a/test/testhelpers/PhysQuantities.jl
+++ b/test/testhelpers/PhysQuantities.jl
@@ -1,0 +1,25 @@
+module PhysQuantities
+
+export PhysQuantity
+
+# Mimic a quantity with a physical unit that is not convertible to a real number
+struct PhysQuantity{n,T}   # n is like the exponent of the unit
+    val::T
+end
+PhysQuantity{n}(x::T) where {n,T} = PhysQuantity{n,T}(x)
+Base.zero(::Type{PhysQuantity{n,T}}) where {n,T} = PhysQuantity{n,T}(zero(T))
+Base.zero(x::PhysQuantity) = zero(typeof(x))
+Base.:+(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val + y.val)
+Base.:-(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val - y.val)
+Base.:*(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val*y)
+Base.:/(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val/y)
+Base.:*(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
+    PhysQuantity{n1+n2}(x.val*y.val)
+Base.:/(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
+    PhysQuantity{n1-n2}(x.val/y.val)
+Base.convert(::Type{PhysQuantity{0,T}}, x::Int) where T = PhysQuantity{0}(convert(T, x))
+Base.convert(::Type{P}, ::Int) where P<:PhysQuantity =
+    error("Int is incommensurate with PhysQuantity")
+end
+
+end #module


### PR DESCRIPTION
This is done to reduce the number of test dependencies in the stdlibs.
For example now, the REPL depends on LinearAlgebra for testing since we have REPL -> TestHelpers -> Furlong -> LinearAlgebra.sylvester.

I am trying to get stdlibs passing using the Pkg testing framework but Pkg prevents packages not in the project to be loaded when testing and while adding these test-dependencies to the stdlibs I noticed that things were quite tangled. It also makes sense to just include what you use instead of a fat "test helper" file that is common for the whole of Base + stdlibs.
