### PR TITLE
[WIP] Add `QueuePool` abstraction to `Distributed`

### DIFF
--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -88,6 +88,7 @@ include("process_messages.jl")  # process incoming messages
 include("remotecall.jl")  # the remotecall* api
 include("macros.jl")      # @spawn and friends
 include("workerpool.jl")
+include("queuepool.jl")   # QueuePool
 include("pmap.jl")
 include("managers.jl")    # LocalManager and SSHManager
 include("precompile.jl")

--- a/stdlib/Distributed/src/queuepool.jl
+++ b/stdlib/Distributed/src/queuepool.jl
@@ -188,7 +188,7 @@ function take!(qp::QueuePool; timeout::Number = Inf)
     )
 
     if ret == :error
-        throw("Timeout within take!()")
+        error("Timeout within take!()")
     end
 
     if isempty(qp.results_buffer)

--- a/stdlib/Distributed/src/queuepool.jl
+++ b/stdlib/Distributed/src/queuepool.jl
@@ -1,0 +1,252 @@
+export QueuePool, close, push_job!, fetch_result
+import Base: close
+
+"""
+    QueuePool
+
+A pool of workers that asynchronously execute jobs passed to them, with
+facilities for both in-order and out-of-order result fetching.  This construct
+is intended to act like an asynchronous `pmap()`, allowing streaming parallel
+operations to dynamically add jobs to a work queue and fetch results with a
+minimum of fuss. To use, construct a `QueuePool`, submit work items with
+`push_job!()`, and get output through `fetch_result()`.  Example usage:
+
+```julia
+using Distributed
+
+workers = addprocs(Sys.CPU_THREADS-1)
+
+using Statistics
+@everywhere function do_work(x, y)
+    # Be sure to import Statistics for `mean()`
+    z = mean((x .+ y).^2)
+    sleep(1 + sum(z))
+    return z
+end
+
+# Create QueuePool to call `do_work()` on every submitted job
+qp = QueuePool(workers, do_work; setup=:(using Statistics))
+
+# Queue many jobs (they will immediately start processing)
+for idx in 1:10000
+    push_job!(qp, randn(10, 10), randn(10))
+end
+
+# pull results out, first asking for specific job IDs.  Note that if we were to
+# request a job ID too far into the future, this would pause interminably, as
+# the worker threads would run up against the default `queue_size` limit of 128,
+# refusing to calculate further results until an earlier result is fetched, so
+# if fetching specific results is important, be sure to that the `queue_size` is
+# set large enough to guarantee that all results will be fetchable.
+fetch_result(qp, 1)
+fetch_result(qp, 10)
+fetch_result(qp, 100)
+
+# Next, just pull out whatever results are available quickest:
+[fetch_result(qp) for idx in 1:222]
+
+# Finally, fetch a result from far in the future, but timing out if it doesn't
+# show up within 10 seconds:
+try
+    fetch_result(qp, 9999; timeout=10.0)
+catch
+    println("Could not fetch jod_id 9999!")
+end
+```
+"""
+mutable struct QueuePool
+    # The worker PIDs
+    workers::Vector{Int}
+
+    # The setup code we execute on the workers
+    setup::Expr
+
+    # Channels for communication
+    queued_jobs::RemoteChannel
+    results::RemoteChannel
+    kill_switch::RemoteChannel
+
+    # The ID of the next job to be submitted
+    next_job::Int
+
+    # Buffer space where we store results for out-of-order execution
+    results_buffer::Dict{Int,Any}
+end
+
+"""
+    QueuePool(workers, proc_func; setup = nothing, queue_size=128)
+
+Construct a QueuePool that wraps the `workers` worker processes, each executing
+`proc_func()` on items submitted to the `QueuePool` via the `push_job!()`
+method. If the quoted expression `setup` is given, it will be executed once on
+each worker before `proc_func` is ever called.  Queued jobs can be added
+without limit, however the workers will process results only up to the given
+`queue_size` limit; if more than `queue_size` results are waiting to be
+fetched, further result calculation will be blocked.
+"""
+function QueuePool(workers::Vector{Int}, proc_func::Function; setup::Expr=quote nothing end, queue_size::Int=128)
+    # Create our QueuePool
+    qp = QueuePool(
+        workers,
+        setup,
+        RemoteChannel(() -> Channel{Tuple}(Inf)),
+        RemoteChannel(() -> Channel{Tuple}(queue_size)),
+        RemoteChannel(() -> Channel{Bool}(1)),
+        1,
+        Dict{Int,Any}(),
+    )
+
+    # Launch workers, running the `worker_task` with a handle to this QueuePool object
+    # and the processing function that will be called within the worker loop.
+    for id in workers
+        remote_do(worker_task, id, qp, proc_func)
+    end
+
+    # Return the queuepool
+    return qp
+end
+
+"""
+    QueuePool(num_workers, proc_func, setup = nothing, queue_size=128)
+
+A variant of the `QueuePool` constructor that takes the number of workers to be
+created rather than already-created worker IDs.
+"""
+function QueuePool(num_workers::Int, args...; kwargs...)
+    # Auto-create the workers
+    workers = addprocs(num_workers)
+
+    return QueuePool(workers, args...; kwargs...)
+end
+
+"""
+    close(qp::QueuePool)
+
+Close the given `QueuePool`, destroying all queue workers
+"""
+function close(qp::QueuePool)
+    # Tell the worker processes to die
+    put!(qp.kill_switch, true)
+
+    # Wait for the workers to descend into the long, dark sleep
+    rmprocs(qp.workers...; waitfor=10)
+end
+
+function worker_task(qp::QueuePool, proc_func)
+    # Tell the workers to include this file and whatever other setup they need,
+    # so that they can communicate with us and complete their tasks.
+    #include(@__FILE__)
+    Core.eval(Main, qp.setup)
+
+    # Loop unless we're burning this whole queue pool down
+    while !isready(qp.kill_switch)
+        # Grab the next queued job from the master
+        local job_id, args
+        try
+            job_id, args = take!(qp.queued_jobs)
+        catch e
+            # If we can't `take!()`, zoom to the kill switch check
+            if isa(e, InvalidStateException)
+                continue
+            end
+            rethrow(e)
+        end
+
+        local y
+        try
+            # Push x through proc_func to get y
+            y = proc_func(args...)
+        catch e
+            if isa(e, InterruptException)
+                rethrow(e)
+            end
+            # Just skip bad processing runs
+            continue
+        end
+
+        # Push the result onto qp.results
+        put!(qp.results, (job_id, y))
+    end
+end
+
+
+"""
+    try_buffer_result!(qp::QueuePool)
+
+Does a nonblocking read of the next result from the QueuePool into our result
+buffer.  If no result is available, returns `nothing` immediately.
+"""
+function try_buffer_result!(qp::QueuePool)
+    if isready(qp.results)
+        job_id, result = take!(qp.results)
+        qp.results_buffer[job_id] = result
+        return job_id
+    end
+    return
+end
+
+# Check to see if it's `nothing` and `yield()` if it is.
+function try_buffer_result!(qp::QueuePool, t_start::Number, timeout::Nothing)
+    if try_buffer_result!(qp) == nothing
+        # No new results available, so just yield
+        yield()
+    end
+end
+
+# Check to see if we've broken through our timeout
+function try_buffer_result!(qp::QueuePool, t_start::Number, timeout::Number)
+    try_buffer_result!(qp, t_start, nothing)
+
+    if (time() - t_start) > timeout
+        error("timeout within fetch_result")
+    end
+end
+
+
+
+"""
+    push_job!(qp::QueuePool, args...)
+
+Push a new job onto the QueuePool, returning the associated job id with this
+job, for future usage with `fetch_result(qp, job_id)`.  `args...` will be passed
+to the `proc_func` within `qp`.
+"""
+function push_job!(qp::QueuePool, args...)
+    job_id = qp.next_job
+    qp.next_job += 1
+
+    put!(qp.queued_jobs, (job_id, args))
+    return job_id
+end
+
+"""
+    fetch_result(qp::QueuePool; timeout = nothing)
+
+Return a result from the QueuePool, regardless of order.  By default, will wait
+for forever; set `timeout` to a value in seconds to time out and throw an error
+if a value does not arrive.
+"""
+function fetch_result(qp::QueuePool; timeout = nothing)
+    # If we don't have any results buffered, then pull one in
+    t_start = time()
+    while isempty(qp.results_buffer)
+        try_buffer_result!(qp, t_start, timeout)
+    end
+    return pop!(qp.results_buffer).second
+end
+
+"""
+    fetch_result(qp::QueuePool, job_id::Int; timeout = nothing)
+
+Return a result from the QueuePool, in specific order.  By default, will wait
+for forever; set `timeout` to a value in seconds to time out and throw an error
+if a value does not arrive.
+"""
+function fetch_result(qp::QueuePool, job_id::Int; timeout=nothing)
+    # Keep accumulating results until we get the job_id we're interested in.
+    t_start = time()
+    while !haskey(qp.results_buffer, job_id)
+        try_buffer_result!(qp, t_start, timeout)
+    end
+    return pop!(qp.results_buffer, job_id)
+end

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -1559,3 +1559,4 @@ end
 # cluster at any time only supports a single topology.
 rmprocs(workers())
 include("topology.jl")
