### PR TITLE
improve slicing lazily transposed sparse matrices: WIP

### DIFF
--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1260,4 +1260,22 @@ end
     end
 end
 
+@testset "slice transpose and adjoint" begin
+    matdim = 1000
+    S = sprand(Complex{Float64}, matdim, matdim, 0.1)
+    St = transpose(S)
+    Sa = adjoint(S)
+    r1 = div(matdim, 4)
+    r2 = div(matdim, 2) + r1
+    irange = r1:r2
+    cirange = collect(irange)
+    for inds1 in ((1, :), (irange, 1), (cirange, 1))
+        for inds in (inds1, reverse(inds1))
+            rinds = reverse(inds)
+            @test S[inds...] == St[rinds...]
+            @test S[inds...] == conj.(Sa[rinds...])
+        end
+    end
+end
+
 end # module


### PR DESCRIPTION
This PR uses the code for getting slices in sparsevector.jl to get slices of sparse matrices
that have lazy adjoint and transpose wrappers. Before, the fallback code in abstractarray.jl created the
slices inefficiently.

Here is an example of a sparse matrix created with `sprand(10^4 10^4, 0.01)`, which shows an increase in speed of 10 to 1000 x.
The [test code](https://gist.github.com/jlapeyre/e6116b5347822bef3dc8d0ee4302ed5c#file-00sparse_slice_benchmark-jl).
[Benchmark before the PR](https://gist.github.com/jlapeyre/e6116b5347822bef3dc8d0ee4302ed5c#file-pre_pr_times-jl).
[Benchmark after the PR](https://gist.github.com/jlapeyre/e6116b5347822bef3dc8d0ee4302ed5c#file-post_pr_times-jl)

The changes should have no effect on the efficiency of  slicing unwrapped, ie `SparseMatrixCSC`, matrices.

The new slicing calls `adjoint` and `transpose` recursively. I don't know of any cases where that is useful, although there may be. Consider for example a sparse matrix with elements that are dense matrices.  If you want to interpret this as a block matrix, then `transpose(S)[1, :]` doesn't give you the correct result. (Neither does `S[1,:]`.) Maybe restricting the recursion to structures that are intended to be used for linear algebra (eg `BlockArray`), rather than any ad-hoc array makes sense. The reason for this restriction would be to reduce complexity. I'm sure this has been discussed elsewhere, but I have not yet read about it.

There could be further optimizations. EDIT: The following has been done and commited to this branch. 
 ~For instance, check if the elements of the parent matrix are numbers (via dispatch), in which case it is not necessary to call `transpose`.~

EDIT: Tests have been added to this branch ~This PR needs tests, there are none.~ I would not be surprised if some or all slicing of wrapped arrays is not covered by existing tests.