### PR TITLE
Don't restore globalUnique.

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -170,7 +170,9 @@ static void jl_load_sysimg_so(void)
         jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars_offsets", (void **)&sysimg_gvars_offsets, 1);
         sysimg_gvars_offsets += 1;
         assert(sysimg_fptrs.base);
-        jl_dlsym(jl_sysimg_handle, "jl_globalUnique", (void **)&globalUnique, 1);
+        int* globalUnique_ptr;
+        jl_dlsym(jl_sysimg_handle, "jl_globalUnique", (void **)&globalUnique_ptr, 1);
+        globalUnique = *globalUnique_ptr;
 #ifdef JULIA_ENABLE_THREADING
         uintptr_t *tls_getter_slot;
         jl_dlsym(jl_sysimg_handle, "jl_get_ptls_states_slot", (void **)&tls_getter_slot, 1);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -144,7 +144,6 @@ static uint32_t read_uint32(ios_t *s) JL_NOTSAFEPOINT
 
 // --- Static Compile ---
 
-extern int globalUnique;
 static void *jl_sysimg_handle = NULL;
 static uint64_t sysimage_base = 0;
 static uintptr_t *sysimg_gvars_base = NULL;
@@ -170,9 +169,6 @@ static void jl_load_sysimg_so(void)
         jl_dlsym(jl_sysimg_handle, "jl_sysimg_gvars_offsets", (void **)&sysimg_gvars_offsets, 1);
         sysimg_gvars_offsets += 1;
         assert(sysimg_fptrs.base);
-        int* globalUnique_ptr;
-        jl_dlsym(jl_sysimg_handle, "jl_globalUnique", (void **)&globalUnique_ptr, 1);
-        globalUnique = *globalUnique_ptr;
 #ifdef JULIA_ENABLE_THREADING
         uintptr_t *tls_getter_slot;
         jl_dlsym(jl_sysimg_handle, "jl_get_ptls_states_slot", (void **)&tls_getter_slot, 1);


### PR DESCRIPTION
Bug introduced in 68cc9f0e28e387b0147d896af73ea40d088d922e/https://github.com/JuliaLang/julia/pull/28888 (cc @staticfloat). Fixes the following silliness:

```julia
julia> @code_llvm 1+1

; Function +
; Location: int.jl:53
define i64 @"julia_+_-948762352"(i64, i64) {
top:
  %2 = add i64 %1, %0
  ret i64 %2
}
```