### PR TITLE
Add missing test dependencies to SparseArrays Project.toml

### DIFF
--- a/stdlib/SparseArrays/Project.toml
+++ b/stdlib/SparseArrays/Project.toml
@@ -7,6 +7,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [targets]
-test = ["Test"]
+test = ["Test", "InteractiveUtils"]


### PR DESCRIPTION
The tests use InteractiveUtils but it is not listed as a test dependency in the SparseArrays Project.toml file. This is causing SparseArrays to fail its tests when run on NewPkgEval, which means every package that uses SparseArrays gets their tests skipped.