### PR TITLE
Pkg don't use startup.jl when building and testing 

### DIFF
--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -494,10 +494,9 @@ function precompile(ctx::Context)
     for pkg in pkgids
         paths = Base.find_all_in_cache_path(pkg)
         sourcepath = Base.locate_package(pkg)
-        if sourcepath == nothing
-            # XXX: this isn't supposed to be fatal
-            pkgerror("couldn't find path to $(pkg.name) when trying to precompile project")
-        end
+        sourcepath == nothing && continue
+        # Heuristic for when precompilation is disabled
+        occursin(r"\b__precompile__\(\s*false\s*\)", read(sourcepath, String)) && continue
         stale = true
         for path_to_try in paths::Vector{String}
             staledeps = Base.stale_cachefile(sourcepath, path_to_try)

--- a/stdlib/Pkg/src/Operations.jl
+++ b/stdlib/Pkg/src/Operations.jl
@@ -1046,7 +1046,7 @@ function build_versions(ctx::Context, uuids::Vector{UUID}; might_need_to_resolve
             """
         cmd = ```
             $(Base.julia_cmd()) -O0 --color=no --history-file=no
-            --startup-file=$(Base.JLOptions().startupfile != 2 ? "yes" : "no")
+            --startup-file=$(Base.JLOptions().startupfile == 1 ? "yes" : "no")
             --compiled-modules=$(Bool(Base.JLOptions().use_compiled_modules) ? "yes" : "no")
             --eval $code
             ```

--- a/stdlib/Pkg/src/REPLMode.jl
+++ b/stdlib/Pkg/src/REPLMode.jl
@@ -1246,7 +1246,6 @@ Create a project called `pkgname` in the current folder.
     precompile
 
 Precompile all the dependencies of the project by running `import` on all of them in a new process.
-The `startup.jl` file is disabled during precompilation unless julia is started with `--startup-file=yes`.
     """,
 ),( CMD_STATUS,
     ["status", "st"],


### PR DESCRIPTION
adds a missing (important) backport, this was supposed to be in 1.0.