### PR TITLE
Allow logging meta-formatter to set suffix color

### DIFF
--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -12,9 +12,9 @@ Log levels less than `min_level` are filtered out.
 Message formatting can be controlled by setting keyword arguments:
 
 * `meta_formatter` is a function which takes the log event metadata
-  `(level, _module, group, id, file, line)` and returns a color (as would be
-  passed to printstyled), prefix and suffix for the log message.  The
-  default is to prefix with the log level and a suffix containing the module,
+  `(level, _module, group, id, file, line)` and returns a prefix color (as would
+  be passed to printstyled), prefix, suffix color, and suffix for the log message.
+  The default is to prefix with the log level and a suffix containing the module,
   file and line location.
 * `show_limited` limits the printing of large data structures to something
   which can fit on the screen by setting the `:limit` `IOContext` key during

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -128,8 +128,14 @@ function handle_message(logger::ConsoleLogger, level, message, _module, group, i
 
     # Format lines as text with appropriate indentation and with a box
     # decoration on the left.
-    prefix_color, prefix, suffix_color ,suffix =
-        logger.meta_formatter(level, _module, group, id, filepath, line)
+    format = logger.meta_formatter(level, _module, group, id, filepath, line)
+    if length(format) == 4
+        prefix_color, prefix, suffix_color, suffix = format
+    else
+        # The three-value version of meta_formatter should be depreciated at some point
+        prefix_color, prefix, suffix = format
+        suffix_color = :light_black
+    end
     minsuffixpad = 2
     buf = IOBuffer()
     iob = IOContext(buf, logger.stream)

--- a/stdlib/Logging/src/ConsoleLogger.jl
+++ b/stdlib/Logging/src/ConsoleLogger.jl
@@ -61,7 +61,7 @@ function default_metafmt(level, _module, group, id, file, line)
     prefix_color = default_logcolor(level)
     prefix = (level == Warn ? "Warning" : string(level))*':'
     suffix = ""
-    suffix_color = :light_black
+    suffix_color = Base.stackframe_lineinfo_color()
     Info <= level < Warn && return prefix_color, prefix, suffix_color, suffix
     _module !== nothing && (suffix *= "$(_module)")
     if file !== nothing

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -41,26 +41,27 @@ import Logging: min_enabled_level, shouldlog, handle_message
     end
     @test String(take!(buf)) == ""
 
+    suffix_color = Base.stackframe_lineinfo_color()
     @testset "Default metadata formatting" begin
         @test Logging.default_metafmt(Logging.Debug, Base, :g, :i, expanduser("~/somefile.jl"), 42) ==
-            (:blue,      "Debug:",   :light_black, "@ Base ~/somefile.jl:42")
+            (:blue,      "Debug:",   suffix_color, "@ Base ~/somefile.jl:42")
         @test Logging.default_metafmt(Logging.Info,  Main, :g, :i, "a.jl", 1) ==
-            (:cyan,      "Info:",    :light_black, "")
+            (:cyan,      "Info:",    suffix_color, "")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2) ==
-            (:yellow,    "Warning:", :light_black, "@ Main b.jl:2")
+            (:yellow,    "Warning:", suffix_color, "@ Main b.jl:2")
         @test Logging.default_metafmt(Logging.Error, Main, :g, :i, "", 0) ==
-            (:light_red, "Error:",   :light_black, "@ Main :0")
+            (:light_red, "Error:",   suffix_color, "@ Main :0")
         # formatting of nothing
         @test Logging.default_metafmt(Logging.Warn,  nothing, :g, :i, "b.jl", 2) ==
-            (:yellow,    "Warning:", :light_black, "@ b.jl:2")
+            (:yellow,    "Warning:", suffix_color, "@ b.jl:2")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, nothing, 2) ==
-            (:yellow,    "Warning:", :light_black, "@ Main")
+            (:yellow,    "Warning:", suffix_color, "@ Main")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", nothing) ==
-            (:yellow,    "Warning:", :light_black, "@ Main b.jl")
+            (:yellow,    "Warning:", suffix_color, "@ Main b.jl")
         @test Logging.default_metafmt(Logging.Warn,  nothing, :g, :i, nothing, 2) ==
