### PR TITLE
Preserve types when adding/subtracting Herm/Sym/UniformScaling

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -329,7 +329,8 @@ transpose(A::Hermitian{<:Real}) = A
 adjoint(A::Symmetric) = Adjoint(A)
 transpose(A::Hermitian) = Transpose(A)
 
-real(A::HermOrSym{<:Real}) = A
+real(A::Symmetric{<:Real}) = A
+real(A::Hermitian{<:Real}) = A
 real(A::Symmetric) = Symmetric(real(A.data), sym_uplo(A.uplo))
 real(A::Hermitian) = Hermitian(real(A.data), sym_uplo(A.uplo))
 imag(A::Symmetric) = Symmetric(imag(A.data), sym_uplo(A.uplo))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -329,6 +329,13 @@ transpose(A::Hermitian{<:Real}) = A
 adjoint(A::Symmetric) = Adjoint(A)
 transpose(A::Hermitian) = Transpose(A)
 
+real(A::Symmetric{<:Real}) = copy(A)
+real(A::Hermitian{<:Real}) = copy(A)
+real(A::Symmetric) = Symmetric(real(A.data), sym_uplo(A.uplo))
+real(A::Hermitian) = Hermitian(real(A.data), sym_uplo(A.uplo))
+imag(A::Symmetric) = Symmetric(imag(A.data), sym_uplo(A.uplo))
+imag(A::Hermitian) = Hermitian(imag(A.data), sym_uplo(A.uplo))
+
 Base.copy(A::Adjoint{<:Any,<:Hermitian}) = copy(A.parent)
 Base.copy(A::Transpose{<:Any,<:Symmetric}) = copy(A.parent)
 Base.copy(A::Adjoint{<:Any,<:Symmetric}) =
@@ -392,6 +399,14 @@ end
 
 (-)(A::Symmetric{Tv,S}) where {Tv,S} = Symmetric{Tv,S}(-A.data, A.uplo)
 (-)(A::Hermitian{Tv,S}) where {Tv,S} = Hermitian{Tv,S}(-A.data, A.uplo)
+
+## Addition/subtraction
+for f in (:+, :-)
+    @eval $f(A::Symmetric, B::Symmetric) = Symmetric($f(A.data, B), sym_uplo(A.uplo))
+    @eval $f(A::Hermitian, B::Hermitian) = Hermitian($f(A.data, B), sym_uplo(A.uplo))
+    @eval $f(A::Hermitian, B::Symmetric{<:Real}) = Hermitian($f(A.data, B), sym_uplo(A.uplo))
+    @eval $f(A::Symmetric{<:Real}, B::Hermitian) = Hermitian($f(A.data, B), sym_uplo(A.uplo))
+end
 
 ## Matvec
 mul!(y::StridedVector{T}, A::Symmetric{T,<:StridedMatrix}, x::StridedVector{T}) where {T<:BlasFloat} =

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -329,8 +329,7 @@ transpose(A::Hermitian{<:Real}) = A
 adjoint(A::Symmetric) = Adjoint(A)
 transpose(A::Hermitian) = Transpose(A)
 
-real(A::Symmetric{<:Real}) = copy(A)
-real(A::Hermitian{<:Real}) = copy(A)
+real(A::HermOrSym{<:Real}) = A
 real(A::Symmetric) = Symmetric(real(A.data), sym_uplo(A.uplo))
 real(A::Hermitian) = Hermitian(real(A.data), sym_uplo(A.uplo))
 imag(A::Symmetric) = Symmetric(imag(A.data), sym_uplo(A.uplo))

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -334,7 +334,6 @@ real(A::Hermitian{<:Real}) = A
 real(A::Symmetric) = Symmetric(real(A.data), sym_uplo(A.uplo))
 real(A::Hermitian) = Hermitian(real(A.data), sym_uplo(A.uplo))
 imag(A::Symmetric) = Symmetric(imag(A.data), sym_uplo(A.uplo))
-imag(A::Hermitian) = Hermitian(imag(A.data), sym_uplo(A.uplo))
 
 Base.copy(A::Adjoint{<:Any,<:Hermitian}) = copy(A.parent)
 Base.copy(A::Transpose{<:Any,<:Symmetric}) = copy(A.parent)

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -110,6 +110,30 @@ for (t1, t2) in ((:UnitUpperTriangular, :UpperTriangular),
     end
 end
 
+# Adding a complex UniformScaling to the diagonal of a Hermitian
+# matrix breaks the hermiticity, if the UniformScaling is non-real.
+# However, to preserve type stability, we do not special-case a
+# UniformScaling{<:Complex} that happens to be real.
+function (+)(A::Hermitian, J::UniformScaling{<:Complex})
+    checksquare(A)
+    A_ = copytri!(copy(parent(A)), A.uplo)
+    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, A_)
+    @inbounds for i in axes(A, 1)
+        B[i,i] += J
+    end
+    return B
+end
+
+function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
+    checksquare(A)
+    A_ = copytri!(copy(parent(A)), A.uplo)
+    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, -A_)
+    @inbounds for i in axes(A, 1)
+        B[i,i] += J
+    end
+    return B
+end
+
 function (+)(A::AbstractMatrix, J::UniformScaling)
     checksquare(A)
     B = copy_oftype(A, Base._return_type(+, Tuple{eltype(A), typeof(J)}))

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -118,7 +118,7 @@ function (+)(A::Hermitian{T,S}, J::UniformScaling{<:Complex}) where {T,S}
     A_ = copytri!(copy(parent(A)), A.uplo)
     B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, A_)
     @inbounds for i in diagind(B)
