### PR TITLE
Make package files read-only for Pkg.add

### DIFF
--- a/stdlib/Pkg/src/API.jl
+++ b/stdlib/Pkg/src/API.jl
@@ -61,7 +61,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; mode::Symbol, s
     any(pkg -> Types.collides_with_project(ctx.env, pkg), pkgs) &&
         pkgerror("Cannot $mode package with the same name or uuid as the project")
 
-    Operations.add_or_develop(ctx, pkgs; new_git=new_git)
+    Operations.add_or_develop(ctx, pkgs; new_git=new_git, mode=mode)
     ctx.preview && preview_info()
     return
 end

--- a/stdlib/Pkg/src/Operations.jl
+++ b/stdlib/Pkg/src/Operations.jl
@@ -59,6 +59,17 @@ function load_package_data_raw(T::Type, path::String)
     return data
 end
 
+function set_readonly(path)
+    for (root, dirs, files) in walkdir(path)
+        for file in files
+            filepath = joinpath(root, file)
+            fmode = filemode(filepath)
+            chmod(filepath, fmode & (typemax(fmode) ⊻ 0o222))
+        end
+    end
+    return nothing
+end
+
 #######################################
 # Dependency gathering and resolution #
 #######################################
@@ -530,12 +541,12 @@ function install_git(
 end
 
 # install & update manifest
-function apply_versions(ctx::Context, pkgs::Vector{PackageSpec})::Vector{UUID}
+function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}; mode=:add)::Vector{UUID}
     hashes, urls = version_data!(ctx, pkgs)
-    apply_versions(ctx, pkgs, hashes, urls)
+    apply_versions(ctx, pkgs, hashes, urls; mode=mode)
 end
 
-function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UUID,SHA1}, urls::Dict{UUID,Vector{String}})
+function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UUID,SHA1}, urls::Dict{UUID,Vector{String}}; mode=:add)
     BinaryProvider.probe_platform_engines!()
     new_versions = UUID[]
 
@@ -578,6 +589,9 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
                 end
                 try
                     success = install_archive(urls[pkg.uuid], hashes[pkg.uuid], path)
+                    if success && mode == :add
+                        set_readonly(path) # In add mode, files should be read-only
+                    end
                     if ctx.use_only_tarballs_for_downloads && !success
                         pkgerror("failed to get tarball from $(urls[pkg.uuid])")
                     end
@@ -609,6 +623,9 @@ function apply_versions(ctx::Context, pkgs::Vector{PackageSpec}, hashes::Dict{UU
         uuid = pkg.uuid
         if !ctx.preview
             install_git(ctx, pkg.uuid, pkg.name, hashes[uuid], urls[uuid], pkg.version::VersionNumber, path)
+            if mode == :add
+                set_readonly(path)
+            end
         end
         vstr = pkg.version != nothing ? "v$(pkg.version)" : "[$h]"
         @info "Installed $(rpad(pkg.name * " ", max_name + 2, "─")) $vstr"
@@ -1142,7 +1159,7 @@ function rm(ctx::Context, pkgs::Vector{PackageSpec})
     write_env(ctx)
 end
 
-function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID[])
+function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID[], mode=:add)
     # copy added name/UUIDs into project
     for pkg in pkgs
         ctx.env.project["deps"][pkg.name] = string(pkg.uuid)
@@ -1162,7 +1179,7 @@ function add_or_develop(ctx::Context, pkgs::Vector{PackageSpec}; new_git = UUID[
     end
     # resolve & apply package versions
     resolve_versions!(ctx, pkgs)
-    new_apply = apply_versions(ctx, pkgs)
+    new_apply = apply_versions(ctx, pkgs; mode=mode)
     write_env(ctx) # write env before building
     build_versions(ctx, union(new_apply, new_git))
 end

--- a/stdlib/Pkg/test/pkg.jl
+++ b/stdlib/Pkg/test/pkg.jl
@@ -126,6 +126,7 @@ temp_pkg_dir() do project_path
         Pkg.add(TEST_PKG.name)
         @test isinstalled(TEST_PKG)
         @eval import $(Symbol(TEST_PKG.name))
+        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
         Pkg.rm(TEST_PKG.name; preview = true)
         @test isinstalled(TEST_PKG)
         Pkg.rm(TEST_PKG.name)
@@ -318,6 +319,8 @@ temp_pkg_dir() do project_path
     @testset "libgit2 downloads" begin
         Pkg.add(TEST_PKG.name; use_libgit2_for_all_downloads=true)
         @test haskey(Pkg.installed(), TEST_PKG.name)
+        @eval import $(Symbol(TEST_PKG.name))
+        @test_throws SystemError open(pathof(eval(Symbol(TEST_PKG.name))), "w") do io end  # check read-only
         Pkg.rm(TEST_PKG.name)
     end
 


### PR DESCRIPTION
Closes https://github.com/JuliaLang/Pkg.jl/issues/32

I wanted to get started on https://github.com/timholy/Revise.jl/issues/146 but I think doing this first is basically a prerequisite to any kind of sensible implementation.