### PR TITLE
Silence an unused result warning when building with Clang

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -631,9 +631,9 @@ void JuliaOJIT::addModule(std::unique_ptr<Module> M)
 void JuliaOJIT::removeModule(ModuleHandleT H)
 {
 #if JL_LLVM_VERSION >= 50000
-    CompileLayer.removeModule(H);
+    (void)CompileLayer.removeModule(H);
 #else
-    CompileLayer.removeModuleSet(H);
+    (void)CompileLayer.removeModuleSet(H);
 #endif
 }
 


### PR DESCRIPTION
LLVM's `removeModule` is documented to return a `bool` but its value isn't used in our `removeModule` function that returns `void`, so Clang emits a warning. This just does a cast to `void` on the call to LLVM's `removeModule`.