### PR TITLE
Implement alias scopes

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -124,7 +124,7 @@ eltype(::Type) = Any
 eltype(::Type{Bottom}) = throw(ArgumentError("Union{} does not have elements"))
 eltype(x) = eltype(typeof(x))
 
-import Core: arraysize, arrayset, arrayref
+import Core: arraysize, arrayset, arrayref, const_arrayref
 
 vect() = Vector{Any}()
 vect(X::T...) where {T} = T[ X[i] for i = 1:length(X) ]

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -89,7 +89,7 @@ const _PURE_BUILTINS = Any[tuple, svec, ===, typeof, nfields]
 # known to be effect-free if the are nothrow
 const _PURE_OR_ERROR_BUILTINS = [
     fieldtype, apply_type, isa, UnionAll,
-    getfield, arrayref, isdefined, Core.sizeof,
+    getfield, arrayref, const_arrayref, isdefined, Core.sizeof,
     Core.kwfunc, ifelse, Core._typevar, (<:)
 ]
 
@@ -307,7 +307,7 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
                 # tuple iteration/destructuring makes that impossible
                 # return plus_saturate(argcost, isknowntype(extyp) ? 1 : params.inline_nonleaf_penalty)
                 return 0
-            elseif f === Main.Core.arrayref && length(ex.args) >= 3
+            elseif (f === Main.Core.arrayref || f === Main.Core.const_arrayref) && length(ex.args) >= 3
                 atyp = argextype(ex.args[3], src, sptypes, slottypes)
                 return isknowntype(atyp) ? 4 : params.inline_nonleaf_penalty
             end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1186,7 +1186,7 @@ function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecializ
         # Check that the element type is compatible with the element we're assigning
         (argtypes[3] ⊑ a.parameters[1]::Type) || return false
         return true
-    elseif f === arrayref
+    elseif f === arrayref || f === const_arrayref
         return array_builtin_common_nothrow(argtypes, 3)
     elseif f === Core._expr
         length(argtypes) >= 1 || return false
@@ -1246,7 +1246,7 @@ function builtin_tfunction(@nospecialize(f), argtypes::Array{Any,1},
             return Bottom
         end
         return argtypes[2]
-    elseif f === arrayref
+    elseif f === arrayref || f === const_arrayref
         if length(argtypes) < 3
             isva && return Any
             return Bottom

--- a/src/ast.c
+++ b/src/ast.c
@@ -61,6 +61,7 @@ jl_sym_t *colon_sym; jl_sym_t *hygienicscope_sym;
 jl_sym_t *throw_undef_if_not_sym; jl_sym_t *getfield_undefref_sym;
 jl_sym_t *gc_preserve_begin_sym; jl_sym_t *gc_preserve_end_sym;
 jl_sym_t *escape_sym;
+jl_sym_t *aliasscope_sym; jl_sym_t *popaliasscope_sym;
 
 static uint8_t flisp_system_image[] = {
 #include <julia_flisp.boot.inc>
@@ -364,6 +365,8 @@ void jl_init_frontend(void)
     throw_undef_if_not_sym = jl_symbol("throw_undef_if_not");
     getfield_undefref_sym = jl_symbol("##getfield##");
     do_sym = jl_symbol("do");
+    aliasscope_sym = jl_symbol("aliasscope");
+    popaliasscope_sym = jl_symbol("popaliasscope");
 }
 
 JL_DLLEXPORT void jl_lisp_prompt(void)

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -28,6 +28,7 @@ DECLARE_BUILTIN(isdefined);  DECLARE_BUILTIN(nfields);
 DECLARE_BUILTIN(tuple);      DECLARE_BUILTIN(svec);
 DECLARE_BUILTIN(getfield);   DECLARE_BUILTIN(setfield);
 DECLARE_BUILTIN(fieldtype);  DECLARE_BUILTIN(arrayref);
+DECLARE_BUILTIN(const_arrayref);
 DECLARE_BUILTIN(arrayset);   DECLARE_BUILTIN(arraysize);
 DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);
 DECLARE_BUILTIN(invoke);     DECLARE_BUILTIN(_expr);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1059,6 +1059,11 @@ JL_CALLABLE(jl_f_arrayref)
     return jl_arrayref(a, i);
 }
 
