### PR TITLE
fix #27907, inference not detecting some cycles during constant prop

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -252,7 +252,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
                         parent = parent::InferenceState
                         parent_method2 = parent.src.method_for_inference_limit_heuristics # limit only if user token match
                         parent_method2 isa Method || (parent_method2 = nothing) # Union{Method, Nothing}
-                        if parent.cached && parent.linfo.def === sv.linfo.def && sv_method2 === parent_method2
+                        if (parent.cached || parent.limited) && parent.linfo.def === sv.linfo.def && sv_method2 === parent_method2
                             topmost = infstate
                             edgecycle = true
                         end

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -486,7 +486,7 @@ function typeinf_edge(method::Method, @nospecialize(atypes), sparams::SimpleVect
             code.inInference = false
             return Any, nothing
         end
-        if caller.cached # don't involve uncached functions in cycle resolution
+        if caller.cached || caller.limited # don't involve uncached functions in cycle resolution
             frame.parent = caller
         end
         typeinf(frame)

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -277,17 +277,29 @@ function _isequal(t1::Any16, t2::Any16)
     return true
 end
 
-==(t1::Tuple, t2::Tuple) = (length(t1) == length(t2)) && _eq(t1, t2, false)
-_eq(t1::Tuple{}, t2::Tuple{}, anymissing) = anymissing ? missing : true
-function _eq(t1::Tuple, t2::Tuple, anymissing)
+==(t1::Tuple, t2::Tuple) = (length(t1) == length(t2)) && _eq(t1, t2)
+_eq(t1::Tuple{}, t2::Tuple{}) = true
+_eq_missing(t1::Tuple{}, t2::Tuple{}) = missing
+function _eq(t1::Tuple, t2::Tuple)
+    eq = t1[1] == t2[1]
+    if eq === false
+        return false
+    elseif ismissing(eq)
+        return _eq_missing(tail(t1), tail(t2))
+    else
+        return _eq(tail(t1), tail(t2))
+    end
+end
+function _eq_missing(t1::Tuple, t2::Tuple)
     eq = t1[1] == t2[1]
     if eq === false
         return false
     else
-        return _eq(tail(t1), tail(t2), anymissing | ismissing(eq))
+        return _eq_missing(tail(t1), tail(t2))
     end
 end
-function _eq(t1::Any16, t2::Any16, anymissing)
+function _eq(t1::Any16, t2::Any16)
+    anymissing = false
     for i = 1:length(t1)
         eq = (t1[i] == t2[i])
         if ismissing(eq)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1772,7 +1772,8 @@ Base.iterate(i::Iterator27434) = i.x, Val(1)
 Base.iterate(i::Iterator27434, ::Val{1}) = i.y, Val(2)
 Base.iterate(i::Iterator27434, ::Val{2}) = i.z, Val(3)
 Base.iterate(::Iterator27434, ::Any) = nothing
-@test @inferred splat27434(Iterator27434(1, 2, 3)) == (1, 2, 3)
+@test @inferred(splat27434(Iterator27434(1, 2, 3))) == (1, 2, 3)
+@test @inferred((1, 2, 3) == (1, 2, 3))
 @test Core.Compiler.return_type(splat27434, Tuple{typeof(Iterators.repeated(1))}) == Union{}
 
 # issue #27078
@@ -1792,3 +1793,16 @@ test28079(p, n, m) = h28079(Foo28079(), Base.pointerref, p, n, m)
 cinfo_unoptimized = code_typed(test28079, (Ptr{Float32}, Int, Int); optimize=false)[].first
 cinfo_optimized = code_typed(test28079, (Ptr{Float32}, Int, Int); optimize=true)[].first
 @test cinfo_unoptimized.ssavaluetypes[end-1] === cinfo_optimized.ssavaluetypes[end-1] === Float32
+
+# issue #27907
+ig27907(T::Type, N::Integer, offsets...) = ig27907(T, T, N, offsets...)
+
+function ig27907(::Type{T}, ::Type, N::Integer, offsets...) where {T}
+    if length(offsets) < N
+        return typeof(ig27907(T, N, offsets..., 0))
+    else
+        return 0
+    end
+end
+
+@test ig27907(Int, Int, 1, 0) == 0


### PR DESCRIPTION
With help from @vtjnash .

I tried additionally replacing `parent.cached` with `parent.cached || parent.limited` in `abstract_call_method`, but that caused sub-optimal inference of `==` on tuples with more than 2 elements.