### PR TITLE
ReinterpretArray and IndexStyle

### DIFF
--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -49,3 +49,22 @@ let A = collect(reshape(1:20, 5, 4))
     @test view(R, :, :) isa StridedArray
     @test reshape(R, :) isa StridedArray
 end
+
+# IndexStyle
+let a = fill(1.0, 5, 3)
+    r = reinterpret(Int64, a)
+    @test @inferred(IndexStyle(r)) == IndexLinear()
+    fill!(r, 2)
+    @test all(a .=== reinterpret(Float64, [Int64(2)])[1])
+    @test all(r .=== Int64(2))
+    r = reinterpret(Int32, a)
+    @test @inferred(IndexStyle(r)) == IndexLinear()
+    fill!(r, 3)
+    @test all(a .=== reinterpret(Float64, [(Int32(3), Int32(3))])[1])
+    @test all(r .=== Int32(3))
+    r = reinterpret(Int64, view(a, 1:2:5, :))
+    @test @inferred(IndexStyle(r)) == IndexCartesian()
+    fill!(r, 4)
+    @test all(a[1:2:5,:] .=== reinterpret(Float64, [Int64(4)])[1])
+    @test all(r .=== Int64(4))
+end


### PR DESCRIPTION
Cartesian indexing has some overhead:
```julia
julia> a = rand(3,3,3,3,3,3);

julia> v1 = view(a,:,:,:,:,:,:);

julia> v2 = view(a,1:3,:,:,:,:,:);

julia> IndexStyle(v1)
IndexLinear()

julia> IndexStyle(v2)
IndexCartesian()

julia> using BenchmarkTools

julia> @btime fill!(v1, 0);
  79.435 ns (0 allocations: 0 bytes)

julia> @btime fill!(v2, 0);
  1.813 μs (0 allocations: 0 bytes)
```
This is why we set `IndexStyle(a) == IndexLinear()` whenever possible. This PR turns on `IndexLinear()` for appropriate (I hope!) `ReinterpretArray`s. Demo:
```julia
julia> r = reinterpret(Int64, a);

julia> @btime fill!(r, 0);       # on current master
  34.229 μs (0 allocations: 0 bytes)

julia> Revise.track(Base)        # this PR

julia> @btime fill!(r, 0);
  83.182 ns (0 allocations: 0 bytes)
```
That's a 400× improvement. Some of this seems likely to be due to the performance optimizations planned in #27213, but as the example above illustrates, I suspect we'd be seeing some substantial performance gains even if all the LLVM optimizations had been applied. 