### PR TITLE
WIP: dict.jl resize/refactor

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -707,7 +707,7 @@ length(t::Dict) = t.count
     isempty(v.dict) && return nothing
     is = _iterate(v.dict)
     is === nothing && return nothing
-    i,s = is 
+    i,s = is
     (v isa KeySet ? v.dict.keys[i] : v.dict.vals[i], s)
 end
 

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -669,7 +669,7 @@ function skip_deleted_floor!(h::Dict)
 end
 
 @inline function _iterate(h::Dict)
-    (isempty(h) || length(h.slots)<8) && return nothing
+    isempty(h) && return nothing #always length(h.slots) >= 16
     return _iterate(h, (1, ltoh(unsafe_load(convert(Ptr{UInt64}, pointer(h.slots)),1)) & 0x0101010101010101))
 end
 
@@ -721,7 +721,7 @@ end
 function filter!(pred, h::Dict{K,V}) where {K,V}
     isempty(h) && return h
     is = _iterate(h)
-    @inbounds while s !== nothing
+    @inbounds while is !== nothing
         i, state = is
         if !pred(Pair{K,V}(h.keys[i], h.vals[i]))
             _delete!(h, i)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -720,12 +720,13 @@ end
 
 function filter!(pred, h::Dict{K,V}) where {K,V}
     isempty(h) && return h
-    s = _iterate(h)
+    is = _iterate(h)
     @inbounds while s !== nothing
-        i, state = s
+        i, state = is
         if !pred(Pair{K,V}(h.keys[i], h.vals[i]))
             _delete!(h, i)
         end
+        is = _iterate(h, state)
     end
     return h
 end

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -621,7 +621,7 @@ end
 @inline function _delete_clean!(h::Dict{K,V}, index) where {K,V}
     isbitstype(K) || isbitsunion(K) || ccall(:jl_arrayunset, Cvoid, (Any, UInt), h.keys, index-1)
     isbitstype(V) || isbitsunion(V) || ccall(:jl_arrayunset, Cvoid, (Any, UInt), h.vals, index-1)
-    off = 3 
+    off = 3
     if (index-off -1)%UInt <= length(h.slots)-8
         p = convert(Ptr{UInt64}, pointer(h.slots, index-off))
         c = xor(ltoh(unsafe_load(p)), 0x0000000000000003<<(off*8))


### PR DESCRIPTION
We can very cheaply clean up after deletions: deleted (`0x02`) slots that are followed by empty (`0x00`) slots can be reset to `0x00`. For speed, this is maintained only approximately (on deletion, we move the head of a `0x02`-chain back by max 4 indices, mostly branch-free).

We can then also maintain a new invariant: `ndel` equals the number of deleted (`0x02`)-slots (if we insert into deleted slot, then decrement `ndel`). 

Using this, we can almost reach homeostasis: Take a dictionary, pop a random item and add a new random item (without changing the size). One rollover is when `count` items have been added and removed. I took some measurements on [https://gist.github.com/chethega/1b11bcb8aa1a6871392cd44e03f4b6e5](https://gist.github.com/chethega/1b11bcb8aa1a6871392cd44e03f4b6e5); upshot: At a fill (`h.count/length(h.slots)`) of 25%, I observed about 18%  deletion (`h.ndel/length(h.slots)`) after 32 rollovers, increasing to 27% after 1024 rollovers. Not a single `rehash` triggered.

Of course, aiming for 1024 rollovers without rehash is overkill. But the current code, rehashing every 3 rollovers (at 0.25 fill) or every 1.5 rollovers (at 0.5 fill) is excessive.

Hence, we should update the entire thresholding logic: The decisions of how much to over-allocate, when to rehash due to deletions, when to shrink (which is perfectly possible). 