### PR TITLE
If stdio is not available, be permissive and do not exit

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -339,7 +339,7 @@ int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
         fd == NULL ||
         fd == (HANDLE) -2) {
         *dupfd = INVALID_HANDLE_VALUE;
-        return ERROR_INVALID_HANDLE;
+        return 0; // allow the execution to continue even if stdio is not available as in batchmode or without a console
     }
 
     current_process = GetCurrentProcess();


### PR DESCRIPTION
Fix https://github.com/JuliaLang/julia/issues/28820
Be as permissive as Julia v0.6 was.  Before this patch Julia v1.0 exists if fd is -1 (INVALID_HANDLE_VALUE).  I fixed the Windows part of the code, so should not affect other architectures.