### PR TITLE
[RFC] Use v# instead of v#.# as default environment.

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -70,7 +70,7 @@ end
 # this will inherit an existing JULIA_LOAD_PATH value or if there is none, leave
 # a trailing empty entry in JULIA_LOAD_PATH which will be replaced with defaults.
 
-const DEFAULT_LOAD_PATH = ["@", "@v#.#", "@stdlib"]
+const DEFAULT_LOAD_PATH = ["@", "@v#", "@stdlib"]
 
 """
     LOAD_PATH


### PR DESCRIPTION
Since those default environments probably will be used for playing in the repl it is a bit annoying that we have a new one for each minor julia version. We could also change it to `["@", "@v#", "@v#.#", "@stdlib"]` I guess...