### PR TITLE
module.c: clarify assignment error message

### DIFF
--- a/doc/src/manual/variables.md
+++ b/doc/src/manual/variables.md
@@ -81,13 +81,13 @@ julia> pi
 π = 3.1415926535897...
 
 julia> pi = 3
-ERROR: cannot assign variable MathConstants.pi from module Main
+ERROR: cannot assign a value to variable MathConstants.pi from module Main
 
 julia> sqrt(100)
 10.0
 
 julia> sqrt = 4
-ERROR: cannot assign variable Base.sqrt from module Main
+ERROR: cannot assign a value to variable Base.sqrt from module Main
 ```
 
 ## Allowed Variable Names

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3243,7 +3243,7 @@ static Value *global_binding_pointer(jl_codectx_t &ctx, jl_module_t *m, jl_sym_t
         assert(b != NULL);
         if (b->owner != m) {
             char *msg;
-            (void)asprintf(&msg, "cannot assign variable %s.%s from module %s",
+            (void)asprintf(&msg, "cannot assign a value to variable %s.%s from module %s",
                     jl_symbol_name(b->owner->name), jl_symbol_name(s), jl_symbol_name(m->name));
             emit_error(ctx, msg);
             free(msg);

--- a/src/module.c
+++ b/src/module.c
@@ -114,7 +114,7 @@ JL_DLLEXPORT jl_binding_t *jl_get_binding_wr(jl_module_t *m, jl_sym_t *var, int 
                 b->owner = m;
             }
             else if (error) {
-                jl_errorf("cannot assign variable %s.%s from module %s",
+                jl_errorf("cannot assign a value to variable %s.%s from module %s",
                           jl_symbol_name(b->owner->name), jl_symbol_name(var), jl_symbol_name(m->name));
             }
         }


### PR DESCRIPTION
This is a small wording change to make the assignment error message more intuitive. It was first reported in [this discourse thread](https://discourse.julialang.org/t/confusing-error-message/18997).

I found an identical string in https://github.com/JuliaLang/julia/blob/8221c87b09b8456f4fe422ee2d8756a2a2630c7b/src/codegen.cpp#L3246

Should I also change that? Is there any simple way to avoid duplicating the message?