### PR TITLE
Check for overflow when negating typemin in Rational

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,7 +11,7 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && __throw_rational_argerror(T)
-        (num < 0 && den < 0) && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)
+        num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -23,6 +23,9 @@ struct Rational{T<:Integer} <: Real
 		    __throw_rational_ovferror(num, den)
 		end
         num2, den2 = divgcd(num, den)
+        if den2 < 0
+			num2, den2 = -num2, -den2
+		end
         new(num2, den2)
     end
 end
@@ -36,11 +39,7 @@ Rational(n::Integer) = Rational(n,one(n))
 
 function divgcd(x::Integer,y::Integer)
     g = gcd(x,y)
-	xg, yg = div(x,g), div(y,g)
-	if yg < 0
-	    xg, yg = -xg, -yg
-    end
-	return xg, yg
+    div(x,g), div(y,g)
 end
 
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -17,13 +17,14 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
         num == den == zero(T) && __throw_rational_argerror(T)
-        num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)
+        if num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(num, den)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end
 end
 @noinline __throw_rational_argerror(T) = throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
-@noinline __throw_rational_ovferror(T) = throw(OverflowError("num[den] is typemin(T) and den[num] is negative"))
+@noinline __throw_rational_ovferror(num::T, den::T) where {T} =
+    (num < den) ? throw(OverflowError("typemin($T)//$den")) : throw(OverflowError("$num//typemin($T)"))
 
 Rational(n::T, d::T) where {T<:Integer} = Rational{T}(n,d)
 Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -19,8 +19,10 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
         num == den == zero(T) && __throw_rational_argerror(T)
-        num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
-        num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(num, den)
+        if (num == typemin(T) && isodd(den)) || (den == typemin(T) && isodd(num))
+		    __throw_rational_ovferror(num, den)
+		end
+        num2, den2 = divgcd(num, den)
         new(num2, den2)
     end
 end
@@ -34,8 +36,13 @@ Rational(n::Integer) = Rational(n,one(n))
 
 function divgcd(x::Integer,y::Integer)
     g = gcd(x,y)
-    div(x,g), div(y,g)
+	xg, yg = div(x,g), div(y,g)
+	if yg < 0
+	    xg, yg = -xg, -yg 
+    end
+	return xg, yg
 end
+
 
 """
     //(num, den)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -17,7 +17,7 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
         num == den == zero(T) && __throw_rational_argerror(T)
-        if num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(num, den)
+        num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(num, den)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,6 +11,12 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && __throw_rational_argerror(T)
+        num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
+        new(num2, den2)
+    end
+    
+    function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
+        num == den == zero(T) && __throw_rational_argerror(T)
         num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -231,7 +231,12 @@ copysign(x::Rational, y::Real) = copysign(x.num,y) // x.den
 copysign(x::Rational, y::Rational) = copysign(x.num,y.num) // x.den
 
 abs(x::Rational) = Rational(abs(x.num), x.den)
-
+function abs(x::Rational{T}) where T<:BitSigned
+    x.num === typemin(T) && throw(OverflowError("rational numerator is typemin(T)"))
+    x.den === typemin(T) && throw(OverflowError("rational denominator is typemin(T)"))
+    abs(x.num) // x.den
+end
+    
 typemin(::Type{Rational{T}}) where {T<:Integer} = -one(T)//zero(T)
 typemax(::Type{Rational{T}}) where {T<:Integer} = one(T)//zero(T)
 
@@ -239,7 +244,8 @@ isinteger(x::Rational) = x.den == 1
 
 -(x::Rational) = (-x.num) // x.den
 function -(x::Rational{T}) where T<:BitSigned
-    x.num == typemin(T) && throw(OverflowError("rational numerator is typemin(T)"))
+    x.num === typemin(T) && throw(OverflowError("rational numerator is typemin(T)"))
+    x.den === typemin(T) && throw(OverflowError("rational denominator is typemin(T)"))
     (-x.num) // x.den
 end
 function -(x::Rational{T}) where T<:Unsigned

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,12 +11,14 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && __throw_rational_argerror(T)
+        (num < 0 && den < 0) && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)            
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end
 end
 @noinline __throw_rational_argerror(T) = throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
-
+@noinline __throw_rational_ovferror(T) = throw(OverflowError("num[den] is typemin(T) and den[num] is negative"))
+        
 Rational(n::T, d::T) where {T<:Integer} = Rational{T}(n,d)
 Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 Rational(n::Integer) = Rational(n,one(n))

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -18,7 +18,7 @@ struct Rational{T<:Integer} <: Real
 end
 @noinline __throw_rational_argerror(T) = throw(ArgumentError("invalid rational: zero($T)//zero($T)"))
 @noinline __throw_rational_ovferror(T) = throw(OverflowError("num[den] is typemin(T) and den[num] is negative"))
-        
+
 Rational(n::T, d::T) where {T<:Integer} = Rational{T}(n,d)
 Rational(n::Integer, d::Integer) = Rational(promote(n,d)...)
 Rational(n::Integer) = Rational(n,one(n))

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -17,8 +17,8 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
         num == den == zero(T) && __throw_rational_argerror(T)
-        num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(num, den)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
+        num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(num, den)
         new(num2, den2)
     end
 end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -38,7 +38,7 @@ function divgcd(x::Integer,y::Integer)
     g = gcd(x,y)
 	xg, yg = div(x,g), div(y,g)
 	if yg < 0
-	    xg, yg = -xg, -yg 
+	    xg, yg = -xg, -yg
     end
 	return xg, yg
 end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -11,7 +11,7 @@ struct Rational{T<:Integer} <: Real
 
     function Rational{T}(num::Integer, den::Integer) where T<:Integer
         num == den == zero(T) && __throw_rational_argerror(T)
-        (num < 0 && den < 0) && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)            
+        (num < 0 && den < 0) && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -238,7 +238,7 @@ function abs(x::Rational{T}) where T<:BitSigned
     x.den === typemin(T) && throw(OverflowError("rational denominator is typemin(T)"))
     abs(x.num) // x.den
 end
-    
+
 typemin(::Type{Rational{T}}) where {T<:Integer} = -one(T)//zero(T)
 typemax(::Type{Rational{T}}) where {T<:Integer} = one(T)//zero(T)
 

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -4,6 +4,8 @@
     Rational{T<:Integer} <: Real
 
 Rational number type, with numerator and denominator of type `T`.
+
+Rational numbers are checked for overflow.
 """
 struct Rational{T<:Integer} <: Real
     num::T

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -14,7 +14,7 @@ struct Rational{T<:Integer} <: Real
         num2, den2 = (sign(den) < 0) ? divgcd(-num, -den) : divgcd(num, den)
         new(num2, den2)
     end
