### PR TITLE
convert methods between String and Symbol

### DIFF
--- a/base/strings/basic.jl
+++ b/base/strings/basic.jl
@@ -207,6 +207,10 @@ Symbol(s::AbstractString) = Symbol(String(s))
 convert(::Type{T}, s::T) where {T<:AbstractString} = s
 convert(::Type{T}, s::AbstractString) where {T<:AbstractString} = T(s)
 
+convert(::Type{String}, s::Symbol) = String(s)
+convert(::Type{Symbol}, s::AbstractString) = Symbol(s)
+convert(::Type{T}, s::Symbol) where T<:AbstractString = T(String(s))
+
 ## string & character concatenation ##
 
 """

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -155,6 +155,8 @@ end
 
 @testset "Symbol and gensym" begin
     @test Symbol("asdf") === :asdf
+    @test convert(Symbol, "asdf") === :asdf
+    @test convert(String, :asdf) == "asdf"
     @test Symbol(:abc,"def",'g',"hi",0) === :abcdefghi0
     @test :a < :b
     @test startswith(string(gensym("asdf")),"##asdf#")
@@ -320,6 +322,8 @@ end
     @test nextind("fóobar", 0, 3) == 4
 
     @test Symbol(gstr) == Symbol("12")
+    @test convert(Symbol, gstr) == Symbol("12")
+    @test GenericString("foo") == convert(GenericString, :foo)
 
     @test sizeof(gstr) == 2
     @test ncodeunits(gstr) == 2


### PR DESCRIPTION
Unfortunately
```
julia> A=["foo", "bar"];
julia> convert(Vector{Symbol}, A)
ERROR: MethodError: Cannot `convert` an object of type String to an object of type Symbol
```
This is especially annoying when trying to apply types to a dataframe that comes out of a CSV file: Some string-columns represent categorical data that is often represented by a Symbol, and Symbol is turned into String for CSV purposes anyway. Representing categorical data by `Symbol` is sometimes questionable, but definitely makes sense in cases where it represents a column index of a different dataframe.

Is there any reason why we couldn't allow this?