### PR TITLE
Fix throw_complex_domainerror error message for log[1p]

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -27,7 +27,7 @@ using Core.Intrinsics: sqrt_llvm
 
 using .Base: IEEEFloat
 
-@noinline function throw_complex_domainerror(f, x)
+@noinline function throw_complex_domainerror(f::Symbol, x)
     throw(DomainError(x, string("$f will only return a complex result if called with a ",
                                 "complex argument. Try $f(Complex(x)).")))
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -198,17 +198,17 @@ julia> log(4,2)
 0.5
 
 julia> log(-2, 3)
-ERROR: DomainError with log:
--2.0 will only return a complex result if called with a complex argument. Try -2.0(Complex(x)).
+ERROR: DomainError with -2.0:
+log will only return a complex result if called with a complex argument. Try log(Complex(x)).
 Stacktrace:
- [1] throw_complex_domainerror(::Float64, ::Symbol) at ./math.jl:31
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
 [...]
 
 julia> log(2, -3)
-ERROR: DomainError with log:
--3.0 will only return a complex result if called with a complex argument. Try -3.0(Complex(x)).
+ERROR: DomainError with -3.0:
+log will only return a complex result if called with a complex argument. Try log(Complex(x)).
 Stacktrace:
- [1] throw_complex_domainerror(::Float64, ::Symbol) at ./math.jl:31
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
 [...]
 ```
 
@@ -459,10 +459,10 @@ julia> log1p(0)
 0.0
 
 julia> log1p(-2)
-ERROR: DomainError with log1p:
--2.0 will only return a complex result if called with a complex argument. Try -2.0(Complex(x)).
+ERROR: DomainError with -2.0:
+log1p will only return a complex result if called with a complex argument. Try log1p(Complex(x)).
 Stacktrace:
- [1] throw_complex_domainerror(::Float64, ::Symbol) at ./math.jl:31
+ [1] throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:31
 [...]
 ```
 """

--- a/base/special/log.jl
+++ b/base/special/log.jl
@@ -282,7 +282,7 @@ function log(x::Float64)
     elseif isnan(x)
         NaN
     else
-        throw_complex_domainerror(x, :log)
+        throw_complex_domainerror(:log, x)
     end
 end
 
@@ -318,7 +318,7 @@ function log(x::Float32)
     elseif isnan(x)
         NaN32
     else
-        throw_complex_domainerror(x, :log)
+        throw_complex_domainerror(:log, x)
     end
 end
 
@@ -353,7 +353,7 @@ function log1p(x::Float64)
     elseif isnan(x)
         NaN
     else
-        throw_complex_domainerror(x, :log1p)
+        throw_complex_domainerror(:log1p, x)
     end
 end
 
@@ -386,7 +386,7 @@ function log1p(x::Float32)
     elseif isnan(x)
         NaN32
     else
-        throw_complex_domainerror(x, :log1p)
+        throw_complex_domainerror(:log1p, x)
     end
 end
 


### PR DESCRIPTION
This seems pretty clearly unintentional.  Relevant history is in d4229beb7e8d2c665fe6bd3fc9624ec2ffa4d096 and d555a9a3874f4c47e16d1fdcbae4866cc0d3917f.