### PR TITLE
Add cholesky(!) methods for Adjoint and Transpose

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ Standard library changes
 
 #### LinearAlgebra
 
+* `cholesky` and `cholesky!` now work for `Adjoint` and `Transpose` matrices ([#31302]).
 
 #### SparseArrays
 

--- a/stdlib/LinearAlgebra/test/adjtrans.jl
+++ b/stdlib/LinearAlgebra/test/adjtrans.jl
@@ -504,4 +504,21 @@ using .Main.OffsetArrays
     @test_throws BoundsError s[1, 4]
 end
 
+@testset "$f(::$T{<:$E})" for T in [Adjoint, Transpose],
+                              f in [cholesky, cholesky!],
+                              E in [Float32, Complex{Float32}]
+    A = (Y->Y'Y)(randn(E, 6, 6))
+    AT = T(A)
+    B = copy(A)
+    CA = f(AT)
+    @test CA isa Cholesky{E,Matrix{E}}
+    if f === cholesky!
+        @test !(A ≈ B)
+    else
+        @test A ≈ B
+    end
+    fB = f(T === Transpose ? conj(B) : B)
+    @test CA.factors ≈ fB.factors
+end
+
 end # module TestAdjointTranspose


### PR DESCRIPTION
This adds methods to `cholesky` and `cholesky!` which simply call the corresponding method for the parent matrix.