### PR TITLE
Add generic function `loggerstream`

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -15,6 +15,7 @@ export
     @logmsg,
     with_logger,
     current_logger,
+    loggerstream,
     global_logger,
     disable_logging,
     SimpleLogger
@@ -83,6 +84,7 @@ min_enabled_level(::NullLogger) = AboveMaxLevel
 shouldlog(::NullLogger, args...) = false
 handle_message(::NullLogger, args...; kwargs...) =
     error("Null logger handle_message() should not be called")
+loggerstream(::NullLogger) = devnull
 
 
 #-------------------------------------------------------------------------------
@@ -488,6 +490,20 @@ is attached to the task.
 """
 current_logger() = current_logstate().logger
 
+"""
+    loggerstream()
+
+Return the underlying IO stream of the current logger.
+"""
+loggerstream() = loggerstream(current_logger())
+
+"""
+    loggerstream(logger::AbstractLogger)
+
+Return the IO stream of `logger`.
+"""
+loggerstream(::AbstractLogger)
+
 
 #-------------------------------------------------------------------------------
 # SimpleLogger
@@ -503,6 +519,7 @@ struct SimpleLogger <: AbstractLogger
     message_limits::Dict{Any,Int}
 end
 SimpleLogger(stream::IO=stderr, level=Info) = SimpleLogger(stream, level, Dict{Any,Int}())
+loggerstream(logger::SimpleLogger) = logger.stream
 
 shouldlog(logger::SimpleLogger, level, _module, group, id) =
     get(logger.message_limits, id, 1) > 0

--- a/stdlib/Logging/docs/src/index.md
+++ b/stdlib/Logging/docs/src/index.md
@@ -215,6 +215,7 @@ Event processing is controlled by overriding functions associated with
 | [`Logging.min_enabled_level`](@ref) |                        | Lower bound for log level of accepted events |
 | **Optional methods**                | **Default definition** | **Brief description**                    |
 | [`Logging.catch_exceptions`](@ref)  | `true`                 | Catch exceptions during event evaluation |
+| [`Logging.loggerstream`](@ref)      |                        | Return the IO stream of the logger       |
 
 
 ```@docs
@@ -224,6 +225,7 @@ Logging.shouldlog
 Logging.min_enabled_level
 Logging.catch_exceptions
 Logging.disable_logging
+Logging.loggerstream
 ```
 
 ### Using Loggers

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -37,6 +37,8 @@ function ConsoleLogger(stream::IO=stderr, min_level=Info;
                   show_limited, right_justify, Dict{Any,Int}())
 end
 
+loggerstream(logger::ConsoleLogger) = logger.stream
+
 shouldlog(logger::ConsoleLogger, level, _module, group, id) =
     get(logger.message_limits, id, 1) > 0
 

--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -22,6 +22,7 @@ import Base.CoreLogging:
     @logmsg,
     with_logger,
     current_logger,
+    loggerstream,
     global_logger,
     disable_logging,
     SimpleLogger
@@ -37,6 +38,7 @@ export
     @logmsg,
     with_logger,
     current_logger,
+    loggerstream,
     global_logger,
     disable_logging,
     SimpleLogger,

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -227,6 +227,15 @@ import Logging: min_enabled_level, shouldlog, handle_message
     \e[36m\e[1m└ \e[22m\e[39m\e[90mSUFFIX\e[39m
     """
 
+    # loggerstream
+    io = IOBuffer()
+    logger = ConsoleLogger(io)
+    with_logger(logger) do
+        print(loggerstream(), "Hello,")
+        print(loggerstream(logger), " world!")
+    end
+    @test String(take!(io)) == "Hello, world!"
+
 end
 
 end

--- a/test/logging.jl
+++ b/test/logging.jl
@@ -312,6 +312,24 @@ end
     """
 end
 
+@testset "loggerstream" begin
+    # NullLogger
+    logger = NullLogger()
+    @test loggerstream(logger) == devnull
+    with_logger(logger) do
+        @test loggerstream() == devnull
+    end
+
+    # SimpleLogger
+    io = IOBuffer()
+    logger = SimpleLogger(io)
+    with_logger(logger) do
+        print(loggerstream(), "Hello,")
+        print(loggerstream(logger), " world!")
+    end
+    @test String(take!(io)) == "Hello, world!"
+end
+
 # Issue #26273
 let m = Module(:Bare26273i, false)
     Core.eval(m, :(import Base: @error))


### PR DESCRIPTION
Add generic function `loggerstream` to get the IO stream of the current logger. Sometimes you just wanna `print` something directly to the current logging stream, instead of going through `@info` etc. With this PR you can do e.g.
```julia
println(loggerstream(), "Hello, world!")
```
to print raw stuff to the loggerstream.