### PR TITLE
added methods of istriu and istril for Transpose and Adjoint arguments

### DIFF
--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -236,6 +236,10 @@ istril(A::LowerTriangular) = true
 istril(A::UnitLowerTriangular) = true
 istriu(A::UpperTriangular) = true
 istriu(A::UnitUpperTriangular) = true
+istril(A::Adjoint) = istriu(A.parent)
+istril(A::Transpose) = istriu(A.parent)
+istriu(A::Adjoint) = istril(A.parent)
+istriu(A::Transpose) = istril(A.parent)
 
 function tril!(A::UpperTriangular, k::Integer=0)
     n = size(A,1)

--- a/stdlib/LinearAlgebra/test/triangular.jl
+++ b/stdlib/LinearAlgebra/test/triangular.jl
@@ -99,9 +99,17 @@ for elty1 in (Float32, Float64, BigFloat, ComplexF32, ComplexF64, Complex{BigFlo
         if uplo1 == :L
             @test istril(A1)
             @test !istriu(A1)
+            @test istriu(A1')
+            @test istriu(transpose(A1))
+            @test !istril(A1')
+            @test !istril(transpose(A1))
         else
             @test istriu(A1)
             @test !istril(A1)
+            @test istril(A1')
+            @test istril(transpose(A1))
+            @test !istriu(A1')
+            @test !istriu(transpose(A1))
         end
 
         #tril/triu


### PR DESCRIPTION
Performance optimization can be achieved. The following demonstrates the difference:

```
julia> @btime istriu(qrf.R)
  2.192 μs (0 allocations: 0 bytes)
true

julia> @btime istril(transpose(qrf.R))
  3.537 ms (1 allocation: 16 bytes)
true

julia> typeof(qrf.R)  # this was a 960x960 sparse matrix with 20% fill ratio.
SparseMatrixCSC{Float64,Int64}

# the follwing uses the new method:
julia> @btime istril(qrf.R')
  2.227 μs (1 allocation: 16 bytes)
true
```
There is a performance improvement of factor 1500 (3.54 ms vs. 2.23 µs).