### PR TITLE
Avoid recursion in print_to_string.

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -89,7 +89,7 @@ function IOBuffer(
         maxsize::Integer=typemax(Int),
         sizehint::Union{Integer,Nothing}=nothing)
     if maxsize < 0
-        throw(ArgumentError("negative maxsize: $(maxsize)"))
+        throw(ArgumentError("negative maxsize"))
     end
     if sizehint !== nothing
         sizehint!(data, sizehint)


### PR DESCRIPTION
Currently, `print_to_string` creates an `IOBuffer`, whose constructor may throw an `ArgumentError` that uses string interpolation, in turn relying on `string` which calls `print_to_string`.
Avoid that recursion by not using string interpolation in `IOBuffer`.

Implements https://github.com/JuliaLang/julia/pull/29953#issuecomment-436883010
Supersedes #29953 (avoiding https://github.com/JuliaLang/julia/pull/29953#issuecomment-436658796)