### PR TITLE
RFC: implement a biased rand(a:b) (fix #20582)

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -303,6 +303,11 @@ julia> rand(Int, 2)
 julia> rand(MersenneTwister(0), Dict(1=>2, 3=>4))
 1=>2
 ```
+As an experimental feature, it's possible to obtain faster sampling from an array
+(in particular ranges) at the cost of getting a possibly biased distribution,
+by wrapping the array in a call to the `Random.fast` function,
+e.g. `rand(Random.fast(1:10))`. It is not recommended to use this method
+for arrays of big length (in particular of the order of 2^52 or greater).
 
 !!! note
     The complexity of `rand(rng, s::Union{AbstractDict,AbstractSet})`

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -694,3 +694,10 @@ end
     a = rand(Int, 1)
     @test shuffle(a) == a
 end
+
+@testset "fast(a:b)" begin
+    for bounds = (rand(Int, 2), rand(-1000:1000, 2))
+        a, b = minmax(bounds...)
+        @test rand(fast(a:b)) ∈ a:b
+    end
+end


### PR DESCRIPTION
See #20582 for details. This basically uses `a+floor(Int,n*rand())` to get a random number in `a:a+n-1`. This can be significantly faster than regular `rand(a:b)`, but introduces a bias. I don't have a strong opininion about this, but thought that having a PR could move the discussion forward.

This also implements `rand(fast(a))` where `a` is an array, but for some reason this allocates, which trumps the benefits. I have no idea why this is so, as the implementation is simpler for `rand(fast(a))` than for `rand(a)`... any help to sort this out would be appreciated!