### PR TITLE
change `widen` to strict 2x widening

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -496,8 +496,7 @@ This section lists changes that do not have deprecation warnings.
   * `isequal` for `Ptr`s now compares element types; `==` still compares only addresses
     ([#26858]).
 
-  * `widen` on 8- and 16-bit integer types now widens to the platform word size (`Int`)
-    instead of to a 32-bit type ([#26859]).
+  * `widen` on 8- and 16-bit integer types now widens to 16- and 32-bit types, respectively. ([#28045]).
 
   * `mv`,`cp`, `touch`, `mkdir`, `mkpath`, `chmod` and `chown` now return the path that was created/modified
     rather than `nothing` ([#27071]).

--- a/base/int.jl
+++ b/base/int.jl
@@ -659,10 +659,13 @@ typemax(::Type{UInt64}) = 0xffffffffffffffff
 @eval typemin(::Type{Int128} ) = $(convert(Int128, 1) << 127)
 @eval typemax(::Type{Int128} ) = $(bitcast(Int128, typemax(UInt128) >> 1))
 
-widen(::Type{<:Union{Int8, Int16}}) = Int
+
+widen(::Type{Int8}) = Int16
+widen(::Type{Int16}) = Int32
 widen(::Type{Int32}) = Int64
 widen(::Type{Int64}) = Int128
-widen(::Type{<:Union{UInt8, UInt16}}) = UInt
+widen(::Type{UInt8}) = UInt16
+widen(::Type{UInt16}) = UInt32
 widen(::Type{UInt32}) = UInt64
 widen(::Type{UInt64}) = UInt128
 

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -780,6 +780,9 @@ If `x` is a type, return a "larger" type, defined so that arithmetic operations
 `+` and `-` are guaranteed not to overflow nor lose precision for any combination
 of values that type `x` can hold.
 
+For fixed-size integer types less than 128 bits, `widen` will return a type with
+twice the number of bits.
+
 If `x` is a value, it is converted to `widen(typeof(x))`.
 
 # Examples

--- a/test/int.jl
+++ b/test/int.jl
@@ -188,18 +188,28 @@ end
     end
 end
 @testset "widen/widemul" begin
-    @test widen(UInt8(3)) === UInt(3)
-    @test widen(UInt16(3)) === UInt(3)
+    @test widen(UInt8(3)) === UInt16(3)
+    @test widen(UInt16(3)) === UInt32(3)
     @test widen(UInt32(3)) === UInt64(3)
     @test widen(UInt64(3)) === UInt128(3)
     @test widen(UInt128(3)) == 3
+
+    @test typeof(widen(UInt8(3))) == UInt16
+    @test typeof(widen(UInt16(3))) == UInt32
+    @test typeof(widen(UInt32(3))) == UInt64
+    @test typeof(widen(UInt64(3))) == UInt128
     @test typeof(widen(UInt128(3))) == BigInt
 
-    @test widen(Int8(-3)) === Int(-3)
-    @test widen(Int16(-3)) === Int(-3)
+    @test widen(Int8(-3)) === Int16(-3)
+    @test widen(Int16(-3)) === Int32(-3)
     @test widen(Int32(-3)) === Int64(-3)
     @test widen(Int64(-3)) === Int128(-3)
     @test widen(Int128(-3)) == -3
+
+    @test typeof(widen(Int8(-3))) == Int16
+    @test typeof(widen(Int16(-3))) == Int32
+    @test typeof(widen(Int32(-3))) == Int64
+    @test typeof(widen(Int64(-3))) == Int128
     @test typeof(widen(Int128(-3))) == BigInt
 
     @test widemul(false, false) == false

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2026,7 +2026,7 @@ end
 @testset "widen and widemul" begin
     @test widen(1.5f0) === 1.5
     @test widen(Int32(42)) === Int64(42)
-    @test widen(Int8) === Int
+    @test widen(Int8) === Int16
     @test widen(Int64) === Int128
     @test widen(Float32) === Float64
     @test widen(Float16) === Float32


### PR DESCRIPTION
Per https://github.com/JuliaLang/julia/issues/14407#issuecomment-403955465 _et seq._, change the behavior of `widen()` as follows:

for all types with bit size `n`, `widen()` will produce a similarly-signed type with bit size `2n` regardless of underlying word size / architecture. This changes the following:

|Type | Current `widen()` | This PR |
|-|-|-|
|`UInt8` | `UInt` | `UInt16`|
|`UInt16` | `UInt` | `UInt32`|
|`Int8` | `Int` | `Int16`|
|`Int16` | `Int` | `Int32`|

In addition, added explicit type tests.
