### PR TITLE
Have 'cat' only accept positive dimensions.

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1345,8 +1345,17 @@ end
 _cs(d, a, b) = (a == b ? a : throw(DimensionMismatch(
     "mismatch in dimension $d (expected $a got $b)")))
 
-dims2cat(::Val{n}) where {n} = ntuple(i -> (i == n), Val(n))
-dims2cat(dims) = ntuple(in(dims), maximum(dims))
+function dims2cat(::Val{n}) where {n}
+    n <= 0 && throw(ArgumentError("cat dimension must be a positive integer, but got $n"))
+    ntuple(i -> (i == n), Val(n))
+end
+
+function dims2cat(dims)
+    if any(dims .<= 0)
+        throw(ArgumentError("All cat dimensions must be positive integers, but got $dims"))
+    end
+    ntuple(in(dims), maximum(dims))
+end
 
 _cat(dims, X...) = cat_t(promote_eltypeof(X...), X...; dims=dims)
 

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -661,6 +661,10 @@ function test_cat(::Type{TestAbstractArray})
 
     @test @inferred(vcat(["a"], "b"))::Vector{String} == ["a", "b"]
     @test @inferred(vcat((1,), (2.0,)))::Vector{Tuple{Real}} == [(1,), (2.0,)]
+
+    # 29172
+    @test_throws ArgumentError cat([1], [2], dims=0)
+    @test_throws ArgumentError cat([1], [2], dims=[5, -3])
 end
 
 function test_ind2sub(::Type{TestAbstractArray})


### PR DESCRIPTION
Closes https://github.com/JuliaLang/julia/issues/29172.