### PR TITLE
manually inline setfield! in Stateful popfirst!

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -1075,7 +1075,7 @@ convert(::Type{Stateful}, itr) = Stateful(itr)
         throw(EOFError())
     else
         val, state = vs
-        s.nextvalstate = iterate(s.itr, state)
+        Core.setfield!(s, :nextvalstate, iterate(s.itr, state))
         s.taken += 1
         return val
     end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/pull/27030#issuecomment-398702322

```
julia> chars = [rand(Char) for i in 1:10^4];

# Before
julia> @btime join(chars, "");
  4.729 ms (30019 allocations: 1004.14 KiB)

# After
julia> @btime join(chars, "");
  548.426 μs (22 allocations: 66.73 KiB)
```