### PR TITLE
fix hypot with more than two arguments

### DIFF
--- a/test/math.jl
+++ b/test/math.jl
@@ -276,6 +276,7 @@ end
             @test hypot(T(0), T(0)) === T(0)
             @test hypot(T(Inf), T(Inf)) === T(Inf)
             @test hypot(T(Inf), T(x)) === T(Inf)
+            @test hypot(T(Inf), T(NaN)) === T(Inf)
             @test isnan_type(T, hypot(T(x), T(NaN)))
         end
     end

--- a/test/math.jl
+++ b/test/math.jl
@@ -276,7 +276,6 @@ end
             @test hypot(T(0), T(0)) === T(0)
             @test hypot(T(Inf), T(Inf)) === T(Inf)
             @test hypot(T(Inf), T(x)) === T(Inf)
-            @test hypot(T(Inf), T(NaN)) === T(Inf)
             @test isnan_type(T, hypot(T(x), T(NaN)))
         end
     end
@@ -1032,8 +1031,67 @@ end
 
 isdefined(Main, :Furlongs) || @eval Main include("testhelpers/Furlongs.jl")
 using .Main.Furlongs
-@test hypot(Furlong(0), Furlong(0)) == Furlong(0.0)
-@test hypot(Furlong(3), Furlong(4)) == Furlong(5.0)
-@test hypot(Furlong(NaN), Furlong(Inf)) == Furlong(Inf)
-@test hypot(Furlong(Inf), Furlong(NaN)) == Furlong(Inf)
-@test hypot(Furlong(Inf), Furlong(Inf)) == Furlong(Inf)
+@test (@inferred hypot(Furlong(0), Furlong(0))) == Furlong(0.0)
+@test (@inferred hypot(Furlong(3), Furlong(4))) == Furlong(5.0)
+@test (@inferred hypot(Furlong(NaN), Furlong(Inf))) == Furlong(Inf)
+@test (@inferred hypot(Furlong(Inf), Furlong(NaN))) == Furlong(Inf)
+@test (@inferred hypot(Furlong(0), Furlong(0), Furlong(0))) == Furlong(0.0)
+@test (@inferred hypot(Furlong(Inf), Furlong(Inf))) == Furlong(Inf)
+@test (@inferred hypot(Furlong(1), Furlong(1), Furlong(1))) == Furlong(sqrt(3))
+@test (@inferred hypot(Furlong(Inf), Furlong(NaN), Furlong(0))) == Furlong(Inf)
+@test (@inferred hypot(Furlong(Inf), Furlong(Inf), Furlong(Inf))) == Furlong(Inf)
+@test isnan(hypot(Furlong(NaN), Furlong(0), Furlong(1)))
+
+@testset "hypot" begin
+    @test_throws MethodError hypot()
+    @test (@inferred hypot(floatmax())) == floatmax()
+    @test (@inferred hypot(floatmax(), floatmax())) == Inf
+    @test (@inferred hypot(floatmin(), floatmin())) == √2floatmin()
+    @test (@inferred hypot(floatmin(), floatmin(), floatmin())) == √3floatmin()
+    @test (@inferred hypot(1e-162)) ≈ 1e-162
+    @test (@inferred hypot(2e-162, 1e-162, 1e-162)) ≈ hypot(2,1,1)*1e-162
+    @test (@inferred hypot(1e162)) ≈ 1e162
+    @test hypot(-2) === 2.0
+    @test hypot(-2, 0) === 2.0
+    let i = typemax(Int)
+        @test (@inferred hypot(i, i)) ≈ i * √2
+        @test (@inferred hypot(i, i, i)) ≈ i * √3
+        @test (@inferred hypot(i, i, i, i)) ≈ 2.0i
+        @test (@inferred hypot(i//1, 1//i, 1//i)) ≈ i
+    end
+    let i = typemin(Int)
+        @test (@inferred hypot(i, i)) ≈ -√2i
+        @test (@inferred hypot(i, i, i)) ≈ -√3i
+        @test (@inferred hypot(i, i, i, i)) ≈ -2.0i
+    end
+    @testset "$T" for T in (Float32, Float64)
+        @test (@inferred hypot(T(Inf), T(NaN))) == T(Inf) # IEEE754 says so
+        @test (@inferred hypot(T(Inf), T(3//2), T(NaN))) == T(Inf)
+        @test (@inferred hypot(T(1e10), T(1e10), T(1e10), T(1e10))) ≈ 2e10
+        @test isnan_type(T, hypot(T(3), T(3//4), T(NaN)))
+        @test hypot(T(1), T(0)) === T(1)
+	    @test hypot(T(1), T(0), T(0)) === T(1)
+        @test (@inferred hypot(T(Inf), T(Inf), T(Inf))) == T(Inf)
+        for s in (zero(T), floatmin(T)*1e3, floatmax(T)*1e-3, T(Inf))
+            @test hypot(1s, 2s)     ≈ s * hypot(1,2)   rtol=8eps(T)
+            @test hypot(1s, 2s, 3s) ≈ s * hypot(1,2,3) rtol=8eps(T)
+        end
+    end
+    @testset "$T" for T in (Float16, Float32, Float64, BigFloat)
+        let x = 1.1sqrt(floatmin(T))
+            @test (@inferred hypot(x,x/4)) ≈ x * sqrt(17/BigFloat(16))
+            @test (@inferred hypot(x,x/4,x/4)) ≈ x * sqrt(9/BigFloat(8))
+        end
+        let x = 2sqrt(nextfloat(zero(T)))
+            @test (@inferred hypot(x,x/4)) ≈ x * sqrt(17/BigFloat(16))
+            @test (@inferred hypot(x,x/4,x/4)) ≈ x * sqrt(9/BigFloat(8))
+        end
+        let x = sqrt(nextfloat(zero(T))/eps(T))/8, f = sqrt(4eps(T))
+            @test hypot(x,x*f) ≈ x * hypot(one(f),f) rtol=eps(T)
+            @test hypot(x,x*f,x*f) ≈ x * hypot(one(f),f,f) rtol=eps(T)
+        end
+    end
+    # hypot on Complex returns Real
+    @test (@inferred hypot(3, 4im)) === 5.0
+    @test (@inferred hypot(3, 4im, 12)) == 13.0
+end

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -28,6 +28,13 @@ Base.oneunit(x::Type{Furlong{p,T}}) where {p,T} = Furlong{p,T}(one(T))
 Base.zero(x::Furlong{p,T}) where {p,T} = Furlong{p,T}(zero(T))
 Base.zero(::Type{Furlong{p,T}}) where {p,T} = Furlong{p,T}(zero(T))
 Base.iszero(x::Furlong) = iszero(x.val)
+Base.float(x::Furlong{p}) where {p} = Furlong{p}(float(x.val))
+Base.eps(::Type{Furlong{p,T}}) where {p,T<:AbstractFloat} = Furlong{p}(eps(T))
+Base.eps(::Furlong{p,T}) where {p,T<:AbstractFloat} = eps(Furlong{p,T})
+Base.floatmin(::Type{Furlong{p,T}}) where {p,T<:AbstractFloat} = Furlong{p}(floatmin(T))
+Base.floatmin(::Furlong{p,T}) where {p,T<:AbstractFloat} = floatmin(Furlong{p,T})
+Base.floatmax(::Type{Furlong{p,T}}) where {p,T<:AbstractFloat} = Furlong{p}(floatmax(T))
+Base.floatmax(::Furlong{p,T}) where {p,T<:AbstractFloat} = floatmax(Furlong{p,T})
 
 # convert Furlong exponent p to a canonical form.  This
 # is not type stable, but it doesn't matter since it is used
@@ -46,7 +53,7 @@ for f in (:real,:imag,:complex,:+,:-)
 end
 
 import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^, hypot
-for op in (:+, :-, :hypot)
+for op in (:+, :-)
     @eval function $op(x::Furlong{p}, y::Furlong{p}) where {p}
         v = $op(x.val, y.val)
         Furlong{p}(v)

--- a/test/testhelpers/Furlongs.jl
+++ b/test/testhelpers/Furlongs.jl
@@ -52,7 +52,7 @@ for f in (:real,:imag,:complex,:+,:-)
     @eval Base.$f(x::Furlong{p}) where {p} = Furlong{p}($f(x.val))
 end
 
-import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^, hypot
+import Base: +, -, ==, !=, <, <=, isless, isequal, *, /, //, div, rem, mod, ^
 for op in (:+, :-)
     @eval function $op(x::Furlong{p}, y::Furlong{p}) where {p}
         v = $op(x.val, y.val)


### PR DESCRIPTION
Fixes  #27141: The previous code led to under/overflow.

Before this change:

```
a = 10^10
hypot(a, a, a, a)
# ERROR: DomainError with -5.828369621610136e18:
```

After this change:

```
a = 10^10
hypot(a,a,a,a)
# 2.0e10
```