### PR TITLE
Add target defines for wasm/emscripten

### DIFF
--- a/base/sysinfo.jl
+++ b/base/sysinfo.jl
@@ -29,6 +29,7 @@ export BINDIR,
        isopenbsd,
        isunix,
        iswindows,
+       isjsvm,
        isexecutable,
        which
 
@@ -279,6 +280,12 @@ function isunix(os::Symbol)
         return false
     elseif islinux(os) || isbsd(os)
         return true
+    elseif os === :Emscripten
+        # Emscripten implements the POSIX ABI and provides traditional
+        # Unix-style operating system functions such as file system support.
+        # Therefor, we consider it a unix, even though this need not be
+        # generally true for a jsvm embedding.
+        return true
     else
         throw(ArgumentError("unknown operating system \"$os\""))
     end
@@ -377,7 +384,18 @@ See documentation in [Handling Operating System Variation](@ref).
 """
 isapple(os::Symbol) = (os === :Apple || os === :Darwin)
 
-for f in (:isunix, :islinux, :isbsd, :isapple, :iswindows, :isfreebsd, :isopenbsd, :isnetbsd, :isdragonfly)
+"""
+    Sys.isjsvm([os])
+
+Predicate for testing if Julia is running in a JavaScript VM (JSVM),
+including e.g. a WebAssembly JavaScript embedding in a web browser.
+
+!!! compat "Julia 1.2"
+    This function requires at least Julia 1.2.
+"""
+isjsvm(os::Symbol) = (os === :Emscripten)
+
+for f in (:isunix, :islinux, :isbsd, :isapple, :iswindows, :isfreebsd, :isopenbsd, :isnetbsd, :isdragonfly, :isjsvm)
     @eval $f() = $(getfield(@__MODULE__, f)(KERNEL))
 end
 

--- a/src/support/platform.h
+++ b/src/support/platform.h
@@ -22,11 +22,13 @@
  *          _OS_LINUX_
  *          _OS_WINDOWS_
  *          _OS_DARWIN_
+ *          _OS_EMSCRIPTEN_
  *
  *      CPU/Architecture:
  *          _CPU_X86_
  *          _CPU_X86_64_
  *          _CPU_ARM_
+ *          _CPU_WASM_
  */
 
 /*******************************************************************************
@@ -71,6 +73,8 @@
 #define _OS_WINDOWS_
 #elif defined(__APPLE__) && defined(__MACH__)
 #define _OS_DARWIN_
+#elif defined(__EMSCRIPTEN__)
+#define _OS_EMSCRIPTEN_
 #endif
 
 /*******************************************************************************
@@ -89,6 +93,8 @@
 #define _CPU_PPC64_
 #elif defined(_ARCH_PPC)
 #define _CPU_PPC_
+#elif defined(__wasm__)
+#define _CPU_WASM_
 #endif
 
 #if defined(_CPU_X86_64_)


### PR DESCRIPTION
This is perhaps a bit of an overeager commit, given that most of the
code to support wasm is not yet upstream, but I think it's important
to get our terminology clear early. This attempts to define platform
defines in both our C code and at the Julia level. For background,
wasm is a general standard for secure execution of untrusted code
arising out of the Javascript world (many web browsers these days
ship wasm support in their Javascript engine). However, wasm is not
tied to JS, so it would be good to avoid hardcoding any such
assumptions into our platform defines (e.g. people are considering
wasm for kernel space vms, etc.). Emscripten on the other hand is
the original C-to-JS compiler, as well as corresponding runtime
libraries, simulatenously fulfulling the role of C library and
operating system kernel (for some features at least - e.g.
providing file system emulation). As such, my suggestion is the
following:

- Sys.OS gets set to `Emscripten`, which is also what the emulated
  `uname` syscall returns when emulated by Emscripten, so is consistent
  with our documentation for what that global means.
- A new `isjsvm` function can be used to determine if we're running
  inside a JavaScript VM (I'd expect this check to be quite common,
  e.g. to call out to the native RegEx engine).
- `isunix` is true for Emscripten, but I don't envision it being true
  generally for either `isjvm` platforms or wasm platforms.
- I didn't currently add a specific check for wasm, since I'd suspect
  this to be rather rare (e.g. only if you wanted to do something like
  emit inline wasm, or have a specific implementation for wasm targets).
  However, you can of course always check Sys.MACHINE for
  wasm32-*-* or wasm64-*-*. If it turns out to be useful, we can add it.

The C code follows the same reasoning and defines _OS_EMSCRIPTEN_ and
_CPU_WASM_. I didn't bother defining something for jsvm, since the changes
to the C code will have to be quite closely tied to specifics of
Emscripten.

cc @SimonDanisch @tshort @staticfloat for thoughts.