### PR TITLE
Fix stack range computation in gc_scrub_task

### DIFF
--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -583,8 +583,8 @@ static void gc_scrub_task(jl_task_t *ta)
     char *low;
     char *high;
     if (ta->copy_stack && ta == ptls2->current_task) {
-        low  = (char*)ptls2->stackbase;
-        high = (char*)ptls2->stackbase + ptls2->stacksize;
+        low  = (char*)ptls2->stackbase - ptls2->stacksize;
+        high = (char*)ptls2->stackbase;
     }
     else if (ta->stkbuf) {
         low  = (char*)ta->stkbuf;


### PR DESCRIPTION
I believe the logic introduced in `gc_scrub_task ` via PR #29489 by @vchuravy is not quite correct. With this patch, the code matches e.g. `is_addr_on_stack` in `src/signals-unix.c` and other code.

However, I have no idea how to test run this code, and so this is a purely theoretical analysis. My apologies for wasting your time if I am misunderstanding this code, and everything is correct after all. In that case, I'd greatly appreciate if somebody were to briefly explain why this is correct; we are currently debugging some crashes in the task scanner code of our GC extension framework, and so understanding this area of the code properly is of high importance to us.

CC @rbehrends 