### PR TITLE
Add Channel{T}(f::Function) constructors.

### DIFF
--- a/base/channels.jl
+++ b/base/channels.jl
@@ -96,6 +96,9 @@ julia> istaskdone(taskref[])
 true
 ```
 
+!!! compat "Julia 1.3"
+  The following constructors were added in Julia 1.3.
+
 Other constructors:
 * `Channel{T}(func::Function, sz=0)`
 * `Channel{T}(func::Function; csize=0, taskref=nothing)`

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -95,6 +95,22 @@ Hello
 julia> istaskdone(taskref[])
 true
 ```
+
+Other constructors:
+* `Channel{T}(func::Function, sz=0)`
+* `Channel{T}(func::Function; csize=0, taskref=nothing)`
+
+```jldoctest
+julia> chnl = Channel{Char}(1) do ch
+           for c in "hello world"
+               put!(ch, c)
+           end
+       end
+>> Channel{Char}(sz_max:1,sz_curr:1)
+
+julia> String(collect(chnl))
+>> "hello world"
+```
 """
 function Channel(func::Function; ctype=Any, csize=0, taskref=nothing)
     chnl = Channel{ctype}(csize)
@@ -104,6 +120,12 @@ function Channel(func::Function; ctype=Any, csize=0, taskref=nothing)
 
     isa(taskref, Ref{Task}) && (taskref[] = task)
     return chnl
+end
+function Channel{T}(f::Function, sz=0) where T
+    return Channel(f, csize=sz, ctype=T)
+end
+function Channel{T}(f::Function; csize=0, taskref=nothing) where T
+    return Channel(f, csize=csize, ctype=T, taskref=taskref)
 end
 
 

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -24,7 +24,7 @@ Other constructors:
 * `Channel(sz)`: equivalent to `Channel{Any}(sz)`
 
 !!! compat "Julia 1.3"
-  The default constructor `Channel()` was added in Julia 1.3.
+  The default constructor `Channel()` and default `sz=0` were added in Julia 1.3.
 """
 mutable struct Channel{T} <: AbstractChannel{T}
     cond_take::Threads.Condition                 # waiting for data to become available
@@ -36,7 +36,7 @@ mutable struct Channel{T} <: AbstractChannel{T}
     data::Vector{T}
     sz_max::Int                          # maximum size of channel
 
-    function Channel{T}(sz::Integer) where T
+    function Channel{T}(sz::Integer = 0) where T
         if sz < 0
             throw(ArgumentError("Channel size must be either 0, a positive integer or Inf"))
         end

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -114,10 +114,10 @@ julia> chnl = Channel{Char}(1) do ch
                put!(ch, c)
            end
        end
->> Channel{Char}(sz_max:1,sz_curr:1)
+Channel{Char}(sz_max:1,sz_curr:1)
 
 julia> String(collect(chnl))
