### PR TITLE
RFC: Implement unique consistently

### DIFF
--- a/test/sets.jl
+++ b/test/sets.jl
@@ -381,6 +381,28 @@ end
     u = [1,2,5,1,3,2]
 end
 
+@testset "unique(!) types" begin
+    @test @inferred(unique!(collect(1:1))) == [1]
+    @test unique(Real[1., 1])::Vector{Real} == unique!(Real[1., 1])::Vector{Real} == [1.]
+    @test unique(Real[1, 1.])::Vector{Real} == unique!(Real[1, 1.])::Vector{Real} == [1]
+    for t in [Int, Integer, Any]
+        a = t[1,-1, 1, -1]
+        g = (x for x in a)
+        @test unique(abs,a)::typeof(a) == unique!(abs, copy(a))::typeof(a) == [1]
+        @test unique(a)::typeof(a) == unique!(copy(a))::typeof(a) == [1,-1]
+        @test unique(abs, g)::Vector{Int} == [1]
+        @test unique(g)::Vector{Int} == [1,-1]
+    end
+end
+
+@testset "unique!(f)" begin
+    a = [5, 1, 8, 9, 3, 4, 10, 7, 2, 6]
+    b = copy(a)
+    @test unique!(iseven, a) === a == [5, 8]
+    @test unique!(n -> n % 3, b) === b == [5, 1, 9]
+    @test unique!(n -> n % 3, Int[]) == Int[]
+end
+
 @testset "allunique" begin
     @test allunique([])
     @test allunique(Set())


### PR DESCRIPTION
This pull request updates the `unique[!]([f], itr)` implementation in sets.jl and achieves a couple of things:
 * Fixes https://github.com/JuliaLang/julia/issues/28415 by adding the missing `unqiue!(f,itr)`
 * Fixes https://github.com/JuliaLang/julia/issues/20105 but this time for `unique(f,itr)` instead of `unique(itr)`, meaning that unique(f, itr) will behave as unique(itr) regarding returned types.
 * Improves performance
 * Algorithms are implemented consistently for `unique[!]([f], itr)`
 
Remarks:
 * The documentation currently speaks of performance improvements if the data is sorted - this is not quite correct, as the performant sorted unqiue! algorithm is only available for a couple of types (`<:AbstractString, <:Real, <:Symbol`). Using `hasmethod` to assert sortability would be slow...
* I've toyed around with merging the sorting detection into the uniquifying loop, but the code quickly gets untidy and is not worth the hassle.

## Benchmarks 
#### Datasets
```
Dict(
    "Sparse random Any" => repeat(Any[1.,2.2,2,3,4,0x00,"String","Strong"],1000),
    "Dense random Any" => convert(Vector{Any},rand(rand([Float64,Int,Int16]),10000)),
    "Sparse sorted Int" => sort!(rand(1:100, 10000)),
    "Dense sorted Int" => sort!(rand(1:10000, 10000)),
    "Sparse random Int" => rand(1:10, 10000),
    "Dense random Int" => rand(1:10000, 10000),
    "Small random Int" => rand(1:5, 30))
```

#### `unique(itr)` and `unique(f,itr)`
```
 Dense random Any
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(-57.02% => improvement)
  "unique(generator)" => TrialJudgement(-36.85% => improvement)
  "unique(x*x,vector)" => TrialJudgement(-52.84% => improvement)

 Sparse sorted Int
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(-65.58% => improvement)
  "unique(generator)" => TrialJudgement(-5.16% => improvement)
  "unique(x*x,vector)" => TrialJudgement(-67.83% => improvement)

 Small random Int
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(-45.96% => improvement)
  "unique(generator)" => TrialJudgement(+2.59% => invariant)
  "unique(x*x,vector)" => TrialJudgement(-46.33% => improvement)

 Sparse random Any
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(+5.89% => regression)
  "unique(generator)" => TrialJudgement(-20.46% => improvement)
  "unique(x*x,vector)" => TrialJudgement(+8.33% => regression)

 Dense random Int
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(-60.12% => improvement)
  "unique(generator)" => TrialJudgement(-0.13% => invariant)
  "unique(x*x,vector)" => TrialJudgement(-57.74% => improvement)

 Dense sorted Int
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(-60.17% => improvement)
  "unique(generator)" => TrialJudgement(+2.06% => invariant)
  "unique(x*x,vector)" => TrialJudgement(-57.98% => improvement)

 Sparse random Int
3-element BenchmarkTools.BenchmarkGroup:
  tags: []
  "unique(x*x,generator)" => TrialJudgement(-41.09% => improvement)
  "unique(generator)" => TrialJudgement(-4.47% => invariant)
  "unique(x*x,vector)" => TrialJudgement(-42.47% => improvement)
```

#### `unique!(itr)`

```
  "Dense random Any" => TrialJudgement(-59.70% => improvement)
  "Sparse sorted Int" => TrialJudgement(-67.74% => improvement)
  "Small random Int" => TrialJudgement(-8.58% => improvement)
  "Sparse random Any" => TrialJudgement(+8.40% => regression)
  "Dense random Int" => TrialJudgement(-7.46% => improvement)
  "Dense sorted Int" => TrialJudgement(-46.25% => improvement)
  "Sparse random Int" => TrialJudgement(-18.38% => improvement)
```
#### Discussion
* Sparse Random Any regression for `unqiue!` is understandable, as the default element type for the seen `Set` is currently `Any`