### PR TITLE
Base.windowserror function to encapsulate Windows errors in SystemErrors

### DIFF
--- a/base/env.jl
+++ b/base/env.jl
@@ -15,9 +15,7 @@ if Sys.iswindows()
         end
         val = zeros(UInt16,len)
         ret = ccall(:GetEnvironmentVariableW,stdcall,UInt32,(Ptr{UInt16},Ptr{UInt16},UInt32),var,val,len)
-        if (ret == 0 && len != 1) || ret != len-1 || val[end] != 0
-            error(string("getenv: ", str, ' ', len, "-1 != ", ret, ": ", Libc.FormatMessage()))
-        end
+        windowserror(:getenv, (ret == 0 && len != 1) || ret != len-1 || val[end] != 0)
         pop!(val) # NUL
         return transcode(String, val)
     end
@@ -27,14 +25,14 @@ if Sys.iswindows()
         val = cwstring(sval)
         if overwrite || !_hasenv(var)
             ret = ccall(:SetEnvironmentVariableW,stdcall,Int32,(Ptr{UInt16},Ptr{UInt16}),var,val)
-            systemerror(:setenv, ret == 0)
+            windowserror(:setenv, ret == 0)
         end
     end
 
     function _unsetenv(svar::AbstractString)
         var = cwstring(svar)
         ret = ccall(:SetEnvironmentVariableW,stdcall,Int32,(Ptr{UInt16},Ptr{UInt16}),var,C_NULL)
-        systemerror(:setenv, ret == 0)
+        windowserror(:setenv, ret == 0)
     end
 else # !windows
     _getenv(var::AbstractString) = ccall(:getenv, Cstring, (Cstring,), var)

--- a/base/error.jl
+++ b/base/error.jl
@@ -135,13 +135,11 @@ systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(str
 
 
 # like systemerror, but for Windows API calls that use GetLastError instead of errno
-if Sys.iswindows()
-    struct WindowsError <: Exception
-        errnum::UInt32
-        extrainfo
-    end
-    windowserror(p, b::PBool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsError(Libc.GetLastError(), extrainfo))) : nothing
+struct WindowsErrorInfo
+    errnum::UInt32
+    extrainfo
 end
+windowserror(p, b::PBool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsErrorInfo(Libc.GetLastError(), extrainfo))) : nothing
 
 
 ## assertion macro ##

--- a/base/error.jl
+++ b/base/error.jl
@@ -139,7 +139,7 @@ struct WindowsErrorInfo
     errnum::UInt32
     extrainfo
 end
-windowserror(p, b::PBool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsErrorInfo(Libc.GetLastError(), extrainfo))) : nothing
+windowserror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsErrorInfo(Libc.GetLastError(), extrainfo))) : nothing
 
 
 ## assertion macro ##

