### PR TITLE
make length(::String, ::Int, ::Int, ::Int) private again

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -178,10 +178,10 @@ is_valid_continuation(c) = c & 0xc0 == 0x80
     b = codeunit(s, i)
     u = UInt32(b) << 24
     between(b, 0x80, 0xf7) || return reinterpret(Char, u), i+1
-    return next_continued(s, i, u)
+    return iterate_continued(s, i, u)
 end
 
-function next_continued(s::String, i::Int, u::UInt32)
+function iterate_continued(s::String, i::Int, u::UInt32)
     u < 0xc0000000 && (i += 1; @goto ret)
     n = ncodeunits(s)
     # first continuation byte
@@ -253,6 +253,8 @@ getindex(s::String, r::UnitRange{<:Integer}) = s[Int(first(r)):Int(last(r))]
     return ss
 end
 
+length(s::String) = length_continued(s, 1, ncodeunits(s), ncodeunits(s))
+
 @inline function length(s::String, i::Int, j::Int)
     @boundscheck begin
         0 < i ≤ ncodeunits(s)+1 || throw(BoundsError(s, i))
@@ -261,12 +263,10 @@ end
     j < i && return 0
     @inbounds i, k = thisind(s, i), i
     c = j - i + (i == k)
-    length(s, i, j, c)
+    length_continued(s, i, j, c)
 end
 
-length(s::String) = length(s, 1, ncodeunits(s), ncodeunits(s))
-
-@inline function length(s::String, i::Int, n::Int, c::Int)
+@inline function length_continued(s::String, i::Int, n::Int, c::Int)
     i < n || return c
     @inbounds b = codeunit(s, i)
     @inbounds while true


### PR DESCRIPTION
This was unintentionally made public by the great `_length` rename:

e99191a667e2a14c34186f54faed4e474943796c

Arrays and strings were using the `_length` name for private stuff
in different ways and the refactor made this part of the `length`
API when it should have remained private. Fortunately, it's not
documented and it seems unlikely that anyone is using it.

Also rename `next_continued` to `iterate_continued` to match the
name of the method that it's continuing.