### PR TITLE
loading code simplifications

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -117,8 +117,7 @@ end
 
 const ns_dummy_uuid = UUID("fe0723d6-3a44-4c41-8065-ee0f42c8ceab")
 
-dummy_uuid(project_file::String) = isfile_casesensitive(project_file) ?
-    uuid5(ns_dummy_uuid, realpath(project_file)) : nothing
+dummy_uuid(project_file::String) = uuid5(ns_dummy_uuid, realpath(project_file))
 
 ## package path slugs: turning UUID + SHA1 into a pair of 4-byte "slugs" ##
 
@@ -147,7 +146,11 @@ end
 
 ## package identification: determine unique identity of package to be loaded ##
 
-find_package(args...) = locate_package(identify_package(args...))
+function find_package(args...)
+    pkg = identify_package(args...)
+    pkg === nothing && return nothing
+    return locate_package(pkg)
+end
 
 struct PkgId
     uuid::Union{UUID,Nothing}
@@ -192,62 +195,72 @@ function binunpack(s::String)
     return PkgId(UUID(uuid), name)
 end
 
-function identify_package(where::Module, name::String)::Union{Nothing,PkgId}
-    identify_package(PkgId(where), name)
-end
+## package identity: given a package name and a context, try to return its identity ##
 
+identify_package(where::Module, name::String) = identify_package(PkgId(where), name)
+
+# identify_package computes the PkgId for `name` from the context of `where`
+# or return `nothing` if no mapping exists for it
 function identify_package(where::PkgId, name::String)::Union{Nothing,PkgId}
     where.name === name && return where
-    where.uuid === nothing && return identify_package(name)
+    where.uuid === nothing && return identify_package(name) # ignore `where`
     for env in load_path()
-        found_or_uuid = manifest_deps_get(env, where, name)
-        found_or_uuid isa UUID && return PkgId(found_or_uuid, name)
-        found_or_uuid && return nothing
+        uuid = manifest_deps_get(env, where, name)
+        uuid === nothing && continue # not found--keep looking
+        uuid.uuid === nothing || return uuid # found in explicit environment--use it
+        return nothing # found in implicit environment--return "not found"
     end
     return nothing
 end
 
+# identify_package computes the PkgId for `name` from toplevel context
+# by looking through the Project.toml files and directories
 function identify_package(name::String)::Union{Nothing,PkgId}
     for env in load_path()
-        found_or_uuid = project_deps_get(env, name)
-        found_or_uuid isa UUID && return PkgId(found_or_uuid, name)
-        found_or_uuid && return PkgId(name)
+        uuid = project_deps_get(env, name)
+        uuid === nothing || return uuid # found--return it
     end
     return nothing
 end
 
 function identify_package(name::String, names::String...)
     pkg = identify_package(name)
-    pkg      === nothing ? nothing :
-    pkg.uuid === nothing ? identify_package(names...) :
-                           identify_package(pkg, names...)
+    pkg === nothing && return nothing
+    return identify_package(pkg, names...)
 end
 
+# locate `tail(names)` package by following the search path graph through `names` starting from `where`
 function identify_package(where::PkgId, name::String, names::String...)
     pkg = identify_package(where, name)
-    pkg      === nothing ? nothing :
-    pkg.uuid === nothing ? identify_package(names...) :
-                           identify_package(pkg, names...)
+    pkg === nothing && return nothing
+    return identify_package(pkg, names...)
 end
 
-## package location: given a package identity find file to load ##
+## package location: given a package identity, find file to load ##
 
 function locate_package(pkg::PkgId)::Union{Nothing,String}
     if pkg.uuid === nothing
         for env in load_path()
