### PR TITLE
faster circshift! for SparseMatrixCSC

### DIFF
--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -27,7 +27,7 @@ import Base: @get!, acos, acosd, acot, acotd, acsch, asech, asin, asind, asinh,
     vcat, hcat, hvcat, cat, imag, argmax, kron, length, log, log1p, max, min,
     maximum, minimum, one, promote_eltype, real, reshape, rot180,
     rotl90, rotr90, round, setindex!, similar, size, transpose,
-    vec, permute!, map, map!, Array, diff
+    vec, permute!, map, map!, Array, diff, circshift!, circshift
 
 using Random: GLOBAL_RNG, AbstractRNG, randsubseq, randsubseq!
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3514,63 +3514,38 @@ end
 
 ## circular shift
 
-# thius helper in-place swaps blocks start:split and split+1:fin in col
-function _swap!(col::AbstractVector, start::Integer, fin::Integer, split::Integer)
-    split == fin && return
-    reverse!(col, start, split)
-    reverse!(col, split + 1, fin)
-    reverse!(col, start, fin)
-    return
-end
-
-
-# this helper shifts a column by r. Used also by sparsevector.jl
-function subvector_shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Integer, m::Integer, r::Integer)
-    split = fin
-    @inbounds for j = start:fin
-        # shift in the vertical direction...
-        R[j] += r
-        if R[j] <= m
-            split = j
-        else
-            R[j] -= m
-        end
-    end
-    # ...but rowval should be sorted within columns
-    _swap!(R, start, fin, split)
-    _swap!(V, start, fin, split)
-end
-
-
 function circshift!(O::SparseMatrixCSC, X::SparseMatrixCSC, (r,c)::Base.DimsInteger{2})
     nnz = length(X.nzval)
 
-    ##### readjust output
-    resize!(O.colptr, X.n + 1)
-    resize!(O.rowval, nnz)
-    resize!(O.nzval, nnz)
-    O.colptr[X.n + 1] = nnz + 1
+    iszero(nnz) && return copy!(O, X)
 
-    nnz == 0 && return O
-
-    ##### horizontal shift
+    ##### column shift
     c = mod(c, X.n)
-    nleft = X.colptr[X.n - c + 1] - 1
-    nright = nnz - nleft
+    if iszero(c)
+        copy!(O, X)
+    else
+        ##### readjust output
+        resize!(O.colptr, X.n + 1)
+        resize!(O.rowval, nnz)
+        resize!(O.nzval, nnz)
+        O.colptr[X.n + 1] = nnz + 1
 
-    # exchange left and right blocks
-    @inbounds for i=c+1:X.n
-        O.colptr[i] = X.colptr[i-c] + nright
+        # exchange left and right blocks
+        nleft = X.colptr[X.n - c + 1] - 1
+        nright = nnz - nleft
+        @inbounds for i=c+1:X.n
+            O.colptr[i] = X.colptr[i-c] + nright
+        end
+        @inbounds for i=1:c
+            O.colptr[i] = X.colptr[X.n - c + i] - nleft
+        end
+        # rotate rowval and nzval by the right number of elements
+        circshift!(O.rowval, X.rowval, (nright,))
+        circshift!(O.nzval, X.nzval, (nright,))
     end
-    @inbounds for i=1:c
-        O.colptr[i] = X.colptr[X.n - c + i] - nleft
-    end
-    # rotate rowval and nzval by the right number of elements
-    circshift!(O.rowval, X.rowval, (nright,))
-    circshift!(O.nzval, X.nzval, (nright,))
-
-    ##### vertical shift
+    ##### row shift
     r = mod(r, X.m)
+    iszero(r) && return O
     @inbounds for i=1:O.n
         subvector_shifter!(O.rowval, O.nzval, O.colptr[i], O.colptr[i+1]-1, O.m, r)
     end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3543,12 +3543,18 @@ end
 
 
 function circshift!(O::SparseMatrixCSC, X::SparseMatrixCSC, (r,c)::Base.DimsInteger{2})
-    O .= similar(X)
+    nnz = length(X.nzval)
+
+    ##### readjust output
+    resize!(O.colptr, X.n + 1)
+    resize!(O.rowval, nnz)
+    resize!(O.nzval, nnz)
+    O.colptr[X.n + 1] = nnz + 1
+
+    nnz == 0 && return O
 
     ##### horizontal shift
     c = mod(c, X.n)
-    nnz = length(X.nzval)
-    nnz == 0 && return O
     nleft = X.colptr[X.n - c + 1] - 1
     nright = nnz - nleft
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3514,8 +3514,8 @@ end
 
 ## circular shift
 
