### PR TITLE
store more unnecessary information in CodeInfo

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -90,8 +90,7 @@
 #end
 
 #struct LineInfoNode
-#    mod::Module
-#    method::Symbol
+#    method::Any
 #    file::Symbol
 #    line::Int
 #    inlined_at::Int
@@ -375,8 +374,8 @@ eval(Core, :(PiNode(val, typ) = $(Expr(:new, :PiNode, :val, :typ))))
 eval(Core, :(PhiCNode(values::Array{Any, 1}) = $(Expr(:new, :PhiCNode, :values))))
 eval(Core, :(UpsilonNode(val) = $(Expr(:new, :UpsilonNode, :val))))
 eval(Core, :(UpsilonNode() = $(Expr(:new, :UpsilonNode))))
-eval(Core, :(LineInfoNode(mod::Module, method::Symbol, file::Symbol, line::Int, inlined_at::Int) =
-             $(Expr(:new, :LineInfoNode, :mod, :method, :file, :line, :inlined_at))))
+eval(Core, :(LineInfoNode(@nospecialize(method), file::Symbol, line::Int, inlined_at::Int) =
+             $(Expr(:new, :LineInfoNode, :method, :file, :line, :inlined_at))))
 
 Module(name::Symbol=:anonymous, std_imports::Bool=true) = ccall(:jl_f_new_module, Ref{Module}, (Any, Bool), name, std_imports)
 

--- a/base/compiler/inferencestate.jl
+++ b/base/compiler/inferencestate.jl
@@ -58,7 +58,7 @@ mutable struct InferenceState
         s_types = Any[ nothing for i = 1:n ]
 
         # initial types
-        nslots = length(src.slotnames)
+        nslots = length(src.slotflags)
         argtypes = result.argtypes
         nargs = length(argtypes)
         s_argtypes = VarTable(undef, nslots)
@@ -122,7 +122,7 @@ end
 
 function sptypes_from_meth_instance(linfo::MethodInstance)
     toplevel = !isa(linfo.def, Method)
-    if !toplevel && isempty(linfo.sparam_vals) && !isempty(linfo.def.sparam_syms)
+    if !toplevel && isempty(linfo.sparam_vals) && isa(linfo.def.sig, UnionAll)
         # linfo is unspecialized
         sp = Any[]
         sig = linfo.def.sig

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -37,8 +37,11 @@ mutable struct OptimizationState
         if nssavalues isa Int
             src.ssavaluetypes = Any[ Any for i = 1:nssavalues ]
         end
-        nslots = length(src.slotnames)
-        slottypes = Any[ Any for i = 1:nslots ]
+        nslots = length(src.slotflags)
+        slottypes = src.slottypes
+        if slottypes === nothing
+            slottypes = Any[ Any for i = 1:nslots ]
+        end
         s_edges = []
         # cache some useful state computations
         toplevel = !isa(linfo.def, Method)
@@ -73,7 +76,7 @@ end
 # This is implied by `SLOT_USEDUNDEF`.
 # If this is not set, all the uses are (statically) dominated by the defs.
 # In particular, if a slot has `AssignedOnce && !StaticUndef`, it is an SSA.
-const SLOT_STATICUNDEF  = 1
+const SLOT_STATICUNDEF  = 1 # slot might be used before it is defined (structurally)
 const SLOT_ASSIGNEDONCE = 16 # slot is assigned to only once
 const SLOT_USEDUNDEF    = 32 # slot has uses that might raise UndefVarError
 # const SLOT_CALLED      = 64

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -1,7 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Core: LineInfoNode
-const NullLineInfo = LineInfoNode(@__MODULE__, Symbol(""), Symbol(""), 0, 0)
 
 if false
     import Base: Base, @show
@@ -103,8 +102,7 @@ function just_construct_ssa(ci::CodeInfo, code::Vector{Any}, nargs::Int, sv::Opt
     defuse_insts = scan_slot_def_use(nargs, ci, code)
     @timeit "domtree 1" domtree = construct_domtree(cfg)
     ir = let code = Any[nothing for _ = 1:length(code)]
-             argtypes = sv.slottypes[1:(nargs+1)]
-            IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), argtypes, meta, sv.sptypes)
+            IRCode(code, Any[], ci.codelocs, flags, cfg, collect(LineInfoNode, ci.linetable), sv.slottypes, meta, sv.sptypes)
         end
     @timeit "construct_ssa" ir = construct_ssa!(ci, code, ir, domtree, defuse_insts, nargs, sv.sptypes, sv.slottypes)
     return ir

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -1,13 +1,11 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ Any for i = 1:length(ci.slotnames) ])
-
 function inflate_ir(ci::CodeInfo, linfo::MethodInstance)
     sptypes = sptypes_from_meth_instance(linfo)
     if ci.inferred
         argtypes, _ = matching_cache_argtypes(linfo, nothing)
     else
-        argtypes = Any[ Any for i = 1:length(ci.slotnames) ]
+        argtypes = Any[ Any for i = 1:length(ci.slotflags) ]
     end
     return inflate_ir(ci, sptypes, argtypes)
 end
@@ -92,3 +90,6 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
         end
     end
 end
+
+# used by some tests
+inflate_ir(ci::CodeInfo) = inflate_ir(ci, Any[], Any[ Any for i = 1:length(ci.slotflags) ])

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -51,7 +51,6 @@ end
 function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
     @assert isempty(ir.new_nodes)
     # All but the first `nargs` slots will now be unused
-    resize!(ci.slotnames, nargs+1)
     resize!(ci.slotflags, nargs+1)
     ci.code = ir.stmts
     ci.codelocs = ir.lines

--- a/base/compiler/ssair/show.jl
+++ b/base/compiler/ssair/show.jl
@@ -153,6 +153,12 @@ function default_expr_type_printer(io::IO, @nospecialize(typ), used::Bool)
     nothing
 end
 
+normalize_method_name(m::Method) = m.name
+normalize_method_name(m::MethodInstance) = (m.def::Method).name
+normalize_method_name(m::Symbol) = m
+normalize_method_name(m) = Symbol("")
+@noinline method_name(m::LineInfoNode) = normalize_method_name(m.method)
+
 # converts the linetable for line numbers
 # into a list in the form:
 #   1 outer-most-frame
@@ -266,7 +272,7 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
                 # be a line number mismatch in inner most frame. Ignore those
                 if length(last_stack) == length(stack) && first_mismatch == length(stack)
                     last_entry, entry = linetable[last_stack[end]], linetable[stack[end]]
-                    if last_entry.method == entry.method && last_entry.file == entry.file
+                    if method_name(last_entry) === method_name(entry) && last_entry.file === entry.file
                         first_mismatch = nothing
                     end
                 end
@@ -299,13 +305,14 @@ function compute_ir_line_annotations(code::Union{IRCode, CodeInfo})
                         print(buf, "│")
                     end
                 end
-                print(buf, "╷"^max(0,depth-last_depth-stole_one))
+                print(buf, "╷"^max(0, depth - last_depth - stole_one))
                 if printing_depth != 0
                     if length(stack) == printing_depth
-                        loc_method = String(linetable[line].method)
+                        loc_method = line
                     else
-                        loc_method = String(linetable[stack[printing_depth+1]].method)
+                        loc_method = stack[printing_depth + 1]
                     end
+                    loc_method = method_name(linetable[loc_method])
                 end
                 loc_method = string(" "^printing_depth, loc_method)
             end
@@ -326,14 +333,14 @@ Base.show(io::IO, code::IRCode) = show_ir(io, code)
 
 lineinfo_disabled(io::IO, linestart::String, lineidx::Int32) = ""
 
-function DILineInfoPrinter(linetable::Vector)
+function DILineInfoPrinter(linetable::Vector, showtypes::Bool=false)
     context = LineInfoNode[]
     context_depth = Ref(0)
     indent(s::String) = s^(max(context_depth[], 1) - 1)
     function emit_lineinfo_update(io::IO, linestart::String, lineidx::Int32)
         # internal configuration options:
         linecolor = :yellow
