### PR TITLE
Fix #27775: broadcast!ing over nested scalar operations

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+using Test, Random
+
 module TestBroadcastInternals
 
 using Base.Broadcast: check_broadcast_axes, check_broadcast_shape, newindex, _bcs
@@ -736,12 +738,12 @@ end
     a .= sqrt.(1 ./ 2)
     @test a == [sqrt(1/2), sqrt(1/2)]
     rng = MersenneTwister(1234)
-    a .= rand.(rng)
+    a .= rand.((rng,))
     rng = MersenneTwister(1234)
     @test a == [rand(rng), rand(rng)]
     @test a[1] != a[2]
     rng = MersenneTwister(1234)
-    broadcast!(rand, a, rng)
+    broadcast!(rand, a, (rng,))
     rng = MersenneTwister(1234)
     @test a == [rand(rng), rand(rng)]
     @test a[1] != a[2]

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -727,6 +727,26 @@ let f(args...) = *(args...)
     @test f.(x..., f.(x..., y, z...), y, z...) == broadcast(f, x..., broadcast(f, x..., y, z...), y, z...) == 120*120
 end
 
+@testset "Issue #27775: Broadcast!ing over nested scalar operations" begin
+    a = zeros(2)
+    a .= 1 ./ (1 + 2)
+    @test a == [1/3, 1/3]
+    a .= 1 ./ (1 .+ 3)
+    @test a == [1/4, 1/4]
+    a .= sqrt.(1 ./ 2)
+    @test a == [sqrt(1/2), sqrt(1/2)]
+    rng = MersenneTwister(1234)
+    a .= rand.(rng)
+    rng = MersenneTwister(1234)
+    @test a == [rand(rng), rand(rng)]
+    @test a[1] != a[2]
+    rng = MersenneTwister(1234)
+    broadcast!(rand, a, rng)
+    rng = MersenneTwister(1234)
+    @test a == [rand(rng), rand(rng)]
+    @test a[1] != a[2]
+end
+
 # Issue #27446: Broadcasting pair operator
 let
     c = ["foo", "bar"]


### PR DESCRIPTION
Previously, we had three branches:

* If there were no nested `Broadcasted`s and we knew it was the scalar `dest .= val` case
    * optimize it to `fill!`
* Else if there were no nested `Broadcasted`s
    * Hand code a loop. This was essentially equivalent to `copyto!(::AbstractArray, :Broadcasted{Nothing})`.
* Otherwise:
    * Throw a stack overflow error

This removes the last branch, properly defers to `copyto!(::AbstractArray, :Broadcasted{Nothing})` in the second case, and adds comments to make things a bit more clear in the first place. Fix #27775.