### PR TITLE
Normalize the argument order in lstrip and rstrip

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -691,6 +691,9 @@ Library improvements
   * `IOBuffer` can take the `sizehint` keyword argument to suggest a capacity of
     the buffer ([#25944]).
 
+  * `lstrip` and `rstrip` now accept a predicate function that defaults to `isspace`
+    ([#27309]).
+
   * `trunc`, `floor`, `ceil`, and `round` specify `digits`, `sigdigits` and `base` using
     keyword arguments. ([#26156], [#26670])
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -135,15 +135,17 @@ function chomp(s::String)
 end
 
 """
-    lstrip(str::AbstractString[, chars])
+    lstrip([pred=isspace,] str::AbstractString)
+    lstrip(str::AbstractString, chars)
 
-Remove leading characters from `str`.
+Remove leading characters from `str`, either those specified by `chars` or those for
+which the function `pred` returns `true`.
 
 The default behaviour is to remove leading whitespace and delimiters: see
 [`isspace`](@ref) for precise details.
 
-The optional `chars` argument specifies which characters to remove: it can be a single character,
-vector or set of characters, or a predicate function.
+The optional `chars` argument specifies which characters to remove: it can be a single
+character, or a vector or set of characters.
 
 # Examples
 ```jldoctest
@@ -154,25 +156,28 @@ julia> lstrip(a)
 "March"
 ```
 """
-function lstrip(s::AbstractString, f=isspace)
+function lstrip(f, s::AbstractString)
     e = lastindex(s)
     for (i, c) in pairs(s)
         !f(c) && return SubString(s, i, e)
     end
     SubString(s, e+1, e)
 end
-lstrip(s::AbstractString, chars::Chars) = lstrip(s, in(chars))
+lstrip(s::AbstractString) = lstrip(isspace, s)
+lstrip(s::AbstractString, chars::Chars) = lstrip(in(chars), s)
 
 """
-    rstrip(str::AbstractString[, chars])
+    rstrip([pred=isspace,] str::AbstractString)
+    rstrip(str::AbstractString, chars)
 
-Remove trailing characters from `str`.
+Remove trailing characters from `str`, either those specified by `chars` or those for
+which the function `pred` returns `true`.
 
 The default behaviour is to remove leading whitespace and delimiters: see
 [`isspace`](@ref) for precise details.
 
-The optional `chars` argument specifies which characters to remove: it can be a single character,
-vector or set of characters, or a predicate function.
+The optional `chars` argument specifies which characters to remove: it can be a single
+character, or a vector or set of characters.
 
 # Examples
 ```jldoctest
@@ -183,13 +188,14 @@ julia> rstrip(a)
 "March"
 ```
 """
-function rstrip(s::AbstractString, f=isspace)
+function rstrip(f, s::AbstractString)
     for (i, c) in Iterators.reverse(pairs(s))
         f(c) || return SubString(s, 1, i)
     end
     SubString(s, 1, 0)
 end
-rstrip(s::AbstractString, chars::Chars) = rstrip(s, in(chars))
+rstrip(s::AbstractString) = rstrip(isspace, s)
+rstrip(s::AbstractString, chars::Chars) = rstrip(in(chars), s)
 
 """
     strip(str::AbstractString, [chars])

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -10,7 +10,7 @@ module DelimitedFiles
 
 using Mmap
 
-import Base: _default_delims, tryparse_internal, show
+import Base: tryparse_internal, show
 
 export readdlm, writedlm
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -73,6 +73,11 @@ end
             @test typeof(fb) == SubString{T}
         end
     end
+
+    @test lstrip(isnumeric, "0123abc") == "abc"
+    @test rstrip(isnumeric, "abc0123") == "abc"
+    @test lstrip("ello", ['e','o']) == "llo"
+    @test rstrip("ello", ['e','o']) == "ell"
 end
 
 @testset "rsplit/split" begin


### PR DESCRIPTION
This puts the function argument first, as dictated in the style guide.