### PR TITLE
make &x sugar for RefValue(x)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -612,7 +612,7 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val}) = Ref(x)
+broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val}) = &x
 broadcastable(x::Ptr) = Ref{Ptr}(x) # Cannot use Ref(::Ptr) until ambiguous deprecation goes through
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -698,7 +698,7 @@ end
 @noinline function Broadcast.broadcastable(x)
     depwarn("""
         broadcast will default to iterating over its arguments in the future. Wrap arguments of
-        type `x::$(typeof(x))` with `Ref(x)` to ensure they broadcast as "scalar" elements.
+        type `x::$(typeof(x))` with `&x` to ensure they broadcast as "scalar" elements.
         """, (:broadcast, :broadcast!))
     return Ref{typeof(x)}(x)
 end

--- a/base/event.jl
+++ b/base/event.jl
@@ -166,7 +166,7 @@ function yield(t::Task, @nospecialize x = nothing)
     t.state == :runnable || error("schedule: Task not runnable")
     t.result = x
     enq_work(current_task())
-    return try_yieldto(ensure_rescheduled, Ref(t))
+    return try_yieldto(ensure_rescheduled, &t)
 end
 
 """
@@ -179,7 +179,7 @@ or scheduling in any way. Its use is discouraged.
 """
 function yieldto(t::Task, @nospecialize x = nothing)
     t.result = x
-    return try_yieldto(identity, Ref(t))
+    return try_yieldto(identity, &t)
 end
 
 function try_yieldto(undo, reftask::Ref{Task})
@@ -237,7 +237,7 @@ end
         return
     end
     t.state = :runnable
-    return Ref(t)
+    return &t
 end
 
 function wait()

