### PR TITLE
Accept only Number as input for sincos

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -200,9 +200,8 @@ end
 
 _sincos(x::AbstractFloat) = sincos(x)
 _sincos(x) = (sin(x), cos(x))
-
-sincos(x) = _sincos(float(x))
-
+sincos(x::Number) = _sincos(float(x))
+sincos(x) = (sin(x), cos(x))
 
 
 # There's no need to write specialized kernels, as inlining takes care of remo-


### PR DESCRIPTION
With the old definition, it was possible to call `sincos` with Char inputs, which is not defined for `sin` and `cos`. Hence, we should accept only Real variables as input for `sincos`.

I put this in a separated PR because this is a breaking change (kind of...).