### PR TITLE
faster indexing for ReinterpretArray for homogeneous struct.

### DIFF
--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -339,7 +339,6 @@ end
         push!(struct_args,:(@inbounds data[I-$(NF-j)]))
     end
     push!(struct_args,:(@inbounds data[I]))
- 
     push!(exarg, element)
     return ex
 end
@@ -366,7 +365,6 @@ end
         push!(struct_args,:(@inbounds $(Expr(:call, :getindex, :data, :(I-$(NF-j)), rest_of_indices...))))
     end
     push!(struct_args,:(@inbounds $(Expr(:call, :getindex, :data, :I, rest_of_indices...))))
- 
     push!(exarg, element)
     return ex
 end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -308,8 +308,8 @@ using .Iterators: Stateful
     return true
 end
 
-@pure is_ntuple_wrapper(::Type{ST}) where ST = fieldcount(ST) == 1 && fieldtype(ST, 1) <: NTuple
-@pure myfieldcount(::Type{ST}) where {ST} = is_ntuple_wrapper(ST) ? fieldcount(fieldtype(ST, 1)) : fieldcount(ST)
+is_ntuple_wrapper(::Type{ST}) where ST = fieldcount(ST) == 1 && fieldtype(ST, 1) <: NTuple
+myfieldcount(::Type{ST}) where {ST} = is_ntuple_wrapper(ST) ? fieldcount(fieldtype(ST, 1)) : fieldcount(ST)
 
 @generated function check_applicable_homogeneous_struct(::Type{ST}, ::Type{T}) where {ST, T}
     # Check whether ST is a homogeneous struct of T's

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -92,11 +92,17 @@ unsafe_convert(::Type{Ptr{T}}, a::ReinterpretArray{T,N,S} where N) where {T,S} =
 
 @inline @propagate_inbounds function getindex(a::ReinterpretArray{T,N,S}, inds::Vararg{Int, N}) where {T,N,S}
     check_readable(a)
+    if check_applicable_homogeneous_struct(T,S)
+        return homogeneous_struct_getindex(T,a.parent,inds...)
+    end
     _getindex_ra(a, inds[1], tail(inds))
 end
 
 @inline @propagate_inbounds function getindex(a::ReinterpretArray{T,N,S}, i::Int) where {T,N,S}
     check_readable(a)
+    if check_applicable_homogeneous_struct(T,S)
+        return homogeneous_struct_getindex(T,a.parent,i)
+    end
     if isa(IndexStyle(a), IndexLinear)
         return _getindex_ra(a, i, ())
     end
@@ -144,11 +150,17 @@ end
 
 @inline @propagate_inbounds function setindex!(a::ReinterpretArray{T,N,S}, v, inds::Vararg{Int, N}) where {T,N,S}
     check_writable(a)
+    if check_applicable_homogeneous_struct(T,S)
+        return homogeneous_struct_setindex!(a.parent,T,v,inds...)
+    end
     _setindex_ra!(a, v, inds[1], tail(inds))
 end
 
 @inline @propagate_inbounds function setindex!(a::ReinterpretArray{T,N,S}, v, i::Int) where {T,N,S}
     check_writable(a)
+    if check_applicable_homogeneous_struct(T,S)
+        return homogeneous_struct_setindex!(a.parent,T,v,i)
+    end
     if isa(IndexStyle(a), IndexLinear)
         return _setindex_ra!(a, v, i, ())
     end
@@ -294,4 +306,99 @@ using .Iterators: Stateful
         checked_size = pad.offset + pad.size
     end
     return true
