### PR TITLE
Use QuickSort rather than MergeSort by default for Union{<:Number, Missing} arrays

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -10,7 +10,7 @@ using .Base: copymutable, LinearIndices, IndexStyle, viewindexing, IndexLinear, 
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
     extrema, sub_with_overflow, add_with_overflow, oneunit, div, getindex, setindex!,
-    length, resize!, fill
+    length, resize!, fill, Missing
 
 using .Base: >>>, !==
 
@@ -568,7 +568,7 @@ end
 ## generic sorting methods ##
 
 defalg(v::AbstractArray) = DEFAULT_STABLE
-defalg(v::AbstractArray{<:Number}) = DEFAULT_UNSTABLE
+defalg(v::AbstractArray{<:Union{Number, Missing}}) = DEFAULT_UNSTABLE
 
 function sort!(v::AbstractVector, alg::Algorithm, order::Ordering)
     inds = axes(v,1)


### PR DESCRIPTION
This eliminates allocations and is about 30% faster for `Vector{Union{Float64,Missing}}`.

Mitigates (but doesn't completely fix) https://github.com/JuliaLang/julia/issues/27781.

Benchmark added at https://github.com/JuliaCI/BaseBenchmarks.jl/pull/211.