### PR TITLE
[gh-pages] Remove CNAME from JuliaLang/julia:gh-pages.

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.julialang.org


### PR DESCRIPTION
This should flip the switch to point docs.julialang.org to https://github.com/JuliaLang/docs.julialang.org

cc @mortenpi 