### PR TITLE
Decouple InteractiveUtils from LinearAlgebra

### DIFF
--- a/stdlib/InteractiveUtils/Project.toml
+++ b/stdlib/InteractiveUtils/Project.toml
@@ -3,7 +3,6 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [deps]
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -415,6 +415,7 @@ LinearAlgebra.adjoint!
 Base.copy(::Union{Transpose,Adjoint})
 LinearAlgebra.stride1
 LinearAlgebra.checksquare
+LinearAlgebra.peakflops
 ```
 
 ## Low-level matrix operations

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -379,6 +379,36 @@ const ⋅ = dot
 const × = cross
 export ⋅, ×
 
+"""
+    LinearAlgebra.peakflops(n::Integer=2000; parallel::Bool=false)
+
+`peakflops` computes the peak flop rate of the computer by using double precision
+[`gemm!`](@ref LinearAlgebra.BLAS.gemm!). By default, if no arguments are specified, it
+multiplies a matrix of size `n x n`, where `n = 2000`. If the underlying BLAS is using
+multiple threads, higher flop rates are realized. The number of BLAS threads can be set with
+[`BLAS.set_num_threads(n)`](@ref).
+
+If the keyword argument `parallel` is set to `true`, `peakflops` is run in parallel on all
+the worker processors. The flop rate of the entire parallel computer is returned. When
+running in parallel, only 1 BLAS thread is used. The argument `n` still refers to the size
+of the problem that is solved on each processor.
+"""
+function peakflops(n::Integer=2000; parallel::Bool=false)
+    a = fill(1.,100,100)
+    t = @elapsed a2 = a*a
+    a = fill(1.,n,n)
+    t = @elapsed a2 = a*a
+    @assert a2[1,1] == n
+    if parallel
+        let Distributed = Base.require(Base.PkgId(
+                Base.UUID((0x8ba89e20_285c_5b6f, 0x9357_94700520ee1b)), "Distributed"))
+            return sum(Distributed.pmap(peakflops, fill(n, Distributed.nworkers())))
+        end
+    else
+        return 2*Float64(n)^3 / t
+    end
+end
+
 
 function versioninfo(io::IO=stdout)
     if Base.libblas_name == "libopenblas" || BLAS.vendor() == :openblas || BLAS.vendor() == :openblas64

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -382,4 +382,8 @@ end
     @test ismissing(norm(missing))
 end
 
+@testset "peakflops" begin
+    @test LinearAlgebra.peakflops() > 0
+end
+
 end # module TestGeneric


### PR DESCRIPTION
Decouple InteractiveUtils from LinearAlgebra, schedule peakflops for move to LinearAlgebra; this is similar to #29975 in that it lets you create the sysimg without LinearAlgebra.