### PR TITLE
Add using Random to rand(n) docstring examples [ci skip]

### DIFF
--- a/stdlib/Random/src/Random.jl
+++ b/stdlib/Random/src/Random.jl
@@ -301,6 +301,8 @@ julia> rand(Int, 2)
  1339893410598768192
  1575814717733606317
 
+julia> using Random
+
 julia> rand(MersenneTwister(0), Dict(1=>2, 3=>4))
 1=>2
 ```

--- a/stdlib/Random/src/normal.jl
+++ b/stdlib/Random/src/normal.jl
@@ -22,6 +22,8 @@ from the circularly symmetric complex normal distribution.
 
 # Examples
 ```jldoctest
+julia> using Random
+
 julia> rng = MersenneTwister(1234);
 
 julia> randn(rng, ComplexF64)


### PR DESCRIPTION
Small tweak to clarify that `Random` must be loaded to use `MersenneTwister` in the `rand` and `randn` docstring examples.

Fixes #29317