### PR TITLE
Refactor `Expr(:simdloop)` to `Expr(:loopinfo, ...)`

### DIFF
--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -1154,7 +1154,7 @@ function typeinf_local(frame::InferenceState)
                     if isa(fname, Slot)
                         changes = StateUpdate(fname, VarState(Any, false), changes)
                     end
-                elseif hd === :inbounds || hd === :meta || hd === :simdloop
+                elseif hd === :inbounds || hd === :meta || hd === :loopinfo
                 else
                     t = abstract_eval(stmt, changes, frame)
                     t === Bottom && break

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -155,7 +155,7 @@ function stmt_affects_purity(@nospecialize(stmt), ir)
         return !(t ⊑ Bool)
     end
     if isa(stmt, Expr)
-        return stmt.head != :simdloop && stmt.head != :enter
+        return stmt.head != :loopinfo && stmt.head != :enter
     end
     return true
 end

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -50,7 +50,7 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, sptypes::
         elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck
             return true
         else
-            # e.g. :simdloop
+            # e.g. :loopinfo
             return false
         end
     end

--- a/base/compiler/utilities.jl
+++ b/base/compiler/utilities.jl
@@ -59,7 +59,7 @@ end
 
 # Meta expression head, these generally can't be deleted even when they are
 # in a dead branch but can be ignored when analyzing uses/liveness.
-is_meta_expr_head(head::Symbol) = (head === :inbounds || head === :boundscheck || head === :meta || head === :simdloop)
+is_meta_expr_head(head::Symbol) = (head === :inbounds || head === :boundscheck || head === :meta || head === :loopinfo)
 
 sym_isless(a::Symbol, b::Symbol) = ccall(:strcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}), a, b) < 0
 

