### PR TITLE
Work around #29952.

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -108,7 +108,7 @@ tostr_sizehint(x::AbstractString) = lastindex(x)
 tostr_sizehint(x::Float64) = 20
 tostr_sizehint(x::Float32) = 12
 
-function print_to_string(xs...)
+function print_to_string(xs...; dontcare=nothing)
     if isempty(xs)
         return ""
     end

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -108,7 +108,7 @@ tostr_sizehint(x::AbstractString) = lastindex(x)
 tostr_sizehint(x::Float64) = 20
 tostr_sizehint(x::Float32) = 12
 
-function print_to_string(xs...; dontcare=nothing)
+function print_to_string(xs...; dontcare=nothing) # unused kwarg: JuliaLang/julia#29952
     if isempty(xs)
         return ""
     end


### PR DESCRIPTION
Proposed hotfix for https://github.com/JuliaGPU/CUDAnative.jl/issues/278, easy to backport. `print_to_string` is a very common function; even though in the case of GPU code it typically doesn't get emitted or optimized away, after https://github.com/JuliaLang/julia/pull/28876 it requires recursion which is GPU incompatible. Unless of course there's a easy fix for https://github.com/JuliaLang/julia/issues/29952.