### PR TITLE
Update variables after normalizing varargs

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6702,3 +6702,7 @@ end
 @test_throws ErrorException Array{Int, 2}(undef, 0, -10)
 @test_throws ErrorException Array{Int, 2}(undef, -10, 0)
 @test_throws ErrorException Array{Int, 2}(undef, -1, -1)
+
+# issue #28812
+@test Tuple{Vararg{Array{T},3} where T} === Tuple{Array,Array,Array}
+@test Tuple{Vararg{Array{T} where T,3}} === Tuple{Array,Array,Array}


### PR DESCRIPTION
This code was a bit odd. It started by normalzing the varargs, but
then used `va0` and `va1` from the original, unnormalized type.
Either the unormalized version was intended in which case normalizing
first was wasteful, or the normalized version was intended in which
case the code was incorrct. Talking with Jeff, he believes the latter
was intended, so update the code to do that instead.