### PR TITLE
Streamline InexactError output

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -268,6 +268,7 @@ struct InexactError <: Exception
     val
     InexactError(f::Symbol, @nospecialize(T), @nospecialize(val)) = (@_noinline_meta; new(f, T, val))
 end
+InexactError(@nospecialize(T), @nospecialize(val)) = InexactError(Symbol(T), T, val)
 struct OverflowError <: Exception
     msg::AbstractString
 end

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -264,11 +264,12 @@ struct TypeError <: Exception
 end
 struct InexactError <: Exception
     func::Symbol
-    T  # Type
     val
-    InexactError(f::Symbol, @nospecialize(T), @nospecialize(val)) = (@_noinline_meta; new(f, T, val))
+    T # optional type
+    InexactError(f::Symbol, @nospecialize(T), @nospecialize(val)) = (@_noinline_meta; new(f, val, T))
+    InexactError(f::Symbol, @nospecialize(val)) = (@_noinline_meta; new(f, val))
 end
-InexactError(@nospecialize(T), @nospecialize(val)) = InexactError(Symbol(T), T, val)
+
 struct OverflowError <: Exception
     msg::AbstractString
 end

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -35,7 +35,7 @@ const ComplexF16  = Complex{Float16}
 Complex{T}(x::Real) where {T<:Real} = Complex{T}(x,0)
 Complex{T}(z::Complex) where {T<:Real} = Complex{T}(real(z),imag(z))
 (::Type{T})(z::Complex) where {T<:Real} =
-    isreal(z) ? T(real(z))::T : throw(InexactError(T, z))
+    isreal(z) ? T(real(z))::T : throw(InexactError(Symbol(T), z))
 
 Complex(z::Complex) = z
 

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -35,7 +35,7 @@ const ComplexF16  = Complex{Float16}
 Complex{T}(x::Real) where {T<:Real} = Complex{T}(x,0)
 Complex{T}(z::Complex) where {T<:Real} = Complex{T}(real(z),imag(z))
 (::Type{T})(z::Complex) where {T<:Real} =
-    isreal(z) ? T(real(z))::T : throw(InexactError(Symbol(string(T)), T, z))
+    isreal(z) ? T(real(z))::T : throw(InexactError(T, z))
 
 Complex(z::Complex) = z
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -948,10 +948,10 @@ Stacktrace:
 BoundsError
 
 """
-    InexactError(T, val)
+    InexactError(name::Symbol, val)
     InexactError(name::Symbol, T, val)
 
-Cannot exactly convert `val` to type `T` in its constructor or in a method of function `name`.
+Cannot exactly convert `val` to type `T` in a method of function `name`.
 
 # Examples
 ```jldoctest

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -948,14 +948,15 @@ Stacktrace:
 BoundsError
 
 """
+    InexactError(T, val)
     InexactError(name::Symbol, T, val)
 
-Cannot exactly convert `val` to type `T` in a method of function `name`.
+Cannot exactly convert `val` to type `T` in its constructor or in a method of function `name`.
 
 # Examples
 ```jldoctest
 julia> convert(Float64, 1+2im)
-ERROR: InexactError: Float64(Float64, 1 + 2im)
+ERROR: InexactError: Float64(1 + 2im)
 Stacktrace:
 [...]
 ```

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -151,11 +151,9 @@ function showerror(io::IO, ex::UndefVarError)
 end
 
 function showerror(io::IO, ex::InexactError)
-    f = string(ex.func)
-    t = string(ex.T)
-    print(io, "InexactError: ", f, '(')
-    if f != t
-        print(io, t, ", ")
+    print(io, "InexactError: ", ex.func, '(')
+    if isdefined(ex, :T)
+        print(io, ex.T, ", ")
     end
     print(io, ex.val, ')')
 end

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -151,7 +151,13 @@ function showerror(io::IO, ex::UndefVarError)
 end
 
 function showerror(io::IO, ex::InexactError)
-    print(io, "InexactError: ", ex.func, '(', ex.T, ", ", ex.val, ')')
+    f = string(ex.func)
+    t = string(ex.T)
+    print(io, "InexactError: ", f, '(')
+    if f != t
+        print(io, t, ", ")
+    end
+    print(io, ex.val, ')')
 end
 
 typesof(args...) = Tuple{Any[ Core.Typeof(a) for a in args ]...}

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -115,7 +115,7 @@ julia> convert(Int, 3.0)
 3
 
 julia> convert(Int, 3.5)
