### PR TITLE
Add matrix representation of complex numbers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@ New language features
 
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
+* Complex numbers can now be converted to their matrix representation using the `Matrix`
+  constructor ([#30602]).
 
 Multi-threading changes
 -----------------------

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1014,3 +1014,29 @@ function complex(A::AbstractArray{T}) where T
     end
     convert(AbstractArray{typeof(complex(zero(T)))}, A)
 end
+
+# Matrix representation of a complex number
+"""
+    Matrix(z::Complex)
+    Matrix{T}(z::Complex)
+
+Construct a 2×2 matrix containing the
+[matrix representation](https://en.wikipedia.org/wiki/Complex_number#Matrix_representation_of_complex_numbers)
+of the complex number `z`.
+If a type parameter `T` is included, the result is converted to have element type `T`.
+
+# Examples
+```jldoctest
+julia> Matrix(1 + 2im)
+2×2 Array{Int64,2}:
+ 1  -2
+ 2   1
+
+julia> Matrix{Float64}(1 + 2im)
+2×2 Array{Float64,2}:
+ 1.0  -2.0
+ 2.0   1.0
+```
+"""
+Matrix(z::Complex{T}) where {T<:Real} = ((a, b) = reim(z); T[a -b; b a])
+Matrix{S}(z::Complex) where {S<:Real} = ((a, b) = reim(z); S[a -b; b a])

--- a/doc/src/base/math.md
+++ b/doc/src/base/math.md
@@ -160,6 +160,7 @@ Base.reim
 Base.conj
 Base.angle
 Base.cis
+Base.Matrix(::Complex)
 Base.binomial
 Base.factorial
 Base.gcd

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1065,3 +1065,14 @@ end
 
     @test @inferred(2.0^(3.0+0im)) === @inferred((2.0+0im)^(3.0+0im)) === @inferred((2.0+0im)^3.0) === 8.0+0.0im
 end
+
+@testset "Matrix representation" begin
+    @test @inferred(Matrix(1.0f0 + 2.0f0im)) == Float32[1 -2; 2 1]
+    @test isequal(@inferred(Matrix(NaN + 0.0im)), [NaN -0.0; 0.0 NaN])
+    @test Matrix((1 + 2im) * (2 + 3im)) == Matrix(-4 + 7im) == [-4 -7; 7 -4]
+    # Converting to the given eltype
+    @test @inferred(Matrix{Int}(im)) == [0 -1; 1 0]
+    for T = [Int8, Int16, Int32, Int64, Int128, Float32, Float64]
+        @test @inferred(Matrix{T}((1 + 2im) * (2 + 3im))) == Matrix{T}(-4 + 7im) == T[-4 -7; 7 -4]
+    end
+end


### PR DESCRIPTION
Complex numbers can be represented as a 2x2 matrix. This adds a method `Matrix(::Complex)` to construct this representation.