### PR TITLE
Add missing backslashes in LaTeX syntax in the document of binomial function

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -828,18 +828,18 @@ end
 """
     binomial(n::Integer, k::Integer)
 
-The _binomial coefficient_ ``\binom{n}{k}``, being the coefficient of the ``k``th term in
+The _binomial coefficient_ ``\\binom{n}{k}``, being the coefficient of the ``k``th term in
 the polynomial expansion of ``(1+x)^n``.
 
 If ``n`` is non-negative, then it is the number of ways to choose `k` out of `n` items:
 ```math
-\binom{n}{k} = \frac{n!}{k! (n-k)!}
+\\binom{n}{k} = \\frac{n!}{k! (n-k)!}
 ```
 where ``n!`` is the [`factorial`](@ref) function.
 
 If ``n`` is negative, then it is defined in terms of the identity
 ```math
-\binom{n}{k} = (-1)^k \binom{k-n-1}{k}
+\\binom{n}{k} = (-1)^k \\binom{k-n-1}{k}
 ```
 
 # Examples

--- a/doc/src/manual/documentation.md
+++ b/doc/src/manual/documentation.md
@@ -606,6 +606,11 @@ A paragraph containing some ``\LaTeX`` markup.
     backticks use an even number greater than two. Note that if a single literal backtick needs to
     be included within ``\LaTeX`` markup then two enclosing backticks is sufficient.
 
+!!! note
+    The `\` character should be escaped appropriately if the text is embedded in a Julia source code,
+    for example, ``` "``\\LaTeX`` syntax in a docstring." ```, since it is interpreted as a string
+    literal.
+
 #### Links
 
 Links to either external or internal addresses can be written using the following syntax, where


### PR DESCRIPTION
I looked up the document of binomial function in Base today, and it seems a little weird. I think it is because of the lack of backslashes for LaTeX syntax. Could you check?