### PR TITLE
Identify used SSAValues from within :struct_type Exprs

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -394,11 +394,26 @@ iterate(it::UseRefIterator) = (it.use[1].op = 0; iterate(it, nothing))
     end
 end
 
+function scan_ssa_use_recursive!(push!, used, @nospecialize(a))
+    if isa(a, SSAValue)
+        push!(used, a.id)
+    elseif isa(a, Expr)
+        for aa in a.args
+            scan_ssa_use_recursive!(push!, used, aa)
+        end
+    end
+    return used
+end
+
 # This function is used from the show code, which may have a different
 # `push!`/`used` type since it's in Base.
 function scan_ssa_use!(push!, used, @nospecialize(stmt))
     if isa(stmt, SSAValue)
         push!(used, stmt.id)
+    elseif isexpr(stmt, :struct_type)
+        for a in stmt.args
+            scan_ssa_use_recursive!(push!, used, a)
+        end
     end
     for useref in userefs(stmt)
         val = useref[]

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -33,6 +33,23 @@ let
     # XXX: missing @test
 end
 
+let
+    ex = quote
+        function fouter(x)
+            finner(::Float16) = 2x
+            return finner(Float16(1))
+        end
+    end
+    thunk1 = Meta.lower(Main, ex)
+    thunk2 = thunk1.args[1].code[2]
+    code = thunk2.args[1]
+    used = BitSet()
+    for stmt in code.code
+        Compiler.scan_ssa_use!(push!, used, stmt)
+    end
+    @test !isempty(used)
+end
+
 for compile in ("min", "yes")
     cmd = `$(Base.julia_cmd()) --compile=$compile interpreter_exec.jl`
     if !success(pipeline(Cmd(cmd, dir=@__DIR__); stdout=stdout, stderr=stderr))


### PR DESCRIPTION
I don't know if this is even worth fixing, but I noticed that

```julia
    ex = quote
        function fouter(x)
            finner(::Float16) = 2x
            return finner(Float16(1))
        end
    end
    thunk1 = Meta.lower(Main, ex)
    thunk2 = thunk1.args[1].code[2]
    code = thunk2.args[1]
```
yields
```
julia> code = thunk2.args[1]
CodeInfo(
 1 ─     global #finner#11                                                                                                                                                                              │
 │       const #finner#11                                                                                                                                                                               │
 │       (Core.TypeVar)(:x, Core.Any)                                                                                                                                                                   │
 │       $(Expr(:struct_type, Symbol("#finner#11"), :((Core.svec)(%3)), :((Core.svec)(:x)), :(Core.Function), :((Core.svec)(%3)), false, 1))                                                            │
 └──     return                                                                                                                                                                                         │
)
```
and that the `%3` reference in the `:struct_type` `Expr` is missing.

Initially I added `:struct_type` to `is_relevant_expr` but then I grew worried that the `svec`s could be nested more than one layer deep.