### PR TITLE
Fix `llvmcall` in uninferred code

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -946,14 +946,14 @@ static jl_cgval_t emit_llvmcall(jl_codectx_t &ctx, jl_value_t **args, size_t nar
     if (jl_is_ssavalue(ir_arg))
         ir_arg = jl_arrayref((jl_array_t*)ctx.source->code, ((jl_ssavalue_t*)ir_arg)->id - 1);
     ir = try_eval(ctx, ir_arg, "error statically evaluating llvm IR argument");
-    if (jl_is_ssavalue(args[2])) {
+    if (jl_is_ssavalue(args[2]) && jl_is_array(ctx.source->ssavaluetypes)) {
         jl_value_t *rtt = jl_arrayref((jl_array_t*)ctx.source->ssavaluetypes, ((jl_ssavalue_t*)args[2])->id - 1);
         if (jl_is_type_type(rtt))
             rt = jl_tparam0(rtt);
     }
     if (rt == NULL)
         rt = try_eval(ctx, args[2], "error statically evaluating llvmcall return type");
-    if (jl_is_ssavalue(args[3])) {
+    if (jl_is_ssavalue(args[3]) && jl_is_array(ctx.source->ssavaluetypes)) {
         jl_value_t *att = jl_arrayref((jl_array_t*)ctx.source->ssavaluetypes, ((jl_ssavalue_t*)args[3])->id - 1);
         if (jl_is_type_type(att))
             at = jl_tparam0(att);


### PR DESCRIPTION
Before inference is run, `ssavaluetypes` is not an array, but an integer, and cannot by used to obtain the type. Instead, only use `try_eval` which is sufficient for common cases like a `Tuple` of const types.

I ran into this when trying to use `llvmcall` inside `corecompiler`. Not sure how to test, though. Is there a way to compile a function without inferring it in a proper julia?