### PR TITLE
Make InterruptException capturable in a program

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -256,9 +256,6 @@ function exec_options(opts)
     # load file
     if arg_is_program
         # program
-        if !is_interactive
-            ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 1)
-        end
         include(Main, PROGRAM_FILE)
     end
     repl |= is_interactive


### PR DESCRIPTION
In `julia` 1.0 (probably since 0.3?), Julia program launched outside REPL (and `-e` and `-E`) cannot catch `InterruptException`:

```console
$ cat catch-sleep.jl
try
    println("sleeping...")
    sleep(10)
catch err
    @show err
finally
    println("woke up")
end

$ julia --startup-file=no catch-sleep.jl
sleeping...
^C
signal (2): Interrupt
```

This PR makes it work:

```console
$ julia --startup-file=no catch-sleep.jl
sleeping...
^Cerr = InterruptException()
woke up
```

It seems `ccall(:jl_exit_on_sigint, Void, (Cint,), 1)` is added in #6754 but I don't see the discussion why it was required. I also checked the PRs touching this code but couldn't find any relevant discussion (#25162, #23775, #12679, #11347, #9482).

I think it makes sense for various ways of running Julia program

```
$ julia script.jl
$ julia -e 'include("script.jl")'
$ julia
julia> include("script.jl")
```

behave consistently.  Are there any reasons why `exit_on_sigint` is set to `1` only in the case of `julia script.jl`?

Even if this change is reasonable, since this breaks the API, I suppose this has to be blocked until 2.0?  Still, adding CLI option `--handle-interrupt` or a documented Julia function wrapping `jl_exit_on_sigint` would be nice.

closes #25308