--- a/base/io.jl
+++ b/base/io.jl
@@ -511,7 +511,7 @@ unsafe_write(s::IO, p::Ptr, n::Integer) = unsafe_write(s, convert(Ptr{UInt8}, p)
 write(s::IO, x::Ref{T}) where {T} = unsafe_write(s, x, Core.sizeof(T))
 write(s::IO, x::Int8) = write(s, reinterpret(UInt8, x))
 function write(s::IO, x::Union{Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128,Float16,Float32,Float64})
-    return write(s, Ref(x))
+    return write(s, &x)
 end
 
 write(s::IO, x::Bool) = write(s, UInt8(x))

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -768,7 +768,7 @@ const include_callbacks = Any[]
 # used to optionally track dependencies when requiring a module:
 const _concrete_dependencies = Pair{PkgId,UInt64}[] # these dependency versions are "set in stone", and the process should try to avoid invalidating them
 const _require_dependencies = Any[] # a list of (mod, path, mtime) tuples that are the file dependencies of the module currently being precompiled
-const _track_dependencies = Ref(false) # set this to true to track the list of file dependencies
+const _track_dependencies = &false # set this to true to track the list of file dependencies
 function _include_dependency(mod::Module, _path::AbstractString)
     prev = source_path(nothing)
     if prev === nothing
@@ -840,7 +840,7 @@ function __precompile__(isprecompilable::Bool=true)
 end
 
 # require always works in Main scope and loads files from node 1
-const toplevel_load = Ref(true)
+const toplevel_load = &true
 
 """
     require(module::Symbol)

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -352,7 +352,7 @@ end
 
 # Global log limiting mechanism for super fast but inflexible global log
 # limiting.
-const _min_enabled_level = Ref(Debug)
+const _min_enabled_level = &Debug
 
 # LogState - a concretely typed cache of data extracted from the logger, plus
 # the logger itself.

--- a/base/refpointer.jl
+++ b/base/refpointer.jl
@@ -9,7 +9,7 @@ freeing by the garbage collector as long as the `Ref` itself is referenced.
 
 In Julia, `Ref` objects are dereferenced (loaded or stored) with `[]`.
 
-Creation of a `Ref` to a value `x` of type `T` is usually written `Ref(x)`.
+Creation of a `Ref` to a value `x` of type `T` is usually written `&x` or `Ref(x)`.
 Additionally, for creating interior pointers to containers (such as Array or Ptr),
 it can be written `Ref(a, i)` for creating a reference to the `i`-th element of `a`.
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -339,7 +339,7 @@ function show_default(io::IO, @nospecialize(x))
         end
     else
         print(io, "0x")
-        r = Ref(x)
+        r = &x
         GC.@preserve r begin
             p = unsafe_convert(Ptr{Cvoid}, r)
             for i in (nb - 1):-1:0

--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -19,7 +19,7 @@ on `threadid()`.
 nthreads() = Int(unsafe_load(cglobal(:jl_n_threads, Cint)))
 
 # Only read/written by the main thread
-const in_threaded_loop = Ref(false)
+const in_threaded_loop = &false
 
 function _threadsfor(iter,lbody)
     lidx = iter.args[1]         # index

--- a/base/version.jl
+++ b/base/version.jl
@@ -83,7 +83,7 @@ function print(io::IO, v::VersionNumber)
 end
 show(io::IO, v::VersionNumber) = print(io, "v\"", v, "\"")
 
-Broadcast.broadcastable(v::VersionNumber) = Ref(v)
+Broadcast.broadcastable(v::VersionNumber) = &v
 
 const VERSION_REGEX = r"^
     v?                                      # prefix        (optional)

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1480,7 +1480,7 @@ julia> using Base.Threads
 julia> nthreads()
 4
 
-julia> acc = Ref(0)
+julia> acc = &0
 Base.RefValue{Int64}(0)
 
 julia> @threads for i in 1:1000

--- a/stdlib/Dates/src/arithmetic.jl
+++ b/stdlib/Dates/src/arithmetic.jl
@@ -99,4 +99,4 @@ end
 (-)(x::AbstractRange{T}, y::AbstractRange{T}) where {T<:TimeType} = Vector(x) - Vector(y)
 
 # Allow dates and times to broadcast as unwrapped scalars
-Base.Broadcast.broadcastable(x::AbstractTime) = Ref(x)
+Base.Broadcast.broadcastable(x::AbstractTime) = &x

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -378,7 +378,7 @@ function Base.show(io::IO, df::DateFormat)
     end
     print(io, '"')
 end
-Base.Broadcast.broadcastable(x::DateFormat) = Ref(x)
+Base.Broadcast.broadcastable(x::DateFormat) = &x
 
 """
     dateformat"Y-m-d H:M:S"

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -28,7 +28,7 @@ end
 ClusterSerializer(io::IO) = ClusterSerializer{typeof(io)}(io)
 
 const object_numbers = WeakKeyDict()
-const obj_number_salt = Ref(0)
+const obj_number_salt = &0
 function object_number(s::ClusterSerializer, @nospecialize(l))
     global obj_number_salt, object_numbers
     if haskey(object_numbers, l)

--- a/stdlib/Distributed/src/messages.jl
+++ b/stdlib/Distributed/src/messages.jl
@@ -2,7 +2,7 @@
 
 abstract type AbstractMsg end
 
-const REF_ID = Ref(1)
+const REF_ID = &1
 next_ref_id() = (id = REF_ID[]; REF_ID[] = id+1; id)
 
 struct RRID

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -902,7 +902,7 @@ let (p, p2) = filter!(p -> p != myid(), procs())
     @test !remotecall_fetch(isdefined, p2, Main, :defined_on_p)
     @test nothing === @everywhere [p, p] defined_on_p += 1
     @test 3 === @everywhere p defined_on_p
-    let ref = Ref(0)
+    let ref = &0
         @test nothing ===
             @everywhere [myid(), p, myid(), myid(), p] begin
                 Test.@test Main === @__MODULE__

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -248,7 +248,7 @@ end
 @which get_A18434()(1, y=2)
 @test counter18434 == 2
 
-let _true = Ref(true), f, g, h
+let _true = &true, f, g, h
     @noinline f() = ccall((:time, "error_library_doesnt_exist\0"), Cvoid, ()) # some expression that throws an error in codegen
     @noinline g() = _true[] ? 0 : h()
     @noinline h() = (g(); f())

--- a/stdlib/LibGit2/src/blame.jl
+++ b/stdlib/LibGit2/src/blame.jl
@@ -12,7 +12,7 @@ function GitBlame(repo::GitRepo, path::AbstractString; options::BlameOptions=Bla
     blame_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_blame_file, :libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Cstring, Ptr{BlameOptions}),
-                   blame_ptr_ptr, repo.ptr, path, Ref(options))
+                   blame_ptr_ptr, repo.ptr, path, &options)
     return GitBlame(repo, blame_ptr_ptr[])
 end
 

