### PR TITLE
Update round(::Missing) to match float version

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -116,13 +116,12 @@ round(::Type{T}, x::Any, ::RoundingMode=RoundNearest) where {T>:Missing} = round
 round(::Type{T}, x::Rational, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
 round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
 
-trunc(::Missing; kwargs...) = round(missing, RoundToZero; kwargs...)
-floor(::Missing; kwargs...) = round(missing, RoundDown; kwargs...)
- ceil(::Missing; kwargs...) = round(missing, RoundUp; kwargs...)
-
-trunc(::Type{T}, ::Missing) where {T} = round(T, missing, RoundToZero)
-floor(::Type{T}, ::Missing) where {T} = round(T, missing, RoundDown)
- ceil(::Type{T}, ::Missing) where {T} = round(T, missing, RoundUp)
+for f in (:(ceil), :(floor), :(trunc))
+    @eval begin
+        $(f)(::Missing; kwargs...) = round(T, missing; kwargs...)
+        $(f)(::Type{T}, ::Missing) where {T} = round(T, missing)
+    end
+end
 
 # to avoid ambiguity warnings
 (^)(::Missing, ::Integer) = missing

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -107,18 +107,22 @@ max(::Missing, ::Any)     = missing
 max(::Any,     ::Missing) = missing
 
 # Rounding and related functions
-for f in (:(ceil), :(floor), :(round), :(trunc))
-    @eval begin
-        ($f)(::Missing; digits::Integer=0, base::Integer=0) = missing
-        ($f)(::Type{>:Missing}, ::Missing) = missing
-        ($f)(::Type{T}, ::Missing) where {T} =
-            throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
-        ($f)(::Type{T}, x::Any) where {T>:Missing} = $f(nonmissingtype(T), x)
-        # to fix ambiguities
-        ($f)(::Type{T}, x::Rational) where {T>:Missing} = $f(nonmissingtype(T), x)
-        ($f)(::Type{T}, x::Rational{Bool}) where {T>:Missing} = $f(nonmissingtype(T), x)
-    end
-end
+round(::Missing, ::RoundingMode=RoundNearest; sigdigits::Integer=0, digits::Integer=0, base::Integer=0) = missing
+round(::Type{>:Missing}, ::Missing, ::RoundingMode=RoundNearest) = missing
+round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
+    throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
+round(::Type{T}, x::Any, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
+# to fix ambiguities
+round(::Type{T}, x::Rational, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
+round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
+
+trunc(::Missing; kwargs...) = round(missing, RoundToZero; kwargs...)
+floor(::Missing; kwargs...) = round(missing, RoundDown; kwargs...)
+ ceil(::Missing; kwargs...) = round(missing, RoundUp; kwargs...)
+
+trunc(::Type{T}, ::Missing; kwargs...) where {T} = round(T, missing, RoundToZero; kwargs...)
+floor(::Type{T}, ::Missing; kwargs...) where {T} = round(T, missing, RoundDown; kwargs...)
+ ceil(::Type{T}, ::Missing; kwargs...) where {T} = round(T, missing, RoundUp; kwargs...)
 
 # to avoid ambiguity warnings
 (^)(::Missing, ::Integer) = missing

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -109,7 +109,7 @@ max(::Any,     ::Missing) = missing
 # Rounding and related functions
 for f in (:(ceil), :(floor), :(round), :(trunc))
     @eval begin
-        ($f)(::Missing, digits::Integer=0, base::Integer=0) = missing
+        ($f)(::Missing; digits::Integer=0, base=0) = missing
         ($f)(::Type{>:Missing}, ::Missing) = missing
         ($f)(::Type{T}, ::Missing) where {T} =
             throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -113,8 +113,14 @@ round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
     throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
 round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 # to fix ambiguities
-round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
-round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
+round(::Type{T}, x::Rational) where {T>:Missing} = round(nonmissingtype(T), x)
+round(::Type{T}, x::Rational, ::RoundingMode{:Nearest}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearest)
+round(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesAway}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesAway)
+round(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesUp}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesUp)
+round(::Type{T}, x::Rational{Bool}) where {T>:Missing} = round(nonmissingtype(T), x)
+round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:Nearest}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearest)
+round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesAway}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesAway)
+round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesUp}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesUp)
 
 # Handle ceil, floor, and trunc separately as they have no RoundingMode argument
 for f in (:(ceil), :(floor), :(trunc))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -112,6 +112,9 @@ round(::Type{>:Missing}, ::Missing, ::RoundingMode=RoundNearest) = missing
 round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
     throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
 round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
