### PR TITLE
Stop removing functions without proving them nothrow in inlining

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -135,6 +135,19 @@ function isinlineable(m::Method, me::OptimizationState, bonus::Int=0)
     return inlineable
 end
 
+# These affect control flow within the function (so may not be removed
+# if there is no usage within the function), but don't affect the purity
+# of the function as a whole.
+function stmt_affects_purity(stmt)
+    if isa(stmt, GotoIfNot) || isa(stmt, GotoNode) || isa(stmt, ReturnNode)
+        return false
+    end
+    if isa(stmt, Expr)
+        return stmt.head != :simdloop && stmt.head != :enter
+    end
+    return true
+end
+
 # run the optimization work
 function optimize(opt::OptimizationState, @nospecialize(result))
     def = opt.linfo.def
@@ -153,13 +166,7 @@ function optimize(opt::OptimizationState, @nospecialize(result))
             proven_pure = true
             for i in 1:length(ir.stmts)
                 stmt = ir.stmts[i]
-                # These affect control flow within the function (so may not be removed
-                # if there is no usage within the function), but don't affect the purity
-                # of the function as a whole.
-                if isa(stmt, GotoIfNot) || isa(stmt, GotoNode) || isa(stmt, ReturnNode)
-                    continue
-                end
-                if !stmt_effect_free(stmt, ir, ir.spvals)
+                if stmt_affects_purity(stmt) && !stmt_effect_free(stmt, ir, ir.spvals)
                     proven_pure = false
                     break
                 end

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -82,8 +82,15 @@ const SLOT_USEDUNDEF    = 32 # slot has uses that might raise UndefVarError
 
 const IR_FLAG_INBOUNDS = 0x01
 
-# known affect-free calls (also effect-free)
-const _PURE_BUILTINS = Any[tuple, svec, fieldtype, apply_type, ===, isa, typeof, UnionAll, nfields]
+# known to be always effect-free (in particular nothrow)
+const _PURE_BUILTINS = Any[tuple, svec, ===, typeof, nfields]
+
+# known to be effect-free if the are nothrow
+const _PURE_OR_ERROR_BUILTINS = [
+    fieldtype, apply_type, isa, UnionAll,
+    getfield, arrayref, isdefined, Core.sizeof,
+    Core.kwfunc
+]
 
 const TOP_TUPLE = GlobalRef(Core, :tuple)
 
@@ -166,7 +173,7 @@ function optimize(opt::OptimizationState, @nospecialize(result))
             proven_pure = true
             for i in 1:length(ir.stmts)
                 stmt = ir.stmts[i]
-                if stmt_affects_purity(stmt) && !stmt_effect_free(stmt, ir, ir.spvals)
+                if stmt_affects_purity(stmt) && !stmt_effect_free(stmt, ir.types[i], ir, ir.spvals)
                     proven_pure = false
                     break
                 end

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -998,6 +998,14 @@ function compute_invoke_data(@nospecialize(atypes), argexprs::Vector{Any}, sv::O
     return svec(f, ft, atypes, argexprs, invoke_data)
 end
 
+# Check for a number of functions known to be pure
+function ispuretopfunction(@nospecialize(f))
+    return istopfunction(f, :typejoin) ||
+        istopfunction(f, :isbits) ||
+        istopfunction(f, :isbitstype) ||
+        istopfunction(f, :promote_type)
+end
+
 function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(ft), e::Expr, atypes::Vector{Any}, sv::OptimizationState,
                                    @nospecialize(etype))
     if (f === typeassert || ft ⊑ typeof(typeassert)) && length(atypes) == 3
