### PR TITLE
Double-escape literal $-s in docstrings

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -20,7 +20,7 @@ cglobal
     CFunction struct
 
 Garbage-collection handle for the return value from `@cfunction`
-when the first argument is annotated with '\$'.
+when the first argument is annotated with '\\\$'.
 Like all `cfunction` handles, it should be passed to `ccall` as a `Ptr{Cvoid}`,
 and will be converted automatically at the call site to the appropriate type.
 
@@ -46,7 +46,7 @@ To pass the return value to a `ccall`, use the argument type `Ptr{Cvoid}` in the
 Note that the argument type tuple must be a literal tuple, and not a tuple-valued variable or expression
 (although it can include a splat expression). And that these arguments will be evaluated in global scope
 during compile-time (not deferred until runtime).
-Adding a '\$' in front of the function argument changes this to instead create a runtime closure
+Adding a '\\\$' in front of the function argument changes this to instead create a runtime closure
 over the local variable `callable`.
 
 See [manual section on ccall and cfunction usage](@ref Calling-C-and-Fortran-Code).

--- a/base/show.jl
+++ b/base/show.jl
@@ -1809,7 +1809,7 @@ used by [`summary`](@ref) to display type information in terms of sequences of
 function calls on objects. `toplevel` is `true` if this is
 the direct call from `summary` and `false` for nested (recursive) calls.
 
-The fallback definition is to print `x` as "::\$(typeof(x))",
+The fallback definition is to print `x` as "::\\\$(typeof(x))",
 representing argument `x` in terms of its type. (The double-colon is
 omitted if `toplevel=true`.) However, you can
 specialize this function for specific types to customize printing.


### PR DESCRIPTION
Literal dollar signs need to be double escaped, since they have special meaning for the Markdown parser (for deprecated LaTeX delimiters and [syntax extension interpolation](https://docs.julialang.org/en/latest/manual/documentation/#Markdown-Syntax-Extensions-1)). Fixes #27654.

I noticed here that the whole handling of the dollar signs in the parser is pretty brittle actually (sometimes it works without escaping, sometimes not etc.), so I am wondering if it would be worth opening an issue for that.

cc @vtjnash 