### PR TITLE
Added docs for the StridedArrays and fixed a doctest fail

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1893,4 +1893,35 @@ The syntax `a.b = c` calls `setproperty!(a, :b, c)`.
 """
 Base.setproperty!
 
+"""
+    StridedArray{T, N}
+
+An `N` dimensional *strided* array with elements of type `T`. A strided array may *not* be contiguous
+in memory: elements are separated by constant stride(s). [`DenseArray`](@ref)s are `StridedArray`s with
+strides of `1` (thus, they are contiguous). A `StridedArray` with any stride larger than 1 is no longer
+contiguous.
+"""
+StridedArray
+
+"""
+    StridedVector{T}
+
+One dimensional [`StridedArray`](@ref) with elements of type `T`.
+"""
+StridedVector
+
+"""
+    StridedMatrix{T}
+
+Two dimensional [`StridedArray`](@ref) with elements of type `T`.
+"""
+StridedMatrix
+
+"""
+    StridedVecOrMat{T}
+
+Union type of [`StridedVector`](@ref) and [`StridedMatrix`](@ref) with elements of type `T`.
+"""
+StridedVecOrMat
+
 end

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1896,10 +1896,14 @@ Base.setproperty!
 """
     StridedArray{T, N}
 
-An `N` dimensional *strided* array with elements of type `T`. A strided array may *not* be contiguous
-in memory: elements are separated by constant stride(s). [`DenseArray`](@ref)s are `StridedArray`s with
-strides of `1` (thus, they are contiguous). A `StridedArray` with any stride larger than 1 is no longer
-contiguous.
+An `N` dimensional *strided* array with elements of type `T`. These arrays follow
+the [strided array interface](@ref man-interface-strided-arrays). If `A` is a
+`StridedArray`, then its elements are stored in memory with offsets, which may
+vary between dimensions but are constant within a dimension. For example, `A` could
+have stride 2 in dimension 1, and stride 3 in dimension 2. Incrementing `A` along
+dimension `d` jumps in memory by [`strides(A, d)`] slots. Strided arrays are
+particularly important and useful because they can sometimes be passed directly
+as pointers to foreign language libraries like BLAS.
 """
 StridedArray
 

--- a/base/file.jl
+++ b/base/file.jl
@@ -383,6 +383,8 @@ Stacktrace:
 julia> mv("hello.txt", "goodbye.txt", force=true)
 "goodbye.txt"
 
+julia> rm("goodbye.txt");
+
 ```
 """
 function mv(src::AbstractString, dst::AbstractString; force::Bool=false,

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -26,6 +26,10 @@ Core.DenseArray
 Base.DenseVector
 Base.DenseMatrix
 Base.DenseVecOrMat
+Base.StridedArray
+Base.StridedVector
+Base.StridedMatrix
+Base.StridedVecOrMat
 Base.getindex(::Type, ::Any...)
 Base.zeros
 Base.ones

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -835,7 +835,7 @@ provided, the memory layout must correspond in the same way to these strides. `D
 very specific example of a strided array where the elements are arranged contiguously, thus it
 provides its subtypes with the approporiate definition of `strides`. More concrete examples
 can be found within the [interface guide for strided arrays](@ref man-interface-strided-arrays).
-`StridedVector` and `StridedMatrix` are convenient aliases for many of the builtin array types that
+[`StridedVector`](@ref) and [`StridedMatrix`](@ref) are convenient aliases for many of the builtin array types that
 are considered strided arrays, allowing them to dispatch to select specialized implementations that
 call highly tuned and optimized BLAS and LAPACK functions using just the pointer and strides.
 


### PR DESCRIPTION
I wasn't removing the file in that `base/file` doctest I wrote and it was bad. Now it is fixed. Also more docs for the `Strided*` types. Sorry for the bad branch name.