### PR TITLE
doc: Fix call to round for Julia 1.0

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1086,7 +1086,7 @@ julia> for p in workers() # start tasks on the workers to process requests in pa
 
 julia> @elapsed while n > 0 # print out results
            job_id, exec_time, where = take!(results)
-           println("$job_id finished in $(round(exec_time,2)) seconds on worker $where")
+           println("$job_id finished in $(round(exec_time; digits=2)) seconds on worker $where")
            n = n - 1
        end
 1 finished in 0.18 seconds on worker 4


### PR DESCRIPTION
This is a very minor fix to the documentation. In #28800 I did some updates to `parallel-computing.md`, and I have just realized there was another example that is not 1.0 compliant.

I have gone through the rest of the examples in this document, and I think the rest of examples are all compliant.