### PR TITLE
Print timings to stderr in stead of stdout, when using ENABLE_TIMINGS.

### DIFF
--- a/src/timing.c
+++ b/src/timing.c
@@ -29,7 +29,7 @@ void jl_print_timings(void)
     }
     for (int i = 0; i < JL_TIMING_LAST; i++) {
         if (jl_timing_data[i] != 0)
-            printf("%-25s : %.2f %%   %" PRIu64 "\n", jl_timing_names[i],
+            fprintf(stderr,"%-25s : %.2f %%   %" PRIu64 "\n", jl_timing_names[i],
                     100 * (((double)jl_timing_data[i]) / total_time), jl_timing_data[i]);
     }
 }


### PR DESCRIPTION
This makes it possible to use a version of julia compiled with ENABLE_TIMINGS
in projects that use e.g. CxxWrap, which depend on some output that is printed
to stdout. Also, it is better not to use stdout with debug/info messages.