### PR TITLE
Avoid allocating a vector with typemax(Int) entries from read

### DIFF
--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -458,14 +458,15 @@ function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)
 end
 
 function readbytes_some!(s::IOStream, b::Array{UInt8}, nb)
-    olb = lb = length(b)
-    if nb > lb
+    olb = length(b)
+    if nb > olb
         resize!(b, nb)
     end
     nr = GC.@preserve b Int(ccall(:ios_read, Csize_t, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t),
                                   s.ios, pointer(b), nb))
+    lb = length(b)
     if lb > olb && lb > nr
-        resize!(b, nr)
+        resize!(b, nr) # shrink to just contain input data if was resized
     end
     return nr
 end
@@ -477,7 +478,10 @@ Read at most `nb` bytes from `stream` into `b`, returning the number of bytes re
 The size of `b` will be increased if needed (i.e. if `nb` is greater than `length(b)`
 and enough bytes could be read), but it will never be decreased.
 
-See [`read`](@ref) for a description of the `all` option.
+If `all` is `true` (the default), this function will block repeatedly trying to read all
+requested bytes, until an error or end-of-file occurs. If `all` is `false`, at most one
+`read` call is performed, and the amount of data returned is device-dependent. Note that not
+all stream types support the `all` option.
 """
 function readbytes!(s::IOStream, b::Array{UInt8}, nb=length(b); all::Bool=true)
     return all ? readbytes_all!(s, b, nb) : readbytes_some!(s, b, nb)
@@ -509,7 +513,9 @@ requested bytes, until an error or end-of-file occurs. If `all` is `false`, at m
 all stream types support the `all` option.
 """
 function read(s::IOStream, nb::Integer; all::Bool=true)
-    b = Vector{UInt8}(undef, nb)
+    # When all=false we have to allocate a buffer of the requested size upfront
+    # since a single call will be made
+    b = Vector{UInt8}(undef, all && nb == typemax(Int) ? 1024 : nb)
     nr = readbytes!(s, b, nb, all=all)
     resize!(b, nr)
 end

--- a/base/iostream.jl
+++ b/base/iostream.jl
@@ -452,7 +452,7 @@ function readbytes_all!(s::IOStream, b::Array{UInt8}, nb)
         eof(s) && break
     end
     if lb > olb && lb > nr
-        resize!(b, nr) # shrink to just contain input data if was resized
+        resize!(b, max(olb, nr)) # shrink to just contain input data if was resized
     end
     return nr
 end
@@ -466,7 +466,7 @@ function readbytes_some!(s::IOStream, b::Array{UInt8}, nb)
                                   s.ios, pointer(b), nb))
     lb = length(b)
     if lb > olb && lb > nr
-        resize!(b, nr) # shrink to just contain input data if was resized
+        resize!(b, max(olb, nr)) # shrink to just contain input data if was resized
     end
     return nr
 end

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -85,18 +85,19 @@ end
 @test Base.open_flags(read=false, write=true, append=false) == (read=false, write=true, create=true, truncate=true, append=false)
 
 @testset "issue #30978" begin
-    path, io = mktemp()
-    x = rand(UInt8, 100)
-    write(path, x)
-    # Should not throw OutOfMemoryError
-    y = open(x -> read(x, typemax(Int)), path)
-    @test x == y
+    mktemp() do path, io
+        x = rand(UInt8, 100)
+        write(path, x)
+        # Should not throw OutOfMemoryError
+        y = open(x -> read(x, typemax(Int)), path)
+        @test x == y
 
-    # Should resize y to right length
-    y = zeros(UInt8, 99)
-    open(x -> readbytes!(x, y, 101, all=true), path)
-    @test x == y
-    y = zeros(UInt8, 99)
-    open(x -> readbytes!(x, y, 101, all=false), path)
-    @test x == y
+        # Should resize y to right length
+        y = zeros(UInt8, 99)
+        open(x -> readbytes!(x, y, 101, all=true), path)
+        @test x == y
+        y = zeros(UInt8, 99)
+        open(x -> readbytes!(x, y, 101, all=false), path)
+        @test x == y
+    end
 end

--- a/test/iostream.jl
+++ b/test/iostream.jl
@@ -89,15 +89,23 @@ end
         x = rand(UInt8, 100)
         write(path, x)
         # Should not throw OutOfMemoryError
-        y = open(x -> read(x, typemax(Int)), path)
+        y = open(f -> read(f, typemax(Int)), path)
         @test x == y
 
         # Should resize y to right length
         y = zeros(UInt8, 99)
-        open(x -> readbytes!(x, y, 101, all=true), path)
+        open(f -> readbytes!(f, y, 101, all=true), path)
         @test x == y
         y = zeros(UInt8, 99)
-        open(x -> readbytes!(x, y, 101, all=false), path)
+        open(f -> readbytes!(f, y, 101, all=false), path)
         @test x == y
+
+        # Should never shrink y below original size
+        y = zeros(UInt8, 101)
+        open(f -> readbytes!(f, y, 102, all=true), path)
+        @test y == [x; 0]
+        y = zeros(UInt8, 101)
+        open(f -> readbytes!(f, y, 102, all=false), path)
+        @test y == [x; 0]
     end
 end


### PR DESCRIPTION
Also fix a bug when `all=false` and the input vector is too small, and improve docstrings a bit.

Fixes #30978.