### PR TITLE
sprand and SparseMatrixCSC constructor simplifications

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -374,8 +374,8 @@ SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(
 function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
     require_one_based_indexing(M)
     C = findall(v->v != 0, M)
-    I = convert(Vector{Ti},LinearIndices(M)[C])
-    V = convert(Vector{Tv},M[C])
+    @inbounds I = convert(Vector{Ti},LinearIndices(M)[C])
+    @inbounds V = convert(Vector{Tv},M[C])
     sparse_sorted_unique!(I, V, size(M)...)
 end
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -383,7 +383,7 @@ function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
             push!(V, v)
         end
     end
-    sparse_increasing!(I, V, size(M)...)
+    return sparse_sortedlinearindices!(I, V, size(M)...)
 end
 
 function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}
@@ -1340,7 +1340,7 @@ function _sparse_findprevnz(m::SparseMatrixCSC, i::Integer)
 end
 
 
-function sparse_increasing!(I::Vector{Ti}, V::Vector, m::Int, n::Int) where Ti
+function sparse_sortedlinearindices!(I::Vector{Ti}, V::Vector, m::Int, n::Int) where Ti
     length(I) == length(V) || throw(ArgumentError("I and V should have the same length"))
     nnz = length(V)
     colptr = Vector{Ti}(undef, n + 1)
@@ -1353,7 +1353,7 @@ function sparse_increasing!(I::Vector{Ti}, V::Vector, m::Int, n::Int) where Ti
         j <= nnz && (I[j] += colm)
         colm += m
     end
-    SparseMatrixCSC(m, n, colptr, I, V)
+    return SparseMatrixCSC(m, n, colptr, I, V)
 end
 
 """
@@ -1382,7 +1382,7 @@ function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat, 
     (m < 0 || n < 0) && throw(ArgumentError("invalid Array dimensions"))
     0 <= density <= 1 || throw(ArgumentError("$density not in [0,1]"))
     I = randsubseq(r, 1:(m*n), density)
-    sparse_increasing!(I, convert(Vector{T}, rfn(r,length(I))), m, n)
+    return sparse_sortedlinearindices!(I, convert(Vector{T}, rfn(r,length(I))), m, n)
 end
 
 sprand(m::Integer, n::Integer, density::AbstractFloat, rfn::Function, ::Type{T} = eltype(rfn(1))) where T = sprand(GLOBAL_RNG,m,n,density,(r, i) -> rfn(i))

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -373,12 +373,12 @@ SparseMatrixCSC(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
     require_one_based_indexing(M)
-    I = findall(x -> x != 0, M)
-    eltypeTiI = Ti[i[1] for i in I]
-    eltypeTiJ = Ti[i[2] for i in I]
-    eltypeTvV = Tv[M[i] for i in I]
-    return sparse_IJ_sorted!(eltypeTiI, eltypeTiJ, eltypeTvV, size(M)...)
+    C = findall(v->v != 0, M)
+    @inbounds I = convert(Vector{Ti},LinearIndices(M)[C])
+    @inbounds V = convert(Vector{Tv},M[C])
+    @inbounds sparse_sorted_unique!(I, V, size(M)...)
 end
+
 function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}
     nz = count(t -> t != 0, M)
     colptr = zeros(Ti, size(M, 2) + 1)
@@ -455,56 +455,6 @@ julia> sparse(A)
 sparse(A::AbstractMatrix{Tv}) where {Tv} = convert(SparseMatrixCSC{Tv,Int}, A)
 
 sparse(S::SparseMatrixCSC) = copy(S)
-
-sparse_IJ_sorted!(I,J,V,m,n) = sparse_IJ_sorted!(I,J,V,m,n,+)
-
-sparse_IJ_sorted!(I,J,V::AbstractVector{Bool},m,n) = sparse_IJ_sorted!(I,J,V,m,n,|)
-
-function sparse_IJ_sorted!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
-                           V::AbstractVector,
-                           m::Integer, n::Integer, combine::Function) where Ti<:Integer
-    require_one_based_indexing(I, J, V)
-    m = m < 0 ? 0 : m
-    n = n < 0 ? 0 : n
-    if isempty(V); return spzeros(eltype(V),Ti,m,n); end
-
-    cols = zeros(Ti, n+1)
-    cols[1] = 1  # For cumsum purposes
-    cols[J[1] + 1] = 1
-
-    lastdup = 1
-    ndups = 0
-    I_lastdup = I[1]
-    J_lastdup = J[1]
-    L = length(I)
-
-    @inbounds for k=2:L
-        if I[k] == I_lastdup && J[k] == J_lastdup
-            V[lastdup] = combine(V[lastdup], V[k])
-            ndups += 1
-        else
-            cols[J[k] + 1] += 1
-            lastdup = k-ndups
-            I_lastdup = I[k]
-            J_lastdup = J[k]
-            if ndups != 0
-                I[lastdup] = I_lastdup
-                V[lastdup] = V[k]
-            end
-        end
-    end
-
-    colptr = cumsum!(similar(cols), cols)
-
-    # Allow up to 20% slack
-    if ndups > 0.2*L
-        numnz = L-ndups
-        deleteat!(I, (numnz+1):L)
-        deleteat!(V, (numnz+1):length(V))
-    end
-
-    return SparseMatrixCSC(m, n, colptr, I, V)
-end
 
 """
     sparse(I, J, V,[ m, n, combine])