+JL_CALLABLE(jl_f_const_arrayref)
+{
+    return jl_f_arrayref(F, args, nargs);
+}
+
 JL_CALLABLE(jl_f_arrayset)
 {
     JL_NARGSV(arrayset, 4);
@@ -1210,6 +1215,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
 
     // array primitives
     add_builtin_func("arrayref", jl_f_arrayref);
+    add_builtin_func("const_arrayref", jl_f_arrayref);
     add_builtin_func("arrayset", jl_f_arrayset);
     add_builtin_func("arraysize", jl_f_arraysize);
 

--- a/src/cgutils.cpp
+++ b/src/cgutils.cpp
@@ -1240,7 +1240,8 @@ static Value *emit_bounds_check(jl_codectx_t &ctx, const jl_cgval_t &ainfo, jl_v
 static Value *emit_unbox(jl_codectx_t &ctx, Type *to, const jl_cgval_t &x, jl_value_t *jt, Value* dest = NULL, MDNode *tbaa_dest = nullptr, bool isVolatile = false);
 
 static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, jl_value_t *jltype,
-                             MDNode *tbaa, bool maybe_null_if_boxed = true, unsigned alignment = 0)
+                             MDNode *tbaa, MDNode *aliasscope,
+                             bool maybe_null_if_boxed = true, unsigned alignment = 0)
 {
     bool isboxed;
     Type *elty = julia_type_to_llvm(jltype, &isboxed);
@@ -1265,8 +1266,12 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
         Instruction *load = ctx.builder.CreateAlignedLoad(data,
             isboxed || alignment ?  alignment : julia_alignment(jltype),
             false);
-        if (isboxed)
+        if (aliasscope) {
+            load->setMetadata("alias.scope", aliasscope);
+        }
+        if (isboxed) {
             load = maybe_mark_load_dereferenceable(load, true, jltype);
+        }
         if (tbaa) {
             elt = tbaa_decorate(tbaa, load);
         }
@@ -1282,7 +1287,7 @@ static jl_cgval_t typed_load(jl_codectx_t &ctx, Value *ptr, Value *idx_0based, j
 
 static void typed_store(jl_codectx_t &ctx,
         Value *ptr, Value *idx_0based, const jl_cgval_t &rhs,
-        jl_value_t *jltype, MDNode *tbaa,
+        jl_value_t *jltype, MDNode *tbaa, MDNode *aliasscope,
         Value *parent,  // for the write barrier, NULL if no barrier needed
         unsigned alignment = 0)
 {
@@ -1313,6 +1318,8 @@ static void typed_store(jl_codectx_t &ctx,
     if (idx_0based)
         data = ctx.builder.CreateInBoundsGEP(r->getType(), data, idx_0based);
     Instruction *store = ctx.builder.CreateAlignedStore(r, data, isboxed || alignment ? alignment : julia_alignment(jltype));
+    if (aliasscope)
+        store->setMetadata("noalias", aliasscope);
     if (tbaa)
         tbaa_decorate(tbaa, store);
 }
@@ -1465,7 +1472,7 @@ static bool emit_getfield_unknownidx(jl_codectx_t &ctx,
                 *ret = mark_julia_slot(addr, jt, NULL, strct.tbaa);
                 return true;
             }
-            *ret = typed_load(ctx, ptr, idx, jt, strct.tbaa, false);
+            *ret = typed_load(ctx, ptr, idx, jt, strct.tbaa, nullptr, false);
             return true;
         }
         else if (strct.isboxed) {
@@ -1590,7 +1597,7 @@ static jl_cgval_t emit_getfield_knownidx(jl_codectx_t &ctx, const jl_cgval_t &st
             // just compute the pointer and let user load it when necessary
             return mark_julia_slot(addr, jfty, NULL, strct.tbaa);
         }
-        return typed_load(ctx, addr, NULL, jfty, strct.tbaa, true, align);
+        return typed_load(ctx, addr, NULL, jfty, strct.tbaa, nullptr, true, align);
     }
     else if (isa<UndefValue>(strct.V)) {
         return jl_cgval_t();
@@ -2424,7 +2431,7 @@ static void emit_setfield(jl_codectx_t &ctx,
         else {
             unsigned align = jl_field_align(sty, idx0);
             typed_store(ctx, addr, NULL, rhs, jfty,
-                strct.tbaa, maybe_bitcast(ctx,
+                strct.tbaa, nullptr, maybe_bitcast(ctx,
                 data_pointer(ctx, strct), T_pjlvalue), align);
         }
     }

--- a/src/init.c
+++ b/src/init.c
@@ -913,6 +913,7 @@ void jl_get_builtins(void)
     jl_builtin_tuple = core("tuple");           jl_builtin_svec = core("svec");
     jl_builtin_getfield = core("getfield");     jl_builtin_setfield = core("setfield!");
     jl_builtin_fieldtype = core("fieldtype");   jl_builtin_arrayref = core("arrayref");
+    jl_builtin_const_arrayref = core("const_arrayref");
     jl_builtin_arrayset = core("arrayset");     jl_builtin_arraysize = core("arraysize");
     jl_builtin_apply_type = core("apply_type"); jl_builtin_applicable = core("applicable");
     jl_builtin_invoke = core("invoke");         jl_builtin__expr = core("_expr");

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -601,7 +601,7 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
         Type *ptrty = julia_type_to_llvm(ety, &isboxed);
         assert(!isboxed);
         Value *thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
-        return typed_load(ctx, thePtr, im1, ety, tbaa_data, true, align_nb);
+        return typed_load(ctx, thePtr, im1, ety, tbaa_data, nullptr, true, align_nb);
     }
 }
 
@@ -664,7 +664,7 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
         Type *ptrty = julia_type_to_llvm(ety, &isboxed);
         assert(!isboxed);
         thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
-        typed_store(ctx, thePtr, im1, x, ety, tbaa_data, NULL, align_nb);
+        typed_store(ctx, thePtr, im1, x, ety, tbaa_data, nullptr, nullptr, align_nb);
     }
     return mark_julia_type(ctx, thePtr, false, aty);
 }

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -10,6 +10,7 @@
 #include <llvm/Analysis/Passes.h>
 #include <llvm/Analysis/BasicAliasAnalysis.h>
 #include <llvm/Analysis/TypeBasedAliasAnalysis.h>
