### PR TITLE
Loosens time limit to 0.5 sec during stress.jl test.

### DIFF
--- a/test/stress.jl
+++ b/test/stress.jl
@@ -98,7 +98,7 @@ if !Sys.iswindows()
     @test_throws InterruptException begin
         ccall(:kill, Cvoid, (Cint, Cint,), getpid(), 2)
         for i in 1:10
-            Libc.systemsleep(0.1)
+            Libc.systemsleep(0.5)
             ccall(:jl_gc_safepoint, Cvoid, ()) # wait for SIGINT to arrive
         end
     end


### PR DESCRIPTION
Reference buildlog:

  https://buildd.debian.org/status/fetch.php?pkg=julia&arch=all&ver=0.7.0-1&stamp=1533838647&raw=0

The same problem occurred during the julia 1.0.0 build. After applying this patch this failure disappeared.
http://debomatic-amd64.debian.net/distribution#experimental/julia/1.0.0-1/buildlog

This is not a good solution though.