### PR TITLE
show dimensions for non-1-based arrays

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1843,7 +1843,7 @@ function summary(io::IO, a, inds::Tuple{Vararg{OneTo}})
     showarg(io, a, true)
 end
 function summary(io::IO, a, inds)
-    print(io, dims2string(length.(inds)), " ")   
+    print(io, dims2string(length.(inds)), " ")
     showarg(io, a, true)
     print(io, " with indices ", inds2string(inds))
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1843,6 +1843,7 @@ function summary(io::IO, a, inds::Tuple{Vararg{OneTo}})
     showarg(io, a, true)
 end
 function summary(io::IO, a, inds)
+    print(io, dims2string(length.(inds)), " ")   
     showarg(io, a, true)
     print(io, " with indices ", inds2string(inds))
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1837,12 +1837,12 @@ _indsstring(i) = string(i)
 _indsstring(i::Union{IdentityUnitRange, Slice}) = string(i.indices)
 
 # anything array-like gets summarized e.g. 10-element Array{Int64,1}
-summary(io::IO, a::AbstractArray) = summary(io, a, axes(a))
-function summary(io::IO, a, inds::Tuple{Vararg{OneTo}})
+summary(io::IO, a::AbstractArray) = array_summary(io, a, axes(a))
+function array_summary(io::IO, a, inds::Tuple{Vararg{OneTo}})
     print(io, dims2string(length.(inds)), " ")
     showarg(io, a, true)
 end
-function summary(io::IO, a, inds)
+function array_summary(io::IO, a, inds)
     print(io, dims2string(length.(inds)), " ")
     showarg(io, a, true)
     print(io, " with indices ", inds2string(inds))

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -204,10 +204,10 @@ cmp_showf(Base.print_matrix, io, OffsetArray(rand(5,10^3), (10,-9)))    # rows f
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,10^3), (10,-9))) # neither fits
 cmp_showf(Base.print_matrix, io, OffsetArray(reshape(range(-0.212121212121, stop=2/11, length=3*29), 3, 29), (-2, -15)); options=(:displaysize=>(53,210),))
 targets1 = ["0-dimensional $OAs_name.OffsetArray{Float64,0,Array{Float64,0}}:\n1.0",
-            "$OAs_name.OffsetArray{Float64,1,Array{Float64,1}} with indices 2:2:\n 1.0",
-            "$OAs_name.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",
-            "$OAs_name.OffsetArray{Float64,3,Array{Float64,3}} with indices 2:2×3:3×4:4:\n[:, :, 4] =\n 1.0",
-            "$OAs_name.OffsetArray{Float64,4,Array{Float64,4}} with indices 2:2×3:3×4:4×5:5:\n[:, :, 4, 5] =\n 1.0"]
+            "1-element $OAs_name.OffsetArray{Float64,1,Array{Float64,1}} with indices 2:2:\n 1.0",
+            "1×1 $OAs_name.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",
+            "1×1×1 $OAs_name.OffsetArray{Float64,3,Array{Float64,3}} with indices 2:2×3:3×4:4:\n[:, :, 4] =\n 1.0",
+            "1×1×1×1 $OAs_name.OffsetArray{Float64,4,Array{Float64,4}} with indices 2:2×3:3×4:4×5:5:\n[:, :, 4, 5] =\n 1.0"]
 targets2 = ["(1.0, 1.0)",
             "([1.0], [1.0])",
             "([1.0], [1.0])",


### PR DESCRIPTION
Currently, the dimensions of non-1-based arrays are not printed in the summary display. 

Now:
```
Julia-1.1.0> A = rand(3,4)
3×4 Array{Float64,2}:
 0.635532  0.211795  0.432328  0.533066
 0.503243  0.417005  0.970291  0.70385
 0.755147  0.248952  0.114318  0.463304

Julia-1.1.0> B = OffsetArray(rand(3,4), (-1,-2))
OffsetArray(::Array{Float64,2}, 0:2, -1:2) with eltype Float64 with indices 0:2×-1:2:
 0.0170339  0.32503    0.745922  0.677098
 0.240773   0.73962    0.573145  0.281953
 0.746045   0.0651564  0.218817  0.152283
```
With this PR:
```
Julia-1.1.0> B = OffsetArray(rand(3,4), (-1,-2))
3×4 OffsetArray(::Array{Float64,2}, 0:2, -1:2) with eltype Float64 with indices 0:2×-1:2:
 0.121477  0.492515  0.596008  0.67312
 0.642371  0.784409  0.400125  0.68988
 0.466458  0.942553  0.574724  0.882686
```

I like the dimensions printed explicitly, so I don't have to deduce them from the indices.