### PR TITLE
manually deconstruct and reconstruct subarray when throwing boundserror 

### DIFF
--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -37,6 +37,14 @@ check_parent_index_match(parent::AbstractArray{T,N}, ::NTuple{N, Bool}) where {T
 check_parent_index_match(parent, ::NTuple{N, Bool}) where {N} =
     throw(ArgumentError("number of indices ($N) must match the parent dimensionality ($(ndims(parent)))"))
 
+# This makes it possible to elide view allocation in cases where the
+# view is indexed with a boundscheck but otherwise all its uses
+# are inlined
+@inline Base.throw_boundserror(A::SubArray, I) =
+    __subarray_throw_boundserror(typeof(A), A.parent, A.indices, A.offset1, A.stride1, I)
+@noinline __subarray_throw_boundserror(T, parent, indices, offset1, stride1, I) =
+    throw(BoundsError(T(parent, indices, offset1, stride1), I))
+
 # This computes the linear indexing compatibility for a given tuple of indices
 viewindexing() = IndexLinear()
 # Leading scalar indices simply increase the stride


### PR DESCRIPTION
This is perhaps stupid but anyway.

```jl
julia> f(x) = view(x, :)[3]
```

Before

```jl
julia> @btime f($x);
  8.618 ns (1 allocation: 48 bytes)
```

After

```jl
julia> @btime f($x);
  5.526 ns (0 allocations: 0 bytes)
```

IR Before

```jl
julia> @code_typed f(x)
CodeInfo(
1 1 ── %1  = (Base.arraysize)(x, 1)::Int64                                                               │╻╷╷╷╷╷    view
  │    %2  = (Base.slt_int)(%1, 0)::Bool                                                                 ││╻╷╷╷      to_indices
  │    %3  = (Base.ifelse)(%2, 0, %1)::Int64                                                             │││┃││││││   eachindex
  │    %4  = %new(OneTo{Int64}, %3)::OneTo{Int64}                                                        ││││┃││││     axes1
  │    %5  = %new(Slice{OneTo{Int64}}, %4)::Slice{OneTo{Int64}}                                          ││││╻╷╷       uncolon
  └───       goto #3 if not true                                                                         │╻         view
  2 ──       (Base.arraysize)(x, 1)::Int64                                                               ││╻╷╷╷╷     checkbounds
  3 ── %8  = (Core.tuple)(%5)::Tuple{Slice{OneTo{Int64}}}                                                ││╻╷╷       unsafe_view
  │          (Base.arraysize)(x, 1)::Int64                                                               │││╻╷╷       Type
  │    %10 = %new(SubArray{Float64,1,Array{Float64,1},Tuple{Slice{OneTo{Int64}}},true}, x, %8, 0, 1)::SubArray{Float64,1,Array{Float64,1},Tuple{Slice{OneTo{Int64}}},true}
  └───       goto #4                                                                                     ││        
  4 ──       goto #9 if not true                                                                         │╻         getindex
  5 ── %13 = (Core.tuple)(3)::Tuple{Int64}                                                               ││        
  │    %14 = (Base.sle_int)(1, 3)::Bool                                                                  ││╻╷╷       checkbounds
  │    %15 = (Base.sle_int)(3, %3)::Bool                                                                 │││┃││       checkbounds
  │    %16 = (Base.and_int)(%14, %15)::Bool                                                              ││││╻         checkindex
  └───       goto #7 if not %16                                                                          │││       
  6 ──       goto #8                                                                                     │││       
  7 ──       invoke Base.throw_boundserror(%10::SubArray{Float64,1,Array{Float64,1},Tuple{Base.Slice{Base.OneTo{Int64}}},true}, %13::Tuple{Int64})::Union{}
  └───       $(Expr(:unreachable))::Union{}                                                              │││       
  8 ┄─       nothing::Nothing                                                                            │         
  9 ── %22 = (Base.add_int)(0, 3)::Int64                                                                 ││╻         +
  │    %23 = (Base.arrayref)(false, x, %22)::Float64                                                     ││╻         getindex
  └───       goto #10                                                                                    │╻         getindex
  10 ─       return %23                                                                                  │         
) => Float64
```

IR After
```jl
julia> @code_typed f(x)
CodeInfo(
1 1 ── %1  = (Base.arraysize)(x, 1)::Int64                                                         │╻╷╷╷╷╷    view
  │    %2  = (Base.slt_int)(%1, 0)::Bool                                                           ││╻╷╷╷      to_indices
  │    %3  = (Base.ifelse)(%2, 0, %1)::Int64                                                       │││┃││││││   eachindex
  │    %4  = %new(OneTo{Int64}, %3)::OneTo{Int64}                                                  ││││┃││││     axes1
  │    %5  = %new(Slice{OneTo{Int64}}, %4)::Slice{OneTo{Int64}}                                    ││││╻╷╷       uncolon
  └───       goto #3 if not true                                                                   │╻         view
  2 ──       (Base.arraysize)(x, 1)::Int64                                                         ││╻╷╷╷╷     checkbounds
  3 ── %8  = (Core.tuple)(%5)::Tuple{Slice{OneTo{Int64}}}                                          ││╻╷╷       unsafe_view
  │          (Base.arraysize)(x, 1)::Int64                                                         │││╻╷╷       Type
  └───       goto #4                                                                               ││        
  4 ──       goto #9 if not true                                                                   │╻         getindex
  5 ── %12 = (Core.tuple)(3)::Tuple{Int64}                                                         ││        
  │    %13 = (Base.sle_int)(1, 3)::Bool                                                            ││╻╷╷       checkbounds
  │    %14 = (Base.sle_int)(3, %3)::Bool                                                           │││┃││       checkbounds
  │    %15 = (Base.and_int)(%13, %14)::Bool                                                        ││││╻         checkindex
  └───       goto #7 if not %15                                                                    │││       
  6 ──       goto #8                                                                               │││       
  7 ──       invoke Main.__subarray_throw_boundserror(SubArray{Float64,1,Array{Float64,1},Tuple{Base.Slice{Base.OneTo{Int64}}},true}::Type, _2::Array{Float64,1}, %8::Tuple{Base.Slice{Base.OneTo{Int64}}}, 0::Int64, 1::Int64, %12::Tuple{Int64})::Union{}
  │          $(Expr(:unreachable))::Union{}                                                        ││││      
  │          φ ()::Union{}                                                                         │││       
  └───       $(Expr(:unreachable))::Union{}                                                        │││       
  8 ┄─       nothing::Nothing                                                                      │         
  9 ── %23 = (Base.add_int)(0, 3)::Int64                                                           ││╻         +
  │    %24 = (Base.arrayref)(false, x, %23)::Float64                                               ││╻         getindex
  └───       goto #10                                                                              │╻         getindex
  10 ─       return %24                                                                            │         
) => Float64
```

So long dear `%10`.

Fixes https://github.com/JuliaLang/julia/issues/29860