### PR TITLE
use a type parameter for stream in EachLine, improves performance

### DIFF
--- a/base/io.jl
+++ b/base/io.jl
@@ -842,13 +842,12 @@ read(s::IO, T::Type) = error("The IO stream does not support reading objects of 
 
 ## high-level iterator interfaces ##
 
-struct EachLine
-    stream::IO
+struct EachLine{IOT <: IO}
+    stream::IOT
     ondone::Function
     keep::Bool
-
     EachLine(stream::IO=stdin; ondone::Function=()->nothing, keep::Bool=false) =
-        new(stream, ondone, keep)
+        new{typeof(stream)}(stream, ondone, keep)
 end
 
 """
@@ -898,9 +897,9 @@ function iterate(itr::EachLine, state=nothing)
     (readline(itr.stream, keep=itr.keep), nothing)
 end
 
-eltype(::Type{EachLine}) = String
+eltype(::Type{<:EachLine}) = String
 
-IteratorSize(::Type{EachLine}) = SizeUnknown()
+IteratorSize(::Type{<:EachLine}) = SizeUnknown()
 
 # IOStream Marking
 # Note that these functions expect that io.mark exists for


### PR DESCRIPTION
From @martinholters idea in https://github.com/JuliaLang/julia/issues/19141#issuecomment-407308746

```jl
function countchars(filename)
    io = open(filename, "r")
    c = 0
    for line in eachline(io, keep=true)
        c += length(line)
    end
    close(io)    
    c
end

@time countchars("PF00089.fasta")
```

File at https://raw.githubusercontent.com/diegozea/mitos-benchmarks/master/data/PF00089.fasta

Before:

```
0.255199 seconds (1.63 M allocations: 57.544 MiB, 0.66% gc time)
```

After:

```
0.064163 seconds (1.09 M allocations: 49.241 MiB, 5.91% gc time)
```

Julia 0.6

```
0.157770 seconds (1.63 M allocations: 99.056 MiB, 9.22% gc time)
```
