### PR TITLE
WeakKeyDict with no conversion on key-insertion (#24941)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -517,9 +517,9 @@ This section lists changes that do not have deprecation warnings.
     This change makes `@schedule` redundant with `@async`, so `@schedule` has been
     deprecated ([#27164]).
 
- * `norm(A::AbstractMatrix, p=2)` computes no longer the operator/matrix norm but the `norm` of `A`
-   as for other iterables, i.e. as if it were a vector. Especially, `norm(A::AbstractMatrix)` is the
-   Frobenius norm. To compute the operator/matrix norm, use the new function `opnorm` ([#27401]).
+  * `norm(A::AbstractMatrix, p=2)` computes no longer the operator/matrix norm but the `norm` of `A`
+    as for other iterables, i.e. as if it were a vector. Especially, `norm(A::AbstractMatrix)` is the
+    Frobenius norm. To compute the operator/matrix norm, use the new function `opnorm` ([#27401]).
 
   * `dot(u, v)` now acts recursively. Instead of `sum(u[i]' * v[i] for i in ...)`, it computes
     `sum(dot(u[i], v[i]) for i in ...)`, similarly to `vecdot` before ([#27401]).
@@ -528,6 +528,8 @@ This section lists changes that do not have deprecation warnings.
     of "logical cores" (including hyperthreading) rather than the number of physical
     cores present on the CPU. Similarly, the environment variable `JULIA_CPU_CORES` is
     deprecated in favor of `JULIA_CPU_THREADS` ([#27856]).
+
+  * `WeakKeyDict` does not convert keys on insertion anymore (#24941).
 
 Library improvements
 --------------------

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -94,8 +94,22 @@ end
 
 get(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get(wkh.ht, key, default), wkh)
 get(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(default, wkh.ht, key), wkh)
-get!(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get!(wkh.ht, key, default), wkh)
-get!(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get!(default, wkh.ht, key), wkh)
+function get!(wkh::WeakKeyDict{K}, key, default) where {K}
+    if haskey(wkh, key)
+        return wkh[key]
+    else
+        !isa(key, K) && throw(ArgumentError("$key is not a valid key for type $K"))
+        return wkh[key] = default
+    end
+end
+function get!(default::Callable, wkh::WeakKeyDict{K}, key) where {K}
+    if haskey(wkh, key)
+        return wkh[key]
+    else
+        !isa(key, K) && throw(ArgumentError("$key is not a valid key for type $K"))
+        return wkh[key] = default()
+    end
+end
 pop!(wkh::WeakKeyDict{K}, key) where {K} = lock(() -> pop!(wkh.ht, key), wkh)
 pop!(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> pop!(wkh.ht, key, default), wkh)
 delete!(wkh::WeakKeyDict, key) = lock(() -> delete!(wkh.ht, key), wkh)

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -95,20 +95,12 @@ end
 get(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get(wkh.ht, key, default), wkh)
 get(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(default, wkh.ht, key), wkh)
 function get!(wkh::WeakKeyDict{K}, key, default) where {K}
-    if haskey(wkh, key)
-        return wkh[key]
-    else
-        !isa(key, K) && throw(ArgumentError("$key is not a valid key for type $K"))
-        return wkh[key] = default
-    end
+    !isa(key, K) && throw(ArgumentError("$key is not a valid key for type $K"))
+    lock(() -> get!(wkh.ht, WeakRef(key), default), wkh)
 end
 function get!(default::Callable, wkh::WeakKeyDict{K}, key) where {K}
-    if haskey(wkh, key)
-        return wkh[key]
-    else
-        !isa(key, K) && throw(ArgumentError("$key is not a valid key for type $K"))
-        return wkh[key] = default()
-    end
+    !isa(key, K) && throw(ArgumentError("$key is not a valid key for type $K"))
+    lock(() -> get!(default, wkh.ht, WeakRef(key)), wkh)
 end
 pop!(wkh::WeakKeyDict{K}, key) where {K} = lock(() -> pop!(wkh.ht, key), wkh)
 pop!(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> pop!(wkh.ht, key, default), wkh)

--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -176,6 +176,8 @@ two functions for custom types to override how they are stored in a hash table.
 
 [`WeakKeyDict`](@ref) is a hash table implementation where the keys are weak references to objects, and
 thus may be garbage collected even when referenced in a hash table.
+Like `Dict` it uses `hash` for hashing and `isequal` for equality, unlike `Dict` it does
+not convert keys on insertion.
 
 [`Dict`](@ref)s can be created by passing pair objects constructed with `=>` to a [`Dict`](@ref)
 constructor: `Dict("A"=>1, "B"=>2)`. This call will attempt to infer type information from the

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -841,13 +841,14 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     # WeakKeyDict does not convert keys on setting
     @test_throws ArgumentError WeakKeyDict{Vector{Int},Any}([5.0]=>1)
     wkd = WeakKeyDict(A=>2)
-    @test_throws ArgumentError get!(wkd, [2.0], 2) # get fails as it cannot set [2.0] as key
+    @test_throws ArgumentError get!(wkd, [2.0], 2)
+    @test_throws ArgumentError get!(wkd, [1.0], 2) # get! fails even if the key is only
+                                                   # used for getting and not setting
 
     # WeakKeyDict does convert on getting
     wkd = WeakKeyDict(A=>2)
     @test keytype(wkd)==Vector{Int}
     @test wkd[[1.0]] == 2
-    @test get!(wkd, [1.0], 2) == 2 # get succeeds
     @test haskey(wkd, [1.0])
     @test pop!(wkd, [1.0]) == 2
 end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -783,12 +783,6 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     A = [1]
     B = [2]
     C = [3]
-    local x = 0
-    local y = 0
-    local z = 0
-    finalizer(a->(x+=1), A)
-    finalizer(b->(y+=1), B)
-    finalizer(c->(z+=1), C)
 
     # construction
     wkd = WeakKeyDict()

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -830,6 +830,9 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
 
     @test_throws ArgumentError WeakKeyDict([1, 2, 3])
 
+    wkd = WeakKeyDict(A=>1)
+    @test delete!(wkd, A) == empty(wkd)
+
     # issue #26939
     d26939 = WeakKeyDict()
     d26939[big"1.0" + 1.1] = 1
@@ -837,13 +840,16 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
 
     # WeakKeyDict does not convert keys on setting
     @test_throws ArgumentError WeakKeyDict{Vector{Int},Any}([5.0]=>1)
+    wkd = WeakKeyDict(A=>2)
+    @test_throws ArgumentError get!(wkd, [2.0], 2) # get fails as it cannot set [2.0] as key
 
     # WeakKeyDict does convert on getting
     wkd = WeakKeyDict(A=>2)
     @test keytype(wkd)==Vector{Int}
     @test wkd[[1.0]] == 2
-
-    @show x,y,z
+    @test get!(wkd, [1.0], 2) == 2 # get succeeds
+    @test haskey(wkd, [1.0])
+    @test pop!(wkd, [1.0]) == 2
 end
 
 @testset "issue #19995, hash of dicts" begin

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -834,6 +834,16 @@ Dict(1 => rand(2,3), 'c' => "asdf") # just make sure this does not trigger a dep
     d26939 = WeakKeyDict()
     d26939[big"1.0" + 1.1] = 1
     GC.gc() # make sure this doesn't segfault
+
+    # WeakKeyDict does not convert keys on setting
+    @test_throws ArgumentError WeakKeyDict{Vector{Int},Any}([5.0]=>1)
+
+    # WeakKeyDict does convert on getting
+    wkd = WeakKeyDict(A=>2)
+    @test keytype(wkd)==Vector{Int}
+    @test wkd[[1.0]] == 2
+
+    @show x,y,z
 end
 
 @testset "issue #19995, hash of dicts" begin


### PR DESCRIPTION
This fixes #24941 as discussed in today's triage call https://github.com/JuliaLang/julia/issues/24941#issuecomment-406375676.

Notes:
- I found a bug in `get!` which is now also fixed (`get!(WeakKeyDict(), [1], 1)` errored)
- Some extra tests added
- reviewer should take a decision on https://github.com/JuliaLang/julia/issues/24941#issuecomment-406408088

~~Todo: NEWS.md~~