### PR TITLE
Fix #30944, ranges with non-IEEEFloat types

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -108,6 +108,8 @@ _range(a::Real,          st::AbstractFloat, ::Nothing, len::Integer) = _range(fl
 _range(a::AbstractFloat, st::Real,          ::Nothing, len::Integer) = _range(a, float(st),      nothing, len)
 _range(a,                ::Nothing,         ::Nothing, len::Integer) = _range(a, oftype(a-a, 1), nothing, len)
 
+_range(a::T, step::T, ::Nothing, len::Integer) where {T <: AbstractFloat} =
+    _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _range(a::T, step, ::Nothing, len::Integer) where {T} =
     _rangestyle(OrderStyle(T), ArithmeticStyle(T), a, step, len)
 _rangestyle(::Ordered, ::ArithmeticWraps, a::T, step::S, len::Integer) where {T,S} =

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -1458,3 +1458,10 @@ end
                                             Base.TwicePrecision(-1.0, -0.0), 0)
     @test reverse(reverse(1.0:0.0)) === 1.0:0.0
 end
+
+@testset "Issue #30944 ranges with non-IEEEFloat types" begin
+    # We want to test the creation of a range with BigFloat start or step
+    @test range(big(1.0), length=10) == big(1.0):1:10
+    @test range(1, step = big(1.0), length=10) == big(1.0):1:10
+    @test range(1.0, step = big(1.0), length=10) == big(1.0):1:10
+end


### PR DESCRIPTION
This pull request adds a fallback for the creation of a range (using the `range` function) where `start` and `step` promote to an `AbstractFloat` that is not one of `Float16`, `Float32` or `Float64`. See  the explanation in #30944: the IEEE types are caught in `twiceprecision.jl`, but other floating point types are never caught leading to a stack overflow.

I've added tests that would trigger a stack overflow without the fix, and which also test the promotion of `start` and `step` to a joined type (which seems like it wasn't tested before). I'm not sure about these tests, and in fact not about the fix either: the code in `range.jl` looks like it carefully sidesteps many issues I'm not aware of, so I may well have missed something... Since a promotion rule is present in the code, but the fallback isn't, it seems that it was at least at one point intended.