### PR TITLE
pkg mode added, fixes #28584

### DIFF
--- a/stdlib/Pkg/docs/src/index.md
+++ b/stdlib/Pkg/docs/src/index.md
@@ -176,7 +176,7 @@ global configuration data is saved. Later entries in the depot path are treated
 as read-only and are appropriate for registries, packages, etc. installed and
 managed by system administrators.
 
-## Getting Started
+## Getting Started(@id pkg_getting_started)
 
 The Pkg REPL-mode is entered from the Julia REPL using the key `]`.
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -94,7 +94,11 @@ search: Int32 UInt32
   32-bit signed integer type.
 ```
 
-Help mode can be exited by pressing backspace at the beginning of the line.
+### Pkg mode
+
+When the cursor is the beginning of the line, typing `]` will enter pkg mode. This mode allows
+simpler syntax than the standard Pkg API and is fully documented [here](@ref pkg_getting_started).
+To return to the julia> prompt, either press backspace when the input line is empty or press Ctrl+C. 
 
 ### [Shell mode](@id man-shell-mode)
 


### PR DESCRIPTION
Added pkg mode in the REPL stdlib documentation page. There is not much description here but there is a link that redirects to the excellent already written docs on Pkg page.