### PR TITLE
[WIP] RCU primitives in Julia + typemap thread safety

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -131,6 +131,7 @@ struct _jl_tls_states_t {
     int finalizers_inhibited;
     arraylist_t finalizers;
     jl_gc_mark_cache_t gc_cache;
+    int rcu_reader_gp;
 };
 
 // Update codegen version in `ccall.cpp` after changing either `pause` or `wake`

--- a/src/threading.h
+++ b/src/threading.h
@@ -54,6 +54,10 @@ void ti_threadfun(void *arg);
 // helpers for thread function
 jl_value_t *ti_runthread(jl_function_t *f, jl_svec_t *args, size_t nargs);
 
+void rcu_read_lock(jl_ptls_t ptls);
+void rcu_read_unlock(jl_ptls_t ptls);
+void rcu_synchronize(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In this PR is intended to implement [RCU primitives](https://lwn.net/Articles/573436/) on the Julia userland.
The idea behind this particular work case is that:

1) We don't really memory barriers, as the GC should provide enough protection against memory leaks.
2) `synchroinze_rcu()` is NOT responsible of acquiring\releasing spin lock for writing threads, as that is usually already implemented in Julia with faster methods.
3) We should NOT block if a resource on particular thread is busy, instead we should allow multiple reads from a particular thread even if another one has not already come into the critical section (ie its busy ecc)
4) Deadlocks and resource blocks should be avoided. Basically we are enforcing a status of coherence between what a thread reads in-out of a critical section, ie grace period should can only start before a writing thread, or end after another one, not both( [a nice graphic that depicts it better.](https://static.lwn.net/images/ns/kernel/rcu/GracePeriodGood.png) ).

You can find a general idea of how this is implemented at [chapter B.7 of Is Parallel Programming Hard, And, If So,
What Can You Do About It? by Paul McKenney](https://mirrors.edge.kernel.org/pub/linux/kernel/people/paulmck/perfbook/perfbook.2017.11.22a.pdf)

With this in mind, I would like to continue this PR by working on the typemap cache, in particular in enforcing coherent reads between thread updates. It would be really great if any of you has encountered any issue with method update/redefinition on multi-thread code, so we can test this out!