### PR TITLE
Constructor for SharedMatrix and SharedVector

### DIFF
--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -280,8 +280,13 @@ end
 
 const SharedVector{T} = SharedArray{T,1}
 const SharedMatrix{T} = SharedArray{T,2}
+
 SharedVector(A::Vector) = SharedArray(A)
 SharedMatrix(A::Matrix) = SharedArray(A)
+
+SharedVector{T}(m::Integer; kwargs...) where {T} = SharedArray{T}((m,); kwargs...)
+SharedMatrix{T}(m::Integer, n::Integer; kwargs...) where {T} = SharedArray{T}((m, n); kwargs...)
+
 
 
 length(S::SharedArray) = prod(S.dims)

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -280,6 +280,9 @@ end
 
 const SharedVector{T} = SharedArray{T,1}
 const SharedMatrix{T} = SharedArray{T,2}
+SharedVector(A::Vector) = SharedArray(A)
+SharedMatrix(A::Matrix) = SharedArray(A)
+
 
 length(S::SharedArray) = prod(S.dims)
 size(S::SharedArray) = S.dims

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -277,7 +277,6 @@ function finalize_refs(S::SharedArray{T,N}) where T where N
     S
 end
 
-
 const SharedVector{T} = SharedArray{T,1}
 const SharedMatrix{T} = SharedArray{T,2}
 

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -284,11 +284,6 @@ const SharedMatrix{T} = SharedArray{T,2}
 SharedVector(A::Vector) = SharedArray(A)
 SharedMatrix(A::Matrix) = SharedArray(A)
 
-SharedVector{T}(m::Integer; kwargs...) where {T} = SharedArray{T}((m,); kwargs...)
-SharedMatrix{T}(m::Integer, n::Integer; kwargs...) where {T} = SharedArray{T}((m, n); kwargs...)
-
-
-
 length(S::SharedArray) = prod(S.dims)
 size(S::SharedArray) = S.dims
 ndims(S::SharedArray) = length(S.dims)

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -312,6 +312,3 @@ end
 #28133
 @test SharedVector([1; 2; 3]) == [1; 2; 3]
 @test SharedMatrix([0.1 0.2; 0.3 0.4]) == [0.1 0.2; 0.3 0.4]
-            
-            
-            

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -308,7 +308,7 @@ let S = SharedArray(Int64[]) # Issue #26582
     @test sprint(show, S) == "Int64[]"
     @test sprint(show, "text/plain", S) == "0-element SharedArray{Int64,1}:\n"
 end
-            
+
 #28133
 @test SharedVector([1; 2; 3]) == [1; 2; 3]
 @test SharedMatrix([0.1 0.2; 0.3 0.4]) == [0.1 0.2; 0.3 0.4]

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -312,5 +312,5 @@ end
 #28133
 @test SharedVector([1; 2; 3]) == [1; 2; 3]
 @test SharedMatrix([0.1 0.2; 0.3 0.4]) == [0.1 0.2; 0.3 0.4]
-@test_throws MethodError SharedVector(rand(4,4))           
+@test_throws MethodError SharedVector(rand(4,4))
 @test_throws MethodError SharedMatrix(rand(4))

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -308,3 +308,10 @@ let S = SharedArray(Int64[]) # Issue #26582
     @test sprint(show, S) == "Int64[]"
     @test sprint(show, "text/plain", S) == "0-element SharedArray{Int64,1}:\n"
 end
+            
+#28133
+@test SharedVector([1; 2; 3]) == [1; 2; 3]
+@test SharedMatrix([0.1 0.2; 0.3 0.4]) == [0.1 0.2; 0.3 0.4]
+            
+            
+            

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -312,3 +312,5 @@ end
 #28133
 @test SharedVector([1; 2; 3]) == [1; 2; 3]
 @test SharedMatrix([0.1 0.2; 0.3 0.4]) == [0.1 0.2; 0.3 0.4]
+@test_throws MethodError SharedVector(rand(4,4))           
+@test_throws MethodError SharedMatrix(rand(4))


### PR DESCRIPTION
I implemented the constructor of ``SharedMatrix`` and ``SharedVector`` type.
These types are the alias of ``SharedArray`` type.
This will fix #28131.