### PR TITLE
stdlib/linalg: add test to detect openblas 0.3.1 dgesvd regression bug.

### DIFF
--- a/stdlib/LinearAlgebra/test/svd.jl
+++ b/stdlib/LinearAlgebra/test/svd.jl
@@ -142,4 +142,14 @@ a2img  = randn(n,n)/2
     end
 end
 
+@testset "dgesvd OpenBLAS 0.3.1 regression" begin
+	# https://github.com/xianyi/OpenBLAS/issues/1666
+	shapes = [(300, 600), (600, 300)]
+	for shape in shapes
+		A = rand(Float64, (shape)...)
+		F = svd(A)
+		@test (F.U * Diagonal(F.S) * F.Vt) ≈ A
+	end
+end
+
 end # module TestSVD


### PR DESCRIPTION
OpenBLAS issue: https://github.com/xianyi/OpenBLAS/issues/1666

Julia's openblas version has been reverted, but it still needs a test to warn distribution maintainers when they are building Julia against openblas 0.3.1 in case if they aren't aware of this regression bug.