### PR TITLE
Fix getindex inlining for Array{Union{T,Missing}}

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -415,8 +415,9 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector
                     # impossible
                     # return plus_saturate(argcost, isknowntype(extyp) ? 1 : params.inline_nonleaf_penalty)
                     return argcost
-                elseif f == Main.Core.arrayref
-                    return plus_saturate(argcost, isknowntype(extyp) ? 4 : params.inline_nonleaf_penalty)
+                elseif f == Main.Core.arrayref && length(ex.args) >= 3
+                    atyp = argextype(ex.args[3], src, spvals)
+                    return plus_saturate(argcost, isknowntype(atyp) ? 4 : params.inline_nonleaf_penalty)
                 end
                 fidx = findfirst(x->x===f, T_FFUNC_KEY)
                 if fidx === nothing

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -132,13 +132,13 @@
            ,loc
            (call (core eval) ,name ,x)))
        (if (&& (call (top isdefined) (core Main) (quote Base))
-               (call (top isdefined) (top Base) (quote @deprecate)))
+               (call (top isdefined) (|.| (core Main) (quote Base)) (quote @deprecate)))
            (call eval
                  (quote
-                  (macrocall (top @deprecate)
+                  (macrocall (|.| (|.| (core Main) (quote Base)) (quote @deprecate))
                              (line 0 none)
                              (call eval m x)
-                             (call (|.| Core (quote eval)) m x)
+                             (call (|.| Core (quote eval)) m x) ; should be (core eval), but format as Core.eval(m, x) for deprecation warning
                              false))))
        (= (call include ,x)
           (block

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -122,3 +122,18 @@ end
     @test f19122()
     @test g19122()
 end
+
+@testset "issue #27403: getindex is inlined with Union{Int,Missing}" begin
+    function sum27403(X::AbstractArray)
+        s = zero(eltype(X)) + zero(eltype(X))
+        for x in X
+            if !ismissing(x)
+                s += x
+            end
+        end
+        s
+    end
+
+    (src, _) = code_typed(sum27403, Tuple{Vector{Int}})[1]
+    @test !any(x -> x isa Expr && x.head === :invoke, src.code)
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/27403.

With this PR, a naive sum over non-missing values in a `Vector{Union{Int,Missing}}` is (probably) as fast as it could theoretically be. Masked SIMD instructions are used, which is almost too good to be true.
```julia
function mysum(X)
    s = zero(eltype(X))
    @inbounds @simd for x in X
        if x !== missing
            s += x
        end
    end
    s
end

X1 = rand(Int, 10_000_000);
X2 = Vector{Union{Missing,Int}}(X1);
X3 = ifelse.(rand(length(X2)) .< 0.9, X2, missing);

julia> @btime mysum(X1);
  5.787 ms (1 allocation: 16 bytes)

julia> @btime mysum(X2);
  5.726 ms (1 allocation: 16 bytes)

julia> @btime mysum(X3);
  5.844 ms (1 allocation: 16 bytes)
```

I've added a test to check that `getindex` is inlined, but I'm really not sure that's the best way to do it. There are also benchmarks for this in BaseBenchmarks, and I'll add another one (EDIT: see https://github.com/JuliaCI/BaseBenchmarks.jl/pull/207).