### PR TITLE
No-arg Ptr constructor.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@ Standard library changes
 * `hasmethod` can now check for matching keyword argument names ([#30712]).
 * `startswith` and `endswith` now accept a `Regex` for the second argument ([#29790]).
 * `retry` supports arbitrary callable objects ([#30382]).
+* A no-argument construct to `Ptr{T}` has been added which constructs a null pointer ([#30919])
 
 #### LinearAlgebra
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -80,6 +80,7 @@ Deprecated or removed
 [#21598]: https://github.com/JuliaLang/julia/issues/21598
 [#24980]: https://github.com/JuliaLang/julia/issues/24980
 [#28850]: https://github.com/JuliaLang/julia/issues/28850
+[#29777]: https://github.com/JuliaLang/julia/issues/29777
 [#29790]: https://github.com/JuliaLang/julia/issues/29790
 [#29998]: https://github.com/JuliaLang/julia/issues/29998
 [#30061]: https://github.com/JuliaLang/julia/issues/30061
@@ -89,6 +90,7 @@ Deprecated or removed
 [#30349]: https://github.com/JuliaLang/julia/issues/30349
 [#30372]: https://github.com/JuliaLang/julia/issues/30372
 [#30382]: https://github.com/JuliaLang/julia/issues/30382
+[#30577]: https://github.com/JuliaLang/julia/issues/30577
 [#30583]: https://github.com/JuliaLang/julia/issues/30583
 [#30584]: https://github.com/JuliaLang/julia/issues/30584
 [#30593]: https://github.com/JuliaLang/julia/issues/30593
@@ -97,3 +99,4 @@ Deprecated or removed
 [#30712]: https://github.com/JuliaLang/julia/issues/30712
 [#30724]: https://github.com/JuliaLang/julia/issues/30724
 [#30915]: https://github.com/JuliaLang/julia/issues/30915
+[#30919]: https://github.com/JuliaLang/julia/issues/30919

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -722,7 +722,7 @@ Int64(x::Ptr) = Int64(UInt32(x))
 UInt64(x::Ptr) = UInt64(UInt32(x))
 end
 Ptr{T}(x::Union{Int,UInt,Ptr}) where {T} = bitcast(Ptr{T}, x)
-Ptr{T}() where {T} = Ptr{T}(0)
+Ptr{T}() where {T} = Ptr{T}(C_NULL)
 
 Signed(x::UInt8)    = Int8(x)
 Unsigned(x::Int8)   = UInt8(x)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -722,6 +722,7 @@ Int64(x::Ptr) = Int64(UInt32(x))
 UInt64(x::Ptr) = UInt64(UInt32(x))
 end
 Ptr{T}(x::Union{Int,UInt,Ptr}) where {T} = bitcast(Ptr{T}, x)
+Ptr{T}() where {T} = Ptr{T}(0)
 
 Signed(x::UInt8)    = Int8(x)
 Unsigned(x::Int8)   = UInt8(x)

--- a/base/boot.jl
+++ b/base/boot.jl
@@ -722,7 +722,6 @@ Int64(x::Ptr) = Int64(UInt32(x))
 UInt64(x::Ptr) = UInt64(UInt32(x))
 end
 Ptr{T}(x::Union{Int,UInt,Ptr}) where {T} = bitcast(Ptr{T}, x)
-Ptr{T}() where {T} = Ptr{T}(C_NULL)
 
 Signed(x::UInt8)    = Int8(x)
 Unsigned(x::Int8)   = UInt8(x)

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -8,6 +8,13 @@ memory is actually valid, or that it actually represents data of the specified t
 """
 Ptr
 
+"""
+    Ptr{T}()
+
+Creates a null pointer to type `T`.
+"""
+Ptr{T}() where {T} = Ptr{T}(C_NULL)
+
 ## converting pointers to an appropriate unsigned ##
 
 """

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -730,3 +730,6 @@ end
     @test isless(b, a)
     @test sort([a, b]) == [b, a]
 end
+
+# Pointer 0-arg constructor
+@test Ptr{Cvoid}() == C_NULL


### PR DESCRIPTION
Lets you write e.g. `Ptr{Cvoid}()` as a shorthand for `Ptr{Cvoid}(0)`. Nice for when you're creating a bunch of pointers you're going to pass as references to C libraries to set so you don't care about the initial value. 