### PR TITLE
Request: Allow arbitrary array type for nzval of sparse matrix

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -204,6 +204,7 @@ section of the standard library reference.
 ```@docs
 SparseArrays.SparseVector
 SparseArrays.SparseMatrixCSC
+SparseArrays.GenericMatrixCSC
 SparseArrays.sparse
 SparseArrays.sparsevec
 SparseArrays.issparse

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -31,7 +31,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
 
 using Random: GLOBAL_RNG, AbstractRNG, randsubseq, randsubseq!
 
-export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector,
+export AbstractSparseArray, AbstractSparseMatrix, AbstractSparseVector, GenericMatrixCSC,
     SparseMatrixCSC, SparseVector, blockdiag, droptol!, dropzeros!, dropzeros,
     issparse, nonzeros, nzrange, rowvals, sparse, sparsevec, spdiagm,
     sprand, sprandn, spzeros, nnz, permute, findnz

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -4,22 +4,22 @@ import LinearAlgebra: checksquare
 
 ## sparse matrix multiplication
 
-*(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
+*(A::GenericMatrixCSC{TvA,TiA}, B::GenericMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
     *(sppromote(A, B)...)
-*(A::SparseMatrixCSC{TvA,TiA}, transB::Transpose{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(A::GenericMatrixCSC{TvA,TiA}, transB::Transpose{<:Any,<:GenericMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (B = transB.parent; (pA, pB) = sppromote(A, B); *(pA, transpose(pB)))
-*(A::SparseMatrixCSC{TvA,TiA}, adjB::Adjoint{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(A::GenericMatrixCSC{TvA,TiA}, adjB::Adjoint{<:Any,<:GenericMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (B = adjB.parent; (pA, pB) = sppromote(A, B); *(pA, adjoint(pB)))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TvA,TiA}}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
+*(transA::Transpose{<:Any,<:GenericMatrixCSC{TvA,TiA}}, B::GenericMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
     (A = transA.parent; (pA, pB) = sppromote(A, B); *(transpose(pA), pB))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TvA,TiA}}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
+*(adjA::Adjoint{<:Any,<:GenericMatrixCSC{TvA,TiA}}, B::GenericMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB} =
     (A = adjA.parent; (pA, pB) = sppromote(A, B); *(adjoint(pA), pB))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TvA,TiA}}, transB::Transpose{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(transA::Transpose{<:Any,<:GenericMatrixCSC{TvA,TiA}}, transB::Transpose{<:Any,<:GenericMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (A = transA.parent; B = transB.parent; (pA, pB) = sppromote(A, B); *(transpose(pA), transpose(pB)))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TvA,TiA}}, adjB::Adjoint{<:Any,<:SparseMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
+*(adjA::Adjoint{<:Any,<:GenericMatrixCSC{TvA,TiA}}, adjB::Adjoint{<:Any,<:GenericMatrixCSC{TvB,TiB}}) where {TvA,TiA,TvB,TiB} =
     (A = adjA.parent; B = adjB.parent; (pA, pB) = sppromote(A, B); *(adjoint(pA), adjoint(pB)))
 
-function sppromote(A::SparseMatrixCSC{TvA,TiA}, B::SparseMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
+function sppromote(A::GenericMatrixCSC{TvA,TiA}, B::GenericMatrixCSC{TvB,TiB}) where {TvA,TiA,TvB,TiB}
     Tv = promote_type(TvA, TvB)
     Ti = promote_type(TiA, TiB)
     A  = convert(SparseMatrixCSC{Tv,Ti}, A)
@@ -29,7 +29,7 @@ end
 
 # In matrix-vector multiplication, the correct orientation of the vector is assumed.
 
-function mul!(C::StridedVecOrMat, A::SparseMatrixCSC, B::StridedVecOrMat, α::Number, β::Number)
+function mul!(C::StridedVecOrMat, A::GenericMatrixCSC, B::StridedVecOrMat, α::Number, β::Number)
     A.n == size(B, 1) || throw(DimensionMismatch())
     A.m == size(C, 1) || throw(DimensionMismatch())
     size(B, 2) == size(C, 2) || throw(DimensionMismatch())
@@ -48,12 +48,12 @@ function mul!(C::StridedVecOrMat, A::SparseMatrixCSC, B::StridedVecOrMat, α::Nu
     end
     C
 end
-*(A::SparseMatrixCSC{TA,S}, x::StridedVector{Tx}) where {TA,S,Tx} =
+*(A::GenericMatrixCSC{TA,S}, x::StridedVector{Tx}) where {TA,S,Tx} =
     (T = promote_type(TA, Tx); mul!(similar(x, T, A.m), A, x, one(T), zero(T)))
-*(A::SparseMatrixCSC{TA,S}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
+*(A::GenericMatrixCSC{TA,S}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
     (T = promote_type(TA, Tx); mul!(similar(B, T, (A.m, size(B, 2))), A, B, one(T), zero(T)))
 
-function mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat, α::Number, β::Number)
+function mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:GenericMatrixCSC}, B::StridedVecOrMat, α::Number, β::Number)
     A = adjA.parent
     A.n == size(C, 1) || throw(DimensionMismatch())
     A.m == size(B, 1) || throw(DimensionMismatch())
@@ -74,12 +74,12 @@ function mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::Str
     end
     C
 end
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
+*(adjA::Adjoint{<:Any,<:GenericMatrixCSC{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
     (A = adjA.parent; T = promote_type(TA, Tx); mul!(similar(x, T, A.n), adjoint(A), x, one(T), zero(T)))
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
+*(adjA::Adjoint{<:Any,<:GenericMatrixCSC{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
     (A = adjA.parent; T = promote_type(TA, Tx); mul!(similar(B, T, (A.n, size(B, 2))), adjoint(A), B, one(T), zero(T)))
 
-function mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat, α::Number, β::Number)
+function mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:GenericMatrixCSC}, B::StridedVecOrMat, α::Number, β::Number)
     A = transA.parent
     A.n == size(C, 1) || throw(DimensionMismatch())
     A.m == size(B, 1) || throw(DimensionMismatch())
@@ -100,21 +100,21 @@ function mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:SparseMatrixCSC}, B:
     end
     C
 end
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
+*(transA::Transpose{<:Any,<:GenericMatrixCSC{TA,S}}, x::StridedVector{Tx}) where {TA,S,Tx} =
     (A = transA.parent; T = promote_type(TA, Tx); mul!(similar(x, T, A.n), transpose(A), x, one(T), zero(T)))
-*(transA::Transpose{<:Any,<:SparseMatrixCSC{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
+*(transA::Transpose{<:Any,<:GenericMatrixCSC{TA,S}}, B::StridedMatrix{Tx}) where {TA,S,Tx} =
     (A = transA.parent; T = promote_type(TA, Tx); mul!(similar(B, T, (A.n, size(B, 2))), transpose(A), B, one(T), zero(T)))
 
 # For compatibility with dense multiplication API. Should be deleted when dense multiplication
 # API is updated to follow BLAS API.
-mul!(C::StridedVecOrMat, A::SparseMatrixCSC, B::StridedVecOrMat) =
+mul!(C::StridedVecOrMat, A::GenericMatrixCSC, B::StridedVecOrMat) =
     mul!(C, A, B, one(eltype(B)), zero(eltype(C)))
-mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat) =
+mul!(C::StridedVecOrMat, adjA::Adjoint{<:Any,<:GenericMatrixCSC}, B::StridedVecOrMat) =
     (A = adjA.parent; mul!(C, adjoint(A), B, one(eltype(B)), zero(eltype(C))))
-mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:SparseMatrixCSC}, B::StridedVecOrMat) =
+mul!(C::StridedVecOrMat, transA::Transpose{<:Any,<:GenericMatrixCSC}, B::StridedVecOrMat) =
     (A = transA.parent; mul!(C, transpose(A), B, one(eltype(B)), zero(eltype(C))))
 
-function (*)(X::StridedMatrix{TX}, A::SparseMatrixCSC{TvA,TiA}) where {TX,TvA,TiA}
+function (*)(X::StridedMatrix{TX}, A::GenericMatrixCSC{TvA,TiA}) where {TX,TvA,TiA}
     mX, nX = size(X)
     nX == A.m || throw(DimensionMismatch())
     Y = zeros(promote_type(TX,TvA), mX, A.n)
@@ -126,11 +126,11 @@ function (*)(X::StridedMatrix{TX}, A::SparseMatrixCSC{TvA,TiA}) where {TX,TvA,Ti
     Y
 end
 
-function (*)(D::Diagonal, A::SparseMatrixCSC)
+function (*)(D::Diagonal, A::GenericMatrixCSC)
     T = Base.promote_op(*, eltype(D), eltype(A))
     mul!(LinearAlgebra.copy_oftype(A, T), D, A)
 end
-function (*)(A::SparseMatrixCSC, D::Diagonal)
+function (*)(A::GenericMatrixCSC, D::Diagonal)
     T = Base.promote_op(*, eltype(D), eltype(A))
     mul!(LinearAlgebra.copy_oftype(A, T), A, D)
 end
@@ -138,15 +138,15 @@ end
 # Sparse matrix multiplication as described in [Gustavson, 1978]:
 # http://dl.acm.org/citation.cfm?id=355796
 
-*(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(A,B)
-*(A::SparseMatrixCSC{Tv,Ti}, B::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(A, copy(B))
-*(A::SparseMatrixCSC{Tv,Ti}, B::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(A, copy(B))
-*(A::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(copy(A), B)
-*(A::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}, B::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(copy(A), B)
-*(A::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}, B::Adjoint{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(copy(A), copy(B))
-*(A::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}, B::Transpose{<:Any,<:SparseMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(copy(A), copy(B))
+*(A::GenericMatrixCSC{Tv,Ti}, B::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(A,B)
+*(A::GenericMatrixCSC{Tv,Ti}, B::Adjoint{<:Any,<:GenericMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(A, copy(B))
+*(A::GenericMatrixCSC{Tv,Ti}, B::Transpose{<:Any,<:GenericMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(A, copy(B))
+*(A::Transpose{<:Any,<:GenericMatrixCSC{Tv,Ti}}, B::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(copy(A), B)
+*(A::Adjoint{<:Any,<:GenericMatrixCSC{Tv,Ti}}, B::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti} = spmatmul(copy(A), B)
+*(A::Adjoint{<:Any,<:GenericMatrixCSC{Tv,Ti}}, B::Adjoint{<:Any,<:GenericMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(copy(A), copy(B))
+*(A::Transpose{<:Any,<:GenericMatrixCSC{Tv,Ti}}, B::Transpose{<:Any,<:GenericMatrixCSC{Tv,Ti}}) where {Tv,Ti} = spmatmul(copy(A), copy(B))
 
-function spmatmul(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
+function spmatmul(A::GenericMatrixCSC{Tv,Ti}, B::GenericMatrixCSC{Tv,Ti};
                   sortindices::Symbol = :sortcols) where {Tv,Ti}
     mA, nA = size(A)
     mB, nB = size(B)
@@ -198,13 +198,13 @@ function spmatmul(A::SparseMatrixCSC{Tv,Ti}, B::SparseMatrixCSC{Tv,Ti};
     deleteat!(nzvalC, colptrC[end]:length(nzvalC))
 
     # The Gustavson algorithm does not guarantee the product to have sorted row indices.
-    Cunsorted = SparseMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
+    Cunsorted = GenericMatrixCSC(mA, nB, colptrC, rowvalC, nzvalC)
     C = SparseArrays.sortSparseMatrixCSC!(Cunsorted, sortindices=sortindices)
     return C
 end
 
 # Frobenius dot/inner product: trace(A'B)
-function dot(A::SparseMatrixCSC{T1,S1},B::SparseMatrixCSC{T2,S2}) where {T1,T2,S1,S2}
+function dot(A::GenericMatrixCSC{T1,S1},B::GenericMatrixCSC{T2,S2}) where {T1,T2,S1,S2}
     m, n = size(A)
     size(B) == (m,n) || throw(DimensionMismatch("matrices must have the same dimensions"))
     r = dot(zero(T1), zero(T2))
@@ -242,24 +242,24 @@ possible_adjoint(adj::Bool, a ) = adj ? adjoint(a) : a
 const UnitDiagonalTriangular = Union{UnitUpperTriangular,UnitLowerTriangular}
 
 const LowerTriangularPlain{T} = Union{
-            LowerTriangular{T,<:SparseMatrixCSCUnion{T}},
-            UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}}
+            LowerTriangular{T,<:GenericMatrixCSCUnion{T}},
+            UnitLowerTriangular{T,<:GenericMatrixCSCUnion{T}}}
 
 const LowerTriangularWrapped{T} = Union{
-            Adjoint{T,<:UpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Adjoint{T,<:UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:UpperTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}}} where T
+            Adjoint{T,<:UpperTriangular{T,<:GenericMatrixCSCUnion{T}}},
+            Adjoint{T,<:UnitUpperTriangular{T,<:GenericMatrixCSCUnion{T}}},
+            Transpose{T,<:UpperTriangular{T,<:GenericMatrixCSCUnion{T}}},
+            Transpose{T,<:UnitUpperTriangular{T,<:GenericMatrixCSCUnion{T}}}} where T
 
 const UpperTriangularPlain{T} = Union{
-            UpperTriangular{T,<:SparseMatrixCSCUnion{T}},
-            UnitUpperTriangular{T,<:SparseMatrixCSCUnion{T}}}
+            UpperTriangular{T,<:GenericMatrixCSCUnion{T}},
+            UnitUpperTriangular{T,<:GenericMatrixCSCUnion{T}}}
 
 const UpperTriangularWrapped{T} = Union{
-            Adjoint{T,<:LowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Adjoint{T,<:UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:LowerTriangular{T,<:SparseMatrixCSCUnion{T}}},
-            Transpose{T,<:UnitLowerTriangular{T,<:SparseMatrixCSCUnion{T}}}} where T
+            Adjoint{T,<:LowerTriangular{T,<:GenericMatrixCSCUnion{T}}},
+            Adjoint{T,<:UnitLowerTriangular{T,<:GenericMatrixCSCUnion{T}}},
+            Transpose{T,<:LowerTriangular{T,<:GenericMatrixCSCUnion{T}}},
+            Transpose{T,<:UnitLowerTriangular{T,<:GenericMatrixCSCUnion{T}}}} where T
 
 const UpperTriangularSparse{T} = Union{
             UpperTriangularWrapped{T}, UpperTriangularPlain{T}} where T
@@ -630,16 +630,16 @@ function _ldiv!(U::UpperTriangularWrapped, B::StridedVecOrMat)
     B
 end
 
-(\)(L::TriangularSparse, B::SparseMatrixCSC) = ldiv!(L, Array(B))
-(*)(L::TriangularSparse, B::SparseMatrixCSC) = lmul!(L, Array(B))
+(\)(L::TriangularSparse, B::GenericMatrixCSC) = ldiv!(L, Array(B))
+(*)(L::TriangularSparse, B::GenericMatrixCSC) = lmul!(L, Array(B))
 
 ## end of triangular
 
-\(A::Transpose{<:Real,<:Hermitian{<:Real,<:SparseMatrixCSC}}, B::Vector) = A.parent \ B
-\(A::Transpose{<:Complex,<:Hermitian{<:Complex,<:SparseMatrixCSC}}, B::Vector) = copy(A) \ B
-\(A::Transpose{<:Number,<:Symmetric{<:Number,<:SparseMatrixCSC}}, B::Vector) = A.parent \ B
+\(A::Transpose{<:Real,<:Hermitian{<:Real,<:GenericMatrixCSC}}, B::Vector) = A.parent \ B
+\(A::Transpose{<:Complex,<:Hermitian{<:Complex,<:GenericMatrixCSC}}, B::Vector) = copy(A) \ B
+\(A::Transpose{<:Number,<:Symmetric{<:Number,<:GenericMatrixCSC}}, B::Vector) = A.parent \ B
 
-function rdiv!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T
+function rdiv!(A::GenericMatrixCSC{T}, D::Diagonal{T}) where T
     dd = D.diag
     if (k = length(dd)) ≠ A.n
         throw(DimensionMismatch("size(A, 2)=$(A.n) should be size(D, 1)=$k"))
@@ -657,14 +657,14 @@ function rdiv!(A::SparseMatrixCSC{T}, D::Diagonal{T}) where T
     A
 end
 
-rdiv!(A::SparseMatrixCSC{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
+rdiv!(A::GenericMatrixCSC{T}, adjD::Adjoint{<:Any,<:Diagonal{T}}) where {T} =
     (D = adjD.parent; rdiv!(A, conj(D)))
-rdiv!(A::SparseMatrixCSC{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
+rdiv!(A::GenericMatrixCSC{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
     (D = transD.parent; rdiv!(A, D))
 
 ## triu, tril
 
-function triu(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
+function triu(S::GenericMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     m,n = size(S)
     colptr = Vector{Ti}(undef, n+1)
     nnz = 0
@@ -692,7 +692,7 @@ function triu(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     A
 end
 
-function tril(S::SparseMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
+function tril(S::GenericMatrixCSC{Tv,Ti}, k::Integer=0) where {Tv,Ti}
     m,n = size(S)
     colptr = Vector{Ti}(undef, n+1)
     nnz = 0
@@ -725,7 +725,7 @@ end
 
 ## diff
 
-function sparse_diff1(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+function sparse_diff1(S::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti}
     m,n = size(S)
     m > 1 || return SparseMatrixCSC(0, n, fill(one(Ti),n+1), Ti[], Tv[])
     colptr = Vector{Ti}(undef, n+1)
@@ -765,7 +765,7 @@ function sparse_diff1(S::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     return SparseMatrixCSC(m-1, n, colptr, rowval, nzval)
 end
 
-function sparse_diff2(a::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
+function sparse_diff2(a::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti}
     m,n = size(a)
     colptr = Vector{Ti}(undef, max(n,1))
     numnz = 2 * nnz(a) # upper bound; will shrink later
@@ -854,12 +854,12 @@ function sparse_diff2(a::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti}
     return SparseMatrixCSC(m, n-1, colptr, rowval, nzval)
 end
 
-diff(a::SparseMatrixCSC; dims::Integer) = dims==1 ? sparse_diff1(a) : sparse_diff2(a)
+diff(a::GenericMatrixCSC; dims::Integer) = dims==1 ? sparse_diff1(a) : sparse_diff2(a)
 
 ## norm and rank
-norm(A::SparseMatrixCSC, p::Real=2) = norm(view(A.nzval, 1:nnz(A)), p)
+norm(A::GenericMatrixCSC, p::Real=2) = norm(view(A.nzval, 1:nnz(A)), p)
 
-function opnorm(A::SparseMatrixCSC, p::Real=2)
+function opnorm(A::GenericMatrixCSC, p::Real=2)
     m, n = size(A)
     if m == 0 || n == 0 || isempty(A)
         return float(real(zero(eltype(A))))
@@ -895,7 +895,7 @@ end
 # TODO rank
 
 # cond
-function cond(A::SparseMatrixCSC, p::Real=2)
+function cond(A::GenericMatrixCSC, p::Real=2)
     if p == 1
         normAinv = opnormestinv(A)
         normA = opnorm(A, 1)
@@ -911,7 +911,7 @@ function cond(A::SparseMatrixCSC, p::Real=2)
     end
 end
 
-function opnormestinv(A::SparseMatrixCSC{T}, t::Integer = min(2,maximum(size(A)))) where T
+function opnormestinv(A::GenericMatrixCSC{T}, t::Integer = min(2,maximum(size(A)))) where T
     maxiter = 5
     # Check the input
     n = checksquare(A)
@@ -1085,7 +1085,7 @@ end
 ## kron
 
 # sparse matrix ⊗ sparse matrix
-function kron(A::SparseMatrixCSC{T1,S1}, B::SparseMatrixCSC{T2,S2}) where {T1,S1,T2,S2}
+function kron(A::GenericMatrixCSC{T1,S1}, B::GenericMatrixCSC{T2,S2}) where {T1,S1,T2,S2}
     nnzC = nnz(A)*nnz(B)
     mA, nA = size(A); mB, nB = size(B)
     mC, nC = mA*mB, nA*nB
@@ -1134,23 +1134,23 @@ function kron(x::SparseVector{T1,S1}, y::SparseVector{T2,S2}) where {T1,S1,T2,S2
 end
 
 # sparse matrix ⊗ sparse vector & vice versa
-kron(A::SparseMatrixCSC, x::SparseVector) = kron(A, SparseMatrixCSC(x))
-kron(x::SparseVector, A::SparseMatrixCSC) = kron(SparseMatrixCSC(x), A)
+kron(A::GenericMatrixCSC, x::SparseVector) = kron(A, SparseMatrixCSC(x))
+kron(x::SparseVector, A::GenericMatrixCSC) = kron(SparseMatrixCSC(x), A)
 
 # sparse vec/mat ⊗ vec/mat and vice versa
-kron(A::Union{SparseVector,SparseMatrixCSC}, B::VecOrMat) = kron(A, sparse(B))
-kron(A::VecOrMat, B::Union{SparseVector,SparseMatrixCSC}) = kron(sparse(A), B)
+kron(A::Union{SparseVector,GenericMatrixCSC}, B::VecOrMat) = kron(A, sparse(B))
+kron(A::VecOrMat, B::Union{SparseVector,GenericMatrixCSC}) = kron(sparse(A), B)
 
 ## det, inv, cond
 
-inv(A::SparseMatrixCSC) = error("The inverse of a sparse matrix can often be dense and can cause the computer to run out of memory. If you are sure you have enough memory, please convert your matrix to a dense matrix.")
+inv(A::GenericMatrixCSC) = error("The inverse of a sparse matrix can often be dense and can cause the computer to run out of memory. If you are sure you have enough memory, please convert your matrix to a dense matrix.")
 
 # TODO
 
 ## scale methods
 
 # Copy colptr and rowval from one sparse matrix to another
-function copyinds!(C::SparseMatrixCSC, A::SparseMatrixCSC)
+function copyinds!(C::GenericMatrixCSC, A::GenericMatrixCSC)
     if C.colptr !== A.colptr
         resize!(C.colptr, length(A.colptr))
         copyto!(C.colptr, A.colptr)
@@ -1162,7 +1162,7 @@ function copyinds!(C::SparseMatrixCSC, A::SparseMatrixCSC)
 end
 
 # multiply by diagonal matrix as vector
-function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, D::Diagonal{T, <:Vector}) where T
+function mul!(C::GenericMatrixCSC, A::GenericMatrixCSC, D::Diagonal{T, <:Vector}) where T
     m, n = size(A)
     b    = D.diag
     (n==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
@@ -1176,7 +1176,7 @@ function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, D::Diagonal{T, <:Vector}) 
     C
 end
 
-function mul!(C::SparseMatrixCSC, D::Diagonal{T, <:Vector}, A::SparseMatrixCSC) where T
+function mul!(C::GenericMatrixCSC, D::Diagonal{T, <:Vector}, A::GenericMatrixCSC) where T
     m, n = size(A)
     b    = D.diag
     (m==length(b) && size(A)==size(C)) || throw(DimensionMismatch())
@@ -1191,7 +1191,7 @@ function mul!(C::SparseMatrixCSC, D::Diagonal{T, <:Vector}, A::SparseMatrixCSC) 
     C
 end
 
-function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Number)
+function mul!(C::GenericMatrixCSC, A::GenericMatrixCSC, b::Number)
     size(A)==size(C) || throw(DimensionMismatch())
     copyinds!(C, A)
     resize!(C.nzval, length(A.nzval))
@@ -1199,7 +1199,7 @@ function mul!(C::SparseMatrixCSC, A::SparseMatrixCSC, b::Number)
     C
 end
 
-function mul!(C::SparseMatrixCSC, b::Number, A::SparseMatrixCSC)
+function mul!(C::GenericMatrixCSC, b::Number, A::GenericMatrixCSC)
     size(A)==size(C) || throw(DimensionMismatch())
     copyinds!(C, A)
     resize!(C.nzval, length(A.nzval))
@@ -1207,17 +1207,17 @@ function mul!(C::SparseMatrixCSC, b::Number, A::SparseMatrixCSC)
     C
 end
 
-function rmul!(A::SparseMatrixCSC, b::Number)
+function rmul!(A::GenericMatrixCSC, b::Number)
     rmul!(A.nzval, b)
     return A
 end
 
-function lmul!(b::Number, A::SparseMatrixCSC)
+function lmul!(b::Number, A::GenericMatrixCSC)
     lmul!(b, A.nzval)
     return A
 end
 
-function rmul!(A::SparseMatrixCSC, D::Diagonal)
+function rmul!(A::GenericMatrixCSC, D::Diagonal)
     m, n = size(A)
     (n == size(D, 1)) || throw(DimensionMismatch())
     Anzval = A.nzval
@@ -1227,7 +1227,7 @@ function rmul!(A::SparseMatrixCSC, D::Diagonal)
     return A
 end
 
-function lmul!(D::Diagonal, A::SparseMatrixCSC)
+function lmul!(D::Diagonal, A::GenericMatrixCSC)
     m, n = size(A)
     (m == size(D, 2)) || throw(DimensionMismatch())
     Anzval = A.nzval
@@ -1238,7 +1238,7 @@ function lmul!(D::Diagonal, A::SparseMatrixCSC)
     return A
 end
 
-function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
+function \(A::GenericMatrixCSC, B::AbstractVecOrMat)
     @assert !has_offset_axes(A, B)
     m, n = size(A)
     if m == n
@@ -1261,7 +1261,7 @@ function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
 end
 for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
     @eval begin
-        function \(xformA::($xformtype){<:Any,<:SparseMatrixCSC}, B::AbstractVecOrMat)
+        function \(xformA::($xformtype){<:Any,<:GenericMatrixCSC}, B::AbstractVecOrMat)
             A = xformA.parent
             @assert !has_offset_axes(A, B)
             m, n = size(A)
@@ -1286,7 +1286,7 @@ for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
     end
 end
 
-function factorize(A::SparseMatrixCSC)
+function factorize(A::GenericMatrixCSC)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -1307,7 +1307,7 @@ function factorize(A::SparseMatrixCSC)
     end
 end
 
-# function factorize(A::Symmetric{Float64,SparseMatrixCSC{Float64,Ti}}) where Ti
+# function factorize(A::Symmetric{Float64,<:GenericMatrixCSC{Float64,Ti}}) where Ti
 #     F = cholesky(A)
 #     if LinearAlgebra.issuccess(F)
 #         return F
@@ -1316,7 +1316,7 @@ end
 #         return F
 #     end
 # end
-function factorize(A::LinearAlgebra.RealHermSymComplexHerm{Float64,<:SparseMatrixCSC})
+function factorize(A::LinearAlgebra.RealHermSymComplexHerm{Float64,<:GenericMatrixCSC})
     F = cholesky(A; check = false)
     if LinearAlgebra.issuccess(F)
         return F
@@ -1326,5 +1326,5 @@ function factorize(A::LinearAlgebra.RealHermSymComplexHerm{Float64,<:SparseMatri
     end
 end
 
-eigen(A::SparseMatrixCSC) =
+eigen(A::GenericMatrixCSC) =
     error("eigen(A) not supported for sparse matrices. Use for example eigs(A) from the Arpack package instead.")

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -30,9 +30,9 @@ end
 SparseVector(n::Integer, nzind::Vector{Ti}, nzval::Vector{Tv}) where {Tv,Ti} =
     SparseVector{Tv,Ti}(n, nzind, nzval)
 
-# Define an alias for a view of a whole column of a SparseMatrixCSC. Many methods can be written for the
+# Define an alias for a view of a whole column of a GenericMatrixCSC. Many methods can be written for the
 # union of such a view and a SparseVector so we define an alias for such a union as well
-const SparseColumnView{T}  = SubArray{T,1,<:SparseMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
+const SparseColumnView{T}  = SubArray{T,1,<:GenericMatrixCSC,Tuple{Base.Slice{Base.OneTo{Int}},Int},false}
 const SparseVectorUnion{T} = Union{SparseVector{T}, SparseColumnView{T}}
 
 ### Basic properties
@@ -69,11 +69,11 @@ _sparsesimilar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}, dims::Dims{1}) whe
     SparseVector(dims..., similar(S.nzind, TiNew, 0), similar(S.nzval, TvNew, 0))
 # parent method for similar that preserves storage space (for old and new dims differ, and new is 2d)
 _sparsesimilar(S::SparseVector, ::Type{TvNew}, ::Type{TiNew}, dims::Dims{2}) where {TvNew,TiNew} =
-    SparseMatrixCSC(dims..., fill(one(TiNew), last(dims)+1), similar(S.nzind, TiNew), similar(S.nzval, TvNew))
+    GenericMatrixCSC(dims..., fill(one(TiNew), last(dims)+1), similar(S.nzind, TiNew), similar(S.nzval, TvNew))
 # The following methods hook into the AbstractArray similar hierarchy. The first method
 # covers similar(A[, Tv]) calls, which preserve stored-entry structure, and the latter
 # methods cover similar(A[, Tv], shape...) calls, which preserve nothing if the dims
-# specify a SparseVector result and storage space if the dims specify a SparseMatrixCSC result.
+# specify a SparseVector result and storage space if the dims specify a GenericMatrixCSC result.
 similar(S::SparseVector{<:Any,Ti}, ::Type{TvNew}) where {Ti,TvNew} =
     _sparsesimilar(S, TvNew, Ti)
 similar(S::SparseVector{<:Any,Ti}, ::Type{TvNew}, dims::Union{Dims{1},Dims{2}}) where {Ti,TvNew} =
@@ -346,15 +346,15 @@ end
 
 ### Conversion
 
-# convert SparseMatrixCSC to SparseVector
-function SparseVector{Tv,Ti}(s::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti<:Integer}
+# convert GenericMatrixCSC to SparseVector
+function SparseVector{Tv,Ti}(s::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti<:Integer}
     size(s, 2) == 1 || throw(ArgumentError("The input argument must have a single-column."))
     SparseVector(s.m, s.rowval, s.nzval)
 end
 
-SparseVector{Tv}(s::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
+SparseVector{Tv}(s::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
 
-SparseVector(s::SparseMatrixCSC{Tv,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
+SparseVector(s::GenericMatrixCSC{Tv,Ti}) where {Tv,Ti} = SparseVector{Tv,Ti}(s)
 
 # convert Vector to SparseVector
 
@@ -425,7 +425,7 @@ SparseVector{Tv}(s::SparseVector{<:Any,Ti}) where {Tv,Ti} =
 
 convert(T::Type{<:SparseVector}, m::AbstractVector) = m isa T ? m : T(m)
 
-convert(T::Type{<:SparseVector}, m::SparseMatrixCSC) = T(m)
+convert(T::Type{<:SparseVector}, m::GenericMatrixCSC) = T(m)
 convert(T::Type{<:SparseMatrixCSC}, v::SparseVector) = T(v)
 
 ### copying
@@ -461,7 +461,7 @@ function copyto!(A::SparseVector, B::SparseVector)
     return A
 end
 
-function copyto!(A::SparseVector, B::SparseMatrixCSC)
+function copyto!(A::SparseVector, B::GenericMatrixCSC)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))
 
     ptr = 1
@@ -478,7 +478,7 @@ function copyto!(A::SparseVector, B::SparseMatrixCSC)
     return A
 end
 
-copyto!(A::SparseMatrixCSC, B::SparseVector{TvB,TiB}) where {TvB,TiB} =
+copyto!(A::GenericMatrixCSC, B::SparseVector{TvB,TiB}) where {TvB,TiB} =
     copyto!(A, SparseMatrixCSC{TvB,TiB}(B.n, 1, TiB[1, length(B.nzind)+1], B.nzind, B.nzval))
 
 
@@ -512,14 +512,14 @@ sprandn(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where T = spran
 ## Indexing into Matrices can return SparseVectors
 
 # Column slices
-function getindex(x::SparseMatrixCSC, ::Colon, j::Integer)
+function getindex(x::GenericMatrixCSC, ::Colon, j::Integer)
     checkbounds(x, :, j)
     r1 = convert(Int, x.colptr[j])
     r2 = convert(Int, x.colptr[j+1]) - 1
     SparseVector(x.m, x.rowval[r1:r2], x.nzval[r1:r2])
 end
 
-function getindex(x::SparseMatrixCSC, I::AbstractUnitRange, j::Integer)
+function getindex(x::GenericMatrixCSC, I::AbstractUnitRange, j::Integer)
     checkbounds(x, I, j)
     # Get the selected column
     c1 = convert(Int, x.colptr[j])
@@ -530,15 +530,15 @@ function getindex(x::SparseMatrixCSC, I::AbstractUnitRange, j::Integer)
     SparseVector(length(I), [x.rowval[i] - first(I) + 1 for i = r1:r2], x.nzval[r1:r2])
 end
 
-# In the general case, we piggy back upon SparseMatrixCSC's optimized solution
-@inline function getindex(A::SparseMatrixCSC, I::AbstractVector, J::Integer)
+# In the general case, we piggy back upon GenericMatrixCSC's optimized solution
+@inline function getindex(A::GenericMatrixCSC, I::AbstractVector, J::Integer)
     M = A[I, [J]]
     SparseVector(M.m, M.rowval, M.nzval)
 end
 
 # Row slices
-getindex(A::SparseMatrixCSC, i::Integer, ::Colon) = A[i, 1:end]
-function Base.getindex(A::SparseMatrixCSC{Tv,Ti}, i::Integer, J::AbstractVector) where {Tv,Ti}
+getindex(A::GenericMatrixCSC, i::Integer, ::Colon) = A[i, 1:end]
+function Base.getindex(A::GenericMatrixCSC{Tv,Ti}, i::Integer, J::AbstractVector) where {Tv,Ti}
     @assert !has_offset_axes(A, J)
     checkbounds(A, i, J)
     nJ = length(J)
@@ -570,9 +570,9 @@ end
 
 
 # Logical and linear indexing into SparseMatrices
-getindex(A::SparseMatrixCSC, I::AbstractVector{Bool}) = _logical_index(A, I) # Ambiguities
-getindex(A::SparseMatrixCSC, I::AbstractArray{Bool}) = _logical_index(A, I)
-function _logical_index(A::SparseMatrixCSC{Tv}, I::AbstractArray{Bool}) where Tv
+getindex(A::GenericMatrixCSC, I::AbstractVector{Bool}) = _logical_index(A, I) # Ambiguities
+getindex(A::GenericMatrixCSC, I::AbstractArray{Bool}) = _logical_index(A, I)
+function _logical_index(A::GenericMatrixCSC{Tv}, I::AbstractArray{Bool}) where Tv
     @assert !has_offset_axes(A, I)
     checkbounds(A, I)
     n = sum(I)
@@ -612,9 +612,9 @@ function _logical_index(A::SparseMatrixCSC{Tv}, I::AbstractArray{Bool}) where Tv
 end
 
 # TODO: further optimizations are available for ::Colon and other types of AbstractRange
-getindex(A::SparseMatrixCSC, ::Colon) = A[1:end]
+getindex(A::GenericMatrixCSC, ::Colon) = A[1:end]
 
-function getindex(A::SparseMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
+function getindex(A::GenericMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
     @assert !has_offset_axes(A, I)
     checkbounds(A, I)
     szA = size(A)
@@ -651,7 +651,7 @@ function getindex(A::SparseMatrixCSC{Tv}, I::AbstractUnitRange) where Tv
     SparseVector(n, rowvalB, nzvalB)
 end
 
-function getindex(A::SparseMatrixCSC{Tv,Ti}, I::AbstractVector) where {Tv,Ti}
+function getindex(A::GenericMatrixCSC{Tv,Ti}, I::AbstractVector) where {Tv,Ti}
     @assert !has_offset_axes(A, I)
     szA = size(A)
     nA = szA[1]*szA[2]
@@ -804,14 +804,14 @@ end
 getindex(x::AbstractSparseVector, I::AbstractVector{Bool}) = x[findall(I)]
 getindex(x::AbstractSparseVector, I::AbstractArray{Bool}) = x[findall(I)]
 @inline function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractVector) where {Tv,Ti}
-    # SparseMatrixCSC has a nicely optimized routine for this; punt
-    S = SparseMatrixCSC(x.n, 1, Ti[1,length(x.nzind)+1], x.nzind, x.nzval)
+    # GenericMatrixCSC has a nicely optimized routine for this; punt
+    S = GenericMatrixCSC(x.n, 1, Ti[1,length(x.nzind)+1], x.nzind, x.nzval)
     S[I, 1]
 end
 
 function getindex(x::AbstractSparseVector{Tv,Ti}, I::AbstractArray) where {Tv,Ti}
-    # punt to SparseMatrixCSC
-    S = SparseMatrixCSC(x.n, 1, Ti[1,length(x.nzind)+1], x.nzind, x.nzval)
+    # punt to GenericMatrixCSC
+    S = GenericMatrixCSC(x.n, 1, Ti[1,length(x.nzind)+1], x.nzind, x.nzval)
     S[I]
 end
 
@@ -915,7 +915,7 @@ complex(x::AbstractSparseVector) =
 
 # Without the first of these methods, horizontal concatenations of SparseVectors fall
 # back to the horizontal concatenation method that ensures that combinations of
-# sparse/special/dense matrix/vector types concatenate to SparseMatrixCSCs, instead
+# sparse/special/dense matrix/vector types concatenate to GenericMatrixCSCs, instead
 # of _absspvec_hcat below. The <:Integer qualifications are necessary for correct dispatch.
 hcat(X::SparseVector{Tv,Ti}...) where {Tv,Ti<:Integer} = _absspvec_hcat(X...)
 hcat(X::AbstractSparseVector{Tv,Ti}...) where {Tv,Ti<:Integer} = _absspvec_hcat(X...)
@@ -950,7 +950,7 @@ end
 
 # Without the first of these methods, vertical concatenations of SparseVectors fall
 # back to the vertical concatenation method that ensures that combinations of
-# sparse/special/dense matrix/vector types concatenate to SparseMatrixCSCs, instead
+# sparse/special/dense matrix/vector types concatenate to GenericMatrixCSCs, instead
 # of _absspvec_vcat below. The <:Integer qualifications are necessary for correct dispatch.
 vcat(X::SparseVector{Tv,Ti}...) where {Tv,Ti<:Integer} = _absspvec_vcat(X...)
 vcat(X::AbstractSparseVector{Tv,Ti}...) where {Tv,Ti<:Integer} = _absspvec_vcat(X...)
@@ -991,7 +991,7 @@ hcat(Xin::Union{Vector, AbstractSparseVector}...) = hcat(map(sparse, Xin)...)
 vcat(Xin::Union{Vector, AbstractSparseVector}...) = vcat(map(sparse, Xin)...)
 # Without the following method, vertical concatenations of SparseVectors with Vectors
 # fall back to the vertical concatenation method that ensures that combinations of
-# sparse/special/dense matrix/vector types concatenate to SparseMatrixCSCs (because
+# sparse/special/dense matrix/vector types concatenate to GenericMatrixCSCs (because
 # the vcat method immediately above is less specific, being defined in AbstractSparseVector
 # rather than SparseVector).
 vcat(X::Union{Vector,SparseVector}...) = vcat(map(sparse, X)...)
@@ -1005,7 +1005,7 @@ vcat(X::Union{Vector,SparseVector}...) = vcat(map(sparse, X)...)
 
 # TODO: A definition similar to the third exists in base/linalg/bidiag.jl. These definitions
 # should be consolidated in a more appropriate location, e.g. base/linalg/special.jl.
-const _SparseArrays = Union{SparseVector, SparseMatrixCSC, Adjoint{<:Any,<:SparseVector}, Transpose{<:Any,<:SparseVector}}
+const _SparseArrays = Union{SparseVector, GenericMatrixCSC, Adjoint{<:Any,<:SparseVector}, Transpose{<:Any,<:SparseVector}}
 const _SpecialArrays = Union{Diagonal, Bidiagonal, Tridiagonal, SymTridiagonal}
 const _SparseConcatArrays = Union{_SpecialArrays, _SparseArrays}
 
@@ -1560,7 +1560,7 @@ end
 
 ### BLAS-2 / sparse A * sparse x -> dense y
 
-function densemv(A::SparseMatrixCSC, x::AbstractSparseVector; trans::AbstractChar='N')
+function densemv(A::GenericMatrixCSC, x::AbstractSparseVector; trans::AbstractChar='N')
     local xlen::Int, ylen::Int
     @assert !has_offset_axes(A, x)
     m, n = size(A)
@@ -1588,10 +1588,10 @@ end
 
 # * and mul!
 
-mul!(y::AbstractVector{Ty}, A::SparseMatrixCSC, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
+mul!(y::AbstractVector{Ty}, A::GenericMatrixCSC, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
     mul!(y, A, x, one(Tx), zero(Ty))
 
-function mul!(y::AbstractVector, A::SparseMatrixCSC, x::AbstractSparseVector, α::Number, β::Number)
+function mul!(y::AbstractVector, A::GenericMatrixCSC, x::AbstractSparseVector, α::Number, β::Number)
     @assert !has_offset_axes(y, A, x)
     m, n = size(A)
     length(x) == n && length(y) == m || throw(DimensionMismatch())
@@ -1622,20 +1622,20 @@ end
 
 # * and *(Tranpose(A), B)
 
-mul!(y::AbstractVector{Ty}, transA::Transpose{<:Any,<:SparseMatrixCSC}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
+mul!(y::AbstractVector{Ty}, transA::Transpose{<:Any,<:GenericMatrixCSC}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
     (A = transA.parent; mul!(y, transpose(A), x, one(Tx), zero(Ty)))
 
-mul!(y::AbstractVector, transA::Transpose{<:Any,<:SparseMatrixCSC}, x::AbstractSparseVector, α::Number, β::Number) =
+mul!(y::AbstractVector, transA::Transpose{<:Any,<:GenericMatrixCSC}, x::AbstractSparseVector, α::Number, β::Number) =
     (A = transA.parent; _At_or_Ac_mul_B!(*, y, A, x, α, β))
 
-mul!(y::AbstractVector{Ty}, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
+mul!(y::AbstractVector{Ty}, adjA::Adjoint{<:Any,<:GenericMatrixCSC}, x::AbstractSparseVector{Tx}) where {Tx,Ty} =
     (A = adjA.parent; mul!(y, adjoint(A), x, one(Tx), zero(Ty)))
 
-mul!(y::AbstractVector, adjA::Adjoint{<:Any,<:SparseMatrixCSC}, x::AbstractSparseVector, α::Number, β::Number) =
+mul!(y::AbstractVector, adjA::Adjoint{<:Any,<:GenericMatrixCSC}, x::AbstractSparseVector, α::Number, β::Number) =
     (A = adjA.parent; _At_or_Ac_mul_B!(dot, y, A, x, α, β))
 
 function _At_or_Ac_mul_B!(tfun::Function,
-                          y::AbstractVector, A::SparseMatrixCSC, x::AbstractSparseVector,
+                          y::AbstractVector, A::GenericMatrixCSC, x::AbstractSparseVector,
                           α::Number, β::Number)
     @assert !has_offset_axes(y, A, x)
     m, n = size(A)
@@ -1665,20 +1665,20 @@ end
 
 ### BLAS-2 / sparse A * sparse x -> dense y
 
-function *(A::SparseMatrixCSC, x::AbstractSparseVector)
+function *(A::GenericMatrixCSC, x::AbstractSparseVector)
     @assert !has_offset_axes(A, x)
     y = densemv(A, x)
     initcap = min(nnz(A), size(A,1))
     _dense2sparsevec(y, initcap)
 end
 
-*(transA::Transpose{<:Any,<:SparseMatrixCSC}, x::AbstractSparseVector) =
+*(transA::Transpose{<:Any,<:GenericMatrixCSC}, x::AbstractSparseVector) =
     (A = transA.parent; _At_or_Ac_mul_B(*, A, x))
 
-*(adjA::Adjoint{<:Any,<:SparseMatrixCSC}, x::AbstractSparseVector) =
+*(adjA::Adjoint{<:Any,<:GenericMatrixCSC}, x::AbstractSparseVector) =
     (A = adjA.parent; _At_or_Ac_mul_B(dot, A, x))
 
-function _At_or_Ac_mul_B(tfun::Function, A::SparseMatrixCSC{TvA,TiA}, x::AbstractSparseVector{TvX,TiX}) where {TvA,TiA,TvX,TiX}
+function _At_or_Ac_mul_B(tfun::Function, A::GenericMatrixCSC{TvA,TiA}, x::AbstractSparseVector{TvX,TiX}) where {TvA,TiA,TvX,TiX}
     @assert !has_offset_axes(A, x)
     m, n = size(A)
     length(x) == m || throw(DimensionMismatch())
@@ -1937,7 +1937,7 @@ julia> dropzeros(A)
 dropzeros(x::SparseVector; trim::Bool = true) = dropzeros!(copy(x), trim = trim)
 
 
-function _fillnonzero!(arr::SparseMatrixCSC{Tv, Ti}, val) where {Tv,Ti}
+function _fillnonzero!(arr::GenericMatrixCSC{Tv, Ti}, val) where {Tv,Ti}
     m, n = size(arr)
     resize!(arr.colptr, n+1)
     resize!(arr.rowval, m*n)
@@ -1966,7 +1966,7 @@ function _fillnonzero!(arr::SparseVector{Tv,Ti}, val) where {Tv,Ti}
 end
 
 import Base.fill!
-function fill!(A::Union{SparseVector, SparseMatrixCSC}, x)
+function fill!(A::Union{SparseVector, GenericMatrixCSC}, x)
     T = eltype(A)
     xT = convert(T, x)
     if xT == zero(T)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1898,7 +1898,7 @@ end
 
 # Test temporary fix for issue #16548 in PR #16979. Somewhat brittle. Expect to remove with `\` revisions.
 @testset "issue #16548" begin
-    ms = methods(\, (SparseMatrixCSC, AbstractVecOrMat)).ms
+    ms = methods(\, (GenericMatrixCSC, AbstractVecOrMat)).ms
     @test all(m -> m.module == SparseArrays, ms)
 end
 
@@ -1959,7 +1959,7 @@ end
 
 # Check calling of unary minus method specialized for SparseMatrixCSCs
 @testset "issue #19503" begin
-    @test which(-, (SparseMatrixCSC,)).module == SparseArrays
+    @test which(-, (GenericMatrixCSC,)).module == SparseArrays
 end
 
 @testset "issue #14398" begin


### PR DESCRIPTION
I request a generalization of `SparseMatrixCSC` such that `nzval` can be an arbitrary vector type, not just a `Vector`.  This let us compose the sparse matrix type with custom array types.  For example, the following code works with this PR:

```julia
using SparseArrays
using MappedArrays
using LazyArrays
using FillArrays
using Setfield: @set

