### PR TITLE
initialize previous_exception

### DIFF
--- a/src/threading.c
+++ b/src/threading.c
@@ -283,6 +283,7 @@ static void ti_initthread(int16_t tid)
     memset(bt_data, 0, sizeof(uintptr_t) * (JL_MAX_BT_SIZE + 1));
     ptls->bt_data = (uintptr_t*)bt_data;
     ptls->sig_exception = NULL;
+    ptls->previous_exception = NULL;
 #ifdef _OS_WINDOWS_
     ptls->needs_resetstkoflw = 0;
 #endif


### PR DESCRIPTION
Fix uninitialized `previous_exception` bug in #28878 

Discovered and fixed by @JeffBezanson over at #22631