### PR TITLE
Revert "log when a worker begins a testset to improve debuggability when workers hang in CI"

### DIFF
--- a/test/testdefs.jl
+++ b/test/testdefs.jl
@@ -15,7 +15,6 @@ function runtests(name, path, isolate=true; seed=nothing)
             m = Main
         end
         @eval(m, using Test, Random)
-        println("running testset ", name, "...")
         ex = quote
             @timed @testset $"$name" begin
                 # Random.seed!(nothing) will fail


### PR DESCRIPTION
This really hurt the beautiful table for the test output giving a worse overview.

Reverts JuliaLang/julia#26877