### PR TITLE
delete replace!(pred, A, new)

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -363,27 +363,6 @@ function replace_pairs!(res, A, count::Int, old_new::Tuple{Vararg{Pair}})
 end
 
 """
-    replace!(pred::Function, A, new; [count::Integer])
-
-Replace all occurrences `x` in collection `A` for which `pred(x)` is true
-by `new`.
-
-# Examples
-```jldoctest
-julia> A = [1, 2, 3, 1];
-
-julia> replace!(isodd, A, 0, count=2)
-4-element Array{Int64,1}:
- 0
- 2
- 0
- 1
-```
-"""
-replace!(pred::Callable, A, new; count::Integer=typemax(Int)) =
-    replace!(x -> ifelse(pred(x), new, x), A, count=check_count(count))
-
-"""
     replace!(new::Function, A; [count::Integer])
 
 Replace each element `x` in collection `A` by `new(x)`.
@@ -472,28 +451,6 @@ function subtract_singletontype(::Type{T}, x::Pair{K}) where {T, K}
 end
 subtract_singletontype(::Type{T}, x::Pair{K}, y::Pair...) where {T, K} =
     subtract_singletontype(subtract_singletontype(T, y...), x)
-
-"""
-    replace(pred::Function, A, new; [count::Integer])
-
-Return a copy of collection `A` where all occurrences `x` for which
-`pred(x)` is true are replaced by `new`.
-If `count` is specified, then replace at most `count` occurrences in total.
-
-# Examples
-```jldoctest
-julia> replace(isodd, [1, 2, 3, 1], 0, count=2)
-4-element Array{Int64,1}:
- 0
- 2
- 0
- 1
-```
-"""
-function replace(pred::Callable, A, new; count::Integer=typemax(Int))
-    T = promote_type(eltype(A), typeof(new))
-    _replace!(x -> ifelse(pred(x), new, x), _similar_or_copy(A, T), A, check_count(count))
-end
 
 """
     replace(new::Function, A; [count::Integer])

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -134,7 +134,6 @@ Base.collect(::Type, ::Any)
 Base.filter
 Base.filter!
 Base.replace(::Any, ::Pair...)
-Base.replace(::Base.Callable, ::Any, ::Any)
 Base.replace(::Base.Callable, ::Any)
 Base.replace!
 ```

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -518,16 +518,12 @@ end
     @test replace!(x->2x, a, count=0x2) == [4, 8, 3, 2]
 
     d = Dict(1=>2, 3=>4)
-    @test replace(x->x.first > 2, d, 0=>0) == Dict(1=>2, 0=>0)
     @test replace!(x -> x.first > 2 ? x.first=>2*x.second : x, d) === d
     @test d == Dict(1=>2, 3=>8)
     @test replace(d, (3=>8)=>(0=>0)) == Dict(1=>2, 0=>0)
     @test replace!(d, (3=>8)=>(2=>2)) === d
     @test d == Dict(1=>2, 2=>2)
-    for count = (1, 0x1, big(1))
-        @test replace(x->x.second == 2, d, 0=>0, count=count) in [Dict(1=>2, 0=>0),
-                                                                  Dict(2=>2, 0=>0)]
-    end
+
     s = Set([1, 2, 3])
     @test replace(x -> x > 1 ? 2x : x, s) == Set([1, 4, 6])
     for count = (1, 0x1, big(1))
@@ -553,12 +549,8 @@ end
     # test eltype promotion
     x = @inferred replace([1, 2], 2=>2.5)
     @test x == [1, 2.5] && x isa Vector{Float64}
-    x = @inferred replace(x -> x > 1, [1, 2], 2.5)
-    @test x == [1, 2.5] && x isa Vector{Float64}
 
     x = @inferred replace([1, 2], 2=>missing)
-    @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
-    x = @inferred replace(x -> x > 1, [1, 2], missing)
     @test isequal(x, [1, missing]) && x isa Vector{Union{Int, Missing}}
 
     @test_broken @inferred replace([1, missing], missing=>2)


### PR DESCRIPTION
`replace!(pred, A, new)` replaces all values in `A` for which `pred` is true by the value `new`. It's a very thin wrapper over `replace!(new, A)`.

It was noted in #26206 that this method is ambiguous with another potentially useful method `replace!(new, destination, source)` where `new` is a function giving the updated value given the old value. This method is already more or less implemented with the name `Base._replace!`. It would be a more general version of `replace!(new, A)`.

Admitedly, this `replace!(new, destination, source)` method would have quite some overlap with `map!` (one difference being that `replace!` accepts a `count` keyword).

We could decide to remove conservatively `replace!(pred, A, new)` so that we have more time to think about this problem.
`replace!` was introduced in 0.7, so it would not be (strongly) breaking. 

I don't have a clear opinion on this; marking for triage. 

