### PR TITLE
Revert "correct AST show regressions, fix formatting around pending nodes"

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -37,125 +37,105 @@ StmtRange(range::UnitRange{Int}) = StmtRange(first(range), last(range))
 
 struct BasicBlock
     stmts::StmtRange
+    #error_handler::Bool
     preds::Vector{Int}
     succs::Vector{Int}
 end
 function BasicBlock(stmts::StmtRange)
-    return BasicBlock(stmts, Int[], Int[])
+    BasicBlock(stmts, Int[], Int[])
 end
 function BasicBlock(old_bb, stmts)
-    return BasicBlock(stmts, old_bb.preds, old_bb.succs)
+    BasicBlock(stmts, #= old_bb.error_handler, =# old_bb.preds, old_bb.succs)
 end
-copy(bb::BasicBlock) = BasicBlock(bb.stmts, copy(bb.preds), copy(bb.succs))
+copy(bb::BasicBlock) = BasicBlock(bb.stmts, #= bb.error_handler, =# copy(bb.preds), copy(bb.succs))
 
 struct CFG
     blocks::Vector{BasicBlock}
-    index::Vector{Int} # map from instruction => basic-block number
-                       # TODO: make this O(1) instead of O(log(n_blocks))?
+    index::Vector{Int}
 end
 copy(c::CFG) = CFG(copy(c.blocks), copy(c.index))
 
 function block_for_inst(index, inst)
-    return searchsortedfirst(index, inst, lt=(<=))
+    searchsortedfirst(index, inst, lt=(<=))
 end
 block_for_inst(cfg::CFG, inst) = block_for_inst(cfg.index, inst)
 
-function basic_blocks_starts(stmts::Vector{Any})
-    jump_dests = BitSet()
-    push!(jump_dests, 1) # function entry point
+function compute_basic_blocks(stmts::Vector{Any})
+    jump_dests = BitSet(1)
     # First go through and compute jump destinations
-    for idx in 1:length(stmts)
-        stmt = stmts[idx]
+    for (idx, stmt) in pairs(stmts)
         # Terminators
-        if isa(stmt, GotoIfNot)
-            push!(jump_dests, idx+1)
-            push!(jump_dests, stmt.dest)
-        elseif isa(stmt, ReturnNode)
-            idx < length(stmts) && push!(jump_dests, idx+1)
-        elseif isa(stmt, GotoNode)
-            # This is a fake dest to force the next stmt to start a bb
-            idx < length(stmts) && push!(jump_dests, idx+1)
-            push!(jump_dests, stmt.label)
-        elseif isa(stmt, Expr)
-            if stmt.head === :leave
-                # :leave terminates a BB
+        if isa(stmt, GotoIfNot) || isa(stmt, GotoNode) || isa(stmt, ReturnNode)
+            if isa(stmt, GotoIfNot)
                 push!(jump_dests, idx+1)
-            elseif stmt.head == :enter
-                # :enter starts/ends a BB
-                push!(jump_dests, idx)
-                push!(jump_dests, idx+1)
-                # The catch block is a jump dest
-                push!(jump_dests, stmt.args[1])
-            elseif stmt.head === :gotoifnot
-                # also tolerate expr form of IR
-                push!(jump_dests, idx+1)
-                push!(jump_dests, stmt.args[2])
-            elseif stmt.head === :return
-                # also tolerate expr form of IR
+                push!(jump_dests, stmt.dest)
+            else
                 # This is a fake dest to force the next stmt to start a bb
                 idx < length(stmts) && push!(jump_dests, idx+1)
+                if isa(stmt, GotoNode)
+                    push!(jump_dests, stmt.label)
+                end
             end
+        elseif isa(stmt, Expr) && stmt.head === :leave
+            # :leave terminates a BB
+            push!(jump_dests, idx+1)
+        elseif isa(stmt, Expr) && stmt.head == :enter
+            # :enter starts/ends a BB
+            push!(jump_dests, idx)
+            push!(jump_dests, idx+1)
+            # The catch block is a jump dest
+            push!(jump_dests, stmt.args[1])
         end
     end
-    # and add add one more basic block start after the last statement
+    bb_starts = collect(jump_dests)
     for i = length(stmts):-1:1
         if stmts[i] != nothing
-            push!(jump_dests, i+1)
+            push!(bb_starts, i+1)
             break
         end
     end
-    return jump_dests
-end
-
-function compute_basic_blocks(stmts::Vector{Any})
-    bb_starts = basic_blocks_starts(stmts)
     # Compute ranges
-    pop!(bb_starts, 1)
-    basic_block_index = collect(bb_starts)
+    basic_block_index = Int[]
     blocks = BasicBlock[]
-    sizehint!(blocks, length(basic_block_index))
-    let first = 1
-        for last in basic_block_index
-            push!(blocks, BasicBlock(StmtRange(first, last - 1)))
-            first = last
-        end
+    sizehint!(blocks, length(bb_starts)-1)
+    for (first, last) in Iterators.zip(bb_starts, Iterators.drop(bb_starts, 1))
+        push!(basic_block_index, first)
+        push!(blocks, BasicBlock(StmtRange(first, last-1)))
     end
+    popfirst!(basic_block_index)
     # Compute successors/predecessors
-    for (num, b) in enumerate(blocks)
+    for (num, b) in pairs(blocks)
         terminator = stmts[last(b.stmts)]
-        if isa(terminator, ReturnNode)
-            continue
-        end
-        if isa(terminator, GotoNode)
-            block′ = block_for_inst(basic_block_index, terminator.label)
-            push!(blocks[block′].preds, num)
-            push!(b.succs, block′)
-            continue
-        end
         # Conditional Branch
         if isa(terminator, GotoIfNot)
             block′ = block_for_inst(basic_block_index, terminator.dest)
             push!(blocks[block′].preds, num)
             push!(b.succs, block′)
-        elseif isa(terminator, Expr) && terminator.head == :enter
-            # :enter gets a virtual edge to the exception handler and
-            # the exception handler gets a virtual edge from outside
-            # the function.
-            # See the devdocs on exception handling in SSA form (or
-            # bug Keno to write them, if you're reading this and they
-            # don't exist)
-            block′ = block_for_inst(basic_block_index, terminator.args[1])
-            push!(blocks[block′].preds, num)
-            push!(blocks[block′].preds, 0)
-            push!(b.succs, block′)
         end
-        # statement fall-through
-        if num + 1 <= length(blocks)
-            push!(blocks[num + 1].preds, num)
-            push!(b.succs, num + 1)
+        if isa(terminator, GotoNode)
+            block′ = block_for_inst(basic_block_index, terminator.label)
+            push!(blocks[block′].preds, num)
+            push!(b.succs, block′)
+        elseif !isa(terminator, ReturnNode)
+            if isa(terminator, Expr) && terminator.head == :enter
+                # :enter gets a virtual edge to the exception handler and
+                # the exception handler gets a virtual edge from outside
+                # the function.
+                # See the devdocs on exception handling in SSA form (or
+                # bug Keno to write them, if you're reading this and they
+                # don't exist)
+                block′ = block_for_inst(basic_block_index, terminator.args[1])
+                push!(blocks[block′].preds, num)
+                push!(blocks[block′].preds, 0)
+                push!(b.succs, block′)
+            end
+            if num + 1 <= length(blocks)
+                push!(blocks[num+1].preds, num)
+                push!(b.succs, num+1)
+            end
         end
     end
-    return CFG(blocks, basic_block_index)
+    CFG(blocks, basic_block_index)
 end
 
 function first_insert_for_bb(code, cfg::CFG, block::Int)
@@ -177,11 +157,9 @@ struct NewNode
     # The node itself
     node::Any
     # The index into the line number table of this entry
-    line::Int32
-
-    NewNode(pos::Int, attach_after::Bool, @nospecialize(typ), @nospecialize(node), line::Int32) =
-        new(pos, attach_after, typ, node, line)
+    line::Int
 end
+copy(n::NewNode) = copy(n.pos, n.attach_after, n.typ, copy(n.node), n.line)
 
 struct IRCode
     stmts::Vector{Any}
@@ -305,8 +283,7 @@ function is_relevant_expr(e::Expr)
                       :gc_preserve_begin, :gc_preserve_end,
                       :foreigncall, :isdefined, :copyast,
                       :undefcheck, :throw_undef_if_not,
-                      :cfunction, :method,
-                      #=legacy IR format support=# :gotoifnot, :return)
+                      :cfunction, :method)
 end
 
 function setindex!(x::UseRef, @nospecialize(v))

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -9,141 +9,142 @@ length(s::String) = Base.length(s)
 ^(s::String, i::Int) = Base.:^(s, i)
 end
 
-import Base: show_unquoted
-using Base: printstyled, with_output_color, prec_decl
-
 function Base.show(io::IO, cfg::CFG)
-    for (idx, block) in enumerate(cfg.blocks)
-        print(io, idx, "\t=>\t")
-        join(io, block.succs, ", ")
-        println(io)
+    foreach(pairs(cfg.blocks)) do (idx, block)
+        Base.println("$idx\t=>\t", join(block.succs, ", "))
     end
 end
 
-function print_stmt(io::IO, idx::Int, @nospecialize(stmt), used::BitSet, maxlength_idx::Int, color::Bool, show_type::Bool)
-    indent = maxlength_idx + 4
-    if idx in used
-        pad = " "^(maxlength_idx - length(string(idx)) + 1)
-        print(io, "%", idx, pad, "= ")
+print_ssa(io::IO, val::SSAValue, argnames) = Base.print(io, "%$(val.id)")
+print_ssa(io::IO, val::Argument, argnames) = Base.print(io, isempty(argnames) ? "%%$(val.n)" : "%%$(argnames[val.n])")
+print_ssa(io::IO, val::GlobalRef, argnames) = Base.print(io, val)
+function print_ssa(io::IO, val::QuoteNode, argnames)
+    if val.value isa Symbol && Base.isidentifier(val.value)
+        Base.print(io, ":", val.value)
     else
-        print(io, " "^indent)
+        Base.show(io, val)
     end
-    if !color && stmt isa PiNode
-        print(io, "π (")
-        show_unquoted(io, stmt.val, indent)
-        print(io, ", ")
-        print(io, stmt.typ)
-        print(io, ")")
+end
+print_ssa(io::IO, @nospecialize(val), argnames) = Base.show(io, val)
+
+
+function print_node(io::IO, idx::Int, @nospecialize(stmt), used, argnames, maxsize; color::Bool=true, print_typ::Bool=true)
+    if idx in used
+        pad = " "^(maxsize-length(string(idx)))
+        Base.print(io, "%$idx $pad= ")
+    else
+        Base.print(io, " "^(maxsize+4))
+    end
+    if isa(stmt, PhiNode)
+        args = map(1:length(stmt.edges)) do i
+            e = stmt.edges[i]
+            v = !isassigned(stmt.values, i) ? "#undef" :
+                sprint() do io′
+                    print_ssa(io′, stmt.values[i], argnames)
+                end
+            "$e => $v"
+        end
+        Base.print(io, "φ ", '(', join(args, ", "), ')')
+    elseif isa(stmt, PhiCNode)
+        Base.print(io, "φᶜ ", '(', join(map(x->sprint(print_ssa, x, argnames), stmt.values), ", "), ')')
+    elseif isa(stmt, PiNode)
+        Base.print(io, "π (")
+        print_ssa(io, stmt.val, argnames)
+        Base.print(io, ", ")
+        if color
+            Base.printstyled(io, stmt.typ, color=:cyan)
+        else
+            Base.print(io, stmt.typ)
+        end
+        Base.print(io, ")")
+    elseif isa(stmt, UpsilonNode)
+        Base.print(io, "ϒ (")
+        isdefined(stmt, :val) ?
+            print_ssa(io, stmt.val, argnames) :
+            Base.print(io, "#undef")
+        Base.print(io, ")")
+    elseif isa(stmt, ReturnNode)
+        if !isdefined(stmt, :val)
+            Base.print(io, "unreachable")
+        else
+            Base.print(io, "return ")
+            print_ssa(io, stmt.val, argnames)
+        end
+    elseif isa(stmt, GotoIfNot)
+        Base.print(io, "goto ", stmt.dest, " if not ")
+        print_ssa(io, stmt.cond, argnames)
+    elseif isexpr(stmt, :call)
+        print_ssa(io, stmt.args[1], argnames)
+        Base.print(io, "(")
+        Base.print(io, join(map(arg->sprint(io->print_ssa(io, arg, argnames)), stmt.args[2:end]), ", "))
+        Base.print(io, ")")
     elseif isexpr(stmt, :invoke)
-        # TODO: why is this here, and not in Base.show_unquoted
         print(io, "invoke ")
         linfo = stmt.args[1]
-        show_unquoted(io, stmt.args[2], indent)
-        print(io, "(")
-        # XXX: this is wrong if `sig` is not a concretetype method
-        # more correct would be to use `fieldtype(sig, i)`, but that would obscure / discard Varargs information in show
-        sig = linfo.specTypes == Tuple ? Core.svec() : Base.unwrap_unionall(linfo.specTypes).parameters::Core.SimpleVector
+        print_ssa(io, stmt.args[2], argnames)
+        Base.print(io, "(")
+        sig = linfo.specTypes === Tuple ? () : Base.unwrap_unionall(linfo.specTypes).parameters
         print_arg(i) = sprint() do io
-            show_unquoted(io, stmt.args[i], indent)
-            if (i - 1) <= length(sig)
-                print(io, "::", sig[i - 1])
+            print_ssa(io, stmt.args[2+i], argnames)
+            if (i + 1) <= length(sig)
+                print(io, "::$(sig[i+1])")
             end
         end
-        join(io, (print_arg(i) for i = 3:length(stmt.args)), ", ")
-        print(io, ")")
+        Base.print(io, join((print_arg(i) for i=1:(length(stmt.args)-2)), ", "))
+        Base.print(io, ")")
+    elseif isexpr(stmt, :new)
+        Base.print(io, "new(")
+        Base.print(io, join(String[sprint(io->print_ssa(io, arg, argnames)) for arg in stmt.args], ", "))
+        Base.print(io, ")")
+    elseif isa(stmt, GotoNode)
+        Base.print(io, stmt)
     else
-        show_unquoted(io, stmt, indent, show_type ? prec_decl : 0)
-    end
-    nothing
-end
-
-show_unquoted(io::IO, val::Argument, indent::Int, prec::Int) = show_unquoted(io, Core.SlotNumber(val.n), indent, prec)
-
-function show_unquoted(io::IO, stmt::PhiNode, indent::Int, ::Int)
-    args = map(1:length(stmt.edges)) do i
-        e = stmt.edges[i]
-        v = !isassigned(stmt.values, i) ? "#undef" :
-            sprint() do io′
-                show_unquoted(io′, stmt.values[i], indent)
-            end
-        return "$e => $v"
-    end
-    print(io, "φ ", '(')
-    join(io, args, ", ")
-    print(io, ')')
-end
-
-function show_unquoted(io::IO, stmt::PhiCNode, indent::Int, prec::Int)
-    show_enclosed_list(io, "φᶜ (", stmt.values, ", ", ")", indent)
-end
-
-function show_unquoted(io::IO, stmt::PiNode, indent::Int, prec::Int)
-    print(io, "π (")
-    show_unquoted(io, stmt.val, indent)
-    print(io, ", ")
-    printstyled(io, stmt.typ, color=:cyan)
-    print(io, ")")
-end
-
-function show_unquoted(io::IO, stmt::UpsilonNode, indent::Int, ::Int)
-    print(io, "ϒ (")
-    isdefined(stmt, :val) ?
-        show_unquoted(io, stmt.val, indent) :
-        print(io, "#undef")
-    print(io, ")")
-end
-
-function show_unquoted(io::IO, stmt::ReturnNode, indent::Int, ::Int)
-    if !isdefined(stmt, :val)
-        print(io, "unreachable")
-    else
-        print(io, "return ")
-        show_unquoted(io, stmt.val, indent)
+        Base.show(io, stmt)
     end
 end
 
-function show_unquoted(io::IO, stmt::GotoIfNot, indent::Int, ::Int)
-    print(io, "goto ", stmt.dest, " if not ")
-    show_unquoted(io, stmt.cond, indent)
-end
-
-function compute_inlining_depth(linetable::Vector, iline::Int32)
-    iline == 0 && return 1
-    depth = -1
+function compute_inlining_depth(linetable, iline::Int32)
+    depth = 0
     while iline != 0
+        linetable[iline].inlined_at == 0 && break
         depth += 1
-        lineinfo = linetable[iline]::LineInfoNode
-        iline = lineinfo.inlined_at
+        iline = linetable[iline].inlined_at
     end
     return depth
 end
 
 function should_print_ssa_type(@nospecialize node)
     if isa(node, Expr)
-        return !(node.head in (:gc_preserve_begin, :gc_preserve_end, :gotoifnot, :meta, :return, :enter, :leave))
+        return !(node.head in (:gc_preserve_begin, :gc_preserve_end))
     end
     return !isa(node, PiNode)   && !isa(node, GotoIfNot) &&
-           !isa(node, GotoNode) && !isa(node, ReturnNode) &&
-           !isa(node, QuoteNode)
+           !isa(node, GotoNode) && !isa(node, ReturnNode)
 end
 
-function default_expr_type_printer(io::IO, @nospecialize(typ), used::Bool)
-    printstyled(io, "::", typ, color=(used ? :cyan : :light_black))
+function default_expr_type_printer(io::IO, @nospecialize typ)
+    typ_str = try
+        string(typ)
+    catch
+        "<error_printing>"
+    end
+    Base.printstyled(io, "::$(typ_str)", color=:cyan)
     nothing
 end
 
-# converts the linetable for line numbers
-# into a list in the form:
-#   1 outer-most-frame
-#   2   inlined-frame
-#   3     innermost-frame
-function compute_loc_stack(linetable::Vector, line::Int32)
-    stack = Int[]
-    while line != 0
-        entry = linetable[line]::LineInfoNode
-        pushfirst!(stack, line)
-        line = entry.inlined_at
+function compute_loc_stack(code::IRCode, line::Int32)
+    stack = []
+    line == 0 && return stack
+    inlined_at = code.linetable[line].inlined_at
+    if inlined_at != 0
+        push!(stack, inlined_at)
+        entry = code.linetable[inlined_at]
+        while entry.inlined_at != 0
+            push!(stack, entry.inlined_at)
+            entry = code.linetable[entry.inlined_at]
+        end
+        reverse!(stack)
     end
+    push!(stack, line)
     return stack
 end
 
@@ -160,7 +161,7 @@ example (taken from `@code_typed sin(1.0)`):
 ```
 
 The three annotations are indicated with `*`. The first one is the line number of the
-active function (printed once whenver the outer most line number changes). The second
+active function (printed once whenever the outer most line number changes). The second
 is the inlining indicator. The number of lines indicate the level of nesting, with a
 half-size line (╷) indicating the start of a scope and a full size line (│) indicating
 a continuing scope. The last annotation is the most complicated one. It is a heuristic
@@ -207,7 +208,7 @@ to catch up and print the intermediate scopes. Which scope is printed is indicat
 by the indentation of the method name and by an increased thickness of the appropriate
 line for the scope.
 """
-function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
+function compute_ir_line_annotations(code::IRCode)
     loc_annotations = String[]
     loc_methods = String[]
     loc_lineno = String[]
@@ -216,20 +217,17 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
     last_lineno = 0
     last_stack = []
     last_printed_depth = 0
-    stmts = (code isa IRCode ? code.stmts : code.code)
-    linetable = code.linetable
-    lines = (code isa IRCode ? code.lines : code.codelocs)
-    for idx in eachindex(stmts)
+    for idx in eachindex(code.stmts)
         buf = IOBuffer()
-        line = lines[idx]
-        depth = compute_inlining_depth(linetable, line)
+        line = code.lines[idx]
+        depth = compute_inlining_depth(code.linetable, line)
         iline = line
         lineno = 0
         loc_method = ""
         print(buf, "│")
         if line != 0
-            stack = compute_loc_stack(linetable, line)
-            lineno = linetable[stack[1]].line
+            stack = compute_loc_stack(code, line)
+            lineno = code.linetable[stack[1]].line
             x = min(length(last_stack), length(stack))
             if length(stack) != 0
                 # Compute the last depth that was in common
@@ -237,7 +235,7 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
                 # If the first mismatch is the last stack frame, that might just
                 # be a line number mismatch in inner most frame. Ignore those
                 if length(last_stack) == length(stack) && first_mismatch == length(stack)
-                    last_entry, entry = linetable[last_stack[end]], linetable[stack[end]]
+                    last_entry, entry = code.linetable[last_stack[end]], code.linetable[stack[end]]
                     if last_entry.method == entry.method && last_entry.file == entry.file
                         first_mismatch = nothing
                     end
@@ -274,15 +272,15 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
                 print(buf, "╷"^max(0,depth-last_depth-stole_one))
                 if printing_depth != 0
                     if length(stack) == printing_depth
-                        loc_method = String(linetable[line].method)
+                        loc_method = String(code.linetable[line].method)
                     else
-                        loc_method = String(linetable[stack[printing_depth+1]].method)
+                        loc_method = String(code.linetable[stack[printing_depth+1]].method)
                     end
                 end
                 loc_method = string(" "^printing_depth, loc_method)
             end
             last_stack = stack
-            entry = linetable[line]
+            entry = code.linetable[line]
         end
         push!(loc_annotations, String(take!(buf)))
         push!(loc_lineno, (lineno != 0 && lineno != last_lineno) ? string(lineno) : "")
@@ -294,34 +292,26 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
 end
 
 Base.show(io::IO, code::IRCode) = show_ir(io, code)
-
-function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_printer; verbose_linetable=false)
-    cols = displaysize(io)[2]
-    used = BitSet()
-    stmts = code.stmts
-    types = code.types
-    for stmt in stmts
-        scan_ssa_use!(push!, used, stmt)
-    end
+function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_printer; argnames=Symbol[], verbose_linetable=false)
+    (lines, cols) = displaysize(io)
+    used = IdSet{Int}()
+    foreach(stmt->scan_ssa_use!(push!, used, stmt), code.stmts)
     cfg = code.cfg
     max_bb_idx_size = length(string(length(cfg.blocks)))
     bb_idx = 1
-    new_nodes = code.new_nodes
-    if any(i -> !isassigned(code.new_nodes, i), 1:length(code.new_nodes))
+    if any(i->!isassigned(code.new_nodes, i), 1:length(code.new_nodes))
         printstyled(io, :red, "ERROR: New node array has unset entry\n")
-        new_nodes = new_nodes[filter(i -> isassigned(code.new_nodes, i), 1:length(code.new_nodes))]
     end
-    for nn in new_nodes
-        scan_ssa_use!(push!, used, nn.node)
-    end
+    new_nodes = code.new_nodes[filter(i->isassigned(code.new_nodes, i), 1:length(code.new_nodes))]
+    foreach(nn -> scan_ssa_use!(push!, used, nn.node), new_nodes)
     perm = sortperm(new_nodes, by = x->x.pos)
     new_nodes_perm = Iterators.Stateful(perm)
 
     if isempty(used)
-        maxlength_idx = 0
+        maxsize = 0
     else
         maxused = maximum(used)
-        maxlength_idx = length(string(maxused))
+        maxsize = length(string(maxused))
     end
     if !verbose_linetable
         (loc_annotations, loc_methods, loc_lineno) = compute_ir_line_annotations(code)
@@ -329,24 +319,22 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         max_lineno_width = maximum(length(str) for str in loc_lineno)
         max_method_width = maximum(length(str) for str in loc_methods)
     end
-    max_depth = maximum(compute_inlining_depth(code.linetable, line) for line in code.lines)
+    max_depth = maximum(line == 0 ? 1 : compute_inlining_depth(code.linetable, line) for line in code.lines)
     last_stack = []
-    for idx in eachindex(stmts)
-        if !isassigned(stmts, idx)
+    for idx in eachindex(code.stmts)
+        if !isassigned(code.stmts, idx)
             # This is invalid, but do something useful rather
             # than erroring, to make debugging easier
-            printstyled(io, :red, "#UNDEF\n")
+            printstyled(io, :red, "UNDEF\n")
             continue
         end
-        stmt = stmts[idx]
+        stmt = code.stmts[idx]
         # Compute BB guard rail
         bbrange = cfg.blocks[bb_idx].stmts
         bbrange = bbrange.first:bbrange.last
-        bb_idx_str = string(bb_idx)
-        bb_pad = max_bb_idx_size - length(bb_idx_str)
-        bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
-        bb_start_str = string(bb_idx_str, " ", bb_type, "─"^bb_pad, " ")
-        bb_guard_rail_cont = string("│  ", " "^max_bb_idx_size)
+        bb_pad = max_bb_idx_size - length(string(bb_idx))
+        bb_start_str = string("$(bb_idx) ",length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄",  "─"^(bb_pad)," ")
+        bb_guard_rail_cont = string("│  "," "^max_bb_idx_size)
         if idx == first(bbrange)
             bb_guard_rail = bb_start_str
         else
@@ -354,7 +342,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         end
         # Print linetable information
         if verbose_linetable
-            stack = compute_loc_stack(code.linetable, code.lines[idx])
+            stack = compute_loc_stack(code, code.lines[idx])
             # We need to print any stack frames that did not exist in the last stack
             ndepth = max(1, length(stack))
             rail = string(" "^(max_depth+1-ndepth), "│"^ndepth)
@@ -364,167 +352,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
                     entry = code.linetable[x]
                     printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
                     print(io, bb_guard_rail)
-                    ssa_guard = " "^(maxlength_idx + 4 + (i - 1))
-                    entry_label = "$(ssa_guard)$(entry.method) at $(entry.file):$(entry.line) "
-                    hline = string("─"^(start_column-length(entry_label)-length(bb_guard_rail)+max_depth-i), "┐")
-                    printstyled(io, string(entry_label, hline), "\n"; color=:light_black)
-                    bb_guard_rail = bb_guard_rail_cont
-                end
-            end
-            printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
-            last_stack = stack
-        else
-            annotation = loc_annotations[idx]
-            loc_method = loc_methods[idx]
-            lineno = loc_lineno[idx]
-            # Print location information right aligned. If the line below is too long, it'll overwrite this,
-            # but that's what we want.
-            if get(io, :color, false)
-                method_start_column = cols - max_method_width - max_loc_width - 2
-                filler = " "^(max_loc_width-length(annotation))
-                printstyled(io, "\e[$(method_start_column)G$(annotation)$(filler)$(loc_method)\e[1G", color = :light_black)
-            end
-            printstyled(io, lineno, " "^(max_lineno_width - length(lineno) + 1); color = :light_black)
-        end
-        idx != last(bbrange) && print(io, bb_guard_rail)
-        print_sep = false
-        if idx == last(bbrange)
-            print_sep = true
-        end
-        floop = true
-        # print new nodes first in the right position
-        while !isempty(new_nodes_perm) && new_nodes[Iterators.peek(new_nodes_perm)].pos == idx
-            node_idx = popfirst!(new_nodes_perm)
-            new_node = new_nodes[node_idx]
-            node_idx += length(stmts)
-            if !floop && !verbose_linetable
-                print(io, " "^(max_lineno_width + 1))
-            end
-            if print_sep
-                if idx == first(bbrange) && floop
-                    print(io, bb_start_str)
-                else
-                    print(io, "│  ", " "^max_bb_idx_size)
-                end
-            end
-            print_sep = true
-            floop = false
-            show_type = should_print_ssa_type(new_node.node)
-            with_output_color(:yellow, io) do io′
-                print_stmt(io′, node_idx, new_node.node, used, maxlength_idx, false, show_type)
-            end
-            if show_type
-                expr_type_printer(io, new_node.typ, node_idx in used)
-            end
-            println(io)
-        end
-        if !floop && !verbose_linetable
-            print(io, " "^(max_lineno_width + 1))
-        end
-        if print_sep
-            if idx == first(bbrange) && floop
-                print(io, bb_start_str)
-            elseif idx == last(bbrange)
-                print(io, "└", "─"^(1 + max_bb_idx_size), " ")
-            else
-                print(io, "│  ", " "^max_bb_idx_size)
-            end
-        end
-        if idx == last(bbrange)
-            bb_idx += 1
-        end
-        show_type = should_print_ssa_type(stmt)
-        print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)
-        if !isassigned(types, idx)
-            # This is an error, but can happen if passes don't update their type information
-            printstyled(io, "::#UNDEF", color=:red)
-        elseif show_type
-            typ = types[idx]
-            expr_type_printer(io, typ, idx in used)
-        end
-        println(io)
-    end
-end
-
-function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_printer; verbose_linetable=false)
-    cols = displaysize(io)[2]
-    used = BitSet()
-    stmts = code.code
-    types = code.ssavaluetypes
-    for stmt in stmts
-        scan_ssa_use!(push!, used, stmt)
-        # also add "uses" for labels for visualization
-        if isexpr(stmt, :gotoifnot) && length(stmt.args) == 2
-            let label = stmt.args[2]
-                label isa Int && push!(used, label)
-            end
-        end
-        if isexpr(stmt, :enter) && length(stmt.args) == 1
-            let label = stmt.args[1]
-                label isa Int && push!(used, label)
-            end
-        end
-        if stmt isa GotoNode
-            push!(used, stmt.label)
-        end
-        if stmt isa PhiNode
-            for label in stmt.edges
-                label isa Int && push!(used, label)
-            end
-        end
-    end
-    cfg = compute_basic_blocks(stmts)
-    max_bb_idx_size = length(string(length(cfg.blocks)))
-    bb_idx = 1
-
-    if isempty(used)
-        maxlength_idx = 0
-    else
-        maxused = maximum(used)
-        maxlength_idx = length(string(maxused))
-    end
-    if !verbose_linetable
-        (loc_annotations, loc_methods, loc_lineno) = compute_ir_line_annotations(code)
-        max_loc_width = maximum(length(str) for str in loc_annotations)
-        max_lineno_width = maximum(length(str) for str in loc_lineno)
-        max_method_width = maximum(length(str) for str in loc_methods)
-    end
-    max_depth = maximum(compute_inlining_depth(code.linetable, line) for line in code.codelocs)
-    last_stack = []
-    for idx in eachindex(stmts)
-        if !isassigned(stmts, idx)
-            # This is invalid, but do something useful rather
-            # than erroring, to make debugging easier
-            printstyled(io, :red, "#UNDEF\n")
-            continue
-        end
-        stmt = stmts[idx]
-        # Compute BB guard rail
-        bbrange = cfg.blocks[bb_idx].stmts
-        bbrange = bbrange.first:bbrange.last
-        bb_idx_str = string(bb_idx)
-        bb_pad = max_bb_idx_size - length(bb_idx_str)
-        bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
-        bb_start_str = string(bb_idx_str, " ", bb_type, "─"^bb_pad, " ")
-        bb_guard_rail_cont = string("│  ", " "^max_bb_idx_size)
-        if idx == first(bbrange)
-            bb_guard_rail = bb_start_str
-        else
-            bb_guard_rail = bb_guard_rail_cont
-        end
-        # Print linetable information
-        if verbose_linetable
-            stack = compute_loc_stack(code.linetable, code.codelocs[idx])
-            # We need to print any stack frames that did not exist in the last stack
-            ndepth = max(1, length(stack))
-            rail = string(" "^(max_depth+1-ndepth), "│"^ndepth)
-            start_column = cols - max_depth - 10
-            for (i, x) in enumerate(stack)
-                if i > length(last_stack) || last_stack[i] != x
-                    entry = code.linetable[x]
-                    printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
-                    print(io, bb_guard_rail)
-                    ssa_guard = " "^(maxlength_idx + 4 + (i - 1))
+                    ssa_guard = " "^(maxsize+4+(i-1))
                     entry_label = "$(ssa_guard)$(entry.method) at $(entry.file):$(entry.line) "
                     hline = string("─"^(start_column-length(entry_label)-length(bb_guard_rail)+max_depth-i), "┐")
                     printstyled(io, string(entry_label, hline), "\n"; color=:light_black)
@@ -546,29 +374,58 @@ function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_pri
             end
             printstyled(io, lineno, " "^(max_lineno_width-length(lineno)+1); color = :light_black)
         end
-        idx != last(bbrange) && print(io, bb_guard_rail)
-        if idx == last(bbrange) # print separator
-            if idx == first(bbrange)
-                print(io, bb_start_str)
-            elseif idx == last(bbrange)
-                print(io, "└", "─"^(1 + max_bb_idx_size), " ")
+        idx != last(bbrange) && Base.print(io, bb_guard_rail)
+        print_sep = false
+        if idx == last(bbrange)
+            print_sep = true
+        end
+        floop = true
+        while !isempty(new_nodes_perm) && new_nodes[Iterators.peek(new_nodes_perm)].pos == idx
+            node_idx = popfirst!(new_nodes_perm)
+            new_node = new_nodes[node_idx]
+            node_idx += length(code.stmts)
+            if print_sep
+                if floop
+                    Base.print(io, bb_start_str)
+                else
+                    Base.print(io, "│  "," "^max_bb_idx_size)
+                end
+            end
+            print_sep = true
+            floop = false
+            Base.with_output_color(:yellow, io) do io′
+                print_node(io′, node_idx, new_node.node, used, argnames, maxsize; color = false, print_typ=false)
+            end
+            if should_print_ssa_type(new_node.node) && node_idx in used
+                expr_type_printer(io, new_node.typ)
+            end
+            Base.println(io)
+        end
+        if print_sep
+            if idx == first(bbrange) && floop
+                Base.print(io, bb_start_str)
             else
-                print(io, "│  ", " "^max_bb_idx_size)
+                Base.print(io, idx == last(bbrange) ? string("└", "─"^(1+max_bb_idx_size), " ") :
+                    string("│  ", " "^max_bb_idx_size))
             end
         end
         if idx == last(bbrange)
             bb_idx += 1
         end
-        show_type = types isa Vector{Any} && should_print_ssa_type(stmt)
-        print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)
-        if types isa Vector{Any} # ignore types for pre-inference code
-            if !isassigned(types, idx)
-                # This is an error, but can happen if passes don't update their type information
-                printstyled(io, "::#UNDEF", color=:red)
-            elseif show_type
-                typ = types[idx]
-                expr_type_printer(io, typ, idx in used)
-            end
+        if !isassigned(code.types, idx)
+            # Again, this is an error, but can happen if passes don't update their type information
+            printstyled(io, "::UNDEF", color=:red)
+            println(io)
+            continue
+        end
+        typ = code.types[idx]
+        try
+            print_node(io, idx, stmt, used, argnames, maxsize, print_typ=false)
+        catch e
+            print(io, "<error printing>")
+        end
+        if should_print_ssa_type(stmt) && idx in used
+            expr_type_printer(io, typ)
         end
         println(io)
     end

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -96,9 +96,9 @@ as assignments, branches, and calls:
 ```jldoctest
 julia> Meta.lower(@__MODULE__, :([1+2, sin(0.5)]) )
 :($(Expr(:thunk, CodeInfo(
- 1 ─ %1 = 1 + 2
- │   %2 = sin(0.5)
- │   %3 = (Base.vect)(%1, %2)
+ 1 ─ %1 = :+(1, 2)::Any
+ │   %2 = :sin(0.5)::Any
+ │   %3 = Base.vect(%1, %2)::Any
  └──      return %3
 ))))
 ```

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1268,25 +1268,25 @@ Returns the result of `f(x)` if the types match,
 and an `Error` `Result` if it finds different types.
 
 ```jldoctest; setup = :(using InteractiveUtils), filter = r"begin\\n(.|\\n)*end"
-julia> f(a, b, c) = b > 1 ? 1 : 1.0
+julia> f(a,b,c) = b > 1 ? 1 : 1.0
 f (generic function with 1 method)
 
-julia> typeof(f(1, 2, 3))
+julia> typeof(f(1,2,3))
 Int64
 
-julia> @code_warntype f(1, 2, 3)
+julia> @code_warntype f(1,2,3)
 Body::UNION{FLOAT64, INT64}
-1 1 ─ %1 = (Base.slt_int)(1, b)::Bool
-  └──      unless %1 goto 4
+1 1 ─ %1 = Base.slt_int(1, %%b)::Bool
+  └──      goto 3 if not %1
   2 ─      return 1
-  3 ─ %4 = return 1.0
+  3 ─      return 1.0
 
-julia> @inferred f(1, 2, 3)
+julia> @inferred f(1,2,3)
 ERROR: return type Int64 does not match inferred return type Union{Float64, Int64}
 Stacktrace:
 [...]
 
-julia> @inferred max(1, 2)
+julia> @inferred max(1,2)
 2
 ```
 """

--- a/test/show.jl
+++ b/test/show.jl
@@ -866,17 +866,10 @@ test_repr("(!).:~")
 test_repr("a.:(begin
         #= none:3 =#
     end)")
-test_repr("a.:(=)")
-test_repr("a.:(:)")
-test_repr("(:).a")
 @test repr(Expr(:., :a, :b, :c)) == ":(\$(Expr(:., :a, :b, :c)))"
 @test repr(Expr(:., :a, :b)) == ":(\$(Expr(:., :a, :b)))"
 @test repr(Expr(:., :a)) == ":(\$(Expr(:., :a)))"
 @test repr(Expr(:.)) == ":(\$(Expr(:.)))"
-@test repr(GlobalRef(Main, :a)) == ":(Main.a)"
-@test repr(GlobalRef(Main, :in)) == ":(Main.in)"
-@test repr(GlobalRef(Main, :+)) == ":(Main.:+)"
-@test repr(GlobalRef(Main, :(:))) == ":(Main.:(:))"
 
 # Test compact printing of homogeneous tuples
 @test repr(NTuple{7,Int64}) == "NTuple{7,Int64}"
@@ -1282,7 +1275,7 @@ function compute_annotations(f, types)
     ir = Core.Compiler.inflate_ir(src)
     la, lb, ll = Base.IRShow.compute_ir_line_annotations(ir)
     max_loc_method = maximum(length(s) for s in la)
-    return join((strip(string(a, " "^(max_loc_method-length(a)), b)) for (a, b) in zip(la, lb)), '\n')
+    join((strip(string(a, " "^(max_loc_method-length(a)), b)) for (a, b) in zip(la, lb)), '\n')
 end
 
 @noinline leaffunc() = print()
@@ -1301,60 +1294,6 @@ h_line() = f_line()
     │╻╷ f_line
     ││╻  g_line
     ││╻  g_line""")
-
-# Tests for printing Core.Compiler internal objects
-@test sprint(Base.show_unquoted, Core.Compiler.SSAValue(23)) == "%23"
-@test sprint(Base.show_unquoted, Core.Compiler.SSAValue(-2)) == "%-2"
-@test sprint(Base.show_unquoted, Core.Compiler.ReturnNode(23)) == "return 23"
-@test sprint(Base.show_unquoted, Core.Compiler.Argument(23)) == "_23"
-@test sprint(Base.show_unquoted, Core.Compiler.Argument(-2)) == "_-2"
-@test sprint(Base.show_unquoted, Core.Compiler.ReturnNode(23)) == "return 23"
-@test sprint(Base.show_unquoted, Core.Compiler.ReturnNode()) == "unreachable"
-@test sprint(Base.show_unquoted, Core.Compiler.GotoIfNot(true, 4)) == "goto 4 if not true"
-
-eval(Meta.parse("""function my_fun28173(x)
-    y = if x == 1
-            "HI"
-        elseif x == 2
-            "BYE"
-        else
-            "three"
-        end
-    return y
-end""")) # use parse to control the line numbers
-let src = code_typed(my_fun28173, (Int,))[1][1]
-    ir = Core.Compiler.inflate_ir(src)
-    ## TODO: should this work? currently, `src` is labeled by statement,
-    ##       and `ir` is labeled by basic-block
-    # source_slotnames = String["my_fun28173", "x"]
-    # irshow = sprint(show, ir, context = :SOURCE_SLOTNAMES=>source_slotnames)
-    # @test repr(src) == "CodeInfo(\n" * irshow * ")"
-    lines1 = split(repr(ir), '\n')
-    @test isempty(pop!(lines1))
-    Core.Compiler.insert_node!(ir, 1, Val{1}, QuoteNode(1), false)
-    Core.Compiler.insert_node!(ir, 1, Val{2}, QuoteNode(2), true)
-    Core.Compiler.insert_node!(ir, length(ir.stmts), Val{3}, QuoteNode(3), false)
-    Core.Compiler.insert_node!(ir, length(ir.stmts), Val{4}, QuoteNode(4), true)
-    lines2 = split(repr(ir), '\n')
-    @test isempty(pop!(lines2))
-    @test popfirst!(lines2) == "2 1 ─      $(QuoteNode(1))"
-    @test popfirst!(lines2) == "  │        $(QuoteNode(2))" # TODO: this should print after the next statement
-    let line1 = popfirst!(lines1)
-        line2 = popfirst!(lines2)
-        @test startswith(line1, "2 1 ─ ")
-        @test startswith(line2, "  │   ")
-        @test line1[9:end] == line2[9:end]
-    end
-    let line1 = pop!(lines1)
-        line2 = pop!(lines2)
-        @test startswith(line1, "9 ")
-        @test startswith(line2, "  ")
-        @test line1[2:end] == line2[2:end]
-    end
-    @test pop!(lines2) == "  │        \$(QuoteNode(4))"
-    @test pop!(lines2) == "9 │        \$(QuoteNode(3))" # TODO: this should print after the next statement
-    @test lines1 == lines2
-end
 
 # issue #27352
 @test_deprecated print(nothing)


### PR DESCRIPTION
#28195 had massive behavior changes to code printing that I think are extremely confusing. My preference would be to revert it, cherry-pick the bug fixes and then have a proper design discussion on how to properly print this, rather than sneaking such changes in right before an RC.

Reverts JuliaLang/julia#28195