### PR TITLE
Implement @big macro for making an entire expression arbitrary precision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ New language features
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
 
-* Added `@big` macro that converts all numeric literals in an expression to arbitrary precision
+* Added `@big` macro that converts all numeric literals in an expression to arbitrary precision ([#30779])
 
 Multi-threading changes
 -----------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ New language features
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
 
+* Added `@big` macro that converts all numeric literals in an expression to arbitrary precision
+
 Multi-threading changes
 -----------------------
 

--- a/base/mpfr.jl
+++ b/base/mpfr.jl
@@ -4,7 +4,8 @@ module MPFR
 
 export
     BigFloat,
-    setprecision
+    setprecision,
+    @big
 
 import
     .Base: *, +, -, /, <, <=, ==, >, >=, ^, ceil, cmp, convert, copysign, div,
@@ -1029,6 +1030,31 @@ end
 function Base.lerpi(j::Integer, d::Integer, a::BigFloat, b::BigFloat)
     t = BigFloat(j)/d
     fma(t, b, fma(-t, a, a))
+end
+
+
+walk(x, inner, outer) = outer(x)
+walk(x::Expr, inner, outer) = outer(Expr(x.head, map(inner, x.args)...))
+postwalk(f, x) = walk(x, x -> postwalk(f, x), f)
+
+"""
+    @big
+A macro that converts all enclosed numeric literals to their `big` versions, allowing
+for arbitrary precision arithmetic without converting each numeric literal by hand.
+See also [`big`](@ref), [`BigInt`](@ref), [`BigFloat`](@ref)
+```julia-repl
+julia> factorial(100)/factorial(99)
+ERROR: OverflowError: 100 is too large to look up in the table
+Stacktrace:
+ [1] factorial_lookup(::Int64, ::Array{Int64,1}, ::Int64) at ./combinatorics.jl:19
+ [2] factorial(::Int64) at ./combinatorics.jl:27
+ [3] top-level scope at none:0
+
+julia> @big factorial(100)/factorial(99)
+100.0
+"""
+macro big(ex)
+    postwalk(x -> x isa Number ? big(x) : x, ex)
 end
 
 end #module

--- a/base/util.jl
+++ b/base/util.jl
@@ -293,30 +293,6 @@ macro timed(ex)
     end
 end
 
-walk(x, inner, outer) = outer(x)
-walk(x::Expr, inner, outer) = outer(Expr(x.head, map(inner, x.args)...))
-postwalk(f, x) = walk(x, x -> postwalk(f, x), f)
-
-"""
-    @big
-A macro that converts all enclosed numeric literals to their `big` versions, allowing
-for arbitrary precision arithmetic without converting each numeric literal by hand.
-See also [`big`](@ref), [`BigInt`](@ref), [`BigFloat`](@ref)
-```julia-repl
-julia> factorial(100)/factorial(99)
-ERROR: OverflowError: 100 is too large to look up in the table
-Stacktrace:
- [1] factorial_lookup(::Int64, ::Array{Int64,1}, ::Int64) at ./combinatorics.jl:19
- [2] factorial(::Int64) at ./combinatorics.jl:27
- [3] top-level scope at none:0
-
-julia> @big factorial(100)/factorial(99)
-100.0
-"""
-macro big(ex)
-    postwalk(x -> x isa Number ? big(x) : x, ex)
-end
-
 ## printing with color ##
 
 const text_colors = AnyDict(

--- a/base/util.jl
+++ b/base/util.jl
@@ -294,6 +294,32 @@ macro timed(ex)
 end
 
 
+
+walk(x, inner, outer) = outer(x)
+walk(x::Expr, inner, outer) = outer(Expr(x.head, map(inner, x.args)...))
+postwalk(f, x) = walk(x, x -> postwalk(f, x), f)
+
+"""
+    @big
+A macro that converts all enclosed numeric literals to their `big` versions, allowing 
+for arbitrary precision arithmetic without converting each numeric literal by hand.
+See also [`big`](@ref), [`BigInt`](@ref), [`BigFloat`](@ref)
+```julia-repl
+julia> factorial(100)/factorial(99)
+ERROR: OverflowError: 100 is too large to look up in the table
+Stacktrace:
+ [1] factorial_lookup(::Int64, ::Array{Int64,1}, ::Int64) at ./combinatorics.jl:19
+ [2] factorial(::Int64) at ./combinatorics.jl:27
+ [3] top-level scope at none:0
+
+julia> @big factorial(100)/factorial(99)
+100.0
+"""
+macro big(ex)
+    postwalk(x -> x isa Number ? big(x) : x, ex)
+end
+
+
 ## printing with color ##
 
 const text_colors = AnyDict(

--- a/base/util.jl
+++ b/base/util.jl
@@ -293,15 +293,13 @@ macro timed(ex)
     end
 end
 
-
-
 walk(x, inner, outer) = outer(x)
 walk(x::Expr, inner, outer) = outer(Expr(x.head, map(inner, x.args)...))
 postwalk(f, x) = walk(x, x -> postwalk(f, x), f)
 
 """
     @big
-A macro that converts all enclosed numeric literals to their `big` versions, allowing 
+A macro that converts all enclosed numeric literals to their `big` versions, allowing
 for arbitrary precision arithmetic without converting each numeric literal by hand.
 See also [`big`](@ref), [`BigInt`](@ref), [`BigFloat`](@ref)
 ```julia-repl
@@ -318,7 +316,6 @@ julia> @big factorial(100)/factorial(99)
 macro big(ex)
     postwalk(x -> x isa Number ? big(x) : x, ex)
 end
-
 
 ## printing with color ##
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2612,3 +2612,10 @@ end
         end
     end
 end
+
+@testset "@big macro" begin
+    @test (@big 1) == BigInt(1)
+    @test (@big 1.0) == BigFloat(1.0)
+    @test (@big factorial(100)/factorial(99)) == BigFloat(100.0)
+    @test (@big 1 + 2//3) isa Rational{BigInt}
+end


### PR DESCRIPTION
I'm going to guess that not many people will agree with this but I'll throw it out there just in case.

Proposal: Include a `@big` macro that acts like the following
```
(@macroexpand @big (f(20) + 3.0)^45) == :((f(big(20)) + big(3.0))^big(45))

@big factorial(100)/factorial(99) == 100.0
```
this is meant to be a handy little utility that one can quickly stick in front of an expression to make sure their result isn't effected by 64bit precision without having to go in and write `big(_)` all over the place or reason about how promotion should happen if they just want to change the type of one number in a big expression.

Its relatively painless to include in base and is nice to have in much the same way a macro like `@fastmath` is nice to have. 

I put the code in `mpfr.jl` but I'm not sure thats the most appropriate spot. 

____

As an aside: I also happened to include an implementation of @MikeInnes ' `postwalk` function in order to implement the macro.