### PR TITLE
Suggestion: Use different precompilation cache path for different system image

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -135,8 +135,6 @@ end
 
 function package_slug(uuid::UUID, p::Int=5)
     crc = _crc32c(uuid)
-    crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
-    crc = _crc32c(unsafe_string(JLOptions().julia_bin), crc)
     return slug(crc, p)
 end
 
@@ -1193,7 +1191,10 @@ function compilecache_path(pkg::PkgId)::String
     if pkg.uuid === nothing
         abspath(cachepath, entryfile) * ".ji"
     else
-        project_precompile_slug = slug(_crc32c(something(Base.active_project(), "")), 5)
+        crc = _crc32c(something(Base.active_project(), ""))
+        crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
+        crc = _crc32c(unsafe_string(JLOptions().julia_bin), crc)
+        project_precompile_slug = slug(crc, 5)
         abspath(cachepath, string(entryfile, "_", project_precompile_slug, ".ji"))
     end
 end

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -135,6 +135,7 @@ end
 
 function package_slug(uuid::UUID, p::Int=5)
     crc = _crc32c(uuid)
+    crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
     return slug(crc, p)
 end
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -136,6 +136,7 @@ end
 function package_slug(uuid::UUID, p::Int=5)
     crc = _crc32c(uuid)
     crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
+    crc = _crc32c(unsafe_string(JLOptions().julia_bin), crc)
     return slug(crc, p)
 end
 


### PR DESCRIPTION
With PackageCompiler.jl, it is easy to create custom system images.  I think it would be useful if you can create a custom image for some Julia projects you use repeatedly.  However, it is hard to use different system images since all the precompilation cache files are stale after switching the system image.  This patch makes it possible to use dedicated set of cache files for each system image.  Each system image is identified by its path so that precompilation cache files used for Julia master are updated in-place after you pulled and build Julia (as oppose to increase disk usage for each pull).

(As a side-effect, this patch can be used as a workaround of #27418.)
