### PR TITLE
don't print `Type{Vararg}` in type errors, since that expr is invalid

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -56,7 +56,9 @@ function showerror(io::IO, ex::TypeError)
     if ex.expected === Bool
         print(io, "non-boolean (", typeof(ex.got), ") used in boolean context")
     else
-        if isa(ex.got, Type)
+        if isvarargtype(ex.got)
+            targs = (ex.got,)
+        elseif isa(ex.got, Type)
             targs = ("Type{", ex.got, "}")
         else
             targs = (typeof(ex.got),)

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -260,6 +260,8 @@ let undefvar
     @test err_str == "TypeError: in Type, in parameter, expected Type, got String"
     err_str = @except_str TypeWithIntParam{Any} TypeError
     @test err_str == "TypeError: in TypeWithIntParam, in T, expected T<:Integer, got Type{Any}"
+    err_str = @except_str Type{Vararg} TypeError
+    @test err_str == "TypeError: in Type, in parameter, expected Type, got Vararg"
 
     err_str = @except_str mod(1,0) DivideError
     @test err_str == "DivideError: integer division error"


### PR DESCRIPTION
Before:
```
julia> Type{Vararg}
ERROR: TypeError: in Type, in parameter, expected Type, got Type{Vararg}
```
After:
```
julia> Type{Vararg}
ERROR: TypeError: in Type, in parameter, expected Type, got Vararg
```
