### PR TITLE
WIP/RFC: Converted WeakKeyDict to hash & compare with object-id

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -467,7 +467,7 @@ end
 
 function ==(l::AbstractDict, r::AbstractDict)
     l === r && return true
-    if isa(l,IdDict) != isa(r,IdDict)
+    if isa(l,IdDict) != isa(r,IdDict) || isa(l,WeakKeyDict) != isa(r,WeakKeyDict)
         return false
     end
     length(l) != length(r) && return false

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -835,11 +835,13 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
 
     # WeakKeyDict hashes with object-id
     AA = copy(A)
-    wkd = WeakKeyDict(A=>1, AA=>2)
-    @test length(wkd)==2
-    kk = collect(keys(wkd))
-    @test kk[1]==kk[2]
-    @test kk[1]!==kk[2]
+    GC.@preserve A AA begin
+        wkd = WeakKeyDict(A=>1, AA=>2)
+        @test length(wkd)==2
+        kk = collect(keys(wkd))
+        @test kk[1]==kk[2]
+        @test kk[1]!==kk[2]
+    end
 
     # WeakKeyDict compares false to non-WeakKeyDict
     @test IdDict(A=>1)!=WeakKeyDict(A=>1)

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -830,6 +830,21 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
 
     @test_throws ArgumentError WeakKeyDict([1, 2, 3])
 
+    # WeakKeyDict does not convert keys
+    @test_throws ArgumentError WeakKeyDict{Int,Any}(5.0=>1)
+
+    # WeakKeyDict hashes with object-id
+    AA = copy(A)
+    wkd = WeakKeyDict(A=>1, AA=>2)
+    @test length(wkd)==2
+    kk = collect(keys(wkd))
+    @test kk[1]==kk[2]
+    @test kk[1]!==kk[2]
+
+    # WeakKeyDict compares false to non-WeakKeyDict
+    @test IdDict(A=>1)!=WeakKeyDict(A=>1)
+    @test Dict(A=>1)!=WeakKeyDict(A=>1)
+
     # issue #26939
     d26939 = WeakKeyDict()
     d26939[big"1.0" + 1.1] = 1


### PR DESCRIPTION
This implements Stefan's suggestion to use object-id hash in the WeakKeyDict:  https://github.com/JuliaLang/julia/issues/24941#issuecomment-404263168, which has currently a "Triage" label.  Maybe this PR can help inform that decision. The changes were pretty minimal and no breakage occurred.

TODO if we go ahead with this:
- [ ] run package evaluator(?)
- [ ] rename `WeakKeyDict` to `WeakKeyIdDict`
- [ ] deprecate
- [ ] NEWS item

I can do this on Friday if triage is positive.

TODO if we don't go ahead with this:
- add a test for key-conversion and the key-dropping (#24941)

x-refs: #3002, #24941, #28182