### PR TITLE
Revert "Use recursion rather than iteration for error check in uncolon"

### DIFF
--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -106,15 +106,12 @@ reshape(parent::AbstractArray, dims::Tuple{Vararg{Union{Int,Colon}}}) = _reshape
         "must be divisible by the product of the new dimensions $dims")))
     pre = _before_colon(dims...)
     post = _after_colon(dims...)
-    _any_colon(post...) && throw1(dims)
+    any(d -> d isa Colon, post) && throw1(dims)
     sz, remainder = divrem(length(A), prod(pre)*prod(post))
     remainder == 0 || throw2(A, dims)
     (pre..., Int(sz), post...)
 end
-@inline _any_colon() = false
-@inline _any_colon(dim::Colon, tail...) = true
-@inline _any_colon(dim::Any, tail...) = _any_colon(tail...)
-@inline _before_colon(dim::Any, tail...) = (dim, _before_colon(tail...)...)
+@inline _before_colon(dim::Any, tail...) =  (dim, _before_colon(tail...)...)
 @inline _before_colon(dim::Colon, tail...) = ()
 @inline _after_colon(dim::Any, tail...) =  _after_colon(tail...)
 @inline _after_colon(dim::Colon, tail...) = tail


### PR DESCRIPTION
This reverts commit 6eb4921f1b43d096f80c3bdf175b28fd446c859f.

@vtjnash doesn't like it. I'll see if I can work out the underlying issue. If I can do so
relatively quickly, I'll probably just push that here as well.