### PR TITLE
Address some missed shred calls

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -446,7 +446,7 @@ function securezero! end
 unsafe_securezero!(p::Ptr{Cvoid}, len::Integer=1) = Ptr{Cvoid}(unsafe_securezero!(Ptr{UInt8}(p), len))
 
 """
-    Base.getpass(message::AbstractString) -> `Base.SecretBuffer`
+    Base.getpass(message::AbstractString) -> Base.SecretBuffer
 
 Display a message and wait for the user to input a secret, returning an `IO`
 object containing the secret.
@@ -475,7 +475,7 @@ function getpass(prompt::AbstractString)
             write(s, c)
         end
     end
-    return  s
+    return s
 end
 else
 function getpass(prompt::AbstractString)

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -294,6 +294,8 @@ function fetch(repo::GitRepo; remote::AbstractString="origin",
     catch err
         if isa(err, GitError) && err.code == Error.EAUTH
             reject(cred_payload)
+        else
+            Base.shred!(cred_payload)
         end
         rethrow()
     finally
@@ -350,6 +352,8 @@ function push(repo::GitRepo; remote::AbstractString="origin",
     catch err
         if isa(err, GitError) && err.code == Error.EAUTH
             reject(cred_payload)
+        else
+            Base.shred!(cred_payload)
         end
         rethrow()
     finally
@@ -584,6 +588,8 @@ function clone(repo_url::AbstractString, repo_path::AbstractString;
         catch err
             if isa(err, GitError) && err.code == Error.EAUTH
                 reject(cred_payload)
+            else
+                Base.shred!(cred_payload)
             end
             rethrow()
         end

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1361,6 +1361,12 @@ end
 
 CredentialPayload(p::CredentialPayload) = p
 
+function Base.shred!(p::CredentialPayload)
+    # Note: Avoid shredding the `explicit` or `cache` fields as these are just references
+    # and it is not our responsibility to shred them.
+    p.credential !== nothing && Base.shred!(p.credential)
+    p.credential = nothing
+end
 
 """
     reset!(payload, [config]) -> CredentialPayload

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -1208,6 +1208,14 @@ mutable struct UserPasswordCredential <: AbstractCredential
     UserPasswordCredential(prompt_if_incorrect::Bool) = UserPasswordCredential("","",prompt_if_incorrect)
 end
 
+function Base.setproperty!(cred::UserPasswordCredential, name::Symbol, value)
+    if name == :pass
+        field = getfield(cred, name)
+        Base.shred!(field)
+    end
+    setfield!(cred, name, convert(fieldtype(typeof(cred), name), value))
+end
+
 function Base.shred!(cred::UserPasswordCredential)
     cred.user = ""
     Base.shred!(cred.pass)
@@ -1245,6 +1253,15 @@ mutable struct SSHCredential <: AbstractCredential
     SSHCredential(u::AbstractString, p::AbstractString, prompt_if_incorrect::Bool) = SSHCredential(u,p,"","",prompt_if_incorrect)
     SSHCredential(prompt_if_incorrect::Bool) = SSHCredential("","","","",prompt_if_incorrect)
 end
+
+function Base.setproperty!(cred::SSHCredential, name::Symbol, value)
+    if name == :pass
+        field = getfield(cred, name)
+        Base.shred!(field)
+    end
+    setfield!(cred, name, convert(fieldtype(typeof(cred), name), value))
+end
+
 
 function Base.shred!(cred::SSHCredential)
     cred.user = ""
@@ -1378,7 +1395,7 @@ should be destroyed. Should only be set to `false` during testing.
 """
 function approve(p::CredentialPayload; shred::Bool=true)
     cred = p.credential
-    cred === nothing && return  # No credentials were used
+    cred === nothing && return  # No credential was used
 
     if p.cache !== nothing
         approve(p.cache, cred, p.url)
@@ -1388,7 +1405,10 @@ function approve(p::CredentialPayload; shred::Bool=true)
         approve(p.config, cred, p.url)
     end
 
-    shred && Base.shred!(cred)
+    if shred
+        Base.shred!(cred)
+        p.credential = nothing
+    end
     nothing
 end
 
@@ -1403,17 +1423,19 @@ should be destroyed. Should only be set to `false` during testing.
 """
 function reject(p::CredentialPayload; shred::Bool=true)
     cred = p.credential
-    cred === nothing && return  # No credentials were used
+    cred === nothing && return  # No credential was used
 
     if p.cache !== nothing
         reject(p.cache, cred, p.url)
-        shred = false  # Avoid wiping `cred` as this would also wipe the cached copy
     end
     if p.allow_git_helpers
         reject(p.config, cred, p.url)
     end
 
-    shred && Base.shred!(cred)
+    if shred
+        Base.shred!(cred)
+        p.credential = nothing
+    end
     nothing
 end
 


### PR DESCRIPTION
Discovered some missing shred calls when using Julia 0.7-beta. These were noticed by using pkg `up` with a repo requiring credentials and reaching the prompt abort condition.

Introduced in https://github.com/JuliaLang/julia/pull/27565