### PR TITLE
Improve aliasing detection of wrappers of SubArrays

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -707,7 +707,7 @@ end
 
 # In the common case where we have two views into the same parent, aliasing checks
 # are _much_ easier and more important to get right
-function mightalias(A::SubArray{T,<:Any,P}, B::SubArray{T,<:Any,P}) where {T,P}
+function _mightalias(A::SubArray{T,<:Any,P}, B::SubArray{T,<:Any,P}) where {T,P}
     if !_parentsmatch(A.parent, B.parent)
         # We cannot do any better than the usual dataids check
         return !_isdisjoint(dataids(A), dataids(B))

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -68,6 +68,7 @@ IndexStyle(a::ReinterpretArray) = IndexStyle(a.parent)
 
 parent(a::ReinterpretArray) = a.parent
 dataids(a::ReinterpretArray) = dataids(a.parent)
+mightalias(A::ReinterpretArray, B::ReinterpretArray) = mightalias(parent(A), parent(B))
 
 function size(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     psize = size(a.parent)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -68,7 +68,7 @@ IndexStyle(a::ReinterpretArray) = IndexStyle(a.parent)
 
 parent(a::ReinterpretArray) = a.parent
 dataids(a::ReinterpretArray) = dataids(a.parent)
-aliasingroots(a::ReinterpretArray) = (a.parent,)
+aliasingroots(a::ReinterpretArray) = aliasingroots(a.parent)
 
 function size(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     psize = size(a.parent)

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -68,7 +68,7 @@ IndexStyle(a::ReinterpretArray) = IndexStyle(a.parent)
 
 parent(a::ReinterpretArray) = a.parent
 dataids(a::ReinterpretArray) = dataids(a.parent)
-mightalias(A::ReinterpretArray, B::ReinterpretArray) = mightalias(parent(A), parent(B))
+aliasingroots(a::ReinterpretArray) = (a.parent,)
 
 function size(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     psize = size(a.parent)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -196,6 +196,7 @@ elsize(::Type{<:ReshapedArray{<:Any,<:Any,P}}) where {P} = elsize(P)
 
 unaliascopy(A::ReshapedArray) = typeof(A)(unaliascopy(A.parent), A.dims, A.mi)
 dataids(A::ReshapedArray) = dataids(A.parent)
+aliasingroots(a::ReshapedArray) = aliasingroots(a.parent)
 
 @inline ind2sub_rs(ax, ::Tuple{}, i::Int) = (i,)
 @inline ind2sub_rs(ax, strds, i) = _ind2sub_rs(ax, strds, i - 1)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -92,6 +92,8 @@ julia> parentindices(V)
 parentindices(a::AbstractArray) = map(OneTo, size(a))
 
 ## Aliasing detection
+# Note: Not defining `aliasingroots(::SubArray)` since `SubArray` needs to act
+# as a root for the custom `mightalias` check to work.
 dataids(A::SubArray) = (dataids(A.parent)..., _splatmap(dataids, A.indices)...)
 _splatmap(f, ::Tuple{}) = ()
 _splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -160,3 +160,14 @@ let a = [0.1 0.2; 0.3 0.4], at = reshape([(i,i+1) for i = 1:2:8], 2, 2)
     r = reinterpret(Int, vt)
     @test r == OffsetArray(reshape(1:8, 2, 2, 2), (0, offsetvt...))
 end
+
+@testset "broadcast" begin
+    # https://github.com/JuliaLang/julia/issues/29545
+    buffer = zeros(UInt8, 4 * sizeof(Int))
+    mid = length(buffer) ÷ 2
+    x1 = reinterpret(Int, @view buffer[1:mid])
+    x2 = reinterpret(Int, @view buffer[mid+1:end])
+    @test !Base.mightalias(x1, x2)
+    x1 .= x2
+    @test x1 == x2
+end


### PR DESCRIPTION
It fixes #29545, i.e., it makes the following snippet work

```julia
buffer = zeros(UInt8, 4 * sizeof(Int))
mid = length(buffer) ÷ 2
x1 = reinterpret(Int, @view buffer[1:mid])
x2 = reinterpret(Int, @view buffer[mid+1:end])
x1 .= x2
```

However, this PR still has some problems.  For example, it does not support `mightalias(::ReinterpretArray, ::SubArray)`.  But defining `mightalias(::ReinterpretArray, ::AbstractArray)` and `mightalias(::AbstractArray, ::ReinterpretArray)` would cause the ambiguity problem (and not DRY).

A general question is: How one can ensure that `mightalias` is symmetric (i.e., `mightalias(a, b) == mightalias(b, a)`) and easily overloadable?  One possibility is to define a function (say)

```julia
symmetric_mightalias(a, b) = mightalias(a, b) && mightalias(b, a)
```

and document that the first argument of `mightalias` has to specify the type user defined (to reduce ambiguity).

Note that `symmetric_mightalias` has to be exposed as a public (non-overloadable) API so that it can be called from user's `mightalias`:

```julia
mightalias(a::ReinterpretArray, b::AbstractArray) = symmetric_mightalias(parent(a), b)
```

Is it a sane approach?  I'm pretty sure this is a generic problem solved in Julia community ages ago.
