### PR TITLE
Add compat annotation for NaN handling in (l|r)mul!

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -34,12 +34,12 @@ mul!(C::AbstractArray, X::AbstractArray, s::Number) = generic_mul!(C, s, X)
 Scale an array `A` by a scalar `b` overwriting `A` in-place.  Use
 [`lmul!`](@ref) to multiply scalar from left.  The scaling operation
 respects the semantics of the multiplication [`*`](@ref) between an
-element of `A` and `b`.  In particular, `NaN` entries in `A` are not
-modified (unless the type of `b` defines a non-standard behavior).
+element of `A` and `b`.  In particular, this also applies to
+multiplication involving non-finite numbers such as `NaN` and `±Inf`.
 
 !!! compat "Julia 1.1"
-    Prior to Julia 1.1, how `NaN` entries in `A` were treated was
-    inconsistent.  As of Julia 1.1 `NaN` entries are unmodified.
+    Prior to Julia 1.1, `NaN` and `±Inf` entries in `A` were treated
+    inconsistently.
 
 # Examples
 ```jldoctest
@@ -68,12 +68,12 @@ end
 Scale an array `B` by a scalar `a` overwriting `B` in-place.  Use
 [`rmul!`](@ref) to multiply scalar from right.  The scaling operation
 respects the semantics of the multiplication [`*`](@ref) between `a`
-and an element of `B`.  In particular, `NaN` entries in `B` are not
-modified (unless the type of `a` defines a non-standard behavior).
+and an element of `B`.  In particular, this also applies to
+multiplication involving non-finite numbers such as `NaN` and `±Inf`.
 
 !!! compat "Julia 1.1"
-    Prior to Julia 1.1, how `NaN` entries in `B` were treated was
-    inconsistent.  As of Julia 1.1 `NaN` entries are unmodified.
+    Prior to Julia 1.1, `NaN` and `±Inf` entries in `B` were treated
+    inconsistently.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -52,6 +52,10 @@ julia> rmul!(A, 2)
 2×2 Array{Int64,2}:
  2  4
  6  8
+
+julia> rmul!([NaN], 0.0)
+1-element Array{Float64,1}:
+ NaN
 ```
 """
 function rmul!(X::AbstractArray, s::Number)
@@ -86,6 +90,10 @@ julia> lmul!(2, B)
 2×2 Array{Int64,2}:
  2  4
  6  8
+
+julia> lmul!(0.0, [Inf])
+1-element Array{Float64,1}:
+ NaN
 ```
 """
 function lmul!(s::Number, X::AbstractArray)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -31,7 +31,15 @@ mul!(C::AbstractArray, X::AbstractArray, s::Number) = generic_mul!(C, s, X)
 """
     rmul!(A::AbstractArray, b::Number)
 
-Scale an array `A` by a scalar `b` overwriting `A` in-place.
+Scale an array `A` by a scalar `b` overwriting `A` in-place.  Use
+[`lmul!`](@ref) to multiply scalar from left.  The scaling operation
+respects the semantics of the element-wise multiplication.  In
+particular, `NaN` entries in `A` are not modified (unless the type of
+`b` defines a specific behavior).
+
+!!! compat "Julia 1.1"
+    Prior to Julia 1.1, how `NaN` entries in `A` were treated was
+    inconsistent.  As of Julia 1.1 `NaN` entries are unmodified.
 
 # Examples
 ```jldoctest
@@ -57,7 +65,15 @@ end
 """
     lmul!(a::Number, B::AbstractArray)
 
-Scale an array `B` by a scalar `a` overwriting `B` in-place.
+Scale an array `B` by a scalar `a` overwriting `B` in-place.  Use
+[`rmul!`](@ref) to multiply scalar from right.  The scaling operation
+respects the semantics of the element-wise multiplication.  In
+particular, `NaN` entries in `B` are not modified (unless the type of
+`a` defines a specific behavior).
+
+!!! compat "Julia 1.1"
+    Prior to Julia 1.1, how `NaN` entries in `B` were treated was
+    inconsistent.  As of Julia 1.1 `NaN` entries are unmodified.
 
 # Examples
 ```jldoctest

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -33,9 +33,9 @@ mul!(C::AbstractArray, X::AbstractArray, s::Number) = generic_mul!(C, s, X)
 
 Scale an array `A` by a scalar `b` overwriting `A` in-place.  Use
 [`lmul!`](@ref) to multiply scalar from left.  The scaling operation
-respects the semantics of the element-wise multiplication.  In
-particular, `NaN` entries in `A` are not modified (unless the type of
-`b` defines a specific behavior).
+respects the semantics of the multiplication [`*`](@ref) between an
+element of `A` and `b`.  In particular, `NaN` entries in `A` are not
+modified (unless the type of `b` defines a non-standard behavior).
 
 !!! compat "Julia 1.1"
     Prior to Julia 1.1, how `NaN` entries in `A` were treated was
@@ -67,9 +67,9 @@ end
 
 Scale an array `B` by a scalar `a` overwriting `B` in-place.  Use
 [`rmul!`](@ref) to multiply scalar from right.  The scaling operation
-respects the semantics of the element-wise multiplication.  In
-particular, `NaN` entries in `B` are not modified (unless the type of
-`a` defines a specific behavior).
+respects the semantics of the multiplication [`*`](@ref) between `a`
+and an element of `B`.  In particular, `NaN` entries in `B` are not
+modified (unless the type of `a` defines a non-standard behavior).
 
 !!! compat "Julia 1.1"
     Prior to Julia 1.1, how `NaN` entries in `B` were treated was

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -389,4 +389,16 @@ end
     @test LinearAlgebra.peakflops() > 0
 end
 
+@testset "NaN handling: Issue 28972" begin
+    @test all(isnan, rmul!([NaN], 0.0))
+    @test all(isnan, rmul!(Any[NaN], 0.0))
+    @test all(isnan, lmul!(0.0, [NaN]))
+    @test all(isnan, lmul!(0.0, Any[NaN]))
+
+    @test all(!isnan, rmul!([NaN], false))
+    @test all(!isnan, rmul!(Any[NaN], false))
+    @test all(!isnan, lmul!(false, [NaN]))
+    @test all(!isnan, lmul!(false, Any[NaN]))
+end
+
 end # module TestGeneric


### PR DESCRIPTION
As discussed in JuliaLang/LinearAlgebra.jl#560, the behavior of `lmul!` and `rmul!` was changed between 1.0 and 1.1.  I think issue JuliaLang/LinearAlgebra.jl#560 should be treated as an API documentation bug (and I think it would be nice if similar issues are closed by PRs addressing the issue).  This PR adds docstring to elaborate the API of those functions and adds compat annotation for the incompatible change.