### PR TITLE
RFC/Julep: Introduce getproperty on `Array` for built-in data tables.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -208,6 +208,18 @@ function isassigned(a::Array, i::Int...)
     ccall(:jl_array_isassigned, Cint, (Any, UInt), a, ii) == 1
 end
 
+## getproperty ##
+
+struct GetProperty{name} <: Function
+end
+
+(::GetProperty{name})(x) where {name} = getproperty(x, name::Symbol)
+
+# Arrays behave as native "tables"
+if getproperty !== getfield
+    getproperty(a::Array, name::Symbol) = map(GetProperty{name}(), a)
+end
+
 ## copy ##
 
 """


### PR DESCRIPTION
This is a bit of a fun one, while the v1.2 development cycle is young. I'm not sure if this approach will receive universal support, but discussion of this may be helpful, so here goes.

Julia is an awesome language for maths with arrays (linear algebra) and for a while now I've been wondering if we can make it equally ergonomic and awesome for other typical data operations with array-like data structures, such as tables. For example, *relations* are collections of (named) tuples and `Array{<:NamedTuple}` seems like a relatively natural candidate to behave as a relation. In fact, the community (e.g. Tables.jl) generally seems to be trending towards "table rows are things that we can do `getproperty` on to get cell values" and "table columns iterate cell values", and from tables themselves we might want to extract rows or columns via iteration or `getproperty`, respectively.

This PR uses a simple trick to make our built-in arrays behave more friendly as data tables. It automatically broadcasts `getproperty` over array `Array` (greedily via `map`, in this basic implementation, though we theoretically can do a lazy approach and support `setproperty!` and so-on). Here's a simple example:

```julia
julia> table = [(a=1, b=true), (a=2, b=false), (a=3, b=true)]
3-element Array{NamedTuple{(:a, :b),Tuple{Int64,Bool}},1}:
 (a = 1, b = true) 
 (a = 2, b = false)
 (a = 3, b = true) 

julia> table.a
3-element Array{Int64,1}:
 1
 2
 3

julia> table.b
3-element Array{Bool,1}:
  true
 false
  true
```

And finally, it's notable that this is useful for general data manipulation and broader contexts. It works on structs and so-on, not just `NamedTuple` elements. For example, for doing complex linear algebra this is relatively nice:

```julia
julia> a = rand(Complex{Float64}, 2, 2)
2×2 Array{Complex{Float64},2}:
 0.876236+0.403676im  0.349794+0.233915im
 0.476042+0.530344im  0.913785+0.263034im

julia> a.re
2×2 Array{Float64,2}:
 0.876236  0.349794
 0.476042  0.913785

julia> a.im
2×2 Array{Float64,2}:
 0.403676  0.233915
 0.530344  0.263034
```

Looking forward speculatively, I wonder if we could make this a part of the `AbstractArray` spec for Julia 2.0 (obviously a breaking change) where library writers would use `getfield` and helper functions to manipulate custom array internals, and mostly external users don't directly access the fields/properties of arrays anyway.