### PR TITLE
Resolve all method ambiguities in LinearAlgebra

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -277,9 +277,9 @@ mul!(out::AbstractVector, A::Diagonal, in::AbstractVector) = out .= A.diag .* in
 mul!(out::AbstractVector, A::Adjoint{<:Any,<:Diagonal}, in::AbstractVector) = out .= adjoint.(A.parent.diag) .* in
 mul!(out::AbstractVector, A::Transpose{<:Any,<:Diagonal}, in::AbstractVector) = out .= transpose.(A.parent.diag) .* in
 
-mul!(out::AbstractMatrix, A::Diagonal, in::AbstractMatrix) = out .= A.diag .* in
-mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= adjoint.(A.parent.diag) .* in
-mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::AbstractMatrix) = out .= transpose.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Diagonal, in::StridedMatrix) = out .= A.diag .* in
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::StridedMatrix) = out .= adjoint.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::StridedMatrix) = out .= transpose.(A.parent.diag) .* in
 
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -1324,8 +1324,8 @@ julia> promote_leaf_eltypes(a)
 Complex{Float64}
 ```
 """
-promote_leaf_eltypes(x::Union{AbstractArray{T},Tuple{Vararg{T}}}) where {T<:Number} = T
-promote_leaf_eltypes(x::Union{AbstractArray{T},Tuple{Vararg{T}}}) where {T<:NumberArray} = eltype(T)
+promote_leaf_eltypes(x::Union{AbstractArray{T},Tuple{T,Vararg{T}}}) where {T<:Number} = T
+promote_leaf_eltypes(x::Union{AbstractArray{T},Tuple{T,Vararg{T}}}) where {T<:NumberArray} = eltype(T)
 promote_leaf_eltypes(x::T) where {T} = T
 promote_leaf_eltypes(x::Union{AbstractArray,Tuple}) = mapreduce(promote_leaf_eltypes, promote_type, x; init=Bool)
 

--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -445,4 +445,8 @@ end
     @test Xv1'*Xv3' ≈ XcXc
 end
 
+@testset "method ambiguity" begin
+    @test detect_ambiguities(LinearAlgebra, Base; imported=true, recursive=true) == []
+end
+
 end # module TestMatmul


### PR DESCRIPTION
This PR has three commits to:

1. Add a test using `detect_ambiguities` to avoid further introduction of method ambiguities within `LinearAlgebra`.  I'm suggesting a similar test across all standard libraries in #28665.  But I think in general it's nice to have it per-package basis especially if it were to split into a separate repository at some point.

2. Simply apply @andreasnoack's suggestion https://github.com/JuliaLang/julia/pull/27405#issuecomment-394198207 and define `mul!(::AbstractMatrix, ::Diagonal, ::StridedMatrix)` instead of `mul!(::AbstractMatrix, ::Diagonal, ::AbstractMatrix)`. Similar change for `Adjoint{<:Any,<:Diagonal}` and `Transpose{<:Any,<:Diagonal}` too.

3. Tweak `promote_leaf_eltypes` signature to make the test suite happy.  I don't think it will introduce any change for working code.  I'll inline-comment on this.
