### PR TITLE
Fix 29932 - sync put!/take! for unbuffered RemoteChannels

### DIFF
--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -13,7 +13,7 @@ import Base: getindex, wait, put!, take!, fetch, isready, push!, length,
 using Base: Process, Semaphore, JLOptions, AnyDict, buffer_writes, wait_connected,
             VERSION_STRING, binding_module, notify_error, atexit, julia_exename,
             julia_cmd, AsyncGenerator, acquire, release, invokelatest,
-            shell_escape_posixly, uv_error, something, notnothing
+            shell_escape_posixly, uv_error, something, notnothing, isbuffered
 
 using Serialization, Sockets
 import Serialization: serialize, deserialize

--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -480,10 +480,10 @@ function call_on_owner(f, rr::AbstractRemoteRef, args...)
     end
 end
 
-function wait_ref(rid, callee, args...)
+function wait_ref(rid, caller, args...)
     v = fetch_ref(rid, args...)
     if isa(v, RemoteException)
-        if myid() == callee
+        if myid() == caller
             throw(v)
         else
             return v
@@ -549,12 +549,12 @@ function put!(rr::Future, v)
     rr.v = Some(v)
     rr
 end
-function put_future(rid, v, callee)
+function put_future(rid, v, caller)
     rv = lookup_ref(rid)
     isready(rv) && error("Future can be set only once")
     put!(rv, v)
-    # The callee has the value and hence can be removed from the remote store.
-    del_client(rid, callee)
+    # The caller has the value and hence can be removed from the remote store.
+    del_client(rid, caller)
     nothing
 end
 
@@ -574,9 +574,9 @@ put!(rr::RemoteChannel, args...) = (call_on_owner(put_ref, rr, args...); rr)
 # take! is not supported on Future
 
 take!(rv::RemoteValue, args...) = take!(rv.c, args...)
-function take_ref(rid, callee, args...)
+function take_ref(rid, caller, args...)
     v=take!(lookup_ref(rid), args...)
-    isa(v, RemoteException) && (myid() == callee) && throw(v)
+    isa(v, RemoteException) && (myid() == caller) && throw(v)
     v
 end
 

--- a/stdlib/Distributed/src/remotecall.jl
+++ b/stdlib/Distributed/src/remotecall.jl
@@ -560,7 +560,16 @@ end
 
 
 put!(rv::RemoteValue, args...) = put!(rv.c, args...)
-put_ref(rid, args...) = (put!(lookup_ref(rid), args...); nothing)
+function put_ref(rid, caller, args...)
+    rv = lookup_ref(rid)
+    put!(rv, args...)
+    if myid() == caller && rv.synctake !== nothing
+        # Wait till a "taken" value is serialized out - github issue #29932
+        lock(rv.synctake)
+        unlock(rv.synctake)
+    end
+    nothing
+end
 
 """
     put!(rr::RemoteChannel, args...)
@@ -569,15 +578,29 @@ Store a set of values to the [`RemoteChannel`](@ref).
 If the channel is full, blocks until space is available.
 Return the first argument.
 """
-put!(rr::RemoteChannel, args...) = (call_on_owner(put_ref, rr, args...); rr)
+put!(rr::RemoteChannel, args...) = (call_on_owner(put_ref, rr, myid(), args...); rr)
 
 # take! is not supported on Future
 
 take!(rv::RemoteValue, args...) = take!(rv.c, args...)
 function take_ref(rid, caller, args...)
-    v=take!(lookup_ref(rid), args...)
+    rv = lookup_ref(rid)
+    synctake = false
+    if myid() != caller && rv.synctake !== nothing
+        # special handling for local put! / remote take! on unbuffered channel
+        # github issue #29932
+        synctake = true
+        lock(rv.synctake)
+    end
+
+    v=take!(rv, args...)
     isa(v, RemoteException) && (myid() == caller) && throw(v)
-    v
+
+    if synctake
+        return SyncTake(v, rv)
+    else
+        return v
+    end
 end
 
 """


### PR DESCRIPTION
This PR is in 3 commits and closes JuliaLang/julia#29932 .

1) An argname `callee` has been corrected to `caller` which it should have been all along. No change in logic. 

2) Fixes JuliaLang/julia#29932 for the specific case of local `put!` with a remote `take!` on an unbuffered `RemoteChannel`.  Does not affect any other use case. It required the `put!` call to wait till the locally proxied `take!` to be serialized completely before returning. Locking / unlocking was outside lexical scope in the `take!` scenario and hence the slightly convoluted solution.

3) Documents behavior of local invocations of remote calls in the manual. Differences w.r.t. arguments in these two cases are highlighted.

