### PR TITLE
Add local to for outer description

### DIFF
--- a/doc/src/manual/variables-and-scoping.md
+++ b/doc/src/manual/variables-and-scoping.md
@@ -449,7 +449,7 @@ julia> f()
 0
 ```
 
-However, it is occasionally useful to reuse an existing variable as the iteration variable.
+However, it is occasionally useful to reuse an existing local variable as the iteration variable.
 This can be done conveniently by adding the keyword `outer`:
 
 ```jldoctest

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2430,7 +2430,7 @@
          '(null))
         ((eq? (car e) 'require-existing-local)
          (if (not (memq (cadr e) env))
-             (error "no outer variable declaration exists for \"for outer\""))
+             (error "no outer local variable declaration exists for \"for outer\""))
          '(null))
         ((eq? (car e) 'lambda)
          (let* ((lv   (lam:vars e))

--- a/test/core.jl
+++ b/test/core.jl
@@ -3256,7 +3256,7 @@ let
     @test forouter() == 3
 end
 
-@test_throws ErrorException("syntax: no outer variable declaration exists for \"for outer\"") @eval function f()
+@test_throws ErrorException("syntax: no outer local variable declaration exists for \"for outer\"") @eval function f()
     for outer i = 1:2
     end
 end


### PR DESCRIPTION
`for outer` statement works only with local variables. This PR clarifies it in docs and error message.
The reason for this clarification is that users cannot use `for outer` with a global variable (and when doing copy-paste of code from local scope to global scope they do not understand why it fails).