### PR TITLE
Faster findall for bitarrays

### DIFF
--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1510,37 +1510,70 @@ function findprev(testf::Function, B::BitArray, start::Integer)
 end
 #findlast(testf::Function, B::BitArray) = findprev(testf, B, 1)  ## defined in array.jl
 
-function findall(B::BitArray)
-    l = length(B)
-    nnzB = count(B)
+# findall helper functions
+# Generic case (>2 dimensions)
+function allindices!(I, B::BitArray)
     ind = first(keys(B))
-    I = Vector{typeof(ind)}(undef, nnzB)
-    nnzB == 0 && return I
-    Bc = B.chunks
-    Icount = 1
-    for i = 1:length(Bc)-1
-        u = UInt64(1)
-        c = Bc[i]
-        for j = 1:64
-            if c & u != 0
-                I[Icount] = ind
-                Icount += 1
-            end
-            ind = nextind(B, ind)
-            u <<= 1
-        end
-    end
-    u = UInt64(1)
-    c = Bc[end]
-    for j = 0:_mod64(l-1)
-        if c & u != 0
-            I[Icount] = ind
-            Icount += 1
-        end
+    for k = 1:length(B)
+        I[k] = ind
         ind = nextind(B, ind)
-        u <<= 1
     end
-    return I
+end
+
+# Optimized case for vector
+function allindices!(I, B::BitVector)
+    I[:] .= 1:length(B)
+end
+
+# Optimized case for matrix
+function allindices!(I, B::BitMatrix)
+    k = 1
+    for c = 1:size(B,2), r = 1:size(B,1)
+        I[k] = CartesianIndex(r, c)
+        k += 1
+    end
+end
+
+@inline overflowind(i1, irest::Tuple{}, size) = (i1, irest)
+@inline function overflowind(i1, irest, size)
+    i2 = irest[1]
+    while i1 > size[1]
+        i1 -= size[1]
+        i2 += 1
+    end
+    i2, irest = overflowind(i2, tail(irest), tail(size))
+    return (i1, (i2, irest...))
+end
+
+@inline toind(i1, irest::Tuple{}) = i1
+@inline toind(i1, irest) = CartesianIndex(i1, irest...)
+
+function findall(B::BitArray)
+    nnzB = count(B)
+    I = Vector{eltype(keys(B))}(undef, nnzB)
+    nnzB == 0 && return I
+    nnzB == length(B) && (allindices!(I, B); return I)
+    Bc = B.chunks
+    Bs = size(B)
+    Bi = i1 = i = 1
+    irest = ntuple(one, length(B.dims) - 1)
+    c = Bc[1]
+    @inbounds while true
+        while c == 0
+            Bi == length(Bc) && return I
+            i1 += 64
+            Bi += 1
+            c = Bc[Bi]
+        end
+
+        tz = trailing_zeros(c)
+        c = _blsr(c)
+
+        i1, irest = overflowind(i1 + tz, irest, Bs)
+        I[i] = toind(i1, irest)
+        i += 1
+        i1 -= tz
+    end
 end
 
 # For performance

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -1534,19 +1534,19 @@ function allindices!(I, B::BitMatrix)
     end
 end
 
-@inline overflowind(i1, irest::Tuple{}, size) = (i1, irest)
-@inline function overflowind(i1, irest, size)
+@inline _overflowind(i1, irest::Tuple{}, size) = (i1, irest)
+@inline function _overflowind(i1, irest, size)
     i2 = irest[1]
     while i1 > size[1]
         i1 -= size[1]
         i2 += 1
     end
-    i2, irest = overflowind(i2, tail(irest), tail(size))
+    i2, irest = _overflowind(i2, tail(irest), tail(size))
     return (i1, (i2, irest...))
 end
 
-@inline toind(i1, irest::Tuple{}) = i1
-@inline toind(i1, irest) = CartesianIndex(i1, irest...)
+@inline _toind(i1, irest::Tuple{}) = i1
+@inline _toind(i1, irest) = CartesianIndex(i1, irest...)
 
 function findall(B::BitArray)
     nnzB = count(B)
@@ -1556,7 +1556,7 @@ function findall(B::BitArray)
     Bc = B.chunks
     Bs = size(B)
     Bi = i1 = i = 1
-    irest = ntuple(one, length(B.dims) - 1)
+    irest = ntuple(one, ndims(B) - 1)
     c = Bc[1]
     @inbounds while true
         while c == 0
@@ -1569,8 +1569,8 @@ function findall(B::BitArray)
         tz = trailing_zeros(c)
         c = _blsr(c)
 
-        i1, irest = overflowind(i1 + tz, irest, Bs)
-        I[i] = toind(i1, irest)
+        i1, irest = _overflowind(i1 + tz, irest, Bs)
+        I[i] = _toind(i1, irest)
         i += 1
         i1 -= tz
     end

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1176,11 +1176,12 @@ timesofar("datamove")
     @check_bit_operation findall(b1) Vector{CartesianIndex{3}}
 
     # BitArrays of various dimensions
-    for dims = 2:8
+    for dims = 0:8
         t = Tuple(fill(2, dims))
