### PR TITLE
ArgumentError("stream is closed or unusable") -> IOError

### DIFF
--- a/base/stream.jl
+++ b/base/stream.jl
@@ -253,7 +253,7 @@ end
 
 function check_open(x::Union{LibuvStream, LibuvServer})
     if !isopen(x) || x.status == StatusClosing
-        throw(ArgumentError("stream is closed or unusable"))
+        throw(IOError("stream is closed or unusable", 0))
     end
 end
 

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -328,7 +328,7 @@ let out = Pipe(), echo = `$exename --startup-file=no -e 'print(stdout, " 1\t", r
             @test !isopen(out.out)
             @test !isreadable(out)
         end
-        @test_throws ArgumentError write(out, "now closed error")
+        @test_throws Base.IOError write(out, "now closed error")
         if Sys.iswindows()
             # WINNT kernel appears to not provide a fast mechanism for async propagation
             # of EOF for a blocking stream, so just wait for it to catch up.


### PR DESCRIPTION
Fix #29260