### PR TITLE
fix bug in parsing extended colon-like operators

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -830,7 +830,7 @@
              (first? #t))
     (let* ((t   (peek-token s))
            (spc (ts:space? s)))
-      (cond ((and first? (eq? t '|..|))
+      (cond ((and first? (is-prec-colon? t) (not (eq? t ':)))
              (take-token s)
              `(call ,t ,ex ,(parse-expr s)))
             ((and range-colon-enabled (eq? t ':))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1728,3 +1728,10 @@ function test_26037()
     end
 end
 @test test_26037() === nothing  # no UndefVarError
+
+# range and interval operators
+@test Meta.parse("1…2") == Expr(:call, :…, 1, 2)
+@test Meta.parse("1⁝2") == Expr(:call, :⁝, 1, 2)
+@test Meta.parse("1..2") == Expr(:call, :.., 1, 2)
+# we don't parse chains of these since the associativity and meaning aren't clear
+@test_throws ParseError Meta.parse("1..2..3")


### PR DESCRIPTION
#26262 added some operators to the `:` precedence level, but the parsing code for that is a bit non-standard so they did not actually parse. This fixes it. Should be non-breaking since trying to use the operators gave an error before.