### PR TITLE
remove CodeInfo.slottypes

### DIFF
--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -22,11 +22,20 @@ end
 
 function get_argtypes(result::InferenceResult)
     result.args === EMPTY_VECTOR || return result.args # already cached
-    linfo = result.linfo
+    argtypes, vargs = get_argtypes(result.linfo)
+    result.args = argtypes
+    if vargs !== nothing
+        result.vargs = vargs
+    end
+    return argtypes
+end
+
+function get_argtypes(linfo::MethodInstance)
     toplevel = !isa(linfo.def, Method)
     atypes::SimpleVector = unwrap_unionall(linfo.specTypes).parameters
     nargs::Int = toplevel ? 0 : linfo.def.nargs
     args = Vector{Any}(undef, nargs)
+    vargs = nothing
     if !toplevel && linfo.def.isva
         if linfo.specTypes == Tuple
             if nargs > 1
@@ -62,7 +71,7 @@ function get_argtypes(result::InferenceResult)
                     end
                 end
             end
-            result.vargs = vararg_type_vec
+            vargs = vararg_type_vec
         end
         args[nargs] = vararg_type
         nargs -= 1
@@ -100,8 +109,7 @@ function get_argtypes(result::InferenceResult)
     else
         @assert nargs == 0 "invalid specialization of method" # wrong number of arguments
     end
-    result.args = args
-    return args
+    return args, vargs
 end
 
 function cache_lookup(code::MethodInstance, argtypes::Vector{Any}, cache::Vector{InferenceResult})

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -7,6 +7,7 @@ mutable struct InferenceState
     result::InferenceResult # remember where to put the result
     linfo::MethodInstance # used here for the tuple (specTypes, env, Method) and world-age validity
     sp::SimpleVector     # static parameters
+    slottypes::Vector{Any}
     mod::Module
     currpc::LineNum
 
@@ -61,11 +62,11 @@ mutable struct InferenceState
         argtypes = get_argtypes(result)
         nargs = length(argtypes)
         s_argtypes = VarTable(undef, nslots)
-        src.slottypes = Vector{Any}(undef, nslots)
+        slottypes = Vector{Any}(undef, nslots)
         for i in 1:nslots
             at = (i > nargs) ? Bottom : argtypes[i]
             s_argtypes[i] = VarState(at, i > nargs)
-            src.slottypes[i] = at
+            slottypes[i] = at
         end
         s_types[1] = s_argtypes
 
@@ -95,7 +96,7 @@ mutable struct InferenceState
         end
         frame = new(
             params, result, linfo,
-            sp, inmodule, 0,
+            sp, slottypes, inmodule, 0,
             src, min_valid, max_valid,
             nargs, s_types, s_edges,
             Union{}, W, 1, n,

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -15,6 +15,7 @@ mutable struct OptimizationState
     max_valid::UInt
     params::Params
     sp::SimpleVector # static parameters
+    slottypes::Vector{Any}
     const_api::Bool
     function OptimizationState(frame::InferenceState)
         s_edges = frame.stmt_edges[1]
@@ -27,7 +28,7 @@ mutable struct OptimizationState
                    s_edges::Vector{Any},
                    src, frame.mod, frame.nargs,
                    frame.min_valid, frame.max_valid,
-                   frame.params, frame.sp, false)
+                   frame.params, frame.sp, frame.slottypes, false)
     end
     function OptimizationState(linfo::MethodInstance, src::CodeInfo,
                                params::Params)
@@ -37,10 +38,8 @@ mutable struct OptimizationState
         if nssavalues isa Int
             src.ssavaluetypes = Any[ Any for i = 1:nssavalues ]
         end
-        if src.slottypes === nothing
-            nslots = length(src.slotnames)
-            src.slottypes = Any[ Any for i = 1:nslots ]
-        end
+        nslots = length(src.slotnames)
+        slottypes = Any[ Any for i = 1:nslots ]
         s_edges = []
         # cache some useful state computations
         toplevel = !isa(linfo.def, Method)
@@ -57,7 +56,7 @@ mutable struct OptimizationState
                    s_edges::Vector{Any},
                    src, inmodule, nargs,
                    min_world(linfo), max_world(linfo),
-                   params, spvals_from_meth_instance(linfo), false)
+                   params, spvals_from_meth_instance(linfo), slottypes, false)
         end
 end
 
