### PR TITLE
LibGit2: only call shutdown once [fix #28306]

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -978,7 +978,7 @@ end
 
     atexit() do
         # refcount zero, no objects to be finalized
-        if Threads.atomic_sub!(REFCOUNT, 1) >= 1
+        if Threads.atomic_sub!(REFCOUNT, 1) == 1
             ccall((:git_libgit2_shutdown, :libgit2), Cint, ())
         end
     end


### PR DESCRIPTION
I had a hunch, looking at https://github.com/JuliaLang/julia/pull/28113 and indeed, this fixes https://github.com/JuliaLang/julia/issues/28306. I'm not sure if this is worth adding a test for; I could just use the test code given in the issue but it assumes that `dirname(Sys.BINDIR)` is going to be a git repo, which it won't necessarily be in a non-source install of Julia.