### PR TITLE
Fix #27767. Fix a missing memset when resizing isbitsunion arrays

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -809,6 +809,7 @@ STATIC_INLINE void jl_array_grow_at_end(jl_array_t *a, size_t idx,
             memcpy(newdata, data, nb1);
             if (isbitsunion) {
                 memmove(newdata + (oldmaxsize + inc) * elsz, data + oldmaxsize * elsz, idx);
+                memset(newdata + (oldmaxsize + inc) * elsz + idx, 0, inc);
             }
             if (has_gap) {
                 memcpy(newdata + nb1 + nbinc, data + nb1, n * elsz - nb1);

--- a/test/core.jl
+++ b/test/core.jl
@@ -5981,6 +5981,13 @@ for U in unboxedunions
     end
 end
 
+# issue #27767
+let A=Vector{Union{Int, Missing}}(undef, 1)
+    resize!(A, 2)
+    @test length(A) == 2
+    @test A[2] === missing
+end
+
 end # module UnionOptimizations
 
 # issue #6614, argument destructuring


### PR DESCRIPTION
Fixes #27767.