### PR TITLE
Use recursion rather than iteration for error check in uncolon

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -106,12 +106,15 @@ reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = _reshape
         "must be divisible by the product of the new dimensions $dims")))
     pre = _before_colon(dims...)
     post = _after_colon(dims...)
-    any(d -> d isa Colon, post) && throw1(dims)
+    _any_colon(post...) && throw1(dims)
     sz, remainder = divrem(length(A), prod(pre)*prod(post))
     remainder == 0 || throw2(A, dims)
     (pre..., Int(sz), post...)
 end
-@inline _before_colon(dim::Any, tail...) =  (dim, _before_colon(tail...)...)
+@inline _any_colon() = false
+@inline _any_colon(dim::Colon, tail...) = true
+@inline _any_colon(dim::Any, tail...) = _any_colon(tail...)
+@inline _before_colon(dim::Any, tail...) = (dim, _before_colon(tail...)...)
 @inline _before_colon(dim::Colon, tail...) = ()
 @inline _after_colon(dim::Any, tail...) =  _after_colon(tail...)
 @inline _after_colon(dim::Colon, tail...) = tail


### PR DESCRIPTION
Inference has an easier time analyzing recursion (esp if structural
over tuples) than iteration, which is why the rest of this function
is using recursion. With sufficient inlining, LLVM does generally
get rid of the extra error check and branch, but by switching
to recursion, we make things easier on non-LLVM backends.