### PR TITLE
Fix error message in copyto!(::AbstractArray, ::Any)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -653,7 +653,7 @@ function copyto!(dest::AbstractArray, src)
     y = iterate(destiter)
     for x in src
         y === nothing &&
-            throw(ArgumentError(string("source has fewer elements than required")))
+            throw(ArgumentError(string("destination has fewer elements than required")))
         dest[y[1]] = x
         y = iterate(destiter, y[2])
     end


### PR DESCRIPTION
It seems to me that the error message is wrong, e.g.:

```
julia> copyto!([1,2], "abcd")
ERROR: ArgumentError: source has fewer elements than required
```

so I changed "source" -> "destination".