### PR TITLE
use inbounds in generic matvecmul

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -504,6 +504,7 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
 
     Astride = size(A, 1)
 
+    @inbounds begin
     if tA == 'T'  # fastest case
         for k = 1:mA
             aoffs = (k-1)*Astride
@@ -546,6 +547,7 @@ function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::Ab
             end
         end
     end
+    end # @inbounds
     C
 end
 


### PR DESCRIPTION
This mirrors the usage of `@inbounds` in `generic_matmatmul` a hundred lines below. Fixes https://github.com/JuliaLang/LinearAlgebra.jl/issues/532