### PR TITLE
workaround for F_DUPFD_CLOEXEC on Linux kernel <2.6.24 before it existed

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -345,8 +345,15 @@ int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
 }
 #else
 int uv_dup(uv_os_fd_t fd, uv_os_fd_t* dupfd) {
+// F_DUPFD_CLOEXEC only available since Linux 2.6.24
+#ifdef F_DUPFD_CLOEXEC
     if ((*dupfd = fcntl(fd, F_DUPFD_CLOEXEC, 3)) == -1)
         return -errno;
+#else
+    if ((*dupfd = fcntl(fd, F_DUPFD, 3)) == -1)
+        return -errno;
+    fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
     return 0;
 }
 #endif


### PR DESCRIPTION
As per http://man7.org/linux/man-pages/man2/fcntl.2.html, the `F_DUPFD_CLOEXEC` flag was only introduced in Linux 2.6.24. Before that, my reading is that its equivalent to an `F_DUPFD` then setting `FD_CLOEXEC`, although slightly worse bc of the possibility of a race condition, but it seems to work fine. 

Anyway, this change was the only thing standing between me and compiling Julia on a 2.6.16 kernel, everything else works great. Of course this is an ancient kernel, but its a what's on a legacy cluster that's actually got quite alot of nodes. I figured other people in similar situations could benefit and the code change isn't too huge. That said, completely understand if there's no interest in supporting that old of a system, in which case feel free to close the PR. 