### PR TITLE
Ignore `build_h.jl.phony`

### DIFF
--- a/base/.gitignore
+++ b/base/.gitignore
@@ -1,6 +1,7 @@
 /pcre_h.jl
 /errno_h.jl
 /build_h.jl
+/build_h.jl.phony
 /file_constants.jl
 /uv_constants.jl
 /version_git.jl


### PR DESCRIPTION
When running `version_git.sh` to build `version_git.jl`, we encode whether the current buildtree is modified.  Unfortunately, this often runs in parallel with the  eneration of `build_h.jl`, which means that more often than not, `build_h.jl.phony` is sitting around in the build tree, and since `git` hasn't been told to ignore that file, we get modified build trees a lot during `make -jN`.

We don't see this in final builds however, because when we swing back around in `make binary-dist`, the Makefile regenerates `version_git.jl.phony`, checks it against `version_git.jl` and notices that `git` no longer things the build tree is dirty.  (This being because `build_h.jl.phony` does not exist.  Note that we never run `make binary-dist` in parallel).  Thus, we always end up with a `version_git.jl` that identifies itself as coming from a pristine build, and the price we paid was just that we would always build the system image twice.

This closes https://github.com/JuliaLang/julia/issues/27548