### PR TITLE
allow prompt and getpass to dispatch on the input-stream type

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -413,6 +413,9 @@ end
 let buf = IOBuffer()
     @test Base.prompt(IOBuffer("foo\nbar\n"), buf, "baz") == "foo"
     @test String(take!(buf)) == "baz: "
+    @test Base.prompt(IOBuffer("\n"), buf, "baz", default="foobar") == "foobar"
+    @test String(take!(buf)) == "baz [foobar]: "
+    @test Base.prompt(IOBuffer("blah\n"), buf, "baz", default="foobar") == "blah"
 end
 
 # Test that we can VirtualProtect jitted code to writable

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -408,6 +408,13 @@ let a = [1,2,3]
     @test a == [0,0,0]
 end
 
+# PR #28038 (prompt/getpass stream args)
+@test_throws MethodError Base.getpass(IOBuffer(), stdout, "pass")
+let buf = IOBuffer()
+    @test Base.prompt(IOBuffer("foo\nbar\n"), buf, "baz") == "foo"
+    @test String(take!(buf)) == "baz: "
+end
+
 # Test that we can VirtualProtect jitted code to writable
 @noinline function WeVirtualProtectThisToRWX(x, y)
     return x + y


### PR DESCRIPTION
We have non-exported methods `Base.getpass(msg)` and `Base.prompt(msg)` that are new in 0.7.   These assume that `stdin` is a TTY, and in fact on Windows they bypass libuv entirely via `ccall(:_getch)`.  Hence, they may lead to unexpected results if `stdin` has been redirected.

For example, in IJulia, this apparently causes the password to be printed in the clear on Mac and Linux (JuliaLang/IJulia.jl#678), whereas on Windows the password read may block in the terminal where Jupyter was launched.

This PR makes `getpass(msg) = getpass(stdin, stdout, msg)` and similarly for `prompt`.   This way, they can dispatch in the type of `stdin`.  If `stdin` or `stdout` has been redirected, they will either throw a `MethodError` or call a custom method if one has been defined (e.g. in IJulia).