### PR TITLE
Add missing checkbounds method and tests

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -185,7 +185,7 @@ end
 checkbounds(::Type{Bool}, s::AbstractString, i::Integer) =
     1 ≤ i ≤ ncodeunits(s)
 checkbounds(::Type{Bool}, s::AbstractString, i::Real) =
-    1 ≤ i ≤ ncodeunits(s)
+    isinteger(i) && 1 ≤ i ≤ ncodeunits(s)
 checkbounds(::Type{Bool}, s::AbstractString, r::AbstractRange{<:Integer}) =
     isempty(r) || (1 ≤ minimum(r) && maximum(r) ≤ ncodeunits(s))
 checkbounds(::Type{Bool}, s::AbstractString, I::AbstractArray{<:Real}) =

--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -184,6 +184,8 @@ end
 
 checkbounds(::Type{Bool}, s::AbstractString, i::Integer) =
     1 ≤ i ≤ ncodeunits(s)
+checkbounds(::Type{Bool}, s::AbstractString, i::Real) =
+    1 ≤ i ≤ ncodeunits(s)
 checkbounds(::Type{Bool}, s::AbstractString, r::AbstractRange{<:Integer}) =
     isempty(r) || (1 ≤ minimum(r) && maximum(r) ≤ ncodeunits(s))
 checkbounds(::Type{Bool}, s::AbstractString, I::AbstractArray{<:Real}) =

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -177,6 +177,7 @@ end
 
 @testset "issue #7248" begin
     @test_throws BoundsError length("hello", 1, -1)
+    @test_throws BoundsError length("hello", Int8(1), Int8(-1))
     @test_throws BoundsError prevind("hello", 0, 1)
     @test_throws BoundsError length("hellø", 1, -1)
     @test_throws BoundsError prevind("hellø", 0, 1)
@@ -204,6 +205,7 @@ end
     @test checkbounds(Bool, "hello", 1:6) === false
     @test checkbounds(Bool, "hello", 1:5) === true
     @test checkbounds(Bool, "hello", [0:5;]) === false
+    @test checkbounds(Bool, "hello", [0.0:5.0;]) === false
     @test checkbounds(Bool, "hello", [1:6;]) === false
     @test checkbounds(Bool, "hello", [1:5;]) === true
 end


### PR DESCRIPTION
With an `AbstractArray` of `Real`s, the method would fail because
we had no `checkbounds` for a single index of `Real` (but maybe
not `Integer`) type.