-#swaps blocks start:split and split+1:fin in col
-function swap!(col::AbstractVector, start::Integer, fin::Integer, split::Integer)
+# thius helper in-place swaps blocks start:split and split+1:fin in col
+function _swap!(col::AbstractVector, start::Integer, fin::Integer, split::Integer)
     split == fin && return
     reverse!(col, start, split)
     reverse!(col, split + 1, fin)
@@ -3524,8 +3524,8 @@ function swap!(col::AbstractVector, start::Integer, fin::Integer, split::Integer
 end
 
 
-#this helper shifts a column by r
-function shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Integer, m::Integer, r::Integer)
+# this helper shifts a column by r. Used also by sparsevector.jl
+function subvector_shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Integer, m::Integer, r::Integer)
     split = fin
     @inbounds for j = start:fin
         # shift in the vertical direction...
@@ -3537,8 +3537,8 @@ function shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Int
         end
     end
     # ...but rowval should be sorted within columns
-    swap!(R, start, fin, split)
-    swap!(V, start, fin, split)
+    _swap!(R, start, fin, split)
+    _swap!(V, start, fin, split)
 end
 
 
@@ -3572,7 +3572,7 @@ function circshift!(O::SparseMatrixCSC, X::SparseMatrixCSC, (r,c)::Base.DimsInte
     ##### vertical shift
     r = mod(r, X.m)
     @inbounds for i=1:O.n
-        shifter!(O.rowval, O.nzval, O.colptr[i], O.colptr[i+1]-1, O.m, r)
+        subvector_shifter!(O.rowval, O.nzval, O.colptr[i], O.colptr[i+1]-1, O.m, r)
     end
     return O
 end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3566,8 +3566,8 @@ function circshift!(O::SparseMatrixCSC, X::SparseMatrixCSC, (r,c)::Base.DimsInte
         O.colptr[i] = X.colptr[X.n - c + i] - nleft
     end
     # rotate rowval and nzval by the right number of elements
-    circshift!(O.rowval, X.rowval, nright)
-    circshift!(O.nzval, X.nzval, nright)
+    circshift!(O.rowval, X.rowval, (nright,))
+    circshift!(O.nzval, X.nzval, (nright,))
 
     ##### vertical shift
     r = mod(r, X.m)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -3527,7 +3527,7 @@ end
 #this helper shifts a column by r
 function shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Integer, m::Integer, r::Integer)
     split = fin
-    for j = start:fin
+    @inbounds for j = start:fin
         # shift in the vertical direction...
         R[j] += r
         if R[j] <= m
@@ -3559,10 +3559,10 @@ function circshift!(O::SparseMatrixCSC, X::SparseMatrixCSC, (r,c)::Base.DimsInte
     nright = nnz - nleft
 
     # exchange left and right blocks
-    for i=c+1:X.n
+    @inbounds for i=c+1:X.n
         O.colptr[i] = X.colptr[i-c] + nright
     end
-    for i=1:c
+    @inbounds for i=1:c
         O.colptr[i] = X.colptr[X.n - c + i] - nleft
     end
     # rotate rowval and nzval by the right number of elements
@@ -3571,7 +3571,7 @@ function circshift!(O::SparseMatrixCSC, X::SparseMatrixCSC, (r,c)::Base.DimsInte
 
     ##### vertical shift
     r = mod(r, X.m)
-    for i=1:O.n
+    @inbounds for i=1:O.n
         shifter!(O.rowval, O.nzval, O.colptr[i], O.colptr[i+1]-1, O.m, r)
     end
     return O

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1977,8 +1977,37 @@ function fill!(A::Union{SparseVector, SparseMatrixCSC}, x)
 end
 
 
+
+# in-place swaps (dense) blocks start:split and split+1:fin in col
+function _swap!(col::AbstractVector, start::Integer, fin::Integer, split::Integer)
+    split == fin && return
+    reverse!(col, start, split)
+    reverse!(col, split + 1, fin)
+    reverse!(col, start, fin)
+    return
+end
+
+
+# in-place shifts a sparse subvector by r. Used also by sparsevector.jl
+function subvector_shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Integer, m::Integer, r::Integer)
+    split = fin
+    @inbounds for j = start:fin
+        # shift positions ...
+        R[j] += r
+        if R[j] <= m
+            split = j
+        else
+            R[j] -= m
+        end
+    end
+    # ...but rowval should be sorted within columns
+    _swap!(R, start, fin, split)
+    _swap!(V, start, fin, split)
+end
+
+
 function circshift!(O::SparseVector, X::SparseVector, (r,)::Base.DimsInteger{1})
-    O .= X
+    copy!(O, X)
     subvector_shifter!(O.nzind, O.nzval, 1, length(O.nzind), O.n, mod(r, X.n))
     return O
 end

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1975,3 +1975,13 @@ function fill!(A::Union{SparseVector, SparseMatrixCSC}, x)
     end
     return A
 end
+
+
+function circshift!(O::SparseVector, X::SparseVector, (r,)::Base.DimsInteger{1})
+    O .= X
+    shifter!(O.nzind, O.nzval, 1, length(O.nzind), O.n, mod(r, X.n))
+    return O
+end
+
+
+circshift!(O::SparseVector, X::SparseVector, r::Real,) = circshift!(O, X, (Integer(r),))

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -2007,7 +2007,7 @@ end
 
 
 function circshift!(O::SparseVector, X::SparseVector, (r,)::Base.DimsInteger{1})
-    copy!(O, X)
+    O .= X
     subvector_shifter!(O.nzind, O.nzval, 1, length(O.nzind), O.n, mod(r, X.n))
     return O
 end

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1988,7 +1988,7 @@ function _swap!(col::AbstractVector, start::Integer, fin::Integer, split::Intege
 end
 
 
-# in-place shifts a sparse subvector by r. Used also by sparsevector.jl
+# in-place shifts a sparse subvector by r. Used also by sparsematrix.jl
 function subvector_shifter!(R::AbstractVector, V::AbstractVector, start::Integer, fin::Integer, m::Integer, r::Integer)
     split = fin
     @inbounds for j = start:fin

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1979,7 +1979,7 @@ end
 
 function circshift!(O::SparseVector, X::SparseVector, (r,)::Base.DimsInteger{1})
     O .= X
-    shifter!(O.nzind, O.nzval, 1, length(O.nzind), O.n, mod(r, X.n))
+    subvector_shifter!(O.nzind, O.nzval, 1, length(O.nzind), O.n, mod(r, X.n))
     return O
 end
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2411,10 +2411,10 @@ end
 end
 
 @testset "circshift" begin
-    for i=1:20
-        m,n = 17,15
-        A = sprand(m, n, rand())
-        shifts = rand(-m:m), rand(-n:n)
+    m,n = 17,15
+    A = sprand(m, n, 0.5)
+    for rshift in (-1, 0, 1, 10), cshift in (-1, 0, 1, 10)
+        shifts = (rshift, cshift)
         # using dense circshift to compare
         B = circshift(Matrix(A), shifts)
         # sparse circshift
@@ -2434,26 +2434,6 @@ end
         circshift!(E1, A2, shifts)
         circshift!(E2, Matrix(A2), shifts)
         @test E1 == E2
-
-        # test sparse vector
-        n = 100
-        shift = rand(-n:n)
-        v = sprand(n, rand())
-        x = circshift(Vector(v), shift)
-        w = circshift(v, shift)
-        @test nnz(v) == nnz(w)
-        @test w == x
-        # test circshift!
-        v1 = similar(v)
-        circshift!(v1, v, shift)
-        @test v1 == x
-        # test different in/out types
-        y1 = spzeros(Int64, n)
-        y2 = spzeros(Int64, n)
-        v2 = floor.(100v)
-        circshift!(y1, v2, shift)
-        circshift!(y2, Vector(v2), shift)
-        @test y1 == y2
     end
 end
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2419,6 +2419,12 @@ end
     circshift!(O, A, (11,13))
     @test nnz(O) == nnz(A)
     @test O == circshift(A, (11,13))
+    v = sprand(1000, 0.2)
+    @test nnz(v) == nnz(circshift(v,13))
+    @test circshift(v, 13) == circshift(Vector(v), 13)
+    v1 = similar(v)
+    circshift!(v1, v, 100)
+    @test v1 == circshift(v, 100)
 end
 
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2408,6 +2408,17 @@ end
     @test oneunit(A) isa SparseMatrixCSC{Second}
     @test one(sprand(2, 2, 0.5)) isa SparseMatrixCSC{Float64}
     @test one(A) isa SparseMatrixCSC{Int}
+
+@testset "circshift" begin
+    A = sprand(40, 30, 0.3)
+    @test nnz(A) == nnz(circshift(A,(1,2)))
+    @test circshift(A, (3,4)) == circshift(Matrix(A), (3,4))
+    @test circshift(A, (7,-4)) == circshift(Matrix(A), (7,-4))
+    @test circshift(A, 14) == circshift(Matrix(A), 14)
+    O = similar(A)
+    circshift!(O, A, (11,13))
+    @test nnz(O) == nnz(A)
+    @test O == circshift(A, (11,13))
 end
 
 end # module

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -1265,4 +1265,26 @@ end
     end
 end
 
+@testset "SparseVector circshift" begin
+    n = 100
+    v = sprand(n, 0.5)
+    for shift in (0,-1,1,5,-7,n+10)
+        x = circshift(Vector(v), shift)
+        w = circshift(v, shift)
+        @test nnz(v) == nnz(w)
+        @test w == x
+        # test circshift!
+        v1 = similar(v)
+        circshift!(v1, v, shift)
+        @test v1 == x
+        # test different in/out types
+        y1 = spzeros(Int64, n)
+        y2 = spzeros(Int64, n)
+        v2 = floor.(100v)
+        circshift!(y1, v2, shift)
+        circshift!(y2, Vector(v2), shift)
+        @test y1 == y2
+    end
+end
+
 end # module


### PR DESCRIPTION
So this is another (much faster) version of the circshift! implementation for SparseMatrixCSC. Unfortunately, the code is much less legible than the two-liner of #30300, but

- avoids allocations ~~almost~~ completely
- has exactly two `mod` calls

In its current state, for SparseMatrixCSC matrices, it seems comparable to the dense version for small dense matrices, faster for larger ones and much much faster for both sparse and larger ones.

~~Question1: is it possible to replace the `O .= similar(X)` in the first line and just check/assert that allocated memory is compatible (i.e. colptr, rowval and nzval are of the same length and n,m are ==)?  I suppose no, because it would be a breaking change. This would avoid a double allocation in the call from circshift. Otherwise, I suppose I could move everything to a helper function and implement circshift instead of relying on the generic one. If this is the way to go, I would replace `O .= similar(X)` by just allocating the memory (no need to copy colptr and rowval)~~

EDIT: I realized that this question is kind of stupid... I just `resize!` colptr, rowval and nzval -- this does not involve allocation if they are already of the right size. It also makes things work when the output has different type than the input -- which didn't work before. I added some tests that would have catched it.

~~Question2: ~~even without `O .= similar(X)`,~~ there seems to be some very small allocation reported by `@benchmark`... I don't know where it comes from (but I may be missinterpreting).~~

I believe that this is a good improvement wrt to the current situation. The implementation is reasonably straightforward. Thoughts?

Updated benchmarks:

Summary of mean times, raw data [here](https://github.com/JuliaLang/julia/files/2660625/benchmarks.txt)



x                                    |  MASTER | BRANCH
--------------------------------|----------------|-----------------
sprand(10,10,1.0)          | 1.211 μs     | 1.218 μs
sprand(10,10,0.1)          | 789.932 ns | 765.545 ns
sprand(1000,1000,1.0)  | 71.192 ms  | 3.904 ms
sprand(1000,1000,0.1)  | 37.105 ms  | 196.435 μs
sprand(1000,1000,0.01)| 11.689 ms  | 26.761 μs


Updated benchmarks with some `@inbounds`, raw data [here](https://github.com/JuliaLang/julia/files/2663239/bench2.txt)


x                                    |  MASTER | BRANCH
--------------------------------|----------------|-----------------
sprand(10,10,1.0)          | 1.211 μs     | 1.172 μs
sprand(10,10,0.1)          | 789.932 ns | 725.866 ns
sprand(1000,1000,1.0)  | 71.192 ms  | 3.656 ms
sprand(1000,1000,0.1)  | 37.105 ms  | 167.782 μs
sprand(1000,1000,0.01)| 11.689 ms  | 20.948 μs


EDIT3: Found the solution to Question2 above: I think it the splat in the call to (dense) `circshift!` (in [multidimensional.jl):](https://github.com/JuliaLang/julia/blob/0a401f2b5dfa288e1812016b2b0311316de77697/base/multidimensional.jl#L935)

```
julia> x=rand(10); y=similar(x); @btime circshift!($y,$x,1);
  307.100 ns (3 allocations: 144 bytes)

julia> x=rand(10); y=similar(x); @btime circshift!($y,$x,(1,));
  35.272 ns (0 allocations: 0 bytes)

julia> @btime (1...,);
  263.556 ns (3 allocations: 144 bytes)
```
I thought that the temporary tuple would have been optimized out... can this be solved there? 

For the moment, I will just solve it localy. This gives a huge improvement for small matrices!

Updated benchmarks, raw data [here](https://github.com/JuliaLang/julia/files/2663513/bench3.txt)

x                                    |  MASTER | BRANCH
--------------------------------|----------------|-----------------
sprand(10,10,1.0)          | 1.211 μs     | 463.476 ns
sprand(10,10,0.1)          | 789.932 ns | 110.585 ns
sprand(1000,1000,1.0)  | 71.192 ms  | 3.669 ms
sprand(1000,1000,0.1)  | 37.105 ms  | 171.386 μs
sprand(1000,1000,0.01)| 11.689 ms  | 20.705 μs
