### PR TITLE
optimize slightly BigFloat(-NaN)

### DIFF
--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -133,8 +133,7 @@ function BigFloat(x::Float64)
     z = BigFloat()
     ccall((:mpfr_set_d, :libmpfr), Int32, (Ref{BigFloat}, Float64, Int32), z, x, ROUNDING_MODE[])
     if isnan(x) && signbit(x) != signbit(z)
-        # for some reason doing mpfr_neg in-place doesn't work here
-        return -z
+        z.sign = -z.sign
     end
     return z
 end


### PR DESCRIPTION
This operation was allocating internally one unnecessary temporary
BigFloat object, doubling the construction time.

This is an utterly unimportant change, but it's hard for me to leave an unefficiency in the code when the fix is so simple. This touches directly the internal representation (`z.sign`), but I can change that to the library call if preferred (which I didn't see a problem with, despite what the deleted comment says).