### PR TITLE
Record the module=>file associations in stdlib

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -532,10 +532,17 @@ let
     print_time = (mod, t) -> (print(rpad(string(mod) * "  ", maxlen + 3, "─")); Base.time_print(t * 10^9); println())
     print_time(Base, (Base.end_base_include - Base.start_base_include) * 10^(-9))
 
+    Base._track_dependencies[] = true
     Base.tot_time_stdlib[] = @elapsed for stdlib in stdlibs
         tt = @elapsed Base.require(Base, stdlib)
         print_time(stdlib, tt)
     end
+    for dep in Base._require_dependencies
+        dep[3] == 0.0 && continue
+        push!(Base._included_files, dep[1:2])
+    end
+    empty!(Base._require_dependencies)
+    Base._track_dependencies[] = false
 
     print_time("Stdlibs total", Base.tot_time_stdlib[])
 end


### PR DESCRIPTION
Since we record these for Base and also write them into the `.ji` files for precompiled packages,
let's also do it for stdlibs. This appends them to the end of `Base._included_files`. I think that's not too much of a misnomer since Base currently contains the stdlibs. But let's see what others think.

Companion PR: https://github.com/timholy/Revise.jl/pull/104. That PR works for `Core.Compiler` without this PR, except on Travis where you don't have a full a git repo these tests are disabled (which is why that PR passes tests). You need this just for stdlibs.