### PR TITLE
Fix make error message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,6 +193,7 @@ $(build_private_libdir)/corecompiler.ji: $(COMPILER_SRCS) | $(build_private_libd
 		--startup-file=no -g0 -O0 compiler/compiler.jl)
 	@mv $@.tmp $@
 
+COMMA:=,
 $(build_private_libdir)/sys.ji: $(build_private_libdir)/corecompiler.ji $(JULIAHOME)/VERSION $(BASE_SRCS) $(STDLIB_SRCS)
 	@$(call PRINT_JULIA, cd $(JULIAHOME)/base && \
 	if ! $(call spawn,$(JULIA_EXECUTABLE)) -g1 -O0 -C "$(JULIA_CPU_TARGET)" --output-ji $(call cygpath_w,$@).tmp $(JULIA_SYSIMG_BUILD_FLAGS) \
@@ -202,7 +203,6 @@ $(build_private_libdir)/sys.ji: $(build_private_libdir)/corecompiler.ji $(JULIAH
 	fi )
 	@mv $@.tmp $@
 
-COMMA:=,
 define sysimg_builder
 $$(build_private_libdir)/sys$1-o.a $$(build_private_libdir)/sys$1-bc.a : $$(build_private_libdir)/sys$1-%.a : $$(build_private_libdir)/sys.ji
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \


### PR DESCRIPTION
COMMA was used before being defined, and was therefore printed as is.

I guess we could as well remove the comma, but now that it's here... ;-)