### PR TITLE
Issue #27957: diff(ones(6),dims=1) gives error

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -652,12 +652,20 @@ end
     end
 end
 
+function diff(a::AbstractVector)
+    @assert !has_offset_axes(a)
+    [ a[i+1] - a[i] for i=1:length(a)-1 ]
+end
+
 function diff(a::AbstractArray)
     @assert !has_offset_axes(a)
     [ a[i+1] - a[i] for i=1:length(a)-1 ]
 end
 
 """
+    diff(A::AbstractVector)
+    diff(A::AbstractMatrix; dims::Integer)
+
     diff(A::AbstractArray)
     diff(A::AbstractArray; dims::Integer)
 
@@ -683,6 +691,16 @@ julia> diff(vec(a))
  12
 ```
 """
+function diff(A::AbstractMatrix; dims::Integer)
+    if dims == 1
+        [A[i+1,j] - A[i,j] for i=1:size(A,1)-1, j=1:size(A,2)]
+    elseif dims == 2
+        [A[i,j+1] - A[i,j] for i=1:size(A,1), j=1:size(A,2)-1]
+    else
+        throw(ArgumentError("dimension must be 1 or 2, got $dims"))
+    end
+end
+
 function diff(A::AbstractArray; dims::Integer)
     if dims == 1
         [A[i+1,j] - A[i,j] for i=1:size(A,1)-1, j=1:size(A,2)]

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -652,14 +652,14 @@ end
     end
 end
 
-function diff(a::AbstractVector)
+function diff(a::AbstractArray)
     @assert !has_offset_axes(a)
     [ a[i+1] - a[i] for i=1:length(a)-1 ]
 end
 
 """
-    diff(A::AbstractVector)
-    diff(A::AbstractMatrix; dims::Integer)
+    diff(A::AbstractArray)
+    diff(A::AbstractArray; dims::Integer)
 
 Finite difference operator of matrix or vector `A`. If `A` is a matrix,
 specify the dimension over which to operate with the `dims` keyword argument.
@@ -683,7 +683,7 @@ julia> diff(vec(a))
  12
 ```
 """
-function diff(A::AbstractMatrix; dims::Integer)
+function diff(A::AbstractArray; dims::Integer)
     if dims == 1
         [A[i+1,j] - A[i,j] for i=1:size(A,1)-1, j=1:size(A,2)]
     elseif dims == 2


### PR DESCRIPTION
AbstractVector is the supertype for 1-D arrays, while AbstractMatrix is the subtype for 2-D arrays. So, for diff function instead of having exclusive parameters as AbstractVector or AbstractMatrix, changing the parameter to AbstarctArray will solve the bug number: #27957 