### PR TITLE
fix #27914, parsing juxtaposition of more than two factors

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1016,14 +1016,20 @@
            (error (string "invalid numeric constant \"" expr t "\"")))))
 
 (define (parse-juxtapose s)
-  (let ((ex (parse-unary s)))
-    (let ((next (peek-token s)))
-      (if (juxtapose? s ex next)
-          (begin
-             #;(if (and (number? ex) (= ex 0))
-                   (error "juxtaposition with literal \"0\""))
-            `(call * ,ex ,(parse-factor s)))
-          ex))))
+  (let ((first (parse-unary s)))
+    (let loop ((ex   first)
+               (args (list first)))
+      (let ((next (peek-token s)))
+        (if (juxtapose? s ex next)
+            (begin
+              #;(if (and (number? ex) (= ex 0))
+                    (error "juxtaposition with literal \"0\""))
+              (let ((next (parse-factor s)))
+                (loop `(call * ,ex ,next)
+                      (cons next args))))
+            (if (length= args 1)
+                (car args)
+                (list* 'call '* (reverse args))))))))
 
 (define (maybe-negate op num)
   (if (eq? op '-)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1353,6 +1353,14 @@ end
 @test_throws ParseError Meta.parse("2!3")
 @test_throws ParseError Meta.parse("2√3")
 
+# issue #27914
+@test Meta.parse("2f(x)")        == Expr(:call, :*, 2, Expr(:call, :f, :x))
+@test Meta.parse("f(x)g(x)")     == Expr(:call, :*, Expr(:call, :f, :x), Expr(:call, :g, :x))
+@test Meta.parse("2f(x)g(x)")    == Expr(:call, :*, 2, Expr(:call, :f, :x), Expr(:call, :g, :x))
+@test Meta.parse("f(x)g(x)h(x)") == Expr(:call, :*, Expr(:call, :f, :x), Expr(:call, :g, :x), Expr(:call, :h, :x))
+@test Meta.parse("2(x)")         == Expr(:call, :*, 2, :x)
+@test Meta.parse("2(x)y")        == Expr(:call, :*, 2, :x, :y)
+
 @test_throws ParseError Meta.parse("a.: b")
 @test Meta.parse("a.:end") == Expr(:., :a, QuoteNode(:end))
 @test Meta.parse("a.:catch") == Expr(:., :a, QuoteNode(:catch))


### PR DESCRIPTION
I'm not sure juxtaposing more than 2 expressions was intentional --- interestingly, it seems to have had the wrong associativity. This restores the functionality and parses multiple arguments to a single `*` call, like `*` usually does.