### PR TITLE
Create a `define_editor` command to customize `@edit` and friends.

### DIFF
--- a/stdlib/InteractiveUtils/docs/src/index.md
+++ b/stdlib/InteractiveUtils/docs/src/index.md
@@ -9,6 +9,7 @@ InteractiveUtils.subtypes
 InteractiveUtils.edit(::AbstractString, ::Integer)
 InteractiveUtils.edit(::Any)
 InteractiveUtils.@edit
+InteractiveUtils.define_editor
 InteractiveUtils.less(::AbstractString)
 InteractiveUtils.less(::Any)
 InteractiveUtils.@less

--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -4,7 +4,8 @@ module InteractiveUtils
 
 export apropos, edit, less, code_warntype, code_llvm, code_native, methodswith, varinfo,
     versioninfo, subtypes, @which, @edit, @less, @functionloc, @code_warntype,
-    @code_typed, @code_lowered, @code_llvm, @code_native, clipboard
+    @code_typed, @code_lowered, @code_llvm, @code_native, clipboard,
+    define_editor
 
 import Base.Docs.apropos
 

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -143,7 +143,7 @@ function define_default_editors()
     define_editor("code") do cmd, path, line
         `$cmd -g $path:$line`
     end
-    define_editor(r"\bnotepad++") do cmd, paht,line
+    define_editor(r"\bnotepad++") do cmd, path, line
         `$cmd $path -n$line`
     end
     if Sys.iswindows()

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -150,7 +150,7 @@ function define_default_editors()
         define_editor("open") do cmd, path, line
             function()
                 # don't emit this ccall on other platforms
