### PR TITLE
remove redundant text in a docstring

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -223,7 +223,7 @@ IOBuffer(s::SubString{String}) = IOBuffer(view(unsafe_wrap(Vector{UInt8}, s.stri
 Join an array of `strings` into a single string, inserting the given delimiter between
 adjacent strings. If `last` is given, it will be used instead of `delim` between the last
 two strings. If `io` is given, the result is written to `io` rather than returned as
-as a `String`.  For example,
+as a `String`.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
No sentence follows after this "For example,".