### PR TITLE
bi/tri/symdiagonal matrix multiplication should return sparse matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -503,7 +503,7 @@ end
 const SpecialMatrix = Union{Bidiagonal,SymTridiagonal,Tridiagonal}
 # to avoid ambiguity warning, but shouldn't be necessary
 *(A::AbstractTriangular, B::SpecialMatrix) = Array(A) * Array(B)
-*(A::SpecialMatrix, B::SpecialMatrix) = Array(A) * Array(B)
+*(A::SpecialMatrix, B::SpecialMatrix) = mul!(spzeros(size(A)...), A, B)
 
 #Generic multiplication
 *(A::Bidiagonal{T}, B::AbstractVector{T}) where {T} = *(Array(A), B)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -503,7 +503,8 @@ end
 const SpecialMatrix = Union{Bidiagonal,SymTridiagonal,Tridiagonal}
 # to avoid ambiguity warning, but shouldn't be necessary
 *(A::AbstractTriangular, B::SpecialMatrix) = Array(A) * Array(B)
-*(A::SpecialMatrix, B::SpecialMatrix) = mul!(spzeros(size(A)...), A, B)
+# moving this to sparsearrays since it needs spzeros
+# *(A::SpecialMatrix, B::SpecialMatrix) = mul!(spzeros(size(A)...), A, B)
 
 #Generic multiplication
 *(A::Bidiagonal{T}, B::AbstractVector{T}) where {T} = *(Array(A), B)

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -52,5 +52,6 @@ similar(B::Bidiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spze
 similar(D::Diagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
 similar(S::SymTridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
 similar(M::Tridiagonal, ::Type{T}, dims::Union{Dims{1},Dims{2}}) where {T} = spzeros(T, dims...)
+*(A::Union{Bidiagonal,SymTridiagonal,Tridiagonal}, B::Union{Bidiagonal,SymTridiagonal,Tridiagonal}) = mul!(spzeros(size(A)...), A, B)
 
 end


### PR DESCRIPTION
PR #15505 added faster bi/tri/symdiagonal matrix multiplication methods, but the fallback caused them to output dense matrices which removed any speed-up:
```
const SpecialMatrix = Union{Bidiagonal,SymTridiagonal,Tridiagonal}
# to avoid ambiguity warning, but shouldn't be necessary
*(A::AbstractTriangular, B::SpecialMatrix) = Array(A) * Array(B)
*(A::SpecialMatrix, B::SpecialMatrix) = Array(A) * Array(B)
```
at bidiag.jl:507

This PR changes it so these multiplication methods return sparse arrays instead of dense.

Some basic timings:
Before:
```
julia> A = Tridiagonal(rand(5000,5000))
julia> B = Tridiagonal(rand(5000,5000))
julia> @time A*B
  3.957645 seconds (10 allocations: 572.205 MiB, 2.23% gc time)
```
After:
```
julia> A = Tridiagonal(rand(5000,5000))
julia> B = Tridiagonal(rand(5000,5000))
julia> @time A*B
  0.063493 seconds (39 allocations: 1.078 MiB)
```

I think there are a few more combinations of special matrices that can benefit from something like this. 

Also, it may be worth discussing if we should just return band matrices directly instead of sparse.

--------------------
```
julia> versioninfo()
Julia Version 0.7.0-beta2.0
Commit b145832402 (2018-07-13 19:54 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.0 (ORCJIT, skylake)
```