### PR TITLE
Documentation of ambiguous syntax, operator suffix

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -106,6 +106,9 @@ will reassign it. Most of the Unicode infix operators (in category Sm), such as 
 as infix operators and are available for user-defined methods (e.g. you can use `const ⊗ = kron`
 to define `⊗` as an infix Kronecker product).  Operators can also be suffixed with modifying marks,
 primes, and sub/superscripts, e.g. `+̂ₐ″` is parsed as an infix operator with the same precedence as `+`.
+A space is required between an operator that ends with a subscript/superscript letter and a subsequent 
+variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be written as `+ᵃ x` to distinguish 
+it from `+ ᵃx` where `ᵃx` is the variable name.
 
 The only explicitly disallowed names for variables are the names of built-in statements:
 

--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -106,8 +106,8 @@ will reassign it. Most of the Unicode infix operators (in category Sm), such as 
 as infix operators and are available for user-defined methods (e.g. you can use `const ⊗ = kron`
 to define `⊗` as an infix Kronecker product).  Operators can also be suffixed with modifying marks,
 primes, and sub/superscripts, e.g. `+̂ₐ″` is parsed as an infix operator with the same precedence as `+`.
-A space is required between an operator that ends with a subscript/superscript letter and a subsequent 
-variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be written as `+ᵃ x` to distinguish 
+A space is required between an operator that ends with a subscript/superscript letter and a subsequent
+variable name. For example, if `+ᵃ` is an operator, then `+ᵃx` must be written as `+ᵃ x` to distinguish
 it from `+ ᵃx` where `ᵃx` is the variable name.
 
 The only explicitly disallowed names for variables are the names of built-in statements:


### PR DESCRIPTION
This updates the documentation in line with the proposal in #28441 to disallow `+ᵃx`

Ideally, the parser should be updated together with the documentation, but I'm not familiar enough with the parser internals to do that myself.

This is a breaking change, since `+ᵃx` is currently legal syntax. (The way I interpret semantic versioning, the breaking change occurs when the documentation is updated. If the parser is later updated to work in accordance with the documentation, then that would technically be a bugfix, and wouldn't have to wait until the next major release. In practice though, people will be upset if code that was working in 1.0 suddenly stops working in 1.x.)