### PR TITLE
Fix whitespace error which has broken the CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ When building Julia, or its dependencies, libraries installed by third party pac
 ### FreeBSD
 
 Clang is the default compiler on FreeBSD 11.0-RELEASE and above.
-The remaining build tools are available from the Ports Collection, and can be installed using 
+The remaining build tools are available from the Ports Collection, and can be installed using
 `pkg install git gcc gmake cmake pkgconf`.
 To build Julia, simply run `gmake`.
 (Note that `gmake` must be used rather than `make`, since `make` on FreeBSD corresponds to the incompatible BSD Make rather than GNU Make.)


### PR DESCRIPTION
Remove an errant ' ' from ea00782e5