### PR TITLE
improve codegen for isdigit

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -344,7 +344,7 @@ julia> isdigit('α')
 false
 ```
 """
-isdigit(c::AbstractChar) = '0' <= c <= '9'
+isdigit(c::AbstractChar) = (c >= '0') & (c <= '9')
 
 """
     isletter(c::AbstractChar) -> Bool


### PR DESCRIPTION
This makes us emit the same code as e.g. clang does for the `isdigit` function:

https://godbolt.org/z/djkWdQ

Before

```jl
julia> @code_native isdigit('2')
	cmpl	$805306368, %edi        ## imm = 0x30000000
	jae	L11
	xorl	%eax, %eax
	retq
L11:
	cmpl	$956301313, %edi        ## imm = 0x39000001
	setb	%al
	retq
	nopw	%cs:(%rax,%rax)
```

After

```jl
julia> @code_native isdigit('2')
	addl	$3489660928, %edi       ## imm = 0xD0000000
	cmpl	$150994945, %edi        ## imm = 0x9000001
	setb	%al
	retq
```