### PR TITLE
show type information for invalid index error

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -226,12 +226,13 @@ indexing behaviors. This must return either an `Int` or an `AbstractArray` of
 """
 to_index(i::Integer) = convert(Int,i)::Int
 # TODO: Enable this new definition after the deprecations introduced in 0.7 are removed
-# to_index(i::Bool) = throw(ArgumentError("invalid index: $i"))
+# to_index(i::Bool) = throw(ArgumentError("invalid index: $i of type $(typeof(i))"))
 to_index(I::AbstractArray{Bool}) = LogicalIndex(I)
 to_index(I::AbstractArray) = I
-to_index(I::AbstractArray{<:Union{AbstractArray, Colon}}) = throw(ArgumentError("invalid index: $I"))
+to_index(I::AbstractArray{<:Union{AbstractArray, Colon}}) =
+    throw(ArgumentError("invalid index: $I of type $(typeof(I))"))
 to_index(::Colon) = throw(ArgumentError("colons must be converted by to_indices(...)"))
-to_index(i) = throw(ArgumentError("invalid index: $i"))
+to_index(i) = throw(ArgumentError("invalid index: $i of type $(typeof(i))"))
 
 # The general to_indices is mostly defined in multidimensional.jl, but this
 # definition is required for bootstrap:


### PR DESCRIPTION
Changes
```
julia> [1,][1.0]
ERROR: ArgumentError: invalid index: 1.0
```
to
```
julia> [1,][1.0]
ERROR: ArgumentError: invalid index: 1.0 of type Float64
```
The previous error confused someone on SO; the value 1 is a valid index, the problem here is more about the type of the value so it is good to show that.