### PR TITLE
RFC: fix #31295, allow e.g. `view(a,:) .+= view(b,:)`

### DIFF
--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -812,3 +812,9 @@ let
     @test eltype(copy(bc)) == eltype([v for v in bc]) == eltype(collect(bc))
     @test ndims(copy(bc)) == ndims([v for v in bc]) == ndims(collect(bc)) == ndims(bc)
 end
+
+# issue #31295
+let a = rand(5), b = rand(5), c = copy(a)
+    view(identity(a), 1:3) .+= view(b, 1:3)
+    @test a == [(c+b)[1:3]; c[4:5]]
+end


### PR DESCRIPTION
I'm not 100% sure what to do here, but basically for any LHS expression except a `getindex` this will be lowered to
```
temp = LHS
temp .= temp .+ RHS
```
So there's no fusion between the LHS and RHS, but that seems tricky.