### PR TITLE
POC/WIP: leverage LLVM function attributes for better CSE

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2940,6 +2940,9 @@ static jl_cgval_t emit_call_specfun_other(jl_codectx_t &ctx, jl_method_instance_
     jl_returninfo_t returninfo = get_specsig_function(jl_Module, specFunctionObject, li->specTypes, jlretty);
     FunctionType *cft = returninfo.decl->getFunctionType();
 
+    if (li->functionObjectsDecls.specFunctionAttrs)
+        returninfo.decl->addFnAttr(Attribute::ReadNone);
+
     size_t nfargs = cft->getNumParams();
     Value **argvals = (Value**)alloca(nfargs * sizeof(Value*));
     unsigned idx = 0;
@@ -6562,6 +6565,7 @@ static std::unique_ptr<Module> emit_function(
 
     if (optimize)
         jl_globalPM->run(*M);
+    declarations->specFunctionAttrs = f->hasFnAttribute(Attribute::ReadNone);
 
     if (JL_HOOK_TEST(ctx.params, emitted_function)) {
         JL_HOOK_CALL(ctx.params, emitted_function, 3, (jl_value_t*)ctx.linfo,

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -29,6 +29,8 @@
 #include <llvm/Transforms/Vectorize.h>
 #include <llvm/Transforms/Scalar/GVN.h>
 #include <llvm/Transforms/IPO/AlwaysInliner.h>
+#include <llvm/Transforms/IPO/FunctionAttrs.h>
+#include <llvm/Transforms/IPO/InferFunctionAttrs.h>
 
 namespace llvm {
     extern Pass *createLowerSimdLoopPass();
@@ -230,6 +232,8 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     // Clean up write barrier and ptls lowering
     PM->add(createCFGSimplificationPass());
     PM->add(createCombineMulAddPass());
+    // we just want the attrs
+    PM->add(createPostOrderFunctionAttrsLegacyPass());
 }
 
 extern "C" JL_DLLEXPORT

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -366,7 +366,6 @@ JuliaOJIT::JuliaOJIT(TargetMachine &TM)
         )
 {
     addTargetPasses(&PM, &TM);
-    addOptimizationPasses(&PM, jl_generating_output() ? 0 : jl_options.opt_level);
     if (TM.addPassesToEmitMC(PM, Ctx, ObjStream))
         llvm_unreachable("Target does not support MC emission.");
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -231,6 +231,7 @@ JL_EXTENSION typedef union {
 typedef struct _jl_llvm_functions_t {
     const char *functionObject;         // jl_callptr_t llvm Function name
     const char *specFunctionObject;     // specialized llvm Function name (on sig+rettype)
+    uint8_t specFunctionAttrs;          // readnone | readonly
 } jl_llvm_functions_t;
 
 // This type describes a single function body


### PR DESCRIPTION
This branch is a proof-of-concept showing how we can get LLVM to do better CSE by leveraging/inferring function attributes. This is entirely @maleadt's work, I just want to call attention to it before the branch goes stale w.r.t. master 😛

I think Tim might be a bit busy right now, but I would be willing to devote some cycles to polishing this in November, if folks agree it's a good idea.

With this PR:

```julia
julia> function f(x)
         _1 = exp(x)
         _2 = exp(x)
         return _1 + _2
       end
f (generic function with 1 method)

julia> @code_llvm f(1.)

; Function f
; Location: REPL[1]:2
; Function Attrs: readnone
define double @julia_f_1527076232(double) #0 {
top:
  %1 = call double @julia_exp_1527076233(double %0) #0
; Location: REPL[1]:4
; Function +; {
; Location: float.jl:395
  %2 = fadd double %1, %1
;}
  ret double %2
}
```