### PR TITLE
Fix typo in documentation for `range`.

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -49,7 +49,7 @@ end
     range(start; length, stop, step=1)
 
 Given a starting value, construct a range either by length or from `start` to `stop`,
-optionally with a given step (defaults to 1). One of `length` or `step` is required.
+optionally with a given step (defaults to 1). One of `length` or `stop` is required.
 If `length`, `stop`, and `step` are all specified, they must agree.
 
 If `length` and `stop` are provided and `step` is not, the step size will be computed


### PR DESCRIPTION
one of `length` or `stop` must be specified, not one of `length` or `step`.