### PR TITLE
Adding det and tr for block diagonal matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -451,8 +451,10 @@ function diag(D::Diagonal, k::Integer=0)
             "and at most $(size(D, 2)) for an $(size(D, 1))-by-$(size(D, 2)) matrix")))
     end
 end
-tr(D::Diagonal) = sum(D.diag)
-det(D::Diagonal) = prod(D.diag)
+tr(D::Diagonal{<:Number}) = sum(D.diag)
+tr(D::Diagonal) = sum(tr.(D.diag))
+det(D::Diagonal{<:Number}) = prod(D.diag)
+det(D::Diagonal) = prod(det.(D.diag))
 logdet(D::Diagonal{<:Real}) = sum(log, D.diag)
 function logdet(D::Diagonal{<:Complex}) # make sure branch cut is correct
     z = sum(log, D.diag)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -451,10 +451,8 @@ function diag(D::Diagonal, k::Integer=0)
             "and at most $(size(D, 2)) for an $(size(D, 1))-by-$(size(D, 2)) matrix")))
     end
 end
-tr(D::Diagonal{<:Number}) = sum(D.diag)
-tr(D::Diagonal) = sum(tr.(D.diag))
-det(D::Diagonal{<:Number}) = prod(D.diag)
-det(D::Diagonal) = prod(det.(D.diag))
+tr(D::Diagonal) = sum(tr, D.diag)
+det(D::Diagonal) = prod(det, D.diag)
 logdet(D::Diagonal{<:Real}) = sum(log, D.diag)
 function logdet(D::Diagonal{<:Complex}) # make sure branch cut is correct
     z = sum(log, D.diag)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -437,6 +437,9 @@ end
     @test exp(D) == Diagonal([exp([1 2; 3 4]), exp([1 2; 3 4])])
     @test log(D) == Diagonal([log([1 2; 3 4]), log([1 2; 3 4])])
     @test sqrt(D) == Diagonal([sqrt([1 2; 3 4]), sqrt([1 2; 3 4])])
+
+    @test tr(D) == 10
+    @test det(D) == 4
 end
 
 @testset "multiplication with Symmetric/Hermitian" begin
@@ -497,5 +500,6 @@ end
         @test (D \ L)::LowerTriangular{elty} == LowerTriangular(Matrix(D) \ Matrix(L))
     end
 end
+
 
 end # module TestDiagonal


### PR DESCRIPTION
Block diagonal matrices are (loosely?) supported but `tr` and `det` were not defined. This PR adds recursive `tr` and `det` methods. This was briefly discussed [here](https://github.com/JuliaLang/julia/pull/21019#discussion_r106161824).

`inv` is also a candidate for a future PR if this one is deemed necessary.