+# to fix ambiguities
+round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
+round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 
 # Handle ceil, floor, and trunc separately as they have no RoundingMode argument
 for f in (:(ceil), :(floor), :(trunc))
@@ -121,6 +124,8 @@ for f in (:(ceil), :(floor), :(trunc))
         ($f)(::Type{T}, ::Missing) where {T} =
             throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
         ($f)(::Type{T}, x::Any) where {T>:Missing} = $f(nonmissingtype(T), x)
+        # to fix ambiguities
+        ($f)(::Type{T}, x::Rational) where {T>:Missing} = $f(nonmissingtype(T), x)
     end
 end
 

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -109,7 +109,7 @@ max(::Any,     ::Missing) = missing
 # Rounding and related functions
 for f in (:(ceil), :(floor), :(round), :(trunc))
     @eval begin
-        ($f)(::Missing; digits::Integer=0, base=0) = missing
+        ($f)(::Missing; digits::Integer=0, base::Integer=0) = missing
         ($f)(::Type{>:Missing}, ::Missing) = missing
         ($f)(::Type{T}, ::Missing) where {T} =
             throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -111,10 +111,10 @@ round(::Missing, ::RoundingMode=RoundNearest; sigdigits::Integer=0, digits::Inte
 round(::Type{>:Missing}, ::Missing, ::RoundingMode=RoundNearest) = missing
 round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
     throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
-round(::Type{T}, x::Any, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
+round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 # to fix ambiguities
-round(::Type{T}, x::Rational, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x)
+round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
+round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 
 # Handle ceil, floor, and trunc separately as they have no RoundingMode argument
 for f in (:(ceil), :(floor), :(trunc))

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -118,8 +118,8 @@ round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where {T>:Missi
 
 for f in (:(ceil), :(floor), :(trunc))
     @eval begin
-        $(f)(::Missing; kwargs...) = round(missing; kwargs...)
-        $(f)(::Type{T}, ::Missing) where {T} = round(T, missing)
+        ($f)(::Missing; kwargs...) = round(missing; kwargs...)
+        ($f)(::Type{T}, ::Missing) where {T} = round(T, missing)
     end
 end
 

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -112,9 +112,6 @@ round(::Type{>:Missing}, ::Missing, ::RoundingMode=RoundNearest) = missing
 round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
     throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
 round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
-# to fix ambiguities
-round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
-round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 
 # Handle ceil, floor, and trunc separately as they have no RoundingMode argument
 for f in (:(ceil), :(floor), :(trunc))
@@ -124,8 +121,6 @@ for f in (:(ceil), :(floor), :(trunc))
         ($f)(::Type{T}, ::Missing) where {T} =
             throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
         ($f)(::Type{T}, x::Any) where {T>:Missing} = $f(nonmissingtype(T), x)
-        # to fix ambiguities
-        ($f)(::Type{T}, x::Rational) where {T>:Missing} = $f(nonmissingtype(T), x)
     end
 end
 

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -120,9 +120,9 @@ trunc(::Missing; kwargs...) = round(missing, RoundToZero; kwargs...)
 floor(::Missing; kwargs...) = round(missing, RoundDown; kwargs...)
  ceil(::Missing; kwargs...) = round(missing, RoundUp; kwargs...)
 
-trunc(::Type{T}, ::Missing; kwargs...) where {T} = round(T, missing, RoundToZero; kwargs...)
-floor(::Type{T}, ::Missing; kwargs...) where {T} = round(T, missing, RoundDown; kwargs...)
- ceil(::Type{T}, ::Missing; kwargs...) where {T} = round(T, missing, RoundUp; kwargs...)
+trunc(::Type{T}, ::Missing) where {T} = round(T, missing, RoundToZero)
+floor(::Type{T}, ::Missing) where {T} = round(T, missing, RoundDown)
+ ceil(::Type{T}, ::Missing) where {T} = round(T, missing, RoundUp)
 
 # to avoid ambiguity warnings
 (^)(::Missing, ::Integer) = missing

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -118,7 +118,7 @@ round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where {T>:Missi
 
 for f in (:(ceil), :(floor), :(trunc))
     @eval begin
-        $(f)(::Missing; kwargs...) = round(T, missing; kwargs...)
+        $(f)(::Missing; kwargs...) = round(missing; kwargs...)
         $(f)(::Type{T}, ::Missing) where {T} = round(T, missing)
     end
 end

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -113,14 +113,8 @@ round(::Type{T}, ::Missing, ::RoundingMode=RoundNearest) where {T} =
     throw(MissingException("cannot convert a missing value to type $T: use Union{$T, Missing} instead"))
 round(::Type{T}, x::Any, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 # to fix ambiguities
-round(::Type{T}, x::Rational) where {T>:Missing} = round(nonmissingtype(T), x)
-round(::Type{T}, x::Rational, ::RoundingMode{:Nearest}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearest)
-round(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesAway}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesAway)
-round(::Type{T}, x::Rational, ::RoundingMode{:NearestTiesUp}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesUp)
-round(::Type{T}, x::Rational{Bool}) where {T>:Missing} = round(nonmissingtype(T), x)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:Nearest}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearest)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesAway}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesAway)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesUp}) where {T>:Missing} = round(nonmissingtype(T), x, RoundNearestTiesUp)
+round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
+round(::Type{T}, x::Rational{Bool}, r::RoundingMode=RoundNearest) where {T>:Missing} = round(nonmissingtype(T), x, r)
 
 # Handle ceil, floor, and trunc separately as they have no RoundingMode argument
 for f in (:(ceil), :(floor), :(trunc))
