### PR TITLE
RFC/WIP: creation of mapdict method to modify Dict values

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -716,7 +716,7 @@ Dict{Symbol,Int64} with 2 entries:
   :a => 1
   :b => 2
 
-julia> map!(v->v-1,values(D))
+julia> map!(v -> v-1, values(d))
 Dict{Symbol,Int64} with 2 entries:
   :a => 0
   :b => 1

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -709,7 +709,7 @@ Takes the function `f(value) and transforms values stored in `dict` with the tra
 
 # Examples
 ```jldoctest
-julia> D=Dict(:a=>1,:b=>2)
+julia> d = Dict(:a => 1, :b => 2)
 Dict{Symbol,Int64} with 2 entries:
   :a => 1
   :b => 2

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -729,4 +729,5 @@ function map!(f, iter::ValueIterator)
     for (key, val) in pairs(dict)
         dict[key] = f(val)
     end
+    return iter
 end

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -719,7 +719,7 @@ Dict{Symbol,Int64} with 2 entries:
   :b => 1
  ```
 """
-function map!(f, iter::Base.ValueIterator{D}) where D <:Base.AbstractDict
+function map!(f, iter::ValueIterator)
     # This is the naive fallback which requires hash evaluations
     # Contrary to the example Dict has an implementation which does not require hash evaluations
     dict = iter.dict

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -705,7 +705,9 @@ end
 """
     map!(f, values(dict::AbstractDict))
 
-Takes the function `f(value) and transforms values stored in `dict` with the transformation `value=f(value).
+Modifies `dict` by transforming each value from `val` to `f(val)`.
+Note that the type of `dict` cannot be changed: if `f(val)` is not an instance of the key type
+of `dict` then it will be converted to the key type if possible and otherwise raise an error.
 
 # Examples
 ```jldoctest

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -704,6 +704,7 @@ end
 
 """
     map!(f, values(dict::AbstractDict))
+
 Takes the function `f(value) and transforms values stored in `dict` with the transformation `value=f(value).
 
 # Examples

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -701,3 +701,29 @@ function iterate(s::IdSet, state...)
     ((k, _), i) = y
     return (k, i)
 end
+
+"""
+    map!(f, values(dict::AbstractDict))
+Takes the function f(value) and transforms values stored in  `dict` with the transformation value=f(value).
+
+# Examples
+```jldoctest
+julia> D=Dict(:a=>1,:b=>2)
+Dict{Symbol,Int64} with 2 entries:
+  :a => 1
+  :b => 2
+
+julia> map!(v->v-1,values(D))
+Dict{Symbol,Int64} with 2 entries:
+  :a => 0
+  :b => 1
+ ```
+"""
+function map!(f, iter::Base.ValueIterator{D}) where D <:Base.AbstractDict
+    # This is the naive fallback which requires hash evaluations
+    # Contrary to the example Dict has an implementation which does not require hash evaluations
+    dict = iter.dict
+    for (key, val) in pairs(dict)
+        dict[key] = f(val)
+    end
+end

--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -704,7 +704,7 @@ end
 
 """
     map!(f, values(dict::AbstractDict))
