### PR TITLE
Fix mention of Base.worker_timeout() in manual

### DIFF
--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -151,7 +151,7 @@ logical CPU cores available.
 
 ### `JULIA_WORKER_TIMEOUT`
 
-A [`Float64`](@ref) that sets the value of `Base.worker_timeout()` (default: `60.0`).
+A [`Float64`](@ref) that sets the value of `Distributed.worker_timeout()` (default: `60.0`).
 This function gives the number of seconds a worker process will wait for
 a master process to establish a connection before dying.
 


### PR DESCRIPTION
The manual mentions at https://docs.julialang.org/en/v1/manual/environment-variables/#JULIA_WORKER_TIMEOUT-1 a function Base.worker_timeout() but the Julia 1.0.3 implementation has instead only a function Distributed.worker_timeout()