### PR TITLE
remove unnecessary named let in parse-assignment

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -737,8 +737,8 @@
       ex))
 
 (define (parse-assignment s down)
-  (let loop ((ex (down s))
-             (t  (peek-token s)))
+  (let* ((ex (down s))
+         (t  (peek-token s)))
     (if (not (is-prec-assignment? t))
         ex
         (begin


### PR DESCRIPTION
The `loop` is not used in the function body and `let*` is much clearer to readers.