### PR TITLE
fix #27352, disallow `print`/`string` of `nothing`

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -88,7 +88,7 @@ function print_node(io::IO, idx::Int, @nospecialize(stmt), used, argnames, maxsi
         Base.print(io, join(String[sprint(io->print_ssa(io, arg, argnames)) for arg in stmt.args], ", "))
         Base.print(io, ")")
     else
-        Base.print(io, stmt)
+        Base.show(io, stmt)
     end
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -557,6 +557,7 @@ function show(io::IO, tn::Core.TypeName)
 end
 
 show(io::IO, ::Nothing) = print(io, "nothing")
+print(io::IO, ::Nothing) = throw(MethodError(print, (io, nothing)))
 show(io::IO, b::Bool) = print(io, b ? "true" : "false")
 show(io::IO, n::Signed) = (write(io, string(n)); nothing)
 show(io::IO, n::Unsigned) = print(io, "0x", string(n, pad = sizeof(n)<<1, base = 16))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1248,3 +1248,13 @@ h_line() = f_line()
     │╻╷ f_line
     ││╻  g_line
     ││╻  g_line""")
+
+# issue #27352
+@test_throws MethodError print(nothing)
+@test_throws MethodError print(stdout, nothing)
+@test_throws MethodError string(nothing)
+@test_throws MethodError string(1, "", nothing)
+@test_throws MethodError let x = nothing; "x = $x" end
+@test let x = nothing; "x = $(repr(x))" end == "x = nothing"
+@test_throws MethodError `/bin/foo $nothing`
+@test_throws MethodError `$nothing`


### PR DESCRIPTION
fixes #27352