### PR TITLE
Deprecate unused startswith(::Vector{UInt8}, ::Vector{UInt8})

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1740,6 +1740,8 @@ end
 @deprecate mapfoldl(f, op, v0, itr) mapfoldl(f, op, itr; init=v0)
 @deprecate mapfoldr(f, op, v0, itr) mapfoldr(f, op, itr; init=v0)
 
+@deprecate startswith(a::Vector{UInt8}, b::Vector{UInt8}) view(a, 1:length(b)) == b
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1740,7 +1740,7 @@ end
 @deprecate mapfoldl(f, op, v0, itr) mapfoldl(f, op, itr; init=v0)
 @deprecate mapfoldr(f, op, v0, itr) mapfoldr(f, op, itr; init=v0)
 
-@deprecate startswith(a::Vector{UInt8}, b::Vector{UInt8}) view(a, 1:length(b)) == b
+@deprecate startswith(a::Vector{UInt8}, b::Vector{UInt8}) length(a) >= length(b) && view(a, 1:length(b)) == b
 
 # END 0.7 deprecations
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -58,9 +58,6 @@ function startswith(a::Union{String, SubString{String}},
     end
 end
 
-startswith(a::Vector{UInt8}, b::Vector{UInt8}) = length(a) ≥ length(b) &&
-    ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, length(b)) == 0
-
 function endswith(a::Union{String, SubString{String}},
                   b::Union{String, SubString{String}})
     cub = ncodeunits(b)


### PR DESCRIPTION
It's the only `startswith`/`endswith` method to be defined for non-strings (it was used to implement the string methods but shouldn't have been exported).

Extracted from https://github.com/JuliaLang/julia/pull/26631.