### PR TITLE
some latency hacks

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -267,7 +267,7 @@ offset `do`. Return `dest`.
 """
 function copyto!(dest::Array{T}, doffs::Integer, src::Array{T}, soffs::Integer, n::Integer) where T
     n == 0 && return dest
-    n > 0 || _throw_argerror(n)
+    n > 0 || _throw_argerror()
     if soffs < 1 || doffs < 1 || soffs+n-1 > length(src) || doffs+n-1 > length(dest)
         throw(BoundsError())
     end
@@ -276,10 +276,11 @@ function copyto!(dest::Array{T}, doffs::Integer, src::Array{T}, soffs::Integer, 
 end
 
 # Outlining this because otherwise a catastrophic inference slowdown
-# occurs, see discussion in #27874
-function _throw_argerror(n)
+# occurs, see discussion in #27874.
+# It is also mitigated by using a constant string.
+function _throw_argerror()
     @_noinline_meta
-    throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
+    throw(ArgumentError("Number of elements to copy must be nonnegative."))
 end
 
 copyto!(dest::Array{T}, src::Array{T}) where {T} = copyto!(dest, 1, src, 1, length(src))

--- a/base/checked.jl
+++ b/base/checked.jl
@@ -87,7 +87,7 @@ function checked_neg(x::T) where T<:Integer
     checked_sub(T(0), x)
 end
 throw_overflowerr_negation(x) = (@_noinline_meta;
-    throw(OverflowError("checked arithmetic: cannot compute -x for x = $x::$(typeof(x))")))
+    throw(OverflowError(Base.invokelatest(string, "checked arithmetic: cannot compute -x for x = ", x, "::", typeof(x)))))
 if BrokenSignedInt != Union{}
 function checked_neg(x::BrokenSignedInt)
     r = -x
@@ -151,7 +151,7 @@ end
 
 
 throw_overflowerr_binaryop(op, x, y) = (@_noinline_meta;
-    throw(OverflowError("$x $op $y overflowed for type $(typeof(x))")))
+    throw(OverflowError(Base.invokelatest(string, x, " ", op, "y", " overflowed for type ", typeof(x)))))
 
 """
     Base.checked_add(x, y)

--- a/base/show.jl
+++ b/base/show.jl
@@ -455,14 +455,14 @@ function show_type_name(io::IO, tn::Core.TypeName)
     globname = isdefined(tn, :mt) ? tn.mt.name : nothing
     globfunc = false
     if globname !== nothing
-        globname_str = string(globname)
+        globname_str = string(globname::Symbol)
         if ('#' ∉ globname_str && '@' ∉ globname_str && isdefined(tn, :module) &&
                 isbindingresolved(tn.module, globname) && isdefined(tn.module, globname) &&
                 isconcretetype(tn.wrapper) && isa(getfield(tn.module, globname), tn.wrapper))
             globfunc = true
         end
     end
-    sym = globfunc ? globname : tn.name
+    sym = (globfunc ? globname : tn.name)::Symbol
     if get(io, :compact, false)
         if globfunc
             return print(io, "typeof(", sym, ")")

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -105,6 +105,7 @@ end
 
 tostr_sizehint(x) = 8
 tostr_sizehint(x::AbstractString) = lastindex(x)
+tostr_sizehint(x::Union{String,SubString{String}}) = sizeof(x)
 tostr_sizehint(x::Float64) = 20
 tostr_sizehint(x::Float32) = 12
 

--- a/stdlib/Distributed/src/managers.jl
+++ b/stdlib/Distributed/src/managers.jl
@@ -373,7 +373,7 @@ manage
 struct DefaultClusterManager <: ClusterManager
 end
 
-const tunnel_hosts_map = Dict{AbstractString, Semaphore}()
+const tunnel_hosts_map = Dict{String, Semaphore}()
 
 """
     connect(manager::ClusterManager, pid::Int, config::WorkerConfig) -> (instrm::IO, outstrm::IO)


### PR DESCRIPTION
These changes cut some method dependency edges that tend to lead to invalidations when loading packages. Cuts another 10-15 seconds off the time to precompile DataFrames. Hopefully knowing the exact negative element count passed to `copyto!` is not essential.