### PR TITLE
propagate IO context more; use 2-argument `summary`

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -44,8 +44,10 @@ struct ValueIterator{T<:AbstractDict}
     dict::T
 end
 
-summary(iter::T) where {T<:Union{KeySet,ValueIterator}} =
-    string(T.name, " for a ", summary(iter.dict))
+function summary(io::IO, iter::T) where {T<:Union{KeySet,ValueIterator}}
+    print(io, T.name, " for a ")
+    summary(io, iter.dict)
+end
 
 show(io::IO, iter::Union{KeySet,ValueIterator}) = show_vector(io, iter)
 

--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -410,7 +410,7 @@ _show_nonempty(::IO, ::AbstractVector, ::String) =
 _show_nonempty(io::IO, X::AbstractArray{T,0} where T, prefix::String) = print_array(io, X)
 
 # NOTE: it's not clear how this method could use the :typeinfo attribute
-_show_empty(io::IO, X::Array{T}) where {T} = print(io, "Array{$T}(", join(size(X),','), ')')
+_show_empty(io::IO, X::Array{T}) where {T} = print(io, "Array{", T, "}(", join(size(X),','), ')')
 _show_empty(io, X) = nothing # by default, we don't know this constructor
 
 # typeinfo aware (necessarily)

--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -319,7 +319,7 @@ function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
 end
 
 function show(io::IO, mime::MIME"text/html", mt::AbstractVector{Method})
-    print(io, summary(mt))
+    summary(io, mt)
     if !isempty(mt)
         print(io, ":<ul>")
         for d in mt

--- a/base/show.jl
+++ b/base/show.jl
@@ -11,7 +11,7 @@ function show(io::IO, ::MIME"text/plain", r::LinRange)
     # range(1, stop=3, length=7)
     # 7-element LinRange{Float64}:
     #   1.0,1.33333,1.66667,2.0,2.33333,2.66667,3.0
-    print(io, summary(r))
+    summary(io, r)
     if !isempty(r)
         println(io, ":")
         print_range(io, r)
@@ -41,7 +41,7 @@ function show(io::IO, ::MIME"text/plain", f::Function)
 end
 
 function show(io::IO, ::MIME"text/plain", iter::Union{KeySet,ValueIterator})
-    print(io, summary(iter))
+    summary(io, iter)
     isempty(iter) && return
     print(io, ". ", isa(iter,KeySet) ? "Keys" : "Values", ":")
     limit::Bool = get(io, :limit, false)
@@ -78,7 +78,7 @@ function show(io::IO, ::MIME"text/plain", t::AbstractDict{K,V}) where {K,V}
         recur_io = IOContext(recur_io, :compact => true)
     end
 
-    print(io, summary(t))
+    summary(io, t)
     isempty(t) && return
     print(io, ":")
     show_circular(io, t) && return
@@ -1653,7 +1653,7 @@ function dump_elts(io::IOContext, x::Array, n::Int, indent, i0, i1)
 end
 
 function dump(io::IOContext, x::Array, n::Int, indent)
-    print(io, "Array{$(eltype(x))}($(size(x)))")
+    print(io, "Array{", eltype(x), "}(", size(x), ")")
     if eltype(x) <: Number
         print(io, " ")
         show(io, x)
