### PR TITLE
fix #29955, intersection bugs involving triangular constraints

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -810,7 +810,8 @@ static int within_typevar(jl_value_t *t, jl_value_t *vlb, jl_value_t *vub)
     else if (!jl_is_type(t)) {
         return vlb == jl_bottom_type && vub == (jl_value_t*)jl_any_type;
     }
-    return jl_subtype(vlb, lb) && jl_subtype(ub, vub);
+    return ((jl_has_free_typevars(vlb) || jl_subtype(vlb, lb)) &&
+            (jl_has_free_typevars(vub) || jl_subtype(ub, vub)));
 }
 
 typedef struct _jl_typestack_t jl_typestack_t;

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2043,7 +2043,10 @@ static jl_value_t *intersect(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int pa
                         return xlb;
                     return jl_bottom_type;
                 }
-                if (!(subtype_in_env(xlb, yub, e) && subtype_in_env(ylb, xub, e)))
+                if (R) flip_vars(e);
+                int ccheck = subtype_in_env(xlb, yub, e) && subtype_in_env(ylb, xub, e);
+                if (R) flip_vars(e);
+                if (!ccheck)
                     return jl_bottom_type;
                 jl_value_t *ub=NULL, *lb=NULL;
                 JL_GC_PUSH2(&lb, &ub);

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1357,3 +1357,25 @@ end
 @testintersect(Tuple{Vararg{Val{N}, N}} where N,
                Tuple{Val{2}, Vararg{Val{3}}},
                Union{})
+
+# issue #29955
+struct M29955{T, TV<:AbstractVector{T}}
+end
+@testintersect(M29955,
+               M29955{<:Any,TV} where TV>:Vector{Float64},
+               M29955{Float64,TV} where Array{Float64,1}<:TV<:AbstractArray{Float64,1})
+
+struct A29955{T, TV<:AbstractVector{T}, TModel<:M29955{T,TV}}
+end
+@testintersect(Tuple{Type{A29955{Float64,Array{Float64,1},_1}} where _1,
+                     Any},
+               Tuple{Type{A29955{T,TV,TM}},
+                     TM} where {T,TV<:AbstractVector{T},TM<:M29955{T,TV}},
+               Tuple{Type{A29955{Float64,Array{Float64,1},TM}},
+                     TM} where TM<:M29955{Float64,Array{Float64,1}})
+let M = M29955{T,Vector{Float64}} where T
+    @test M == (M29955{T,Vector{Float64}} where T)
+    @test M{Float64} == M29955{Float64,Vector{Float64}}
+    @test_throws TypeError M{Float32}
+    @test_throws TypeError M{Real}
+end


### PR DESCRIPTION
So far I feel this fix is pretty safe, so likely a candidate for backporting. We'll see what the tests say.

@nanosoldier `runbenchmarks(ALL, vs = ":master")`