### PR TITLE
in Channel `put!`, convert value to Channel type

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -246,8 +246,9 @@ Append an item `v` to the channel `c`. Blocks if the channel is full.
 For unbuffered channels, blocks until a [`take!`](@ref) is performed by a different
 task.
 """
-function put!(c::Channel, v)
+function put!(c::Channel{T}, v) where T
     check_channel_state(c)
+    v = convert(T, v)
     isbuffered(c) ? put_buffered(c,v) : put_unbuffered(c,v)
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -43,6 +43,15 @@ end
     testcpt(32)
     testcpt(Inf)
 end
+
+@testset "type conversion in put!" begin
+    c = Channel{Int64}(0)
+    @async put!(c, Int32(1))
+    wait(c)
+    @test isa(take!(c), Int64)
+    @test_throws MethodError put!(c, "")
+end
+
 @testset "multiple for loops waiting on the same channel" begin
     # Test multiple "for" loops waiting on the same channel which
     # is closed after adding a few elements.


### PR DESCRIPTION
`put!(ch::Channel{T}, v)` should convert `v` to type `T`.

This can prevent errors like:

```
julia> c = Channel{Int}(0)
Channel{Int64}(sz_max:0,sz_curr:0)

julia> @async put!(c, :a)
Task (runnable) @0x00007ff5b9d79270

julia> isready(c) && take!(c)
ERROR: TypeError: in take_unbuffered, in typeassert, expected Int64, got Symbol
Stacktrace:
 [1] take_unbuffered(::Channel{Int64}) at ./channels.jl:323
 [2] take!(::Channel{Int64}) at ./channels.jl:306
 [3] top-level scope at none:0
```