### PR TITLE
adding == for structured matrices (split off of #29724)

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -322,7 +322,14 @@ end
 *(A::Bidiagonal, B::Number) = Bidiagonal(A.dv*B, A.ev*B, A.uplo)
 *(B::Number, A::Bidiagonal) = A*B
 /(A::Bidiagonal, B::Number) = Bidiagonal(A.dv/B, A.ev/B, A.uplo)
-==(A::Bidiagonal, B::Bidiagonal) = (A.uplo==B.uplo) && (A.dv==B.dv) && (A.ev==B.ev)
+
+function ==(A::Bidiagonal, B::Bidiagonal)
+    if A.uplo == B.uplo
+        return A.dv == B.dv && A.ev == B.ev
+    else
+        return iszero(A.ev) && iszero(B.ev) && A.dv == B.dv
+    end
+end
 
 const BiTriSym = Union{Bidiagonal,Tridiagonal,SymTridiagonal}
 const BiTri = Union{Bidiagonal,Tridiagonal}

--- a/stdlib/LinearAlgebra/src/special.jl
+++ b/stdlib/LinearAlgebra/src/special.jl
@@ -148,3 +148,25 @@ function fill!(A::Union{Diagonal,Bidiagonal,Tridiagonal,SymTridiagonal}, x)
     throw(ArgumentError("array of type $(typeof(A)) and size $(size(A)) can
     not be filled with $x, since some of its entries are constrained."))
 end
+
+# equals and approx equals methods for structured matrices
+# SymTridiagonal == Tridiagonal is already defined in tridiag.jl
+
+# SymTridiagonal and Bidiagonal have the same field names
+==(A::Diagonal, B::Union{SymTridiagonal, Bidiagonal}) = iszero(B.ev) && A.diag == B.dv
+==(B::Bidiagonal, A::Diagonal) = A == B
+
+==(A::Diagonal, B::Tridiagonal) = iszero(B.dl) && iszero(B.du) && A.diag == B.d
+==(B::Tridiagonal, A::Diagonal) = A == B
+
+function ==(A::Bidiagonal, B::Tridiagonal)
+    if A.uplo == 'U'
+        return iszero(B.dl) && A.dv == B.d && A.ev == B.du
+    else
+        return iszero(B.du) && A.dv == B.d && A.ev == B.dl
+    end
+end
+==(B::Tridiagonal, A::Bidiagonal) = A == B
+
+==(A::Bidiagonal, B::SymTridiagonal) = iszero(B.ev) && iszero(A.ev) && A.dv == B.dv
+==(B::SymTridiagonal, A::Bidiagonal) = A == B

--- a/stdlib/LinearAlgebra/test/special.jl
+++ b/stdlib/LinearAlgebra/test/special.jl
@@ -252,4 +252,28 @@ end
     @test isa((@inferred vcat(Float64[], spzeros(1))), SparseVector)
 end
 
+@testset "== for structured matrices" begin
+    diag = rand(10)
+    offdiag = rand(9)
+    D = Diagonal(rand(10))
+    Bup = Bidiagonal(diag, offdiag, 'U')
+    Blo = Bidiagonal(diag, offdiag, 'L')
+    Bupd = Bidiagonal(diag, zeros(9), 'U')
+    Blod = Bidiagonal(diag, zeros(9), 'L')
+    T = Tridiagonal(offdiag, diag, offdiag)
+    Td = Tridiagonal(zeros(9), diag, zeros(9))
+    Tu = Tridiagonal(zeros(9), diag, offdiag)
+    Tl = Tridiagonal(offdiag, diag, zeros(9))
+    S = SymTridiagonal(diag, offdiag)
+    Sd = SymTridiagonal(diag, zeros(9))
+
+    mats = [D, Bup, Blo, Bupd, Blod, T, Td, Tu, Tl, S, Sd]
+
+    for a in mats
+        for b in mats
+            @test (a == b) == (Matrix(a) == Matrix(b)) == (b == a) == (Matrix(b) == Matrix(a))
+        end
+    end
+end
+
 end # module TestSpecial


### PR DESCRIPTION
This is the completed half of https://github.com/JuliaLang/julia/pull/29724

The logic I implemented in #29724 is flawed for `isapprox` and several new methods (specifically norms) need to be implemented. This PR contains just the exact equality code for structured matrices. It also includes a bug fix for comparing two `Bidiagonal` matrices when they have different `uplo`, which shouldn't be held up by the other PR.

The `Bidiagonal` bug:

```
julia> x = rand(3)
3-element Array{Float64,1}:
 0.7279081769922535
 0.8949580887222155
 0.7781661021218007

julia> Bu = Bidiagonal(x, zeros(2), 'U')
3×3 Bidiagonal{Float64,Array{Float64,1}}:
 0.727908  0.0        ⋅      
  ⋅        0.894958  0.0     
  ⋅         ⋅        0.778166

julia> Bl = Bidiagonal(x, zeros(2), 'L')
3×3 Bidiagonal{Float64,Array{Float64,1}}:
 0.727908   ⋅         ⋅      
 0.0       0.894958   ⋅      
  ⋅        0.0       0.778166

julia> Bu == Bl
false

julia> Matrix(Bu) == Matrix(Bl)
true
```

This PR

```
julia> x = rand(3)
3-element Array{Float64,1}:
 0.3172029052612273 
 0.8635761133663176 
 0.17013855660697486

julia> Bu = Bidiagonal(x, zeros(2), 'U')
3×3 Bidiagonal{Float64,Array{Float64,1}}:
 0.317203  0.0        ⋅      
  ⋅        0.863576  0.0     
  ⋅         ⋅        0.170139

julia> Bl = Bidiagonal(x, zeros(2), 'L')
3×3 Bidiagonal{Float64,Array{Float64,1}}:
 0.317203   ⋅         ⋅      
 0.0       0.863576   ⋅      
  ⋅        0.0       0.170139

julia> Bu == Bl
true

julia> Matrix(Bu) == Matrix(Bl)
true
```

------------------------------------------------------------

Some timings (these are pessimal cases):
v1.0
```
julia> D=Diagonal(zeros(1000));B=Bidiagonal(zeros(1000), zeros(999), 'U');T=Tridiagonal(zeros(999), zeros(1000), zeros(999))

julia> @time D == B
  0.636254 seconds (4 allocations: 160 bytes)
true

julia> @time D == T
  0.008160 seconds (4 allocations: 160 bytes)
true

julia> @time B == T
  0.629008 seconds (4 allocations: 160 bytes)
true
```

This PR

```
julia> D=Diagonal(zeros(1000));B=Bidiagonal(zeros(1000), zeros(999), 'U');T=Tridiagonal(zeros(999), zeros(1000), zeros(999))

julia> @time D == B
  0.000007 seconds (4 allocations: 160 bytes)
true

julia> @time D == T
  0.000005 seconds (4 allocations: 160 bytes)
true

julia> @time B == T
  0.000012 seconds (4 allocations: 160 bytes)
true
```