### PR TITLE
Fix @which for getindex methods using [] syntax

### DIFF
--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -18,6 +18,9 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
         elseif ex0.head == :call
             return Expr(:call, fcn, esc(ex0.args[1]),
                         Expr(:call, typesof, map(esc, ex0.args[2:end])...))
+        elseif ex0.head == :ref
+            return Expr(:call, fcn, Base.getindex,
+                        Expr(:call, typesof, map(esc, ex0.args)...))
         elseif ex0.head == :(.)
             return Expr(:call, fcn, Base.getproperty,
                         Expr(:call, typesof, map(esc, ex0.args)...))

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -202,6 +202,9 @@ const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
 # issue #13264
 @test isa((@which vcat(1...)), Method)
 
+# PR #28122
+@test isa((@which [1][1]), Method)
+
 # issue #13464
 let t13464 = "hey there sailor"
     try

--- a/stdlib/InteractiveUtils/test/runtests.jl
+++ b/stdlib/InteractiveUtils/test/runtests.jl
@@ -200,10 +200,13 @@ const curmod_str = curmod === Main ? "Main" : join(curmod_name, ".")
 
 @test_throws ErrorException("\"this_is_not_defined\" is not defined in module $curmod_str") @which this_is_not_defined
 # issue #13264
-@test isa((@which vcat(1...)), Method)
+@test (@which vcat(1...)).name == :vcat
 
 # PR #28122
-@test isa((@which [1][1]), Method)
+@test (@which [1][1]).name === :getindex
+@test (@which [1 2]).name == :hcat
+@test (@which [1; 2]).name == :vcat
+@test (@which [1]).name == :vect
 
 # issue #13464
 let t13464 = "hey there sailor"


### PR DESCRIPTION
I'm not completely sure the implementation is correct, but here are the effects of this PR:

Before:
```julia
julia> @which [1][1]
ERROR: expression is not a function call, or is too complex for @which to analyze; break it down to simpler parts if possible
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at none:0

julia> @which [1;2][2,1]
ERROR: expression is not a function call, or is too complex for @which to analyze; break it down to simpler parts if possible
Stacktrace:
 [1] error(::String) at ./error.jl:33
 [2] top-level scope at none:0
```

After:
```julia
julia> @which [1][1]
getindex(A::Array, i1::Int64) in Base at array.jl:731

julia> @which [1;2][2,1]
getindex(A::Array, i1::Int64, i2::Int64, I::Int64...) in Base at array.jl:732
```