### PR TITLE
update push! & append! docstrings (wrt orderedness)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -830,7 +830,8 @@ _deleteat!(a::Vector, i::Integer, delta::Integer) =
 """
     push!(collection, items...) -> collection
 
-Insert one or more `items` at the end of `collection`.
+Insert one or more `items` in `collection`. If `collection` is an ordered container,
+the items are inserted at the end (in the given order).
 
 # Examples
 ```jldoctest
@@ -844,9 +845,9 @@ julia> push!([1, 2, 3], 4, 5, 6)
  6
 ```
 
-Use [`append!`](@ref) to add all the elements of another collection to
-`collection`. The result of the preceding example is equivalent to `append!([1, 2, 3], [4,
-5, 6])`.
+If `collection` is ordered, use [`append!`](@ref) to add all the elements of another
+collection to it. The result of the preceding example is equivalent to `append!([1, 2, 3], [4,
+5, 6])`. For `AbstractSet` objects, [`union!`](@ref) can be used instead.
 """
 function push! end
 
@@ -867,7 +868,7 @@ end
 """
     append!(collection, collection2) -> collection.
 
-Add the elements of `collection2` to the end of `collection`.
+For an ordered container `collection`, add the elements of `collection2` to the end of it.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
`Base` provides implementation of `append!` only for vectors, but the docstring didn't give any constraint on the input collection. I added that it must be "ordered", but are there methods somewhere which implement `append!` for non-`AbstractVector` ?