### PR TITLE
Decouple Distributed from LinearAlgebra

### DIFF
--- a/stdlib/Distributed/Project.toml
+++ b/stdlib/Distributed/Project.toml
@@ -2,7 +2,6 @@ name = "Distributed"
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -164,9 +164,13 @@ mutable struct LocalProcess
 end
 
 
-import LinearAlgebra
 function disable_threaded_libs()
-    LinearAlgebra.BLAS.set_num_threads(1)
+    LA = Base.PkgId(Base.UUID((0x37e2e46d_f89d_539d,0xb4ee_838fcccc9c8e)), "LinearAlgebra")
+    if haskey(Base.loaded_modules, LA)
+        let LinearAlgebra = Base.require(LA)
+            LinearAlgebra.BLAS.set_num_threads(1)
+        end
+    end
 end
 
 worker_timeout() = parse(Float64, get(ENV, "JULIA_WORKER_TIMEOUT", "60.0"))


### PR DESCRIPTION
Decouples `Distributed` from `LinearAlgebra`; this makes it possible to have `Distributed` in the sysimg without the constraint to also have `LinearAlgebra` in there.