### PR TITLE
Treat zero-dimensional views as contiguous SubArrays

### DIFF
--- a/test/subarray.jl
+++ b/test/subarray.jl
@@ -619,3 +619,6 @@ function _test_27632(A)
 end
 # check that this doesn't crash
 _test_27632(view(ones(Int64, (1, 1, 1)), 1, 1, 1))
+
+# issue #29608 - views of single values can be considered contiguous
+@test Base.iscontiguous(view(ones(1), 1))


### PR DESCRIPTION
This makes sure that zero-dimensional SubArrays (views of a single value) are indexed with `IndexLinear` and are a subtype of `FastContiguousSubArray`. This way, `iscontiguous` returns `true` for such a view.

The rationale for this is that `iscontiguous` can be used to decide whether a SubArray can be passed to a C function, as is done in the package [MPI.jl](https://github.com/JuliaParallel/MPI.jl). With the proposed changes, single values of an array can be sent and received with MPI by passing a zero-dimensional view to the MPI functions.

Fixes #29608 