### PR TITLE
Handle :error and :invalid expressions gracefully in REPL helpmode

### DIFF
--- a/stdlib/REPL/src/docview.jl
+++ b/stdlib/REPL/src/docview.jl
@@ -21,13 +21,13 @@ helpmode(line::AbstractString) = helpmode(stdout, line)
 
 function _helpmode(io::IO, line::AbstractString)
     line = strip(line)
+    x = Meta.parse(line, raise = false, depwarn = false)
     expr =
-        if haskey(keywords, Symbol(line))
+        if haskey(keywords, Symbol(line)) || isexpr(x, :error) || isexpr(x, :invalid)
             # Docs for keywords must be treated separately since trying to parse a single
             # keyword such as `function` would throw a parse error due to the missing `end`.
             Symbol(line)
         else
-            x = Meta.parse(line, raise = false, depwarn = false)
             # Retrieving docs for macros requires us to make a distinction between the text
             # `@macroname` and `@macroname()`. These both parse the same, but are used by
             # the docsystem to return different results. The first returns all documentation

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -972,6 +972,12 @@ for (line, expr) in Pair[
     @test Base.eval(REPL._helpmode(buf, line)) isa Union{Markdown.MD,Nothing}
 end
 
+# PR 30754, Issues #22013, #24871, #26933, #29282, #29361, #30348
+for line in ["′", "abstract", "type", "|=", ".="]
+    @test occursin("No documentation found.",
+        sprint(show, Base.eval(REPL._helpmode(IOBuffer(), line))::Union{Markdown.MD,Nothing}))
+end
+
 # PR #27562
 fake_repl() do stdin_write, stdout_read, repl
     repltask = @async begin


### PR DESCRIPTION
fixes #22013, fixes #24871, fixes #26933,
fixes #29282, fixes #29361 and fixes #30348.