-        collapse = true
+        collapse = showtypes ? false : true
         indent_all = true
         # convert lineidx to a vector
         if lineidx < 0
@@ -373,11 +380,11 @@ function DILineInfoPrinter(linetable::Vector)
                 # if so, drop all existing calls to it from the top of the context
                 # AND check if instead the context was previously printed that way
                 # but now has removed the recursive frames
-                let method = context[nctx].method
-                    if (nctx < nframes && DI[nframes - nctx].method === method) ||
-                       (nctx < length(context) && context[nctx + 1].method === method)
+                let method = method_name(context[nctx])
+                    if (nctx < nframes && method_name(DI[nframes - nctx]) === method) ||
+                       (nctx < length(context) && method_name(context[nctx + 1]) === method)
                         update_line_only = true
-                        while nctx > 0 && context[nctx].method === method
+                        while nctx > 0 && method_name(context[nctx]) === method
                             nctx -= 1
                         end
                     end
@@ -388,9 +395,9 @@ function DILineInfoPrinter(linetable::Vector)
                 # compute the new inlining depth
                 if collapse
                     npops = 1
-                    let Prev = context[nctx + 1].method
+                    let Prev = method_name(context[nctx + 1])
                         for i = (nctx + 2):length(context)
-                            Next = context[i].method
+                            Next = method_name(context[i])
                             Prev === Next || (npops += 1)
                             Prev = Next
                         end
@@ -402,9 +409,8 @@ function DILineInfoPrinter(linetable::Vector)
                 if !update_line_only && nctx < nframes
                     let CtxLine = context[nctx + 1],
                         FrameLine = DI[nframes - nctx]
-                        if CtxLine.file == FrameLine.file &&
-                                CtxLine.method == FrameLine.method &&
-                                CtxLine.mod == FrameLine.mod
+                        if CtxLine.file === FrameLine.file &&
+                                method_name(CtxLine) === method_name(FrameLine)
                             update_line_only = true
                         end
                     end
@@ -426,12 +432,12 @@ function DILineInfoPrinter(linetable::Vector)
                 if frame.line != typemax(frame.line) && frame.line != 0
                     print(io, linestart)
                     Base.with_output_color(linecolor, io) do io
-                        print(io, indent("│"), " @ ", frame.file, ":", frame.line, " within `", frame.method, "'")
+                        print(io, indent("│"), " @ ", frame.file, ":", frame.line, " within `", method_name(frame), "'")
                         if collapse
-                            method = frame.method
+                            method = method_name(frame)
                             while nctx < nframes
                                 frame = DI[nframes - nctx]
-                                frame.method === method || break
+                                method_name(frame) === method || break
                                 nctx += 1
                                 push!(context, frame)
                                 print(io, " @ ", frame.file, ":", frame.line)
@@ -444,23 +450,33 @@ function DILineInfoPrinter(linetable::Vector)
             # now print the rest of the new frames
             while nctx < nframes
                 frame = DI[nframes - nctx]
+                nctx += 1
+                started = false
+                if showtypes && !isa(frame.method, Symbol) && nctx != 1
+                    print(io, linestart)
+                    Base.with_output_color(linecolor, io) do io
+                        print(io, indent("│"))
+                        print(io, "┌ invoke ", frame.method)
+                        println(io)
+                    end
+                    started = true
+                end
                 print(io, linestart)
                 Base.with_output_color(linecolor, io) do io
                     print(io, indent("│"))
-                    nctx += 1
                     push!(context, frame)
                     context_depth[] += 1
-                    nctx != 1 && print(io, "┌")
+                    nctx != 1 && print(io, started ? "│" : "┌")
                     print(io, " @ ", frame.file)
                     if frame.line != typemax(frame.line) && frame.line != 0
                         print(io, ":", frame.line)
                     end
-                    print(io, " within `", frame.method, "'")
+                    print(io, " within `", method_name(frame), "'")
                     if collapse
-                        method = frame.method
+                        method = method_name(frame)
                         while nctx < nframes
                             frame = DI[nframes - nctx]
-                            frame.method === method || break
+                            method_name(frame) === method || break
                             nctx += 1
                             push!(context, frame)
                             print(io, " @ ", frame.file, ":", frame.line)
@@ -471,10 +487,10 @@ function DILineInfoPrinter(linetable::Vector)
             end
             # FOR DEBUGGING `collapse`:
             # this double-checks the computation of context_depth
-            #let Prev = context[1].method,
+            #let Prev = method_name(context[1]),
             #    depth2 = 1
             #    for i = 2:nctx
-            #        Next = context[i].method
+            #        Next = method_name(context[i])
             #        (collapse && Prev === Next) || (depth2 += 1)
             #        Prev = Next
             #    end
@@ -565,7 +581,7 @@ function show_ir(io::IO, code::IRCode, expr_type_printer=default_expr_type_print
                     printstyled(io, "\e[$(start_column)G$(rail)\e[1G", color = :light_black)
                     print(io, bb_guard_rail)
                     ssa_guard = " "^(maxlength_idx + 4 + (i - 1))
-                    entry_label = "$(ssa_guard)$(entry.method) at $(entry.file):$(entry.line) "
+                    entry_label = "$(ssa_guard)$(method_name(entry)) at $(entry.file):$(entry.line) "
                     hline = string("─"^(start_column-length(entry_label)-length(bb_guard_rail)+max_depth-i), "┐")
                     printstyled(io, string(entry_label, hline), "\n"; color=:light_black)
                     bb_guard_rail = bb_guard_rail_cont

--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -45,7 +45,7 @@ end
 
 @inline slot_id(s) = isa(s, SlotNumber) ? (s::SlotNumber).id : (s::TypedSlot).id
 function scan_slot_def_use(nargs::Int, ci::CodeInfo, code::Vector{Any})
-    nslots = length(ci.slotnames)
+    nslots = length(ci.slotflags)
     result = SlotInfo[SlotInfo() for i = 1:nslots]
     # Set defs for arguments
     for var in result[1:(1+nargs)]
@@ -654,7 +654,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
             undef_token
         else
             SSAValue(-1)
-        end for x in 1:length(ci.slotnames)
+        end for x in 1:length(ci.slotflags)
     ]
     worklist = Tuple{Int, Int, Vector{Any}}[(1, 0, initial_incoming_vals)]
     visited = BitSet()

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -56,10 +56,12 @@ function typeinf(frame::InferenceState)
                 end
             end
         end
+    end
+    for caller in frames
+        caller.src.min_world = min_valid % Int
+        caller.src.max_world = max_valid % Int
         if cached
-            for caller in results
-                cache_result(caller, min_valid, max_valid)
-            end
+            cache_result(caller.result, min_valid, max_valid)
         end
     end
     # if we aren't cached, we don't need this edge
@@ -308,6 +310,8 @@ function type_annotate!(sv::InferenceState)
     # compute the required type for each slot
     # to hold all of the items assigned into it
     record_slot_assign!(sv)
+    sv.src.slottypes = sv.slottypes
+    sv.src.rettype = sv.bestguess
 
     # annotate variables load types
     # remove dead code optimization
@@ -544,16 +548,20 @@ function typeinf_ext(linfo::MethodInstance, params::Params)
                 if invoke_api(linfo) == 2
                     tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
                     tree.code = Any[ Expr(:return, quoted(linfo.inferred_const)) ]
-                    tree.method_for_inference_limit_heuristics = nothing
-                    tree.slotnames = Any[ COMPILER_TEMP_SYM for i = 1:method.nargs ]
-                    tree.slotflags = fill(0x00, Int(method.nargs))
-                    tree.ssavaluetypes = 0
+                    nargs = Int(method.nargs)
+                    tree.slotnames = ccall(:jl_uncompress_argnames, Any, (Any,), method.slot_syms)
+                    tree.slotflags = fill(0x00, nargs)
+                    tree.ssavaluetypes = 1
                     tree.codelocs = Int32[1]
                     tree.linetable = [LineInfoNode(method.module, method.name, method.file, Int(method.line), 0)]
                     tree.inferred = true
