### PR TITLE
fix perf regression from not specializing on iterate on tuples

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -38,7 +38,7 @@ _setindex(v, i::Integer) = ()
 
 ## iterating ##
 
-iterate(@nospecialize(t::Tuple), i::Int=1) = 1 <= i <= length(t) ? (@inbounds t[i], i+1) : nothing
+iterate(t::Tuple, i::Int=1) = 1 <= i <= length(t) ? (@inbounds t[i], i+1) : nothing
 
 keys(@nospecialize t::Tuple) = OneTo(length(t))
 


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/pull/28764#issuecomment-419917783.

cc @haampie 

```jl
perf_setindex!(A, val, inds) = setindex!(A, val, inds...)

using BenchmarkTools
s = 2
A = rand(Float64, ntuple(one, s)...)
y = one(eltype(A))
i = length(A)
@btime perf_setindex!($(fill!(A, y)), $y, $i)
```

Before:

```
1.308 μs (8 allocations: 336 bytes)
```

After:

```
570.000 ns (8 allocations: 336 bytes)
```