### PR TITLE
Add missing devdoc pages to make.jl

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -132,6 +132,8 @@ const PAGES = [
             "devdocs/offset-arrays.md",
             "devdocs/require.md",
             "devdocs/inference.md",
+            "devdocs/ssair.md",
+            "devdocs/gc-sa.md",
         ],
         "Developing/debugging Julia's C code" => [
             "devdocs/backtraces.md",


### PR DESCRIPTION
It looks like that these two devdocs pages are not being built in the manual (thanks to @jekbradbury for noticing this!). Didn't look at the contents, just assuming that if they are present under `devdocs/`, they should probably be part of the manual.