### PR TITLE
Use code font for `jl_value_t` in h2

### DIFF
--- a/doc/src/devdocs/object.md
+++ b/doc/src/devdocs/object.md
@@ -1,6 +1,6 @@
 # Memory layout of Julia Objects
 
-## Object layout (jl_value_t)
+## Object layout (`jl_value_t`)
 
 The `jl_value_t` struct is the name for a block of memory owned by the Julia Garbage Collector,
 representing the data associated with a Julia object in memory. Absent any type information, it


### PR DESCRIPTION
By just using text, the underscores around value are interpreted as begin/end italics.

See:

![screenshot from 2018-08-16 10-08-27](https://user-images.githubusercontent.com/520669/44223388-56baea00-a13c-11e8-9bed-b58d346cfd3b.png)
