### PR TITLE
fix #29326, return type lowering interfering with closure optimization

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -160,21 +160,11 @@
                    (let ((meta (take-while (lambda (x) (and (pair? x)
                                                             (memq (car x) '(line meta))))
                                            (cdr body)))
-                         (val (last body)))
-                     ;; wrap one-liners in `convert` instead of adding an ssavalue
-                     (if (and (length= (cdr body) (+ 1 (length meta)))
-                              (not (expr-contains-p return? (if (return? val)
-                                                                (cadr val)
-                                                                val))))
-                         `(,(car body) ,@meta
-                           ,(if (return? val)
-                                `(return ,(convert-for-type-decl (cadr val) rett))
-                                (convert-for-type-decl val rett)))
-                         (let ((R (make-ssavalue)))
-                           `(,(car body) ,@meta
-                             (= ,R ,rett)
-                             (meta ret-type ,R)
-                             ,@(list-tail body (+ 1 (length meta))))))))))))
+                         (R (make-ssavalue)))
+                     `(,(car body) ,@meta
+                       (= ,R ,rett)
+                       (meta ret-type ,R)
+                       ,@(list-tail body (+ 1 (length meta))))))))))
 
 ;; convert x<:T<:y etc. exprs into (name lower-bound upper-bound)
 ;; a bound is #f if not specified

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -1748,6 +1748,15 @@ function f15276(x)
 end
 @test Base.return_types(f15276(1), (Int,)) == [Int]
 
+# issue #29326
+function f29326()::Any
+    begin
+        a = 1
+        (() -> a)()
+    end
+end
+@test Base.return_types(f29326, ()) == [Int]
+
 function g15276()
     spp = Int[0]
     sol = [spp[i] for i=1:0]


### PR DESCRIPTION
I had a special alternate lowering for return types that used to give slightly smaller code. Now that we linearize everything, it's unnecessary.