### PR TITLE
fix #29995: latex printing of Markdown.HorizontalRule

### DIFF
--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -101,6 +101,9 @@ function latex(io::IO, md::List)
 end
 
 function show(io::IO, ::MIME"text/latex", md::HorizontalRule)
+    latex(io, md)
+end
+function latex(io::IO, md::HorizontalRule)
     println(io, "\\rule{\\textwidth}{1pt}")
 end
 

--- a/stdlib/Markdown/src/render/latex.jl
+++ b/stdlib/Markdown/src/render/latex.jl
@@ -100,9 +100,6 @@ function latex(io::IO, md::List)
     end
 end
 
-function show(io::IO, ::MIME"text/latex", md::HorizontalRule)
-    latex(io, md)
-end
 function latex(io::IO, md::HorizontalRule)
     println(io, "\\rule{\\textwidth}{1pt}")
 end

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -1108,3 +1108,9 @@ let
     @test v.content[5].loose
     @test !v.content[7].loose
 end
+
+# issue #29995
+let m = Markdown.parse("---"), io = IOBuffer()
+    show(io, "text/latex", m)
+    @test String(take!(io)) == "\\rule{\\textwidth}{1pt}\n"
+end


### PR DESCRIPTION
I split this into two commits; the first one can safely be backported, and the other one just removes the old method. No other Markdown components can be `show(io, "text/latex", x)` directly so I think it is safe to remove this one.