### PR TITLE
Remove errant hyphen in Travis config [skip appveyor]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,6 @@ script:
         pushd julia && make -C doc doctest=true && popd; fi
 # uncomment the following if failures are suspected to be due to the out-of-memory killer
 #    - dmesg
--after_success:
+after_success:
     - if [ `uname` = "Linux" ] && [ $ARCH = "x86_64" ]; then
         cd julia && make -C doc deploy; fi


### PR DESCRIPTION
I believe this was causing docs to not be deployed. 