### PR TITLE
build MPFR with float128 support

### DIFF
--- a/deps/mpfr.mk
+++ b/deps/mpfr.mk
@@ -20,6 +20,8 @@ ifeq ($(OS),Darwin)
 MPFR_CHECK_MFLAGS := LDFLAGS="$(LDFLAGS) -Wl,-rpath,'$(build_libdir)'"
 endif
 
+MPFR_OPTS += --enable-float128
+
 ifeq ($(SANITIZE),1)
 # Force generic C build
 MPFR_OPTS += --host=none-unknown-linux


### PR DESCRIPTION
This PR adds the configure option `--enable-float128` to `mpfr`. My plan is to get the `Quadmath` package which provides the `Float128` type in better shape and easy to use. Julia already provides `libquadmath` and `libgcc_s` so everything else is already in place. In theory it would be possible for `Quadmath` to build its own copy of `mpfr`, but this is currently a real hassle especially on Windows and Mac. Also it would have to be ABI compatible to the one provided by Julia. If I'm not wrong, Julia hooks its own allocator into `gmp/mpfr` so this would have to be done as well. If it builds on all supported platforms, I don't see any downside.