### PR TITLE
some IR size improvements

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -564,11 +564,11 @@ end
 
 import .Intrinsics: eq_int, trunc_int, lshr_int, sub_int, shl_int, bitcast, sext_int, zext_int, and_int
 
-throw_inexacterror(f::Symbol, T::Type, val) = (@_noinline_meta; throw(InexactError(f, T, val)))
+throw_inexacterror(f::Symbol, T::Type, @nospecialize(val)) = (@_noinline_meta; throw(InexactError(f, T, val)))
 
 function is_top_bit_set(x)
     @_inline_meta
-    eq_int(trunc_int(Int8, lshr_int(x, sub_int(shl_int(sizeof(x), 3), 1))), trunc_int(Int8, 1))
+    eq_int(trunc_int(UInt8, lshr_int(x, sub_int(shl_int(sizeof(x), 3), 1))), trunc_int(UInt8, 1))
 end
 
 function is_top_bit_set(x::Union{Int8,UInt8})

--- a/base/compiler/ssair/inlining2.jl
+++ b/base/compiler/ssair/inlining2.jl
@@ -273,7 +273,7 @@ function ir_inline_item!(compact::IncrementalCompact, idx::Int, argexprs::Vector
     stmt = compact.result[idx]
     linetable_offset = length(linetable)
     # Append the linetable of the inlined function to our line table
-    inlined_at = compact.result_lines[idx]
+    inlined_at = Int(compact.result_lines[idx])
     for entry in item.linetable
         push!(linetable, LineInfoNode(entry.mod, entry.method, entry.file, entry.line,
             (entry.inlined_at > 0 ? entry.inlined_at + linetable_offset : inlined_at)))
@@ -958,7 +958,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
     todo
 end
 
-function mk_tuplecall!(compact::IncrementalCompact, args::Vector{Any}, line_idx::Int)
+function mk_tuplecall!(compact::IncrementalCompact, args::Vector{Any}, line_idx::Int32)
     e = Expr(:call, TOP_TUPLE, args...)
     etyp = tuple_tfunc(Tuple{Any[widenconst(compact_exprtype(compact, args[i])) for i in 1:length(args)]...})
     return insert_node_here!(compact, e, etyp, line_idx)

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -164,7 +164,7 @@ copy(n::NewNode) = copy(n.pos, n.attach_after, n.typ, copy(n.node), n.line)
 struct IRCode
     stmts::Vector{Any}
     types::Vector{Any}
-    lines::Vector{Int}
+    lines::Vector{Int32}
     flags::Vector{UInt8}
     argtypes::Vector{Any}
     spvals::SimpleVector
@@ -173,12 +173,12 @@ struct IRCode
     new_nodes::Vector{NewNode}
     meta::Vector{Any}
 
-    function IRCode(stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int}, flags::Vector{UInt8},
+    function IRCode(stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int32}, flags::Vector{UInt8},
             cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Any},
             spvals::SimpleVector)
         return new(stmts, types, lines, flags, argtypes, spvals, linetable, cfg, NewNode[], meta)
     end
-    function IRCode(ir::IRCode, stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int}, flags::Vector{UInt8},
+    function IRCode(ir::IRCode, stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int32}, flags::Vector{UInt8},
             cfg::CFG, new_nodes::Vector{NewNode})
         return new(stmts, types, lines, flags, ir.argtypes, ir.spvals, ir.linetable, cfg, new_nodes, ir.meta)
     end
@@ -414,7 +414,7 @@ mutable struct IncrementalCompact
     ir::IRCode
     result::Vector{Any}
     result_types::Vector{Any}
-    result_lines::Vector{Int}
+    result_lines::Vector{Int32}
     result_flags::Vector{UInt8}
     result_bbs::Vector{BasicBlock}
     ssa_rename::Vector{Any}
@@ -439,7 +439,7 @@ mutable struct IncrementalCompact
         new_len = length(code.stmts) + length(code.new_nodes)
         result = Array{Any}(undef, new_len)
         result_types = Array{Any}(undef, new_len)
-        result_lines = fill(0, new_len)
+        result_lines = fill(Int32(0), new_len)
         result_flags = fill(0x00, new_len)
         used_ssas = fill(0, new_len)
         ssa_rename = Any[SSAValue(i) for i = 1:new_len]
