### PR TITLE
REPL: allow tweaking the implicit IOContext of the REPL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,11 @@ Standard library changes
 * The performance of `rand(::Tuple)` is improved in some cases ([#32208]). As a consequence, the
   stream of generated values produced for a given seed has changed.
 
+#### REPL
+
+* The attributes of the implicit `IOContext` used by the REPL to display objects can be
+  modified by the user (experimental feature) ([#29249]).
+
 #### SparseArrays
 
 #### Dates

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -52,6 +52,38 @@ If it is enabled, you can try it out by pasting the code block above this paragr
 the REPL. This feature does not work on the standard Windows command prompt due to its limitation
 at detecting when a paste occurs.
 
+Objects are printed at the REPL using the [`show`](@ref) function with a specific [`IOContext`](@ref).
+In particular, the `:limit` attribute is set to `true`.
+Other attributes can receive in certain `show` methods a default value if it's not already set,
+like `:compact`.
+It's possible, as an experimental feature, to specify the attributes used by the REPL via the
+`Base.active_repl.options.iocontext` dictionary (associating values to attributes). For example:
+
+```julia-repl
+julia> rand(2, 2)
+2×2 Array{Float64,2}:
+ 0.8833    0.329197
+ 0.719708  0.59114
+
+julia> show(IOContext(stdout, :compact => false), "text/plain", rand(2, 2))
+ 0.43540323669187075  0.15759787870609387
+ 0.2540832269192739   0.4597637838786053
+julia> Base.active_repl.options.iocontext[:compact] = false;
+
+julia> rand(2, 2)
+2×2 Array{Float64,2}:
+ 0.2083967319174056  0.13330606013126012
+ 0.6244375177790158  0.9777957560761545
+```
+
+In order to define automatically the values of this dictionary at startup time, one can use the
+[`atreplinit`](@ref) function in the `~/.julia/config/startup.jl` file, for example:
+```julia
+atreplinit() do repl
+    repl.options.iocontext[:compact] = false
+end
+```
+
 ### Help mode
 
 When the cursor is at the beginning of the line, the prompt can be changed to a help mode by typing
@@ -174,7 +206,6 @@ to do so), or pressing Esc and then the key.
 | `^Q`                | Write a number in REPL and press `^Q` to open editor at corresponding stackframe or method                 |
 | `meta-Left Arrow`   | indent the current line on the left                                                                        |
 | `meta-Right Arrow`  | indent the current line on the right                                                                       |
-
 
 ### Customizing keybindings
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -129,7 +129,12 @@ end
 function display(d::REPLDisplay, mime::MIME"text/plain", x)
     io = outstream(d.repl)
     get(io, :color, false) && write(io, answer_color(d.repl))
-    show(IOContext(io, :limit => true, :module => Main), mime, x)
+    if isdefined(d.repl, :options) && isdefined(d.repl.options, :iocontext)
+        # this can override the :limit property set initially
+        io = foldl(IOContext, d.repl.options.iocontext,
+                   init=IOContext(io, :limit => true, :module => Main))
+    end
+    show(io, mime, x)
     println(io)
     nothing
 end
@@ -283,6 +288,8 @@ mutable struct Options
     auto_indent_bracketed_paste::Bool # set to true if terminal knows paste mode
     # cancel auto-indent when next character is entered within this time frame :
     auto_indent_time_threshold::Float64
+    # default IOContext settings at the REPL
+    iocontext::Dict{Symbol,Any}
 end
 
 Options(;
@@ -299,13 +306,16 @@ Options(;
         auto_indent = true,
         auto_indent_tmp_off = false,
         auto_indent_bracketed_paste = false,
-        auto_indent_time_threshold = 0.005) =
+        auto_indent_time_threshold = 0.005,
+        iocontext = Dict{Symbol,Any}()) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
                     beep_duration, beep_blink, beep_maxduration,
                     beep_colors, beep_use_current,
                     backspace_align, backspace_adjust, confirm_exit,
-                    auto_indent, auto_indent_tmp_off, auto_indent_bracketed_paste, auto_indent_time_threshold)
+                    auto_indent, auto_indent_tmp_off, auto_indent_bracketed_paste,
+                    auto_indent_time_threshold,
+                    iocontext)
 
 # for use by REPLs not having an options field
 const GlobalOptions = Options()


### PR DESCRIPTION
This adds an `iocontext::Dict{Symbol,Any}` field to `LineEditREPL`,
which can be initialized with `atreplinit`, and updated
interactively, e.g. `Base.active_repl.iocontext[:compact] = true`.

Fixes #20509.

An alternative would be providing specific functions, e.g. `setiocontext(:key, value)`, `resetiocontext(:key)` or something. I think I prefer the dictionnary approach, because a `Dict` already has a convenient API for the needs here, and as an interactive feature, this can be changed relatively easily if needed.

I wonder whether we should think about a namespace policy to use this, as package `X` could say for example "use `iocontext[:format] = :bin` for printing with binary digits", while package `Y` could say have `iocontext[:format] = whatever` to control formatting of other stuff, and it becomes impossible to have control over both packages at the same time.
Another option would therefore to have a predetermined list of settable properties (`:compact`, `:limit` etc), in which case using a `mutable struct` with corresponding fields would probably be a more appropriate implementation than a `Dict`. 