### PR TITLE
`Base.parse` in section on Julia ASTs should be to `Meta.parse`

### DIFF
--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -1,7 +1,7 @@
 # Julia ASTs
 
 Julia has two representations of code. First there is a surface syntax AST returned by the parser
-(e.g. the [`parse`](@ref) function), and manipulated by macros. It is a structured representation
+(e.g. the [`Meta.parse`](@ref) function), and manipulated by macros. It is a structured representation
 of code as it is written, constructed by `julia-parser.scm` from a character stream. Next there
 is a lowered form, or IR (intermediate representation), which is used by type inference and code
 generation. In the lowered form there are fewer types of nodes, all macros are expanded, and all


### PR DESCRIPTION
Fixes issue #28125 

My first pull request 👍 