### PR TITLE
inference: add missing limit-cycle poisoning

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -310,25 +310,7 @@ function abstract_call_method(method::Method, @nospecialize(sig), sparams::Simpl
                 # (non-typically, this means that we lose the ability to detect a guaranteed StackOverflow in some cases)
                 return Any, false, nothing
             end
-            infstate = sv
-            topmost = topmost::InferenceState
-            while !(infstate === topmost.parent)
-                if call_result_unused(infstate)
-                    # If we won't propagate the result any further (since it's typically unused),
-                    # it's OK that we keep and cache the "limited" result in the parents
-                    # (non-typically, this means that we lose the ability to detect a guaranteed StackOverflow in some cases)
-                    # TODO: we might be able to halt progress much more strongly here,
-                    # since now we know we won't be able to keep anything much that we learned.
-                    # We were mainly only here to compute the calling convention return type,
-                    # but in most situations now, we are unlikely to be able to use that information.
-                    break
-                end
-                infstate.limited = true
-                for infstate_cycle in infstate.callers_in_cycle
-                    infstate_cycle.limited = true
-                end
-                infstate = infstate.parent
-            end
+            poison_callstack(sv, topmost::InferenceState, true)
             sig = newsig
             sparams = svec()
         end

--- a/test/compiler/compiler.jl
+++ b/test/compiler/compiler.jl
@@ -2134,3 +2134,11 @@ end
 # Test that inference can infer .instance of types
 f_instance(::Type{T}) where {T} = T.instance
 @test @inferred(f_instance(Nothing)) === nothing
+
+# test for some limit-cycle caching poisoning
+_false30098 = false
+f30098() = _false30098 ? g30098() : 3
+g30098() = (h30098(:f30098); 4)
+h30098(f) = getfield(@__MODULE__, f)()
+@test @inferred(g30098()) == 4 # make sure that this
+@test @inferred(f30098()) == 3 # doesn't pollute the inference cache of this


### PR DESCRIPTION
Seems to have been missing since the original implementation of IPO constant-prop.
It's impressive how long we got away with just poisoning the cache with `Any`
if there was a self-recursive call.

Fix #29923