### PR TITLE
Allow boolean parsing of strings containing 0 and 1

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -175,6 +175,13 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString{String}},
         return nothing
     end
 
+    if isnumeric(sbuff[1])
+        intres = tryparse_internal(UInt8, sbuff, startpos, endpos, base, false)
+        (intres == 1) && return true
+        (intres == 0) && return false
+        raise && throw(ArgumentError("invalid Bool representation: $(repr(sbuff))"))
+    end
+
     orig_start = startpos
     orig_end   = endpos
 

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -321,3 +321,14 @@ end
     @test eltype([tryparse(Float64, s) for s in String[]]) == Union{Nothing, Float64}
     @test eltype([tryparse(Complex{Int}, s) for s in String[]]) == Union{Nothing, Complex{Int}}
 end
+
+@testset "isssue #29980" begin
+    @test parse(Bool, "1") === true
+    @test parse(Bool, "01") === true
+    @test parse(Bool, "0") === false
+    @test parse(Bool, "000000000000000000000000000000000000000000000000001") === true
+    @test parse(Bool, "000000000000000000000000000000000000000000000000000") === false
+    @test_throws ArgumentError parse(Bool, "1000000000000000000000000000000000000000000000000000")
+    @test_throws ArgumentError parse(Bool, "2")
+    @test_throws ArgumentError parse(Bool, "02")
+end


### PR DESCRIPTION
Fixes #29980 

The following tests pass:

```julia
@test parse(Bool, "1") == true
@test parse(Bool, "01") == true
@test parse(Bool, "0") == false
@test parse(Bool, "000000000000000000000000000000000000000000000000001") == true
@test parse(Bool, "000000000000000000000000000000000000000000000000000") == false
@test_throws ArgumentError parse(Bool, "1000000000000000000000000000000000000000000000000000")
@test_throws ArgumentError parse(Bool, "2")
@test_throws ArgumentError parse(Bool, "02")
```