### PR TITLE
Remove at-pure from manual

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -1383,7 +1383,7 @@ for cases where you don't need a more elaborate hierarchy.
 julia> struct Val{x}
        end
 
-julia> Base.@pure Val(x) = Val{x}()
+julia> Val(x) = Val{x}()
 Val
 ```
 


### PR DESCRIPTION
This is the documentation change from #27432.

Quoting myself:

> I am not sure I understood the conclusion when this should get in. These changes are not really essential for 0.7/1.0 except for the docs change that removes `@pure` from the manual.