### PR TITLE
Make `broadcast_axes` inferrable even if axes are of different types

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -435,11 +435,19 @@ end
 _bcs1(a::Integer, b::Integer) = a == 1 ? b : (b == 1 ? a : (a == b ? a : throw(DimensionMismatch("arrays could not be broadcast to a common size"))))
 _bcs1(a::Integer, b) = a == 1 ? b : (first(b) == 1 && last(b) == a ? b : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
 _bcs1(a, b::Integer) = _bcs1(b, a)
-_bcs1(a, b) = _bcsm(b, a) ? b : (_bcsm(a, b) ? a : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
+_bcs1(a, b) = _bcsm(b, a) ? _sametype(b, a) : (_bcsm(a, b) ? _sametype(a, b) : throw(DimensionMismatch("arrays could not be broadcast to a common size")))
 # _bcsm tests whether the second index is consistent with the first
 _bcsm(a, b) = a == b || length(b) == 1
 _bcsm(a, b::Number) = b == 1
 _bcsm(a::Number, b::Number) = a == b || b == 1
+# Ensure inferrability when dealing with axes of different AbstractUnitRange types
+# (We may not want to define general promotion rules between, say, OneTo and Slice, but if
+#  we get here we know the axes are at least consistent)
+_sametype(a::T, b::T) where T = a
+_sametype(a::OneTo, b::OneTo) = OneTo{Int}(a)
+_sametype(a::OneTo, b) = OneTo{Int}(a)
+_sametype(a, b::OneTo) = OneTo{Int}(a)
+_sametype(a, b) = UnitRange{Int}(a)
 
 ## Check that all arguments are broadcast compatible with shape
 # comparing one input against a shape

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -466,6 +466,11 @@ A = OffsetArray(rand(4,4), (-3,5))
 A = OffsetArray(view(rand(4,4), 1:4, 4:-1:1), (-3,5))
 @test vec(A) == reshape(A, :) == reshape(A, 16) == reshape(A, Val(1)) == A[:] == vec(A.parent)
 
+# broadcast
+a = [1]
+b = OffsetArray(a, (0,))
+@test @inferred(a .+ b) == [2]
+
 end # let
 
 # Check that similar throws a MethodError rather than a


### PR DESCRIPTION
This was originally discovered as https://github.com/JuliaArrays/StaticArrays.jl/issues/546 but there's a non-static fix needed too. This uses `OneTo` and `UnitRange` as the default fallbacks.