### PR TITLE
use the simpler copyto! even if element types are different

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -826,7 +826,7 @@ julia> y
 """
 copyto!(dest, src)
 
-function copyto!(dest::AbstractArray{T,N}, src::AbstractArray{T,N}) where {T,N}
+function copyto!(dest::AbstractArray{T1,N}, src::AbstractArray{T2,N}) where {T1,T2,N}
     checkbounds(dest, axes(src)...)
     src′ = unalias(dest, src)
     for I in eachindex(IndexStyle(src′,dest), src′)


### PR DESCRIPTION
Avoids having to fall back to the `copyto!` below which does more boundschecks.

Seems to me like there is no reason to restrict this to arrays with the same element type.