### PR TITLE
Fix issue with Git Credential Manager for Windows

### DIFF
--- a/stdlib/LibGit2/src/gitcredential.jl
+++ b/stdlib/LibGit2/src/gitcredential.jl
@@ -1,5 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+const GIT_CRED_ATTRIBUTES = ("protocol", "host", "path", "username", "password", "url")
+
 """
     GitCredential
 
@@ -111,16 +113,19 @@ function Base.read!(io::IO, cred::GitCredential)
         else
             value = readuntil(io, '\n')
         end
+
         if key == "url"
             # Any components which are missing from the URL will be set to empty
             # https://git-scm.com/docs/git-credential#git-credential-codeurlcode
             Base.shred!(parse(GitCredential, value)) do urlcred
                 copy!(cred, urlcred)
             end
-        else
+        elseif key in GIT_CRED_ATTRIBUTES
             field = getproperty(cred, Symbol(key))
             field !== nothing && Symbol(key) == :password && Base.shred!(field)
             setproperty!(cred, Symbol(key), value)
+        elseif !all(isspace, key)
+            @warn "Unknown git credential attribute found: $(repr(key))"
         end
     end
 


### PR DESCRIPTION
- Ignores additional whitespace when reading in credentials.
- Warn when encountering unknown attributes. Should allow for more graceful failures in the future if the protocol is extended.