### PR TITLE
delay part of Distributed's initialization to improve startup time

### DIFF
--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -103,7 +103,6 @@ include("precompile.jl")
 @deprecate pmap(p::AbstractWorkerPool, f, c1, c...; kwargs...) pmap(f, p, c1, c...; kwargs...)
 
 function __init__()
-    push!(Base.package_callbacks, _require_callback)
     init_parallel()
 end
 

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -188,6 +188,8 @@ It does not return.
 """
 start_worker(cookie::AbstractString=readline(stdin)) = start_worker(stdout, cookie)
 function start_worker(out::IO, cookie::AbstractString=readline(stdin))
+    init_multi()
+
     close(stdin) # workers will not use it
     redirect_stderr(stdout)
 
@@ -358,6 +360,8 @@ master can be specified via variable `JULIA_WORKER_TIMEOUT` in the worker proces
 environment. Relevant only when using TCP/IP as transport.
 """
 function addprocs(manager::ClusterManager; kwargs...)
+    init_multi()
+
     cluster_mgmt_from_master_check()
 
     lock(worker_lock)
@@ -1111,17 +1115,27 @@ end
 
 using Random: randstring
 
+let inited = false
+    # do initialization that's only needed when there is more than 1 processor
+    global function init_multi()
+        if !inited
+            inited = true
+            push!(Base.package_callbacks, _require_callback)
+            atexit(terminate_all_workers)
+            init_bind_addr()
+            cluster_cookie(randstring(HDR_COOKIE_LEN))
+        end
+        return nothing
+    end
+end
+
 function init_parallel()
     start_gc_msgs_task()
-    atexit(terminate_all_workers)
-
-    init_bind_addr()
 
     # start in "head node" mode, if worker, will override later.
     global PGRP
     global LPROC
     LPROC.id = 1
-    cluster_cookie(randstring(HDR_COOKIE_LEN))
     @assert isempty(PGRP.workers)
     register_worker(LPROC)
 end


### PR DESCRIPTION
This shaves off another ~40ms for me.