### PR TITLE
Attempt at fixing realloc use for isbits Union Arrays

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -606,7 +606,7 @@ static int NOINLINE array_resize_buffer(jl_array_t *a, size_t newlen)
         oldnbytes += oldlen;
     }
     int newbuf = 0;
-    if (a->flags.how == 2) {
+    if (a->flags.how == 2 && !is_discriminated_union) {
         // already malloc'd - use realloc
         char *olddata = (char*)a->data - oldoffsnb;
         a->data = jl_gc_managed_realloc(olddata, nbytes, oldnbytes,

--- a/test/core.jl
+++ b/test/core.jl
@@ -5988,6 +5988,15 @@ let A=Vector{Union{Int, Missing}}(undef, 1)
     @test A[2] === missing
 end
 
+# issue #27809
+let A=Vector{Union{Int, Missing}}(undef, 0)
+    while length(A) < 2^17
+        push!(A, 0.0)
+    end
+    push!(A, 0.0)
+    @test !any(ismissing, A)
+end
+
 end # module UnionOptimizations
 
 # issue #6614, argument destructuring


### PR DESCRIPTION
@vtjnash, as far as I understand in debugging the issue reduced [here](https://github.com/JuliaLang/julia/issues/27809#issuecomment-400644398), the problem is we're hitting the `realloc` codepath, yet this messes up isbits Union Arrays since they require a specific memory layout of the data + type tag bytes.

This is the simplest fix for accuracy, but basically punts on ever using realloc for isbits Union Arrays. How bad is that performance-wise? Alternatively, we could probably do some additional isbits Union gymnastics when realloc is used to ensure the right layout is achieved.

Let me know your thoughts and I can take this in another direction if desired.