### PR TITLE
use type inference world in `return_type`

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -633,7 +633,12 @@ end
 
 
 function return_type(@nospecialize(f), @nospecialize(t))
-    params = Params(ccall(:jl_get_tls_world_age, UInt, ()))
+    world = ccall(:jl_get_tls_world_age, UInt, ())
+    return ccall(:jl_call_in_typeinf_world, Any, (Ptr{Ptr{Cvoid}}, Cint), Any[_return_type, f, t, world], 4)
+end
+
+function _return_type(@nospecialize(f), @nospecialize(t), world)
+    params = Params(world)
     rt = Union{}
     if isa(f, Builtin)
         rt = builtin_tfunction(f, Any[t.parameters...], nothing, params)

--- a/src/gf.c
+++ b/src/gf.c
@@ -300,6 +300,16 @@ jl_code_info_t *jl_type_infer(jl_method_instance_t **pli JL_ROOTS_TEMPORARILY, s
     return src;
 }
 
+JL_DLLEXPORT jl_value_t *jl_call_in_typeinf_world(jl_value_t **args, int nargs)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    size_t last_age = ptls->world_age;
+    ptls->world_age = jl_typeinf_world;
+    jl_value_t *ret = jl_apply(args, nargs);
+    ptls->world_age = last_age;
+    return ret;
+}
+
 int jl_is_rettype_inferred(jl_method_instance_t *li) JL_NOTSAFEPOINT
 {
     if (!li->inferred)


### PR DESCRIPTION
I found that one large source of latency in code loading is that we're repeatedly compiling the type inference code when it's called from `return_type`, since the type inference code in the system image is for a different world. This instead re-uses the precompiled world.

Significantly helps #15048. With this, precompiling DataFrames goes from 77 to 50 seconds, and precompiling JuliaDB goes from 130 to 75 seconds.