@@ -134,7 +133,7 @@ function isinlineable(m::Method, me::OptimizationState, bonus::Int=0)
         end
     end
     if !inlineable
-        inlineable = inline_worthy(me.src.code, me.src, me.sp, me.params, cost_threshold + bonus)
+        inlineable = inline_worthy(me.src.code, me.src, me.sp, me.slottypes, me.params, cost_threshold + bonus)
     end
     return inlineable
 end
@@ -266,16 +265,14 @@ function statement_effect_free(@nospecialize(e), me::OptimizationState, @nospeci
     return effect_free(e, me, false, etype)
 end
 
-effect_free(@nospecialize(e), s::InferenceState, allow_volatile::Bool, @nospecialize(etype)) =
-    effect_free(e, s.src, s.sp, allow_volatile, etype)
-
 effect_free(@nospecialize(e), s::OptimizationState, allow_volatile::Bool, @nospecialize(etype)) =
-    effect_free(e, s.src, s.sp, allow_volatile, etype)
+    effect_free(e, s.src, s.sp, allow_volatile, etype, s.slottypes)
 
 # detect some important side-effect-free calls (allow_volatile=true)
 # and some affect-free calls (allow_volatile=false) -- affect_free means the call
 # cannot be affected by previous calls, except assignment nodes
-function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile::Bool, @nospecialize(etype))
+function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile::Bool, @nospecialize(etype),
+                     slottypes::Vector{Any} = empty_slottypes)
     if isa(e, GlobalRef)
         return (isdefined(e.mod, e.name) && (allow_volatile || isconst(e.mod, e.name)))
     elseif isa(e, Slot)
@@ -295,18 +292,18 @@ function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile
         end
         ea = e.args
         if head === :call
-            if is_known_call_p(e, is_pure_builtin, src, spvals)
+            if is_known_call_p(e, is_pure_builtin, src, spvals, slottypes)
                 if !allow_volatile
-                    if is_known_call(e, arrayref, src, spvals) || is_known_call(e, arraylen, src, spvals)
+                    if is_known_call(e, arrayref, src, spvals, slottypes) || is_known_call(e, arraylen, src, spvals, slottypes)
                         return false
-                    elseif is_known_call(e, getfield, src, spvals)
+                    elseif is_known_call(e, getfield, src, spvals, slottypes)
                         nargs = length(ea)
                         (3 <= nargs <= 4) || return false
                         # TODO: check ninitialized
                         if !isa(etype, Const) && !isconstType(etype)
                             # first argument must be immutable to ensure e is affect_free
                             a = ea[2]
-                            typ = unwrap_unionall(widenconst(argextype(a, src, spvals)))
+                            typ = unwrap_unionall(widenconst(argextype(a, src, spvals, slottypes)))
                             if isType(typ)
                                 # all fields of subtypes of Type are effect-free
                                 # (including the non-inferrable uid field)
@@ -317,8 +314,8 @@ function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile
                     end
                 end
                 # fall-through
-            elseif is_known_call(e, _apply, src, spvals) && length(ea) > 1
-                ft = argextype(ea[2], src, spvals)
+            elseif is_known_call(e, _apply, src, spvals, slottypes) && length(ea) > 1
+                ft = argextype(ea[2], src, spvals, slottypes)
                 if !isa(ft, Const) || (!contains_is(_PURE_BUILTINS, ft.val) &&
                                        ft.val !== Core.sizeof)
                     return false
@@ -329,7 +326,7 @@ function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile
             end
         elseif head === :new
             a = ea[1]
-            typ = argextype(a, src, spvals)
+            typ = argextype(a, src, spvals, slottypes)
             # `Expr(:new)` of unknown type could raise arbitrary TypeError.
             typ, isexact = instanceof_tfunc(typ)
             isexact || return false
@@ -340,7 +337,7 @@ function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile
             end
             fieldcount(typ) >= length(ea) - 1 || return false
             for fld_idx in 1:(length(ea) - 1)
-                eT = argextype(ea[fld_idx + 1], src, spvals)
+                eT = argextype(ea[fld_idx + 1], src, spvals, slottypes)
                 fT = fieldtype(typ, fld_idx)
                 eT ⊑ fT || return false
             end