-    
+
     function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
         num == den == zero(T) && __throw_rational_argerror(T)
         num < 0 && den < 0 && (num === typemin(T) || den === typemin(T)) && __throw_rational_ovferror(T)

--- a/base/rational.jl
+++ b/base/rational.jl
@@ -20,12 +20,12 @@ struct Rational{T<:Integer} <: Real
     function Rational{T}(num::Integer, den::Integer) where T<:BitSigned
         num == den == zero(T) && __throw_rational_argerror(T)
         if (num == typemin(T) && isodd(den)) || (den == typemin(T) && isodd(num))
-		    __throw_rational_ovferror(num, den)
-		end
+            __throw_rational_ovferror(num, den)
+        end
         num2, den2 = divgcd(num, den)
         if den2 < 0
-			num2, den2 = -num2, -den2
-		end
+            num2, den2 = -num2, -den2
+        end
         new(num2, den2)
     end
 end

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -19,6 +19,8 @@ using Test
     @test -7//0 == -1//0
 
     @test_throws OverflowError -(0x01//0x0f)
+    @test_throws OverflowError typemin(Int)//(-1)
+    @test_throws OverflowError -1//typemin(Int)
     @test_throws OverflowError -(typemin(Int)//1)
     @test_throws OverflowError -(1//typemin(Int))
     @test_throws OverflowError abs(typemin(Int)//1)

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -20,6 +20,9 @@ using Test
 
     @test_throws OverflowError -(0x01//0x0f)
     @test_throws OverflowError -(typemin(Int)//1)
+    @test_throws OverflowError -(1//typemin(Int))
+    @test_throws OverflowError abs(typemin(Int)//1)
+    @test_throws OverflowError abs(1//typemin(Int))
     @test_throws OverflowError (typemax(Int)//3) + 1
     @test_throws OverflowError (typemax(Int)//3) * 2
     @test (typemax(Int)//1) * (1//typemax(Int)) == 1

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -21,6 +21,7 @@ using Test
     @test_throws OverflowError -(0x01//0x0f)
     @test_throws OverflowError typemin(Int)//(-1)
     @test_throws OverflowError -1//typemin(Int)
+    @test -2 // typemin(Int) == 1//abs(typemin(Int)>>1)
     @test_throws OverflowError -(typemin(Int)//1)
     @test_throws OverflowError -(1//typemin(Int))
     @test_throws OverflowError abs(typemin(Int)//1)


### PR DESCRIPTION
This PR corrects the check for rational overflow when either unary `-` or `abs` is applied to a value `q::Rational{S} where {S::BitSigned} && (numerator(q) == typemin(S) || denominator(q) == typemin(S))`.

tests have been added