@@ -132,7 +126,6 @@ for f in (:(ceil), :(floor), :(trunc))
         ($f)(::Type{T}, x::Any) where {T>:Missing} = $f(nonmissingtype(T), x)
         # to fix ambiguities
         ($f)(::Type{T}, x::Rational) where {T>:Missing} = $f(nonmissingtype(T), x)
-        ($f)(::Type{T}, x::Rational{Bool}) where {T>:Missing} = $f(nonmissingtype(T), x)
     end
 end
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -368,9 +368,9 @@ end
 trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))
 floor(::Type{T}, x::Rational) where {T} = convert(T,fld(x.num,x.den))
 ceil(::Type{T}, x::Rational) where {T} = convert(T,cld(x.num,x.den))
+round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T} = _round_rational(T, x, r)
 
-
-function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr}
+function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr}
     if denominator(x) == zero(Tr) && T <: Integer
         throw(DivideError())
     elseif denominator(x) == zero(Tr)
@@ -384,9 +384,7 @@ function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr
     convert(T, s)
 end
 
-round(::Type{T}, x::Rational) where {T} = round(T, x, RoundNearest)
-
-function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway}) where {T,Tr}
+function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway}) where {T,Tr}
     if denominator(x) == zero(Tr) && T <: Integer
         throw(DivideError())
     elseif denominator(x) == zero(Tr)
@@ -400,7 +398,7 @@ function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesAway}) whe
     convert(T, s)
 end
 
-function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp}) where {T,Tr}
+function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp}) where {T,Tr}
     if denominator(x) == zero(Tr) && T <: Integer
         throw(DivideError())
     elseif denominator(x) == zero(Tr)
@@ -414,17 +412,12 @@ function round(::Type{T}, x::Rational{Tr}, ::RoundingMode{:NearestTiesUp}) where
     convert(T, s)
 end
 
-function round(::Type{T}, x::Rational{Bool}) where T
+function round(::Type{T}, x::Rational{Bool}, ::RoundingMode=RoundNearest) where T
     if denominator(x) == false && (T <: Union{Integer, Bool})
         throw(DivideError())
     end
     convert(T, x)
 end
-
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:Nearest}) where {T} = round(T, x)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesAway}) where {T} = round(T, x)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode{:NearestTiesUp}) where {T} = round(T, x)
-round(::Type{T}, x::Rational{Bool}, ::RoundingMode) where {T} = round(T, x)
 
 trunc(x::Rational{T}) where {T} = Rational(trunc(T,x))
 floor(x::Rational{T}) where {T} = Rational(floor(T,x))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -191,6 +191,8 @@ end
     # All rounding functions return missing when evaluating missing as first argument
     @test ismissing(round(missing, RoundToZero))
     @test ismissing(round(Union{Int, Missing}, missing, RoundToZero))
+    @test round(Union{Int, Missing}, 0.9) == round(Int, 0.9)
+    @test round(Union{Int, Missing}, 0.9, RoundToZero) == round(Int, 0.9, RoundToZero)
     @test ismissing.(round.([1.0, missing], RoundToZero)) == [false, true]
     @test ismissing.(round.(Union{Int, Missing}, [1.0, missing], RoundToZero)) == [false, true]
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -193,7 +193,7 @@ end
     @test ismissing(round(Union{Int, Missing}, missing, RoundToZero))
     @test round(Union{Int, Missing}, 0.9) === round(Int, 0.9)
     @test round(Union{Int, Missing}, 0.9, RoundToZero) === round(Int, 0.9, RoundToZero)
