### PR TITLE
Add `missing` support in `isapprox`

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -65,14 +65,17 @@ isequal(::Any, ::Missing) = false
 isless(::Missing, ::Missing) = false
 isless(::Missing, ::Any) = false
 isless(::Any, ::Missing) = true
+isapprox(::Missing, ::Missing; kwargs...) = missing
+isapprox(::Missing, ::Any; kwargs...) = missing
+isapprox(::Any, ::Missing; kwargs...) = missing
 
 # Unary operators/functions
 for f in (:(!), :(~), :(+), :(-), :(identity), :(zero), :(one), :(oneunit),
           :(isfinite), :(isinf), :(isodd),
           :(isinteger), :(isreal), :(isnan),
           :(iszero), :(transpose), :(adjoint), :(float), :(conj),
-	  :(abs), :(abs2), :(iseven), :(ispow2),
-	  :(real), :(imag), :(sign))
+          :(abs), :(abs2), :(iseven), :(ispow2),
+          :(real), :(imag), :(sign))
     @eval ($f)(::Missing) = missing
 end
 for f in (:(Base.zero), :(Base.one), :(Base.oneunit))

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -467,7 +467,7 @@ julia> norm(-2, Inf)
 ```
 """
 @inline norm(x::Number, p::Real=2) = p == 0 ? (x==0 ? zero(abs(x)) : oneunit(abs(x))) : abs(x)
-
+norm(::Missing, p::Real=2) = missing
 
 # special cases of opnorm
 function opnorm1(A::AbstractMatrix{T}) where T

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -369,4 +369,8 @@ end
     end
 end
 
+@testset "missing values" begin
+    @test ismissing(norm(missing))
+end
+
 end # module TestGeneric

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -69,6 +69,9 @@ end
     @test !isless(missing, missing)
     @test !isless(missing, 1)
     @test isless(1, missing)
+    @test (missing ≈ missing) === missing
+    @test isapprox(missing, 1.0, atol=1e-6) === missing
+    @test isapprox(1.0, missing, rtol=1e-6) === missing
 
     @test !any(T -> T === Union{Missing,Bool}, Base.return_types(isequal, Tuple{Any,Any}))
 end


### PR DESCRIPTION
`isapprox` now behaves the same way as `==` in the presence of missing values: if either argument is `missing`, the result is `missing`.

Fixes #28088.