@@ -1010,22 +1018,19 @@ function early_inline_special_case(ir::IRCode, @nospecialize(f), @nospecialize(f
             return val
         end
     end
-    # special-case inliners for known pure functions that compute types
+
     if sv.params.inlining
         if isa(etype, Const) # || isconstType(etype)
             val = etype.val
-            if (f === apply_type || f === fieldtype || f === typeof || f === (===) ||
-                f === Core.sizeof || f === isdefined ||
-                istopfunction(f, :typejoin) ||
-                istopfunction(f, :isbits) ||
-                istopfunction(f, :isbitstype) ||
-                istopfunction(f, :promote_type) ||
-                (f === Core.kwfunc && length(atypes) == 2) ||
-                (is_inlineable_constant(val) &&
-                 (contains_is(_PURE_BUILTINS, f) ||
-                  (f === getfield && stmt_effect_free(e, ir, ir.spvals)) ||
-                  (isa(f, IntrinsicFunction) && is_pure_intrinsic_optim(f)))))
+            is_inlineable_constant(val) || return nothing
+            if ispuretopfunction(f) ||
+                    (isa(f, IntrinsicFunction) ? is_pure_intrinsic_optim(f) :
+                    contains_is(_PURE_BUILTINS, f))
                 return quoted(val)
+            elseif contains_is(_PURE_OR_ERROR_BUILTINS, f)
+                if _builtin_nothrow(f, atypes[2:end], etype)
+                    return quoted(val)
+                end
             end
         end
     end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -871,7 +871,7 @@ function maybe_erase_unused!(extra_worklist, compact, idx, callback = x->nothing
     if compact_exprtype(compact, SSAValue(idx)) === Bottom
         effect_free = false
     else
-        effect_free = stmt_effect_free(stmt, compact, compact.ir.spvals)
+        effect_free = stmt_effect_free(stmt, compact.result_types[idx], compact, compact.ir.spvals)
     end
     if effect_free
         for ops in userefs(stmt)

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -19,13 +19,7 @@ function stmt_effect_free(@nospecialize(stmt), src, spvals::SimpleVector)
         ea = e.args
         if head === :call
             f = argextype(ea[1], src, spvals)
-            if isa(f, Const)
-                f = f.val
-            elseif isType(f)
-                f = f.parameters[1]
-            else
-                return false
-            end
+            f = isa(f, Const) ? f.val : isType(f) ? f.parameters[1] : return false
             f === return_type && return true
             # TODO: This needs significant refinement
             contains_is(_PURE_BUILTINS, f) || return false

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -687,8 +687,8 @@ function fieldtype_tfunc(@nospecialize(s0), @nospecialize(name))
     u = unwrap_unionall(s)
 
     if isa(u, Union)
-        return tmerge(rewrap(fieldtype_tfunc(u.a, name), s),
-                      rewrap(fieldtype_tfunc(u.b, name), s))
+        return tmerge(rewrap(fieldtype_tfunc(Type{u.a}, name), s),
+                      rewrap(fieldtype_tfunc(Type{u.b}, name), s))
     end
 
     if !isa(u, DataType) || u.abstract

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1147,6 +1147,7 @@ test_const_return(()->sizeof(Int), Tuple{}, sizeof(Int))
 test_const_return(()->sizeof(1), Tuple{}, sizeof(Int))
 test_const_return(()->sizeof(DataType), Tuple{}, sizeof(DataType))
 test_const_return(()->sizeof(1 < 2), Tuple{}, 1)
+test_const_return(()->fieldtype(Dict{Int64,Nothing}, :age), Tuple{}, UInt)
 @eval test_const_return(()->Core.sizeof($(Array{Int,0}(undef))), Tuple{}, sizeof(Int))
 @eval test_const_return(()->Core.sizeof($(Matrix{Float32}(undef, 2, 2))), Tuple{}, 4 * 2 * 2)
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -6292,3 +6292,9 @@ end
     end
 end
 @test isa(bam28102(), Int)
+
+# Check that the tfunc for fieldtype is correct
+struct FooFieldType; x::Int; end
+f_fieldtype(b) = fieldtype(b ? Int : FooFieldType, 1)
+
+@test @inferred(f_fieldtype(false)) == Int

--- a/test/core.jl
+++ b/test/core.jl
@@ -6298,3 +6298,4 @@ struct FooFieldType; x::Int; end
 f_fieldtype(b) = fieldtype(b ? Int : FooFieldType, 1)
 
 @test @inferred(f_fieldtype(false)) == Int
+@test_throws BoundsError f_fieldtype(true)


### PR DESCRIPTION
This is essentially a generalization of #27912, for other intrinsics
that can throw. As our tfuncs get more precise, this will get more and more
important for correctness. WIP because I'm seeing compile time regressions
that I need to investigate.