+end
+
+@pure is_ntuple_wrapper(::Type{ST}) where ST = fieldcount(ST) == 1 && fieldtype(ST, 1) <: NTuple
+@pure myfieldcount(::Type{ST}) where {ST} = is_ntuple_wrapper(ST) ? fieldcount(fieldtype(ST, 1)) : fieldcount(ST)
+
+@generated function check_applicable_homogeneous_struct(::Type{ST}, ::Type{T}) where {ST, T}
+    # Check whether ST is a homogeneous struct of T's
+    fieldcount(ST) == 0 && return false # not a struct
+    TT = is_ntuple_wrapper(ST) ? fieldtype(ST,1) : ST
+    NF = fieldcount(TT)
+    t = fieldtype(TT,1)
+    t === T || return false # struct element and type don't match
+    return all(x -> x === t, [fieldtype(TT,i) for i in 1:NF]) # check if struct is homogeneous.
+end
+
+@generated function homogeneous_struct_getindex(::Type{ST}, data::AbstractArray{T,N},i::Int) where {ST,T,N}
+    NF = myfieldcount(ST)
+    ex = Expr(:block)
+    exarg = ex.args
+    push!(exarg,Expr(:meta,:inline))
+    push!(exarg,:(I=$NF*i))
+    push!(exarg,:(@boundscheck checkbounds(data,I)))
+    element = ST <: NTuple ? Expr(:tuple) : Expr(:call,ST)
+    for j in 1:(NF-1)
+        push!(element.args,:(@inbounds data[I-$(NF-j)]))
+    end
+    push!(element.args,:(@inbounds data[I]))
+
+    push!(exarg, element)
+    return ex
+end
+
+@generated function homogeneous_struct_getindex(::Type{ST}, data::AbstractArray{T,N},i::Vararg{Int,N}) where {ST,T,N}
+    NF = myfieldcount(ST)
+    ex = Expr(:block)
+    exarg = ex.args
+    push!(exarg,Expr(:meta,:inline))
+    push!(exarg,:(I=$NF*i[1]))
+    rest_of_indices = Vector{Any}()
+    for j = 2:N
+        push!(rest_of_indices,:(i[$j]))
+    end
+    push!(exarg,:(@boundscheck $(Expr(:call,:checkbounds,:data,:I,rest_of_indices...))))
+    element = ST <: NTuple ? Expr(:tuple) : Expr(:call,ST)
+    for j in 1:(NF-1)
+        push!(element.args,:(@inbounds $(Expr(:call, :getindex, :data, :(I-$(NF-j)), rest_of_indices...))))
+    end
+    push!(element.args,:(@inbounds $(Expr(:call, :getindex, :data, :I, rest_of_indices...))))
+
+    push!(exarg, element)
+    return ex
+end
+
+@generated function homogeneous_struct_setindex!(data::AbstractArray{T,N},::Type{ST},val,i::Int) where {ST,T,N}
+    NF = myfieldcount(ST)
+    ex = quote
+        $(Expr(:meta,:inline))
+        I=$NF*i
+        @boundscheck checkbounds(data,I)
+    end
+    exarg = ex.args
+
+    push!(exarg, is_ntuple_wrapper(ST) ? :(val2 = getfield(convert($ST,val),1)) : :(val2 = convert($ST,val)))
+
+    for j in 1:(NF-1)
+        push!(exarg,:(@inbounds $(Expr(:call,:setindex!, :data, :(getfield(val2,$j)), :(I-$(NF-j))))))
+    end
+    push!(exarg,:(@inbounds $(Expr(:call,:setindex!, :data, :(getfield(val2,$NF)), :I))))
+
+    return ex
+end
+
+@generated function homogeneous_struct_setindex!(data::AbstractArray{T,N},::Type{ST},val,i::Vararg{Int,N}) where {ST,T,N}
+    NF = myfieldcount(ST)
+    rest_of_indices = Vector{Any}()
+
+    for j = 2:N
+        push!(rest_of_indices,:(i[$j]))
+    end
+
+    ex = quote
+        $(Expr(:meta,:inline))
+        I=$NF*i[1]
+        @boundscheck $(Expr(:call,:checkbounds,:data,:I,rest_of_indices...))
+    end
+    exarg = ex.args
+
+    push!(exarg, is_ntuple_wrapper(ST) ? :(val2 = getfield(convert($ST,val),1)) : :(val2 = convert($ST,val)))
+
+    for j in 1:(NF-1)
+        push!(exarg,:(@inbounds $(Expr(:call,:setindex!, :data, :(getfield(val2,$j)), :(I-$(NF-j)),rest_of_indices...))))
+    end
+    push!(exarg,:(@inbounds $(Expr(:call,:setindex!, :data, :(getfield(val2,$NF)), :I,rest_of_indices...))))
+
+    return ex
 end

