### PR TITLE
default to /usr/bin/curl on macOS

### DIFF
--- a/base/download.jl
+++ b/base/download.jl
@@ -23,7 +23,9 @@ if Sys.iswindows()
     end
 else
     function download(url::AbstractString, filename::AbstractString)
-        if Sys.which("curl") !== nothing
+        if Sys.isapple() && Sys.isexecutable("/usr/bin/curl")
+            run(`/usr/bin/curl -g -L -f -o $filename $url`) # issue #30956
+        elseif Sys.which("curl") !== nothing
             run(`curl -g -L -f -o $filename $url`)
         elseif Sys.which("wget") !== nothing
             try


### PR DESCRIPTION
Fixes #30956.

We don't even document how `download()` decides what program to use, we want to default to a working `download` command if at all possible, and generally on macOS people don't expect that installing e.g. homebrew or anaconda will affect how "unrelated" programs like Julia work. 