### PR TITLE
make allunique work for StepRange{Date,Day}

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -283,6 +283,7 @@ end
 allunique(::Set) = true
 
 allunique(r::AbstractRange{T}) where {T} = (step(r) != zero(T)) || (length(r) <= 1)
+allunique(r::StepRange{T,S}) where {T,S} = (step(r) != zero(S)) || (length(r) <= 1)
 
 filter!(f, s::Set) = unsafe_filter!(f, s)
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -4,6 +4,8 @@
 isdefined(Main, :TestHelpers) || @eval Main include("TestHelpers.jl")
 using .Main.TestHelpers.OAs
 
+using Dates
+
 @testset "Construction, collect" begin
     @test Set([1,2,3]) isa Set{Int}
     @test Set{Int}([3]) isa Set{Int}
@@ -392,6 +394,8 @@ end
     @test allunique(4.0:0.3:7.0)
     @test allunique(4:-1:5)       # empty range
     @test allunique(7:-1:1)       # negative step
+    @test allunique(Date(2018, 8, 7):Day(1):Date(2018, 8, 11))  # JuliaCon 2018
+    @test allunique(DateTime(2018, 8, 7):Hour(1):DateTime(2018, 8, 11))
 end
 @testset "filter(f, ::$S)" for S = (Set, BitSet)
     s = S([1,2,3,4])


### PR DESCRIPTION
I got this on master
```julia
julia> allunique(Date(2011, 1, 1):Day(1):Date(2011, 2, 1))
ERROR: MethodError: no method matching zero(::Type{Date})
Closest candidates are:
  zero(::Type{LibGit2.GitHash}) at /home/iblis/git/julia/usr/share/julia/stdlib/v0.7/LibGit2/src/oid.jl:220
  zero(::Type{OldPkg.Resolve.VersionWeights.VWPreBuildItem}) at /home/iblis/git/julia/usr/share/julia/stdlib/v0.7/OldPkg/src/resolve/versionweight.
jl:80
  zero(::Type{OldPkg.Resolve.VersionWeights.VWPreBuild}) at /home/iblis/git/julia/usr/share/julia/stdlib/v0.7/OldPkg/src/resolve/versionweight.jl:1
16
  ...
Stacktrace:
 [1] allunique(::StepRange{Date,Day}) at ./set.jl:285
 [2] top-level scope at none:0
```