### PR TITLE
improve checking of malformed `using`/`import` Exprs

### DIFF
--- a/test/show.jl
+++ b/test/show.jl
@@ -144,6 +144,9 @@ end
 @test_repr "import A.B.C: a, x, y.z"
 @test_repr "import ..A: a, x, y.z"
 
+@test repr(Expr(:using, :Foo)) == ":(\$(Expr(:using, :Foo)))"
+@test repr(Expr(:using, Expr(:(.), ))) == ":(\$(Expr(:using, :(\$(Expr(:.))))))"
+
 # range syntax
 @test_repr "1:2"
 @test_repr "3:4:5"

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1792,3 +1792,6 @@ let f = f30772(1.0), g = f()
     @test g(1.0) === nothing
     @test_throws MethodError g(1)
 end
+
+@test_throws ErrorException("syntax: malformed \"using\" statement")  eval(Expr(:using, :X))
+@test_throws ErrorException("syntax: malformed \"import\" statement") eval(Expr(:import, :X))


### PR DESCRIPTION
Inspired by https://discourse.julialang.org/t/internal-representation-of-using-foo/19771

We were missing some checks in the interpreter and `show` for malformed `using` exprs. One case could crash, and some others just did nothing instead of reporting an error.

The AST devdocs mentioned `import` but not `using`, so add that. Also put AST docs first since they are important to macro authors. The IR part should perhaps be moved to a separate file.