### PR TITLE
fix #28991, error when adding default defs to constructed module Exprs

### DIFF
--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -133,16 +133,19 @@
   (jl-expand-to-thunk
    (let* ((name (caddr e))
           (body (cadddr e))
-          (loc (cadr body))
-          (x (if (eq? name 'x) 'y 'x)))
+          (loc  (cadr body))
+          (loc  (if (and (pair? loc) (eq? (car loc) 'line))
+                    (list loc)
+                    '()))
+          (x    (if (eq? name 'x) 'y 'x)))
      `(block
        (= (call eval ,x)
           (block
-           ,loc
+           ,@loc
            (call (core eval) ,name ,x)))
        (= (call include ,x)
           (block
-           ,loc
+           ,@loc
            (call (top include) ,name ,x)))))))
 
 ;; parse only, returning end position, no expansion.

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1647,6 +1647,14 @@ end
 @test Meta.isexpr(Meta.parse("1 == 2 ?"), :incomplete)
 @test Meta.isexpr(Meta.parse("1 == 2 ? 3 :"), :incomplete)
 
+# issue #28991
+eval(Expr(:toplevel,
+          Expr(:module, true, :Mod28991,
+               Expr(:block,
+                    Expr(:export, :Inner),
+                    Expr(:abstract, :Inner)))))
+@test names(Mod28991) == Symbol[:Inner, :Mod28991]
+
 # issue #28593
 macro a28593()
     quote


### PR DESCRIPTION
The code for this expected the first element of a block to be a line number; check to make sure it is before using it.