### PR TITLE
Add handling of an empty iterator for mean and var

### DIFF
--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -57,7 +57,8 @@ julia> mean([√1, √2, √3])
 function mean(f::Base.Callable, itr)
     y = iterate(itr)
     if y === nothing
-        throw(ArgumentError("mean of empty collection undefined: $(repr(itr))"))
+        return Base.mapreduce_empty_iter(f, Base.add_sum, itr,
+                                         Base.IteratorEltype(itr)) / 0
     end
     count = 1
     value, state = y
@@ -148,7 +149,8 @@ var(iterable; corrected::Bool=true, mean=nothing) = _var(iterable, corrected, me
 function _var(iterable, corrected::Bool, mean)
     y = iterate(iterable)
     if y === nothing
-        throw(ArgumentError("variance of empty collection undefined: $(repr(iterable))"))
+        T = eltype(iterable)
+        return typeof((abs2(zero(T)) + abs2(zero(T)))/2)(NaN)
     end
     count = 1
     value, state = y

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -131,8 +131,8 @@ mean(A::AbstractArray; dims=:) = _mean(A, dims)
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
 _mean(A::AbstractArray, ::Colon) = sum(A) / length(A)
 
-function mean(r::AbstractRange{<:Real})
-    isempty(r) && throw(ArgumentError("mean of an empty range is undefined"))
+function Statistics.mean(r::AbstractRange{<:Real})
+    isempty(r) && return oftype((first(r) + last(r)) / 2, NaN)
     (first(r) + last(r)) / 2
 end
 
@@ -150,7 +150,7 @@ function _var(iterable, corrected::Bool, mean)
     y = iterate(iterable)
     if y === nothing
         T = eltype(iterable)
-        return typeof((abs2(zero(T)) + abs2(zero(T)))/2)(NaN)
+        return oftype((abs2(zero(T)) + abs2(zero(T)))/2, NaN)
     end
     count = 1
     value, state = y
@@ -267,7 +267,7 @@ varm(A::AbstractArray, m; corrected::Bool=true) = _varm(A, m, corrected, :)
 
 function _varm(A::AbstractArray{T}, m, corrected::Bool, ::Colon) where T
     n = length(A)
-    n == 0 && return typeof((abs2(zero(T)) + abs2(zero(T)))/2)(NaN)
+    n == 0 && return oftype((abs2(zero(T)) + abs2(zero(T)))/2, NaN)
     return centralize_sumabs2(A, m) / (n - Int(corrected))
 end
 

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -131,7 +131,7 @@ mean(A::AbstractArray; dims=:) = _mean(A, dims)
 _mean(A::AbstractArray{T}, region) where {T} = mean!(Base.reducedim_init(t -> t/2, +, A, region), A)
 _mean(A::AbstractArray, ::Colon) = sum(A) / length(A)
 
-function Statistics.mean(r::AbstractRange{<:Real})
+function mean(r::AbstractRange{<:Real})
     isempty(r) && return oftype((first(r) + last(r)) / 2, NaN)
     (first(r) + last(r)) / 2
 end

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -119,6 +119,8 @@ end
             @test f(2:0.1:n) ≈ f([2:0.1:n;])
         end
     end
+    @test mean(2:1) === NaN
+    @test mean(big(2):1) isa BigFloat
 end
 
 @testset "var & std" begin

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -87,18 +87,20 @@ end
     @test isequal(mean([missing 1.0; 2.0 3.0], dims=1), [missing 2.0])
     @test mean(skipmissing([1, missing, 2])) === 1.5
     @test isequal(mean(Complex{Float64}[]), NaN+NaN*im)
-    @test isequal(mean(skipmissing(Complex{Float64}[])), NaN+NaN*im)
     @test mean(Complex{Float64}[]) isa Complex{Float64}
+    @test isequal(mean(skipmissing(Complex{Float64}[])), NaN+NaN*im)
     @test mean(skipmissing(Complex{Float64}[])) isa Complex{Float64}
     @test isequal(mean(abs, Complex{Float64}[]), NaN)
-    @test isequal(mean(abs, skipmissing(Complex{Float64}[])), NaN)
     @test mean(abs, Complex{Float64}[]) isa Float64
+    @test isequal(mean(abs, skipmissing(Complex{Float64}[])), NaN)
     @test mean(abs, skipmissing(Complex{Float64}[])) isa Float64
+    @test isequal(mean(Int[]), NaN)
+    @test mean(Int[]) isa Float64
+    @test isequal(mean(skipmissing(Int[])), NaN)
+    @test mean(skipmissing(Int[])) isa Float64
     @test_throws MethodError mean([])
     @test_throws MethodError mean(skipmissing([]))
-    @test_throws MethodError mean((1 for i in 2:1))
-    @test mean(Int[]) isa Float64
-    @test mean(skipmissing(Int[])) isa Float64
+    @test_throws ArgumentError mean((1 for i in 2:1))
 
     # Check that small types are accumulated using wider type
     for T in (Int8, UInt8)
@@ -260,13 +262,15 @@ end
     end
 
     @test isequal(var(Complex{Float64}[]), NaN)
-    @test isequal(var(skipmissing(Complex{Float64}[])), NaN)
     @test var(Complex{Float64}[]) isa Float64
+    @test isequal(var(skipmissing(Complex{Float64}[])), NaN)
     @test var(skipmissing(Complex{Float64}[])) isa Float64
     @test_throws MethodError var([])
     @test_throws MethodError var(skipmissing([]))
-    @test_throws ArgumentError var((1 for i in 2:1))
+    @test_throws MethodError var((1 for i in 2:1))
+    @test isequal(var(Int[]), NaN)
     @test var(Int[]) isa Float64
+    @test isequal(var(skipmissing(Int[])), NaN)
     @test var(skipmissing(Int[])) isa Float64
 end
 

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -60,7 +60,7 @@ end
 end
 
 @testset "mean" begin
-    @test_throws ArgumentError mean(())
+    @test_throws MethodError mean(())
     @test mean((1,2,3)) === 2.
     @test mean([0]) === 0.
     @test mean([1.]) === 1.
@@ -88,8 +88,17 @@ end
     @test mean(skipmissing([1, missing, 2])) === 1.5
     @test isequal(mean(Complex{Float64}[]), NaN+NaN*im)
     @test isequal(mean(skipmissing(Complex{Float64}[])), NaN+NaN*im)
+    @test mean(Complex{Float64}[]) isa Complex{Float64}
+    @test mean(skipmissing(Complex{Float64}[])) isa Complex{Float64}
     @test isequal(mean(abs, Complex{Float64}[]), NaN)
     @test isequal(mean(abs, skipmissing(Complex{Float64}[])), NaN)
+    @test mean(abs, Complex{Float64}[]) isa Float64
+    @test mean(abs, skipmissing(Complex{Float64}[])) isa Float64
+    @test_throws MethodError mean([])
+    @test_throws MethodError mean(skipmissing([]))
+    @test_throws MethodError mean((1 for i in 2:1))
+    @test mean(Int[]) isa Float64
+    @test mean(skipmissing(Int[])) isa Float64
 
     # Check that small types are accumulated using wider type
     for T in (Int8, UInt8)
@@ -113,10 +122,10 @@ end
 @testset "var & std" begin
     # edge case: empty vector
     # iterable; this has to throw for type stability
-    @test_throws ArgumentError var(())
-    @test_throws ArgumentError var((); corrected=false)
-    @test_throws ArgumentError var((); mean=2)
-    @test_throws ArgumentError var((); mean=2, corrected=false)
+    @test_throws MethodError var(())
+    @test_throws MethodError var((); corrected=false)
+    @test_throws MethodError var((); mean=2)
+    @test_throws MethodError var((); mean=2, corrected=false)
     # reduction
     @test isnan(var(Int[]))
     @test isnan(var(Int[]; corrected=false))
@@ -250,8 +259,15 @@ end
         @test f(skipmissing([1, missing, 2]), 0) === f([1, 2], 0)
     end
 
-    @test isequal(mean(Complex{Float64}[]), NaN)
-    @test isequal(mean(skipmissing(Complex{Float64}[])), NaN)
+    @test isequal(var(Complex{Float64}[]), NaN)
+    @test isequal(var(skipmissing(Complex{Float64}[])), NaN)
+    @test var(Complex{Float64}[]) isa Float64
+    @test var(skipmissing(Complex{Float64}[])) isa Float64
+    @test_throws MethodError var([])
+    @test_throws MethodError var(skipmissing([]))
+    @test_throws ArgumentError var((1 for i in 2:1))
+    @test var(Int[]) isa Float64
+    @test var(skipmissing(Int[])) isa Float64
 end
 
 function safe_cov(x, y, zm::Bool, cr::Bool)

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -86,6 +86,10 @@ end
     @test ismissing(mean([missing, NaN]))
     @test isequal(mean([missing 1.0; 2.0 3.0], dims=1), [missing 2.0])
     @test mean(skipmissing([1, missing, 2])) === 1.5
+    @test isequal(mean(Complex{Float64}[]), NaN+NaN*im)
+    @test isequal(mean(skipmissing(Complex{Float64}[])), NaN+NaN*im)
+    @test isequal(mean(abs, Complex{Float64}[]), NaN)
+    @test isequal(mean(abs, skipmissing(Complex{Float64}[])), NaN)
 
     # Check that small types are accumulated using wider type
     for T in (Int8, UInt8)
@@ -245,6 +249,9 @@ end
         @test ismissing(f([missing, NaN], missing))
         @test f(skipmissing([1, missing, 2]), 0) === f([1, 2], 0)
     end
+
+    @test isequal(mean(Complex{Float64}[]), NaN)
+    @test isequal(mean(skipmissing(Complex{Float64}[])), NaN)
 end
 
 function safe_cov(x, y, zm::Bool, cr::Bool)


### PR DESCRIPTION
This is a follow up of #28777 fixing what is minimally needed to be consistent in Julia 1.0 between empty arrays and empty collections (needed for `skipmissing`).

Major cleanup of consistency of the outputs for different scenarios of application of functions from Statistics module are left for Julia 2.0.