### PR TITLE
base64urlencode, base64urldecode

### DIFF
--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -7,8 +7,10 @@ using Base: has_offset_axes
 export
     Base64EncodePipe,
     base64encode,
+    base64urlencode,
     Base64DecodePipe,
     base64decode,
+    base64urldecode,
     stringmime
 
 # Base64EncodePipe is a pipe-like IO object, which converts into base64 data

--- a/stdlib/Base64/test/runtests.jl
+++ b/stdlib/Base64/test/runtests.jl
@@ -4,8 +4,10 @@ using Test, Random
 import Base64:
     Base64EncodePipe,
     base64encode,
+    base64urlencode,
     Base64DecodePipe,
     base64decode,
+    base64urldecode,
     stringmime
 
 const inputText = "Man is distinguished, not only by his reason, but by this singular passion from other animals, which is a lust of the mind, that by a perseverance of delight in the continued and indefatigable generation of knowledge, exceeds the short vehemence of any carnal pleasure."
@@ -67,6 +69,19 @@ ZSBzaG9ydCB2ZWhlbWVuY2Ugb2YgYW55IGNhcm5hbCBwbGVhc3VyZS4="""
 
     # issue #21314
     @test base64decode(chomp("test")) == base64decode("test")
+
+    # base64url
+    let
+        data = "?d?.?/.>>a"
+        data_encoded_base64    = "P2Q/Lj8vLj4+YQ=="
+        data_encoded_base64url = "P2Q_Lj8vLj4-YQ=="
+
+        @test base64encode(data) == data_encoded_base64
+        @test String(base64decode(data_encoded_base64)) == data
+
+        @test base64urlencode(data) == data_encoded_base64url
+        @test String(base64urldecode(data_encoded_base64url)) == data
+    end
 end
 
 @testset "Random data" begin
@@ -74,6 +89,7 @@ end
     for _ in 1:1000
         data = rand(mt, UInt8, rand(0:300))
         @test hash(base64decode(base64encode(data))) == hash(data)
+        @test hash(base64urldecode(base64urlencode(data))) == hash(data)
     end
 end
 


### PR DESCRIPTION
This adds base64url encode/decode functions to Base64 stdlib, without breaking current public API.

# Benchmarks

I ran some benchmarks comparing current implementation (module **Base64**) and the new one (mock module **Base64URL**), on existing functions `base64encode` and `base64decode` to detect possible performance regressions. Results below.

```julia
julia> @benchmark Base64.base64encode(inputText)

BenchmarkTools.Trial: 
  memory estimate:  2.09 KiB
  allocs estimate:  12
  --------------
  minimum time:     1.332 μs (0.00% GC)
  median time:      1.456 μs (0.00% GC)
  mean time:        2.977 μs (46.50% GC)
  maximum time:     5.873 ms (98.51% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> @benchmark Base64URL.base64encode(inputText)
BenchmarkTools.Trial: 
  memory estimate:  2.09 KiB
  allocs estimate:  12
  --------------
  minimum time:     1.208 μs (0.00% GC)
  median time:      1.340 μs (0.00% GC)
  mean time:        2.826 μs (48.69% GC)
  maximum time:     6.152 ms (98.42% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> @benchmark Base64.base64decode(encodedText)

BenchmarkTools.Trial: 
  memory estimate:  2.42 KiB
  allocs estimate:  28
  --------------
  minimum time:     1.209 μs (0.00% GC)
  median time:      1.293 μs (0.00% GC)
  mean time:        1.961 μs (28.00% GC)
  maximum time:     3.832 ms (99.95% GC)
  --------------
  samples:          10000
  evals/sample:     10

julia> @benchmark Base64URL.base64decode(encodedText)
BenchmarkTools.Trial: 
  memory estimate:  2.42 KiB
  allocs estimate:  28
  --------------
  minimum time:     1.144 μs (0.00% GC)
  median time:      1.230 μs (0.00% GC)
  mean time:        1.951 μs (31.45% GC)
  maximum time:     4.423 ms (99.95% GC)
  --------------
  samples:          10000
  evals/sample:     10
```