### PR TITLE
RFC allow packages to fall back to finding UUID in project if not in deps of manifest

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -829,21 +829,18 @@ function require(into::Module, mod::Symbol)
             - Otherwise you may need to report an issue with $(where.name)"""
 
             uuidkey = identify_package(PkgId(string(into)), String(mod))
-            # Attempt fall back to toplevel loading
-            if uuidkey === nothing
-                @error s
-            else
-                if !(where in modules_warned_for)
-                    @warn string(
-                        full_warning_showed[] ? "" : s, "\n",
-                        string("Loading $(mod) into $(where.name) from project dependency, ",
-                               "future warnings for $(where.name) are suppressed.")
-                    ) _module = nothing _file = nothing
-                end
+            uuidkey === nothing && throw(ArgumentError(s))
 
+            # fall back to toplevel loading with a warning
+            if !(where in modules_warned_for)
+                @warn string(
+                    full_warning_showed[] ? "" : s, "\n",
+                    string("Loading $(mod) into $(where.name) from project dependency, ",
+                           "future warnings for $(where.name) are suppressed.")
+                ) _module = nothing _file = nothing
                 push!(modules_warned_for, where)
-                full_warning_showed[] = true
             end
+            full_warning_showed[] = true
         end
     end
     if _track_dependencies[]


### PR DESCRIPTION
A common developer situation is that you have a project with a bunch of dependencies. You are working on the dependencies and want to add a dependency to one of them. 

As a concrete example, let's say I have:

```
(Env) pkg> st
    Status `Project.toml`
  [7876af07] Example v0.5.1+ [`~/.julia/dev/Example`]
  [682c06a0] JSON v0.18.0+ [`~/.julia/dev/JSON`]
```

Now, I want to use `Example` in `JSON`.

The current steps to properly do this before `JSON` can be loaded is:


1. Add `import Example` to `JSON`.
2. Make the `JSON` project your active project.
3. Do `Pkg.add("Example")` to update `Project.toml` in `JSON` (this could potentially fail due to some weird constraints in the Manifest file in the JSON project)
4. Make your previous main project your active project 
5. Do `Pkg.resolve()` to update the main project's `Manifest.toml`, which looks at JSON's `Project.toml` (populate `deps = ["Example"]` for `JSON`).
6. Load `JSON`.

Arguably, the steps 2-5 is  kinda annoying while you are in the heat of developing. The reason we need to lookup the `deps` section in the Manifest is because `JSON´ could potentially have used another package (another UUID) that also had the name Example. However, sometimes the Project.toml Example is the only package with that name in the Manifest, and it is  likely that that is the package that one wanted to load into JSON anyway. So it feels a bit cruel to not allow it to just be loaded.

This PR instead makes the workflow:

1. Add `import Example` to `JSON`.
2. Load `JSON`.

with the result

```
julia> import JSON
[ Info: Precompiling module JSON
┌ Warning: Package JSON does not have Example in its dependencies:
│  - If you have JSON checked out for development and have
│    added Example as a dependency but haven't updated your primary
│    environment's manifest file, try `Pkg.resolve()`.
│  - Otherwise you may need to report an issue with JSON
│
│ Attempting fallback to project dependency with name Example.
└ @ Base loading.jl:817

julia>
```

So it is quite clear that something wrong is happening but you can still continue working.

There are of course other solutions to this issue:

* Make steps 2-5 easier (`pkg> add JSON:Example; resolve`)
* Somehow detect when this situation occurs and do it manually.

The current implementation is not perfect. It will look for fallback packages in environments below you in the stack which is perhaps not wanted. Also, maybe this should only be enabled for packages that are in "developer mode", i.e. tracking a path.

cc @Keno, @stevengj who has been "bitten" by this issue, cc @StefanKarpinski 