--- a/base/error.jl
+++ b/base/error.jl
@@ -134,11 +134,17 @@ Raises a `SystemError` for `errno` with the descriptive string `sysfunc` if `ift
 systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), extrainfo)) : nothing
 
 
-# like systemerror, but for Windows API calls that use GetLastError instead of errno
+## system errors from Windows API functions
 struct WindowsErrorInfo
     errnum::UInt32
     extrainfo
 end
+"""
+    windowserror(sysfunc, iftrue)
+
+Like [`systemerror`](@ref), but for Windows API functions that use [`GetLastError`](@ref) instead
+of setting [`errno`](@ref).
+"""
 windowserror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsErrorInfo(Libc.GetLastError(), extrainfo))) : nothing
 
 

--- a/base/error.jl
+++ b/base/error.jl
@@ -133,6 +133,17 @@ Raises a `SystemError` for `errno` with the descriptive string `sysfunc` if `ift
 """
 systemerror(p, b::Bool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), extrainfo)) : nothing
 
+
+# like systemerror, but for Windows API calls that use GetLastError instead of errno
+if Sys.iswindows()
+    struct WindowsError <: Exception
+        errnum::UInt32
+        extrainfo
+    end
+    windowserror(p, b::PBool; extrainfo=nothing) = b ? throw(Main.Base.SystemError(string(p), Libc.errno(), WindowsError(Libc.GetLastError(), extrainfo))) : nothing
+end
+
+
 ## assertion macro ##
 
 

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -115,7 +115,7 @@ function showerror(io::IO, ex::DomainError, bt; backtrace=true)
 end
 
 function showerror(io::IO, ex::SystemError)
-    if @static(Sys.iswindows() ? ex.extrainfo isa WindowsError : false)
+    if @static(Sys.iswindows() ? ex.extrainfo isa WindowsErrorInfo : false)
         errstring = Libc.FormatMessage(ex.extrainfo.errnum)
         extrainfo = ex.extrainfo.extrainfo
     else

--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -115,12 +115,20 @@ function showerror(io::IO, ex::DomainError, bt; backtrace=true)
 end
 
 function showerror(io::IO, ex::SystemError)
-    if ex.extrainfo === nothing
-        print(io, "SystemError: $(ex.prefix): $(Libc.strerror(ex.errnum))")
+    if @static(Sys.iswindows() ? ex.extrainfo isa WindowsError : false)
+        errstring = Libc.FormatMessage(ex.extrainfo.errnum)
+        extrainfo = ex.extrainfo.extrainfo
     else
-        print(io, "SystemError (with $(ex.extrainfo)): $(ex.prefix): $(Libc.strerror(ex.errnum))")
+        errstring = Libc.strerror(ex.errnum)
+        extrainfo = ex.extrainfo
+    end
+    if extrainfo === nothing
+        print(io, "SystemError: $(ex.prefix): $errstring")
+    else
+        print(io, "SystemError (with $extrainfo): $(ex.prefix): $errstring")
     end
 end
+
 showerror(io::IO, ::DivideError) = print(io, "DivideError: integer division error")
 showerror(io::IO, ::StackOverflowError) = print(io, "StackOverflowError:")
 showerror(io::IO, ::UndefRefError) = print(io, "UndefRefError: access to undefined reference")

--- a/base/file.jl
+++ b/base/file.jl
@@ -421,9 +421,7 @@ if Sys.iswindows()
 function tempdir()
     temppath = Vector{UInt16}(undef, 32767)
     lentemppath = ccall(:GetTempPathW,stdcall,UInt32,(UInt32,Ptr{UInt16}),length(temppath),temppath)
-    if lentemppath >= length(temppath) || lentemppath == 0
-        error("GetTempPath failed: $(Libc.FormatMessage())")
-    end
+    windowserror("GetTempPath", lentemppath >= length(temppath) || lentemppath == 0)
     resize!(temppath,lentemppath)
     return transcode(String, temppath)
 end
@@ -434,9 +432,7 @@ function _win_tempname(temppath::AbstractString, uunique::UInt32)
     tname = Vector{UInt16}(undef, 32767)
     uunique = ccall(:GetTempFileNameW,stdcall,UInt32,(Ptr{UInt16},Ptr{UInt16},UInt32,Ptr{UInt16}), tempp,temp_prefix,uunique,tname)
     lentname = something(findfirst(iszero,tname), 0)-1
-    if uunique == 0 || lentname <= 0
-        error("GetTempFileName failed: $(Libc.FormatMessage())")
-    end
+    windowserror("GetTempFileName", uunique == 0 || lentname <= 0)
     resize!(tname,lentname)
     return transcode(String, tname)
 end

--- a/base/filesystem.jl
+++ b/base/filesystem.jl
@@ -42,7 +42,7 @@ import .Base:
     IOError, _UVError, _sizeof_uv_fs, check_open, close, eof, eventloop, fd, isopen,
     bytesavailable, position, read, read!, readavailable, seek, seekend, show,
     skip, stat, unsafe_read, unsafe_write, write, transcode, uv_error,
-    rawhandle, OS_HANDLE, INVALID_OS_HANDLE
+    rawhandle, OS_HANDLE, INVALID_OS_HANDLE, windowserror
 
 if Sys.iswindows()
     import .Base: cwstring

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -5,7 +5,7 @@ module Libc
 Interface to libc, the C standard library.
 """ Libc
 
-import Base: transcode
+import Base: transcode, windowserror
 import Core.Intrinsics: bitcast
 
 export FILE, TmStruct, strftime, strptime, getpid, gethostname, free, malloc, calloc, realloc,

