### PR TITLE
Remove caveat about WSL timestamps in /mnt

### DIFF
--- a/README.windows.md
+++ b/README.windows.md
@@ -166,10 +166,7 @@ for the former instructions for compiling using MSYS2.
 ### Cross-compiling from Unix
 
 You can also use MinGW-w64 cross compilers to build a Windows version of Julia from
-Linux, Mac, or the Windows Subsystem for Linux (WSL). Note that when compiling in
-WSL, you should use the Linux file system environment, not the `/mnt/` emulated Windows
-paths, since time stamps in `/mnt/` do not work properly as required by configure
-scripts and makefiles (see https://github.com/Microsoft/BashOnWindows/issues/1939).
+Linux, Mac, or the Windows Subsystem for Linux (WSL).
 
 For maximum compatibility with packages that use [WinRPM.jl](
 https://github.com/JuliaLang/WinRPM.jl) for binary dependencies on Windows, it


### PR DESCRIPTION
I believe the underlying problem with the WSL filesystem has been fixed, meaning we can remove this caveat in the windows build instructions. I tested locally and was able to build from source and then rerun make without anything further being recompiled (or, if I pull in new changes, only relevant parts are recompiled).

For reference, original issue in WSL, which has now been closed/fixed: https://github.com/Microsoft/WSL/issues/1939

We can probably also close [this](https://github.com/Microsoft/WSL/issues/2162) issue in WSL that is a julia-specific version of the above issue.