### PR TITLE
An edge case for `length`

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -523,7 +523,7 @@ firstindex(::UnitRange) = 1
 firstindex(::StepRange) = 1
 firstindex(::LinRange) = 1
 
-function length(r::StepRange{T}) where T<:Union{Int,UInt,Int64,UInt64}
+function length(r::StepRange{T}) where T<:Union{Int,UInt,Int64,UInt64,Int128,UInt128}
     isempty(r) && return zero(T)
     if r.step > 1
         return checked_add(convert(T, div(unsigned(r.stop - r.start), r.step)), one(T))

--- a/base/range.jl
+++ b/base/range.jl
@@ -536,13 +536,13 @@ function length(r::StepRange{T}) where T<:Union{Int,UInt,Int64,UInt64}
     end
 end
 
-function length(r::AbstractUnitRange{T}) where T<:Union{Int,Int64}
+function length(r::AbstractUnitRange{T}) where T<:Union{Int,Int64,Int128}
     @_inline_meta
     checked_add(checked_sub(last(r), first(r)), one(T))
 end
 length(r::OneTo{T}) where {T<:Union{Int,Int64}} = T(r.stop)
 
-length(r::AbstractUnitRange{T}) where {T<:Union{UInt,UInt64}} =
+length(r::AbstractUnitRange{T}) where {T<:Union{UInt,UInt64,UInt128}} =
     r.stop < r.start ? zero(T) : checked_add(last(r) - first(r), one(T))
 
 # some special cases to favor default Int type

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -406,9 +406,15 @@ end
 @test length(1:4:typemax(Int)) == div(typemax(Int),4) + 1
 
 @testset "overflow in length" begin
-    @test_throws OverflowError length(0:typemax(Int))
-    @test_throws OverflowError length(typemin(Int):typemax(Int))
-    @test_throws OverflowError length(-1:typemax(Int)-1)
+    Tset = Int === Int64 ? (Int,UInt,Int128,UInt128) :
+                           (Int,UInt,Int64,UInt64,Int128, UInt128)
+    for T in Tset
+        @test_throws OverflowError length(0:typemax(T))
+        @test_throws OverflowError length(typemin(T):typemax(T))
+        if T <: Signed
+            @test_throws OverflowError length(-one(T):typemax(T)-one(T))
+        end
+    end
 end
 @testset "loops involving typemin/typemax" begin
     n = 0

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -409,10 +409,13 @@ end
     Tset = Int === Int64 ? (Int,UInt,Int128,UInt128) :
                            (Int,UInt,Int64,UInt64,Int128, UInt128)
     for T in Tset
-        @test_throws OverflowError length(0:typemax(T))
+        @test_throws OverflowError length(zero(T):typemax(T))
         @test_throws OverflowError length(typemin(T):typemax(T))
+        @test_throws OverflowError length(zero(T):one(T):typemax(T))
+        @test_throws OverflowError length(typemin(T):one(T):typemax(T))
         if T <: Signed
             @test_throws OverflowError length(-one(T):typemax(T)-one(T))
+            @test_throws OverflowError length(-one(T):one(T):typemax(T)-one(T))
         end
     end
 end


### PR DESCRIPTION
Though `length` of `AbstractUnitRange` for `(U)Int` and `(U)Int64` has special cased with checked arithmetic, the `(U)Int128` dosen't and uses generic fallback. Therefore, it overflows for
```julia
julia> r = typemin(Int128):typemax(Int128)
-170141183460469231731687303715884105728:170141183460469231731687303715884105727

julia> length(r)
0

julia> r = typemin(UInt128):typemax(UInt128)
0x00000000000000000000000000000000:0xffffffffffffffffffffffffffffffff

julia> length(r)
0x00000000000000000000000000000000
```
whereas
```julia
julia> r = typemin(Int64):typemax(Int64)
-9223372036854775808:9223372036854775807

julia> length(r)
ERROR: OverflowError: 9223372036854775807 -y overflowed for type Int64
Stacktrace:
 [1] throw_overflowerr_binaryop(::Symbol, ::Int64, ::Int64) at ./checked.jl:154
 [2] checked_sub at ./checked.jl:223 [inlined]
 [3] length(::UnitRange{Int64}) at ./range.jl:540
 [4] top-level scope at none:0

julia> r = typemin(UInt64):typemax(UInt64)
0x0000000000000000:0xffffffffffffffff

julia> length(r)
ERROR: OverflowError: 18446744073709551615 +y overflowed for type UInt64
Stacktrace:
 [1] throw_overflowerr_binaryop(::Symbol, ::UInt64, ::UInt64) at ./checked.jl:154
 [2] checked_add at ./checked.jl:166 [inlined]
 [3] length(::UnitRange{UInt64}) at ./range.jl:544
 [4] top-level scope at none:0
```
I believe this is an inconsistency.