### PR TITLE
Allow const declarations by ccall

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -655,6 +655,12 @@ JL_DLLEXPORT void jl_declare_constant(jl_binding_t *b)
     b->constp = 1;
 }
 
+JL_DLLEXPORT void jl_declare_constant_ref(jl_module_t *m, jl_sym_t *var)
+{
+    jl_binding_t *b = jl_get_binding_wr(m, var, 1);
+    jl_declare_constant(b);
+}
+
 JL_DLLEXPORT jl_value_t *jl_module_usings(jl_module_t *m)
 {
     jl_array_t *a = jl_alloc_array_1d(jl_array_any_type, 0);

--- a/test/core.jl
+++ b/test/core.jl
@@ -6816,3 +6816,9 @@ f29828() = 2::String
 g29828() = 2::Any[String][1]
 @test_throws TypeError(:typeassert, String, 2) f29828()
 @test_throws TypeError(:typeassert, String, 2) g29828()
+
+module CoreBinding end
+ccall(:jl_declare_constant_ref, Cvoid, (Any, Any), CoreBinding, :x)
+Core.eval(CoreBinding, :(x = 2))
+@test CoreBinding.x == 2
+@test isconst(CoreBinding, :x)


### PR DESCRIPTION
This is designed to enable support for the lowered form

```
const x
x = 2
```

Motivated by https://github.com/JuliaDebug/ASTInterpreter2.jl/pull/41. (If there's a better way to do it, I'm all ears.)