### PR TITLE
Request: Enhance partition iterator to allow arbitrary step and uniform partition size

### DIFF
--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -399,6 +399,49 @@ let v = collect(partition([1,2,3,4,5], 2))
     @test v[3] == [5]
 end
 
+let v = collect(partition([1,2,3,4,5], 2; flush=false))
+    @test v[1] == [1,2]
+    @test v[2] == [3,4]
+    @test length(v) == 2
+end
+
+let v = collect(partition([1,2,3,4,5], 2, step=1))
+    @test v[1] == [1,2]
+    @test v[2] == [2,3]
+    @test v[3] == [3,4]
+    @test v[4] == [4,5]
+    @test length(v) == 4
+end
+
+let v = collect(partition(1:10, 3, step=5))
+    @test v[1] == [1,2,3]
+    @test v[2] == [6,7,8]
+    @test length(v) == 2
+end
+
+let v = collect(partition(1:8, 4, step=3))
+    @test v[1] == [1, 2, 3, 4]
+    @test v[2] == [4, 5, 6, 7]
+    @test v[3] == [7, 8]
+    @test length(v) == 3
+end
+
+let v = collect(partition(1:8, 4, step=3, flush=false))
+    @test v[1] == [1, 2, 3, 4]
+    @test v[2] == [4, 5, 6, 7]
+    @test length(v) == 2
+end
+
+@testset for l in 1:10
+    @testset for n in 1:10
+        @testset for step in 1:10, flush in [false, true]
+            v1 = map(copy, partition(collect(1:l), n, step=step, flush=flush))
+            v2 = map(copy, partition(Base.Generator(identity, 1:l), n, step=step, flush=flush))
+            @test v1 == v2
+        end
+    end
+end
+
 let v = collect(partition(enumerate([1,2,3,4,5]), 3))
     @test v[1] == [(1,1),(2,2),(3,3)]
     @test v[2] == [(4,4),(5,5)]


### PR DESCRIPTION
This PR adds `step` and `flush` keyword arguments to `partition` iterator.  Quoting new docstring:

> ```julia
> partition(collection, n; step = n, flush = true)
> ```
>
> Iterate over a collection `n` elements at a time for each `step`.  If `flush` is `true` (default), elements fewer than `n` may be returned at the end of the iteration.
>
> ```julia
> julia> collect(Iterators.partition([1,2,3,4,5], 2))
> 3-element Array{Array{Int64,1},1}:
>  [1, 2]
>  [3, 4]
>  [5]
> 
> julia> collect(Iterators.partition([1,2,3,4,5], 2; flush=true))
> 2-element Array{Array{Int64,1},1}:
>  [1, 2]
>  [3, 4]
> 
> julia> collect(Iterators.partition([1,2,3,4,5], 2; step=1))
> 4-element Array{Array{Int64,1},1}:
>  [1, 2]
>  [2, 3]
>  [3, 4]
>  [4, 5]
> ```

**Rationale for `step`**:  It acts like the same argument as in [`IterTools.partition`](https://juliacollections.github.io/IterTools.jl/latest/#partition(xs,-n,-[step])-1).  The main difference between `IterTools.partition` and `Iterators.partition` is that the former returns a `Tuple` while the latter returns a `view` so that it can be efficient for large `n`.  So, I think it makes sense to support `step` in `Iterators` as well.

**Rationale for `flush`**: Currently, `partition` may return a vector shorter than `n` at the end if there are not enough elements.  It is useful to suppress this behavior when you need exactly `n` elements in the vector.  For example, [`IterTools.partition`](https://juliacollections.github.io/IterTools.jl/latest/#partition(xs,-n,-[step])-1) and [`pandas.DataFrame.rolling`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.rolling.html) both have this behavior.  Clojure has both [`partition-all`](https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/partition-all) and [`partition`](https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/partition) functions for two different behaviors.  So, I suggest to add a new keyword argument (say) `flush` to toggle it.

I also added an optimization for `step >= n` case to re-use buffer `v` in each iteration.  Currently, this is "turned off" by this [`copy` statement](https://github.com/JuliaLang/julia/pull/30822/files#diff-e80ce162aca95afbd43e8cd8782118a1R1033).  I actually see this as requirement for the symmetry to `step < n` case where the input has to be buffered.  However, this optimization is, strictly speaking, a breaking change for code storing the reference to returned vector.  Indeed, it breaks some tests.  Note that, [as I'm also suggesting to broaden the `view`-based implementation](https://github.com/JuliaLang/julia/pull/30822/files#r250467180), I think the effect may be "small enough".  Please let me know if this is regarded as a "minor change" (my gut feeling is that it's not) so that I can finalize this PR.