### PR TITLE
Replace trivial uses of rethrow(exc) with rethrow()

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -354,7 +354,7 @@ function isassigned(a::AbstractArray, i::Integer...)
         if isa(e, BoundsError) || isa(e, UndefRefError)
             return false
         else
-            rethrow(e)
+            rethrow()
         end
     end
 end

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -402,7 +402,7 @@ function filter(f, d::AbstractDict)
                 end
             end
         else
-            rethrow(e)
+            rethrow()
         end
     end
     return df
@@ -550,12 +550,12 @@ end
 function IdDict(kv)
     try
         dict_with_eltype((K, V) -> IdDict{K, V}, kv, eltype(kv))
-    catch e
+    catch
         if !applicable(iterate, kv) || !all(x->isa(x,Union{Tuple,Pair}),kv)
             throw(ArgumentError(
                 "IdDict(kv): kv needs to be an iterator of tuples or pairs"))
         else
-            rethrow(e)
+            rethrow()
         end
     end
 end

--- a/base/asyncmap.jl
+++ b/base/asyncmap.jl
@@ -167,7 +167,7 @@ function maptwice(wrapped_f, chnl, worker_tasks, c...)
             # in asyncrun due to a closed channel.
             asyncrun_excp = ex
         else
-            rethrow(ex)
+            rethrow()
         end
     end
 

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -270,9 +270,9 @@ function put_unbuffered(c::Channel, v)
 
         try
             wait()
-        catch ex
+        catch
             filter!(x->x!=current_task(), c.putters)
-            rethrow(ex)
+            rethrow()
         end
     end
     taker = popfirst!(c.takers)
@@ -329,9 +329,9 @@ function take_unbuffered(c::Channel{T}) where T
         else
             return wait()::T
         end
-    catch ex
+    catch
         filter!(x->x!=current_task(), c.takers)
-        rethrow(ex)
+        rethrow()
     end
 end
 
@@ -389,7 +389,7 @@ function iterate(c::Channel, state=nothing)
         if isa(e, InvalidStateException) && e.state==:closed
             return nothing
         else
-            rethrow(e)
+            rethrow()
         end
     end
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -122,9 +122,9 @@ function eval_user_input(@nospecialize(ast), show_value::Bool)
                     end
                     try
                         invokelatest(display, value)
-                    catch err
+                    catch
                         println(stderr, "Evaluation succeeded, but an error occurred while showing value of type ", typeof(value), ":")
-                        rethrow(err)
+                        rethrow()
                     end
                     println()
                 end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -315,7 +315,7 @@ function _const_sizeof(@nospecialize(x))
         # Might return
         # "argument is an abstract type; size is indeterminate" or
         # "type does not have a fixed size"
-        isa(ex, ErrorException) || rethrow(ex)
+        isa(ex, ErrorException) || rethrow()
         return Int
     end
     return Const(size)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -127,11 +127,11 @@ Dict(ps::Pair...)                  = Dict(ps)
 function Dict(kv)
     try
         dict_with_eltype((K, V) -> Dict{K, V}, kv, eltype(kv))
-    catch e
+    catch
         if !isiterable(typeof(kv)) || !all(x->isa(x,Union{Tuple,Pair}),kv)
             throw(ArgumentError("Dict(kv): kv needs to be an iterator of tuples or pairs"))
         else
-            rethrow(e)
+            rethrow()
         end
     end
 end

--- a/base/error.jl
+++ b/base/error.jl
@@ -226,11 +226,11 @@ function retry(f::Function;  delays=ExponentialBackOff(), check=nothing)
             try
                 return f(args...; kwargs...)
             catch e
-                y === nothing && rethrow(e)
+                y === nothing && rethrow()
                 if check !== nothing
                     result = check(state, e)
                     state, retry_or_not = length(result) == 2 ? result : (state, result)
-                    retry_or_not || rethrow(e)
+                    retry_or_not || rethrow()
                 end
             end
             sleep(delay)

--- a/base/event.jl
+++ b/base/event.jl
@@ -185,9 +185,9 @@ end
 function try_yieldto(undo, reftask::Ref{Task})
     try
         ccall(:jl_switchto, Cvoid, (Any,), reftask)
-    catch e
+    catch
         undo(reftask[])
-        rethrow(e)
+        rethrow()
     end
     ct = current_task()
     exc = ct.exception
