### PR TITLE
Deprecate ordschur() methods two methods where the individual components are passed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -782,6 +782,14 @@ Deprecated or removed
     (`vals, vecs = eigen(A, B)`), or as a `GeneralizedEigen` object
     (`X = eigen(A, B)`) ([#26997], [#27159], [#27212]).
 
+  * `ordschur(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector})`
+    and `ordschur(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},
+    Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector})` and their respective
+    inplace versions have been deprecated.
+    Use `ordschur(schur::Schur, select::Union{Vector{Bool},BitVector})` and
+    `ordschur(gschur::GeneralizedSchur, select::Union{Vector{Bool},BitVector})` instead
+    ([#28155]).
+
   * Indexing into multidimensional arrays with more than one index but fewer indices than there are
     dimensions is no longer permitted when those trailing dimensions have lengths greater than 1.
     Instead, reshape the array or add trailing indices so the dimensionality and number of indices

--- a/stdlib/LinearAlgebra/src/deprecated.jl
+++ b/stdlib/LinearAlgebra/src/deprecated.jl
@@ -1593,3 +1593,36 @@ function Base.getindex(S::GeneralizedSVD, i::Integer)
     i == 6 ? (return S.R0) :
         throw(BoundsError(S, i))
 end
+
+# deprecate two ordschur methods where the individual components are passed instead of
+# the factorization
+
+function ordschur!(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat}
+    depwarn(string("`ordschur!(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector})`",
+        "`where {Ty<:BlasFloat}` is deprecated, use `ordschur!(schur::Schur, select::Union{Vector{Bool},BitVector})`", "instead."), :ordschur!)
+    return LinearAlgebra.LAPACK.trsen!(convert(Vector{BlasInt}, select), T, Z)[1:3]
+end
+
+function ordschur(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat}
+    depwarn(string("`ordschur!(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector})`",
+        "`where {Ty<:BlasFloat}` is deprecated, use `ordschur(schur::Schur, select::Union{Vector{Bool},BitVector})`", "instead."), :ordschur)
+    return ordschur!(copy(T), copy(Z), select)
+end
+
+function ordschur!(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},
+    Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat}
+    depwarn(string("`ordschur!(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},`",
+        "`Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat}`",
+        "is deprecated, use `ordschur!(gschur::GeneralizedSchur, select::Union{Vector{Bool},BitVector})`",
+        "instead."), :ordschur!)
+    return LinearAlgebra.LAPACK.tgsen!(convert(Vector{BlasInt}, select), S, T, Q, Z)
+end
+
+function ordschur(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},
+    Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat}
+    depwarn(string("`ordschur(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},`",
+        "`Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat}`",
+        "is deprecated, use `ordschur(gschur::GeneralizedSchur, select::Union{Vector{Bool},BitVector})`",
+        "instead."), :ordschur)
+    return ordschur!(copy(S), copy(T), copy(Q), copy(Z), select)
+end

--- a/stdlib/LinearAlgebra/src/schur.jl
+++ b/stdlib/LinearAlgebra/src/schur.jl
@@ -149,27 +149,6 @@ included or both excluded via `select`.
 ordschur(schur::Schur, select::Union{Vector{Bool},BitVector}) =
     Schur(ordschur(schur.T, schur.Z, select)...)
 
-"""
-    ordschur!(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
-
-Same as [`ordschur`](@ref) but overwrites the input arguments.
-"""
-ordschur!(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat} =
-    LinearAlgebra.LAPACK.trsen!(convert(Vector{BlasInt}, select), T, Z)[1:3]
-
-"""
-    ordschur(T::StridedMatrix, Z::StridedMatrix, select::Union{Vector{Bool},BitVector}) -> T::StridedMatrix, Z::StridedMatrix, λ::Vector
-
-Reorders the Schur factorization of a real matrix `A = Z*T*Z'` according to the logical
-array `select` returning the reordered matrices `T` and `Z` as well as the vector of
-eigenvalues `λ`. The selected eigenvalues appear in the leading diagonal of `T` and the
-corresponding leading columns of `Z` form an orthogonal/unitary basis of the corresponding
-right invariant subspace. In the real case, a complex conjugate pair of eigenvalues must be
-either both included or both excluded via `select`.
-"""
-ordschur(T::StridedMatrix{Ty}, Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat} =
-    ordschur!(copy(T), copy(Z), select)
-
 struct GeneralizedSchur{Ty,M<:AbstractMatrix} <: Factorization{Ty}
     S::M
     T::M
@@ -247,29 +226,6 @@ and `B` can still be obtained with `F.α./F.β`.
 """
 ordschur(gschur::GeneralizedSchur, select::Union{Vector{Bool},BitVector}) =
     GeneralizedSchur(ordschur(gschur.S, gschur.T, gschur.Q, gschur.Z, select)...)
-
-"""
-    ordschur!(S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, select) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
-
-Same as [`ordschur`](@ref) but overwrites the factorization the input arguments.
-"""
-ordschur!(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},
-    Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat} =
-        LinearAlgebra.LAPACK.tgsen!(convert(Vector{BlasInt}, select), S, T, Q, Z)
-
-"""
-    ordschur(S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, select) -> S::StridedMatrix, T::StridedMatrix, Q::StridedMatrix, Z::StridedMatrix, α::Vector, β::Vector
-
-Reorders the Generalized Schur factorization of a matrix pair `(A, B) = (Q*S*Z', Q*T*Z')`
-according to the logical array `select` and returns the matrices `S`, `T`, `Q`, `Z` and
-vectors `α` and `β`.  The selected eigenvalues appear in the leading diagonal of both `S`
-and `T`, and the left and right unitary/orthogonal Schur vectors are also reordered such
-that `(A, B) = Q*(S, T)*Z'` still holds and the generalized eigenvalues of `A` and `B` can
-still be obtained with `α./β`.
-"""
-ordschur(S::StridedMatrix{Ty}, T::StridedMatrix{Ty}, Q::StridedMatrix{Ty},
-    Z::StridedMatrix{Ty}, select::Union{Vector{Bool},BitVector}) where {Ty<:BlasFloat} =
-        ordschur!(copy(S), copy(T), copy(Q), copy(Z), select)
 
 function getproperty(F::GeneralizedSchur, d::Symbol)
     if d == :values


### PR DESCRIPTION
Adresses JuliaLang/LinearAlgebra.jl#543. The idea is to deprecate the `ordschur` methods that accept the individual components instead of the `schur` factorization.

@andreasnoack I tried to follow the example you gave but, locally, no deprecation messages are shown.  One "problem" could be that I had to install 0.7 for this PR and my setup is still a bit shaky. So any feedback is welcome.