### PR TITLE
Defining a method to allow diagm(V) for a vector V 

### DIFF
--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -271,6 +271,26 @@ julia> diagm(1 => [1,2,3], -1 => [4,5])
  0  0  0  0
 ```
 """
+function diagm(kv::AbstractVector...)
+    A = diagm_container(kv...)
+    for p in kv
+        inds = diagind(A)
+        for (i, val) in enumerate(p)
+            A[inds[i]] += val
+        end
+    end
+    return A
+end
+function diagm_container(kv::AbstractVector...)
+    T = promote_type(map(x -> eltype(x), kv)...)
+    n = mapreduce(x -> length(x), max, kv)
+    return zeros(T, n, n)
+end
+function diagm_container(kv::BitVector...)
+    T = promote_type(map(x -> eltype(x), kv)...)
+    n = mapreduce(x -> length(x), max, kv)
+    return zeros(T, n, n)
+end
 function diagm(kv::Pair{<:Integer,<:AbstractVector}...)
     A = diagm_container(kv...)
     for p in kv

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -134,6 +134,8 @@ end
         e = rand(eltya,n-1)
         e2 = rand(eltya,n-1)
         f = rand(eltya,n-2)
+        A = diagm(d)
+        @test factorize(A) == Diagonal(d)
         A = diagm(0 => d)
         @test factorize(A) == Diagonal(d)
         A += diagm(-1 => e)


### PR DESCRIPTION
Defining a missing method to allow diagm(V) for a vector V rather diagm(0=>v)