### PR TITLE
Use correct effect_free predicate in inlining

### DIFF
--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -1027,7 +1027,7 @@ function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(f
                 (f === Core.kwfunc && length(atypes) == 2) ||
                 (is_inlineable_constant(val) &&
                  (contains_is(_PURE_BUILTINS, f) ||
-                  (f === getfield && effect_free(e, ir, ir.spvals, false, etype)) ||
+                  (f === getfield && stmt_effect_free(e, ir, ir.spvals)) ||
                   (isa(f, IntrinsicFunction) && is_pure_intrinsic_optim(f)))))
                 return quoted(val)
             end

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -3,7 +3,7 @@
 """
 Determine whether a statement is side-effect-free, i.e. may be removed if it has no uses.
 """
-function stmt_effect_free(@nospecialize(stmt), src::IncrementalCompact, spvals::SimpleVector)
+function stmt_effect_free(@nospecialize(stmt), src, spvals::SimpleVector)
     isa(stmt, Union{PiNode, PhiNode}) && return true
     isa(stmt, Union{ReturnNode, GotoNode, GotoIfNot}) && return false
     isa(stmt, GlobalRef) && return isdefined(stmt.mod, stmt.name)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6270,3 +6270,7 @@ foo27770() = get27770(Nullable27770(), Handle27770())
 
 bar27770() = Nullable27770().value
 @test_throws UndefRefError bar27770()
+
+# Issue 27910
+f27910() = ((),)[2]
+@test_throws BoundsError f27910()

--- a/test/core.jl
+++ b/test/core.jl
@@ -6274,3 +6274,8 @@ bar27770() = Nullable27770().value
 # Issue 27910
 f27910() = ((),)[2]
 @test_throws BoundsError f27910()
+
+# Issue 9765
+f9765(::Bool) = 1
+g9765() = f9765(isa(1, 1))
+@test_throws TypeError g9765()


### PR DESCRIPTION
As part of the new optimizer work, I wrote a more accurate effect_free
predicate (stmt_effect_free). However, the old optimizer's less accurate
predicate stuck around and snuck into two places
 1) The inliner
 2) The optimize.jl code that computes proven_pure

As a result, the compiler would eliminate certain statements, even if it could
not prove that they were effect_free. Fix all that by getting rid
of the old predicate and using the new one everywhere.

Fixes #27910