### PR TITLE
improve docstring of SparseMatrixCSC

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -10,6 +10,7 @@
 
 Matrix type for storing sparse matrices in the
 [Compressed Sparse Column](@ref man-csc) format.
+See also [`spzeros`](@ref) and [`sparse`](@ref).
 """
 struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -12,7 +12,7 @@ Matrix type for storing sparse matrices in the
 [Compressed Sparse Column](@ref man-csc) format.
 The standard way of constructing SparseMatrixCSC
 is through the [`sparse`](@ref) function. See
-also [`spzeros`](@ref), [`sprand`](@ref).
+also [`spzeros`](@ref) and [`sprand`](@ref).
 """
 struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -9,10 +9,9 @@
     SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
 
 Matrix type for storing sparse matrices in the
-[Compressed Sparse Column](@ref man-csc) format.
-The standard way of constructing SparseMatrixCSC
-is through the [`sparse`](@ref) function. See
-also [`spzeros`](@ref) and [`sprand`](@ref).
+[Compressed Sparse Column](@ref man-csc) format. The standard way
+of constructing SparseMatrixCSC is through the [`sparse`](@ref) function.
+See also [`spzeros`](@ref), [`spdiagm`](@ref) and [`sprand`](@ref).
 """
 struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -10,7 +10,9 @@
 
 Matrix type for storing sparse matrices in the
 [Compressed Sparse Column](@ref man-csc) format.
-See also [`spzeros`](@ref) and [`sparse`](@ref).
+The standard way of constructing SparseMatrixCSC
+is through the [`sparse`](@ref) function. See
+also [`spzeros`](@ref), [`sprand`](@ref).
 """
 struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     m::Int                  # Number of rows


### PR DESCRIPTION
Give the poor user a hint about constructing these matrices by cross-referencing to `spzeros` and `sparse`.