### PR TITLE
Replace @assert with throw() in winprompt()

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -587,7 +587,7 @@ if Sys.iswindows()
         #         the default username (in theory could also provide a default password)
         credbuf = Vector{UInt8}(undef, 1024)
         credbufsize = Ref{UInt32}(sizeof(credbuf))
-        succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), stdcall, Bool,
+        succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), Bool,
             (UInt32, Cwstring, Cwstring, Ptr{UInt8}, Ptr{UInt32}),
              CRED_PACK_GENERIC_CREDENTIALS, default_username, "", credbuf, credbufsize)
         @assert succeeded

--- a/base/util.jl
+++ b/base/util.jl
@@ -587,7 +587,7 @@ if Sys.iswindows()
         #         the default username (in theory could also provide a default password)
         credbuf = Vector{UInt8}(undef, 1024)
         credbufsize = Ref{UInt32}(sizeof(credbuf))
-        succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), Bool,
+        succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), stdcall, Bool,
             (UInt32, Cwstring, Cwstring, Ptr{UInt8}, Ptr{UInt32}),
              CRED_PACK_GENERIC_CREDENTIALS, default_username, "", credbuf, credbufsize)
         succeeded || throw(SystemError("Cannot convert a user name and password into an authentication buffer."))

--- a/base/util.jl
+++ b/base/util.jl
@@ -590,7 +590,7 @@ if Sys.iswindows()
         succeeded = ccall((:CredPackAuthenticationBufferW, "credui.dll"), Bool,
             (UInt32, Cwstring, Cwstring, Ptr{UInt8}, Ptr{UInt32}),
              CRED_PACK_GENERIC_CREDENTIALS, default_username, "", credbuf, credbufsize)
-        @assert succeeded
+        succeeded || throw(SystemError("Cannot convert a user name and password into an authentication buffer."))
 
         # Step 2: Create the actual dialog
         #      2.1: Set up the window


### PR DESCRIPTION
1. The extra argument, stdcall, is a bug. The return value is just a boolean.
2. T conversion can be failed if something wrong happens in the system. So, in this case, need to raise an exception rather than assertion. I think SystemError would be the best choice for this case.

Wondering why the extra argument bug was not caught by tests. If it is missing in tests, can I have your help to add a unit test for winprompt()?