### PR TITLE
Add Base.fieldtypes.

### DIFF
--- a/base/exports.jl
+++ b/base/exports.jl
@@ -694,6 +694,7 @@ export
     fieldname,
     fieldnames,
     fieldcount,
+    fieldtypes,
     propertynames,
     isabstracttype,
     isbitstype,

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -623,6 +623,24 @@ function fieldcount(@nospecialize t)
     return length(t.types)
 end
 
+"""
+    fieldtypes(T::Type)
+
+The declared types of all fields in a composite DataType `T` as a tuple.
+
+# Examples
+```jldoctest
+julia> struct Foo
+           x::Int64
+           y::String
+       end
+
+julia> fieldtypes(Foo)
+(Int64, String)
+```
+"""
+fieldtypes(T::Type) = ntuple(i -> fieldtype(T, i), fieldcount(T))
+
 # return all instances, for types that can be enumerated
 
 """

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -167,6 +167,7 @@ Base.isconcretetype
 Base.isbits
 Base.isbitstype
 Core.fieldtype
+Base.fieldtypes
 Base.fieldcount
 Base.fieldoffset
 Base.datatype_alignment

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -262,6 +262,10 @@ tlayout = TLayout(5,7,11)
 @test fieldtype((NamedTuple{(:a,:b),T} where T<:Tuple{Vararg{Integer}}), 2) === Integer
 @test_throws BoundsError fieldtype(NamedTuple{(:a,:b)}, 3)
 
+@test fieldtypes(NamedTuple{(:a,:b)}) == (Any, Any)
+@test fieldtypes((NamedTuple{T,Tuple{Int,String}} where T)) === (Int, String)
+@test fieldtypes(TLayout) === (Int8, Int16, Int32)
+
 import Base: datatype_alignment, return_types
 @test datatype_alignment(UInt16) == 2
 @test datatype_alignment(TLayout) == 4


### PR DESCRIPTION
Add `Base.fieldtypes`. Cf `fieldnames` vs `fieldname`.

Fixes #24312, but is more general. See discussion there.