### PR TITLE
Fix handling of pending values in `argexprtype`

### DIFF
--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -57,7 +57,7 @@ function stmt_effect_free(@nospecialize(stmt), src::IncrementalCompact, spvals::
 end
 
 function abstract_eval_ssavalue(s::SSAValue, src::IRCode)
-    return src.types[s.id]
+    return types(src)[s]
 end
 
 function abstract_eval_ssavalue(s::SSAValue, src::IncrementalCompact)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6194,3 +6194,11 @@ function baz27365()
 end
 
 @test isa(baz27365(), Float64)
+
+# Issue #27566
+function test27566(a,b)
+    c = (b,(0,1)...)
+    test27566(a, c...)
+end
+test27566(a, b, c, d) = a.*(b, c, d)
+@test test27566(1,1) == (1,0,1)


### PR DESCRIPTION
In inlining, we insert pending nodes to rewrite an apply call.
Make sure that subsequently calling `argexprtype` on one of these
values does not throw an error.

Fixes #27566