+include("queuepool.jl")

--- a/stdlib/Distributed/test/queuepool.jl
+++ b/stdlib/Distributed/test/queuepool.jl
@@ -1,0 +1,60 @@
+using Statistics, Distributed, Test
+
+#addprocs_with_testenv = addprocs
+
+# Create QueuePool to call `do_work()` on every submitted job
+qp_workers = addprocs_with_testenv(4)
+qp = QueuePool(qp_workers, identity)
+
+# Queue many jobs (they will immediately start processing)
+for idx in 1:100
+    push_job!(qp, idx)
+end
+
+# First, test that we can fetch results in the order we ask
+@test fetch_result(qp, 1) == 1
+@test fetch_result(qp, 4) == 4
+@test fetch_result(qp, 10) == 10
+@test fetch_result(qp, 100) == 100
+
+# Next, test fetching results in a greedy way gets literally anything
+# other than what we've already gotten:
+for idx in 1:50
+    @test !in(fetch_result(qp), [1, 4, 10, 100])
+end
+
+# Destroy the queuepool
+close(qp)
+
+# Create test that uses functions that must be imported
+num_workers = 4
+qp_workers = addprocs_with_testenv(num_workers)
+@everywhere function do_work(x, y)
+    # Be sure to import Statistics for `mean()`
+    sleep(rand(1:100)./10000.0)
+    return mean((x .+ y).^2)
+end
+
+qp = QueuePool(qp_workers, do_work; setup = :(using Statistics))
+for idx in 1:4
+    push_job!(qp, randn(10, 10), randn(10))
+end
+
+for idx in 1:4
+    z = fetch_result(qp)
+    @test z > 0.0 && z < 10.0
+end
+close(qp)
+
+
+# Finally, test timeouts
+qp_workers = addprocs_with_testenv(1)
+qp = QueuePool(qp_workers, x -> sleep(x); queue_size = 10)
+
+for idx in 0:4
+    push_job!(qp, idx*1000)
+end
+@test fetch_result(qp, 1; timeout=10) == nothing
+@test_throws ErrorException fetch_result(qp, 2; timeout=10)
+
+close(qp)

