### PR TITLE
fix overflow in CartesianIndices iteration

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1604,10 +1604,11 @@ CartesianIndex(2, 1)
 function findnext(A, start)
     l = last(keys(A))
     i = start
-    while i <= l
-        if A[i]
-            return i
-        end
+    i > l && return nothing
+    while true
+        A[i] && return i
+        i == l && break
+        # nextind(A, l) can throw/overflow
         i = nextind(A, i)
     end
     return nothing
@@ -1685,10 +1686,11 @@ CartesianIndex(1, 1)
 function findnext(testf::Function, A, start)
     l = last(keys(A))
     i = start
-    while i <= l
-        if testf(A[i])
-            return i
-        end
+    i > l && return nothing
+    while true
+        testf(A[i]) && return i
+        i == l && break
+        # nextind(A, l) can throw/overflow
         i = nextind(A, i)
     end
     return nothing
@@ -1781,8 +1783,12 @@ CartesianIndex(2, 1)
 """
 function findprev(A, start)
     i = start
-    while i >= first(keys(A))
+    f = first(keys(A))
+    i < f && return nothing
+    while true
         A[i] && return i
+        i == f && break
+        # prevind(A, l) can throw/underflow
         i = prevind(A, i)
     end
     return nothing
@@ -1868,8 +1874,12 @@ CartesianIndex(2, 1)
 """
 function findprev(testf::Function, A, start)
     i = start
-    while i >= first(keys(A))
+    f = first(keys(A))
+    i < f && return nothing
+    while true
         testf(A[i]) && return i
+        i == f && break
+        # prevind(A, l) can throw/underflow
         i = prevind(A, i)
     end
     return nothing

--- a/base/array.jl
+++ b/base/array.jl
@@ -1788,7 +1788,7 @@ function findprev(A, start)
     while true
         A[i] && return i
         i == f && break
-        # prevind(A, l) can throw/underflow
+        # prevind(A, f) can throw/underflow
         i = prevind(A, i)
     end
     return nothing
@@ -1879,7 +1879,7 @@ function findprev(testf::Function, A, start)
     while true
         testf(A[i]) && return i
         i == f && break
-        # prevind(A, l) can throw/underflow
+        # prevind(A, f) can throw/underflow
         i = prevind(A, i)
     end
     return nothing

--- a/test/cartesian.jl
+++ b/test/cartesian.jl
@@ -15,3 +15,52 @@ ex = Base.Cartesian.exprresolve(:(if 5 > 4; :x; else :y; end))
     # can't convert higher-dimensional indices to Int
     @test_throws MethodError convert(Int, CartesianIndex(42, 1))
 end
+
+@testset "CartesianIndices overflow" begin
+    I = CartesianIndices((1:typemax(Int),))
+    i = last(I)
+    @test iterate(I, i) === nothing
+
+    I = CartesianIndices((1:(typemax(Int)-1),))
+    i = CartesianIndex(typemax(Int))
+    @test iterate(I, i) === nothing
+
+    I = CartesianIndices((1:typemax(Int), 1:typemax(Int)))
+    i = last(I)
+    @test iterate(I, i) === nothing
+
+    i = CartesianIndex(typemax(Int), 1)
+    @test iterate(I, i) === (CartesianIndex(1, 2), CartesianIndex(1,2))
+
+    # reverse cartesian indices
+    I = CartesianIndices((typemin(Int):(typemin(Int)+3),))
+    i = last(I)
+    @test iterate(I, i) === nothing
+end
+
+@testset "CartesianIndices iteration" begin
+    I = CartesianIndices((2:4, 0:1, 1:1, 3:5))
+    indices = Vector{eltype(I)}()
+    for i in I
+        push!(indices, i)
+    end
+    @test length(I) == length(indices)
+    @test vec(I) == indices
+
+    empty!(indices)
+    I = Iterators.reverse(I)
+    for i in I
+        push!(indices, i)
+    end
+    @test length(I) == length(indices)
+    @test vec(collect(I)) == indices
+
+    # test invalid state
+    I = CartesianIndices((2:4, 3:5))
+    @test iterate(I, CartesianIndex(typemax(Int), 3))[1] == CartesianIndex(2,4)
+    @test iterate(I, CartesianIndex(typemax(Int), 4))[1] == CartesianIndex(2,5)
+    @test iterate(I, CartesianIndex(typemax(Int), 5))    === nothing
+
+    @test iterate(I, CartesianIndex(3, typemax(Int)))[1] == CartesianIndex(4,typemax(Int))
+    @test iterate(I, CartesianIndex(4, typemax(Int)))    === nothing
+end


### PR DESCRIPTION
Make iteration over CartesianIndices blazing fast.
Fixes #30998, by avoiding the potential overflow.

LLVM was right..., based on the given semantics it
is not possible to determine the loop-bounds of the
loop in:

```julia
function vecfail(A)
     @inbounds begin
         acc = zero(eltype(A))
         N = length(A)
         for I in CartesianIndices(A)
              acc = Base.FastMath.add_fast(acc, A[I])
         end
     end
     return acc
end
```

Since it is possible for the iteration to overflow:

```julia-repl
julia> I = CartesianIndices(1:typemax(Int64));

julia> i= last(I)
CartesianIndex(9223372036854775807,)

julia> iterate(I, i)
(CartesianIndex(-9223372036854775808,), CartesianIndex(-9223372036854775808,))
```