### PR TITLE
Update the Regex section of strings.md.

### DIFF
--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -947,7 +947,7 @@ julia> d = Date(1962,7,10)
 julia> regex_d = Regex("Day " * string(day(d)))
 r"Day 10"
 
-julia> match(regex_d,"It happened on Day 10")
+julia> match(regex_d, "It happened on Day 10")
 RegexMatch("Day 10")
 
 julia> name = "Jon"

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -936,6 +936,33 @@ ERROR: syntax: invalid escape sequence
 Triple-quoted regex strings, of the form `r"""..."""`, are also supported (and may be convenient
 for regular expressions containing quotation marks or newlines).
 
+The Regex() constructor may be used to create a valid regex string programmatically.  This permits using the contents of string variables and other string operations when constructing the regex string. Any of the regex codes above can be used within the single string argument to Regex(). Here are some examples:
+
+```julia-repl
+julia> using Dates
+
+julia> d = Date(1962,7,10)
+1962-07-10
+
+julia> regex_d = Regex("Day " * string(day(d)))
+r"Day 10"
+
+julia> match(regex_d,"It happened on Day 10")
+RegexMatch("Day 10")
+
+julia> name = "Jon"
+"Jon"
+
+julia> regex_name = Regex("[\"( ]$name[\") ]")  # interpolate value of name
+r"[\"( ]Jon[\") ]"
+
+julia> match(regex_name," Jon ")
+RegexMatch(" Jon ")
+
+julia> match(regex_name,"[Jon]") === nothing
+true
+```
+
 ## [Byte Array Literals](@id man-byte-array-literals)
 
 Another useful non-standard string literal is the byte-array string literal: `b"..."`. This

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -938,7 +938,7 @@ for regular expressions containing quotation marks or newlines).
 
 The `Regex()` constructor may be used to create a valid regex string programmatically.  This permits using the contents of string variables and other string operations when constructing the regex string. Any of the regex codes above can be used within the single string argument to `Regex()`. Here are some examples:
 
-```julia-repl
+```jldoctest
 julia> using Dates
 
 julia> d = Date(1962,7,10)

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -936,7 +936,7 @@ ERROR: syntax: invalid escape sequence
 Triple-quoted regex strings, of the form `r"""..."""`, are also supported (and may be convenient
 for regular expressions containing quotation marks or newlines).
 
-The Regex() constructor may be used to create a valid regex string programmatically.  This permits using the contents of string variables and other string operations when constructing the regex string. Any of the regex codes above can be used within the single string argument to Regex(). Here are some examples:
+The `Regex()` constructor may be used to create a valid regex string programmatically.  This permits using the contents of string variables and other string operations when constructing the regex string. Any of the regex codes above can be used within the single string argument to `Regex()`. Here are some examples:
 
 ```julia-repl
 julia> using Dates


### PR DESCRIPTION
This adds a brief description and example of using the Regex constructor to create regex strings programmatically.  I could not find this in documentation, but found Regex in source code.