### PR TITLE
more compact output for Irrational show/print

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1430,7 +1430,7 @@ Construct a tuple of the given objects.
 # Examples
 ```jldoctest
 julia> tuple(1, 'a', pi)
-(1, 'a', π = 3.1415926535897...)
+(1, 'a', π)
 ```
 """
 tuple

--- a/base/irrationals.jl
+++ b/base/irrationals.jl
@@ -17,7 +17,11 @@ symbol `sym`.
 """
 struct Irrational{sym} <: AbstractIrrational end
 
-show(io::IO, x::Irrational{sym}) where {sym} = print(io, "$sym = $(string(float(x))[1:15])...")
+show(io::IO, x::Irrational{sym}) where {sym} = print(io, sym)
+
+function show(io::IO, ::MIME"text/plain", x::Irrational{sym}) where {sym}
+    print(io, sym, " = ", string(float(x))[1:15], "...")
+end
 
 promote_rule(::Type{<:AbstractIrrational}, ::Type{Float16}) = Float16
 promote_rule(::Type{<:AbstractIrrational}, ::Type{Float32}) = Float32

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -164,9 +164,9 @@ julia> a = Real[]
 
 julia> push!(a, 1); push!(a, 2.0); push!(a, π)
 3-element Array{Real,1}:
-  1
-  2.0
- π = 3.1415926535897...
+ 1
+ 2.0
+ π
 ```
 
 Because `a` is a an array of abstract type [`Real`](@ref), it must be able to hold any

--- a/test/math.jl
+++ b/test/math.jl
@@ -43,8 +43,11 @@ end
 
     @test Float16(3.0) < pi
     @test pi < Float16(4.0)
-    @test occursin("3.14159", sprint(show, π))
     @test widen(pi) === pi
+
+    @test occursin("3.14159", sprint(show, MIME"text/plain"(), π))
+    @test repr(Any[pi ℯ; ℯ pi]) == "Any[π ℯ; ℯ π]"
+    @test string(pi) == "π"
 end
 
 @testset "frexp,ldexp,significand,exponent" begin


### PR DESCRIPTION
`Irrational` currently has only one rather verbose output format. This makes show/print/string/repr just use the name, and uses the current verbose output for text/plain.