### PR TITLE
Don't close over broadcast arguments when flattening

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -744,6 +744,11 @@ let
     @test @inferred(Broadcast.materialize(Broadcast.flatten(bc))) == @inferred(Broadcast.materialize(bc)) == 60.8
 end
 
+let
+  bc = Broadcasted(+, (Broadcasted(*, ([1, 2, 3], 4)), 5))
+  @test isbits(Broadcast.flatten(bc).f)
+end
+
 # Issue #26127: multiple splats in a fused dot-expression
 let f(args...) = *(args...)
     x, y, z = (1,2), 3, (4, 5)


### PR DESCRIPTION
When we flatten a broadcast we currently close over all arguments to the broadcast, which makes the broadcast function significantly more complex than it needs to be. This impacts poorly with GPU arrays, where the broadcast function needs to be an `isbits` type to compile for the GPU.

This patch just avoids that, and therefore allows `flatten` to be used with broadcasts over GPU array types.