### PR TITLE
Clarify `Base.getproperty` usage in docs

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1868,6 +1868,29 @@ typeassert
 
 The syntax `a.b` calls `getproperty(a, :b)`.
 
+For example, to run custom code to evaluate
+a property by a specific symbol name, you can
+override this method and create a specific
+if-branch as shown below.
+
+```
+struct MyType
+  x
+end
+
+function Base.getproperty(obj::MyType, sym::Symbol)
+    if sym == :special
+        obj.x + 1
+    else
+        # fallback to getfield
+        getfield(obj, sym)
+    end
+end
+
+obj = MyType(1)
+obj.special
+```
+
 See also [`propertynames`](@ref Base.propertynames) and
 [`setproperty!`](@ref Base.setproperty!).
 """

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1875,11 +1875,11 @@ if-branch as shown below.
 
 ```
 struct MyType
-  x
+    x
 end
 
 function Base.getproperty(obj::MyType, sym::Symbol)
-    if sym == :special
+    if sym === :special
         obj.x + 1
     else
         # fallback to getfield

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1868,27 +1868,27 @@ typeassert
 
 The syntax `a.b` calls `getproperty(a, :b)`.
 
-For example, to run custom code to evaluate
-a property by a specific symbol name, you can
-override this method and create a specific
-if-branch as shown below.
+# Examples
+```jldoctest
+julia> struct MyType
+           x
+       end
 
-```
-struct MyType
-    x
-end
+julia> function Base.getproperty(obj::MyType, sym::Symbol)
+           if sym === :special
+               return obj.x + 1
+           else # fallback to getfield
+               return getfield(obj, sym)
+           end
+       end
 
-function Base.getproperty(obj::MyType, sym::Symbol)
-    if sym === :special
-        obj.x + 1
-    else
-        # fallback to getfield
-        getfield(obj, sym)
-    end
-end
+julia> obj = MyType(1);
 
-obj = MyType(1)
-obj.special
+julia> obj.special
+2
+
+julia> obj.x
+1
 ```
 
 See also [`propertynames`](@ref Base.propertynames) and


### PR DESCRIPTION
This stumped me for a bit (https://discourse.julialang.org/t/help-with-base-getproperty-syntax/16628) and also at least one other long-time user (https://discourse.julialang.org/t/examples-of-getproperty-setproperty-usage/15368).  It could be helpful to others to make a simple example like this in the docs based on @KristofferC 's tip from discourse.