### PR TITLE
fix logic in `getfield_nothrow` to allow removing more getfields

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -537,8 +537,10 @@ function getfield_nothrow(@nospecialize(s00), @nospecialize(name), @nospecialize
             sv = s00.val
         end
         if isa(name, Const)
-            (isa(sv, Module) && isa(name.val, Symbol)) || return false
-            (isa(name.val, Symbol) || isa(name.val, Int)) || return false
+            if !isa(name.val, Symbol)
+                isa(sv, Module) && return false
+                isa(name.val, Int) || return false
+            end
             return isdefined(sv, name.val)
         end
         if bounds_check_disabled && !isa(sv, Module)

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -137,3 +137,7 @@ end
     (src, _) = code_typed(sum27403, Tuple{Vector{Int}})[1]
     @test !any(x -> x isa Expr && x.head === :invoke, src.code)
 end
+
+# check that type.mutable can be fully eliminated
+f_mutable_nothrow(s::String) = Val{typeof(s).mutable}
+@test length(code_typed(f_mutable_nothrow, (String,))[1][1].code) == 1


### PR DESCRIPTION
The existing code unintentionally returned `false` for every constant unless it was a module.