### PR TITLE
rm redundant `show` method for Enum types

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -158,9 +158,6 @@ macro enum(T, syms...)
                 show(io, $basetype(x))
             end
         end
-        function Base.show(io::IO, t::Type{$(esc(typename))})
-            Base.show_datatype(io, t)
-        end
         function Base.show(io::IO, ::MIME"text/plain", t::Type{$(esc(typename))})
             print(io, "Enum ")
             Base.show_datatype(io, t)


### PR DESCRIPTION
This should have no effect, since it has the same implementation as the fallback `show(io, ::DataType)` method.