### PR TITLE
another finalizer order fix

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -274,11 +274,11 @@ static void schedule_all_finalizers(arraylist_t *flist)
 
 void jl_gc_run_all_finalizers(jl_ptls_t ptls)
 {
+    schedule_all_finalizers(&finalizer_list_marked);
     for (int i = 0;i < jl_n_threads;i++) {
         jl_ptls_t ptls2 = jl_all_tls_states[i];
         schedule_all_finalizers(&ptls2->finalizers);
     }
-    schedule_all_finalizers(&finalizer_list_marked);
     run_finalizers(ptls);
 }
 

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -54,12 +54,6 @@ include("ConsoleLogger.jl")
 
 function __init__()
     global_logger(ConsoleLogger(stderr))
-    atexit() do
-        logger = global_logger()
-        if isa(logger, ConsoleLogger)
-            global_logger(ConsoleLogger(Core.stderr, min_enabled_level(logger)))
-        end
-    end
 end
 
 end


### PR DESCRIPTION
This makes the atexit hook in Logging unnecessary.

Before:
```
julia> finalizer(println, [])
0-element Array{Any,1}

julia> 
error in running finalizer: ArgumentError(msg="stream is closed or unusable")
jeff@gurren:~/src/julia$ ./julia -q
julia> finalizer(x->@info(x), [])
0-element Array{Any,1}

julia> 
[ Info: Any[]
```

after:
```
julia> finalizer(println, [])
0-element Array{Any,1}

julia> 
Any[]
jeff@gurren:~/src/julia$ ./julia -q
julia> finalizer(x->@info(x), [])
0-element Array{Any,1}

julia> 
[ Info: Any[]
```