### PR TITLE
Fix History `eye` deprecation PR: should be 24415

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -625,7 +625,7 @@ Library improvements
   * The `crc32c` function for CRC-32c checksums is now exported ([#22274]).
 
   * `eye(::Type{Diagonal{T}}, m::Integer)` has been deprecated in favor of
-    `Diagonal{T}(I, m)` ([#24413]).
+    `Diagonal{T}(I, m)` ([#24415]).
 
   * The output of `versioninfo` is now controlled with keyword arguments ([#21974]).
 
@@ -1575,6 +1575,7 @@ Command-line option changes
 [#24404]: https://github.com/JuliaLang/julia/issues/24404
 [#24413]: https://github.com/JuliaLang/julia/issues/24413
 [#24414]: https://github.com/JuliaLang/julia/issues/24414
+[#24415]: https://github.com/JuliaLang/julia/issues/24415
 [#24438]: https://github.com/JuliaLang/julia/issues/24438
 [#24445]: https://github.com/JuliaLang/julia/issues/24445
 [#24452]: https://github.com/JuliaLang/julia/issues/24452


### PR DESCRIPTION
The History.md file linked to #24413 for `eye` deprecation in 0.7. This commit changes it to link to #24415.

It looks like it was a typo, since 24413 was already used on that page, and is about deprecating `fill!`. I _think_ 24415 is the correct new number, but i'm not 100% positive.