### PR TITLE
Remove redundant definition of 'identity'

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -74,7 +74,7 @@ isapprox(::Missing, ::Any; kwargs...) = missing
 isapprox(::Any, ::Missing; kwargs...) = missing
 
 # Unary operators/functions
-for f in (:(!), :(~), :(+), :(-), :(identity), :(zero), :(one), :(oneunit),
+for f in (:(!), :(~), :(+), :(-), :(zero), :(one), :(oneunit),
           :(isfinite), :(isinf), :(isodd),
           :(isinteger), :(isreal), :(isnan),
           :(iszero), :(transpose), :(adjoint), :(float), :(conj),


### PR DESCRIPTION
A separate definition of identity(missing) currently exists (which
returns missing).  However, the main definition already returns missing
for missing, so there's no need for this one to be here.