--- a/stdlib/LibGit2/src/index.jl
+++ b/stdlib/LibGit2/src/index.jl
@@ -197,7 +197,7 @@ before the attempted merge, stage `1` is the changes which have been made locall
 stages `2` and larger are for changes from other branches (for instance, in the case
 of a multi-branch "octopus" merge, stages `2`, `3`, and `4` might be used).
 """
-stage(ie::IndexEntry) = ccall((:git_index_entry_stage, :libgit2), Cint, (Ptr{IndexEntry},), Ref(ie))
+stage(ie::IndexEntry) = ccall((:git_index_entry_stage, :libgit2), Cint, (Ptr{IndexEntry},), &ie)
 
 function Base.show(io::IO, idx::GitIndex)
     println(io, "GitIndex:\nRepository: ", repository(idx), "\nNumber of elements: ", count(idx))

--- a/stdlib/LibGit2/src/merge.jl
+++ b/stdlib/LibGit2/src/merge.jl
@@ -17,7 +17,7 @@ function GitAnnotated(repo::GitRepo, commit_id::GitHash)
     ann_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_annotated_commit_lookup, :libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{GitHash}),
-                   ann_ptr_ptr, repo.ptr, Ref(commit_id))
+                   ann_ptr_ptr, repo.ptr, &commit_id)
     return GitAnnotated(repo, ann_ptr_ptr[])
 end
 
@@ -145,7 +145,7 @@ function merge!(repo::GitRepo, anns::Vector{GitAnnotated};
                   (Ptr{Cvoid}, Ptr{Ptr{Cvoid}}, Csize_t,
                    Ptr{MergeOptions}, Ptr{CheckoutOptions}),
                    repo.ptr, Base.map(x->x.ptr, anns), anns_size,
-                   Ref(merge_opts), Ref(checkout_opts))
+                   &merge_opts, &checkout_opts)
     @info "Review and commit merged changes"
     return true
 end

--- a/stdlib/LibGit2/src/oid.jl
+++ b/stdlib/LibGit2/src/oid.jl
@@ -179,7 +179,7 @@ Base.hash(id::GitHash, h::UInt) = hash(id.val, h)
 function Base.cmp(id1::GitHash, id2::GitHash)
     Int(ccall((:git_oid_cmp, :libgit2), Cint,
               (Ptr{GitHash}, Ptr{GitHash}),
-              Ref(id1), Ref(id2)))
+              &id1, &id2))
 end
 function Base.cmp(id1::GitShortHash, id2::GitShortHash)
     # shortened hashes appear at the beginning of the order, i.e.

--- a/stdlib/LibGit2/src/rebase.jl
+++ b/stdlib/LibGit2/src/rebase.jl
@@ -8,7 +8,7 @@ function GitRebase(repo::GitRepo, branch::GitAnnotated, upstream::GitAnnotated;
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid},
                    Ptr{Cvoid}, Ptr{RebaseOptions}),
                    rebase_ptr_ptr, repo.ptr, branch.ptr, upstream.ptr,
-                   onto === nothing ? C_NULL : onto.ptr, Ref(opts))
+                   onto === nothing ? C_NULL : onto.ptr, &opts)
     return GitRebase(repo, rebase_ptr_ptr[])
 end
 

--- a/stdlib/LibGit2/src/reference.jl
+++ b/stdlib/LibGit2/src/reference.jl
@@ -13,7 +13,7 @@ function GitReference(repo::GitRepo, obj_oid::GitHash, refname::AbstractString =
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_create, :libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{UInt8}, Ptr{GitHash}, Cint, Cstring),
-                   ref_ptr_ptr, repo.ptr, refname, Ref(obj_oid), Cint(force),
+                   ref_ptr_ptr, repo.ptr, refname, &obj_oid, Cint(force),
                    isempty(msg) ? C_NULL : msg)
     return GitReference(repo, ref_ptr_ptr[])
 end
@@ -307,7 +307,7 @@ function target!(ref::GitReference, new_oid::GitHash; msg::AbstractString="")
     ref_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_reference_set_target, :libgit2), Cint,
              (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{GitHash}, Cstring),
-             ref_ptr_ptr, ref.ptr, Ref(new_oid), isempty(msg) ? C_NULL : msg)
+             ref_ptr_ptr, ref.ptr, &new_oid, isempty(msg) ? C_NULL : msg)
     return GitReference(ref.owner, ref_ptr_ptr[])
 end
 

--- a/stdlib/LibGit2/src/remote.jl
+++ b/stdlib/LibGit2/src/remote.jl
@@ -285,7 +285,7 @@ function fetch(rmt::GitRemote, refspecs::Vector{<:AbstractString};
     msg = "libgit2.fetch: $msg"
     @check ccall((:git_remote_fetch, :libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Ptr{FetchOptions}, Cstring),
-                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, Ref(options), msg)
+                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, &options, msg)
 end
 
 """
