### PR TITLE
Capture curl download agent error message

### DIFF
--- a/base/download.jl
+++ b/base/download.jl
@@ -38,8 +38,7 @@ end
 function download_curl(curl_exe::AbstractString, url::AbstractString, filename::AbstractString)
     err = PipeBuffer()
     process = run(pipeline(`$curl_exe -s -S -g -L -f -o $filename $url`, stderr=err), wait=false)
-    wait(process)
-    if process.exitcode != 0
+    if !success(process)
         stderr = readline(err)
         error(stderr)
     end

--- a/base/download.jl
+++ b/base/download.jl
@@ -35,8 +35,14 @@ function find_curl()
     end
 end
 
-function download_curl(curl_exe, url, filename)
-    run(`$curl_exe -s -S -g -L -f -o $filename $url`)
+function download_curl(curl_exe::AbstractString, url::AbstractString, filename::AbstractString)
+    err = PipeBuffer()
+    process = run(pipeline(`$curl_exe -s -S -g -L -f -o $filename $url`, stderr=err), wait=false)
+    wait(process)
+    if process.exitcode != 0
+        stderr = readline(err)
+        error(stderr)
+    end
     return filename
 end
 


### PR DESCRIPTION
Second commit only, first commit is https://github.com/JuliaLang/julia/pull/31173

Here instead of allowing curl to print stderr to the repl we capture them.

Ex: 

master
```julia
julia> download("googsdle.asdfcom")
curl: (6) Could not resolve host: googsdle.asdfcom
ERROR: failed process: Process(`'C:\WINDOWS\System32\curl.exe' -s -S -g -L -f -o S googsdle.asdfcom`, ProcessExited(6)) [6]
Stacktrace:
 [1] error(::String, ::Base.Process, ::String, ::Int64, ::String) at .\error.jl:42
 [2] pipeline_error at .\process.jl:785 [inlined]
 [3] #run#515(::Bool, ::Function, ::Cmd) at .\process.jl:726
 [4] run at .\process.jl:724 [inlined]
 [5] download_curl(::String, ::String, ::String) at .\REPL[3]:2
 [6] top-level scope at none:0
```

PR
```julia
julia> download("googsdle.asdfcom")
ERROR: curl: (6) Could not resolve host: googsdle.asdfcom
Stacktrace:
 [1] error(::SubString{String}) at .\error.jl:33
 [2] download_curl(::String, ::String, ::String) at .\REPL[26]:9
 [3] top-level scope at none:0
```