### PR TITLE
Correct assertion checking for deleted typemap entry

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -1883,8 +1883,7 @@ static jl_value_t *jl_deserialize_typemap_entry(jl_serializer_state *s)
         jl_deserialize_struct(s, v, 1);
 #ifndef NDEBUG
         if (te->func.value && jl_typeis(te->func.value, jl_method_instance_type)) {
-            assert(((te->func.linfo->max_world == 0 &&
-                    te->func.linfo->min_world == 1) ||
+            assert(((te->max_world == 0 && te->min_world == 1) ||
                     (te->func.linfo->max_world >= te->max_world &&
                      te->func.linfo->min_world <= te->min_world)) &&
                    "corrupt typemap entry structure");


### PR DESCRIPTION
This assertion was added in #27568. However from my understanding
the first part of the assertion is wrong, since that PR added
logic to mark deleted typemap entries as min_world 0, max_world 1.
It seems valid for a typemap entry to be deleted, even if the referenced
(while the reverse does not seem valid).

Fixes #28213