### PR TITLE
Support repeat at any dimension

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -377,8 +377,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
 
     # fill the first inner block
     if all(x -> x == 1, inner)
-        idxs = (axes(A)..., ntuple(n->OneTo(1), length(shape) - length(inner))...) # keep dimension consistent
-        R[idxs...] = A
+        R[axes(A)...,:] = A
     else
         inner_indices = [1:n for n in inner]
         for c in CartesianIndices(axes(A))

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -377,7 +377,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
 
     # fill the first inner block
     if all(x -> x == 1, inner)
-        idxs = (axes(A)..., ntuple(n->OneTo(1), length(shape) - length(inner))...)
+        idxs = (axes(A)..., ntuple(n->1, length(shape) - length(inner))...) # keep dimension consistent
         R[idxs...] = A
     else
         inner_indices = [1:n for n in inner]

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -377,7 +377,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
 
     # fill the first inner block
     if all(x -> x == 1, inner)
-        idxs = (axes(A)..., ntuple(n->1, length(shape) - length(inner))...) # keep dimension consistent
+        idxs = (axes(A)..., ntuple(n->OneTo(1), length(shape) - length(inner))...) # keep dimension consistent
         R[idxs...] = A
     else
         inner_indices = [1:n for n in inner]

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -377,7 +377,8 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
 
     # fill the first inner block
     if all(x -> x == 1, inner)
-        R[axes(A)...] = A
+        idxs = (axes(A)..., ntuple(n->OneTo(1), length(shape) - length(inner))...) # keep dimension consistent
+        R[idxs...] = A
     else
         inner_indices = [1:n for n in inner]
         for c in CartesianIndices(axes(A))

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -377,7 +377,8 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
 
     # fill the first inner block
     if all(x -> x == 1, inner)
-        R[axes(A)...,:] = A
+        idxs = (axes(A)..., ntuple(n->OneTo(1), length(shape) - length(inner))...)
+        R[idxs...] = A
     else
         inner_indices = [1:n for n in inner]
         for c in CartesianIndices(axes(A))

--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -377,7 +377,7 @@ _reperr(s, n, N) = throw(ArgumentError("number of " * s * " repetitions " *
 
     # fill the first inner block
     if all(x -> x == 1, inner)
-        idxs = (axes(A)..., ntuple(n->OneTo(1), length(shape) - length(inner))...) # keep dimension consistent
+        idxs = (axes(A)..., ntuple(n->OneTo(1), ndims(R)-ndims(A))...) # keep dimension consistent
         R[idxs...] = A
     else
         inner_indices = [1:n for n in inner]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -699,6 +699,11 @@ end
     @test_throws MethodError repeat(1, 2, 3)
     @test repeat([1, 2], 1, 2, 3) == repeat([1, 2], outer = (1, 2, 3))
 
+    # issue 29614
+    @test repeat(ones(2,2), 1, 1, 1) == ones(2,2,1)
+    @test repeat(ones(2,2), 2, 2, 2) == ones(4,4,2)
+    @test repeat(ones(2), 2, 2, 2) == ones(4,2,2)
+
     R = repeat([1, 2])
     @test R == [1, 2]
     R = repeat([1, 2], inner=1)

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -703,6 +703,7 @@ end
     @test repeat(ones(2,2), 1, 1, 1) == ones(2,2,1)
     @test repeat(ones(2,2), 2, 2, 2) == ones(4,4,2)
     @test repeat(ones(2), 2, 2, 2) == ones(4,2,2)
+    @test repeat(ones(2,2), inner=(1, 1, 1), outer=(2, 2, 2)) == ones(4,2,2)
 
     R = repeat([1, 2])
     @test R == [1, 2]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -703,7 +703,7 @@ end
     @test repeat(ones(2,2), 1, 1, 1) == ones(2,2,1)
     @test repeat(ones(2,2), 2, 2, 2) == ones(4,4,2)
     @test repeat(ones(2), 2, 2, 2) == ones(4,2,2)
-    @test repeat(ones(2,2), inner=(1, 1, 1), outer=(2, 2, 2)) == ones(4,2,2)
+    @test repeat(ones(2,2), inner=(1, 1, 1), outer=(2, 2, 2)) == ones(4,4,2)
 
     R = repeat([1, 2])
     @test R == [1, 2]

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -700,10 +700,10 @@ end
     @test repeat([1, 2], 1, 2, 3) == repeat([1, 2], outer = (1, 2, 3))
 
     # issue 29614
-    @test repeat(ones(2,2), 1, 1, 1) == ones(2,2,1)
-    @test repeat(ones(2,2), 2, 2, 2) == ones(4,4,2)
-    @test repeat(ones(2), 2, 2, 2) == ones(4,2,2)
-    @test repeat(ones(2,2), inner=(1, 1, 1), outer=(2, 2, 2)) == ones(4,4,2)
+    @test repeat(ones(2, 2), 1, 1, 1) == ones(2, 2, 1)
+    @test repeat(ones(2, 2), 2, 2, 2) == ones(4, 4, 2)
+    @test repeat(ones(2), 2, 2, 2) == ones(4, 2, 2)
+    @test repeat(ones(2, 2), inner=(1, 1, 1), outer=(2, 2, 2)) == ones(4, 4, 2)
 
     R = repeat([1, 2])
     @test R == [1, 2]


### PR DESCRIPTION
This solves issue #29614 as an enhancement

now `repeat(ones(2,2), 2,2,2)` won't raise `BoundsError` but instead return a `Array{T,3}` as intuition expects. 

Benchmark:
```julia
julia> a = ones(100,100,100);
# before this patch
julia> @btime repeat(a, 2,2,2);
  81.971 ms (40 allocations: 114.44 MiB)
# after this patch
julia> @btime repeat(a, 2,2,2);
  82.136 ms (40 allocations: 114.44 MiB)
```