-        B[i] += J.λ
+        B[i] += J
     end
     return B
 end
@@ -130,7 +130,7 @@ function (-)(J::UniformScaling{<:Complex}, A::Hermitian{T,S}) where {T,S}
         B[i] = -B[i]
     end
     @inbounds for i in diagind(B)
-        B[i] += J.λ
+        B[i] += J
     end
     return B
 end

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -114,22 +114,23 @@ end
 # matrix breaks the hermiticity, if the UniformScaling is non-real.
 # However, to preserve type stability, we do not special-case a
 # UniformScaling{<:Complex} that happens to be real.
-function (+)(A::Hermitian, J::UniformScaling{<:Complex})
-    checksquare(A)
+function (+)(A::Hermitian{T,S}, J::UniformScaling{<:Complex}) where {T,S}
     A_ = copytri!(copy(parent(A)), A.uplo)
     B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, A_)
-    @inbounds for i in axes(A, 1)
-        B[i,i] += J
+    @inbounds for i in diagind(B)
+        B[i] += J.λ
     end
     return B
 end
 
-function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
-    checksquare(A)
+function (-)(J::UniformScaling{<:Complex}, A::Hermitian{T,S}) where {T,S}
     A_ = copytri!(copy(parent(A)), A.uplo)
-    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, -A_)
-    @inbounds for i in axes(A, 1)
-        B[i,i] += J
+    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, A_)
+    @inbounds for i in eachindex(B)
+        B[i] = -B[i]
+    end
+    @inbounds for i in diagind(B)
+        B[i] += J.λ
     end
     return B
 end

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -90,6 +90,17 @@ end
                 @test (-Hermitian(aherm))::typeof(Hermitian(aherm)) == -aherm
             end
 
+            @testset "Addition and subtraction for Symmetric/Hermitian matrices" begin
+                for f in (+, -)
+                    @test (f(Symmetric(asym), Symmetric(aposs)))::typeof(Symmetric(asym)) == f(asym, aposs)
+                    @test (f(Hermitian(aherm), Hermitian(apos)))::typeof(Hermitian(aherm)) == f(aherm, apos)
+                    @test (f(Symmetric(real(asym)), Hermitian(aherm)))::typeof(Hermitian(aherm)) == f(real(asym), aherm)
+                    @test (f(Hermitian(aherm), Symmetric(real(asym))))::typeof(Hermitian(aherm)) == f(aherm, real(asym))
+                    @test (f(Symmetric(asym), Hermitian(aherm))) == f(asym, aherm)
+                    @test (f(Hermitian(aherm), Symmetric(asym))) == f(aherm, asym)
+                end
+            end
+
             @testset "getindex and unsafe_getindex" begin
                 @test aherm[1,1] == Hermitian(aherm)[1,1]
                 @test asym[1,1] == Symmetric(asym)[1,1]
@@ -415,9 +426,6 @@ end
 
         @test T([true false; false true]) .+ true == T([2 1; 1 2])
     end
-
-    @test_throws ArgumentError Hermitian(X) + 2im*I
-    @test_throws ArgumentError Hermitian(X) - 2im*I
 end
 
 @testset "Issue #21981" begin

--- a/stdlib/LinearAlgebra/test/symmetric.jl
+++ b/stdlib/LinearAlgebra/test/symmetric.jl
@@ -164,6 +164,21 @@ end
                     @test transpose(H) ==  Hermitian(copy(transpose(aherm)))
                 end
             end
+
+            @testset "real, imag" begin
+                S = Symmetric(asym)
+                H = Hermitian(aherm)
+                @test issymmetric(real(S))
+                @test ishermitian(real(H))
+                if eltya <: Real
+                    @test real(S) === S == asym
+                    @test real(H) === H == aherm
+                elseif eltya <: Complex
+                    @test issymmetric(imag(S))
+                    @test !ishermitian(imag(H))
+                end
+            end
+
         end
 
         @testset "linalg unary ops" begin

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -173,6 +173,16 @@ let
                 @test @inferred(J - T) == J - Array(T)
                 @test @inferred(T\I) == inv(T)
 
+                if isa(A, Array)
+                    T = Hermitian(randn(3,3))
+                else
+                    T = Hermitian(view(randn(3,3), 1:3, 1:3))
+                end
+                @test @inferred(T + J) == Array(T) + J
+                @test @inferred(J + T) == J + Array(T)
+                @test @inferred(T - J) == Array(T) - J
+                @test @inferred(J - T) == J - Array(T)
+
                 @test @inferred(I\A) == A
                 @test @inferred(A\I) == inv(A)
                 @test @inferred(λ\I) === UniformScaling(1/λ)


### PR DESCRIPTION
This PR implements some basic type–preserving methods to `+`, `-`, `real` and `imag` for `Hermitian` and `Symmetric` matrices, which are true by definition, and I believe were probably just left out due to oversight.  In addition to making `Hermitian`/`Symmetric` matrices form a group under addition (geeky yay) it is also slightly faster (more yay!).  The original reason for this PR, however, was due to some head–scratching over why I couldn't add a complex `UniformScaling` to a `Hermitian` matrix, which I believe should be pretty generically implemented here (using the `AbstractArray` constructor).  I actually found that there was a test to check that it *didn't* work (added in this PR: https://github.com/JuliaLang/julia/pull/19228), but couldn't find a good argument why adding a complex `UniformScaling` to a `Hermitian` should throw, except that, well ... it did.  So I also removed those two tests.

This should probably be two PRs, functionality wise, but hopefully the changes aren't too plentiful to review.