-ERROR: InexactError: Int64(Int64, 3.5)
+ERROR: InexactError: Int64(3.5)
 Stacktrace:
 [...]
 ```

--- a/base/float.jl
+++ b/base/float.jl
@@ -70,7 +70,7 @@ for t1 in (Float32, Float64)
 end
 (::Type{T})(x::Float16) where {T<:Integer} = T(Float32(x))
 
-Bool(x::Real) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, Bool, x))
+Bool(x::Real) = x==0 ? false : x==1 ? true : throw(InexactError(Bool, x))
 
 promote_rule(::Type{Float64}, ::Type{UInt128}) = Float64
 promote_rule(::Type{Float64}, ::Type{Int128}) = Float64
@@ -259,7 +259,7 @@ AbstractFloat(x::UInt32)  = Float64(x)
 AbstractFloat(x::UInt64)  = Float64(x) # LOSSY
 AbstractFloat(x::UInt128) = Float64(x) # LOSSY
 
-Bool(x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, Bool, x))
+Bool(x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError(Bool, x))
 
 """
     float(x)

--- a/base/float.jl
+++ b/base/float.jl
@@ -70,7 +70,7 @@ for t1 in (Float32, Float64)
 end
 (::Type{T})(x::Float16) where {T<:Integer} = T(Float32(x))
 
-Bool(x::Real) = x==0 ? false : x==1 ? true : throw(InexactError(Bool, x))
+Bool(x::Real) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, x))
 
 promote_rule(::Type{Float64}, ::Type{UInt128}) = Float64
 promote_rule(::Type{Float64}, ::Type{Int128}) = Float64
@@ -259,7 +259,7 @@ AbstractFloat(x::UInt32)  = Float64(x)
 AbstractFloat(x::UInt64)  = Float64(x) # LOSSY
 AbstractFloat(x::UInt128) = Float64(x) # LOSSY
 
-Bool(x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError(Bool, x))
+Bool(x::Float16) = x==0 ? false : x==1 ? true : throw(InexactError(:Bool, x))
 
 """
     float(x)
@@ -676,7 +676,7 @@ for Ti in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UIn
                     if ($(Tf(typemin(Ti))) <= x <= $(Tf(typemax(Ti)))) && (round(x, RoundToZero) == x)
                         return unsafe_trunc($Ti,x)
                     else
-                        throw(InexactError($(Expr(:quote,Ti.name.name)), $Ti, x))
+                        throw(InexactError($(Expr(:quote,Ti.name.name)), x))
                     end
                 end
             end
@@ -697,7 +697,7 @@ for Ti in (Int8, Int16, Int32, Int64, Int128, UInt8, UInt16, UInt32, UInt64, UIn
                     if ($(Tf(typemin(Ti))) <= x < $(Tf(typemax(Ti)))) && (round(x, RoundToZero) == x)
                         return unsafe_trunc($Ti,x)
                     else
-                        throw(InexactError($(Expr(:quote,Ti.name.name)), $Ti, x))
+                        throw(InexactError($(Expr(:quote,Ti.name.name)), x))
                     end
                 end
             end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -270,7 +270,7 @@ BigInt(x::Bool) = BigInt(UInt(x))
 unsafe_trunc(::Type{BigInt}, x::Union{Float32,Float64}) = MPZ.set_d(x)
 
 function BigInt(x::Union{Float32,Float64})
-    isinteger(x) || throw(InexactError(BigInt, x))
+    isinteger(x) || throw(InexactError(:BigInt, x))
     unsafe_trunc(BigInt,x)
 end
 
@@ -321,7 +321,7 @@ function (::Type{T})(x::BigInt) where T<:Base.BitUnsigned
     if sizeof(T) < sizeof(Limb)
         convert(T, convert(Limb,x))
     else
-        0 <= x.size <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(T, x))
+        0 <= x.size <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(Symbol(T), x))
         x % T
     end
 end
@@ -332,9 +332,9 @@ function (::Type{T})(x::BigInt) where T<:Base.BitSigned
         SLimb = typeof(Signed(one(Limb)))
         convert(T, convert(SLimb, x))
     else
-        0 <= n <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(T, x))
+        0 <= n <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(Symbol(T), x))
         y = x % T
-        ispos(x) ⊻ (y > 0) && throw(InexactError(T, x)) # catch overflow
+        ispos(x) ⊻ (y > 0) && throw(InexactError(Symbol(T), x)) # catch overflow
         y
     end
 end

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -270,7 +270,7 @@ BigInt(x::Bool) = BigInt(UInt(x))
 unsafe_trunc(::Type{BigInt}, x::Union{Float32,Float64}) = MPZ.set_d(x)
 
 function BigInt(x::Union{Float32,Float64})
-    isinteger(x) || throw(InexactError(:BigInt, BigInt, x))
+    isinteger(x) || throw(InexactError(BigInt, x))
     unsafe_trunc(BigInt,x)
 end
 
@@ -321,7 +321,7 @@ function (::Type{T})(x::BigInt) where T<:Base.BitUnsigned
     if sizeof(T) < sizeof(Limb)
         convert(T, convert(Limb,x))
     else
-        0 <= x.size <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(Symbol(string(T)), T, x))
+        0 <= x.size <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(T, x))
         x % T
     end
 end
@@ -332,9 +332,9 @@ function (::Type{T})(x::BigInt) where T<:Base.BitSigned
         SLimb = typeof(Signed(one(Limb)))
         convert(T, convert(SLimb, x))
     else
-        0 <= n <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(Symbol(string(T)), T, x))
+        0 <= n <= cld(sizeof(T),sizeof(Limb)) || throw(InexactError(T, x))
         y = x % T
-        ispos(x) ⊻ (y > 0) && throw(InexactError(Symbol(string(T)), T, x)) # catch overflow
+        ispos(x) ⊻ (y > 0) && throw(InexactError(T, x)) # catch overflow
         y
     end
 end

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -265,15 +265,15 @@ round(::Type{Integer}, x::BigFloat) = round(BigInt, x)
 function Bool(x::BigFloat)
     iszero(x) && return false
     isone(x) && return true
-    throw(InexactError(Bool, x))
+    throw(InexactError(:Bool, x))
 end
 function BigInt(x::BigFloat)
-    isinteger(x) || throw(InexactError(BigInt, x))
+    isinteger(x) || throw(InexactError(:BigInt, x))
     trunc(BigInt, x)
 end
 
 function (::Type{T})(x::BigFloat) where T<:Integer
-    isinteger(x) || throw(InexactError(T, x))
+    isinteger(x) || throw(InexactError(Symbol(T), x))
     trunc(T,x)
 end
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -265,15 +265,15 @@ round(::Type{Integer}, x::BigFloat) = round(BigInt, x)
 function Bool(x::BigFloat)
     iszero(x) && return false
     isone(x) && return true
-    throw(InexactError(:Bool, Bool, x))
+    throw(InexactError(Bool, x))
 end
 function BigInt(x::BigFloat)
-    isinteger(x) || throw(InexactError(:BigInt, BigInt, x))
+    isinteger(x) || throw(InexactError(BigInt, x))
     trunc(BigInt, x)
 end
 
 function (::Type{T})(x::BigFloat) where T<:Integer
-    isinteger(x) || throw(InexactError(Symbol(string(T)), T, x))
+    isinteger(x) || throw(InexactError(T, x))
     trunc(T,x)
 end
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -81,9 +81,9 @@ Rational{T}(x::Integer) where {T<:Integer} = Rational{T}(convert(T,x), convert(T
 Rational(x::Rational) = x
 
 Bool(x::Rational) = x==0 ? false : x==1 ? true :
-    throw(InexactError(Bool, x)) # to resolve ambiguity
+    throw(InexactError(:Bool, x)) # to resolve ambiguity
 (::Type{T})(x::Rational) where {T<:Integer} = (isinteger(x) ? convert(T, x.num) :
-    throw(InexactError(T, x)))
+    throw(InexactError(Symbol(T), x)))
 
 AbstractFloat(x::Rational) = float(x.num)/float(x.den)
 function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
@@ -93,7 +93,7 @@ end
 
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)
-    x == convert(typeof(x), r) || throw(InexactError(Rational{T}, x))
+    x == convert(typeof(x), r) || throw(InexactError(Symbol(Rational{T}), x))
     r
 end
 Rational(x::Float64) = Rational{Int64}(x)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -81,9 +81,9 @@ Rational{T}(x::Integer) where {T<:Integer} = Rational{T}(convert(T,x), convert(T
 Rational(x::Rational) = x
 
 Bool(x::Rational) = x==0 ? false : x==1 ? true :
-    throw(InexactError(:Bool, Bool, x)) # to resolve ambiguity
+    throw(InexactError(Bool, x)) # to resolve ambiguity
 (::Type{T})(x::Rational) where {T<:Integer} = (isinteger(x) ? convert(T, x.num) :
-    throw(InexactError(Symbol(string(T)), T, x)))
+    throw(InexactError(T, x)))
 
 AbstractFloat(x::Rational) = float(x.num)/float(x.den)
 function (::Type{T})(x::Rational{S}) where T<:AbstractFloat where S
@@ -93,7 +93,7 @@ end
 
 function Rational{T}(x::AbstractFloat) where T<:Integer
     r = rationalize(T, x, tol=0)
-    x == convert(typeof(x), r) || throw(InexactError(:Rational, Rational{T}, x))
+    x == convert(typeof(x), r) || throw(InexactError(Rational{T}, x))
     r
 end
 Rational(x::Float64) = Rational{Int64}(x)

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -300,7 +300,7 @@ julia> Point{Int64}(1, 2) ## explicit T ##
 Point{Int64}(1, 2)
 
 julia> Point{Int64}(1.0,2.5) ## explicit T ##
-ERROR: InexactError: Int64(Int64, 2.5)
+ERROR: InexactError: Int64(2.5)
 Stacktrace:
 [...]
 

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -432,12 +432,12 @@ julia> Int8(127.0)
 127
 
 julia> Int8(3.14)
-ERROR: InexactError: Int8(Int8, 3.14)
+ERROR: InexactError: Int8(3.14)
 Stacktrace:
 [...]
 
 julia> Int8(128.0)
-ERROR: InexactError: Int8(Int8, 128.0)
+ERROR: InexactError: Int8(128.0)
 Stacktrace:
 [...]
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -344,7 +344,7 @@ must be convertible to `Int`:
 
 ```jldoctest footype
 julia> Foo((), 23.5, 1)
