### PR TITLE
More Static Analyzer Annotations

### DIFF
--- a/doc/src/devdocs/gc-sa.md
+++ b/doc/src/devdocs/gc-sa.md
@@ -253,10 +253,10 @@ This annotations is essentially equivalent to JL_GLOBALLY_ROOTED, except that
 is should only be used if those values are globally rooted by virtue of being
 a leaftype. The rooting of leaftypes is a bit complicated. They are generally
 rooted through `cache` field of the corresponding `TypeName`, which itself is
-rooted by the containing module (so they're rooted as long as the containing module is ok) and we can generally
-assume that leaftypes are rooted where they are used, but we may refine this
-property in the future, so the separate annotation helps split out the reason
-for being globally rooted.
+rooted by the containing module (so they're rooted as long as the containing
+module is ok) and we can generally assume that leaftypes are rooted where they
+are used, but we may refine this property in the future, so the separate
+annotation helps split out the reason for being globally rooted.
 
 The analyzer also automatically detects checks for leaftype-ness and will not
 complain about missing GC roots on these paths.

--- a/src/gc.c
+++ b/src/gc.c
@@ -96,7 +96,7 @@ static inline void jl_gc_wait_for_the_world(void)
 #define malloc_cache_align(sz) jl_malloc_aligned(sz, JL_CACHE_BYTE_ALIGNMENT)
 #define realloc_cache_align(p, sz, oldsz) jl_realloc_aligned(p, sz, oldsz, JL_CACHE_BYTE_ALIGNMENT)
 
-static void schedule_finalization(void *o, void *f)
+static void schedule_finalization(void *o, void *f) JL_NOTSAFEPOINT
 {
     arraylist_push(&to_finalize, o);
     arraylist_push(&to_finalize, f);
@@ -125,7 +125,7 @@ static void run_finalizer(jl_ptls_t ptls, jl_value_t *o, jl_value_t *ff)
 // if `need_sync` is true, the `list` is the `finalizers` list of another
 // thread and we need additional synchronizations
 static void finalize_object(arraylist_t *list, jl_value_t *o,
-                            arraylist_t *copied_list, int need_sync)
+                            arraylist_t *copied_list, int need_sync) JL_NOTSAFEPOINT
 {
     // The acquire load makes sure that the first `len` objects are valid.
     // If `need_sync` is true, all mutations of the content should be limited
@@ -258,7 +258,7 @@ JL_DLLEXPORT void jl_gc_enable_finalizers(jl_ptls_t ptls, int on)
     }
 }
 
-static void schedule_all_finalizers(arraylist_t *flist)
+static void schedule_all_finalizers(arraylist_t *flist) JL_NOTSAFEPOINT
 {
     void **items = flist->items;
     size_t len = flist->len;
@@ -458,7 +458,7 @@ STATIC_INLINE void gc_update_heap_size(int64_t sz_ub, int64_t sz_est)
     last_full_live_est = sz_est;
 }
 
