### PR TITLE
fixed dense times diagonal matrix multiplication

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -504,6 +504,7 @@ const SpecialMatrix = Union{Bidiagonal,SymTridiagonal,Tridiagonal}
 # to avoid ambiguity warning, but shouldn't be necessary
 *(A::AbstractTriangular, B::SpecialMatrix) = Array(A) * Array(B)
 *(A::SpecialMatrix, B::SpecialMatrix) = Array(A) * Array(B)
+*(A::AbstractMatrix, B::SpecialMatrix) = A_mul_B_td!(zeros(eltype(A),size(A)...), A, B)
 
 #Generic multiplication
 *(A::Bidiagonal{T}, B::AbstractVector{T}) where {T} = *(Array(A), B)

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -502,7 +502,7 @@ end
 
 const SpecialMatrix = Union{Bidiagonal,SymTridiagonal,Tridiagonal}
 # to avoid ambiguity warning, but shouldn't be necessary
-*(A::AbstractTriangular, B::SpecialMatrix) = Array(A) * Array(B)
+#*(A::AbstractTriangular, B::SpecialMatrix) = Array(A) * Array(B)
 *(A::SpecialMatrix, B::SpecialMatrix) = Array(A) * Array(B)
 *(A::AbstractMatrix, B::SpecialMatrix) = A_mul_B_td!(zeros(eltype(A),size(A)...), A, B)
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -290,6 +290,11 @@ srand(1)
     @test Matrix{Complex{Float64}}(BD) == BD
 end
 
+# Issue 27176
+Diag = Tridiagonal([1,],[2,2],[1,])
+Dense = [0.42 0.18; 0.08 0.58]
+@test typeof(Diag*Dense) == typeof(Dense*Diag) == typeof(Dense)
+
 # Issue 10742 and similar
 let A = Bidiagonal([1,2,3], [0,0], :U)
     @test istril(A)


### PR DESCRIPTION
Fixing JuliaLang/LinearAlgebra.jl#525 to make dense times diagonal matrix multiplication return dense matrices.

Some basic timings:

Before:
```
julia> A = Tridiagonal(rand(2000,2000))
julia> B = rand(2000,2000)
julia> @time A*B
  0.075236 seconds (6 allocations: 30.518 MiB, 87.87% gc time)
julia> @time B*A
  4.515886 seconds (50 allocations: 66.017 MiB, 0.07% gc time)
```
After:
```
julia> A = Tridiagonal(rand(2000,2000))
julia> B = rand(2000,2000)
julia> @time A*B
  0.023720 seconds (6 allocations: 30.518 MiB, 7.70% gc time)
julia> @time B*A
  0.017339 seconds (6 allocations: 30.518 MiB, 10.38% gc time)
```

This also affects dense times Bidiagonal and SymTriDiagonal matrix multiplication.

----------
```
julia> versioninfo()
Julia Version 0.7.0-beta2.0
Commit b145832402* (2018-07-13 19:54 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: Intel(R) Core(TM) i7-6600U CPU @ 2.60GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.0 (ORCJIT, skylake)
```