### PR TITLE
Add a line continuation character '⤸'

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -107,6 +107,7 @@ const latex_symbols = Dict(
     "\\impliedby" => "⟸",
     "\\to" => "→",
     "\\euler" => "ℯ",
+    "\\linecontinuation" => "⤸",
 
     # Superscripts
     "\\^0" => "⁰",

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1719,6 +1719,13 @@ let g = @foo28900 f28900(kwarg = x->2x)
     @test g(10) == 20
 end
 
+# Line continuation - issue #27533
+@test Meta.parse("[1 ⤸\n 2]") == Expr(:hcat, 1, 2)
+@test Meta.parse("@f ⤸\n a") == Expr(:macrocall, Symbol("@f"), LineNumberNode(1, :none), :a)
+@test Meta.isexpr(Meta.parse("@f ⤸"), :incomplete)
+@test_throws ParseError("Line continuation '⤸' is only allowed for space separated lists like macros arugments and matrix literals") Meta.parse("x ⤸\n = 1")
+@test_throws ParseError("Line continuation '⤸' must be followed by a newline. Got \"⤸ \" instead") Meta.parse("@x ⤸ \n")
+
 # issue #26037
 x26037() = 10
 function test_26037()


### PR DESCRIPTION
Closes #27533 by adding a line continuation character which is only valid in space sensitive parsing contexts (see https://github.com/JuliaLang/julia/issues/27533#issuecomment-422672161)

I've often wanted a nice way to continue space separated argument lists for macros across multiple lines. Resorting to function call syntax isn't very satisfying because it's quite syntactically different from the usual way that macros look in julia code.

Demo:

```julia
# Valid - space sensitive context
@info "A message which could be rather long" ⤸
      a="something more"                     ⤸
      b="another thing"

# Invalid - there should only be one way to do this
x = some_variable ⤸
    + other_variable
# Valid - the current, perfectly good convention for writing this
x = some_variable +
    other_variable
```