### PR TITLE
Getting Started: Capitalize "CPU" for consistency

### DIFF
--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -111,7 +111,7 @@ julia [switches] -- [programfile] [args...]
 |`--history-file={yes\|no}`             |Load or save history|
 |`--depwarn={yes\|no\|error}`           |Enable or disable syntax and method deprecation warnings (`error` turns warnings into errors)|
 |`--warn-overwrite={yes\|no}`           |Enable or disable method overwrite warnings|
-|`-C`, `--cpu-target <target>`          |Limit usage of cpu features up to <target>; set to `help` to see the available options|
+|`-C`, `--cpu-target <target>`          |Limit usage of CPU features up to `<target>`; set to `help` to see the available options|
 |`-O`, `--optimize={0,1,2,3}`           |Set the optimization level (default level is 2 if unspecified or 3 if used without a level)|
 |`-g`, `-g <level>`                     |Enable / Set the level of debug info generation (default level is 1 if unspecified or 2 if used without a level)|
 |`--inline={yes\|no}`                   |Control whether inlining is permitted, including overriding `@inline` declarations|

--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -110,7 +110,7 @@ static const char opts[]  =
 
     // code generation options
     //" --compile={yes|no|all|min}Enable or disable JIT compiler, or request exhaustive compilation\n"
-    " -C, --cpu-target <target> Limit usage of cpu features up to <target>; set to \"help\" to see the available options\n"
+    " -C, --cpu-target <target> Limit usage of CPU features up to <target>; set to \"help\" to see the available options\n"
     " -O, --optimize={0,1,2,3}  Set the optimization level (default level is 2 if unspecified or 3 if used without a level)\n"
     " -g, -g <level>            Enable / Set the level of debug info generation"
 #ifdef JL_DEBUG_BUILD


### PR DESCRIPTION
Minor style fix in docs: "CPU" is capitalized elsewhere in the manual; capitalize it here too.

Also style "<target>" in monospaced font, as code snippets elsewhere are styled.