### PR TITLE
Make `using LinearAlgebra` explicit

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -5,7 +5,7 @@ DocTestSetup = :(using LinearAlgebra)
 ```
 
 In addition to (and as part of) its support for multi-dimensional arrays, Julia provides native implementations
-of many common and useful linear algebra operations. Basic operations, such as [`tr`](@ref), [`det`](@ref),
+of many common and useful linear algebra operations which can be loaded with `using LinearAlgebra`. Basic operations, such as [`tr`](@ref), [`det`](@ref),
 and [`inv`](@ref) are all supported:
 
 ```jldoctest


### PR DESCRIPTION
Ref. https://discourse.julialang.org/t/error-undefvarerror-eigvecs-not-defined/14923/2?u=stillyslalom

An aside: `using LinearAlgebra` is already embedded in DocTestSetup. Is there (or should there be) a way to seamlessly make this visible in the resulting doc page?