### PR TITLE
Allow multiple pair arguments in replace on strings.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ New language features
 
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
+* The `replace` function can now perform multiple replacements on a single string
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ New language features
 
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
-* The `replace` function can now perform multiple replacements on a single string([#30457])
+* The `replace` function can now perform multiple replacements on a single string ([#30457])
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ New language features
 
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
-* The `replace` function can now perform multiple replacements on a single string
+* The `replace` function can now perform multiple replacements on a single string([#30457])
 
 Multi-threading changes
 -----------------------

--- a/base/set.jl
+++ b/base/set.jl
@@ -577,7 +577,6 @@ replace!(a::Callable, b::Pair; count::Integer=-1) = throw(MethodError(replace!, 
 replace!(a::Callable, b::Pair, c::Pair; count::Integer=-1) = throw(MethodError(replace!, (a, b, c)))
 replace(a::Callable, b::Pair; count::Integer=-1) = throw(MethodError(replace, (a, b)))
 replace(a::Callable, b::Pair, c::Pair; count::Integer=-1) = throw(MethodError(replace, (a, b, c)))
-replace(a::AbstractString, b::Pair, c::Pair) = throw(MethodError(replace, (a, b, c)))
 
 ### replace! for AbstractDict/AbstractSet
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -484,9 +484,10 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 
 
 """
-    replace(s::AbstractString, reps::Pair...; count::Integer=typemax(Int))
+    replace(s::AbstractString, reps::Pair...)
 
-perform a successive series of `replace` operations on `s`.
+Perform a successive series of `replace` operations on `s`, evaluating the replacements in `reps...` 
+sequentially from left to right. 
 
 # Examples
 ```jldoctest
@@ -497,7 +498,7 @@ julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 "barbaz"
 ```
 """
-function replace(s::AbstractString, reps::Pair...; count::Integer=typemax(Int))
+function replace(s::AbstractString, reps::Pair...)
     foldl((s, rep) -> replace(s, rep, count=count), reps, init=s)
 end
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -489,12 +489,18 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 perform a successive series of `replace` operations on `s`.
 
 # Examples
-```
+```jldoctest
 julia> replace("Python is a programming language.", 
                "Python" => "Julia",
                "is a" => "is",
                "programming language"=> "awesome")
 "Julia is awesome."
+
+julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
+"bazbaz"
+
+julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
+"barbaz"
 ```
 """
 function replace(s::AbstractString, reps::Pair...; count::Integer=typemax(Int))

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -496,10 +496,11 @@ julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
 
 julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 "barbaz"
+```
 !!! note
     This method is not currently recommended for performance critical code; consider a regular
     expression based approach in such cases instead.
-```
+
 """
 function replace(s::AbstractString, reps::Pair...)
     foldl((s, rep) -> replace(s, rep), reps, init=s)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -482,6 +482,25 @@ julia> replace("The quick foxes run quickly.", r"fox(es)?" => s"bus\\1")
 replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
     replace(String(s), pat_f, count=count)
 
+
+"""
+    replace(s::AbstractString, reps::Pair...; count::Integer=typemax(Int))
+
+perform a successive series of `replace` operations on `s`.
+
+# Examples
+```
+julia> replace("Python is a programming language.", 
+               "Python" => "Julia",
+               "is a" => "is",
+               "programming language"=> "awesome")
+"Julia is awesome."
+```
+"""
+function replace(s::AbstractString, reps::Pair...; count::Integer=typemax(Int))
+    foldl((s, rep) -> replace(s, rep, count=count), reps, init=s)
+end
+
 # TODO: allow transform as the first argument to replace?
 
 # hex <-> bytes conversion

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -500,7 +500,6 @@ julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 !!! note
     This method is not currently recommended for performance critical code; consider a regular
     expression based approach in such cases instead.
-
 """
 function replace(s::AbstractString, reps::Pair...)
     foldl((s, rep) -> replace(s, rep), reps, init=s)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -490,7 +490,7 @@ Perform a successive series of `replace` operations on `s`, evaluating the repla
 sequentially from left to right.
 
 This method is not recommended for performance critical code and regex based approaches are recommended instead
-when perfomrance is needed. 
+when perfomrance is needed.
 
 # Examples
 ```jldoctest

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -489,6 +489,9 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 Perform a successive series of `replace` operations on `s`, evaluating the replacements in `reps...`
 sequentially from left to right.
 
+This method is not recommended for performance critical code and regex based approaches are recommended instead
+when perfomrance is needed. 
+
 # Examples
 ```jldoctest
 julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
@@ -497,9 +500,6 @@ julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
 julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 "barbaz"
 ```
-
-This method is not recommended for performance critical code and regex based approaches are recommended instead
-when perfomrance is needed. 
 """
 function replace(s::AbstractString, reps::Pair...)
     foldl((s, rep) -> replace(s, rep), reps, init=s)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -490,12 +490,6 @@ perform a successive series of `replace` operations on `s`.
 
 # Examples
 ```jldoctest
-julia> replace("Python is a programming language.", 
-               "Python" => "Julia",
-               "is a" => "is",
-               "programming language"=> "awesome")
-"Julia is awesome."
-
 julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
 "bazbaz"
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -502,7 +502,7 @@ julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
     expression based approach in such cases instead.
 """
 function replace(s::AbstractString, reps::Pair...)
-    foldl((s, rep) -> replace(s, rep), reps, init=s)
+    foldl(replace, reps, init=s)
 end
 
 # TODO: allow transform as the first argument to replace?

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -489,9 +489,6 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 Perform a successive series of `replace` operations on `s`, evaluating the replacements in `reps...`
 sequentially from left to right.
 
-This method is not recommended for performance critical code and regex based approaches are recommended instead
-when perfomrance is needed.
-
 # Examples
 ```jldoctest
 julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
@@ -499,6 +496,9 @@ julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
 
 julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 "barbaz"
+!!! note
+    This method is not currently recommended for performance critical code; consider a regular
+    expression based approach in such cases instead.
 ```
 """
 function replace(s::AbstractString, reps::Pair...)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -487,7 +487,7 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
     replace(s::AbstractString, reps::Pair...)
 
 Perform a successive series of `replace` operations on `s`, evaluating the replacements in `reps...` 
-sequentially from left to right. 
+sequentially from left to right.
 
 # Examples
 ```jldoctest

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -486,7 +486,7 @@ replace(s::AbstractString, pat_f::Pair; count=typemax(Int)) =
 """
     replace(s::AbstractString, reps::Pair...)
 
-Perform a successive series of `replace` operations on `s`, evaluating the replacements in `reps...` 
+Perform a successive series of `replace` operations on `s`, evaluating the replacements in `reps...`
 sequentially from left to right.
 
 # Examples

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -497,6 +497,9 @@ julia> replace("foobar", "foo"=>"bar", "bar"=>"baz")
 julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 "barbaz"
 ```
+
+This method is not recommended for performance critical code and regex based approaches are recommended instead
+when perfomrance is needed. 
 """
 function replace(s::AbstractString, reps::Pair...)
     foldl((s, rep) -> replace(s, rep), reps, init=s)

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -499,7 +499,7 @@ julia> replace("foobar","bar"=>"baz", "foo"=>"bar")
 ```
 """
 function replace(s::AbstractString, reps::Pair...)
-    foldl((s, rep) -> replace(s, rep, count=count), reps, init=s)
+    foldl((s, rep) -> replace(s, rep), reps, init=s)
 end
 
 # TODO: allow transform as the first argument to replace?

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -295,6 +295,7 @@ end
 
     @test replace("foobar", "foo"=>"bar", "bar"=>"baz") == "bazbaz"
     @test replace("foobar", "bar"=>"baz", "foo"=>"bar") == "barbaz"
+    @test replace("foobar". "foo"=>"baz", "baz"=>" b a z ") == " b a z bar"
 end
 
 @testset "chomp/chop" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -295,7 +295,7 @@ end
 
     @test replace("foobar", "foo"=>"bar", "bar"=>"baz") == "bazbaz"
     @test replace("foobar", "bar"=>"baz", "foo"=>"bar") == "barbaz"
-    @test replace("foobar". "foo"=>"baz", "baz"=>" b a z ") == " b a z bar"
+    @test replace("foobar", "foo"=>"baz", "baz"=>" b a z ") == " b a z bar"
 end
 
 @testset "chomp/chop" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -292,7 +292,7 @@ end
     @test replace("a", 'a' => typeof) == "Char"
     @test replace("a", in("a") => typeof) == "Char"
     @test replace("a", ['a'] => typeof) == "Char"
-    
+
     @test replace("foobar", "foo"=>"bar", "bar"=>"baz") == "bazbaz"
     @test replace("foobar", "bar"=>"baz", "foo"=>"bar") == "barbaz"
 end

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -292,6 +292,13 @@ end
     @test replace("a", 'a' => typeof) == "Char"
     @test replace("a", in("a") => typeof) == "Char"
     @test replace("a", ['a'] => typeof) == "Char"
+    
+    @test replace("foobar", "foo"=>"bar", "bar"=>"baz") == "bazbaz"
+    @test replace("foobar", "bar"=>"baz", "foo"=>"bar") == "barbaz"
+    @test replace("Python is a programming language.", 
+                  "Python" => "Julia", 
+                  "is a" => "is", 
+                  "programming language"=> "awesome") == "Julia is awesome."
 
 end
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -295,11 +295,10 @@ end
     
     @test replace("foobar", "foo"=>"bar", "bar"=>"baz") == "bazbaz"
     @test replace("foobar", "bar"=>"baz", "foo"=>"bar") == "barbaz"
-    @test replace("Python is a programming language.", 
-                  "Python" => "Julia", 
-                  "is a" => "is", 
+    @test replace("Python is a programming language.",
+                  "Python" => "Julia",
+                  "is a" => "is",
                   "programming language"=> "awesome") == "Julia is awesome."
-
 end
 
 @testset "chomp/chop" begin

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -295,10 +295,6 @@ end
     
     @test replace("foobar", "foo"=>"bar", "bar"=>"baz") == "bazbaz"
     @test replace("foobar", "bar"=>"baz", "foo"=>"bar") == "barbaz"
-    @test replace("Python is a programming language.",
-                  "Python" => "Julia",
-                  "is a" => "is",
-                  "programming language"=> "awesome") == "Julia is awesome."
 end
 
 @testset "chomp/chop" begin


### PR DESCRIPTION
This PR is intended to allow syntax like
```julia
replace("abc", 'a'=>'A', 'c'=>'C')
```
in order to be more in line with other methods of `replace` like
```julia
replace([1, 2, 1, 3], 1=>0, 2=>4)
```