### PR TITLE
Don't bundle sys.ji in binary-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,6 @@ endif
 	# Copy public headers
 	cp -R -L $(build_includedir)/julia/* $(DESTDIR)$(includedir)/julia
 	# Copy system image
-	-$(INSTALL_F) $(build_private_libdir)/sys.ji $(DESTDIR)$(private_libdir)
 	$(INSTALL_M) $(build_private_libdir)/sys.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	$(INSTALL_M) $(build_private_libdir)/sys-debug.$(SHLIB_EXT) $(DESTDIR)$(private_libdir)
 	# Copy in system image build script


### PR DESCRIPTION
This seems to be an old remnant from days when we used to ship sys.ji, and then stopped doing it, and now found it again.

Fix #27779