+#include <llvm/Analysis/ScopedNoAliasAA.h>
 #include <llvm/Analysis/TargetTransformInfo.h>
 #include <llvm/Analysis/TargetLibraryInfo.h>
 #include <llvm/IR/Verifier.h>
@@ -124,6 +125,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
         return;
     }
     PM->add(createPropagateJuliaAddrspaces());
+    PM->add(createScopedNoAliasAAWrapperPass());
     PM->add(createTypeBasedAAWrapperPass());
     if (opt_level >= 3) {
         PM->add(createBasicAAWrapperPass());

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2951,7 +2951,7 @@ f(x) = yt(x)
 
 (define lambda-opt-ignored-exprs
   (Set '(quote top core line inert local local-def unnecessary copyast
-         meta inbounds boundscheck simdloop decl
+         meta inbounds boundscheck simdloop decl aliasscope popaliasscope
          struct_type abstract_type primitive_type thunk with-static-parameters
          implicit-global global globalref outerref const-if-global
          const null ssavalue isdefined toplevel module lambda error
@@ -3971,7 +3971,7 @@ f(x) = yt(x)
                s))
 
             ;; metadata expressions
-            ((line meta inbounds simdloop gc_preserve_end)
+            ((line meta inbounds simdloop gc_preserve_end aliasscope popaliasscope)
              (let ((have-ret? (and (pair? code) (pair? (car code)) (eq? (caar code) 'return))))
                (cond ((eq? (car e) 'line)
                       (set! current-loc e)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -999,6 +999,7 @@ extern jl_sym_t *structtype_sym;   extern jl_sym_t *foreigncall_sym;
 extern jl_sym_t *global_sym; extern jl_sym_t *list_sym;
 extern jl_sym_t *dot_sym;    extern jl_sym_t *newvar_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;
+extern jl_sym_t *aliasscope_sym; extern jl_sym_t *popaliasscope_sym;
 extern jl_sym_t *copyast_sym; extern jl_sym_t *cfunction_sym;
 extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
 extern jl_sym_t *meta_sym; extern jl_sym_t *inert_sym;

--- a/src/method.c
+++ b/src/method.c
@@ -37,7 +37,8 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
         if (jl_is_toplevel_only_expr(expr) || e->head == const_sym || e->head == copyast_sym ||
             e->head == quote_sym || e->head == inert_sym ||
             e->head == meta_sym || e->head == inbounds_sym ||
-            e->head == boundscheck_sym || e->head == simdloop_sym) {
+            e->head == boundscheck_sym || e->head == simdloop_sym || e->head == aliasscope_sym ||
+            e->head == popaliasscope_sym) {
             // ignore these
         }
         else {

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -62,7 +62,7 @@ static const jl_fptr_args_t id_to_fptrs[] = {
     jl_f_typeassert, jl_f__apply, jl_f__apply_pure, jl_f__apply_latest, jl_f_isdefined,
     jl_f_tuple, jl_f_svec, jl_f_intrinsic_call, jl_f_invoke_kwsorter,
     jl_f_getfield, jl_f_setfield, jl_f_fieldtype, jl_f_nfields,
-    jl_f_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
+    jl_f_arrayref, jl_f_const_arrayref, jl_f_arrayset, jl_f_arraysize, jl_f_apply_type,
     jl_f_applicable, jl_f_invoke, jl_f_sizeof, jl_f__expr, jl_f__typevar,
     jl_f_ifelse,
     NULL };

--- a/test/compiler/codegen.jl
+++ b/test/compiler/codegen.jl
@@ -334,3 +334,33 @@ mktemp() do f_22330, _
     write(f_22330, str_22330)
     @test success(`$(Base.julia_cmd()) --startup-file=no $f_22330`)
 end
+
+# Alias scope
+macro aliasscope(body)
+    sym = gensym()
+    esc(quote
+        $(Expr(:aliasscope))
+        $sym = $body
+        $(Expr(:popaliasscope))
+        $sym
+    end)
+end
+
+struct Const{T<:Array}
+    a::T
+end
+
+@eval Base.getindex(A::Const, i1::Int) = Core.const_arrayref($(Expr(:boundscheck)), A.a, i1)
+@eval Base.getindex(A::Const, i1::Int, i2::Int, I::Int...) =  (Base.@_inline_meta; Core.const_arrayref($(Expr(:boundscheck)), A.a, i1, i2, I...))
+
+function foo31018!(a, b)
+    @aliasscope for i in eachindex(a, b)
+        a[i] = Const(b)[i]
+    end
+end
+io = IOBuffer()
+code_llvm(io, foo31018!, Tuple{Vector{Int}, Vector{Int}}, optimize=false, raw=true, dump_module=true)
+str = String(take!(io))
+@test occursin("alias.scope", str)
+@test occursin("aliasscope", str)
+@test occursin("noalias", str)


### PR DESCRIPTION
This PR is based on the original PR #20257 by @Keno.
```julia
struct Const{T<:Array}
    a::T
end

@eval Base.getindex(A::Const, i1::Int) = Core.const_arrayref($(Expr(:boundscheck)), A.a, i1)
@eval Base.getindex(A::Const, i1::Int, i2::Int, I::Int...) =  (Base.@_inline_meta; Core.const_arrayref($(Expr(:boundscheck)), A.a, i1, i2, I...))

macro aliasscope(body)
    sym = gensym()
    esc(quote
        $(Expr(:aliasscope))
        $sym = $body
        $(Expr(:popaliasscope))
        $sym
    end)
end

using BenchmarkTools, Test
function micro_ker_const!(AB, Ac::Vector{Float64}, Bc::Vector{Float64}, kc::Int, offSetA::Int, offSetB::Int)
    MR = 8; NR = 6;
    @inbounds @aliasscope for k in 1:kc
        for j in 1:NR, i in 1:MR
            AB[i+(j-1)*MR] = muladd(Const(Ac)[offSetA+i], Const(Bc)[offSetB+j], Const(AB)[i+(j-1)*MR])
        end
        offSetA += MR
        offSetB += NR
    end
    return
end
function micro_ker!(AB, Ac::Vector{Float64}, Bc::Vector{Float64}, kc::Int, offSetA::Int, offSetB::Int)
    MR = 8; NR = 6;
    @inbounds for k in 1:kc
        for j in 1:NR, i in 1:MR
            AB[i+(j-1)*MR] = muladd(Ac[offSetA+i], Bc[offSetB+j], AB[i+(j-1)*MR])
        end
        offSetA += MR
        offSetB += NR
    end
    return
end
AB = zeros(8, 6); Ac = rand(8*32); Bc = rand(32*6);
micro_ker!(AB, Ac, Bc, 32, 0, 0)
@test reshape(Ac, 8, 32) * reshape(Bc, 6, 32)' ≈ reshape(AB, 8, 6)
AB .= 0
micro_ker_const!(AB, Ac, Bc, 32, 0, 0)
@test reshape(Ac, 8, 32) * reshape(Bc, 6, 32)' ≈ reshape(AB, 8, 6)
@btime micro_ker_const!($AB, $Ac, $Bc, 32, 0, 0)
@btime micro_ker!($AB, $Ac, $Bc, 32, 0, 0)
```
```julia
julia> @btime micro_ker_const!($AB, $Ac, $Bc, 32, 0, 0)
  231.211 ns (0 allocations: 0 bytes)

julia> @btime micro_ker!($AB, $Ac, $Bc, 32, 0, 0)
  863.300 ns (0 allocations: 0 bytes)
```

```julia
julia> @code_llvm optimize=false raw=true dump_module=true micro_ker_const!(AB, Ac, Bc, 32, 0, 0)
...
    %34 = load double, double addrspace(13)* %33, align 8, !dbg !40, !tbaa !48, !alias.scope !51
...
    %46 = load double, double addrspace(13)* %45, align 8, !dbg !40, !tbaa !48, !alias.scope !51
...
    %60 = load double, double addrspace(13)* %59, align 8, !dbg !40, !tbaa !48, !alias.scope !51
...
    store double %62, double addrspace(13)* %75, align 8, !dbg !61, !tbaa !48, !noalias !51
...
!51 = !{!52}
!52 = !{!"aliasscope", !53}
```

CC: @vchuravy