### PR TITLE
Two small fixes noted during wasm bringup

### DIFF
--- a/src/anticodegen.c
+++ b/src/anticodegen.c
@@ -26,11 +26,7 @@ JL_DLLEXPORT size_t jl_LLVMDisasmInstruction(void *DC, uint8_t *Bytes, uint64_t 
 int32_t jl_assign_functionID(const char *fname) UNAVAILABLE
 
 void jl_init_codegen(void) { }
-void jl_fptr_to_llvm(jl_fptr_t fptr, jl_method_instance_t *lam, int specsig)
-{
-    if (!specsig)
-        lam->fptr = fptr;
-}
+void jl_fptr_to_llvm(void *fptr, jl_method_instance_t *lam, int specsig) { }
 
 int jl_getFunctionInfo(jl_frame_t **frames, uintptr_t pointer, int skipC, int noInline)
 {
@@ -59,16 +55,15 @@ jl_llvm_functions_t jl_compile_linfo(jl_method_instance_t **pli, jl_code_info_t 
     return decls;
 }
 
-jl_value_t *jl_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs);
-jl_generic_fptr_t jl_generate_fptr(jl_method_instance_t *li, const char *F, size_t world)
+jl_value_t *jl_fptr_interpret_call(jl_method_instance_t *lam, jl_value_t **args, uint32_t nargs);
+jl_callptr_t jl_generate_fptr(jl_method_instance_t **pli, jl_llvm_functions_t decls, size_t world)
 {
-    jl_generic_fptr_t fptr;
-    fptr.fptr = (jl_fptr_t)&jl_interpret_call;
-    fptr.jlcall_api = JL_API_INTERPRETED;
-    return fptr;
+    return (jl_callptr_t)&jl_fptr_interpret_call;
 }
 
 JL_DLLEXPORT uint32_t jl_get_LLVM_VERSION(void)
 {
     return 0;
 }
+
+jl_array_t *jl_cfunction_list;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -814,6 +814,7 @@ static int within_typevar(jl_value_t *t, jl_value_t *vlb, jl_value_t *vub)
             (jl_has_free_typevars(vub) || jl_subtype(ub, vub)));
 }
 
+struct _jl_typestack_t;
 typedef struct _jl_typestack_t jl_typestack_t;
 
 static jl_value_t *inst_datatype(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **iparams, size_t ntp,
@@ -912,10 +913,10 @@ JL_DLLEXPORT jl_value_t *jl_tupletype_fill(size_t n, jl_value_t *v)
     return p;
 }
 
-JL_EXTENSION typedef struct _jl_typestack_t {
+JL_EXTENSION struct _jl_typestack_t {
     jl_datatype_t *tt;
     struct _jl_typestack_t *prev;
-} jl_typestack_t;
+};
 
 static jl_value_t *inst_type_w_(jl_value_t *t, jl_typeenv_t *env, jl_typestack_t *stack, int check);
 static jl_svec_t *inst_all(jl_svec_t *p, jl_typeenv_t *env, jl_typestack_t *stack, int check);


### PR DESCRIPTION
- anticodegen.c was not updated for API changes (we should probably test it somewhere)
- Fix a compile error in jltypes.c