### PR TITLE
avoid expensive runtime div in parse for common bases

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -107,7 +107,10 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     end
 
     base = convert(T, base)
-    m::T = div(typemax(T) - base + 1, base)
+    # Special case the common cases of base being 10 or 16 to avoid expensive runtime div
+    m::T = base == 10 ? div(typemax(T) - T(9), T(10)) :
+           base == 16 ? div(typemax(T) - T(15), T(16)) :
+                        div(typemax(T) - base + 1, base)
     n::T = 0
     a::Int = base <= 36 ? 10 : 36
     _0 = UInt32('0')


### PR DESCRIPTION
10 and 16 are common bases to parse to so let's avoid the "killer div" in those cases.

Benchmarks:

```jl
julia> @btime parse(Int64, "12");
  45.326 ns (0 allocations: 0 bytes)

julia> @btime parse(Int64, "12345678912345");
  84.381 ns (0 allocations: 0 bytes)

julia> @btime parse(UInt8, "0x10");
  47.826 ns (0 allocations: 0 bytes)

julia> @btime parse(UInt64, "0x123aca1231a");
  78.174 ns (0 allocations: 0 bytes)
```


After

```jl
julia> @btime parse(Int64, "12");
  36.399 ns (0 allocations: 0 bytes)

julia> @btime parse(Int64, "12345678912345");
  74.086 ns (0 allocations: 0 bytes)

julia> @btime parse(UInt8, "0x10");
  39.586 ns (0 allocations: 0 bytes)

julia> @btime parse(UInt64, "0x123aca1231a");
  72.017 ns (0 allocations: 0 bytes)
```

I have some thought on how this overflow handling can be done a bit better, but for now, might as well do the incremental thing.
