### PR TITLE
Adding Type argument to sprandn

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1471,12 +1471,13 @@ sprand(r::AbstractRNG, ::Type{Bool}, m::Integer, n::Integer, density::AbstractFl
 sprand(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T, m, n, density)
 
 """
-    sprandn([rng], m[,n],p::AbstractFloat)
+    sprandn([rng,] [T,] m, [n,] p::AbstractFloat)
 
 Create a random sparse vector of length `m` or sparse matrix of size `m` by `n`
 with the specified (independent) probability `p` of any entry being nonzero,
-where nonzero values are sampled from the normal distribution. The optional `rng`
-argument specifies a random number generator, see [Random Numbers](@ref).
+where nonzero values have type T and are sampled from the normal distribution.
+The optional `rng` argument specifies a random number generator, see
+[Random Numbers](@ref).
 
 # Examples
 ```jldoctest; setup = :(using Random; Random.seed!(0))
@@ -1488,6 +1489,8 @@ julia> sprandn(2, 2, 0.75)
 """
 sprandn(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,randn,Float64)
 sprandn(m::Integer, n::Integer, density::AbstractFloat) = sprandn(GLOBAL_RNG,m,n,density)
+sprandn(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r, T, m, n, density)
+sprandn(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprandn(GLOBAL_RNG, T, m, n, density)
 
 LinearAlgebra.fillstored!(S::SparseMatrixCSC, x) = (fill!(nzvalview(S), x); S)
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1489,7 +1489,7 @@ julia> sprandn(2, 2, 0.75)
 """
 sprandn(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,randn,Float64)
 sprandn(m::Integer, n::Integer, density::AbstractFloat) = sprandn(GLOBAL_RNG,m,n,density)
-sprandn(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r,m,n,density,randn,T)
+sprandn(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r,m,n,density,(r,i)->randn(r,T,i),T)
 sprandn(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprandn(GLOBAL_RNG,T,m,n,density)
 
 LinearAlgebra.fillstored!(S::SparseMatrixCSC, x) = (fill!(nzvalview(S), x); S)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1489,8 +1489,8 @@ julia> sprandn(2, 2, 0.75)
 """
 sprandn(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat) = sprand(r,m,n,density,randn,Float64)
 sprandn(m::Integer, n::Integer, density::AbstractFloat) = sprandn(GLOBAL_RNG,m,n,density)
-sprandn(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r, T, m, n, density)
-sprandn(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprandn(GLOBAL_RNG, T, m, n, density)
+sprandn(r::AbstractRNG, ::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprand(r,m,n,density,randn,T)
+sprandn(::Type{T}, m::Integer, n::Integer, density::AbstractFloat) where {T} = sprandn(GLOBAL_RNG,T,m,n,density)
 
 LinearAlgebra.fillstored!(S::SparseMatrixCSC, x) = (fill!(nzvalview(S), x); S)
 

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -506,6 +506,8 @@ sprand(::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T
 
 sprandn(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, randn)
 sprandn(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, randn)
+sprandn(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(r, n, p, (r, i) -> randn(r, T, i))
+sprandn(::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprandn(GLOBAL_RNG, T, n, p)
 
 ## Indexing into Matrices can return SparseVectors
 

--- a/stdlib/SparseArrays/test/sparsematrix.jl
+++ b/stdlib/SparseArrays/test/sparsematrix.jl
@@ -55,8 +55,8 @@ using Random
             @test sprand(r1, 10, 10, .9) == sprand(r2, 10, 10, .9)
             @test sprandn(r1, 10, 10, .9) == sprandn(r2, 10, 10, .9)
             @test sprand(r1, Bool, 10, 10, .9) == sprand(r2,  Bool, 10, 10, .9)
-            @test sprandn(r1, Float32, 10, 10, .9) == sprand(r2,  Float32, 10, 10, .9)
-            @test sprandn(r1, Complex{Float64}, 10, 10, .9) == sprand(r2,  Complex{Float64}, 10, 10, .9)
+            @test sprandn(r1, Float32, 10, 10, .9) == sprandn(r2,  Float32, 10, 10, .9)
+            @test sprandn(r1, Complex{Float64}, 10, 10, .9) == sprandn(r2,  Complex{Float64}, 10, 10, .9)
         end
     end
 

--- a/stdlib/SparseArrays/test/sparsematrix.jl
+++ b/stdlib/SparseArrays/test/sparsematrix.jl
@@ -1,0 +1,65 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+module SparseMatrixTests
+
+using Test
+using SparseArrays
+using Random
+
+@testset "other constructors" begin
+
+    @testset "sprand & sprandn" begin
+        let xr = sprand(30, 30, 0.9)
+            @test isa(xr, SparseMatrixCSC{Float64,Int})
+            @test size(xr) == (30, 30)
+            @test all(nonzeros(xr) .>= 0.0)
+        end
+
+        let xr = sprand(Float32, 30, 30, 0.9)
+            @test isa(xr, SparseMatrixCSC{Float32,Int})
+            @test size(xr) == (30, 30)
+            @test all(nonzeros(xr) .>= 0.0)
+        end
+
+        let xr = sprandn(30, 30, 0.9)
+            @test isa(xr, SparseMatrixCSC{Float64,Int})
+            @test size(xr) == (30, 30)
+            if !isempty(nonzeros(xr))
+                @test any(nonzeros(xr) .> 0.0) && any(nonzeros(xr) .< 0.0)
+            end
+        end
+
+        let xr = sprandn(Float32, 30, 30, 0.9)
+            @test isa(xr, SparseMatrixCSC{Float32,Int})
+            @test size(xr) == (30, 30)
+            if !isempty(nonzeros(xr))
+                @test any(nonzeros(xr) .> 0.0) && any(nonzeros(xr) .< 0.0)
+            end
+        end
+
+        let xr = sprandn(Complex{Float64}, 30, 30, 0.9)
+            @test isa(xr, SparseMatrixCSC{Complex{Float64},Int})
+            @test size(xr) == (30, 30)
+            if !isempty(nonzeros(xr))
+                @test any(real.(nonzeros(xr)) .> 0.0) && any(real.(nonzeros(xr)) .< 0.0) && any(imag.(nonzeros(xr)) .> 0.0) && any(imag.(nonzeros(xr)) .< 0.0)
+            end
+        end
+
+        let xr = sprand(Bool, 30, 30, 0.9)
+            @test isa(xr, SparseMatrixCSC{Bool,Int})
+            @test size(xr) == (30, 30)
+            @test all(nonzeros(xr))
+        end
+
+        let r1 = MersenneTwister(0), r2 = MersenneTwister(0)
+            @test sprand(r1, 10, 10, .9) == sprand(r2, 10, 10, .9)
+            @test sprandn(r1, 10, 10, .9) == sprandn(r2, 10, 10, .9)
+            @test sprand(r1, Bool, 10, 10, .9) == sprand(r2,  Bool, 10, 10, .9)
+            @test sprandn(r1, Float32, 10, 10, .9) == sprand(r2,  Float32, 10, 10, .9)
+            @test sprandn(r1, Complex{Float64}, 10, 10, .9) == sprand(r2,  Complex{Float64}, 10, 10, .9)
+        end
+    end
+
+end
+
+end # module

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -180,8 +180,8 @@ end
             @test sprand(r1, 100, .9) == sprand(r2, 100, .9)
             @test sprandn(r1, 100, .9) == sprandn(r2, 100, .9)
             @test sprand(r1, Bool, 100, .9) == sprand(r2,  Bool, 100, .9)
-            @test sprandn(r1, Float32, 100, .9) == sprand(r2,  Float32, 100, .9)
-            @test sprandn(r1, Complex{Float64}, 100, .9) == sprand(r2,  Complex{Float64}, 100, .9)
+            @test sprandn(r1, Float32, 100, .9) == sprandn(r2, Float32, 100, .9)
+            @test sprandn(r1, Complex{Float64}, 100, .9) == sprandn(r2, Complex{Float64}, 100, .9)
         end
     end
 end

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -166,7 +166,7 @@ end
             @test isa(xr, SparseVector{Complex{Float64},Int})
             @test length(xr) == 1000
             if !isempty(nonzeros(xr))
-                @test any(nonzeros(xr) .> 0.0) && any(nonzeros(xr) .< 0.0)
+                @test any(real.(nonzeros(xr)) .> 0.0) && any(real.(nonzeros(xr)) .< 0.0) && any(imag.(nonzeros(xr)) .> 0.0) && any(imag.(nonzeros(xr)) .< 0.0)
             end
         end
 

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -180,6 +180,8 @@ end
             @test sprand(r1, 100, .9) == sprand(r2, 100, .9)
             @test sprandn(r1, 100, .9) == sprandn(r2, 100, .9)
             @test sprand(r1, Bool, 100, .9) == sprand(r2,  Bool, 100, .9)
+            @test sprandn(r1, Float32, 100, .9) == sprand(r2,  Float32, 100, .9)
+            @test sprandn(r1, Complex{Float64}, 100, .9) == sprand(r2,  Complex{Float64}, 100, .9)
         end
     end
 end

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -154,6 +154,22 @@ end
             end
         end
 
+        let xr = sprandn(Float32, 1000, 0.9)
+            @test isa(xr, SparseVector{Float32,Int})
+            @test length(xr) == 1000
+            if !isempty(nonzeros(xr))
+                @test any(nonzeros(xr) .> 0.0) && any(nonzeros(xr) .< 0.0)
+            end
+        end
+
+        let xr = sprandn(Complex{Float64}, 1000, 0.9)
+            @test isa(xr, SparseVector{Complex{Float64},Int})
+            @test length(xr) == 1000
+            if !isempty(nonzeros(xr))
+                @test any(nonzeros(xr) .> 0.0) && any(nonzeros(xr) .< 0.0)
+            end
+        end
+
         let xr = sprand(Bool, 1000, 0.9)
             @test isa(xr, SparseVector{Bool,Int})
             @test length(xr) == 1000

--- a/stdlib/SparseArrays/test/testgroups
+++ b/stdlib/SparseArrays/test/testgroups
@@ -1,3 +1,4 @@
 higherorderfns
 sparse
 sparsevector
+sparsematrix


### PR DESCRIPTION
This is a shot at solving #29018. I added tests for the `Vector` cases, but not for the `Matrix` case: these are nowhere to be found for `sprand` and `sprandn`. Or am I missing something?

In addition to this, I did minor rephrasing to the docstring, in particular to how optional arguments are listed: it makes more sense to me like this.

First PR, go easy on me :-)