### PR TITLE
Hooked GDB to JITEventListener, cleaned jitlayers GDB interface

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7471,6 +7471,11 @@ extern "C" void *jl_init_llvm(void)
     jl_data_layout.reset(DL);
 #endif
 
+// Register GDB event listener
+#ifdef JL_DEBUG_BUILD
+    jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createGDBRegistrationListener());
+#endif
+
 #ifdef JL_USE_INTEL_JITEVENTS
     if (jl_using_intel_jitevents)
         jl_ExecutionEngine->RegisterJITEventListener(JITEventListener::createIntelJITEventListener());

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -103,7 +103,6 @@ using RTDyldObjHandleT = orc::ObjectLinkingLayerBase::ObjSetHandleT;
 
 class JuliaOJIT {
     // Custom object emission notification handler for the JuliaOJIT
-    // TODO: hook up RegisterJITEventListener, instead of hard-coding the GDB and JuliaListener targets
     class DebugObjectRegistrar {
     public:
         DebugObjectRegistrar(JuliaOJIT &JIT);
@@ -112,7 +111,6 @@ class JuliaOJIT {
     private:
         template <typename ObjT, typename LoadResult>
         void registerObject(RTDyldObjHandleT H, const ObjT &Object, const LoadResult &LO);
-        void NotifyGDB(object::OwningBinary<object::ObjectFile> &DebugObj);
         std::vector<object::OwningBinary<object::ObjectFile>> SavedObjects;
         std::unique_ptr<JITEventListener> JuliaListener;
         JuliaOJIT &JIT;


### PR DESCRIPTION
After #27466 we can hook GDB Listener to JITEventListener.

cc @vtjnash @vchuravy 