### PR TITLE
RFC: rename UVError to IOError

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -395,6 +395,8 @@ end
 @deprecate readstring(filename::AbstractString) read(filename, String)
 @deprecate readstring(cmd::AbstractCmd) read(cmd, String)
 
+@deprecate_binding UVError IOError false
+
 # issue #11310
 # remove "parametric method syntax" deprecation in julia-syntax.scm
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -191,7 +191,7 @@ retry(f, delays=fill(5.0, 3))
 retry(f, delays=rand(5:10, 2))
 retry(f, delays=Base.ExponentialBackOff(n=3, first_delay=5, max_delay=1000))
 retry(http_get, check=(s,e)->e.status == "503")(url)
-retry(read, check=(s,e)->isa(e, UVError))(io, 128; all=false)
+retry(read, check=(s,e)->isa(e, IOError))(io, 128; all=false)
 ```
 """
 function retry(f::Function;  delays=ExponentialBackOff(), check=nothing)

--- a/base/event.jl
+++ b/base/event.jl
@@ -295,7 +295,7 @@ mutable struct AsyncCondition
             #TODO: this codepath is currently not tested
             Libc.free(this.handle)
             this.handle = C_NULL
-            throw(UVError("uv_async_init", err))
+            throw(_UVError("uv_async_init", err))
         end
         return this
     end
@@ -353,7 +353,7 @@ mutable struct Timer
             #TODO: this codepath is currently not tested
             Libc.free(this.handle)
             this.handle = C_NULL
-            throw(UVError("uv_timer_init", err))
+            throw(_UVError("uv_timer_init", err))
         end
 
         associate_julia_struct(this.handle, this)

--- a/base/file.jl
+++ b/base/file.jl
@@ -236,7 +236,7 @@ julia> rm("my", recursive=true)
 julia> rm("this_file_does_not_exist", force=true)
 
 julia> rm("this_file_does_not_exist")
-ERROR: unlink: no such file or directory (ENOENT)
+ERROR: IOError: unlink: no such file or directory (ENOENT)
 Stacktrace:
 [...]
 ```
@@ -252,7 +252,7 @@ function rm(path::AbstractString; force::Bool=false, recursive::Bool=false)
             end
             unlink(path)
         catch err
-            if force && isa(err, UVError) && err.code==Base.UV_ENOENT
+            if force && isa(err, IOError) && err.code==Base.UV_ENOENT
                 return
             end
             rethrow()

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -39,7 +39,7 @@ export File,
        S_IROTH, S_IWOTH, S_IXOTH, S_IRWXO
 
 import .Base:
-    UVError, _sizeof_uv_fs, check_open, close, eof, eventloop, fd, isopen,
+    IOError, _UVError, _sizeof_uv_fs, check_open, close, eof, eventloop, fd, isopen,
     bytesavailable, position, read, read!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error,
     rawhandle, OS_HANDLE, INVALID_OS_HANDLE

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -100,7 +100,7 @@ end
 function current_project()
     dir = try pwd()
     catch err
-        err isa UVError || rethrow(err)
+        err isa IOError || rethrow(err)
         return nothing
     end
     return current_project(dir)

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -65,20 +65,24 @@ end
 
 ## Libuv error handling ##
 
-struct UVError <: Exception
-    prefix::AbstractString
+struct IOError <: Exception
+    msg::AbstractString
     code::Int32
-    UVError(p::AbstractString, code::Integer) = new(p,code)
+    IOError(msg::AbstractString, code::Integer) = new(msg, code)
+end
+
+showerror(io::IO, e::IOError) = print(io, "IOError: ", e.msg)
+
+function _UVError(pfx::AbstractString, code::Integer)
+    code = Int32(code)
+    IOError(string(pfx, ": ", struverror(code), " (", uverrorname(code), ")"), code)
 end
 
 struverror(err::Int32) = unsafe_string(ccall(:uv_strerror,Cstring,(Int32,),err))
-struverror(err::UVError) = struverror(err.code)
 uverrorname(err::Int32) = unsafe_string(ccall(:uv_err_name,Cstring,(Int32,),err))
-uverrorname(err::UVError) = uverrorname(err.code)
 
 uv_error(prefix::Symbol, c::Integer) = uv_error(string(prefix),c)
