### PR TITLE
Fix PCRE2 error constants and gracefully handle disabled JIT

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -14,7 +14,7 @@ endif
 
 all: $(addprefix $(BUILDDIR)/,pcre_h.jl errno_h.jl build_h.jl.phony file_constants.jl uv_constants.jl version_git.jl.phony)
 
-PCRE_CONST := 0x[0-9a-fA-F]+|[0-9]+
+PCRE_CONST := 0x[0-9a-fA-F]+|[0-9]+|\([\-0-9]+\)
 ifeq ($(USE_SYSTEM_PCRE), 1)
   PCRE_INCL_PATH := $(shell $(PCRE_CONFIG) --prefix)/include/pcre2.h
 else
@@ -22,7 +22,7 @@ else
 endif
 
 $(BUILDDIR)/pcre_h.jl: $(PCRE_INCL_PATH)
-	@$(call PRINT_PERL, $(CPP) -D PCRE2_CODE_UNIT_WIDTH=8 -dM $< | perl -nle '/^\s*#define\s+PCRE2_(\w*)\s*\(?($(PCRE_CONST))\)?u?\s*$$/ and print "const $$1 = UInt32($$2)"' | LC_ALL=C sort > $@)
+	@$(call PRINT_PERL, $(CPP) -D PCRE2_CODE_UNIT_WIDTH=8 -dM $< | perl -nle '/^\s*#define\s+PCRE2_(\w*)\s*\(?($(PCRE_CONST))\)?u?\s*$$/ and print "const $$1 = $$2 % UInt32"' | LC_ALL=C sort > $@)
 
 $(BUILDDIR)/errno_h.jl:
 	@$(call PRINT_PERL, echo '#include <errno.h>' | $(CPP) -dM - | perl -nle 'print "const $$1 = Int32($$2)" if /^#define\s+(E\w+)\s+(\d+)\s*$$/' | LC_ALL=C sort > $@)

--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -76,7 +76,7 @@ function info(regex::Ptr{Cvoid}, what::Integer, ::Type{T}) where T
     buf = RefValue{T}()
     ret = ccall((:pcre2_pattern_info_8, PCRE_LIB), Int32,
                 (Ptr{Cvoid}, Int32, Ptr{Cvoid}),
-                regex, what, buf)
+                regex, what, buf) % UInt32
     if ret != 0
         error(ret == ERROR_NULL      ? "NULL regex object" :
               ret == ERROR_BADMAGIC  ? "invalid regex object" :
@@ -106,8 +106,10 @@ end
 
 function jit_compile(regex::Ptr{Cvoid})
     errno = ccall((:pcre2_jit_compile_8, PCRE_LIB), Cint,
-                  (Ptr{Cvoid}, UInt32), regex, JIT_COMPLETE)
-    errno == 0 || error("PCRE JIT error: $(err_message(errno))")
+                  (Ptr{Cvoid}, UInt32), regex, JIT_COMPLETE) % UInt32
+    errno == 0 && return true
+    errno == ERROR_JIT_BADOPTION && return false
+    error("PCRE JIT error: $(err_message(errno))")
 end
 
 free_match_data(match_data) =

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -65,4 +65,8 @@
 
     # Regex behaves like a scalar in broadcasting
     @test occursin.(r"Hello", ["Hello", "World"]) == [true, false]
+
+    # Test that PCRE throws the correct kind of error
+    # TODO: Uncomment this once the corresponding change has propagated to CI
+    #@test_throws ErrorException Base.PCRE.info(C_NULL, Base.PCRE.INFO_NAMECOUNT, UInt32)
 end


### PR DESCRIPTION
When the JIT is disabled, the PCRE.jit_compile function would throw
to complain. That's not particularly nice, since we don't check before
whether the JIT is enabled. Instead, return a boolean to indicate whether
the jit was enabled (other errors still throw at jit compile time).
While I was at it, I noticed that we no longer have the ERROR_ flags
in pcre_h.jl (I'm sure we once did, because there's other parts of
this file that use them, in particular the error path in PCRE.info).
Adjust the regex to also capture those error falgs, which are specified
as e.g.:
```
#define PCRE2_ERROR_JIT_BADOPTION     (-45)
```
Finally, add a test for the error path in PCRE.info to make sure it
throws an ErrorException, not an UndefVarError.