### PR TITLE
Fix dispatch of SparseMatrixCSC*Diagonal multiplication

### DIFF
--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -982,7 +982,7 @@ function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, D::Diagonal{T, <:Vector}) 
     C
 end
 
-function mul!(C::SparseMatrixCSC, D::Diagonal{T, <:Vector}, A::SparseMatrixCSC) where T 
+function mul!(C::SparseMatrixCSC, D::Diagonal{T, <:Vector}, A::SparseMatrixCSC) where T
     m, n = size(A)
     b    = D.diag
     (m==length(b) && size(A)==size(C)) || throw(DimensionMismatch())

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -968,7 +968,7 @@ function copyinds!(C::SparseMatrixCSC, A::SparseMatrixCSC)
 end
 
 # multiply by diagonal matrix as vector
-function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, D::Diagonal{<:Vector})
+function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, D::Diagonal{T, <:Vector}) where T
     m, n = size(A)
     b    = D.diag
     (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
@@ -982,7 +982,7 @@ function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, D::Diagonal{<:Vector})
     C
 end
 
-function mul!(C::SparseMatrixCSC, D::Diagonal{<:Vector}, A::SparseMatrixCSC)
+function mul!(C::SparseMatrixCSC, D::Diagonal{T, <:Vector}, A::SparseMatrixCSC) where T 
     m, n = size(A)
     b    = D.diag
     (m==length(b) && size(A)==size(C)) || throw(DimensionMismatch())

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2300,7 +2300,7 @@ end
 @testset "Issue #28934" begin
     A = sprand(5,5,0.5)
     D = Diagonal(rand(5))
-    C = deepcopy(A)
+    C = copy(A)
     m1 = @which mul!(C,A,D)
     m2 = @which mul!(C,D,A)
     @test m1.module == SparseArrays

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -8,6 +8,7 @@ using LinearAlgebra
 using Base.Printf: @printf
 using Random
 using Test: guardseed
+using InteractiveUtils: @which
 
 @testset "issparse" begin
     @test issparse(sparse(fill(1,5,5)))
@@ -2293,6 +2294,17 @@ end
     a = SparseMatrixCSC{Int8, Int16}([1 2; 3 4])
     na = SparseMatrixCSC(a)
     @test typeof(a) === typeof(na)
+end
+
+#PR #29045
+@testset "Issue #28934" begin
+    A = sprand(5,5,0.5)
+    D = Diagonal(rand(5))
+    C = deepcopy(A)
+    m1 = @which mul!(C,A,D)
+    m2 = @which mul!(C,D,A)
+    @test m1.module == SparseArrays
+    @test m2.module == SparseArrays
 end
 
 end # module


### PR DESCRIPTION
This fixes #28934. In short, multiplication of a `SparseMatrixCSC` with a `Diagonal` matrix was getting dispatched to a generic matmul routine rather than the specialized methods defined at
https://github.com/JuliaLang/julia/blob/c8450d862f0e2653011f68118daecfe12b398c90/stdlib/SparseArrays/src/linalg.jl#L971
because the type signature of the diagonal matrix input in those methods was wrong, as pointed out by @GiggleLiu. 

Correctness of results is already tested at
https://github.com/JuliaLang/julia/blob/3fbdc9bbc97e4e5b1d682883ad9d14be5d65c862/stdlib/SparseArrays/test/sparse.jl#L314
I'm not sure how to write a test that checks that calling, say, `A*D` for compatible sparse and diagonal matrices dispatches to the right method. Is that doable/necessary?