### PR TITLE
rough fix to allow at-pure optimization for generated thunks that have the pure field set

### DIFF
--- a/test/compiler/contextual.jl
+++ b/test/compiler/contextual.jl
@@ -108,3 +108,9 @@ f() = 2
 
 # Test that MiniCassette is at least somewhat capable by overdubbing gcd
 @test overdub(Ctx(), gcd, 10, 20) === gcd(10, 20)
+
+# Test that pure propagates for Cassette
+Base.@pure isbitstype(T) = T.isbitstype
+f31012(T) = Val(isbitstype(T))
+@test @inferred overdub(Ctx(), f31012, Int64) == Val(true)
+


### PR DESCRIPTION
I'm sure this is a broken implementation, but it fixes https://github.com/jrevels/Cassette.jl/issues/108.

Before this PR:

```julia
julia> Base.@pure datatype_align(::Type{T}) where T = T.layout
datatype_align (generic function with 1 method)

julia> function broken(::Type{T}) where {T}
            align = datatype_align(T)
            Val(align)
       end
broken (generic function with 1 method)

julia> using Cassette

julia> Cassette.@context CUDACtx;

julia> const cudactx = Cassette.disablehooks(CUDACtx());

julia> @code_typed Cassette.overdub(cudactx, broken, Float64)
CodeInfo(
1 ─ %1 = Base.getfield($(QuoteNode(Float64)), :layout)::Ptr{Nothing}
│   %2 = invoke Cassette.overdub(_2::Cassette.Context{nametype(CUDACtx),Nothing,Nothing,getfield(Cassette, Symbol("##PassType#365")),Nothing,Cassette.DisableHooks}, Main.Val::Type{Val}, %1::Ptr{Nothing})::Any
└──      return %2
) => Any
```

After this PR:

```julia
julia> @code_typed Cassette.overdub(cudactx, broken, Float64)
CodeInfo(
1 ─ %1 = Base.getfield($(QuoteNode(Float64)), :layout)::Ptr{Nothing}
│   %2 = invoke Cassette.overdub(_2::Cassette.Context{nametype(CUDACtx),Nothing,Nothing,getfield(Cassette, Symbol("##PassType#365")),Nothing,Cassette.DisableHooks}, Main.Val::Type{Val}, %1::Ptr{Nothing})::Const(Val{Ptr{Nothing} @0x000000011495c010}(), true)
└──      return %2
) => Val{Ptr{Nothing} @0x000000011495c010}
```