### PR TITLE
Fix copying of documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -7,6 +7,7 @@ SRCDIR           := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
 JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
+DOCBUILDROOT     := $(call cygpath_w,$(BUILDROOT)) # must use cygpath_w since doc build path is directly passed to cross-compiled executable
 
 .PHONY: help clean cleanall html pdf deps deploy
 
@@ -35,16 +36,16 @@ cleanall: clean
 
 html: deps
 	@echo "Building HTML documentation."
-	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) $(DOCUMENTER_OPTIONS)
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) $(DOCBUILDROOT) $(DOCUMENTER_OPTIONS)
 	@echo "Build finished. The HTML pages are in _build/html."
 
 pdf: deps
 	@echo "Building PDF documentation."
-	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- pdf $(DOCUMENTER_OPTIONS)
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) $(DOCBUILDROOT) -- pdf $(DOCUMENTER_OPTIONS)
 	@echo "Build finished."
 
 # The deploy target should only be called in Travis builds
 deploy: deps
 	@echo "Deploying HTML documentation."
-	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) -- deploy $(DOCUMENTER_OPTIONS)
+	$(JULIA_EXECUTABLE) --color=yes $(call cygpath_w,$(SRCDIR)/make.jl) $(DOCBUILDROOT) -- deploy $(DOCUMENTER_OPTIONS)
 	@echo "Build & deploy of docs finished."

--- a/doc/make.jl
+++ b/doc/make.jl
@@ -1,4 +1,5 @@
 # Install dependencies needed to build the documentation.
+# must pass first argument to this script which defines where the docs are built to
 empty!(LOAD_PATH)
 push!(LOAD_PATH, @__DIR__, "@stdlib")
 empty!(DEPOT_PATH)
@@ -146,9 +147,10 @@ for stdlib in STDLIB_DOCS
     @eval using $(stdlib.stdlib)
 end
 
+const buildroot = ARGS[1]
 const render_pdf = "pdf" in ARGS
 makedocs(
-    build     = joinpath(@__DIR__, "_build", (render_pdf ? "pdf" : "html"), "en"),
+    build     = joinpath(buildroot, "_build", (render_pdf ? "pdf" : "html"), "en"),
     modules   = [Base, Core, BuildSysImg, [Base.root_module(Base, stdlib.stdlib) for stdlib in STDLIB_DOCS]...],
     clean     = true,
     doctest   = ("doctest=fix" in ARGS) ? (:fix) : ("doctest=true" in ARGS) ? true : false,
@@ -171,7 +173,7 @@ makedocs(
 if "deploy" in ARGS && Sys.ARCH === :x86_64 && Sys.KERNEL === :Linux
     deploydocs(
         repo = "github.com/JuliaLang/julia.git",
-        target = "_build/html/en",
+        target = joinpath(buildroot, "doc", "_build", "html", "en"),
         dirname = "en",
         devurl = "v1.1-dev",
         versions = ["v#.#", "v1.1-dev" => "v1.1-dev"]


### PR DESCRIPTION
For out of tree builds `make -C builddir docs` does not actually correctly build the docs to `builddir/docs` but leaves them in the root julia folder, thus this copy step fails when trying to create a `binary-dist`.

Ideally the  makefiles  for the docs should be fixed to  properly build to the `builddir/docs` folder, instead of requiring this temporary fix. 
