### PR TITLE
clarify pinv documentation

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -1224,8 +1224,8 @@ factorize(A::Transpose) = transpose(factorize(parent(A)))
 Computes the Moore-Penrose pseudoinverse.
 
 For matrices `M` with floating point elements, it is convenient to compute
-the pseudoinverse by inverting only singular values above a given threshold,
-`tol`.
+the pseudoinverse by inverting only singular values greater than
+`tol * maximum(svdvals(M))`.
 
 The optimal choice of `tol` varies both with the value of `M` and the intended application
 of the pseudoinverse. The default value of `tol` is


### PR DESCRIPTION
The `pinv` documentation falsely implied that it discarded singular values `σ ≤ tol`, when in fact it discards `σ ≤ tol max(σ)`.  This PR corrects the docstring.

(`σ ≤ tol max(σ)` is a good criterion!  `tol` should be a dimensionless quantity that doesn't depend on the overall scaling/units of the matrix.  I was relieved when I checked the source code and verified that `tol` was dimensionless.)