### PR TITLE
Initialise DEPOT_PATH and LOAD_PATH before stdio

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -466,12 +466,12 @@ function __init__()
     end
     # for the few uses of Libc.rand in Base:
     Libc.srand()
-    # Base library init
-    reinit_stdio()
-    Multimedia.reinit_displays() # since Multimedia.displays uses stdout as fallback
     # initialize loading
     init_depot_path()
     init_load_path()
+    # Base library init
+    reinit_stdio()
+    Multimedia.reinit_displays() # since Multimedia.displays uses stdout as fallback
     nothing
 end
 


### PR DESCRIPTION
If stdin is a TCP socket, init_stdio tries to include the Sockets
module, but this is in stdlib and it fails to find the package if the
LOAD_PATH is not initialised.

julialang/julia#29234