### PR TITLE
Make `blockdiag` return a 0×0 `SparseMatrixCSC{Union{},Int}`

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3137,7 +3137,7 @@ function blockdiag(X::SparseMatrixCSC...)
     n = sum(nX)
 
     Tv = promote_type(map(x->eltype(x.nzval), X)...)
-    Ti = promote_type(map(x->eltype(x.rowval), X)...)
+    Ti = isempty(X) ? Int : promote_type(map(x->eltype(x.rowval), X)...)
 
     colptr = Vector{Ti}(undef, n+1)
     nnzX = Int[ nnz(x) for x in X ]
@@ -3156,6 +3156,7 @@ function blockdiag(X::SparseMatrixCSC...)
         nX_sofar += nX[i]
         mX_sofar += mX[i]
     end
+    colptr[n+1] = nnz_sofar + 1
 
     SparseMatrixCSC(m, n, colptr, rowval, nzval)
 end

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -118,6 +118,8 @@ end
 
     @testset "blockdiag concatenation" begin
         @test blockdiag(se33, se33) == sparse(1:6,1:6,fill(1.,6))
+        @test blockdiag() == spzeros(0, 0)
+        @test nnz(blockdiag()) == 0
     end
 
     @testset "concatenation promotion" begin


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#306.