### PR TITLE
make it possible to `eval` exprs with head `:const`

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -716,17 +716,6 @@ SECT_INTERP static jl_value_t *eval_body(jl_array_t *stmts, interpreter_state *s
                 size_t prev_state = jl_unbox_ulong(eval_value(jl_exprarg(stmt, 0), s));
                 jl_restore_excstack(prev_state);
             }
-            else if (head == const_sym) {
-                jl_sym_t *sym = (jl_sym_t*)jl_exprarg(stmt, 0);
-                jl_module_t *modu = s->module;
-                if (jl_is_globalref(sym)) {
-                    modu = jl_globalref_mod(sym);
-                    sym = jl_globalref_name(sym);
-                }
-                assert(jl_is_symbol(sym));
-                jl_binding_t *b = jl_get_binding_wr(modu, sym, 1);
-                jl_declare_constant(b);
-            }
             else if (toplevel) {
                 if (head == method_sym && jl_expr_nargs(stmt) > 1) {
                     eval_methoddef((jl_expr_t*)stmt, s);

--- a/src/jlfrontend.scm
+++ b/src/jlfrontend.scm
@@ -59,7 +59,7 @@
   (and (pair? e)
        (or (memq (car e) '(toplevel line module import using export
                                     error incomplete))
-           (and (eq? (car e) 'global) (every symbol? (cdr e))
+           (and (memq (car e) '(global const)) (every symbol? (cdr e))
                 (every (lambda (x) (not (memq x '(true false)))) (cdr e))))))
 
 (define (expand-toplevel-expr e file line)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1795,3 +1795,8 @@ end
 
 @test_throws ErrorException("syntax: malformed \"using\" statement")  eval(Expr(:using, :X))
 @test_throws ErrorException("syntax: malformed \"import\" statement") eval(Expr(:import, :X))
+
+# eval'ing :const exprs
+eval(Expr(:const, :_var_30877))
+@test !isdefined(@__MODULE__, :_var_30877)
+@test isconst(@__MODULE__, :_var_30877)


### PR DESCRIPTION
This rearranges handling of :const exprs to match :global exprs, which are very similar.

Designed to supplant #30877.