### PR TITLE
Remove line info from macro calls in remove_linenums!

### DIFF
--- a/base/expr.jl
+++ b/base/expr.jl
@@ -350,6 +350,12 @@ function remove_linenums!(ex::Expr)
             isa(x, LineNumberNode) && return false
             return true
         end
+    elseif ex.head === :macrocall
+        # Replace line information embedded into macro calls with `nothing`
+        # Removing the argument entirely invalidates the expression
+        map!(ex.args, ex.args) do arg
+            arg isa LineNumberNode ? nothing : remove_linenums!(arg)
+        end
     end
     for subex in ex.args
         remove_linenums!(subex)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -722,3 +722,11 @@ end
        end
    end
 end
+
+@testset "remove_linenums!" begin
+    # Ensure line information is removed from macro calls
+    ex = :(@macro argument)
+    @test any(arg->arg isa LineNumberNode, ex.args)
+    Base.remove_linenums!(ex)
+    @test !any(arg->arg isa LineNumberNode, ex.args)
+end


### PR DESCRIPTION
Currently `Base.remove_linenums!` removes line information from code blocks, but not from macro calls, which embed line information as the second argument in the expression. Having the line information in there makes it difficult to test user code that performs transformations on expressions, since the line information may differ in the input and resulting expressions.

This change extends `Base.remove_linenums!` to handle macro call expressions, replacing their line information with `nothing`. The result is:

```julia
julia> :(@macro argument)
:(#= REPL[10]:1 =# @macro argument)

julia> Base.remove_linenums!(:(@macro argument))
:(@macro argument)
```

The function isn't exported or documented, so this is largely not a user-facing change, but it is a change in behavior for existing code. It is unlikely to _break_ code, I would think, but I suppose there is a slight potential that someone is expecting line information to be preserved when using this function...