--- a/stdlib/Distributed/test/queuepool.jl
+++ b/stdlib/Distributed/test/queuepool.jl
@@ -1,60 +1,63 @@
 using Statistics, Distributed, Test
 
-#addprocs_with_testenv = addprocs
-
 # Create QueuePool to call `do_work()` on every submitted job
-qp_workers = addprocs_with_testenv(4)
-qp = QueuePool(qp_workers, identity)
+qp_workers = addprocs(4)
 
-# Queue many jobs (they will immediately start processing)
-for idx in 1:100
-    push_job!(qp, idx)
+@testset "QueuePool" begin
+    @testset "Simple push!()/take!()" begin
+        qp = QueuePool(qp_workers, identity)
+
+        # Queue many jobs (they will immediately start processing)
+        for idx in 1:100
+            push!(qp, idx)
+        end
+
+        # First, test that we can fetch results in the order we ask
+        @test take!(qp, 1) == 1
+        @test take!(qp, 4) == 4
+        @test take!(qp, 10) == 10
+        @test take!(qp, 100) == 100
+
+        # Next, test fetching results in a greedy way gets literally anything
+        # other than what we've already gotten:
+        for idx in 1:50
+            @test !in(take!(qp), [1, 4, 10, 100])
+        end
+
+        # Ensure we can explicitly call `close()`
+        close(qp)
+    end
+
+    @testset "Setup/Work function" begin
+        # Create test that uses functions that must be imported
+        @everywhere function do_work(x, y)
+            # Be sure to import Statistics for `mean()`
+            sleep(rand(1:100)./10000.0)
+            return mean((x .+ y).^2)
+        end
+
+        qp = QueuePool(qp_workers, do_work; setup = :(using Statistics))
+        for idx in 1:4
+            push!(qp, randn(10, 10), randn(10))
+        end
+
+        for idx in 1:4
+            z = take!(qp)
+            @test z > 0.0 && z < 10.0
+        end
+    end
+
+    @testset "Timeouts" begin
+        # Finally, test timeouts
+        qp = QueuePool(qp_workers, x -> sleep(x); queue_size = 10)
+
+        for idx in 0:4
+            push!(qp, idx*1000)
+        end
+        @test take!(qp, 1; timeout=10) == nothing
+        @test_throws ErrorException take!(qp, 2; timeout=10)
+    end
 end
 
