### PR TITLE
fix digits(n::Unsigned) with neg base for `n > typemax(n)÷2`

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -743,26 +743,23 @@ julia> digits!([2,2,2,2,2,2], 10, base = 2)
  0
 ```
 """
-function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10, _skipfirst=false) where T<:Integer
+function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10) where T<:Integer
     2 <= abs(base) || throw(ArgumentError("base must be ≥ 2 or ≤ -2, got $base"))
     hastypemax(T) && abs(base) - 1 > typemax(T) &&
         throw(ArgumentError("type $T too small for base $base"))
     isempty(a) && return a
-
+    skipfirst = false
     if base < 0 && n isa Unsigned
         d = mod(n, -base)
-        ns = -signed(fld(n, -base))
-        digits!(a, ns, base = base, _skipfirst=true)
-        a[firstindex(a)] = d
-        return a
+        n = -signed(fld(n, -base))
+        skipfirst = true
     end
 
     for i in eachindex(a)
-        if _skipfirst
-            _skipfirst = false
-            continue
-        end
-        if base > 0
+        if skipfirst
+            skipfirst = false
+            a[i] = d
+        elseif base > 0
             a[i] = rem(n, base)
             n = div(n, base)
         else

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -743,12 +743,25 @@ julia> digits!([2,2,2,2,2,2], 10, base = 2)
  0
 ```
 """
-function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10) where T<:Integer
-    base < 0 && isa(n, Unsigned) && return digits!(a, convert(Signed, n), base = base)
+function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10, skipfirst=false) where T<:Integer
     2 <= abs(base) || throw(ArgumentError("base must be ≥ 2 or ≤ -2, got $base"))
     hastypemax(T) && abs(base) - 1 > typemax(T) &&
         throw(ArgumentError("type $T too small for base $base"))
+    isempty(a) && return a
+
+    if base < 0 && n isa Unsigned
+        d = mod(n, -base)
+        ns = -signed(fld(n, -base))
+        digits!(a, ns, base = base, skipfirst=true)
+        a[firstindex(a)] = d
+        return a
+    end
+
     for i in eachindex(a)
+        if skipfirst
+            skipfirst = false
+            continue
+        end
         if base > 0
             a[i] = rem(n, base)
             n = div(n, base)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -743,7 +743,7 @@ julia> digits!([2,2,2,2,2,2], 10, base = 2)
  0
 ```
 """
-function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10, skipfirst=false) where T<:Integer
+function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10, _skipfirst=false) where T<:Integer
     2 <= abs(base) || throw(ArgumentError("base must be ≥ 2 or ≤ -2, got $base"))
     hastypemax(T) && abs(base) - 1 > typemax(T) &&
         throw(ArgumentError("type $T too small for base $base"))
@@ -752,14 +752,14 @@ function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10, skipfirst
     if base < 0 && n isa Unsigned
         d = mod(n, -base)
         ns = -signed(fld(n, -base))
-        digits!(a, ns, base = base, skipfirst=true)
+        digits!(a, ns, base = base, _skipfirst=true)
         a[firstindex(a)] = d
         return a
     end
 
     for i in eachindex(a)
-        if skipfirst
-            skipfirst = false
+        if _skipfirst
+            _skipfirst = false
             continue
         end
         if base > 0

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -179,10 +179,17 @@ end
     @test digits(5, base = 3) == [2, 1]
 
     @testset "digits/base with negative bases" begin
-        @testset "digits(n::$T, base = b)" for T in (Int, UInt, BigInt, Int32)
+        @testset "digits(n::$T, base = b)" for T in (Int, UInt, BigInt, Int32, UInt32)
             @test digits(T(8163), base = -10) == [3, 4, 2, 2, 1]
             if !(T<:Unsigned)
                 @test digits(T(-8163), base = -10) == [7, 7, 9, 9]
+            end
+            if T !== BigInt
+                b = rand(-32:-2)
+                for n = T[rand(T), typemax(T), typemin(T)]
+                    # issue #29183
+                    @test digits(n, base=b) == digits(signed(widen(n)), base=b)
+                end
             end
         end
         @test [string(n, base = b)


### PR DESCRIPTION
Fixes #29183. The same idea as in #29148 is used.