### PR TITLE
some improvements to static parameter handling in inference

### DIFF
--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -152,6 +152,24 @@ function sptypes_from_meth_instance(linfo::MethodInstance)
             end
             if Any <: ub && lb <: Bottom
                 ty = Any
+                # if this parameter came from arg::Type{T}, we know that T::Type
+                sig = linfo.def.sig
+                temp = sig
+                for j = 1:i-1
+                    temp = temp.body
+                end
+                Pi = temp.var
+                while temp isa UnionAll
+                    temp = temp.body
+                end
+                sigtypes = temp.parameters
+                for j = 1:length(sigtypes)
+                    tj = sigtypes[j]
+                    if isType(tj) && tj.parameters[1] === Pi
+                        ty = Type
+                        break
+                    end
+                end
             else
                 tv = TypeVar(v.name, lb, ub)
                 ty = UnionAll(tv, Type{tv})

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -5,8 +5,8 @@ const LineNum = Int
 mutable struct InferenceState
     params::Params # describes how to compute the result
     result::InferenceResult # remember where to put the result
-    linfo::MethodInstance # used here for the tuple (specTypes, env, Method) and world-age validity
-    sp::SimpleVector     # static parameters
+    linfo::MethodInstance   # used here for the tuple (specTypes, env, Method) and world-age validity
+    sptypes::Vector{Any}    # types of static parameter
     slottypes::Vector{Any}
     mod::Module
     currpc::LineNum
@@ -48,7 +48,7 @@ mutable struct InferenceState
         code = src.code::Array{Any,1}
         toplevel = !isa(linfo.def, Method)
 
-        sp = spvals_from_meth_instance(linfo::MethodInstance)
+        sp = sptypes_from_meth_instance(linfo::MethodInstance)
 
         nssavalues = src.ssavaluetypes::Int
         src.ssavaluetypes = Any[ NOT_FOUND for i = 1:nssavalues ]
@@ -120,7 +120,7 @@ function InferenceState(result::InferenceResult, cached::Bool, params::Params)
     return InferenceState(result, src, cached, params)
 end
 
-function spvals_from_meth_instance(linfo::MethodInstance)
+function sptypes_from_meth_instance(linfo::MethodInstance)
     toplevel = !isa(linfo.def, Method)
     if !toplevel && isempty(linfo.sparam_vals) && !isempty(linfo.def.sparam_syms)
         # linfo is unspecialized
@@ -130,35 +130,36 @@ function spvals_from_meth_instance(linfo::MethodInstance)
             push!(sp, sig.var)
             sig = sig.body
         end
-        sp = svec(sp...)
     else
-        sp = linfo.sparam_vals
-        if _any(t->isa(t,TypeVar), sp)
-            sp = collect(Any, sp)
-        end
+        sp = collect(Any, linfo.sparam_vals)
     end
-    if !isa(sp, SimpleVector)
-        for i = 1:length(sp)
-            v = sp[i]
-            if v isa TypeVar
-                ub = v.ub
-                while ub isa TypeVar
-                    ub = ub.ub
-                end
-                if has_free_typevars(ub)
-                    ub = Any
-                end
-                lb = v.lb
-                while lb isa TypeVar
-                    lb = lb.lb
-                end
-                if has_free_typevars(lb)
-                    lb = Bottom
-                end
-                sp[i] = TypeVar(v.name, lb, ub)
+    for i = 1:length(sp)
+        v = sp[i]
+        if v isa TypeVar
+            ub = v.ub
+            while ub isa TypeVar
+                ub = ub.ub
             end
+            if has_free_typevars(ub)
+                ub = Any
+            end
+            lb = v.lb
+            while lb isa TypeVar
+                lb = lb.lb
+            end
+            if has_free_typevars(lb)
+                lb = Bottom
+            end
+            if Any <: ub && lb <: Bottom
+                ty = Any
+            else
+                tv = TypeVar(v.name, lb, ub)
+                ty = UnionAll(tv, Type{tv})
+            end
+        else
+            ty = Const(v)
         end
