### PR TITLE
Extend PartialTuple for structs

### DIFF
--- a/base/compiler/inferenceresult.jl
+++ b/base/compiler/inferenceresult.jl
@@ -22,7 +22,7 @@ end
 function is_argtype_match(@nospecialize(given_argtype),
                           @nospecialize(cache_argtype),
                           overridden_by_const::Bool)
-    if isa(given_argtype, Const) || isa(given_argtype, PartialTuple)
+    if isa(given_argtype, Const) || isa(given_argtype, PartialStruct)
         return is_lattice_equal(given_argtype, cache_argtype)
     end
     return !overridden_by_const
@@ -66,7 +66,7 @@ function matching_cache_argtypes(linfo::MethodInstance, ::Nothing)
     nargs::Int = toplevel ? 0 : linfo.def.nargs
     cache_argtypes = Vector{Any}(undef, nargs)
     # First, if we're dealing with a varargs method, then we set the last element of `args`
-    # to the appropriate `Tuple` type or `PartialTuple` instance.
+    # to the appropriate `Tuple` type or `PartialStruct` instance.
     if !toplevel && linfo.def.isva
         if linfo.specTypes == Tuple
             if nargs > 1

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -583,7 +583,8 @@ function rewrite_apply_exprargs!(ir::IRCode, idx::Int, argexprs::Vector{Any}, at
     for i in 3:length(argexprs)
         def = argexprs[i]
         def_type = atypes[i]
-        if def_type isa PartialTuple
+        if def_type isa PartialStruct
+            # def_type.typ <: Tuple is assumed
             def_atypes = def_type.fields
         else
             def_atypes = Any[]

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -716,9 +716,12 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
             end
         end
         s = typeof(sv)
-    elseif isa(s, PartialTuple)
+    elseif isa(s, PartialStruct)
         if isa(name, Const)
             nv = name.val
+            if isa(nv, Symbol)
+                nv = fieldindex(widenconst(s), nv, false)
+            end
             if isa(nv, Int) && 1 <= nv <= length(s.fields)
                 return s.fields[nv]
             end
@@ -1139,7 +1142,7 @@ function tuple_tfunc(atypes::Vector{Any})
     typ = Tuple{params...}
     # replace a singleton type with its equivalent Const object
     isdefined(typ, :instance) && return Const(typ.instance)
-    return anyinfo ? PartialTuple(typ, atypes) : typ
+    return anyinfo ? PartialStruct(typ, atypes) : typ
 end
 
 function array_type_undefable(@nospecialize(a))

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -70,7 +70,7 @@ struct StateUpdate
     state::VarTable
 end
 
-struct PartialTuple
+struct PartialStruct
     typ
     fields::Vector{Any} # elements are other type lattice members
 end
@@ -125,8 +125,8 @@ function ⊑(@nospecialize(a), @nospecialize(b))
     elseif isa(b, Conditional)
         return false
     end
-    if isa(a, PartialTuple)
-        if isa(b, PartialTuple)
+    if isa(a, PartialStruct)
+        if isa(b, PartialStruct)
             if !(length(a.fields) == length(b.fields) && a.typ <: b.typ)
                 return false
             end
@@ -137,9 +137,15 @@ function ⊑(@nospecialize(a), @nospecialize(b))
             return true
         end
         return isa(b, Type) && a.typ <: b
-    elseif isa(b, PartialTuple)
+    elseif isa(b, PartialStruct)
         if isa(a, Const)
             nfields(a.val) == length(b.fields) || return false
+            widenconst(b).name === widenconst(a).name || return false
+            # We can skip the subtype check if b is a Tuple, since in that
+            # case, the ⊑ of the elements is sufficient.
+            if b.typ.name !== Tuple.name && !(widenconst(a) <: widenconst(b))
+                return false
+            end
             for i in 1:nfields(a.val)
                 # XXX: let's handle varargs later
                 ⊑(Const(getfield(a.val, i)), b.fields[i]) || return false
@@ -173,15 +179,16 @@ end
 # `a ⊑ b && b ⊑ a` but with extra performance optimizations.
 function is_lattice_equal(@nospecialize(a), @nospecialize(b))
     a === b && return true
-    if isa(a, PartialTuple)
-        isa(b, PartialTuple) || return false
+    if isa(a, PartialStruct)
+        isa(b, PartialStruct) || return false
         length(a.fields) == length(b.fields) || return false
+        widenconst(a) == widenconst(b) || return false
         for i in 1:length(a.fields)
             is_lattice_equal(a.fields[i], b.fields[i]) || return false
         end
         return true
     end
-    isa(b, PartialTuple) && return false
+    isa(b, PartialStruct) && return false
     a isa Const && return false
     b isa Const && return false
     return a ⊑ b && b ⊑ a
@@ -200,7 +207,7 @@ function widenconst(c::Const)
 end
 widenconst(m::MaybeUndef) = widenconst(m.typ)
 widenconst(c::PartialTypeVar) = TypeVar
-widenconst(t::PartialTuple) = t.typ
+widenconst(t::PartialStruct) = t.typ
 widenconst(@nospecialize(t)) = t
 
 issubstate(a::VarState, b::VarState) = (a.typ ⊑ b.typ && a.undef <= b.undef)

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -317,6 +317,27 @@ function tmerge(@nospecialize(typea), @nospecialize(typeb))
         end
         return Bool
     end
+    if (isa(typea, PartialStruct) || isa(typea, Const)) &&
+       (isa(typeb, PartialStruct) || isa(typeb, Const)) &&
+        widenconst(typea) === widenconst(typeb)
+
+       typea_nfields = nfields_tfunc(typea)
+       typeb_nfields = nfields_tfunc(typeb)
+       if !isa(typea_nfields, Const) || !isa(typea_nfields, Const) || typea_nfields.val !== typeb_nfields.val
+            return widenconst(typea)
+       end
+
+       type_nfields = typea_nfields.val::Int
+       fields = Vector{Any}(undef, type_nfields)
+       anyconst = false
+       for i = 1:type_nfields
+            fields[i] = tmerge(getfield_tfunc(typea, Const(i)),
+                               getfield_tfunc(typeb, Const(i)))
+            anyconst |= has_nontrivial_const_info(fields[i])
+       end
+       return anyconst ? PartialStruct(widenconst(typea), fields) :
+            widenconst(typea)
+    end
     # no special type-inference lattice, join the types
     typea, typeb = widenconst(typea), widenconst(typeb)
     typea === typeb && return typea

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -33,7 +33,7 @@ function issingletontype(@nospecialize t)
 end
 
 function has_nontrivial_const_info(@nospecialize t)
-    isa(t, PartialTuple) && return true
+    isa(t, PartialStruct) && return true
     return isa(t, Const) && !isdefined(typeof(t.val), :instance) && !(isa(t.val, Type) && issingletontype(t.val))
 end
 


### PR DESCRIPTION
This aims to address the following issue:

Say we have:
```
function foo(b)
    a = 1
    f = ()->Val(a)
    f()
end
```

This infers beautifully, because the closure struct gets `Const`'ed
and thus inter-procedural constant prop takes care of it. However,
if we instead do

```
function foo(b)
    a = 1
    f = ()->(println(b); Val(a))
    f()
end
```

the best inference can tell us about this is that we get `Val`, because
the captured arguments are no longer constant. This leads to significant
inference problems for Zygote, because the backwards pass is always
specified as a closure. Thus, even if constant information is present
in the forward pass, it is often lost for the part of the function
that's the backwards pass, because it has to pass through the closure
struct. This fixes that by keeping track of field types individually.

Of course as always, there is a concern that this will increase compile times.
I see three options:
1. Always put this behind an inference parameter, as we do with aggressive_const_prop
2. Same as 1, but unconditionally enable it for closures
3. Always enable it

Thoughts?