### PR TITLE
Define typemin/typemax for BigInt

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -10,7 +10,7 @@ import .Base: *, +, -, /, <, <<, >>, >>>, <=, ==, >, >=, ^, (~), (&), (|), xor,
              sum, trailing_zeros, trailing_ones, count_ones, tryparse_internal,
              bin, oct, dec, hex, isequal, invmod, _prevpow2, _nextpow2, ndigits0zpb,
              widen, signed, unsafe_trunc, trunc, iszero, isone, big, flipsign, signbit,
-             hastypemax
+             typemin, typemax, hastypemax
 
 if Clong == Int32
     const ClongMax = Union{Int8, Int16, Int32}
@@ -225,6 +225,9 @@ end # module MPZ
 const ZERO = BigInt()
 const ONE  = BigInt()
 const _ONE = Limb[1]
+
+typemin(::Type{BigInt}) = nothing
+typemax(::Type{BigInt}) = nothing
 
 widen(::Type{Int128})  = BigInt
 widen(::Type{UInt128}) = BigInt

--- a/base/int.jl
+++ b/base/int.jl
@@ -637,7 +637,8 @@ promote_rule(::Type{UInt128}, ::Type{Int128}) = UInt128
 """
     typemin(T)
 
-The lowest value representable by the given (real) numeric DataType `T`.
+The lowest value representable by the given (real) numeric DataType `T`. If the type does
+not have a minimum value then `nothing` will be returned.
 
 # Examples
 ```jldoctest
@@ -653,7 +654,8 @@ function typemin end
 """
     typemax(T)
 
-The highest value representable by the given (real) numeric `DataType`.
+The highest value representable by the given (real) numeric `DataType`. If the type does not
+have a maximum value then `nothing` will be returned.
 
 # Examples
 ```jldoctest

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -712,10 +712,10 @@ end
 """
     hastypemax(T::Type) -> Bool
 
-Return `true` if and only if `typemax(T)` is defined.
+Return `true` if and only if `typemax(T)` is defined and does not return `nothing`.
 """
 hastypemax(::Base.BitIntegerType) = true
-hastypemax(::Type{T}) where {T} = applicable(typemax, T)
+hastypemax(::Type{T}) where {T} = applicable(typemax, T) && typemax(T) !== nothing
 
 """
     digits!(array, n::Integer; base::Integer = 10)

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -69,6 +69,10 @@ ee = typemax(Int64)
             @test big(typeof(complex(x, x))) == typeof(big(complex(x, x)))
         end
     end
+    @testset "limits" begin
+        @test typemin(BigInt) === nothing
+        @test typemax(BigInt) === nothing
+    end
 end
 @testset "div, fld, mod, rem" begin
     for i = -10:10, j = [-10:-1; 1:10]


### PR DESCRIPTION
I think it would be nice to have `typemin`/`typemax` defined for all `Integer` subtypes. I don't think it unreasonable to say that any custom type which is a subtype of `Integer` should have these methods defined for that type.

This concept was thought of this while working on speeding up some generic code in [FixedPointDecimals](https://github.com/JuliaMath/FixedPointDecimals.jl/pull/30) which used `typemax` on `Integer` types. While creating this PR I discovered `hastypemax` which works but I think it should be eventually be deprecated as the `applicable(typemax, T)` fallback is not very performant for custom types.