### PR TITLE
REPL: really fix #29347, searching a string not in history

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -623,12 +623,17 @@ function history_search(hist::REPLHistoryProvider, query_buffer::IOBuffer, respo
     b = b ≤ ncodeunits(response_str) ? prevind(response_str, b) : b-1
     b = min(lastindex(response_str), b) # ensure that b is valid
 
-    !skip_current && searchdata == response_str[a:b] && return true
-
     searchfunc1, searchfunc2, searchstart, skipfunc = backwards ?
                                                       (findlast, findprev, b, prevind) :
                                                       (findfirst, findnext, a, nextind)
-    skip_current && (searchstart = skipfunc(response_str, searchstart))
+
+    if searchdata == response_str[a:b]
+        if skip_current
+            searchstart = skipfunc(response_str, searchstart)
+        else
+            return true
+        end
+    end
 
     # Start searching
     # First the current response buffer

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -601,6 +601,16 @@ for prompt = ["TestΠ", () -> randstring(rand(1:10))]
         @test buffercontents(LineEdit.buffer(s)) == "x ΔxΔ"
         @test position(LineEdit.buffer(s)) == 0
 
+        LineEdit.edit_clear(s)
+        LineEdit.enter_search(s, histp, true)
+        ss = LineEdit.state(s, histp)
+        write(ss.query_buffer, "Å") # should not be in history
+        LineEdit.update_display_buffer(ss, ss)
+        @test buffercontents(ss.response_buffer) == ""
+        @test position(ss.response_buffer) == 0
+        LineEdit.history_next_result(s, ss) # should not throw BoundsError
+        LineEdit.accept_result(s, histp)
+
         # Try entering search mode while in custom repl mode
         LineEdit.enter_search(s, custom_histp, true)
     end


### PR DESCRIPTION
The error likeliy appeared when `nextind` /  `prevind` started to throw when the index is out of bounds.