### PR TITLE
Update libgfortran name matching to include SOVERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -321,8 +321,8 @@ endef
 # don't inadvertently link to /lib/libgcc_s.so.1, which is incompatible with
 # libgfortran, and on Windows we copy them in earlier as well.
 ifeq (,$(findstring $(OS),FreeBSD WINNT))
-julia-base: $(build_libdir)/libgfortran.$(SHLIB_EXT)
-$(build_libdir)/libgfortran.$(SHLIB_EXT): | $(build_libdir)
+julia-base: $(build_libdir)/libgfortran*.$(SHLIB_EXT)*
+$(build_libdir)/libgfortran*.$(SHLIB_EXT)*: | $(build_libdir) julia-deps
 	-$(CUSTOM_LD_LIBRARY_PATH) PATH=$(PATH):$(build_depsbindir) $(JULIAHOME)/contrib/fixup-libgfortran.sh --verbose $(build_libdir)
 JL_PRIVATE_LIBS-0 += libgfortran libgcc_s libquadmath
 endif


### PR DESCRIPTION
This fixes the annoying re-copying of `libgfortran` every time on machines that have an SOVERSIONed filename.  This also fixes an ordering bug that could occur if too many cores are used, allowing `fixup-libgfortran` to be run before `openblas` or `arpack` are installed, which is no good.