### PR TITLE
Fix phinode rename bug during domsort

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -363,11 +363,7 @@ function rename_phinode_edges(node, bb, result_order, bb_rename)
             resize!(new_values, length(new_values)+1)
         end
     end
-    if length(new_edges) == 1
-        return isassigned(new_values, 1) ? new_values[1] : PhiNode(Any[], Any[])
-    else
-        return PhiNode(new_edges, new_values)
-    end
+    return PhiNode(new_edges, new_values)
 end
 
 """

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -107,7 +107,7 @@ function choosetests(choices = [])
         prepend!(tests, ["subarray"])
     end
 
-    compilertests = ["compiler/compiler", "compiler/validation", "compiler/ssair"]
+    compilertests = ["compiler/compiler", "compiler/validation", "compiler/ssair", "compiler/irpasses"]
 
     if "compiler" in skip_tests
         filter!(x -> (x != "compiler" && !(x in compilertests)), tests)

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1,0 +1,39 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+using Test
+
+# Tests for domsort
+
+## Test that domsort doesn't mangle single-argument phis (#29262)
+let m = Meta.@lower 1 + 1
+    @assert Meta.isexpr(m, :thunk)
+    src = m.args[1]::Core.CodeInfo
+    src.code = Any[
+        # block 1
+        Expr(:call, :opaque),
+        Expr(:gotoifnot, Core.SSAValue(1), 10),
+        # block 2
+        Core.PhiNode(Any[8], Any[Core.SSAValue(7)]), # <- This phi must not get replaced by %7
+        Core.PhiNode(Any[2, 8], Any[true, false]),
+        Expr(:gotoifnot, Core.SSAValue(1), 7),
+        # block 3
+        Expr(:call, :+, Core.SSAValue(3), 1),
+        # block 4
+        Core.PhiNode(Any[5, 6], Any[0, Core.SSAValue(6)]),
+        Expr(:call, >, Core.SSAValue(7), 10),
+        Expr(:gotoifnot, Core.SSAValue(8), 3),
+        # block 5
+        Core.PhiNode(Any[2, 8], Any[0, Core.SSAValue(7)]),
+        Expr(:return, Core.SSAValue(10)),
+    ]
+    nstmts = length(src.code)
+    src.ssavaluetypes = nstmts
+    src.codelocs = fill(Int32(1), nstmts)
+    src.ssaflags = fill(Int32(0), nstmts)
+    ir = Core.Compiler.inflate_ir(src)
+    Core.Compiler.verify_ir(ir)
+    domtree = Core.Compiler.construct_domtree(ir.cfg)
+    ir = Core.Compiler.domsort_ssa!(ir, domtree)
+    Core.Compiler.verify_ir(ir)
+    @test isa(ir.stmts[3], Core.PhiNode) && length(ir.stmts[3].edges) == 1
+end


### PR DESCRIPTION
Since the edge list of a phi may be incomplete with respect to
predecessors, it is not safe to replace a one-value phi by its
value, unless we know that there is only one predecessor. Remove
the incorrect logic from domsort. We do also do the correct
transformation in compaction right afterwards these days.