### PR TITLE
build: work correctly when linking to a system llvm which is not the default

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -199,7 +199,7 @@ endif # WINNT
 
 symlink_libLLVM: $(build_private_libdir)/libLLVM.dylib
 $(build_private_libdir)/libLLVM.dylib:
-	REALPATH=`$(LLVM_CONFIG_HOST) --libdir`/libLLVM.$(SHLIB_EXT) && \
+	REALPATH=`$(LLVM_CONFIG_HOST) --libfiles` && \
 	$(call resolve_path,REALPATH) && \
 	[ -e "$$REALPATH" ] && \
 	([ ! -e "$@" ] || rm "$@") && \

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,12 +89,8 @@ endif
 PUBLIC_HEADER_TARGETS := $(addprefix $(build_includedir)/julia/,$(notdir $(PUBLIC_HEADERS)) $(UV_HEADERS))
 
 ifeq ($(JULIACODEGEN),LLVM)
-# In LLVM < 3.4, --ldflags includes both options and libraries, so use it both before and after --libs
-# In LLVM >= 3.4, --ldflags has only options, and --system-libs has the libraries.
-ifneq ($(USE_LLVM_SHLIB),1)
-LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --libs $(LLVM_LIBS)) $(shell $(LLVM_CONFIG_HOST) --ldflags) $(shell $(LLVM_CONFIG_HOST) --system-libs 2> /dev/null)
-else
-LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags) -lLLVM
+LLVMLINK += $(shell $(LLVM_CONFIG_HOST) --ldflags --libs --system-libs)
+ifeq ($(USE_LLVM_SHLIB),1)
 FLAGS += -DLLVM_SHLIB
 endif # USE_LLVM_SHLIB == 1
 endif


### PR DESCRIPTION
It's erroneous to assume hardcoded -lLLVM works, when it will either not
exist, or exist and be a symlink to -lLLVM-6.0, or exist and be a
symlink to a completely invalid -lLLVM-7

Instead, use llvm-config for what it's meant to do, and acquire the
linker --libs. In one case this means we can simplify on --libfiles
rather than --libdir plus appending some hardcoded strings, and in
another case we can simply drop a huge, confusingly repetitive
invocation which was meant to work around very old llvm versions that
are no longer supported.