### PR TITLE
fix `at-everywhere using` in Distributed stdlib

### DIFF
--- a/stdlib/Distributed/src/macros.jl
+++ b/stdlib/Distributed/src/macros.jl
@@ -135,24 +135,17 @@ end
 extract_imports!(imports, x) = imports
 function extract_imports!(imports, ex::Expr)
     if Meta.isexpr(ex, (:import, :using))
-        m = ex.args[1]
-        if isa(m, Expr) && m.head === :(:)
-            push!(imports, m.args[1].args[1])
-        else
-            for a in ex.args
-                push!(imports, a.args[1])
-            end
-        end
+        push!(imports, ex)
     elseif Meta.isexpr(ex, :let)
         extract_imports!(imports, ex.args[2])
     elseif Meta.isexpr(ex, (:toplevel, :block))
-        for i in eachindex(ex.args)
-            extract_imports!(imports, ex.args[i])
+        for arg in ex.args
+            extract_imports!(imports, arg)
         end
     end
     return imports
 end
-extract_imports(x) = extract_imports!(Symbol[], x)
+extract_imports(x) = extract_imports!(Any[], x)
 
 """
     @everywhere [procs()] expr
@@ -183,7 +176,7 @@ macro everywhere(ex)
 end
 
 macro everywhere(procs, ex)
-    imps = [Expr(:import, m) for m in extract_imports(ex)]
+    imps = extract_imports(ex)
     return quote
         $(isempty(imps) ? nothing : Expr(:toplevel, imps...)) # run imports locally first
         let ex = $(Expr(:quote, ex)), procs = $(esc(procs))

--- a/stdlib/Distributed/test/distributed_exec.jl
+++ b/stdlib/Distributed/test/distributed_exec.jl
@@ -8,7 +8,7 @@ import Distributed: launch, manage
 include(joinpath(Sys.BINDIR, "..", "share", "julia", "test", "testenv.jl"))
 
 @test Distributed.extract_imports(:(begin; import Foo, Bar; let; using Baz; end; end)) ==
-      [:Foo, :Bar, :Baz]
+      Any[:(import Foo, Bar), :(using Baz)]
 
 # Test a few "remote" invocations when no workers are present
 @test remote(myid)() == 1


### PR DESCRIPTION
`Distributed` does a transformation of `@everywhere using X` to try to do the importing locally first, to avoid precompilation races. However this has been broken since 0.7 due to a changed AST representation. This should fix it.