### PR TITLE
avoid more conversions to `Any` in default constructors

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -737,7 +737,9 @@
           (else
            (if (equal? type-params params)
                `(new ,Texpr ,@(map (lambda (fty val)
-                                     `(call (top convert) ,fty ,val))
+                                     (if (equal? fty '(core Any))
+                                         val
+                                         `(call (top convert) ,fty ,val)))
                                    (list-head field-types (length args)) args))
                (let ((tn (make-ssavalue)))
                  `(block


### PR DESCRIPTION
This is similar to 179a311c5be0fe22fa31c5d4a757835fddfdf98f from #27918. It doesn't have a huge impact, but it's still worth removing the unnecessary calls.