### PR TITLE
add pairs for Core.Svec

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -224,6 +224,7 @@ pairs(A::AbstractArray)  = pairs(IndexCartesian(), A)
 pairs(A::AbstractVector) = pairs(IndexLinear(), A)
 pairs(tuple::Tuple) = Pairs(tuple, keys(tuple))
 pairs(nt::NamedTuple) = Pairs(nt, keys(nt))
+pairs(v::Core.SimpleVector) = Pairs(v, LinearIndices(v))
 # pairs(v::Pairs) = v # listed for reference, but already defined from being an AbstractDict
 
 length(v::Pairs) = length(v.itr)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -541,3 +541,9 @@ end
 	@test !isempty(a)
     end
 end
+
+@testset "pair for Svec" begin
+    ps = pairs(Core.svec(:a, :b))
+    @test ps isa Iterators.Pairs
+    @test collect(ps) == [1 => :a, 2 => :b]
+end


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/27995

```jl
julia> v = Core.svec([Symbol("s$n") for n in 1:20]...)
svec(:s1, :s2, :s3, :s4, :s5, :s6, :s7, :s8, :s9, :s10, :s11, :s12, :s13, :s14, :s15, :s16, :s17, :s18, :s19, :s20)

julia> using BenchmarkTools

julia> @btime findfirst(x->(x===:s20), v);
  115.023 ns (0 allocations: 0 bytes)
```