### PR TITLE
[PropagateAddrSpaces] Pass through the insertion point

### DIFF
--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -222,7 +222,7 @@ Value *PropagateJuliaAddrspaces::LiftPointer(Value *V, Type *LocTy, Instruction 
         }
     }
 
-    return CollapseCastsAndLift(V, cast<Instruction>(V));
+    return CollapseCastsAndLift(V, InsertPt);
 }
 
 void PropagateJuliaAddrspaces::visitLoadInst(LoadInst &LI) {


### PR DESCRIPTION
This doesn't really make a difference in proper use, but
it's a trap for bugpoint to fall into during reduction,
so change it to something less likely to be a problem.