### PR TITLE
Two small build system improvements

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -976,7 +976,7 @@ ifeq ($(OS), FreeBSD)
   RPATH += -Wl,-rpath,'$$ORIGIN/$(build_private_libdir_rel)'
 endif
   RPATH_ORIGIN := -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
-  RPATH_ESCAPED_ORIGIN := -Wl,-rpath,'\$$\$$ORIGIN' -Wl,-z,origin
+  RPATH_ESCAPED_ORIGIN := -Wl,-rpath,'\$$\$$ORIGIN' -Wl,-z,origin -Wl,-rpath-link,$(build_shlibdir)
   RPATH_LIB := -Wl,-rpath,'$$ORIGIN/julia' -Wl,-rpath,'$$ORIGIN' -Wl,-z,origin
 endif
 

--- a/deps/libssh2.mk
+++ b/deps/libssh2.mk
@@ -24,6 +24,10 @@ ifneq (,$(findstring $(OS),Linux FreeBSD))
 LIBSSH2_OPTS += -DCMAKE_INSTALL_RPATH="\$$ORIGIN"
 endif
 
+ifeq ($(LIBSSH2_ENABLE_TESTS), 0)
+LIBSSH2_OPTS += -DBUILD_TESTING=OFF
+endif
+
 $(SRCCACHE)/$(LIBSSH2_SRC_DIR)/libssh2-encryptedpem.patch-applied: $(SRCCACHE)/$(LIBSSH2_SRC_DIR)/source-extracted
 	cd $(SRCCACHE)/$(LIBSSH2_SRC_DIR) && patch -p1 -f < $(SRCDIR)/patches/libssh2-encryptedpem.patch
 	echo 1 > $@


### PR DESCRIPTION
Found while trying to bootstrap Julia (x86_64 linux only) under BinaryBuilder, which doesn't have any global copies of our dependencies (as most linux distros do).