### PR TITLE
fix performance in printf

### DIFF
--- a/base/printf.jl
+++ b/base/printf.jl
@@ -863,7 +863,7 @@ function decode_oct(d::Integer)
     @handle_zero x digits
     pt = i = div((sizeof(x)<<3)-leading_zeros(x)+2,3)
     while i > 0
-        digits[i] = '0'+(x&0x7)
+        digits[i] = 48+(x&0x7)
         x >>= 3
         i -= 1
     end
@@ -876,7 +876,7 @@ function decode_0ct(d::Integer)
     pt = i = div((sizeof(x)<<3)-leading_zeros(x)+5,3)
     digits = DIGITSs[Threads.threadid()]
     while i > 0
-        digits[i] = '0'+(x&0x7)
+        digits[i] = 48+(x&0x7)
         x >>= 3
         i -= 1
     end
@@ -889,7 +889,7 @@ function decode_dec(d::Integer)
     @handle_zero x digits
     pt = i = Base.ndigits0z(x)
     while i > 0
-        digits[i] = '0'+rem(x,10)
+        digits[i] = 48+rem(x,10)
         x = div(x,10)
         i -= 1
     end


### PR DESCRIPTION
Same story as in https://github.com/JuliaLang/julia/pull/28661.

Improves the benchmark in `print_to_file` (that we show on the benchmark plot on the homepage).

```jl
julia> using Printf

julia> function printfd(n)
           open("/dev/null", "w") do io
               for i = 1:n
                   @printf(io, "%d %d\n", i, i + 1)
               end
           end
       end
```

Before
```
julia> @btime printfd(1000)
  117.889 μs (5 allocations: 400 bytes)
```

After
```
julia> @btime printfd(1000)
  74.283 μs (5 allocations: 400 bytes)
```

