### PR TITLE
Docs of construction undef arrays with missing

### DIFF
--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -262,6 +262,7 @@ julia> Array{Union{Missing, String}}(missing, 2, 3)
     `Union{Missing, T}` creates an array filled with `missing`. If `T` is a
     singleton type the value that is used to fill the array is undefined and
     could change in the future, so it should not be relied upon.
+
 An array allowing for `missing` values but which does not contain any such value
 can be converted back to an array which does not allow for missing values using
 [`convert`](@ref). If the array contains `missing` values, a `MethodError` is thrown

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -254,6 +254,23 @@ julia> Array{Union{Missing, String}}(missing, 2, 3)
  missing  missing  missing
 ```
 
+For `T` that is bits type (`isbitstype(T)` returns `true`),
+`Array{Union{Missing, T}}(undef, dims)` creates an array filled with
+missing values. Also calling `similar` to create an unitialized array that has
+element type of the form `Union{Missing, T}` creates an array filled with `missing`
+if `T` is bits type:
+```jldoctest
+julia> similar([1, missing])
+2-element Array{Union{Missing, Int64},1}:
+ missing
+ missing
+
+julia> similar([1, 2], Union{Missing, Float64})
+2-element Array{Union{Missing, Float64},1}:
+ missing
+ missing
+ ```
+
 An array allowing for `missing` values but which does not contain any such value
 can be converted back to an array which does not allow for missing values using
 [`convert`](@ref). If the array contains `missing` values, a `MethodError` is thrown

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -255,13 +255,13 @@ julia> Array{Union{Missing, String}}(missing, 2, 3)
 ```
 
 !!! note
-    Currently for `T` that is bits type (`isbitstype(T)` returns `true`),
-    `Array{Union{Missing, T}}(undef, dims)` creates an array filled with
-    missing values. Also calling `similar` to create an unitialized array that
-    has element type of the form `Union{Missing, T}` creates an array filled with
-    `missing` if `T` is bits type. This behavior is an implementation detail
-    that may change in the future and should not be relied upon.
-
+    Currently for `T` that is bits type (`isbitstype(T)` returns `true`), if `T`
+    is not a singleton type then `Array{Union{Missing, T}}(undef, dims)` creates
+    an array filled with `missing` values. Also in this case calling `similar`
+    to create an unitialized array that has element type of the form
+    `Union{Missing, T}` creates an array filled with `missing`. If `T` is a
+    singleton type the value that is used to fill the array is undefined and
+    could change in the future, so it should not be relied upon.
 An array allowing for `missing` values but which does not contain any such value
 can be converted back to an array which does not allow for missing values using
 [`convert`](@ref). If the array contains `missing` values, a `MethodError` is thrown

--- a/doc/src/manual/missing.md
+++ b/doc/src/manual/missing.md
@@ -254,22 +254,13 @@ julia> Array{Union{Missing, String}}(missing, 2, 3)
  missing  missing  missing
 ```
 
-For `T` that is bits type (`isbitstype(T)` returns `true`),
-`Array{Union{Missing, T}}(undef, dims)` creates an array filled with
-missing values. Also calling `similar` to create an unitialized array that has
-element type of the form `Union{Missing, T}` creates an array filled with `missing`
-if `T` is bits type:
-```jldoctest
-julia> similar([1, missing])
-2-element Array{Union{Missing, Int64},1}:
- missing
- missing
-
-julia> similar([1, 2], Union{Missing, Float64})
-2-element Array{Union{Missing, Float64},1}:
- missing
- missing
- ```
+!!! note
+    Currently for `T` that is bits type (`isbitstype(T)` returns `true`),
+    `Array{Union{Missing, T}}(undef, dims)` creates an array filled with
+    missing values. Also calling `similar` to create an unitialized array that
+    has element type of the form `Union{Missing, T}` creates an array filled with
+    `missing` if `T` is bits type. This behavior is an implementation detail
+    that may change in the future and should not be relied upon.
 
 An array allowing for `missing` values but which does not contain any such value
 can be converted back to an array which does not allow for missing values using


### PR DESCRIPTION
This PR explains the behavior I observe, but it is not documented, so maybe it is not guaranteed (therefore before merging it should be confirmed that Base wants to guarantee this contract).

The contract is that if `T` is a bits type then creation of uninitialized array of type `Union{Missing, T}` initializes it to hold `missing` in all entries.

CC @nalimilan