### PR TITLE
Turn unspecified defaults in at-kwdef into required kwargs

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -621,23 +621,24 @@ _crc32c(uuid::UUID, crc::UInt32=0x00000000) =
 This is a helper macro that automatically defines a keyword-based constructor for the type
 declared in the expression `typedef`, which must be a `struct` or `mutable struct`
 expression. The default argument is supplied by declaring fields of the form `field::T =
-default`. If no default is provided then the default is provided by the `kwdef_val(T)`
-function.
+default` or `field = default`. If no default is provided then the keyword argument becomes
+a required keyword argument in the resulting type constructor.
 
 # Examples
 ```jldoctest
-julia> struct Bar end
-
 julia> Base.@kwdef struct Foo
-           a::Cint            # implied default Cint(0)
-           b::Cint = 1        # specified default
-           z::Cstring         # implied default Cstring(C_NULL)
-           y::Bar             # implied default Bar()
+           a::Int = 1         # specified default
+           b::String          # required keyword
        end
 Foo
 
+julia> Foo(b="hi")
+Foo(1, "hi")
+
 julia> Foo()
-Foo(0, 1, Cstring(0x0000000000000000), Bar())
+ERROR: UndefKeywordError: keyword argument b not assigned
+Stacktrace:
+[...]
 ```
 """
 macro kwdef(expr)
@@ -646,10 +647,15 @@ macro kwdef(expr)
     params_ex = Expr(:parameters)
     call_ex = Expr(:call, T)
     _kwdef!(expr.args[3], params_ex, call_ex)
-    quote
+    ret = quote
         Base.@__doc__($(esc(expr)))
-        $(esc(Expr(:call,T,params_ex))) = $(esc(call_ex))
     end
+    # Only define a constructor if the type has fields, otherwise we'll get a stack
+    # overflow on construction
+    if !isempty(params_ex.args)
+        push!(ret.args, :($(esc(Expr(:call, T, params_ex))) = $(esc(call_ex))))
+    end
+    ret
 end
 
 # @kwdef helper function
@@ -657,11 +663,19 @@ end
 function _kwdef!(blk, params_ex, call_ex)
     for i in eachindex(blk.args)
         ei = blk.args[i]
-        isa(ei, Expr) || continue
-        if ei.head == :(=)
+        if isa(ei, Symbol)
+            push!(params_ex.args, ei)
+            push!(call_ex.args, ei)
+        elseif !isa(ei, Expr)
+            continue
+        elseif ei.head == :(=)
             # var::Typ = defexpr
             dec = ei.args[1]  # var::Typ
-            var = dec.args[1] # var
+            if isa(dec, Expr) && dec.head == :(::)
+                var = dec.args[1]
+            else
+                var = dec
+            end
             def = ei.args[2]  # defexpr
             push!(params_ex.args, Expr(:kw, var, def))
             push!(call_ex.args, var)
@@ -669,9 +683,8 @@ function _kwdef!(blk, params_ex, call_ex)
         elseif ei.head == :(::)
             dec = ei # var::Typ
             var = dec.args[1] # var
-            def = :(Base.kwdef_val($(ei.args[2])))
-            push!(params_ex.args, Expr(:kw, var, def))
-            push!(call_ex.args, dec.args[1])
+            push!(params_ex.args, var)
+            push!(call_ex.args, var)
         elseif ei.head == :block
             # can arise with use of @static inside type decl
             _kwdef!(ei, params_ex, call_ex)
@@ -679,44 +692,6 @@ function _kwdef!(blk, params_ex, call_ex)
     end
     blk
 end
-
-
-
-"""
-    kwdef_val(T)
-
-The default value for a type for use with the `@kwdef` macro. Returns:
-
- - null pointer for pointer types (`Ptr{T}`, `Cstring`, `Cwstring`)
- - zero for integer types
- - no-argument constructor calls (e.g. `T()`) for all other types
-
-# Examples
-```jldoctest
-julia> struct Foo
-           i::Int
-       end
-
-julia> Base.kwdef_val(::Type{Foo}) = Foo(42)
-
-julia> Base.@kwdef struct Bar
-           y::Foo
-       end
-Bar
-
-julia> Bar()
-Bar(Foo(42))
-```
-"""
-function kwdef_val end
-
-kwdef_val(::Type{Ptr{T}}) where {T} = Ptr{T}(C_NULL)
-kwdef_val(::Type{Cstring}) = Cstring(C_NULL)
-kwdef_val(::Type{Cwstring}) = Cwstring(C_NULL)
-
-kwdef_val(::Type{T}) where {T<:Integer} = zero(T)
-
-kwdef_val(::Type{T}) where {T} = T()
 
 # testing
 

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -161,34 +161,34 @@ The fields represent:
   * `perfdata_payload`: Payload for the performance callback.
 """
 @kwdef struct CheckoutOptions
-    version::Cuint = 1
+    version::Cuint               = Cuint(1)
 
-    checkout_strategy::Cuint    = Consts.CHECKOUT_SAFE
+    checkout_strategy::Cuint     = Consts.CHECKOUT_SAFE
 
-    disable_filters::Cint
-    dir_mode::Cuint
-    file_mode::Cuint
-    file_open_flags::Cint
+    disable_filters::Cint        = Cint(0)
+    dir_mode::Cuint              = Cuint(0)
+    file_mode::Cuint             = Cuint(0)
+    file_open_flags::Cint        = Cint(0)
 
-    notify_flags::Cuint         = Consts.CHECKOUT_NOTIFY_NONE
-    notify_cb::Ptr{Cvoid}
-    notify_payload::Ptr{Cvoid}
+    notify_flags::Cuint          = Consts.CHECKOUT_NOTIFY_NONE
+    notify_cb::Ptr{Cvoid}        = C_NULL
+    notify_payload::Ptr{Cvoid}   = C_NULL
 
-    progress_cb::Ptr{Cvoid}
-    progress_payload::Ptr{Cvoid}
+    progress_cb::Ptr{Cvoid}      = C_NULL
+    progress_payload::Ptr{Cvoid} = C_NULL
 
-    paths::StrArrayStruct
+    paths::StrArrayStruct        = StrArrayStruct()
 
-    baseline::Ptr{Cvoid}
-    baseline_index::Ptr{Cvoid}
+    baseline::Ptr{Cvoid}         = C_NULL
+    baseline_index::Ptr{Cvoid}   = C_NULL
 
-    target_directory::Cstring
-    ancestor_label::Cstring
-    our_label::Cstring
-    their_label::Cstring
+    target_directory::Cstring    = Cstring(C_NULL)
+    ancestor_label::Cstring      = Cstring(C_NULL)
+    our_label::Cstring           = Cstring(C_NULL)
+    their_label::Cstring         = Cstring(C_NULL)
 
-    perfdata_cb::Ptr{Cvoid}
-    perfdata_payload::Ptr{Cvoid}
+    perfdata_cb::Ptr{Cvoid}      = C_NULL
+    perfdata_payload::Ptr{Cvoid} = C_NULL
 end
 
 """
@@ -198,29 +198,29 @@ Transfer progress information used by the `transfer_progress` remote callback.
 Matches the [`git_transfer_progress`](https://libgit2.github.com/libgit2/#HEAD/type/git_transfer_progress) struct.
 """
 @kwdef struct TransferProgress
-    total_objects::Cuint
-    indexed_objects::Cuint
-    received_objects::Cuint
-    local_objects::Cuint
-    total_deltas::Cuint
-    indexed_deltas::Cuint
-    received_bytes::Csize_t
+    total_objects::Cuint    = Cuint(0)
+    indexed_objects::Cuint  = Cuint(0)
+    received_objects::Cuint = Cuint(0)
+    local_objects::Cuint    = Cuint(0)
+    total_deltas::Cuint     = Cuint(0)
+    indexed_deltas::Cuint   = Cuint(0)
+    received_bytes::Csize_t = Csize_t(0)
 end
 
 @kwdef struct RemoteCallbacksStruct
-    version::Cuint                    = 1
-    sideband_progress::Ptr{Cvoid}
-    completion::Ptr{Cvoid}
-    credentials::Ptr{Cvoid}
-    certificate_check::Ptr{Cvoid}
-    transfer_progress::Ptr{Cvoid}
-    update_tips::Ptr{Cvoid}
-    pack_progress::Ptr{Cvoid}
-    push_transfer_progress::Ptr{Cvoid}
-    push_update_reference::Ptr{Cvoid}
-    push_negotiation::Ptr{Cvoid}
-    transport::Ptr{Cvoid}
-    payload::Ptr{Cvoid}
+    version::Cuint                     = Cuint(1)
+    sideband_progress::Ptr{Cvoid}      = C_NULL
+    completion::Ptr{Cvoid}             = C_NULL
+    credentials::Ptr{Cvoid}            = C_NULL
+    certificate_check::Ptr{Cvoid}      = C_NULL
+    transfer_progress::Ptr{Cvoid}      = C_NULL
+    update_tips::Ptr{Cvoid}            = C_NULL
+    pack_progress::Ptr{Cvoid}          = C_NULL
+    push_transfer_progress::Ptr{Cvoid} = C_NULL
+    push_update_reference::Ptr{Cvoid}  = C_NULL
+    push_negotiation::Ptr{Cvoid}       = C_NULL
+    transport::Ptr{Cvoid}              = C_NULL
+    payload::Ptr{Cvoid}                = C_NULL
 end
 
 """
@@ -309,25 +309,25 @@ julia> fetch(remote, "master", options=fo)
 ```
 """
 @kwdef struct ProxyOptions
-    version::Cuint               = 1
+    version::Cuint               = Cuint(1)
     proxytype::Consts.GIT_PROXY  = Consts.PROXY_AUTO
-    url::Cstring
-    credential_cb::Ptr{Cvoid}
-    certificate_cb::Ptr{Cvoid}
-    payload::Ptr{Cvoid}
+    url::Cstring                 = Cstring(C_NULL)
+    credential_cb::Ptr{Cvoid}    = C_NULL
+    certificate_cb::Ptr{Cvoid}   = C_NULL
+    payload::Ptr{Cvoid}          = C_NULL
 end
 
 @kwdef struct FetchOptionsStruct
-    version::Cuint                  = 1
-    callbacks::RemoteCallbacksStruct
-    prune::Cint                     = Consts.FETCH_PRUNE_UNSPECIFIED
-    update_fetchhead::Cint          = 1
-    download_tags::Cint             = Consts.REMOTE_DOWNLOAD_TAGS_AUTO
+    version::Cuint                     = Cuint(1)
+    callbacks::RemoteCallbacksStruct   = RemoteCallbacksStruct()
+    prune::Cint                        = Consts.FETCH_PRUNE_UNSPECIFIED
+    update_fetchhead::Cint             = Cint(1)
+    download_tags::Cint                = Consts.REMOTE_DOWNLOAD_TAGS_AUTO
     @static if LibGit2.VERSION >= v"0.25.0"
-        proxy_opts::ProxyOptions
+        proxy_opts::ProxyOptions       = ProxyOptions()
     end
     @static if LibGit2.VERSION >= v"0.24.0"
-        custom_headers::StrArrayStruct
+        custom_headers::StrArrayStruct = StrArrayStruct()
     end
 end
 
@@ -360,16 +360,16 @@ end
 
 
 @kwdef struct CloneOptionsStruct
-    version::Cuint                      = 1
-    checkout_opts::CheckoutOptions
-    fetch_opts::FetchOptionsStruct
-    bare::Cint
+    version::Cuint                      = Cuint(1)
+    checkout_opts::CheckoutOptions      = CheckoutOptions()
+    fetch_opts::FetchOptionsStruct      = FetchOptionsStruct()
+    bare::Cint                          = Cint(0)
     localclone::Cint                    = Consts.CLONE_LOCAL_AUTO
-    checkout_branch::Cstring
-    repository_cb::Ptr{Cvoid}
-    repository_cb_payload::Ptr{Cvoid}
-    remote_cb::Ptr{Cvoid}
-    remote_cb_payload::Ptr{Cvoid}
+    checkout_branch::Cstring            = Cstring(C_NULL)
+    repository_cb::Ptr{Cvoid}           = C_NULL
+    repository_cb_payload::Ptr{Cvoid}   = C_NULL
+    remote_cb::Ptr{Cvoid}               = C_NULL
+    remote_cb_payload::Ptr{Cvoid}       = C_NULL
 end
 
 """
