### PR TITLE
Change `Zip` data structure to a flat one

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -267,8 +267,11 @@ end
 """
     zip(iters...)
 
-For a set of iterable objects, return an iterable of tuples, where the `i`th tuple contains
-the `i`th component of each input iterable.
+Run multiple iterators at the same time, until any of them is exhausted. The value type of
+the `zip` iterator is a tuple of values of its subiterators.
+
+Note: `zip` orders the calls to its subiterators in such a way that stateful iterators will
+not advance when another iterator finishes in the current iteration.
 
 # Examples
 ```jldoctest

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -390,10 +390,13 @@ eltype(::Type{Zip{Is}}) where {Is<:Tuple} = _zip_eltype(Is)
 _zip_eltype(::Type{Is}) where {Is<:Tuple} =
     tuple_type_cons(eltype(tuple_type_head(Is)), _zip_eltype(tuple_type_tail(Is)))
 _zip_eltype(::Type{Tuple{}}) = Tuple{}
-@inline isdone(z::Zip) = any(isdone, z.is)
-@inline isdone(z::Zip, ss) = _zip_any_isdone(z.is, ss)
-@inline _zip_any_isdone(is, ss) =
-    isdone(is[1], ss[1]) === true || _zip_any_isdone(tail(is), tail(ss))
+@inline isdone(z::Zip) = _zip_any_isdone(z.is, map(_ -> (), z.is))
+@inline isdone(z::Zip, ss) = _zip_any_isdone(z.is, map(tuple, ss))
+@inline function _zip_any_isdone(is, ss)
+    d1 = isdone(is[1], ss[1]...)
+    d1 === true && return true
+    return d1 | _zip_any_isdone(tail(is), tail(ss))
+end
 @inline _zip_any_isdone(::Tuple{}, ::Tuple{}) = false
 
 @propagate_inbounds iterate(z::Zip) = _zip_iterate_all(z.is, map(_ -> (), z.is))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -313,8 +313,10 @@ function _zip_min_length(n, is)
     end
 end
 _zip_min_length(n::Integer, is::Tuple{}) = n
-size(z::Zip) = reduce(promote_shape, map(size, z.is))
-axes(z::Zip) = reduce(promote_shape, map(axes, z.is))
+size(z::Zip) = _promote_shape(map(size, z.is)...)
+axes(z::Zip) = _promote_shape(map(axes, z.is)...)
+_promote_shape(a, b...) = promote_shape(a, _promote_shape(b...))
+_promote_shape(a) = a
 eltype(::Type{Zip{Is}}) where {Is<:Tuple} = _zip_eltype(Is)
 _zip_eltype(::Type{Is}) where {Is<:Tuple} =
     tuple_type_cons(eltype(tuple_type_head(Is)), _zip_eltype(tuple_type_tail(Is)))

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -293,7 +293,7 @@ julia> first(c)
 (1, "e")
 ```
 """
-zip(a, b...) = Zip((a, b...))
+zip(a...) = Zip(a)
 length(z::Zip) = _zip_min_length(nothing, z.is)
 function _zip_min_length(::Nothing, is)
     i = is[1]
@@ -378,11 +378,12 @@ _zip_iterator_size(::Type{Is}) where {Is<:Tuple} =
     zip_iteratorsize(IteratorSize(tuple_type_head(Is)),
                      _zip_iterator_size(tuple_type_tail(Is)))
 _zip_iterator_size(::Type{Tuple{I}}) where {I} = IteratorSize(I)
+_zip_iterator_size(::Type{Tuple{}}) = IsInfinite()
 IteratorEltype(::Type{Zip{Is}}) where {Is<:Tuple} = _zip_iterator_eltype(Is)
 _zip_iterator_eltype(::Type{Is}) where {Is<:Tuple} =
     and_iteratoreltype(IteratorEltype(tuple_type_head(Is)),
                        _zip_iterator_eltype(tuple_type_tail(Is)))
-_zip_iterator_eltype(::Type{Tuple{I}}) where {I} = IteratorEltype(I)
+_zip_iterator_eltype(::Type{Tuple{}}) = HasEltype()
 
 reverse(z::Zip) = Zip(map(reverse, z.is))
 

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -396,58 +396,20 @@ _zip_eltype(::Type{Tuple{}}) = Tuple{}
     isdone(is[1], ss[1]) === true || _zip_any_isdone(tail(is), tail(ss))
 @inline _zip_any_isdone(::Tuple{}, ::Tuple{}) = false
 
