### PR TITLE
REPL: disable auto-indent when code is likely being pasted (fix #25186)

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -726,15 +726,18 @@ end
 function edit_insert_newline(s::PromptState, align::Int = 0 - options(s).auto_indent)
     push_undo(s)
     buf = buffer(s)
-    if align < 0
+    autoindent = align < 0
+    if autoindent
         beg = beginofline(buf)
         align = min(something(findnext(_notspace, buf.data[beg+1:buf.size], 1), 0) - 1,
                     position(buf) - beg) # indentation must not increase
         align < 0 && (align = buf.size-beg)
     end
     edit_insert(buf, '\n' * ' '^align)
-    align > 0 && (s.last_newline = time())
     refresh_line(s)
+    # updating s.last_newline should happen after refresh_line(s) which can take
+    # an unpredictable amount of time and makes "paste detection" unreliable
+    autoindent && align > 0 && (s.last_newline = time())
 end
 
 # align: delete up to 4 spaces to align to a multiple of 4 chars

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -273,6 +273,8 @@ mutable struct Options
     backspace_adjust::Bool
     confirm_exit::Bool # ^D must be repeated to confirm exit
     auto_indent::Bool # indent a newline like line above
+    # cancel auto-indent when next character is entered within this time frame :
+    auto_indent_time_threshold::Float64
 end
 
 Options(;
@@ -286,12 +288,14 @@ Options(;
         beep_use_current = true,
         backspace_align = true, backspace_adjust = backspace_align,
         confirm_exit = false,
-        auto_indent = true) =
+        auto_indent = true,
+        auto_indent_time_threshold = 0.005) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
                     beep_duration, beep_blink, beep_maxduration,
                     beep_colors, beep_use_current,
-                    backspace_align, backspace_adjust, confirm_exit, auto_indent)
+                    backspace_align, backspace_adjust, confirm_exit,
+                    auto_indent, auto_indent_time_threshold)
 
 # for use by REPLs not having an options field
 const GlobalOptions = Options()

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -9,7 +9,9 @@ include("FakeTerminals.jl")
 import .FakeTerminals.FakeTerminal
 
 # no need to have animation in tests
-REPL.GlobalOptions.region_animation_duration=0.001
+REPL.GlobalOptions.region_animation_duration=0.0001
+# tests are inserting code much faster than humans
+REPL.GlobalOptions.auto_indent_time_threshold = -0.0
 
 ## helper functions
 


### PR DESCRIPTION
On some Windows terminals, pasting is not recognized as such.
This happens also with tmux' builtin paste.
In those cases, auto-indent is better disabled, as we want
to preserve the original indentation of the code being pasted.

This fix is quite a hack, but seems to work: using time(), if
the next character after a newline is being inserted very fast,
assume this was with paste, and cancel the insertion of the
spaces done by auto-indent.

I couldn't insert two characters in a raw within less than
about 0.03 or 0.02 seconds, so the threshold for "very fast"
is set to 0.005, but this is an option which can changed.