### PR TITLE
Add `splitpath(p::AbstractString)` to Base.Filesystem.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -832,6 +832,7 @@ export
     splitdir,
     splitdrive,
     splitext,
+    splitpath,
 
 # filesystem operations
     cd,

--- a/base/path.jl
+++ b/base/path.jl
@@ -214,13 +214,13 @@ function splitpath(p::String)
     out = String[]
     while !isempty(p)
         dir, base = splitdir(p)
-        dir == p && (push!(out, dir); break)  # Reached root node.
+        dir == p && (pushfirst!(out, dir); break)  # Reached root node.
         if !isempty(base)  # Skip trailing '/' in basename
-            push!(out, base)
+            pushfirst!(out, base)
         end
-        p = dir;
+        p = dir
     end
-    return reverse!(out)
+    return out
 end
 
 joinpath(a::AbstractString) = a

--- a/base/path.jl
+++ b/base/path.jl
@@ -15,7 +15,8 @@ export
     relpath,
     splitdir,
     splitdrive,
-    splitext
+    splitext,
+    splitpath
 
 if Sys.isunix()
     const path_separator    = "/"
@@ -194,6 +195,29 @@ function pathsep(paths::AbstractString...)
         m !== nothing && return m.match[1:1]
     end
     return path_separator
+end
+
+"""
+    splitpath(path::AbstractString) -> (AbstractString, AbstractString, AbstractString...)
+
+Split a file path into all its path components. This is the opposite of
+`joinpath`. Returns a tuple of strings, one for each directory or file in the
+path, including the root directory if present.
+
+# Examples
+```jldoctest
+julia> splitpath("/home/myuser/example.jl")
+("/", "home", "myuser", "example.jl")
+```
+"""
+function splitpath(p::AbstractString)
+    out = ()
+    while true
+        isempty(p) && return out  # Finished p.
+        dirname(p) == p && return (dirname(p), out...)  # Reached the root.
+        isempty(basename(p)) && (p = dirname(p); continue)  # Trailing '/'.
+        (p, out) = dirname(p), (basename(p), out...)
+    end
 end
 
 joinpath(a::AbstractString) = a

--- a/base/path.jl
+++ b/base/path.jl
@@ -211,7 +211,9 @@ julia> splitpath("/home/myuser/example.jl")
 ```
 """
 function splitpath(p::String)
+    drive, p = splitdrive(p)
     out = String[]
+    isempty(p) && (pushfirst!(out,p))  # "" means the current directory.
     while !isempty(p)
         dir, base = splitdir(p)
         dir == p && (pushfirst!(out, dir); break)  # Reached root node.
@@ -219,6 +221,9 @@ function splitpath(p::String)
             pushfirst!(out, base)
         end
         p = dir
+    end
+    if !isempty(drive)  # Tack the drive back on to the first element.
+        out[1] = drive*out[1]  # Note that length(out) is always >= 1.
     end
     return out
 end

--- a/base/path.jl
+++ b/base/path.jl
@@ -213,7 +213,11 @@ the path, including the root directory if present.
 # Examples
 ```jldoctest
 julia> splitpath("/home/myuser/example.jl")
-["/", "home", "myuser", "example.jl"]
+4-element Array{String,1}:
+ "/"
+ "home"
+ "myuser"
+ "example.jl"
 ```
 """
 function splitpath(p::String)

--- a/base/path.jl
+++ b/base/path.jl
@@ -198,7 +198,7 @@ function pathsep(paths::AbstractString...)
 end
 
 """
-    splitpath(path::AbstractString) -> [AbstractString, AbstractString, AbstractString...]
+    splitpath(path::AbstractString) -> Vector{String}
 
 Split a file path into all its path components. This is the opposite of
 `joinpath`. Returns an array of substrings, one for each directory or file in

--- a/base/path.jl
+++ b/base/path.jl
@@ -213,8 +213,8 @@ julia> splitpath("/home/myuser/example.jl")
 function splitpath(p::AbstractString)
     out = ()
     while true
-        isempty(p) && return out  # Finished p.
-        dirname(p) == p && return (dirname(p), out...)  # Reached the root.
+        isempty(p) && return out
+        ismount(p) && return (dirname(p), out...)
         isempty(basename(p)) && (p = dirname(p); continue)  # Trailing '/'.
         (p, out) = dirname(p), (basename(p), out...)
     end

--- a/base/path.jl
+++ b/base/path.jl
@@ -207,18 +207,18 @@ the path, including the root directory if present.
 # Examples
 ```jldoctest
 julia> splitpath("/home/myuser/example.jl")
