### PR TITLE
Document multiple return types of redirect_stdout and friends

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -950,6 +950,8 @@ the pipe. The `wr` end is given for convenience in case the old
 [`stdout`](@ref) object was cached by the user and needs to be replaced
 elsewhere.
 
+If called with the optional `stream` argument, then returns `stream` itself.
+
 !!! note
     `stream` must be a `TTY`, a `Pipe`, or a socket.
 """


### PR DESCRIPTION
As noted in #27805, the return type of `redirect_stdout` and other functions
such as `redirect_stdin` is not accurate when the optional input argument is
used. Instead of returning a tuple with the `(rd, wr)` pipe ends for the new
`stdout`, it instead returns the argument itself.

The new documentation accounts for this behavior.