### PR TITLE
License headers, NEWS update, and doc fixes for 0.7

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1447,7 +1447,6 @@ Command-line option changes
 [#23035]: https://github.com/JuliaLang/julia/issues/23035
 [#23051]: https://github.com/JuliaLang/julia/issues/23051
 [#23054]: https://github.com/JuliaLang/julia/issues/23054
-[#23066]: https://github.com/JuliaLang/julia/issues/23066
 [#23117]: https://github.com/JuliaLang/julia/issues/23117
 [#23120]: https://github.com/JuliaLang/julia/issues/23120
 [#23144]: https://github.com/JuliaLang/julia/issues/23144
@@ -1506,6 +1505,7 @@ Command-line option changes
 [#24278]: https://github.com/JuliaLang/julia/issues/24278
 [#24279]: https://github.com/JuliaLang/julia/issues/24279
 [#24281]: https://github.com/JuliaLang/julia/issues/24281
+[#24282]: https://github.com/JuliaLang/julia/issues/24282
 [#24320]: https://github.com/JuliaLang/julia/issues/24320
 [#24356]: https://github.com/JuliaLang/julia/issues/24356
 [#24362]: https://github.com/JuliaLang/julia/issues/24362
@@ -1530,7 +1530,6 @@ Command-line option changes
 [#24679]: https://github.com/JuliaLang/julia/issues/24679
 [#24684]: https://github.com/JuliaLang/julia/issues/24684
 [#24713]: https://github.com/JuliaLang/julia/issues/24713
-[#24714]: https://github.com/JuliaLang/julia/issues/24714
 [#24715]: https://github.com/JuliaLang/julia/issues/24715
 [#24774]: https://github.com/JuliaLang/julia/issues/24774
 [#24781]: https://github.com/JuliaLang/julia/issues/24781
@@ -1569,6 +1568,7 @@ Command-line option changes
 [#25472]: https://github.com/JuliaLang/julia/issues/25472
 [#25496]: https://github.com/JuliaLang/julia/issues/25496
 [#25501]: https://github.com/JuliaLang/julia/issues/25501
+[#25522]: https://github.com/JuliaLang/julia/issues/25522
 [#25532]: https://github.com/JuliaLang/julia/issues/25532
 [#25545]: https://github.com/JuliaLang/julia/issues/25545
 [#25564]: https://github.com/JuliaLang/julia/issues/25564
@@ -1576,6 +1576,7 @@ Command-line option changes
 [#25571]: https://github.com/JuliaLang/julia/issues/25571
 [#25616]: https://github.com/JuliaLang/julia/issues/25616
 [#25622]: https://github.com/JuliaLang/julia/issues/25622
+[#25631]: https://github.com/JuliaLang/julia/issues/25631
 [#25633]: https://github.com/JuliaLang/julia/issues/25633
 [#25634]: https://github.com/JuliaLang/julia/issues/25634
 [#25654]: https://github.com/JuliaLang/julia/issues/25654
@@ -1618,6 +1619,7 @@ Command-line option changes
 [#26347]: https://github.com/JuliaLang/julia/issues/26347
 [#26436]: https://github.com/JuliaLang/julia/issues/26436
 [#26442]: https://github.com/JuliaLang/julia/issues/26442
+[#26486]: https://github.com/JuliaLang/julia/issues/26486
 [#26559]: https://github.com/JuliaLang/julia/issues/26559
 [#26576]: https://github.com/JuliaLang/julia/issues/26576
 [#26600]: https://github.com/JuliaLang/julia/issues/26600
@@ -1642,4 +1644,17 @@ Command-line option changes
 [#27189]: https://github.com/JuliaLang/julia/issues/27189
 [#27212]: https://github.com/JuliaLang/julia/issues/27212
 [#27248]: https://github.com/JuliaLang/julia/issues/27248
+[#27309]: https://github.com/JuliaLang/julia/issues/27309
 [#27401]: https://github.com/JuliaLang/julia/issues/27401
+[#27447]: https://github.com/JuliaLang/julia/issues/27447
+[#27459]: https://github.com/JuliaLang/julia/issues/27459
+[#27470]: https://github.com/JuliaLang/julia/issues/27470
+[#27473]: https://github.com/JuliaLang/julia/issues/27473
+[#27554]: https://github.com/JuliaLang/julia/issues/27554
+[#27616]: https://github.com/JuliaLang/julia/issues/27616
+[#27635]: https://github.com/JuliaLang/julia/issues/27635
+[#27641]: https://github.com/JuliaLang/julia/issues/27641
+[#27711]: https://github.com/JuliaLang/julia/issues/27711
+[#27746]: https://github.com/JuliaLang/julia/issues/27746
+[#27859]: https://github.com/JuliaLang/julia/issues/27859
+[#27908]: https://github.com/JuliaLang/julia/issues/27908

--- a/base/secretbuffer.jl
+++ b/base/secretbuffer.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 """
     Base.SecretBuffer()
 

--- a/contrib/fixup-rpath.sh
+++ b/contrib/fixup-rpath.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 # Usage: fixup-rpath.sh <patchelf path> <dir to process> <build libdir>
 
 if [ $# -ne 3 ]; then

--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -83,7 +83,7 @@ although it can also be invoked directly by a call to [`macroexpand()`](@ref)/`j
 
 ## [Type Inference](@id dev-type-inference)
 
-Type inference is implemented in Julia by [`typeinf()` in `compiler/typeinf.jl`](https://github.com/JuliaLang/julia/blob/master/base/compiler/typeinf.jl).
+Type inference is implemented in Julia by [`typeinf()` in `compiler/typeinfer.jl`](https://github.com/JuliaLang/julia/blob/master/base/compiler/typeinfer.jl).
 Type inference is the process of examining a Julia function and determining bounds for the types
 of each of its variables, as well as bounds on the type of the return value from the function.
 This enables many future optimizations, such as unboxing of known immutable values, and compile-time

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1143,7 +1143,7 @@ Newly launched workers are connected to each other and the master process in an 
 Specifying the command line argument `--worker[=<cookie>]` results in the launched processes
 initializing themselves as workers and connections being set up via TCP/IP sockets.
 
-All workers in a cluster share the same [cookie](#cluster-cookie) as the master. When the cookie is
+All workers in a cluster share the same [cookie](@ref man-cluster-cookie) as the master. When the cookie is
 unspecified, i.e, with the `--worker` option, the worker tries to read it from its standard input.
  `LocalManager` and `SSHManager` both pass the cookie to newly launched workers via their
  standard inputs.
@@ -1306,7 +1306,7 @@ requirements for the inbuilt `LocalManager` and `SSHManager`:
     Securing and encrypting all worker-worker traffic (via SSH) or encrypting individual messages
     can be done via a custom `ClusterManager`.
 
-## Cluster Cookie
+## [Cluster Cookie](@id man-cluster-cookie)
 
 All processes in a cluster share the same cookie which, by default, is a randomly generated string
 on the master process:

--- a/stdlib/LinearAlgebra/test/trickyarithmetic.jl
+++ b/stdlib/LinearAlgebra/test/trickyarithmetic.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module TrickyArithmetic
     struct A
         x::Int

--- a/stdlib/Pkg/src/versions.jl
+++ b/stdlib/Pkg/src/versions.jl
@@ -1,3 +1,4 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ################
 # VersionBound #

--- a/stdlib/Pkg/test/test_packages/BigProject/RecursiveDep/src/RecursiveDep.jl
+++ b/stdlib/Pkg/test/test_packages/BigProject/RecursiveDep/src/RecursiveDep.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module RecursiveDep
 
 using RecursiveDep2

--- a/stdlib/Pkg/test/test_packages/BigProject/RecursiveDep2/src/RecursiveDep2.jl
+++ b/stdlib/Pkg/test/test_packages/BigProject/RecursiveDep2/src/RecursiveDep2.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 module RecursiveDep2
 
 end

--- a/test/TestPkg/src/TestPkg.jl
+++ b/test/TestPkg/src/TestPkg.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 __precompile__()
 module TestPkg
 

--- a/test/secretbuffer.jl
+++ b/test/secretbuffer.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Base: SecretBuffer, SecretBuffer!, shred!, isshredded
 using Test
 


### PR DESCRIPTION
Should be merged before #27973.

Note that `make -C doc linkcheck=true` still fails due to a relative reference that Curl doesn't know how to deal with: a link to NEWS.md near the top of doc/src/index.md. The link itself works in the rendered documentation though.