### PR TITLE
improve performance of parse

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -106,14 +106,21 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
         return nothing
     end
 
-    base = convert(T,base)
-    m::T = div(typemax(T)-base+1,base)
+    base = convert(T, base)
+    m::T = div(typemax(T) - base + 1, base)
     n::T = 0
     a::Int = base <= 36 ? 10 : 36
+    _0 = UInt32('0')
+    _9 = UInt32('9')
+    _A = UInt32('A')
+    _a = UInt32('a')
+    _Z = UInt32('Z')
+    _z = UInt32('z')
     while n <= m
-        d::T = '0' <= c <= '9' ? c-'0'    :
-               'A' <= c <= 'Z' ? c-'A'+10 :
-               'a' <= c <= 'z' ? c-'a'+a  : base
+        _c = UInt32(c)
+        d::T = _0 <= _c <= _9 ? _c-_0             :
+               _A <= _c <= _Z ? _c-_A+ UInt32(10) :
+               _a <= _c <= _z ? _c-_a+a           : base
         if d >= base
             raise && throw(ArgumentError("invalid base $base digit $(repr(c)) in $(repr(SubString(s,startpos,endpos)))"))
             return nothing
@@ -129,9 +136,10 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     end
     (T <: Signed) && (n *= sgn)
     while !isspace(c)
-        d::T = '0' <= c <= '9' ? c-'0'    :
-        'A' <= c <= 'Z' ? c-'A'+10 :
-            'a' <= c <= 'z' ? c-'a'+a  : base
+        _c = UInt32(c)
+        d::T = _0 <= _c <= _9 ? _c-_0             :
+               _A <= _c <= _Z ? _c-_A+ UInt32(10) :
+               _a <= _c <= _z ? _c-_a+a           : base
         if d >= base
             raise && throw(ArgumentError("invalid base $base digit $(repr(c)) in $(repr(SubString(s,startpos,endpos)))"))
             return nothing


### PR DESCRIPTION
Improves performance by preventing everything getting lifted to the Char domain.

Benchmark

```jl
function parseintperf(t)
   local n, m
   for i=1:t
       n = rand(UInt32)
       s = string(n, base = 16)
       m = UInt32(parse(Int64,s, base = 16))
       @assert m == n
   end
   return n
end


strings = [string(rand(UInt32)) for i in 1:10^4];
f(strings) = for s in strings; parse(Int, s) end;
```

Before

```jl
julia> @btime parseintperf(1000);
  189.958 μs (2999 allocations: 109.36 KiB)

julia> @btime f(strings)
  848.226 μs (0 allocations: 0 bytes)
```

After

```jl
julia> @btime parseintperf(1000)
  170.692 μs (2999 allocations: 109.36 KiB)

julia> @btime f(strings)
  709.092 μs (0 allocations: 0 bytes)
```

Still not completely caught up with 0.6 for `parseintperf` but getting close.