### PR TITLE
some Enum improvements

### DIFF
--- a/base/Enums.jl
+++ b/base/Enums.jl
@@ -5,7 +5,7 @@ module Enums
 import Core.Intrinsics.bitcast
 export Enum, @enum
 
-function basetype end
+function namemap end
 
 """
     Enum{T<:Integer}
@@ -14,10 +14,48 @@ The abstract supertype of all enumerated types defined with [`@enum`](@ref).
 """
 abstract type Enum{T<:Integer} end
 
+basetype(::Type{<:Enum{T}}) where {T<:Integer} = T
+
 (::Type{T})(x::Enum{T2}) where {T<:Integer,T2<:Integer} = T(bitcast(T2, x))::T
 Base.cconvert(::Type{T}, x::Enum{T2}) where {T<:Integer,T2<:Integer} = T(x)
 Base.write(io::IO, x::Enum{T}) where {T<:Integer} = write(io, T(x))
-Base.read(io::IO, ::Type{T}) where {T<:Enum} = T(read(io, Enums.basetype(T)))
+Base.read(io::IO, ::Type{T}) where {T<:Enum} = T(read(io, basetype(T)))
+
+Base.isless(x::T, y::T) where {T<:Enum} = isless(basetype(T)(x), basetype(T)(y))
+
+Base.Symbol(x::Enum) = namemap(typeof(x))[Integer(x)]::Symbol
+
+Base.print(io::IO, x::Enum) = print(io, Symbol(x))
+
+function Base.show(io::IO, x::Enum)
+    sym = Symbol(x)
+    if !get(io, :compact, false)
+        from = get(io, :module, Main)
+        def = typeof(x).name.module
+        if from === nothing || !Base.isvisible(sym, def, from)
+            show(io, def)
+            print(io, ".")
+        end
+    end
+    print(io, sym)
+end
+
+function Base.show(io::IO, ::MIME"text/plain", x::Enum)
+    print(io, x, "::")
+    show(IOContext(io, :compact => true), typeof(x))
+    print(io, " = ")
+    show(io, Integer(x))
+end
+
+function Base.show(io::IO, ::MIME"text/plain", t::Type{<:Enum})
+    print(io, "Enum ")
+    Base.show_datatype(io, t)
+    print(io, ":")
+    for x in instances(t)
+        print(io, "\n", Symbol(x), " = ")
+        show(io, Integer(x))
+    end
+end
 
 # generate code to test whether expr is in the given set of values
 function membershiptest(expr, values)
