### PR TITLE
Adding specialized iszero and isone for structured matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -11,11 +11,11 @@ import Base: \, /, *, ^, +, -, ==
 import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, asec, asech,
     asin, asinh, atan, atanh, axes, big, broadcast, ceil, conj, convert, copy, copyto!, cos,
     cosh, cot, coth, csc, csch, eltype, exp, findmax, findmin, fill!, floor, getindex, hcat,
-    getproperty, imag, inv, isapprox, isone, IndexStyle, kron, length, log, map, ndims,
+    getproperty, imag, inv, isapprox, isone, iszero, IndexStyle, kron, length, log, map, ndims,
     oneunit, parent, power_by_squaring, print_matrix, promote_rule, real, round, sec, sech,
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
-using Base: hvcat_fill, iszero, IndexLinear, promote_op, promote_typeof,
+using Base: hvcat_fill, IndexLinear, promote_op, promote_typeof,
     @propagate_inbounds, @pure, reduce, typed_vcat, has_offset_axes
 using Base.Broadcast: Broadcasted
 

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -244,6 +244,8 @@ function Base.copy(tB::Transpose{<:Any,<:Bidiagonal})
     return Bidiagonal(map(x -> copy.(transpose.(x)), (B.dv, B.ev))..., B.uplo == 'U' ? :L : :U)
 end
 
+iszero(M::Bidiagonal) = iszero(M.dv) && iszero(M.ev)
+isone(M::Bidiagonal) = all(isone, M.dv) && iszero(M.ev)
 istriu(M::Bidiagonal) = M.uplo == 'U' || iszero(M.ev)
 istril(M::Bidiagonal) = M.uplo == 'L' || iszero(M.ev)
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -123,6 +123,9 @@ factorize(D::Diagonal) = D
 real(D::Diagonal) = Diagonal(real(D.diag))
 imag(D::Diagonal) = Diagonal(imag(D.diag))
 
+iszero(D::Diagonal) = all(iszero, D.diag)
+iszero(D::Diagonal{<:Number}) = iszero(D.diag)
+isone(D::Diagonal) = all(isone, D.diag)
 isdiag(D::Diagonal) = all(isdiag, D.diag)
 isdiag(D::Diagonal{<:Number}) = true
 istriu(D::Diagonal) = true

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -124,7 +124,6 @@ real(D::Diagonal) = Diagonal(real(D.diag))
 imag(D::Diagonal) = Diagonal(imag(D.diag))
 
 iszero(D::Diagonal) = all(iszero, D.diag)
-iszero(D::Diagonal{<:Number}) = iszero(D.diag)
 isone(D::Diagonal) = all(isone, D.diag)
 isdiag(D::Diagonal) = all(isdiag, D.diag)
 isdiag(D::Diagonal{<:Number}) = true

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -272,6 +272,9 @@ eigvecs(A::SymTridiagonal{<:BlasFloat}, eigvals::Vector{<:Real}) = LAPACK.stein!
 
 istriu(M::SymTridiagonal) = iszero(M.ev)
 istril(M::SymTridiagonal) = iszero(M.ev)
+iszero(M::SymTridiagonal) = iszero(M.ev) && iszero(M.dv)
+isone(M::SymTridiagonal) = iszero(M.ev) && all(isone, M.dv)
+isdiag(M::SymTridiagonal) = iszero(M.ev)
 
 function tril!(M::SymTridiagonal, k::Integer=0)
     n = length(M.dv)
@@ -598,6 +601,8 @@ end
 
 #tril and triu
 
+iszero(M::Tridiagonal) = iszero(M.dl) && iszero(M.d) && iszero(M.du)
+isone(M::Tridiagonal) = iszero(M.dl) && all(isone, M.d) && iszero(M.du)
 istriu(M::Tridiagonal) = iszero(M.dl)
 istril(M::Tridiagonal) = iszero(M.du)
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -152,6 +152,22 @@ Random.seed!(1)
             @test_throws ArgumentError triu!(bidiagcopy(dv, ev, :U), n + 2)
         end
 