--- a/base/libc.jl
+++ b/base/libc.jl
@@ -54,7 +54,7 @@ if Sys.iswindows()
         status = ccall(:DuplicateHandle, stdcall, Int32,
             (Ptr{Cvoid}, WindowsRawSocket, Ptr{Cvoid}, Ptr{WindowsRawSocket}, UInt32, Int32, UInt32),
             my_process, src, my_process, new_handle, 0, false, DUPLICATE_SAME_ACCESS)
-        status == 0 && error("dup failed: $(FormatMessage())")
+        windowserror("dup failed", status == 0)
         return new_handle[]
     end
     function dup(src::WindowsRawSocket, target::RawFD)

--- a/base/path.jl
+++ b/base/path.jl
@@ -340,7 +340,7 @@ function realpath(path::AbstractString)
         n = ccall((:GetFullPathNameW, "kernel32"), stdcall,
             UInt32, (Ptr{UInt16}, UInt32, Ptr{UInt16}, Ptr{Cvoid}),
             p, length(buf), buf, C_NULL)
-        systemerror(:realpath, n == 0)
+        windowserror(:realpath, n == 0)
         x = n < length(buf) # is the buffer big enough?
         resize!(buf, n) # shrink if x, grow if !x
         x && return transcode(String, buf)
@@ -354,7 +354,7 @@ function longpath(path::AbstractString)
         n = ccall((:GetLongPathNameW, "kernel32"), stdcall,
             UInt32, (Ptr{UInt16}, Ptr{UInt16}, UInt32),
             p, buf, length(buf))
-        systemerror(:longpath, n == 0)
+        windowserror(:longpath, n == 0)
         x = n < length(buf) # is the buffer big enough?
         resize!(buf, n) # shrink if x, grow if !x
         x && return transcode(String, buf)

--- a/base/util.jl
+++ b/base/util.jl
@@ -614,11 +614,8 @@ if Sys.iswindows()
 
         #      2.3: If that failed for any reason other than the user canceling, error out.
         #           If the user canceled, just return nothing
-        if code == ERROR_CANCELLED
-            return nothing
-        elseif code != ERROR_SUCCESS
-            error(Base.Libc.FormatMessage(code))
-        end
+        code == ERROR_CANCELLED && return nothing
+        windowserror(:winprompt, code != ERROR_SUCCESS)
 
         # Step 3: Convert encrypted credentials back to plain text
         passbuf = Vector{UInt16}(undef, 1024)
@@ -630,9 +627,7 @@ if Sys.iswindows()
         succeeded = ccall((:CredUnPackAuthenticationBufferW, "credui.dll"), Bool,
             (UInt32, Ptr{Cvoid}, UInt32, Ptr{UInt16}, Ptr{UInt32}, Ptr{UInt16}, Ptr{UInt32}, Ptr{UInt16}, Ptr{UInt32}),
             0, outbuf_data[], outbuf_size[], usernamebuf, usernamelen, dummybuf, Ref{UInt32}(1024), passbuf, passlen)
-        if !succeeded
-            error(Base.Libc.FormatMessage())
-        end
+        windowserror(:winprompt, !succeeded)
 
         # Step 4: Free the encrypted buffer
         # ccall(:SecureZeroMemory, Ptr{Cvoid}, (Ptr{Cvoid}, Csize_t), outbuf_data[], outbuf_size[]) - not an actual function

--- a/stdlib/InteractiveUtils/src/clipboard.jl
+++ b/stdlib/InteractiveUtils/src/clipboard.jl
@@ -62,34 +62,34 @@ elseif Sys.iswindows()
         if Base.containsnul(x)
             throw(ArgumentError("Windows clipboard strings cannot contain NUL character"))
         end
-        systemerror(:OpenClipboard, 0==ccall((:OpenClipboard, "user32"), stdcall, Cint, (Ptr{Cvoid},), C_NULL))
-        systemerror(:EmptyClipboard, 0==ccall((:EmptyClipboard, "user32"), stdcall, Cint, ()))
+        Base.windowserror(:OpenClipboard, 0==ccall((:OpenClipboard, "user32"), stdcall, Cint, (Ptr{Cvoid},), C_NULL))
+        Base.windowserror(:EmptyClipboard, 0==ccall((:EmptyClipboard, "user32"), stdcall, Cint, ()))
         x_u16 = Base.cwstring(x)
         # copy data to locked, allocated space
         p = ccall((:GlobalAlloc, "kernel32"), stdcall, Ptr{UInt16}, (UInt16, Int32), 2, sizeof(x_u16))
