### PR TITLE
convert Integer in Cholesky constructors to BlasInt

### DIFF
--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -58,7 +58,7 @@ struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
 end
 function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{<:Integer},
                             rank::Integer, tol::Real, info::Integer) where T
-    CholeskyPivoted{T,typeof(A)}(A, uplo, convert(Vector{BlasInt}, piv), rank, tol, info)
+    CholeskyPivoted{T,typeof(A)}(A, uplo, piv, rank, tol, info)
 end
 
 # make a copy that allow inplace Cholesky factorization

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -58,7 +58,7 @@ struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
 end
 function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{<:Integer},
                             rank::Integer, tol::Real, info::Integer) where T
-    CholeskyPivoted{T,typeof(A)}(A, uplo, Vector{BlasInt}(piv), BlasInt(rank), tol,
+    CholeskyPivoted{T,typeof(A)}(A, uplo, convert(Vector{BlasInt}, piv), BlasInt(rank), tol,
                                  BlasInt(info))
 end
 

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -38,10 +38,10 @@ struct Cholesky{T,S<:AbstractMatrix} <: Factorization{T}
         new(factors, uplo, info)
     end
 end
-Cholesky(A::AbstractMatrix{T}, uplo::Symbol, info::BlasInt) where {T} =
-    Cholesky{T,typeof(A)}(A, char_uplo(uplo), info)
-Cholesky(A::AbstractMatrix{T}, uplo::AbstractChar, info::BlasInt) where {T} =
-    Cholesky{T,typeof(A)}(A, uplo, info)
+Cholesky(A::AbstractMatrix{T}, uplo::Symbol, info::Integer) where {T} =
+    Cholesky{T,typeof(A)}(A, char_uplo(uplo), BlasInt(info))
+Cholesky(A::AbstractMatrix{T}, uplo::AbstractChar, info::Integer) where {T} =
+    Cholesky{T,typeof(A)}(A, uplo, BlasInt(info))
 
 struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
     factors::S
@@ -56,9 +56,10 @@ struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
         new(factors, uplo, piv, rank, tol, info)
     end
 end
-function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{BlasInt},
-                            rank::BlasInt, tol::Real, info::BlasInt) where T
-    CholeskyPivoted{T,typeof(A)}(A, uplo, piv, rank, tol, info)
+function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{<:Integer},
+                            rank::Integer, tol::Real, info::Integer) where T
+    CholeskyPivoted{T,typeof(A)}(A, uplo, Vector{BlasInt}(piv), BlasInt(rank), tol,
+                                 BlasInt(info))
 end
 
 # make a copy that allow inplace Cholesky factorization

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -39,9 +39,9 @@ struct Cholesky{T,S<:AbstractMatrix} <: Factorization{T}
     end
 end
 Cholesky(A::AbstractMatrix{T}, uplo::Symbol, info::Integer) where {T} =
-    Cholesky{T,typeof(A)}(A, char_uplo(uplo), BlasInt(info))
+    Cholesky{T,typeof(A)}(A, char_uplo(uplo), info)
 Cholesky(A::AbstractMatrix{T}, uplo::AbstractChar, info::Integer) where {T} =
-    Cholesky{T,typeof(A)}(A, uplo, BlasInt(info))
+    Cholesky{T,typeof(A)}(A, uplo, info)
 
 struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
     factors::S
@@ -58,8 +58,7 @@ struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
 end
 function CholeskyPivoted(A::AbstractMatrix{T}, uplo::AbstractChar, piv::Vector{<:Integer},
                             rank::Integer, tol::Real, info::Integer) where T
-    CholeskyPivoted{T,typeof(A)}(A, uplo, convert(Vector{BlasInt}, piv), BlasInt(rank), tol,
-                                 BlasInt(info))
+    CholeskyPivoted{T,typeof(A)}(A, uplo, convert(Vector{BlasInt}, piv), rank, tol, info)
 end
 
 # make a copy that allow inplace Cholesky factorization

--- a/stdlib/LinearAlgebra/test/cholesky.jl
+++ b/stdlib/LinearAlgebra/test/cholesky.jl
@@ -306,4 +306,30 @@ end
     @test_throws InexactError cholesky!(Diagonal([2, 1]))
 end
 
+@testset "constructor with non-BlasInt arguments" begin
+
+    x = rand(5,5)
+    chol = cholesky(x'x)
+
+    factors, uplo, info = chol.factors, chol.uplo, chol.info
+
+    @test Cholesky(factors, uplo, Int32(info)) == chol
+    @test Cholesky(factors, uplo, Int64(info)) == chol
+
+    cholp = cholesky(x'x, Val(true))
+
+    factors, uplo, piv, rank, tol, info =
+        cholp.factors, cholp.uplo, cholp.piv, cholp.rank, cholp.tol, cholp.info
+
+    @test CholeskyPivoted(factors, uplo, Vector{Int32}(piv), rank, tol, info) == cholp
+    @test CholeskyPivoted(factors, uplo, Vector{Int64}(piv), rank, tol, info) == cholp
+
+    @test CholeskyPivoted(factors, uplo, piv, Int32(rank), tol, info) == cholp
+    @test CholeskyPivoted(factors, uplo, piv, Int64(rank), tol, info) == cholp
+
+    @test CholeskyPivoted(factors, uplo, piv, rank, tol, Int32(info)) == cholp
+    @test CholeskyPivoted(factors, uplo, piv, rank, tol, Int64(info)) == cholp
+
+end
+
 end # module TestCholesky


### PR DESCRIPTION
As discussed on slack with @nalimilan and @mbauman, this loosens the constructors for `Cholesky` to allow `Integer` `info` arguments, which are converted to `BlasInt`.

Fixes dmbates/MixedModels.jl#143 (which is caused by `BlasInt=Int32` on builds with non-ILP64 BLAS, like arch linux).