### PR TITLE
Avoid recursion in print_to_string.

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1003,7 +1003,7 @@ function resize!(a::Vector, nl::Integer)
         _growend!(a, nl-l)
     elseif nl != l
         if nl < 0
-            throw(ArgumentError("new length must be ≥ 0, got $nl"))
+            throw(ArgumentError("new length must be ≥ 0"))
         end
         _deleteend!(a, l-nl)
     end


### PR DESCRIPTION
Re-fix https://github.com/JuliaLang/julia/pull/29957 after being reintroduced by https://github.com/JuliaLang/julia/pull/31027 (this time, `string` -> `print_to_string` -> `resize!` -> `ArgumentError` -> `string`).