### PR TITLE
fix deleteat! for 0-length arrays

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1213,6 +1213,7 @@ function _deleteat!(a::Vector, inds)
     n = length(a)
     y = iterate(inds)
     y === nothing && return a
+    n == 0 && throw(BoundsError(a, inds))
     (p, s) = y
     q = p+1
     while true

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -933,6 +933,7 @@ function deleteat!(B::BitVector, inds)
     n = new_l = length(B)
     y = iterate(inds)
     y === nothing && return B
+    n == 0 && throw(BoundsError(B, inds))
 
     Bc = B.chunks
 

--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1363,6 +1363,12 @@ end
     @test_throws BoundsError deleteat!(a, Bool[])
     @test_throws BoundsError deleteat!(a, [true])
     @test_throws BoundsError deleteat!(a, falses(11))
+
+    @test_throws BoundsError deleteat!([], 1)
+    @test_throws BoundsError deleteat!([], [1])
+    @test_throws BoundsError deleteat!([], [2])
+    @test deleteat!([], []) == []
+    @test deleteat!([], Bool[]) == []
 end
 
 @testset "comprehensions" begin

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -647,9 +647,16 @@ timesofar("indexing")
         @test bitcheck(b1)
     end
     @test length(b1) == 0
+
     b1 = bitrand(v1)
     @test_throws ArgumentError deleteat!(b1, [1, 1, 2])
     @test_throws BoundsError deleteat!(b1, [1, length(b1)+1])
+
+    @test_throws BoundsError deleteat!(BitVector(), 1)
+    @test_throws BoundsError deleteat!(BitVector(), [1])
+    @test_throws BoundsError deleteat!(BitVector(), [2])
+    @test deleteat!(BitVector(), []) == BitVector()
+    @test deleteat!(BitVector(), Bool[]) == BitVector()
 
     b1 = bitrand(v1)
     i1 = Array(b1)


### PR DESCRIPTION
Currently `deleteat!` sometimes allows removing elements from an empty vector:
```
julia> deleteat!([], [1])
0-element Array{Any,1}

julia> deleteat!(BitVector(), [10])
0-element BitArray{1}:
```
This PR fixes this and in these cases it will throw `BoundsError`.

It is still allow to remove zero elements from an empty vector.