### PR TITLE
Add `ldiv!` and `rdiv!` for arrays with numbers and UniformScaling

### DIFF
--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -122,7 +122,12 @@ julia> rdiv!(A, 2.0)
  1.5  2.0
 ```
 """
-rdiv!(X::AbstractArray, s::Number) = rmul!(X, inv(s))
+function rdiv!(X::AbstractArray, s::Number)
+    @simd for I in eachindex(X)
+        @inbounds X[I] /= s
+    end
+    X
+end
 
 """
     ldiv!(a::Number, B::AbstractArray)
@@ -143,7 +148,12 @@ julia> ldiv!(2.0, B)
  1.5  2.0
 ```
 """
-ldiv!(s::Number, X::AbstractArray) = lmul!(inv(s), X)
+function ldiv!(s::Number, X::AbstractArray)
+    @simd for I in eachindex(X)
+        @inbounds X[I] = s\X[I]
+    end
+    X
+end
 
 """
     cross(x, y)

--- a/stdlib/LinearAlgebra/src/generic.jl
+++ b/stdlib/LinearAlgebra/src/generic.jl
@@ -104,6 +104,48 @@ function lmul!(s::Number, X::AbstractArray)
 end
 
 """
+    rdiv!(A::AbstractArray, b::Number)
+
+Divide each entry in an array `A` by a scalar `b` overwriting `A`
+in-place.  Use [`ldiv!`](@ref) to divide scalar from left.
+
+# Examples
+```jldoctest
+julia> A = [1.0 2.0; 3.0 4.0]
+2×2 Array{Float64,2}:
+ 1.0  2.0
+ 3.0  4.0
+
+julia> rdiv!(A, 2.0)
+2×2 Array{Float64,2}:
+ 0.5  1.0
+ 1.5  2.0
+```
+"""
+rdiv!(X::AbstractArray, s::Number) = rmul!(X, inv(s))
+
+"""
+    ldiv!(a::Number, B::AbstractArray)
+
+Divide each entry in an array `B` by a scalar `a` overwriting `B`
+in-place.  Use [`rdiv!`](@ref) to divide scalar from right.
+
+# Examples
+```jldoctest
+julia> B = [1.0 2.0; 3.0 4.0]
+2×2 Array{Float64,2}:
+ 1.0  2.0
+ 3.0  4.0
+
+julia> ldiv!(2.0, B)
+2×2 Array{Float64,2}:
+ 0.5  1.0
+ 1.5  2.0
+```
+"""
+ldiv!(s::Number, X::AbstractArray) = lmul!(inv(s), X)
+
+"""
     cross(x, y)
     ×(x,y)
 

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -219,6 +219,8 @@ mul!(C::AbstractMatrix, A::AbstractMatrix, J::UniformScaling) = mul!(C, A, J.λ)
 mul!(C::AbstractVecOrMat, J::UniformScaling, B::AbstractVecOrMat) = mul!(C, J.λ, B)
 rmul!(A::AbstractMatrix, J::UniformScaling) = rmul!(A, J.λ)
 lmul!(J::UniformScaling, B::AbstractVecOrMat) = lmul!(J.λ, B)
+rdiv!(A::AbstractMatrix, J::UniformScaling) = rdiv!(A, J.λ)
+ldiv!(J::UniformScaling, B::AbstractVecOrMat) = ldiv!(J.λ, B)
 
 Broadcast.broadcasted(::typeof(*), x::Number,J::UniformScaling) = UniformScaling(x*J.λ)
 Broadcast.broadcasted(::typeof(*), J::UniformScaling,x::Number) = UniformScaling(J.λ*x)

--- a/stdlib/LinearAlgebra/test/generic.jl
+++ b/stdlib/LinearAlgebra/test/generic.jl
@@ -116,6 +116,11 @@ end
             @test_throws DimensionMismatch rmul!(a, Diagonal(Vector{Float64}(undef,an+1)))
         end
 
+        @testset "Scaling with rdiv! and ldiv!" begin
+            @test rdiv!(copy(a), 5.) == a/5
+            @test ldiv!(5., copy(a)) == a/5
+        end
+
         @testset "Scaling with 3-argument mul!" begin
             @test mul!(similar(a), 5., a) == a*5
             @test mul!(similar(a), a, 5.) == a*5

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -300,15 +300,18 @@ end
     @test_throws MethodError I .+ [1 1; 1 1]
 end
 
-@testset "in-place mul! methods" begin
+@testset "in-place mul! and div! methods" begin
     J = randn()*I
     A = randn(4, 3)
     C = similar(A)
-    target = J * A
-    @test mul!(C, J, A) == target
-    @test mul!(C, A, J) == target
-    @test lmul!(J, copyto!(C, A)) == target
-    @test rmul!(copyto!(C, A), J) == target
+    target_mul = J * A
+    target_div = A / J
+    @test mul!(C, J, A) == target_mul
+    @test mul!(C, A, J) == target_mul
+    @test lmul!(J, copyto!(C, A)) == target_mul
+    @test rmul!(copyto!(C, A), J) == target_mul
+    @test ldiv!(J, copyto!(C, A)) == target_div
+    @test rdiv!(copyto!(C, A), J) == target_div
 end
 
 @testset "Construct Diagonal from UniformScaling" begin


### PR DESCRIPTION
This PR implements some rudimentary definitions of `ldiv!(scalar, array)` and `rdiv!(array, scalar)`.  The motivation for this PR is two–fold: 1) convenience, and 2) I discovered that in most cases, `rmul!(copy(array), inv(scalar))` introduces floating point noise that you don't get from, e.g., `array / scalar`.