### PR TITLE
Do not put the stdlib path in JULIA_LOAD_PATH when testing or building

### DIFF
--- a/stdlib/Base64/Project.toml
+++ b/stdlib/Base64/Project.toml
@@ -1,2 +1,6 @@
 name = "Base64"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/CRC32c/Project.toml
+++ b/stdlib/CRC32c/Project.toml
@@ -1,2 +1,6 @@
 name = "CRC32c"
 uuid = "8bf52ea8-c179-5cab-976a-9e18b702a9bc"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/Dates/Project.toml
+++ b/stdlib/Dates/Project.toml
@@ -3,3 +3,7 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/stdlib/DelimitedFiles/Project.toml
+++ b/stdlib/DelimitedFiles/Project.toml
@@ -3,3 +3,7 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [deps]
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/Distributed/Project.toml
+++ b/stdlib/Distributed/Project.toml
@@ -6,3 +6,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/FileWatching/Project.toml
+++ b/stdlib/FileWatching/Project.toml
@@ -1,2 +1,5 @@
 name = "FileWatching"
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Future/Project.toml
+++ b/stdlib/Future/Project.toml
@@ -3,3 +3,7 @@ uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/stdlib/LibGit2/Project.toml
+++ b/stdlib/LibGit2/Project.toml
@@ -1,2 +1,8 @@
 name = "LibGit2"
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -7,8 +7,8 @@ using Test
 using Random, Serialization, Sockets
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-import .Main.TestHelpers: with_fake_pty
+isdefined(Main, :FakePTYs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FakePTYs.jl"))
+import .Main.FakePTYs: with_fake_pty
 
 function challenge_prompt(code::Expr, challenges; timeout::Integer=60, debug::Bool=true)
     input_code = tempname()

--- a/stdlib/Libdl/Project.toml
+++ b/stdlib/Libdl/Project.toml
@@ -1,2 +1,5 @@
 name = "Libdl"
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/LinearAlgebra/Project.toml
+++ b/stdlib/LinearAlgebra/Project.toml
@@ -3,3 +3,8 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -482,8 +482,8 @@ end
 end
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
+using .Main.OffsetArrays
 
 @testset "offset axes" begin
     s = Base.Slice(-3:3)'

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -519,8 +519,10 @@ end
 
 # dimensional correctness:
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
+using .Main.Furlongs
+LinearAlgebra.sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
+
 let A = UpperTriangular([Furlong(1) Furlong(4); Furlong(0) Furlong(1)])
     @test sqrt(A) == Furlong{1//2}.(UpperTriangular([1 2; 0 1]))
 end

--- a/stdlib/Logging/Project.toml
+++ b/stdlib/Logging/Project.toml
@@ -1,2 +1,5 @@
 name = "Logging"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Markdown/Project.toml
+++ b/stdlib/Markdown/Project.toml
@@ -3,3 +3,6 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Mmap/Project.toml
+++ b/stdlib/Mmap/Project.toml
@@ -1,2 +1,6 @@
 name = "Mmap"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/OldPkg/Project.toml
+++ b/stdlib/OldPkg/Project.toml
@@ -3,3 +3,7 @@ uuid = "fe1c5a76-5840-53d2-82f9-288dd83ce2ce"
 
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/Pkg/Project.toml
+++ b/stdlib/Pkg/Project.toml
@@ -13,3 +13,6 @@ REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Pkg/src/Operations.jl
+++ b/stdlib/Pkg/src/Operations.jl
@@ -148,7 +148,7 @@ function collect_project!(ctx::Context, pkg::PackageSpec, path::String, fix_deps
     if haskey(project, "version")
         pkg.version = VersionNumber(project["version"])
     else
-        @warn "project file for $(pkg.name) is missing a `version` entry"
+        # @warn "project file for $(pkg.name) is missing a `version` entry"
         set_maximum_version_registry!(ctx.env, pkg)
     end
     return true
@@ -175,11 +175,22 @@ function collect_require!(ctx::Context, pkg::PackageSpec, path::String, fix_deps
                 push!(fix_deps, deppkg)
             end
         end
+
         # Packages from REQUIRE files need to get their UUID from the registry
         registry_resolve!(ctx.env, fix_deps)
         project_deps_resolve!(ctx.env, fix_deps)
         ensure_resolved(ctx.env, fix_deps; registry=true)
     end
+
+    # And collect the stdlibs
+    stdlibs = find_stdlib_deps(ctx, path)
+    for (uuid, stdlib) in stdlibs
+        deppkg = PackageSpec(stdlib, uuid, VersionSpec())
+        push!(fix_deps_map[pkg.uuid], deppkg)
+        push!(fix_deps, deppkg)
+    end
+
+    return
 end
 
 
@@ -217,32 +228,52 @@ function deps_graph(ctx::Context, uuid_to_name::Dict{UUID,String}, reqs::Require
                 deps_u_allvers["julia"] = uuid_julia
             end
 
+            # Collect deps + compat for stdlib
             if uuid in keys(ctx.stdlibs)
-                push!(all_versions_u, VERSION)
-                continue
-            end
+                path = Types.stdlib_path(ctx.stdlibs[uuid])
+                proj_file = projectfile_path(path)
+                @assert proj_file != nothing
+                proj = Types.read_package(proj_file)
 
-            for path in registered_paths(ctx.env, uuid)
-                version_info = load_versions(path)
-                versions = sort!(collect(keys(version_info)))
-                deps_data = load_package_data_raw(UUID, joinpath(path, "Deps.toml"))
-                compat_data = load_package_data_raw(VersionSpec, joinpath(path, "Compat.toml"))
+                v = haskey(proj, "version") ? (VersionNumber(proj["version"])) : VERSION
+                push!(all_versions_u, v)
+                vr = VersionRange(v)
 
-                union!(all_versions_u, versions)
-
-                for (vr, dd) in deps_data
-                    all_deps_u_vr = get_or_make!(all_deps_u, vr)
-                    for (name,other_uuid) in dd
-                        # check conflicts??
-                        all_deps_u_vr[name] = other_uuid
-                        other_uuid in uuids || push!(uuids, other_uuid)
-                    end
+                all_deps_u_vr = get_or_make!(all_deps_u, vr)
+                for (name, _other_uuid) in proj["deps"]
+                    other_uuid = UUID(_other_uuid)
+                    all_deps_u_vr[name] = other_uuid
+                    other_uuid in uuids || push!(uuids, other_uuid)
                 end
-                for (vr, cd) in compat_data
-                    all_compat_u_vr = get_or_make!(all_compat_u, vr)
-                    for (name,vs) in cd
-                        # check conflicts??
-                        all_compat_u_vr[name] = vs
+
+                # TODO look at compat section for stdlibs?
+                all_compat_u_vr = get_or_make!(all_compat_u, vr)
+                for (name, other_uuid) in proj["deps"]
+                    all_compat_u_vr[name] = VersionSpec()
+                end
+            else
+                for path in registered_paths(ctx.env, uuid)
+                    version_info = load_versions(path)
+                    versions = sort!(collect(keys(version_info)))
+                    deps_data = load_package_data_raw(UUID, joinpath(path, "Deps.toml"))
+                    compat_data = load_package_data_raw(VersionSpec, joinpath(path, "Compat.toml"))
+
+                    union!(all_versions_u, versions)
+
+                    for (vr, dd) in deps_data
+                        all_deps_u_vr = get_or_make!(all_deps_u, vr)
+                        for (name,other_uuid) in dd
+                            # check conflicts??
+                            all_deps_u_vr[name] = other_uuid
+                            other_uuid in uuids || push!(uuids, other_uuid)
+                        end
+                    end
+                    for (vr, cd) in compat_data
+                        all_compat_u_vr = get_or_make!(all_compat_u, vr)
+                        for (name,vs) in cd
+                            # check conflicts??
+                            all_compat_u_vr[name] = vs
+                        end
                     end
                 end
             end
@@ -637,36 +668,43 @@ function update_manifest(ctx::Context, pkg::PackageSpec, hash::Union{SHA1, Nothi
         info = Dict{String,Any}("uuid" => string(uuid))
         push!(infos, info)
     end
+    is_stdlib = uuid in keys(ctx.stdlibs)
     # We do not print out the whole dependency chain for the standard libraries right now
-    uuid in keys(ctx.stdlibs) && return info
-    info["version"] = string(version)
-    hash == nothing ? delete!(info, "git-tree-sha1") : (info["git-tree-sha1"] = string(hash))
-    path == nothing ? delete!(info, "path")          : (info["path"]          = relative_project_path_if_in_project(ctx, path))
-    if special_action == PKGSPEC_DEVELOPED
-        delete!(info, "pinned")
-        delete!(info, "repo-url")
-        delete!(info, "repo-rev")
-    elseif special_action == PKGSPEC_FREED
-        if get(info, "pinned", false)
+    if !is_stdlib
+        info["version"] = string(version)
+        hash == nothing ? delete!(info, "git-tree-sha1")  : (info["git-tree-sha1"] = string(hash))
+        path == nothing ? delete!(info, "path")          : (info["path"]          = relative_project_path_if_in_project(ctx, path))
+        if special_action == PKGSPEC_DEVELOPED
             delete!(info, "pinned")
-        else
             delete!(info, "repo-url")
             delete!(info, "repo-rev")
+        elseif special_action == PKGSPEC_FREED
+            if get(info, "pinned", false)
+                delete!(info, "pinned")
+            else
+                delete!(info, "repo-url")
+                delete!(info, "repo-rev")
+            end
+        elseif special_action == PKGSPEC_PINNED
+            info["pinned"] = true
+        elseif special_action == PKGSPEC_REPO_ADDED
+            info["repo-url"] = repo.url
+            info["repo-rev"] = repo.rev
+            path = find_installed(name, uuid, hash)
         end
-    elseif special_action == PKGSPEC_PINNED
-        info["pinned"] = true
-    elseif special_action == PKGSPEC_REPO_ADDED
-        info["repo-url"] = repo.url
-        info["repo-rev"] = repo.rev
-        path = find_installed(name, uuid, hash)
-    end
-    if haskey(info, "repo-url")
-        path = find_installed(name, uuid, hash)
+        if haskey(info, "repo-url")
+            path = find_installed(name, uuid, hash)
+        end
     end
 
     delete!(info, "deps")
-    if path != nothing
-        path = joinpath(dirname(ctx.env.project_file), path)
+    if path != nothing || is_stdlib
+        if is_stdlib
+            path = Types.stdlib_path(name)
+        else
+            path = joinpath(dirname(ctx.env.project_file), path)
+        end
+
         deps = Dict{String,String}()
 
         # Check for deps in project file
@@ -708,7 +746,7 @@ function update_manifest(ctx::Context, pkg::PackageSpec, hash::Union{SHA1, Nothi
             break
         end
     end
-    return info
+    return
 end
 
 function prune_manifest(env::EnvCache)
@@ -764,7 +802,6 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
     else
         # Only put `pkg` and its deps (recursively) in the temp project
         collect_deps!(seen, pkg) = begin
-            pkg.uuid in keys(localctx.stdlibs) && return
             pkg.uuid in seen && return
             push!(seen, pkg.uuid)
             info = manifest_info(localctx.env, pkg.uuid)
@@ -796,13 +833,22 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         localctx.env.project_file = joinpath(tmpdir, "Project.toml")
         localctx.env.manifest_file = joinpath(tmpdir, "Manifest.toml")
 
-        # Rewrite paths in Manifest since relative paths won't work here due to the temporary environment
-        for (_, infos) in localctx.env.manifest
-            info = infos[1]
-            if haskey(info, "path")
-                info["path"] = project_rel_path(mainctx, info["path"])
+        function rewrite_manifests(manifest)
+            # Rewrite paths in Manifest since relative paths won't work here due to the temporary environment
+            for (name, infos) in manifest
+                for iinfo in infos
+                    # Is stdlib
+                    if UUID(iinfo["uuid"]) in keys(localctx.stdlibs)
+                        iinfo["path"] = Types.stdlib_path(name)
+                    end
+                    if haskey(iinfo, "path")
+                        iinfo["path"] = project_rel_path(mainctx, iinfo["path"])
+                    end
+                end
             end
         end
+
+        rewrite_manifests(localctx.env.manifest)
 
         # Add target deps to deps (https://github.com/JuliaLang/Pkg.jl/issues/427)
         if !isempty(pkgs)
@@ -810,12 +856,15 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
             add_or_develop(localctx, pkgs)
             need_to_resolve = false # add resolves
             info = manifest_info(localctx.env, pkg.uuid)
-            !haskey(info, "deps") && info["deps"] == Dict{String, Any}()
+            !haskey(info, "deps") && (info["deps"] = Dict{String, Any}())
             deps = info["deps"]
             for deppkg in target_deps
                 deps[deppkg.name] = string(deppkg.uuid)
             end
         end
+
+        # Might have added stdlibs in `add` above
+        rewrite_manifests(localctx.env.manifest)
 
         local new
         will_resolve = might_need_to_resolve && need_to_resolve
@@ -828,7 +877,7 @@ function with_dependencies_loadable_at_toplevel(f, mainctx::Context, pkg::Packag
         write_env(localctx, display_diff = false)
         will_resolve && build_versions(localctx, new)
         sep = Sys.iswindows() ? ';' : ':'
-        withenv(f, "JULIA_LOAD_PATH" => "@$sep$tmpdir$sep$(Types.stdlib_dir())")
+        withenv(f, "JULIA_LOAD_PATH" => "@$sep$tmpdir", "JULIA_PROJECT"=>nothing)
     end
 end
 

--- a/stdlib/Pkg/test/test_packages/BigProject/SubModule/Project.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/SubModule/Project.toml
@@ -5,3 +5,6 @@ version = "0.1.0"
 
 [deps]
 RecursiveDep = "f5db5478-804a-11e8-3275-3180cf89cd91"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Pkg/test/test_packages/BigProject/SubModule2/Project.toml
+++ b/stdlib/Pkg/test/test_packages/BigProject/SubModule2/Project.toml
@@ -4,3 +4,4 @@ uuid = "2d3cad7e-26b9-11e8-3e8d-a543003d541d"
 version = "0.1.0"
 
 [deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Pkg/test/test_packages/UnregisteredWithProject/Project.toml
+++ b/stdlib/Pkg/test/test_packages/UnregisteredWithProject/Project.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 
 [deps]
 Example = "7876af07-990d-54b4-ab0e-23690620f79a"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Printf/Project.toml
+++ b/stdlib/Printf/Project.toml
@@ -3,3 +3,6 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [deps]
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Profile/Project.toml
+++ b/stdlib/Profile/Project.toml
@@ -3,3 +3,7 @@ uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
 [deps]
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/stdlib/REPL/Project.toml
+++ b/stdlib/REPL/Project.toml
@@ -5,3 +5,8 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+OldPkg = "fe1c5a76-5840-53d2-82f9-288dd83ce2ce"

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -8,10 +8,6 @@ import REPL.LineEdit: edit_insert, buffer, content, setmark, getmark, region
 include("FakeTerminals.jl")
 import .FakeTerminals.FakeTerminal
 
-const BASE_TEST_PATH = joinpath(@__DIR__, "..", "..", "..", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-import .Main.TestHelpers
-
 # no need to have animation in tests
 REPL.GlobalOptions.region_animation_duration=0.001
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -7,8 +7,8 @@ import REPL.LineEdit
 using Markdown
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-import .Main.TestHelpers
+isdefined(Main, :FakePTYs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "FakePTYs.jl"))
+import .Main.FakePTYs: with_fake_pty
 
 # For curmod_*
 include(joinpath(BASE_TEST_PATH, "testenv.jl"))
@@ -719,7 +719,7 @@ ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 1)
 let exename = Base.julia_cmd()
     # Test REPL in dumb mode
     if !Sys.iswindows()
-        TestHelpers.with_fake_pty() do slave, master
+        with_fake_pty() do slave, master
             nENV = copy(ENV)
             nENV["TERM"] = "dumb"
             p = run(setenv(`$exename --startup-file=no -q`,nENV),slave,slave,slave,wait=false)

--- a/stdlib/Random/Project.toml
+++ b/stdlib/Random/Project.toml
@@ -3,3 +3,8 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [deps]
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -4,8 +4,8 @@ using Test, SparseArrays
 using Test: guardsrand
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "OffsetArrays.jl"))
+using .Main.OffsetArrays
 
 using Random
 using Random.DSFMT

--- a/stdlib/SHA/Project.toml
+++ b/stdlib/SHA/Project.toml
@@ -1,3 +1,5 @@
 name = "SHA"
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Serialization/Project.toml
+++ b/stdlib/Serialization/Project.toml
@@ -1,2 +1,7 @@
 name = "Serialization"
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+

--- a/stdlib/SharedArrays/Project.toml
+++ b/stdlib/SharedArrays/Project.toml
@@ -6,3 +6,6 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Sockets/Project.toml
+++ b/stdlib/Sockets/Project.toml
@@ -1,2 +1,6 @@
 name = "Sockets"
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/stdlib/SparseArrays/Project.toml
+++ b/stdlib/SparseArrays/Project.toml
@@ -4,3 +4,6 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Statistics/Project.toml
+++ b/stdlib/Statistics/Project.toml
@@ -4,3 +4,6 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -505,8 +505,8 @@ end
 
 # dimensional correctness
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include(joinpath($(BASE_TEST_PATH), "testhelpers", "Furlongs.jl"))
+using .Main.Furlongs
 
 Statistics.middle(x::Furlong{p}) where {p} = Furlong{p}(middle(x.val))
 Statistics.middle(x::Furlong{p}, y::Furlong{p}) where {p} = Furlong{p}(middle(x.val, y.val))

--- a/stdlib/SuiteSparse/Project.toml
+++ b/stdlib/SuiteSparse/Project.toml
@@ -5,3 +5,9 @@ uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/stdlib/UUIDs/Project.toml
+++ b/stdlib/UUIDs/Project.toml
@@ -3,3 +3,6 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/Unicode/Project.toml
+++ b/stdlib/Unicode/Project.toml
@@ -1,2 +1,5 @@
 name = "Unicode"
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[targets.test.deps]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/Makefile
+++ b/test/Makefile
@@ -8,7 +8,7 @@ include $(JULIAHOME)/Make.inc
 TESTGROUPS = unicode strings compiler
 TESTS = all stdlib $(TESTGROUPS) \
         $(patsubst $(STDLIBDIR)/%/,%,$(dir $(wildcard $(STDLIBDIR)/*/.))) \
-		$(filter-out TestHelpers runtests testdefs, \
+		$(filter-out runtests testdefs, \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/*.jl))) \
 		$(foreach group,$(TESTGROUPS), \
 			$(patsubst $(SRCDIR)/%.jl,%,$(wildcard $(SRCDIR)/$(group)/*.jl)))

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Array test
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 using SparseArrays
 
 using Random, LinearAlgebra

--- a/test/math.jl
+++ b/test/math.jl
@@ -956,8 +956,8 @@ float(x::FloatWrapper) = x
     @test isa(cos(z), Complex)
 end
 
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+using .Main.Furlongs
 @test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
 @test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
 @test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 using DelimitedFiles
 using Random
 using LinearAlgebra
 using Statistics
 
-const OAs_name = join(fullname(OAs), ".")
+const OAs_name = join(fullname(OffsetArrays), ".")
 
 let
 # Basics

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1,7 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Dates, Random
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
+isdefined(Main, :PhysQuantities) || @eval Main include("testhelpers/PhysQuantities.jl")
+using .Main.PhysQuantities
 
 # Compare precision in a manner sensitive to subnormals, which lose
 # precision compared to widening.
@@ -187,10 +188,10 @@ end
     @test isnan(Float64(x0/0))
     @test isnan(Float64(x0/0.0))
 
-    x = Base.TwicePrecision(Main.TestHelpers.PhysQuantity{1}(4.0))
-    @test x.hi*2 === Main.TestHelpers.PhysQuantity{1}(8.0)
+    x = Base.TwicePrecision(PhysQuantity{1}(4.0))
+    @test x.hi*2 === PhysQuantity{1}(8.0)
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x*2   # not a MethodError for convert
-    @test x.hi/2 === Main.TestHelpers.PhysQuantity{1}(2.0)
+    @test x.hi/2 === PhysQuantity{1}(2.0)
     @test_throws ErrorException("Int is incommensurate with PhysQuantity") x/2
 end
 @testset "ranges" begin
@@ -1224,8 +1225,9 @@ Base.rem(x, y::NotReal) = rem(x, y.val)
 Base.isless(x, y::NotReal) = isless(x, y.val)
 @test (:)(1, NotReal(1), 5) isa StepRange{Int,NotReal}
 
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers: Furlong
+isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
+using .Main.Furlongs
+
 @testset "dimensional correctness" begin
     @test length(Vector(Furlong(2):Furlong(10))) == 9
     @test length(range(Furlong(2), length=9)) == 9

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Random
-isdefined(Main, :TestHelpers) || @eval Main include(joinpath(dirname(@__FILE__), "TestHelpers.jl"))
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 # fold(l|r) & mapfold(l|r)
 @test foldl(+, Int64[]) === Int64(0) # In reference to issues #7465/#20144 (PR #20160)

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 A = Int64[1, 2, 3, 4]
 B = Complex{Int64}[5+6im, 7+8im, 9+10im]

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -1,8 +1,8 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Set tests
-isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
-using .Main.TestHelpers.OAs
+isdefined(Main, :OffsetArrays) || @eval Main include("testhelpers/OffsetArrays.jl")
+using .Main.OffsetArrays
 
 @testset "Construction, collect" begin
     @test Set([1,2,3]) isa Set{Int}

--- a/test/testhelpers/FakePTYs.jl
+++ b/test/testhelpers/FakePTYs.jl
@@ -1,0 +1,39 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module FakePTYs
+
+function open_fake_pty()
+    @static if Sys.iswindows()
+        error("Unable to create a fake PTY in Windows")
+    end
+
+    O_RDWR = Base.Filesystem.JL_O_RDWR
+    O_NOCTTY = Base.Filesystem.JL_O_NOCTTY
+
+    fdm = ccall(:posix_openpt, Cint, (Cint,), O_RDWR|O_NOCTTY)
+    fdm == -1 && error("Failed to open PTY master")
+    rc = ccall(:grantpt, Cint, (Cint,), fdm)
+    rc != 0 && error("grantpt failed")
+    rc = ccall(:unlockpt, Cint, (Cint,), fdm)
+    rc != 0 && error("unlockpt")
+
+    fds = ccall(:open, Cint, (Ptr{UInt8}, Cint),
+        ccall(:ptsname, Ptr{UInt8}, (Cint,), fdm), O_RDWR|O_NOCTTY)
+
+    # slave
+    slave = RawFD(fds)
+    master = Base.TTY(RawFD(fdm); readable = true)
+    slave, master
+end
+
+function with_fake_pty(f)
+    slave, master = open_fake_pty()
+    try
+        f(slave, master)
+    finally
+        ccall(:close,Cint,(Cint,),slave) # XXX: this causes the kernel to throw away all unread data on the pty
+        close(master)
+    end
+end
+
+end

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -1,8 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+module Furlongs
+
+export Furlong
+
 # Here we implement a minimal dimensionful type Furlong, which is used
-# to test dimensional correctness of various functions in Base.  Furlong
-# is exported by the TestHelpers module.
+# to test dimensional correctness of various functions in Base.
 
 # represents a quantity in furlongs^p
 struct Furlong{p,T<:Number} <: Number
@@ -34,8 +37,6 @@ canonical_p(p) = isinteger(p) ? Int(p) : Rational{Int}(p)
 Base.abs(x::Furlong{p}) where {p} = Furlong{p}(abs(x.val))
 @generated Base.abs2(x::Furlong{p}) where {p} = :(Furlong{$(canonical_p(2p))}(abs2(x.val)))
 @generated Base.inv(x::Furlong{p}) where {p} = :(Furlong{$(canonical_p(-p))}(inv(x.val)))
-import LinearAlgebra: sylvester
-sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 
 for f in (:isfinite, :isnan, :isreal, :isinf)
     @eval Base.$f(x::Furlong) = $f(x.val)
@@ -76,3 +77,5 @@ for op in (:rem, :mod)
     end
 end
 Base.sqrt(x::Furlong) = _div(sqrt(x.val), x, Val(2))
+
+end

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -1,52 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-module TestHelpers
-
-using Serialization
-
-include("dimensionful.jl")
-export Furlong
-
-function open_fake_pty()
-    @static if Sys.iswindows()
-        error("Unable to create a fake PTY in Windows")
-    end
-
-    O_RDWR = Base.Filesystem.JL_O_RDWR
-    O_NOCTTY = Base.Filesystem.JL_O_NOCTTY
-
-    fdm = ccall(:posix_openpt, Cint, (Cint,), O_RDWR|O_NOCTTY)
-    fdm == -1 && error("Failed to open PTY master")
-    rc = ccall(:grantpt, Cint, (Cint,), fdm)
-    rc != 0 && error("grantpt failed")
-    rc = ccall(:unlockpt, Cint, (Cint,), fdm)
-    rc != 0 && error("unlockpt")
-
-    fds = ccall(:open, Cint, (Ptr{UInt8}, Cint),
-        ccall(:ptsname, Ptr{UInt8}, (Cint,), fdm), O_RDWR|O_NOCTTY)
-
-    # slave
-    slave = RawFD(fds)
-    master = Base.TTY(RawFD(fdm); readable = true)
-    slave, master
-end
-
-function with_fake_pty(f)
-    slave, master = open_fake_pty()
-    try
-        f(slave, master)
-    finally
-        ccall(:close,Cint,(Cint,),slave) # XXX: this causes the kernel to throw away all unread data on the pty
-        close(master)
-    end
-end
-
 # OffsetArrays (arrays with indexing that doesn't start at 1)
 
 # This test file is designed to exercise support for generic indexing,
 # even though offset arrays aren't implemented in Base.
 
-module OAs
+module OffsetArrays
 
 using Base: Indices, IndexCartesian, IndexLinear, tail
 
@@ -174,26 +133,5 @@ indslength(i::Integer) = i
 
 
 Base.resize!(A::OffsetVector, nl::Integer) = (resize!(A.parent, nl); A)
-
-end
-
-# Mimic a quantity with a physical unit that is not convertible to a real number
-struct PhysQuantity{n,T}   # n is like the exponent of the unit
-    val::T
-end
-PhysQuantity{n}(x::T) where {n,T} = PhysQuantity{n,T}(x)
-Base.zero(::Type{PhysQuantity{n,T}}) where {n,T} = PhysQuantity{n,T}(zero(T))
-Base.zero(x::PhysQuantity) = zero(typeof(x))
-Base.:+(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val + y.val)
-Base.:-(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val - y.val)
-Base.:*(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val*y)
-Base.:/(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val/y)
-Base.:*(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
-    PhysQuantity{n1+n2}(x.val*y.val)
-Base.:/(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
-    PhysQuantity{n1-n2}(x.val/y.val)
-Base.convert(::Type{PhysQuantity{0,T}}, x::Int) where T = PhysQuantity{0}(convert(T, x))
-Base.convert(::Type{P}, ::Int) where P<:PhysQuantity =
-    error("Int is incommensurate with PhysQuantity")
 
 end

--- a/test/testhelpers/PhysQuantities.jl
+++ b/test/testhelpers/PhysQuantities.jl
@@ -1,0 +1,24 @@
+module PhysQuantities
+
+export PhysQuantity
+
+# Mimic a quantity with a physical unit that is not convertible to a real number
+struct PhysQuantity{n,T}   # n is like the exponent of the unit
+    val::T
+end
+PhysQuantity{n}(x::T) where {n,T} = PhysQuantity{n,T}(x)
+Base.zero(::Type{PhysQuantity{n,T}}) where {n,T} = PhysQuantity{n,T}(zero(T))
+Base.zero(x::PhysQuantity) = zero(typeof(x))
+Base.:+(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val + y.val)
+Base.:-(x::PhysQuantity{n}, y::PhysQuantity{n}) where n = PhysQuantity{n}(x.val - y.val)
+Base.:*(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val*y)
+Base.:/(x::PhysQuantity{n,T}, y::Int) where {n,T} = PhysQuantity{n}(x.val/y)
+Base.:*(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
+    PhysQuantity{n1+n2}(x.val*y.val)
+Base.:/(x::PhysQuantity{n1,S}, y::PhysQuantity{n2,T}) where {n1,n2,S,T} =
+    PhysQuantity{n1-n2}(x.val/y.val)
+Base.convert(::Type{PhysQuantity{0,T}}, x::Int) where T = PhysQuantity{0}(convert(T, x))
+Base.convert(::Type{P}, ::Int) where P<:PhysQuantity =
+    error("Int is incommensurate with PhysQuantity")
+
+end #module


### PR DESCRIPTION
By having the stdlib path in the JULIA_LOAD_PATH when building or testing packages can load stdlibs when that happens without declaring a dependency on them. Moving out stdlibs from Base would then be breaking.

This fixes it, and also adds the needed test-deps to the stdlibs in case someone wants to use Pkg to test stdlibs (one of the Pkg tests does that).
