### PR TITLE
adds `printstyled` to NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -551,6 +551,9 @@ Library improvements
   * `get(io, :color, false)` can now be used to query whether a stream `io` supports
     [ANSI color codes](https://en.wikipedia.org/wiki/ANSI_escape_code) ([#25067]),
     rather than using the undocumented `Base.have_color` global flag.
+    
+  * `print_with_color` has been deprecated in favor of
+    `printstyled([io], xs...; bold=false, color=:normal)` for printing styled text ([#25522]).
 
   * Functions `first` and `last` now accept `nchar` argument for `AbstractString`.
     If this argument is used they return a string consisting of first/last `nchar`

--- a/NEWS.md
+++ b/NEWS.md
@@ -551,7 +551,7 @@ Library improvements
   * `get(io, :color, false)` can now be used to query whether a stream `io` supports
     [ANSI color codes](https://en.wikipedia.org/wiki/ANSI_escape_code) ([#25067]),
     rather than using the undocumented `Base.have_color` global flag.
-    
+
   * `print_with_color` has been deprecated in favor of
     `printstyled([io], xs...; bold=false, color=:normal)` for printing styled text ([#25522]).
 


### PR DESCRIPTION
the `needs_news` tag can be removed from #25522

[ci skip]