### PR TITLE
Add julia line to compat example

### DIFF
--- a/stdlib/Pkg/docs/src/index.md
+++ b/stdlib/Pkg/docs/src/index.md
@@ -734,6 +734,7 @@ Compatibility for a dependency is entered in the `Project.toml` file as for exam
 
 ```toml
 [compat]
+julia = "1.0"
 Example = "0.4.3"
 ```
 


### PR DESCRIPTION
Add `julia = "1.0"` to compat example in Compatibility section.  Since julia is not a package, it's not obvious this is the place to put this, so adding the explicit example is helpful.