### PR TITLE
auditing all cases of `assert !has_offset_axes(...)` 

### DIFF
--- a/doc/src/devdocs/offset-arrays.md
+++ b/doc/src/devdocs/offset-arrays.md
@@ -15,7 +15,7 @@ the exported interfaces of Julia.
 If you find it more convenient to just force your users to supply traditional arrays where indexing starts at one, you can add
 
 ```julia
-@assert !Base.has_offset_axes(arrays...)
+Base.require_one_based_indexing(arrays...)
 ```
 
 where `arrays...` is a list of the array objects that you wish to check for anything that

--- a/stdlib/Base64/src/Base64.jl
+++ b/stdlib/Base64/src/Base64.jl
@@ -2,7 +2,7 @@
 
 module Base64
 
-using Base: has_offset_axes
+using Base: require_one_based_indexing
 
 export
     Base64EncodePipe,

--- a/stdlib/Base64/src/decode.jl
+++ b/stdlib/Base64/src/decode.jl
@@ -109,7 +109,7 @@ function Base.read(pipe::Base64DecodePipe, ::Type{UInt8})
 end
 
 function Base.readbytes!(pipe::Base64DecodePipe, data::AbstractVector{UInt8}, nb::Integer=length(data))
-    @assert !has_offset_axes(data)
+    require_one_based_indexing(data)
     filled::Int = 0
     while filled < nb && !eof(pipe)
         if length(data) == filled

--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -16,7 +16,7 @@ import Base: USE_BLAS64, abs, acos, acosh, acot, acoth, acsc, acsch, adjoint, as
     setindex!, show, similar, sin, sincos, sinh, size, size_to_strides, sqrt, StridedReinterpretArray,
     StridedReshapedArray, strides, stride, tan, tanh, transpose, trunc, typed_hcat, vec
 using Base: hvcat_fill, IndexLinear, promote_op, promote_typeof,
-    @propagate_inbounds, @pure, reduce, typed_vcat, has_offset_axes
+    @propagate_inbounds, @pure, reduce, typed_vcat, require_one_based_indexing
 using Base.Broadcast: Broadcasted
 
 export

