### PR TITLE
RFC: don't show module prefix in `:compact` printing mode

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -312,7 +312,12 @@ print_array(io::IO, X::AbstractArray) = show_nd(io, X, print_matrix, true)
 # typeinfo aware
 # implements: show(io::IO, ::MIME"text/plain", X::AbstractArray)
 function show(io::IO, ::MIME"text/plain", X::AbstractArray)
-    # 0) compute new IOContext
+    # 0) show summary before setting :compact
+    summary(io, X)
+    isempty(X) && return
+    print(io, ":")
+
+    # 1) compute new IOContext
     if !haskey(io, :compact) && length(axes(X, 2)) > 1
         io = IOContext(io, :compact => true)
     end
@@ -321,10 +326,6 @@ function show(io::IO, ::MIME"text/plain", X::AbstractArray)
         io = IOContext(io, :limit => false)
     end
 
-    # 1) print summary info
-    summary(io, X)
-    isempty(X) && return
-    print(io, ":")
     if get(io, :limit, false) && displaysize(io)[1]-4 <= 0
         return print(io, " …")
     else

--- a/base/show.jl
+++ b/base/show.jl
@@ -369,7 +369,7 @@ function show(io::IO, f::Function)
     mt = ft.name.mt
     if isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
         getfield(mt.module, mt.name) === f
-        if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
+        if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main || get(io, :compact, false)
             print(io, mt.name)
         else
             print(io, mt.module, ".", mt.name)
@@ -464,6 +464,13 @@ function show_type_name(io::IO, tn::Core.TypeName)
         end
     end
     sym = globfunc ? globname : tn.name
+    if get(io, :compact, false)
+        if globfunc
+            return print(io, "typeof(", sym, ")")
+        else
+            return print(io, sym)
+        end
+    end
     sym_str = string(sym)
     hidden = !globfunc && '#' ∈ sym_str
     quo = false

--- a/test/core.jl
+++ b/test/core.jl
@@ -1410,7 +1410,7 @@ struct Foo2509; foo::Int; end
 # issue #2517
 struct Foo2517; end
 @test repr(Foo2517()) == "$(curmod_prefix)Foo2517()"
-@test repr(Vector{Foo2517}(undef, 1)) == "$(curmod_prefix)Foo2517[$(curmod_prefix)Foo2517()]"
+@test repr(Vector{Foo2517}(undef, 1)) == "$(curmod_prefix)Foo2517[Foo2517()]"
 @test Foo2517() === Foo2517()
 
 # issue #1474

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -128,11 +128,11 @@ end
 # test for unique Enum values
 @test_throws ArgumentError("values for Enum Test14 are not unique") @macrocall(@enum(Test14, _zero_Test14, _one_Test14, _two_Test14=0))
 
-@test repr(apple) == "apple::$(string(Fruit)) = 0"
+@test repr(apple) == "apple::Fruit = 0"
 @test string(apple) == "apple"
 
 @test repr("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"
-@test repr("text/plain", orange) == "orange::$(curmod_prefix)Fruit = 1"
+@test repr("text/plain", orange) == "orange::Fruit = 1"
 let io = IOBuffer()
     ioc = IOContext(io, :compact=>false)
     show(io, Fruit)

--- a/test/show.jl
+++ b/test/show.jl
@@ -563,8 +563,8 @@ let
     @test sprint(show, B)  == "\n  [1, 1]  =  #undef\n  [2, 2]  =  #undef\n  [3, 3]  =  #undef"
     @test sprint(print, B) == "\n  [1, 1]  =  #undef\n  [2, 2]  =  #undef\n  [3, 3]  =  #undef"
     B[1,2] = T12960()
-    @test sprint(show, B)  == "\n  [1, 1]  =  #undef\n  [1, 2]  =  $(curmod_prefix)T12960()\n  [2, 2]  =  #undef\n  [3, 3]  =  #undef"
-    @test sprint(print, B) == "\n  [1, 1]  =  #undef\n  [1, 2]  =  $(curmod_prefix)T12960()\n  [2, 2]  =  #undef\n  [3, 3]  =  #undef"
+    @test sprint(show, B)  == "\n  [1, 1]  =  #undef\n  [1, 2]  =  T12960()\n  [2, 2]  =  #undef\n  [3, 3]  =  #undef"
+    @test sprint(print, B) == "\n  [1, 1]  =  #undef\n  [1, 2]  =  T12960()\n  [2, 2]  =  #undef\n  [3, 3]  =  #undef"
 end
 
 # issue #13127


### PR DESCRIPTION
Before:
```
julia> fill(Foo.X(), 2, 2)
2×2 Array{Main.Foo.X,2}:
 Main.Foo.X()  Main.Foo.X()
 Main.Foo.X()  Main.Foo.X()
```

after:
```
julia> fill(Foo.X(), 2, 2)
2×2 Array{Main.Foo.X,2}:
 X()  X()
 X()  X()
```

I suspect some packages have added `show` methods just because of this, since it gets quite annoying for big arrays. This doesn't affect 1-d arrays, since they no longer use `:compact`, but I'd like to do something about that if possible --- either use compact printing for all array elements, or change it based on the type of each element.