-@propagate_inbounds function iterate(z::Zip)
-    ds = _zip_isdone(z.is)
-    ds === true && return nothing
-    xs = _zip_iterate_all1(z.is, ds)
-    xs === nothing && return nothing
-    _zip_iterate_all2(z.is, ds, xs)
-end
-@propagate_inbounds function _zip_iterate_all1(is, ds)
-    if ds[1] === missing
-        x = iterate(is[1])
-        x === nothing && return nothing
-        y = _zip_iterate_all1(tail(is), tail(ds))
-        y === nothing && return nothing
-        return (x, y...)
-    else
-        _zip_iterate_all1(tail(is), tail(ds))
-    end
-end
-_zip_iterate_all1(::Tuple{}, ::Tuple{}) = ()
-@propagate_inbounds function _zip_iterate_all2(is, ds, xs)
-    if ds[1] !== missing
-        x = iterate(is[1])
-        x === nothing && return nothing
-        y = _zip_iterate_all2(tail(is), tail(ds), xs)
-        y === nothing && return nothing
-        return ((x[1], y[1]...), (x[2], y[2]...))
-    else
-        y = _zip_iterate_all2(tail(is), tail(ds), tail(xs))
-        y === nothing && return nothing
-        return ((xs[1][1], y[1]...), (xs[1][2], y[2]...))
-    end
-end
-_zip_iterate_all2(::Tuple{}, ::Tuple{}, ::Tuple{}) = ((), ())
-function _zip_isdone(is)
-    d = isdone(is[1])
-    d === true && return true
-    ds = _zip_isdone(tail(is))
-    ds === true && return true
-    return (d, ds...)
-end
-_zip_isdone(::Tuple{}) = ()
+@propagate_inbounds iterate(z::Zip) = _zip_iterate_all(z.is, map(_ -> (), z.is))
+@propagate_inbounds iterate(z::Zip, ss) = _zip_iterate_all(z.is, map(tuple, ss))
 
-@propagate_inbounds function iterate(z::Zip, ss)
-    ds = _zip_isdone(z.is, ss)
+@propagate_inbounds function _zip_iterate_all(is, ss)
+    ds = _zip_isdone(is, ss)
     ds === true && return nothing
-    xs = _zip_iterate_all1(z.is, ss, ds)
+    xs = _zip_iterate_all1(is, ss, ds)
     xs === nothing && return nothing
-    _zip_iterate_all2(z.is, ss, ds, xs)
+    return _zip_iterate_all2(is, ss, ds, xs)
 end
+
 @propagate_inbounds function _zip_iterate_all1(is, ss, ds)
     if ds[1] === missing
-        x = iterate(is[1], ss[1])
+        x = iterate(is[1], ss[1]...)
         x === nothing && return nothing
         y = _zip_iterate_all1(tail(is), tail(ss), tail(ds))
         y === nothing && return nothing
