### PR TITLE
fix pessimistic maxprobe in Dict rehash

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -177,7 +177,7 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
     oldv = h.vals
     sz = length(olds)
     newsz = _tablesz(newsz)
-    h.age += 1
+    h.age += 1 + (1<<32)
     h.idxfloor = 1
     if h.count == 0
         resize!(h.slots, newsz)
@@ -193,7 +193,7 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
     vals = Vector{V}(undef, newsz)
     age0 = h.age
     count = 0
-    maxprobe = h.maxprobe
+    maxprobe = 0
 
     for i = 1:sz
         @inbounds if olds[i] == 0x1

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -177,7 +177,7 @@ function rehash!(h::Dict{K,V}, newsz = length(h.keys)) where V where K
     oldv = h.vals
     sz = length(olds)
     newsz = _tablesz(newsz)
-    h.age += 1 + (1<<32)
+    h.age += 1
     h.idxfloor = 1
     if h.count == 0
         resize!(h.slots, newsz)


### PR DESCRIPTION
Maxprobe is the maximal actual offset between hashindex and actual index. When we rehash for other reasons than overfull, then not resetting `maxprobe` defies the point.

This is in principle superseded by [https://github.com/JuliaLang/julia/pull/31291](https://github.com/JuliaLang/julia/pull/31291), but here stand-alone and ready for backport (since this is arguably unintendend / a bug).