### PR TITLE
Generalize condition in is_known_call

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -279,7 +279,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
             else
                 def = compact[leaf]
             end
-            if is_tuple_call(compact.ir, def) && isa(field, Int) && 1 <= field < length(def.args)
+            if is_tuple_call(compact, def) && isa(field, Int) && 1 <= field < length(def.args)
                 lifted = def.args[1+field]
                 if isa(leaf, OldSSAValue) && isa(lifted, SSAValue)
                     lifted = OldSSAValue(lifted.id)

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -74,5 +74,5 @@ function is_known_call(e::Expr, @nospecialize(func), src::IncrementalCompact)
         return false
     end
     f = compact_exprtype(src, e.args[1])
-    return isa(f, Const) && f.val === func
+    return singleton_type(f) === func
 end

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -19,7 +19,8 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, spvals::S
         ea = e.args
         if head === :call
             f = argextype(ea[1], src, spvals)
-            f = isa(f, Const) ? f.val : isType(f) ? f.parameters[1] : return false
+            f = singleton_type(f)
+            f === nothing && return false
             is_return_type(f) && return true
             contains_is(_PURE_BUILTINS, f) && return true
             contains_is(_PURE_OR_ERROR_BUILTINS, f) || return false


### PR DESCRIPTION
We're not consistent about whether singletons are represented as
Consts or as types (particularly after round-tripping through
a representation that doesn't have `Const`). As such, it is
easy for the compiler to miss calls.