### PR TITLE
[RFC] don't load Pkg automatically

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -335,14 +335,6 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
             @warn "Failed to import InteractiveUtils into module Main" exception=(ex, catch_backtrace())
         end
     end
-    try
-        let Pkg = require(PkgId(UUID(0x44cfe95a_1eb2_52ea_b672_e2afdf69b78f), "Pkg"))
-            Core.eval(Main, :(const Pkg = $Pkg))
-            Core.eval(Main, :(using .Pkg))
-        end
-    catch ex
-        @warn "Failed to import Pkg into module Main" exception=(ex, catch_backtrace())
-    end
 
     if interactive && isassigned(REPL_MODULE_REF)
         invokelatest(REPL_MODULE_REF[]) do REPL


### PR DESCRIPTION
In fbc30cd6c744c8cef82cb6fd54d10bdce9b36692 automatic loading of `Pkg` was added in interactive use. I propose to revert this for the following reasons:
- For interactive use most people should use the `Pkg` REPL, which will work regardless of this.
- It is a bit weird to load things automatically based on the mode; it makes interactive and non-interactive scripts behave differently.
- You can't load another package called `Pkg`.