### PR TITLE
Quick fix for Upsilon node intersecting loop backedge

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -725,8 +725,8 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 unode = ivalundef ? UpsilonNode() : UpsilonNode(incoming_vals[slot_id(slot)])
                 typ = ivalundef ? MaybeUndef(Union{}) : slottypes[slot_id(slot)]
                 push!(node.values,
-                    NewSSAValue(insert_node!(ir, first_insert_for_bb(code, cfg, item)+1,
-                                 typ, unode).id - length(ir.stmts)))
+                    NewSSAValue(insert_node!(ir, first_insert_for_bb(code, cfg, item),
+                                 typ, unode, true).id - length(ir.stmts)))
             end
         end
         push!(visited, item)

--- a/test/core.jl
+++ b/test/core.jl
@@ -6299,3 +6299,16 @@ f_fieldtype(b) = fieldtype(b ? Int : FooFieldType, 1)
 
 @test @inferred(f_fieldtype(false)) == Int
 @test_throws BoundsError f_fieldtype(true)
+
+# Issue #28224
+@noinline make_error28224(n) = n == 5 ? error() : true
+function foo28224()
+    z = 0
+    try
+        while make_error28224(z)
+            z+=1
+        end
+    catch end
+    return z
+end
+@test foo28224() == 5


### PR DESCRIPTION
The issue is well illustrated by the MWE in #28224:
```
julia> @noinline make_error(n) =  n == 5 ? error() : true
make_error (generic function with 1 method)

julia> function foo()
           z = 0
           try
               while make_error(z)
                   z+=1
               end
           catch end
           return z
       end
foo (generic function with 1 method)

julia> foo()
0
```

In the typed code, we see that the initial Upsilon node,
marking the value at the beginning of the critical region,
is accidentally put after the loop backedge:
```
  1 ─      nothing
3 2 ─      :($(Expr(:enter, 4)))
4 3 ┄ %3 = φ (2 => 0, 3 => %6)::Int64
  │   %4 = ϒ (0)::Int64
  │        invoke Main.make_error(%3::Int64)
5 │   %6 = Base.add_int(%3, 1)::Int64
  │   %7 = ϒ (%6)::Int64
  └──      goto 3
  4 ┄ %9 = φᶜ (%4, %7)::Int64
  └──      :($(Expr(:leave, 1)))
8 5 ─      return %9
  6 ─      goto 4
```
Thus getting reset on every loop iteration.

This is a quick fix to instead insert the initial upsilon node
in the :enter's BB. That's not technically supposed to work,
since the :enter is a terminator, but it works fine for now,
since we never look at terminators again after the initial
CFG construction. Once we round trip through the statement-addressed
representation, the CFG is correct. In the future, compaction
should fix up the CFG during insertion, but we currently don't
touch the CFG at all during optimization, so we can't do that
at the moment. This solution should hold us over until then.

Fixes #28224