### PR TITLE
Logging: print full filepath

### DIFF
--- a/base/path.jl
+++ b/base/path.jl
@@ -5,6 +5,7 @@ export
     basename,
     dirname,
     expanduser,
+    contractuser,
     homedir,
     isabspath,
     isdirpath,
@@ -335,7 +336,9 @@ realpath(path::AbstractString)
 
 
 if Sys.iswindows()
-expanduser(path::AbstractString) = path # on windows, ~ means "temporary file"
+# on windows, ~ means "temporary file"
+expanduser(path::AbstractString) = path
+contractuser(path::AbstractString) = path
 else
 function expanduser(path::AbstractString)
     y = iterate(path)
@@ -347,6 +350,16 @@ function expanduser(path::AbstractString)
     y[1] == '/' && return homedir() * path[i:end]
     throw(ArgumentError("~user tilde expansion not yet implemented"))
 end
+function contractuser(path::AbstractString)
+    home = homedir()
+    if path == home
+        return "~"
+    elseif startswith(path, home)
+        return joinpath("~", relpath(path, home))
+    else
+        return path
+    end
+end
 end
 
 
@@ -356,6 +369,13 @@ end
 On Unix systems, replace a tilde character at the start of a path with the current user's home directory.
 """
 expanduser(path::AbstractString)
+
+"""
+    contractuser(path::AbstractString) -> AbstractString
+
+On Unix systems, if the path starts with `homedir()`, replace it with a tilde character.
+"""
+contractuser(path::AbstractString)
 
 
 """

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -61,7 +61,7 @@ function default_metafmt(level, _module, group, id, file, line)
     color = default_logcolor(level)
     prefix = (level == Warn ? "Warning" : string(level))*':'
     mod = _module === nothing ? "" : "$(_module) "
-    suffix = (Info <= level < Warn) ? "" : "@ $mod$(basename(file)):$line"
+    suffix = (Info <= level < Warn) ? "" : "@ $mod$(Base.contractuser(file)):$line"
     color,prefix,suffix
 end
 

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -22,8 +22,8 @@ import Logging: min_enabled_level, shouldlog, handle_message
     @test shouldlog(logger, Logging.Info, Base, :group, :asdf) === false
 
     @testset "Default metadata formatting" begin
-        @test Logging.default_metafmt(Logging.Debug, Base, :g, :i, "path/to/somefile.jl", 42) ==
-            (:blue,      "Debug:",   "@ Base somefile.jl:42")
+        @test Logging.default_metafmt(Logging.Debug, Base, :g, :i, expanduser("~/somefile.jl"), 42) ==
+            (:blue,      "Debug:",   "@ Base ~/somefile.jl:42")
         @test Logging.default_metafmt(Logging.Info,  Main, :g, :i, "a.jl", 1) ==
             (:cyan,      "Info:",    "")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2) ==

--- a/test/path.jl
+++ b/test/path.jl
@@ -17,6 +17,12 @@
         @test expanduser(S("x")) == "x"
         @test expanduser(S("~")) == (Sys.iswindows() ? "~" : homedir())
     end
+    @testset "Base.contractuser" begin
+        @test Base.contractuser(S(homedir())) == (Sys.iswindows() ? homedir() : "~")
+        @test Base.contractuser(S(joinpath(homedir(), "x"))) ==
+              (Sys.iswindows() ? joinpath(homedir(), "x") : "~$(sep)x")
+        @test Base.contractuser(S("/foo/bar")) == "/foo/bar"
+    end
     @testset "isdirpath" begin
         @test !isdirpath(S("foo"))
         @test isdirpath(S("foo$sep"))


### PR DESCRIPTION
Since logging location are only printed for `@warn` and `@error` I think this should not be too verbose, and when you look for the souce of the warning the extra information is extremely valuable, a filename alone is basically useless.
It is especially annoying when upgrading package, since those tend to have a `src/foo.jl` file accompanied with a `test/foo.jl` file, and it is very frustrating that the depwarn messages don't give the location.
I think this will also help with terminals etc that generate clickable links to the file (@pfitzseb asked about this the other day).

See https://discourse.julialang.org/t/log-eg-depwarn-message-source-full-path/12207 cc @tpapp 