### PR TITLE
fix a bug in `sizeof_nothrow`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -293,10 +293,10 @@ end
 add_tfunc(isdefined, 1, 2, isdefined_tfunc, 1)
 function sizeof_nothrow(@nospecialize(x))
     if isa(x, Const)
-        if !isa(x, Type)
+        x = x.val
+        if !isa(x, Type) || x === DataType
             return true
         end
-        x = x.val
     elseif isa(x, Conditional)
         return true
     else

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -1344,6 +1344,7 @@ let PT = PartialTuple(Tuple{Int64,UInt64}, Any[Const(10, false), UInt64])
     @test nfields_tfunc(PT) === Const(2, false)
     @test sizeof_nothrow(PT) === true
 end
+@test sizeof_nothrow(Const(Tuple)) === false
 
 function f23024(::Type{T}, ::Int) where T
     1 + 1


### PR DESCRIPTION
Fixes the bug reported here: https://github.com/JuliaLang/julia/pull/31014#issuecomment-462083859
In practice this is very minor since it only affects abstract types, where we wouldn't try to optimize out a `sizeof` call anyway since we don't know the result.