### PR TITLE
stop specializing on argument types of `display`

### DIFF
--- a/base/multimedia.jl
+++ b/base/multimedia.jl
@@ -43,8 +43,8 @@ julia> showable("img/png", rand(5))
 false
 ```
 """
-showable(::MIME{mime}, x) where {mime} = hasmethod(show, Tuple{IO, MIME{mime}, typeof(x)})
-showable(m::AbstractString, x) = showable(MIME(m), x)
+showable(::MIME{mime}, @nospecialize x) where {mime} = hasmethod(show, Tuple{IO, MIME{mime}, typeof(x)})
+showable(m::AbstractString, @nospecialize x) = showable(MIME(m), x)
 
 """
     show(io, mime, x)
@@ -175,8 +175,8 @@ end
 abstract type AbstractDisplay end
 
 # it is convenient to accept strings instead of ::MIME
-display(d::AbstractDisplay, mime::AbstractString, x) = display(d, MIME(mime), x)
-display(mime::AbstractString, x) = display(MIME(mime), x)
+display(d::AbstractDisplay, mime::AbstractString, @nospecialize x) = display(d, MIME(mime), x)
+display(mime::AbstractString, @nospecialize x) = display(MIME(mime), x)
 
 """
     displayable(mime) -> Bool
@@ -201,12 +201,12 @@ objects are printed in the Julia REPL.)
 struct TextDisplay <: AbstractDisplay
     io::IO
 end
-display(d::TextDisplay, M::MIME"text/plain", x) = show(d.io, M, x)
-display(d::TextDisplay, x) = display(d, MIME"text/plain"(), x)
+display(d::TextDisplay, M::MIME"text/plain", @nospecialize x) = show(d.io, M, x)
+display(d::TextDisplay, @nospecialize x) = display(d, MIME"text/plain"(), x)
 
 # if you explicitly call display("text/foo", x), it should work on a TextDisplay:
 displayable(d::TextDisplay, M::MIME) = istextmime(M)
-function display(d::TextDisplay, M::MIME, x)
+function display(d::TextDisplay, M::MIME, @nospecialize x)
     displayable(d, M) || throw(MethodError(display, (d, M, x)))
     show(d.io, M, x)
 end
@@ -254,7 +254,7 @@ function reinit_displays()
     pushdisplay(TextDisplay(stdout))
 end
 
-xdisplayable(D::AbstractDisplay, args...) = applicable(display, D, args...)
+xdisplayable(D::AbstractDisplay, @nospecialize args...) = applicable(display, D, args...)
 
 """
     display(x)
@@ -280,7 +280,7 @@ variants, one can also supply the "raw" data in the requested MIME type by passi
 `x::AbstractString` (for MIME types with text-based storage, such as text/html or
 application/postscript) or `x::Vector{UInt8}` (for binary MIME types).
 """
-function display(x)
+function display(@nospecialize x)
     for i = length(displays):-1:1
         if xdisplayable(displays[i], x)
             try
@@ -294,7 +294,7 @@ function display(x)
     throw(MethodError(display, (x,)))
 end
 
-function display(m::MIME, x)
+function display(m::MIME, @nospecialize x)
     for i = length(displays):-1:1
         if xdisplayable(displays[i], m, x)
             try
@@ -339,7 +339,7 @@ Using `redisplay` is also a hint to the backend that `x` may be redisplayed
 several times, and the backend may choose to defer the display until
 (for example) the next interactive prompt.
 """
-function redisplay(x)
+function redisplay(@nospecialize x)
     for i = length(displays):-1:1
         if xdisplayable(displays[i], x)
             try
@@ -353,7 +353,7 @@ function redisplay(x)
     throw(MethodError(redisplay, (x,)))
 end
 
-function redisplay(m::Union{MIME,AbstractString}, x)
+function redisplay(m::Union{MIME,AbstractString}, @nospecialize x)
     for i = length(displays):-1:1
         if xdisplayable(displays[i], m, x)
             try
@@ -368,8 +368,8 @@ function redisplay(m::Union{MIME,AbstractString}, x)
 end
 
 # default redisplay is simply to call display
-redisplay(d::AbstractDisplay, x) = display(d, x)
-redisplay(d::AbstractDisplay, m::Union{MIME,AbstractString}, x) = display(d, m, x)
+redisplay(d::AbstractDisplay, @nospecialize x) = display(d, x)
+redisplay(d::AbstractDisplay, m::Union{MIME,AbstractString}, @nospecialize x) = display(d, m, x)
 
 ###########################################################################
 


### PR DESCRIPTION
There is no real advantage in specializing on the argument types for display since it goes through a quite complicated machinery of trying to find applicable displays anyway. This function is getting compiled for every type we show in the REPL for example.

Before:
```
julia> let
        @time precompile(Tuple{typeof(Base.Multimedia.display), Int32})
        @time precompile(Tuple{typeof(Base.Multimedia.display), Vector{Int}})
        @time precompile(Tuple{typeof(Base.Multimedia.display), Float64})
        @time precompile(Tuple{typeof(Base.Multimedia.display), Symbol})
       end
  0.034542 seconds (37.08 k allocations: 1.916 MiB)
  0.042272 seconds (92.57 k allocations: 4.810 MiB)
  0.039003 seconds (90.20 k allocations: 4.758 MiB)
  0.030826 seconds (61.08 k allocations: 3.066 MiB)
```

After:

```
julia> let
        @time precompile(Tuple{typeof(Base.Multimedia.display), Int32})
        @time precompile(Tuple{typeof(Base.Multimedia.display), Vector{Int}})
        @time precompile(Tuple{typeof(Base.Multimedia.display), Float64})
        @time precompile(Tuple{typeof(Base.Multimedia.display), Symbol})
       end

  0.000041 seconds (12 allocations: 640 bytes)
  0.000029 seconds (10 allocations: 544 bytes)
  0.000024 seconds (9 allocations: 496 bytes)
  0.000021 seconds (9 allocations: 496 bytes)
```