### PR TITLE
more backticks, xrefs, and doctests for essentials and basedocs

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -104,7 +104,7 @@ kw"module"
     baremodule
 
 `baremodule` declares a module that does not contain `using Base`
-or a definition of `eval`. It does still import `Core`.
+or a definition of [`eval`](@ref Base.eval). It does still import `Core`.
 """
 kw"baremodule"
 
@@ -133,7 +133,7 @@ kw"primitive type"
 A macro maps a sequence of argument expressions to a returned expression, and the
 resulting expression is substituted directly into the program at the point where
 the macro is invoked.
-Macros are a way to run generated code without calling `eval`, since the generated
+Macros are a way to run generated code without calling [`eval`](@ref Base.eval), since the generated
 code instead simply becomes part of the surrounding program.
 Macro arguments may include expressions, literal values, and symbols.
 
@@ -270,7 +270,7 @@ julia> push!(a, 2, 3)
  3
 
 ```
-Assigning `[]` does not eliminate elements from a collection; instead use `filter!`.
+Assigning `[]` does not eliminate elements from a collection; instead use [`filter!`](@ref).
 ```jldoctest
 julia> a = collect(1:3); a[a .<= 1] = []
 ERROR: DimensionMismatch("tried to assign 0 elements to 1 destinations")
@@ -329,7 +329,7 @@ kw"quote"
     Expr(head::Symbol, args...)
 
 A type representing compound expressions in parsed julia code (ASTs).
-Each expression consists of a `head` Symbol identifying which kind of
+Each expression consists of a `head` `Symbol` identifying which kind of
 expression it is (e.g. a call, for loop, conditional statement, etc.),
 and subexpressions (e.g. the arguments of a call).
 The subexpressions are stored in a `Vector{Any}` field called `args`.
@@ -870,7 +870,7 @@ The `where` keyword creates a type that is an iterated union of other types, ove
 values of some variable. For example `Vector{T} where T<:Real` includes all [`Vector`](@ref)s
 where the element type is some kind of `Real` number.
 
-The variable bound defaults to `Any` if it is omitted:
+The variable bound defaults to [`Any`](@ref) if it is omitted:
 
 ```julia
 Vector{T} where T    # short for `where T<:Any`
@@ -910,7 +910,7 @@ kw"ans"
     devnull
 
 Used in a stream redirect to discard all data written to it. Essentially equivalent to
-/dev/null on Unix or NUL on Windows. Usage:
+`/dev/null` on Unix or `NUL` on Windows. Usage:
 
 ```julia
 run(pipeline(`cat test.txt`, devnull))
@@ -947,6 +947,7 @@ Core.TypeofBottom
 
 Abstract type of all functions.
 
+# Examples
 ```jldoctest
 julia> isa(+, Function)
 true
@@ -972,7 +973,7 @@ ReadOnlyMemoryError
 
 Generic error type. The error message, in the `.msg` field, may provide more specific details.
 
-# Example
+# Examples
 ```jldoctest
 julia> ex = ErrorException("I've done a bad thing");
 
@@ -995,6 +996,21 @@ Core.WrappedException
     UndefRefError()
 
 The item or field is not defined for the given object.
+
+# Examples
+```jldoctest
+julia> struct MyType
+           a::Int
+       end
+
+julia> A = MyType(5)
+MyType(5)
+
+julia> getfield(A, b)
+ERROR: UndefVarError: b not defined
+Stacktrace:
+[...]
+```
 """
 UndefRefError
 
@@ -1185,6 +1201,20 @@ UndefVarError
     UndefKeywordError(var::Symbol)
 
 The required keyword argument `var` was not assigned in a function call.
+
+# Examples
+```jldoctest; filter = r"Stacktrace:(\\n \\[[0-9]+\\].*)*"
+julia> function my_func(;my_arg)
+           return my_arg + 1
+       end
+my_func (generic function with 1 method)
+
+julia> my_func()
+ERROR: UndefKeywordError: keyword argument my_arg not assigned
+Stacktrace:
+ [1] my_func() at ./REPL[1]:2
+ [2] top-level scope at REPL[2]:1
+```
 """
 UndefKeywordError
 
@@ -1881,7 +1911,7 @@ AssertionError
 """
     LoadError(file::AbstractString, line::Int, error)
 
-An error occurred while `include`ing, `require`ing, or [`using`](@ref) a file. The error specifics
+An error occurred while [`include`](@ref Base.include)ing, [`require`](@ref Base.require)ing, or [`using`](@ref) a file. The error specifics
 should be available in the `.error` field.
 """
 LoadError
@@ -2029,8 +2059,16 @@ kw"Base"
 """
     typeassert(x, type)
 
-Throw a TypeError unless `x isa type`.
+Throw a [`TypeError`](@ref) unless `x isa type`.
 The syntax `x::type` calls this function.
