### PR TITLE
RFC: prettier IR-show for line number and inlining information

### DIFF
--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -321,9 +321,14 @@ lineinfo_disabled(io::IO, linestart::String, lineidx::Int32) = ""
 
 function DILineInfoPrinter(linetable::Vector)
     context = LineInfoNode[]
-    indent(s::String) = s^(max(length(context), 1) - 1)
+    context_depth = Ref(0)
+    indent(s::String) = s^(max(context_depth[], 1) - 1)
     function emit_lineinfo_update(io::IO, linestart::String, lineidx::Int32)
-        lineidx == 0 && return indent("│") # just skip over lines with no debug info at all
+        # internal configuration options:
+        collapse = true
+        indent_all = true
+        # convert lineidx to a vector
+        lineidx == 0 && return indent_all ? indent("│") : "" # just skip over lines with no debug info at all
         DI = LineInfoNode[]
         while lineidx != 0
             entry = linetable[lineidx]::LineInfoNode
@@ -331,50 +336,120 @@ function DILineInfoPrinter(linetable::Vector)
             lineidx = entry.inlined_at
         end
         nframes = length(DI)
-        nctx = length(context)
-        # look for a matching prefix in the inlining information stack
-        if nctx > nframes
-            resize!(context, nframes)
-        end
-        update_line_only = false
-        for i = 1:length(context)
+        nctx = 0
+        pop_skips = 0
+        # compute the size of the matching prefix in the inlining information stack
+        for i = 1:min(length(context), nframes)
             CtxLine = context[i]
             FrameLine = DI[nframes - i + 1]
-            if CtxLine !== FrameLine
-                if CtxLine.file == FrameLine.file &&
-                        CtxLine.method == FrameLine.method &&
-                        CtxLine.mod == FrameLine.mod
+            CtxLine === FrameLine || break
+            nctx = i
+        end
+        update_line_only = false
+        if collapse && 0 < nctx
+            # check if we're adding more frames with the same method name,
+            # if so, drop all existing calls to it from the top of the context
+            # AND check if instead the context was previously printed that way
+            # but now has removed the recursive frames
+            let method = context[nctx].method
+                if (nctx < nframes && DI[nframes - nctx].method === method) ||
+                   (nctx < length(context) && context[nctx + 1].method === method)
                     update_line_only = true
+                    while nctx > 0 && context[nctx].method === method
+                        nctx -= 1
+                    end
                 end
-                resize!(context, i - 1)
-                break
             end
         end
-        npops = nctx - length(context) - update_line_only
-        if npops > 0
-            print(io, linestart, indent("│"))
-            update_line_only && print(io, "│")
-            print(io, "┘"^npops, "\n")
+        # examine what frames we're returning from
+        if nctx < length(context)
+            # compute the new inlining depth
+            if collapse
+                npops = 1
+                let Prev = context[nctx + 1].method
+                    for i = (nctx + 2):length(context)
+                        Next = context[i].method
+                        Prev === Next || (npops += 1)
+                        Prev = Next
+                    end
+                end
+            else
+                npops = length(context) - nctx
+            end
+            # look at the first non-matching element to see if we are only changing the line number
+            if !update_line_only && nctx < nframes
+                let CtxLine = context[nctx + 1],
+                    FrameLine = DI[nframes - nctx]
+                    if CtxLine.file == FrameLine.file &&
+                            CtxLine.method == FrameLine.method &&
+                            CtxLine.mod == FrameLine.mod
+                        update_line_only = true
+                    end
+                end
+            end
+            resize!(context, nctx)
+            update_line_only && (npops -= 1)
+            if npops > 0
+                context_depth[] -= npops
+                print(io, linestart, indent("│"), "┘"^npops, "\n")
+            end
         end
+        # see what change we made to the outermost line number
         if update_line_only
-            frame = DI[nframes - length(context)]
+            frame = DI[nframes - nctx]
+            nctx += 1
             push!(context, frame)
             if frame.line != typemax(frame.line) && frame.line != 0
-                print(io, linestart, indent("│"), " @ ", frame.file, ":", frame.line, " within `", frame.method, "'\n")
+                print(io, linestart, indent("│"), " @ ", frame.file, ":", frame.line, " within `", frame.method, "'")
+                if collapse
+                    method = frame.method
+                    while nctx < nframes
+                        frame = DI[nframes - nctx]
+                        frame.method === method || break
+                        nctx += 1
+                        push!(context, frame)
+                        print(io, " @ ", frame.file, ":", frame.line)
+                    end
+                end
+                print(io, "\n")
             end
         end
-        for i = length(context):(nframes - 1)
-            frame = DI[nframes - i]
+        # now print the rest of the new frames
+        while nctx < nframes
+            frame = DI[nframes - nctx]
             print(io, linestart, indent("│"))
+            nctx += 1
             push!(context, frame)
-            i != 0 && print(io, "┌")
+            context_depth[] += 1
+            nctx != 1 && print(io, "┌")
             print(io, " @ ", frame.file)
             if frame.line != typemax(frame.line) && frame.line != 0
                 print(io, ":", frame.line)
             end
-            print(io, " within `", frame.method, "'\n")
+            print(io, " within `", frame.method, "'")
+            if collapse
+                method = frame.method
+                while nctx < nframes
+                    frame = DI[nframes - nctx]
+                    frame.method === method || break
+                    nctx += 1
+                    push!(context, frame)
+                    print(io, " @ ", frame.file, ":", frame.line)
+                end
+            end
+            print(io, "\n")
         end
-        return indent("│")
+        # FOR DEBUGGING `collapse`:
+        #let Prev = context[1].method,
+        #    depth2 = 1
+        #    for i = 2:nctx
+        #        Next = context[i].method
+        #        (collapse && Prev === Next) || (depth2 += 1)
+        #        Prev = Next
+        #    end
+        #    @assert context_depth[] == depth2
+        #end
+        return indent_all ? indent("│") : ""
     end
     return emit_lineinfo_update
 end

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -21,13 +21,15 @@ function Base.show(io::IO, cfg::CFG)
 end
 
 function print_stmt(io::IO, idx::Int, @nospecialize(stmt), used::BitSet, maxlength_idx::Int, color::Bool, show_type::Bool)
-    indent = maxlength_idx + 4
     if idx in used
-        pad = " "^(maxlength_idx - length(string(idx)) + 1)
-        print(io, "%", idx, pad, "= ")
+        idx_s = string(idx)
+        pad = " "^(maxlength_idx - length(idx_s) + 1)
+        print(io, "%", idx_s, pad, "= ")
     else
-        print(io, " "^indent)
+        print(io, " "^(maxlength_idx + 4))
     end
