### PR TITLE
Fix `big(typemin(T))`

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -288,6 +288,7 @@ function BigInt(x::Integer)
     z = MPZ.realloc2(nd)
     s = sign(x)
     s == -1 && (x = -x)
+    x = unsigned(x)
     size = 0
     limbnbits = sizeof(Limb) << 3
     while nd > 0

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -432,3 +432,11 @@ end
     y = rand(UInt128)
     @test BigInt(y) % UInt128 === y
 end
+
+@testset "conversion from typemin(T)" begin
+    @test big(Int8(-128)) == big"-128"
+    @test big(Int16(-32768)) == big"-32768"
+    @test big(Int32(-2147483648)) == big"-2147483648"
+    @test big(Int64(-9223372036854775808)) == big"-9223372036854775808"
+    @test big(Int128(-170141183460469231731687303715884105728)) == big"-170141183460469231731687303715884105728"
+end


### PR DESCRIPTION
master:
```julia
julia> big(typemin(Int8))
-18446744073709551488

julia> big(typemin(Int16))
-18446744073709518848
```
this PR:
```julia
julia> big(typemin(Int8))
-128

julia> big(typemin(Int16))
-32768
```
(Bug was introduced by #29165, i.e. after 1.0.)