### PR TITLE
Make π < π work as expected

### DIFF
--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -56,6 +56,17 @@ float(::Type{<:AbstractIrrational}) = Float64
 ==(::Irrational{s}, ::Irrational{s}) where {s} = true
 ==(::AbstractIrrational, ::AbstractIrrational) = false
 
+<(::Irrational{s}, ::Irrational{s}) where {s} = false
+function <(x::AbstractIrrational, y::AbstractIrrational)
+    # If two different Irrationals round to the same Float64, then explicit
+    # < methods are needed for those inputs, as the below assertation will fail.
+    @assert Float64(x) != Float64(y)
+    return Float64(x) < Float64(y)
+end
+
+<=(::Irrational{s}, ::Irrational{s}) where {s} = true
+<=(x::AbstractIrrational, y::AbstractIrrational) = x==y || x<y
+
 # Irrationals, by definition, can't have a finite representation equal them exactly
 ==(x::AbstractIrrational, y::Real) = false
 ==(x::Real, y::AbstractIrrational) = false

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -58,9 +58,7 @@ float(::Type{<:AbstractIrrational}) = Float64
 
 <(::Irrational{s}, ::Irrational{s}) where {s} = false
 function <(x::AbstractIrrational, y::AbstractIrrational)
-    # If two different Irrationals round to the same Float64, then explicit
-    # < methods are needed for those inputs, as the below assertation will fail.
-    @assert Float64(x) != Float64(y)
+    Float64(x) != Float64(y) || throw(MethodError(<, (x, y)))
     return Float64(x) < Float64(y)
 end
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -999,6 +999,19 @@ end
     @test !(1 > NaN)
 end
 
+@testset "Irrationals compared with Irrationals" begin
+    for i in (π, ℯ, γ, catalan)
+        for j in (π, ℯ, γ, catalan)
+            @test isequal(i==j, Float64(i)==Float64(j))
+            @test isequal(i!=j, Float64(i)!=Float64(j))
+            @test isequal(i<=j, Float64(i)<=Float64(j))
+            @test isequal(i>=j, Float64(i)>=Float64(j))
+            @test isequal(i<j, Float64(i)<Float64(j))
+            @test isequal(i>j, Float64(i)>Float64(j))
+        end
+    end
+end
+
 @testset "Irrationals compared with Rationals and Floats" begin
     @test Float64(pi,RoundDown) < pi
     @test Float64(pi,RoundUp) > pi


### PR DESCRIPTION
Methods are added for < and <= comparing Irrationals. (The corresponding
methods for > and >= are then handled by existing fallback methods.)

Currently, expressions like `ℯ < π` result in promotion to Float64.
This works most of the time. However, `π < π` does not result in
promotion and throws an error. This commit introduces methods
for comparing an Irrational to itself.

This commit also introduces a test to make sure that incorrect results
are not being returned due to different user-defined irrationals
rounding to the same Float64.