### PR TITLE
Add link to the pdf version of the documentation to the html pages

### DIFF
--- a/doc/src/index.md
+++ b/doc/src/index.md
@@ -20,6 +20,18 @@ Markdown.parse(String(take!(io)))
 ```
 Please read the [release notes](NEWS.md) to see what has changed since the last release.
 
+```@eval
+release = isempty(VERSION.prerelease)
+file = release ? "julia-$(VERSION).pdf" :
+       "julia-$(VERSION.major).$(VERSION.minor).$(VERSION.patch)-$(first(VERSION.prerelease)).pdf"
+url = "https://raw.githubusercontent.com/JuliaLang/docs.julialang.org/assets/$(file)"
+import Markdown
+Markdown.parse("""
+!!! note
+    The documentation is also available in PDF format: [$file]($url).
+""")
+```
+
 ### [Introduction](@id man-introduction)
 
 Scientific computing has traditionally required the highest performance, yet domain experts have


### PR DESCRIPTION
After https://github.com/JuliaDocs/Documenter.jl/pull/891, https://github.com/JuliaLang/docs.julialang.org/pull/1 and #30339 we are now succesfully building a pdf version of the docs, both for new releases and for master. This adds a link to the pdf on the frontpage of the Julia manual.

cc @mortenpi