### PR TITLE
inference performance: drop some unnecessary edges, cache more

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -312,7 +312,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
             end
             infstate = sv
             topmost = topmost::InferenceState
-            while !(infstate.parent === topmost.parent)
+            while !(infstate === topmost.parent)
                 if call_result_unused(infstate)
                     # If we won't propagate the result any further (since it's typically unused),
                     # it's OK that we keep and cache the "limited" result in the parents

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -12,6 +12,10 @@ const _REF_NAME = Ref.body.name
 # logic #
 #########
 
+# see if the inference result might affect the final answer
+call_result_unused(frame::InferenceState, pc::LineNum=frame.currpc) =
+    isexpr(frame.src.code[frame.currpc], :call) && isempty(frame.ssavalue_uses[pc])
+
 function abstract_call_gf_by_type(@nospecialize(f), argtypes::Vector{Any}, @nospecialize(atype), sv::InferenceState)
     atype_params = unwrap_unionall(atype).parameters
     ft = unwrap_unionall(atype_params[1]) # TODO: ccall jl_first_argument_datatype here
@@ -95,6 +99,7 @@ function abstract_call_gf_by_type(@nospecialize(f), argtypes::Vector{Any}, @nosp
         rettype === Any && break
     end
     # try constant propagation if only 1 method is inferred to non-Bottom
+    # this is in preparation for inlining, or improving the return result
     if nonbot > 0 && seen == napplicable && !edgecycle && isa(rettype, Type) && sv.params.ipo_constant_propagation
         # if there's a possibility we could constant-propagate a better result
         # (hopefully without doing too much work), try to do that now
@@ -104,6 +109,15 @@ function abstract_call_gf_by_type(@nospecialize(f), argtypes::Vector{Any}, @nosp
             # use the better result, if it's a refinement of rettype
             rettype = const_rettype
         end
+    end
+    if call_result_unused(sv) && !(rettype === Bottom)
+        # We're mainly only here because the optimizer might want this code,
+        # but we ourselves locally don't typically care about it locally
+        # (beyond checking if it always throws).
+        # So avoid adding an edge, since we don't want to bother attempting
+        # to improve our result even if it does change (to always throw),
+        # and avoid keeping track of a more complex result type.
+        rettype = Any
     end
     if !(rettype === Any) # adding a new method couldn't refine (widen) this type
         for edge in edges
@@ -214,6 +228,13 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
             if infstate.linfo.specTypes == sig
                 # avoid widening when detecting self-recursion
                 # TODO: merge call cycle and return right away
+                if call_result_unused(infstate)
+                    # since we don't use the result (typically),
+                    # we have a self-cycle in the call-graph, but not in the inference graph (typically):
+                    # break this edge now (before we record it) by returning early
+                    # (non-typically, this means that we lose the ability to detect a guaranteed StackOverflow in some cases)
+                    return Any, false, nothing
+                end
                 topmost = nothing
                 edgecycle = true
                 break
@@ -281,9 +302,27 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
         if newsig !== sig
             # continue inference, but note that we've limited parameter complexity
             # on this call (to ensure convergence), so that we don't cache this result
+            if call_result_unused(sv)
+                # if we don't (typically) actually care about this result,
+                # don't bother trying to examine some complex abstract signature
+                # since it's very unlikely that we'll try to inline this,
+                # or want make an invoke edge to its calling convention return type.
+                # (non-typically, this means that we lose the ability to detect a guaranteed StackOverflow in some cases)
+                return Any, false, nothing
+            end
             infstate = sv
             topmost = topmost::InferenceState
             while !(infstate.parent === topmost.parent)
+                if call_result_unused(infstate)
+                    # If we won't propagate the result any further (since it's typically unused),
+                    # it's OK that we keep and cache the "limited" result in the parents
+                    # (non-typically, this means that we lose the ability to detect a guaranteed StackOverflow in some cases)
+                    # TODO: we might be able to halt progress much more strongly here,
+                    # since now we know we won't be able to keep anything much that we learned.
+                    # We were mainly only here to compute the calling convention return type,
+                    # but in most situations now, we are unlikely to be able to use that information.
+                    break
+                end
                 infstate.limited = true
                 for infstate_cycle in infstate.callers_in_cycle
                     infstate_cycle.limited = true
@@ -1045,7 +1084,9 @@ function typeinf_local(frame::InferenceState)
                     frame.bestguess = tmerge(frame.bestguess, rt)
                     for (caller, caller_pc) in frame.cycle_backedges
                         # notify backedges of updated type information
-                        if caller.stmt_types[caller_pc] !== ()
+                        typeassert(caller.stmt_types[caller_pc], VarTable) # we must have visited this statement before
+                        if !(caller.src.ssavaluetypes[caller_pc] === Any)
+                            # no reason to revisit if that call-site doesn't affect the final result
                             if caller_pc < caller.pc´´
                                 caller.pc´´ = caller_pc
                             end


### PR DESCRIPTION
As noted by Simon in analyzing #27874, the compiler performance can become unstable in the presence of inference-limiting recursion. This is normally rare in most code, but is actually extremely common in the IO show code. Now that we have fully linearized IR, we can easily detect some of these cases and avoid some computational work and rework.

Note that backedges can't represent the full suite of information that was contained in this forward edge, so we're still forced to make an over-approximation (until we switch that design).