### PR TITLE
Check referential equality before comparing the content when checking String equality.

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -97,8 +97,7 @@ function cmp(a::String, b::String)
 end
 
 function ==(a::String, b::String)
-    al = sizeof(a)
-    al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
+    a === b
 end
 
 typemin(::Type{String}) = ""

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -98,7 +98,7 @@ end
 
 function ==(a::String, b::String)
     pointer_from_objref(a) == pointer_from_objref(b) && return true
-    
+
     al=sizeof(a)
     return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
 end

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -98,7 +98,6 @@ end
 
 function ==(a::String, b::String)
     pointer_from_objref(a) == pointer_from_objref(b) && return true
-
     al = sizeof(a)
     return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
 end

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -99,7 +99,7 @@ end
 function ==(a::String, b::String)
     pointer_from_objref(a) == pointer_from_objref(b) && return true
 
-    al=sizeof(a)
+    al = sizeof(a)
     return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
 end
 

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -97,7 +97,10 @@ function cmp(a::String, b::String)
 end
 
 function ==(a::String, b::String)
-    a === b
+    pointer_from_objref(a) == pointer_from_objref(b) && return true
+    
+    al=sizeof(a)
+    return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
 end
 
 typemin(::Type{String}) = ""


### PR DESCRIPTION
This should work because of:
https://github.com/JuliaLang/julia/commit/deaf6683072124e2f62c0ff11bf4abc039519050
for
https://github.com/JuliaLang/julia/issues/22193

I think we might be able to just delete the definition of `==` all together as isn't `===` the fallback?
**Edit:**  No, it will fallback to `==(a::AbstractString, b::AbstractString)` first

My microbenchmarks show a fairly solid improvement.
From what I understand of https://github.com/JuliaLang/julia/commit/deaf6683072124e2f62c0ff11bf4abc039519050
this is basically just moving the code from julia into C.
but it is code that was already moved into C, it is just the julia code was left behind.

Here are my benchmarks:

```
julia> a1 = "a"^150
"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

julia> a2 = lowercase("A")^150
"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"

julia> @btime a1 === a2
  12.950 ns (0 allocations: 0 bytes)
true

julia> @btime a1 == a2
  28.680 ns (0 allocations: 0 bytes)
true

###

julia> @btime a1 === a1
  4.466 ns (0 allocations: 0 bytes)
true

julia> @btime a1 == a1
  25.870 ns (0 allocations: 0 bytes)
true

##############

julia> b1 = "a"^5
"aaaaa"

julia> b2 = lowercase("A")^5
"aaaaa"

julia> @btime b1 === b2
  7.804 ns (0 allocations: 0 bytes)
true

julia> @btime b1 == b2
  22.511 ns (0 allocations: 0 bytes)
true
##

julia> @btime b1 === b1
  4.189 ns (0 allocations: 0 bytes)
true

julia> @btime b1 == b1
  20.868 ns (0 allocations: 0 bytes)
true

############

julia> @btime b1 === a1
  5.589 ns (0 allocations: 0 bytes)
false

julia> @btime b1 == a1
  19.065 ns (0 allocations: 0 bytes)
false

############

julia> z2 = lowercase("z")^150
"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"

julia> @btime z2 === a1
  11.132 ns (0 allocations: 0 bytes)
false

julia> @btime z2 == a1
  23.736 ns (0 allocations: 0 bytes)
false
```