@@ -439,20 +439,20 @@ The fields represent:
 
     # options controlling which files are in the diff
     ignore_submodules::GIT_SUBMODULE_IGNORE  = Consts.SUBMODULE_IGNORE_UNSPECIFIED
-    pathspec::StrArrayStruct
-    notify_cb::Ptr{Cvoid}
+    pathspec::StrArrayStruct                 = StrArrayStruct()
+    notify_cb::Ptr{Cvoid}                    = C_NULL
     @static if LibGit2.VERSION >= v"0.24.0"
-        progress_cb::Ptr{Cvoid}
+        progress_cb::Ptr{Cvoid}              = C_NULL
     end
-    payload::Ptr{Cvoid}
+    payload::Ptr{Cvoid}                      = C_NULL
 
     # options controlling how the diff text is generated
     context_lines::UInt32                    = UInt32(3)
-    interhunk_lines::UInt32
+    interhunk_lines::UInt32                  = UInt32(0)
     id_abbrev::UInt16                        = UInt16(7)
     max_size::Int64                          = Int64(512*1024*1024) #512Mb
-    old_prefix::Cstring
-    new_prefix::Cstring
+    old_prefix::Cstring                      = Cstring(C_NULL)
+    new_prefix::Cstring                      = Cstring(C_NULL)
 end
 
 """
@@ -475,13 +475,13 @@ The fields represent:
      commit's [`GitHash`](@ref) instead of throwing an error (the default behavior).
 """
 @kwdef struct DescribeOptions
