### PR TITLE
Let rdiv! accept a LU factorization object

### DIFF
--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -367,18 +367,6 @@ function rdiv!(A::StridedVecOrMat, B::LU{<:Any,<:StridedMatrix})
     _apply_inverse_ipiv_cols!(B, A)
 end
 
-function rdiv!(A::StridedVecOrMat, transB::Transpose{LU{<:Any,<:StridedMatrix}})
-    B = transB.parent
-    rdiv!(rdiv!(A, transpose(UpperTriangular(B.factors))), transpose(UnitLowerTriangular(B.factors)))
-    _apply_inverse_ipiv_cols!(B, A)
-end
-
-function rdiv!(A::StridedVecOrMat, adjB::Adjoint{<:Any, LU{<:Any,<:StridedMatrix}})
-    B = adjB.parent
-    rdiv!(rdiv!(A, adjoint(UpperTriangular(B.factors))), adjoint(UnitLowerTriangular(B.factors)))
-    _apply_inverse_ipiv_cols!(B, A)
-end
-
 ldiv!(A::LU{T,<:StridedMatrix}, B::StridedVecOrMat{T}) where {T<:BlasFloat} =
     LAPACK.getrs!('N', A.factors, A.ipiv, B)
 

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -362,7 +362,7 @@ function _swap_cols!(B::StridedMatrix, i::Integer, j::Integer)
     B
 end
 
-function rdiv!(A::StridedVecOrMat, B::LU{<:Any,<:StridedMatrix}) 
+function rdiv!(A::StridedVecOrMat, B::LU{<:Any,<:StridedMatrix})
     rdiv!(rdiv!(A, UpperTriangular(B.factors)), UnitLowerTriangular(B.factors))
     _apply_inverse_ipiv_cols!(B, A)
 end

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -364,19 +364,19 @@ end
 
 function rdiv!(A::StridedVecOrMat, B::LU{<:Any,<:StridedMatrix}) 
     rdiv!(rdiv!(A, UpperTriangular(B.factors)), UnitLowerTriangular(B.factors))
-    _apply_inverse_ipiv_col!(B, A)
+    _apply_inverse_ipiv_cols!(B, A)
 end
 
 function rdiv!(A::StridedVecOrMat, transB::Transpose{LU{<:Any,<:StridedMatrix}})
     B = transB.parent
     rdiv!(rdiv!(A, transpose(UpperTriangular(B.factors))), transpose(UnitLowerTriangular(B.factors)))
-    _apply_inverse_ipiv_col!(B, A)
+    _apply_inverse_ipiv_cols!(B, A)
 end
 
 function rdiv!(A::StridedVecOrMat, adjB::Adjoint{<:Any, LU{<:Any,<:StridedMatrix}})
     B = adjB.parent
     rdiv!(rdiv!(A, adjoint(UpperTriangular(B.factors))), adjoint(UnitLowerTriangular(B.factors)))
-    _apply_inverse_ipiv_col!(B, A)
+    _apply_inverse_ipiv_cols!(B, A)
 end
 
 ldiv!(A::LU{T,<:StridedMatrix}, B::StridedVecOrMat{T}) where {T<:BlasFloat} =

--- a/stdlib/LinearAlgebra/src/lu.jl
+++ b/stdlib/LinearAlgebra/src/lu.jl
@@ -315,10 +315,10 @@ function show(io::IO, mime::MIME{Symbol("text/plain")}, F::LU)
     end
 end
 
-_apply_ipiv!(A::LU, B::StridedVecOrMat) = _ipiv!(A, 1 : length(A.ipiv), B)
-_apply_inverse_ipiv!(A::LU, B::StridedVecOrMat) = _ipiv!(A, length(A.ipiv) : -1 : 1, B)
+_apply_ipiv_rows!(A::LU, B::StridedVecOrMat) = _ipiv_rows!(A, 1 : length(A.ipiv), B)
+_apply_inverse_ipiv_rows!(A::LU, B::StridedVecOrMat) = _ipiv_rows!(A, length(A.ipiv) : -1 : 1, B)
 
-function _ipiv!(A::LU, order::OrdinalRange, B::StridedVecOrMat)
+function _ipiv_rows!(A::LU, order::OrdinalRange, B::StridedVecOrMat)
     for i = order
         if i != A.ipiv[i]
             _swap_rows!(B, i, A.ipiv[i])
