### PR TITLE
WIP/RFC: Split GC lowering pass into a platform-agnostic pass and a CPU-specific pass

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -55,9 +55,9 @@ LLVMLINK :=
 
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-ptls llvm-muladd \
-	llvm-late-gc-lowering llvm-lower-handlers llvm-gc-invariant-verifier \
-	llvm-propagate-addrspaces llvm-multiversioning llvm-alloc-opt cgmemmgr \
-	llvm-api
+	llvm-pass-helpers llvm-late-gc-lowering \
+	llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces \
+	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-api
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
 LLVM_LIBS := all
 ifeq ($(USE_POLLY),1)
@@ -211,6 +211,8 @@ $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/staticdata.o $(BUILDDIR)/staticdata.dbg.obj: $(SRCDIR)/processor.h
+$(BUILDDIR)/llvm-pass-helpers.o $(BUILDDIR)/llvm-pass-helpers.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
+$(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-pages.o $(BUILDDIR)/gc-pages.dbg.obj: $(SRCDIR)/gc.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ LLVMLINK :=
 
 ifeq ($(JULIACODEGEN),LLVM)
 SRCS += codegen jitlayers disasm debuginfo llvm-simdloop llvm-ptls llvm-muladd \
-	llvm-pass-helpers llvm-late-gc-lowering \
+	llvm-final-gc-lowering llvm-pass-helpers llvm-late-gc-lowering \
 	llvm-lower-handlers llvm-gc-invariant-verifier llvm-propagate-addrspaces \
 	llvm-multiversioning llvm-alloc-opt cgmemmgr llvm-api
 FLAGS += -I$(shell $(LLVM_CONFIG_HOST) --includedir)
@@ -211,8 +211,9 @@ $(BUILDDIR)/disasm.o $(BUILDDIR)/disasm.dbg.obj: $(SRCDIR)/debuginfo.h $(SRCDIR)
 $(BUILDDIR)/jitlayers.o $(BUILDDIR)/jitlayers.dbg.obj: $(SRCDIR)/jitlayers.h
 $(BUILDDIR)/builtins.o $(BUILDDIR)/builtins.dbg.obj: $(SRCDIR)/table.c
 $(BUILDDIR)/staticdata.o $(BUILDDIR)/staticdata.dbg.obj: $(SRCDIR)/processor.h
-$(BUILDDIR)/llvm-pass-helpers.o $(BUILDDIR)/llvm-pass-helpers.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
+$(BUILDDIR)/llvm-final-gc-lowering.o $(BUILDDIR)/llvm-final-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/llvm-late-gc-lowering.o $(BUILDDIR)/llvm-late-gc-lowering.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
+$(BUILDDIR)/llvm-pass-helpers.o $(BUILDDIR)/llvm-pass-helpers.dbg.obj: $(SRCDIR)/llvm-pass-helpers.h
 $(BUILDDIR)/gc.o $(BUILDDIR)/gc.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-debug.o $(BUILDDIR)/gc-debug.dbg.obj: $(SRCDIR)/gc.h
 $(BUILDDIR)/gc-pages.o $(BUILDDIR)/gc-pages.dbg.obj: $(SRCDIR)/gc.h

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -126,6 +126,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
             PM->add(createLowerExcHandlersPass());
             PM->add(createGCInvariantVerifierPass(false));
             PM->add(createLateLowerGCFramePass());
+            PM->add(createFinalLowerGCPass());
             PM->add(createLowerPTLSPass(dump_native));
         }
         PM->add(createLowerSimdLoopPass());        // Annotate loop marked with "loopinfo" as LLVM parallel loop
