### PR TITLE
Fix corner case in getfield elim

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -662,9 +662,9 @@ function getfield_elim_pass!(ir::IRCode, domtree)
         # Insert the undef check if necessary
         if any_undef && !is_unchecked
             if val === nothing
-                insert_node!(compact, SSAValue(idx), Nothing, Expr(:throw_undef_if_not, :getfield, false))
+                insert_node!(compact, SSAValue(idx), Nothing, Expr(:throw_undef_if_not, Symbol("##getfield##"), false))
             else
-                insert_node!(compact, SSAValue(idx), Nothing, Expr(:undefcheck, :getfield, val.x))
+                insert_node!(compact, SSAValue(idx), Nothing, Expr(:undefcheck, Symbol("##getfield##"), val.x))
             end
         else
             @assert val !== nothing

--- a/src/ast.c
+++ b/src/ast.c
@@ -67,7 +67,7 @@ jl_sym_t *macrocall_sym; jl_sym_t *colon_sym;
 jl_sym_t *hygienicscope_sym;
 jl_sym_t *escape_sym;
 jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
-jl_sym_t *throw_undef_if_not_sym;
+jl_sym_t *throw_undef_if_not_sym; jl_sym_t *getfield_undefref_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -392,6 +392,7 @@ void jl_init_frontend(void)
     generated_sym = jl_symbol("generated");
     generated_only_sym = jl_symbol("generated_only");
     throw_undef_if_not_sym = jl_symbol("throw_undef_if_not");
+    getfield_undefref_sym = jl_symbol("##getfield##");
     do_sym = jl_symbol("do");
 }
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -466,7 +466,11 @@ SECT_INTERP static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
         jl_value_t *cond = eval_value(args[1], s);
         assert(jl_is_bool(cond));
         if (cond == jl_false) {
-            jl_undefined_var_error((jl_sym_t*)args[0]);
+            jl_sym_t *var = (jl_sym_t*)args[0];
+            if (var == getfield_undefref_sym)
+                jl_throw(jl_undefref_exception);
+            else
+                jl_undefined_var_error(var);
         }
         return jl_nothing;
     }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -973,6 +973,7 @@ extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *generated_sym;
 extern jl_sym_t *generated_only_sym;
 extern jl_sym_t *throw_undef_if_not_sym;
+extern jl_sym_t *getfield_undefref_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -6267,3 +6267,6 @@ get27770(n::Nullable27770, v::Handle27770) = n.hasvalue ? n.value : v
 
 foo27770() = get27770(Nullable27770(), Handle27770())
 @test foo27770().ptr == Ptr{Cvoid}(UInt(0xfeedface))
+
+bar27770() = Nullable27770().value
+@test_throws UndefRefError bar27770()

--- a/test/core.jl
+++ b/test/core.jl
@@ -6250,3 +6250,20 @@ end
 wrap22291(ind) = (ind...,)
 @test @inferred(wrap22291(1)) == (1,)
 @test @inferred(wrap22291((1, 2))) == (1, 2)
+
+# Issue 27770
+mutable struct Handle27770
+    ptr::Ptr{Cvoid}
+end
+Handle27770() = Handle27770(Ptr{Cvoid}(UInt(0xfeedface)))
+
+struct Nullable27770
+    hasvalue::Bool
+    value::Handle27770
+    Nullable27770() = new(false)
+    Nullable27770(v::Handle27770) = new(true, Handle27770)
+end
+get27770(n::Nullable27770, v::Handle27770) = n.hasvalue ? n.value : v
+
+foo27770() = get27770(Nullable27770(), Handle27770())
+@test foo27770().ptr == Ptr{Cvoid}(UInt(0xfeedface))


### PR DESCRIPTION
Fixes #27770. The actual fix is rather un-interesting (essentially just a missed case where the actual value itself did not go through a phi node first). While I was at it, I also threw in a fix to make sure to emit the correct kind of error in this case.