### PR TITLE
Fix comparison in `getipaddrs()` test with multiple IPs

### DIFF
--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -424,7 +424,7 @@ end
     @test getipaddr() in getipaddrs()
 
     @testset "include lo" begin
-        @test getipaddrs(true) >= getipaddrs()
+        @test issubset(getipaddrs(), getipaddrs(true))
     end
 end
 


### PR DESCRIPTION
Thanks to @samuel-massinon for the quick fix suggestion in https://github.com/JuliaLang/julia/pull/30349#issuecomment-450692151

This fixes errors we've been seeing on the buildbots in the `Sockets` test case.