### PR TITLE
Document destructuring syntax in anonymous function argument

### DIFF
--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -343,6 +343,15 @@ Notice the extra set of parentheses in the definition of `range`.
 Without those, `range` would be a two-argument function, and this example would
 not work.
 
+For anonymous functions, destructuring a single tuple requires an extra comma:
+
+```
+julia> map(((x,y),) -> x + y, [(1,2), (3,4)])
+2-element Array{Int64,1}:
+ 3
+ 7
+```
+
 ## Varargs Functions
 
 It is often convenient to be able to write functions taking an arbitrary number of arguments.

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -352,6 +352,17 @@ julia> map(((x,y),) -> x + y, [(1,2), (3,4)])
  7
 ```
 
+However, destructuring the argument to a do-block does not require an extra comma:
+
+```
+julia> map([(1,2), (3,4)]) do (x,y)
+           x + y
+       end
+2-element Array{Int64,1}:
+ 3
+ 7
+```
+
 ## Varargs Functions
 
 It is often convenient to be able to write functions taking an arbitrary number of arguments.
@@ -625,8 +636,8 @@ end
 ```
 
 The `do x` syntax creates an anonymous function with argument `x` and passes it as the first argument
-to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function, and a
-plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
+to [`map`](@ref). Similarly, `do a,b` would create a two-argument anonymous function. Note that `do (a,b)` would create a one-argument anonymous function,
+whose argument is a tuple to be deconstructed. A plain `do` would declare that what follows is an anonymous function of the form `() -> ...`.
 
 How these arguments are initialized depends on the "outer" function; here, [`map`](@ref) will
 sequentially set `x` to `A`, `B`, `C`, calling the anonymous function on each, just as would happen

--- a/doc/src/manual/functions.md
+++ b/doc/src/manual/functions.md
@@ -352,17 +352,6 @@ julia> map(((x,y),) -> x + y, [(1,2), (3,4)])
  7
 ```
 
-However, destructuring the argument to a do-block does not require an extra comma:
-
-```
-julia> map([(1,2), (3,4)]) do (x,y)
-           x + y
-       end
-2-element Array{Int64,1}:
- 3
- 7
-```
-
 ## Varargs Functions
 
 It is often convenient to be able to write functions taking an arbitrary number of arguments.


### PR DESCRIPTION
When destructuring a single tuple in an anonymous function argument, 
you have to include an extra comma to force a 1-tuple. Otherwise ((x,y)) 
collapses to (x,y). This is not the case for named functions.