### PR TITLE
rm incorrect `copysign` methods for Unsigned second argument

### DIFF
--- a/base/sysimg.jl
+++ b/base/sysimg.jl
@@ -395,11 +395,6 @@ using .Enums
 include("gmp.jl")
 using .GMP
 
-for T in [Signed, Integer, BigInt, Float32, Float64, Real, Complex, Rational]
-    @eval flipsign(x::$T, ::Unsigned) = +x
-    @eval copysign(x::$T, ::Unsigned) = +x
-end
-
 include("mpfr.jl")
 using .MPFR
 big(n::Integer) = convert(BigInt,n)

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -592,6 +592,17 @@ end
     # test x = Inf
     @test isinf(copysign(1/0,1))
     @test isinf(copysign(1/0,-1))
+
+    # with Unsigned argument
+    @test copysign(Float16(-1), 0x01) === Float16(1)
+    @test copysign(Float16(1), 0x01) === Float16(1)
+    @test copysign(-1.0f0, 0x01) === 1.0f0
+    @test copysign(1.0f0, 0x01) === 1.0f0
+    @test copysign(-1.0, 0x01) === 1.0
+    @test copysign(-1, 0x02) === 1
+    @test copysign(big(-1), 0x02) == 1
+    @test copysign(big(-1.0), 0x02) == 1.0
+    @test copysign(-1//2, 0x01) == 1//2
 end
 
 @testset "isnan/isinf/isfinite" begin


### PR DESCRIPTION
`copysign` gives the wrong answer when its second argument is Unsigned.

This also removes the only method of `copysign` for Complex, which is slightly breaking, but it's highly unlikely anybody calls `copysign(::Complex, ::Unsigned)`, especially since it doesn't do anything useful.