### PR TITLE
fix #26419, be able to infer `read(filename, String)`

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -289,6 +289,8 @@ Read the entire contents of a file as a string.
 """
 read(filename::AbstractString, args...) = open(io->read(io, args...), filename)
 
+read(filename::AbstractString, ::Type{T}) where {T} = open(io->read(io, T), filename)
+
 """
     read!(stream::IO, array::Union{Array, BitArray})
     read!(filename::AbstractString, array::Union{Array, BitArray})

--- a/test/read.jl
+++ b/test/read.jl
@@ -568,3 +568,6 @@ let p = Pipe()
     @test length(s) == 660_000 + typemax(UInt16)
     @test s[(end - typemax(UInt16)):end] == UInt16.(0:typemax(UInt16))
 end
+
+# issue #26419
+@test Base.return_types(read, (String, Type{String})) == Any[String]


### PR DESCRIPTION
This is such a simple and common function I think it's worth quickly point-fixing this case.