### PR TITLE
added documentation for read command methods

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -625,6 +625,11 @@ function open(f::Function, cmds::AbstractCmd, args...)
     return ret
 end
 
+"""
+    read(command)
+
+Run a command asynchronously and return an array of bytes from the resulting stream.
+"""
 function read(cmd::AbstractCmd)
     procs = open(cmd, "r", devnull)
     bytes = read(procs.out)
@@ -632,6 +637,11 @@ function read(cmd::AbstractCmd)
     return bytes
 end
 
+"""
+    read(command, String)
+
+Run a command asynchronously and convert the resulting stream to a string.
+"""
 read(cmd::AbstractCmd, ::Type{String}) = String(read(cmd))
 
 """

--- a/base/process.jl
+++ b/base/process.jl
@@ -626,9 +626,9 @@ function open(f::Function, cmds::AbstractCmd, args...)
 end
 
 """
-    read(command)
+    read(command::Cmd)
 
-Run a command asynchronously and return an array of bytes from the resulting stream.
+Run `command` and return the resulting output as an array of bytes.
 """
 function read(cmd::AbstractCmd)
     procs = open(cmd, "r", devnull)
@@ -638,9 +638,9 @@ function read(cmd::AbstractCmd)
 end
 
 """
-    read(command, String)
+    read(command::Cmd, String)
 
-Run a command asynchronously and convert the resulting stream to a string.
+Run `command` and return the resulting output as a `String`.
 """
 read(cmd::AbstractCmd, ::Type{String}) = String(read(cmd))
 


### PR DESCRIPTION
Added documentation for the `read(::Cmd)` and `read(::Cmd, ::Type{String})` methods.

I'm only vaguely familiar with the correct terminology here, so if you have suggestions of how to improve these, please make them.