### PR TITLE
Random: make randjump(m, 2) == randjump(m, 2)

### DIFF
--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -498,8 +498,8 @@ let mta = MersenneTwister(42), mtb = MersenneTwister(42)
     @test sprand(mta,10,10,0.3) == sprand(mtb,10,10,0.3)
 end
 
-# test MersenneTwister polynomial generation and jump
-let seed = rand(UInt)
+@testset "MersenneTwister polynomial generation and jump" begin
+    seed = rand(UInt)
     mta = MersenneTwister(seed)
     mtb = MersenneTwister(seed)
     step = 25000*2
@@ -519,6 +519,11 @@ let seed = rand(UInt)
 
     for x in (rand(mts[k], Float64) for j=1:step, k=1:size)
         @test rand(mtb, Float64) == x
+    end
+
+    @testset "generated RNGs are in a deterministic state (relatively to ==)" begin
+        m = MersenneTwister()
+        @test randjump(m, 25000, 2) == randjump(m, 25000, 2)
     end
 end
 


### PR DESCRIPTION
This was in practice true, in that the produced RNGs were generating equal streams, but the `==` operator didn't recognize it because of uninitialized memory.