### PR TITLE
Fix incorrect sign of atanh(complex(x,y)) if x == -1

### DIFF
--- a/base/complex.jl
+++ b/base/complex.jl
@@ -955,7 +955,7 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
     elseif ax==1
         if y == 0
             ξ = copysign(oftype(x,Inf),x)
-            η = zero(y)
+            η = y
         else
             ym = ay+ρ
             ξ = copysign(log(sqrt(sqrt(4+y*y))/sqrt(ym)), x)

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -953,7 +953,7 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
         end
         return Complex(real(1/z), copysign(oftype(y,pi)/2, y))
     end
-    β = copysign(1, x)
+    β = copysign(one(T), x)
     z *= β
     x, y = reim(z)
     if x == 1

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -958,7 +958,7 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
             η = zero(y)
         else
             ym = ay+ρ
-            ξ = log(sqrt(sqrt(4+y*y))/sqrt(ym))
+            ξ = copysign(log(sqrt(sqrt(4+y*y))/sqrt(ym)),x)
             η = copysign(oftype(y,pi)/2 + atan(ym/2), y)/2
         end
     else #Normal case

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -958,7 +958,7 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
             η = zero(y)
         else
             ym = ay+ρ
-            ξ = copysign(log(sqrt(sqrt(4+y*y))/sqrt(ym)),x)
+            ξ = copysign(log(sqrt(sqrt(4+y*y))/sqrt(ym)), x)
             η = copysign(oftype(y,pi)/2 + atan(ym/2), y)/2
         end
     else #Normal case

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -952,13 +952,17 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
             return Complex(copysign(zero(x),x), copysign(oftype(y,pi)/2, y))
         end
         return Complex(real(1/z), copysign(oftype(y,pi)/2, y))
-    elseif ax==1
+    end
+    β = copysign(1, x)
+    z *= β
+    x, y = reim(z)
+    if x == 1
         if y == 0
-            ξ = copysign(oftype(x,Inf),x)
+            ξ = oftype(x, Inf)
             η = y
         else
             ym = ay+ρ
-            ξ = copysign(log(sqrt(sqrt(4+y*y))/sqrt(ym)), x)
+            ξ = log(sqrt(sqrt(4+y*y))/sqrt(ym))
             η = copysign(oftype(y,pi)/2 + atan(ym/2), y)/2
         end
     else #Normal case
@@ -970,7 +974,7 @@ function atanh(z::Complex{T}) where T<:AbstractFloat
         end
         η = angle(Complex((1-x)*(1+x)-ysq, 2y))/2
     end
-    Complex(ξ, η)
+    β * Complex(ξ, η)
 end
 atanh(z::Complex) = atanh(float(z))
 

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -926,7 +926,7 @@ this function, see [^AH16_1].
 ```jldoctest
 julia> acos(cos([0.5 0.1; -0.2 0.3]))
 2×2 Array{Complex{Float64},2}:
-  0.5-8.32667e-17im  0.1+0.0im        
+  0.5-8.32667e-17im  0.1+0.0im
  -0.2+2.63678e-16im  0.3-3.46945e-16im
 ```
 """

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -926,8 +926,8 @@ this function, see [^AH16_1].
 ```jldoctest
 julia> acos(cos([0.5 0.1; -0.2 0.3]))
 2×2 Array{Complex{Float64},2}:
-  0.5-5.55112e-17im  0.1-2.77556e-17im
- -0.2+2.498e-16im    0.3-3.46945e-16im
+  0.5-8.32667e-17im  0.1+0.0im        
+ -0.2+2.63678e-16im  0.3-3.46945e-16im
 ```
 """
 function acos(A::AbstractMatrix)

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1067,5 +1067,8 @@ end
 end
 
 @testset "issue #31054" begin
-    @test tanh(atanh(-1.0+1.0im)) == -1.0+1.0im
+    @test tanh(atanh(complex(1.0,1.0))) == complex(1.0,1.0)
+    @test tanh(atanh(complex(1.0,-1.0))) == complex(1.0,-1.0)
+    @test tanh(atanh(complex(-1.0,1.0))) == complex(-1.0,1.0)
+    @test tanh(atanh(complex(-1.0,-1.0))) == complex(-1.0,-1.0)
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -696,7 +696,9 @@ end
     @test isequal(atanh(complex(-0.0,-Inf)),complex(-0.0,-pi/2))
 
     @test isequal(atanh(complex( 1.0, 0.0)),complex( Inf, 0.0))
+    @test isequal(atanh(complex( 1.0,-0.0)),complex( Inf,-0.0))
     @test isequal(atanh(complex(-1.0, 0.0)),complex(-Inf, 0.0))
+    @test isequal(atanh(complex(-1.0,-0.0)),complex(-Inf,-0.0))
     @test isequal(atanh(complex( 5.0, Inf)),complex( 0.0, pi/2))
     @test isequal(atanh(complex( 5.0,-Inf)),complex( 0.0,-pi/2))
     @test isequal(atanh(complex( 5.0, NaN)),complex( NaN, NaN))

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -1065,3 +1065,7 @@ end
 
     @test @inferred(2.0^(3.0+0im)) === @inferred((2.0+0im)^(3.0+0im)) === @inferred((2.0+0im)^3.0) === 8.0+0.0im
 end
+
+@testset "issue #31054" begin
+    @test tanh(atanh(-1.0+1.0im)) == -1.0+1.0im
+end


### PR DESCRIPTION
In the case that x==-1, we have to flip the sign of ξ. Fixes the problem noticed in #31054.

Update:
The current Julia implementation was mistranscribed from the reference: The multiplication with the sign of x is missing (see [#31061 (comment)](https://github.com/JuliaLang/julia/pull/31061#issuecomment-463653341)). This PR currently adds that multiplication, fixing both the original sign issue and the problems (DomainError) near `z=-1+0im`.