### PR TITLE
Fix issue ref typo in comments of `doc/make.jl` (#30489)

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -15,7 +15,7 @@ baremodule GenStdLib end
 symlink_q(tgt, link) = isfile(link) || symlink(tgt, link)
 cp_q(src, dest) = isfile(dest) || cp(src, dest)
 
-# make links for stdlib package docs, this is needed until #522 in Documenter.jl is finished
+# make links for stdlib package docs, this is needed until #552 in Documenter.jl is finished
 const STDLIB_DOCS = []
 const STDLIB_DIR = Sys.STDLIB
 const EXT_STDLIB_DOCS = ["Pkg"]


### PR DESCRIPTION
In the doc/make.jl, there is a code block for making links for
stdlib. It mentioned JuliaDocs/Documenter.jl#522 in the comment
but JuliaDocs/Documenter.jl#522 seems not relevant to this and
it should be JuliaDocs/Documenter.jl#552.

Fix #30489.