### PR TITLE
added iterate method for Missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Language changes
 ----------------
 
 * `Enum` now behaves like a scalar when used in broadcasting ([#30670]).
+* `Missing` now behaves like `Number` when iterated on ([#30760]).
 
 Command-line option changes
 ---------------------------

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -149,6 +149,9 @@ function float(A::AbstractArray{Union{T, Missing}}) where {T}
 end
 float(A::AbstractArray{Missing}) = A
 
+iterate(x::Missing) = (x, nothing)
+iterate(x::Missing, ::Any) = nothing
+
 """
     skipmissing(itr)
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -335,6 +335,11 @@ end
     @test float([missing]) isa Vector{Missing}
 end
 
+@testset "iterate" begin
+    @test isequal(iterate(missing), (missing, nothing))
+    @test isequal(iterate(missing, 1), nothing)
+end
+
 @testset "skipmissing" begin
     x = skipmissing([1, 2, missing, 4])
     @test eltype(x) === Int


### PR DESCRIPTION
This PR defines `iterate` for `Missing` consistently with `Number`, and has the side effect of addressing #30756. Is the definition in the best place? Are any tests required?