### PR TITLE
Fix #30876, make GITHUB_REGEX match ssh://git@github.com URLs.

### DIFF
--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -12,7 +12,7 @@ using Base.Printf: @printf
 export with, GitRepo, GitConfig
 
 const GITHUB_REGEX =
-    r"^(?:git@|git://|https://|ssh://git@(?:[\w\.\+\-]+@)?)github.com[:/](([^/].+)/(.+?))(?:\.git)?$"i
+    r"^(?:(?:ssh://)?git@|git://|https://(?:[\w\.\+\-]+@)?)github.com[:/](([^/].+)/(.+?))(?:\.git)?$"i
 
 const REFCOUNT = Threads.Atomic{Int}(0)
 

--- a/stdlib/LibGit2/src/LibGit2.jl
+++ b/stdlib/LibGit2/src/LibGit2.jl
@@ -12,7 +12,7 @@ using Base.Printf: @printf
 export with, GitRepo, GitConfig
 
 const GITHUB_REGEX =
-    r"^(?:git@|git://|https://(?:[\w\.\+\-]+@)?)github.com[:/](([^/].+)/(.+?))(?:\.git)?$"i
+    r"^(?:git@|git://|https://|ssh://git@(?:[\w\.\+\-]+@)?)github.com[:/](([^/].+)/(.+?))(?:\.git)?$"i
 
 const REFCOUNT = Threads.Atomic{Int}(0)
 

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -574,7 +574,7 @@ end
     @testset "GITHUB_REGEX" begin
         github_regex_test = function(url, user, repo)
             m = match(LibGit2.GITHUB_REGEX, url)
-            @test m != nothing
+            @test m !== nothing
             @test m[1] == "$user/$repo"
             @test m[2] == user
             @test m[3] == repo

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -583,11 +583,13 @@ end
         repo = "Repo"
         github_regex_test("git@github.com/$user/$repo.git", user, repo)
         github_regex_test("https://github.com/$user/$repo.git", user, repo)
+        github_regex_test("https://username@github.com/$user/$repo.git", user, repo)
         github_regex_test("ssh://git@github.com/$user/$repo.git", user, repo)
         github_regex_test("git@github.com/$user/$repo", user, repo)
         github_regex_test("https://github.com/$user/$repo", user, repo)
+        github_regex_test("https://username@github.com/$user/$repo", user, repo)
         github_regex_test("ssh://git@github.com/$user/$repo", user, repo)
-        @test match(LibGit2.GITHUB_REGEX, "git@notgithub.com/$user/$repo.git") == nothing
+        @test !occursin(LibGit2.GITHUB_REGEX, "git@notgithub.com/$user/$repo.git")
     end
 end
 

--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -570,6 +570,25 @@ end
         @test !LibGit2.ismatch("https://@github.com", cred)
         Base.shred!(cred)
     end
+
+    @testset "GITHUB_REGEX" begin
+        github_regex_test = function(url, user, repo)
+            m = match(LibGit2.GITHUB_REGEX, url)
+            @test m != nothing
+            @test m[1] == "$user/$repo"
+            @test m[2] == user
+            @test m[3] == repo
+        end
+        user = "User"
+        repo = "Repo"
+        github_regex_test("git@github.com/$user/$repo.git", user, repo)
+        github_regex_test("https://github.com/$user/$repo.git", user, repo)
+        github_regex_test("ssh://git@github.com/$user/$repo.git", user, repo)
+        github_regex_test("git@github.com/$user/$repo", user, repo)
+        github_regex_test("https://github.com/$user/$repo", user, repo)
+        github_regex_test("ssh://git@github.com/$user/$repo", user, repo)
+        @test match(LibGit2.GITHUB_REGEX, "git@notgithub.com/$user/$repo.git") == nothing
+    end
 end
 
 mktempdir() do dir


### PR DESCRIPTION
Fixes: #30876