### PR TITLE
Fix unknown type name '__WAIT_STATUS' errors when compiling Julia on systems with older glibc versions.

### DIFF
--- a/deps/blas.mk
+++ b/deps/blas.mk
@@ -92,7 +92,12 @@ endif
 # Do not overwrite the "-j" flag
 OPENBLAS_BUILD_OPTS += MAKE_NB_JOBS=0
 
-$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas_0.3.0_to_0.3.3_unknown_wait_status.patch-applied: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/source-extracted
+	cd $(BUILDDIR)/$(OPENBLAS_SRC_DIR) && \
+		patch -p1 -f < $(SRCDIR)/patches/openblas_0.3.0_to_0.3.3_unknown_wait_status.patch
+	echo 1 > $@
+
+$(BUILDDIR)/$(OPENBLAS_SRC_DIR)/build-configured: $(BUILDDIR)/$(OPENBLAS_SRC_DIR)/openblas_0.3.0_to_0.3.3_unknown_wait_status.patch-applied
 	perl -i -ple 's/^\s*(EXTRALIB\s*\+=\s*-lSystemStubs)\s*$$/# $$1/g' $(dir $<)/Makefile.system
 	echo 1 > $@
 

--- a/deps/patches/openblas_0.3.0_to_0.3.3_unknown_wait_status.patch
+++ b/deps/patches/openblas_0.3.0_to_0.3.3_unknown_wait_status.patch
@@ -1,0 +1,16 @@
+diff --git a/utest/test_fork.c b/utest/test_fork.c
+index 9fc5128..0b90407 100644
+--- a/utest/test_fork.c
++++ b/utest/test_fork.c
+@@ -31,10 +31,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ 
+ **********************************************************************************/
+ 
+-#include "openblas_utest.h"
+ #include <sys/types.h>
+ #include <sys/wait.h>
+ #include <cblas.h>
++#include "openblas_utest.h"
+ 
+ void* xmalloc(size_t n)
+ {


### PR DESCRIPTION
@StefanKarpinski @ararslan 

When I compile Julia v1.0.3 on SUSE SLES 11 SP4, my compilation fails due to one of OpenBLAS's tests:

```
In file included from test_fork.c:36:0:
/usr/include/sys/wait.h:116:22: error: unknown type name ‘__WAIT_STATUS’
 extern __pid_t wait (__WAIT_STATUS __stat_loc);
                      ^
In file included from test_fork.c:36:0:
/usr/include/sys/wait.h:169:23: error: unknown type name ‘__WAIT_STATUS’
 extern __pid_t wait3 (__WAIT_STATUS __stat_loc, int __options,
                       ^
/usr/include/sys/wait.h:175:38: error: unknown type name ‘__WAIT_STATUS’
 extern __pid_t wait4 (__pid_t __pid, __WAIT_STATUS __stat_loc, int __options,
                                      ^
test_fork.c: In function ‘__ctest_fork_safety_run’:
test_fork.c:114:13: warning: implicit declaration of function ‘wait’ [-Wimplicit-function-declaration]
             pid_t wait_pid = wait(&child_status);
             ^
test_fork.c:116:13: warning: implicit declaration of function ‘WEXITSTATUS’ [-Wimplicit-function-declaration]
             ASSERT_EQUAL(0, WEXITSTATUS (child_status));
             ^
make[3]: *** [test_fork.o] Error 1
make[2]: *** [tests] Error 2
\033[33;1m*** Clean the OpenBLAS build with 'make -C deps clean-openblas'. Rebuild with 'make OPENBLAS_USE_THREAD=0' if OpenBLAS had trouble linking libpthread.so, and with 'make OPENBLAS_TARGET_ARCH=NEHALEM' if there were errors building SandyBridge support. Both these options can also be used simultaneously. ***\033[0m
make[1]: *** [scratch/openblas-e8a68ef261a33568b0f0cf53e0e2287e9f12e69e/build-compiled] Error 1
make: *** [julia-deps] Error 2
```

This particular issue was introduced in https://github.com/xianyi/OpenBLAS/pull/1450 (bug appears in OpenBLAS v0.3.0).


The software bug fix (https://github.com/xianyi/OpenBLAS/pull/1787) first appeared in OpenBLAS v0.3.4, so OpenBLAS v0.3.0 to v0.3.3 are affected by this bug.

This pull request adds the bug fix as a patch to OpenBLAS v0.3.2 (Julia v1.0.3) during compilation.

In addition, this bug fix could be backported to Julia v0.7.0 (also uses OpenBLAS v0.3.2).