### PR TITLE
Update LibGit2 findfirst test

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -158,8 +158,8 @@ end
 
 @testset "Check library features" begin
     f = LibGit2.features()
-    @test findfirst(isequal(LibGit2.Consts.FEATURE_SSH), f) > 0
-    @test findfirst(isequal(LibGit2.Consts.FEATURE_HTTPS), f) > 0
+    @test findfirst(isequal(LibGit2.Consts.FEATURE_SSH), f) !== nothing
+    @test findfirst(isequal(LibGit2.Consts.FEATURE_HTTPS), f) !== nothing
 end
 
 @testset "OID" begin


### PR DESCRIPTION
Updates these tests to expect `nothing` upon a failure instead of `0`.