### PR TITLE
RFC: Iterate over smaller set for setdiff[!](a,b)

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -67,6 +67,21 @@ rehash!(s::Set) = (rehash!(s.dict); s)
 
 iterate(s::Set, i...)       = iterate(KeySet(s.dict), i...)
 
+# get rid of pathological cases where length(s) <<< length(t)
+# the 0.5*length is a very conservative threshold
+function setdiff!(s::Set, t::Set)
+    if length(s) < length(t) * 0.5
+        for x in s
+            x in t && delete!(s, x)
+        end
+    else
+        for x in t
+            delete!(s, x)
+        end
+    end
+    return s
+end
+
 """
     unique(itr)
 

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -264,6 +264,14 @@ end
     s = Set([1,2,3,4])
     setdiff!(s, Set([2,4,5,6]))
     @test isequal(s,Set([1,3]))
+
+    # setdiff iterates the shorter set - make sure this algorithm works
+    sa, sb = Set([1,2,3,4,5,6,7]), Set([2,3,9])
+    @test Set([1,4,5,6,7]) == setdiff(sa, sb) !== sa
+    @test Set([1,4,5,6,7]) == setdiff!(sa, sb) === sa
+    sa, sb = Set([1,2,3,4,5,6,7]), Set([2,3,9])
+    @test Set([9]) == setdiff(sb, sa) !== sb
+    @test Set([9]) == setdiff!(sb, sa) === sb
 end
 
 @testset "ordering" begin


### PR DESCRIPTION
Attempt to fix https://github.com/JuliaLang/julia/issues/25317 by specialising on `setdiff!(a::Set, b::Set)` and iterating over `a` instead of `b` if `length(a) < length(b) * 0.5`. This `0.5` length threshold is a conservative guess after benchmarking has shown, that the iteration over `a` in case `length(a) == length(b)` slows down execution by ~20%.

`setdiff()` uses `setdiff!` internally, so both profit from the performance improvement.

## Benchmarks
#### Code:
```
using Combinatorics
s = Set.([[1],1:450_000,1:550_000,1:1_000_000]);
p = collect(permutations([1,2,3,4],2));
for x in p
    for f in [setdiff, setdiff!]
        l,r = length(s[x[1]]), length(s[x[2]])
        print(lpad(string(f,"(",l,",",r,"): "),28))
        @btime $(f)(y...) evals=1 setup=(y=($copy($s[$x[1]]),$copy($s[$x[2]])))
    end
end
```
#### Master:
```
         setdiff(1,450000):   11.234 ms (5 allocations: 496 bytes)
        setdiff!(1,450000):   11.197 ms (0 allocations: 0 bytes)
         setdiff(1,550000):   12.250 ms (5 allocations: 496 bytes)
        setdiff!(1,550000):   12.740 ms (0 allocations: 0 bytes)
        setdiff(1,1000000):   24.942 ms (5 allocations: 496 bytes)
       setdiff!(1,1000000):   25.276 ms (0 allocations: 0 bytes)
         setdiff(450000,1):   1.742 ms (7 allocations: 9.00 MiB)
        setdiff!(450000,1):   742.000 ns (0 allocations: 0 bytes)
    setdiff(450000,550000):   21.525 ms (7 allocations: 9.00 MiB)
   setdiff!(450000,550000):   18.574 ms (0 allocations: 0 bytes)
   setdiff(450000,1000000):   37.417 ms (7 allocations: 9.00 MiB)
  setdiff!(450000,1000000):   35.589 ms (0 allocations: 0 bytes)
         setdiff(550000,1):   1.719 ms (7 allocations: 9.00 MiB)
        setdiff!(550000,1):   409.000 ns (0 allocations: 0 bytes)
    setdiff(550000,450000):   20.650 ms (7 allocations: 9.00 MiB)
   setdiff!(550000,450000):   18.009 ms (0 allocations: 0 bytes)
   setdiff(550000,1000000):   40.565 ms (7 allocations: 9.00 MiB)
  setdiff!(550000,1000000):   38.338 ms (0 allocations: 0 bytes)
        setdiff(1000000,1):   4.435 ms (7 allocations: 18.00 MiB)
       setdiff!(1000000,1):   748.000 ns (0 allocations: 0 bytes)
   setdiff(1000000,450000):   22.211 ms (7 allocations: 18.00 MiB)
  setdiff!(1000000,450000):   18.457 ms (0 allocations: 0 bytes)
   setdiff(1000000,550000):   24.539 ms (7 allocations: 18.00 MiB)
  setdiff!(1000000,550000):   20.906 ms (0 allocations: 0 bytes)
```
#### This PR:
```
         setdiff(1,450000):   815.000 ns (5 allocations: 496 bytes)
        setdiff!(1,450000):   474.000 ns (0 allocations: 0 bytes)
         setdiff(1,550000):   916.000 ns (5 allocations: 496 bytes)
        setdiff!(1,550000):   414.000 ns (0 allocations: 0 bytes)
        setdiff(1,1000000):   1.813 μs (5 allocations: 496 bytes)
       setdiff!(1,1000000):   715.000 ns (0 allocations: 0 bytes)
         setdiff(450000,1):   1.579 ms (7 allocations: 9.00 MiB)
        setdiff!(450000,1):   341.000 ns (0 allocations: 0 bytes)
    setdiff(450000,550000):   20.185 ms (7 allocations: 9.00 MiB)
   setdiff!(450000,550000):   18.336 ms (0 allocations: 0 bytes)
   setdiff(450000,1000000):   18.241 ms (7 allocations: 9.00 MiB)
  setdiff!(450000,1000000):   16.689 ms (0 allocations: 0 bytes)
         setdiff(550000,1):   1.575 ms (7 allocations: 9.00 MiB)
        setdiff!(550000,1):   391.000 ns (0 allocations: 0 bytes)
    setdiff(550000,450000):   19.741 ms (7 allocations: 9.00 MiB)
   setdiff!(550000,450000):   17.697 ms (0 allocations: 0 bytes)
   setdiff(550000,1000000):   39.603 ms (7 allocations: 9.00 MiB)
  setdiff!(550000,1000000):   38.109 ms (0 allocations: 0 bytes)
        setdiff(1000000,1):   3.316 ms (7 allocations: 18.00 MiB)
       setdiff!(1000000,1):   705.000 ns (0 allocations: 0 bytes)
   setdiff(1000000,450000):   21.766 ms (7 allocations: 18.00 MiB)
  setdiff!(1000000,450000):   18.333 ms (0 allocations: 0 bytes)
   setdiff(1000000,550000):   24.342 ms (7 allocations: 18.00 MiB)
  setdiff!(1000000,550000):   21.027 ms (0 allocations: 0 bytes)
```
