### PR TITLE
inference: remove ability to infer `f(svec(a, b, c)...)`

### DIFF
--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -960,22 +960,6 @@ f21653() = f21653()
 @test code_typed(f21653, Tuple{}, optimize=false)[1] isa Pair{CodeInfo, typeof(Union{})}
 @test which(f21653, ()).specializations.func.rettype === Union{}
 
-# ensure _apply can "see-through" SSAValue to infer precise container types
-let f, m
-    f() = 0
-    m = first(methods(f))
-    m.source = Base.uncompressed_ast(m)::CodeInfo
-    m.source.code = Any[
-        Expr(:call, GlobalRef(Core, :svec), 1, 2, 3),
-        Expr(:call, Core._apply, GlobalRef(Base, :+), SSAValue(1)),
-        Expr(:return, SSAValue(2))
-    ]
-    nstmts = length(m.source.code)
-    m.source.ssavaluetypes = nstmts
-    m.source.codelocs = fill(Int32(1), nstmts)
-    @test @inferred(f()) == 6
-end
-
 # issue #22290
 f22290() = return 3
 for i in 1:3


### PR DESCRIPTION
It seems unlikely that this code pattern is used anywhere (since the code would need to literally syntactically call `svec` and immediately splat the result into another call--as shown above), and it is the last instance of this inference hack we have remaining (after the PartialTuple work). If some package does end up needing it, we can easily reimplement it much better (via adding PartialSimpleVector), but I strongly suspect this is effectively dead-code, and thus not worthwhile to maintain.