### PR TITLE
Change simd loop lowering

### DIFF
--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -65,19 +65,13 @@ function compile(x, ivdep)
         let $r = $range
             for $j in Base.simd_outer_range($r)
                 let $n = Base.simd_inner_length($r,$j)
-                    if zero($n) < $n
-                        # Lower loop in way that seems to work best for LLVM 3.3 vectorizer.
-                        let $i = zero($n)
-                            while $i < $n
-                                local $var = Base.simd_index($r,$j,$i)
-                                $(x.args[2])        # Body of loop
-                                $i += 1
-                                $(Expr(:simdloop, ivdep))  # Mark loop as SIMD loop
-                            end
-                        end
-                        # Set index to last value just like a regular for loop would
-                        $var = last($r)
+                    for $i in 0:($n-1)
+                        local $var = Base.simd_index($r,$j,$i)
+                        $(x.args[2])        # Body of loop
+                        $(Expr(:simdloop, ivdep))  # Mark loop as SIMD loop
                     end
+                    # Set index to last value just like a regular for loop would
+                    $var = last($r)
                 end
             end
         end

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -65,13 +65,11 @@ function compile(x, ivdep)
         let $r = $range
             for $j in Base.simd_outer_range($r)
                 let $n = Base.simd_inner_length($r,$j)
-                    for $i in 0:($n-1)
-                        local $var = Base.simd_index($r,$j,$i)
+                    for $i in 1:$n
+                        local $var = Base.simd_index($r,$j,$i-1)
                         $(x.args[2])        # Body of loop
                         $(Expr(:simdloop, ivdep))  # Mark loop as SIMD loop
                     end
-                    # Set index to last value just like a regular for loop would
-                    $var = last($r)
                 end
             end
         end

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -58,19 +58,24 @@ for T in [Int32,Int64,Float32,Float64]
 end
 
 # Test that scope rules match regular for
-let j=4
+let j=4, k=4
     # Use existing local variable.
     @simd for j=1:0 end
-    @test j==4
+          for k=1:0 end
+    @test j==k
     @simd for j=1:3 end
-    @test j==3
+          for k=1:3 end
+    @test j==k
 
     # Use global variable
     global simd_glob = 4
+    global glob = 4
     @simd for simd_glob=1:0 end
-    @test simd_glob==4
+          for      glob=1:0 end
+    @test simd_glob==glob
     @simd for simd_glob=1:3 end
-    @test simd_glob==3
+          for      glob=1:3 end
+    @test simd_glob==glob
 
     # Index that is local to loop
     @simd for simd_loop_local=1:0 end


### PR DESCRIPTION
An experiment based on the benchmark in https://github.com/JuliaLang/julia/issues/25964.

Benchmark

```jl
regular = complex.(randn(1000000), randn(1000000));

function f_nosimd(x, a)
    s = zero(eltype(x))
    for i in 1:length(x)
        @inbounds s += x[i] * a
    end
    s
end


function f(x, a)
    s = zero(eltype(x))
    @simd for i in 1:length(x)
        @inbounds s += x[i] * a
    end
    s
end

using BenchmarkTools
```

```jl
julia> @btime f_nosimd($regular, 0.5+0.5im)
  1.191 ms (0 allocations: 0 bytes)
```

Before:

```jl
julia> @btime f($regular, 0.5+0.5im)
  1.194 ms (0 allocations: 0 bytes)
```

After:

```jl
julia> @btime f($regular, 0.5+0.5im)
  918.342 μs (0 allocations: 0 bytes)
```

This is a bit scary though:

https://github.com/JuliaLang/julia/blob/5f2759d85eeeb9c68e35e5e84b10715a49f4449d/src/llvm-simdloop.cpp#L38-L40

cc @vchuravy 

Fixes #29716 