### PR TITLE
Don't log nothing.

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -307,7 +307,10 @@ function logmsg_code(_module, file, line, level, message, exs...)
                     line = $line
                     try
                         msg = $(esc(message))
-                        handle_message(logger, level, msg, _module, group, id, file, line; $(kwargs...))
+                        if msg !== nothing
+                            handle_message(logger, level, msg, _module, group, id, file, line;
+                                           $(kwargs...))
+                        end
                     catch err
                         logging_error(logger, level, _module, group, id, file, line, err)
                     end

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -177,6 +177,17 @@ end
         end
     end
     ENV["JULIA_DEBUG"] = ""
+
+    @testset "Log filtering - empty messages" begin
+        @test_logs @info nothing
+
+        # make sure `nothing` kwargs still print properly
+        logs, _ = collect_test_logs() do
+            @info "something" nothing
+        end
+        record = logs[1]
+        @test record.kwargs[:nothing] === nothing
+    end
 end
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The logging macros support a very useful block-like syntax where the body builds and returns the message to log, making it easy to conditionalize complex or expensive message building code:

```julia
julia> @info begin
           msg = "expensive log message"
           msg
       end
[ Info: expensive log message
```

Meanwhile, some C APIs have additional log buffer or log level arguments, and as such need some log-conditional set-up that does not immediately produce a message. One solution would be for the logging macros to ignore `nothing` messages, enabling the following paradigm (taken from CUDAdrv.jl):

```julia
@debug begin
    options[INFO_LOG_BUFFER] = Vector{UInt8}(undef, 1024*1024)
    options[LOG_VERBOSE] = true
    nothing
end
optionKeys, optionVals = encode(options)

@apicall(:cuModuleLoadDataEx,
         (Ptr{CuModule_t}, Ptr{Cchar}, Cuint, Ptr{CUjit_option}, Ptr{Ptr{Cvoid}}),
         handle_ref, data, length(optionKeys), optionKeys, optionVals)

@debug begin
    options = decode(optionKeys, optionVals)
    if isempty(options[INFO_LOG_BUFFER])
        """JIT info log is empty"""
    else
        """JIT info log:
           $(options[INFO_LOG_BUFFER])"""
    end
end
```

An alternative solution would be to query the log level of the active logger, but that could be complex (which logger, env flag overrides, ...). This seemed like a DRY solution. Thoughts?