### PR TITLE
RFC: make default module-prefix showing independent of the state of Main(e)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -446,6 +446,9 @@ function isvisible(sym::Symbol, parent::Module, from::Module)
         isdefined(from, sym) # if we're going to return true, force binding resolution
 end
 
+module HasOnlyDefaultImports
+end
+
 function show_type_name(io::IO, tn::Core.TypeName)
     if tn === UnionAll.name
         # by coincidence, `typeof(Type)` is a valid representation of the UnionAll type.
@@ -478,9 +481,9 @@ function show_type_name(io::IO, tn::Core.TypeName)
     elseif globfunc
         print(io, "typeof(")
     end
-    # Print module prefix unless type is visible from module passed to IOContext
-    # If :module is not set, default to Main. nothing can be used to force printing prefix
-    from = get(io, :module, Main)
+    # Print module prefix unless type is visible from module passed to IOContext.
+    # If :module is not set, consider only default imports visible (Core and Base).
+    from = get(io, :module, HasOnlyDefaultImports)
     if isdefined(tn, :module) && (hidden || from === nothing || !isvisible(sym, tn.module, from))
         show(io, tn.module)
         if !hidden

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -128,7 +128,7 @@ end
 function display(d::REPLDisplay, mime::MIME"text/plain", x)
     io = outstream(d.repl)
     get(io, :color, false) && write(io, answer_color(d.repl))
-    show(IOContext(io, :limit => true), mime, x)
+    show(IOContext(io, :limit => true, :module => Main), mime, x)
     println(io)
     nothing
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1402,3 +1402,11 @@ end
 replstrcolor(x) = sprint((io, x) -> show(IOContext(io, :limit => true, :color => true),
                                          MIME("text/plain"), x), x)
 @test occursin("\e[", replstrcolor(`curl abc`))
+
+module TestMainIndependentShowing
+# make sure state of Main does not affect `show`
+using Sockets, Test
+@test repr(IPv4) == "Sockets.IPv4"
+Core.eval(Main, :(using Sockets))
+@test repr(IPv4) == "Sockets.IPv4"
+end


### PR DESCRIPTION
Currently, whether module prefixes are included in type name representations depends on what you have `using`'d in Main. This is not good. For example:
```
julia> module Foo
       using Sockets
       f() = repr(IPv4)
       end

julia> Foo.f()
"Sockets.IPv4"

julia> using Sockets

julia> Foo.f()
"IPv4"
```
In other words, behavior of code in some random place depends on what you happen to have loaded in your session. The idea behind this (more concise object representations at the REPL) makes sense, but I believe it should be implemented by setting the `:module` IOContext variable instead of by making Main the default.

With this change, both outputs above are `"Sockets.IPv4"`, but the type is still shown as just `IPv4` in the REPL.