### PR TITLE
Make copyto!(A,I) work for rectangular matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -207,10 +207,9 @@ isapprox(A::AbstractMatrix, J::UniformScaling; kwargs...) = isapprox(J, A; kwarg
 
 function copyto!(A::AbstractMatrix, J::UniformScaling)
     @assert !has_offset_axes(A)
-    size(A,1)==size(A,2) || throw(DimensionMismatch("a UniformScaling can only be copied to a square matrix"))
     fill!(A, 0)
     λ = J.λ
-    for i = 1:size(A,1)
+    for i = 1:min(size(A,1),size(A,2))
         @inbounds A[i,i] = λ
     end
     return A

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -85,6 +85,13 @@ let
         @test cond(I) == 1
         @test cond(J) == (λ ≠ zero(λ) ? one(real(λ)) : oftype(real(λ), Inf))
     end
+    
+    @testset "copyto!" begin
+        A = Matrix{Int}(undef, (3,3))
+        @test copyto!(A, I) == one(A)
+        B = Matrix{ComplexF64}(undef, (1,2))
+        @test copyto!(B, J) == [λ zero(λ)]
+    end
 
     @testset "binary ops with matrices" begin
         B = bitrand(2, 2)

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -85,7 +85,7 @@ let
         @test cond(I) == 1
         @test cond(J) == (λ ≠ zero(λ) ? one(real(λ)) : oftype(real(λ), Inf))
     end
-    
+
     @testset "copyto!" begin
         A = Matrix{Int}(undef, (3,3))
         @test copyto!(A, I) == one(A)


### PR DESCRIPTION
Given that `Matrix{T}(I, (m,n))` works for rectangular matrices `m != n`, I would also expect `copyto!(A,I)` to work. I often use this to initialize an existing matrix with ones on the diagonal, even if it is rectangular.

An example is in LinearAlgebra, suppose you want to materialize the q factor in a QR decomposition. You might have two equally sized matrices `A` and `B` lying around:
```julia
using LinearAlgebra
Q,R = qr!(A)
Qmaterialized = lmul!(Q, copyto!(B,I))
```

I'll probably need to update some tests as well?