-            found_or_uuid = project_deps_get(env, pkg.name)
-            found_or_uuid isa UUID &&
-                return locate_package(PkgId(found_or_uuid, pkg.name))
-            found_or_uuid && return implicit_manifest_uuid_path(env, pkg)
+            # look for the toplevel pkg `pkg.name` in this entry
+            found = project_deps_get(env, pkg.name)
+            found === nothing && continue
+            if pkg == found
+                # pkg.name is present in this directory or project file,
+                # return the path the entry point for the code, if it could be found
+                # otherwise, signal failure
+                return implicit_manifest_uuid_path(env, pkg)
+            end
+            @assert found.uuid !== nothing
+            return locate_package(found) # restart search now that we know the uuid for pkg
         end
     else
         for env in load_path()
             path = manifest_uuid_path(env, pkg)
-            path != nothing && return entry_path(path, pkg.name)
+            path === nothing || return entry_path(path, pkg.name)
         end
     end
+    return nothing
 end
-locate_package(::Nothing) = nothing
 
 """
     pathof(m::Module)
@@ -269,8 +282,8 @@ end
 const project_names = ("JuliaProject.toml", "Project.toml")
 const manifest_names = ("JuliaManifest.toml", "Manifest.toml")
 
-# return means
-#  - `false`: nothing to see here
+# classify the LOAD_PATH entry to be one of:
+#  - `false`: nonexistant / nothing to see here
 #  - `true`: `env` is an implicit environment
 #  - `path`: the path of an explicit project file
 function env_project_file(env::String)::Union{Bool,String}
@@ -286,46 +299,52 @@ function env_project_file(env::String)::Union{Bool,String}
     return false
 end
 
-function project_deps_get(env::String, name::String)::Union{Bool,UUID}
+function project_deps_get(env::String, name::String)::Union{Nothing,PkgId}
     project_file = env_project_file(env)
     if project_file isa String
-        return explicit_project_deps_get(project_file, name)
+        pkg_uuid = explicit_project_deps_get(project_file, name)
+        pkg_uuid === nothing || return PkgId(pkg_uuid, name)
+    elseif project_file
+        return implicit_project_deps_get(env, name)
     end
-    project_file && implicit_project_deps_get(env, name)
+    return nothing
 end
 
-function manifest_deps_get(env::String, where::PkgId, name::String)::Union{Bool,UUID}
+function manifest_deps_get(env::String, where::PkgId, name::String)::Union{Nothing,PkgId}
     @assert where.uuid !== nothing
     project_file = env_project_file(env)
     if project_file isa String
-        proj_name, proj_uuid = project_file_name_uuid_path(project_file, where.name)
-        if proj_name == where.name && proj_uuid == where.uuid
-            # `where` matches the project, use deps as manifest
-            found_or_uuid = explicit_project_deps_get(project_file, name)
-            return found_or_uuid isa UUID ? found_or_uuid : true
+        # first check if `where` names the Project itself
+        proj = project_file_name_uuid(project_file, where.name)
+        if proj == where
+            # if `where` matches the project, use [deps] section as manifest, and stop searching
+            pkg_uuid = explicit_project_deps_get(project_file, name)
+            return PkgId(pkg_uuid, name)
         end
-        # look for `where` stanza in manifest file
-        manifest_file = project_file_manifest_path(project_file)
-        if isfile_casesensitive(manifest_file)
-            return explicit_manifest_deps_get(manifest_file, where.uuid, name)
-        end
-        return false # `where` stanza not found
+        # look for manifest file and `where` stanza
+        return explicit_manifest_deps_get(project_file, where.uuid, name)
+    elseif project_file
+        # if env names a directory, search it
+        return implicit_manifest_deps_get(env, where, name)
     end
-    project_file && implicit_manifest_deps_get(env, where, name)
+    return nothing
 end
 
 function manifest_uuid_path(env::String, pkg::PkgId)::Union{Nothing,String}
     project_file = env_project_file(env)
     if project_file isa String
-        proj_name, proj_uuid, path = project_file_name_uuid_path(project_file, pkg.name)
-        proj_name == pkg.name && proj_uuid == pkg.uuid && return path
-        manifest_file = project_file_manifest_path(project_file)
-        if isfile_casesensitive(manifest_file)
-            return explicit_manifest_uuid_path(manifest_file, pkg)
+        proj = project_file_name_uuid(project_file, pkg.name)
+        if proj == pkg
+            # if `pkg` matches the project, return the project itself
+            return project_file_path(project_file, pkg.name)
         end
-        return nothing
+        # look for manifest file and `where` stanza
+        return explicit_manifest_uuid_path(project_file, pkg)
+    elseif project_file
+        # if env names a directory, search it
+        return implicit_manifest_uuid_path(env, pkg)
     end
-    project_file ? implicit_manifest_uuid_path(env, pkg) : nothing
+    return nothing
 end
 
 # regular expressions for scanning project & manifest files
@@ -344,25 +363,35 @@ const re_manifest_to_string = r"^\s*manifest\s*=\s*\"(.*)\"\s*(?:#|$)"
 const re_deps_to_any        = r"^\s*deps\s*=\s*(.*?)\s*(?:#|$)"
 
 # find project file's top-level UUID entry (or nothing)
-function project_file_name_uuid_path(project_file::String,
-    name::String)::Tuple{String,UUID,String}
-    open(project_file) do io
+function project_file_name_uuid(project_file::String, name::String)::PkgId
+    pkg = open(project_file) do io
         uuid = dummy_uuid(project_file)
-        path = joinpath("src", "$name.jl")
         for line in eachline(io)
             occursin(re_section, line) && break
-            if (m = match(re_name_to_string, line)) != nothing
+            if (m = match(re_name_to_string, line)) !== nothing
                 name = String(m.captures[1])
-            elseif (m = match(re_uuid_to_string, line)) != nothing
+            elseif (m = match(re_uuid_to_string, line)) !== nothing
                 uuid = UUID(m.captures[1])
-            elseif (m = match(re_path_to_string, line)) != nothing
-                path = String(m.captures[1])
             end
         end
-        path = joinpath(dirname(project_file), path)
-        return name, uuid, path
+        return PkgId(uuid, name)
     end
+    return pkg
 end
+
+function project_file_path(project_file::String, name::String)::String
+    path = open(project_file) do io
+        for line in eachline(io)
+            occursin(re_section, line) && break
+            if (m = match(re_path_to_string, line)) !== nothing
+                return String(m.captures[1])
+            end
+        end
+        return ""
+    end
+    return joinpath(dirname(project_file), path)
+end
+
 
 # find project file's corresponding manifest file
 function project_file_manifest_path(project_file::String)::Union{Nothing,String}
@@ -370,48 +399,62 @@ function project_file_manifest_path(project_file::String)::Union{Nothing,String}
         dir = abspath(dirname(project_file))
         for line in eachline(io)
             occursin(re_section, line) && break
-            if (m = match(re_manifest_to_string, line)) != nothing
-                return normpath(joinpath(dir, m.captures[1]))
+            if (m = match(re_manifest_to_string, line)) !== nothing
+                manifest_file = normpath(joinpath(dir, m.captures[1]))
+                isfile_casesensitive(manifest_file) && return manifest_file
+                return nothing # silently stop if the explicitly listed manifest file is not present
             end
         end
-        local manifest_file
         for mfst in manifest_names
             manifest_file = joinpath(dir, mfst)
             isfile_casesensitive(manifest_file) && return manifest_file
         end
-        return manifest_file
+        return nothing
     end
 end
 
 # find `name` in a manifest file and return its UUID
-function manifest_file_name_uuid(manifest_file::String, name::String, io::IO)::Union{Nothing,UUID}
-    uuid = name′ = nothing
-    for line in eachline(io)
-        if (m = match(re_section_capture, line)) != nothing
-            name′ == name && break
-            name′ = String(m.captures[1])
-        elseif (m = match(re_uuid_to_string, line)) != nothing
-            uuid = UUID(m.captures[1])
-        end
-    end
-    name′ == name ? uuid : nothing
-end
-
-# given package dir and name, find an entry point
-# and project file if one exists (or nothing if not)
-function entry_point_and_project_file(dir::String, name::String)::Union{Tuple{Nothing,Nothing},Tuple{String,Nothing},Tuple{String,String}}
-    for entry in ("", joinpath(name, "src"), joinpath("$name.jl", "src"))
-        path = normpath(joinpath(dir, entry, "$name.jl"))
-        isfile_casesensitive(path) || continue
-        if !isempty(entry)
-            for proj in project_names
-                project_file = normpath(joinpath(dir, dirname(entry), proj))
-                isfile_casesensitive(project_file) || continue
-                return path, project_file
+# return `nothing` on failure
+function manifest_file_name_uuid(manifest_file::IO, name::String)::Union{Nothing,UUID}
+    name_section = false
+    uuid = nothing
+    for line in eachline(manifest_file)
+        if (m = match(re_section_capture, line)) !== nothing
+            name_section && break
+            name_section = (m.captures[1] == name)
+        elseif name_section
+            if (m = match(re_uuid_to_string, line)) !== nothing
+                uuid = UUID(m.captures[1])
             end
         end
-        return path, nothing
     end
+    return uuid
+end
+
+# given a directory (implicit env from LOAD_PATH) and a name,
+# check if it is an implicit package
+function entry_point_and_project_file_inside(dir::String, name::String)::Union{Tuple{Nothing,Nothing},Tuple{String,Nothing},Tuple{String,String}}
+    path = normpath(joinpath(dir, "src", "$name.jl"))
+    isfile_casesensitive(path) || return nothing, nothing
+    for proj in project_names
+        project_file = normpath(joinpath(dir, proj))
+        isfile_casesensitive(project_file) || continue
+        return path, project_file
+    end
+    return path, nothing
+end
+
+# given a project directory (implicit env from LOAD_PATH) and a name,
+# find an entry point for `name`, and see if it has an associated project file
+function entry_point_and_project_file(dir::String, name::String)::Union{Tuple{Nothing,Nothing},Tuple{String,Nothing},Tuple{String,String}}
+    path = normpath(joinpath(dir, "$name.jl"))
+    isfile_casesensitive(path) && return path, nothing
+    dir = joinpath(dir, name)
+    path, project_file = entry_point_and_project_file_inside(dir, name)
+    path === nothing || return path, project_file
+    dir = dir * ".jl"
+    path, project_file = entry_point_and_project_file_inside(dir, name)
+    path === nothing || return path, project_file
     return nothing, nothing
 end
 
@@ -419,9 +462,9 @@ end
 function entry_path(path::String, name::String)::Union{Nothing,String}
     isfile_casesensitive(path) && return normpath(path)
     path = normpath(joinpath(path, "src", "$name.jl"))
-    isfile_casesensitive(path) ? path : nothing
+    isfile_casesensitive(path) && return path
+    return nothing # source not found
 end
-entry_path(::Nothing, name::String) = nothing
 
 # given a project path (project directory or entry point)
 # return the project file
@@ -435,61 +478,57 @@ function package_path_to_project_file(path::String)::Union{Nothing,String}
         project_file = joinpath(path, proj)
         isfile_casesensitive(project_file) && return project_file
     end
+    return nothing
 end
 
 ## explicit project & manifest API ##
 
 # find project file root or deps `name => uuid` mapping
-#  - `false` means: did not find `name`
-#  - `true` means: found `name` without UUID (can't happen in explicit projects)
-#  - `uuid` means: found `name` with `uuid` in project file
-
-function explicit_project_deps_get(project_file::String, name::String)::Union{Bool,UUID}
-    open(project_file) do io
+# return `nothing` if `name` is not found
+function explicit_project_deps_get(project_file::String, name::String)::Union{Nothing,UUID}
+    pkg_uuid = open(project_file) do io
         root_name = nothing
         root_uuid = dummy_uuid(project_file)
         state = :top
         for line in eachline(io)
-            if state == :top
-                if occursin(re_section, line)
-                    root_name == name && return root_uuid
-                    state = occursin(re_section_deps, line) ? :deps : :other
-                elseif (m = match(re_name_to_string, line)) != nothing
+            if occursin(re_section, line)
+                state == :top && root_name == name && return root_uuid
+                state = occursin(re_section_deps, line) ? :deps : :other
+            elseif state == :top
+                if (m = match(re_name_to_string, line)) !== nothing
                     root_name = String(m.captures[1])
-                elseif (m = match(re_uuid_to_string, line)) != nothing
+                elseif (m = match(re_uuid_to_string, line)) !== nothing
                     root_uuid = UUID(m.captures[1])
                 end
             elseif state == :deps
-                if (m = match(re_key_to_string, line)) != nothing
+                if (m = match(re_key_to_string, line)) !== nothing
                     m.captures[1] == name && return UUID(m.captures[2])
                 end
             end
-            if occursin(re_section, line)
-                state = occursin(re_section_deps, line) ? :deps : :other
-            end
         end
-        return root_name == name && root_uuid
+        return root_name == name ? root_uuid : nothing
     end
+    return pkg_uuid
 end
 
-# find `where` stanza and `name` in its deps and return its UUID
-#  - `false` means: did not find `where`
-#  - `true` means: found `where` but `name` not in its deps
-#  - `uuid` means: found `where` and `name` mapped to `uuid` in its deps
-
-function explicit_manifest_deps_get(manifest_file::String, where::UUID, name::String)::Union{Bool,UUID}
-    open(manifest_file) do io
+# find `where` stanza and return the PkgId for `name`
+# return `nothing` if it did not find `where` (indicating caller should continue searching)
+function explicit_manifest_deps_get(project_file::String, where::UUID, name::String)::Union{Nothing,PkgId}
+    manifest_file = project_file_manifest_path(project_file)
+    manifest_file === nothing && return nothing # manifest not found--keep searching LOAD_PATH
+    found_or_uuid = open(manifest_file) do io
         uuid = deps = nothing
         state = :other
+        # first search the manifest for the deps section associated with `where` (by uuid)
         for line in eachline(io)
             if occursin(re_array_of_tables, line)
                 uuid == where && break
                 uuid = deps = nothing
                 state = :stanza
             elseif state == :stanza
-                if (m = match(re_uuid_to_string, line)) != nothing
+                if (m = match(re_uuid_to_string, line)) !== nothing
                     uuid = UUID(m.captures[1])
-                elseif (m = match(re_deps_to_any, line)) != nothing
+                elseif (m = match(re_deps_to_any, line)) !== nothing
                     deps = String(m.captures[1])
                 elseif occursin(re_subsection_deps, line)
                     state = :deps
@@ -497,93 +536,106 @@ function explicit_manifest_deps_get(manifest_file::String, where::UUID, name::St
                     state = :other
                 end
             elseif state == :deps && uuid == where
-                if (m = match(re_key_to_string, line)) != nothing
+                # [deps] section format gives both name and uuid
+                if (m = match(re_key_to_string, line)) !== nothing
                     m.captures[1] == name && return UUID(m.captures[2])
                 end
             end
         end
+        # now search through `deps = []` string to see if we have an entry for `name`
         uuid == where || return false
         deps === nothing && return true
         # TODO: handle inline table syntax
         if deps[1] != '[' || deps[end] != ']'
             @warn "Unexpected TOML deps format:\n$deps"
-            return nothing
+            return false
         end
         occursin(repr(name), deps) || return true
         seekstart(io) # rewind IO handle
-        return manifest_file_name_uuid(manifest_file, name, io)
+        # finally, find out the `uuid` associated with `name`
+        return something(manifest_file_name_uuid(io, name), false)
     end
+    found_or_uuid isa UUID && return PkgId(found_or_uuid, name)
+    found_or_uuid && return PkgId(name)
+    return nothing
 end
 
 # find `uuid` stanza, return the corresponding path
-function explicit_manifest_uuid_path(manifest_file::String, pkg::PkgId)::Union{Nothing,String}
+function explicit_manifest_uuid_path(project_file::String, pkg::PkgId)::Union{Nothing,String}
+    manifest_file = project_file_manifest_path(project_file)
+    manifest_file === nothing && return nothing # no manifest, skip env
     open(manifest_file) do io
         uuid = name = path = hash = nothing
         for line in eachline(io)
-            if (m = match(re_section_capture, line)) != nothing
+            if (m = match(re_section_capture, line)) !== nothing
                 uuid == pkg.uuid && break
                 name = String(m.captures[1])
                 path = hash = nothing
-            elseif (m = match(re_uuid_to_string, line)) != nothing
+            elseif (m = match(re_uuid_to_string, line)) !== nothing
                 uuid = UUID(m.captures[1])
-            elseif (m = match(re_path_to_string, line)) != nothing
+            elseif (m = match(re_path_to_string, line)) !== nothing
                 path = String(m.captures[1])
-            elseif (m = match(re_hash_to_string, line)) != nothing
+            elseif (m = match(re_hash_to_string, line)) !== nothing
                 hash = SHA1(m.captures[1])
             end
         end
         uuid == pkg.uuid || return nothing
         name == pkg.name || return nothing # TODO: allow a mismatch?
-        if path != nothing
+        if path !== nothing
             path = normpath(abspath(dirname(manifest_file), path))
-            return entry_path(path, name)
+            return path
         end
-        hash == nothing && return nothing
+        hash === nothing && return nothing
         # Keep the 4 since it used to be the default
         for slug in (version_slug(uuid, hash, 4), version_slug(uuid, hash))
             for depot in DEPOT_PATH
                 path = abspath(depot, "packages", name, slug)
-                ispath(path) && return entry_path(path, name)
+                ispath(path) && return path
             end
         end
+        return nothing
     end
 end
 
 ## implicit project & manifest API ##
 
-# look for an entry point for `name`:
-#  - `false` means: did not find `name`
-#  - `true` means: found `name` without project file
-#  - `uuid` means: found `name` with project file with real or dummy `uuid`
-function implicit_project_deps_get(dir::String, name::String)::Union{Bool,UUID}
+# look for an entry point for `name` from a top-level package (no environment)
+# otherwise return `nothing` to indicate the caller should keep searching
+function implicit_project_deps_get(dir::String, name::String)::Union{Nothing,PkgId}
     path, project_file = entry_point_and_project_file(dir, name)
-    project_file == nothing && return path != nothing
-    proj_name, proj_uuid = project_file_name_uuid_path(project_file, name)
-    proj_name == name && proj_uuid
+    if project_file === nothing
+        path === nothing && return nothing
+        return PkgId(name)
+    end
+    proj = project_file_name_uuid(project_file, name)
+    proj.name == name || return nothing
+    return proj
 end
 
-# look for an entry-point for `where` by name, check that UUID matches
+# look for an entry-point for `name`, check that UUID matches
 # if there's a project file, look up `name` in its deps and return that
-#  - `false` means: did not find `where`
-#  - `true` means: found `where` but `name` not in its deps
-#  - `uuid` means: found `where` and `name` mapped to `uuid` in its deps
-function implicit_manifest_deps_get(dir::String, where::PkgId, name::String)::Union{Bool,UUID}
+# otherwise return `nothing` to indicate the caller should keep searching
+function implicit_manifest_deps_get(dir::String, where::PkgId, name::String)::Union{Nothing,PkgId}
     @assert where.uuid !== nothing
     project_file = entry_point_and_project_file(dir, where.name)[2]
-    project_file === nothing && return false
-    proj_name, proj_uuid = project_file_name_uuid_path(project_file, where.name)
-    proj_name == where.name && proj_uuid == where.uuid || return false
-    found_or_uuid = explicit_project_deps_get(project_file, name)
-    found_or_uuid isa UUID ? found_or_uuid : true
+    project_file === nothing && return nothing # a project file is mandatory for a package with a uuid
+    proj = project_file_name_uuid(project_file, where.name)
+    proj == where || return nothing # verify that this is the correct project file
+    # this is the correct project, so stop searching here
+    pkg_uuid = explicit_project_deps_get(project_file, name)
+    return PkgId(pkg_uuid, name)
 end
 
 # look for an entry-point for `pkg` and return its path if UUID matches
 function implicit_manifest_uuid_path(dir::String, pkg::PkgId)::Union{Nothing,String}
     path, project_file = entry_point_and_project_file(dir, pkg.name)
-    pkg.uuid === nothing && project_file === nothing && return path
-    pkg.uuid === nothing || project_file === nothing && return nothing
-    proj_name, proj_uuid = project_file_name_uuid_path(project_file, pkg.name)
-    proj_name == pkg.name && proj_uuid == pkg.uuid ? path : nothing
+    if project_file === nothing
+        pkg.uuid === nothing || return nothing
+        return path
+    end
+    proj = project_file_name_uuid(project_file, pkg.name)
+    proj == pkg || return nothing
+    return path
 end
 
 ## other code loading functionality ##

--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -544,10 +544,10 @@ function project_deps_get_completion_candidates(pkgstarts::String, project_file:
     open(project_file) do io
         state = :top
         for line in eachline(io)
-            if state == :top
-                if occursin(Base.re_section, line)
-                    state = occursin(Base.re_section_deps, line) ? :deps : :other
-                elseif (m = match(Base.re_name_to_string, line)) != nothing
+            if occursin(Base.re_section, line)
+                state = occursin(Base.re_section_deps, line) ? :deps : :other
+            elseif state == :top
+                if (m = match(Base.re_name_to_string, line)) != nothing
                     root_name = String(m.captures[1])
                     startswith(root_name, pkgstarts) && push!(loading_candidates, root_name)
                 end
@@ -556,8 +556,6 @@ function project_deps_get_completion_candidates(pkgstarts::String, project_file:
                     dep_name = m.captures[1]
                     startswith(dep_name, pkgstarts) && push!(loading_candidates, dep_name)
                 end
-            elseif occursin(Base.re_section, line)
-                state = occursin(Base.re_section_deps, line) ? :deps : :other
             end
         end
     end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -163,10 +163,10 @@ end
                 this = Base.explicit_project_deps_get(project_file, "This")
                 that = Base.explicit_project_deps_get(project_file, "That")
                 # test that the correct answers are given
-                @test root == (something(n, N+1) ≥ something(d, N+1) ? false :
+                @test root == (something(n, N+1) ≥ something(d, N+1) ? nothing :
                                something(u, N+1) < something(d, N+1) ? root_uuid : proj_uuid)
-                @test this == (something(d, N+1) < something(t, N+1) ≤ N ? this_uuid : false)
-                @test that == false
+                @test this == (something(d, N+1) < something(t, N+1) ≤ N ? this_uuid : nothing)
+                @test that == nothing
             end
         end
     end
@@ -502,7 +502,7 @@ function test_find(
     for name in NAMES
         id = identify_package(name)
         @test id == get(roots, name, nothing)
-        path = locate_package(id)
+        path = id === nothing ? nothing : locate_package(id)
         @test path == get(paths, id, nothing)
     end
     # check indirect dependencies
@@ -512,7 +512,7 @@ function test_find(
         for name in NAMES
             id = identify_package(where, name)
             @test id == get(deps, name, nothing)
-            path = locate_package(id)
+            path = id === nothing ? nothing : locate_package(id)
             @test path == get(paths, id, nothing)
         end
     end


### PR DESCRIPTION
In my attempts to better understand the existing loading code (before making more major changes, such as making the environment maps explicit for the Distributed and precompile code), I experimented with trying to simplify the code logic here and adding or expanding upon comments. I turned up a few minor bugs (such as places where we returned `nothing::Bool`) and other slight inconsistencies (such as potentially attempting to search `X/src/X.jl/src/X.jl`). The biggest change here is removing all of the 3VL (UUID, true, or false) in favor of nullable (PkgId or nothing).

Relatedly, I then turned to the code-loading docs, and attempted to simplify and clarify those, and correct a couple places where the code doesn't quite do what was documented. I'd like to do a bigger rearrangement of this also (splitting it into a couple files, and possibly adding more support to Documenter to handle nested documents better), but sometime later.

I'm not strongly opinionated about merging all of this, and rather expect that we might cherry-pick some bits or alter others further (both in the docs changes and in the code).