-    version::Cuint             = 1
-    max_candidates_tags::Cuint = 10
-    describe_strategy::Cuint   = Consts.DESCRIBE_DEFAULT
+    version::Cuint                    = Cuint(1)
+    max_candidates_tags::Cuint        = Cuint(10)
+    describe_strategy::Cuint          = Consts.DESCRIBE_DEFAULT
 
-    pattern::Cstring
-    only_follow_first_parent::Cint
-    show_commit_oid_as_fallback::Cint
+    pattern::Cstring                  = Cstring(C_NULL)
+    only_follow_first_parent::Cint    = Cint(0)
+    show_commit_oid_as_fallback::Cint = Cint(0)
 end
 
 """
@@ -496,10 +496,10 @@ The fields represent:
   * `dirty_suffix`: if set, this will be appended to the end of the description string if the [`workdir`](@ref) is dirty.
 """
 @kwdef struct DescribeFormatOptions
-    version::Cuint          = 1
-    abbreviated_size::Cuint = 7
-    always_use_long_format::Cint
-    dirty_suffix::Cstring
+    version::Cuint               = Cuint(1)
+    abbreviated_size::Cuint      = Cuint(7)
+    always_use_long_format::Cint = Cint(0)
+    dirty_suffix::Cstring        = Cstring(C_NULL)
 end
 
 """
@@ -616,16 +616,16 @@ The fields represent:
   * `file_flags`: guidelines for merging files.
 """
 @kwdef struct MergeOptions
