### PR TITLE
Include pthread_np on FreeBSD

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -17,6 +17,10 @@
 #include <getopt.h>
 #endif
 
+#if defined(_OS_FREEBSD_)
+#include <pthread_np.h>
+#endif
+
 #include "julia.h"
 #include "julia_internal.h"
 #define DEFINE_BUILTIN_GLOBALS


### PR DESCRIPTION
This is where `pthread_attr_get_np` is defined, which is used in init.c.

Fixes #30735.