### PR TITLE
made TwicePrecision a subtype of Number

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -181,7 +181,7 @@ roundoff error).  If `step` has an exact rational representation
 where `nb` is the number of trailing zero bits of `step.hi`.  For
 ranges, you can set `nb = ceil(Int, log2(len-1))`.
 """
-struct TwicePrecision{T}
+struct TwicePrecision{T} <: Number
     hi::T    # most significant bits
     lo::T    # least significant bits
 end

--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -181,7 +181,7 @@ roundoff error).  If `step` has an exact rational representation
 where `nb` is the number of trailing zero bits of `step.hi`.  For
 ranges, you can set `nb = ceil(Int, log2(len-1))`.
 """
-struct TwicePrecision{T} <: Number
+struct TwicePrecision{T} <: AbstractFloat
     hi::T    # most significant bits
     lo::T    # least significant bits
 end


### PR DESCRIPTION
Currently,
```Julia
julia> Base.TwicePrecision <: Number
false
```
but it makes more sense to have it as a subtype of `Number`.