@@ -309,7 +309,7 @@ function push(rmt::GitRemote, refspecs::Vector{<:AbstractString};
               force::Bool = false, options::PushOptions = PushOptions())
     @check ccall((:git_remote_push, :libgit2), Cint,
                  (Ptr{Cvoid}, Ptr{StrArrayStruct}, Ptr{PushOptions}),
-                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, Ref(options))
+                 rmt.ptr, isempty(refspecs) ? C_NULL : refspecs, &options)
 end
 
 """

--- a/stdlib/LibGit2/src/status.jl
+++ b/stdlib/LibGit2/src/status.jl
@@ -13,7 +13,7 @@ function GitStatus(repo::GitRepo; status_opts=StatusOptions())
     stat_ptr_ptr = Ref{Ptr{Cvoid}}(C_NULL)
     @check ccall((:git_status_list_new, :libgit2), Cint,
                   (Ptr{Ptr{Cvoid}}, Ptr{Cvoid}, Ptr{StatusOptions}),
-                  stat_ptr_ptr, repo.ptr, Ref(status_opts))
+                  stat_ptr_ptr, repo.ptr, &status_opts)
     return GitStatus(repo, stat_ptr_ptr[])
 end
 

--- a/stdlib/LibGit2/src/walker.jl
+++ b/stdlib/LibGit2/src/walker.jl
@@ -60,7 +60,7 @@ to apply a function to all commits since a certain year, by passing the first co
 of that year as `cid` and then passing the resulting `w` to [`map`](@ref LibGit2.map).
 """
 function push!(w::GitRevWalker, cid::GitHash)
-    @check ccall((:git_revwalk_push, :libgit2), Cint, (Ptr{Cvoid}, Ptr{GitHash}), w.ptr, Ref(cid))
+    @check ccall((:git_revwalk_push, :libgit2), Cint, (Ptr{Cvoid}, Ptr{GitHash}), w.ptr, &cid)
     return w
 end
 

--- a/stdlib/Pkg/src/resolve/FieldValues.jl
+++ b/stdlib/Pkg/src/resolve/FieldValues.jl
@@ -106,6 +106,6 @@ function secondmax(f::Field, msk::BitVector = trues(length(f)))
 end
 
 # Support broadcasting like a scalar by default
-Base.Broadcast.broadcastable(a::FieldValue) = Ref(a)
+Base.Broadcast.broadcastable(a::FieldValue) = &a
 
 end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -746,7 +746,7 @@ end
 repl_filename(repl, hp::REPLHistoryProvider) = "REPL[$(length(hp.history)-hp.start_idx)]"
 repl_filename(repl, hp) = "REPL"
 
