### PR TITLE
Avoid excessive output from test errors

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -111,10 +111,8 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
         valbuf = IOBuffer()
         rows_per_value = max(1, dsize[1]÷(length(kwargs)+1))
         valio = IOContext(IOContext(valbuf, logger.stream),
-                          :displaysize=>(rows_per_value,dsize[2]-5))
-        if logger.show_limited
-            valio = IOContext(valio, :limit=>true)
-        end
+                          :displaysize => (rows_per_value,dsize[2]-5),
+                          :limit => logger.show_limited)
         for (key,val) in pairs(kwargs)
             showvalue(valio, val)
             vallines = split(String(take!(valbuf)), '\n')

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -141,7 +141,11 @@ mutable struct Error <: Result
         else
             bt_str = ""
         end
-        new(test_type, orig_expr, repr(value), bt_str, source)
+        new(test_type,
+            orig_expr,
+            sprint(show, value, context = :limit => true),
+            bt_str,
+            source)
     end
 end
 function Base.show(io::IO, t::Error)
@@ -157,7 +161,7 @@ function Base.show(io::IO, t::Error)
         println(io, "  Expression: ", t.orig_expr)
         print(  io, "       Value: ", t.value)
     elseif t.test_type == :test_error
-        println(io, "  Test threw exception ", t.value)
+        println(io, "  Test threw exception")
         println(io, "  Expression: ", t.orig_expr)
         # Capture error message and indent to match
         print(io, join(map(line->string("  ",line),
@@ -169,7 +173,7 @@ function Base.show(io::IO, t::Error)
         println(io, " Got correct result, please change to @test if no longer broken.")
     elseif t.test_type == :nontest_error
         # we had an error outside of a @test
-        println(io, "  Got exception $(t.value) outside of a @test")
+        println(io, "  Got exception outside of a @test")
         # Capture error message and indent to match
         print(io, join(map(line->string("  ",line),
                            split(t.backtrace, "\n")), "\n"))


### PR DESCRIPTION
This is an attempt to fix https://github.com/JuliaLang/julia/issues/28096. As @KristofferC pointed out in the issue, it is redundant to print the `repr` version of the exception when the backtrace is also printed so this PR stops printing the `repr` version of the error. This was the main reason for excessive output. When the test isn't a Boolean, we don't print the backtrace so there I've kept the behavior of printing the `repr` version of the error. However, I've changed it to the `MIME"test/plain"` version of `repr` and changed `show(IO,MIME"text/plain",x)` to limit the output by default. I think that is generally the right thing to do anyway. For anything but trivial tests matrices, printing all the values is causing big problems such as frozen terminals or gigabytes of error logs.