### PR TITLE
Add proper ASAN support to task switching

### DIFF
--- a/src/julia.h
+++ b/src/julia.h
@@ -65,6 +65,36 @@
 #  define JL_THREAD_LOCAL
 #endif
 
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define JL_ASAN_ENABLED     // Clang flavor
+#endif
+#elif defined(__SANITIZE_ADDRESS__)
+#define JL_ASAN_ENABLED     // GCC flavor
+#endif
+
+#ifdef JL_ASAN_ENABLED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+void __sanitizer_start_switch_fiber(void**, const void*, size_t);
+void __sanitizer_finish_switch_fiber(void*, const void**, size_t*);
+#ifdef __cplusplus
+}
+#endif
+
+static inline void sanitizer_start_switch_fiber(const void* bottom, size_t size) {
+    __sanitizer_start_switch_fiber(NULL, bottom, size);
+}
+static inline void sanitizer_finish_switch_fiber() {
+    __sanitizer_finish_switch_fiber(NULL, NULL, NULL);
+}
+#else
+static inline void sanitizer_start_switch_fiber(const void* bottom, size_t size) {}
+static inline void sanitizer_finish_switch_fiber() {}
+#endif
+
 #define container_of(ptr, type, member) \
     ((type *) ((char *)(ptr) - offsetof(type, member)))
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -21,6 +21,7 @@
 #define JL_ASAN_ENABLED     // GCC flavor
 #endif
 
+
 #if defined(__has_feature)
 #if __has_feature(memory_sanitizer)
 #define JL_MSAN_ENABLED

--- a/src/task.c
+++ b/src/task.c
@@ -138,6 +138,8 @@ static void NOINLINE JL_NORETURN restore_stack(jl_task_t *t, jl_ptls_t ptls, cha
     }
     assert(t->stkbuf != NULL);
     memcpy_a16((uint64_t*)_x, (uint64_t*)t->stkbuf, nb); // destroys all but the current stackframe
+
+    sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
     jl_set_fiber(&t->ctx);
     abort(); // unreachable
 }
@@ -147,7 +149,9 @@ static void restore_stack2(jl_task_t *t, jl_ptls_t ptls, jl_task_t *lastt)
     char *_x = (char*)ptls->stackbase - nb;
     assert(t->stkbuf != NULL);
     memcpy_a16((uint64_t*)_x, (uint64_t*)t->stkbuf, nb); // destroys all but the current stackframe
+    sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
     jl_swap_fiber(&lastt->ctx, &t->ctx);
+    sanitizer_finish_switch_fiber();
 }
 #endif
 
@@ -277,6 +281,7 @@ static void ctx_switch(jl_ptls_t ptls, jl_task_t **pt)
         if (lastt->copy_stack) { // save the old copy-stack
             save_stack(ptls, lastt, pt); // allocates (gc-safepoint, and can also fail)
             if (jl_setjmp(lastt->ctx.uc_mcontext, 0)) {
+                sanitizer_finish_switch_fiber();
                 // TODO: mutex unlock the thread we just switched from
                 return;
             }
@@ -318,18 +323,27 @@ static void ctx_switch(jl_ptls_t ptls, jl_task_t **pt)
         }
         else
 #endif
-        if (!lastt_ctx)
-            jl_set_fiber(&t->ctx);
-        else
+        if (!lastt_ctx) {
+            sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
+            jl_set_fiber(&t->ctx); // (doesn't return)
+            abort(); // unreachable
+        } else {
+            sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
             jl_swap_fiber(lastt_ctx, &t->ctx);
+            sanitizer_finish_switch_fiber();
+        }
     }
     else {
+        sanitizer_start_switch_fiber(t->stkbuf, t->bufsz);
+        if (always_copy_stacks) {
 #ifdef COPY_STACKS
-        if (always_copy_stacks)
             jl_longjmp(ptls->base_ctx.uc_mcontext, 1);
-        else
+            abort(); // unreachable
 #endif
+        } else {
             jl_start_fiber(lastt_ctx, &t->ctx);
+            sanitizer_finish_switch_fiber();
+        }
     }
 }
 
@@ -627,6 +641,7 @@ STATIC_OR_JS void NOINLINE JL_NORETURN start_task(void)
 #endif
 
     // this runs the first time we switch to a task
+    sanitizer_finish_switch_fiber();
     jl_ptls_t ptls = jl_get_ptls_states();
     jl_task_t *t = ptls->current_task;
     jl_value_t *res;
@@ -724,8 +739,10 @@ static void start_basefiber(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (jl_setjmp(ptls->base_ctx.uc_mcontext, 0))
-        start_task();
+        start_task(); // sanitizer_finish_switch_fiber is part of start_task
+    sanitizer_start_switch_fiber(jl_root_task->stkbuf, jl_root_task->bufsz);
     jl_longjmp(jl_root_task->ctx.uc_mcontext, 1);
+    abort(); // unreachable
 }
 #if defined(_CPU_X86_) || defined(_CPU_X86_64_)
 #define PUSH_RET(ctx, stk) \
@@ -791,7 +808,9 @@ static void jl_init_basefiber(size_t ssize)
     char *stkbuf = jl_alloc_fiber(&ptls->base_ctx, &ssize, NULL);
     ptls->stackbase = stkbuf + ssize;
     ptls->stacksize = ssize;
+    sanitizer_start_switch_fiber(stkbuf, sksize);
     jl_start_fiber(jl_root_task, &ptls->base_ctx); // finishes initializing jl_basectx
+    sanitizer_finish_switch_fiber();
 #endif
 }
 #endif
@@ -906,7 +925,7 @@ static void start_basefiber(void)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
     if (jl_setjmp(ptls->base_ctx.uc_mcontext, 0))
-        start_task();
+        start_task(); // sanitizer_finish_switch_fiber is part of start_task
 }
 static char *jl_alloc_fiber(jl_ucontext_t *t, size_t *ssize, jl_task_t *owner)
 {
@@ -1056,7 +1075,7 @@ void jl_init_root_task(void *stack_lo, void *stack_hi)
         ptls->stackbase = stack_hi;
         ptls->stacksize = ssize;
         if (jl_setjmp(ptls->base_ctx.uc_mcontext, 0))
-            start_task();
+            start_task(); // sanitizer_finish_switch_fiber is part of start_task
         return;
     }
 #endif


### PR DESCRIPTION
When we are using ASAN we need to inform it when we switch stacks.
```
WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7ffee525b000; bottom 0x7efe8a835000; size: 0x01005aa26000 (1101032218624)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
```

Originally needed by https://github.com/JuliaLang/julia/pull/22631

@vtjnash any ideas for how to do this cleverly?