### PR TITLE
_!=1 -> !isone(_)

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -503,7 +503,7 @@ Base.@propagate_inbounds _newindex(ax::Tuple{}, I::Tuple{}) = ()
 @inline function _newindexer(indsA::Tuple)
     ind1 = indsA[1]
     keep, Idefault = _newindexer(tail(indsA))
-    (Base.length(ind1)!=1, keep...), (first(ind1), Idefault...)
+    (!isone(Base.length(ind1)), keep...), (first(ind1), Idefault...)
 end
 
 @inline function Base.getindex(bc::Broadcasted, I::Union{Integer,CartesianIndex})


### PR DESCRIPTION
`length` could return any `Integer`. For custom subtypes of `Integer`,
it is easier to implement `isone` than equality with arbitrary `Int`.