### PR TITLE
Remove the "net_on" guard in runtests.

### DIFF
--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -7,7 +7,7 @@ const STDLIBS = filter!(x -> isdir(joinpath(STDLIB_DIR, x)), readdir(STDLIB_DIR)
 
 """
 
-`tests, net_on, exit_on_error, seed = choosetests(choices)` selects a set of tests to be
+`tests, exit_on_error, seed = choosetests(choices)` selects a set of tests to be
 run. `choices` should be a vector of test names; if empty or set to
 `["all"]`, all tests are selected.
 
@@ -17,7 +17,6 @@ directories.
 
 Upon return:
   - `tests` is a vector of fully-expanded test names,
-  - `net_on` is true if networking is available (required for some tests),
   - `exit_on_error` is true if an error in one test should cancel
     remaining tests to be run (otherwise, all tests are run unconditionally),
   - `seed` is a seed which will be used to initialize the global RNG for each
@@ -182,5 +181,5 @@ function choosetests(choices = [])
     # Filter out tests from the test groups in the stdlibs
     filter!(!in(skip_tests), tests)
 
-    tests, net_on, exit_on_error, seed
+    tests, exit_on_error, seed
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,12 +59,9 @@ limited_worker_rss && move_to_node1("Distributed")
 
 import LinearAlgebra
 cd(dirname(@__FILE__)) do
-    n = 1
-    if net_on
-        n = min(Sys.CPU_THREADS, length(tests))
-        n > 1 && addprocs_with_testenv(n)
-        LinearAlgebra.BLAS.set_num_threads(1)
-    end
+    n = min(Sys.CPU_THREADS, length(tests))
+    n > 1 && addprocs_with_testenv(n)
+    LinearAlgebra.BLAS.set_num_threads(1)
     skipped = 0
 
     @everywhere include("testdefs.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using Base.Printf: @sprintf
 include("choosetests.jl")
 include("testenv.jl")
 
-tests, net_on, exit_on_error, seed = choosetests(ARGS)
+tests, exit_on_error, seed = choosetests(ARGS)
 tests = unique(tests)
 
 const max_worker_rss = if haskey(ENV, "JULIA_TEST_MAXRSS_MB")


### PR DESCRIPTION
According to `choosetests.jl`, the network access is only required by the `["Sockets", "LibGit2"]` tests. We set the `net_on` variable to false by force to comply with Debian policy while building Julia for Debian (and Ubuntu). Then Julia's runtests starts to work in a strange way until we removed this guard.

I don't have idea why the three lines are guarded by `net_on`. And I suspect it's a bug.

The patch that I used to disable network related tests is shown as follows
```diff
Index: julia/test/choosetests.jl
===================================================================
--- julia.orig/test/choosetests.jl
+++ julia/test/choosetests.jl
@@ -147,6 +147,9 @@ function choosetests(choices = [])
         @warn "Networking unavailable: Skipping tests [" * join(net_required_for, ", ") * "]"
         net_on = false
     end
+    if true == tryparse(Bool, get(ENV, "DEBIAN_FORCE_NONET", "false"))
+        net_on = false
+    end
 
     if !net_on
         filter!(!in(net_required_for), tests)

diff --git a/test/runtests.jl b/test/runtests.jl
index b4e7098..e0e195a 100644
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,11 +60,9 @@ limited_worker_rss && move_to_node1("Distributed")
 import LinearAlgebra
 cd(dirname(@__FILE__)) do
     n = 1
-    if net_on
         n = min(Sys.CPU_THREADS, length(tests))
         n > 1 && addprocs_with_testenv(n)
         LinearAlgebra.BLAS.set_num_threads(1)
-    end
     skipped = 0
 
     @everywhere include("testdefs.jl")
```

@ginggs 