### PR TITLE
Allow dotted binary tilde

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ New language features
     the experimental function `Base.catch_stack` ([#28878]).
   * The experimental macro `Base.@locals` returns a dictionary of current local variable names
     and values ([#29733]).
+  * Binary `~` can now be dotted, as in `x .~ y` ([#30341]).
 
 Language changes
 ----------------

--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -8,7 +8,8 @@
 ;; be an operator.
 (define prec-assignment
   (append! (add-dots '(= += -= *= /= //= |\\=| ^= ÷= %= <<= >>= >>>= |\|=| &= ⊻= ≔ ⩴ ≕))
-           '(:= ~ $=)))
+           (add-dots '(~))
+           '(:= $=)))
 ;; comma - higher than assignment outside parentheses, lower when inside
 (define prec-pair (add-dots '(=>)))
 (define prec-conditional '(?))
@@ -742,7 +743,7 @@
         ex
         (begin
           (take-token s)
-          (cond ((eq? t '~) ;; ~ is the only non-syntactic assignment-precedence operators
+          (cond ((or (eq? t '~) (eq? t '|.~|)) ;; ~ is the only non-syntactic assignment-precedence operators
                  (if (and space-sensitive (ts:space? s)
                           (not (space-before-next-token? s)))
                      (begin (ts:put-back! s t (ts:space? s))

--- a/test/parse.jl
+++ b/test/parse.jl
@@ -332,3 +332,9 @@ end
     @test_throws ArgumentError parse(Bool, "2")
     @test_throws ArgumentError parse(Bool, "02")
 end
+
+@testset "issue #30341" begin
+    @test Meta.parse("x .~ y") == Expr(:call, :.~, :x, :y)
+    # Ensure dotting binary doesn't break dotting unary
+    @test Meta.parse(".~[1,2]") == Expr(:call, :.~, Expr(:vect, 1, 2))
+end


### PR DESCRIPTION
The expression `x .~ y` now parses. Currently it's a syntax error.

Fixes #30341.