### PR TITLE
more precise types in keyword argument method lowering

### DIFF
--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1812,3 +1812,23 @@ end
 eval(Expr(:const, :_var_30877))
 @test !isdefined(@__MODULE__, :_var_30877)
 @test isconst(@__MODULE__, :_var_30877)
+
+# anonymous kw function in value position at top level
+f30926 = function (;k=0)
+    k
+end
+@test f30926(k=2) == 2
+
+if false
+elseif false
+    g30926(x) = 1
+end
+@test !isdefined(@__MODULE__, :g30926)
+
+@testset "closure conversion in testsets" begin
+    p = (2, 3, 4)
+    @test p == (2, 3, 4)
+    identity(p)
+    allocs = @allocated identity(p)
+    @test allocs == 0
+end


### PR DESCRIPTION
We have a bad interaction between two features: (1) generated methods for keyword arguments need to pass the original function around in case it contains closure data, (2) functions that take a function argument but don't call it aren't specialized on that argument (to avoid excessive specialization). That can lead to slow calls in keyword method shims, but is a bit unpredictable. For example it caused the slowdown observed in https://github.com/JuliaLang/julia/pull/30830#issuecomment-457823137, and likely other intermittent performance changes we've seen.

Long story short, this is before:
```
julia> code_typed(string, (Int,))
1-element Array{Any,1}:
 CodeInfo(
1 ─ %1 = invoke Base.:(#string#322)(10::Int64, 1::Int64, _1::Function, _2::Int64)::String
└──      return %1
) => String
```
and this is after:
```
julia> code_typed(string, (Int,))
1-element Array{Any,1}:
 CodeInfo(
1 ─ %1 = invoke Base.:(#string#322)(10::Int64, 1::Int64, _1::typeof(string), _2::Int64)::String
└──      return %1
) => String
```

Now the front end puts a specific type on the argument slot used to forward the function. After all, it knows exactly what function we're dealing with...right? Well, it can be quite difficult to do for closures, where we need to ensure everything is defined in just the right order, since there are some circular dependencies (method A calls method B, but method B needs to mention A in its signature). I hope this works.