### PR TITLE
Update sha3.jl

### DIFF
--- a/stdlib/SHA/src/sha3.jl
+++ b/stdlib/SHA/src/sha3.jl
@@ -58,7 +58,7 @@ end
 # Finalize data in the buffer, append total bitlength, and return our precious hash!
 function digest!(context::T) where {T<:SHA3_CTX}
     usedspace = context.bytecount % blocklen(T)
-    # If we have anything in the buffer still, pad and transform that data
+    # pad and transform that data (buffer is never full; two cases: at least two bytes free or only one)
     if usedspace < blocklen(T) - 1
         # Begin padding with a 0x06
         context.buffer[usedspace+1] = 0x06
@@ -67,12 +67,7 @@ function digest!(context::T) where {T<:SHA3_CTX}
         # Finish it off with a 0x80
         context.buffer[end] = 0x80
     else
-        # Otherwise, we have to add on a whole new buffer just for the zeros and 0x80
-        context.buffer[end] = 0x06
-        transform!(context)
-
-        context.buffer[1:end-1] = 0x0
-        context.buffer[end] = 0x80
+        context.buffer[end] = 0x86
     end
 
     # Final transform:

--- a/stdlib/SHA/test/runtests.jl
+++ b/stdlib/SHA/test/runtests.jl
@@ -290,6 +290,34 @@ for f in sha_funcs
     nerrors += 1
 end
 
+# test proper padding for sha3_512 in case message length = - 1 mod block length
+VERBOSE && print("Testing padding on msg len = -1 mod blk len for SHA3_512")
+let
+    global nerrors
+    nerrors_old= nerrors
+    sha_func = sha3_512
+    data = repeat([0x41], 25*8-64*2-1)
+    answer = "e9e7f1016227a4d58c3a2c597adc2f58de10b6e78f17ff079624fede5eb8341bf0ebeda4f8296d5a070751ab3b7ffa48d35950f793e21f9c16c095b3b354da5e"
+    hash = try
+        bytes2hex(sha_func(data))
+    catch exc
+        exc
+    end
+    if hash != answer
+        print("\n")
+        @warn("""
+            For $(describe_hash(sha_types[sha_func])) expected:
+                $(answer)
+            Calculated:
+                $(hash)
+        """)
+        nerrors += 1
+    else
+        VERBOSE && print(".")
+    end
+    VERBOSE && println("Done! [$(nerrors - nerrors_old) errors]")
+end
+
 # Clean up the I/O mess
 rm(file)
 rm(tempdir)


### PR DESCRIPTION
The padding in case the message is of size blocklength-1 modulo blocklength was not right. In this case just a single byte 0x86 should
be padded (see https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf , page 28). In addition, the old code crashed for me:

ERROR: LoadError: MethodError: no method matching setindex_shape_check(::UInt8, ::Int64)
Closest candidates are:
  setindex_shape_check(!Matched::AbstractArray{#s72,1} where #s72, ::Integer) at indices.jl:218
  setindex_shape_check(!Matched::AbstractArray{#s72,1} where #s72, ::Integer, !Matched::Integer) at indices.jl:221
  setindex_shape_check(!Matched::AbstractArray{#s72,2} where #s72, ::Integer, !Matched::Integer) at indices.jl:225
  ...
Stacktrace:
 [1] macro expansion at ./multidimensional.jl:694 [inlined]
 [2] _unsafe_setindex!(::IndexLinear, ::Array{UInt8,1}, ::UInt8, ::UnitRange{Int64}) at ./multidimensional.jl:689 
 [3] _setindex! at ./multidimensional.jl:684 [inlined]
 [4] setindex! at ./abstractarray.jl:1020 [inlined]
 [5] digest!(::SHA3_256_CTX) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/SHA/src/sha3.jl:74
 [6] sha3_256(::Array{UInt8,1}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/SHA/src/SHA.jl:51
 [7] top-level scope at none:0
 [8] include at ./boot.jl:326 [inlined]
 [9] include_relative(::Module, ::String) at ./loading.jl:1038
 [10] include(::Module, ::String) at ./sysimg.jl:29
 [11] exec_options(::Base.JLOptions) at ./client.jl:267
 [12] _start() at ./client.jl:436
in expression starting at /home/tr/prog/julia/test/t.jl:4