### PR TITLE
[DO NOT MERGE] sprand sanity with rfn argument

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -492,31 +492,24 @@ copyto!(A::SparseMatrixCSC, B::SparseVector{TvB,TiB}) where {TvB,TiB} =
 
 
 ### Rand Construction
-sprand(n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where {T} = sprand(GLOBAL_RNG, n, p, rfn, T)
-function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function, ::Type{T}) where T
-    I = randsubseq(r, 1:convert(Int, n), p)
-    V = rfn(r, T, length(I))
-    SparseVector(n, I, V)
-end
-
 sprand(n::Integer, p::AbstractFloat, rfn::Function) = sprand(GLOBAL_RNG, n, p, rfn)
 function sprand(r::AbstractRNG, n::Integer, p::AbstractFloat, rfn::Function)
     I = randsubseq(r, 1:convert(Int, n), p)
-    V = rfn(r, length(I))
+    V = rfn(length(I))
     SparseVector(n, I, V)
 end
 
 sprand(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, rand)
 
-sprand(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, rand)
-sprand(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(r, n, p, (r, i) -> rand(r, T, i))
-sprand(r::AbstractRNG, ::Type{Bool}, n::Integer, p::AbstractFloat) = sprand(r, n, p, truebools)
+sprand(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, i->rand(r,i))
+sprand(r::AbstractRNG, ::Type{Bool}, n::Integer, p::AbstractFloat) = sprand(r, n, p, i->fill(true,i))
 sprand(::Type{T}, n::Integer, p::AbstractFloat) where {T} = sprand(GLOBAL_RNG, T, n, p)
+sprand(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where T = sprand(r, n, p, i->rand(r, T, i))
 
 sprandn(n::Integer, p::AbstractFloat) = sprand(GLOBAL_RNG, n, p, randn)
-sprandn(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, randn)
-sprandn(::Type{T}, n::Integer, p::AbstractFloat) where T = sprand(GLOBAL_RNG, n, p, (r, i) -> randn(r, T, i))
-sprandn(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where T = sprand(r, n, p, (r, i) -> randn(r, T, i))
+sprandn(r::AbstractRNG, n::Integer, p::AbstractFloat) = sprand(r, n, p, i->randn(r,i))
+sprandn(::Type{T}, n::Integer, p::AbstractFloat) where T = sprand(GLOBAL_RNG, n, p, i->randn(T, i))
+sprandn(r::AbstractRNG, ::Type{T}, n::Integer, p::AbstractFloat) where T = sprand(r, n, p, i->randn(r, T, i))
 
 ## Indexing into Matrices can return SparseVectors
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1921,7 +1921,7 @@ end
 
 @testset "issue #16073" begin
     @inferred sprand(1, 1, 1.0)
-    @inferred sprand(1, 1, 1.0, rand, Float64)
+    @inferred sprand(1, 1, 1.0, rand)
     @inferred sprand(1, 1, 1.0, x -> round.(Int, rand(x) * 100))
 end
 

--- a/stdlib/SparseArrays/test/sparsevector.jl
+++ b/stdlib/SparseArrays/test/sparsevector.jl
@@ -179,7 +179,7 @@ end
                 @test all(nonzeros(xr) .> 0.0)
             end
         end
-        let xr = sprand(1000, 0.9, rand, Float32)
+        let xr = sprand(1000, 0.9, i->rand(Float32,i))
             @test isa(xr, SparseVector{Float32,Int})
             @test length(xr) == 1000
             if !isempty(nonzeros(xr))


### PR DESCRIPTION
This PR fixes inconsistencies in `sprand` when the `rfn` argument is specified (issue #30627). Breaks the current interface, so I think not to be merged during 1.x. I'm copying here from #30627 what this PR hopefully achieves:

    Whenever `rfn` is passed, this function accepts always only one argument (the number of 
    values to generate) and no type can be specified. In this way, the caller can supply the 
    function (using a random generator or not) he wants and generating the type of values 
    he want (that will become the Tv type of the matrix).