### PR TITLE
Clarify that `repr` should make julia code

### DIFF
--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -179,15 +179,17 @@ end
 """
     repr(x; context=nothing)
 
-Create a string from any value using the [`show`](@ref) function.
+Create a representation of `x` similar to how `x` would be defined in Julia code.
+In general `eval(Mata.parse(repr(x)))` should be equal to `x`,
+where this is not possible `repr(x)` should not `parse`.
 
-The optional keyword argument `context` can be set to an `IO` or [`IOContext`](@ref)
-object whose attributes are used for the I/O stream passed to `show`.
-
-Note that `repr(x)` is usually similar to how the value of `x` would
-be entered in Julia.  See also [`repr(MIME("text/plain"), x)`](@ref) to instead
+See also [`repr(MIME("text/plain"), x)`](@ref) to instead
 return a "pretty-printed" version of `x` designed more for human consumption,
 equivalent to the REPL display of `x`.
+
+By default `repr` falls back to the [`show`](@ref) function.
+The optional keyword argument `context` can be set to an `IO` or [`IOContext`](@ref)
+object whose attributes are used for the I/O stream passed to `show`.
 
 # Examples
 ```jldoctest

--- a/base/strings/io.jl
+++ b/base/strings/io.jl
@@ -180,7 +180,7 @@ end
     repr(x; context=nothing)
 
 Create a representation of `x` similar to how `x` would be defined in Julia code.
-In general `eval(Mata.parse(repr(x)))` should be equal to `x`,
+In general `eval(Meta.parse(repr(x)))` should be equal to `x`,
 where this is not possible `repr(x)` should not `parse`.
 
 See also [`repr(MIME("text/plain"), x)`](@ref) to instead


### PR DESCRIPTION
The docs currently are descriptive, they say "this **usually** make",
this changers them to be perscriptive, saying "this **should** make".

A problem with this is that the docstring under this PR is now written to be read by an implementer,
not by a user.
An alternative would be to put this presriptive statment in a _Note to Implementors_
bit at the bottom.

Here is the [equivalent  python docs](https://docs.python.org/3/reference/datamodel.html#object.__repr__)

>  object.__repr__(self)
>
>    Called by the repr() built-in function to compute the “official” string representation of an object. If at all possible, this should look like a valid Python expression that could be used to recreate an object with the same value (given an appropriate environment). If this is not possible, a string of the form <...some useful description...> should be returned. The return value must be a string object. If a class defines __repr__() but not __str__(), then __repr__() is also used when an “informal” string representation of instances of that class is required.
>
>    This is typically used for debugging, so it is important that the representation is information-rich and unambiguous.



@omus  this is re: our discussion yesterday.



