### PR TITLE
fix typeinfo for sparse-matrix/vector display

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -152,7 +152,7 @@ function Base.show(io::IO, ::MIME"text/plain", S::SparseMatrixCSC)
               xnnz == 1 ? "entry" : "entries")
     if xnnz != 0
         print(io, ":")
-        show(io, S)
+        show(IOContext(io, :typeinfo => eltype(S)), S)
     end
 end
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -170,18 +170,16 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
         return
     end
 
-    iob = IOBuffer()
-    ioc = IOContext(iob, :compact => true)
+    ioc = IOContext(io, :compact => true)
 
-    function _format_line(r, col)
+    function _format_line(ioc, r, col)
         pad = ndigits(max(S.m, S.n))
-        print(ioc, "  [", rpad(S.rowval[r], pad), ", ", lpad(col, pad), "]  =  ")
+        print(ioc, "\n  [", rpad(S.rowval[r], pad), ", ", lpad(col, pad), "]  =  ")
         if isassigned(S.nzval, Int(r))
             show(ioc, S.nzval[r])
         else
             print(ioc, Base.undef_ref_str)
         end
-        return String(take!(iob))
     end
 
     if will_fit
@@ -193,7 +191,7 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
     count = 0
     for col = 1:S.n, r = nzrange(S, col)
         count += 1
-        print(io, "\n", _format_line(r, col))
+        _format_line(ioc, r, col)
         count == print_count && break
     end
 
@@ -202,11 +200,11 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
         # find the column to start printing in for the last print_count elements
         nextcol = searchsortedfirst(S.colptr, nnz(S) - print_count + 1)
         for r = (nnz(S) - print_count + 1) : (S.colptr[nextcol] - 1)
-            print(io, "\n", _format_line(r, nextcol - 1))
+            _format_line(ioc, r, nextcol - 1)
         end
         # print all of the remaining columns
         for col = nextcol:S.n, r = nzrange(S, col)
-            print(io, "\n", _format_line(r, col))
+            _format_line(ioc, r, col)
         end
     end
 end

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1414,7 +1414,7 @@ argument specifies a random number generator, see [Random Numbers](@ref).
 ```jldoctest; setup = :(using Random; Random.seed!(1234))
 julia> sprand(Bool, 2, 2, 0.5)
 2×2 SparseMatrixCSC{Bool,Int64} with 1 stored entry:
-  [2, 2]  =  true
+  [2, 2]  =  1
 
 julia> sprand(Float64, 3, 0.75)
 3-element SparseVector{Float64,Int64} with 1 stored entry:

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -171,9 +171,9 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
     end
 
     ioc = IOContext(io, :compact => true)
+    pad = ndigits(max(S.m, S.n))
 
-    function _format_line(ioc, r, col)
-        pad = ndigits(max(S.m, S.n))
+    function _format_line(r, col)
         print(ioc, "\n  [", rpad(S.rowval[r], pad), ", ", lpad(col, pad), "]  =  ")
         if isassigned(S.nzval, Int(r))
             show(ioc, S.nzval[r])
@@ -191,7 +191,7 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
     count = 0
     for col = 1:S.n, r = nzrange(S, col)
         count += 1
-        _format_line(ioc, r, col)
+        _format_line(r, col)
         count == print_count && break
     end
 
@@ -200,11 +200,11 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
         # find the column to start printing in for the last print_count elements
         nextcol = searchsortedfirst(S.colptr, nnz(S) - print_count + 1)
         for r = (nnz(S) - print_count + 1) : (S.colptr[nextcol] - 1)
-            _format_line(ioc, r, nextcol - 1)
+            _format_line(r, nextcol - 1)
         end
         # print all of the remaining columns
         for col = nextcol:S.n, r = nzrange(S, col)
-            _format_line(ioc, r, col)
+            _format_line(r, col)
         end
     end
 end

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -834,7 +834,7 @@ function show(io::IO, ::MIME"text/plain", x::AbstractSparseVector)
            " stored ", xnnz == 1 ? "entry" : "entries")
     if xnnz != 0
         println(io, ":")
-        show(io, x)
+        show(IOContext(io, :typeinfo => eltype(x)), x)
     end
 end
 

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -182,9 +182,9 @@ julia> sparsevec(II, V, 8, -)
 
 julia> sparsevec([1, 3, 1, 2, 2], [true, true, false, false, false])
 3-element SparseVector{Bool,Int64} with 3 stored entries:
-  [1]  =  true
-  [2]  =  false
-  [3]  =  true
+  [1]  =  1
+  [2]  =  0
+  [3]  =  1
 ```
 """
 function sparsevec(I::AbstractVector{<:Integer}, V::AbstractVector, combine::Function)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2105,6 +2105,10 @@ end
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5,6], Int64[1,1,2,2,3,3], [1.0,2.0,3.0,4.0,5.0,6.0]))
     @test String(take!(io)) ==  string("6×3 SparseArrays.SparseMatrixCSC{Float64,Int64} with 6 stored entries:\n  [1, 1]  =  1.0\n",
         "  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")
+
+    # issue #30589
+    @test repr("text/plain", sparse([true true])) == "1×2 SparseMatrixCSC{Bool,$Int} with 2 stored entries:\n  [1, 1]  =  1\n  [1, 2]  =  1"
+    @test
 end
 
 @testset "check buffers" for n in 1:3

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2107,7 +2107,7 @@ end
         "  [2, 1]  =  2.0\n  [3, 2]  =  3.0\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0\n  [6, 3]  =  6.0")
 
     # issue #30589
-    @test repr("text/plain", sparse([true true])) == "1×2 SparseMatrixCSC{Bool,$Int} with 2 stored entries:\n  [1, 1]  =  1\n  [1, 2]  =  1"
+    @test repr("text/plain", sparse([true true])) == "1×2 SparseArrays.SparseMatrixCSC{Bool,$Int} with 2 stored entries:\n  [1, 1]  =  1\n  [1, 2]  =  1"
 end
 
 @testset "check buffers" for n in 1:3

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2108,7 +2108,6 @@ end
 
     # issue #30589
     @test repr("text/plain", sparse([true true])) == "1×2 SparseMatrixCSC{Bool,$Int} with 2 stored entries:\n  [1, 1]  =  1\n  [1, 2]  =  1"
-    @test
 end
 
 @testset "check buffers" for n in 1:3

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -44,6 +44,9 @@ end
     @test occursin("1.25", string(spv_x1))
     @test occursin("-0.75", string(spv_x1))
     @test occursin("3.5", string(spv_x1))
+
+    # issue #30589
+    @test repr("text/plain", sparse([true])) == "1-element SparseVector{Bool,$Int} with 1 stored entry:\n  [1]  =  1"
 end
 
 ### Comparison helper to ensure exact equality with internal structure

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -46,7 +46,7 @@ end
     @test occursin("3.5", string(spv_x1))
 
     # issue #30589
-    @test repr("text/plain", sparse([true])) == "1-element SparseVector{Bool,$Int} with 1 stored entry:\n  [1]  =  1"
+    @test repr("text/plain", sparse([true])) == "1-element SparseArrays.SparseVector{Bool,$Int} with 1 stored entry:\n  [1]  =  1"
 end
 
 ### Comparison helper to ensure exact equality with internal structure


### PR DESCRIPTION
When implementing #30575, I noticed that sparse matrices and vectors were not setting the `typeinfo` property of the `IOContext`, despite the fact that they print the element type.   This PR fixes that.