-                    tree.ssaflags = UInt8[]
+                    tree.ssaflags = UInt8[0]
                     tree.pure = true
                     tree.inlineable = true
+                    tree.parent = linfo
+                    tree.rettype = typeof(linfo.inferred_const)
+                    tree.min_world = li.min_world
+                    tree.max_world = li.max_world
                     i == 2 && ccall(:jl_typeinf_end, Cvoid, ())
                     return svec(linfo, tree)
                 elseif isa(inf, CodeInfo)

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -96,11 +96,12 @@ end
 
 function retrieve_code_info(linfo::MethodInstance)
     m = linfo.def::Method
+    c = nothing
     if isdefined(m, :generator)
         # user code might throw errors – ignore them
-        return get_staged(linfo)
-    else
-        # TODO: post-inference see if we can swap back to the original arrays?
+        c = get_staged(linfo)
+    end
+    if c === nothing && isdefined(m, :source)
         src = m.source
         if isa(src, Array{UInt8,1})
             c = ccall(:jl_uncompress_ast, Any, (Any, Any), m, src)
@@ -108,7 +109,10 @@ function retrieve_code_info(linfo::MethodInstance)
             c = copy(src::CodeInfo)
         end
     end
-    return c::CodeInfo
+    if c isa CodeInfo
+        c.parent = linfo
+        return c
+    end
 end
 
 function code_for_method(method::Method, @nospecialize(atypes), sparams::SimpleVector, world::UInt, preexisting::Bool=false)

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -41,7 +41,7 @@ const INVALID_RVALUE = "invalid RHS value"
 const INVALID_RETURN = "invalid argument to :return"
 const INVALID_CALL_ARG = "invalid :call argument"
 const EMPTY_SLOTNAMES = "slotnames field is empty"
-const SLOTFLAGS_MISMATCH = "length(slotnames) != length(slotflags)"
+const SLOTFLAGS_MISMATCH = "length(slotnames) < length(slotflags)"
 const SSAVALUETYPES_MISMATCH = "not all SSAValues in AST have a type in ssavaluetypes"
 const SSAVALUETYPES_MISMATCH_UNINFERRED = "uninferred CodeInfo ssavaluetypes field does not equal the number of present SSAValues"
 const NON_TOP_LEVEL_METHOD = "encountered `Expr` head `:method` in non-top-level code (i.e. `nargs` > 0)"
@@ -168,7 +168,7 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_
     nslotflags = length(c.slotflags)
     nssavals = length(c.code)
     !is_top_level && nslotnames == 0 && push!(errors, InvalidCodeError(EMPTY_SLOTNAMES))
-    nslotnames != nslotflags && push!(errors, InvalidCodeError(SLOTFLAGS_MISMATCH, (nslotnames, nslotflags)))
+    nslotnames < nslotflags && push!(errors, InvalidCodeError(SLOTFLAGS_MISMATCH, (nslotnames, nslotflags)))
     if c.inferred
         nssavaluetypes = length(c.ssavaluetypes)
         nssavaluetypes < nssavals && push!(errors, InvalidCodeError(SSAVALUETYPES_MISMATCH, (nssavals, nssavaluetypes)))

--- a/base/show.jl
+++ b/base/show.jl
@@ -635,7 +635,7 @@ function sourceinfo_slotnames(src::CodeInfo)
     for i in eachindex(slotnames)
         name = string(slotnames[i])
         idx = get!(names, name, i)
-        if idx != i
+        if idx != i || isempty(name)
             printname = "$name@_$i"
             idx > 0 && (printnames[idx] = "$name@_$idx")
             names[name] = 0

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ default: html
 SRCDIR           := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 JULIAHOME        := $(abspath $(SRCDIR)/..)
 include $(JULIAHOME)/Make.inc
-JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia)
+JULIA_EXECUTABLE := $(call spawn,$(build_bindir)/julia) --startup-file=no
 
 .PHONY: help clean cleanall html pdf deps deploy
 

--- a/doc/src/manual/performance-tips.md
+++ b/doc/src/manual/performance-tips.md
@@ -1362,29 +1362,21 @@ julia> @noinline pos(x) = x < 0 ? 0 : x;
 
 julia> function f(x)
            y = pos(x)
-           sin(y*x + 1)
+           return sin(y*x + 1)
        end;
 
 julia> @code_warntype f(3.2)
+Variables
+  #self#::Core.Compiler.Const(f, false)
+  x::Float64
+  y::Union{Float64, Int64}
+
 Body::Float64
