### PR TITLE
Extend code_typed to be able to debug constant prop

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -503,11 +503,13 @@ end
 #### entry points for inferring a MethodInstance given a type signature ####
 
 # compute an inferred AST and return type
-function typeinf_code(method::Method, @nospecialize(atypes), sparams::SimpleVector, run_optimizer::Bool, params::Params)
-    code = code_for_method(method, atypes, sparams, params.world)
+function typeinf_code(method::Method, @nospecialize(msig), sparams::SimpleVector,
+                      run_optimizer::Bool, params::Params,
+                      atypes::Union{Nothing, Vector{Any}} = nothing)
+    code = code_for_method(method, msig, sparams, params.world)
     code === nothing && return (nothing, Any)
     ccall(:jl_typeinf_begin, Cvoid, ())
-    result = InferenceResult(code)
+    result = atypes === nothing ? InferenceResult(code) : InferenceResult(code, atypes)
     frame = InferenceState(result, false, params)
     frame === nothing && return (nothing, Any)
     if typeinf(frame) && run_optimizer

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -866,13 +866,18 @@ function func_for_method_checked(m::Method, @nospecialize types)
 end
 
 """
-    code_typed(f, types; optimize=true)
+    code_typed(f, types [, constvals::Vector{Any}]; optimize=true)
 
 Returns an array of type-inferred lowered form (IR) for the methods matching the given
 generic function and type signature. The keyword argument `optimize` controls whether
 additional optimizations, such as inlining, are also applied.
+
+If `constvals` is specified, every non #undef argument, specified in
+`constvals` will be provided to inference (as it would during interprocedural
+constant propagation). This is useful for IPO debugging purposes.
 """
-function code_typed(@nospecialize(f), @nospecialize(types=Tuple); optimize=true)
+function code_typed(@nospecialize(f), @nospecialize(types=Tuple),
+                    constvals::Union{Nothing, Array{Any, 1}}=nothing; optimize=true)
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -883,7 +888,16 @@ function code_typed(@nospecialize(f), @nospecialize(types=Tuple); optimize=true)
     params = Core.Compiler.Params(world)
     for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
-        (code, ty) = Core.Compiler.typeinf_code(meth, x[1], x[2], optimize, params)
+        argtypes = nothing
+        if constvals !== nothing
+            argtypes = Vector(undef, length(types.parameters)+1)
+            for i = 1:length(types.parameters)+1
+                argtypes[i] = isassigned(constvals, i) ?
+                    Core.Compiler.Const(constvals[i]) : (
+                        i == 1 ? typeof(f) : types.parameters[i-1])
+            end
+        end
+        (code, ty) = Core.Compiler.typeinf_code(meth, x[1], x[2], optimize, params, argtypes)
         code === nothing && error("inference not successful") # inference disabled?
         push!(asts, code => ty)
     end


### PR DESCRIPTION
I'm currently debugging code that uses a lot of arrays with
dimensions in their type parameters. This type of code heavily
relies on constant propagation to lift dimensions from the value
domain into the type domain. Unfortunately, it's a bit hard to
discover what exactly causes inference to drop information from
constants, because there's no way to feed in constants for a
particular invocation using code_typed. This is a quick hack to
remidy that, by making `$`-interpolated expressions available
as constants to type inference, e.g.

```julia
julia> @code_typed 1+1
CodeInfo(
53 1 ─ %1 = (Base.add_int)(x, y)::Int64
   └──      return %1
) => Int64

julia> @code_typed $(1)+$(1)
CodeInfo(
53 1 ─     return 2
) => Int64
```

This is missing handling for a bunch of the other cases in code_typed, which is why this is WIP. I plan to put those in and finish this up once I've confirmed this is useful, but figured I'd put it up in the meantime. 