### PR TITLE
Use longer sleep time in test stress

### DIFF
--- a/test/stress.jl
+++ b/test/stress.jl
@@ -98,7 +98,7 @@ if !Sys.iswindows()
     @test_throws InterruptException begin
         ccall(:kill, Cvoid, (Cint, Cint,), getpid(), 2)
         for i in 1:10
-            Libc.systemsleep(0.1)
+            Libc.systemsleep(1.0)
             ccall(:jl_gc_safepoint, Cvoid, ()) # wait for SIGINT to arrive
         end
     end


### PR DESCRIPTION
With the current delay, the test fails very often on Fedora and Debian build machines.

Before https://github.com/JuliaLang/julia/commit/10321f558def85e4752b041a5de6638d07014cf0, there was a second call to `systemsleep`. Maybe that would help too?

Fixes https://github.com/JuliaLang/julia/issues/28580.

Cc: @cdluminate 