-2 1 ─ %1  = invoke Main.pos(%%x::Float64)::UNION{FLOAT64, INT64}
-3 │   %2  = isa(%1, Float64)::Bool
-  └──       goto 3 if not %2
-  2 ─ %4  = π (%1, Float64)
-  │   %5  = Base.mul_float(%4, %%x)::Float64
-  └──       goto 6
-  3 ─ %7  = isa(%1, Int64)::Bool
-  └──       goto 5 if not %7
-  4 ─ %9  = π (%1, Int64)
-  │   %10 = Base.sitofp(Float64, %9)::Float64
-  │   %11 = Base.mul_float(%10, %%x)::Float64
-  └──       goto 6
-  5 ─       Base.error("fatal error in type inference (type bound)")
-  └──       unreachable
-  6 ┄ %15 = φ (2 => %5, 4 => %11)::Float64
-  │   %16 = Base.add_float(%15, 1.0)::Float64
-  │   %17 = invoke Main.sin(%16::Float64)::Float64
-  └──       return %17
+1 ─      (y = Main.pos(x))
+│   %2 = (y * x)::Float64
+│   %3 = (%2 + 1)::Float64
+│   %4 = Main.sin(%3)::Float64
+└──      return %4
 ```
 
 Interpreting the output of [`@code_warntype`](@ref), like that of its cousins [`@code_lowered`](@ref),

--- a/src/array.c
+++ b/src/array.c
@@ -470,6 +470,8 @@ JL_DLLEXPORT jl_value_t *jl_array_to_string(jl_array_t *a)
 JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
 {
     size_t sz = sizeof(size_t) + len + 1; // add space for trailing \nul protector and size
+    if (len == 0)
+        return jl_an_empty_string;
     jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, jl_string_type); // force inlining
     *(size_t*)s = len;
     memcpy((char*)s + sizeof(size_t), str, len);
@@ -480,6 +482,8 @@ JL_DLLEXPORT jl_value_t *jl_pchar_to_string(const char *str, size_t len)
 JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
 {
     size_t sz = sizeof(size_t) + len + 1; // add space for trailing \nul protector and size
+    if (len == 0)
+        return jl_an_empty_string;
     jl_value_t *s = jl_gc_alloc_(jl_get_ptls_states(), sz, jl_string_type); // force inlining
     *(size_t*)s = len;
     ((char*)s + sizeof(size_t))[len] = 0;

--- a/src/ast.c
+++ b/src/ast.c
@@ -554,7 +554,7 @@ static jl_value_t *scm_to_julia_(fl_context_t *fl_ctx, value_t e, jl_module_t *m
         else if (sym == thunk_sym) {
             ex = scm_to_julia_(fl_ctx, car_(e), mod);
             assert(jl_is_code_info(ex));
-            jl_linenumber_to_lineinfo((jl_code_info_t*)ex, mod, jl_symbol("top-level scope"));
+            jl_linenumber_to_lineinfo((jl_code_info_t*)ex, (jl_value_t*)jl_symbol("top-level scope"));
             temp = (jl_value_t*)jl_exprn(sym, 1);
             jl_exprargset(temp, 0, ex);
         }

--- a/src/ast.c
+++ b/src/ast.c
@@ -50,17 +50,17 @@ jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *inbounds_sym;
 jl_sym_t *copyast_sym; jl_sym_t *cfunction_sym;
 jl_sym_t *pure_sym; jl_sym_t *simdloop_sym;
-jl_sym_t *meta_sym; jl_sym_t *compiler_temp_sym;
-jl_sym_t *inert_sym;  jl_sym_t *polly_sym;
-jl_sym_t *unused_sym; jl_sym_t *static_parameter_sym;
-jl_sym_t *inline_sym; jl_sym_t *noinline_sym;
-jl_sym_t *generated_sym; jl_sym_t *generated_only_sym;
-jl_sym_t *isdefined_sym; jl_sym_t *propagate_inbounds_sym;
-jl_sym_t *specialize_sym; jl_sym_t *nospecialize_sym;
-jl_sym_t *macrocall_sym;  jl_sym_t *colon_sym;
-jl_sym_t *hygienicscope_sym; jl_sym_t *escape_sym;
-jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
+jl_sym_t *meta_sym; jl_sym_t *inert_sym;
+jl_sym_t *polly_sym; jl_sym_t *unused_sym;
+jl_sym_t *static_parameter_sym; jl_sym_t *inline_sym;
+jl_sym_t *noinline_sym; jl_sym_t *generated_sym;
+jl_sym_t *generated_only_sym; jl_sym_t *isdefined_sym;
+jl_sym_t *propagate_inbounds_sym; jl_sym_t *specialize_sym;
+jl_sym_t *nospecialize_sym; jl_sym_t *macrocall_sym;
+jl_sym_t *colon_sym; jl_sym_t *hygienicscope_sym;
 jl_sym_t *throw_undef_if_not_sym; jl_sym_t *getfield_undefref_sym;
+jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
+jl_sym_t *escape_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -347,7 +347,6 @@ void jl_init_frontend(void)
     unused_sym = jl_symbol("#unused#");
     slot_sym = jl_symbol("slot");
     static_parameter_sym = jl_symbol("static_parameter");
-    compiler_temp_sym = jl_symbol("#temp#");
     inline_sym = jl_symbol("inline");
     noinline_sym = jl_symbol("noinline");
     polly_sym = jl_symbol("polly");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -3315,8 +3315,12 @@ static jl_cgval_t emit_sparam(jl_codectx_t &ctx, size_t i)
     Value *sp = tbaa_decorate(tbaa_const, ctx.builder.CreateLoad(bp));
     Value *isnull = ctx.builder.CreateICmpNE(emit_typeof(ctx, sp),
             maybe_decay_untracked(literal_pointer_val(ctx, (jl_value_t*)jl_tvar_type)));
-    jl_sym_t *name = (jl_sym_t*)jl_svecref(ctx.linfo->def.method->sparam_syms, i);
-    undef_var_error_ifnot(ctx, isnull, name);
+    jl_unionall_t *sparam = (jl_unionall_t*)ctx.linfo->def.method->sig;
+    for (size_t j = 0; j < i; j++) {
+        sparam = (jl_unionall_t*)sparam->body;
+        assert(jl_is_unionall(sparam));
+    }
+    undef_var_error_ifnot(ctx, isnull, sparam->var->name);
     return mark_julia_type(ctx, sp, true, jl_any_type);
 }
 
@@ -5375,7 +5379,7 @@ static std::unique_ptr<Module> emit_function(
 
     // step 2. process var-info lists to see what vars need boxing
     int n_ssavalues = jl_is_long(src->ssavaluetypes) ? jl_unbox_long(src->ssavaluetypes) : jl_array_len(src->ssavaluetypes);
-    size_t vinfoslen = jl_array_dim0(src->slotnames);
+    size_t vinfoslen = jl_array_dim0(src->slotflags);
     ctx.slots.resize(vinfoslen);
     size_t nreq = ctx.nargs;
     int va = 0;
@@ -5397,7 +5401,7 @@ static std::unique_ptr<Module> emit_function(
 
     bool needsparams = false;
     if (jl_is_method(lam->def.method)) {
-        if (jl_svec_len(lam->def.method->sparam_syms) != jl_svec_len(lam->sparam_vals))
+        if ((size_t)jl_subtype_env_size(lam->def.method->sig) != jl_svec_len(lam->sparam_vals))
             needsparams = true;
         for (size_t i = 0; i < jl_svec_len(lam->sparam_vals); ++i) {
             if (jl_is_typevar(jl_svecref(lam->sparam_vals, i)))
@@ -5597,7 +5601,7 @@ static std::unique_ptr<Module> emit_function(
             for (i = 0; i < vinfoslen; i++) {
                 jl_sym_t *s = (jl_sym_t*)jl_array_ptr_ref(src->slotnames, i);
                 jl_varinfo_t &varinfo = ctx.slots[i];
-                if (varinfo.isArgument || s == compiler_temp_sym || s == unused_sym)
+                if (varinfo.isArgument || s == empty_sym || s == unused_sym)
                     continue;
                 // LLVM 4.0: Assume the variable has default alignment
                 varinfo.dinfo = dbuilder.createAutoVariable(
@@ -6027,14 +6031,14 @@ static std::unique_ptr<Module> emit_function(
             return;
         while (dbg) {
             new_lineinfo.push_back(dbg);
-            dbg = linetable[dbg].inlined_at;
+            dbg = linetable.at(dbg).inlined_at;
         }
         current_lineinfo.resize(new_lineinfo.size(), 0);
         for (dbg = 0; dbg < new_lineinfo.size(); dbg++) {
             unsigned newdbg = new_lineinfo[new_lineinfo.size() - dbg - 1];
             if (newdbg != current_lineinfo[dbg]) {
                 current_lineinfo[dbg] = newdbg;
-                const auto &info = linetable[newdbg];
+                const auto &info = linetable.at(newdbg);
                 if (do_coverage(info.is_user_code))
                     coverageVisitLine(ctx, info.file, info.line);
             }
@@ -6044,9 +6048,9 @@ static std::unique_ptr<Module> emit_function(
     auto mallocVisitStmt = [&] (unsigned dbg) {
         if (!do_malloc_log(mod_is_user_mod) || dbg == 0)
             return;
-        while (linetable[dbg].inlined_at)
-            dbg = linetable[dbg].inlined_at;
-        mallocVisitLine(ctx, ctx.file, linetable[dbg].line);
+        while (linetable.at(dbg).inlined_at)
+            dbg = linetable.at(dbg).inlined_at;
+        mallocVisitLine(ctx, ctx.file, linetable.at(dbg).line);
     };
 
     come_from_bb[0] = ctx.builder.GetInsertBlock();
@@ -6111,7 +6115,7 @@ static std::unique_ptr<Module> emit_function(
         int32_t debuginfoloc = ((int32_t*)jl_array_data(src->codelocs))[cursor];
         if (debuginfoloc > 0) {
             if (ctx.debug_enabled)
-                ctx.builder.SetCurrentDebugLocation(linetable[debuginfoloc].loc);
+                ctx.builder.SetCurrentDebugLocation(linetable.at(debuginfoloc).loc);
             coverageVisitStmt(debuginfoloc);
         }
         jl_value_t *stmt = jl_array_ptr_ref(stmts, cursor);

--- a/src/dump.c
+++ b/src/dump.c
@@ -796,7 +796,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         write_int8(s->s, m->isva);
         write_int8(s->s, m->pure);
         jl_serialize_value(s, (jl_value_t*)m->module);
-        jl_serialize_value(s, (jl_value_t*)m->sparam_syms);
+        jl_serialize_value(s, (jl_value_t*)m->slot_syms);
         jl_serialize_value(s, (jl_value_t*)m->roots);
         jl_serialize_value(s, (jl_value_t*)m->source);
         jl_serialize_value(s, (jl_value_t*)m->unspecialized);
@@ -865,9 +865,14 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         jl_error("Task cannot be serialized");
     }
     else if (jl_typeis(v, jl_string_type)) {
-        write_uint8(s->s, TAG_STRING);
-        write_int32(s->s, jl_string_len(v));
-        ios_write(s->s, jl_string_data(v), jl_string_len(v));
+        if (jl_string_len(v) == 0) {
+            jl_serialize_value(s, jl_an_empty_string);
+        }
+        else {
+            write_uint8(s->s, TAG_STRING);
+            write_int32(s->s, jl_string_len(v));
+            ios_write(s->s, jl_string_data(v), jl_string_len(v));
+        }
     }
     else if (jl_typeis(v, jl_typemap_entry_type)) {
         write_uint8(s->s, TAG_TYPEMAP_ENTRY);
@@ -1658,8 +1663,8 @@ static jl_value_t *jl_deserialize_value_method(jl_serializer_state *s, jl_value_
     m->pure = read_int8(s->s);
     m->module = (jl_module_t*)jl_deserialize_value(s, (jl_value_t**)&m->module);
     jl_gc_wb(m, m->module);
-    m->sparam_syms = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&m->sparam_syms);
-    jl_gc_wb(m, m->sparam_syms);
+    m->slot_syms = jl_deserialize_value(s, (jl_value_t**)&m->slot_syms);
+    jl_gc_wb(m, m->slot_syms);
     m->roots = (jl_array_t*)jl_deserialize_value(s, (jl_value_t**)&m->roots);
     if (m->roots)
         jl_gc_wb(m, m->roots);
@@ -2456,31 +2461,33 @@ JL_DLLEXPORT jl_array_t *jl_compress_ast(jl_method_t *m, jl_code_info_t *code)
                   | (code->pure << 0);
     write_uint8(s.s, flags);
 
-    size_t nsyms = jl_array_len(code->slotnames);
-    assert(nsyms >= m->nargs && nsyms < INT32_MAX); // required by generated functions
-    write_int32(s.s, nsyms);
-    assert(nsyms == jl_array_len(code->slotflags));
-    ios_write(s.s, (char*)jl_array_data(code->slotflags), nsyms);
+    size_t nslots = jl_array_len(code->slotflags);
+    assert(nslots >= m->nargs && nslots < INT32_MAX); // required by generated functions
+    write_int32(s.s, nslots);
+    ios_write(s.s, (char*)jl_array_data(code->slotflags), nslots);
 
     // N.B.: The layout of everything before this point is explicitly referenced
     // by the various jl_ast_ accessors. Make sure to adjust those if you change
     // the data layout.
 
-    for (i = 0; i < nsyms; i++) {
-        jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(code->slotnames, i);
-        assert(jl_is_symbol(name));
-        char *namestr = jl_symbol_name(name);
-        size_t namelen = strlen(namestr);
-        ios_write(s.s, namestr, namelen + 1); // include nul-byte
-    }
-
-    size_t nf = jl_datatype_nfields(jl_code_info_type);
-    for (i = 0; i < nf - 6; i++) {
-        if (i == 1)  // skip codelocs
+    for (i = 0; i < 6; i++) {
+        int copy = 1;
+        if (i == 1) { // skip codelocs
+            assert(jl_field_offset(jl_code_info_type, i) == offsetof(jl_code_info_t, codelocs));
             continue;
-        int copy = (i != 2); // don't copy contents of method_for_inference_limit_heuristics field
+        }
+        if (i == 4) { // don't copy contents of method_for_inference_limit_heuristics field
+            assert(jl_field_offset(jl_code_info_type, i) == offsetof(jl_code_info_t, method_for_inference_limit_heuristics));
+            copy = 0;
+        }
         jl_serialize_value_(&s, jl_get_nth_field((jl_value_t*)code, i), copy);
     }
+
+    if (m->generator)
+        // can't optimize generated functions
+        jl_serialize_value_(&s, (jl_value_t*)jl_compress_argnames(code->slotnames), 1);
+    else
+        jl_serialize_value(&s, jl_nothing);
 
     size_t nstmt = jl_array_len(code->code);
     assert(nstmt == jl_array_len(code->codelocs));
@@ -2516,7 +2523,6 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ast(jl_method_t *m, jl_array_t *data)
     if (jl_is_code_info(data))
         return (jl_code_info_t*)data;
     JL_TIMING(AST_UNCOMPRESS);
-    jl_ptls_t ptls = jl_get_ptls_states();
     JL_LOCK(&m->writelock); // protect the roots array (Might GC)
     assert(jl_is_method(m));
     assert(jl_typeis(data, jl_array_uint8_type));
@@ -2533,9 +2539,7 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ast(jl_method_t *m, jl_array_t *data)
         NULL
     };
 
-    jl_code_info_t *code =
-        (jl_code_info_t*)jl_gc_alloc(ptls, sizeof(jl_code_info_t),
-                                       jl_code_info_type);
+    jl_code_info_t *code = jl_new_code_info_uninit();
     uint8_t flags = read_uint8(s.s);
     code->inferred = !!(flags & (1 << 3));
     code->inlineable = !!(flags & (1 << 2));
@@ -2546,24 +2550,18 @@ JL_DLLEXPORT jl_code_info_t *jl_uncompress_ast(jl_method_t *m, jl_array_t *data)
     code->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
     ios_read(s.s, (char*)jl_array_data(code->slotflags), nslots);
 
-    jl_array_t *syms = jl_alloc_vec_any(nslots);
-    code->slotnames = syms;
-    for (i = 0; i < nslots; i++) {
-        char *namestr = s.s->buf + s.s->bpos;
-        size_t namelen = strlen(namestr);
-        jl_sym_t *name = jl_symbol_n(namestr, namelen);
-        jl_array_ptr_set(syms, i, name);
-        ios_skip(s.s, namelen + 1);
-    }
-
-    size_t nf = jl_datatype_nfields(jl_code_info_type);
-    for (i = 0; i < nf - 6; i++) {
-        if (i == 1)
+    for (i = 0; i < 6; i++) {
+        if (i == 1)  // skip codelocs
             continue;
         assert(jl_field_isptr(jl_code_info_type, i));
         jl_value_t **fld = (jl_value_t**)((char*)jl_data_ptr(code) + jl_field_offset(jl_code_info_type, i));
         *fld = jl_deserialize_value(&s, fld);
     }
+
+    jl_value_t *slotnames = jl_deserialize_value(&s, NULL);
+    if (!jl_is_string(slotnames))
+        slotnames = m->slot_syms;
+    code->slotnames = jl_uncompress_argnames(m->slot_syms);
 
     size_t nstmt = jl_array_len(code->code);
     code->codelocs = (jl_value_t*)jl_alloc_array_1d(jl_array_int32_type, nstmt);
@@ -2617,6 +2615,32 @@ JL_DLLEXPORT uint8_t jl_ast_flag_pure(jl_array_t *data)
     return !!(flags & (1 << 0));
 }
 
+JL_DLLEXPORT jl_value_t *jl_compress_argnames(jl_array_t *syms)
+{
+    size_t nsyms = jl_array_len(syms);
+    size_t i, len = 0;
+    for (i = 0; i < nsyms; i++) {
+        jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(syms, i);
+        assert(jl_is_symbol(name));
+        char *namestr = jl_symbol_name(name);
+        size_t namelen = strlen(namestr) + 1;
+        len += namelen;
+    }
+    jl_value_t *str = jl_alloc_string(len);
+    len = 0;
+    for (i = 0; i < nsyms; i++) {
+        jl_sym_t *name = (jl_sym_t*)jl_array_ptr_ref(syms, i);
+        assert(jl_is_symbol(name));
+        char *namestr = jl_symbol_name(name);
+        size_t namelen = strlen(namestr) + 1; // include nul-byte
+        assert(len + namelen <= jl_string_len(str));
+        memcpy(jl_string_data(str) + len, namestr, namelen);
+        len += namelen;
+    }
+    assert(len == jl_string_len(str));
+    return str;
+}
+
 JL_DLLEXPORT ssize_t jl_ast_nslots(jl_array_t *data)
 {
     if (jl_is_code_info(data)) {
@@ -2635,35 +2659,53 @@ JL_DLLEXPORT uint8_t jl_ast_slotflag(jl_array_t *data, size_t i)
     assert(i < jl_ast_nslots(data));
     if (jl_is_code_info(data))
         return ((uint8_t*)((jl_code_info_t*)data)->slotflags->data)[i];
+    assert(jl_typeis(data, jl_array_uint8_type));
     return ((uint8_t*)data->data)[1 + sizeof(int32_t) + i];
 }
 
-JL_DLLEXPORT void jl_fill_argnames(jl_array_t *data, jl_array_t *names)
+JL_DLLEXPORT jl_array_t *jl_uncompress_argnames(jl_value_t *syms)
 {
-    size_t i, nargs = jl_array_len(names);
-    if (jl_is_code_info(data)) {
-        jl_code_info_t *func = (jl_code_info_t*)data;
-        assert(jl_array_len(func->slotnames) >= nargs);
-        for (i = 0; i < nargs; i++) {
-            jl_value_t *name = jl_array_ptr_ref(func->slotnames, i);
-            jl_array_ptr_set(names, i, name);
-        }
+    assert(jl_is_string(syms));
+    char *namestr;
+    namestr = jl_string_data(syms);
+    size_t remaining = jl_string_len(syms);
+    size_t i, len = 0;
+    while (remaining) {
+        size_t namelen = strlen(namestr);
+        len += 1;
+        namestr += namelen + 1;
+        remaining -= namelen + 1;
     }
-    else {
-        assert(jl_typeis(data, jl_array_uint8_type));
-        char *d = (char*)data->data;
-        int nslots = jl_load_unaligned_i32(d + 1);
-        assert(nslots >= nargs);
-        (void)nslots;
-        char *namestr = d + 5 + nslots;
-        for (i = 0; i < nargs; i++) {
-            size_t namelen = strlen(namestr);
-            jl_sym_t *name = jl_symbol_n(namestr, namelen);
-            jl_array_ptr_set(names, i, name);
-            namestr += namelen + 1;
-        }
+    namestr = jl_string_data(syms);
+    jl_array_t *names = jl_alloc_vec_any(len);
+    JL_GC_PUSH1(&names);
+    for (i = 0; i < len; i++) {
+        size_t namelen = strlen(namestr);
+        jl_sym_t *name = jl_symbol_n(namestr, namelen);
+        jl_array_ptr_set(names, i, name);
+        namestr += namelen + 1;
     }
+    JL_GC_POP();
+    return names;
 }
+
+JL_DLLEXPORT jl_value_t *jl_uncompress_argname_n(jl_value_t *syms, size_t i)
+{
+    assert(jl_is_string(syms));
+    char *namestr = jl_string_data(syms);
+    size_t remaining = jl_string_len(syms);
+    while (remaining) {
+        size_t namelen = strlen(namestr);
+        if (i-- == 0) {
+            jl_sym_t *name = jl_symbol_n(namestr, namelen);
+            return (jl_value_t*)name;
+        }
+        namestr += namelen + 1;
+        remaining -= namelen + 1;
+    }
+    return jl_nothing;
+}
+
 
 JL_DLLEXPORT int jl_save_incremental(const char *fname, jl_array_t *worklist)
 {
@@ -3190,7 +3232,7 @@ void jl_init_serializer(void)
 
     void *vals[] = { jl_emptysvec, jl_emptytuple, jl_false, jl_true, jl_nothing, jl_any_type,
                      call_sym, invoke_sym, goto_ifnot_sym, return_sym, jl_symbol("tuple"),
-                     unreachable_sym,
+                     unreachable_sym, jl_an_empty_string,
 
                      // empirical list of very common symbols
                      #include "common_symbols1.inc"

--- a/src/gf.c
+++ b/src/gf.c
@@ -206,7 +206,7 @@ void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr
     m->isva = 1;
     m->nargs = 2;
     m->sig = (jl_value_t*)jl_anytuple_type;
-    m->sparam_syms = jl_emptysvec;
+    m->slot_syms = jl_an_empty_string;
 
     jl_methtable_t *mt = dt->name->mt;
     jl_typemap_insert(&mt->cache, (jl_value_t*)mt, jl_anytuple_type,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1981,8 +1981,8 @@ void jl_init_types(void) JL_GC_DISABLED
 
     jl_lineinfonode_type =
         jl_new_datatype(jl_symbol("LineInfoNode"), core, jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(5, "mod", "method", "file", "line", "inlined_at"),
-                        jl_svec(5, jl_module_type, jl_sym_type, jl_sym_type, jl_long_type, jl_long_type), 0, 0, 5);
+                        jl_perm_symsvec(4, "method", "file", "line", "inlined_at"),
+                        jl_svec(4, jl_any_type, jl_sym_type, jl_long_type, jl_long_type), 0, 0, 4);
 
     jl_gotonode_type =
         jl_new_datatype(jl_symbol("GotoNode"), core, jl_any_type, jl_emptysvec,

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -33,7 +33,7 @@ jl_datatype_t *jl_typedslot_type;
 jl_datatype_t *jl_simplevector_type;
 jl_typename_t *jl_tuple_typename;
 jl_datatype_t *jl_anytuple_type;
-jl_datatype_t *jl_emptytuple_type=NULL;
+jl_datatype_t *jl_emptytuple_type;
 jl_unionall_t *jl_anytuple_type_type;
 jl_typename_t *jl_vecelement_typename;
 jl_unionall_t *jl_vararg_type;
@@ -67,7 +67,7 @@ jl_datatype_t *jl_floatingpoint_type;
 jl_datatype_t *jl_number_type;
 jl_datatype_t *jl_signed_type;
 
-JL_DLLEXPORT jl_value_t *jl_emptytuple=NULL;
+JL_DLLEXPORT jl_value_t *jl_emptytuple;
 jl_svec_t *jl_emptysvec;
 jl_value_t *jl_nothing;
 
@@ -79,7 +79,7 @@ jl_unionall_t *jl_typetype_type;
 jl_unionall_t *jl_array_type;
 jl_typename_t *jl_array_typename;
 jl_value_t *jl_array_uint8_type;
-jl_value_t *jl_array_any_type=NULL;
+jl_value_t *jl_array_any_type;
 jl_value_t *jl_array_symbol_type;
 jl_value_t *jl_array_int32_type;
 jl_datatype_t *jl_weakref_type;
@@ -101,9 +101,10 @@ jl_datatype_t *jl_methtable_type;
 jl_datatype_t *jl_typemap_entry_type;
 jl_datatype_t *jl_typemap_level_type;
 jl_datatype_t *jl_method_instance_type;
+jl_datatype_t *jl_lambda_type;
 jl_datatype_t *jl_code_info_type;
 jl_datatype_t *jl_module_type;
-jl_datatype_t *jl_errorexception_type=NULL;
+jl_datatype_t *jl_errorexception_type;
 jl_datatype_t *jl_argumenterror_type;
 jl_datatype_t *jl_typeerror_type;
 jl_datatype_t *jl_methoderror_type;
@@ -118,7 +119,8 @@ jl_datatype_t *jl_void_type;
 jl_datatype_t *jl_voidpointer_type;
 jl_typename_t *jl_namedtuple_typename;
 jl_unionall_t *jl_namedtuple_type;
-jl_value_t *jl_an_empty_vec_any=NULL;
+jl_value_t *jl_an_empty_vec_any;
+jl_value_t *jl_an_empty_string;
 jl_value_t *jl_stackovf_exception;
 #ifdef SEGV_EXCEPTION
 jl_value_t *jl_segv_exception;
@@ -1877,6 +1879,14 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_false = jl_permbox8(jl_bool_type, 0);
     jl_true  = jl_permbox8(jl_bool_type, 1);
 
+    jl_abstractstring_type = jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractString"), core, jl_any_type, jl_emptysvec);
+    jl_string_type = jl_new_datatype(jl_symbol("String"), core, jl_abstractstring_type, jl_emptysvec,
+                                     jl_emptysvec, jl_emptysvec, 0, 1, 0);
+    jl_string_type->instance = NULL;
+    jl_compute_field_offsets(jl_string_type);
+    jl_an_empty_string = jl_pchar_to_string("\0", 1);
+    *(size_t*)jl_an_empty_string = 0;
+
     jl_typemap_level_type =
         jl_new_datatype(jl_symbol("TypeMapLevel"), core, jl_any_type, jl_emptysvec,
                         jl_perm_symsvec(7,
@@ -2017,36 +2027,43 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_code_info_type =
         jl_new_datatype(jl_symbol("CodeInfo"), core,
                         jl_any_type, jl_emptysvec,
-                        jl_perm_symsvec(12,
+                        jl_perm_symsvec(17,
                             "code",
                             "codelocs",
-                            "method_for_inference_limit_heuristics",
                             "ssavaluetypes",
-                            "linetable",
                             "ssaflags",
-                            "slotflags",
+                            "method_for_inference_limit_heuristics",
+                            "linetable",
                             "slotnames",
+                            "slotflags",
+                            "slottypes",
+                            "rettype",
+                            "parent",
+                            "min_world",
+                            "max_world",
                             "inferred",
                             "inlineable",
                             "propagate_inbounds",
                             "pure"),
-                        jl_svec(12,
+                        jl_svec(17,
                             jl_array_any_type,
                             jl_any_type,
+                            jl_any_type,
+                            jl_array_uint8_type,
                             jl_any_type,
                             jl_any_type,
                             jl_any_type,
                             jl_array_uint8_type,
-                            jl_array_uint8_type,
-                            // Note: The following fields have special serialization.
-                            // If you change them, you'll have to adjust the
-                            // serializer
-                            jl_array_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_any_type,
+                            jl_long_type,
+                            jl_long_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type,
                             jl_bool_type),
-                        0, 1, 12);
+                        0, 1, 17);
 
     jl_method_type =
         jl_new_datatype(jl_symbol("Method"), core,
@@ -2061,7 +2078,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             "max_world",
                             "ambig",
                             "specializations",
-                            "sparam_syms",
+                            "slot_syms",
                             "source",
                             "unspecialized",
                             "generator",
@@ -2082,7 +2099,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_long_type,
                             jl_any_type, // Union{Array, Nothing}
                             jl_any_type, // TypeMap
-                            jl_simplevector_type,
+                            jl_string_type,
                             jl_any_type,
                             jl_any_type, // jl_method_instance_type
                             jl_any_type,
@@ -2160,12 +2177,6 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_typetype_type =
         (jl_unionall_t*)jl_new_struct(jl_unionall_type, typetype_tvar,
                                       jl_apply_type1((jl_value_t*)jl_type_type, (jl_value_t*)typetype_tvar));
-
-    jl_abstractstring_type = jl_new_abstracttype((jl_value_t*)jl_symbol("AbstractString"), core, jl_any_type, jl_emptysvec);
-    jl_string_type = jl_new_datatype(jl_symbol("String"), core, jl_abstractstring_type, jl_emptysvec,
-                                     jl_emptysvec, jl_emptysvec, 0, 1, 0);
-    jl_string_type->instance = NULL;
-    jl_compute_field_offsets(jl_string_type);
 
     jl_tvar_t *ntval_var = jl_new_typevar(jl_symbol("T"), (jl_value_t*)jl_bottom_type,
                                           (jl_value_t*)jl_anytuple_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -309,7 +309,7 @@ typedef struct _jl_method_t {
 } jl_method_t;
 
 // This type caches the data for a specType signature specialization of a Method
-typedef struct _jl_method_instance_t {
+struct _jl_method_instance_t {
     JL_DATA_TYPE
     union {
         jl_value_t *value; // generic accessor
@@ -332,7 +332,7 @@ typedef struct _jl_method_instance_t {
     // names of declarations in the JIT,
     // suitable for referencing in LLVM IR
     jl_llvm_functions_t functionObjectsDecls;
-} jl_method_instance_t;
+};
 
 // all values are callable as Functions
 typedef jl_value_t jl_function_t;

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -441,7 +441,7 @@ jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                           jl_svec_t *sparam_vals);
 int jl_is_toplevel_only_expr(jl_value_t *e) JL_NOTSAFEPOINT;
 jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr, jl_module_t *inmodule);
-void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_module_t *mod, jl_sym_t *name);
+void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_value_t *name);
 
 jl_method_instance_t *jl_method_lookup(jl_methtable_t *mt JL_PROPAGATES_ROOT,
     jl_value_t **args, size_t nargs, int cache, size_t world);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1001,18 +1001,18 @@ extern jl_sym_t *dot_sym;    extern jl_sym_t *newvar_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;
 extern jl_sym_t *copyast_sym; extern jl_sym_t *cfunction_sym;
 extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
-extern jl_sym_t *meta_sym; extern jl_sym_t *compiler_temp_sym;
-extern jl_sym_t *inert_sym;  extern jl_sym_t *polly_sym;
-extern jl_sym_t *unused_sym; extern jl_sym_t *static_parameter_sym;
-extern jl_sym_t *inline_sym; extern jl_sym_t *noinline_sym;
-extern jl_sym_t *generated_sym; extern jl_sym_t *generated_only_sym;
-extern jl_sym_t *isdefined_sym; extern jl_sym_t *propagate_inbounds_sym;
-extern jl_sym_t *specialize_sym; extern jl_sym_t *nospecialize_sym;
-extern jl_sym_t *macrocall_sym;  extern jl_sym_t *colon_sym;
-extern jl_sym_t *hygienicscope_sym; extern jl_sym_t *escape_sym;
-extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
+extern jl_sym_t *meta_sym; extern jl_sym_t *inert_sym;
+extern jl_sym_t *polly_sym; extern jl_sym_t *unused_sym;
+extern jl_sym_t *static_parameter_sym; extern jl_sym_t *inline_sym;
+extern jl_sym_t *noinline_sym; extern jl_sym_t *generated_sym;
+extern jl_sym_t *generated_only_sym; extern jl_sym_t *isdefined_sym;
+extern jl_sym_t *propagate_inbounds_sym; extern jl_sym_t *specialize_sym;
+extern jl_sym_t *nospecialize_sym; extern jl_sym_t *macrocall_sym;
+extern jl_sym_t *colon_sym; extern jl_sym_t *hygienicscope_sym;
 extern jl_sym_t *throw_undef_if_not_sym; extern jl_sym_t *getfield_undefref_sym;
+extern jl_sym_t *gc_preserve_begin_sym; extern jl_sym_t *gc_preserve_end_sym;
 extern jl_sym_t *failed_sym; extern jl_sym_t *done_sym; extern jl_sym_t *runnable_sym;
+extern jl_sym_t *escape_sym;
 
 struct _jl_sysimg_fptrs_t;
 

--- a/src/precompile.c
+++ b/src/precompile.c
@@ -372,7 +372,7 @@ static void jl_compile_specializations(void)
     JL_GC_PUSH1(&m);
     jl_foreach_reachable_mtable(precompile_enq_all_specializations_, m);
     // Ensure stable ordering to make inference problems more reproducible (#29923)
-    jl_sort_types(jl_array_data(m), jl_array_len(m));
+    jl_sort_types((jl_value_t**)jl_array_data(m), jl_array_len(m));
     size_t i, l;
     for (i = 0, l = jl_array_len(m); i < l; i++) {
         jl_compile_hint((jl_tupletype_t*)jl_array_ptr_ref(m, i));

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -1632,7 +1632,7 @@ static void jl_init_serializer2(int for_serialize)
                      jl_module_type, jl_tvar_type, jl_method_instance_type, jl_method_type,
                      jl_emptysvec, jl_emptytuple, jl_false, jl_true, jl_nothing, jl_any_type,
                      call_sym, invoke_sym, goto_ifnot_sym, return_sym, jl_symbol("tuple"),
-                     unreachable_sym,
+                     unreachable_sym, jl_an_empty_string,
                      jl_linenumbernode_type, jl_lineinfonode_type,
                      jl_gotonode_type, jl_quotenode_type,
                      jl_pinode_type, jl_phinode_type, jl_phicnode_type, jl_upsilonnode_type,

--- a/src/support/htable.c
+++ b/src/support/htable.c
@@ -20,7 +20,7 @@ extern "C" {
 
 htable_t *htable_new(htable_t *h, size_t size)
 {
-    if (size <= HT_N_INLINE/2) {
+    if (size <= HT_N_INLINE / 2) {
         h->size = size = HT_N_INLINE;
         h->table = &h->_space[0];
     }
@@ -29,11 +29,12 @@ htable_t *htable_new(htable_t *h, size_t size)
         size *= 2;  // 2 pointers per key/value pair
         size *= 2;  // aim for 50% occupancy
         h->size = size;
-        h->table = (void**)LLT_ALLOC(size*sizeof(void*));
+        h->table = (void**)LLT_ALLOC(size * sizeof(void*));
     }
-    if (h->table == NULL) return NULL;
+    if (h->table == NULL)
+        return NULL;
     size_t i;
-    for(i=0; i < size; i++)
+    for (i = 0; i < size; i++)
         h->table[i] = HT_NOTFOUND;
     return h;
 }
@@ -48,15 +49,17 @@ void htable_free(htable_t *h)
 void htable_reset(htable_t *h, size_t sz)
 {
     sz = next_power_of_two(sz);
-    if (h->size > sz*4 && h->size > HT_N_INLINE) {
-        size_t newsz = sz*4;
-        void **newtab = (void**)LLT_REALLOC(h->table, newsz*sizeof(void*));
-        h->size = newsz;
-        h->table = newtab;
+    if (h->size > sz * 4 && h->size > HT_N_INLINE) {
+        LLT_FREE(h->table);
+        h->table = NULL;
+        if (htable_new(h, sz) == NULL)
+            htable_new(h, 0);
     }
-    size_t i, hsz=h->size;
-    for(i=0; i < hsz; i++)
-        h->table[i] = HT_NOTFOUND;
+    else {
+        size_t i, hsz = h->size;
+        for (i = 0; i < hsz; i++)
+            h->table[i] = HT_NOTFOUND;
+    }
 }
 
 #ifdef __cplusplus

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -65,7 +65,7 @@ const TAGS = Any[
     :sub_int, :mul_int, :add_float, :sub_float, :new, :mul_float, :bitcast, :start, :done, :next,
     :indexed_iterate, :getfield, :meta, :eq_int, :slt_int, :sle_int, :ne_int, :push_loc, :pop_loc,
     :pop, :arrayset, :arrayref, :apply_type, :inbounds, :getindex, :setindex!, :Core, :!, :+,
-    :Base, :static_parameter, :convert, :colon, Symbol("#self#"), Symbol("#temp#"), :tuple,
+    :Base, :static_parameter, :convert, :colon, Symbol("#self#"), Symbol(""), :tuple,
 
     fill(:_reserved_, n_reserved_slots)...,
 

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -390,7 +390,7 @@ function serialize(s::AbstractSerializer, meth::Method)
     serialize(s, meth.file)
     serialize(s, meth.line)
     serialize(s, meth.sig)
-    serialize(s, meth.sparam_syms)
+    serialize(s, meth.slot_syms)
     serialize(s, meth.ambig)
     serialize(s, meth.nargs)
     serialize(s, meth.isva)
@@ -913,7 +913,7 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
     file = deserialize(s)::Symbol
     line = deserialize(s)::Int32
     sig = deserialize(s)::Type
-    sparam_syms = deserialize(s)::SimpleVector
+    slot_syms = deserialize(s)::String
     ambig = deserialize(s)::Union{Array{Any,1}, Nothing}
     nargs = deserialize(s)::Int32
     isva = deserialize(s)::Bool
@@ -925,7 +925,7 @@ function deserialize(s::AbstractSerializer, ::Type{Method})
         meth.file = file
         meth.line = line
         meth.sig = sig
-        meth.sparam_syms = sparam_syms
+        meth.slot_syms = slot_syms
         meth.ambig = ambig
         meth.nargs = nargs
         meth.isva = isva

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1287,6 +1287,7 @@ end
 
 _args_and_call(args...; kwargs...) = (args[1:end-1], kwargs, args[end](args[1:end-1]...; kwargs...))
 _materialize_broadcasted(f, args...) = Broadcast.materialize(Broadcast.broadcasted(f, args...))
+
 """
     @inferred [AllowedType] f(x)
 
@@ -1309,8 +1310,12 @@ julia> typeof(f(2))
 Int64
 
 julia> @code_warntype f(2)
+Variables
+  #self#::Core.Compiler.Const(f, false)
+  a::Int64
+
 Body::UNION{FLOAT64, INT64}
-1 ─ %1 = Base.slt_int(1, a)::Bool
+1 ─ %1 = (a > 1)::Bool
 └──      goto #3 if not %1
 2 ─      return 1
 3 ─      return 1.0

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1384,7 +1384,7 @@ let linfo = get_linfo(Base.convert, Tuple{Type{Int64}, Int32}),
     opt = Core.Compiler.OptimizationState(linfo, Core.Compiler.Params(world))
     # make sure the state of the properties look reasonable
     @test opt.src !== linfo.def.source
-    @test length(opt.src.slotflags) == length(opt.src.slotnames)
+    @test length(opt.src.slotflags) == linfo.def.nargs <= length(opt.src.slotnames)
     @test opt.src.ssavaluetypes isa Vector{Any}
     @test !opt.src.inferred
     @test opt.mod === Base

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -22,7 +22,8 @@ const Compiler = Core.Compiler
 #        false, false, false, false
 #    ))
 #
-#    Compiler.run_passes(ci, 1, Compiler.LineInfoNode[Compiler.NullLineInfo])
+#    NullLineInfo = Core.LineInfoNode(Symbol(""), Symbol(""), 0, 0)
+#    Compiler.run_passes(ci, 1, [NullLineInfo])
 #    # XXX: missing @test
 #end
 

--- a/test/compiler/validation.jl
+++ b/test/compiler/validation.jl
@@ -83,7 +83,7 @@ end
 
 @testset "SLOTFLAGS_MISMATCH" begin
     c = copy(c0)
-    push!(c.slotnames, :dummy)
+    push!(c.slotflags, 0x00)
     errors = Core.Compiler.validate_code(c)
     @test length(errors) == 1
     @test errors[1].kind === Core.Compiler.SLOTFLAGS_MISMATCH

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -332,13 +332,13 @@ function g15714(array_var15714)
         array_var15714[index_var15714] += 0
     end
     let index_var15714
-        for index_var15714 in eachindex(array_var15714)
+        for outer index_var15714 in eachindex(array_var15714)
             array_var15714[index_var15714] += 0
         end
         index_var15714
     end
     let index_var15714
-        for index_var15714 in eachindex(array_var15714)
+        for outer index_var15714 in eachindex(array_var15714)
             array_var15714[index_var15714] += 0
         end
         index_var15714
@@ -350,11 +350,11 @@ import InteractiveUtils.code_warntype
 used_dup_var_tested15714 = false
 used_unique_var_tested15714 = false
 function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types), must_used_vars)
-    src, rettype = code_typed(f, types)[1]
+    src, rettype = code_typed(f, types, optimize=false)[1]
     dupnames = Set()
     slotnames = Set()
     for name in src.slotnames
-        if name in slotnames
+        if name in slotnames || name === Symbol("")
             push!(dupnames, name)
         else
             push!(slotnames, name)
@@ -368,7 +368,7 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
     for sym in must_used_vars
         must_used_checked[sym] = false
     end
-    for str in (sprint(code_warntype, f, types),
+    for str in (sprint(io -> code_warntype(io, f, types, optimize=false)),
                 repr("text/plain", src))
         for var in must_used_vars
             @test occursin(string(var), str)
@@ -410,9 +410,9 @@ function test_typed_ast_printing(Base.@nospecialize(f), Base.@nospecialize(types
     end
 end
 test_typed_ast_printing(f15714, Tuple{Vector{Float32}},
-                        [:array_var15714])
+                        [:array_var15714,  :index_var15714])
 test_typed_ast_printing(g15714, Tuple{Vector{Float32}},
-                        [:array_var15714])
+                        [:array_var15714,  :index_var15714])
 #This test doesn't work with the new optimizer because we drop slotnames
 #We may want to test it against debug info eventually
 #@test used_dup_var_tested15715


### PR DESCRIPTION
We've previously been pretty careful to only have useful information in CodeInfo. That's probably not really necessary though, since having the ability to expose extra information (slottypes, rettype, parent, min/max world) isn't too harmful, and is occasionally useful. Here we use it to close #29287.