### PR TITLE
only freeze require world age in processess generating output

### DIFF
--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -417,21 +417,25 @@ static jl_module_t *call_require(jl_module_t *mod, jl_sym_t *var)
 {
     static jl_value_t *require_func = NULL;
     static size_t require_world = 0;
+    int build_mode = jl_generating_output();
     jl_module_t *m = NULL;
     jl_ptls_t ptls = jl_get_ptls_states();
     if (require_func == NULL && jl_base_module != NULL) {
         require_func = jl_get_global(jl_base_module, jl_symbol("require"));
-        require_world = ptls->world_age;
+        if (build_mode)
+            require_world = ptls->world_age;
     }
     if (require_func != NULL) {
         size_t last_age = ptls->world_age;
-        ptls->world_age = require_world;
+        if (build_mode)
+            ptls->world_age = require_world;
         jl_value_t *reqargs[3];
         reqargs[0] = require_func;
         reqargs[1] = (jl_value_t*)mod;
         reqargs[2] = (jl_value_t*)var;
         m = (jl_module_t*)jl_apply(reqargs, 3);
-        ptls->world_age = last_age;
+        if (build_mode)
+            ptls->world_age = last_age;
     }
     if (m == NULL || !jl_is_module(m)) {
         jl_errorf("failed to load module %s", jl_symbol_name(var));


### PR DESCRIPTION
Alt. to https://github.com/JuliaLang/julia/pull/28274. Fixes https://github.com/JuliaLang/julia/issues/28042.

<img width="519" alt="screen shot 2018-07-26 at 11 32 07" src="https://user-images.githubusercontent.com/1282691/43254475-c1242bc0-90c7-11e8-808d-664f94861e18.png">

Precompilation time of CSV before:

```
 42.693428 seconds (3.82 M allocations: 232.627 MiB, 0.33% gc time)
```

After:

```
 44.479788 seconds (3.83 M allocations: 233.338 MiB, 0.42% gc time)
```

Would be good if people could try locally as well.