### PR TITLE
gh-pages: Add a robots.txt to exclude old docs for SEO

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -7,3 +7,10 @@ Disallow: /en/v0.5.2/
 Disallow: /en/v0.6.0/
 Disallow: /en/v0.6.1/
 Disallow: /en/v0.6.2/
+# Also exclude the old release-0.x directories. While they have since been
+# removed, they still show up on searches sometimes. Hopefully this will
+# cause them to be de-indexed.
+Disallow: /en/release-0.3/
+Disallow: /en/release-0.4/
+Disallow: /en/release-0.5/
+Disallow: /en/release-0.6/

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,9 @@
+# Make sure that the search engines do not index old documentation which did not
+# have canonical URLs pointing to the latest.
+User-agent: *
+Disallow: /en/v0.3.12/
+Disallow: /en/v0.4.7/
+Disallow: /en/v0.5.2/
+Disallow: /en/v0.6.0/
+Disallow: /en/v0.6.1/
+Disallow: /en/v0.6.2/


### PR DESCRIPTION
The old docs do not define canonical URLs and can show up in Google searches even though more up to date docs are available. Having a `robots.txt` will hopefully prevent the old docs from showing up in searches in the future.

Just excluding these from indexing is easier, and possible more reliable, than adding canonical URLs to the old docs. Having someone more familiar with search engine optimization give their opinion on this would be handy though.

Note: this PR is against `gh-pages`.

cc @fredrikekre 