### PR TITLE
lineinfo color in logger and in stacktrace should be the same

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -27,7 +27,7 @@ debug_color()  = repl_color("JULIA_DEBUG_COLOR" , default_color_debug)
 input_color()  = text_colors[repl_color("JULIA_INPUT_COLOR", default_color_input)]
 answer_color() = text_colors[repl_color("JULIA_ANSWER_COLOR", default_color_answer)]
 
-stackframe_lineinfo_color() = repl_color("JULIA_STACKFRAME_LINEINFO_COLOR", :bold)
+stackframe_lineinfo_color() = repl_color("JULIA_STACKFRAME_LINEINFO_COLOR", :light_black)
 stackframe_function_color() = repl_color("JULIA_STACKFRAME_FUNCTION_COLOR", :bold)
 
 function repl_cmd(cmd, out)

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -146,7 +146,7 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
         if i == length(msglines) && !isempty(suffix)
             npad = max(0, justify_width - nonpadwidth) + minsuffixpad
             print(iob, " "^npad)
-            printstyled(iob, suffix, color=:light_black)
+            printstyled(iob, suffix, color=Base.stackframe_lineinfo_color())
         end
         println(iob)
     end


### PR DESCRIPTION
Before this PR:

![Screenshot showing the line info is printed in different color with logger and back trace](https://user-images.githubusercontent.com/5127634/42409224-d084c330-8209-11e8-8f08-9418f6276755.png)


Notionally, line info in the full StackTrace and the line info shown by the logger are the same thing.
I kind of think of `@warn` as showing a mini-stacktrace (even though it doesn't show stack).

Thus they should be the same (configurable) color..

This PR changes it so they both use the same source of info for that color.
Possibly that function could be renamed to `lineinfo_color()`.


Now for the Bikeshed.
I set it to light-black by default (Or "gray" as we humans call it).
as that was the non-configurable setting used by the logger.
Which presumably already did that bike-shed.
And also the logger output looks really great, IMO.