### PR TITLE
Use a tier system for platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,41 @@ New developers may find the notes in [CONTRIBUTING](https://github.com/JuliaLang
 
 ## Currently Supported Platforms
 
-Julia is built and tested regularly on the following platforms:
-
 | Operating System | Architecture     | CI | Binaries | Support Level |
 |:----------------:|:----------------:|:--:|:--------:|:-------------:|
-| Linux 2.6.18+    | x86-64 (64-bit)  | ✓  | ✓        | Official      |
-|                  | i686 (32-bit)    | ✓  | ✓        | Official      |
-|                  | ARM v7 (32-bit)  |    | ✓        | Official      |
-|                  | ARM v8 (64-bit)  |    |          | Community     |
-|                  | PowerPC (64-bit) |    |          | Community     |
+| macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Tier 1        |
+| Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Tier 1        |
+|                  | i686 (32-bit)    | ✓  | ✓        | Tier 1        |
+| FreeBSD 11.0+    | x86-64 (64-bit)  | [✓](https://build.julialang.org/#/builders/68)  | ✓        | Tier 1        |
+| Linux 2.6.18+    | x86-64 (64-bit)  | ✓  | ✓        | Tier 1        |
+|                  | i686 (32-bit)    | ✓  | ✓        | Tier 1        |
+|                  | ARM v7 (32-bit)  |    | ✓        | Tier 2        |
+|                  | ARM v8 (64-bit)  |    |          | Tier 3        |
+|                  | x86-64 musl libc |    |          | Tier 3        |
+|                  | PowerPC (64-bit) |    |          | Tier 4        |
 |                  | PTX (64-bit)     | [✓](https://gitlab.com/JuliaGPU/CUDAnative.jl/pipelines)  |          | [External](https://github.com/JuliaGPU/CUDAnative.jl)     |
-| macOS 10.8+      | x86-64 (64-bit)  | ✓  | ✓        | Official      |
-| Windows 7+       | x86-64 (64-bit)  | ✓  | ✓        | Official      |
-|                  | i686 (32-bit)    | ✓  | ✓        | Official      |
-| FreeBSD 11.0+    | x86-64 (64-bit)  | [✓](https://build.julialang.org/#/builders/68)  | ✓        | Official      |
 
 All systems marked with ✓ for CI are tested using continuous integration for every commit.
-Systems with ✓ for binaries have official binaries available on the [downloads](https://julialang.org/downloads) page and are tested regularly. The PTX backend needs the [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl) package.
-The systems listed here with neither CI nor official binaries are known to build and work, but ongoing support for those platforms is dependent on community efforts.
-It is possible that Julia will build and work on other platforms too, and we're always looking to improve our platform coverage.
+Systems with ✓ for binaries have official binaries available on the
+[downloads](https://julialang.org/downloads) page and are tested regularly.
+The PTX backend is supported by the [JuliaGPU](https://github.com/JuliaGPU) organization and
+requires the [CUDAnative.jl](https://github.com/JuliaGPU/CUDAnative.jl) package.
+
+### Support Tiers
+
+* Tier 1: Julia is guaranteed to build from source and pass all tests on these platforms
+  when built with default options. Official binaries are available for releases and CI is
+  run on every commit.
+
+* Tier 2: Julia is guaranteed to build from source using default build options, but may
+  or may not pass all tests. Official binaries are available on a case-by-case basis.
+
+* Tier 3: Julia may or may not build. If it does, it is unlikely to pass tests.
+
+* Tier 4: Julia is known not to build.
+
+It is possible that Julia will build and work on other platforms too, and we're always
+looking to improve our platform coverage.
 If you're using Julia on a platform not listed here, let us know!
 
 ## Source Download and Compilation


### PR DESCRIPTION
This makes the level to which we support various platforms more specific and adds a bit of formalism that's typical of other projects, e.g. Rust. The tier system is explained in the document, but to recap:

1. Builds and passes tests, have binaries and CI
2. Builds, may pass tests, may have binaries
3. May build
4. Hardcore broken

All of our listed platforms have been assigned a tier, which is pretty obvious for most of them.

I've also added an entry in the support table for Linux with musl libc. Julia builds and passes most tests on Alpine, but that isn't verified regularly so I've assigned that tier 3 for now.