### PR TITLE
Documentation `mynorm` should not divide by n

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1231,7 +1231,7 @@ function mynorm(u::Vector)
     @fastmath @inbounds @simd for i in 1:n
         s += u[i]^2
     end
-    @fastmath @inbounds return sqrt(s/n)
+    @fastmath @inbounds return sqrt(s)
 end
 
 function main()


### PR DESCRIPTION
Test with:
```julia
a = randn(10)
abs(norm(a) - mynorm(a)) < 1e10
```

Tested here:
```julia-repl
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: https://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.6.4 (2018-07-09 19:09 UTC)
 _/ |\__'_|_|_|\__'_|  |  Official http://julialang.org/ release
|__/                   |  x86_64-pc-linux-gnu

julia> function mynorm(u::Vector)
           n = length(u)
           T = eltype(u)
           s = zero(T)
           @fastmath @inbounds @simd for i in 1:n
               s += u[i]^2
           end
           @fastmath @inbounds return sqrt(s)
       end
mynorm (generic function with 1 method)

julia> function mynorm_old(u::Vector)
           n = length(u)
           T = eltype(u)
           s = zero(T)
           @fastmath @inbounds @simd for i in 1:n
               s += u[i]^2
           end
           @fastmath @inbounds return sqrt(s/n)
       end
mynorm_old (generic function with 1 method)

julia> a = randn(10)
10-element Array{Float64,1}:
 -0.564163
 -3.45236 
 -0.50901 
 -0.030296
  0.114156
  0.661961
 -1.19972 
  2.20883 
  1.74529 
  0.82515 

julia> abs(norm(a)-mynorm(a))
0.0

julia> abs(norm(a)-mynorm_old(a))
3.2787896367314344
```