### PR TITLE
Add `+/-` for `Number` and `AbstractMatrix` to `LinearAlgebra` 

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -97,6 +97,12 @@ isposdef(J::UniformScaling) = isposdef(J.λ)
 (-)(J::UniformScaling, B::BitArray{2})      = J - Array(B)
 (-)(A::AbstractMatrix, J::UniformScaling)   = A + (-J)
 
+# Promotion of scalar to uniform scaling under addition/subtraction
+(+)(a::Number, A::AbstractMatrix) = UniformScaling(a) + A
+(+)(A::AbstractMatrix, a::Number) = A + UniformScaling(a)
+(-)(a::Number, A::AbstractMatrix) = UniformScaling(a) - A
+(-)(A::AbstractMatrix, a::Number) = A - UniformScaling(a)
+
 # Unit{Lower/Upper}Triangular matrices become {Lower/Upper}Triangular under
 # addition with a UniformScaling
 for (t1, t2) in ((:UnitUpperTriangular, :UpperTriangular),

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -64,6 +64,16 @@ end
     @test UniformScaling(α)/α == UniformScaling(1.0)
 end
 
+@testset "conversion of Number" begin
+    α = randn()
+    J = UniformScaling(α)
+    A = randn(2, 2)
+    @test α + A == J + A
+    @test A + α == A + J
+    @test α - A == J - A
+    @test A - α == A - J
+end
+
 @testset "det and logdet" begin
     @test det(I) === true
     @test det(1.0I) === 1.0


### PR DESCRIPTION
This is a follow-up to: https://github.com/JuliaLang/LinearAlgebra.jl/issues/449.

With the deprecation of automatic broadcasting and things having seemingly settled, it is now possible to introduce automatic promotion of `Number` to `UniformScaling`.  The arguments for this can be found in the issue linked above, but distils to:
 * a desire for `+` to obey the common distributive property of `(A + B)*C == A*C + B*C` for all mathematical objects in Julia where this is generally valid; this does not currently hold for `(matrix + scalar)*vector == matrix*vector + scalar*vector`
 * a desire to be able to write generic code like `f(x, y) = x^2 + y^2 + 2*x*y` which does not require special casing on scalars and matrices; the "generic" definition `f(x, y) = (I*x)^2 + (I*y)^2 + 2*(I*x)*(I*y)` will promote `f(::Number, ::Number)` to a `UniformScaling`.

The type piracy done here currently has the unfortunate side–effect of adding these methods to the method table of `+` and `-` without the user doing `using LinearAlgebra`, similar to how matrix multiplication is also exported.

Ideally, I think the feature implemented in this PR should only be available after `using LinearAlgebra`, but I have not been able to find a good way to do it.