### PR TITLE
Fix performance of broadcast and collect with Union{T, Missing}

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -687,8 +687,7 @@ function grow_to!(dest, itr, st)
     y = iterate(itr, st)
     while y !== nothing
         el, st = y
-        S = typeof(el)
-        if S === T || S <: T
+        if el isa T || typeof(el) === T
             push!(dest, el::T)
         else
             new = push_widen(dest, el)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -926,13 +926,12 @@ function copyto_nonleaf!(dest, bc::Broadcasted, iter, state, count)
         y === nothing && break
         I, state = y
         @inbounds val = bc[I]
-        S = typeof(val)
-        if S <: T
+        if val isa T || typeof(val) === T
             @inbounds dest[I] = val
         else
             # This element type doesn't fit in dest. Allocate a new dest with wider eltype,
             # copy over old values, and continue
-            newdest = Base.similar(dest, promote_typejoin(T, S))
+            newdest = Base.similar(dest, promote_typejoin(T, typeof(val)))
             for II in Iterators.take(iter, count)
                 newdest[II] = dest[II]
             end


### PR DESCRIPTION
Use the same pattern as in `collect_to!` (which is used when size is known). Follows what was done by https://github.com/JuliaLang/julia/pull/25828.

Fixes https://github.com/JuliaLang/julia/issues/30455.

Before:
```julia
julia> using BenchmarkTools

julia> v = fill(2.0, 50000);

julia> v2 = vcat(v, missing);

julia> v3 = vcat(missing, v);

julia> @btime $v .* 3.0;
  46.964 μs (2 allocations: 390.70 KiB)

julia> @btime $v2 .* 3.0;
  1.838 ms (99498 allocations: 2.33 MiB)

julia> @btime $v3 .* 3.0;
  3.569 ms (7 allocations: 439.77 KiB)

julia> @btime collect($(x for x in v if true));
  336.170 μs (17 allocations: 1.00 MiB)

julia> @btime collect($(x for x in v2 if true));
  569.995 μs (21 allocations: 2.29 MiB)

julia> @btime collect($(x for x in v3 if true));
  4.041 ms (20 allocations: 1.13 MiB)

```
After:
```julia
julia> @btime $v .* 3.0;
  46.908 μs (2 allocations: 390.70 KiB)

julia> @btime $v2 .* 3.0;
  1.351 ms (99498 allocations: 2.33 MiB)

julia> @btime $v3 .* 3.0;
  102.446 μs (7 allocations: 439.77 KiB)

julia> @btime collect($(x for x in v if true));
  332.648 μs (17 allocations: 1.00 MiB)

julia> @btime collect($(x for x in v2 if true));
  527.674 μs (21 allocations: 2.29 MiB)

julia> @btime collect($(x for x in v3 if true));
  625.985 μs (19 allocations: 1.13 MiB)
```