### PR TITLE
use `IdSet` instead of `Set` in `subtypes`

### DIFF
--- a/stdlib/InteractiveUtils/src/InteractiveUtils.jl
+++ b/stdlib/InteractiveUtils/src/InteractiveUtils.jl
@@ -173,7 +173,7 @@ function methodswith(t::Type; supertypes::Bool=false)
 end
 
 # subtypes
-function _subtypes(m::Module, x::Type, sts=Set{Any}(), visited=Set{Module}())
+function _subtypes(m::Module, x::Type, sts=Base.IdSet{Any}(), visited=Base.IdSet{Module}())
     push!(visited, m)
     xt = unwrap_unionall(x)
     if !isa(xt, DataType)
@@ -212,8 +212,8 @@ function _subtypes_in(mods::Array, x::Type)
         # Fast path
         return Type[]
     end
-    sts = Set{Any}()
-    visited = Set{Module}()
+    sts = Base.IdSet{Any}()
+    visited = Base.IdSet{Module}()
     for m in mods
         _subtypes(m, x, sts, visited)
     end


### PR DESCRIPTION
For me this makes `subtypes(Function)` take about half a second instead of 5 minutes (see #30704). This is because the code for `IdSet` has `@nospecialize` annotations.