### PR TITLE
Fix #29766: printing of InexactError

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -957,7 +957,7 @@ Cannot exactly convert `val` to type `T` in a method of function `name`.
 # Examples
 ```jldoctest
 julia> convert(Float64, 1+2im)
-ERROR: InexactError: Float64(Float64, 1 + 2im)
+ERROR: InexactError: Float64(1 + 2im)
 Stacktrace:
 [...]
 ```

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -153,7 +153,9 @@ function showerror(io::IO, ex::UndefVarError)
 end
 
 function showerror(io::IO, ex::InexactError)
-    print(io, "InexactError: ", ex.func, '(', ex.T, ", ", ex.val, ')')
+    print(io, "InexactError: ", ex.func, '(')
+    nameof(ex.T) === ex.func || print(io, ex.T, ", ")
+    print(io, ex.val, ')')
 end
 
 typesof(args...) = Tuple{Any[ Core.Typeof(a) for a in args ]...}

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -115,7 +115,7 @@ julia> convert(Int, 3.0)
 3
 
 julia> convert(Int, 3.5)
-ERROR: InexactError: Int64(Int64, 3.5)
+ERROR: InexactError: Int64(3.5)
 Stacktrace:
 [...]
 ```

--- a/doc/src/manual/constructors.md
+++ b/doc/src/manual/constructors.md
@@ -300,7 +300,7 @@ julia> Point{Int64}(1, 2) ## explicit T ##
 Point{Int64}(1, 2)
 
 julia> Point{Int64}(1.0,2.5) ## explicit T ##
-ERROR: InexactError: Int64(Int64, 2.5)
+ERROR: InexactError: Int64(2.5)
 Stacktrace:
 [...]
 

--- a/doc/src/manual/mathematical-operations.md
+++ b/doc/src/manual/mathematical-operations.md
@@ -432,12 +432,12 @@ julia> Int8(127.0)
 127
 
 julia> Int8(3.14)
-ERROR: InexactError: Int8(Int8, 3.14)
+ERROR: InexactError: Int8(3.14)
 Stacktrace:
 [...]
 
 julia> Int8(128.0)
-ERROR: InexactError: Int8(Int8, 128.0)
+ERROR: InexactError: Int8(128.0)
 Stacktrace:
 [...]
 

--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -344,7 +344,7 @@ must be convertible to `Int`:
 
 ```jldoctest footype
 julia> Foo((), 23.5, 1)
-ERROR: InexactError: Int64(Int64, 23.5)
+ERROR: InexactError: Int64(23.5)
 Stacktrace:
 [...]
 ```

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -171,7 +171,7 @@ julia> A = [1 2; 2 50]
  2  50
 
 julia> cholesky!(A)
-ERROR: InexactError: Int64(Int64, 6.782329983125268)
+ERROR: InexactError: Int64(6.782329983125268)
 Stacktrace:
 [...]
 ```

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -78,7 +78,7 @@ julia> iA = [4 3; 6 3]
  6  3
 
 julia> lu!(iA)
-ERROR: InexactError: Int64(Int64, 0.6666666666666666)
+ERROR: InexactError: Int64(0.6666666666666666)
 Stacktrace:
 [...]
 ```

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -277,7 +277,7 @@ julia> a = [1 2; 3 4]
  3  4
 
 julia> qr!(a)
-ERROR: InexactError: Int64(Int64, -3.1622776601683795)
+ERROR: InexactError: Int64(-3.1622776601683795)
 Stacktrace:
 [...]
 ```


### PR DESCRIPTION
Only omits the type, if the function is not that type's constructor