### PR TITLE
Allow recursion that decreases the total number of arguments

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -234,6 +234,7 @@ function type_more_complex(@nospecialize(t), @nospecialize(c), sources::SimpleVe
         if isa(c, DataType) && t.name === c.name
             cP = c.parameters
             length(cP) < length(tP) && return true
+            length(cP) > length(tP) && !isvarargtype(tP[end]) && depth == 1 && return false
             ntail = length(cP) - length(tP) # assume parameters were dropped from the tuple head
             # allow creating variation within a nested tuple, but only so deep
             if t.name === Tuple.name && tupledepth > 0

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -2246,3 +2246,10 @@ call_ntuple(a, b) = my_ntuple(i->(a+b; i), Val(4))
 
 @generated unionall_sig_generated(::Vector{T}, b::Vector{S}) where {T, S} = :($b)
 @test length(code_typed(unionall_sig_generated, Tuple{Any, Vector{Int}})) == 1
+
+# Test that we don't limit recursions on the number of arguments, even if the
+# arguments themselves are getting more complex
+f_incr(x::Tuple, y::Tuple, args...) = f_incr((x, y), args...)
+f_incr(x::Tuple) = x
+@test @inferred(f_incr((), (), (), (), (), (), (), ())) ==
+    ((((((((), ()), ()), ()), ()), ()), ()), ())


### PR DESCRIPTION
Inference limits recursion unless it can prove that it must
eventually converge (e.g. by looking at the arguments and seeing
them get less complex). This adds another rule to the "must converge"
check, by allowing recursive calls with strictly decreasing numbers
of arguments, even if the individual arguments increase in complexity.
There are other ways to do this kind of recursion (e.g. by having total
additive complexity measures), but this seems to work well for now
and fits in with the existing rules.

This fixes inference for higher-order autodiff in Flux models. Flux has
the following function:
```
function partial(f::F, Δ, i, args::Vararg{Any,N}) where {F,N}
  dargs = ntuple(j -> dual(args[j], i==j), Val(N))
  return Δ * f(dargs...).partials[1]
end
```
which is recursive if `f` is itself `partial` (as happens in higher
order autodiff). This change allows this to infer, because the
inner call to `f` is on strictly fewer arguments (despite those
being wrapped in an additional layer of `Dual`).