### PR TITLE
Fix gc rooting in exception throwing

### DIFF
--- a/src/task.c
+++ b/src/task.c
@@ -548,9 +548,9 @@ void JL_NORETURN throw_internal(jl_value_t *e)
     ptls->io_wait = 0;
     if (ptls->safe_restore)
         jl_longjmp(*ptls->safe_restore, 1);
-    jl_gc_unsafe_enter(ptls);
     assert(e != NULL);
     ptls->exception_in_transit = e;
+    jl_gc_unsafe_enter(ptls);
     jl_handler_t *eh = ptls->current_task->eh;
     if (eh != NULL) {
 #ifdef ENABLE_TIMINGS


### PR DESCRIPTION
Most paths to `throw_internal` assume that `e` may be unrooted. However, the static analyzer complains that a transition from gc-safe to gc-unsafe (`jl_gc_unsafe_enter`) is a safepoint, so `e` may have been collected there before it gets assigned to `exception_in_transit` (which is a root). Switch the order of operations to fix that.