### PR TITLE
Don't assume the user is using getfield correctly

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -526,8 +526,10 @@ function getfield_elim_pass!(ir::IRCode, domtree::DomTree)
         # Step 1: Check whether the statement we're looking at is a getfield/setfield!
         if is_known_call(stmt, setfield!, compact)
             is_setfield = true
+            4 <= length(stmt.args) <= 5 || continue
         elseif is_known_call(stmt, getfield, compact)
             is_getfield = true
+            3 <= length(stmt.args) <= 4 || continue
         elseif is_known_call(stmt, isa, compact)
             # TODO
             continue

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -89,3 +89,12 @@ function f(x::Vector{T}) where {T}
 end
 
 @test f([Bar29983(1.0)]).x[1].x == 2.0
+
+# Issue #31139 - Checking for correct number of arguments in getfield elim
+let nt = (a=1, b=2)
+    blah31139(x) = getfield(x)
+    # Shouldn't throw
+    @test isa(code_typed(blah31139, Tuple{typeof(nt)}), Array)
+    # Should throw
+    @test_throws ArgumentError blah31139(nt)
+end


### PR DESCRIPTION
Sometimes there's fewer arguments than we expect. Fixes #31139.