--- a/base/compiler/validation.jl
+++ b/base/compiler/validation.jl
@@ -26,7 +26,7 @@ const VALID_EXPR_HEADS = IdDict{Any,Any}(
     :foreigncall => 3:typemax(Int),
     :cfunction => 5:5,
     :isdefined => 1:1,
-    :simdloop => 1:1,
+    :loopinfo => 0:typemax(Int),
     :gc_preserve_begin => 0:typemax(Int),
     :gc_preserve_end => 0:typemax(Int),
     :thunk => 1:1,
@@ -143,7 +143,7 @@ function validate_code!(errors::Vector{>:InvalidCodeError}, c::CodeInfo, is_top_
                 head === :inbounds || head === :foreigncall || head === :cfunction ||
                 head === :const || head === :enter || head === :leave || head == :pop_exception ||
                 head === :method || head === :global || head === :static_parameter ||
-                head === :new || head === :splatnew || head === :thunk || head === :simdloop ||
+                head === :new || head === :splatnew || head === :thunk || head === :loopinfo ||
                 head === :throw_undef_if_not || head === :unreachable
                 validate_val!(x)
             else

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -293,6 +293,6 @@ end
 
 _instantiate_type_in_env(x, spsig, spvals) = ccall(:jl_instantiate_type_in_env, Any, (Any, Any, Ptr{Any}), x, spsig, spvals)
 
-is_meta_expr_head(head::Symbol) = (head === :inbounds || head === :boundscheck || head === :meta || head === :simdloop)
+is_meta_expr_head(head::Symbol) = (head === :inbounds || head === :boundscheck || head === :meta || head === :loopinfo)
 
 end # module

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -37,7 +37,7 @@ check_body!(x::QuoteNode) = check_body!(x.value)
 check_body!(x) = true
 
 # @simd splits a for loop into two loops: an outer scalar loop and
-# an inner loop marked with :simdloop. The simd_... functions define
+# an inner loop marked with :loopinfo. The simd_... functions define
 # the splitting.
 # Custom iterators that do not support random access cannot support
 # vectorization. In order to be compatible with `@simd` annotated loops,
@@ -76,7 +76,7 @@ function compile(x, ivdep)
                                 local $var = Base.simd_index($r,$j,$i)
                                 $(x.args[2])        # Body of loop
                                 $i += 1
-                                $(Expr(:simdloop, ivdep))  # Mark loop as SIMD loop
+                                $(Expr(:loopinfo, Symbol("julia.simdloop"), ivdep))  # Mark loop as SIMD loop
                             end
                         end
                     end
@@ -125,12 +125,12 @@ either case, your inner loop should have the following properties to allow vecto
 * No iteration ever waits on a previous iteration to make forward progress.
 """
 macro simd(forloop)
-    esc(compile(forloop, false))
+    esc(compile(forloop, nothing))
 end
 
 macro simd(ivdep, forloop)
     if ivdep == :ivdep
-        esc(compile(forloop, true))
+        esc(compile(forloop, Symbol("julia.ivdep")))
     else
         throw(SimdError("Only ivdep is valid as the first argument to @simd"))
     end

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -452,9 +452,10 @@ These symbols appear in the `head` field of [`Expr`](@ref)s in lowered form.
     Has the value `false` if inlined into a section of code marked with `@inbounds`,
     otherwise has the value `true`.
 
-  * `simdloop`
+  * `loopinfo`
 
-    Marks the end of the inner loop of a `@simd` expression.
+    Marks the end of the a loop. Contains metadata that is passed to `LowerSimdLoop` to either mark
+    the inner loop of `@simd` expression, or to propagate information to LLVM loop passes.
 
   * `copyast`
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -49,7 +49,7 @@ jl_sym_t *global_sym; jl_sym_t *list_sym;
 jl_sym_t *dot_sym;    jl_sym_t *newvar_sym;
 jl_sym_t *boundscheck_sym; jl_sym_t *inbounds_sym;
 jl_sym_t *copyast_sym; jl_sym_t *cfunction_sym;
-jl_sym_t *pure_sym; jl_sym_t *simdloop_sym;
+jl_sym_t *pure_sym; jl_sym_t *loopinfo_sym;
 jl_sym_t *meta_sym; jl_sym_t *inert_sym;
 jl_sym_t *polly_sym; jl_sym_t *unused_sym;
 jl_sym_t *static_parameter_sym; jl_sym_t *inline_sym;
@@ -341,7 +341,7 @@ void jl_init_frontend(void)
     inbounds_sym = jl_symbol("inbounds");
     newvar_sym = jl_symbol("newvar");
     copyast_sym = jl_symbol("copyast");
-    simdloop_sym = jl_symbol("simdloop");
+    loopinfo_sym = jl_symbol("loopinfo");
     pure_sym = jl_symbol("pure");
     meta_sym = jl_symbol("meta");
     list_sym = jl_symbol("list");

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -86,9 +86,6 @@
 #include <llvm/ExecutionEngine/ExecutionEngine.h>
 
 using namespace llvm;
-namespace llvm {
-    extern bool annotateSimdLoop(BasicBlock *latch);
-}
 
 #if defined(_OS_WINDOWS_) && !defined(NOMINMAX)
 #define NOMINMAX
@@ -296,8 +293,7 @@ static Function *jlegal_func;
 static Function *jl_alloc_obj_func;
 static Function *jl_newbits_func;
 static Function *jl_typeof_func;
-static Function *jl_simdloop_marker_func;
-static Function *jl_simdivdep_marker_func;
+static Function *jl_loopinfo_marker_func;
 static Function *jl_write_barrier_func;
 static Function *jlisa_func;
 static Function *jlsubtype_func;
@@ -4100,14 +4096,43 @@ static jl_cgval_t emit_expr(jl_codectx_t &ctx, jl_value_t *expr, ssize_t ssaval)
                 ctx.builder.CreateCall(prepare_call(jlcopyast_func),
                     maybe_decay_untracked(boxed(ctx, ast))), true, jl_expr_type);
     }
-    else if (head == simdloop_sym) {
-        jl_value_t *ivdep = args[0];
-        assert(jl_expr_nargs(ex) == 1 && jl_is_bool(ivdep));
-        if (ivdep == jl_false) {
-            ctx.builder.CreateCall(prepare_call(jl_simdloop_marker_func));
-        } else {
-            ctx.builder.CreateCall(prepare_call(jl_simdivdep_marker_func));
+    else if (head == loopinfo_sym) {
+        // parse Expr(:loopinfo, "julia.simdloop", ("llvm.loop.vectorize.width", 4))
+        SmallVector<Metadata *, 8> MDs;
+        for (int i = 0, ie = jl_expr_nargs(ex); i < ie; ++i) {
+            jl_value_t *arg = args[i];
+            Metadata *MD;
+            if (arg == jl_nothing)
+                continue;
+            if (jl_is_symbol(arg)) {
+                MD = MDString::get(jl_LLVMContext, jl_symbol_name((jl_sym_t*)arg));
+            } else if (jl_is_tuple(arg)) {
+                // TODO: are there loopinfo with more than one field?
+                if (jl_nfields(arg) != 2)
+                    jl_error("loopinfo: only accept 2-arg tuple");
+                jl_value_t* name  = jl_fieldref(arg, 0);
+                jl_value_t* value = jl_fieldref(arg, 1);
+                if (!jl_is_symbol(name))
+                    jl_error("loopinfo: name needs to be a symbol");
+                Metadata *MDVal;
+                if(jl_is_bool(value))
+                    MDVal = ConstantAsMetadata::get(ConstantInt::get(T_int1, jl_unbox_bool(value)));
+                if(jl_is_long(value))
+                    MDVal = ConstantAsMetadata::get(ConstantInt::get(T_int64, jl_unbox_long(value)));
+                if(!MDVal)
+                    jl_error("loopinfo: value can only be a bool or a long");
+                MD = MDNode::get(jl_LLVMContext,
+                        { MDString::get(jl_LLVMContext, jl_symbol_name((jl_sym_t*)name)), MDVal });
+            }
+            if (MD)
+                MDs.push_back(MD);
+            else
+                jl_error("loopinfo: argument needs to be either a symbol or a tuple of type (Symbol, Union{Int, Bool}");
         }
+
+        MDNode* MD = MDNode::get(jl_LLVMContext, MDs);
+        CallInst *I = ctx.builder.CreateCall(prepare_call(jl_loopinfo_marker_func));
+        I->setMetadata("julia.loopinfo", MD);
         return jl_cgval_t();
     }
     else if (head == goto_ifnot_sym) {
@@ -7356,19 +7381,12 @@ static void init_julia_llvm_env(Module *m)
     add_return_attr(jl_newbits_func, Attribute::NonNull);
     add_named_global(jl_newbits_func, (void*)jl_new_bits);
 
-    jl_simdloop_marker_func = Function::Create(FunctionType::get(T_void, {}, false),
+    jl_loopinfo_marker_func = Function::Create(FunctionType::get(T_void, {}, false),
                                                Function::ExternalLinkage,
-                                               "julia.simdloop_marker");
-    jl_simdloop_marker_func->addFnAttr(Attribute::NoUnwind);
-    jl_simdloop_marker_func->addFnAttr(Attribute::NoRecurse);
-    jl_simdloop_marker_func->addFnAttr(Attribute::InaccessibleMemOnly);
-
-    jl_simdivdep_marker_func = Function::Create(FunctionType::get(T_void, {}, false),
-                                               Function::ExternalLinkage,
-                                               "julia.simdivdep_marker");
-    jl_simdivdep_marker_func->addFnAttr(Attribute::NoUnwind);
-    jl_simdivdep_marker_func->addFnAttr(Attribute::NoRecurse);
-    jl_simdivdep_marker_func->addFnAttr(Attribute::InaccessibleMemOnly);
+                                               "julia.loopinfo_marker");
+    jl_loopinfo_marker_func->addFnAttr(Attribute::NoUnwind);
+    jl_loopinfo_marker_func->addFnAttr(Attribute::NoRecurse);
+    jl_loopinfo_marker_func->addFnAttr(Attribute::InaccessibleMemOnly);
 
     jl_typeof_func = Function::Create(FunctionType::get(T_prjlvalue, {T_prjlvalue}, false),
                                       Function::ExternalLinkage,

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -498,7 +498,7 @@ SECT_INTERP static jl_value_t *eval_value(jl_value_t *e, interpreter_state *s)
     else if (head == boundscheck_sym) {
         return jl_true;
     }
-    else if (head == meta_sym || head == inbounds_sym || head == simdloop_sym) {
+    else if (head == meta_sym || head == inbounds_sym || head == loopinfo_sym) {
         return jl_nothing;
     }
     else if (head == gc_preserve_begin_sym || head == gc_preserve_end_sym) {

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -121,8 +121,8 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
             PM->add(createGCInvariantVerifierPass(false));
             PM->add(createLateLowerGCFramePass());
             PM->add(createLowerPTLSPass(dump_native));
-            PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
         }
+        PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "loopinfo" as LLVM parallel loop
         if (dump_native)
             PM->add(createMultiVersioningPass());
         return;
@@ -180,7 +180,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
     PM->add(polly::createCodegenCleanupPass());
 #endif
     // LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
-    PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
+    PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "loopinfo" as LLVM parallel loop
     PM->add(createLICMPass());                 // Hoist loop invariants
     PM->add(createLoopUnswitchPass());         // Unswitch loops.
     // Subsequent passes not stripping metadata from terminator
@@ -236,8 +236,8 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         PM->add(createLowerPTLSPass(dump_native));
         // Clean up write barrier and ptls lowering
         PM->add(createCFGSimplificationPass());
-        PM->add(createCombineMulAddPass());
     }
+    PM->add(createCombineMulAddPass());
 }
 
 extern "C" JL_DLLEXPORT

--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -2951,7 +2951,7 @@ f(x) = yt(x)
 
 (define lambda-opt-ignored-exprs
   (Set '(quote top core line inert local local-def unnecessary copyast
-         meta inbounds boundscheck simdloop decl aliasscope popaliasscope
+         meta inbounds boundscheck loopinfo decl aliasscope popaliasscope
          struct_type abstract_type primitive_type thunk with-static-parameters
          implicit-global global globalref outerref const-if-global
          const null ssavalue isdefined toplevel module lambda error
@@ -3971,7 +3971,7 @@ f(x) = yt(x)
                s))
 
             ;; metadata expressions
-            ((line meta inbounds simdloop gc_preserve_end aliasscope popaliasscope)
+            ((line meta inbounds loopinfo gc_preserve_end aliasscope popaliasscope)
              (let ((have-ret? (and (pair? code) (pair? (car code)) (eq? (caar code) 'return))))
                (cond ((eq? (car e) 'line)
                       (set! current-loc e)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -1003,7 +1003,7 @@ extern jl_sym_t *dot_sym;    extern jl_sym_t *newvar_sym;
 extern jl_sym_t *boundscheck_sym; extern jl_sym_t *inbounds_sym;
 extern jl_sym_t *aliasscope_sym; extern jl_sym_t *popaliasscope_sym;
 extern jl_sym_t *copyast_sym; extern jl_sym_t *cfunction_sym;
-extern jl_sym_t *pure_sym; extern jl_sym_t *simdloop_sym;
+extern jl_sym_t *pure_sym; extern jl_sym_t *loopinfo_sym;
 extern jl_sym_t *meta_sym; extern jl_sym_t *inert_sym;
 extern jl_sym_t *polly_sym; extern jl_sym_t *unused_sym;
 extern jl_sym_t *static_parameter_sym; extern jl_sym_t *inline_sym;

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -3,9 +3,15 @@
 #define DEBUG_TYPE "lower_simd_loop"
 #undef DEBUG
 
-// This file defines two entry points:
-//     global function annotateSimdLoop: mark a loop as a SIMD loop.
-//     createLowerSimdLoopPass: construct LLVM for lowering a marked loop later.
+// This file defines a LLVM pass that:
+// 1. Set's loop information in form of metadata
+// 2. If the metadata contains `julia.simdloop` finds reduction chains and marks
+//    floating-point operations as fast-math. `See enableUnsafeAlgebraIfReduction`.
+// 3. If the metadata contains `julia.ivdep` marks all memory accesses in the loop
+//    as independent of each other.
+//
+// The pass hinges on a call to a marker function that has metadata attached to it.
+// To construct the pass call `createLowerSimdLoopPass`.
 
 #include "llvm-version.h"
 #include "support/dtypes.h"
@@ -20,40 +26,6 @@
 #include "julia_assert.h"
 
 namespace llvm {
-
-// simd loop
-static unsigned simd_loop_mdkind = 0;
-static MDNode *simd_loop_md = NULL;
-
-/// Mark loop as a SIMD loop.  Return false if loop cannot be marked.
-/// incr should be the basic block that increments the loop counter.
-bool annotateSimdLoop(BasicBlock *incr)
-{
-    DEBUG(dbgs() << "LSL: annotating simd_loop\n");
-    // Lazy initialization
-    if (!simd_loop_mdkind) {
-        simd_loop_mdkind = incr->getContext().getMDKindID("simd_loop");
-        simd_loop_md = MDNode::get(incr->getContext(), ArrayRef<Metadata*>());
-    }
-    // Ideally, the decoration would go on the block itself, but LLVM 3.3 does not
-    // support putting metadata on blocks.  So instead, put the decoration on the last
-    // Add instruction, which (somewhat riskily) is assumed to be the loop increment.
-    for (BasicBlock::reverse_iterator ri = incr->rbegin(); ri!=incr->rend(); ++ri) {
-        Instruction& i = *ri;
-        unsigned op = i.getOpcode();
-        if (op==Instruction::Add) {
-            if (i.getType()->isIntegerTy()) {
-                DEBUG(dbgs() << "LSL: setting simd_loop metadata\n");
-                i.setMetadata(simd_loop_mdkind, simd_loop_md);
-                return true;
-            }
-            else {
-                return false;
-            }
-        }
-    }
-    return false;
-}
 
 /// This pass should run after reduction variables have been converted to phi nodes,
 /// otherwise floating-point reductions might not be recognized as such and
@@ -76,27 +48,13 @@ struct LowerSIMDLoop : public ModulePass {
     private:
     bool runOnModule(Module &M) override;
 
-    bool markSIMDLoop(Module &M, Function *marker, bool ivdep);
-
-    /// Check if loop has "simd_loop" annotation.
-    /// If present, the annotation is an MDNode attached to an instruction in the loop's latch.
-    bool hasSIMDLoopMetadata( Loop *L) const;
+    bool markLoopInfo(Module &M, Function *marker);
 
     /// If Phi is part of a reduction cycle of FAdd, FSub, FMul or FDiv,
     /// mark the ops as permitting reassociation/commuting.
     /// As of LLVM 4.0, FDiv is not handled by the loop vectorizer
     void enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const;
 };
-
-bool LowerSIMDLoop::hasSIMDLoopMetadata(Loop *L) const
-{
-    // Note: If a loop has 0 or multiple latch blocks, it's probably not a simd_loop anyway.
-    if (BasicBlock *latch = L->getLoopLatch())
-        for (BasicBlock::iterator II = latch->begin(), EE = latch->end(); II!=EE; ++II)
-            if (II->getMetadata(simd_loop_mdkind))
-                return true;
-    return false;
-}
 
 static unsigned getReduceOpcode(Instruction *J, Instruction *operand)
 {
@@ -170,47 +128,81 @@ void LowerSIMDLoop::enableUnsafeAlgebraIfReduction(PHINode *Phi, Loop *L) const
 
 bool LowerSIMDLoop::runOnModule(Module &M)
 {
-    Function *simdloop_marker = M.getFunction("julia.simdloop_marker");
-    Function *simdivdep_marker = M.getFunction("julia.simdivdep_marker");
+    Function *loopinfo_marker = M.getFunction("julia.loopinfo_marker");
 
     bool Changed = false;
-    if (simdloop_marker)
-        Changed |= markSIMDLoop(M, simdloop_marker, false);
-
-    if (simdivdep_marker)
-        Changed |= markSIMDLoop(M, simdivdep_marker, true);
+    if (loopinfo_marker)
+        Changed |= markLoopInfo(M, loopinfo_marker);
 
     return Changed;
 }
 
-bool LowerSIMDLoop::markSIMDLoop(Module &M, Function *marker, bool ivdep)
+bool LowerSIMDLoop::markLoopInfo(Module &M, Function *marker)
 {
     bool Changed = false;
     std::vector<Instruction*> ToDelete;
     for (User *U : marker->users()) {
         Instruction *I = cast<Instruction>(U);
         ToDelete.push_back(I);
+
         LoopInfo &LI = getAnalysis<LoopInfoWrapperPass>(*I->getParent()->getParent()).getLoopInfo();
         Loop *L = LI.getLoopFor(I->getParent());
         I->removeFromParent();
         if (!L)
             continue;
 
-        DEBUG(dbgs() << "LSL: simd_loop found\n");
-        DEBUG(dbgs() << "LSL: ivdep is: " << ivdep << "\n");
+        DEBUG(dbgs() << "LSL: loopinfo marker found\n");
+        bool simd = false;
+        bool ivdep = false;
+        SmallVector<Metadata *, 8> MDs;
+
         BasicBlock *Lh = L->getHeader();
         DEBUG(dbgs() << "LSL: loop header: " << *Lh << "\n");
-        MDNode *n = L->getLoopID();
-        if (!n) {
-            // Loop does not have a LoopID yet, so give it one.
-            n = MDNode::get(Lh->getContext(), ArrayRef<Metadata *>(NULL));
-            n->replaceOperandWith(0, n);
-            L->setLoopID(n);
-        }
 
+        // Reserve first location for self reference to the LoopID metadata node.
+        TempMDTuple TempNode = MDNode::getTemporary(Lh->getContext(), None);
+        MDs.push_back(TempNode.get());
+
+        // Walk `julia.loopinfo` metadata and filter out `julia.simdloop` and `julia.ivdep`
+        if (I->hasMetadataOtherThanDebugLoc()) {
+            MDNode *JLMD= I->getMetadata("julia.loopinfo");
+            if (JLMD) {
+                DEBUG(dbgs() << "LSL: has julia.loopinfo metadata with " << JLMD->getNumOperands() <<" operands\n");
+                for (unsigned i = 0, ie = JLMD->getNumOperands(); i < ie; ++i) {
+                    Metadata *Op = JLMD->getOperand(i);
+                    const MDString *S = dyn_cast<MDString>(Op);
+                    if (S) {
+                        DEBUG(dbgs() << "LSL: found " << S->getString() << "\n");
+                        if (S->getString().startswith("julia")) {
+                            if (S->getString().equals("julia.simdloop"))
+                                simd = true;
+                            if (S->getString().equals("julia.ivdep"))
+                                ivdep = true;
+                            continue;
+                        }
+                    }
+                    MDs.push_back(Op);
+                }
+            }
+        }
+        DEBUG(dbgs() << "LSL: simd: " << simd << " ivdep: " << ivdep << "\n");
+
+        MDNode *n = L->getLoopID();
+        if (n) {
+            // Loop already has a LoopID so copy over Metadata
+            // original loop id is operand 0
+            for (unsigned i = 1, ie = n->getNumOperands(); i < ie; ++i) {
+                Metadata *Op = n->getOperand(i);
+                MDs.push_back(Op);
+            }
+        }
+        MDNode *LoopID = MDNode::getDistinct(Lh->getContext(), MDs);
+        // Replace the temporary node with a self-reference.
+        LoopID->replaceOperandWith(0, LoopID);
+        L->setLoopID(LoopID);
         assert(L->getLoopID());
 
-        MDNode *m = MDNode::get(Lh->getContext(), ArrayRef<Metadata *>(n));
+        MDNode *m = MDNode::get(Lh->getContext(), ArrayRef<Metadata *>(LoopID));
 
         // If ivdep is true we assume that there is no memory dependency between loop iterations
         // This is a fairly strong assumption and does often not hold true for generic code.
@@ -226,12 +218,14 @@ bool LowerSIMDLoop::markSIMDLoop(Module &M, Function *marker, bool ivdep)
             assert(L->isAnnotatedParallel());
         }
 
-        // Mark floating-point reductions as okay to reassociate/commute.
-        for (BasicBlock::iterator I = Lh->begin(), E = Lh->end(); I != E; ++I) {
-            if (PHINode *Phi = dyn_cast<PHINode>(I))
-                enableUnsafeAlgebraIfReduction(Phi, L);
-            else
-                break;
+        if (simd) {
+            // Mark floating-point reductions as okay to reassociate/commute.
+            for (BasicBlock::iterator I = Lh->begin(), E = Lh->end(); I != E; ++I) {
+                if (PHINode *Phi = dyn_cast<PHINode>(I))
+                    enableUnsafeAlgebraIfReduction(Phi, L);
+                else
+                    break;
+            }
         }
 
         Changed = true;

--- a/src/macroexpand.scm
+++ b/src/macroexpand.scm
@@ -342,7 +342,7 @@
                                    ,(resolve-expansion-vars-with-new-env (caddr arg) env m parent-scope inarg))))
                              (else
                               `(global ,(resolve-expansion-vars-with-new-env arg env m parent-scope inarg))))))
-           ((using import export meta line inbounds boundscheck simdloop gc_preserve gc_preserve_end) (map unescape e))
+           ((using import export meta line inbounds boundscheck loopinfo gc_preserve gc_preserve_end) (map unescape e))
            ((macrocall) e) ; invalid syntax anyways, so just act like it's quoted.
            ((symboliclabel) e)
            ((symbolicgoto) e)

--- a/src/method.c
+++ b/src/method.c
@@ -37,8 +37,8 @@ static jl_value_t *resolve_globals(jl_value_t *expr, jl_module_t *module, jl_sve
         if (jl_is_toplevel_only_expr(expr) || e->head == const_sym || e->head == copyast_sym ||
             e->head == quote_sym || e->head == inert_sym ||
             e->head == meta_sym || e->head == inbounds_sym ||
-            e->head == boundscheck_sym || e->head == simdloop_sym || e->head == aliasscope_sym ||
-            e->head == popaliasscope_sym) {
+            e->head == boundscheck_sym || e->head == loopinfo_sym ||
+            e->head == aliasscope_sym || e->head == popaliasscope_sym) {
             // ignore these
         }
         else {

--- a/test/llvmpasses/simdloop.ll
+++ b/test/llvmpasses/simdloop.ll
@@ -1,8 +1,8 @@
 ; RUN: opt -load libjulia%shlibext -LowerSIMDLoop -S %s | FileCheck %s
 
-declare void @julia.simdivdep_marker()
-declare void @julia.simdloop_marker()
+declare void @julia.loopinfo_marker()
 
+; CHECK-LABEL: @simd_test(
 define void @simd_test(double *%a, double *%b) {
 top:
   br label %loop
@@ -16,13 +16,14 @@ loop:
   %cval = fadd double %aval, %bval
   store double %cval, double *%bptr
   %nexti = add i64 %i, 1
-  call void @julia.simdivdep_marker()
+  call void @julia.loopinfo_marker(), !julia.loopinfo !3
   %done = icmp sgt i64 %nexti, 500
   br i1 %done, label %loopdone, label %loop
 loopdone:
   ret void
 }
 
+; CHECK-LABEL: @simd_test_sub(
 define double @simd_test_sub(double *%a) {
 top:
   br label %loop
@@ -35,13 +36,14 @@ loop:
   %nextv = fsub double %v, %aval
 ; CHECK: fsub fast double %v, %aval
   %nexti = add i64 %i, 1
-  call void @julia.simdivdep_marker()
+  call void @julia.loopinfo_marker(), !julia.loopinfo !3
   %done = icmp sgt i64 %nexti, 500
   br i1 %done, label %loopdone, label %loop
 loopdone:
   ret double %nextv
 }
 
+; CHECK-LABEL: @simd_test_sub2(
 define double @simd_test_sub2(double *%a) {
 top:
   br label %loop
@@ -53,11 +55,41 @@ loop:
   %nextv = fsub double %v, %aval
 ; CHECK: fsub fast double %v, %aval
   %nexti = add i64 %i, 1
-  call void @julia.simdloop_marker()
+  call void @julia.loopinfo_marker(), !julia.loopinfo !2
   %done = icmp sgt i64 %nexti, 500
   br i1 %done, label %loopdone, label %loop
 loopdone:
   ret double %nextv
 }
 
+; Tests if we correctly pass through other metadata
+; CHECK-LABEL: @disabled(
+define i32 @disabled(i32* noalias nocapture %a, i32* noalias nocapture readonly %b, i32 %N) {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %for.body, %entry
+  %indvars.iv = phi i64 [ 0, %entry ], [ %indvars.iv.next, %for.body ]
+  %arrayidx = getelementptr inbounds i32, i32* %b, i64 %indvars.iv
+  %0 = load i32, i32* %arrayidx, align 4
+  %add = add nsw i32 %0, %N
+  %arrayidx2 = getelementptr inbounds i32, i32* %a, i64 %indvars.iv
+  store i32 %add, i32* %arrayidx2, align 4
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  call void @julia.loopinfo_marker(), !julia.loopinfo !4
+  %exitcond = icmp eq i64 %indvars.iv.next, 48
+; CHECK: br {{.*}} !llvm.loop [[LOOP:![0-9]+]]
+  br i1 %exitcond, label %for.end, label %for.body
+
+for.end:                                          ; preds = %for.body
+  %1 = load i32, i32* %a, align 4
+  ret i32 %1
+}
+
 !1 = !{}
+!2 = !{!"julia.simdloop"}
+!3 = !{!"julia.simdloop", !"julia.ivdep"}
+!4 = !{!"julia.simdloop", !"julia.ivdep", !5}
+!5 = !{!"llvm.loop.vectorize.disable", i1 0}
+; CHECK: [[LOOP]] = distinct !{[[LOOP]], [[LOOP_DISABLE:![0-9]+]]}
+; CHECK-NEXT: [[LOOP_DISABLE]] = !{!"llvm.loop.vectorize.disable", i1 false}


### PR DESCRIPTION
- `Expr(:loopinfo, Symbol("julia.simdloop"))` replaces `Expr(:simdloop, false)`
- `Expr(:loopinfo, Symbol("julia.simdloop"), Symbol("julia.ivdep"))` replaces `Expr(:simdloop, true)`

While currently not directly exposed, users can now pass other [loopinfo](https://llvm.org/docs/LangRef.html#llvm-loop) metadata to LLVM.
Codegen attaches the loop metadata to the call to the marker and the `LowerSIMD` pass consumes that metadata and
attaches it to the loop.

```
@eval function unroll(X)
           acc = 0.0
           @inbounds for i in 1:length(X)
               acc += X[i]
               $(Expr(:loopinfo, (Symbol("llvm.loop.unroll.count"), 4),
                                 (Symbol("llvm.loop.vectorize.enable"), false)))
           end
           return acc
       end
```

I needed this for #31086, this also removes unneeded and untested machinery from `llvm-simdloop.cpp`.