-        sp = svec(sp...)
+        sp[i] = ty
     end
     return sp
 end

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -104,9 +104,9 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, sv::Opt
     @timeit "domtree 1" domtree = construct_domtree(cfg)
     ir = let code = Any[nothing for _ = 1:length(code)]
              argtypes = sv.slottypes[1:(nargs+1)]
-            IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), argtypes, meta, sv.sp)
+            IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), argtypes, meta, sv.sptypes)
         end
-    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs, sv.sp, sv.slottypes)
+    @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs, sv.sptypes, sv.slottypes)
     return ir
 end
 

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -787,7 +787,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
         isempty(eargs) && continue
         arg1 = eargs[1]
 
-        ft = argextype(arg1, ir, sv.sp)
+        ft = argextype(arg1, ir, sv.sptypes)
         has_free_typevars(ft) && continue
         f = singleton_type(ft)
         f === Core.Intrinsics.llvmcall && continue
@@ -797,7 +797,7 @@ function assemble_inline_todo!(ir::IRCode, linetable::Vector{LineInfoNode}, sv::
         atypes[1] = ft
         ok = true
         for i = 2:length(stmt.args)
-            a = argextype(stmt.args[i], ir, sv.sp)
+            a = argextype(stmt.args[i], ir, sv.sptypes)
             (a === Bottom || isvarargtype(a)) && (ok = false; break)
             atypes[i] = a
         end

--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -213,7 +213,7 @@ struct IRCode
     lines::Vector{Int32}
     flags::Vector{UInt8}
     argtypes::Vector{Any}
-    spvals::SimpleVector
+    sptypes::Vector{Any}
     linetable::Vector{LineInfoNode}
     cfg::CFG
     new_nodes::Vector{NewNode}
@@ -221,12 +221,12 @@ struct IRCode
 
     function IRCode(stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int32}, flags::Vector{UInt8},
             cfg::CFG, linetable::Vector{LineInfoNode}, argtypes::Vector{Any}, meta::Vector{Any},
-            spvals::SimpleVector)
-        return new(stmts, types, lines, flags, argtypes, spvals, linetable, cfg, NewNode[], meta)
+            sptypes::Vector{Any})
+        return new(stmts, types, lines, flags, argtypes, sptypes, linetable, cfg, NewNode[], meta)
     end
     function IRCode(ir::IRCode, stmts::Vector{Any}, types::Vector{Any}, lines::Vector{Int32}, flags::Vector{UInt8},
             cfg::CFG, new_nodes::Vector{NewNode})
-        return new(stmts, types, lines, flags, ir.argtypes, ir.spvals, ir.linetable, cfg, new_nodes, ir.meta)
+        return new(stmts, types, lines, flags, ir.argtypes, ir.sptypes, ir.linetable, cfg, new_nodes, ir.meta)
     end
 end
 copy(code::IRCode) = IRCode(code, copy(code.stmts), copy(code.types),
@@ -1143,7 +1143,7 @@ function maybe_erase_unused!(extra_worklist, compact, idx, callback = x->nothing
     if compact_exprtype(compact, SSAValue(idx)) === Bottom
         effect_free = false
     else
-        effect_free = stmt_effect_free(stmt, compact.result_types[idx], compact, compact.ir.spvals)
+        effect_free = stmt_effect_free(stmt, compact.result_types[idx], compact, compact.ir.sptypes)
     end
     if effect_free
         for ops in userefs(stmt)

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -1,18 +1,18 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-inflate_ir(ci::CodeInfo) = inflate_ir(ci, Core.svec(), Any[ Any for i = 1:length(ci.slotnames) ])
+inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ Any for i = 1:length(ci.slotnames) ])
 
 function inflate_ir(ci::CodeInfo, linfo::MethodInstance)
-    spvals = spvals_from_meth_instance(linfo)
+    sptypes = sptypes_from_meth_instance(linfo)
     if ci.inferred
         argtypes, _ = matching_cache_argtypes(linfo, nothing)
     else
         argtypes = Any[ Any for i = 1:length(ci.slotnames) ]
     end