-    version::Cuint                    = 1
-    flags::Cint
-    rename_threshold::Cuint           = 50
-    target_limit::Cuint               = 200
-    metric::Ptr{Cvoid}
+    version::Cuint                    = Cuint(1)
+    flags::Cint                       = Cint(0)
+    rename_threshold::Cuint           = Cuint(50)
+    target_limit::Cuint               = Cuint(200)
+    metric::Ptr{Cvoid}                = C_NULL
     @static if LibGit2.VERSION >= v"0.24.0"
-        recursion_limit::Cuint
+        recursion_limit::Cuint        = Cuint(0)
     end
     @static if LibGit2.VERSION >= v"0.25.0"
-        default_driver::Cstring
+        default_driver::Cstring       = Cstring(C_NULL)
     end
     file_favor::GIT_MERGE_FILE_FAVOR  = Consts.MERGE_FILE_FAVOR_NORMAL
     file_flags::GIT_MERGE_FILE        = Consts.MERGE_FILE_DEFAULT
@@ -651,24 +651,24 @@ The fields represent:
     last line of the file.
 """
 @kwdef struct BlameOptions
-    version::Cuint                    = 1
-    flags::UInt32                     = 0
-    min_match_characters::UInt16      = 20
-    newest_commit::GitHash
-    oldest_commit::GitHash
-    min_line::Csize_t                 = 1
-    max_line::Csize_t                 = 0
+    version::Cuint                    = Cuint(1)
+    flags::UInt32                     = UInt32(0)
+    min_match_characters::UInt16      = UInt16(20)
+    newest_commit::GitHash            = GitHash()
+    oldest_commit::GitHash            = GitHash()
+    min_line::Csize_t                 = Csize_t(1)
+    max_line::Csize_t                 = Csize_t(0)
 end
 
 @kwdef struct PushOptionsStruct
-    version::Cuint                     = 1
-    parallelism::Cint                  = 1
-    callbacks::RemoteCallbacksStruct
+    version::Cuint                     = Cuint(1)
+    parallelism::Cint                  = Cint(1)
+    callbacks::RemoteCallbacksStruct   = RemoteCallbacksStruct()
     @static if LibGit2.VERSION >= v"0.25.0"
-        proxy_opts::ProxyOptions
+        proxy_opts::ProxyOptions       = ProxyOptions()
     end
     @static if LibGit2.VERSION >= v"0.24.0"
-        custom_headers::StrArrayStruct
+        custom_headers::StrArrayStruct = StrArrayStruct()
     end
 end
 
@@ -712,10 +712,10 @@ The fields represent:
      for more information.
 """
 @kwdef struct CherrypickOptions
