### PR TITLE
Don't use OpenBLAS from BinaryBuilder on AppVeyor

### DIFF
--- a/contrib/windows/appveyor_build.sh
+++ b/contrib/windows/appveyor_build.sh
@@ -196,7 +196,6 @@ if [ -n "$USEMSVC" ]; then
 else
   # Use BinaryBuilder
   echo 'USE_BINARYBUILDER_LLVM = 1' >> Make.user
-  echo 'USE_BINARYBUILDER_OPENBLAS = 1' >> Make.user
   echo 'BINARYBUILDER_LLVM_ASSERTS = 1' >> Make.user
   echo 'override DEP_LIBS += llvm openlibm' >> Make.user
   export CCACHE_DIR=/cygdrive/c/ccache


### PR DESCRIPTION
Shot in the dark at fixing the recent CI failures.