### PR TITLE
Docstrings for quot, isexpr and show_sexpr

### DIFF
--- a/base/docs/basedocs.jl
+++ b/base/docs/basedocs.jl
@@ -2178,4 +2178,11 @@ The base library of Julia. `Base` is a module that contains basic functionality 
 """
 Base.Base
 
+"""
+    QuoteNode
+
+A quoted piece of code, that does not support interpolation. See the [manual section about QuoteNodes](@ref man-quote-node) for details.
+"""
+QuoteNode
+
 end

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -39,6 +39,8 @@ quot(ex) = Expr(:quote, ex)
     isexpr(ex, head[, n])::Bool
 
 Check if `ex` is an expression with head `head` and `n` arguments.
+
+# Examples
 ```jldoctest
 julia> ex = :(f(x))
 :(f(x))

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -16,6 +16,8 @@ export quot,
     quot(ex)::Expr
 
 Quote expression `ex` to produce an expression with head `quote`. This can for instance be used to represent objects of type `Expr` in the AST.
+
+# Examples
 ```jldoctest
 julia> eval(quot(:x))
 :x

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -12,15 +12,64 @@ export quot,
        show_sexpr,
        @dump
 
+"""
+    quot(ex)::Expr
+
+Quote expression `ex` to produce an expression with head `quote`. This can for instance be used to represent objects of type `Expr` in the AST.
+```jldoctest
+julia> eval(quot(:x))
+:x
+
+julia> dump(quot(:x))
+Expr
+  head: Symbol quote
+  args: Array{Any}((1,))
+    1: Symbol x
+
+julia> eval(quot(:(1+2)))
+:(1 + 2)
+```
+See also the manual section about [QuoteNode](@ref man-quote-node).
+"""
 quot(ex) = Expr(:quote, ex)
 
+"""
+    isexpr(ex, head[, n])::Bool
+
+Check if `ex` is an expression with head `head` and `n` arguments.
+```jldoctest
+julia> ex = :(f(x))
+:(f(x))
+
+julia> isexpr(ex, :block)
+false
+
+julia> isexpr(ex, :call)
+true
+
+julia> isexpr(ex, [:block, :call]) # multiple possible heads
+true
+
+julia> isexpr(ex, :call, 1)
+false
+
+julia> isexpr(ex, :call, 2)
+true
+```
+"""
 isexpr(@nospecialize(ex), head::Symbol) = isa(ex, Expr) && ex.head === head
 isexpr(@nospecialize(ex), heads::Union{Set,Vector,Tuple}) = isa(ex, Expr) && in(ex.head, heads)
 isexpr(@nospecialize(ex), heads, n::Int) = isexpr(ex, heads) && length(ex.args) == n
 
+"""
+    show_sexpr([io::IO,], ex)
 
-# ---- show_sexpr: print an AST as an S-expression ----
-
+Show expression `ex` as a lisp style S-expression.
+```jldoctest
+julia> show_sexpr(:(f(x, g(y,z))))
+(:call, :f, :x, (:call, :g, :y, :z))
+```
+"""
 show_sexpr(ex) = show_sexpr(stdout, ex)
 show_sexpr(io::IO, ex) = show_sexpr(io, ex, 0)
 show_sexpr(io::IO, ex, indent::Int) = show(io, ex)

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -16,6 +16,7 @@ export quot,
     quot(ex)::Expr
 
 Quote expression `ex` to produce an expression with head `quote`. This can for instance be used to represent objects of type `Expr` in the AST.
+See also the manual section about [QuoteNode](@ref man-quote-node).
 
 # Examples
 ```jldoctest
@@ -31,7 +32,6 @@ Expr
 julia> eval(quot(:(1+2)))
 :(1 + 2)
 ```
-See also the manual section about [QuoteNode](@ref man-quote-node).
 """
 quot(ex) = Expr(:quote, ex)
 

--- a/base/meta.jl
+++ b/base/meta.jl
@@ -69,6 +69,8 @@ isexpr(@nospecialize(ex), heads, n::Int) = isexpr(ex, heads) && length(ex.args) 
     show_sexpr([io::IO,], ex)
 
 Show expression `ex` as a lisp style S-expression.
+
+# Examples
 ```jldoctest
 julia> show_sexpr(:(f(x, g(y,z))))
 (:call, :f, :x, (:call, :g, :y, :z))

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -397,6 +397,7 @@ Meta.@lower
 Meta.parse(::AbstractString, ::Int)
 Meta.parse(::AbstractString)
 Meta.ParseError
+Core.QuoteNode
 Base.macroexpand
 Base.@macroexpand
 Base.@macroexpand1

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -404,3 +404,10 @@ Base.code_lowered
 Base.code_typed
 Base.precompile
 ```
+
+## Meta
+```@docs
+Meta.quot
+Meta.isexpr
+Meta.show_sexpr
+```

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -330,7 +330,7 @@ However, in some situations it is necessary to quote code *without* performing i
 This kind of quoting does not yet have syntax, but is represented internally
 as an object of type `QuoteNode`:
 ```jldoctest interp1
-julia> quot(Expr(:$, :(1+2))) |> eval
+julia> eval(quot(Expr(:$, :(1+2))))
 3
 
 julia> QuoteNode(Expr(:$, :(1+2))) |> eval

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -333,7 +333,7 @@ as an object of type `QuoteNode`:
 julia> eval(quot(Expr(:$, :(1+2))))
 3
 
-julia> QuoteNode(Expr(:$, :(1+2))) |> eval
+julia> eval(QuoteNode(Expr(:$, :(1+2))))
 :($(Expr(:$, :(1 + 2))))
 ```
 The parser yields `QuoteNode`s for simple quoted items like symbols:

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -328,9 +328,15 @@ Expr
 As we have seen, such expressions support interpolation with `$`.
 However, in some situations it is necessary to quote code *without* performing interpolation.
 This kind of quoting does not yet have syntax, but is represented internally
-as an object of type `QuoteNode`.
-The parser yields `QuoteNode`s for simple quoted items like symbols:
+as an object of type `QuoteNode`:
+```jldoctest interp1
+julia> quot(Expr(:$, :(1+2))) |> eval
+3
 
+julia> QuoteNode(Expr(:$, :(1+2))) |> eval
+:($(Expr(:$, :(1 + 2))))
+```
+The parser yields `QuoteNode`s for simple quoted items like symbols:
 ```jldoctest interp1
 julia> dump(Meta.parse(":x"))
 QuoteNode

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -308,7 +308,7 @@ The intuition behind this behavior is that `x` is evaluated once for each `$`:
 one `$` works similarly to `eval(:x)`, giving `x`'s value, while two `$`s do the
 equivalent of `eval(eval(:x))`.
 
-### QuoteNode
+### [QuoteNode](@id man-quote-node)
 
 The usual representation of a `quote` form in an AST is an [`Expr`](@ref) with head `:quote`:
 


### PR DESCRIPTION
Towards  #26919
I would also like to add a docstring for QuoteNode. But despite reading [this](https://docs.julialang.org/en/v1/manual/metaprogramming/#QuoteNode-1) it is not clear to me:
* What the difference between the difference between `Expr(:quote,...)` and `QuoteNode` is
* Why these are two such concepts
* When to use which