### PR TITLE
Fix phi node value renumbering issue

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -808,7 +808,7 @@ function process_newnode!(compact, new_idx, new_node_entry, idx, active_bb, do_r
     bb = compact.ir.cfg.blocks[active_bb]
     compact.result_types[old_result_idx] = new_node_entry.typ
     compact.result_lines[old_result_idx] = new_node_entry.line
-    result_idx = process_node!(compact, old_result_idx, new_node_entry.node, new_idx, idx, do_rename_ssa)
+    result_idx = process_node!(compact, old_result_idx, new_node_entry.node, new_idx, idx - 1, do_rename_ssa)
     compact.result_idx = result_idx
     # If this instruction has reverse affinity and we were at the end of a basic block,
     # finish it now.

--- a/test/goto.jl
+++ b/test/goto.jl
@@ -154,3 +154,17 @@ function f15561()
     @label crater
 end
 @test f15561() === nothing
+
+# issue #28077
+function foo28077()
+    s = 0
+    i = 0
+    @label L
+    i += 1
+    s += i
+    if i < 10
+        @goto L
+    end
+    return s
+end
+@test foo28077() == 55


### PR DESCRIPTION
If a φ node got placed at a position one of its values referenced, that reference wasn't updated.
Fixes #28077.