### PR TITLE
Add new API afterreplinit for REPL mode packages

### DIFF
--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -784,6 +784,7 @@ Prior to Julia 1.6, and still supported throughout Julia 1.x, one can also confi
 
 ```@docs
 Base.atreplinit
+Base.afterreplinit
 ```
 
 ### TerminalMenus

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -934,9 +934,9 @@ end
             try
                 empty!(Base._afterreplinit_hooks)
                 called = Ref(false)
-                Base.afterreplinit((_) -> (called[] = true))
+                Base.afterreplinit((_, _) -> (called[] = true))
                 if !(repl_was_defined && backend_was_defined)
-                    Base._afterreplinit(nothing)
+                    Base._afterreplinit(nothing, nothing)
                 end
                 @test called[]
 
@@ -944,8 +944,9 @@ end
                 Base.eval(Base, :(active_repl_backend = :DUMMY_BACKEND))
                 called = Ref(false)
                 n = length(Base._afterreplinit_hooks)
-                Base.afterreplinit() do repl
+                Base.afterreplinit() do repl, backend
                     @test repl == :DUMMY_REPL
+                    @test backend == :DUMMY_BACKEND
                     called[] = true
                 end
                 @test called[]

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -955,12 +955,6 @@ end
             end
         end
     end
-
-    was_defined = isdefined(Base, :active_repl)
-    if was_defined
-        repl = Base.active_repl
-    end
-
 end
 
 let ends_with_semicolon = REPL.ends_with_semicolon


### PR DESCRIPTION
As I mentioned in https://github.com/JuliaLang/PackageCompiler.jl/issues/68#issuecomment-435235879, it would be nice to have a variant of `atreplinit` which ensures that the hook is run even after REPL is initialized.

For example, `Pkg.__init__` can be simplified to:

```diff
@@ -336,14 +336,9 @@ const setprotocol! = API.setprotocol!
 
 
 function __init__()
-    if isdefined(Base, :active_repl)
-        REPLMode.repl_init(Base.active_repl)
-    else
-        atreplinit() do repl
-            if isinteractive() && repl isa REPL.LineEditREPL
-                isdefined(repl, :interface) || (repl.interface = REPL.setup_interface(repl))
-                REPLMode.repl_init(repl)
-            end
+    Base.afterreplinit() do repl
+        if isinteractive() && repl isa REPL.LineEditREPL
+            REPLMode.repl_init(repl)
         end
     end
 end
```

Additionally, I suggest to initialize `repl.interface` before `atreplinit` (hence `afterreplinit`).  This gets rid of `isdefined(repl, :interface)` in `Pkg.__init__` above and also helps some REPL-based packages to register keybinds etc.
