### PR TITLE
Deprecate findnz(::AbstractArray)

### DIFF
--- a/stdlib/SparseArrays/src/abstractsparse.jl
+++ b/stdlib/SparseArrays/src/abstractsparse.jl
@@ -67,52 +67,20 @@ end
 """
     findnz(A)
 
-Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the non-zero
-values in matrix `A`, and `V` is a vector of the non-zero values.
+Return a tuple `(I, J, V)` where `I` and `J` are the row and column indices of the stored
+("structurally non-zero") values in sparse matrix `A`, and `V` is a vector of the values.
 
 # Examples
 ```jldoctest
-julia> A = [1 2 0; 0 0 3; 0 4 0]
-3×3 Array{Int64,2}:
- 1  2  0
- 0  0  3
- 0  4  0
+julia> A = sparse([1 2 0; 0 0 3; 0 4 0])
+3×3 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
+  [1, 1]  =  1
+  [1, 2]  =  2
+  [3, 2]  =  4
+  [2, 3]  =  3
 
 julia> findnz(A)
 ([1, 1, 3, 2], [1, 2, 2, 3], [1, 2, 4, 3])
 ```
 """
-function findnz(A::AbstractMatrix{T}) where T
-    nnzA = count(t -> t != 0, A)
-    I = zeros(Int, nnzA)
-    J = zeros(Int, nnzA)
-    NZs = Vector{T}(undef, nnzA)
-    cnt = 1
-    if nnzA > 0
-        for j=axes(A,2), i=axes(A,1)
-            Aij = A[i,j]
-            if Aij != 0
-                I[cnt] = i
-                J[cnt] = j
-                NZs[cnt] = Aij
-                cnt += 1
-            end
-        end
-    end
-    return (I, J, NZs)
-end
-
-function findnz(B::BitMatrix)
-    nnzB = count(B)
-    I = Vector{Int}(undef, nnzB)
-    J = Vector{Int}(undef, nnzB)
-    cnt = 1
-    for j = 1:size(B,2), i = 1:size(B,1)
-        if B[i,j]
-            I[cnt] = i
-            J[cnt] = j
-            cnt += 1
-        end
-    end
-    return I, J, trues(length(I))
-end
+function findnz end

--- a/stdlib/SparseArrays/src/deprecated.jl
+++ b/stdlib/SparseArrays/src/deprecated.jl
@@ -233,6 +233,8 @@ Base.@deprecate_binding blkdiag blockdiag
 
 @deprecate diff(a::SparseMatrixCSC, dim::Integer) diff(a, dims=dim)
 
+@deprecate findnz(A::AbstractMatrix) (I = findall(!iszero, A); (getindex.(I, 1), getindex.(I, 2), A[I]))
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -371,10 +371,10 @@ SparseMatrixCSC(M::Matrix) = sparse(M)
 SparseMatrixCSC(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
-    (I, J, V) = findnz(M)
-    eltypeTiI = convert(Vector{Ti}, I)
-    eltypeTiJ = convert(Vector{Ti}, J)
-    eltypeTvV = convert(Vector{Tv}, V)
+    I = findall(x -> x != 0, M)
+    eltypeTiI = Ti[i[1] for i in I]
+    eltypeTiJ = Ti[i[2] for i in I]
+    eltypeTvV = Tv[M[i] for i in I]
     return sparse_IJ_sorted!(eltypeTiI, eltypeTiJ, eltypeTvV, size(M)...)
 end
 function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2197,11 +2197,6 @@ end
     @test A[1,1] == 2
 end
 
-@testset "findnz on non-sparse arrays" begin
-    @test findnz([0 1; 0 2]) == ([1, 2], [2, 2], [1, 2])
-    @test findnz(BitArray([false true; false true])) == ([1, 2], [2, 2], trues(2))
-end
-
 # #25943
 @testset "operations on Integer subtypes" begin
     s = sparse(UInt8[1, 2, 3], UInt8[1, 2, 3], UInt8[1, 2, 3])


### PR DESCRIPTION
The `findnz` function previously had two distinct behaviors: it would either find _stored_ values or _nonzero_ values, depending upon the type of the argument.  This deprecates the `AbstractMatrix` fallback (nonzero) behavior, leaving only the sparse (stored) behavior.