### PR TITLE
remove some `::Callable` argument restrictions no longer necessary

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -465,8 +465,8 @@ function mapreduce_impl(f, op::Union{typeof(max), typeof(min)},
     v
 end
 
-maximum(f::Callable, a) = mapreduce(f, max, a)
-minimum(f::Callable, a) = mapreduce(f, min, a)
+maximum(f, a) = mapreduce(f, max, a)
+minimum(f, a) = mapreduce(f, min, a)
 
 """
     maximum(itr)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -643,7 +643,7 @@ for (fname, _fname, op) in [(:sum,     :_sum,     :add_sum), (:prod,    :_prod, 
     @eval begin
         # User-facing methods with keyword arguments
         @inline ($fname)(a::AbstractArray; dims=:) = ($_fname)(a, dims)
-        @inline ($fname)(f::Callable, a::AbstractArray; dims=:) = ($_fname)(f, a, dims)
+        @inline ($fname)(f, a::AbstractArray; dims=:) = ($_fname)(f, a, dims)
 
         # Underlying implementations using dispatch
         ($_fname)(a, ::Colon) = ($_fname)(identity, a, :)

--- a/base/set.jl
+++ b/base/set.jl
@@ -165,7 +165,7 @@ julia> unique(x -> x^2, [1, -1, 3, -3, 4])
  4
 ```
 """
-function unique(f::Callable, C)
+function unique(f, C)
     out = Vector{eltype(C)}()
     seen = Set()
     for x in C

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -54,7 +54,7 @@ julia> mean([√1, √2, √3])
 1.3820881233139908
 ```
 """
-function mean(f::Base.Callable, itr)
+function mean(f, itr)
     y = iterate(itr)
     if y === nothing
         return Base.mapreduce_empty_iter(f, Base.add_sum, itr,
@@ -73,7 +73,7 @@ function mean(f::Base.Callable, itr)
     end
     return total/count
 end
-mean(f::Base.Callable, A::AbstractArray) = sum(f, A) / length(A)
+mean(f, A::AbstractArray) = sum(f, A) / length(A)
 
 """
     mean!(r, v)


### PR DESCRIPTION
These were needed to disambiguate methods that accepted `dims` as an optional positional argument. Post-1.0 that's no longer necessary and we can open up these arguments for anything actually callable instead of just `Callable`.

It would be good to gradually phase out `Callable` as much as possible, since it is not terribly meaningful. The only remaining ambiguous functions are `get(!)` and `replace(!)`.