-uv_error(prefix::AbstractString, c::Integer) = c < 0 ? throw(UVError(prefix,c)) : nothing
-show(io::IO, e::UVError) = print(io, e.prefix*": "*struverror(e)*" ("*uverrorname(e)*")")
+uv_error(prefix::AbstractString, c::Integer) = c < 0 ? throw(_UVError(prefix,c)) : nothing
 
 ## event loop ##
 

--- a/base/process.jl
+++ b/base/process.jl
@@ -367,7 +367,7 @@ function _jl_spawn(file, argv, cmd::Cmd, stdio)
         uv_jl_return_spawn::Ptr{Cvoid})
     if error != 0
         ccall(:jl_forceclose_uv, Cvoid, (Ptr{Cvoid},), proc)
-        throw(UVError("could not spawn " * string(cmd), error))
+        throw(_UVError("could not spawn " * string(cmd), error))
     end
     return proc
 end
@@ -687,7 +687,7 @@ function test_success(proc::Process)
     @assert process_exited(proc)
     if proc.exitcode < 0
         #TODO: this codepath is not currently tested
-        throw(UVError("could not start process $(string(proc.cmd))", proc.exitcode))
+        throw(_UVError("could not start process $(string(proc.cmd))", proc.exitcode))
     end
     proc.exitcode == 0 && (proc.termsignal == 0 || proc.termsignal == SIGPIPE)
 end
@@ -743,7 +743,7 @@ function kill(p::Process, signum::Integer)
         @assert p.handle != C_NULL
         err = ccall(:uv_process_kill, Int32, (Ptr{Cvoid}, Int32), p.handle, signum)
         if err != 0 && err != UV_ESRCH
-            throw(UVError("kill", err))
+            throw(_UVError("kill", err))
         end
     end
 end

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -65,7 +65,7 @@ macro stat_call(sym, arg1type, arg)
     return quote
         stat_buf = zeros(UInt8, ccall(:jl_sizeof_stat, Int32, ()))
         r = ccall($(Expr(:quote, sym)), Int32, ($(esc(arg1type)), Ptr{UInt8}), $(esc(arg)), stat_buf)
-        r == 0 || r == Base.UV_ENOENT || r == Base.UV_ENOTDIR || throw(UVError("stat", r))
+        r == 0 || r == Base.UV_ENOENT || r == Base.UV_ENOTDIR || throw(_UVError("stat", r))
         st = StatStruct(stat_buf)
         if ispath(st) != (r == 0)
             error("stat returned zero type for a valid path")

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -490,7 +490,7 @@ function uv_readcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid})
                 # This is a fatal connection error. Shutdown requests as per the usual
                 # close function won't work and libuv will fail with an assertion failure
                 ccall(:jl_forceclose_uv, Cvoid, (Ptr{Cvoid},), stream)
-                notify_error(stream.readnotify, UVError("read", nread))
+                notify_error(stream.readnotify, _UVError("read", nread))
             end
         else
             notify_filled(stream.buffer, nread)
@@ -882,7 +882,7 @@ function uv_writecb_task(req::Ptr{Cvoid}, status::Cint)
         uv_req_set_data(req, C_NULL) # let the Task know we got the writecb
         t = unsafe_pointer_to_objref(d)::Task
         if status < 0
-            err = UVError("write", status)
+            err = _UVError("write", status)
             schedule(t, err, error=true)
         else
             schedule(t)

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -20,8 +20,8 @@ export
     PollingFileWatcher,
     FDWatcher
 
-import Base: @handle_as, wait, close, eventloop, notify_error, stream_wait,
-    _sizeof_uv_poll, _sizeof_uv_fs_poll, _sizeof_uv_fs_event, _uv_hook_close, uv_error, UVError,
+import Base: @handle_as, wait, close, eventloop, notify_error, stream_wait, IOError,
+    _sizeof_uv_poll, _sizeof_uv_fs_poll, _sizeof_uv_fs_event, _uv_hook_close, uv_error, _UVError,
     associate_julia_struct, disassociate_julia_struct, isreadable, iswritable, |
 import Base.Filesystem.StatStruct
 if Sys.iswindows()
