### PR TITLE
Check for __precompile__(false) before attempting to precompile

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -926,9 +926,10 @@ function _require(pkg::PkgId)
                  - Run `Pkg.instantiate()` to install all recorded dependencies.
                 """))
         end
+        needs_precompile = !occursin(r"__precompile__\(false\)", read(path, String))
 
         # attempt to load the module file via the precompile cache locations
-        if JLOptions().use_compiled_modules != 0
+        if JLOptions().use_compiled_modules != 0 && needs_precompile
             m = _require_search_from_serialized(pkg, path)
             if !isa(m, Bool)
                 return
@@ -948,7 +949,7 @@ function _require(pkg::PkgId)
             end
         end
 
-        if JLOptions().use_compiled_modules != 0
+        if JLOptions().use_compiled_modules != 0 && needs_precompile
             if (0 == ccall(:jl_generating_output, Cint, ())) || (JLOptions().incremental != 0)
                 # spawn off a new incremental pre-compile task for recursive `require` calls
                 # or if the require search declared it was pre-compiled before (and therefore is expected to still be pre-compilable)

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -281,6 +281,7 @@ try
           """
           __precompile__(false)
           module Baz
+          baz() = 1
           end
           """)
 
@@ -291,6 +292,8 @@ try
         isa(exc, ErrorException) || rethrow(exc)
         occursin("__precompile__(false)", exc.msg) && rethrow(exc)
     end
+    @eval using Baz
+    @test Base.invokelatest(Baz.baz) == 1
 
     # Issue #12720
     FooBar1_file = joinpath(dir, "FooBar1.jl")


### PR DESCRIPTION
Fixes #28384

This is far from ideal, because it triggers an extra file-read for every single package. But given the urgency, I was reluctant to embark on a more serious reorganization without posting the simple fix first.
