### PR TITLE
fix #30234, don't resolve bindings when tab-completing `using`

### DIFF
--- a/stdlib/REPL/src/REPLCompletions.jl
+++ b/stdlib/REPL/src/REPLCompletions.jl
@@ -665,7 +665,7 @@ function completions(string, pos, context_module=Main)::Completions
                 end
             end
         end
-        ffunc = (mod,x)->(isdefined(mod, x) && isa(getfield(mod, x), Module))
+        ffunc = (mod,x)->(Base.isbindingresolved(mod, x) && isdefined(mod, x) && isa(getfield(mod, x), Module))
         comp_keywords = false
     end
     startpos == 0 && (pos = -1)

--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -105,6 +105,8 @@ end
 let s = "using REP"
     c, r = test_complete(s)
     @test count(isequal("REPL"), c) == 1
+    # issue #30234
+    @test !Base.isbindingresolved(Main, :tanh)
 end
 
 let s = "Comp"


### PR DESCRIPTION
fix #30234