-            (:yellow,    "Warning:", :light_black, "")
+            (:yellow,    "Warning:", suffix_color, "")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2:5) ==
-            (:yellow,    "Warning:", :light_black, "@ Main b.jl:2-5")
+            (:yellow,    "Warning:", suffix_color, "@ Main b.jl:2-5")
     end
 
     function dummy_metafmt(level, _module, group, id, file, line)

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -43,28 +43,28 @@ import Logging: min_enabled_level, shouldlog, handle_message
 
     @testset "Default metadata formatting" begin
         @test Logging.default_metafmt(Logging.Debug, Base, :g, :i, expanduser("~/somefile.jl"), 42) ==
-            (:blue,      "Debug:",   "@ Base ~/somefile.jl:42")
+            (:blue,      "Debug:",   :light_black, "@ Base ~/somefile.jl:42")
         @test Logging.default_metafmt(Logging.Info,  Main, :g, :i, "a.jl", 1) ==
-            (:cyan,      "Info:",    "")
+            (:cyan,      "Info:",    :light_black, "")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2) ==
-            (:yellow,    "Warning:", "@ Main b.jl:2")
+            (:yellow,    "Warning:", :light_black, "@ Main b.jl:2")
         @test Logging.default_metafmt(Logging.Error, Main, :g, :i, "", 0) ==
-            (:light_red, "Error:",   "@ Main :0")
+            (:light_red, "Error:",   :light_black, "@ Main :0")
         # formatting of nothing
         @test Logging.default_metafmt(Logging.Warn,  nothing, :g, :i, "b.jl", 2) ==
-            (:yellow,    "Warning:", "@ b.jl:2")
+            (:yellow,    "Warning:", :light_black, "@ b.jl:2")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, nothing, 2) ==
-            (:yellow,    "Warning:", "@ Main")
+            (:yellow,    "Warning:", :light_black, "@ Main")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", nothing) ==
-            (:yellow,    "Warning:", "@ Main b.jl")
+            (:yellow,    "Warning:", :light_black, "@ Main b.jl")
         @test Logging.default_metafmt(Logging.Warn,  nothing, :g, :i, nothing, 2) ==
-            (:yellow,    "Warning:", "")
+            (:yellow,    "Warning:", :light_black, "")
         @test Logging.default_metafmt(Logging.Warn,  Main, :g, :i, "b.jl", 2:5) ==
-            (:yellow,    "Warning:", "@ Main b.jl:2-5")
+            (:yellow,    "Warning:", :light_black, "@ Main b.jl:2-5")
     end
 
     function dummy_metafmt(level, _module, group, id, file, line)
-        :cyan,"PREFIX","SUFFIX"
+        :cyan,"PREFIX",:light_black,"SUFFIX"
     end
 
     # Log formatting
@@ -98,7 +98,7 @@ import Logging: min_enabled_level, shouldlog, handle_message
     # Full metadata formatting
     @test genmsg("msg", level=Logging.Debug,
                  meta_formatter=(level, _module, group, id, file, line)->
-                                (:white,"Foo!", "$level $_module $group $id $file $line")) ==
+                                (:white,"Foo!",:red, "$level $_module $group $id $file $line")) ==
     """
     ┌ Foo! msg
     └ Debug Main a_group an_id some/path.jl 101
@@ -116,11 +116,11 @@ import Logging: min_enabled_level, shouldlog, handle_message
         └ SUFFIX
         """
         # Behavior with empty prefix / suffix
-        @test genmsg("msg", meta_formatter=(args...)->(:white, "PREFIX", "")) ==
+        @test genmsg("msg", meta_formatter=(args...)->(:white, "PREFIX", :red, "")) ==
         """
         [ PREFIX msg
         """
-        @test genmsg("msg", meta_formatter=(args...)->(:white, "", "SUFFIX")) ==
+        @test genmsg("msg", meta_formatter=(args...)->(:white, "", :red, "SUFFIX")) ==
         """
         ┌ msg
         └ SUFFIX


### PR DESCRIPTION
For example, [SolarizedLogging.jl](https://github.com/adamslc/SolarizedLogging.jl/blob/master/src/SolarizedLogging.jl) needs this behavior to make log messages readable with a solarized color scheme. By default, the suffix is invisible with this color scheme!