### PR TITLE
Make StridedArray display as StridedArray

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -150,6 +150,8 @@ Standard library changes
   ambiguity.
 * `close` on a file (`IOStream`) can now throw an exception if an error occurs when trying
   to flush buffered data to disk ([#35303]).
+* The large `StridedArray` `Union` now has special printing to avoid printing out its entire
+  contents ([#31149]).
 
 #### LinearAlgebra
 * The BLAS submodule now supports the level-2 BLAS subroutine `hpmv!` ([#34211]).

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2373,9 +2373,10 @@ Base.setproperty!
 """
     StridedArray{T, N}
 
-An `N` dimensional *strided* array with elements of type `T`. These arrays follow
-the [strided array interface](@ref man-interface-strided-arrays). If `A` is a
-`StridedArray`, then its elements are stored in memory with offsets, which may
+A hard-coded [`Union`](@ref) of common array types that follow the [strided array interface](@ref man-interface-strided-arrays),
+with elements of type `T` and `N` dimensions.
+
+If `A` is a `StridedArray`, then its elements are stored in memory with offsets, which may
 vary between dimensions but are constant within a dimension. For example, `A` could
 have stride 2 in dimension 1, and stride 3 in dimension 2. Incrementing `A` along
 dimension `d` jumps in memory by [`strides(A, d)`] slots. Strided arrays are

--- a/base/show.jl
+++ b/base/show.jl
@@ -490,6 +490,22 @@ function show(io::IO, @nospecialize(x::Type))
         show_datatype(io, x)
         return
     elseif x isa Union
+        if x.a isa DataType && Core.Compiler.typename(x.a) === Core.Compiler.typename(DenseArray)
+            T, N = x.a.parameters
+            if x == StridedArray{T,N}
+                print(io, "StridedArray")
+                show_delim_array(io, (T,N), '{', ',', '}', false)
+                return
+            elseif x == StridedVecOrMat{T}
+                print(io, "StridedVecOrMat")
+                show_delim_array(io, (T,), '{', ',', '}', false)
+                return
+            elseif StridedArray{T,N} <: x
+                print(io, "Union")
+                show_delim_array(io, vcat(StridedArray{T,N}, uniontypes(Core.Compiler.typesubtract(x, StridedArray{T,N}))), '{', ',', '}', false)
+                return
+            end
+        end
         print(io, "Union")
         show_delim_array(io, uniontypes(x), '{', ',', '}', false)
         return

--- a/test/show.jl
+++ b/test/show.jl
@@ -1909,6 +1909,16 @@ end
     @test replstr(Set(['a'^100])) == "Set{String} with 1 element:\n  \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…"
 end
 
+@testset "Simple printing of StridedArray" begin
+    @test startswith(sprint(show, StridedArray), "StridedArray")
+    @test startswith(sprint(show, StridedVecOrMat), "StridedVecOrMat")
+    @test startswith(sprint(show, StridedVector), "Strided")
+    @test startswith(sprint(show, StridedMatrix), "Strided")
+    @test occursin("StridedArray", sprint(show, SubArray{T, N, A} where {T,N,A<:StridedArray}))
+    @test !occursin("Strided", sprint(show, Union{DenseArray, SubArray}))
+    @test !occursin("Strided", sprint(show, Union{DenseArray, Base.ReinterpretArray, Base.ReshapedArray, SubArray}))
+end
+
 @testset "0-dimensional Array. Issue #31481" begin
     for x in (zeros(Int32), collect('b'), fill(nothing), BitArray(0))
         @test eval(Meta.parse(repr(x))) == x


### PR DESCRIPTION
Instead of a huge union.  This is just a special-casing for this particular union instead of pursuing the general (and hard\!) typealias search.  But given the ubiquity of StridedArray in method lists, I find this special case to be warranted and hugely beneficial. Here is a sampling from `methods(*)`:

```julia
[242] *(A::LinearAlgebra.AbstractQ, b::StridedArray{T, 1} where T) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/qr.jl:556
[243] *(A::LinearAlgebra.AbstractQ, B::StridedArray{T, 2} where T) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/qr.jl:568
[244] *(Q::LinearAlgebra.AbstractQ, adjB::LinearAlgebra.Adjoint{#s614,#s613} where #s613<:(StridedVecOrMat{T} where T) where #s614) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/qr.jl:623
[245] *(A::StridedArray{T, 2} where T, Q::LinearAlgebra.AbstractQ) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/qr.jl:668
[246] *(A::StridedArray{T, 2} where T, adjB::LinearAlgebra.Adjoint{#s614,#s613} where #s613<:LinearAlgebra.AbstractQ where #s614) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/qr.jl:708
[247] *(A::LinearAlgebra.LQPackedQ, B::StridedVecOrMat{T} where T) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/lq.jl:153
[248] *(A::LinearAlgebra.LQPackedQ, adjB::LinearAlgebra.Adjoint{#s614,#s613} where #s613<:(StridedVecOrMat{T} where T) where #s614) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/lq.jl:177
[249] *(A::StridedVecOrMat{T} where T, adjQ::LinearAlgebra.Adjoint{#s614,#s613} where #s613<:LinearAlgebra.LQPackedQ where #s614) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/lq.jl:216
[250] *(A::StridedVecOrMat{T} where T, Q::LinearAlgebra.LQPackedQ) in LinearAlgebra at /home/mbauman/julia/usr/share/julia/stdlib/v1.2/LinearAlgebra/src/lq.jl:240
```