### PR TITLE
Mask a few corner case cpu features to make rr work out of the box

### DIFF
--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -676,6 +676,8 @@ static TargetData<feature_sz> arg_target_data(const TargetData<feature_sz> &arg,
         }
     }
     enable_depends(res.en.features);
+    // Mask our rdrand/rdseed/rtm/xsaveopt features that LLVM doesn't use and rr disables
+    unset_bits(res.en.features, Feature::rdrnd, Feature::rdseed, Feature::rtm, Feature::xsaveopt);
     for (size_t i = 0; i < feature_sz; i++)
         res.en.features[i] &= ~res.dis.features[i];
     if (require_host) {


### PR DESCRIPTION
rr disables certain non-deterministic CPU features, which throws off
our system image compatibility detection and prevents rr from working
out of the box on an unmodified julia buit from source. However, since
LLVM doesn't make use of these feature bits, it seems fine to just
unconditionally mask them off. If we ever want to use them in the
future, we should use a different mechanism to query them, rather
than burning them into the system image.