### PR TITLE
faster maximum, minimum (#28849)

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -464,8 +464,9 @@ function _fast(::typeof(min),x,y)
         ifelse(x < y, x, y))
 end
 
-isbadzero(::typeof(max), x) = (x == zero(x)) & signbit(x)
-isbadzero(::typeof(min), x) = (x == zero(x)) & !signbit(x)
+isbadzero(::typeof(max), x::AbstractFloat) = (x == zero(x)) & signbit(x)
+isbadzero(::typeof(min), x::AbstractFloat) = (x == zero(x)) & !signbit(x)
+isbadzero(op, x) = false
 isgoodzero(::typeof(max), x) = isbadzero(min, x)
 isgoodzero(::typeof(min), x) = isbadzero(max, x)
 

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -125,7 +125,7 @@ function _reducedim_init(f, op, fv, fop, A, region)
 end
 
 # initialization when computing minima and maxima requires a little care
-for (f1, f2, initval) in ((:min_minimum, :max_maximum, :Inf), (:max_maximum, :min_minimum, :(-Inf)))
+for (f1, f2, initval) in ((:min, :max, :Inf), (:max, :min, :(-Inf)))
     @eval function reducedim_init(f, op::typeof($f1), A::AbstractArray, region)
         # First compute the reduce indices. This will throw an ArgumentError
         # if any region is invalid
@@ -642,7 +642,7 @@ julia> any!([1 1], A)
 any!(r, A)
 
 for (fname, _fname, op) in [(:sum,     :_sum,     :add_sum), (:prod,    :_prod,    :mul_prod),
-                            (:maximum, :_maximum, :max_maximum),     (:minimum, :_minimum, :min_minimum)]
+                            (:maximum, :_maximum, :max),     (:minimum, :_minimum, :min)]
     @eval begin
         # User-facing methods with keyword arguments
         @inline ($fname)(a::AbstractArray; dims=:) = ($_fname)(a, dims)
@@ -662,7 +662,7 @@ all(f::Function, a::AbstractArray; dims=:) = _all(f, a, dims)
 _all(a, ::Colon)                           = _all(identity, a, :)
 
 for (fname, op) in [(:sum, :add_sum), (:prod, :mul_prod),
-                    (:maximum, :max_maximum), (:minimum, :min_minimum),
+                    (:maximum, :max), (:minimum, :min),
                     (:all, :&),       (:any, :|)]
     fname! = Symbol(fname, '!')
     _fname = Symbol('_', fname)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -125,7 +125,7 @@ function _reducedim_init(f, op, fv, fop, A, region)
 end
 
 # initialization when computing minima and maxima requires a little care
-for (f1, f2, initval) in ((:min, :max, :Inf), (:max, :min, :(-Inf)))
+for (f1, f2, initval) in ((:min_minimum, :max_maximum, :Inf), (:max_maximum, :min_minimum, :(-Inf)))
     @eval function reducedim_init(f, op::typeof($f1), A::AbstractArray, region)
         # First compute the reduce indices. This will throw an ArgumentError
         # if any region is invalid
@@ -642,7 +642,7 @@ julia> any!([1 1], A)
 any!(r, A)
 
 for (fname, _fname, op) in [(:sum,     :_sum,     :add_sum), (:prod,    :_prod,    :mul_prod),
-                            (:maximum, :_maximum, :max),     (:minimum, :_minimum, :min)]
+                            (:maximum, :_maximum, :max_maximum),     (:minimum, :_minimum, :min_minimum)]
     @eval begin
         # User-facing methods with keyword arguments
         @inline ($fname)(a::AbstractArray; dims=:) = ($_fname)(a, dims)
@@ -662,7 +662,7 @@ all(f::Function, a::AbstractArray; dims=:) = _all(f, a, dims)
 _all(a, ::Colon)                           = _all(identity, a, :)
 
 for (fname, op) in [(:sum, :add_sum), (:prod, :mul_prod),
-                    (:maximum, :max), (:minimum, :min),
+                    (:maximum, :max_maximum), (:minimum, :min_minimum),
                     (:all, :&),       (:any, :|)]
     fname! = Symbol(fname, '!')
     _fname = Symbol('_', fname)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -190,7 +190,9 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test isequal(extrema([NaN]), (NaN, NaN))
 
 @test isnan(maximum([NaN, 2.]))
+@test isnan(maximum([2., NaN]))
 @test isnan(minimum([NaN, 2.]))
+@test isnan(minimum([2., NaN]))
 @test isequal(extrema([NaN, 2.]), (NaN,NaN))
 
 @test isnan(maximum([NaN, 2., 3.]))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -185,6 +185,16 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test minimum([4, 3, 5, 2]) == 2
 @test extrema([4, 3, 5, 2]) == (2, 5)
 
