### PR TITLE
Fix dict replcompletion error without key

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -527,7 +527,7 @@ function dict_identifier_key(str,tag)
         # Avoid `isdefined(::Array, ::Symbol)`
         isa(obj, Array) && return (nothing, nothing, nothing)
     end
-    begin_of_key = first(findnext(r"\S", str, nextind(str, end_of_identifier) + 1)) # 1 for [
+    begin_of_key = first(something(findnext(r"\S", str, nextind(str, end_of_identifier) + 1), 1)) # 1 for [
     begin_of_key==0 && return (true, nothing, nothing)
     partial_key = str[begin_of_key:end]
     (isa(obj, AbstractDict) && length(obj) < 1e6) || return (true, nothing, nothing)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -905,6 +905,9 @@ function test_dict_completion(dict_name)
     s = "$dict_name[:α"
     c, r = test_complete(s)
     @test c == Any[":α]"]
+    s = "$dict_name["
+    c, r = test_complete(s)
+    @test !isempty(c)
 end
 test_dict_completion("CompletionFoo.test_dict")
 test_dict_completion("CompletionFoo.test_customdict")


### PR DESCRIPTION
This fixes an error triggered by trying to autocomplete in a `Dict`s `getindex` call.

Before:
```
julia> foo = Dict(:bar => 3)
Dict{Symbol,Int64} with 1 entry:
  :bar => 3

julia> foo[┌ Error: Error in the keymap
│   exception =
│    MethodError: no method matching iterate(::Nothing)
│    Closest candidates are:
│      iterate(::Any) at essentials.jl:821
│      iterate(::Any, ::Any) at essentials.jl:816
│      iterate(::Core.SimpleVector) at essentials.jl:552
│      ...
│    Stacktrace:
│     [1] start(::Nothing) at ./essentials.jl:843
│     [2] iterate at ./essentials.jl:821 [inlined]
│     [3] first(::Nothing) at ./abstractarray.jl:287
│     [4] dict_identifier_key(::String, ::Symbol) ...
```

After:
```
julia> foo = Dict(:bar => 3)
Dict{Symbol,Int64} with 1 entry:
  :bar => 3

julia> foo[
!                        Channel                   TypeError                 delete!                   isabstract                numerator                 size
!=                       Char                      TypeVar                   deleteat!                 isabstracttype            object_id                 sizehint!
!==                      Cint                      UInt                      denominator               isalnum                   objectid                  sizeof
%                        Cintmax_t                 UInt128                   detach                    isalpha                   occursin      
...
```