### PR TITLE
faster dense kron

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -345,12 +345,11 @@ julia> kron(A, B)
 function kron(a::AbstractMatrix{T}, b::AbstractMatrix{S}) where {T,S}
     require_one_based_indexing(a, b)
     R = Matrix{promote_op(*,T,S)}(undef, size(a,1)*size(b,1), size(a,2)*size(b,2))
-    m = 1
-    for j = 1:size(a,2), l = 1:size(b,2), i = 1:size(a,1)
+    m = 0
+    @inbounds for j = 1:size(a,2), l = 1:size(b,2), i = 1:size(a,1)
         aij = a[i,j]
         for k = 1:size(b,1)
-            R[m] = aij*b[k,l]
-            m += 1
+            R[m += 1] = aij*b[k,l]
         end
     end
     R


### PR DESCRIPTION
Simple optimization with high reward for dense `kron`. Saves one line ;-)


MASTER:

```
a=rand(20,20);

julia> @benchmark kron($a,$a)
BenchmarkTools.Trial: 
  memory estimate:  1.22 MiB
  allocs estimate:  2
  --------------
  minimum time:     124.824 μs (0.00% GC)
  median time:      134.279 μs (0.00% GC)
  mean time:        207.965 μs (8.57% GC)
  maximum time:     27.515 ms (98.35% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

PR

```
julia> @benchmark kron($a,$a)
BenchmarkTools.Trial: 
  memory estimate:  1.22 MiB
  allocs estimate:  2
  --------------
  minimum time:     64.399 μs (0.00% GC)
  median time:      84.397 μs (0.00% GC)
  mean time:        112.454 μs (11.47% GC)
  maximum time:     28.646 ms (98.90% GC)
  --------------
  samples:          10000
  evals/sample:     1
```