### PR TITLE
Let tmerge form a Union more often

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -355,9 +355,10 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
         return Any
     end
     typea == typeb && return typea
-    # it's always ok to form a Union of two concrete types
-    if (isconcretetype(typea) || isType(typea)) && (isconcretetype(typeb) || isType(typeb))
-        return Union{typea, typeb}
+    # it's always ok to form a Union of two Union-free types
+    u = Union{typea, typeb}
+    if unioncomplexity(u) <= 1
+        return u
     end
     # collect the list of types from past tmerge calls returning Union
     # and then reduce over that list

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2033,6 +2033,12 @@ let rt = Base.return_types(splat27434, (NamedTuple{(:x,), Tuple{T}} where T,))
     @test !Base.has_free_typevars(rt[1])
 end
 
+# PR #27843
+bar27843(x, y::Bool) = fill(x, 0)
+bar27843(x, y) = fill(x, ntuple(_ -> 0, y))::Array{typeof(x)}
+foo27843(x, y) = bar27843(x, y)
+@test Core.Compiler.return_type(foo27843, Tuple{Union{Float64,Int}, Any}) == Union{Array{Float64}, Array{Int}}
+
 # issue #27078
 f27078(T::Type{S}) where {S} = isa(T, UnionAll) ? f27078(T.body) : T
 T27078 = Vector{Vector{T}} where T

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2038,6 +2038,10 @@ bar27843(x, y::Bool) = fill(x, 0)
 bar27843(x, y) = fill(x, ntuple(_ -> 0, y))::Array{typeof(x)}
 foo27843(x, y) = bar27843(x, y)
 @test Core.Compiler.return_type(foo27843, Tuple{Union{Float64,Int}, Any}) == Union{Array{Float64}, Array{Int}}
+let atypes1 = Tuple{Union{IndexCartesian, IndexLinear}, Any, Union{Tuple{}, Tuple{Any,Vararg{Any,N}} where N}, Tuple},
+    atypes2 = Tuple{Union{IndexCartesian, IndexLinear}, Any, Tuple, Tuple}
+    @test Core.Compiler.return_type(SubArray, atypes1) <: Core.Compiler.return_type(SubArray, atypes2)
+end
 
 # issue #27078
 f27078(T::Type{S}) where {S} = isa(T, UnionAll) ? f27078(T.body) : T


### PR DESCRIPTION
This addresses the performance regression of `mapslices` introduced by #27417 and noticed in  #27828. I think replacing `isconcretetype(typea) || isType(typea)` with `unioncomplexity(typea) == 0` makes a lot of sense and is in the same spirit as the original PR.

However, I had to introduce another condition due to this quirk (which happens both before #27417 and with this PR):
```julia
julia> foo(a,b,c,d) = SubArray(a,b,c,d)
foo (generic function with 1 method)

julia> atypes = Tuple{Union{IndexCartesian, IndexLinear}, Any, Union{Tuple{}, Tuple{Any,Vararg{Any,N} where N}}, Tuple}
Tuple{Union{IndexCartesian, IndexLinear},Any,Union{Tuple{}, Tuple{Any,Vararg{Any,N} where N}},Tuple}

julia> atypes2 = Tuple{Union{IndexCartesian, IndexLinear}, Any, Tuple, Tuple}
Tuple{Union{IndexCartesian, IndexLinear},Any,Tuple,Tuple}

julia> atypes <: atypes2
true

julia> code_typed(foo, atypes)
1-element Array{Any,1}:
 CodeInfo(
1 1 ─ %1 = Main.SubArray(%%a, %%b, %%c, %%d)::SubArray                      │
  └──      return %1                                                        │
) => SubArray

julia> code_typed(foo, atypes2)
1-element Array{Any,1}:
 CodeInfo(
1 1 ─ %1 = Main.SubArray(%%a, %%b, %%c, %%d)::Union{SubArray{_1,_2,_3,_4,false} where _4 where _3 where _2 where _1, SubArray{_1,_2,_3,_4,true} where _4 where _3 where _2 where _1}
  └──      return %1                                                        │
) => Union{SubArray{_1,_2,_3,_4,false} where _4 where _3 where _2 where _1, SubArray{_1,_2,_3,_4,true} where _4 where _3 where _2 where _1}
```
Note that the wider `atypes2` gives the narrower inference result. Hence the additional `Tuple` condition to turn `Union{Tuple{}, Tuple{Any,Vararg{Any,N} where N}}` into `Tuple`. (They should probably be type-equal anyway, but that's a different issue.) This leaves me a bit unsatisfied, but seems to be necessary to fix the regression.