### PR TITLE
Implement a hook in base for disabling threading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,9 @@ New library functions
   * `uuid5` has been added to the `UUIDs` standard library ([#28761]).
   * Predicate functions `Sys.isfreebsd`, `Sys.isopenbsd`, `Sys.isnetbsd`, and `Sys.isdragonfly` for
     detecting BSD systems have been added ([#30249]).
+  * Internal `Base.disable_library_threading` that sets libraries to use one thread.
+    It executes function hooks that have been registered with
+    `Base.at_disable_library_threading` ([#30004]).
 
 Standard library changes
 ------------------------

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -236,3 +236,30 @@ function _atexit()
         end
     end
 end
+
+## hook for disabling threaded libraries ##
+
+library_threading_enabled = true
+const disable_library_threading_hooks = []
+
+function at_disable_library_threading(f)
+    push!(disable_library_threading_hooks, f)
+    if !library_threading_enabled
+        disable_library_threading()
+    end
+    return
+end
+
+function disable_library_threading()
+    global library_threading_enabled = false
+    while !isempty(disable_library_threading_hooks)
+        f = pop!(disable_library_threading_hooks)
+        try
+            f()
+        catch err
+            @warn("a hook from a library to disable threading failed:",
+                  exception = (err, catch_backtrace()))
+        end
+    end
+    return
+end

--- a/stdlib/Distributed/Project.toml
+++ b/stdlib/Distributed/Project.toml
@@ -2,7 +2,6 @@ name = "Distributed"
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [deps]
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -163,12 +163,6 @@ mutable struct LocalProcess
     LocalProcess() = new(1)
 end
 
-
-import LinearAlgebra
-function disable_threaded_libs()
-    LinearAlgebra.BLAS.set_num_threads(1)
-end
-
 worker_timeout() = parse(Float64, get(ENV, "JULIA_WORKER_TIMEOUT", "60.0"))
 
 

--- a/stdlib/Distributed/src/process_messages.jl
+++ b/stdlib/Distributed/src/process_messages.jl
@@ -307,7 +307,7 @@ function handle_msg(msg::JoinPGRPMsg, header, r_stream, w_stream, version)
     topology(msg.topology)
 
     if !msg.enable_threaded_blas
-        disable_threaded_libs()
+        Base.disable_library_threading()
     end
 
     lazy = msg.lazy

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -437,6 +437,8 @@ function __init__()
         Base.showerror_nostdio(ex,
             "WARNING: Error during initialization of module LinearAlgebra")
     end
+    # register a hook to disable BLAS threading
+    Base.at_disable_library_threading(() -> BLAS.set_num_threads(1))
 end
 
 end # module LinearAlgebra


### PR DESCRIPTION
Implement a hook in base for disabling threading of libraries, use it to decouple `Distributed` from `LinearAlgebra`.

Alternative to #29975, WIP because I don't know if this is the interface we want, where the code should live, and what the names of the functions should be. Maybe not very important since these are all internal functions.