### PR TITLE
ndigits: make base and pad keywords

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1300,6 +1300,8 @@ Deprecated or removed
     (along with other utilities mostly used at the interactive prompt, such as `edit`
     and `less`) ([#27635]).
 
+  * `ndigits(n, b, [pad])` is deprecated in favor of `ndigits(n, base=b, pad=pad)` ([#27908]).
+
 Command-line option changes
 ---------------------------
 

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1443,6 +1443,10 @@ end
 @deprecate digits(n, base, pad) digits(n, base = base, pad = pad)
 @deprecate digits(T, n, base, pad) digits(T, n, base = base, pad = pad)
 
+#27908
+@deprecate ndigits(n, base)      ndigits(n, base=base)
+@deprecate ndigits(n, base, pad) ndigits(n, base=base, pad=pad)
+
 @deprecate print_with_color(color, args...; kwargs...) printstyled(args...; kwargs..., color=color)
 
 @deprecate base(b, n)      string(n, base = b)

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1440,8 +1440,10 @@ end
 @deprecate countlines(x, eol) countlines(x, eol = eol)
 @deprecate PipeBuffer(data, maxsize) PipeBuffer(data, maxsize = maxsize)
 @deprecate unsafe_wrap(T, pointer, dims, own) unsafe_wrap(T, pointer, dims, own = own)
-@deprecate digits(n, base, pad) digits(n, base = base, pad = pad)
-@deprecate digits(T, n, base, pad) digits(T, n, base = base, pad = pad)
+@deprecate digits(n, base)         digits(n, base = base)
+@deprecate digits(n, base, pad)    digits(n, base = base, pad = pad)
+@deprecate digits(T::Type{<:Integer}, n, base)      digits(T, n, base = base)
+@deprecate digits(T::Type{<:Integer}, n, base, pad) digits(T, n, base = base, pad = pad)
 
 #27908
 @deprecate ndigits(n, base)      ndigits(n, base=base)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -600,7 +600,7 @@ function string(n::BigInt; base::Integer = 10, pad::Integer = 1)
     base < 0 && return Base._base(Int(base), n, pad, (base>0) & (n.size<0))
     2 <= base <= 62 || throw(ArgumentError("base must be 2 ≤ base ≤ 62, got $base"))
     iszero(n) && pad < 1 && return ""
-    nd1 = ndigits(n, base)
+    nd1 = ndigits(n, base=base)
     nd  = max(nd1, pad)
     sv  = Base.StringVector(nd + isneg(n))
     GC.@preserve sv MPZ.get_str!(pointer(sv) + nd - nd1, base, n)
@@ -618,7 +618,7 @@ function ndigits0zpb(x::BigInt, b::Integer)
         MPZ.sizeinbase(x, b)
     else
         # non-base 2 mpz_sizeinbase might return an answer 1 too big
-        # use property that log(b, x) < ndigits(x, b) <= log(b, x) + 1
+        # use property that log(b, x) < ndigits(x, base=b) <= log(b, x) + 1
         n = MPZ.sizeinbase(x, 2)
         lb = log2(b) # assumed accurate to <1ulp (true for openlibm)
         q,r = divrem(n,lb)
@@ -636,8 +636,8 @@ end
 
 # below, ONE is always left-shifted by at least one digit, so a new BigInt is
 # allocated, which can be safely mutated
-prevpow2(x::BigInt) = -2 <= x <= 2 ? x : flipsign!(ONE << (ndigits(x, 2) - 1), x)
-nextpow2(x::BigInt) = count_ones_abs(x) <= 1 ? x : flipsign!(ONE << ndigits(x, 2), x)
+prevpow2(x::BigInt) = -2 <= x <= 2 ? x : flipsign!(ONE << (ndigits(x, base=2) - 1), x)
+nextpow2(x::BigInt) = count_ones_abs(x) <= 1 ? x : flipsign!(ONE << ndigits(x, base=2), x)
 
 Base.checked_abs(x::BigInt) = abs(x)
 Base.checked_neg(x::BigInt) = -x

--- a/base/printf.jl
+++ b/base/printf.jl
@@ -917,7 +917,7 @@ decode_HEX(x::Integer) = decode_hex(x,HEX_symbols)
 
 function decode(b::Int, x::BigInt)
     neg = x.size < 0
-    pt = Base.ndigits(x, abs(b))
+    pt = Base.ndigits(x, base=abs(b))
     digits = DIGITSs[Threads.threadid()]
     length(digits) < pt+1 && resize!(digits, pt+1)
     neg && (x.size = -x.size)

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -309,7 +309,7 @@ end
 function Sampler(::AbstractRNG, r::AbstractUnitRange{BigInt}, ::Repetition)
     m = last(r) - first(r)
     m < 0 && throw(ArgumentError("range must be non-empty"))
-    nd = ndigits(m, 2)
+    nd = ndigits(m, base=2)
     nlimbs, highbits = divrem(nd, 8*sizeof(Limb))
     highbits > 0 && (nlimbs += 1)
     mask = highbits == 0 ? ~zero(Limb) : one(Limb)<<highbits - one(Limb)

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -301,12 +301,12 @@ end
     @test !any(ndigits_mismatch, 8192:9999)
 end
 # The following should not crash (#16579)
-ndigits(big(rand(Int)), rand(63:typemax(Int)))
-ndigits(big(rand(Int)), big(2)^rand(2:999))
+ndigits(big(rand(Int)), base=rand(63:typemax(Int)))
+ndigits(big(rand(Int)), base=big(2)^rand(2:999))
 
 for x in big.([-20:20; rand(Int)])
     for _base in -1:1
-        @test_throws DomainError ndigits(x, _base)
+        @test_throws DomainError ndigits(x, base=_base)
     end
 end
 

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -104,42 +104,42 @@ end
 end
 @testset "ndigits/ndigits0z" begin
     @testset "issue #8266" begin
-        @test ndigits(-15, 10) == 2
-        @test ndigits(-15, -10) == 2
-        @test ndigits(-1, 10) == 1
-        @test ndigits(-1, -10) == 2
-        @test ndigits(2, 10) == 1
-        @test ndigits(2, -10) == 1
-        @test ndigits(10, 10) == 2
-        @test ndigits(10, -10) == 3
-        @test ndigits(17, 10) == 2
-        @test ndigits(17, -10) == 3
-        @test ndigits(unsigned(17), -10) == 3
+        @test ndigits(-15, base=10) == 2
+        @test ndigits(-15, base=-10) == 2
+        @test ndigits(-1, base=10) == 1
+        @test ndigits(-1, base=-10) == 2
+        @test ndigits(2, base=10) == 1
+        @test ndigits(2, base=-10) == 1
+        @test ndigits(10, base=10) == 2
+        @test ndigits(10, base=-10) == 3
+        @test ndigits(17, base=10) == 2
+        @test ndigits(17, base=-10) == 3
+        @test ndigits(unsigned(17), base=-10) == 3
 
-        @test ndigits(146, -3) == 5
+        @test ndigits(146, base=-3) == 5
     end
     let (n, b) = rand(Int, 2)
         -1 <= b <= 1 && (b = 2) # invalid bases
-        @test ndigits(n) == ndigits(big(n)) == ndigits(n, 10)
-        @test ndigits(n, b) == ndigits(big(n), b)
+        @test ndigits(n) == ndigits(big(n)) == ndigits(n, base=10)
+        @test ndigits(n, base=b) == ndigits(big(n), base=b)
     end
 
     for b in -1:1
-        @test_throws DomainError ndigits(rand(Int), b)
+        @test_throws DomainError ndigits(rand(Int), base=b)
     end
     @test ndigits(Int8(5)) == ndigits(5)
 
     # issue #19367
-    @test ndigits(Int128(2)^64, 256) == 9
+    @test ndigits(Int128(2)^64, base=256) == 9
 
     # test unsigned bases
-    @test ndigits(9, 0x2) == 4
-    @test ndigits(0x9, 0x2) == 4
+    @test ndigits(9, base=0x2) == 4
+    @test ndigits(0x9, base=0x2) == 4
 
     # ndigits is defined for Bool
     @test iszero([Base.ndigits0z(false, b) for b in [-20:-2;2:20]])
     @test all(n -> n == 1, Base.ndigits0z(true, b) for b in [-20:-2;2:20])
-    @test all(n -> n == 1, ndigits(x, b) for b in [-20:-2;2:20] for x in [true, false])
+    @test all(n -> n == 1, ndigits(x, base=b) for b in [-20:-2;2:20] for x in [true, false])
 end
 @testset "bin/oct/dec/hex/bits" begin
     @test string(UInt32('3'), base = 2) == "110011"


### PR DESCRIPTION
My initial motivation was that `ndigits(x, [base])` and `log([base], x)` do quite related things (`ndigits(x, base)` and `log(base, x)` are numerically close), but they take their arguments in reverse order, which is rather confusing. One fix would be to reverse the arguments of `ndigits`, but as `ndigits` is also closely related to `digits`, it seems nicer to use keywords, to follow the `digits` API. Also, this allows to specify `pad` while using the default value for `base` -- which also removes one TODO from the code :)

I had started to do the same for `Base.ndigits0z`, but I noticed some performance degradation, so I suspect that constant propagation does not happen with keyword argument... As `ndigits0z` may be used in somewhat more performance sensitive code and is not exported, I propose to keep its old API for now (and using `pad=0` in `ndigits` has the same behavior as `ndigits0z`, so `ndigits` is enough for user-facing API).