### PR TITLE
fix displaying arrays of pairs containing an array as first member

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -575,15 +575,19 @@ isdelimited(io::IO, x) = true
 # without its explicit type (like in "Pair{Integer,Integer}(1, 2)")
 isdelimited(io::IO, p::Pair) = !(has_tight_type(p) || get(io, :typeinfo, Any) == typeof(p))
 
+function gettypeinfos(io::IO, p::Pair)
+    typeinfo = get(io, :typeinfo, Any)
+    p isa typeinfo <: Pair ?
+        fieldtype(typeinfo, 1) => fieldtype(typeinfo, 2) :
+        Any => Any
+end
+
 function show(io::IO, p::Pair)
     compact = get(io, :compact, false)
     iocompact = IOContext(io, :compact => get(io, :compact, true))
     isdelimited(io, p) && return show_default(iocompact, p)
 
-    typeinfo = get(io, :typeinfo, Any)
-    typeinfos = p isa typeinfo <: Pair ?
-        (fieldtype(typeinfo, 1), fieldtype(typeinfo, 2)) : (Any, Any)
-
+    typeinfos = gettypeinfos(io, p)
     isdelimited(iocompact, p.first) || print(io, "(")
     show(IOContext(iocompact, :typeinfo => typeinfos[1]), p.first)
     isdelimited(iocompact, p.first) || print(io, ")")
@@ -1749,7 +1753,8 @@ end
 function alignment(io::IO, x::Pair)
     s = sprint(show, x, context=io, sizehint=0)
     if !isdelimited(io, x) # i.e. use "=>" for display
-        iocompact = IOContext(io, :compact => get(io, :compact, true))
+        iocompact = IOContext(io, :compact => get(io, :compact, true),
+                                  :typeinfo => gettypeinfos(io, x)[1])
         left = length(sprint(show, x.first, context=iocompact, sizehint=0))
         left += 2 * !isdelimited(iocompact, x.first) # for parens around p.first
         left += !get(io, :compact, false) # spaces are added around "=>"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1201,6 +1201,9 @@ end
     @test showstr(Pair{Integer,Integer}(1, 2), :typeinfo => Pair{Integer,Integer}) == "1 => 2"
     @test showstr([Pair{Integer,Integer}(1, 2)]) == "Pair{Integer,Integer}[1=>2]"
     @test showstr(Dict{Integer,Integer}(1 => 2)) == "Dict{Integer,Integer}(1=>2)"
+
+    # issue #27979 (dislaying arrays of pairs containing arrays as first member)
+    @test replstr([[1.0]=>1.0]) == "1-element Array{Pair{Array{Float64,1},Float64},1}:\n [1.0] => 1.0"
 end
 
 @testset "#14684: `display` should print associative types in full" begin


### PR DESCRIPTION
Fix the fact that displaying `[[1]=>1]` at the REPL currently fails.