### PR TITLE
[RFC] constructors for similar structured matrices with different containers

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -21,6 +21,7 @@ function Bidiagonal{T}(dv::AbstractVector, ev::AbstractVector, uplo::Union{Symbo
                convert(AbstractVector{T}, ev)::AbstractVector{T},
                uplo)
 end
+Bidiagonal{T, V}(A::Bidiagonal) where {T, V<:AbstractVector{T}} = Bidiagonal(convert(V, A.dv), convert(V, A.ev), A.uplo)
 
 """
     Bidiagonal(dv::V, ev::V, uplo::Symbol) where V <: AbstractVector

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -12,7 +12,7 @@ struct Diagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
 end
 Diagonal(v::AbstractVector{T}) where {T} = Diagonal{T,typeof(v)}(v)
 Diagonal{T}(v::AbstractVector) where {T} = Diagonal(convert(AbstractVector{T}, v)::AbstractVector{T})
-
+Diagonal{T, V}(A::Diagonal) where {T, V<:AbstractVector{T}} = Diagonal(convert(V, A.diag))
 """
     Diagonal(A::AbstractMatrix)
 

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -419,6 +419,12 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     # constructor used in lu!
     function Tridiagonal{T,V}(dl, d, du, du2) where {T,V<:AbstractVector{T}}
         @assert !has_offset_axes(dl, d, du, du2)
+        n = length(d)
+        if (length(dl) != n-1 || length(du) != n-1 || length(du2) != n-2)
+            throw(ArgumentError(string("cannot construct Tridiagonal from incompatible ",
+            "lengths of subdiagonal, diagonal and superdiagonal: ",
+            "($(length(dl)), $(length(d)), $(length(du)), $(length(du2)))")))
+        end
         # length checks?
         new{T,V}(dl, d, du, du2)
     end
@@ -488,7 +494,7 @@ Tridiagonal(A::AbstractMatrix) = Tridiagonal(diag(A,-1), diag(A,0), diag(A,1))
 Tridiagonal(A::Tridiagonal) = A
 Tridiagonal{T}(A::SymTridiagonal) where T = Tridiagonal{T}(A.ev, A.dv, A.ev)
 function Tridiagonal{T}(A::Tridiagonal) where {T}
-    if isdefined(A, :du2)
+    if isdefined(A, :du2) && (length(A.du2) == length(A.d)-2)
         Tridiagonal{T}(A.dl, A.d, A.du, A.du2)
     else
         Tridiagonal{T}(A.dl, A.d, A.du)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -423,6 +423,8 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
         new{T,V}(dl, d, du, du2)
     end
 end
+Tridiagonal{T, V}(A::Tridiagonal) where {T, V<:AbstractVector{T}} = Tridiagonal(map(x->convert(V, x), (A.dl, A.d, A.du))...)
+Tridiagonal{T, V}(A::SymTridiagonal) where {T, V<:AbstractVector{T}} = Tridiagonal(map(x->convert(V, x), (A.ev, A.dv, A.ev))...)
 
 """
     Tridiagonal(dl::V, d::V, du::V) where V <: AbstractVector
@@ -454,6 +456,9 @@ Tridiagonal(dl::V, d::V, du::V, du2::V) where {T,V<:AbstractVector{T}} = Tridiag
 function Tridiagonal{T}(dl::AbstractVector, d::AbstractVector, du::AbstractVector) where {T}
     Tridiagonal(map(x->convert(AbstractVector{T}, x), (dl, d, du))...)
 end
+function Tridiagonal{T}(dl::AbstractVector, d::AbstractVector, du::AbstractVector, du2::AbstractVector) where {T}
+    Tridiagonal(map(x->convert(AbstractVector{T}, x), (dl, d, du, du2))...)
+end
 
 """
     Tridiagonal(A)
@@ -481,14 +486,12 @@ julia> Tridiagonal(A)
 Tridiagonal(A::AbstractMatrix) = Tridiagonal(diag(A,-1), diag(A,0), diag(A,1))
 
 Tridiagonal(A::Tridiagonal) = A
-Tridiagonal{T}(A::Tridiagonal{T}) where {T} = A
+Tridiagonal{T}(A::SymTridiagonal) where T = Tridiagonal{T}(A.ev, A.dv, A.ev)
 function Tridiagonal{T}(A::Tridiagonal) where {T}
-    dl, d, du = map(x->convert(AbstractVector{T}, x)::AbstractVector{T},
-                    (A.dl, A.d, A.du))
     if isdefined(A, :du2)
-        Tridiagonal(dl, d, du, convert(AbstractVector{T}, A.du2)::AbstractVector{T})
+        Tridiagonal{T}(A.dl, A.d, A.du, A.du2)
     else
-        Tridiagonal(dl, d, du)
+        Tridiagonal{T}(A.dl, A.d, A.du)
     end
 end
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -298,6 +298,14 @@ end
 # test construct from range
 @test Bidiagonal(1:3, 1:2, :U) == [1 1 0; 0 2 2; 0 0 3]
 
+# Issue 29054
+@testset "conversion and ranges" begin
+    Brange = Bidiagonal(1:3, 1:2, :U)
+    @test isa(Bidiagonal{Float64, Vector{Float64}}(Brange), Bidiagonal{Float64, Vector{Float64}})
+    @test isa(convert(Bidiagonal{ComplexF64, Vector{ComplexF64}}, Brange), Bidiagonal{ComplexF64, Vector{ComplexF64}})
+    @test typeof(Bidiagonal{Float64}(Brange)) <: Bidiagonal{Float64}
+end
+
 @testset "promote_rule" begin
     A = Bidiagonal(fill(1f0,10),fill(1f0,9),:U)
     B = rand(Float64,10,10)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -19,6 +19,7 @@ Random.seed!(1)
     end
     D = Diagonal(dd)
     DM = Matrix(Diagonal(dd))
+    Drange = Diagonal(1:3)
 
     @testset "constructor" begin
         for x in (dd, GenericArray(dd))
@@ -34,12 +35,15 @@ Random.seed!(1)
         @test isa(Diagonal{elty}(DI), Diagonal{elty})
         # issue #26178
         @test_throws MethodError convert(Diagonal, [1, 2, 3, 4])
+        @test isa(Diagonal{Float64, Vector{Float64}}(Drange), Diagonal{Float64, Vector{Float64}})
     end
 
     @testset "Basic properties" begin
         @test_throws ArgumentError size(D,0)
         @test typeof(convert(Diagonal{ComplexF32},D)) <: Diagonal{ComplexF32}
         @test typeof(convert(AbstractMatrix{ComplexF32},D)) <: Diagonal{ComplexF32}
+        @test typeof(convert(Diagonal{ComplexF64},Drange)) <: Diagonal{ComplexF64}
+        @test typeof(convert(Diagonal{ComplexF64, Vector{ComplexF64}},Drange)) <: Diagonal{ComplexF64, Vector{ComplexF64}}
 
         @test Array(real(D)) == real(DM)
         @test Array(abs.(D)) == abs.(DM)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -113,8 +113,8 @@ end
         @test isa(convert(Tridiagonal{Int64, Vector{Int64}}, Trange), Tridiagonal{Int64, Vector{Int64}})
         @test isa(convert(Tridiagonal{Float64, Vector{Float64}}, Srange), Tridiagonal{Float64, Vector{Float64}})
         @test Tridiagonal{Float64, Vector{Float64}}(Srange) == Srange
-        #@test typeof(Tridiagonal{ComplexF64}(Trange)) <: Tridiagonal{ComplexF64}
-        #@test typeof(Tridiagonal{ComplexF64}(Srange)) <: Tridiagonal{ComplexF64}
+        @test typeof(Tridiagonal{ComplexF64}(Trange)) <: Tridiagonal{ComplexF64}
+        @test typeof(Tridiagonal{ComplexF64}(Srange)) <: Tridiagonal{ComplexF64}
     end
     @testset "tril/triu" begin
         zerosd = fill!(similar(d), 0)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -98,6 +98,8 @@ end
         @test isa(TTI2y, Tridiagonal{elty})
         @test TTI2y.du2 == convert(Vector{elty}, [1,2])
     end
+
+    # Added tests here for Issue #29054
     @testset "interconversion of Tridiagonal and SymTridiagonal" begin
         @test Tridiagonal(dl, d, dl) == SymTridiagonal(d, dl)
         @test SymTridiagonal(d, dl) == Tridiagonal(dl, d, dl)
@@ -105,6 +107,14 @@ end
         @test SymTridiagonal(d, dl) + Tridiagonal(dl, d, du) == Tridiagonal(dl + dl, d+d, dl+du)
         @test convert(SymTridiagonal,Tridiagonal(SymTridiagonal(d, dl))) == SymTridiagonal(d, dl)
         @test Array(convert(SymTridiagonal{ComplexF32},Tridiagonal(SymTridiagonal(d, dl)))) == convert(Matrix{ComplexF32}, SymTridiagonal(d, dl))
+
+        Trange = Tridiagonal(1:2, 1:3, 1:2)
+        Srange = SymTridiagonal(1:3, 1:2)
+        @test isa(convert(Tridiagonal{Int64, Vector{Int64}}, Trange), Tridiagonal{Int64, Vector{Int64}})
+        @test isa(convert(Tridiagonal{Float64, Vector{Float64}}, Srange), Tridiagonal{Float64, Vector{Float64}})
+        @test Tridiagonal{Float64, Vector{Float64}}(Srange) == Srange
+        #@test typeof(Tridiagonal{ComplexF64}(Trange)) <: Tridiagonal{ComplexF64}
+        #@test typeof(Tridiagonal{ComplexF64}(Srange)) <: Tridiagonal{ComplexF64}
     end
     @testset "tril/triu" begin
         zerosd = fill!(similar(d), 0)


### PR DESCRIPTION
Adding constructors to convert between similar structured matrices with different container types. This fixes  JuliaLang/LinearAlgebra.jl#564 
```
julia> convert(Diagonal{Int,Vector{Int}}, Diagonal(1:4))
4×4 Diagonal{Int64,Array{Int64,1}}:
 1  ⋅  ⋅  ⋅
 ⋅  2  ⋅  ⋅
 ⋅  ⋅  3  ⋅
 ⋅  ⋅  ⋅  4
```

This also adds similar support for `Bidiagonal`, `Tridiagonal`, and `SymTridiagonal`. 
There is an error in it when using ranges for `Tridiagonal` only where `du2` is never given but is undefined after initialization. This causes an `OutOfMemoryError` when it is converted.

```
julia> Trange = Tridiagonal(1:2, 1:3, 1:2)
3×3 Tridiagonal{Int64,UnitRange{Int64}}:
 1  1  ⋅
 1  2  2
 ⋅  2  3

julia> Trange.du2
0:140275788100048

julia> Tnorm = Tridiagonal(rand(2), rand(3), rand(2))
3×3 Tridiagonal{Float64,Array{Float64,1}}:
 0.574761  0.765595   ⋅       
 0.125415  0.804884  0.395248 
  ⋅        0.115691  0.0521253

julia> Tnorm.du2
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getproperty(::Any, ::Symbol) at ./sysimg.jl:18
```

I cannot pin down the cause of this but it seems like just uninitialized ranges. For example
```
julia> Vector{UnitRange{Int64}}(undef, 2)
2-element Array{UnitRange{Int64},1}:
 140275945593040:140275798608064
 140275798608128:0
```

Comments are appreciated.