### PR TITLE
fix shuffle! on empty arrays

### DIFF
--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -182,6 +182,7 @@ julia> shuffle!(rng, Vector(1:16))
 function shuffle!(r::AbstractRNG, a::AbstractArray)
     @assert !has_offset_axes(a)
     n = length(a)
+    n <= 1 && return a # nextpow below won't work with n == 0
     @assert n <= Int64(2)^52
     mask = nextpow(2, n) - 1
     for i = n:-1:2

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -686,3 +686,11 @@ end
     @test Random.gentype(Random.UInt52(UInt128)) == UInt128
     @test Random.gentype(Random.UInt104()) == UInt128
 end
+
+@testset "shuffle[!]" begin
+    a = []
+    @test shuffle(a) == a # issue #28727
+    @test shuffle!(a) === a
+    a = rand(Int, 1)
+    @test shuffle(a) == a
+end


### PR DESCRIPTION
`shuffle([])` doesn't work anymore since nextpow2(n) has
been replaced by nextpow(2, n), where n == 0.
