### PR TITLE
Use `require(pkgid, ...)` instead of relative require

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -226,7 +226,11 @@ function exec_options(opts)
     # Load Distributed module only if any of the Distributed options have been specified.
     distributed_mode = (opts.worker == 1) || (opts.nprocs > 0) || (opts.machine_file != C_NULL)
     if distributed_mode
-        Core.eval(Main, :(using Distributed))
+        let Distributed = require(PkgId(UUID((0x8ba89e20_285c_5b6f, 0x9357_94700520ee1b)), "Distributed"))
+            Core.eval(Main, :(const Distributed = $Distributed))
+            Core.eval(Main, :(using .Distributed))
+        end
+
         invokelatest(Main.Distributed.process_opts, opts)
     end
 

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -216,8 +216,6 @@ unlock(s::LibuvStream) = unlock(s.lock)
 rawhandle(stream::LibuvStream) = stream.handle
 unsafe_convert(::Type{Ptr{Cvoid}}, s::Union{LibuvStream, LibuvServer}) = s.handle
 
-const Sockets_mod = Ref{Module}()
-
 function init_stdio(handle::Ptr{Cvoid})
     t = ccall(:jl_uv_handle_type, Int32, (Ptr{Cvoid},), handle)
     if t == UV_FILE
@@ -233,10 +231,8 @@ function init_stdio(handle::Ptr{Cvoid})
     elseif t == UV_TTY
         return TTY(handle, StatusOpen)
     elseif t == UV_TCP
-        if !isassigned(Sockets_mod)
-            Sockets_mod[] = Base.require(Base, :Sockets)
-        end
-        return Sockets_mod[].TCPSocket(handle, StatusOpen)
+        Sockets = require(PkgId(UUID((0x6462fe0b_24de_5631, 0x8697_dd941f90decc)), "Sockets"))
+        return Sockets.TCPSocket(handle, StatusOpen)
     elseif t == UV_NAMED_PIPE
         return PipeEndpoint(handle, StatusOpen)
     else

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -433,6 +433,21 @@ end
     end
 end
 
+@static if !Sys.iswindows()
+    # Issue #29234
+    @testset "TCPSocket stdin" begin
+        let addr = Sockets.InetAddr(ip"127.0.0.1", 4455)
+            srv = listen(addr)
+            s = connect(addr)
+
+            @test success(pipeline(`$(Base.julia_cmd()) -e "exit()" -i`, stdin=s))
+
+            close(s)
+            close(srv)
+        end
+    end
+end
+
 # Issues #18818 and #24169
 mutable struct RLimit
     cur::Int64


### PR DESCRIPTION
Should fix #29234 and supersedes #29252