### PR TITLE
fix #29936, precompile should not assume UnionAlls have stable addresses

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -257,7 +257,7 @@ static int type_parameter_recursively_external(jl_value_t *p0) JL_NOTSAFEPOINT
         return 0;
     if (module_in_worklist(p->name->module))
         return 0;
-    if (p->name->wrapper != (jl_value_t*)p0) {
+    if (jl_unwrap_unionall(p->name->wrapper) != (jl_value_t*)p) {
         if (!type_recursively_external(p))
             return 0;
     }
@@ -745,7 +745,7 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
     else if (jl_is_unionall(v)) {
         write_uint8(s->s, TAG_UNIONALL);
         jl_datatype_t *d = (jl_datatype_t*)jl_unwrap_unionall(v);
-        if (jl_is_datatype(d) && d->name->wrapper == v &&
+        if (jl_is_datatype(d) && jl_unwrap_unionall(d->name->wrapper) == (jl_value_t*)d &&
             !module_in_worklist(d->name->module)) {
             write_uint8(s->s, 1);
             jl_serialize_value(s, d->name->module);

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -744,5 +744,27 @@ let
     end
 end
 
+# issue #29936
+let
+    load_path = mktempdir()
+    load_cache_path = mktempdir()
+    try
+        write(joinpath(load_path, "Foo29936.jl"),
+              """
+              module Foo29936
+              const global m = Val{nothing}()
+              const global h = Val{:hey}()
+              wab = [("a", m), ("b", h),]
+              end
+              """)
+        pushfirst!(LOAD_PATH, load_path)
+        pushfirst!(DEPOT_PATH, load_cache_path)
+        @eval using Foo29936
+        @test [("Plan", Foo29936.m), ("Plan", Foo29936.h),] isa Vector{Tuple{String,Val}}
+    finally
+        rm(load_path, recursive=true)
+        rm(load_cache_path, recursive=true)
+    end
+end
 
 end # !withenv


### PR DESCRIPTION
`typejoin` can re-form a type like `Val{x} where x`, re-using `Val.var` and `Val.body` but allocating a new UnionAll. However, `jl_serialize_datatype` compares the address of the inner type (`Val.body`) while the code for serializing UnionAll compares the address of the UnionAll itself, leading to a possible inconsistency. This makes them both use the inner type, which has a stable address.

Backportable like whoa.