### PR TITLE
Random: define Sampler from types, not objects

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -548,7 +548,7 @@ end
 #### from a range
 
 for T in BitInteger_types, R=(1, Inf) # eval because of ambiguity otherwise
-    @eval Sampler(rng::MersenneTwister, r::UnitRange{$T}, ::Val{$R}) =
+    @eval Sampler(::Type{MersenneTwister}, r::UnitRange{$T}, ::Val{$R}) =
         SamplerRangeFast(r)
 end
 

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -112,19 +112,22 @@ const Repetition = Union{Val{1},Val{Inf}}
 # Sampler(::AbstractRNG, X, ::Val{Inf}) = Sampler(X)
 # Sampler(::AbstractRNG, ::Type{X}, ::Val{Inf}) where {X} = Sampler(X)
 
-Sampler(rng::AbstractRNG, sp::Sampler, ::Repetition) =
+Sampler(rng::AbstractRNG, x, r::Repetition=Val(Inf)) = Sampler(typeof(rng), x, r)
+Sampler(rng::AbstractRNG, ::Type{X}, r::Repetition=Val(Inf)) where {X} = Sampler(typeof(rng), X, r)
+
+Sampler(::Type{<:AbstractRNG}, sp::Sampler, ::Repetition) =
     throw(ArgumentError("Sampler for this object is not defined"))
 
 # default shortcut for the general case
-Sampler(rng::AbstractRNG, X) = Sampler(rng, X, Val(Inf))
-Sampler(rng::AbstractRNG, ::Type{X}) where {X} = Sampler(rng, X, Val(Inf))
+Sampler(::Type{RNG}, X) where {RNG<:AbstractRNG} = Sampler(RNG, X, Val(Inf))
+Sampler(::Type{RNG}, ::Type{X}) where {RNG<:AbstractRNG,X} = Sampler(RNG, X, Val(Inf))
 
 #### pre-defined useful Sampler types
 
 # default fall-back for types
 struct SamplerType{T} <: Sampler{T} end
 
-Sampler(::AbstractRNG, ::Type{T}, ::Repetition) where {T} = SamplerType{T}()
+Sampler(::Type{<:AbstractRNG}, ::Type{T}, ::Repetition) where {T} = SamplerType{T}()
 
 Base.getindex(::SamplerType{T}) where {T} = T
 
@@ -135,7 +138,7 @@ end
 
 SamplerTrivial(x::T) where {T} = SamplerTrivial{T,eltype(T)}(x)
 
-Sampler(::AbstractRNG, x, ::Repetition) = SamplerTrivial(x)
+Sampler(::Type{<:AbstractRNG}, x, ::Repetition) = SamplerTrivial(x)
 
 Base.getindex(sp::SamplerTrivial) = sp.self
 

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -16,8 +16,8 @@
 
 ### random floats
 
-Sampler(rng::AbstractRNG, ::Type{T}, n::Repetition) where {T<:AbstractFloat} =
-    Sampler(rng, CloseOpen01(T), n)
+Sampler(::Type{RNG}, ::Type{T}, n::Repetition) where {RNG<:AbstractRNG,T<:AbstractFloat} =
+    Sampler(RNG, CloseOpen01(T), n)
 
 # generic random generation function which can be used by RNG implementors
 # it is not defined as a fallback rand method as this could create ambiguities
@@ -53,7 +53,7 @@ struct SamplerBigFloat{I<:FloatInterval{BigFloat}} <: Sampler{BigFloat}
     end
 end
 
-Sampler(::AbstractRNG, I::FloatInterval{BigFloat}, ::Repetition) =
+Sampler(::Type{<:AbstractRNG}, I::FloatInterval{BigFloat}, ::Repetition) =
     SamplerBigFloat{typeof(I)}(precision(BigFloat))
 
 function _rand(rng::AbstractRNG, sp::SamplerBigFloat)
@@ -274,7 +274,7 @@ function SamplerRangeInt(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}
     SamplerRangeInt{T,U}(a, bw, k, mult) # overflow ok
 end
 
