### PR TITLE
codegen: avoid emitting more unnecessary addrspace casts

### DIFF
--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -54,6 +54,7 @@ static Value *prepare_call_in(Module *M, Value *Callee)
     return Callee;
 }
 
+// Take an arbitrary untracked value and make it gc-tracked
 static Value *maybe_decay_untracked(IRBuilder<> &irbuilder, Value *V)
 {
     if (V->getType() == T_pjlvalue)
@@ -63,6 +64,7 @@ static Value *maybe_decay_untracked(IRBuilder<> &irbuilder, Value *V)
     return V;
 }
 
+// Take an untracked value and make it tracked (specialized on Constant)
 static Constant *maybe_decay_untracked(IRBuilder<> &irbuilder, Constant *C)
 {
     if (C->getType() == T_pjlvalue)
@@ -72,12 +74,23 @@ static Constant *maybe_decay_untracked(IRBuilder<> &irbuilder, Constant *C)
     return C;
 }
 
+// Take any value and mark that it may be derived from a rooted value
 static Value *decay_derived(IRBuilder<> &irbuilder, Value *V)
 {
     Type *T = V->getType();
     if (cast<PointerType>(T)->getAddressSpace() == AddressSpace::Derived)
         return V;
     // Once llvm deletes pointer element types, we won't need it here any more either.
+    Type *NewT = PointerType::get(cast<PointerType>(T)->getElementType(), AddressSpace::Derived);
+    return irbuilder.CreateAddrSpaceCast(V, NewT);
+}
+
+// Take any value and make it safe to pass to GEP
+static Value *maybe_decay_tracked(IRBuilder<> &irbuilder, Value *V)
+{
+    Type *T = V->getType();
+    if (cast<PointerType>(T)->getAddressSpace() != AddressSpace::Tracked)
+        return V;
     Type *NewT = PointerType::get(cast<PointerType>(T)->getElementType(), AddressSpace::Derived);
     return irbuilder.CreateAddrSpaceCast(V, NewT);
 }
@@ -92,6 +105,7 @@ static Value *mark_callee_rooted(IRBuilder<> &irbuilder, Value *V)
 #define maybe_decay_untracked(V)  maybe_decay_untracked(ctx.builder, (V))
 #define maybe_decay_untracked(V)  maybe_decay_untracked(ctx.builder, (V))
 #define decay_derived(V)          decay_derived(ctx.builder, (V))
+#define maybe_decay_tracked(V)    maybe_decay_tracked(ctx.builder, (V))
 #define mark_callee_rooted(V)     mark_callee_rooted(ctx.builder, (V))
 
 
@@ -746,13 +760,13 @@ static unsigned get_box_tindex(jl_datatype_t *jt, jl_value_t *ut)
 
 static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, ssize_t n, bool gctracked = true)
 {
-    return ctx.builder.CreateGEP(emit_bitcast(ctx, gctracked ? decay_derived(v) : v, T_pprjlvalue),
+    return ctx.builder.CreateGEP(emit_bitcast(ctx, maybe_decay_tracked(v), T_pprjlvalue),
                              ConstantInt::get(T_size, n));
 }
 
-static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, Value *idx, bool gctracked = true)
+static Value *emit_nthptr_addr(jl_codectx_t &ctx, Value *v, Value *idx)
 {
-    return ctx.builder.CreateGEP(emit_bitcast(ctx, gctracked ? decay_derived(v) : v, T_pprjlvalue), idx);
+    return ctx.builder.CreateGEP(emit_bitcast(ctx, maybe_decay_tracked(v), T_pprjlvalue), idx);
 }
 
 static Value *emit_nthptr(jl_codectx_t &ctx, Value *v, ssize_t n, MDNode *tbaa)
@@ -762,17 +776,17 @@ static Value *emit_nthptr(jl_codectx_t &ctx, Value *v, ssize_t n, MDNode *tbaa)
     return tbaa_decorate(tbaa, ctx.builder.CreateLoad(T_prjlvalue, vptr));
 }
 
-static Value *emit_nthptr_recast(jl_codectx_t &ctx, Value *v, Value *idx, MDNode *tbaa, Type *ptype, bool gctracked = true)
+static Value *emit_nthptr_recast(jl_codectx_t &ctx, Value *v, Value *idx, MDNode *tbaa, Type *ptype)
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
-    Value *vptr = emit_nthptr_addr(ctx, v, idx, gctracked);
+    Value *vptr = emit_nthptr_addr(ctx, v, idx);
     return tbaa_decorate(tbaa, ctx.builder.CreateLoad(emit_bitcast(ctx, vptr, ptype)));
 }
 
