### PR TITLE
Deprecate v0 in accumulate in favor of init keyword

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -721,7 +721,8 @@ Library improvements
 
   * The initial element `v0` in `reduce(op, v0, itr)` has been replaced with an `init`
     optional keyword argument, as in `reduce(op, itr; init=v0)`. Similarly for `foldl`,
-    `foldr`, `mapreduce`, `mapfoldl` and `mapfoldr`. ([#27711])
+    `foldr`, `mapreduce`, `mapfoldl`, `mapfoldr`, `accumulate` and `accumulate!`.
+    ([#27711], [#27859])
 
 Compiler/Runtime improvements
 -----------------------------

--- a/base/accumulate.jl
+++ b/base/accumulate.jl
@@ -268,7 +268,9 @@ julia> x = [1, 0, 2, 0, 3];
 
 julia> y = [0, 0, 0, 0, 0];
 
-julia> accumulate!(+, y,julia> , Somey
+julia> accumulate!(+, y, x);
+
+julia> y
 5-element Array{Int64,1}:
  1
  1
@@ -283,8 +285,8 @@ julia> B = [0 0; 0 0];
 julia> accumulate!(-, B, A, dims=1);
 
 julia> B
-2×2 Array{Int64,Union{2}:
-  1, Some}   2
+2×2 Array{Int64,2}:
+  1,  2
  -2  -2
 
 julia> accumulate!(-, B, A, dims=2);
@@ -383,12 +385,15 @@ function _accumulate1!(op, B, v1, A::AbstractVector, dim::Integer)
     inds = LinearIndices(A)
     inds == LinearIndices(B) || throw(DimensionMismatch("LinearIndices of A and B don't match"))
     dim > 1 && return copyto!(B, A)
-    i1 = inds[1]
+    (i1, state) = iterate(inds) # We checked earlier that A isn't empty
     cur_val = v1
     B[i1] = cur_val
-    @inbounds for i in inds[2:end]
+    next = iterate(inds, state)
+    @inbounds while next !== nothing
+        (i, state) = next
         cur_val = op(cur_val, A[i])
         B[i] = cur_val
+        next = iterate(inds, state)
     end
     return B
 end

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1749,6 +1749,10 @@ end
 
 @deprecate startswith(a::Vector{UInt8}, b::Vector{UInt8}) length(a) >= length(b) && view(a, 1:length(b)) == b
 
+# PR #27859
+@deprecate accumulate(op, v0, x::AbstractVector) accumulate(op, x; init=v0)
+@deprecate accumulate!(op, y, v0, x::AbstractVector) accumulate!(op, y, x; init=v0)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -518,7 +518,7 @@ end
     # test PRNG jump
 
     function randjumpvec(m, steps, len) # old version of randjump
-        mts = accumulate(Future.randjump, m, fill(steps, len-1))
+        mts = accumulate(Future.randjump, fill(steps, len-1); init=m)
         pushfirst!(mts, m)
         mts
     end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2283,11 +2283,11 @@ end
     @test accumulate(min, [1 0; 0 1], dims=1) == [1 0; 0 0]
     @test accumulate(min, [1 0; 0 1], dims=2) == [1 0; 0 0]
 
-    @test isa(accumulate(+,     Int[]) , Vector{Int})
-    @test isa(accumulate(+, 1., Int[]) , Vector{Float64})
-    @test accumulate(+, 1, [1,2]) == [2, 4]
+    @test isa(accumulate(+, Int[]), Vector{Int})
+    @test isa(accumulate(+, Int[]; init=1.), Vector{Float64})
+    @test accumulate(+, [1,2]; init=1) == [2, 4]
     arr = randn(4)
-    @test accumulate(*, 1, arr) ≈ accumulate(*, arr)
+    @test accumulate(*, arr; init=1) ≈ accumulate(*, arr)
 
     N = 5
     for arr in [rand(Float64, N), rand(Bool, N), rand(-2:2, N)]
@@ -2313,7 +2313,7 @@ end
     @test accumulate(+, oarr).parent == accumulate(+, arr)
 
     @inferred accumulate(+, randn(3))
-    @inferred accumulate(+, 1, randn(3))
+    @inferred accumulate(+, randn(3); init=1)
 
     # asymmetric operation
     op(x,y) = 2x+y
@@ -2321,7 +2321,7 @@ end
     @test accumulate(op, [10 20 30], dims=2) == [10 op(10, 20) op(op(10, 20), 30)] == [10 40 110]
 
     #25506
-    @test accumulate((acc, x) -> acc+x[1], 0, [(1,2), (3,4), (5,6)]) == [1, 4, 9]
+    @test accumulate((acc, x) -> acc+x[1], [(1,2), (3,4), (5,6)]; init=0) == [1, 4, 9]
     @test accumulate(*, ['a', 'b']) == ["a", "ab"]
     @inferred accumulate(*, String[])
     @test accumulate(*, ['a' 'b'; 'c' 'd'], dims=1) == ["a" "b"; "ac" "bd"]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2283,6 +2283,9 @@ end
     @test accumulate(min, [1 0; 0 1], dims=1) == [1 0; 0 0]
     @test accumulate(min, [1 0; 0 1], dims=2) == [1 0; 0 0]
 
+    @test accumulate(min, [3 2 1; 3 2 1], dims=2) == [3 2 1; 3 2 1]
+    @test accumulate(min, [3 2 1; 3 2 1], dims=2, init=2) == [2 2 1; 2 2 1]
+
     @test isa(accumulate(+, Int[]), Vector{Int})
     @test isa(accumulate(+, Int[]; init=1.), Vector{Float64})
     @test accumulate(+, [1,2]; init=1) == [2, 4]
@@ -2311,6 +2314,7 @@ end
     arr = randn(4)
     oarr = OffsetArray(arr, (-3,))
     @test accumulate(+, oarr).parent == accumulate(+, arr)
+    @test accumulate(+, oarr, init = 10).parent == accumulate(+, arr; init = 10)
 
     @inferred accumulate(+, randn(3))
     @inferred accumulate(+, randn(3); init=1)


### PR DESCRIPTION
Implements the same as #27711 for `accumulate` and `accumulate!`.