### PR TITLE
Add Sys.is* for all recognized kernels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,8 @@ New library functions
   * `eachrow`, `eachcol` and `eachslice` functions provide efficient iterators over slices of arrays ([#29749]).
   * `fieldtypes(T::Type)` which return the declared types of the field in type T ([#29600]).
   * `uuid5` has been added to the `UUIDs` standard library ([#28761]).
+  * Predicate functions `Sys.isfreebsd`, `Sys.isopenbsd`, `Sys.isnetbsd`, and `Sys.isdragonfly` for
+    detecting BSD systems have been added ([#30249]).
 
 Standard library changes
 ------------------------
@@ -175,3 +177,4 @@ Deprecated or removed
 [#30035]: https://github.com/JuliaLang/julia/issues/30035
 [#30083]: https://github.com/JuliaLang/julia/issues/30083
 [#30159]: https://github.com/JuliaLang/julia/issues/30159
+[#30249]: https://github.com/JuliaLang/julia/issues/30249

--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -22,7 +22,11 @@ export BINDIR,
        total_memory,
        isapple,
        isbsd,
+       isdragonfly,
+       isfreebsd,
        islinux,
+       isnetbsd,
+       isopenbsd,
        isunix,
        iswindows,
        isexecutable,
@@ -286,7 +290,7 @@ end
 Predicate for testing if the OS is a derivative of Linux.
 See documentation in [Handling Operating System Variation](@ref).
 """
-islinux(os::Symbol) = (os == :Linux)
+islinux(os::Symbol) = (os === :Linux)
 
 """
     Sys.isbsd([os])
@@ -299,7 +303,63 @@ See documentation in [Handling Operating System Variation](@ref).
     `true` on macOS systems. To exclude macOS from a predicate, use
     `Sys.isbsd() && !Sys.isapple()`.
 """
-isbsd(os::Symbol) = (os == :FreeBSD || os == :OpenBSD || os == :NetBSD || os == :DragonFly || os == :Darwin || os == :Apple)
+isbsd(os::Symbol) = (isfreebsd(os) || isopenbsd(os) || isnetbsd(os) || isdragonfly(os) || isapple(os))
+
+"""
+    Sys.isfreebsd([os])
+
+Predicate for testing if the OS is a derivative of FreeBSD.
+See documentation in [Handling Operating System Variation](@ref).
+
+!!! note
+    Not to be confused with `Sys.isbsd()`, which is `true` on FreeBSD but also on
+    other BSD-based systems. `Sys.isfreebsd()` refers only to FreeBSD.
+!!! compat "Julia 1.1"
+    This function requires at least Julia 1.1.
+"""
+isfreebsd(os::Symbol) = (os === :FreeBSD)
+
+"""
+    Sys.isopenbsd([os])
+
+Predicate for testing if the OS is a derivative of OpenBSD.
+See documentation in [Handling Operating System Variation](@ref).
+
+!!! note
+    Not to be confused with `Sys.isbsd()`, which is `true` on OpenBSD but also on
+    other BSD-based systems. `Sys.isopenbsd()` refers only to OpenBSD.
+!!! compat "Julia 1.1"
+    This function requires at least Julia 1.1.
+"""
+isopenbsd(os::Symbol) = (os === :OpenBSD)
+
+"""
+    Sys.isnetbsd([os])
+
+Predicate for testing if the OS is a derivative of NetBSD.
+See documentation in [Handling Operating System Variation](@ref).
+
+!!! note
+    Not to be confused with `Sys.isbsd()`, which is `true` on NetBSD but also on
+    other BSD-based systems. `Sys.isnetbsd()` refers only to NetBSD.
+!!! compat "Julia 1.1"
+    This function requires at least Julia 1.1.
+"""
+isnetbsd(os::Symbol) = (os === :NetBSD)
+
+"""
+    Sys.isdragonfly([os])
+
+Predicate for testing if the OS is a derivative of DragonFly BSD.
+See documentation in [Handling Operating System Variation](@ref).
+
+!!! note
+    Not to be confused with `Sys.isbsd()`, which is `true` on DragonFly but also on
+    other BSD-based systems. `Sys.isdragonfly()` refers only to DragonFly.
+!!! compat "Julia 1.1"
+    This function requires at least Julia 1.1.
+"""
+isdragonfly(os::Symbol) = (os === :DragonFly)
 
 """
     Sys.iswindows([os])
@@ -307,7 +367,7 @@ isbsd(os::Symbol) = (os == :FreeBSD || os == :OpenBSD || os == :NetBSD || os == 
 Predicate for testing if the OS is a derivative of Microsoft Windows NT.
 See documentation in [Handling Operating System Variation](@ref).
 """
-iswindows(os::Symbol) = (os == :Windows || os == :NT)
+iswindows(os::Symbol) = (os === :Windows || os === :NT)
 
 """
     Sys.isapple([os])
@@ -315,9 +375,9 @@ iswindows(os::Symbol) = (os == :Windows || os == :NT)
 Predicate for testing if the OS is a derivative of Apple Macintosh OS X or Darwin.
 See documentation in [Handling Operating System Variation](@ref).
 """
-isapple(os::Symbol) = (os == :Apple || os == :Darwin)
+isapple(os::Symbol) = (os === :Apple || os === :Darwin)
 
-for f in (:isunix, :islinux, :isbsd, :isapple, :iswindows)
+for f in (:isunix, :islinux, :isbsd, :isapple, :iswindows, :isfreebsd, :isopenbsd, :isnetbsd, :isdragonfly)
     @eval $f() = $(getfield(@__MODULE__, f)(KERNEL))
 end
 

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -285,6 +285,10 @@ Base.Sys.isunix
 Base.Sys.isapple
 Base.Sys.islinux
 Base.Sys.isbsd
+Base.Sys.isfreebsd
+Base.Sys.isopenbsd
+Base.Sys.isnetbsd
+Base.Sys.isdragonfly
 Base.Sys.iswindows
 Base.Sys.windows_version
 Base.@static

--- a/doc/src/manual/handling-operating-system-variation.md
+++ b/doc/src/manual/handling-operating-system-variation.md
@@ -2,8 +2,9 @@
 
 When writing cross-platform applications or libraries, it is often necessary to allow for
 differences between operating systems. The variable `Sys.KERNEL` can be used to handle such
-cases. There are several functions in the `Sys` module intended to make this easier:
-`isunix`, `islinux`, `isapple`, `isbsd`, and `iswindows`. These may be used as follows:
+cases. There are several functions in the `Sys` module intended to make this easier, such as
+`isunix`, `islinux`, `isapple`, `isbsd`, `isfreebsd`, and `iswindows`. These may be used
+as follows:
 
 ```julia
 if Sys.iswindows()
@@ -11,9 +12,9 @@ if Sys.iswindows()
 end
 ```
 
-Note that `islinux` and `isapple` are mutually exclusive subsets of `isunix`. Additionally,
-there is a macro `@static` which makes it possible to use these functions to conditionally hide
-invalid code, as demonstrated in the following examples.
+Note that `islinux`, `isapple`, and `isfreebsd` are mutually exclusive subsets of `isunix`.
+Additionally, there is a macro `@static` which makes it possible to use these functions to
+conditionally hide invalid code, as demonstrated in the following examples.
 
 Simple blocks:
 

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-@testset "isunix/islinux/iswindows" begin
+@testset "Operating system predicates" begin
     @test !Sys.isunix(:Windows)
     @test !Sys.islinux(:Windows)
     @test Sys.islinux(:Linux)
@@ -12,6 +12,16 @@
     @test !Sys.isapple(:Windows)
     @test Sys.isunix(:Darwin)
     @test Sys.isunix(:FreeBSD)
+    for bsd in (:FreeBSD, :OpenBSD, :NetBSD, :DragonFly)
+        f = Symbol("is", lowercase(String(bsd)))
+        q = QuoteNode(bsd)
+        @eval begin
+            @test Sys.$f($q)
+            @test Sys.isbsd($q)
+            @test Sys.isunix($q)
+            @test !Sys.isapple($q)
+        end
+    end
     @test_throws ArgumentError Sys.isunix(:BeOS)
     if !Sys.iswindows()
         @test Sys.windows_version() == v"0.0.0"


### PR DESCRIPTION
I've found myself wanting `Sys.isfreebsd` while writing some FreeBSD-specific package code in my spare time. Per Elliot's suggestion (see below), this adds predicates for all kernels.