### PR TITLE
Fix toggling of debuginfo for show methods

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -745,9 +745,12 @@ Note that an error will be thrown if `types` are not leaf types when `generated`
 `true` and any of the corresponding methods are an `@generated` method.
 """
 function code_lowered(@nospecialize(f), @nospecialize(t=Tuple); generated::Bool=true, debuginfo::Symbol=:default)
-    if debuginfo == :default
+    if @isdefined(IRShow)
+        debuginfo = IRShow.debuginfo(debuginfo)
+    elseif debuginfo == :default
         debuginfo = :source
-    elseif debuginfo != :source && debuginfo != :none
+    end
+    if debuginfo != :source && debuginfo != :none
         throw(ArgumentError("'debuginfo' must be either :source or :none"))
     end
     return map(method_instances(f, t)) do m
@@ -951,9 +954,12 @@ function code_typed(@nospecialize(f), @nospecialize(types=Tuple);
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
     end
-    if debuginfo == :default
+    if @isdefined(IRShow)
+        debuginfo = IRShow.debuginfo(debuginfo)
+    elseif debuginfo == :default
         debuginfo = :source
-    elseif debuginfo != :source && debuginfo != :none
+    end
+    if debuginfo != :source && debuginfo != :none
         throw(ArgumentError("'debuginfo' must be either :source or :none"))
     end
     types = to_tuple_type(types)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -940,7 +940,8 @@ end
 Returns an array of type-inferred lowered form (IR) for the methods matching the given
 generic function and type signature. The keyword argument `optimize` controls whether
 additional optimizations, such as inlining, are also applied.
-The keyword debuginfo controls the amount of code metadata present in the output.
+The keyword `debuginfo` controls the amount of code metadata present in the output,
+possible options are `:source` or `:none`.
 """
 function code_typed(@nospecialize(f), @nospecialize(types=Tuple);
                     optimize=true, debuginfo::Symbol=:default,

--- a/base/show.jl
+++ b/base/show.jl
@@ -1572,7 +1572,8 @@ module IRShow
         # :oneliner => src -> Base.IRShow.PartialLineInfoPrinter(src.linetable),
         :none => src -> Base.IRShow.lineinfo_disabled,
         )
-    debuginfo[:default] = debuginfo[:none]
+    # setting debuginfo[:default] = debuginfo[:none] will disable debuginfo printing globally
+    debuginfo[:default] = debuginfo[:source]
 end
 
 function show(io::IO, src::CodeInfo; debuginfo::Symbol=:default)

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -96,6 +96,7 @@ as assignments, branches, and calls:
 ```jldoctest
 julia> Meta.lower(@__MODULE__, :( [1+2, sin(0.5)] ))
 :($(Expr(:thunk, CodeInfo(
+    @ none within `top-level scope'
 1 ─ %1 = 1 + 2
 │   %2 = sin(0.5)
 │   %3 = (Base.vect)(%1, %2)
@@ -122,7 +123,6 @@ calls and expand argument types automatically:
 ```julia-repl
 julia> @code_llvm +(1,1)
 
-;  @ int.jl:53 within `+'
 define i64 @"julia_+_130862"(i64, i64) {
 top:
     %2 = add i64 %1, %0
@@ -130,5 +130,24 @@ top:
 }
 ```
 
-See [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code_warntype`](@ref),
+For more informations see [`@code_lowered`](@ref), [`@code_typed`](@ref), [`@code_warntype`](@ref),
 [`@code_llvm`](@ref), and [`@code_native`](@ref).
