### PR TITLE
fix REPL completions not always being unique

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -346,7 +346,7 @@ function complete_line(c::REPLCompletionProvider, s)
     partial = beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
     ret, range, should_complete = completions(full, lastindex(partial))
-    return map(completion_text, ret), partial[range], should_complete
+    return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 
 function complete_line(c::ShellCompletionProvider, s)
@@ -354,14 +354,14 @@ function complete_line(c::ShellCompletionProvider, s)
     partial = beforecursor(s.input_buffer)
     full = LineEdit.input_string(s)
     ret, range, should_complete = shell_completions(full, lastindex(partial))
-    return map(completion_text, ret), partial[range], should_complete
+    return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 
 function complete_line(c::LatexCompletions, s)
     partial = beforecursor(LineEdit.buffer(s))
     full = LineEdit.input_string(s)
     ret, range, should_complete = bslash_completions(full, lastindex(partial))[2]
-    return map(completion_text, ret), partial[range], should_complete
+    return unique!(map(completion_text, ret)), partial[range], should_complete
 end
 
 mutable struct REPLHistoryProvider <: HistoryProvider

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -102,6 +102,11 @@ let s = ""
     @test s[r] == ""
 end
 
+let s = "using REP"
+    c, r = test_complete(s)
+    @test count(isequal("REPL"), c) == 1
+end
+
 let s = "Comp"
     c, r = test_complete(s)
     @test "CompletionFoo" in c


### PR DESCRIPTION
Bug introduced in https://github.com/JuliaLang/julia/pull/26930 since completion types with the same text but different type no longer are filtered out by the `unique!` in `completions`.

I don't think the filtering should take place in `LineEdit` since other consumers (with a more rich display system than the REPL) might want to show duplicates with different types.

Gotta think of a test...

Fixes #28692 

cc @jamii