@@ -85,7 +85,7 @@ mutable struct FileMonitor
         err = ccall(:uv_fs_event_init, Cint, (Ptr{Cvoid}, Ptr{Cvoid}), eventloop(), handle)
         if err != 0
             Libc.free(handle)
-            throw(UVError("FileMonitor", err))
+            throw(_UVError("FileMonitor", err))
         end
         finalizer(uvfinalize, this)
         return this
@@ -95,7 +95,7 @@ end
 
 mutable struct FolderMonitor
     handle::Ptr{Cvoid}
-    notify::Channel{Any} # eltype = Union{Pair{String, FileEvent}, UVError}
+    notify::Channel{Any} # eltype = Union{Pair{String, FileEvent}, IOError}
     open::Bool
     FolderMonitor(folder::AbstractString) = FolderMonitor(String(folder))
     function FolderMonitor(folder::String)
@@ -105,7 +105,7 @@ mutable struct FolderMonitor
         err = ccall(:uv_fs_event_init, Cint, (Ptr{Cvoid}, Ptr{Cvoid}), eventloop(), handle)
         if err != 0
             Libc.free(handle)
-            throw(UVError("FolderMonitor", err))
+            throw(_UVError("FolderMonitor", err))
         end
         this.open = true
         finalizer(uvfinalize, this)
@@ -132,7 +132,7 @@ mutable struct PollingFileWatcher
         err = ccall(:uv_fs_poll_init, Int32, (Ptr{Cvoid}, Ptr{Cvoid}), eventloop(), handle)
         if err != 0
             Libc.free(handle)
-            throw(UVError("PollingFileWatcher", err))
+            throw(_UVError("PollingFileWatcher", err))
         end
         finalizer(uvfinalize, this)
         return this
@@ -180,7 +180,7 @@ mutable struct _FDWatcher
                 err = ccall(:uv_poll_init, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, RawFD), eventloop(), handle, fd)
                 if err != 0
                     Libc.free(handle)
-                    throw(UVError("FDWatcher", err))
+                    throw(_UVError("FDWatcher", err))
                 end
                 finalizer(uvfinalize, this)
                 FDWatchers[fdnum] = this
@@ -229,7 +229,7 @@ mutable struct _FDWatcher
                                                eventloop(), handle,    fd)
             if err != 0
                 Libc.free(handle)
-                throw(UVError("FDWatcher", err))
+                throw(_UVError("FDWatcher", err))
             end
             finalizer(uvfinalize, this)
             return this
@@ -314,7 +314,7 @@ end
 function uv_fseventscb_file(handle::Ptr{Cvoid}, filename::Ptr, events::Int32, status::Int32)
     t = @handle_as handle FileMonitor
     if status != 0
-        notify_error(t.notify, UVError("FileMonitor", status))
+        notify_error(t.notify, _UVError("FileMonitor", status))
     else
         t.events |= events
         notify(t.notify, FileEvent(events))
@@ -325,7 +325,7 @@ end
 function uv_fseventscb_folder(handle::Ptr{Cvoid}, filename::Ptr, events::Int32, status::Int32)
     t = @handle_as handle FolderMonitor
     if status != 0
-        put!(t.notify, UVError("FolderMonitor", status))
+        put!(t.notify, _UVError("FolderMonitor", status))
     else
         fname = (filename == C_NULL) ? "" : unsafe_string(convert(Cstring, filename))
         put!(t.notify, fname => FileEvent(events))
@@ -336,7 +336,7 @@ end
 function uv_pollcb(handle::Ptr{Cvoid}, status::Int32, events::Int32)
     t = @handle_as handle _FDWatcher
     if status != 0
-        notify_error(t.notify, UVError("FDWatcher", status))
+        notify_error(t.notify, _UVError("FDWatcher", status))
     else
         t.events |= events
         if t.active[1] || t.active[2]
@@ -491,7 +491,7 @@ function wait(pfw::PollingFileWatcher)
     if pfw.handle == C_NULL
         return prevstat, EOFError()
     elseif pfw.curr_error != 0
-        return prevstat, UVError("PollingFileWatcher", pfw.curr_error)
+        return prevstat, _UVError("PollingFileWatcher", pfw.curr_error)
     else
         return prevstat, pfw.curr_stat
     end
