### PR TITLE
Don't use recursion in IncrementalCompact

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -1133,8 +1133,8 @@ function iterate(compact::IncrementalCompact, (idx, active_bb)::Tuple{Int, Int}=
         active_bb += 1
     end
     compact.idx = idx + 1
-    if (old_result_idx == compact.result_idx)
-        idx = idx + 1
+    if old_result_idx == compact.result_idx
+        idx += 1
         @goto restart
     end
     if !isassigned(compact.result, old_result_idx)


### PR DESCRIPTION
This dodges a stack overflow seen with extremely large blocks of code.

This commit was lying around on kf/tpu3, but it's generally applicable to avoid stack overflows when simplifying large bits of code. That doesn't tend to happen as often on master (because the ir tends to be smaller, because master does less inlining), but it is a possibility, so we might as well take the fix.