### PR TITLE
reflection.jl raises ArgumentError rather than a generic ErrorException

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -709,11 +709,11 @@ function to_tuple_type(@nospecialize(t))
     if isa(t,Type) && t<:Tuple
         for p in unwrap_unionall(t).parameters
             if !(isa(p,Type) || isa(p,TypeVar))
-                error("argument tuple type must contain only types")
+                throw(ArgumentError("argument tuple type must contain only types"))
             end
         end
     else
-        error("expected tuple type")
+        throw(ArgumentError("expected tuple type"))
     end
     t
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1035,7 +1035,7 @@ Returns a tuple `(filename,line)` giving the location of a `Method` definition.
 function functionloc(m::Method)
     ln = m.line
     if ln <= 0
-        throw(ArgumentError("could not determine location of method definition"))
+        error("could not determine location of method definition")
     end
     return (find_source_file(string(m.file)), ln)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1051,13 +1051,13 @@ function functionloc(@nospecialize(f))
     mt = methods(f)
     if isempty(mt)
         if isa(f, Function)
-            error("function has no definitions")
+            throw(ArgumentError("function has no definitions"))
         else
-            error("object is not callable")
+            throw(ArgumentError("object is not callable"))
         end
     end
     if length(mt) > 1
-        error("function has multiple methods; please specify a type signature")
+        throw(ArgumentError("function has multiple methods; please specify a type signature"))
     end
     return functionloc(first(mt))
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1012,7 +1012,7 @@ Return the module in which the binding for the variable referenced by `symbol` i
 """
 function which(m::Module, s::Symbol)
     if !isdefined(m, s)
-        error("\"$s\" is not defined in module $m")
+        throw(ArgumentError("\"$s\" is not defined in module $m"))
     end
     return binding_module(m, s)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1035,7 +1035,7 @@ Returns a tuple `(filename,line)` giving the location of a `Method` definition.
 function functionloc(m::Method)
     ln = m.line
     if ln <= 0
-        error("could not determine location of method definition")
+        throw(ArgumentError("could not determine location of method definition"))
     end
     return (find_source_file(string(m.file)), ln)
 end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1078,7 +1078,7 @@ Determine the module containing a given definition of a generic function.
 function parentmodule(@nospecialize(f), @nospecialize(types))
     m = methods(f, types)
     if isempty(m)
-        error("no matching methods")
+        throw(ArgumentError("no matching methods"))
     end
     return first(m).module
 end


### PR DESCRIPTION
Would be better to be specific about the type of an error when raising and handling exceptions.