### PR TITLE
Fix jldoctest example in mapreduce(...)

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -293,7 +293,7 @@ julia> mapreduce(isodd, *, a, dims=1)
 1×4 Array{Bool,2}:
  false  false  false  false
 
-julia> mapreduce(isodd, |, true, a, dims=1)
+julia> mapreduce(isodd, |, a, dims=1)
 1×4 Array{Bool,2}:
  true  true  true  true
 ```


### PR DESCRIPTION
Previously, the example produced an error, as no such method exists; just a typo I imagine. 

Out of curiosity: isn't it the intention of ```` ```jldoctest ...``` ```` that documentation-examples such as this one would be automatically checked and caught by Documenter.jl's doctests?