### PR TITLE
flatten empty tuple - fix #29112

### DIFF
--- a/base/generator.jl
+++ b/base/generator.jl
@@ -126,4 +126,3 @@ IteratorEltype(::Type) = HasEltype()  # HasEltype is the default
 IteratorEltype(::Type{Generator{I,T}}) where {I,T} = EltypeUnknown()
 
 IteratorEltype(::Type{Any}) = EltypeUnknown()
-IteratorEltype(::Type{Union{}}) = EltypeUnknown()

--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -873,18 +873,20 @@ julia> collect(Iterators.flatten((1:2, 8:9)))
 flatten(itr) = Flatten(itr)
 
 eltype(::Type{Flatten{I}}) where {I} = eltype(eltype(I))
+eltype(::Type{Flatten{Tuple{}}}) = eltype(Tuple{})
 IteratorEltype(::Type{Flatten{I}}) where {I} = _flatteneltype(I, IteratorEltype(I))
+IteratorEltype(::Type{Flatten{Tuple{}}}) = IteratorEltype(Tuple{})
 _flatteneltype(I, ::HasEltype) = IteratorEltype(eltype(I))
 _flatteneltype(I, et) = EltypeUnknown()
 
 flatten_iteratorsize(::Union{HasShape, HasLength}, ::Type{<:NTuple{N,Any}}) where {N} = HasLength()
 flatten_iteratorsize(::Union{HasShape, HasLength}, ::Type{<:Tuple}) = SizeUnknown()
 flatten_iteratorsize(::Union{HasShape, HasLength}, ::Type{<:Number}) = HasLength()
-flatten_iteratorsize(::Union{HasShape, HasLength}, ::Type{Union{}}) = SizeUnknown()
 flatten_iteratorsize(a, b) = SizeUnknown()
 
 _flatten_iteratorsize(sz, ::EltypeUnknown, I) = SizeUnknown()
 _flatten_iteratorsize(sz, ::HasEltype, I) = flatten_iteratorsize(sz, eltype(I))
+_flatten_iteratorsize(sz, ::HasEltype, ::Type{Tuple{}}) = HasLength()
 
 IteratorSize(::Type{Flatten{I}}) where {I} = _flatten_iteratorsize(IteratorSize(I), IteratorEltype(I), I)
 
@@ -895,6 +897,7 @@ flatten_length(f, ::Type{<:Number}) = length(f.it)
 flatten_length(f, T) = throw(ArgumentError(
     "Iterates of the argument to Flatten are not known to have constant length"))
 length(f::Flatten{I}) where {I} = flatten_length(f, eltype(I))
+length(f::Flatten{Tuple{}}) = 0
 
 @propagate_inbounds function iterate(f::Flatten, state=())
     if state !== ()

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -370,6 +370,8 @@ end
 @test_throws ArgumentError length(flatten([[1], [1]]))
 
 @test Base.IteratorEltype(Base.Flatten((i for i=1:2) for j=1:1)) == Base.EltypeUnknown()
+# see #29112, #29464, #29548
+@test Base.return_types(Base.IteratorEltype, Tuple{Array}) == [Base.HasEltype]
 
 # partition(c, n)
 let v = collect(partition([1,2,3,4,5], 1))


### PR DESCRIPTION
As PR https://github.com/JuliaLang/julia/pull/29112 caused a performance regression, this is an attempt to solve the original issue without referring to the element type of `Tuple{}`.
The changes of 29112 are reverted, except the added test case.