### PR TITLE
add propertynames(QRSparse)

### DIFF
--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -314,7 +314,7 @@ end
 
 function Base.propertynames(F::QRSparse, private::Bool=false)
     public = (:R, :Q, :prow, :pcol)
-    (public..., (private ? setdiff(fieldnames(typeof(F)), public) : ())...)
+    private ? ((public ∪ fieldnames(typeof(F)))...,) : public
 end
 
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, F::QRSparse)

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -312,6 +312,11 @@ julia> F.pcol
     end
 end
 
+function Base.propertynames(F::QRSparse, private::Bool=false)
+    public = (:R, :Q, :prow, :pcol)
+    (public..., (private ? setdiff(fieldnames(typeof(F)), public) : ())...)
+end
+
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, F::QRSparse)
     println(io, summary(F))
     println(io, "Q factor:")

--- a/stdlib/SuiteSparse/test/spqr.jl
+++ b/stdlib/SuiteSparse/test/spqr.jl
@@ -87,4 +87,10 @@ end
     @test F.Q*F.R == A[F.prow,F.pcol]
 end
 
+@testset "propertynames of QRSparse" begin
+    A = sparse([0.0 1 0 0; 0 0 0 0])
+    F = qr(A)
+    @test propertynames(F) == (:R, :Q, :prow, :pcol)
+    @test propertynames(F, true) == (:R, :Q, :prow, :pcol, :factors, :τ, :cpiv, :rpivinv)
+end
 end


### PR DESCRIPTION
Add `propertynames` compatible with existing `getproperty` for `QRSparse` in `stdlib/SuiteSparse`.