### PR TITLE
RFC: I::CartesianIndices .+ j::CartesianIndex -> ::CartesianIndices

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ Standard library changes
 ------------------------
 
   * `CartesianIndices` can now be constructed from two `CartesianIndex`es `I` and `J` with `I:J` ([#29440]).
+  * `CartesianIndices` support broadcasting arithmetic (+ and -) with a `CartesianIndex` ([#29890]).
   * `copy!` support for arrays, dicts, and sets has been moved to Base from the Future package ([#29173]).
   * Channels now convert inserted values (like containers) instead of requiring types to match ([#29092]).
   * `range` can accept the stop value as a positional argument, e.g. `range(1,10,step=2)` ([#28708]).

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1006,6 +1006,18 @@ broadcasted(::DefaultArrayStyle{1}, ::typeof(big), r::StepRange) = big(r.start):
 broadcasted(::DefaultArrayStyle{1}, ::typeof(big), r::StepRangeLen) = StepRangeLen(big(r.ref), big(r.step), length(r), r.offset)
 broadcasted(::DefaultArrayStyle{1}, ::typeof(big), r::LinRange) = LinRange(big(r.start), big(r.stop), length(r))
 
+## CartesianIndices
+broadcasted(::typeof(+), I::CartesianIndices{N}, j::CartesianIndex{N}) where N =
+    CartesianIndices(map((rng, offset)->rng .+ offset, I.indices, Tuple(j)))
+broadcasted(::typeof(+), j::CartesianIndex{N}, I::CartesianIndices{N}) where N =
+    I .+ j
+broadcasted(::typeof(-), I::CartesianIndices{N}, j::CartesianIndex{N}) where N =
+    CartesianIndices(map((rng, offset)->rng .- offset, I.indices, Tuple(j)))
+function broadcasted(::typeof(-), j::CartesianIndex{N}, I::CartesianIndices{N}) where N
+    diffrange(offset, rng) = range(offset-last(rng), length=length(rng))
+    Iterators.reverse(CartesianIndices(map(diffrange, Tuple(j), I.indices)))
+end
+
 ## In specific instances, we can broadcast masked BitArrays whole chunks at a time
 # Very intentionally do not support much functionality here: scalar indexing would be O(n)
 struct BitMaskedBitArray{N,M}

--- a/test/abstractarray.jl
+++ b/test/abstractarray.jl
@@ -909,6 +909,11 @@ end
         J1, J2 = @inferred(promote(I1, I2))
         @test J1 === J2
     end
+
+    i = CartesianIndex(17,-2)
+    @test CR .+ i === i .+ CR === CartesianIndices((19:21, -1:3))
+    @test CR .- i === CartesianIndices((-15:-13, 3:7))
+    @test collect(i .- CR) == Ref(i) .- collect(CR)
 end
 
 @testset "issue #25770" begin


### PR DESCRIPTION
In the course of implementing a multidimensional convolution I noticed this seems to be a natural but missing operation. This PR might be slightly provocative because it further cements the notion that [`CartesianIndex` objects are treated like scalars](https://github.com/JuliaLang/julia/issues/26227#issuecomment-369742126) when it comes to broadcasting. Currently this operation results in a "helpful" error message:

```julia
julia> I = CartesianIndices((0:2, 1:5))
3×5 CartesianIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}}:
 CartesianIndex(0, 1)  CartesianIndex(0, 2)  CartesianIndex(0, 3)  CartesianIndex(0, 4)  CartesianIndex(0, 5)
 CartesianIndex(1, 1)  CartesianIndex(1, 2)  CartesianIndex(1, 3)  CartesianIndex(1, 4)  CartesianIndex(1, 5)
 CartesianIndex(2, 1)  CartesianIndex(2, 2)  CartesianIndex(2, 3)  CartesianIndex(2, 4)  CartesianIndex(2, 5)

julia> j = CartesianIndex(14,-22)
CartesianIndex(14, -22)

julia> I .+ j
ERROR: iteration is deliberately unsupported for CartesianIndex. Use `I` rather than `I...`, or use `Tuple(I)...`
Stacktrace:
 [1] getindex at ./array.jl:739 [inlined]
 [2] error(::String) at ./dict.jl:327
 [3] iterate(::CartesianIndex{2}) at ./multidimensional.jl:153
 [4] copyto!(::Array{Int64,1}, ::CartesianIndex{2}) at ./abstractarray.jl:646
 [5] _collect(::UnitRange{Int64}, ::CartesianIndex{2}, ::Base.HasEltype, ::Base.HasLength) at ./array.jl:563
 [6] collect(::CartesianIndex{2}) at ./array.jl:557
 [7] broadcastable(::CartesianIndex{2}) at ./broadcast.jl:609
 [8] broadcasted(::Function, ::CartesianIndices{2,Tuple{UnitRange{Int64},UnitRange{Int64}}}, ::CartesianIndex{2}) at ./broadcast.jl:1164
 [9] top-level scope at none:0
 [10] eval(::Module, ::Any) at ./client.jl:209
 [11] eval_user_input(::Any, ::REPL.REPLBackend) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:501
 [12] run_backend(::REPL.REPLBackend) at /home/tim/.julia/dev/Revise/src/Revise.jl:766
 [13] (::getfield(Revise, Symbol("##58#60")){REPL.REPLBackend})() at ./task.jl:259
```

That error message is really intended to catch cases like `a[j...]`, but it gets triggered here too. In any event, we'd need a specialized implementation just as we do for `AbstractRange` objects, because it's important to return it as a `CartesianIndices` object.

This has one notable omission: `j .- I`. That's because the result can't be expressed as a `CartesianIndices`. We could return an `Iterators.product(...)` result here, or a dense array, or just let it error. Thoughts?

I pushed this with `ci skip` because I want to insert the issue number into NEWS, and I don't know what will be assigned. Once any discussion happens I'll push an amended version.