### PR TITLE
deprecate `:body` expression head

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -329,7 +329,7 @@ end
 
 remove_linenums!(ex) = ex
 function remove_linenums!(ex::Expr)
-    if ex.head === :body || ex.head === :block || ex.head === :quote
+    if ex.head === :block || ex.head === :quote
         # remove line number expressions from metadata (not argument literal or inert) position
         filter!(ex.args) do x
             isa(x, Expr) && x.head === :line && return false

--- a/base/show.jl
+++ b/base/show.jl
@@ -910,7 +910,7 @@ function show_block(io::IO, head, args::Vector, body, indent::Int)
     end
 
     ind = head === :module || head === :baremodule ? indent : indent + indent_width
-    exs = (is_expr(body, :block) || is_expr(body, :body)) ? body.args : Any[body]
+    exs = is_expr(body, :block) ? body.args : Any[body]
     for ex in exs
         print(io, '\n', " "^ind)
         show_unquoted(io, ex, ind, -1)
@@ -1347,7 +1347,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         end
         print(io, "end")
 
-    elseif head === :block || head === :body
+    elseif head === :block
         show_block(io, "begin", ex, indent)
         print(io, "end")
 
@@ -1573,7 +1573,7 @@ function show(io::IO, src::CodeInfo)
         IRShow.show_ir(lambda_io, src)
     else
         # this is a CodeInfo that has not been used as a method yet, so its locations are still LineNumberNodes
-        body = Expr(:body)
+        body = Expr(:block)
         body.args = src.code
         show(lambda_io, body)
     end

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -805,8 +805,6 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         }
         else {
             char sep = ' ';
-            if (e->head == body_sym)
-                sep = '\n';
             n += jl_printf(out, "Expr(:%s", jl_symbol_name(e->head));
             size_t i, len = jl_array_len(e->args);
             for (i = 0; i < len; i++) {

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -52,15 +52,6 @@ function gen_call_with_extracted_types(__module__, fcn, ex0)
             exret = Expr(:call, fcn, esc(ex.args[1]),
                          Expr(:call, typesof, map(esc, ex.args[2:end])...))
         end
-    elseif ex.head == :body
-        a1 = ex.args[1]
-        if isa(a1, Expr) && a1.head == :call
-            a11 = a1.args[1]
-            if a11 == :setindex!
-                exret = Expr(:call, fcn, a11,
-                             Expr(:call, typesof, map(esc, a1.args[2:end])...))
-            end
-        end
     end
     if ex.head == :thunk || exret.head == :none
         exret = Expr(:call, :error, "expression is not a function call, "

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -2258,14 +2258,7 @@ function run_interface(terminal::TextTerminal, m::ModalInterface, s::MIState=ini
             @static if Sys.isunix(); ccall(:jl_repl_raise_sigtstp, Cint, ()); end
             buf, ok, suspend = prompt!(terminal, m, s)
         end
-        Core.eval(Main,
-            Expr(:body,
-                Expr(:return,
-                     Expr(:call,
-                          QuoteNode(mode(state(s)).on_done),
-                          QuoteNode(s),
-                          QuoteNode(buf),
-                          QuoteNode(ok)))))
+        Base.invokelatest(mode(state(s)).on_done, s, buf, ok)
     end
 end
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -3764,7 +3764,7 @@ let
 end
 
 # issue #14323
-@test eval(Expr(:body, :(1))) === 1
+@test eval(Expr(:block, :(1))) === 1
 
 # issue #14339
 f14339(x::T, y::T) where {T<:Union{}} = 0

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -21,7 +21,7 @@ Helper to test that every slot is in range after inlining.
 function test_inlined_symbols(func, argtypes)
     src, rettype = code_typed(func, argtypes)[1]
     nl = length(src.slotnames)
-    ast = Expr(:body)
+    ast = Expr(:block)
     ast.args = src.code
     walk(ast) do e
         if isa(e, Core.Slot)


### PR DESCRIPTION
This was used rarely and inconsistently, and is now redundant.