### PR TITLE
Disallow double edges in IR

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -109,8 +109,13 @@ function compute_basic_blocks(stmts::Vector{Any})
         # Conditional Branch
         if isa(terminator, GotoIfNot)
             block′ = block_for_inst(basic_block_index, terminator.dest)
-            push!(blocks[block′].preds, num)
-            push!(b.succs, block′)
+            if block′ == num + 1
+                # This GotoIfNot acts like a noop - treat it as such.
+                # We will drop it during SSA renaming
+            else
+                push!(blocks[block′].preds, num)
+                push!(b.succs, block′)
+            end
         end
         if isa(terminator, GotoNode)
             block′ = block_for_inst(basic_block_index, terminator.label)

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -791,12 +791,19 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
     ssavalmap = Any[SSAValue(-1) for _ in 1:(length(ci.ssavaluetypes)+1)]
     result_types = Any[Any for _ in 1:length(new_code)]
     # Detect statement positions for assignments and construct array
-    for (idx, stmt) in Iterators.enumerate(code)
+    for (bb, idx) in bbidxiter(ir)
+        stmt = code[idx]
         # Convert GotoNode/GotoIfNot/PhiNode to BB addressing
         if isa(stmt, GotoNode)
             new_code[idx] = GotoNode(block_for_inst(cfg, stmt.label))
         elseif isa(stmt, GotoIfNot)
-            new_code[idx] = GotoIfNot(stmt.cond, block_for_inst(cfg, stmt.dest))
+            new_dest = block_for_inst(cfg, stmt.dest)
+            if new_dest == bb+1
+                # Drop this node - it's a noop
+                new_code[idx] = stmt.cond
+            else
+                new_code[idx] = GotoIfNot(stmt.cond, new_dest)
+            end
         elseif isexpr(stmt, :enter)
             new_code[idx] = Expr(:enter, block_for_inst(cfg, stmt.args[1]))
         elseif isexpr(stmt, :leave) || isexpr(stmt, :(=)) || isexpr(stmt, :return) ||

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -40,6 +40,16 @@ function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, 
     end
 end
 
+function count_int(val::Int, arr::Vector{Int})
+    n = 0
+    for x in arr
+        if x === val
+            n += 1
+        end
+    end
+    n
+end
+
 function verify_ir(ir::IRCode)
     # For now require compact IR
     # @assert isempty(ir.new_nodes)
@@ -52,10 +62,45 @@ function verify_ir(ir::IRCode)
             error()
         end
         last_end = last(block.stmts)
+        terminator = ir.stmts[last_end]
         for p in block.preds
             p == 0 && continue
-            if !(idx in ir.cfg.blocks[p].succs)
-                @verify_error "Predeccsor $p of block $idx not in successor list"
+            c = count_int(idx, ir.cfg.blocks[p].succs)
+            if c == 0
+                @verify_error "Predecessor $p of block $idx not in successor list"
+                error()
+            elseif c > 1
+                @verify_error "Predecessor $p of block $idx occurs too often in successor list"
+                error()
+            end
+        end
+        if isa(terminator, ReturnNode)
+            if !isempty(block.succs)
+                @verify_error "Block $idx ends in return or unreachable, but has successors"
+                error()
+            end
+        elseif isa(terminator, GotoNode)
+            if length(block.succs) != 1 || block.succs[1] != terminator.label
+                @verify_error "Block $idx successors ($(block.succs)), does not match GotoNode terminator"
+                error()
+            end
+        elseif isa(terminator, GotoIfNot)
+            if terminator.dest == idx + 1
+                @verify_error "Block $idx terminator forms a double edge to block $(idx+1)"
+                error()
+            end
+            if length(block.succs) != 2 || (block.succs != [terminator.dest, idx+1] && block.succs != [idx+1, terminator.dest])
+                @verify_error "Block $idx successors ($(block.succs)), does not match GotoIfNot terminator"
+                error()
+            end
+        elseif isexpr(terminator, :enter)
+            if length(block.succs) != 2 || (block.succs != [terminator.args[1], idx+1] && block.succs != [idx+1, terminator.args[1]])
+                @verify_error "Block $idx successors ($(block.succs)), does not match :enter terminator"
+                error()
+            end
+        else
+            if length(block.succs) != 1 || block.succs[1] != idx + 1
+                @verify_error "Block $idx successors ($(block.succs)), does not match fall-through terminator"
                 error()
             end
         end


### PR DESCRIPTION
A double edge is an edge of the form:
```
4 - goto 5 if not %%x
5 - ...
```
i.e. where both the fall through and the explicit edge of
the conditional branch go to the same basic block (note
however that such branches are basically no-ops). LLVM
allows this (with some restrictions - e.g. if there is
a phi node the value on both edges has to be the same),
so I also decided to allow it. However, it turns out to
cause an enormous amount of pain because edges are no
longer uniquely identified by just the two basic blocks
at the edge's end points. In the near future, I want to
start doing CFG transforms at the IR level and these double
edges require a special case for basically every operation.
Thus, in preparation for that, let's disallow such edges as
an IR invariant. The trade off here is that when we modify
conditional branches now, we have to check whether they
would be a noop and delete them in that case. However,
a) we likely want to do that anyway for IR compactness and
b) it seems a lot less fidegedy than dealing with double edge.