### PR TITLE
Handle nothing in logging

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -229,7 +229,7 @@ _log_record_ids = Set{Symbol}()
 # versions of the originating module, provided the log generating statement
 # itself doesn't change.
 function log_record_id(_module, level, message_ex)
-    modname = join(fullname(_module), "_")
+    modname = _module === nothing ?  "" : join(fullname(_module), "_")
     # Use (1<<31) to fit well within an (arbitriraly chosen) eight hex digits,
     # as we increment h to resolve any collisions.
     h = hash(string(modname, level, message_ex)) % (1<<31)
@@ -289,8 +289,8 @@ function logmsg_code(_module, file, line, level, message, exs...)
         end
     end
     # Note that it may be necessary to set `id` and `group` manually during bootstrap
-    id !== nothing || (id = :(log_record_id(_module, level, $exs)))
-    group !== nothing || (group = :(Symbol(splitext(basename($file))[1])))
+    id = something(id, :(log_record_id(_module, level, $exs)))
+    group = something(group, :(Symbol(splitext(basename(something($file, "")))[1])))
     quote
         level = $level
         std_level = convert(LogLevel, level)

--- a/base/logging.jl
+++ b/base/logging.jl
@@ -529,8 +529,8 @@ function handle_message(logger::SimpleLogger, level, message, _module, group, id
     for (key, val) in kwargs
         println(iob, "│   ", key, " = ", val)
     end
-    mod = _module === nothing ? "" : "$(_module) "
-    println(iob, "└ @ ", mod, filepath, ":", line)
+    println(iob, "└ @ ", something(_module, "nothing"), " ",
+            something(filepath, "nothing"), ":", something(line, "nothing"))
     write(logger.stream, take!(buf))
     nothing
 end

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -60,9 +60,18 @@ end
 function default_metafmt(level, _module, group, id, file, line)
     color = default_logcolor(level)
     prefix = (level == Warn ? "Warning" : string(level))*':'
-    mod = _module === nothing ? "" : "$(_module) "
-    suffix = (Info <= level < Warn) ? "" : "@ $mod$(Base.contractuser(file)):$line"
-    color,prefix,suffix
+    suffix = ""
+    Info <= level < Warn && return color, prefix, suffix
+    _module !== nothing && (suffix *= "$(_module)")
+    if file !== nothing
+        _module !== nothing && (suffix *= " ")
+        suffix *= Base.contractuser(file)
+        if line !== nothing
+            suffix *= ":$(isa(line, UnitRange) ? "$(first(line))-$(last(line))" : line)"
+        end
+    end
+    !isempty(suffix) && (suffix = "@ " * suffix)
+    return color, prefix, suffix
 end
 
 # Length of a string as it will appear in the terminal (after ANSI color codes

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -30,6 +30,17 @@ import Logging: min_enabled_level, shouldlog, handle_message
             (:yellow,    "Warning:", "@ Main b.jl:2")
         @test Logging.default_metafmt(Logging.Error, Main, :g, :i, "", 0) ==
             (:light_red, "Error:",   "@ Main :0")
+        # formatting of nothing
+        @test Logging.default_metafmt(Logging.Warn,  nothing, :g, :i, "b.jl", 2) ==
+            (:yellow,    "Warning:", "@ b.jl:2")
+        @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, nothing, 2) ==
+            (:yellow,    "Warning:", "@ Main")
+        @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", nothing) ==
+            (:yellow,    "Warning:", "@ Main b.jl")
+        @test Logging.default_metafmt(Logging.Warn,  nothing, :g, :i, nothing, 2) ==
+            (:yellow,    "Warning:", "")
+        @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2:5) ==
+            (:yellow,    "Warning:", "@ Main b.jl:2-5")
     end
 
     function dummy_metafmt(level, _module, group, id, file, line)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Base.CoreLogging
+using Test, Base.CoreLogging
 import Base.CoreLogging: BelowMinLevel, Debug, Info, Warn, Error,
     handle_message, shouldlog, min_enabled_level, catch_exceptions
 
@@ -109,6 +109,17 @@ end
     @test record._module == logger.shouldlog_args[2]
     @test record.group   == logger.shouldlog_args[3]
     @test record.id      == logger.shouldlog_args[4]
+
+    # handling of nothing
+    logger = TestLogger()
+    with_logger(logger) do
+        @info "foo" _module = nothing _file = nothing _line = nothing
+    end
+    @test length(logger.logs) == 1
+    record = logger.logs[1]
+    @test record._module == nothing
+    @test record.file == nothing
+    @test record.line == nothing
 end
 
 

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -303,6 +303,13 @@ end
     │   b = asdf
     └ @ Base other.jl:101
     """
+
+    # nothing values
+    @test genmsg(Warn, "msg", nothing, nothing, nothing) ==
+    """
+    ┌ Warning: msg
+    └ @ nothing nothing:nothing
+    """
 end
 
 # Issue #26273


### PR DESCRIPTION
This enables `nothing` to be used for the `_module`, `_file` and `_line` kwargs for logging. For the `ConsoleLogger` `nothing` values will not be printed out. This also enables better formatting when setting `_line` to a `UnitRange` (previously printed as `somefile.jl:9:10` but now prints as `somefile.jl:9-10`):
Examples:

| Input                                           | Output                                                  |
| ----------------------------------------------- | ----------------                                        |
| `@warn "msg"`                                   | `┌ Warning: msg`<br/>`└ @ Main ~/julia/logging.jl:1`    |
| `@warn "msg" _module = nothing`                 | `┌ Warning: msg`<br/>`└ @ ~/julia/logging.jl:2`         |
| `@warn "msg" _file = nothing`                   | `┌ Warning: msg`<br/>`└ @ Main`                         |
| `@warn "msg" _module = nothing _file = nothing` | `[ Warning: msg`                                        |
| `@warn "msg" _line = nothing`                   | `┌ Warning: msg`<br/>`└ @ Main ~/julia/logging.jl`      |
| `@warn "msg" _line = 9:10`                      | `┌ Warning: msg`<br/>`└ @ Main ~/julia/logging.jl:9-10` |
