### PR TITLE
Random: make RandomDevice() instances share the same /dev/urandom file 

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -29,7 +29,7 @@ export rand!, randn!,
        shuffle, shuffle!,
        randperm, randperm!,
        randcycle, randcycle!,
-       AbstractRNG, MersenneTwister, RandomDevice
+       AbstractRNG, MersenneTwister, RandomDevice, RANDOM_DEVICE
 
 ## general definitions
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -16,10 +16,8 @@ using Base.GMP: Limb
 
 using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
 
-import Base: copymutable, copy, copy!, ==, hash, convert
-using Serialization
-import Serialization: serialize, deserialize
-import Base: rand, randn
+import Base: copymutable, copy, copy!, ==, hash, convert,
+             rand, randn
 
 export rand!, randn!,
        randexp, randexp!,
@@ -29,7 +27,7 @@ export rand!, randn!,
        shuffle, shuffle!,
        randperm, randperm!,
        randcycle, randcycle!,
-       AbstractRNG, MersenneTwister, RandomDevice, RANDOM_DEVICE
+       AbstractRNG, MersenneTwister, RandomDevice
 
 ## general definitions
 

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -778,3 +778,7 @@ end
 @testset "RNGs broadcast as scalars: T" for T in (MersenneTwister, RandomDevice)
     @test length.(rand.(T(), 1:3)) == 1:3
 end
+
+@testset "RANDOM_DEVICE" begin
+    @test rand(Random.RANDOM_DEVICE) isa Float64
+end

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -778,7 +778,3 @@ end
 @testset "RNGs broadcast as scalars: T" for T in (MersenneTwister, RandomDevice)
     @test length.(rand.(T(), 1:3)) == 1:3
 end
-
-@testset "RANDOM_DEVICE" begin
-    @test rand(Random.RANDOM_DEVICE) isa Float64
-end


### PR DESCRIPTION
This is a solution to the problem that too many `RandomDevice()` couldn't co-exist because each one would open a separate file.

EDIT: the initial OP below was about "add a global RANDOM_DEVICE generator Random", which was the initial solution to the same problem.

Creating a RandomDevice object is cheap but it opens a file
on unix systems, so one can't call `rand(RandomDevice())`
repeatedly too quicly (e.g. in a loop). It can therefore be
convenient to have a readily available generator.

It was surprisingly difficult to implement this global `RandomDevice` object (of course it would be easier to use a `Ref{RandomDevice}`), so users shouldn't be expected to have to do so themselves, which justifies I think to put it in `Random`. The current implementation is ugly (and possibly wrong), so improvement suggestions are welcome.