### PR TITLE
Improve consistency of ArgumentError with >= 0

### DIFF
--- a/base/abstractarraymath.jl
+++ b/base/abstractarraymath.jl
@@ -121,7 +121,7 @@ julia> selectdim(A, 2, 3)
 """
 @inline selectdim(A::AbstractArray, d::Integer, i) = _selectdim(A, d, i, setindex(map(Slice, axes(A)), i, d))
 @noinline function _selectdim(A, d, i, idxs)
-    d >= 1 || throw(ArgumentError("dimension must be ≥ 1"))
+    d >= 1 || throw(ArgumentError("dimension must be ≥ 1, got $d"))
     nd = ndims(A)
     d > nd && (i == 1 || throw(BoundsError(A, (ntuple(k->Colon(),d-1)..., i))))
     return view(A, idxs...)

--- a/base/array.jl
+++ b/base/array.jl
@@ -1003,7 +1003,7 @@ function resize!(a::Vector, nl::Integer)
         _growend!(a, nl-l)
     elseif nl != l
         if nl < 0
-            throw(ArgumentError("new length must be ≥ 0"))
+            throw(ArgumentError("new length must be ≥ 0, got $nl"))
         end
         _deleteend!(a, l-nl)
     end

--- a/base/iobuffer.jl
+++ b/base/iobuffer.jl
@@ -505,7 +505,7 @@ end
 
 # copy-free crc32c of IOBuffer:
 function _crc32c(io::IOBuffer, nb::Integer, crc::UInt32=0x00000000)
-    nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0"))
+    nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0, got $nb"))
     io.readable || throw(ArgumentError("read failed, IOBuffer is not readable"))
     n = min(nb, bytesavailable(io))
     n == 0 && return crc

--- a/base/ntuple.jl
+++ b/base/ntuple.jl
@@ -32,7 +32,7 @@ end
 
 function _ntuple(f, n)
     @_noinline_meta
-    (n >= 0) || throw(ArgumentError(string("tuple length should be ≥0, got ", n)))
+    (n >= 0) || throw(ArgumentError(string("tuple length should be ≥ 0, got ", n)))
     ([f(i) for i = 1:n]...,)
 end
 
@@ -44,7 +44,7 @@ ntuple(f, ::Val{3}) = (@_inline_meta; (f(1), f(2), f(3)))
 
 @inline function ntuple(f::F, ::Val{N}) where {F,N}
     N::Int
-    (N >= 0) || throw(ArgumentError(string("tuple length should be ≥0, got ", N)))
+    (N >= 0) || throw(ArgumentError(string("tuple length should be ≥ 0, got ", N)))
     if @generated
         quote
             @nexprs $N i -> t_i = f(i)

--- a/base/util.jl
+++ b/base/util.jl
@@ -654,7 +654,7 @@ _crc32c(a::Union{Array{UInt8},FastContiguousSubArray{UInt8,N,<:Array{UInt8}} whe
 _crc32c(s::String, crc::UInt32=0x00000000) = unsafe_crc32c(s, sizeof(s) % Csize_t, crc)
 
 function _crc32c(io::IO, nb::Integer, crc::UInt32=0x00000000)
-    nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0"))
+    nb < 0 && throw(ArgumentError("number of bytes to checksum must be ≥ 0, got $nb"))
     # use block size 24576=8192*3, since that is the threshold for
     # 3-way parallel SIMD code in the underlying jl_crc32c C function.
     buf = Vector{UInt8}(undef, min(nb, 24576))


### PR DESCRIPTION
I notices many `ArgumentError` in base were in the form "... must be ≥ 0, got ..." but some were inconsistent.