### PR TITLE
allow chop to take an empty string

### DIFF
--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -96,6 +96,9 @@ julia> chop(a, head = 5, tail = 5)
 ```
 """
 function chop(s::AbstractString; head::Integer = 0, tail::Integer = 1)
+    if isempty(s)
+        return SubString(s)
+    end
     SubString(s, nextind(s, firstindex(s), head), prevind(s, lastindex(s), tail))
 end
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -302,6 +302,7 @@ end
     @test chomp("foo\r\n") == "foo"
     @test chomp("fo∀\r\n") == "fo∀"
     @test chomp("fo∀") == "fo∀"
+    @test chop("") == ""
     @test chop("fooε") == "foo"
     @test chop("foεo") == "foε"
     @test chop("∃∃∃∃") == "∃∃∃"


### PR DESCRIPTION
The following behavior contradicts the docstring of `chop`. So, I fixed the behavior in this pull request.

```
julia> chop("")
ERROR: BoundsError: attempt to access ""
  at index [1]
Stacktrace:
 [1] nextind(::String, ::Int64, ::Int64) at ./strings/basic.jl:521
 [2] #chop#328(::Int64, ::Int64, ::typeof(chop), ::String) at ./strings/util.jl:99
 [3] chop(::String) at ./strings/util.jl:99
 [4] top-level scope at REPL[1]:1

help?> chop
search: chop chomp readchomp chown chmod Cshort eachrow eachcol

  chop(s::AbstractString; head::Integer = 0, tail::Integer = 1)

  Remove the first head and the last tail characters from s. The
  call chop(s) removes the last character from s. If it is
  requested to remove more characters than length(s) then an empty
  string is returned.

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  julia> a = "March"
  "March"

  julia> chop(a)
  "Marc"

  julia> chop(a, head = 1, tail = 2)
  "ar"

  julia> chop(a, head = 5, tail = 5)
  ""
```