### PR TITLE
Make `simd_inner_length` generic fallback less specific

### DIFF
--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -39,6 +39,10 @@ check_body!(x) = true
 # @simd splits a for loop into two loops: an outer scalar loop and
 # an inner loop marked with :simdloop. The simd_... functions define
 # the splitting.
+# Custom iterators that do not support random access cannot support
+# vectorization. In order to be compatible with `@simd` annotated loops,
+#they should override `simd_inner_length(v::MyIter, j) = 1`,
+#`simd_outer_range(v::MyIter) = v`, and `simd_index(v::MyIter, j, i) = j`.
 
 # Get range for outer loop.
 simd_outer_range(r) = 0:0
@@ -119,10 +123,6 @@ either case, your inner loop should have the following properties to allow vecto
 
 * There exists no loop-carried memory dependencies
 * No iteration ever waits on a previous iteration to make forward progress.
-
-!!! note Custom iterators that do not support random access cannot support vectorization. In order to be compatible with
-    `@simd` annotated loops, they should override `simd_inner_length(v::MyIter, j) = 1`, `simd_outer_range(v::MyIter) = v`,
-    and `simd_index(v::MyIter, j, i) = j`.
 """
 macro simd(forloop)
     esc(compile(forloop, false))

--- a/base/simdloop.jl
+++ b/base/simdloop.jl
@@ -44,10 +44,10 @@ check_body!(x) = true
 simd_outer_range(r) = 0:0
 
 # Get trip count for inner loop.
-@inline simd_inner_length(r,j::Int) = Base.length(r)
+@inline simd_inner_length(r, j) = Base.length(r)
 
 # Construct user-level element from original range, outer loop index j, and inner loop index i.
-@inline simd_index(r,j::Int,i) = (@inbounds ret = r[i+firstindex(r)]; ret)
+@inline simd_index(r, j, i) = (@inbounds ret = r[i+firstindex(r)]; ret)
 
 # Compile Expr x in context of @simd.
 function compile(x, ivdep)
@@ -119,6 +119,10 @@ either case, your inner loop should have the following properties to allow vecto
 
 * There exists no loop-carried memory dependencies
 * No iteration ever waits on a previous iteration to make forward progress.
+
+!!! note Custom iterators that do not support random access cannot support vectorization. In order to be compatible with
+    `@simd` annotated loops, they should override `simd_inner_length(v::MyIter, j) = 1`, `simd_outer_range(v::MyIter) = v`,
+    and `simd_index(v::MyIter, j, i) = j`.
 """
 macro simd(forloop)
     esc(compile(forloop, false))

--- a/test/simdloop.jl
+++ b/test/simdloop.jl
@@ -163,3 +163,14 @@ function simd_sum_over_array(a)
 end
 @test 2001000 == simd_sum_over_array(Vector(1:2000))
 @test 2001000 == simd_sum_over_array(Float32[i+j*500 for i=1:500, j=0:3])
+
+#Opt out of simd
+struct iter31113{T}
+    parent::T
+end
+Base.iterate(it::iter31113, args...) = iterate(it.parent, args...)
+Base.eltype(it::iter31113) = eltype(it.parent)
+Base.SimdLoop.simd_index(v::iter31113, j, i) = j
+Base.SimdLoop.simd_inner_length(v::iter31113, j) = 1
+Base.SimdLoop.simd_outer_range(v::iter31113) = v
+@test 2001000 == simd_sum_over_array(iter31113(Vector(1:2000)))


### PR DESCRIPTION
Changed specifity of `simd_inner_length` and `simd_index` generic fallbacks in order to simplify opt-out for custom iterators that do not support random access. Of course such iterators cannot successfully `simd`, but they can at least work such that the optimistic `@simd` annotation does not cause an error.

Without this patch, this is somewhat inconvenient, since one gets method ambiguities unless one hard-codes the return type of the custom iterator. 

I hope this breaks nothing. 

Before: 
```
julia> r=rand(10).>0.5;
julia> li = Base.LogicalIndex(r);
julia> for i in li
       i
       end
julia> @simd for i in li
       i
       end
ERROR: getindex not defined for Base.LogicalIndex{Int64,BitArray{1}}

julia> begin
       T = typeof(li)
       Base.SimdLoop.simd_index(v::T, j, i) = j
       Base.SimdLoop.simd_inner_length(v::T, j) = 1
       Base.SimdLoop.simd_outer_range(v::T) = v
       end

julia> @simd for i in li
       i
       end
ERROR: MethodError: Base.SimdLoop.simd_inner_length(::Base.LogicalIndex{Int64,BitArray{1}}, ::Int64) is ambiguous. Candidates:
  simd_inner_length(v::Base.LogicalIndex{Int64,BitArray{1}}, j) in Main at REPL[5]:4
  simd_inner_length(r, j::Int64) in Base.SimdLoop at simdloop.jl:47
Possible fix, define
  simd_inner_length(::Base.LogicalIndex{Int64,BitArray{1}}, ::Int64)

julia> begin
       T = typeof(li); RT = Int64
       Base.SimdLoop.simd_index(v::T, j::RT, i) = j
       Base.SimdLoop.simd_inner_length(v::T, j::RT) = 1
       Base.SimdLoop.simd_outer_range(v::T) = v
       end

julia> @simd for i in li
       i
       end
```

After:
```
julia> r=rand(10).>0.5;
julia> li = Base.LogicalIndex(r);
julia> @simd for i in li
       i
       end
ERROR: getindex not defined for Base.LogicalIndex{Int64,BitArray{1}}

julia> begin
       T = typeof(li)
       Base.SimdLoop.simd_index(v::T, j, i) = j
       Base.SimdLoop.simd_inner_length(v::T, j) = 1
       Base.SimdLoop.simd_outer_range(v::T) = v
       end

julia> @simd for i in li
       i
       end
```

As an aside, do we want docs for simd opt-out for custom iterators? Or do these docs exist and I failed at RTFM?