### PR TITLE
Test: unexport guardsrand

### DIFF
--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, SparseArrays
+using Test: guardsrand
 
 const BASE_TEST_PATH = joinpath(Sys.BINDIR, "..", "share", "julia", "test")
 isdefined(Main, :TestHelpers) || @eval Main include(joinpath($(BASE_TEST_PATH), "TestHelpers.jl"))

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -7,6 +7,7 @@ using SparseArrays
 using LinearAlgebra
 using Base.Printf: @printf
 using Random
+using Test: guardsrand
 
 @testset "issparse" begin
     @test issparse(sparse(fill(1,5,5)))

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Statistics, Test, Random, LinearAlgebra, SparseArrays
+using Test: guardsrand
 
 @testset "middle" begin
     @test middle(3) === 3.0

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -24,7 +24,7 @@ export @testset
 export @inferred
 export detect_ambiguities, detect_unbound_args
 export GenericString, GenericSet, GenericDict, GenericArray
-export guardsrand, TestSetException
+export TestSetException
 
 import Distributed: myid
 

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test, Distributed, Random
+using Test: guardsrand
 
 import Logging: Debug, Info, Warn
 

--- a/test/error.jl
+++ b/test/error.jl
@@ -6,7 +6,7 @@
     @test maximum(ExponentialBackOff(n=10, max_delay=0.06)) == 0.06
     ratio(x) = x[2:end]./x[1:end-1]
     @test all(x->x ≈ 10.0, ratio(collect(ExponentialBackOff(n=10, max_delay=Inf, factor=10, jitter=0.0))))
-    guardsrand(12345) do
+    Test.guardsrand(12345) do
         x = ratio(collect(ExponentialBackOff(n=100, max_delay=Inf, factor=1, jitter=0.1)))
         xm = sum(x) / length(x)
         @test (xm - 1.0) < 1e-4


### PR DESCRIPTION
This is mostly superseded by the new behavior of `@testset`, which reinitializes the state of the GLOBAL_RNG.

As `guardsrand` was introduced in 0.7, I don't think it needs a deprecation. It could also be entirely removed, as the few uses in the repo could easily be replaced by `@testset` or by using an explicit RNG. ~I'm just not clear if code which was moved out of the repo contains call to this function.~ (EDIT: I found only `IterativeEigensolvers` removed from the repo, which doesn't use anymore `guardsrand`).  