### PR TITLE
Support zero et al on ::Type{Missing}

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -83,6 +83,7 @@ for f in (:(!), :(~), :(+), :(-), :(zero), :(one), :(oneunit),
     @eval ($f)(::Missing) = missing
 end
 for f in (:(Base.zero), :(Base.one), :(Base.oneunit))
+    @eval ($f)(::Type{Missing}) = missing
     @eval function $(f)(::Type{Union{T, Missing}}) where T
         T === Any && throw(MethodError($f, (Any,)))  # To prevent StackOverflowError
         $f(T)

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -179,6 +179,10 @@ Base.one(::Type{Unit}) = 1
         @test oneunit(Union{T, Missing}) === T(1)
     end
 
+    @test zero(Missing) === missing
+    @test one(Missing) === missing
+    @test oneunit(Missing) === missing
+
     @test_throws MethodError zero(Any)
     @test_throws MethodError one(Any)
     @test_throws MethodError oneunit(Any)


### PR DESCRIPTION
Previously the three methods in question would give:
```julia
julia> zero(Missing)
ERROR: UndefVarError: T not defined
Stacktrace:
 [1] zero(::Type{Missing}) at ./missing.jl:87
 [2] top-level scope at none:0
```
because `T` wasn't matched