### PR TITLE
Fix signature of git_libgit2_opts

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -1003,7 +1003,7 @@ function set_ssl_cert_locations(cert_loc)
     cert_dir  = isdir(cert_loc) ? cert_loc : Cstring(C_NULL)
     cert_file == C_NULL && cert_dir == C_NULL && return
     @check ccall((:git_libgit2_opts, :libgit2), Cint,
-          (Cint, Cstring, Cstring),
+          (Cint, Cstring...),
           Cint(Consts.SET_SSL_CERT_LOCATIONS), cert_file, cert_dir)
 end
 


### PR DESCRIPTION
On most platforms this doesn't make a difference,
but the PowerPC ABI uses the signature to decide
whether or not to allocate a parameter save area.
Without this, the caller does not, but the callee
assumes it's there causing the callee to overwrite
critical parts of the caller stack.

Fixes #27007