-    return inflate_ir(ci, spvals, argtypes)
+    return inflate_ir(ci, sptypes, argtypes)
 end
 
-function inflate_ir(ci::CodeInfo, spvals::SimpleVector, argtypes::Vector{Any})
+function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
     code = copy_exprargs(ci.code)
     for i = 1:length(code)
         if isa(code[i], Expr)
@@ -46,7 +46,7 @@ function inflate_ir(ci::CodeInfo, spvals::SimpleVector, argtypes::Vector{Any})
     end
     ssavaluetypes = ci.ssavaluetypes isa Vector{Any} ? copy(ci.ssavaluetypes) : Any[ Any for i = 1:(ci.ssavaluetypes::Int) ]
     ir = IRCode(code, ssavaluetypes, copy(ci.codelocs), copy(ci.ssaflags), cfg, collect(LineInfoNode, ci.linetable),
-                argtypes, Any[], spvals)
+                argtypes, Any[], sptypes)
     return ir
 end
 

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -3,7 +3,7 @@
 """
 Determine whether a statement is side-effect-free, i.e. may be removed if it has no uses.
 """
-function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, spvals::SimpleVector)
+function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, sptypes::Vector{Any})
     isa(stmt, Union{PiNode, PhiNode}) && return true
     isa(stmt, Union{ReturnNode, GotoNode, GotoIfNot}) && return false
     isa(stmt, GlobalRef) && return isdefined(stmt.mod, stmt.name)
@@ -12,13 +12,13 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, spvals::S
         e = stmt::Expr
         head = e.head
         if head === :static_parameter
-            etyp = sparam_type(spvals[e.args[1]])
+            etyp = sptypes[e.args[1]]
             # if we aren't certain enough about the type, it might be an UndefVarError at runtime
             return isa(etyp, Const)
         end
         ea = e.args
         if head === :call
-            f = argextype(ea[1], src, spvals)
+            f = argextype(ea[1], src, sptypes)
             f = singleton_type(f)
             f === nothing && return false
             is_return_type(f) && return true
@@ -26,15 +26,15 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, spvals::S
                 is_pure_intrinsic_infer(f) || return false
                 return intrinsic_nothrow(f) ||
                     intrinsic_nothrow(f,
-                        Any[argextype(ea[i], src, spvals) for i = 2:length(ea)])
+                        Any[argextype(ea[i], src, sptypes) for i = 2:length(ea)])
             end
             contains_is(_PURE_BUILTINS, f) && return true
             contains_is(_PURE_OR_ERROR_BUILTINS, f) || return false
             rt === Bottom && return false
-            return _builtin_nothrow(f, Any[argextype(ea[i], src, spvals) for i = 2:length(ea)], rt)
+            return _builtin_nothrow(f, Any[argextype(ea[i], src, sptypes) for i = 2:length(ea)], rt)
         elseif head === :new
             a = ea[1]
-            typ = argextype(a, src, spvals)
+            typ = argextype(a, src, sptypes)
             # `Expr(:new)` of unknown type could raise arbitrary TypeError.
             typ, isexact = instanceof_tfunc(typ)
             isexact || return false
@@ -42,7 +42,7 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, spvals::S
             typ = typ::DataType
             fieldcount(typ) >= length(ea) - 1 || return false
             for fld_idx in 1:(length(ea) - 1)
-                eT = argextype(ea[fld_idx + 1], src, spvals)
+                eT = argextype(ea[fld_idx + 1], src, sptypes)
                 fT = fieldtype(typ, fld_idx)
                 eT ⊑ fT || return false
             end
@@ -71,10 +71,10 @@ function compact_exprtype(compact::IncrementalCompact, @nospecialize(value))
     elseif isa(value, Argument)
         return compact.ir.argtypes[value.n]
     end
-    return argextype(value, compact.ir, compact.ir.spvals)
+    return argextype(value, compact.ir, compact.ir.sptypes)
 end
 
