### PR TITLE
Don't bundle busybox with Windows

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -79,7 +79,6 @@ Julia's build process uses the following external tools:
 Julia bundles the following external programs and libraries on some platforms:
 
 - [7-Zip](http://www.7-zip.org/license.txt)
-- [BUSYBOX](https://github.com/rmyorston/busybox-w32/blob/master/LICENSE)
 - [ZLIB](http://zlib.net/zlib_license.html)
 - [LIBEXPAT](http://expat.cvs.sourceforge.net/viewvc/expat/expat/README)
 

--- a/Makefile
+++ b/Makefile
@@ -483,10 +483,6 @@ endif
 ifeq ($(OS), WINNT)
 	[ ! -d $(JULIAHOME)/dist-extras ] || ( cd $(JULIAHOME)/dist-extras && \
 		cp 7z.exe 7z.dll libexpat-1.dll zlib1.dll $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin )
-ifeq ($(USE_GPL_LIBS), 1)
-	[ ! -d $(JULIAHOME)/dist-extras ] || ( cd $(JULIAHOME)/dist-extras && \
-		cp busybox.exe $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin )
-endif
 	cd $(BUILDROOT)/julia-$(JULIA_COMMIT)/bin && rm -f llvm* llc.exe lli.exe opt.exe LTO.dll bugpoint.exe macho-dump.exe
 
 	# create file listing for uninstall. note: must have Windows path separators and line endings.
@@ -639,11 +635,6 @@ endif
 	chmod a+x 7z.dll && \
 	$(call spawn,./7z.exe) x -y -onsis nsis-2.46.5-Unicode-setup.exe && \
 	chmod a+x ./nsis/makensis.exe
-ifeq ($(USE_GPL_LIBS), 1)
-	cd $(JULIAHOME)/dist-extras && \
-	$(JLDOWNLOAD) busybox.exe http://frippery.org/files/busybox/busybox-w32-FRP-875-gc6ec14a.exe && \
-	chmod a+x busybox.exe
-endif
 
 # various statistics about the build that may interest the user
 ifeq ($(USE_SYSTEM_LLVM), 1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,6 @@ cache:
   - C:\cygdownloads
   - llvm-3.9.1-i686-w64-mingw32-juliadeps-r07.7z
   - llvm-3.9.1-x86_64-w64-mingw32-juliadeps-r07.7z
-  - usr/bin/busybox.exe
   - C:\ccache
 
 build_script:

--- a/contrib/windows/appveyor_build.sh
+++ b/contrib/windows/appveyor_build.sh
@@ -165,12 +165,6 @@ if [ -z "`which make 2>/dev/null`" ]; then
   export PATH=$PWD/bin:$PATH
 fi
 
-if ! [ -e usr/bin/busybox.exe ]; then
-  f=busybox-w32-FRP-875-gc6ec14a.exe
-  echo "Downloading $f"
-  $curlflags -o usr/bin/busybox.exe http://frippery.org/files/busybox/$f
-fi
-chmod -R +x usr/bin usr/tools
 
 for lib in SUITESPARSE ARPACK BLAS LAPACK \
     GMP MPFR PCRE LIBUNWIND; do
@@ -218,6 +212,5 @@ cat Make.user
 make -j3 VERBOSE=1 release
 make -j3 VERBOSE=1 install
 make VERBOSE=1 JULIA=../../usr/bin/julia.exe BIN=. "$(make print-CC)" -C test/embedding release
-cp usr/bin/busybox.exe julia-*/bin
 make build-stats
 ccache -s

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -20,7 +20,7 @@ sleepcmd = `sleep`
 lscmd = `ls`
 havebb = false
 if Sys.iswindows()
-    busybox = joinpath(Sys.BINDIR, "busybox.exe")
+    busybox = download("http://frippery.org/files/busybox/busybox.exe", joinpath(tempdir(), "busybox.exe"))
     havebb = try # use busybox-w32 on windows, if available
         success(`$busybox`)
         true
@@ -617,4 +617,9 @@ open(`$catcmd`, "r+") do f
     end
     @test read(f, Char) == 'δ'
     wait(t)
+end
+
+# clean up busybox download
+if Sys.iswindows()
+    rm(busybox, force=true)
 end


### PR DESCRIPTION
Looks like busybox is only used in the `spawn.jl` test file; I don't see the reason for distributing busybox with all julia installs if it's only used there. (it also removes a GPL lib)

Rationale:
- Busybox is shipped with every install, even though it's used *only* for the spawn.jl tests
