### PR TITLE
WIP: towards transitive specificity

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -375,6 +375,11 @@ getindex(::Type{T}, x) where {T} = (@_inline_meta; a = Vector{T}(undef, 1); @inb
 getindex(::Type{T}, x, y) where {T} = (@_inline_meta; a = Vector{T}(undef, 2); @inbounds (a[1] = x; a[2] = y); a)
 getindex(::Type{T}, x, y, z) where {T} = (@_inline_meta; a = Vector{T}(undef, 3); @inbounds (a[1] = x; a[2] = y; a[3] = z); a)
 
+getindex(::Type{Any}) = Vector{Any}()
+getindex(::Type{Any}, @nospecialize(x)) = (a = Vector{Any}(undef, 1); @inbounds a[1] = x; a)
+getindex(::Type{Any}, @nospecialize(x), @nospecialize(y)) = (a = Vector{Any}(undef, 2); @inbounds (a[1] = x; a[2] = y); a)
+getindex(::Type{Any}, @nospecialize(x), @nospecialize(y), @nospecialize(z)) = (a = Vector{Any}(undef, 3); @inbounds (a[1] = x; a[2] = y; a[3] = z); a)
+
 function getindex(::Type{Any}, @nospecialize vals...)
     a = Vector{Any}(undef, length(vals))
     @inbounds for i = 1:length(vals)
@@ -382,7 +387,6 @@ function getindex(::Type{Any}, @nospecialize vals...)
     end
     return a
 end
-getindex(::Type{Any}) = Vector{Any}()
 
 function fill!(a::Union{Array{UInt8}, Array{Int8}}, x::Integer)
     ccall(:memset, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Csize_t), a, x, length(a))

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -56,7 +56,9 @@ function showerror(io::IO, ex::TypeError)
     if ex.expected === Bool
         print(io, "non-boolean (", typeof(ex.got), ") used in boolean context")
     else
-        if isa(ex.got, Type)
+        if isvarargtype(ex.got)
+            targs = (ex.got,)
+        elseif isa(ex.got, Type)
             targs = ("Type{", ex.got, "}")
         else
             targs = (typeof(ex.got),)

--- a/base/indices.jl
+++ b/base/indices.jl
@@ -331,7 +331,8 @@ getindex(S::Slice, i::Int) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::AbstractUnitRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 getindex(S::Slice, i::StepRange{<:Integer}) = (@_inline_meta; @boundscheck checkbounds(S, i); i)
 show(io::IO, r::Slice) = print(io, "Base.Slice(", r.indices, ")")
