### PR TITLE
nitpick: crazy -> overboard

### DIFF
--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -707,7 +707,7 @@ type-domain.
 
 ## The dangers of abusing multiple dispatch (aka, more on types with values-as-parameters)
 
-Once one learns to appreciate multiple dispatch, there's an understandable tendency to go crazy
+Once one learns to appreciate multiple dispatch, there's an understandable tendency to go overboard
 and try to use it for everything. For example, you might imagine using it to store information,
 e.g.
 


### PR DESCRIPTION
[ci skip]
Following some discussion on slack, some consensus grew around removing unhelpful and ableist usage of "crazy".
This seems to be the only instance I found from grepping base for any instance of 
- "crazy", "insane", "psycho" et al.