### PR TITLE
improve perf for string with both strings and chars as argument

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -323,11 +323,11 @@ end
 codelen(c::Char) = 4 - (trailing_zeros(0xff000000 | reinterpret(UInt32, c)) >> 3)
 
 function string(a::Union{String,AbstractChar}...)
-    sprint() do io
-        for x in a
-            print(io, x)
-        end
+    io = IOBuffer()
+    for x in a
+        print(io, x)
     end
+    return String(resize!(io.data, io.size))
 end
 
 function repeat(s::String, r::Integer)


### PR DESCRIPTION
Before:

```
julia> @btime string("foo", 'b', "ar")
  443.838 ns (8 allocations: 288 bytes)
````

After

```
julia> @btime string("Foo", 'b', "ar")
  110.836 ns (3 allocations: 192 bytes)
```

Ref https://github.com/JuliaLang/julia/pull/27030#issuecomment-398736638