### PR TITLE
doc: add factorizations docstrings

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -287,20 +287,24 @@ The following table summarizes the types of matrix factorizations that have been
 Julia. Details of their associated methods can be found in the [Standard Functions](@ref) section
 of the Linear Algebra documentation.
 
-| Type              | Description                                                                                                    |
-|:----------------- |:-------------------------------------------------------------------------------------------------------------- |
-| `Cholesky`        | [Cholesky factorization](https://en.wikipedia.org/wiki/Cholesky_decomposition)                                 |
-| `CholeskyPivoted` | [Pivoted](https://en.wikipedia.org/wiki/Pivot_element) Cholesky factorization                                  |
-| `LU`              | [LU factorization](https://en.wikipedia.org/wiki/LU_decomposition)                                             |
-| `LUTridiagonal`   | LU factorization for [`Tridiagonal`](@ref) matrices                                                            |
-| `QR`              | [QR factorization](https://en.wikipedia.org/wiki/QR_decomposition)                                             |
-| `QRCompactWY`     | Compact WY form of the QR factorization                                                                        |
-| `QRPivoted`       | Pivoted [QR factorization](https://en.wikipedia.org/wiki/QR_decomposition)                                     |
-| `Hessenberg`      | [Hessenberg decomposition](http://mathworld.wolfram.com/HessenbergDecomposition.html)                          |
-| `Eigen`           | [Spectral decomposition](https://en.wikipedia.org/wiki/Eigendecomposition_(matrix))                            |
-| `SVD`             | [Singular value decomposition](https://en.wikipedia.org/wiki/Singular_value_decomposition)                     |
-| `GeneralizedSVD`  | [Generalized SVD](https://en.wikipedia.org/wiki/Generalized_singular_value_decomposition#Higher_order_version) |
-
+| Type               | Description                                                                                                    |
+|:------------------ |:-------------------------------------------------------------------------------------------------------------- |
+| `BunchKaufman`     | Bunch-Kaufman factorization                                                                                    |
+| `Cholesky`         | [Cholesky factorization](https://en.wikipedia.org/wiki/Cholesky_decomposition)                                 |
+| `CholeskyPivoted`  | [Pivoted](https://en.wikipedia.org/wiki/Pivot_element) Cholesky factorization                                  |
+| `LDLt`             | [LDL(T) factorization](https://en.wikipedia.org/wiki/Cholesky_decomposition#LDL_decomposition)                 |
+| `LU`               | [LU factorization](https://en.wikipedia.org/wiki/LU_decomposition)                                             |
+| `QR`               | [QR factorization](https://en.wikipedia.org/wiki/QR_decomposition)                                             |
+| `QRCompactWY`      | Compact WY form of the QR factorization                                                                        |
+| `QRPivoted`        | Pivoted [QR factorization](https://en.wikipedia.org/wiki/QR_decomposition)                                     |
+| `LQ`               | [QR factorization](https://en.wikipedia.org/wiki/QR_decomposition) of `transpose(A)`                           |
+| `Hessenberg`       | [Hessenberg decomposition](http://mathworld.wolfram.com/HessenbergDecomposition.html)                          |
+| `Eigen`            | [Spectral decomposition](https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix)                         |
+| `GeneralizedEigen` | [Generalized spectral decomposition](https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix#Generalized_eigenvalue_problem)                            |
+| `SVD`              | [Singular value decomposition](https://en.wikipedia.org/wiki/Singular_value_decomposition)                     |
+| `GeneralizedSVD`   | [Generalized SVD](https://en.wikipedia.org/wiki/Generalized_singular_value_decomposition#Higher_order_version) |
+| `Schur`            | [Schur decomposition](https://en.wikipedia.org/wiki/Schur_decomposition)                                       |
+| `GeneralizedSchur` | [Generalized Schur decomposition](https://en.wikipedia.org/wiki/Schur_decomposition#Generalized_Schur_decomposition) |
 
 
 
@@ -329,25 +333,34 @@ LinearAlgebra.UnitLowerTriangular
 LinearAlgebra.UnitUpperTriangular
 LinearAlgebra.UpperHessenberg
 LinearAlgebra.UniformScaling
+LinearAlgebra.Factorization
+LinearAlgebra.LU
 LinearAlgebra.lu
 LinearAlgebra.lu!
+LinearAlgebra.Cholesky
+LinearAlgebra.CholeskyPivoted
 LinearAlgebra.cholesky
 LinearAlgebra.cholesky!
 LinearAlgebra.lowrankupdate
 LinearAlgebra.lowrankdowndate
 LinearAlgebra.lowrankupdate!
 LinearAlgebra.lowrankdowndate!
+LinearAlgebra.LDLt
 LinearAlgebra.ldlt
 LinearAlgebra.ldlt!
-LinearAlgebra.qr
-LinearAlgebra.qr!
 LinearAlgebra.QR
 LinearAlgebra.QRCompactWY
 LinearAlgebra.QRPivoted
-LinearAlgebra.lq!
+LinearAlgebra.qr
+LinearAlgebra.qr!
+LinearAlgebra.LQ
 LinearAlgebra.lq
+LinearAlgebra.lq!
+LinearAlgebra.BunchKaufman
 LinearAlgebra.bunchkaufman
 LinearAlgebra.bunchkaufman!
+LinearAlgebra.Eigen
+LinearAlgebra.GeneralizedEigen
 LinearAlgebra.eigvals
 LinearAlgebra.eigvals!
 LinearAlgebra.eigmax
@@ -355,12 +368,17 @@ LinearAlgebra.eigmin
 LinearAlgebra.eigvecs
 LinearAlgebra.eigen
 LinearAlgebra.eigen!
+LinearAlgebra.Hessenberg
 LinearAlgebra.hessenberg
 LinearAlgebra.hessenberg!
-LinearAlgebra.schur!
+LinearAlgebra.Schur
+LinearAlgebra.GeneralizedSchur
 LinearAlgebra.schur
+LinearAlgebra.schur!
 LinearAlgebra.ordschur
 LinearAlgebra.ordschur!
+LinearAlgebra.SVD
+LinearAlgebra.GeneralizedSVD
 LinearAlgebra.svd
 LinearAlgebra.svd!
 LinearAlgebra.svdvals

--- a/stdlib/LinearAlgebra/src/bunchkaufman.jl
+++ b/stdlib/LinearAlgebra/src/bunchkaufman.jl
@@ -4,6 +4,65 @@
 ## LD for BunchKaufman, UL for CholeskyDense, LU for LUDense and
 ## define size methods for Factorization types using it.
 
+"""
+    BunchKaufman <: Factorization
+
+Matrix factorization type of the Bunch-Kaufman factorization of a symmetric or
+Hermitian matrix `A` as `P'UDU'P` or `P'LDL'P`, depending on whether the upper
+(the default) or the lower triangle is stored in `A`. If `A` is complex symmetric
+then `U'` and `L'` denote the unconjugated transposes, i.e. `transpose(U)` and
+`transpose(L)`, respectively. This is the return type of [`bunchkaufman`](@ref),
+the corresponding matrix factorization function.
+
+If `S::BunchKaufman` is the factorization object, the components can be obtained
+via `S.D`, `S.U` or `S.L` as appropriate given `S.uplo`, and `S.p`.
+
+Iterating the decomposition produces the components `S.D`, `S.U` or `S.L`
+as appropriate given `S.uplo`, and `S.p`.
+
+# Examples
+```jldoctest
+julia> A = [1 2; 2 3]
+2×2 Array{Int64,2}:
+ 1  2
+ 2  3
+
+julia> S = bunchkaufman(A) # A gets wrapped internally by Symmetric(A)
+BunchKaufman{Float64,Array{Float64,2}}
+D factor:
+2×2 Tridiagonal{Float64,Array{Float64,1}}:
+ -0.333333  0.0
+  0.0       3.0
+U factor:
+2×2 UnitUpperTriangular{Float64,Array{Float64,2}}:
+ 1.0  0.666667
+  ⋅   1.0
+permutation:
+2-element Array{Int64,1}:
+ 1
+ 2
+
+julia> d, u, p = S; # destructuring via iteration
+
+julia> d == S.D && u == S.U && p == S.p
+true
+
+julia> S = bunchkaufman(Symmetric(A, :L))
+BunchKaufman{Float64,Array{Float64,2}}
+D factor:
+2×2 Tridiagonal{Float64,Array{Float64,1}}:
+ 3.0   0.0
+ 0.0  -0.333333
+L factor:
+2×2 UnitLowerTriangular{Float64,Array{Float64,2}}:
+ 1.0        ⋅
+ 0.666667  1.0
+permutation:
+2-element Array{Int64,1}:
+ 2
+ 1
+```
+"""
 struct BunchKaufman{T,S<:AbstractMatrix} <: Factorization{T}
     LD::S
     ipiv::Vector{BlasInt}
@@ -59,8 +118,8 @@ end
 """
     bunchkaufman(A, rook::Bool=false; check = true) -> S::BunchKaufman
 
-Compute the Bunch-Kaufman [^Bunch1977] factorization of a `Symmetric` or
-`Hermitian` matrix `A` as ``P'*U*D*U'*P`` or ``P'*L*D*L'*P``, depending on
+Compute the Bunch-Kaufman [^Bunch1977] factorization of a symmetric or
+Hermitian matrix `A` as `P'*U*D*U'*P` or `P'*L*D*L'*P`, depending on
 which triangle is stored in `A`, and return a `BunchKaufman` object.
 Note that if `A` is complex symmetric then `U'` and `L'` denote
 the unconjugated transposes, i.e. `transpose(U)` and `transpose(L)`.
@@ -90,7 +149,7 @@ julia> A = [1 2; 2 3]
  1  2
  2  3
 
-julia> S = bunchkaufman(A)
+julia> S = bunchkaufman(A) # A gets wrapped internally by Symmetric(A)
 BunchKaufman{Float64,Array{Float64,2}}
 D factor:
 2×2 Tridiagonal{Float64,Array{Float64,1}}:
@@ -109,6 +168,21 @@ julia> d, u, p = S; # destructuring via iteration
 
 julia> d == S.D && u == S.U && p == S.p
 true
+
+julia> S = bunchkaufman(Symmetric(A, :L))
+BunchKaufman{Float64,Array{Float64,2}}
+D factor:
+2×2 Tridiagonal{Float64,Array{Float64,1}}:
+ 3.0   0.0
+ 0.0  -0.333333
+L factor:
+2×2 UnitLowerTriangular{Float64,Array{Float64,2}}:
+ 1.0        ⋅
+ 0.666667  1.0
+permutation:
+2-element Array{Int64,1}:
+ 2
+ 1
 ```
 """
 bunchkaufman(A::AbstractMatrix{T}, rook::Bool=false; check::Bool = true) where {T} =

--- a/stdlib/LinearAlgebra/src/cholesky.jl
+++ b/stdlib/LinearAlgebra/src/cholesky.jl
@@ -27,7 +27,48 @@
 # the cost would be extra unnecessary/unused fields for the unpivoted Cholesky and runtime
 # checks of those fields before calls to LAPACK to check which version of the Cholesky
 # factorization the type represents.
+"""
+    Cholesky <: Factorization
 
+Matrix factorization type of the Cholesky factorization of a dense symmetric/Hermitian
+positive definite matrix `A`. This is the return type of [`cholesky`](@ref),
+the corresponding matrix factorization function.
+
+The triangular Cholesky factor can be obtained from the factorization `F::Cholesky`
+via `F.L` and `F.U`.
+
+# Examples
+```jldoctest
+julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]
+3×3 Array{Float64,2}:
+   4.0   12.0  -16.0
+  12.0   37.0  -43.0
+ -16.0  -43.0   98.0
+
+julia> C = cholesky(A)
+Cholesky{Float64,Array{Float64,2}}
+U factor:
+3×3 UpperTriangular{Float64,Array{Float64,2}}:
+ 2.0  6.0  -8.0
+  ⋅   1.0   5.0
+  ⋅    ⋅    3.0
+
+julia> C.U
+3×3 UpperTriangular{Float64,Array{Float64,2}}:
+2.0  6.0  -8.0
+⋅   1.0   5.0
+⋅    ⋅    3.0
+
+julia> C.L
+3×3 LowerTriangular{Float64,Array{Float64,2}}:
+2.0   ⋅    ⋅
+6.0  1.0   ⋅
+-8.0  5.0  3.0
+
+julia> C.L * C.U == A
+true
+```
+"""
 struct Cholesky{T,S<:AbstractMatrix} <: Factorization{T}
     factors::S
     uplo::Char
@@ -43,6 +84,38 @@ Cholesky(A::AbstractMatrix{T}, uplo::Symbol, info::Integer) where {T} =
 Cholesky(A::AbstractMatrix{T}, uplo::AbstractChar, info::Integer) where {T} =
     Cholesky{T,typeof(A)}(A, uplo, info)
 
+"""
+    CholeskyPivoted
+
+Matrix factorization type of the pivoted Cholesky factorization of a dense symmetric/Hermitian
+positive semi-definite matrix `A`. This is the return type of [`cholesky(_, Val(true))`](@ref),
+the corresponding matrix factorization function.
+
+The triangular Cholesky factor can be obtained from the factorization `F::CholeskyPivoted`
+via `F.L` and `F.U`.
+
+# Examples
+```jldoctest
+julia> A = [4. 12. -16.; 12. 37. -43.; -16. -43. 98.]
+3×3 Array{Float64,2}:
+   4.0   12.0  -16.0
+  12.0   37.0  -43.0
+ -16.0  -43.0   98.0
+
+julia> C = cholesky(A, Val(true))
+CholeskyPivoted{Float64,Array{Float64,2}}
+U factor with rank 3:
+3×3 UpperTriangular{Float64,Array{Float64,2}}:
+ 9.89949  -4.34366  -1.61624
+  ⋅        4.25825   1.1694
+  ⋅         ⋅        0.142334
+permutation:
+3-element Array{Int64,1}:
+ 3
+ 2
+ 1
+```
+"""
 struct CholeskyPivoted{T,S<:AbstractMatrix} <: Factorization{T}
     factors::S
     uplo::Char

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -1,6 +1,52 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Eigendecomposition
+"""
+    Eigen <: Factorization
+
+Matrix factorization type of the eigenvalue/spectral decomposition of a square
+matrix `A`. This is the return type of [`eigen`](@ref), the corresponding matrix
+factorization function.
+
+If `F::Eigen` is the factorization object, the eigenvalues can be obtained via
+`F.values` and the eigenvectors as the columns of the matrix `F.vectors`.
+(The `k`th eigenvector can be obtained from the slice `F.vectors[:, k]`.)
+
+Iterating the decomposition produces the components `F.values` and `F.vectors`.
+
+# Examples
+```jldoctest
+julia> F = eigen([1.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 18.0])
+Eigen{Float64,Float64,Array{Float64,2},Array{Float64,1}}
+eigenvalues:
+3-element Array{Float64,1}:
+  1.0
+  3.0
+ 18.0
+eigenvectors:
+3×3 Array{Float64,2}:
+ 1.0  0.0  0.0
+ 0.0  1.0  0.0
+ 0.0  0.0  1.0
+
+julia> F.values
+3-element Array{Float64,1}:
+1.0
+3.0
+18.0
+
+julia> F.vectors
+3×3 Array{Float64,2}:
+1.0  0.0  0.0
+0.0  1.0  0.0
+0.0  0.0  1.0
+
+julia> vals, vecs = F; # destructuring via iteration
+
+julia> vals == F.values && vecs == F.vectors
+true
+```
+"""
 struct Eigen{T,V,S<:AbstractMatrix,U<:AbstractVector} <: Factorization{T}
     values::U
     vectors::S
@@ -11,6 +57,57 @@ Eigen(values::AbstractVector{V}, vectors::AbstractMatrix{T}) where {T,V} =
     Eigen{T,V,typeof(vectors),typeof(values)}(values, vectors)
 
 # Generalized eigenvalue problem.
+"""
+    GeneralizedEigen <: Factorization
+
+Matrix factorization type of the generalized eigenvalue/spectral decomposition of
+`A` and `B`. This is the return type of [`eigen`](@ref), the corresponding
+matrix factorization function, when called with two matrix arguments.
+
+If `F::GeneralizedEigen` is the factorization object, the eigenvalues can be obtained via
+`F.values` and the eigenvectors as the columns of the matrix `F.vectors`.
+(The `k`th eigenvector can be obtained from the slice `F.vectors[:, k]`.)
+
+Iterating the decomposition produces the components `F.values` and `F.vectors`.
+
+# Examples
+```jldoctest
+julia> A = [1 0; 0 -1]
+2×2 Array{Int64,2}:
+ 1   0
+ 0  -1
+
+julia> B = [0 1; 1 0]
+2×2 Array{Int64,2}:
+ 0  1
+ 1  0
+
+julia> F = eigen(A, B)
+GeneralizedEigen{Complex{Float64},Complex{Float64},Array{Complex{Float64},2},Array{Complex{Float64},1}}
+eigenvalues:
+2-element Array{Complex{Float64},1}:
+ 0.0 + 1.0im
+ 0.0 - 1.0im
+eigenvectors:
+2×2 Array{Complex{Float64},2}:
+  0.0-1.0im   0.0+1.0im
+ -1.0-0.0im  -1.0+0.0im
+
+julia> F.values
+2-element Array{Complex{Float64},1}:
+0.0 - 1.0im
+0.0 + 1.0im
+
+julia> F.vectors
+2×2 Array{Complex{Float64},2}:
+0.0+1.0im   0.0-1.0im
+-1.0+0.0im  -1.0-0.0im
+
+julia> vals, vecs = F; # destructuring via iteration
+
+julia> vals == F.values && vecs == F.vectors
+true
+"""
 struct GeneralizedEigen{T,V,S<:AbstractMatrix,U<:AbstractVector} <: Factorization{T}
     values::U
     vectors::S

--- a/stdlib/LinearAlgebra/src/factorization.jl
+++ b/stdlib/LinearAlgebra/src/factorization.jl
@@ -1,7 +1,14 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 ## Matrix factorizations and decompositions
+"""
+    LinearAlgebra.Factorization
 
+Abstract type for [matrix factorizations](https://en.wikipedia.org/wiki/Matrix_decomposition)
+a.k.a. matrix decompositions.
+See [online documentation](@ref man-linalg-factorizations) for a list of available
+matrix factorizations.
+"""
 abstract type Factorization{T} end
 
 eltype(::Type{<:Factorization{T}}) where {T} = T

--- a/stdlib/LinearAlgebra/src/hessenberg.jl
+++ b/stdlib/LinearAlgebra/src/hessenberg.jl
@@ -14,6 +14,13 @@ Efficient algorithms are implemented for `H \\ b`, `det(H)`, and similar.
 See also the [`hessenberg`](@ref) function to factor any matrix into a similar
 upper-Hessenberg matrix.
 
+If `F::Hessenberg` is the factorization object, the unitary matrix can be accessed
+with `F.Q` and the Hessenberg matrix with `F.H`. When `Q` is extracted, the resulting
+type is the `HessenbergQ` object, and may be converted to a regular matrix with
+[`convert(Array, _)`](@ref) (or `Array(_)` for short).
+
+Iterating the decomposition produces the factors `F.Q` and `F.H`.
+
 # Examples
 ```jldoctest
 julia> A = [1 2 3 4; 5 6 7 8; 9 10 11 12; 13 14 15 16]

--- a/stdlib/LinearAlgebra/src/ldlt.jl
+++ b/stdlib/LinearAlgebra/src/ldlt.jl
@@ -1,5 +1,26 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
+"""
+    LDLt <: Factorization
+
+Matrix factorization type of the `LDLt` factorization of a real [`SymTridiagonal`](@ref)
+matrix `S` such that `S = L*Diagonal(d)*L'`, where `L` is a [`UnitLowerTriangular`](@ref)
+matrix and `d` is a vector. The main use of an `LDLt` factorization `F = ldlt(S)`
+is to solve the linear system of equations `Sx = b` with `F\\b`. This is the
+return type of [`ldlt`](@ref), the corresponding matrix factorization function.
+
+# Examples
+```jldoctest
+julia> S = SymTridiagonal([3., 4., 5.], [1., 2.])
+3×3 SymTridiagonal{Float64,Array{Float64,1}}:
+ 3.0  1.0   ⋅
+ 1.0  4.0  2.0
+  ⋅   2.0  5.0
+
+julia> F = ldlt(S)
+LDLt{Float64,SymTridiagonal{Float64,Array{Float64,1}}}([3.0 0.333333 0.0; 0.333333 3.66667 0.545455; 0.0 0.545455 3.90909])
+```
+"""
 struct LDLt{T,S<:AbstractMatrix{T}} <: Factorization{T}
     data::S
 

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -1,7 +1,41 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # LQ Factorizations
+"""
+    LQ <: Factorization
 
+Matrix factorization type of the `LQ` factorization of a matrix `A`. The `LQ`
+decomposition is the `QR` decomposition of `transpose(A)`. This is the return
+type of [`lq`](@ref), the corresponding matrix factorization function.
+
+If `S::LQ` is the factorization object, the lower triangular component can be
+obtained via `S.L`, and the orthogonal/unitary component via `S.Q`, such that
+`A ≈ S.L*S.Q`.
+
+Iterating the decomposition produces the components `S.L` and `S.Q`.
+
+# Examples
+```jldoctest
+julia> A = [5. 7.; -2. -4.]
+2×2 Array{Float64,2}:
+  5.0   7.0
+ -2.0  -4.0
+
+julia> S = lq(A)
+LQ{Float64,Array{Float64,2}} with factors L and Q:
+[-8.60233 0.0; 4.41741 -0.697486]
+[-0.581238 -0.813733; -0.813733 0.581238]
+
+julia> S.L * S.Q
+2×2 Array{Float64,2}:
+  5.0   7.0
+ -2.0  -4.0
+
+julia> l, q = S; # destructuring via iteration
+
+julia> l == S.L &&  q == S.Q
+true
+"""
 struct LQ{T,S<:AbstractMatrix{T}} <: Factorization{T}
     factors::S
     τ::Vector{T}

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -3,6 +3,50 @@
 ####################
 # LU Factorization #
 ####################
+"""
+    LU <: Factorization
+
+Matrix factorization type of the `LU` factorization of a square matrix `A`. This
+is the return type of [`lu`](@ref), the corresponding matrix factorization function.
+
+The individual components of the factorization `F::LU` can be accessed via `getproperty`:
+
+| Component | Description                              |
+|:----------|:-----------------------------------------|
+| `F.L`     | `L` (unit lower triangular) part of `LU` |
+| `F.U`     | `U` (upper triangular) part of `LU`      |
+| `F.p`     | (right) permutation `Vector`             |
+| `F.P`     | (right) permutation `Matrix`             |
+
+Iterating the factorization produces the components `F.L`, `F.U`, and `F.p`.
+
+# Examples
+```jldoctest
+julia> A = [4 3; 6 3]
+2×2 Array{Int64,2}:
+ 4  3
+ 6  3
+
+julia> F = lu(A)
+LU{Float64,Array{Float64,2}}
+L factor:
+2×2 Array{Float64,2}:
+ 1.0  0.0
+ 1.5  1.0
+U factor:
+2×2 Array{Float64,2}:
+ 4.0   3.0
+ 0.0  -1.5
+
+julia> F.L * F.U == A[F.p, :]
+true
+
+julia> l, u, p = lu(A); # destructuring via iteration
+
+julia> l == F.L && u == F.U && p == F.p
+true
+```
+"""
 struct LU{T,S<:AbstractMatrix{T}} <: Factorization{T}
     factors::S
     ipiv::Vector{BlasInt}

--- a/stdlib/LinearAlgebra/src/schur.jl
+++ b/stdlib/LinearAlgebra/src/schur.jl
@@ -1,6 +1,52 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Schur decomposition
+"""
+    Schur <: Factorization
+
+Matrix factorization type of the Schur factorization of a matrix `A`. This is the
+return type of [`schur(_)`](@ref), the corresponding matrix factorization function.
+
+If `F::Schur` is the factorization object, the (quasi) triangular Schur factor can
+be obtained via either `F.Schur` or `F.T` and the orthogonal/unitary Schur vectors
+via `F.vectors` or `F.Z` such that `A = F.vectors * F.Schur * F.vectors'`. The
+eigenvalues of `A` can be obtained with `F.values`.
+
+Iterating the decomposition produces the components `F.T`, `F.Z`, and `F.values`.
+
+# Examples
+```jldoctest
+julia> A = [5. 7.; -2. -4.]
+2×2 Array{Float64,2}:
+  5.0   7.0
+ -2.0  -4.0
+
+julia> F = schur(A)
+Schur{Float64,Array{Float64,2}}
+T factor:
+2×2 Array{Float64,2}:
+ 3.0   9.0
+ 0.0  -2.0
+Z factor:
+2×2 Array{Float64,2}:
+  0.961524  0.274721
+ -0.274721  0.961524
+eigenvalues:
+2-element Array{Float64,1}:
+  3.0
+ -2.0
+
+julia> F.vectors * F.Schur * F.vectors'
+2×2 Array{Float64,2}:
+  5.0   7.0
+ -2.0  -4.0
+
+julia> t, z, vals = F; # destructuring via iteration
+
+julia> t == F.T && z == F.Z && vals == F.values
+true
+```
+"""
 struct Schur{Ty,S<:AbstractMatrix} <: Factorization{Ty}
     T::S
     Z::S
@@ -155,6 +201,23 @@ included or both excluded via `select`.
 ordschur(schur::Schur, select::Union{Vector{Bool},BitVector}) =
     Schur(_ordschur(schur.T, schur.Z, select)...)
 
+"""
+    GeneralizedSchur <: Factorization
+
+Matrix factorization type of the generalized Schur factorization of two matrices
+`A` and `B`. This is the return type of [`schur(_, _)`](@ref), the corresponding
+matrix factorization function.
+
+If `F::GeneralizedSchur` is the factorization object, the (quasi) triangular Schur
+factors can be obtained via `F.S` and `F.T`, the left unitary/orthogonal Schur
+vectors via `F.left` or `F.Q`, and the right unitary/orthogonal Schur vectors can
+be obtained with `F.right` or `F.Z` such that `A=F.left*F.S*F.right'` and
+`B=F.left*F.T*F.right'`. The generalized eigenvalues of `A` and `B` can be obtained
+with `F.α./F.β`.
+
+Iterating the decomposition produces the components `F.S`, `F.T`, `F.Q`, `F.Z`,
+`F.α`, and `F.β`.
+"""
 struct GeneralizedSchur{Ty,M<:AbstractMatrix} <: Factorization{Ty}
     S::M
     T::M

--- a/stdlib/LinearAlgebra/src/svd.jl
+++ b/stdlib/LinearAlgebra/src/svd.jl
@@ -1,6 +1,43 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Singular Value Decomposition
+"""
+    SVD <: Factorization
+
+Matrix factorization type of the singular value decomposition (SVD) of a matrix `A`.
+This is the return type of [`svd(_)`](@ref), the corresponding matrix factorization function.
+
+If `F::SVD` is the factorization object, `U`, `S`, `V` and `Vt` can be obtained
+via `F.U`, `F.S`, `F.V` and `F.Vt`, such that `A = U * Diagonal(S) * Vt`.
+The singular values in `S` are sorted in descending order.
+
+Iterating the decomposition produces the components `U`, `S`, and `V`.
+
+# Examples
+```jldoctest
+julia> A = [1. 0. 0. 0. 2.; 0. 0. 3. 0. 0.; 0. 0. 0. 0. 0.; 0. 2. 0. 0. 0.]
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+
+julia> F = svd(A)
+SVD{Float64,Float64,Array{Float64,2}}([0.0 1.0 0.0 0.0; 1.0 0.0 0.0 0.0; 0.0 0.0 0.0 -1.0; 0.0 0.0 1.0 0.0], [3.0, 2.23607, 2.0, 0.0], [-0.0 0.0 … -0.0 0.0; 0.447214 0.0 … 0.0 0.894427; -0.0 1.0 … -0.0 0.0; 0.0 0.0 … 1.0 0.0])
+
+julia> F.U * Diagonal(F.S) * F.Vt
+4×5 Array{Float64,2}:
+ 1.0  0.0  0.0  0.0  2.0
+ 0.0  0.0  3.0  0.0  0.0
+ 0.0  0.0  0.0  0.0  0.0
+ 0.0  2.0  0.0  0.0  0.0
+
+julia> u, s, v = F; # destructuring via iteration
+
+julia> u == F.U && s == F.S && v == F.V
+true
+```
+"""
 struct SVD{T,Tr,M<:AbstractArray{T}} <: Factorization{T}
     U::M
     S::Vector{Tr}
@@ -100,6 +137,11 @@ julia> F.U * Diagonal(F.S) * F.Vt
  0.0  0.0  3.0  0.0  0.0
  0.0  0.0  0.0  0.0  0.0
  0.0  2.0  0.0  0.0  0.0
+
+julia> u, s, v = F; # destructuring via iteration
+
+julia> u == F.U && s == F.S && v == F.V
+true
 ```
 """
 function svd(A::StridedVecOrMat{T}; full::Bool = false) where T
@@ -200,6 +242,59 @@ size(A::SVD, dim::Integer) = dim == 1 ? size(A.U, dim) : size(A.Vt, dim)
 size(A::SVD) = (size(A, 1), size(A, 2))
 
 # Generalized svd
+"""
+    GeneralizedSVD <: Factorization
+
+Matrix factorization type of the generalized singular value decomposition (SVD)
+of two matrices `A` and `B`, such that `A = F.U*F.D1*F.R0*F.Q'` and
+`B = F.V*F.D2*F.R0*F.Q'`. This is the return type of [`svd(_, _)`](@ref), the
+corresponding matrix factorization function.
+
+For an M-by-N matrix `A` and P-by-N matrix `B`,
+
+- `U` is a M-by-M orthogonal matrix,
+- `V` is a P-by-P orthogonal matrix,
+- `Q` is a N-by-N orthogonal matrix,
+- `D1` is a M-by-(K+L) diagonal matrix with 1s in the first K entries,
+- `D2` is a P-by-(K+L) matrix whose top right L-by-L block is diagonal,
+- `R0` is a (K+L)-by-N matrix whose rightmost (K+L)-by-(K+L) block is
+           nonsingular upper block triangular,
+
+`K+L` is the effective numerical rank of the matrix `[A; B]`.
+
+Iterating the decomposition produces the components `U`, `V`, `Q`, `D1`, `D2`, and `R0`.
+
+The entries of `F.D1` and `F.D2` are related, as explained in the LAPACK
+documentation for the
+[generalized SVD](http://www.netlib.org/lapack/lug/node36.html) and the
+[xGGSVD3](http://www.netlib.org/lapack/explore-html/d6/db3/dggsvd3_8f.html)
+routine which is called underneath (in LAPACK 3.6.0 and newer).
+
+# Examples
+```jldoctest
+julia> A = [1. 0.; 0. -1.]
+2×2 Array{Float64,2}:
+ 1.0   0.0
+ 0.0  -1.0
+
+julia> B = [0. 1.; 1. 0.]
+2×2 Array{Float64,2}:
+ 0.0  1.0
+ 1.0  0.0
+
+julia> F = svd(A, B);
+
+julia> F.U*F.D1*F.R0*F.Q'
+2×2 Array{Float64,2}:
+ 1.0   0.0
+ 0.0  -1.0
+
+julia> F.V*F.D2*F.R0*F.Q'
+2×2 Array{Float64,2}:
+ 0.0  1.0
+ 1.0  0.0
+```
+"""
 struct GeneralizedSVD{T,S} <: Factorization{T}
     U::S
     V::S


### PR DESCRIPTION
Contributes to #31202.

I have added a very short docstring to `Factorization`, and updated the manual. Now, all `subtypes(Factorization)` are listed, except the three SuiteSparse ones. I couldn't find `LUTridiagonal ` anywhere, so I deleted it from the manual. This certainly needs a careful review to make everything consistent. For example, would the reference to the online manual work like that? Once all types have their own docstrings, should the table in the manual contain references? ~~Should we keep this PR restricted to `Factorization`, or should we collect docstrings for each concrete factorization type here?~~ I went ahead with adding docstrings for the concrete factorization types.