### PR TITLE
WIP: Julia interface for custom Unicode normalization

### DIFF
--- a/base/strings/unicode.jl
+++ b/base/strings/unicode.jl
@@ -139,7 +139,7 @@ function utf8proc_map(str::String, options::Integer)
     nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
                    str, sizeof(str), C_NULL, 0, options)
     nwords < 0 && utf8proc_error(nwords)
-    buffer = Base.StringVector(nwords*4)
+    buffer = Base.StringVector(nwords*sizeof(Cint))
     nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
                    str, sizeof(str), buffer, nwords, options)
     nwords < 0 && utf8proc_error(nwords)
@@ -165,7 +165,7 @@ function utf8proc_map(str::String, options::Integer, custom_func, custom_data)
                    (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint, Ptr{Cvoid}, Ptr{Cvoid}),
                    str, sizeof(str), C_NULL, 0, options, ccustom_func, data_ptr)
     nwords < 0 && utf8proc_error(nwords)
-    buffer = Base.StringVector(nwords*4)
+    buffer = Base.StringVector(nwords*sizeof(Cint))
     nwords = ccall(:utf8proc_decompose_custom, Int,
                    (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint, Ptr{Cvoid}, Ptr{Cvoid}),
                    str, sizeof(str), buffer, nwords, options, ccustom_func, data_ptr)

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -51,20 +51,19 @@ julia> Unicode.normalize("JúLiA", stripmark=true)
 "JuLiA"
 ```
 
-You can also passing a `custom_func` and `custom_data` to the `normalize` to do custom normalization
-by calling `Unicode.normalize(s::AbstractString, nf::Symbol, custom_func, custom_data)` or
+You can also passing a `custom_func` to the `normalize` to do custom normalization
+by calling `Unicode.normalize(s::AbstractString, nf::Symbol, custom_func)` or
 `Unicode.normalize(s::AbstractString, custom_func, custom_data)`
-where custom function should be in `custom_func(codepoint, custom_data)::Cint` and return a new
-codepoint. `custom_data` can be Any Julia type.
+where custom function should be in `custom_func(codepoint)::Cint` and return a new codepoint.
 
 """
 function normalize end
 normalize(s::AbstractString, nf::Symbol) = Base.Unicode.normalize(s, nf)
 normalize(s::AbstractString; kwargs...) = Base.Unicode.normalize(s; kwargs...)
-normalize(s::AbstractString, nf::Symbol, custom_func, custom_data) =
-    Base.Unicode.normalize(s, nf, custom_func, custom_data)
-normalize(s::AbstractString, custom_func, custom_data; kwargs...) =
-    Base.Unicode.normalize(s, custom_func, custom_data; kwargs...)
+normalize(s::AbstractString, nf::Symbol, custom_func) =
+    Base.Unicode.normalize(s, nf, custom_func)
+normalize(s::AbstractString, custom_func; kwargs...) =
+    Base.Unicode.normalize(s, custom_func; kwargs...)
 
 
 

--- a/stdlib/Unicode/src/Unicode.jl
+++ b/stdlib/Unicode/src/Unicode.jl
@@ -50,10 +50,23 @@ julia> Unicode.normalize("JuLiA", casefold=true)
 julia> Unicode.normalize("JúLiA", stripmark=true)
 "JuLiA"
 ```
+
+You can also passing a `custom_func` and `custom_data` to the `normalize` to do custom normalization
+by calling `Unicode.normalize(s::AbstractString, nf::Symbol, custom_func, custom_data)` or
+`Unicode.normalize(s::AbstractString, custom_func, custom_data)`
+where custom function should be in `custom_func(codepoint, custom_data)::Cint` and return a new
+codepoint. `custom_data` can be Any Julia type.
+
 """
 function normalize end
 normalize(s::AbstractString, nf::Symbol) = Base.Unicode.normalize(s, nf)
 normalize(s::AbstractString; kwargs...) = Base.Unicode.normalize(s; kwargs...)
+normalize(s::AbstractString, nf::Symbol, custom_func, custom_data) =
+    Base.Unicode.normalize(s, nf, custom_func, custom_data)
+normalize(s::AbstractString, custom_func, custom_data; kwargs...) =
+    Base.Unicode.normalize(s, custom_func, custom_data; kwargs...)
+
+
 
 """
     Unicode.isassigned(c) -> Bool

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -951,3 +951,11 @@ let x = SubString("ab", 1, 1)
     @test y === x
     chop("ab") === chop.(["ab"])[1]
 end
+
+# custom unicode normalize function
+let d = Dict{Cint, Cint}(Cint('a')=>Cint('\u6666'))
+    function mycustom(uc, d)::Cint
+        get(d, uc, Cint('\u2721'))
+    end
+    @test Unicode.normalize("abcd",:NFKC, mycustom, d) == "\u6666\u2721\u2721\u2721"
+end

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -954,8 +954,9 @@ end
 
 # custom unicode normalize function
 let d = Dict{Cint, Cint}(Cint('a')=>Cint('\u6666'))
-    function mycustom(uc, d)::Cint
+    function mycustom(uc)::Cint
+        @show d
         get(d, uc, Cint('\u2721'))
     end
-    @test Unicode.normalize("abcd",:NFKC, mycustom, d) == "\u6666\u2721\u2721\u2721"
+    @test Unicode.normalize("abcd",:NFKC, mycustom) == "\u6666\u2721\u2721\u2721"
 end


### PR DESCRIPTION
I found there was a `utf8proc_decompose_custom` function under the c call of `utf8proc_map` inside `Base.Unicode.utf8proc_map` but not expose to the Julia interface. So I made another `Base.Unicode.utf8proc_map` method that support the `custom func` and `custom data` with native Julia function and data type
*there is another [PR](https://github.com/JuliaLang/julia/pull/19464) that seems to make a custom unicode normalization, but I didn't found a Julia function to it.