### PR TITLE
deps: add pcre mirror link

### DIFF
--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -5,7 +5,8 @@ PCRE_CFLAGS := -O3
 PCRE_LDFLAGS := $(RPATH_ESCAPED_ORIGIN)
 
 $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2: | $(SRCCACHE)
-	$(JLDOWNLOAD) $@ https://ftp.pcre.org/pub/pcre/pcre2-$(PCRE_VER).tar.bz2
+	$(JLDOWNLOAD) $@ https://ftp.pcre.org/pub/pcre/pcre2-$(PCRE_VER).tar.bz2 || \
+	    $(JLDOWNLOAD) $@ https://sourceforge.net/projects/pcre/files/pcre2/$(PCRE_VER)/pcre2-$(PCRE_VER).tar.bz2/download
 
 $(SRCCACHE)/pcre2-$(PCRE_VER)/source-extracted: $(SRCCACHE)/pcre2-$(PCRE_VER).tar.bz2
 	$(JLCHECKSUM) $<


### PR DESCRIPTION
Since the ftp.pcre.org is down for FreeBSD CI,
I add a mirror link from SourceForge:
- https://sourceforge.net/projects/pcre/files/pcre2/