### PR TITLE
Build: fix output directory when specified with O=

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -96,7 +96,7 @@ ARCH:=
 ifeq ($(BUILDROOT),)
 ifeq ("$(origin O)", "command line")
   BUILDROOT := $(abspath $O)
-  BUILDDIR := $(abspath $(BUILDROOT)/$(shell $(JULIAHOME)/contrib/relative_path.sh $(JULIAHOME) $(SRCDIR)))
+  BUILDDIR := $(abspath $(BUILDROOT)/$(shell $(JULIAHOME)/contrib/relative_path.sh $(JULIAHOME) $(abspath $(dir $(lastword $(MAKEFILE_LIST))))))
   $(info $(shell printf '\033[32;1mBuilding into $(BUILDROOT)\033[0m')) # use printf to expand the escape sequences
 else
   BUILDROOT:=$(JULIAHOME)


### PR DESCRIPTION
Fix `abspath` call when output directory is specified with `O=` and `SRCDIR` is not set.