### PR TITLE
WIP: Add a flag to trace inference's heuristic limiting decisions

### DIFF
--- a/base/compiler/params.jl
+++ b/base/compiler/params.jl
@@ -34,6 +34,10 @@ struct Params
     # contains more than this many elements
     MAX_TUPLE_SPLAT::Int
 
+    # Whether to trace when inference decides to truncate inference
+    trace_inference_limits::Bool
+    trace_buffer::Vector{Any}
+
     # reasonable defaults
     global function CustomParams(world::UInt,
                     ;
@@ -47,13 +51,14 @@ struct Params
                     tupletype_depth::Int = DEFAULT_PARAMS.TUPLE_COMPLEXITY_LIMIT_DEPTH,
                     tuple_splat::Int = DEFAULT_PARAMS.MAX_TUPLE_SPLAT,
                     union_splitting::Int = DEFAULT_PARAMS.MAX_UNION_SPLITTING,
-                    apply_union_enum::Int = DEFAULT_PARAMS.MAX_APPLY_UNION_ENUM)
+                    apply_union_enum::Int = DEFAULT_PARAMS.MAX_APPLY_UNION_ENUM,
+                    trace_inference_limits::Bool = false)
         return new(Vector{InferenceResult}(),
                    world, false,
                    inlining, ipo_constant_propagation, aggressive_constant_propagation,
                    inline_cost_threshold, inline_nonleaf_penalty, inline_tupleret_bonus,
                    max_methods, union_splitting, apply_union_enum, tupletype_depth,
-                   tuple_splat)
+                   tuple_splat, trace_inference_limits, Any[])
     end
     function Params(world::UInt)
         inlining = inlining_enabled()
@@ -64,7 +69,7 @@ struct Params
                    #=inline_tupleret_bonus, max_methods, union_splitting, apply_union_enum=#
                    400, 4, 4, 8,
                    #=tupletype_depth, tuple_splat=#
-                   3, 32)
+                   3, 32, false, Any[])
     end
 end
 const DEFAULT_PARAMS = Params(UInt(0))

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -962,7 +962,8 @@ possible options are `:source` or `:none`.
 function code_typed(@nospecialize(f), @nospecialize(types=Tuple);
                     optimize=true, debuginfo::Symbol=:default,
                     world = ccall(:jl_get_world_counter, UInt, ()),
-                    params = Core.Compiler.Params(world))
+                    trace = false,
+                    params = Core.Compiler.CustomParams(world; trace_inference_limits=trace))
     ccall(:jl_is_in_pure_context, Bool, ()) && error("code reflection cannot be used from generated functions")
     if isa(f, Core.Builtin)
         throw(ArgumentError("argument is not a generic function"))
@@ -983,6 +984,11 @@ function code_typed(@nospecialize(f), @nospecialize(types=Tuple);
         code === nothing && error("inference not successful") # inference disabled?
         debuginfo == :none && remove_linenums!(code)
         push!(asts, code => ty)
+    end
+    if trace && !isempty(params.trace_buffer)
+        for entry in params.trace_buffer
+            @info entry
+        end
     end
     return asts
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1614,6 +1614,15 @@ function show(io::IO, src::CodeInfo; debuginfo::Symbol=:source)
     print(io, ")")
 end
 
+# Show for inference limit trace objects
+function show(io::IO, ecl::Core.Compiler.EdgeCycleLimited)
+    print(io, "Signature ")
+    show_tuple_as_call(io, Symbol("<unknown>"), ecl.sig)
+    print(io, " was narrowed to ")
+    show_tuple_as_call(io, Symbol("<unknown>"), ecl.newsig)
+    println(io, " due to recursion [EdgeCycleLimited]")
+end
+
 
 function dump(io::IOContext, x::SimpleVector, n::Int, indent)
     if isempty(x)


### PR DESCRIPTION
There's generally two reasons for sub-optimal type inference.
1) The user did something that inference couldn't reason about (read from a global,
   get an arbitrary object from the network, deserialization, etc). We now have
   some pretty good tooling to detect this (e.g. interactively in Cthulhu.jl and
   some basic automation in XLA.jl).
2) Inference decided that it wouldn't be worth further pursuing an inference avenue
   (e.g. because of recursion or because one of our other inference limits).

Hitting the second case is frustrating, because the limits don't apply transitively
(e.g. you may enter a method that infers fine if used as the starting method, but
does not infer properly if called from another method). These cases are frustrating
because our tooling gets confused (since at the leaf, it infers fine). They are also
really hard to debug (esp to people not intimately familiar with inference).

This attempts to add some tooling that allows users to ask inference to tell us when
it hits this limits. The tracing is enabled by a special flag in the Params object and
each kind of limit is supposed to be its own kind of object (in order for it to be
automatically consumable by tooling). I also added a flag to code_typed that will just
dump out each trace entry as an info log record. Example usage:

```
julia> f(::Val{4000}) = 0
f (generic function with 1 methods)

julia> f(::Val{n}) where {n} = f(Val(n+1))
f (generic function with 2 methods)

julia> @eval @code_typed optimize=false trace=true f(Val(1))
[ Info: Signature f(::Val{4}) was narrowed to f(::Val) due to recursion [EdgeCycleLimited]
CodeInfo(
1 ─ %1 = ($(Expr(:static_parameter, 1)) + 1)::Const(2, false)
│   %2 = Main.Val(%1)::Const(Val{2}(), true)
│   %3 = Main.f(%2)::Const(0, false)
└──      return %3
) => Int64
```

I intend to add more features to this before merging this and prototype some integration with the above mentioned tools, but wanted to open this early for discussion. 