### PR TITLE
doc: fix accumulate examples not using the init keyword

### DIFF
--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -628,10 +628,10 @@ or [`nothing`](@ref) if the string does not contain a valid number.
 """
 ```
 
-This will create a link in the generated docs to the `parse` documentation
-(which has more information about what this function actually does). It's good to include
-cross references to mutating/non-mutating versions of a function, or to highlight a difference
-between two similar-seeming functions.
+This will create a link in the generated docs to the [`parse`](@ref) documentation
+(which has more information about what this function actually does), and to the
+[`nothing`](@ref) documentation. It's good to include cross references to mutating/non-mutating
+versions of a function, or to highlight a difference between two similar-seeming functions.
 
 !!! note
     The above cross referencing is *not* a Markdown feature, and relies on

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -621,13 +621,14 @@ the Julia documentation itself. For example:
 
 ```julia
 """
-    accumulate!(op, y, x)
+    tryparse(type, str; base)
 
-Cumulative operation `op` on a vector `x`, storing the result in `y`. See also [`accumulate`](@ref).
+Like [`parse`](@ref), but returns either a value of the requested type,
+or [`nothing`](@ref) if the string does not contain a valid number.
 """
 ```
 
-This will create a link in the generated docs to the `accumulate` documentation
+This will create a link in the generated docs to the `parse` documentation
 (which has more information about what this function actually does). It's good to include
 cross references to mutating/non-mutating versions of a function, or to highlight a difference
 between two similar-seeming functions.

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -465,7 +465,7 @@ julia> function g_fix(r)
 g_fix (generic function with 1 method)
 
 julia>  r = let m = MersenneTwister(1)
-                [m; accumulate(Future.randjump, m, fill(big(10)^20, nthreads()-1))]
+                [m; accumulate(Future.randjump, fill(big(10)^20, nthreads()-1), init=m)]
             end;
 
 julia> g_fix(r)


### PR DESCRIPTION
I replaced `accumulate!` with `tryparse` in one example because it's the first fitting function I found whose docstring was actually short (compared to that of `accumulate!`).