### PR TITLE
gh-pages: Update redirects to docs

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=http://docs.julialang.org/en/stable"/>
+<meta http-equiv="refresh" content="0; url=http://docs.julialang.org/en/v1"/>

--- a/en/index.html
+++ b/en/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=http://docs.julialang.org/en/v1"/>
+<meta http-equiv="refresh" content="0; url=https://docs.julialang.org/en/v1"/>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=http://docs.julialang.org/en/stable"/>
+<meta http-equiv="refresh" content="0; url=http://docs.julialang.org/en/v1"/>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<meta http-equiv="refresh" content="0; url=http://docs.julialang.org/en/v1"/>
+<meta http-equiv="refresh" content="0; url=https://docs.julialang.org/en/v1"/>


### PR DESCRIPTION
Updates the https://docs.julialang.org/ and https://docs.julialang.org/en/ redirects to point to `v1/`, instead of `stable/`.

Should not be merged yet --  the new `v1/` URL could use some testing to make sure that there are no subtle issues in accessing docs via that URL (which is implemented as a symlink, not a copy of the files on the `gh-pages` branch). Follows up #28821, related to #26825.