### PR TITLE
Add a negate ignore pattern for checksums of CA certificate store files.

### DIFF
--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -4,3 +4,6 @@
 
 # Ignore CA certificate store files
 *.pem
+
+# Include checksums of CA certificate store files
+!/checksums/*.pem


### PR DESCRIPTION
@staticfloat @StefanKarpinski 
As discussed in #27734, @staticfloat pushed commit 536d2c0 which adds a pattern for `*.pem` files.

This inadvertently causes git to ignore the file checksums of the CA certificate files in the `checksums` folder.

As a result, this pull request adds a negated pattern to allow for `/checksums/*.pem`.