### PR TITLE
WIP FreeBSD/aarch64 support

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -693,6 +693,15 @@ else
 ISX86:=0
 endif
 
+# clang needs this flag to compile CRC instructions (used conditionally with detection)
+ifneq (,$(findstring aarch64,$(ARCH)))
+ifeq ($(USECLANG),1)
+ifeq ($(MARCH),)
+JCFLAGS += -mcrc
+endif
+endif
+endif
+
 # If we are running on powerpc64le or ppc64le, set certain options automatically
 ifneq (,$(filter $(ARCH), powerpc64le ppc64le))
 JCFLAGS += -fsigned-char

--- a/src/cgmemmgr.cpp
+++ b/src/cgmemmgr.cpp
@@ -506,6 +506,7 @@ public:
     virtual ~ROAllocator() {}
     virtual void finalize()
     {
+#ifndef _CPU_AARCH64_
         for (auto &alloc: allocations) {
             // ensure the mapped pages are consistent
             sys::Memory::InvalidateInstructionCache(alloc.wr_addr,
@@ -513,6 +514,7 @@ public:
             sys::Memory::InvalidateInstructionCache(alloc.rt_addr,
                                                     alloc.sz);
         }
+#endif
         completed.clear();
         allocations.clear();
     }

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -324,6 +324,9 @@ CRC_TARGET static uint32_t crc32c_armv8(uint32_t crc, const char *buf, size_t le
 }
 
 // HW feature detection
+#ifndef HWCAP_CRC32
+#define HWCAP_CRC32 (1<<7)
+#endif
 #  ifdef __ARM_FEATURE_CRC32
 // The C code is compiled with CRC32 being required. Skip runtime dispatch.
 JL_DLLEXPORT uint32_t jl_crc32c(uint32_t crc, const char *buf, size_t len)

--- a/src/signal-handling.c
+++ b/src/signal-handling.c
@@ -135,6 +135,8 @@ static uintptr_t jl_get_pc_from_ctx(const void *_ctx)
     return ((CONTEXT*)_ctx)->Rip;
 #elif defined(_OS_LINUX_) && defined(_CPU_AARCH64_)
     return ((ucontext_t*)_ctx)->uc_mcontext.pc;
+#elif defined(_OS_FREEBSD_) && defined(_CPU_AARCH64_)
+    return ((ucontext_t*)_ctx)->uc_mcontext.mc_gpregs.gp_elr;
 #elif defined(_OS_LINUX_) && defined(_CPU_ARM_)
     return ((ucontext_t*)_ctx)->uc_mcontext.arm_pc;
 #else
@@ -168,7 +170,7 @@ void jl_show_sigill(void *_ctx)
         }
         jl_safe_printf("\n");
     }
