### PR TITLE
add extra convenience kwargs to CustomParams and code_typed

### DIFF
--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -41,6 +41,8 @@ struct Params
                     inline_cost_threshold::Int = DEFAULT_PARAMS.inline_cost_threshold,
                     inline_nonleaf_penalty::Int = DEFAULT_PARAMS.inline_nonleaf_penalty,
                     inline_tupleret_bonus::Int = DEFAULT_PARAMS.inline_tupleret_bonus,
+                    ipo_constant_propagation::Bool = true,
+                    aggressive_constant_propagation::Bool = false,
                     max_methods::Int = DEFAULT_PARAMS.MAX_METHODS,
                     tupletype_depth::Int = DEFAULT_PARAMS.TUPLE_COMPLEXITY_LIMIT_DEPTH,
                     tuple_splat::Int = DEFAULT_PARAMS.MAX_TUPLE_SPLAT,
@@ -48,9 +50,10 @@ struct Params
                     apply_union_enum::Int = DEFAULT_PARAMS.MAX_APPLY_UNION_ENUM)
         return new(Vector{InferenceResult}(),
                    world, false,
-                   inlining, true, false, inline_cost_threshold, inline_nonleaf_penalty,
-                   inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum,
-                   tupletype_depth, tuple_splat)
+                   inlining, ipo_constant_propagation, aggressive_constant_propagation,
+                   inline_cost_threshold, inline_nonleaf_penalty, inline_tupleret_bonus,
+                   max_methods, union_splitting, apply_union_enum, tupletype_depth,
+                   tuple_splat)
     end
     function Params(world::UInt)
         inlining = inlining_enabled()

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -942,7 +942,10 @@ generic function and type signature. The keyword argument `optimize` controls wh
 additional optimizations, such as inlining, are also applied.
 The keyword debuginfo controls the amount of code metadata present in the output.
 """
-function code_typed(@nospecialize(f), @nospecialize(types=Tuple); optimize=true, debuginfo::Symbol=:default)
+function code_typed(@nospecialize(f), @nospecialize(types=Tuple);
+                    optimize=true, debuginfo::Symbol=:default,
+                    world = ccall(:jl_get_world_counter, UInt, ()),
+                    params = Core.Compiler.Params(world))
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -954,8 +957,6 @@ function code_typed(@nospecialize(f), @nospecialize(types=Tuple); optimize=true,
     end
     types = to_tuple_type(types)
     asts = []
-    world = ccall(:jl_get_world_counter, UInt, ())
-    params = Core.Compiler.Params(world)
     for x in _methods(f, types, -1, world)
         meth = func_for_method_checked(x[3], types)
         (code, ty) = Core.Compiler.typeinf_code(meth, x[1], x[2], optimize, params)


### PR DESCRIPTION
- adds `ipo_constant_propagation` and `aggressive_constant_propagation` to `CustomParams` constructor
- adds `world` and `params` kwargs to `code_typed`

This makes it easier to play around with custom parameter configurations when debugging inference.