### PR TITLE
Allow constant-folding intrinsics that are non-pure for inference only

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -252,15 +252,19 @@ function optimize(opt::OptimizationState, @nospecialize(result))
     nothing
 end
 
-
-# whether `f` is pure for inference
-function is_pure_intrinsic_infer(f::IntrinsicFunction)
+# whether `f` is pure for optimization purposes
+function is_pure_intrinsic_optimize(f::IntrinsicFunction)
     return !(f === Intrinsics.pointerref || # this one is volatile
              f === Intrinsics.pointerset || # this one is never effect-free
              f === Intrinsics.llvmcall ||   # this one is never effect-free
              f === Intrinsics.arraylen ||   # this one is volatile
-             f === Intrinsics.sqrt_llvm ||  # this one may differ at runtime (by a few ulps)
              f === Intrinsics.cglobal)  # cglobal lookup answer changes at runtime
+end
+
+# whether `f` is pure for inference
+is_pure_intrinsic_optimize_only(f) = f === Intrinsics.sqrt_llvm # this one may differ by a few ulps at runtime
+function is_pure_intrinsic_infer(f::IntrinsicFunction)
+    return is_pure_intrinsic_optimize(f) && !is_pure_intrinsic_optimize_only(f)
 end
 
 # whether `f` is effect free if nothrow

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -247,3 +247,14 @@ let code = code_typed(f_pointerref, Tuple{Type{Int}})[1][1].code
     end
     @test !any_ptrref
 end
+
+f_sqrt() = sqrt(2)
+let code = code_typed(f_sqrt, Tuple{})[1][1].code
+    @test length(code) == 1
+    @test isa(code[1], Expr) && code[1].head == :return && isa(code[1].args[1], Float64)
+end
+# Make sure that the optimization doesn't apply to invalid calls
+f_sqrt_wrong() = Base.Math.sqrt_llvm(1.0, 2.0)
+let (ci, rt) = (code_typed(f_sqrt_wrong, Tuple{})[1])
+    @test rt === Union{}
+end


### PR DESCRIPTION
Any constants produced during inference must be *exact* (in the === to
what would have been produced at runtime sense). As a result, we disallow
constant folding the sqrt intrinsic, since we can't guarantee that this
will be the case (depending on what LLVM decides to do). However, this does
not apply to the optimizer (and in fact we do it all the time by inlining
pure functions here). Thus, for code size, inlining heuristics and non-LLVM
backends, enable the optimizer to constant fold sqrt.

Before:
```
julia> f() = sqrt(2)
f (generic function with 1 method)

julia> @code_typed f()
CodeInfo(
1 ─ %1 = Base.Math.sqrt_llvm(2.0)::Float64
└──      return %1
) => Float64

julia> @code_typed optimize=false f()
CodeInfo(
1 ─ %1 = Main.sqrt(2)::Float64
└──      return %1
) => Float64
```

After
```
julia> @code_typed f()
CodeInfo(
1 ─     return 1.4142135623730951
) => Float64

julia> @code_typed optimize=false f()
CodeInfo(
1 ─ %1 = Main.sqrt(2)::Float64
└──      return %1
) => Float64
```

Note that we are not able to infer `Const`, but still inline the
constant in the optimized version of the IR.