### PR TITLE
Make generated code for rational constructor and gcd slightly smaller

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -28,7 +28,6 @@ end
 # binary GCD (aka Stein's) algorithm
 # about 1.7x (2.1x) faster for random Int64s (Int128s)
 function gcd(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128}
-    @noinline throw1(a, b) = throw(OverflowError("gcd($a, $b) overflows"))
     a == 0 && return abs(b)
     b == 0 && return abs(a)
     za = trailing_zeros(a)
@@ -45,9 +44,10 @@ function gcd(a::T, b::T) where T<:Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Int
     end
     r = u << k
     # T(r) would throw InexactError; we want OverflowError instead
-    r > typemax(T) && throw1(a, b)
+    r > typemax(T) && __throw_gcd_overflow(a, b)
     r % T
 end
+@noinline __throw_gcd_overflow(a, b) = throw(OverflowError("gcd($a, $b) overflows"))
 
 """
     lcm(x,y)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -10,11 +10,13 @@ struct Rational{T<:Integer} <: Real
     den::T
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
-        num == den == zero(T) && throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
+        num == den == zero(T) && __throw_rational_argerror(T)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end
 end
+@noinline __throw_rational_argerror(T) = throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
+
 Rational(n::T, d::T) where {T<:Integer} = Rational{T}(n,d)
 Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 Rational(n::Integer) = Rational(n,one(n))


### PR DESCRIPTION
#### Rational

39 -> 15 SSA values in LLVM and no more GC frames.

#### Gcd

67 -> 45 SSA values in LLVM and no more GC frames.