### PR TITLE
Make parse position accept an Integer

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -114,7 +114,7 @@ julia> Meta.parse("x = 3, y = 5", 5)
 (:((3, y) = 5), 13)
 ```
 """
-function parse(str::AbstractString, pos::Int; greedy::Bool=true, raise::Bool=true,
+function parse(str::AbstractString, pos::Integer; greedy::Bool=true, raise::Bool=true,
                depwarn::Bool=true)
     # pos is one based byte offset.
     # returns (expr, end_pos). expr is () in case of parse error.


### PR DESCRIPTION
The following [code taken from Coverage.jl](https://github.com/JuliaCI/Coverage.jl/blob/591ba4a78c3c7529b10b5470a9bfdf0a265bf911/src/parser.jl#L41) will fail on 32-bit Julia:
```julia
Meta.parse(read(io, String), position(io)+1)
```
This code fails since `position` will always return a `Int64` and `parse(::AbstractString, ::Int)` will only take a `Int32` on 32-bit.