### PR TITLE
Add unconjugated dot product `dotu`

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -299,6 +299,7 @@ Linear algebra functions in Julia are largely implemented by calling functions f
 Base.:*(::AbstractMatrix, ::AbstractMatrix)
 Base.:\(::AbstractMatrix, ::AbstractVecOrMat)
 LinearAlgebra.dot
+LinearAlgebra.dotu
 LinearAlgebra.cross
 LinearAlgebra.factorize
 LinearAlgebra.Diagonal

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -80,6 +80,7 @@ export
     diagind,
     diagm,
     dot,
+    dotu,
     eigen,
     eigen!,
     eigmax,

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -729,6 +729,78 @@ function dot(x::AbstractVector, y::AbstractVector)
     return s
 end
 
+"""
+    dotu(x, y)
+
+For any iterable containers `x` and `y` (including arrays of any dimension) of numbers (or
+any element type for which `*` is defined), compute the unconjugated dot product, i.e. the
+sum of `x[i]*y[i]`, as if they were vectors.
+
+# Examples
+```jldoctest
+julia> dotu(1:5, 2:6)
+70
+
+julia> v = [1, im]; dotu(v, v)
+0 + 0im
+
+julia> σ = [[0 1; 1 0], [0 -im; im 0], [1 0; 0 -1]]; n = [1, 2, 3]; dotu(σ, n)
+2×2 Array{Complex{Int64},2}:
+ 3+0im   1-2im
+ 1+2im  -3+0im
+
+julia> dotu(σ[1:1], σ[1:1])
+2×2 Array{Complex{Int64},2}:
+ 1+0im  0+0im
+ 0+0im  1+0im
+
+julia> dotu(σ, σ)
+ 2×2 Array{Complex{Int64},2}:
+  3+0im  0+0im
+  0+0im  3+0im
+```
+"""
+function dotu(x, y) # arbitrary iterables
+    ix = iterate(x)
+    iy = iterate(y)
+    if ix == nothing
+        if iy != nothing
+            throw(DimensionMismatch("x and y are of different lengths!"))
+        end
+        return zero(eltype(x)) * zero(eltype(y))
+    end
+    if iy == nothing
+        throw(DimensionMismatch("x and y are of different lengths!"))
+    end
+    s = ix[1] * iy[1]
+    ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
+    while ix != nothing && iy != nothing
+        s += ix[1] * iy[1]
+        ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
+    end
+    if !(iy == nothing && ix == nothing)
+        throw(DimensionMismatch("x and y are of different lengths!"))
+    end
+    return s
+end
+
+dotu(x::Number, y::Number) = x * y
+
+function dotu(x::AbstractArray, y::AbstractArray)
+    lx = _length(x)
+    if lx != _length(y)
+        throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(_length(y))."))
+    end
+    if lx == 0
+        return zero(eltype(x)) * zero(eltype(y))
+    end
+    s = zero(first(x) * first(y))
+    @inbounds for (Ix, Iy) in zip(eachindex(x), eachindex(y))
+        s += x[Ix] * y[Iy]
+    end
+    s
+end
+
 
 ###########################################################################################
 

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -763,22 +763,27 @@ julia> dotu(σ, σ)
 function dotu(x, y) # arbitrary iterables
     ix = iterate(x)
     iy = iterate(y)
-    if ix == nothing
-        if iy != nothing
+    if ix === nothing
+        if iy !== nothing
             throw(DimensionMismatch("x and y are of different lengths!"))
         end
         return zero(eltype(x)) * zero(eltype(y))
     end
-    if iy == nothing
+    if iy === nothing
         throw(DimensionMismatch("x and y are of different lengths!"))
     end
-    s = ix[1] * iy[1]
-    ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
-    while ix != nothing && iy != nothing
-        s += ix[1] * iy[1]
-        ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
+    (vx, xs) = ix
+    (vy, ys) = iy
+    s = vx * vy
+    while true
+        ix = iterate(x, xs)
+        iy = iterate(y, ys)
+        ix === nothing && break
+        iy === nothing && break
+        (vx, xs), (vy, ys) = ix, iy
+        s += vx * vy
     end
