### PR TITLE
Fixes an undef compilation warning

### DIFF
--- a/deps/patches/llvm-D44892-Perf-integration.patch
+++ b/deps/patches/llvm-D44892-Perf-integration.patch
@@ -87,7 +87,7 @@ index ff7840f00a4..1cc2c423a8b 100644
    }
  #endif // USE_OPROFILE
 
-+#if LLVM_USE_PERF
++#ifdef LLVM_USE_PERF
 +  static JITEventListener *createPerfJITEventListener();
 +#else
 +  static JITEventListener *createPerfJITEventListener()


### PR DESCRIPTION
You may have noticed lately a warning during compilation of Julia master introduced by #27466 
```
In file included from /home/rodia/dev/julia/src/jitlayers.h:19,
                 from /home/rodia/dev/julia/src/codegen.cpp:107:
/home/rodia/dev/julia/usr/include/llvm/ExecutionEngine/JITEventListener.h:118:5: warning: 
"LLVM_USE_PERF" is not defined, evaluates to 0 [-Wundef]
 #if LLVM_USE_PERF
     ^~~~~~~~~~~~~
    CC src/disasm.o
In file included from /home/rodia/dev/julia/src/jitlayers.h:19,
                 from /home/rodia/dev/julia/src/jitlayers.cpp:69:
/home/rodia/dev/julia/usr/include/llvm/ExecutionEngine/JITEventListener.h:118:5: warning: 
"LLVM_USE_PERF" is not defined, evaluates to 0 [-Wundef]
 #if LLVM_USE_PERF
     ^~~~~~~~~~~~~
In file included from /home/rodia/dev/julia/src/disasm.cpp:62:
/home/rodia/dev/julia/usr/include/llvm/ExecutionEngine/JITEventListener.h:118:5: warning: 
"LLVM_USE_PERF" is not defined, evaluates to 0 [-Wundef]
 #if LLVM_USE_PERF
     ^~~~~~~~~~~~~
```
This PR fixes it.