### PR TITLE
Tell `fixup-libgfortran.sh` to ignore missing libraries

### DIFF
--- a/contrib/fixup-libgfortran.sh
+++ b/contrib/fixup-libgfortran.sh
@@ -35,7 +35,7 @@ find_shlib()
     lib_path="$1"
     if [ -f "$lib_path" ]; then
         if [ "$UNAME" = "Linux" ]; then
-            ldd "$lib_path" | grep $2 | cut -d' ' -f3 | xargs
+            ldd "$lib_path" | grep $2 | grep -v "not found" | cut -d' ' -f3 | xargs
         else # $UNAME is "Darwin", we only have two options, see above
             otool -L "$lib_path" | grep $2 | cut -d' ' -f1 | xargs
         fi


### PR DESCRIPTION
This prevents us from adding the SONAME `"not"` to our list of possible
libgfortran SONAMES (because it thinks the string `"not found"` might be
a valid SONAME).