### PR TITLE
propgate inbounds to substring and use it in split

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -35,11 +35,11 @@ struct SubString{T<:AbstractString} <: AbstractString
     end
 end
 
-SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
-SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s)) = SubString(s, Int(i), Int(j))
-SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, first(r), last(r))
+Base.@propagate_inbounds Base.SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
+Base.@propagate_inbounds SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s)) = SubString(s, Int(i), Int(j))
+Base.@propagate_inbounds SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, first(r), last(r))
 
-function SubString(s::SubString, i::Int, j::Int)
+Base.@propagate_inbounds function SubString(s::SubString, i::Int, j::Int)
     @boundscheck i ≤ j && checkbounds(s, i:j)
     SubString(s.string, s.offset+i, s.offset+j)
 end

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -35,11 +35,11 @@ struct SubString{T<:AbstractString} <: AbstractString
     end
 end
 
-Base.@propagate_inbounds Base.SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
-Base.@propagate_inbounds SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s)) = SubString(s, Int(i), Int(j))
-Base.@propagate_inbounds SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, first(r), last(r))
+@propagate_inbounds SubString(s::T, i::Int, j::Int) where {T<:AbstractString} = SubString{T}(s, i, j)
+@propagate_inbounds SubString(s::AbstractString, i::Integer, j::Integer=lastindex(s)) = SubString(s, Int(i), Int(j))
+@propagate_inbounds SubString(s::AbstractString, r::UnitRange{<:Integer}) = SubString(s, first(r), last(r))
 
-Base.@propagate_inbounds function SubString(s::SubString, i::Int, j::Int)
+@propagate_inbounds function SubString(s::SubString, i::Int, j::Int)
     @boundscheck i ≤ j && checkbounds(s, i:j)
     SubString(s.string, s.offset+i, s.offset+j)
 end

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -323,7 +323,7 @@ function _split(str::AbstractString, splitter, limit::Integer, keepempty::Bool, 
         while 0 < j <= n && length(strs) != limit-1
             if i < k
                 if keepempty || i < j
-                    push!(strs, SubString(str,i,prevind(str,j)))
+                    push!(strs, @inbounds SubString(str,i,prevind(str,j)))
                 end
                 i = k
             end
@@ -334,7 +334,7 @@ function _split(str::AbstractString, splitter, limit::Integer, keepempty::Bool, 
         end
     end
     if keepempty || i <= ncodeunits(str)
-        push!(strs, SubString(str,i))
+        push!(strs, @inbounds SubString(str,i))
     end
     return strs
 end


### PR DESCRIPTION
Using it in `split` is mostly a proof of concept that the propagation works,

Before

```
julia> @btime split("str,str,str,str,str,str,str", ",")
  745.398 ns (10 allocations: 432 bytes)
```

After

```
julia> @btime split("str,str,str,str,str,str,str", ",")
  662.151 ns (10 allocations: 432 bytes)
```

Ref https://github.com/JuliaLang/julia/issues/26818