### PR TITLE
Force specialization on the type argument of `_similar_for`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -512,10 +512,12 @@ function _collect(::Type{T}, itr, isz::SizeUnknown) where T
 end
 
 # make a collection similar to `c` and appropriate for collecting `itr`
-_similar_for(c::AbstractArray, T, itr, ::SizeUnknown) = similar(c, T, 0)
-_similar_for(c::AbstractArray, T, itr, ::HasLength) = similar(c, T, Int(length(itr)::Integer))
-_similar_for(c::AbstractArray, T, itr, ::HasShape) = similar(c, T, axes(itr))
-_similar_for(c, T, itr, isz) = similar(c, T)
+_similar_for(c::AbstractArray, ::Type{T}, itr, ::SizeUnknown) where {T} = similar(c, T, 0)
+_similar_for(c::AbstractArray, ::Type{T}, itr, ::HasLength) where {T} =
+    similar(c, T, Int(length(itr)::Integer))
+_similar_for(c::AbstractArray, ::Type{T}, itr, ::HasShape) where {T} =
+    similar(c, T, axes(itr))
+_similar_for(c, ::Type{T}, itr, isz) where {T} = similar(c, T)
 
 """
     collect(collection)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -760,4 +760,5 @@ isempty(t::ImmutableDict) = !isdefined(t, :parent)
 empty(::ImmutableDict, ::Type{K}, ::Type{V}) where {K, V} = ImmutableDict{K,V}()
 
 _similar_for(c::Dict, ::Type{Pair{K,V}}, itr, isz) where {K, V} = empty(c, K, V)
-_similar_for(c::AbstractDict, T, itr, isz) = throw(ArgumentError("for AbstractDicts, similar requires an element type of Pair;\n  if calling map, consider a comprehension instead"))
+_similar_for(c::AbstractDict, ::Type{T}, itr, isz) where {T} =
+    throw(ArgumentError("for AbstractDicts, similar requires an element type of Pair;\n  if calling map, consider a comprehension instead"))

--- a/base/set.jl
+++ b/base/set.jl
@@ -34,7 +34,7 @@ empty(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 # by default, a Set is returned
 emptymutable(s::AbstractSet{T}, ::Type{U}=T) where {T,U} = Set{U}()
 
-_similar_for(c::AbstractSet, T, itr, isz) = empty(c, T)
+_similar_for(c::AbstractSet, ::Type{T}, itr, isz) where {T} = empty(c, T)
 
 function show(io::IO, s::Set)
     print(io, "Set(")


### PR DESCRIPTION
Looking into the `["misc", "iterators", "zip(1:1, 1:1, 1:1, 1:1)"] ` regression reported in https://github.com/JuliaLang/julia/pull/30218#issuecomment-443746637, it looks like #28284 pushed the `HasShape` method of `_similar_for` beyond the inlining threshold for that case, causing the regression. Adding a `@_meta_inline` would directly combat that, but forcing specialization on the type argument is less invasive and still restores performance:
```julia
julia> for N in (1,1000), M in (1,2,3,4)
           @btime collect(zip($(Iterators.repeated(1:N, M)...,)...))
       end
# master
  30.213 ns (1 allocation: 96 bytes)
  32.706 ns (1 allocation: 96 bytes)
  38.512 ns (1 allocation: 112 bytes)
  130.325 ns (5 allocations: 272 bytes)
  1.069 μs (1 allocation: 7.94 KiB)
  1.753 μs (1 allocation: 15.75 KiB)
  2.367 μs (2 allocations: 23.52 KiB)
  3.187 μs (6 allocations: 31.48 KiB)
# this PR
  30.425 ns (1 allocation: 96 bytes)
  32.565 ns (1 allocation: 96 bytes)
  37.667 ns (1 allocation: 112 bytes)
  42.188 ns (1 allocation: 112 bytes)
  1.048 μs (1 allocation: 7.94 KiB)
  1.781 μs (1 allocation: 15.75 KiB)
  2.359 μs (2 allocations: 23.52 KiB)
  2.837 μs (2 allocations: 31.33 KiB)
```

I hope @nanosoldier `runbenchmarks(ALL, vs = ":master")` agrees. In that case, I guess we want this on 1.1 as well.

I vaguely remember having noticed this when working on #29238 but decided it was an orthogonal change to be done in a separate PR and then forgot about it...