### PR TITLE
Copy global variable linkages when moving functions

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -822,7 +822,7 @@ public:
             GlobalVariable *newGV = new GlobalVariable(*destModule,
                 GV->getType()->getElementType(),
                 GV->isConstant(),
-                GlobalVariable::ExternalLinkage,
+                GV->getLinkage(),
                 NULL,
                 GV->getName(),
                 NULL,

--- a/src/llvmcalltest.cpp
+++ b/src/llvmcalltest.cpp
@@ -29,4 +29,28 @@ JL_DLLEXPORT llvm::Function *MakeIdentityFunction(llvm::PointerType *AnyTy) {
     return F;
 }
 
+JL_DLLEXPORT llvm::Function *MakeLoadGlobalFunction(llvm::PointerType *AnyTy) {
+    auto M = new Module("shadow", AnyTy->getContext());
+    auto intType = Type::getInt32Ty(AnyTy->getContext());
+    auto G = new GlobalVariable(
+        *M,
+        intType,
+        true,
+        GlobalValue::InternalLinkage,
+        Constant::getNullValue(intType),
+        "test_global_var");
+
+    auto resultType = Type::getInt64Ty(AnyTy->getContext());
+    auto F = Function::Create(
+        FunctionType::get(resultType, {}, false),
+        GlobalValue::ExternalLinkage,
+        "load_global_var",
+        M);
+
+    IRBuilder<> Builder(BasicBlock::Create(AnyTy->getContext(), "top", F));
+    Builder.CreateRet(Builder.CreatePtrToInt(G, resultType));
+
+    return F;
+}
+
 }

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -228,6 +228,18 @@ module LLVMCallFunctionTest
     let x = boxed_struct()
         @test really_complicated_identity(x) === x
     end
+
+    # Define two functions that each compute the address of a dedicated internal global variable.
+    # The names of these globals are the same, so if their linkages are overwritten, then the
+    # linker will merge the globals. Consequently, we can test that linkage is preserved by testing
+    # that the addresses of the globals differ. The next few lines of code do just that.
+    const the_other_f1 = ccall((:MakeLoadGlobalFunction, libllvmcalltest), Ptr{Cvoid}, (Ptr{Cvoid},), AnyTy)
+    const the_other_f2 = ccall((:MakeLoadGlobalFunction, libllvmcalltest), Ptr{Cvoid}, (Ptr{Cvoid},), AnyTy)
+
+    @eval global_value_address1() = llvmcall($(the_other_f1), Int64, Tuple{})
+    @eval global_value_address2() = llvmcall($(the_other_f2), Int64, Tuple{})
+
+    @test global_value_address1() != global_value_address2()
 end
 
 # support for calling external functions


### PR DESCRIPTION
Hi! I'd like to propose a one-line change to the `GlobalVariable` copying logic that is invoked when `llvmcall` is passed a pointer to an LLVM function. Currently, any global variables that are used by such a function are copied to the module that performs the `llvmcall`. However, the current global variable copying logic discards linkage information by making all copied globals external.

It'd be really nice if linkage information didn't get discarded&mdash;the current semantics are not what `llvmcall` users seem to expect, judging from, e.g., [this line of code](https://github.com/JuliaGPU/CUDAnative.jl/blob/e6876972af098db99f2e164733037f562eb39704/src/device/cuda_intrinsics/memory_shared.jl#L79) in CUDAnative. The change I'm proposing is to copy global variable linkages when copying global variables. Is that okay?