### PR TITLE
inference: fix recursion limit heuristic

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -305,10 +305,26 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
     # if sig changed, may need to recompute the sparams environment
     if isa(method.sig, UnionAll) && isempty(sparams)
         recomputed = ccall(:jl_type_intersection_with_env, Any, (Any, Any), sig, method.sig)::SimpleVector
-        sig = recomputed[1]
-        if !isa(unwrap_unionall(sig), DataType) # probably Union{}
-            return Any, false, nothing
-        end
+        #@assert recomputed[1] !== Bottom
+        # We must not use `sig` here, since that may re-introduce structural complexity that
+        # our limiting heuristic sought to eliminate. The alternative would be to not increment depth over covariant contexts,
+        # but we prefer to permit inference of tuple-destructuring, so we don't do that right now
+        # For example, with a signature such as `Tuple{T, Ref{T}} where {T <: S}`
+        # we might want to limit this to `Tuple{S, Ref}`, while type-intersection can instead give us back the original type
+        # (which moves `S` back up to a lower comparison depth)
+        # Optionally, we could try to drive this to a fixed point, but I think this is getting too complex,
+        # and this would only cause more questions and more problems
+        # (the following is only an example, most of the statements are probable in the wrong order):
+        #     newsig = sig
+        #     seen = IdSet()
+        #     while !(newsig in seen)
+        #         push!(seen, newsig)
+        #         lsig = length((unwrap_unionall(sig)::DataType).parameters)
+        #         newsig = limit_type_size(newsig, sig, sv.linfo.specTypes, sv.params.TUPLE_COMPLEXITY_LIMIT_DEPTH, lsig)
+        #         recomputed = ccall(:jl_type_intersection_with_env, Any, (Any, Any), newsig, method.sig)::SimpleVector
+        #         newsig = recomputed[2]
+        #     end
+        #     sig = ?
         sparams = recomputed[2]::SimpleVector
     end
 


### PR DESCRIPTION
There's several related issues here:

1. Covariant kinds provide no meaningful information for the type size
limit heuristic. We should be just ignoring those and walking through to
the actual structural information of any real substance.
This seems to also make type_more_complex, _limit_type_size, and
is_derived_type more similar, which is probably always preferable.

2. Allowing type intersection to revise our type later can
cause it to reintroduce complexity (constraints) according to our metric,
while we want to only move up the type-hierarchy,
which can allow us to accidentally escape from the limit.
So if we've limited the type, we don't want to use a different type
that was derived by type-intersection and may not have our limits
applied anymore.

3. Inside `is_derived_type`, the var field of a UnionAll
should not increase the nesting depth, since `T<:(Ref{S} where S<:Any)`,
should observe the same depth as `{S<:Any, T<:Ref{S}}`.

fix #26665