-    @test isequal(round.([1.0, missing], RoundToZero)), [1, missing])
+    @test isequal(round.([1.0, missing], RoundToZero), [1, missing])
     @test isequal(round.(Union{Int, Missing}, [1.0, missing], RoundToZero), [1, missing])
 
     rounding_functions = [ceil, floor, round, trunc]

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -198,6 +198,10 @@ end
         @test ismissing(f(Union{Int, Missing}, missing))
         @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
+        @test ismissing.(f.([1.0, missing])) == [false, true]
+        @test ismissing.(f.([1.0, missing], digits=1)) == [false, true]
+        @test ismissing.(f.([1.0, missing], digits=1, base=1)) == [false, true]
+        @test ismissing.(f.(Union{Int, Missing}, [1.0, missing])) == [false, true]
     end
 end
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -196,18 +196,17 @@ end
 
     # Test elementwise on mixed arrays to ensure signature of Missing methods matches that of Float methods
     test_array = [1.0, missing]
-    rounded_array = [1, missing]
 
-    @test isequal(round.(test_array, RoundNearest), rounded_array)
-    @test isequal(round.(Union{Int, Missing}, test_array, RoundNearest), rounded_array)
+    @test isequal(round.(test_array, RoundNearest), test_array)
+    @test isequal(round.(Union{Int, Missing}, test_array, RoundNearest), test_array)
 
     rounding_functions = [ceil, floor, round, trunc]
     for f in rounding_functions
         @test_throws MissingException f(Int, missing)
-        @test isequal(f.(test_array), rounded_array)
-        @test isequal(f.(test_array, digits=0, base=10), rounded_array)
-        @test isequal(f.(test_array, sigdigits=1, base=10), rounded_array)
-        @test isequal(f.(Union{Int, Missing}, test_array), rounded_array)
+        @test isequal(f.(test_array), test_array)
+        @test isequal(f.(test_array, digits=0, base=10), test_array)
+        @test isequal(f.(test_array, sigdigits=1, base=10), test_array)
+        @test isequal(f.(Union{Int, Missing}, test_array), test_array)
     end
 end
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -193,8 +193,8 @@ end
     # All rounding functions return missing when evaluating missing as first argument
     for f in rounding_functions
         @test ismissing(f(missing))
-        @test ismissing(f(missing, 1))
-        @test ismissing(f(missing, 1, 1))
+        @test ismissing(f(missing, digits=1))
+        @test ismissing(f(missing, digits=1, base=1))
         @test ismissing(f(Union{Int, Missing}, missing))
         @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -189,25 +189,25 @@ end
 
 @testset "rounding functions" begin
     # All rounding functions return missing when evaluating missing as first argument
-    @test ismissing(round(missing, RoundToZero))
-    @test ismissing(round(Union{Int, Missing}, missing, RoundToZero))
+
+    # Check that the RoundingMode argument is passed on correctly
     @test round(Union{Int, Missing}, 0.9) === round(Int, 0.9)
     @test round(Union{Int, Missing}, 0.9, RoundToZero) === round(Int, 0.9, RoundToZero)
-    @test isequal(round.([1.0, missing], RoundToZero), [1, missing])
-    @test isequal(round.(Union{Int, Missing}, [1.0, missing], RoundToZero), [1, missing])
+
+    # Test elementwise on mixed arrays to ensure signature of Missing methods matches that of Float methods
+    test_array = [1.0, missing]
+    rounded_array = [1, missing]
+
+    @test isequal(round.(test_array, RoundNearest), rounded_array)
+    @test isequal(round.(Union{Int, Missing}, test_array, RoundNearest), rounded_array)
 
     rounding_functions = [ceil, floor, round, trunc]
     for f in rounding_functions
-        @test ismissing(f(missing))
-        @test ismissing(f(missing, digits=0, base=2))
-        @test ismissing(f(missing, sigdigits=1, base=2))
-        @test ismissing(f(Union{Int, Missing}, missing))
-        @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
-        @test isequal(f.([1.0, missing]), [1, missing])
-        @test isequal(f.([1.0, missing], digits=0, base=10), [1, missing])
-        @test isequal(f.([1.0, missing], sigdigits=1, base=10), [1, missing])
-        @test isequal(f.(Union{Int, Missing}, [1.0, missing]), [1, missing])
+        @test isequal(f.(test_array), rounded_array)
+        @test isequal(f.(test_array, digits=0, base=10), rounded_array)
+        @test isequal(f.(test_array, sigdigits=1, base=10), rounded_array)
+        @test isequal(f.(Union{Int, Missing}, test_array), rounded_array)
     end
 end
 

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -199,13 +199,14 @@ end
     rounding_functions = [ceil, floor, round, trunc]
     for f in rounding_functions
         @test ismissing(f(missing))
