### PR TITLE
Don't overload split for LibGit2.ConfigEntry

### DIFF
--- a/stdlib/LibGit2/docs/src/index.md
+++ b/stdlib/LibGit2/docs/src/index.md
@@ -137,6 +137,7 @@ LibGit2.revcount
 LibGit2.set_remote_url
 LibGit2.shortname
 LibGit2.snapshot
+LibGit2.split_cfg_entry
 LibGit2.status
 LibGit2.stage
 LibGit2.tag_create

--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -208,7 +208,7 @@ function credential_helpers(cfg::GitConfig, cred::GitCredential)
 
     # https://git-scm.com/docs/gitcredentials#gitcredentials-helper
     for entry in GitConfigIter(cfg, r"credential.*\.helper")
-        section, url, name, value = split(entry)
+        section, url, name, value = split_cfg_entry(entry)
         @assert name == "helper"
 
         # Only use configuration settings where the URL applies to the git credential
@@ -244,7 +244,7 @@ specified `git_cred`.
 function default_username(cfg::GitConfig, cred::GitCredential)
     # https://git-scm.com/docs/gitcredentials#gitcredentials-username
     for entry in GitConfigIter(cfg, r"credential.*\.username")
-        section, url, name, value = split(entry)
+        section, url, name, value = split_cfg_entry(entry)
         @assert name == "username"
 
         # Only use configuration settings where the URL applies to the git credential
@@ -263,7 +263,7 @@ function use_http_path(cfg::GitConfig, cred::GitCredential)
     # Note: Ideally the regular expression should use "useHttpPath"
     # https://github.com/libgit2/libgit2/issues/4390
     for entry in GitConfigIter(cfg, r"credential.*\.usehttppath")
-        section, url, name, value = split(entry)
+        section, url, name, value = split_cfg_entry(entry)
 
         ismatch(url, cred) || continue
         use_path = value == "true"

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -921,7 +921,7 @@ function Base.show(io::IO, ce::ConfigEntry)
 end
 
 """
-    split(ce::LibGit2.ConfigEntry) -> Tuple{String,String,String,String}
+    LibGit2.split_cfg_entry(ce::LibGit2.ConfigEntry) -> Tuple{String,String,String,String}
 
 Break the `ConfigEntry` up to the following pieces: section, subsection, name, and value.
 
@@ -938,14 +938,14 @@ The `ConfigEntry` would look like the following:
 julia> entry
 ConfigEntry("credential.https://example.com.username", "me")
 
-julia> split(entry)
+julia> LibGit2.split_cfg_entry(entry)
 ("credential", "https://example.com", "username", "me")
 ```
 
 Refer to the [git config syntax documenation](https://git-scm.com/docs/git-config#_syntax)
 for more details.
 """
-function Base.split(ce::ConfigEntry)
+function split_cfg_entry(ce::ConfigEntry)
     key = unsafe_string(ce.name)
 
     # Determine the positions of the delimiters


### PR DESCRIPTION
It doesn't really match what `split` is doing, and we've removed these puns in the past. Also, it clogs up the help screen for `split`.