--- a/base/reinterpretarray.jl
+++ b/base/reinterpretarray.jl
@@ -328,12 +328,18 @@ end
     push!(exarg,Expr(:meta,:inline))
     push!(exarg,:(I=$NF*i))
     push!(exarg,:(@boundscheck checkbounds(data,I)))
-    element = ST <: NTuple ? Expr(:tuple) : Expr(:call,ST)
-    for j in 1:(NF-1)
-        push!(element.args,:(@inbounds data[I-$(NF-j)]))
+    element = Expr(:new,ST)
+    if is_ntuple_wrapper(ST)
+        push!(element.args,Expr(:tuple))
+        struct_args = element.args[2].args
+    else
+        struct_args = element.args
     end
-    push!(element.args,:(@inbounds data[I]))
-
+    for j in 1:(NF-1)
+        push!(struct_args,:(@inbounds data[I-$(NF-j)]))
+    end
+    push!(struct_args,:(@inbounds data[I]))
+ 
     push!(exarg, element)
     return ex
 end
@@ -349,12 +355,18 @@ end
         push!(rest_of_indices,:(i[$j]))
     end
     push!(exarg,:(@boundscheck $(Expr(:call,:checkbounds,:data,:I,rest_of_indices...))))
-    element = ST <: NTuple ? Expr(:tuple) : Expr(:call,ST)
-    for j in 1:(NF-1)
-        push!(element.args,:(@inbounds $(Expr(:call, :getindex, :data, :(I-$(NF-j)), rest_of_indices...))))
+    element = Expr(:new,ST)
+    if is_ntuple_wrapper(ST)
+        push!(element.args,Expr(:tuple))
+        struct_args = element.args[2].args
+    else
+        struct_args = element.args
     end
-    push!(element.args,:(@inbounds $(Expr(:call, :getindex, :data, :I, rest_of_indices...))))
-
+    for j in 1:(NF-1)
+        push!(struct_args,:(@inbounds $(Expr(:call, :getindex, :data, :(I-$(NF-j)), rest_of_indices...))))
+    end
+    push!(struct_args,:(@inbounds $(Expr(:call, :getindex, :data, :I, rest_of_indices...))))
+ 
     push!(exarg, element)
     return ex
 end


### PR DESCRIPTION
I've created specific `getindex` and `setindex!` method for reinterpret of arrays to a homogeneous struct (all fields of the struct have the same type as the original array).
I believe that is the most common usage for `reinterpret` and since the reinterpret overhaul it lost some performance.
This PR seems to fix that for those simple - yet widely used - cases.

Before this PR:
```julia

julia> using BenchmarkTools

julia> using StaticArrays

julia> a = rand(16,16);

julia> r = reinterpret(SVector{2,Float64},a);

julia> nr = Array(r);

julia> @benchmark sum($nr)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     95.941 ns (0.00% GC)
  median time:      96.077 ns (0.00% GC)
  mean time:        96.413 ns (0.00% GC)
  maximum time:     437.737 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     950

julia> @benchmark sum($r)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     120.970 ns (0.00% GC)
  median time:      121.436 ns (0.00% GC)
  mean time:        122.972 ns (0.00% GC)
  maximum time:     411.434 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     907

```

After the PR:

```julia
julia> using BenchmarkTools

julia> using StaticArrays

julia> a = rand(16,16);

julia> r = reinterpret(SVector{2,Float64},a);

julia> nr = Array(r);

julia> @benchmark sum($nr)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     96.426 ns (0.00% GC)
  median time:      96.509 ns (0.00% GC)
  mean time:        96.805 ns (0.00% GC)
  maximum time:     181.838 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     949

julia> @benchmark sum($r)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     97.666 ns (0.00% GC)
  median time:      98.251 ns (0.00% GC)
  mean time:        99.009 ns (0.00% GC)
  maximum time:     200.624 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     946
```

It uses a few generated functions. I don't know if that is desirable or not.
I'm also not sure I'm making some improper assumption about the padding of structs or something related to that.