### PR TITLE
Clean up exports list, removing undefined identifiers:

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -124,7 +124,6 @@ export
     InvalidStateException,
     KeyError,
     MissingException,
-    ParseError,
     SystemError,
     StringIndexError,
 
@@ -411,8 +410,6 @@ export
     rot180,
     rotl90,
     rotr90,
-    shuffle,
-    shuffle!,
     size,
     selectdim,
     sort!,
@@ -607,9 +604,6 @@ export
     summary,
 
 # logging
-    info,
-    logging,
-    warn,
     @debug,
     @info,
     @warn,


### PR DESCRIPTION
* ParseError was deprecate_moved, but was not removed from exports list.
* Remove old logging function exports -- these were deprecated to their macros
* Shuffle was deprecate_move'd to Random