### PR TITLE
Allow removing non-inlined functions that are proven pure

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -117,7 +117,7 @@ function cache_result(result::InferenceResult, min_valid::UInt, max_valid::UInt)
             end
             if !toplevel && inferred_result isa CodeInfo
                 cache_the_tree = result.src.inferred &&
-                    (result.src.inlineable ||
+                    (result.src.inlineable || result.src.pure ||
                      ccall(:jl_isa_compileable_sig, Int32, (Any, Any), result.linfo.specTypes, def) != 0)
                 if cache_the_tree
                     # compress code for non-toplevel thunks

--- a/src/julia.h
+++ b/src/julia.h
@@ -245,7 +245,8 @@ typedef struct _jl_code_info_t {
         // 0 = inbounds
         // 1,2 = <reserved> inlinehint,always-inline,noinline
         // 3 = <reserved> strict-ieee (strictfp)
-        // 4-6 = <unused>
+        // 4 = effect-free
+        // 5-6 = <unused>
         // 7 = has out-of-band info
     // miscellaneous data:
     jl_value_t *method_for_inference_limit_heuristics; // optional method used during inference

--- a/test/compiler/inline.jl
+++ b/test/compiler/inline.jl
@@ -257,3 +257,11 @@ end
 let ci = code_typed(foo_apply_apply_type_svec, Tuple{})[1].first
     @test length(ci.code) == 1 && ci.code[1] == Expr(:return, NTuple{3, Float32})
 end
+
+# Test that inlining can eliminate noinline functions if they are proven pure
+# and their result is unused.
+@noinline noinline_add(x, y) = x + y
+noinline_unused(x, y) = (noinline_add(x, y); nothing)
+let ci = code_typed(noinline_unused, Tuple{Int, Int})[1].first
+    @test length(ci.code) == 1 && ci.code[1].head === :return
+end


### PR DESCRIPTION
Right now all of our effect-free modeling that forms the basis
of our dead-code elimination operates on intrinsics (since we now
have pretty good effect free modeling for those). Of course, this
means that up until now dce has been tied to inlinability. That
isn't great, because there are lots of otherwise effect-free things
that we don't want to inline (e.g. matrix multiply is effect free
in a certain sense, and it would be nice to eliminate matmuls whose
result isn't used). This commit starts us down that track by marking
things we have proven to be pure as effect-free.