-    version::Cuint = 1
-    mainline::Cuint = 0
-    merge_opts::MergeOptions=MergeOptions()
-    checkout_opts::CheckoutOptions=CheckoutOptions()
+    version::Cuint = Cuint(1)
+    mainline::Cuint = Cuint(0)
+    merge_opts::MergeOptions = MergeOptions()
+    checkout_opts::CheckoutOptions = CheckoutOptions()
 end
 
 
@@ -775,16 +775,16 @@ The fields represent:
     through it, and aborting it. See [`CheckoutOptions`](@ref) for more information.
 """
 @kwdef struct RebaseOptions
-    version::Cuint                 = 1
-    quiet::Cint                    = 1
+    version::Cuint                 = Cuint(1)
+    quiet::Cint                    = Cint(1)
     @static if LibGit2.VERSION >= v"0.24.0"
-        inmemory::Cint
+        inmemory::Cint             = Cint(0)
     end
-    rewrite_notes_ref::Cstring
+    rewrite_notes_ref::Cstring     = Cstring(C_NULL)
     @static if LibGit2.VERSION >= v"0.24.0"
-        merge_opts::MergeOptions
+        merge_opts::MergeOptions   = MergeOptions()
     end
-    checkout_opts::CheckoutOptions
+    checkout_opts::CheckoutOptions = CheckoutOptions()
 end
 
 """
@@ -837,15 +837,15 @@ The fields represent:
     index; defaults to HEAD.
 """
 @kwdef struct StatusOptions
-    version::Cuint           = 1
+    version::Cuint           = Cuint(1)
     show::Cint               = Consts.STATUS_SHOW_INDEX_AND_WORKDIR
     flags::Cuint             = Consts.STATUS_OPT_INCLUDE_UNTRACKED |
                                Consts.STATUS_OPT_RECURSE_UNTRACKED_DIRS |
                                Consts.STATUS_OPT_RENAMES_HEAD_TO_INDEX |
                                Consts.STATUS_OPT_SORT_CASE_SENSITIVELY
-    pathspec::StrArrayStruct
+    pathspec::StrArrayStruct = StrArrayStruct()
     @static if LibGit2.VERSION >= v"0.27.0"
-        baseline::Ptr{Cvoid}
+        baseline::Ptr{Cvoid} = C_NULL
     end
 end
 
@@ -909,11 +909,11 @@ end
 Matches the [`git_config_entry`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_entry) struct.
 """
 @kwdef struct ConfigEntry
-    name::Cstring
-    value::Cstring
-    level::GIT_CONFIG = Consts.CONFIG_LEVEL_DEFAULT
-    free::Ptr{Cvoid}
-    payload::Ptr{Cvoid}
+    name::Cstring       = Cstring(C_NULL)
+    value::Cstring      = Cstring(C_NULL)
+    level::GIT_CONFIG   = Consts.CONFIG_LEVEL_DEFAULT
+    free::Ptr{Cvoid}    = C_NULL
+    payload::Ptr{Cvoid} = C_NULL
 end
 
 function Base.show(io::IO, ce::ConfigEntry)
