### PR TITLE
Make slicing short tuple inferable

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -283,7 +283,10 @@ unitrange_last(start::T, stop::T) where {T} =
                           convert(T,start-oneunit(stop-start)))
 
 if isdefined(Main, :Base)
-    function getindex(t::Tuple, r::AbstractUnitRange{<:Real})
+    getindex(t::Tuple, r::AbstractUnitRange{<:Real}) =
+        (o = first(r) - 1; ntuple(n -> t[o + n], length(r)))
+
+    function getindex(t::Any16, r::AbstractUnitRange{<:Real})
         n = length(r)
         n == 0 && return ()
         a = Vector{eltype(t)}(undef, n)

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -430,3 +430,12 @@ end
     @test findnext(isequal(1), (2, 3), 1) === nothing
     @test findprev(isequal(1), (2, 3), 2) === nothing
 end
+
+@testset "Inferable short tuple slicing: issue #30386" begin
+    head2(xs) = xs[1:2]
+    butlast(xs) = xs[1:end-1]
+    @test @inferred(head2((1, 2, 3))) == (1, 2)
+    @test @inferred(head2((1, 2, 3, 4, 5, 6, 7))) == (1, 2)
+    @test @inferred(butlast((1, 2, 3))) == (1, 2)
+    @test @inferred(butlast((1, 2, 3, 4, 5, 6, 7))) == (1, 2, 3, 4, 5, 6)
+end


### PR DESCRIPTION
This patch uses `Any16` as @timholy suggested: https://github.com/JuliaLang/julia/issues/30386#issuecomment-447269397.

@JeffBezanson mentioned that:

> So any change to make this inferrable needs to show minimal compile-time cost. --- https://github.com/JuliaLang/julia/issues/30386#issuecomment-447212885

How do you check it?

closes #30386