### PR TITLE
replace use of `()` as a sentinel in inference with `nothing`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -446,7 +446,7 @@ function abstract_iteration(@nospecialize(itertype), vtypes::VarTable, sv::Infer
         return Any[Vararg{Any}]
     end
     iteratef = getfield(Main.Base, :iterate)
-    stateordonet = abstract_call(iteratef, (), Any[Const(iteratef), itertype], vtypes, sv)
+    stateordonet = abstract_call(iteratef, nothing, Any[Const(iteratef), itertype], vtypes, sv)
     # Return Bottom if this is not an iterator.
     # WARNING: Changes to the iteration protocol must be reflected here,
     # this is not just an optimization.
@@ -465,7 +465,7 @@ function abstract_iteration(@nospecialize(itertype), vtypes::VarTable, sv::Infer
         valtype = stateordonet.parameters[1]
         statetype = stateordonet.parameters[2]
         push!(ret, valtype)
-        stateordonet = abstract_call(iteratef, (), Any[Const(iteratef), itertype, statetype], vtypes, sv)
+        stateordonet = abstract_call(iteratef, nothing, Any[Const(iteratef), itertype, statetype], vtypes, sv)
         stateordonet = widenconst(stateordonet)
     end
     if stateordonet === Nothing
@@ -482,7 +482,7 @@ function abstract_iteration(@nospecialize(itertype), vtypes::VarTable, sv::Infer
         end
         valtype = tmerge(valtype, nounion.parameters[1])
         statetype = tmerge(statetype, nounion.parameters[2])
-        stateordonet = abstract_call(iteratef, (), Any[Const(iteratef), itertype, statetype], vtypes, sv)
+        stateordonet = abstract_call(iteratef, nothing, Any[Const(iteratef), itertype, statetype], vtypes, sv)
         stateordonet = widenconst(stateordonet)
     end
     push!(ret, Vararg{valtype})
@@ -524,9 +524,9 @@ function abstract_apply(@nospecialize(aft), aargtypes::Vector{Any}, vtypes::VarT
     end
     for ct in ctypes
         if isa(aft, Const)
-            rt = abstract_call(aft.val, (), ct, vtypes, sv, max_methods)
+            rt = abstract_call(aft.val, nothing, ct, vtypes, sv, max_methods)
         elseif isconstType(aft)
-            rt = abstract_call(aft.parameters[1], (), ct, vtypes, sv, max_methods)
+            rt = abstract_call(aft.parameters[1], nothing, ct, vtypes, sv, max_methods)
         else
             astype = argtypes_to_type(ct)
             rt = abstract_call_gf_by_type(nothing, ct, astype, sv, max_methods)
@@ -570,7 +570,7 @@ function pure_eval_call(@nospecialize(f), argtypes::Vector{Any}, @nospecialize(a
     end
 end
 
-function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argtypes::Vector{Any}, vtypes::VarTable, sv::InferenceState, max_methods = sv.params.MAX_METHODS)
+function abstract_call(@nospecialize(f), fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any}, vtypes::VarTable, sv::InferenceState, max_methods = sv.params.MAX_METHODS)
     if f === _apply
         return abstract_apply(argtypes[2], argtypes[3:end], vtypes, sv, max_methods)
     end
@@ -728,7 +728,7 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
         return Any
     elseif is_return_type(f)
         rt_rt = return_type_tfunc(argtypes, vtypes, sv)
-        if rt_rt !== NOT_FOUND
+        if rt_rt !== nothing
             return rt_rt
         end
     elseif length(argtypes) == 2 && istopfunction(f, :!)
@@ -753,7 +753,7 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
         if length(fargs) == 3
             fargs = Any[<:, fargs[3], fargs[2]]
         else
-            fargs = ()
+            fargs = nothing
         end
         argtypes = Any[typeof(<:), argtypes[3], argtypes[2]]
         rty = abstract_call(<:, fargs, argtypes, vtypes, sv)
@@ -785,7 +785,7 @@ function abstract_call(@nospecialize(f), fargs::Union{Tuple{},Vector{Any}}, argt
 end
 
 # wrapper around `abstract_call` for first computing if `f` is available
-function abstract_eval_call(fargs::Union{Tuple{},Vector{Any}}, argtypes::Vector{Any}, vtypes::VarTable, sv::InferenceState)
+function abstract_eval_call(fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any}, vtypes::VarTable, sv::InferenceState)
     #print("call ", e.args[1], argtypes, "\n\n")
     for x in argtypes
         x === Bottom && return Bottom
@@ -859,7 +859,7 @@ function abstract_eval_cfunction(e::Expr, vtypes::VarTable, sv::InferenceState)
     # this may be the wrong world for the call,
     # but some of the result is likely to be valid anyways
     # and that may help generate better codegen
-    abstract_eval_call((), at, vtypes, sv)
+    abstract_eval_call(nothing, at, vtypes, sv)
     nothing
 end
 
@@ -1035,7 +1035,7 @@ function typeinf_local(frame::InferenceState)
             delete!(W, pc)
             frame.currpc = pc
             frame.cur_hand = frame.handler_at[pc]
-            frame.stmt_edges[pc] === () || empty!(frame.stmt_edges[pc])
+            frame.stmt_edges[pc] === nothing || empty!(frame.stmt_edges[pc])
             stmt = frame.src.code[pc]
             changes = s[pc]::VarTable
             t = nothing
@@ -1105,9 +1105,8 @@ function typeinf_local(frame::InferenceState)
                 end
             elseif hd === :enter
                 l = stmt.args[1]::Int
-                frame.cur_hand = (l, frame.cur_hand)
+                frame.cur_hand = Pair{Any,Any}(l, frame.cur_hand)
                 # propagate type info to exception handler
-                l = frame.cur_hand[1]
                 old = s[l]
                 new = s[pc]::Array{Any,1}
                 newstate_catch = stupdate!(old, new)
@@ -1122,7 +1121,7 @@ function typeinf_local(frame::InferenceState)
                 frame.handler_at[l] = frame.cur_hand
             elseif hd === :leave
                 for i = 1:((stmt.args[1])::Int)
-                    frame.cur_hand = frame.cur_hand[2]
+                    frame.cur_hand = (frame.cur_hand::Pair{Any,Any}).second
                 end
             else
                 if hd === :(=)
@@ -1148,11 +1147,11 @@ function typeinf_local(frame::InferenceState)
                         frame.src.ssavaluetypes[pc] = t
                     end
                 end
-                if frame.cur_hand !== () && isa(changes, StateUpdate)
+                if frame.cur_hand !== nothing && isa(changes, StateUpdate)
                     # propagate new type info to exception handler
                     # the handling for Expr(:enter) propagates all changes from before the try/catch
                     # so this only needs to propagate any changes
-                    l = frame.cur_hand[1]
+                    l = frame.cur_hand.first::Int
                     if stupdate1!(s[l]::VarTable, changes::StateUpdate) !== false
                         if l < frame.pc´´
                             frame.pc´´ = l

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -18,7 +18,7 @@ mutable struct OptimizationState
     const_api::Bool
     function OptimizationState(frame::InferenceState)
         s_edges = frame.stmt_edges[1]
-        if s_edges === ()
+        if s_edges === nothing
             s_edges = []
             frame.stmt_edges[1] = s_edges
         end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1195,7 +1195,6 @@ function fixup_node(compact::IncrementalCompact, @nospecialize(stmt))
         return compact.ssa_rename[stmt.id]
     else
         urs = userefs(stmt)
-        urs === () && return stmt
         for ur in urs
             val = ur[]
             if isa(val, NewSSAValue)

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -660,7 +660,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
     visited = BitSet()
     type_refine_phi = BitSet()
     @timeit "SSA Rename" while !isempty(worklist)
-        (item, pred, incoming_vals) = pop!(worklist)
+        (item::Int, pred, incoming_vals) = pop!(worklist)
         # Rename existing phi nodes first, because their uses occur on the edge
         # TODO: This isn't necessary if inlining stops replacing arguments by slots.
         for idx in cfg.blocks[item].stmts

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1330,9 +1330,9 @@ function return_type_tfunc(argtypes::Vector{Any}, vtypes::VarTable, sv::Inferenc
                     end
                     astype = argtypes_to_type(argtypes_vec)
                     if isa(aft, Const)
-                        rt = abstract_call(aft.val, (), argtypes_vec, vtypes, sv, -1)
+                        rt = abstract_call(aft.val, nothing, argtypes_vec, vtypes, sv, -1)
                     elseif isconstType(aft)
-                        rt = abstract_call(aft.parameters[1], (), argtypes_vec, vtypes, sv, -1)
+                        rt = abstract_call(aft.parameters[1], nothing, argtypes_vec, vtypes, sv, -1)
                     else
                         rt = abstract_call_gf_by_type(nothing, argtypes_vec, astype, sv, -1)
                     end
@@ -1356,7 +1356,7 @@ function return_type_tfunc(argtypes::Vector{Any}, vtypes::VarTable, sv::Inferenc
             end
         end
     end
-    return NOT_FOUND
+    return nothing
 end
 
 # N.B.: typename maps type equivalence classes to a single value

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -190,6 +190,7 @@ function store_backedges(frame::InferenceState)
     if !toplevel && (frame.cached || frame.parent !== nothing)
         caller = frame.result.linfo
         for edges in frame.stmt_edges
+            edges === nothing && continue
             i = 1
             while i <= length(edges)
                 to = edges[i]
@@ -314,7 +315,7 @@ function type_annotate!(sv::InferenceState)
     src = sv.src
     states = sv.stmt_types
     nargs = sv.nargs
-    nslots = length(states[1])
+    nslots = length(states[1]::Array{Any,1})
     undefs = fill(false, nslots)
     body = src.code::Array{Any,1}
     nexpr = length(body)
@@ -339,7 +340,7 @@ function type_annotate!(sv::InferenceState)
         st_i = states[i]
         expr = body[i]
         if isa(st_i, VarTable)
-            # st_i === ()  =>  unreached statement  (see issue #7836)
+            # st_i === nothing  =>  unreached statement  (see issue #7836)
             if isa(expr, Expr)
                 annotate_slot_load!(expr, st_i, sv, undefs)
             elseif isa(expr, Slot)

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -228,7 +228,7 @@ function widenconditional(typ::Conditional)
     end
 end
 
-function stupdate!(state::Tuple{}, changes::StateUpdate)
+function stupdate!(state::Nothing, changes::StateUpdate)
     newst = copy(changes.state)
     if isa(changes.var, Slot)
         changeid = slot_id(changes.var::Slot)
@@ -288,9 +288,9 @@ function stupdate!(state::VarTable, changes::VarTable)
     return newstate
 end
 
-stupdate!(state::Tuple{}, changes::VarTable) = copy(changes)
+stupdate!(state::Nothing, changes::VarTable) = copy(changes)
 
-stupdate!(state::Tuple{}, changes::Tuple{}) = false
+stupdate!(state::Nothing, changes::Nothing) = false
 
 function stupdate1!(state::VarTable, change::StateUpdate)
     if !isa(change.var, Slot)


### PR DESCRIPTION
Using `()` as a sentinel value dates from a loooong time ago and doesn't really make sense. No functional change.