-        systemerror(:GlobalAlloc, p==C_NULL)
+        Base.windowserror(:GlobalAlloc, p==C_NULL)
         plock = ccall((:GlobalLock, "kernel32"), stdcall, Ptr{UInt16}, (Ptr{UInt16},), p)
-        systemerror(:GlobalLock, plock==C_NULL)
+        Base.windowserror(:GlobalLock, plock==C_NULL)
         ccall(:memcpy, Ptr{UInt16}, (Ptr{UInt16},Ptr{UInt16},Int), plock, x_u16, sizeof(x_u16))
-        systemerror(:GlobalUnlock, 0==ccall((:GlobalUnlock, "kernel32"), stdcall, Cint, (Ptr{Cvoid},), plock))
+        Base.windowserror(:GlobalUnlock, 0==ccall((:GlobalUnlock, "kernel32"), stdcall, Cint, (Ptr{Cvoid},), plock))
         pdata = ccall((:SetClipboardData, "user32"), stdcall, Ptr{UInt16}, (UInt32, Ptr{UInt16}), 13, p)
-        systemerror(:SetClipboardData, pdata!=p)
+        Base.windowserror(:SetClipboardData, pdata!=p)
         ccall((:CloseClipboard, "user32"), stdcall, Cvoid, ())
     end
     clipboard(x) = clipboard(sprint(print, x)::String)
     function clipboard()
-        systemerror(:OpenClipboard, 0==ccall((:OpenClipboard, "user32"), stdcall, Cint, (Ptr{Cvoid},), C_NULL))
+        Base.windowserror(:OpenClipboard, 0==ccall((:OpenClipboard, "user32"), stdcall, Cint, (Ptr{Cvoid},), C_NULL))
         pdata = ccall((:GetClipboardData, "user32"), stdcall, Ptr{UInt16}, (UInt32,), 13)
-        systemerror(:GetClipboardData, pdata==C_NULL)
-        systemerror(:CloseClipboard, 0==ccall((:CloseClipboard, "user32"), stdcall, Cint, ()))
+        Base.windowserror(:GetClipboardData, pdata==C_NULL)
+        Base.windowserror(:CloseClipboard, 0==ccall((:CloseClipboard, "user32"), stdcall, Cint, ()))
         plock = ccall((:GlobalLock, "kernel32"), stdcall, Ptr{UInt16}, (Ptr{UInt16},), pdata)
-        systemerror(:GlobalLock, plock==C_NULL)
+        Base.windowserror(:GlobalLock, plock==C_NULL)
         # find NUL terminator (0x0000 16-bit code unit)
         len = 0
         while unsafe_load(plock, len+1) != 0; len += 1; end
         # get Vector{UInt16}, transcode data to UTF-8, make a String of it
         s = transcode(String, unsafe_wrap(Array, plock, len))
-        systemerror(:GlobalUnlock, 0==ccall((:GlobalUnlock, "kernel32"), stdcall, Cint, (Ptr{UInt16},), plock))
+        Base.windowserror(:GlobalUnlock, 0==ccall((:GlobalUnlock, "kernel32"), stdcall, Cint, (Ptr{UInt16},), plock))
         return s
     end
 

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -107,7 +107,7 @@ const FILE_MAP_EXECUTE       = DWORD(0x20)
 
 function gethandle(io::IO)
     handle = Libc._get_osfhandle(RawFD(fd(io)))
-    systemerror("could not get handle for file to map: $(Libc.FormatMessage())", handle == INVALID_OS_HANDLE)
+    Base.windowserror(:mmap, handle == INVALID_OS_HANDLE)
     return handle
 end
 