@@ -339,11 +339,51 @@ function _swap_rows!(B::StridedMatrix, i::Integer, j::Integer)
     B
 end
 
+_apply_ipiv_cols!(A::LU, B::StridedVecOrMat) = _ipiv_cols!(A, 1 : length(A.ipiv), B)
+_apply_inverse_ipiv_cols!(A::LU, B::StridedVecOrMat) = _ipiv_cols!(A, length(A.ipiv) : -1 : 1, B)
+
+function _ipiv_cols!(A::LU, order::OrdinalRange, B::StridedVecOrMat)
+    for i = order
+        if i != A.ipiv[i]
+            _swap_cols!(B, i, A.ipiv[i])
+        end
+    end
+    B
+end
+
+function _swap_cols!(B::StridedVector, i::Integer, j::Integer)
+    _swap_rows!(B, i, j)
+end
+
+function _swap_cols!(B::StridedMatrix, i::Integer, j::Integer)
+    for row = 1 : size(B, 1)
+        B[row,i], B[row,j] = B[row,j], B[row,i]
+    end
+    B
+end
+
+function rdiv!(A::StridedVecOrMat, B::LU{<:Any,<:StridedMatrix}) 
+    rdiv!(rdiv!(A, UpperTriangular(B.factors)), UnitLowerTriangular(B.factors))
+    _apply_inverse_ipiv_col!(B, A)
+end
+
+function rdiv!(A::StridedVecOrMat, transB::Transpose{LU{<:Any,<:StridedMatrix}})
+    B = transB.parent
+    rdiv!(rdiv!(A, transpose(UpperTriangular(B.factors))), transpose(UnitLowerTriangular(B.factors)))
+    _apply_inverse_ipiv_col!(B, A)
+end
+
+function rdiv!(A::StridedVecOrMat, adjB::Adjoint{<:Any, LU{<:Any,<:StridedMatrix}})
+    B = adjB.parent
+    rdiv!(rdiv!(A, adjoint(UpperTriangular(B.factors))), adjoint(UnitLowerTriangular(B.factors)))
+    _apply_inverse_ipiv_col!(B, A)
+end
+
 ldiv!(A::LU{T,<:StridedMatrix}, B::StridedVecOrMat{T}) where {T<:BlasFloat} =
     LAPACK.getrs!('N', A.factors, A.ipiv, B)
 
 function ldiv!(A::LU{<:Any,<:StridedMatrix}, B::StridedVecOrMat)
-    _apply_ipiv!(A, B)
+    _apply_ipiv_rows!(A, B)
     ldiv!(UpperTriangular(A.factors), ldiv!(UnitLowerTriangular(A.factors), B))
 end
 
@@ -353,7 +393,7 @@ ldiv!(transA::Transpose{T,<:LU{T,<:StridedMatrix}}, B::StridedVecOrMat{T}) where
 function ldiv!(transA::Transpose{<:Any,<:LU{<:Any,<:StridedMatrix}}, B::StridedVecOrMat)
     A = transA.parent
     ldiv!(transpose(UnitLowerTriangular(A.factors)), ldiv!(transpose(UpperTriangular(A.factors)), B))
-    _apply_inverse_ipiv!(A, B)
+    _apply_inverse_ipiv_rows!(A, B)
 end
 
 ldiv!(adjF::Adjoint{T,<:LU{T,<:StridedMatrix}}, B::StridedVecOrMat{T}) where {T<:Real} =
