### PR TITLE
Singleton Types H4 -> H3

### DIFF
--- a/doc/src/manual/types.md
+++ b/doc/src/manual/types.md
@@ -938,7 +938,7 @@ julia> NamedTuple{(:a, :b)}((1,""))
 If field types are specified, the arguments are converted. Otherwise the types of the arguments
 are used directly.
 
-#### [Singleton Types](@id man-singleton-types)
+### [Singleton Types](@id man-singleton-types)
 
 There is a special kind of abstract parametric type that must be mentioned here: singleton types.
 For each type, `T`, the "singleton type" `Type{T}` is an abstract type whose only instance is


### PR DESCRIPTION
It's not apparent to me why this section should have an H4 header, which makes it look like a subsection of "Named Tuple Types". Making it H3.