### PR TITLE
speed up dispatch on parameterized function types

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -47,6 +47,7 @@ JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *mo
     mt->kwsorter = NULL;
     mt->backedges = NULL;
     JL_MUTEX_INIT(&mt->writelock);
+    mt->offs = 1;
     return mt;
 }
 
@@ -480,6 +481,8 @@ JL_DLLEXPORT jl_datatype_t *jl_new_datatype(
             if (!abstract) {
                 tn->mt = jl_new_method_table(name, module);
                 jl_gc_wb(tn, tn->mt);
+                if (jl_svec_len(parameters) > 0)
+                    tn->mt->offs = 0;
             }
         }
         t->name = tn;

--- a/src/dump.c
+++ b/src/dump.c
@@ -2370,7 +2370,7 @@ static void jl_reinit_item(jl_value_t *v, int how, arraylist_t *tracee_list)
                 jl_methtable_t *mt = (jl_methtable_t*)v;
                 jl_typemap_rehash(mt->defs, 0);
                 // TODO: consider reverting this when we can split on Type{...} better
-                jl_typemap_rehash(mt->cache, 1); //(mt == jl_type_typename->mt) ? 0 : 1);
+                jl_typemap_rehash(mt->cache, mt->offs);
                 if (tracee_list)
                     arraylist_push(tracee_list, mt);
                 break;

--- a/src/gf.c
+++ b/src/gf.c
@@ -117,8 +117,7 @@ const struct jl_typemap_info tfunc_cache = {
 
 static int8_t jl_cachearg_offset(jl_methtable_t *mt)
 {
-    // TODO: consider reverting this when we can split on Type{...} better
-    return 1; //(mt == jl_type_type_mt) ? 0 : 1;
+    return mt->offs;
 }
 
 /// ----- Insertion logic for special entries ----- ///

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1734,13 +1734,14 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_methtable_type->name->mt = jl_new_method_table(jl_methtable_type->name->name, core);
     jl_methtable_type->super = jl_any_type;
     jl_methtable_type->parameters = jl_emptysvec;
-    jl_methtable_type->name->names = jl_perm_symsvec(9, "name", "defs",
+    jl_methtable_type->name->names = jl_perm_symsvec(10, "name", "defs",
                                                      "cache", "max_args",
                                                      "kwsorter", "module",
-                                                     "backedges", "", "");
-    jl_methtable_type->types = jl_svec(9, jl_sym_type, jl_any_type, jl_any_type, jl_any_type/*jl_long*/,
+                                                     "backedges", "", "", "offs");
+    jl_methtable_type->types = jl_svec(10, jl_sym_type, jl_any_type, jl_any_type, jl_any_type/*jl_long*/,
                                        jl_any_type, jl_any_type/*module*/,
-                                       jl_any_type/*any vector*/, jl_any_type/*long*/, jl_any_type/*int32*/);
+                                       jl_any_type/*any vector*/, jl_any_type/*long*/, jl_any_type/*int32*/,
+                                       jl_any_type/*uint8*/);
     jl_methtable_type->uid = jl_assign_type_uid();
     jl_methtable_type->instance = NULL;
     jl_methtable_type->struct_decl = NULL;
@@ -2201,10 +2202,12 @@ void jl_init_types(void) JL_GC_DISABLED
     jl_svecset(jl_methtable_type->types, 6, jl_array_any_type);
 #ifdef __LP64__
     jl_svecset(jl_methtable_type->types, 7, jl_int64_type); // unsigned long
+    jl_svecset(jl_methtable_type->types, 8, jl_int64_type); // uint32_t plus alignment
 #else
     jl_svecset(jl_methtable_type->types, 7, jl_int32_type); // DWORD
-#endif
     jl_svecset(jl_methtable_type->types, 8, jl_int32_type); // uint32_t
+#endif
+    jl_svecset(jl_methtable_type->types, 9, jl_uint8_type);
     jl_svecset(jl_method_type->types, 11, jl_method_instance_type);
     jl_svecset(jl_method_instance_type->types, 11, jl_voidpointer_type);
     jl_svecset(jl_method_instance_type->types, 12, jl_voidpointer_type);

--- a/src/julia.h
+++ b/src/julia.h
@@ -504,6 +504,7 @@ typedef struct _jl_methtable_t {
     jl_module_t *module; // used for incremental serialization to locate original binding
     jl_array_t *backedges;
     jl_mutex_t writelock;
+    uint8_t offs;  // 0, or 1 to skip splitting typemap on first (function) argument
 } jl_methtable_t;
 
 typedef struct {

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -1085,6 +1085,9 @@ function deserialize_typename(s::AbstractSerializer, number)
         maxa = deserialize(s)::Int
         if makenew
             tn.mt = ccall(:jl_new_method_table, Any, (Any, Any), name, tn.module)
+            if !isempty(parameters)
+                tn.mt.offs = 0
+            end
             tn.mt.name = mtname
             tn.mt.max_args = maxa
             for def in defs


### PR DESCRIPTION
This should be a safe subset of #21760. Allows splitting on the type of the function for parameterized types. Does not change dispatch on Types (constructors), since it is not strictly better in that case --- many constructors are abstract types that we can't split on. Improving that case will require a more complex change.

Using the benchmark from #21760:
Before:
```
  0.000000 seconds
  0.015294 seconds
  0.001139 seconds (10.00 k allocations: 156.250 KiB)
  0.068189 seconds (489 allocations: 7.641 KiB)
  0.042070 seconds (383 allocations: 26.453 KiB)
  0.043586 seconds (383 allocations: 26.453 KiB)
```
After:
```
  0.000000 seconds
  0.015087 seconds
  0.001219 seconds (10.00 k allocations: 156.250 KiB)
  0.044221 seconds (489 allocations: 7.641 KiB)
  0.000946 seconds (383 allocations: 26.453 KiB)
  0.000969 seconds (383 allocations: 26.453 KiB)
```
(Note we are now able to optimize out the first benchmark completely.)