### PR TITLE
RFC: Introduce pzip iterator

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -643,6 +643,7 @@ export
 
     enumerate,  # re-exported from Iterators
     zip,
+    pzip,
 
 # object identity and equality
     copy,

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -170,7 +170,7 @@ Array{T}(::Missing, d...) where {T} = fill!(Array{T}(undef, d...), missing)
 include("abstractdict.jl")
 
 include("iterators.jl")
-using .Iterators: zip, enumerate
+using .Iterators: zip, pzip, enumerate
 using .Iterators: Flatten, product  # for generators
 
 include("namedtuple.jl")

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -541,3 +541,14 @@ end
 	@test !isempty(a)
     end
 end
+
+@testset "pzip" begin
+    @test_throws MethodError pzip(1:2)
+    @test_throws DimensionMismatch collect(pzip(1:2, 3:-1:1, 3:4))
+    @test collect(pzip(1:2, 3:4)) == [(1,)=>3, (2,)=>4]
+    @test collect(pzip(1:2, 3:-1:2, 3:4)) == [(1,3)=>3, (2,2)=>4]
+    @test collect(pzip([1 2; 3 4], [5 6; 7 8])) == [
+        (1,)=>5 (2,)=>6;
+        (3,)=>7 (4,)=>8
+    ]
+end


### PR DESCRIPTION
This introduces a new simple iterator I've tentatively dubbed `pzip`.
The idea is that this iterator is useful to convert from "coordinate
form" to "associative form" for higher level sparse arrays. E.g. if
you have sparse indices (I, J) and values V, you could use
`pzip(I, J, V)` to get an iterator of pairs `(i, j) => v` (i.e. what
would be returned by pairs on an NDSparse array). The direction
I want to go here is to get rid of the `sparse(i, j, v, [m,] [n,])`
constructor in favor of a single `sparse(what, [m,] [n,])` where `what`
can be either a kind of structured array or an iterator that returns
pairs of coord => value. With this iterator, the existing
`sparse(i, j, v, m, n)` method could then be written as
`sparse(pzip(i, j, v), m, n)` but I'm hoping the `pzip` pattern will
be useable more generally, since it's a fairly simple abstraction.

Some current examples:
```
julia> collect(pzip(10:19, 20:29, 30:39))
10-element Array{Pair{Tuple{Int64,Int64},Int64},1}:
 (10, 20) => 30
 (11, 21) => 31
 (12, 22) => 32
 (13, 23) => 33
 (14, 24) => 34
 (15, 25) => 35
 (16, 26) => 36
 (17, 27) => 37
 (18, 28) => 38
 (19, 29) => 39

julia> Dict(pzip(10:19, 20:29, 30:39))
Dict{Tuple{Int64,Int64},Int64} with 10 entries:
  (10, 20) => 30
  (16, 26) => 36
  (12, 22) => 32
  (14, 24) => 34
  (13, 23) => 33
  (17, 27) => 37
  (18, 28) => 38
  (19, 29) => 39
  (15, 25) => 35
  (11, 21) => 31
```