### PR TITLE
Ensure jl_get_excstack can't read from concurrently running tasks

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1011,6 +1011,7 @@ extern jl_sym_t *macrocall_sym;  extern jl_sym_t *colon_sym;
 extern jl_sym_t *hygienicscope_sym; extern jl_sym_t *escape_sym;
 extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *throw_undef_if_not_sym; extern jl_sym_t *getfield_undefref_sym;
+extern jl_sym_t *failed_sym; extern jl_sym_t *done_sym; extern jl_sym_t *runnable_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/src/task.c
+++ b/src/task.c
@@ -59,9 +59,9 @@ volatile int jl_in_stackwalk = 0;
 
 #define ROOT_TASK_STACK_ADJUSTMENT 3000000
 
-static jl_sym_t *done_sym;
-static jl_sym_t *failed_sym;
-static jl_sym_t *runnable_sym;
+jl_sym_t *done_sym;
+jl_sym_t *failed_sym;
+jl_sym_t *runnable_sym;
 
 extern size_t jl_page_size;
 jl_datatype_t *jl_task_type;

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -247,6 +247,10 @@ end
     end == ErrorException("expected")
     @test length(catch_stack(t)) == 1
     @test length(catch_stack(t)[1][2]) > 0 # backtrace is nonempty
+    # Exception stacks should not be accessed on concurrently running tasks
+    t = @task ()->nothing
+    @test_throws ErrorException("Inspecting the exception stack of a task which might "*
+                                "be running concurrently isn't allowed.") catch_stack(t)
 end
 
 @testset "rethrow" begin


### PR DESCRIPTION
A minor tweak extracted from #29901 to prevent users from accidentally calling `catch_stack` on a concurrently running task. I don't think this is something which makes sense to do and the current implementation would cause crashes once PARTR lands.