### PR TITLE
Remove `n_waiters(c::GenericCondition)`

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -154,8 +154,6 @@ end
 
 notify_error(c::GenericCondition, err) = notify(c, err, true, true)
 
-n_waiters(c::GenericCondition) = length(c.waitq)
-
 """
     isempty(condition)
 


### PR DESCRIPTION
Wasn't tested, according to coverage.