### PR TITLE
Fix powerpc build

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -429,6 +429,7 @@ ifeq ($(LLVM_VER_PATCH), 0)
 $(eval $(call LLVM_PATCH,llvm-windows-race))
 endif
 $(eval $(call LLVM_PATCH,llvm-D51842-win64-byval-cc))
+$(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
 endif # LLVM_VER
 
 # Independent to the llvm version add a JL prefix to the version map

--- a/deps/patches/llvm-D57118-powerpc.patch
+++ b/deps/patches/llvm-D57118-powerpc.patch
@@ -1,0 +1,30 @@
+commit 812db527538f30ac77a19d755e24109a6db7e569
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Wed Jan 23 16:46:59 2019 -0500
+
+    [CMake][PowerPC] Recognize LLVM_NATIVE_TARGET="ppc64le" as PowerPC
+    
+    Summary:
+    This value is derived from the host triple, which on the machine
+    I'm currently using is `ppc64le-linux-redhat`. This change makes
+    LLVM compile.
+    
+    Reviewers: hfinkel
+    
+    Subscribers: nemanjai, mgorny, jsji, llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D57118
+
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index 900c35ee4f0..b9c9757a4f6 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -386,6 +386,8 @@ elseif (LLVM_NATIVE_ARCH MATCHES "sparc")
+   set(LLVM_NATIVE_ARCH Sparc)
+ elseif (LLVM_NATIVE_ARCH MATCHES "powerpc")
+   set(LLVM_NATIVE_ARCH PowerPC)
++elseif (LLVM_NATIVE_ARCH MATCHES "ppc64le")
++  set(LLVM_NATIVE_ARCH PowerPC)
+ elseif (LLVM_NATIVE_ARCH MATCHES "aarch64")
+   set(LLVM_NATIVE_ARCH AArch64)
+ elseif (LLVM_NATIVE_ARCH MATCHES "arm64")

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -27,7 +27,8 @@ typedef win32_ucontext_t jl_ucontext_t;
     !defined(JL_HAVE_ASM) && \
     !defined(JL_HAVE_UNW_CONTEXT) && \
     !defined(JL_HAVE_SIGALTSTACK)
-#if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) || defined(_CPU_ARM_))
+#if (defined(_CPU_X86_64_) || defined(_CPU_X86_) || defined(_CPU_AARCH64_) ||  \
+     defined(_CPU_ARM_) || defined(_CPU_PPC64_))
 #define JL_HAVE_ASM
 #elif defined(_OS_DARWIN_)
 #define JL_HAVE_UNW_CONTEXT


### PR DESCRIPTION
Just for what I need. I'm not working on any more general fixes to our powerpc support.
The first patch is for the failure noted in #30087 (though that issue still exists afterwards, this just implements the fast path for ppc), the second is a patch to fix the LLVM build.