@@ -364,7 +404,7 @@ ldiv!(adjA::Adjoint{T,<:LU{T,<:StridedMatrix}}, B::StridedVecOrMat{T}) where {T<
 function ldiv!(adjA::Adjoint{<:Any,<:LU{<:Any,<:StridedMatrix}}, B::StridedVecOrMat)
     A = adjA.parent
     ldiv!(adjoint(UnitLowerTriangular(A.factors)), ldiv!(adjoint(UpperTriangular(A.factors)), B))
-    _apply_inverse_ipiv!(A, B)
+    _apply_inverse_ipiv_rows!(A, B)
 end
 
 \(A::Adjoint{<:Any,<:LU}, B::Adjoint{<:Any,<:StridedVecOrMat}) = A \ copy(B)

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -129,20 +129,16 @@ dimg  = randn(n)/2
                 @test norm(b_dest - lua' \ b, 1) < ε*κ*2n
                 @test norm(c_dest - lua' \ c, 1) < ε*κ*n
 
-                rdiv!(b_dest, b, lua)
-                rdiv!(c_dest, c, lua)
-                @test norm(b_dest - b / lua, 1) < ε*κ*2n
-                @test norm(c_dest - c / lua, 1) < ε*κ*n
-
-                rdiv!(b_dest, b, transpose(lua))
-                rdiv!(c_dest, c, transpose(lua))
-                @test norm(b_dest - b / transpose(lua), 1) < ε*κ*2n
-                @test norm(c_dest - c / transpose(lua), 1) < ε*κ*n
-
-                rdiv!(b_dest, b, adjoint(lua))
-                rdiv!(c_dest, c, adjoint(lua))
-                @test norm(b_dest - b / lua', 1) < ε*κ*2n
-                @test norm(c_dest - c / lua', 1) < ε*κ*n
+                if eltyb != Int && !(eltya <: Complex) || eltya <: Complex && eltyb <: Complex
+                    p = Matrix(b')
+                    q = Matrix(c')
+                    p_dest = copy(p)
+                    q_dest = copy(q)
+                    rdiv!(p_dest, lua)
+                    rdiv!(q_dest, lua)
+                    @test norm(p_dest - p / lua, 1) < ε*κ*2n
+                    @test norm(q_dest - q / lua, 1) < ε*κ*n
+                end
             end
             if eltya <: BlasFloat && eltyb <: BlasFloat
                 e = rand(eltyb,n,n)

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -3,7 +3,7 @@
 module TestLU
 
 using Test, LinearAlgebra, Random
-using LinearAlgebra: ldiv!, BlasInt, BlasFloat
+using LinearAlgebra: ldiv!, BlasInt, BlasFloat, rdiv!
 
 n = 10
 
@@ -128,6 +128,21 @@ dimg  = randn(n)/2
                 ldiv!(c_dest, adjoint(lua), c)
                 @test norm(b_dest - lua' \ b, 1) < ε*κ*2n
                 @test norm(c_dest - lua' \ c, 1) < ε*κ*n
+                
+                rdiv!(b_dest, b, lua)
+                rdiv!(c_dest, c, lua)
+                @test norm(b_dest - b / lua, 1) < ε*κ*2n
+                @test norm(c_dest - c / lua, 1) < ε*κ*n
+
+                rdiv!(b_dest, b, transpose(lua))
+                rdiv!(c_dest, c, transpose(lua))
+                @test norm(b_dest - b / transpose(lua), 1) < ε*κ*2n
+                @test norm(c_dest - c / transpose(lua), 1) < ε*κ*n
+
+                rdiv!(b_dest, b, adjoint(lua))
+                rdiv!(c_dest, c, adjoint(lua))
+                @test norm(b_dest - b / lua', 1) < ε*κ*2n
+                @test norm(c_dest - c / lua', 1) < ε*κ*n
             end
             if eltya <: BlasFloat && eltyb <: BlasFloat
                 e = rand(eltyb,n,n)

--- a/stdlib/LinearAlgebra/test/lu.jl
+++ b/stdlib/LinearAlgebra/test/lu.jl
@@ -128,7 +128,7 @@ dimg  = randn(n)/2
                 ldiv!(c_dest, adjoint(lua), c)
                 @test norm(b_dest - lua' \ b, 1) < ε*κ*2n
                 @test norm(c_dest - lua' \ c, 1) < ε*κ*n
-                
+
                 rdiv!(b_dest, b, lua)
                 rdiv!(c_dest, c, lua)
                 @test norm(b_dest - b / lua, 1) < ε*κ*2n


### PR DESCRIPTION
The documentation of `rdiv!` implies that `rdiv!` does accept an factorization object. While this true for `ldiv!` it has not been implemented for `rdiv!`, yet.
```
  rdiv!(A, B)

  Compute A / B in-place and overwriting A to store the result.

  The argument B should not be a matrix. Rather, instead of matrices it should be a factorization object (e.g. produced by factorize or cholesky). The reason for this is that factorization itself is
  both expensive and typically allocates memory (although it can also be done in-place via, e.g., lu!), and performance-critical situations requiring rdiv! usually also require fine-grained control
  over the factorization of B.
```
This is an attempt to fix this at least for the lu factorization.