### PR TITLE
Rf/autoindentpaste improvements

### DIFF
--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -726,15 +726,18 @@ end
 function edit_insert_newline(s::PromptState, align::Int = 0 - options(s).auto_indent)
     push_undo(s)
     buf = buffer(s)
-    if align < 0
+    autoindent = align < 0
+    if autoindent
         beg = beginofline(buf)
         align = min(something(findnext(_notspace, buf.data[beg+1:buf.size], 1), 0) - 1,
                     position(buf) - beg) # indentation must not increase
         align < 0 && (align = buf.size-beg)
     end
     edit_insert(buf, '\n' * ' '^align)
-    align > 0 && (s.last_newline = time())
     refresh_line(s)
+    # updating s.last_newline should happen after refresh_line(s) which can take
+    # an unpredictable amount of time and makes "paste detection" unreliable
+    autoindent && align > 0 && (s.last_newline = time())
 end
 
 # align: delete up to 4 spaces to align to a multiple of 4 chars

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -680,22 +680,29 @@ end
 edit_splice!(s, ins::AbstractString) = edit_splice!(s, region(s), ins)
 
 function edit_insert(s::PromptState, c)
-    if time() - s.last_newline < options(s).auto_indent_time_threshold
-        # the first inserted character since last newline was inserted very fast,
-        # so it must have been inserted automatically (e.g. "paste" which is not
-        # recognized as so)
-        buf = buffer(s)
-        pos = position(buf)
-        nl = findprev(c -> c == _newline, buf.data, pos)::Int
-        seek(buf, nl)
-        # delete auto-inserted spaces
-        edit_splice!(buf, nl => pos)
-        s.last_newline = -Inf
-        refresh_line(s) # necessary, as the code below doesn't do it necessarily
-    end
-
     push_undo(s)
     buf = s.input_buffer
+
+    if ! options(s).auto_indent_bracketed_paste
+        pos=position(buf)
+        if pos > 0
+            if buf.data[pos] != _space && string(c) != " "
+                options(s).auto_indent_tmp_off = false
+            end
+            if buf.data[pos] == _space
+                #tabulators are already expanded to space
+                #this expansion may take longer than auto_indent_time_threshold which breaks the timing
+                s.last_newline = time()
+            else
+                #if characters after new line are coming in very fast
+                #its probably copy&paste => switch auto-indent off for the next coming new line
+                if ! options(s).auto_indent_tmp_off && time() - s.last_newline < options(s).auto_indent_time_threshold
+                    options(s).auto_indent_tmp_off = true
+                end
+            end
+        end
+    end
+
     str = string(c)
     edit_insert(buf, str)
     offset = s.ias.curs_row == 1 || s.indent < 0 ?
