### PR TITLE
fix #27964, spurious error about local name conflicting with argument

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2589,7 +2589,7 @@
                                (error (string "variable \"" v "\" declared both local and global"))))
                          glob)
                (let ((argnames (if lam (lam:vars lam) '())))
-                 (if (pair? argnames)
+                 (if (and (pair? argnames) (eq? e (lam:body lam)))
                      (for-each (lambda (v)
                                  (if (memq v argnames)
                                      (error (string "local variable name \"" v "\" conflicts with an argument"))))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1414,6 +1414,30 @@ end
 # issue #15229
 @test Meta.lower(@__MODULE__, :(function f(x); local x; 0; end)) ==
     Expr(:error, "local variable name \"x\" conflicts with an argument")
+@test Meta.lower(@__MODULE__, :(function f(x); begin; local x; 0; end; end)) ==
+    Expr(:error, "local variable name \"x\" conflicts with an argument")
+
+# issue #27964
+a27964(x) = Any[x for x in []]
+@test a27964(0) == Any[]
+function b27964(x)
+    local y
+    let
+        local x
+        x = 2
+        y = x
+    end
+    return (x, y)
+end
+@test b27964(8) == (8, 2)
+function c27964(x)
+    local y
+    let x = 2
+        y = x
+    end
+    return (x, y)
+end
+@test c27964(8) == (8, 2)
 
 # issue #26739
 @test_throws ErrorException("syntax: invalid syntax \"sin.[1]\"") Core.eval(@__MODULE__, :(sin.[1]))


### PR DESCRIPTION
This error should only apply to the outermost scope of the function, not to nested scopes. I believe with this we're back to how it worked in <= v0.4.