### PR TITLE
`isdeprecated` should not resolve binding

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -534,8 +534,11 @@ JL_DLLEXPORT void jl_deprecate_binding(jl_module_t *m, jl_sym_t *var, int flag)
 
 JL_DLLEXPORT int jl_is_binding_deprecated(jl_module_t *m, jl_sym_t *var)
 {
-    jl_binding_t *b = jl_get_binding(m, var);
-    return b && b->deprecated;
+    if (jl_binding_resolved_p(m, var)) {
+        jl_binding_t *b = jl_get_binding(m, var);
+        return b && b->deprecated;
+    }
+    return 0;
 }
 
 extern const char *jl_filename;

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -809,3 +809,7 @@ f20872(::Val, ::Val) = false
 @test which(f20872, Tuple{Val,Val}).sig == Tuple{typeof(f20872), Val, Val}
 @test which(f20872, Tuple{Val,Val{N}} where N).sig == Tuple{typeof(f20872), Val, Val}
 @test_throws ErrorException which(f20872, Tuple{Any,Val{N}} where N)
+
+module M29962 end
+# make sure checking if a binding is deprecated does not resolve it
+@test !Base.isdeprecated(M29962, :sin) && !Base.isbindingresolved(M29962, :sin)


### PR DESCRIPTION
This is one way to fix https://discourse.julialang.org/t/inconsistent-base-method-overwrite-behaviour/15367 and related issues. Without this PR the following rather undesirable things happen:
```
λ j1 --quiet
julia> sin<tab>
sin    sinc    sincos  sind    sinh    sinpi
julia> sin=2
ERROR: cannot assign variable Base.sin from module Main
Stacktrace:
 [1] top-level scope at none:0

julia on sp/isdepnoresolve 
λ j1 --quiet
julia> Base.isdeprecated(Main, :sin); sin = 3
ERROR: cannot assign variable Base.sin from module Main
Stacktrace:
 [1] top-level scope at none:0
```

I think this behaviour is more sensible than making sure to write 
```
isbindingesolved(mod, sym) && isdeprecated(mod, sym)
```
to avoid accidentally resolving bindings.