-#elif defined(_OS_LINUX_) && defined(_CPU_AARCH64_)
+#elif defined(_CPU_AARCH64_)
     uint32_t inst = 0;
     size_t len = jl_safe_read_mem(pc, (char*)&inst, 4);
     if (len < 4)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -120,6 +120,11 @@ static void jl_call_in_ctx(jl_ptls_t ptls, void (*fptr)(void), int sig, void *_c
     ctx->uc_mcontext.sp = rsp;
     ctx->uc_mcontext.regs[29] = 0; // Clear link register (x29)
     ctx->uc_mcontext.pc = (uintptr_t)fptr;
+#elif defined(_OS_FREEBSD_) && defined(_CPU_AARCH64_)
+    ucontext_t *ctx = (ucontext_t*)_ctx;
+    ctx->uc_mcontext.mc_gpregs.gp_sp = rsp;
+    ctx->uc_mcontext.mc_gpregs.gp_x[29] = 0; // Clear link register (x29)
+    ctx->uc_mcontext.mc_gpregs.gp_elr = (uintptr_t)fptr;
 #elif defined(_OS_LINUX_) && defined(_CPU_ARM_)
     ucontext_t *ctx = (ucontext_t*)_ctx;
     uintptr_t target = (uintptr_t)fptr;


### PR DESCRIPTION
I'm trying to get it to work…

- building with libunwind disabled for now (I'm actually working on it separately: https://github.com/libunwind/libunwind/pull/83)
- crc/auxval and mcontext related fixes are done
- (hmm, is this Linux code correct: `// Clear link register (x29)` — `lr` is not x29, it's `gp_lr` on FreeBSD, IIRC Linux has the register array declared as `[31]` so it's `regs[30]`??)
- still can't finish the build because of crashes. (using llvm 6.0.1 from system)

`sys::Memory::InvalidateInstructionCache` segfaults the compiler:

```
* thread #1, name = 'julia', stop reason = signal SIGSEGV
  * frame #0: 0x0000000043ee3f1c libLLVM-6.0.so
    frame #1: 0x0000000042439120 libLLVM-6.0.so`llvm::sys::Memory::InvalidateInstructionCache(void const*, unsigned long) + 28                                                        
    frame #2: 0x0000000040270838 libjulia.so.0.7`(anonymous namespace)::DualMapAllocator<true>::finalize(void) at cgmemmgr.cpp:513                                                    
    frame #3: 0x0000000040270814 libjulia.so.0.7`(anonymous namespace)::DualMapAllocator<true>::finalize(this=0x0000000044904800) at cgmemmgr.cpp:644                                 
    frame #4: 0x000000004026f968 libjulia.so.0.7`(anonymous namespace)::RTDyldMemoryManagerJL::finalizeMemory(this=0x0000000044898a00, ErrMsg=<unavailable>)::RTDyldMemoryManagerJL::fi
nalizeMemory::char_traits<char>, (anonymous namespace)::RTDyldMemoryManagerJL::finalizeMemory::allocator<char> >*) at cgmemmgr.cpp:869                                                
    frame #5: 0x0000000043414fd0 libLLVM-6.0.so`llvm::RuntimeDyld::finalizeWithMemoryManagerLocking(void) + 84                                                                        
    frame #6: 0x000000004023ac48 libjulia.so.0.7`_ZN4llvm3orc24RTDyldObjectLinkingLayer20ConcreteLinkedObjectINSt3__110shared_ptrINS_11RuntimeDyld13MemoryManagerEEENS4_INS_17JITSymbol
ResolverEEEZNS1_9addObjectENS4_INS_6object12OwningBinaryINSA_10ObjectFileEEEEES9_EUlNS3_15__list_iteratorINS3_10unique_ptrINS0_28RTDyldObjectLinkingLayerBase12LinkedObjectENS3_14defau
lt_deleteISI_EEEEPvEERS5_RKSE_NS3_8functionIFvvEEEE_E8finalizeEv [inlined] _ZZN4llvm3orc24RTDyldObjectLinkingLayer9addObjectENSt3__110shared_ptrINS_6object12OwningBinaryINS4_10ObjectF
ileEEEEENS3_INS_17JITSymbolResolverEEEENKUlNS2_15__list_iteratorINS2_10unique_ptrINS0_28RTDyldObjectLinkingLayerBase12LinkedObjectENS2_14default_deleteISE_EEEEPvEERNS_11RuntimeDyldERK
S8_NS2_8functionIFvvEEEE_clESJ_SL_SN_SQ_(this=<unavailable>, H=llvm::orc::RTDyldObjectLinkingLayerBase::ObjHandleT @ x21, RTDyld=0x000000004a6e2800, ObjToLoad=0x000000004a78edc0) at R
TDyldObjectLinkingLayer.h:274
    frame #7: 0x000000004023abf4 libjulia.so.0.7`_ZN4llvm3orc24RTDyldObjectLinkingLayer20ConcreteLinkedObjectINSt3__110shared_ptrINS_11RuntimeDyld13MemoryManagerEEENS4_INS_17JITSymbol
ResolverEEEZNS1_9addObjectENS4_INS_6object12OwningBinaryINSA_10ObjectFileEEEEES9_EUlNS3_15__list_iteratorINS3_10unique_ptrINS0_28RTDyldObjectLinkingLayerBase12LinkedObjectENS3_14defau
lt_deleteISI_EEEEPvEERS5_RKSE_NS3_8functionIFvvEEEE_E8finalizeEv(this=0x000000004a73cbc0) at RTDyldObjectLinkingLayer.h:144                                                           
    frame #8: 0x0000000040235ecc libjulia.so.0.7`JuliaOJIT::addModule(std::__1::unique_ptr<llvm::Module, JuliaOJIT::addModule::default_delete<llvm> >) [inlined] llvm::orc::RTDyldObjec
tLinkingLayer::emitAndFinalize(std::__1::__list_iterator<llvm::orc::RTDyldObjectLinkingLayer::emitAndFinalize::unique_ptr<llvm::orc::RTDyldObjectLinkingLayerBase::LinkedObject, llvm::
orc::RTDyldObjectLinkingLayer::emitAndFinalize::default_delete<llvm::orc::RTDyldObjectLinkingLayerBase> >, void*>) at RTDyldObjectLinkingLayer.h:343
    frame #9: 0x0000000040235ebc libjulia.so.0.7`JuliaOJIT::addModule(std::__1::unique_ptr<llvm::Module, JuliaOJIT::addModule::default_delete<llvm> >) [inlined] llvm::orc::IRCompileLa
yer<llvm::orc::RTDyldObjectLinkingLayer, JuliaOJIT::CompilerT>::emitAndFinalize(this=<unavailable>) at IRCompileLayer.h:91
    frame #10: 0x0000000040235ebc libjulia.so.0.7`JuliaOJIT::addModule(this=<unavailable>, M=<unavailable>) at jitlayers.cpp:622
    frame #11: 0x000000004023683c libjulia.so.0.7`jl_finalize_function(llvm::StringRef) [inlined] jl_add_to_ee(m=unique_ptr<llvm::Module, std::__1::default_delete<llvm::Module> > @ sc
alar) at jitlayers.cpp:850
    frame #12: 0x0000000040236824 libjulia.so.0.7`jl_finalize_function(F=<unavailable>) at jitlayers.cpp:858
    frame #13: 0x00000000401dea80 libjulia.so.0.7`getAddressForFunction(fname=<unavailable>) at codegen.cpp:1299
    frame #14: 0x00000000401def44 libjulia.so.0.7`::jl_generate_fptr(pli=0x0000ffffffffd8d8, decls=<unavailable>, world=<unavailable>) at codegen.cpp:1410
    frame #15: 0x0000000040168e34 libjulia.so.0.7`jl_fptr_trampoline(m=0x0000000045927110, args=0x0000ffffffffd910, nargs=2) at gf.c:1820
    frame #16: 0x00000000402ce8b0 libjulia.so.0.7`do_call(args=<unavailable>, nargs=2, s=0x0000ffffffffdd30) at interpreter.c:324
    frame #17: 0x00000000402cd464 libjulia.so.0.7`eval_body(stmts=0x000000004595c010, s=0x0000ffffffffdd30, start=<unavailable>, toplevel=1) at interpreter.c:558
    frame #18: 0x00000000402cda7c libjulia.so.0.7`jl_interpret_toplevel_thunk_callback(s=0x0000ffffffffdd30, vargs=<unavailable>) at interpreter.c:792
    frame #19: 0x000000004017fbf4 libjulia.so.0.7`Lenter_interpreter_frame_start_val + 4
    frame #20: 0x00000000402cdacc libjulia.so.0.7`jl_interpret_toplevel_thunk(m=<unavailable>, src=<unavailable>) at interpreter.c:801
    frame #21: 0x00000000401979ac libjulia.so.0.7`jl_toplevel_eval_flex(m=<unavailable>, e=<unavailable>, fast=<unavailable>, expanded=<unavailable>) at toplevel.c:821
    frame #22: 0x0000000040175410 libjulia.so.0.7`jl_parse_eval_all(fname=<unavailable>, content=<unavailable>, contentlen=<unavailable>, inmodule=0x00000000458cc010) at ast.c:855
    frame #23: 0x0000000040198560 libjulia.so.0.7`jl_load(module=0x00000000458cc010, fname="") at toplevel.c:855
    frame #24: 0x0000000040182bfc libjulia.so.0.7`_julia_init(rel=<unavailable>) at init.c:749
    frame #25: 0x0000000040183fe4 libjulia.so.0.7`julia_init__threading(rel=<unavailable>) at task.c:302
    frame #26: 0x00000000000202f8 julia
    frame #27: 0x00000000000200b8 julia`__start(argc=-6792, argv=0x0000ffffffffe570, env=0x0000000000000009, cleanup=<unavailable>) at crt1.c:84
