### PR TITLE
do less inference in top-level expressions

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -62,10 +62,16 @@ function abstract_call_gf_by_type(@nospecialize(f), argtypes::Vector{Any}, @nosp
     edges = Any[]
     nonbot = 0  # the index of the only non-Bottom inference result if > 0
     seen = 0    # number of signatures actually inferred
+    istoplevel = sv.linfo.def isa Module
     for i in 1:napplicable
         match = applicable[i]::SimpleVector
         method = match[3]::Method
         sig = match[1]
+        if istoplevel && !isdispatchtuple(sig)
+            # only infer concrete call sites in top-level expressions
+            rettype = Any
+            break
+        end
         sigtuple = unwrap_unionall(sig)::DataType
         splitunions = false
         this_rt = Bottom


### PR DESCRIPTION
This is very helpful for avoiding situations like https://discourse.julialang.org/t/strange-issue-with-julia-hanging/20298 --- there, we decide to infer and optimize a top-level expression, but it refers to non-constant globals, which kicks off a lot of inference of abstract method signatures. That's not useful, since we don't need to determine a return type for a top-level expression.

Of course this might also slow down some top-level code, but the top level is never going to be very fast anyway. Only optimizing where we have full type information seems like a good compromise (for now).