### PR TITLE
More analyzer annotations

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -547,13 +547,15 @@ JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i)
     return 1;
 }
 
-JL_DLLEXPORT void jl_arrayset(jl_array_t *a, jl_value_t *rhs, size_t i)
+JL_DLLEXPORT void jl_arrayset(jl_array_t *a JL_ROOTING_ARGUMENT, jl_value_t *rhs JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, size_t i)
 {
     assert(i < jl_array_len(a));
     jl_value_t *eltype = jl_tparam0(jl_typeof(a));
     if (eltype != (jl_value_t*)jl_any_type) {
+        JL_GC_PUSH1(&rhs);
         if (!jl_isa(rhs, eltype))
             jl_type_error("arrayset", eltype, rhs);
+        JL_GC_POP();
     }
     if (!a->flags.ptrarray) {
         if (jl_is_uniontype(eltype)) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -3116,8 +3116,10 @@ static jl_value_t *_jl_restore_incremental(ios_t *f, jl_array_t *mod_array)
     jl_gc_enable_finalizers(ptls, 1); // make sure we don't run any Julia code concurrently before this point
     if (tracee_list) {
         jl_methtable_t *mt;
-        while ((mt = (jl_methtable_t*)arraylist_pop(tracee_list)) != NULL)
+        while ((mt = (jl_methtable_t*)arraylist_pop(tracee_list)) != NULL) {
+            JL_GC_PROMISE_ROOTED(mt);
             jl_typemap_visitor(mt->defs, trace_method, NULL);
+        }
         arraylist_free(tracee_list);
         free(tracee_list);
     }

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -386,6 +386,7 @@ JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
     return jl_typeof(v);
 }
 
+#ifndef __clang_analyzer__
 JL_DLLEXPORT int8_t (jl_gc_unsafe_enter)(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
@@ -409,6 +410,7 @@ JL_DLLEXPORT void (jl_gc_safe_leave)(int8_t state)
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_gc_safe_leave(ptls, state);
 }
+#endif
 
 JL_DLLEXPORT void (jl_gc_safepoint)(void)
 {

--- a/src/julia.h
+++ b/src/julia.h
@@ -96,9 +96,12 @@ JL_EXTENSION struct _jl_taggedvalue_t {
 };
 
 #ifdef __clang_analyzer__
-JL_DLLEXPORT jl_taggedvalue_t *jl_astaggedvalue(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
-jl_value_t *jl_valueof(jl_taggedvalue_t *tv JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
-JL_DLLEXPORT jl_value_t *jl_typeof(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+JL_DLLEXPORT jl_taggedvalue_t *_jl_astaggedvalue(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+#define jl_astaggedvalue(v) _jl_astaggedvalue((jl_value_t*)v)
+jl_value_t *_jl_valueof(jl_taggedvalue_t *tv JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+#define jl_valueof(v) _jl_valueof((jl_taggedvalue_t*)v)
+JL_DLLEXPORT jl_value_t *_jl_typeof(jl_value_t *v JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT;
+#define jl_typeof(v) _jl_typeof((jl_value_t*)v)
 #else
 #define jl_astaggedvalue(v)                                             \
     ((jl_taggedvalue_t*)((char*)(v) - sizeof(jl_taggedvalue_t)))
@@ -1103,7 +1106,7 @@ STATIC_INLINE int jl_is_concrete_type(jl_value_t *v) JL_NOTSAFEPOINT
     return jl_is_datatype(v) && ((jl_datatype_t*)v)->isconcretetype;
 }
 
-STATIC_INLINE jl_value_t *jl_typemap_entry_sig(jl_typemap_t *tmap) JL_NOTSAFEPOINT
+STATIC_INLINE jl_value_t *jl_typemap_entry_sig(jl_typemap_t *tmap JL_PROPAGATES_ROOT) JL_NOTSAFEPOINT
 {
     assert(jl_typeof(tmap) == (jl_value_t*)jl_typemap_entry_type);
     return (jl_value_t*)((jl_typemap_entry_t*)tmap)->sig;
@@ -1306,7 +1309,7 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a);
 JL_DLLEXPORT jl_array_t *jl_alloc_vec_any(size_t n);
 JL_DLLEXPORT jl_value_t *jl_arrayref(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT jl_value_t *jl_ptrarrayref(jl_array_t *a JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT;  // 0-indexed
-JL_DLLEXPORT void jl_arrayset(jl_array_t *a JL_ROOTING_ARGUMENT, jl_value_t *v JL_ROOTED_ARGUMENT, size_t i) JL_NOTSAFEPOINT;  // 0-indexed
+JL_DLLEXPORT void jl_arrayset(jl_array_t *a JL_ROOTING_ARGUMENT, jl_value_t *v JL_ROOTED_ARGUMENT JL_MAYBE_UNROOTED, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_arrayunset(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT int jl_array_isassigned(jl_array_t *a, size_t i);  // 0-indexed
 JL_DLLEXPORT void jl_array_grow_end(jl_array_t *a, size_t inc);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -445,7 +445,7 @@ jl_value_t *jl_interpret_toplevel_thunk(jl_module_t *m, jl_code_info_t *src);
 jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                           jl_code_info_t *src,
                                           jl_svec_t *sparam_vals);
-int jl_is_toplevel_only_expr(jl_value_t *e);
+int jl_is_toplevel_only_expr(jl_value_t *e) JL_NOTSAFEPOINT;
 jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr, jl_module_t *inmodule);
 void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_module_t *mod, jl_sym_t *name);
 
@@ -568,7 +568,7 @@ static inline void jl_set_gc_and_wait(void)
 JL_DLLEXPORT jl_value_t *jl_dump_fptr_asm(uint64_t fptr, int raw_mc, const char* asm_variant);
 
 void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char *obj_fname, const char *sysimg_data, size_t sysimg_len);
-int32_t jl_get_llvm_gv(jl_value_t *p);
+int32_t jl_get_llvm_gv(jl_value_t *p) JL_NOTSAFEPOINT;
 int32_t jl_assign_functionID(const char *fname);
 // the first argument to jl_idtable_rehash is used to return a value
 // make sure it is rooted if it is used after the function returns

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -128,12 +128,12 @@ typedef enum {
 #define write_uint8(s, n) ios_putc((n), (s))
 #define read_uint8(s) ((uint8_t)ios_getc((s)))
 
-static void write_uint32(ios_t *s, uint32_t i)
+static void write_uint32(ios_t *s, uint32_t i) JL_NOTSAFEPOINT
 {
     ios_write(s, (char*)&i, 4);
 }
 
-static uint32_t read_uint32(ios_t *s)
+static uint32_t read_uint32(ios_t *s) JL_NOTSAFEPOINT
 {
     uint32_t x = 0;
     ios_read(s, (char*)&x, 4);
@@ -305,7 +305,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v)
     }
 }
 
-static void ios_ensureroom(ios_t *s, size_t newsize)
+static void ios_ensureroom(ios_t *s, size_t newsize) JL_NOTSAFEPOINT
 {
     size_t prevsize = s->size;
     if (prevsize < newsize) {
@@ -315,7 +315,7 @@ static void ios_ensureroom(ios_t *s, size_t newsize)
     }
 }
 
-static void record_gvar(jl_serializer_state *s, int gid, uintptr_t reloc_id)
+static void record_gvar(jl_serializer_state *s, int gid, uintptr_t reloc_id) JL_NOTSAFEPOINT
 {
     if (gid == 0)
         return;
@@ -326,7 +326,7 @@ static void record_gvar(jl_serializer_state *s, int gid, uintptr_t reloc_id)
 }
 
 
-static void write_padding(ios_t *s, size_t nb)
+static void write_padding(ios_t *s, size_t nb) JL_NOTSAFEPOINT
 {
     static const char zeros[16] = {0};
     while (nb > 16) {
@@ -338,7 +338,7 @@ static void write_padding(ios_t *s, size_t nb)
 }
 
 
-static void write_pointer(ios_t *s)
+static void write_pointer(ios_t *s) JL_NOTSAFEPOINT
 {
     assert((ios_pos(s) & (sizeof(void*) - 1)) == 0 && "stream misaligned for writing a word-sized value");
     write_padding(s, sizeof(void*));
@@ -346,7 +346,7 @@ static void write_pointer(ios_t *s)
 
 
 #define backref_id(s, v) _backref_id(s, (jl_value_t*)(v))
-static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v)
+static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v) JL_NOTSAFEPOINT
 {
     assert(v != NULL && "cannot get backref to NULL object");
     void *idx = HT_NOTFOUND;
@@ -374,7 +374,7 @@ static uintptr_t _backref_id(jl_serializer_state *s, jl_value_t *v)
 }
 
 
-static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld)
+static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld) JL_NOTSAFEPOINT
 {
     if (fld != NULL) {
         arraylist_push(&s->relocs_list, (void*)(uintptr_t)ios_pos(s->s));
@@ -383,7 +383,7 @@ static void write_pointerfield(jl_serializer_state *s, jl_value_t *fld)
     write_pointer(s->s);
 }
 
-static void write_gctaggedfield(jl_serializer_state *s, uintptr_t ref)
+static void write_gctaggedfield(jl_serializer_state *s, uintptr_t ref) JL_NOTSAFEPOINT
 {
     arraylist_push(&s->gctags_list, (void*)(uintptr_t)ios_pos(s->s));
     arraylist_push(&s->gctags_list, (void*)ref);
@@ -473,7 +473,7 @@ static void jl_write_module(jl_serializer_state *s, uintptr_t item, jl_module_t 
                 write_pointer(s->s);
                 tot += sizeof(void*);
             }
-            newm = (jl_module_t*)&s->s->buf[reloc_offset];
+            // newm = (jl_module_t*)&s->s->buf[reloc_offset];
         }
     }
 }
@@ -1487,6 +1487,7 @@ static void jl_restore_system_image_from_stream(ios_t *f)
     deser_tag.items[0] = (void*)const_data.buf;
     jl_read_relocations(&s, GC_OLD_MARKED); // gctags
     size_t sizeof_tags = ios_pos(&relocs);
+    (void)sizeof_tags;
     jl_read_relocations(&s, 0); // general relocs
     ios_close(&relocs);
     ios_close(&const_data);

--- a/src/support/analyzer_annotations.h
+++ b/src/support/analyzer_annotations.h
@@ -23,8 +23,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  void JL_GC_PROMISE_ROOTED(void *v);
-  void jl_may_leak(uintptr_t);
+  void JL_GC_PROMISE_ROOTED(void *v) JL_NOTSAFEPOINT;
+  void jl_may_leak(uintptr_t) JL_NOTSAFEPOINT;
 #ifdef __cplusplus
 }
 #endif

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -76,10 +76,10 @@ extern void (*ios_set_io_wait_func)(int);
 JL_DLLEXPORT size_t ios_read(ios_t *s, char *dest, size_t n);
 JL_DLLEXPORT size_t ios_readall(ios_t *s, char *dest, size_t n);
 JL_DLLEXPORT size_t ios_write(ios_t *s, const char *data, size_t n) JL_NOTSAFEPOINT;
-JL_DLLEXPORT int64_t ios_seek(ios_t *s, int64_t pos);   // absolute seek
+JL_DLLEXPORT int64_t ios_seek(ios_t *s, int64_t pos) JL_NOTSAFEPOINT; // absolute seek
 JL_DLLEXPORT int64_t ios_seek_end(ios_t *s);
 JL_DLLEXPORT int64_t ios_skip(ios_t *s, int64_t offs);  // relative seek
-JL_DLLEXPORT int64_t ios_pos(ios_t *s);  // get current position
+JL_DLLEXPORT int64_t ios_pos(ios_t *s) JL_NOTSAFEPOINT;  // get current position
 JL_DLLEXPORT int ios_trunc(ios_t *s, size_t size) JL_NOTSAFEPOINT;
 JL_DLLEXPORT int ios_eof(ios_t *s);
 JL_DLLEXPORT int ios_eof_blocking(ios_t *s);
@@ -102,7 +102,7 @@ JL_DLLEXPORT size_t ios_readprep(ios_t *from, size_t n);
 
 /* stream creation */
 JL_DLLEXPORT
-ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc);
+ios_t *ios_file(ios_t *s, const char *fname, int rd, int wr, int create, int trunc) JL_NOTSAFEPOINT;
 JL_DLLEXPORT ios_t *ios_mkstemp(ios_t *f, char *fname);
 JL_DLLEXPORT ios_t *ios_mem(ios_t *s, size_t initsize) JL_NOTSAFEPOINT;
 ios_t *ios_str(ios_t *s, char *str);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -323,7 +323,7 @@ JL_DLLEXPORT jl_module_t *jl_base_relative_to(jl_module_t *m)
     return jl_top_module;
 }
 
