### PR TITLE
make the `code missing` warning optional with --warn-missing-code

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -23,6 +23,7 @@ struct JLOptions
     check_bounds::Int8
     depwarn::Int8
     warn_overwrite::Int8
+    warn_missing_code::Int8
     can_inline::Int8
     polly::Int8
     fast_math::Int8

--- a/src/gf.c
+++ b/src/gf.c
@@ -1750,7 +1750,8 @@ jl_callptr_t jl_compile_method_internal(jl_method_instance_t **pli, size_t world
             li->invoke = jl_fptr_interpret_call;
             return jl_fptr_interpret_call;
         }
-        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF) {
+        if (jl_options.compile_enabled == JL_OPTIONS_COMPILE_OFF &&
+            jl_options.warn_missing_code == JL_OPTIONS_WARN_MISSING_CODE_ON) {
             jl_printf(JL_STDERR, "code missing for ");
             jl_static_show(JL_STDERR, (jl_value_t*)li);
             jl_printf(JL_STDERR, " : sysimg may not have been built with --compile=all\n");

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -51,7 +51,8 @@ jl_options_t jl_options = { 0,    // quiet
 #endif
                             JL_OPTIONS_CHECK_BOUNDS_DEFAULT, // check_bounds
                             JL_OPTIONS_DEPWARN_ON,    // deprecation warning
-                            0,    // method overwrite warning
+                            JL_OPTIONS_WARN_OVERWRITE_OFF,   // method overwrite warning
+                            JL_OPTIONS_WARN_MISSING_CODE_OFF,
                             1,    // can_inline
                             JL_OPTIONS_POLLY_ON, // polly
                             JL_OPTIONS_FAST_MATH_DEFAULT,
@@ -156,6 +157,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_output_bc,
            opt_depwarn,
            opt_warn_overwrite,
+           opt_warn_missing_code,
            opt_inline,
            opt_polly,
            opt_math_mode,
@@ -210,6 +212,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "output-incremental",required_argument, 0, opt_incremental },
         { "depwarn",         required_argument, 0, opt_depwarn },
         { "warn-overwrite",  required_argument, 0, opt_warn_overwrite },
+        { "warn-missing-code", required_argument, 0, opt_warn_missing_code },
         { "inline",          required_argument, 0, opt_inline },
         { "polly",           required_argument, 0, opt_polly },
         { "math-mode",       required_argument, 0, opt_math_mode },
@@ -541,7 +544,15 @@ restart_switch:
             else if (!strcmp(optarg,"no"))
                 jl_options.warn_overwrite = JL_OPTIONS_WARN_OVERWRITE_OFF;
             else
-                jl_errorf("julia: invalid argument to --warn-overwrite={yes|no|} (%s)", optarg);
+                jl_errorf("julia: invalid argument to --warn-overwrite={yes|no} (%s)", optarg);
+            break;
+        case opt_warn_missing_code:
+            if (!strcmp(optarg,"yes"))
+                jl_options.warn_missing_code = JL_OPTIONS_WARN_MISSING_CODE_ON;
+            else if (!strcmp(optarg,"no"))
+                jl_options.warn_missing_code = JL_OPTIONS_WARN_MISSING_CODE_OFF;
+            else
+                jl_errorf("julia: invalid argument to --warn-missing-code={yes|no} (%s)", optarg);
             break;
         case opt_inline:
             if (!strcmp(optarg,"yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1791,6 +1791,7 @@ typedef struct {
     int8_t check_bounds;
     int8_t depwarn;
     int8_t warn_overwrite;
+    int8_t warn_missing_code;
     int8_t can_inline;
     int8_t polly;
     int8_t fast_math;
@@ -1861,6 +1862,9 @@ JL_DLLEXPORT int jl_generating_output(void);
 
 #define JL_OPTIONS_WARN_OVERWRITE_OFF 0
 #define JL_OPTIONS_WARN_OVERWRITE_ON 1
+
+#define JL_OPTIONS_WARN_MISSING_CODE_OFF 0
+#define JL_OPTIONS_WARN_MISSING_CODE_ON 1
 
 #define JL_OPTIONS_POLLY_ON 1
 #define JL_OPTIONS_POLLY_OFF 0


### PR DESCRIPTION
This warning is only useful in the fairly narrow scenario where (1) you precompile code, (2) you expected compilation to be exhaustive, (3) the JIT is still available. If the JIT weren't available, there'd be another warning or error anyway. So it seems this warning should be off by default, making it possible to use the repl reasonably with --compile=no.