### PR TITLE
document aliasing properties of zero / address #29168

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -398,7 +398,8 @@ fill(v, dims::Tuple{}) = (a=Array{typeof(v),0}(undef, dims); fill!(a, v); a)
 """
     zeros([T=Float64,] dims...)
 
-Create an `Array`, with element type `T`, of all zeros with size specified by `dims`.
+Create an `Array`, with element type `T`, of all zeros with size specified by `dims`. This is by
+default equivalent to `fill(zero(T), dims...)`, i.e. each entry will be the same zero.
 See also [`fill`](@ref), [`ones`](@ref).
 
 # Examples
@@ -411,6 +412,11 @@ julia> zeros(Int8, 2, 3)
 2×3 Array{Int8,2}:
  0  0  0
  0  0  0
+
+julia> a = zeros(BigInt, 2);
+
+julia> a[1] === a[2]
+true
 ```
 """
 function zeros end
@@ -419,6 +425,7 @@ function zeros end
     ones([T=Float64,] dims...)
 
 Create an `Array`, with element type `T`, of all ones with size specified by `dims`.
+This is by default equivalent to `fill(one(T), dims...)`, i.e. each entry will be the same one.
 See also: [`fill`](@ref), [`zeros`](@ref).
 
 # Examples


### PR DESCRIPTION
Addresses [#29168](https://github.com/JuliaLang/julia/issues/29168) by just documenting the current behavior of `zeros` and `ones`. Even if we decide to adopt @jrevels proposal, we might still want to backport the docfix.