### PR TITLE
Remove deprecation of DevNull

### DIFF
--- a/base/coreio.jl
+++ b/base/coreio.jl
@@ -4,21 +4,21 @@ print(xs...)   = print(stdout::IO, xs...)
 println(xs...) = println(stdout::IO, xs...)
 println(io::IO) = print(io, '\n')
 
-struct DevNullStream <: IO end
-const devnull = DevNullStream()
-isreadable(::DevNullStream) = false
-iswritable(::DevNullStream) = true
-isopen(::DevNullStream) = true
-read(::DevNullStream, ::Type{UInt8}) = throw(EOFError())
-write(::DevNullStream, ::UInt8) = 1
-unsafe_write(::DevNullStream, ::Ptr{UInt8}, n::UInt)::Int = n
-close(::DevNullStream) = nothing
-flush(::DevNullStream) = nothing
-wait_connected(::DevNullStream) = nothing
-wait_readnb(::DevNullStream) = wait()
-wait_readbyte(::DevNullStream) = wait()
-wait_close(::DevNullStream) = wait()
-eof(::DevNullStream) = true
+struct DevNull <: IO end
+const devnull = DevNull()
+isreadable(::DevNull) = false
+iswritable(::DevNull) = true
+isopen(::DevNull) = true
+read(::DevNull, ::Type{UInt8}) = throw(EOFError())
+write(::DevNull, ::UInt8) = 1
+unsafe_write(::DevNull, ::Ptr{UInt8}, n::UInt)::Int = n
+close(::DevNull) = nothing
+flush(::DevNull) = nothing
+wait_connected(::DevNull) = nothing
+wait_readnb(::DevNull) = wait()
+wait_readbyte(::DevNull) = wait()
+wait_close(::DevNull) = wait()
+eof(::DevNull) = true
 
 let CoreIO = Union{Core.CoreSTDOUT, Core.CoreSTDERR}
     global write, unsafe_write

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -1406,9 +1406,6 @@ function (r::Regex)(s)
     occursin(r, s)
 end
 
-# Issue #25786
-@deprecate_binding DevNull devnull
-
 # PR 25062
 @deprecate(link_pipe(pipe; julia_only_read = true, julia_only_write = true),
            link_pipe!(pipe, reader_supports_async = julia_only_read, writer_supports_async = julia_only_write),

--- a/base/process.jl
+++ b/base/process.jl
@@ -145,7 +145,7 @@ struct FileRedirect
     end
 end
 
-rawhandle(::DevNullStream) = C_NULL
+rawhandle(::DevNull) = C_NULL
 rawhandle(x::OS_HANDLE) = x
 if OS_HANDLE !== RawFD
     rawhandle(x::RawFD) = Libc._get_osfhandle(x)

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -24,7 +24,7 @@ abstract type LibuvStream <: IO end
 # .  +- Process (not exported)
 # .  +- ProcessChain (not exported)
 # +- BufferStream
-# +- DevNullStream (not exported)
+# +- DevNull (not exported)
 # +- Filesystem.File
 # +- LibuvStream (not exported)
 # .  +- PipeEndpoint (not exported)


### PR DESCRIPTION
Remove deprecation of `DevNull` and rename `DevNullStream` to `DevNull`, fix #26132