+@testset "maximum checks all elements" begin
+    N = 1025
+    for i in 1:N
+        arr = fill(0., N)
+        truth = rand()
+        arr[i] = truth
+        @test maximum(arr) == truth
+    end
+end
+
 @test isnan(maximum([NaN]))
 @test isnan(minimum([NaN]))
 @test isequal(extrema([NaN]), (NaN, NaN))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -185,21 +185,44 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test minimum([4, 3, 5, 2]) == 2
 @test extrema([4, 3, 5, 2]) == (2, 5)
 
+@test maximum([-0.,0.]) === 0.0
+@test maximum([0.,-0.]) === 0.0
+@test maximum([0.,-0.,0.]) === 0.0
+@test minimum([-0.,0.]) === -0.0
+@test minimum([0.,-0.]) === -0.0
+@test minimum([0.,-0.,0.]) === -0.0
+
 @testset "minimum/maximum checks all elements" begin
-    N = 1025
-    for i in 1:N
-        arr = fill(0., N)
-        truth = rand()
-        arr[i] = truth
-        @test maximum(arr) == truth
+    for N in [2:20;150;300]
+        for i in 1:N
+            arr = fill(0., N)
+            truth = rand()
+            arr[i] = truth
+            @test maximum(arr) == truth
 
-        truth = -rand()
-        arr[i] = truth
-        @test minimum(arr) == truth
+            truth = -rand()
+            arr[i] = truth
+            @test minimum(arr) == truth
 
-        arr[i] = NaN
-        @test isnan(maximum(arr))
-        @test isnan(minimum(arr))
+            arr[i] = NaN
+            @test isnan(maximum(arr))
+            @test isnan(minimum(arr))
+
+            arr = zeros(N)
+            @test minimum(arr) === 0.0
+            @test maximum(arr) === 0.0
+
+            arr[i] = -0.0
+            @test minimum(arr) === -0.0
+            @test maximum(arr) ===  0.0
+
+            arr = -zeros(N)
+            @test minimum(arr) === -0.0
+            @test maximum(arr) === -0.0
+            arr[i] = 0.0
+            @test minimum(arr) === -0.0
+            @test maximum(arr) === 0.0
+        end
     end
 end
 

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -185,13 +185,21 @@ prod2(itr) = invoke(prod, Tuple{Any}, itr)
 @test minimum([4, 3, 5, 2]) == 2
 @test extrema([4, 3, 5, 2]) == (2, 5)
 
-@testset "maximum checks all elements" begin
+@testset "minimum/maximum checks all elements" begin
     N = 1025
     for i in 1:N
         arr = fill(0., N)
         truth = rand()
         arr[i] = truth
         @test maximum(arr) == truth
+
+        truth = -rand()
+        arr[i] = truth
+        @test minimum(arr) == truth
+
+        arr[i] = NaN
+        @test isnan(maximum(arr))
+        @test isnan(minimum(arr))
     end
 end
 


### PR DESCRIPTION
Borrowing an idea from @antoine-levitt https://github.com/JuliaLang/julia/issues/26003#issuecomment-364907362.
~There is one slight difference to the current `maximum/minimum` behavior. Namely `-0.0` and `0.0` are not always ordered correctly (the same thing happens with numpy.):~

## Old
```julia
julia> using BenchmarkTools; arr = randn(10^6); @benchmark maximum($arr)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     5.818 ms (0.00% GC)
  median time:      6.048 ms (0.00% GC)
  mean time:        6.054 ms (0.00% GC)
  maximum time:     6.973 ms (0.00% GC)
  --------------
  samples:          825
  evals/sample:     1
```
## Numpy
```python
In [1]: import numpy as np

In [2]: arr = np.random.randn(10**6);

In [3]: %timeit np.max(arr)
429 µs ± 2.25 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```


## ~New~
```julia
julia> using BenchmarkTools; arr = randn(10^6); @benchmark maximum($arr)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     1.215 ms (0.00% GC)
  median time:      1.264 ms (0.00% GC)
  mean time:        1.265 ms (0.00% GC)
  maximum time:     1.420 ms (0.00% GC)
  --------------
  samples:          3930
  evals/sample:     1
```

## ~New~
```julia
julia> using BenchmarkTools; arr = randn(10^6); @benchmark maximum($arr)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     909.563 μs (0.00% GC)
  median time:      937.093 μs (0.00% GC)
  mean time:        947.286 μs (0.00% GC)
  maximum time:     1.398 ms (0.00% GC)
  --------------
  samples:          5234
  evals/sample:     1
```
## New
```julia
julia> using BenchmarkTools; arr = randn(10^6); @benchmark maximum($arr)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     566.788 μs (0.00% GC)
  median time:      582.718 μs (0.00% GC)
  mean time:        590.280 μs (0.00% GC)
  maximum time:     880.178 μs (0.00% GC)
  --------------
  samples:          8369
  evals/sample:     1

```
