### PR TITLE
Fix #28619, logabsdet for singular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1274,7 +1274,7 @@ julia> logabsdet(B)
 (0.6931471805599453, 1.0)
 ```
 """
-logabsdet(A::AbstractMatrix) = logabsdet(lu(A))
+logabsdet(A::AbstractMatrix) = logabsdet(lu(A, check=false))
 
 """
     logdet(M)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -80,6 +80,8 @@ n = 5 # should be odd
         @test logdet(A) ≈ log(det(A))
         @test logabsdet(A)[1] ≈ log(abs(det(A)))
         @test logabsdet(Matrix{elty}(-I, n, n))[2] == -1
+        infinity = convert(float(elty), Inf)
+        @test logabsdet(zeros(elty, n, n)) == (-infinity, zero(elty))
         if elty <: Real
             @test logabsdet(A)[2] == sign(det(A))
             @test_throws DomainError logdet(Matrix{elty}(-I, n, n))


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#550.

Of course, the "backport pending" labels are my opinion; feel free to adjust as necessary.