### PR TITLE
fix #27993: remove OldPkg from precompilation setup

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1104,7 +1104,6 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
     try
         write(in, """
         begin
-        import OldPkg
         $(Base.load_path_setup_code())
         Base._track_dependencies[] = true
         empty!(Base._concrete_dependencies)


### PR DESCRIPTION
Make sure that the precompile-process do not pick up `JULIA_LOAD_PATH` when precompiling
Documenter in the doc build. This now works for me:
```
$ export JULIA_LOAD_PATH="" && make docs
```