### PR TITLE
Distributed: Set number of BLAS threads if LinearAlgebra is loaded, otherwise do nothing

### DIFF
--- a/stdlib/Distributed/Project.toml
+++ b/stdlib/Distributed/Project.toml
@@ -2,7 +2,6 @@ name = "Distributed"
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -161,10 +161,9 @@ mutable struct LocalProcess
     LocalProcess() = new(1)
 end
 
-
-import LinearAlgebra
 function disable_threaded_libs()
-    LinearAlgebra.BLAS.set_num_threads(1)
+    LinearAlgebra = get(Base.loaded_modules, Base.PkgId(Base.UUID("37e2e46d-f89d-539d-b4ee-838fcccc9c8e"), "LinearAlgebra"), nothing)
+    LinearAlgebra == nothing || LinearAlgebra.BLAS.set_num_threads(1)
 end
 
 worker_timeout() = parse(Float64, get(ENV, "JULIA_WORKER_TIMEOUT", "60.0"))


### PR DESCRIPTION
Breaks a dependency from Distributed -> LinearAlgebra.