### PR TITLE
special case flatten of AbstractArray

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -909,6 +909,33 @@ length(f::Flatten{Tuple{}}) = 0
     iterate(f, (x[2], x[1]))
 end
 
+@propagate_inbounds function iterate(f::Flatten{<:AbstractArray})
+    it = f.it
+    length(it) == 0 && return nothing
+    idx = firstindex(it)
+    sn = iterate(it[idx])
+    while sn === nothing
+        idx += 1
+        idx <= lastindex(it) || return nothing
+        sn = iterate(it[idx])
+    end
+    elem, s_inner = sn
+    return (elem, (idx, s_inner))
+end
+
+@propagate_inbounds function iterate(f::Flatten{<:AbstractArray}, state)
+    idx, s_inner = state
+    it = f.it
+    sn = iterate(it[idx], s_inner)
+    while sn === nothing
+        idx += 1
+        idx <= lastindex(it) || return nothing
+        sn = iterate(it[idx])
+    end
+    elem, s_inner = sn
+    return (elem, (idx, s_inner))
+end
+
 reverse(f::Flatten) = Flatten(reverse(itr) for itr in reverse(f.it))
 
 """


### PR DESCRIPTION
Adresses [https://github.com/JuliaLang/julia/issues/29762](https://github.com/JuliaLang/julia/issues/29762).

Idea is that we can keep the state bitstype if the outer iterator is stateless.

Well, `AbstractArray` is definitely stateless, so it is OK if we access the same element (which is an iterator) multiple times instead of saving it in the `state` for reuse. Is it guaranteed that `A::AbstractArray` can be iterated over as `firstindex(A), firstindex(A)+1, ... ,lastindex(A)`? 

The problem with `eachindex` is that I currently see no way to generically and type-stably access the first element. I am very open for suggestions on how to use the iterator interface for the outer array.

Before:
```
julia> using BenchmarkTools, Random
julia> Random.seed!(23);
julia> r=[rand(rand(1:10)) for i=1:1000];
julia> @btime collect($(Iterators.flatten(r)));
  149.063 μs (11109 allocations: 475.33 KiB)
```
After:
```
julia> using BenchmarkTools, Random
julia> Random.seed!(23);
julia> r=[rand(rand(1:10)) for i=1:1000];
julia> @btime collect($(Iterators.flatten(r)));
  78.652 μs (13 allocations: 128.58 KiB)
```