@@ -1383,23 +1333,20 @@ function _sparse_findprevnz(m::SparseMatrixCSC, i::Integer)
 end
 
 
-function _sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat, rfn)
-    m, n = Int(m), Int(n)
-    (m < 0 || n < 0) && throw(ArgumentError("invalid Array dimensions"))
-    0 <= density <= 1 || throw(ArgumentError("$density not in [0,1]"))
-    j, colm  = 1, 0
-    rowval = randsubseq(r, 1:(m*n), density)
-    nnz = length(rowval)
-    colptr = Vector{Int}(undef, n + 1)
+function sparse_sorted_unique!(I::Vector{Ti}, V::Vector, m::Int, n::Int) where Ti
+    length(I) == length(V) || throw(ArgumentError("I and V should have the same length"))
+    nnz = length(V)
+    colptr = Vector{Ti}(undef, n + 1)
+    j, colm = 1, 0
     @inbounds for col = 1:n+1
         colptr[col] = j
-        while j <= nnz && (rowval[j] -= colm) <= m
+        while j <= nnz && (I[j] -= colm) <= m
             j += 1
         end
-        j <= nnz && (rowval[j] += colm)
+        j <= nnz && (I[j] += colm)
         colm += m
     end
-    return SparseMatrixCSC(m, n, colptr, rowval, rfn(nnz))
+    SparseMatrixCSC(m, n, colptr, I, V)
 end
 
 """
@@ -1423,23 +1370,16 @@ julia> sprand(Float64, 3, 0.75)
   [3]  =  0.298614
 ```
 """
-function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat,
-                rfn::Function, ::Type{T}=eltype(rfn(r,1))) where T
-    m,n = Int(m), Int(n)
-    N = m*n
-    N == 0 && return spzeros(T,m,n)
-    N == 1 && return rand(r) <= density ? sparse([1], [1], rfn(r,1)) : spzeros(T,1,1)
-    _sprand(r,m,n,density,i->rfn(r,i))
+
+function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat, rfn::Function, ::Type{T} = eltype(rfn(r, 1))) where T
+    m, n = Int(m), Int(n)
+    (m < 0 || n < 0) && throw(ArgumentError("invalid Array dimensions"))
+    0 <= density <= 1 || throw(ArgumentError("$density not in [0,1]"))
+    I = randsubseq(r, 1:(m*n), density)
+    sparse_sorted_unique!(I, rfn(r,length(I)), m, n)
 end
 