-        @check_bit_operation findall(trues(t)) Vector{CartesianIndex{dims}}
-        @check_bit_operation findall(falses(t)) Vector{CartesianIndex{dims}}
-        @check_bit_operation findall(bitrand(t)) Vector{CartesianIndex{dims}}
+        ret_type = Vector{dims == 1 ? Int : CartesianIndex{dims}}
+        @check_bit_operation findall(trues(t)) ret_type
+        @check_bit_operation findall(falses(t)) ret_type
+        @check_bit_operation findall(bitrand(t)) ret_type
     end
 end
 

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -1159,9 +1159,29 @@ timesofar("datamove")
         @test findnextnot((.~(b1 >> i)) .⊻ submask, j) == i+1
     end
 
+    # Do a few more thorough tests for findall
     b1 = bitrand(n1, n2)
     @check_bit_operation findall(b1) Vector{CartesianIndex{2}}
     @check_bit_operation findall(!iszero, b1) Vector{CartesianIndex{2}}
+
+    # tall-and-skinny (test index overflow logic in findall)
+    @check_bit_operation findall(bitrand(1, 1, 1, 250)) Vector{CartesianIndex{4}}
+
+    # empty dimensions
+    @check_bit_operation findall(bitrand(0, 0, 10)) Vector{CartesianIndex{3}}
+
+    # sparse (test empty 64-bit chunks in findall)
+    b1 = falses(8, 8, 8)
+    b1[3,3,3] = b1[6,6,6] = true
+    @check_bit_operation findall(b1) Vector{CartesianIndex{3}}
+
+    # BitArrays of various dimensions
+    for dims = 2:8
+        t = Tuple(fill(2, dims))
+        @check_bit_operation findall(trues(t)) Vector{CartesianIndex{dims}}
+        @check_bit_operation findall(falses(t)) Vector{CartesianIndex{dims}}
+        @check_bit_operation findall(bitrand(t)) Vector{CartesianIndex{dims}}
+    end
 end
 
 timesofar("find")


