### PR TITLE
Fix doctest execution in README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -23,7 +23,7 @@ from the root directory. This will build the HTML documentation and output it to
 To run the doctests found in the manual run
 
 ```sh
-$ make -C doc check
+$ make -C doc doctest=true
 ```
 
 from the root directory.


### PR DESCRIPTION
The information on how to run doctests  in `doc/README.md` wasn't correct. I replaced it with what I found in `CONTRIBUTING.md`.