### PR TITLE
[release-0.6] Avoid segfault when ptls->safepoint is NULL

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -438,7 +438,7 @@ JL_DLLEXPORT void (jl_cpu_wake)(void);
 // Accessing the tls variables, gc safepoint and gc states
 JL_DLLEXPORT JL_CONST_FUNC jl_ptls_t (jl_get_ptls_states)(void);
 // This triggers a SegFault when we are in GC
-// Assign it to a variable to make sure the compiler emit the load
+// Assign it to a variable to make sure the compiler emits the load
 // and to avoid Clang warning for -Wunused-volatile-lvalue
 #define jl_gc_safepoint_(ptls) do {                     \
         jl_signal_fence();                              \

--- a/test/threads.jl
+++ b/test/threads.jl
@@ -449,3 +449,10 @@ function test_nested_loops()
     end
 end
 test_nested_loops()
+
+function test_27020_SIGSEGV()
+    x = BigInt()
+    # We only care that this call does not throw a SIGSEGV, so no need to check return value
+    @threadcall((:__gmpz_init, :libgmp), Void, (Ptr{BigInt}, ), Ref(x))
+end
+test_27020_SIGSEGV()


### PR DESCRIPTION
This is a backport of #27020 to the release-0.6 branch

There are cases (eg: when __gmpz_init is called from python via PyCall in a
secondary thread) where ptls->safepoint is NULL when maybe_collect is called,
and *ptls->safepoint causes a NULL pointer dereference and a segfault.  This
change fixes that case.

Included test in test/threads.jl that will reproduce this issue.

See #27020 for backtrace and more details