### PR TITLE
improve findnext/findprev docstring for strings

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -238,8 +238,8 @@ must be of type `String`.
 The return value is a range of indices where the matching sequence is found, such that
 `s[findnext(x, s, i)] == x`:
 
-`findnext("substring", string, i)` = `start:end` such that
-`string[start:end] == "substring"`, or `nothing` if unmatched.
+`findnext("substring", string, i)` == `start:stop` such that
+`string[start:stop] == "substring"` and `i <= start`, or `nothing` if unmatched.
 
 # Examples
 ```jldoctest
@@ -415,8 +415,8 @@ must be of type `String`.
 The return value is a range of indices where the matching sequence is found, such that
 `s[findprev(x, s, i)] == x`:
 
-`findprev("substring", string, i)` = `start:end` such that
-`string[start:end] == "substring"`, or `nothing` if unmatched.
+`findprev("substring", string, i)` == `start:stop` such that
+`string[start:stop] == "substring"` and `stop <= i`, or `nothing` if unmatched.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
There are 3 tiny changes:
- use `stop` instead of `end`, as `end` has a special meaning for indexing;
- add an inequality characterizing the condition on the passed indice;
- use `==` instead of `=` as `=` looks like a method definition.