### PR TITLE
fix typo in string search api docs

### DIFF
--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -259,7 +259,7 @@ findnext(t::AbstractString, s::AbstractString, i::Integer) = _search(s, t, i)
     findlast(pattern::AbstractString, string::AbstractString)
 
 Find the last occurrence of `pattern` in `string`. Equivalent to
-[`findprev(pattern, string, lastindex(s))`](@ref).
+[`findprev(pattern, string, lastindex(string))`](@ref).
 
 # Examples
 ```jldoctest

--- a/base/strings/search.jl
+++ b/base/strings/search.jl
@@ -259,7 +259,7 @@ findnext(t::AbstractString, s::AbstractString, i::Integer) = _search(s, t, i)
     findlast(pattern::AbstractString, string::AbstractString)
 
 Find the last occurrence of `pattern` in `string`. Equivalent to
-[`findlast(pattern, string, lastindex(s))`](@ref).
+[`findprev(pattern, string, lastindex(s))`](@ref).
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
findlast cannot be called with 3 arguments, (with the third being a a start index), this should read `findprev(`