+    # TODO: `indent` is supposed to be the full width of the leader for correct alignment
+    indent = 16
     if !color && stmt isa PiNode
         # when the outer context is already colored (yellow, for pending nodes), don't use the usual coloring printer
         print(io, "π (")
@@ -314,6 +316,70 @@ end
 
 Base.show(io::IO, code::IRCode) = show_ir(io, code)
 
+
+lineinfo_disabled(io::IO, linestart::String, lineidx::Int32) = ""
+
+function DILineInfoPrinter(linetable::Vector)
+    context = LineInfoNode[]
+    indent(s::String) = s^(max(length(context), 1) - 1)
+    function emit_lineinfo_update(io::IO, linestart::String, lineidx::Int32)
+        lineidx == 0 && return indent("│") # just skip over lines with no debug info at all
+        DI = LineInfoNode[]
+        while lineidx != 0
+            entry = linetable[lineidx]::LineInfoNode
+            push!(DI, entry)
+            lineidx = entry.inlined_at
+        end
+        nframes = length(DI)
+        nctx = length(context)
+        # look for a matching prefix in the inlining information stack
+        if nctx > nframes
+            resize!(context, nframes)
+        end
+        update_line_only = false
+        for i = 1:length(context)
+            CtxLine = context[i]
+            FrameLine = DI[nframes - i + 1]
+            if CtxLine !== FrameLine
+                if CtxLine.file == FrameLine.file &&
+                        CtxLine.method == FrameLine.method &&
+                        CtxLine.mod == FrameLine.mod
+                    update_line_only = true
+                end
+                resize!(context, i - 1)
+                break
+            end
+        end
+        npops = nctx - length(context) - update_line_only
+        if npops > 0
+            print(io, linestart, indent("│"))
+            update_line_only && print(io, "│")
+            print(io, "┘"^npops, "\n")
+        end
+        if update_line_only
+            frame = DI[nframes - length(context)]
+            push!(context, frame)
+            if frame.line != typemax(frame.line) && frame.line != 0
+                print(io, linestart, indent("│"), " @ ", frame.file, ":", frame.line, " within `", frame.method, "'\n")
+            end
+        end
+        for i = length(context):(nframes - 1)
+            frame = DI[nframes - i]
+            print(io, linestart, indent("│"))
+            push!(context, frame)
+            i != 0 && print(io, "┌")
+            print(io, " @ ", frame.file)
+            if frame.line != typemax(frame.line) && frame.line != 0
+                print(io, ":", frame.line)
+            end
+            print(io, " within `", frame.method, "'\n")
+        end
+        return indent("│")
+    end
+    return emit_lineinfo_update
+end
+
+
 function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_printer; verbose_linetable=false)
     cols = displaysize(io)[2]
     used = BitSet()
@@ -465,7 +531,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
     end
 end
 
-function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_printer; verbose_linetable=false)
+function show_ir(io::IO, code::CodeInfo, line_info_preprinter=DILineInfoPrinter(code.linetable), line_info_postprinter=default_expr_type_printer)
     cols = displaysize(io)[2]
     used = BitSet()
     stmts = code.code
@@ -483,14 +549,6 @@ function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_pri
         maxused = maximum(used)
         maxlength_idx = length(string(maxused))
     end
-    if !verbose_linetable
-        (loc_annotations, loc_methods, loc_lineno) = compute_ir_line_annotations(code)
-        max_loc_width = maximum(length(str) for str in loc_annotations)
-        max_lineno_width = maximum(length(str) for str in loc_lineno)
-        max_method_width = maximum(length(str) for str in loc_methods)
-    end
-    max_depth = maximum(compute_inlining_depth(code.linetable, line) for line in code.codelocs)
-    last_stack = []
     for idx in eachindex(stmts)
         if !isassigned(stmts, idx)
             # This is invalid, but do something useful rather
@@ -499,63 +557,24 @@ function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_pri
             continue
         end
         stmt = stmts[idx]
-        # Compute BB guard rail
         bbrange = cfg.blocks[bb_idx].stmts
         bbrange = bbrange.first:bbrange.last
-        bb_idx_str = string(bb_idx)
-        bb_pad = max_bb_idx_size - length(bb_idx_str)
-        bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
-        bb_start_str = string(bb_idx_str, " ", bb_type, "─"^bb_pad, " ")
-        bb_guard_rail_cont = string("│  ", " "^max_bb_idx_size)
+        # Print line info update
+        linestart = idx == first(bbrange) ? "  " : sprint(io -> printstyled(io, "│ ", color=:light_black), context=io)
+        linestart *= " "^max_bb_idx_size
+        inlining_indent = line_info_preprinter(io, linestart, code.codelocs[idx])
+        # Compute BB guard rail
         if idx == first(bbrange)
-            bb_guard_rail = bb_start_str
+            bb_idx_str = string(bb_idx)
+            bb_pad = max_bb_idx_size - length(bb_idx_str)
+            bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
+            printstyled(io, bb_idx_str, " ", bb_type, "─"^bb_pad, color=:light_black)
+        elseif idx == last(bbrange) # print separator
+            printstyled(io, "└", "─"^(1 + max_bb_idx_size), color=:light_black)
         else
-            bb_guard_rail = bb_guard_rail_cont
+            printstyled(io, "│ ", " "^max_bb_idx_size, color=:light_black)
         end
-        # Print linetable information
-        if verbose_linetable
-            stack = compute_loc_stack(code.linetable, code.codelocs[idx])
-            # We need to print any stack frames that did not exist in the last stack
-            ndepth = max(1, length(stack))
-            rail = string(" "^(max_depth+1-ndepth), "│"^ndepth)
-            start_column = cols - max_depth - 10
-            for (i, x) in enumerate(stack)
-                if i > length(last_stack) || last_stack[i] != x
-                    entry = code.linetable[x]
-                    printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
-                    print(io, bb_guard_rail)
-                    ssa_guard = " "^(maxlength_idx + 4 + (i - 1))
-                    entry_label = "$(ssa_guard)$(entry.method) at $(entry.file):$(entry.line) "
-                    hline = string("─"^(start_column-length(entry_label)-length(bb_guard_rail)+max_depth-i), "┐")
-                    printstyled(io, string(entry_label, hline), "\n"; color=:light_black)
-                    bb_guard_rail = bb_guard_rail_cont
-                end
-            end
-            printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
-            last_stack = stack
-        else
-            annotation = loc_annotations[idx]
-            loc_method = loc_methods[idx]
-            lineno = loc_lineno[idx]
-            # Print location information right aligned. If the line below is too long, it'll overwrite this,
-            # but that's what we want.
-            if get(io, :color, false)
-                method_start_column = cols - max_method_width - max_loc_width - 2
-                filler = " "^(max_loc_width-length(annotation))
-                printstyled(io, "\e[$(method_start_column)G$(annotation)$(filler)$(loc_method)\e[1G", color = :light_black)
-            end
-            printstyled(io, lineno, " "^(max_lineno_width-length(lineno)+1); color = :light_black)
-        end
-        idx != last(bbrange) && print(io, bb_guard_rail)
-        if idx == last(bbrange) # print separator
-            if idx == first(bbrange)
-                print(io, bb_start_str)
-            elseif idx == last(bbrange)
-                print(io, "└", "─"^(1 + max_bb_idx_size), " ")
-            else
-                print(io, "│  ", " "^max_bb_idx_size)
-            end
-        end
+        print(io, inlining_indent, " ")
         if idx == last(bbrange)
             bb_idx += 1
         end
