### PR TITLE
Add 2-argument method for `atand`

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -1082,7 +1082,7 @@ for (fd, f, fn) in ((:sind, :sin, "sine"), (:cosd, :cos, "cosine"), (:tand, :tan
     end
 end
 
-for (fd, f, fn) in ((:asind, :asin, "sine"), (:acosd, :acos, "cosine"), (:atand, :atan, "tangent"),
+for (fd, f, fn) in ((:asind, :asin, "sine"), (:acosd, :acos, "cosine"),
                     (:asecd, :asec, "secant"), (:acscd, :acsc, "cosecant"), (:acotd, :acot, "cotangent"))
     name = string(fd)
     @eval begin
@@ -1092,3 +1092,12 @@ for (fd, f, fn) in ((:asind, :asin, "sine"), (:acosd, :acos, "cosine"), (:atand,
         Compute the inverse $($fn) of `x`, where the output is in degrees. """ ($fd)(y) = rad2deg(($f)(y))
     end
 end
+
+"""
+    atand(y)
+    atand(y,x)
+
+Compute the inverse tangent of `y` or `y/x`, respectively, where the output is in degrees.
+"""
+atand(y)    = rad2deg(atan(y))
+atand(y, x) = rad2deg(atan(y,x))

--- a/test/math.jl
+++ b/test/math.jl
@@ -763,6 +763,44 @@ end
     end
 end
 
+@testset "atand" begin
+    for T in (Float32, Float64)
+        r = T(randn())
+        absr = abs(r)
+
+        # Tests related to the 1-argument version of `atan`.
+        # ==================================================
+
+        @test atand(T(Inf))  === T(90.0)
+        @test atand(-T(Inf)) === -T(90.0)
+        @test atand(zero(T)) === T(0.0)
+        @test atand(one(T))  === T(45.0)
+        @test atand(-one(T)) === -T(45.0)
+
+        # Tests related to the 2-argument version of `atan`.
+        # ==================================================
+
+        # If `x` is one, then `atand(y,x)` must be equal to `atand(y)`.
+        @test atand(T(r), one(T))    === atand(T(r))
+
+        # `y` zero.
+        @test atand(zero(T), absr)   === zero(T)
+        @test atand(-zero(T), absr)  === -zero(T)
+        @test atand(zero(T), -absr)  === T(180.0)
+        @test atand(-zero(T), -absr) === -T(180.0)
+
+        # `x` zero and `y` not zero.
+        @test atand(one(T), zero(T))  === T(90.0)
+        @test atand(-one(T), zero(T)) === -T(90.0)
+
+        # `x` and `y` equal for each quadrant.
+        @test atand(+absr, +absr) === T(45.0)
+        @test atand(-absr, +absr) === -T(45.0)
+        @test atand(+absr, -absr) === T(135.0)
+        @test atand(-absr, -absr) === -T(135.0)
+    end
+end
+
 @testset "acos #23283" begin
     for T in (Float32, Float64)
         @test acos(zero(T)) === T(pi)/2


### PR DESCRIPTION
The function `atand` was only defined for one argument. Since `atan2` is now deprecated in favor of the 2-argument version of `atan`, it makes sense to also define `atand` for 2-arguments.

Closes #27615