@@ -1095,18 +1095,18 @@ The fields represent:
        equal to an oldest commit set in `options`).
 """
 @kwdef struct BlameHunk
-    lines_in_hunk::Csize_t
+    lines_in_hunk::Csize_t                = Csize_t(0)
 
-    final_commit_id::GitHash
-    final_start_line_number::Csize_t
-    final_signature::Ptr{SignatureStruct}
+    final_commit_id::GitHash              = GitHash()
+    final_start_line_number::Csize_t      = Csize_t(0)
+    final_signature::Ptr{SignatureStruct} = Ptr{SignatureStruct}(C_NULL)
 
-    orig_commit_id::GitHash
-    orig_path::Cstring
-    orig_start_line_number::Csize_t
-    orig_signature::Ptr{SignatureStruct}
+    orig_commit_id::GitHash               = GitHash()
+    orig_path::Cstring                    = Cstring(C_NULL)
+    orig_start_line_number::Csize_t       = Csize_t(0)
+    orig_signature::Ptr{SignatureStruct}  = Ptr{SignatureStruct}(C_NULL)
 
-    boundary::Char
+    boundary::Char                        = '\0'
 end
 
 """

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -1275,8 +1275,8 @@ mktempdir() do dir
             LibGit2.commit(repo, "move file1")
             LibGit2.branch!(repo, "master")
             upst_ann = LibGit2.GitAnnotated(repo, "branch/merge_b")
-            rename_flag = 0
-            rename_flag = LibGit2.toggle(rename_flag, 0) # turns on the find renames opt
+            rename_flag = Cint(0)
+            rename_flag = LibGit2.toggle(rename_flag, Cint(0)) # turns on the find renames opt
             mos = LibGit2.MergeOptions(flags=rename_flag)
             @test_logs (:info,"Review and commit merged changes") LibGit2.merge!(repo, [upst_ann], merge_opts=mos)
         end

--- a/stdlib/Pkg/src/GitTools.jl
+++ b/stdlib/Pkg/src/GitTools.jl
@@ -7,7 +7,7 @@ import LibGit2
 using Printf
 
 Base.@kwdef mutable struct MiniProgressBar
-    max::Float64 = 1
+    max::Float64 = 1.0
     header::String = ""
     color::Symbol = :white
     width::Int = 40

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -641,3 +641,30 @@ end
     @test isvalid(timestr_c)
     @test isvalid(timestr_aAbBpZ)
 end
+
+
+using Base: @kwdef
+
+@kwdef struct Test27970Typed
+    a::Int
+    b::String = "hi"
+end
+
+@kwdef struct Test27970Untyped
+    a
+end
+
+@kwdef struct Test27970Empty end
+
+@testset "No default values in @kwdef" begin
+    @test Test27970Typed(a=1) == Test27970Typed(1, "hi")
+    # Implicit type conversion (no assertion on kwarg)
+    @test Test27970Typed(a=0x03) == Test27970Typed(3, "hi")
+    @test_throws UndefKeywordError Test27970Typed()
+
+    @test Test27970Untyped(a=1) == Test27970Untyped(1)
+    @test_throws UndefKeywordError Test27970Untyped()
+
+    # Just checking that this doesn't stack overflow on construction
+    @test Test27970Empty() == Test27970Empty()
+end


### PR DESCRIPTION
The existence of `@kwdef` predates the existence of required keyword arguments; before that, all keyword arguments needed a default value. So currently when no value is specified for a field in the type definition given to `@kwdef`, it's assigned a default value based on the field's type.

Now, with this change, any field not explicitly given a default becomes a required keyword argument in the resulting type constructor when using `@kwdef`. In doing this, we're also able to drop the requirement that the type's fields be typed, and that the type has fields at all. That is, we can now allow
```julia
@kwdef struct A
    a = 1
end
```
as well as
```julia
@kwdef struct A end
```
(though of course the latter case isn't particularly useful).

~~Lastly, this adds type assertions to the keyword arguments in the resulting constructor.~~ That piece has been removed.

Fixes #27970.