### PR TITLE
Add isnothing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ New language features
 ---------------------
 
   * `CartesianIndices` can now be constructed from two `CartesianIndex`es `I` and `J` with `I:J` ([#29440]).
+  * `isnothing(::Any)` function can now be called to check whether something is a `Nothing`, returns a `Bool` ([#29679])
 
 Language changes
 ----------------

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -669,6 +669,7 @@ export
     missing,
     skipmissing,
     something,
+    isnothing,
 
 # time
     sleep,

--- a/base/some.jl
+++ b/base/some.jl
@@ -45,7 +45,8 @@ notnothing(::Nothing) = throw(ArgumentError("nothing passed to notnothing"))
 
 Return `true` if `x === nothing`, and return `false` if not.
 """
-isnothing(x::Any) = x === nothing ? true : false
+isnothing(::Any) = false
+isnothing(::Nothing) = true
 
 
 """

--- a/base/some.jl
+++ b/base/some.jl
@@ -41,6 +41,14 @@ notnothing(x::Any) = x
 notnothing(::Nothing) = throw(ArgumentError("nothing passed to notnothing"))
 
 """
+    isnothing(x)
+
+Return `true` if `x === nothing`, and return `false` if not.
+"""
+isnothing(x::Any) = x === nothing ? true : false
+
+
+"""
     something(x, y...)
 
 Return the first value in the arguments which is not equal to [`nothing`](@ref),

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -199,6 +199,7 @@ Core.NamedTuple
 Base.Val
 Core.Vararg
 Core.Nothing
+Base.isnothing
 Base.Some
 Base.something
 Base.Enums.@enum

--- a/test/some.jl
+++ b/test/some.jl
@@ -94,3 +94,9 @@ b = [ "replacement", "replacement", nothing, missing ]
 using Base: notnothing
 @test notnothing(1) === 1
 @test_throws ArgumentError notnothing(nothing)
+
+# isnothing()
+
+using Base: isnothing
+@test !isnothing(1)
+@test isnothing(nothing)

--- a/test/some.jl
+++ b/test/some.jl
@@ -96,7 +96,5 @@ using Base: notnothing
 @test_throws ArgumentError notnothing(nothing)
 
 # isnothing()
-
-using Base: isnothing
 @test !isnothing(1)
 @test isnothing(nothing)


### PR DESCRIPTION
This adds an `isnothing()` function to `Base` to mirror `ismissing()` and `isnan()` (see #29674)

I thought it would be pretty straightforward, but... I was naive.

**First**, I wasn't sure where to put it. Near `notnothing()` seemed like a good candidate, but I noticed that `notnothing()` is not exported. `ismissing()` [is defined here](https://github.com/JuliaLang/julia/blob/master/base/essentials.jl#L754-L769) near the definition of `Missing`

```
struct Missing end

"""
    missing
The singleton instance of type [`Missing`](@ref) representing a missing value.
"""
const missing = Missing()

"""
    ismissing(x)
Indicate whether `x` is [`missing`](@ref).
"""
ismissing(::Any) = false
ismissing(::Missing) = true
```

But `Nothing` [seems to be defined](https://github.com/JuliaLang/julia/blob/master/base/boot.jl#L312) in `boot.jl`, which doesn't seem like the best place for this function. Any advice on location from someone that knows the code better than me (eg. anyone at all) would be appreciated. And if it's **not** in `boot.jl`, where should I export it from? (I can't find where `ismissing()` is exported for example). 

**Second**, folks on slack said that doing `x === nothing` was the most performant way to do this check, so I defined it as

```
isnothing(x::Any) = x === nothing ? true : false
```

But the way `ismissing` is defined above seems way more elegant. Should it be:

```
isnothing(::Any) = false
isnothing(::Nothing) = true
```

instead?

**Finally**, I'm having trouble building julia locally, so I can't do all the steps in [`CONTRIBUTING.md`](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md#contributing-to-core-functionality-or-base-libraries). I can't imagine how this could cause something to break, but I've been wrong with simple things before. Apologies if I'm missing something important.