### PR TITLE
fix #31194, latex chars `upharpoonright` and `upharpoonleft` swapped

### DIFF
--- a/stdlib/REPL/src/latex_symbols.jl
+++ b/stdlib/REPL/src/latex_symbols.jl
@@ -31,6 +31,10 @@ for c in child_nodes(root(xdoc))
                 else
                     if U[1] == '\u22a5' # unicode.xml incorrectly uses \perp for \bot
                         L = "\\bot"
+                    elseif U[1] == '\u21be'
+                        L = "\\upharpoonright"
+                    elseif U[1] == '\u21bf'
+                        L = "\\upharpoonleft"
                     end
                     push!(latexsym, (L, U))
                     push!(Ls, L)
@@ -471,8 +475,8 @@ const latex_symbols = Dict(
     "\\circlearrowright" => "↻",
     "\\leftharpoonup" => "↼",
     "\\leftharpoondown" => "↽",
-    "\\upharpoonleft" => "↾",
-    "\\upharpoonright" => "↿",
+    "\\upharpoonright" => "↾",
+    "\\upharpoonleft" => "↿",
     "\\rightharpoonup" => "⇀",
     "\\rightharpoondown" => "⇁",
     "\\downharpoonright" => "⇂",


### PR DESCRIPTION
This seems to be another mistake in unicode.xml.