### PR DESCRIPTION
Inspired by a [recent PR](https://github.com/JuliaLang/julia/pull/29746) by @chethega for logically indexing a BitArray, and a [challenge on Discourse](https://discourse.julialang.org/t/compiling-to-branch-table/16599/14) to create an efficient `findall(::BitMatrix)`, here's my attempt -- an optimized `findall` that works for any `BitArray`.

The idea is very similar to the PR by @chethega ; using `trailing_zeros` and `_blsr` to iterate through the bits. For multidimensional indices, when the index for a dimension grows larger than its size, it's carried over to the next dimension. I solve this with a `while` loop and recursive inlining.

This version is around 0.7 - 75 times faster than the current `findall(::BitArray)` in my tests (on Intel Broadwell and Skylake; see timings below). The biggest speedups are for sparse matrices. It may perform worse than the current implementation for certain arrays, typically arrays that share one or more of the following traits: almost all values true (say >90%), has a small first dimension (say < 16), and has many dimensions (≥ 4-5, where the current code, due to its simplicity, is better at storing variables in registers). To mitigate this a bit, I threw in a cheap optimization for arrays that are all true.

I experimented with a few other ideas to improve performance:

- For an empty chunk, instead of adding 64 to the 1st dimension index, and then possibly doing several iterations to carry indices over to larger dimensions, pre-compute a vector of index additions. E.g. for a (5x5x5) array, adding 64 would add (4,2,2) to the indices. This technique greatly speeds up finding in sparse arrays where the first dimension is small (say < 16). However, it's slower for every other type of array. One could imagine an introspective algorithm that does this when the first dimension is small, however I'm not sure that it's worth the more complicated code.

- Use the "Division by invariant integers using multiplication" technique to branchlessly update indices, at the cost of a few multiplications, shifts and subtractions. This proved to be slower than the carry-over solution in all cases except arrays where the first dimension is small. It also significantly increases the risk for bugs (like rounding errors for certain dimensions).

This is my first PR and contribution to Julia, so please bear with me if I've missed something in the process. It's probably a good idea to add a few more tests in `test/bitarray.jl`, I'm thinking to test higher dimensions, sparse matrices (empty chunks), all true matrices, etc. I'll wait with that until I get some feedback on this PR.

Below are timings for a few differently sized arrays and fill rates, run on a 2.6 GHz Skylake, Julia 1.0.1, Ubuntu. To reproduce these experiments, run [this script](https://github.com/maxbennedich/julia-scripts/blob/master/findall_benchmark.jl).

```
       size      | selected |  old time  |   per idx  |  cycles |  new time  |   per idx  |  cycles | speedup
-------------------------------------------------------------------------------------------------------------
          100000 |    0.1 % |   80.95 μs |  785.95 ns | 2043.47 |    1.12 μs |   10.84 ns |   28.18 | 72.52 x
          100000 |    1.0 % |   84.33 μs |   83.75 ns |  217.74 |    2.06 μs |    2.05 ns |    5.32 | 40.92 x
          100000 |    5.0 % |  110.87 μs |   22.32 ns |   58.03 |    6.60 μs |    1.33 ns |    3.45 | 16.80 x
          100000 |   20.1 % |  240.57 μs |   11.96 ns |   31.10 |   23.09 μs |    1.15 ns |    2.99 | 10.42 x
          100000 |   50.0 % |  347.19 μs |    6.94 ns |   18.04 |   42.96 μs |    0.86 ns |    2.23 |  8.08 x
          100000 |   80.0 % |  212.94 μs |    2.66 ns |    6.92 |   59.93 μs |    0.75 ns |    1.95 |  3.55 x
          100000 |   99.0 % |   91.03 μs |    0.92 ns |    2.39 |   71.33 μs |    0.72 ns |    1.87 |  1.28 x
          100000 |  100.0 % |   80.60 μs |    0.81 ns |    2.10 |   47.35 μs |    0.47 ns |    1.23 |  1.70 x
       191 x 211 |    0.1 % |   35.32 μs |  802.80 ns | 2087.27 |    0.53 μs |   12.08 ns |   31.42 | 66.44 x
       191 x 211 |    1.0 % |   41.88 μs |  102.15 ns |  265.58 |    1.09 μs |    2.66 ns |    6.93 | 38.34 x
       191 x 211 |    5.1 % |   51.54 μs |   25.05 ns |   65.14 |    2.97 μs |    1.45 ns |    3.76 | 17.33 x
       191 x 211 |   20.2 % |   91.44 μs |   11.23 ns |   29.20 |   11.91 μs |    1.46 ns |    3.80 |  7.68 x
       191 x 211 |   50.1 % |  150.58 μs |    7.46 ns |   19.40 |   25.44 μs |    1.26 ns |    3.28 |  5.92 x
       191 x 211 |   80.0 % |   96.48 μs |    2.99 ns |    7.78 |   39.09 μs |    1.21 ns |    3.15 |  2.47 x
       191 x 211 |   99.0 % |   58.39 μs |    1.46 ns |    3.81 |   47.41 μs |    1.19 ns |    3.09 |  1.23 x
       191 x 211 |  100.0 % |   53.74 μs |    1.33 ns |    3.47 |   36.30 μs |    0.90 ns |    2.34 |  1.48 x
   15 x 201 x 10 |    0.1 % |   31.97 μs | 1031.29 ns | 2681.35 |    1.15 μs |   37.19 ns |   96.69 | 27.73 x
   15 x 201 x 10 |    1.0 % |   28.17 μs |   91.46 ns |  237.81 |    1.51 μs |    4.89 ns |   12.71 | 18.71 x
   15 x 201 x 10 |    5.1 % |   42.36 μs |   27.69 ns |   71.99 |    3.26 μs |    2.13 ns |    5.54 | 12.98 x
   15 x 201 x 10 |   20.2 % |   82.04 μs |   13.48 ns |   35.06 |   17.71 μs |    2.91 ns |    7.57 |  4.63 x
   15 x 201 x 10 |   50.0 % |  123.95 μs |    8.22 ns |   21.38 |   34.65 μs |    2.30 ns |    5.98 |  3.58 x
   15 x 201 x 10 |   80.1 % |   83.27 μs |    3.45 ns |    8.96 |   49.03 μs |    2.03 ns |    5.28 |  1.70 x
   15 x 201 x 10 |   99.0 % |   52.59 μs |    1.76 ns |    4.58 |   48.26 μs |    1.62 ns |    4.20 |  1.09 x
   15 x 201 x 10 |  100.0 % |   41.09 μs |    1.36 ns |    3.54 |   38.28 μs |    1.27 ns |    3.30 |  1.07 x
 64 x 9 x 3 x 18 |    0.1 % |   31.06 μs |  913.62 ns | 2375.41 |    0.55 μs |   16.13 ns |   41.94 | 56.63 x
 64 x 9 x 3 x 18 |    1.0 % |   32.98 μs |  102.74 ns |  267.14 |    1.23 μs |    3.82 ns |    9.93 | 26.90 x
 64 x 9 x 3 x 18 |    5.1 % |   39.37 μs |   24.90 ns |   64.75 |    4.70 μs |    2.97 ns |    7.73 |  8.38 x
 64 x 9 x 3 x 18 |   20.1 % |   71.85 μs |   11.47 ns |   29.83 |   14.86 μs |    2.37 ns |    6.17 |  4.84 x
 64 x 9 x 3 x 18 |   50.0 % |  114.08 μs |    7.34 ns |   19.08 |   34.62 μs |    2.23 ns |    5.79 |  3.29 x
 64 x 9 x 3 x 18 |   80.2 % |   77.28 μs |    3.10 ns |    8.06 |   56.98 μs |    2.28 ns |    5.94 |  1.36 x
 64 x 9 x 3 x 18 |   99.0 % |   62.85 μs |    2.04 ns |    5.31 |   68.60 μs |    2.23 ns |    5.79 |  0.92 x
 64 x 9 x 3 x 18 |  100.0 % |   69.02 μs |    2.22 ns |    5.77 |   60.30 μs |    1.94 ns |    5.04 |  1.14 x
```
