### PR TITLE
Improve Irrational vs BigFloat comparisons

### DIFF
--- a/test/mpfr.jl
+++ b/test/mpfr.jl
@@ -944,3 +944,13 @@ end
         @test big(typeof(complex(x, x))) == typeof(big(complex(x, x)))
     end
 end
+
+Base.@irrational zzz 1.0 1+pi*BigFloat(1e-100)
+
+@testset "Irrational edge cases" begin
+    @test Float64(zzz, RoundDown) < Float64(zzz, RoundUp)
+    @test BigFloat(1.0) < zzz
+    @test !(nextfloat(BigFloat(1.0)) < zzz)
+    @test !(zzz < BigFloat(1.0))
+    @test zzz < nextfloat(BigFloat(1.0))
+end


### PR DESCRIPTION
This creates a fast path via Float64, and falls back on extended precision only when necessary. It also adds a loop to deal with potential edge cases.