### PR TITLE
fix type annotation of dynamic `new` expressions in codegen

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4065,6 +4065,8 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         }
         Value *typ = boxed(ctx, argv[0]);
         Value *val = emit_jlcall(ctx, jlnew_func, typ, &argv[1], nargs - 1);
+        // temporarily mark as `Any`, expecting `emit_ssaval_assign` to update
+        // it to the inferred type.
         return mark_julia_type(ctx, val, true, (jl_value_t*)jl_any_type);
     }
     else if (head == exc_sym) {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -4065,7 +4065,7 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
         }
         Value *typ = boxed(ctx, argv[0]);
         Value *val = emit_jlcall(ctx, jlnew_func, typ, &argv[1], nargs - 1);
-        return mark_julia_type(ctx, val, true, ty);
+        return mark_julia_type(ctx, val, true, (jl_value_t*)jl_any_type);
     }
     else if (head == exc_sym) {
         return mark_julia_type(ctx,


### PR DESCRIPTION
Here `ty` is the type of the type, not the type of the new instance. This code path is very difficult to hit; in fact we might not ever hit it in practice. But might as well get it right.