### PR TITLE
Speed up dictionary iteration by reducing branchmisses

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -707,7 +707,7 @@ length(t::Dict) = t.count
     isempty(v.dict) && return nothing
     is = _iterate(v.dict)
     is === nothing && return nothing
-    i,s = is 
+    i,s = is
     (v isa KeySet ? v.dict.keys[i] : v.dict.vals[i], s)
 end
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -669,7 +669,7 @@ function skip_deleted_floor!(h::Dict)
 end
 
 @inline function _iterate(h::Dict)
-    (isempty(h) || length(h.slots)<8) && return nothing
+    isempty(h) && return nothing #always length(h.slots) >= 16
     return _iterate(h, (1, ltoh(unsafe_load(convert(Ptr{UInt64}, pointer(h.slots)),1)) & 0x0101010101010101))
 end
 
@@ -721,7 +721,7 @@ end
 function filter!(pred, h::Dict{K,V}) where {K,V}
     isempty(h) && return h
     is = _iterate(h)
-    @inbounds while s !== nothing
+    @inbounds while is !== nothing
         i, state = is
         if !pred(Pair{K,V}(h.keys[i], h.vals[i]))
             _delete!(h, i)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -720,12 +720,13 @@ end
 
 function filter!(pred, h::Dict{K,V}) where {K,V}
     isempty(h) && return h
-    s = _iterate(h)
+    is = _iterate(h)
     @inbounds while s !== nothing
-        i, state = s
+        i, state = is
         if !pred(Pair{K,V}(h.keys[i], h.vals[i]))
             _delete!(h, i)
         end
+        is = _iterate(h, state)
     end
     return h
 end


### PR DESCRIPTION
Before:
```
julia> d=Dict(i=>i for i=1:10_000);
julia> d2 = filter!(kv->iseven(kv.first), copy(d));
julia> using BenchmarkTools
julia> @btime collect(d);
  110.355 μs (2 allocations: 156.33 KiB)
julia> @btime collect(d2);
  92.760 μs (2 allocations: 78.20 KiB)
julia> @show hash(collect(d2));
hash(collect(d2)) = 0x6f19949be84bcf1e
```
Monkey-Patch:
```
julia> @eval Base begin
       @inline function _iterate(h::Dict)
           (isempty(h) || length(h.slots)<8) && return nothing
           return _iterate(h, (1, ltoh(unsafe_load(convert(Ptr{UInt64}, pointer(h.slots)),1)) & 0x0101010101010101))
       end

       @inline function _iterate(h::Dict, s)
           i,c = s
           while c == 0
               i % UInt >= (length(h.slots)>>3) && return nothing
               i += 1
               c = ltoh(unsafe_load(convert(Ptr{UInt64}, pointer(h.slots)),i)) & 0x0101010101010101
           end
           idx = 1 + (i-1)<<3 + trailing_zeros(c)>>3

           return  idx, (i, _blsr(c))
       end

       function iterate(h::Dict{K,V}) where {K,V}
           isempty(h) && return nothing
           s = _iterate(h)
           s === nothing && return nothing
           i, state = s
           @inbounds return Pair{K,V}(h.keys[i], h.vals[i]), state
       end

       function iterate(h::Dict{K,V}, state) where {K,V}
           s = _iterate(h, state)
           s === nothing && return nothing
           i, state = s
           @inbounds return Pair{K,V}(h.keys[i], h.vals[i]), state
       end
       end
```
After:
```
julia> @btime collect(d);
  43.042 μs (2 allocations: 156.33 KiB)

julia> @btime collect(d2);
  24.426 μs (2 allocations: 78.20 KiB)

julia> @show hash(collect(d2));
hash(collect(d2)) = 0x6f19949be84bcf1e
```
Note that this makes `idxfloor` mostly obsolete. I think it was mostly obsolete before: The expensive part are the branch-misses. But I was not sure whether there is any code relying on `idxfloor` (even though it is internal), so removal of obsolete parts should probably wait for a chance at breaking things. 

This needs extra-careful testing on non-little-endian, if there are any that we support, and some benchmarks on 32bit.

If accepted, then this supersedes [https://github.com/JuliaLang/julia/pull/31242](https://github.com/JuliaLang/julia/pull/31242). But I think this change is more controversal than the other one, because it looks a little hacky. Is there a non-hacky official way of loading aligned UInt64 from an array of UInt8?

Can we get a nanosoldier?