### PR TITLE
Fix dump in the presence of nothing

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1607,8 +1607,9 @@ function dump(io::IOContext, @nospecialize(x), n::Int, indent)
                 end
             end
         end
-    else
-        !isa(x, Function) && print(io, " ", x)
+    elseif !isa(x, Function)
+        print(io, " ")
+        show(io, x)
     end
     nothing
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -820,6 +820,9 @@ end
 let repr = sprint(dump, Test)
     @test repr == "Module Test\n"
 end
+let repr = sprint(dump, nothing)
+    @test repr == "Nothing nothing\n"
+end
 let a = Vector{Any}(undef, 10000)
     a[2] = "elemA"
     a[4] = "elemB"


### PR DESCRIPTION
Currently anything that's `dump`ed that contains `nothing` will error, since there's no logic in place for handling `nothing` in `dump` after PR #27829, which removed `print(::Nothing)`.

Before:
```
julia> dump(first(methods(sin)))
Method
  name: Symbol sin
  module: Module Base.MPFR
  file: Symbol mpfr.jl
  line: Int32 683
  sig: Tuple{typeof(sin),BigFloat} <: Any
  min_world: Int64 12691
  ambig: Nothing ERROR: ArgumentError: `nothing` should not be printed; use `show`, `repr`, or custom output instead.
Stacktrace:
 [1] print(::IOContext{Base.TTY}, ::Nothing) at ./show.jl:560
 [2] print(::IOContext{Base.TTY}, ::String, ::Nothing) at ./strings/io.jl:40
 [3] dump(::IOContext{Base.TTY}, ::Any, ::Int64, ::String) at ./show.jl:1611
 [4] dump(::IOContext{Base.TTY}, ::Any, ::Int64, ::String) at ./show.jl:1604
 [5] #dump#368 at ./show.jl:1688 [inlined]
 [6] (::getfield(Base, Symbol("#kw##dump")))(::NamedTuple{(:maxdepth,),Tuple{Int64}}, ::typeof(dump), ::IOContext{Base.TTY}, ::Method) at ./none:0
 [7] #dump#369(::Int64, ::Function, ::Method) at ./show.jl:1720
 [8] dump(::Method) at ./show.jl:1720
 [9] top-level scope at none:0
```

After:
```
julia> dump(first(methods(sin)))
Method
  name: Symbol sin
  module: Module Base.MPFR
  file: Symbol mpfr.jl
  line: Int32 683
  sig: Tuple{typeof(sin),BigFloat} <: Any
  min_world: Int64 12689
  ambig: Nothing nothing
  specializations: Nothing nothing
  sparam_syms: empty SimpleVector
  source: Array{UInt8}((579,)) UInt8[0x00, 0x03, 0x00, 0x00, 0x00, 0x23, 0x73, 0x65, 0x6c, 0x66  …  0xb7, 0xf6, 0x16, 0x01, 0xba, 0xf6, 0x00, 0x00, 0x10, 0x00]
  unspecialized: #undef
  generator: #undef
  roots: Array{Any}((3,))
    1: String "mpfr_sin"
    2: Ref{BigFloat} <: Any
    3: String "NaN result for non-NaN input."
  invokes: #undef
  nargs: Int32 2
  called: Int32 0
  nospecialize: Int32 0
  isva: Bool false
  pure: Bool false
```