### PR TITLE
fix #27529, generator exprs should turn off space-sensitive after `for`

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -1837,7 +1837,8 @@
           `(generator ,first ,@iters)))))
 
 (define (parse-comprehension s first closer)
-  (with-whitespace-newline
+  (with-bindings ((whitespace-newline #t)
+                  (space-sensitive #f))
    (let ((gen (parse-generator s first)))
      (if (not (eqv? (require-token s) closer))
          (error (string "expected \"" closer "\""))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1371,6 +1371,11 @@ end
 # issue #25994
 @test Meta.parse("[a\nfor a in b]") == Expr(:comprehension, Expr(:generator, :a, Expr(:(=), :a, :b)))
 
+# issue #27529
+let len = 10
+    @test [ i for i in 0:len -1 ] == [0:9;]
+end
+
 # Module name cannot be a reserved word.
 @test_throws ParseError Meta.parse("module module end")
 


### PR DESCRIPTION
The issue here is that `[` enters space-sensitive mode, where `len -1` is two expressions. After the `for` introducing a comprehension though, we should arguably no longer be in space-sensitive mode and should revert to more usual parsing.