### PR TITLE
fixes issue 28553, improves error message for missing packages

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -816,7 +816,7 @@ function require(into::Module, mod::Symbol)
         if where.uuid === nothing
             throw(ArgumentError("""
                 Package $mod not found in current path:
-                - Run `Pkg.add($(repr(String(mod))))` to install the $mod package.
+                - Run `import Pkg; Pkg.add($(repr(String(mod))))` to install the $mod package.
                 """))
         else
             s = """


### PR DESCRIPTION
This PR improves the message for missing packages when using `using [PkgName]` if the package is not installed. 

Fixes #28553 