### PR TITLE
enable abstract interpreter to constant prop even if method source is generated

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -140,7 +140,7 @@ function abstract_call_method_with_const_args(@nospecialize(f), argtypes::Vector
     code === nothing && return Any
     code = code::MethodInstance
     # decide if it's likely to be worthwhile
-    declared_inline = isdefined(method, :source) && ccall(:jl_ast_flag_inlineable, Bool, (Any,), method.source)
+    declared_inline = isdefined(method, :source) ? ccall(:jl_ast_flag_inlineable, Bool, (Any,), method.source) : true
     cache_inlineable = declared_inline
     if isdefined(code, :inferred) && !cache_inlineable
         cache_inf = code.inferred


### PR DESCRIPTION
I made this change entirely because @vtjnash dreamed that he had already made me make this change, and was surprised to find that this was not the case in his wakeful reality