-function sprand(m::Integer, n::Integer, density::AbstractFloat,
-                rfn::Function, ::Type{T}=eltype(rfn(1))) where T
-    m,n = Int(m), Int(n)
-    N = m*n
-    N == 0 && return spzeros(T,m,n)
-    N == 1 && return rand() <= density ? sparse([1], [1], rfn(1)) : spzeros(T,1,1)
-    _sprand(GLOBAL_RNG,m,n,density,rfn)
-end
+sprand(m::Integer, n::Integer, density::AbstractFloat, rfn::Function, ::Type{T} = eltype(rfn(1))) where T = sprand(GLOBAL_RNG,m,n,density,(r, i) -> rfn(i))
 
 truebools(r::AbstractRNG, n::Integer) = fill(true, n)
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -374,9 +374,9 @@ SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(
 function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
     require_one_based_indexing(M)
     C = findall(v->v != 0, M)
-    @inbounds I = convert(Vector{Ti},LinearIndices(M)[C])
-    @inbounds V = convert(Vector{Tv},M[C])
-    @inbounds sparse_sorted_unique!(I, V, size(M)...)
+    I = convert(Vector{Ti},LinearIndices(M)[C])
+    V = convert(Vector{Tv},M[C])
+    sparse_sorted_unique!(I, V, size(M)...)
 end
 
 function SparseMatrixCSC{Tv,Ti}(M::StridedMatrix) where {Tv,Ti}

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1370,7 +1370,6 @@ julia> sprand(Float64, 3, 0.75)
   [3]  =  0.298614
 ```
 """
-
 function sprand(r::AbstractRNG, m::Integer, n::Integer, density::AbstractFloat, rfn::Function, ::Type{T} = eltype(rfn(r, 1))) where T
     m, n = Int(m), Int(n)
     (m < 0 || n < 0) && throw(ArgumentError("invalid Array dimensions"))


### PR DESCRIPTION
This PR implements some simplifications to the sparse code made very easy by #30494. In there, sparse random matrices were effectively constructed from a vector of linear indices (which for `sprand` were taken from `randsubseq`). So I factored out the sparse matrix construction part from `sprand` that can be used now both in `sprand` and in the fallback sparse constructor from `AbstractMatrix` (which does not catch e.g. `Matrix` because there is a more specialized constructor from `StridedMatrix`). I tested that there is no performance regression by checking against `Traspose`. In fact there seems to be a (small) performance gain as (a) there is no need to check for duplicates and (b) using linear indices one avoids the allocation of an extra vector of indices. Is there a way to check for performance regressions more systematically? 
(net outcome from this PR is -60 lines)

```
for n=(10,100,1000), p=(1.0,1e-1,1e-2,1e-3,1e-4)
    @show(n,p)
    Random.seed!(1); x=Transpose(Matrix(sprand(n,n,p))); @show @benchmark sparse($x)
end
```

MASTER:
-------------------------------------------------------------
|    n\p        | 1.0         |   0.1     | 0.01          |  0.001       | 0.0001
|-----------|------------|-----------|---------------|---------------|-------------
| n=10     | 1.481 μs | 517.677 ns | 379.346 ns | 350.789 ns | 353.089 ns
| n=100    | 121.878 μs | 37.005 μs | 20.916 μs | 18.598 μs | 18.476 μs
| n=1000   | 20.618 ms | 6.356 ms | 3.295 ms | 2.892 ms | 2.936 ms
----------------------------------------------------------------------------------


PR:
-------------------------------------------------------------
|    n\p        | 1.0         |   0.1     | 0.01          |  0.001       | 0.0001
|-----------|------------|-----------|---------------|---------------|-------------
| n=10     | 1.357 μs | 445.061 ns | 332.215 ns | 305.885 ns | 307.341 ns
| n=100    | 113.133 μs | 37.731 μs | 20.636 μs | 18.667 μs | 18.342 μs
| n=1000   | 18.671 ms | 6.013 ms | 3.290 ms | 2.924 ms | 2.939 ms
----------------------------------------------------------------------------------

