### PR TITLE
External build tools for stdlibs other than Pkg

### DIFF
--- a/deps/tools/stdlib-external.mk
+++ b/deps/tools/stdlib-external.mk
@@ -1,0 +1,27 @@
+# Define a set of targets for downloading, caching, and building the source of
+# a stdlib library. The commit and git branch should be defined in a file
+# $stdlib_name.version in the current directory. See the git-external macro for
+# additional documentation.
+#
+# Parameters to the stdlib-external macro:
+#
+#   $1 = stdlib_name
+#   $2 = var_prefix (by convention, use upper cased stdlib_name)
+
+include $(JULIAHOME)/deps/tools/git-external.mk
+
+define stdlib-external
+
+$$(eval $$(call git-external,$1,$2,,,$$(BUILDDIR)))
+$$(BUILDDIR)/$$($2_SRC_DIR)/build-compiled: $$(BUILDDIR)/$$($2_SRC_DIR)/source-extracted
+	@# no build steps
+	echo 1 > $$@
+$$(eval $$(call symlink_install,$1,$$$$($2_SRC_DIR),$$$$(build_datarootdir)/julia/stdlib/$$$$(VERSDIR)))
+clean-$1:
+	-rm $$(BUILDDIR)/$$($2_SRC_DIR)/build-compiled
+get-$1: $$($2_SRC_FILE)
+extract-$1: $$(BUILDDIR)/$$($2_SRC_DIR)/source-extracted
+configure-$1: extract-$1
+compile-$1: $$(BUILDDIR)/$$($2_SRC_DIR)/build-compiled
+
+endef

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -7,7 +7,7 @@ BUILDDIR := .
 
 include $(JULIAHOME)/Make.inc
 include $(JULIAHOME)/deps/tools/common.mk
-include $(JULIAHOME)/deps/tools/git-external.mk
+include $(JULIAHOME)/deps/tools/stdlib-external.mk
 
 VERSDIR := v$(shell cut -d. -f1-2 < $(JULIAHOME)/VERSION)
 
@@ -18,30 +18,18 @@ STDLIBS = Base64 CRC32c Dates DelimitedFiles Distributed FileWatching \
           Future InteractiveUtils Libdl LibGit2 LinearAlgebra Logging \
           Markdown Mmap Printf Profile Random REPL Serialization SHA \
           SharedArrays Sockets SparseArrays Statistics SuiteSparse Test Unicode UUIDs
-STDLIBS-EXT = Pkg
-
-# Download and extract Pkg
+STDLIBS_EXT = Pkg
 PKG_GIT_URL := git://github.com/JuliaLang/Pkg.jl.git
 PKG_TAR_URL = https://api.github.com/repos/JuliaLang/Pkg.jl/tarball/$1
-$(eval $(call git-external,Pkg,PKG,,,$(BUILDDIR)))
-$(BUILDDIR)/$(PKG_SRC_DIR)/build-compiled: $(BUILDDIR)/$(PKG_SRC_DIR)/source-extracted
-	@# no build steps
-	echo 1 > $@
-$(eval $(call symlink_install,Pkg,$$(PKG_SRC_DIR),$$(build_datarootdir)/julia/stdlib/$$(VERSDIR)))
-clean-Pkg:
-	-rm $(BUILDDIR)/$(PKG_SRC_DIR)/build-compiled
-get-Pkg: $(PKG_SRC_FILE)
-extract-Pkg: $(BUILDDIR)/$(PKG_SRC_DIR)/source-extracted
-configure-Pkg: extract-Pkg
-compile-Pkg: $(BUILDDIR)/$(PKG_SRC_DIR)/build-compiled
 
+$(foreach module, $(STDLIBS_EXT), $(eval $(call stdlib-external,$(module),$(shell echo $(module) | tr a-z A-Z))))
 
 # Generate symlinks to all stdlibs at usr/share/julia/stdlib/vX.Y/
 $(foreach module, $(STDLIBS), $(eval $(call symlink_target,$$(JULIAHOME)/stdlib/$(module),$$(build_datarootdir)/julia/stdlib/$$(VERSDIR),$(module))))
 
 STDLIBS_LINK_TARGETS := $(addprefix $(build_datarootdir)/julia/stdlib/$(VERSDIR)/,$(STDLIBS))
 
-getall get: get-Pkg
-install: install-Pkg $(STDLIBS_LINK_TARGETS)
-clean: clean-Pkg $(CLEAN_TARGETS)
-distclean: distclean-Pkg clean
+getall get: $(addprefix get-, $(STDLIBS_EXT))
+install: $(addprefix install-, $(STDLIBS_EXT)) $(STDLIBS_LINK_TARGETS)
+clean: $(addprefix clean-, $(STDLIBS_EXT)) $(CLEAN_TARGETS)
+distclean: $(addprefix distclean-, $(STDLIBS_EXT)) clean


### PR DESCRIPTION
Extracts some common functionalities to make it easier to install other stdlibs the same way we do with Pkg.
cc @c42f