```

Disabled that, now it builds `corecompiler.ji` successfully, but building `sys.ji` crashes:

```
…
combinatorics.jl           
hashing2.jl             
irrationals.jl            
mathconstants.jl           
Segmentation fault (core dumped)
```

```
* thread #1, name = 'julia', stop reason = signal SIGSEGV
  * frame #0: 0x00000000444984e0 libthr.so.3`thr_sighandler(sig=11, info=0x0000000045769be0, _ucp=0x0000000045769c30) at thr_sig.c:165
    frame #1: 0x0000fffffffff000
    frame #2: 0x000000005432d2c8
    frame #3: 0x0000000040168e4c libjulia.so.0.7`jl_fptr_trampoline(m=<unavailable>, args=<unavailable>, nargs=<unavailable>) at gf.c:1821
    frame #4: 0x00000000402bb0a0 libjulia.so.0.7`do_call(args=<unavailable>, nargs=2, s=0x0000ffffffffbcd0) at interpreter.c:324
    frame #5: 0x00000000402b9e9c libjulia.so.0.7`eval_body [inlined] eval_stmt_value(stmt=<unavailable>, s=<unavailable>) at interpreter.c:363
    frame #6: 0x00000000402b9e90 libjulia.so.0.7`eval_body(stmts=0x0000000046debb90, s=0x0000ffffffffbcd0, start=<unavailable>, toplevel=1) at interpreter.c:694
    frame #7: 0x00000000402ba26c libjulia.so.0.7`jl_interpret_toplevel_thunk_callback(s=0x0000ffffffffbcd0, vargs=<unavailable>) at interpreter.c:792
    frame #8: 0x000000004017fbf4 libjulia.so.0.7`Lenter_interpreter_frame_start_val + 4
    frame #9: 0x00000000402ba2bc libjulia.so.0.7`jl_interpret_toplevel_thunk(m=<unavailable>, src=<unavailable>) at interpreter.c:801
    frame #10: 0x00000000401979ac libjulia.so.0.7`jl_toplevel_eval_flex(m=<unavailable>, e=<unavailable>, fast=<unavailable>, expanded=<unavailable>) at toplevel.c:821
    frame #11: 0x000000004019692c libjulia.so.0.7`jl_eval_module_expr(parent_module=0x00000000457e0010, ex=<unavailable>) at toplevel.c:233
    frame #12: 0x0000000040196f08 libjulia.so.0.7`jl_toplevel_eval_flex(m=0x00000000457e0010, e=0x0000000047244cf0, fast=1, expanded=0) at toplevel.c:612
    frame #13: 0x0000000040197814 libjulia.so.0.7`jl_toplevel_eval_flex(m=0x00000000457e0010, e=<unavailable>, fast=1, expanded=<unavailable>) at toplevel.c:769
    frame #14: 0x0000000040175410 libjulia.so.0.7`jl_parse_eval_all(fname=<unavailable>, content=<unavailable>, contentlen=<unavailable>, inmodule=0x00000000457e0010) at ast.c:855   
    frame #15: 0x00000000401985f0 libjulia.so.0.7`jl_load_ [inlined] jl_load(module=0x00000000457e0010, fname="mathconstants.jl") at toplevel.c:855
    frame #16: 0x000000004019859c libjulia.so.0.7`jl_load_(module=0x00000000457e0010, str=<unavailable>) at toplevel.c:862
    frame #17: 0x0000000051a5cbb4
    frame #18: 0x0000000051a5c724
    frame #19: 0x00000000402bb0a0 libjulia.so.0.7`do_call(args=<unavailable>, nargs=2, s=0x0000ffffffffceb0) at interpreter.c:324
    frame #20: 0x00000000402b9e9c libjulia.so.0.7`eval_body [inlined] eval_stmt_value(stmt=<unavailable>, s=<unavailable>) at interpreter.c:363
    frame #21: 0x00000000402b9e90 libjulia.so.0.7`eval_body(stmts=0x0000000046e1c190, s=0x0000ffffffffceb0, start=<unavailable>, toplevel=1) at interpreter.c:694
    frame #22: 0x00000000402ba26c libjulia.so.0.7`jl_interpret_toplevel_thunk_callback(s=0x0000ffffffffceb0, vargs=<unavailable>) at interpreter.c:792
    frame #23: 0x000000004017fbf4 libjulia.so.0.7`Lenter_interpreter_frame_start_val + 4
    frame #24: 0x00000000402ba2bc libjulia.so.0.7`jl_interpret_toplevel_thunk(m=<unavailable>, src=<unavailable>) at interpreter.c:801
    frame #25: 0x00000000401979ac libjulia.so.0.7`jl_toplevel_eval_flex(m=<unavailable>, e=<unavailable>, fast=<unavailable>, expanded=<unavailable>) at toplevel.c:821
    frame #26: 0x000000004019692c libjulia.so.0.7`jl_eval_module_expr(parent_module=0x000000004a61b570, ex=<unavailable>) at toplevel.c:233
    frame #27: 0x0000000040196f08 libjulia.so.0.7`jl_toplevel_eval_flex(m=0x000000004a61b570, e=0x00000000457b3110, fast=1, expanded=1) at toplevel.c:612
    frame #28: 0x0000000040175410 libjulia.so.0.7`jl_parse_eval_all(fname=<unavailable>, content=<unavailable>, contentlen=<unavailable>, inmodule=0x000000004a61b570) at ast.c:855   
    frame #29: 0x0000000040198560 libjulia.so.0.7`jl_load(module=0x000000004a61b570, fname="sysimg.jl") at toplevel.c:855
    frame #30: 0x0000000000020bb8 julia
    frame #31: 0x0000000000020518 julia
    frame #32: 0x0000000000020304 julia
    frame #33: 0x00000000000200b8 julia`__start(argc=1, argv=0x0000ffffffffe738, env=0x000000004472d010, cleanup=<unavailable>) at crt1.c:84
    frame #34: 0x0000000040040018 ld-elf.so.1`.rtld_start at rtld_start.S:41
```