### PR TITLE
Changed one identifier in one example

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2052,11 +2052,11 @@ collection. `destination` must be at least as large as the first collection.
 
 # Examples
 ```jldoctest
-julia> x = zeros(3);
+julia> a = zeros(3);
 
-julia> map!(x -> x * 2, x, [1, 2, 3]);
+julia> map!(x -> x * 2, a, [1, 2, 3]);
 
-julia> x
+julia> a
 3-element Array{Float64,1}:
  2.0
  4.0


### PR DESCRIPTION
The example used identifier `x` for two different purposes. While this isn't a problem for Julia, it makes humans have to read much more carefully. For examples I think it is much clearer to use different identifiers for different purposes.