-    if !(iy == nothing && ix == nothing)
+    if !(iy === nothing && ix === nothing)
         throw(DimensionMismatch("x and y are of different lengths!"))
     end
     return s

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -35,6 +35,35 @@ function dot(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector
     GC.@preserve x y BLAS.dotc(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
 end
 
+dotu(x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where {T<:BlasReal} = BLAS.dot(x, y)
+dotu(x::Union{DenseArray{T},StridedVector{T}}, y::Union{DenseArray{T},StridedVector{T}}) where {T<:BlasComplex} = BLAS.dotu(x, y)
+
+function dotu(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector{T}, ry::Union{UnitRange{TI},AbstractRange{TI}}) where {T<:BlasReal,TI<:Integer}
+    if length(rx) != length(ry)
+        throw(DimensionMismatch("length of rx, $(length(rx)), does not equal length of ry, $(length(ry))"))
+    end
+    if minimum(rx) < 1 || maximum(rx) > length(x)
+        throw(BoundsError(x, rx))
+    end
+    if minimum(ry) < 1 || maximum(ry) > length(y)
+        throw(BoundsError(y, ry))
+    end
+    GC.@preserve x y BLAS.dot(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+end
+
+function dotu(x::Vector{T}, rx::Union{UnitRange{TI},AbstractRange{TI}}, y::Vector{T}, ry::Union{UnitRange{TI},AbstractRange{TI}}) where {T<:BlasComplex,TI<:Integer}
+    if length(rx) != length(ry)
+        throw(DimensionMismatch("length of rx, $(length(rx)), does not equal length of ry, $(length(ry))"))
+    end
+    if minimum(rx) < 1 || maximum(rx) > length(x)
+        throw(BoundsError(x, rx))
+    end
+    if minimum(ry) < 1 || maximum(ry) > length(y)
+        throw(BoundsError(y, ry))
+    end
+    GC.@preserve x y BLAS.dotu(length(rx), pointer(x)+(first(rx)-1)*sizeof(T), step(rx), pointer(y)+(first(ry)-1)*sizeof(T), step(ry))
+end
+
 function *(transx::Transpose{<:Any,<:StridedVector{T}}, y::StridedVector{T}) where {T<:BlasComplex}
     x = transx.parent
     return BLAS.dotu(x, y)

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -12,7 +12,7 @@ using Base.Sort: Forward
 using LinearAlgebra
 
 import Base: +, -, *, \, /, &, |, xor, ==
-import LinearAlgebra: mul!, ldiv!, rdiv!, chol, adjoint!, diag, eigen, dot,
+import LinearAlgebra: mul!, ldiv!, rdiv!, chol, adjoint!, diag, eigen, dot, dotu,
     issymmetric, istril, istriu, lu, tr, transpose!, tril!, triu!,
     cond, diagm, factorize, ishermitian, norm, opnorm, lmul!, rmul!, tril, triu
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -356,8 +356,10 @@ end
         A = sprand(ComplexF64,10,15,0.4)
         B = sprand(ComplexF64,10,15,0.5)
         @test dot(A,B) ≈ dot(Matrix(A),Matrix(B))
+        @test dotu(A,B) ≈ dotu(Matrix(A),Matrix(B))
     end
     @test_throws DimensionMismatch dot(sprand(5,5,0.2),sprand(5,6,0.2))
+    @test_throws DimensionMismatch dotu(sprand(5,5,0.2),sprand(5,6,0.2))
 end
 
 sA = sprandn(3, 7, 0.5)

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -379,6 +379,7 @@ I = findall(!iszero, z)
 @test norm(v) ≈ norm(parent(v))
 @test norm(A) ≈ norm(parent(A))
 @test dot(v, v) ≈ dot(v0, v0)
+@test dotu(v, v) ≈ dotu(v0, v0)
 
 # Prior to its removal from Base, cumsum_kbn was used here. To achieve the same level of
 # accuracy in the tests, we need to use BigFloats with enlarged precision.


### PR DESCRIPTION
This came up in JuliaLang/LinearAlgebra.jl#496 and JuliaLang/julia#8300. Sometimes, it is useful to have an unconjugated dot product, computing the sum of the elementwise product of two vectors `x` and `y` as in  `dotu(x, y) = sum(x .* y)`. As suggested in https://github.com/JuliaLang/julia/pull/27401#issuecomment-394545580, I've added this function in a new PR.

Contrary to `dot` (cf. JuliaLang/julia#27401), `dotu` is not defined recursively. Thus, the unconjugated dot product of a vector of matrices and a vector of scalars can be computed, which is often used for Pauli matrices as in
```
julia> σ = [[0 1; 1 0], [0 -im; im 0], [1 0; 0 -1]]; n = [1, 2, 3]; dotu(σ, n)
2×2 Array{Complex{Int64},2}:
 3+0im   1-2im
 1+2im  -3+0im
```