### PR TITLE
Work around invalid register errors with 64-bit Windows

### DIFF
--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -62,6 +62,15 @@ OPENBLAS_FFLAGS += -mincoming-stack-boundary=2
 endif
 endif
 
+# Work around invalid register errors on 64-bit Windows
+# See discussion in https://github.com/xianyi/OpenBLAS/issues/1708
+# TODO: Remove this once we use a version of OpenBLAS where this is set automatically
+ifeq ($(OS),WINNT)
+ifeq ($(ARCH),x86_64)
+OPENBLAS_CFLAGS += -fno-asynchronous-unwind-tables
+endif
+endif
+
 OPENBLAS_BUILD_OPTS += CFLAGS="$(CFLAGS) $(OPENBLAS_CFLAGS)"
 OPENBLAS_BUILD_OPTS += FFLAGS="$(FFLAGS) $(OPENBLAS_FFLAGS)"
 OPENBLAS_BUILD_OPTS += LDFLAGS="$(LDFLAGS) $(RPATH_ESCAPED_ORIGIN)"


### PR DESCRIPTION
Adding `-fno-asynchronous-unwind-tables` to the C compiler flags passed to OpenBLAS works around errors claiming an invalid register for `.seh_savexmm`. We've been running into this on the 64-bit Windows buildbot.

See discussion in https://github.com/xianyi/OpenBLAS/issues/1708.