### PR TITLE
restrict second argument of `size` and `axes` to Integer for most types

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -35,7 +35,7 @@ julia> size(A, 2)
 3
 ```
 """
-size(t::AbstractArray{T,N}, d) where {T,N} = d <= N ? size(t)[d] : 1
+size(t::AbstractArray{T,N}, d) where {T,N} = d::Integer <= N ? size(t)[d] : 1
 
 """
     axes(A, d)
@@ -54,7 +54,7 @@ Base.OneTo(6)
 """
 function axes(A::AbstractArray{T,N}, d) where {T,N}
     @_inline_meta
-    d <= N ? axes(A)[d] : OneTo(1)
+    d::Integer <= N ? axes(A)[d] : OneTo(1)
 end
 
 """

--- a/base/array.jl
+++ b/base/array.jl
@@ -151,7 +151,7 @@ function vect(X...)
     return copyto!(Vector{T}(undef, length(X)), X)
 end
 
-size(a::Array, d) = arraysize(a, d)
+size(a::Array, d::Integer) = arraysize(a, convert(Int, d))
 size(a::Vector) = (arraysize(a,1),)
 size(a::Matrix) = (arraysize(a,1), arraysize(a,2))
 size(a::Array{<:Any,N}) where {N} = (@_inline_meta; ntuple(M -> size(a, M), Val(N)))

--- a/base/bitarray.jl
+++ b/base/bitarray.jl
@@ -77,7 +77,7 @@ length(B::BitArray) = B.len
 size(B::BitVector) = (B.len,)
 size(B::BitArray) = B.dims
 
-@inline function size(B::BitVector, d)
+@inline function size(B::BitVector, d::Integer)
     d < 1 && throw_boundserror(size(B), d)
     ifelse(d == 1, B.len, 1)
 end

--- a/base/char.jl
+++ b/base/char.jl
@@ -187,7 +187,7 @@ typemax(::Type{Char}) = reinterpret(Char, typemax(UInt32))
 typemin(::Type{Char}) = reinterpret(Char, typemin(UInt32))
 
 size(c::AbstractChar) = ()
-size(c::AbstractChar,d) = convert(Int, d) < 1 ? throw(BoundsError()) : 1
+size(c::AbstractChar, d::Integer) = d < 1 ? throw(BoundsError()) : 1
 ndims(c::AbstractChar) = 0
 ndims(::Type{<:AbstractChar}) = 0
 length(c::AbstractChar) = 1

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -570,7 +570,7 @@ eltype(::Type{SimpleVector}) = Any
 keys(v::SimpleVector) = OneTo(length(v))
 isempty(v::SimpleVector) = (length(v) == 0)
 axes(v::SimpleVector) = (OneTo(length(v)),)
-axes(v::SimpleVector, d) = d <= 1 ? axes(v)[d] : OneTo(1)
+axes(v::SimpleVector, d::Integer) = d <= 1 ? axes(v)[d] : OneTo(1)
 
 function ==(v1::SimpleVector, v2::SimpleVector)
     length(v1)==length(v2) || return false

--- a/base/number.jl
+++ b/base/number.jl
@@ -60,9 +60,9 @@ true
 isone(x) = x == one(x) # fallback method
 
 size(x::Number) = ()
-size(x::Number,d) = convert(Int,d)<1 ? throw(BoundsError()) : 1
+size(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : 1
 axes(x::Number) = ()
-axes(x::Number,d) = convert(Int,d)<1 ? throw(BoundsError()) : OneTo(1)
+axes(x::Number, d::Integer) = d < 1 ? throw(BoundsError()) : OneTo(1)
 eltype(::Type{T}) where {T<:Number} = T
 ndims(x::Number) = 0
 ndims(::Type{<:Number}) = 0

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -19,7 +19,7 @@ NTuple
 length(@nospecialize t::Tuple) = nfields(t)
 firstindex(@nospecialize t::Tuple) = 1
 lastindex(@nospecialize t::Tuple) = length(t)
-size(@nospecialize(t::Tuple), d) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
+size(@nospecialize(t::Tuple), d::Integer) = (d == 1) ? length(t) : throw(ArgumentError("invalid tuple dimension $d"))
 axes(@nospecialize t::Tuple) = (OneTo(length(t)),)
 @eval getindex(@nospecialize(t::Tuple), i::Int) = getfield(t, i, $(Expr(:boundscheck)))
 @eval getindex(@nospecialize(t::Tuple), i::Real) = getfield(t, convert(Int, i), $(Expr(:boundscheck)))


### PR DESCRIPTION
This argument had a variety of strange behaviors:
```
julia> size([1], Int8(1))
ERROR: TypeError: in arraysize, expected Int64, got Int8

julia> size((), Int8(1))
0

julia> size((), :x)
ERROR: ArgumentError: invalid tuple dimension x

julia> size((1,), 1.0)
1

julia> size(1, :x)
ERROR: MethodError: Cannot `convert` an object of type Symbol to an object of type Int64
```

After:
```
julia> size([1], Int8(1))
1

julia> size((), Int8(1))
0

julia> size((), :x)
ERROR: MethodError: no method matching size(::Tuple{}, ::Symbol)

julia> size((1,), 1.0)
ERROR: MethodError: no method matching size(::Tuple{Int64}, ::Float64)

julia> size(1, :x)
ERROR: MethodError: no method matching size(::Int64, ::Symbol)
```
