### PR TITLE
fix #29083, not eliminating kwfunc due to logic error in builtin_nothrow

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1056,7 +1056,7 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
         length(argtypes) == 1 || return false
         return sizeof_nothrow(argtypes[1])
     elseif f === Core.kwfunc
-        length(argtypes) == 2 || return false
+        length(argtypes) == 1 || return false
         return isa(rt, Const)
     end
     return false

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -111,6 +111,16 @@ let a = read21311()
     @test a[] == 1
 end
 
+# issue #29083
+f29083(;μ,σ) = μ + σ*randn()
+g29083() = f29083(μ=2.0,σ=0.1)
+let c = code_typed(g29083, ())[1][1].code
+    # make sure no call to kwfunc remains
+    @test !any(e->(isa(e,Expr) && ((e.head === :invoke && e.args[1].def.name === :kwfunc) ||
+                                   (e.head === :foreigncall && e.args[1] === QuoteNode(:jl_get_keyword_sorter)))),
+               c)
+end
+
 @testset "issue #19122: [no]inline of short func. def. with return type annotation" begin
     exf19122 = @macroexpand(@inline f19122()::Bool = true)
     exg19122 = @macroexpand(@noinline g19122()::Bool = true)


### PR DESCRIPTION
Bit of a forehead-slapper.