### PR TITLE
Fix `-`, `conj`, and `conj!` for sparse matrices with invalid entries  in `nzval`

### DIFF
--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2518,4 +2518,16 @@ end
     @test_throws ArgumentError sparse(I1, J1, zero(length(I1)zero(length(I1))))
 end
 
+@testset "unary operations on matrices where length(nzval)>nnz" begin
+    # this should create a sparse matrix with length(nzval)>nnz
+    A = SparseMatrixCSC(Complex{BigInt}[1+im 2+2im]')'[1:1, 2:2]
+    # ...ensure it does! If necessary, the test needs to be updated to use
+    # another mechanism to create a suitable A.
+    @assert length(A.nzval) > nnz(A)
+    @test -A == fill(-2-2im, 1, 1)
+    @test conj(A) == fill(2-2im, 1, 1)
+    conj!(A)
+    @test A == fill(2-2im, 1, 1)
+end
+
 end # module


### PR DESCRIPTION
Ref. https://github.com/JuliaLang/julia/issues/30662#issuecomment-467436621. I chose to keep the extra elements in `nzval`, just not apply `-` or `conj` to them, respectively. This should be minimally invasive and hence safe for backporting. In the future, we might consider instead dropping extra entries in these functions.