### PR TITLE
faster conversion from Integer to BigInt

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -283,7 +283,7 @@ BigInt(x::Float16) = BigInt(Float64(x))
 BigInt(x::Float32) = BigInt(Float64(x))
 
 function BigInt(x::Integer)
-    x == 0 && return BigInt(0)
+    x == 0 && return BigInt(Culong(0))
     nd = ndigits(x, base=2)
     z = MPZ.realloc2(nd)
     s = sign(x)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -283,31 +283,21 @@ BigInt(x::Float16) = BigInt(Float64(x))
 BigInt(x::Float32) = BigInt(Float64(x))
 
 function BigInt(x::Integer)
-    if x < 0
-        if typemin(Clong) <= x
-            return BigInt(convert(Clong,x))
-        end
-        b = BigInt(0)
-        shift = 0
-        while x < -1
-            b += BigInt(~UInt32(x&0xffffffff))<<shift
-            x >>= 32
-            shift += 32
-        end
-        return -b-1
-    else
-        if x <= typemax(Culong)
-            return BigInt(convert(Culong,x))
-        end
-        b = BigInt(0)
-        shift = 0
-        while x > 0
-            b += BigInt(UInt32(x&0xffffffff))<<shift
-            x >>>= 32
-            shift += 32
-        end
-        return b
+    x == 0 && return BigInt(0)
+    nd = ndigits(x, base=2)
+    z = MPZ.realloc2(nd)
+    s = sign(x)
+    s == -1 && (x = -x)
+    size = 0
+    limbnbits = sizeof(Limb) << 3
+    while nd > 0
+        size += 1
+        unsafe_store!(z.d, x % Limb, size)
+        x >>>= limbnbits
+        nd -= limbnbits
     end
+    z.size = s*size
+    z
 end
 
 

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -425,3 +425,10 @@ end
     @test c ∈ (-1, 0, 1)
     @test c isa Int
 end
+
+@testset "generic conversion from Integer" begin
+    x = rand(Int128)
+    @test BigInt(x) % Int128 === x
+    y = rand(UInt128)
+    @test BigInt(y) % UInt128 === y
+end


### PR DESCRIPTION
This applies mainly to `BigInt(::[U]Int128)`, for which it's about 10 times faster. For isbits integers with 1024 bits, I observe a 20x improvement. The drawback is that this uses directly the `BigInt` internals (but we already do this sometimes, e.g. in `rand(BigInt)`). 