@@ -567,7 +567,7 @@ function insert_node!(compact::IncrementalCompact, before, @nospecialize(typ), @
     end
 end
 
-function insert_node_here!(compact::IncrementalCompact, @nospecialize(val), @nospecialize(typ), ltable_idx::Int, reverse_affinity=false)
+function insert_node_here!(compact::IncrementalCompact, @nospecialize(val), @nospecialize(typ), ltable_idx::Int32, reverse_affinity::Bool=false)
     if compact.result_idx > length(compact.result)
         @assert compact.result_idx == length(compact.result) + 1
         resize!(compact, compact.result_idx)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -92,7 +92,7 @@ function print_node(io::IO, idx::Int, @nospecialize(stmt), used, argnames, maxsi
     end
 end
 
-function compute_inlining_depth(linetable, iline::Int)
+function compute_inlining_depth(linetable, iline::Int32)
     depth = 0
     while iline != 0
         linetable[iline].inlined_at == 0 && break
@@ -120,9 +120,9 @@ function default_expr_type_printer(io::IO, @nospecialize typ)
     nothing
 end
 
-function compute_loc_stack(code::IRCode, line::Int)
+function compute_loc_stack(code::IRCode, line::Int32)
     stack = []
-    line === 0 && return stack
+    line == 0 && return stack
     inlined_at = code.linetable[line].inlined_at
     if inlined_at != 0
         push!(stack, inlined_at)
@@ -214,7 +214,7 @@ function compute_ir_line_annotations(code::IRCode)
         lineno = 0
         loc_method = ""
         print(buf, "│")
-        if line !== 0
+        if line != 0
             stack = compute_loc_stack(code, line)
             lineno = code.linetable[stack[1]].line
             x = min(length(last_stack), length(stack))

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -426,7 +426,7 @@ function domsort_ssa!(ir::IRCode, domtree::DomTree)
     nstmts = sum(length(ir.cfg.blocks[i].stmts) for i in result_order if i !== 0)
     result_stmts = Vector{Any}(undef, nstmts + ncritbreaks + nnewfallthroughs)
     result_types = Any[Any for i = 1:length(result_stmts)]
-    result_ltable = fill(0, length(result_stmts))
+    result_ltable = fill(Int32(0), length(result_stmts))
     result_flags = fill(0x00, length(result_stmts))
     inst_rename = Vector{Any}(undef, length(ir.stmts))
     for i = 1:length(ir.new_nodes)

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -596,7 +596,7 @@ function typeinf_ext(linfo::MethodInstance, params::Params)
                     tree.slotflags = fill(0x00, Int(method.nargs))
                     tree.slottypes = nothing
                     tree.ssavaluetypes = 0
-                    tree.codelocs = Int[1]
+                    tree.codelocs = Int32[1]
                     tree.linetable = [LineInfoNode(method.module, method.name, method.file, Int(method.line), 0)]
                     tree.inferred = true
                     tree.ssaflags = UInt8[]

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -401,7 +401,7 @@ function append_any(xs...)
                 _growend!(out, 16)
                 l += 16
             end
-            Core.arrayset(true, out, y, i)
+            arrayset(true, out, y, i)
             i += 1
         end
     end
@@ -410,7 +410,7 @@ function append_any(xs...)
 end
 
 # simple Array{Any} operations needed for bootstrap
-@eval setindex!(A::Array{Any}, @nospecialize(x), i::Int) = Core.arrayset($(Expr(:boundscheck)), A, x, i)
+@eval setindex!(A::Array{Any}, @nospecialize(x), i::Int) = arrayset($(Expr(:boundscheck)), A, x, i)
 
 """
     precompile(f, args::Tuple{Vararg{Any}})

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -152,6 +152,6 @@ isless(x::Ptr{T}, y::Ptr{T}) where {T} = x < y
 <(x::Ptr,  y::Ptr) = UInt(x) < UInt(y)
 -(x::Ptr,  y::Ptr) = UInt(x) - UInt(y)
 
-+(x::Ptr, y::Integer) = oftype(x, Intrinsics.add_ptr(UInt(x), (y % UInt) % UInt))
--(x::Ptr, y::Integer) = oftype(x, Intrinsics.sub_ptr(UInt(x), (y % UInt) % UInt))
++(x::Ptr, y::Integer) = oftype(x, add_ptr(UInt(x), (y % UInt) % UInt))
+-(x::Ptr, y::Integer) = oftype(x, sub_ptr(UInt(x), (y % UInt) % UInt))
 +(x::Integer, y::Ptr) = y + x

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3900,6 +3900,10 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                 expr = jl_box_int64(val);
             }
         }
+        else if (jl_is_uint8(expr)) {
+            expr = jl_box_uint8(jl_unbox_uint8(expr));
+            needroot = false;
+        }
         if (needroot && jl_is_method(ctx.linfo->def.method)) { // toplevel exprs and some integers are already rooted
             jl_add_method_root(ctx, expr);
         }
@@ -5964,7 +5968,7 @@ static std::unique_ptr<Module> emit_function(
         }
         size_t prev_loc = 0;
         for (i = 0; i < stmtslen; i++) {
-            size_t loc = ((size_t*)jl_array_data(src->codelocs))[i];
+            size_t loc = ((int32_t*)jl_array_data(src->codelocs))[i];
             StmtProp &cur_prop = stmtprops[i];
             cur_prop.is_poploc = false;
             if (loc > 0) {

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -82,7 +82,7 @@ jl_typename_t *jl_array_typename;
 jl_value_t *jl_array_uint8_type;
 jl_value_t *jl_array_any_type=NULL;
 jl_value_t *jl_array_symbol_type;
-jl_value_t *jl_array_int_type;
+jl_value_t *jl_array_int32_type;
 jl_datatype_t *jl_weakref_type;
 jl_datatype_t *jl_abstractstring_type;
 jl_datatype_t *jl_string_type;
@@ -1954,7 +1954,7 @@ void jl_init_types(void)
     jl_array_any_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_any_type, jl_box_long(1));
     jl_array_symbol_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_sym_type, jl_box_long(1));
     jl_array_uint8_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_uint8_type, jl_box_long(1));
-    jl_array_int_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_long_type, jl_box_long(1));
+    jl_array_int32_type = jl_apply_type2((jl_value_t*)jl_array_type, (jl_value_t*)jl_int32_type, jl_box_long(1));
 
     jl_expr_type =
         jl_new_datatype(jl_symbol("Expr"), core,

--- a/src/julia.h
+++ b/src/julia.h
@@ -598,7 +598,7 @@ extern JL_DLLEXPORT jl_unionall_t *jl_namedtuple_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_array_uint8_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_array_any_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_array_symbol_type JL_GLOBALLY_ROOTED;
-extern JL_DLLEXPORT jl_value_t *jl_array_int_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_value_t *jl_array_int32_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_expr_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_globalref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_linenumbernode_type JL_GLOBALLY_ROOTED;

--- a/src/method.c
+++ b/src/method.c
@@ -209,10 +209,11 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
     jl_value_t *codelocs = jl_exprarg(ast, 3);
     li->linetable = jl_exprarg(ast, 4);
     size_t nlocs = jl_array_len(codelocs);
-    li->codelocs = (jl_value_t*)jl_alloc_array_1d(jl_array_int_type, nlocs);
+    li->codelocs = (jl_value_t*)jl_alloc_array_1d(jl_array_int32_type, nlocs);
     size_t j;
     for (j = 0; j < nlocs; j++) {
-        jl_arrayset((jl_array_t*)li->codelocs, jl_arrayref((jl_array_t*)codelocs, j), j);
+        jl_arrayset((jl_array_t*)li->codelocs, jl_box_int32(jl_unbox_long(jl_arrayref((jl_array_t*)codelocs, j))),
+                    j);
     }
     assert(jl_is_expr(bodyex));
     jl_array_t *body = bodyex->args;

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1615,7 +1615,7 @@ static void jl_init_serializer2(int for_serialize)
                      jl_methtable_type, jl_typemap_level_type, jl_typemap_entry_type,
                      jl_voidpointer_type, jl_newvarnode_type,
                      jl_array_symbol_type, jl_anytuple_type, jl_tparam0(jl_anytuple_type),
-                     jl_emptytuple_type, jl_array_uint8_type, jl_array_int_type,
+                     jl_emptytuple_type, jl_array_uint8_type, jl_array_int32_type,
                      jl_symbol_type->name, jl_ssavalue_type->name, jl_tuple_typename,
                      ((jl_datatype_t*)jl_unwrap_unionall((jl_value_t*)jl_ref_type))->name,
                      jl_pointer_typename, jl_simplevector_type->name,
@@ -1683,6 +1683,12 @@ static void jl_init_serializer2(int for_serialize)
         arraylist_push(&deser_tag, v64);
         if (for_serialize)
             ptrhash_put(&sertag_table, v64, (void*)((char*)HT_NOTFOUND + ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + deser_tag.len));
+    }
+    for (i = 0; i < 256; i++) {
+        jl_value_t *vu = jl_box_uint8(i);
+        arraylist_push(&deser_tag, vu);
+        if (for_serialize)
+            ptrhash_put(&sertag_table, vu, (void*)((char*)HT_NOTFOUND + ((uintptr_t)TagRef << RELOC_TAG_OFFSET) + deser_tag.len));
     }
 
     if (for_serialize) {

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -938,7 +938,7 @@ let f, m
     m = first(methods(f))
     m.source = Base.uncompressed_ast(m)::CodeInfo
     m.source.ssavaluetypes = 3
-    m.source.codelocs = [1, 1, 1]
+    m.source.codelocs = Int32[1, 1, 1]
     m.source.code = Any[
         Expr(:call, GlobalRef(Core, :svec), 1, 2, 3),
         Expr(:call, Core._apply, GlobalRef(Base, :+), SSAValue(1)),


### PR DESCRIPTION
- serialize Method's enclosing Module more compactly
- use Int32 instead of Int for source location indices
- use UInt8 instead of Int8 and serialize it more compactly

This shrinks basecompiler.ji by almost 10% and the system image by ~4%.