### PR TITLE
Base.check_new_version: two fixes and a minor change

### DIFF
--- a/base/version.jl
+++ b/base/version.jl
@@ -212,13 +212,13 @@ nextminor(v::VersionNumber) = v < thisminor(v) ? thisminor(v) : VersionNumber(v.
 nextmajor(v::VersionNumber) = v < thismajor(v) ? thismajor(v) : VersionNumber(v.major+1, 0, 0)
 
 function check_new_version(existing::Vector{VersionNumber}, ver::VersionNumber)
-    @assert issorted(existing)
     if isempty(existing)
         for v in [v"0", v"0.0.1", v"0.1", v"1"]
             lowerbound(v) <= ver <= v && return
         end
         error("$ver is not a valid initial version (try 0.0.0, 0.0.1, 0.1 or 1.0)")
     end
+    issorted(existing) || (existing = sort(existing))
     idx = searchsortedlast(existing, ver)
     prv = existing[idx]
     ver == prv && error("version $ver already exists")

--- a/base/version.jl
+++ b/base/version.jl
@@ -216,7 +216,7 @@ function check_new_version(existing::Vector{VersionNumber}, ver::VersionNumber)
         for v in [v"0.0.1", v"0.1", v"1"]
             lowerbound(v) <= ver <= v && return
         end
-        error("$ver is not a valid initial version (try 0.0.1, 0.1 or 1.0)")
+        error("version $ver is invalid initial version (try 0.0.1, 0.1, 1.0)")
     end
     issorted(existing) || (existing = sort(existing))
     idx = searchsortedlast(existing, ver)
@@ -225,10 +225,10 @@ function check_new_version(existing::Vector{VersionNumber}, ver::VersionNumber)
     ver == prv && error("version $ver already exists")
     nxt = thismajor(ver) != thismajor(prv) ? nextmajor(prv) :
           thisminor(ver) != thisminor(prv) ? nextminor(prv) : nextpatch(prv)
-    ver <= nxt || error("$ver skips over $nxt")
+    ver <= nxt || error("version $ver skips over $nxt")
     thispatch(ver) <= ver && return # regular or build release
     idx < length(existing) && thispatch(existing[idx+1]) <= nxt &&
-        error("$ver is a pre-release of existing version $(existing[idx+1])")
+        error("version $ver is pre-release of existing version $(existing[idx+1])")
     return # acceptable new version
 end
 

--- a/base/version.jl
+++ b/base/version.jl
@@ -213,10 +213,10 @@ nextmajor(v::VersionNumber) = v < thismajor(v) ? thismajor(v) : VersionNumber(v.
 
 function check_new_version(existing::Vector{VersionNumber}, ver::VersionNumber)
     if isempty(existing)
-        for v in [v"0", v"0.0.1", v"0.1", v"1"]
+        for v in [v"0.0.1", v"0.1", v"1"]
             lowerbound(v) <= ver <= v && return
         end
-        error("$ver is not a valid initial version (try 0.0.0, 0.0.1, 0.1 or 1.0)")
+        error("$ver is not a valid initial version (try 0.0.1, 0.1 or 1.0)")
     end
     issorted(existing) || (existing = sort(existing))
     idx = searchsortedlast(existing, ver)

--- a/base/version.jl
+++ b/base/version.jl
@@ -220,6 +220,7 @@ function check_new_version(existing::Vector{VersionNumber}, ver::VersionNumber)
     end
     issorted(existing) || (existing = sort(existing))
     idx = searchsortedlast(existing, ver)
+    idx > 0 || error("version $ver less than least existing version $(existing[1])")
     prv = existing[idx]
     ver == prv && error("version $ver already exists")
     nxt = thismajor(ver) != thismajor(prv) ? nextmajor(prv) :

--- a/test/version.jl
+++ b/test/version.jl
@@ -222,6 +222,8 @@ import Base.check_new_version
 @test_throws ErrorException check_new_version(VersionNumber[v"1", v"2", v"3"], v"2")
 @test_throws ErrorException check_new_version([v"1", v"2"], v"4")
 @test_throws ErrorException check_new_version([v"1", v"2"], v"2-rc")
+@test_throws ErrorException check_new_version([v"1", v"2"], v"0")
+@test_throws ErrorException check_new_version([v"1", v"2"], v"0.9")
 @test check_new_version([v"1", v"2"], v"2.0.1") === nothing
 @test check_new_version([v"1", v"2"], v"2.1") === nothing
 @test check_new_version([v"1", v"2"], v"3") === nothing

--- a/test/version.jl
+++ b/test/version.jl
@@ -212,7 +212,7 @@ import Base.check_new_version
 @test check_new_version([v"1", v"2"], v"3") === nothing
 @test check_new_version([v"2", v"1"], v"3") === nothing
 @test_throws ErrorException check_new_version([v"1", v"2"], v"2")
-@test check_new_version(VersionNumber[], v"0") === nothing
+@test_throws ErrorException check_new_version(VersionNumber[], v"0")
 @test check_new_version(VersionNumber[], v"0.0.1") === nothing
 @test_throws ErrorException check_new_version(VersionNumber[], v"0.0.2")
 @test check_new_version(VersionNumber[], v"0.1") === nothing

--- a/test/version.jl
+++ b/test/version.jl
@@ -210,7 +210,7 @@ end
 # check_new_version
 import Base.check_new_version
 @test check_new_version([v"1", v"2"], v"3") === nothing
-@test_throws AssertionError check_new_version([v"2", v"1"], v"3")
+@test check_new_version([v"2", v"1"], v"3") === nothing
 @test_throws ErrorException check_new_version([v"1", v"2"], v"2")
 @test check_new_version(VersionNumber[], v"0") === nothing
 @test check_new_version(VersionNumber[], v"0.0.1") === nothing
@@ -225,6 +225,11 @@ import Base.check_new_version
 @test check_new_version([v"1", v"2"], v"2.0.1") === nothing
 @test check_new_version([v"1", v"2"], v"2.1") === nothing
 @test check_new_version([v"1", v"2"], v"3") === nothing
+
+let vers = [v"2", v"1"]
+    @test check_new_version(vers, v"3") == nothing
+    @test vers == [v"2", v"1"] # no mutation
+end
 
 # banner
 import Base.banner


### PR DESCRIPTION
Don't squash these three commits:

1. Removes an incorrectly used (my fault) `@assert` and just relaxes the restriction: don't require the first argument to be sorted—just sort it if necessary instead.

2. Fixes a corner case where the new version number is less than all existing versions, which caused and out-of-bounds exception previously.

3. Don't allow `0.0.0` as an initial version.

The first two commits can be backported, the last one probably shouldn't since it might break something, even though this isn't a public API.