-const JL_PROMPT_PASTE = Ref(true)
+const JL_PROMPT_PASTE = &true
 enable_promptpaste(v::Bool) = JL_PROMPT_PASTE[] = v
 
 setup_interface(

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -769,7 +769,7 @@ fake_repl() do stdin_write, stdout_read, repl
     # Relies on implementation detail to make sure we only have the single
     # replinit callback we want to test.
     saved_replinit = copy(Base.repl_hooks)
-    slot = Ref(false)
+    slot = &false
     # Create a closure from a newer world to check if `_atreplinit`
     # can run it correctly
     atreplinit(@eval(repl::REPL.LineEditREPL -> ($slot[] = true)))

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -813,7 +813,7 @@ function print_test_results(ts::DefaultTestSet, depth_pad=0)
 end
 
 
-const TESTSET_PRINT_ENABLE = Ref(true)
+const TESTSET_PRINT_ENABLE = &true
 
 # Called at the end of a @testset, behaviour depends on whether
 # this is a child of another testset, or the "root" testset

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -418,7 +418,9 @@ end
 @test (-).(C_NULL, C_NULL)::UInt == 0
 @test (+).(1, &2) == 3
 @test (+).(&1, &2) == 3
-@test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) == [[1,1], [2,2]]
+@test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) ==
+      [[0,2], [1,3]] .+ &[1,-1] == [[1,1], [2,2]]
+@test string.(1:3, &[3,4,5]) == @.(string(1:3, &[3,4,5])) == ["1[3, 4, 5]", "2[3, 4, 5]", "3[3, 4, 5]"]
 
 # Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722),
 # and similarly for broadcast!(f, A, numbers...) (#19799).

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -416,8 +416,8 @@ end
 
 # Ref as 0-dimensional array for broadcast
 @test (-).(C_NULL, C_NULL)::UInt == 0
-@test (+).(1, Ref(2)) == 3
-@test (+).(Ref(1), Ref(2)) == 3
+@test (+).(1, &2) == 3
+@test (+).(&1, &2) == 3
 @test (+).([[0,2], [1,3]], Ref{Vector{Int}}([1,-1])) == [[1,1], [2,2]]
 
 # Check that broadcast!(f, A) populates A via independent calls to f (#12277, #19722),
@@ -557,7 +557,7 @@ Base.BroadcastStyle(::Type{T}) where {T<:AD2Dim} = AD2DimStyle()
 end
 
 # broadcast should only "peel off" one container layer
-@test getindex.([Ref(1), Ref(2)]) == [1, 2]
+@test getindex.([&1, &2]) == [1, 2]
 let io = IOBuffer()
     broadcast(x -> print(io, x), [Ref(1.0)])
     @test String(take!(io)) == "Base.RefValue{Float64}(1.0)"

--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -52,7 +52,7 @@ mutable struct IntLike
     x::Int
 end
 @test @ccall_echo_load(132, Ptr{Int}, Ref{Int}) === 132
-@test @ccall_echo_load(Ref(921), Ptr{Int}, Ref{Int}) === 921
+@test @ccall_echo_load(&921, Ptr{Int}, Ref{Int}) === 921
 @test @ccall_echo_load(IntLike(993), Ptr{Int}, Ref{IntLike}) === 993
 @test @ccall_echo_load(IntLike(881), Ptr{IntLike}, Ref{IntLike}).x === 881
 @test @ccall_echo_func(532, Int, Int) === 532

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -107,7 +107,7 @@ using Distributed
 
     # Multiple tasks, first one to terminate closes the channel
     nth = rand(1:5)
-    ref = Ref(0)
+    ref = &0
     cond = Condition()
     tf3(i) = begin
         if i == nth
@@ -210,7 +210,7 @@ end
 
 @testset "yield/wait/event failures" begin
     @noinline garbage_finalizer(f) = finalizer(f, "gar" * "bage")
-    run = Ref(0)
+    run = &0
     GC.enable(false)
     # test for finalizers trying to yield leading to failed attempts to context switch
     garbage_finalizer((x) -> (run[] += 1; sleep(1)))
@@ -276,7 +276,7 @@ end
 end
 
 @testset "Timer / AsyncCondition triggering and race #12719" begin
-    tc = Ref(0)
+    tc = &0
     t = Timer(0) do t
         tc[] += 1
     end
@@ -287,7 +287,7 @@ end
     yield()
     @test tc[] == 1
 
-    tc = Ref(0)
+    tc = &0
     t = Timer(0) do t
         tc[] += 1
     end
@@ -297,7 +297,7 @@ end
     sleep(0.1)
     @test tc[] == 0
 
-    tc = Ref(0)
+    tc = &0
     async = Base.AsyncCondition() do async
         tc[] += 1
     end
