### PR TITLE
Add OneTo(::AbstractUnitRange) constructors

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -215,8 +215,16 @@ be 1.
 struct OneTo{T<:Integer} <: AbstractUnitRange{T}
     stop::T
     OneTo{T}(stop) where {T<:Integer} = new(max(zero(T), stop))
+    function OneTo{T}(r::AbstractRange) where {T<:Integer}
+        throwstart(r) = (@_noinline_meta; throw(ArgumentError("first element must be 1, got $(first(r))")))
+        throwstep(r)  = (@_noinline_meta; throw(ArgumentError("step must be 1, got $(step(r))")))
+        first(r) == 1 || throwstart(r)
+        step(r)  == 1 || throwstep(r)
+        return new(max(zero(T), last(r)))
+    end
 end
 OneTo(stop::T) where {T<:Integer} = OneTo{T}(stop)
+OneTo(r::AbstractRange{T}) where {T<:Integer} = OneTo{T}(r)
 
 ## Step ranges parameterized by length
 

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1143,6 +1143,15 @@ end
         @test findall(in(2:(length(r) - 1)), r) === 2:(length(r) - 1)
         @test findall(in(r), 2:(length(r) - 1)) === 1:(length(r) - 2)
     end
+    @test convert(Base.OneTo, 1:2) === Base.OneTo{Int}(2)
+    @test_throws ArgumentError("first element must be 1, got 2") convert(Base.OneTo, 2:3)
+    @test_throws ArgumentError("step must be 1, got 2") convert(Base.OneTo, 1:2:5)
+    @test Base.OneTo(1:2) === Base.OneTo{Int}(2)
+    @test Base.OneTo(1:1:2) === Base.OneTo{Int}(2)
+    @test Base.OneTo{Int32}(1:2) === Base.OneTo{Int32}(2)
+    @test Base.OneTo(Int32(1):Int32(2)) === Base.OneTo{Int32}(2)
+    @test Base.OneTo{Int16}(3.0) === Base.OneTo{Int16}(3)
+    @test_throws InexactError(:Int16, Int16, 3.2) Base.OneTo{Int16}(3.2)
 end
 
 @testset "range of other types" begin


### PR DESCRIPTION
This fixes some method omissions with confusing messages, e.g.:
```julia
julia> convert(Base.OneTo{Int}, 1:2)
ERROR: MethodError: no method matching isless(::UnitRange{Int64}, ::Int64)
Closest candidates are:
  isless(::Missing, ::Any) at missing.jl:66
  isless(::AbstractFloat, ::Real) at operators.jl:150
  isless(::Real, ::Real) at operators.jl:338
  ...
Stacktrace:
 [1] max(::Int64, ::UnitRange{Int64}) at ./operators.jl:400
 [2] Type at ./range.jl:217 [inlined]
 [3] convert(::Type{Base.OneTo{Int64}}, ::UnitRange{Int64}) at ./range.jl:114
 [4] top-level scope at none:0
```
