### PR TITLE
Some debugging robustness for early boostrap

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -735,6 +735,8 @@ JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t sz)
 {
     maybe_collect(ptls);
     size_t offs = offsetof(bigval_t, header);
+    assert(sz >= sizeof(jl_taggedvalue_t) && "sz must include tag");
+    static_assert(offsetof(bigval_t, header) >= sizeof(void*), "Empty bigval header?");
     static_assert(sizeof(bigval_t) % JL_HEAP_ALIGNMENT == 0, "");
     size_t allocsz = LLT_ALIGN(sz + offs, JL_CACHE_BYTE_ALIGNMENT);
     if (allocsz < sz)  // overflow in adding offs, size was "negative"


### PR DESCRIPTION
As a weekend project, I played with bootstrapping the julia runtime on a new platform. Didn't get very far, but I'd have gotten farther with these changes. The first makes `jl_` more robust during early bootstrap (useful if you memory allocator is broken and things crash during early bootstrap). The second adds an assertion that would have caught my particular issue.