-ERROR: InexactError: Int64(Int64, 23.5)
+ERROR: InexactError: Int64(23.5)
 Stacktrace:
 [...]
 ```

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -171,7 +171,7 @@ julia> A = [1 2; 2 50]
  2  50
 
 julia> cholesky!(A)
-ERROR: InexactError: Int64(Int64, 6.782329983125268)
+ERROR: InexactError: Int64(6.782329983125268)
 Stacktrace:
 [...]
 ```

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -78,7 +78,7 @@ julia> iA = [4 3; 6 3]
  6  3
 
 julia> lu!(iA)
-ERROR: InexactError: Int64(Int64, 0.6666666666666666)
+ERROR: InexactError: Int64(0.6666666666666666)
 Stacktrace:
 [...]
 ```

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -277,7 +277,7 @@ julia> a = [1 2; 3 4]
  3  4
 
 julia> qr!(a)
-ERROR: InexactError: Int64(Int64, -3.1622776601683795)
+ERROR: InexactError: Int64(-3.1622776601683795)
 Stacktrace:
 [...]
 ```

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1154,7 +1154,7 @@ end
     @test Base.OneTo{Int32}(1:2) === Base.OneTo{Int32}(2)
     @test Base.OneTo(Int32(1):Int32(2)) === Base.OneTo{Int32}(2)
     @test Base.OneTo{Int16}(3.0) === Base.OneTo{Int16}(3)
-    @test_throws InexactError(:Int16, Int16, 3.2) Base.OneTo{Int16}(3.2)
+    @test_throws InexactError Base.OneTo{Int16}(3.2)
 end
 
 @testset "range of other types" begin


### PR DESCRIPTION
- Added a two argument convenient constructor of `InexactError(T, val)` that reuses the provided `T` as a `name` symbol.
- If the string representation of `name` equals that of `T`, as is the case when using the newly added constructor, the error output is adjusted to omit the redundant information. Fixes: https://github.com/JuliaLang/julia/issues/29766

This might still be confusing to users, but I'm not sure if this needs to be fixed:
```julia
julia> Int8(127.3)
ERROR: InexactError: Int8(127.3)
Stacktrace:
 [1] Int8(::Float64) at ./float.jl:679
 [2] top-level scope at none:0

julia> Int8(129)
ERROR: InexactError: trunc(Int8, 129)
Stacktrace:
 [1] throw_inexacterror(::Symbol, ::Any, ::Int64) at ./boot.jl:567
 [2] checked_trunc_sint at ./boot.jl:589 [inlined]
 [3] toInt8 at ./boot.jl:604 [inlined]
 [4] Int8(::Int64) at ./boot.jl:714
 [5] top-level scope at none:0
```
