### PR TITLE
rearrange inlining of `ensureroom` and speed it up

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -267,11 +267,19 @@ offset `do`. Return `dest`.
 """
 function copyto!(dest::Array{T}, doffs::Integer, src::Array{T}, soffs::Integer, n::Integer) where T
     n == 0 && return dest
-    n > 0 || throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
+    n > 0 || _throw_argerror(n)
     if soffs < 1 || doffs < 1 || soffs+n-1 > length(src) || doffs+n-1 > length(dest)
         throw(BoundsError())
     end
     unsafe_copyto!(dest, doffs, src, soffs, n)
+    return dest
+end
+
+# Outlining this because otherwise a catastrophic inference slowdown
+# occurs, see discussion in #27874
+function _throw_argerror(n)
+    @_noinline_meta
+    throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
 end
 
 copyto!(dest::Array{T}, src::Array{T}) where {T} = copyto!(dest, 1, src, 1, length(src))
@@ -284,7 +292,7 @@ function fill!(dest::Array{T}, x) where T
     for i in 1:length(dest)
         @inbounds dest[i] = xT
     end
-    dest
+    return dest
 end
 
 """

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -289,11 +289,9 @@ function compact(io::GenericIOBuffer)
     return io
 end
 
-@inline ensureroom(io::GenericIOBuffer, nshort::Int) = ensureroom(io, UInt(nshort))
-@inline function ensureroom(io::GenericIOBuffer, nshort::UInt)
+@noinline function ensureroom_slowpath(io::GenericIOBuffer, nshort::UInt)
     io.writable || throw(ArgumentError("ensureroom failed, IOBuffer is not writeable"))
     if !io.seekable
-        nshort >= 0 || throw(ArgumentError("ensureroom failed, requested number of bytes must be ≥ 0, got $nshort"))
         if !ismarked(io) && io.ptr > 1 && io.size <= io.ptr - 1
             io.ptr = 1
             io.size = 0
@@ -308,9 +306,17 @@ end
             end
         end
     end
-    n = min(nshort + (io.append ? io.size : io.ptr-1), io.maxsize)
-    if n > length(io.data)
-        resize!(io.data, n)
+end
+
+@inline ensureroom(io::GenericIOBuffer, nshort::Int) = ensureroom(io, UInt(nshort))
+@inline function ensureroom(io::GenericIOBuffer, nshort::UInt)
+    if !io.writable || (!io.seekable && io.ptr > 1)
+        ensureroom_slowpath(io, nshort)
+    end
+    n = min((nshort % Int) + (io.append ? io.size : io.ptr-1), io.maxsize)
+    l = length(io.data)
+    if n > l
+        _growend!(io.data, (n - l) % UInt)
     end
     return io
 end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -306,6 +306,7 @@ end
             end
         end
     end
+    return
 end
 
 @inline ensureroom(io::GenericIOBuffer, nshort::Int) = ensureroom(io, UInt(nshort))


### PR DESCRIPTION
If you look at the IR for `write(::IOBuffer, ::UInt8)`, it is absurdly large since both `ensureroom` and `compact` get inlined, plus there are spurious error checks for cases that don't happen. This separates the rare part of `ensureroom` into its own noinline function, and tightens up some of the rest of the code. This benchmark:

```
function buf()
    b = IOBuffer()
    for i = 1:100000
        write(b, '\u2200')
    end
    String(take!(b))
end
```

gets almost 2x faster plus code size is significantly reduced.