### PR TITLE
Fix dump(::NamedTuple)

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1713,7 +1713,7 @@ function dump(io::IOContext, x::DataType, n::Int, indent)
     if x !== Any
         print(io, " <: ", supertype(x))
     end
-    if n > 0 && !(x <: Tuple) && !x.abstract
+    if n > 0 && !(x <: Tuple || x <: NamedTuple) && !x.abstract
         tvar_io::IOContext = io
         for tparam in x.parameters
             # approximately recapture the list of tvar parameterization

--- a/test/show.jl
+++ b/test/show.jl
@@ -796,6 +796,9 @@ end
 let repr = sprint(dump, Tuple)
     @test repr == "Tuple <: Any\n"
 end
+let repr = sprint(dump, NamedTuple)
+    @test repr == "NamedTuple <: Any\n"
+end
 let repr = sprint(dump, Int64)
     @test repr == "Int64 <: Signed\n"
 end


### PR DESCRIPTION
I'm not sure if this is the ideal way to print it, but it's consistent with `Tuple`.

Fixes #30985.