### PR TITLE
Broaden signature of eigen and eigvals to AbstractMatrix to allow for Adjoint and Transpose input.

### DIFF
--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -133,7 +133,7 @@ julia> vals == F.values && vecs == F.vectors
 true
 ```
 """
-function eigen(A::StridedMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T
+function eigen(A::AbstractMatrix{T}; permute::Bool=true, scale::Bool=true, sortby::Union{Function,Nothing}=eigsortby) where T
     AA = copy_oftype(A, eigtype(T))
     isdiag(AA) && return eigen(Diagonal(AA); permute=permute, scale=scale, sortby=sortby)
     return eigen!(AA; permute=permute, scale=scale, sortby=sortby)
@@ -225,7 +225,7 @@ julia> eigvals(diag_matrix)
  4.0
 ```
 """
-eigvals(A::StridedMatrix{T}; kws...) where T =
+eigvals(A::AbstractMatrix{T}; kws...) where T =
     eigvals!(copy_oftype(A, eigtype(T)); kws...)
 
 """
@@ -272,7 +272,7 @@ Stacktrace:
 [...]
 ```
 """
-function eigmax(A::Union{Number, StridedMatrix}; permute::Bool=true, scale::Bool=true)
+function eigmax(A::Union{Number, AbstractMatrix}; permute::Bool=true, scale::Bool=true)
     v = eigvals(A, permute = permute, scale = scale)
     if eltype(v)<:Complex
         throw(DomainError(A, "`A` cannot have complex eigenvalues."))

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -136,6 +136,8 @@ end
     A = randn(3,3)
     @test eigvals(A') == eigvals(copy(A'))
     @test eigen(A')   == eigen(copy(A'))
+    @test eigmin(A') == eigmin(copy(A'))
+    @test eigmax(A') == eigmax(copy(A'))
 end
 
 

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -138,6 +138,5 @@ end
     @test eigen(A')   == eigen(copy(A'))
 end
 
-end
 
 end # module TestEigen

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -132,4 +132,12 @@ end
     @test factstring == "$(summary(e))\neigenvalues:\n$valsstring\neigenvectors:\n$vecsstring"
 end
 
+@testset "eigen of an Adjoint" begin
+    A = randn(3,3)
+    @test eigvals(A') == eigvals(copy(A'))
+    @test eigen(A')   == eigen(copy(A'))
+end
+
+end
+
 end # module TestEigen


### PR DESCRIPTION
The is a very simple fix of JuliaLang/LinearAlgebra.jl#551. Eventually, we might be able to avoid materializing the adjoint, but the benefit will in most cases be very limited so I think we should add the simple fix right away.

Fixes JuliaLang/LinearAlgebra.jl#551