### PR TITLE
Fix `fixup-libgfortran`

### DIFF
--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -4,7 +4,7 @@
 # Run as: fixup-libgfortran.sh [--verbose] <$private_libdir>
 
 # If we're invoked with "--verbose", create a `debug` function that prints stuff out
-if [ "$1" == "--verbose" ] || [ "$1" == "-v" ]; then
+if [ "$1" = "--verbose" ] || [ "$1" = "-v" ]; then
 shift 1
 debug() { echo "$*"; }
 else

--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -52,9 +52,9 @@ for lib in lapack blas openblas; do
 
         # Take the directories, add them onto LIBGFORTRAN_DIRS, which we use to
         # search for these libraries in the future.
-        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(dirname $LIBGFORTRAN_PATH)"
-        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(dirname $LIBGCC_PATH)"
-        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(dirname $LIBQUADMATH_PATH)"
+        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(dirname $LIBGFORTRAN_PATH 2>/dev/null)"
+        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(dirname $LIBGCC_PATH 2>/dev/null)"
+        LIBGFORTRAN_DIRS="$LIBGFORTRAN_DIRS $(dirname $LIBQUADMATH_PATH 2>/dev/null)"
 
         # Save the SONAMES
         LIBGFORTRAN_SONAMES="$LIBGFORTRAN_SONAMES $(basename "$LIBGFORTRAN_PATH")"

--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -41,19 +41,14 @@ find_shlib()
     fi
 }
 
-private_libname()
-{
-    echo "$private_libdir/lib$1.$SHLIB_EXT"
-}
-
 # First, discover all the places where libgfortran/libgcc is, as well as their true SONAMES
-for lib in lapack; do
-    if [ -f "$private_libdir/lib$lib.$SHLIB_EXT" ]; then
+for lib in lapack blas openblas; do
+    for private_libname in ${private_libdir}/lib$lib*.$SHLIB_EXT*; do
         # Find the paths to the libraries we're interested in.  These are almost
         # always within the same directory, but we like to be general.
-        LIBGFORTRAN_PATH=$(find_shlib "$(private_libname $lib)" libgfortran)
-        LIBGCC_PATH=$(find_shlib "$(private_libname $lib)" libgcc_s)
-        LIBQUADMATH_PATH=$(find_shlib "$(private_libname $lib)" libquadmath)
+        LIBGFORTRAN_PATH=$(find_shlib "$private_libname" libgfortran)
+        LIBGCC_PATH=$(find_shlib "$private_libname" libgcc_s)
+        LIBQUADMATH_PATH=$(find_shlib "$private_libname" libquadmath)
 
         # Take the directories, add them onto LIBGFORTRAN_DIRS, which we use to
         # search for these libraries in the future.
@@ -65,7 +60,7 @@ for lib in lapack; do
         LIBGFORTRAN_SONAMES="$LIBGFORTRAN_SONAMES $(basename "$LIBGFORTRAN_PATH")"
         LIBGCC_SONAMES="$LIBGCC_SONAMES $(basename "$LIBGCC_PATH")"
         LIBQUADMATH_SONAMES="$LIBQUADMATH_SONAMES $(basename "$LIBQUADMATH_PATH")"
-    fi
+    done
 done
 
 # Take in a list of space-separated tokens, return a deduplicated list of the same


### PR DESCRIPTION
We accidentally broke `fixup-libgfortran` by only telling it to look at `liblapack.so` to get its hints about where `libgfortran` lives.  However, `liblapack.so` doesn't exist most of the time, it's just called `libopenblas64_.so`.  This PR causes `fixup-libgfortran` to look around a bit harder to find these sneaky little runtime libraries so that we can pull them in to our libdir during `make binary-dist`.