-("/", "home", "myuser", "example.jl")
+["/", "home", "myuser", "example.jl"]
 ```
 """
 function splitpath(p::String)
     out = String[]
-    while true
-        isempty(p) && break
-        d, b = splitdir(p)
-        ismount(p) && (push!(out, d); break)
-        isempty(b) && (p = d; continue)  # Trailing '/'.
-        push!(out, b)
-        p = d
+    while !isempty(p)
+        dir, base = splitdir(p)
+        dir == p && (push!(out, dir); break)  # Reached root node.
+        if !isempty(base)  # Skip trailing '/' in basename
+            push!(out, base)
+        end
+        p = dir;
     end
     return reverse!(out)
 end

--- a/base/path.jl
+++ b/base/path.jl
@@ -130,6 +130,12 @@ julia> splitdir("/home/myuser")
 """
 function splitdir(path::String)
     a, b = splitdrive(path)
+    _splitdir_nodrive(a,b)
+end
+
+# Common splitdir functionality without splitdrive, needed for splitpath.
+_splitdir_nodrive(path::String) = _splitdir_nodrive("", path)
+function _splitdir_nodrive(a::String, b::String)
     m = match(path_dir_splitter,b)
     m === nothing && return (a,b)
     a = string(a, isempty(m.captures[1]) ? m.captures[2][1] : m.captures[1])
@@ -215,7 +221,7 @@ function splitpath(p::String)
     out = String[]
     isempty(p) && (pushfirst!(out,p))  # "" means the current directory.
     while !isempty(p)
-        dir, base = splitdir(p)
+        dir, base = _splitdir_nodrive(p)
         dir == p && (pushfirst!(out, dir); break)  # Reached root node.
         if !isempty(base)  # Skip trailing '/' in basename
             pushfirst!(out, base)

--- a/base/path.jl
+++ b/base/path.jl
@@ -210,8 +210,8 @@ julia> splitpath("/home/myuser/example.jl")
 ("/", "home", "myuser", "example.jl")
 ```
 """
-function splitpath(p::AbstractString)
-    out = AbstractString[]
+function splitpath(p::String)
+    out = String[]
     while true
         isempty(p) && break
         ismount(p) && (push!(out, dirname(p)); break)

--- a/base/path.jl
+++ b/base/path.jl
@@ -198,11 +198,11 @@ function pathsep(paths::AbstractString...)
 end
 
 """
-    splitpath(path::AbstractString) -> (AbstractString, AbstractString, AbstractString...)
+    splitpath(path::AbstractString) -> [AbstractString, AbstractString, AbstractString...]
 
 Split a file path into all its path components. This is the opposite of
