### PR TITLE
Add nothrow modeling for <:

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -87,7 +87,7 @@ const _PURE_BUILTINS = Any[tuple, svec, ===, typeof, nfields]
 const _PURE_OR_ERROR_BUILTINS = [
     fieldtype, apply_type, isa, UnionAll,
     getfield, arrayref, isdefined, Core.sizeof,
-    Core.kwfunc, ifelse, Core._typevar
+    Core.kwfunc, ifelse, Core._typevar, (<:)
 ]
 
 const TOP_TUPLE = GlobalRef(Core, :tuple)

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1176,6 +1176,9 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
     elseif f === isa
         length(argtypes) == 2 || return false
         return argtypes[2] ⊑ Type
+    elseif f === (<:)
+        length(argtypes) == 2 || return false
+        return argtypes[1] ⊑ Type && argtypes[2] ⊑ Type
     elseif f === UnionAll
         return length(argtypes) == 2 &&
             (argtypes[1] ⊑ TypeVar && argtypes[2] ⊑ Type)

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -220,3 +220,14 @@ end
 
 f_identity_splat(t) = (t...,)
 @test length(code_typed(f_identity_splat, (Tuple{Int,Int},))[1][1].code) == 1
+
+# check that <: can be fully eliminated
+struct SomeArbitraryStruct; end
+function f_subtype()
+    T = SomeArbitraryStruct
+    T <: Bool
+end
+let code = code_typed(f_subtype, Tuple{})[1][1].code
+    @test length(code) == 1
+    @test code[1] == Expr(:return, false)
+end


### PR DESCRIPTION
Allows eliminating dead <: calls (e.g. because we were able to evaluate them at compile time).
Consider
```
struct SomeArbitraryStruct; end
function f_subtype()
    T = SomeArbitraryStruct
    T <: Bool
end
```
Before:
```
julia> @code_typed f_subtype()
CodeInfo(
2 1 ─ %1 = Main.SomeArbitraryStruct::Const(SomeArbitraryStruct, false)
3 │   %2 = (%1 <: Main.Bool)::Const(false, false)
  └──      return %2
) => Bool
```
After:
```
julia> @code_typed f_subtype()
CodeInfo(
3 1 ─     return false
) => Bool
```