### PR TITLE
RFC: Show single column array as permutedims of single row

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -361,6 +361,11 @@ function _show_nonempty(io::IO, X::AbstractMatrix, prefix::String)
     limit = get(io, :limit, false)::Bool
     indr, indc = axes(X,1), axes(X,2)
     nr, nc = length(indr), length(indc)
+    if nc == 1
+        print(io, prefix, "hcat(")
+        _show_nonempty(io, X, "")
+        return print(io, ")")
+    end
     rdots, cdots = false, false
     rr1, rr2 = UnitRange{Int}(indr), 1:0
     cr1, cr2 = UnitRange{Int}(indc), 1:0

--- a/test/show.jl
+++ b/test/show.jl
@@ -1475,5 +1475,11 @@ end
 Z = Array{Float64}(undef,0,0)
 @test eval(Meta.parse(repr(Z))) == Z
 
+
 # issue #31065, do not print parentheses for nested dot expressions
 @test sprint(Base.show_unquoted, :(foo.x.x)) == "foo.x.x"
+
+# issue #31019: printing of single column matrix
+Z = ones(3,1)
+@test eval(Meta.parse(repr(Z))) == Z
+


### PR DESCRIPTION
The current matrix syntax has no elegant way for representing a matrix of a single column. Currently `show` (and `repr`) print elements separated by semicolons, which is actually parsed as a vector, e.g.
```julia
julia> x = [i for i=1:3, j=1:1]
3×1 Array{Int64,2}:
 1
 2
 3

julia> repr(x)
"[1; 2; 3]"

julia> eval(Meta.parse(repr(x)))
3-element Array{Int64,1}:
 1
 2
 3
```

This changes it so that it is represented as `permutedims` of a single row matrix:
```julia
julia> repr(x)
"permutedims([1 2 3])"
```
It's not the most elegant solution: feedback appreciated.