### PR TITLE
Fix maximum(abs/abs2, T[])

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -252,9 +252,6 @@ mapreduce_empty(::typeof(identity), op, T) = reduce_empty(op, T)
 mapreduce_empty(::typeof(abs), op, T)      = abs(reduce_empty(op, T))
 mapreduce_empty(::typeof(abs2), op, T)     = abs2(reduce_empty(op, T))
 
-mapreduce_empty(f::typeof(abs),  ::typeof(max), T) = abs(zero(T))
-mapreduce_empty(f::typeof(abs2), ::typeof(max), T) = abs2(zero(T))
-
 mapreduce_empty_iter(f, op, itr, ::HasEltype) = mapreduce_empty(f, op, eltype(itr))
 mapreduce_empty_iter(f, op::typeof(&), itr, ::EltypeUnknown) = true
 mapreduce_empty_iter(f, op::typeof(|), itr, ::EltypeUnknown) = false

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1323,6 +1323,8 @@ for f in [:sum, :maximum, :minimum], op in [:abs, :abs2]
     SV = :AbstractSparseVector
     if f == :minimum
         @eval ($f)(::typeof($op), x::$SV{T}) where {T<:Number} = nnz(x) < length(x) ? ($op)(zero(T)) : ($f)($op, nonzeros(x))
+    elseif f == :maximum
+        @eval ($f)(::typeof($op), x::$SV{T}) where {T<:Number} = length(x) > 0 && nnz(x) == 0 ? ($op)(zero(T)) : ($f)($op, nonzeros(x))
     else
         @eval ($f)(::typeof($op), x::$SV) = ($f)($op, nonzeros(x))
     end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -50,8 +50,10 @@ using .Main.OffsetArrays
 @test mapreduce(-, +, Vector(range(1.0, stop=10000.0, length=10000))) == -50005000.0
 # empty mr
 @test mapreduce(abs2, +, Float64[]) === 0.0
-@test mapreduce(abs2, max, Float64[]) === 0.0
-@test mapreduce(abs, max, Float64[]) === 0.0
+@test_throws ArgumentError mapreduce(abs, max, Float64[])
+@test_throws ArgumentError mapreduce(abs2, max, Float64[])
+@test_throws ArgumentError mapreduce(abs, min, Float64[])
+@test_throws ArgumentError mapreduce(abs2, min, Float64[])
 @test_throws ArgumentError mapreduce(abs2, &, Float64[])
 @test_throws ArgumentError mapreduce(abs2, |, Float64[])
 


### PR DESCRIPTION
At the moment
```
julia> maximum(Float64[])
ERROR: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
 [1] reduce_empty(::Function, ::Type) at ./reduce.jl:224
 [2] mapreduce_empty(::typeof(identity), ::Function, ::Type) at ./reduce.jl:249
 [3] _mapreduce(::typeof(identity), ::typeof(max), ::IndexLinear, ::Array{Float64,1}) at ./reduce.jl:303
 [4] _mapreduce_dim at ./reducedim.jl:305 [inlined]
 [5] #mapreduce#542 at ./reducedim.jl:301 [inlined]
 [6] mapreduce at ./reducedim.jl:301 [inlined]
 [7] _maximum at ./reducedim.jl:650 [inlined]
 [8] _maximum at ./reducedim.jl:649 [inlined]
 [9] #maximum#548 at ./reducedim.jl:645 [inlined]
 [10] maximum(::Array{Float64,1}) at ./reducedim.jl:645
 [11] top-level scope at none:0

julia> maximum(abs, Float64[])
0.0

julia> minimum(abs, Float64[])
ERROR: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
 [1] reduce_empty(::Function, ::Type) at ./reduce.jl:224
 [2] mapreduce_empty(::typeof(abs), ::Function, ::Type) at ./reduce.jl:250
 [3] _mapreduce(::typeof(abs), ::typeof(min), ::IndexLinear, ::Array{Float64,1}) at ./reduce.jl:303
 [4] _mapreduce_dim(::Function, ::Function, ::NamedTuple{(),Tuple{}}, ::Array{Float64,1}, ::Colon) at ./reducedim.jl:305
 [5] #mapreduce#542 at ./reducedim.jl:301 [inlined]
 [6] mapreduce at ./reducedim.jl:301 [inlined]
 [7] _minimum at ./reducedim.jl:650 [inlined]
 [8] #minimum#551 at ./reducedim.jl:646 [inlined]
 [9] minimum(::Function, ::Array{Float64,1}) at ./reducedim.jl:646
 [10] top-level scope at none:0
```

It doesn't seem right to me. I suppose `maximum()` over an empty collection should throw in all cases.

The second commit improves
```
julia> sum(Bool[])
0

julia> sum(isequal(2), Int[])
ERROR: ArgumentError: reducing over an empty collection is not allowed
Stacktrace:
 [1] mapreduce_empty(::Function, ::Function, ::Type) at ./reduce.jl:248
 [2] _mapreduce(::Base.Fix2{typeof(isequal),Int64}, ::typeof(Base.add_sum), ::IndexLinear, ::Array{Any,1}) at ./reduce.jl:303
 [3] _mapreduce_dim(::Function, ::Function, ::NamedTuple{(),Tuple{}}, ::Array{Any,1}, ::Colon) at ./reducedim.jl:305
 [4] #mapreduce#542 at ./reducedim.jl:301 [inlined]
 [5] mapreduce at ./reducedim.jl:301 [inlined]
 [6] _sum at ./reducedim.jl:650 [inlined]
 [7] #sum#545 at ./reducedim.jl:646 [inlined]
 [8] sum(::Function, ::Array{Any,1}) at ./reducedim.jl:646
 [9] top-level scope at none:0
```

It seems valid to return 0 in the second case. Of course, `isequal()` is just one specific case of bool-valued `f`, OTOH it's quite a common one.