### PR TITLE
Add a do-block form of the CachingPool

### DIFF
--- a/stdlib/Distributed/src/workerpool.jl
+++ b/stdlib/Distributed/src/workerpool.jl
@@ -265,6 +265,30 @@ function CachingPool(workers::Vector{Int})
     return pool
 end
 
+
+
+"""
+    CachingPool(func, workers::Vector{Int})
+
+Excute `func(pool)`, clearing out any cached functions from the workers when complete.
+
+# Examples
+```julia
+CachingPool(workers()) do wp
+    foo = rand(10^8);
+    pmap(wp, i -> sum(foo) + i, 1:100);
+end
+"""
+function CachingPool(fun, workers::Vector{Int})
+    pool = CachingPool(workers)
+    try
+        fun(pool)
+    finally
+        clear!(pool)
+    end
+end
+
+
 """
     clear!(pool::CachingPool) -> pool
 

--- a/stdlib/Distributed/src/workerpool.jl
+++ b/stdlib/Distributed/src/workerpool.jl
@@ -279,10 +279,10 @@ CachingPool(workers()) do wp
     pmap(wp, i -> sum(foo) + i, 1:100);
 end
 """
-function CachingPool(fun, workers::Vector{Int})
+function CachingPool(func, workers::Vector{Int})
     pool = CachingPool(workers)
     try
-        fun(pool)
+        func(pool)
     finally
         clear!(pool)
     end


### PR DESCRIPTION
This feels right.

Generally I think there is some region of code in which the cached functions need to be keep.
So a do-block  form that runs the function,
then when done `clear!`s the pool seems right.

I guess maybe not required as the finalizer will clean up once the pool get garbage collected.
But given that the reason you are using a `CachingPool` in the first place is because you are worried that you have huge closures being passed around,
clearing sooner is better than latter.

This needs tests I guess, but I figured I'ld wait and see if the idea was sound