### PR TITLE
More robust show for invalid CFG

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -26,12 +26,12 @@ Like UnitRange{Int}, but can handle the `last` field, being temporarily
 < first (this can happen during compacting)
 """
 struct StmtRange <: AbstractUnitRange{Int}
-    first::Int
-    last::Int
+    start::Int
+    stop::Int
 end
-first(r::StmtRange) = r.first
-last(r::StmtRange) = r.last
-iterate(r::StmtRange, state=0) = (r.last - r.first < state) ? nothing : (r.first + state, state + 1)
+first(r::StmtRange) = r.start
+last(r::StmtRange) = r.stop
+iterate(r::StmtRange, state=0) = (last(r) - first(r) < state) ? nothing : (first(r) + state, state + 1)
 
 StmtRange(range::UnitRange{Int}) = StmtRange(first(range), last(range))
 

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -240,12 +240,19 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
     lines = (code isa IRCode ? code.lines : code.codelocs)
     for idx in eachindex(stmts)
         buf = IOBuffer()
-        line = lines[idx]
+        # N.B.: The line array length not matching is invalid,
+        # but let's be robust here
+        if idx > length(lines)
+            line = Int32(0)
+            print(buf, "!")
+        else
+            line = lines[idx]
+            print(buf, "│")
+        end
         depth = compute_inlining_depth(linetable, line)
         iline = line
         lineno = 0
         loc_method = ""
-        print(buf, "│")
         if line != 0
             stack = compute_loc_stack(linetable, line)
             lineno = linetable[stack[1]].line
@@ -359,11 +366,18 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         end
         stmt = stmts[idx]
         # Compute BB guard rail
-        bbrange = cfg.blocks[bb_idx].stmts
-        bbrange = bbrange.start:bbrange.stop
-        bb_idx_str = string(bb_idx)
+        if bb_idx > length(cfg.blocks)
+            # Even if invariants are violated, try our best to still print
+            bbrange = (last(cfg.blocks[end].stmts) + 1):typemax(Int)
+            bb_idx_str = "!"
+            bb_type = "─"
+        else
+            bbrange = cfg.blocks[bb_idx].stmts
+            bbrange = bbrange.start:bbrange.stop
+            bb_idx_str = string(bb_idx)
+            bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
+        end
         bb_pad = max_bb_idx_size - length(bb_idx_str)
-        bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
         bb_start_str = string(bb_idx_str, " ", bb_type, "─"^bb_pad, " ")
         bb_guard_rail_cont = string("│  ", " "^max_bb_idx_size)
         if idx == first(bbrange)
@@ -500,11 +514,18 @@ function show_ir(io::IO, code::CodeInfo, expr_type_printer=default_expr_type_pri
         end
         stmt = stmts[idx]
         # Compute BB guard rail
-        bbrange = cfg.blocks[bb_idx].stmts
-        bbrange = bbrange.first:bbrange.last
-        bb_idx_str = string(bb_idx)
+        if bb_idx > length(cfg.blocks)
+            # Even if invariants are violated, try out best to still print
+            bb_range = last(cfg.blocks[end].stmts):typemax(Int)
+            bb_idx_str = "!!!"
+            bb_type = "─"
+        else
+            bbrange = cfg.blocks[bb_idx].stmts
+            bbrange = bbrange.start:bbrange.stop
+            bb_idx_str = string(bb_idx)
+            bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
+        end
         bb_pad = max_bb_idx_size - length(bb_idx_str)
-        bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
         bb_start_str = string(bb_idx_str, " ", bb_type, "─"^bb_pad, " ")
         bb_guard_rail_cont = string("│  ", " "^max_bb_idx_size)
         if idx == first(bbrange)

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -360,7 +360,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
         stmt = stmts[idx]
         # Compute BB guard rail
         bbrange = cfg.blocks[bb_idx].stmts
-        bbrange = bbrange.first:bbrange.last
+        bbrange = bbrange.start:bbrange.stop
         bb_idx_str = string(bb_idx)
         bb_pad = max_bb_idx_size - length(bb_idx_str)
         bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -387,7 +387,7 @@ function domsort_ssa!(ir::IRCode, domtree::DomTree)
     while node !== -1
         push!(result_order, node)
         cs = domtree.nodes[node].children
-        terminator = ir.stmts[ir.cfg.blocks[node].stmts.last]
+        terminator = ir.stmts[last(ir.cfg.blocks[node].stmts)]
         iscondbr = isa(terminator, GotoIfNot)
         let old_node = node + 1
             if length(cs) >= 1

--- a/base/show.jl
+++ b/base/show.jl
@@ -1559,7 +1559,8 @@ module IRShow
     import ..Base
     import .Compiler: IRCode, ReturnNode, GotoIfNot, CFG, scan_ssa_use!, Argument, isexpr, compute_basic_blocks, block_for_inst
     Base.size(r::Compiler.StmtRange) = Compiler.size(r)
-    Base.show(io::IO, r::Compiler.StmtRange) = print(io, Compiler.first(r):Compiler.last(r))
+    Base.first(r::Compiler.StmtRange) = Compiler.first(r)
+    Base.last(r::Compiler.StmtRange) = Compiler.last(r)
     include("compiler/ssair/show.jl")
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -1373,6 +1373,17 @@ let src = code_typed(my_fun28173, (Int,))[1][1]
     @test lines1 == lines2
 end
 
+# Verify that extra instructions at the end of the IR
+# don't throw errors in the printing, but instead print
+# with as unnamed "!" BB.
+let src = code_typed(gcd, (Int, Int))[1][1]
+    ir = Core.Compiler.inflate_ir(src)
+    push!(ir.stmts, Core.Compiler.ReturnNode())
+    lines = split(sprint(show, ir), '\n')
+    @test isempty(pop!(lines))
+    @test pop!(lines) == "   ! ──       unreachable::#UNDEF"
+end
+
 # issue #27352
 @test_throws ArgumentError print(nothing)
 @test_throws ArgumentError print(stdout, nothing)


### PR DESCRIPTION
Despite the fact that the compiler should never generate invalid
data structures, it is a good practice for the show functions to
be able to handle these and indicate what the problem is. In this
case, if the IR has more instructions than its supposed to according
to the CFG, put all trailing instructions into a "!" basic block to
indicate an error.