### PR TITLE
typeinfo: require no more that Base types handle typeinfo

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -474,7 +474,6 @@ end
 function typeinfo_prefix(io::IO, X)
     typeinfo = get(io, :typeinfo, Any)::Type
     if !(X isa typeinfo)
-        @assert typeinfo.name.module ∉ (Base, Core) "$(typeof(X)) is not a subtype of $typeinfo"
         typeinfo = Any # no error for user-defined types
     end
     # what the context already knows about the eltype of X:


### PR DESCRIPTION
For Julia version 1.0, it will be annoying to have the `show` code fail seemingly randomly like it happened since the feature was implemented, as people won't get fixes for it easily or fast enough. So this simply removes the assertion which was here only to discover places in Base where `typeinfo` was not yet handled. I think this can wait 1.0, but feel free to merge anytime, e.g. for 0.7.
This is a completion of #26630. 
Reference discussion at #27979.
