### PR TITLE
LinearAlgebra remove unused export

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -60,7 +60,6 @@ export
     axpby!,
     bunchkaufman,
     bunchkaufman!,
-    chol,
     cholesky,
     cholesky!,
     cond,


### PR DESCRIPTION
Maybe we should CI that nothing exports undefined symbols?