### PR TITLE
Reduce repetitions from long backtrace

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -12,10 +12,7 @@ struct CapturedException <: Exception
         # Typically the result of a catch_backtrace()
 
         # Process bt_raw so that it can be safely serialized
-        bt_lines = Any[]
-        process_func(args...) = push!(bt_lines, args)
-        process_backtrace(process_func, bt_raw, 100) # Limiting this to 100 lines.
-
+        bt_lines = process_backtrace(bt_raw, 100) # Limiting this to 100 lines.
         CapturedException(ex, bt_lines)
     end
 


### PR DESCRIPTION
This PR fixes #24592.

The stacktrace itself is not modified, but the printing function `show_backtrace` now shrinks repeated sequences of function calls into a single sequence, followed by a message stating how many times this sequence occurred in the backtrace. This works in a recursive fashion too and does not override the original optimization (for sequences of only one call), as the following example shows:
```julia
begin_loop() = a(120)
a(n) = n==0 ? switch_loop() : b(n-1)  # a calls b
b(n) = n==0 ? switch_loop() : c(n-1)  # b calls c
c(n) = n==0 ? switch_loop() : a(n-1)  # c calls a
switch_loop() = d(10)
d(n) = n==0 ? restart_loop() : d(n-1)  # d calls itself (old optimization)
restart_loop() = begin_loop() # big loop that encompasses the different cycles and stack overflows

julia> begin_loop()
ERROR: StackOverflowError:
Stacktrace:
 [1] c(::Int64) at ./REPL[4]:1
 [2] b(::Int64) at ./REPL[3]:1
 [3] a(::Int64) at ./REPL[2]:1
 ... (the last 3 lines are repeated 4 more times)
 [16] begin_loop() at ./REPL[1]:1
 [17] restart_loop() at ./REPL[7]:1
 [18] d(::Int64) at ./REPL[6]:1 (repeats 11 times)
 [19] switch_loop() at ./REPL[5]:1
 [20] a(::Int64) at ./REPL[2]:1
 [21] c(::Int64) at ./REPL[4]:1
 [22] b(::Int64) at ./REPL[3]:1
 ... (the last 3 lines are repeated 39 more times)
 [140] a(::Int64) at ./REPL[2]:1
 ... (the last 125 lines are repeated 591 more times)
 [74016] begin_loop() at ./REPL[1]:1
 [74017] restart_loop() at ./REPL[7]:1
 [74018] d(::Int64) at ./REPL[6]:1 (repeats 11 times)
 [74019] switch_loop() at ./REPL[5]:1
 [74020] a(::Int64) at ./REPL[2]:1
 [74021] c(::Int64) at ./REPL[4]:1
 [74022] b(::Int64) at ./REPL[3]:1
 ... (the last 3 lines are repeated 15 more times)
 [74068] a(::Int64) at ./REPL[2]:1
 [74069] c(::Int64) at ./REPL[4]:1

julia>
```

This PR is not specific to StackOverflowError, it works with any showed backtrace. It should also work with backtraces from the compiler, such as a stack overflow during inference, but I did not test that.

Additionally, since the whole operation of detecting repetitions in backtraces can take some time, it is only triggered if the backtrace contains more than 50 function calls. This restriction (and the constant 50) can be changed of course, I just didn't know how desirable it was to impact small backtraces.

I took this opportunity to remove the side-effect function argument of `process_backtrace` since it could advantageously be replaced by a simple return value. This change is breaking but `process_backtrace` is not exported and I couldn't find any use of it in the packages I had installed.