### PR TITLE
Benchmark against 1.0.0 for potential 1.1.0 release

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.1.0-DEV
+1.1.0-benchmark


### PR DESCRIPTION
@nanosoldier `runbenchmarks(ALL, vs = ":release-1.0")`

Not sure if we should also run against `1.0.0`?