@@ -727,17 +734,21 @@ function edit_insert_newline(s::PromptState, align::Int = 0 - options(s).auto_in
     push_undo(s)
     buf = buffer(s)
     autoindent = align < 0
-    if autoindent
+    if autoindent && ! options(s).auto_indent_tmp_off
         beg = beginofline(buf)
         align = min(something(findnext(_notspace, buf.data[beg+1:buf.size], 1), 0) - 1,
                     position(buf) - beg) # indentation must not increase
         align < 0 && (align = buf.size-beg)
+    else
+        align = 0
     end
     edit_insert(buf, '\n' * ' '^align)
     refresh_line(s)
     # updating s.last_newline should happen after refresh_line(s) which can take
     # an unpredictable amount of time and makes "paste detection" unreliable
-    autoindent && align > 0 && (s.last_newline = time())
+    if ! options(s).auto_indent_bracketed_paste
+        s.last_newline = time()
+    end
 end
 
 # align: delete up to 4 spaces to align to a multiple of 4 chars
@@ -1937,6 +1948,7 @@ function commit_line(s)
 end
 
 function bracketed_paste(s; tabwidth=options(s).tabwidth)
+    options(s).auto_indent_bracketed_paste = true
     ps = state(s, mode(s))
     input = readuntil(ps.terminal, "\e[201~")
     input = replace(input, '\r' => '\n')

--- a/stdlib/REPL/src/LineEdit.jl
+++ b/stdlib/REPL/src/LineEdit.jl
@@ -739,9 +739,10 @@ function edit_insert_newline(s::PromptState, align::Int = 0 - options(s).auto_in
         align = min(something(findnext(_notspace, buf.data[beg+1:buf.size], 1), 0) - 1,
                     position(buf) - beg) # indentation must not increase
         align < 0 && (align = buf.size-beg)
-    else
-        align = 0
+    #else
+    #    align = 0
     end
+	align < 0 && (align = 0)
     edit_insert(buf, '\n' * ' '^align)
     refresh_line(s)
     # updating s.last_newline should happen after refresh_line(s) which can take

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -273,6 +273,8 @@ mutable struct Options
     backspace_adjust::Bool
     confirm_exit::Bool # ^D must be repeated to confirm exit
     auto_indent::Bool # indent a newline like line above
+    # cancel auto-indent when next character is entered within this time frame :
+    auto_indent_time_threshold::Float64
 end
 
 Options(;
@@ -286,12 +288,14 @@ Options(;
         beep_use_current = true,
         backspace_align = true, backspace_adjust = backspace_align,
         confirm_exit = false,
-        auto_indent = true) =
+        auto_indent = true,
+        auto_indent_time_threshold = 0.005) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
                     beep_duration, beep_blink, beep_maxduration,
                     beep_colors, beep_use_current,
-                    backspace_align, backspace_adjust, confirm_exit, auto_indent)
+                    backspace_align, backspace_adjust, confirm_exit,
+                    auto_indent, auto_indent_time_threshold)
 
 # for use by REPLs not having an options field
 const GlobalOptions = Options()

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -273,6 +273,8 @@ mutable struct Options
     backspace_adjust::Bool
     confirm_exit::Bool # ^D must be repeated to confirm exit
     auto_indent::Bool # indent a newline like line above
+    auto_indent_tmp_off::Bool # switch auto_indent temporarily off if copy&paste
+    auto_indent_bracketed_paste::Bool # set to true if terminal knows paste mode
     # cancel auto-indent when next character is entered within this time frame :
     auto_indent_time_threshold::Float64
 end
@@ -289,13 +291,15 @@ Options(;
         backspace_align = true, backspace_adjust = backspace_align,
         confirm_exit = false,
         auto_indent = true,
+        auto_indent_tmp_off = false,
+        auto_indent_bracketed_paste = false,
         auto_indent_time_threshold = 0.005) =
             Options(hascolor, extra_keymap, tabwidth,
                     kill_ring_max, region_animation_duration,
                     beep_duration, beep_blink, beep_maxduration,
                     beep_colors, beep_use_current,
                     backspace_align, backspace_adjust, confirm_exit,
-                    auto_indent, auto_indent_time_threshold)
+                    auto_indent, auto_indent_tmp_off, auto_indent_bracketed_paste, auto_indent_time_threshold)
 
 # for use by REPLs not having an options field
 const GlobalOptions = Options()

--- a/stdlib/REPL/test/lineedit.jl
+++ b/stdlib/REPL/test/lineedit.jl
@@ -9,7 +9,9 @@ include("FakeTerminals.jl")
 import .FakeTerminals.FakeTerminal
 
 # no need to have animation in tests
-REPL.GlobalOptions.region_animation_duration=0.001
+REPL.GlobalOptions.region_animation_duration=0.0001
+# tests are inserting code much faster than humans
+REPL.GlobalOptions.auto_indent_time_threshold = -0.0
 
 ## helper functions
 


### PR DESCRIPTION
Improvements based on rf/autoindentpaste
https://github.com/JuliaLang/julia/tree/rf/autoindentpaste

For additional issues which are solved by this PR see
https://discourse.julialang.org/t/repl-copy-paste-and-auto-indent-in-julia-0-7/10230
e.g. pasting a mix of space and tabs and empty lines at once still break autoindentation

This PR replaces the PR of @rfourquet:
https://github.com/JuliaLang/julia/pull/29129
