### PR TITLE
Use `xnnz` in show of SparseVector

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -835,8 +835,7 @@ function show(io::IOContext, x::AbstractSparseVector)
     n = length(x)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
-    xnnz = length(nzind)
-    if xnnz == 0
+    if isempty(nzind)
         return show(io, MIME("text/plain"), x)
     end
     limit::Bool = get(io, :limit, false)
@@ -845,8 +844,8 @@ function show(io::IOContext, x::AbstractSparseVector)
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
     end
-    for k = 1:xnnz
-        if k < half_screen_rows || k > xnnz - half_screen_rows
+    for k = eachindex(nzind)
+        if k < half_screen_rows || k > length(nzind) - half_screen_rows
             print(io, "  ", '[', rpad(nzind[k], pad), "]  =  ")
             if isassigned(nzval, Int(k))
                 show(io, nzval[k])

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -836,7 +836,7 @@ function show(io::IOContext, x::AbstractSparseVector)
     nzind = nonzeroinds(x)
     nzval = nonzeros(x)
     xnnz = length(nzind)
-    if length(nzind) == 0
+    if xnnz == 0
         return show(io, MIME("text/plain"), x)
     end
     limit::Bool = get(io, :limit, false)
@@ -845,7 +845,7 @@ function show(io::IOContext, x::AbstractSparseVector)
     if !haskey(io, :compact)
         io = IOContext(io, :compact => true)
     end
-    for k = 1:length(nzind)
+    for k = 1:xnnz
         if k < half_screen_rows || k > xnnz - half_screen_rows
             print(io, "  ", '[', rpad(nzind[k], pad), "]  =  ")
             if isassigned(nzval, Int(k))


### PR DESCRIPTION
It is a bit confusing to read `xnnz = length(nzind)` and in the following line `length(nzind)` instead of using `xnnz`