### PR TITLE
Put boxed arguments in llvmcall into the correct addrspace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,9 @@ julia-base: julia-deps $(build_sysconfdir)/julia/startup.jl $(build_man1dir)/jul
 julia-libccalltest: julia-deps
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src libccalltest
 
+julia-libllvmcalltest: julia-deps
+	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src libllvmcalltest
+
 julia-src-release julia-src-debug : julia-src-% : julia-deps julia_flisp.boot.inc.phony
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT)/src libjulia-$*
 
@@ -80,7 +83,7 @@ julia-sysimg-release : julia-stdlib julia-sysimg julia-ui-release
 julia-sysimg-debug : julia-stdlib julia-sysimg julia-ui-debug
 	@$(MAKE) $(QUIET_MAKE) -C $(BUILDROOT) $(build_private_libdir)/sys-debug.$(SHLIB_EXT)
 
-julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest julia-base-cache
+julia-debug julia-release : julia-% : julia-ui-% julia-sysimg-% julia-symlink julia-libccalltest julia-libllvmcalltest julia-base-cache
 
 debug release : % : julia-%
 
@@ -230,7 +233,7 @@ JL_TARGETS += julia-debug
 endif
 
 # private libraries, that are installed in $(prefix)/lib/julia
-JL_PRIVATE_LIBS-0 := libccalltest
+JL_PRIVATE_LIBS-0 := libccalltest libllvmcalltest
 ifeq ($(USE_GPL_LIBS), 1)
 JL_PRIVATE_LIBS-0 += libsuitesparse_wrapper
 JL_PRIVATE_LIBS-$(USE_SYSTEM_SUITESPARSE) += libamd libcamd libccolamd libcholmod libcolamd libumfpack libspqr libsuitesparseconfig

--- a/src/Makefile
+++ b/src/Makefile
@@ -149,6 +149,7 @@ $(build_includedir)/julia/uv/*.h: $(LIBUV_INC)/uv/*.h | $(build_includedir)/juli
 	$(INSTALL_F) $^ $(build_includedir)/julia/uv
 
 libccalltest: $(build_shlibdir)/libccalltest.$(SHLIB_EXT)
+libllvmcalltest: $(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT)
 
 ifeq ($(OS), Linux)
 JULIA_SPLITDEBUG := 1
@@ -169,6 +170,9 @@ endif
 	@## because we want to test the non-default debug configuration
 	@#rm -r $@.dSYM && mv $@.tmp.dSYM $@.dSYM
 	mv $@.tmp $@
+
+$(build_shlibdir)/libllvmcalltest.$(SHLIB_EXT): $(SRCDIR)/llvmcalltest.cpp
+	@$(call PRINT_CC, $(CXX) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CXXFLAGS) $(CPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@ $(LDFLAGS) -L$(build_shlibdir) -L$(build_libdir) $(NO_WHOLE_ARCHIVE) $(LLVMLINK))
 
 julia_flisp.boot.inc.phony: $(BUILDDIR)/julia_flisp.boot.inc
 
@@ -305,4 +309,4 @@ clean-support:
 
 cleanall: clean clean-flisp clean-support
 
-.PHONY: default all debug release clean cleanall clean-* libccalltest julia_flisp.boot.inc.phony
+.PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -999,7 +999,10 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
         jl_value_t *tti = jl_svecref(tt,i);
         bool toboxed;
         Type *t = julia_type_to_llvm(tti, &toboxed);
-        argtypes.push_back(t);
+        if (toboxed)
+            argtypes.push_back(T_prjlvalue);
+        else
+            argtypes.push_back(t);
         if (4 + i > nargs) {
             jl_error("Missing arguments to llvmcall!");
         }
@@ -1014,6 +1017,8 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     Function *f;
     bool retboxed;
     Type *rettype = julia_type_to_llvm(rtt, &retboxed);
+    if (retboxed)
+        rettype = T_prjlvalue;
     if (isString) {
         // Make sure to find a unique name
         std::string ir_name;

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1799,8 +1799,10 @@ bool LateLowerGCFrame::CleanupIR(Function &F, State *S) {
                 size_t nframeargs = nargs - (CC == JLCALL_F_CC);
                 SmallVector<Value *, 3> ReplacementArgs;
                 auto it = CI->arg_begin();
-                if (CC == JLCALL_F_CC)
+                if (CC == JLCALL_F_CC) {
+                    assert(it != CI->arg_end());
                     ReplacementArgs.push_back(*(it++));
+                }
                 maxframeargs = std::max(maxframeargs, nframeargs);
                 int slot = 0;
                 IRBuilder<> Builder (CI);

--- a/src/llvmcalltest.cpp
+++ b/src/llvmcalltest.cpp
@@ -1,0 +1,32 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include "../src/support/platform.h"
+#include "../src/support/dtypes.h"
+
+#include "llvm/Config/llvm-config.h"
+#include "llvm/IR/IRBuilder.h"
+
+#include "codegen_shared.h"
+
+using namespace llvm;
+
+extern "C" {
+
+JL_DLLEXPORT llvm::Function *MakeIdentityFunction(llvm::PointerType *AnyTy) {
+    Type *TrackedTy = PointerType::get(AnyTy->getElementType(), AddressSpace::Tracked);
+    Module *M = new llvm::Module("shadow", AnyTy->getContext());
+    Function *F = Function::Create(
+        FunctionType::get(
+            TrackedTy, {TrackedTy}, false),
+        llvm::GlobalValue::ExternalLinkage,
+        "identity",
+        M
+    );
+
+    IRBuilder<> Builder(BasicBlock::Create(AnyTy->getContext(), "top", F));
+    Builder.CreateRet(&*F->arg_begin());
+
+    return F;
+}
+
+}


### PR DESCRIPTION
I suspect Cxx is the only user at the moment, but absent this
you either get an incorrect assert in debug builds (if you're
setting addrspaces correctly in the called function), or missing
GC roots (if you don't, to avoid the assert). Fix that.