### PR TITLE
Workaround for `git_tree_walk` raising an exception

### DIFF
--- a/stdlib/LibGit2/src/tree.jl
+++ b/stdlib/LibGit2/src/tree.jl
@@ -167,6 +167,10 @@ function Base.getindex(tree::GitTree, target::AbstractString)
         if path == target
             # we found the target, save the oid and stop the walk
             oid = entryid(entry)
+            # workaround for issue: https://github.com/libgit2/libgit2/issues/4693
+            ccall((:giterr_set_str, :libgit2), Cvoid,
+                  (Cint, Cstring), Cint(Error.Callback),
+                  "git_tree_walk callback returned -1")
             return -1
         elseif entrytype(entry) == GitTree && !startswith(target, path)
             # this subtree isn't relevant, so skip it


### PR DESCRIPTION
Issue noticed in https://github.com/timholy/Revise.jl/pull/104. This PR works around [the libgit2 issue](https://github.com/libgit2/libgit2/issues/4693) by emulating the behaviour of [`giterr_set_after_callback_function`](https://github.com/libgit2/libgit2/blob/26f5d36d2f14dc1d711ed0a2c844ef4d7887a9b3/src/common.h#L115-L133).