### PR TITLE
fix method overwrite in new 0-arg Ptr constructor

### DIFF
--- a/base/boot.jl
+++ b/base/boot.jl
@@ -721,6 +721,7 @@ Int64(x::Ptr) = Int64(UInt32(x))
 UInt64(x::Ptr) = UInt64(UInt32(x))
 end
 Ptr{T}(x::Union{Int,UInt,Ptr}) where {T} = bitcast(Ptr{T}, x)
+Ptr{T}() where {T} = Ptr{T}(0)
 
 Signed(x::UInt8)    = Int8(x)
 Unsigned(x::Int8)   = UInt8(x)

--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -1751,6 +1751,13 @@ julia> Array{Float64,1}(undef, 3)
 undef
 
 """
+    Ptr{T}()
+
+Creates a null pointer to type `T`.
+"""
+Ptr{T}()
+
+"""
     +(x, y...)
 
 Addition operator. `x+y+z+...` calls this function with all arguments, i.e. `+(x, y, z, ...)`.

--- a/base/pointer.jl
+++ b/base/pointer.jl
@@ -8,13 +8,6 @@ memory is actually valid, or that it actually represents data of the specified t
 """
 Ptr
 
-"""
-    Ptr{T}()
-
-Creates a null pointer to type `T`.
-"""
-Ptr{T}() where {T} = Ptr{T}(C_NULL)
-
 ## converting pointers to an appropriate unsigned ##
 
 """


### PR DESCRIPTION
Unfortunately putting this docstring in `pointer.jl` doesn't work (I think it needs the full version of the docsystem to be able to handle `Ptr{T}()` as a signature).