### PR TITLE
Extend `edit` for modules.

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -84,14 +84,21 @@ end
 
 """
     edit(function, [types])
+    edit(module)
 
-Edit the definition of a function, optionally specifying a tuple of types to
-indicate which method to edit. The editor can be changed by setting `JULIA_EDITOR`,
-`VISUAL` or `EDITOR` as an environment variable.
+Edit the definition of a function, optionally specifying a tuple of types to indicate which
+method to edit.
+
+For modules, open the main source file. The module needs to be loaded with `using` or
+`import` first.
+
+The editor can be changed by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment
+variable.
 """
 edit(f)                   = edit(functionloc(f)...)
 edit(f, @nospecialize t)  = edit(functionloc(f,t)...)
 edit(file, line::Integer) = error("could not find source file for function")
+edit(m::Module) = edit(pathof(m))
 
 # terminal pager
 


### PR DESCRIPTION
Sometimes one just wants to open the source of a package to read the code. With `Pkg3`, the source location is no longer that obvious. This PR allows eg
```julia
julia> using Tables

julia> edit(Tables) # open src/Tables.jl in the editor
```

This is made possible via `Base.pathof`, courtesy of #28310.

As currently `edit(::Module)` errors, this is not a breaking change, but an extension.