### PR TITLE
Update supported platforms in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Julia is built and tested regularly on the following platforms:
 | macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 | Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 |                  | i686 (32-bit)    | ✓  | ✓        | Official      |
-| FreeBSD 11.0+    | x86-64 (64-bit)  | [✓](https://build.julialang.org/#/builders/68)  |          | Community     |
+| FreeBSD 11.0+    | x86-64 (64-bit)  | [✓](https://build.julialang.org/#/builders/68)  | ✓        | Official      |
 
 All systems marked with ✓ for CI are tested using continuous integration for every commit.
 Systems with ✓ for binaries have official binaries available on the [downloads](https://julialang.org/downloads) page and are tested regularly. The PTX backend needs the [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl) package.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Julia is built and tested regularly on the following platforms:
 | Linux 2.6.18+    | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 |                  | i686 (32-bit)    | ✓  | ✓        | Official      |
 |                  | ARM v7 (32-bit)  |    | ✓        | Official      |
-|                  | ARM v8 (64-bit)  |    | ✓        | Official      |
+|                  | ARM v8 (64-bit)  |    |          | Community     |
 |                  | PowerPC (64-bit) |    |          | Community     |
 |                  | PTX (64-bit)     | [✓](http://ci.maleadt.net:8010/)  |          | [External](https://github.com/JuliaGPU/CUDAnative.jl)     |
 | macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Julia is built and tested regularly on the following platforms:
 |                  | ARM v7 (32-bit)  |    | ✓        | Official      |
 |                  | ARM v8 (64-bit)  |    |          | Community     |
 |                  | PowerPC (64-bit) |    |          | Community     |
-|                  | PTX (64-bit)     | [✓](http://ci.maleadt.net:8010/)  |          | [External](https://github.com/JuliaGPU/CUDAnative.jl)     |
+|                  | PTX (64-bit)     | [✓](https://gitlab.com/JuliaGPU/CUDAnative.jl/pipelines)  |          | [External](https://github.com/JuliaGPU/CUDAnative.jl)     |
 | macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 | Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Official      |
 |                  | i686 (32-bit)    | ✓  | ✓        | Official      |


### PR DESCRIPTION
We have official release binaries in addition to CI for FreeBSD, so I've added the check mark for binaries and I've bumped "community" to "official."

I've also bumped AArch64 down from "official" to "community" and removed the check mark for binaries. We haven't had AArch64 support in quite some time, so as it is it looks a bit misleading.