### PR TITLE
xref for the show macro

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -564,7 +564,7 @@ show_supertypes(typ::DataType) = show_supertypes(stdout, typ)
 """
     @show
 
-Show an expression and result, returning the result.
+Show an expression and result, returning the result. See also [`show`](@ref).
 """
 macro show(exs...)
     blk = Expr(:block)


### PR DESCRIPTION
it grinds my gears the macro, which many people are likely to use, doesn't link to the main `show()` documentation.