### PR TITLE
ndigits with negative base: error out instead of giving incorrect result

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -440,7 +440,8 @@ function ndigits0znb(x::Integer, b::Integer)
     return d
 end
 
-ndigits0znb(x::Unsigned, b::Integer) = ndigits0znb(Signed(x), b)
+# do first division before conversion with signed here, which can otherwise overflow
+ndigits0znb(x::Unsigned, b::Integer) = ndigits0znb(-signed(fld(x, -b)), b) + (x != 0)
 ndigits0znb(x::Bool, b::Integer) = x % Int
 
 # The suffix "pb" stands for "positive base"

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -440,7 +440,7 @@ function ndigits0znb(x::Integer, b::Integer)
     return d
 end
 
-ndigits0znb(x::Unsigned, b::Integer) = ndigits0znb(signed(x), b)
+ndigits0znb(x::Unsigned, b::Integer) = ndigits0znb(Signed(x), b)
 ndigits0znb(x::Bool, b::Integer) = x % Int
 
 # The suffix "pb" stands for "positive base"

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -139,6 +139,9 @@ end
     @test iszero([Base.ndigits0z(false, b) for b in [-20:-2;2:20]])
     @test all(n -> n == 1, Base.ndigits0z(true, b) for b in [-20:-2;2:20])
     @test all(n -> n == 1, ndigits(x, base=b) for b in [-20:-2;2:20] for x in [true, false])
+
+    # with negative bases, we don't support yet unsigned integers which can't be converted to Signed
+    @test_throws InexactError ndigits(typemax(UInt64), base=-2)
 end
 @testset "bin/oct/dec/hex/bits" begin
     @test string(UInt32('3'), base = 2) == "110011"

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -140,8 +140,14 @@ end
     @test all(n -> n == 1, Base.ndigits0z(true, b) for b in [-20:-2;2:20])
     @test all(n -> n == 1, ndigits(x, base=b) for b in [-20:-2;2:20] for x in [true, false])
 
-    # with negative bases, we don't support yet unsigned integers which can't be converted to Signed
-    @test_throws InexactError ndigits(typemax(UInt64), base=-2)
+    # issue #29148
+    @test ndigits(typemax(UInt64), base=-2) == ndigits(big(typemax(UInt64)), base=-2)
+    for T in Base.BitInteger_types
+        n = rand(T)
+        b = -rand(2:100)
+        @test ndigits(n, base=b) == ndigits(big(n), base=b)
+    end
+
 end
 @testset "bin/oct/dec/hex/bits" begin
     @test string(UInt32('3'), base = 2) == "110011"


### PR DESCRIPTION
Because of an unchecked conversion via `signed` (instead of `Signed`),
we were giving wrong results, e.g. we had
`ndigits(typemax(UInt), base=-2) != ndigits(big(typemax(UInt)), base=-2)`