### PR TITLE
fix sections ref in 'Declared Types' (docu), closes #21612

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -452,8 +452,8 @@ To recap, two essential properties define immutability in Julia:
 
 ## Declared Types
 
-The three kinds of types discussed in the previous three sections are actually all closely related.
-They share the same key properties:
+The three kinds of types (abstract, primitive, composite) discussed in the previous
+sections are actually all closely related. They share the same key properties:
 
   * They are explicitly declared.
   * They have names.


### PR DESCRIPTION
The reference _three_ previous sections is wrong. As there is a section 'Mutable Composite Types' one would have to write the previous _four_ sections. I left out the exact number and mentioned the type kinds instead.