@@ -323,7 +323,7 @@ end
     sleep(0.1) # no further events
     @test tc[] == 2
 
-    tc = Ref(0)
+    tc = &0
     async = Base.AsyncCondition() do async
         tc[] += 1
     end
@@ -368,7 +368,7 @@ end
     @test a[] == 0
     nothing
 end
-let a = Ref(0)
+let a = &0
     make_unrooted_timer(a)
     GC.gc()
     @test a[] == 1

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -111,7 +111,7 @@ if opt_level > 0
 end
 
 # Make sure we will not elide the allocation
-@noinline create_ref1() = Ref(1)
+@noinline create_ref1() = &1
 function pointer_not_safepoint()
     a = create_ref1()
     unsafe_store!(Ptr{Int}(pointer_from_objref(a)), 3)
@@ -127,7 +127,7 @@ struct LargeStruct
 end
 
 const large_struct = LargeStruct()
-@noinline create_ref_struct() = Ref(large_struct)
+@noinline create_ref_struct() = &large_struct
 function compare_large_struct(a)
     b = create_ref_struct()
     if a[] === b[]
@@ -237,13 +237,13 @@ let was_gced = false
     @noinline assert_not_gced() = @test !was_gced
 
     function foo22770()
-        b = Ref(2)
+        b = &2
         finalizer(x -> was_gced = true, b)
         y = make_tuple(b)
         x = y[1]
-        a = Ref(1)
+        a = &1
         use(x); use(a); use(y)
-        c = Ref(3)
+        c = &3
         GC.gc()
         assert_not_gced()
         use(x)
@@ -311,10 +311,10 @@ end
 # Test no gcframe is allocated for `x.x.x` even though `x.x` isn't live at the call site
 g24108(x::B24108) = f24108(x.x.x)
 
-@test g22421_1(Ref(1), Ref(2), true) === 7
-@test g22421_1(Ref(3), Ref(4), false) === 16
-@test g22421_2(Ref(5), Ref(6), true) === 17
-@test g22421_2(Ref(7), Ref(8), false) === 24
+@test g22421_1(&1, &2, true) === 7
+@test g22421_1(&3, &4, false) === 16
+@test g22421_2(&5, &6, true) === 17
+@test g22421_2(&7, &8, false) === 24
 
 if opt_level > 0
     @test !occursin("%gcframe",

--- a/test/core.jl
+++ b/test/core.jl
@@ -3723,7 +3723,7 @@ end
 # check if finalizers for the old gen can be triggered manually
 # issue #13986
 let
-    obj = Ref(1)
+    obj = &1
     finalized = 0
     finalizer((obj) -> (finalized = 1), obj)
     # obj should be marked for promotion after the second gc and be promoted
@@ -3752,8 +3752,8 @@ let
     GC.gc(false)
     # all objects in `finalizer_list` are now moved to `finalizer_list_marked`
 
-    obj1 = Ref(1)
-    obj2 = Ref(1)
+    obj1 = &1
+    obj2 = &1
     finalized = 0
     finalizer((obj) -> (finalized += 1), obj1)
     finalizer((obj) -> (finalized += 1), obj1)
@@ -4103,7 +4103,7 @@ end
 # Use a `@noinline` function to make sure the inefficient gc root generation
 # doesn't keep the object alive.
 @noinline function create_dead_object13995(finalized)
-    obj = Ref(1)
+    obj = &1
     finalizer((x)->(finalized[1] = true), obj)
     finalizer((x)->(finalized[2] = true), obj)
     finalizer((x)->(finalized[3] = true), obj)
@@ -4343,7 +4343,7 @@ function count_expr_push(ex::Expr, head::Symbol, counter)
 end
 
 function metadata_matches(ast::Core.CodeInfo)
-    inbounds_cnt = Ref(0)
+    inbounds_cnt = &0
     for ex in ast.code::Array{Any,1}
         if isa(ex, Expr)
             ex = ex::Expr
@@ -4914,7 +4914,7 @@ end
     b0 = Base.gc_bytes()
     local a
     for i in 1:n
-        a, t, allocd = @timed [Ref(1) for i in 1:1000]
+        a, t, allocd = @timed [&1 for i in 1:1000]
         @test allocd > 0
         b1 = Base.gc_bytes()
         if b1 < b0
@@ -5742,7 +5742,7 @@ function constant23367 end
 let
     b = B23367(91, A23367(ntuple(i -> Int8(i), Val(7))), 23)
     @eval @noinline constant23367(a, b) = (a ? b : $b)
-    b2 = Ref(b)[] # copy b via field assignment
+    b2 = &b[] # copy b via field assignment
     b3 = B23367[b][1] # copy b via array assignment
     addr(@nospecialize x) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), x)
     @test addr(b)  == addr(b)

