### PR TITLE
Fix BoundsError for regex deepcopy

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -27,7 +27,7 @@ updated as appropriate before returning.
 """
 deepcopy(x) = deepcopy_internal(x, IdDict())::typeof(x)
 
-deepcopy_internal(x::Union{Symbol,Core.MethodInstance,Method,GlobalRef,DataType,Union,UnionAll,Task},
+deepcopy_internal(x::Union{Symbol,Core.MethodInstance,Method,GlobalRef,DataType,Union,UnionAll,Task,Regex},
                   stackdict::IdDict) = x
 deepcopy_internal(x::Tuple, stackdict::IdDict) =
     ntuple(i->deepcopy_internal(x[i], stackdict), length(x))

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -84,6 +84,15 @@ end
     @test c[1] === c[2]
 end
 
+@testset "issue #31309" begin
+    rgx1 = match(deepcopy(r""), "")
+    @test rgx1.regex == r""
+    @test rgx1.offset == 1
+    @test rgx1.match == ""
+    @test isempty(rgx1.offsets)
+    @test isempty(rgx1.captures)
+end
+
 # issue #30911
 @test deepcopy(Array{Int,N} where N) == Array{Int,N} where N
 


### PR DESCRIPTION
Fixes #31260 , as per https://github.com/JuliaLang/julia/issues/31260#issuecomment-469827890
