### PR TITLE
[release-1.0] Remove mention of a predicate function in strip docstring

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -202,8 +202,8 @@ Remove leading and trailing characters from `str`.
 The default behaviour is to remove leading whitespace and delimiters: see
 [`isspace`](@ref) for precise details.
 
-The optional `chars` argument specifies which characters to remove: it can be a single character,
-vector or set of characters, or a predicate function.
+The optional `chars` argument specifies which characters to remove: it can be a single character
+or a vector or set of characters.
 
 # Examples
 ```jldoctest


### PR DESCRIPTION
`lstrip` and `rstrip` take a predicate function as the first argument. It seems `strip` did not receive that addition, though its docstring suggests that it did.

See #31195. Companion to #31211.