### PR TITLE
fix #28244, segfault on `@macroexpand` with macro returning an invalid expr

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1121,7 +1121,7 @@ JL_DLLEXPORT jl_value_t *jl_macroexpand(jl_value_t *expr, jl_module_t *inmodule)
     JL_GC_PUSH1(&expr);
     expr = jl_copy_ast(expr);
     expr = jl_expand_macros(expr, inmodule, NULL, 0);
-    expr = jl_call_scm_on_ast("julia-expand-macroscope", expr, inmodule);
+    expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
     JL_GC_POP();
     return expr;
 }
@@ -1132,7 +1132,7 @@ JL_DLLEXPORT jl_value_t *jl_macroexpand1(jl_value_t *expr, jl_module_t *inmodule
     JL_GC_PUSH1(&expr);
     expr = jl_copy_ast(expr);
     expr = jl_expand_macros(expr, inmodule, NULL, 1);
-    expr = jl_call_scm_on_ast("julia-expand-macroscope", expr, inmodule);
+    expr = jl_call_scm_on_ast("jl-expand-macroscope", expr, inmodule);
     JL_GC_POP();
     return expr;
 }

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1570,3 +1570,12 @@ begin
     Val{code28044} where code28044
 end
 @test f28044(Val(identity)) == 2
+
+# issue #28244
+macro foo28244(sym)
+    x = :(bar())
+    push!(x.args, Expr(sym))
+    x
+end
+@test (@macroexpand @foo28244(kw)) == Expr(:call, GlobalRef(@__MODULE__,:bar), Expr(:kw))
+@test eval(:(@macroexpand @foo28244($(Symbol("let"))))) == Expr(:error, "malformed expression")


### PR DESCRIPTION
There are two things going on here:

1. The scope resolving code in macroexpand.scm sometimes assumes that expressions are well-formed, and you can get an implementation-defined error if they're not.
2. The entry point to this code from C did not catch lisp exceptions, leading to a segfault.

This fixes (2) entirely, and (1) in the case of `kw` expressions in case that's useful.