### PR TITLE
add pathof(::Module)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -545,7 +545,7 @@ Library improvements
   * `Char` is now a subtype of `AbstractChar`, and most of the functions that
     take character arguments now accept any `AbstractChar` ([#26286]).
 
-  * `abspath(module)` returns the path a module was imported from ([#28310]).
+  * `pathof(module)` returns the path a module was imported from ([#28310]).
 
   * `bytes2hex` now accepts an optional `io` argument to output to a hexadecimal stream
     without allocating a `String` first ([#27121]).

--- a/NEWS.md
+++ b/NEWS.md
@@ -545,6 +545,9 @@ Library improvements
   * `Char` is now a subtype of `AbstractChar`, and most of the functions that
     take character arguments now accept any `AbstractChar` ([#26286]).
 
+  * `abspath(module, paths...)` returns the path a module was imported
+    from ([#28310]).
+
   * `bytes2hex` now accepts an optional `io` argument to output to a hexadecimal stream
     without allocating a `String` first ([#27121]).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -545,8 +545,7 @@ Library improvements
   * `Char` is now a subtype of `AbstractChar`, and most of the functions that
     take character arguments now accept any `AbstractChar` ([#26286]).
 
-  * `abspath(module, paths...)` returns the path a module was imported
-    from ([#28310]).
+  * `abspath(module)` returns the path a module was imported from ([#28310]).
 
   * `bytes2hex` now accepts an optional `io` argument to output to a hexadecimal stream
     without allocating a `String` first ([#27121]).

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -742,6 +742,7 @@ export
     methods,
     nameof,
     parentmodule,
+    pathof,
     names,
     which,
     @isdefined,

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -250,12 +250,12 @@ end
 locate_package(::Nothing) = nothing
 
 """
-    abspath(m::Module)
+    pathof(m::Module)
 
 Return the path of `m.jl` file that was used to `import` module `m`,
 or `nothing` if `m` was not imported from a package.
 """
-function Base.Filesystem.abspath(m::Module)
+function pathof(m::Module)
     pkgid = get(Base.module_keys, m, nothing)
     pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -258,9 +258,7 @@ or `nothing` if `m` was not imported from a package.
 function pathof(m::Module)
     pkgid = get(Base.module_keys, m, nothing)
     pkgid === nothing && return nothing
-    path = Base.locate_package(pkgid)
-    path === nothing && return nothing
-    return normpath(path)
+    return Base.locate_package(pkgid)
 end
 
 ## generic project & manifest API ##

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -258,7 +258,9 @@ or `nothing` if `m` was not imported from a package.
 function Base.Filesystem.abspath(m::Module)
     pkgid = get(Base.module_keys, m, nothing)
     pkgid === nothing && return nothing
-    return normpath(Base.locate_package(pkgid))
+    path = Base.locate_package(pkgid)
+    path === nothing && return nothing
+    return normpath(path)
 end
 
 ## generic project & manifest API ##

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -250,23 +250,15 @@ end
 locate_package(::Nothing) = nothing
 
 """
-    abspath(m::Module, paths::AbstractString...)
+    abspath(m::Module)
 
 Return the path of `m.jl` file that was used to `import` module `m`,
-or `nothing` if `m` was not imported from a package. The optional
-`paths` arguments are appended to `abspath(m)`, equivalent to
-[`joinpath`](@ref)`(abspath(m), paths...)`.
-
-Note that the source directory containing the module file can be
-obtained by `abspath(m, "..")`, and the parent package directory
-is `abspath(m, "..", "..")`.
+or `nothing` if `m` was not imported from a package.
 """
-function Base.Filesystem.abspath(m::Module, paths::AbstractString...)
+function Base.Filesystem.abspath(m::Module)
     pkgid = get(Base.module_keys, m, nothing)
     pkgid === nothing && return nothing
-    path = Base.locate_package(pkgid)
-    path === nothing && return nothing
-    return normpath(abspath(path, paths...))
+    return normpath(Base.locate_package(pkgid))
 end
 
 ## generic project & manifest API ##

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -249,6 +249,26 @@ function locate_package(pkg::PkgId)::Union{Nothing,String}
 end
 locate_package(::Nothing) = nothing
 
+"""
+    abspath(m::Module, paths::AbstractString...)
+
+Return the path of `m.jl` file that was used to `import` module `m`,
+or `nothing` if `m` was not imported from a package. The optional
+`paths` arguments are appended to `abspath(m)`, equivalent to
+[`joinpath`](@ref)`(abspath(m), paths...)`.
+
+Note that the source directory containing the module file can be
+obtained by `abspath(m, "..")`, and the parent package directory
+is `abspath(m, "..", "..")`.
+"""
+function Base.Filesystem.abspath(m::Module, paths::AbstractString...)
+    pkgid = get(Base.module_keys, m, nothing)
+    pkgid === nothing && return nothing
+    path = Base.locate_package(pkgid)
+    path === nothing && return nothing
+    return normpath(abspath(path, paths...))
+end
+
 ## generic project & manifest API ##
 
 const project_names = ("JuliaProject.toml", "Project.toml")

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -332,6 +332,7 @@ Base.AsyncCondition(::Function)
 ```@docs
 Base.nameof(::Module)
 Base.parentmodule
+Base.pathof(::Module)
 Base.moduleroot
 Base.@__MODULE__
 Base.fullname

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -430,7 +430,7 @@ function clone(url::String, name::String = "")
 end
 
 function dir(pkg::String, paths::AbstractString...)
-    Base.depwarn("`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; abspath($pkg, \"..\", \"..\", paths...)`.", :dir)
+    @warn "`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; abspath($pkg, \"..\", \"..\", paths...)`." maxlog=1
     pkgid = Base.identify_package(pkg)
     pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -429,7 +429,7 @@ function clone(url::String, name::String = "")
     develop(ctx, [parse_package(url)])
 end
 
-function dir(pkg::String, paths::String...)
+function dir(pkg::String, paths::AbstractString...)
     Base.depwarn("`Pkg.dir(pkgname, ...)` is deprecated; instead, first import the package module `m` and then call `Pkg.dir(m, ...)`.", :dir)
     pkgid = Base.identify_package(pkg)
     pkgid === nothing && return nothing
@@ -439,14 +439,14 @@ function dir(pkg::String, paths::String...)
 end
 
 """
-    dir(m::Module, paths::String...)
+    dir(m::Module, paths::AbstractString...)
 
 Return the package directory that was used to load module `m`,
 or `nothing` if `m` was not loaded from a package.  The
 optional `paths` arguments are appended to `dir(m)`,
 equivalent to [`joinpath`](@ref)`(dir(m), paths...)`.
 """
-function dir(m::Module, paths::String...)
+function dir(m::Module, paths::AbstractString...)
     pkgid = get(Base.module_keys, m, nothing)
     pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -430,12 +430,28 @@ function clone(url::String, name::String = "")
 end
 
 function dir(pkg::String, paths::String...)
-    @warn "Pkg.dir is only kept for legacy CI script reasons" maxlog=1
+    Base.depwarn("`Pkg.dir(pkgname, ...)` is deprecated; instead, first import the package module `m` and then call `Pkg.dir(m, ...)`.", :dir)
     pkgid = Base.identify_package(pkg)
-    pkgid == nothing && return nothing
+    pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)
-    pkgid == nothing && return nothing
-    return joinpath(abspath(path, "..", "..", paths...))
+    path === nothing && return nothing
+    return abspath(path, "..", "..", paths...)
+end
+
+"""
+    dir(m::Module, paths::String...)
+
+Return the package directory that was used to load module `m`,
+or `nothing` if `m` was not loaded from a package.  The
+optional `paths` arguments are appended to `dir(m)`,
+equivalent to [`joinpath`](@ref)`(dir(m), paths...)`.
+"""
+function dir(m::Module, paths::String...)
+    pkgid = get(Base.module_keys, m, nothing)
+    pkgid === nothing && return nothing
+    path = Base.locate_package(pkgid)
+    path === nothing && return nothing
+    return abspath(path, "..", "..", paths...)
 end
 
 precompile() = precompile(Context())

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -430,7 +430,7 @@ function clone(url::String, name::String = "")
 end
 
 function dir(pkg::String, paths::AbstractString...)
-    @warn "`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; abspath($pkg, \"..\", \"..\", paths...)`." maxlog=1
+    @warn "`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; joinpath(dirname(abspath($pkg)), \"..\", paths...)`." maxlog=1
     pkgid = Base.identify_package(pkg)
     pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -430,7 +430,7 @@ function clone(url::String, name::String = "")
 end
 
 function dir(pkg::String, paths::AbstractString...)
-    @warn "`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; joinpath(dirname(abspath($pkg)), \"..\", paths...)`." maxlog=1
+    @warn "`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; joinpath(dirname(pathof($pkg)), \"..\", paths...)`." maxlog=1
     pkgid = Base.identify_package(pkg)
     pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)

--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -430,24 +430,8 @@ function clone(url::String, name::String = "")
 end
 
 function dir(pkg::String, paths::AbstractString...)
-    Base.depwarn("`Pkg.dir(pkgname, ...)` is deprecated; instead, first import the package module `m` and then call `Pkg.dir(m, ...)`.", :dir)
+    Base.depwarn("`Pkg.dir(pkgname, paths...)` is deprecated; instead, do `import $pkg; abspath($pkg, \"..\", \"..\", paths...)`.", :dir)
     pkgid = Base.identify_package(pkg)
-    pkgid === nothing && return nothing
-    path = Base.locate_package(pkgid)
-    path === nothing && return nothing
-    return abspath(path, "..", "..", paths...)
-end
-
-"""
-    dir(m::Module, paths::AbstractString...)
-
-Return the package directory that was used to load module `m`,
-or `nothing` if `m` was not loaded from a package.  The
-optional `paths` arguments are appended to `dir(m)`,
-equivalent to [`joinpath`](@ref)`(dir(m), paths...)`.
-"""
-function dir(m::Module, paths::AbstractString...)
-    pkgid = get(Base.module_keys, m, nothing)
     pkgid === nothing && return nothing
     path = Base.locate_package(pkgid)
     path === nothing && return nothing

--- a/stdlib/Pkg/test/pkg.jl
+++ b/stdlib/Pkg/test/pkg.jl
@@ -401,12 +401,6 @@ temp_pkg_dir() do project_path
     end
 end
 
-module NotPkgModule; end
-@testset "Pkg.dir" begin
-    @test Pkg.dir(Pkg, "test", "pkg.jl") == abspath(@__FILE__)
-    @test Pkg.dir(NotPkgModule) === nothing
-end
-
 include("repl.jl")
 
 end # module

--- a/stdlib/Pkg/test/pkg.jl
+++ b/stdlib/Pkg/test/pkg.jl
@@ -401,6 +401,12 @@ temp_pkg_dir() do project_path
     end
 end
 
+module NotPkgModule; end
+@testset "Pkg.dir" begin
+    @test Pkg.dir(Pkg, "test", "pkg.jl") == abspath(@__FILE__)
+    @test Pkg.dir(NotPkgModule) === nothing
+end
+
 include("repl.jl")
 
 end # module

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -258,9 +258,7 @@ module NotPkgModule; end
     @test Foo.which == "path"
 
     @testset "abspath" begin
-        p = normpath(abspath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
-        @test abspath(Foo) == p
-        @test abspath(Foo, "..", "blah") == joinpath(dirname(p), "blah")
+        @test abspath(Foo) == normpath(abspath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
         @test abspath(NotPkgModule) === nothing
     end
 

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -257,9 +257,9 @@ module NotPkgModule; end
     end
     @test Foo.which == "path"
 
-    @testset "abspath" begin
-        @test abspath(Foo) == normpath(abspath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
-        @test abspath(NotPkgModule) === nothing
+    @testset "pathof" begin
+        @test pathof(Foo) == normpath(abspath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
+        @test pathof(NotPkgModule) === nothing
     end
 
 end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -218,6 +218,8 @@ Base.ACTIVE_PROJECT[] = nothing
     end
 end
 
+module NotPkgModule; end
+
 @testset "project & manifest import" begin
     @test !@isdefined Foo
     @test !@isdefined Bar
@@ -254,6 +256,14 @@ end
         end
     end
     @test Foo.which == "path"
+
+    @testset "abspath" begin
+        p = normpath(abspath(@__DIR__, "project/deps/Foo1/src/Foo.jl"))
+        @test abspath(Foo) == p
+        @test abspath(Foo, "..", "blah") == joinpath(dirname(p), "blah")
+        @test abspath(NotPkgModule) === nothing
+    end
+
 end
 
 ## systematic generation of test environments ##


### PR DESCRIPTION
Closes #27592.   `abspath(FooModule)` returns the path of `FooModule.jl`.    The package directory can be obtained from `abspath(FooModule, "..", "..")`.