### PR TITLE
stdlib/SparseArrays: add rmul! and lmul! of sparse matrix with Diagonal

### DIFF
--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1027,11 +1027,8 @@ function rmul!(A::SparseMatrixCSC, D::Diagonal{T}) where T
     m, n = size(A)
     (n == size(D, 1)) || throw(DimensionMismatch())
     Anzval = A.nzval
-    @inbounds for col = 1:n
-        scale = D.diag[col]
-        for p = A.colptr[col]:(A.colptr[col + 1] - 1)
-            Anzval[p] *= scale
-        end
+    @inbounds for col = 1:n, p = A.colptr[col]:(A.colptr[col + 1] - 1)
+         Anzval[p] *= D.diag[col]
     end
     return A
 end

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1023,7 +1023,7 @@ function lmul!(b::Number, A::SparseMatrixCSC)
     return A
 end
 
-function rmul!(A::SparseMatrixCSC, D::Diagonal{T}) where T
+function rmul!(A::SparseMatrixCSC, D::Diagonal)
     m, n = size(A)
     (n == size(D, 1)) || throw(DimensionMismatch())
     Anzval = A.nzval
@@ -1033,7 +1033,7 @@ function rmul!(A::SparseMatrixCSC, D::Diagonal{T}) where T
     return A
 end
 
-function lmul!(D::Diagonal{T}, A::SparseMatrixCSC) where T
+function lmul!(D::Diagonal, A::SparseMatrixCSC)
     m, n = size(A)
     (m == size(D, 2)) || throw(DimensionMismatch())
     Anzval = A.nzval

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1017,8 +1017,30 @@ function rmul!(A::SparseMatrixCSC, b::Number)
     rmul!(A.nzval, b)
     return A
 end
+
 function lmul!(b::Number, A::SparseMatrixCSC)
     lmul!(b, A.nzval)
+    return A
+end
+
+function rmul!(A::SparseMatrixCSC, D::Diagonal{T}) where T
+    m, n = size(A)
+    (n == size(D, 1)) || throw(DimensionMismatch())
+    Anzval = A.nzval
+    for col = 1:n, p = A.colptr[col]:(A.colptr[col+1]-1)
+        @inbounds Anzval[p] *= D.diag[col]
+    end
+    return A
+end
+
+function lmul!(D::Diagonal{T}, A::SparseMatrixCSC) where T
+    m, n = size(A)
+    (m == size(D, 2)) || throw(DimensionMismatch())
+    Anzval = A.nzval
+    Arowval = A.rowval
+    for col = 1:n, p = A.colptr[col]:(A.colptr[col+1]-1)
+        @inbounds Anzval[p] *= D.diag[Arowval[p]]
+    end
     return A
 end
 

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1027,8 +1027,11 @@ function rmul!(A::SparseMatrixCSC, D::Diagonal{T}) where T
     m, n = size(A)
     (n == size(D, 1)) || throw(DimensionMismatch())
     Anzval = A.nzval
-    for col = 1:n, p = A.colptr[col]:(A.colptr[col+1]-1)
-        @inbounds Anzval[p] *= D.diag[col]
+    @inbounds for col = 1:n
+        scale = D.diag[col]
+        for p = A.colptr[col]:(A.colptr[col + 1] - 1)
+            Anzval[p] *= scale
+        end
     end
     return A
 end
@@ -1038,8 +1041,8 @@ function lmul!(D::Diagonal{T}, A::SparseMatrixCSC) where T
     (m == size(D, 2)) || throw(DimensionMismatch())
     Anzval = A.nzval
     Arowval = A.rowval
-    for col = 1:n, p = A.colptr[col]:(A.colptr[col+1]-1)
-        @inbounds Anzval[p] *= D.diag[Arowval[p]]
+    @inbounds for col = 1:n, p = A.colptr[col]:(A.colptr[col + 1] - 1)
+        Anzval[p] *= D.diag[Arowval[p]]
     end
     return A
 end


### PR DESCRIPTION
Fixes #29111. Previously, `lmul!` and `rmul!` had no special method for multiplying a sparse matrix with a diagonal matrix in-place, but fell back to the generic `LinearAlgebra/Diagonal`-method. Tests had been included before.