### PR TITLE
Make `unique(f, itr)` and `unique!(f, itr)` faster

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -167,15 +167,39 @@ julia> unique(x -> x^2, [1, -1, 3, -3, 4])
 """
 function unique(f, C)
     out = Vector{eltype(C)}()
-    seen = Set()
-    for x in C
-        y = f(x)
-        if !in(y, seen)
-            push!(seen, y)
-            push!(out, x)
-        end
+
+    s = iterate(C)
+    if s === nothing
+        return out
     end
-    out
+    (x, i) = s
+    y = f(x)
+    seen = Set{typeof(y)}()
+    push!(seen, y)
+    push!(out, x)
+
+    return _unique!(f, out, C, seen, i)
+end
+
+function _unique!(f, out::AbstractVector, C, seen::Set, i)
+    s = iterate(C, i)
+    while s !== nothing
+        (x, i) = s
+        y = f(x)
+        if y ∉ seen
+            push!(out, x)
+            if y isa eltype(seen)
+                push!(seen, y)
+            else
+                seen2 = convert(Set{promote_typejoin(eltype(seen), typeof(y))}, seen)
+                push!(seen2, y)
+                return _unique!(f, out, C, seen2, i)
+            end
+        end
+        s = iterate(C, i)
+    end
+
+    return out
 end
 
 """
@@ -205,21 +229,38 @@ julia> unique!(iseven, [2, 3, 5, 7, 9])
 ```
 """
 function unique!(f, A::AbstractVector)
-    seen = Set()
-    idxs = eachindex(A)
-    y = iterate(idxs)
-    count = 0
-    for x in A
-        t = f(x)
-        if t ∉ seen
-            push!(seen,t)
-            count += 1
-            A[y[1]] = x
-            y = iterate(idxs, y[2])
-        end
+    if length(A) <= 1
+        return A
     end
-    resize!(A, count)
+
+    i = firstindex(A)
+    x = @inbounds A[i]
+    y = f(x)
+    seen = Set{typeof(y)}()
+    push!(seen, y)
+    return _unique!(f, A, seen, 1, i+1)
 end
+
+function _unique!(f, A::AbstractVector, seen::Set, count::Integer, i::Integer)
+    while i <= lastindex(A)
+        x = @inbounds A[i]
+        y = f(x)
+        if y ∉ seen
+            count += 1
+            @inbounds A[count] = x
+            if y isa eltype(seen)
+                push!(seen, y)
+            else
+                seen2 = convert(Set{promote_typejoin(eltype(seen), typeof(y))}, seen)
+                push!(seen2, y)
+                return _unique!(f, A, seen2, count, i+1)
+            end
+        end
+        i += 1
+    end
+    return resize!(A, count)
+end
+
 
 # If A is not grouped, then we will need to keep track of all of the elements that we have
 # seen so far.

--- a/base/set.jl
+++ b/base/set.jl
@@ -238,27 +238,27 @@ function unique!(f, A::AbstractVector)
     y = f(x)
     seen = Set{typeof(y)}()
     push!(seen, y)
-    return _unique!(f, A, seen, 1, i+1)
+    return _unique!(f, A, seen, i, i+1)
 end
 
-function _unique!(f, A::AbstractVector, seen::Set, count::Integer, i::Integer)
+function _unique!(f, A::AbstractVector, seen::Set, current::Integer, i::Integer)
     while i <= lastindex(A)
         x = @inbounds A[i]
         y = f(x)
         if y ∉ seen
-            count += 1
-            @inbounds A[count] = x
+            current += 1
+            @inbounds A[current] = x
             if y isa eltype(seen)
                 push!(seen, y)
             else
                 seen2 = convert(Set{promote_typejoin(eltype(seen), typeof(y))}, seen)
                 push!(seen2, y)
-                return _unique!(f, A, seen2, count, i+1)
+                return _unique!(f, A, seen2, current, i+1)
             end
         end
         i += 1
     end
-    return resize!(A, count)
+    return resize!(A, current - firstindex(A) + 1)
 end
 
 


### PR DESCRIPTION
Avoid creation of a `Set{Any}` to make the function-providing forms faster, and address regression of `unique(itr)` perfermance from #30141.

cc @raghav9-97 @oxinabox @fredrikekre 

Setup:

```julia
julia> x = rand(1:100_000, 1_000_000);
```

Before #30141:

```julia
julia> @btime unique(x);
  13.898 ms (49 allocations: 5.00 MiB)
```

After #30141:

```julia
julia> @btime unique(identity, x);
  40.192 ms (644863 allocations: 14.84 MiB)
```

After this PR:
```julia
julia> @btime unique(identity, x);
  14.092 ms (50 allocations: 5.00 MiB)
```