@@ -74,7 +112,7 @@ To list all the instances of an enum use `instances`, e.g.
 
 ```jldoctest fruitenum
 julia> instances(Fruit)
-(apple::Fruit = 1, orange::Fruit = 2, kiwi::Fruit = 3)
+(apple, orange, kiwi)
 ```
 """
 macro enum(T, syms...)
@@ -92,7 +130,9 @@ macro enum(T, syms...)
     elseif !isa(T, Symbol)
         throw(ArgumentError("invalid type expression for enum $T"))
     end
-    vals = Vector{Tuple{Symbol,Integer}}()
+    values = basetype[]
+    seen = Set{Symbol}()
+    namemap = Dict{basetype,Symbol}()
     lo = hi = 0
     i = zero(basetype)
     hasexpr = false
@@ -103,7 +143,7 @@ macro enum(T, syms...)
     for s in syms
         s isa LineNumberNode && continue
         if isa(s, Symbol)
-            if i == typemin(basetype) && !isempty(vals)
+            if i == typemin(basetype) && !isempty(values)
                 throw(ArgumentError("overflow in value \"$s\" of Enum $typename"))
             end
         elseif isa(s, Expr) &&
@@ -120,20 +160,24 @@ macro enum(T, syms...)
             throw(ArgumentError(string("invalid argument for Enum ", typename, ": ", s)))
         end
         if !Base.isidentifier(s)
-            throw(ArgumentError("invalid name for Enum $typename; \"$s\" is not a valid identifier."))
+            throw(ArgumentError("invalid name for Enum $typename; \"$s\" is not a valid identifier"))
         end
-        push!(vals, (s,i))
-        if length(vals) == 1
+        if hasexpr && haskey(namemap, i)
+            throw(ArgumentError("both $s and $(namemap[i]) have value $i in Enum $typename; values must be unique"))
+        end
+        namemap[i] = s
+        push!(values, i)
+        if s in seen
+            throw(ArgumentError("name \"$s\" in Enum $typename is not unique"))
+        end
+        push!(seen, s)
+        if length(values) == 1
             lo = hi = i
         else
             lo = min(lo, i)
             hi = max(hi, i)
         end
         i += oneunit(i)
-    end
-    values = basetype[i[2] for i in vals]
-    if hasexpr && values != unique(values)
-        throw(ArgumentError("values for Enum $typename are not unique"))
     end
     blk = quote
         # enum definition
@@ -142,42 +186,15 @@ macro enum(T, syms...)
             $(membershiptest(:x, values)) || enum_argument_error($(Expr(:quote, typename)), x)
             return bitcast($(esc(typename)), convert($(basetype), x))
         end
-        Enums.basetype(::Type{$(esc(typename))}) = $(esc(basetype))
+        Enums.namemap(::Type{$(esc(typename))}) = $(esc(namemap))
         Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
         Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)
-        Base.isless(x::$(esc(typename)), y::$(esc(typename))) = isless($basetype(x), $basetype(y))
-        let insts = ntuple(i->$(esc(typename))($values[i]), $(length(vals)))
+        let insts = ntuple(i->$(esc(typename))($values[i]), $(length(values)))
             Base.instances(::Type{$(esc(typename))}) = insts
-        end
-        function Base.print(io::IO, x::$(esc(typename)))
-            for (sym, i) in $vals
-                if i == $(basetype)(x)
-                    print(io, sym); break
-                end
-            end
-        end
-        function Base.show(io::IO, x::$(esc(typename)))
-            if get(io, :compact, false)
-                print(io, x)
-            else
-                print(io, x, "::")
-                show(IOContext(io, :compact => true), typeof(x))
-                print(io, " = ")
-                show(io, $basetype(x))
-            end
-        end
-        function Base.show(io::IO, ::MIME"text/plain", t::Type{$(esc(typename))})
-            print(io, "Enum ")
-            Base.show_datatype(io, t)
-            print(io, ":")
-            for (sym, i) in $vals
-                print(io, "\n", sym, " = ")
-                show(io, i)
-            end
         end
     end
     if isa(typename, Symbol)
-        for (sym,i) in vals
+        for (i, sym) in namemap
             push!(blk.args, :(const $(esc(sym)) = $(esc(typename))($i)))
         end
     end

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -709,7 +709,7 @@ enumerated types (see `@enum`).
 julia> @enum Color red blue green
 
 julia> instances(Color)
-(red::Color = 0, blue::Color = 1, green::Color = 2)
+(red, blue, green)
 ```
 """
 function instances end

--- a/base/show.jl
+++ b/base/show.jl
@@ -398,6 +398,7 @@ function show(io::IO, x::Core.IntrinsicFunction)
 end
 
 show(io::IO, ::Core.TypeofBottom) = print(io, "Union{}")
+show(io::IO, ::MIME"text/plain", ::Core.TypeofBottom) = print(io, "Union{}")
 
 function print_without_params(@nospecialize(x))
     if isa(x,UnionAll)

--- a/test/enums.jl
+++ b/test/enums.jl
@@ -126,9 +126,11 @@ end
 @test_throws ArgumentError("overflow in value \"y\" of Enum EnumOvf") @macrocall(@enum EnumOvf x=typemax(Int32) y)
 
 # test for unique Enum values
-@test_throws ArgumentError("values for Enum Test14 are not unique") @macrocall(@enum(Test14, _zero_Test14, _one_Test14, _two_Test14=0))
+@test_throws ArgumentError("both _two_Test14 and _zero_Test14 have value 0 in Enum Test14; values must be unique") @macrocall(@enum(Test14, _zero_Test14, _one_Test14, _two_Test14=0))
+# and names
+@test_throws ArgumentError("name \"_zero_Test15\" in Enum Test15 is not unique") @macrocall(@enum(Test15, _zero_Test15, _one_Test15, _zero_Test15))
 
-@test repr(apple) == "apple::Fruit = 0"
+@test repr(apple) == "$(@__MODULE__).apple"
 @test string(apple) == "apple"
 
 @test repr("text/plain", Fruit) == "Enum $(string(Fruit)):\napple = 0\norange = 1\nkiwi = 2"


### PR DESCRIPTION
- define fewer methods per type
isless and printing methods can be defined once for all Enums.

- normalize print and show methods
  - print, string, Symbol just give the name (as before)
  - `show` shows the name, prefixed with its defining module based on compactness and visibility, like how types are displayed
  - `show` for text/plain shows the longer `name::type = value` output

- check for duplicate names
We checked for duplicate values, but not names. I assume that was an oversight?