### PR TITLE
Make rest type-idempotent

### DIFF
--- a/base/iterators.jl
+++ b/base/iterators.jl
@@ -462,6 +462,7 @@ julia> collect(Iterators.rest([1,2,3,4], 2))
 ```
 """
 rest(itr,state) = Rest(itr,state)
+rest(itr::Rest,state) = Rest(itr.itr,state)
 rest(itr) = itr
 
 """

--- a/test/iterators.jl
+++ b/test/iterators.jl
@@ -72,6 +72,7 @@ let s = "hello"
     c = collect(rest(s, st))
     @test c == ['e','l','l','o']
     @test c isa Vector{Char}
+    @test rest(s, st) == rest(rest(s,4),st)
 end
 
 @test_throws MethodError collect(rest(countfrom(1), 5))


### PR DESCRIPTION
Following #30869, this PR implements `rest` for `Rest` objects returning a `Rest` instead of a nested `Rest{Rest{...}}`, thus avoiding problems with type-interference and performance with repeated applications of `rest`.