@@ -215,10 +215,10 @@ function mmap(io::IO,
                                 file_desc, C_NULL, readonly ? PAGE_READONLY : PAGE_READWRITE, szfile >> 32, szfile & typemax(UInt32), name) :
                           ccall(:OpenFileMappingW, stdcall, Ptr{Cvoid}, (DWORD, Cint, Cwstring),
                                 readonly ? FILE_MAP_READ : FILE_MAP_WRITE, true, name)
-        handle == C_NULL && error("could not create file mapping: $(Libc.FormatMessage())")
+        Base.windowserror(:mmap, handle == C_NULL)
         ptr = ccall(:MapViewOfFile, stdcall, Ptr{Cvoid}, (Ptr{Cvoid}, DWORD, DWORD, DWORD, Csize_t),
                     handle, readonly ? FILE_MAP_READ : FILE_MAP_WRITE, offset_page >> 32, offset_page & typemax(UInt32), (offset - offset_page) + len)
-        ptr == C_NULL && error("could not create mapping view: $(Libc.FormatMessage())")
+        Base.windowserror(:mmap, ptr == C_NULL)
     end # os-test
     # convert mmapped region to Julia Array at `ptr + (offset - offset_page)` since file was mapped at offset_page
     A = unsafe_wrap(Array, convert(Ptr{T}, UInt(ptr) + UInt(offset - offset_page)), dims)
@@ -228,7 +228,7 @@ function mmap(io::IO,
         else
             status = ccall(:UnmapViewOfFile, stdcall, Cint, (Ptr{Cvoid},), ptr)!=0
             status |= ccall(:CloseHandle, stdcall, Cint, (Ptr{Cvoid},), handle)!=0
-            status || error("could not unmap view: $(Libc.FormatMessage())")
+            Base.windowserror(:UnmapViewOfFile, status == 0)
         end
     end
     return A
@@ -337,8 +337,8 @@ function sync!(m::Array{T}, flags::Integer=MS_SYNC) where T
         systemerror("msync",
                     ccall(:msync, Cint, (Ptr{Cvoid}, Csize_t, Cint), ptr, length(m) * sizeof(T), flags) != 0)
     else
-        systemerror("could not FlushViewOfFile: $(Libc.FormatMessage())",
-                    ccall(:FlushViewOfFile, stdcall, Cint, (Ptr{Cvoid}, Csize_t), ptr, length(m)) == 0)
+        Base.windowserror(:FlushViewOfFile,
+            call(:FlushViewOfFile, stdcall, Cint, (Ptr{Cvoid}, Csize_t), ptr, length(m)) == 0)
     end
 end
 sync!(B::BitArray, flags::Integer=MS_SYNC) = sync!(B.chunks, flags)

--- a/stdlib/Mmap/src/Mmap.jl
+++ b/stdlib/Mmap/src/Mmap.jl
@@ -338,7 +338,7 @@ function sync!(m::Array{T}, flags::Integer=MS_SYNC) where T
                     ccall(:msync, Cint, (Ptr{Cvoid}, Csize_t, Cint), ptr, length(m) * sizeof(T), flags) != 0)
     else
         Base.windowserror(:FlushViewOfFile,
-            call(:FlushViewOfFile, stdcall, Cint, (Ptr{Cvoid}, Csize_t), ptr, length(m)) == 0)
+            ccall(:FlushViewOfFile, stdcall, Cint, (Ptr{Cvoid}, Csize_t), ptr, length(m)) == 0)
     end
 end
 sync!(B::BitArray, flags::Integer=MS_SYNC) = sync!(B.chunks, flags)


### PR DESCRIPTION
While working on #30611, I noticed a need for a function like `systemerror` but for Windows errors that use `GetLastError()` instead of `errno`, in order to:

* Delay the cost of creating the formatted error string (with `Libc.FormatMessage`) until the error is actually displayed (if ever).
* Still use a `SystemError` exception type, so that the exception type is consistent across platforms.  (The fact that it is a Windows exception is stored in the `extrainfo` field.)
* Encapsulate a common pattern to shorten the code.

Along the way, I found and fixed a bunch of apparent bugs — functions that were calling `systemerror` after Windows API calls that don't set `errno`.  (These would have thrown a `SystemError` exception with `errorshow` function that confusingly prints "no error" or similar as the error message.)

The resulting `Base.windowserror` function is not exported.