### PR TITLE
doc/interface: correct signature of `size`

### DIFF
--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -16,12 +16,12 @@ to generically build upon those behaviors.
 | `IteratorEltype(IterType)`     | `HasEltype()`          | Either `EltypeUnknown()` or `HasEltype()` as appropriate                              |
 | `eltype(IterType)`             | `Any`                  | The type of the first entry of the tuple returned by `iterate()`                      |
 | `length(iter)`                 | (*undefined*)          | The number of items, if known                                                         |
-| `size(iter, [dim...])`         | (*undefined*)          | The number of items in each dimension, if known                                       |
+| `size(iter, [dim])`            | (*undefined*)          | The number of items in each dimension, if known                                       |
 
 | Value returned by `IteratorSize(IterType)` | Required Methods                           |
 |:------------------------------------------ |:------------------------------------------ |
 | `HasLength()`                              | [`length(iter)`](@ref)                     |
-| `HasShape{N}()`                            | `length(iter)`  and `size(iter, [dim...])` |
+| `HasShape{N}()`                            | `length(iter)`  and `size(iter, [dim])`    |
 | `IsInfinite()`                             | (*none*)                                   |
 | `SizeUnknown()`                            | (*none*)                                   |
 


### PR DESCRIPTION
I think `size(A, [dim...])` has been deprecated.
```julia
julia> size(A, 1,2)
┌ Warning: `size(x, d1::Integer, d2::Integer)` is deprecated, use `(size(x, d1), size(x, d2))` instead.
│   caller = top-level scope at none:0
└ @ Core none:0
```