### PR TITLE
improve performance for string(...)

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -103,31 +103,43 @@ function sprint(f::Function, args...; context=nothing, sizehint::Integer=0)
     String(resize!(s.data, s.size))
 end
 
-tostr_sizehint(x) = 0
+tostr_sizehint(x) = 8
 tostr_sizehint(x::AbstractString) = lastindex(x)
 tostr_sizehint(x::Float64) = 20
 tostr_sizehint(x::Float32) = 12
 
-function print_to_string(xs...; env=nothing)
+function print_to_string(xs...)
     if isempty(xs)
         return ""
     end
+    siz = 0
+    for x in xs
+        siz += tostr_sizehint(x)
+    end
     # specialized for performance reasons
-    s = IOBuffer(sizehint=tostr_sizehint(xs[1]))
-    if env !== nothing
-        env_io = IOContext(s, env)
-        for x in xs
-            print(env_io, x)
-        end
-    else
-        for x in xs
-            print(s, x)
-        end
+    s = IOBuffer(sizehint=siz)
+    for x in xs
+        print(s, x)
     end
     String(resize!(s.data, s.size))
 end
 
-string_with_env(env, xs...) = print_to_string(xs...; env=env)
+function string_with_env(env, xs...)
+    if isempty(xs)
+        return ""
+    end
+    siz = 0
+    for x in xs
+        siz += tostr_sizehint(x)
+    end
+    # specialized for performance reasons
+    s = IOBuffer(sizehint=siz)
+    env_io = IOContext(s, env)
+    for x in xs
+        print(env_io, x)
+    end
+    String(resize!(s.data, s.size))
+end
 
 """
     string(xs...)

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -34,6 +34,7 @@ using Random
     @test string("∀∃", "1∀∃") === "∀∃1∀∃"
     @test string(SubString("∀∃"), SubString("1∀∃", 2)) === "∀∃∀∃"
     @test string(s"123") === s"123"
+    @test string("123", 'α', SubString("1∀∃", 2), 'a', "foo") === "123α∀∃afoo"
     codegen_egal_of_strings(x, y) = (x===y, x!==y)
     @test codegen_egal_of_strings(string("ab", 'c'), "abc") === (true, false)
     let strs = ["", "a", "a b c", "до свидания"]


### PR DESCRIPTION
Before:

```
julia> @btime string('a') # what is even going on here...
  732.898 ns (4 allocations: 192 bytes)
"a"

julia> @btime string('a', "aa")
  168.540 ns (4 allocations: 192 bytes)
"aaa"

julia> @btime string("a", 'a', 3)
  467.898 ns (6 allocations: 288 bytes)
"aa3"

julia> @btime string('a', 3, "fdsfhjsdfjdlsfjldsjflsdjfkldsjflksdjflkdsjfldsjfk")
  537.153 ns (7 allocations: 368 bytes)
"a3fdsfhjsdfjdlsfjldsjflsdjfkldsjflksdjflkdsjfldsjfk"
```

After:

```
julia> @btime string('a')
  12.222 ns (1 allocation: 32 bytes)
"a"

julia> @btime string('a', "aa")
  37.108 ns (2 allocations: 64 bytes)
"aaa"

julia> @btime string("a", 'a', 3)
  293.483 ns (5 allocations: 272 bytes)
"aa3"

julia> @btime string('a', 3, "fdsfhjsdfjdlsfjldsjflsdjfkldsjflksdjflkdsjfldsjfk")
  313.825 ns (5 allocations: 320 bytes)
"a3fdsfhjsdfjdlsfjldsjflsdjfkldsjflksdjflkdsjfldsjfk"
```

Ref JuliaLang/LinearAlgebra.jl#557 
