### PR TITLE
Native division for UInt128 on 32bit platforms

### DIFF
--- a/base/int.jl
+++ b/base/int.jl
@@ -808,24 +808,22 @@ if Core.sizeof(Int) == 4
         iszero(y) && throw(DivideError())
         n = leading_zeros(y) - leading_zeros(x)
         ys = y << n
-        for s in (96, 64, 32, 0)
-            while n >= s
-                if ys <= x
-                    x -= ys
-                    if (x >> 64) % UInt64 == 0
-                        break
-                    end
+        while n >= 0
+            if ys <= x
+                x -= ys
+                if (x >> 64) % UInt64 == 0
+                    break
                 end
-                ys >>>= 1
-                n -= 1
             end
-            if (x >> 64) % UInt64 == 0
-                if (y >> 64) % UInt64 == 0
-                    x64 = rem(x % UInt64, y % UInt64)
-                    x = UInt128(x64)
-                end
-                return x
+            ys >>>= 1
+            n -= 1
+        end
+        if (x >> 64) % UInt64 == 0
+            if (y >> 64) % UInt64 == 0
+                x64 = rem(x % UInt64, y % UInt64)
+                x = UInt128(x64)
             end
+            return x
         end
         return x
     end

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -1526,6 +1526,18 @@ end
     @test signed(cld(typemax(UInt),typemin(Int)>>1))     == -3
     @test signed(cld(typemax(UInt),(typemin(Int)>>1)+1)) == -4
 
+    @testset "UInt128 div/rem" begin
+        uints = [0xadc0db298a7401251f4fa96ba429cb24, 0xd11ef418102afb1f7959b6df48d08044]
+        for x in uints, y in uints, sx in 0:128, sy in 0:127
+            xs = x >> sx
+            ys = y >> sy
+            q, r = @inferred(divrem(xs, ys))::Tuple{UInt128,UInt128}
+            @test xs == q*ys + r && r < ys
+            @test q == @inferred(div(xs, ys))::UInt128
+            @test r == @inferred(rem(xs, ys))::UInt128
+        end
+    end
+
     @testset "exceptions and special cases" begin
         for T in (Int8,Int16,Int32,Int64,Int128, UInt8,UInt16,UInt32,UInt64,UInt128)
             @test_throws DivideError div(T(1), T(0))


### PR DESCRIPTION
I'm sure there are clever tricks to pull off, but it seems to be an improvement against master already, and this not quite my field of expertise. Note that these benchmarks are made with a 32bit-julia (ARCH=i686) on a 64bit system.

Master:
```julia
julia> @btime $(one(UInt128)) ÷ $(one(UInt128));
  757.851 ns (11 allocations: 156 bytes)

julia> @btime $(-one(UInt128)) ÷ $(one(UInt128));
  868.255 ns (12 allocations: 180 bytes)

julia> @btime $(one(UInt128)) % $(one(UInt128));
  296.552 ns (8 allocations: 60 bytes)

julia> @btime $(-one(UInt128)) % $(one(UInt128));
  318.302 ns (8 allocations: 72 bytes)

julia> @eval Base function div(x::UInt128, y::UInt128)
           return UInt128(div(BigInt(x), BigInt(y)))::UInt128
       end;
       
julia> one(UInt128) ÷ one(UInt128);

julia> @btime $(one(UInt128)) ÷ $(one(UInt128));
  344.019 ns (10 allocations: 124 bytes)

julia> @btime $(-one(UInt128)) ÷ $(one(UInt128));
  451.320 ns (11 allocations: 148 bytes)

julia> @btime $(one(UInt128)) % $(one(UInt128));
  332.386 ns (10 allocations: 124 bytes)

julia> @btime $(-one(UInt128)) % $(one(UInt128));
  355.200 ns (10 allocations: 136 bytes)
```
The recursion limiting heuristics make it so that the results depend on which function is compiled first, so re-evaluating the original definition yields different results.

This PR:
```julia
julia> @btime $(one(UInt128)) ÷ $(one(UInt128));
  0.628 ns (0 allocations: 0 bytes)

julia> @btime $(-one(UInt128)) ÷ $(one(UInt128));
  383.621 ns (0 allocations: 0 bytes)

julia> @btime $(one(UInt128)) % $(one(UInt128));
  0.628 ns (0 allocations: 0 bytes)

julia> @btime $(-one(UInt128)) % $(one(UInt128));
  301.164 ns (0 allocations: 0 bytes)
```

I'm not 100% sure `0xfff...fff % 0x000...001` shows the worst-case performance, so there might be inputs where current master is slightly faster, but in any case, we get rid of the allocations.