### PR TITLE
ComplexF64 division: combine four if-statements into two if-elseif-statements

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -360,8 +360,8 @@ inv(z::Complex{<:Union{Float16,Float32}}) =
 #             c + i*d
 function /(z::ComplexF64, w::ComplexF64)
     a, b = reim(z); c, d = reim(w)
-    @fastmath ab = max(abs(a), abs(b))
-    @fastmath cd = max(abs(c), abs(d))
+    absa = abs(a); absb = abs(b);  ab = absa >= absb ? absa : absb # equiv. to max(abs(a),abs(b)) but without NaN-handling (faster)
+    absc = abs(c); absd = abs(d);  cd = absc >= absd ? absc : absd
 
     # constants
     ov = floatmax(Float64)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -367,21 +367,21 @@ function /(z::ComplexF64, w::ComplexF64)
     ov = floatmax(Float64)
     un = floatmin(Float64)
     ϵ  = eps(Float64)
-    half = 0.5; halfov = half*ov
-    two = 2.0;  twounϵ = un*two/ϵ
-    bs = two/(ϵ*ϵ)
+    halfov = 0.5*ov
+    twounϵ = un*2.0/ϵ
+    bs = 2.0/(ϵ*ϵ)
 
     # scaling
     s = 1.0
     if ab >= halfov
-        a*=half; b*=half; s*=two  # scale down a,b
+        a*=0.5; b*=0.5; s*=2.0  # scale down a,b
     elseif ab <= twounϵ
-        a*=bs;   b*=bs;   s/=bs   # scale up a,b
+        a*=bs;  b*=bs;  s/=bs   # scale up a,b
     end
     if cd >= halfov
-        c*=half; d*=half; s*=half # scale down c,d
+        c*=0.5; d*=0.5; s*=0.5  # scale down c,d
     elseif cd <= twounϵ
-        c*=bs;   d*=bs;   s*=bs   # scale up c,d
+        c*=bs;  d*=bs;  s*=bs   # scale up c,d
     end
 
     # division operations

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -360,8 +360,8 @@ inv(z::Complex{<:Union{Float16,Float32}}) =
 #             c + i*d
 function /(z::ComplexF64, w::ComplexF64)
     a, b = reim(z); c, d = reim(w)
-    ab = max(abs(a), abs(b))
-    cd = max(abs(c), abs(d))
+    @fastmath ab = max(abs(a), abs(b))
+    @fastmath cd = max(abs(c), abs(d))
 
     # constants
     ov = floatmax(Float64)


### PR DESCRIPTION
This commit combines what was previously four `if`-statements into two `if`-`elseif`-statements in the implementation of over/underflow-proof complex division, i.e. of `/(z::ComplexF64, w::ComplexF64)`. This should allow branching to terminate sooner: in practice, testing with a pair of random numbers, I get a 1.22× speedup with this change.

The rewrite from four `if`-statements to two `if`-`elseif`-statements is allowable since `floatmax(Float64)/2 > floatmin(Float64)*2/eps(Float64)`, so the previous `ab`-pairs of `if`-statements cannot be reached simultaneously; similarly for the `cd`-pairs.

There's also some minor restructuring, just to make the function a simpler read.

Overall, complex division still seems surprisingly slow - certainly, the slowdown is greater than what was quoted in the [algorithm's paper](https://arxiv.org/pdf/1210.4539.pdf). Most of that might be due to additional branching though.