### PR TITLE
Bump MbedTLS to 2.12.0

### DIFF
--- a/deps/Versions.make
+++ b/deps/Versions.make
@@ -9,8 +9,8 @@ OSXUNWIND_VER = 0.0.3
 GMP_VER = 6.1.2
 MPFR_VER = 4.0.1
 PATCHELF_VER = 0.9
-MBEDTLS_VER = 2.12.0
-CURL_VER = 7.61.0
+MBEDTLS_VER = 2.7.5
+CURL_VER = 7.56.0
 
 # Specify the version of the Mozilla CA Certificate Store to obtain.
 # The versions of cacert.pem are identified by the date (YYYY-MM-DD) of their changes.

--- a/deps/Versions.make
+++ b/deps/Versions.make
@@ -10,7 +10,7 @@ GMP_VER = 6.1.2
 MPFR_VER = 4.0.1
 PATCHELF_VER = 0.9
 MBEDTLS_VER = 2.12.0
-CURL_VER = 7.56.0
+CURL_VER = 7.61.0
 
 # Specify the version of the Mozilla CA Certificate Store to obtain.
 # The versions of cacert.pem are identified by the date (YYYY-MM-DD) of their changes.

--- a/deps/Versions.make
+++ b/deps/Versions.make
@@ -9,7 +9,7 @@ OSXUNWIND_VER = 0.0.3
 GMP_VER = 6.1.2
 MPFR_VER = 4.0.1
 PATCHELF_VER = 0.9
-MBEDTLS_VER = 2.6.0
+MBEDTLS_VER = 2.12.0
 CURL_VER = 7.56.0
 
 # Specify the version of the Mozilla CA Certificate Store to obtain.


### PR DESCRIPTION
Version 2.6.0 has a security issue, see https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2018-02.

Another option would be to move to the long-term supported version, 2.7.5. This would have the advantage that we will be able to backport security fixes in the future without risking to break anything.