### PR TITLE
avoid kind type dispatch bugs in tuple_type_head and tuple_type_tail

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -141,7 +141,7 @@ end
 argtail(x, rest...) = rest
 tail(x::Tuple) = argtail(x...)
 
-tuple_type_head(T::Type) = fieldtype(T::Type{<:Tuple}, 1)
+tuple_type_head(T::Type) = (@_pure_meta; fieldtype(T::Type{<:Tuple}, 1))
 
 function tuple_type_tail(T::Type)
     @_pure_meta

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -141,31 +141,21 @@ end
 argtail(x, rest...) = rest
 tail(x::Tuple) = argtail(x...)
 
-# TODO: a better / more infer-able definition would pehaps be
-#   tuple_type_head(T::Type) = fieldtype(T::Type{<:Tuple}, 1)
-tuple_type_head(T::UnionAll) = (@_pure_meta; UnionAll(T.var, tuple_type_head(T.body)))
-function tuple_type_head(T::Union)
-    @_pure_meta
-    return Union{tuple_type_head(T.a), tuple_type_head(T.b)}
-end
-function tuple_type_head(T::DataType)
-    @_pure_meta
-    T.name === Tuple.name || throw(MethodError(tuple_type_head, (T,)))
-    return unwrapva(T.parameters[1])
-end
+tuple_type_head(T::Type) = fieldtype(T::Type{<:Tuple}, 1)
 
-tuple_type_tail(T::UnionAll) = (@_pure_meta; UnionAll(T.var, tuple_type_tail(T.body)))
-function tuple_type_tail(T::Union)
+function tuple_type_tail(T::Type)
     @_pure_meta
-    return Union{tuple_type_tail(T.a), tuple_type_tail(T.b)}
-end
-function tuple_type_tail(T::DataType)
-    @_pure_meta
-    T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))
-    if isvatuple(T) && length(T.parameters) == 1
-        return T
+    if isa(T, UnionAll)
+        return UnionAll(T.var, tuple_type_tail(T.body))
+    elseif isa(T, Union)
+        return Union{tuple_type_tail(T.a), tuple_type_tail(T.b)}
+    else
+        T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))
+        if isvatuple(T) && length(T.parameters) == 1
+            return T
+        end
+        return Tuple{argtail(T.parameters...)...}
     end
-    return Tuple{argtail(T.parameters...)...}
 end
 
 tuple_type_cons(::Type, ::Type{Union{}}) = Union{}


### PR DESCRIPTION
This is a much more narrowly-scoped alternative to some of the tuple code changes that were originally in #27736 (i.e. https://github.com/JuliaLang/julia/commit/c16a1096a0f97a0538fa54a4f0885b27af1ae6e8).

It would still be nice eventually to figure out alternative implementations for https://github.com/JuliaLang/julia/commit/c16a1096a0f97a0538fa54a4f0885b27af1ae6e8, since switching to `fieldtype` is more sound in general (see discussion from #27736). However, for now, this much more palatable change works around the problems that are blocking Cassette.

Unfortunately, I don't have a non-Cassette test case for these bugs yet; they're pretty hard to work out MWEs for.