### PR TITLE
Propagate constant calls to new!

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -912,13 +912,11 @@ function abstract_eval(@nospecialize(e), vtypes::VarTable, sv::InferenceState)
                 t = Bottom
             end
             isconst &= ae isa Const
+            isconst = isconst && (ae.val isa fieldtype(t, i - 1))
         end
         if isconst
             flds = Any[ argtypes[i].val for i = 2:length(argtypes) ]
-            try
-                t = Const(ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), t, flds, length(flds)))
-            catch ex
-            end
+            t = Const(ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), t, flds, length(flds)))
         end
     elseif e.head === :&
         abstract_eval(e.args[1], vtypes, sv)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -932,6 +932,13 @@ f21771(::Val{U}) where {U} = Tuple{g21771(U)}
 @test @inferred(f21771(Val{Union{}}())) === Tuple{Union{}}
 @test @inferred(f21771(Val{Integer}())) === Tuple{Integer}
 
+# PR #28284, check that constants propagate through calls to new
+struct t28284
+  x::Int
+end
+f28284() = Val(t28284(1))
+@inferred f28284()
+
 # missing method should be inferred as Union{}, ref https://github.com/JuliaLang/julia/issues/20033#issuecomment-282228948
 @test Base.return_types(f -> f(1), (typeof((x::String) -> x),)) == Any[Union{}]
 


### PR DESCRIPTION
Please infer that calls to new with constant arguments are constant.

A MWE. Without this feature:

```julia
julia> fizzle(x) = Val(Base.OneTo(3))
fizzle (generic function with 1 method)

julia> @code_typed fizzle(1)
CodeInfo(
1 1 ─      Base.ifelse(false, 0, 3)     │╻╷╷ Type
  │   %2 = new(Base.OneTo{Int64}, 3)::Base.OneTo{Int64}     ││┃   Type
  │   %3 = invoke Main.Val(%2::Base.OneTo{Int64})::Val{_1} where _1     │
  └──      return %3     │
) => Val{_1} where _1
```

With this feature:
```julia
julia> fizzle(x) = Val(Base.OneTo(3))
fizzle (generic function with 1 method)

julia> @code_typed fizzle(1)
CodeInfo(
1 1 ─     Base.ifelse(false, 0, 3)                                        │╻╷╷ Type
  └──     return :($(QuoteNode(Val{Base.OneTo(3)}())))                    │
) => Val{Base.OneTo(3)}
```