### PR TITLE
Add deprecations to the old iteration protocol shims

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -849,7 +849,11 @@ function iterate(x, state)
     return next(x, state)
 end
 const old_iterate_line_prev = (@__LINE__)
-iterate(x) = (@_inline_meta; iterate(x, start(x)))
+function iterate(x)
+    r = iterate(x, start(x))
+    depwarn("The start/next/done iteration protocol is deprecated. Implement `iterate(::$(typeof(x)))`.", :start)
+    r
+end
 
 struct LegacyIterationCompat{I,T,S}
     done::Bool
@@ -872,6 +876,7 @@ end
 const compat_start_line_prev = (@__LINE__)
 function start(itr::T) where {T}
     has_non_default_iterate(T) || throw(MethodError(iterate, (itr,)))
+    depwarn("The start/next/done iteration protocol is deprecated. Use `iterate` instead.", :start)
     y = iterate(itr)
     y === nothing && return LegacyIterationCompat{T, Union{}, Union{}}()
     val, state = y

--- a/test/core.jl
+++ b/test/core.jl
@@ -6418,23 +6418,6 @@ end
 @test !Base.isvatuple(Tuple{T,Vararg{Int,2}} where T)
 @test !Base.isvatuple(Tuple{Int,Int,Vararg{Int,2}})
 
-# The old iteration protocol shims deprecation test
-struct DelegateIterator{T}
-    x::T
-end
-Base.start(itr::DelegateIterator) = start(itr.x)
-Base.next(itr::DelegateIterator, state) = next(itr.x, state)
-Base.done(itr::DelegateIterator, state) = done(itr.x, state)
-let A = [1], B = [], C = DelegateIterator([1]), D = DelegateIterator([]), E = Any[1,"abc"]
-    @test next(A, start(A))[1] == 1
-    @test done(A, next(A, start(A))[2])
-    @test done(B, start(B))
-    @test next(C, start(C))[1] == 1
-    @test done(C, next(C, start(C))[2])
-    @test done(D, start(D))
-    @test next(E, next(E, start(E))[2])[1] == "abc"
-end
-
 # Issue 27103
 function f27103()
     a = @isdefined x

--- a/test/deprecation_exec.jl
+++ b/test/deprecation_exec.jl
@@ -352,4 +352,27 @@ end # @testset
 
 end
 
+# The old iteration protocol shims deprecation test
+struct DelegateIterator{T}
+    x::T
+end
+Base.start(itr::DelegateIterator) = start(itr.x)
+Base.next(itr::DelegateIterator, state) = next(itr.x, state)
+Base.done(itr::DelegateIterator, state) = done(itr.x, state)
+
+@testset "Iteration protocol" begin
+    let A = [1], B = [], C = DelegateIterator([1]), D = DelegateIterator([]), E = Any[1,"abc"]
+        @test (@test_deprecated next(A, start(A))[1]) == 1
+        @test @test_deprecated done(A, next(A, start(A))[2])
+        @test @test_deprecated done(B, start(B))
+        @test (@test_deprecated next(C, start(C))[1]) == 1
+        @test @test_deprecated done(C, next(C, start(C))[2])
+        @test @test_deprecated done(D, start(D))
+        @test (@test_deprecated next(E, next(E, start(E))[2])[1]) == "abc"
+    end
+
+    # rest with state from old iteration protocol
+    @test (@test_deprecated collect(Iterators.rest(1:6, Base.start(1:6)))) == collect(1:6)
+end
+
 # END 0.7 deprecations

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -70,8 +70,6 @@ let s = "hello"
     @test c == ['e','l','l','o']
     @test c isa Vector{Char}
 end
-# rest with state from old iteration protocol
-@test collect(rest(1:6, start(1:6))) == collect(1:6)
 
 @test_throws MethodError collect(rest(countfrom(1), 5))
 


### PR DESCRIPTION
When we originally Switched over the iteration protocol,
we kept these without depwarns to avoid spamming everybody.
Now that packages have had some time, add the depwarns.