### PR TITLE
Add optional arguments for @code_typed and @code_llvm

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1767,6 +1767,9 @@ end
 @deprecate indices1 axes1
 @deprecate _length length
 
+# PR #28223
+@deprecate code_llvm_raw(f, types=Tuple) code_llvm(f, types; raw=true)
+
 # END 0.7 deprecations
 
 # BEGIN 1.0 deprecations

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -102,12 +102,14 @@ end
 Prints the LLVM bitcodes generated for running the method matching the given generic
 function and type signature to `io`.
 
-All metadata and dbg.* calls are removed from the printed bitcode. Use `code_llvm_raw` for the full IR.
+If the `optimize` keyword is unset, the code will be shown before LLVM optimizations.
+All metadata and dbg.* calls are removed from the printed bitcode. Set the `raw` keyword for the full IR.
+To dump the entire module that encapsulates the function, with debug info and metadata, set the `dump_module` keyword.
 """
-code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Tuple), strip_ir_metadata=true, dump_module=false) =
-    print(io, _dump_function(f, types, false, false, strip_ir_metadata, dump_module))
-code_llvm(@nospecialize(f), @nospecialize(types=Tuple)) = code_llvm(stdout, f, types)
-code_llvm_raw(@nospecialize(f), @nospecialize(types=Tuple)) = code_llvm(stdout, f, types, false)
+code_llvm(io::IO, @nospecialize(f), @nospecialize(types=Tuple), strip_ir_metadata=true, dump_module=false, optimize=true) =
+    print(io, _dump_function(f, types, false, false, strip_ir_metadata, dump_module, :att, optimize))
+code_llvm(@nospecialize(f), @nospecialize(types=Tuple); raw=false, dump_module=false, optimize=true) =
+    code_llvm(stdout, f, types, !raw, dump_module, optimize)
 
 """
     code_native([io=stdout,], f, types; syntax = :att)

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -2,7 +2,7 @@
 
 # macro wrappers for various reflection functions
 
-import Base.typesof
+import Base: typesof, insert!
 
 separate_kwargs(args...; kwargs...) = (args, kwargs.data)
 
@@ -70,8 +70,34 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
     return exret
 end
 
-for fname in [:which, :less, :edit, :functionloc, :code_warntype,
-              :code_llvm, :code_llvm_raw, :code_native]
+"""
+Same behaviour as gen_call_with_extracted_types except that keyword arguments
+of the form "foo=bar" are passed on to the called function as well.
+The keyword arguments must be given before the mandatory argument.
+"""
+function gen_call_with_extracted_types_and_kwargs(__module__, fcn, ex0)
+    kwargs = Vector{Any}[]
+    arg = ex0[end] # Mandatory argument
+    for i in 1:length(ex0)-1
+        x = ex0[i]
+        if x isa Expr && x.head == :(=) # Keyword given of the form "foo=bar"
+            push!(kwargs, x.args)
+        else
+            return Expr(:call, :error, "@$fcn expects only one non-keyword argument")
+        end
+    end
+    thecall = gen_call_with_extracted_types(__module__, fcn, arg)
+    for kwarg in kwargs
+        if length(kwarg) != 2
+            x = string(Expr(:(=), kwarg...))
+            return Expr(:call, :error, "Invalid keyword argument: $x")
+        end
+        push!(thecall.args, Expr(:kw, kwarg[1], kwarg[2]))
+    end
+    return thecall
+end
+
+for fname in [:which, :less, :edit, :functionloc, :code_warntype, :code_native]
     @eval begin
         macro ($fname)(ex0)
             gen_call_with_extracted_types(__module__, $(Expr(:quote, fname)), ex0)
@@ -83,15 +109,23 @@ macro which(ex0::Symbol)
     return :(which($__module__, $ex0))
 end
 
-for fname in [:code_typed, :code_lowered]
-    @eval begin
-        macro ($fname)(ex0)
-            thecall = gen_call_with_extracted_types(__module__, $(Expr(:quote, fname)), ex0)
-            quote
-                results = $thecall
-                length(results) == 1 ? results[1] : results
-            end
-        end
+macro code_llvm(ex0...)
+    gen_call_with_extracted_types_and_kwargs(__module__, :code_llvm, ex0)
+end
+
+macro code_typed(ex0...)
+    thecall = gen_call_with_extracted_types_and_kwargs(__module__, :code_typed, ex0)
+    quote
+        results = $thecall
+        length(results) == 1 ? results[1] : results
+    end
+end
+
+macro code_lowered(ex0)
+    thecall = gen_call_with_extracted_types(__module__, :code_lowered, ex0)
+    quote
+        results = $thecall
+        length(results) == 1 ? results[1] : results
     end
 end
 
@@ -134,7 +168,11 @@ function on the resulting expression.
     @code_typed
 
 Evaluates the arguments to the function or macro call, determines their types, and calls
-[`code_typed`](@ref) on the resulting expression.
+[`code_typed`](@ref) on the resulting expression. Use the optional argument `optimize` with
+
+    @code_typed optimize=true foo(x)
+
+to control whether additional optimizations, such as inlining, are also applied.
 """
 :@code_typed
 
@@ -159,6 +197,15 @@ Evaluates the arguments to the function or macro call, determines their types, a
 
 Evaluates the arguments to the function or macro call, determines their types, and calls
 [`code_llvm`](@ref) on the resulting expression.
+Set the optional keyword arguments `raw`, `dump_module` and `optimize` by putting them and
+their value before the function call, like this:
+
+    @code_llvm raw=true dump_module=true f(x)
+    @code_llvm optimize=false f(x)
+
+`optimize` controls whether additional optimizations, such as inlining, are also applied.
+`raw` makes all metadata and dbg.* calls visible.
+`dump_module` prints the entire module that encapsulates the function, with debug info and metadata.
 """
 :@code_llvm
 


### PR DESCRIPTION
EDIT: see https://github.com/JuliaLang/julia/pull/28223#issuecomment-407211642 for the current contents of the PR

```julia
julia> @code_typed maximum(7)
CodeInfo(
485 1 ─     return %%a                                                      │
) => Int64

julia> @code_typed optimize=true maximum(7)
CodeInfo(
485 1 ─     return %%a                                                      │
) => Int64

julia> @code_typed optimize=false maximum(7)
CodeInfo(
485 1 ─ %1 = Base.mapreduce(Base.identity, Base.max, %%a)::Int64            │
    └──      return %1                                                      │
) => Int64
```

cc @Keno 