+
+### Printing of debug information
+
+The aforementioned functions and macros take the keyword argument `debuginfo` that controls the level
+debug information printed.
+
+```
+julia> @code_typed debuginfo=:source +(1,1)
+CodeInfo(
+    @ int.jl:53 within `+'
+1 ─ %1 = (Base.add_int)(x, y)::Int64
+└──      return %1
+) => Int64
+```
+
+Possible values for `debuginfo` are: `:none`, `:source`, and`:default`.
+Per default debug information is not printed, but that can be changed
+by setting `Base.IRShow.default_debuginfo[] = :source`.
+

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -859,6 +859,7 @@ static void jl_dump_asm_internal(
         DILineInfoTable::iterator di_lineIter = di_lineinfo.begin();
         DILineInfoTable::iterator di_lineEnd = di_lineinfo.end();
         DILineInfoPrinter dbgctx{"; ", true};
+        dbgctx.SetVerbosity(debuginfo);
         if (pass != 0) {
             if (di_ctx && di_lineIter != di_lineEnd) {
                 // Set up the line info

--- a/stdlib/InteractiveUtils/src/codeview.jl
+++ b/stdlib/InteractiveUtils/src/codeview.jl
@@ -27,12 +27,13 @@ problematic for performance, so the results need to be used judiciously.
 In particular, unions containing either [`missing`](@ref) or [`nothing`](@ref) are displayed in yellow, since
 these are often intentional.
 
-Keyword argument `debuginfo` may be one of source or none (default), to specify the verbosity of code comments.
+Keyword argument `debuginfo` may be one of `:source` or `:none` (default), to specify the verbosity of code comments.
 
 See [`@code_warntype`](@ref man-code-warntype) for more information.
 """
 function code_warntype(io::IO, @nospecialize(f), @nospecialize(t); debuginfo::Symbol=:default)
-    lineprinter = Base.IRShow.debuginfo[debuginfo]
+    debuginfo = Base.IRShow.debuginfo(debuginfo)
+    lineprinter = Base.IRShow.__debuginfo[debuginfo]
     for (src, rettype) in code_typed(f, t)
         lambda_io::IOContext = io
         if src.slotnames !== nothing

--- a/stdlib/InteractiveUtils/src/macros.jl
+++ b/stdlib/InteractiveUtils/src/macros.jl
@@ -229,7 +229,7 @@ by putting them and their value before the function call, like this:
 
 `optimize` controls whether additional optimizations, such as inlining, are also applied.
 `raw` makes all metadata and dbg.* calls visible.
-`debuginfo` may be one of full, source (default), none, to specify the verbosity of code comments.
+`debuginfo` may be one of `:source` (default) or `:none`,  to specify the verbosity of code comments.
 `dump_module` prints the entire module that encapsulates the function.
 """
 :@code_llvm
@@ -244,6 +244,6 @@ Set the optional keyword argument `debuginfo` by putting it before the function 
 
     @code_native debuginfo=:default f(x)
 
-`debuginfo` may be one of source (default) or none, to specify the verbosity of code comments.
+`debuginfo` may be one of `:source` (default) or `:none`, to specify the verbosity of code comments.
 """
 :@code_native

--- a/test/show.jl
+++ b/test/show.jl
@@ -1309,7 +1309,7 @@ end
 
 # Tests for code_typed linetable annotations
 function compute_annotations(f, types)
-    src = code_typed(f, types)[1][1]
+    src = code_typed(f, types, debuginfo=:source)[1][1]
     ir = Core.Compiler.inflate_ir(src)
     la, lb, ll = Base.IRShow.compute_ir_line_annotations(ir)
     max_loc_method = maximum(length(s) for s in la)
@@ -1364,7 +1364,7 @@ eval(Meta.parse("""function my_fun28173(x)
         end
     return y
 end""")) # use parse to control the line numbers
-let src = code_typed(my_fun28173, (Int,))[1][1]
+let src = code_typed(my_fun28173, (Int,), debuginfo=:source)[1][1]
     ir = Core.Compiler.inflate_ir(src)
     fill!(src.codelocs, 0) # IRCode printing is only capable of printing partial line info
     let source_slotnames = String["my_fun28173", "x"],
@@ -1402,7 +1402,7 @@ end
 # Verify that extra instructions at the end of the IR
 # don't throw errors in the printing, but instead print
 # with as unnamed "!" BB.
-let src = code_typed(gcd, (Int, Int))[1][1]
+let src = code_typed(gcd, (Int, Int), debuginfo=:source)[1][1]
     ir = Core.Compiler.inflate_ir(src)
     push!(ir.stmts, Core.Compiler.ReturnNode())
     lines = split(sprint(show, ir), '\n')

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -736,8 +736,8 @@ end
     end
 end
 
-f1_ci = code_typed(f1, (Int,))[1][1]
-f2_ci = code_typed(f2, (Int,))[1][1]
+f1_ci = code_typed(f1, (Int,), debuginfo=:source)[1][1]
+f2_ci = code_typed(f2, (Int,), debuginfo=:source)[1][1]
 
 f1_exprs = get_expr_list(f1_ci)
 f2_exprs = get_expr_list(f2_ci)


### PR DESCRIPTION
This adds a global switch `Base.IRShow.default_debuginfo[] == :none` that can be toggled. Previously having the global option be `:none`, broke
the local toggel of `code_warntype(..., debuginfo=:source)`.

Still needs better docs to describe how to change the default behaviour and I would appreciate feedback on the design (I am kinda meh on it).