### PR TITLE
make simd loop over ranges perform better

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -498,6 +498,11 @@ length(r::OneTo) = unsafe_length(r)
 length(r::StepRangeLen) = r.len
 length(r::LinRange) = r.len
 
+# Needed to fold the `firstindex` call in SimdLoop.simd_index
+firstindex(::UnitRange) = 1
+firstindex(::StepRange) = 1
+firstindex(::LinRange) = 1
+
 function length(r::StepRange{T}) where T<:Union{Int,UInt,Int64,UInt64}
     isempty(r) && return zero(T)
     if r.step > 1


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/27773 (and likely the `sumlinear_view` benchmarks in https://github.com/JuliaLang/julia/pull/27030)

```jl
julia> function perf_sumlinear_view(A)
           s = zero(eltype(A))
           @inbounds @simd for I in 1:length(A)
               val = view(A, I)
               s += val[]
           end
           return s
       end
perf_sumlinear_view (generic function with 1 method)

julia> A = 1:1000000
1:1000000

julia> using BenchmarkTools

julia> @btime perf_sumlinear_view(A)
  110.620 μs (1 allocation: 16 bytes)
500000500000

julia> Base.firstindex(::UnitRange) = 1

julia> @btime perf_sumlinear_view(A)
  28.288 ns (1 allocation: 16 bytes)
500000500000
```

Apparently `firstindex(::UnitRange)` is right now too complex to see through. Arguably it would be better to try to figure out why it cannot be folded but it is a quite deep chain of calls...

Regression introduced in https://github.com/JuliaLang/julia/pull/27038 (with no Nanosoldier run, perhaps it was nonfunctional at the time)

