### PR TITLE
Allow :new constant inference in more cases

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -893,7 +893,7 @@ function abstract_eval(@nospecialize(e), vtypes::VarTable, sv::InferenceState)
         t = abstract_eval_call(e.args, argtypes, vtypes, sv)
     elseif e.head === :new
         t = instanceof_tfunc(abstract_eval(e.args[1], vtypes, sv))[1]
-        if isbitstype(t)
+        if isconcretetype(t) && !t.mutable
             args = Vector{Any}(undef, length(e.args)-1)
             isconst = true
             for i = 2:length(e.args)

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -939,6 +939,17 @@ end
 f28284() = Val(t28284(1))
 @inferred f28284()
 
+# ...even if we have a non-bitstype
+struct NonBitstype
+    a::NTuple{N, Int} where N
+    b::NTuple{N, Int} where N
+end
+function fNonBitsTypeConstants()
+    val = NonBitstype((1,2),(3,4))
+    Val((val.a[1],val.b[2]))
+end
+@test @inferred(fNonBitsTypeConstants()) === Val((1,4))
+
 # missing method should be inferred as Union{}, ref https://github.com/JuliaLang/julia/issues/20033#issuecomment-282228948
 @test Base.return_types(f -> f(1), (typeof((x::String) -> x),)) == Any[Union{}]
 


### PR DESCRIPTION
Previously we allowed only bitstypes. However, it is legal to do
so for and the current code works for all concrete immutables,
so weaken the guarding condition appropriately here.

cc @peterahrens 