### PR TITLE
improve unsized type error message.

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -408,7 +408,7 @@ If `DataType` `T` does not have a specific size, an error is thrown.
 
 ```jldoctest
 julia> sizeof(AbstractArray)
-ERROR: argument is an abstract type; size is indeterminate
+ERROR: Argument abstract type AbstractArray does not have a fixed size
 Stacktrace:
 [...]
 ```

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -373,14 +373,19 @@ JL_CALLABLE(jl_f_sizeof)
         if (isinline)
             return jl_box_long(elsize);
         if (!jl_is_datatype(x))
-            jl_error("argument is an abstract type; size is indeterminate");
+            jl_error("Argument is an abstract type and does not have a fixed size");
     }
     if (jl_is_datatype(x)) {
         jl_datatype_t *dx = (jl_datatype_t*)x;
-        if (dx->layout == NULL)
-            jl_error("argument is an abstract type; size is indeterminate");
+        if (dx->layout == NULL) {
+            if (dx->abstract) {
+                jl_errorf("Argument abstract type %s does not have a fixed size", jl_symbol_name(dx->name->name));
+            } else {
+                jl_errorf("Argument type %s does not have a fixed size", jl_symbol_name(dx->name->name));
+            }
+        }
         if (jl_is_layout_opaque(dx->layout))
-            jl_error("type does not have a fixed size");
+            jl_errorf("Opaque type %s does not have a fixed size", jl_symbol_name(dx->name->name));
         return jl_box_long(jl_datatype_size(x));
     }
     if (x == jl_bottom_type)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -604,7 +604,7 @@ end
 @test sizeof(TypeWithIrrelevantParameter{Int8}) == sizeof(Int32)
 @test sizeof(:abc) == 3
 @test sizeof(Symbol("")) == 0
-@test_throws(ErrorException("argument is an abstract type; size is indeterminate"),
+@test_throws(ErrorException("Argument abstract type Real does not have a fixed size"),
              sizeof(Real))
 @test sizeof(Union{ComplexF32,ComplexF64}) == 16
 @test sizeof(Union{Int8,UInt8}) == 1


### PR DESCRIPTION
Before:
```julia
julia> abstract type Hey end

julia> sizeof(Hey)
ERROR: argument is an abstract type; size is indeterminate
Stacktrace:
 [1] sizeof(::Type) at ./essentials.jl:416
 [2] top-level scope at none:0
```

After this patch:

```julia
julia> sizeof(Real) # Abstract
ERROR: Argument abstract type Real does not have a fixed size

julia> sizeof(AbstractArray) # Abstract
ERROR: Argument abstract type AbstractArray does not have a fixed size

julia> sizeof(Complex) # Parametric
ERROR: Argument type Complex does not have a fixed size

julia> sizeof(Vector) # UnionAll
ERROR: Argument type Array does not have a fixed size

julia> sizeof(Symbol) # Opaque
ERROR: Opaque type Symbol does not have a fixed size

julia> sizeof(Vector{Int}) # Opaque
ERROR: Opaque type Array does not have a fixed size

julia> sizeof(Union{Float32, Float64}) # Union with concrete types
8

julia> sizeof(Union{Complex, Int}) # Union with unsized types
ERROR: Argument is an abstract type and does not have a fixed size
```