### PR TITLE
Fix #29983

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -130,7 +130,7 @@ function simple_walk(compact::IncrementalCompact, @nospecialize(defssa#=::AnySSA
                 return defssa
             end
             if isa(def.val, SSAValue)
-                if isa(defssa, OldSSAValue) && !already_inserted(compact, defssa)
+                if is_old(compact, defssa)
                     defssa = OldSSAValue(def.val.id)
                 else
                     defssa = def.val
@@ -281,7 +281,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
             end
             if is_tuple_call(compact, def) && isa(field, Int) && 1 <= field < length(def.args)
                 lifted = def.args[1+field]
-                if isa(leaf, OldSSAValue) && isa(lifted, SSAValue)
+                if is_old(compact, leaf) && isa(lifted, SSAValue)
                     lifted = OldSSAValue(lifted.id)
                 end
                 if isa(lifted, GlobalRef) || isa(lifted, Expr)
@@ -320,7 +320,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
                     compact[leaf] = def
                 end
                 lifted = def.args[1+field]
-                if isa(leaf, OldSSAValue) && isa(lifted, SSAValue)
+                if is_old(compact, leaf) && isa(lifted, SSAValue)
                     lifted = OldSSAValue(lifted.id)
                 end
                 if isa(lifted, GlobalRef) || isa(lifted, Expr)
@@ -339,7 +339,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
                     # N.B.: This can be a bit dangerous because it can lead to
                     # infinite loops if we accidentally insert a node just ahead
                     # of where we are
-                    if isa(leaf, OldSSAValue) && (isa(field, Int) || isa(field, Symbol))
+                    if is_old(compact, leaf) && (isa(field, Int) || isa(field, Symbol))
                         (isa(typ, DataType) && (!typ.abstract)) || return nothing
                         @assert !typ.mutable
                         # If there's the potential for an undefref error on access, we cannot insert a getfield

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -63,3 +63,29 @@ let results = Float64[]
     foo30594(4, -1)
     @test results == [0.0, -1.0, -2.0, -3.0]
 end
+
+# Issue #29983
+# This one is a bit hard to trigger, but the key is to create a case
+# where SROA needs to introduce an intermediate type-unstable phi node
+struct Foo29983{T}
+    x::Tuple{T}
+end
+struct Bar29983{S}
+    x::S
+end
+Base.:+(a::T, b::Bar29983{S}) where {T, S} = Bar29983(a + b.x)
+Base.:+(a::Bar29983{S}, b::T) where {T, S} = b + a
+Base.:+(a::Bar29983{S}, b::Bar29983{T}) where {T, S} = Bar29983(a.x + b.x)
+Base.:+(a::Foo29983, b::Foo29983) = Foo29983((a.x[1] + b.x[1],))
+
+function f(x::Vector{T}) where {T}
+    x1 = Foo29983((x[1],))
+    la1 = Foo29983((x[1],))
+    f1 = Foo29983((0,))
+    for _ in 1:2
+        f1 += la1
+    end
+    return f1
+end
+
+@test f([Bar29983(1.0)]).x[1].x == 2.0


### PR DESCRIPTION
SROA was accidentally treating a pending node as old and thus
getting the wrong type when querying the predecessor. As a result
it thought one of the paths was unreachable causing undefined data
to be introduced on that path (generally the `1.0` that happened to
already be in register).