### PR TITLE
canonicalize Windows environment variables to uppercase

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,6 @@ New library functions
 Standard library changes
 ------------------------
 
-
 #### LinearAlgebra
 
 * Added keyword arguments `rtol`, `atol` to `pinv` and `nullspace` ([#29998]).
@@ -42,6 +41,10 @@ Standard library changes
 
 * Fixed `repr` such that it displays `DateTime` as it would be entered in Julia ([#30200]).
 
+#### Miscellaneous
+
+* Since environment variables on Windows are case-insensitive, `ENV` now converts its keys
+  to uppercase for display, iteration, and copying ([#30593]).
 
 External dependencies
 ---------------------

--- a/base/env.jl
+++ b/base/env.jl
@@ -92,7 +92,7 @@ if Sys.iswindows()
         ws = transcode(UInt16, String(s))
         result = ccall(:LCMapStringW, stdcall, Cint, (UInt32, UInt32, Ptr{UInt16}, Cint, Ptr{UInt16}, Cint),
                        LOCALE_INVARIANT, LCMAP_UPPERCASE, ws, length(ws), ws, length(ws))
-        iszero(result) && error("unexpected LCMapStringW error")
+        systemerror("LCMapStringW", iszero(result))
         return transcode(String, ws)
     end
     function iterate(hash::EnvDict, block::Tuple{Ptr{UInt16},Ptr{UInt16}} = GESW())

--- a/base/env.jl
+++ b/base/env.jl
@@ -70,6 +70,10 @@ struct EnvDict <: AbstractDict{String,String}; end
 
 Reference to the singleton `EnvDict`, providing a dictionary interface to system environment
 variables.
+
+(On Windows, system environment variables are case-insensitive, and `ENV` correspondingly converts
+all keys to uppercase for display, iteration, and copying.  Portable code should not rely on the
+existence of lower-case environment variables or on the ability to distinguish variables by case.)
 """
 const ENV = EnvDict()
 

--- a/base/env.jl
+++ b/base/env.jl
@@ -100,7 +100,7 @@ if Sys.iswindows()
         if m === nothing
             error("malformed environment entry: $env")
         end
-        return (Pair{String,String}(m.captures[1], m.captures[2]), (pos+(len+1)*2, blk))
+        return (Pair{String,String}(uppercase(m.captures[1]), m.captures[2]), (pos+(len+1)*2, blk))
     end
 else # !windows
     function iterate(::EnvDict, i=0)

--- a/base/env.jl
+++ b/base/env.jl
@@ -96,7 +96,7 @@ if Sys.iswindows()
         ws = transcode(UInt16, String(s))
         result = ccall(:LCMapStringW, stdcall, Cint, (UInt32, UInt32, Ptr{UInt16}, Cint, Ptr{UInt16}, Cint),
                        LOCALE_INVARIANT, LCMAP_UPPERCASE, ws, length(ws), ws, length(ws))
-        systemerror("LCMapStringW", iszero(result))
+        systemerror(:LCMapStringW, iszero(result))
         return transcode(String, ws)
     end
     function iterate(hash::EnvDict, block::Tuple{Ptr{UInt16},Ptr{UInt16}} = GESW())

--- a/test/env.jl
+++ b/test/env.jl
@@ -81,3 +81,19 @@ end
     @test ENV["testing_envdict"] == "tested"
     delete!(ENV, "testing_envdict")
 end
+
+if Sys.iswindows()
+    @testset "windows case-insensitivity" begin
+        push!(ENV, "testing_envdict" => "tested")
+        @test haskey(ENV, "TESTING_ENVDICT")
+        @test ENV["TESTING_ENVDICT"] == "tested"
+        @test "TESTING_ENVDICT" in keys(ENV)
+        @test "TESTING_ENVDICT" in collect(keys(ENV))
+        @test "testing_envdict" ∉ collect(keys(ENV))
+        env = copy(ENV)
+        @test haskey(env, "TESTING_ENVDICT")
+        @test !haskey(env, "testing_envdict")
+        delete!(ENV, "testing_envdict")
+        @test !haskey(ENV, "TESTING_ENVDICT")
+    end
+end

--- a/test/env.jl
+++ b/test/env.jl
@@ -36,7 +36,7 @@ end
 end
 @testset "#17956" begin
     @test length(ENV) > 1
-    k1, k2 = "__test__", "__test1__"
+    k1, k2 = "__TEST__", "__TEST1__"
     withenv(k1=>k1, k2=>k2) do
         b_k1, b_k2 = false, false
         for (k, v) in ENV

--- a/test/env.jl
+++ b/test/env.jl
@@ -84,16 +84,21 @@ end
 
 if Sys.iswindows()
     @testset "windows case-insensitivity" begin
-        push!(ENV, "testing_envdict" => "tested")
-        @test haskey(ENV, "TESTING_ENVDICT")
-        @test ENV["TESTING_ENVDICT"] == "tested"
-        @test "TESTING_ENVDICT" in keys(ENV)
-        @test "TESTING_ENVDICT" in collect(keys(ENV))
-        @test "testing_envdict" ∉ collect(keys(ENV))
-        env = copy(ENV)
-        @test haskey(env, "TESTING_ENVDICT")
-        @test !haskey(env, "testing_envdict")
-        delete!(ENV, "testing_envdict")
-        @test !haskey(ENV, "TESTING_ENVDICT")
+        for k in ("testing_envdict", "testing_envdict_\u00ee")
+            K = uppercase(k)
+            v = "tested $k"
+            ENV[k] = v
+            @test haskey(ENV, K)
+            @test ENV[K] == v
+            @test K in keys(ENV)
+            @test K in collect(keys(ENV))
+            @test k ∉ collect(keys(ENV))
+            env = copy(ENV)
+            @test haskey(env, K)
+            @test env[K] == v
+            @test !haskey(env, k)
+            delete!(ENV, k)
+            @test !haskey(ENV, K)
+        end
     end
 end


### PR DESCRIPTION
This PR mostly fixes #29334 by canonicalizing Windows environment variables (which are case-insensitive case-preserving) to uppercase when they are iterated, copied, etcetera.

Otherwise it is easy to write buggy code for Windows by following our [`setenv` documentation](https://github.com/JuliaLang/julia/blob/a153feaa0b167520d6e42d1aa03d224ec0064a7c/base/process.jl#L226), e.g.
```jl
env = copy(ENV)
env["PATH"] = ....   # incorrect if PATH was capitalized as Path!
setenv(`some command`, env)
```
For example, I found code "in the wild" that does problematic things like this in [Conda.jl](https://github.com/JuliaPy/Conda.jl/blob/4725842e6985ec3c8def8da0ebd5f42a9d27fcae/src/Conda.jl#L95-L98), [BinDeps.jl](https://github.com/JuliaPackaging/BinDeps.jl/blob/master/src/dependencies.jl#L216-L217), [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl/blob/e7709648f122284318a63cf9914d6eef95300825/src/Documenter.jl#L759-L760), the [REPL](https://github.com/JuliaLang/julia/blob/a153feaa0b167520d6e42d1aa03d224ec0064a7c/stdlib/REPL/test/repl.jl#L733-L734), and [`Base.runtests`](https://github.com/JuliaLang/julia/blob/a153feaa0b167520d6e42d1aa03d224ec0064a7c/base/util.jl#L816-L817) — all of these examples don't take into account the case-insensitivity of Windows environment variables, and all should be fixed by this PR.

It still doesn't throw if the user explicitly writes something like `merge!(ENV, Dict("key" => "1", "KEY" => "2"))`, but that could be addressed in a separate PR … that seems like a much less pressing problem to me.
