### PR TITLE
Add map! method with single array param when source and dest are the same

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -2010,6 +2010,9 @@ function map!(f::F, dest::AbstractArray, A::AbstractArray) where F
     return dest
 end
 
+# same dest as source
+map!(f::F, A::AbstractArray) where F = map!(f, A, A)
+
 # map on collections
 map(f, A::AbstractArray) = collect_similar(A, Generator(f,A))
 
@@ -2067,6 +2070,7 @@ end
 
 Like [`map`](@ref), but stores the result in `destination` rather than a new
 collection. `destination` must be at least as large as the first collection.
+If the destination is the source, the array may be specified just once.
 
 # Examples
 ```jldoctest
@@ -2079,6 +2083,15 @@ julia> a
  2.0
  4.0
  6.0
+
+julia> map!(x -> x / 2, a);
+
+julia> a
+3-element Array{Float64,1}:
+ 1.0
+ 2.0
+ 3.0
+
 ```
 """
 map!(f::F, dest::AbstractArray, As::AbstractArray...) where {F} = map_n!(f, dest, As)


### PR DESCRIPTION
```
julia> arr = [1,2,3];

julia> map!(x -> 2x, arr)
ERROR: BoundsError: attempt to access ()
  at index [1]
Stacktrace:
 [1] map_n!(::getfield(Main, Symbol("##3#4")), ::Array{Int64,1}, ::Tuple{}) at ./abstractarray.jl:2032
 [2] map!(::getfield(Main, Symbol("##3#4")), ::Array{Int64,1}) at ./abstractarray.jl:2057
 [3] top-level scope at none:0
```

This code produces a very non-descriptive error and the attempt is clear. Instead, `map!(x -> 2x, arr, arr)` has to be used, which is not obvious (especially when comparing with `map`). This PR adds a method to `map!` that accepts this input and maps in the same array.