### PR TITLE
some fixes to `fill!`

### DIFF
--- a/test/arrayops.jl
+++ b/test/arrayops.jl
@@ -1307,6 +1307,12 @@ end
     fill!(A, [1, 2])
     @test A[1] == [1, 2]
     @test A[1] === A[2]
+    # byte arrays
+    @test_throws InexactError fill!(UInt8[0], -1)
+    @test_throws InexactError fill!(UInt8[0], 300)
+    @test_throws InexactError fill!(Int8[0], 200)
+    @test fill!(UInt8[0,0], 200) == [200,200]
+    @test fill!(Int8[0,0], -2) == [-2,-2]
 end
 
 @testset "splice!" begin


### PR DESCRIPTION
The method for UInt8/Int8 did not check conversions, since the argument gets converted to `Cint` to call memset, instead of getting converted to the array element type.

There also seems to have been a redundant method for `fill!`.

Also make some `fill!` callers easier to infer; `fill!` always returns its first argument but we don't want to have to look at every possible call target to find that out.