### PR TITLE
Add special case in verification for trailing statements after :enter

### DIFF
--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -63,6 +63,11 @@ function verify_ir(ir::IRCode)
         end
         last_end = last(block.stmts)
         terminator = ir.stmts[last_end]
+        # As a special case, we allow extra statements in the BB of an :enter
+        # statement, until we can do proper CFG manipulations during compaction.
+        if isexpr(ir.stmts[first(block.stmts)], :enter)
+            terminator = ir.stmts[first(block.stmts)]
+        end
         for p in block.preds
             p == 0 && continue
             c = count_int(idx, ir.cfg.blocks[p].succs)


### PR DESCRIPTION
In #28230, I had the compiler make use of some not-quite-legal
IR to quickfix #28224. Somewhat ironically, a simultaneous PR
I was working on made the verifier realize that this IR is illegal
and complain during bootstrap. Add a special case in verification
to allow this pattern for now.