### PR TITLE
Make broadcast eltype widening type-stable

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -963,6 +963,15 @@ end
 @noinline throwdm(axdest, axsrc) =
     throw(DimensionMismatch("destination axes $axdest are not compatible with source axes $axsrc"))
 
+function restart_copyto_nonleaf!(newdest, dest, bc, val, I, iter, state, count)
+    # Function barrier that makes the copying to newdest type stable
+    for II in Iterators.take(iter, count)
+        newdest[II] = dest[II]
+    end
+    newdest[I] = val
+    return copyto_nonleaf!(newdest, bc, iter, state, count+1)
+end
+
 function copyto_nonleaf!(dest, bc::Broadcasted, iter, state, count)
     T = eltype(dest)
     while true
@@ -976,11 +985,7 @@ function copyto_nonleaf!(dest, bc::Broadcasted, iter, state, count)
             # This element type doesn't fit in dest. Allocate a new dest with wider eltype,
             # copy over old values, and continue
             newdest = Base.similar(dest, promote_typejoin(T, typeof(val)))
-            for II in Iterators.take(iter, count)
-                newdest[II] = dest[II]
-            end
-            newdest[I] = val
-            return copyto_nonleaf!(newdest, bc, iter, state, count+1)
+            return restart_copyto_nonleaf!(newdest, dest, bc, val, I, iter, state, count)
         end
         count += 1
     end


### PR DESCRIPTION
The broadcast code that copies to the new array was type-unstable, causing allocation and slowdown in `v2`:

Before:

```julia
julia> using BenchmarkTools

julia> v = fill(2.0, 50000);

julia> v2 = vcat(v, missing);

julia> v3 = vcat(missing, v);

julia> @btime $v .* 3.0;
  49.728 μs (2 allocations: 390.70 KiB)

julia> @btime $v2 .* 3.0;
  1.490 ms (99498 allocations: 2.33 MiB)

julia> @btime $v3 .* 3.0;
  103.577 μs (7 allocations: 439.77 KiB)
```

After:

```julia
julia> @btime $v .* 3.0;
  50.147 μs (2 allocations: 390.70 KiB)

julia> @btime $v2 .* 3.0;
  147.158 μs (8 allocations: 830.45 KiB)

julia> @btime $v3 .* 3.0;
  92.611 μs (7 allocations: 439.77 KiB)
```

This fixes the second half of https://github.com/JuliaLang/julia/issues/30455. First half was fixed by https://github.com/JuliaLang/julia/pull/30480