### PR TITLE
Fix #30462, out of bounds access in maximum/minimum for certain-sized arrays

### DIFF
--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -492,6 +492,7 @@ function mapreduce_impl(f, op::Union{typeof(max), typeof(min)},
             v3 = _fast(op, v3, f(A[i+2]))
             v4 = _fast(op, v4, f(A[i+3]))
         end
+        checkbounds(A, simdstop+3)
         start += chunk_len
         simdstop += chunk_len
     end

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -244,9 +244,21 @@ end
     end
 end
 
-# 30462
-# test that there is no out of bounds access
-maximum(randn(128,128))
+@testset "maximum no out of bounds access #30462" begin
+    arr = fill(-Inf, 128,128)
+    @test maximum(arr) == -Inf
+    arr = fill(Inf, 128^2)
+    @test minimum(arr) == Inf
+    for center in [256, 1024, 4096, 128^2]
+        for offset in -10:10
+            len = center + offset
+            x = randn()
+            arr = fill(x, len)
+            @test maximum(arr) === x
+            @test minimum(arr) === x
+        end
+    end
+end
 
 @test isnan(maximum([NaN]))
 @test isnan(minimum([NaN]))

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -244,6 +244,10 @@ end
     end
 end
 
+# 30462
+# test that there is no out of bounds access
+maximum(randn(128,128))
+
 @test isnan(maximum([NaN]))
 @test isnan(minimum([NaN]))
 @test isequal(extrema([NaN]), (NaN, NaN))


### PR DESCRIPTION
#30462 This is still fast:
```julia
julia> using BenchmarkTools; arr = randn(10^6); @benchmark maximum($arr)
[ Info: Recompiling stale cache file /home/jan/.julia/compiled/v1.2/BenchmarkTools/ZXPQo.ji for BenchmarkTools [6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf]
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     557.330 μs (0.00% GC)
  median time:      587.258 μs (0.00% GC)
  mean time:        588.535 μs (0.00% GC)
  maximum time:     855.520 μs (0.00% GC)
  --------------
  samples:          8403
  evals/sample:     1
```