### PR TITLE
Show dot expressions without parentheses

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1120,7 +1120,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             item = args[1]
             # field
             field = unquoted(args[2])
-            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item))
+            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && item.head !== :(.)
             parens && print(io, '(')
             show_unquoted(io, item, indent)
             parens && print(io, ')')

--- a/base/show.jl
+++ b/base/show.jl
@@ -1120,7 +1120,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             item = args[1]
             # field
             field = unquoted(args[2])
-            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && item.head !== :(.)
+            parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && !Meta.isexpr(item, :(.))
             parens && print(io, '(')
             show_unquoted(io, item, indent)
             parens && print(io, ')')

--- a/test/show.jl
+++ b/test/show.jl
@@ -1464,8 +1464,4 @@ Z = Array{Float64}(undef,0,0)
 @test eval(Meta.parse(repr(Z))) == Z
 
 # issue #31065, do not print parentheses for nested dot expressions
-let
-    struct I31065 x::Union{I31065,Nothing} end
-    foo = I31065(I31065(nothing))
-    @test sprint(Base.show_unquoted, :(foo.x.x)) == "foo.x.x"
-end
+@test sprint(Base.show_unquoted, :(foo.x.x)) == "foo.x.x"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1462,3 +1462,10 @@ end
 # issue #30927
 Z = Array{Float64}(undef,0,0)
 @test eval(Meta.parse(repr(Z))) == Z
+
+# issue #31065, do not print parentheses for nested dot expressions
+let
+    struct I31065 x::Union{I31065,Nothing} end
+    foo = I31065(I31065(nothing))
+    @test sprint(Base.show_unquoted, :(foo.x.x)) == "foo.x.x"
+end


### PR DESCRIPTION
Nested dot expressions (nested struct `obj.field.field`) not show without parentheses.
Fixes #31065