### PR TITLE
Add SHA to UUIDs dependencies in Project.toml

### DIFF
--- a/stdlib/UUIDs/Project.toml
+++ b/stdlib/UUIDs/Project.toml
@@ -3,6 +3,7 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
A dependency on SHA was added to UUIDs in #28761 but the Project.toml was not updated to reflect that, resulting in warnings while building Julia.