### PR TITLE
Support missing values in fpsort

### DIFF
--- a/test/missing.jl
+++ b/test/missing.jl
@@ -552,3 +552,29 @@ end
     me = try missing(1) catch e e end
     @test sprint(showerror, me) == "MethodError: objects of type Missing are not callable"
 end
+
+@testset "sort and sortperm with $(eltype(X))" for (X, P, RP) in
+    (([2, missing, -2, 5, missing], [3, 1, 4, 2, 5], [2, 5, 4, 1, 3]),
+     ([NaN, missing, 5, -0.0, NaN, missing, Inf, 0.0, -Inf],
+      [9, 4, 8, 3, 7, 1, 5, 2, 6], [2, 6, 1, 5, 7, 3, 8, 4, 9]),
+     ([missing, "a", "c", missing, "b"], [2, 5, 3, 1, 4], [1, 4, 3, 5, 2]))
+    @test sortperm(X) == P
+    @test sortperm(X, alg=QuickSort) == P
+    @test sortperm(X, alg=MergeSort) == P
+
+    XP = X[P]
+    @test isequal(sort(X), XP)
+    @test isequal(sort(X, alg=QuickSort), XP)
+    @test isequal(sort(X, alg=MergeSort), XP)
+
+    @test sortperm(X, rev=true) == RP
+    @test sortperm(X, alg=QuickSort, rev=true) == RP
+    @test sortperm(X, alg=MergeSort, rev=true) == RP
+
+    XRP = X[RP]
+    @test isequal(sort(X, rev=true), XRP)
+    @test isequal(sort(X, alg=QuickSort, rev=true), XRP)
+    @test isequal(sort(X, alg=MergeSort, rev=true), XRP)
+end
+
+sortperm(reverse([NaN, missing, NaN, missing]))


### PR DESCRIPTION
Use the fast algorithm for floating point even in the presence of missing values, adapting existing code to handle `NaN`. After sorting `NaN` and `missing` at the end, a second pass is made over these to put missing after `NaN`.

Fixes https://github.com/JuliaLang/julia/issues/27781 (when combined with https://github.com/JuliaLang/julia/pull/27789).

I see a 2× performance improvement when the input contains 10% of missing values (and no `NaN`), making it about twice slower than a `Vector{Float64}`:
```julia
# Before
julia> @btime sort!(y, alg=QuickSort) setup=(y = rand(100));
  460.335 ns (0 allocations: 0 bytes)

julia> @btime sort!(y2, alg=QuickSort) setup=(y = rand(100); y2 = ifelse.(rand(length(y)) .< 0.9, y, missing));
  1.861 μs (0 allocations: 0 bytes)

# After
julia> @btime sort!(y, alg=QuickSort) setup=(y = rand(100));
  445.944 ns (0 allocations: 0 bytes)

julia> @btime sort!(y2, alg=QuickSort) setup=(y = rand(100); y2 = ifelse.(rand(length(y)) .< 0.9, y, missing));
  849.537 ns (0 allocations: 0 bytes)
```

Even with this, we're still a bit slower than R (by about 50%) EDIT: for a vector with 10M entries.

Nanosoldier should be run only after merging https://github.com/JuliaLang/julia/pull/27789 since benchmarks only cover the default algorithm, which is currently `MergeSort` with missing values.