### PR TITLE
add efficient `findfirst` method for `StepRange`

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1741,6 +1741,13 @@ end
 findfirst(testf::Function, A::Union{AbstractArray, AbstractString}) =
     findnext(testf, A, first(keys(A)))
 
+function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
+    first(r) <= p.x <= last(r) || return nothing
+    d = convert(S, p.x - first(r))
+    iszero(d % step(r)) || return nothing
+    return d ÷ step(r) + 1
+end
+
 """
     findprev(A, i)
 

--- a/base/range.jl
+++ b/base/range.jl
@@ -996,6 +996,13 @@ in(x::AbstractChar, r::AbstractRange{<:AbstractChar}) =
     !isempty(r) && x >= minimum(r) && x <= maximum(r) &&
         (mod(Int(x) - Int(first(r)), step(r)) == 0)
 
+function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
+    first(r) <= p.x <= last(r) || return nothing
+    d = convert(S, p.x - first(r))
+    iszero(d % step(r)) || return nothing
+    return d ÷ step(r) + 1
+end
+
 # Addition/subtraction of ranges
 
 function _define_range_op(@nospecialize f)

--- a/base/range.jl
+++ b/base/range.jl
@@ -996,13 +996,6 @@ in(x::AbstractChar, r::AbstractRange{<:AbstractChar}) =
     !isempty(r) && x >= minimum(r) && x <= maximum(r) &&
         (mod(Int(x) - Int(first(r)), step(r)) == 0)
 
-function findfirst(p::Union{Fix2{typeof(isequal),T},Fix2{typeof(==),T}}, r::StepRange{T,S}) where {T,S}
-    first(r) <= p.x <= last(r) || return nothing
-    d = convert(S, p.x - first(r))
-    iszero(d % step(r)) || return nothing
-    return d ÷ step(r) + 1
-end
-
 # Addition/subtraction of ranges
 
 function _define_range_op(@nospecialize f)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -269,6 +269,12 @@ end
             @test findall(in(span), r) == 1:6
         end
     end
+    @testset "findfirst" begin
+        @test findfirst(isequal(7), 1:2:10) == 4
+        @test findfirst(==(7), 1:2:10) == 4
+        @test findfirst(==(10), 1:2:10) == nothing
+        @test findfirst(==(11), 1:2:10) == nothing
+    end
     @testset "reverse" begin
         @test reverse(reverse(1:10)) == 1:10
         @test reverse(reverse(typemin(Int):typemax(Int))) == typemin(Int):typemax(Int)


### PR DESCRIPTION
Several functions like `sum`, `reverse`, etc. have efficient (O(1)) methods for ranges implemented in Base.
This PR adds such method for `findfirst`, where the predicate is equality, and the iterable is a `StepRange`.

before
```julia-repl
julia> @btime findfirst(==(10^5), 1:3:10^6)
  27.386 μs (3 allocations: 64 bytes)
33334
```
after
```julia-repl
julia> @btime findfirst(==(10^5), 1:3:10^6)
  15.881 ns (0 allocations: 0 bytes)
33334
```