### PR TITLE
Sort method signatures before precompile to avoid order dependence.

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -630,9 +630,9 @@ static int dt_compare(const void *ap, const void *bp) JL_NOTSAFEPOINT
     return typekey_compare(b, jl_svec_data(a->parameters), jl_svec_len(a->parameters));
 }
 
-void jl_resort_type_cache(jl_svec_t *c)
+void jl_sort_types(jl_value_t **types, size_t length)
 {
-    qsort(jl_svec_data(c), jl_svec_len(c), sizeof(jl_value_t*), dt_compare);
+    qsort(types, length, sizeof(jl_value_t*), dt_compare);
 }
 
 static int typekey_eq(jl_datatype_t *tt, jl_value_t **key, size_t n)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -364,7 +364,7 @@ void jl_print_gc_stats(JL_STREAM *s);
 void jl_gc_reset_alloc_count(void);
 int jl_assign_type_uid(void);
 jl_value_t *jl_cache_type_(jl_datatype_t *type);
-void jl_resort_type_cache(jl_svec_t *c);
+void jl_sort_types(jl_value_t **types, size_t length);
 int  jl_get_t_uid_ctr(void);
 void jl_set_t_uid_ctr(int i);
 uint32_t jl_get_gs_ctr(void);

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -371,6 +371,8 @@ static void jl_compile_specializations(void)
     jl_array_t *m = jl_alloc_vec_any(0);
     JL_GC_PUSH1(&m);
     jl_foreach_reachable_mtable(precompile_enq_all_specializations_, m);
+    // Ensure stable ordering to make inference problems more reproducible (#29923)
+    jl_sort_types(jl_array_data(m), jl_array_len(m));
     size_t i, l;
     for (i = 0, l = jl_array_len(m); i < l; i++) {
         jl_compile_hint((jl_tupletype_t*)jl_array_ptr_ref(m, i));

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1538,7 +1538,7 @@ static void jl_restore_system_image_from_stream(ios_t *f)
         jl_gc_wb(tn, tn->cache);
         tn->linearcache = (jl_svec_t*)jl_read_value(&s);
         jl_gc_wb(tn, tn->linearcache);
-        jl_resort_type_cache(tn->cache);
+        jl_sort_types(jl_svec_data(tn->cache), jl_svec_len(tn->cache));
     }
 
     jl_core_module = (jl_module_t*)jl_get_global(jl_main_module, jl_symbol("Core"));


### PR DESCRIPTION
This should help in making ordering-dependent bugs such as #29923 (an
error in caching of inferred methods) deterministic, which will make
them much easier to find in the future.

Timing this just for good measure, it appears there's only ~5000 elements to be sorted, which costs a paltry ~ 1 ms.

[edit] I should mention that I tested this with the error in #29923, and it makes the compile completely reproducible.