### PR TITLE
Add kw args to squeeze deprecation

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1388,7 +1388,7 @@ export readandwrite
 
 @deprecate flipdim(A, d) reverse(A, dims=d)
 
-@deprecate squeeze dropdims
+@deprecate squeeze(args...; kwargs...) dropdims(args...; kwargs...)
 @deprecate dropdims(A, dims) dropdims(A, dims=dims)
 
 @deprecate diff(A::AbstractMatrix, dim::Integer) diff(A, dims=dim)


### PR DESCRIPTION
Just `@deprecate` doesn't pass through keyword arguments. `@deprecate_binding` seems more appropriate for a renaming.