### PR TITLE
Capture pid in ProcessExitedException

### DIFF
--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1040,6 +1040,9 @@ struct ProcessExitedException <: Exception
     worker_id::Int
 end
 
+# No-arg constructor added for compatibility with Julia 1.0 & 1.1, should be deprecated in the future
+ProcessExitedException() = ProcessExitedException(-1)
+
 worker_from_id(i) = worker_from_id(PGRP, i)
 function worker_from_id(pg::ProcessGroup, i)
     if !isempty(map_del_wrkr) && in(i, map_del_wrkr)

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1031,13 +1031,13 @@ end
 
 
 """
-    ProcessExitedException(pid::Int)
+    ProcessExitedException(worker_id::Int)
 
 After a client Julia process has exited, further attempts to reference the dead child will
 throw this exception.
 """
 struct ProcessExitedException <: Exception
-    pid::Int
+    worker_id::Int
 end
 
 worker_from_id(i) = worker_from_id(PGRP, i)

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1140,7 +1140,7 @@ function deregister_worker(pg, pid)
 
         # throw exception to tasks waiting for this pid
         for (id, rv) in tonotify
-            close(rv.c, ProcessExitedException(id))
+            close(rv.c, ProcessExitedException(pid))
             delete!(pg.refs, id)
         end
     end

--- a/stdlib/Distributed/src/cluster.jl
+++ b/stdlib/Distributed/src/cluster.jl
@@ -1030,20 +1030,20 @@ function _rmprocs(pids, waitfor)
 end
 
 
-struct ProcessExitedException <: Exception end
-
 """
-    ProcessExitedException()
+    ProcessExitedException(pid::Int)
 
 After a client Julia process has exited, further attempts to reference the dead child will
 throw this exception.
 """
-ProcessExitedException()
+struct ProcessExitedException <: Exception
+    pid::Int
+end
 
 worker_from_id(i) = worker_from_id(PGRP, i)
 function worker_from_id(pg::ProcessGroup, i)
     if !isempty(map_del_wrkr) && in(i, map_del_wrkr)
-        throw(ProcessExitedException())
+        throw(ProcessExitedException(i))
     end
     w = get(map_pid_wrkr, i, nothing)
     if w === nothing
@@ -1137,7 +1137,7 @@ function deregister_worker(pg, pid)
 
         # throw exception to tasks waiting for this pid
         for (id, rv) in tonotify
-            close(rv.c, ProcessExitedException())
+            close(rv.c, ProcessExitedException(id))
             delete!(pg.refs, id)
         end
     end

--- a/stdlib/Distributed/src/precompile.jl
+++ b/stdlib/Distributed/src/precompile.jl
@@ -121,7 +121,6 @@ precompile(Tuple{getfield(Distributed, Symbol("#kw##remote_do")), Array{Any, 1},
 precompile(Tuple{Type{Distributed.ResultMsg}, Distributed.RemoteException})
 precompile(Tuple{Type{Distributed.ResultMsg}, Symbol})
 precompile(Tuple{typeof(Distributed.send_msg_now), Sockets.TCPSocket, Distributed.MsgHeader, Distributed.ResultMsg})
-precompile(Tuple{typeof(Base.notify), Base.Condition, Distributed.ProcessExitedException, Bool, Bool})
 precompile(Tuple{typeof(Base.pop!), Base.Dict{Int64, Union{Distributed.Worker, Distributed.LocalProcess}}, Int64, Nothing})
 precompile(Tuple{typeof(Distributed.deregister_worker), Distributed.ProcessGroup, Int64})
 precompile(Tuple{typeof(Distributed.process_hdr), Sockets.TCPSocket, Bool})


### PR DESCRIPTION
Would it be possible to capture the worker pid in `ProcessExitedException`?
For my purpose, I would like to know the pid of a failed worker to ultimately determine the host machine.

This RFC is really asking whether this would be feasible and/or desirable.
Here's a first stab at it. I don't know how to test locally, so here it is raw.
