### PR TITLE
improve ispath docstring

### DIFF
--- a/base/stat.jl
+++ b/base/stat.jl
@@ -153,7 +153,7 @@ ctime(st::StatStruct) = st.ctime
 
 Return `true` if a valid filesystem entity exists at `path`,
 otherwise returns `false`.
-This is the generalization of [isfile](@ref), [isdir](@ref) etc.
+This is the generalization of [`isfile`](@ref), [`isdir`](@ref) etc.
 """
 ispath(st::StatStruct) = filemode(st) & 0xf000 != 0x0000
 
@@ -185,7 +185,7 @@ julia> isdir("not/a/directory")
 false
 ```
 
-See also: [isfile](@ref) and [ispath](@ref).
+See also: [`isfile`](@ref) and [`ispath`](@ref).
 """
 isdir(st::StatStruct) = filemode(st) & 0xf000 == 0x4000
 
@@ -214,7 +214,7 @@ true
 julia> close(f); rm("test_file.txt")
 ```
 
-See also: [isdir](@ref) and [ispath](@ref).
+See also: [`isdir`](@ref) and [`ispath`](@ref).
 """
 isfile(st::StatStruct) = filemode(st) & 0xf000 == 0x8000
 

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -14,7 +14,7 @@ export
     isfile,
     islink,
     ismount,
-    nz,
+    ispath,
     issetgid,
     issetuid,
     issocket,

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -151,7 +151,9 @@ ctime(st::StatStruct) = st.ctime
 """
     ispath(path) -> Bool
 
-Return `true` if `path` is a valid filesystem path, `false` otherwise.
+Return `true` if a valid filesystem entity exists at `path`,
+otherwise returns `false`.
+This is the generalization of [isfile](@ref), [isdir](@ref) etc. 
 """
 ispath(st::StatStruct) = filemode(st) & 0xf000 != 0x0000
 
@@ -182,6 +184,8 @@ true
 julia> isdir("not/a/directory")
 false
 ```
+
+See also: [isfile](@ref) and [ispath](@ref).
 """
 isdir(st::StatStruct) = filemode(st) & 0xf000 == 0x4000
 
@@ -209,6 +213,8 @@ true
 
 julia> close(f); rm("test_file.txt")
 ```
+
+See also: [isdir](@ref) and [ispath](@ref).
 """
 isfile(st::StatStruct) = filemode(st) & 0xf000 == 0x8000
 

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -14,7 +14,7 @@ export
     isfile,
     islink,
     ismount,
-    ispath,
+    nz,
     issetgid,
     issetuid,
     issocket,
@@ -153,7 +153,7 @@ ctime(st::StatStruct) = st.ctime
 
 Return `true` if a valid filesystem entity exists at `path`,
 otherwise returns `false`.
-This is the generalization of [isfile](@ref), [isdir](@ref) etc. 
+This is the generalization of [isfile](@ref), [isdir](@ref) etc.
 """
 ispath(st::StatStruct) = filemode(st) & 0xf000 != 0x0000
 


### PR DESCRIPTION
I had assumed from the current docstring that `ispath(str)` returned if `str` was a legal filename.
This change hopefully clears it up.

I added crossreferences to `isfile` and `isdir` as when I was looking for `isexistantthing` those are where I checked first hoping to find cross references.
I did not add similar to `islink` or `isfifo` or ...
because there are many of them and it felt spammy