### PR TITLE
Use at-DIR instead of Sys.BINDIR to find UnicodeData.txt in doc build.

### DIFF
--- a/doc/src/manual/unicode-input.md
+++ b/doc/src/manual/unicode-input.md
@@ -31,7 +31,7 @@ function tab_completions(symbols...)
 end
 
 function unicode_data()
-    file = normpath(Sys.BINDIR, "..", "..", "doc", "UnicodeData.txt")
+    file = normpath(@__DIR__, "..", "..", "..", "..", "..", "doc", "UnicodeData.txt")
     names = Dict{UInt32, String}()
     open(file) do unidata
         for line in readlines(unidata)


### PR DESCRIPTION
`Sys.BINDIR` is not correct if one sets the `JULIA_EXECUTABLE` variable in `docs/Makefile`.