@@ -241,6 +242,7 @@ void addOptimizationPasses(legacy::PassManagerBase *PM, int opt_level,
         PM->add(createLowerExcHandlersPass());
         PM->add(createGCInvariantVerifierPass(false));
         PM->add(createLateLowerGCFramePass());
+        PM->add(createFinalLowerGCPass());
         // Remove dead use of ptls
         PM->add(createDeadCodeEliminationPass());
         PM->add(createLowerPTLSPass(dump_native));

--- a/src/jitlayers.h
+++ b/src/jitlayers.h
@@ -187,6 +187,7 @@ JL_DLLEXPORT extern LLVMContext jl_LLVMContext;
 
 Pass *createLowerPTLSPass(bool imaging_mode);
 Pass *createCombineMulAddPass();
+Pass *createFinalLowerGCPass();
 Pass *createLateLowerGCFramePass();
 Pass *createLowerExcHandlersPass();
 Pass *createGCInvariantVerifierPass(bool Strong);

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -214,9 +214,9 @@ bool FinalLowerGC::doInitialization(Module &M) {
     initAll(M);
 
     // Initialize platform-specific references.
-    queueRootFunc = getOrDefine(jl_well_known::GCQueueRoot);
-    poolAllocFunc = getOrDefine(jl_well_known::GCPoolAlloc);
-    bigAllocFunc = getOrDefine(jl_well_known::GCBigAlloc);
+    queueRootFunc = getOrDeclare(jl_well_known::GCQueueRoot);
+    poolAllocFunc = getOrDeclare(jl_well_known::GCPoolAlloc);
+    bigAllocFunc = getOrDeclare(jl_well_known::GCBigAlloc);
 
     GlobalValue *functionList[] = {queueRootFunc, poolAllocFunc, bigAllocFunc};
     unsigned j = 0;

--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -1,0 +1,240 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include <llvm/IR/LegacyPassManager.h>
+#include <llvm/IR/Function.h>
+#include <llvm/IR/IntrinsicInst.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/Pass.h>
+#include <llvm/Support/Debug.h>
+
+#include "llvm-version.h"
+#include "codegen_shared.h"
+#include "julia.h"
+#include "julia_internal.h"
+#include "llvm-pass-helpers.h"
+
+#define DEBUG_TYPE "final_gc_lowering"
+
+using namespace llvm;
+
+// The final GC lowering pass. This pass lowers platform-agnostic GC
+// intrinsics to platform-dependent instruction sequences. The
+// intrinsics it targets are those produced by the late GC frame
+// lowering pass.
+//
+// This pass targets typical back-ends for which the standard Julia
+// runtime library is available. Atypical back-ends should supply
+// their own lowering pass.
+struct FinalLowerGC: public FunctionPass, private JuliaPassContext {
+    static char ID;
+    FinalLowerGC() : FunctionPass(ID)
+    { }
+
+private:
+    CallInst *ptlsStates;
+
+    bool doInitialization(Module &M) override;
+    bool runOnFunction(Function &F) override;
+
+    // Lowers a `julia.new_gc_frame` intrinsic.
+    Value *lowerNewGCFrame(CallInst *target, Function &F);
+
+    // Lowers a `julia.push_gc_frame` intrinsic.
+    void lowerPushGCFrame(CallInst *target, Function &F);
+
+    // Lowers a `julia.pop_gc_frame` intrinsic.
+    void lowerPopGCFrame(CallInst *target, Function &F);
+
+    // Lowers a `julia.get_gc_frame_slot` intrinsic.
+    Value *lowerGetGCFrameSlot(CallInst *target, Function &F);
+
+    Instruction *getPgcstack(Instruction *ptlsStates);
+};
+
+Value *FinalLowerGC::lowerNewGCFrame(CallInst *target, Function &F)
+{
+    assert(target->getNumArgOperands() == 1);
+    unsigned nRoots = cast<ConstantInt>(target->getArgOperand(0))->getLimitedValue(INT_MAX);
+
+    // Create the GC frame.
+    AllocaInst *gcframe = new AllocaInst(
+        T_prjlvalue,
+        0,
+        ConstantInt::get(T_int32, nRoots + 2));
+    gcframe->insertAfter(target);
+    gcframe->takeName(target);
+
+    // Zero out the GC frame.
+    BitCastInst *tempSlot_i8 = new BitCastInst(gcframe, Type::getInt8PtrTy(F.getContext()), "");
+    tempSlot_i8->insertAfter(gcframe);
+    Type *argsT[2] = {tempSlot_i8->getType(), T_int32};
+    Function *memset = Intrinsic::getDeclaration(F.getParent(), Intrinsic::memset, makeArrayRef(argsT));
+#if JL_LLVM_VERSION >= 70000
+        Value *args[4] = {
+            tempSlot_i8, // dest
+            ConstantInt::get(Type::getInt8Ty(F.getContext()), 0), // val
+            ConstantInt::get(T_int32, sizeof(jl_value_t*)*(nRoots+2)), // len
+            ConstantInt::get(Type::getInt1Ty(F.getContext()), 0)}; // volatile
+#else
+        Value *args[5] = {
+            tempSlot_i8, // dest
+            ConstantInt::get(Type::getInt8Ty(F.getContext()), 0), // val
+            ConstantInt::get(T_int32, sizeof(jl_value_t*)*(nRoots+2)), // len
+            ConstantInt::get(T_int32, 0), // align
+            ConstantInt::get(Type::getInt1Ty(F.getContext()), 0)}; // volatile
+#endif
+    CallInst *zeroing = CallInst::Create(memset, makeArrayRef(args));
+    zeroing->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    zeroing->insertAfter(tempSlot_i8);
+
+    return gcframe;
+}
+
+void FinalLowerGC::lowerPushGCFrame(CallInst *target, Function &F)
+{
+    assert(target->getNumArgOperands() == 2);
+    auto gcframe = target->getArgOperand(0);
+    unsigned nRoots = cast<ConstantInt>(target->getArgOperand(1))->getLimitedValue(INT_MAX);
+
+    IRBuilder<> builder(target->getContext());
+    builder.SetInsertPoint(&*(++BasicBlock::iterator(target)));
+    Instruction *inst =
+        builder.CreateStore(
+            ConstantInt::get(T_size, nRoots << 1),
+            builder.CreateBitCast(
+                builder.CreateConstGEP1_32(gcframe, 0),
+                T_size->getPointerTo()));
+    inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    Value *pgcstack = builder.Insert(getPgcstack(ptlsStates));
+    inst = builder.CreateStore(
+        builder.CreateLoad(pgcstack),
+        builder.CreatePointerCast(
+            builder.CreateConstGEP1_32(gcframe, 1),
+            PointerType::get(T_ppjlvalue, 0)));
+    inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    builder.CreateStore(gcframe, builder.CreateBitCast(pgcstack,
+        PointerType::get(PointerType::get(T_prjlvalue, 0), 0)));
+}
+
+void FinalLowerGC::lowerPopGCFrame(CallInst *target, Function &F)
+{
+    assert(target->getNumArgOperands() == 1);
+    auto gcframe = target->getArgOperand(0);
+
+    IRBuilder<> builder(target->getContext());
+    builder.SetInsertPoint(target);
+    Instruction *gcpop =
+        cast<Instruction>(builder.CreateConstGEP1_32(gcframe, 1));
+    Instruction *inst = builder.CreateLoad(gcpop);
+    inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+    inst = builder.CreateStore(
+        inst,
+        builder.CreateBitCast(
+            builder.Insert(getPgcstack(ptlsStates)),
+            PointerType::get(T_prjlvalue, 0)));
+    inst->setMetadata(LLVMContext::MD_tbaa, tbaa_gcframe);
+}
+
+Value *FinalLowerGC::lowerGetGCFrameSlot(CallInst *target, Function &F)
+{
+    assert(target->getNumArgOperands() == 3);
+    auto gcframe = target->getArgOperand(0);
+    auto index = target->getArgOperand(1);
+
+    // Initialize an IR builder.
+    IRBuilder<> builder(target->getContext());
+    builder.SetInsertPoint(target);
+
+    // The first two slots are reserved, so we'll add two to the index.
+    index = builder.CreateAdd(index, ConstantInt::get(T_int32, 2));
+
+    // Lower the intrinsic as a GEP.
+    auto gep = builder.CreateGEP(gcframe, index);
+    gep->takeName(target);
+    return gep;
+}
+
+Instruction *FinalLowerGC::getPgcstack(Instruction *ptlsStates)
+{
+    Constant *offset = ConstantInt::getSigned(T_int32, offsetof(jl_tls_states_t, pgcstack) / sizeof(void*));
+    return GetElementPtrInst::Create(
+        nullptr,
+        ptlsStates,
+        ArrayRef<Value*>(offset),
+        "jl_pgcstack");
+}
+
+bool FinalLowerGC::doInitialization(Module &M)
+{
+    initAll(M);
+    return true;
+}
+
+bool FinalLowerGC::runOnFunction(Function &F)
+{
+    DEBUG(dbgs() << "FINAL GC LOWERING: Processing function " << F.getName() << "\n");
+    // Check availability of functions again since they might have been deleted.
+    initFunctions(*F.getParent());
+    if (!ptls_getter)
+        return true;
+
+    // Look for a call to 'julia.ptls_states'.
+    ptlsStates = getPtls(F);
+    if (!ptlsStates)
+        return true;
+
+    // Acquire intrinsic functions.
+    auto newGCFrameFunc = getOrNull(jl_intrinsics::newGCFrame);
+    auto pushGCFrameFunc = getOrNull(jl_intrinsics::pushGCFrame);
+    auto popGCFrameFunc = getOrNull(jl_intrinsics::popGCFrame);
+    auto getGCFrameSlotFunc = getOrNull(jl_intrinsics::getGCFrameSlot);
+
+    // Lower all calls to supported intrinsics.
+    for (BasicBlock &BB : F) {
+        for (auto it = BB.begin(); it != BB.end();) {
+            auto *CI = dyn_cast<CallInst>(&*it);
+            if (!CI) {
+                ++it;
+                continue;
+            }
+
+            auto callee = CI->getCalledValue();
+
+            if (callee == newGCFrameFunc) {
+                CI->replaceAllUsesWith(lowerNewGCFrame(CI, F));
+                it = CI->eraseFromParent();
+            }
+            else if (callee == pushGCFrameFunc) {
+                lowerPushGCFrame(CI, F);
+                it = CI->eraseFromParent();
+            }
+            else if (callee == popGCFrameFunc) {
+                lowerPopGCFrame(CI, F);
+                it = CI->eraseFromParent();
+            }
+            else if (callee == getGCFrameSlotFunc) {
+                CI->replaceAllUsesWith(lowerGetGCFrameSlot(CI, F));
+                it = CI->eraseFromParent();
+            }
+            else {
+                ++it;
+            }
+        }
+    }
+
+    return true;
+}
+
+char FinalLowerGC::ID = 0;
+static RegisterPass<FinalLowerGC> X("FinalLowerGC", "Final GC intrinsic lowering pass", false, false);
+
+Pass *createFinalLowerGCPass()
+{
+    return new FinalLowerGC();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddFinalLowerGCPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createFinalLowerGCPass());
+}

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -30,6 +30,7 @@
 #include "julia.h"
 #include "julia_internal.h"
 #include "julia_assert.h"
+#include "llvm-pass-helpers.h"
 
 #define DEBUG_TYPE "late_lower_gcroot"
 #if JL_LLVM_VERSION < 70000
@@ -304,17 +305,11 @@ namespace llvm {
     void initializeLateLowerGCFramePass(PassRegistry &Registry);
 }
 
-extern std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=nullptr, bool isConstant=false);
-struct LateLowerGCFrame: public FunctionPass {
+struct LateLowerGCFrame: public FunctionPass, private JuliaPassContext {
     static char ID;
     LateLowerGCFrame() : FunctionPass(ID)
     {
         llvm::initializeDominatorTreeWrapperPassPass(*PassRegistry::getPassRegistry());
-        tbaa_gcframe = tbaa_make_child("jtbaa_gcframe").first;
-        MDNode *tbaa_data;
-        MDNode *tbaa_data_scalar;
-        std::tie(tbaa_data, tbaa_data_scalar) = tbaa_make_child("jtbaa_data");
-        tbaa_tag = tbaa_make_child("jtbaa_tag", tbaa_data_scalar).first;
     }
 
 protected:
@@ -326,25 +321,6 @@ protected:
     }
 
 private:
-    Type *T_prjlvalue;
-    Type *T_ppjlvalue;
-    Type *T_size;
-    Type *T_int8;
-    Type *T_int32;
-    Type *T_pint8;
-    Type *T_pjlvalue;
-    Type *T_pjlvalue_der;
-    Type *T_ppjlvalue_der;
-    MDNode *tbaa_gcframe;
-    MDNode *tbaa_tag;
-    Function *ptls_getter;
-    Function *gc_flush_func;
-    Function *gc_preserve_begin_func;
-    Function *gc_preserve_end_func;
-    Function *pointer_from_objref_func;
-    Function *alloc_obj_func;
-    Function *typeof_func;
-    Function *write_barrier_func;
     Function *queueroot_func;
     Function *pool_alloc_func;
     Function *big_alloc_func;
@@ -376,7 +352,6 @@ private:
     void PlaceGCFrameStores(State &S, unsigned MinColorRoot, const std::vector<int> &Colors, Value *GCFrame);
     void PlaceRootsAndUpdateCalls(std::vector<int> &Colors, State &S, std::map<Value *, std::pair<int, int>>);
     bool doInitialization(Module &M) override;
-    void reinitFunctions(Module &M);
     bool doFinalization(Module &) override;
     bool runOnFunction(Function &F) override;
     Instruction *get_pgcstack(Instruction *ptlsStates);
@@ -2038,26 +2013,13 @@ void LateLowerGCFrame::PlaceRootsAndUpdateCalls(std::vector<int> &Colors, State 
     }
 }
 
