### PR TITLE
Clarification for try/catch documentation in the manual

### DIFF
--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -734,6 +734,7 @@ julia> try
            println("You should have entered a numeric value")
        end
 You should have entered a numeric value
+```
 
 `try/catch` statements also allow the `Exception` to be saved in a variable. The following
 contrived example calculates the square root of the second element of `x` if `x`

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -722,9 +722,10 @@ graceful handling of things that may ordinarily break your application. For exam
 in the below code the function for square root would normally throw an exception. By
 placing a `try/catch` block around it we can mitigate that here. You may choose how
 you wish to handle this exception, whether logging it, return a placeholder value or
-as in the case below where we just printed out a statement. Below there are more
-examples of handling exceptions with
-the `try/catch` block:
+as in the case below where we just printed out a statement. One thing to think about
+when deciding how to handle unexpected situations is that using a `try/catch` block is 
+much slower than using conditional branching to handle those situations. 
+Below there are more examples of handling exceptions with a `try/catch` block:
 
 ```jldoctest
 julia> try
@@ -732,15 +733,14 @@ julia> try
        catch e
            println("You should have entered a numeric value")
        end
+You should have entered a numeric value
+
 julia> f(1)
 1.0
 
 julia> f(-1)
 0.0 + 1.0im
 ```
-
-It is important to note that in real code computing this function, one would compare `x` to zero
-instead of catching an exception. The exception is much slower than simply comparing and branching.
 
 `try/catch` statements also allow the `Exception` to be saved in a variable. The following
 contrived example calculates the square root of the second element of `x` if `x`

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -732,7 +732,6 @@ julia> try
        catch e
            println("You should have entered a numeric value")
        end
-       
 julia> f(1)
 1.0
 

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -723,8 +723,8 @@ in the below code the function for square root would normally throw an exception
 placing a `try/catch` block around it we can mitigate that here. You may choose how
 you wish to handle this exception, whether logging it, return a placeholder value or
 as in the case below where we just printed out a statement. One thing to think about
-when deciding how to handle unexpected situations is that using a `try/catch` block is 
-much slower than using conditional branching to handle those situations. 
+when deciding how to handle unexpected situations is that using a `try/catch` block is
+much slower than using conditional branching to handle those situations.
 Below there are more examples of handling exceptions with a `try/catch` block:
 
 ```jldoctest

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -717,17 +717,16 @@ Stacktrace:
 
 ### The `try/catch` statement
 
-The `try/catch` statement allows for `Exception`s to be tested for. For example, a customized
-square root function can be written to automatically call either the real or complex square root
-method on demand using `Exception`s :
+The `try/catch` statement allows for `Exception`s to be tested for, and for the graceful handling of things that may ordinarily break your application. For example, in the below code the function for square root would normally throw an exception and break your application. By placing a `try/catch` block around it we can mitigate that here. You may choose how you wish to handle this exception, whether logging it, return a placeholder value or as in the case below where we just printed out a statement. On line 740 and below there are more examples of handling exceptions with
+the `try/catch` block:
 
 ```jldoctest
-julia> f(x) = try
-           sqrt(x)
-       catch
-           sqrt(complex(x, 0))
+julia> try
+        sqrt("ten")
+       catch e
+       println("You should have entered a numeric value")
        end
-f (generic function with 1 method)
+       
 
 julia> f(1)
 1.0

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -735,13 +735,6 @@ julia> try
        end
 You should have entered a numeric value
 
-julia> f(1)
-1.0
-
-julia> f(-1)
-0.0 + 1.0im
-```
-
 `try/catch` statements also allow the `Exception` to be saved in a variable. The following
 contrived example calculates the square root of the second element of `x` if `x`
 is indexable, otherwise assumes `x` is a real number and returns its square root:

--- a/doc/src/manual/control-flow.md
+++ b/doc/src/manual/control-flow.md
@@ -717,17 +717,22 @@ Stacktrace:
 
 ### The `try/catch` statement
 
-The `try/catch` statement allows for `Exception`s to be tested for, and for the graceful handling of things that may ordinarily break your application. For example, in the below code the function for square root would normally throw an exception and break your application. By placing a `try/catch` block around it we can mitigate that here. You may choose how you wish to handle this exception, whether logging it, return a placeholder value or as in the case below where we just printed out a statement. On line 740 and below there are more examples of handling exceptions with
+The `try/catch` statement allows for `Exception`s to be tested for, and for the
+graceful handling of things that may ordinarily break your application. For example,
+in the below code the function for square root would normally throw an exception. By
+placing a `try/catch` block around it we can mitigate that here. You may choose how
+you wish to handle this exception, whether logging it, return a placeholder value or
+as in the case below where we just printed out a statement. Below there are more
+examples of handling exceptions with
 the `try/catch` block:
 
 ```jldoctest
 julia> try
-        sqrt("ten")
+           sqrt("ten")
        catch e
-       println("You should have entered a numeric value")
+           println("You should have entered a numeric value")
        end
        
-
 julia> f(1)
 1.0
 


### PR DESCRIPTION
Hi team! I saw this issue was still open from a year ago, I read the comments on the other pull request and changed the documentation to reflect that while you can 'throw' an exception you do not have to, you can do something as simple as print a message. 

this is one of my first pull requests, so if there's anything I can do to modify it please let me know. thanks. 