### PR TITLE
broadcast cleanup

### DIFF
--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -20,7 +20,7 @@ length(@nospecialize t::Tuple) = nfields(t)
 firstindex(@nospecialize t::Tuple) = 1
 lastindex(@nospecialize t::Tuple) = length(t)
 size(@nospecialize(t::Tuple), d) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
-axes(@nospecialize t::Tuple) = OneTo(length(t))
+axes(@nospecialize t::Tuple) = (OneTo(length(t)),)
 @eval getindex(@nospecialize(t::Tuple), i::Int) = getfield(t, i, $(Expr(:boundscheck)))
 @eval getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))
 getindex(t::Tuple, r::AbstractArray{<:Any,1}) = ([t[ri] for ri in r]...,)

--- a/doc/src/base/arrays.md
+++ b/doc/src/base/arrays.md
@@ -76,7 +76,6 @@ Base.@__dot__
 For specializing broadcast on custom types, see
 ```@docs
 Base.BroadcastStyle
-Base.broadcast_axes
 Base.Broadcast.AbstractArrayStyle
 Base.Broadcast.ArrayStyle
 Base.Broadcast.DefaultArrayStyle

--- a/doc/src/manual/interfaces.md
+++ b/doc/src/manual/interfaces.md
@@ -440,7 +440,7 @@ V = view(A, [1,2,4], :)   # is not strided, as the spacing between rows is not f
 | `Base.similar(bc::Broadcasted{DestStyle}, ::Type{ElType})` | Allocation of output container |
 | **Optional methods** | | |
 | `Base.BroadcastStyle(::Style1, ::Style2) = Style12()` | Precedence rules for mixing styles |
-| `Base.broadcast_axes(x)` | Declaration of the indices of `x` for broadcasting purposes (defaults to [`axes(x)`](@ref)) |
+| `Base.axes(x)` | Declaration of the indices of `x`, as per [`axes(x)`](@ref). |
 | `Base.broadcastable(x)` | Convert `x` to an object that has `axes` and supports indexing |
 | **Bypassing default machinery** | |
 | `Base.copy(bc::Broadcasted{DestStyle})` | Custom implementation of `broadcast` |

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -709,7 +709,7 @@ struct T22053
     t
 end
 Broadcast.BroadcastStyle(::Type{T22053}) = Broadcast.Style{T22053}()
-Broadcast.broadcast_axes(::T22053) = ()
+Broadcast.axes(::T22053) = ()
 Broadcast.broadcastable(t::T22053) = t
 function Base.copy(bc::Broadcast.Broadcasted{Broadcast.Style{T22053}})
     all(x->isa(x, T22053), bc.args) && return 1


### PR DESCRIPTION
I noticed a bit of code in here was to work around the lack of constant prop. Now that we have that, we can remove the extra code. And also, with PartialTuple, we can remove even more!

Then there's also the function `broadcast_axes`. I'm not sure why the below method was added, instead of correcting the definition of `axes(::Tuple)`, but my timeline might be wrong on that.
```
broadcast_axes(A::Tuple) = (OneTo(length(A)),)
```
It's a bit of a code-smell to me that this function only has one remaining method (The only type that refuses to implement `axes`, but needs it anyways, is Base.Broadcast.Extruded).