### PR TITLE
Fix linear indexing of one-dimensional CartesianIndices

### DIFF
--- a/base/indices.jl
+++ b/base/indices.jl
@@ -390,11 +390,11 @@ function getindex(iter::LinearIndices, i::AbstractRange{<:Integer})
 end
 # More efficient iteration — predominantly for non-vector LinearIndices
 # but one-dimensional LinearIndices must be special-cased to support OffsetArrays
-iterate(iter::LinearIndices{1}, s...) = iterate(iter.indices[1], s...)
+iterate(iter::LinearIndices{1}, s...) = iterate(axes1(iter.indices[1]), s...)
 iterate(iter::LinearIndices, i=1) = i > length(iter) ? nothing : (i, i+1)
 
 # Needed since firstindex and lastindex are defined in terms of LinearIndices
 first(iter::LinearIndices) = 1
-first(iter::LinearIndices{1}) = (@_inline_meta; first(iter.indices[1]))
+first(iter::LinearIndices{1}) = (@_inline_meta; first(axes1(iter.indices[1])))
 last(iter::LinearIndices) = (@_inline_meta; length(iter))
-last(iter::LinearIndices{1}) = (@_inline_meta; last(iter.indices[1]))
+last(iter::LinearIndices{1}) = (@_inline_meta; last(axes1(iter.indices[1])))

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -145,6 +145,17 @@ end
         #   indices may be nontraditional
         @test_throws ArgumentError Base._sub2ind((1:3,), 2)
         @test_throws ArgumentError Base._ind2sub((1:3,), 2)
+
+        ci = CartesianIndices((2:4,))
+        @test first(ci) == ci[1] == CartesianIndex(2)
+        @test last(ci)  == ci[end] == ci[3] == CartesianIndex(4)
+        li = LinearIndices(ci)
+        @test collect(li) == [1,2,3]
+        @test first(li) == li[1] == 1
+        @test last(li)  == li[3] == 3
+        io = IOBuffer()
+        show(io, ci)
+        @test String(take!(io)) == "CartesianIndex{1}[CartesianIndex(2,), CartesianIndex(3,), CartesianIndex(4,)]"
     end
 
     @testset "2-dimensional" begin


### PR DESCRIPTION
This fixes some surprising outcomes:
```julia
julia> ci = CartesianIndices((2:4,))
3-element CartesianIndices{1,Tuple{UnitRange{Int64}}}:
 CartesianIndex(2,)
 CartesianIndex(3,)
 CartesianIndex(4,)

julia> show(ci)
CartesianIndex{1}[CartesianIndex(3,), CartesianIndex(4,), #undef]
julia> collect(ci)
3-element Array{CartesianIndex{1},1}:
 CartesianIndex(2,)
 CartesianIndex(3,)
 CartesianIndex(4,)

julia> collect(LinearIndices(ci))
3-element Array{Int64,1}:
 1
 2
 3

julia> for i in LinearIndices(ci)
           @show i
       end
i = 2
i = 3
i = 4
```
CC @mbauman 