### PR TITLE
accept AbstractString for BigFloat construction

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -204,7 +204,7 @@ end
 
 Create a representation of the string `x` as a [`BigFloat`](@ref).
 """
-BigFloat(x::String) = parse(BigFloat, x)
+BigFloat(x::AbstractString) = parse(BigFloat, x)
 
 
 ## BigFloat -> Integer

--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -12,7 +12,7 @@ import Base.MPFR
     @test x == BigFloat(x) == BigFloat(0xc) == BigFloat(12.) ==
           BigFloat(BigInt(12)) == BigFloat(BigFloat(12)) == parse(BigFloat,"12") ==
           parse(BigFloat,"12 ") == parse(BigFloat," 12") == parse(BigFloat," 12 ") ==
-          BigFloat(Float32(12.)) == BigFloat(12//1)
+          BigFloat(Float32(12.)) == BigFloat(12//1) == BigFloat(SubString("12"))
 
     @test typeof(BigFloat(typemax(Int8))) == BigFloat
     @test typeof(BigFloat(typemax(Int16))) == BigFloat


### PR DESCRIPTION
Minor change to allow `BigFloat` construction from an `AbstractString` (and not only from a `String`). E.g.:

```
julia> BigFloat(strip(" 42"))
4.2e+01
```

Without this:

```
julia> BigFloat(strip(" 42"))
ERROR: MethodError: Cannot `convert` an object of type SubString{String} to an object of type BigFloat
...
```