### PR TITLE
Some more compat annotations

### DIFF
--- a/base/set.jl
+++ b/base/set.jl
@@ -184,6 +184,9 @@ end
 Selects one value from `A` for each unique value produced by `f` applied to
 elements of `A` , then return the modified A.
 
+!!! compat "Julia 1.1"
+    This method is available as of Julia 1.1.
+
 # Examples
 ```jldoctest
 julia> unique!(x -> x^2, [1, -1, 3, -3, 4])

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -725,7 +725,7 @@ the element type of `A`.
 !!! compat "Julia 1.1"
     The `atol` and `rtol` keyword arguments requires at least Julia 1.1.
     In Julia 1.0 `rtol` is available as a positional argument, but this
-    will be deprecated in a future Julia version.
+    will be deprecated in Julia 2.0.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -713,7 +713,7 @@ end
 
 """
     rank(A::AbstractMatrix; atol::Real=0, rtol::Real=atol>0 ? 0 : n*ϵ)
-    rank(A::AbstractMatrix, rtol::Real) = rank(A; rtol=rtol)  # to be deprecated in Julia 2.0
+    rank(A::AbstractMatrix, rtol::Real)
 
 Compute the rank of a matrix by counting how many singular
 values of `A` have magnitude greater than `max(atol, rtol*σ₁)` where `σ₁` is
@@ -721,6 +721,11 @@ values of `A` have magnitude greater than `max(atol, rtol*σ₁)` where `σ₁` 
 tolerances, respectively. The default relative tolerance is `n*ϵ`, where `n`
 is the size of the smallest dimension of `A`, and `ϵ` is the [`eps`](@ref) of
 the element type of `A`.
+
+!!! compat "Julia 1.1"
+    The `atol` and `rtol` keyword arguments requires at least Julia 1.1.
+    In Julia 1.0 `rtol` is available as a positional argument, but this
+    will be deprecated in a future Julia version.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
Compat annotation for `unique!(f, A)`, #30141.
Compat annotation for `rank(A; rtol=..., atol=...)`, #29926.