### PR TITLE
Revert "Revert "enable the SLP Vectorizer optimization pass by default""

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -726,6 +726,9 @@ Compiler/Runtime improvements
   * Inference now propagates constants inter-procedurally, and can compute
     various constants expressions at compile-time ([#24362]).
 
+  * The LLVM SLP Vectorizer optimization pass is now enabled at the default
+    optimization level.
+
 Deprecated or removed
 ---------------------
 

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -257,14 +257,9 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     PM->add(createLoopIdiomPass());
     PM->add(createLoopDeletionPass());          // Delete dead loops
     PM->add(createJumpThreadingPass());         // Thread jumps
-
-    if (opt_level >= 3) {
-        PM->add(createSLPVectorizerPass());     // Vectorize straight-line code
-    }
-
+    PM->add(createSLPVectorizerPass());         // Vectorize straight-line code
     PM->add(createAggressiveDCEPass());         // Delete dead instructions
-    if (opt_level >= 3)
-        PM->add(createInstructionCombiningPass());   // Clean up after SLP loop vectorizer
+    PM->add(createInstructionCombiningPass());  // Clean up after SLP loop vectorizer
     PM->add(createLoopVectorizePass());         // Vectorize loops
     PM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
     // LowerPTLS removes an indirect call. As a result, it is likely to trigger


### PR DESCRIPTION
Reverts JuliaLang/julia#27049

After #27182 we should be able to run the SLP by default again. Can someone one a new enough CPU confirm?