### PR TITLE
fix `show` of GlobalRefs with macro names

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -969,7 +969,8 @@ end
 function show_call(io::IO, head, func, func_args, indent)
     op, cl = expr_calls[head]
     if (isa(func, Symbol) && func !== :(:) && !(head === :. && isoperator(func))) ||
-            (isa(func, Expr) && (func.head == :. || func.head == :curly))
+            (isa(func, Expr) && (func.head == :. || func.head == :curly)) ||
+            isa(func, GlobalRef)
         show_unquoted(io, func, indent)
     else
         print(io, '(')
@@ -999,7 +1000,7 @@ show_unquoted(io::IO, ex::GotoNode, ::Int, ::Int)       = print(io, "goto %", ex
 function show_unquoted(io::IO, ex::GlobalRef, ::Int, ::Int)
     print(io, ex.mod)
     print(io, '.')
-    quoted = !isidentifier(ex.name)
+    quoted = !isidentifier(ex.name) && !startswith(string(ex.name), "@")
     parens = quoted && (!isoperator(ex.name) || (ex.name in quoted_syms))
     quoted && print(io, ':')
     parens && print(io, '(')

--- a/doc/src/devdocs/reflection.md
+++ b/doc/src/devdocs/reflection.md
@@ -83,7 +83,7 @@ be passed instead!). For example:
 
 ```jldoctest; setup = :(using InteractiveUtils)
 julia> macroexpand(@__MODULE__, :(@edit println("")) )
-:((InteractiveUtils.edit)(println, (Base.typesof)("")))
+:(InteractiveUtils.edit(println, (Base.typesof)("")))
 ```
 
 The functions `Base.Meta.show_sexpr` and [`dump`](@ref) are used to display S-expr style views
@@ -99,7 +99,7 @@ julia> Meta.lower(@__MODULE__, :( [1+2, sin(0.5)] ))
     @ none within `top-level scope'
 1 ─ %1 = 1 + 2
 │   %2 = sin(0.5)
-│   %3 = (Base.vect)(%1, %2)
+│   %3 = Base.vect(%1, %2)
 └──      return %3
 ))))
 ```
@@ -142,7 +142,7 @@ debug information printed.
 julia> @code_typed debuginfo=:source +(1,1)
 CodeInfo(
     @ int.jl:53 within `+'
-1 ─ %1 = (Base.add_int)(x, y)::Int64
+1 ─ %1 = Base.add_int(x, y)::Int64
 └──      return %1
 ) => Int64
 ```

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -511,7 +511,7 @@ this is an extremely useful tool for debugging macros):
 
 ```julia-repl sayhello2
 julia> ex = macroexpand(Main, :(@sayhello("human")) )
-:((Main.println)("Hello, ", "human"))
+:(Main.println("Hello, ", "human"))
 
 julia> typeof(ex)
 Expr
@@ -524,7 +524,7 @@ There also exists a macro [`@macroexpand`](@ref) that is perhaps a bit more conv
 
 ```jldoctest sayhello2
 julia> @macroexpand @sayhello "human"
-:((println)("Hello, ", "human"))
+:(println("Hello, ", "human"))
 ```
 
 ### Hold up: why macros?
@@ -555,7 +555,7 @@ julia> typeof(ex)
 Expr
 
 julia> ex
-:((println)("I execute at runtime. The argument is: ", $(Expr(:copyast, :($(QuoteNode(:((1, 2, 3)))))))))
+:(println("I execute at runtime. The argument is: ", $(Expr(:copyast, :($(QuoteNode(:((1, 2, 3)))))))))
 
 julia> eval(ex)
 I execute at runtime. The argument is: (1, 2, 3)
@@ -698,14 +698,14 @@ julia> @macroexpand @assert a == b
 :(if Main.a == Main.b
         Main.nothing
     else
-        (Main.throw)((Main.AssertionError)("a == b"))
+        Main.throw(Main.AssertionError("a == b"))
     end)
 
 julia> @macroexpand @assert a==b "a should equal b!"
 :(if Main.a == Main.b
         Main.nothing
     else
-        (Main.throw)((Main.AssertionError)("a should equal b!"))
+        Main.throw(Main.AssertionError("a should equal b!"))
     end)
 ```
 

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -986,11 +986,11 @@ fake_repl() do stdin_write, stdout_read, repl
     end
     write(stdin_write, "Expr(:call, GlobalRef(Base.Math, :float), Core.SlotNumber(1))\n")
     readline(stdout_read)
-    @test readline(stdout_read) == "\e[0m:((Base.Math.float)(_1))"
+    @test readline(stdout_read) == "\e[0m:(Base.Math.float(_1))"
     write(stdin_write, "ans\n")
     readline(stdout_read)
     readline(stdout_read)
-    @test readline(stdout_read) == "\e[0m:((Base.Math.float)(_1))"
+    @test readline(stdout_read) == "\e[0m:(Base.Math.float(_1))"
     write(stdin_write, '\x04')
     Base.wait(repltask)
 end

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1300,7 +1300,7 @@ Int64
 
 julia> @code_warntype f(2)
 Body::UNION{FLOAT64, INT64}
-1 ─ %1 = (Base.slt_int)(1, a)::Bool
+1 ─ %1 = Base.slt_int(1, a)::Bool
 └──      goto #3 if not %1
 2 ─      return 1
 3 ─      return 1.0

--- a/test/show.jl
+++ b/test/show.jl
@@ -885,6 +885,7 @@ test_repr("a.:(begin
 test_repr("a.:(=)")
 test_repr("a.:(:)")
 test_repr("(:).a")
+@test eval(eval(Meta.parse(repr(:`ls x y`)))) == `ls x y`
 @test repr(Expr(:., :a, :b, :c)) == ":(\$(Expr(:., :a, :b, :c)))"
 @test repr(Expr(:., :a, :b)) == ":(\$(Expr(:., :a, :b)))"
 @test repr(Expr(:., :a)) == ":(\$(Expr(:., :a)))"


### PR DESCRIPTION
This allows command expressions to round-trip properly.