### PR TITLE
help type inference for logical indexing

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -517,6 +517,10 @@ end
     # We're looking for the n-th true element, using iterator r at state i
     n = s[1]
     n > length(L) && return nothing
+    #unroll once to help inference, cf issue #29418
+    idx, i = iterate(tail(s)...)
+    s = (n+1, s[2], i)
+    L.mask[idx] && return (idx, s)
     while true
         idx, i = iterate(tail(s)...)
         s = (n+1, s[2], i)


### PR DESCRIPTION
Before:
```
julia> using BenchmarkTools
julia> d=rand(10_000); m=rand(Bool, 10_000);
julia> @btime getindex($d,$m);
  742.062 μs (23906 allocations: 643.13 KiB)
```
After:
```
julia> using BenchmarkTools
julia> d=rand(10_000); m=rand(Bool, 10_000);
julia> @btime getindex($d,$m);
  51.177 μs (4 allocations: 39.06 KiB)
```
Not sure whether really related to [https://github.com/JuliaLang/julia/issues/29418](https://github.com/JuliaLang/julia/issues/29418). See also [https://discourse.julialang.org/t/is-boolean-indexing-100-times-slower-in-1-0/16286/8](https://discourse.julialang.org/t/is-boolean-indexing-100-times-slower-in-1-0/16286/8).

Problem was that we have a type change in the loop between the very first and subsequent iterations over logical indexing and this confused inference.