### PR TITLE
RFC: Don't bail current_project() at Git repos

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -90,8 +90,8 @@ function current_project(dir::AbstractString)
             file = joinpath(dir, proj)
             isfile_casesensitive(file) && return file
         end
-        # bail at home directory or top of git repo
-        (dir == home || ispath(joinpath(dir, ".git"))) && break
+        # bail at home directory
+        dir == home && break
         old, dir = dir, dirname(dir)
         dir == old && break
     end


### PR DESCRIPTION
Currently, assuming you have the following directory structure

```
myproject/Project.toml
myproject/non-julia-repo/.git
```

running `julia --project` somewhere in `myproject/non-julia-repo` will not activate `myproject/`.

I don't quite see why Git repos are treated specially here, so in the PR I propose removing the `.git` directory check in `current_project` and let it continue searching up the directory tree for `Project.toml`s.