### PR TITLE
Make it possible to add optimization passes without lowering intrinsics.

### DIFF
--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -91,7 +91,8 @@ void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM)
 
 // this defines the set of optimization passes defined for Julia at various optimization levels.
 // it assumes that the TLI and TTI wrapper passes have already been added.
-void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump_native)
+void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
+                           bool lower_intrinsics, bool dump_native)
 {
 #ifdef JL_DEBUG_BUILD
     PM->add(createGCInvariantVerifierPass(true));
@@ -113,12 +114,14 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
         }
         PM->add(createMemCpyOptPass()); // Remove memcpy / form memset
         PM->add(createAlwaysInlinerLegacyPass()); // Respect always_inline
-        PM->add(createBarrierNoopPass());
-        PM->add(createLowerExcHandlersPass());
-        PM->add(createGCInvariantVerifierPass(false));
-        PM->add(createLateLowerGCFramePass());
-        PM->add(createLowerPTLSPass(dump_native));
-        PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
+        if (lower_intrinsics) {
+            PM->add(createBarrierNoopPass());
+            PM->add(createLowerExcHandlersPass());
+            PM->add(createGCInvariantVerifierPass(false));
+            PM->add(createLateLowerGCFramePass());
+            PM->add(createLowerPTLSPass(dump_native));
+            PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "simdloop" as LLVM parallel loop
+        }
         if (dump_native)
             PM->add(createMultiVersioningPass());
         return;
@@ -217,24 +220,27 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump
     PM->add(createInstructionCombiningPass());  // Clean up after SLP loop vectorizer
     PM->add(createLoopVectorizePass());         // Vectorize loops
     PM->add(createInstructionCombiningPass());  // Clean up after loop vectorizer
-    // LowerPTLS removes an indirect call. As a result, it is likely to trigger
-    // LLVM's devirtualization heuristics, which would result in the entire
-    // pass pipeline being re-exectuted. Prevent this by inserting a barrier.
-    PM->add(createBarrierNoopPass());
-    PM->add(createLowerExcHandlersPass());
-    PM->add(createGCInvariantVerifierPass(false));
-    PM->add(createLateLowerGCFramePass());
-    // Remove dead use of ptls
-    PM->add(createDeadCodeEliminationPass());
-    PM->add(createLowerPTLSPass(dump_native));
-    // Clean up write barrier and ptls lowering
-    PM->add(createCFGSimplificationPass());
-    PM->add(createCombineMulAddPass());
+
+    if (lower_intrinsics) {
+        // LowerPTLS removes an indirect call. As a result, it is likely to trigger
+        // LLVM's devirtualization heuristics, which would result in the entire
+        // pass pipeline being re-exectuted. Prevent this by inserting a barrier.
+        PM->add(createBarrierNoopPass());
+        PM->add(createLowerExcHandlersPass());
+        PM->add(createGCInvariantVerifierPass(false));
+        PM->add(createLateLowerGCFramePass());
+        // Remove dead use of ptls
+        PM->add(createDeadCodeEliminationPass());
+        PM->add(createLowerPTLSPass(dump_native));
+        // Clean up write barrier and ptls lowering
+        PM->add(createCFGSimplificationPass());
+        PM->add(createCombineMulAddPass());
+    }
 }
 
 extern "C" JL_DLLEXPORT
-void jl_add_optimization_passes(LLVMPassManagerRef PM, int opt_level) {
-    addOptimizationPasses(unwrap(PM), opt_level);
+void jl_add_optimization_passes(LLVMPassManagerRef PM, int opt_level, int lower_intrinsics) {
+    addOptimizationPasses(unwrap(PM), opt_level, lower_intrinsics);
 }
 
 #if defined(_OS_LINUX_) || defined(_OS_WINDOWS_) || defined(_OS_FREEBSD_)
@@ -944,7 +950,7 @@ void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char
     if (unopt_bc_fname)
         PM.add(createBitcodeWriterPass(unopt_bc_OS));
     if (bc_fname || obj_fname)
-        addOptimizationPasses(&PM, jl_options.opt_level, true);
+        addOptimizationPasses(&PM, jl_options.opt_level, true, true);
     if (bc_fname)
         PM.add(createBitcodeWriterPass(bc_OS));
     if (obj_fname)

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -34,7 +34,7 @@ extern Function *juliapersonality_func;
 typedef struct {Value *gv; int32_t index;} jl_value_llvm; // uses 1-based indexing
 
 void addTargetPasses(legacy::PassManagerBase *PM, TargetMachine *TM);
-void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool dump_native=false);
+void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level, bool lower_intrinsics=true, bool dump_native=false);
 void* jl_emit_and_add_to_shadow(GlobalVariable *gv, void *gvarinit = NULL);
 void* jl_get_globalvar(GlobalVariable *gv);
 GlobalVariable *jl_get_global_for(const char *cname, void *addr, Module *M);


### PR DESCRIPTION
Many of those passes generate CPU-specific code, so add a way to disable them.
CUDAnative is now using its own lowering passes [1], but it might make sense to split some of the existing lowering passes (eg. `LowerGCFrame`) into more generic optimization + CPU-specific lowering.

1: https://github.com/JuliaGPU/CUDAnative.jl/blob/dc37a71024869034ecb58cfe65c0f9658ea60aa7/src/compiler/optim.jl#L18-L21

cc @jonathanvdc