### PR TITLE
improve performance for materializing a string from a vector of Char

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -576,6 +576,19 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
     String(take!(buf))
 end
 
+function String(a::Vector{Char})
+    n = 0
+    for v in a
+        n += ncodeunits(v)
+    end
+    out = _string_n(n)
+    offs = 1
+    for v in a
+        offs += __string!(out, v, offs)
+    end
+    return out
+end
+
 function String(chars::AbstractVector{<:AbstractChar})
     sprint(sizehint=length(chars)) do io
         for c in chars

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -576,7 +576,7 @@ function unindent(str::AbstractString, indent::Int; tabwidth=8)
     String(take!(buf))
 end
 
-function String(a::Vector{Char})
+function String(a::AbstractVector{Char})
     n = 0
     for v in a
         n += ncodeunits(v)
@@ -584,7 +584,7 @@ function String(a::Vector{Char})
     out = _string_n(n)
     offs = 1
     for v in a
-        offs += __string!(out, v, offs)
+        offs += __unsafe_string!(out, v, offs)
     end
     return out
 end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -145,7 +145,7 @@ end
 string(a::String)            = String(a)
 string(a::SubString{String}) = String(a)
 
-@inline function __string!(out, c::Char, offs::Integer)
+@inline function __unsafe_string!(out, c::Char, offs::Integer)
     x = bswap(reinterpret(UInt32, c))
     n = ncodeunits(c)
     unsafe_store!(pointer(out, offs), x % UInt8)
@@ -161,7 +161,7 @@ string(a::SubString{String}) = String(a)
     return n
 end
 
-@inline function __string!(out, s::Union{String, SubString{String}}, offs::Integer)
+@inline function __unsafe_string!(out, s::Union{String, SubString{String}}, offs::Integer)
     n = sizeof(s)
     unsafe_copyto!(pointer(out, offs), pointer(s), n)
     return n
@@ -179,7 +179,7 @@ function string(a::Union{Char, String, SubString{String}}...)
     out = _string_n(n)
     offs = 1
     for v in a
-        offs += __string!(out, v, offs)
+        offs += __unsafe_string!(out, v, offs)
     end
     return out
 end


### PR DESCRIPTION
Before

```jl
julia> a = rand(Char, 10^4);

julia> @btime String(a);
  363.761 μs (6 allocations: 49.20 KiB)
```

After

```jl
julia> a = rand(Char, 10^4);

julia> @btime String(a);
  51.856 μs (1 allocation: 38.56 KiB)
```

The unrolling of the loop to write the char made a significant difference here (but is not where the major performance benefit comes from).

cc @bkamins 