-static Value *emit_nthptr_recast(jl_codectx_t &ctx, Value *v, ssize_t n, MDNode *tbaa, Type *ptype, bool gctracked = true)
+static Value *emit_nthptr_recast(jl_codectx_t &ctx, Value *v, ssize_t n, MDNode *tbaa, Type *ptype)
 {
     // p = (jl_value_t**)v; *(ptype)&p[n]
-    Value *vptr = emit_nthptr_addr(ctx, v, n, gctracked);
+    Value *vptr = emit_nthptr_addr(ctx, v, n);
     return tbaa_decorate(tbaa, ctx.builder.CreateLoad(emit_bitcast(ctx, vptr, ptype)));
 }
 
@@ -1322,7 +1336,7 @@ static Value *data_pointer(jl_codectx_t &ctx, const jl_cgval_t &x)
             data = get_pointer_to_constant(val, "", *jl_Module);
         }
         else {
-            data = boxed(ctx, x);
+            data = literal_pointer_val(ctx, x.constant);
         }
     }
     return data;
@@ -1413,13 +1427,11 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
                 if (minimum_field_size == 0)
                     break;
             }
+            Value *fldptr = ctx.builder.CreateGEP(maybe_decay_tracked(
+                emit_bitcast(ctx, data_pointer(ctx, strct), T_pprjlvalue)), idx);
             Value *fld = tbaa_decorate(strct.tbaa,
                 maybe_mark_load_dereferenceable(
-                    ctx.builder.CreateLoad(
-                        ctx.builder.CreateBitCast(
-                            ctx.builder.CreateGEP(decay_derived(
-                            emit_bitcast(ctx, data_pointer(ctx, strct), T_pprjlvalue)), idx),
-                            PointerType::get(T_prjlvalue, AddressSpace::Derived))),
+                    ctx.builder.CreateLoad(fldptr),
                     maybe_null, minimum_field_size));
             if (maybe_null)
                 null_pointer_check(ctx, fld);
@@ -1430,7 +1442,7 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
             assert(nfields > 0); // nf == 0 trapped by all_pointers case
             jl_value_t *jt = jl_field_type(stt, 0);
             idx = emit_bounds_check(ctx, strct, (jl_value_t*)stt, idx, ConstantInt::get(T_size, nfields), inbounds);
-            Value *ptr = decay_derived(data_pointer(ctx, strct));
+            Value *ptr = maybe_decay_tracked(data_pointer(ctx, strct));
             if (!stt->mutabl) {
                 // just compute the pointer and let user load it when necessary
                 Type *fty = julia_type_to_llvm(jt);
@@ -1487,7 +1499,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
         return ghostValue(jfty);
     Value *fldv = NULL;
     if (strct.ispointer()) {
-        Value *staddr = decay_derived(data_pointer(ctx, strct));
+        Value *staddr = maybe_decay_tracked(data_pointer(ctx, strct));
         bool isboxed;
         Type *lt = julia_type_to_llvm((jl_value_t*)jt, &isboxed);
         size_t byte_offset = jl_field_offset(jt, idx);
@@ -2374,7 +2386,7 @@ static void emit_setfield(jl_codectx_t &ctx,
         Value *addr = data_pointer(ctx, strct);
         if (byte_offset > 0) {
             addr = ctx.builder.CreateGEP(
-                emit_bitcast(ctx, decay_derived(addr), T_pint8),
+                emit_bitcast(ctx, maybe_decay_tracked(addr), T_pint8),
                 ConstantInt::get(T_size, byte_offset)); // TODO: use emit_struct_gep
         }
         jl_value_t *jfty = jl_svecref(sty->types, idx0);
@@ -2393,7 +2405,7 @@ static void emit_setfield(jl_codectx_t &ctx,
                 return;
             Value *tindex = compute_tindex_unboxed(ctx, rhs_union, jfty);
             tindex = ctx.builder.CreateNUWSub(tindex, ConstantInt::get(T_int8, 1));
-            Value *ptindex = ctx.builder.CreateGEP(T_int8, emit_bitcast(ctx, decay_derived(addr), T_pint8), ConstantInt::get(T_size, fsz - 1));
+            Value *ptindex = ctx.builder.CreateGEP(T_int8, emit_bitcast(ctx, maybe_decay_tracked(addr), T_pint8), ConstantInt::get(T_size, fsz - 1));
             ctx.builder.CreateStore(tindex, ptindex);
             // copy data
             if (!rhs.isghost) {


### PR DESCRIPTION
While looking at #27715, I wanted to simplify our codegen output a bit (avoiding emitting unnecessary addrspace casts), to make sure the mix of addrspace casts were not the direct cause of that issue.