-                @static if Sys.iswindows() 
+                @static if Sys.iswindows()
                     result = ccall((:ShellExecuteW, "shell32"), stdcall,
                                    Int, (Ptr{Cvoid}, Cwstring, Cwstring,
                                          Ptr{Cvoid}, Ptr{Cvoid}, Cint),

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -69,7 +69,7 @@ match the value of `EDITOR`, `VISUAL` or `JULIA_EDITOR`.  For strings, only
 whole words can match (i.e. "vi" doesn't match "vim -g" but will match
 "/usr/bin/vi -m").
 
-If multiple defined editors match the one most recently defined will be
+If multiple defined editors match, the one most recently defined will be
 used.
 
 By default julia does not wait for the editor to close, running it in the

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -54,14 +54,14 @@ given editor.  It should take 2 or 3 arguments, as follows:
 * `command` - an array of strings representing the editor command. It can be
   safely interpolated into a command created using backtick notation.
 * `path`  - the path to the source file to open
-* `line` - the optional line number to open to; if specified the returned command
-  must open the file at the given line.
+* `line` - the optional line number to open to; if specified the returned 
+   command must open the file at the given line.
 
-`fn` must return either an appropriate `Cmd` object to open a
-file, a function (taking 0 arguments) that will open the file directly
-(returning a `Cmd` is the preferred approach), or `nothing`. Use `nothing`
-to indicate that this editor is not appropriate for the current environment
-and another editor should be attempted.
+`fn` must return either an appropriate `Cmd` object to open a file, a
+zero-argument function that will open the file directly, or `nothing`.
+Returning a `Cmd` is preferred over returning a function. Use `nothing` to
+indicate that this editor is not appropriate for the current environment and
+another editor should be attempted.
 
 The `pattern` argument is a string, regular expression, or an array of strings
 and regular expressions. For the `fn` to be called one of the patterns must
@@ -69,7 +69,7 @@ match the value of `EDITOR`, `VISUAL` or `JULIA_EDITOR`.  For strings, only
 whole words can match (i.e. "vi" doesn't match "vim -g" but will match
 "/usr/bin/vi -m").
 
-If multiple defined editors match, the one most recently defined will be
+If multiple defined editors match the one most recently defined will be
 used.
 
 By default julia does not wait for the editor to close, running it in the
@@ -79,8 +79,8 @@ set `wait=true` and julia will wait for the editor to close before resuming.
 If no editor entry can be found, then a file is opened by running
 `\$command \$path`.
 
-Note that a number of default editors (all priority 0) are already defined. All
-of the following commands should already work:
+Note that many editors are already defined. All of the following commands
+should already work:
 
 - emacs
 - vim
@@ -149,7 +149,8 @@ function define_default_editors()
         end
         define_editor("open") do cmd, path, line
             function()
-                @static if Sys.iswindows() # don't emit this ccall on other platforms
+                # don't emit this ccall on other platforms
+                @static if Sys.iswindows() 
                     result = ccall((:ShellExecuteW, "shell32"), stdcall,
                                    Int, (Ptr{Cvoid}, Cwstring, Cwstring,
                                          Ptr{Cvoid}, Ptr{Cvoid}, Cint),

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -121,15 +121,15 @@ function define_default_editors()
                   wait=true) do cmd, path, line
         `$cmd +$line $path`
     end
+    define_editor([r"\bemacs","gedit",r"\bgvim"]) do cmd, path, line
+        `$cmd +$line $path`
+    end
     define_editor(r"\bemacs\b.*(-nw|--no-window-system)",
                   wait=true) do cmd, path, line
         `$cmd +$line $path`
     end
     define_editor(r"\bemacsclient\b.*(-nw|-t|-tty)",
                   wait=true) do cmd, path, line
-        `$cmd +$line $path`
-    end
-    define_editor([r"\bemacs","gedit",r"\bgvim"]) do cmd, path, line
         `$cmd +$line $path`
     end
     define_editor(["textmate","mate","kate"]) do cmd, path, line

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -46,28 +46,31 @@ Base.run(x::EditorCommand{Function}) = x.parsed_command()
 """
     define_editor(fn,pattern;background=true,priority=0)
 
-Define a new editor matching `pattern` which can be used via `edit`, possibly
-handling line numbers.
+Define a new editor matching `pattern` that can be used to open a file
+(possibly at a given line number) using `fn`.
 
-The function `fn` determines how to open a file with the given editor. It takes
-the arguments `command`, `path` and optionally a third argument `line`, and must
-return either an appropriate `Cmd` object to open a file, or a function (taking
-0 arguments) that will open the file directly (returning a `Cmd` is the
-preferred approach). If `fn` takes a third argument then the resulting command
-or function should open the file at the given line number.
+The `fn` argument is a function that determines how to open a file with the
+given editor.  It should take 2 or 3 arguments, as follows:
 
-The `pattern` argument can be a string, regular expression, or an array of
-strings and regular expressions. For the `fn` to be called one of the patterns
-must match the value of `EDITOR`, `VISUAL` or `JULIA_EDITOR`.  For strings, only
-whole words can match (i.e. "vi" doesn't match "vim -g" but will match
-"/usr/bin/vi -m").
+* `command` - an array of strings representing the editor command. It can be
+  safely interpolated into a command created using backtick notation.
+* `path`  - the path to the source file to open
+* `line` - the optional line number to open to; if specified the returned command
+  must open the file at the given line.
 
-If `fn` is called, but returns nothing, the pattern is considered to have not
-matched and other editors are considered. This allows you to verify the
-environment when `edit` is called, before deciding to return a non-nothing
-value.
+`fn` must return either an appropriate `Cmd` object to open a
+file, a function (taking 0 arguments) that will open the file directly
+(returning a `Cmd` is the preferred approach), or `nothing`. Use `nothing`
+to indicate that this editor is not appropriate for the current environment
+and another editor should be attempted.
 
-If multiple editors match, the one with the highest priority is selected,
+The `pattern` argument is string, regular expression, or an array of strings and
+regular expressions. For the `fn` to be called one of the patterns must match
+the value of `EDITOR`, `VISUAL` or `JULIA_EDITOR`.  For strings, only whole
+words can match (i.e. "vi" doesn't match "vim -g" but will match "/usr/bin/vi
+-m").
+
+If multiple defined editors match, the one with the highest priority is selected,
 and if there is a tie in priority, the first editor added will be used.
 
 By default the editor is opened in the background, but terminal-based editors
@@ -76,8 +79,8 @@ will want to set `background=false`.
 If no editor entry can be found, then a file is opened by running
 `\$command \$path`.
 
-Note that a number of default editors are already defined. All of the following
-commands should already work:
+Note that a number of default editors (all priority 0) are already defined. All
+of the following commands should already work:
 - emacs
 - vim
 - nvim

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -54,7 +54,7 @@ given editor.  It should take 2 or 3 arguments, as follows:
 * `command` - an array of strings representing the editor command. It can be
   safely interpolated into a command created using backtick notation.
 * `path`  - the path to the source file to open
-* `line` - the optional line number to open to; if specified the returned 
+* `line` - the optional line number to open to; if specified the returned
    command must open the file at the given line.
 
 `fn` must return either an appropriate `Cmd` object to open a file, a

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -5,6 +5,162 @@
 import Base.shell_split
 using Base: find_source_file
 
+struct EditorEntry{P,Fn}
+  pattern::P
+  fn::Fn
+  background::Bool
+  takesline::Bool
+  priority::Float64
+end
+const editors = Vector{EditorEntry}(undef,0)
+
+struct EditorCommand{C,E}
+    parsed_command::C
+    entry::E
+end
+function parse_command(entry::EditorEntry,command,path,line)
+    if entry.takesline
+        cmd = entry.fn(command,path,line)
+        if !(cmd isa Nothing)
+            return EditorCommand(cmd,entry), true
+        end
+    end
+
+    cmd = entry.fn(command,path)
+    if !(cmd isa Nothing)
+        return EditorCommand(cmd,entry), false
+    end
+
+    nothing, false
+end
+
+function Base.run(x::EditorCommand{Cmd})
+    if x.entry.background
+        run(pipeline(x.parsed_command, stderr=stderr), wait=false)
+    else
+        run(x.parsed_command)
+    end
+end
+Base.run(x::EditorCommand{Function}) = x.parsed_command()
+
+"""
+    define_editor(fn,pattern;background=true,priority=0)
+
+Define a new editor matching `pattern` which can be used via `edit`, possibly
+handling line numbers.
+
+The function `fn` determines how to open a file with the given editor. It takes
+the arguments `command`, `path` and optionally a third argument `line`, and must
+return either an appropriate `Cmd` object to open a file, or a function (taking
+0 arguments) that will open the file directly (returning a `Cmd` is the
+preferred approach). If `fn` takes a third argument then the resulting command
+or function should open the file at the given line number.
+
+The `pattern` argument can be a string, regular expression, or an array of
+strings and regular expressions. For the `fn` to be called one of the patterns
+must match the value of `EDITOR`, `VISUAL` or `JULIA_EDITOR`.  For strings, only
+whole words can match (i.e. "vi" doesn't match "vim -g" but will match
+"/usr/bin/vi -m").
+
+If `fn` is called, but returns nothing, the pattern is considered to have not
+matched and other editors are considered. This allows you to verify the
+environment when `edit` is called, before deciding to return a non-nothing
+value.
+
+If multiple editors match, the one with the highest priority is selected,
+and if there is a tie in priority, the first editor added will be used.
+
+By default the editor is opened in the background, but terminal-based editors
+will want to set `background=false`.
+
+If no editor entry can be found, then a file is opened by running
+`\$command \$path`.
+
+Note that a number of default editors are already defined. All of the following
+commands should already work:
+- emacs
+- vim
+- nvim
+- nano
+- textmate
+- mate
+- kate
+- subl
+- atom
+- notepad++
+- VSCode
+- open
+
+# Example:
+The following defines the usage of terminal-based `emacs`:
+
+    define_editor(r"\bemacs\b.*(-nw|--no-window-system)",
+                  background=false) do cmd,path,line
+        `\$cmd +\$line \$path`
+    end
+"""
+
+function define_editor(fn,pattern;background=true,priority=0)
+    nargs = map(x -> x.nargs - 1,methods(fn).ms)
+    has3args = 3 ∈ nargs
+    has2args = 2 ∈ nargs
+    push!(editors,EditorEntry(pattern,fn,background,has3args,Float64(priority)))
+
+    if !(has3args || has2args)
+        error("Editor function must take 2 or 3 arguments")
+    end
+end
+
+function define_default_editors()
+    define_editor(["vim","vi","nvim","mvim","nano"],
+                  background=false) do cmd,path,line
+        `$cmd +$line $path`
+    end
+    define_editor(r"\bemacs\b.*(-nw|--no-window-system)",
+                  background=false) do cmd,path,line
+        `$cmd +$line $path`
+    end
+    define_editor(r"\bemacsclient\b.*(-nw|-t|-tty)",
+                  background=true) do cmd,path,line
+        `$cmd +$line $path`
+    end
+    define_editor([r"\bemacs","gedit",r"\bgvim"]) do cmd,path,line
+        `$cmd +$line $path`
+    end
+    define_editor(["textmate","mate","kate"]) do cmd,path,line
+        `$cmd $path -l $line`
+    end
+    define_editor([r"\bsubl",r"\batom"]) do cmd,path,line
+        `$cmd $path:$line`
+    end
+    define_editor("code") do cmd,path,line
+        `$cmd -g $path:$line`
+    end
+    define_editor(r"\bnotepad++") do cmd,paht,line
+        `$cmd $path -n$line`
+    end
+    if Sys.iswindows()
+        define_editor(r"\bCODE\.EXE\b"i) do cmd,path,line
+            `$cmd -g $path:$line`
+        end
+        define_editor("open") do cmd,path,line
+            function()
+                @static if Sys.iswindows() # don't emit this ccall on other platforms
+                    result = ccall((:ShellExecuteW, "shell32"), stdcall,
+                                   Int, (Ptr{Cvoid}, Cwstring, Cwstring,
+                                         Ptr{Cvoid}, Ptr{Cvoid}, Cint),
+                                   C_NULL, "open", path, C_NULL, C_NULL, 10)
+                    systemerror(:edit, result ≤ 32)
+                end
+            end
+        end
+    elseif Sys.isapple()
+        define_editor("open") do cmd,path
+            `open -t $path`
+        end
+    end
+end
+
 """
     editor()
 
@@ -26,6 +182,27 @@ function editor()
     return args
 end
 
+editormatches(pattern::String,command) =
+    occursin(Regex("\\b"*pattern*"\\b"),command)
+editormatches(pattern::Regex,command) =
+    occursin(pattern,command)
+editormatches(pattern::AbstractArray,command) =
+    any(x -> editormatches(x,command),pattern)
+function findeditors(command)
+    command_str = join(command," ")
+    matches = (-Inf,EditorEntry[])
+    for entry in editors
+        if editormatches(entry.pattern,command_str)
+            if matches[1] < entry.priority
+                matches = (entry.priority,EditorEntry[entry])
+            elseif matches[1] == entry.priority
+                matches = (matches[1],push!(matches[2],entry))
+            end
+        end
+    end
+    matches[2]
+end
+
 """
     edit(path::AbstractString, line::Integer=0)
 
@@ -34,52 +211,29 @@ Return to the `julia` prompt when you quit the editor. The editor can be changed
 by setting `JULIA_EDITOR`, `VISUAL` or `EDITOR` as an environment variable.
 """
 function edit(path::AbstractString, line::Integer=0)
+    !isempty(editors) || define_default_editors()
     command = editor()
-    name = basename(first(command))
     if endswith(path, ".jl")
         f = find_source_file(path)
         f !== nothing && (path = f)
     end
-    background = true
-    line_unsupported = false
-    if startswith(name, "vim.") || name == "vi" || name == "vim" || name == "nvim" ||
-            name == "mvim" || name == "nano" ||
-            name == "emacs" && any(c -> c in ["-nw", "--no-window-system" ], command) ||
-            name == "emacsclient" && any(c -> c in ["-nw", "-t", "-tty"], command)
-        cmd = line != 0 ? `$command +$line $path` : `$command $path`
-        background = false
-    elseif startswith(name, "emacs") || name == "gedit" || startswith(name, "gvim")
-        cmd = line != 0 ? `$command +$line $path` : `$command $path`
-    elseif name == "textmate" || name == "mate" || name == "kate"
-        cmd = line != 0 ? `$command $path -l $line` : `$command $path`
-    elseif name == "rmate"
-        cmd = line != 0 ? `$command $path -l $line -f` : `$command $path -f`
-    elseif startswith(name, "subl") || startswith(name, "atom")
-        cmd = line != 0 ? `$command $path:$line` : `$command $path`
-    elseif name == "code" || (Sys.iswindows() && (uppercase(name) == "CODE.EXE" || uppercase(name) == "CODE.CMD"))
-        cmd = line != 0 ? `$command -g $path:$line` : `$command -g $path`
-    elseif startswith(name, "notepad++")
-        cmd = line != 0 ? `$command $path -n$line` : `$command $path`
-    elseif Sys.isapple() && name == "open"
-        cmd = `open -t $path`
-        line_unsupported = true
-    else
-        cmd = `$command $path`
-        background = false
-        line_unsupported = true
+
+    parsed = nothing
+    line_supported = false
+    for entry in findeditors(command)
+        parsed, line_supported = parse_command(entry,command,path,line)
+        parsed isa Nothing || break
+    end
+    if parsed isa Nothing
+        parsed = `$command $path`
+        line_supported = false
     end
 
-    if Sys.iswindows() && name == "open"
-        @static Sys.iswindows() && # don't emit this ccall on other platforms
-            systemerror(:edit, ccall((:ShellExecuteW, "shell32"), stdcall, Int,
-                                     (Ptr{Cvoid}, Cwstring, Cwstring, Ptr{Cvoid}, Ptr{Cvoid}, Cint),
-                                     C_NULL, "open", path, C_NULL, C_NULL, 10) ≤ 32)
-    elseif background
-        run(pipeline(cmd, stderr=stderr), wait=false)
-    else
-        run(cmd)
+    if line != 0 && !line_supported
+        @info("Unknown editor: no line number information passed.\n"*
+              "The method is defined at line $line.")
     end
-    line != 0 && line_unsupported && println("Unknown editor: no line number information passed.\nThe method is defined at line $line.")
+    run(parsed)
 
     nothing
 end

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -20,13 +20,13 @@ end
 function parse_command(entry::EditorEntry, command, path, line)
     if entry.takesline
         cmd = entry.fn(command, path, line)
-        if !(cmd isa Nothing)
+        if !isnothing(cmd)
             return EditorCommand(cmd, entry), true
         end
     end
 
     cmd = entry.fn(command, path)
-    if !(cmd isa Nothing)
+    if !isnothing(cmd)
         return EditorCommand(cmd, entry), false
     end
 
@@ -218,9 +218,9 @@ function edit(path::AbstractString, line::Integer=0)
     line_supported = false
     for entry in findeditors(command)
         parsed, line_supported = parse_command(entry, command, path, line)
-        parsed isa Nothing || break
+        isnothing(parsed) || break
     end
-    if parsed isa Nothing
+    if isnothing(parsed)
         parsed = `$command $path`
         line_supported = false
     end

--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -103,7 +103,6 @@ The following defines the usage of terminal-based `emacs`:
         `\$cmd +\$line \$path`
     end
 """
-
 function define_editor(fn, pattern; wait=false, priority=0)
     nargs = map(x -> x.nargs - 1, methods(fn).ms)
     has3args = 3 ∈ nargs


### PR DESCRIPTION
This is my initial proposal to create a `define_editor` command to make it possible to customize how `@edit` tells an editor about line numbers. I described this in #29979. As implemented, one can define a new editor, like so, in `~/.julia/config/startup.jl`

```julia
define_editor(r"\bemacs\b.*(-nw|--no-window-system)",background=false) do cmd,path,line
    `$cmd +$line $path`
end
```

If the pattern matches the value of `$EDITOR` the `do` function body will be used to issue the editor command. At present the function is not exported, though maybe it would be better if it were?

I recognize there might a little bit more work to clean this up (docs? tests?). However, before I do any clean up, I wanted to check that there weren't any other changes I should make to the interface or implementation.