-is_tuple_call(ir::IRCode, @nospecialize(def)) = isa(def, Expr) && is_known_call(def, tuple, ir, ir.spvals)
+is_tuple_call(ir::IRCode, @nospecialize(def)) = isa(def, Expr) && is_known_call(def, tuple, ir, ir.sptypes)
 is_tuple_call(compact::IncrementalCompact, @nospecialize(def)) = isa(def, Expr) && is_known_call(def, tuple, compact)
 function is_known_call(e::Expr, @nospecialize(func), src::IncrementalCompact)
     if e.head !== :call

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -211,14 +211,14 @@ struct DelayedTyp
 end
 
 # maybe use expr_type?
-function typ_for_val(@nospecialize(x), ci::CodeInfo, spvals::SimpleVector, idx::Int, slottypes::Vector{Any})
+function typ_for_val(@nospecialize(x), ci::CodeInfo, sptypes::Vector{Any}, idx::Int, slottypes::Vector{Any})
     if isa(x, Expr)
         if x.head === :static_parameter
-            return sparam_type(spvals[x.args[1]])
+            return sptypes[x.args[1]]
         elseif x.head === :boundscheck
             return Bool
         elseif x.head === :copyast
-            return typ_for_val(x.args[1], ci, spvals, idx, slottypes)
+            return typ_for_val(x.args[1], ci, sptypes, idx, slottypes)
         end
         return ci.ssavaluetypes[idx]
     end
@@ -545,7 +545,7 @@ function compute_live_ins(cfg::CFG, defuse)
     BlockLiveness(bb_defs, bb_uses)
 end
 
-function recompute_type(node::Union{PhiNode, PhiCNode}, ci::CodeInfo, ir::IRCode, spvals::SimpleVector, slottypes::Vector{Any})
+function recompute_type(node::Union{PhiNode, PhiCNode}, ci::CodeInfo, ir::IRCode, sptypes::Vector{Any}, slottypes::Vector{Any})
     new_typ = Union{}
     for i = 1:length(node.values)
         if isa(node, PhiNode) && !isassigned(node.values, i)
