### PR TITLE
Reduce allocation in flatten

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -906,7 +906,13 @@ length(f::Flatten{Tuple{}}) = 0
     end
     x = (state === () ? iterate(f.it) : iterate(f.it, state[1]))
     x === nothing && return nothing
-    iterate(f, (x[2], x[1]))
+    y = iterate(x[1])
+    while y === nothing
+         x = iterate(f.it, x[2])
+         x === nothing && return nothing
+         y = iterate(x[1])
+    end
+    return y[1], (x[2], x[1], y[2])
 end
 
 reverse(f::Flatten) = Flatten(reverse(itr) for itr in reverse(f.it))


### PR DESCRIPTION
Fix #29762.

Before 
```
z = rand(50)
fl = flatten([z for i in 1:10000])
@btime sum(fl)
  11.299 ms (1000001 allocations: 30.52 MiB)
```
After
```
julia> @btime sum(fl)
  791.038 μs (7 allocations: 128 bytes)
259558.6656132105
```