### PR TITLE
Clarified matrix column order example in performance-tips.md

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -843,6 +843,8 @@ function copy_row_col(x::Vector{T}) where T
 end
 ```
 
+(Note that the assignment operation `out[_] = x[_]` is an implicit inner loop.)
+
 Now we will time each of these functions using the same random `10000` by `1` input vector:
 
 ```julia-repl


### PR DESCRIPTION
For newcomers, it is really important to highlight that the "inner loop" is implicit in the assignment operation of the given examples. Took me longer than I care to admit to catch what I was missing.

I'm not certain how to run "make docs" on Windows, so I haven't checked it.