### PR TITLE
Support mapreduce over dimensions with SkipMissing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -324,6 +324,20 @@ reducedim_initarray(itr::SkipMissing{<:AbstractArray}, region, init, ::Type{R}) 
 reducedim_initarray(itr::SkipMissing{<:AbstractArray}, region, init::T) where {T} =
     reducedim_initarray(itr.x, region, init, T)
 
+reducedim_init(f, op::Union{typeof(+),typeof(add_sum)},
+               itr::SkipMissing{<:AbstractArray}, region) =
+    _reducedim_init(f, op, zero, sum, itr, region)
+reducedim_init(f, op::Union{typeof(*),typeof(mul_prod)},
+               itr::SkipMissing{<:AbstractArray}, region) =
+    _reducedim_init(f, op, one, prod, itr, region)
+reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max),
+               itr::SkipMissing{<:AbstractArray}, region) =
+    reducedim_initarray(itr, region, zero(f(zero(eltype(itr)))))
+reducedim_init(f, op::typeof(&), itr::SkipMissing{<:AbstractArray}, region) =
+    reducedim_initarray(itr, region, true)
+reducedim_init(f, op::typeof(|), itr::SkipMissing{<:AbstractArray}, region) =
+    reducedim_initarray(itr, region, false)
+
 # initialization when computing minima and maxima requires a little care
 for (f1, f2, initval) in ((:min, :max, :Inf), (:max, :min, :(-Inf)))
     @eval function reducedim_init(f, op::typeof($f1), itr::SkipMissing{<:AbstractArray}, region)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -99,10 +99,10 @@ reducedim_initarray(A::AbstractArray, region, init::T) where {T} = reducedim_ini
 promote_union(T::Union) = promote_type(promote_union(T.a), promote_union(T.b))
 promote_union(T) = T
 
-function reducedim_init(f, op::Union{typeof(+),typeof(add_sum)}, A, region)
+function reducedim_init(f, op::Union{typeof(+),typeof(add_sum)}, A::AbstractArray, region)
     _reducedim_init(f, op, zero, sum, A, region)
 end
-function reducedim_init(f, op::Union{typeof(*),typeof(mul_prod)}, A, region)
+function reducedim_init(f, op::Union{typeof(*),typeof(mul_prod)}, A::AbstractArray, region)
     _reducedim_init(f, op, one, prod, A, region)
 end
 function _reducedim_init(f, op, fv, fop, A, region)
@@ -145,11 +145,11 @@ for (f1, f2, initval) in ((:min, :max, :Inf), (:max, :min, :(-Inf)))
         end
     end
 end
-reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max), A, region) =
-    reducedim_initarray(A, region, zero(f(zero(eltype(A)))))
+reducedim_init(f::Union{typeof(abs),typeof(abs2)}, op::typeof(max), A::AbstractArray{T}, region) where {T} =
+    reducedim_initarray(A, region, zero(f(zero(T))))
 
-reducedim_init(f, op::typeof(&), A, region) = reducedim_initarray(A, region, true)
-reducedim_init(f, op::typeof(|), A, region) = reducedim_initarray(A, region, false)
+reducedim_init(f, op::typeof(&), A::AbstractArray, region) = reducedim_initarray(A, region, true)
+reducedim_init(f, op::typeof(|), A::AbstractArray, region) = reducedim_initarray(A, region, false)
 
 # specialize to make initialization more efficient for common cases
 

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -305,7 +305,36 @@ julia> mapreduce(sqrt, +, skipmissing([3, missing, 2, 1]))
 4.146264369941973
 ```
 
-Use [`collect`](@ref) to extract non-`missing` values and store them in an array
+Reduction over dimensions is also supported
+```jldoctest
+julia> B = [1 missing; 3 4]
+2×2 Array{Union{Missing, Int64},2}:
+ 1   missing
+ 3  4
+
+julia> sum(skipmissing(B), dims=1)
+1×2 Array{Int64,2}:
+ 4  4
+
+julia> sum(skipmissing(B), dims=2)
+2×1 Array{Int64,2}:
+ 1
+ 7
+
+julia> reduce(*, skipmissing(B), dims=1)
+1×2 Array{Int64,2}:
+ 3  4
+
+julia> mapreduce(cos, +, skipmissing(B), dims=1)
+1×2 Array{Float64,2}:
+ -0.44969  -0.653644
+```
+
+However, note that the special iterator object returned by `skipmissing` is not an
+`AbstractArray`: since `missing` entries of the original array are skipped,
+it does not have a regular shape and cannot be indexed.
+Use [`collect`](@ref) to extract non-`missing` values and store them in a vector,
+losing the shape of the original array
 ```jldoctest
 julia> collect(skipmissing([3, missing, 2, 1]))
 3-element Array{Int64,1}:


### PR DESCRIPTION
~~The first commit fixes things like `mapreduce(cos, +, Union{Int,Missing}[1], dims=1)`. See https://github.com/JuliaLang/julia/issues/26709 and https://github.com/JuliaLang/julia/pull/27457. A deeper revamp is needed, but given that the current code doesn't make sense, that sounds like an improvement.~~ EDIT: first commit moved to  #28089.

The second commit adds an implementation of `mapreduce` over dimensions for `SkipMissing{<:AbstractArray}`, closely based on the existing `AbstractArray` methods. This allows doing things which currently don't work like `mapreduce(skipmissing([1 2; missing 4]), dims=1)` to compute column sums while skipping missing values.

Unfortunately, the simple idea I had of just wrapping the user-provided reduction operation in a function which skips missing values does not work, because `_mapreducedim!` calls `mapreduce_impl` for efficiency when possible, and it fails when a slice contains only missing values (cf. https://github.com/JuliaLang/julia/pull/27743). Also performance would probably be worse, at least for now.

I'm not really happy about the amount of duplication this requires, but that's the only solution I could find. Apart from the boilerplate dispatching methods, we could avoid duplicating `_mapreducedim!` and `reducedim_initarray0` but that would introduce several not-so-pretty `A isa SkipMissing` checks. So maybe maintaining two very similar sets of functions in parallel isn't so bad. It should be quite easy to apply changes to both, as long as one doesn't forget that two methods exist.

Replaces https://github.com/JuliaLang/julia/pull/27818.