### PR TITLE
Docs: fix deprecated docm syntax use of deprecated REPL reference

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -497,7 +497,7 @@ function docm(source::LineNumberNode, mod::Module, ex)
         return docm(source, mod, ex.args...)
     else
         # TODO: this is a shim to continue to allow `@doc` for looking up docstrings
-        REPL = Base.root_module(Base, :REPL)
+        REPL = Base.REPL_MODULE_REF[]
         return REPL.lookup_doc(ex)
     end
 end


### PR DESCRIPTION
Commit by @vtjnash. Fixes a precompilation error in Distances.jl

https://travis-ci.org/JuliaStats/Distances.jl/builds/410480874?utm_source=github_status&utm_medium=notification

```
ERROR: LoadError: LoadError: LoadError: MethodError: no method matching root_module(::Nothing)
Closest candidates are:
  root_module(!Matched::Module, !Matched::Symbol) at loading.jl:893
  root_module(!Matched::Base.PkgId) at loading.jl:892
Stacktrace:
 [1] root_module(::Module, ::Symbol) at ./loading.jl:893
 [2] docm(::LineNumberNode, ::Module, ::Any) at ./docs/Docs.jl:500
 [3] @doc(::LineNumberNode, ::Module, ::Symbol) at ./boot.jl:451
 [4] include at ./boot.jl:317 [inlined]
 [5] include_relative(::Module, ::String) at ./loading.jl:1034
 [6] include at ./sysimg.jl:29 [inlined]
 [7] include(::String) at /home/travis/build/JuliaStats/Distances.jl/src/Distances.jl:3
 [8] top-level scope at none:0
 [9] include at ./boot.jl:317 [inlined]
 [10] include_relative(::Module, ::String) at ./loading.jl:1034
 [11] include(::Module, ::String) at ./sysimg.jl:29
 [12] top-level scope at none:0
 [13] eval at ./boot.jl:319 [inlined]
 [14] eval(::Expr) at ./client.jl:399
 [15] top-level scope at ./none:3
```
