### PR TITLE
Properly set eqtable signatures to jl_value_t* rather than void*

### DIFF
--- a/src/gf.c
+++ b/src/gf.c
@@ -479,7 +479,7 @@ static void foreach_mtable_in_module(
 {
     size_t i;
     void **table = m->bindings.table;
-    jl_eqtable_put(visited, m, jl_true, NULL);
+    jl_eqtable_put(visited, (jl_value_t*)m, jl_true, NULL);
     for (i = 1; i < m->bindings.size; i += 2) {
         if (table[i] != HT_NOTFOUND) {
             jl_binding_t *b = (jl_binding_t*)table[i];

--- a/src/julia.h
+++ b/src/julia.h
@@ -1381,8 +1381,8 @@ STATIC_INLINE jl_function_t *jl_get_function(jl_module_t *m, const char *name)
 int jl_is_submodule(jl_module_t *child, jl_module_t *parent) JL_NOTSAFEPOINT;
 
 // eq hash tables
-JL_DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, void *key, void *val, int *inserted);
-JL_DLLEXPORT jl_value_t *jl_eqtable_get(jl_array_t *h, void *key,
+JL_DLLEXPORT jl_array_t *jl_eqtable_put(jl_array_t *h, jl_value_t *key, jl_value_t *val, int *inserted);
+JL_DLLEXPORT jl_value_t *jl_eqtable_get(jl_array_t *h, jl_value_t *key,
                                         jl_value_t *deflt);
 
 // system information


### PR DESCRIPTION
Of course this doesn't currently make any difference to the generated
code, but we have a few tools that parse the C source to perform additional
analysis (e.g. the GC root analyzer), that rely on tracked pointers having
a GC-tracked type for proper functioning, so switch that over.