### PR TITLE
Remove explicit message handling for easier log macro behaviour overriding

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -208,11 +208,11 @@ macro _sourceinfo()
     end)
 end
 
-macro logmsg(level, message, exs...) logmsg_code((@_sourceinfo)..., esc(level), message, exs...) end
-macro debug(message, exs...) logmsg_code((@_sourceinfo)..., :Debug, message, exs...) end
-macro  info(message, exs...) logmsg_code((@_sourceinfo)..., :Info,  message, exs...) end
-macro  warn(message, exs...) logmsg_code((@_sourceinfo)..., :Warn,  message, exs...) end
-macro error(message, exs...) logmsg_code((@_sourceinfo)..., :Error, message, exs...) end
+macro logmsg(level, exs...) logmsg_code((@_sourceinfo)..., esc(level), exs...) end
+macro debug(exs...) logmsg_code((@_sourceinfo)..., :Debug, exs...) end
+macro  info(exs...) logmsg_code((@_sourceinfo)..., :Info,  exs...) end
+macro  warn(exs...) logmsg_code((@_sourceinfo)..., :Warn,  exs...) end
+macro error(exs...) logmsg_code((@_sourceinfo)..., :Error, exs...) end
 
 # Logging macros share documentation
 @eval @doc $_logmsg_docs :(@logmsg)

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -196,4 +196,16 @@ Base.convert(::Type{PhysQuantity{0,T}}, x::Int) where T = PhysQuantity{0}(conver
 Base.convert(::Type{P}, ::Int) where P<:PhysQuantity =
     error("Int is incommensurate with PhysQuantity")
 
+export @macrocall
+
+macro macrocall(ex)
+    @assert Meta.isexpr(ex, :macrocall)
+    ex.head = :call
+    for i in 2:length(ex.args)
+        ex.args[i] = QuoteNode(ex.args[i])
+    end
+    insert!(ex.args, 3, __module__)
+    return esc(ex)
+end
+
 end

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -5,17 +5,10 @@ include("testenv.jl")
 
 using Test, Serialization
 
-@test_throws MethodError convert(Enum, 1.0)
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
+using Main.TestHelpers
 
-macro macrocall(ex)
-    @assert Meta.isexpr(ex, :macrocall)
-    ex.head = :call
-    for i in 2:length(ex.args)
-        ex.args[i] = QuoteNode(ex.args[i])
-    end
-    insert!(ex.args, 3, __module__)
-    return esc(ex)
-end
+@test_throws MethodError convert(Enum, 1.0)
 
 @test_throws ArgumentError("no arguments given for Enum Foo") @macrocall(@enum Foo)
 @test_throws ArgumentError("invalid base type for Enum Foo2, Foo2::Float64=::Float64; base type must be an integer primitive type") @macrocall(@enum Foo2::Float64 apple=1.)

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -7,6 +7,9 @@ import Base.CoreLogging: BelowMinLevel, Debug, Info, Warn, Error,
 import Test: collect_test_logs, TestLogger
 using Base.Printf: @sprintf
 
+isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
+using Main.TestHelpers
+
 #-------------------------------------------------------------------------------
 @testset "Logging" begin
 
@@ -120,6 +123,15 @@ end
     @test record._module == nothing
     @test record.file == nothing
     @test record.line == nothing
+end
+
+# PR #28209
+@testset "0-arg MethodErrors" begin
+    @test_throws MethodError @macrocall(@logmsg :Notice)
+    @test_throws MethodError @macrocall(@debug)
+    @test_throws MethodError @macrocall(@info)
+    @test_throws MethodError @macrocall(@warn)
+    @test_throws MethodError @macrocall(@error)
 end
 
 


### PR DESCRIPTION
This shouldn't change existing behaviour. `@debug()` etc. now pass through rather than erroring but I don't think that's a big deal.

This will make it easier to add additional log behaviour to the macros by adding new methods to `logmsg_code` using user-typed arguments. For example, Memento would implement:

```julia
logmsg_code(_module, file, line, level, logger::Memento.Logger, message, exs...)
```