### PR TITLE
Loosen mmap offset signature for BitArray types

### DIFF
--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -286,7 +286,7 @@ julia> rm("mmap.bin")
 This creates a 25-by-30000 `BitArray`, linked to the file associated with stream `io`.
 """
 function mmap(io::IOStream, ::Type{<:BitArray}, dims::NTuple{N,Integer},
-              offset::Int64=position(io); grow::Bool=true, shared::Bool=true) where N
+              offset::Integer=position(io); grow::Bool=true, shared::Bool=true) where N
     n = prod(dims)
     nc = Base.num_bit_chunks(n)
     chunks = mmap(io, Vector{UInt64}, (nc,), offset; grow=grow, shared=shared)

--- a/stdlib/Mmap/test/runtests.jl
+++ b/stdlib/Mmap/test/runtests.jl
@@ -303,3 +303,14 @@ open(file, "r+") do s
     finalize(A); A = nothing; GC.gc()
 end
 rm(file)
+
+# test #30537
+file = tempname()
+rdat = rand(128)
+open(f->write(f, rdat), file, "w+")
+for T in (Int32, UInt32, UInt64, Int64)
+    Mmap.mmap(file, BitVector, (64), T(8))
+end
+GC.gc()
+rm(file)
+


### PR DESCRIPTION
[Documentation](https://docs.julialang.org/en/v1.0/stdlib/Mmap/#Mmap.mmap) states that the signature for mmap to BitArray types is identical to that of normal arrays, though in fact the type required for the offset is more specific. 

(This is pertinent because these methods can be put to good use in manipulating memory mapped registers on embedded systems, where it is natural to express an offset in, e.g., `/dev/mem/` using the word size of the machine, often < 64 bits.)
