### PR TITLE
fix LOAD_PATH for doc building

### DIFF
--- a/doc/Project.toml
+++ b/doc/Project.toml
@@ -1,3 +1,2 @@
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -1,8 +1,9 @@
 # Install dependencies needed to build the documentation.
+empty!(LOAD_PATH)
+push!(LOAD_PATH, @__DIR__, "@stdlib")
 using Pkg
 empty!(DEPOT_PATH)
 pushfirst!(DEPOT_PATH, joinpath(@__DIR__, "deps"))
-pushfirst!(LOAD_PATH, @__DIR__)
 Pkg.instantiate()
 
 using Documenter


### PR DESCRIPTION
Should make doc building a bit more robust against if the user modifies `LOAD_PATH`, and should in theory fix #27993 
Also removes `Compat` from deps, since that was only needed in the Pkg2 -> Pkg3 transition IIRC.