### PR TITLE
Add support for angle bracket ⟨ ⟩

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,9 @@ New language features
 
   * Added `⟂` (`\perp`) operator with comparison precedence ([#24404]).
 
+  * Added angle bracket `⟨ ⟩`, it is lowered to the function call `anglebracket`.
+    You can input them via LaTeX names `\langle`(`⟨`) and `\rangle`(`⟩`) ([#27712]).
+
   * The `missing` singleton object (of type `Missing`) has been added to represent
     missing values ([#24653]). It propagates through standard operators and mathematical functions,
     and implements three-valued logic, similar to SQLs `NULL` and R's `NA`.
@@ -1624,3 +1627,4 @@ Command-line option changes
 [#27212]: https://github.com/JuliaLang/julia/issues/27212
 [#27248]: https://github.com/JuliaLang/julia/issues/27248
 [#27401]: https://github.com/JuliaLang/julia/issues/27401
+[#27712]: https://github.com/JuliaLang/julia/issues/27712

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -193,6 +193,9 @@ export
     =>,
     ∘,
 
+# brackets
+    anglebracket,
+
 # scalar math
     @evalpoly,
     abs,

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -906,4 +906,9 @@ julia> map(splat(+), zip(1:3,4:6))
 """
 splat(f) = args->f(args...)
 
+"""
+    anglebracket(x, y)
+
+The syntax `⟨x, y⟩` calls `anglebracket(x, y)`.
+"""
 function anglebracket end

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -905,3 +905,5 @@ julia> map(splat(+), zip(1:3,4:6))
 ```
 """
 splat(f) = args->f(args...)
+
+function anglebracket end

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -198,6 +198,7 @@ Base.invokelatest
 new
 Base.:(|>)
 Base.:(∘)
+Base.anglebracket
 ```
 
 ## Syntax

--- a/doc/src/base/punctuation.md
+++ b/doc/src/base/punctuation.md
@@ -20,6 +20,7 @@ Extended documentation for mathematical symbols & functions is [here](@ref math-
 | `⊻`         | bitwise xor operator                                                                        |
 | `*`         | multiply, or matrix multiply                                                                |
 | `()`        | the empty tuple                                                                             |
+| `⟨ ⟩`        | the angle bracket (calling [`anglebracket`](@ref))                                          |
 | `~`         | bitwise not operator                                                                        |
 | `\`         | backslash operator                                                                          |
 | `'`         | complex transpose operator Aᴴ                                                               |

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -183,6 +183,7 @@ A few special expressions correspond to calls to functions with non-obvious name
 | `A[i] = x`        | [`setindex!`](@ref)     |
 | `A.n`             | [`getproperty`](@ref Base.getproperty) |
 | `A.n = x`         | [`setproperty!`](@ref Base.setproperty!) |
+| `⟨x, y⟩`           | [`anglebracket`](@ref Base.anglebracket) |
 
 ## [Anonymous Functions](@id man-anonymous-functions)
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -159,7 +159,7 @@
 (define reserved-word? (Set reserved-words))
 
 (define closing-token?
-  (let ((closer? (Set '(else elseif catch finally #\, #\) #\] #\} #\;))))
+  (let ((closer? (Set '(else elseif catch finally #\, #\) #\] #\} #\⟩ #\;))))
     (lambda (tok)
       (or (and (eq? tok 'end) (not end-symbol))
           (closer? tok)
@@ -404,7 +404,7 @@
                (let ((nxt (peek-char port)))
                  (and (not (eof-object? nxt))
                       (or (identifier-start-char? nxt)
-                          (memv nxt '(#\( #\[ #\{ #\@ #\` #\~ #\"))))))
+                          (memv nxt '(#\( #\[ #\{ #\⟨ #\@ #\` #\~ #\"))))))
           (error (string "numeric constant \"" s "\" cannot be implicitly multiplied because it ends with \".\"")))
       ;; n is #f for integers > typemax(UInt64)
       (cond (is-hex-float-literal (numchk n s) (double n))
@@ -530,7 +530,7 @@
 
           ((identifier-start-char? c)     (accum-julia-symbol c port))
 
-          ((string.find "()[]{},;\"`@" c) (read-char port))
+          ((string.find "()[]{}⟨⟩,;\"`@" c) (read-char port))
 
           ((string.find "0123456789" c)   (read-number port #f #f))
 
@@ -712,7 +712,7 @@
     (if (or (number? t) (and (symbol? t) (not (non-standalone-symbol-token? t))))
         (begin (take-token s)
                (let ((nxt (peek-token s)))
-                 (if (or (eqv? nxt #\,) (eqv? nxt #\) ) (eqv? nxt #\}) (eqv? nxt #\]))
+                 (if (or (eqv? nxt #\,) (eqv? nxt #\) ) (eqv? nxt #\}) (eqv? nxt #\]) (eqv? nxt #\⟩))
                      t
                      (begin (ts:put-back! s t spc)
                             (parse-assignment s parse-pair)))))
@@ -1069,7 +1069,7 @@
                                            (initial-reserved-word? (car expr))))))
            ;; to allow x'y as a special case
            #;(and (pair? expr) (memq (car expr) '(|'| |.'|))
-                (not (memv t '(#\( #\[ #\{))))
+                (not (memv t '(#\( #\[ #\{ #\⟨ ))))
            )
        (not (ts:space? s))
        (not (operator? t))
@@ -2359,6 +2359,10 @@
                        ((hcat) `(bracescat (row ,@(cdr vex))))
                        ((comprehension) `(braces ,@(cdr vex)))
                        (else   `(bracescat ,@(cdr vex))))))))
+
+          ((eqv? t #\⟨ )
+           (take-token s)
+           `(anglebracket ,@(parse-call-arglist s #\⟩)))
 
           ;; string literal
           ((eqv? t #\")

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2243,6 +2243,14 @@
    '$
    (lambda (e) (error "\"$\" expression outside quote"))
 
+   'anglebracket
+   (lambda (e)
+     (if (has-parameters? (cdr e))
+         (error "unexpected semicolon inside ⟨ ⟩"))
+     (if (any assignment? (cdr e))
+         (error "unexpected assignment inside ⟨ ⟩"))
+     (expand-forms `(call (top anglebracket) ,@(cdr e))))
+
    'vect
    (lambda (e)
      (if (has-parameters? (cdr e))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1353,6 +1353,14 @@ end
 # issue #25994
 @test Meta.parse("[a\nfor a in b]") == Expr(:comprehension, Expr(:generator, :a, Expr(:(=), :a, :b)))
 
+# pr 27712
+@test Meta.parse("⟨⟩") == Expr(:anglebracket)
+@test Meta.parse("⟨a,b⟩") == Expr(:anglebracket, :a, :b)
+@test Meta.lower(@__MODULE__, :(⟨a;⟩)) == Expr(:error, "unexpected semicolon inside ⟨ ⟩")
+@test_throws ParseError Meta.parse("⟨a b⟩")
+@test_throws ParseError Meta.parse("⟨1 2;3 4⟩")
+@test Meta.parse("f⟨x⟩") == :(f * $(Expr(:anglebracket, :x)))
+
 # Module name cannot be a reserved word.
 @test_throws ParseError Meta.parse("module module end")
 


### PR DESCRIPTION
This is part of https://github.com/JuliaLang/julia/pull/27697, in which we decided to add brackets one by one.

On this pr:

```julia
julia> dump(:( ⟨a,b⟩ ))
Expr
  head: Symbol anglebracket
  args: Array{Any}((2,))
    1: Symbol a
    2: Symbol b
```

Note, this pr implements the angle bracket as function call `anglebracket`. No other functionality is implemented. Especially, 

* do not support `⟨1; 2⟩`
* do not support `⟨1 2⟩`
* do not support `⟨1 2; 3 4⟩`
* do not support `f⟨x⟩`
* did not add any pre-defined methods for it
