### PR TITLE
add rand(::Pair)

### DIFF
--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -430,3 +430,12 @@ function rand(rng::AbstractRNG, sp::SamplerSimple{<:AbstractString,<:Sampler})::
         isvalid_unsafe(str, pos) && return str[pos]
     end
 end
+
+
+## random elements from pairs
+
+Sampler(RNG::Type{<:AbstractRNG}, t::Pair, n::Repetition) =
+    SamplerSimple(t, Sampler(RNG, Bool, n))
+
+rand(rng::AbstractRNG, sp::SamplerSimple{<:Pair}) =
+    @inbounds return sp[][1 + rand(rng, sp.data)]

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -686,3 +686,9 @@ end
     @test Random.gentype(Random.UInt52(UInt128)) == UInt128
     @test Random.gentype(Random.UInt104()) == UInt128
 end
+
+@testset "rand(::Pair)" begin
+    @test rand(1=>3) ∈ (1, 3)
+    @test rand(1=>2, 3) isa Vector{Int}
+    @test rand(1=>'2', 3) isa Vector{Union{Char, Int}}
+end


### PR DESCRIPTION
This is similar to #25278, which adds `rand(::Tuple)`. `Pair` has the attributes of a collection, so there is no reason to exclude it from `rand`able objects.