-Takes the function f(value) and transforms values stored in  `dict` with the transformation value=f(value).
+Takes the function `f(value) and transforms values stored in `dict` with the transformation `value=f(value).
 
 # Examples
 ```jldoctest

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -686,18 +686,16 @@ end
 
 filter!(f, d::Dict) = filter_in_one_pass!(f, d)
 
-function map!(f, iter::ValueIterator{Dict{K,V}}) where {K, V}
+function map!(f, iter::ValueIterator{<:Dict})
     dict = iter.dict
     vals = dict.vals
-    i = dict.idxfloor
-    len=length(vals)
-    @inbounds while i < len
-        if !(isslotfilled(dict, i))
-            i += 1; continue
+    # @inbounds is here so the it gets propigated to isslotfiled
+    @inbounds for i = dict.idxfloor:lastindex(vals)
+        if isslotfilled(dict, i)
+            vals[i] = f(vals[i])
         end
-        @inbounds vals[i] = f(vals[i])
-        i += 1; continue
     end
+    return vals
 end
 
 struct ImmutableDict{K,V} <: AbstractDict{K,V}

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -733,6 +733,33 @@ end
 """
     mapdict(f, dict) -> dict
 Takes the function f(value) and returns a new Dict with the values transfor with new_value=f(value).
+
+# Examples
+```jldoctest
+julia> D=Dict(:a=>1,:b=>2,:c=>3)
+Dict{Symbol,Int64} with 3 entries:
+  :a => 1
+  :b => 2
+  :c => 3
+
+julia> E=mapdict(v->v-1,D)
+Dict{Symbol,Int64} with 3 entries:
+  :a => 0
+  :b => 1
+  :c => 2
+
+julia> D
+Dict{Symbol,Int64} with 3 entries:
+  :a => 1
+  :b => 2
+  :c => 3
+
+julia> E=mapdict(v->float(v-1),D)
+Dict{Symbol,Float64} with 3 entries:
+  :a => 0.0
+  :b => 1.0
+  :c => 2.0
+ ```
 """
 function mapdict(f, d::Dict{K,V}) where K where V
     isempty(d) && return d

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -695,7 +695,7 @@ function map!(f, iter::ValueIterator{<:Dict})
             vals[i] = f(vals[i])
         end
     end
-    return vals
+    return iter
 end
 
 struct ImmutableDict{K,V} <: AbstractDict{K,V}

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -506,6 +506,8 @@ export
     length,
     map!,
     map,
+    mapdict!,
+    mapdict,
     mapfoldl,
     mapfoldr,
     mapreduce,

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -506,8 +506,6 @@ export
     length,
     map!,
     map,
-    mapdict!,
-    mapdict,
     mapfoldl,
     mapfoldr,
     mapreduce,

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -92,7 +92,7 @@ function getkey(wkh::WeakKeyDict{K}, kk, default) where K
     end
 end
 
-map!(f,iter::ValueIterator{<:WeakKeyDict})= map!(f,values(iter.dict.ht))
+map!(f,iter::ValueIterator{<:WeakKeyDict})= map!(f, values(iter.dict.ht))
 get(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get(wkh.ht, key, default), wkh)
 get(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(default, wkh.ht, key), wkh)
 function get!(wkh::WeakKeyDict{K}, key, default) where {K}

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -92,6 +92,7 @@ function getkey(wkh::WeakKeyDict{K}, kk, default) where K
     end
 end
 
+Base.map!(f,iter::Base.ValueIterator{WeakKeyDict{K,V}}) where {K, V} = Base.map!(f,values(iter.dict.ht))
 get(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get(wkh.ht, key, default), wkh)
 get(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(default, wkh.ht, key), wkh)
 function get!(wkh::WeakKeyDict{K}, key, default) where {K}

--- a/base/weakkeydict.jl
+++ b/base/weakkeydict.jl
@@ -92,7 +92,7 @@ function getkey(wkh::WeakKeyDict{K}, kk, default) where K
     end
 end
 
-Base.map!(f,iter::Base.ValueIterator{WeakKeyDict{K,V}}) where {K, V} = Base.map!(f,values(iter.dict.ht))
+map!(f,iter::ValueIterator{<:WeakKeyDict})= map!(f,values(iter.dict.ht))
 get(wkh::WeakKeyDict{K}, key, default) where {K} = lock(() -> get(wkh.ht, key, default), wkh)
 get(default::Callable, wkh::WeakKeyDict{K}, key) where {K} = lock(() -> get(default, wkh.ht, key), wkh)
 function get!(wkh::WeakKeyDict{K}, key, default) where {K}

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1021,3 +1021,28 @@ end
         end
     end
 end
+
+@testset "map!(f,values(dict))" begin
+    @testset "AbstractDict & Fallback" begin
+        mutable struct TestDict{K, V}  <: AbstractDict{K, V}
+            dict::Dict{K, V}
+            function TestDict(args...)
+                d=Dict(args...)
+                new{keytype(d), valtype(d)}(d)
+            end
+        end
+        Base.setindex!(td::TestDict, args...) = setindex!(td.dict, args...)
+        Base.getindex(td::TestDict, args...) = getindex(td.dict, args...)
+        Base.pairs(D::TestDict) = pairs(D.dict)
+        testdict = TestDict(:a=>1, :b=>2)
+        map!(v->v-1, values(testdict))
+        @test testdict[:a] == 0
+        @test testdict[:b] == 1
+    end
+    @testset "Dict" begin
+        testdict = Dict(:a=>1, :b=>2)
+        map!(v->v-1, values(testdict))
+        @test testdict[:a] == 0
+        @test testdict[:b] == 1
+    end
+end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1027,7 +1027,7 @@ end
         mutable struct TestDict{K, V}  <: AbstractDict{K, V}
             dict::Dict{K, V}
             function TestDict(args...)
-                d=Dict(args...)
+                d = Dict(args...)
                 new{keytype(d), valtype(d)}(d)
             end
         end

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -1022,7 +1022,7 @@ end
     end
 end
 
-@testset "map!(f,values(dict))" begin
+@testset "map!(f, values(dict))" begin
     @testset "AbstractDict & Fallback" begin
         mutable struct TestDict{K, V}  <: AbstractDict{K, V}
             dict::Dict{K, V}


### PR DESCRIPTION
This is the initial pass at the inclusion of  methods `mapdict` & `mapdict!` which allows the modification of Dict values without the overhead of using the Dict keys to access & store the values.  

The need for this method was discuss at:
https://discourse.julialang.org/t/fast-dict-value-modification-by-accessing-dict-vals
At the recommendation of @tpapp this was built out for base.

An example of the use would be as follows:
```julia
julia> D=Dict(:a=>1,:b=>2)
Dict{Symbol,Int64} with 2 entries:
  :a => 1
  :b => 2

julia> mapdict!(v->v-1,D)
Dict{Symbol,Int64} with 2 entries:
  :a => 0
  :b => 1

julia> D=mapdict!(v->Float64(v),D) #For the type mutating case you must use an =
Dict{Symbol,Float64} with 2 entries:
  :a => 0.0
  :b => 1.0
```

Currently this implementation handles most of the function cases that were brought up:
1.) Functions which return the same type as the input
2.) Functions that are mutate the value type but are typesafe
3.) Functions which are not type safe.

While the function is currently only implemented for `Dict`, it would be simple to add a naive fallback for `AbstractDict` using keys.

If there is interest in including this in Base, test would also be built out.


Benchmarking results for essentially ```mapdict!(v-> v > row ? v-1 : v,D)``` where row is set to change half the values.

![image](https://user-images.githubusercontent.com/45537276/53643471-23d0d300-3c02-11e9-8a2e-7faa65859eee.png)
