### PR TITLE
fix unionall env in showing nested method static parameters

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -104,7 +104,16 @@ function show_method_params(io::IO, tv)
         if length(tv) == 1
             show(io, tv[1])
         else
-            show_delim_array(io, tv, '{', ',', '}', false)
+            print(io, "{")
+            for i = 1:length(tv)
+                if i > 1
+                    print(io, ", ")
+                end
+                x = tv[i]
+                show(io, x)
+                io = IOContext(io, :unionall_env => x)
+            end
+            print(io, "}")
         end
     end
 end

--- a/test/show.jl
+++ b/test/show.jl
@@ -602,6 +602,12 @@ let repr = sprint(show, "text/html", methods(f16580))
     @test occursin("f16580(x, y...; <i>z, w, q...</i>)", repr)
 end
 
+function triangular_methodshow(x::T1, y::T2) where {T2<:Integer, T1<:T2}
+end
+let repr = sprint(show, "text/plain", methods(triangular_methodshow))
+    @test occursin("where {T2<:Integer, T1<:T2}", repr)
+end
+
 if isempty(Base.GIT_VERSION_INFO.commit)
     @test occursin("https://github.com/JuliaLang/julia/tree/v$VERSION/base/special/trig.jl#L", Base.url(which(sin, (Float64,))))
 else


### PR DESCRIPTION
```
julia> f(x::T1, y::T2) where {T2<:Integer, T1<:T2} = 0;

julia> methods(f)
```

Before:
```
# 1 method for generic function "f":
[1] f(x::T1, y::T2) where {T2<:Integer, T1<:T2<:Integer} in Main at REPL[1]:1
```
after:
```
# 1 method for generic function "f":
[1] f(x::T1, y::T2) where {T2<:Integer, T1<:T2} in Main at REPL[1]:1
```