### PR TITLE
GC improvements for #28986

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -947,7 +947,7 @@ void gc_time_mallocd_array_end(void)
 }
 
 void gc_time_mark_pause(int64_t t0, int64_t scanned_bytes,
-                        int64_t perm_scanned_bytes)
+                        int64_t old_scanned_bytes)
 {
     int64_t last_remset_len = 0;
     int64_t remset_nptr = 0;
@@ -960,8 +960,8 @@ void gc_time_mark_pause(int64_t t0, int64_t scanned_bytes,
               "scanned %" PRId64 " kB = %" PRId64 " + %" PRId64 " | "
               "remset %" PRId64 " %" PRId64 "\n",
               jl_ns2ms(gc_premark_end - t0),
-              (scanned_bytes + perm_scanned_bytes) / 1024,
-              scanned_bytes / 1024, perm_scanned_bytes / 1024,
+              (scanned_bytes + old_scanned_bytes) / 1024,
+              scanned_bytes / 1024, old_scanned_bytes / 1024,
               last_remset_len, remset_nptr);
 }
 

--- a/src/gc.h
+++ b/src/gc.h
@@ -538,7 +538,7 @@ void gc_time_count_mallocd_array(int bits) JL_NOTSAFEPOINT;
 void gc_time_mallocd_array_end(void) JL_NOTSAFEPOINT;
 
 void gc_time_mark_pause(int64_t t0, int64_t scanned_bytes,
-                        int64_t perm_scanned_bytes);
+                        int64_t old_scanned_bytes);
 void gc_time_sweep_pause(uint64_t gc_end_t, int64_t actual_allocd,
                          int64_t live_bytes, int64_t estimate_freed,
                          int sweep_full);
@@ -564,7 +564,7 @@ STATIC_INLINE void gc_time_count_mallocd_array(int bits) JL_NOTSAFEPOINT
     (void)bits;
 }
 #define gc_time_mallocd_array_end()
-#define gc_time_mark_pause(t0, scanned_bytes, perm_scanned_bytes)
+#define gc_time_mark_pause(t0, scanned_bytes, old_scanned_bytes)
 #define gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,        \
                             estimate_freed, sweep_full)
 #endif

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -59,8 +59,8 @@ typedef struct {
 // This is sync'd after marking.
 typedef union _jl_gc_mark_data jl_gc_mark_data_t;
 typedef struct {
-    // thread local increment of `perm_scanned_bytes`
-    size_t perm_scanned_bytes;
+    // thread local increment of `old_scanned_bytes`
+    size_t old_scanned_bytes;
     // thread local increment of `scanned_bytes`
     size_t scanned_bytes;
     // Number of queued big objects (<= 1024)


### PR DESCRIPTION
@ekinakyurek @denizyuret Please try your code with this and see what happens.

This (1) clears roots with null in codegen to allow freeing objects sooner, and (2) updates the size-based heuristic for full collections to only use old objects. Both of these seem to be necessary to make a good dent in the issue.

With this change:
```
julia> @timev ffast();
  2.100257 seconds (154 allocations: 980.006 MiB, 1.49% gc time)
elapsed time (ns): 2100256760
gc time (ns):      31207794
bytes allocated:   1027610400
pool allocs:       124
malloc() calls:    30
GC pauses:         30

julia> @timev fslow();
  2.658944 seconds (154 allocations: 980.006 MiB, 2.12% gc time)
elapsed time (ns): 2658943611
gc time (ns):      56324324
bytes allocated:   1027610400
pool allocs:       124
malloc() calls:    30
GC pauses:         30
```
No full collections, but see the end of the issue for discussion of the remaining difference.

Fun stat: the extra root-nulling adds 0.2% to the system image (about 280k).

@nanosoldier `runbenchmarks(ALL, vs=":master")`