### PR TITLE
Add `show(::IO, ::AbstractUnitRange)`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -690,7 +690,7 @@ function getindex(r::LinRange, s::OrdinalRange{<:Integer})
 end
 
 show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
-show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
+show(io::IO, r::AbstractUnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
 show(io::IO, r::OneTo) = print(io, "Base.OneTo(", r.stop, ")")
 
 ==(r::T, s::T) where {T<:AbstractRange} =

--- a/base/range.jl
+++ b/base/range.jl
@@ -689,9 +689,11 @@ function getindex(r::LinRange, s::OrdinalRange{<:Integer})
     return LinRange(vfirst, vlast, length(s))
 end
 
-show(io::IO, r::AbstractRange) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
-show(io::IO, r::AbstractUnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
-show(io::IO, r::OneTo) = print(io, "Base.OneTo(", r.stop, ")")
+show(io::IO, r::AbstractRange) = print(io, typeof(r), '(', repr(first(r)), ':', repr(step(r)), ':', repr(last(r)), ')')
+show(io::IO, r::AbstractUnitRange) = print(io, typeof(r), '(', repr(first(r)), ':', repr(last(r)), ')')
+show(io::IO, r::Union{StepRange, StepRangeLen}) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
+show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
+show(io::IO, r::OneTo) = print(io, typeof(r), '(', repr(last(r)), ')')
 
 ==(r::T, s::T) where {T<:AbstractRange} =
     (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))

--- a/base/range.jl
+++ b/base/range.jl
@@ -693,7 +693,7 @@ show(io::IO, r::AbstractRange) = print(io, typeof(r), '(', repr(first(r)), ':', 
 show(io::IO, r::AbstractUnitRange) = print(io, typeof(r), '(', repr(first(r)), ':', repr(last(r)), ')')
 show(io::IO, r::Union{StepRange, StepRangeLen}) = print(io, repr(first(r)), ':', repr(step(r)), ':', repr(last(r)))
 show(io::IO, r::UnitRange) = print(io, repr(first(r)), ':', repr(last(r)))
-show(io::IO, r::OneTo) = print(io, typeof(r), '(', repr(last(r)), ')')
+show(io::IO, r::OneTo) = print(io, typeof(r).name, '(', repr(last(r)), ')')
 
 ==(r::T, s::T) where {T<:AbstractRange} =
     (first(r) == first(s)) & (step(r) == step(s)) & (last(r) == last(s))


### PR DESCRIPTION
Currently only `show(::IO, ::UnitRange)` is implemented in `range.jl`, but the very same definition works for `AbstractUnitRange` in general.