### PR TITLE
Audit `!has_offset_axes(...)` checks in Base. (#30610)

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -86,7 +86,7 @@ has_offset_axes(A)    = _tuple_any(x->first(x)!=1, axes(A))
 has_offset_axes(A...) = _tuple_any(has_offset_axes, A)
 has_offset_axes(::Colon) = false
 
-ensure_non_offset_axes(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
+require_one_based_indexing(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
 
 # Performance optimization: get rid of a branch on `d` in `axes(A, d)`
 # for d=1. 1d arrays are heavily used, and the first dimension comes up

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -86,6 +86,8 @@ has_offset_axes(A)    = _tuple_any(x->first(x)!=1, axes(A))
 has_offset_axes(A...) = _tuple_any(has_offset_axes, A)
 has_offset_axes(::Colon) = false
 
+ensure_non_offset_axes(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))
+
 # Performance optimization: get rid of a branch on `d` in `axes(A, d)`
 # for d=1. 1d arrays are heavily used, and the first dimension comes up
 # in other applications.

--- a/base/array.jl
+++ b/base/array.jl
@@ -455,7 +455,7 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
 end
 
 function _one(unit::T, x::AbstractMatrix) where T
-    ensure_non_offset_axes(x)
+    require_one_based_indexing(x)
     m,n = size(x)
     m==n || throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
     # Matrix{T}(I, m, m)
@@ -771,7 +771,7 @@ function setindex! end
 function setindex!(A::Array, X::AbstractArray, I::AbstractVector{Int})
     @_propagate_inbounds_meta
     @boundscheck setindex_shape_check(X, length(I))
-    ensure_non_offset_axes(X)
+    require_one_based_indexing(X)
     X′ = unalias(A, X)
     I′ = unalias(A, I)
     count = 1
@@ -900,7 +900,7 @@ append!(a::Vector, iter) = _append!(a, IteratorSize(iter), iter)
 push!(a::Vector, iter...) = append!(a, iter)
 
 function _append!(a, ::Union{HasLength,HasShape}, iter)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     n = length(a)
     resize!(a, n+length(iter))
     @inbounds for (i,item) in zip(n+1:length(a), iter)
@@ -948,7 +948,7 @@ prepend!(a::Vector, iter) = _prepend!(a, IteratorSize(iter), iter)
 pushfirst!(a::Vector, iter...) = prepend!(a, iter)
 
 function _prepend!(a, ::Union{HasLength,HasShape}, iter)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     n = length(iter)
     _growbeg!(a, n)
     i = 0

--- a/base/array.jl
+++ b/base/array.jl
@@ -455,7 +455,7 @@ for (fname, felt) in ((:zeros, :zero), (:ones, :one))
 end
 
 function _one(unit::T, x::AbstractMatrix) where T
-    @assert !has_offset_axes(x)
+    ensure_non_offset_axes(x)
     m,n = size(x)
     m==n || throw(DimensionMismatch("multiplicative identity defined only for square matrices"))
     # Matrix{T}(I, m, m)
@@ -771,7 +771,7 @@ function setindex! end
 function setindex!(A::Array, X::AbstractArray, I::AbstractVector{Int})
     @_propagate_inbounds_meta
     @boundscheck setindex_shape_check(X, length(I))
-    @assert !has_offset_axes(X)
+    ensure_non_offset_axes(X)
     X′ = unalias(A, X)
     I′ = unalias(A, I)
     count = 1
@@ -900,7 +900,7 @@ append!(a::Vector, iter) = _append!(a, IteratorSize(iter), iter)
 push!(a::Vector, iter...) = append!(a, iter)
 
 function _append!(a, ::Union{HasLength,HasShape}, iter)
-    @assert !has_offset_axes(a)
+    ensure_non_offset_axes(a)
     n = length(a)
     resize!(a, n+length(iter))
     @inbounds for (i,item) in zip(n+1:length(a), iter)
@@ -948,7 +948,7 @@ prepend!(a::Vector, iter) = _prepend!(a, IteratorSize(iter), iter)
 pushfirst!(a::Vector, iter...) = prepend!(a, iter)
 
 function _prepend!(a, ::Union{HasLength,HasShape}, iter)
-    @assert !has_offset_axes(a)
+    ensure_non_offset_axes(a)
     n = length(iter)
     _growbeg!(a, n)
     i = 0

--- a/base/c.jl
+++ b/base/c.jl
@@ -292,7 +292,7 @@ transcode(T, src::String) = transcode(T, codeunits(src))
 transcode(::Type{String}, src) = String(transcode(UInt8, src))
 
 function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
-    @assert !has_offset_axes(src)
+    ensure_non_offset_axes(src)
     dst = UInt16[]
     i, n = 1, length(src)
     n > 0 || return dst
@@ -343,7 +343,7 @@ function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
 end
 
 function transcode(::Type{UInt8}, src::AbstractVector{UInt16})
-    @assert !has_offset_axes(src)
+    ensure_non_offset_axes(src)
     n = length(src)
     n == 0 && return UInt8[]
 

--- a/base/c.jl
+++ b/base/c.jl
@@ -292,7 +292,7 @@ transcode(T, src::String) = transcode(T, codeunits(src))
 transcode(::Type{String}, src) = String(transcode(UInt8, src))
 
 function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
-    ensure_non_offset_axes(src)
+    require_one_based_indexing(src)
     dst = UInt16[]
     i, n = 1, length(src)
     n > 0 || return dst
@@ -343,7 +343,7 @@ function transcode(::Type{UInt16}, src::AbstractVector{UInt8})
 end
 
 function transcode(::Type{UInt8}, src::AbstractVector{UInt16})
-    ensure_non_offset_axes(src)
+    require_one_based_indexing(src)
     n = length(src)
     n == 0 && return UInt8[]
 

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -64,7 +64,7 @@ isperm(p::Tuple{Int}) = p[1] == 1
 isperm(p::Tuple{Int,Int}) = ((p[1] == 1) & (p[2] == 2)) | ((p[1] == 2) & (p[2] == 1))
 
 function permute!!(a, p::AbstractVector{<:Integer})
-    @assert !has_offset_axes(a, p)
+    ensure_non_offset_axes(a, p)
     count = 0
     start = 0
     while count < length(a)
@@ -115,7 +115,7 @@ julia> A
 permute!(a, p::AbstractVector) = permute!!(a, copymutable(p))
 
 function invpermute!!(a, p::AbstractVector{<:Integer})
-    @assert !has_offset_axes(a, p)
+    ensure_non_offset_axes(a, p)
     count = 0
     start = 0
     while count < length(a)
@@ -196,7 +196,7 @@ julia> B[invperm(v)]
 ```
 """
 function invperm(a::AbstractVector)
-    @assert !has_offset_axes(a)
+    ensure_non_offset_axes(a)
     b = zero(a) # similar vector of zeros
     n = length(a)
     @inbounds for (i, j) in enumerate(a)

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -64,7 +64,7 @@ isperm(p::Tuple{Int}) = p[1] == 1
 isperm(p::Tuple{Int,Int}) = ((p[1] == 1) & (p[2] == 2)) | ((p[1] == 2) & (p[2] == 1))
 
 function permute!!(a, p::AbstractVector{<:Integer})
-    ensure_non_offset_axes(a, p)
+    require_one_based_indexing(a, p)
     count = 0
     start = 0
     while count < length(a)
@@ -115,7 +115,7 @@ julia> A
 permute!(a, p::AbstractVector) = permute!!(a, copymutable(p))
 
 function invpermute!!(a, p::AbstractVector{<:Integer})
-    ensure_non_offset_axes(a, p)
+    require_one_based_indexing(a, p)
     count = 0
     start = 0
     while count < length(a)
@@ -196,7 +196,7 @@ julia> B[invperm(v)]
 ```
 """
 function invperm(a::AbstractVector)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     b = zero(a) # similar vector of zeros
     n = length(a)
     @inbounds for (i, j) in enumerate(a)

--- a/base/io.jl
+++ b/base/io.jl
@@ -798,7 +798,7 @@ The size of `b` will be increased if needed (i.e. if `nb` is greater than `lengt
 and enough bytes could be read), but it will never be decreased.
 """
 function readbytes!(s::IO, b::AbstractArray{UInt8}, nb=length(b))
-    @assert !has_offset_axes(b)
+    ensure_non_offset_axes(b)
     olb = lb = length(b)
     nr = 0
     while nr < nb && !eof(s)

--- a/base/io.jl
+++ b/base/io.jl
@@ -798,7 +798,7 @@ The size of `b` will be increased if needed (i.e. if `nb` is greater than `lengt
 and enough bytes could be read), but it will never be decreased.
 """
 function readbytes!(s::IO, b::AbstractArray{UInt8}, nb=length(b))
-    ensure_non_offset_axes(b)
+    require_one_based_indexing(b)
     olb = lb = length(b)
     nr = 0
     while nr < nb && !eof(s)

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -16,7 +16,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
 
     function GenericIOBuffer{T}(data::T, readable::Bool, writable::Bool, seekable::Bool, append::Bool,
                                 maxsize::Integer) where T<:AbstractVector{UInt8}
-        ensure_non_offset_axes(data)
+        require_one_based_indexing(data)
         new(data,readable,writable,seekable,append,length(data),maxsize,1,-1)
     end
 end
@@ -183,7 +183,7 @@ function read(from::GenericIOBuffer, T::Union{Type{Int16},Type{UInt16},Type{Int3
 end
 
 function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
@@ -425,7 +425,7 @@ function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
 end
 
 function write_sub(to::GenericIOBuffer, a::AbstractArray{UInt8}, offs, nel)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -16,7 +16,7 @@ mutable struct GenericIOBuffer{T<:AbstractVector{UInt8}} <: IO
 
     function GenericIOBuffer{T}(data::T, readable::Bool, writable::Bool, seekable::Bool, append::Bool,
                                 maxsize::Integer) where T<:AbstractVector{UInt8}
-        @assert !has_offset_axes(data)
+        ensure_non_offset_axes(data)
         new(data,readable,writable,seekable,append,length(data),maxsize,1,-1)
     end
 end
@@ -183,7 +183,7 @@ function read(from::GenericIOBuffer, T::Union{Type{Int16},Type{UInt16},Type{Int3
 end
 
 function read_sub(from::GenericIOBuffer, a::AbstractArray{T}, offs, nel) where T
-    @assert !has_offset_axes(a)
+    ensure_non_offset_axes(a)
     from.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
@@ -425,7 +425,7 @@ function unsafe_write(to::GenericIOBuffer, p::Ptr{UInt8}, nb::UInt)
 end
 
 function write_sub(to::GenericIOBuffer, a::AbstractArray{UInt8}, offs, nel)
-    @assert !has_offset_axes(a)
+    ensure_non_offset_axes(a)
     if offs+nel-1 > length(a) || offs < 1 || nel < 0
         throw(BoundsError())
     end

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -738,7 +738,7 @@ julia> diff(vec(a))
 ```
 """
 function diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
 
     r = axes(a)
@@ -1526,7 +1526,7 @@ function _extrema_dims(f, A::AbstractArray, dims)
 end
 
 @noinline function extrema!(f, B, A)
-    ensure_non_offset_axes(B, A)
+    require_one_based_indexing(B, A)
     sA = size(A)
     sB = size(B)
     for I in CartesianIndices(sB)

--- a/base/multidimensional.jl
+++ b/base/multidimensional.jl
@@ -738,7 +738,7 @@ julia> diff(vec(a))
 ```
 """
 function diff(a::AbstractArray{T,N}; dims::Integer) where {T,N}
-    has_offset_axes(a) && throw(ArgumentError("offset axes unsupported"))
+    ensure_non_offset_axes(a)
     1 <= dims <= N || throw(ArgumentError("dimension $dims out of range (1:$N)"))
 
     r = axes(a)
@@ -1526,7 +1526,7 @@ function _extrema_dims(f, A::AbstractArray, dims)
 end
 
 @noinline function extrema!(f, B, A)
-    @assert !has_offset_axes(B, A)
+    ensure_non_offset_axes(B, A)
     sA = size(A)
     sB = size(B)
     for I in CartesianIndices(sB)

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -164,7 +164,7 @@ _reshape(parent::Array, dims::Dims) = reshape(parent, dims)
 
 # When reshaping Vector->Vector, don't wrap with a ReshapedArray
 function _reshape(v::AbstractVector, dims::Dims{1})
-    ensure_non_offset_axes(v)
+    require_one_based_indexing(v)
     len = dims[1]
     len == length(v) || _throw_dmrs(length(v), "length", len)
     v

--- a/base/reshapedarray.jl
+++ b/base/reshapedarray.jl
@@ -164,7 +164,7 @@ _reshape(parent::Array, dims::Dims) = reshape(parent, dims)
 
 # When reshaping Vector->Vector, don't wrap with a ReshapedArray
 function _reshape(v::AbstractVector, dims::Dims{1})
-    @assert !has_offset_axes(v)
+    ensure_non_offset_axes(v)
     len = dims[1]
     len == length(v) || _throw_dmrs(length(v), "length", len)
     v

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -10,7 +10,7 @@ using .Base: copymutable, LinearIndices, length, (:),
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
     extrema, sub_with_overflow, add_with_overflow, oneunit, div, getindex, setindex!,
-    length, resize!, fill, Missing, has_offset_axes
+    length, resize!, fill, Missing, ensure_non_offset_axes
 
 using .Base: >>>, !==
 
@@ -222,7 +222,7 @@ function searchsorted(v::AbstractVector, x, ilo::Int, ihi::Int, o::Ordering)
 end
 
 function searchsortedlast(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
-    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
+    ensure_non_offset_axes(a)
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -232,7 +232,7 @@ function searchsortedlast(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
 end
 
 function searchsortedfirst(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
-    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
+    ensure_non_offset_axes(a)
     if step(a) == 0
         lt(o, first(a), x) ? length(a) + 1 : 1
     else
@@ -242,7 +242,7 @@ function searchsortedfirst(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
 end
 
 function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrdering)
-    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
+    ensure_non_offset_axes(a)
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -251,7 +251,7 @@ function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderin
 end
 
 function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrdering)
-    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
+    ensure_non_offset_axes(a)
     if step(a) == 0
         lt(o, first(a), x) ? length(a)+1 : 1
     else
@@ -260,7 +260,7 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderi
 end
 
 function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOrdering)
-    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
+    ensure_non_offset_axes(a)
     if lt(o, first(a), x)
         if step(a) == 0
             length(a) + 1
@@ -273,7 +273,7 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOr
 end
 
 function searchsortedlast(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOrdering)
-    has_offset_axes(a) && throw(ArgumentError("range must be indexed starting with 1"))
+    ensure_non_offset_axes(a)
     if lt(o, x, first(a))
         0
     elseif step(a) == 0

--- a/base/sort.jl
+++ b/base/sort.jl
@@ -10,7 +10,7 @@ using .Base: copymutable, LinearIndices, length, (:),
     AbstractVector, @inbounds, AbstractRange, @eval, @inline, Vector, @noinline,
     AbstractMatrix, AbstractUnitRange, isless, identity, eltype, >, <, <=, >=, |, +, -, *, !,
     extrema, sub_with_overflow, add_with_overflow, oneunit, div, getindex, setindex!,
-    length, resize!, fill, Missing, ensure_non_offset_axes
+    length, resize!, fill, Missing, require_one_based_indexing
 
 using .Base: >>>, !==
 
@@ -222,7 +222,7 @@ function searchsorted(v::AbstractVector, x, ilo::Int, ihi::Int, o::Ordering)
 end
 
 function searchsortedlast(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -232,7 +232,7 @@ function searchsortedlast(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
 end
 
 function searchsortedfirst(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if step(a) == 0
         lt(o, first(a), x) ? length(a) + 1 : 1
     else
@@ -242,7 +242,7 @@ function searchsortedfirst(a::AbstractRange{<:Real}, x::Real, o::DirectOrdering)
 end
 
 function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrdering)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if step(a) == 0
         lt(o, x, first(a)) ? 0 : length(a)
     else
@@ -251,7 +251,7 @@ function searchsortedlast(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderin
 end
 
 function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrdering)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if step(a) == 0
         lt(o, first(a), x) ? length(a)+1 : 1
     else
@@ -260,7 +260,7 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Real, o::DirectOrderi
 end
 
 function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOrdering)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if lt(o, first(a), x)
         if step(a) == 0
             length(a) + 1
@@ -273,7 +273,7 @@ function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOr
 end
 
 function searchsortedlast(a::AbstractRange{<:Integer}, x::Unsigned, o::DirectOrdering)
-    ensure_non_offset_axes(a)
+    require_one_based_indexing(a)
     if lt(o, x, first(a))
         0
     elseif step(a) == 0


### PR DESCRIPTION
Ref issue: #30610. Added function `ensure_non_offset_axes(A...) = !has_offset_axes(A...) || throw(ArgumentError("offset arrays are not supported but got an array with index other than 1"))` to `abstractarray.jl` and updated all `!has_offset_axes(...)` checks in Base.