### PR TITLE
Kill several GCC compiler warnings

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -941,7 +941,7 @@ STATIC_INLINE void jl_array_shrink(jl_array_t *a, size_t dec)
         char *typetagdata;
         char *newtypetagdata;
         if (isbitsunion) {
-            typetagdata = malloc(a->nrows);
+            typetagdata = (char*)malloc(a->nrows);
             memcpy(typetagdata, jl_array_typetagdata(a), a->nrows);
         }
         size_t oldoffsnb = a->offset * elsz;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1040,6 +1040,11 @@ const char *name_from_method_instance(jl_method_instance_t *li)
     return jl_is_method(li->def.method) ? jl_symbol_name(li->def.method->name) : "top-level scope";
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+// Use of `li` is not clobbered in JL_TRY, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
+#pragma GCC diagnostic ignored "-Wclobbered"
+#endif
 // this generates llvm code for the lambda info
 // and adds the result to the jitlayers
 // (and the shadow module), but doesn't yet compile
@@ -1232,6 +1237,9 @@ locked_out:
     JL_GC_POP();
     return decls;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #define getModuleFlag(m,str) m->getModuleFlag(str)
 
@@ -3784,6 +3792,11 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
     }
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+// `expr` is not clobbered in JL_TRY, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
+#pragma GCC diagnostic ignored "-Wclobbered"
+#endif
 static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
 {
     if (jl_is_symbol(expr)) {
@@ -4093,6 +4106,9 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
     }
     return jl_cgval_t();
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 // --- generate function bodies ---
 

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -692,7 +692,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     else if (vt == jl_bool_type) {
         n += jl_printf(out, "%s", *(uint8_t*)v ? "true" : "false");
     }
-    else if (v == jl_nothing || (jl_nothing && vt == jl_typeof(jl_nothing))) {
+    else if (v == jl_nothing || (jl_nothing && (jl_value_t*)vt == jl_typeof(jl_nothing))) {
         n += jl_printf(out, "nothing");
     }
     else if (vt == jl_string_type) {

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -157,6 +157,11 @@ static void trampoline_deleter(void **f)
         free(nval);
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+// Use of `cache` is not clobbered in JL_TRY, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
+#pragma GCC diagnostic ignored "-Wclobbered"
+#endif
 // TODO: need a thread lock around the cache access parts of this function
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_get_cfunction_trampoline(
@@ -240,3 +245,6 @@ jl_value_t *jl_get_cfunction_trampoline(
     ptrhash_put(cache, (void*)fobj, result);
     return result;
 }
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
The bogus -Wclobbered warning "argument ‘x’ might be clobbered by
‘longjmp’ or ‘vfork’" is a gcc bug. It's been reported several times on
gcc bugzilla, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041 for
example. I wasn't sure how to work around this in code so I've disabled
it as locally as possible.

This makes the build warning free, at least with gcc-7.3 (ubuntu 18.04)