### PR TITLE
RFC: remove deprecation about __precompile__(true)

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -769,16 +769,14 @@ precompilableerror(@nospecialize ex) = false
 
 # Call __precompile__(false) at the top of a tile prevent it from being precompiled (false)
 """
-    __precompile__(false)
+    __precompile__(isprecompilable::Bool)
 
-Specify that the file calling this function is not precompilable.
+Specify whether the file calling this function is precompilable, defaulting to `true`.
 If a module or file is *not* safely precompilable, it should call `__precompile__(false)` in
 order to throw an error if Julia attempts to precompile it.
 """
 @noinline function __precompile__(isprecompilable::Bool=true)
-    if isprecompilable
-        depwarn("__precompile__() is now the default", :__precompile__)
-    elseif 0 != ccall(:jl_generating_output, Cint, ())
+    if !isprecompilable && ccall(:jl_generating_output, Cint, ()) != 0
         throw(PrecompilableError())
     end
     nothing


### PR DESCRIPTION
Doesn't seem to be much value in deprecating this?