### PR TITLE
Update the various links at the top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,11 @@ This is the GitHub repository of Julia source code, including instructions for c
 
 - **Homepage:** <https://julialang.org>
 - **Binaries:** <https://julialang.org/downloads/>
-- **Documentation:** <https://docs.julialang.org/>
-- **Packages:** <https://pkg.julialang.org/>
 - **Source code:** <https://github.com/JuliaLang/julia>
-- **Git clone URL:** <git://github.com/JuliaLang/julia.git>
+- **Documentation:** <https://docs.julialang.org/>
+- **Packages:** <https://juliaobserver.com/>
 - **Discussion forum:** <https://discourse.julialang.org>
-- **Mailing lists:** <https://julialang.org/community/>
 - **Slack:** <https://julialang.slack.com> (get an invite from <https://slackinvite.julialang.org>)
-- **Gitter:** <https://gitter.im/JuliaLang/julia>
-- **IRC:** <https://webchat.freenode.net/?channels=julia>
 - **Code coverage:** <https://coveralls.io/r/JuliaLang/julia>
 
 New developers may find the notes in [CONTRIBUTING](https://github.com/JuliaLang/julia/blob/master/CONTRIBUTING.md) helpful to start contributing to the Julia codebase.


### PR DESCRIPTION
Deleting Gitter and IRC, so that Slack is the default place people join. I do see a lot of traffic on gitter, and perhaps we want to retain Gitter (with maybe a note that nudges people towards slack?). In any case, I think it is best to remove IRC.

The mailing lists was not really pointing to mailing lists - so removing is best.

Having source code and git clone URL seemed a bit redundant.

Removed the link to pkg.julialang.org so people are not directed there. (Perhaps we should just take it down).