### PR TITLE
fewer `convert` methods for `Missing` and `Nothing`

### DIFF
--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -24,7 +24,6 @@ include(mod, x) = Core.include(mod, x)
 
 # essential files and libraries
 include("essentials.jl")
-include("some.jl")
 include("ctypes.jl")
 include("generator.jl")
 include("reflection.jl")

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -43,15 +43,12 @@ promote_rule(::Type{Union{Nothing, Missing, S}}, ::Type{T}) where {T,S} =
     Union{Nothing, Missing, promote_type(T, S)}
 
 convert(::Type{Union{T, Missing}}, x::Union{T, Missing}) where {T} = x
-convert(::Type{Union{T, Missing}}, x) where {T} = convert(T, x)
+# To print more appropriate message than "T not defined"
+convert(::Type{Union{T, Missing}}, x) where {T} =
+    @isdefined(T) ? convert(T, x) : throw(MethodError(convert, (Missing, x)))
 # To fix ambiguities
-convert(::Type{Missing}, ::Missing) = missing
 convert(::Type{Union{Nothing, Missing}}, x::Union{Nothing, Missing}) = x
 convert(::Type{Union{Nothing, Missing, T}}, x::Union{Nothing, Missing, T}) where {T} = x
-convert(::Type{Union{Nothing, Missing}}, x) =
-    throw(MethodError(convert, (Union{Nothing, Missing}, x)))
-# To print more appropriate message than "T not defined"
-convert(::Type{Missing}, x) = throw(MethodError(convert, (Missing, x)))
 
 # Comparison operators
 ==(::Missing, ::Missing) = missing

--- a/base/some.jl
+++ b/base/some.jl
@@ -19,9 +19,8 @@ convert(::Type{Some{T}}, x::Some) where {T} = Some{T}(convert(T, x.value))
 convert(::Type{Union{Some{T}, Nothing}}, x::Some) where {T} = convert(Some{T}, x)
 
 convert(::Type{Union{T, Nothing}}, x::Union{T, Nothing}) where {T} = x
-convert(::Type{Union{T, Nothing}}, x::Any) where {T} = convert(T, x)
-convert(::Type{Nothing}, x::Nothing) = nothing
-convert(::Type{Nothing}, x::Any) = throw(MethodError(convert, (Nothing, x)))
+convert(::Type{Union{T, Nothing}}, x::Any) where {T} =
+    @isdefined(T) ? convert(T, x) : throw(MethodError(convert, (Nothing, x)))
 
 function show(io::IO, x::Some)
     if get(io, :typeinfo, Any) == typeof(x)


### PR DESCRIPTION
`@isdefined` is a better approach than trying to add lots of methods to cover all cases. Some of the methods created bad cases for specificity. In particular defining conversions from `Any` (`convert(::T, ::Any)`) should be minimized since they tend to conflict with the fallback `convert(::Type{T}, ::T)`.