### PR TITLE
fix #29036, large slowdown in DelimitedFiles

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -57,7 +57,7 @@ end
 
 # this allows partial evaluation of bounded sequences of next() calls on tuples,
 # while reducing to plain next() for arbitrary iterables.
-indexed_iterate(t::Tuple, i::Int, state=1) = (@_inline_meta; (t[i], i+1))
+indexed_iterate(t::Tuple, i::Int, state=1) = (@_inline_meta; (getfield(t, i), i+1))
 indexed_iterate(a::Array, i::Int, state=1) = (@_inline_meta; (a[i], i+1))
 function indexed_iterate(I, i)
     x = iterate(I)

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1916,16 +1916,19 @@
                                     (ssavalue? x))
                                 x (make-ssavalue)))
                        (ini (if (eq? x xx) '() `((= ,xx ,(expand-forms x)))))
+                       (n   (length lhss))
                        (st  (gensy)))
                   `(block
                     ,@ini
                     ,.(map (lambda (i lhs)
                              (expand-forms
                               (lower-tuple-assignment
-                               (list lhs st)
+                               (if (= i (- n 1))
+                                   (list lhs)
+                                   (list lhs st))
                                `(call (top indexed_iterate)
                                       ,xx ,(+ i 1) ,.(if (eq? i 0) '() `(,st))))))
-                           (iota (length lhss))
+                           (iota n)
                            lhss)
                     (unnecessary ,xx))))))
          ((typed_hcat)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1990,3 +1990,10 @@ struct VoxelIndices{T <: Integer}
 end
 f28641(x::VoxelIndices, f) = getfield(x, f)
 @test Base.return_types(f28641, (Any,Symbol)) == Any[Tuple]
+
+# issue #29036
+function f29036(s, i)
+    val, i = iterate(s, i)
+    val
+end
+@test Base.return_types(f29036, (String, Int)) == Any[Char]


### PR DESCRIPTION
Fixes #29036.
The cause was poor inference of `val,i = iterate(x,i)`. From the commit message:

In this case, the result of `iterate` has not been checked for `nothing`, so we try to call `indexed_iterate` (for destructuring assignment) on a Union of Nothing and the tuple returned by `iterate`. That has two method matches, and so was excluded from constant propagation. This commit fixes that by generalizing the constant prop heuristic from requiring one method match to requiring one non-Bottom method match.
