### PR TITLE
fix #31256, support `catch_stack` in test system

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -166,6 +166,13 @@ eachindex(itrs...) = keys(itrs...)
 # eachindex iterates over all indices. IndexCartesian definitions are later.
 eachindex(A::AbstractVector) = (@_inline_meta(); axes1(A))
 
+@noinline function throw_eachindex_mismatch(::IndexLinear, A...)
+    throw(DimensionMismatch("all inputs to eachindex must have the same indices, got $(join(LinearIndices.(A), ", ", " and "))"))
+end
+@noinline function throw_eachindex_mismatch(::IndexCartesian, A...)
+    throw(DimensionMismatch("all inputs to eachindex must have the same axes, got $(join(axes.(A), ", ", " and "))"))
+end
+
 """
     eachindex(A...)
 


### PR DESCRIPTION
Also fixes a couple minor problems, (1) output limiting for errors was no longer happening, and (2) DomainError no longer needs to overload 3-argument `showerror`, which was causing it to print slightly differently than other error messages.

fixes #31256 