### PR TITLE
tweak storing char into string

### DIFF
--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -161,7 +161,7 @@ string(a::SubString{String}) = String(a)
         unsafe_store!(pointer(out, offs + 1), (0x80 | (0x3f & x >>  6)) % UInt8)
         unsafe_store!(pointer(out, offs + 2), (0x80 | (0x3f & x >>  0)) % UInt8)
         l = 3
-    elseif x <= 0x10ffff
+    else
         unsafe_store!(pointer(out, offs + 0), (0xF0 |         x >> 18)  % UInt8)
         unsafe_store!(pointer(out, offs + 1), (0x80 | (0x3f & x >> 12)) % UInt8)
         unsafe_store!(pointer(out, offs + 2), (0x80 | (0x3f & x >>  6)) % UInt8)


### PR DESCRIPTION
Seems faster for latin text.

```jl
julia> using Random

julia> a = randstring(10^4) |> collect;

julia> @btime String($a);
```

Before

```
  19.786 μs (1 allocation: 9.88 KiB)
```

After

```
  15.020 μs (1 allocation: 9.88 KiB)
```

Happy to do other benchmarks if people have some ideas.