### PR TITLE
pass LOAD_PATH to precompile/build/test children (fix #27993)

### DIFF
--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -475,7 +475,6 @@ function precompile(ctx::Context)
     code = join(["import " * pkg for pkg in needs_to_be_precompiled], '\n') * "\nexit(0)"
     for (i, pkg) in enumerate(needs_to_be_precompiled)
         code = """
-            import OldPkg
             $(Base.load_path_setup_code())
             import $pkg
         """

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -3,7 +3,6 @@
 using REPL.REPLCompletions
 using Test
 using Random
-import OldPkg
 
 let ex = quote
     module CompletionFoo

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -3,6 +3,7 @@
 using REPL.REPLCompletions
 using Test
 using Random
+import OldPkg
 
 let ex = quote
     module CompletionFoo


### PR DESCRIPTION
also remove no-longer-needed `import OldPkg` statements