### PR TITLE
fix mismatch in max_methods between `return_type` and its t-func

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1335,11 +1335,11 @@ function return_type_tfunc(argtypes::Vector{Any}, vtypes::VarTable, sv::Inferenc
                     end
                     astype = argtypes_to_type(argtypes_vec)
                     if isa(aft, Const)
-                        rt = abstract_call(aft.val, (), argtypes_vec, vtypes, sv)
+                        rt = abstract_call(aft.val, (), argtypes_vec, vtypes, sv, -1)
                     elseif isconstType(aft)
-                        rt = abstract_call(aft.parameters[1], (), argtypes_vec, vtypes, sv)
+                        rt = abstract_call(aft.parameters[1], (), argtypes_vec, vtypes, sv, -1)
                     else
-                        rt = abstract_call_gf_by_type(nothing, argtypes_vec, astype, sv)
+                        rt = abstract_call_gf_by_type(nothing, argtypes_vec, astype, sv, -1)
                     end
                     if isa(rt, Const)
                         # output was computed to be constant

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2196,3 +2196,13 @@ j30385(T, y) = k30385(f30385(T, y))
 
 @test Base.return_types(Tuple, (NamedTuple{<:Any,Tuple{Any,Int}},)) == Any[Tuple{Any,Int}]
 @test Base.return_types(Base.splat(tuple), (typeof((a=1,)),)) == Any[Tuple{Int}]
+
+# test that return_type_tfunc isn't affected by max_methods differently than return_type
+_rttf_test(::Int8) = 0
+_rttf_test(::Int16) = 0
+_rttf_test(::Int32) = 0
+_rttf_test(::Int64) = 0
+_rttf_test(::Int128) = 0
+_call_rttf_test() = Core.Compiler.return_type(_rttf_test, Tuple{Any})
+@test Core.Compiler.return_type(_rttf_test, Tuple{Any}) === Int
+@test _call_rttf_test() === Int


### PR DESCRIPTION
It's good to be able to use a different `max_methods` (the maximum number of method matches to infer for a single call) in `return_type` than in inference generally. That allows us to change the compiler without changing program behavior as much (to the extent we haven't been able to convince people not to use `return_type` :smile: ).