### PR TITLE
Fix for the markdown table in getting-started.md

### DIFF
--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -95,7 +95,7 @@ julia [switches] -- [programfile] [args...]
 |:---                                   |:---|
 |`-v`, `--version`                      |Display version information|
 |`-h`, `--help`                         |Print this message|
-|`--project[={<dir>|@.}]`               |Set <dir> as the home project/environment. The default @. option will search through parent directories until a Project.toml or JuliaProject.toml file is found.
+|`--project[={<dir>\|@.}]`              |Set <dir> as the home project/environment. The default @. option will search through parent directories until a Project.toml or JuliaProject.toml file is found.|
 |`-J`, `--sysimage <file>`              |Start up with the given system image file|
 |`-H`, `--home <dir>`                   |Set location of `julia` executable|
 |`--startup-file={yes\|no}`             |Load `~/.julia/config/startup.jl`|


### PR DESCRIPTION
The `--project` option has documented by PR https://github.com/JuliaLang/julia/pull/29731
I open a PR to format the markdown syntax correctly.