### PR TITLE
fix doc for `rstrip`

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -170,7 +170,7 @@ lstrip(s::AbstractString, chars::Chars) = lstrip(in(chars), s)
 Remove trailing characters from `str`, either those specified by `chars` or those for
 which the function `pred` returns `true`.
 
-The default behaviour is to remove leading whitespace and delimiters: see
+The default behaviour is to remove trailing whitespace and delimiters: see
 [`isspace`](@ref) for precise details.
 
 The optional `chars` argument specifies which characters to remove: it can be a single


### PR DESCRIPTION
I think it's a copy-paste error from `lstrip`