### PR TITLE
Remove type assertion hack in mapreduce for skipmissing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -254,8 +254,6 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
         end
         i > ilast && return Some(mapreduce_first(f, op, a1))
         a2 = ai::eltype(itr)
-        # Unexpectedly, the following assertion allows SIMD instructions to be emitted
-        A[i]::eltype(itr)
         i += 1
         v = op(f(a1), f(a2))
         @simd for i = i:ilast


### PR DESCRIPTION
No longer needed since https://github.com/JuliaLang/julia/pull/27945.

@nanosoldier `runbenchmarks("union", vs=":master")`