### PR TITLE
Workaround subarray test failure due to associativity.

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -608,7 +608,7 @@ V = view(A, 1:1 ,:, 1:3, :)
 A = rand(5,5,5,5)
 V = view(A, 2:5, :, 2:5, 1:2:5)
 @test @inferred(Base.unaliascopy(V)) == V == A[2:5, :, 2:5, 1:2:5]
-@test @inferred(sum(Base.unaliascopy(V))) == sum(V) == sum(A[2:5, :, 2:5, 1:2:5])
+@test @inferred(sum(Base.unaliascopy(V))) ≈ sum(V) ≈ sum(A[2:5, :, 2:5, 1:2:5])
 
 # issue #27632
 function _test_27632(A)


### PR DESCRIPTION
The failure was spotted on Ubuntu builds.
```
subarray: Test Failed at /usr/share/julia/test/subarray.jl:611
  Expression: #= /usr/share/julia/test/subarray.jl:611 =# @inferred(sum(Base.unaliascopy(V))) == sum(V) == sum(A[2:5, :, 2:5, 1:2:5])
   Evaluated: 121.8579669083425 == 121.8579669083425 == 121.85796690834263
```

```julia
A = rand(5,5,5,5)
V = view(A, 2:5, :, 2:5, 1:2:5)
@code_typed sum(V)  # calls mapfoldl
@code_typed sum(A[2:5, :, 2:5, 1:2:5])  # calls mapreduce
```

mapreduce doesn't guarantee the associativity, which is likely
the cause of this precision issue spotted in the sum of random numbers.

@ginggs 