-Sampler(::AbstractRNG, r::AbstractUnitRange{T},
+Sampler(::Type{<:AbstractRNG}, r::AbstractUnitRange{T},
         ::Repetition) where {T<:BitInteger} = SamplerRangeInt(r)
 
 
@@ -306,7 +306,7 @@ struct SamplerBigInt <: Sampler{BigInt}
     mask::Limb        # applied to the highest limb
 end
 
-function Sampler(::AbstractRNG, r::AbstractUnitRange{BigInt}, ::Repetition)
+function Sampler(::Type{<:AbstractRNG}, r::AbstractUnitRange{BigInt}, ::Repetition)
     m = last(r) - first(r)
     m < 0 && throw(ArgumentError("range must be non-empty"))
     nd = ndigits(m, base=2)
@@ -339,8 +339,8 @@ end
 
 ## random values from AbstractArray
 
-Sampler(rng::AbstractRNG, r::AbstractArray, n::Repetition) =
-    SamplerSimple(r, Sampler(rng, firstindex(r):lastindex(r), n))
+Sampler(::Type{RNG}, r::AbstractArray, n::Repetition) where {RNG<:AbstractRNG} =
+    SamplerSimple(r, Sampler(RNG, firstindex(r):lastindex(r), n))
 
 rand(rng::AbstractRNG, sp::SamplerSimple{<:AbstractArray,<:Sampler}) =
     @inbounds return sp[][rand(rng, sp.data)]
@@ -348,11 +348,11 @@ rand(rng::AbstractRNG, sp::SamplerSimple{<:AbstractArray,<:Sampler}) =
 
 ## random values from Dict
 
-function Sampler(rng::AbstractRNG, t::Dict, ::Repetition)
+function Sampler(::Type{RNG}, t::Dict, ::Repetition) where RNG<:AbstractRNG
     isempty(t) && throw(ArgumentError("collection must be non-empty"))
     # we use Val(Inf) below as rand is called repeatedly internally
     # even for generating only one random value from t
-    SamplerSimple(t, Sampler(rng, LinearIndices(t.slots), Val(Inf)))
+    SamplerSimple(t, Sampler(RNG, LinearIndices(t.slots), Val(Inf)))
 end
 
 function rand(rng::AbstractRNG, sp::SamplerSimple{<:Dict,<:Sampler})
@@ -364,16 +364,16 @@ end
 
 ## random values from Set
 
-Sampler(rng::AbstractRNG, t::Set{T}, n::Repetition) where {T} =
-    SamplerTag{Set{T}}(Sampler(rng, t.dict, n))
+Sampler(::Type{RNG}, t::Set{T}, n::Repetition) where {RNG<:AbstractRNG,T} =
+    SamplerTag{Set{T}}(Sampler(RNG, t.dict, n))
 
 rand(rng::AbstractRNG, sp::SamplerTag{<:Set,<:Sampler}) = rand(rng, sp.data).first
 
 ## random values from BitSet
 
-function Sampler(rng::AbstractRNG, t::BitSet, n::Repetition)
+function Sampler(RNG::Type{<:AbstractRNG}, t::BitSet, n::Repetition)
     isempty(t) && throw(ArgumentError("collection must be non-empty"))
-    SamplerSimple(t, Sampler(rng, minimum(t):maximum(t), Val(Inf)))
+    SamplerSimple(t, Sampler(RNG, minimum(t):maximum(t), Val(Inf)))
 end
 
 function rand(rng::AbstractRNG, sp::SamplerSimple{BitSet,<:Sampler})
@@ -386,15 +386,15 @@ end
 ## random values from AbstractDict/AbstractSet
 
 # we defer to _Sampler to avoid ambiguities with a call like Sampler(rng, Set(1), Val(1))
-Sampler(rng::AbstractRNG, t::Union{AbstractDict,AbstractSet}, n::Repetition) =
-    _Sampler(rng, t, n)
+Sampler(RNG::Type{<:AbstractRNG}, t::Union{AbstractDict,AbstractSet}, n::Repetition) =
+    _Sampler(RNG, t, n)
 
 # avoid linear complexity for repeated calls
-_Sampler(rng::AbstractRNG, t::Union{AbstractDict,AbstractSet}, n::Val{Inf}) =
-    Sampler(rng, collect(t), n)
+_Sampler(RNG::Type{<:AbstractRNG}, t::Union{AbstractDict,AbstractSet}, n::Val{Inf}) =
+    Sampler(RNG, collect(t), n)
 
 # when generating only one element, avoid the call to collect
-_Sampler(::AbstractRNG, t::Union{AbstractDict,AbstractSet}, ::Val{1}) =
+_Sampler(::Type{<:AbstractRNG}, t::Union{AbstractDict,AbstractSet}, ::Val{1}) =
     SamplerTrivial(t)
 
 function nth(iter, n::Integer)::eltype(iter)
@@ -411,12 +411,12 @@ rand(rng::AbstractRNG, sp::SamplerTrivial{<:Union{AbstractDict,AbstractSet}}) =
 
 # we use collect(str), which is most of the time more efficient than specialized methods
 # (except maybe for very small arrays)
-Sampler(rng::AbstractRNG, str::AbstractString, n::Val{Inf}) = Sampler(rng, collect(str), n)
+Sampler(RNG::Type{<:AbstractRNG}, str::AbstractString, n::Val{Inf}) = Sampler(RNG, collect(str), n)
 
 # when generating only one char from a string, the specialized method below
 # is usually more efficient
-Sampler(rng::AbstractRNG, str::AbstractString, ::Val{1}) =
-    SamplerSimple(str, Sampler(rng, 1:_lastindex(str), Val(Inf)))
+Sampler(RNG::Type{<:AbstractRNG}, str::AbstractString, ::Val{1}) =
+    SamplerSimple(str, Sampler(RNG, 1:_lastindex(str), Val(Inf)))
 
 isvalid_unsafe(s::String, i) = !Base.is_valid_continuation(GC.@preserve s unsafe_load(pointer(s), i))
 isvalid_unsafe(s::AbstractString, i) = isvalid(s, i)


### PR DESCRIPTION
Currently, one defines a sampler on a type with `Sampler(rng::AbstractRNG, x, r) = ...`. This changes this to `Sampler(RNG::Type{<:AbstractRNG}, x, r)`.

The reasoning is that an instance of an RNG shouldn't be used in this function, i.e. only the type is enough to create a `Sampler` object, which can then be used by different rng instances of the same type.

For convenience, a fall-back `Sampler(rng::AbstractRNG, x, r) = Sampler(typeof(rng), x, r)` is defined. This is similar to what `eltype` does.