### PR TITLE
Add a cd keyword to mktempdir to cd into the new dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ New language features
 * The `extrema` function now accepts a function argument in the same manner as `minimum` and
   `maximum` ([#30323]).
 * `hasmethod` can now check for matching keyword argument names ([#30712]).
+* `mktempdir` now accepts a `cd` keyword that changes directory to the new temp dir ([#30883]).
 
 Multi-threading changes
 -----------------------

--- a/base/file.jl
+++ b/base/file.jl
@@ -566,18 +566,25 @@ function mktemp(fn::Function, parent=tempdir())
 end
 
 """
-    mktempdir(f::Function, parent=tempdir())
+    mktempdir(f::Function, parent=tempdir(); cd=false)
 
 Apply the function `f` to the result of [`mktempdir(parent)`](@ref) and remove the
-temporary directory upon completion.
+temporary directory upon completion. If `cd` is `true`, change the current directory
+to the created temporary directory for the duration of `f`.
+
+!!! compat "Julia 1.2"
+    The `cd` keyword argument requires Julia 1.2 or later.
 """
-function mktempdir(fn::Function, parent=tempdir())
+function mktempdir(fn::Function, parent=tempdir(); cd::Bool=false)
     tmpdir = mktempdir(parent)
+    wd = pwd()
     try
+        cd && Base.cd(tmpdir)
         fn(tmpdir)
     finally
         # TODO: should we call GC.gc() first on error, to make it much more likely that `rm` succeeds?
         try
+            cd && Base.cd(wd)
             rm(tmpdir, recursive=true)
         catch ex
             @error "mktempdir cleanup" _group=:file exception=(ex, catch_backtrace())

--- a/test/file.jl
+++ b/test/file.jl
@@ -892,8 +892,7 @@ end
 #     walkdir     #
 ###################
 
-dirwalk = mktempdir()
-cd(dirwalk) do
+mktempdir(cd=true) do dirwalk
     for i=1:2
         mkdir("sub_dir$i")
         open("file$i", "w") do f end
@@ -986,7 +985,6 @@ cd(dirwalk) do
     @test dirs == []
     @test files == ["file_dir2"]
 end
-rm(dirwalk, recursive=true)
 
 ############
 # Clean up #
@@ -1041,18 +1039,16 @@ end
 
 # issue #30588
 @test realpath(".") == realpath(pwd())
-mktempdir() do dir
-    cd(dir) do
-        path = touch("FooBar.txt")
-        @test ispath(realpath(path))
-        if ispath(uppercase(path)) # case-insensitive filesystem
-            @test realpath(path) == realpath(uppercase(path)) == realpath(lowercase(path)) ==
-                  realpath(uppercase(realpath(path))) == realpath(lowercase(realpath(path)))
-            @test basename(realpath(uppercase(path))) == path
-        end
-        rm(path)
-        @test_throws SystemError realpath(path)
+mktempdir(cd=true) do dir
+    path = touch("FooBar.txt")
+    @test ispath(realpath(path))
+    if ispath(uppercase(path)) # case-insensitive filesystem
+        @test realpath(path) == realpath(uppercase(path)) == realpath(lowercase(path)) ==
+              realpath(uppercase(realpath(path))) == realpath(lowercase(realpath(path)))
+        @test basename(realpath(uppercase(path))) == path
     end
+    rm(path)
+    @test_throws SystemError realpath(path)
 end
 
 # issue #9687
@@ -1069,3 +1065,10 @@ let n = tempname()
 end
 
 @test_throws ArgumentError mkpath("fakepath", mode = -1)
+
+let wd = pwd()
+    mktempdir(cd=true) do dir
+        @test pwd() == dir
+    end
+    @test pwd() == wd
+end

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -55,27 +55,25 @@ let exename = `$(Base.julia_cmd()) --compiled-modules=yes --startup-file=no`,
 end
 
 # Issue #5789 and PR #13542:
-mktempdir() do dir
-    cd(dir) do
-        let true_filename = "cAsEtEsT.jl", lowered_filename="casetest.jl"
-            touch(true_filename)
-            @test Base.isfile_casesensitive(true_filename)
-            @test !Base.isfile_casesensitive(lowered_filename)
+mktempdir(cd=true) do dir
+    let true_filename = "cAsEtEsT.jl", lowered_filename="casetest.jl"
+        touch(true_filename)
+        @test Base.isfile_casesensitive(true_filename)
+        @test !Base.isfile_casesensitive(lowered_filename)
 
-            # check that case-sensitivity only applies to basename of a path:
-            if isfile(lowered_filename) # case-insensitive filesystem
-                mkdir("cAsEtEsT")
-                touch(joinpath("cAsEtEsT", true_filename))
-                @test Base.isfile_casesensitive(joinpath("casetest", true_filename))
-                @test !Base.isfile_casesensitive(joinpath("casetest", lowered_filename))
-            end
+        # check that case-sensitivity only applies to basename of a path:
+        if isfile(lowered_filename) # case-insensitive filesystem
+            mkdir("cAsEtEsT")
+            touch(joinpath("cAsEtEsT", true_filename))
+            @test Base.isfile_casesensitive(joinpath("casetest", true_filename))
+            @test !Base.isfile_casesensitive(joinpath("casetest", lowered_filename))
         end
+    end
 
-        # Test Unicode normalization; pertinent for OS X
-        let nfc_name = "\U00F4.jl"
-            touch(nfc_name)
-            @test Base.isfile_casesensitive(nfc_name)
-        end
+    # Test Unicode normalization; pertinent for OS X
+    let nfc_name = "\U00F4.jl"
+        touch(nfc_name)
+        @test Base.isfile_casesensitive(nfc_name)
     end
 end
 
@@ -560,7 +558,7 @@ finally
 end
 
 @testset "--project and JULIA_PROJECT paths should be absolutified" begin
-    mktempdir() do dir; cd(dir) do
+    mktempdir(cd=true) do dir
         mkdir("foo")
         script = """
         using Test
@@ -572,7 +570,7 @@ end
         withenv("JULIA_PROJECT" => "foo") do
             @test success(`$(Base.julia_cmd()) -e $(script)`)
         end
-    end; end
+    end
 end
 
 # Base.active_project when version directory exist in depot, but contains no project file


### PR DESCRIPTION
A common pattern is
```julia
mktempdir() do d
    cd(d) do
        ...
    end
end
```
With this change, this pattern can be simplified to
```julia
mktempdir(cd=true) do d
    ...
end
```