### PR TITLE
Don't export `reindex` and `substrides`

### DIFF
--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -166,7 +166,7 @@ function promote_eltype_op end
 # @deprecate one(::Type{I}) where I<:CartesianIndex oneunit(I)
 
 @deprecate reindex(V, idxs, subidxs) reindex(idxs, subidxs) false
-@deprecate substrides(parent::AbstractArray, strds::Tuple, I::Tuple) substrides(strds, I)
+@deprecate substrides(parent::AbstractArray, strds::Tuple, I::Tuple) substrides(strds, I) false
 
 # TODO: deprecate these
 one(::CartesianIndex{N}) where {N} = one(CartesianIndex{N})

--- a/base/deprecated.jl
+++ b/base/deprecated.jl
@@ -165,7 +165,7 @@ function promote_eltype_op end
 # @deprecate one(i::CartesianIndex) oneunit(i)
 # @deprecate one(::Type{I}) where I<:CartesianIndex oneunit(I)
 
-@deprecate reindex(V, idxs, subidxs) reindex(idxs, subidxs)
+@deprecate reindex(V, idxs, subidxs) reindex(idxs, subidxs) false
 @deprecate substrides(parent::AbstractArray, strds::Tuple, I::Tuple) substrides(strds, I)
 
 # TODO: deprecate these


### PR DESCRIPTION
These were inadvertently exported by the deprecate macro in #30789.  Both are tailored to `SubArray` and don't check for preconditions that are enforced by the `SubArray` constructor. While we could perhaps export them, I'd like to do so intentionally... and add friendlier errors for violations of these preconditions.