### PR TITLE
Make grisu thread-safe again

### DIFF
--- a/base/grisu/grisu.jl
+++ b/base/grisu/grisu.jl
@@ -9,14 +9,6 @@ const SHORTEST = 1
 const FIXED = 2
 const PRECISION = 3
 
-const DIGITS = Vector{UInt8}(undef, 309+17)
-
-# thread-safe code should use a per-thread DIGITS buffer DIGITSs[Threads.threadid()]
-const DIGITSs = [DIGITS]
-function __init__()
-    Threads.resize_nthreads!(DIGITSs)
-end
-
 include("grisu/float.jl")
 include("grisu/fastshortest.jl")
 include("grisu/fastprecision.jl")
@@ -24,9 +16,19 @@ include("grisu/fastfixed.jl")
 include("grisu/bignums.jl")
 include("grisu/bignum.jl")
 
+const DIGITS = Vector{UInt8}(undef, 309+17)
 const BIGNUMS = [Bignums.Bignum(),Bignums.Bignum(),Bignums.Bignum(),Bignums.Bignum()]
 
-function grisu(v::AbstractFloat,mode,requested_digits,buffer=DIGITSs[Threads.threadid()],bignums=BIGNUMS)
+# thread-safe code should use a per-thread DIGITS buffer DIGITSs[Threads.threadid()]
+const DIGITSs = [DIGITS]
+const BIGNUMSs = [BIGNUMS]
+function __init__()
+    Threads.resize_nthreads!(DIGITSs)
+    Threads.resize_nthreads!(BIGNUMSs)
+end
+
+
+function grisu(v::AbstractFloat,mode,requested_digits,buffer=DIGITSs[Threads.threadid()],bignums=BIGNUMSs[Threads.threadid()])
     if signbit(v)
         neg = true
         v = -v

--- a/base/threads.jl
+++ b/base/threads.jl
@@ -13,7 +13,7 @@ include("locks.jl")
     resize_nthreads!(A, copyvalue=A[1])
 
 Resize the array `A` to length [`nthreads()`](@ref).   Any new
-elements that are allocated are initialized to `copy(copyvalue)`,
+elements that are allocated are initialized to `deepcopy(copyvalue)`,
 where `copyvalue` defaults to `A[1]`.
 
 This is typically used to allocate per-thread variables, and
@@ -24,7 +24,7 @@ function resize_nthreads!(A::AbstractVector, copyvalue=A[1])
     nold = length(A)
     resize!(A, nthr)
     for i = nold+1:nthr
-        A[i] = copy(copyvalue)
+        A[i] = deepcopy(copyvalue)
     end
     return A
 end


### PR DESCRIPTION
Digit printing on the slow path was still not thread-safe after #26562, e.g. with `JULIA_NUM_THREADS=4` I get errors with the following:

```julia
using Base.Threads
V = fill(2.99965547519468e17, 100)
function test_without_mutex(V)
    @threads for v in V
        y = "$v"
        @assert v == parse(Float64, y)
    end
end
test_without_mutex(V)
```