### PR TITLE
fix #28297, deserializing structs with compact Union-typed fields

### DIFF
--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -133,6 +133,14 @@ try
               Base.convert(::Type{Ref}, ::Value18343{T}) where {T} = 3
 
 
+              # issue #28297
+              mutable struct Result
+                  result::Union{Int,Missing}
+              end
+
+              const x28297 = Result(missing)
+
+
               let some_method = which(Base.include, (String,))
                     # global const some_method // FIXME: support for serializing a direct reference to an external Method not implemented
                   global const some_linfo =


### PR DESCRIPTION
I believe this was just an assumption that needed to be updated for the new Union representation.

fix #28297