### PR TITLE
Add custom deserialize method for UmfpackLU to avoid memory leak

### DIFF
--- a/stdlib/SuiteSparse/Project.toml
+++ b/stdlib/SuiteSparse/Project.toml
@@ -4,13 +4,14 @@ uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Random", "DelimitedFiles", "Serialization"]

--- a/stdlib/SuiteSparse/src/umfpack.jl
+++ b/stdlib/SuiteSparse/src/umfpack.jl
@@ -11,6 +11,8 @@ import LinearAlgebra: Factorization, det, lu, ldiv!
 using SparseArrays
 import SparseArrays: nnz
 
+import Serialization: AbstractSerializer, deserialize
+
 import ..increment, ..increment!, ..decrement, ..decrement!
 
 include("umfpack_h.jl")
@@ -190,6 +192,22 @@ end
 function show(io::IO, F::UmfpackLU)
     print(io, "UMFPACK LU Factorization of a $(size(F)) sparse matrix")
     F.numeric != C_NULL && print(io, '\n', F.numeric)
+end
+
+function deserialize(s::AbstractSerializer, t::Type{UmfpackLU{Tv,Ti}}) where {Tv,Ti}
+    symbolic = deserialize(s)
+    numeric  = deserialize(s)
+    m        = deserialize(s)
+    n        = deserialize(s)
+    colptr   = deserialize(s)
+    rowval   = deserialize(s)
+    nzval    = deserialize(s)
+    status   = deserialize(s)
+    obj      = UmfpackLU{Tv,Ti}(symbolic, numeric, m, n, colptr, rowval, nzval, status)
+
+    finalizer(umfpack_free_symbolic, obj)
+
+    return obj
 end
 
 ## Wrappers for UMFPACK functions

--- a/stdlib/SuiteSparse/test/umfpack.jl
+++ b/stdlib/SuiteSparse/test/umfpack.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using SuiteSparse: increment!
+using Serialization
 using LinearAlgebra: Adjoint, Transpose, SingularException
 
 @testset "UMFPACK wrappers" begin
@@ -173,6 +174,18 @@ using LinearAlgebra: Adjoint, Transpose, SingularException
         for A in sparse.((Float64[1 2; 0 0], ComplexF64[1 2; 0 0]))
             @test_throws SingularException lu(A)
             @test !issuccess(lu(A; check = false))
+        end
+    end
+
+    @testset "deserialization" begin
+        A  = sprandn(10, 10, 0.4)
+        F1 = lu(A)
+        b  = IOBuffer()
+        serialize(b, F1)
+        seekstart(b)
+        F2 = deserialize(b)
+        for nm in (:colptr, :m, :n, :nzval, :rowval, :status)
+            @test getfield(F1, nm) == getfield(F2, nm)
         end
     end
 


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#317 

I'm not sure what would be a good way to test this. Can I compare some of the values from the GC output before and after running 
```julia
foreach(1:10000) do i
    seekstart(b)
    serialize(b, F)
    seekstart(b)
    SuiteSparse.UMFPACK.umfpack_symbolic!(deserialize(b))
end
```
Which of the gc values would be appropriate to compare?