### PR TITLE
Don't modify GCC diagnostics when using Clang

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1040,11 +1040,8 @@ const char *name_from_method_instance(jl_method_instance_t *li)
     return jl_is_method(li->def.method) ? jl_symbol_name(li->def.method->name) : "top-level scope";
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-// Use of `li` is not clobbered in JL_TRY, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
-#pragma GCC diagnostic ignored "-Wclobbered"
-#endif
+// Use of `li` is not clobbered in JL_TRY
+JL_GCC_IGNORE_START("-Wclobbered")
 // this generates llvm code for the lambda info
 // and adds the result to the jitlayers
 // (and the shadow module), but doesn't yet compile
@@ -1237,9 +1234,7 @@ locked_out:
     JL_GC_POP();
     return decls;
 }
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+JL_GCC_IGNORE_STOP
 
 #define getModuleFlag(m,str) m->getModuleFlag(str)
 
@@ -3792,11 +3787,8 @@ static void emit_stmtpos(jl_codectx_t &ctx, jl_value_t *expr, int ssaval_result)
     }
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-// `expr` is not clobbered in JL_TRY, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
-#pragma GCC diagnostic ignored "-Wclobbered"
-#endif
+// `expr` is not clobbered in JL_TRY
+JL_GCC_IGNORE_START("-Wclobbered")
 static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
 {
     if (jl_is_symbol(expr)) {
@@ -4106,9 +4098,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
     }
     return jl_cgval_t();
 }
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+JL_GCC_IGNORE_STOP
 
 // --- generate function bodies ---
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1038,6 +1038,21 @@ jl_assume_aligned(T ptr, unsigned align)
 #  define jl_unreachable() ((void)jl_assume(0))
 #endif
 
+// GCC misidentifies some variables as being clobbered in JL_TRY, so we'll define a macro
+// to stop and resume GCC diagnostics for -Wclobbered that can be used to wrap affected code
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
+#ifdef _COMPILER_GCC_
+#define JL_DO_PRAGMA(s) _Pragma(#s)
+#define JL_GCC_IGNORE_START(warning) \
+    JL_DO_PRAGMA(GCC diagnostic push) \
+    JL_DO_PRAGMA(GCC diagnostic ignored warning)
+#define JL_GCC_IGNORE_STOP \
+    JL_DO_PRAGMA(GCC diagnostic pop)
+#else
+#define JL_GCC_IGNORE_START(w)
+#define JL_GCC_IGNORE_STOP
+#endif // _COMPILER_GCC_
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1038,9 +1038,14 @@ jl_assume_aligned(T ptr, unsigned align)
 #  define jl_unreachable() ((void)jl_assume(0))
 #endif
 
-// GCC misidentifies some variables as being clobbered in JL_TRY, so we'll define a macro
-// to stop and resume GCC diagnostics for -Wclobbered that can be used to wrap affected code
-// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
+// Tools for locally disabling spurious compiler warnings
+//
+// Particular calls which are used elsewhere in the code include:
+//
+// * JL_GCC_IGNORE_START(-Wclobbered) - gcc misidentifies some variables which
+//   are used inside a JL_TRY as being "clobbered" if JL_CATCH is entered. This
+//   warning is spurious if the variable is not modified inside the JL_TRY.
+//   See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
 #ifdef _COMPILER_GCC_
 #define JL_DO_PRAGMA(s) _Pragma(#s)
 #define JL_GCC_IGNORE_START(warning) \

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -157,11 +157,8 @@ static void trampoline_deleter(void **f)
         free(nval);
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-// Use of `cache` is not clobbered in JL_TRY, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65041
-#pragma GCC diagnostic ignored "-Wclobbered"
-#endif
+// Use of `cache` is not clobbered in JL_TRY
+JL_GCC_IGNORE_START("-Wclobbered")
 // TODO: need a thread lock around the cache access parts of this function
 extern "C" JL_DLLEXPORT
 jl_value_t *jl_get_cfunction_trampoline(
@@ -245,6 +242,4 @@ jl_value_t *jl_get_cfunction_trampoline(
     ptrhash_put(cache, (void*)fobj, result);
     return result;
 }
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+JL_GCC_IGNORE_STOP


### PR DESCRIPTION
The `-Wclobbered` warnings were fixed in #29642 by disabling that particular GCC diagnostic for particular blocks of code. However, it was guarded by a check on `__GNUC__`, which Clang also defines, and Clang doesn't understand that diagnostic group, so it emits its own warning. This changes the guards to be GCC-only by checking for `__GNUC__` and not `__clang__`.