### PR TITLE
issubset aces Discrete Math but flunks Topology

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -226,14 +226,15 @@ end
 <=(l::AbstractSet, r::AbstractSet) = l ⊆ r
 
 function issubset(l, r)
+    if haslength(r)
+        rlen = length(r)
+        #This threshold was empirically determined by repeatedly
+        #sampling using these two methods (see #26198)
+        lenthresh = 70
 
-    rlen = length(r)
-    #This threshold was empirically determined by repeatedly
-    #sampling using these two methods.
-    lenthresh = 70
-
-    if rlen > lenthresh && !isa(r, AbstractSet)
-       return issubset(l, Set(r))
+        if rlen > lenthresh && !isa(r, AbstractSet)
+            return issubset(l, Set(r))
+        end
     end
 
     for elt in l

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -604,3 +604,16 @@ end
         end
     end
 end
+
+struct OpenInterval{T}
+    lower::T
+    upper::T
+end
+Base.in(x, i::OpenInterval) = i.lower < x < i.upper
+Base.IteratorSize(::Type{<:OpenInterval}) = Base.SizeUnknown()
+
+@testset "Continuous sets" begin
+    i = OpenInterval(2, 4)
+    @test 3 ∈ i
+    @test issubset(3, i)
+end


### PR DESCRIPTION
#26198 did some fantastic performance tuning of `issubset` based on a very thorough analysis of scaling behavior. However, the change implicitly assumed that the "superset" is countable, specifically that `length` is defined and will return an integer value. Ranges are an example of a container for which this succeeds (this example leverages the fact that numbers are iterable):

```julia
julia> r = 1:3
1:3

julia> issubset(2, r)
true

julia> issubset(4, r)
false
```

So far so good. However, `length` can't be reasonably defined for [many mathematical sets](https://en.wikipedia.org/wiki/General_topology), and as a consequence bad things happen in `issubset`:

```julia
julia> struct OpenInterval{T}
           lower::T
           upper::T
       end

julia> Base.in(x, i::OpenInterval) = i.lower < x < i.upper

julia> issubset(3, OpenInterval(2, 4))
ERROR: MethodError: no method matching length(::OpenInterval{Int64})
Closest candidates are:
  length(::Core.SimpleVector) at essentials.jl:571
  length(::Base.MethodList) at reflection.jl:728
  length(::Core.MethodTable) at reflection.jl:802
  ...
Stacktrace:
 [1] issubset(::Int64, ::OpenInterval{Int64}) at ./abstractset.jl:230
 [2] top-level scope at none:0
```

This PR addresses the issue in a minimalistic fashion: it checks the `IteratorSize` trait of the superset, and skips the performance-tuning block if `length` can't reasonably be expected to succeed.

This isn't an ideal solution, because `HasLength()` is the default, but at least it gives package authors a means to avoid the bad behavior.