### PR TITLE
Remove incorrect return in load_path_expand

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -166,7 +166,6 @@ function load_path_expand(env::AbstractString)::Union{String, Nothing}
                 file = abspath(path, proj)
                 isfile_casesensitive(file) && return file
             end
-            return path
         end
         isempty(DEPOT_PATH) && return nothing
         return abspath(DEPOT_PATH[1], "environments", name, project_names[end])

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -571,6 +571,21 @@ end
     end; end
 end
 
+# Base.active_project when version directory exist in depot, but contains no project file
+mktempdir() do dir
+    vdir = Base.DEFAULT_LOAD_PATH[2]
+    vdir = replace(vdir, "#" => VERSION.major, count = 1)
+    vdir = replace(vdir, "#" => VERSION.minor, count = 1)
+    vdir = replace(vdir, "#" => VERSION.patch, count = 1)
+    vdir = vdir[2:end] # remove @
+    vpath = joinpath(dir, "environments", vdir)
+    mkpath(vpath)
+    withenv("JULIA_DEPOT_PATH" => dir) do
+        script = "@assert startswith(Base.active_project(), $(repr(vpath)))"
+        @test success(`$(Base.julia_cmd()) -e $(script)`)
+    end
+end
+
 ## cleanup after tests ##
 
 for env in keys(envs)


### PR DESCRIPTION
This fixes a problem where Julia does not find an active project when the `~/.julia/environments/v#.#` folder exist but does not contain a `Project.toml` file.