--- a/test/core.jl
+++ b/test/core.jl
@@ -5742,7 +5742,7 @@ function constant23367 end
 let
     b = B23367(91, A23367(ntuple(i -> Int8(i), Val(7))), 23)
     @eval @noinline constant23367(a, b) = (a ? b : $b)
-    b2 = &b[] # copy b via field assignment
+    b2 = (&b)[] # copy b via field assignment
     b3 = B23367[b][1] # copy b via array assignment
     addr(@nospecialize x) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), x)
     @test addr(b)  == addr(b)

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -205,9 +205,6 @@ end
             for i=1:10
             end
         end))
-
-    # #6080
-    @test_deprecated r"Syntax `&argument`.*is deprecated" Meta.lower(@__MODULE__, :(ccall(:a, Cvoid, (Cint,), &x)))
 end
 
 module LogTest

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -94,7 +94,7 @@ let (src, _) = code_typed(g21074, ())[1]
 end
 
 # issue #21311
-counter21311 = Ref(0)
+counter21311 = &0
 @noinline function update21311!(x)
     counter21311[] += 1
     x[] = counter21311[]
@@ -103,7 +103,7 @@ end
 @noinline map21311(t::Tuple{Any}) = (update21311!(t[1]),)
 @inline map21311(t::Tuple) = (update21311!(t[1]), map21311(Base.tail(t))...)
 function read21311()
-    xs = Ref(1), Ref(1)
+    xs = &1, &1
     map21311(xs)
     return xs[1]
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -88,7 +88,7 @@ end
 # lock / unlock
 let l = ReentrantLock()
     lock(l)
-    success = Ref(false)
+    success = &false
     @test trylock(l) do
         @test lock(l) do
             success[] = true
@@ -117,7 +117,7 @@ end
     Base._wait(t)
     nothing
 end
-let c = Ref(0),
+let c = &0,
     t2 = @async (wait(); c[] += 99)
     @test c[] == 0
     f6597(c)
@@ -131,7 +131,7 @@ end
 
 # test that @sync is lexical (PR #27164)
 
-const x27164 = Ref(0)
+const x27164 = &0
 do_something_async_27164() = @async(begin sleep(1); x27164[] = 2; end)
 
 let t = nothing

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1083,9 +1083,6 @@ end
 @test_throws ParseError Meta.parse("x@time 2")
 @test_throws ParseError Meta.parse("@ time")
 
-# issue #7479
-@test Meta.lower(Main, Meta.parse("(true &&& false)")) == Expr(:error, "misplaced \"&\" expression")
-
 # if an indexing expression becomes a cat expression, `end` is not special
 @test_throws ParseError Meta.parse("a[end end]")
 @test_throws ParseError Meta.parse("a[end;end]")


### PR DESCRIPTION
As suggested in #27563.     Note that `&x` was already parsed as a special expression node `Expr(:&, :x)`, which previously was used for a deprecated `ccall` syntax.   So all this PR does is to change the lowering to `RefValue(x)` (eliminating the deprecation).

This is especially useful for "scalarizing" arguments in dot calls (it also works with `@.`).  For example:
```jl
julia> x = [3,4,5]; 

julia> string.(x)
3-element Array{String,1}:
 "3"
 "4"
 "5"

julia> string.(&x)
"[3, 4, 5]"

julia> @. string(&x)
"[3, 4, 5]"
```
I updated the Base, stdlib, and test code to use the `&` syntax and it looks pretty natural to me.

To do (assuming the consensus is in favor):
- [x] Tests.  (Already exercised in Base.)
- [ ] Documentation.