### PR TITLE
Slight refactor to collection widening

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -656,6 +656,19 @@ function collect_to_with_first!(dest, v1, itr, st)
     return grow_to!(dest, itr, st)
 end
 
+function setindex_widen!(dest::Array{T}, el, i) where T
+    if el isa T || typeof(el) === T
+        @inbounds dest[i] = el::T
+        dest
+    else
+        R = promote_typejoin(T, typeof(el))
+        new = similar(dest, R)
+        copyto!(new,1, dest,1, i-1)
+        @inbounds new[i] = el
+        new
+    end
+end
+
 function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
     # collect to dest array, checking the type of each result. if a result does not
     # match, widen the result type and re-dispatch.
@@ -668,10 +681,7 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
             @inbounds dest[i] = el::T
             i += 1
         else
-            R = promote_typejoin(T, typeof(el))
-            new = similar(dest, R)
-            copyto!(new,1, dest,1, i-1)
-            @inbounds new[i] = el
+            new = setindex_widen!(dest, el, i)
             return collect_to!(new, itr, i+1, st)
         end
     end
@@ -686,6 +696,25 @@ function grow_to!(dest, itr)
     grow_to!(dest2, itr, y[2])
 end
 
+function push_widen!(dest, el)
+    T = eltype(dest)
+    S = typeof(el)
+    if S === T || S <: T
+        push!(dest, el::T)
+        dest
+    else
+        new = sizehint!(empty(dest, promote_typejoin(T, S)), length(dest))
+        if new isa AbstractSet
+            # TODO: merge back these two branches when copy! is re-enabled for sets/vectors
+            union!(new, dest)
+        else
+            append!(new, dest)
+        end
+        push!(new, el)
+        new
+    end
+end
+
 function grow_to!(dest, itr, st)
     T = eltype(dest)
     y = iterate(itr, st)
@@ -695,14 +724,7 @@ function grow_to!(dest, itr, st)
         if S === T || S <: T
             push!(dest, el::T)
         else
-            new = sizehint!(empty(dest, promote_typejoin(T, S)), length(dest))
-            if new isa AbstractSet
-                # TODO: merge back these two branches when copy! is re-enabled for sets/vectors
-                union!(new, dest)
-            else
-                append!(new, dest)
-            end
-            push!(new, el)
+            new = push_widen!(dest, el)
             return grow_to!(new, itr, st)
         end
         y = iterate(itr, st)

--- a/base/array.jl
+++ b/base/array.jl
@@ -673,7 +673,7 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
         y = iterate(itr, st)
         y === nothing && break
         el, st = y
-        if el isa T
+        if el isa T || typeof(el) === T
             @inbounds dest[i] = el::T
             i += 1
         else

--- a/base/array.jl
+++ b/base/array.jl
@@ -656,7 +656,8 @@ function collect_to_with_first!(dest, v1, itr, st)
     return grow_to!(dest, itr, st)
 end
 
-@inline function setindex_widen!(dest::Array{T}, el, i) where T
+function setindex_widen!(dest::Array{T}, el, i) where T
+    @_inline_meta
     if el isa T || typeof(el) === T
         @inbounds dest[i] = el::T
         dest
@@ -696,7 +697,8 @@ function grow_to!(dest, itr)
     grow_to!(dest2, itr, y[2])
 end
 
-@inline function push_widen!(dest, el)
+function push_widen!(dest, el)
+    @_inline_meta
     T = eltype(dest)
     S = typeof(el)
     if S === T || S <: T

--- a/base/array.jl
+++ b/base/array.jl
@@ -656,7 +656,7 @@ function collect_to_with_first!(dest, v1, itr, st)
     return grow_to!(dest, itr, st)
 end
 
-function setindex_widen!(dest::Array{T}, el, i) where T
+@inline function setindex_widen!(dest::Array{T}, el, i) where T
     if el isa T || typeof(el) === T
         @inbounds dest[i] = el::T
         dest
@@ -696,7 +696,7 @@ function grow_to!(dest, itr)
     grow_to!(dest2, itr, y[2])
 end
 
-function push_widen!(dest, el)
+@inline function push_widen!(dest, el)
     T = eltype(dest)
     S = typeof(el)
     if S === T || S <: T

--- a/base/array.jl
+++ b/base/array.jl
@@ -658,8 +658,7 @@ end
 
 function setindex_widen_up_to(dest::AbstractArray{T}, el, i) where T
     @_inline_meta
-    R = promote_typejoin(T, typeof(el))
-    new = similar(dest, R)
+    new = similar(dest, promote_typejoin(T, typeof(el)))
     copyto!(new, firstindex(new), dest, firstindex(dest), i-1)
     @inbounds new[i] = el
     return new
@@ -694,9 +693,7 @@ end
 
 function push_widen(dest, el)
     @_inline_meta
-    T = eltype(dest)
-    S = typeof(el)
-    new = sizehint!(empty(dest, promote_typejoin(T, S)), length(dest))
+    new = sizehint!(empty(dest, promote_typejoin(eltype(dest), typeof(el))), length(dest))
     if new isa AbstractSet
         # TODO: merge back these two branches when copy! is re-enabled for sets/vectors
         union!(new, dest)

--- a/base/array.jl
+++ b/base/array.jl
@@ -656,11 +656,11 @@ function collect_to_with_first!(dest, v1, itr, st)
     return grow_to!(dest, itr, st)
 end
 
-function setindex_widen!(dest::Array{T}, el, i) where T
+function setindex_widen_up_to(dest::AbstractArray{T}, el, i) where T
     @_inline_meta
     R = promote_typejoin(T, typeof(el))
     new = similar(dest, R)
-    copyto!(new,1, dest,1, i-1)
+    copyto!(new, firstindex(new), dest, firstindex(dest), i-1)
     @inbounds new[i] = el
     return new
 end
@@ -677,7 +677,7 @@ function collect_to!(dest::AbstractArray{T}, itr, offs, st) where T
             @inbounds dest[i] = el::T
             i += 1
         else
-            new = setindex_widen!(dest, el, i)
+            new = setindex_widen_up_to(dest, el, i)
             return collect_to!(new, itr, i+1, st)
         end
     end
@@ -692,7 +692,7 @@ function grow_to!(dest, itr)
     grow_to!(dest2, itr, y[2])
 end
 
-function push_widen!(dest, el)
+function push_widen(dest, el)
     @_inline_meta
     T = eltype(dest)
     S = typeof(el)
@@ -716,7 +716,7 @@ function grow_to!(dest, itr, st)
         if S === T || S <: T
             push!(dest, el::T)
         else
-            new = push_widen!(dest, el)
+            new = push_widen(dest, el)
             return grow_to!(new, itr, st)
         end
         y = iterate(itr, st)


### PR DESCRIPTION
Pull out specifically collection widening to its own functions. This will allow overloading these functions for data-structures which are easier to widen than Arrays, e.g. ModelArrays (see #13942)
The eltype checks seem redundant but help make the functions more generalizable. I think they're costless anyway.