### PR TITLE
Fix hashing of Dates.Time. Fixes #29480

### DIFF
--- a/stdlib/Dates/src/types.jl
+++ b/stdlib/Dates/src/types.jl
@@ -350,6 +350,9 @@ function ==(a::Time, b::Time)
         microsecond(a) == microsecond(b) && nanosecond(a) == nanosecond(b)
 end
 (==)(x::TimeType, y::TimeType) = (===)(promote(x, y)...)
+Base.hash(x::Time, h::UInt) =
+    hash(hour(x), hash(minute(x), hash(second(x),
+        hash(millisecond(x), hash(microsecond(x), hash(nanosecond(x), h))))))
 
 import Base: sleep, Timer, timedwait
 sleep(time::Period) = sleep(toms(time) / 1000)

--- a/stdlib/Dates/test/types.jl
+++ b/stdlib/Dates/test/types.jl
@@ -194,6 +194,10 @@ c = Dates.Time(0)
     @test isfinite(Dates.Date)
     @test isfinite(Dates.DateTime)
     @test isfinite(Dates.Time)
+    @test c == c
+    @test c == (c + Dates.Hour(24))
+    @test hash(c) == hash(c + Dates.Hour(24))
+    @test hash(c + Dates.Nanosecond(10)) == hash(c + Dates.Hour(24) + Dates.Nanosecond(10))
 end
 @testset "Date-DateTime conversion/promotion" begin
     global a, b, c, d


### PR DESCRIPTION
While this changes hash values, it fixes a case where `hash` lacked the correctness property, so can probably be backported?

Picked from #29509