+        @testset "iszero and isone" begin
+            for uplo in (:U, :L)
+                BDzero = Bidiagonal(zeros(elty, 10), zeros(elty, 9), uplo)
+                BDone = Bidiagonal(ones(elty, 10), zeros(elty, 9), uplo)
+                BDmix = Bidiagonal(zeros(elty, 10), zeros(elty, 9), uplo)
+                BDmix[end,end] = one(elty)
+
+                @test iszero(BDzero)
+                @test !isone(BDzero)
+                @test !iszero(BDone)
+                @test isone(BDone)
+                @test !iszero(BDmix)
+                @test !isone(BDmix)
+            end
+        end
+
         Tfull = Array(T)
         @testset "Linear solves" begin
             if relty <: AbstractFloat

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -201,7 +201,17 @@ Random.seed!(1)
         DM3= Matrix(D3)
         Matrix(kron(D, D3)) ≈ kron(DM, DM3)
     end
-    @testset "triu/tril" begin
+    @testset "iszero, isone, triu, tril" begin
+        Dzero = Diagonal(zeros(elty, 10))
+        Done = Diagonal(ones(elty, 10))
+        Dmix = Diagonal(zeros(elty, 10))
+        Dmix[end,end] = one(elty)
+        @test iszero(Dzero)
+        @test !isone(Dzero)
+        @test !iszero(Done)
+        @test isone(Done)
+        @test !iszero(Dmix)
+        @test !isone(Dmix)
         @test istriu(D)
         @test istril(D)
         @test iszero(triu(D,1))

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -142,6 +142,32 @@ end
         @test istril(Tridiagonal(dl,d,zerosdu))
     end
 
+    @testset "iszero and isone" begin
+        Tzero = Tridiagonal(zeros(elty, 9), zeros(elty, 10), zeros(elty, 9))
+        Tone = Tridiagonal(zeros(elty, 9), ones(elty, 10), zeros(elty, 9))
+        Tmix = Tridiagonal(zeros(elty, 9), zeros(elty, 10), zeros(elty, 9))
+        Tmix[end, end] = one(elty)
+
+        Szero = SymTridiagonal(zeros(elty, 10), zeros(elty, 9))
+        Sone = SymTridiagonal(ones(elty, 10), zeros(elty, 9))
+        Smix = SymTridiagonal(zeros(elty, 10), zeros(elty, 9))
+        Smix[end, end] = one(elty)
+
+        @test iszero(Tzero)
+        @test !isone(Tzero)
+        @test !iszero(Tone)
+        @test isone(Tone)
+        @test !iszero(Tmix)
+        @test !isone(Tmix)
+
+        @test iszero(Szero)
+        @test !isone(Szero)
+        @test !iszero(Sone)
+        @test isone(Sone)
+        @test !iszero(Smix)
+        @test !isone(Smix)
+    end
+
     @testset for mat_type in (Tridiagonal, SymTridiagonal)
         A = mat_type == Tridiagonal ? mat_type(dl, d, du) : mat_type(d, dl)
         fA = map(elty <: Complex ? ComplexF64 : Float64, Array(A))


### PR DESCRIPTION
Currently, `iszero` and `isone` fall back to generic methods in LinearAlgebra. This PR adds faster versions for these methods. `Diagonal`, `Bidiagonal`, `Tridiagonal`, and `SymTridiagonal` are supported. 
This is, of course, open to comments. In particular the result of these when `eltype` is not a Number (for example block diagonal matrices).

For random matrices, there isn't much speedup (because they should both fail pretty early) but in the worst case these are `O(n)` vs `O(n^2)`.

As an example, on v1.0
```
julia> T = Tridiagonal(zeros(10000), zeros(10001), zeros(10000))

julia> T[end-1,end] = .1
0.1

julia> iszero(T)
false

julia> @time iszero(T)
  0.222727 seconds (4 allocations: 160 bytes)
false

julia> versioninfo()
Julia Version 1.0.0
Commit 5d4eaca (2018-08-08 20:58 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: AMD Ryzen 7 1700 Eight-Core Processor
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-6.0.0 (ORCJIT, znver1)
```

and after the PR

```
julia> T = Tridiagonal(zeros(10000), zeros(10001), zeros(10000))

julia> T[end-1,end] = .1
0.1

julia> iszero(T)
false

julia> @time iszero(T)
  0.000067 seconds (4 allocations: 160 bytes)
false
```
