### PR TITLE
LOAD_PATH: make `@@` do late expansion to curent env

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -103,7 +103,7 @@ function parse_load_path(str::String)
         if isempty(env)
             first_empty && append!(envs, DEFAULT_LOAD_PATH)
             first_empty = false
-        elseif env == "@"
+        elseif env == "@" # use "@@" to do delayed expansion
             dir = current_env()
             dir !== nothing && push!(envs, dir)
         else

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -152,7 +152,7 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
     if startswith(env, '@')
         # `@` in JULIA_LOAD_PATH is expanded early (at startup time)
         # if you put a `@` in LOAD_PATH manually, it's expanded late
-        env == "@" && return current_env()
+        (env == "@" || env == "@@") && return current_env()
         env == "@stdlib" && return Sys.STDLIB
         env = replace(env, '#' => VERSION.major, count=1)
         env = replace(env, '#' => VERSION.minor, count=1)


### PR DESCRIPTION
With this PR, you can get back to the pre-#27696 behavior by doing:
```sh
export JULIA_LOAD_PATH="@@:"
```
With this, you can `shell> cd $proj` and have `proj` automatically become your primary environment.