### PR TITLE
Specialize string and repeat for SubString{String}

### DIFF
--- a/base/strings/strings.jl
+++ b/base/strings/strings.jl
@@ -1,6 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-include("strings/substring.jl")
 include("strings/search.jl")
 include("strings/unicode.jl")
 

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -142,4 +142,37 @@ function reverse(s::Union{String,SubString{String}})::String
     end
 end
 
+function string(a::Union{String, SubString{String}}...)
+    if length(a) == 1
+        return String(a[1])
+    end
+    n = 0
+    for str in a
+        n += sizeof(str)
+    end
+    out = _string_n(n)
+    offs = 1
+    for str in a
+        unsafe_copyto!(pointer(out,offs), pointer(str), sizeof(str))
+        offs += sizeof(str)
+    end
+    return out
+end
+
+function repeat(s::Union{String, SubString{String}}, r::Integer)
+    r < 0 && throw(ArgumentError("can't repeat a string $r times"))
+    r == 1 && return String(s)
+    n = sizeof(s)
+    out = _string_n(n*r)
+    if n == 1 # common case: repeating a single-byte string
+        @inbounds b = codeunit(s, 1)
+        ccall(:memset, Ptr{Cvoid}, (Ptr{UInt8}, Cint, Csize_t), out, b, r)
+    else
+        for i = 0:r-1
+            unsafe_copyto!(pointer(out, i*n+1), pointer(s), n)
+        end
+    end
+    return out
+end
+
 getindex(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, r)

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -222,6 +222,7 @@ include("set.jl")
 include("char.jl")
 include("strings/basic.jl")
 include("strings/string.jl")
+include("strings/substring.jl")
 
 # Definition of StridedArray
 StridedFastContiguousSubArray{T,N,A<:DenseArray} = FastContiguousSubArray{T,N,A}

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -29,6 +29,11 @@ using Random
     @test "ab"  !== "abc"
     @test string("ab", 'c') === "abc"
     @test string() === ""
+    @test string(SubString("123", 2)) === "23"
+    @test string("∀∃", SubString("1∀∃", 2)) === "∀∃∀∃"
+    @test string("∀∃", "1∀∃") === "∀∃1∀∃"
+    @test string(SubString("∀∃"), SubString("1∀∃", 2)) === "∀∃∀∃"
+    @test string(s"123") === s"123"
     codegen_egal_of_strings(x, y) = (x===y, x!==y)
     @test codegen_egal_of_strings(string("ab", 'c'), "abc") === (true, false)
     let strs = ["", "a", "a b c", "до свидания"]
@@ -125,7 +130,7 @@ end
 end
 
 # issue #3597
-@test string(GenericString("Test")[1:1], "X") == "TX"
+@test string(GenericString("Test")[1:1], "X") === "TX"
 
 @testset "parsing Int types" begin
     let b, n
@@ -570,10 +575,10 @@ end
 
 @testset "repeat" begin
     @inferred repeat(GenericString("x"), 1)
-    @test repeat("xx",3) == repeat("x",6) == repeat('x',6) == repeat(GenericString("x"), 6) == "xxxxxx"
-    @test repeat("αα",3) == repeat("α",6) == repeat('α',6) == repeat(GenericString("α"), 6) == "αααααα"
-    @test repeat("x",1) == repeat('x',1) == "x"^1 == 'x'^1 == GenericString("x")^1 == "x"
-    @test repeat("x",0) == repeat('x',0) == "x"^0 == 'x'^0 == GenericString("x")^0 == ""
+    @test repeat("xx",3) === repeat(SubString("xx", 2),6) === repeat("x",6) === repeat('x',6) === repeat(GenericString("x"), 6) === "xxxxxx"
+    @test repeat("αα",3) === repeat(SubString("αα", 3),6) === repeat("α",6) === repeat('α',6) === repeat(GenericString("α"), 6) === "αααααα"
+    @test repeat("x",1) === repeat('x',1) === "x"^1 == 'x'^1 === GenericString("x")^1 === "x"
+    @test repeat("x",0) === repeat('x',0) === "x"^0 == 'x'^0 === GenericString("x")^0 === ""
 
     for S in ["xxx", "ååå", "∀∀∀", "🍕🍕🍕"]
         c = S[1]
@@ -581,15 +586,15 @@ end
         @test_throws ArgumentError repeat(c, -1)
         @test_throws ArgumentError repeat(s, -1)
         @test_throws ArgumentError repeat(S, -1)
-        @test repeat(c, 0) == ""
-        @test repeat(s, 0) == ""
-        @test repeat(S, 0) == ""
-        @test repeat(c, 1) == s
-        @test repeat(s, 1) == s
-        @test repeat(S, 1) == S
-        @test repeat(c, 3) == S
-        @test repeat(s, 3) == S
-        @test repeat(S, 3) == S*S*S
+        @test repeat(c, 0) === ""
+        @test repeat(s, 0) === ""
+        @test repeat(S, 0) === ""
+        @test repeat(c, 1) === s
+        @test repeat(s, 1) === s
+        @test repeat(S, 1) === S
+        @test repeat(c, 3) === S
+        @test repeat(s, 3) === S
+        @test repeat(S, 3) === S*S*S
     end
 end
 @testset "issue #12495: check that logical indexing attempt raises ArgumentError" begin


### PR DESCRIPTION
Current implementation of `string` and `repeat` methods can be a bit faster if we use the same methods for `SubString{String}` as we use for `String`. This PR implements this change.

There is one breaking change so this PR might be not acceptable (but I would consider that we had a bug in Base so I have proposed it).

I propose to remove the method:
```
string(s::AbstractString) = s
```
The reason is that with this method `string` might have return type other than `String`, which can be problematic. Consider for instance the following code:
```
julia> x = [SubString("a"), SubString("b"), SubString("b")]
3-element Array{SubString{String},1}:
 "a"
 "b"
 "b"

julia> for i in 1:3
       println((string(x[1:i]...), typeof(string(x[1:i]...))))
       end
("a", SubString{String})
("ab", String)
("abb", String)
```

However, maybe there are reasons why such behavior is desired (apart from performance which I think is less important here as ensuring that `string` always returns `String` type).