### PR TITLE
 Inliner cost model: don't count :unreachable branches 

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -18,6 +18,7 @@ const T_IFUNC_COST = Vector{Int}(undef, N_IFUNC)
 const T_FFUNC_KEY = Vector{Any}()
 const T_FFUNC_VAL = Vector{Tuple{Int, Int, Any}}()
 const T_FFUNC_COST = Vector{Int}()
+const T_CFUNC_COST = Vector{Tuple{Symbol, Int}}()  # for ccalls that get special-cased by the compiler
 function find_tfunc(@nospecialize f)
     for i = 1:length(T_FFUNC_KEY)
         if T_FFUNC_KEY[i] === f
@@ -36,6 +37,14 @@ const DATATYPE_INSTANCE_FIELDINDEX = fieldindex(DataType, :instance)
 const TYPENAME_NAME_FIELDINDEX = fieldindex(Core.TypeName, :name)
 const TYPENAME_MODULE_FIELDINDEX = fieldindex(Core.TypeName, :module)
 const TYPENAME_WRAPPER_FIELDINDEX = fieldindex(Core.TypeName, :wrapper)
+
+##########
+# ccalls #
+##########
+push!(T_CFUNC_COST, (:jl_array_ptr, 2))
+push!(T_CFUNC_COST, (:jl_value_ptr, 2))
+push!(T_CFUNC_COST, (:jl_array_isassigned, 5))
+push!(T_CFUNC_COST, (:jl_string_ptr, 2))
 
 ##########
 # tfuncs #

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -229,6 +229,20 @@ end
 # using a function to ensure we can infer this
 @inline slot_id(s) = isa(s, SlotNumber) ? (s::SlotNumber).id : (s::TypedSlot).id
 
+#####################
+# sparams/slottypes #
+#####################
+function get_params_slottypes(@nospecialize(f), @nospecialize(argtypes))
+    world = typemax(UInt)
+    params = Params(world)
+    match = _methods(f, argtypes, -1, world)[1]
+    mi = code_for_method(match[3], argtypes, match[2], world)
+    istate = InferenceState(InferenceResult(mi),
+                            retrieve_code_info(mi),
+                            false, params)
+    return istate.sp, istate.slottypes, params
+end
+
 ###########
 # options #
 ###########

--- a/doc/src/devdocs/ssair.md
+++ b/doc/src/devdocs/ssair.md
@@ -14,7 +14,7 @@ form representation, but the lack of such a representation ultimately proved pro
 
 ## New IR nodes
 
-With the new IR representation, the compiler learned to handle four new IR nodes, Phi nodes, Pi
+With the new IR representation, the compiler learned to handle four new IR nodes: Phi nodes, Pi
 nodes as well as PhiC nodes and Upsilon nodes (the latter two are only used for exception handling).
 
 ### Phi nodes and Pi nodes

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -253,3 +253,18 @@ end
         i += 1
     end
 end
+
+# cost assignment for arrayset and arrayref
+@testset "inlining cost for arrayref and arrayset" begin
+    f(a, b) = a[2] = b[1]
+    v = [1.0, 2.0]
+    tt = Tuple{typeof(v), typeof(v)}
+    # Create the objects we need to interact with the compiler
+    spvals, slottypes, params = Core.Compiler.get_params_slottypes(f, tt)
+    ci = code_typed(f, tt)[1][1]
+    # Calculate cost of each statement
+    cost(stmt::Expr) = Core.Compiler.statement_cost(stmt, -1, ci, spvals, slottypes, params)
+    cost(stmt) = 0
+    cst = map(cost, ci.code)
+    @test sum(cst) < 10
+end


### PR DESCRIPTION
This improves the heuristic for inlining by not penalizing branches that end with a `throw`. The idea is that exception paths don't reflect the typical run-time cost of a function, since generally one shouldn't be using exceptions for control-flow.

I have some local data suggesting this is helpful, but let's let nanosoldier chime in:
@nanosoldier `runbenchmarks(ALL, vs = ":master")`

Overall this seemed suspiciously easy, so I'm guessing I'm missing something. Would love to have input from someone who knows more.

Replaces #23986. Ref #29798; closing that also requires that we adjust the cost model for some `ccall`s that end up being [special-cased by the compiler](https://github.com/JuliaLang/julia/blob/3dd678f646e4403aede51389fcca7262839b5d15/src/ccall.cpp#L1586-L1793). I haven't yet invested the time to figure out exactly how those should be modeled. 
