### PR TITLE
Implement dimension-aware `skipmissing`

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -175,8 +175,8 @@ skipmissing(itr) = SkipMissing(itr)
 
 Return an array of `skipmissing` iterators sliced along `dims`.
 
-A function which reduces each iterator can be broadcast over the resulting array. 
-Note that if all the values along a slice are `missing`, an error will result, since 
+A function which reduces each iterator can be broadcast over the resulting array.
+Note that if all the values along a slice are `missing`, an error will result, since
 broadcasting over an empty set is undefined.
 
 # Examples
@@ -191,7 +191,7 @@ julia> B = reshape(A, (2,2,2))
 2×2×2 Array{Union{Missing, Int64},3}:
 [:, :, 1] =
  1   missing
- 5  6       
+ 5  6
 
 [:, :, 2] =
  3         4

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -170,6 +170,41 @@ julia> collect(skipmissing([1 missing; 2 missing]))
 """
 skipmissing(itr) = SkipMissing(itr)
 
+"""
+    skipmissing(array, dims)
+
+Return an array of `skipmissing` iterators sliced along `dims`.
+
+A function which reduces each iterator can be broadcast over the resulting array. 
+Note that if all the values along a slice are `missing`, an error will result, since 
+broadcasting over an empty set is undefined.
+
+# Examples
+```jldoctest
+julia> A = [1 missing 3 4; 5 6 missing 8];
+
+julia> sum.(skipmissing(A, 1))
+1×4 Array{Int64,2}:
+ 6  6  3  12
+
+julia> B = reshape(A, (2,2,2))
+2×2×2 Array{Union{Missing, Int64},3}:
+[:, :, 1] =
+ 1   missing
+ 5  6       
+
+[:, :, 2] =
+ 3         4
+  missing  8
+
+julia> maximum.(skipmissing(B, (1,3)))
+1×2×1 Array{Int64,3}:
+[:, :, 1] =
+ 5  8
+```
+"""
+skipmissing(v, dims) = mapslices(skipmissing, v, dims)
+
 struct SkipMissing{T}
     x::T
 end


### PR DESCRIPTION
I added a method `skipmissing(v, dims) = mapslices(skipmissing, v, dims)` which allows compact notation for `skipmissing` over multidimensional arrays. Can be composed with basic stats functions to provide functionality similar to Matlab & Numpy's `nanmean(array, dim)`, etc:

```
julia> mean.(skipmissing([1 missing; 3 4], 1))
1×2 Array{Float64,2}:
 2.0  4.0
```

This generates lots of views & iterators, so it's not the most performant, but it's a decent start. [ref](https://discourse.julialang.org/t/arithmetic-operations-on-multi-dimensional-arrays-with-missings/11491/3?u=stillyslalom) 