### PR TITLE
NEWS: clarify type of keyword argument containers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@ New language features
   * Named tuples, with the syntax `(a=1, b=2)`. These behave very similarly to tuples,
     except components can also be accessed by name using dot syntax `t.a` ([#22194]).
 
-  * Keyword argument containers (`kw` in `f(; kw...)`) are now named tuples. Dictionary
+  * Keyword argument containers (`kw` in `f(; kw...)`) are now based on named tuples. Dictionary
     functions like `haskey` and indexing can be used on them, and name-value pairs can be
     iterated using `pairs(kw)`. `kw` can no longer contain multiple entries for the same
     argument name ([#4916]).


### PR DESCRIPTION
As keyword argument containers are not actually named tuples, rephrase the NEWS entry to "based on named tuples".

Closes #25875.