### PR TITLE
Workaround #28126, support SIMDing broadcast in more cases

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -464,7 +464,8 @@ julia> Broadcast.combine_axes(1, 1, 1)
 ()
 ```
 """
-@inline combine_axes(A, B...) = broadcast_shape(axes(A), combine_axes(B...))
+@inline combine_axes(A, B, C...) = broadcast_shape(axes(A), combine_axes(B, C...))
+@inline combine_axes(A, B) = broadcast_shape(axes(A), axes(B))
 combine_axes(A) = axes(A)
 
 # shape (i.e., tuple-of-indices) inputs
@@ -502,7 +503,7 @@ function check_broadcast_shape(shp, Ashp::Tuple)
     _bcsm(shp[1], Ashp[1]) || throw(DimensionMismatch("array could not be broadcast to match destination"))
     check_broadcast_shape(tail(shp), tail(Ashp))
 end
-check_broadcast_axes(shp, A) = check_broadcast_shape(shp, axes(A))
+@inline check_broadcast_axes(shp, A) = check_broadcast_shape(shp, axes(A))
 # comparing many inputs
 @inline function check_broadcast_axes(shp, A, As...)
     check_broadcast_axes(shp, A)
@@ -911,7 +912,7 @@ _is_static_broadcast_28126(dest::AbstractArray, x::AbstractArray{<:Any,1}) = axe
 _is_static_broadcast_28126(dest::AbstractArray, x::AbstractArray) = axes(dest) == axes(x) # This can be better with other missing dimensions
 
 @inline _is_static_broadcast_28126_args(dest, args::Tuple) = _is_static_broadcast_28126(dest, args[1]) && _is_static_broadcast_28126_args(dest, tail(args))
-_is_static_broadcast_28126_args(dest, args::Tuple{Any}) = _is_static_broadcast_28126(dest, args[1])
+@inline _is_static_broadcast_28126_args(dest, args::Tuple{Any}) = _is_static_broadcast_28126(dest, args[1])
 _is_static_broadcast_28126_args(dest, args::Tuple{}) = true
 
 struct _NonExtruded28126{T}

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -870,7 +870,7 @@ broadcast_unalias(::Nothing, src) = src
 preprocess(f, dest, x) = f(broadcast_unalias(dest, x))
 
 @inline preprocess_args(f, dest, args::Tuple) = (preprocess(f, dest, args[1]), preprocess_args(f, dest, tail(args))...)
-preprocess_args(f, dest, args::Tuple{Any}) = (preprocess(f, dest, args[1]),)
+@inline preprocess_args(f, dest, args::Tuple{Any}) = (preprocess(f, dest, args[1]),)
 preprocess_args(f, dest, args::Tuple{}) = ()
 
 # Specialize this method if all you want to do is specialize on typeof(dest)

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -918,7 +918,10 @@ struct _NonExtruded28126{T}
     x::T
 end
 @inline axes(b::_NonExtruded28126) = axes(b.x)
-Base.@propagate_inbounds _broadcast_getindex(b::_NonExtruded28126, i) = b.x[i]
+Base.@propagate_inbounds _broadcast_getindex(b::_NonExtruded28126, i) = _broadcast_getindex(b, i)
+Base.@propagate_inbounds _broadcast_getindex(b::_NonExtruded28126{<:AbstractArray{<:Any,0}}, i) = b.x[]
+Base.@propagate_inbounds _broadcast_getindex(b::_NonExtruded28126{<:AbstractVector}, i) = b.x[i[1]]
+Base.@propagate_inbounds _broadcast_getindex(b::_NonExtruded28126{<:AbstractArray}, i) = b.x[i]
 _nonextrude_28126(x::AbstractArray) = _NonExtruded28126(x)
 _nonextrude_28126(x) = x
 

--- a/test/boundscheck_exec.jl
+++ b/test/boundscheck_exec.jl
@@ -251,5 +251,13 @@ if bc_opt == bc_default || bc_opt == bc_off
     @test occursin("vector.body", sprint(code_llvm, g27079, Tuple{Vector{Int}}))
 end
 
+# Ensure broadcasting can vectorize when bounds checks are off
+if bc_opt != bc_on
+    function goo28126(u, uprev, k1, k2, k3, k4, k5, k6, k7)
+        @. u = uprev + 0.1*(0.1*k1 + 0.2*k2 + 0.3*k3 + 0.4*k4 + 0.5*k5 + 0.6*k6 + 0.7*k7)
+        nothing
+    end
+    @test occursin("vector.body", sprint(code_llvm, goo28126, NTuple{9, Vector{Float32}}))
+end
 
 end

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -791,14 +791,15 @@ let
 end
 
 @testset "large fusions vectorize and don't allocate (#28126)" begin
-    u, k1, k2, k3, k4, k5, k6, k7 = (ones(1000) for i in 1:8)
-    function goo(u, k1, k2, k3, k4, k5, k6, k7)
-        @. u = 0.1*(0.1*k1 + 0.2*k2 + 0.3*k3 + 0.4*k4 + 0.5*k5 + 0.6*k6 + 0.7*k7)
+    using InteractiveUtils: code_llvm
+    u, uprev, k1, k2, k3, k4, k5, k6, k7 = (ones(1000) for i in 1:9)
+    function goo(u, uprev, k1, k2, k3, k4, k5, k6, k7)
+        @. u = uprev + 0.1*(0.1*k1 + 0.2*k2 + 0.3*k3 + 0.4*k4 + 0.5*k5 + 0.6*k6 + 0.7*k7)
         nothing
     end
-    @allocated goo(u, k1, k2, k3, k4, k5, k6, k7)
-    @test @allocated(goo(u, k1, k2, k3, k4, k5, k6, k7)) == 0
-    @test occursin("vector.body", sprint(code_llvm, goo, NTuple{8, Vector{Float32}}))
+    @allocated goo(u, uprev, k1, k2, k3, k4, k5, k6, k7)
+    @test @allocated(goo(u, uprev, k1, k2, k3, k4, k5, k6, k7)) == 0
+    @test occursin("vector.body", sprint(code_llvm, goo, NTuple{9, Vector{Float32}}))
 end
 
 # Broadcasted iterable/indexable APIs

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -791,7 +791,6 @@ let
 end
 
 @testset "large fusions vectorize and don't allocate (#28126)" begin
-    using InteractiveUtils: code_llvm
     u, uprev, k1, k2, k3, k4, k5, k6, k7 = (ones(1000) for i in 1:9)
     function goo(u, uprev, k1, k2, k3, k4, k5, k6, k7)
         @. u = uprev + 0.1*(0.1*k1 + 0.2*k2 + 0.3*k3 + 0.4*k4 + 0.5*k5 + 0.6*k6 + 0.7*k7)
@@ -799,7 +798,6 @@ end
     end
     @allocated goo(u, uprev, k1, k2, k3, k4, k5, k6, k7)
     @test @allocated(goo(u, uprev, k1, k2, k3, k4, k5, k6, k7)) == 0
-    @test occursin("vector.body", sprint(code_llvm, goo, NTuple{9, Vector{Float32}}))
 end
 
 # Broadcasted iterable/indexable APIs

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -790,6 +790,17 @@ let
     @test Dict(c .=> d) == Dict("foo" => 1, "bar" => 2)
 end
 
+@testset "large fusions vectorize and don't allocate (#28126)" begin
+    u, k1, k2, k3, k4, k5, k6, k7 = (ones(1000) for i in 1:8)
+    function goo(u, k1, k2, k3, k4, k5, k6, k7)
+        @. u = 0.1*(0.1*k1 + 0.2*k2 + 0.3*k3 + 0.4*k4 + 0.5*k5 + 0.6*k6 + 0.7*k7)
+        nothing
+    end
+    @allocated goo(u, k1, k2, k3, k4, k5, k6, k7)
+    @test @allocated(goo(u, k1, k2, k3, k4, k5, k6, k7)) == 0
+    @test occursin("vector.body", sprint(code_llvm, goo, NTuple{8, Vector{Float32}}))
+end
+
 # Broadcasted iterable/indexable APIs
 let
     bc = Broadcast.instantiate(Broadcast.broadcasted(+, zeros(5), 5))


### PR DESCRIPTION
This is an ugly performance hack around issue #28126 in some limited (but common) cases. The problem in short: when given many arrays of the same size, LLVM has difficulty hoisting the decision of whether a given dimension should be "extruded" out of the loop. This extra indirection in the index computation seems to foil the array bounds aliasing checks, which stymies SIMDification. The solution: check to see if _Julia_ can statically decide whether or not to extrude any dimensions in a given broadcast expression -- and if so, use a special array wrapper that flags that none of the dimensions in that array need to be extruded out in order to perform the broadcast.

No idea if tests will pass or if this actually is a good idea in general.

@nanosoldier `runbenchmarks(ALL, vs = ":master")` (edit: whoops, sorry Nanosoldier — should have waited for CI before sending you down a dead-end alley)