### PR TITLE
Add C-linkage to gc extensions for correct compiling in C++

### DIFF
--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -1,6 +1,10 @@
 #ifndef JL_GCEXT_H
 #define JL_GCEXT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // requires including "julia.h" beforehand.
 
 // Callbacks that allow C code to hook into the GC.
@@ -120,5 +124,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_internal_obj_base_ptr(void *p);
 // current task, that thread's id will be stored in *tid; otherwise,
 // *tid will be set to -1.
 JL_DLLEXPORT void *jl_task_stack_buffer(jl_task_t *task, size_t *size, int *tid);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _JULIA_GCEXT_H

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -11,6 +11,10 @@
 // range goes from 0 to 2^k-1 (region tables), we simply convert
 // to uintptr_t and compare those.
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static inline int cmp_ptr(void *p, void *q)
 {
     uintptr_t paddr = (uintptr_t)p;
@@ -662,3 +666,7 @@ int main()
             "  include(\"LocalTest.jl\")\n"
             "end");
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
I failed to compile a C++ project linking against Julia using the new GC extensions and the missing extern-C definitions seem to be the problem.