### PR TITLE
speed up initialization of LinearAlgebra

### DIFF
--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -71,7 +71,7 @@ import Libdl
 
 # utility routines
 let lib = C_NULL
-global function vendor()
+global function determine_vendor()
     lib == C_NULL && (lib = Libdl.dlopen_e(Base.libblas_name))
     vend = :unknown
     if lib != C_NULL
@@ -86,6 +86,9 @@ global function vendor()
     return vend
 end
 end
+
+const _vendor = determine_vendor()
+vendor() = _vendor
 
 if vendor() == :openblas64
     macro blasfunc(x)
@@ -123,6 +126,7 @@ function set_num_threads(n::Integer)
     return nothing
 end
 
+const _testmat = [1.0 0.0; 0.0 -1.0]
 function check()
     blas = vendor()
     if blas == :openblas || blas == :openblas64
@@ -152,7 +156,7 @@ function check()
     #
     # Check if BlasInt is the expected bitsize, by triggering an error
     #
-    (_, info) = LinearAlgebra.LAPACK.potrf!('U', [1.0 0.0; 0.0 -1.0])
+    (_, info) = LinearAlgebra.LAPACK.potrf!('U', _testmat)
     if info != 2 # mangled info code
         if info == 2^33
             error("BLAS and LAPACK are compiled with 32-bit integer support, but Julia expects 64-bit integers. Please build Julia with USE_BLAS64=0.")


### PR DESCRIPTION
Since BLAS.check is called at `__init__` time, it seemed to me `vendor()` is a run-time property, however it is also used at load time to define the `blasfunc` macro. I changed it to cache the value the first time it runs which (1) is faster and (2) prevents it from returning conflicting values. I hope this is ok. Also helps JuliaLang/LinearAlgebra.jl#540.

The other change avoids compiling `hvcat` during `check`.