### PR TITLE
add colno to invalid-char parse error

### DIFF
--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <sys/types.h>
 #include "flisp.h"
+#include "utf8proc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -167,6 +168,7 @@ value_t fl_ioungetc(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     if (wc >= 0x80) {
         lerror(fl_ctx, fl_ctx->ArgError, "io_ungetc: unicode not yet supported");
     }
+    s->u_colno -= utf8proc_charwidth(wc);
     return fixnum(ios_ungetc((int)wc,s));
 }
 
@@ -207,6 +209,13 @@ value_t fl_iolineno(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     argcount(fl_ctx, "input-port-line", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "input-port-line");
     return size_wrap(fl_ctx, s->lineno);
+}
+
+value_t fl_iocolno(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+{
+    argcount(fl_ctx, "input-port-column", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "input-port-column");
+    return size_wrap(fl_ctx, s->u_colno);
 }
 
 value_t fl_ioseek(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
@@ -423,6 +432,7 @@ static const builtinspec_t iostreamfunc_info[] = {
     { "io.copyuntil", fl_iocopyuntil },
     { "io.tostring!", fl_iotostring },
     { "input-port-line", fl_iolineno },
+    { "input-port-column", fl_iocolno },
 
     { NULL, NULL }
 };

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -211,7 +211,7 @@ value_t fl_iolineno(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return size_wrap(fl_ctx, s->lineno);
 }
 
-value_t fl_iocolno(fl_context_t *fl_ctx, value_t *args, u_int32_t nargs)
+value_t fl_iocolno(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
 {
     argcount(fl_ctx, "input-port-column", nargs, 1);
     ios_t *s = toiostream(fl_ctx, args[0], "input-port-column");

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -519,6 +519,7 @@
       (memv c '(#\u00ad #\u2061 #\u115f))))
 
 (define (scolno port) (string " near column " (input-port-column port)))
+(define (scolno+1 port) (string " near column " (+ 1 (input-port-column port))))
 
 (define (next-token port s)
   (aset! s 2 (eq? (skip-ws port whitespace-newline) #t))
@@ -553,8 +554,8 @@
           (else
            (read-char port)
            (if (default-ignorable-char? c)
-               (error (string "invisible character \\u" (number->string (fixnum c) 16) (scolno port)))
-               (error (string "invalid character \"" c "\"" (scolno port))))))))
+               (error (string "invisible character \\u" (number->string (fixnum c) 16) (scolno+1 port)))
+               (error (string "invalid character \"" c "\"" (scolno+1 port))))))))
 
 ;; --- token stream ---
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -518,6 +518,8 @@
       (and (char>=? c #\u200c) (char<=? c #\u200f))
       (memv c '(#\u00ad #\u2061 #\u115f))))
 
+(define (scolno port) (string " near column " (input-port-column port)))
+
 (define (next-token port s)
   (aset! s 2 (eq? (skip-ws port whitespace-newline) #t))
   (let ((c (peek-char port)))
@@ -542,7 +544,7 @@
                         ((opchar? nextc)
                          (let ((op (read-operator port c)))
                            (if (and (eq? op '..) (opchar? (peek-char port)))
-                               (error (string "invalid operator \"" op (peek-char port) "\"")))
+                               (error (string "invalid operator \"" op (peek-char port) "\"" (scolno port))))
                            op))
                         (else '|.|)))))
 
@@ -551,8 +553,8 @@
           (else
            (read-char port)
            (if (default-ignorable-char? c)
-               (error (string "invisible character \\u" (number->string (fixnum c) 16)))
-               (error (string "invalid character \"" c "\"")))))))
+               (error (string "invisible character \\u" (number->string (fixnum c) 16) (scolno port)))
+               (error (string "invalid character \"" c "\"" (scolno port))))))))
 
 ;; --- token stream ---
 

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -43,6 +43,7 @@ typedef struct {
 
     int64_t fpos;       // cached file pos
     size_t lineno;    // current line number
+    size_t u_colno;     // current column number (in Unicode charwidths)
 
     // pointer-size integer to support platforms where it might have
     // to be a pointer

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -150,7 +150,7 @@ end
     @test String(sym) == string(Char(0xdcdb))
     @test Meta.lower(Main, sym) === sym
     res = string(Meta.parse(string(Char(0xdcdb)," = 1"),1,raise=false)[1])
-    @test res == """\$(Expr(:error, "invalid character \\\"\\udcdb\\\"\"))"""
+    @test res == """\$(Expr(:error, "invalid character \\\"\\udcdb\\\" near column 0\"))"""
 end
 
 @testset "Symbol and gensym" begin

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -150,7 +150,7 @@ end
     @test String(sym) == string(Char(0xdcdb))
     @test Meta.lower(Main, sym) === sym
     res = string(Meta.parse(string(Char(0xdcdb)," = 1"),1,raise=false)[1])
-    @test res == """\$(Expr(:error, "invalid character \\\"\\udcdb\\\" near column 0\"))"""
+    @test res == """\$(Expr(:error, "invalid character \\\"\\udcdb\\\" near column 1\"))"""
 end
 
 @testset "Symbol and gensym" begin


### PR DESCRIPTION
Fixes #28339.  Now we get error messages like:
```
julia> -0.6626458266981849E−01
ERROR: syntax: invalid character "−" near column 21
```
(Colno-tracking code adapted somewhat from #9579, but accumulates unicode charwidths rather than codeunits/bytes.)