### PR TITLE
add build option to reuse a previous precompile statement file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /julia-*
 /source-dist.tmp
 /source-dist.tmp1
+/contrib/precompile_statements.jl
 
 *.exe
 *.dll

--- a/Make.inc
+++ b/Make.inc
@@ -13,6 +13,8 @@
 # Julia precompilation options
 # Set to zero to turn off extra precompile (e.g. for the REPL)
 JULIA_PRECOMPILE ?= 1
+# Set to 1 to try reuse precompile file from earlier build
+JULIA_REUSE_PRECOMPILE ?= 0
 
 FORCE_ASSERTIONS ?= 0
 

--- a/contrib/generate_precompile.jl
+++ b/contrib/generate_precompile.jl
@@ -3,6 +3,11 @@
 if isempty(ARGS) || ARGS[1] !== "0"
 # Prevent this from being put into the Main namespace
 @eval Module() begin
+REUSE_PRECOMPILE = false
+if !isempty(ARGS)
+    length(ARGS) >= 2 && ARGS[2] == "1" && (REUSE_PRECOMPILE = true)
+end
+
 if !isdefined(Base, :uv_eventloop)
     Base.reinit_stdio()
 end
@@ -40,6 +45,8 @@ cd("complet_path\t\t$CTRL_C
 """
 
 julia_exepath() = joinpath(Sys.BINDIR, Base.julia_exename())
+
+PRECOMPILE_FILE = joinpath(@__DIR__, "precompile_statements.jl")
 
 have_repl =  haskey(Base.loaded_modules,
                     Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL"))
@@ -85,121 +92,148 @@ function generate_precompile_statements()
     end
 
     print("Generating precompile statements...")
-    mktemp() do precompile_file, precompile_file_h
-        # Run a repl process and replay our script
-        pty_slave, pty_master = open_fake_pty()
-        blackhole = Sys.isunix() ? "/dev/null" : "nul"
-        if have_repl
-            cmdargs = ```--color=yes
-                      -e 'import REPL; REPL.Terminals.is_precompiling[] = true'
-                      ```
-        else
-            cmdargs = `-e nothing`
-        end
-        p = withenv("JULIA_HISTORY" => blackhole,
-                    "JULIA_PROJECT" => nothing, # remove from environment
-                    "JULIA_LOAD_PATH" => Sys.iswindows() ? "@;@stdlib" : "@:@stdlib",
-                    "TERM" => "") do
-            sysimg = Base.unsafe_string(Base.JLOptions().image_file)
-            run(```$(julia_exepath()) -O0 --trace-compile=$precompile_file --sysimage $sysimg
-                   --cpu-target=native --startup-file=no --color=yes
-                   -e 'import REPL; REPL.Terminals.is_precompiling[] = true'
-                   -i $cmdargs```,
-                pty_slave, pty_slave, pty_slave; wait=false)
-        end
-        Base.close_stdio(pty_slave)
-        # Prepare a background process to copy output from process until `pty_slave` is closed
-        output_copy = Base.BufferStream()
-        tee = @async try
-            while !eof(pty_master)
-                l = readavailable(pty_master)
-                write(debug_output, l)
-                Sys.iswindows() && (sleep(0.1); yield(); yield()) # workaround hang - probably a libuv issue?
-                write(output_copy, l)
-            end
-            close(output_copy)
-            close(pty_master)
-        catch ex
-            close(output_copy)
-            close(pty_master)
-            if !(ex isa Base.IOError && ex.code == Base.UV_EIO)
-                rethrow() # ignore EIO on pty_master after pty_slave dies
-            end
-        end
-        # wait for the definitive prompt before start writing to the TTY
-        readuntil(output_copy, "julia>")
-        sleep(0.1)
-        readavailable(output_copy)
-        # Input our script
-        if have_repl
-            for l in split(precompile_script, '\n'; keepempty=false)
-                sleep(0.1)
-                # consume any other output
-                bytesavailable(output_copy) > 0 && readavailable(output_copy)
-                # push our input
-                write(debug_output, "\n#### inputting statement: ####\n$(repr(l))\n####\n")
-                write(pty_master, l, "\n")
-                readuntil(output_copy, "\n")
-                # wait for the next prompt-like to appear
-                # NOTE: this is rather innaccurate because the Pkg REPL mode is a special flower
-                readuntil(output_copy, "\n")
-                readuntil(output_copy, "> ")
-            end
-        end
-        write(pty_master, "exit()\n")
-        wait(tee)
-        success(p) || Base.pipeline_error(p)
-        close(pty_master)
-        write(debug_output, "\n#### FINISHED ####\n")
-
-        # Extract the precompile statements from the precompile file
-        statements = Set{String}()
-        for statement in eachline(precompile_file_h)
-            # Main should be completely clean
-            occursin("Main.", statement) && continue
-            push!(statements, statement)
-        end
-
-        for statement in split(hardcoded_precompile_statements, '\n')
-            push!(statements, statement)
-        end
-
-        # Create a staging area where all the loaded packages are available
-        PrecompileStagingArea = Module()
-        for (_pkgid, _mod) in Base.loaded_modules
-            if !(_pkgid.name in ("Main", "Core", "Base"))
-                eval(PrecompileStagingArea, :(const $(Symbol(_mod)) = $_mod))
-            end
-        end
-
-        # Execute the collected precompile statements
-        n_succeeded = 0
-        include_time = @elapsed for statement in sort(collect(statements))
-            # println(statement)
-            try
-                Base.include_string(PrecompileStagingArea, statement)
-                n_succeeded += 1
-            catch
-                # See #28808
-                # @error "Failed to precompile $statement"
-            end
-        end
-        if have_repl
-            # Seems like a reasonable number right now, adjust as needed
-            # comment out if debugging script
-            @assert n_succeeded > 1500
-        end
-
-        print(" $(length(statements)) generated in ")
-        tot_time = time_ns() - start_time
-        Base.time_print(tot_time)
-        print(" (overhead "); Base.time_print(tot_time - (include_time * 1e9)); println(")")
+    # Run a repl process and replay our script
+    pty_slave, pty_master = open_fake_pty()
+    blackhole = Sys.isunix() ? "/dev/null" : "nul"
+    if have_repl
+        cmdargs = ```--color=yes
+                  -e 'import REPL; REPL.Terminals.is_precompiling[] = true'
+                  ```
+    else
+        cmdargs = `-e nothing`
     end
+    p = withenv("JULIA_HISTORY" => blackhole,
+                "JULIA_PROJECT" => nothing, # remove from environment
+                "JULIA_LOAD_PATH" => Sys.iswindows() ? "@;@stdlib" : "@:@stdlib",
+                "TERM" => "") do
+        sysimg = Base.unsafe_string(Base.JLOptions().image_file)
+        run(```$(julia_exepath()) -O0 --trace-compile=$PRECOMPILE_FILE --sysimage $sysimg
+               --cpu-target=native --startup-file=no --color=yes
+               -e 'import REPL; REPL.Terminals.is_precompiling[] = true'
+               -i $cmdargs```,
+            pty_slave, pty_slave, pty_slave; wait=false)
+    end
+    Base.close_stdio(pty_slave)
+    # Prepare a background process to copy output from process until `pty_slave` is closed
+    output_copy = Base.BufferStream()
+    tee = @async try
+        while !eof(pty_master)
+            l = readavailable(pty_master)
+            write(debug_output, l)
+            Sys.iswindows() && (sleep(0.1); yield(); yield()) # workaround hang - probably a libuv issue?
+            write(output_copy, l)
+        end
+        close(output_copy)
+        close(pty_master)
+    catch ex
+        close(output_copy)
+        close(pty_master)
+        if !(ex isa Base.IOError && ex.code == Base.UV_EIO)
+            rethrow() # ignore EIO on pty_master after pty_slave dies
+        end
+    end
+    # wait for the definitive prompt before start writing to the TTY
+    readuntil(output_copy, "julia>")
+    sleep(0.1)
+    readavailable(output_copy)
+    # Input our script
+    if have_repl
+        for l in split(precompile_script, '\n'; keepempty=false)
+            sleep(0.1)
+            # consume any other output
+            bytesavailable(output_copy) > 0 && readavailable(output_copy)
+            # push our input
+            write(debug_output, "\n#### inputting statement: ####\n$(repr(l))\n####\n")
+            write(pty_master, l, "\n")
+            readuntil(output_copy, "\n")
+            # wait for the next prompt-like to appear
+            # NOTE: this is rather innaccurate because the Pkg REPL mode is a special flower
+            readuntil(output_copy, "\n")
+            readuntil(output_copy, "> ")
+        end
+    end
+    write(pty_master, "exit()\n")
+    wait(tee)
+    success(p) || Base.pipeline_error(p)
+    close(pty_master)
+    write(debug_output, "\n#### FINISHED ####\n")
 
+    include_time, n_statements = load_precompile_statements(PRECOMPILE_FILE)
+
+    print(" $n_statements generated in ")
+    tot_time = time_ns() - start_time
+    Base.time_print(tot_time)
+
+    print(" (overhead "); Base.time_print((tot_time - include_time)); println(")")
     return
 end
 
-generate_precompile_statements()
+function load_precompile_statements(precompile_file)
+    # Extract the precompile statements from the precompile file
+    statements = Set{String}()
+    for statement in eachline(precompile_file)
+        # Main should be completely clean
+        occursin("Main.", statement) && continue
+        push!(statements, statement)
+    end
+
+    for statement in split(hardcoded_precompile_statements, '\n')
+        push!(statements, statement)
+    end
+
+    # Create a staging area where all the loaded packages are available
+    PrecompileStagingArea = Module()
+    for (_pkgid, _mod) in Base.loaded_modules
+        if !(_pkgid.name in ("Main", "Core", "Base"))
+            eval(PrecompileStagingArea, :(const $(Symbol(_mod)) = $_mod))
+        end
+    end
+
+    # Execute the collected precompile statements
+    n_succeeded = 0
+    include_time = @elapsed for statement in sort(collect(statements))
+        # println(statement)
+        try
+            Base.include_string(PrecompileStagingArea, statement)
+            n_succeeded += 1
+        catch
+            # See #28808
+            # @error "Failed to precompile $statement"
+        end
+    end
+    if have_repl
+        # Seems like a reasonable number right now, adjust as needed
+        # comment out if debugging script
+        # @assert n_succeeded > 1500
+    end
+    return include_time*10^9, length(statements)
+end
+
+function do_precompile()
+    if REUSE_PRECOMPILE
+        if isfile(PRECOMPILE_FILE)
+            println("Trying to reuse precompile statements from $(repr(abspath(PRECOMPILE_FILE)))")
+            reuse_success = true
+            local include_time, n_statements
+            try
+                include_time, n_statements = load_precompile_statements(PRECOMPILE_FILE)
+            catch e
+                println("Failed to reuse precompile statements")
+                Base.showerror(stdout, e, catch_backtrace())
+                reuse_success = false
+            end
+            if reuse_success
+                print("$n_statements precompile statements loaded in ")
+                Base.time_print(include_time)
+                println()
+                return
+            end
+        end
+    end
+    generate_precompile_statements()
+end
+
+do_precompile()
 
 end # @eval
 end

--- a/sysimage.mk
+++ b/sysimage.mk
@@ -76,7 +76,7 @@ define sysimg_builder
 $$(build_private_libdir)/sys$1-o.a $$(build_private_libdir)/sys$1-bc.a : $$(build_private_libdir)/sys$1-%.a : $$(build_private_libdir)/sys.ji
 	@$$(call PRINT_JULIA, cd $$(JULIAHOME)/base && \
 	if ! JULIA_BINDIR=$$(call cygpath_w,$(build_bindir)) $$(call spawn, $3) $2 -C "$$(JULIA_CPU_TARGET)" --output-$$* $$(call cygpath_w,$$@).tmp $$(JULIA_SYSIMG_BUILD_FLAGS) \
-		--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE); then \
+		--startup-file=no --warn-overwrite=yes --sysimage $$(call cygpath_w,$$<) $$(call cygpath_w,$$(JULIAHOME)/contrib/generate_precompile.jl) $(JULIA_PRECOMPILE) $(JULIA_REUSE_PRECOMPILE); then \
 		echo '*** This error is usually fixed by running `make clean`. If the error persists$$(COMMA) try `make cleanall`. ***'; \
 		false; \
 	fi )


### PR DESCRIPTION
Often, regenerating all precompile statements from scratch is not needed and kind of annoying. During print out of the timing stats for precompile generation, e.g.:

```
Generating precompile statements... 1083 generated in  96.365000 seconds (overhead  80.354744 seconds)
```

the "overhead" time is the time spent running everything that generates the statements. The rest of the time is actually including them, which is typically significantly shorter.

This PR saves the precompile statements from a build in a persistent file and one can with a setting in `Make.user` (`JULIA_REUSE_PRECOMPILE=1`) chose to use that existing file instead of regenerating a new one. If using the old precompile file fails, a new one will be generated. So reusing the previous one is a bit quicker:

```
Trying to reuse precompile statements from "C:\\Users\\Kristoffer\\julia\\contrib\\precompile_statements.jl"
1083 precompile statements loaded in  16.833387 seconds
```