### PR TITLE
Improve performance of generic dot products

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -648,22 +648,27 @@ julia> dot(x, y)
 function dot(x, y) # arbitrary iterables
     ix = iterate(x)
     iy = iterate(y)
-    if ix == nothing
-        if iy != nothing
+    if ix === nothing
+        if iy !== nothing
             throw(DimensionMismatch("x and y are of different lengths!"))
         end
         return dot(zero(eltype(x)), zero(eltype(y)))
     end
-    if iy == nothing
+    if iy === nothing
         throw(DimensionMismatch("x and y are of different lengths!"))
     end
-    s = dot(ix[1], iy[1])
-    ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
-    while ix != nothing && iy != nothing
-        s += dot(ix[1], iy[1])
-        ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
+    (vx, xs) = ix
+    (vy, ys) = iy
+    s = dot(vx, vy)
+    while true
+        ix = iterate(x, xs)
+        iy = iterate(y, ys)
+        ix === nothing && break
+        iy === nothing && break
+        (vx, xs), (vy, ys) = ix, iy
+        s += dot(vx, vy)
     end
-    if !(iy == nothing && ix == nothing)
+    if !(iy === nothing && ix === nothing)
         throw(DimensionMismatch("x and y are of different lengths!"))
     end
     return s

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -232,16 +232,18 @@ end
     @test dot(Z, Z) == convert(elty, 34.0)
 end
 
-dot_(x,y) = invoke(dot, Tuple{Any,Any}, x,y)
+dot1(x,y) = invoke(dot, Tuple{Any,Any}, x,y)
+dot2(x,y) = invoke(dot, Tuple{AbstractArray,AbstractArray}, x,y)
 @testset "generic dot" begin
     AA = [1+2im 3+4im; 5+6im 7+8im]
     BB = [2+7im 4+1im; 3+8im 6+5im]
     for A in (copy(AA), view(AA, 1:2, 1:2)), B in (copy(BB), view(BB, 1:2, 1:2))
-        @test dot(A,B) == dot(vec(A),vec(B)) == dot_(A,B) == dot(float.(A),float.(B))
-        @test dot(Int[], Int[]) == 0 == dot_(Int[], Int[])
+        @test dot(A,B) == dot(vec(A),vec(B)) == dot1(A,B) == dot2(A,B) == dot(float.(A),float.(B))
+        @test dot(Int[], Int[]) == 0 == dot1(Int[], Int[]) == dot2(Int[], Int[])
         @test_throws MethodError dot(Any[], Any[])
-        @test_throws MethodError dot_(Any[], Any[])
-        for n1 = 0:2, n2 = 0:2, d in (dot, dot_)
+        @test_throws MethodError dot1(Any[], Any[])
+        @test_throws MethodError dot2(Any[], Any[])
+        for n1 = 0:2, n2 = 0:2, d in (dot, dot1, dot2)
             if n1 != n2
                 @test_throws DimensionMismatch d(1:n1, 1:n2)
             else


