### PR TITLE
fix perf in exp(::Matrix) (for smallish matrices)

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -541,10 +541,10 @@ function exp!(A::StridedMatrix{T}) where T<:BlasFloat
         A2 = A * A
         A4 = A2 * A2
         A6 = A2 * A4
-        U  = A * (A6 * (CC[14]*A6 + CC[12]*A4 + CC[10]*A2) +
-                  CC[8]*A6 + CC[6]*A4 + CC[4]*A2 + CC[2]*Inn)
-        V  = A6 * (CC[13]*A6 + CC[11]*A4 + CC[9]*A2) +
-                   CC[7]*A6 + CC[5]*A4 + CC[3]*A2 + CC[1]*Inn
+        U  = A * (A6 * (CC[14].*A6 .+ CC[12].*A4 .+ CC[10].*A2) .+
+                  CC[8].*A6 .+ CC[6].*A4 .+ CC[4].*A2 .+ CC[2].*Inn)
+        V  = A6 * (CC[13].*A6 .+ CC[11].*A4 .+ CC[9].*A2) .+
+                   CC[7].*A6 .+ CC[5].*A4 .+ CC[3].*A2 .+ CC[1].*Inn
 
         X = V + U
         LAPACK.gesv!(V-U, X)


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/LinearAlgebra.jl/issues/565

Before:
```jl
julia> @btime exp([1. 0; 2 0])
  18.912 μs (73 allocations: 4.80 KiB)
```

After:

```jl
julia> @btime exp([1. 0; 2 0])
  3.529 μs (25 allocations: 2.30 KiB)
```

**Edit: The text below is no longer relevant:**

Should the broadcasting be able to do better here? cc @mbauman  Here is a MWE

```jl
f(A, A2, A4, A6, CC, Inn)      =  A * (A6 * (CC[14]*A6  + CC[12]*A4  + CC[10]*A2)  + CC[8]*A6  + CC[6]*A4  + CC[4]*A2  + CC[2]*Inn)
f_dots(A, A2, A4, A6, CC, Inn) =  A * (A6 * (CC[14]*A6 .+ CC[12]*A4 .+ CC[10]*A2) .+ CC[8]*A6 .+ CC[6]*A4 .+ CC[4]*A2 .+ CC[2]*Inn)
CC = rand(100); A = rand(2,2); A2 = A*A; A4 = A2*A2; A6 = A2 * A4; Inn = rand(2,2);

@btime f($A, $A2, $A4, $A6, $CC, $Inn)
  6.949 μs (28 allocations: 1.69 KiB)

@btime f_dots($A, $A2, $A4, $A6, $CC, $Inn)
  565.278 ns (11 allocations: 1.20 KiB)
```

Update since it is being discussed: using full fusion:

```jl
f_ddots(A, A2, A4, A6, CC, Inn) =  A * (A6 * @.((CC[14]*A6  + CC[12]*A4  + CC[10]*A2)  + CC[8]*A6  + CC[6]*A4  + CC[4]*A2  + CC[2]*Inn))

@btime f_ddots($A, $A2, $A4, $A6, $CC, $Inn)
  1.787 μs (7 allocations: 464 bytes)
```