@@ -1738,7 +1738,11 @@ MyStruct
   y: Tuple{Int64,Int64}
 ```
 """
-dump(arg; maxdepth=DUMP_DEFAULT_MAXDEPTH) = dump(IOContext(stdout::IO, :limit => true), arg; maxdepth=maxdepth)
+function dump(arg; maxdepth=DUMP_DEFAULT_MAXDEPTH)
+    # this is typically used interactively, so default to being in Main
+    mod = get(stdout, :module, Main)
+    dump(IOContext(stdout::IO, :limit => true, :module => mod), arg; maxdepth=maxdepth)
+end
 
 
 """
@@ -1908,14 +1912,14 @@ function showarg(io::IO, r::ReshapedArray, toplevel)
 end
 
 function showarg(io::IO, r::ReinterpretArray{T}, toplevel) where {T}
-    print(io, "reinterpret($T, ")
+    print(io, "reinterpret(", T, ", ")
     showarg(io, parent(r), false)
     print(io, ')')
 end
 
 # pretty printing for Iterators.Pairs
 function Base.showarg(io::IO, r::Iterators.Pairs{<:Integer, <:Any, <:Any, T}, toplevel) where T<:AbstractArray
-    print(io, "pairs(IndexLinear(), ::$T)")
+    print(io, "pairs(IndexLinear(), ::", T, ")")
 end
 
 function Base.showarg(io::IO, r::Iterators.Pairs{Symbol, <:Any, <:Any, T}, toplevel) where {T <: NamedTuple}
@@ -1923,7 +1927,7 @@ function Base.showarg(io::IO, r::Iterators.Pairs{Symbol, <:Any, <:Any, T}, tople
 end
 
 function Base.showarg(io::IO, r::Iterators.Pairs{<:Any, <:Any, I, D}, toplevel) where {D, I}
-    print(io, "Iterators.Pairs(::$D, ::$I)")
+    print(io, "Iterators.Pairs(::", D, ", ::", I, ")")
 end
 
 # printing BitArrays

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -208,7 +208,7 @@ end
 
 function show(io::IO, M::Bidiagonal)
     # TODO: make this readable and one-line
-    println(io, summary(M), ":")
+    summary(io, M); println(io, ":")
     print(io, " diag:")
     print_matrix(io, (M.dv)')
     print(io, M.uplo == 'U' ? "\n super:" : "\n sub:")

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -250,7 +250,7 @@ issuccess(B::BunchKaufman) = B.info == 0
 
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, B::BunchKaufman)
     if issuccess(B)
-        println(io, summary(B))
+        summary(io, B); println(io)
         println(io, "D factor:")
         show(io, mime, B.D)
         println(io, "\n$(B.uplo) factor:")

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -379,7 +379,7 @@ issuccess(C::Cholesky) = C.info == 0
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, C::Cholesky{<:Any,<:AbstractMatrix})
     if issuccess(C)
-        println(io, summary(C))
+        summary(io, C); println(io)
         println(io, "$(C.uplo) factor:")
         show(io, mime, C.UL)
     else
@@ -388,7 +388,7 @@ function show(io::IO, mime::MIME{Symbol("text/plain")}, C::Cholesky{<:Any,<:Abst
 end
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, C::CholeskyPivoted{<:Any,<:AbstractMatrix})
-    println(io, summary(C))
+    summary(io, C); println(io)
     println(io, "$(C.uplo) factor with rank $(rank(C)):")
     show(io, mime, C.uplo == 'U' ? C.U : C.L)
     println(io, "\npermutation:")

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -489,7 +489,7 @@ julia> eigvecs(A, B)
 eigvecs(A::AbstractMatrix, B::AbstractMatrix) = eigvecs(eigen(A, B))
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::Union{Eigen,GeneralizedEigen})
-    println(io, summary(F))
+    summary(io, F); println(io)
     println(io, "eigenvalues:")
     show(io, mime, F.values)
     println(io, "\neigenvectors:")

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -105,7 +105,7 @@ getindex(A::LQPackedQ, i::Integer, j::Integer) =
     lmul!(A, setindex!(zeros(eltype(A), size(A, 2)), 1, j))[i]
 
 function show(io::IO, C::LQ)
-    println(io, "$(typeof(C)) with factors L and Q:")
+    println(io, typeof(C), " with factors L and Q:")
     show(io, C.L)
     println(io)
     show(io, C.Q)

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -305,7 +305,7 @@ issuccess(F::LU) = F.info == 0
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::LU)
     if issuccess(F)
-        println(io, summary(F))
+        summary(io, F); println(io)
         println(io, "L factor:")
         show(io, mime, F.L)
         println(io, "\nU factor:")

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -395,7 +395,7 @@ Matrix(F::QRPivoted) = Array(AbstractArray(F))
 Array(F::QRPivoted) = Matrix(F)
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::Union{QR, QRCompactWY, QRPivoted})
-    println(io, summary(F))
+    summary(io, F); println(io)
     println(io, "Q factor:")
     show(io, mime, F.Q)
     println(io, "\nR factor:")

--- a/stdlib/LinearAlgebra/src/schur.jl
+++ b/stdlib/LinearAlgebra/src/schur.jl
@@ -116,7 +116,7 @@ Base.propertynames(F::Schur) =
     (:Schur, :vectors, fieldnames(typeof(F))...)
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::Schur)
-    println(io, summary(F))
+    summary(io, F); println(io)
     println(io, "T factor:")
     show(io, mime, F.T)
     println(io, "\nZ factor:")
@@ -261,7 +261,7 @@ Base.propertynames(F::GeneralizedSchur) =
     (:values, :left, :right, fieldnames(typeof(F))...)
 
 function show(io::IO, mime::MIME{Symbol("text/plain")}, F::GeneralizedSchur)
-    println(io, summary(F))
+    summary(io, F); println(io)
     println(io, "S factor:")
     show(io, mime, F.S)
     println(io, "\nT factor:")

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -58,7 +58,7 @@ function show(io::IO, J::UniformScaling)
     if occursin(r"\w+\s*[\+\-]\s*\w+", s)
         s = "($s)"
     end
-    print(io, "$(typeof(J))\n$s*I")
+    print(io, typeof(J), "\n$s*I")
 end
 copy(J::UniformScaling) = UniformScaling(J.λ)
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -128,7 +128,7 @@ end
 function display(d::REPLDisplay, mime::MIME"text/plain", x)
     io = outstream(d.repl)
     get(io, :color, false) && write(io, answer_color(d.repl))
-    show(IOContext(io, :limit => true), mime, x)
+    show(IOContext(io, :limit => true, :module => Main), mime, x)
     println(io)
     nothing
 end
@@ -136,7 +136,8 @@ display(d::REPLDisplay, x) = display(d, MIME("text/plain"), x)
 
 function print_response(repl::AbstractREPL, @nospecialize(val), bt, show_value::Bool, have_color::Bool)
     repl.waserror = bt !== nothing
-    print_response(outstream(repl), val, bt, show_value, have_color, specialdisplay(repl))
+    io = IOContext(outstream(repl), :module => Main)
+    print_response(io, val, bt, show_value, have_color, specialdisplay(repl))
     nothing
 end
 function print_response(errio::IO, @nospecialize(val), bt, show_value::Bool, have_color::Bool, specialdisplay=nothing)

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -487,7 +487,7 @@ function show(io::IO, mime::MIME"text/plain", S::SharedArray)
         invoke(show, Tuple{IO,MIME"text/plain",DenseArray}, io, MIME"text/plain"(), S)
     else
         # retrieve from the first worker mapping the array.
-        println(io, summary(S), ":")
+        summary(io, S); println(io, ":")
         Base.print_array(io, remotecall_fetch(sharr->sharr.s, S.pids[1], S))
     end
 end

--- a/stdlib/SharedArrays/test/runtests.jl
+++ b/stdlib/SharedArrays/test/runtests.jl
@@ -306,5 +306,5 @@ end
 
 let S = SharedArray(Int64[]) # Issue #26582
     @test sprint(show, S) == "Int64[]"
-    @test sprint(show, "text/plain", S) == "0-element SharedArray{Int64,1}:\n"
+    @test sprint(show, "text/plain", S, context = :module=>@__MODULE__) == "0-element SharedArray{Int64,1}:\n"
 end

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -321,7 +321,7 @@ function Base.propertynames(F::QRSparse, private::Bool=false)
 end
 
 function Base.show(io::IO, mime::MIME{Symbol("text/plain")}, F::QRSparse)
-    println(io, summary(F))
+    summary(io, F); println(io)
     println(io, "Q factor:")
     show(io, mime, F.Q)
     println(io, "\nR factor:")


### PR DESCRIPTION
Some subtle printing fixes found during #29466. Should be non-breaking.

- Set the `:module` IOContext property to Main during REPL display. I really thought we were doing this already.
- Use and define `summary(io, x)` instead of just `summary(x)` everywhere.
- Replace `print(io, "$T")` with `print(io, T)` to allow printing types to see the context in `io`. Could probably be done in more places but this catches most in Base.
