### PR TITLE
RFC: Add an alternative implementation of closures

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -232,6 +232,9 @@ using .Libc: getpid, gethostname, time
 
 include("env.jl")
 
+# YAKC
+include("yakc.jl")
+
 # Concurrency
 include("linked_list.jl")
 include("condition.jl")

--- a/base/compiler/abstractinterpretation.jl
+++ b/base/compiler/abstractinterpretation.jl
@@ -89,7 +89,7 @@ function abstract_call_gf_by_type(interp::AbstractInterpreter, @nospecialize(f),
     edges = Any[]
     nonbot = 0  # the index of the only non-Bottom inference result if > 0
     seen = 0    # number of signatures actually inferred
-    istoplevel = sv.linfo.def isa Module
+    istoplevel = sv.linfo !== nothing && sv.linfo.def isa Module
     multiple_matches = napplicable > 1
 
     if f !== nothing && napplicable == 1 && is_method_pure(applicable[1]::MethodMatch)
@@ -337,7 +337,7 @@ function abstract_call_method(interp::AbstractInterpreter, method::Method, @nosp
     sv_method2 isa Method || (sv_method2 = nothing) # Union{Method, Nothing}
     while !(infstate === nothing)
         infstate = infstate::InferenceState
-        if method === infstate.linfo.def
+        if infstate.linfo !== nothing && method === infstate.linfo.def
             if infstate.linfo.specTypes == sig
                 # avoid widening when detecting self-recursion
                 # TODO: merge call cycle and return right away
@@ -790,6 +790,10 @@ function abstract_call_builtin(interp::AbstractInterpreter, f::Builtin, fargs::U
             ty = typeintersect(ty, cnd.elsetype)
         end
         return tmerge(tx, ty)
+    elseif f === Core._yakc
+        la >= 5 || return Union{}
+        return _yakc_tfunc(argtypes[2], argtypes[3], argtypes[4],
+            argtypes[5], argtypes[6:end], sv.linfo)
     end
     rt = builtin_tfunction(interp, f, argtypes[2:end], sv)
     if f === getfield && isa(fargs, Vector{Any}) && la == 3 && isa(argtypes[3], Const) && isa(argtypes[3].val, Int) && argtypes[2] ⊑ Tuple
@@ -1003,6 +1007,28 @@ function abstract_call_known(interp::AbstractInterpreter, @nospecialize(f),
     return abstract_call_gf_by_type(interp, f, argtypes, atype, sv, max_methods)
 end
 
+function abstract_call_yakc(interp::AbstractInterpreter, yakc::PartialYAKC, argtypes::Vector{Any}, sv::InferenceState)
+    if isa(yakc.ci, CodeInfo)
+        nargtypes = argtypes[2:end]
+        pushfirst!(nargtypes, yakc.env)
+        result = InferenceResult(Core.YAKC, nargtypes)
+        state = InferenceState(result, copy(yakc.ci), false, interp)
+        typeinf_local(interp, state)
+        finish(state, interp)
+        result.src.src.inferred = true
+        yakc.ci = result.src
+        return CallMeta(result.result, false)
+    elseif isa(yakc.ci, OptimizationState)
+        return CallMeta(yakc.ci.src.rettype, nothing)
+    else
+        nargtypes = argtypes[2:end]
+        pushfirst!(nargtypes, Core.YAKC)
+        sig = argtypes_to_type(nargtypes)
+        rt, edge = abstract_call_method(interp, yakc.ci::Method, sig, Core.svec(), false, sv)
+        return CallMeta(rt, edge)
+    end
+end
+
 # call where the function is any lattice element
 function abstract_call(interp::AbstractInterpreter, fargs::Union{Nothing,Vector{Any}}, argtypes::Vector{Any},
                        sv::InferenceState, max_methods::Int = InferenceParams(interp).MAX_METHODS)
@@ -1014,6 +1040,8 @@ function abstract_call(interp::AbstractInterpreter, fargs::Union{Nothing,Vector{
         f = ft.parameters[1]
     elseif isa(ft, DataType) && isdefined(ft, :instance)
         f = ft.instance
+    elseif isa(ft, PartialYAKC)
+        return abstract_call_yakc(interp, ft, argtypes, sv)
     else
         # non-constant function, but the number of arguments is known
         # and the ft is not a Builtin or IntrinsicFunction
@@ -1326,14 +1354,14 @@ function typeinf_local(interp::AbstractInterpreter, frame::InferenceState)
             elseif isa(stmt, ReturnNode)
                 pc´ = n + 1
                 rt = widenconditional(abstract_eval_value(interp, stmt.val, s[pc], frame))
-                if !isa(rt, Const) && !isa(rt, Type) && !isa(rt, PartialStruct)
+                if !isa(rt, Const) && !isa(rt, Type) && !isa(rt, PartialStruct) && !isa(rt, PartialYAKC)
                     # only propagate information we know we can store
                     # and is valid inter-procedurally
                     rt = widenconst(rt)
                 end
                 if tchanged(rt, frame.bestguess)
                     # new (wider) return type for frame
-                    frame.bestguess = tmerge(frame.bestguess, rt)
+                    frame.bestguess = frame.bestguess === NOT_FOUND ? rt : tmerge(frame.bestguess, rt)
                     for (caller, caller_pc) in frame.cycle_backedges
                         # notify backedges of updated type information
                         typeassert(caller.stmt_types[caller_pc], VarTable) # we must have visited this statement before

--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -34,7 +34,7 @@ struct InliningState{S <: Union{EdgeTracker, Nothing}, T <: Union{InferenceCache
 end
 
 mutable struct OptimizationState
-    linfo::MethodInstance
+    linfo::Union{MethodInstance, Nothing}
     src::CodeInfo
     stmt_info::Vector{Any}
     mod::Module
@@ -310,6 +310,13 @@ function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}
             if isa(farg, GlobalRef) || isa(farg, QuoteNode) || isa(farg, IntrinsicFunction) || isexpr(farg, :static_parameter)
                 ftyp = argextype(farg, src, sptypes, slottypes)
             end
+        end
+        # Give calls to YAKCs zero cost. The plan is for these to be a single
+        # indirect call so have very little cost. On the other hand, there
+        # is enormous benefit to inlining these into a function where we can
+        # see the definition of the YAKC. Perhaps this should even be negative
+        if widenconst(ftyp) <: Core.YAKC
+            return 0
         end
         f = singleton_type(ftyp)
         if isa(f, IntrinsicFunction)

--- a/base/compiler/ssair/driver.jl
+++ b/base/compiler/ssair/driver.jl
@@ -33,7 +33,24 @@ function normalize(@nospecialize(stmt), meta::Vector{Any})
     return stmt
 end
 
-function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int, sv::OptimizationState)
+function add_yakc_argtypes!(argtypes, t)
+    dt = unwrap_unionall(t)
+    dt1 = unwrap_unionall(dt.parameters[1])
+    if isa(dt1, TypeVar) || isa(dt1.parameters[1], TypeVar)
+        push!(argtypes, Any)
+    else
+        TT = dt1.parameters[1]
+        if isa(TT, Union)
+            TT = tuplemerge(TT.a, TT.b)
+        end
+        for p in TT.parameters
+            push!(argtypes, rewrap_unionall(p, t))
+        end
+    end
+end
+
+
+function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, nargs::Int, sv::OptimizationState, slottypes=sv.slottypes, stmtinfo=sv.stmt_info)
     # Go through and add an unreachable node after every
     # Union{} call. Then reindex labels.
     idx = 1
@@ -41,7 +58,8 @@ function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, narg
     changemap = fill(0, length(code))
     labelmap = coverage ? fill(0, length(code)) : changemap
     prevloc = zero(eltype(ci.codelocs))
-    stmtinfo = sv.stmt_info
+    stmtinfo = copy(stmtinfo)
+    yakcs = IRCode[]
     while idx <= length(code)
         codeloc = ci.codelocs[idx]
         if coverage && codeloc != prevloc && codeloc != 0
@@ -57,7 +75,22 @@ function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, narg
             idx += 1
             prevloc = codeloc
         end
-        if code[idx] isa Expr && ci.ssavaluetypes[idx] === Union{}
+        stmt = code[idx]
+        if isexpr(stmt, :(=))
+            stmt = stmt.args[2]
+        end
+        ssat = ci.ssavaluetypes[idx]
+        if isa(ssat, PartialYAKC) && isexpr(stmt, :call)
+            ft = argextype(stmt.args[1], ci, sv.sptypes)
+            # Pre-convert any YAKC objects
+            if isa(ft, Const) && ft.val === Core._yakc && isa(ssat.ci, OptimizationState)
+                yakc_ir = make_ir(ssat.ci.src, 0, ssat.ci)
+                push!(yakcs, yakc_ir)
+                stmt.head = :new_yakc
+                stmt.args[5] = YAKCIdx(length(yakcs))
+            end
+        end
+        if stmt isa Expr && ssat === Union{}
             if !(idx < length(code) && isa(code[idx + 1], ReturnNode) && !isdefined((code[idx + 1]::ReturnNode), :val))
                 # insert unreachable in the same basic block after the current instruction (splitting it)
                 insert!(code, idx + 1, ReturnNode())
@@ -105,7 +138,7 @@ function convert_to_ircode(ci::CodeInfo, code::Vector{Any}, coverage::Bool, narg
     cfg = compute_basic_blocks(code)
     types = Any[]
     stmts = InstructionStream(code, types, stmtinfo, ci.codelocs, flags)
-    ir = IRCode(stmts, cfg, collect(LineInfoNode, ci.linetable), sv.slottypes, meta, sv.sptypes)
+    ir = IRCode(stmts, cfg, collect(LineInfoNode, ci.linetable), slottypes, meta, sv.sptypes, yakcs)
     return ir
 end
 
@@ -117,24 +150,37 @@ function slot2reg(ir::IRCode, ci::CodeInfo, nargs::Int, sv::OptimizationState)
     return ir
 end
 
-function run_passes(ci::CodeInfo, nargs::Int, sv::OptimizationState)
-    preserve_coverage = coverage_enabled(sv.mod)
-    ir = convert_to_ircode(ci, copy_exprargs(ci.code), preserve_coverage, nargs, sv)
+function compact_all!(ir::IRCode)
+    length(ir.stmts) == 0 && return ir
+    for i in 1:length(ir.yakcs)
+        ir.yakcs[i] = compact_all!(ir.yakcs[i])
+    end
+    compact!(ir)
+end
+
+function make_ir(ci::CodeInfo, nargs::Int, sv::OptimizationState)
+    ir = convert_to_ircode(ci, copy_exprargs(ci.code), coverage_enabled(sv.mod), nargs, sv)
     ir = slot2reg(ir, ci, nargs, sv)
+    ir
+end
+
+function run_passes(ci::CodeInfo, nargs::Int, sv::OptimizationState)
+    ir = make_ir(ci, nargs, sv)
     #@Base.show ("after_construct", ir)
     # TODO: Domsorting can produce an updated domtree - no need to recompute here
     @timeit "compact 1" ir = compact!(ir)
     @timeit "Inlining" ir = ssa_inlining_pass!(ir, ir.linetable, sv.inlining, ci.propagate_inbounds)
     #@timeit "verify 2" verify_ir(ir)
-    ir = compact!(ir)
+    ir = compact_all!(ir)
     #@Base.show ("before_sroa", ir)
     @timeit "SROA" ir = getfield_elim_pass!(ir)
+    ir = yakc_optim_pass!(ir)
     #@Base.show ir.new_nodes
     #@Base.show ("after_sroa", ir)
     ir = adce_pass!(ir)
     #@Base.show ("after_adce", ir)
     @timeit "type lift" ir = type_lift_pass!(ir)
-    @timeit "compact 3" ir = compact!(ir)
+    @timeit "compact 3" ir = compact_all!(ir)
     #@Base.show ir
     if JLOptions().debug_level == 2
         @timeit "verify 3" (verify_ir(ir); verify_linetable(ir.linetable))

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -13,6 +13,7 @@ end
 function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
     code = copy_exprargs(ci.code) # TODO: this is a huge hot-spot
     cfg = compute_basic_blocks(code)
+    yakcs = IRCode[]
     for i = 1:length(code)
         stmt = code[i]
         # Translate statement edges to bb_edges
@@ -25,6 +26,8 @@ function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
         elseif isa(stmt, Expr) && stmt.head === :enter
             stmt.args[1] = block_for_inst(cfg, stmt.args[1])
             code[i] = stmt
+        elseif isa(stmt, Expr) && stmt.head == :new
+            code[i] = stmt
         else
             code[i] = stmt
         end
@@ -33,7 +36,7 @@ function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
     nstmts = length(code)
     ssavaluetypes = ci.ssavaluetypes isa Vector{Any} ? copy(ci.ssavaluetypes) : Any[ Any for i = 1:(ci.ssavaluetypes::Int) ]
     stmts = InstructionStream(code, ssavaluetypes, Any[nothing for i = 1:nstmts], copy(ci.codelocs), copy(ci.ssaflags))
-    ir = IRCode(stmts, cfg, collect(LineInfoNode, ci.linetable), argtypes, Any[], sptypes)
+    ir = IRCode(stmts, cfg, collect(LineInfoNode, ci.linetable), argtypes, Any[], sptypes, yakcs)
     return ir
 end
 
@@ -62,6 +65,12 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
             stmt = PhiNode(Int32[last(ir.cfg.blocks[edge].stmts) for edge in stmt.edges], stmt.values)
         elseif isa(stmt, Expr) && stmt.head === :enter
             stmt.args[1] = first(ir.cfg.blocks[stmt.args[1]::Int].stmts)
+        elseif isa(stmt, Expr) && stmt.head == :new_yakc
+            ci′ = copy((ci.ssavaluetypes[i]::PartialYAKC).ci.src)
+            ir′ = ir.yakcs[(stmt.args[5]::YAKCIdx).n]
+            replace_code_newstyle!(ci′, ir′, length(ir′.argtypes)-1)
+            stmt.args[5] = ci′
+            stmt.head = :call
         end
         ci.code[i] = stmt
     end

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -1194,3 +1194,41 @@ function cfg_simplify!(ir::IRCode)
     compact.active_result_bb = length(bb_starts)
     return finish(compact)
 end
+
+function analyze_env_uses(yakc_ir)
+    uses = BitSet()
+    for idx in 1:length(yakc_ir.stmts)
+        stmt = yakc_ir.stmts[idx][:inst]
+        isexpr(stmt, :call) || continue
+        if is_known_call(stmt, getfield, yakc_ir, Any[])
+            if stmt.args[2] == Argument(1)
+                push!(uses, stmt.args[3])
+            end
+        end
+    end
+    uses
+end
+
+function yakc_optim_pass!(ir::IRCode)
+    if isempty(ir.yakcs)
+        return ir
+    end
+
+    # For any yakcs being co-optimized, optimize the capture environment
+    uses = BitSet[]
+    for ir′ in ir.yakcs
+        push!(uses, analyze_env_uses(ir′))
+    end
+
+    compact = IncrementalCompact(ir)
+    for ((_, idx), stmt) in compact
+        isexpr(stmt, :new_yakc) || continue
+        this_yakc_uses = uses[(stmt.args[5]::YAKCIdx).n]
+        if isempty(this_yakc_uses)
+            resize!(stmt.args, 5)
+        end
+    end
+
+    # TODO: We could hoise code here
+    return finish(compact)
+end

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -42,14 +42,15 @@ function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, sptypes::
             isexact || return false
             isconcretedispatch(typ) || return false
             typ = typ::DataType
-            fieldcount(typ) >= length(ea) - 1 || return false
-            for fld_idx in 1:(length(ea) - 1)
+            nargs = length(ea) - (head === :new ? 1 : 2)
+            fieldcount(typ) >= nargs || return false
+            for fld_idx in 1:nargs
                 eT = argextype(ea[fld_idx + 1], src, sptypes)
                 fT = fieldtype(typ, fld_idx)
                 eT ⊑ fT || return false
             end
             return true
-        elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck
+        elseif head === :isdefined || head === :the_exception || head === :copyast || head === :inbounds || head === :boundscheck || head === :new_yakc
             return true
         else
             # e.g. :loopinfo

--- a/base/compiler/ssair/verify.jl
+++ b/base/compiler/ssair/verify.jl
@@ -14,13 +14,13 @@ end
 function check_op(ir::IRCode, domtree::DomTree, @nospecialize(op), use_bb::Int, use_idx::Int, print::Bool)
     if isa(op, SSAValue)
         if op.id > length(ir.stmts)
-            def_bb = block_for_inst(ir.cfg, ir.new_nodes[op.id - length(ir.stmts)].pos)
+            def_bb = block_for_inst(ir.cfg, ir.new_nodes.info[op.id - length(ir.stmts)].pos)
         else
             def_bb = block_for_inst(ir.cfg, op.id)
         end
         if (def_bb == use_bb)
             if op.id > length(ir.stmts)
-                @assert ir.new_nodes[op.id - length(ir.stmts)].pos <= use_idx
+                @assert ir.new_nodes.info[op.id - length(ir.stmts)].pos <= use_idx
             else
                 if op.id >= use_idx
                     @verify_error "Def ($(op.id)) does not dominate use ($(use_idx)) in same BB"

--- a/base/compiler/stmtinfo.jl
+++ b/base/compiler/stmtinfo.jl
@@ -79,3 +79,13 @@ This info is illegal on any statement that is not an `_apply_iterate` call.
 struct UnionSplitApplyCallInfo
     infos::Vector{ApplyCallInfo}
 end
+
+"""
+    struct YAKCCallInfo
+
+The call was to a YAKC of known provenance. A MethodInstance was created to
+hold the optimized code for this YAKC.
+"""
+struct YAKCCallInfo
+    mi::MethodInstance
+end

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -1368,6 +1368,24 @@ function array_builtin_common_nothrow(argtypes::Array{Any,1}, first_idx_idx::Int
     return false
 end
 
+function _yakc_tfunc(@nospecialize(arg), @nospecialize(lb), @nospecialize(ub),
+    @nospecialize(ci), env::Vector{Any}, linfo::MethodInstance)
+    argt, argt_exact = instanceof_tfunc(arg)
+    lbt, lb_exact = instanceof_tfunc(lb)
+    if !lb_exact
+    lbt = Union{}
+    end
+
+    ubt, ub_exact = instanceof_tfunc(ub)
+
+    t = Core.YAKC{argt_exact ? argt : <:argt}
+    t = t{(lbt == ubt && ub_exact) ? ubt : T} where lbt<:T<:ubt
+
+    isa(ci, Const) || return t
+
+    PartialYAKC(t, tuple_tfunc(env), linfo, ci.val)
+end
+
 # Query whether the given builtin is guaranteed not to throw given the argtypes
 function _builtin_nothrow(@nospecialize(f), argtypes::Array{Any,1}, @nospecialize(rt))
     if f === arrayset

--- a/base/compiler/typelattice.jl
+++ b/base/compiler/typelattice.jl
@@ -54,6 +54,15 @@ struct PartialTypeVar
     PartialTypeVar(tv::TypeVar, lb_certain::Bool, ub_certain::Bool) = new(tv, lb_certain, ub_certain)
 end
 
+mutable struct PartialYAKC
+    t::Type
+    env::Any
+    parent::MethodInstance
+    ci::Any
+    # TODO: Where do we cache these results?
+end
+widenconst(py::PartialYAKC) = py.t
+
 # Wraps a type and represents that the value may also be undef at this point.
 # (only used in optimize, not abstractinterpret)
 struct MaybeUndef
@@ -161,6 +170,9 @@ function ⊑(@nospecialize(a), @nospecialize(b))
             return true
         end
         return false
+    end
+    if isa(a, PartialYAKC)
+        return widenconst(a) <: widenconst(b)
     end
     if isa(a, Const)
         if isa(b, Const)

--- a/base/compiler/types.jl
+++ b/base/compiler/types.jl
@@ -23,7 +23,7 @@ abstract type AbstractInterpreter; end
 A type that represents the result of running type inference on a chunk of code.
 """
 mutable struct InferenceResult
-    linfo::MethodInstance
+    linfo::Union{Nothing, MethodInstance}
     argtypes::Vector{Any}
     overridden_by_const::BitVector
     result # ::Type, or InferenceState if WIP
@@ -31,6 +31,9 @@ mutable struct InferenceResult
     function InferenceResult(linfo::MethodInstance, given_argtypes = nothing)
         argtypes, overridden_by_const = matching_cache_argtypes(linfo, given_argtypes)
         return new(linfo, argtypes, overridden_by_const, Any, nothing)
+    end
+    function InferenceResult(::Type{Core.YAKC}, argtypes::Vector{Any})
+        new(nothing, argtypes, BitVector(), Any, nothing)
     end
 end
 

--- a/base/yakc.jl
+++ b/base/yakc.jl
@@ -1,0 +1,19 @@
+@noinline function (y::Core.YAKC{A, R})(args...) where {A,R}
+    typeassert(args, A)
+    ccall(y.fptr1, Any, (Any, Ptr{Any}, Int), y, Any[args...], length(args))::R
+end
+
+"""
+    _yakc(argt::Type{<:Tuple}, lb::Type, ub::Type, source::CodeInfo, captures...)
+
+Create a new YAKC taking arguments specified by the types `argt`. When called,
+this yakc will execute the source specified in `source`. The `lb` and `ub`
+arguments constrain the return type of the yakc. In particular, any return
+value of type `Core.YAKC{argt, R} where lb<:R<:ub` is semantically valid. If
+the optimizer runs, it may replace `R` by the narrowest possible type inference
+was able to determine. To guarantee a particular value of `R`, set lb===ub.
+"""
+Core._yakc
+
+
+# YAKC macro goes here

--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,7 @@ RUNTIME_SRCS := \
 	simplevector runtime_intrinsics precompile \
 	threading partr stackwalk gc gc-debug gc-pages gc-stacks method \
 	jlapi signal-handling safepoint timing subtype \
-	crc32c APInt-C processor ircode
+	crc32c APInt-C processor ircode yakc
 SRCS := jloptions runtime_ccall rtutils
 
 LLVMLINK :=

--- a/src/builtin_proto.h
+++ b/src/builtin_proto.h
@@ -35,6 +35,7 @@ DECLARE_BUILTIN(apply_type); DECLARE_BUILTIN(applicable);
 DECLARE_BUILTIN(invoke);     DECLARE_BUILTIN(_expr);
 DECLARE_BUILTIN(typeassert); DECLARE_BUILTIN(ifelse);
 DECLARE_BUILTIN(_typevar);   DECLARE_BUILTIN(_typebody);
+DECLARE_BUILTIN(_yakc);
 
 JL_CALLABLE(jl_f_invoke_kwsorter);
 JL_CALLABLE(jl_f__structtype);

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -1395,6 +1395,20 @@ JL_CALLABLE(jl_f__equiv_typedef)
     return equiv_type(args[0], args[1]) ? jl_true : jl_false;
 }
 
+// yakc
+JL_CALLABLE(jl_f__yakc)
+{
+    JL_NARGSV(_yakc, 4)
+    JL_TYPECHK(_yakc, type, args[0]);
+    JL_TYPECHK(_yakc, type, args[1]);
+    JL_TYPECHK(_yakc, type, args[2]);
+    if (!jl_is_method(args[3]) && !jl_is_code_info(args[3])) {
+        jl_error("Invalid YAKC source");
+    }
+    return (jl_value_t*)jl_new_yakc((jl_tupletype_t*)args[0], args[1], args[2],
+        args[3], args+4, nargs-4);
+}
+
 // IntrinsicFunctions ---------------------------------------------------------
 
 static void (*runtime_fp[num_intrinsics])(void);
@@ -1554,6 +1568,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     jl_builtin__apply_iterate = add_builtin_func("_apply_iterate", jl_f__apply_iterate);
     jl_builtin__expr = add_builtin_func("_expr", jl_f__expr);
     jl_builtin_svec = add_builtin_func("svec", jl_f_svec);
+    jl_builtin__yakc = add_builtin_func("_yakc", jl_f__yakc);
     add_builtin_func("_apply_pure", jl_f__apply_pure);
     add_builtin_func("_apply_latest", jl_f__apply_latest);
     add_builtin_func("_apply_in_world", jl_f__apply_in_world);
@@ -1604,6 +1619,7 @@ void jl_init_primitives(void) JL_GC_DISABLED
     add_builtin("Ptr", (jl_value_t*)jl_pointer_type);
     add_builtin("LLVMPtr", (jl_value_t*)jl_llvmpointer_type);
     add_builtin("Task", (jl_value_t*)jl_task_type);
+    add_builtin("YAKC", (jl_value_t*)jl_yakc_type);
 
     add_builtin("AbstractArray", (jl_value_t*)jl_abstractarray_type);
     add_builtin("DenseArray", (jl_value_t*)jl_densearray_type);

--- a/src/clangsa/GCChecker.cpp
+++ b/src/clangsa/GCChecker.cpp
@@ -756,6 +756,7 @@ bool GCChecker::isGCTrackedType(QualType QT) {
                    Name.endswith_lower("jl_task_t") ||
                    Name.endswith_lower("jl_uniontype_t") ||
                    Name.endswith_lower("jl_method_match_t") ||
+                   Name.endswith_lower("jl_yakc_t") ||
                    // Probably not technically true for these, but let's allow
                    // it
                    Name.endswith_lower("typemap_intersection_env") ||

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -930,8 +930,9 @@ static void init_struct_tail(jl_datatype_t *type, jl_value_t *jv, size_t na)
 JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, uint32_t na)
 {
     jl_ptls_t ptls = jl_get_ptls_states();
-    if (!jl_is_datatype(type) || type->layout == NULL)
+    if (!jl_is_datatype(type) || type->layout == NULL) {
         jl_type_error("new", (jl_value_t*)jl_datatype_type, (jl_value_t*)type);
+    }
     if (type->ninitialized > na || na > jl_datatype_nfields(type))
         jl_error("invalid struct allocation");
     for (size_t i = 0; i < na; i++) {

--- a/src/dump.c
+++ b/src/dump.c
@@ -2576,7 +2576,6 @@ void jl_init_serializer(void)
                      jl_box_int64(12), jl_box_int64(13), jl_box_int64(14),
                      jl_box_int64(15), jl_box_int64(16), jl_box_int64(17),
                      jl_box_int64(18), jl_box_int64(19), jl_box_int64(20),
-                     jl_box_int64(21),
 
                      jl_bool_type, jl_linenumbernode_type, jl_pinode_type,
                      jl_upsilonnode_type, jl_type_type, jl_bottom_type, jl_ref_type,
@@ -2592,6 +2591,7 @@ void jl_init_serializer(void)
                      jl_namedtuple_type, jl_array_int32_type,
                      jl_typedslot_type, jl_uint32_type, jl_uint64_type,
                      jl_type_type_mt, jl_nonfunction_mt,
+                     jl_yakc_type,
 
                      ptls->root_task,
 
@@ -2660,6 +2660,7 @@ void jl_init_serializer(void)
     arraylist_push(&builtin_typenames, jl_tuple_typename);
     arraylist_push(&builtin_typenames, jl_vararg_typename);
     arraylist_push(&builtin_typenames, jl_namedtuple_typename);
+    arraylist_push(&builtin_typenames, jl_yakc_typename);
 }
 
 #ifdef __cplusplus

--- a/src/gf.c
+++ b/src/gf.c
@@ -205,7 +205,6 @@ JL_DLLEXPORT jl_value_t *jl_methtable_lookup(jl_methtable_t *mt, jl_value_t *typ
 
 // ----- MethodInstance specialization instantiation ----- //
 
-JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t*);
 JL_DLLEXPORT jl_code_instance_t* jl_new_codeinst(
         jl_method_instance_t *mi, jl_value_t *rettype,
         jl_value_t *inferred_const, jl_value_t *inferred,
@@ -2410,8 +2409,6 @@ JL_DLLEXPORT jl_value_t *jl_gf_invoke_lookup_worlds(jl_value_t *types, size_t wo
     return (jl_value_t*)matc->method;
 }
 
-static jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
-
 // invoke()
 // this does method dispatch with a set of types to match other than the
 // types of the actual arguments. this means it sometimes does NOT call the
@@ -2441,7 +2438,7 @@ jl_value_t *jl_gf_invoke(jl_value_t *types0, jl_value_t *gf, jl_value_t **args, 
     return jl_gf_invoke_by_method(method, gf, args, nargs);
 }
 
-static jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs)
+jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs)
 {
     jl_method_instance_t *mfunc = NULL;
     jl_typemap_entry_t *tm = NULL;

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -44,9 +44,9 @@ extern void JL_GC_ENABLEFRAME(interpreter_state*) JL_NOTSAFEPOINT;
 // This is necessary, because otherwise the analyzer considers this undefined
 // behavior and terminates the exploration
 #define JL_GC_PUSHFRAME(frame,n)     \
-  JL_CPPALLOCA(frame, sizeof(*frame)+((n) * sizeof(jl_value_t*)));                  \
+  JL_CPPALLOCA(frame, sizeof(*frame)+((n+3) * sizeof(jl_value_t*)));                  \
   memset(&frame[1], 0, sizeof(void*) * n); \
-  _JL_GC_PUSHARGS((jl_value_t**)&frame[1], n);
+  _JL_GC_PUSHARGS(&((void**)&frame[1])[3], n);
 
 #else
 
@@ -646,6 +646,41 @@ jl_value_t *NOINLINE jl_fptr_interpret_call(jl_value_t *f, jl_value_t **args, ui
     s->continue_at = 0;
     s->mi = mi;
     JL_GC_ENABLEFRAME(s);
+    jl_value_t *r = eval_body(stmts, s, 0, 0);
+    JL_GC_POP();
+    return r;
+}
+
+jl_value_t *jl_interpret_yakc(jl_yakc_t *yakc, jl_value_t **args, size_t nargs)
+{
+    jl_code_info_t *source = NULL;
+    jl_value_t *code = yakc->code;
+    if (jl_is_method(code)) {
+        source = (jl_code_info_t*)yakc->method->source;
+    }
+    else {
+        source = yakc->source;
+    }
+    jl_array_t *stmts = source->code;
+    assert(jl_typeis(stmts, jl_array_any_type));
+    interpreter_state *s;
+    unsigned nroots = jl_source_nslots(source) + jl_source_nssavalues(source) + 2;
+    JL_GC_PUSHFRAME(s, nroots);
+    jl_value_t **locals = (jl_value_t**)&s[1] + 3;
+    locals[0] = (jl_value_t*)yakc;
+    // The analyzer has some trouble with this
+    locals[1] = (jl_value_t*)stmts;
+    JL_GC_PROMISE_ROOTED(stmts);
+    locals[2] = (jl_value_t*)yakc->env;
+    s->locals = locals + 2;
+    s->src = source;
+    s->module = NULL;
+    s->sparam_vals = NULL;
+    s->preevaluation = 0;
+    s->continue_at = 0;
+    s->mi = NULL;
+    for (int i = 0; i < nargs; ++i)
+        s->locals[1 + i] = args[i];
     jl_value_t *r = eval_body(stmts, s, 0, 0);
     JL_GC_POP();
     return r;

--- a/src/julia.h
+++ b/src/julia.h
@@ -351,6 +351,19 @@ struct _jl_method_instance_t {
     uint8_t inInference; // flags to tell if inference is running on this object
 };
 
+// YACK - Yet another kind of closure.
+typedef struct jl_yakc_t {
+    JL_DATA_TYPE
+    jl_value_t *env;
+    union {
+        jl_value_t *code;
+        jl_code_info_t *source;
+        jl_method_t *method;
+    };
+    jl_fptr_args_t fptr1;
+    void *fptr;
+} jl_yakc_t;
+
 // This type represents an executable operation
 typedef struct _jl_code_instance_t {
     JL_DATA_TYPE
@@ -624,6 +637,8 @@ extern JL_DLLEXPORT jl_unionall_t *jl_vararg_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_vararg_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_function_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_builtin_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_unionall_t *jl_yakc_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_typename_t *jl_yakc_typename JL_GLOBALLY_ROOTED;
 
 extern JL_DLLEXPORT jl_value_t *jl_bottom_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_method_instance_type JL_GLOBALLY_ROOTED;
@@ -1206,6 +1221,19 @@ STATIC_INLINE int jl_is_array(void *v) JL_NOTSAFEPOINT
 {
     jl_value_t *t = jl_typeof(v);
     return jl_is_array_type(t);
+}
+
+
+STATIC_INLINE int jl_is_yakc_type(void *t) JL_NOTSAFEPOINT
+{
+    return (jl_is_datatype(t) &&
+            ((jl_datatype_t*)(t))->name == jl_yakc_typename);
+}
+
+STATIC_INLINE int jl_is_yakc(void *v) JL_NOTSAFEPOINT
+{
+    jl_value_t *t = jl_typeof(v);
+    return jl_is_yakc_type(t);
 }
 
 STATIC_INLINE int jl_is_cpointer_type(jl_value_t *t) JL_NOTSAFEPOINT

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -484,6 +484,7 @@ jl_array_t *jl_get_loaded_modules(void);
 jl_value_t *jl_toplevel_eval_flex(jl_module_t *m, jl_value_t *e, int fast, int expanded);
 
 jl_value_t *jl_eval_global_var(jl_module_t *m JL_PROPAGATES_ROOT, jl_sym_t *e);
+jl_value_t *jl_interpret_yakc(jl_yakc_t *yakc, jl_value_t **args, size_t nargs);
 jl_value_t *jl_interpret_toplevel_thunk(jl_module_t *m, jl_code_info_t *src);
 jl_value_t *jl_interpret_toplevel_expr_in(jl_module_t *m, jl_value_t *e,
                                           jl_code_info_t *src,
@@ -493,6 +494,8 @@ jl_value_t *jl_call_scm_on_ast(const char *funcname, jl_value_t *expr, jl_module
 void jl_linenumber_to_lineinfo(jl_code_info_t *ci, jl_module_t *mod, jl_value_t *name);
 
 jl_method_instance_t *jl_method_lookup(jl_value_t **args, size_t nargs, size_t world);
+
+jl_value_t *jl_gf_invoke_by_method(jl_method_t *method, jl_value_t *gf, jl_value_t **args, size_t nargs);
 jl_value_t *jl_gf_invoke(jl_value_t *types, jl_value_t *f, jl_value_t **args, size_t nargs);
 JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int include_ambiguous,
                                              size_t world, size_t *min_valid, size_t *max_valid, int *ambig);
@@ -514,6 +517,8 @@ void jl_binding_deprecation_warning(jl_module_t *m, jl_binding_t *b);
 extern jl_array_t *jl_module_init_order JL_GLOBALLY_ROOTED;
 extern htable_t jl_current_modules JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT void jl_compile_extern_c(void *llvmmod, void *params, void *sysimg, jl_value_t *declrt, jl_value_t *sigt);
+
+jl_yakc_t *jl_new_yakc(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub, jl_value_t *source,  jl_value_t **env, size_t nenv);
 
 // Each tuple can exist in one of 4 Vararg states:
 //   NONE: no vararg                            Tuple{Int,Float32}
@@ -707,6 +712,8 @@ void jl_get_function_id(void *native_code, jl_code_instance_t *ncode,
 // make sure it is rooted if it is used after the function returns
 JL_DLLEXPORT jl_array_t *jl_idtable_rehash(jl_array_t *a, size_t newsz);
 jl_value_t **jl_table_peek_bp(jl_array_t *a, jl_value_t *key) JL_NOTSAFEPOINT;
+
+JL_DLLEXPORT jl_method_t *jl_new_method_uninit(jl_module_t*);
 
 JL_DLLEXPORT jl_methtable_t *jl_new_method_table(jl_sym_t *name, jl_module_t *module);
 jl_method_instance_t *jl_get_specialization1(jl_tupletype_t *types, size_t world, size_t *min_valid, size_t *max_valid, int mt_cache);

--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -46,6 +46,7 @@ static void *const _tags[] = {
          &jl_vararg_type, &jl_abstractarray_type,
          &jl_densearray_type, &jl_nothing_type, &jl_function_type, &jl_typeofbottom_type,
          &jl_unionall_type, &jl_typename_type, &jl_builtin_type, &jl_code_info_type,
+         &jl_yakc_type,
          &jl_task_type, &jl_uniontype_type, &jl_abstractstring_type,
          &jl_array_any_type, &jl_intrinsic_type, &jl_abstractslot_type,
          &jl_methtable_type, &jl_typemap_level_type, &jl_typemap_entry_type,
@@ -60,7 +61,7 @@ static void *const _tags[] = {
          // special typenames
          &jl_tuple_typename, &jl_pointer_typename, &jl_llvmpointer_typename, &jl_array_typename, &jl_type_typename,
          &jl_vararg_typename, &jl_namedtuple_typename,
-         &jl_vecelement_typename,
+         &jl_vecelement_typename, &jl_yakc_typename,
          // special exceptions
          &jl_errorexception_type, &jl_argumenterror_type, &jl_typeerror_type,
          &jl_methoderror_type, &jl_loaderror_type, &jl_initerror_type,
@@ -85,6 +86,7 @@ static void *const _tags[] = {
          &jl_builtin_const_arrayref, &jl_builtin_arrayset, &jl_builtin_arraysize,
          &jl_builtin_apply_type, &jl_builtin_applicable, &jl_builtin_invoke,
          &jl_builtin__expr, &jl_builtin_ifelse, &jl_builtin__typebody,
+         &jl_builtin__yakc,
          NULL };
 static jl_value_t **const*const tags = (jl_value_t**const*const)_tags;
 
@@ -125,7 +127,7 @@ static const jl_fptr_args_t id_to_fptrs[] = {
     &jl_f_arrayref, &jl_f_const_arrayref, &jl_f_arrayset, &jl_f_arraysize, &jl_f_apply_type,
     &jl_f_applicable, &jl_f_invoke, &jl_f_sizeof, &jl_f__expr, &jl_f__typevar,
     &jl_f_ifelse, &jl_f__structtype, &jl_f__abstracttype, &jl_f__primitivetype,
-    &jl_f__typebody, &jl_f__setsuper, &jl_f__equiv_typedef,
+    &jl_f__typebody, &jl_f__setsuper, &jl_f__equiv_typedef, &jl_f__yakc,
     NULL };
 
 typedef struct {

--- a/src/yakc.c
+++ b/src/yakc.c
@@ -1,0 +1,48 @@
+#include "julia.h"
+#include "julia_internal.h"
+
+JL_DLLEXPORT jl_value_t *jl_invoke_yakc(jl_yakc_t *yakc, jl_value_t **args, size_t nargs)
+{
+    // TODO: Compiler support
+    jl_tupletype_t *argt = jl_tparam0(jl_typeof(yakc));
+    if (nargs != jl_nparams(argt))
+        jl_error("Incorrect argument count for YAKC");
+    for (int i = 0; i < nargs; ++i)
+        jl_typeassert(args[i], jl_field_type(argt, i));
+    jl_value_t *ret;
+    JL_GC_PUSH1(&ret);
+    if (jl_is_method(yakc->source)) {
+        ret = jl_gf_invoke_by_method((jl_method_t*)yakc->source, yakc, args, nargs + 1);
+    } else {
+        ret = jl_interpret_yakc(yakc, args, nargs);
+    }
+    jl_typeassert(ret, jl_tparam1(jl_typeof(yakc)));
+    JL_GC_POP();
+    return ret;
+}
+
+jl_yakc_t *jl_new_yakc(jl_tupletype_t *argt, jl_value_t *rt_lb, jl_value_t *rt_ub, jl_value_t *source, jl_value_t **env, size_t nenv)
+{
+    jl_ptls_t ptls = jl_get_ptls_states();
+    jl_value_t *yakc_t;
+    jl_yakc_t *yakc;
+    JL_GC_PUSH2(&yakc_t, &yakc);
+    yakc_t = jl_apply_type2((jl_value_t*)jl_yakc_type, argt, rt_ub);
+    yakc = jl_gc_alloc(ptls, sizeof(jl_yakc_t), yakc_t);
+    yakc->source = source;
+    yakc->fptr1 = jl_invoke_yakc;
+    yakc->fptr = NULL;
+    yakc->env = jl_f_tuple(NULL, env, nenv);
+    JL_GC_POP();
+    return yakc;
+}
+
+
+JL_DLLEXPORT jl_method_t* jl_mk_yakc_method(jl_module_t *def_mod)
+{
+    jl_method_t *m = jl_new_method_uninit(def_mod);
+    m->name = jl_symbol("YAKC");
+    m->sig = (jl_value_t*)jl_anytuple_type;
+    m->slot_syms = jl_an_empty_string;
+    return m;
+}

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -54,7 +54,8 @@ function choosetests(choices = [])
         "checked", "bitset", "floatfuncs", "precompile",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap"
+        "reinterpretarray", "syntax", "corelogging", "missing", "asyncmap",
+        "yakc"
     ]
 
     tests = []

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -121,7 +121,7 @@ let cfg = CFG(BasicBlock[
     make_bb([2, 3]    , []    ),
 ], Int[])
     insts = Compiler.InstructionStream([], [], Any[], Int32[], UInt8[])
-    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], [], [])
+    code = Compiler.IRCode(insts, cfg, LineInfoNode[], [], [], [], Compiler.IRCode[])
     compact = Compiler.IncrementalCompact(code, true)
     @test length(compact.result_bbs) == 4 && 0 in compact.result_bbs[3].preds
 end

--- a/test/yakc.jl
+++ b/test/yakc.jl
@@ -1,0 +1,96 @@
+using Test
+using InteractiveUtils
+
+const_int() = 1
+
+let ci = @code_lowered const_int()
+    @eval function yakc_trivial()
+        $(Expr(:call, Core._yakc, Tuple{}, Any, Any, ci))
+    end
+end
+@test isa(yakc_trivial(), Core.YAKC{Tuple{}, Any})
+@test yakc_trivial()() == 1
+
+let ci = @code_lowered const_int()
+    @eval function yakc_simple_inf()
+        $(Expr(:call, Core._yakc, Tuple{}, Union{}, Any, ci))
+    end
+end
+@test isa(yakc_simple_inf(), Core.YAKC{Tuple{}, Int})
+@test yakc_simple_inf()() == 1
+
+struct YakcClos2Int
+    a::Int
+    b::Int
+end
+(a::YakcClos2Int)() = getfield(a, 1) + getfield(a, 2)
+let ci = @code_lowered YakcClos2Int(1, 2)();
+    @eval function yakc_trivial_clos()
+        $(Expr(:call, Core._yakc, Tuple{}, Int, Int, ci, 1, 2))
+    end
+end
+@test yakc_trivial_clos()() == 3
+
+let ci = @code_lowered YakcClos2Int(1, 2)();
+    @eval function yakc_self_call_clos()
+        $(Expr(:call, Core._yakc, Tuple{}, Int, Int, ci, 1, 2))()
+    end
+end
+@test yakc_self_call_clos() == 3
+let opt = @code_typed yakc_self_call_clos()
+    @test length(opt[1].code) == 1
+    @test isa(opt[1].code[1], Core.ReturnNode)
+end
+
+struct YakcClos1Any
+    a
+end
+(a::YakcClos1Any)() = getfield(a, 1)
+let ci = @code_lowered YakcClos1Any(1)()
+    @eval function yakc_pass_clos(x)
+        $(Expr(:call, Core._yakc, Tuple{}, Any, Any, ci, :x))
+    end
+end
+@test yakc_pass_clos(1)() == 1
+@test yakc_pass_clos("a")() == "a"
+
+let ci = @code_lowered YakcClos1Any(1)()
+    @eval function yakc_infer_pass_clos(x)
+        $(Expr(:call, Core._yakc, Tuple{}, Union{}, Any, ci, :x))
+    end
+end
+@test isa(yakc_infer_pass_clos(1), Core.YAKC{Tuple{}, typeof(1)})
+@test isa(yakc_infer_pass_clos("a"), Core.YAKC{Tuple{}, typeof("a")})
+@test yakc_infer_pass_clos(1)() == 1
+@test yakc_infer_pass_clos("a")() == "a"
+
+let ci = @code_lowered identity(1)
+    @eval function yakc_infer_pass_id()
+        $(Expr(:call, Core._yakc, Tuple{Any}, Any, Any, ci))
+    end
+end
+function complicated_identity(x)
+    yakc_infer_pass_id()(x)
+end
+@test @inferred(complicated_identity(1)) == 1
+@test @inferred(complicated_identity("a")) == "a"
+
+struct YakcOpt
+    A
+end
+
+(A::YakcOpt)() = ndims(getfield(A, 1))
+
+let ci = @code_lowered YakcOpt([1 2])()
+    @eval function yakc_opt_ndims(A)
+        $(Expr(:call, Core._yakc, Tuple{}, Union{}, Any,  ci, :A))
+    end
+end
+yakc_opt_ndims([1 2])
+
+let A = [1 2]
+    let yakc = yakc_opt_ndims(A)
+        @test sizeof(yakc.env) == 0
+        @test yakc() == 2
+    end
+end


### PR DESCRIPTION
 # Overview

This PR is a sketch implementation of an alternative mechanism of
implementing closures. It is designed to be complementary to the
existing closure mechanism and makes some different trade offs.
The motivation for this mechanism comes primarily from closure-based
AD tools like Zygote, but I'm expecting it will find other use cases
as well. It's a little hard to name this, because it's just another
way to implement closures. I discussed this with jeff and options
that were considered were "Arrow Closures" or "Non-Nominal Closures",
but for now I'm just calling them "Yet Another Kind of Closure" (YAKC,
pronounced yak-c, rhymes with yahtzee). This PR is in very early
stages, so in order to explain what this is and what this does, I
may describe features that are not yet implemented. See the end of the
commit message to see the current status.

 # Motivation
 ## Optimization across closure boundaries

Consider the following situation (type annotations are inference
results, not type asserts)
```
function foo()
    a = expensive_but_effect_free()::Any
    b = something()::Float64
    ()->!isa(b, Float64) ? return a : return nothing
end
```

now, the traditional closure mechanism will lower this to:

```
struct ###{T, S}
   a::T
   b::S
end
(x::###{T,S}) = !isa(x.b, Float64) ? return x.a : return nothing
function foo()
    a = expensive_but_effect_free()::Any
    b = something()::Float64
    new(a, b)
end
```

the problem with this is apparent: Even though after inference,
we know that `a` is unused in the closure (and thus would be
able to delete the expensive call were it not for the capture),
we may not delete it, simply because we need to satisfy the full
capture list of the closure. Ideally, we would like to have a mechanism
where the optimizer may modify the capture list of a closure in
response to information it discovers.

 ## Closures from Casette transforms

Compiler passes like Zygote would like to generate new closures
from untyped IR (i.e. after the frontend runs) (and in the future
potentially typed IR also). We currently do not have a great mechanism
to support this (it is somewhat possible by constructing an object
that redoes the primal analysis, but it's awkward at the very least).
This provides a very straightforward implementation of this feature.

 # Mechanism

The primary concept introduced by this PR is the `YAKC` type, defined
as follows:
```
struct YAKC{A <: Tuple, R}
     env::Any
     ci::CodeInfo
 end

 function (y::YAKC{A, R})(args...) where {A,R}
     typeassert(args, A)
     ccall(:jl_invoke_yakc, Any, (Any, Any), y, args)::R
 end
```
The dynamic semantics are that calling the yakc will run whatever code
is stored in the `.ci` object, using `env` as the self argument. This
is augmented by special support in inference and the optimizer to
co-optimize yakcs that appear in bodies of functions along with their
containing functions in order to enable things like cross-closure DCE.

Note that argument types and return types are explicitly specified,
rather than inferred. The reason for this is to prevent YAKCs from
participating in inference cycles and to allow return-type information
to be provided to inference without having to look at the contained
CodeInfo (because the contents of the CodeInfo are not interprocedurally
valid and may in general depend on what the optimizer was able to
figure out about the program). This is also done with a few to an
extension where the CodeInfo inside the yakc is not generated until
later in the optimization pipeline. It would be possible to optionally
allow return-type inference of the yatc based on the unoptimized
CodeInfo (if available), but that is not currently within the scope
of my planned work in this PR.

 # Status

The PR has the bare bones support for yakcs, including some initial
support for inling and inference, though that support is known to
be incorrect and incomplete. There are also currently no nice
front-end forms. For explanatory and testing purposes, I would like to
provide a macro of the form:
```
function foo()
    a = expensive_but_effect_free()::Any
    b = something()::Float64
    @yakc ()->!isa(b, Float64) ? return a : return nothing
end
```
but that is not implemented yet. At the moment, the codeinfo needs
to be spliced in manually (here we're abusing `code_lowered` to construct
us a CodeInfo of the appropriate form), e.g.:
```
julia> bar() = 1
bar (generic function with 1 method)

julia> ci = @code_lowered bar();

julia> @eval function foo1()
          f = $(Expr(:new, :(Core.YAKC{Tuple{}, Int64}), nothing, ci))
       end
foo1 (generic function with 1 method)

julia> @eval function foo2()
          f = $(Expr(:new, :(Core.YAKC{Tuple{}, Int64}), nothing, ci))
          f()
       end
foo2 (generic function with 1 method)

julia> foo1()
Core.YAKC{Tuple{},Int64}(nothing, CodeInfo(
1 ─     return 1
))

julia> foo1()()
1

julia> @code_typed foo2()
CodeInfo(
1 ─     return 1
) => Int64

julia> struct Test
           a::Int
           b::Int
       end

julia> (a::Test)() = getfield(a, 1) + getfield(a, 2)

julia> ci2 = @code_lowered Test(1, 2)();

julia> @eval function foo2()
          f = $(Expr(:new, :(Core.YAKC{Tuple{}, Int64}), (1, 2), ci2))
          f()
       end
foo2 (generic function with 1 method)

julia> @code_typed foo2()
CodeInfo(
1 ─     return 3
) => Int64
```

TODO:
 - [x] Show that this actually helps the Zygote use case I care about
 - [ ] Frontend support
 - [x] Better optimizations (detection of need for recursive inlining)
 - [x] Codegen for yakcs (right now they're interpreted)