### PR TITLE
improve docstring of pathof

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -254,6 +254,9 @@ locate_package(::Nothing) = nothing
 
 Return the path of `m.jl` file that was used to `import` module `m`,
 or `nothing` if `m` was not imported from a package.
+
+Use [`dirname`](@ref) to get the directory part and [`basename`](@ref) 
+to get the file name part of the path.
 """
 function pathof(m::Module)
     pkgid = get(Base.module_keys, m, nothing)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -255,7 +255,7 @@ locate_package(::Nothing) = nothing
 Return the path of `m.jl` file that was used to `import` module `m`,
 or `nothing` if `m` was not imported from a package.
 
-Use [`dirname`](@ref) to get the directory part and [`basename`](@ref) 
+Use [`dirname`](@ref) to get the directory part and [`basename`](@ref)
 to get the file name part of the path.
 """
 function pathof(m::Module)


### PR DESCRIPTION
Added references to `dirname` and `basename` to the docstring of `pathof`. It was not immediately clear to me how to use the results of `pathof` without knowing the existence of `dirname`. Could simplify this pr to just show `See also dirname and basename`.