### PR TITLE
Disable CFG transforms for now

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -471,7 +471,7 @@ mutable struct IncrementalCompact
     active_result_bb::Int
     renamed_new_nodes::Bool
     allow_cfg_transforms::Bool
-    function IncrementalCompact(code::IRCode, allow_cfg_transforms::Bool=true)
+    function IncrementalCompact(code::IRCode, allow_cfg_transforms::Bool=false)
         # Sort by position with attach after nodes affter regular ones
         perm = my_sortperm(Int[(code.new_nodes[i].pos*2 + Int(code.new_nodes[i].attach_after)) for i in 1:length(code.new_nodes)])
         new_len = length(code.stmts) + length(code.new_nodes)

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -159,4 +159,4 @@ function f_ifelse(x)
     return b ? x + 1 : x
 end
 # 2 for now because the compiler leaves a GotoNode around
-@test length(code_typed(f_ifelse, (String,))[1][1].code) <= 2
+@test_broken length(code_typed(f_ifelse, (String,))[1][1].code) <= 2


### PR DESCRIPTION
CFG transforms can currently cause issues like #29107,
but I'm still a few days away from fixing this properly. In the meantime,
disable the transform.