### PR TITLE
Fix RemoteChannel example in parallel-computing.md

### DIFF
--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -1088,7 +1088,7 @@ julia> for p in workers() # start tasks on the workers to process requests in pa
 julia> @elapsed while n > 0 # print out results
            job_id, exec_time, where = take!(results)
            println("$job_id finished in $(round(exec_time; digits=2)) seconds on worker $where")
-           n = n - 1
+           global n = n - 1
        end
 1 finished in 0.18 seconds on worker 4
 2 finished in 0.26 seconds on worker 5


### PR DESCRIPTION
The example demonstrating the use of RemoteChannel does not work in Julia 0.7+,
due to new scoping of variables inside of for loops. Consequently, the example
would not work as intended. Adding global scope to the variable corrects this
problem.