### PR TITLE
Correct docstring for rem_pio2_kernel

### DIFF
--- a/base/special/rem_pio2.jl
+++ b/base/special/rem_pio2.jl
@@ -208,12 +208,13 @@ function paynehanek(x::Float64)
 end
 
 """
-    rem_pio2_kernel(x)
+    rem_pio2_kernel(x::Union{Float32, Float64})
 
-Return the remainder of `x` modulo π/2 as a double-double pair, along with a `k`
-such that ``k \\mod 3 == K \\mod 3`` where ``K*π/2 = x - rem``. Note, that it is
-only meant for use when ``|x|>=π/4``, and that ``π/2`` is always subtracted or
-added for ``π/4<|x|<=π/2`` instead of simply returning `x`.
+Calculate `x` divided by `π/2` accurately for arbitrarily large `x`.
+Returns a pair `(k, r)`, where `k` is the quadrant of the result
+(multiple of π/2) and `r` is the remainder, such that ``k * π/2 = x - r``.
+The remainder is given as a double-double pair.
+`k` is positive if `x > 0` and is negative if `x ≤ 0`.
 """
 @inline function rem_pio2_kernel(x::Float64)
     xhp = poshighword(x)


### PR DESCRIPTION
Corrects the docstring of `rem_pio2_kernel`.

cc @pkofod 