### PR TITLE
fix #27710, scope error with static param. and variable name conflicts

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1447,3 +1447,11 @@ f27129(x = 1) = (@Base._inline_meta; x)
 for meth in methods(f27129)
     @test ccall(:jl_uncompress_ast, Any, (Any, Any), meth, meth.source).inlineable
 end
+
+# issue #27710
+struct Foo27710{T} end
+function test27710()
+    types(::Foo27710{T}) where T = T
+    T = types(Foo27710{Int64}())
+end
+@test test27710() === Int64


### PR DESCRIPTION
The basic issue here was that `resolve-scopes` was not aware of static parameters. Typically it would mark them as `outerref`, but if an enclosing scope had a variable with the same name then it wouldn't. I decided that static parameters are more local, so I switched to always leaving them as bare symbols and adding them to a lambda's local environment.