### PR TITLE
update Documenter and fix build path for pdf

### DIFF
--- a/doc/Manifest.toml
+++ b/doc/Manifest.toml
@@ -2,10 +2,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "f3e87ca1e2df8e1e4f82ea504fddf0b9b0894f61"
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "c478aec93ea90bb99c307a92df17a76131bf275f"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "0.69.0"
+version = "1.0.0"
 
 [[Dates]]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -18,15 +18,15 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["Compat"]
-git-tree-sha1 = "0e9a957a5c1cc5d06e54aab3b8b9c4c495253269"
+git-tree-sha1 = "0d767d338c201b1b2064e2186a0b63ac1e55dbb1"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.4.4"
+version = "0.4.5"
 
 [[Documenter]]
 deps = ["Compat", "DocStringExtensions", "Logging", "REPL"]
-git-tree-sha1 = "4fc4abdb5ac20ece943ff6e0a7e2a254d148f434"
+git-tree-sha1 = "8591d5cc4c7dcf23e0e38d664fb696e1f1ea4577"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.18.0"
+version = "0.19.0"
 
 [[InteractiveUtils]]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -72,6 +72,9 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[SparseArrays]]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[Statistics]]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[Test]]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -1,9 +1,9 @@
 # Install dependencies needed to build the documentation.
 empty!(LOAD_PATH)
 push!(LOAD_PATH, @__DIR__, "@stdlib")
-using Pkg
 empty!(DEPOT_PATH)
 pushfirst!(DEPOT_PATH, joinpath(@__DIR__, "deps"))
+using Pkg
 Pkg.instantiate()
 
 using Documenter
@@ -145,8 +145,9 @@ for stdlib in STDLIB_DOCS
     @eval using $(stdlib.stdlib)
 end
 
+const render_pdf = "pdf" in ARGS
 makedocs(
-    build     = joinpath(@__DIR__, "_build/html/en"),
+    build     = joinpath(@__DIR__, "_build", (render_pdf ? "pdf" : "html"), "en"),
     modules   = [Base, Core, BuildSysImg, [Base.root_module(Base, stdlib.stdlib) for stdlib in STDLIB_DOCS]...],
     clean     = true,
     doctest   = ("doctest=fix" in ARGS) ? (:fix) : ("doctest=true" in ARGS) ? true : false,
@@ -154,7 +155,7 @@ makedocs(
     linkcheck_ignore = ["https://bugs.kde.org/show_bug.cgi?id=136779"], # fails to load from nanosoldier?
     strict    = true,
     checkdocs = :none,
-    format    = "pdf" in ARGS ? :latex : :html,
+    format    = render_pdf ? :latex : :html,
     sitename  = "The Julia Language",
     authors   = "The Julia Project",
     analytics = "UA-28835595-6",


### PR DESCRIPTION
Updates Documenter to 0.19.

Also, change the output directory to be "pdf" in case pdf generation is performed. Note that it is currently broken on the julia docs but hopefully https://github.com/JuliaDocs/Documenter.jl/pull/763 fixes it.