### PR TITLE
stdlib/Pkg: build without startup file by default

### DIFF
--- a/stdlib/Pkg/src/Operations.jl
+++ b/stdlib/Pkg/src/Operations.jl
@@ -1045,7 +1045,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
             """
         cmd = ```
             $(Base.julia_cmd()) -O0 --color=no --history-file=no
-            --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
+            --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
             --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
             --eval $code
             ```


### PR DESCRIPTION
My startup file interfered with a package build and led to an error.
I feel like loading the startup file for building shouldn't be the default (it isn't the default for testing either).

Sidenote: the BigProject test for Pkg is failing for me because of my startup file, but that is a different issue.