-void LateLowerGCFrame::reinitFunctions(Module &M) {
-    ptls_getter = M.getFunction("julia.ptls_states");
-    gc_flush_func = M.getFunction("julia.gcroot_flush");
-    gc_preserve_begin_func = M.getFunction("llvm.julia.gc_preserve_begin");
-    gc_preserve_end_func = M.getFunction("llvm.julia.gc_preserve_end");
-    pointer_from_objref_func = M.getFunction("julia.pointer_from_objref");
-    typeof_func = M.getFunction("julia.typeof");
-    write_barrier_func = M.getFunction("julia.write_barrier");
-    alloc_obj_func = M.getFunction("julia.gc_alloc_obj");
-}
-
 bool LateLowerGCFrame::doInitialization(Module &M) {
-    ptls_getter = M.getFunction("julia.ptls_states");
+    // Initialize platform-agnostic references.
+    initAll(M);
+
+    // Initialize platform-specific references.
     auto &ctx = M.getContext();
-    T_size = M.getDataLayout().getIntPtrType(ctx);
-    T_int8 = Type::getInt8Ty(ctx);
-    T_pint8 = PointerType::get(T_int8, 0);
-    T_int32 = Type::getInt32Ty(ctx);
-    if ((write_barrier_func = M.getFunction("julia.write_barrier"))) {
-        T_prjlvalue = write_barrier_func->getFunctionType()->getParamType(0);
+    if (write_barrier_func) {
         if (!(queueroot_func = M.getFunction("jl_gc_queue_root"))) {
             queueroot_func = Function::Create(FunctionType::get(Type::getVoidTy(ctx),
                                                                 {T_prjlvalue}, false),
@@ -2070,8 +2032,7 @@ bool LateLowerGCFrame::doInitialization(Module &M) {
     }
     pool_alloc_func = nullptr;
     big_alloc_func = nullptr;
-    if ((alloc_obj_func = M.getFunction("julia.gc_alloc_obj"))) {
-        T_prjlvalue = alloc_obj_func->getReturnType();
+    if (alloc_obj_func) {
         if (!(pool_alloc_func = M.getFunction("jl_gc_pool_alloc"))) {
             std::vector<Type*> args(0);
             args.push_back(T_pint8);
@@ -2095,28 +2056,8 @@ bool LateLowerGCFrame::doInitialization(Module &M) {
                 alloc_obj_func->getAttributes().getRetAttributes(),
                 None));
         }
-        auto T_jlvalue = cast<PointerType>(T_prjlvalue)->getElementType();
-        T_pjlvalue = PointerType::get(T_jlvalue, 0);
-        T_ppjlvalue = PointerType::get(T_pjlvalue, 0);
-        T_pjlvalue_der = PointerType::get(T_jlvalue, AddressSpace::Derived);
-        T_ppjlvalue_der = PointerType::get(T_prjlvalue, AddressSpace::Derived);
     }
-    else if (ptls_getter) {
-        auto functype = ptls_getter->getFunctionType();
-        T_ppjlvalue = cast<PointerType>(functype->getReturnType())->getElementType();
-        T_pjlvalue = cast<PointerType>(T_ppjlvalue)->getElementType();
-        auto T_jlvalue = cast<PointerType>(T_pjlvalue)->getElementType();
-        T_prjlvalue = PointerType::get(T_jlvalue, AddressSpace::Tracked);
-        T_pjlvalue_der = PointerType::get(T_jlvalue, AddressSpace::Derived);
-        T_ppjlvalue_der = PointerType::get(T_prjlvalue, AddressSpace::Derived);
-    }
-    else {
-        T_ppjlvalue = nullptr;
-        T_prjlvalue = nullptr;
-        T_pjlvalue = nullptr;
-        T_pjlvalue_der = nullptr;
-        T_ppjlvalue_der = nullptr;
-    }
+
     GlobalValue *function_list[] = {queueroot_func, pool_alloc_func, big_alloc_func};
     unsigned j = 0;
     for (unsigned i = 0; i < sizeof(function_list) / sizeof(void*); i++) {
@@ -2165,21 +2106,14 @@ bool LateLowerGCFrame::doFinalization(Module &M)
 bool LateLowerGCFrame::runOnFunction(Function &F) {
     LLVM_DEBUG(dbgs() << "GC ROOT PLACEMENT: Processing function " << F.getName() << "\n");
     // Check availability of functions again since they might have been deleted.
-    reinitFunctions(*F.getParent());
+    initFunctions(*F.getParent());
     if (!ptls_getter)
         return CleanupIR(F);
-    ptlsStates = nullptr;
-    for (auto I = F.getEntryBlock().begin(), E = F.getEntryBlock().end();
-         ptls_getter && I != E; ++I) {
-        if (CallInst *callInst = dyn_cast<CallInst>(&*I)) {
-            if (callInst->getCalledValue() == ptls_getter) {
-                ptlsStates = callInst;
-                break;
-            }
-        }
-    }
+
+    ptlsStates = getPtls(F);
     if (!ptlsStates)
         return CleanupIR(F);
+
     State S = LocalScan(F);
     ComputeLiveness(S);
     std::vector<int> Colors = ColorRoots(S);

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -125,6 +125,7 @@ namespace jl_intrinsics {
     static const char *PUSH_GC_FRAME_NAME = "julia.push_gc_frame";
     static const char *POP_GC_FRAME_NAME = "julia.pop_gc_frame";
     static const char *GET_GC_FRAME_SLOT_NAME = "julia.get_gc_frame_slot";
+    static const char *GC_ALLOC_BYTES_NAME = "julia.gc_alloc_bytes";
 
     const IntrinsicDescription newGCFrame(
         NEW_GC_FRAME_NAME,
@@ -181,6 +182,24 @@ namespace jl_intrinsics {
                 Function::ExternalLinkage,
                 GET_GC_FRAME_SLOT_NAME,
                 &M);
+
+            return intrinsic;
+        });
+
+    const IntrinsicDescription GCAllocBytes(
+        GC_ALLOC_BYTES_NAME,
+        [](llvm::Module &M, const JuliaPassContext &context) {
+            auto intrinsic = Function::Create(
+                FunctionType::get(
+                    context.T_prjlvalue,
+                    { context.T_pint8, context.T_size },
+                    false),
+                Function::ExternalLinkage,
+                GC_ALLOC_BYTES_NAME,
+                &M);
+            intrinsic->addAttribute(AttributeList::ReturnIndex, Attribute::NoAlias);
+            intrinsic->addAttribute(AttributeList::ReturnIndex, Attribute::NonNull);
+            intrinsic->addFnAttr(Attribute::getWithAllocSizeArgs(M.getContext(), 1, None)); // returns %1 bytes
 
             return intrinsic;
         });

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -106,7 +106,7 @@ llvm::Function *JuliaPassContext::getOrNull(
     return module->getFunction(desc.name);
 }
 
-llvm::Function *JuliaPassContext::getOrDefine(
+llvm::Function *JuliaPassContext::getOrDeclare(
     const jl_intrinsics::IntrinsicDescription &desc) const
 {
     auto local = getOrNull(desc);
@@ -114,7 +114,7 @@ llvm::Function *JuliaPassContext::getOrDefine(
         return local;
     }
     else {
-        return desc.define(*module, *this);
+        return desc.declare(*module, *this);
     }
 }
 
@@ -221,8 +221,8 @@ namespace jl_well_known {
     const WellKnownFunctionDescription GCBigAlloc(
         GC_BIG_ALLOC_NAME,
         [](llvm::Module &M, const JuliaPassContext &context) {
-            // Get or define `julia.gc_alloc_bytes` so we can copy its attributes.
-            auto allocBytes = context.getOrDefine(jl_intrinsics::GCAllocBytes);
+            // Get or declare `julia.gc_alloc_bytes` so we can copy its attributes.
+            auto allocBytes = context.getOrDeclare(jl_intrinsics::GCAllocBytes);
 
             auto bigAllocFunc = Function::Create(
                 FunctionType::get(
@@ -244,8 +244,8 @@ namespace jl_well_known {
     const WellKnownFunctionDescription GCPoolAlloc(
         GC_POOL_ALLOC_NAME,
         [](llvm::Module &M, const JuliaPassContext &context) {
-            // Get or define `julia.gc_alloc_bytes` so we can copy its attributes.
-            auto allocBytes = context.getOrDefine(jl_intrinsics::GCAllocBytes);
+            // Get or declare `julia.gc_alloc_bytes` so we can copy its attributes.
+            auto allocBytes = context.getOrDeclare(jl_intrinsics::GCAllocBytes);
 
             auto poolAllocFunc = Function::Create(
                 FunctionType::get(

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -121,15 +121,16 @@ llvm::Function *JuliaPassContext::getOrDefine(
 }
 
 namespace jl_intrinsics {
-    static const char* NEW_GC_FRAME_NAME = "julia.new_gc_frame";
-    static const char* PUSH_GC_FRAME_NAME = "julia.push_gc_frame";
-    static const char* POP_GC_FRAME_NAME = "julia.pop_gc_frame";
+    static const char *NEW_GC_FRAME_NAME = "julia.new_gc_frame";
+    static const char *PUSH_GC_FRAME_NAME = "julia.push_gc_frame";
+    static const char *POP_GC_FRAME_NAME = "julia.pop_gc_frame";
+    static const char *GET_GC_FRAME_SLOT_NAME = "julia.get_gc_frame_slot";
 
     const IntrinsicDescription newGCFrame(
         NEW_GC_FRAME_NAME,
         [](llvm::Module &M, const JuliaPassContext &context) {
             auto intrinsic = Function::Create(
-                FunctionType::get(PointerType::get(context.T_prjlvalue, 0), {context.T_size}, false),
+                FunctionType::get(PointerType::get(context.T_prjlvalue, 0), {context.T_int32}, false),
                 Function::ExternalLinkage,
                 NEW_GC_FRAME_NAME,
                 &M);
@@ -145,7 +146,7 @@ namespace jl_intrinsics {
             auto intrinsic = Function::Create(
                 FunctionType::get(
                     Type::getVoidTy(M.getContext()),
-                    {PointerType::get(context.T_prjlvalue, 0), context.T_size},
+                    {PointerType::get(context.T_prjlvalue, 0), context.T_int32},
                     false),
                 Function::ExternalLinkage,
                 PUSH_GC_FRAME_NAME,
@@ -164,6 +165,21 @@ namespace jl_intrinsics {
                     false),
                 Function::ExternalLinkage,
                 POP_GC_FRAME_NAME,
+                &M);
+
+            return intrinsic;
+        });
+
+    const IntrinsicDescription getGCFrameSlot(
+        GET_GC_FRAME_SLOT_NAME,
+        [](llvm::Module &M, const JuliaPassContext &context) {
+            auto intrinsic = Function::Create(
+                FunctionType::get(
+                    PointerType::get(context.T_prjlvalue, 0),
+                    {PointerType::get(context.T_prjlvalue, 0), context.T_int32},
+                    false),
+                Function::ExternalLinkage,
+                GET_GC_FRAME_SLOT_NAME,
                 &M);
 
             return intrinsic;

--- a/src/llvm-pass-helpers.cpp
+++ b/src/llvm-pass-helpers.cpp
@@ -1,0 +1,171 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+//
+// This file implements common functionality that is useful for the late GC frame
+// lowering and final GC intrinsic lowering passes. See the corresponding header
+// for docs.
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+
+#include <iostream>
+
+#include "llvm-version.h"
+#include "codegen_shared.h"
+#include "julia_assert.h"
+#include "llvm-pass-helpers.h"
+
+using namespace llvm;
+
+extern std::pair<MDNode*,MDNode*> tbaa_make_child(const char *name, MDNode *parent=nullptr, bool isConstant=false);
+
+JuliaPassContext::JuliaPassContext()
+    : module(nullptr), T_prjlvalue(nullptr), T_ppjlvalue(nullptr), T_size(nullptr),
+        T_int8(nullptr), T_int32(nullptr), T_pint8(nullptr), T_pjlvalue(nullptr),
+        T_pjlvalue_der(nullptr), T_ppjlvalue_der(nullptr), ptls_getter(nullptr),
+        gc_flush_func(nullptr), gc_preserve_begin_func(nullptr), gc_preserve_end_func(nullptr),
+        pointer_from_objref_func(nullptr), alloc_obj_func(nullptr), typeof_func(nullptr),
+        write_barrier_func(nullptr)
+{
+    tbaa_gcframe = tbaa_make_child("jtbaa_gcframe").first;
+    MDNode *tbaa_data;
+    MDNode *tbaa_data_scalar;
+    std::tie(tbaa_data, tbaa_data_scalar) = tbaa_make_child("jtbaa_data");
+    tbaa_tag = tbaa_make_child("jtbaa_tag", tbaa_data_scalar).first;
+}
+
+void JuliaPassContext::initFunctions(Module &M)
+{
+    module = &M;
+
+    ptls_getter = M.getFunction("julia.ptls_states");
+    gc_flush_func = M.getFunction("julia.gcroot_flush");
+    gc_preserve_begin_func = M.getFunction("llvm.julia.gc_preserve_begin");
+    gc_preserve_end_func = M.getFunction("llvm.julia.gc_preserve_end");
+    pointer_from_objref_func = M.getFunction("julia.pointer_from_objref");
+    typeof_func = M.getFunction("julia.typeof");
+    write_barrier_func = M.getFunction("julia.write_barrier");
+    alloc_obj_func = M.getFunction("julia.gc_alloc_obj");
+}
+
+void JuliaPassContext::initAll(Module &M)
+{
+    // First initialize the functions.
+    initFunctions(M);
+
+    // Then initialize types and metadata nodes.
+    auto &ctx = M.getContext();
+    T_size = M.getDataLayout().getIntPtrType(ctx);
+    T_int8 = Type::getInt8Ty(ctx);
+    T_pint8 = PointerType::get(T_int8, 0);
+    T_int32 = Type::getInt32Ty(ctx);
+    if (write_barrier_func) {
+        T_prjlvalue = write_barrier_func->getFunctionType()->getParamType(0);
+    }
+    if (alloc_obj_func) {
+        T_prjlvalue = alloc_obj_func->getReturnType();
+        auto T_jlvalue = cast<PointerType>(T_prjlvalue)->getElementType();
+        T_pjlvalue = PointerType::get(T_jlvalue, 0);
+        T_ppjlvalue = PointerType::get(T_pjlvalue, 0);
+        T_pjlvalue_der = PointerType::get(T_jlvalue, AddressSpace::Derived);
+        T_ppjlvalue_der = PointerType::get(T_prjlvalue, AddressSpace::Derived);
+    }
+    else if (ptls_getter) {
+        auto functype = ptls_getter->getFunctionType();
+        T_ppjlvalue = cast<PointerType>(functype->getReturnType())->getElementType();
+        T_pjlvalue = cast<PointerType>(T_ppjlvalue)->getElementType();
+        auto T_jlvalue = cast<PointerType>(T_pjlvalue)->getElementType();
+        T_prjlvalue = PointerType::get(T_jlvalue, AddressSpace::Tracked);
+        T_pjlvalue_der = PointerType::get(T_jlvalue, AddressSpace::Derived);
+        T_ppjlvalue_der = PointerType::get(T_prjlvalue, AddressSpace::Derived);
+    }
+    else {
+        T_ppjlvalue = nullptr;
+        T_prjlvalue = nullptr;
+        T_pjlvalue = nullptr;
+        T_pjlvalue_der = nullptr;
+        T_ppjlvalue_der = nullptr;
+    }
+}
+
+llvm::CallInst *JuliaPassContext::getPtls(llvm::Function &F) const
+{
+    for (auto I = F.getEntryBlock().begin(), E = F.getEntryBlock().end();
+         ptls_getter && I != E; ++I) {
+        if (CallInst *callInst = dyn_cast<CallInst>(&*I)) {
+            if (callInst->getCalledValue() == ptls_getter) {
+                return callInst;
+            }
+        }
+    }
+    return nullptr;
+}
+
+llvm::Function *JuliaPassContext::getOrNull(
+    const jl_intrinsics::IntrinsicDescription &desc) const
+{
+    return module->getFunction(desc.name);
+}
+
+llvm::Function *JuliaPassContext::getOrDefine(
+    const jl_intrinsics::IntrinsicDescription &desc) const
+{
+    auto local = getOrNull(desc);
+    if (local) {
+        return local;
+    }
+    else {
+        return desc.define(*module, *this);
+    }
+}
+
+namespace jl_intrinsics {
+    static const char* NEW_GC_FRAME_NAME = "julia.new_gc_frame";
+    static const char* PUSH_GC_FRAME_NAME = "julia.push_gc_frame";
+    static const char* POP_GC_FRAME_NAME = "julia.pop_gc_frame";
+
+    const IntrinsicDescription newGCFrame(
+        NEW_GC_FRAME_NAME,
+        [](llvm::Module &M, const JuliaPassContext &context) {
+            auto intrinsic = Function::Create(
+                FunctionType::get(PointerType::get(context.T_prjlvalue, 0), {context.T_size}, false),
+                Function::ExternalLinkage,
+                NEW_GC_FRAME_NAME,
+                &M);
+            intrinsic->addAttribute(AttributeList::ReturnIndex, Attribute::NoAlias);
+            intrinsic->addAttribute(AttributeList::ReturnIndex, Attribute::NonNull);
+
+            return intrinsic;
+        });
+
+    const IntrinsicDescription pushGCFrame(
+        PUSH_GC_FRAME_NAME,
+        [](llvm::Module &M, const JuliaPassContext &context) {
+            auto intrinsic = Function::Create(
+                FunctionType::get(
+                    Type::getVoidTy(M.getContext()),
+                    {PointerType::get(context.T_prjlvalue, 0), context.T_size},
+                    false),
+                Function::ExternalLinkage,
+                PUSH_GC_FRAME_NAME,
+                &M);
+
+            return intrinsic;
+        });
+
+    const IntrinsicDescription popGCFrame(
+        POP_GC_FRAME_NAME,
+        [](llvm::Module &M, const JuliaPassContext &context) {
+            auto intrinsic = Function::Create(
+                FunctionType::get(
+                    Type::getVoidTy(M.getContext()),
+                    {PointerType::get(context.T_prjlvalue, 0)},
+                    false),
+                Function::ExternalLinkage,
+                POP_GC_FRAME_NAME,
+                &M);
+
+            return intrinsic;
+        });
+}

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -12,7 +12,7 @@
 
 struct JuliaPassContext;
 
-// A namespace for Julia intrinsic definitions.
+// A namespace for Julia intrinsic descriptions.
 namespace jl_intrinsics {
     // A description of an intrinsic that can be used to find existing
     // intrinsics and materialize new intrinsics if necessary.
@@ -41,17 +41,25 @@ namespace jl_intrinsics {
 struct JuliaPassContext {
     llvm::Module *module;
 
-    llvm::Type *T_prjlvalue;
-    llvm::Type *T_ppjlvalue;
+    // Standard types.
     llvm::Type *T_size;
     llvm::Type *T_int8;
     llvm::Type *T_int32;
-    llvm::Type *T_pint8;
-    llvm::Type *T_pjlvalue;
-    llvm::Type *T_pjlvalue_der;
-    llvm::Type *T_ppjlvalue_der;
+    llvm::PointerType *T_pint8;
+
+    // Types derived from 'jl_value_t'.
+    llvm::Type *T_jlvalue;
+    llvm::PointerType *T_prjlvalue;
+    llvm::PointerType *T_ppjlvalue;
+    llvm::PointerType *T_pjlvalue;
+    llvm::PointerType *T_pjlvalue_der;
+    llvm::PointerType *T_ppjlvalue_der;
+
+    // TBAA metadata nodes.
     llvm::MDNode *tbaa_gcframe;
     llvm::MDNode *tbaa_tag;
+
+    // Intrinsics.
     llvm::Function *ptls_getter;
     llvm::Function *gc_flush_func;
     llvm::Function *gc_preserve_begin_func;
@@ -78,14 +86,15 @@ struct JuliaPassContext {
     // Otherwise, `nullptr` is returned.
     llvm::CallInst *getPtls(llvm::Function &F) const;
 
-    // Gets the intrinsic that conforms to the given description
-    // if it exists in the module. If not, `nullptr` is returned.
+    // Gets the intrinsic or well-known function that conforms to
+    // the given description if it exists in the module. If not,
+    // `nullptr` is returned.
     llvm::Function *getOrNull(
         const jl_intrinsics::IntrinsicDescription &desc) const;
 
-    // Gets the intrinsic that conforms to the given description
-    // if it exists in the module. If not, creates the intrinsic
-    // and adds it to the module.
+    // Gets the intrinsic or well-known function that conforms to
+    // the given description if it exists in the module. If not,
+    // creates the intrinsic and adds it to the module.
     llvm::Function *getOrDefine(
         const jl_intrinsics::IntrinsicDescription &desc) const;
 };
@@ -114,6 +123,26 @@ namespace jl_intrinsics {
 
     // `julia.queue_gc_root`: an intrinsic that queues a GC root.
     extern const IntrinsicDescription queueGCRoot;
+}
+
+// A namespace for well-known Julia runtime function descriptions.
+namespace jl_well_known {
+    // A description of a well-known function that can be used to
+    // find existing declarations of that function and create new
+    // declarations if necessary.
+    //
+    // Aliased to `jl_intrinsics::IntrinsicDescription` because
+    // intrinsic descriptions are essentially the same thing.
+    typedef jl_intrinsics::IntrinsicDescription WellKnownFunctionDescription;
+
+    // `jl_gc_big_alloc`: allocates bytes.
+    extern const WellKnownFunctionDescription GCBigAlloc;
+
+    // `jl_gc_pool_alloc`: allocates bytes.
+    extern const WellKnownFunctionDescription GCPoolAlloc;
+
+    // `jl_gc_queue_root`: queues a GC root.
+    extern const WellKnownFunctionDescription GCQueueRoot;
 }
 
 #endif

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -15,23 +15,23 @@ struct JuliaPassContext;
 // A namespace for Julia intrinsic descriptions.
 namespace jl_intrinsics {
     // A description of an intrinsic that can be used to find existing
-    // intrinsics and materialize new intrinsics if necessary.
+    // intrinsics and declare new intrinsics if necessary.
     struct IntrinsicDescription final {
-        // The type of function that defines a new intrinsic.
-        typedef llvm::Function *(*DefinitionFunction)(llvm::Module&, const JuliaPassContext&);
+        // The type of function that declares an intrinsic.
+        typedef llvm::Function *(*DeclarationFunction)(llvm::Module&, const JuliaPassContext&);
 
         // Creates an intrinsic description with a particular
-        // name and definition function.
+        // name and declaration function.
         IntrinsicDescription(
             const llvm::StringRef &name,
-            const DefinitionFunction &define)
-            : name(name), define(define)
+            const DeclarationFunction &declare)
+            : name(name), declare(declare)
         { }
 
         // The intrinsic's name.
         llvm::StringRef name;
-        // A function that defines the intrinsic in a module.
-        DefinitionFunction define;
+        // A function that declares the intrinsic in a module.
+        DeclarationFunction declare;
     };
 }
 
@@ -94,8 +94,9 @@ struct JuliaPassContext {
 
     // Gets the intrinsic or well-known function that conforms to
     // the given description if it exists in the module. If not,
-    // creates the intrinsic and adds it to the module.
-    llvm::Function *getOrDefine(
+    // declares the intrinsic or well-known function and adds it
+    // to the module.
+    llvm::Function *getOrDeclare(
         const jl_intrinsics::IntrinsicDescription &desc) const;
 };
 

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -91,17 +91,26 @@ struct JuliaPassContext {
 };
 
 namespace jl_intrinsics {
-    // An intrinsic that creates a new GC frame.
+    // `julia.new_gc_frame`: an intrinsic that creates a new GC frame.
     extern const IntrinsicDescription newGCFrame;
 
-    // An intrinsic that pushes a GC frame.
+    // `julia.push_gc_frame`: an intrinsic that pushes a GC frame.
     extern const IntrinsicDescription pushGCFrame;
 
-    // An intrinsic that pops a GC frame.
+    // `julia.pop_gc_frame`: an intrinsic that pops a GC frame.
     extern const IntrinsicDescription popGCFrame;
 
-    // An intrinsic that creates a pointer to a GC frame slot.
+    // `julia.get_gc_frame_slot`: an intrinsic that creates a
+    // pointer to a GC frame slot.
     extern const IntrinsicDescription getGCFrameSlot;
+
+    // `julia.gc_alloc_bytes`: an intrinsic that allocates
+    // the bytes for an object, but does not initialize the
+    // tag field. That is, its semantics and signature are
+    // the same as for `julia.gc_alloc_obj`, except that
+    // the object's tag field is neither initialized nor
+    // passed as an argument.
+    extern const IntrinsicDescription GCAllocBytes;
 }
 
 #endif

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -91,15 +91,6 @@ struct JuliaPassContext {
 };
 
 namespace jl_intrinsics {
-    // `julia.new_gc_frame`: an intrinsic that creates a new GC frame.
-    extern const IntrinsicDescription newGCFrame;
-
-    // `julia.push_gc_frame`: an intrinsic that pushes a GC frame.
-    extern const IntrinsicDescription pushGCFrame;
-
-    // `julia.pop_gc_frame`: an intrinsic that pops a GC frame.
-    extern const IntrinsicDescription popGCFrame;
-
     // `julia.get_gc_frame_slot`: an intrinsic that creates a
     // pointer to a GC frame slot.
     extern const IntrinsicDescription getGCFrameSlot;
@@ -111,6 +102,18 @@ namespace jl_intrinsics {
     // the object's tag field is neither initialized nor
     // passed as an argument.
     extern const IntrinsicDescription GCAllocBytes;
+
+    // `julia.new_gc_frame`: an intrinsic that creates a new GC frame.
+    extern const IntrinsicDescription newGCFrame;
+
+    // `julia.push_gc_frame`: an intrinsic that pushes a GC frame.
+    extern const IntrinsicDescription pushGCFrame;
+
+    // `julia.pop_gc_frame`: an intrinsic that pops a GC frame.
+    extern const IntrinsicDescription popGCFrame;
+
+    // `julia.queue_gc_root`: an intrinsic that queues a GC root.
+    extern const IntrinsicDescription queueGCRoot;
 }
 
 #endif

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -5,6 +5,7 @@
 
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Metadata.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Type.h>
@@ -18,7 +19,7 @@ namespace jl_intrinsics {
     // intrinsics and declare new intrinsics if necessary.
     struct IntrinsicDescription final {
         // The type of function that declares an intrinsic.
-        typedef llvm::Function *(*DeclarationFunction)(llvm::Module&, const JuliaPassContext&);
+        typedef llvm::Function *(*DeclarationFunction)(const JuliaPassContext&);
 
         // Creates an intrinsic description with a particular
         // name and declaration function.
@@ -39,8 +40,6 @@ namespace jl_intrinsics {
 // from modules or add them if they're not available yet.
 // Mainly useful for building Julia-specific LLVM passes.
 struct JuliaPassContext {
-    llvm::Module *module;
-
     // Standard types.
     llvm::Type *T_size;
     llvm::Type *T_int8;
@@ -81,6 +80,12 @@ struct JuliaPassContext {
     // Also sets the current module to the given module.
     void initFunctions(llvm::Module &M);
 
+    // Gets the LLVM context for this pass context.
+    llvm::LLVMContext &getLLVMContext() const
+    {
+        return module->getContext();
+    }
+
     // Gets a call to the `julia.ptls_states` intrinisc in the entry
     // point of the given function, if there exists such a call.
     // Otherwise, `nullptr` is returned.
@@ -97,7 +102,10 @@ struct JuliaPassContext {
     // declares the intrinsic or well-known function and adds it
     // to the module.
     llvm::Function *getOrDeclare(
-        const jl_intrinsics::IntrinsicDescription &desc) const;
+        const jl_intrinsics::IntrinsicDescription &desc);
+
+private:
+    llvm::Module *module;
 };
 
 namespace jl_intrinsics {

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -1,0 +1,104 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#ifndef LLVM_PASS_HELPERS_H
+#define LLVM_PASS_HELPERS_H
+
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Metadata.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/Value.h>
+
+struct JuliaPassContext;
+
+// A namespace for Julia intrinsic definitions.
+namespace jl_intrinsics {
+    // A description of an intrinsic that can be used to find existing
+    // intrinsics and materialize new intrinsics if necessary.
+    struct IntrinsicDescription final {
+        // The type of function that defines a new intrinsic.
+        typedef llvm::Function *(*DefinitionFunction)(llvm::Module &M, const JuliaPassContext&);
+
+        // Creates an intrinsic description with a particular
+        // name and definition function.
+        IntrinsicDescription(
+            const llvm::StringRef &name,
+            const DefinitionFunction &define)
+            : name(name), define(define)
+        { }
+
+        // The intrinsic's name.
+        llvm::StringRef name;
+        // A function that defines the intrinsic in a module.
+        DefinitionFunction define;
+    };
+}
+
+// A data structure that can read Julia-specific intrinsics
+// from modules or add them if they're not available yet.
+// Mainly useful for building Julia-specific LLVM passes.
+struct JuliaPassContext {
+    llvm::Module *module;
+
+    llvm::Type *T_prjlvalue;
+    llvm::Type *T_ppjlvalue;
+    llvm::Type *T_size;
+    llvm::Type *T_int8;
+    llvm::Type *T_int32;
+    llvm::Type *T_pint8;
+    llvm::Type *T_pjlvalue;
+    llvm::Type *T_pjlvalue_der;
+    llvm::Type *T_ppjlvalue_der;
+    llvm::MDNode *tbaa_gcframe;
+    llvm::MDNode *tbaa_tag;
+    llvm::Function *ptls_getter;
+    llvm::Function *gc_flush_func;
+    llvm::Function *gc_preserve_begin_func;
+    llvm::Function *gc_preserve_end_func;
+    llvm::Function *pointer_from_objref_func;
+    llvm::Function *alloc_obj_func;
+    llvm::Function *typeof_func;
+    llvm::Function *write_barrier_func;
+
+    // Creates a GC lowering refs structure. Type and function pointers
+    // are set to `nullptr`. Metadata nodes are initialized.
+    JuliaPassContext();
+
+    // Populates a GC lowering refs structure by inspecting a module.
+    // Also sets the current module to the given module.
+    void initAll(llvm::Module &M);
+
+    // Initializes a GC lowering refs structure's functions only.
+    // Also sets the current module to the given module.
+    void initFunctions(llvm::Module &M);
+
+    // Gets a call to the `julia.ptls_states` intrinisc in the entry
+    // point of the given function, if there exists such a call.
+    // Otherwise, `nullptr` is returned.
+    llvm::CallInst *getPtls(llvm::Function &F) const;
+
+    // Gets the intrinsic that conforms to the given description
+    // if it exists in the module. If not, `nullptr` is returned.
+    llvm::Function *getOrNull(
+        const jl_intrinsics::IntrinsicDescription &desc) const;
+
+    // Gets the intrinsic that conforms to the given description
+    // if it exists in the module. If not, creates the intrinsic
+    // and adds it to the module.
+    llvm::Function *getOrDefine(
+        const jl_intrinsics::IntrinsicDescription &desc) const;
+};
+
+namespace jl_intrinsics {
+    // An intrinsic that creates a new GC frame.
+    extern const IntrinsicDescription newGCFrame;
+
+    // An intrinsic that pushes a GC frame.
+    extern const IntrinsicDescription pushGCFrame;
+
+    // An intrinsic that pops a GC frame.
+    extern const IntrinsicDescription popGCFrame;
+}
+
+#endif

--- a/src/llvm-pass-helpers.h
+++ b/src/llvm-pass-helpers.h
@@ -18,7 +18,7 @@ namespace jl_intrinsics {
     // intrinsics and materialize new intrinsics if necessary.
     struct IntrinsicDescription final {
         // The type of function that defines a new intrinsic.
-        typedef llvm::Function *(*DefinitionFunction)(llvm::Module &M, const JuliaPassContext&);
+        typedef llvm::Function *(*DefinitionFunction)(llvm::Module&, const JuliaPassContext&);
 
         // Creates an intrinsic description with a particular
         // name and definition function.
@@ -61,15 +61,15 @@ struct JuliaPassContext {
     llvm::Function *typeof_func;
     llvm::Function *write_barrier_func;
 
-    // Creates a GC lowering refs structure. Type and function pointers
+    // Creates a pass context. Type and function pointers
     // are set to `nullptr`. Metadata nodes are initialized.
     JuliaPassContext();
 
-    // Populates a GC lowering refs structure by inspecting a module.
+    // Populates a pass context by inspecting a module.
     // Also sets the current module to the given module.
     void initAll(llvm::Module &M);
 
-    // Initializes a GC lowering refs structure's functions only.
+    // Initializes a pass context's functions only.
     // Also sets the current module to the given module.
     void initFunctions(llvm::Module &M);
 
@@ -99,6 +99,9 @@ namespace jl_intrinsics {
 
     // An intrinsic that pops a GC frame.
     extern const IntrinsicDescription popGCFrame;
+
+    // An intrinsic that creates a pointer to a GC frame slot.
+    extern const IntrinsicDescription getGCFrameSlot;
 }
 
 #endif

--- a/test/llvmpasses/alloc-opt.jl
+++ b/test/llvmpasses/alloc-opt.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# RUN: julia --startup-file=no %s | opt -load libjulia%shlibext -AllocOpt -LateLowerGCFrame -S - | FileCheck %s
+# RUN: julia --startup-file=no %s | opt -load libjulia%shlibext -AllocOpt -LateLowerGCFrame -FinalLowerGC -S - | FileCheck %s
 
 isz = sizeof(UInt) == 8 ? "i64" : "i32"
 

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -1,0 +1,56 @@
+; RUN: opt -load libjulia%shlibext -FinalLowerGC -S %s | FileCheck %s
+
+%jl_value_t = type opaque
+
+declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
+declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare %jl_value_t*** @julia.ptls_states()
+declare void @jl_safepoint()
+declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
+
+declare noalias nonnull %jl_value_t addrspace(10)** @julia.new_gc_frame(i32)
+declare void @julia.push_gc_frame(%jl_value_t addrspace(10)**, i32)
+declare %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)**, i32)
+declare void @julia.pop_gc_frame(%jl_value_t addrspace(10)**)
+
+define void @gc_frame_lowering(i64 %a, i64 %b) {
+top:
+; CHECK-LABEL: @gc_frame_lowering
+; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+  %gcframe = call %jl_value_t addrspace(10)** @julia.new_gc_frame(i32 2)
+; CHECK: %ptls = call %jl_value_t*** @julia.ptls_states()
+  %ptls = call %jl_value_t*** @julia.ptls_states()
+; CHECK-NEXT: [[GCFRAME_SIZE_PTR:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 0
+; CHECK-NEXT: [[GCFRAME_SIZE_PTR2:%.*]] = bitcast %jl_value_t addrspace(10)** [[GCFRAME_SIZE_PTR]] to i64*
+; CHECK-NEXT: store i64 4, i64* [[GCFRAME_SIZE_PTR2]], !tbaa !0
+; CHECK-NEXT: [[GCFRAME_SLOT:%.*]] = getelementptr %jl_value_t**, %jl_value_t*** %ptls, i32 0
+; CHECK-NEXT: [[PREV_GCFRAME_PTR:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
+; CHECK-NEXT: [[PREV_GCFRAME_PTR2:%.*]] = bitcast %jl_value_t addrspace(10)** [[PREV_GCFRAME_PTR]] to %jl_value_t***
+; CHECK-NEXT: [[PREV_GCFRAME:%.*]] = load %jl_value_t**, %jl_value_t*** [[GCFRAME_SLOT]]
+; CHECK-NEXT: store %jl_value_t** [[PREV_GCFRAME]], %jl_value_t*** [[PREV_GCFRAME_PTR2]], !tbaa !0
+; CHECK-NEXT: [[GCFRAME_SLOT2:%.*]] = bitcast %jl_value_t*** [[GCFRAME_SLOT]] to %jl_value_t addrspace(10)***
+; CHECK-NEXT: store %jl_value_t addrspace(10)** %gcframe, %jl_value_t addrspace(10)*** [[GCFRAME_SLOT2]]
+  call void @julia.push_gc_frame(%jl_value_t addrspace(10)** %gcframe, i32 2)
+  %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: %frame_slot_1 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 3
+  %frame_slot_1 = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 1)
+  store %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)** %frame_slot_1
+  %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
+; CHECK: %frame_slot_2 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 2
+  %frame_slot_2 = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 0)
+  store %jl_value_t addrspace(10)* %bboxed, %jl_value_t addrspace(10)** %frame_slot_2
+; CHECK: call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)* %bboxed)
+  call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)* %bboxed)
+; CHECK-NEXT: [[PREV_GCFRAME_PTR3:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
+; CHECK-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** [[PREV_GCFRAME_PTR3]], !tbaa !0
+; CHECK-NEXT: [[GCFRAME_SLOT3:%.*]] = getelementptr %jl_value_t**, %jl_value_t*** %ptls, i32 0
+; CHECK-NEXT: [[GCFRAME_SLOT4:%.*]] = bitcast %jl_value_t*** [[GCFRAME_SLOT3]] to %jl_value_t addrspace(10)**
+; CHECK-NEXT: store %jl_value_t addrspace(10)* [[PREV_GCFRAME_PTR4]], %jl_value_t addrspace(10)** [[GCFRAME_SLOT4]], !tbaa !0
+  call void @julia.pop_gc_frame(%jl_value_t addrspace(10)** %gcframe)
+; CHECK-NEXT: ret void
+  ret void
+}
+
+!0 = !{!1, !1, i64 0}
+!1 = !{!"jtbaa_gcframe", !2, i64 0}
+!2 = !{!"jtbaa"}

--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
+; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -FinalLowerGC -S %s | FileCheck %s
 
 %jl_value_t = type opaque
 

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -1,12 +1,14 @@
 ; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
 
 %jl_value_t = type opaque
+@tag = external addrspace(10) global %jl_value_t
 
 declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
 declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
 declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
 declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
+declare noalias nonnull %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8*, i64, %jl_value_t addrspace(10)*)
 
 define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
@@ -30,4 +32,18 @@ top:
                             %jl_value_t addrspace(10)* %bboxed)
 ; CHECK-NEXT: call void @julia.pop_gc_frame(%jl_value_t addrspace(10)** %gcframe)
     ret void
+}
+
+define %jl_value_t addrspace(10)* @gc_alloc_lowering() {
+top:
+; CHECK-LABEL: @gc_alloc_lowering
+    %ptls = call %jl_value_t*** @julia.ptls_states()
+    %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
+; CHECK: %v = call %jl_value_t addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
+; CHECK-NEXT: [[V2:%.*]] = bitcast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(10)* addrspace(10)*
+; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* [[V2]], i64 -1
+; CHECK-NEXT: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* [[V_HEADROOM]], !tbaa !0
+    %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, %jl_value_t addrspace(10)* @tag)
+; CHECK-NEXT: ret %jl_value_t addrspace(10)* %v
+    ret %jl_value_t addrspace(10)* %v
 }

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -1,0 +1,33 @@
+; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
+
+%jl_value_t = type opaque
+
+declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
+declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare %jl_value_t*** @julia.ptls_states()
+declare void @jl_safepoint()
+declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
+
+define void @gc_frame_lowering(i64 %a, i64 %b) {
+top:
+; CHECK-LABEL: @gc_frame_lowering
+; CHECK: %gcframe = call %jl_value_t addrspace(10)** @julia.new_gc_frame(i32 2)
+    %ptls = call %jl_value_t*** @julia.ptls_states()
+; CHECK: %ptls = call %jl_value_t*** @julia.ptls_states()
+; CHECK-NEXT: call void @julia.push_gc_frame(%jl_value_t addrspace(10)** %gcframe, i32 2)
+; CHECK-NEXT: call %jl_value_t addrspace(10)* @jl_box_int64
+    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
+; CHECK: [[GEP0:%.*]] = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]])
+; CHECK-NEXT: store %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)** [[GEP0]]
+    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
+; CHECK-NEXT: %bboxed =
+; Make sure the same gc slot isn't re-used
+; CHECK-NOT: call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0]])
+; CHECK: [[GEP1:%.*]] = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT1:[0-9]+]])
+; CHECK-NEXT: store %jl_value_t addrspace(10)* %bboxed, %jl_value_t addrspace(10)** [[GEP1]]
+; CHECK-NEXT: call void @boxed_simple
+    call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed,
+                            %jl_value_t addrspace(10)* %bboxed)
+; CHECK-NEXT: call void @julia.pop_gc_frame(%jl_value_t addrspace(10)** %gcframe)
+    ret void
+}

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
+; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -FinalLowerGC -S %s | FileCheck %s
 
 %jl_value_t = type opaque
 

--- a/test/llvmpasses/returnstwicegc.ll
+++ b/test/llvmpasses/returnstwicegc.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
+; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -FinalLowerGC -S %s | FileCheck %s
 
 %jl_value_t = type opaque
 

--- a/test/llvmpasses/safepoint_stress.jl
+++ b/test/llvmpasses/safepoint_stress.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-# RUN: julia --startup-file=no %s | opt -load libjulia%shlibext -LateLowerGCFrame -S - | FileCheck %s
+# RUN: julia --startup-file=no %s | opt -load libjulia%shlibext -LateLowerGCFrame -FinalLowerGC -S - | FileCheck %s
 
 println("""
 %jl_value_t = type opaque


### PR DESCRIPTION
Hello! This is my first PR here. I'm an MSc student working on making CUDAnative interact more organically with the Julia compiler. @maleadt is my supervisor. (Hi, Tim)

Some background: I'm proposing the changes in this PR in order to make GPU codegen more efficient for constructs that require GC support. The `LateLowerGCFrame` pass performs desirable platform-agnostic optimizations and we'd like to enable it in the CUDAnative pass pipeline. Sadly, we actually can't do that at the moment because `LateLowerGCFrame` also lowers GC intrinsics to LLVM IR that can only be expected to work on a CPU. See [1] for an issue where this is discussed in a little more depth.

This PR retains only the platform-agnostic aspects of `LateLowerGCFrame` and moves the CPU-specific parts into a new pass called `FinalLowerGC`. This doesn't change any of the resulting codegen for CPU platforms, but it should make `LateLowerGCFrame` eligible for reuse by CUDAnative.

I also added a helper file (`llvm-pass-helpers.{cpp,h}`) that contains functionality used by both the `LateLowerGCFrame` and `FinalLowerGC` passes—creating some helper functions and types seemed like a much more appropriate solution than duplicating code shared by `LateLowerGCFrame` and `FinalLowerGC`.

The helper functions/types mostly deal with scanning an `llvm::Module&` for Julia types, intrinsics and well-known functions. I did my best to design the helpers in such a way that they'll also be useful to other passes. For example, the initialization logic in `AllocOpt` could be simplified by using the helpers.

Anyway, I'd love to get some feedback on this PR and I'm happy to make changes accordingly. Thanks!

[1]: https://github.com/JuliaGPU/CUDAnative.jl/issues/340