### PR TITLE
Fix #18303, better error message for overflowing factorial

### DIFF
--- a/base/combinatorics.jl
+++ b/base/combinatorics.jl
@@ -16,7 +16,7 @@ end
 
 function factorial_lookup(n::Integer, table, lim)
     n < 0 && throw(DomainError(n, "`n` must not be negative."))
-    n > lim && throw(OverflowError(string(n, " is too large to look up in the table")))
+    n > lim && throw(OverflowError(string(n, " is too large to look up in the table; consider using `factorial(big(", n, "))` instead")))
     n == 0 && return one(n)
     @inbounds f = table[n]
     return oftype(n, f)


### PR DESCRIPTION
Beginners with Julia may try factorials with "large" numbers, and they would quickly receive a strange error message (#18303): they don't really care about look-up tables, provided they know what this is. This PR provides a better error message for this case, explaining how to compute factorials of large numbers (which is what these beginners want), instead of having them go through the documentation and find the relevant piece.

Before: 

```
julia> factorial(100)
ERROR: OverflowError: 100 is too large to look up in the table
Stacktrace:
 [1] factorial_lookup(::Int64, ::Array{Int64,1}, ::Int64) at ./REPL[2]:3
 [2] factorial(::Int64) at ./combinatorics.jl:27
 [3] top-level scope at none:0
```

After: 

```
julia> factorial(100)
ERROR: OverflowError: 100 is too large to look up in the table; consider using `factorial(big(100))` instead
Stacktrace:
 [1] factorial_lookup(::Int64, ::Array{Int64,1}, ::Int64) at ./REPL[4]:3
 [2] factorial(::Int64) at ./combinatorics.jl:27
 [3] top-level scope at none:0
```