->> "hello world"
+"hello world"
 ```
 """
 function Channel(func::Function; ctype=Any, csize=0, taskref=nothing)

--- a/base/channels.jl
+++ b/base/channels.jl
@@ -8,7 +8,7 @@ Representation of a channel passing objects of type `T`.
 abstract type AbstractChannel{T} end
 
 """
-    Channel{T}(sz::Int)
+    Channel{T}(sz::Int=0)
 
 Constructs a `Channel` with an internal buffer that can hold a maximum of `sz` objects
 of type `T`.
@@ -19,8 +19,12 @@ And vice-versa.
 
 Other constructors:
 
+* `Channel()`: default constructor, equivalent to `Channel{Any}(0)`
 * `Channel(Inf)`: equivalent to `Channel{Any}(typemax(Int))`
 * `Channel(sz)`: equivalent to `Channel{Any}(sz)`
+
+!!! compat "Julia 1.3"
+  The default constructor `Channel()` was added in Julia 1.3.
 """
 mutable struct Channel{T} <: AbstractChannel{T}
     cond_take::Threads.Condition                 # waiting for data to become available
@@ -48,6 +52,7 @@ function Channel{T}(sz::Float64) where T
     return Channel{T}(sz)
 end
 Channel(sz) = Channel{Any}(sz)
+Channel() = Channel{Any}(0)
 
 # special constructors
 """

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -58,7 +58,7 @@ end
     @test c.sz_max == 0
     @test istaskstarted(taskref[])
     @test !istaskdone(taskref[])
-    take!(c); yield()
+    take!(c); wait(taskref[])
     @test istaskdone(taskref[])
 end
 

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -13,6 +13,9 @@ using Random
 end
 
 @testset "various constructors" begin
+    c = Channel()
+    @test eltype(c) == Any
+
     c = Channel(1)
     @test eltype(c) == Any
     @test put!(c, 1) == 1
@@ -31,7 +34,6 @@ end
     tvals = Int[take!(c) for i in 1:10^6]
     @test pvals == tvals
 
-    @test_throws MethodError Channel()
     @test_throws ArgumentError Channel(-1)
     @test_throws InexactError Channel(1.5)
 end
@@ -47,6 +49,10 @@ end
     @test eltype(c) == Int
     @test c.sz_max == 0
     @test collect(c) == 1:100
+
+    c = Channel() do c; put!(c, 1); put!(c, "hi") end
+    @test c.sz_max == 0
+    @test collect(c) == [1, "hi"]
 
     c = Channel{Int}(Inf) do c; put!(c,1); end
     @test eltype(c) == Int

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -15,6 +15,7 @@ end
 @testset "various constructors" begin
     c = Channel()
     @test eltype(c) == Any
+    @test c.sz_max == 0
 
     c = Channel(1)
     @test eltype(c) == Any
@@ -27,6 +28,10 @@ end
     c = Channel{Int}(1)
     @test eltype(c) == Int
     @test_throws MethodError put!(c, "Hello")
+
+    c = Channel{Int}()
+    @test eltype(c) == Int
+    @test c.sz_max == 0
 
     c = Channel{Int}(Inf)
     @test eltype(c) == Int


### PR DESCRIPTION
The existing Channel constructors are a bit inconvenient to work with. I love that you can create a Channel and spawn a task at the same time; it's super convenient! But the task-spawning constructor is a bit more cumbersome than the non-task-spawning constructor, because it takes its params as keyword arguments instead of the nicer way that the non-task constructor does it.

This PR adds two convenience constructors to combine those styles, to allow you to write things like this:
```julia
Channel{Char}(1) do chnl
    for c in "hello world"
        put!(chnl, c)
    end
end
``` 


----------

The Channel constructors that do and don't create a Task are currently
written in different styles:

 - The non-Task constructor takes a Type {T} as a type parameter, and
 the size as a positional argument.
    - `Channel{Int}(Inf)`
    - `Channel(0)`

 - The Task constructor takes a Function, but the size and type are
keyword arguments:
    - `Channel(c->put!(c,0), ctype=Int, csize=0)`
    - `Channel(ctype=Int, csize=0, taskref=t) do c; put!(c,0); end`

This commit adds convenience methods to the Task-creating constructor,
allowing you to specify the Type and (optionally) size as in the non-Task constructor:

- `Channel{Char}(c->put!(c, 'a'))`
- `Channel{Char}(1) do c; put!(c, 'a'); end`
- `Channel{Char}(csize=2, taskref=t) do c; put!(c, 'a'); end`
- `Channel{Char}(c->put!(c, 'a'), Inf)`

It also adds default constructors, defaulting to unbuffered channels (ie `sz=0`):
- `Channel() = Channel(0)`
- `Channel{T}() where T = Channel{T}(0)`


---

I also added tests for the existing Task-creating constructors, which weren't explicitly tested before.

--------------

EDIT: Some other things to consider:

- [x] In this PR, I kept it so that the empty constructor, `Channel()` is not valid. I think that's probably still reasonable, although one could argue that this should simply use all the defaults -- ie `Channel() = Channel{Any}(0)`. But I dunno, it's probably fine as-is.
- [x] Let me know if the tests are reasonable.