@@ -457,9 +419,10 @@ end
     end
 end
 _zip_iterate_all1(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
+
 @propagate_inbounds function _zip_iterate_all2(is, ss, ds, xs)
     if ds[1] !== missing
-        x = iterate(is[1], ss[1])
+        x = iterate(is[1], ss[1]...)
         x === nothing && return nothing
         y = _zip_iterate_all2(tail(is), tail(ss), tail(ds), xs)
         y === nothing && return nothing
@@ -471,8 +434,9 @@ _zip_iterate_all1(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
     end
 end
 _zip_iterate_all2(::Tuple{}, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ((), ())
+
 function _zip_isdone(is, ss)
-    d = isdone(is[1], ss[1])
+    d = isdone(is[1], ss[1]...)
     d === true && return true
     ds = _zip_isdone(tail(is), tail(ss))
     ds === true && return true

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -364,11 +364,7 @@ function _zip_iterate_interleave(xs1, xs2, ds::Tuple{Bool,Vararg{Any}})
 end
 _zip_iterate_interleave(::Tuple{}, ::Tuple{}, ::Tuple{}) = ((), ())
 
-function _zip_isdone(is, ss)
-    d = isdone(is[1], ss[1]...)
-    d === true && return map(_ -> true, is) # no need to check the remaining ones, but fill with trues for type stability
-    return (d, _zip_isdone(tail(is), tail(ss))...)
-end
+_zip_isdone(is, ss) = (isdone(is[1], ss[1]...), _zip_isdone(tail(is), tail(ss))...)
 _zip_isdone(::Tuple{}, ::Tuple{}) = ()
 
 IteratorSize(::Type{Zip{Is}}) where {Is<:Tuple} = _zip_iterator_size(Is)

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -336,6 +336,10 @@ end
 @propagate_inbounds iterate(z::Zip) = _zip_iterate_all(z.is, map(_ -> (), z.is))
 @propagate_inbounds iterate(z::Zip, ss) = _zip_iterate_all(z.is, map(tuple, ss))
 
+# This first queries isdone from every iterator. If any gives true, it immediately returns
+# nothing. It then iterates all those where isdone returned missing, afterwards all those
+# it returned false, again terminating immediately if any iterator is exhausted. Finally,
+# the results are interleaved appropriately.
 @propagate_inbounds function _zip_iterate_all(is, ss)
     ds = _zip_isdone(is, ss)
     any(map(d -> d === true, ds)) === true && return nothing

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -337,8 +337,8 @@ end
 # it returned false, again terminating immediately if any iterator is exhausted. Finally,
 # the results are interleaved appropriately.
 @propagate_inbounds function _zip_iterate_all(is, ss)
-    ds = _zip_isdone(is, ss)
-    any(map(d -> d === true, ds)) === true && return nothing
+    d, ds = _zip_isdone(is, ss)
+    d && return nothing
     xs1 = _zip_iterate_some(is, ss, ds, missing)
     xs1 === nothing && return nothing
     xs2 = _zip_iterate_some(is, ss, ds, false)
@@ -367,8 +367,12 @@ function _zip_iterate_interleave(xs1, xs2, ds::Tuple{Bool,Vararg{Any}})
 end
 _zip_iterate_interleave(::Tuple{}, ::Tuple{}, ::Tuple{}) = ((), ())
 
-_zip_isdone(is, ss) = (isdone(is[1], ss[1]...), _zip_isdone(tail(is), tail(ss))...)
-_zip_isdone(::Tuple{}, ::Tuple{}) = ()
+function _zip_isdone(is, ss)
+    d = isdone(is[1], ss[1]...)
+    d´, ds = _zip_isdone(tail(is), tail(ss))
+    return (d === true || d´, (d, ds...))
+end
+_zip_isdone(::Tuple{}, ::Tuple{}) = (false, ())
 
 IteratorSize(::Type{Zip{Is}}) where {Is<:Tuple} = _zip_iterator_size(Is)
 _zip_iterator_size(::Type{Is}) where {Is<:Tuple} =

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -297,25 +297,21 @@ julia> first(c)
 ```
 """
 zip(a...) = Zip(a)
-length(z::Zip) = _zip_min_length(nothing, z.is)
-function _zip_min_length(::Nothing, is)
+function length(z::Zip)
+    n = _zip_min_length(z.is)
+    n === nothing && throw(ArgumentError("iterator is of undefined length"))
+    return n
+end
+function _zip_min_length(is)
     i = is[1]
+    n = _zip_min_length(tail(is))
     if IteratorSize(i) isa IsInfinite
-        return _zip_min_length(nothing, tail(is))
+        return n
     else
-        return _zip_min_length(length(i), tail(is))
+        return n === nothing ? length(i) : min(n, length(i))
     end
 end
-_zip_min_length(::Nothing, is::Tuple{Any}) = length(is[1])
-function _zip_min_length(n, is)
-    i = is[1]
-    if IteratorSize(i) isa IsInfinite
-        return _zip_min_length(n, tail(is))
-    else
-        return _zip_min_length(min(n, length(i)), tail(is))
-    end
-end
-_zip_min_length(n::Integer, is::Tuple{}) = n
+_zip_min_length(is::Tuple{}) = nothing
 size(z::Zip) = _promote_shape(map(size, z.is)...)
 axes(z::Zip) = _promote_shape(map(axes, z.is)...)
 _promote_shape(a, b...) = promote_shape(a, _promote_shape(b...))

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -540,6 +540,60 @@ end
 	@test isempty(collect(zip(b,a)))
 	@test !isempty(a)
     end
+    let a = Iterators.Stateful("a"), b = "", c = Iterators.Stateful("c")
+       @test isempty(collect(zip(a,b,c)))
+       @test !isempty(a)
+       @test !isempty(c)
+       @test isempty(collect(zip(a,c,b)))
+       @test !isempty(a)
+       @test !isempty(c)
+       @test isempty(collect(zip(b,a,c)))
+       @test !isempty(a)
+       @test !isempty(c)
+       @test isempty(collect(zip(b,c,a)))
+       @test !isempty(a)
+       @test !isempty(c)
+       @test isempty(collect(zip(c,a,b)))
+       @test !isempty(a)
+       @test !isempty(c)
+       @test isempty(collect(zip(c,b,a)))
+       @test !isempty(a)
+       @test !isempty(c)
+    end
+    let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+       @test length(collect(zip(a,b,c))) == 1
+       @test !isempty(a)
+       @test !isempty(c)
+   end
+   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+       @test length(collect(zip(a,c,b))) == 1
+       @test !isempty(a)
+       @test !isempty(c)
+   end
+   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+       @test length(collect(zip(b,a,c))) == 1
+       @test !isempty(a)
+       @test !isempty(c)
+   end
+   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+       @test length(collect(zip(b,c,a))) == 1
+       @test !isempty(a)
+       @test !isempty(c)
+   end
+   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+       @test length(collect(zip(c,a,b))) == 1
+       @test !isempty(a)
+       @test !isempty(c)
+   end
+   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+       @test length(collect(zip(c,b,a))) == 1
+       @test !isempty(a)
+       @test !isempty(c)
+    end
+    let z = zip(Iterators.Stateful("ab"), Iterators.Stateful("b"), Iterators.Stateful("c"))
+        v, s = iterate(z)
+        @test Base.isdone(z, s)
+    end
 end
 
 @testset "pair for Svec" begin

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -605,6 +605,8 @@ end
 @testset "inference for large zip #26765" begin
     x = zip(1:1, ["a"], (1.0,), Base.OneTo(1), Iterators.repeated("a"), 1.0:0.2:2.0,
             (1 for i in 1:1), Iterators.Stateful(["a"]), (1.0 for i in 1:2, j in 1:3), 1)
+    @test @inferred(length(x)) == 1
     z = Iterators.filter(x -> x[1] == 1, x)
+    @test @inferred(eltype(z)) <: Tuple{Int,String,Float64,Int,String,Float64,Any,String,Any,Int}
     @test @inferred(first(z)) == (1, "a", 1.0, 1, "a", 1.0, 1, "a", 1.0, 1)
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -541,54 +541,54 @@ end
 	@test !isempty(a)
     end
     let a = Iterators.Stateful("a"), b = "", c = Iterators.Stateful("c")
-       @test isempty(collect(zip(a,b,c)))
-       @test !isempty(a)
-       @test !isempty(c)
-       @test isempty(collect(zip(a,c,b)))
-       @test !isempty(a)
-       @test !isempty(c)
-       @test isempty(collect(zip(b,a,c)))
-       @test !isempty(a)
-       @test !isempty(c)
-       @test isempty(collect(zip(b,c,a)))
-       @test !isempty(a)
-       @test !isempty(c)
-       @test isempty(collect(zip(c,a,b)))
-       @test !isempty(a)
-       @test !isempty(c)
-       @test isempty(collect(zip(c,b,a)))
-       @test !isempty(a)
-       @test !isempty(c)
+        @test isempty(collect(zip(a,b,c)))
+        @test !isempty(a)
+        @test !isempty(c)
+        @test isempty(collect(zip(a,c,b)))
+        @test !isempty(a)
+        @test !isempty(c)
+        @test isempty(collect(zip(b,a,c)))
+        @test !isempty(a)
+        @test !isempty(c)
+        @test isempty(collect(zip(b,c,a)))
+        @test !isempty(a)
+        @test !isempty(c)
+        @test isempty(collect(zip(c,a,b)))
+        @test !isempty(a)
+        @test !isempty(c)
+        @test isempty(collect(zip(c,b,a)))
+        @test !isempty(a)
+        @test !isempty(c)
     end
     let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
-       @test length(collect(zip(a,b,c))) == 1
-       @test !isempty(a)
-       @test !isempty(c)
-   end
-   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
-       @test length(collect(zip(a,c,b))) == 1
-       @test !isempty(a)
-       @test !isempty(c)
-   end
-   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
-       @test length(collect(zip(b,a,c))) == 1
-       @test !isempty(a)
-       @test !isempty(c)
-   end
-   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
-       @test length(collect(zip(b,c,a))) == 1
-       @test !isempty(a)
-       @test !isempty(c)
-   end
-   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
-       @test length(collect(zip(c,a,b))) == 1
-       @test !isempty(a)
-       @test !isempty(c)
-   end
-   let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
-       @test length(collect(zip(c,b,a))) == 1
-       @test !isempty(a)
-       @test !isempty(c)
+        @test length(collect(zip(a,b,c))) == 1
+        @test !isempty(a)
+        @test !isempty(c)
+    end
+    let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+        @test length(collect(zip(a,c,b))) == 1
+        @test !isempty(a)
+        @test !isempty(c)
+    end
+    let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+        @test length(collect(zip(b,a,c))) == 1
+        @test !isempty(a)
+        @test !isempty(c)
+    end
+    let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+        @test length(collect(zip(b,c,a))) == 1
+        @test !isempty(a)
+        @test !isempty(c)
+    end
+    let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+        @test length(collect(zip(c,a,b))) == 1
+        @test !isempty(a)
+        @test !isempty(c)
+    end
+    let a = Iterators.Stateful("aa"), b = "b", c = Iterators.Stateful("cc")
+        @test length(collect(zip(c,b,a))) == 1
+        @test !isempty(a)
+        @test !isempty(c)
     end
     let z = zip(Iterators.Stateful("ab"), Iterators.Stateful("b"), Iterators.Stateful("c"))
         v, s = iterate(z)

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -604,7 +604,7 @@ end
 
 @testset "inference for large zip #26765" begin
     x = zip(1:1, ["a"], (1.0,), Base.OneTo(1), Iterators.repeated("a"), 1.0:0.2:2.0,
-            (1 for i in 1:1), ["a"], (1.0 for i in 1:2, j in 1:3), 1)
+            (1 for i in 1:1), Iterators.Stateful(["a"]), (1.0 for i in 1:2, j in 1:3), 1)
     z = Iterators.filter(x -> x[1] == 1, x)
     @test @inferred(first(z)) == (1, "a", 1.0, 1, "a", 1.0, 1, "a", 1.0, 1)
 end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -547,3 +547,10 @@ end
     @test ps isa Iterators.Pairs
     @test collect(ps) == [1 => :a, 2 => :b]
 end
+
+@testset "inference for large zip #26765" begin
+    x = zip(1:1, ["a"], (1.0,), Base.OneTo(1), Iterators.repeated("a"), 1.0:0.2:2.0,
+            (1 for i in 1:1), ["a"], (1.0 for i in 1:2, j in 1:3), 1)
+    z = Iterators.filter(x -> x[1] == 1, x)
+    @test @inferred(first(z)) == (1, "a", 1.0, 1, "a", 1.0, 1, "a", 1.0, 1)
+end

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -603,10 +603,11 @@ end
 end
 
 @testset "inference for large zip #26765" begin
-    x = zip(1:1, ["a"], (1.0,), Base.OneTo(1), Iterators.repeated("a"), 1.0:0.2:2.0,
-            (1 for i in 1:1), Iterators.Stateful(["a"]), (1.0 for i in 1:2, j in 1:3), 1)
-    @test @inferred(length(x)) == 1
-    z = Iterators.filter(x -> x[1] == 1, x)
-    @test @inferred(eltype(z)) <: Tuple{Int,String,Float64,Int,String,Float64,Any,String,Any,Int}
-    @test @inferred(first(z)) == (1, "a", 1.0, 1, "a", 1.0, 1, "a", 1.0, 1)
+    x = zip(1:2, ["a", "b"], (1.0, 2.0), Base.OneTo(2), Iterators.repeated("a"), 1.0:0.2:2.0,
+            (1 for i in 1:2), Iterators.Stateful(["a", "b", "c"]), (1.0 for i in 1:2, j in 1:3))
+    @test @inferred(length(x)) == 2
+    z = Iterators.filter(x -> x[1] >= 1, x)
+    @test @inferred(eltype(z)) <: Tuple{Int,String,Float64,Int,String,Float64,Any,String,Any}
+    @test @inferred(first(z)) == (1, "a", 1.0, 1, "a", 1.0, 1, "a", 1.0)
+    @test @inferred(first(Iterators.drop(z, 1))) == (2, "b", 2.0, 2, "a", 1.2, 1, "c", 1.0)
 end


### PR DESCRIPTION
Instead of creating a `zip` of more than two iterators by forming a tree structure, store all iterators in a tuple. It should be possible to get rid of `Zip1` and `Zip2`, but I wasn't sure of a good benchmark to quickly check locally whether the more general code was sub-optimal in the short case, hence WIP—ideas welcome!

Fixes #26765.