-static void gc_sync_cache_nolock(jl_ptls_t ptls, jl_gc_mark_cache_t *gc_cache)
+static void gc_sync_cache_nolock(jl_ptls_t ptls, jl_gc_mark_cache_t *gc_cache) JL_NOTSAFEPOINT
 {
     const int nbig = gc_cache->nbig_obj;
     for (int i = 0; i < nbig; i++) {
@@ -480,7 +480,7 @@ static void gc_sync_cache_nolock(jl_ptls_t ptls, jl_gc_mark_cache_t *gc_cache)
     gc_cache->scanned_bytes = 0;
 }
 
-static void gc_sync_cache(jl_ptls_t ptls)
+static void gc_sync_cache(jl_ptls_t ptls) JL_NOTSAFEPOINT
 {
     JL_LOCK_NOGC(&gc_cache_lock);
     gc_sync_cache_nolock(ptls, &ptls->gc_cache);
@@ -497,7 +497,7 @@ static void gc_sync_all_caches_nolock(jl_ptls_t ptls)
 }
 
 STATIC_INLINE void gc_queue_big_marked(jl_ptls_t ptls, bigval_t *hdr,
-                                       int toyoung)
+                                       int toyoung) JL_NOTSAFEPOINT
 {
     const int nentry = sizeof(ptls->gc_cache.big_obj) / sizeof(void*);
     size_t nobj = ptls->gc_cache.nbig_obj;
@@ -521,7 +521,7 @@ STATIC_INLINE void gc_queue_big_marked(jl_ptls_t ptls, bigval_t *hdr,
 // The return value is `1` if the object was not marked before.
 // Returning `0` can happen if another thread marked it in parallel.
 STATIC_INLINE int gc_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode,
-                                 uintptr_t tag, uint8_t *bits)
+                                 uintptr_t tag, uint8_t *bits) JL_NOTSAFEPOINT
 {
     assert(!gc_marked(tag));
     assert(gc_marked(mark_mode));
@@ -545,7 +545,7 @@ STATIC_INLINE int gc_setmark_tag(jl_taggedvalue_t *o, uint8_t mark_mode,
 // This function should be called exactly once during marking for each big
 // object being marked to update the big objects metadata.
 STATIC_INLINE void gc_setmark_big(jl_ptls_t ptls, jl_taggedvalue_t *o,
-                                  uint8_t mark_mode)
+                                  uint8_t mark_mode) JL_NOTSAFEPOINT
 {
     assert(!page_metadata(o));
     bigval_t *hdr = bigval_header(o);
@@ -572,7 +572,7 @@ STATIC_INLINE void gc_setmark_big(jl_ptls_t ptls, jl_taggedvalue_t *o,
 // object being marked to update the page metadata.
 STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
                                     uint8_t mark_mode,
-                                    jl_gc_pagemeta_t *page)
+                                    jl_gc_pagemeta_t *page) JL_NOTSAFEPOINT
 {
 #ifdef MEMDEBUG
     gc_setmark_big(ptls, o, mark_mode);
@@ -598,13 +598,13 @@ STATIC_INLINE void gc_setmark_pool_(jl_ptls_t ptls, jl_taggedvalue_t *o,
 }
 
 STATIC_INLINE void gc_setmark_pool(jl_ptls_t ptls, jl_taggedvalue_t *o,
-                                   uint8_t mark_mode)
+                                   uint8_t mark_mode) JL_NOTSAFEPOINT
 {
     gc_setmark_pool_(ptls, o, mark_mode, jl_assume(page_metadata(o)));
 }
 
 STATIC_INLINE void gc_setmark(jl_ptls_t ptls, jl_taggedvalue_t *o,
-                              uint8_t mark_mode, size_t sz)
+                              uint8_t mark_mode, size_t sz) JL_NOTSAFEPOINT
 {
     if (sz <= GC_MAX_SZCLASS) {
         gc_setmark_pool(ptls, o, mark_mode);
@@ -614,7 +614,7 @@ STATIC_INLINE void gc_setmark(jl_ptls_t ptls, jl_taggedvalue_t *o,
     }
 }
 
-STATIC_INLINE void gc_setmark_buf_(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz)
+STATIC_INLINE void gc_setmark_buf_(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz) JL_NOTSAFEPOINT
 {
     jl_taggedvalue_t *buf = jl_astaggedvalue(o);
     uintptr_t tag = buf->header;
@@ -637,12 +637,12 @@ STATIC_INLINE void gc_setmark_buf_(jl_ptls_t ptls, void *o, uint8_t mark_mode, s
     }
 }
 
-void gc_setmark_buf(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz)
+void gc_setmark_buf(jl_ptls_t ptls, void *o, uint8_t mark_mode, size_t minsz) JL_NOTSAFEPOINT
 {
     gc_setmark_buf_(ptls, o, mark_mode, minsz);
 }
 
-void jl_gc_force_mark_old(jl_ptls_t ptls, jl_value_t *v)
+void jl_gc_force_mark_old(jl_ptls_t ptls, jl_value_t *v) JL_NOTSAFEPOINT
 {
     jl_taggedvalue_t *o = jl_astaggedvalue(v);
     jl_datatype_t *dt = (jl_datatype_t*)jl_typeof(v);
@@ -759,7 +759,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t sz)
 
 // Sweep list rooted at *pv, removing and freeing any unmarked objects.
 // Return pointer to last `next` field in the culled list.
-static bigval_t **sweep_big_list(int sweep_full, bigval_t **pv)
+static bigval_t **sweep_big_list(int sweep_full, bigval_t **pv) JL_NOTSAFEPOINT
 {
     bigval_t *v = *pv;
     while (v != NULL) {
@@ -819,7 +819,7 @@ static void sweep_big(jl_ptls_t ptls, int sweep_full)
 
 // tracking Arrays with malloc'd storage
 
-void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a)
+void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a) JL_NOTSAFEPOINT
 {
     // This is **NOT** a GC safe point.
     mallocarray_t *ma;
@@ -835,20 +835,19 @@ void jl_gc_track_malloced_array(jl_ptls_t ptls, jl_array_t *a)
     ptls->heap.mallocarrays = ma;
 }
 
-void jl_gc_count_allocd(size_t sz)
+void jl_gc_count_allocd(size_t sz) JL_NOTSAFEPOINT
 {
-    // This is **NOT** a GC safe point.
     gc_num.allocd += sz;
 }
 
-void jl_gc_reset_alloc_count(void)
+void jl_gc_reset_alloc_count(void) JL_NOTSAFEPOINT
 {
     live_bytes += (gc_num.deferred_alloc + (gc_num.allocd + gc_num.interval));
     gc_num.allocd = -(int64_t)gc_num.interval;
     gc_num.deferred_alloc = 0;
 }
 
-static size_t array_nbytes(jl_array_t *a)
+static size_t array_nbytes(jl_array_t *a) JL_NOTSAFEPOINT
 {
     size_t sz = 0;
     int isbitsunion = jl_array_isbitsunion(a);
@@ -862,7 +861,7 @@ static size_t array_nbytes(jl_array_t *a)
     return sz;
 }
 
-static void jl_gc_free_array(jl_array_t *a)
+static void jl_gc_free_array(jl_array_t *a) JL_NOTSAFEPOINT
 {
     if (a->flags.how == 2) {
         char *d = (char*)a->data - a->offset*a->elsize;
@@ -874,7 +873,7 @@ static void jl_gc_free_array(jl_array_t *a)
     }
 }
 
-static void sweep_malloced_arrays(void)
+static void sweep_malloced_arrays(void) JL_NOTSAFEPOINT
 {
     gc_time_mallocd_array_start();
     for (int t_i = 0;t_i < jl_n_threads;t_i++) {
@@ -1013,7 +1012,7 @@ int jl_gc_classify_pools(size_t sz, int *osize)
 int64_t lazy_freed_pages = 0;
 
 // Returns pointer to terminal pointer of list rooted at *pfl.
-static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t **pfl, int sweep_full, int osize)
+static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_taggedvalue_t **pfl, int sweep_full, int osize) JL_NOTSAFEPOINT
 {
     char *data = pg->data;
     uint8_t *ages = pg->ages;
@@ -1129,7 +1128,7 @@ done:
 }
 
 // the actual sweeping over all allocated pages in a memory pool
-static inline void sweep_pool_page(jl_taggedvalue_t ***pfl, jl_gc_pagemeta_t *pg, int sweep_full)
+static inline void sweep_pool_page(jl_taggedvalue_t ***pfl, jl_gc_pagemeta_t *pg, int sweep_full) JL_NOTSAFEPOINT
 {
     int p_n = pg->pool_n;
     int t_n = pg->thread_n;
@@ -1140,7 +1139,7 @@ static inline void sweep_pool_page(jl_taggedvalue_t ***pfl, jl_gc_pagemeta_t *pg
 }
 
 // sweep over a pagetable0 for all allocated pages
-static inline int sweep_pool_pagetable0(jl_taggedvalue_t ***pfl, pagetable0_t *pagetable0, int sweep_full)
+static inline int sweep_pool_pagetable0(jl_taggedvalue_t ***pfl, pagetable0_t *pagetable0, int sweep_full) JL_NOTSAFEPOINT
 {
     unsigned ub = 0;
     unsigned alloc = 0;
@@ -1164,7 +1163,7 @@ static inline int sweep_pool_pagetable0(jl_taggedvalue_t ***pfl, pagetable0_t *p
 }
 
 // sweep over pagetable1 for all pagetable0 that may contain allocated pages
-static inline int sweep_pool_pagetable1(jl_taggedvalue_t ***pfl, pagetable1_t *pagetable1, int sweep_full)
+static inline int sweep_pool_pagetable1(jl_taggedvalue_t ***pfl, pagetable1_t *pagetable1, int sweep_full) JL_NOTSAFEPOINT
 {
     unsigned ub = 0;
     unsigned alloc = 0;
@@ -1189,7 +1188,7 @@ static inline int sweep_pool_pagetable1(jl_taggedvalue_t ***pfl, pagetable1_t *p
 }
 
 // sweep over all memory for all pagetable1 that may contain allocated pages
-static void sweep_pool_pagetable(jl_taggedvalue_t ***pfl, int sweep_full)
+static void sweep_pool_pagetable(jl_taggedvalue_t ***pfl, int sweep_full) JL_NOTSAFEPOINT
 {
     if (REGION2_PG_COUNT == 1) { // compile-time optimization
         pagetable1_t *pagetable1 = memory_map.meta1[0];
@@ -1216,13 +1215,13 @@ static void sweep_pool_pagetable(jl_taggedvalue_t ***pfl, int sweep_full)
 }
 
 // sweep over all memory that is being used and not in a pool
-static void gc_sweep_other(jl_ptls_t ptls, int sweep_full)
+static void gc_sweep_other(jl_ptls_t ptls, int sweep_full) JL_NOTSAFEPOINT
 {
     sweep_malloced_arrays();
     sweep_big(ptls, sweep_full);
 }
 
-static void gc_pool_sync_nfree(jl_gc_pagemeta_t *pg, jl_taggedvalue_t *last)
+static void gc_pool_sync_nfree(jl_gc_pagemeta_t *pg, jl_taggedvalue_t *last) JL_NOTSAFEPOINT
 {
     assert(pg->fl_begin_offset != (uint16_t)-1);
     char *cur_pg = gc_page_data(last);
@@ -1244,13 +1243,17 @@ static void gc_sweep_pool(int sweep_full)
     gc_time_pool_start();
     lazy_freed_pages = 0;
 
+    // For the benfit of the analyzer, which doesn't know that jl_n_threads
+    // doesn't change over the course of this function
+    size_t n_threads = jl_n_threads;
+
     // allocate enough space to hold the end of the free list chain
     // for every thread and pool size
-    jl_taggedvalue_t ***pfl = (jl_taggedvalue_t ***) alloca(jl_n_threads * JL_GC_N_POOLS * sizeof(jl_taggedvalue_t**));
+    jl_taggedvalue_t ***pfl = (jl_taggedvalue_t ***) alloca(n_threads * JL_GC_N_POOLS * sizeof(jl_taggedvalue_t**));
 
     // update metadata of pages that were pointed to by freelist or newpages from a pool
     // i.e. pages being the current allocation target
-    for (int t_i = 0; t_i < jl_n_threads; t_i++) {
+    for (int t_i = 0; t_i < n_threads; t_i++) {
         jl_ptls_t ptls2 = jl_all_tls_states[t_i];
         for (int i = 0; i < JL_GC_N_POOLS; i++) {
             jl_gc_pool_t *p = &ptls2->heap.norm_pools[i];
@@ -1279,7 +1282,7 @@ static void gc_sweep_pool(int sweep_full)
     sweep_pool_pagetable(pfl, sweep_full);
 
     // null out terminal pointers of free lists
-    for (int t_i = 0; t_i < jl_n_threads; t_i++) {
+    for (int t_i = 0; t_i < n_threads; t_i++) {
         for (int i = 0; i < JL_GC_N_POOLS; i++) {
             *pfl[t_i * JL_GC_N_POOLS + i] = NULL;
         }
@@ -1399,7 +1402,7 @@ static void NOINLINE gc_mark_stack_resize(jl_gc_mark_cache_t *gc_cache, gc_mark_
 // in `gc_cache` or `sp`
 // The `sp` will be updated on return if `inc` is true.
 STATIC_INLINE void gc_mark_stack_push(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp,
-                                      void *pc, void *data, size_t data_size, int inc)
+                                      void *pc, void *data, size_t data_size, int inc) JL_NOTSAFEPOINT
 {
     assert(data_size <= sizeof(jl_gc_mark_data_t));
     if (__unlikely(sp->pc == sp->pc_end))
@@ -1417,7 +1420,7 @@ STATIC_INLINE void gc_mark_stack_push(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t
 // Return the tag (with GC bits cleared) and the GC bits in `*ptag` and `*pbits`.
 // Return whether the object needs to be scanned / have metadata updated.
 STATIC_INLINE int gc_try_setmark(jl_value_t *obj, uintptr_t *nptr,
-                                 uintptr_t *ptag, uint8_t *pbits)
+                                 uintptr_t *ptag, uint8_t *pbits) JL_NOTSAFEPOINT
 {
     if (!obj)
         return 0;
@@ -1469,7 +1472,7 @@ STATIC_INLINE void gc_mark_queue_scan_obj(jl_gc_mark_cache_t *gc_cache, gc_mark_
 // The object will be marked atomically which can also happen concurrently.
 // It will be queued if the object wasn't marked already (or concurrently by another thread)
 // Returns whether the object is young.
-STATIC_INLINE int gc_mark_queue_obj(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp, void *_obj)
+STATIC_INLINE int gc_mark_queue_obj(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp, void *_obj) JL_NOTSAFEPOINT
 {
     jl_value_t *obj = (jl_value_t*)jl_assume(_obj);
     uintptr_t nptr = 0;
@@ -1485,7 +1488,7 @@ STATIC_INLINE int gc_mark_queue_obj(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *
 
 // Check if `nptr` is tagged for `old + refyoung`,
 // Push the object to the remset and update the `nptr` counter if necessary.
-STATIC_INLINE void gc_mark_push_remset(jl_ptls_t ptls, jl_value_t *obj, uintptr_t nptr)
+STATIC_INLINE void gc_mark_push_remset(jl_ptls_t ptls, jl_value_t *obj, uintptr_t nptr) JL_NOTSAFEPOINT
 {
     if (__unlikely((nptr & 0x3) == 0x3)) {
         ptls->heap.remset_nptr += nptr >> 2;
@@ -1571,7 +1574,7 @@ STATIC_INLINE int gc_mark_scan_obj8(jl_ptls_t ptls, gc_mark_sp_t *sp, gc_mark_ob
 // Scan an object with 16bits field descriptors. see `gc_mark_obj16_t`
 STATIC_INLINE int gc_mark_scan_obj16(jl_ptls_t ptls, gc_mark_sp_t *sp, gc_mark_obj16_t *obj16,
                                      char *parent, jl_fielddesc16_t *begin, jl_fielddesc16_t *end,
-                                     jl_value_t **pnew_obj, uintptr_t *ptag, uint8_t *pbits)
+                                     jl_value_t **pnew_obj, uintptr_t *ptag, uint8_t *pbits) JL_NOTSAFEPOINT
 {
     (void)jl_assume(obj16 == (gc_mark_obj16_t*)sp->data);
     (void)jl_assume(begin < end);
@@ -2933,6 +2936,7 @@ static void *gc_perm_alloc_large(size_t sz, int zero, unsigned align, unsigned o
     if (align > 1 && (offset != 0 || align > malloc_align))
         sz += align - 1;
     uintptr_t base = (uintptr_t)(zero ? calloc(1, sz) : malloc(sz));
+    jl_may_leak(base);
     unsigned diff = (offset - base) % align;
     return (void*)(base + diff);
 }

--- a/src/gc.h
+++ b/src/gc.h
@@ -348,6 +348,9 @@ typedef struct {
     int ub;
 } pagetable_t;
 
+#ifdef __clang_analyzer__
+unsigned ffs_u32(uint32_t bitvec) JL_NOTSAFEPOINT;
+#else
 STATIC_INLINE unsigned ffs_u32(uint32_t bitvec)
 {
 #if defined(_COMPILER_MINGW_)
@@ -360,6 +363,7 @@ STATIC_INLINE unsigned ffs_u32(uint32_t bitvec)
     return ffs(bitvec) - 1;
 #endif
 }
+#endif
 
 extern jl_gc_num_t gc_num;
 extern pagetable_t memory_map;
@@ -368,7 +372,7 @@ extern arraylist_t finalizer_list_marked;
 extern arraylist_t to_finalize;
 extern int64_t lazy_freed_pages;
 
-STATIC_INLINE bigval_t *bigval_header(jl_taggedvalue_t *o)
+STATIC_INLINE bigval_t *bigval_header(jl_taggedvalue_t *o) JL_NOTSAFEPOINT
 {
     return container_of(o, bigval_t, header);
 }
@@ -389,34 +393,34 @@ STATIC_INLINE jl_taggedvalue_t *page_pfl_end(jl_gc_pagemeta_t *p)
     return (jl_taggedvalue_t*)(p->data + p->fl_end_offset);
 }
 
-STATIC_INLINE int gc_marked(uintptr_t bits)
+STATIC_INLINE int gc_marked(uintptr_t bits) JL_NOTSAFEPOINT
 {
     return (bits & GC_MARKED) != 0;
 }
 
-STATIC_INLINE int gc_old(uintptr_t bits)
+STATIC_INLINE int gc_old(uintptr_t bits) JL_NOTSAFEPOINT
 {
     return (bits & GC_OLD) != 0;
 }
 
-STATIC_INLINE uintptr_t gc_set_bits(uintptr_t tag, int bits)
+STATIC_INLINE uintptr_t gc_set_bits(uintptr_t tag, int bits) JL_NOTSAFEPOINT
 {
     return (tag & ~(uintptr_t)3) | bits;
 }
 
-STATIC_INLINE uintptr_t gc_ptr_tag(void *v, uintptr_t mask)
+STATIC_INLINE uintptr_t gc_ptr_tag(void *v, uintptr_t mask) JL_NOTSAFEPOINT
 {
     return ((uintptr_t)v) & mask;
 }
 
-STATIC_INLINE void *gc_ptr_clear_tag(void *v, uintptr_t mask)
+STATIC_INLINE void *gc_ptr_clear_tag(void *v, uintptr_t mask) JL_NOTSAFEPOINT
 {
     return (void*)(((uintptr_t)v) & ~mask);
 }
 
 NOINLINE uintptr_t gc_get_stack_ptr(void);
 
-STATIC_INLINE jl_gc_pagemeta_t *page_metadata(void *_data)
+STATIC_INLINE jl_gc_pagemeta_t *page_metadata(void *_data) JL_NOTSAFEPOINT
 {
     uintptr_t data = ((uintptr_t)_data);
     unsigned i;
@@ -441,7 +445,7 @@ struct jl_gc_metadata_ext {
     unsigned pagetable0_i32, pagetable0_i;
 };
 
-STATIC_INLINE struct jl_gc_metadata_ext page_metadata_ext(void *_data)
+STATIC_INLINE struct jl_gc_metadata_ext page_metadata_ext(void *_data) JL_NOTSAFEPOINT
 {
     uintptr_t data = (uintptr_t)_data;
     struct jl_gc_metadata_ext info;
@@ -462,7 +466,7 @@ STATIC_INLINE struct jl_gc_metadata_ext page_metadata_ext(void *_data)
     return info;
 }
 
-STATIC_INLINE void gc_big_object_unlink(const bigval_t *hdr)
+STATIC_INLINE void gc_big_object_unlink(const bigval_t *hdr) JL_NOTSAFEPOINT
 {
     *hdr->prev = hdr->next;
     if (hdr->next) {
@@ -470,7 +474,7 @@ STATIC_INLINE void gc_big_object_unlink(const bigval_t *hdr)
     }
 }
 
-STATIC_INLINE void gc_big_object_link(bigval_t *hdr, bigval_t **list)
+STATIC_INLINE void gc_big_object_link(bigval_t *hdr, bigval_t **list) JL_NOTSAFEPOINT
 {
     hdr->next = *list;
     hdr->prev = list;
@@ -623,7 +627,7 @@ JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;
 int gc_debug_check_other(void);
 int gc_debug_check_pool(void);
 void gc_debug_print(void);
-void gc_scrub_record_task(jl_task_t *ta);
+void gc_scrub_record_task(jl_task_t *ta) JL_NOTSAFEPOINT;
 void gc_scrub(void);
 #else
 #define gc_sweep_always_full 0
@@ -638,7 +642,7 @@ static inline int gc_debug_check_pool(void)
 static inline void gc_debug_print(void)
 {
 }
-static inline void gc_scrub_record_task(jl_task_t *ta)
+static inline void gc_scrub_record_task(jl_task_t *ta) JL_NOTSAFEPOINT
 {
     (void)ta;
 }
@@ -648,11 +652,11 @@ static inline void gc_scrub(void)
 #endif
 
 #ifdef OBJPROFILE
-void objprofile_count(void *ty, int old, int sz);
+void objprofile_count(void *ty, int old, int sz) JL_NOTSAFEPOINT;
 void objprofile_printall(void);
 void objprofile_reset(void);
 #else
-static inline void objprofile_count(void *ty, int old, int sz)
+static inline void objprofile_count(void *ty, int old, int sz) JL_NOTSAFEPOINT
 {
 }
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -204,7 +204,7 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *typ
 
 JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t*);
 
-void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr)
+void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED
 {
     jl_sym_t *sname = jl_symbol(name);
     if (dt == NULL) {
@@ -289,7 +289,7 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli, size_t world, int forc
     return src;
 }
 
-int jl_is_rettype_inferred(jl_method_instance_t *li)
+int jl_is_rettype_inferred(jl_method_instance_t *li) JL_NOTSAFEPOINT
 {
     if (!li->inferred)
         return 0;
@@ -587,7 +587,7 @@ static void jl_compilation_sig(
     jl_method_t *definition,
     intptr_t nspec,
     // output:
-    jl_svec_t **const newparams)
+    jl_svec_t **const newparams JL_REQUIRE_ROOTED_SLOT)
 {
     if (definition->generator) {
         // staged functions aren't optimized
@@ -921,7 +921,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
 }
 
 static jl_method_instance_t *cache_method(
-        jl_methtable_t *mt, union jl_typemap_t *cache, jl_value_t *parent,
+        jl_methtable_t *mt, union jl_typemap_t *cache, jl_value_t *parent JL_PROPAGATES_ROOT,
         jl_tupletype_t *tt, // the original tupletype of the signature
         jl_method_t *definition,
         size_t world,
@@ -2061,7 +2061,7 @@ STATIC_INLINE int sig_match_fast(jl_value_t **args, jl_value_t **sig, size_t i, 
     return 1;
 }
 
-jl_typemap_entry_t *call_cache[N_CALL_CACHE];
+jl_typemap_entry_t *call_cache[N_CALL_CACHE] JL_GLOBALLY_ROOTED;
 static uint8_t pick_which[N_CALL_CACHE];
 #ifdef JL_GF_PROFILE
 size_t ncalls;
@@ -2183,7 +2183,7 @@ JL_DLLEXPORT jl_value_t *jl_apply_generic(jl_value_t **args, uint32_t nargs)
     return verify_type(res);
 }
 
-JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types, size_t world)
+JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup(jl_value_t *types JL_PROPAGATES_ROOT, size_t world)
 {
     jl_methtable_t *mt = jl_first_argument_datatype(types)->name->mt;
     jl_svec_t *env = jl_emptysvec;

--- a/src/gf.c
+++ b/src/gf.c
@@ -1413,7 +1413,7 @@ static int invalidate_backedges(jl_typemap_entry_t *oldentry, struct typemap_int
         jl_array_t *backedges = def.replaced->backedges;
         if (backedges) {
             size_t i, l = jl_array_len(backedges);
-            jl_method_instance_t **replaced = (jl_method_instance_t**)jl_array_data(backedges);
+            jl_method_instance_t **replaced = (jl_method_instance_t**)jl_array_ptr_data(backedges);
             for (i = 0; i < l; i++) {
                 invalidate_method_instance(replaced[i], closure->max_world, 0);
             }
@@ -1921,6 +1921,7 @@ JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types)
 {
     size_t world = jl_world_counter;
     jl_method_instance_t *li = jl_get_specialization1(types, world, 1);
+    JL_GC_PROMISE_ROOTED(li); // Rooted via types since mt_cache==1
     if (li == NULL)
         return 0;
     if (jl_generating_output()) {

--- a/src/init.c
+++ b/src/init.c
@@ -278,6 +278,7 @@ JL_DLLEXPORT void jl_atexit_hook(int exitcode)
             }
             JL_CATCH {
                 //error handling -- continue cleanup, as much as possible
+                assert(item);
                 uv_unref(item->h);
                 jl_printf(JL_STDERR, "error during exit cleanup: close: ");
                 jl_static_show(JL_STDERR, ptls->exception_in_transit);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -124,7 +124,7 @@ SECT_INTERP void jl_set_datatype_super(jl_datatype_t *tt, jl_value_t *super)
 
 static void eval_abstracttype(jl_expr_t *ex, interpreter_state *s)
 {
-    jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
+    jl_value_t **args = jl_array_ptr_data(ex->args);
     if (inside_typedef)
         jl_error("cannot eval a new abstract type definition while defining another type");
     jl_value_t *name = args[0];
@@ -168,7 +168,7 @@ static void eval_abstracttype(jl_expr_t *ex, interpreter_state *s)
 
 static void eval_primitivetype(jl_expr_t *ex, interpreter_state *s)
 {
-    jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
+    jl_value_t **args = (jl_value_t**)jl_array_ptr_data(ex->args);
     if (inside_typedef)
         jl_error("cannot eval a new primitive type definition while defining another type");
     jl_value_t *name = args[0];
@@ -219,7 +219,7 @@ static void eval_primitivetype(jl_expr_t *ex, interpreter_state *s)
 
 static void eval_structtype(jl_expr_t *ex, interpreter_state *s)
 {
-    jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
+    jl_value_t **args = jl_array_ptr_data(ex->args);
     if (inside_typedef)
         jl_error("cannot eval a new struct type definition while defining another type");
     jl_value_t *name = args[0];
@@ -285,7 +285,7 @@ static void eval_structtype(jl_expr_t *ex, interpreter_state *s)
 
 static jl_value_t *eval_methoddef(jl_expr_t *ex, interpreter_state *s)
 {
-    jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
+    jl_value_t **args = jl_array_ptr_data(ex->args);
     jl_sym_t *fname = (jl_sym_t*)args[0];
     jl_module_t *modu = s->module;
     if (jl_is_globalref(fname)) {
@@ -348,12 +348,12 @@ SECT_INTERP jl_value_t *jl_eval_global_var(jl_module_t *m, jl_sym_t *e)
     return v;
 }
 
-SECT_INTERP static int jl_source_nslots(jl_code_info_t *src)
+SECT_INTERP static int jl_source_nslots(jl_code_info_t *src) JL_NOTSAFEPOINT
 {
     return jl_array_len(src->slotflags);
 }
 
-SECT_INTERP static int jl_source_nssavalues(jl_code_info_t *src)
+SECT_INTERP static int jl_source_nssavalues(jl_code_info_t *src) JL_NOTSAFEPOINT
 {
     return jl_is_long(src->ssavaluetypes) ? jl_unbox_long(src->ssavaluetypes) : jl_array_len(src->ssavaluetypes);
 }
@@ -417,13 +417,13 @@ SECT_INTERP static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
             // edges list doesn't contain last branch. this value should be unused.
             return NULL;
         }
-        jl_value_t *val = jl_arrayref((jl_array_t*)jl_fieldref_noalloc(e, 1), edge);
+        jl_value_t *val = jl_array_ptr_ref((jl_array_t*)jl_fieldref_noalloc(e, 1), edge);
         return eval_value(val, s);
     }
     if (!jl_is_expr(e))
         return e;
     jl_expr_t *ex = (jl_expr_t*)e;
-    jl_value_t **args = (jl_value_t**)jl_array_data(ex->args);
+    jl_value_t **args = jl_array_ptr_data(ex->args);
     size_t nargs = jl_array_len(ex->args);
     jl_sym_t *head = ex->head;
     if (head == call_sym) {
@@ -746,6 +746,7 @@ SECT_INTERP CALLBACK_ABI void *jl_interpret_call_callback(interpreter_state *s, 
 {
     struct jl_interpret_call_args *args =
         (struct jl_interpret_call_args *)vargs;
+    JL_GC_PROMISE_ROOTED(args);
     jl_code_info_t *src = jl_code_for_interpreter(args->lam);
     args->lam->inferred = (jl_value_t*)src;
     jl_gc_wb(args->lam, src);
@@ -787,6 +788,7 @@ struct jl_interpret_toplevel_thunk_args {
 SECT_INTERP CALLBACK_ABI void *jl_interpret_toplevel_thunk_callback(interpreter_state *s, void *vargs) {
     struct jl_interpret_toplevel_thunk_args *args =
         (struct jl_interpret_toplevel_thunk_args*)vargs;
+    JL_GC_PROMISE_ROOTED(args);
     jl_array_t *stmts = args->src->code;
     assert(jl_typeis(stmts, jl_array_any_type));
     jl_value_t **locals;
@@ -824,6 +826,7 @@ SECT_INTERP CALLBACK_ABI void *jl_interpret_toplevel_expr_in_callback(interprete
 {
     struct interpret_toplevel_expr_in_args *args =
         (struct interpret_toplevel_expr_in_args*)vargs;
+    JL_GC_PROMISE_ROOTED(args);
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_value_t *v=NULL;
     jl_module_t *last_m = ptls->current_module;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -314,7 +314,7 @@ int jl_count_union_components(jl_value_t *v)
 // Return the `*pi`th element of a nested type union, according to a
 // standard traversal order. Anything that is not itself a `Union` is
 // considered an "element". `*pi` is destroyed in the process.
-static jl_value_t *nth_union_component(jl_value_t *v, int *pi)
+static jl_value_t *nth_union_component(jl_value_t *v, int *pi) JL_NOTSAFEPOINT
 {
     if (!jl_is_uniontype(v)) {
         if (*pi == 0)
@@ -328,13 +328,13 @@ static jl_value_t *nth_union_component(jl_value_t *v, int *pi)
     return nth_union_component(u->b, pi);
 }
 
-jl_value_t *jl_nth_union_component(jl_value_t *v, int i)
+jl_value_t *jl_nth_union_component(jl_value_t *v, int i) JL_NOTSAFEPOINT
 {
     return nth_union_component(v, &i);
 }
 
 // inverse of jl_nth_union_component
-int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth)
+int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *nth) JL_NOTSAFEPOINT
 {
     if (jl_is_uniontype(haystack)) {
         if (jl_find_union_component(((jl_uniontype_t*)haystack)->a, needle, nth))
@@ -349,7 +349,7 @@ int jl_find_union_component(jl_value_t *haystack, jl_value_t *needle, unsigned *
     return 0;
 }
 
-static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, size_t *idx)
+static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, size_t *idx) JL_NOTSAFEPOINT
 {
     size_t i;
     for(i=0; i < n; i++) {
@@ -366,25 +366,25 @@ static void flatten_type_union(jl_value_t **types, size_t n, jl_value_t **out, s
     }
 }
 
-STATIC_INLINE const char *datatype_module_name(jl_value_t *t)
+STATIC_INLINE const char *datatype_module_name(jl_value_t *t) JL_NOTSAFEPOINT
 {
     if (((jl_datatype_t*)t)->name->module == NULL)
         return NULL;
     return jl_symbol_name(((jl_datatype_t*)t)->name->module->name);
 }
 
-STATIC_INLINE const char *str_(const char *s)
+STATIC_INLINE const char *str_(const char *s) JL_NOTSAFEPOINT
 {
     return s == NULL ? "" : s;
 }
 
-STATIC_INLINE int cmp_(int a, int b)
+STATIC_INLINE int cmp_(int a, int b) JL_NOTSAFEPOINT
 {
     return a < b ? -1 : a > b;
 }
 
 // a/b are jl_datatype_t* & not NULL
-int datatype_name_cmp(jl_value_t *a, jl_value_t *b)
+int datatype_name_cmp(jl_value_t *a, jl_value_t *b) JL_NOTSAFEPOINT
 {
     if (!jl_is_datatype(a))
         return jl_is_datatype(b) ? 1 : 0;
@@ -426,7 +426,7 @@ int datatype_name_cmp(jl_value_t *a, jl_value_t *b)
 
 // sort singletons first, then DataTypes, then UnionAlls,
 // ties broken alphabetically including module name & type parameters
-int union_sort_cmp(const void *ap, const void *bp)
+int union_sort_cmp(const void *ap, const void *bp) JL_NOTSAFEPOINT
 {
     jl_value_t *a = *(jl_value_t**)ap;
     jl_value_t *b = *(jl_value_t**)bp;
@@ -558,7 +558,7 @@ static int contains_unions(jl_value_t *type)
     return 0;
 }
 
-static intptr_t wrapper_id(jl_value_t *t)
+static intptr_t wrapper_id(jl_value_t *t) JL_NOTSAFEPOINT
 {
     // DataType wrappers occur often, e.g. when called as constructors.
     // make sure any type equal to a wrapper gets a consistent, ordered ID.
@@ -587,7 +587,7 @@ static int is_typekey_ordered(jl_value_t **key, size_t n)
 }
 
 // ordered comparison of types
-static int typekey_compare(jl_datatype_t *tt, jl_value_t **key, size_t n)
+static int typekey_compare(jl_datatype_t *tt, jl_value_t **key, size_t n) JL_NOTSAFEPOINT
 {
     size_t j;
     if (tt == NULL) return -1;  // place NULLs at end to allow padding for fast growing
@@ -634,7 +634,7 @@ static int typekey_compare(jl_datatype_t *tt, jl_value_t **key, size_t n)
     return 0;
 }
 
-static int dt_compare(const void *ap, const void *bp)
+static int dt_compare(const void *ap, const void *bp) JL_NOTSAFEPOINT
 {
     jl_datatype_t *a = *(jl_datatype_t**)ap;
     jl_datatype_t *b = *(jl_datatype_t**)bp;
@@ -971,6 +971,7 @@ static jl_value_t *lookup_type_stack(jl_typestack_t *stack, jl_datatype_t *tt, s
     // stack, return it. this computes a fixed point for recursive types.
     jl_typename_t *tn = tt->name;
     while (stack != NULL) {
+        JL_GC_PROMISE_ROOTED(stack->tt);
         if (stack->tt->name == tn &&
             ntp == jl_svec_len(stack->tt->parameters) &&
             typekey_eq(stack->tt, iparams, ntp)) {
@@ -1322,6 +1323,7 @@ static jl_tupletype_t *jl_apply_tuple_type_v_(jl_value_t **p, size_t np, jl_svec
 {
     int cacheable = 1;
     for (size_t i = 0; i < np; i++) {
+        assert(p[i]);
         if (!jl_is_concrete_type(p[i]))
             cacheable = 0;
     }
@@ -1638,7 +1640,7 @@ static jl_tvar_t *tvar(const char *name)
 
 extern void jl_init_int32_int64_cache(void);
 
-void jl_init_types(void)
+void jl_init_types(void) JL_GC_DISABLED
 {
     jl_module_t *core = NULL; // will need to be assigned later
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -781,11 +781,13 @@ JL_DLLEXPORT size_t jl_array_len_(jl_array_t *a);
 JL_DLLEXPORT char *jl_array_typetagdata(jl_array_t *a);
 
 #ifdef __clang_analyzer__
+jl_value_t **jl_array_ptr_data(jl_array_t *a JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 STATIC_INLINE jl_value_t *jl_array_ptr_ref(void *a JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;
 STATIC_INLINE jl_value_t *jl_array_ptr_set(
     void *a JL_ROOTING_ARGUMENT, size_t i,
     void *x JL_ROOTED_ARGUMENT) JL_NOTSAFEPOINT;
 #else
+#define jl_array_ptr_data(a)  ((jl_value_t**)((jl_array_t*)(a))->data)
 STATIC_INLINE jl_value_t *jl_array_ptr_ref(void *a JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT
 {
     assert(i < jl_array_len(a));
@@ -846,7 +848,6 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x) JL_NOTSAFEPO
 // get a pointer to the data in a datatype
 #define jl_data_ptr(v)  ((jl_value_t**)v)
 
-#define jl_array_ptr_data(a)   ((jl_value_t**)((jl_array_t*)a)->data)
 #define jl_string_data(s) ((char*)s + sizeof(void*))
 #define jl_string_len(s)  (*(size_t*)s)
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1297,7 +1297,7 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_alloc_vec_any(size_t n);
 JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT jl_value_t *jl_ptrarrayref(jl_array_t *a JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;  // 0-indexed
-JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *v, size_t i);  // 0-indexed
+JL_DLLEXPORT void jl_arrayset(jl_array_t *a JL_ROOTING_ARGUMENT, jl_value_t *v JL_ROOTED_ARGUMENT, size_t i) JL_NOTSAFEPOINT;  // 0-indexed
 JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1334,8 +1334,8 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m JL_PROPAGATES_ROOT, 
 JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m JL_PROPAGATES_ROOT,
                                                          jl_sym_t *var);
 JL_DLLEXPORT int jl_boundp(jl_module_t *m, jl_sym_t *var);
-JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var);
-JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT int jl_defines_or_exports_p(jl_module_t *m, jl_sym_t *var) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_binding_resolved_p(jl_module_t *m, jl_sym_t *var) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT,
@@ -1352,7 +1352,7 @@ JL_DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from,
                                    jl_sym_t *s);
 JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
-JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var);
+JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var) JL_NOTSAFEPOINT;
 JL_DLLEXPORT jl_module_t *jl_new_main_module(void);
 JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
@@ -1770,11 +1770,11 @@ JL_DLLEXPORT JL_STREAM *jl_stdin_stream(void);
 JL_DLLEXPORT JL_STREAM *jl_stderr_stream(void);
 
 // showing and std streams
-JL_DLLEXPORT void jl_flush_cstdio(void);
-JL_DLLEXPORT jl_value_t *jl_stdout_obj(void);
-JL_DLLEXPORT jl_value_t *jl_stderr_obj(void);
-JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v);
-JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type);
+JL_DLLEXPORT void jl_flush_cstdio(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_stdout_obj(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT;
+JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jlbacktrace(void);
 // Mainly for debugging, use `void*` so that no type cast is needed in C++.
 JL_DLLEXPORT void jl_(void *jl_value);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1073,7 +1073,7 @@ JL_DLLEXPORT uintptr_t jl_object_id(jl_value_t *v) JL_NOTSAFEPOINT;
 
 // type predicates and basic operations
 JL_DLLEXPORT int jl_has_free_typevars(jl_value_t *v) JL_NOTSAFEPOINT;
-JL_DLLEXPORT int jl_has_typevar(jl_value_t *t, jl_tvar_t *v);
+JL_DLLEXPORT int jl_has_typevar(jl_value_t *t, jl_tvar_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_has_typevar_from_unionall(jl_value_t *t, jl_unionall_t *ua);
 JL_DLLEXPORT int jl_subtype_env_size(jl_value_t *t);
 JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, int envsz);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1086,7 +1086,7 @@ JL_DLLEXPORT jl_value_t *jl_type_unionall(jl_tvar_t *v, jl_value_t *body);
 JL_DLLEXPORT const char *jl_typename_str(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT const char *jl_typeof_str(jl_value_t *v) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int jl_type_morespecific(jl_value_t *a, jl_value_t *b);
-jl_value_t *jl_unwrap_unionall(jl_value_t *v) JL_NOTSAFEPOINT;
+jl_value_t *jl_unwrap_unionall(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
 jl_value_t *jl_rewrap_unionall(jl_value_t *t, jl_value_t *u);
 
 STATIC_INLINE int jl_is_dispatch_tupletype(jl_value_t *v) JL_NOTSAFEPOINT
@@ -1833,7 +1833,7 @@ JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp);
 // argc/argv
 JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv);
 
-JL_DLLEXPORT int jl_generating_output(void);
+JL_DLLEXPORT int jl_generating_output(void) JL_NOTSAFEPOINT;
 
 // Settings for code_coverage and malloc_log
 // NOTE: if these numbers change, test/cmdlineargs.jl will have to be updated

--- a/src/julia.h
+++ b/src/julia.h
@@ -1340,10 +1340,10 @@ JL_DLLEXPORT int jl_is_const(jl_module_t *m, jl_sym_t *var);
 JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var);
 JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT,
                                 jl_sym_t *var,
-                                jl_value_t *val JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED);
+                                jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT,
                                jl_sym_t *var,
-                               jl_value_t *val JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED);
+                               jl_value_t *val JL_ROOTED_ARGUMENT);
 JL_DLLEXPORT void jl_checked_assignment(jl_binding_t *b, jl_value_t *rhs);
 JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b);
 JL_DLLEXPORT void jl_module_using(jl_module_t *to, jl_module_t *from);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -332,7 +332,7 @@ jl_llvm_functions_t jl_compile_linfo(
 jl_callptr_t jl_compile_method_internal(jl_method_instance_t **pmeth, size_t world);
 JL_DLLEXPORT int jl_compile_hint(jl_tupletype_t *types);
 jl_code_info_t *jl_code_for_interpreter(jl_method_instance_t *lam);
-int jl_code_requires_compiler(jl_code_info_t *src);
+int jl_code_requires_compiler(jl_code_info_t *src) JL_NOTSAFEPOINT;
 jl_code_info_t *jl_new_code_info_from_ast(jl_expr_t *ast);
 JL_DLLEXPORT jl_code_info_t *jl_new_code_info_uninit(void);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -479,7 +479,7 @@ extern char jl_using_perf_jitevents;
 #endif
 extern size_t jl_arr_xtralloc_limit;
 
-void jl_init_types(void);
+void jl_init_types(void) JL_GC_DISABLED;
 void jl_init_box_caches(void);
 void jl_init_frontend(void);
 void jl_init_primitives(void) JL_GC_DISABLED;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -488,7 +488,7 @@ void *jl_init_llvm(void);
 void jl_init_codegen(void);
 void jl_init_intrinsic_functions(void);
 void jl_init_intrinsic_properties(void);
-void jl_init_tasks(void);
+void jl_init_tasks(void) JL_GC_DISABLED;
 void jl_init_stack_limits(int ismaster);
 void jl_init_root_task(void *stack, size_t ssize);
 void jl_init_serializer(void);
@@ -635,8 +635,8 @@ typedef unw_cursor_t bt_cursor_t;
 typedef int bt_context_t;
 typedef int bt_cursor_t;
 #endif
-size_t rec_backtrace(uintptr_t *data, size_t maxsize);
-size_t rec_backtrace_ctx(uintptr_t *data, size_t maxsize, bt_context_t *ctx);
+size_t rec_backtrace(uintptr_t *data, size_t maxsize) JL_NOTSAFEPOINT;
+size_t rec_backtrace_ctx(uintptr_t *data, size_t maxsize, bt_context_t *ctx) JL_NOTSAFEPOINT;
 #ifdef LIBOSXUNWIND
 size_t rec_backtrace_ctx_dwarf(uintptr_t *data, size_t maxsize, bt_context_t *ctx);
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -465,6 +465,7 @@ void jl_compute_field_offsets(jl_datatype_t *st);
 jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, size_t *dims,
                                              int isunboxed, int elsz);
 void jl_module_run_initializer(jl_module_t *m);
+jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT;
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern jl_array_t *jl_cfunction_list JL_GLOBALLY_ROOTED;
 
@@ -699,8 +700,8 @@ extern JL_DLLEXPORT jl_value_t *jl_segv_exception;
 #endif
 
 // -- Runtime intrinsics -- //
-JL_DLLEXPORT const char *jl_intrinsic_name(int f);
-unsigned jl_intrinsic_nargs(int f);
+JL_DLLEXPORT const char *jl_intrinsic_name(int f) JL_NOTSAFEPOINT;
+unsigned jl_intrinsic_nargs(int f) JL_NOTSAFEPOINT;
 
 JL_DLLEXPORT jl_value_t *jl_bitcast(jl_value_t *ty, jl_value_t *v);
 JL_DLLEXPORT jl_value_t *jl_pointerref(jl_value_t *p, jl_value_t *i, jl_value_t *align);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -397,10 +397,10 @@ jl_fptr_args_t jl_get_builtin_fptr(jl_value_t *b);
 extern uv_loop_t *jl_io_loop;
 void jl_uv_flush(uv_stream_t *stream);
 
-typedef struct _typeenv {
+typedef struct jl_typeenv_t {
     jl_tvar_t *var;
     jl_value_t *val;
-    struct _typeenv *prev;
+    struct jl_typeenv_t *prev;
 } jl_typeenv_t;
 
 int jl_tuple_isa(jl_value_t **child, size_t cl, jl_datatype_t *pdt);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -452,7 +452,7 @@ void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_module_t *mod, jl_sym_t *n
 jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt JL_PROPAGATES_ROOT,
     jl_value_t **args, size_t nargs, int cache, size_t world);
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t **args, size_t nargs);
-jl_method_instance_t *jl_lookup_generic(jl_value_t **args, uint32_t nargs, uint32_t callsite, size_t world);
+jl_method_instance_t *jl_lookup_generic(jl_value_t **args, uint32_t nargs, uint32_t callsite, size_t world) JL_ALWAYS_LEAFTYPE;
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous,
                                              size_t world, size_t *min_valid, size_t *max_valid);
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -137,7 +137,7 @@ STATIC_INLINE uint32_t jl_int32hash_fast(uint32_t a)
 #define GC_OLD_MARKED (GC_OLD | GC_MARKED) // reachable and old
 
 // useful constants
-extern jl_methtable_t *jl_type_type_mt;
+extern jl_methtable_t *jl_type_type_mt JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT extern size_t jl_world_counter;
 
 typedef void (*tracer_cb)(jl_value_t *tracee);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -209,10 +209,17 @@ STATIC_INLINE int8_t jl_gc_state_save_and_set(jl_ptls_t ptls,
 {
     return jl_gc_state_set(ptls, state, jl_gc_state(ptls));
 }
+#ifdef __clang_analyzer__
+int8_t jl_gc_unsafe_enter(jl_ptls_t ptls); // Can be a safepoint
+int8_t jl_gc_unsafe_leave(jl_ptls_t ptls, int8_t state) JL_NOTSAFEPOINT;
+int8_t jl_gc_safe_enter(jl_ptls_t ptls) JL_NOTSAFEPOINT;
+int8_t jl_gc_safe_leave(jl_ptls_t ptls, int8_t state); // Can be a safepoint
+#else
 #define jl_gc_unsafe_enter(ptls) jl_gc_state_save_and_set(ptls, 0)
 #define jl_gc_unsafe_leave(ptls, state) ((void)jl_gc_state_set(ptls, (state), 0))
 #define jl_gc_safe_enter(ptls) jl_gc_state_save_and_set(ptls, JL_GC_STATE_SAFE)
 #define jl_gc_safe_leave(ptls, state) ((void)jl_gc_state_set(ptls, (state), JL_GC_STATE_SAFE))
+#endif
 JL_DLLEXPORT void (jl_gc_safepoint)(void);
 
 JL_DLLEXPORT void jl_gc_enable_finalizers(jl_ptls_t ptls, int on);

--- a/src/method.c
+++ b/src/method.c
@@ -220,7 +220,7 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
     li->code = body;
     jl_gc_wb(li, li->code);
     size_t n = jl_array_len(body);
-    jl_value_t **bd = (jl_value_t**)jl_array_data((jl_array_t*)li->code);
+    jl_value_t **bd = (jl_value_t**)jl_array_ptr_data((jl_array_t*)li->code);
     for (j = 0; j < n; j++) {
         jl_value_t *st = bd[j];
         if (jl_is_expr(st) && ((jl_expr_t*)st)->head == meta_sym) {
@@ -599,7 +599,7 @@ JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t *module)
     return m;
 }
 
-jl_array_t *jl_all_methods;
+jl_array_t *jl_all_methods JL_GLOBALLY_ROOTED;
 static jl_method_t *jl_new_method(
         jl_code_info_t *definition,
         jl_sym_t *name,
@@ -695,7 +695,7 @@ JL_DLLEXPORT jl_value_t *jl_generic_function_def(jl_sym_t *name,
     return gf;
 }
 
-static jl_datatype_t *first_arg_datatype(jl_value_t *a, int got_tuple1)
+static jl_datatype_t *first_arg_datatype(jl_value_t *a JL_PROPAGATES_ROOT, int got_tuple1) JL_NOTSAFEPOINT
 {
     if (jl_is_datatype(a)) {
         if (got_tuple1)
@@ -726,13 +726,13 @@ static jl_datatype_t *first_arg_datatype(jl_value_t *a, int got_tuple1)
 }
 
 // get DataType of first tuple element, or NULL if cannot be determined
-JL_DLLEXPORT jl_datatype_t *jl_first_argument_datatype(jl_value_t *argtypes)
+JL_DLLEXPORT jl_datatype_t *jl_first_argument_datatype(jl_value_t *argtypes JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
     return first_arg_datatype(argtypes, 0);
 }
 
 // get DataType implied by a single given type, or `nothing`
-JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt)
+JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
     jl_datatype_t *dt = first_arg_datatype(argt, 1);
     if (dt == NULL)

--- a/src/module.c
+++ b/src/module.c
@@ -125,6 +125,23 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var, int 
     return *bp;
 }
 
+// Hash tables don't generically root their contents, but they do for bindings.
+// Express this to the analyzer.
+#ifdef __clang_analyzer__
+jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT;
+jl_binding_t **jl_get_module_binding_bp(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT;
+#else
+static inline jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT
+{
+    return (jl_binding_t*)ptrhash_get(&m->bindings, var);
+}
+static inline jl_binding_t **jl_get_module_binding_bp(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT
+{
+    return (jl_binding_t**)ptrhash_bp(&m->bindings, var);
+}
+#endif
+
+
 // return module of binding
 JL_DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var)
 {
@@ -138,7 +155,7 @@ JL_DLLEXPORT jl_module_t *jl_get_module_of_binding(jl_module_t *m, jl_sym_t *var
 // like jl_get_binding_wr, but has different error paths
 JL_DLLEXPORT jl_binding_t *jl_get_binding_for_method_def(jl_module_t *m, jl_sym_t *var)
 {
-    jl_binding_t **bp = (jl_binding_t**)ptrhash_bp(&m->bindings, var);
+    jl_binding_t **bp = jl_get_module_binding_bp(m, var);
     jl_binding_t *b = *bp;
 
     if (b != HT_NOTFOUND) {
@@ -177,16 +194,16 @@ typedef struct _modstack_t {
     struct _modstack_t *prev;
 } modstack_t;
 
-static jl_binding_t *jl_get_binding_(jl_module_t *m, jl_sym_t *var, modstack_t *st);
+static jl_binding_t *jl_get_binding_(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, modstack_t *st);
 
 // find a binding from a module's `usings` list
-static jl_binding_t *using_resolve_binding(jl_module_t *m, jl_sym_t *var, modstack_t *st, int warn)
+static jl_binding_t *using_resolve_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var, modstack_t *st, int warn)
 {
     jl_binding_t *b = NULL;
     jl_module_t *owner = NULL;
     for(int i=(int)m->usings.len-1; i >= 0; --i) {
         jl_module_t *imp = (jl_module_t*)m->usings.items[i];
-        jl_binding_t *tempb = (jl_binding_t*)ptrhash_get(&imp->bindings, var);
+        jl_binding_t *tempb = jl_get_module_binding(imp, var);
         if (tempb != HT_NOTFOUND && tempb->exportp) {
             tempb = jl_get_binding_(imp, var, st);
             if (tempb == NULL || tempb->owner == NULL)
@@ -227,7 +244,7 @@ static jl_binding_t *jl_get_binding_(jl_module_t *m, jl_sym_t *var, modstack_t *
         }
         tmp = tmp->prev;
     }
-    jl_binding_t *b = (jl_binding_t*)ptrhash_get(&m->bindings, var);
+    jl_binding_t *b = jl_get_module_binding(m, var);
     if (b == HT_NOTFOUND || b->owner == NULL) {
         b = using_resolve_binding(m, var, &top, 1);
         if (b != NULL) {
@@ -473,7 +490,7 @@ JL_DLLEXPORT jl_value_t *jl_get_global(jl_module_t *m, jl_sym_t *var)
     return b->value;
 }
 
-JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
     if (!bp->constp) {
@@ -482,7 +499,7 @@ JL_DLLEXPORT void jl_set_global(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
     }
 }
 
-JL_DLLEXPORT void jl_set_const(jl_module_t *m, jl_sym_t *var, jl_value_t *val)
+JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var, jl_value_t *val JL_ROOTED_ARGUMENT)
 {
     jl_binding_t *bp = jl_get_binding_wr(m, var, 1);
     if (!bp->constp) {

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -462,20 +462,20 @@ JL_DLLEXPORT int jl_substrtof(char *str, int offset, size_t len, float *out)
 
 // showing --------------------------------------------------------------------
 
-JL_DLLEXPORT void jl_flush_cstdio(void)
+JL_DLLEXPORT void jl_flush_cstdio(void) JL_NOTSAFEPOINT
 {
     fflush(stdout);
     fflush(stderr);
 }
 
-JL_DLLEXPORT jl_value_t *jl_stdout_obj(void)
+JL_DLLEXPORT jl_value_t *jl_stdout_obj(void) JL_NOTSAFEPOINT
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stdout_obj = jl_get_global(jl_base_module, jl_symbol("stdout"));
     return stdout_obj;
 }
 
-JL_DLLEXPORT jl_value_t *jl_stderr_obj(void)
+JL_DLLEXPORT jl_value_t *jl_stderr_obj(void) JL_NOTSAFEPOINT
 {
     if (jl_base_module == NULL) return NULL;
     jl_value_t *stderr_obj = jl_get_global(jl_base_module, jl_symbol("stderr"));
@@ -484,7 +484,7 @@ JL_DLLEXPORT jl_value_t *jl_stderr_obj(void)
 
 // toys for debugging ---------------------------------------------------------
 
-static size_t jl_show_svec(JL_STREAM *out, jl_svec_t *t, const char *head, const char *opn, const char *cls)
+static size_t jl_show_svec(JL_STREAM *out, jl_svec_t *t, const char *head, const char *opn, const char *cls) JL_NOTSAFEPOINT
 {
     size_t i, n=0, len = jl_svec_len(t);
     n += jl_printf(out, "%s", head);
@@ -504,12 +504,12 @@ struct recur_list {
     jl_value_t *v;
 };
 
-static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth);
+static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT int jl_id_start_char(uint32_t wc);
-JL_DLLEXPORT int jl_id_char(uint32_t wc);
+JL_DLLEXPORT int jl_id_start_char(uint32_t wc) JL_NOTSAFEPOINT;
+JL_DLLEXPORT int jl_id_char(uint32_t wc) JL_NOTSAFEPOINT;
 
-JL_DLLEXPORT int jl_is_identifier(char *str)
+JL_DLLEXPORT int jl_is_identifier(char *str) JL_NOTSAFEPOINT
 {
     size_t i = 0;
     uint32_t wc = u8_nextchar(str, &i);
@@ -528,7 +528,7 @@ JL_DLLEXPORT int jl_is_identifier(char *str)
 // This is necessary to make sure that this function doesn't allocate any
 // memory through the Julia GC
 static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt,
-                                struct recur_list *depth)
+                                struct recur_list *depth) JL_NOTSAFEPOINT
 {
     size_t n = 0;
     if ((uintptr_t)vt < 4096U) {
@@ -576,7 +576,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         if (globname && !strchr(jl_symbol_name(globname), '#') &&
             !strchr(jl_symbol_name(globname), '@') && dv->name->module &&
             jl_binding_resolved_p(dv->name->module, globname)) {
-            jl_binding_t *b = jl_get_binding(dv->name->module, globname);
+            jl_binding_t *b = jl_get_module_binding(dv->name->module, globname);
             if (b && jl_typeof(b->value) == v)
                 globfunc = 1;
         }
@@ -933,7 +933,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     return n;
 }
 
-static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth)
+static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list *depth) JL_NOTSAFEPOINT
 {
     // show values without calling a julia method or allocating through the GC
     if (v == NULL) {
@@ -953,12 +953,12 @@ static size_t jl_static_show_x(JL_STREAM *out, jl_value_t *v, struct recur_list 
     return jl_static_show_x_(out, v, (jl_datatype_t*)jl_typeof(v), &this_item);
 }
 
-JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v)
+JL_DLLEXPORT size_t jl_static_show(JL_STREAM *out, jl_value_t *v) JL_NOTSAFEPOINT
 {
     return jl_static_show_x(out, v, 0);
 }
 
-JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type)
+JL_DLLEXPORT size_t jl_static_show_func_sig(JL_STREAM *s, jl_value_t *type) JL_NOTSAFEPOINT
 {
     jl_value_t *ftype = (jl_value_t*)jl_first_argument_datatype(type);
     if (ftype == NULL)

--- a/src/signals-unix.c
+++ b/src/signals-unix.c
@@ -577,7 +577,6 @@ static void *signal_listener(void *arg)
     }
 #endif
     while (1) {
-        profile = 0;
         sig = 0;
         errno = 0;
 #ifdef HAVE_KEVENT

--- a/src/stackwalk.c
+++ b/src/stackwalk.c
@@ -95,7 +95,7 @@ size_t rec_backtrace(uintptr_t *data, size_t maxsize)
     return rec_backtrace_ctx(data, maxsize, &context);
 }
 
-static jl_value_t *array_ptr_void_type = NULL;
+static jl_value_t *array_ptr_void_type JL_ALWAYS_LEAFTYPE = NULL;
 JL_DLLEXPORT jl_value_t *jl_backtrace_from_here(int returnsp)
 {
     jl_array_t *ip = NULL;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -52,7 +52,7 @@ typedef struct {
 // during the computation.
 // Most of the complexity is due to the "diagonal rule", requiring us to
 // identify which type vars range over only concrete types.
-typedef struct _varbinding {
+typedef struct jl_varbinding_t {
     jl_tvar_t *var;
     jl_value_t *lb;
     jl_value_t *ub;
@@ -79,14 +79,16 @@ typedef struct _varbinding {
     // array of typevars that our bounds depend on, whose UnionAlls need to be
     // moved outside ours.
     jl_array_t *innervars;
-    struct _varbinding *prev;
+    struct jl_varbinding_t *prev;
 } jl_varbinding_t;
 
 // subtype algorithm state
-typedef struct {
+typedef struct jl_stenv_t {
+    // N.B.: varbindings are created on the stack and rooted there
     jl_varbinding_t *vars;    // type variable environment
     jl_unionstate_t Lunions;  // union state for unions on the left of A <: B
     jl_unionstate_t Runions;  // union state for unions on the right
+    // N.B.: envout is gc-rooted
     jl_value_t **envout;      // for passing caller the computed bounds of right-side variables
     int envsz;                // length of envout
     int envidx;               // current index in envout
@@ -99,7 +101,10 @@ typedef struct {
 // state manipulation utilities
 
 // look up a type variable in an environment
-static jl_varbinding_t *lookup(jl_stenv_t *e, jl_tvar_t *v)
+#ifdef __clang_analyzer__
+static jl_varbinding_t *lookup(jl_stenv_t *e, jl_tvar_t *v) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT;
+#else
+static jl_varbinding_t *lookup(jl_stenv_t *e, jl_tvar_t *v) JL_GLOBALLY_ROOTED JL_NOTSAFEPOINT
 {
     jl_varbinding_t *b = e->vars;
     while (b != NULL) {
@@ -108,15 +113,16 @@ static jl_varbinding_t *lookup(jl_stenv_t *e, jl_tvar_t *v)
     }
     return b;
 }
+#endif
 
-static int statestack_get(jl_unionstate_t *st, int i)
+static int statestack_get(jl_unionstate_t *st, int i) JL_NOTSAFEPOINT
 {
     assert(i >= 0 && i < sizeof(st->stack) * 8);
     // get the `i`th bit in an array of 32-bit words
     return (st->stack[i>>5] & (1<<(i&31))) != 0;
 }
 
-static void statestack_set(jl_unionstate_t *st, int i, int val)
+static void statestack_set(jl_unionstate_t *st, int i, int val) JL_NOTSAFEPOINT
 {
     assert(i >= 0 && i < sizeof(st->stack) * 8);
     if (val)
@@ -140,6 +146,10 @@ static void save_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se)
     }
     *root = (jl_value_t*)jl_alloc_svec(len*3);
     se->buf = (int8_t*)(len ? malloc(len*2) : NULL);
+#ifdef __clang_analyzer__
+    if (len)
+        memset(se->buf, 0, len*2);
+#endif
     int i=0, j=0; v = e->vars;
     while (v != NULL) {
         jl_svecset(*root, i++, v->lb);
@@ -152,7 +162,7 @@ static void save_env(jl_stenv_t *e, jl_value_t **root, jl_savedenv_t *se)
     se->rdepth = e->Runions.depth;
 }
 
-static void restore_env(jl_stenv_t *e, jl_value_t *root, jl_savedenv_t *se)
+static void restore_env(jl_stenv_t *e, jl_value_t *root, jl_savedenv_t *se) JL_NOTSAFEPOINT
 {
     jl_varbinding_t *v = e->vars;
     int i = 0, j = 0;
@@ -163,6 +173,7 @@ static void restore_env(jl_stenv_t *e, jl_value_t *root, jl_savedenv_t *se)
         i++;
         if (root) v->innervars = (jl_array_t*)jl_svecref(root, i);
         i++;
+        assert(se->buf);
         v->occurs_inv = se->buf[j++];
         v->occurs_cov = se->buf[j++];
         v = v->prev;
@@ -416,7 +427,7 @@ static jl_unionall_t *rename_unionall(jl_unionall_t *u)
 
 static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param);
 
-static jl_value_t *pick_union_element(jl_value_t *u, jl_stenv_t *e, int8_t R)
+static jl_value_t *pick_union_element(jl_value_t *u JL_PROPAGATES_ROOT, jl_stenv_t *e, int8_t R) JL_NOTSAFEPOINT
 {
     jl_unionstate_t *state = R ? &e->Runions : &e->Lunions;
     do {
@@ -467,7 +478,7 @@ static int subtype_ccheck(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)
 
 // use the current context to record where a variable occurred, for the purpose
 // of determining whether the variable is concrete.
-static void record_var_occurrence(jl_varbinding_t *vb, jl_stenv_t *e, int param)
+static void record_var_occurrence(jl_varbinding_t *vb, jl_stenv_t *e, int param) JL_NOTSAFEPOINT
 {
     if (vb != NULL && param) {
         // saturate counters at 2; we don't need values bigger than that
@@ -552,7 +563,7 @@ static int var_gt(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int param)
 // check that a type is concrete or quasi-concrete (Type{T}).
 // this is used to check concrete typevars:
 // issubtype is false if the lower bound of a concrete type var is not concrete.
-static int is_leaf_bound(jl_value_t *v)
+static int is_leaf_bound(jl_value_t *v) JL_NOTSAFEPOINT
 {
     if (v == jl_bottom_type)
         return 1;
@@ -567,12 +578,12 @@ static int is_leaf_bound(jl_value_t *v)
     return !jl_is_type(v) && !jl_is_typevar(v);
 }
 
-static int is_leaf_typevar(jl_tvar_t *v)
+static int is_leaf_typevar(jl_tvar_t *v) JL_NOTSAFEPOINT
 {
     return is_leaf_bound(v->lb);
 }
 
-static jl_value_t *widen_Type(jl_value_t *t)
+static jl_value_t *widen_Type(jl_value_t *t JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
     if (jl_is_type_type(t) && !jl_is_typevar(jl_tparam0(t)))
         return jl_typeof(jl_tparam0(t));
@@ -594,7 +605,7 @@ JL_DLLEXPORT jl_array_t *jl_find_free_typevars(jl_value_t *v);
 // but this causes us to infer the larger `Type{T} where T<:Vector` instead.
 // However this is needed because many contexts check `isa(sp, TypeVar)` to determine
 // when a static parameter value is not known exactly.
-static jl_value_t *fix_inferred_var_bound(jl_tvar_t *var, jl_value_t *ty)
+static jl_value_t *fix_inferred_var_bound(jl_tvar_t *var, jl_value_t *ty JL_MAYBE_UNROOTED)
 {
     if (!jl_is_typevar(ty) && jl_has_free_typevars(ty)) {
         jl_value_t *ans = ty;
@@ -612,7 +623,7 @@ static jl_value_t *fix_inferred_var_bound(jl_tvar_t *var, jl_value_t *ty)
     return ty;
 }
 
-static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want_inv);
+static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want_inv) JL_NOTSAFEPOINT;
 
 // compare UnionAll type `u` to `t`. `R==1` if `u` came from the right side of A <: B.
 static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8_t R, int param)
@@ -729,8 +740,9 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
 }
 
 // unwrap <=2 layers of UnionAlls, leaving the vars in *p1 and *p2 and returning the body
-static jl_value_t *unwrap_2_unionall(jl_value_t *t, jl_tvar_t **p1, jl_tvar_t **p2)
+static jl_value_t *unwrap_2_unionall(jl_value_t *t, jl_tvar_t **p1, jl_tvar_t **p2) JL_NOTSAFEPOINT
 {
+    assert(t);
     if (jl_is_unionall(t)) {
         *p1 = ((jl_unionall_t*)t)->var;
         t = ((jl_unionall_t*)t)->body;
@@ -950,6 +962,7 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
     jl_value_t *ux = jl_unwrap_unionall(x);
     jl_value_t *uy = jl_unwrap_unionall(y);
     if ((x != ux || y != uy) && y != (jl_value_t*)jl_any_type && jl_is_datatype(ux) && jl_is_datatype(uy)) {
+        assert(ux);
         jl_datatype_t *xd = (jl_datatype_t*)ux, *yd = (jl_datatype_t*)uy;
         while (xd != NULL && xd != jl_any_type && xd->name != yd->name) {
             xd = xd->super;
@@ -1330,7 +1343,7 @@ static jl_value_t *intersect_ufirst(jl_value_t *x, jl_value_t *y, jl_stenv_t *e,
 }
 
 // set a variable to a non-type constant
-static jl_value_t *set_var_to_const(jl_varbinding_t *bb, jl_value_t *v, jl_varbinding_t *othervar)
+static jl_value_t *set_var_to_const(jl_varbinding_t *bb, jl_value_t *v JL_MAYBE_UNROOTED, jl_varbinding_t *othervar)
 {
     int offset = bb->offset;
     if (othervar && offset == 0)
@@ -1474,7 +1487,7 @@ static jl_value_t *intersect_var(jl_tvar_t *b, jl_value_t *a, jl_stenv_t *e, int
 // test whether `var` occurs inside constructors. `want_inv` tests only inside
 // invariant constructors. `inside` means we are currently inside a constructor of the
 // requested kind.
-static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want_inv)
+static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want_inv) JL_NOTSAFEPOINT
 {
     if (v == (jl_value_t*)var) {
         return inside;
@@ -1503,7 +1516,7 @@ static int var_occurs_inside(jl_value_t *v, jl_tvar_t *var, int inside, int want
 }
 
 // Caller might not have rooted `res`
-static jl_value_t *finish_unionall(jl_value_t *res, jl_varbinding_t *vb, jl_stenv_t *e)
+static jl_value_t *finish_unionall(jl_value_t *res JL_MAYBE_UNROOTED, jl_varbinding_t *vb, jl_stenv_t *e)
 {
     jl_value_t *varval = NULL;
     jl_tvar_t *newvar = vb->var;
@@ -1605,7 +1618,7 @@ static jl_value_t *finish_unionall(jl_value_t *res, jl_varbinding_t *vb, jl_sten
     if (res != jl_bottom_type && vb->innervars != NULL) {
         int i;
         for(i=0; i < jl_array_len(vb->innervars); i++) {
-            jl_tvar_t *var = (jl_tvar_t*)jl_arrayref(vb->innervars, i);
+            jl_tvar_t *var = (jl_tvar_t*)jl_array_ptr_ref(vb->innervars, i);
             if (jl_has_typevar(res, var))
                 res = jl_new_struct(jl_unionall_type, (jl_tvar_t*)var, res);
         }
@@ -1896,13 +1909,15 @@ static jl_value_t *intersect_invariant(jl_value_t *x, jl_value_t *y, jl_stenv_t 
     if (jl_is_typevar(x) && jl_is_typevar(y) && (jl_is_typevar(ii) || !jl_is_type(ii)))
         return ii;
     if (ii == jl_bottom_type) {
-        if (!subtype_in_env(x, ii, e))
+        if (!subtype_in_env(x, jl_bottom_type, e))
             return NULL;
         flip_vars(e);
-        if (!subtype_in_env(y, ii, e))
-            ii = NULL;
+        if (!subtype_in_env(y, jl_bottom_type, e)) {
+            flip_vars(e);
+            return NULL;
+        }
         flip_vars(e);
-        return ii;
+        return jl_bottom_type;
     }
     /*
       TODO: This is a band-aid for issue #23685. A better solution would be to
@@ -2482,7 +2497,7 @@ static int type_morespecific_(jl_value_t *a, jl_value_t *b, int invariant, jl_ty
 
 static int num_occurs(jl_tvar_t *v, jl_typeenv_t *env);
 
-static jl_value_t *nth_tuple_elt(jl_datatype_t *t, size_t i)
+static jl_value_t *nth_tuple_elt(jl_datatype_t *t JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT
 {
     size_t len = jl_field_count(t);
     if (len == 0)

--- a/src/support/analyzer_annotations.h
+++ b/src/support/analyzer_annotations.h
@@ -1,5 +1,13 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+#if !(defined(__clang__) && __has_feature(nullability))
+#define _Nonnull
+#endif
+#define JL_NONNULL _Nonnull
+
 #ifdef __clang_analyzer__
 
 #define JL_PROPAGATES_ROOT __attribute__((annotate("julia_propagates_root")))

--- a/src/support/arraylist.h
+++ b/src/support/arraylist.h
@@ -9,6 +9,8 @@
 extern "C" {
 #endif
 
+#include "analyzer_annotations.h"
+
 typedef struct {
     size_t len;
     size_t max;
@@ -19,7 +21,7 @@ typedef struct {
 arraylist_t *arraylist_new(arraylist_t *a, size_t size);
 void arraylist_free(arraylist_t *a);
 
-void arraylist_push(arraylist_t *a, void *elt);
+void arraylist_push(arraylist_t *a, void *elt) JL_NOTSAFEPOINT;
 void *arraylist_pop(arraylist_t *a);
 void arraylist_grow(arraylist_t *a, size_t n);
 

--- a/src/support/htable.h
+++ b/src/support/htable.h
@@ -5,6 +5,8 @@
 
 #define HT_N_INLINE 32
 
+#include "analyzer_annotations.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,13 +27,13 @@ void htable_free(htable_t *h);
 // clear and (possibly) change size
 void htable_reset(htable_t *h, size_t sz);
 
-#define HTPROT(HTNAME)                                          \
-void *HTNAME##_get(htable_t *h, void *key);                     \
-void HTNAME##_put(htable_t *h, void *key, void *val);           \
-void HTNAME##_adjoin(htable_t *h, void *key, void *val);        \
-int HTNAME##_has(htable_t *h, void *key);                       \
-int HTNAME##_remove(htable_t *h, void *key);                    \
-void **HTNAME##_bp(htable_t *h, void *key);
+#define HTPROT(HTNAME)                                                  \
+void *HTNAME##_get(htable_t *h, void *key) JL_NOTSAFEPOINT;             \
+void HTNAME##_put(htable_t *h, void *key, void *val) JL_NOTSAFEPOINT;   \
+void HTNAME##_adjoin(htable_t *h, void *key, void *val) JL_NOTSAFEPOINT;\
+int HTNAME##_has(htable_t *h, void *key) JL_NOTSAFEPOINT;               \
+int HTNAME##_remove(htable_t *h, void *key) JL_NOTSAFEPOINT;            \
+void **HTNAME##_bp(htable_t *h, void *key) JL_NOTSAFEPOINT;
 
 #define HTPROT_R(HTNAME)                                                \
 void *HTNAME##_get_r(htable_t *h, void *key, void *ctx);                \

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -80,7 +80,7 @@ JL_DLLEXPORT int64_t ios_seek(ios_t *s, int64_t pos);   // absolute seek
 JL_DLLEXPORT int64_t ios_seek_end(ios_t *s);
 JL_DLLEXPORT int64_t ios_skip(ios_t *s, int64_t offs);  // relative seek
 JL_DLLEXPORT int64_t ios_pos(ios_t *s);  // get current position
-JL_DLLEXPORT int ios_trunc(ios_t *s, size_t size);
+JL_DLLEXPORT int ios_trunc(ios_t *s, size_t size) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_eof(ios_t *s);
 JL_DLLEXPORT int ios_eof_blocking(ios_t *s);
 JL_DLLEXPORT int ios_flush(ios_t *s);
@@ -88,14 +88,14 @@ JL_DLLEXPORT void ios_close(ios_t *s);
 JL_DLLEXPORT int ios_isopen(ios_t *s);
 JL_DLLEXPORT char *ios_take_buffer(ios_t *s, size_t *psize);  // release buffer to caller
 // set buffer space to use
-JL_DLLEXPORT int ios_setbuf(ios_t *s, char *buf, size_t size, int own);
+JL_DLLEXPORT int ios_setbuf(ios_t *s, char *buf, size_t size, int own) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_bufmode(ios_t *s, bufmode_t mode);
 JL_DLLEXPORT int ios_get_readable(ios_t *s);
 JL_DLLEXPORT int ios_get_writable(ios_t *s);
 JL_DLLEXPORT void ios_set_readonly(ios_t *s);
 JL_DLLEXPORT size_t ios_copy(ios_t *to, ios_t *from, size_t nbytes);
 JL_DLLEXPORT size_t ios_copyall(ios_t *to, ios_t *from);
-JL_DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim);
+JL_DLLEXPORT size_t ios_copyuntil(ios_t *to, ios_t *from, char delim) JL_NOTSAFEPOINT;
 JL_DLLEXPORT size_t ios_nchomp(ios_t *from, size_t ntowrite);
 // ensure at least n bytes are buffered if possible. returns # available.
 JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
@@ -104,7 +104,7 @@ JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 JL_DLLEXPORT
 ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc);
 JL_DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
-JL_DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize);
+JL_DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize) JL_NOTSAFEPOINT;
 ios_t *ios_str(ios_t *s, char *str);
 ios_t *ios_static_buffer(ios_t *s, char *buf, size_t sz);
 JL_DLLEXPORT ios_t *ios_fd(ios_t *s, long fd, int isfile, int own);

--- a/src/support/utf8.h
+++ b/src/support/utf8.h
@@ -7,6 +7,8 @@
 extern "C" {
 #endif
 
+#include "analyzer_annotations.h"
+
 /* is c the start of a utf8 sequence? */
 #define isutf(c) (((c)&0xC0)!=0x80)
 
@@ -28,7 +30,7 @@ JL_DLLEXPORT size_t u8_offset(const char *str, size_t charnum);
 JL_DLLEXPORT size_t u8_charnum(const char *str, size_t offset);
 
 /* return next character, updating an index variable */
-uint32_t u8_nextchar(const char *s, size_t *i);
+uint32_t u8_nextchar(const char *s, size_t *i) JL_NOTSAFEPOINT;
 
 /* next character without NUL character terminator */
 uint32_t u8_nextmemchar(const char *s, size_t *i);

--- a/src/task.c
+++ b/src/task.c
@@ -41,7 +41,9 @@ volatile int jl_in_stackwalk = 0;
 #endif
 
 /* This probing code is derived from Douglas Jones' user thread library */
+static void _probe_arch(void);
 
+#ifndef __clang_analyzer__
 /* true if stack grows up, false if down */
 static int _stack_grows_up;
 
@@ -137,6 +139,7 @@ static void _probe_arch(void)
     intptr_t prior_diff = p.probe_local - p.prior_local;
     _frame_offset = labs(prior_diff);
 }
+#endif
 
 /* end probing code */
 
@@ -196,7 +199,7 @@ static void NOINLINE restore_stack(jl_ptls_t ptls, char *p)
 
 static jl_function_t *task_done_hook_func=NULL;
 
-static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
+static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval JL_MAYBE_UNROOTED)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     JL_SIGATOMIC_BEGIN();
@@ -240,7 +243,7 @@ static void JL_NORETURN finish_task(jl_task_t *t, jl_value_t *resultval)
     abort();
 }
 
-static void record_backtrace(void)
+static void record_backtrace(void) JL_NOTSAFEPOINT
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     ptls->bt_size = rec_backtrace(ptls->bt_data, JL_MAX_BT_SIZE);
@@ -532,7 +535,7 @@ static void init_task(jl_task_t *t, char *stack)
 #endif /* !COPY_STACKS */
 
 jl_timing_block_t *jl_pop_timing_block(jl_timing_block_t *cur_block);
-JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
+JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e) JL_NOTSAFEPOINT
 {
     jl_printf(JL_STDERR, "fatal: error thrown and no exception handler available.\n");
     jl_static_show(JL_STDERR, e);
@@ -542,7 +545,7 @@ JL_DLLEXPORT JL_NORETURN void jl_no_exc_handler(jl_value_t *e)
 }
 
 // yield to exception handler
-void JL_NORETURN throw_internal(jl_value_t *e)
+void JL_NORETURN throw_internal(jl_value_t *e JL_MAYBE_UNROOTED)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     ptls->io_wait = 0;
@@ -667,7 +670,7 @@ JL_DLLEXPORT jl_value_t *jl_get_current_task(void)
 jl_function_t *jl_unprotect_stack_func;
 
 // Do one-time initializations for task system
-void jl_init_tasks(void)
+void jl_init_tasks(void) JL_GC_DISABLED
 {
     _probe_arch();
     jl_task_type = (jl_datatype_t*)

--- a/src/threading.c
+++ b/src/threading.c
@@ -396,6 +396,7 @@ void ti_threadfun(void *arg)
 
         ti_threadgroup_fork(tg, ptls->tid, (void **)&work, init);
         init = 0;
+        JL_GC_PROMISE_ROOTED(work);
 
 #if PROFILE_JL_THREADING
         uint64_t tfork = uv_hrtime();
@@ -609,12 +610,15 @@ void jl_start_threads(void)
         mask[0] = 0;
     }
 
+    // The analyzer doesn't know jl_n_threads doesn't change, help it
+    size_t nthreads = jl_n_threads;
+
     // create threads
-    targs = (ti_threadarg_t **)malloc((jl_n_threads - 1) * sizeof (ti_threadarg_t *));
+    targs = (ti_threadarg_t **)malloc((nthreads - 1) * sizeof (ti_threadarg_t *));
 
-    uv_barrier_init(&thread_init_done, jl_n_threads);
+    uv_barrier_init(&thread_init_done, nthreads);
 
-    for (i = 0;  i < jl_n_threads - 1;  ++i) {
+    for (i = 0;  i < nthreads - 1;  ++i) {
         targs[i] = (ti_threadarg_t *)malloc(sizeof (ti_threadarg_t));
         targs[i]->state = TI_THREAD_INIT;
         targs[i]->tid = i + 1;
@@ -628,13 +632,13 @@ void jl_start_threads(void)
     }
 
     // set up the world thread group
-    ti_threadgroup_create(1, jl_n_threads, 1, &tgworld);
-    for (i = 0;  i < jl_n_threads;  ++i)
+    ti_threadgroup_create(1, nthreads, 1, &tgworld);
+    for (i = 0;  i < nthreads;  ++i)
         ti_threadgroup_addthread(tgworld, i, NULL);
     ti_threadgroup_initthread(tgworld, ptls->tid);
 
     // give the threads the world thread group; they will block waiting for fork
-    for (i = 0;  i < jl_n_threads - 1;  ++i) {
+    for (i = 0;  i < nthreads - 1;  ++i) {
         targs[i]->tg = tgworld;
         jl_atomic_store_release(&targs[i]->state, TI_THREAD_WORK);
     }
@@ -719,6 +723,7 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_value_t *_args)
 #endif
 
     // this thread must do work too (TODO: reduction?)
+    JL_GC_PROMISE_ROOTED(threadwork.mfunc);
     tw->ret = ti_run_fun(threadwork.fptr, threadwork.mfunc, args, nargs);
 
 #if PROFILE_JL_THREADING

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -73,7 +73,7 @@ JL_DLLEXPORT jl_module_t *jl_new_main_module(void)
     return old_main;
 }
 
-static jl_function_t *jl_module_get_initializer(jl_module_t *m)
+static jl_function_t *jl_module_get_initializer(jl_module_t *m JL_PROPAGATES_ROOT)
 {
     return (jl_function_t*)jl_get_global(m, jl_symbol("__init__"));
 }
@@ -273,7 +273,9 @@ jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex)
         JL_TRY {
             size_t i, l = module_stack.len;
             for (i = stackidx; i < l; i++) {
-                jl_module_load_time_initialize((jl_module_t*)module_stack.items[i]);
+                jl_module_t *m = (jl_module_t*)module_stack.items[i];
+                JL_GC_PROMISE_ROOTED(m);
+                jl_module_load_time_initialize(m);
             }
             assert(module_stack.len == l);
             module_stack.len = stackidx;
@@ -418,7 +420,7 @@ static void body_attributes(jl_array_t *body, int *has_intrinsics, int *has_defs
     }
 }
 
-static jl_module_t *call_require(jl_module_t *mod, jl_sym_t *var)
+static jl_module_t *call_require(jl_module_t *mod, jl_sym_t *var) JL_GLOBALLY_ROOTED
 {
     static jl_value_t *require_func = NULL;
     static size_t require_world = 0;
@@ -451,7 +453,7 @@ static jl_module_t *call_require(jl_module_t *mod, jl_sym_t *var)
 // either:
 //   - sets *name and returns the module to import *name from
 //   - sets *name to NULL and returns a module to import
-static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from, jl_array_t *args, jl_sym_t **name, const char *keyword)
+static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from JL_PROPAGATES_ROOT, jl_array_t *args, jl_sym_t **name, const char *keyword) JL_GLOBALLY_ROOTED
 {
     jl_sym_t *var = (jl_sym_t*)jl_array_ptr_ref(args, 0);
     size_t i = 1;
@@ -488,6 +490,7 @@ static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from, jl_a
             if (var != dot_sym)
                 break;
             i++;
+            assert(m);
             m = m->parent;
         }
     }
@@ -501,6 +504,7 @@ static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from, jl_a
         if (i == jl_array_len(args)-1)
             break;
         m = (jl_module_t*)jl_eval_global_var(m, var);
+        JL_GC_PROMISE_ROOTED(m);
         if (!jl_is_module(m))
             jl_errorf("invalid %s path: \"%s\" does not name a module", keyword, jl_symbol_name(var));
         i++;
@@ -535,8 +539,9 @@ static jl_method_instance_t *method_instance_for_thunk(jl_code_info_t *src, jl_m
     return li;
 }
 
-static void import_module(jl_module_t *m, jl_module_t *import)
+static void import_module(jl_module_t *JL_NONNULL m, jl_module_t *import)
 {
+    assert(m);
     jl_sym_t *name = import->name;
     jl_binding_t *b;
     if (jl_binding_resolved_p(m, name)) {
@@ -558,7 +563,7 @@ static void import_module(jl_module_t *m, jl_module_t *import)
 }
 
 // in `import A.B: x, y, ...`, evaluate the `A.B` part if it exists
-static jl_module_t *eval_import_from(jl_module_t *m, jl_expr_t *ex, const char *keyword)
+static jl_module_t *eval_import_from(jl_module_t *m JL_PROPAGATES_ROOT, jl_expr_t *ex, const char *keyword)
 {
     if (jl_expr_nargs(ex) == 1 && jl_is_expr(jl_exprarg(ex, 0))) {
         jl_expr_t *fr = (jl_expr_t*)jl_exprarg(ex, 0);
@@ -582,7 +587,7 @@ static jl_module_t *eval_import_from(jl_module_t *m, jl_expr_t *ex, const char *
     return NULL;
 }
 
-jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded)
+jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_value_t *e, int fast, int expanded)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (!jl_is_expr(e)) {


### PR DESCRIPTION
This adds static analyzer annotations for most of the rest of the .c files. We're down to about 50 warnings across all of these files. Most of them are related to `union jl_typemap_t`. Unfortunately, the clang static analyzer is very bad at unions. I tried most of today to work around that, but didn't make much headway. To get the rest of this passing, I'll either have to fix the analyzer or we'll have to stop using the union in favor of just regular pointer casts. I'm somewhat tempted to just do the latter.