### PR TITLE
Support filter for SkipMissing-wrapped arrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ Standard library changes
 * `hasmethod` can now check for matching keyword argument names ([#30712]).
 * `startswith` and `endswith` now accept a `Regex` for the second argument ([#29790]).
 * `retry` supports arbitrary callable objects ([#30382]).
+* `filter` now supports `SkipMissing`-wrapped arrays ([#31235]).
 * A no-argument construct to `Ptr{T}` has been added which constructs a null pointer ([#30919])
 
 #### LinearAlgebra

--- a/base/missing.jl
+++ b/base/missing.jl
@@ -329,6 +329,37 @@ mapreduce_impl(f, op, A::SkipMissing, ifirst::Integer, ilast::Integer) =
 end
 
 """
+    filter(f, itr::SkipMissing{<:AbstractArray})
+
+Return a vector similar to the array wrapped by the given `SkipMissing` iterator
+but with all missing elements and those for which `f` returns `false` removed.
+
+!!! compat "Julia 1.2"
+    This method requires Julia 1.2 or later.
+
+# Examples
+```jldoctest
+julia> x = [1 2; missing 4]
+2×2 Array{Union{Missing, Int64},2}:
+ 1         2
+  missing  4
+
+julia> filter(isodd, skipmissing(x))
+1-element Array{Int64,1}:
+ 1
+```
+"""
+function filter(f, itr::SkipMissing{<:AbstractArray})
+    y = similar(itr.x, eltype(itr), 0)
+    for xi in itr.x
+        if xi !== missing && f(xi)
+            push!(y, xi)
+        end
+    end
+    y
+end
+
+"""
     coalesce(x, y...)
 
 Return the first value in the arguments which is not equal to [`missing`](@ref),

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -469,6 +469,15 @@ end
             @test_throws ArgumentError mapreduce(x -> x/2, +, itr)
         end
     end
+
+    @testset "filter" begin
+        allmiss = Vector{Union{Int,Missing}}(missing, 10)
+        @test isempty(filter(isodd, skipmissing(allmiss))::Vector{Int})
+        twod1 = [1.0f0 missing; 3.0f0 missing]
+        @test filter(x->x > 0, skipmissing(twod1))::Vector{Float32} == [1, 3]
+        twod2 = [1.0f0 2.0f0; 3.0f0 4.0f0]
+        @test filter(x->x > 0, skipmissing(twod2)) == reshape(twod2, (4,))
+    end
 end
 
 @testset "coalesce" begin


### PR DESCRIPTION
See discussion in #31188. This makes `filter(f, skipmissing(x))` eagerly return an array similar to the wrapped array but with missing values and `!f(xi)` elements removed.