### PR TITLE
Add LinearAlgebra as test dependency to Distributed.

### DIFF
--- a/stdlib/Distributed/Project.toml
+++ b/stdlib/Distributed/Project.toml
@@ -2,12 +2,13 @@ name = "Distributed"
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [deps]
-Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["LinearAlgebra", "Test"]


### PR DESCRIPTION
```
(v1) pkg> test Distributed
   Testing Distributed
 Resolving package versions...
    Status `/tmp/tmpcorZD1/Manifest.toml`
  [2a0f44e3] Base64  [`@stdlib/Base64`]
  [8ba89e20] Distributed  [`@stdlib/Distributed`]
  [b77e0a4c] InteractiveUtils  [`@stdlib/InteractiveUtils`]
  [8f399da3] Libdl  [`@stdlib/Libdl`]
  [37e2e46d] LinearAlgebra  [`@stdlib/LinearAlgebra`]
  [56ddb016] Logging  [`@stdlib/Logging`]
  [d6f4376e] Markdown  [`@stdlib/Markdown`]
  [9a3f8284] Random  [`@stdlib/Random`]
  [9e88b42a] Serialization  [`@stdlib/Serialization`]
  [6462fe0b] Sockets  [`@stdlib/Sockets`]
  [8dfed614] Test  [`@stdlib/Test`]
   Testing Distributed tests passed
```