### PR TITLE
RFC Revert "Enable PCRE UTF-8 validity string checks (#26731)"

### DIFF
--- a/base/regex.jl
+++ b/base/regex.jl
@@ -4,8 +4,8 @@
 
 include("pcre.jl")
 
-const DEFAULT_COMPILER_OPTS = PCRE.UTF | PCRE.ALT_BSUX | PCRE.UCP
-const DEFAULT_MATCH_OPTS = zero(UInt32)
+const DEFAULT_COMPILER_OPTS = PCRE.UTF | PCRE.NO_UTF_CHECK | PCRE.ALT_BSUX | PCRE.UCP
+const DEFAULT_MATCH_OPTS = PCRE.NO_UTF_CHECK
 
 mutable struct Regex
     pattern::String

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -58,22 +58,6 @@ end
 # Proper unicode handling
 @test  match(r"∀∀", "∀x∀∀∀").match == "∀∀"
 
-@test_throws ErrorException match(r"a", "\xe2\x88") # 1 byte missing at end
-@test_throws ErrorException match(r"a", "\xe2\x08\x80") # byte 2 top bits not 0x80
-@test_throws ErrorException match(r"a", "\xf8\x89\x89\x80\x80") # 5-byte character is not allowed (RFC 3629)
-@test_throws ErrorException match(r"a", "\xf4\x9f\xbf\xbf") # code points greater than 0x10ffff are not defined
-@test_throws ErrorException match(r"a", "\Udfff") # code points 0xd800-0xdfff are not defined
-@test_throws ErrorException match(r"a", "\xc0\x80") #  overlong 2-byte sequence
-@test_throws ErrorException match(r"a", "\xff") # illegal byte (0xfe or 0xff)
-
-@test_throws ErrorException Regex("\xe2\x88") # 1 byte missing at end
-@test_throws ErrorException Regex("\xe2\x08\x80") # byte 2 top bits not 0x80
-@test_throws ErrorException Regex("\xf8\x89\x89\x80\x80") # 5-byte character is not allowed (RFC 3629)
-@test_throws ErrorException Regex("\xf4\x9f\xbf\xbf") # code points greater than 0x10ffff are not defined
-@test_throws ErrorException Regex("\Udfff") # code points 0xd800-0xdfff are not defined
-@test_throws ErrorException Regex("\xc0\x80") #  overlong 2-byte sequence
-@test_throws ErrorException Regex("\xff") # illegal byte (0xfe or 0xff)
-
 # 'a' flag to disable UCP
 @test match(r"\w+", "Düsseldorf").match == "Düsseldorf"
 @test match(r"\w+"a, "Düsseldorf").match == "D"


### PR DESCRIPTION
#26731 came with performance regression which severity I think was not fully realized until post merge.

Some examples are:

* The following code went from 0.5 seconds to ~30 minutes https://github.com/JuliaCI/BaseBenchmarks.jl/blob/4362420a20b4e912f9b619819933127976a1097d/src/problem/SpellCheck.jl#L26-L33 (ref https://github.com/JuliaCI/BaseBenchmarks.jl/issues/202).
* https://github.com/JuliaLang/julia/pull/27030#issuecomment-398673598:
  ```
  julia> f(seq) = search(seq, r">.*\n|\n", 1)
  f (generic function with 1 method)
  
  # 0.6
  julia> @btime f(seq)
  100.660 ns (1 allocation: 32 bytes)
  ```

  ```
  julia> f(seq) = findnext(r">.*\n|\n",seq,1)
  f (generic function with 1 method)

  # 0.7
  julia> @btime f(seq)
    60.167 μs (1 allocation: 32 bytes)
  ```

These regressions are of the type "this used to go instantly" -> "this never finishes in a reasonable time".
Since the PR had possible performance implications that were unknown at the time, I feel the cost/benefit should be considered again.

@nanosoldier `runbenchmarks("shootout" || "string" || "problem", vs=":master")`