### PR TITLE
Support (+).(1:10)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -960,6 +960,10 @@ _longest_tuple(A::NTuple{N,Any}, B::NTuple{N,Any}) where N = A
 
 ## scalar-range broadcast operations ##
 # DefaultArrayStyle and \ are not available at the time of range.jl
+broadcasted(::DefaultArrayStyle{1}, ::typeof(+), r::OrdinalRange) = r
+broadcasted(::DefaultArrayStyle{1}, ::typeof(+), r::StepRangeLen) = r
+broadcasted(::DefaultArrayStyle{1}, ::typeof(+), r::LinRange) = r
+
 broadcasted(::DefaultArrayStyle{1}, ::typeof(-), r::OrdinalRange) = range(-first(r), step=-step(r), length=length(r))
 broadcasted(::DefaultArrayStyle{1}, ::typeof(-), r::StepRangeLen) = StepRangeLen(-r.ref, -r.step, length(r), r.offset)
 broadcasted(::DefaultArrayStyle{1}, ::typeof(-), r::LinRange) = LinRange(-r.start, -r.stop, length(r))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -491,8 +491,10 @@ end
     @test sum(0:0.1:10) == 505.
 end
 @testset "broadcasted operations with scalars" begin
+    @test broadcast(-, 1:3) === -1:-1:-3
     @test broadcast(-, 1:3, 2) === -1:1
     @test broadcast(-, 1:3, 0.25) === 1-0.25:3-0.25
+    @test broadcast(+, 1:3) === 1:3
     @test broadcast(+, 1:3, 2) === 3:5
     @test broadcast(+, 1:3, 0.25) === 1+0.25:3+0.25
     @test broadcast(+, 1:2:6, 1) === 2:2:6


### PR DESCRIPTION
This resolves the following inconsistency:
```julia
julia> (+).(1:10)
10-element Array{Int64,1}:
  1
  2
  3
  4
  5
  6
  7
  8
  9
 10

julia> (-).(1:10)
-1:-1:-10
```