### PR TITLE
Add link to `Symbol` in docstring of `:`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -35,7 +35,7 @@ Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (
 , and `a:s:b` is similar but uses a step size of `s` (a [`StepRange`](@ref)).
 
 `:` is also used in indexing to select whole dimensions
-and to signal [`Symbol`](@ref)s.
+ and for [`Symbol`](@ref) literals, as in e.g. `:hello`.
 """
 (:)(start::T, step, stop::T) where {T} = _colon(start, step, stop)
 (:)(start::T, step, stop::T) where {T<:Real} = _colon(start, step, stop)

--- a/base/range.jl
+++ b/base/range.jl
@@ -34,7 +34,8 @@ _colon(::Any, ::Any, start::T, step, stop::T) where {T} =
 Range operator. `a:b` constructs a range from `a` to `b` with a step size of 1 (a [`UnitRange`](@ref))
 , and `a:s:b` is similar but uses a step size of `s` (a [`StepRange`](@ref)).
 
-`:` is also used in indexing to select whole dimensions.
+`:` is also used in indexing to select whole dimensions
+and to signal [`Symbol`](@ref)s.
 """
 (:)(start::T, step, stop::T) where {T} = _colon(start, step, stop)
 (:)(start::T, step, stop::T) where {T<:Real} = _colon(start, step, stop)


### PR DESCRIPTION
I believe it would be helpful to add
a reference to `Symbol` to the docstring of `:`.

ATM searching for `?:` in the REPL does not mention the use of `:` in symbols.