### PR TITLE
Allow .V to be null in emit_unionmove

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6643,3 +6643,20 @@ function foo28224()
     return z
 end
 @test foo28224() == 5
+
+# Issue #28208
+@noinline function foo28208(a::Bool, b::Bool)
+    x = (1, 2)
+    if a
+        if b
+            y = nothing
+        else
+            y = missing
+        end
+        x = y
+    end
+    x
+end
+@test isa(foo28208(false, true), Tuple)
+@test foo28208(true, false) === missing
+@test foo28208(true, true) === nothing


### PR DESCRIPTION
We generally handle the case where the .V of a split union is as small
as the active element of the union. If the active element happens to be
a ghost is thus seems reasonable for the split union to not have any storage
at all. Such a union is generated e.g. if we widen from an all-ghost split
union to one that includes sized elements, e.g. in the following example:
```
function foo()
    x = (1, 2)
    if rand() < 0.5
        if rand() < 0.5
            y = nothing
        else
            y = missing
        end
        x = y
    end
    x
end
```

Fixes #28208