### PR TITLE
fire package_loading callback at every require

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -850,10 +850,10 @@ end
 function require(uuidkey::PkgId)
     if !root_module_exists(uuidkey)
         _require(uuidkey)
-        # After successfully loading, notify downstream consumers
-        for callback in package_callbacks
-            invokelatest(callback, uuidkey)
-        end
+    end
+    # After loading, notify downstream consumers
+    for callback in package_callbacks
+        invokelatest(callback, uuidkey)
     end
     return root_module(uuidkey)
 end

--- a/doc/src/devdocs/require.md
+++ b/doc/src/devdocs/require.md
@@ -9,24 +9,14 @@ Before building upon them inform yourself about the current thinking and whether
 
 ### Module loading callbacks
 
-It is possible to listen to the modules loaded by `Base.require`, by registering a callback.
+It is possible to listen to calls to `Base.require`, by registering a callback.
 
 ```julia
-loaded_packages = Channel{Symbol}()
-callback = (mod::Symbol) -> put!(loaded_packages, mod)
+loaded_packages = Channel{Base.PkgId}()
+callback = (mod::PkgId) -> put!(loaded_packages, mod)
 push!(Base.package_callbacks, callback)
 ```
 
-Please note that the symbol given to the callback is a non-unique identifier and
-it is the responsibility of the callback provider to walk the module chain to
-determine the fully qualified name of the loaded binding.
-
-The callback below is an example of how to do that:
-
-```julia
-# Get the fully-qualified name of a module.
-function module_fqn(name::Symbol)
-    fqn = fullname(Base.root_module(name))
-    return join(fqn, '.')
-end
-```
+The callback will fire once per `Base.require` call and it is the users responsibility
+to filter calls. As an example one might only be interested in the first time a package
+is required.

--- a/stdlib/Distributed/test/TestPkg/Project.toml
+++ b/stdlib/Distributed/test/TestPkg/Project.toml
@@ -1,0 +1,6 @@
+authors = ["Valentin Churavy <v.churavy@gmail.com>"]
+name = "TestPkg"
+uuid = "d2561e9c-a7ee-11e8-393f-bde77b68e4fb"
+version = "0.1.0"
+
+[deps]

--- a/stdlib/Distributed/test/TestPkg/src/TestPkg.jl
+++ b/stdlib/Distributed/test/TestPkg/src/TestPkg.jl
@@ -1,0 +1,3 @@
+module TestPkg
+
+end # module

--- a/stdlib/Distributed/test/TestPkg2/Project.toml
+++ b/stdlib/Distributed/test/TestPkg2/Project.toml
@@ -1,0 +1,6 @@
+authors = ["Valentin Churavy <v.churavy@gmail.com>"]
+name = "TestPkg2"
+uuid = "d353d51e-a7ee-11e8-3291-15e5127f6df0"
+version = "0.1.0"
+
+[deps]

--- a/stdlib/Distributed/test/TestPkg2/src/TestPkg2.jl
+++ b/stdlib/Distributed/test/TestPkg2/src/TestPkg2.jl
@@ -1,0 +1,5 @@
+module TestPkg2
+
+f(x) = x
+
+end # module


### PR DESCRIPTION
Before this change we only fired package callbacks when a top-level module was freshly loaded or in https://github.com/JuliaLang/julia/blob/d55b04430c9eebc229b6dafd8725697d86acf1b3/base/loading.jl#L644-L646, with this change we fire the callbacks on every `require` so that `Distributed` has a change to propagate the users intent.

The other solution that would come to mind is that we do a 
```
remotecall(map, id->Base.require(id), keys(Base.loaded_modules))
```
as part of the worker setup, so that workers a `remotecall` is guaranteed to succeed.


fixes JuliaLang/Distributed.jl#56 
cc: other users of this callback @MikeInnes for Requires.jl and @timholy for Revise.jl (maybe?)