@@ -685,7 +685,7 @@ function poll_file(s::AbstractString, interval_seconds::Real=5.007, timeout_s::R
             @async (sleep(timeout_s); close(pfw))
         end
         statdiff = wait(pfw)
-        if isa(statdiff[2], UVError)
+        if isa(statdiff[2], IOError)
             # file didn't initially exist, continue watching for it to be created (or the error to change)
             statdiff = wait(pfw)
         end

--- a/stdlib/FileWatching/test/runtests.jl
+++ b/stdlib/FileWatching/test/runtests.jl
@@ -421,9 +421,9 @@ let changes = []
     @test all(x -> (isa(x, Pair) && x[1] == F_PATH && (x[2].changed ⊻ x[2].renamed)), changes) || changes
 end
 
-@test_throws(Base.UVError("FileMonitor (start)", Base.UV_ENOENT),
+@test_throws(Base._UVError("FileMonitor (start)", Base.UV_ENOENT),
              watch_file("____nonexistent_file", 10))
-@test_throws(Base.UVError("FolderMonitor (start)", Base.UV_ENOENT),
+@test_throws(Base._UVError("FolderMonitor (start)", Base.UV_ENOENT),
              watch_folder("____nonexistent_file", 10))
 @test(@elapsed(
     @test(poll_file("____nonexistent_file", 1, 3.1) ===

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -59,7 +59,7 @@ close(s); finalize(m); m=nothing; GC.gc()
 
 s = open(file, "r")
 close(s)
-@test_throws Base.UVError Mmap.mmap(s) # closed IOStream
+@test_throws Base.IOError Mmap.mmap(s) # closed IOStream
 @test_throws ArgumentError Mmap.mmap(s,Vector{UInt8},12,0) # closed IOStream
 @test_throws SystemError Mmap.mmap("")
 

--- a/stdlib/Sockets/src/PipeServer.jl
+++ b/stdlib/Sockets/src/PipeServer.jl
@@ -52,7 +52,7 @@ function bind(server::PipeServer, name::AbstractString)
     if err != 0
         if err != UV_EADDRINUSE && err != UV_EACCES
             #TODO: this codepath is currently not tested
-            throw(UVError("bind",err))
+            throw(_UVError("bind",err))
         else
             return false
         end

--- a/stdlib/Sockets/src/Sockets.jl
+++ b/stdlib/Sockets/src/Sockets.jl
@@ -27,7 +27,7 @@ export
 import Base: isless, show, print, parse, bind, convert, isreadable, iswritable, alloc_buf_hook, _uv_hook_close
 
 using Base: LibuvStream, LibuvServer, PipeEndpoint, @handle_as, uv_error, associate_julia_struct, uvfinalize,
-    notify_error, stream_wait, uv_req_data, uv_req_set_data, preserve_handle, unpreserve_handle, UVError,
+    notify_error, stream_wait, uv_req_data, uv_req_set_data, preserve_handle, unpreserve_handle, _UVError, IOError,
     eventloop, StatusUninit, StatusInit, StatusConnecting, StatusOpen, StatusClosing, StatusClosed, StatusActive,
     uv_status_string, check_open, wait_connected,
     UV_EINVAL, UV_ENOMEM, UV_ENOBUFS, UV_EAGAIN, UV_ECONNABORTED, UV_EADDRINUSE, UV_EACCES, UV_EADDRNOTAVAIL,
@@ -229,7 +229,7 @@ function bind(sock::Union{TCPServer, UDPSocket}, host::IPAddr, port::Integer; ip
     if err < 0
         if err != UV_EADDRINUSE && err != UV_EACCES && err != UV_EADDRNOTAVAIL
             #TODO: this codepath is not currently tested
-            throw(UVError("bind", err))
+            throw(_UVError("bind", err))
         else
             return false
         end
@@ -306,7 +306,7 @@ function uv_recvcb(handle::Ptr{Cvoid}, nread::Cssize_t, buf::Ptr{Cvoid}, addr::P
     sock = @handle_as handle UDPSocket
     if nread < 0
         Libc.free(buf_addr)
-        notify_error(sock.recvnotify, UVError("recv", nread))
+        notify_error(sock.recvnotify, _UVError("recv", nread))
     elseif flags & UV_UDP_PARTIAL > 0
         Libc.free(buf_addr)
         notify_error(sock.recvnotify, "Partial message received")
@@ -359,7 +359,7 @@ end
 function uv_sendcb(handle::Ptr{Cvoid}, status::Cint)
     sock = @handle_as handle UDPSocket
     if status < 0
-        notify_error(sock.sendnotify, UVError("UDP send failed", status))
+        notify_error(sock.sendnotify, _UVError("UDP send failed", status))
     end
     notify(sock.sendnotify)
     Libc.free(handle)
@@ -378,7 +378,7 @@ function uv_connectcb(conn::Ptr{Cvoid}, status::Cint)
         notify(sock.connectnotify)
     else
         ccall(:jl_forceclose_uv, Cvoid, (Ptr{Cvoid},), hand)
-        err = UVError("connect", status)
+        err = _UVError("connect", status)
         notify_error(sock.connectnotify, err)
     end
     Libc.free(conn)
@@ -497,8 +497,7 @@ function uv_connectioncb(stream::Ptr{Cvoid}, status::Cint)
     if status >= 0
         notify(sock.connectnotify)
     else
-        err = UVError("connection", status)
-        notify_error(sock.connectnotify, err)
+        notify_error(sock.connectnotify, _UVError("connection", status))
     end
     nothing
 end

--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -16,7 +16,7 @@ function uv_getaddrinfocb(req::Ptr{Cvoid}, status::Cint, addrinfo::Ptr{Cvoid})
         t = unsafe_pointer_to_objref(data)::Task
         uv_req_set_data(req, C_NULL)
         if status != 0 || addrinfo == C_NULL
-            schedule(t, UVError("getaddrinfocb", status))
+            schedule(t, _UVError("getaddrinfocb", status))
         else
             freeaddrinfo = addrinfo
             addrs = IPAddr[]
@@ -88,7 +88,7 @@ function getalladdrinfo(host::String)
         end
         unpreserve_handle(ct)
     end
-    if isa(r, UVError)
+    if isa(r, IOError)
         code = r.code
         if code in (UV_EAI_ADDRFAMILY, UV_EAI_AGAIN, UV_EAI_BADFLAGS,
                     UV_EAI_BADHINTS, UV_EAI_CANCELED, UV_EAI_FAIL,
@@ -99,7 +99,7 @@ function getalladdrinfo(host::String)
         elseif code == UV_EAI_MEMORY
             throw(OutOfMemoryError())
         else
-            throw(UVError("getaddrinfo", code))
+            throw(_UVError("getaddrinfo", code))
         end
     end
     return r::Vector{IPAddr}
@@ -130,7 +130,7 @@ function uv_getnameinfocb(req::Ptr{Cvoid}, status::Cint, hostname::Cstring, serv
         t = unsafe_pointer_to_objref(data)::Task
         uv_req_set_data(req, C_NULL)
         if status != 0
-            schedule(t, UVError("getnameinfocb", status))
+            schedule(t, _UVError("getnameinfocb", status))
         else
             schedule(t, unsafe_string(hostname))
         end
@@ -194,7 +194,7 @@ function getnameinfo(address::Union{IPv4, IPv6})
         end
         unpreserve_handle(ct)
     end
-    if isa(r, UVError)
+    if isa(r, IOError)
         code = r.code
         if code in (UV_EAI_ADDRFAMILY, UV_EAI_AGAIN, UV_EAI_BADFLAGS,
                     UV_EAI_BADHINTS, UV_EAI_CANCELED, UV_EAI_FAIL,
@@ -205,7 +205,7 @@ function getnameinfo(address::Union{IPv4, IPv6})
         elseif code == UV_EAI_MEMORY
             throw(OutOfMemoryError())
         else
-            throw(UVError("getnameinfo", code))
+            throw(_UVError("getnameinfo", code))
         end
     end
     return r::String

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -118,7 +118,7 @@ defaultport = rand(2000:4000)
         let p = fetch(port)
             otherip = getipaddr()
             if otherip != Sockets.localhost
-                @test_throws Base.UVError("connect", Base.UV_ECONNREFUSED) connect(otherip, p)
+                @test_throws Base._UVError("connect", Base.UV_ECONNREFUSED) connect(otherip, p)
             end
             for i in 1:3
                 client = connect(p)
@@ -185,7 +185,7 @@ end
     end
     @test_throws Sockets.DNSError getaddrinfo(".invalid")
     @test_throws ArgumentError getaddrinfo("localhost\0") # issue #10994
-    @test_throws Base.UVError("connect", Base.UV_ECONNREFUSED) connect(ip"127.0.0.1", 21452)
+    @test_throws Base._UVError("connect", Base.UV_ECONNREFUSED) connect(ip"127.0.0.1", 21452)
     e = (try; getaddrinfo(".invalid"); catch ex; ex; end)
     @test startswith(sprint(show, e), "DNSError:")
 end
@@ -202,7 +202,7 @@ end
     r = Channel(1)
     tsk = @async begin
         put!(r, :start)
-        @test_throws Base.UVError("accept", Base.UV_ECONNABORTED) accept(server)
+        @test_throws Base._UVError("accept", Base.UV_ECONNABORTED) accept(server)
     end
     @test fetch(r) === :start
     close(server)
@@ -216,7 +216,7 @@ let localhost = getaddrinfo("localhost")
     @async connect("localhost", randport)
     s1 = accept(server)
     @test_throws ErrorException("client TCPSocket is not in initialization state") accept(server, s1)
-    @test_throws Base.UVError("listen", Base.UV_EADDRINUSE) listen(randport)
+    @test_throws Base._UVError("listen", Base.UV_EADDRINUSE) listen(randport)
     port2, server2 = listenany(localhost, randport)
     @test randport != port2
     close(server)
@@ -348,7 +348,7 @@ end
                 wait_with_timeout(recvs)
             end
         catch e
-            if isa(e, Base.UVError) && Base.uverrorname(e) == "EPERM"
+            if isa(e, Base.IOError) && Base.uverrorname(e.code) == "EPERM"
                 @warn "UDP broadcast test skipped (permission denied upon send, restrictive firewall?)"
             else
                 rethrow()
@@ -412,7 +412,7 @@ end
     let addr = Sockets.InetAddr(ip"127.0.0.1", 4444)
         srv = listen(addr)
         r = @async close(srv)
-        @test_throws Base.UVError("accept", Base.UV_ECONNABORTED) accept(srv)
+        @test_throws Base._UVError("accept", Base.UV_ECONNABORTED) accept(srv)
         fetch(r)
     end
 
@@ -421,7 +421,7 @@ end
         s = Sockets.TCPSocket()
         Sockets.connect!(s, addr)
         r = @async close(s)
-        @test_throws Base.UVError("connect", Base.UV_ECANCELED) Sockets.wait_connected(s)
+        @test_throws Base._UVError("connect", Base.UV_ECANCELED) Sockets.wait_connected(s)
         fetch(r)
     end
 end

--- a/test/file.jl
+++ b/test/file.jl
@@ -176,9 +176,9 @@ close(f)
 
 rm(c_tmpdir, recursive=true)
 @test !isdir(c_tmpdir)
-@test_throws Base.UVError rm(c_tmpdir)
+@test_throws Base.IOError rm(c_tmpdir)
 @test rm(c_tmpdir, force=true) === nothing
-@test_throws Base.UVError rm(c_tmpdir, recursive=true)
+@test_throws Base.IOError rm(c_tmpdir, recursive=true)
 @test rm(c_tmpdir, force=true, recursive=true) === nothing
 
 if !Sys.iswindows()
@@ -193,8 +193,8 @@ if !Sys.iswindows()
         @test stat(file).gid ==0
         @test stat(file).uid ==0
     else
-        @test_throws Base.UVError chown(file, -2, -1)  # Non-root user cannot change ownership to another user
-        @test_throws Base.UVError chown(file, -1, -2)  # Non-root user cannot change group to a group they are not a member of (eg: nogroup)
+        @test_throws Base.IOError chown(file, -2, -1)  # Non-root user cannot change ownership to another user
+        @test_throws Base.IOError chown(file, -1, -2)  # Non-root user cannot change group to a group they are not a member of (eg: nogroup)
     end
 else
     # test that chown doesn't cause any errors for Windows
@@ -608,10 +608,10 @@ if !Sys.iswindows() || Sys.windows_version() >= Sys.WINDOWS_VISTA_VER
         @test_throws ArgumentError Base.cptree(none_existing_src,dst; force=true, follow_symlinks=false)
         @test_throws ArgumentError Base.cptree(none_existing_src,dst; force=true, follow_symlinks=true)
         # cp
-        @test_throws Base.UVError cp(none_existing_src,dst; force=true, follow_symlinks=false)
-        @test_throws Base.UVError cp(none_existing_src,dst; force=true, follow_symlinks=true)
+        @test_throws Base.IOError cp(none_existing_src,dst; force=true, follow_symlinks=false)
+        @test_throws Base.IOError cp(none_existing_src,dst; force=true, follow_symlinks=true)
         # mv
-        @test_throws Base.UVError mv(none_existing_src,dst; force=true)
+        @test_throws Base.IOError mv(none_existing_src,dst; force=true)
     end
 end
 

--- a/test/read.jl
+++ b/test/read.jl
@@ -54,8 +54,8 @@ function run_test_server(srv, text)
             try
                 write(sock, text)
             catch e
-                if !(isa(e, Base.UVError) && e.code == Base.UV_EPIPE)
-                    if !(isa(e, Base.UVError) && e.code == Base.UV_ECONNRESET)
+                if !(isa(e, Base.IOError) && e.code == Base.UV_EPIPE)
+                    if !(isa(e, Base.IOError) && e.code == Base.UV_ECONNRESET)
                         rethrow(e)
                     end
                 end
@@ -463,7 +463,7 @@ if !Sys.iswindows() && get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") !=
     # msvcrt _wchmod documentation states that all files are readable,
     # so we don't test that it correctly set the umask on windows
     @test_throws SystemError open(f)
-    @test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDONLY)
+    @test_throws Base.IOError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDONLY)
 else
     Sys.iswindows() || @warn "File permissions tests skipped due to running tests as root (not recommended)"
     close(open(f))
@@ -504,14 +504,14 @@ end
 @test eof(f1)
 @test eof(f2)
 @test_throws ArgumentError write(f1, '*')
-@test_throws Base.UVError write(f2, '*')
+@test_throws Base.IOError write(f2, '*')
 close(f1)
 close(f2)
 @test eof(f1)
-@test_throws Base.UVError eof(f2)
+@test_throws Base.IOError eof(f2)
 if get(ENV, "USER", "") != "root" && get(ENV, "HOME", "") != "/root"
     @test_throws SystemError open(f, "r+")
-    @test_throws Base.UVError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
+    @test_throws Base.IOError Base.Filesystem.open(f, Base.Filesystem.JL_O_RDWR)
 else
     @warn "File permissions tests skipped due to running tests as root (not recommended)"
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -70,8 +70,8 @@ end
 
 if valgrind_off
     # If --trace-children=yes is passed to valgrind, valgrind will
-    # exit here with an error code, and no UVError will be raised.
-    @test_throws Base.UVError run(`foo_is_not_a_valid_command`)
+    # exit here with an error code, and no IOError will be raised.
+    @test_throws Base.IOError run(`foo_is_not_a_valid_command`)
 end
 
 if Sys.isunix()
@@ -494,7 +494,7 @@ end
 # `kill` error conditions
 let p = run(`$sleepcmd 100`, wait=false)
     # Should throw on invalid signals
-    @test_throws Base.UVError kill(p, typemax(Cint))
+    @test_throws Base.IOError kill(p, typemax(Cint))
     kill(p)
     wait(p)
     # Should not throw if already dead

--- a/test/stress.jl
+++ b/test/stress.jl
@@ -17,7 +17,7 @@ if Sys.isunix()
                 @test false
             end
         catch ex
-            isa(ex, Base.UVError) || rethrow(ex)
+            isa(ex, Base.IOError) || rethrow(ex)
             @test ex.code in (Base.UV_EMFILE, Base.UV_ENFILE)
         finally
             foreach(close, ps)


### PR DESCRIPTION
fixes #7841

This is a bit tricky because the error sources we have use libuv-specific codes. So I tried this approach:

1. Rename `UVError` to `IOError`. It still has an integer code, but the code should be considered implementation-defined.
2. When libuv wrapper code throws an error, it uses the constructor `_UVError(...)`. That function converts the error code to a message using the knowledge that it's a libuv code.

That way you always consume `IOError`s, and they're self contained, but you can still use the code if you happen to know what it means.