### PR TITLE
fix incorrect show for Pair

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -593,14 +593,14 @@ function show(io::IO, p::Pair)
     iocompact = IOContext(io, :compact => get(io, :compact, true))
     isdelimited(io, p) && return show_default(iocompact, p)
 
-    typeinfos = gettypeinfos(io, p)
-    isdelimited(iocompact, p.first) || print(io, "(")
-    show(IOContext(iocompact, :typeinfo => typeinfos[1]), p.first)
-    isdelimited(iocompact, p.first) || print(io, ")")
+    io1, io2 = (IOContext(iocompact, :typeinfo => ti) for ti in gettypeinfos(io, p))
+    isdelimited(io1, p.first) || print(io, "(")
+    show(io1, p.first)
+    isdelimited(io1, p.first) || print(io, ")")
     print(io, compact ? "=>" : " => ")
-    isdelimited(iocompact, p.second) || print(io, "(")
-    show(IOContext(iocompact, :typeinfo => typeinfos[2]), p.second)
-    isdelimited(iocompact, p.second) || print(io, ")")
+    isdelimited(io2, p.second) || print(io, "(")
+    show(io2, p.second)
+    isdelimited(io2, p.second) || print(io, ")")
     nothing
 end
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -589,19 +589,16 @@ function gettypeinfos(io::IO, p::Pair)
 end
 
 function show(io::IO, p::Pair)
-    compact = get(io, :compact, false)
     iocompact = IOContext(io, :compact => get(io, :compact, true))
     isdelimited(io, p) && return show_default(iocompact, p)
-
-    io1, io2 = (IOContext(iocompact, :typeinfo => ti) for ti in gettypeinfos(io, p))
-    isdelimited(io1, p.first) || print(io, "(")
-    show(io1, p.first)
-    isdelimited(io1, p.first) || print(io, ")")
-    print(io, compact ? "=>" : " => ")
-    isdelimited(io2, p.second) || print(io, "(")
-    show(io2, p.second)
-    isdelimited(io2, p.second) || print(io, ")")
-    nothing
+    typeinfos = gettypeinfos(io, p)
+    for i = (1, 2)
+        io_i = IOContext(iocompact, :typeinfo => typeinfos[i])
+        isdelimited(io_i, p[i]) || print(io, "(")
+        show(io_i, p[i])
+        isdelimited(io_i, p[i]) || print(io, ")")
+        i == 1 && print(io, get(io, :compact, false) ? "=>" : " => ")
+    end
 end
 
 function show(io::IO, m::Module)

--- a/test/show.jl
+++ b/test/show.jl
@@ -990,6 +990,10 @@ end
     s = IOBuffer()
     show(IOContext(s, :compact => false), (1=>2) => Pair{Any,Any}(3,4))
     @test String(take!(s)) == "(1 => 2) => Pair{Any,Any}(3, 4)"
+
+    # issue #28327
+    d = Dict(Pair{Integer,Integer}(1,2)=>Pair{Integer,Integer}(1,2))
+    @test showstr(d) == "Dict((1=>2)=>(1=>2))" # correct parenthesis
 end
 
 @testset "alignment for pairs" begin  # (#22899)


### PR DESCRIPTION
E.g. `show(Dict(Pair{Integer,Integer}(1,2) => 3))` was producing
`Dict(1=>2=>3)`, i.e. a pair of parenthesis was missing.