### PR TITLE
improve performance for number to string conversion functions

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -543,11 +543,11 @@ function bin(x::Unsigned, pad::Int, neg::Bool)
     i = neg + max(pad,sizeof(x)<<3-leading_zeros(x))
     a = StringVector(i)
     while i > neg
-        a[i] = 48+(x&0x1)
+        @inbounds a[i] = 48+(x&0x1)
         x >>= 1
         i -= 1
     end
-    if neg; a[1]='-'; end
+    if neg; @inbounds a[1]=0x2d; end
     String(a)
 end
 
@@ -559,7 +559,7 @@ function oct(x::Unsigned, pad::Int, neg::Bool)
         x >>= 3
         i -= 1
     end
-    if neg; @inbounds a[1]='-'; end
+    if neg; @inbounds a[1]=0x2d; end
     String(a)
 end
 
@@ -571,7 +571,7 @@ function dec(x::Unsigned, pad::Int, neg::Bool)
         x = oftype(x,div(x,10))
         i -= 1
     end
-    if neg; @inbounds a[1]='-'; end
+    if neg; @inbounds a[1]=0x2d; end
     String(a)
 end
 
@@ -584,7 +584,7 @@ function hex(x::Unsigned, pad::Int, neg::Bool)
         x >>= 4
         i -= 1
     end
-    if neg; @inbounds a[1]='-'; end
+    if neg; @inbounds a[1]=0x2d; end
     String(a)
 end
 

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -543,7 +543,7 @@ function bin(x::Unsigned, pad::Int, neg::Bool)
     i = neg + max(pad,sizeof(x)<<3-leading_zeros(x))
     a = StringVector(i)
     while i > neg
-        a[i] = '0'+(x&0x1)
+        a[i] = 48+(x&0x1)
         x >>= 1
         i -= 1
     end
@@ -555,11 +555,11 @@ function oct(x::Unsigned, pad::Int, neg::Bool)
     i = neg + max(pad,div((sizeof(x)<<3)-leading_zeros(x)+2,3))
     a = StringVector(i)
     while i > neg
-        a[i] = '0'+(x&0x7)
+        @inbounds a[i] = 48+(x&0x7)
         x >>= 3
         i -= 1
     end
-    if neg; a[1]='-'; end
+    if neg; @inbounds a[1]='-'; end
     String(a)
 end
 
@@ -567,11 +567,11 @@ function dec(x::Unsigned, pad::Int, neg::Bool)
     i = neg + ndigits(x, base=10, pad=pad)
     a = StringVector(i)
     while i > neg
-        a[i] = '0'+rem(x,10)
+        @inbounds a[i] = 48+rem(x,10)
         x = oftype(x,div(x,10))
         i -= 1
     end
-    if neg; a[1]='-'; end
+    if neg; @inbounds a[1]='-'; end
     String(a)
 end
 
@@ -580,11 +580,11 @@ function hex(x::Unsigned, pad::Int, neg::Bool)
     a = StringVector(i)
     while i > neg
         d = x & 0xf
-        a[i] = '0'+d+39*(d>9)
+        @inbounds a[i] = 48+d+39*(d>9)
         x >>= 4
         i -= 1
     end
-    if neg; a[1]='-'; end
+    if neg; @inbounds a[1]='-'; end
     String(a)
 end
 


### PR DESCRIPTION
This is kinda silly but it is what it is...

Benchmark:

```jl
for base in (2, 8, 10, 16)
    @btime begin
        u = rand(UInt32)
        string(u; base=$base)
    end
end
```

Before
```jl
  385.406 ns (2 allocations: 118 bytes)
  168.925 ns (2 allocations: 96 bytes)
  131.273 ns (2 allocations: 96 bytes)
  149.896 ns (2 allocations: 96 bytes)
```

After

```jl
  72.232 ns (2 allocations: 118 bytes)
  49.118 ns (2 allocations: 96 bytes)
  61.106 ns (2 allocations: 96 bytes)
  68.188 ns (2 allocations: 96 bytes)
```