### PR TITLE
clarify the default setting of --track-allocation option

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -133,7 +133,7 @@ static const char opts[]  =
     "                           Append coverage information to the LCOV tracefile (filename supports format tokens).\n"
 // TODO: These TOKENS are defined in `runtime_ccall.cpp`. A more verbose `--help` should include that list here.
     " --track-allocation={none|user|all}, --track-allocation\n"
-    "                           Count bytes allocated by each source line\n\n"
+    "                           Count bytes allocated by each source line (omitting setting is equivalent to \"user\")\n\n"
 ;
 
 static const char opts_hidden[]  =


### PR DESCRIPTION
Because I forget things easily. The default value is set here: https://github.com/JuliaLang/julia/blob/34f7a4a50458594e6d72793b4f371227e8e842e3/src/jloptions.c#L472-L487.