### PR TITLE
Add new gitignore pattern for CA certificate store (*.pem) files in 'deps' folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 *.ji
 
 .DS_Store
+
+/deps/*.pem


### PR DESCRIPTION
@StefanKarpinski 

As requested in #26983, `.gitignore` has been updated to ignore *.pem files in the `deps` folder.