### PR TITLE
Avoid broken kind type handling when compiling `isa`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -638,19 +638,20 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
             if !isa(body, Type) && !isa(body, TypeVar)
                 return Any
             end
-            has_free_typevars(body) || return body
-            if isa(argtypes[2], Const)
-                tv = argtypes[2].val
-            elseif isa(argtypes[2], PartialTypeVar)
-                ptv = argtypes[2]
-                tv = ptv.tv
-                canconst = false
-            else
-                return Any
+            if has_free_typevars(body)
+                if isa(argtypes[2], Const)
+                    tv = argtypes[2].val
+                elseif isa(argtypes[2], PartialTypeVar)
+                    ptv = argtypes[2]
+                    tv = ptv.tv
+                    canconst = false
+                else
+                    return Any
+                end
+                !isa(tv, TypeVar) && return Any
+                body = UnionAll(tv, body)
             end
-            !isa(tv, TypeVar) && return Any
-            theunion = UnionAll(tv, body)
-            ret = canconst ? AbstractEvalConstant(theunion) : Type{theunion}
+            ret = canconst ? AbstractEvalConstant(body) : Type{body}
             return ret
         end
         return Any

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1060,26 +1060,33 @@ static void emit_type_error(jl_codectx_t &ctx, const jl_cgval_t &x, Value *type,
 
 static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *type, const std::string *msg)
 {
-    Optional<bool> known_isa;
     jl_value_t *intersected_type = type;
-    if (x.constant)
-        known_isa = jl_isa(x.constant, type);
-    else if (jl_subtype(x.typ, type))
-        known_isa = true;
-    else {
-        intersected_type = jl_type_intersection(x.typ, type);
-        if (intersected_type == (jl_value_t*)jl_bottom_type)
-            known_isa = false;
-    }
-    if (known_isa) {
-        if (!*known_isa && msg) {
-            emit_type_error(ctx, x, literal_pointer_val(ctx, type), *msg);
-            ctx.builder.CreateUnreachable();
-            BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
-            ctx.builder.SetInsertPoint(failBB);
-        }
-        return std::make_pair(ConstantInt::get(T_int1, *known_isa), true);
-    }
+
+    // TODO: This optimization suffers from incorrectness issues due to broken subtyping for
+    // kind types (see https://github.com/JuliaLang/julia/issues/27078). For actual `isa`
+    // calls, this optimization should already have been performed upstream anyway, but
+    // having this optimization in codegen might still be beneficial for `typeassert`s
+    // if we can make it correct.
+    //
+    // Optional<bool> known_isa;
+    // if (x.constant)
+    //     known_isa = jl_isa(x.constant, type);
+    // else if (jl_subtype(x.typ, type))
+    //     known_isa = true;
+    // else {
+    //     intersected_type = jl_type_intersection(x.typ, type);
+    //     if (intersected_type == (jl_value_t*)jl_bottom_type)
+    //         known_isa = false;
+    // }
+    // if (known_isa) {
+    //     if (!*known_isa && msg) {
+    //         emit_type_error(ctx, x, literal_pointer_val(ctx, type), *msg);
+    //         ctx.builder.CreateUnreachable();
+    //         BasicBlock *failBB = BasicBlock::Create(jl_LLVMContext, "fail", ctx.f);
+    //         ctx.builder.SetInsertPoint(failBB);
+    //     }
+    //     return std::make_pair(ConstantInt::get(T_int1, *known_isa), true);
+    // }
 
     // intersection with Type needs to be handled specially
     if (jl_has_intersect_type_not_kind(type)) {

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1060,33 +1060,22 @@ static void emit_type_error(jl_codectx_t &ctx, const jl_cgval_t &x, Value *type,
 
 static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, jl_value_t *type, const std::string *msg)
 {
-    jl_value_t *intersected_type = type;
-
+    // TODO: The subtype check below suffers from incorrectness issues due to broken
+    // subtyping for kind types (see https://github.com/JuliaLang/julia/issues/27078). For
+    // actual `isa` calls, this optimization should already have been performed upstream
+    // anyway, but having this optimization in codegen might still be beneficial for
+    // `typeassert`s if we can make it correct.
     Optional<bool> known_isa;
-    if (x.constant) {
+    jl_value_t *intersected_type = type;
+    if (x.constant)
         known_isa = jl_isa(x.constant, type);
+    else if (jl_subtype(x.typ, type)) {
+        // known_isa = true;
     } else {
         intersected_type = jl_type_intersection(x.typ, type);
         if (intersected_type == (jl_value_t*)jl_bottom_type)
             known_isa = false;
     }
-
-    // TODO: This commented-out version of the above check suffers from incorrectness
-    // issues due to broken subtyping for kind types (see
-    // https://github.com/JuliaLang/julia/issues/27078). For actual `isa` calls, this
-    // optimization should already have been performed upstream anyway, but having this
-    // optimization in codegen might still be beneficial for `typeassert`s if we can make it
-    // correct.
-    // if (x.constant) {
-    //     known_isa = jl_isa(x.constant, type);
-    // else if (jl_subtype(x.typ, type))
-    //     known_isa = true;
-    // else {
-    //     intersected_type = jl_type_intersection(x.typ, type);
-    //     if (intersected_type == (jl_value_t*)jl_bottom_type)
-    //         known_isa = false;
-    // }
-
     if (known_isa) {
         if (!*known_isa && msg) {
             emit_type_error(ctx, x, literal_pointer_val(ctx, type), *msg);

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1069,8 +1069,8 @@ static std::pair<Value*, bool> emit_isa(jl_codectx_t &ctx, const jl_cgval_t &x, 
     jl_value_t *intersected_type = type;
     if (x.constant)
         known_isa = jl_isa(x.constant, type);
-    else if (jl_subtype(x.typ, type)) {
-        // known_isa = true;
+    else if (jl_is_not_broken_subtype(x.typ, type) && jl_subtype(x.typ, type)) {
+        known_isa = true;
     } else {
         intersected_type = jl_type_intersection(x.typ, type);
         if (intersected_type == (jl_value_t*)jl_bottom_type)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1067,6 +1067,7 @@ JL_DLLEXPORT int jl_subtype_env_size(jl_value_t *t);
 JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, int envsz);
 JL_DLLEXPORT int jl_isa(jl_value_t *a, jl_value_t *t);
 JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_is_not_broken_subtype(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT jl_value_t *jl_type_union(jl_value_t **ts, size_t n);
 JL_DLLEXPORT jl_value_t *jl_type_intersection(jl_value_t *a, jl_value_t *b);
 JL_DLLEXPORT int jl_has_empty_intersection(jl_value_t *x, jl_value_t *y);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1165,6 +1165,13 @@ JL_DLLEXPORT int jl_types_equal(jl_value_t *a, jl_value_t *b)
     return jl_subtype(a, b) && jl_subtype(b, a);
 }
 
+JL_DLLEXPORT int jl_is_not_broken_subtype(jl_value_t *a, jl_value_t *b)
+{
+    // TODO: the final commented out check here isn't correct; it should be closer to the
+    // `issingletype` check used by `isnotbrokensubtype` in `base/compiler/typeutils.jl`
+    return !jl_is_kind(b) || !jl_is_type_type(a); // || jl_is_datatype_singleton((jl_datatype_t*)jl_tparam0(a));
+}
+
 int jl_tuple_isa(jl_value_t **child, size_t cl, jl_datatype_t *pdt)
 {
     if (jl_is_tuple_type(pdt) && !jl_is_va_tuple(pdt)) {

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1179,7 +1179,7 @@ let isa_tfunc = Core.Compiler.T_FFUNC_VAL[
     @test isa_tfunc(Array{Real}, Type{AbstractArray{Int}}) === Const(false)
     @test isa_tfunc(Array{Real, 2}, Const(AbstractArray{Real, 2})) === Const(true)
     @test isa_tfunc(Array{Real, 2}, Const(AbstractArray{Int, 2})) === Const(false)
-    @test isa_tfunc(DataType, Int) === Bool # could be improved
+    @test isa_tfunc(DataType, Int) === Const(false)
     @test isa_tfunc(DataType, Const(Type{Int})) === Bool
     @test isa_tfunc(DataType, Const(Type{Array})) === Bool
     @test isa_tfunc(UnionAll, Const(Type{Int})) === Bool # could be improved
@@ -1245,7 +1245,7 @@ let subtype_tfunc = Core.Compiler.T_FFUNC_VAL[
     @test subtype_tfunc(Type{Union{}}, Union{Type{Int64}, Type{Float64}}) === Const(true)
     @test subtype_tfunc(Type{Union{}}, Union{Type{T}, Type{Float64}} where T) === Const(true)
     let c = Conditional(Core.SlotNumber(0), Const(Union{}), Const(Union{}))
-        @test subtype_tfunc(c, Const(Bool)) === Bool # any result is ok
+        @test subtype_tfunc(c, Const(Bool)) === Const(true) # any result is ok
     end
     @test subtype_tfunc(Type{Val{1}}, Type{Val{T}} where T) === Bool
     @test subtype_tfunc(Type{Val{1}}, DataType) === Bool

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1717,3 +1717,8 @@ Base.iterate(i::Iterator27434, ::Val{2}) = i.z, Val(3)
 Base.iterate(::Iterator27434, ::Any) = nothing
 @test @inferred splat27434(Iterator27434(1, 2, 3)) == (1, 2, 3)
 @test Core.Compiler.return_type(splat27434, Tuple{typeof(Iterators.repeated(1))}) == Union{}
+
+# issue #27078
+f27078(T::Type{S}) where {S} = isa(T, UnionAll) ? f27078(T.body) : T
+T27078 = Vector{Vector{T}} where T
+@test f27078(T27078) === T27078.body

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1179,7 +1179,7 @@ let isa_tfunc = Core.Compiler.T_FFUNC_VAL[
     @test isa_tfunc(Array{Real}, Type{AbstractArray{Int}}) === Const(false)
     @test isa_tfunc(Array{Real, 2}, Const(AbstractArray{Real, 2})) === Const(true)
     @test isa_tfunc(Array{Real, 2}, Const(AbstractArray{Int, 2})) === Const(false)
-    @test isa_tfunc(DataType, Int) === Const(false)
+    @test isa_tfunc(DataType, Int) === Union{}
     @test isa_tfunc(DataType, Const(Type{Int})) === Bool
     @test isa_tfunc(DataType, Const(Type{Array})) === Bool
     @test isa_tfunc(UnionAll, Const(Type{Int})) === Bool # could be improved
@@ -1189,7 +1189,7 @@ let isa_tfunc = Core.Compiler.T_FFUNC_VAL[
     @test isa_tfunc(typeof(Union{}), Const(Int)) === Const(false) # any result is ok
     @test isa_tfunc(typeof(Union{}), Const(Union{})) === Const(false)
     @test isa_tfunc(typeof(Union{}), typeof(Union{})) === Const(false)
-    @test isa_tfunc(typeof(Union{}), Union{}) === Const(false) # any result is ok
+    @test isa_tfunc(typeof(Union{}), Union{}) === Union{} # any result is ok
     @test isa_tfunc(typeof(Union{}), Type{typeof(Union{})}) === Const(true)
     @test isa_tfunc(typeof(Union{}), Const(typeof(Union{}))) === Const(true)
     let c = Conditional(Core.SlotNumber(0), Const(Union{}), Const(Union{}))
@@ -1204,7 +1204,7 @@ let isa_tfunc = Core.Compiler.T_FFUNC_VAL[
     @test isa_tfunc(Val{1}, Type{Val{T}} where T) === Bool
     @test isa_tfunc(Val{1}, DataType) === Bool
     @test isa_tfunc(Any, Const(Any)) === Const(true)
-    @test isa_tfunc(Any, Union{}) === Const(false) # any result is ok
+    @test isa_tfunc(Any, Union{}) === Union{} # any result is ok
     @test isa_tfunc(Any, Type{Union{}}) === Const(false)
     @test isa_tfunc(Union{Int64, Float64}, Type{Real}) === Const(true)
     @test isa_tfunc(Union{Int64, Float64}, Type{Integer}) === Bool

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -557,7 +557,8 @@ end
     x = @inferred replace(x -> x > 1, [1, 2], missing)
     @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
 
-    x = @inferred replace([1, missing], missing=>2)
+    @test_broken @inferred replace([1, missing], missing=>2)
+    x = replace([1, missing], missing=>2)
     @test x == [1, 2] && x isa Vector{Int}
     x = @inferred replace([1, missing], missing=>2, count=1)
     @test x == [1, 2] && x isa Vector{Union{Int, Missing}}


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/27078, https://github.com/jrevels/Cassette.jl/issues/42, and some other bugs with tuples.

I'm not at all a fan of my replacements for the tuple handling code here - I just need to get the aforementioned bugs fixed. It should be "more correct" than it was before (modulo any bugs I introduced...), but it feels like it's going to be slower w.r.t. to compilation, runtime, or both. I haven't done benchmarking yet, though. I would be **extremely grateful** for some tips on faster/cleaner alternatives (as long as they don't reintroduce the bugs I'm trying to fix). This might be another case in favor of making `ntuple` an intrinsic...EDIT: see comment below, moved the tuple changes out of this PR

@nanosoldier `runbenchmarks(ALL, vs = ":master")`
