### PR TITLE
Fixed long stacktrace printing

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -458,28 +458,28 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
     end
 end
 
-# In case the line numbers in the source code have changed since the code was compiled,
-# allow packages to set a callback function that corrects them.
-# (Used by Revise and perhaps other packages.)
-#
-# Set this with
-#     Base.update_stackframes_callback[] = my_updater
-# where my_updater takes a single argument, a StackFrame, and returns a StackFrame
-# with the appropriate modifications.
-const update_stackframes_callback = Ref{Function}(identity)
-
 # Contains file name and file number. Gets set when a backtrace
 # or methodlist is shown. Used by the REPL to make it possible to open
 # the location of a stackframe/method in the editor.
 global LAST_SHOWN_LINE_INFOS = Tuple{String, Int}[]
 
 function show_trace_entry(io, frame, n; prefix = "")
-    frame = try update_stackframes_callback[](frame) catch _ frame end
     push!(LAST_SHOWN_LINE_INFOS, (string(frame.file), frame.line))
     print(io, "\n", prefix)
     show(io, frame, full_path=true)
     n > 1 && print(io, " (repeats ", n, " times)")
 end
+
+# In case the line numbers in the source code have changed since the code was compiled,
+# allow packages to set a callback function that corrects them.
+# (Used by Revise and perhaps other packages.)
+#
+# Set this with
+#     Base.update_stackframes_callback[] = my_updater!
+# where my_updater! takes a single argument and works in-place. The argument will be a
+# Vector{Any} storing tuples (sf::StackFrame, nrepetitions::Int), and the updater should
+# replace `sf` as needed.
+const update_stackframes_callback = Ref{Function}(identity)
 
 const BIG_STACKTRACE_SIZE = 50 # Arbitrary constant chosen here
 
@@ -489,6 +489,11 @@ function show_reduced_backtrace(io::IO, t::Vector, with_prefix::Bool)
     such that hash(t[i-1]) == h, ie the list of positions in which the
     frame appears just before. =#
 
+    displayed_stackframes = []
+    repeated_cycle = Tuple{Int,Int,Int}[]
+    # First:  line to introuce the "cycle repetition" message
+    # Second: length of the cycle
+    # Third:  number of repetitions
     frame_counter = 1
     while frame_counter < length(t)
         (last_frame, n) = t[frame_counter]
@@ -510,20 +515,37 @@ function show_reduced_backtrace(io::IO, t::Vector, with_prefix::Bool)
             if j >= frame_counter-1
                 #= At least one cycle repeated =#
                 repetitions = div(i - frame_counter + 1, cycle_length)
-                print(io, "\n ... (the last ", cycle_length, " lines are repeated ",
-                      repetitions, " more time", repetitions>1 ? "s)" : ")")
+                push!(repeated_cycle, (length(displayed_stackframes), cycle_length, repetitions))
                 frame_counter += cycle_length * repetitions - 1
                 break
             end
         end
 
         if repetitions==0
-            if with_prefix
-                show_trace_entry(io, last_frame, n, prefix = string(" [", frame_counter-1, "] "))
-            else
-                show_trace_entry(io, last_frame, n)
-            end
+            push!(displayed_stackframes, (last_frame, n))
         end
+    end
+
+    try invokelatest(update_stackframes_callback[], displayed_stackframes) catch end
+
+    push!(repeated_cycle, (0,0,0)) # repeated_cycle is never empty
+    frame_counter = 1
+    for i in 1:length(displayed_stackframes)
+        (frame, n) = displayed_stackframes[i]
+        if with_prefix
+            show_trace_entry(io, frame, n, prefix = string(" [", frame_counter, "] "))
+        else
+            show_trace_entry(io, frame, n)
+        end
+        while repeated_cycle[1][1] == i # never empty because of the initial (0,0,0)
+            cycle_length = repeated_cycle[1][2]
+            repetitions = repeated_cycle[1][3]
+            popfirst!(repeated_cycle)
+            print(io, "\n ... (the last ", cycle_length, " lines are repeated ",
+                  repetitions, " more time", repetitions>1 ? "s)" : ")")
+            frame_counter += cycle_length * repetitions
+        end
+        frame_counter += 1
     end
 end
 
@@ -543,6 +565,7 @@ function show_backtrace(io::IO, t::Vector)
     print(io, "\nStacktrace:")
     if length(filtered) < BIG_STACKTRACE_SIZE
         # Fast track: no duplicate stack frame detection.
+        try invokelatest(update_stackframes_callback[], filtered) catch end
         frame_counter = 0
         for (last_frame, n) in filtered
             frame_counter += 1
@@ -556,6 +579,7 @@ end
 
 function show_backtrace(io::IO, t::Vector{Any})
     if length(t) < BIG_STACKTRACE_SIZE
