### PR TITLE
News for #24980 (sparsity preserving outer products)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,9 @@ Standard library changes
 #### SparseArrays
 
 * performance improvements for sparse matrix-matrix multiplication ([#30372]).
+* Sparse vector outer products are more performant and maintain sparsity in products of the
+  form `kron(u, v')`, `u * v'`, and `u .* v'` where `u` and `v` are sparse vectors or column
+  views. ([#24980])
 
 #### Dates
 


### PR DESCRIPTION
Adds a news entry for the changes added in PR #24980.