@@ -315,7 +315,7 @@ function AsyncCondition(cb::Function)
                 wait(async)
                 true
             catch exc # ignore possible exception on close()
-                isa(exc, EOFError) || rethrow(exc)
+                isa(exc, EOFError) || rethrow()
             end
             success && cb(async)
         end
@@ -469,7 +469,7 @@ function Timer(cb::Function, timeout::Real; interval::Real = 0.0)
                 wait(t)
                 true
             catch exc # ignore possible exception on close()
-                isa(exc, EOFError) || rethrow(exc)
+                isa(exc, EOFError) || rethrow()
                 false
             end
             success && cb(t)

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -100,7 +100,7 @@ end
 function current_project()
     dir = try pwd()
     catch err
-        err isa IOError || rethrow(err)
+        err isa IOError || rethrow()
         return nothing
     end
     return current_project(dir)

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1135,7 +1135,7 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
             try
                 Base.include(Base.__toplevel__, $(repr(abspath(input))))
             catch ex
-                Base.precompilableerror(ex) || Base.rethrow(ex)
+                Base.precompilableerror(ex) || Base.rethrow()
                 Base.@debug "Aborting `createexprcache'" exception=(Base.ErrorException("Declaration of __precompile__(false) not allowed"), Base.catch_backtrace())
                 Base.exit(125) # we define status = 125 means PrecompileableError
             end\0""")
@@ -1145,10 +1145,10 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
         end
         write(in, "ccall(:jl_set_module_uuid, Cvoid, (Any, NTuple{2, UInt64}), Base.__toplevel__, (0, 0))\0")
         close(in)
-    catch ex
+    catch
         close(in)
         process_running(io) && Timer(t -> kill(io), 5.0) # wait a short time before killing the process to give it a chance to clean up on its own first
-        rethrow(ex)
+        rethrow()
     end
     return io
 end

--- a/base/process.jl
+++ b/base/process.jl
@@ -615,9 +615,9 @@ function open(f::Function, cmds::AbstractCmd, args...)
     P = open(cmds, args...)
     ret = try
         f(P)
-    catch e
+    catch
         kill(P)
-        rethrow(e)
+        rethrow()
     finally
         close(P.in)
     end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -155,7 +155,7 @@ function rationalize(::Type{T}, x::AbstractFloat, tol::Real) where T<:Integer
             p, pp = np, p
             q, qq = nq, q
         catch e
-            isa(e,InexactError) || isa(e,OverflowError) || rethrow(e)
+            isa(e,InexactError) || isa(e,OverflowError) || rethrow()
             return p // q
         end
 
@@ -180,7 +180,7 @@ function rationalize(::Type{T}, x::AbstractFloat, tol::Real) where T<:Integer
         nq = checked_add(checked_mul(ia,q),qq)
         return np // nq
     catch e
-        isa(e,InexactError) || isa(e,OverflowError) || rethrow(e)
+        isa(e,InexactError) || isa(e,OverflowError) || rethrow()
         return p // q
     end
 end

--- a/base/stream.jl
+++ b/base/stream.jl
@@ -596,15 +596,15 @@ function link_pipe!(read_end::PipeEndpoint, reader_supports_async::Bool,
     try
         try
             open_pipe!(read_end, rd, true, false)
-        catch e
+        catch
             close_pipe_sync(rd)
-            rethrow(e)
+            rethrow()
         end
         read_end.status = StatusOpen
         open_pipe!(write_end, wr, false, true)
-    catch e
+    catch
         close_pipe_sync(wr)
-        rethrow(e)
+        rethrow()
     end
     write_end.status = StatusOpen
     nothing

--- a/base/task.jl
+++ b/base/task.jl
@@ -211,9 +211,9 @@ function sync_end(refs)
     for r in refs
         try
             wait(r)
-        catch ex
+        catch
             if !isa(r, Task) || (isa(r, Task) && !istaskfailed(r))
-                rethrow(ex)
+                rethrow()
             end
         finally
             if isa(r, Task) && istaskfailed(r)
@@ -316,7 +316,7 @@ function task_done_hook(t::Task)
             active_repl_backend.in_eval
             throwto(active_repl_backend.backend_task, e)
         else
-            rethrow(e)
+            rethrow()
         end
     end
 end

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -60,11 +60,11 @@ WeakKeyDict(ps::Pair...)                            = WeakKeyDict{Any,Any}(ps)
 function WeakKeyDict(kv)
     try
         Base.dict_with_eltype((K, V) -> WeakKeyDict{K, V}, kv, eltype(kv))
-    catch e
+    catch
         if !isiterable(typeof(kv)) || !all(x->isa(x,Union{Tuple,Pair}),kv)
             throw(ArgumentError("WeakKeyDict(kv): kv needs to be an iterator of tuples or pairs"))
         else
-            rethrow(e)
+            rethrow()
         end
     end
 end

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -167,9 +167,9 @@ function generate_precompile_statements()
             statement == "precompile(Tuple{typeof(Base.show), Base.IOContext{Base.TTY}, Type{Vararg{Any, N} where N}})" && continue
             try
                 Base.include_string(PrecompileStagingArea, statement)
-            catch ex
+            catch
                 @error "Failed to precompile $statement"
-                rethrow(ex)
+                rethrow()
             end
         end
         print(" $(length(statements)) generated in ")

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -458,7 +458,7 @@ function readdlm_string(sbuff::String, dlm::AbstractChar, T::Type, eol::Abstract
             if isa(ex, TypeError) && (ex.func == :store_cell)
                 T = ex.expected
             else
-                rethrow(ex)
+                rethrow()
             end
             offset_handler = (dims === nothing) ? DLMOffsets(sbuff) : DLMStore(T, dims, has_header, sbuff, auto, eol)
         end
@@ -713,7 +713,7 @@ function dlm_parse(dbuff::String, eol::D, dlm::D, qchar::D, cchar::D,
         end
     catch ex
         if isa(ex, TypeError) && (ex.func == :store_cell)
-            rethrow(ex)
+            rethrow()
         else
             error("at row $(nrows+1), column $col : $ex)")
         end

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -136,7 +136,7 @@ function exec_conn_func(w::Worker)
         f()
     catch e
         w.conn_func = () -> throw(e)
-        rethrow(e)
+        rethrow()
     end
     nothing
 end
@@ -505,9 +505,9 @@ function create_worker(manager, wconfig)
     local r_s, w_s
     try
         (r_s, w_s) = connect(manager, w.id, wconfig)
-    catch e
+    catch
         deregister_worker(w.id)
-        rethrow(e)
+        rethrow()
     end
 
     w = Worker(w.id, r_s, w_s, manager; config=wconfig)

--- a/stdlib/Distributed/src/clusterserialize.jl
+++ b/stdlib/Distributed/src/clusterserialize.jl
@@ -159,7 +159,7 @@ function serialize_global_from_main(s::ClusterSerializer, sym)
             if isa(ex, ErrorException)
                 record_v = false
             else
-                rethrow(ex)
+                rethrow()
             end
         end
     end

--- a/stdlib/Distributed/src/pmap.jl
+++ b/stdlib/Distributed/src/pmap.jl
@@ -93,7 +93,7 @@ pmap(f, c; retry_delays = zeros(3))
 Example: Retry `f` only if the exception is not of type `InexactError`, with exponentially increasing
 delays up to 3 times. Return a `NaN` in place for all `InexactError` occurrences.
 ```julia
-pmap(f, c; on_error = e->(isa(e, InexactError) ? NaN : rethrow(e)), retry_delays = ExponentialBackOff(n = 3))
+pmap(f, c; on_error = e->(isa(e, InexactError) ? NaN : rethrow()), retry_delays = ExponentialBackOff(n = 3))
 ```
 """
 function pmap(f, p::AbstractWorkerPool, c; distributed=true, batch_size=1, on_error=nothing,
@@ -189,7 +189,7 @@ function wrap_batch(f, p, handle_errors)
             if handle_errors
                 return Any[BatchProcessingError(b, e) for b in batch]
             else
-                rethrow(e)
+                rethrow()
             end
         end
     end

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -227,7 +227,7 @@ function message_handler_loop(r_stream::IO, w_stream::IO, incoming::Bool)
         if (myid() == 1) && (wpid > 1)
             if oldstate != W_TERMINATING
                 println(stderr, "Worker $wpid terminated.")
-                rethrow(e)
+                rethrow()
             end
         end
 

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -492,7 +492,7 @@ end
 pmap_args = [
                 (:distributed, [:default, false]),
                 (:batch_size, [:default,2]),
-                (:on_error, [:default, e -> (e.msg == "foobar" ? true : rethrow(e))]),
+                (:on_error, [:default, e -> (e.msg == "foobar" ? true : rethrow())]),
                 (:retry_delays, [:default, fill(0.001, 1000)]),
                 (:retry_check, [:default, (s,e) -> (s,endswith(e.msg,"foobar"))]),
             ]
@@ -552,9 +552,9 @@ function walk_args(i)
 
         try
             results_test(pmap(mapf, data; kwargs...))
-        catch e
+        catch
             println("pmap executing with args : ", kwargs)
-            rethrow(e)
+            rethrow()
         end
 
         return
@@ -662,12 +662,12 @@ if Sys.isunix() # aka have ssh
             w_in_remote = sort(remotecall_fetch(workers, p))
             try
                 @test intersect(new_pids, w_in_remote) == new_pids
-            catch e
+            catch
                 print("p       :     $p\n")
                 print("newpids :     $new_pids\n")
                 print("w_in_remote : $w_in_remote\n")
                 print("intersect   : $(intersect(new_pids, w_in_remote))\n\n\n")
-                rethrow(e)
+                rethrow()
             end
         end
 

--- a/stdlib/FileWatching/src/FileWatching.jl
+++ b/stdlib/FileWatching/src/FileWatching.jl
@@ -517,7 +517,7 @@ function wait(m::FolderMonitor)
                 if ex isa InvalidStateException && ex.state == :closed
                     rethrow(EOFError()) # `wait(::Channel)` throws the wrong exception
                 end
-                rethrow(ex)
+                rethrow()
             end
     end
     if evt isa Pair{String, FileEvent}

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -833,9 +833,9 @@ function rebase!(repo::GitRepo, upstream::AbstractString="", newbase::AbstractSt
                         commit(rbs, sig)
                     end
                     finish(rbs, sig)
-                catch err
+                catch
                     abort(rbs)
-                    rethrow(err)
+                    rethrow()
                 finally
                     close(rbs)
                 end

--- a/stdlib/LibGit2/src/config.jl
+++ b/stdlib/LibGit2/src/config.jl
@@ -17,9 +17,9 @@ function GitConfig(path::AbstractString,
     cfg = GitConfig(cfg_ptr_ptr[])
     try
         addfile(cfg, path, level, repo, force)
-    catch ex
+    catch
         close(cfg)
-        rethrow(ex)
+        rethrow()
     end
     return cfg
 end

--- a/stdlib/LibGit2/src/rebase.jl
+++ b/stdlib/LibGit2/src/rebase.jl
@@ -84,7 +84,7 @@ function commit(rb::GitRebase, sig::GitSignature)
     catch err
         # TODO: return current HEAD instead
         err.code == Error.EAPPLIED && return nothing
-        rethrow(err)
+        rethrow()
     end
     return oid_ptr[]
 end

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -1076,7 +1076,7 @@ mktempdir() do dir
                     if isa(err, LibGit2.Error.GitError) && err.class == LibGit2.Error.Invalid
                         @test false
                     else
-                        rethrow(err)
+                        rethrow()
                     end
                 end
             end

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -156,9 +156,9 @@ function print_response(errio::IO, @nospecialize(val), bt, show_value::Bool, hav
                         else
                             Base.invokelatest(display, specialdisplay, val)
                         end
-                    catch err
+                    catch
                         println(errio, "Error showing value of type ", typeof(val), ":")
-                        rethrow(err)
+                        rethrow()
                     end
                 end
             end

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -246,7 +246,7 @@ function complete_path(path::AbstractString, pos; use_envpath=false)::Completion
                     continue
                 else
                     # We only handle SystemErrors here
-                    rethrow(e)
+                    rethrow()
                 end
             end
 

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -637,9 +637,9 @@ function shm_mmap_array(T, dims, shm_seg_name, mode)
 
     try
         A = _shm_mmap_array(T, dims, shm_seg_name, mode)
-    catch e
+    catch
         print_shmem_limits(prod(dims)*sizeof(T))
-        rethrow(e)
+        rethrow()
 
     finally
         if s !== nothing

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -459,7 +459,7 @@ function get_test_result(ex, source)
         try
             $testret
         catch _e
-            _e isa InterruptException && rethrow(_e)
+            _e isa InterruptException && rethrow()
             Threw(_e, catch_backtrace(), $(QuoteNode(source)))
         end
     end
@@ -536,7 +536,7 @@ macro test_throws(extype, ex)
             Returned($(esc(ex)), nothing, $(QuoteNode(__source__)))
         catch _e
             if $(esc(extype)) != InterruptException && _e isa InterruptException
-                rethrow(_e)
+                rethrow()
             end
             Threw(_e, nothing, $(QuoteNode(__source__)))
         end
@@ -1082,7 +1082,7 @@ function testset_beginend(args, tests, source)
             Random.seed!(GLOBAL_RNG.seed)
             $(esc(tests))
         catch err
-            err isa InterruptException && rethrow(err)
+            err isa InterruptException && rethrow()
             # something in the test block threw an error. Count that as an
             # error in this test set
             record(ts, Error(:nontest_error, :(), err, catch_backtrace(), $(QuoteNode(source))))
@@ -1155,7 +1155,7 @@ function testset_forloop(args, testloop, source)
         try
             $(esc(tests))
         catch err
-            err isa InterruptException && rethrow(err)
+            err isa InterruptException && rethrow()
             # Something in the test block threw an error. Count that as an
             # error in this test set
             record(ts, Error(:nontest_error, :(), err, catch_backtrace(), $(QuoteNode(source))))

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -240,7 +240,7 @@ catch err
     if isa(err, MethodError)
         error("Test correctly returned a MethodError, please change to @test_throws MethodError")
     else
-        rethrow(err)
+        rethrow()
     end
 end
 

--- a/test/file.jl
+++ b/test/file.jl
@@ -238,7 +238,7 @@ close(s)
         open("this file is not expected to exist")
         false
     catch e
-        isa(e, SystemError) || rethrow(e)
+        isa(e, SystemError) || rethrow()
         @test sprint(showerror, e) == "SystemError: opening file \"this file is not expected to exist\": No such file or directory"
         true
     end

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -363,8 +363,8 @@ try
         Base.require(Main, :FooBar2)
         error("\"LoadError: break me\" test failed")
     catch exc
-        isa(exc, ErrorException) || rethrow(exc)
-        occursin("ERROR: LoadError: break me", exc.msg) && rethrow(exc)
+        isa(exc, ErrorException) || rethrow()
+        occursin("ERROR: LoadError: break me", exc.msg) && rethrow()
     end
 
     # Test transitive dependency for #21266

--- a/test/read.jl
+++ b/test/read.jl
@@ -56,7 +56,7 @@ function run_test_server(srv, text)
             catch e
                 if !(isa(e, Base.IOError) && e.code == Base.UV_EPIPE)
                     if !(isa(e, Base.IOError) && e.code == Base.UV_ECONNRESET)
-                        rethrow(e)
+                        rethrow()
                     end
                 end
             finally

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,7 +126,7 @@ cd(dirname(@__FILE__)) do
                         end
                     end
                 catch e
-                    isa(e, InterruptException) || rethrow(e)
+                    isa(e, InterruptException) || rethrow()
                 finally
                     REPL.Terminals.raw!(term, false)
                 end
@@ -191,7 +191,7 @@ cd(dirname(@__FILE__)) do
             push!(results, (t, resp))
         end
     catch e
-        isa(e, InterruptException) || rethrow(e)
+        isa(e, InterruptException) || rethrow()
         # If the test suite was merely interrupted, still print the
         # summary, which can be useful to diagnose what's going on
         foreach(task->try; schedule(task, InterruptException(); error=true); catch; end, all_tasks)

--- a/test/stress.jl
+++ b/test/stress.jl
@@ -17,7 +17,7 @@ if Sys.isunix()
                 @test false
             end
         catch ex
-            isa(ex, Base.IOError) || rethrow(ex)
+            isa(ex, Base.IOError) || rethrow()
             @test ex.code in (Base.UV_EMFILE, Base.UV_ENFILE)
         finally
             foreach(close, ps)

--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -224,11 +224,11 @@ function runsubarraytests(@nospecialize(A), I...)
     local S
     try
         S = view(A, I...)
-    catch err
+    catch
         @show typeof(A)
         @show A.indices
         @show I
-        rethrow(err)
+        rethrow()
     end
     test_linear(S, C)
     test_cartesian(S, C)


### PR DESCRIPTION
In all these cases we're merely rethrowing the existing exception, so it
seems simpler and clearer just to use `rethrow()` without arguments.

Now that #28878 is merged this should actually be reliable.