### PR TITLE
fix (\) SparseVector in SuiteSparse.CHOLMOD

### DIFF
--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1714,7 +1714,8 @@ end
 (\)(L::Factor{T}, B::StridedMatrix) where {T<:VTypes} = Matrix(L\Dense{T}(B))
 (\)(L::Factor, B::Sparse) = spsolve(CHOLMOD_A, L, B)
 # When right hand side is sparse, we have to ensure that the rhs is not marked as symmetric.
-(\)(L::Factor, B::SparseVecOrMat) = sparse(spsolve(CHOLMOD_A, L, Sparse(B)))
+(\)(L::Factor, B::SparseMatrixCSC) = sparse(spsolve(CHOLMOD_A, L, Sparse(B, 0)))
+(\)(L::Factor, B::SparseVector) = sparse(spsolve(CHOLMOD_A, L, Sparse(B)))
 
 \(adjL::Adjoint{<:Any,<:Factor}, B::Dense) = (L = adjL.parent; solve(CHOLMOD_A, L, B))
 \(adjL::Adjoint{<:Any,<:Factor}, B::VecOrMat) = (L = adjL.parent; Matrix(solve(CHOLMOD_A, L, Dense(B))))

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -1714,7 +1714,7 @@ end
 (\)(L::Factor{T}, B::StridedMatrix) where {T<:VTypes} = Matrix(L\Dense{T}(B))
 (\)(L::Factor, B::Sparse) = spsolve(CHOLMOD_A, L, B)
 # When right hand side is sparse, we have to ensure that the rhs is not marked as symmetric.
-(\)(L::Factor, B::SparseVecOrMat) = sparse(spsolve(CHOLMOD_A, L, Sparse(B, 0)))
+(\)(L::Factor, B::SparseVecOrMat) = sparse(spsolve(CHOLMOD_A, L, Sparse(B)))
 
 \(adjL::Adjoint{<:Any,<:Factor}, B::Dense) = (L = adjL.parent; solve(CHOLMOD_A, L, B))
 \(adjL::Adjoint{<:Any,<:Factor}, B::VecOrMat) = (L = adjL.parent; Matrix(solve(CHOLMOD_A, L, Dense(B))))

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -693,6 +693,7 @@ end
     chI = cholesky(sparseI)
     @test chI \ sparseb ≈ sparseb
     @test chI \ sparseB ≈ sparseB
+    @test chI \ sparseI ≈ sparseI
 end
 
 @testset "Real factorization and complex rhs" begin

--- a/stdlib/SuiteSparse/test/cholmod.jl
+++ b/stdlib/SuiteSparse/test/cholmod.jl
@@ -686,6 +686,15 @@ end
     @test A\view(Matrix(1.0I, 5, 5), :, :) ≈ Matrix(Diagonal(x))
 end
 
+@testset "Test \\ for Factor and SparseVecOrMat" begin
+    sparseI = sparse(1.0I, 100, 100)
+    sparseb = sprandn(100, 0.5)
+    sparseB = sprandn(100, 100, 0.5)
+    chI = cholesky(sparseI)
+    @test chI \ sparseb ≈ sparseb
+    @test chI \ sparseB ≈ sparseB
+end
+
 @testset "Real factorization and complex rhs" begin
     A = sprandn(5, 5, 0.4) |> t -> t't + I
     B = complex.(randn(5, 2), randn(5, 2))


### PR DESCRIPTION
(\\) for Factor and SparseVecOrMat has the following method error:
```julia
julia> using SparseArrays, LinearAlgebra
julia> sparseI = sparse(1.0I, 100, 100);
julia> sparseb = sprandn(100, 0.5); #SparseVector
julia> chI = cholesky(sparseI); #Factor
julia> chI \ sparseb ≈ sparseb #(\)(Factor, SparseVecOrMat)
ERROR: MethodError: no method matching SuiteSparse.CHOLMOD.Sparse(::SparseVector{Float64,Int64}, ::Int64)
Closest candidates are:
  SuiteSparse.CHOLMOD.Sparse(::Integer, ::Integer, ::Array{Int64,1}, ::Array{Int64,1}, ::Array{#s608,1} where #s608<:Union{Complex{Float64}, Float64}) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/SuiteSparse/src/cholmod.jl:882
  SuiteSparse.CHOLMOD.Sparse(::Integer, ::Integer, ::Array{Int64,1}, ::Array{Int64,1}, ::Array{Tv<:Union{Complex{Float64}, Float64},1}, ::Any) where Tv<:Union{Complex{Float64}, Float64} at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/SuiteSparse/src/cholmod.jl:848
  SuiteSparse.CHOLMOD.Sparse(::SparseMatrixCSC{Tv<:Union{Complex{Float64}, Float64},Int64}, ::Integer) where Tv<:Union{Complex{Float64}, Float64} at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/SuiteSparse/src/cholmod.jl:896
  ...
Stacktrace:
 [1] \(::SuiteSparse.CHOLMOD.Factor{Float64}, ::SparseVector{Float64,Int64}) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v0.7/SuiteSparse/src/cholmod.jl:1718
 [2] top-level scope at none:0
```

The method error is due to the call `Sparse(A::SparseMatrixCSC{Tv,SuiteSparse_long}, stype::Integer)`. 
It should call `Sparse(A::SparseVector{<:VTypes,SuiteSparse_long})` and `Sparse(A::SparseMatrixCSC{<:VTypes,<:ITypes})` instead.

I fixed it and wrote a test:
```julia
Test Summary:                        | Pass  Total
Test \ for Factor and SparseVecOrMat |    2      2
```