-static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs)
+static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs) JL_NOTSAFEPOINT
 {
     if (!jl_is_expr(v))
         return;
@@ -362,7 +362,7 @@ static void expr_attributes(jl_value_t *v, int *has_intrinsics, int *has_defs)
             jl_module_t *mod = jl_globalref_mod(f);
             jl_sym_t *name = jl_globalref_name(f);
             if (jl_binding_resolved_p(mod, name)) {
-                jl_binding_t *b = jl_get_binding(mod, name);
+                jl_binding_t *b = jl_get_module_binding(mod, name);
                 if (b && b->value && b->constp)
                     called = b->value;
             }
@@ -513,7 +513,7 @@ static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from JL_PR
     return m;
 }
 
-int jl_is_toplevel_only_expr(jl_value_t *e)
+int jl_is_toplevel_only_expr(jl_value_t *e) JL_NOTSAFEPOINT
 {
     return jl_is_expr(e) &&
         (((jl_expr_t*)e)->head == module_sym ||

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -242,7 +242,7 @@ static jl_array_t *jl_alloc_int_1d(size_t np, size_t len)
 }
 
 static inline
-jl_typemap_t *mtcache_hash_lookup(const struct jl_ordereddict_t *a JL_PROPAGATES_ROOT, jl_value_t *ty, int8_t tparam, int8_t offs)
+jl_typemap_t *mtcache_hash_lookup(const struct jl_ordereddict_t *a JL_PROPAGATES_ROOT, jl_value_t *ty, int8_t tparam, int8_t offs) JL_NOTSAFEPOINT
 {
     uintptr_t uid = ((jl_datatype_t*)ty)->uid;
     jl_typemap_t *ml = jl_nothing;
@@ -349,7 +349,7 @@ static jl_typemap_t **mtcache_hash_bp(struct jl_ordereddict_t *pa JL_PROPAGATES_
                 if (idx > jl_max_int(pa->indices))
                     mtcache_rehash(pa, jl_array_len(pa->indices), parent, tparam, offs);
                 jl_intset(pa->indices, slot, idx);
-                return &((jl_typemap_t **)jl_array_data(pa->values))[idx - 1];
+                return &((jl_typemap_t **)jl_array_ptr_data(pa->values))[idx - 1];
             }
             jl_typemap_t **pml = &((jl_typemap_t **)jl_array_ptr_data(pa->values))[idx - 1];
             if (*pml == jl_nothing)


### PR DESCRIPTION
This gets us far enough to pass all the .c files without warning.
The .cpp files are another issue (partly because C++ is more complicated,
partly because they play a bit fast and lose with GC rooting).
However, once this is merged, we should be able to set up CI for
the .c files at least.