@@ -357,7 +354,7 @@ function effect_free(@nospecialize(e), src, spvals::SimpleVector, allow_volatile
             return false
         end
         for a in ea
-            if !effect_free(a, src, spvals, allow_volatile, argextype(a, src, spvals))
+            if !effect_free(a, src, spvals, allow_volatile, argextype(a, src, spvals, slottypes))
                 return false
             end
         end
@@ -375,7 +372,7 @@ plus_saturate(x, y) = max(x, y, x+y)
 # known return type
 isknowntype(@nospecialize T) = (T == Union{}) || isconcretetype(T)
 
-function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector, params::Params)
+function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector, slottypes::Vector{Any}, params::Params)
     head = ex.head
     if is_meta_expr_head(head) || head == :copyast # not sure if copyast is right
         return 0
@@ -383,7 +380,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector
     argcost = 0
     for a in ex.args
         if a isa Expr
-            argcost = plus_saturate(argcost, statement_cost(a, -1, src, spvals, params))
+            argcost = plus_saturate(argcost, statement_cost(a, -1, src, spvals, slottypes, params))
         end
     end
     if head == :return || head == :(=)
@@ -391,7 +388,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector
     end
     extyp = line == -1 ? Any : src.ssavaluetypes[line]
     if head == :call
-        ftyp = argextype(ex.args[1], src, spvals)
+        ftyp = argextype(ex.args[1], src, spvals, slottypes)
         if isa(ftyp, Type)
             return argcost
         end
@@ -416,7 +413,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector
                     # return plus_saturate(argcost, isknowntype(extyp) ? 1 : params.inline_nonleaf_penalty)
                     return argcost
                 elseif f == Main.Core.arrayref && length(ex.args) >= 3
-                    atyp = argextype(ex.args[3], src, spvals)
+                    atyp = argextype(ex.args[3], src, spvals, slottypes)
                     return plus_saturate(argcost, isknowntype(atyp) ? 4 : params.inline_nonleaf_penalty)
                 end
                 fidx = findfirst(x->x===f, T_FFUNC_KEY)
@@ -454,13 +451,13 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, spvals::SimpleVector
     return argcost
 end
 
-function inline_worthy(body::Array{Any,1}, src::CodeInfo, spvals::SimpleVector, params::Params,
-                       cost_threshold::Integer=params.inline_cost_threshold)
+function inline_worthy(body::Array{Any,1}, src::CodeInfo, spvals::SimpleVector, slottypes::Vector{Any},
+                       params::Params, cost_threshold::Integer=params.inline_cost_threshold)
     bodycost = 0
     for line = 1:length(body)
         stmt = body[line]
         if stmt isa Expr
-            thiscost = statement_cost(stmt, line, src, spvals, params)::Int
+            thiscost = statement_cost(stmt, line, src, spvals, slottypes, params)::Int
         elseif stmt isa GotoNode
             # loops are generally always expensive
             # but assume that forward jumps are already counted for from
@@ -475,19 +472,19 @@ function inline_worthy(body::Array{Any,1}, src::CodeInfo, spvals::SimpleVector, 
     return bodycost <= cost_threshold
 end
 
-function is_known_call(e::Expr, @nospecialize(func), src, spvals)
+function is_known_call(e::Expr, @nospecialize(func), src, spvals::SimpleVector, slottypes::Vector{Any} = empty_slottypes)
     if e.head !== :call
         return false
     end
-    f = argextype(e.args[1], src, spvals)
+    f = argextype(e.args[1], src, spvals, slottypes)
     return isa(f, Const) && f.val === func
 end
 
-function is_known_call_p(e::Expr, @nospecialize(pred), src, spvals)
+function is_known_call_p(e::Expr, @nospecialize(pred), src, spvals::SimpleVector, slottypes::Vector{Any})
     if e.head !== :call
         return false
     end
-    f = argextype(e.args[1], src, spvals)
+    f = argextype(e.args[1], src, spvals, slottypes)
     return (isa(f, Const) && pred(f.val)) || (isType(f) && pred(f.parameters[1]))
 end
 

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -50,7 +50,7 @@ function normalize(@nospecialize(stmt), meta::Vector{Any})
     return stmt
 end
 
-function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, spvals::SimpleVector)
+function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, sv::OptimizationState)
     # Go through and add an unreachable node after every
     # Union{} call. Then reindex labels.
     idx = 1
@@ -103,15 +103,15 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, spvals:
     defuse_insts = scan_slot_def_use(nargs, ci, code)
     @timeit "domtree 1" domtree = construct_domtree(cfg)
     ir = let code = Any[nothing for _ = 1:length(code)]
