### PR TITLE
simplify `setproperty!` lowering

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -1896,12 +1896,7 @@
                 ,.(if (eq? aa a)   '() `((= ,aa ,(expand-forms a))))
                 ,.(if (eq? bb b)   '() `((= ,bb ,(expand-forms b))))
                 ,.(if (eq? rr rhs) '() `((= ,rr ,(expand-forms rhs))))
-                (call (top setproperty!) ,aa ,bb
-                      (if (call (top ===) (top setproperty!) (core setfield!))
-                          (call (top convert)
-                                (call (core fieldtype) (call (core typeof) ,aa) ,bb)
-                                ,rr)
-                          ,rr))
+                (call (top setproperty!) ,aa ,bb ,rr)
                 (unnecessary ,rr)))))
          ((tuple)
           ;; multiple assignment


### PR DESCRIPTION
AFAICT this is unnecessary, since in Core where `setproperty! === setfield!` the `convert` function is only identity.