### PR TITLE
coverage: support output in LCOV tracefile format

### DIFF
--- a/base/options.jl
+++ b/base/options.jl
@@ -39,6 +39,7 @@ struct JLOptions
     outputjitbc::Ptr{UInt8}
     outputo::Ptr{UInt8}
     outputji::Ptr{UInt8}
+    output_code_coverage::Ptr{UInt8}
     incremental::Int8
 end
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1810,6 +1810,7 @@ typedef struct {
     const char *outputjitbc;
     const char *outputo;
     const char *outputji;
+    const char *output_code_coverage;
     int8_t incremental;
     int8_t image_file_specified;
 } jl_options_t;
@@ -1820,6 +1821,7 @@ JL_DLLEXPORT ssize_t jl_sizeof_jl_options(void);
 // Parse an argc/argv pair to extract general julia options, passing back out
 // any arguments that should be passed on to the script.
 JL_DLLEXPORT void jl_parse_opts(int *argcp, char ***argvp);
+JL_DLLEXPORT char *jl_format_filename(const char *output_pattern);
 
 // Set julia-level ARGS array according to the arguments provided in
 // argc/argv

--- a/src/processor.cpp
+++ b/src/processor.cpp
@@ -2,6 +2,10 @@
 
 // Processor feature detection
 
+#include "llvm-version.h"
+#include <llvm/ADT/StringRef.h>
+#include <llvm/Support/MathExtras.h>
+
 #include "processor.h"
 
 #include "julia.h"
@@ -9,10 +13,6 @@
 
 #include <map>
 #include <algorithm>
-
-#include "llvm-version.h"
-#include <llvm/ADT/StringRef.h>
-#include <llvm/Support/MathExtras.h>
 
 #include "julia_assert.h"
 

