### PR TITLE
Fix arrayref nothrow predicate for undef-able arrays

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6658,3 +6658,14 @@ end
 @test isa(foo28208(false, true), Tuple)
 @test foo28208(true, false) === missing
 @test foo28208(true, true) === nothing
+
+# Issue #28326
+function foo28326(a)
+    try
+        @inbounds a[1]
+        return false
+    catch
+        return true
+    end
+end
+@test foo28326(Vector(undef, 1))


### PR DESCRIPTION
Previously the nothrow predicate said we were allowed to remove an unused
call if it was marked as inbounds. However, this is only true if none of
the entries of the array can be `#undef` (i.e. if the element type is a
bitstype of bitsunion). Correct the predicate and add a test case.

Fixes #28326