### PR TITLE
Add license headers and fix links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ Julia uses the following external libraries, which are automatically downloaded 
 [GMP]:          http://gmplib.org
 [MPFR]:         http://www.mpfr.org
 [libuv]:        https://github.com/JuliaLang/libuv
-[libgit2]:      https://libgit2.github.com/
+[libgit2]:      https://libgit2.org/
 [utf8proc]:     https://julialang.org/utf8proc/
 [libosxunwind]: https://github.com/JuliaLang/libosxunwind
 [libunwind]:    http://www.nongnu.org/libunwind

--- a/base/version.jl
+++ b/base/version.jl
@@ -1,13 +1,13 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-## semantic version numbers (http://semver.org)
+## semantic version numbers (https://semver.org/)
 
 const VInt = UInt32
 """
     VersionNumber
 
 Version number type which follow the specifications of
-[semantic versioning](http://semver.org), composed of major, minor
+[semantic versioning](https://semver.org/), composed of major, minor
 and patch numeric values, followed by pre-release and build
 alpha-numeric annotations. See also [`@v_str`](@ref).
 

--- a/doc/src/base/numbers.md
+++ b/doc/src/base/numbers.md
@@ -115,7 +115,7 @@ Base.@uint128_str
 
 The [`BigFloat`](@ref) and [`BigInt`](@ref) types implements
 arbitrary-precision floating point and integer arithmetic, respectively. For
-[`BigFloat`](@ref) the [GNU MPFR library](http://www.mpfr.org/) is used,
+[`BigFloat`](@ref) the [GNU MPFR library](https://www.mpfr.org/) is used,
 and for [`BigInt`](@ref) the [GNU Multiple Precision Arithmetic Library (GMP)]
 (https://gmplib.org) is used.
 

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -75,7 +75,7 @@ in CPU cycles) to each of Julia's intrinsic functions. These costs are
 based on
 [standard ranges for common architectures](http://ithare.com/wp-content/uploads/part101_infographics_v08.png)
 (see
-[Agner Fog's analysis](http://www.agner.org/optimize/instruction_tables.pdf)
+[Agner Fog's analysis](https://www.agner.org/optimize/instruction_tables.pdf)
 for more detail).
 
 We supplement this low-level lookup table with a number of special

--- a/doc/src/manual/code-loading.md
+++ b/doc/src/manual/code-loading.md
@@ -204,7 +204,7 @@ paths = Dict(
 
 This example map includes three different kinds of package locations (the first and third are part of the default load path):
 
-1. The private `Priv` package is "[vendored](https://stackoverflow.com/a/35109534/659248)" inside the `App` repository.
+1. The private `Priv` package is "[vendored](https://stackoverflow.com/a/35109534)" inside the `App` repository.
 2. The public `Priv` and `Zebra` packages are in the system depot, where packages installed and managed by the system administrator live. These are available to all users on the system.
 3. The `Pub` package is in the user depot, where packages installed by the user live. These are only available to the user who installed them.
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -284,7 +284,7 @@ event listener for just-in-time (JIT) profiling.
 
     This environment variable only has an effect if Julia was compiled with JIT
     profiling support, using either
-    * Intel's [VTune™ Amplifier](https://software.intel.com/en-us/intel-vtune-amplifier-xe)
+    * Intel's [VTune™ Amplifier](https://software.intel.com/en-us/vtune)
       (`USE_INTEL_JITEVENTS` set to `1` in the build configuration), or
     * [OProfile](http://oprofile.sourceforge.net/news/) (`USE_OPROFILE_JITEVENTS` set to `1`
       in the build configuration).

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -741,7 +741,7 @@ Because supporting generic programming is deemed more important than potential p
 that can be achieved by other means (e.g., using explicit loops), operators like `+=` and `*=`
 work by rebinding new values.
 
-## Asynchronous IO and concurrent synchronous writes
+## [Asynchronous IO and concurrent synchronous writes](@id faq-async-io)
 
 ### Why do concurrent writes to the same stream result in inter-mixed output?
 

--- a/doc/src/manual/integers-and-floating-point-numbers.md
+++ b/doc/src/manual/integers-and-floating-point-numbers.md
@@ -505,7 +505,7 @@ Floating-point arithmetic entails many subtleties which can be surprising to use
 with the low-level implementation details. However, these subtleties are described in detail in
 most books on scientific computation, and also in the following references:
 
-  * The definitive guide to floating point arithmetic is the [IEEE 754-2008 Standard](http://standards.ieee.org/findstds/standard/754-2008.html);
+  * The definitive guide to floating point arithmetic is the [IEEE 754-2008 Standard](https://standards.ieee.org/standard/754-2008.html);
     however, it is not available for free online.
   * For a brief but lucid presentation of how floating-point numbers are represented, see John D.
     Cook's [article](https://www.johndcook.com/blog/2009/04/06/anatomy-of-a-floating-point-number/)
@@ -523,7 +523,7 @@ most books on scientific computation, and also in the following references:
 ## Arbitrary Precision Arithmetic
 
 To allow computations with arbitrary-precision integers and floating point numbers, Julia wraps
-the [GNU Multiple Precision Arithmetic Library (GMP)](https://gmplib.org) and the [GNU MPFR Library](http://www.mpfr.org),
+the [GNU Multiple Precision Arithmetic Library (GMP)](https://gmplib.org) and the [GNU MPFR Library](https://www.mpfr.org),
 respectively. The [`BigInt`](@ref) and [`BigFloat`](@ref) types are available in Julia for arbitrary
 precision integer and floating point numbers respectively.
 

--- a/doc/src/manual/networking-and-streams.md
+++ b/doc/src/manual/networking-and-streams.md
@@ -234,7 +234,7 @@ Sockets.PipeServer(active)
 Note that the return type of the last invocation is different. This is because this server does not
 listen on TCP, but rather on a named pipe (Windows) or UNIX domain socket. Also note that Windows
 named pipe format has to be a specific pattern such that the name prefix (`\\.\pipe\`) uniquely
-identifies the [file type](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365783(v=vs.85).aspx).
+identifies the [file type](https://docs.microsoft.com/windows/desktop/ipc/pipe-names).
 The difference between TCP and named pipes or
 UNIX domain sockets is subtle and has to do with the [`accept`](@ref) and [`connect`](@ref)
 methods. The [`accept`](@ref) method retrieves a connection to the client that is connecting on

--- a/doc/src/manual/noteworthy-differences.md
+++ b/doc/src/manual/noteworthy-differences.md
@@ -144,7 +144,7 @@ For users coming to Julia from R, these are some noteworthy differences:
     For example:
 
       * Functions pertaining to probability distributions are provided by the [Distributions package](https://github.com/JuliaStats/Distributions.jl).
-      * The [DataFrames package](https://github.com/JuliaStats/DataFrames.jl) provides data frames.
+      * The [DataFrames package](https://github.com/JuliaData/DataFrames.jl) provides data frames.
       * Generalized linear models are provided by the [GLM package](https://github.com/JuliaStats/GLM.jl).
   * Julia provides tuples and real hash tables, but not R-style lists. When returning multiple items,
     you should typically use a tuple or a named tuple: instead of `list(a = 1, b = 2)`, use `(1, 2)`

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -627,7 +627,8 @@ block, at which point it surrenders control and waits for all the local tasks to
 returning from the function.
 As for v0.7 and beyond, the feeder tasks are able to share state via `nextidx` because
 they all run on the same process.
-Even if `Tasks` are scheduled cooperatively, locking may still be required in some contexts, as in [asynchronous I\O](https://docs.julialang.org/en/stable/manual/faq/#Asynchronous-IO-and-concurrent-synchronous-writes-1).
+Even if `Tasks` are scheduled cooperatively, locking may still be required in some contexts, as in
+[asynchronous I/O](@ref faq-async-io).
 This means context switches only occur at well-defined points: in this case,
 when [`remotecall_fetch`](@ref) is called. This is the current state of implementation and it may change
 for future Julia versions, as it is intended to make it possible to run up to N `Tasks` on M `Process`, aka
@@ -1025,7 +1026,7 @@ on a [`RemoteChannel`](@ref) are proxied onto the backing store on the remote pr
 
 [`RemoteChannel`](@ref) can thus be used to refer to user implemented `AbstractChannel` objects.
 A simple example of this is provided in `dictchannel.jl` in the
-[Examples repository](https://github.com/JuliaArchive/Examples), which uses a dictionary as its
+[Examples repository](https://github.com/JuliaAttic/Examples), which uses a dictionary as its
 remote store.
 
 
@@ -1635,7 +1636,7 @@ transport and Julia's in-built parallel infrastructure.
 A `BufferStream` is an in-memory [`IOBuffer`](@ref) which behaves like an `IO`--it is a stream which can
 be handled asynchronously.
 
-The folder `clustermanager/0mq` in the [Examples repository](https://github.com/JuliaArchive/Examples)
+The folder `clustermanager/0mq` in the [Examples repository](https://github.com/JuliaAttic/Examples)
 contains an example of using ZeroMQ to connect Julia workers
 in a star topology with a 0MQ broker in the middle. Note: The Julia processes are still all *logically*
 connected to each other--any worker can message any other worker directly without any awareness
@@ -1885,7 +1886,7 @@ mpirun -np 4 ./julia example.jl
     In this context, MPI refers to the MPI-1 standard. Beginning with MPI-2, the MPI standards committee
     introduced a new set of communication mechanisms, collectively referred to as Remote Memory Access
     (RMA). The motivation for adding rma to the MPI standard was to facilitate one-sided communication
-    patterns. For additional information on the latest MPI standard, see [http://mpi-forum.org/docs](http://mpi-forum.org/docs/).
+    patterns. For additional information on the latest MPI standard, see <https://mpi-forum.org/docs>.
 
 [^2]:
     [Julia GPU man pages](http://juliagpu.github.io/CUDAnative.jl/stable/man/usage.html#Julia-support-1)

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1129,7 +1129,7 @@ Sometimes you can enable better optimization by promising certain program proper
 
 The common idiom of using 1:n to index into an AbstractArray is not safe if the Array uses unconventional indexing,
 and may cause a segmentation fault if bounds checking is turned off. Use `LinearIndices(x)` or `eachindex(x)`
-instead (see also [offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays)).
+instead (see also [offset-arrays](https://docs.julialang.org/en/latest/devdocs/offset-arrays/)).
 
 !!! note
     While `@simd` needs to be placed directly in front of an innermost `for` loop, both `@inbounds` and `@fastmath`

--- a/doc/src/manual/strings.md
+++ b/doc/src/manual/strings.md
@@ -397,7 +397,7 @@ character because `|` is not a valid continuation to it. Finally the string `s2`
 one too high code point.
 
 Julia uses the UTF-8 encoding by default, and support for new encodings can be added by packages.
-For example, the [LegacyStrings.jl](https://github.com/JuliaArchive/LegacyStrings.jl) package
+For example, the [LegacyStrings.jl](https://github.com/JuliaStrings/LegacyStrings.jl) package
 implements `UTF16String` and `UTF32String` types. Additional discussion of other encodings and
 how to implement support for them is beyond the scope of this document for the time being. For
 further discussion of UTF-8 encoding issues, see the section below on [byte array literals](@ref man-byte-array-literals).
@@ -1059,7 +1059,7 @@ some confusion regarding the matter.
 
 Version numbers can easily be expressed with non-standard string literals of the form [`v"..."`](@ref @v_str).
 Version number literals create [`VersionNumber`](@ref) objects which follow the
-specifications of [semantic versioning](http://semver.org),
+specifications of [semantic versioning](https://semver.org/),
 and therefore are composed of major, minor and patch numeric values, followed by pre-release and
 build alpha-numeric annotations. For example, `v"0.2.1-rc1+win64"` is broken into major version
 `0`, minor version `2`, patch version `1`, pre-release `rc1` and build `win64`. When entering

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -1,3 +1,5 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
 #ifndef JL_GCEXT_H
 #define JL_GCEXT_H
 

--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -347,7 +347,7 @@ The `Dates` module approach tries to follow the simple principle of trying to ch
 little as possible when doing [`Period`](@ref) arithmetic. This approach is also often known as
 *calendrical* arithmetic or what you would probably guess if someone were to ask you the same
 calculation in a conversation. Why all the fuss about this? Let's take a classic example: add
-1 month to January 31st, 2014. What's the answer? Javascript will say [March 3](http://www.markhneedham.com/blog/2009/01/07/javascript-add-a-month-to-a-date/)
+1 month to January 31st, 2014. What's the answer? Javascript will say [March 3](https://markhneedham.com/blog/2009/01/07/javascript-add-a-month-to-a-date/)
 (assumes 31 days). PHP says [March 2](https://stackoverflow.com/questions/5760262/php-adding-months-to-a-date-while-not-exceeding-the-last-day-of-the-month)
 (assumes 30 days). The fact is, there is no right answer. In the `Dates` module, it gives
 the result of February 28th. How does it figure that out? I like to think of the classic 7-7-7

--- a/stdlib/LibGit2/docs/src/index.md
+++ b/stdlib/LibGit2/docs/src/index.md
@@ -4,7 +4,7 @@
 DocTestSetup = :(using LibGit2)
 ```
 
-The LibGit2 module provides bindings to [libgit2](https://libgit2.github.com/), a portable C library that
+The LibGit2 module provides bindings to [libgit2](https://libgit2.org/), a portable C library that
 implements core functionality for the [Git](https://git-scm.com/) version control system.
 These bindings are currently used to power Julia's package manager.
 It is expected that this module will eventually be moved into a separate package.
@@ -13,7 +13,7 @@ It is expected that this module will eventually be moved into a separate package
 
 Some of this documentation assumes some prior knowledge of the libgit2 API.
 For more information on some of the objects and methods referenced here, consult the upstream
-[libgit2 API reference](https://libgit2.github.com/libgit2/#v0.25.1).
+[libgit2 API reference](https://libgit2.org/libgit2/#v0.25.1).
 
 ```@docs
 LibGit2.Buffer

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -1,7 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 """
-Interface to [libgit2](https://libgit2.github.com/).
+Interface to [libgit2](https://libgit2.org/).
 """
 module LibGit2
 

--- a/stdlib/LibGit2/src/callbacks.jl
+++ b/stdlib/LibGit2/src/callbacks.jl
@@ -262,7 +262,7 @@ authentication was successful or not. To avoid an infinite loop from repeatedly
 using the same faulty credentials, we will keep track of state using the payload.
 
 For addition details see the LibGit2 guide on
-[authenticating against a server](https://libgit2.github.com/docs/guides/authentication/).
+[authenticating against a server](https://libgit2.org/docs/guides/authentication/).
 """
 function credentials_callback(libgit2credptr::Ptr{Ptr{Cvoid}}, url_ptr::Cstring,
                               username_ptr::Cstring, allowed_types::Cuint,

--- a/stdlib/LibGit2/src/commit.jl
+++ b/stdlib/LibGit2/src/commit.jl
@@ -87,7 +87,7 @@ end
 """
     commit(repo::GitRepo, msg::AbstractString; kwargs...) -> GitHash
 
-Wrapper around [`git_commit_create`](https://libgit2.github.com/libgit2/#HEAD/group/commit/git_commit_create).
+Wrapper around [`git_commit_create`](https://libgit2.org/libgit2/#HEAD/group/commit/git_commit_create).
 Create a commit in the repository `repo`. `msg` is the commit message. Return the OID of the new commit.
 
 The keyword arguments are:

--- a/stdlib/LibGit2/src/diff.jl
+++ b/stdlib/LibGit2/src/diff.jl
@@ -16,10 +16,10 @@ end
 
 Generate a [`GitDiff`](@ref) between `tree` (which will be used for the "old"
 side of the [`DiffDelta`](@ref)) and `repo` (which will be used for the "new" side).
-If `repo` is `cached`, calls [`git_diff_tree_to_index`](https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_tree_to_index).
+If `repo` is `cached`, calls [`git_diff_tree_to_index`](https://libgit2.org/libgit2/#HEAD/group/diff/git_diff_tree_to_index).
 The `cached` version is generally used to examine the diff for staged changes from one
 commit to the next. If `cached` is `false`, calls
-[`git_diff_tree_to_workdir_with_index`](https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_tree_to_workdir_with_index).
+[`git_diff_tree_to_workdir_with_index`](https://libgit2.org/libgit2/#HEAD/group/diff/git_diff_tree_to_workdir_with_index).
 This compares the current working directory against the [`GitIndex`](@ref) and can,
 for example, be used to examine the changes in staged files before a commit.
 """
@@ -43,7 +43,7 @@ end
 
 Generate a [`GitDiff`](@ref) between `oldtree` (which will be used for the "old"
 side of the [`DiffDelta`](@ref)) and `newtree` (which will be used for the "new"
-side of the `DiffDelta`). Equivalent to [`git_diff_tree_to_tree`](https://libgit2.github.com/libgit2/#HEAD/group/diff/git_diff_tree_to_tree).
+side of the `DiffDelta`). Equivalent to [`git_diff_tree_to_tree`](https://libgit2.org/libgit2/#HEAD/group/diff/git_diff_tree_to_tree).
 This can be used to generate a diff between two commits. For instance, it could
 be used to compare a commit made 2 months ago with the current latest commit, or
 to compare a commit on another branch with the current latest commit on `master`.

--- a/stdlib/LibGit2/src/types.jl
+++ b/stdlib/LibGit2/src/types.jl
@@ -40,7 +40,7 @@ end
     LibGit2.TimeStruct
 
 Time in a signature.
-Matches the [`git_time`](https://libgit2.github.com/libgit2/#HEAD/type/git_time) struct.
+Matches the [`git_time`](https://libgit2.org/libgit2/#HEAD/type/git_time) struct.
 """
 struct TimeStruct
     time::Int64     # time in seconds from epoch
@@ -54,7 +54,7 @@ end
     LibGit2.SignatureStruct
 
 An action signature (e.g. for committers, taggers, etc).
-Matches the [`git_signature`](https://libgit2.github.com/libgit2/#HEAD/type/git_signature) struct.
+Matches the [`git_signature`](https://libgit2.org/libgit2/#HEAD/type/git_signature) struct.
 
 The fields represent:
   * `name`: The full name of the committer or author of the commit.
@@ -72,7 +72,7 @@ end
     LibGit2.StrArrayStruct
 
 A LibGit2 representation of an array of strings.
-Matches the [`git_strarray`](https://libgit2.github.com/libgit2/#HEAD/type/git_strarray) struct.
+Matches the [`git_strarray`](https://libgit2.org/libgit2/#HEAD/type/git_strarray) struct.
 
 When fetching data from LibGit2, a typical usage would look like:
 ```julia
@@ -106,7 +106,7 @@ end
     LibGit2.Buffer
 
 A data buffer for exporting data from libgit2.
-Matches the [`git_buf`](https://libgit2.github.com/libgit2/#HEAD/type/git_buf) struct.
+Matches the [`git_buf`](https://libgit2.org/libgit2/#HEAD/type/git_buf) struct.
 
 When fetching data from LibGit2, a typical usage would look like:
 ```julia
@@ -132,7 +132,7 @@ end
 """
     LibGit2.CheckoutOptions
 
-Matches the [`git_checkout_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_checkout_options) struct.
+Matches the [`git_checkout_options`](https://libgit2.org/libgit2/#HEAD/type/git_checkout_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -197,7 +197,7 @@ end
     LibGit2.TransferProgress
 
 Transfer progress information used by the `transfer_progress` remote callback.
-Matches the [`git_transfer_progress`](https://libgit2.github.com/libgit2/#HEAD/type/git_transfer_progress) struct.
+Matches the [`git_transfer_progress`](https://libgit2.org/libgit2/#HEAD/type/git_transfer_progress) struct.
 """
 @kwdef struct TransferProgress
     total_objects::Cuint    = Cuint(0)
@@ -242,7 +242,7 @@ julia> c = LibGit2.Callbacks(:credentials => (LibGit2.credentials_cb(), LibGit2.
 julia> LibGit2.clone(url, callbacks=c);
 ```
 
-See [`git_remote_callbacks`](https://libgit2.github.com/libgit2/#HEAD/type/git_remote_callbacks)
+See [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_remote_callbacks)
 for details on supported callbacks.
 """
 const Callbacks = Dict{Symbol, Tuple{Ptr{Cvoid}, Any}}
@@ -251,7 +251,7 @@ const Callbacks = Dict{Symbol, Tuple{Ptr{Cvoid}, Any}}
     LibGit2.RemoteCallbacks
 
 Callback settings.
-Matches the [`git_remote_callbacks`](https://libgit2.github.com/libgit2/#HEAD/type/git_remote_callbacks) struct.
+Matches the [`git_remote_callbacks`](https://libgit2.org/libgit2/#HEAD/type/git_remote_callbacks) struct.
 """
 struct RemoteCallbacks
     cb::RemoteCallbacksStruct
@@ -282,12 +282,12 @@ end
 
 Options for connecting through a proxy.
 
-Matches the [`git_proxy_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_proxy_options) struct.
+Matches the [`git_proxy_options`](https://libgit2.org/libgit2/#HEAD/type/git_proxy_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
   * `proxytype`: an `enum` for the type of proxy to use.
-     Defined in [`git_proxy_t`](https://libgit2.github.com/libgit2/#HEAD/type/git_proxy_t).
+     Defined in [`git_proxy_t`](https://libgit2.org/libgit2/#HEAD/type/git_proxy_t).
      The corresponding Julia enum is `GIT_PROXY` and has values:
      - `PROXY_NONE`: do not attempt the connection through a proxy.
      - `PROXY_AUTO`: attempt to figure out the proxy configuration from the git configuration.
@@ -336,7 +336,7 @@ end
 """
     LibGit2.FetchOptions
 
-Matches the [`git_fetch_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_fetch_options) struct.
+Matches the [`git_fetch_options`](https://libgit2.org/libgit2/#HEAD/type/git_fetch_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -377,7 +377,7 @@ end
 """
     LibGit2.CloneOptions
 
-Matches the [`git_clone_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_clone_options) struct.
+Matches the [`git_clone_options`](https://libgit2.org/libgit2/#HEAD/type/git_clone_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -407,7 +407,7 @@ end
 """
     LibGit2.DiffOptionsStruct
 
-Matches the [`git_diff_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_diff_options) struct.
+Matches the [`git_diff_options`](https://libgit2.org/libgit2/#HEAD/type/git_diff_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -460,7 +460,7 @@ end
 """
     LibGit2.DescribeOptions
 
-Matches the [`git_describe_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_describe_options) struct.
+Matches the [`git_describe_options`](https://libgit2.org/libgit2/#HEAD/type/git_describe_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -489,7 +489,7 @@ end
 """
     LibGit2.DescribeFormatOptions
 
-Matches the [`git_describe_format_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_describe_format_options) struct.
+Matches the [`git_describe_format_options`](https://libgit2.org/libgit2/#HEAD/type/git_describe_format_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -508,7 +508,7 @@ end
     LibGit2.DiffFile
 
 Description of one side of a delta.
-Matches the [`git_diff_file`](https://libgit2.github.com/libgit2/#HEAD/type/git_diff_file) struct.
+Matches the [`git_diff_file`](https://libgit2.org/libgit2/#HEAD/type/git_diff_file) struct.
 
 The fields represent:
   * `id`: the [`GitHash`](@ref) of the item in the diff. If the item is empty on this
@@ -516,7 +516,7 @@ The fields represent:
      be `GitHash(0)`.
   * `path`: a `NULL` terminated path to the item relative to the working directory of the repository.
   * `size`: the size of the item in bytes.
-  * `flags`: a combination of the [`git_diff_flag_t`](https://libgit2.github.com/libgit2/#HEAD/type/git_diff_flag_t)
+  * `flags`: a combination of the [`git_diff_flag_t`](https://libgit2.org/libgit2/#HEAD/type/git_diff_flag_t)
      flags. The `i`th bit of this integer sets the `i`th flag.
   * `mode`: the [`stat`](@ref) mode for the item.
   * `id_abbrev`: only present in LibGit2 versions newer than or equal to `0.25.0`.
@@ -544,7 +544,7 @@ end
     LibGit2.DiffDelta
 
 Description of changes to one entry.
-Matches the [`git_diff_delta`](https://libgit2.github.com/libgit2/#HEAD/type/git_diff_delta) struct.
+Matches the [`git_diff_delta`](https://libgit2.org/libgit2/#HEAD/type/git_diff_delta) struct.
 
 The fields represent:
   * `status`: One of `Consts.DELTA_STATUS`, indicating whether the file has been added/modified/deleted.
@@ -577,7 +577,7 @@ end
 """
     LibGit2.MergeOptions
 
-Matches the [`git_merge_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_merge_options) struct.
+Matches the [`git_merge_options`](https://libgit2.org/libgit2/#HEAD/type/git_merge_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -636,7 +636,7 @@ end
 """
     LibGit2.BlameOptions
 
-Matches the [`git_blame_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_blame_options) struct.
+Matches the [`git_blame_options`](https://libgit2.org/libgit2/#HEAD/type/git_blame_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -677,7 +677,7 @@ end
 """
     LibGit2.PushOptions
 
-Matches the [`git_push_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_push_options) struct.
+Matches the [`git_push_options`](https://libgit2.org/libgit2/#HEAD/type/git_push_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -702,7 +702,7 @@ end
 """
     LibGit2.CherrypickOptions
 
-Matches the [`git_cherrypick_options`](https://libgit2.github.com/libgit2/#HEAD/type/git_cherrypick_options) struct.
+Matches the [`git_cherrypick_options`](https://libgit2.org/libgit2/#HEAD/type/git_cherrypick_options) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -724,7 +724,7 @@ end
 """
     LibGit2.IndexTime
 
-Matches the [`git_index_time`](https://libgit2.github.com/libgit2/#HEAD/type/git_index_time) struct.
+Matches the [`git_index_time`](https://libgit2.org/libgit2/#HEAD/type/git_index_time) struct.
 """
 struct IndexTime
     seconds::Int64
@@ -735,7 +735,7 @@ end
     LibGit2.IndexEntry
 
 In-memory representation of a file entry in the index.
-Matches the [`git_index_entry`](https://libgit2.github.com/libgit2/#HEAD/type/git_index_entry) struct.
+Matches the [`git_index_entry`](https://libgit2.org/libgit2/#HEAD/type/git_index_entry) struct.
 """
 struct IndexEntry
     ctime::IndexTime
@@ -793,7 +793,7 @@ end
     LibGit2.RebaseOperation
 
 Describes a single instruction/operation to be performed during the rebase.
-Matches the [`git_rebase_operation`](https://libgit2.github.com/libgit2/#HEAD/type/git_rebase_operation_t) struct.
+Matches the [`git_rebase_operation`](https://libgit2.org/libgit2/#HEAD/type/git_rebase_operation_t) struct.
 
 The fields represent:
   * `optype`: the type of rebase operation currently being performed. The options are:
@@ -826,7 +826,7 @@ end
     LibGit2.StatusOptions
 
 Options to control how `git_status_foreach_ext()` will issue callbacks.
-Matches the [`git_status_opt_t`](https://libgit2.github.com/libgit2/#HEAD/type/git_status_opt_t) struct.
+Matches the [`git_status_opt_t`](https://libgit2.org/libgit2/#HEAD/type/git_status_opt_t) struct.
 
 The fields represent:
   * `version`: version of the struct in use, in case this changes later. For now, always `1`.
@@ -908,7 +908,7 @@ end
 """
     LibGit2.ConfigEntry
 
-Matches the [`git_config_entry`](https://libgit2.github.com/libgit2/#HEAD/type/git_config_entry) struct.
+Matches the [`git_config_entry`](https://libgit2.org/libgit2/#HEAD/type/git_config_entry) struct.
 """
 @kwdef struct ConfigEntry
     name::Cstring       = Cstring(C_NULL)
@@ -1050,7 +1050,7 @@ end
     LibGit2.GitSignature
 
 This is a Julia wrapper around a pointer to a
-[`git_signature`](https://libgit2.github.com/libgit2/#HEAD/type/git_signature) object.
+[`git_signature`](https://libgit2.org/libgit2/#HEAD/type/git_signature) object.
 """
 mutable struct GitSignature <: AbstractGitObject
     ptr::Ptr{SignatureStruct}
@@ -1080,7 +1080,7 @@ end
 """
     LibGit2.BlameHunk
 
-Matches the [`git_blame_hunk`](https://libgit2.github.com/libgit2/#HEAD/type/git_blame_hunk) struct.
+Matches the [`git_blame_hunk`](https://libgit2.org/libgit2/#HEAD/type/git_blame_hunk) struct.
 The fields represent:
     * `lines_in_hunk`: the number of lines in this hunk of the blame.
     * `final_commit_id`: the [`GitHash`](@ref) of the commit where this section was last changed.

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -1,3 +1,5 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
 using Test
 using Base: catch_stack
 


### PR DESCRIPTION
Same changes as https://github.com/JuliaLang/julia/pull/30532 but applied to `master`, and without the NEWS update, as that causes unnecessary merge conflicts with other PRs.