### PR TITLE
bb: fix normalize_triplet to accept other version outputs

### DIFF
--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -115,7 +115,7 @@ if gcc_version == "blank_gcc":
             "6": "gcc4",
             "7": "gcc7",
             "8": "gcc8",
-        }[sys.argv[2][0]]
+        }[list(filter(lambda x: re.match("\d+\.\d+\.\d+", x), sys.argv[2].split()))[-1][0]]
 
 
 print(arch+p(platform)+p(libc)+r(call_abi)+p(gcc_version)+p(cxx_abi))

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -1,7 +1,7 @@
 define bb-install
 # If the user has signified that this is a GCC-multiversioned tarball, then generate the proper tarball
 ifeq ($(3),true)
-$(2)_BB_TRIPLET := $(shell python $(call cygpath_w,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(lastword $(shell $(FC) --version | head -1))")
+$(2)_BB_TRIPLET := $(shell python $(call cygpath_w,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)")
 else
 $(2)_BB_TRIPLET := $(shell python $(call cygpath_w,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)))
 endif


### PR DESCRIPTION
Modify `normalize_triplet` to accept other output of `gfortran --version` by taking the last entry that matches a version regex. E.g. on my system the output is:
```
$ gfortran --version | head -1
GNU Fortran (Ubuntu 5.5.0-12ubuntu1~16.04) 5.5.0 20171010
```