### PR TITLE
don't allow U+0387 (·) in identifiers

### DIFF
--- a/src/flisp/julia_extensions.c
+++ b/src/flisp/julia_extensions.c
@@ -132,9 +132,7 @@ JL_DLLEXPORT int jl_id_char(uint32_t wc)
         cat == UTF8PROC_CATEGORY_SK || cat == UTF8PROC_CATEGORY_ME ||
         cat == UTF8PROC_CATEGORY_NO ||
         // primes (single, double, triple, their reverses, and quadruple)
-        (wc >= 0x2032 && wc <= 0x2037) || (wc == 0x2057) ||
-        // Other_ID_Continue
-        wc == 0x0387 || wc == 0x19da || (wc >= 0x1369 && wc <= 0x1371))
+        (wc >= 0x2032 && wc <= 0x2037) || (wc == 0x2057))
         return 1;
     return 0;
 }


### PR DESCRIPTION
As discussed in #25157 and [on discourse](https://discourse.julialang.org/t/why-is-greek-ano-teleia-a-valid-identifier-character/12442), it doesn't make sense to accept [U+0387](http://www.fileformat.info/info/unicode/char/0387/index.htm) (`·`) in identifiers, despite the fact that it is included in [UAX#31](http://unicode.org/reports/tr31/) for legacy reasons.

Julia NFC-normalizes identifiers (#5434), and U+0387 NFC-normalizes to [U+00b7](http://www.fileformat.info/info/unicode/char/b7/index.htm) (middle-dot `·`, i.e. `\cdotp`), but we don't allow U+00b7 in identifiers.  It makes no sense to treat them differently (the code for this stems from #6805 by @JeffBezanson).   At some point in the future, we may want to normalize both to U+22c5 (`\cdot` `⋅`) (see #25157).

The other special cases that we included from Other_ID_Continue are in category No, which we already allow anyway, which is why I deleted the whole Other_ID_Continue line.

This is a breaking change. I seriously doubt that it breaks any real-world code, but we should try to get it in for 0.7.  cc @mlhetland.