### PR TITLE
make cmp with BigInt return in [-1, 0, 1]

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -487,13 +487,13 @@ count_ones_abs(x::BigInt) = iszero(x) ? 0 : MPZ.mpn_popcount(x)
 
 divrem(x::BigInt, y::BigInt) = MPZ.tdiv_qr(x, y)
 
-cmp(x::BigInt, y::BigInt) = MPZ.cmp(x, y)
-cmp(x::BigInt, y::ClongMax) = MPZ.cmp_si(x, y)
-cmp(x::BigInt, y::CulongMax) = MPZ.cmp_ui(x, y)
+cmp(x::BigInt, y::BigInt) = sign(MPZ.cmp(x, y))
+cmp(x::BigInt, y::ClongMax) = sign(MPZ.cmp_si(x, y))
+cmp(x::BigInt, y::CulongMax) = sign(MPZ.cmp_ui(x, y))
 cmp(x::BigInt, y::Integer) = cmp(x, big(y))
 cmp(x::Integer, y::BigInt) = -cmp(y, x)
 
-cmp(x::BigInt, y::CdoubleMax) = isnan(y) ? -1 : MPZ.cmp_d(x, y)
+cmp(x::BigInt, y::CdoubleMax) = isnan(y) ? -1 : sign(MPZ.cmp_d(x, y))
 cmp(x::CdoubleMax, y::BigInt) = -cmp(y, x)
 
 isqrt(x::BigInt) = MPZ.sqrt(x)

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -401,3 +401,16 @@ end
 
 # Issue #24298
 @test mod(BigInt(6), UInt(5)) == mod(6, 5)
+
+@testset "cmp has values in [-1, 0, 1], issue #28780" begin
+    bigrand() = rand(-big(2)^rand(1:rand(1:1000)):big(2)^rand(1:rand(1:1000)))
+    for T in (Base.BitInteger_types..., BigInt, Float64, Float32, Float16, BigFloat)
+        @test cmp(big(2)^130, one(T)) == 1
+        @test cmp(-big(2)^130, one(T)) == -1
+        T === BigInt && continue
+        @test cmp(big(2)^130, rand(T)) == 1
+        @test cmp(-big(2)^130, rand(T)) == -1
+        @test cmp(bigrand(), rand(T)) ∈ (-1, 0, 1)
+    end
+    @test cmp(bigrand(), bigrand()) ∈ (-1, 0, 1)
+end

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -403,14 +403,25 @@ end
 @test mod(BigInt(6), UInt(5)) == mod(6, 5)
 
 @testset "cmp has values in [-1, 0, 1], issue #28780" begin
-    bigrand() = rand(-big(2)^rand(1:rand(1:1000)):big(2)^rand(1:rand(1:1000)))
-    for T in (Base.BitInteger_types..., BigInt, Float64, Float32, Float16, BigFloat)
-        @test cmp(big(2)^130, one(T)) == 1
-        @test cmp(-big(2)^130, one(T)) == -1
-        T === BigInt && continue
-        @test cmp(big(2)^130, rand(T)) == 1
-        @test cmp(-big(2)^130, rand(T)) == -1
-        @test cmp(bigrand(), rand(T)) ∈ (-1, 0, 1)
+    # _rand produces values whose log2 is better distributed than rand
+    _rand(::Type{BigInt}, n=1000) = let x = big(2)^rand(1:rand(1:n))
+        rand(-x:x)
     end
-    @test cmp(bigrand(), bigrand()) ∈ (-1, 0, 1)
+    _rand(F::Type{<:AbstractFloat}) = F(_rand(BigInt, round(Int, log2(floatmax(F))))) + rand(F)
+    _rand(T) = rand(T)
+    for T in (Base.BitInteger_types..., BigInt, Float64, Float32, Float16)
+        @test cmp(big(2)^130, one(T)) === 1
+        @test cmp(-big(2)^130, one(T)) === -1
+        c = cmp(_rand(BigInt), _rand(T))
+        @test c ∈ (-1, 0, 1)
+        @test c isa Int
+        (T <: Integer && T !== BigInt) || continue
+        x = rand(T)
+        @test cmp(big(2)^130, x) === cmp(x, -big(2)^130) === 1
+        @test cmp(-big(2)^130, x) === cmp(x, big(2)^130) === -1
+        @test cmp(big(x), x) === cmp(x, big(x)) === 0
+    end
+    c = cmp(_rand(BigInt), _rand(BigInt))
+    @test c ∈ (-1, 0, 1)
+    @test c isa Int
 end


### PR DESCRIPTION
This is to adhere to the documentation.

The added `sign` call doesn't seem to add overhead to the comparison functions using `cmp`. Adding this `sign` call for `cmp(::BigInt, ::UInt)` seems unnecessary according to the current GMP implementation of `mpz_cmp_ui`, but it's more maintenable to rely only on the documentation (which doesn't make garranties). A similar treatment could be made for MPFR, but my few tries didn't find a case where the values is not in `[-1, 0, 1]`.