### PR TITLE
Match headers of stdlib doc pages to stdlib name

### DIFF
--- a/stdlib/DelimitedFiles/docs/src/index.md
+++ b/stdlib/DelimitedFiles/docs/src/index.md
@@ -1,4 +1,4 @@
-# Delimited Files
+# DelimitedFiles
 
 ```@meta
 DocTestSetup = :(using DelimitedFiles)

--- a/stdlib/Distributed/docs/src/index.md
+++ b/stdlib/Distributed/docs/src/index.md
@@ -1,4 +1,4 @@
-# Distributed Computing
+# Distributed
 
 ```@meta
 DocTestSetup = :(using Distributed)

--- a/stdlib/FileWatching/docs/src/index.md
+++ b/stdlib/FileWatching/docs/src/index.md
@@ -1,4 +1,4 @@
-# [File Events](@id lib-filewatching)
+# [FileWatching](@id lib-filewatching)
 
 ```@docs
 FileWatching.poll_fd

--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -1,4 +1,4 @@
-# Interactive Utilities
+# InteractiveUtils
 
 ```@meta
 DocTestSetup = :(using InteractiveUtils)

--- a/stdlib/Libdl/docs/src/index.md
+++ b/stdlib/Libdl/docs/src/index.md
@@ -1,4 +1,4 @@
-# Dynamic Linker
+# Libdl
 
 ```@docs
 Libdl.dlopen

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -1,4 +1,4 @@
-# Linear Algebra
+# LinearAlgebra
 
 ```@meta
 DocTestSetup = :(using LinearAlgebra)

--- a/stdlib/Mmap/docs/src/index.md
+++ b/stdlib/Mmap/docs/src/index.md
@@ -1,4 +1,4 @@
-# Memory-mapped I/O
+# Mmap
 
 ```@meta
 DocTestSetup = :(using Mmap)

--- a/stdlib/Profile/docs/src/index.md
+++ b/stdlib/Profile/docs/src/index.md
@@ -1,4 +1,4 @@
-# [Profiling](@id lib-profiling)
+# [Profile](@id lib-profiling)
 
 ```@docs
 Profile.@profile

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -1,4 +1,4 @@
-# The Julia REPL
+# REPL
 
 Julia comes with a full-featured interactive command-line REPL (read-eval-print loop) built into
 the `julia` executable. In addition to allowing quick and easy evaluation of Julia statements,

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -1,4 +1,4 @@
-# Random Numbers
+# Random
 
 ```@meta
 DocTestSetup = :(using Random)

--- a/stdlib/SharedArrays/docs/src/index.md
+++ b/stdlib/SharedArrays/docs/src/index.md
@@ -1,4 +1,4 @@
-# Shared Arrays
+# SharedArrays
 
 ```@docs
 SharedArrays.SharedArray

--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -1,4 +1,4 @@
-# Sparse Arrays
+# SparseArrays
 
 ```@meta
 DocTestSetup = :(using SparseArrays, LinearAlgebra)

--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -1,4 +1,4 @@
-# Unit Testing
+# Test
 
 ```@meta
 DocTestSetup = :(using Test)


### PR DESCRIPTION
This came up in #documentation on Slack (@KristofferC). Currently, the doc page headers of stdlibs do not math their actual names (e.g. "Random numbers" vs "Random", "Unit Testing" vs "Test", "Memory-mapped I/O" vs "Mmap"). This is confusing, especially for beginners, as they can not do `using Random numbers`. This PR adjusts the header to match the stdlib's name.

See also https://github.com/JuliaLang/julia/issues/28712.