### PR TITLE
Allow passing a function to join

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -95,6 +95,7 @@ Standard library changes
     `--project=@.` ([#29108]).
   * The `spawn` API is now more flexible and supports taking IOBuffer directly as a I/O stream,
     converting to a system pipe as needed ([#30278]).
+  * `join` now accepts a function argument ([#TODO]).
 
 #### Dates
   * New `DateTime(::Date, ::Time)` constructor ([#29754]).

--- a/test/strings/io.jl
+++ b/test/strings/io.jl
@@ -156,6 +156,9 @@ end
     @test join(()) == ""
     @test join((), ", ") == ""
     @test join((), ", ", ", and ") == ""
+    @test join(uppercase, ["a", "b", "c"]) == "ABC"
+    @test join(abs2, 1:4, " ") == "1 4 9 16"
+    @test join(x->round(x, digits=3), [π, π, π], ' ', "... ") == "3.142 3.142... 3.142"
 end
 
 # quotes + interpolation (issue #455)


### PR DESCRIPTION
Patterns such as `join(map(uppercase, xs))` can now be written more succinctly and efficiently as `join(uppercase, xs)`. I've found myself wanting this often lately.

I've set the `!!! compat` notice to 1.1, but I can change it to 1.2 or whatever as needed.