### PR TITLE
avoid assertion due to overflow if Num is negative

### DIFF
--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -821,9 +821,9 @@ void LateLowerGCFrame::NoteUse(State &S, BBState &BBS, Value *V, BitVector &Uses
     else if (isSpecialPtrVec(V->getType())) {
         std::vector<int> Nums = NumberVector(S, V);
         for (int Num : Nums) {
-            MaybeResize(BBS, Num);
             if (Num < 0)
                 continue;
+            MaybeResize(BBS, Num);
             Uses[Num] = 1;
         }
     }


### PR DESCRIPTION
Fixes #30621 

This fixes the symptom,  Num is `-2` at this place which we then take to be unsigned.
@Keno is `-2` a valid value here?