-# First, test that we can fetch results in the order we ask
-@test fetch_result(qp, 1) == 1
-@test fetch_result(qp, 4) == 4
-@test fetch_result(qp, 10) == 10
-@test fetch_result(qp, 100) == 100
+rmprocs(qp_workers...; waitfor=10)
 
-# Next, test fetching results in a greedy way gets literally anything
-# other than what we've already gotten:
-for idx in 1:50
-    @test !in(fetch_result(qp), [1, 4, 10, 100])
-end
-
-# Destroy the queuepool
-close(qp)
-
-# Create test that uses functions that must be imported
-num_workers = 4
-qp_workers = addprocs_with_testenv(num_workers)
-@everywhere function do_work(x, y)
-    # Be sure to import Statistics for `mean()`
-    sleep(rand(1:100)./10000.0)
-    return mean((x .+ y).^2)
-end
-
-qp = QueuePool(qp_workers, do_work; setup = :(using Statistics))
-for idx in 1:4
-    push_job!(qp, randn(10, 10), randn(10))
-end
-
-for idx in 1:4
-    z = fetch_result(qp)
-    @test z > 0.0 && z < 10.0
-end
-close(qp)
-
-
-# Finally, test timeouts
-qp_workers = addprocs_with_testenv(1)
-qp = QueuePool(qp_workers, x -> sleep(x); queue_size = 10)
-
-for idx in 0:4
-    push_job!(qp, idx*1000)
-end
-@test fetch_result(qp, 1; timeout=10) == nothing
-@test_throws ErrorException fetch_result(qp, 2; timeout=10)
-
-close(qp)

--- a/stdlib/Distributed/test/topology.jl
+++ b/stdlib/Distributed/test/topology.jl
@@ -141,3 +141,4 @@ def_count_conn()
 
 # Cannot add more workers with a different `lazy` value
 @test_throws ArgumentError addprocs_with_testenv(1; lazy=true)
+rmprocs(workers())


### PR DESCRIPTION
I wrote this up as a helper class for some of our ML work, and I thought it would be useful to have as a general tool.  It solves a slightly different problem than `pmap`; it allows for "streaming" parallel operations (e.g. queue 10,000 operations, but then deal with the results as they come in, and even add more while you are pulling some out).

It works fairly well, the main pain points are the following:

* Code loading is somewhat restrictive; you have to first create your workers via `addprocs()`, then define your worker function with `@everywhere`, then create your `QueuePool`.

* The way I've implemented timeouts for waiting for a new result is awful.  I really just need a `wait(condition; timeout=x)` primitive, but one doesn't seem to exist.

* I wanted to add `close()` as a finalizer to a `QueuePool`, but it seems that finalizers cannot switch tasks, which `rmprocs()` tries to do.  What is the best way to do this?