### PR TITLE
[WIP] Try to fix FreeBSD ccall failure

### DIFF
--- a/deps/libuv.mk
+++ b/deps/libuv.mk
@@ -24,7 +24,13 @@ else
 UV_FLAGS := --disable-shared $(UV_MFLAGS)
 endif
 
-$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured: $(SRCCACHE)/$(LIBUV_SRC_DIR)/source-extracted
+$(SRCCACHE)/$(LIBUV_SRC_DIR)/libuv-unix-signal.patch-applied: $(SRCCACHE)/$(LIBUV_SRC_DIR)/source-extracted
+	cd $(SRCCACHE)/$(LIBUV_SRC_DIR) && \
+		patch -p1 -f < $(SRCDIR)/patches/libuv-unix-signal.patch
+	echo 1 > $@
+
+$(BUILDDIR)/$(LIBUV_SRC_DIR)/build-configured: \
+    $(SRCCACHE)/$(LIBUV_SRC_DIR)/source-extracted $(SRCCACHE)/$(LIBUV_SRC_DIR)/libuv-unix-signal.patch-applied
 	touch -c $(SRCCACHE)/$(LIBUV_SRC_DIR)/aclocal.m4 # touch a few files to prevent autogen from getting called
 	touch -c $(SRCCACHE)/$(LIBUV_SRC_DIR)/Makefile.in
 	touch -c $(SRCCACHE)/$(LIBUV_SRC_DIR)/configure

--- a/deps/patches/libuv-unix-signal.patch
+++ b/deps/patches/libuv-unix-signal.patch
@@ -1,0 +1,20 @@
+--- a/src/unix/signal.c	2018-07-20 11:48:33.810322000 +0800
++++ b/src/unix/signal.c	2018-07-20 11:50:32.989729000 +0800
+@@ -80,7 +80,7 @@
+ 
+   do {
+     r = read(uv__signal_lock_pipefd[0], &data, sizeof data);
+-  } while (r < 0 && errno == EINTR);
++  } while (r < 0 && (errno == EINTR || errno == EAGAIN));
+ 
+   return (r < 0) ? -1 : 0;
+ }
+@@ -92,7 +92,7 @@
+ 
+   do {
+     r = write(uv__signal_lock_pipefd[1], &data, sizeof data);
+-  } while (r < 0 && errno == EINTR);
++  } while (r < 0 && (errno == EINTR || errno == EAGAIN));
+ 
+   return (r < 0) ? -1 : 0;
+ }


### PR DESCRIPTION
```
  Got exception LoadError("/.../build/test/ccall.jl", 994, ErrorException("failed process: Process(`/.../build/usr/bin/julia -Cnative -J/.../build/usr/lib/julia/sys.so --compile=yes --depwarn=error --startup-file=no -e 'A = Ref{Cint}(42); finalizer(cglobal((:c_exit_finalizer, \"libccalltest\"), Cvoid), A)'`, ProcessSignaled(6)) [0]")) outside of a @test
  LoadError: failed process: Process(`/.../build/usr/bin/julia -Cnative -J/.../build/usr/lib/julia/sys.so --compile=yes --depwarn=error --startup-file=no -e 'A = Ref{Cint}(42); finalizer(cglobal((:c_exit_finalizer, "libccalltest"), Cvoid), A)'`, ProcessSignaled(6)) [0]
```

The process got aborted(`ProcessSignaled(6)`).

I also found a core file on my CI worker.
```
[venv] julia@abeing:~/julia-fbsd-buildbot/worker/11rel-amd64/build % lldb40 -c test/julia.core ./julia
(lldb) target create "./julia" --core "test/julia.core"
Core file '/home/julia/julia-fbsd-buildbot/worker/11rel-amd64/build/test/julia.core' (x86_64) was loaded.
(lldb) bt
* thread #1, name = 'julia', stop reason = signal SIGABRT
  * frame #0: 0x00000008012b779a libc.so.7`_thr_kill + 10
    frame #1: 0x00000008012b7764 libc.so.7`_raise + 52
    frame #2: 0x00000008012b76d9 libc.so.7`abort + 73
    frame #3: libjulia.so.0.7`uv__signal_global_init at signal.c:67
    frame #4: 0x00000008007b0bc8 libthr.so.3`_pthread_once + 216
    frame #5: libjulia.so.0.7`uv_once(guard=0x0000000800f6ce98, callback=(libjulia.so.0.7`uv__signal_global_init at signal.c:62)) at thread.c:286
    frame #6: libjulia.so.0.7`uv__signal_global_once_init at signal.c:72
    frame #7: libjulia.so.0.7`uv_loop_init(loop=0x0000000800f6cbe0) at loop.c:34
    frame #8: libjulia.so.0.7`uv_default_loop at uv-common.c:602
    frame #9: libjulia.so.0.7`_julia_init(rel=JL_IMAGE_CWD) at init.c:633
    frame #10: libjulia.so.0.7`julia_init__threading(rel=<unavailable>) at task.c:302
    frame #11: julia`main(argc=0, argv=0x00007fffffffe310) at repl.c:237
    frame #12: 0x0000000000401625 julia`_start + 149
(lldb) f 3
frame #3: libjulia.so.0.7`uv__signal_global_init at signal.c:67
   64       abort();
   65
   66     if (uv__signal_unlock())
-> 67       abort();
   68   }
   69
   70
```

So, I guess the core dump happened under pressure, and the libuv init failed.