### PR TITLE
Add eigmin(::Diagonal).

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -445,8 +445,9 @@ function pinv(D::Diagonal{T}, tol::Real) where T
 end
 
 #Eigensystem
-eigvals(D::Diagonal{<:Number}) = D.diag
-eigvals(D::Diagonal) = [eigvals(x) for x in D.diag] #For block matrices, etc.
+eigvals(D::Diagonal{<:Number}; permute::Bool=true, scale::Bool=true) = D.diag
+eigvals(D::Diagonal; permute::Bool=true, scale::Bool=true) =
+    [eigvals(x) for x in D.diag] #For block matrices, etc.
 eigvecs(D::Diagonal) = Matrix{eltype(D)}(I, size(D))
 function eigen(D::Diagonal; permute::Bool=true, scale::Bool=true)
     if any(!isfinite, D.diag)

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -296,7 +296,8 @@ Stacktrace:
 [...]
 ```
 """
-function eigmin(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)
+function eigmin(A::Union{Number, AbstractMatrix};
+                permute::Bool=true, scale::Bool=true)
     v = eigvals(A, permute = permute, scale = scale)
     if eltype(v)<:Complex
         throw(DomainError(A, "`A` cannot have complex eigenvalues."))

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -267,12 +267,22 @@ srand(1)
         @test svdvals(D) == s
         @test svd(D).V == V
     end
+
 end
 
 @testset "svdvals and eigvals (#11120/#11247)" begin
     D = Diagonal(Matrix{Float64}[randn(3,3), randn(2,2)])
     @test sort([svdvals(D)...;], rev = true) ≈ svdvals([D.diag[1] zeros(3,2); zeros(2,3) D.diag[2]])
     @test [eigvals(D)...;] ≈ eigvals([D.diag[1] zeros(3,2); zeros(2,3) D.diag[2]])
+
+end
+
+@testset "eigmin (#27847)" begin
+    for _ in 1:100
+        d = randn(rand(1:10))
+        D = Diagonal(d)
+        @test eigmin(D) == minimum(d)
+    end
 end
 
 @testset "isposdef" begin


### PR DESCRIPTION
Fixes #27847 by extenting `eigmin` to `AbstractMatrix`.

This requires that `eigvals` accepts `permute` and `scale`, which are then ignored.