### PR TITLE
Expr & Core.CodeInfo should broadcast as a scalar

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -651,7 +651,7 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex}) = Ref(x)
+broadcastable(x::Union{Expr,Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex}) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -651,7 +651,7 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Expr,Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex}) = Ref(x)
+broadcastable(x::Union{Core.CodeInfo,Expr,Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex}) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables


### PR DESCRIPTION
It is a strange world where one finds oneself wanting to broadcast over an `Expr`, or over `CodeInfo`.
But in said strange world, one never the less expects it to be as a scalar -- like a `Symbol`.

If people don't think this is crazy, I'll add tests and news