### PR TITLE
Added a note to sortperm! docstring that setting initialized=true can be dangerous!

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -866,7 +866,8 @@ end
     sortperm!(ix, v; alg::Algorithm=DEFAULT_UNSTABLE, lt=isless, by=identity, rev::Bool=false, order::Ordering=Forward, initialized::Bool=false)
 
 Like [`sortperm`](@ref), but accepts a preallocated index vector `ix`.  If `initialized` is `false`
-(the default), `ix` is initialized to contain the values `1:length(v)`.
+(the default), `ix` is initialized to contain the values `1:length(v)`. Note that if `initialized` is `true`,
+and `ix` is not properly initialized, julia is likely to crash.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Fixes #29179 

Please close with prejudice if this is not actually desired!

EDIT: @chethega does this addition seem like it would be sufficient, or is there additional information that should be added/changed?