### PR DESCRIPTION
Due to some recent work on dot products in Julia (#27401 and #27677), I'm interested in the generic implementations of those functions. Here are some benchmark result using the recent master branch of Julia:
```
julia> using BenchmarkTools, LinearAlgebra

julia> using LinearAlgebra: _length

julia> # new generic dot product for LinearAlgebra/src/generic.jl
       function dot0(x, y)
           ix = iterate(x)
           iy = iterate(y)
           if ix == nothing
               if iy != nothing
                   throw(DimensionMismatch("x and y are of different lengths!"))
               end
               return dot(zero(eltype(x)), zero(eltype(y)))
           end
           if iy == nothing
               throw(DimensionMismatch("x and y are of different lengths!"))
           end
           s = dot(ix[1], iy[1])
           ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
           while ix != nothing && iy != nothing
               s += dot(ix[1], iy[1])
               ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
           end
           if !(iy == nothing && ix == nothing)
               throw(DimensionMismatch("x and y are of different lengths!"))
           end
           return s
       end
dot0 (generic function with 1 method)

julia> # generic dot product in LinearAlgebra/src/generic.jl
       function dot1(x, y)
           ix = iterate(x)
           iy = iterate(y)
           if ix === nothing
               if iy !== nothing
                   throw(DimensionMismatch("x and y are of different lengths!"))
               end
               return dot(zero(eltype(x)), zero(eltype(y)))
           end
           if iy === nothing
               throw(DimensionMismatch("x and y are of different lengths!"))
           end
           (vx, xs) = ix
           (vy, ys) = iy
           s = dot(vx, vy)
           while true
               ix = iterate(x, xs)
               iy = iterate(y, ys)
               if (ix == nothing) || (iy == nothing)
                   break
               end
               (vx, xs), (vy, ys) = ix, iy
               s += dot(vx, vy)
           end
           if !(iy == nothing && ix == nothing)
               throw(DimensionMismatch("x and y are of different lengths!"))
           end
           return s
       end
dot1 (generic function with 1 method)

julia> # dot product for `AbstractVector`s in LinearAlgebra/src/generic.jl
       function dot2(x::AbstractArray, y::AbstractArray)
           if length(LinearIndices(x)) != length(LinearIndices(y))
               throw(DimensionMismatch("dot product arguments have unequal lengths $(length(LinearIndices(x))) and $(length(LinearIndices(y)))"))
           end
           ix = iterate(x)
           if ix === nothing
               # we only need to check the first vector, since equal lengths have been asserted
               return dot(zero(eltype(x)), zero(eltype(y)))
           end
           iy = iterate(y)
           s = dot(ix[1], iy[1])
           ix, iy = iterate(x, ix[2]), iterate(y, iy[2])
           while ix != nothing
               s += dot(ix[1], iy[1])
               ix = iterate(x, ix[2])
               iy = iterate(y, iy[2])
           end
           return s
       end
dot2 (generic function with 1 method)

julia> # dot product for `AbstractArray`s in LinearAlgebra/src/generic.jl
       function dot3(x::AbstractArray, y::AbstractArray)
           lx = _length(x)
           if lx != _length(y)
               throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(_length(y))."))
           end
           if lx == 0
               return dot(zero(eltype(x)), zero(eltype(y)))
           end
           s = zero(dot(first(x), first(y)))
           for (Ix, Iy) in zip(eachindex(x), eachindex(y))
               @inbounds s += dot(x[Ix], y[Iy])
           end
           s
       end
dot3 (generic function with 1 method)

julia> function test(T, Ns...)
           x = rand(T, Ns...)
           y = rand(T, Ns...)

           display("Dot product using BLAS.")
           display(@btime dot($x, $y))

           display("New generic dot product.")
           display(@btime dot0($x, $y))

           display("Generic dot product in LinearAlgebra/src/generic.jl.")
           display(@btime dot1($x, $y))

           display("Dot product for `AbstractVector`s in LinearAlgebra/src/generic.jl.")
           display(@btime dot2($x, $y))

           display("Dot product for `AbstractArray`s in LinearAlgebra/src/generic.jl.")
           display(@btime dot3($x, $y))
       end
test (generic function with 1 method)

julia> test(Float64, 100)
"Dot product using BLAS."
  41.156 ns (0 allocations: 0 bytes)
23.49389537040023
"New generic dot product."
  207.198 ns (0 allocations: 0 bytes)
23.493895370400235
"Generic dot product in LinearAlgebra/src/generic.jl."
  5.841 μs (198 allocations: 6.19 KiB)
23.493895370400235
"Dot product for `AbstractVector`s in LinearAlgebra/src/generic.jl."
  254.789 ns (0 allocations: 0 bytes)
23.493895370400235
"Dot product for `AbstractArray`s in LinearAlgebra/src/generic.jl."
  78.806 ns (0 allocations: 0 bytes)
23.493895370400235

julia> test(Float64, 10, 10)
"Dot product using BLAS."
  31.015 ns (0 allocations: 0 bytes)
25.062379286171122
"New generic dot product."
  199.772 ns (0 allocations: 0 bytes)
25.06237928617112
"Generic dot product in LinearAlgebra/src/generic.jl."
  5.880 μs (198 allocations: 6.19 KiB)
25.06237928617112
"Dot product for `AbstractVector`s in LinearAlgebra/src/generic.jl."
  228.787 ns (0 allocations: 0 bytes)
25.06237928617112
"Dot product for `AbstractArray`s in LinearAlgebra/src/generic.jl."
  85.951 ns (0 allocations: 0 bytes)
25.06237928617112

julia> test(ComplexF64, 100)
"Dot product using BLAS."
  61.193 ns (0 allocations: 0 bytes)
43.02892041305856 + 1.2252503100128251im
"New generic dot product."
  281.028 ns (0 allocations: 0 bytes)
43.028920413058586 + 1.2252503100128243im
"Generic dot product in LinearAlgebra/src/generic.jl."
  6.067 μs (198 allocations: 6.19 KiB)
43.028920413058586 + 1.2252503100128243im
"Dot product for `AbstractVector`s in LinearAlgebra/src/generic.jl."
  443.242 ns (0 allocations: 0 bytes)
43.028920413058586 + 1.2252503100128243im
"Dot product for `AbstractArray`s in LinearAlgebra/src/generic.jl."
  118.485 ns (0 allocations: 0 bytes)
43.028920413058586 + 1.2252503100128243im

julia> test(ComplexF64, 10, 10)
"Dot product using BLAS."
  61.055 ns (0 allocations: 0 bytes)
46.18083236484251 - 0.2818033108671578im
"New generic dot product."
  261.608 ns (0 allocations: 0 bytes)
46.18083236484251 - 0.2818033108671528im
"Generic dot product in LinearAlgebra/src/generic.jl."
  6.074 μs (198 allocations: 6.19 KiB)
46.18083236484251 - 0.2818033108671528im
"Dot product for `AbstractVector`s in LinearAlgebra/src/generic.jl."
  395.637 ns (0 allocations: 0 bytes)
46.18083236484251 - 0.2818033108671528im
"Dot product for `AbstractArray`s in LinearAlgebra/src/generic.jl."
  120.597 ns (0 allocations: 0 bytes)
46.18083236484251 - 0.2818033108671528im
```
There seem to be some serious type stability issues for the generic dot product in LinearAlgebra/src/generic.jl. Moreover, the generic dot product for `AbstractArray`s seems to be superior to the one for `AbstractVector`s. Thus, I've added a new generic dot product and have removed the generic one for `AbstractVector`s.