### PR TITLE
Prepend a version number too in source tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,9 +515,14 @@ endif
 
 # Make tarball with only Julia code
 light-source-dist: light-source-dist.tmp
-	# The --transform option prepends julia-$(commit-sha)/ or julia-$(version)/ to filenames
-	# (but requires a tar implementation supporting it).
-	tar -cz --no-recursion --transform "s/^/julia-$(JULIA_COMMIT)\//" -T light-source-dist.tmp -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz
+	# Prefix everything with "julia-$(commit-sha)/" or "julia-$(version)/" and then create tarball
+	# To achieve prefixing, we temporarily create a symlink in the source directory that points back
+	# to the source directory.
+	DIRNAME=julia-$(JULIA_COMMIT); \
+	sed -e "s_.*_$$DIRNAME/&_" light-source-dist.tmp > light-source-dist.tmp1; \
+	ln -s . $$DIRNAME || exit 1; \
+	tar -cz --no-recursion -T light-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz; \
+	rm -v $$DIRNAME
 
 source-dist:
 	@echo \'source-dist\' target is deprecated: use \'full-source-dist\' instead.
@@ -531,9 +536,14 @@ full-source-dist: light-source-dist.tmp
 	cp light-source-dist.tmp full-source-dist.tmp
 	-ls deps/srccache/*.tar.gz deps/srccache/*.tar.bz2 deps/srccache/*.tar.xz deps/srccache/*.tgz deps/srccache/*.zip deps/srccache/*.pem >> full-source-dist.tmp
 
-	# Create the tarball. The --transform option prepends julia-$(commit-sha)/ or
-	# julia-$(version)/ to filenames (but requires a tar implementation supporting it).
-	tar -cz --no-recursion --transform "s/^/julia-$(JULIA_COMMIT)\//" -T full-source-dist.tmp -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz
+	# Prefix everything with "julia-$(commit-sha)/" or "julia-$(version)/" and then create tarball
+	# To achieve prefixing, we temporarily create a symlink in the source directory that points back
+	# to the source directory.
+	DIRNAME=julia-$(JULIA_COMMIT); \
+	sed -e "s_.*_$$DIRNAME/&_" full-source-dist.tmp > full-source-dist.tmp1; \
+	ln -s . $$DIRNAME || exit 1; \
+	tar -cz --no-recursion -T full-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz; \
+	rm -v $$DIRNAME
 
 clean: | $(CLEAN_TARGETS)
 	@-$(MAKE) -C $(BUILDROOT)/base clean

--- a/Makefile
+++ b/Makefile
@@ -515,10 +515,9 @@ endif
 
 # Make tarball with only Julia code
 light-source-dist: light-source-dist.tmp
-	# Prefix everything with the current directory name (usually "julia"), then create tarball
-	DIRNAME=$$(basename $$(pwd)); \
-	sed -e "s_.*_$$DIRNAME/&_" light-source-dist.tmp > light-source-dist.tmp1; \
-	cd ../ && tar -cz --no-recursion -T $$DIRNAME/light-source-dist.tmp1 -f $$DIRNAME/julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz
+	# The --transform option prepends julia-$(commit-sha)/ or julia-$(version)/ to filenames
+	# (but requires a tar implementation supporting it).
+	tar -cz --no-recursion --transform "s/^/julia-$(JULIA_COMMIT)\//" -T light-source-dist.tmp -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz
 
 source-dist:
 	@echo \'source-dist\' target is deprecated: use \'full-source-dist\' instead.
@@ -532,10 +531,9 @@ full-source-dist: light-source-dist.tmp
 	cp light-source-dist.tmp full-source-dist.tmp
 	-ls deps/srccache/*.tar.gz deps/srccache/*.tar.bz2 deps/srccache/*.tar.xz deps/srccache/*.tgz deps/srccache/*.zip deps/srccache/*.pem >> full-source-dist.tmp
 
-	# Prefix everything with the current directory name (usually "julia"), then create tarball
-	DIRNAME=$$(basename $$(pwd)); \
-	sed -e "s_.*_$$DIRNAME/&_" full-source-dist.tmp > full-source-dist.tmp1; \
-	cd ../ && tar -cz --no-recursion -T $$DIRNAME/full-source-dist.tmp1 -f $$DIRNAME/julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz
+	# Create the tarball. The --transform option prepends julia-$(commit-sha)/ or
+	# julia-$(version)/ to filenames (but requires a tar implementation supporting it).
+	tar -cz --no-recursion --transform "s/^/julia-$(JULIA_COMMIT)\//" -T full-source-dist.tmp -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz
 
 clean: | $(CLEAN_TARGETS)
 	@-$(MAKE) -C $(BUILDROOT)/base clean

--- a/Makefile
+++ b/Makefile
@@ -518,11 +518,10 @@ light-source-dist: light-source-dist.tmp
 	# Prefix everything with "julia-$(commit-sha)/" or "julia-$(version)/" and then create tarball
 	# To achieve prefixing, we temporarily create a symlink in the source directory that points back
 	# to the source directory.
-	DIRNAME=julia-$(JULIA_COMMIT); \
-	sed -e "s_.*_$$DIRNAME/&_" light-source-dist.tmp > light-source-dist.tmp1; \
-	ln -s . $$DIRNAME || exit; \
-	tar -cz --no-recursion -T light-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz; \
-	rm -v $$DIRNAME
+	sed -e "s_.*_julia-${JULIA_COMMIT}/&_" light-source-dist.tmp > light-source-dist.tmp1
+	ln -s . julia-${JULIA_COMMIT}
+	tar -cz --no-recursion -T light-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz
+	rm julia-${JULIA_COMMIT}
 
 source-dist:
 	@echo \'source-dist\' target is deprecated: use \'full-source-dist\' instead.
@@ -539,11 +538,10 @@ full-source-dist: light-source-dist.tmp
 	# Prefix everything with "julia-$(commit-sha)/" or "julia-$(version)/" and then create tarball
 	# To achieve prefixing, we temporarily create a symlink in the source directory that points back
 	# to the source directory.
-	DIRNAME=julia-$(JULIA_COMMIT); \
-	sed -e "s_.*_$$DIRNAME/&_" full-source-dist.tmp > full-source-dist.tmp1; \
-	ln -s . $$DIRNAME || exit; \
-	tar -cz --no-recursion -T full-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz; \
-	rm -v $$DIRNAME
+	sed -e "s_.*_julia-${JULIA_COMMIT}/&_" full-source-dist.tmp > full-source-dist.tmp1
+	ln -s . julia-${JULIA_COMMIT}
+	tar -cz --no-recursion -T full-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz
+	rm julia-${JULIA_COMMIT}
 
 clean: | $(CLEAN_TARGETS)
 	@-$(MAKE) -C $(BUILDROOT)/base clean

--- a/Makefile
+++ b/Makefile
@@ -520,7 +520,7 @@ light-source-dist: light-source-dist.tmp
 	# to the source directory.
 	DIRNAME=julia-$(JULIA_COMMIT); \
 	sed -e "s_.*_$$DIRNAME/&_" light-source-dist.tmp > light-source-dist.tmp1; \
-	ln -s . $$DIRNAME || exit 1; \
+	ln -s . $$DIRNAME || exit; \
 	tar -cz --no-recursion -T light-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT).tar.gz; \
 	rm -v $$DIRNAME
 
@@ -541,7 +541,7 @@ full-source-dist: light-source-dist.tmp
 	# to the source directory.
 	DIRNAME=julia-$(JULIA_COMMIT); \
 	sed -e "s_.*_$$DIRNAME/&_" full-source-dist.tmp > full-source-dist.tmp1; \
-	ln -s . $$DIRNAME || exit 1; \
+	ln -s . $$DIRNAME || exit; \
 	tar -cz --no-recursion -T full-source-dist.tmp1 -f julia-$(JULIA_VERSION)_$(JULIA_COMMIT)-full.tar.gz; \
 	rm -v $$DIRNAME
 


### PR DESCRIPTION
Currently the files in _source_ tarballs just have `julia/` prepended to them (e.g. [1.0.1 tarball](https://github.com/JuliaLang/julia/releases/download/v1.0.1/julia-1.0.1.tar.gz)), but I propose including the version number too, i.e. prepend `julia-x.y.z/`.

I switched over to using the `--transform` option of `tar` for modifying the filenames. However, this might not be very portable -- it seems to be that `--transform`/`--xform` is specific to GNU tar. [BSD tar](https://www.freebsd.org/cgi/man.cgi?query=tar&apropos=0&sektion=1&manpath=FreeBSD+11.2-RELEASE+and+Ports&arch=default&format=html) does not appear to have it.. or rather calls a similar option `-s` if I understand correctly.

How important is it to keep these targets cross-platform? I do not have any other idea how to approach this at the moment, other than doing something similar to the original implementation of `cd`-ing up and then renaming or symlinking the directory, or copying files over to temporary directory.