### PR TITLE
still optimize top-level expressions with loops and `global` decls

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5294,6 +5294,11 @@ static std::unique_ptr<Module> emit_function(
         if (lam->def.method->file != empty_sym)
             filename = jl_symbol_name(lam->def.method->file);
     }
+    else if (jl_array_len(src->linetable) > 0) {
+        jl_value_t *locinfo = jl_array_ptr_ref(src->linetable, 0);
+        filename = jl_symbol_name((jl_sym_t*)jl_fieldref_noalloc(locinfo, 2));
+        toplineno = jl_unbox_long(jl_fieldref(locinfo, 3));
+    }
     ctx.file = filename;
     // jl_printf(JL_STDERR, "\n*** compiling %s at %s:%d\n\n",
     //           jl_symbol_name(ctx.name), filename.str().c_str(), toplineno);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -330,7 +330,12 @@ static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs)
     if (head == toplevel_sym || head == thunk_sym) {
         return;
     }
-    else if (head == global_sym || head == const_sym || head == copyast_sym) {
+    else if (head == global_sym) {
+        // this could be considered has_defs, but loops that assign to globals
+        // might still need to be optimized.
+        return;
+    }
+    else if (head == const_sym || head == copyast_sym) {
         // Note: `copyast` is included here since it indicates the presence of
         // `quote` and probably `eval`.
         *has_defs = 1;


### PR DESCRIPTION
In an effort to reduce load times, we stopped compiling top-level expressions that contain `global` declarations. However, that conflicts badly with the recommendation in this variable scope deprecation:
```
julia> n = 0;

julia> for i = 1:2
         n += 1
       end
┌ Warning: Deprecated syntax `implicit assignment to global variable `n``.
│ Use `global n` instead.
└ @ none:0
```

If `n` is replaced with `global n`, you get really bad performance. This fixes it so that writing `global n += 1` in the loop is only as slow as it was before, instead of even slower.