### PR TITLE
Fix empty parens in header if git information is missing

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -279,7 +279,7 @@ function banner(io::IO = stdout)
         end
     end
 
-    commit_date = isempty(Base.GIT_VERSION_INFO.date_string) ? "" : split(Base.GIT_VERSION_INFO.date_string)[1]
+    commit_date = isempty(Base.GIT_VERSION_INFO.date_string) ? "" : " ($(split(Base.GIT_VERSION_INFO.date_string)[1]))"
 
     if get(io, :color, false)
         c = text_colors
@@ -295,7 +295,7 @@ function banner(io::IO = stdout)
           $(d1)(_)$(jl)     | $(d2)(_)$(tx) $(d4)(_)$(tx)    |
            $(jl)_ _   _| |_  __ _$(tx)   |  Type \"?\" for help, \"]?\" for Pkg help.
           $(jl)| | | | | | |/ _` |$(tx)  |
-          $(jl)| | |_| | | | (_| |$(tx)  |  Version $(VERSION) ($(commit_date))
+          $(jl)| | |_| | | | (_| |$(tx)  |  Version $(VERSION)$(commit_date)
          $(jl)_/ |\\__'_|_|_|\\__'_|$(tx)  |  $(commit_string)
         $(jl)|__/$(tx)                   |
 
@@ -307,7 +307,7 @@ function banner(io::IO = stdout)
           (_)     | (_) (_)    |
            _ _   _| |_  __ _   |  Type \"?\" for help, \"]?\" for Pkg help.
           | | | | | | |/ _` |  |
-          | | |_| | | | (_| |  |  Version $(VERSION) ($(commit_date))
+          | | |_| | | | (_| |  |  Version $(VERSION)$(commit_date)
          _/ |\\__'_|_|_|\\__'_|  |  $(commit_string)
         |__/                   |
 


### PR DESCRIPTION
I jumped the shark a bit on merging https://github.com/JuliaLang/julia/pull/28522, and didn't fully test all the conditions in which it could be printed.

To make this more explicit, with #28522 and this both merged, the startup banner will look like this for dev builds:

```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.0.0-rc1.6 (2018-08-08)
 _/ |\__'_|_|_|\__'_|  |  sf/banner/2cdd82edd0 (fork: 1 commits, 0 days)
|__/                   |
```

And like this for tagged builds:
```
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.0.0 (2018-08-08)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org release
|__/                   |
```