### PR TITLE
Handle missing values in clamp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ Standard library changes
   (environment, flags, working directory, etc) if `x` is the first interpolant and errors
   otherwise ([#24353]).
 * `IPAddr` subtypes now behave like scalars when used in broadcasting ([#32133]).
+* `clamp` can now handle missing values ([#31066]).
 
 #### Libdl
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -1083,5 +1083,6 @@ for f in (:(acos), :(acosh), :(asin), :(asinh), :(atan), :(atanh),
           :(log2), :(exponent), :(sqrt))
     @eval $(f)(::Missing) = missing
 end
+clamp(::Missing, lo, hi) = missing
 
 end # module

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -164,6 +164,8 @@ Base.one(::Type{Unit}) = 1
         @test ismissing(f(missing))
     end
 
+    @test ismissing(clamp(missing, 1, 2))
+
     for T in (Int, Float64)
         @test zero(Union{T, Missing}) === T(0)
         @test one(Union{T, Missing}) === T(1)


### PR DESCRIPTION
This adds support for `clamp`ing missing values. The existing `clamp` code errors on `missing` as it uses `ifelse` on comparisons that can return `missing`. This came up in some private code.