+        try invokelatest(update_stackframes_callback[], t) catch end
         for entry in t
             show_trace_entry(io, entry...)
         end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -458,7 +458,18 @@ function show_method_candidates(io::IO, ex::MethodError, @nospecialize kwargs=()
     end
 end
 
+# In case the line numbers in the source code have changed since the code was compiled,
+# allow packages to set a callback function that corrects them.
+# (Used by Revise and perhaps other packages.)
+#
+# Set this with
+#     Base.update_stackframes_callback[] = my_updater
+# where my_updater takes a single argument, a StackFrame, and returns a StackFrame
+# with the appropriate modifications.
+const update_stackframes_callback = Ref{Function}(identity)
+
 function show_trace_entry(io, frame, n; prefix = "")
+    frame = try update_stackframes_callback[](frame) catch _ frame end
     print(io, "\n", prefix)
     show(io, frame, full_path=true)
     n > 1 && print(io, " (repeats ", n, " times)")
@@ -469,17 +480,6 @@ end
 # the location of a stackframe/method in the editor.
 global LAST_SHOWN_LINE_INFOS = Tuple{String, Int}[]
 
-# In case the line numbers in the source code have changed since the code was compiled,
-# allow packages to set a callback function that corrects them.
-# (Used by Revise and perhaps other packages.)
-#
-# Set this with
-#     Base.update_stackframes_callback[] = my_updater!
-# where my_updater! takes a single argument and works in-place. The argument will be a
-# Vector{Any} storing tuples (sf::StackFrame, nrepetitions::Int), and the updater should
-# replace `sf` as needed.
-const update_stackframes_callback = Ref{Function}(identity)
-
 const BIG_STACKTRACE_SIZE = 50 # Arbitrary constant chosen here
 
 function show_reduced_backtrace(io::IO, t::Vector, with_prefix::Bool)
@@ -488,7 +488,6 @@ function show_reduced_backtrace(io::IO, t::Vector, with_prefix::Bool)
     such that hash(t[i-1]) == h, ie the list of positions in which the
     frame appears just before. =#
 
-    displayed_stackframes = []
     frame_counter = 1
     while frame_counter < length(t)
         (last_frame, n) = t[frame_counter]
@@ -507,7 +506,7 @@ function show_reduced_backtrace(io::IO, t::Vector, with_prefix::Bool)
             while i < length(t) && t[i] == t[j]
                 i+=1 ; j+=1
             end
-            if j >= frame_counter
+            if j >= frame_counter-1
                 #= At least one cycle repeated =#
                 repetitions = div(i - frame_counter + 1, cycle_length)
                 print(io, "\n ... (the last ", cycle_length, " lines are repeated ",
@@ -518,18 +517,12 @@ function show_reduced_backtrace(io::IO, t::Vector, with_prefix::Bool)
         end
 
         if repetitions==0
-            push!(displayed_stackframes, (last_frame, n))
-        end
-    end
-
-    try invokelatest(update_stackframes_callback[], displayed_stackframes) catch end
-
-    for (frame, n) in displayed_stackframes
-        if with_prefix
-            show_trace_entry(io, frame, n, prefix = string(" [", frame_counter-1, "] "))
-            push!(LAST_SHOWN_LINE_INFOS, (string(frame.file), frame.line))
-        else
-            show_trace_entry(io, frame, n)
+            if with_prefix
+                show_trace_entry(io, last_frame, n, prefix = string(" [", frame_counter-1, "] "))
+                push!(LAST_SHOWN_LINE_INFOS, (string(last_frame.file), last_frame.line))
+            else
+                show_trace_entry(io, last_frame, n)
+            end
         end
     end
 end
@@ -550,7 +543,6 @@ function show_backtrace(io::IO, t::Vector)
     print(io, "\nStacktrace:")
     if length(filtered) < BIG_STACKTRACE_SIZE
         # Fast track: no duplicate stack frame detection.
-        try invokelatest(update_stackframes_callback[], filtered) catch end
         frame_counter = 0
         for (last_frame, n) in filtered
             frame_counter += 1
@@ -565,7 +557,6 @@ end
 
 function show_backtrace(io::IO, t::Vector{Any})
     if length(t) < BIG_STACKTRACE_SIZE
-        try invokelatest(update_stackframes_callback[], t) catch end
         for entry in t
             show_trace_entry(io, entry...)
         end

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -521,3 +521,18 @@ end
     end
 end
 
+# issue #28442
+@testset "Long stacktrace printing" begin
+    f28442(c) = g28442(c + 1)
+    g28442(c) = c > 10000 ? (return backtrace()) : f28442(c+1)
+    bt = f28442(1)
+    io = IOBuffer()
+    Base.show_backtrace(io, bt)
+    output = split(String(take!(io)), '\n')
+    @test output[3][1:4] == " [1]"
+    @test occursin("g28442", output[3])
+    @test output[4][1:4] == " [2]"
+    @test occursin("f28442", output[4])
+    @test occursin("the last 2 lines are repeated 5000 more times", output[5])
+    @test output[6][1:8] == " [10003]"
+end


### PR DESCRIPTION
Fix #28442.

This PR makes long stacktrace printing work again by correcting #28328 in the case of stacktraces of length greater than `BIG_STACKTRACE_SIZE = 50`. ~However, it breaks the non-official API introduced in that same PR revolving around the possible modification of `update_stackframes_callback[]` by external packages to fix the number of lines:~
- ~Before this PR, `update_stackframes_callback[]` was called only once, and updated in-place the entire vector of `Tuple{StackFrame, Int}` where `Int` was the number of repetitions of the stackframe.~
- ~After this PR, `update_stackframes_callback[]` is called on each stackframe individually and should return a corrected stackframe.~

~I also removed the use of `invokelatest` since `update_stackframes_callback` is a `Ref`, thus `update_stackframes_callback[]` should automatically refer to the latest implementation of the updater. Feel free to correct me if I was wrong here. I would also like to remove the `try...catch` block around the updater call but since it was in the original PR, I kept it here.~

Incidentally, this fixes a minor issue where cycles that were repeated only once were not shrunk.

@timholy I think you should review this. ~I checked the code from Revise which is broken by this new API but it seems only a few lines need to be changed in the definition of `update_stacktrace_lineno!`(namely: get rid of the loop and return `t` instead of modifying `trace[i]` in-place) so that shouldn't be too bad.~

EDIT: see https://github.com/JuliaLang/julia/pull/28453#issuecomment-410791493