### PR TITLE
Use a custom hashing function for remotecall_fetch

### DIFF
--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -55,15 +55,10 @@ hashall(x, h::UInt) = fieldcount(typeof(x)) == 0 ? hash(x, h) : hashfields(x, h)
 end
 hashall(x::Type, h::UInt) = hash(x, h)
 hashall(x::Module, h::UInt) = hash(x, h)
+hashall(S::String, h::UInt) = hash(S, h)
 function hashall(A::Array, h::UInt)
     for i in eachindex(A)
         h = hashall(isassigned(A, i) ? A[i] : 0x0a57083376608372, h)
-    end
-    return h
-end
-function hashall(S::String, h::UInt)
-    for c in S
-        h = hashall(c, h)
     end
     return h
 end

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -82,6 +82,19 @@ let
     @test count == 0
 end
 
+# mitigation of issue #25220
+@everywhere begin
+mutable struct S25220
+    val
+end
+Base.hash(::S25220, h::UInt) = hash(0, h)
+end
+x25220 = S25220(1)
+@test remotecall_fetch(()->x25220, id_other).val == 1
+x25220.val = 2
+@test remotecall_fetch(()->x25220, id_other).val == 2
+
+
 # Test Futures
 function testf(id)
     f=Future(id)


### PR DESCRIPTION
Mitigates issue JuliaLang/Distributed.jl#48 (but does not fix it).

This implements a custom hashing function for Distributed to use in determining if it should resend values between workers. Previously, this just used `Base.hash`. This has the possibility that a custom type could opt for a cheaper "partial" or constant-valued hash function, leading to failure to update values between workers. Instead, this implements a generic hashing scheme that works directly on the internal fields --- we don't need to worry about hash equality between different types for this use-case.