### PR TITLE
Fix broadcast style resolution docstring

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -113,7 +113,7 @@ ArrayConflict(::Val) = ArrayConflict()
 
 Indicate how to resolve different `BroadcastStyle`s. For example,
 
-    Broadcast.rule(::Primary, ::Secondary) = Primary()
+    BroadcastStyle(::Primary, ::Secondary) = Primary()
 
 would indicate that style `Primary` has precedence over `Secondary`.
 You do not have to (and generally should not) define both argument orders.


### PR DESCRIPTION
Referenced previous `Broadcast.rule` API, which seems to have been replaced by `BroadcastStyle`.