### PR TITLE
Move codelen and first_utf8_byte to Char.jl

### DIFF
--- a/base/char.jl
+++ b/base/char.jl
@@ -196,6 +196,9 @@ isless(x::Char, y::Char) = reinterpret(UInt32, x) < reinterpret(UInt32, y)
 hash(x::Char, h::UInt) =
     hash_uint64(((reinterpret(UInt32, x) + UInt64(0xd4d64234)) << 32) ⊻ UInt64(h))
 
+first_utf8_byte(c::Char) = (reinterpret(UInt32, c) >> 24) % UInt8
+codelen(c::Char) = 4 - (trailing_zeros(0xff000000 | reinterpret(UInt32, c)) >> 3)
+
 # fallbacks:
 isless(x::AbstractChar, y::AbstractChar) = isless(Char(x), Char(y))
 ==(x::AbstractChar, y::AbstractChar) = Char(x) == Char(y)

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -293,16 +293,9 @@ length(s::String) = length(s, 1, ncodeunits(s), ncodeunits(s))
     end
 end
 
-# TODO: delete or move to char.jl
-first_utf8_byte(c::Char) = (reinterpret(UInt32, c) >> 24) % UInt8
-
 ## overload methods for efficiency ##
 
 isvalid(s::String, i::Int) = checkbounds(Bool, s, i) && thisind(s, i) == i
-
-# UTF-8 encoding length of a character
-# TODO: delete or move to char.jl
-codelen(c::Char) = 4 - (trailing_zeros(0xff000000 | reinterpret(UInt32, c)) >> 3)
 
 """
     repeat(c::AbstractChar, r::Integer) -> String


### PR DESCRIPTION
Cleanup of `codelen` and `first_utf8_byte` location. Both functions are used in Base, so I think we should keep them (#28876 makes use of `codelen` and `first_utf8_byte` is used in searches).