### PR TITLE
Make `hypot` dimensionally aware and add tests

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -547,8 +547,8 @@ function hypot(x::T, y::T) where T<:Number
     if ax < ay
         ax, ay = ay, ax
     end
-    if ax == 0
-        r = ay / one(ax)
+    if iszero(ax)
+        r = ay / oneunit(ax)
     else
         r = ay / ax
     end

--- a/test/dimensionful.jl
+++ b/test/dimensionful.jl
@@ -20,6 +20,8 @@ Base.promote_type(::Type{Furlong{p,T}}, ::Type{Furlong{p,S}}) where {p,T,S} =
 
 Base.one(x::Furlong{p,T}) where {p,T} = one(T)
 Base.one(::Type{Furlong{p,T}}) where {p,T} = one(T)
+Base.oneunit(x::Furlong{p,T}) where {p,T} = Furlong{p,T}(one(T))
+Base.oneunit(x::Type{Furlong{p,T}}) where {p,T} = Furlong{p,T}(one(T))
 Base.zero(x::Furlong{p,T}) where {p,T} = Furlong{p,T}(zero(T))
 Base.zero(::Type{Furlong{p,T}}) where {p,T} = Furlong{p,T}(zero(T))
 Base.iszero(x::Furlong) = iszero(x.val)
@@ -35,7 +37,7 @@ Base.abs(x::Furlong{p}) where {p} = Furlong{p}(abs(x.val))
 import LinearAlgebra: sylvester
 sylvester(a::Furlong,b::Furlong,c::Furlong) = -c / (a + b)
 
-for f in (:isfinite, :isnan, :isreal)
+for f in (:isfinite, :isnan, :isreal, :isinf)
     @eval Base.$f(x::Furlong) = $f(x.val)
 end
 for f in (:real,:imag,:complex,:+,:-)

--- a/test/math.jl
+++ b/test/math.jl
@@ -952,3 +952,24 @@ float(x::FloatWrapper) = x
     @test isa(sin(z), Complex)
     @test isa(cos(z), Complex)
 end
+
+module HypotTest
+    import Base: abs, isless, isinf, oneunit, /, *
+    using Test
+
+    struct MeterUnits{T} <: Number
+        val::T
+    end
+    abs(a::MeterUnits) = MeterUnits(abs(a.val))
+    isless(a::MeterUnits{T}, b::MeterUnits{T}) where T  = isless(a.val, b.val)
+    isinf(a::MeterUnits) = isinf(a.val)
+    oneunit(a::MeterUnits) = MeterUnits(one(a.val))
+    /(a::MeterUnits, b::MeterUnits) = a.val / b.val
+    *(a::MeterUnits, b::Real) = MeterUnits(a.val*b)
+
+    @test hypot(MeterUnits(0), MeterUnits(0)) == MeterUnits(0.0)
+    @test hypot(MeterUnits(3), MeterUnits(4)) == MeterUnits(5.0)
+    @test hypot(MeterUnits(NaN), MeterUnits(Inf)) == MeterUnits(Inf)
+    @test hypot(MeterUnits(Inf), MeterUnits(NaN)) == MeterUnits(Inf)
+    @test hypot(MeterUnits(Inf), MeterUnits(Inf)) == MeterUnits(Inf)
+end

--- a/test/math.jl
+++ b/test/math.jl
@@ -953,23 +953,10 @@ float(x::FloatWrapper) = x
     @test isa(cos(z), Complex)
 end
 
-module HypotTest
-    import Base: abs, isless, isinf, oneunit, /, *
-    using Test
-
-    struct MeterUnits{T} <: Number
-        val::T
-    end
-    abs(a::MeterUnits) = MeterUnits(abs(a.val))
-    isless(a::MeterUnits{T}, b::MeterUnits{T}) where T  = isless(a.val, b.val)
-    isinf(a::MeterUnits) = isinf(a.val)
-    oneunit(a::MeterUnits) = MeterUnits(one(a.val))
-    /(a::MeterUnits, b::MeterUnits) = a.val / b.val
-    *(a::MeterUnits, b::Real) = MeterUnits(a.val*b)
-
-    @test hypot(MeterUnits(0), MeterUnits(0)) == MeterUnits(0.0)
-    @test hypot(MeterUnits(3), MeterUnits(4)) == MeterUnits(5.0)
-    @test hypot(MeterUnits(NaN), MeterUnits(Inf)) == MeterUnits(Inf)
-    @test hypot(MeterUnits(Inf), MeterUnits(NaN)) == MeterUnits(Inf)
-    @test hypot(MeterUnits(Inf), MeterUnits(Inf)) == MeterUnits(Inf)
-end
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
+using .Main.TestHelpers: Furlong
+@test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
+@test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
+@test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)
+@test hypot(Furlong(Inf), Furlong(NaN)) == Furlong(Inf)
+@test hypot(Furlong(Inf), Furlong(Inf)) == Furlong(Inf)


### PR DESCRIPTION
I noticed `hypot` could be made more generic. Cross-ref https://github.com/ajkeller34/Unitful.jl/issues/143. I added some tests in the style of those found in [test/arrayops.jl](https://github.com/JuliaLang/julia/blob/b7dc60f7b4e972610846a506b7405f3631bec364/test/arrayops.jl#L1868). 