### PR TITLE
Add docstring to Symbol type

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1251,7 +1251,7 @@ end
 """
     Symbol::DataType
 
-Created when the Symbol(x...) constructor is used to concatenate 
+Created when the Symbol(x...) constructor is used to concatenate
 the string representations of the arguments passed to it.
 
 """

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1257,7 +1257,7 @@ the string representations of the arguments passed to it.
 """
 """
     Symbol(x...)
-    
+
 The constructor.
 
 Create a `Symbol` by concatenating the string representations of the arguments together.

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1249,7 +1249,16 @@ for bit in (8, 16, 32, 64, 128)
 end
 
 """
-    Symbol(x...) -> Symbol
+    Symbol::DataType
+
+Created when the Symbol(x...) constructor is used to concatenate 
+the string representations of the arguments passed to it.
+
+"""
+"""
+    Symbol(x...)
+    
+The constructor.
 
 Create a `Symbol` by concatenating the string representations of the arguments together.
 

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1255,6 +1255,8 @@ Created when the Symbol(x...) constructor is used to concatenate
 the string representations of the arguments passed to it.
 
 """
+Symbol
+
 """
     Symbol(x...)
 
@@ -1271,7 +1273,7 @@ julia> Symbol("day", 4)
 :day4
 ```
 """
-Symbol
+Symbol(x...)
 
 """
     tuple(xs...)


### PR DESCRIPTION
Added an additional docstring for the Symbol type to resolve issue to resolve Issue #28647
Now, ?Symbol will first display the type and then the constructor.