### PR TITLE
Document SharedVector and SharedMatrix

### DIFF
--- a/stdlib/SharedArrays/docs/src/index.md
+++ b/stdlib/SharedArrays/docs/src/index.md
@@ -2,6 +2,8 @@
 
 ```@docs
 SharedArrays.SharedArray
+SharedArrays.SharedVector
+SharedArrays.SharedMatrix
 SharedArrays.procs(::SharedArray)
 SharedArrays.sdata
 SharedArrays.indexpids

--- a/stdlib/SharedArrays/src/SharedArrays.jl
+++ b/stdlib/SharedArrays/src/SharedArrays.jl
@@ -275,7 +275,17 @@ function finalize_refs(S::SharedArray{T,N}) where T where N
     S
 end
 
+"""
+    SharedVector
+
+A one-dimensional [`SharedArray`](@ref).
+"""
 const SharedVector{T} = SharedArray{T,1}
+"""
+    SharedMatrix
+
+A one-dimensional [`SharedArray`](@ref).
+"""
 const SharedMatrix{T} = SharedArray{T,2}
 
 SharedVector(A::Vector) = SharedArray(A)


### PR DESCRIPTION
Since the `SharedArray` docs are so extensive and thorough I thought it was better to be a bit minimalist with these.