### PR TITLE
fix fastpaths for materializing transposes / adjoints of sparse matrices

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -397,6 +397,8 @@ function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}
     end
     return SparseMatrixCSC(size(M, 1), size(M, 2), colptr, rowval, nzval)
 end
+SparseMatrixCSC(M::LinearAlgebra.Adjoint{Tv,SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = copy(M)
+SparseMatrixCSC(M::LinearAlgebra.Transpose{Tv,SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = copy(M)
 
 # converting from SparseMatrixCSC to other matrix types
 function Matrix(S::SparseMatrixCSC{Tv}) where Tv

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -397,8 +397,8 @@ function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}
     end
     return SparseMatrixCSC(size(M, 1), size(M, 2), colptr, rowval, nzval)
 end
-SparseMatrixCSC(M::LinearAlgebra.Adjoint{Tv,SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = copy(M)
-SparseMatrixCSC(M::LinearAlgebra.Transpose{Tv,SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = copy(M)
+SparseMatrixCSC(M::Adjoint{<:Any,<:SparseMatrixCSC}) = copy(M)
+SparseMatrixCSC(M::Transpose{<:Any,<:SparseMatrixCSC}) = copy(M)
 
 # converting from SparseMatrixCSC to other matrix types
 function Matrix(S::SparseMatrixCSC{Tv}) where Tv

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2242,4 +2242,10 @@ _length_or_count_or_five(x) = length(x)
     end
 end
 
+@testset "sparse transpose adjoint" begin
+    A = sprand(10, 10, 0.75)
+    @test A' == SparseMatrixCSC(A')
+    @test transpose(A) == SparseMatrixCSC(transpose(A))
+end
+
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2245,7 +2245,9 @@ end
 @testset "sparse transpose adjoint" begin
     A = sprand(10, 10, 0.75)
     @test A' == SparseMatrixCSC(A')
+    @test SparseMatrixCSC(A') isa SparseMatrixCSC
     @test transpose(A) == SparseMatrixCSC(transpose(A))
+    @test SparseMatrixCSC(transpose(A)) isa SparseMatrixCSC
 end
 
 end # module


### PR DESCRIPTION
Setup:

```jl
using LinearAlgebra
using SparseArrays
using BenchmarkTools
n = 1000
A = sparse(1.0I,n,n);
B = sparse(1.0I,n,n);

```

Before PR:

```jl
julia> @btime $A + $B';
  5.307 ms (28 allocations: 112.11 KiB)

julia> @btime $A + $(B');
  5.305 ms (27 allocations: 112.09 KiB)
```


After PR:

```jl
julia> @btime $A + $B';
  13.897 μs (10 allocations: 63.52 KiB)

julia> @btime $A + $(B');
  13.852 μs (9 allocations: 63.50 KiB)
```




Fixes https://github.com/JuliaLang/julia/issues/28012