### PR TITLE
revert 28449 - workaround for openblas on Win64

### DIFF
--- a/deps/openblas.mk
+++ b/deps/openblas.mk
@@ -63,15 +63,6 @@ OPENBLAS_FFLAGS += -mincoming-stack-boundary=2
 endif
 endif
 
-# Work around invalid register errors on 64-bit Windows
-# See discussion in https://github.com/xianyi/OpenBLAS/issues/1708
-# TODO: Remove this once we use a version of OpenBLAS where this is set automatically
-ifeq ($(OS),WINNT)
-ifeq ($(ARCH),x86_64)
-OPENBLAS_CFLAGS += -fno-asynchronous-unwind-tables
-endif
-endif
-
 OPENBLAS_BUILD_OPTS += CFLAGS="$(CFLAGS) $(OPENBLAS_CFLAGS)"
 OPENBLAS_BUILD_OPTS += FFLAGS="$(FFLAGS) $(OPENBLAS_FFLAGS)"
 OPENBLAS_BUILD_OPTS += LDFLAGS="$(LDFLAGS) $(RPATH_ESCAPED_ORIGIN)"


### PR DESCRIPTION
No longer necessary on OpenBLAS 0.3.3. (#29845)