### PR TITLE
Fixing abs for Rational{<:Unsigned}

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -226,6 +226,8 @@ signbit(x::Rational) = signbit(x.num)
 copysign(x::Rational, y::Real) = copysign(x.num,y) // x.den
 copysign(x::Rational, y::Rational) = copysign(x.num,y.num) // x.den
 
+abs(x::Rational{T}) where {T<:Unsigned} = x
+
 typemin(::Type{Rational{T}}) where {T<:Integer} = -one(T)//zero(T)
 typemax(::Type{Rational{T}}) where {T<:Integer} = one(T)//zero(T)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -226,7 +226,7 @@ signbit(x::Rational) = signbit(x.num)
 copysign(x::Rational, y::Real) = copysign(x.num,y) // x.den
 copysign(x::Rational, y::Rational) = copysign(x.num,y.num) // x.den
 
-abs(x::Rational{T}) where {T<:Unsigned} = x
+abs(x::Rational) = Rational(abs(x.num), x.den)
 
 typemin(::Type{Rational{T}}) where {T<:Integer} = -one(T)//zero(T)
 typemax(::Type{Rational{T}}) where {T<:Integer} = one(T)//zero(T)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -96,6 +96,10 @@ using Test
     @test !(1//3 < NaN)
     @test !(1//3 == NaN)
     @test !(1//3 > NaN)
+    
+    @test abs(one(Rational{UInt})) === one(Rational{UInt})
+    @test abs(one(Rational{Int})) === one(Rational{Int})
+    @test abs(-one(Rational{Int})) === one(Rational{Int})
 end
 
 @testset "Rational methods" begin

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -96,7 +96,7 @@ using Test
     @test !(1//3 < NaN)
     @test !(1//3 == NaN)
     @test !(1//3 > NaN)
-    
+
     @test abs(one(Rational{UInt})) === one(Rational{UInt})
     @test abs(one(Rational{Int})) === one(Rational{Int})
     @test abs(-one(Rational{Int})) === one(Rational{Int})

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -97,6 +97,7 @@ using Test
     @test !(1//3 == NaN)
     @test !(1//3 > NaN)
 
+    # PR 29561
     @test abs(one(Rational{UInt})) === one(Rational{UInt})
     @test abs(one(Rational{Int})) === one(Rational{Int})
     @test abs(-one(Rational{Int})) === one(Rational{Int})


### PR DESCRIPTION
I noticed that calling `abs` for values of type `Rational{<:Unsigned}` results in an `OverflowError` being raised. E.g., in Julia 1.0.1 I get
```
julia> abs(one(Rational{UInt}))
ERROR: OverflowError: cannot negate unsigned number
Stacktrace:
 [1] - at ./rational.jl:240 [inlined]
 [2] abs(::Rational{UInt64}) at ./number.jl:144
 [3] top-level scope at none:0
```
Since `abs(x::Real)` in `number.jl` uses `ifelse`, it tries to compute `-x` which is not possible for `x::Rational{<:Unsigned}`. A possible solution for this problem is specializing `abs` like
```
Base.abs(x::Rational{<:Unsigned}) = x
```
as done in this pull request.