### PR TITLE
add document on JULIA_PROJECT environment variable

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -70,8 +70,8 @@ and a global configuration search path of
 A directory path that points to the current Julia project. Setting this
 environment variable has the same effect as specifying the `--project` start-up
 option, but `--project` has higher precedence.  If the variable is set to `@.`,
-Julia tries to find a project directory that contains Project.toml or
-JuliaProject.toml file from the current directory and its parents.  See also
+Julia tries to find a project directory that contains `Project.toml` or
+`JuliaProject.toml` file from the current directory and its parents.  See also
 the chapter on [Code Loading](@ref).
 
 ### `JULIA_LOAD_PATH`

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -65,6 +65,15 @@ and a global configuration search path of
 /etc/julia/startup.jl
 ```
 
+### `JULIA_PROJECT`
+
+A directory path that points to the current Julia project. Setting this
+environment variable has the same effect as specifying the `--project` start-up
+option, but `--project` has higher precedence.  If the variable is set to `@.`,
+Julia tries to find a project directory that contains Project.toml or
+JuliaProject.toml file from the current directory and its parents.  See also
+the chapter on [Code Loading](@ref).
+
 ### `JULIA_LOAD_PATH`
 
 A separated list of absolute paths that are to be appended to the variable


### PR DESCRIPTION
This adds a description on JULIA_PROJECT environment variable, which is yet documented anywhere but would be a standard way to set the current Julia project. I read its behavior from the source code and so my understanding may be wrong.