### PR TITLE
work around a splatting penalty in twiceprecision

### DIFF
--- a/base/twiceprecision.jl
+++ b/base/twiceprecision.jl
@@ -332,11 +332,14 @@ const F_or_FF = Union{AbstractFloat, Tuple{AbstractFloat,AbstractFloat}}
 asF64(x::AbstractFloat) = Float64(x)
 asF64(x::Tuple{AbstractFloat,AbstractFloat}) = Float64(x[1]) + Float64(x[2])
 
+# Defined to prevent splatting in the function below which here has a performance impact
+_TP(x) = TwicePrecision{Float64}(x)
+_TP(x::Tuple{Any, Any}) = TwicePrecision{Float64}(x[1], x[2])
 function steprangelen_hp(::Type{Float64}, ref::F_or_FF,
                          step::F_or_FF, nb::Integer,
                          len::Integer, offset::Integer)
-    StepRangeLen(TwicePrecision{Float64}(ref...),
-                 twiceprecision(TwicePrecision{Float64}(step...), nb), Int(len), offset)
+    StepRangeLen(_TP(ref),
+                 twiceprecision(_TP(step), nb), Int(len), offset)
 end
 
 function steprangelen_hp(::Type{T}, ref::F_or_FF,

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1371,3 +1371,10 @@ end # module NonStandardIntegerRangeTest
         end
     end
 end
+
+@testset "allocation of TwicePrecision call" begin
+    0:286.493442:360
+    0:286:360
+    @test @allocated(0:286.493442:360) == 0
+    @test @allocated(0:286:360) == 0
+end


### PR DESCRIPTION
Before:

```
julia> @btime 0:$(286.493442):360
  1.648 μs (8 allocations: 352 bytes)
```

After:

```
julia> @btime 0:$(286.493442):360
  170.405 ns (0 allocations: 0 bytes)
```

Ref https://discourse.julialang.org/t/a-possible-regression-in-0-7/14597

The typed code before this PR looks like

```
julia> f() = Base.steprangelen_hp(Float64, 2.0, 25.0, 5, 10, 2)
f (generic function with 1 method)

julia> @code_typed f()
CodeInfo(
1 1 ─ %1  = (Core._apply)(TwicePrecision{Float64}, 2.0)::TwicePrecision{Float64}                                                                                                                                   │╻     steprangelen_hp
  │   %2  = (Core._apply)(TwicePrecision{Float64}, 25.0)::TwicePrecision{Float64}  
...           
```

so not sure why that is not devirtualized (if this is the correct term here).