+
+# Examples
+```jldoctest
+julia> typeassert(2.5, Int)
+ERROR: TypeError: in typeassert, expected Int64, got Float64
+Stacktrace:
+[...]
+```
 """
 typeassert
 

--- a/base/loading.jl
+++ b/base/loading.jl
@@ -756,7 +756,7 @@ In a module, declare that the file specified by `path` (relative or absolute) is
 dependency for precompilation; that is, the module will need to be recompiled if this file
 changes.
 
-This is only needed if your module depends on a file that is not used via `include`. It has
+This is only needed if your module depends on a file that is not used via [`include`](@ref). It has
 no effect outside of compilation.
 """
 function include_dependency(path::AbstractString)
@@ -797,22 +797,23 @@ const modules_warned_for = Set{PkgId}()
 """
     require(into::Module, module::Symbol)
 
-This function is part of the implementation of `using` / `import`, if a module is not
+This function is part of the implementation of [`using`](@ref) / [`import`](@ref), if a module is not
 already defined in `Main`. It can also be called directly to force reloading a module,
 regardless of whether it has been loaded before (for example, when interactively developing
 libraries).
 
 Loads a source file, in the context of the `Main` module, on every active node, searching
 standard locations for files. `require` is considered a top-level operation, so it sets the
-current `include` path but does not use it to search for files (see help for `include`).
+current `include` path but does not use it to search for files (see help for [`include`](@ref)).
 This function is typically used to load library code, and is implicitly called by `using` to
 load packages.
 
 When searching for files, `require` first looks for package code in the global array
-`LOAD_PATH`. `require` is case-sensitive on all platforms, including those with
+[`LOAD_PATH`](@ref). `require` is case-sensitive on all platforms, including those with
 case-insensitive filesystems like macOS and Windows.
 
-For more details regarding code loading, see the manual.
+For more details regarding code loading, see the manual sections on [modules](@ref modules) and
+[parallel computing](@ref code-availability).
 """
 function require(into::Module, mod::Symbol)
     uuidkey = identify_package(into, String(mod))
@@ -1006,7 +1007,7 @@ end
 """
     include_string(m::Module, code::AbstractString, filename::AbstractString="string")
 
-Like `include`, except reads code from the given string rather than from a file.
+Like [`include`](@ref), except reads code from the given string rather than from a file.
 """
 include_string(m::Module, txt::String, fname::String) =
     ccall(:jl_load_file_string, Any, (Ptr{UInt8}, Csize_t, Cstring, Any),
@@ -1053,7 +1054,7 @@ end
     Base.include([m::Module,] path::AbstractString)
 
 Evaluate the contents of the input source file in the global scope of module `m`.
-Every module (except those defined with `baremodule`) has its own 1-argument
+Every module (except those defined with [`baremodule`](@ref)) has its own 1-argument
 definition of `include`, which evaluates the file in that module.
 Returns the result of the last evaluated expression of the input file. During including,
 a task-local include path is set to the directory containing the file. Nested calls to
@@ -1065,7 +1066,7 @@ Base.include # defined in sysimg.jl
 """
     evalfile(path::AbstractString, args::Vector{String}=String[])
 
-Load the file using [`Base.include`](@ref), evaluate all expressions,
+Load the file using [`include`](@ref), evaluate all expressions,
 and return the value of the last one.
 """
 function evalfile(path::AbstractString, args::Vector{String}=String[])

--- a/doc/src/manual/parallel-computing.md
+++ b/doc/src/manual/parallel-computing.md
@@ -638,7 +638,7 @@ the same time.
 
 
 
-## Code Availability and Loading Packages
+## [Code Availability and Loading Packages](@id code-availability)
 
 Your code must be available on any process that runs it. For example, type the following into
 the Julia prompt:

--- a/stdlib/Distributed/src/pmap.jl
+++ b/stdlib/Distributed/src/pmap.jl
@@ -15,7 +15,7 @@ For multiple collection arguments, apply `f` elementwise.
 Results are returned in order as they become available.
 
 Note that `f` must be made available to all worker processes; see
-[Code Availability and Loading Packages](@ref)
+[Code Availability and Loading Packages](@ref code-availability)
 for details.
 """
 function pgenerate(p::WorkerPool, f, c)
@@ -38,7 +38,7 @@ workers and tasks.
 For multiple collection arguments, apply `f` elementwise.
 
 Note that `f` must be made available to all worker processes; see
-[Code Availability and Loading Packages](@ref) for details.
+[Code Availability and Loading Packages](@ref code-availability) for details.
 
 If a worker pool is not specified, all available workers, i.e., the default worker pool
 is used.


### PR DESCRIPTION
added a bunch of stuff we can now cross-reference, and more doctests to things that needed them. added an `@id` for code-availability so I had to adjust the links in `pmap.jl`. Doctests passed locally.