### PR TITLE
add test io

### DIFF
--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -61,6 +61,12 @@ end
         @test a === 1
     end
 end
+@testset "@test_io" begin
+    @test_io (1, 2) "(1, 2)"
+    @test_io (1, 2) r"([0-9], [0-9])"
+    @test_io "text/plain" (1, 2) "(1, 2)"
+end
+
 @testset "@test and elements of an array" begin
     a = Array{Float64, 5}(undef, 2, 2, 2, 2, 2)
     a[1, 1, 1, 1, 1] = 10


### PR DESCRIPTION
This is an eye candy for testing IO. I found it convenient to test custom printing and some packages have to implement their own `test_io`, I think it would be great to have this eye candy in `Test` directly.

What's in it?


1. `@test_io` macro: this just forward and expand the test expression to `test_io`

2. `test_io` function, it will test the printing of mime `"text/plain"` by default like `show`, you can use plain string or regex as target, and people can overload it to meet their own mime.