### PR TITLE
fix #28990, improve top-level location info

### DIFF
--- a/base/meta.jl
+++ b/base/meta.jl
@@ -128,10 +128,6 @@ function parse(str::AbstractString, pos::Integer; greedy::Bool=true, raise::Bool
     if raise && isa(ex,Expr) && ex.head === :error
         throw(ParseError(ex.args[1]))
     end
-    if ex === ()
-        raise && throw(ParseError("end of input"))
-        ex = Expr(:error, "end of input")
-    end
     return ex, pos+1 # C is zero-based, Julia is 1-based
 end
 

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -88,7 +88,7 @@ JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str)
     jl_value_t *r;
     JL_TRY {
         const char filename[] = "none";
-        jl_value_t *ast = jl_parse_input_line(str, strlen(str),
+        jl_value_t *ast = jl_parse_all(str, strlen(str),
                 filename, strlen(filename));
         JL_GC_PUSH1(&ast);
         r = jl_toplevel_eval_in(jl_main_module, ast);

--- a/src/julia.h
+++ b/src/julia.h
@@ -1487,6 +1487,7 @@ JL_DLLEXPORT jl_value_t *jl_restore_incremental(const char *fname, jl_array_t *d
 JL_DLLEXPORT jl_value_t *jl_restore_incremental_from_buf(const char *buf, size_t sz, jl_array_t *depmods);
 
 // front end interface
+JL_DLLEXPORT jl_value_t *jl_parse_all(const char *str, size_t len, const char *filename, size_t filename_len);
 JL_DLLEXPORT jl_value_t *jl_parse_input_line(const char *str, size_t len,
                                              const char *filename, size_t filename_len);
 JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
@@ -1494,7 +1495,11 @@ JL_DLLEXPORT jl_value_t *jl_parse_string(const char *str, size_t len,
 JL_DLLEXPORT jl_value_t *jl_load_file_string(const char *text, size_t len,
                                              char *filename, jl_module_t *inmodule);
 JL_DLLEXPORT jl_value_t *jl_expand(jl_value_t *expr, jl_module_t *inmodule);
+JL_DLLEXPORT jl_value_t *jl_expand_with_loc(jl_value_t *expr, jl_module_t *inmodule,
+                                            const char *file, int line);
 JL_DLLEXPORT jl_value_t *jl_expand_stmt(jl_value_t *expr, jl_module_t *inmodule);
+JL_DLLEXPORT jl_value_t *jl_expand_stmt_with_loc(jl_value_t *expr, jl_module_t *inmodule,
+                                                 const char *file, int line);
 JL_DLLEXPORT jl_value_t *jl_eval_string(const char *str);
 
 // external libraries

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -28,7 +28,7 @@ extern "C" {
 // current line number in a file
 JL_DLLEXPORT int jl_lineno = 0; // need to update jl_critical_error if this is TLS
 // current file name
-JL_DLLEXPORT const char *jl_filename = "no file"; // need to update jl_critical_error if this is TLS
+JL_DLLEXPORT const char *jl_filename = "none"; // need to update jl_critical_error if this is TLS
 
 htable_t jl_current_modules;
 
@@ -174,7 +174,7 @@ jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex)
     for (int i = 0; i < jl_array_len(exprs); i++) {
         // process toplevel form
         ptls->world_age = jl_world_counter;
-        form = jl_expand_stmt(jl_array_ptr_ref(exprs, i), newm);
+        form = jl_expand_stmt_with_loc(jl_array_ptr_ref(exprs, i), newm, jl_filename, jl_lineno);
         ptls->world_age = jl_world_counter;
         (void)jl_toplevel_eval_flex(newm, form, 1, 1);
     }
@@ -570,6 +570,11 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_value_t *e, int 
     if (!jl_is_expr(e)) {
         if (jl_is_linenode(e)) {
             jl_lineno = jl_linenode_line(e);
+            jl_value_t *file = jl_linenode_file(e);
+            if (file != jl_nothing) {
+                assert(jl_is_symbol(file));
+                jl_filename = jl_symbol_name((jl_sym_t*)file);
+            }
             return jl_nothing;
         }
         if (jl_is_symbol(e)) {
@@ -605,7 +610,7 @@ jl_value_t *jl_toplevel_eval_flex(jl_module_t *JL_NONNULL m, jl_value_t *e, int 
     size_t last_age = ptls->world_age;
     if (!expanded && jl_needs_lowering(e)) {
         ptls->world_age = jl_world_counter;
-        ex = (jl_expr_t*)jl_expand(e, m);
+        ex = (jl_expr_t*)jl_expand_with_loc(e, m, jl_filename, jl_lineno);
         ptls->world_age = last_age;
     }
     jl_sym_t *head = jl_is_expr(ex) ? ex->head : NULL;

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -84,7 +84,7 @@ function eval_user_input(@nospecialize(ast), backend::REPLBackend)
                 backend.in_eval = true
                 value = Core.eval(Main, ast)
                 backend.in_eval = false
-                # note: value wrapped carefully here to ensure it doesn't get passed through expand
+                # note: use jl_set_global to make sure value isn't passed through `expand`
                 ccall(:jl_set_global, Cvoid, (Any, Any, Any), Main, :ans, value)
                 put!(backend.response_channel, (value, nothing))
             end
@@ -747,7 +747,7 @@ function mode_keymap(julia_prompt::Prompt)
     end)
 end
 
-repl_filename(repl, hp::REPLHistoryProvider) = "REPL[$(length(hp.history)-hp.start_idx)]"
+repl_filename(repl, hp::REPLHistoryProvider) = "REPL[$(max(length(hp.history)-hp.start_idx, 1))]"
 repl_filename(repl, hp) = "REPL"
 
 const JL_PROMPT_PASTE = Ref(true)

--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -327,7 +327,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
         @test !success(`$exename -E "$code" --depwarn=error`)
 
         @test readchomperrors(`$exename -E "$code" --depwarn=yes`) ==
-            (true, "true", "WARNING: Foo.Deprecated is deprecated, use NotDeprecated instead.\n  likely near no file:5")
+            (true, "true", "WARNING: Foo.Deprecated is deprecated, use NotDeprecated instead.\n  likely near none:8")
 
         @test readchomperrors(`$exename -E "$code" --depwarn=no`) ==
             (true, "true", "")

--- a/test/stacktraces.jl
+++ b/test/stacktraces.jl
@@ -157,3 +157,14 @@ catch
 end
 @test bt[1].line == topline+4
 end
+
+# issue #28990
+let bt
+try
+    eval(Expr(:toplevel, LineNumberNode(42, :foo), :(error("blah"))))
+catch
+    bt = stacktrace(catch_backtrace())
+end
+@test bt[2].line == 42
+@test bt[2].file === :foo
+end

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -346,8 +346,8 @@ let b = IOBuffer("""
                  end
                  f()
                  """)
-    @test Base.parse_input_line(b) == Expr(:let, Expr(:(=), :x, :x), Expr(:block, LineNumberNode(2, :none), :x))
-    @test Base.parse_input_line(b) == Expr(:call, :f)
+    @test Base.parse_input_line(b).args[end] == Expr(:let, Expr(:(=), :x, :x), Expr(:block, LineNumberNode(2, :none), :x))
+    @test Base.parse_input_line(b).args[end] == Expr(:call, :f)
     @test Base.parse_input_line(b) === nothing
 end
 


### PR DESCRIPTION
This fixes #28990, plus the following issue:
Before:
```
julia> error()
ERROR: 
Stacktrace:
 [1] error() at ./error.jl:42
 [2] top-level scope at none:0
```
After:
```
julia> error()
ERROR: 
Stacktrace:
 [1] error() at ./error.jl:42
 [2] top-level scope at REPL[1]:1
```

This works by (1) passing an initial filename and line number to lowering (so that locations set in a `:toplevel` expression can apply to the following expression), and (2) making the REPL use the same parsing function that files (and `include_string`) use, which puts a line node before each expression.

`Base.parse_input_line` now wraps everything in a `:toplevel` expression including a line node.

The low-level parser entry points are simplified and renamed to parse-one, parse-all, and parse-file.

The `ex === ()` check in `parse` I believe was dead code; it looks like something that was left out when we replaced `()` with `nothing` a long time ago. All parsing functions return `nothing` for `parse("")`, so giving an error here would be breaking but we can consider whether we want to switch to that.

Question 1: I believe the code in interpreter.c setting `jl_lineno` ~~(which this PR removes)~~ is not necessary, since we should now be able to get line numbers from the interpreter stack trace mechanism. Can anyone think of a reason we need that code?

Question 2: I don't understand the need for the change to `repl_filename`. Without it, the filename for the first repl input is `REPL[0]` if the input is very simple, e.g. `error()` as in the example above. But if I insert even just a single space (within the same input cell) before `error()`, then you get `REPL[1]`.