### PR TITLE
copy! docfix: no teasing about Future

### DIFF
--- a/base/bitset.jl
+++ b/base/bitset.jl
@@ -47,12 +47,11 @@ copy(s1::BitSet) = copy!(BitSet(), s1)
 copymutable(s::BitSet) = copy(s)
 
 """
-    copy!(dst, src)
+    copy!(dst::BitSet, src::BitSet)
 
 In-place [`copy`](@ref) of `src` into `dst`. After the call to `copy!`,
-`dst` must be left equal to `src`, otherwise an error is thrown; this
-function appropriately resizes `dst` if necessary.
-See also [`copyto!`](@ref).
+`dst` is equal to `src`. This function appropriately resizes `dst` if 
+necessary. See also [`copyto!`](@ref).
 """
 function copy!(dest::BitSet, src::BitSet)
     resize!(dest.bits, length(src.bits))


### PR DESCRIPTION
See [https://github.com/JuliaLang/julia/issues/29173](https://github.com/JuliaLang/julia/issues/29173).

Technically correct is the best kind of correct, technically speaking, but the current docstring is just teasing.