### PR TITLE
implement copyto!(::SparseVector, ::AbstractArray)

### DIFF
--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -470,6 +470,13 @@ function copyto!(A::SparseVector, B::SparseVector)
     return A
 end
 
+function copyto!(A::SparseVector, B::AbstractArray)
+    prep_sparsevec_copy_dest!(A::SparseVector, length(B), length(B))
+    copyto!(A.nzind, 1:length(B))
+    copyto!(A.nzval, B)
+    return A
+end
+
 function copyto!(A::SparseVector, B::SparseMatrixCSC)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))
 

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -470,12 +470,7 @@ function copyto!(A::SparseVector, B::SparseVector)
     return A
 end
 
-function copyto!(A::SparseVector, B::AbstractArray)
-    prep_sparsevec_copy_dest!(A::SparseVector, length(B), length(B))
-    copyto!(A.nzind, 1:length(B))
-    copyto!(A.nzval, B)
-    return A
-end
+copyto!(A::SparseVector, B::AbstractArray) = copyto!(A, sparse(B))
 
 function copyto!(A::SparseVector, B::SparseMatrixCSC)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -470,7 +470,7 @@ function copyto!(A::SparseVector, B::SparseVector)
     return A
 end
 
-copyto!(A::SparseVector, B::AbstractArray) = copyto!(A, sparsevec(B))
+copyto!(A::SparseVector, B::AbstractVector) = copyto!(A, sparsevec(B))
 
 function copyto!(A::SparseVector, B::SparseMatrixCSC)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -470,7 +470,7 @@ function copyto!(A::SparseVector, B::SparseVector)
     return A
 end
 
-copyto!(A::SparseVector, B::AbstractArray) = copyto!(A, sparse(B))
+copyto!(A::SparseVector, B::AbstractArray) = copyto!(A, sparsevec(B))
 
 function copyto!(A::SparseVector, B::SparseMatrixCSC)
     prep_sparsevec_copy_dest!(A, length(B), nnz(B))


### PR DESCRIPTION
To avoid the slow `AbstractArray` fallback. [See here](https://github.com/JuliaLang/julia/pull/30531#issuecomment-450683079)

```
julia> y=sprand(100000,0.1); x=rand(10_000);

julia> x2=copy(y); @benchmark copyto!($x2, $x)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     338.034 μs (0.00% GC)
  median time:      347.306 μs (0.00% GC)
  mean time:        351.380 μs (0.00% GC)
  maximum time:     1.147 ms (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     1
```

PR

```
julia> x3=copy(y); @benchmark copyto!($x3, $x)
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     2.657 μs (0.00% GC)
  median time:      2.722 μs (0.00% GC)
  mean time:        2.763 μs (0.00% GC)
  maximum time:     6.791 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     9

```