### PR TITLE
Please CLOSE this one in favor of other PR: Code for faster factorial (and gamma)

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -29,7 +29,7 @@ factorial(n::Union{Int64,UInt64}) = factorial_lookup(n, _fact_table64, 20)
 
 if Int === Int32
     factorial(n::Union{Int8,UInt8,Int16,UInt16}) = factorial(Int32(n))
-    factorial(n::Union{Int32,UInt32}) = factorial_lookup(n, _fact_table64, 12)
+    factorial(n::Union{Int32,UInt32}) = factorial_lookup_helper(n, _fact_table64, 12)
 else
     factorial(n::Union{Int8,UInt8,Int16,UInt16,Int32,UInt32}) = factorial(Int64(n))
 end

--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -2,7 +2,7 @@
 
 # Factorials
 
-const _fact_table64 = [1; cumprod(1:20)]  # tables shifted by 1 so factorial(0) can be looked up; maybe OffsetArray better?
+const _fact_table64 = [1; cumprod(1:Int64(20))]  # tables shifted by 1 so factorial(0) can be looked up; maybe OffsetArray better?
 
 const _fact_table128 = [1; cumprod(1:UInt128(34))]
 


### PR DESCRIPTION
This is kind of my first Julia PR (my other PRs have only been very trivial), and I'm not sure if this function is used much (I was looking into the more general issue); and if the 22% faster speed is important enough to backport to 1.1 and even 1.0.4 but as the change is a small one feel free.

Before, factorial had a call and three checks/taken assembly branches (at least on 0.5 where I was first testing on) before looking up in the table, and now only one not-taken branch and no call and on the fast path (on 1.2 at least, more on 0.5):

```
julia> @code_native factorial_lookup(3, _fact_table64, 34)
	.text
; ┌ @ REPL[200]:2 within `factorial_lookup'
	pushq	%rax
	cmpq	$16, %rdi
	jae	L16
; │ @ REPL[200]:5 within `factorial_lookup'
; │┌ @ array.jl:728 within `getindex'
	movq	(%rsi), %rax
	movq	(%rax,%rdi,8), %rax
; │└
; │ @ REPL[200]:6 within `factorial_lookup'
	popq	%rcx
	retq
; │ @ REPL[200]:3 within `factorial_lookup'
L16:
	movabsq	$julia_factorial_lookup_helper_12541, %rax
	callq	*%rax
	popq	%rcx
	retq
	nop
; └
```

So I achieved my objective, <s>*should* be faster, didn't time,</s> maybe this doesn't matter much, but with *cumprod* the table generation is also simpler and backportable to 0.5 (undef blocked that before). I didn't count bytes for the generated machine code (is there away; from Julia?) and since it's inlined, it may matter?


Rest is stuff that doesn't need reading, just want to make sure BigInt (and BigFloat still works) and also that assemly of non-common types are also ok:

I did have:

factorial(n::BigInt) = factorial_lookup_helper(n, _fact_table128, 34)

originally in the PR, to bypass the inlining. It turned out to be not needed it seems and wrong to have it in anyway.

julia> factorial(BigInt(34))
295232799039604140847618609643520000000

It seems this is all backportable to 1.0 (and even to 0.5; while assembly is not as tight there, but still better) while I got this different error on 0.5 compared to 1.2 for the old outdated code:

julia> factorial(BigInt(35))
ERROR: MethodError: Cannot `convert` an object of type String to an object of type OverflowError
This may have arisen from a call to the constructor OverflowError(...),
since type constructors fall back to convert methods.
 in factorial_lookup_helper(::BigInt, ::Array{UInt128,1}, ::Int64) at ./REPL[3]:3
 in factorial(::BigInt) at ./REPL[13]:1




I was also toying with a fast-path for BigInt, seem not needed:

```
@noinline function factorial_lookup(n::BigInt, table, lim)
    if 0 <= n < 32
        @inbounds f = table[n+1]
        return oftype(n, f)
    else
        return factorial_lookup_helper(n, table, lim)
    end
end
```