### PR TITLE
changed UndefVarError string to reference scoping rules

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -145,7 +145,7 @@ function showerror(io::IO, ex::UndefVarError)
         Then do `using LegacyStrings` to get `$(ex.var)`.
         """))
     end
-    print(io, "UndefVarError: $(ex.var) not defined")
+    print(io, "UndefVarError: $(ex.var) not defined (consider https://docs.julialang.org/en/v1/manual/variables-and-scoping/)")
 end
 
 function showerror(io::IO, ex::InexactError)


### PR DESCRIPTION
There were a lot of discussions about scoping rules of top-level loops confusing new users. One of the simplest improvements, especially for backporting into 1.0.2, is to have a more verbose error string. Here, I made up a more informative one that will surely need discussion or triage and probably need modification as well.

If the errror-string gets changed, then a lot of tests and docs will need to change as well, in order to reflect the new REPL output. Since this is in many places, I'd prefer to grep and modify only once, and hence deferred the actual work for this trivial change. Meaning: Tests will fail and this PR is intentionally incomplete.

Now:
```
julia> x
ERROR: UndefVarError: x not defined (consider https://docs.julialang.org/en/v1/manual/variables-and-scoping/)
```

Relevant issue: [https://github.com/JuliaLang/julia/issues/28789](https://github.com/JuliaLang/julia/issues/28789) and [https://discourse.julialang.org/t/another-possible-solution-to-the-global-scope-debacle/15894](https://discourse.julialang.org/t/another-possible-solution-to-the-global-scope-debacle/15894)
