### PR TITLE
Fix race condition when building LLVM for Windows

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -506,6 +506,7 @@ $(eval $(call LLVM_PATCH,llvm-D49832-SCEVPred)) # Remove for 7.0
 $(eval $(call LLVM_PATCH,llvm-rL323946-LSRTy)) # Remove for 7.0
 $(eval $(call LLVM_PATCH,llvm-D50010-VNCoercion-ni))
 $(eval $(call LLVM_PATCH,llvm-D50167-scev-umin))
+$(eval $(call LLVM_PATCH,llvm-windows-race))
 endif # LLVM_VER
 
 # Remove hardcoded OS X requirements in compilter-rt cmake build

--- a/deps/patches/llvm-windows-race.patch
+++ b/deps/patches/llvm-windows-race.patch
@@ -1,0 +1,25 @@
+commit c0be37352f6d91505d964a7d33ad79b40750d370
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Fri Aug 3 21:03:32 2018 -0400
+
+    [CrossCompile] Add a dependency llvm-config-host -> llvm-tblgen-host
+    
+    These use the same working directory and without a dependency
+    edge between them race to build some of the utility libraries
+    causing build failures.
+
+diff --git a/tools/llvm-config/CMakeLists.txt b/tools/llvm-config/CMakeLists.txt
+index f59402ac4b0..f3b4e60fd99 100644
+--- a/tools/llvm-config/CMakeLists.txt
++++ b/tools/llvm-config/CMakeLists.txt
+@@ -77,5 +77,10 @@ if(CMAKE_CROSSCOMPILING AND NOT LLVM_CONFIG_PATH)
+   add_custom_target(${project}NativeLLVMConfig DEPENDS ${${project}_LLVM_CONFIG_EXE})
+   add_dependencies(${project}NativeLLVMConfig CONFIGURE_LLVM_NATIVE)
+ 
++  # Add a dependency on the host tblgen, which uses the same working
++  # directory and with which we're otherwise racing to build some
++  # of the utility libraries.
++  add_dependencies(${project}NativeLLVMConfig LLVM-tablegen-host)
++
+   add_dependencies(llvm-config ${project}NativeLLVMConfig)
+ endif(CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
`llvm-tblgen` and `llvm-config` both try to build in the same NATIVE
directory and end up stomping on each other.

Co-authored-by: Valentin Churavy <vchuravy@gmail.com>