### PR TITLE
refactor: use fld and cld instead of floor and ceil

### DIFF
--- a/stdlib/DelimitedFiles/test/runtests.jl
+++ b/stdlib/DelimitedFiles/test/runtests.jl
@@ -217,7 +217,7 @@ end
             "Yugoslavia (Cyrillic)", "Djordje Balasevic", "Југославија", "Ђорђе Балашевић",
             "Yugoslavia (Latin)", "Djordje Balasevic", "Jugoslavija", "Đorđe Balašević"]
 
-        i18n_arr = permutedims(reshape(i18n_data, 4, Int(floor(length(i18n_data)/4))), [2, 1])
+        i18n_arr = permutedims(reshape(i18n_data, 4, fld(length(i18n_data),4)), [2, 1])
         i18n_buff = PipeBuffer()
         writedlm(i18n_buff, i18n_arr, ',')
         @test i18n_arr == readdlm(i18n_buff, ',')

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -2153,7 +2153,7 @@ function log(A0::UpperTriangular{T}) where T<:BlasFloat
         else
             logAk = log(Ak)
             logAkp1 = log(Akp1)
-            w = atanh((Akp1 - Ak)/(Akp1 + Ak)) + im*pi*ceil((imag(logAkp1-logAk)-pi)/(2*pi))
+            w = atanh((Akp1 - Ak)/(Akp1 + Ak)) + im*pi*cld((imag(logAkp1-logAk)-pi),(2*pi))
             dd = 2 * exp(p*(logAk+logAkp1)/2) * sinh(p*w) / (Akp1 - Ak)
             A[k,k+1] = A0[k,k+1] * dd
         end
@@ -2215,7 +2215,7 @@ function log(A0::UpperTriangular{T}) where T<:BlasFloat
         elseif 2 * abs(Ak) < abs(Akp1) || 2 * abs(Akp1) < abs(Ak)
             Y[k,k+1] = A0[k,k+1] * (logAkp1 - logAk) / (Akp1 - Ak)
         else
-            w = atanh((Akp1 - Ak)/(Akp1 + Ak) + im*pi*(ceil((imag(logAkp1-logAk) - pi)/(2*pi))))
+            w = atanh((Akp1 - Ak)/(Akp1 + Ak) + im*pi*(cld((imag(logAkp1-logAk) - pi),(2*pi))))
             Y[k,k+1] = 2 * A0[k,k+1] * w / (Akp1 - Ak)
         end
     end


### PR DESCRIPTION
I noticed these cases where it looks like `fld` and `cld` can be used, respectively.