S = sprandn(10, 10, 0.5)

# Creating a mapped array for a sparse matrix:
M1 = @set S.nzval = mappedarray(abs, S.nzval)
# which is equivalent to:
M1 = GenericMatrixCSC(S.m, S.n, S.colptr, S.rowval, mappedarray(abs, S.nzval))

# Similar effect with LazyArrays.BroadcastArray:
M2 = @set S.nzval = BroadcastArray(abs, S.nzval)

# Sometimes it is very useful to have a constant value for `nzval` to save
# space and time.  You can do it with `FillArrays.Fill`:
M3 = @set S.nzval = Fill('a', nnz(S))
```

Achieving similar effect with current `SparseMatrixCSC` is hard.  For example, [here is my attempt to implement very small subset of mapped sparse array based on `MappedArrays`](https://gist.github.com/tkf/ab9ca58f6629ce3d7c3f0ca6ab9eb88c).  It took > 30 lines of code and yet have fewer features than the matrix `M1` above (e.g., efficient `mul!`).  Doing something like constant `nzval` as in `M3` with current `SparseMatrixCSC` would be hard.  I can imagine doing so with singleton number-like `struct` but that would be very awkward and inefficient.

Of course, new feature shouldn't break old ones.  I tired to make `SparseMatrixCSC` is backward compatible as much as possible.  In fact, this PR so far only changed `stdlib/SparseArrays/src` except for two lines of introspection-based code in `stdlib/SparseArrays/test`.  (Of course, once the direction of this PR is approved I will add the tests for the generalized interface.)  Since the tests for `SuiteSparse` pass and it uses `SparseMatrixCSC` heavily, I think the approach in this PR seems to be working.  I also assumed that `show` is part of API (otherwise doctest would break) and defined backward compatible `show(::IO, ::Type{<:SparseMatrixCSC})`.

The main change in this PR is the new `struct` which I tentatively call `GenericMatrixCSC`.  This is just a simple generalization of `SparseMatrixCSC`:

```julia
struct GenericMatrixCSC{Tv, Ti<:Integer,
                        Tc<:AbstractVector{Ti},
                        Tr<:AbstractVector{Ti},
                        Tz<:AbstractVector{Tv}} <: AbstractSparseMatrix{Tv,Ti}
    m::Int                  # Number of rows
    n::Int                  # Number of columns
    colptr::Tc              # Column i is in colptr[i]:(colptr[i+1]-1)
    rowval::Tr              # Row indices of stored values
    nzval::Tz               # Stored values, typically nonzeros

    ...
```

`SparseMatrixCSC` is redefined as

```julia
const SparseMatrixCSC{Tv,Ti} = GenericMatrixCSC{Tv,Ti,Vector{Ti},Vector{Ti},Vector{Tv}}
```

Other than that, the PR is mostly just simple renames although the diff look large.

An alternative approach would be to define all CSC matrix code based on an abstract type and interface (e.g., `nonzeros`) add _add_ `GenericMatrixCSC` while keeping `SparseMatrixCSC` untouched.  The disadvantage is that we need to maintain two very similar structs.  I think `SparseMatrixCSC` would have coded like `GenericMatrixCSC` if the ability to use arbitrary array type for `nzval` was foreseen.  If that's the case using concrete `struct` as in this PR is more natural.  Furthermore, this approach let us succinctly construct sparse matrices using `Setfield.@set` (as in the code above).

Needless to say, the implementation detail is not important.  I can switch to abstract type approach if that's required.

Relevant PRs: #25118, #25151