### PR TITLE
faster String allocation

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -467,7 +467,8 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
 
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
 {
-    jl_value_t *s = jl_gc_alloc(jl_get_ptls_states(), sizeof(size_t)+len+1, jl_string_type);
+    size_t sz = sizeof(size_t) + len + 1; // add space for trailing \nul protector and size
+    jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, jl_string_type); // force inlining
     *(size_t*)s = len;
     memcpy((char*)s + sizeof(size_t), str, len);
     ((char*)s + sizeof(size_t))[len] = 0;
@@ -476,7 +477,8 @@ JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
 
 JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
 {
-    jl_value_t *s = jl_gc_alloc(jl_get_ptls_states(), sizeof(size_t)+len+1, jl_string_type);
+    size_t sz = sizeof(size_t) + len + 1; // add space for trailing \nul protector and size
+    jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, jl_string_type); // force inlining
     *(size_t*)s = len;
     ((char*)s + sizeof(size_t))[len] = 0;
     return s;


### PR DESCRIPTION
Only a few % difference in performance measurements (the majority of time is usually spent in examining the current state of the pool), but this essentially removes the cost of computing the sizeclass, so it should save on processor resources (frontend, BTP) especially.

I'm also hoping this will help unstick #21959, since it makes changing the size classes easy.