### PR TITLE
Fix reverse with empty StepRangeLen

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -941,7 +941,13 @@ Array{T,1}(r::AbstractRange{T}) where {T} = vcat(r)
 collect(r::AbstractRange) = vcat(r)
 
 reverse(r::OrdinalRange) = (:)(last(r), -step(r), first(r))
-reverse(r::StepRangeLen) = StepRangeLen(r.ref, -r.step, length(r), length(r)-r.offset+1)
+function reverse(r::StepRangeLen)
+    # If `r` is empty, `length(r) - r.offset + 1 will be nonpositive hence
+    # invalid. As `reverse(r)` is also empty, any offset would work so we keep
+    # `r.offset`
+    offset = isempty(r) ? r.offset : length(r)-r.offset+1
+    StepRangeLen(r.ref, -r.step, length(r), offset)
+end
 reverse(r::LinRange)     = LinRange(r.stop, r.start, length(r))
 
 ## sorting ##

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1435,3 +1435,13 @@ end
     # require a keyword arg
     @test_throws ArgumentError range(1, 100)
 end
+
+@testset "Reverse empty ranges" begin
+    @test reverse(1:0) === 0:-1:1
+    @test reverse(Base.OneTo(0)) === 0:-1:1
+    # Almost `1.0:-1.0:2.0`, only different is the step which is
+    # `Base.TwicePrecision(-1.0, 0.0)`
+    @test reverse(1.0:0.0) === StepRangeLen(Base.TwicePrecision(1.0, 0.0),
+                                            Base.TwicePrecision(-1.0, -0.0), 0)
+    @test reverse(reverse(1.0:0.0)) === 1.0:0.0
+end


### PR DESCRIPTION
Before this PR:
```julia
julia> reverse(1.0:0.0)
ERROR: ArgumentError: StepRangeLen: offset must be in [1,0], got 0
Stacktrace:
 [1] reverse(::StepRangeLen{Float64,Base.TwicePrecision{Float64},Base.TwicePrecision{Float64}}) at ./range.jl:323
 [2] top-level scope at none:0
```
After this PR:
```julia
julia> reverse(1.0:0.0)
1.0:-1.0:2.0
```