### PR TITLE
Define `copy` on `SubArray` to fallback on `getindex`

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -797,8 +797,6 @@ function copy(a::AbstractArray)
     copymutable(a)
 end
 
-copy(a::SubArray) = a.parent[a.indices...]
-
 function copyto!(B::AbstractVecOrMat{R}, ir_dest::AbstractRange{Int}, jr_dest::AbstractRange{Int},
                A::AbstractVecOrMat{S}, ir_src::AbstractRange{Int}, jr_src::AbstractRange{Int}) where {R,S}
     if length(ir_dest) != length(ir_src)

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -797,6 +797,8 @@ function copy(a::AbstractArray)
     copymutable(a)
 end
 
+copy(a::SubArray) = a.parent[a.indices...]
+
 function copyto!(B::AbstractVecOrMat{R}, ir_dest::AbstractRange{Int}, jr_dest::AbstractRange{Int},
                A::AbstractVecOrMat{S}, ir_src::AbstractRange{Int}, jr_src::AbstractRange{Int}) where {R,S}
     if length(ir_dest) != length(ir_src)

--- a/base/subarray.jl
+++ b/base/subarray.jl
@@ -68,6 +68,8 @@ similar(V::SubArray, T::Type, dims::Dims) = similar(V.parent, T, dims)
 
 sizeof(V::SubArray) = length(V) * sizeof(eltype(V))
 
+copy(V::SubArray) = V.parent[V.indices...]
+
 parent(V::SubArray) = V.parent
 parentindices(V::SubArray) = V.indices
 


### PR DESCRIPTION
Defines a fallback function for `copy` on a `SubArray` that relegates to getindex. This is under the assumption that the type of `a.parent` may have an optimised method for `getindex` defined. In this case it resolves the issue reported here: https://github.com/JuliaLang/julia/issues/21796#issuecomment-456536706 , where @mbauman suggested opening this as a general PR on `SubArray`. A smaller less impactful change would be to only define it for `SubArray{<:SparseMatrixCSC}`.
With and without this PR:
```julia
using SparseArrays, BenchmarkTools
c = sprand(Bool,6000,18000, 0.01);
d = view(c, 1:6000, rand(1:18000, 1800));
@btime copy($d)
#  2.459 s (8 allocations: 18.59 MiB)

Base.copy(a::SubArray) = a.parent[a.indices...]
@btime copy($d)
#  210.270 μs (6 allocations: 967.27 KiB)
```
a 10,000x speedup at no cost.
cc @KlausC who told me he was working on something that would have the same implementation for SparseArrays.