### PR TITLE
Adjust doc test for \ to avoid rounding

### DIFF
--- a/base/operators.jl
+++ b/base/operators.jl
@@ -520,17 +520,17 @@ julia> 3 \\ 6
 julia> inv(3) * 6
 2.0
 
-julia> A = [1 2; 3 4]; x = [5, 6];
+julia> A = [4 3; 2 1]; x = [5, 6];
 
 julia> A \\ x
 2-element Array{Float64,1}:
- -4.0
-  4.5
+  6.5
+ -7.0
 
 julia> inv(A) * x
 2-element Array{Float64,1}:
- -4.0
-  4.5
+  6.5
+ -7.0
 ```
 """
 \(x,y) = adjoint(adjoint(y)/adjoint(x))


### PR DESCRIPTION
With this small adjustment, all intermediate numbers are exact floats so this should make the doc test robust across architectures. @vtjnash recently saw this example fail on a new architecture.