### PR TITLE
Add documentation on the `cx16` CPU capabiilty that we require

### DIFF
--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -715,10 +715,20 @@ static uint32_t sysimg_init_cb(const void *id)
     // We translate `generic` to `pentium4` or `x86-64` before sending it to LLVM
     // (see `get_llvm_target_noext`) which will be serialized into the sysimg target data.
     // Translate them back so we can actually match them.
+    bool sysimg_allows_no_cx16 = false;
     for (auto &t: sysimg) {
         if (auto nname = normalize_cpu_name(t.name)) {
             t.name = nname;
         }
+
+        // Take note to see if the sysimg explicitly allows an architecture without cx16
+        sysimg_allows_no_cx16 |= !test_nbit(t.en.features, Feature::cx16);
+    }
+    if (!sysimg_allows_no_cx16 && !test_nbit(target.en.features, Feature::cx16)) {
+        jl_error("Your CPU does not support the CX16 instruction, which is required "
+                 "by this version of Julia!  This is often due to running inside of a "
+                 "virtualized environment.  Please read "
+                 "https://docs.julialang.org/en/stable/devdocs/sysimg/ for more.");
     }
     auto match = match_sysimg_targets(sysimg, target, max_vector_size);
     // Now we've decided on which sysimg version to use.

--- a/src/processor_x86.cpp
+++ b/src/processor_x86.cpp
@@ -715,7 +715,10 @@ static uint32_t sysimg_init_cb(const void *id)
     // We translate `generic` to `pentium4` or `x86-64` before sending it to LLVM
     // (see `get_llvm_target_noext`) which will be serialized into the sysimg target data.
     // Translate them back so we can actually match them.
-    bool sysimg_allows_no_cx16 = false;
+    // We also track to see if the sysimg allows -cx16, however if the user does
+    // something silly like add +cx16 on a 32bit target, we want to disable this
+    // check, hence the pointer size check.
+    bool sysimg_allows_no_cx16 = sizeof(void *) == 4;;
     for (auto &t: sysimg) {
         if (auto nname = normalize_cpu_name(t.name)) {
             t.name = nname;


### PR DESCRIPTION
VirtualBox fails to run the typical Julia binaries because we require `cx16` but don't say that anywhere outside of `processor_x86.cpp`, so I added it to the docs.