### PR TITLE
Copy SecretBuffer to avoid inadvertent shred

### DIFF
--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -186,8 +186,9 @@ function authenticate_userpass(libgit2credptr::Ptr{Ptr{Cvoid}}, p::CredentialPay
     if p.use_git_helpers && (!revised || !isfilled(cred))
         git_cred = GitCredential(p.config, p.url)
 
+         # Use `deepcopy` to ensure shredding the `git_cred` does not shred the `cred`s copy
         cred.user = something(git_cred.username, "")
-        cred.pass = something(git_cred.password, "")
+        cred.pass = deepcopy(something(git_cred.password, ""))
         Base.shred!(git_cred)
         revised = true
 


### PR DESCRIPTION
Bug introduced in https://github.com/JuliaLang/julia/pull/27565 and breaks the use of git credential helpers. I've introduced a new test case to make sure this doesn't happen again.