### PR TITLE
adding _small_enough for diagonal so that fill! works

### DIFF
--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -138,7 +138,7 @@ fillstored!(A::Bidiagonal, x) = (fill!(A.dv, x); fill!(A.ev, x); A)
 fillstored!(A::Tridiagonal, x) = (fill!(A.dl, x); fill!(A.d, x); fill!(A.du, x); A)
 fillstored!(A::SymTridiagonal, x) = (fill!(A.dv, x); fill!(A.ev, x); A)
 
-_small_enough(A::Bidiagonal) = size(A, 1) <= 1
+_small_enough(A::Union{Diagonal, Bidiagonal}) = size(A, 1) <= 1
 _small_enough(A::Tridiagonal) = size(A, 1) <= 2
 _small_enough(A::SymTridiagonal) = size(A, 1) <= 2
 

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -346,7 +346,7 @@ using LinearAlgebra: fillstored!, UnitLowerTriangular
         sparse(rand(3)),
         # LowerTriangular(randn(3,3)), # AbstractTriangular fill! deprecated, see below
         # UpperTriangular(randn(3,3)) # AbstractTriangular fill! deprecated, see below
-        ]
+        Diagonal(rand(3))]
         for A in exotic_arrays
             @test iszero(fill!(A, 0))
         end
@@ -363,13 +363,15 @@ using LinearAlgebra: fillstored!, UnitLowerTriangular
         val = randn()
         b = Bidiagonal(randn(1,1), :U)
         st = SymTridiagonal(randn(1,1))
-        for x in (b, st)
+        d = Diagonal(rand(1))
+        for x in (b, st, d)
             @test Array(fill!(x, val)) == fill!(Array(x), val)
         end
         b = Bidiagonal(randn(2,2), :U)
         st = SymTridiagonal(randn(3), randn(2))
         t = Tridiagonal(randn(3,3))
-        for x in (b, t, st)
+        d = Diagonal(rand(3))
+        for x in (b, t, st, d)
             @test_throws ArgumentError fill!(x, val)
             @test Array(fill!(x, 0)) == fill!(Array(x), 0)
         end

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -342,17 +342,19 @@ using LinearAlgebra: fillstored!, UnitLowerTriangular
         Bidiagonal(randn(3), randn(2), rand([:U,:L])),
         SymTridiagonal(randn(3), randn(2)),
         sparse(randn(3,4)),
-        # Diagonal(randn(5)), # Diagonal fill! deprecated, see below
+        Diagonal(randn(5)),
         sparse(rand(3)),
         # LowerTriangular(randn(3,3)), # AbstractTriangular fill! deprecated, see below
         # UpperTriangular(randn(3,3)) # AbstractTriangular fill! deprecated, see below
-        Diagonal(rand(3))]
+        ]
         for A in exotic_arrays
             @test iszero(fill!(A, 0))
         end
-        # Diagonal and AbstractTriangular fill! were defined as fillstored!,
-        # not matching the general behavior of fill!, and so have been deprecated.
-        # In a future dev cycle, these fill! methods should probably be reintroduced
+
+        # Diagonal fill! is no longer deprecated. See #29780
+        # AbstractTriangular fill! was defined as fillstored!,
+        # not matching the general behavior of fill!, and so it has been deprecated.
+        # In a future dev cycle, this fill! methods should probably be reintroduced
         # with behavior matching that of fill! for other structured matrix types.
         # In the interim, equivalently test fillstored! below
         @test iszero(fillstored!(Diagonal(fill(1, 3)), 0))


### PR DESCRIPTION
`_small_enough` wasn't defined for `Diagonal` so `fill!(::Diagonal, x)` returns a method error even if the diagonal matrix is small enough.

2 small questions: should the fill and fillstored tests be in test/special.jl (instead of bidiag.jl) since that is where they are defined? And should fillstored be exported by LinearAlgebra?