### PR TITLE
add `bswap` method for `Float16`

### DIFF
--- a/base/float.jl
+++ b/base/float.jl
@@ -841,9 +841,7 @@ eps(::AbstractFloat)
 
 
 ## byte order swaps for arbitrary-endianness serialization/deserialization ##
-bswap(x::Float16) = bswap_int(x)
-bswap(x::Float32) = bswap_int(x)
-bswap(x::Float64) = bswap_int(x)
+bswap(x::IEEEFloat) = bswap_int(x)
 
 # bit patterns
 reinterpret(::Type{Unsigned}, x::Float64) = reinterpret(UInt64, x)

--- a/base/float.jl
+++ b/base/float.jl
@@ -841,6 +841,7 @@ eps(::AbstractFloat)
 
 
 ## byte order swaps for arbitrary-endianness serialization/deserialization ##
+bswap(x::Float16) = bswap_int(x)
 bswap(x::Float32) = bswap_int(x)
 bswap(x::Float64) = bswap_int(x)
 

--- a/test/numbers.jl
+++ b/test/numbers.jl
@@ -2180,8 +2180,10 @@ end
     @test bswap(0x01020304) === 0x04030201
     @test reinterpret(Float64,bswap(0x000000000000f03f)) === 1.0
     @test reinterpret(Float32,bswap(0x0000c03f)) === 1.5f0
+    @test reinterpret(Float16,bswap(0x003c)) === Float16(1.0)
     @test bswap(reinterpret(Float64,0x000000000000f03f)) === 1.0
     @test bswap(reinterpret(Float32,0x0000c03f)) === 1.5f0
+    @test bswap(reinterpret(Float16,0x003e)) === Float16(1.5)
     zbuf = IOBuffer([0xbf, 0xc0, 0x00, 0x00, 0x40, 0x20, 0x00, 0x00,
                      0x40, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                      0xc0, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])


### PR DESCRIPTION
Float16 seems to be the only primitive base numeric type that doesn't support `bswap`. Seems to be an oversight.