### PR TITLE
Catch InterruptException in fallback REPL.

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -380,7 +380,11 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
                         print("julia> ")
                         flush(stdout)
                     end
-                    eval_user_input(parse_input_line(input), true)
+                    try
+                        eval_user_input(parse_input_line(input), true)
+                    catch err
+                        isa(err, InterruptException) ? print("\n\n") : rethrow()
+                    end
                 end
             end
         end


### PR DESCRIPTION
Otherwise `^C` just exits Julia. Changes
```
julia> foo^CERROR: InterruptException:
Stacktrace:
 [1] process_events at ./libuv.jl:98 [inlined]
 [2] wait() at ./event.jl:246
 [3] wait(::Condition) at ./event.jl:46
 [...]

$
```
to
```
julia> foo^C

julia>
```
as in the normal REPL.