### PR TITLE
Improve unary broadcast efficiency for Diagonal type

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -538,3 +538,20 @@ end
 
 cholesky(A::Diagonal, ::Val{false} = Val(false); check::Bool = true) =
     cholesky!(cholcopy(A), Val(false); check = check)
+
+function Broadcast.broadcasted(f::Function, D::Diagonal{T}) where T <: Number
+    fz = f(zero(T))
+    return iszero(fz) ? broadcasted_diag_zero(f, D) : broadcasted_diag_full(f, fz, D)
+end
+
+@inline function broadcasted_diag_zero(f, D)
+    return Diagonal(broadcast(f, D.diag))
+end
+
+@inline function broadcasted_diag_full(f, fz, D::Diagonal{T}) where T
+    R = fill(fz, size(D))
+    for i in 1:size(D, 1)
+        R[i,i] = f(D.diag[i])
+    end
+    return R
+end

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -490,4 +490,19 @@ end
     end
 end
 
+@testset "broadcast" begin
+    K = 10
+    for elty in (Float32, Float64, ComplexF32, ComplexF64)
+        DM = Diagonal(rand(K))
+        DDM = Matrix(DM)
+        @test exp.(DM) == exp.(DDM)
+        @test abs.(DM) == abs.(DDM)
+        @test sin.(DM) == sin.(DDM)
+        @test floor.(DM) == floor.(DDM)
+        @test isa(floor.(DM), Diagonal)
+        @test isa(abs.(DM), Diagonal)
+        @test isa(exp.(DM), Matrix)
+    end
+end
+
 end # module TestDiagonal


### PR DESCRIPTION
This PR decreases the execution time of expressions like exp.(DM::Diagonal)
and abs.(DM::Diagonal). The improvement varies with the function and with
the size of DM, but it can be dramatic:

```julia
julia> M = Diagonal(rand(100));

julia> @btime exp.($DM);     # before
  41.856 μs (2 allocations: 78.20 KiB)

julia> @btime exp.($DM);     # after
  8.304 μs (2 allocations: 78.20 KiB)

julia> @btime abs.($DM);     # before
  179.532 ns (4 allocations: 960 bytes)

julia> @btime abs.($DM);     # after
  108.239 ns (2 allocations: 912 bytes)