### PR TITLE
RFC: Add support for keys(g::Generator) (fixes #27612)

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -50,6 +50,7 @@ length(g::Generator) = length(g.iter)
 size(g::Generator) = size(g.iter)
 axes(g::Generator) = axes(g.iter)
 ndims(g::Generator) = ndims(g.iter)
+keys(g::Generator) = g.iter
 
 
 ## iterator traits

--- a/base/generator.jl
+++ b/base/generator.jl
@@ -51,6 +51,7 @@ size(g::Generator) = size(g.iter)
 axes(g::Generator) = axes(g.iter)
 ndims(g::Generator) = ndims(g.iter)
 keys(g::Generator) = g.iter
+getindex(g::Generator, i) = g.f(i)
 
 
 ## iterator traits

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -224,6 +224,7 @@ pairs(A::AbstractArray)  = pairs(IndexCartesian(), A)
 pairs(A::AbstractVector) = pairs(IndexLinear(), A)
 pairs(tuple::Tuple) = Pairs(tuple, keys(tuple))
 pairs(nt::NamedTuple) = Pairs(nt, keys(nt))
+pairs(g::Generator) = Pairs(g, keys(g))
 # pairs(v::Pairs) = v # listed for reference, but already defined from being an AbstractDict
 
 length(v::Pairs) = length(v.itr)


### PR DESCRIPTION
As discussed [here](https://github.com/JuliaLang/julia/issues/27612#issue-333000374) and [here](https://github.com/JuliaLang/julia/issues/27612#issuecomment-397884789), this PR proposes that `argmax(f(x) for x ∈ itr)` should work and return an `x` in `itr` that maximizes `f(x)`. This is closely related to the mathematical definition of `argmax`, and consistent with other current 1-arg usages of `argmax`, such as `argmax(A::AbstractArray)` and `argmax(d::Dict)` as pointed out [here](https://github.com/JuliaLang/julia/issues/27613#issuecomment-397922680).

*: As pointed out by @Nosferican, this PR is not precisely the same as the mathematical definition of argmax, because it follows the existing pragmatic convention of returning a single maximizer instead of all of them. Discussion of this point can continue [here](https://github.com/JuliaLang/julia/issues/27639).

For context, I also considered whether it would make sense to have a [2-arg flavor](https://github.com/JuliaLang/julia/issues/27613) of `argmax(f, itr)` that returns an `x` in `itr` that maximizes `f(x)`. Helpful feedback from @ararslan and @martinholters persuaded me that this 2-arg syntax should be reserved for a different purpose, explained [here](https://github.com/JuliaLang/julia/issues/27613#issuecomment-398083742).

The strategy taken here is to define `keys(g::Generator)`. This gives us `pairs(g)`, `argmin(g)`, `argmax(g)`, `findmin(g)`, and `findmax(g)` for free. Here's a demo:

```
julia> g = (-x^2 for x in -5:5)
Base.Generator{UnitRange{Int64},getfield(Main, Symbol("##3#4"))}(getfield(Main, Symbol("##3#4"))(), -5:5)

julia> for p in pairs(g)
           display(p)
       end
-5 => -25
-4 => -16
-3 => -9
-2 => -4
-1 => -1
0 => 0
1 => -1
2 => -4
3 => -9
4 => -16
5 => -25

julia> argmin(g)
-5

julia> argmax(g)
0

julia> findmin(g)
(-25, -5)

julia> findmax(g)
(0, 0)
```

If there is support for this PR, then I will add tests and update the docs as well. I should probably check the performance of this solution as well.