### PR TITLE
Use XCode 8.3 for macOS on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
             - gfortran-5
     - os: osx
       env: ARCH="x86_64"
-      osx_image: xcode8
+      osx_image: xcode8.3
 cache: ccache
 branches:
   only:


### PR DESCRIPTION
This corresponds to macOS 10.12 Sierra. XCode 8 covers El Capitan and Sierra, so if Travis is giving us XCode 8.x for x < 3, we're on El Cap. Homebrew supports only three versions of macOS at a time, which means that El Cap (10.11) is no longer supported. This is likely why our Mac builds are trying to build GCC from source; a bottle might not be available.