### PR TITLE
Fix show test when Sockets are loaded in Main.

### DIFF
--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -66,7 +66,8 @@ end
     @test inet.port == 1024
     io = IOBuffer()
     show(io, inet)
-    @test String(take!(io)) == "Sockets.InetAddr{Sockets.IPv4}(ip\"127.0.0.1\", 1024)"
+    str = "Sockets.InetAddr{$(isdefined(Main, :IPv4) ? "" : "Sockets.")IPv4}(ip\"127.0.0.1\", 1024)"
+    @test String(take!(io)) == str
 end
 @testset "InetAddr invalid port" begin
     @test_throws InexactError Sockets.InetAddr(IPv4(127,0,0,1), -1)


### PR DESCRIPTION
Fixes the test added in #29407 to work even when `Sockets` are loaded in `Main` (e.g. when doing `]test Sockets`). Could be updated if we do something like #29466 in the future.

CC @ararslan , this should fix `Sockets` in `PkgEval`.

