### PR TITLE
add docstring for Base.isiterable

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -875,6 +875,12 @@ next element and the new iteration state should be returned.
 """
 function iterate end
 
+"""
+    isiterable(T) -> Bool
+
+Test if type `T` is an iterable collection type or not,
+that is whether it has an `iterate` method or not.
+"""
 function isiterable(T)::Bool
     return hasmethod(iterate, Tuple{T})
 end


### PR DESCRIPTION
Dear Julia dev,
I was looking at way to find if a type is iterable or not, and [searching the keywords "julia isiterable"](https://www.google.com/search?&q=julia+isiterable), I ended up on the @queryverse package [IteratorInterfaceExtensions.jl](https://github.com/queryverse/IteratorInterfaceExtensions.jl) which indeed provides `isiterable`. However, looking at the [source code](https://github.com/queryverse/IteratorInterfaceExtensions.jl/blob/master/src/IteratorInterfaceExtensions.jl#L5), I was surprise to see that `Base.isiterable` in fact exists as standard.

Since I discovered that `Base.isiterable` has no docstring, I'm proposing one. (Unless it's intentional).

The final goal would be increase the discoverability of isiterable, so I think it would be nice to have it in the manual too (in the [Base/Essentials](https://docs.julialang.org/en/v1/base/base/) section). However, if I remember correctly how the manual is written, adding the docstring in this PR will not be enough. Is that right? It should be added somewhere in [doc/src/base/base.md](https://github.com/JuliaLang/julia/blob/master/doc/src/base/base.md) but it's not clear to me where. (There are also some other functions from `essentials.jl` not in the manual, like `isdone`)