### PR TITLE
Fix gen_call_with_extracted_types for literals

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -29,11 +29,14 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
     if isa(ex0, Expr) && ex0.head == :macrocall # Make @edit @time 1+2 edit the macro by using the types of the *expressions*
         return Expr(:call, fcn, esc(ex0.args[1]), Tuple{#=__source__=#LineNumberNode, #=__module__=#Module, Any[ Core.Typeof(a) for a in ex0.args[3:end] ]...})
     end
+
     ex = Meta.lower(__module__, ex0)
-    exret = Expr(:none)
     if !isa(ex, Expr)
         return Expr(:call, :error, "expression is not a function call or symbol")
-    elseif ex.head == :call
+    end
+
+    exret = Expr(:none)
+    if ex.head == :call
         if any(e->(isa(e, Expr) && e.head==:(...)), ex0.args) &&
             (ex.args[1] === GlobalRef(Core,:_apply) ||
              ex.args[1] === GlobalRef(Base,:_apply))

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -32,7 +32,7 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
     ex = Meta.lower(__module__, ex0)
     exret = Expr(:none)
     if !isa(ex, Expr)
-        exret = Expr(:call, :error, "expression is not a function call or symbol")
+        return Expr(:call, :error, "expression is not a function call or symbol")
     elseif ex.head == :call
         if any(e->(isa(e, Expr) && e.head==:(...)), ex0.args) &&
             (ex.args[1] === GlobalRef(Core,:_apply) ||

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -331,6 +331,16 @@ if Sys.ARCH === :x86_64 || occursin(ix86, string(Sys.ARCH))
     @test occursin(rgx, output)
 end
 
+using InteractiveUtils: gen_call_with_extracted_types
+
+@testset "gen_call_with_extracted_types" begin
+    for ex0 in ["", 0, 1.0]
+        exret = gen_call_with_extracted_types(Main, :dummy, ex0)
+        @test exret.head == :call
+        @test exret.args[1] == :error
+    end
+end
+
 using InteractiveUtils: editor
 
 # Issue #13032

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -331,14 +331,11 @@ if Sys.ARCH === :x86_64 || occursin(ix86, string(Sys.ARCH))
     @test occursin(rgx, output)
 end
 
-using InteractiveUtils: gen_call_with_extracted_types
-
-@testset "gen_call_with_extracted_types" begin
-    for ex0 in ["", 0, 1.0]
-        exret = gen_call_with_extracted_types(Main, :dummy, ex0)
-        @test exret.head == :call
-        @test exret.args[1] == :error
-    end
+@testset "error message" begin
+    err = ErrorException("expression is not a function call or symbol")
+    @test_throws err @code_lowered ""
+    @test_throws err @code_lowered 1
+    @test_throws err @code_lowered 1.0
 end
 
 using InteractiveUtils: editor


### PR DESCRIPTION
Prior to this patch, executing (say) `@less 1` in REPL prints a cryptic message `ERROR: LoadError: type Int64 has no field head` although there is a branch in `gen_call_with_extracted_types` which is supposed to handle this case.

Before:

```julia
julia> @less 1
ERROR: LoadError: type Int64 has no field head
Stacktrace:
 [1] getproperty(::Any, ::Symbol) at ./sysimg.jl:18
 [2] gen_call_with_extracted_types(::Module, ::Symbol, ::Int64) at /.../julia/usr/share/julia/stdlib/v0.7/InteractiveUtils/src/macros.jl:58
 [3] @less(::LineNumberNode, ::Module, ::Any) at /.../julia/usr/share/julia/stdlib/v0.7/InteractiveUtils/src/macros.jl:70
in expression starting at REPL[1]:1
```

After:
```julia
julia> @less 1
ERROR: expression is not a function call or symbol
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at none:0
```
