### PR TITLE
implement "nearly division less" algorithm for rand(a:b)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -169,6 +169,13 @@ Standard library changes
 * `randn!(::MersenneTwister, ::Array{Float64})` is faster, and as a result, for a given state of the RNG,
   the corresponding generated numbers have changed ([#35078]).
 
+* A new faster algorithm ("nearly division less") is used for generating random numbers
+  within a range ([#29240]).
+  As a result, the streams of generated numbers is changed.
+  Also, for performance, the undocumented property that, given a seed and `a, b` of type `Int`,
+  `rand(a:b)` produces the same stream on 32 and 64 bits architectures, is dropped.
+
+
 #### REPL
 
 

--- a/stdlib/LinearAlgebra/test/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/test/bunchkaufman.jl
@@ -12,7 +12,7 @@ n = 10
 n1 = div(n, 2)
 n2 = 2*n1
 
-Random.seed!(1234321)
+Random.seed!(12343210)
 
 areal = randn(n,n)/2
 aimg  = randn(n,n)/2

--- a/stdlib/Random/docs/src/index.md
+++ b/stdlib/Random/docs/src/index.md
@@ -145,22 +145,22 @@ Scalar and array methods for `Die` now work as expected:
 
 ```jldoctest Die; setup = :(Random.seed!(1))
 julia> rand(Die)
-Die(18)
+Die(10)
 
 julia> rand(MersenneTwister(0), Die)
-Die(4)
+Die(16)
 
 julia> rand(Die, 3)
 3-element Array{Die,1}:
- Die(6)
- Die(11)
  Die(5)
+ Die(20)
+ Die(9)
 
 julia> a = Vector{Die}(undef, 3); rand!(a)
 3-element Array{Die,1}:
- Die(18)
- Die(6)
- Die(8)
+ Die(11)
+ Die(20)
+ Die(10)
 ```
 
 #### A simple sampler without pre-computed data
@@ -173,11 +173,11 @@ In order to define random generation out of objects of type `S`, the following m
 julia> Random.rand(rng::AbstractRNG, d::Random.SamplerTrivial{Die}) = rand(rng, 1:d[].nsides);
 
 julia> rand(Die(4))
-3
+2
 
 julia> rand(Die(4), 3)
 3-element Array{Any,1}:
- 3
+ 1
  4
  2
 ```

--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -602,14 +602,6 @@ for T in BitInteger_types
     end
 end
 
-#### from a range
-
-for T in BitInteger_types, R=(1, Inf) # eval because of ambiguity otherwise
-    @eval Sampler(::Type{MersenneTwister}, r::AbstractUnitRange{$T}, ::Val{$R}) =
-        SamplerRangeFast(r)
-end
-
-
 ### randjump
 
 # Old randjump methods are deprecated, the scalar version is in the Future module.

--- a/stdlib/Random/src/generation.jl
+++ b/stdlib/Random/src/generation.jl
@@ -303,7 +303,7 @@ end
 
 #### Nearly Division Less
 
-# cf. https://arxiv.org/abs/1805.10941
+# cf. https://arxiv.org/abs/1805.10941 (algorithm 5)
 
 struct SamplerRangeNDL{U<:Unsigned,T} <: Sampler{T}
     a::T  # first element of the range
@@ -326,7 +326,7 @@ function rand(rng::AbstractRNG, sp::SamplerRangeNDL{U,T}) where {U,T}
     m = x * s
     l = m % U
     if l < s
-        t = mod(-s, s)
+        t = mod(-s, s) # as s is unsigned, -s is equal to 2^L - s in the paper
         while l < t
             x = widen(rand(rng, U))
             m = x * s

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -52,14 +52,14 @@ number generator, see [Random Numbers](@ref).
 
 # Examples
 ```jldoctest
-julia> Random.seed!(0); randstring()
-"0IPrGg0J"
+julia> Random.seed!(3); randstring()
+"4zSHdXlw"
 
-julia> randstring(MersenneTwister(0), 'a':'z', 6)
-"aszvqk"
+julia> randstring(MersenneTwister(3), 'a':'z', 6)
+"bzlhqn"
 
 julia> randstring("ACGT")
-"TATCGGTC"
+"AGGACATT"
 ```
 
 !!! note

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -810,3 +810,12 @@ end
 @testset "RNGs broadcast as scalars: T" for T in (MersenneTwister, RandomDevice)
     @test length.(rand.(T(), 1:3)) == 1:3
 end
+
+@testset "fast(a:b)" begin
+    for bounds = (rand(Int, 2), rand(-1000:1000, 2))
+        a, b = minmax(bounds...)
+        a == b && continue
+        @test rand(Random.fast(a:b)) ∈ a:b
+        @test rand(Random.fast(a:1:b)) ∈ a:b
+    end
+end

--- a/stdlib/Random/test/runtests.jl
+++ b/stdlib/Random/test/runtests.jl
@@ -813,7 +813,7 @@ end
 
 @testset "fast(a:b)" begin
     for bounds = (rand(Int, 2), rand(-1000:1000, 2))
-        a, b = minmax(bounds...)
+        a, b = minmax((bounds .>> 2)...) # right-shift to avoid overflow in length(a:1:b)
         a == b && continue
         @test rand(Random.fast(a:b)) ∈ a:b
         @test rand(Random.fast(a:1:b)) ∈ a:b


### PR DESCRIPTION
Cf. https://arxiv.org/abs/1805.10941.
Closes #20582, #29004.

This is still about 30 percent slower than the "biased" solution (e.g. #28987), but as fast as the "best case" of the current version (when the range length is a power of 2). So this is strictly better, and should become the default version in a future (major) release. How do we make this available  in the meantime? `rand(Random.fast(a:b))` is what the PR currently implements.