--- a/stdlib/LinearAlgebra/src/adjtrans.jl
+++ b/stdlib/LinearAlgebra/src/adjtrans.jl
@@ -197,7 +197,7 @@ broadcast(f, tvs::Union{Number,TransposeAbsVec}...) = transpose(broadcast((xs...
 *(u::AdjointAbsVec, v::AbstractVector) = dot(u.parent, v)
 *(u::TransposeAbsVec{T}, v::AbstractVector{T}) where {T<:Real} = dot(u.parent, v)
 function *(u::TransposeAbsVec, v::AbstractVector)
-    @assert !has_offset_axes(u, v)
+    require_one_based_indexing(u, v)
     @boundscheck length(u) == length(v) || throw(DimensionMismatch())
     return sum(@inbounds(u[k]*v[k]) for k in 1:length(u))
 end

--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -6,7 +6,7 @@ struct Bidiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     ev::V      # sub/super diagonal
     uplo::Char # upper bidiagonal ('U') or lower ('L')
     function Bidiagonal{T,V}(dv, ev, uplo::AbstractChar) where {T,V<:AbstractVector{T}}
-        @assert !has_offset_axes(dv, ev)
+        require_one_based_indexing(dv, ev)
         if length(ev) != length(dv)-1
             throw(DimensionMismatch("length of diagonal vector is $(length(dv)), length of off-diagonal vector is $(length(ev))"))
         end
@@ -355,9 +355,9 @@ mul!(C::AbstractMatrix, A::BiTri, B::Adjoint{<:Any,<:AbstractVecOrMat}) = A_mul_
 mul!(C::AbstractVector, A::BiTri, B::Transpose{<:Any,<:AbstractVecOrMat}) = throw(MethodError(mul!, (C, A, B)))
 
 function check_A_mul_B!_sizes(C, A, B)
-    @assert !has_offset_axes(C)
-    @assert !has_offset_axes(A)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(C)
+    require_one_based_indexing(A)
+    require_one_based_indexing(B)
     nA, mA = size(A)
     nB, mB = size(B)
     nC, mC = size(C)
@@ -438,8 +438,8 @@ function A_mul_B_td!(C::AbstractMatrix, A::BiTriSym, B::BiTriSym)
 end
 
 function A_mul_B_td!(C::AbstractVecOrMat, A::BiTriSym, B::AbstractVecOrMat)
-    @assert !has_offset_axes(C)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(C)
+    require_one_based_indexing(B)
     nA = size(A,1)
     nB = size(B,2)
     if !(size(C,1) == size(B,1) == nA)
@@ -577,7 +577,7 @@ ldiv!(A::Union{Bidiagonal, AbstractTriangular}, b::AbstractVector) = naivesub!(A
 ldiv!(A::Transpose{<:Any,<:Bidiagonal}, b::AbstractVector) = ldiv!(copy(A), b)
 ldiv!(A::Adjoint{<:Any,<:Bidiagonal}, b::AbstractVector) = ldiv!(copy(A), b)
 function ldiv!(A::Union{Bidiagonal,AbstractTriangular}, B::AbstractMatrix)
-    @assert !has_offset_axes(A, B)
+    require_one_based_indexing(A, B)
     nA,mA = size(A)
     tmp = similar(B,size(B,1))
     n = size(B, 1)
@@ -592,7 +592,7 @@ function ldiv!(A::Union{Bidiagonal,AbstractTriangular}, B::AbstractMatrix)
     B
 end
 function ldiv!(adjA::Adjoint{<:Any,<:Union{Bidiagonal,AbstractTriangular}}, B::AbstractMatrix)
-    @assert !has_offset_axes(adjA, B)
+    require_one_based_indexing(adjA, B)
     A = adjA.parent
     nA,mA = size(A)
     tmp = similar(B,size(B,1))
@@ -608,7 +608,7 @@ function ldiv!(adjA::Adjoint{<:Any,<:Union{Bidiagonal,AbstractTriangular}}, B::A
     B
 end
 function ldiv!(transA::Transpose{<:Any,<:Union{Bidiagonal,AbstractTriangular}}, B::AbstractMatrix)
-    @assert !has_offset_axes(transA, B)
+    require_one_based_indexing(transA, B)
     A = transA.parent
     nA,mA = size(A)
     tmp = similar(B,size(B,1))
@@ -625,7 +625,7 @@ function ldiv!(transA::Transpose{<:Any,<:Union{Bidiagonal,AbstractTriangular}}, 
 end
 #Generic solver using naive substitution
 function naivesub!(A::Bidiagonal{T}, b::AbstractVector, x::AbstractVector = b) where T
-    @assert !has_offset_axes(A, b, x)
+    require_one_based_indexing(A, b, x)
     N = size(A, 2)
     if N != length(b) || N != length(x)
         throw(DimensionMismatch("second dimension of A, $N, does not match one of the lengths of x, $(length(x)), or b, $(length(b))"))

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -7,7 +7,7 @@ Interface to BLAS subroutines.
 
 import ..axpy!, ..axpby!
 import Base: copyto!
-using Base: has_offset_axes
+using Base: require_one_based_indexing
 
 export
 # Level 1
@@ -328,7 +328,7 @@ for (fname, elty) in ((:cblas_zdotu_sub,:ComplexF64),
 end
 
 function dot(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasReal
-    @assert !has_offset_axes(DX, DY)
+    require_one_based_indexing(DX, DY)
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -336,7 +336,7 @@ function dot(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T}
     GC.@preserve DX DY dot(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 function dotc(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasComplex
-    @assert !has_offset_axes(DX, DY)
+    require_one_based_indexing(DX, DY)
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -344,7 +344,7 @@ function dotc(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T
     GC.@preserve DX DY dotc(n, pointer(DX), stride(DX, 1), pointer(DY), stride(DY, 1))
 end
 function dotu(DX::Union{DenseArray{T},AbstractVector{T}}, DY::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasComplex
-    @assert !has_offset_axes(DX, DY)
+    require_one_based_indexing(DX, DY)
     n = length(DX)
     if n != length(DY)
         throw(DimensionMismatch("dot product arguments have lengths $(length(DX)) and $(length(DY))"))
@@ -525,7 +525,7 @@ for (fname, elty) in ((:daxpby_,:Float64), (:saxpby_,:Float32),
 end
 
 function axpby!(alpha::Number, x::Union{DenseArray{T},AbstractVector{T}}, beta::Number, y::Union{DenseArray{T},AbstractVector{T}}) where T<:BlasFloat
-    @assert !has_offset_axes(x, y)
+    require_one_based_indexing(x, y)
     if length(x) != length(y)
         throw(DimensionMismatch("x has length $(length(x)), but y has length $(length(y))"))
     end
@@ -564,7 +564,7 @@ for (fname, elty) in ((:dgemv_,:Float64),
              #*     .. Array Arguments ..
              #      DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function gemv!(trans::AbstractChar, alpha::($elty), A::AbstractVecOrMat{$elty}, X::AbstractVector{$elty}, beta::($elty), Y::AbstractVector{$elty})
-            @assert !has_offset_axes(A, X, Y)
+            require_one_based_indexing(A, X, Y)
             m,n = size(A,1),size(A,2)
             if trans == 'N' && (length(X) != n || length(Y) != m)
                 throw(DimensionMismatch("A has dimensions $(size(A)), X has length $(length(X)) and Y has length $(length(Y))"))
@@ -649,7 +649,7 @@ for (fname, elty) in ((:dgbmv_,:Float64),
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function gbmv!(trans::AbstractChar, m::Integer, kl::Integer, ku::Integer, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x, y)
+            require_one_based_indexing(A, x, y)
             chkstride1(A)
             ccall((@blasfunc($fname), libblas), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{BlasInt},
@@ -697,7 +697,7 @@ for (fname, elty, lib) in ((:dsymv_,:Float64,libblas),
              #     .. Array Arguments ..
              #      DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function symv!(uplo::AbstractChar, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x, y)
+            require_one_based_indexing(A, x, y)
             m, n = size(A)
             if m != n
                 throw(DimensionMismatch("matrix A is $m by $n but must be square"))
@@ -749,7 +749,7 @@ for (fname, elty) in ((:zhemv_,:ComplexF64),
                       (:chemv_,:ComplexF32))
     @eval begin
         function hemv!(uplo::AbstractChar, α::$elty, A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, β::$elty, y::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x, y)
+            require_one_based_indexing(A, x, y)
             m, n = size(A)
             if m != n
                 throw(DimensionMismatch("matrix A is $m by $n but must be square"))
@@ -794,7 +794,7 @@ for (fname, elty) in ((:dsbmv_,:Float64),
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function sbmv!(uplo::AbstractChar, k::Integer, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x, y)
+            require_one_based_indexing(A, x, y)
             chkstride1(A)
             ccall((@blasfunc($fname), libblas), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
@@ -858,7 +858,7 @@ for (fname, elty) in ((:zhbmv_,:ComplexF64),
              # *     .. Array Arguments ..
              #       DOUBLE PRECISION A(LDA,*),X(*),Y(*)
         function hbmv!(uplo::AbstractChar, k::Integer, alpha::($elty), A::AbstractMatrix{$elty}, x::AbstractVector{$elty}, beta::($elty), y::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x, y)
+            require_one_based_indexing(A, x, y)
             chkstride1(A)
             ccall((@blasfunc($fname), libblas), Cvoid,
                 (Ref{UInt8}, Ref{BlasInt}, Ref{BlasInt}, Ref{$elty},
@@ -914,7 +914,7 @@ for (fname, elty) in ((:dtrmv_,:Float64),
                 # *     .. Array Arguments ..
                 #       DOUBLE PRECISION A(LDA,*),X(*)
         function trmv!(uplo::AbstractChar, trans::AbstractChar, diag::AbstractChar, A::AbstractMatrix{$elty}, x::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x)
+            require_one_based_indexing(A, x)
             n = checksquare(A)
             if n != length(x)
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -968,7 +968,7 @@ for (fname, elty) in ((:dtrsv_,:Float64),
                 #       .. Array Arguments ..
                 #       DOUBLE PRECISION A(LDA,*),X(*)
         function trsv!(uplo::AbstractChar, trans::AbstractChar, diag::AbstractChar, A::AbstractMatrix{$elty}, x::AbstractVector{$elty})
-            @assert !has_offset_axes(A, x)
+            require_one_based_indexing(A, x)
             n = checksquare(A)
             if n != length(x)
                 throw(DimensionMismatch("size of A is $n != length(x) = $(length(x))"))
@@ -1002,7 +1002,7 @@ for (fname, elty) in ((:dger_,:Float64),
                       (:cgerc_,:ComplexF32))
     @eval begin
         function ger!(α::$elty, x::AbstractVector{$elty}, y::AbstractVector{$elty}, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, x, y)
+            require_one_based_indexing(A, x, y)
             m, n = size(A)
             if m != length(x) || n != length(y)
                 throw(DimensionMismatch("A has size ($m,$n), x has length $(length(x)), y has length $(length(y))"))
@@ -1035,7 +1035,7 @@ for (fname, elty, lib) in ((:dsyr_,:Float64,libblas),
                            (:csyr_,:ComplexF32,liblapack))
     @eval begin
         function syr!(uplo::AbstractChar, α::$elty, x::AbstractVector{$elty}, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, x)
+            require_one_based_indexing(A, x)
             n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -1065,7 +1065,7 @@ for (fname, elty, relty) in ((:zher_,:ComplexF64, :Float64),
                              (:cher_,:ComplexF32, :Float32))
     @eval begin
         function her!(uplo::AbstractChar, α::$relty, x::AbstractVector{$elty}, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, x)
+            require_one_based_indexing(A, x)
             n = checksquare(A)
             if length(x) != n
                 throw(DimensionMismatch("A has size ($n,$n), x has length $(length(x))"))
@@ -1108,7 +1108,7 @@ for (gemm, elty) in
 #           if any([stride(A,1), stride(B,1), stride(C,1)] .!= 1)
 #               error("gemm!: BLAS module requires contiguous matrix columns")
 #           end  # should this be checked on every call?
-            @assert !has_offset_axes(A, B, C)
+            require_one_based_indexing(A, B, C)
             m = size(A, transA == 'N' ? 1 : 2)
             ka = size(A, transA == 'N' ? 2 : 1)
             kb = size(B, transB == 'N' ? 1 : 2)
@@ -1168,7 +1168,7 @@ for (mfname, elty) in ((:dsymm_,:Float64),
              #     .. Array Arguments ..
              #     DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
         function symm!(side::AbstractChar, uplo::AbstractChar, alpha::($elty), A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty}, beta::($elty), C::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B, C)
+            require_one_based_indexing(A, B, C)
             m, n = size(C)
             j = checksquare(A)
             if j != (side == 'L' ? m : n)
@@ -1237,7 +1237,7 @@ for (mfname, elty) in ((:zhemm_,:ComplexF64),
              #     .. Array Arguments ..
              #     DOUBLE PRECISION A(LDA,*),B(LDB,*),C(LDC,*)
         function hemm!(side::AbstractChar, uplo::AbstractChar, alpha::($elty), A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty}, beta::($elty), C::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B, C)
+            require_one_based_indexing(A, B, C)
             m, n = size(C)
             j = checksquare(A)
             if j != (side == 'L' ? m : n)
@@ -1303,7 +1303,7 @@ for (fname, elty) in ((:dsyrk_,:Float64),
        function syrk!(uplo::AbstractChar, trans::AbstractChar,
                       alpha::($elty), A::AbstractVecOrMat{$elty},
                       beta::($elty), C::AbstractMatrix{$elty})
-           @assert !has_offset_axes(A, C)
+           require_one_based_indexing(A, C)
            n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
@@ -1360,7 +1360,7 @@ for (fname, elty, relty) in ((:zherk_, :ComplexF64, :Float64),
        #       COMPLEX A(LDA,*),C(LDC,*)
        function herk!(uplo::AbstractChar, trans::AbstractChar, α::$relty, A::AbstractVecOrMat{$elty},
                       β::$relty, C::AbstractMatrix{$elty})
-           @assert !has_offset_axes(A, C)
+           require_one_based_indexing(A, C)
            n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n
@@ -1404,7 +1404,7 @@ for (fname, elty) in ((:dsyr2k_,:Float64),
         function syr2k!(uplo::AbstractChar, trans::AbstractChar,
                         alpha::($elty), A::AbstractVecOrMat{$elty}, B::AbstractVecOrMat{$elty},
                         beta::($elty), C::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B, C)
+            require_one_based_indexing(A, B, C)
             n = checksquare(C)
             nn = size(A, trans == 'N' ? 1 : 2)
             if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
@@ -1445,7 +1445,7 @@ for (fname, elty1, elty2) in ((:zher2k_,:ComplexF64,:Float64), (:cher2k_,:Comple
        function her2k!(uplo::AbstractChar, trans::AbstractChar, alpha::($elty1),
                        A::AbstractVecOrMat{$elty1}, B::AbstractVecOrMat{$elty1},
                        beta::($elty2), C::AbstractMatrix{$elty1})
-           @assert !has_offset_axes(A, B, C)
+           require_one_based_indexing(A, B, C)
            n = checksquare(C)
            nn = size(A, trans == 'N' ? 1 : 2)
            if nn != n throw(DimensionMismatch("C has size ($n,$n), corresponding dimension of A is $nn")) end
@@ -1533,7 +1533,7 @@ for (mmname, smname, elty) in
         #       DOUBLE PRECISION A(LDA,*),B(LDB,*)
         function trmm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar, alpha::Number,
                        A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             m, n = size(B)
             nA = checksquare(A)
             if nA != (side == 'L' ? m : n)
@@ -1561,7 +1561,7 @@ for (mmname, smname, elty) in
         #       DOUBLE PRECISION A(LDA,*),B(LDB,*)
         function trsm!(side::AbstractChar, uplo::AbstractChar, transa::AbstractChar, diag::AbstractChar,
                        alpha::$elty, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             m, n = size(B)
             k = checksquare(A)
             if k != (side == 'L' ? m : n)

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -13,7 +13,7 @@ struct BunchKaufman{T,S<:AbstractMatrix} <: Factorization{T}
     info::BlasInt
 
     function BunchKaufman{T,S}(LD, ipiv, uplo, symmetric, rook, info) where {T,S<:AbstractMatrix}
-        @assert !has_offset_axes(LD)
+        require_one_based_indexing(LD)
         new(LD, ipiv, uplo, symmetric, rook, info)
     end
 end
@@ -126,7 +126,7 @@ issymmetric(B::BunchKaufman) = B.symmetric
 ishermitian(B::BunchKaufman) = !B.symmetric
 
 function _ipiv2perm_bk(v::AbstractVector{T}, maxi::Integer, uplo::AbstractChar) where T
-    @assert !has_offset_axes(v)
+    require_one_based_indexing(v)
     p = T[1:maxi;]
     uploL = uplo == 'L'
     i = uploL ? 1 : maxi

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -34,7 +34,7 @@ struct Cholesky{T,S<:AbstractMatrix} <: Factorization{T}
     info::BlasInt
 
     function Cholesky{T,S}(factors, uplo, info) where {T,S<:AbstractMatrix}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new(factors, uplo, info)
     end
 end
@@ -52,7 +52,7 @@ struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
     info::BlasInt
 
     function CholeskyPivoted{T,S}(factors, uplo, piv, rank, tol, info) where {T,S<:AbstractMatrix}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new(factors, uplo, piv, rank, tol, info)
     end
 end
@@ -85,7 +85,7 @@ end
 
 ## Non BLAS/LAPACK element types (generic)
 function _chol!(A::AbstractMatrix, ::Type{UpperTriangular})
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     n = checksquare(A)
     @inbounds begin
         for k = 1:n
@@ -109,7 +109,7 @@ function _chol!(A::AbstractMatrix, ::Type{UpperTriangular})
     return UpperTriangular(A), convert(BlasInt, 0)
 end
 function _chol!(A::AbstractMatrix, ::Type{LowerTriangular})
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     n = checksquare(A)
     @inbounds begin
         for k = 1:n

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -147,7 +147,7 @@ julia> triu!(M, 1)
 ```
 """
 function triu!(M::AbstractMatrix, k::Integer)
-    @assert !has_offset_axes(M)
+    require_one_based_indexing(M)
     m, n = size(M)
     for j in 1:min(n, m + k)
         for i in max(1, j - k + 1):m
@@ -185,7 +185,7 @@ julia> tril!(M, 2)
 ```
 """
 function tril!(M::AbstractMatrix, k::Integer)
-    @assert !has_offset_axes(M)
+    require_one_based_indexing(M)
     m, n = size(M)
     for j in max(1, k + 1):n
         @inbounds for i in 1:min(j - k - 1, m)
@@ -202,7 +202,7 @@ tril(M::Matrix, k::Integer) = tril!(copy(M), k)
 Fill the band between diagonals `l` and `u` with the value `x`.
 """
 function fillband!(A::AbstractMatrix{T}, x, l, u) where T
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A)
     xT = convert(T, x)
     for j in 1:n
@@ -234,7 +234,7 @@ julia> diagind(A,-1)
 ```
 """
 function diagind(A::AbstractMatrix, k::Integer=0)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     diagind(size(A,1), size(A,2), k)
 end
 
@@ -343,7 +343,7 @@ julia> kron(A, B)
 ```
 """
 function kron(a::AbstractMatrix{T}, b::AbstractMatrix{S}) where {T,S}
-    @assert !has_offset_axes(a, b)
+    require_one_based_indexing(a, b)
     R = Matrix{promote_op(*,T,S)}(undef, size(a,1)*size(b,1), size(a,2)*size(b,2))
     m = 1
     for j = 1:size(a,2), l = 1:size(b,2), i = 1:size(a,1)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -6,7 +6,7 @@ struct Diagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     diag::V
 
     function Diagonal{T,V}(diag) where {T,V<:AbstractVector{T}}
-        @assert !has_offset_axes(diag)
+        require_one_based_indexing(diag)
         new{T,V}(diag)
     end
 end
@@ -171,13 +171,13 @@ end
     lmul!(D, copyto!(similar(A, promote_op(*, eltype(A), eltype(D.diag)), size(A)), A))
 
 function rmul!(A::AbstractMatrix, D::Diagonal)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     A .= A .* transpose(D.diag)
     return A
 end
 
 function lmul!(D::Diagonal, B::AbstractMatrix)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     B .= D.diag .* B
     return B
 end
@@ -319,7 +319,7 @@ function ldiv!(D::Diagonal{T}, v::AbstractVector{T}) where {T}
     v
 end
 function ldiv!(D::Diagonal{T}, V::AbstractMatrix{T}) where {T}
-    @assert !has_offset_axes(V)
+    require_one_based_indexing(V)
     if size(V,1) != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $(size(V,1)) rows"))
     end
@@ -347,7 +347,7 @@ function ldiv!(D::Diagonal, A::Union{LowerTriangular,UpperTriangular})
 end
 
 function rdiv!(A::AbstractMatrix{T}, D::Diagonal{T}) where {T}
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     dd = D.diag
     m, n = size(A)
     if (k = length(dd)) ≠ n
@@ -396,7 +396,7 @@ function kron(A::Diagonal{T1}, B::Diagonal{T2}) where {T1<:Number, T2<:Number}
 end
 
 function kron(A::Diagonal{T}, B::AbstractMatrix{S}) where {T<:Number, S<:Number}
-    @assert ! Base.has_offset_axes(B)
+    Base.require_one_based_indexing(B)
     (mA, nA) = size(A); (mB, nB) = size(B)
     R = zeros(Base.promote_op(*, T, S), mA * mB, nA * nB)
     m = 1
@@ -415,7 +415,7 @@ function kron(A::Diagonal{T}, B::AbstractMatrix{S}) where {T<:Number, S<:Number}
 end
 
 function kron(A::AbstractMatrix{T}, B::Diagonal{S}) where {T<:Number, S<:Number}
-    @assert ! has_offset_axes(A)
+    require_one_based_indexing(A)
     (mA, nA) = size(A); (mB, nB) = size(B)
     R = zeros(promote_op(*, T, S), mA * mB, nA * nB)
     m = 1

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -73,21 +73,21 @@ end
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\)(F::Factorization{T}, B::VecOrMat{Complex{T}}) where T<:BlasReal
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
     x = ldiv!(F, c2r)
     return reshape(copy(reinterpret(Complex{T}, copy(transpose(reshape(x, div(length(x), 2), 2))))), _ret_size(F, B))
 end
 
 function \(F::Factorization, B::AbstractVecOrMat)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
     BB = similar(B, TFB, size(B))
     copyto!(BB, B)
     ldiv!(F, BB)
 end
 function \(adjF::Adjoint{<:Any,<:Factorization}, B::AbstractVecOrMat)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     F = adjF.parent
     TFB = typeof(oneunit(eltype(B)) / oneunit(eltype(F)))
     BB = similar(B, TFB, size(B))
@@ -97,7 +97,7 @@ end
 
 # support the same 3-arg idiom as in our other in-place A_*_B functions:
 function ldiv!(Y::AbstractVecOrMat, A::Factorization, B::AbstractVecOrMat)
-    @assert !has_offset_axes(Y, B)
+    require_one_based_indexing(Y, B)
     m, n = size(A, 1), size(A, 2)
     if m > n
         Bc = copy(B)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -492,7 +492,7 @@ norm(::Missing, p::Real=2) = missing
 
 # special cases of opnorm
 function opnorm1(A::AbstractMatrix{T}) where T
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A)
     Tnorm = typeof(float(real(zero(T))))
     Tsum = promote_type(Float64, Tnorm)
@@ -510,7 +510,7 @@ function opnorm1(A::AbstractMatrix{T}) where T
 end
 
 function opnorm2(A::AbstractMatrix{T}) where T
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m,n = size(A)
     if m == 1 || n == 1 return norm2(A) end
     Tnorm = typeof(float(real(zero(T))))
@@ -518,7 +518,7 @@ function opnorm2(A::AbstractMatrix{T}) where T
 end
 
 function opnormInf(A::AbstractMatrix{T}) where T
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m,n = size(A)
     Tnorm = typeof(float(real(zero(T))))
     Tsum = promote_type(Float64, Tnorm)
@@ -889,7 +889,7 @@ true
 ```
 """
 function (\)(A::AbstractMatrix, B::AbstractVecOrMat)
-    @assert !has_offset_axes(A, B)
+    require_one_based_indexing(A, B)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -1052,7 +1052,7 @@ false
 ```
 """
 function istriu(A::AbstractMatrix, k::Integer = 0)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A)
     for j in 1:min(n, m + k - 1)
         for i in max(1, j - k + 1):m
@@ -1094,7 +1094,7 @@ false
 ```
 """
 function istril(A::AbstractMatrix, k::Integer = 0)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A)
     for j in max(1, k + 2):n
         for i in 1:min(j - k - 1, m)
@@ -1207,7 +1207,7 @@ end
 # Elementary reflection similar to LAPACK. The reflector is not Hermitian but
 # ensures that tridiagonalization of Hermitian matrices become real. See lawn72
 @inline function reflector!(x::AbstractVector)
-    @assert !has_offset_axes(x)
+    require_one_based_indexing(x)
     n = length(x)
     @inbounds begin
         ξ1 = x[1]
@@ -1231,7 +1231,7 @@ end
 
 # apply reflector from left
 @inline function reflectorApply!(x::AbstractVector, τ::Number, A::StridedMatrix)
-    @assert !has_offset_axes(x)
+    require_one_based_indexing(x)
     m, n = size(A)
     if length(x) != m
         throw(DimensionMismatch("reflector has length $(length(x)), which must match the first dimension of matrix A, $m"))

--- a/stdlib/LinearAlgebra/src/givens.jl
+++ b/stdlib/LinearAlgebra/src/givens.jl
@@ -335,7 +335,7 @@ function getindex(G::Givens, i::Integer, j::Integer)
 end
 
 @inline function lmul!(G::Givens, A::AbstractVecOrMat)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A, 1), size(A, 2)
     if G.i2 > m
         throw(DimensionMismatch("column indices for rotation are outside the matrix"))
@@ -348,7 +348,7 @@ end
     return A
 end
 @inline function rmul!(A::AbstractMatrix, G::Givens)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A, 1), size(A, 2)
     if G.i2 > n
         throw(DimensionMismatch("column indices for rotation are outside the matrix"))

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -5,7 +5,7 @@ struct Hessenberg{T,S<:AbstractMatrix{T}} <: Factorization{T}
     τ::Vector{T}
 
     function Hessenberg{T,S}(factors, τ) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(factors, τ)
+        require_one_based_indexing(factors, τ)
         new{T,S}(factors, τ)
     end
 end
@@ -71,7 +71,7 @@ struct HessenbergQ{T,S<:AbstractMatrix} <: AbstractQ{T}
     factors::S
     τ::Vector{T}
     function HessenbergQ{T,S}(factors, τ) where {T,S<:AbstractMatrix}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new(factors, τ)
     end
 end

--- a/stdlib/LinearAlgebra/src/lapack.jl
+++ b/stdlib/LinearAlgebra/src/lapack.jl
@@ -14,7 +14,7 @@ import ..LinearAlgebra: BlasFloat, BlasInt, LAPACKException,
 
 using ..LinearAlgebra: triu, tril, dot
 
-using Base: iszero, has_offset_axes
+using Base: iszero, require_one_based_indexing
 
 #Generic LAPACK error handlers
 """
@@ -120,7 +120,7 @@ for (gbtrf, gbtrs, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   AB( LDAB, * )
         function gbtrf!(kl::Integer, ku::Integer, m::Integer, AB::AbstractMatrix{$elty})
-            @assert !has_offset_axes(AB)
+            require_one_based_indexing(AB)
             chkstride1(AB)
             n    = size(AB, 2)
             mnmn = min(m, n)
@@ -144,7 +144,7 @@ for (gbtrf, gbtrs, elty) in
         function gbtrs!(trans::AbstractChar, kl::Integer, ku::Integer, m::Integer,
                         AB::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt},
                         B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(AB, B)
+            require_one_based_indexing(AB, B)
             chkstride1(AB, B, ipiv)
             chktrans(trans)
             info = Ref{BlasInt}()
@@ -223,7 +223,7 @@ for (gebal, gebak, elty, relty) in
         function gebak!(job::AbstractChar, side::AbstractChar,
                         ilo::BlasInt, ihi::BlasInt, scale::AbstractVector{$relty},
                         V::AbstractMatrix{$elty})
-            @assert !has_offset_axes(scale, V)
+            require_one_based_indexing(scale, V)
             chkstride1(scale, V)
             chkside(side)
             chkfinite(V) # balancing routines don't support NaNs and Infs
@@ -282,7 +282,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #  DOUBLE PRECISION   A( LDA, * ), D( * ), E( * ), TAUP( * ),
         #           TAUQ( * ), WORK( * )
         function gebrd!(A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             m, n  = size(A)
             k     = min(m, n)
@@ -316,7 +316,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function gelqf!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m     = BlasInt(size(A, 1))
             n     = BlasInt(size(A, 2))
@@ -347,7 +347,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function geqlf!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m     = BlasInt(size(A, 1))
             n     = BlasInt(size(A, 2))
@@ -379,7 +379,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #       INTEGER            JPVT( * )
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function geqp3!(A::AbstractMatrix{$elty}, jpvt::AbstractVector{BlasInt}, tau::AbstractVector{$elty})
-            @assert !has_offset_axes(A, jpvt, tau)
+            require_one_based_indexing(A, jpvt, tau)
             chkstride1(A,jpvt,tau)
             m,n = size(A)
             if length(tau) != min(m,n)
@@ -427,7 +427,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         end
 
         function geqrt!(A::AbstractMatrix{$elty}, T::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, T)
+            require_one_based_indexing(A, T)
             chkstride1(A)
             m, n = size(A)
             minmn = min(m, n)
@@ -452,7 +452,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         end
 
         function geqrt3!(A::AbstractMatrix{$elty}, T::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, T)
+            require_one_based_indexing(A, T)
             chkstride1(A)
             chkstride1(T)
             m, n = size(A)
@@ -482,7 +482,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function geqrf!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m, n  = size(A)
             if length(tau) != min(m,n)
@@ -511,7 +511,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function gerqf!(A::AbstractMatrix{$elty},tau::AbstractVector{$elty})
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m, n  = size(A)
             if length(tau) != min(m,n)
@@ -541,7 +541,7 @@ for (gebrd, gelqf, geqlf, geqrf, geqp3, geqrt, geqrt3, gerqf, getrf, elty, relty
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * )
         function getrf!(A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
             lda  = max(1,stride(A, 2))
@@ -768,7 +768,7 @@ for (tzrzf, ormrz, elty) in
          #       .. Array Arguments ..
          #       COMPLEX*16         A( LDA, * ), TAU( * ), WORK( * )
         function tzrzf!(A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             m, n = size(A)
             if n < m
@@ -805,7 +805,7 @@ for (tzrzf, ormrz, elty) in
         #       COMPLEX*16         A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormrz!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, tau, C)
+            require_one_based_indexing(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, tau, C)
@@ -871,7 +871,7 @@ for (gels, gesv, getrs, getri, elty) in
         #       CHARACTER          TRANS
         #       INTEGER            INFO, LDA, LDB, LWORK, M, N, NRHS
         function gels!(trans::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chktrans(trans)
             chkstride1(A, B)
             btrn  = trans == 'T'
@@ -916,7 +916,7 @@ for (gels, gesv, getrs, getri, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function gesv!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             n = checksquare(A)
             if size(B,1) != n
@@ -940,7 +940,7 @@ for (gels, gesv, getrs, getri, elty) in
         #      INTEGER            IPIV( * )
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function getrs!(trans::AbstractChar, A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chktrans(trans)
             chkstride1(A, B, ipiv)
             n = checksquare(A)
@@ -964,7 +964,7 @@ for (gels, gesv, getrs, getri, elty) in
         #      INTEGER            IPIV( * )
         #      DOUBLE PRECISION   A( LDA, * ), WORK( * )
         function getri!(A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt})
-            @assert !has_offset_axes(A, ipiv)
+            require_one_based_indexing(A, ipiv)
             chkstride1(A, ipiv)
             n = checksquare(A)
             if n != length(ipiv)
@@ -1055,7 +1055,7 @@ for (gesvx, elty) in
         function gesvx!(fact::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         AF::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt}, equed::AbstractChar,
                         R::AbstractVector{$elty}, C::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, AF, ipiv, R, C, B)
+            require_one_based_indexing(A, AF, ipiv, R, C, B)
             chktrans(trans)
             chkstride1(ipiv, R, C, B)
             n    = checksquare(A)
@@ -1125,7 +1125,7 @@ for (gesvx, elty, relty) in
         function gesvx!(fact::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         AF::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt}, equed::AbstractChar,
                         R::AbstractVector{$relty}, C::AbstractVector{$relty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, AF, ipiv, R, C, B)
+            require_one_based_indexing(A, AF, ipiv, R, C, B)
             chktrans(trans)
             chkstride1(A, AF, ipiv, R, C, B)
             n   = checksquare(A)
@@ -1223,7 +1223,7 @@ for (gelsd, gelsy, elty) in
         #       INTEGER            IWORK( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), S( * ), WORK( * )
         function gelsd!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=-one($elty))
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             m, n  = size(A)
             if size(B, 1) != m
@@ -1266,7 +1266,7 @@ for (gelsd, gelsy, elty) in
         #       INTEGER            JPVT( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function gelsy!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=eps($elty))
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A)
             m = size(A, 1)
             n = size(A, 2)
@@ -1318,7 +1318,7 @@ for (gelsd, gelsy, elty, relty) in
         #       DOUBLE PRECISION   RWORK( * ), S( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function gelsd!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=-one($relty))
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             m, n  = size(A)
             if size(B, 1) != m
@@ -1364,7 +1364,7 @@ for (gelsd, gelsy, elty, relty) in
         #       DOUBLE PRECISION   RWORK( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function gelsy!(A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, rcond::Real=eps($relty))
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             m, n = size(A)
             nrhs = size(B, 2)
@@ -1438,7 +1438,7 @@ for (gglse, elty) in ((:dgglse_, :Float64),
         #      $                   WORK( * ), X( * )
         function gglse!(A::AbstractMatrix{$elty}, c::AbstractVector{$elty},
                         B::AbstractMatrix{$elty}, d::AbstractVector{$elty})
-            @assert !has_offset_axes(A, c, B, d)
+            require_one_based_indexing(A, c, B, d)
             chkstride1(A, c, B, d)
             m, n = size(A)
             p = size(B, 1)
@@ -1555,7 +1555,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #      DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
         #                        VT( LDVT, * ), WORK( * )
         function gesdd!(job::AbstractChar, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             m, n   = size(A)
             minmn  = min(m, n)
@@ -1636,7 +1636,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #       DOUBLE PRECISION   A( LDA, * ), S( * ), U( LDU, * ),
         #      $                   VT( LDVT, * ), WORK( * )
         function gesvd!(jobu::AbstractChar, jobvt::AbstractChar, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             m, n   = size(A)
             minmn  = min(m, n)
@@ -1705,7 +1705,7 @@ for (geev, gesvd, gesdd, ggsvd, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), Q( LDQ, * ),
         #      $                   U( LDU, * ), V( LDV, * ), WORK( * )
         function ggsvd!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             m, n = size(A)
             if size(B, 2) != n
@@ -1828,7 +1828,7 @@ for (f, elty) in ((:dggsvd3_, :Float64),
                   (:sggsvd3_, :Float32))
     @eval begin
         function ggsvd3!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             m, n = size(A)
             if size(B, 2) != n
@@ -1885,7 +1885,7 @@ for (f, elty, relty) in ((:zggsvd3_, :ComplexF64, :Float64),
                          (:cggsvd3_, :ComplexF32, :Float32))
     @eval begin
         function ggsvd3!(jobu::AbstractChar, jobv::AbstractChar, jobq::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             m, n = size(A)
             if size(B, 2) != n
@@ -2051,7 +2051,7 @@ for (geevx, ggev, elty) in
         #      $                   B( LDB, * ), BETA( * ), VL( LDVL, * ),
         #      $                   VR( LDVR, * ), WORK( * )
         function ggev!(jobvl::AbstractChar, jobvr::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n, m = checksquare(A,B)
             if n != m
@@ -2198,7 +2198,7 @@ for (geevx, ggev, elty, relty) in
         #      $                   BETA( * ), VL( LDVL, * ), VR( LDVR, * ),
         #      $                   WORK( * )
         function ggev!(jobvl::AbstractChar, jobvr::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             n, m = checksquare(A, B)
             if n != m
@@ -2297,7 +2297,7 @@ for (laic1, elty) in
         #  DOUBLE PRECISION   W( J ), X( J )
         function laic1!(job::Integer, x::AbstractVector{$elty},
                         sest::$elty, w::AbstractVector{$elty}, gamma::$elty)
-            @assert !has_offset_axes(x, w)
+            require_one_based_indexing(x, w)
             j = length(x)
             if j != length(w)
                 throw(DimensionMismatch("vectors must have same length, but length of x is $j and length of w is $(length(w))"))
@@ -2331,7 +2331,7 @@ for (laic1, elty, relty) in
        #  COMPLEX*16         W( J ), X( J )
         function laic1!(job::Integer, x::AbstractVector{$elty},
                         sest::$relty, w::AbstractVector{$elty}, gamma::$elty)
-            @assert !has_offset_axes(x, w)
+            require_one_based_indexing(x, w)
             j = length(x)
             if j != length(w)
                 throw(DimensionMismatch("vectors must have same length, but length of x is $j and length of w is $(length(w))"))
@@ -2365,7 +2365,7 @@ for (gtsv, gttrf, gttrs, elty) in
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), DL( * ), DU( * )
         function gtsv!(dl::AbstractVector{$elty}, d::AbstractVector{$elty}, du::AbstractVector{$elty},
                        B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(dl, d, du, B)
+            require_one_based_indexing(dl, d, du, B)
             chkstride1(B, dl, d, du)
             n = length(d)
             if !(n >= length(dl) >= n - 1)
@@ -2396,7 +2396,7 @@ for (gtsv, gttrf, gttrs, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   D( * ), DL( * ), DU( * ), DU2( * )
         function gttrf!(dl::AbstractVector{$elty}, d::AbstractVector{$elty}, du::AbstractVector{$elty})
-            @assert !has_offset_axes(dl, d, du)
+            require_one_based_indexing(dl, d, du)
             chkstride1(dl,d,du)
             n    = length(d)
             if length(dl) != n - 1
@@ -2426,7 +2426,7 @@ for (gtsv, gttrf, gttrs, elty) in
         function gttrs!(trans::AbstractChar, dl::AbstractVector{$elty}, d::AbstractVector{$elty},
                         du::AbstractVector{$elty}, du2::AbstractVector{$elty}, ipiv::AbstractVector{BlasInt},
                         B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(dl, d, du, du2, ipiv, B)
+            require_one_based_indexing(dl, d, du, du2, ipiv, B)
             chktrans(trans)
             chkstride1(B, ipiv, dl, d, du, du2)
             n = length(d)
@@ -2496,7 +2496,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orglq!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             n = size(A, 2)
             m = min(n, size(A, 1))
@@ -2530,7 +2530,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgqr!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m = size(A, 1)
             n = min(m, size(A, 2))
@@ -2566,7 +2566,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgql!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m = size(A, 1)
             n = min(m, size(A, 2))
@@ -2602,7 +2602,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orgrq!(A::AbstractMatrix{$elty}, tau::AbstractVector{$elty}, k::Integer = length(tau))
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A,tau)
             m, n = size(A)
             if n < m
@@ -2639,7 +2639,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormlq!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, tau, C)
+            require_one_based_indexing(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2686,7 +2686,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormqr!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, tau, C)
+            require_one_based_indexing(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2736,7 +2736,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormql!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, tau, C)
+            require_one_based_indexing(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2786,7 +2786,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         #      DOUBLE PRECISION   A( LDA, * ), C( LDC, * ), TAU( * ), WORK( * )
         function ormrq!(side::AbstractChar, trans::AbstractChar, A::AbstractMatrix{$elty},
                         tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, tau, C)
+            require_one_based_indexing(A, tau, C)
             chktrans(trans)
             chkside(side)
             chkstride1(A, C, tau)
@@ -2825,7 +2825,7 @@ for (orglq, orgqr, orgql, orgrq, ormlq, ormqr, ormql, ormrq, gemqrt, elty) in
         end
 
         function gemqrt!(side::AbstractChar, trans::AbstractChar, V::AbstractMatrix{$elty}, T::AbstractMatrix{$elty}, C::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(V, T, C)
+            require_one_based_indexing(V, T, C)
             chktrans(trans)
             chkside(side)
             chkstride1(V, T, C)
@@ -2976,7 +2976,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #     .. Array Arguments ..
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function posv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -3000,7 +3000,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * )
         function potrf!(uplo::AbstractChar, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             checksquare(A)
             chkuplo(uplo)
@@ -3026,7 +3026,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * )
         function potri!(uplo::AbstractChar, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             chkuplo(uplo)
             info = Ref{BlasInt}()
@@ -3045,7 +3045,7 @@ for (posv, potrf, potri, potrs, pstrf, elty, rtyp) in
         #     .. Array Arguments ..
         #      DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function potrs!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A, B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -3163,7 +3163,7 @@ for (ptsv, pttrf, elty, relty) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), E( * )
         function ptsv!(D::AbstractVector{$relty}, E::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(D, E, B)
+            require_one_based_indexing(D, E, B)
             chkstride1(B, D, E)
             n = length(D)
             if length(E) != n - 1
@@ -3187,7 +3187,7 @@ for (ptsv, pttrf, elty, relty) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   D( * ), E( * )
         function pttrf!(D::AbstractVector{$relty}, E::AbstractVector{$elty})
-            @assert !has_offset_axes(D, E)
+            require_one_based_indexing(D, E)
             chkstride1(D, E)
             n = length(D)
             if length(E) != n - 1
@@ -3231,7 +3231,7 @@ for (pttrs, elty, relty) in
         #       .. Array Arguments ..
         #       DOUBLE PRECISION   B( LDB, * ), D( * ), E( * )
         function pttrs!(D::AbstractVector{$relty}, E::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(D, E, B)
+            require_one_based_indexing(D, E, B)
             chkstride1(B, D, E)
             n = length(D)
             if length(E) != n - 1
@@ -3264,7 +3264,7 @@ for (pttrs, elty, relty) in
         #       DOUBLE PRECISION   D( * )
         #       COMPLEX*16         B( LDB, * ), E( * )
         function pttrs!(uplo::AbstractChar, D::AbstractVector{$relty}, E::AbstractVector{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(D, E, B)
+            require_one_based_indexing(D, E, B)
             chkstride1(B, D, E)
             chkuplo(uplo)
             n = length(D)
@@ -3330,7 +3330,7 @@ for (trtri, trtrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function trtrs!(uplo::AbstractChar, trans::AbstractChar, diag::AbstractChar,
                         A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chktrans(trans)
             chkdiag(diag)
             chkstride1(A)
@@ -3418,7 +3418,7 @@ for (trcon, trevc, trrfs, elty) in
         function trevc!(side::AbstractChar, howmny::AbstractChar, select::AbstractVector{BlasInt}, T::AbstractMatrix{$elty},
                         VL::AbstractMatrix{$elty} = similar(T),
                         VR::AbstractMatrix{$elty} = similar(T))
-            @assert !has_offset_axes(select, T, VL, VR)
+            require_one_based_indexing(select, T, VL, VR)
             # Extract
             if side ∉ ['L','R','B']
                 throw(ArgumentError("side argument must be 'L' (left eigenvectors), 'R' (right eigenvectors), or 'B' (both), got $side"))
@@ -3478,7 +3478,7 @@ for (trcon, trevc, trrfs, elty) in
                 A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, X::AbstractVecOrMat{$elty},
                 Ferr::AbstractVector{$elty} = similar(B, $elty, size(B,2)),
                 Berr::AbstractVector{$elty} = similar(B, $elty, size(B,2)))
-            @assert !has_offset_axes(A, B, X, Ferr, Berr)
+            require_one_based_indexing(A, B, X, Ferr, Berr)
             chkstride1(A, B, X, Ferr, Berr)
             chktrans(trans)
             chkuplo(uplo)
@@ -3550,7 +3550,7 @@ for (trcon, trevc, trrfs, elty, relty) in
         function trevc!(side::AbstractChar, howmny::AbstractChar, select::AbstractVector{BlasInt}, T::AbstractMatrix{$elty},
                         VL::AbstractMatrix{$elty} = similar(T),
                         VR::AbstractMatrix{$elty} = similar(T))
-            @assert !has_offset_axes(select, T, VL, VR)
+            require_one_based_indexing(select, T, VL, VR)
             # Extract
             n, mm = checksquare(T), size(VL, 2)
             ldt, ldvl, ldvr = stride(T, 2), stride(VL, 2), stride(VR, 2)
@@ -3610,7 +3610,7 @@ for (trcon, trevc, trrfs, elty, relty) in
                         A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty}, X::AbstractVecOrMat{$elty},
                         Ferr::AbstractVector{$relty} = similar(B, $relty, size(B,2)),
                         Berr::AbstractVector{$relty} = similar(B, $relty, size(B,2)))
-            @assert !has_offset_axes(A, B, X, Ferr, Berr)
+            require_one_based_indexing(A, B, X, Ferr, Berr)
             chkstride1(A, B, X, Ferr, Berr)
             chktrans(trans)
             chkuplo(uplo)
@@ -3685,7 +3685,7 @@ for (stev, stebz, stegr, stein, elty) in
      )
     @eval begin
         function stev!(job::AbstractChar, dv::AbstractVector{$elty}, ev::AbstractVector{$elty})
-            @assert !has_offset_axes(dv, ev)
+            require_one_based_indexing(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
@@ -3707,7 +3707,7 @@ for (stev, stebz, stegr, stein, elty) in
         #*  in the half-open interval (VL, VU], or the IL-th through IU-th
         #*  eigenvalues.
         function stebz!(range::AbstractChar, order::AbstractChar, vl::$elty, vu::$elty, il::Integer, iu::Integer, abstol::Real, dv::AbstractVector{$elty}, ev::AbstractVector{$elty})
-            @assert !has_offset_axes(dv, ev)
+            require_one_based_indexing(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
@@ -3738,7 +3738,7 @@ for (stev, stebz, stegr, stein, elty) in
         end
 
         function stegr!(jobz::AbstractChar, range::AbstractChar, dv::AbstractVector{$elty}, ev::AbstractVector{$elty}, vl::Real, vu::Real, il::Integer, iu::Integer)
-            @assert !has_offset_axes(dv, ev)
+            require_one_based_indexing(dv, ev)
             chkstride1(dv, ev)
             n = length(dv)
             if length(ev) != n - 1
@@ -3780,7 +3780,7 @@ for (stev, stebz, stegr, stein, elty) in
         end
 
         function stein!(dv::AbstractVector{$elty}, ev_in::AbstractVector{$elty}, w_in::AbstractVector{$elty}, iblock_in::AbstractVector{BlasInt}, isplit_in::AbstractVector{BlasInt})
-            @assert !has_offset_axes(dv, ev_in, w_in, iblock_in, isplit_in)
+            require_one_based_indexing(dv, ev_in, w_in, iblock_in, isplit_in)
             chkstride1(dv, ev_in, w_in, iblock_in, isplit_in)
             n = length(dv)
             if length(ev_in) != n - 1
@@ -3920,7 +3920,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4040,7 +4040,7 @@ for (syconv, sysv, sytrf, sytri, sytrs, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function sytrs!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4072,7 +4072,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
         #       INTEGER            IPIV( * )
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4163,7 +4163,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
         #       DOUBLE PRECISION   A( LDA, * ), B( LDB, * )
         function sytrs_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4191,7 +4191,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty) in
         function syconvf_rook!(uplo::AbstractChar, way::AbstractChar,
                                 A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt},
                                 e::AbstractVector{$elty} = Vector{$elty}(undef, length(ipiv)))
-            @assert !has_offset_axes(A, ipiv, e)
+            require_one_based_indexing(A, ipiv, e)
             # extract
             n = checksquare(A)
             lda = max(1, stride(A, 2))
@@ -4261,7 +4261,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function hesv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4379,7 +4379,7 @@ for (syconv, hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function hetrs!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             if n != size(B,1)
@@ -4409,7 +4409,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function hesv_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4497,7 +4497,7 @@ for (hesv, hetrf, hetri, hetrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function hetrs_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                              ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             if n != size(B,1)
@@ -4528,7 +4528,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4649,7 +4649,7 @@ for (sysv, sytrf, sytri, sytrs, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function sytrs!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                        ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4681,7 +4681,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
         #       INTEGER            IPIV( * )
         #       COMPLEX*16         A( LDA, * ), B( LDB, * ), WORK( * )
         function sysv_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             chkstride1(A,B)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4773,7 +4773,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
         #       COMPLEX*16         A( LDA, * ), B( LDB, * )
         function sytrs_rook!(uplo::AbstractChar, A::AbstractMatrix{$elty},
                              ipiv::AbstractVector{BlasInt}, B::AbstractVecOrMat{$elty})
-            @assert !has_offset_axes(A, ipiv, B)
+            require_one_based_indexing(A, ipiv, B)
             chkstride1(A,B,ipiv)
             n = checksquare(A)
             chkuplo(uplo)
@@ -4801,7 +4801,7 @@ for (sysv, sytrf, sytri, sytrs, syconvf, elty, relty) in
         function syconvf_rook!(uplo::AbstractChar, way::AbstractChar,
                                 A::AbstractMatrix{$elty}, ipiv::AbstractVector{BlasInt},
                                 e::AbstractVector{$elty} = Vector{$elty}(undef, length(ipiv)))
-            @assert !has_offset_axes(A, ipiv, e)
+            require_one_based_indexing(A, ipiv, e)
             chkstride1(A, ipiv, e)
 
             # extract
@@ -5282,7 +5282,7 @@ for (bdsqr, relty, elty) in
     @eval begin
         function bdsqr!(uplo::AbstractChar, d::AbstractVector{$relty}, e_::AbstractVector{$relty},
                         Vt::AbstractMatrix{$elty}, U::AbstractMatrix{$elty}, C::AbstractMatrix{$elty})
-            @assert !has_offset_axes(d, e_, Vt, U, C)
+            require_one_based_indexing(d, e_, Vt, U, C)
             chkstride1(d, e_, Vt, U, C)
             # Extract number
             n = length(d)
@@ -5352,7 +5352,7 @@ for (bdsdc, elty) in
         #      DOUBLE PRECISION   D( * ), E( * ), Q( * ), U( LDU, * ),
         #     $                   VT( LDVT, * ), WORK( * )
         function bdsdc!(uplo::AbstractChar, compq::AbstractChar, d::AbstractVector{$elty}, e_::AbstractVector{$elty})
-            @assert !has_offset_axes(d, e_)
+            require_one_based_indexing(d, e_)
             chkstride1(d, e_)
             n, ldiq, ldq, ldu, ldvt = length(d), 1, 1, 1, 1
             chkuplo(uplo)
@@ -5547,7 +5547,7 @@ for (orghr, elty) in
         # *     .. Array Arguments ..
         #       DOUBLE PRECISION   A( LDA, * ), TAU( * ), WORK( * )
         function orghr!(ilo::Integer, ihi::Integer, A::AbstractMatrix{$elty}, tau::AbstractVector{$elty})
-            @assert !has_offset_axes(A, tau)
+            require_one_based_indexing(A, tau)
             chkstride1(A, tau)
             n = checksquare(A)
             if n - length(tau) != 1
@@ -5598,7 +5598,7 @@ for (ormhr, elty) in
         function ormhr!(side::AbstractChar, trans::AbstractChar, ilo::Integer, ihi::Integer, A::AbstractMatrix{$elty},
             tau::AbstractVector{$elty}, C::AbstractVecOrMat{$elty})
 
-            @assert !has_offset_axes(A, tau, C)
+            require_one_based_indexing(A, tau, C)
             chkstride1(A, tau, C)
             n = checksquare(A)
             mC, nC = size(C, 1), size(C, 2)
@@ -5647,7 +5647,7 @@ for (gees, gges, elty) in
         #     DOUBLE PRECISION   A( LDA, * ), VS( LDVS, * ), WI( * ), WORK( * ),
         #    $                   WR( * )
         function gees!(jobvs::AbstractChar, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             n     = checksquare(A)
             sdim  = Vector{BlasInt}(undef, 1)
@@ -5741,7 +5741,7 @@ for (gees, gges, elty, relty) in
         #       DOUBLE PRECISION   RWORK( * )
         #       COMPLEX*16         A( LDA, * ), VS( LDVS, * ), W( * ), WORK( * )
         function gees!(jobvs::AbstractChar, A::AbstractMatrix{$elty})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             chkstride1(A)
             n     = checksquare(A)
             sort  = 'N'
@@ -6186,7 +6186,7 @@ for (fn, elty, relty) in ((:dtrsyl_, :Float64, :Float64),
     @eval begin
         function trsyl!(transa::AbstractChar, transb::AbstractChar, A::AbstractMatrix{$elty},
                         B::AbstractMatrix{$elty}, C::AbstractMatrix{$elty}, isgn::Int=1)
-            @assert !has_offset_axes(A, B, C)
+            require_one_based_indexing(A, B, C)
             chkstride1(A, B, C)
             m, n = checksquare(A, B)
             lda = max(1, stride(A, 2))

--- a/stdlib/LinearAlgebra/src/ldlt.jl
+++ b/stdlib/LinearAlgebra/src/ldlt.jl
@@ -4,7 +4,7 @@ struct LDLt{T,S<:AbstractMatrix{T}} <: Factorization{T}
     data::S
 
     function LDLt{T,S}(data) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(data)
+        require_one_based_indexing(data)
         new{T,S}(data)
     end
 end
@@ -99,7 +99,7 @@ end
 factorize(S::SymTridiagonal) = ldlt(S)
 
 function ldiv!(S::LDLt{T,M}, B::AbstractVecOrMat{T}) where {T,M<:SymTridiagonal{T}}
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     n, nrhs = size(B, 1), size(B, 2)
     if size(S,1) != n
         throw(DimensionMismatch("Matrix has dimensions $(size(S)) but right hand side has first dimension $n"))

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -7,7 +7,7 @@ struct LQ{T,S<:AbstractMatrix{T}} <: Factorization{T}
     τ::Vector{T}
 
     function LQ{T,S}(factors, τ) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new{T,S}(factors, τ)
     end
 end
@@ -286,7 +286,7 @@ end
 # With a real lhs and complex rhs with the same precision, we can reinterpret
 # the complex rhs as a real rhs with twice the number of columns
 function (\)(F::LQ{T}, B::VecOrMat{Complex{T}}) where T<:BlasReal
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
     x = ldiv!(F, c2r)
     return reshape(copy(reinterpret(Complex{T}, copy(transpose(reshape(x, div(length(x), 2), 2))))),

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -9,7 +9,7 @@ struct LU{T,S<:AbstractMatrix{T}} <: Factorization{T}
     info::BlasInt
 
     function LU{T,S}(factors, ipiv, info) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new{T,S}(factors, ipiv, info)
     end
 end
@@ -273,7 +273,7 @@ size(A::LU)    = size(getfield(A, :factors))
 size(A::LU, i) = size(getfield(A, :factors), i)
 
 function ipiv2perm(v::AbstractVector{T}, maxi::Integer) where T
-    @assert !has_offset_axes(v)
+    require_one_based_indexing(v)
     p = T[1:maxi;]
     @inbounds for i in 1:length(v)
         p[i], p[v[i]] = p[v[i]], p[i]
@@ -520,7 +520,7 @@ end
 
 # See dgtts2.f
 function ldiv!(A::LU{T,Tridiagonal{T,V}}, B::AbstractVecOrMat) where {T,V}
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     n = size(A,1)
     if n != size(B,1)
         throw(DimensionMismatch("matrix has dimensions ($n,$n) but right hand side has $(size(B,1)) rows"))
@@ -552,7 +552,7 @@ function ldiv!(A::LU{T,Tridiagonal{T,V}}, B::AbstractVecOrMat) where {T,V}
 end
 
 function ldiv!(transA::Transpose{<:Any,<:LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat) where {T,V}
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     A = transA.parent
     n = size(A,1)
     if n != size(B,1)
@@ -589,7 +589,7 @@ end
 
 # Ac_ldiv_B!(A::LU{T,Tridiagonal{T}}, B::AbstractVecOrMat) where {T<:Real} = At_ldiv_B!(A,B)
 function ldiv!(adjA::Adjoint{<:Any,LU{T,Tridiagonal{T,V}}}, B::AbstractVecOrMat) where {T,V}
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     A = adjA.parent
     n = size(A,1)
     if n != size(B,1)

--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -497,7 +497,7 @@ end
 #       strides != 1 cases
 
 function generic_matvecmul!(C::AbstractVector{R}, tA, A::AbstractVecOrMat, B::AbstractVector) where R
-    @assert !has_offset_axes(C, A, B)
+    require_one_based_indexing(C, A, B)
     mB = length(B)
     mA, nA = lapack_size(tA, A)
     if mB != nA
@@ -586,7 +586,7 @@ end
 generic_matmatmul!(C::AbstractVecOrMat, tA, tB, A::AbstractVecOrMat, B::AbstractVecOrMat) = _generic_matmatmul!(C, tA, tB, A, B)
 
 function _generic_matmatmul!(C::AbstractVecOrMat{R}, tA, tB, A::AbstractVecOrMat{T}, B::AbstractVecOrMat{S}) where {T,S,R}
-    @assert !has_offset_axes(C, A, B)
+    require_one_based_indexing(C, A, B)
     mA, nA = lapack_size(tA, A)
     mB, nB = lapack_size(tB, B)
     if mB != nA
@@ -760,7 +760,7 @@ function matmul2x2(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,
 end
 
 function matmul2x2!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
-    @assert !has_offset_axes(C, A, B)
+    require_one_based_indexing(C, A, B)
     if !(size(A) == size(B) == size(C) == (2,2))
         throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
     end
@@ -802,7 +802,7 @@ function matmul3x3(tA, tB, A::AbstractMatrix{T}, B::AbstractMatrix{S}) where {T,
 end
 
 function matmul3x3!(C::AbstractMatrix, tA, tB, A::AbstractMatrix, B::AbstractMatrix)
-    @assert !has_offset_axes(C, A, B)
+    require_one_based_indexing(C, A, B)
     if !(size(A) == size(B) == size(C) == (3,3))
         throw(DimensionMismatch("A has size $(size(A)), B has size $(size(B)), C has size $(size(C))"))
     end

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -39,7 +39,7 @@ struct QR{T,S<:AbstractMatrix{T}} <: Factorization{T}
     τ::Vector{T}
 
     function QR{T,S}(factors, τ) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new{T,S}(factors, τ)
     end
 end
@@ -106,7 +106,7 @@ struct QRCompactWY{S,M<:AbstractMatrix{S}} <: Factorization{S}
     T::Matrix{S}
 
     function QRCompactWY{S,M}(factors, T) where {S,M<:AbstractMatrix{S}}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new{S,M}(factors, T)
     end
 end
@@ -159,7 +159,7 @@ struct QRPivoted{T,S<:AbstractMatrix{T}} <: Factorization{T}
     jpvt::Vector{BlasInt}
 
     function QRPivoted{T,S}(factors, τ, jpvt) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(factors, τ, jpvt)
+        require_one_based_indexing(factors, τ, jpvt)
         new{T,S}(factors, τ, jpvt)
     end
 end
@@ -178,7 +178,7 @@ Base.iterate(S::QRPivoted, ::Val{:p}) = (S.p, Val(:done))
 Base.iterate(S::QRPivoted, ::Val{:done}) = nothing
 
 function qrfactUnblocked!(A::AbstractMatrix{T}) where {T}
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     m, n = size(A)
     τ = zeros(T, min(m,n))
     for k = 1:min(m - 1 + !(T<:Real), n)
@@ -360,20 +360,20 @@ true
     compactly rather as two separate dense matrices.
 """
 function qr(A::AbstractMatrix{T}, arg) where T
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     AA = similar(A, _qreltype(T), size(A))
     copyto!(AA, A)
     return qr!(AA, arg)
 end
 function qr(A::AbstractMatrix{T}) where T
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     AA = similar(A, _qreltype(T), size(A))
     copyto!(AA, A)
     return qr!(AA)
 end
 qr(x::Number) = qr(fill(x,1,1))
 function qr(v::AbstractVector)
-    @assert !has_offset_axes(v)
+    require_one_based_indexing(v)
     qr(reshape(v, (length(v), 1)))
 end
 
@@ -467,7 +467,7 @@ struct QRPackedQ{T,S<:AbstractMatrix{T}} <: AbstractQ{T}
     τ::Vector{T}
 
     function QRPackedQ{T,S}(factors, τ) where {T,S<:AbstractMatrix{T}}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new{T,S}(factors, τ)
     end
 end
@@ -487,7 +487,7 @@ struct QRCompactWYQ{S, M<:AbstractMatrix{S}} <: AbstractQ{S}
     T::Matrix{S}
 
     function QRCompactWYQ{S,M}(factors, T) where {S,M<:AbstractMatrix{S}}
-        @assert !has_offset_axes(factors)
+        require_one_based_indexing(factors)
         new{S,M}(factors, T)
     end
 end
@@ -527,7 +527,7 @@ lmul!(A::QRCompactWYQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasFloat, S<:Strid
 lmul!(A::QRPackedQ{T,S}, B::StridedVecOrMat{T}) where {T<:BlasFloat, S<:StridedMatrix} =
     LAPACK.ormqr!('L','N',A.factors,A.τ,B)
 function lmul!(A::QRPackedQ, B::AbstractVecOrMat)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
     if mA != mB
@@ -587,7 +587,7 @@ lmul!(adjA::Adjoint{<:Any,<:QRPackedQ{T,S}}, B::StridedVecOrMat{T}) where {T<:Bl
 lmul!(adjA::Adjoint{<:Any,<:QRPackedQ{T,S}}, B::StridedVecOrMat{T}) where {T<:BlasComplex,S<:StridedMatrix} =
     (A = adjA.parent; LAPACK.ormqr!('L','C',A.factors,A.τ,B))
 function lmul!(adjA::Adjoint{<:Any,<:QRPackedQ}, B::AbstractVecOrMat)
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     A = adjA.parent
     mA, nA = size(A.factors)
     mB, nB = size(B,1), size(B,2)
@@ -851,7 +851,7 @@ _zeros(::Type{T}, b::AbstractVector, n::Integer) where {T} = zeros(T, max(length
 _zeros(::Type{T}, B::AbstractMatrix, n::Integer) where {T} = zeros(T, max(size(B, 1), n), size(B, 2))
 
 function (\)(A::Union{QR{TA},QRCompactWY{TA},QRPivoted{TA}}, B::AbstractVecOrMat{TB}) where {TA,TB}
-    @assert !has_offset_axes(B)
+    require_one_based_indexing(B)
     S = promote_type(TA,TB)
     m, n = size(A)
     m == size(B,1) || throw(DimensionMismatch("Both inputs should have the same number of rows"))
@@ -872,7 +872,7 @@ _ret_size(A::Factorization, b::AbstractVector) = (max(size(A, 2), length(b)),)
 _ret_size(A::Factorization, B::AbstractMatrix) = (max(size(A, 2), size(B, 1)), size(B, 2))
 
 function (\)(A::Union{QR{T},QRCompactWY{T},QRPivoted{T}}, BIn::VecOrMat{Complex{T}}) where T<:BlasReal
-    @assert !has_offset_axes(BIn)
+    require_one_based_indexing(BIn)
     m, n = size(A)
     m == size(BIn, 1) || throw(DimensionMismatch("left hand side has $m rows, but right hand side has $(size(BIn,1)) rows"))
 

--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -6,7 +6,7 @@ struct SVD{T,Tr,M<:AbstractArray{T}} <: Factorization{T}
     S::Vector{Tr}
     Vt::M
     function SVD{T,Tr,M}(U, S, Vt) where {T,Tr,M<:AbstractArray{T}}
-        @assert !has_offset_axes(U, S, Vt)
+        require_one_based_indexing(U, S, Vt)
         new{T,Tr,M}(U, S, Vt)
     end
 end

--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -6,7 +6,7 @@ struct Symmetric{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
     uplo::Char
 
     function Symmetric{T,S}(data, uplo) where {T,S<:AbstractMatrix{<:T}}
-        @assert !has_offset_axes(data)
+        require_one_based_indexing(data)
         new{T,S}(data, uplo)
     end
 end
@@ -81,7 +81,7 @@ struct Hermitian{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
     uplo::Char
 
     function Hermitian{T,S}(data, uplo) where {T,S<:AbstractMatrix{<:T}}
-        @assert !has_offset_axes(data)
+        require_one_based_indexing(data)
         new{T,S}(data, uplo)
     end
 end

--- a/stdlib/LinearAlgebra/src/triangular.jl
+++ b/stdlib/LinearAlgebra/src/triangular.jl
@@ -13,7 +13,7 @@ for t in (:LowerTriangular, :UnitLowerTriangular, :UpperTriangular,
             data::S
 
             function $t{T,S}(data) where {T,S<:AbstractMatrix{T}}
-                @assert !has_offset_axes(data)
+                require_one_based_indexing(data)
                 checksquare(data)
                 new{T,S}(data)
             end
@@ -1138,7 +1138,7 @@ end
 # replacing repeated references to A.data[j,j] with [Ajj = A.data[j,j] and references to Ajj]
 # does not significantly impact performance as of Dec 2015
 function naivesub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
-    @assert !has_offset_axes(A, b, x)
+    require_one_based_indexing(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1153,7 +1153,7 @@ function naivesub!(A::UpperTriangular, b::AbstractVector, x::AbstractVector = b)
     x
 end
 function naivesub!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector = b)
-    @assert !has_offset_axes(A, b, x)
+    require_one_based_indexing(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1167,7 +1167,7 @@ function naivesub!(A::UnitUpperTriangular, b::AbstractVector, x::AbstractVector 
     x
 end
 function naivesub!(A::LowerTriangular, b::AbstractVector, x::AbstractVector = b)
-    @assert !has_offset_axes(A, b, x)
+    require_one_based_indexing(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1182,7 +1182,7 @@ function naivesub!(A::LowerTriangular, b::AbstractVector, x::AbstractVector = b)
     x
 end
 function naivesub!(A::UnitLowerTriangular, b::AbstractVector, x::AbstractVector = b)
-    @assert !has_offset_axes(A, b, x)
+    require_one_based_indexing(A, b, x)
     n = size(A, 2)
     if !(n == length(b) == length(x))
         throw(DimensionMismatch("second dimension of left hand side A, $n, length of output x, $(length(x)), and length of right hand side b, $(length(b)), must be equal"))
@@ -1198,7 +1198,7 @@ end
 # in the following transpose and conjugate transpose naive substitution variants,
 # accumulating in z rather than b[j] significantly improves performance as of Dec 2015
 function ldiv!(transA::Transpose{<:Any,<:LowerTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(transA, b, x)
+    require_one_based_indexing(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1217,7 +1217,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:LowerTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(transA::Transpose{<:Any,<:UnitLowerTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(transA, b, x)
+    require_one_based_indexing(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1235,7 +1235,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:UnitLowerTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(transA::Transpose{<:Any,<:UpperTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(transA, b, x)
+    require_one_based_indexing(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1254,7 +1254,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:UpperTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(transA::Transpose{<:Any,<:UnitUpperTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(transA, b, x)
+    require_one_based_indexing(transA, b, x)
     A = transA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1272,7 +1272,7 @@ end
 ldiv!(transA::Transpose{<:Any,<:UnitUpperTriangular}, b::AbstractVector) = ldiv!(transA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:LowerTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(adjA, b, x)
+    require_one_based_indexing(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1291,7 +1291,7 @@ end
 ldiv!(adjA::Adjoint{<:Any,<:LowerTriangular}, b::AbstractVector) = ldiv!(adjA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:UnitLowerTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(adjA, b, x)
+    require_one_based_indexing(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1309,7 +1309,7 @@ end
 ldiv!(adjA::Adjoint{<:Any,<:UnitLowerTriangular}, b::AbstractVector) = ldiv!(adjA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:UpperTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(adjA, b, x)
+    require_one_based_indexing(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1328,7 +1328,7 @@ end
 ldiv!(adjA::Adjoint{<:Any,<:UpperTriangular}, b::AbstractVector) = ldiv!(adjA, b, b)
 
 function ldiv!(adjA::Adjoint{<:Any,<:UnitUpperTriangular}, b::AbstractVector, x::AbstractVector)
-    @assert !has_offset_axes(adjA, b, x)
+    require_one_based_indexing(adjA, b, x)
     A = adjA.parent
     n = size(A, 1)
     if !(n == length(b) == length(x))
@@ -1794,14 +1794,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Multiplication with triangle to the left and hence rhs cannot be transposed.
     @eval begin
         function *(A::AbstractTriangular, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             lmul!(convert(AbstractArray{TAB}, A), BB)
         end
         function *(adjA::Adjoint{<:Any,<:AbstractTriangular}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             A = adjA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1809,7 +1809,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             lmul!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function *(transA::Transpose{<:Any,<:AbstractTriangular}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             A = transA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1820,14 +1820,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. No quotients.
     @eval begin
         function \(A::Union{UnitUpperTriangular,UnitLowerTriangular}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             ldiv!(convert(AbstractArray{TAB}, A), BB)
         end
         function \(adjA::Adjoint{<:Any,<:Union{UnitUpperTriangular,UnitLowerTriangular}}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             A = adjA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1835,7 +1835,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             ldiv!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function \(transA::Transpose{<:Any,<:Union{UnitUpperTriangular,UnitLowerTriangular}}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             A = transA.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             BB = similar(B, TAB, size(B))
@@ -1846,14 +1846,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Left division with triangle to the left hence rhs cannot be transposed. Quotients.
     @eval begin
         function \(A::Union{UpperTriangular,LowerTriangular}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
             copyto!(BB, B)
             ldiv!(convert(AbstractArray{TAB}, A), BB)
         end
         function \(adjA::Adjoint{<:Any,<:Union{UpperTriangular,LowerTriangular}}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             A = adjA.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
@@ -1861,7 +1861,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             ldiv!(adjoint(convert(AbstractArray{TAB}, A)), BB)
         end
         function \(transA::Transpose{<:Any,<:Union{UpperTriangular,LowerTriangular}}, B::$mat)
-            @assert !has_offset_axes(B)
+            require_one_based_indexing(B)
             A = transA.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             BB = similar(B, TAB, size(B))
@@ -1872,14 +1872,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Right division with triangle to the right hence lhs cannot be transposed. No quotients.
     @eval begin
         function /(A::$mat, B::Union{UnitUpperTriangular, UnitLowerTriangular})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
             rdiv!(AA, convert(AbstractArray{TAB}, B))
         end
         function /(A::$mat, adjB::Adjoint{<:Any,<:Union{UnitUpperTriangular, UnitLowerTriangular}})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             B = adjB.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
@@ -1887,7 +1887,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             rdiv!(AA, adjoint(convert(AbstractArray{TAB}, B)))
         end
         function /(A::$mat, transB::Transpose{<:Any,<:Union{UnitUpperTriangular, UnitLowerTriangular}})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             B = transB.parent
             TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
             AA = similar(A, TAB, size(A))
@@ -1898,14 +1898,14 @@ for mat in (:AbstractVector, :AbstractMatrix)
     ### Right division with triangle to the right hence lhs cannot be transposed. Quotients.
     @eval begin
         function /(A::$mat, B::Union{UpperTriangular,LowerTriangular})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
             copyto!(AA, A)
             rdiv!(AA, convert(AbstractArray{TAB}, B))
         end
         function /(A::$mat, adjB::Adjoint{<:Any,<:Union{UpperTriangular,LowerTriangular}})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             B = adjB.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
@@ -1913,7 +1913,7 @@ for mat in (:AbstractVector, :AbstractMatrix)
             rdiv!(AA, adjoint(convert(AbstractArray{TAB}, B)))
         end
         function /(A::$mat, transB::Transpose{<:Any,<:Union{UpperTriangular,LowerTriangular}})
-            @assert !has_offset_axes(A)
+            require_one_based_indexing(A)
             B = transB.parent
             TAB = typeof((zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))/one(eltype(A)))
             AA = similar(A, TAB, size(A))
@@ -1925,14 +1925,14 @@ end
 ### Multiplication with triangle to the right and hence lhs cannot be transposed.
 # Only for AbstractMatrix, hence outside the above loop.
 function *(A::AbstractMatrix, B::AbstractTriangular)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
     AA = similar(A, TAB, size(A))
     copyto!(AA, A)
     rmul!(AA, convert(AbstractArray{TAB}, B))
 end
 function *(A::AbstractMatrix, adjB::Adjoint{<:Any,<:AbstractTriangular})
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     B = adjB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
     AA = similar(A, TAB, size(A))
@@ -1940,7 +1940,7 @@ function *(A::AbstractMatrix, adjB::Adjoint{<:Any,<:AbstractTriangular})
     rmul!(AA, adjoint(convert(AbstractArray{TAB}, B)))
 end
 function *(A::AbstractMatrix, transB::Transpose{<:Any,<:AbstractTriangular})
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     B = transB.parent
     TAB = typeof(zero(eltype(A))*zero(eltype(B)) + zero(eltype(A))*zero(eltype(B)))
     AA = similar(A, TAB, size(A))
@@ -2256,7 +2256,7 @@ end
 # Repeatedly compute the square roots of A so that in the end its
 # eigenvalues are close enough to the positive real line
 function invsquaring(A0::UpperTriangular, theta)
-    @assert !has_offset_axes(theta)
+    require_one_based_indexing(theta)
     # assumes theta is in ascending order
     maxsqrt = 100
     tmax = size(theta, 1)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -7,7 +7,7 @@ struct SymTridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     dv::V                        # diagonal
     ev::V                        # subdiagonal
     function SymTridiagonal{T,V}(dv, ev) where {T,V<:AbstractVector{T}}
-        @assert !has_offset_axes(dv, ev)
+        require_one_based_indexing(dv, ev)
         if !(length(dv) - 1 <= length(ev) <= length(dv))
             throw(DimensionMismatch("subdiagonal has wrong length. Has length $(length(ev)), but should be either $(length(dv) - 1) or $(length(dv))."))
         end
@@ -331,7 +331,7 @@ end
 #    Linear Algebra and its Applications 212-213 (1994), pp.413-414
 #    doi:10.1016/0024-3795(94)90414-6
 function det_usmani(a::V, b::V, c::V) where {T,V<:AbstractVector{T}}
-    @assert !has_offset_axes(a, b, c)
+    require_one_based_indexing(a, b, c)
     n = length(b)
     θa = one(T)
     if n == 0
@@ -378,7 +378,7 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     du::V    # sup-diagonal
     du2::V   # supsup-diagonal for pivoting in LU
     function Tridiagonal{T,V}(dl, d, du) where {T,V<:AbstractVector{T}}
-        @assert !has_offset_axes(dl, d, du)
+        require_one_based_indexing(dl, d, du)
         n = length(d)
         if (length(dl) != n-1 || length(du) != n-1)
             throw(ArgumentError(string("cannot construct Tridiagonal from incompatible ",
@@ -389,7 +389,7 @@ struct Tridiagonal{T,V<:AbstractVector{T}} <: AbstractMatrix{T}
     end
     # constructor used in lu!
     function Tridiagonal{T,V}(dl, d, du, du2) where {T,V<:AbstractVector{T}}
-        @assert !has_offset_axes(dl, d, du, du2)
+        require_one_based_indexing(dl, d, du, du2)
         # length checks?
         new{T,V}(dl, d, du, du2)
     end

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -205,7 +205,7 @@ Broadcast.broadcasted(::typeof(/), J::UniformScaling,x::Number) = UniformScaling
 ## equality comparison with UniformScaling
 ==(J::UniformScaling, A::AbstractMatrix) = A == J
 function ==(A::AbstractMatrix, J::UniformScaling)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     size(A, 1) == size(A, 2) || return false
     iszero(J.λ) && return iszero(A)
     isone(J.λ) && return isone(A)
@@ -247,7 +247,7 @@ Copies a [`UniformScaling`](@ref) onto a matrix.
     support for a rectangular matrix.
 """
 function copyto!(A::AbstractMatrix, J::UniformScaling)
-    @assert !has_offset_axes(A)
+    require_one_based_indexing(A)
     fill!(A, 0)
     λ = J.λ
     for i = 1:min(size(A,1),size(A,2))
@@ -283,7 +283,7 @@ for (f,dim,name) in ((:hcat,1,"rows"), (:vcat,2,"cols"))
             n = -1
             for a in A
                 if !isa(a, UniformScaling)
-                    @assert !has_offset_axes(a)
+                    require_one_based_indexing(a)
                     na = size(a,$dim)
                     n >= 0 && n != na &&
                         throw(DimensionMismatch(string("number of ", $name,
@@ -299,7 +299,7 @@ end
 
 
 function hvcat(rows::Tuple{Vararg{Int}}, A::Union{AbstractVecOrMat,UniformScaling}...)
-    @assert !has_offset_axes(A...)
+    require_one_based_indexing(A...)
     nr = length(rows)
     sum(rows) == length(A) || throw(ArgumentError("mismatch between row sizes and number of arguments"))
     n = fill(-1, length(A))

--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -8,7 +8,7 @@ using .DSFMT
 using Base.GMP.MPZ
 using Base.GMP: Limb
 
-using Base: BitInteger, BitInteger_types, BitUnsigned, has_offset_axes
+using Base: BitInteger, BitInteger_types, BitUnsigned, require_one_based_indexing
 
 import Base: copymutable, copy, copy!, ==, hash, convert
 using Serialization

--- a/stdlib/Random/src/misc.jl
+++ b/stdlib/Random/src/misc.jl
@@ -85,7 +85,7 @@ end
 # (Note that this is different from the problem of finding a random
 #  size-m subset of A where m is fixed!)
 function randsubseq!(r::AbstractRNG, S::AbstractArray, A::AbstractArray, p::Real)
-    @assert !has_offset_axes(S, A)
+    require_one_based_indexing(S, A)
     0 <= p <= 1 || throw(ArgumentError("probability $p not in [0,1]"))
     n = length(A)
     p == 1 && return copyto!(resize!(S, n), A)
@@ -204,7 +204,7 @@ julia> shuffle!(rng, Vector(1:16))
 ```
 """
 function shuffle!(r::AbstractRNG, a::AbstractArray)
-    @assert !has_offset_axes(a)
+    require_one_based_indexing(a)
     n = length(a)
     n <= 1 && return a # nextpow below won't work with n == 0
     @assert n <= Int64(2)^52

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -9,7 +9,7 @@ module Serialization
 
 import Base: GMP, Bottom, unsafe_convert, uncompressed_ast
 import Core: svec, SimpleVector
-using Base: unaliascopy, unwrap_unionall, has_offset_axes
+using Base: unaliascopy, unwrap_unionall, require_one_based_indexing
 using Core.IR
 
 export serialize, deserialize, AbstractSerializer, Serializer
@@ -227,7 +227,7 @@ function serialize(s::AbstractSerializer, x::Symbol)
 end
 
 function serialize_array_data(s::IO, a)
-    @assert !has_offset_axes(a)
+    require_one_based_indexing(a)
     isempty(a) && return 0
     if eltype(a) === Bool
         last = a[1]

--- a/stdlib/SparseArrays/src/SparseArrays.jl
+++ b/stdlib/SparseArrays/src/SparseArrays.jl
@@ -6,7 +6,7 @@ Support for sparse arrays. Provides `AbstractSparseArray` and subtypes.
 module SparseArrays
 
 using Base: ReshapedArray, promote_op, setindex_shape_check, to_shape, tail,
-    has_offset_axes
+    require_one_based_indexing
 using Base.Sort: Forward
 using LinearAlgebra
 

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -314,7 +314,7 @@ const TriangularSparse{T} = Union{
 
 ## triangular multipliers
 function lmul!(A::TriangularSparse{T}, B::StridedVecOrMat{T}) where T
-    @assert !has_offset_axes(A, B)
+    require_one_based_indexing(A, B)
     nrowB, ncolB  = size(B, 1), size(B, 2)
     ncol = LinearAlgebra.checksquare(A)
     if nrowB != ncol
@@ -487,7 +487,7 @@ end
 
 ## triangular solvers
 function ldiv!(A::TriangularSparse{T}, B::StridedVecOrMat{T}) where T
-    @assert !has_offset_axes(A, B)
+    require_one_based_indexing(A, B)
     nrowB, ncolB  = size(B, 1), size(B, 2)
     ncol = LinearAlgebra.checksquare(A)
     if nrowB != ncol
@@ -705,7 +705,7 @@ rdiv!(A::SparseMatrixCSC{T}, transD::Transpose{<:Any,<:Diagonal{T}}) where {T} =
     (D = transD.parent; rdiv!(A, D))
 
 function ldiv!(D::Diagonal{T}, A::SparseMatrixCSC{T}) where {T}
-    # @assert !has_offset_axes(A)
+    # require_one_based_indexing(A)
     if A.m != length(D.diag)
         throw(DimensionMismatch("diagonal matrix is $(length(D.diag)) by $(length(D.diag)) but right hand side has $(A.m) rows"))
     end
@@ -1299,7 +1299,7 @@ function lmul!(D::Diagonal, A::SparseMatrixCSC)
 end
 
 function \(A::SparseMatrixCSC, B::AbstractVecOrMat)
-    @assert !has_offset_axes(A, B)
+    require_one_based_indexing(A, B)
     m, n = size(A)
     if m == n
         if istril(A)
@@ -1323,7 +1323,7 @@ for (xformtype, xformop) in ((:Adjoint, :adjoint), (:Transpose, :transpose))
     @eval begin
         function \(xformA::($xformtype){<:Any,<:SparseMatrixCSC}, B::AbstractVecOrMat)
             A = xformA.parent
-            @assert !has_offset_axes(A, B)
+            require_one_based_indexing(A, B)
             m, n = size(A)
             if m == n
                 if istril(A)

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -9,7 +9,7 @@ module Statistics
 
 using LinearAlgebra, SparseArrays
 
-using Base: has_offset_axes
+using Base: has_offset_axes, require_one_based_indexing
 
 export cor, cov, std, stdm, var, varm, mean!, mean,
     median!, median, middle, quantile!, quantile
@@ -513,7 +513,7 @@ clampcor(x) = x
 # cov2cor!
 
 function cov2cor!(C::AbstractMatrix{T}, xsd::AbstractArray) where T
-    @assert !has_offset_axes(C, xsd)
+    require_one_based_indexing(C, xsd)
     nx = length(xsd)
     size(C) == (nx, nx) || throw(DimensionMismatch("inconsistent dimensions"))
     for j = 1:nx
@@ -528,7 +528,7 @@ function cov2cor!(C::AbstractMatrix{T}, xsd::AbstractArray) where T
     return C
 end
 function cov2cor!(C::AbstractMatrix, xsd, ysd::AbstractArray)
-    @assert !has_offset_axes(C, ysd)
+    require_one_based_indexing(C, ysd)
     nx, ny = size(C)
     length(ysd) == ny || throw(DimensionMismatch("inconsistent dimensions"))
     for (j, y) in enumerate(ysd)   # fixme (iter): here and in all `cov2cor!` we assume that `C` is efficiently indexed by integers
@@ -539,7 +539,7 @@ function cov2cor!(C::AbstractMatrix, xsd, ysd::AbstractArray)
     return C
 end
 function cov2cor!(C::AbstractMatrix, xsd::AbstractArray, ysd)
-    @assert !has_offset_axes(C, xsd)
+    require_one_based_indexing(C, xsd)
     nx, ny = size(C)
     length(xsd) == nx || throw(DimensionMismatch("inconsistent dimensions"))
     for j in 1:ny
@@ -550,7 +550,7 @@ function cov2cor!(C::AbstractMatrix, xsd::AbstractArray, ysd)
     return C
 end
 function cov2cor!(C::AbstractMatrix, xsd::AbstractArray, ysd::AbstractArray)
-    @assert !has_offset_axes(C, xsd, ysd)
+    require_one_based_indexing(C, xsd, ysd)
     nx, ny = size(C)
     (length(xsd) == nx && length(ysd) == ny) ||
         throw(DimensionMismatch("inconsistent dimensions"))
@@ -581,7 +581,7 @@ corzm(x::AbstractMatrix, y::AbstractMatrix, vardim::Int=1) =
 corm(x::AbstractVector{T}, xmean) where {T} = one(real(T))
 corm(x::AbstractMatrix, xmean, vardim::Int=1) = corzm(x .- xmean, vardim)
 function corm(x::AbstractVector, mx, y::AbstractVector, my)
-    @assert !has_offset_axes(x, y)
+    require_one_based_indexing(x, y)
     n = length(x)
     length(y) == n || throw(DimensionMismatch("inconsistent lengths"))
     n > 0 || throw(ArgumentError("correlation only defined for non-empty vectors"))
@@ -806,7 +806,7 @@ julia> y
 """
 function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
                    sorted::Bool=false)
-    @assert !has_offset_axes(q, v, p)
+    require_one_based_indexing(q, v, p)
     if size(p) != size(q)
         throw(DimensionMismatch("size of p, $(size(p)), must equal size of q, $(size(q))"))
     end
@@ -837,7 +837,7 @@ end
 # Function to perform partial sort of v for quantiles in given range
 function _quantilesort!(v::AbstractArray, sorted::Bool, minp::Real, maxp::Real)
     isempty(v) && throw(ArgumentError("empty data vector"))
-    @assert !has_offset_axes(v)
+    require_one_based_indexing(v)
 
     if !sorted
         lv = length(v)
@@ -855,7 +855,7 @@ end
 # Core quantile lookup function: assumes `v` sorted
 @inline function _quantile(v::AbstractVector, p::Real)
     0 <= p <= 1 || throw(ArgumentError("input probability out of [0,1] range"))
-    @assert !has_offset_axes(v)
+    require_one_based_indexing(v)
 
     lv = length(v)
     f0 = (lv - 1)*p # 0-based interpolated index
@@ -947,7 +947,7 @@ end
 
 # This is the function that does the reduction underlying var/std
 function centralize_sumabs2!(R::AbstractArray{S}, A::SparseMatrixCSC{Tv,Ti}, means::AbstractArray) where {S,Tv,Ti}
-    @assert !has_offset_axes(R, A, means)
+    require_one_based_indexing(R, A, means)
     lsiz = Base.check_reducedims(R,A)
     size(means) == size(R) || error("size of means must match size of R")
     isempty(R) || fill!(R, zero(S))

--- a/stdlib/SuiteSparse/src/cholmod.jl
+++ b/stdlib/SuiteSparse/src/cholmod.jl
@@ -12,7 +12,7 @@ module CHOLMOD
 
 import Base: (*), convert, copy, eltype, getindex, getproperty, show, size,
              IndexStyle, IndexLinear, IndexCartesian, adjoint, axes
-using Base: has_offset_axes
+using Base: require_one_based_indexing
 
 using LinearAlgebra
 import LinearAlgebra: (\),
@@ -948,7 +948,7 @@ Base.copyto!(dest::AbstractArray{T,2}, D::Dense{T}) where {T<:VTypes} = _copy!(d
 Base.copyto!(dest::AbstractArray, D::Dense) = _copy!(dest, D)
 
 function _copy!(dest::AbstractArray, D::Dense)
-    @assert !has_offset_axes(dest)
+    require_one_based_indexing(dest)
     s = unsafe_load(pointer(D))
     n = s.nrow*s.ncol
     n <= length(dest) || throw(BoundsError(dest, n))

--- a/stdlib/SuiteSparse/src/spqr.jl
+++ b/stdlib/SuiteSparse/src/spqr.jl
@@ -3,7 +3,7 @@
 module SPQR
 
 import Base: \
-using Base: has_offset_axes
+using Base: require_one_based_indexing
 using LinearAlgebra
 
 # ordering options */
@@ -353,7 +353,7 @@ function (\)(F::QRSparse{T}, B::VecOrMat{Complex{T}}) where T<:LinearAlgebra.Bla
 # |z2|z4|      ->       |y1|y2|y3|y4|     ->      |x2|y2|     ->    |x2|y2|x4|y4|
 #                                                 |x3|y3|
 #                                                 |x4|y4|
-    @assert !has_offset_axes(F, B)
+    require_one_based_indexing(F, B)
     c2r = reshape(copy(transpose(reinterpret(T, reshape(B, (1, length(B)))))), size(B, 1), 2*size(B, 2))
     x = F\c2r
 


### PR DESCRIPTION
Ref Issue: #30610 

* refactored all `assert !has_offset_axes(...)` in stdlib
* replaced `assert !has_offset_axes(...)`  offset-arrays.md documentation

instances of the asserts have been replaced with `require_one_based_indexing(...)`

I noticed in `stdlib` there were some inconsistencies with cases using `has_offset_axes(...)` and `Base.has_offset_axes(...)`. I left the cases as they were and just replaced it with the new function. 