### PR TITLE
Fix `contrib/build_sysimg.jl`

### DIFF
--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -166,16 +166,20 @@ function link_sysimg(sysimg_path=nothing, cc=find_system_compiler(), debug=false
         push!(FLAGS, "-lssp")
     end
 
-    sysimg_file = "$sysimg_path.$(Libdl.dlext)"
-    info("Linking sys.$(Libdl.dlext)")
-    info("$cc $(join(FLAGS, ' ')) -o $sysimg_file $sysimg_path.o")
-    # Windows has difficulties overwriting a file in use so we first link to a temp file
-    if Sys.iswindows() && isfile(sysimg_file)
-        if success(pipeline(`$cc $FLAGS -o $sysimg_path.tmp $sysimg_path.o`; stdout=stdout, stderr=stderr))
-            mv("$sysimg_path.tmp", sysimg_file; force=true)
-        end
+    if Sys.isapple()
+        whole_archive = "-Wl,-all_load"
+        no_whole_archive = ""
     else
-        run(`$cc $FLAGS -o $sysimg_file $sysimg_path.o`)
+        whole_archive = "-Wl,--whole-archive"
+        no_whole_archive = "-Wl,--no-whole-archive"
+    end
+
+    sysimg_file = "$sysimg_path.$(Libdl.dlext)"
+    cc_cmd = `$cc $FLAGS -o $sysimg_path.tmp $whole_archive $sysimg_path.o $no_whole_archive`
+    @info("Linking sys.$(Libdl.dlext) with $cc_cmd")
+    # Windows has difficulties overwriting a file in use so we first link to a temp file
+    if success(pipeline(cc_cmd; stdout=stdout, stderr=stderr))
+        mv("$sysimg_path.tmp", sysimg_file; force=true)
     end
     @info("System image successfully built at $sysimg_path.$(Libdl.dlext)")
     return

--- a/contrib/build_sysimg.jl
+++ b/contrib/build_sysimg.jl
@@ -106,7 +106,7 @@ function build_sysimg(sysimg_path=nothing, cpu_target="native", userimg_path=not
     end
 end
 
-# Search for a compiler to link sys.o into sys.dl_ext. Honor LD environment variable.
+# Search for a compiler to link sys.o into sys.dl_ext. Honor CC environment variable.
 function find_system_compiler()
     warn_msg = String[] # save warning messages into an array
 


### PR DESCRIPTION
The `contrib/build_sysimg.jl` script had bitrotted a bit with the 0.7 changes.  This PR also incorporates @RalphAS's changes to address https://github.com/JuliaLang/julia/issues/27201 and https://github.com/JuliaLang/julia/issues/27451.

Marking this as WIP until testing is done on all major OS's:

- [x] Linux
- [x] OSX
- [x] FreeBSD
- [x] Windows

@ararslan could I ask you to test this out on FreeBSD?  I create the "user image" file:

```julia
# /tmp/usrimg.jl
function foobar()
    println("It worked!")
end
```

Then I compile it into a custom sysimg:
```
$ ./julia --color=yes ./contrib/build_sysimg.jl /tmp/sysimg x86-64 /tmp/usrimg.jl
```

Finally, I test it:
```
$ ./julia -J /tmp/sysimg.so -e 'foobar()'
It worked!
```