### PR TITLE
Show BitSet according to IOContext

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -4,6 +4,7 @@ eltype(::Type{<:AbstractSet{T}}) where {T} = @isdefined(T) ? T : Any
 sizehint!(s::AbstractSet, n) = nothing
 
 function show(io::IO, s::AbstractSet)
+    s isa BitSet && isempty(s) && return print(io, "BitSet([])")
     print(io, string(typeof(s).name))
     print(io,'(')
     show_vector(io, s)

--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -3,6 +3,13 @@
 eltype(::Type{<:AbstractSet{T}}) where {T} = @isdefined(T) ? T : Any
 sizehint!(s::AbstractSet, n) = nothing
 
+function show(io::IO, s::AbstractSet)
+    print(io, string(typeof(s).name))
+    print(io,'(')
+    show_vector(io, s)
+    print(io, ')')
+end
+
 """
     union(s, itrs...)
     ∪(s, itrs...)

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -321,15 +321,10 @@ end
 
 length(s::BitSet) = bitcount(s.bits) # = mapreduce(count_ones, +, s.bits; init=0)
 
-function show(io::IO, s::BitSet)
-    print(io, "BitSet([")
-    first = true
-    for n in s
-        !first && print(io, ", ")
-        print(io, n)
-        first = false
-    end
-    print(io, "])")
+function show(io::IO, bs::BitSet)
+    print(io, "BitSet(")
+    show_vector(io,bs)
+    print(io, ')')
 end
 
 function _check0(a::Vector{UInt64}, b::Int, e::Int)

--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -321,12 +321,6 @@ end
 
 length(s::BitSet) = bitcount(s.bits) # = mapreduce(count_ones, +, s.bits; init=0)
 
-function show(io::IO, bs::BitSet)
-    print(io, "BitSet(")
-    show_vector(io,bs)
-    print(io, ')')
-end
-
 function _check0(a::Vector{UInt64}, b::Int, e::Int)
     @inbounds for i in b:e
         a[i] == CHK0 || return false

--- a/base/set.jl
+++ b/base/set.jl
@@ -36,12 +36,6 @@ emptymutable(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 
 _similar_for(c::AbstractSet, T, itr, isz) = empty(c, T)
 
-function show(io::IO, s::Set)
-    print(io, "Set(")
-    show_vector(io, s)
-    print(io, ')')
-end
-
 isempty(s::Set) = isempty(s.dict)
 length(s::Set)  = length(s.dict)
 in(x, s::Set) = haskey(s.dict, x)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1402,3 +1402,13 @@ end
 replstrcolor(x) = sprint((io, x) -> show(IOContext(io, :limit => true, :color => true),
                                          MIME("text/plain"), x), x)
 @test occursin("\e[", replstrcolor(`curl abc`))
+
+# PR 29143: Show BitSet according to IOContext
+@testset "Limited sets in REPL" begin
+    @test replstr(BitSet(1:2)) == "BitSet([1, 2])"
+    for s in [Set,BitSet]
+        @test !occursin("\u2026", replstr(s(1:2)))
+        @test occursin("\u2026", replstr(s(1:200)))
+        @test length(replstr(s(1:200))) < 200
+    end
+end


### PR DESCRIPTION
In the REPL `BitSet(1:2^18)` dumps the whole set, which isn't a pleasant experience. This PR implements the use of `show_vector`, which adapts to the `:limit` entry in `IOContext`. 

Implementation follows https://github.com/JuliaLang/julia/blob/773540d286fc6a5610b12dfb6f0ad5c98c935732/base/set.jl#L39