### PR TITLE
Use Int8(1) instead of true in I

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -46,7 +46,7 @@ julia> [1 2im 3; 1im 2 3] * I
  0+1im  2+0im  3+0im
 ```
 """
-const I = UniformScaling(true)
+const I = UniformScaling(Int8(1))
 
 eltype(::Type{UniformScaling{T}}) where {T} = T
 ndims(J::UniformScaling) = 2

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -60,7 +60,7 @@ end
 end
 
 @testset "det and logdet" begin
-    @test det(I) === true
+    @test det(I) === Int8(1)
     @test det(1.0I) === 1.0
     @test det(0I) === 0
     @test det(0.0I) === 0.0
@@ -79,7 +79,7 @@ let
         @test ndims(J) == 2
         @test transpose(J) == J
         @test J * [1 0; 0 1] == conj(*(adjoint(J), [1 0; 0 1])) # ctranpose (and A(c)_mul_B)
-        @test I + I === UniformScaling(2) # +
+        @test I + I === UniformScaling(Int8(2)) # +
         @test inv(I) == I
         @test inv(J) == UniformScaling(inv(λ))
         @test cond(I) == 1
@@ -103,7 +103,7 @@ let
                 I22 = Matrix(I, size(A))
                 @test @inferred(A + I) == A + I22
                 @test @inferred(I + A) == A + I22
-                @test @inferred(I - I) === UniformScaling(0)
+                @test @inferred(I - I) === UniformScaling(Int8(0))
                 @test @inferred(B - I) == B - I22
                 @test @inferred(I - B) == I22 - B
                 @test @inferred(A - I) == A - I22

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -583,7 +583,7 @@ end
 
 @testset "findall" begin
     # issue described in https://groups.google.com/d/msg/julia-users/Yq4dh8NOWBQ/GU57L90FZ3EJ
-    A = sparse(I, 5, 5)
+    A = sparse(Diagonal(trues(5)))
     @test findall(A) == findall(x -> x == true, A) == findall(Array(A))
     # Non-stored entries are true
     @test findall(x -> x == false, A) == findall(x -> x == false, Array(A))


### PR DESCRIPTION
This is a slightly modified version of https://github.com/JuliaLang/julia/pull/24396 to make `I` use `Int8` instead of `Bool`. For almost all real use cases, I would expect the behavior to be unaffected by this change since `Int8` and `Bool` have the same promotion behavior in almost all the relevant cases. In particular, they have the same promotion behavior in the cases mentioned in #24396.

The main motivation for this change is that
```julia
julia> Matrix(I, 3, 3)
3×3 Array{Bool,2}:
  true  false  false
 false   true  false
 false  false   true
```
is not really what you'd expect from an identity matrix. With this change, it would instead be
```julia
julia> Matrix(I, 3, 3)
3×3 Array{Int8,2}:
 1  0  0
 0  1  0
 0  0  1
```
I'd be interested in a PkgEval run of this since I wouldn't expect any user code to break from this change.