@@ -554,7 +554,7 @@ function recompute_type(node::Union{PhiNode, PhiCNode}, ci::CodeInfo, ir::IRCode
             end
             continue
         end
-        typ = typ_for_val(node.values[i], ci, spvals, -1, slottypes)
+        typ = typ_for_val(node.values[i], ci, sptypes, -1, slottypes)
         was_maybe_undef = false
         if isa(typ, MaybeUndef)
             typ = typ.typ
@@ -569,7 +569,7 @@ function recompute_type(node::Union{PhiNode, PhiCNode}, ci::CodeInfo, ir::IRCode
     return new_typ
 end
 
-function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::DomTree, defuse, nargs::Int, spvals::SimpleVector,
+function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::DomTree, defuse, nargs::Int, sptypes::Vector{Any},
                         slottypes::Vector{Any})
     cfg = ir.cfg
     left = Int[]
@@ -615,7 +615,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 fixup_uses!(ir, ci, code, slot.uses, idx, nothing)
             else
                 val = code[slot.defs[]].args[2]
-                typ = typ_for_val(val, ci, spvals, slot.defs[], slottypes)
+                typ = typ_for_val(val, ci, sptypes, slot.defs[], slottypes)
                 ssaval = SSAValue(make_ssa!(ci, code, slot.defs[], idx, typ))
                 fixup_uses!(ir, ci, code, slot.uses, idx, ssaval)
             end
@@ -697,7 +697,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
             if isa(incoming_val, NewSSAValue)
                 push!(type_refine_phi, ssaval.id)
             end
-            typ = incoming_val == undef_token ? MaybeUndef(Union{}) : typ_for_val(incoming_val, ci, spvals, -1, slottypes)
+            typ = incoming_val == undef_token ? MaybeUndef(Union{}) : typ_for_val(incoming_val, ci, sptypes, -1, slottypes)
             old_entry = ir.new_nodes[ssaval.id]
             if isa(typ, DelayedTyp)
                 push!(type_refine_phi, ssaval.id)
@@ -743,7 +743,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
                 if isexpr(stmt, :(=)) && isa(stmt.args[1], SlotNumber)
                     id = slot_id(stmt.args[1])
                     val = stmt.args[2]
-                    typ = typ_for_val(val, ci, spvals, idx, slottypes)
+                    typ = typ_for_val(val, ci, sptypes, idx, slottypes)
                     # Having undef_token appear on the RHS is possible if we're on a dead branch.
                     # Do something reasonable here, by marking the LHS as undef as well.
                     if val !== undef_token
@@ -825,7 +825,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
             new_idx = ssa.id
             node = ir.new_nodes[new_idx]
             for i = 1:length(node.node.values)
-                orig_typ = typ = typ_for_val(node.node.values[i], ci, spvals, -1, slottypes)
+                orig_typ = typ = typ_for_val(node.node.values[i], ci, sptypes, -1, slottypes)
                 @assert !isa(typ, MaybeUndef)
                 while isa(typ, DelayedTyp)
                     typ = types(ir)[typ.phi::NewSSAValue]
@@ -843,7 +843,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
         changed = false
         for new_idx in type_refine_phi
             node = ir.new_nodes[new_idx]
-            new_typ = recompute_type(node.node, ci, ir, spvals, slottypes)
+            new_typ = recompute_type(node.node, ci, ir, sptypes, slottypes)
             if !(node.typ ⊑ new_typ) || !(new_typ ⊑ node.typ)
                 ir.new_nodes[new_idx] = NewNode(node.pos, node.attach_after, new_typ, node.node, node.line)
                 changed = true

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -149,18 +149,18 @@ function method_for_inference_heuristics(method::Method, @nospecialize(sig), spa
     return nothing
 end
 
-argextype(@nospecialize(x), state) = argextype(x, state.src, state.sp, state.slottypes)
+argextype(@nospecialize(x), state) = argextype(x, state.src, state.sptypes, state.slottypes)
 
 const empty_slottypes = Any[]
 
-function argextype(@nospecialize(x), src, spvals::SimpleVector, slottypes::Vector{Any} = empty_slottypes)
+function argextype(@nospecialize(x), src, sptypes::Vector{Any}, slottypes::Vector{Any} = empty_slottypes)
     if isa(x, Expr)
         if x.head === :static_parameter
-            return sparam_type(spvals[x.args[1]])
+            return sptypes[x.args[1]]
         elseif x.head === :boundscheck
             return Bool
         elseif x.head === :copyast
-            return argextype(x.args[1], src, spvals, slottypes)
+            return argextype(x.args[1], src, sptypes, slottypes)
         end
         @assert false "argextype only works on argument-position values"
     elseif isa(x, SlotNumber)

--- a/doc/src/devdocs/inference.md
+++ b/doc/src/devdocs/inference.md
@@ -103,7 +103,7 @@ mi = Base.method_instances(f, tt)[1]
 ci = code_typed(f, tt)[1][1]
 opt = Core.Compiler.OptimizationState(mi, params)
 # Calculate cost of each statement
-cost(stmt::Expr) = Core.Compiler.statement_cost(stmt, -1, ci, opt.sp, opt.slottypes, opt.params)
+cost(stmt::Expr) = Core.Compiler.statement_cost(stmt, -1, ci, opt.sptypes, opt.slottypes, opt.params)
 cost(stmt) = 0
 cst = map(cost, ci.code)
 

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2204,3 +2204,6 @@ _rttf_test(::Int128) = 0
 _call_rttf_test() = Core.Compiler.return_type(_rttf_test, Tuple{Any})
 @test Core.Compiler.return_type(_rttf_test, Tuple{Any}) === Int
 @test _call_rttf_test() === Int
+
+f_with_Type_arg(::Type{T}) where {T} = T
+@test Base.return_types(f_with_Type_arg, (Any,)) == Any[Type]


### PR DESCRIPTION
The first commit is just a refactoring to store static parameters as lattice elements instead of their (hopefully constant) values.

The second commit improves type information for static parameters that come from `::Type{T}`, where we didn't know that `T` must be a Type. This is very useful for functions like `zeros` that sometimes take a type argument. Motivated by wanting to get better type info from examining fewer methods.