### PR TITLE
[RFC/WIP] --env command line flag to specify environment

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -70,7 +70,7 @@ end
 # this will inherit an existing JULIA_LOAD_PATH value or if there is none, leave
 # a trailing empty entry in JULIA_LOAD_PATH which will be replaced with defaults.
 
-const DEFAULT_LOAD_PATH = ["@@", "@v#.#", "@stdlib"]
+const DEFAULT_LOAD_PATH = ["@v#.#", "@stdlib"]
 
 """
     LOAD_PATH
@@ -127,6 +127,8 @@ function init_load_path()
         load_path = ["@stdlib"]
     elseif haskey(ENV, "JULIA_LOAD_PATH")
         load_path = parse_load_path(ENV["JULIA_LOAD_PATH"])
+    elseif Base.JLOptions().env != C_NULL
+        load_path = parse_load_path(unsafe_string(Base.JLOptions().env))
     else
         load_path = filter!(env -> env !== nothing,
             [env == "@" ? current_env() : env for env in DEFAULT_LOAD_PATH])

--- a/base/options.jl
+++ b/base/options.jl
@@ -11,6 +11,7 @@ struct JLOptions
     cpu_target::Ptr{UInt8}
     nprocs::Int32
     machine_file::Ptr{UInt8}
+    env::Ptr{UInt8}
     isinteractive::Int8
     color::Int8
     historyfile::Int8

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -31,6 +31,7 @@ jl_options_t jl_options = { 0,    // quiet
                             -1,   // banner
                             NULL, // julia_bindir
                             NULL, // julia_bin
+                            NULL, // env
                             NULL, // cmds
                             NULL, // image_file (will be filled in below)
                             NULL, // cpu_target ("native", "core2", etc...)
@@ -171,6 +172,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
            opt_sysimage_native_code,
            opt_compiled_modules,
            opt_machine_file,
+           opt_env
     };
     static const char* const shortopts = "+vhqH:e:E:L:J:C:ip:O:g:";
     static const struct option longopts[] = {
@@ -194,6 +196,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp)
         { "procs",           required_argument, 0, 'p' },
         { "machinefile",     required_argument, 0, opt_machinefile },   // deprecated
         { "machine-file",    required_argument, 0, opt_machine_file },
+        { "env",             optional_argument, 0, opt_env},
         { "color",           required_argument, 0, opt_color },
         { "history-file",    required_argument, 0, opt_history_file },
         { "startup-file",    required_argument, 0, opt_startup_file },
@@ -398,6 +401,9 @@ restart_switch:
             jl_options.machine_file = strdup(optarg);
             if (!jl_options.machine_file)
                 jl_error("julia: failed to allocate memory");
+            break;
+        case opt_env:
+            jl_options.env = strdup(optarg);
             break;
         case opt_color:
             if (!strcmp(optarg, "yes"))

--- a/src/julia.h
+++ b/src/julia.h
@@ -1779,6 +1779,7 @@ typedef struct {
     const char *cpu_target;
     int32_t nprocs;
     const char *machine_file;
+    const char *env;
     int8_t isinteractive;
     int8_t color;
     int8_t historyfile;


### PR DESCRIPTION
This lets you start julia with `julia --env=@:` to prepend `@:` to `LOAD_PATH`.