### PR TITLE
Fix reinterpret for 0-dimensional arrays

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -33,8 +33,8 @@ struct ReinterpretArray{T,N,S,A<:AbstractArray{S, N}} <: AbstractArray{T, N}
         isbitstype(T) || throwbits(S, T, T)
         isbitstype(S) || throwbits(S, T, S)
         (N != 0 || sizeof(T) == sizeof(S)) || throwsize0(S, T)
-        ax1 = axes(a)[1]
         if N != 0 && sizeof(S) != sizeof(T)
+            ax1 = axes(a)[1]
             dim = length(ax1)
             rem(dim*sizeof(S),sizeof(T)) == 0 || thrownonint(S, T, dim)
             first(ax1) == 1 || throwaxes1(S, T, ax1)
@@ -74,6 +74,7 @@ function size(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     size1 = div(psize[1]*sizeof(S), sizeof(T))
     tuple(size1, tail(psize)...)
 end
+size(a::ReinterpretArray{T,0}) where {T} = ()
 
 function axes(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     paxs = axes(a.parent)
@@ -81,6 +82,7 @@ function axes(a::ReinterpretArray{T,N,S} where {N}) where {T,S}
     size1 = div(l*sizeof(S), sizeof(T))
     tuple(oftype(paxs[1], f:f+size1-1), tail(paxs)...)
 end
+axes(a::ReinterpretArray{T,0}) where {T} = ()
 
 elsize(::Type{<:ReinterpretArray{T}}) where {T} = sizeof(T)
 unsafe_convert(::Type{Ptr{T}}, a::ReinterpretArray{T,N,S} where N) where {T,S} = Ptr{T}(unsafe_convert(Ptr{S},a.parent))

--- a/test/reinterpretarray.jl
+++ b/test/reinterpretarray.jl
@@ -160,3 +160,12 @@ let a = [0.1 0.2; 0.3 0.4], at = reshape([(i,i+1) for i = 1:2:8], 2, 2)
     r = reinterpret(Int, vt)
     @test r == OffsetArray(reshape(1:8, 2, 2, 2), (0, offsetvt...))
 end
+
+# Test 0-dimensional Arrays
+A = zeros(UInt32)
+B = reinterpret(Int32,A)
+@test size(B) == ()
+@test axes(B) == ()
+B[] = Int32(5)
+@test B[] === Int32(5)
+@test A[] === UInt32(5)


### PR DESCRIPTION
On current master `reinterpret` is broken for 0-dimensional arrays, e.g. `reinterpret(Int32,zeros(UInt32))` throws an error. This should be fixed by this PR. 