-`joinpath`. Returns a tuple of strings, one for each directory or file in the
-path, including the root directory if present.
+`joinpath`. Returns an array of substrings, one for each directory or file in
+the path, including the root directory if present.
 
 # Examples
 ```jldoctest
@@ -211,13 +211,15 @@ julia> splitpath("/home/myuser/example.jl")
 ```
 """
 function splitpath(p::AbstractString)
-    out = ()
+    out = AbstractString[]
     while true
-        isempty(p) && return out
-        ismount(p) && return (dirname(p), out...)
+        isempty(p) && break
+        ismount(p) && (push!(out, dirname(p)); break)
         isempty(basename(p)) && (p = dirname(p); continue)  # Trailing '/'.
-        (p, out) = dirname(p), (basename(p), out...)
+        push!(out, basename(p))
+        p = dirname(p)
     end
+    return reverse(out)
 end
 
 joinpath(a::AbstractString) = a

--- a/base/path.jl
+++ b/base/path.jl
@@ -214,12 +214,13 @@ function splitpath(p::String)
     out = String[]
     while true
         isempty(p) && break
-        ismount(p) && (push!(out, dirname(p)); break)
-        isempty(basename(p)) && (p = dirname(p); continue)  # Trailing '/'.
-        push!(out, basename(p))
-        p = dirname(p)
+        d, b = splitdir(p)
+        ismount(p) && (push!(out, d); break)
+        isempty(b) && (p = d; continue)  # Trailing '/'.
+        push!(out, b)
+        p = d
     end
-    return reverse(out)
+    return reverse!(out)
 end
 
 joinpath(a::AbstractString) = a

--- a/doc/src/base/file.md
+++ b/doc/src/base/file.md
@@ -62,4 +62,5 @@ Base.Filesystem.expanduser
 Base.Filesystem.splitdir
 Base.Filesystem.splitdrive
 Base.Filesystem.splitext
+Base.Filesystem.splitpath
 ```

--- a/test/path.jl
+++ b/test/path.jl
@@ -106,8 +106,8 @@
             @test splitpath("C:\\\\") == ["C:\\"]
             @test splitpath("J:\\") == ["J:\\"]
             @test splitpath("C:") == ["C:"]
-            @test splitpath("C:a") == ["C:"]
-            @test splitpath("C:a\\b") == ["C:"]
+            @test splitpath("C:a") == ["C:", "a"]
+            @test splitpath("C:a\\b") == ["C:", "a", "b"]
 
             @test splitpath("a\\") == ["a"]
             @test splitpath("a\\\\b\\\\") == ["a","b"]

--- a/test/path.jl
+++ b/test/path.jl
@@ -89,21 +89,31 @@
         @test ["a", "b", "c"] == splitpath(joinpath("a","b","c"))
         @test [] == splitpath("")
 
+        @test ["cats are", "gr8t"] == splitpath(joinpath("cats are", "gr8t"))
+        @test ["  ", " "] == splitpath(joinpath("  ", " "))
+
         # Unix-style paths are understood by all systems.
         @test ["/", "a", "b"] == splitpath("/a/b")
         @test ["/"] == splitpath("/")
         @test ["a"] == splitpath("a/")
         @test ["a", "b"] == splitpath("a/b/")
+        @test ["a.dir", "b.txt"] == splitpath("a.dir/b.txt")
         @test ["/"] == splitpath("///")
         @test ["/", "a", "b"] == splitpath("///a///b///")
 
         if Sys.iswindows()
             @test ["C:\\", "a", "b", "c"] == splitpath("C:\\\\a\\b\\c")
             @test ["C:\\"] == splitpath("C:\\\\")
-            @test ["J:\\"] == splitpath("J:\\\\")
+            @test ["J:\\"] == splitpath("J:\\")
+            @test ["C:"] == splitpath("C:")
             @test ["a"] == splitpath("a\\")
             @test ["a","b"] == splitpath("a\\\\b\\\\")
+            @test ["a.dir", "b.txt"] == splitpath("a.dir\\b.txt")
             @test ["\\", "a","b"] == splitpath("\\a\\b\\")
+
+            @test ["/", "a", "b", "c", "d", "e"] == splitpath("/a/b\\c/d\\\\e")
+            @test ["/"] == splitpath("/\\/\\")
+            @test ["\\","a","b"] == splitpath("\\/\\a/\\//b")
         end
     end
 

--- a/test/path.jl
+++ b/test/path.jl
@@ -113,7 +113,7 @@
             @test splitpath("a\\\\b\\\\") == ["a","b"]
             @test splitpath("a.dir\\b.txt") == ["a.dir", "b.txt"]
             @test splitpath("\\a\\b\\") == ["\\", "a","b"]
-            @test splitpath("\\\\a\\b") == ["\\", "a","b"]
+            @test splitpath("\\\\a\\b") == ["\\\\a\\b"]  # This is actually a valid drive name in windows.
 
             @test splitpath("/a/b\\c/d\\\\e") == ["/", "a", "b", "c", "d", "e"]
             @test splitpath("/\\/\\") == ["/"]

--- a/test/path.jl
+++ b/test/path.jl
@@ -85,6 +85,17 @@
     end
     @test relpath(S(joinpath("foo","bar")), S("foo")) == "bar"
 
+    @testset "splitpath" begin
+        @test ("a", "b") == splitpath("a/b")
+        @test ("/", "a", "b") == splitpath("/a/b")
+        @test ("/",) == splitpath("/")
+        @test ("a",) == splitpath("a/")
+        @test ("a", "b") == splitpath("a/b/")
+        @test () == splitpath("")
+        @test ("/",) == splitpath("///")
+        @test ("/", "a", "b") == splitpath("///a///b///")
+    end
+
     @testset "splitting" begin
         @test joinpath(splitdir(S(homedir()))...) == homedir()
         @test string(splitdrive(S(homedir()))...) == homedir()

--- a/test/path.jl
+++ b/test/path.jl
@@ -89,22 +89,21 @@
         @test ["a", "b", "c"] == splitpath(joinpath("a","b","c"))
         @test [] == splitpath("")
 
+        # Unix-style paths are understood by all systems.
+        @test ["/", "a", "b"] == splitpath("/a/b")
+        @test ["/"] == splitpath("/")
+        @test ["a"] == splitpath("a/")
+        @test ["a", "b"] == splitpath("a/b/")
+        @test ["/"] == splitpath("///")
+        @test ["/", "a", "b"] == splitpath("///a///b///")
+
         if Sys.iswindows()
-            @test ["C:", "a", "b", "c"] == splitpath("C:\\\\a\\b\\c")
-            @test ["C:"] == splitpath("C:\\\\")
-            @test ["J:"] == splitpath("J:\\\\")
+            @test ["C:\\", "a", "b", "c"] == splitpath("C:\\\\a\\b\\c")
+            @test ["C:\\"] == splitpath("C:\\\\")
+            @test ["J:\\"] == splitpath("J:\\\\")
             @test ["a"] == splitpath("a\\")
             @test ["a","b"] == splitpath("a\\\\b\\\\")
-            # TODO: what should this do for a leading slash?
-            # (what does dirname() do for a leading slash?)
-            # @test ["\\", "a","b"] == splitpath("\\a\\b\\")
-        else
-            @test ["/", "a", "b"] == splitpath("/a/b")
-            @test ["/"] == splitpath("/")
-            @test ["a"] == splitpath("a/")
-            @test ["a", "b"] == splitpath("a/b/")
-            @test ["/"] == splitpath("///")
-            @test ["/", "a", "b"] == splitpath("///a///b///")
+            @test ["\\", "a","b"] == splitpath("\\a\\b\\")
         end
     end
 

--- a/test/path.jl
+++ b/test/path.jl
@@ -86,34 +86,37 @@
     @test relpath(S(joinpath("foo","bar")), S("foo")) == "bar"
 
     @testset "splitpath" begin
-        @test ["a", "b", "c"] == splitpath(joinpath("a","b","c"))
-        @test [] == splitpath("")
+        @test splitpath(joinpath("a","b","c")) == ["a", "b", "c"]
+        @test splitpath("") == []
 
-        @test ["cats are", "gr8t"] == splitpath(joinpath("cats are", "gr8t"))
-        @test ["  ", " "] == splitpath(joinpath("  ", " "))
+        @test splitpath(joinpath("cats are", "gr8t")) == ["cats are", "gr8t"]
+        @test splitpath(joinpath("  ", " ")) == ["  ", " "]
 
         # Unix-style paths are understood by all systems.
-        @test ["/", "a", "b"] == splitpath("/a/b")
-        @test ["/"] == splitpath("/")
-        @test ["a"] == splitpath("a/")
-        @test ["a", "b"] == splitpath("a/b/")
-        @test ["a.dir", "b.txt"] == splitpath("a.dir/b.txt")
-        @test ["/"] == splitpath("///")
-        @test ["/", "a", "b"] == splitpath("///a///b///")
+        @test splitpath("/a/b") == ["/", "a", "b"]
+        @test splitpath("/") == ["/"]
+        @test splitpath("a/") == ["a"]
+        @test splitpath("a/b/") == ["a", "b"]
+        @test splitpath("a.dir/b.txt") == ["a.dir", "b.txt"]
+        @test splitpath("///") == ["/"]
+        @test splitpath("///a///b///") == ["/", "a", "b"]
 
         if Sys.iswindows()
-            @test ["C:\\", "a", "b", "c"] == splitpath("C:\\\\a\\b\\c")
-            @test ["C:\\"] == splitpath("C:\\\\")
-            @test ["J:\\"] == splitpath("J:\\")
-            @test ["C:"] == splitpath("C:")
-            @test ["a"] == splitpath("a\\")
-            @test ["a","b"] == splitpath("a\\\\b\\\\")
-            @test ["a.dir", "b.txt"] == splitpath("a.dir\\b.txt")
-            @test ["\\", "a","b"] == splitpath("\\a\\b\\")
+            @test splitpath("C:\\\\a\\b\\c") == ["C:\\", "a", "b", "c"]
+            @test splitpath("C:\\\\") == ["C:\\"]
+            @test splitpath("J:\\") == ["J:\\"]
+            @test splitpath("C:") == ["C:"]
+            @test splitpath("C:a") == ["C:"]
+            @test splitpath("C:a\\b") == ["C:"]
 
-            @test ["/", "a", "b", "c", "d", "e"] == splitpath("/a/b\\c/d\\\\e")
-            @test ["/"] == splitpath("/\\/\\")
-            @test ["\\","a","b"] == splitpath("\\/\\a/\\//b")
+            @test splitpath("a\\") == ["a"]
+            @test splitpath("a\\\\b\\\\") == ["a","b"]
+            @test splitpath("a.dir\\b.txt") == ["a.dir", "b.txt"]
+            @test splitpath("\\a\\b\\") == ["\\", "a","b"]
+
+            @test splitpath("/a/b\\c/d\\\\e") == ["/", "a", "b", "c", "d", "e"]
+            @test splitpath("/\\/\\") == ["/"]
+            @test splitpath("\\/\\a/\\//b") == ["\\","a","b"]
         end
     end
 

--- a/test/path.jl
+++ b/test/path.jl
@@ -87,7 +87,7 @@
 
     @testset "splitpath" begin
         @test splitpath(joinpath("a","b","c")) == ["a", "b", "c"]
-        @test splitpath("") == []
+        @test splitpath("") == [""]
 
         @test splitpath(joinpath("cats are", "gr8t")) == ["cats are", "gr8t"]
         @test splitpath(joinpath("  ", " ")) == ["  ", " "]
@@ -106,13 +106,14 @@
             @test splitpath("C:\\\\") == ["C:\\"]
             @test splitpath("J:\\") == ["J:\\"]
             @test splitpath("C:") == ["C:"]
-            @test splitpath("C:a") == ["C:", "a"]
-            @test splitpath("C:a\\b") == ["C:", "a", "b"]
+            @test splitpath("C:a") == ["C:a"]
+            @test splitpath("C:a\\b") == ["C:a", "b"]
 
             @test splitpath("a\\") == ["a"]
             @test splitpath("a\\\\b\\\\") == ["a","b"]
             @test splitpath("a.dir\\b.txt") == ["a.dir", "b.txt"]
             @test splitpath("\\a\\b\\") == ["\\", "a","b"]
+            @test splitpath("\\\\a\\b") == ["\\", "a","b"]
 
             @test splitpath("/a/b\\c/d\\\\e") == ["/", "a", "b", "c", "d", "e"]
             @test splitpath("/\\/\\") == ["/"]

--- a/test/path.jl
+++ b/test/path.jl
@@ -86,14 +86,26 @@
     @test relpath(S(joinpath("foo","bar")), S("foo")) == "bar"
 
     @testset "splitpath" begin
-        @test ["a", "b"] == splitpath("a/b")
-        @test ["/", "a", "b"] == splitpath("/a/b")
-        @test ["/",] == splitpath("/")
-        @test ["a",] == splitpath("a/")
-        @test ["a", "b"] == splitpath("a/b/")
+        @test ["a", "b", "c"] == splitpath(joinpath("a","b","c"))
         @test [] == splitpath("")
-        @test ["/",] == splitpath("///")
-        @test ["/", "a", "b"] == splitpath("///a///b///")
+
+        if Sys.iswindows()
+            @test ["C:", "a", "b", "c"] == splitpath("C:\\\\a\\b\\c")
+            @test ["C:"] == splitpath("C:\\\\")
+            @test ["J:"] == splitpath("J:\\\\")
+            @test ["a"] == splitpath("a\\")
+            @test ["a","b"] == splitpath("a\\\\b\\\\")
+            # TODO: what should this do for a leading slash?
+            # (what does dirname() do for a leading slash?)
+            # @test ["\\", "a","b"] == splitpath("\\a\\b\\")
+        else
+            @test ["/", "a", "b"] == splitpath("/a/b")
+            @test ["/"] == splitpath("/")
+            @test ["a"] == splitpath("a/")
+            @test ["a", "b"] == splitpath("a/b/")
+            @test ["/"] == splitpath("///")
+            @test ["/", "a", "b"] == splitpath("///a///b///")
+        end
     end
 
     @testset "splitting" begin

--- a/test/path.jl
+++ b/test/path.jl
@@ -86,14 +86,14 @@
     @test relpath(S(joinpath("foo","bar")), S("foo")) == "bar"
 
     @testset "splitpath" begin
-        @test ("a", "b") == splitpath("a/b")
-        @test ("/", "a", "b") == splitpath("/a/b")
-        @test ("/",) == splitpath("/")
-        @test ("a",) == splitpath("a/")
-        @test ("a", "b") == splitpath("a/b/")
-        @test () == splitpath("")
-        @test ("/",) == splitpath("///")
-        @test ("/", "a", "b") == splitpath("///a///b///")
+        @test ["a", "b"] == splitpath("a/b")
+        @test ["/", "a", "b"] == splitpath("/a/b")
+        @test ["/",] == splitpath("/")
+        @test ["a",] == splitpath("a/")
+        @test ["a", "b"] == splitpath("a/b/")
+        @test [] == splitpath("")
+        @test ["/",] == splitpath("///")
+        @test ["/", "a", "b"] == splitpath("///a///b///")
     end
 
     @testset "splitting" begin


### PR DESCRIPTION
Opposite of `joinpath()`, it separates a path into its parts.