### PR TITLE
Allow AbstractVectors in transcode

### DIFF
--- a/base/c.jl
+++ b/base/c.jl
@@ -250,18 +250,23 @@ function transcode end
 
 transcode(::Type{T}, src::AbstractVector{T}) where {T<:Union{UInt8,UInt16,UInt32,Int32}} = src
 transcode(::Type{T}, src::String) where {T<:Union{Int32,UInt32}} = T[T(c) for c in src]
-transcode(::Type{T}, src::Union{Vector{UInt8},CodeUnits{UInt8,String}}) where {T<:Union{Int32,UInt32}} =
+transcode(::Type{T}, src::AbstractVector{UInt8}) where {T<:Union{Int32,UInt32}} =
+    transcode(T, String(Vector(src)))
+transcode(::Type{T}, src::CodeUnits{UInt8,String}) where {T<:Union{Int32,UInt32}} =
     transcode(T, String(src))
+
 function transcode(::Type{UInt8}, src::Vector{<:Union{Int32,UInt32}})
     buf = IOBuffer()
-    for c in src; print(buf, Char(c)); end
+    for c in src
+        print(buf, Char(c))
+    end
     take!(buf)
 end
 transcode(::Type{String}, src::String) = src
 transcode(T, src::String) = transcode(T, codeunits(src))
 transcode(::Type{String}, src) = String(transcode(UInt8, src))
 
-function transcode(::Type{UInt16}, src::Union{Vector{UInt8},CodeUnits{UInt8,String}})
+function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
     dst = UInt16[]
     i, n = 1, length(src)
     n > 0 || return dst
@@ -311,7 +316,7 @@ function transcode(::Type{UInt16}, src::Union{Vector{UInt8},CodeUnits{UInt8,Stri
     return dst
 end
 
-function transcode(::Type{UInt8}, src::Vector{UInt16})
+function transcode(::Type{UInt8}, src::AbstractVector{UInt16})
     n = length(src)
     n == 0 && return UInt8[]
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -375,6 +375,13 @@ let s = "abcα🐨\0x\0"
     end
 end
 
+let X = UInt8[0x30,0x31,0x32]
+    for T in (UInt8, UInt16, UInt32, Int32)
+        @test transcode(UInt8,transcode(T, X)) == X
+        @test transcode(UInt8,transcode(T, 0x30:0x32)) == X
+    end
+end
+
 let optstring = repr("text/plain", Base.JLOptions())
     @test startswith(optstring, "JLOptions(\n")
     @test !occursin("Ptr", optstring)


### PR DESCRIPTION
Also fix issue where `transcode(UInt32, ::Vector{UInt8})` would destroy contents.