### PR TITLE
Fix enumerate documentation

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -115,7 +115,7 @@ and `x` is the `i`th value from the given iterator. It's useful when
 you need not only the values `x` over which you are iterating, but
 also the number of iterations so far. Note that `i` may not be valid
 for indexing `iter`; it's also possible that `x != iter[i]`, if `iter`
-has indices that do not start at 1. See the `enumerate(IndexLinear(),
+has indices that do not start at 1. See the `pairs(IndexLinear(),
 iter)` method if you want to ensure that `i` is an index.
 
 # Examples


### PR DESCRIPTION
The `enumerate` method referred to in the current documentation no longer exists and has been deprecated to a method of `pairs` in 0.7.

Thanks to @simonschoelly for pointing this out.

```
julia> using OffsetArrays;
julia> pairs(IndexLinear(),OffsetArray(1:5, -2:2))
pairs(::OffsetArray{Int64,1,UnitRange{Int64}}) with 5 entries:
  -2 => 1
  -1 => 2
  0  => 3
  1  => 4
  2  => 5
```