@@ -582,7 +601,7 @@ function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_pri
                 printstyled(io, "::#UNDEF", color=:red)
             elseif show_type
                 typ = types[idx]
-                expr_type_printer(io, typ, idx in used)
+                line_info_postprinter(io, typ, idx in used)
             end
         end
         println(io)

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -94,12 +94,13 @@ particular interest for understanding how language constructs map to primitive o
 as assignments, branches, and calls:
 
 ```jldoctest
-julia> Meta.lower(@__MODULE__, :([1+2, sin(0.5)]) )
+julia> Meta.lower(@__MODULE__, :( [1+2, sin(0.5)] ))
 :($(Expr(:thunk, CodeInfo(
- 1 ─ %1 = 1 + 2
- │   %2 = sin(0.5)
- │   %3 = (Base.vect)(%1, %2)
- └──      return %3
+    @ none within `top-level scope'
+1 ─ %1 = 1 + 2
+│   %2 = sin(0.5)
+│   %3 = (Base.vect)(%1, %2)
+└──      return %3
 ))))
 ```
 
@@ -122,11 +123,11 @@ calls and expand argument types automatically:
 ```julia-repl
 julia> @code_llvm +(1,1)
 
-; Function Attrs: sspreq
-define i64 @"julia_+_130862"(i64, i64) #0 {
+;  @ int.jl:53 within `+'
+define i64 @"julia_+_130862"(i64, i64) {
 top:
-    %2 = add i64 %1, %0, !dbg !8
-    ret i64 %2, !dbg !8
+    %2 = add i64 %1, %0
+    ret i64 %2
 }
 ```
 

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -17,7 +17,7 @@ function warntype_type_printer(io::IO, @nospecialize(ty), used::Bool)
 end
 
 """
-    code_warntype([io::IO], f, types; verbose_linetable=false)
+    code_warntype([io::IO], f, types)
 
 Prints lowered and type-inferred ASTs for the methods matching the given generic function
 and type signature to `io` which defaults to `stdout`. The ASTs are annotated in such a way
@@ -26,12 +26,9 @@ This serves as a warning of potential type instability. Not all non-leaf types a
 problematic for performance, so the results need to be used judiciously.
 In particular, unions containing either [`missing`](@ref) or [`nothing`](@ref) are displayed in yellow, since
 these are often intentional.
-If the `verbose_linetable` keyword is set, the linetable will be printed
-in verbose mode, showing all available information (rather than applying
-the usual heuristics).
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
-function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); verbose_linetable=false)
+function code_warntype(io::IO, @nospecialize(f), @nospecialize(t))
     for (src, rettype) in code_typed(f, t)
         lambda_io::IOContext = io
         if src.slotnames !== nothing
@@ -41,8 +38,7 @@ function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); verbose_linet
         warntype_type_printer(io, rettype, true)
         println(io)
         # TODO: static parameter values
-        Base.IRShow.show_ir(lambda_io, src, warntype_type_printer;
-                            verbose_linetable = verbose_linetable)
+        Base.IRShow.show_ir(lambda_io, src, Base.IRShow.DILineInfoPrinter(src.linetable), warntype_type_printer)
     end
     nothing
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1280,10 +1280,14 @@ Int64
 
 julia> @code_warntype f(1, 2, 3)
 Body::UNION{FLOAT64, INT64}
-1 1 ─ %1 = (Base.slt_int)(1, b)::Bool
-  └──      goto #3 if not %1
-  2 ─      return 1
-  3 ─      return 1.0
+    @ none:1 within `f'
+   ┌ @ operators.jl:286 within `>'
+   │┌ @ int.jl:49 within `<'
+1 ─││ %1 = (Base.slt_int)(1, b)::Bool
+│  ┘┘
+└──      goto #3 if not %1
+2 ─      return 1
+3 ─      return 1.0
 
 julia> @inferred f(1, 2, 3)
 ERROR: return type Int64 does not match inferred return type Union{Float64, Int64}

--- a/test/show.jl
+++ b/test/show.jl
@@ -1343,9 +1343,12 @@ eval(Meta.parse("""function my_fun28173(x)
 end""")) # use parse to control the line numbers
 let src = code_typed(my_fun28173, (Int,))[1][1]
     ir = Core.Compiler.inflate_ir(src)
-    source_slotnames = String["my_fun28173", "x"]
-    irshow = sprint(show, ir, context = :SOURCE_SLOTNAMES=>source_slotnames)
-    @test repr(src) == "CodeInfo(\n" * irshow * ")"
+    fill!(src.codelocs, 0) # IRCode printing is only capable of printing partial line info
+    let source_slotnames = String["my_fun28173", "x"],
+        repr_ir = split(repr(ir, context = :SOURCE_SLOTNAMES=>source_slotnames), '\n'),
+        repr_ir = "CodeInfo(\n" * join((l[4:end] for l in repr_ir), "\n") * ")" # remove line numbers
+        @test repr(src) == repr_ir
+    end
     lines1 = split(repr(ir), '\n')
     @test isempty(pop!(lines1))
     Core.Compiler.insert_node!(ir, 1, Val{1}, QuoteNode(1), false)


### PR DESCRIPTION
As suggested by maleadt in the original LineNumber info PR, this uses box-drawing characters and indentation to improve readability of `code_llvm` (and should trigger detection in certain terminals of line number hyperlinking). As a second step, it uses the same line number formatting across all of `code_lowered` / `code_typed` / `code_warntype` / `code_llvm` / `code_native`, for a more consistent experience.

A sample example:
(note that in the terminal, there is additional usage of color to further improve visibility of various elements)
```
julia> function g(A)
           v = 0
           @simd for i = 1:length(A)
               @inbounds ai = A[i]
               if ai !== missing
                   v += ai
               end
           end
           return v
       end
g (generic function with 1 method)

julia> code_lowered(g, (typeof([1,missing]),))
1-element Array{Core.CodeInfo,1}:
 CodeInfo(
    @ REPL[1]:2 within `g'
1 ──       v = 0
│   @ REPL[1]:3 within `g'
│  ┌ @ simdloop.jl:65 within `macro expansion'
│    %2  = (Main.length)(A)
│          r#368 = 1:%2
│  │ @ simdloop.jl:66 within `macro expansion'
│    %4  = Base.simd_outer_range
│    %5  = (%4)(r#368)
│          #temp# = (Base.iterate)(%5)
│    %7  = #temp# === nothing
│    %8  = (Base.not_int)(%7)
└───       goto #11 if not %8
2 ┄─ %10 = #temp#
│          i#369 = (Core.getfield)(%10, 1)
│    %12 = (Core.getfield)(%10, 2)
│  │ @ simdloop.jl:67 within `macro expansion'
│          Core.NewvarNode(:(i@_7))
│    %14 = Base.simd_inner_length
│    %15 = r#368
│          n#370 = (%14)(%15, i#369)
│  │ @ simdloop.jl:68 within `macro expansion'
│    %17 = (Main.zero)(n#370)
│    %18 = %17 < n#370
└───       goto #9 if not %18
   │ @ simdloop.jl:70 within `macro expansion'
3 ──       i#371 = (Main.zero)(n#370)
   │ @ simdloop.jl:71 within `macro expansion'
4 ┄─ %21 = i#371 < n#370
└───       goto #8 if not %21
   │ @ simdloop.jl:72 within `macro expansion'
5 ── %23 = Base.simd_index
│    %24 = r#368
│    %25 = i#369
│          i@_12 = (%23)(%24, %25, i#371)
│  │ @ simdloop.jl:73 within `macro expansion'
│  │┌ @ REPL[1]:4 within `macro expansion'
│          $(Expr(:inbounds, true))
│    %28 = (Base.getindex)(A, i@_12)
│          ai = %28
│          val = %28
│          $(Expr(:inbounds, :pop))
│          val
│  ││ @ REPL[1]:5 within `macro expansion'
│    %33 = ai !== Main.missing
└───       goto #7 if not %33
   ││ @ REPL[1]:6 within `macro expansion'
6 ──       v = v + ai
   ││ @ REPL[1]:4 within `macro expansion'
7 ┄─       i#371 = i#371 + 1
│  ││ @ REPL[1]:5 within `macro expansion'
│          $(Expr(:simdloop, false))
└───       goto #4
   ││ @ REPL[1]:6 within `macro expansion'
8 ──       i@_7 = (Main.last)(r#368)
9 ┄─       #temp# = (Base.iterate)(%5, %12)
│    %41 = #temp# === nothing
│    %42 = (Base.not_int)(%41)
└───       goto #11 if not %42
10 ─       goto #2
   │┘
   │ @ simdloop.jl:74 within `macro expansion'
11 ┄       Main.nothing
│  │ @ simdloop.jl:65 within `macro expansion'
└───       return v
)

julia> code_typed(g, (typeof([1,missing]),))
1-element Array{Any,1}:
 CodeInfo(
    @ REPL[1]:3 within `g'
   ┌ @ simdloop.jl:65 within `macro expansion'
   │┌ @ array.jl:199 within `length'
1 ── %1  = (Base.arraylen)(A)::Int64
│  │┘
│  │┌ @ range.jl:5 within `Colon'
│  ││┌ @ range.jl:255 within `Type'
│  │││┌ @ range.jl:260 within `unitrange_last'
│  ││││┌ @ operators.jl:333 within `>='
│  │││││┌ @ int.jl:428 within `<='
│    %2  = (Base.sle_int)(1, %1)::Bool
│  ││││┘┘
│  ││││┌ @ int.jl:52 within `-'
│          (Base.sub_int)(%1, 1)::Int64
│  ││││┘
│    %4  = (Base.ifelse)(%2, %1, 0)::Int64
│  │││┘
│    %5  = %new(UnitRange{Int64}, 1, %4)::UnitRange{Int64}
│  │┘┘
│  │ @ simdloop.jl:66 within `macro expansion'
│  │┌ @ simdloop.jl:44 within `simd_outer_range'
│  ││┌ @ range.jl:5 within `Colon'
│  │││┌ @ range.jl:255 within `Type'
│  ││││┌ @ range.jl:260 within `unitrange_last'
│          (Base.ifelse)(true, 0, -1)::Int64
│  │┘┘┘┘
│  │┌ @ range.jl:571 within `iterate'
│  ││┌ @ range.jl:455 within `isempty'
│  │││┌ @ operators.jl:286 within `>'
│  ││││┌ @ int.jl:49 within `<'
│    %7  = (Base.slt_int)(0, 0)::Bool
│  ││┘┘┘
└───       goto #3 if not %7
2 ──       goto #4
3 ──       goto #4
   │┘
4 ┄─ %11 = φ (#2 => true, #3 => false)::Bool
│    %12 = φ (#3 => 0)::Int64
│    %13 = (Base.not_int)(%11)::Bool
└───       goto #36 if not %13
5 ┄─ %15 = φ (#4 => 0, #35 => %70)::Int64
│    %16 = φ (#4 => %12, #35 => %76)::Int64
│  │ @ simdloop.jl:67 within `macro expansion'
│  │┌ @ simdloop.jl:47 within `simd_inner_length'
│  ││┌ @ range.jl:521 within `length'
│  │││┌ @ checked.jl:226 within `checked_sub'
│  ││││┌ @ checked.jl:198 within `sub_with_overflow'
│    %17 = (Base.Checked.checked_ssub_int)(%4, 1)::Tuple{Int64,Bool}
│  ││││┘
│  ││││┌ @ tuple.jl:60 within `indexed_iterate'
│  │││││┌ @ tuple.jl:60 within `indexed_iterate'
│  ││││││┌ @ tuple.jl:24 within `getindex'
│    %18 = (Base.getfield)(%17, 1, true)::Int64
│  │││││┘┘
│  │││││┌ @ tuple.jl:24 within `getindex'
│    %19 = (Base.getfield)(%17, 2, true)::Bool
│  ││││┘┘
│  ││││ @ checked.jl:227 within `checked_sub'
└───       goto #7 if not %19
6 ──       invoke Base.Checked.throw_overflowerr_binaryop(:-::Symbol, %4::Int64, 1::Int64)::Union{}
└───       $(Expr(:unreachable))::Union{}
   ││││ @ checked.jl:228 within `checked_sub'
7 ┄─       goto #8
   │││┘
   │││┌ @ checked.jl:169 within `checked_add'
   ││││┌ @ checked.jl:136 within `add_with_overflow'
8 ── %24 = (Base.Checked.checked_sadd_int)(%18, 1)::Tuple{Int64,Bool}
│  ││││┘
│  ││││┌ @ tuple.jl:60 within `indexed_iterate'
│  │││││┌ @ tuple.jl:60 within `indexed_iterate'
│  ││││││┌ @ tuple.jl:24 within `getindex'
│    %25 = (Base.getfield)(%24, 1, true)::Int64
│  │││││┘┘
│  │││││┌ @ tuple.jl:24 within `getindex'
│    %26 = (Base.getfield)(%24, 2, true)::Bool
│  ││││┘┘
│  ││││ @ checked.jl:170 within `checked_add'
└───       goto #10 if not %26
9 ──       invoke Base.Checked.throw_overflowerr_binaryop(:+::Symbol, %18::Int64, 1::Int64)::Union{}
└───       $(Expr(:unreachable))::Union{}
   ││││ @ checked.jl:171 within `checked_add'
10 ┄       goto #11
   │││┘
11 ─       goto #12
   ││┘
12 ─       goto #13
   │┘
   │ @ simdloop.jl:68 within `macro expansion'
   │┌ @ int.jl:49 within `<'
13 ─ %33 = (Base.slt_int)(0, %25)::Bool
│  │┘
└───       goto #31 if not %33
14 ─       nothing::Nothing
   │ @ simdloop.jl:71 within `macro expansion'
15 ┄ %36 = φ (#14 => %15, #29 => %65)::Int64
│    %37 = φ (#14 => 0, #29 => %66)::Int64
│  │┌ @ int.jl:49 within `<'
│    %38 = (Base.slt_int)(%37, %25)::Bool
│  │┘
└───       goto #30 if not %38
   │ @ simdloop.jl:72 within `macro expansion'
   │┌ @ simdloop.jl:50 within `simd_index'
   ││┌ @ int.jl:53 within `+'
16 ─ %40 = (Base.add_int)(%37, 1)::Int64
│  ││┘
│  ││┌ @ range.jl:596 within `getindex'
│  │││┌ @ int.jl:53 within `+'
│    %41 = (Base.add_int)(1, %40)::Int64
│  │││┘
│  │││┌ @ int.jl:52 within `-'
│    %42 = (Base.sub_int)(%41, 1)::Int64
│  │││┘
│  │││ @ range.jl:597 within `getindex'
└───       goto #25 if not false
   │││┌ @ range.jl:582 within `_in_unit_range'
   ││││┌ @ operators.jl:286 within `>'
   │││││┌ @ int.jl:49 within `<'
17 ─ %44 = (Base.slt_int)(0, %40)::Bool
│  ││││┘┘
└───       goto #21 if not %44
   ││││┌ @ int.jl:428 within `<='
18 ─ %46 = (Base.sle_int)(%42, %4)::Bool
│  ││││┘
└───       goto #20 if not %46
   ││││┌ @ operators.jl:333 within `>='
   │││││┌ @ int.jl:428 within `<='
19 ─ %48 = (Base.sle_int)(1, %42)::Bool
│  ││││┘┘
└───       goto #22
20 ─       goto #22
21 ─       goto #22
   │││┘
22 ┄ %52 = φ (#19 => %48, #20 => false, #21 => false)::Bool
└───       goto #24 if not %52
23 ─       goto #25
24 ─       invoke Base.throw_boundserror(%5::UnitRange{Int64}, %40::Int64)::Union{}
└───       $(Expr(:unreachable))::Union{}
   │││ @ range.jl:598 within `getindex'
25 ┄       goto #26
   ││┘
26 ─       goto #27
   │┘
   │ @ simdloop.jl:73 within `macro expansion'
   │┌ @ REPL[1]:4 within `macro expansion'
   ││┌ @ array.jl:731 within `getindex'
27 ─ %59 = (Base.arrayref)(false, A, %42)::Union{Missing, Int64}
│  ││┘
│  ││ @ REPL[1]:5 within `macro expansion'
│    %60 = (%59 === Main.missing)::Bool
│    %61 = (Core.Intrinsics.not_int)(%60)::Bool
└───       goto #29 if not %61
   ││ @ REPL[1]:6 within `macro expansion'
28 ─ %63 = π (%59, Int64)
│  ││┌ @ int.jl:53 within `+'
└─── %64 = (Base.add_int)(%36, %63)::Int64
   ││┘
   ││ @ REPL[1]:4 within `macro expansion'
29 ┄ %65 = φ (#28 => %64, #27 => %36)::Int64
│  ││┌ @ int.jl:53 within `+'
│    %66 = (Base.add_int)(%37, 1)::Int64
│  ││┘
│  ││ @ REPL[1]:5 within `macro expansion'
│          $(Expr(:simdloop, false))::Any
└───       goto #15
30 ─       nothing::Nothing
   ││ @ REPL[1]:6 within `macro expansion'
31 ┄ %70 = φ (#30 => %36, #13 => %15)::Int64
│  ││┌ @ range.jl:575 within `iterate'
│  │││┌ @ promotion.jl:425 within `=='
│    %71 = (%16 === 0)::Bool
│  │││┘
└───       goto #33 if not %71
32 ─       goto #34
   │││ @ range.jl:576 within `iterate'
   │││┌ @ int.jl:53 within `+'
33 ─ %74 = (Base.add_int)(%16, 1)::Int64
│  │││┘
│  │││ @ range.jl:577 within `iterate'
└───       goto #34
   ││┘
34 ┄ %76 = φ (#33 => %74)::Int64
│    %77 = φ (#32 => true, #33 => false)::Bool
│    %78 = (Base.not_int)(%77)::Bool
└───       goto #36 if not %78
35 ─       goto #5
   │┘
   │ @ simdloop.jl:74 within `macro expansion'
36 ┄ %81 = φ (#34 => %70, #4 => 0)::Int64
│  │ @ simdloop.jl:65 within `macro expansion'
└───       return %81
) => Int64

julia> code_llvm(g, (typeof([1,missing]),))

;  @ REPL[1]:2 within `g'
define i64 @julia_g_33689(%jl_value_t addrspace(10)* nonnull align 16 dereferenceable(40)) {
top:
;  @ REPL[1]:3 within `g'
; ┌ @ simdloop.jl:65 within `macro expansion'
; │┌ @ array.jl:199 within `length'
    %1 = addrspacecast %jl_value_t addrspace(10)* %0 to %jl_value_t addrspace(11)*
    %2 = bitcast %jl_value_t addrspace(11)* %1 to %jl_array_t addrspace(11)*
    %3 = getelementptr inbounds %jl_array_t, %jl_array_t addrspace(11)* %2, i64 0, i32 1
    %4 = load i64, i64 addrspace(11)* %3, align 8
; │┘
; │┌ @ range.jl:5 within `Colon'
; ││┌ @ range.jl:255 within `Type'
; │││┌ @ range.jl:260 within `unitrange_last'
; ││││┌ @ operators.jl:333 within `>='
; │││││┌ @ int.jl:428 within `<='
        %5 = icmp sgt i64 %4, 0
; ││││┘┘
      %6 = select i1 %5, i64 %4, i64 0
; │┘┘┘
; │ @ simdloop.jl:67 within `macro expansion'
; │┌ @ simdloop.jl:47 within `simd_inner_length'
; ││┌ @ range.jl:521 within `length'
; │││┌ @ checked.jl:226 within `checked_sub'
; ││││┌ @ checked.jl:198 within `sub_with_overflow'
       %7 = add nsw i64 %6, -1
; │││┘┘
; │││┌ @ checked.jl:169 within `checked_add'
; ││││┌ @ checked.jl:136 within `add_with_overflow'
       %8 = call { i64, i1 } @llvm.sadd.with.overflow.i64(i64 %7, i64 1)
       %9 = extractvalue { i64, i1 } %8, 1
; ││││┘
; ││││ @ checked.jl:170 within `checked_add'
      br i1 %9, label %L28, label %L33.lr.ph

L33.lr.ph:                                        ; preds = %top
; ││││ @ checked.jl:169 within `checked_add'
; ││││┌ @ checked.jl:136 within `add_with_overflow'
       %10 = extractvalue { i64, i1 } %8, 0
       %11 = icmp slt i64 %10, 1
; ││││┘
; ││││ @ checked.jl:170 within `checked_add'
      br i1 %11, label %L81, label %L40.lr.ph.us33

L40.lr.ph.us33:                                   ; preds = %L33.lr.ph
      %12 = bitcast %jl_value_t addrspace(11)* %1 to [1 x i64] addrspace(13)* addrspace(11)*
      %13 = load [1 x i64] addrspace(13)*, [1 x i64] addrspace(13)* addrspace(11)* %12, align 8
      %14 = getelementptr inbounds %jl_array_t, %jl_array_t addrspace(11)* %2, i64 0, i32 4
      %15 = load i32, i32 addrspace(11)* %14, align 4
      %16 = zext i32 %15 to i64
      %17 = bitcast %jl_value_t addrspace(11)* %1 to %jl_value_t addrspace(10)* addrspace(11)*
      %18 = getelementptr inbounds %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(11)* %17, i64 4
      %19 = bitcast %jl_value_t addrspace(10)* addrspace(11)* %18 to i64 addrspace(11)*
      %20 = load i64, i64 addrspace(11)* %19, align 8
      %21 = sub i64 %20, %16
      %22 = getelementptr inbounds [1 x i64], [1 x i64] addrspace(13)* %13, i64 %21
      %23 = bitcast [1 x i64] addrspace(13)* %22 to i8 addrspace(13)*
      %24 = sext i32 %15 to i64
      %25 = getelementptr inbounds i8, i8 addrspace(13)* %23, i64 %24
; │┘┘┘
; │ @ simdloop.jl:71 within `macro expansion'
   %min.iters.check = icmp ult i64 %6, 32
   br i1 %min.iters.check, label %scalar.ph, label %vector.ph

vector.ph:                                        ; preds = %L40.lr.ph.us33
   %n.vec = and i64 %6, 9223372036854775776
   br label %vector.body

vector.body:                                      ; preds = %vector.body, %vector.ph
; │ @ simdloop.jl:73 within `macro expansion'
; │┌ @ REPL[1]:4 within `macro expansion'
; ││┌ @ int.jl:53 within `+'
     %index = phi i64 [ 0, %vector.ph ], [ %index.next, %vector.body ]
     %vec.phi = phi <8 x i64> [ zeroinitializer, %vector.ph ], [ %50, %vector.body ]
     %vec.phi51 = phi <8 x i64> [ zeroinitializer, %vector.ph ], [ %51, %vector.body ]
     %vec.phi52 = phi <8 x i64> [ zeroinitializer, %vector.ph ], [ %52, %vector.body ]
     %vec.phi53 = phi <8 x i64> [ zeroinitializer, %vector.ph ], [ %53, %vector.body ]
; ││┘
; ││┌ @ array.jl:731 within `getindex'
     %26 = getelementptr inbounds i8, i8 addrspace(13)* %25, i64 %index
     %27 = bitcast i8 addrspace(13)* %26 to <8 x i8> addrspace(13)*
     %wide.load = load <8 x i8>, <8 x i8> addrspace(13)* %27, align 1
     %28 = getelementptr i8, i8 addrspace(13)* %26, i64 8
     %29 = bitcast i8 addrspace(13)* %28 to <8 x i8> addrspace(13)*
     %wide.load54 = load <8 x i8>, <8 x i8> addrspace(13)* %29, align 1
     %30 = getelementptr i8, i8 addrspace(13)* %26, i64 16
     %31 = bitcast i8 addrspace(13)* %30 to <8 x i8> addrspace(13)*
     %wide.load55 = load <8 x i8>, <8 x i8> addrspace(13)* %31, align 1
     %32 = getelementptr i8, i8 addrspace(13)* %26, i64 24
     %33 = bitcast i8 addrspace(13)* %32 to <8 x i8> addrspace(13)*
     %wide.load56 = load <8 x i8>, <8 x i8> addrspace(13)* %33, align 1
     %34 = getelementptr inbounds [1 x i64], [1 x i64] addrspace(13)* %13, i64 %index, i64 0
     %35 = bitcast i64 addrspace(13)* %34 to <8 x i64> addrspace(13)*
     %wide.load57 = load <8 x i64>, <8 x i64> addrspace(13)* %35, align 8
     %36 = getelementptr [1 x i64], [1 x i64] addrspace(13)* %13, i64 %index, i64 8
     %37 = bitcast i64 addrspace(13)* %36 to <8 x i64> addrspace(13)*
     %wide.load58 = load <8 x i64>, <8 x i64> addrspace(13)* %37, align 8
     %38 = getelementptr [1 x i64], [1 x i64] addrspace(13)* %13, i64 %index, i64 16
     %39 = bitcast i64 addrspace(13)* %38 to <8 x i64> addrspace(13)*
     %wide.load59 = load <8 x i64>, <8 x i64> addrspace(13)* %39, align 8
     %40 = getelementptr [1 x i64], [1 x i64] addrspace(13)* %13, i64 %index, i64 24
     %41 = bitcast i64 addrspace(13)* %40 to <8 x i64> addrspace(13)*
     %wide.load60 = load <8 x i64>, <8 x i64> addrspace(13)* %41, align 8
; ││┘
; ││ @ REPL[1]:5 within `macro expansion'
    %42 = icmp eq <8 x i8> %wide.load, zeroinitializer
    %43 = icmp eq <8 x i8> %wide.load54, zeroinitializer
    %44 = icmp eq <8 x i8> %wide.load55, zeroinitializer
    %45 = icmp eq <8 x i8> %wide.load56, zeroinitializer
    %46 = select <8 x i1> %42, <8 x i64> zeroinitializer, <8 x i64> %wide.load57
    %47 = select <8 x i1> %43, <8 x i64> zeroinitializer, <8 x i64> %wide.load58
    %48 = select <8 x i1> %44, <8 x i64> zeroinitializer, <8 x i64> %wide.load59
    %49 = select <8 x i1> %45, <8 x i64> zeroinitializer, <8 x i64> %wide.load60
    %50 = add <8 x i64> %46, %vec.phi
    %51 = add <8 x i64> %47, %vec.phi51
    %52 = add <8 x i64> %48, %vec.phi52
    %53 = add <8 x i64> %49, %vec.phi53
; ││ @ REPL[1]:4 within `macro expansion'
; ││┌ @ int.jl:53 within `+'
     %index.next = add i64 %index, 32
     %54 = icmp eq i64 %index.next, %n.vec
     br i1 %54, label %middle.block, label %vector.body

middle.block:                                     ; preds = %vector.body
; ││┘
; ││ @ REPL[1]:5 within `macro expansion'
    %bin.rdx = add <8 x i64> %51, %50
    %bin.rdx61 = add <8 x i64> %52, %bin.rdx
    %bin.rdx62 = add <8 x i64> %53, %bin.rdx61
    %rdx.shuf = shufflevector <8 x i64> %bin.rdx62, <8 x i64> undef, <8 x i32> <i32 4, i32 5, i32 6, i32 7, i32 undef, i32 undef, i32 undef, i32 undef>
    %bin.rdx63 = add <8 x i64> %bin.rdx62, %rdx.shuf
    %rdx.shuf64 = shufflevector <8 x i64> %bin.rdx63, <8 x i64> undef, <8 x i32> <i32 2, i32 3, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
    %bin.rdx65 = add <8 x i64> %bin.rdx63, %rdx.shuf64
    %rdx.shuf66 = shufflevector <8 x i64> %bin.rdx65, <8 x i64> undef, <8 x i32> <i32 1, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef, i32 undef>
    %bin.rdx67 = add <8 x i64> %bin.rdx65, %rdx.shuf66
    %55 = extractelement <8 x i64> %bin.rdx67, i32 0
    %cmp.n = icmp eq i64 %6, %n.vec
; │┘
; │ @ simdloop.jl:71 within `macro expansion'
   br i1 %cmp.n, label %L81, label %scalar.ph

scalar.ph:                                        ; preds = %middle.block, %L40.lr.ph.us33
   %bc.resume.val = phi i64 [ %n.vec, %middle.block ], [ 0, %L40.lr.ph.us33 ]
   %bc.merge.rdx = phi i64 [ %55, %middle.block ], [ 0, %L40.lr.ph.us33 ]
   br label %L40.us34

L40.us34:                                         ; preds = %L40.us34, %scalar.ph
   %value_phi625.us35 = phi i64 [ %bc.resume.val, %scalar.ph ], [ %62, %L40.us34 ]
   %value_phi524.us36 = phi i64 [ %bc.merge.rdx, %scalar.ph ], [ %value_phi8.us37, %L40.us34 ]
; │ @ simdloop.jl:73 within `macro expansion'
; │┌ @ REPL[1]:4 within `macro expansion'
; ││┌ @ array.jl:731 within `getindex'
     %56 = getelementptr inbounds i8, i8 addrspace(13)* %25, i64 %value_phi625.us35
     %57 = load i8, i8 addrspace(13)* %56, align 1
     %58 = getelementptr inbounds [1 x i64], [1 x i64] addrspace(13)* %13, i64 %value_phi625.us35, i64 0
     %59 = load i64, i64 addrspace(13)* %58, align 8
; ││┘
; ││ @ REPL[1]:5 within `macro expansion'
    %60 = icmp eq i8 %57, 0
    %61 = select i1 %60, i64 0, i64 %59
    %value_phi8.us37 = add i64 %61, %value_phi524.us36
; ││ @ REPL[1]:4 within `macro expansion'
; ││┌ @ int.jl:53 within `+'
     %62 = add nuw nsw i64 %value_phi625.us35, 1
; │┘┘
; │ @ simdloop.jl:71 within `macro expansion'
; │┌ @ int.jl:49 within `<'
    %63 = icmp ult i64 %62, %10
; │┘
   br i1 %63, label %L40.us34, label %L81

L28:                                              ; preds = %top
; │ @ simdloop.jl:67 within `macro expansion'
; │┌ @ simdloop.jl:47 within `simd_inner_length'
; ││┌ @ range.jl:521 within `length'
; │││┌ @ checked.jl:170 within `checked_add'
      call void @julia_throw_overflowerr_binaryop_22657(%jl_value_t addrspace(10)* addrspacecast (%jl_value_t* inttoptr (i64 140059004363544 to %jl_value_t*) to %jl_value_t addrspace(10)*), i64 %7, i64 1)
      call void @llvm.trap()
      unreachable

L81:                                              ; preds = %L40.us34, %middle.block, %L33.lr.ph
      %value_phi10.lcssa = phi i64 [ 0, %L33.lr.ph ], [ %value_phi8.us37, %L40.us34 ], [ %55, %middle.block ]
; │┘┘┘
; │ @ simdloop.jl:65 within `macro expansion'
   ret i64 %value_phi10.lcssa
; ┘
}

julia> code_native(g, (typeof([1,missing]),))
	.text
; ┌ @ REPL[1]:3 within `g'
; │┌ @ simdloop.jl:65 within `macro expansion'
; ││┌ @ REPL[1]:2 within `length'
	pushq	%rbx
	movq	8(%rdi), %rax
; │┘┘
; │┌ @ range.jl:260 within `macro expansion'
	movq	%rax, %rcx
	sarq	$63, %rcx
	andnq	%rax, %rcx, %r10
; │┘
; │┌ @ simdloop.jl:67 within `macro expansion'
; ││┌ @ simdloop.jl:47 within `simd_inner_length'
; │││┌ @ range.jl:521 within `length'
; ││││┌ @ checked.jl:226 within `checked_sub'
; │││││┌ @ checked.jl:198 within `sub_with_overflow'
	leaq	-1(%r10), %rsi
; ││││┘┘
; ││││┌ @ checked.jl:169 within `checked_add'
; │││││┌ @ checked.jl:136 within `add_with_overflow'
	movq	%rsi, %rcx
	incq	%rcx
; │││││┘
; │││││ @ checked.jl:170 within `checked_add'
	jo	L391
	testq	%rcx, %rcx
; │││││ @ checked.jl:170 within `checked_add'
	jle	L67
; │┘┘┘┘
; │┌ @ checked.jl within `macro expansion'
	movq	(%rdi), %rdx
	movq	32(%rdi), %r9
	movslq	20(%rdi), %r8
	movl	%r8d, %r11d
; │┘
; │┌ @ simdloop.jl:71 within `macro expansion'
	cmpq	$32, %r10
	jae	L71
	xorl	%esi, %esi
	xorl	%eax, %eax
	jmp	L326
L67:
	xorl	%eax, %eax
; ││ @ simdloop.jl:65 within `macro expansion'
	popq	%rbx
	retq
; ││ @ simdloop.jl:71 within `macro expansion'
L71:
	movabsq	$9223372036854775776, %rsi # imm = 0x7FFFFFFFFFFFFFE0
	andq	%r10, %rsi
	leaq	192(%rdx), %rax
	leaq	3(%r9), %rdi
	subq	%r11, %rdi
	leaq	(%rdx,%rdi,8), %rdi
	addq	%r8, %rdi
	vpxor	%xmm0, %xmm0, %xmm0
	vpxor	%xmm8, %xmm8, %xmm8
; ││ @ simdloop.jl:73 within `macro expansion'
; ││┌ @ REPL[1]:4 within `macro expansion'
; │││┌ @ int.jl:53 within `+'
	movq	%rsi, %rbx
	vpxor	%xmm2, %xmm2, %xmm2
	vpxor	%xmm3, %xmm3, %xmm3
	vpxor	%xmm4, %xmm4, %xmm4
	nopw	%cs:(%rax,%rax)
; ││┘┘
; ││┌ @ array.jl:731 within `macro expansion'
L144:
	vpmovzxbw	-24(%rdi), %xmm5 # xmm5 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
	vpmovzxbw	-16(%rdi), %xmm6 # xmm6 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
	vpmovzxbw	-8(%rdi), %xmm7 # xmm7 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
	vpmovzxbw	(%rdi), %xmm1   # xmm1 = mem[0],zero,mem[1],zero,mem[2],zero,mem[3],zero,mem[4],zero,mem[5],zero,mem[6],zero,mem[7],zero
; │┘┘
; │ @ REPL[1]:5 within `g'
	vpcmpneqw	%xmm8, %xmm5, %k1
	vpcmpneqw	%xmm8, %xmm6, %k2
	vpcmpneqw	%xmm8, %xmm7, %k3
	vpcmpneqw	%xmm8, %xmm1, %k4
	vmovdqu64	-192(%rax), %zmm1 {%k1} {z}
	vpaddq	%zmm0, %zmm1, %zmm0
	vmovdqu64	-128(%rax), %zmm1 {%k2} {z}
	vpaddq	%zmm2, %zmm1, %zmm2
	vmovdqu64	-64(%rax), %zmm1 {%k3} {z}
	vpaddq	%zmm3, %zmm1, %zmm3
	vmovdqu64	(%rax), %zmm1 {%k4} {z}
	vpaddq	%zmm4, %zmm1, %zmm4
; │ @ REPL[1]:3 within `g'
; │┌ @ simdloop.jl:73 within `macro expansion'
; ││┌ @ REPL[1]:4 within `macro expansion'
; │││┌ @ int.jl:53 within `+'
	addq	$256, %rax              # imm = 0x100
	addq	$32, %rdi
	addq	$-32, %rbx
	jne	L144
; │┘┘┘
; │ @ REPL[1]:5 within `g'
	vpaddq	%zmm0, %zmm2, %zmm0
	vpaddq	%zmm0, %zmm3, %zmm0
	vpaddq	%zmm0, %zmm4, %zmm0
	vextracti64x4	$1, %zmm0, %ymm1
	vpaddq	%zmm1, %zmm0, %zmm0
	vextracti128	$1, %ymm0, %xmm1
	vpaddq	%zmm1, %zmm0, %zmm0
	vpshufd	$78, %xmm0, %xmm1       # xmm1 = xmm0[2,3,0,1]
	vpaddq	%zmm1, %zmm0, %zmm0
	vmovq	%xmm0, %rax
	cmpq	%rsi, %r10
; │ @ REPL[1]:3 within `g'
; │┌ @ simdloop.jl:71 within `macro expansion'
	je	L386
L326:
	leaq	(%rsi,%r9,8), %rdi
	addq	%r8, %rdi
	shlq	$3, %r11
	subq	%r11, %rdi
	nopw	%cs:(%rax,%rax)
; ││ @ simdloop.jl:73 within `macro expansion'
; ││┌ @ REPL[1]:5 within `macro expansion'
L352:
	cmpb	$0, (%rdx,%rdi)
	je	L368
	movq	(%rdx,%rsi,8), %rbx
	jmp	L370
	nopl	(%rax)
; │││ @ REPL[1]:5 within `macro expansion'
L368:
	xorl	%ebx, %ebx
L370:
	addq	%rbx, %rax
; │││ @ REPL[1]:4 within `macro expansion'
; │││┌ @ int.jl:53 within `+'
	addq	$1, %rsi
; ││┘┘
; ││ @ simdloop.jl:71 within `macro expansion'
; ││┌ @ int.jl:49 within `<'
	addq	$1, %rdi
	cmpq	%rcx, %rsi
; ││┘
	jb	L352
; ││ @ simdloop.jl:65 within `macro expansion'
L386:
	popq	%rbx
	vzeroupper
	retq
; ││ @ simdloop.jl:67 within `macro expansion'
; ││┌ @ simdloop.jl:47 within `simd_inner_length'
; │││┌ @ range.jl:521 within `length'
; ││││┌ @ checked.jl:170 within `checked_add'
L391:
	movabsq	$throw_overflowerr_binaryop, %rax
	movabsq	$140059004363544, %rdi  # imm = 0x7F620733E318
	movl	$1, %edx
	callq	*%rax
	ud2
	nopw	%cs:(%rax,%rax)
; ┘┘┘┘┘

julia> 
```

fixes https://github.com/JuliaLang/julia/issues/27526