### PR TITLE
Docs on using dot-notation for modules in local scope

### DIFF
--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -196,8 +196,8 @@ Putting this statement in the file `~/.julia/config/startup.jl` will extend [`LO
 every Julia startup. Alternatively, the module load path can be extended by defining the environment
 variable `JULIA_LOAD_PATH`.
 
-Sometimes a module can be defined in the local scope, for example in the REPL, or from a file brought 
-into scope using `include()`. A module defined in this way can be loaded using the same syntax as 
+Sometimes a module can be defined in the local scope, for example in the REPL, or from a file brought
+into scope using `include()`. A module defined in this way can be loaded using the same syntax as
 loading a submodule from a relative path:
 
 ```julia

--- a/doc/src/manual/modules.md
+++ b/doc/src/manual/modules.md
@@ -196,6 +196,15 @@ Putting this statement in the file `~/.julia/config/startup.jl` will extend [`LO
 every Julia startup. Alternatively, the module load path can be extended by defining the environment
 variable `JULIA_LOAD_PATH`.
 
+Sometimes a module can be defined in the local scope, for example in the REPL, or from a file brought 
+into scope using `include()`. A module defined in this way can be loaded using the same syntax as 
+loading a submodule from a relative path:
+
+```julia
+include("MyModule.jl")
+using .MyModule
+```
+
 ### Namespace miscellanea
 
 If a name is qualified (e.g. `Base.sin`), then it can be accessed even if it is not exported.


### PR DESCRIPTION
I've added a short paragraph describing how to load a module if it
has been defined in local scope. Whilst the submodule notation is
introduced immediately above, it isn't clear whether the submodule
notation works in global scope without significant extra reading.
I believe this change makes things clearer for novice users, as
there are at least a couple of threads on discord asking how to do
this sort of thing.