### PR TITLE
Improve _apply(apply_type, ::Tuple, ::SimpleVector)

### DIFF
--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -247,3 +247,13 @@ let code = code_typed(f_pointerref, Tuple{Type{Int}})[1][1].code
     end
     @test !any_ptrref
 end
+
+# Test that inlining can inline _applys of builtins/_applys on SimpleVectors
+function foo_apply_apply_type_svec()
+    A = (Tuple, Float32)
+    B = Tuple{Float32, Float32}
+    Core.apply_type(A..., B.types...)
+end
+let ci = code_typed(foo_apply_apply_type_svec, Tuple{})[1].first
+    @test length(ci.code) == 1 && ci.code[1] == Expr(:return, NTuple{3, Float32})
+end


### PR DESCRIPTION
This is another one of those patterns that doesn't generally
come up except in Cassette/Zygote code. There's two related
changes here:

1. Expand ininling's _apply rewrite to also handle constant
   svecs (under the restriction that they must be no longer than
   the splatting cutoff and the elements must be individually eligible
   for inlining into the IR)
2. Move the _apply rewrite before the special case inliner for builtins
   such that _apply(apply_type, ...) gets eliminated early.