-iterate(S::Slice, s...) = iterate(S.indices, s...)
+iterate(S::Slice) = iterate(S.indices)
+iterate(S::Slice, s) = iterate(S.indices, s)
 
 """
     LinearIndices(A::AbstractArray)
@@ -419,7 +420,8 @@ function getindex(iter::LinearIndices, i::AbstractRange{<:Integer})
 end
 # More efficient iteration — predominantly for non-vector LinearIndices
 # but one-dimensional LinearIndices must be special-cased to support OffsetArrays
-iterate(iter::LinearIndices{1}, s...) = iterate(axes1(iter.indices[1]), s...)
+iterate(iter::LinearIndices{1})    = iterate(axes1(iter.indices[1]))
+iterate(iter::LinearIndices{1}, s) = iterate(axes1(iter.indices[1]), s)
 iterate(iter::LinearIndices, i=1) = i > length(iter) ? nothing : (i, i+1)
 
 # Needed since firstindex and lastindex are defined in terms of LinearIndices

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -297,6 +297,7 @@ function promote(x, y, z, a...)
     p
 end
 
+promote(x::T, y::T) where {T} = (x, y)
 promote(x::T, y::T, zs::T...) where {T} = (x, y, zs...)
 
 not_sametype(x::T, y::T) where {T} = sametype_error(x)

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -164,7 +164,7 @@ function generate_precompile_statements()
             # println(statement)
             # Work around #28808
             occursin("\"YYYY-mm-dd\\THH:MM:SS\"", statement) && continue
-            statement == "precompile(Tuple{typeof(Base.show), Base.IOContext{Base.TTY}, Type{Vararg{Any, N} where N}})" && continue
+            occursin("Type{Vararg", statement) && continue
             try
                 Base.include_string(PrecompileStagingArea, statement)
             catch

--- a/test/specificity.jl
+++ b/test/specificity.jl
@@ -240,3 +240,24 @@ end
 @test  args_morespecific(Tuple{Array,Int64}, Tuple{Array,Vararg{Int64,N}} where N)
 @test  args_morespecific(Tuple{Array,Int64}, Tuple{Array,Vararg{Int64,N} where N})
 @test !args_morespecific(Tuple{Array,Int64}, Tuple{AbstractArray, Array})
+
+# issue #30114
+let T1 = Tuple{Type{Tuple{Vararg{AbstractUnitRange{Int64},N} where N}},CartesianIndices{N,R} where R<:Tuple{Vararg{AbstractUnitRange{Int64},N}}} where N
+    T2 = Tuple{Type{T},T} where T<:AbstractArray
+    T3 = Tuple{Type{AbstractArray{T,N} where N},AbstractArray} where T
+    T4 = Tuple{Type{AbstractArray{T,N}},AbstractArray{s57,N} where s57} where N where T
+    @test !args_morespecific(T1, T2)
+    @test !args_morespecific(T1, T3)
+    @test !args_morespecific(T1, T4)
+    @test  args_morespecific(T2, T3)
+    @test  args_morespecific(T2, T4)
+end
+
+@test !args_morespecific(Tuple{Type{Tuple{Vararg{AbstractUnitRange{Int64},N}}},} where N,
+                         Tuple{Type{Tuple{Vararg{AbstractUnitRange,N} where N}},})
+
+@test  args_morespecific(Tuple{Type{SubArray{T,2,P} where T}, Array{T}} where T where P,
+                         Tuple{Type{AbstractArray{T,N} where N},AbstractArray} where T)
+
+@test  args_morespecific(Tuple{Type{T},T} where T<:BitArray,
+                         Tuple{Type{BitArray},Any})


### PR DESCRIPTION
This is an experiment to see what it would take to make specificity transitive (at least far more than it is now), fully fixing #29594. It's possible, but would be pretty disruptive.

The main source of non-transitivity in the current system is the following example (`<` is more specific, `!<` is not-more-specific, and `{ }` is short for a tuple type):
```
1. {Array, Real}    < {AbstractArray}
2. {AbstractArray}  < {Any, Integer}
3. {Array, Real}   !< {Any, Integer}
```
To consider how to fix this, we can consider changing each relation (which also sheds light on why it works this way currently).

If we change (3), dispatch is asymmetric (we'd prefer the leftmost argument), which of course is a design that's been used but a huge change for us.

If we change (2), we would have
```
{AbstractArray}  <  {AbstractArray, Int...}  !<  {Any, Integer}
```
(varargs of course will be the theme here). The second relation is not desirable, since it should mean a lot that `Int` is more specific than `Integer` in the second slot even though the last signature is more specific in argument number.

If we change (1), we would have
```
{Array, Real}  <  {Array, Any...}  !<  {AbstractArray}
```
which seems to be the best option, although of course still not great since it would be nice if `Array` in the first slot could take precedence over `AbstractArray`. This is the option I implemented here. Now at least it is clear why we can't have absolutely everything we might want from specificity.

The other big breaking change this implies is that
```
{Array{<:Any,N}, Vararg{Int,N}} where N  <  {Array, Int}
```
no longer holds. That actually simplifies a lot of the specificity code, but adds new ambiguities of course. Some array methods will need to be added or updated, but it shouldn't be too bad.

This pattern seems to be quite common, unfortunately:
```
BitArray(::UndefInitializer, dims::Integer...) = method 1
BitArray(itr) = method 2
```
previously the first method was more specific, but it can't be anymore. A similar pattern occurs with `iterate` methods that use varargs to make the state optional. An interesting fix for this could be to insert two method signatures for vararg methods: the full signature as now, and a copy with the Vararg removed (i.e. add both `Tuple{X, Vararg{Y}}` and `Tuple{X}`). That would keep these methods working without the need to manually add those disambiguating methods. Basically, implementing the behavior we have now with a transitive specificity relation requires occupying two spots in the order instead of just one. It's quite likely that's a better way to implement the behavior.

Of course, this might be a 2.0 thing at this point.

In the current state of this PR, #29594 is fixed and the specificity tests pass, but many other things fail due to ambiguities. I'll try implementing the 2-slots-per-vararg-method trick and see how far it gets.