### PR TITLE
Added note to highlight that some variables can't be set in `startup.jl`

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -17,7 +17,7 @@ those for which `JULIA` appears in the name.
 Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` need to be set before Julia 
 starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process. 
 These must either be set manually before launching Julia through bash with 
-`export JULIA_NUM_THREADS = 4` etc. or added to `.bashrc` to achieve persistence.
+`export JULIA_NUM_THREADS = 4` etc. or added to `-/.bashrc` and/or `~/.bash_profile` to achieve persistence.
 
 ## File locations
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -14,10 +14,10 @@ The environment variables that Julia uses generally start with `JULIA`. If
 output will list defined environment variables relevant for Julia, including
 those for which `JULIA` appears in the name.
 
-Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` needs to be set before Julia 
+Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` need to be set before Julia 
 starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process. 
 These must either be set manually before launching Julia through bash with 
-`export ENV["JULIA_NUM_THREADS"] = 4` etc. or added to `.bashrc` to achieve persistence.
+`export JULIA_NUM_THREADS = 4` etc. or added to `.bashrc` to achieve persistence.
 
 ## File locations
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -14,10 +14,12 @@ The environment variables that Julia uses generally start with `JULIA`. If
 output will list defined environment variables relevant for Julia, including
 those for which `JULIA` appears in the name.
 
-Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` need to be set before Julia 
-starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process. 
-These must either be set manually before launching Julia through bash with 
-`export JULIA_NUM_THREADS = 4` etc. or added to `-/.bashrc` and/or `~/.bash_profile` to achieve persistence.
+!!! note
+
+    Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` need to be set before Julia 
+    starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process. 
+    These must either be set manually before launching Julia through bash with 
+    `export JULIA_NUM_THREADS=4` etc. or added to `-/.bashrc` and/or `~/.bash_profile` to achieve persistence.
 
 ## File locations
 
@@ -81,7 +83,7 @@ the chapter on [Code Loading](@ref).
 
 !!! note
 
-    See note at top as `JULIA_PROJECT` cannot be set in `~/.julia/config/startup.jl`
+    `JULIA_PROJECT` must be defined before starting julia; defining it in `startup.jl` is too late in the startup process.
 
 ### `JULIA_LOAD_PATH`
 
@@ -163,7 +165,7 @@ set to `1`.
 
 !!! note
 
-    See note at top as `JULIA_NUM_THREADS` cannot be set in `~/.julia/config/startup.jl`
+    `JULIA_NUM_THREADS` must be defined before starting julia; defining it in `startup.jl` is too late in the startup process.
 
 ### `JULIA_THREAD_SLEEP_THRESHOLD`
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -16,9 +16,9 @@ those for which `JULIA` appears in the name.
 
 !!! note
 
-    Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` need to be set before Julia 
-    starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process. 
-    These must either be set manually before launching Julia through bash with 
+    Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` need to be set before Julia
+    starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process.
+    These must either be set manually before launching Julia through bash with
     `export JULIA_NUM_THREADS=4` etc. or added to `-/.bashrc` and/or `~/.bash_profile` to achieve persistence.
 
 ## File locations

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -14,6 +14,11 @@ The environment variables that Julia uses generally start with `JULIA`. If
 output will list defined environment variables relevant for Julia, including
 those for which `JULIA` appears in the name.
 
+Some variables, such as `JULIA_NUM_THREADS` and `JULIA_PROJECT` needs to be set before Julia 
+starts, therefore adding these to `~/.julia/config/startup.jl` is too late in the startup process. 
+These must either be set manually before launching Julia through bash with 
+`export ENV["JULIA_NUM_THREADS"] = 4` etc. or added to `.bashrc` to achieve persistence.
+
 ## File locations
 
 ### `JULIA_BINDIR`
@@ -73,6 +78,10 @@ option, but `--project` has higher precedence.  If the variable is set to `@.`,
 Julia tries to find a project directory that contains `Project.toml` or
 `JuliaProject.toml` file from the current directory and its parents.  See also
 the chapter on [Code Loading](@ref).
+
+!!! note
+
+    See note at top as `JULIA_PROJECT` cannot be set in `~/.julia/config/startup.jl`
 
 ### `JULIA_LOAD_PATH`
 
@@ -151,6 +160,10 @@ physical CPU cores, then the number of threads is set to the number of cores. If
 `$JULIA_NUM_THREADS` is not positive or is not set, or if the number of CPU
 cores cannot be determined through system calls, then the number of threads is
 set to `1`.
+
+!!! note
+
+    See note at top as `JULIA_NUM_THREADS` cannot be set in `~/.julia/config/startup.jl`
 
 ### `JULIA_THREAD_SLEEP_THRESHOLD`
 


### PR DESCRIPTION
I got caught out by `JULIA_NUM_THREADS`.
There may be more that would benefit from a short note referring to the generic note at the top