-        @test ismissing(f(missing, sigdigits=1, digits=1, base=1))
+        @test ismissing(f(missing, digits=0, base=2))
+        @test ismissing(f(missing, sigdigits=1, base=2))
         @test ismissing(f(Union{Int, Missing}, missing))
         @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
         @test isequal(f.([1.0, missing]), [1, missing])
-        @test isequal(f.([1.0, missing], digits=1), [1, missing])
-        @test isequal(f.([1.0, missing], digits=1, base=1), [1, missing])
+        @test isequal(f.([1.0, missing], digits=0, base=10), [1, missing])
+        @test isequal(f.([1.0, missing], sigdigits=1, base=10), [1, missing])
         @test isequal(f.(Union{Int, Missing}, [1.0, missing]), [1, missing])
     end
 end

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -188,13 +188,16 @@ Base.one(::Type{Unit}) = 1
 end
 
 @testset "rounding functions" begin
-    rounding_functions = [ceil, floor, round, trunc]
-
     # All rounding functions return missing when evaluating missing as first argument
+    @test ismissing(round(missing, RoundToZero))
+    @test ismissing(round(Union{Int, Missing}, missing, RoundToZero))
+    @test ismissing.(round.([1.0, missing], RoundToZero)) == [false, true]
+    @test ismissing.(round.(Union{Int, Missing}, [1.0, missing], RoundToZero)) == [false, true]
+
+    rounding_functions = [ceil, floor, round, trunc]
     for f in rounding_functions
         @test ismissing(f(missing))
-        @test ismissing(f(missing, digits=1))
-        @test ismissing(f(missing, digits=1, base=1))
+        @test ismissing(f(missing, sigdigits=1, digits=1, base=1))
         @test ismissing(f(Union{Int, Missing}, missing))
         @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -191,10 +191,10 @@ end
     # All rounding functions return missing when evaluating missing as first argument
     @test ismissing(round(missing, RoundToZero))
     @test ismissing(round(Union{Int, Missing}, missing, RoundToZero))
-    @test round(Union{Int, Missing}, 0.9) == round(Int, 0.9)
-    @test round(Union{Int, Missing}, 0.9, RoundToZero) == round(Int, 0.9, RoundToZero)
-    @test ismissing.(round.([1.0, missing], RoundToZero)) == [false, true]
-    @test ismissing.(round.(Union{Int, Missing}, [1.0, missing], RoundToZero)) == [false, true]
+    @test round(Union{Int, Missing}, 0.9) === round(Int, 0.9)
+    @test round(Union{Int, Missing}, 0.9, RoundToZero) === round(Int, 0.9, RoundToZero)
+    @test isequal(round.([1.0, missing], RoundToZero)), [1, missing])
+    @test isequal(round.(Union{Int, Missing}, [1.0, missing], RoundToZero), [1, missing])
 
     rounding_functions = [ceil, floor, round, trunc]
     for f in rounding_functions
@@ -203,10 +203,10 @@ end
         @test ismissing(f(Union{Int, Missing}, missing))
         @test f(Union{Int, Missing}, 1.0) === 1
         @test_throws MissingException f(Int, missing)
-        @test ismissing.(f.([1.0, missing])) == [false, true]
-        @test ismissing.(f.([1.0, missing], digits=1)) == [false, true]
-        @test ismissing.(f.([1.0, missing], digits=1, base=1)) == [false, true]
-        @test ismissing.(f.(Union{Int, Missing}, [1.0, missing])) == [false, true]
+        @test isequal(f.([1.0, missing]), [1, missing])
+        @test isequal(f.([1.0, missing], digits=1), [1, missing])
+        @test isequal(f.([1.0, missing], digits=1, base=1), [1, missing])
+        @test isequal(f.(Union{Int, Missing}, [1.0, missing]), [1, missing])
     end
 end
 


### PR DESCRIPTION
`round()` was updated to accept `digits` and `base` as keyword arguments. It looks like the `Missing` version was... missed? 😈

This prevents e.g. `round(A, digits=4)` and `round(A, 4)` (old signature) from working on `Union{Missing, Float64}` arrays `A`.

Fixes #31076