### PR TITLE
fix a transitivity error in method specificity

### DIFF
--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -225,3 +225,11 @@ MathTypes22592{T,C} = Union{AbstractRGB22592{T},AbstractGray22592{T}}
 @test !args_morespecific(Tuple{MathTypes22592, MathTypes22592}, Tuple{AbstractGray22592})
 
 @test args_morespecific(Union{Set,Dict,Vector}, Union{Vector,AbstractSet})
+
+let N = Tuple{Type{Union{Nothing, T}}, Union{Nothing, T}} where T,
+    LI = Tuple{Type{LinearIndices{N,R}}, LinearIndices{N}} where {N,R},
+    A = Tuple{Type{T},T} where T<:AbstractArray
+    @test  args_morespecific(LI, A)
+    @test !args_morespecific(A, N)
+    @test !args_morespecific(LI, N)
+end


### PR DESCRIPTION
I discovered this while working on #29269. It doesn't seem to cause much of a problem now, because the corresponding type intersections are (incorrectly) empty. However this is required for the #29269 fix to avoid generating fairly bad ambiguity problems.