### PR TITLE
small refactor of renumber_stuff!

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -492,25 +492,30 @@ function is_known_call_p(e::Expr, @nospecialize(pred), src, spvals)
 end
 
 function renumber_stuff!(body::Vector{Any}, changemap::Vector{Int})
-    for i = 1:length(body)
-        el = body[i]
-        if isa(el, GotoNode)
-            body[i] = GotoNode(el.label + changemap[el.label])
-        elseif isa(el, SSAValue)
-            body[i] = SSAValue(el.id + changemap[el.id])
-        elseif isa(el, Expr)
-            if el.head === :gotoifnot
-                cond = el.args[1]
-                if isa(cond, SSAValue)
-                    el.args[1] = SSAValue(cond.id + changemap[cond.id])
+    for i = 2:length(changemap)
+        changemap[i] += changemap[i - 1]
+    end
+    if changemap[end] != 0
+        for i = 1:length(body)
+            el = body[i]
+            if isa(el, GotoNode)
+                body[i] = GotoNode(el.label + changemap[el.label])
+            elseif isa(el, SSAValue)
+                body[i] = SSAValue(el.id + changemap[el.id])
+            elseif isa(el, Expr)
+                if el.head === :gotoifnot
+                    cond = el.args[1]
+                    if isa(cond, SSAValue)
+                        el.args[1] = SSAValue(cond.id + changemap[cond.id])
+                    end
+                    tgt = el.args[2]::Int
+                    el.args[2] = tgt + changemap[tgt]
+                elseif el.head === :enter
+                    tgt = el.args[1]::Int
+                    el.args[1] = tgt + changemap[tgt]
+                elseif !is_meta_expr_head(el.head)
+                    renumber_stuff!(el.args, changemap)
                 end
-                tgt = el.args[2]::Int
-                el.args[2] = tgt + changemap[tgt]
-            elseif el.head === :enter
-                tgt = el.args[1]::Int
-                el.args[1] = tgt + changemap[tgt]
-            elseif !is_meta_expr_head(el.head)
-                renumber_stuff!(el.args, changemap)
             end
         end
     end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -491,7 +491,7 @@ function is_known_call_p(e::Expr, @nospecialize(pred), src, spvals)
     return (isa(f, Const) && pred(f.val)) || (isType(f) && pred(f.parameters[1]))
 end
 
-function renumber_stuff!(body::Vector{Any}, changemap::Vector{Int})
+function renumber_ir_elements!(body::Vector{Any}, changemap::Vector{Int})
     for i = 2:length(changemap)
         changemap[i] += changemap[i - 1]
     end
@@ -514,7 +514,7 @@ function renumber_stuff!(body::Vector{Any}, changemap::Vector{Int})
                     tgt = el.args[1]::Int
                     el.args[1] = tgt + changemap[tgt]
                 elseif !is_meta_expr_head(el.head)
-                    renumber_stuff!(el.args, changemap)
+                    renumber_ir_elements!(el.args, changemap)
                 end
             end
         end

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -71,7 +71,7 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, spvals:
         idx += 1
         oldidx += 1
     end
-    renumber_stuff!(code, changemap)
+    renumber_ir_elements!(code, changemap)
 
     inbounds_depth = 0 # Number of stacked inbounds
     meta = Any[]

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -71,12 +71,7 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, spvals:
         idx += 1
         oldidx += 1
     end
-    for i = 2:length(changemap)
-        changemap[i] += changemap[i-1]
-    end
-    if changemap[end] != 0
-        renumber_stuff!(code, changemap)
-    end
+    renumber_stuff!(code, changemap)
 
     inbounds_depth = 0 # Number of stacked inbounds
     meta = Any[]

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -429,7 +429,7 @@ function type_annotate!(sv::InferenceState)
     end
 
     if run_optimizer
-        renumber_stuff!(body, changemap)
+        renumber_ir_elements!(body, changemap)
     end
 
     # finish marking used-undef variables

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -429,12 +429,7 @@ function type_annotate!(sv::InferenceState)
     end
 
     if run_optimizer
-        for i = 2:length(changemap)
-            changemap[i] += changemap[i - 1]
-        end
-        if changemap[end] != 0
-            renumber_stuff!(body, changemap)
-        end
+        renumber_stuff!(body, changemap)
     end
 
     # finish marking used-undef variables


### PR DESCRIPTION
This just moves in the `changemap` preprocessing + check that all its callers were performing anyway, to make calling the function easier.

I've also given this function the slighty more descriptive (but still suitably broad) name `renumber_ir_elements!`.