### PR TITLE
Fix a bug in implementation of rank

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -756,7 +756,7 @@ Compute the rank of a matrix by counting how many singular
 values of `A` have magnitude greater than `max(atol, rtol*σ₁)` where `σ₁` is
 `A`'s largest singular value. `atol` and `rtol` are the absolute and relative
 tolerances, respectively. The default relative tolerance is `n*ϵ`, where `n`
-is the size of the smallest dimension of `A`, and `ϵ` is the [`eps`](@ref) of
+is the size of the largest dimension of `A`, and `ϵ` is the [`eps`](@ref) of
 the element type of `A`.
 
 !!! compat "Julia 1.1"
@@ -782,7 +782,7 @@ julia> rank(diagm(0 => [1, 0.001, 2]), atol=1.5)
 1
 ```
 """
-function rank(A::AbstractMatrix; atol::Real = 0.0, rtol::Real = (min(size(A)...)*eps(real(float(one(eltype(A))))))*iszero(atol))
+function rank(A::AbstractMatrix; atol::Real = 0.0, rtol::Real = (max(size(A)...)*eps(real(float(one(eltype(A))))))*iszero(atol))
     isempty(A) && return 0 # 0-dimensional case
     s = svdvals(A)
     tol = max(atol, rtol*s[1])

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -179,6 +179,40 @@ end
 @test rank([1.0 0.0; 0.0 0.9],rtol=0.95) == 1
 @test rank([1.0 0.0; 0.0 0.9],atol=0.95) == 1
 @test rank([1.0 0.0; 0.0 0.9],atol=0.95,rtol=0.95)==1
+
+Id = zeros(4, 4)
+for i = 1:4
+    Id[i, i] = 1.0
+end
+
+@test rank(Id) == 4
+Id[4, 4] = 0
+@test rank(Id) == 3
+@test rank(zeros(500, 2)) == 0
+@test rank(ones(500,2)) == 1
+@test rank([1 0 0 0]) == 1
+@test rank(zeros(4,1)) == 0
+
+Id[4, 4] = 1e-8
+@test rank(Id,0.99e-8) == 4
+@test rank(Id,atol=0.99e-8) == 4
+@test rank(Id,rtol=0.99e-8) == 4
+@test rank(Id,atol=0.99e-8,rtol=0.99e-8) == 4
+@test rank(Id,1.01e-8) == 3
+@test rank(Id,atol=1.01e-8) == 3
+@test rank(Id,rtol=1.01e-8) == 3
+@test rank(Id,atol=1.01e-8,rtol=1.01e-8) == 3
+
+@testset "test_rank" begin
+    for i = 1:10
+        X = randn(40, 10)
+        X[:, 1] = X[:, 2] + X[:, 3]
+        @test rank(X) == 9
+        X[:, 6] = X[:, 8] + X[:, 9]
+        @test rank(X) == 8
+    end
+end
+
 @test qr(big.([0 1; 0 0])).R == [0 1; 0 0]
 
 @test norm([2.4e-322, 4.4e-323]) ≈ 2.47e-322


### PR DESCRIPTION
Made the implementation same as that of numpy.  This fixes JuliaLang/LinearAlgebra.jl#604 