### PR TITLE
[WIP] Seperate Channel into two types; BufferedChannel and UnbufferedChannel

### DIFF
--- a/stdlib/Distributed/src/precompile.jl
+++ b/stdlib/Distributed/src/precompile.jl
@@ -172,8 +172,6 @@ precompile(Tuple{typeof(Distributed.call_on_owner), typeof(Distributed.put_ref),
 precompile(Tuple{typeof(Distributed.put_ref), Distributed.RRID, Distributed.WorkerPool})
 precompile(Tuple{typeof(Base.put!), Distributed.RemoteValue, Distributed.WorkerPool})
 precompile(Tuple{typeof(Base.put!), Base.Channel{Any}, Distributed.WorkerPool})
-precompile(Tuple{typeof(Base.put_buffered), Base.Channel{Any}, Distributed.WorkerPool})
-precompile(Tuple{typeof(Base.put_unbuffered), Base.Channel{Any}, Distributed.WorkerPool})
 precompile(Tuple{typeof(Base.push!), Distributed.WorkerPool, Int64})
 precompile(Tuple{typeof(Serialization.serialize), Distributed.ClusterSerializer{Sockets.TCPSocket}, Distributed.RemoteDoMsg})
 precompile(Tuple{typeof(Serialization.serialize), Distributed.ClusterSerializer{Sockets.TCPSocket}, typeof(Distributed.set_valid_processes)})


### PR DESCRIPTION
I mostly wanted to see what this looked like.
I'm not really interested one way or the other in having it merged in the 0.7 timeframe.


The current channel implementation is already basically 2 types.
They have different fields, and different implementations.
And I would argue even different behavour.

But currently the switch between them is keyed off the value of a field (that can only be set at contruction time).
This changes it so it is given by a type.

This PR is currently broken,
I've notyet tracked down what is trying to construct a channel of size zero. to switch it over.
