### PR TITLE
fix #28506, consistently treat comma at end-of-input as incomplete

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,16 +4,23 @@ Julia v1.1.0 Release Notes
 New language features
 ---------------------
 
-  * `CartesianIndices` can now be constructed from two `CartesianIndex`es `I` and `J` with `I:J` ([#29440]).
-  * `isnothing(::Any)` function can now be called to check whether something is a `Nothing`, returns a `Bool` ([#29679])
 
 Language changes
 ----------------
 
-Standard Library Changes
+  * Parser inputs ending with a comma are now consistently treated as incomplete.
+    Previously they were sometimes parsed as tuples, depending on whitespace ([#28506]).
+
+New library functions
+---------------------
+
+  * `splitpath(p::String)` function, which is the opposite of `joinpath(parts...)`: it splits a filepath into its components ([#28156]).
+  * `isnothing(::Any)` function, to check whether something is a `Nothing`, returns a `Bool` ([#29679]).
+
+Standard library changes
 ------------------------
 
-  * New `splitpath(p::String)` function added, which is the opposite of `joinpath(parts...)`: it splits a filepath into its components ([#28156]).
+  * `CartesianIndices` can now be constructed from two `CartesianIndex`es `I` and `J` with `I:J` ([#29440]).
 
 Compiler/Runtime improvements
 -----------------------------

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -767,7 +767,7 @@
             ;; (ex1) => ex1
             (car ex))
         (begin (take-token s)
-               (if (or (eof-object? (peek-token s)) (eq? (peek-token s) '=))
+               (if (eq? (peek-token s) '=) ;; allow x, = ...
                    (loop ex #f (peek-token s))
                    (loop (cons (parse-pair s) ex) #f (peek-token s)))))))
 

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1735,3 +1735,11 @@ end
 @test Meta.parse("1..2") == Expr(:call, :.., 1, 2)
 # we don't parse chains of these since the associativity and meaning aren't clear
 @test_throws ParseError Meta.parse("1..2..3")
+
+# issue #28506
+@test Meta.isexpr(Meta.parse("1,"), :incomplete)
+@test Meta.isexpr(Meta.parse("1, "), :incomplete)
+@test Meta.isexpr(Meta.parse("1,\n"), :incomplete)
+@test Meta.isexpr(Meta.parse("1, \n"), :incomplete)
+@test_throws LoadError include_string(@__MODULE__, "1,")
+@test_throws LoadError include_string(@__MODULE__, "1,\n")


### PR DESCRIPTION
Previously, if the entire input to the parser ended in a comma (e.g. `"1,"`) we allowed parsing it (as `(1,)` in this example). But if you added a newline (`"1,\n"`) it was considered incomplete input. This changes it to be incomplete regardless of the newline. Among other things, this makes it easier to move code from functions to the REPL, as noted in the issue.

This is technically breaking but only affects (1) REPL inputs ending in commas, (2) files whose last character is a comma. I think both of these are not problematic and this could be merged in 1.1.