--- a/src/processor.h
+++ b/src/processor.h
@@ -208,4 +208,5 @@ struct jl_target_spec_t {
 std::vector<jl_target_spec_t> jl_get_llvm_clone_targets(void);
 std::string jl_get_cpu_name_llvm(void);
 std::string jl_get_cpu_features_llvm(void);
+std::string jl_format_filename(llvm::StringRef output_pattern);
 #endif

--- a/src/runtime_ccall.cpp
+++ b/src/runtime_ccall.cpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <cstdio>
 #include <llvm/Support/Host.h>
+#include <llvm/Support/raw_ostream.h>
+
 #include "julia.h"
 #include "julia_internal.h"
 #include "processor.h"
@@ -105,6 +107,85 @@ jl_value_t *jl_get_JIT(void)
 {
     const std::string& HostJITName = "ORCJIT";
     return jl_pchar_to_string(HostJITName.data(), HostJITName.size());
+}
+
+#ifndef MAXHOSTNAMELEN
+# define MAXHOSTNAMELEN 256
+#endif
+
+extern "C" int jl_getpid();
+
+// Form a file name from a pattern made by replacing tokens,
+// similar to many of those provided by ssh_config TOKENS:
+//
+//           %%    A literal `%'.
+//           %p    The process PID
+//           %d    Local user's home directory.
+//           %i    The local user ID.
+//           %L    The local hostname.
+//           %l    The local hostname, including the domain name.
+//           %u    The local username.
+std::string jl_format_filename(StringRef output_pattern)
+{
+    std::string buf;
+    llvm::raw_string_ostream outfile(buf);
+    bool special = false;
+    char hostname[MAXHOSTNAMELEN + 1];
+    uv_passwd_t pwd;
+    bool got_pwd = false;
+    for (auto c : output_pattern) {
+        if (special) {
+            if (!got_pwd && (c == 'i' || c == 'd' || c == 'u')) {
+                uv_os_get_passwd(&pwd);
+                got_pwd = true;
+            }
+            switch (c) {
+            case 'p':
+                outfile << jl_getpid();
+                break;
+            case 'd':
+                outfile << pwd.homedir;
+                break;
+            case 'i':
+                outfile << pwd.uid;
+                break;
+            case 'l':
+            case 'L':
+                if (gethostname(hostname, sizeof(hostname)) == 0) {
+                    hostname[sizeof(hostname) - 1] = '\0'; /* Null terminate, just to be safe. */
+                    outfile << hostname;
+                }
+#ifndef _OS_WINDOWS_
+                if (c == 'l' && getdomainname(hostname, sizeof(hostname)) == 0) {
+                    hostname[sizeof(hostname) - 1] = '\0'; /* Null terminate, just to be safe. */
+                    outfile << hostname;
+                }
+#endif
+                break;
+            case 'u':
+                outfile << pwd.username;
+                break;
+            default:
+                outfile << c;
+                break;
+            }
+            special = false;
+        }
+        else if (c == '%') {
+            special = true;
+        }
+        else {
+            outfile << c;
+        }
+    }
+    if (got_pwd)
+        uv_os_free_passwd(&pwd);
+    return outfile.str();
+}
+
+extern "C" JL_DLLEXPORT char *jl_format_filename(const char *output_pattern)
+{
+    return strdup(jl_format_filename(StringRef(output_pattern)).c_str());
 }
 
 

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -24,8 +24,27 @@ function readchomperrors(exename::Cmd)
     return (success(p), fetch(o), fetch(e))
 end
 
+function format_filename(s)
+    p = ccall(:jl_format_filename, Cstring, (Cstring,), s)
+    r = unsafe_string(p)
+    ccall(:free, Cvoid, (Cstring,), p)
+    return r
+end
 
-let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
+let
+    fn = format_filename("a%d %p %i %L %l %u z")
+    hd = withenv("HOME" => nothing) do
+        homedir()
+    end
+    @test startswith(fn, "a$hd ")
+    @test endswith(fn, " z")
+    @test !occursin('%', fn)
+    @test occursin(" $(getpid()) ", fn)
+    @test occursin(" $(Libc.gethostname()) ", fn)
+    @test format_filename("%a%%b") == "a%b"
+end
+
+let exename = `$(Base.julia_cmd()) --startup-file=no`
     # tests for handling of ENV errors
     let v = writereadpipeline("println(\"REPL: \", @which(less), @isdefined(InteractiveUtils))",
                 setenv(`$exename -i -E 'empty!(LOAD_PATH); @isdefined InteractiveUtils'`,
@@ -65,7 +84,7 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     end
 end
 
-let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
+let exename = `$(Base.julia_cmd()) --startup-file=no`
     # --version
     let v = split(read(`$exename -v`, String), "julia version ")[end]
         @test Base.VERSION_STRING == chomp(v)
@@ -186,14 +205,40 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     @test !success(`$exename --history-file=false`)
 
     # --code-coverage
-    @test readchomp(`$exename -E "Bool(Base.JLOptions().code_coverage)"`) == "false"
-    @test readchomp(`$exename -E "Bool(Base.JLOptions().code_coverage)"
-        --code-coverage=none`) == "false"
-
-    @test readchomp(`$exename -E "Bool(Base.JLOptions().code_coverage)"
-        --code-coverage`) == "true"
-    @test readchomp(`$exename -E "Bool(Base.JLOptions().code_coverage)"
-        --code-coverage=user`) == "true"
+    mktempdir() do dir
+        helperdir = joinpath(@__DIR__, "testhelpers")
+        inputfile = joinpath(helperdir, "coverage_file.jl")
+        expected = replace(read(joinpath(helperdir, "coverage_file.info"), String),
+            "<FILENAME>" => inputfile)
+        covfile = replace(joinpath(dir, "coverage.info"), "%" => "%%")
+        @test !isfile(covfile)
+        defaultcov = readchomp(`$exename -E "Bool(Base.JLOptions().code_coverage)" -L $inputfile`)
+        opts = Base.JLOptions()
+        coverage_file = (opts.output_code_coverage != C_NULL) ?  unsafe_string(opts.output_code_coverage) : ""
+        @test !isfile(covfile)
+        @test defaultcov == string(opts.code_coverage != 0 && (isempty(coverage_file) || occursin("%p", coverage_file)))
+        @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
+            --code-coverage=$covfile --code-coverage=none`) == "0"
+        @test !isfile(covfile)
+        @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
+            --code-coverage=$covfile --code-coverage`) == "1"
+        @test isfile(covfile)
+        got = read(covfile, String)
+        @test occursin(expected, got) || got
+        rm(covfile)
+        @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
+            --code-coverage=$covfile --code-coverage=user`) == "1"
+        @test isfile(covfile)
+        got = read(covfile, String)
+        @test occursin(expected, got) || got
+        rm(covfile)
+        @test readchomp(`$exename -E "Base.JLOptions().code_coverage" -L $inputfile
+            --code-coverage=$covfile --code-coverage=all`) == "2"
+        @test isfile(covfile)
+        got = read(covfile, String)
+        @test occursin(expected, got) || got
+        rm(covfile)
+    end
 
     # --track-allocation
     @test readchomp(`$exename -E "Bool(Base.JLOptions().malloc_log)"`) == "false"
@@ -242,11 +287,13 @@ let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes --startup-file=no`
     let JL_OPTIONS_CHECK_BOUNDS_DEFAULT = 0,
         JL_OPTIONS_CHECK_BOUNDS_ON = 1,
         JL_OPTIONS_CHECK_BOUNDS_OFF = 2
-        @test parse(Int,readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"`)) ==
+        exename_default_checkbounds = `$exename`
+        filter!(a -> !startswith(a, "--check-bounds="), exename_default_checkbounds.exec)
+        @test parse(Int, readchomp(`$exename_default_checkbounds -E "Int(Base.JLOptions().check_bounds)"`)) ==
             JL_OPTIONS_CHECK_BOUNDS_DEFAULT
-        @test parse(Int,readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
+        @test parse(Int, readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
             --check-bounds=yes`)) == JL_OPTIONS_CHECK_BOUNDS_ON
-        @test parse(Int,readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
+        @test parse(Int, readchomp(`$exename -E "Int(Base.JLOptions().check_bounds)"
             --check-bounds=no`)) == JL_OPTIONS_CHECK_BOUNDS_OFF
     end
     # check-bounds takes yes/no as argument
@@ -436,7 +483,7 @@ end
 libjulia = abspath(Libdl.dlpath((ccall(:jl_is_debugbuild, Cint, ()) != 0) ? "libjulia-debug" : "libjulia"))
 
 # test error handling code paths of running --sysimage
-let exename = joinpath(Sys.BINDIR, Base.julia_exename()),
+let exename = Base.julia_cmd()
     sysname = unsafe_string(Base.JLOptions().image_file)
     for nonexist_image in (
             joinpath(@__DIR__, "nonexistent"),
@@ -467,7 +514,7 @@ let exename = joinpath(Sys.BINDIR, Base.julia_exename()),
     end
 end
 
-let exename = `$(Base.julia_cmd()) --sysimage-native-code=yes`
+let exename = Base.julia_cmd()
     # --startup-file
     let JL_OPTIONS_STARTUPFILE_ON = 1,
         JL_OPTIONS_STARTUPFILE_OFF = 2
@@ -563,6 +610,12 @@ end
 
 # Issue #29855
 for yn in ("no", "yes")
-    exename = `$(Base.julia_cmd()) --startup-file=no --inline=$yn`
-    @test occursin("--inline=$yn", first(writereadpipeline("Base.julia_cmd()", exename)))
+    exename = `$(Base.julia_cmd()) --inline=no --startup-file=no --inline=$yn`
+    v = writereadpipeline("Base.julia_cmd()", exename)
+    if yn == "no"
+        @test occursin(r" --inline=no", v[1])
+    else
+        @test !occursin(" --inline", v[1])
+    end
+    @test v[2]
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -527,11 +527,7 @@ end
 # Sys.which() testing
 psep = if Sys.iswindows() ";" else ":" end
 withenv("PATH" => "$(Sys.BINDIR)$(psep)$(ENV["PATH"])") do
-    julia_exe = joinpath(Sys.BINDIR, "julia")
-    if Sys.iswindows()
-        julia_exe *= ".exe"
-    end
-
+    julia_exe = joinpath(Sys.BINDIR, Base.julia_exename())
     @test Sys.which("julia") == realpath(julia_exe)
     @test Sys.which(julia_exe) == realpath(julia_exe)
 end

--- a/test/testenv.jl
+++ b/test/testenv.jl
@@ -10,20 +10,20 @@ if !@isdefined(testenv_defined)
     if haskey(ENV, "JULIA_TEST_EXEFLAGS")
         const test_exeflags = `$(Base.shell_split(ENV["JULIA_TEST_EXEFLAGS"]))`
     else
-        inline_flag = Base.JLOptions().can_inline == 1 ? `` : `--inline=no`
-        cov_flag = ``
-        if Base.JLOptions().code_coverage == 1
-            cov_flag = `--code-coverage=user`
-        elseif Base.JLOptions().code_coverage == 2
-            cov_flag = `--code-coverage=all`
+        const test_exeflags = Base.julia_cmd()
+        filter!(test_exeflags.exec) do c
+            return !(startswith(c, "--depwarn") || startswith(c, "--check-bounds"))
         end
-        const test_exeflags = `$cov_flag $inline_flag --check-bounds=yes --startup-file=no --depwarn=error`
+        push!(test_exeflags.exec, "--check-bounds=yes")
+        push!(test_exeflags.exec, "--startup-file=no")
+        push!(test_exeflags.exec, "--depwarn=error")
     end
 
     if haskey(ENV, "JULIA_TEST_EXENAME")
+        popfirst!(test_exeflags.exec)
         const test_exename = `$(Base.shell_split(ENV["JULIA_TEST_EXENAME"]))`
     else
-        const test_exename = `$(joinpath(Sys.BINDIR, Base.julia_exename()))`
+        const test_exename = popfirst!(test_exeflags.exec)
     end
 
     addprocs_with_testenv(X; kwargs...) = addprocs(X; exename=test_exename, exeflags=test_exeflags, kwargs...)

--- a/test/testhelpers/coverage_file.info
+++ b/test/testhelpers/coverage_file.info
@@ -1,0 +1,10 @@
+SF:<FILENAME>
+DA:4,2
+DA:5,0
+DA:7,1
+DA:8,1
+DA:9,5
+DA:11,1
+LH:5
+LF:6
+end_of_record

--- a/test/testhelpers/coverage_file.jl
+++ b/test/testhelpers/coverage_file.jl
@@ -1,0 +1,17 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+function code_coverage_test()
+    if rand(1:2) == 3
+        return "hello"
+    else
+        r = Int[]
+        for i = 1:3
+            push!(r, i)
+        end
+        return r
+    end
+end
+
+exit(code_coverage_test() == [1, 2, 3] ? 0 : 1)
+
+# end of file


### PR DESCRIPTION
Since Base code-coverage has been broken for stdlibs for a long time, this adds support for a format that doesn't share the same problems. This'll also allow us to adopt the newly-added code-caches for coverage, and to add handling of them to [Coverage.jl](https://github.com/JuliaCI/Coverage.jl) similar to that already present in [Revise.jl](https://github.com/timholy/Revise.jl/blob/f0bca762757eade341e7b97eb6b3d2a82480dbb2/src/Revise.jl#L651).