### PR TITLE
added missing method for `Profile.callers`

### DIFF
--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -258,8 +258,6 @@ end
 
 callers(funcname::String, bt::Vector, lidict::LineInfoDict; kwargs...) =
     callers(funcname, flatten(bt, lidict)...; kwargs...)
-
-
 callers(funcname::String; kwargs...) = callers(funcname, retrieve()...; kwargs...)
 callers(func::Function, bt::Vector, lidict::LineInfoFlatDict; kwargs...) =
     callers(string(func), bt, lidict; kwargs...)

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -256,6 +256,10 @@ function callers(funcname::String, bt::Vector, lidict::LineInfoFlatDict; filenam
     end
 end
 
+callers(funcname::String, bt::Vector, lidict::LineInfoDict; kwargs...) =
+    callers(funcname, flatten(bt, lidict)...; kwargs...)
+
+
 callers(funcname::String; kwargs...) = callers(funcname, retrieve()...; kwargs...)
 callers(func::Function, bt::Vector, lidict::LineInfoFlatDict; kwargs...) =
     callers(string(func), bt, lidict; kwargs...)

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -44,6 +44,7 @@ let iobuf = IOBuffer()
     @test !isempty(String(take!(iobuf)))
     Profile.clear()
     @test isempty(Profile.fetch())
+    @test Profile.callers("\\") !== nothing
 end
 
 # issue #13229

--- a/stdlib/Profile/test/runtests.jl
+++ b/stdlib/Profile/test/runtests.jl
@@ -45,6 +45,7 @@ let iobuf = IOBuffer()
     Profile.clear()
     @test isempty(Profile.fetch())
     @test Profile.callers("\\") !== nothing
+    @test Profile.callers(\) !== nothing
 end
 
 # issue #13229


### PR DESCRIPTION
This PR adds `Profile.callers(..., Dict{UInt64,Array{Base.StackTraces.StackFrame,1}}, ...`, which is obviously required by `Profile.callers(::Function)`.

Before change:
```
julia> Profile.callers(\)
ERROR: MethodError: no method matching callers(::String, ::Array{UInt64,1}, ::Dict{UInt64,Array{Base.StackTraces.StackFrame,1}})
Closest candidates are:
  callers(::String, ::Array{T,1} where T, ::Dict{UInt64,Base.StackTraces.StackFrame}; filename, linerange) at /home/julia/julia/usr/share/julia/stdlib/v0.7/Profile/src/Profile.jl:244
```
