### PR TITLE
Remove bounds checks in iterate(::Tuple)

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -38,7 +38,7 @@ _setindex(v, i::Integer) = ()
 
 ## iterating ##
 
-iterate(t::Tuple, i::Int=1) = length(t) < i ? nothing : (t[i], i+1)
+iterate(@nospecialize(t::Tuple), i::Int=1) = 1 <= i <= length(t) ? (@inbounds t[i], i+1) : nothing
 
 keys(@nospecialize t::Tuple) = OneTo(length(t))
 


### PR DESCRIPTION
This fix seems to help address #28844 partially to get compile-time optimizations

Before:
```julia
julia> g() = 9000 in ntuple(identity, Val(32))
julia> @btime g() # evaluated at runtime
  11.124 ns (0 allocations: 0 bytes)
false
```

After this PR:
```julia
julia> g() = 9000 in ntuple(identity, Val(32))
julia> @btime g() # known at compile-time
  1.541 ns (0 allocations: 0 bytes)
false
```

It also adds `@nospecialize` like in the rest of the function definitions in tuple.jl.

Potentially there's a breaking change here, since `iterate((1,2), -1) === nothing` now, whereas it used to throw a `BoundsError`.