### PR TITLE
varinfo() has been moved to `InteractiveUtils`

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -869,7 +869,7 @@ julia> let B = B
            remotecall_fetch(()->B, 2)
        end;
 
-julia> @fetchfrom 2 varinfo()
+julia> @fetchfrom 2 InteractiveUtils.varinfo()
 name           size summary
 ––––––––– ––––––––– ––––––––––––––––––––––
 A         800 bytes 10×10 Array{Float64,2}


### PR DESCRIPTION
When we want to call `varinfo()` on the remote processes,
we have to call InteractiveUtils.varinfo() instead.
Thus, the example in the document should be changed.
#25751