-             argtypes = ci.slottypes[1:(nargs+1)]
-            IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), argtypes, meta, spvals)
+             argtypes = sv.slottypes[1:(nargs+1)]
+            IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), argtypes, meta, sv.sp)
         end
-    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs, spvals)
+    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs, sv.sp, sv.slottypes)
     return ir
 end
 
 function run_passes(ci::CodeInfo, nargs::Int, sv::OptimizationState)
-    ir = just_construct_ssa(ci, copy_exprargs(ci.code), nargs, sv.sp)
+    ir = just_construct_ssa(ci, copy_exprargs(ci.code), nargs, sv)
     #@Base.show ("after_construct", ir)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
     @timeit "compact 1" ir = compact!(ir)

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -652,7 +652,7 @@ function analyze_method!(idx::Int, @nospecialize(f), @nospecialize(ft), @nospeci
     end
 
     @timeit "inline IR inflation" begin
-        ir2, inline_linetable = inflate_ir(src, spvals_from_meth_instance(linfo)), src.linetable
+        ir2, inline_linetable = inflate_ir(src, linfo), src.linetable
     end
     #verify_ir(ir2)
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -208,71 +208,19 @@ function store_backedges(frame::InferenceState)
 end
 
 # widen all Const elements in type annotations
-function _widen_all_consts!(e::Expr, untypedload::Vector{Bool}, slottypes::Vector{Any})
-    for i = 1:length(e.args)
-        x = e.args[i]
-        if isa(x, Expr)
-            _widen_all_consts!(x, untypedload, slottypes)
-        elseif isa(x, TypedSlot)
-            vt = widenconst(x.typ)
-            if !(vt === x.typ)
-                if slottypes[x.id] ⊑ vt
-                    x = SlotNumber(x.id)
-                    untypedload[x.id] = true
-                else
-                    x = TypedSlot(x.id, vt)
-                end
-                e.args[i] = x
-            end
-        elseif isa(x, PiNode)
-            e.args[i] = PiNode(x.val, widenconst(x.typ))
-        elseif isa(x, SlotNumber) && (i != 1 || e.head !== :(=))
-            untypedload[x.id] = true
-        end
-    end
-    nothing
-end
-
 function widen_all_consts!(src::CodeInfo)
     for i = 1:length(src.ssavaluetypes)
         src.ssavaluetypes[i] = widenconst(src.ssavaluetypes[i])
     end
-    for i = 1:length(src.slottypes)
-        src.slottypes[i] = widenconst(src.slottypes[i])
+
+    for i = 1:length(src.code)
+        x = src.code[i]
+        if isa(x, PiNode)
+            src.code[i] = PiNode(x.val, widenconst(x.typ))
+        end
     end
 
-    nslots = length(src.slottypes)
-    untypedload = fill(false, nslots)
-    e = Expr(:body)
-    e.args = src.code
-    _widen_all_consts!(e, untypedload, src.slottypes)
-    for i = 1:nslots
-        src.slottypes[i] = widen_slot_type(src.slottypes[i], untypedload[i])
-    end
     return src
-end
-
-# widen all slots to their optimal storage layout
-# we also need to preserve the type for any untyped load of a DataType
-# since codegen optimizations of functions like `is` will depend on knowing it
-function widen_slot_type(@nospecialize(ty), untypedload::Bool)
-    if isa(ty, DataType)
-        if untypedload || isbitstype(ty) || isdefined(ty, :instance)
-            return ty
-        end
-    elseif isa(ty, Union)
-        ty_a = widen_slot_type(ty.a, false)
-        ty_b = widen_slot_type(ty.b, false)
-        if ty_a !== Any || ty_b !== Any
-            # TODO: better optimized codegen for unions?
-            return ty
-        end
-    elseif isa(ty, UnionAll)
-        if untypedload
-            return ty
-        end
-    end
-    return Any
 end
 
 maybe_widen_conditional(@nospecialize vt) = vt
@@ -314,7 +262,7 @@ function visit_slot_load!(sl::Slot, vtypes::VarTable, sv::InferenceState, undefs
         undefs[id] = true
     end
     # add type annotations where needed
-    if !(sv.src.slottypes[id] ⊑ vt)
+    if !(sv.slottypes[id] ⊑ vt)
         return TypedSlot(id, vt)
     end
     return sl
@@ -326,7 +274,7 @@ function record_slot_assign!(sv::InferenceState)
     # to compute a lower bound on the storage required
     states = sv.stmt_types
     body = sv.src.code::Vector{Any}
-    slottypes = sv.src.slottypes::Vector{Any}
+    slottypes = sv.slottypes::Vector{Any}
     for i = 1:length(body)
         expr = body[i]
         st_i = states[i]
@@ -589,7 +537,6 @@ function typeinf_ext(linfo::MethodInstance, params::Params)
                     tree.method_for_inference_limit_heuristics = nothing
                     tree.slotnames = Any[ COMPILER_TEMP_SYM for i = 1:method.nargs ]
                     tree.slotflags = fill(0x00, Int(method.nargs))
-                    tree.slottypes = nothing
                     tree.ssavaluetypes = 0
                     tree.codelocs = Int32[1]
                     tree.linetable = [LineInfoNode(method.module, method.name, method.file, Int(method.line), 0)]

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -172,20 +172,22 @@ function method_for_inference_heuristics(method::Method, @nospecialize(sig), spa
     return nothing
 end
 
-argextype(@nospecialize(x), state) = argextype(x, state.src, state.sp)
+argextype(@nospecialize(x), state) = argextype(x, state.src, state.sp, state.slottypes)
 
-function argextype(@nospecialize(x), src, spvals::SimpleVector)
+const empty_slottypes = Any[]
+
+function argextype(@nospecialize(x), src, spvals::SimpleVector, slottypes::Vector{Any} = empty_slottypes)
     if isa(x, Expr)
         if x.head === :static_parameter
             return sparam_type(spvals[x.args[1]])
         elseif x.head === :boundscheck
             return Bool
         elseif x.head === :copyast
-            return argextype(x.args[1], src, spvals)
+            return argextype(x.args[1], src, spvals, slottypes)
         end
         @assert false "argextype only works on argument-position values"
     elseif isa(x, SlotNumber)
-        return src.slottypes[(x::SlotNumber).id]
+        return slottypes[(x::SlotNumber).id]
     elseif isa(x, TypedSlot)
         return (x::TypedSlot).typ
     elseif isa(x, SSAValue)

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -40,8 +40,6 @@ const INVALID_RETURN = "invalid argument to :return"
 const INVALID_CALL_ARG = "invalid :call argument"
 const EMPTY_SLOTNAMES = "slotnames field is empty"
 const SLOTFLAGS_MISMATCH = "length(slotnames) != length(slotflags)"
-const SLOTTYPES_MISMATCH = "length(slotnames) != length(slottypes)"
-const SLOTTYPES_MISMATCH_UNINFERRED = "uninferred CodeInfo slottypes field is not `nothing`"
 const SSAVALUETYPES_MISMATCH = "not all SSAValues in AST have a type in ssavaluetypes"
 const SSAVALUETYPES_MISMATCH_UNINFERRED = "uninferred CodeInfo ssavaluetypes field does not equal the number of present SSAValues"
 const NON_TOP_LEVEL_METHOD = "encountered `Expr` head `:method` in non-top-level code (i.e. `nargs` > 0)"
@@ -170,12 +168,9 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_
     !is_top_level && nslotnames == 0 && push!(errors, InvalidCodeError(EMPTY_SLOTNAMES))
     nslotnames != nslotflags && push!(errors, InvalidCodeError(SLOTFLAGS_MISMATCH, (nslotnames, nslotflags)))
     if c.inferred
-        nslottypes = length(c.slottypes)
         nssavaluetypes = length(c.ssavaluetypes)
-        nslottypes != nslotnames && push!(errors, InvalidCodeError(SLOTTYPES_MISMATCH, (nslotnames, nslottypes)))
         nssavaluetypes < nssavals && push!(errors, InvalidCodeError(SSAVALUETYPES_MISMATCH, (nssavals, nssavaluetypes)))
     else
-        c.slottypes !== nothing && push!(errors, InvalidCodeError(SLOTTYPES_MISMATCH_UNINFERRED, c.slottypes))
         c.ssavaluetypes != nssavals && push!(errors, InvalidCodeError(SSAVALUETYPES_MISMATCH_UNINFERRED, (nssavals, c.ssavaluetypes)))
     end
     return errors

--- a/base/show.jl
+++ b/base/show.jl
@@ -656,7 +656,7 @@ function show(io::IO, src::CodeInfo)
     if isempty(src.linetable) || src.linetable[1] isa LineInfoNode
         println(io)
         # TODO: static parameter values?
-        ir = Core.Compiler.inflate_ir(src, Core.svec())
+        ir = Core.Compiler.inflate_ir(src)
         IRShow.show_ir(lambda_io, ir, argnames=sourceinfo_slotnames(src))
     else
         # this is a CodeInfo that has not been used as a method yet, so its locations are still LineNumberNodes

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5390,11 +5390,11 @@ static std::unique_ptr<Module> emit_function(
     // step 3. some variable analysis
     size_t i;
     for (i = 0; i < nreq; i++) {
+        jl_varinfo_t &varinfo = ctx.slots[i];
+        varinfo.isArgument = true;
         jl_sym_t *argname = (jl_sym_t*)jl_array_ptr_ref(src->slotnames, i);
         if (argname == unused_sym)
             continue;
-        jl_varinfo_t &varinfo = ctx.slots[i];
-        varinfo.isArgument = true;
         jl_value_t *ty = jl_nth_slot_type(lam->specTypes, i);
         varinfo.value = mark_julia_type(ctx, (Value*)NULL, false, ty);
     }
@@ -5411,10 +5411,7 @@ static std::unique_ptr<Module> emit_function(
         varinfo.isSA = (jl_vinfo_sa(flags) != 0);
         varinfo.usedUndef = (jl_vinfo_usedundef(flags) != 0) || (!varinfo.isArgument && !src->inferred);
         if (!varinfo.isArgument) {
-            jl_value_t *typ = jl_is_array(src->slottypes) ? jl_array_ptr_ref(src->slottypes, i) : (jl_value_t*)jl_any_type;
-            if (!jl_is_type(typ))
-                typ = (jl_value_t*)jl_any_type;
-            varinfo.value = mark_julia_type(ctx, (Value*)NULL, false, typ);
+            varinfo.value = mark_julia_type(ctx, (Value*)NULL, false, (jl_value_t*)jl_any_type);
         }
     }
 

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2021,11 +2021,10 @@ void jl_init_types(void)
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(13,
+                        jl_perm_symsvec(12,
                             "code",
                             "codelocs",
                             "method_for_inference_limit_heuristics",
-                            "slottypes",
                             "ssavaluetypes",
                             "linetable",
                             "ssaflags",
@@ -2035,9 +2034,8 @@ void jl_init_types(void)
                             "inlineable",
                             "propagate_inbounds",
                             "pure"),
-                        jl_svec(13,
+                        jl_svec(12,
                             jl_array_any_type,
-                            jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
@@ -2052,7 +2050,7 @@ void jl_init_types(void)
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 13);
+                        0, 1, 12);
 
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,

--- a/src/julia.h
+++ b/src/julia.h
@@ -236,7 +236,6 @@ typedef struct _jl_code_info_t {
     jl_array_t *code;  // Any array of statements
     jl_value_t *codelocs; // Int array of indicies into the line table
     jl_value_t *method_for_inference_limit_heuristics; // optional method used during inference
-    jl_value_t *slottypes; // types of variable slots (or `nothing`)
     jl_value_t *ssavaluetypes;  // types of ssa values (or count of them)
     jl_value_t *linetable; // Table of locations
     jl_array_t *ssaflags; // flags associated with each statement:

--- a/src/method.c
+++ b/src/method.c
@@ -252,7 +252,6 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
     size_t nssavalue = jl_unbox_long(ssavalue_types);
     li->slotnames = jl_alloc_vec_any(nslots);
     jl_gc_wb(li, li->slotnames);
-    li->slottypes = jl_nothing;
     li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
     jl_gc_wb(li, li->slotflags);
     li->ssavaluetypes = jl_box_long(nssavalue);
@@ -316,7 +315,6 @@ JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void)
     src->method_for_inference_limit_heuristics = NULL;
     src->slotnames = NULL;
     src->slotflags = NULL;
-    src->slottypes = NULL;
     src->ssavaluetypes = NULL;
     src->codelocs = jl_nothing;
     src->linetable = jl_nothing;

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -36,7 +36,7 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); verbose_linet
         warntype_type_printer(io, rettype)
         println(io)
         # TODO: static parameter values
-        ir = Core.Compiler.inflate_ir(src, Core.svec())
+        ir = Core.Compiler.inflate_ir(src)
         Base.IRShow.show_ir(io, ir, warntype_type_printer;
                             argnames = Base.sourceinfo_slotnames(src),
                             verbose_linetable = verbose_linetable)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -253,7 +253,6 @@ end
 end
 let ast12474 = code_typed(f12474, Tuple{Float64})
     @test isdispatchelem(ast12474[1][2])
-    @test all(x -> x isa Const || isdispatchelem(Core.Compiler.typesubtract(x, Nothing)), ast12474[1][1].slottypes)
 end
 
 
@@ -490,7 +489,6 @@ function test_inferred_static(arrow::Pair, all_ssa)
     code, rt = arrow
     @test isdispatchelem(rt)
     @test code.inferred
-    @test all(isdispatchelem, code.slottypes)
     for i = 1:length(code.code)
         e = code.code[i]
         test_inferred_static(e)
@@ -537,9 +535,7 @@ for (codetype, all_ssa) in Any[
         (code_typed(g18679, ())[1], false),
         (code_typed(h18679, ())[1], true),
         (code_typed(g19348, (typeof((1, 2.0)),))[1], true)]
-    # make sure none of the slottypes are left as Core.Compiler.Const objects
     code = codetype[1]
-    @test all(x -> isa(x, Type) || isa(x, Const), code.slottypes)
     local notconst(@nospecialize(other)) = true
     notconst(slot::TypedSlot) = @test isa(slot.typ, Type)
     function notconst(expr::Expr)
@@ -1304,7 +1300,7 @@ let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     opt = Core.Compiler.OptimizationState(linfo, Core.Compiler.Params(world))
     # make sure the state of the properties look reasonable
     @test opt.src !== linfo.def.source
-    @test length(opt.src.slotflags) == length(opt.src.slotnames) == length(opt.src.slottypes)
+    @test length(opt.src.slotflags) == length(opt.src.slotnames)
     @test opt.src.ssavaluetypes isa Vector{Any}
     @test !opt.src.inferred
     @test opt.mod === Base

--- a/test/compiler/validation.jl
+++ b/test/compiler/validation.jl
@@ -89,22 +89,6 @@ end
     @test errors[1].kind === Core.Compiler.SLOTFLAGS_MISMATCH
 end
 
-@testset "SLOTTYPES_MISMATCH" begin
-    c = code_typed(f22938, (Int,Int,Int,Int))[1][1]
-    pop!(c.slottypes)
-    errors = Core.Compiler.validate_code(c)
-    @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SLOTTYPES_MISMATCH
-end
-
-@testset "SLOTTYPES_MISMATCH_UNINFERRED" begin
-    c = Core.Compiler.copy_code_info(c0)
-    c.slottypes = 1
-    errors = Core.Compiler.validate_code(c)
-    @test length(errors) == 1
-    @test errors[1].kind === Core.Compiler.SLOTTYPES_MISMATCH_UNINFERRED
-end
-
 @testset "SSAVALUETYPES_MISMATCH" begin
     c = code_typed(f22938, (Int,Int,Int,Int))[1][1]
     empty!(c.ssavaluetypes)

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -20,7 +20,7 @@ Helper to test that every slot is in range after inlining.
 """
 function test_inlined_symbols(func, argtypes)
     src, rettype = code_typed(func, argtypes)[1]
-    nl = length(src.slottypes)
+    nl = length(src.slotnames)
     ast = Expr(:body)
     ast.args = src.code
     walk(ast) do e

--- a/test/show.jl
+++ b/test/show.jl
@@ -1223,7 +1223,7 @@ end
 # Tests for code_typed linetable annotations
 function compute_annotations(f, types)
     src = code_typed(f, types)[1][1]
-    ir = Core.Compiler.inflate_ir(src, Core.svec())
+    ir = Core.Compiler.inflate_ir(src)
     la, lb, ll = Base.IRShow.compute_ir_line_annotations(ir)
     max_loc_method = maximum(length(s) for s in la)
     join((strip(string(a, " "^(max_loc_method-length(a)), b)) for (a, b) in zip(la, lb)), '\n')


### PR DESCRIPTION
This is no longer used by codegen, and so is actually part of the optimizer's ephemeral state.
Consequently the slot type widening logic can also be removed.

Note: this is on top of #27698, so should be rebased after that's merged.