### PR TITLE
Do not run chmod to symbolic links in install.sh

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -23,9 +23,13 @@ for SRC in $ARGS; do
         DESTFILE="$DEST"
     fi
 
-    # Do the chmod dance, and ignore errors on platforms that don't like setting permissions of symlinks
-    # TODO: Test if it's a symlink instead of having to redirect stderr to /dev/null
-    chmod $PERMS $DESTFILE 2>/dev/null
+    # Do the chmod dance.
+    # Symlinks to system libraries are ignored because Julia shouldn't modify
+    # permission of those libraries. If we tried, some platforms would cause
+    # an error.
+    if [ ! -L "$DESTFILE" ]; then
+        chmod $PERMS "$DESTFILE"
+    fi
 done
 
 exit 0


### PR DESCRIPTION
This PR adds correct test of symbolic links to `install.sh`.

Not just a matter of harmless warnings; first of all, Julia shouldn't modify permission of system libralies. In pracitice, Gentoo Linux's sandboxed build system fails by this chmod.

I think it's a bug in the installation script rather than a Gentoo's packaging issue, because Gentoo's sandbox just enforces sane behavior in order to protect a system.