### PR TITLE
slow unidimensional circshift on dense (small) vectors

### DIFF
--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -932,7 +932,10 @@ See also [`circshift`](@ref).
     axes(dest) == inds || throw(ArgumentError("indices of src and dest must match (got $inds and $(axes(dest)))"))
     _circshift!(dest, (), src, (), inds, fill_to_length(shiftamt, 0, Val(N)))
 end
-circshift!(dest::AbstractArray, src, shiftamt) = circshift!(dest, src, (shiftamt...,))
+
+_circshift_helper!(dest::AbstractArray, src, shiftamt) = circshift!(dest, src, (shiftamt...,))
+_circshift_helper!(dest::AbstractArray, src, shiftamt::Integer) = circshift!(dest, src, (shiftamt,))
+circshift!(dest::AbstractArray, src, shiftamt) = _circshift_helper!(dest, src, shiftamt)
 
 # For each dimension, we copy the first half of src to the second half
 # of dest, and the second half of src to the first half of dest. This


### PR DESCRIPTION
on master: 

```
julia> x=rand(10);y=similar(x);

julia> @benchmark circshift!($y,$x,1)

BenchmarkTools.Trial: 
  memory estimate:  144 bytes
  allocs estimate:  3
  --------------
  minimum time:     785.802 ns (0.00% GC)
  median time:      795.614 ns (0.00% GC)
  mean time:        927.788 ns (8.73% GC)
  maximum time:     609.764 μs (99.84% GC)
  --------------
  samples:          10000
  evals/sample:     101

julia> @benchmark circshift!($y,$x,(1,))

BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     60.283 ns (0.00% GC)
  median time:      61.008 ns (0.00% GC)
  mean time:        63.170 ns (0.00% GC)
  maximum time:     516.131 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     982

```
(note the allocations in the first case). With this minimal PR:

```
1.1.0-DEV.841> @benchmark circshift!($y,$x,1)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     65.270 ns (0.00% GC)
  median time:      67.583 ns (0.00% GC)
  mean time:        68.780 ns (0.00% GC)
  maximum time:     240.412 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     981

```

Are there ill effects of the patch? As I see it, enlargement of tuples is already treated separately, so the only remaining case is single integer to tuple, so it seems that there is no need for the splat.

This was hurting #30317, by the way. (Now it's better than in master even for dense matrices in sparse representation)