### PR TITLE
fix set operations on immutable sets (fix #30307)

### DIFF
--- a/base/abstractset.jl
+++ b/base/abstractset.jl
@@ -41,7 +41,7 @@ function union end
 _in(itr) = x -> x in itr
 
 union(s, sets...) = union!(emptymutable(s, promote_eltype(s, sets...)), s, sets...)
-union(s::AbstractSet) = copy(s)
+union(s::AbstractSet) = copymutable(s)
 
 const ∪ = union
 
@@ -198,7 +198,7 @@ julia> symdiff(unique([1,2,1]), unique([2, 1, 2]))
 ```
 """
 symdiff(s, sets...) = symdiff!(emptymutable(s, promote_eltype(s, sets...)), s, sets...)
-symdiff(s) = symdiff!(copy(s))
+symdiff(s) = symdiff!(copymutable(s))
 
 """
     symdiff!(s::Union{AbstractSet,AbstractVector}, itrs...)

--- a/test/sets.jl
+++ b/test/sets.jl
@@ -640,3 +640,15 @@ Base.IteratorSize(::Type{<:OpenInterval}) = Base.SizeUnknown()
     @test 3 ∈ i
     @test issubset(3, i)
 end
+
+@testset "set operations on immutable sets with one element" begin
+    # issue #30307
+    k = keys(Dict(1=>2)) # immutable set
+    m = Set(1)
+    @test union(k) == union(k, k) == m
+    @test intersect(k) == intersect(k, k) == m
+    @test setdiff(k) == m
+    @test isempty(setdiff(k, k))
+    @test symdiff(k) == m
+    @test isempty(symdiff(k, k))
+end


### PR DESCRIPTION
This is one possible fix to #30307. The problem was that `copy` was not defined on `k = keys(Dict(1=>2))`, which was the implementation of `union(::AbstractSet)`. So another fix would be to simply define this `copy` method. But I prefer here to use `copymutable` instead, as
1. `union(k)` and `union(k, k)` now return a set of the same type (`Set{Int}`)
2. `union(1:2)` returns `[1, 2]`, so there is precedent for returning a mutable copy of collections for `union` with a single argument.

The downside is that this is "breaking" for `union(s)` where `s` defines `copy` but not `copymutable` (which by default returns a `Set`). On the other hand we didn't give guaranties on the return type, so this looks fine to me (so I tentatively applied the "minor change" label to this PR).