### PR TITLE
task: drop parent and module references

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1013,22 +1013,16 @@ include_string(m::Module, txt::AbstractString, fname::AbstractString="string") =
     include_string(m, String(txt), String(fname))
 
 function source_path(default::Union{AbstractString,Nothing}="")
-    t = current_task()
-    while true
-        s = t.storage
-        if s !== nothing && haskey(s, :SOURCE_PATH)
-            return s[:SOURCE_PATH]
-        end
-        if t === t.parent
-            return default
-        end
-        t = t.parent
+    s = current_task().storage
+    if s !== nothing && haskey(s, :SOURCE_PATH)
+        return s[:SOURCE_PATH]
     end
+    return default
 end
 
 function source_dir()
     p = source_path(nothing)
-    p === nothing ? pwd() : dirname(p)
+    return p === nothing ? pwd() : dirname(p)
 end
 
 include_relative(mod::Module, path::AbstractString) = include_relative(mod, String(path))

--- a/src/gc.c
+++ b/src/gc.c
@@ -2245,10 +2245,6 @@ extern jl_array_t *jl_all_methods;
 static void jl_gc_queue_thread_local(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp,
                                      jl_ptls_t ptls2)
 {
-    // `current_module` might not have a value when the thread is not
-    // running.
-    if (ptls2->current_module)
-        gc_mark_queue_obj(gc_cache, sp, ptls2->current_module);
     gc_mark_queue_obj(gc_cache, sp, ptls2->current_task);
     gc_mark_queue_obj(gc_cache, sp, ptls2->root_task);
     gc_mark_queue_obj(gc_cache, sp, ptls2->exception_in_transit);
@@ -2259,13 +2255,17 @@ static void mark_roots(jl_gc_mark_cache_t *gc_cache, gc_mark_sp_t *sp)
 {
     // modules
     gc_mark_queue_obj(gc_cache, sp, jl_main_module);
-    gc_mark_queue_obj(gc_cache, sp, jl_internal_main_module);
 
     // invisible builtin values
     if (jl_an_empty_vec_any != NULL)
         gc_mark_queue_obj(gc_cache, sp, jl_an_empty_vec_any);
     if (jl_module_init_order != NULL)
         gc_mark_queue_obj(gc_cache, sp, jl_module_init_order);
+    for (size_t i = 0; i < jl_current_modules.size; i += 2) {
+        if (jl_current_modules.table[i + 1] != HT_NOTFOUND) {
+            gc_mark_queue_obj(gc_cache, sp, jl_current_modules.table[i]);
+        }
+    }
     if (jl_cfunction_list != NULL)
         gc_mark_queue_obj(gc_cache, sp, jl_cfunction_list);
     gc_mark_queue_obj(gc_cache, sp, jl_anytuple_type_type);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -904,28 +904,13 @@ SECT_INTERP CALLBACK_ABI void *jl_interpret_toplevel_expr_in_callback(interprete
     struct interpret_toplevel_expr_in_args *args =
         (struct interpret_toplevel_expr_in_args*)vargs;
     JL_GC_PROMISE_ROOTED(args);
-    jl_ptls_t ptls = jl_get_ptls_states();
-    jl_value_t *v=NULL;
-    jl_module_t *last_m = ptls->current_module;
-    jl_module_t *task_last_m = ptls->current_task->current_module;
     s->src = args->src;
     s->module = args->m;
     s->sparam_vals = args->sparam_vals;
     s->preevaluation = (s->sparam_vals != NULL);
     s->continue_at = 0;
     s->mi = NULL;
-
-    JL_TRY {
-        ptls->current_task->current_module = ptls->current_module = args->m;
-        v = eval_value(args->e, s);
-    }
-    JL_CATCH {
-        ptls->current_module = last_m;
-        ptls->current_task->current_module = task_last_m;
-        jl_rethrow();
-    }
-    ptls->current_module = last_m;
-    ptls->current_task->current_module = task_last_m;
+    jl_value_t *v = eval_value(args->e, s);
     assert(v);
     return (void*)v;
 }

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -86,14 +86,11 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
 {
     jl_value_t *r;
     JL_TRY {
-        const char *filename = "none";
+        const char filename[] = "none";
         jl_value_t *ast = jl_parse_input_line(str, strlen(str),
                 filename, strlen(filename));
         JL_GC_PUSH1(&ast);
-        size_t last_age = jl_get_ptls_states()->world_age;
-        jl_get_ptls_states()->world_age = jl_get_world_counter();
         r = jl_toplevel_eval_in(jl_main_module, ast);
-        jl_get_ptls_states()->world_age = last_age;
         JL_GC_POP();
         jl_exception_clear();
     }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1338,7 +1338,6 @@ JL_DLLEXPORT const char *jl_string_ptr(jl_value_t *s);
 
 // modules and global variables
 extern JL_DLLEXPORT jl_module_t *jl_main_module JL_GLOBALLY_ROOTED;
-extern JL_DLLEXPORT jl_module_t *jl_internal_main_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_core_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_base_module JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_module_t *jl_top_module JL_GLOBALLY_ROOTED;
@@ -1372,7 +1371,6 @@ JL_DLLEXPORT void jl_module_import(jl_module_t *to, jl_module_t *from,
 JL_DLLEXPORT void jl_module_export(jl_module_t *from, jl_sym_t *s);
 JL_DLLEXPORT int jl_is_imported(jl_module_t *m, jl_sym_t *s);
 JL_DLLEXPORT int jl_module_exports_p(jl_module_t *m, jl_sym_t *var) JL_NOTSAFEPOINT;
-JL_DLLEXPORT jl_module_t *jl_new_main_module(void);
 JL_DLLEXPORT void jl_add_standard_imports(jl_module_t *m);
 STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 {
@@ -1599,7 +1597,6 @@ typedef struct _jl_handler_t {
 
 typedef struct _jl_task_t {
     JL_DATA_TYPE
-    struct _jl_task_t *parent;
     jl_value_t *tls;
     jl_sym_t *state;
     jl_value_t *donenotify;
@@ -1620,8 +1617,6 @@ typedef struct _jl_task_t {
     jl_handler_t *eh;
     // saved gc stack top for context switches
     jl_gcframe_t *gcstack;
-    // current module, or NULL if this task has not set one
-    jl_module_t *current_module;
     // current world age
     size_t world_age;
 
@@ -1932,7 +1927,6 @@ typedef struct {
     float value;
 } jl_nullable_float32_t;
 
-#define jl_current_module (jl_get_ptls_states()->current_module)
 #define jl_current_task (jl_get_ptls_states()->current_task)
 #define jl_root_task (jl_get_ptls_states()->root_task)
 #define jl_exception_in_transit (jl_get_ptls_states()->exception_in_transit)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -423,6 +423,7 @@ void jl_assign_bits(void *dest, jl_value_t *bits) JL_NOTSAFEPOINT;
 jl_expr_t *jl_exprn(jl_sym_t *head, size_t n);
 jl_function_t *jl_new_generic_function(jl_sym_t *name, jl_module_t *module);
 jl_function_t *jl_new_generic_function_with_supertype(jl_sym_t *name, jl_module_t *module, jl_datatype_t *st, int iskw);
+void jl_init_main_module(void);
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent);
 jl_array_t *jl_get_loaded_modules(void);
 
@@ -458,6 +459,7 @@ jl_array_t *jl_new_array_for_deserialization(jl_value_t *atype, uint32_t ndims, 
 void jl_module_run_initializer(jl_module_t *m);
 jl_binding_t *jl_get_module_binding(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *var) JL_NOTSAFEPOINT;
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
+extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 extern jl_array_t *jl_cfunction_list JL_GLOBALLY_ROOTED;
 
 #ifdef JL_USE_INTEL_JITEVENTS

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -142,7 +142,6 @@ struct _jl_tls_states_t {
     volatile int8_t in_finalizer;
     int8_t disable_gc;
     volatile sig_atomic_t defer_signal;
-    struct _jl_module_t *current_module;
     struct _jl_task_t *volatile current_task;
     struct _jl_task_t *root_task;
 //#ifdef COPY_STACKS

--- a/src/method.c
+++ b/src/method.c
@@ -394,14 +394,10 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
     jl_ptls_t ptls = jl_get_ptls_states();
     int last_lineno = jl_lineno;
     int last_in = ptls->in_pure_callback;
-    jl_module_t *last_m = ptls->current_module;
-    jl_module_t *task_last_m = ptls->current_task->current_module;
     size_t last_age = jl_get_ptls_states()->world_age;
 
     JL_TRY {
         ptls->in_pure_callback = 1;
-        // need to eval macros in the right module
-        ptls->current_task->current_module = ptls->current_module = linfo->def.method->module;
         // and the right world
         ptls->world_age = def->min_world;
 
@@ -425,16 +421,12 @@ JL_DLLEXPORT jl_code_info_t *jl_code_for_staged(jl_method_instance_t *linfo)
 
         ptls->in_pure_callback = last_in;
         jl_lineno = last_lineno;
-        ptls->current_module = last_m;
-        ptls->current_task->current_module = task_last_m;
         ptls->world_age = last_age;
         jl_linenumber_to_lineinfo(func, def->module, def->name);
     }
     JL_CATCH {
         ptls->in_pure_callback = last_in;
         jl_lineno = last_lineno;
-        ptls->current_module = last_m;
-        ptls->current_task->current_module = task_last_m;
         jl_rethrow();
     }
     JL_GC_POP();

--- a/src/module.c
+++ b/src/module.c
@@ -55,12 +55,15 @@ uint32_t jl_module_next_counter(jl_module_t *m)
 
 JL_DLLEXPORT jl_value_t *jl_f_new_module(jl_sym_t *name, uint8_t std_imports)
 {
+    // TODO: should we prohibit this during incremental compilation?
     jl_module_t *m = jl_new_module(name);
     JL_GC_PUSH1(&m);
-    m->parent = jl_main_module;
+    m->parent = jl_main_module; // TODO: this is a lie
     jl_gc_wb(m, m->parent);
-    if (std_imports) jl_add_standard_imports(m);
+    if (std_imports)
+        jl_add_standard_imports(m);
     JL_GC_POP();
+    // TODO: should we somehow try to gc-root this correctly?
     return (jl_value_t*)m;
 }
 

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1428,7 +1428,6 @@ JL_DLLEXPORT void jl_set_sysimg_so(void *handle)
 static void jl_restore_system_image_from_stream(ios_t *f)
 {
     JL_TIMING(SYSIMG_LOAD);
-    jl_ptls_t ptls = jl_get_ptls_states();
     int en = jl_gc_enable(0);
     jl_init_serializer2(0);
     ios_t sysimg, const_data, symbols, relocs, gvar_record, fptr_record;
@@ -1520,7 +1519,6 @@ static void jl_restore_system_image_from_stream(ios_t *f)
     jl_module_init_order = jl_finalize_deserializer(&s, NULL);
     jl_main_module = (jl_module_t*)jl_read_value(&s);
     jl_top_module = (jl_module_t*)jl_read_value(&s);
-    jl_internal_main_module = jl_main_module;
 
     jl_typeinf_func = (jl_function_t*)jl_read_value(&s);
     jl_typeinf_world = read_uint32(f);
@@ -1546,7 +1544,6 @@ static void jl_restore_system_image_from_stream(ios_t *f)
 
     jl_core_module = (jl_module_t*)jl_get_global(jl_main_module, jl_symbol("Core"));
     jl_base_module = (jl_module_t*)jl_get_global(jl_main_module, jl_symbol("Base"));
-    ptls->current_module = jl_base_module; // run start_image in Base
 
     uint32_t uid_ctr = read_uint32(f);
     uint32_t gs_ctr = read_uint32(f);

--- a/src/threading.c
+++ b/src/threading.c
@@ -274,7 +274,6 @@ static void ti_initthread(int16_t tid)
                                     sizeof(size_t));
     }
     ptls->defer_signal = 0;
-    ptls->current_module = NULL;
     void *bt_data = malloc(sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
     memset(bt_data, 0, sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
     if (bt_data == NULL) {
@@ -413,15 +412,10 @@ void ti_threadfun(void *arg)
                 //       enter GC unsafe region when starting the work.
                 int8_t gc_state = jl_gc_unsafe_enter(ptls);
                 // This is probably always NULL for now
-                jl_module_t *last_m = ptls->current_module;
                 size_t last_age = ptls->world_age;
-                JL_GC_PUSH1(&last_m);
-                ptls->current_module = work->current_module;
                 ptls->world_age = work->world_age;
                 ti_run_fun(work->fptr, work->mfunc, work->args, work->nargs);
-                ptls->current_module = last_m;
                 ptls->world_age = last_age;
-                JL_GC_POP();
                 jl_gc_unsafe_leave(ptls, gc_state);
             }
         }
@@ -703,7 +697,6 @@ JL_DLLEXPORT jl_value_t *jl_threading_run(jl_value_t *_args)
     threadwork.args = args;
     threadwork.nargs = nargs;
     threadwork.ret = jl_nothing;
-    threadwork.current_module = ptls->current_module;
     threadwork.world_age = world;
 
 #if PROFILE_JL_THREADING

--- a/src/threading.h
+++ b/src/threading.h
@@ -44,7 +44,6 @@ typedef struct {
     jl_value_t **args;
     uint32_t nargs;
     jl_value_t *ret;
-    jl_module_t *current_module;
     size_t world_age;
 } ti_threadwork_t;
 

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -92,7 +92,7 @@ int main()
 
         checked_eval_string("my_func(x) = 2 * x");
 
-        jl_function_t *func = jl_get_function(jl_current_module, "my_func");
+        jl_function_t *func = jl_get_function(jl_main_module, "my_func");
         jl_value_t* arg = jl_box_float64(5.0);
         double ret = jl_unbox_float64(jl_call1(func, arg));
 

--- a/test/test_sourcepath.jl
+++ b/test/test_sourcepath.jl
@@ -2,16 +2,22 @@
 
 # source path in tasks
 path = Base.source_path()::String # this variable is leaked to the source script
-@test endswith(path, joinpath("test","test_sourcepath.jl"))
+@test endswith(path, joinpath("test", "test_sourcepath.jl"))
+@test isabspath(path)
+
 @test let ct = current_task()
     yieldto(@task yieldto(ct, Base.source_path()))
-end == path
+end === ""
+
 @test let ct = current_task()
     yieldto(@task schedule(ct, Base.source_path()))
-end == path
-@test let ct = current_task(), t = @task Base.source_path()
+end === ""
+
+@test let ct = current_task(),
+    t = @task Base.source_path()
     schedule(ct)
     yieldto(t)
     fetch(t)
-end == path
-@test isabspath(@__FILE__)
+end === ""
+
+@test @__FILE__() == path


### PR DESCRIPTION
The parent link can unnecessarily hold memory references live, and the current-module function is gone.
Their uses have been deprecated in favor of the macros @`__FILE__` and @`__MODULE__`.
The `workspace()` function is also gone now, so we can remove the support code for it.

To implement detection of broken incremental compilation (and help
ensure the module is permanently rooted as is generally expected),
keep track of all "open" modules in a hashtable (jl_current_modules).
We can further refine this later, if desired (e.g. also allow any
submodule and of any item in `jl_module_init_order`).

Also removes the global `module_stack` state. This makes us a bit more
robust to async module definition. We could perhaps do even more here,
if necessary (e.g. by checking first that all parents are initialized,
instead of just the direct ancestor). But this is hopefully a vanishingly
rare situation anyways.

closes #29059 (rewords the message to be less confusing)