### PR TITLE
fix #27690, quote should disable surrounding `end` indexing context

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -2322,7 +2322,10 @@
                  ':
                  (if (or (ts:space? s) (eqv? nxt #\newline))
                      (error "space not allowed after \":\" used for quoting")
-                     (list 'quote (parse-atom s #f))))))
+                     (list 'quote
+                           ;; being inside quote makes `end` non-special again. issue #27690
+                           (with-bindings ((end-symbol #f))
+                                          (parse-atom s #f)))))))
 
           ;; misplaced =
           ((eq? t '=) (error "unexpected \"=\""))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1368,6 +1368,11 @@ end
 # issue #26717
 @test Meta.lower(@__MODULE__, :( :(:) = 2 )) == Expr(:error, "invalid assignment location \":(:)\"")
 
+# issue #27690
+# previously, this was allowed since it thought `end` was being used for indexing.
+# however the quote should disable that context.
+@test_throws ParseError Meta.parse("Any[:(end)]")
+
 # issue #17781
 let ex = Meta.lower(@__MODULE__, Meta.parse("
     A = function (s, o...)


### PR DESCRIPTION
There turned out to be a small actual bug here in addition to a deprecation issue --- `Any[:(end)]` was incorrectly allowed, while `:(end)` generally is not.