### PR TITLE
Don't error on help for keyword functions

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -295,7 +295,7 @@ repl(x) = repl(stdout, x)
 
 _repl_typeof(arg::Symbol) = :(::(@isdefined($arg) ? typeof($arg) : Any))
 _repl_typeof(arg) = isexpr(arg, :kw) ? :(Expr(:kw, arg[1], _repl_typeof(arg[2]))) :
-                                       :(typeof($arg))
+                                       :(::typeof($arg))
 
 function _repl(x)
     if isexpr(x, :call) && !any(isexpr(x, :(::)) for x in x.args)

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -983,14 +983,28 @@ let dt1 = _repl(:(dynamic_test(1.0)))
     @test dt1.args[1] isa Expr
     @test dt1.args[1].head === :macrocall
     @test dt1.args[1].args[1] == Symbol("@doc")
-    @test dt1.args[1].args[3] == :(dynamic_test(::typeof(1.0;)))
+    @test dt1.args[1].args[3] == :(dynamic_test(::typeof(1.0)))
 end
 let dt2 = _repl(:(dynamic_test(::String)))
     @test dt2 isa Expr
     @test dt2.args[1] isa Expr
     @test dt2.args[1].head === :macrocall
     @test dt2.args[1].args[1] == Symbol("@doc")
-    @test dt2.args[1].args[3] == :(dynamic_test(::String;))
+    @test dt2.args[1].args[3] == :(dynamic_test(::String))
+end
+let dt3 = _repl(:(dynamic_test(a)))
+    @test dt3 isa Expr
+    @test dt3.args[1] isa Expr
+    @test dt3.args[1].head === :macrocall
+    @test dt3.args[1].args[1] == Symbol("@doc")
+    @test dt3.args[1].args[3].args[2].head == :(::) # can't test equality due to line numbers
+end
+let dt4 = _repl(:(dynamic_test(1.0,u=2.0)))
+    @test dt4 isa Expr
+    @test dt4.args[1] isa Expr
+    @test dt4.args[1].head === :macrocall
+    @test dt4.args[1].args[1] == Symbol("@doc")
+    @test dt4.args[1].args[3] == :(dynamic_test(::typeof(1.0); u::typeof(2.0)=2.0))
 end
 
 # Equality testing

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -983,14 +983,14 @@ let dt1 = _repl(:(dynamic_test(1.0)))
     @test dt1.args[1] isa Expr
     @test dt1.args[1].head === :macrocall
     @test dt1.args[1].args[1] == Symbol("@doc")
-    @test dt1.args[1].args[3] == :(dynamic_test(::typeof(1.0)))
+    @test dt1.args[1].args[3] == :(dynamic_test(::typeof(1.0;)))
 end
 let dt2 = _repl(:(dynamic_test(::String)))
     @test dt2 isa Expr
     @test dt2.args[1] isa Expr
     @test dt2.args[1].head === :macrocall
     @test dt2.args[1].args[1] == Symbol("@doc")
-    @test dt2.args[1].args[3] == :(dynamic_test(::String))
+    @test dt2.args[1].args[3] == :(dynamic_test(::String;))
 end
 
 # Equality testing


### PR DESCRIPTION
Fixes #23991.

Also allows for help where some arguments are undefined.