### PR TITLE
jat/prevfloats support prevfloat(x, int)

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -596,7 +596,7 @@ uabs(x::BitSigned) = unsigned(abs(x))
 The result of `n` iterative applications of `nextfloat` to `x` if `n >= 0`, or `-n`
 applications of `prevfloat` if `n < 0`.
 """
-function nextfloat(f::IEEEFloat, d::Integer)
+function nextfloat(f::AbstractFloat, d::Integer)
     F = typeof(f)
     fumax = reinterpret(Unsigned, F(Inf))
     U = typeof(fumax)
@@ -648,7 +648,7 @@ nextfloat(x::AbstractFloat) = nextfloat(x,1)
 The result of `n` iterative applications of `prevfloat` to `x` if `n >= 0`, or `-n`
 applications of `nextfloat` if `n < 0`.
 """
-prevfloat(x::IEEEFloat, d::Integer) = nextfloat(x, -d)
+prevfloat(x::AbstractFloat, d::Integer) = nextfloat(x, -d)
 
 """
     prevfloat(x::AbstractFloat)

--- a/base/float.jl
+++ b/base/float.jl
@@ -643,6 +643,14 @@ such `y` exists (e.g. if `x` is `Inf` or `NaN`), then return `x`.
 nextfloat(x::AbstractFloat) = nextfloat(x,1)
 
 """
+    prevfloat(x::AbstractFloat, n::Integer)
+
+The result of `n` iterative applications of `prevfloat` to `x` if `n >= 0`, or `-n`
+applications of `nextfloat` if `n < 0`.
+"""
+prevfloat(f::IEEEFloat, d::Integer) = nextfloat(x, -d)
+
+"""
     prevfloat(x::AbstractFloat)
 
 Return the largest floating point number `y` of the same type as `x` such `y < x`. If no

--- a/base/float.jl
+++ b/base/float.jl
@@ -648,7 +648,7 @@ nextfloat(x::AbstractFloat) = nextfloat(x,1)
 The result of `n` iterative applications of `prevfloat` to `x` if `n >= 0`, or `-n`
 applications of `nextfloat` if `n < 0`.
 """
-prevfloat(f::IEEEFloat, d::Integer) = nextfloat(x, -d)
+prevfloat(x::IEEEFloat, d::Integer) = nextfloat(x, -d)
 
 """
     prevfloat(x::AbstractFloat)

--- a/base/float.jl
+++ b/base/float.jl
@@ -591,12 +591,12 @@ uabs(x::BitSigned) = unsigned(abs(x))
 
 
 """
-    nextfloat(x::AbstractFloat, n::Integer)
+    nextfloat(x::IEEEFloat, n::Integer)
 
 The result of `n` iterative applications of `nextfloat` to `x` if `n >= 0`, or `-n`
 applications of `prevfloat` if `n < 0`.
 """
-function nextfloat(f::AbstractFloat, d::Integer)
+function nextfloat(f::IEEEFloat, d::Integer)
     F = typeof(f)
     fumax = reinterpret(Unsigned, F(Inf))
     U = typeof(fumax)

--- a/test/math.jl
+++ b/test/math.jl
@@ -56,8 +56,11 @@ end
         end
 
         for (a,b) in [(T(12.8),T(0.8)),
-                      (prevfloat(realmin(T)), nextfloat(one(T),-2)),
-                      (nextfloat(zero(T),3), T(0.75)),
+                      (prevfloat(realmin(T)), prevfloat(one(T), 2)),
+                      (prevfloat(realmin(T)), prevfloat(one(T), 2)),
+                      (prevfloat(realmin(T)), nextfloat(one(T), -2)),
+                      (nextfloat(zero(T), 3), T(0.75)),
+                      (prevfloat(zero(T), -3), T(0.75)),
                       (nextfloat(zero(T)), T(0.5))]
 
             n = Int(log2(a/b))


### PR DESCRIPTION
We support nextfloat(x, ±int). This PR provides symmetry, supporting prevfloat(x, ±int).  The definition is in terms of nextfloat, and tests have been added.  I know this has been discussed; unaware of a resolution, this PR is offered.  If it has been determined not to provide this -- just close the PR. Thanks.