### PR TITLE
Support parallelizing over collections that have non-Int lengths

### DIFF
--- a/stdlib/Distributed/src/macros.jl
+++ b/stdlib/Distributed/src/macros.jl
@@ -231,7 +231,7 @@ end
 
 
 # Statically split range [1,N] into equal sized chunks for np processors
-function splitrange(N::Integer, np::Integer)
+function splitrange(N::Int, np::Int)
     each = div(N,np)
     extras = rem(N,np)
     nchunks = each > 0 ? np : extras
@@ -251,7 +251,7 @@ end
 
 function preduce(reducer, f, R)
     N = length(R)
-    chunks = splitrange(N, nworkers())
+    chunks = splitrange(Int(N), nworkers())
     all_w = workers()[1:length(chunks)]
 
     w_exec = Task[]

--- a/stdlib/Distributed/src/macros.jl
+++ b/stdlib/Distributed/src/macros.jl
@@ -231,7 +231,7 @@ end
 
 
 # Statically split range [1,N] into equal sized chunks for np processors
-function splitrange(N::Int, np::Int)
+function splitrange(N::Integer, np::Integer)
     each = div(N,np)
     extras = rem(N,np)
     nchunks = each > 0 ? np : extras

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1525,6 +1525,10 @@ end
 a27933 = :_not_defined_27933
 @test remotecall_fetch(()->a27933, first(workers())) === a27933
 
+# PR #28651
+for T in [UInt8, Int8, UInt16, Int16, UInt32, Int32]
+    @test Distributed.splitrange(20, 4) == Distributed.splitrange(T(20), 4)
+end
 # Run topology tests last after removing all workers, since a given
 # cluster at any time only supports a single topology.
 rmprocs(workers())

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -15,11 +15,6 @@ include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
         1
     end
 
-# PR #28651
-for T in [UInt8, Int8, UInt16, Int16, UInt32, Int32]
-    @test Distributed.splitrange(20, 4) == Distributed.splitrange(T(20), 4)
-end
-
 addprocs_with_testenv(4)
 @test nprocs() == 5
 
@@ -1529,6 +1524,14 @@ end
 # issue #27933
 a27933 = :_not_defined_27933
 @test remotecall_fetch(()->a27933, first(workers())) === a27933
+
+# PR #28651
+for T in (UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64)
+  n = @distributed (+) for i in Base.OneTo(T(10))
+    i
+  end
+  @test n == 55
+end
 
 # Run topology tests last after removing all workers, since a given
 # cluster at any time only supports a single topology.

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -15,6 +15,11 @@ include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
         1
     end
 
+# PR #28651
+for T in [UInt8, Int8, UInt16, Int16, UInt32, Int32]
+    @test Distributed.splitrange(20, 4) == Distributed.splitrange(T(20), 4)
+end
+
 addprocs_with_testenv(4)
 @test nprocs() == 5
 
@@ -1525,10 +1530,6 @@ end
 a27933 = :_not_defined_27933
 @test remotecall_fetch(()->a27933, first(workers())) === a27933
 
-# PR #28651
-for T in [UInt8, Int8, UInt16, Int16, UInt32, Int32]
-    @test Distributed.splitrange(20, 4) == Distributed.splitrange(T(20), 4)
-end
 # Run topology tests last after removing all workers, since a given
 # cluster at any time only supports a single topology.
 rmprocs(workers())

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1527,10 +1527,10 @@ a27933 = :_not_defined_27933
 
 # PR #28651
 for T in (UInt8, Int8, UInt16, Int16, UInt32, Int32, UInt64)
-  n = @distributed (+) for i in Base.OneTo(T(10))
-    i
-  end
-  @test n == 55
+    n = @distributed (+) for i in Base.OneTo(T(10))
+        i
+    end
+    @test n == 55
 end
 
 # Run topology tests last after removing all workers, since a given


### PR DESCRIPTION
Changes `splitrange` to use `Integer` instead of `Int` so that mixed-width ints can be used. This fixes the following LightGraphs issue on 32-bit machines:
```
julia> g = Graph(10,20)
{10, 20} undirected simple Int32 graph

julia> Parallel.stress_centrality(g);

julia> g = Graph{Int64}(g)
{10, 20} undirected simple Int64 graph

julia> Parallel.stress_centrality(g);
ERROR: MethodError: no method matching splitrange(::Int64, ::Int32)
Closest candidates are:
  splitrange(::Int32, ::Int32) at /buildworker/worker/package_linuxarmv7l/build/usr/share/julia/stdlib/v1.0/Distributed/src/macros.jl:235
```