### PR TITLE
Throw an error when collecting from iterators with inconsistent length

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -687,9 +687,10 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
             return collect_to!(new, itr, i+1, st)
         end
     end
-    i-1 < length(dest) &&
+    lastidx = lastindex(dest)
+    i-1 < lastidx &&
         throw(ErrorException("iterator returned fewer elements than its declared length"))
-    i-1 > length(dest) &&
+    i-1 > lastidx &&
         throw(ErrorException("iterator returned more elements than its declared length"))
     return dest
 end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -815,8 +815,12 @@ julia> y
 """
 copyto!(dest, src)
 
-function copyto!(dest::AbstractArray{T,N}, src::AbstractArray{T,N}) where {T,N}
+function _copyto_impl!(dest::AbstractArray{T,N}, src::AbstractArray{T,N},
+                       allowshorter::Bool) where {T,N}
     checkbounds(dest, axes(src)...)
+    if !allowshorter && length(src) < length(dest)
+        throw(ArgumentError("source has fewer elements than destination"))
+    end
     src′ = unalias(dest, src)
     for I in eachindex(IndexStyle(src′,dest), src′)
         @inbounds dest[I] = src′[I]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2525,29 +2525,27 @@ Base.view(::T25958, args...) = args
     @test t[end,end,end] == @view(t[end,end,end]) == @views t[end,end,end]
 end
 
+# Iterator with declared length too large
+struct InvalidIter1 end
+Base.length(::InvalidIter1) = 2
+Base.iterate(::InvalidIter1, i=1) = i > 1 ? nothing : (i, (i + 1))
+# Iterator with declared length too small
+struct InvalidIter2 end
+Base.length(::InvalidIter2) = 2
+Base.iterate(::InvalidIter2, i=1) = i > 3 ? nothing : (i, (i + 1))
 @testset "collect on iterator with incorrect length" begin
-    # Iterator with declared length too large
-    struct InvalidIter1 end
-    Base.length(::InvalidIter1) = 2
-    Base.iterate(::InvalidIter1, i=1) = i > 1 ? nothing : (i, (i + 1))
-
-    @test_throws ErrorException collect(InvalidIter1())
-    @test_throws ErrorException collect(Any, InvalidIter1())
-    @test_throws ErrorException collect(Int, InvalidIter1())
-    @test_throws ErrorException [x for x in InvalidIter1()]
-    # Should also throw ErrorException
+    @test_throws ArgumentError collect(InvalidIter1())
+    @test_throws ArgumentError collect(Any, InvalidIter1())
+    @test_throws ArgumentError collect(Int, InvalidIter1())
+    @test_throws ArgumentError [x for x in InvalidIter1()]
+    # Should also throw ArgumentError
     @test_broken length(Int[x for x in InvalidIter1()]) != 2
 
-    # Iterator with declared length too small
-    struct InvalidIter2 end
-    Base.length(::InvalidIter2) = 2
-    Base.iterate(::InvalidIter2, i=1) = i > 3 ? nothing : (i, (i + 1))
-
-    @test_throws ErrorException collect(InvalidIter2())
-    @test_throws ErrorException collect(Any, InvalidIter2())
-    @test_throws ErrorException collect(Int, InvalidIter2())
+    @test_throws ArgumentError collect(InvalidIter2())
+    @test_throws ArgumentError collect(Any, InvalidIter2())
+    @test_throws ArgumentError collect(Int, InvalidIter2())
     # These cases cannot be tested without writing to invalid memory
     # unless the function checked bounds on each iteration (#29458)
     # @test_throws ErrorException [x for x in InvalidIter2()]
-    # @test_throws ErrorException Int[x for x in InvalidIter2()]
+    # @test_broken length(Int[x for x in InvalidIter2()]) != 2
 end

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -2546,7 +2546,8 @@ end
     @test_throws ErrorException collect(InvalidIter2())
     @test_throws ErrorException collect(Any, InvalidIter2())
     @test_throws ErrorException collect(Int, InvalidIter2())
-    @test_throws ErrorException [x for x in InvalidIter2()]
-    # Should also throw ErrorException
-    @test_broken length(Int[x for x in InvalidIter2()]) != 2
+    # These cases cannot be tested without writing to invalid memory
+    # unless the function checked bounds on each iteration (#29458)
+    # @test_throws ErrorException [x for x in InvalidIter2()]
+    # @test_throws ErrorException Int[x for x in InvalidIter2()]
 end


### PR DESCRIPTION
Check that `HasLength` and `HasShape` iterators return the same number of elements as indicated by `length(itr)`. An error was already thrown in some situations when the number of elements was higher than the declared length, but not all.

Fixes JuliaLang/DelimitedFiles.jl#3.

I'd appreciate if somebody with Scheme skills could indicate how to change the lowering of `T[x for x in itr]` [here](https://github.com/JuliaLang/julia/blob/39117c9ea5077e72df96bed9bae764496436720a/src/julia-syntax.scm#L2275-L2319) to throw an error if `idx != length(itr)` when `!szunk` in `construct-loops`. That would fix the two `@test_broken` cases.