### PR TITLE
Request: Add an API for configuring julia_cmd

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -470,6 +470,7 @@ function __init__()
     # Base library init
     reinit_stdio()
     Multimedia.reinit_displays() # since Multimedia.displays uses stdout as fallback
+    set_julia_basecmd()
     # initialize loading
     init_depot_path()
     init_load_path()

--- a/base/util.jl
+++ b/base/util.jl
@@ -401,7 +401,7 @@ printstyled(msg...; bold::Bool=false, color::Union{Int,Symbol}=:normal) =
     printstyled(stdout, msg...; bold=bold, color=color)
 
 """
-    julia_cmd([julia]) :: Cmd
+    julia_cmd([julia]) -> Cmd
 
 Return a [`Cmd`](@ref) that can be used to launch a `julia` program
 that inherits the command line options of the current executing
@@ -448,7 +448,7 @@ function julia_exename()
 end
 
 """
-    default_julia_basecmd() :: Cmd
+    default_julia_basecmd() -> Cmd
 
 Default `julia` executable and options.
 """
@@ -457,7 +457,7 @@ default_julia_basecmd() = `$(joinpath(Sys.BINDIR::String, julia_exename()))`
 const _julia_basecmd = Ref(``)
 
 """
-    julia_basecmd() :: Cmd
+    julia_basecmd() -> Cmd
 
 Julia executable which is used by [`julia_cmd`](@ref).  It may be
 changed by [`set_julia_basecmd`](@ref).

--- a/base/util.jl
+++ b/base/util.jl
@@ -454,7 +454,7 @@ Default `julia` executable and options.
 """
 default_julia_basecmd() = `$(joinpath(Sys.BINDIR::String, julia_exename()))`
 
-const _julia_basecmd = Ref(default_julia_basecmd())
+const _julia_basecmd = Ref(``)
 
 """
     julia_basecmd() :: Cmd
@@ -465,11 +465,12 @@ changed by [`set_julia_basecmd`](@ref).
 julia_basecmd() = _julia_basecmd[]
 
 """
-    set_julia_basecmd(path::Cmd)
+    set_julia_basecmd([path::Cmd])
 
-Set the Julia executable used by [`julia_cmd`](@ref).
+Set the Julia executable used by [`julia_cmd`](@ref).  Reset to default
+when no argument is given.
 """
-function set_julia_basecmd(cmd::Cmd)
+function set_julia_basecmd(cmd::Cmd = default_julia_basecmd())
     _julia_basecmd[] = cmd
 end
 

--- a/base/util.jl
+++ b/base/util.jl
@@ -400,7 +400,18 @@ printstyled(io::IO, msg...; bold::Bool=false, color::Union{Int,Symbol}=:normal) 
 printstyled(msg...; bold::Bool=false, color::Union{Int,Symbol}=:normal) =
     printstyled(stdout, msg...; bold=bold, color=color)
 
-function julia_cmd(julia=joinpath(Sys.BINDIR::String, julia_exename()))
+"""
+    julia_cmd([julia]) :: Cmd
+
+Return a [`Cmd`](@ref) that can be used to launch a `julia` program
+that inherits the command line options of the current executing
+process.  An optional argument can be passed to specify the `julia`
+program to be used instead of [`julia_basecmd`](@ref).  Note that
+package load path settings are not automatically reflected in the
+launched process.  Use [`Base.load_path_setup_code`](@ref) to
+replicate the load paths.
+"""
+function julia_cmd(julia=julia_basecmd())
     opts = JLOptions()
     cpu_target = unsafe_string(opts.cpu_target)
     image_file = unsafe_string(opts.image_file)
@@ -434,6 +445,32 @@ function julia_exename()
     else
         return @static Sys.iswindows() ? "julia-debug.exe" : "julia-debug"
     end
+end
+
+"""
+    default_julia_basecmd() :: Cmd
+
+Default `julia` executable and options.
+"""
+default_julia_basecmd() = `$(joinpath(Sys.BINDIR::String, julia_exename()))`
+
+const _julia_basecmd = Ref(default_julia_basecmd())
+
+"""
+    julia_basecmd() :: Cmd
+
+Julia executable which is used by [`julia_cmd`](@ref).  It may be
+changed by [`set_julia_basecmd`](@ref).
+"""
+julia_basecmd() = _julia_basecmd[]
+
+"""
+    set_julia_basecmd(path::Cmd)
+
+Set the Julia executable used by [`julia_cmd`](@ref).
+"""
+function set_julia_basecmd(cmd::Cmd)
+    _julia_basecmd[] = cmd
 end
 
 """

--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -11,7 +11,7 @@ import Base: getindex, wait, put!, take!, fetch, isready, push!, length,
 
 # imports for use
 using Base: Process, Semaphore, JLOptions, AnyDict, buffer_writes, wait_connected,
-            VERSION_STRING, binding_module, notify_error, atexit, julia_exename,
+            VERSION_STRING, binding_module, notify_error, atexit, julia_basecmd,
             julia_cmd, AsyncGenerator, acquire, release, invokelatest,
             shell_escape_posixly, uv_error, something, notnothing
 

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -443,7 +443,7 @@ end
 default_addprocs_params() = AnyDict(
     :topology => :all_to_all,
     :dir      => pwd(),
-    :exename  => joinpath(Sys.BINDIR, julia_exename()),
+    :exename  => julia_basecmd(),
     :exeflags => ``,
     :enable_threaded_blas => false,
     :lazy => true)


### PR DESCRIPTION
In PyJulia, we've been using @Keno's trick (`fake-julia`) to force Julia to use a Python script as the Julia process launched for precompilation: https://github.com/JuliaPy/pyjulia/tree/v0.2.0/julia/fake-julia.  This is required for supporting Python installed by Debian-family such as Ubuntu and also by Anaconda.

In Julia 0.6, `fake-julia` worked by setting the environment variable `JULIA_HOME` to a directory in which a fake executable `julia` exists.  Applying similar trick to modify `Sys.BINDIR` via `JULIA_BINDIR` in Julia 1.0 is problematic because `Sys.BINDIR` is used not only in `Base.julia_cmd` but also in other places such as `Pkg.Types.stdlib_dir` and most importantly for initializing `DEPOT_PATH`.  So, I request to add an API to configure what `Base.julia_cmd` returns.  It could be useful outside PyJulia usage.  For example, it would make it possible to control what command line flags are used in the subprocesses by default (e.g., Pkg.build, Distributed, PackageCompiler).

I tested the concept by [monkey-patching Julia `Base`](https://github.com/tkf/julia-venv/blob/4ccefb119a7c34db96fe2aee3bafe9f4c224ad24/src/julia_venv/JuliaVenv.jl#L46-L57) and it worked in Julia 1.0 as expected.  However, the monkey-patching approach requires to know exactly when the precompilation happens which is impossible.
