### PR TITLE
Change eigvals(::Number) to return a scalar

### DIFF
--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -210,10 +210,17 @@ julia> eigvals(diag_matrix)
 """
 eigvals(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true) where T =
     eigvals!(copy_oftype(A, eigtype(T)), permute = permute, scale = scale)
-function eigvals(x::T; kwargs...) where T<:Number
-    val = convert(eigtype(T), x)
-    return imag(val) == 0 ? [real(val)] : [val]
-end
+
+"""
+For a scalar input, `eigvals` will return a scalar.
+
+# Example
+```jldoctest
+julia> eigvals(-2)
+-2
+```
+"""
+eigvals(x::Number; kwargs...) = imag(x) == 0 ? real(x) : x
 
 """
     eigmax(A; permute::Bool=true, scale::Bool=true)

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -221,7 +221,7 @@ end
                         d, v = eigen(asym)
                         @test asym*v[:,1] ≈ d[1]*v[:,1]
                         @test v*Diagonal(d)*transpose(v) ≈ asym
-                        @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1]))
+                        @test isequal(eigvals(asym[1]), eigvals(asym[1:1,1:1])[1])
                         @test abs.(eigen(Symmetric(asym), 1:2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                         @test abs.(eigen(Symmetric(asym), d[1] - 1, (d[2] + d[3])/2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                         @test eigvals(Symmetric(asym), 1:2) ≈ d[1:2]
@@ -234,7 +234,7 @@ end
                     d, v = eigen(aherm)
                     @test aherm*v[:,1] ≈ d[1]*v[:,1]
                     @test v*Diagonal(d)*v' ≈ aherm
-                    @test isequal(eigvals(aherm[1]), eigvals(aherm[1:1,1:1]))
+                    @test isequal(eigvals(aherm[1]), eigvals(aherm[1:1,1:1])[1])
                     @test abs.(eigen(Hermitian(aherm), 1:2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                     @test abs.(eigen(Hermitian(aherm), d[1] - 1, (d[2] + d[3])/2).vectors'v[:,1:2]) ≈ Matrix(I, 2, 2)
                     @test eigvals(Hermitian(aherm), 1:2) ≈ d[1:2]


### PR DESCRIPTION
This is a proposal for how `eigvals` could return a scalar when given a scalar input, in line with what `svdvals` does. (This avoids allocating a vector to store just one element.) See issue JuliaLang/LinearAlgebra.jl#536

Promotion to float is also skipped. Just like `svdvals`, `eigvals` will now return an `Integer` for a scalar `Integer` input. For a `Complex` scalar input, the return type will depend on whether the imaginary component is zero, as before. 

Since Julia allows indexing into and iterating over a scalar as if it were a length-1 vector, existing code that assumes that a vector is returned will likely continue to work.