### PR TITLE
Backport 1.0.2: Avoid recursion in print_to_string.

### DIFF
--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -89,7 +89,7 @@ function IOBuffer(
         maxsize::Integer=typemax(Int),
         sizehint::Union{Integer,Nothing}=nothing)
     if maxsize < 0
-        throw(ArgumentError("negative maxsize: $(maxsize)"))
+        throw(ArgumentError("negative maxsize"))
     end
     if sizehint !== nothing
         sizehint!(data, sizehint)


### PR DESCRIPTION
(cherry picked from commit f70637d4855568d313e820a5bc9147848519f3df)