### PR TITLE
more compact lowering of broadcast and generators by avoiding `getproperty`

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -73,7 +73,7 @@ include("abstractdict.jl")
 include("abstractset.jl")
 include("iterators.jl")
 using .Iterators: zip, enumerate
-using .Iterators: Flatten, product  # for generators
+using .Iterators: Flatten, Filter, product  # for generators
 include("namedtuple.jl")
 
 # core docsystem

--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -168,7 +168,7 @@ include("abstractdict.jl")
 
 include("iterators.jl")
 using .Iterators: zip, enumerate
-using .Iterators: Flatten, product  # for generators
+using .Iterators: Flatten, Filter, product  # for generators
 
 include("namedtuple.jl")
 
@@ -264,6 +264,7 @@ using .PermutedDimsArrays
 
 include("broadcast.jl")
 using .Broadcast
+using .Broadcast: broadcasted, broadcasted_kwsyntax, materialize, materialize!
 
 # define the real ntuple functions
 @inline function ntuple(f::F, ::Val{N}) where {F,N}

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1589,7 +1589,7 @@
                    (car ranges)
                    `(call (top product) ,@ranges)))
          (iter (if filt?
-                   `(call (|.| (top Iterators) 'Filter)
+                   `(call (top Filter)
                           ,(func-for-generator-ranges (cadr (caddr e)) range-exprs #f '())
                           ,iter)
                    iter))
@@ -1630,7 +1630,7 @@
              (kws (car kws+args))
              (kws (if (null? kws) kws (list (cons 'parameters kws))))
              (args (map dot-to-fuse (cdr kws+args)))
-             (make `(call (|.| (top Broadcast) ,(if (null? kws) ''broadcasted ''broadcasted_kwsyntax)) ,@kws ,f ,@args)))
+             (make `(call (top ,(if (null? kws) 'broadcasted 'broadcasted_kwsyntax)) ,@kws ,f ,@args)))
         (if top (cons 'fuse make) make)))
     (if (and (pair? e) (eq? (car e) '|.|))
         (let ((f (cadr e)) (x (caddr e)))
@@ -1655,12 +1655,13 @@
     (if (fuse? e)
         ; expanded to a fuse op call
         (if (null? lhs)
-            (expand-forms `(call (|.| (top Broadcast) 'materialize) ,(cdr e)))
-            (expand-forms `(call (|.| (top Broadcast) 'materialize!) ,lhs-view ,(cdr e))))
+            (expand-forms `(call (top materialize) ,(cdr e)))
+            (expand-forms `(call (top materialize!) ,lhs-view ,(cdr e))))
         ; expanded to something else (like a getfield)
         (if (null? lhs)
             (expand-forms e)
-            (expand-forms `(call (|.| (top Broadcast) 'materialize!) ,lhs-view (call (|.| (top Broadcast) 'broadcasted) (top identity) ,e)))))))
+            (expand-forms `(call (top materialize!) ,lhs-view
+                                 (call (top broadcasted) (top identity) ,e)))))))
 
 
 (define (expand-where body var)


### PR DESCRIPTION
Using `.` expressions to access the `Iterators` and `Broadcast` modules adds `getproperty` calls to the lowered IR, which is unnecessary since we know everything is a constant.