### PR TITLE
Clarify what jl_atexit_hook calls

### DIFF
--- a/doc/src/devdocs/init.md
+++ b/doc/src/devdocs/init.md
@@ -220,7 +220,7 @@ the stack now rapidly unwinds back to `main()`.
 ## `jl_atexit_hook()`
 
 `main()` calls [`jl_atexit_hook()`](https://github.com/JuliaLang/julia/blob/master/src/init.c).
-This calls `_atexit` for each module, then calls [`jl_gc_run_all_finalizers()`](https://github.com/JuliaLang/julia/blob/master/src/gc.c)
+This calls `Base._atexit`, then calls [`jl_gc_run_all_finalizers()`](https://github.com/JuliaLang/julia/blob/master/src/gc.c)
 and cleans up libuv handles.
 
 ## `julia_save()`


### PR DESCRIPTION
Current documentation says that `jl_atexit_hook` _"calls `_atexit` for each module"_:

https://github.com/JuliaLang/julia/blob/ff74f6bc77e42c974b0f890ff25701f38f362560/doc/src/devdocs/init.md#L220-L224

However, it seems only `Base._atexit` is accessed in `jl_atexit_hook`.

https://github.com/JuliaLang/julia/blob/b84fe52c8876de1537c50481546a734cc1990441/src/init.c#L229

If the documentation says that it "calls `_atexit` for each module" I would imagine that I can define `MyModule._atexit` (like I define `MyModule.__init__`). But I suppose that's not the case?