### PR TITLE
Fix log record IDs

### DIFF
--- a/base/logging.jl
+++ b/base/logging.jl
@@ -221,7 +221,7 @@ macro error(exs...) logmsg_code((@_sourceinfo)..., :Error, exs...) end
 @eval @doc $_logmsg_docs :(@warn)
 @eval @doc $_logmsg_docs :(@error)
 
-_log_record_ids = Dict{String, Symbol}()
+_log_record_ids = Dict{Any, Symbol}()
 # Generate a unique, stable, short, human readable identifier for a logging
 # statement.  The idea here is to have a key against which log records can be
 # filtered and otherwise manipulated. The key should uniquely identify the
@@ -230,7 +230,7 @@ _log_record_ids = Dict{String, Symbol}()
 # itself doesn't change.
 function log_record_id(_module, file, line, level, message_ex)
     modname = _module === nothing ?  "" : join(fullname(_module), "_")
-    get!(_log_record_ids, string(modname, file, line),
+    get!(_log_record_ids, (modname, file, line),
         new_log_record_id(modname, level, message_ex))
 end
 

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -21,6 +21,26 @@ import Logging: min_enabled_level, shouldlog, handle_message
     handle_message(logger, Logging.Info, "msg", Base, :group, :asdf, "somefile", 1, maxlog=2)
     @test shouldlog(logger, Logging.Info, Base, :group, :asdf) === false
 
+    # Check that maxlog works without an explicit ID
+    buf = IOBuffer()
+    io = IOContext(buf, :displaysize=>(30,80), :color=>false)
+    logger = ConsoleLogger(io)
+    with_logger(logger) do
+        for i in 1:2
+            @info "test" maxlog=1
+        end
+    end
+    @test String(take!(buf)) ==
+    """
+    [ Info: test
+    """
+    with_logger(logger) do
+        for i in 1:2
+            @info "test" maxlog=0
+        end
+    end
+    @test String(take!(buf)) == ""
+
     @testset "Default metadata formatting" begin
         @test Logging.default_metafmt(Logging.Debug, Base, :g, :i, expanduser("~/somefile.jl"), 42) ==
             (:blue,      "Debug:",   "@ Base ~/somefile.jl:42")


### PR DESCRIPTION
This PR ensures that a given log statement will always produce the same ID. It is actually a bit tricky to implement because the ID should "uniquely identify the source location in the originating module, but should be stable across versions of the originating module, provided the log generating statement itself doesn't change" (according to the source).

This definitely needs some tests so that this doesn't break again.

Closes #28786.