### PR TITLE
Fix missing GC root in interpreter.c

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -397,7 +397,9 @@ SECT_INTERP static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
     if (jl_is_pinode(e)) {
         jl_value_t *val = eval_value(jl_fieldref_noalloc(e, 0), s);
 #ifndef JL_NDEBUG
+        JL_GC_PUSH1(&val);
         jl_typeassert(val, jl_fieldref_noalloc(e, 1));
+        JL_GC_POP();
 #endif
         return val;
     }

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -134,7 +134,7 @@ static void eval_abstracttype(jl_expr_t *ex, interpreter_state *s)
     jl_datatype_t *dt = NULL;
     jl_value_t *w = NULL;
     jl_module_t *modu = s->module;
-    JL_GC_PUSH4(&para, &super, &temp, &w);
+    JL_GC_PUSH5(&para, &super, &temp, &w, &dt);
     assert(jl_is_svec(para));
     if (jl_is_globalref(name)) {
         modu = jl_globalref_mod(name);


### PR DESCRIPTION
Static analysis complains in relevant part:
```
/home/keno/julia-1.0/src/interpreter.c:154:9: warning: Argument value may have been GCed
        jl_set_datatype_super(dt, super);
        ^
/home/keno/julia-1.0/src/interpreter.c:144:10: note: Started tracking value here
    dt = jl_new_abstracttype(name, modu, NULL, (jl_svec_t*)para);
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia-1.0/src/interpreter.c:146:23: note: Value may have been GCed here
    jl_binding_t *b = jl_get_binding_wr(modu, (jl_sym_t*)name, 1);
                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia-1.0/src/interpreter.c:154:9: note: Argument value may have been GCed
        jl_set_datatype_super(dt, super);
        ^                     ~~
```
Seems true to me. Add `dt` to the roots in this function. I thought we had already done this and indeed we covered similar cases in #25122, but this one seems to have been forgotten.