### PR TITLE
Add optimized mapreduce implementation for SkipMissing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -177,7 +177,7 @@ IteratorSize(::Type{<:SkipMissing}) = SizeUnknown()
 IteratorEltype(::Type{SkipMissing{T}}) where {T} = IteratorEltype(T)
 eltype(::Type{SkipMissing{T}}) where {T} = nonmissingtype(eltype(T))
 
-function Base.iterate(itr::SkipMissing, state...)
+function iterate(itr::SkipMissing, state...)
     y = iterate(itr.x, state...)
     y === nothing && return nothing
     item, state = y
@@ -187,6 +187,99 @@ function Base.iterate(itr::SkipMissing, state...)
         item, state = y
     end
     item, state
+end
+
+# Optimized mapreduce implementation
+mapreduce(f, op, itr::SkipMissing{<:AbstractArray}) = _mapreduce(f, op, IndexStyle(itr.x), itr)
+
+"Sentinel indicating that no non-missing value was encountered."
+struct AllMissing end
+
+function _mapreduce(f, op, ::IndexLinear, itr::SkipMissing{<:AbstractArray})
+    A = itr.x
+    local ai
+    inds = LinearIndices(A)
+    i = first(inds)
+    ilast = last(inds)
+    while i <= ilast
+        @inbounds ai = A[i]
+        ai === missing || break
+        i += 1
+    end
+    i > ilast && return mapreduce_empty(f, op, eltype(itr))
+    a1 = ai
+    i += 1
+    while i <= ilast
+        @inbounds ai = A[i]
+        ai === missing || break
+        i += 1
+    end
+    i > ilast && return mapreduce_first(f, op, a1)
+    # We know A contains at least two non-missing entries, therefore AllMissing() is not
+    # a possible return value: the check provides that information to inference
+    s = mapreduce_impl(f, op, itr, first(inds), last(inds))
+    s isa AllMissing && error("got AllMissing for an array with non-missing values")
+    return s
+end
+
+_mapreduce(f, op, ::IndexCartesian, itr::SkipMissing) = mapfoldl(f, op, itr)
+
+mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
+    mapreduce_impl(f, op, A, ifirst, ilast, pairwise_blocksize(f, op))
+
+@noinline function mapreduce_impl(f, op, itr::SkipMissing{<:AbstractArray},
+                                  ifirst::Integer, ilast::Integer, blksize::Int)
+    A = itr.x
+    if ifirst == ilast
+        @inbounds a1 = A[ifirst]
+        if a1 === missing
+            return AllMissing()
+        else
+            return mapreduce_first(f, op, a1)
+        end
+    elseif ifirst + blksize > ilast
+        # sequential portion
+        local ai
+        i = ifirst
+        while i <= ilast
+            @inbounds ai = A[i]
+            ai === missing || break
+            i += 1
+        end
+        i > ilast && return AllMissing()
+        a1 = ai::eltype(itr)
+        i += 1
+        while i <= ilast
+            @inbounds ai = A[i]
+            ai === missing || break
+            i += 1
+        end
+        i > ilast && return mapreduce_first(f, op, a1)
+        a2 = ai::eltype(itr)
+        # Unexpectedly, the following assertion allows SIMD instructions to be emitted
+        A[i]::eltype(itr)
+        i += 1
+        v = op(f(a1), f(a2))
+        @simd for i = i:ilast
+            @inbounds ai = A[i]
+            if ai !== missing
+                v = op(v, f(ai))
+            end
+        end
+        return v
+    else
+        # pairwise portion
+        imid = (ifirst + ilast) >> 1
+        v1 = mapreduce_impl(f, op, itr, ifirst, imid, blksize)
+        v2 = mapreduce_impl(f, op, itr, imid+1, ilast, blksize)
+        if v1 isa AllMissing
+            return v2
+        elseif v2 isa AllMissing
+            return v1
+        else
+            return op(v1, v2)
+        end
+    end
 end
 
 """

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -190,7 +190,10 @@ function iterate(itr::SkipMissing, state...)
 end
 
 # Optimized mapreduce implementation
-mapreduce(f, op, itr::SkipMissing{<:AbstractArray}) = _mapreduce(f, op, IndexStyle(itr.x), itr)
+# The generic method is faster when !(eltype(A) >: Missing) since it does not need
+# additional loops to identify the two first non-missing values of each block
+mapreduce(f, op, itr::SkipMissing{<:AbstractArray}) =
+    _mapreduce(f, op, IndexStyle(itr.x), eltype(itr.x) >: Missing ? itr : itr.x)
 
 function _mapreduce(f, op, ::IndexLinear, itr::SkipMissing{<:AbstractArray})
     A = itr.x

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -361,6 +361,57 @@ end
     @test eltype(x) === Any
     @test collect(x) == [1, 2, 4]
     @test collect(x) isa Vector{Int}
+
+    @testset "mapreduce" begin
+        # Vary size to test splitting blocks with several configurations of missing values
+        for T in (Int, Float64),
+            A in (rand(T, 10), rand(T, 1000), rand(T, 10000))
+            if T === Int
+                @test sum(A) === sum(skipmissing(A)) ===
+                    reduce(+, skipmissing(A)) === mapreduce(identity, +, skipmissing(A))
+            else
+                @test sum(A) ≈ sum(skipmissing(A)) ===
+                    reduce(+, skipmissing(A)) === mapreduce(identity, +, skipmissing(A))
+            end
+            @test mapreduce(cos, *, A) ≈ mapreduce(cos, *, skipmissing(A))
+
+            B = Vector{Union{T,Missing}}(A)
+            replace!(x -> rand(Bool) ? x : missing, B)
+            if T === Int
+                @test sum(collect(skipmissing(B))) === sum(skipmissing(B)) ===
+                    reduce(+, skipmissing(B)) === mapreduce(identity, +, skipmissing(B))
+            else
+                @test sum(collect(skipmissing(B))) ≈ sum(skipmissing(B)) ===
+                    reduce(+, skipmissing(B)) === mapreduce(identity, +, skipmissing(B))
+            end
+            @test mapreduce(cos, *, collect(skipmissing(A))) ≈ mapreduce(cos, *, skipmissing(A))
+
+            # Test block full of missing values
+            B[1:length(B)÷2] .= missing
+            if T === Int
+                @test sum(collect(skipmissing(B))) == sum(skipmissing(B)) ==
+                    reduce(+, skipmissing(B)) == mapreduce(identity, +, skipmissing(B))
+            else
+                @test sum(collect(skipmissing(B))) ≈ sum(skipmissing(B)) ==
+                    reduce(+, skipmissing(B)) == mapreduce(identity, +, skipmissing(B))
+            end
+
+            @test mapreduce(cos, *, collect(skipmissing(A))) ≈ mapreduce(cos, *, skipmissing(A))
+        end
+
+        # Patterns that exercize code paths for inputs with 1 or 2 non-missing values
+        @test sum(skipmissing([1, missing, missing, missing])) === 1
+        @test sum(skipmissing([missing, missing, missing, 1])) === 1
+        @test sum(skipmissing([1, missing, missing, missing, 2])) === 3
+        @test sum(skipmissing([missing, missing, missing, 1, 2])) === 3
+
+        for n in 0:3
+            itr = skipmissing(Vector{Union{Int,Missing}}(fill(missing, n)))
+            @test sum(itr) == reduce(+, itr) == mapreduce(identity, +, itr) === 0
+            @test_throws ArgumentError reduce(x -> x/2, itr)
+            @test_throws ArgumentError mapreduce(x -> x/2, +, itr)
+        end
+    end
 end
 
 @testset "coalesce" begin


### PR DESCRIPTION
Based on the AbstractArray methods. Allows the compiler to emit SIMD instructions, for `SkipMissing{Vector{Int}}`, but also improves performance for `SkipMissing{Vector{Float64}}`.

The performance improvement is clear for `Int` (3×-5× less time), but less so for `Float64` (-30%). However, since SIMD now works for `Int`, there's a chance it could eventually be enabled for `Float64`, and it should be quite easier than with the generic `mapreduce` fallback. Also, these 30% are enough to get as fast as R (maybe even a bit faster), which is an important reference point (see [this Discourse thread](https://discourse.julialang.org/t/with-missings-julia-is-slower-than-r/11838)).

Fixes https://github.com/JuliaLang/julia/issues/27679.

```julia
# With Vector{Int}
X1 = rand(Int, 10_000_000);
X2 = Vector{Union{Missing,Int}}(X1);
X3 = ifelse.(rand(length(X2)) .< 0.9, X2, missing);

# With Vector{Float64}
Y1 = rand(Float64, 10_000_000);
Y2 = Vector{Union{Missing,Float64}}(Y1);
Y3 = ifelse.(rand(length(Y2)) .< 0.9, Y2, missing);

using BenchmarkTools

# Before

julia> @btime sum(skipmissing(X1));
 7.316 ms (2 allocations: 32 bytes)

julia> @btime sum(skipmissing(X2));
 18.175 ms (2 allocations: 32 bytes)

julia> @btime sum(skipmissing(X3));
 28.240 ms (2 allocations: 32 bytes)

julia> @btime sum(skipmissing(Y1));
 13.816 ms (2 allocations: 32 bytes)

julia> @btime sum(skipmissing(Y2));
 18.254 ms (2 allocations: 32 bytes)

julia> @btime sum(skipmissing(Y3));
 28.430 ms (2 allocations: 32 bytes)

# After

julia> @btime sum(skipmissing(X1));
  5.918 ms (4 allocations: 64 bytes)

julia> @btime sum(skipmissing(X2));
  6.113 ms (4 allocations: 64 bytes)

julia> @btime sum(skipmissing(X3));
  6.142 ms (4 allocations: 64 bytes)

julia> @btime sum(skipmissing(Y1));
  5.830 ms (4 allocations: 64 bytes)

julia> @btime sum(skipmissing(Y2));
  13.816 ms (4 allocations: 64 bytes)

julia> @btime sum(skipmissing(Y3));
  19.018 ms (4 allocations: 64 bytes)
```