### PR TITLE
Better printing of Pair and Dict using typeinfo

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -480,12 +480,20 @@ function typeinfo_prefix(io::IO, X)
     # what the context already knows about the eltype of X:
     eltype_ctx = typeinfo_eltype(typeinfo)
     eltype_X = eltype(X)
-    # Types hard-coded here are those which are created by default for a given syntax
-    if eltype_X == eltype_ctx || !isempty(X) && eltype_X in (Float64, Int, Char, String)
-        ""
-    elseif print_without_params(eltype_X)
-        string(unwrap_unionall(eltype_X).name) # Print "Array" rather than "Array{T,N}"
+    if X isa AbstractDict
+        if eltype_X == eltype_ctx || !isempty(X) && isconcretetype(keytype(X)) && isconcretetype(valtype(X))
+            string(typeof(X).name)
+        else
+            string(typeof(X))
+        end
     else
-        string(eltype_X)
+        # Types hard-coded here are those which are created by default for a given syntax
+        if eltype_X == eltype_ctx || !isempty(X) && eltype_X in (Float64, Int, Char, String)
+            ""
+        elseif print_without_params(eltype_X)
+            string(unwrap_unionall(eltype_X).name) # Print "Array" rather than "Array{T,N}"
+        else
+            string(eltype_X)
+        end
     end
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -571,15 +571,17 @@ has_tight_type(p::Pair) =
 
 isdelimited(io::IO, x) = true
 
-isdelimited(io::IO, p::Pair) = !has_tight_type(p)
+# !isdelimited means that the Pair is printed with "=>" (like in "1 => 2"),
+# without its explicit type (like in "Pair{Integer,Integer}(1, 2)")
+isdelimited(io::IO, p::Pair) = !(has_tight_type(p) || get(io, :typeinfo, Any) == typeof(p))
 
 function show(io::IO, p::Pair)
     compact = get(io, :compact, false)
     iocompact = IOContext(io, :compact => get(io, :compact, true))
-    has_tight_type(p) || return show_default(iocompact, p)
+    isdelimited(io, p) && return show_default(iocompact, p)
 
     typeinfo = get(io, :typeinfo, Any)
-    typeinfos = typeinfo <: Pair && p isa typeinfo ?
+    typeinfos = p isa typeinfo <: Pair ?
         (fieldtype(typeinfo, 1), fieldtype(typeinfo, 2)) : (Any, Any)
 
     isdelimited(iocompact, p.first) || print(io, "(")
@@ -1746,7 +1748,7 @@ end
 
 function alignment(io::IO, x::Pair)
     s = sprint(show, x, context=io, sizehint=0)
-    if has_tight_type(x) # i.e. use "=>" for display
+    if !isdelimited(io, x) # i.e. use "=>" for display
         iocompact = IOContext(io, :compact => get(io, :compact, true))
         left = length(sprint(show, x.first, context=iocompact, sizehint=0))
         left += 2 * !isdelimited(iocompact, x.first) # for parens around p.first

--- a/test/show.jl
+++ b/test/show.jl
@@ -730,8 +730,8 @@ let x = [], y = [], z = Base.ImmutableDict(x => y)
     push!(x, y)
     push!(y, x)
     push!(y, z)
-    @test replstr(x) == "1-element Array{Any,1}:\n Any[Any[Any[#= circular reference @-2 =#]], Base.ImmutableDict(Any[Any[#= circular reference @-3 =#]]=>Any[#= circular reference @-2 =#])]"
-    @test repr(z) == "Base.ImmutableDict(Any[Any[Any[#= circular reference @-2 =#], Base.ImmutableDict(#= circular reference @-3 =#)]]=>Any[Any[Any[#= circular reference @-2 =#]], Base.ImmutableDict(#= circular reference @-2 =#)])"
+    @test replstr(x) == "1-element Array{Any,1}:\n Any[Any[Any[#= circular reference @-2 =#]], Base.ImmutableDict([Any[#= circular reference @-3 =#]]=>[#= circular reference @-2 =#])]"
+    @test repr(z) == "Base.ImmutableDict([Any[Any[#= circular reference @-2 =#], Base.ImmutableDict(#= circular reference @-3 =#)]]=>[Any[Any[#= circular reference @-2 =#]], Base.ImmutableDict(#= circular reference @-2 =#)])"
     @test sprint(dump, x) == """
         Array{Any}((1,))
           1: Array{Any}((2,))
@@ -1200,6 +1200,7 @@ end
 
     @test showstr(Pair{Integer,Integer}(1, 2), :typeinfo => Pair{Integer,Integer}) == "1 => 2"
     @test showstr([Pair{Integer,Integer}(1, 2)]) == "Pair{Integer,Integer}[1=>2]"
+    @test showstr(Dict{Integer,Integer}(1 => 2)) == "Dict{Integer,Integer}(1=>2)"
 end
 
 @testset "#14684: `display` should print associative types in full" begin

--- a/test/show.jl
+++ b/test/show.jl
@@ -990,8 +990,8 @@ end
     @test replstr(Any[Dict(1=>2)=> (3=>4), 1=>2]) ==
         "2-element Array{Any,1}:\n Dict(1=>2) => (3=>4)\n          1 => 2     "
     # left-alignment when not using the "=>" symbol
-    @test replstr(Pair{Integer,Int64}[1=>2, 33=>4]) ==
-        "2-element Array{Pair{Integer,Int64},1}:\n Pair{Integer,Int64}(1, 2) \n Pair{Integer,Int64}(33, 4)"
+    @test replstr(Any[Pair{Integer,Int64}(1, 2), Pair{Integer,Int64}(33, 4)]) ==
+        "2-element Array{Any,1}:\n Pair{Integer,Int64}(1, 2) \n Pair{Integer,Int64}(33, 4)"
 end
 
 @testset "display arrays non-compactly when size(⋅, 2) == 1" begin
@@ -1197,6 +1197,9 @@ end
     @test showstr([keys(Dict('a' => 'b'))]) == "Base.KeySet{Char,Dict{Char,Char}}[['a']]"
     @test showstr([values(Dict('a' => 'b'))]) == "Base.ValueIterator{Dict{Char,Char}}[['b']]"
     @test replstr([keys(Dict('a' => 'b'))]) == "1-element Array{Base.KeySet{Char,Dict{Char,Char}},1}:\n ['a']"
+
+    @test showstr(Pair{Integer,Integer}(1, 2), :typeinfo => Pair{Integer,Integer}) == "1 => 2"
+    @test showstr([Pair{Integer,Integer}(1, 2)]) == "Pair{Integer,Integer}[1=>2]"
 end
 
 @testset "#14684: `display` should print associative types in full" begin


### PR DESCRIPTION
This is a couple small incremental improvements with the typeinfo property, e.g.:
```julia
julia> show(Pair{Integer,Integer}[1=>2]) # BEFORE
Pair{Integer,Integer}[Pair{Integer,Integer}(1, 2)]

julia> show(Dict{Integer,Integer}(1=>2))
Dict{Integer,Integer}(Pair{Integer,Integer}(1, 2))

julia> show(Pair{Integer,Integer}[1=>2]) # AFTER
Pair{Integer,Integer}[1=>2]

julia> show(Dict{Integer,Integer}(1=>2))
Dict{Integer,Integer}(1=>2)
```