### PR TITLE
Change from parametric T signature to Int32 in _ldexp_exp

### DIFF
--- a/base/special/hyperbolic.jl
+++ b/base/special/hyperbolic.jl
@@ -13,10 +13,9 @@
 # software is freely granted, provided that this notice
 # is preserved.
 # ====================================================
-
-_ldexp_exp(x::Float64, i::T) where T = ccall(("__ldexp_exp", libm), Float64, (Float64, T), x, i)
-_ldexp_exp(x::Float32, i::T) where T = ccall(("__ldexp_expf",libm), Float32, (Float32, T), x, i)
-_ldexp_exp(x::Real, i) = _ldexp_exp(float(x, i))
+_ldexp_exp(x::Float64, i::Int32) = ccall(("__ldexp_exp", libm), Float64, (Float64, Int32), x, i)
+_ldexp_exp(x::Float32, i::Int32) = ccall(("__ldexp_expf",libm), Float32, (Float32, Int32), x, i)
+_ldexp_exp(x::Real, i::Int32) = _ldexp_exp(float(x), i)
 
 # Hyperbolic functions
 # sinh methods
@@ -76,7 +75,7 @@ function sinh(x::T) where T <: Union{Float32, Float64}
     end
     # in d)
     if absx < H_OVERFLOW_X(T)
-        return h*T(2)*_ldexp_exp(absx, -1)
+        return h*T(2)*_ldexp_exp(absx, Int32(-1))
     end
     # in e)
     return copysign(T(Inf), x)
@@ -129,7 +128,7 @@ function cosh(x::T) where T <: Union{Float32, Float64}
     end
     # in e)
     if absx < H_OVERFLOW_X(T)
-        return _ldexp_exp(absx, -1)
+        return _ldexp_exp(absx, Int32(-1))
     end
     # in f)
     return T(Inf)


### PR DESCRIPTION
__ldexp_exp(f) requires the second argument to be an Int32, so we might as well hard-code that here. It also seems that the old specification is actually not valid, or might have unexpected results, so we should just go with Int32, see #29400 .