### PR TITLE
remove runtime system deprecations

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -329,16 +329,11 @@ function sizeof_tfunc(@nospecialize(x),)
     return Int
 end
 add_tfunc(Core.sizeof, 1, 1, sizeof_tfunc, 0)
-old_nfields(@nospecialize x) = length((isa(x, DataType) ? x : typeof(x)).types)
 add_tfunc(nfields, 1, 1,
     function (@nospecialize(x),)
-        isa(x, Const) && return Const(old_nfields(x.val))
-        isa(x, Conditional) && return Const(old_nfields(Bool))
-        if isType(x)
-            # TODO: remove with deprecation in builtins.c for nfields(::Type)
-            p = x.parameters[1]
-            issingletontype(p) && return Const(old_nfields(p))
-        elseif isa(x, DataType) && !x.abstract && !(x.name === Tuple.name && isvatuple(x)) && x !== DataType
+        isa(x, Const) && return Const(nfields(x.val))
+        isa(x, Conditional) && return Const(0)
+        if isa(x, DataType) && !x.abstract && !(x.name === Tuple.name && isvatuple(x))
             if !(x.name === _NAMEDTUPLE_NAME && !isconcretetype(x))
                 return Const(length(x.types))
             end

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -8,8 +8,6 @@ struct SummarySize
     chargeall::Any
 end
 
-_nfields(@nospecialize x) = length(typeof(x).types)
-
 """
     Base.summarysize(obj; exclude=Union{...}, chargeall=Union{...}) -> Int
 
@@ -43,7 +41,7 @@ function summarysize(obj;
                 val = x[i]
             end
         else
-            nf = _nfields(x)
+            nf = nfields(x)
             ft = typeof(x).types
             if !isbitstype(ft[i]) && isdefined(x, i)
                 val = getfield(x, i)
@@ -70,7 +68,7 @@ end
     # and so is somewhat approximate.
     key = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), obj)
     haskey(ss.seen, key) ? (return 0) : (ss.seen[key] = true)
-    if _nfields(obj) > 0
+    if nfields(obj) > 0
         push!(ss.frontier_x, obj)
         push!(ss.frontier_i, 1)
     end
@@ -89,7 +87,7 @@ function (ss::SummarySize)(obj::DataType)
     key = pointer_from_objref(obj)
     haskey(ss.seen, key) ? (return 0) : (ss.seen[key] = true)
     size::Int = 7 * Core.sizeof(Int) + 6 * Core.sizeof(Int32)
-    size += 4 * _nfields(obj) + ifelse(Sys.WORD_SIZE == 64, 4, 0)
+    size += 4 * nfields(obj) + ifelse(Sys.WORD_SIZE == 64, 4, 0)
     size += ss(obj.parameters)::Int
     size += ss(obj.types)::Int
     return size

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -37,9 +37,8 @@ function include(path::AbstractString)
     elseif INCLUDE_STATE === 2
         result = _include(Base, path)
     else
-        # to help users avoid error (accidentally evaluating into Base), this is deprecated
-        depwarn("Base.include(string) is deprecated, use `include(fname)` or `Base.include(@__MODULE__, fname)` instead.", :include)
-        result = include_relative(_current_module(), path)
+        # to help users avoid error (accidentally evaluating into Base), this is not allowed
+        error("Base.include(string) is discontinued, use `include(fname)` or `Base.include(@__MODULE__, fname)` instead.")
     end
     result
 end

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -650,43 +650,28 @@ JL_CALLABLE(jl_f_isdefined)
 {
     jl_module_t *m = NULL;
     jl_sym_t *s = NULL;
-    JL_NARGSV(isdefined, 1);
-    if (nargs == 1) {
-        JL_TYPECHK(isdefined, symbol, args[0]);
-        s = (jl_sym_t*)args[0];
-    }
-    if (nargs != 2) {
-        JL_NARGS(isdefined, 1, 1);
-        jl_depwarn("`isdefined(:symbol)` is deprecated, "
-                   "use `@isdefined symbol` instead",
-                   (jl_value_t*)jl_symbol("isdefined"));
-        jl_ptls_t ptls = jl_get_ptls_states();
-        m = ptls->current_module;
-    }
-    else {
-        if (!jl_is_module(args[0])) {
-            jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(args[0]);
-            assert(jl_is_datatype(vt));
-            size_t idx;
-            if (jl_is_long(args[1])) {
-                idx = jl_unbox_long(args[1])-1;
-                if (idx >= jl_datatype_nfields(vt))
-                    return jl_false;
-            }
-            else {
-                JL_TYPECHK(isdefined, symbol, args[1]);
-                idx = jl_field_index(vt, (jl_sym_t*)args[1], 0);
-                if ((int)idx == -1)
-                    return jl_false;
-            }
-            return jl_field_isdefined(args[0], idx) ? jl_true : jl_false;
+    JL_NARGS(isdefined, 2, 2);
+    if (!jl_is_module(args[0])) {
+        jl_datatype_t *vt = (jl_datatype_t*)jl_typeof(args[0]);
+        assert(jl_is_datatype(vt));
+        size_t idx;
+        if (jl_is_long(args[1])) {
+            idx = jl_unbox_long(args[1])-1;
+            if (idx >= jl_datatype_nfields(vt))
+                return jl_false;
         }
-        JL_TYPECHK(isdefined, module, args[0]);
-        JL_TYPECHK(isdefined, symbol, args[1]);
-        m = (jl_module_t*)args[0];
-        s = (jl_sym_t*)args[1];
+        else {
+            JL_TYPECHK(isdefined, symbol, args[1]);
+            idx = jl_field_index(vt, (jl_sym_t*)args[1], 0);
+            if ((int)idx == -1)
+                return jl_false;
+        }
+        return jl_field_isdefined(args[0], idx) ? jl_true : jl_false;
     }
-    assert(s);
+    JL_TYPECHK(isdefined, module, args[0]);
+    JL_TYPECHK(isdefined, symbol, args[1]);
+    m = (jl_module_t*)args[0];
+    s = (jl_sym_t*)args[1];
     return jl_boundp(m, s) ? jl_true : jl_false;
 }
 
@@ -863,12 +848,7 @@ JL_CALLABLE(jl_f_nfields)
 {
     JL_NARGS(nfields, 1, 1);
     jl_value_t *x = args[0];
-    if (jl_is_datatype(x))
-        jl_depwarn("`nfields(::DataType)` is deprecated, use `fieldcount` instead",
-                   (jl_value_t*)jl_symbol("nfields"));
-    else
-        x = jl_typeof(x);
-    return jl_box_long(jl_field_count(x));
+    return jl_box_long(jl_field_count(jl_typeof(x)));
 }
 
 // apply_type -----------------------------------------------------------------
@@ -968,13 +948,6 @@ JL_CALLABLE(jl_f_invoke_kwsorter)
     jl_value_t *argtypes = args[3];
     jl_value_t *kws = jl_get_keyword_sorter(func);
     JL_GC_PUSH1(&argtypes);
-    if (jl_is_tuple(argtypes)) {
-        jl_depwarn("`invoke(f, (types...), ...)` is deprecated, "
-                   "use `invoke(f, Tuple{types...}, ...)` instead",
-                   (jl_value_t*)jl_symbol("invoke"));
-        argtypes = (jl_value_t*)jl_apply_tuple_type_v((jl_value_t**)jl_data_ptr(argtypes),
-                                                      jl_nfields(argtypes));
-    }
     if (jl_is_tuple_type(argtypes)) {
         // construct a tuple type for invoking a keyword sorter by putting the kw container type
         // and the type of the function at the front.

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -327,7 +327,6 @@ static Function *box_ssavalue_func;
 static Function *expect_func;
 static Function *jldlsym_func;
 static Function *jltypeassert_func;
-static Function *jldepwarnpi_func;
 //static Function *jlgetnthfield_func;
 static Function *jlgetnthfieldchecked_func;
 //static Function *jlsetnthfield_func;
@@ -7055,14 +7054,6 @@ static void init_julia_llvm_env(Module *m)
     jlgetfield_func = builtin_func_map[jl_f_getfield];
 
     jlapply2va_func = jlcall_func_to_llvm("jl_apply_2va", &jl_apply_2va, m);
-
-    std::vector<Type*> argsdepwarnpi(0);
-    argsdepwarnpi.push_back(T_size);
-    jldepwarnpi_func = Function::Create(FunctionType::get(T_void, argsdepwarnpi, false),
-                                        Function::ExternalLinkage,
-                                        "jl_depwarn_partial_indexing", m);
-    add_named_global(jldepwarnpi_func, &jl_depwarn_partial_indexing);
-
 
     std::vector<Type *> agargs(0);
     agargs.push_back(T_pprjlvalue);

--- a/src/init.c
+++ b/src/init.c
@@ -559,15 +559,6 @@ static void jl_resolve_sysimg_location(JL_IMAGE_SEARCH rel)
     if (!jl_options.julia_bindir) {
         jl_options.julia_bindir = getenv("JULIA_BINDIR");
         if (!jl_options.julia_bindir) {
-            char *julia_bindir = getenv("JULIA_HOME");
-            if (julia_bindir) {
-                jl_depwarn(
-                    "`JULIA_HOME` environment variable is renamed to `JULIA_BINDIR`",
-                    (jl_value_t*)jl_symbol("JULIA_HOME"));
-                jl_options.julia_bindir = julia_bindir;
-            }
-        }
-        if (!jl_options.julia_bindir) {
             jl_options.julia_bindir = dirname(free_path);
         }
     }

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -923,7 +923,6 @@ STATIC_INLINE void *jl_get_frame_addr(void)
 }
 
 JL_DLLEXPORT jl_array_t *jl_array_cconvert_cstring(jl_array_t *a);
-JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n);
 void jl_depwarn(const char *msg, jl_value_t *sym);
 
 // Log `msg` to the current logger by calling CoreLogging.logmsg_shim() on the

--- a/src/module.c
+++ b/src/module.c
@@ -638,19 +638,6 @@ JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b)
     b->constp = 1;
 }
 
-JL_DLLEXPORT jl_value_t *jl_get_current_module(void)
-{
-    jl_ptls_t ptls = jl_get_ptls_states();
-    return (jl_value_t*)ptls->current_module;
-}
-
-JL_DLLEXPORT void jl_set_current_module(jl_value_t *m)
-{
-    jl_ptls_t ptls = jl_get_ptls_states();
-    assert(jl_typeis(m, jl_module_type));
-    ptls->current_module = (jl_module_t*)m;
-}
-
 JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, 0);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -1112,26 +1112,6 @@ void jl_depwarn(const char *msg, jl_value_t *sym)
     JL_GC_POP();
 }
 
-JL_DLLEXPORT void jl_depwarn_partial_indexing(size_t n)
-{
-    static jl_value_t *depwarn_func = NULL;
-    if (!depwarn_func && jl_base_module) {
-        depwarn_func = jl_get_global(jl_base_module, jl_symbol("_depwarn_for_trailing_indices"));
-    }
-    if (!depwarn_func) {
-        jl_safe_printf("WARNING: omitting indices for non-singleton trailing dimensions is deprecated. Use "
-            "`reshape(A, Val(%zd))` or add trailing `1` indices to make the dimensionality of the array match "
-            "the number of indices\n", n);
-        return;
-    }
-    jl_value_t **depwarn_args;
-    JL_GC_PUSHARGS(depwarn_args, 2);
-    depwarn_args[0] = depwarn_func;
-    depwarn_args[1] = jl_box_long(n);
-    jl_apply(depwarn_args, 2);
-    JL_GC_POP();
-}
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -558,16 +558,6 @@ static void import_module(jl_module_t *m, jl_module_t *import)
     }
 }
 
-// replace Base.X with top-level X
-static jl_module_t *deprecation_replacement_module(jl_module_t *parent, jl_sym_t *name)
-{
-    if (parent == jl_base_module) {
-        if (name == jl_symbol("Test") || name == jl_symbol("Mmap"))
-            return call_require(jl_base_module, name);
-    }
-    return NULL;
-}
-
 // in `import A.B: x, y, ...`, evaluate the `A.B` part if it exists
 static jl_module_t *eval_import_from(jl_module_t *m, jl_expr_t *ex, const char *keyword)
 {
@@ -664,30 +654,18 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
                 jl_module_t *u = import;
                 if (name != NULL)
                     u = (jl_module_t*)jl_eval_global_var(import, name);
-                if (jl_is_module(u)) {
-                    if (from) {
-                        jl_depwarn("`using A: B` will only be allowed for single bindings, not modules. Use "
-                                   "`using A.B` instead",
-                                   (jl_value_t*)jl_symbol("using"));
-                    }
+                if (from) {
+                    // `using A: B` syntax
+                    jl_module_use(m, import, name);
+                }
+                else {
+                    // `using A.B` syntax
                     jl_module_using(m, u);
                     if (m == jl_main_module && name == NULL) {
                         // TODO: for now, `using A` in Main also creates an explicit binding for `A`
                         // This will possibly be extended to all modules.
                         import_module(m, u);
                     }
-                }
-                else {
-                    if (!from) {
-                        jl_depwarn("`using A.B` will only be allowed for modules, not single bindings. Use "
-                                   "`using A: B` instead",
-                                   (jl_value_t*)jl_symbol("using"));
-                    }
-                    jl_module_t *replacement = deprecation_replacement_module(import, name);
-                    if (replacement)
-                        jl_module_using(m, replacement);
-                    else
-                        jl_module_use(m, import, name);
                 }
             }
         }
@@ -714,11 +692,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int e
                     import_module(m, import);
                 }
                 else {
-                    jl_module_t *replacement = deprecation_replacement_module(import, name);
-                    if (replacement)
-                        import_module(m, replacement);
-                    else
-                        jl_module_import(m, import, name);
+                    jl_module_import(m, import, name);
                 }
             }
         }

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -17,11 +17,11 @@ A = rand(5,4,3)
     @test checkbounds(Bool, A, 61) == false
     @test checkbounds(Bool, A, 2, 2, 2, 1) == true  # extra indices
     @test checkbounds(Bool, A, 2, 2, 2, 2) == false
-    # @test checkbounds(Bool, A, 1, 1)  == false       # TODO: partial linear indexing (PLI)
-    # @test checkbounds(Bool, A, 1, 12) == false
-    # @test checkbounds(Bool, A, 5, 12) == false
-    # @test checkbounds(Bool, A, 1, 13) == false
-    # @test checkbounds(Bool, A, 6, 12) == false
+    @test checkbounds(Bool, A, 1, 1)  == false
+    @test checkbounds(Bool, A, 1, 12) == false
+    @test checkbounds(Bool, A, 5, 12) == false
+    @test checkbounds(Bool, A, 1, 13) == false
+    @test checkbounds(Bool, A, 6, 12) == false
 end
 
 @testset "single CartesianIndex" begin
@@ -33,16 +33,16 @@ end
     @test checkbounds(Bool, A, CartesianIndex((6, 4, 3))) == false
     @test checkbounds(Bool, A, CartesianIndex((5, 5, 3))) == false
     @test checkbounds(Bool, A, CartesianIndex((5, 4, 4))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((1,))) == false # TODO: PLI
-    # @test checkbounds(Bool, A, CartesianIndex((60,))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((61,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((1,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((60,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((61,))) == false
     @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 1,))) == true
     @test checkbounds(Bool, A, CartesianIndex((2, 2, 2, 2,))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((1, 1,)))  == false # TODO: PLI
-    # @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((1, 13,))) == false
-    # @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((1, 1,)))  == false
+    @test checkbounds(Bool, A, CartesianIndex((1, 12,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((5, 12,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((1, 13,))) == false
+    @test checkbounds(Bool, A, CartesianIndex((6, 12,))) == false
 end
 
 @testset "mix of CartesianIndex and Int" begin
@@ -68,10 +68,10 @@ end
     @test checkbounds(Bool, A, 1:61) == false
     @test checkbounds(Bool, A, 2, 2, 2, 1:1) == true  # extra indices
     @test checkbounds(Bool, A, 2, 2, 2, 1:2) == false
-    # @test checkbounds(Bool, A, 1:5, 1:4) == false # TODO: PLI
-    # @test checkbounds(Bool, A, 1:5, 1:12) == false
-    # @test checkbounds(Bool, A, 1:5, 1:13) == false
-    # @test checkbounds(Bool, A, 1:6, 1:12) == false
+    @test checkbounds(Bool, A, 1:5, 1:4) == false
+    @test checkbounds(Bool, A, 1:5, 1:12) == false
+    @test checkbounds(Bool, A, 1:5, 1:13) == false
+    @test checkbounds(Bool, A, 1:6, 1:12) == false
 end
 
 @testset "logical" begin
@@ -83,9 +83,9 @@ end
     @test checkbounds(Bool, A, trues(61)) == false
     @test checkbounds(Bool, A, 2, 2, 2, trues(1)) == true  # extra indices
     @test checkbounds(Bool, A, 2, 2, 2, trues(2)) == false
-    # @test checkbounds(Bool, A, trues(5), trues(12)) == false # TODO: PLI
-    # @test checkbounds(Bool, A, trues(5), trues(13)) == false
-    # @test checkbounds(Bool, A, trues(6), trues(12)) == false
+    @test checkbounds(Bool, A, trues(5), trues(12)) == false
+    @test checkbounds(Bool, A, trues(5), trues(13)) == false
+    @test checkbounds(Bool, A, trues(6), trues(12)) == false
     @test checkbounds(Bool, A, trues(5, 4, 3)) == true
     @test checkbounds(Bool, A, trues(5, 4, 2)) == false
     @test checkbounds(Bool, A, trues(5, 12)) == false
@@ -417,11 +417,10 @@ function test_scalar_indexing(::Type{T}, shape, ::Type{TestAbstractArray}) where
         @test A[] == B[] == 0
         @test A == B
     else
-        # TODO: Re-enable after PLI deprecation
-        # @test_throws BoundsError A[] = 0
-        # @test_throws BoundsError B[] = 0
-        # @test_throws BoundsError A[]
-        # @test_throws BoundsError B[]
+        @test_throws BoundsError A[] = 0
+        @test_throws BoundsError B[] = 0
+        @test_throws BoundsError A[]
+        @test_throws BoundsError B[]
     end
 end
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -217,10 +217,9 @@ timesofar("constructors")
             @check_bit_operation setindex!(b1, true)  T
             @check_bit_operation setindex!(b1, false) T
         else
-            # TODO: Re-enable after PLI deprecation is removed
-            # @test_throws getindex(b1)
-            # @test_throws setindex!(b1, true)
-            # @test_throws setindex!(b1, false)
+            @test_throws BoundsError getindex(b1)
+            @test_throws BoundsError setindex!(b1, true)
+            @test_throws BoundsError setindex!(b1, false)
         end
     end
 

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -815,7 +815,7 @@ err20033(x::Float64...) = prod(x)
 
 # nfields tfunc on `DataType`
 let f = ()->Val{nfields(DataType[Int][1])}
-    @test f() == Val{0}
+    @test f() == Val{length(DataType.types)}
 end
 
 # inference on invalid getfield call

--- a/test/core.jl
+++ b/test/core.jl
@@ -629,7 +629,8 @@ let
     @test !isdefined(a, :foo)
     @test !isdefined(2, :a)
 
-    @test_throws TypeError isdefined(2)
+    @test_throws TypeError isdefined(Base, 2)
+    @test_throws ArgumentError isdefined(2)
 end
 
 let
@@ -2450,7 +2451,7 @@ end
 # pull request #9534
 @test_throws BoundsError((1, 2), 3) begin; a, b, c = 1, 2; end
 let a = []
-    @test_broken try; a[]; catch ex; (ex::BoundsError).a === a && ex.i == (1,); end # TODO: Re-enable after PLI
+    @test try; a[]; catch ex; (ex::BoundsError).a === a && ex.i == (); end
     @test_throws BoundsError(a, (1, 2)) a[1, 2]
     @test_throws BoundsError(a, (10,)) a[10]
 end

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -163,17 +163,16 @@ function test_bounds(@nospecialize(A))
     @test_throws BoundsError A[end+1, 1, 1, trailing3...]
     @test_throws BoundsError A[1, 0, 1, trailing3...]
     @test_throws BoundsError A[1, end+1, 1, trailing3...]
-    # TODO: PLI (re-enable after 0.7)
-    # @test_throws BoundsError A[1, 0]
-    # @test_throws BoundsError A[1, end+1]
-    # @test_throws BoundsError A[1, 1, 0]
-    # @test_throws BoundsError A[1, 1, end+1]
-    # @test_throws BoundsError A[0, 1]
-    # @test_throws BoundsError A[end+1, 1]
-    # @test_throws BoundsError A[0, 1, 1]
-    # @test_throws BoundsError A[end+1, 1, 1]
-    # @test_throws BoundsError A[1, 0, 1]
-    # @test_throws BoundsError A[1, end+1, 1]
+    @test_throws BoundsError A[1, 0]
+    @test_throws BoundsError A[1, end+1]
+    @test_throws BoundsError A[1, 1, 0]
+    @test_throws BoundsError A[1, 1, end+1]
+    @test_throws BoundsError A[0, 1]
+    @test_throws BoundsError A[end+1, 1]
+    @test_throws BoundsError A[0, 1, 1]
+    @test_throws BoundsError A[end+1, 1, 1]
+    @test_throws BoundsError A[1, 0, 1]
+    @test_throws BoundsError A[1, end+1, 1]
 end
 
 function dim_break_linindex(I)


### PR DESCRIPTION
@mbauman There's a test in test/core.jl that expects a BoundsError with indices `(1,)` from `a[]`. I found it was `()` instead. Is this right?