### PR TITLE
some fixes to bit shift operators

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -74,17 +74,9 @@ julia> [true; true; false] .⊻ [true; false; false]
 """
 xor(x::Bool, y::Bool) = (x != y)
 
->>(x::Bool, c::Unsigned) = Int(x) >> c
-<<(x::Bool, c::Unsigned) = Int(x) << c
->>>(x::Bool, c::Unsigned) = Int(x) >>> c
-
->>(x::Bool, c::Int) = Int(x) >> c
-<<(x::Bool, c::Int) = Int(x) << c
->>>(x::Bool, c::Int) = Int(x) >>> c
-
->>(x::Bool, c::Integer) = Int(x) >> c
-<<(x::Bool, c::Integer) = Int(x) << c
->>>(x::Bool, c::Integer) = Int(x) >>> c
+>>(x::Bool, c::UInt) = Int(x) >> c
+<<(x::Bool, c::UInt) = Int(x) << c
+>>>(x::Bool, c::UInt) = Int(x) >>> c
 
 signbit(x::Bool) = false
 sign(x::Bool) = x

--- a/base/operators.jl
+++ b/base/operators.jl
@@ -581,10 +581,16 @@ See also [`>>`](@ref), [`>>>`](@ref).
 function <<(x::Integer, c::Integer)
     @_inline_meta
     typemin(Int) <= c <= typemax(Int) && return x << (c % Int)
-    (x >= 0 || c >= 0) && return zero(x)
+    (x >= 0 || c >= 0) && return zero(x) << 0  # for type stability
     oftype(x, -1)
 end
-<<(x::Integer, c::Unsigned) = c <= typemax(UInt) ? x << (c % UInt) : zero(x)
+function <<(x::Integer, c::Unsigned)
+    @_inline_meta
+    if c isa UInt
+        throw(MethodError(<<, (x, c)))
+    end
+    c <= typemax(UInt) ? x << (c % UInt) : zero(x) << UInt(0)
+end
 <<(x::Integer, c::Int) = c >= 0 ? x << unsigned(c) : x >> unsigned(-c)
 
 """
@@ -619,11 +625,13 @@ See also [`>>>`](@ref), [`<<`](@ref).
 """
 function >>(x::Integer, c::Integer)
     @_inline_meta
+    if c isa UInt
+        throw(MethodError(>>, (x, c)))
+    end
     typemin(Int) <= c <= typemax(Int) && return x >> (c % Int)
-    (x >= 0 || c < 0) && return zero(x)
+    (x >= 0 || c < 0) && return zero(x) >> 0
     oftype(x, -1)
 end
->>(x::Integer, c::Unsigned) = c <= typemax(UInt) ? x >> (c % UInt) : zero(x)
 >>(x::Integer, c::Int) = c >= 0 ? x >> unsigned(c) : x << unsigned(-c)
 
 """
@@ -655,9 +663,15 @@ See also [`>>`](@ref), [`<<`](@ref).
 """
 function >>>(x::Integer, c::Integer)
     @_inline_meta
-    typemin(Int) <= c <= typemax(Int) ? x >>> (c % Int) : zero(x)
+    typemin(Int) <= c <= typemax(Int) ? x >>> (c % Int) : zero(x) >>> 0
 end
->>>(x::Integer, c::Unsigned) = c <= typemax(UInt) ? x >>> (c % UInt) : zero(x)
+function >>>(x::Integer, c::Unsigned)
+    @_inline_meta
+    if c isa UInt
+        throw(MethodError(>>>, (x, c)))
+    end
+    c <= typemax(UInt) ? x >>> (c % UInt) : zero(x) >>> 0
+end
 >>>(x::Integer, c::Int) = c >= 0 ? x >>> unsigned(c) : x << unsigned(-c)
 
 # fallback div, fld, and cld implementations

--- a/test/int.jl
+++ b/test/int.jl
@@ -297,3 +297,8 @@ struct MyInt26779 <: Integer
 end
 @test promote_type(MyInt26779, Int) == Integer
 @test_throws ErrorException MyInt26779(1) + 1
+let i = MyInt26779(1)
+    @test_throws MethodError i >> 1
+    @test_throws MethodError i << 1
+    @test_throws MethodError i >>> 1
+end


### PR DESCRIPTION
- `>>(::Integer, ::Unsigned)` was wrong for large shift values:
```
julia> invoke(>>, Tuple{Integer,Unsigned}, -1, typemax(UInt64))
-1

julia> invoke(>>, Tuple{Integer,Unsigned}, -1, typemax(UInt128))
0
```

- the fallbacks could stack overflow
Not a huge problem by itself, but potentially annoying, and also can cause unnecessary recursion in inference.