### PR TITLE
Add a short warning to the doc-frontpage

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -1,6 +1,23 @@
-# Julia 1.0 Documentation
+```@eval
+io = IOBuffer()
+release = isempty(VERSION.prerelease)
+v = "$(VERSION.major).$(VERSION.minor)"
+!release && (v = v*"-$(first(VERSION.prerelease))")
+print(io, """
+    # Julia $(v) Documentation
 
-Welcome to the documentation for Julia 1.0.
+    Welcome to the documentation for Julia $(v).
+
+    """)
+if !release
+    print(io,"""
+        !!! warning "Work in progress!"
+            This documentation is for an unreleased, in-development, version of Julia.
+        """)
+end
+import Markdown
+Markdown.parse(String(take!(io)))
+```
 
 Please read the [release blog post](https://julialang.org/blog/2018/08/one-point-zero) for a general overview of the language and
 many of the changes since Julia v0.6. Note that version 0.7 was released alongside


### PR DESCRIPTION
Add a short warning to the doc-frontpage if the docs are for an in-development version of Julia.

Example:

![screenshot from 2018-08-21 12-03-16](https://user-images.githubusercontent.com/11698744/44395488-522a7300-a53a-11e8-9b47-79ada2d3aa51.png)
