### PR TITLE
Switch to JC-hosted httpbin server

### DIFF
--- a/test/download.jl
+++ b/test/download.jl
@@ -1,30 +1,31 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 mktempdir() do temp_dir
+    httpbin = "https://httpbin.julialang.org"
     # Download a file
     file = joinpath(temp_dir, "ip")
-    @test download("http://httpbin.org/ip", file) == file
+    @test download("$(httpbin)/ip", file) == file
     @test isfile(file)
     @test !isempty(read(file))
 
     # Download an empty file
     empty_file = joinpath(temp_dir, "empty")
-    @test download("http://httpbin.org/status/200", empty_file) == empty_file
+    @test download("$(httpbin)/status/200", empty_file) == empty_file
 
     # Windows and older versions of curl do not create the empty file (https://github.com/curl/curl/issues/183)
     @test !isfile(empty_file) || isempty(read(empty_file))
 
     # Make sure that failed downloads do not leave files around
     missing_file = joinpath(temp_dir, "missing")
-    @test_throws ErrorException download("http://httpbin.org/status/404", missing_file)
+    @test_throws ErrorException download("$(httpbin)/status/404", missing_file)
     @test !isfile(missing_file)
 
     # Make sure we properly handle metachar '
     metachar_file = joinpath(temp_dir, "metachar")
-    download("https://httpbin.org/get?test='^'", metachar_file)
+    download("$(httpbin)/get?test='^'", metachar_file)
     metachar_string = read(metachar_file, String)
     m = match(r"\"url\"\s*:\s*\"(.*)\"", metachar_string)
-    @test m.captures[1] == "https://httpbin.org/get?test='^'"
+    @test m.captures[1] == "$(httpbin)/get?test='^'"
 
     # Use a TEST-NET (192.0.2.0/24) address which shouldn't be bound
     invalid_host_file = joinpath(temp_dir, "invalid_host")


### PR DESCRIPTION
Use our own httpbin server.

Another possible solution to `httpbin` flakiness is to have the buildbots themselves spin up a python instance running the `httpbin` source code, but for now this is the lesser of two evils in terms of complexity.
We probably want a way to try `httpbin.julialang.org` and `httpbin.org` and take success from at least one to be a passing test, but this is good enough for now.