### PR TITLE
improve bitshift precedence deprecation to handle more operators

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -119,8 +119,8 @@ function UInt32(c::Char)
         invalid_char(c)::Union{}
     u &= 0xffffffff >> l1
     u >>= t0
-    (u & 0x0000007f >> 0) | (u & 0x00007f00 >> 2) |
-    (u & 0x007f0000 >> 4) | (u & 0x7f000000 >> 6)
+    ((u & 0x0000007f) >> 0) | ((u & 0x00007f00) >> 2) |
+    ((u & 0x007f0000) >> 4) | ((u & 0x7f000000) >> 6)
 end
 
 function decode_overlong(c::Char)
@@ -129,8 +129,8 @@ function decode_overlong(c::Char)
     t0 = trailing_zeros(u) & 56
     u &= 0xffffffff >> l1
     u >>= t0
-    (u & 0x0000007f >> 0) | (u & 0x00007f00 >> 2) |
-    (u & 0x007f0000 >> 4) | (u & 0x7f000000 >> 6)
+    ((u & 0x0000007f) >> 0) | ((u & 0x00007f00) >> 2) |
+    ((u & 0x007f0000) >> 4) | ((u & 0x7f000000) >> 6)
 end
 
 """

--- a/base/hashing2.jl
+++ b/base/hashing2.jl
@@ -101,7 +101,7 @@ function decompose(x::Float16)::NTuple{3,Int}
     isinf(x) && return ifelse(x < 0, -1, 1), 0, 0
     n = reinterpret(UInt16, x)
     s = (n & 0x03ff) % Int16
-    e = (n & 0x7c00 >> 10) % Int
+    e = ((n & 0x7c00) >> 10) % Int
     s |= Int16(e != 0) << 10
     d = ifelse(signbit(x), -1, 1)
     s, e - 25 + (e == 0), d
@@ -112,7 +112,7 @@ function decompose(x::Float32)::NTuple{3,Int}
     isinf(x) && return ifelse(x < 0, -1, 1), 0, 0
     n = reinterpret(UInt32, x)
     s = (n & 0x007fffff) % Int32
-    e = (n & 0x7f800000 >> 23) % Int
+    e = ((n & 0x7f800000) >> 23) % Int
     s |= Int32(e != 0) << 23
     d = ifelse(signbit(x), -1, 1)
     s, e - 150 + (e == 0), d
@@ -123,7 +123,7 @@ function decompose(x::Float64)::Tuple{Int64, Int, Int}
     isinf(x) && return ifelse(x < 0, -1, 1), 0, 0
     n = reinterpret(UInt64, x)
     s = (n & 0x000fffffffffffff) % Int64
-    e = (n & 0x7ff0000000000000 >> 52) % Int
+    e = ((n & 0x7ff0000000000000) >> 52) % Int
     s |= Int64(e != 0) << 52
     d = ifelse(signbit(x), -1, 1)
     s, e - 1075 + (e == 0), d

--- a/base/math.jl
+++ b/base/math.jl
@@ -325,11 +325,11 @@ end
     elseif x <= -1023
         # if -1073 < x <= -1023 then Result will be a subnormal number
         # Hex literal with padding must be used to work on 32bit machine
-        reinterpret(Float64, 0x0000_0000_0000_0001 << ((x + 1074)) % UInt)
+        reinterpret(Float64, 0x0000_0000_0000_0001 << ((x + 1074) % UInt))
     else
         # We will cast everything to Int64 to avoid errors in case of Int128
         # If x is a Int128, and is outside the range of Int64, then it is not -1023<x<=1023
-        reinterpret(Float64, (exponent_bias(Float64) + (x % Int64)) << (significand_bits(Float64)) % UInt)
+        reinterpret(Float64, (exponent_bias(Float64) + (x % Int64)) << (significand_bits(Float64) % UInt))
     end
 end
 

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -919,16 +919,16 @@
                   ((memq t chain-ops)
                    (loop (list* 'call t ex
                                 (parse-chain s down t))
-                         #t))
+                         t))
                   (else
                    (loop (list 'call t ex (down s))
-                         got))))))))
+                         t))))))))
 
 (define (parse-expr s)     (parse-with-chains s parse-shift         is-prec-plus? '(+ ++)))
 
-(define (bitshift-warn s)
-  (parser-depwarn s (string "call to `*` inside call to bitshift operator")
-                  "parenthesized call to `*`"))
+(define (bitshift-warn s op)
+  (parser-depwarn s (string "call to `" op "` inside call to bitshift operator")
+                  (string "parenthesized call to `" op "`")))
 
 (define (parse-shift s)    #;(parse-LtoR        s parse-term          is-prec-bitshift?)
   (let loop ((ex (parse-term s))
@@ -937,11 +937,11 @@
     (let ((ex (car ex))
           (warn (cdr ex)))
       (if (is-prec-bitshift? t)
-          (begin (if warn (bitshift-warn s))
+          (begin (if warn (bitshift-warn s warn))
                  (take-token s)
                  (let ((nxt (parse-term s)))
                    (loop (cons (list 'call t ex (car nxt)) (cdr nxt)) (peek-token s) (cdr nxt))))
-          (begin (if warn1 (bitshift-warn s))
+          (begin (if warn1 (bitshift-warn s warn1))
                  ex)))))
 
 (define (parse-term s)     (parse-with-chains-warn s parse-rational      is-prec-times? '(*)))

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -196,7 +196,7 @@ function SamplerRangeFast(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}
     isempty(r) && throw(ArgumentError("range must be non-empty"))
     m = (last(r) - first(r)) % unsigned(T) % U # % unsigned(T) to not propagate sign bit
     bw = (sizeof(U) << 3 - leading_zeros(m)) % UInt # bit-width
-    mask = (1 % U << bw) - (1 % U)
+    mask = ((1 % U) << bw) - (1 % U)
     SamplerRangeFast{U,T}(first(r), bw, m, mask)
 end
 

--- a/stdlib/Sockets/src/IPAddr.jl
+++ b/stdlib/Sockets/src/IPAddr.jl
@@ -104,7 +104,7 @@ function ipv6_field(ip::IPv6,i)
     if i < 0 || i > 7
         throw(BoundsError())
     end
-    UInt16(ip.host&(UInt128(0xFFFF)<<(i*16))>>(i*16))
+    UInt16((ip.host&(UInt128(0xFFFF)<<(i*16)))>>(i*16))
 end
 
 show(io::IO, ip::IPv6) = print(io,"ip\"",ip,"\"")


### PR DESCRIPTION
While removing deprecations I discovered that the bitshift precedence deprecation was missing some cases. This is pretty important for avoiding hard-to-find bugs when the precedence changes in 1.0.