### PR TITLE
Logging: don't print out module if it is nothing

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -529,7 +529,8 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
     for (key, val) in kwargs
         println(iob, "│   ", key, " = ", val)
     end
-    println(iob, "└ @ ", _module, " ", filepath, ":", line)
+    mod = _module === nothing ? "" : "$(_module) "
+    println(iob, "└ @ ", mod, filepath, ":", line)
     write(logger.stream, take!(buf))
     nothing
 end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -60,7 +60,8 @@ end
 function default_metafmt(level, _module, group, id, file, line)
     color = default_logcolor(level)
     prefix = (level == Warn ? "Warning" : string(level))*':'
-    suffix = (Info <= level < Warn) ? "" : "@ $_module $(basename(file)):$line"
+    mod = _module === nothing ? "" : "$(_module) "
+    suffix = (Info <= level < Warn) ? "" : "@ $mod$(basename(file)):$line"
     color,prefix,suffix
 end
 


### PR DESCRIPTION
Sometimes (not sure when) the module is `nothing` and prints like
```julia
julia> @warn "Hello"
┌ Warning: Hello
└ @ nothing filename.jl:1234
```
ThisPR  changes this to
```julia
julia> @warn "Hello"
┌ Warning: Hello
└ @ filename.jl:1234
```

Would be simple to test if it wasn't for #26335 so I am leaving it like this.