### PR TITLE
build,macos: correct the install name of several libraries

### DIFF
--- a/deps/pcre.mk
+++ b/deps/pcre.mk
@@ -35,6 +35,7 @@ endif
 $(eval $(call staged-install, \
 	pcre,pcre2-$$(PCRE_VER), \
 	MAKE_INSTALL,$$(LIBTOOL_CCLD),, \
+	rm $$(build_shlibdir)/libpcre2-posix.* && \
 	$$(INSTALL_NAME_CMD)libpcre2-8.$$(SHLIB_EXT) $$(build_shlibdir)/libpcre2-8.$$(SHLIB_EXT)))
 
 clean-pcre:

--- a/src/Makefile
+++ b/src/Makefile
@@ -169,6 +169,7 @@ JULIA_SPLITDEBUG := 0
 endif
 $(build_shlibdir)/libccalltest.$(SHLIB_EXT): $(SRCDIR)/ccalltest.c
 	@$(call PRINT_CC, $(CC) $(JCFLAGS) $(JCPPFLAGS) $(DEBUGFLAGS) -O3 $< $(fPIC) -shared -o $@.tmp $(JLDFLAGS))
+	$(INSTALL_NAME_CMD)libccalltest.$(SHLIB_EXT) $@.tmp
 ifeq ($(JULIA_SPLITDEBUG),1)
 	@# Create split debug info file for libccalltest stacktraces test
 	@# packagers should disable this by setting JULIA_SPLITDEBUG=0 if this is already done by your build system


### PR DESCRIPTION
Had done this for Linux and Windows in #31196, but accidentally dropped it for macOS in the process.

fixes #31259