### PR TITLE
symmetrize/transpose in getindex of SymTridiagonal

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -11,10 +11,7 @@ struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractMatrix{T}
         if !(length(dv) - 1 <= length(ev) <= length(dv))
             throw(DimensionMismatch("subdiagonal has wrong length. Has length $(length(ev)), but should be either $(length(dv) - 1) or $(length(dv))."))
         end
-        if !all(issymmetric.(dv))
-            throw("block matrices on diagonal are not symmetric")
-        end
-        new{T,V}(dv, ev)
+        new{T, V}(dv, ev)
     end
 end
 
@@ -26,8 +23,8 @@ sub/super-diagonal (`ev`), respectively. The result is of type `SymTridiagonal`
 and provides efficient specialized eigensolvers, but may be converted into a
 regular matrix with [`convert(Array, _)`](@ref) (or `Array(_)` for short).
 
-For `SymTridiagonal` block matrices, the elements of `dv` are assumed to be
-symmetric. The argument `ev` is interpreted as the superdiagonal. Blocks from the
+For `SymTridiagonal` block matrices, the elements of `dv` are symmetrized.
+The argument `ev` is interpreted as the superdiagonal. Blocks from the
 subdiagonal are (materialized) transpose of the corresponding superdiagonal blocks.
 
 # Examples
@@ -52,12 +49,12 @@ julia> SymTridiagonal(dv, ev)
  ⋅  8  3  9
  ⋅  ⋅  9  4
 
-julia> A = SymTridiagonal(fill([1 2; 2 3], 3), fill([1 2; 3 4], 2));
+julia> A = SymTridiagonal(fill([1 2; 3 4], 3), fill([1 2; 3 4], 2));
 
 julia> A[1,1]
 2×2 Symmetric{Int64,Array{Int64,2}}:
 1  2
-2  3
+2  4
 
 julia> A[1,2]
 2×2 Array{Int64,2}:

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -14,7 +14,7 @@ struct SymTridiagonal{T, V<:AbstractVector{T}} <: AbstractMatrix{T}
         if !all(issymmetric.(dv))
             throw("block matrices on diagonal are not symmetric")
         end
-        new{T,V}(symmetric.(dv, :U)::AbstractVector{symmetric_type(eltype(dv))}, ev)
+        new{T,V}(dv, ev)
     end
 end
 
@@ -27,9 +27,8 @@ and provides efficient specialized eigensolvers, but may be converted into a
 regular matrix with [`convert(Array, _)`](@ref) (or `Array(_)` for short).
 
 For `SymTridiagonal` block matrices, the elements of `dv` are assumed to be
-symmetric, and made [`Symmetric`](@ref)) at construction. The argument `ev` is
-interpreted as the superdiagonal. Blocks from the subdiagonal are (materialized)
-transpose of the corresponding superdiagonal blocks.
+symmetric. The argument `ev` is interpreted as the superdiagonal. Blocks from the
+subdiagonal are (materialized) transpose of the corresponding superdiagonal blocks.
 
 # Examples
 ```jldoctest
@@ -438,7 +437,7 @@ function getindex(A::SymTridiagonal{T}, i::Integer, j::Integer) where T
         throw(BoundsError(A, (i,j)))
     end
     if i == j
-        return A.dv[i]
+        return symmetric(A.dv[i], :U)::symmetric_type(eltype(A.dv))
     elseif i == j + 1
         return copy(transpose(A.ev[j])) # materialized for type stability
     elseif i + 1 == j

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -104,7 +104,7 @@ julia> SymTridiagonal(B)
 """
 function SymTridiagonal(A::AbstractMatrix)
     if (diag(A, 1) == transpose.(diag(A, -1))) && all(issymmetric.(diag(A, 0)))
-        SymTridiagonal(symmetric.(diag(A, 0), :U), diag(A, 1))
+        SymTridiagonal(diag(A, 0), diag(A, 1))
     else
         throw(ArgumentError("matrix is not symmetric; cannot convert to SymTridiagonal"))
     end

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -53,18 +53,18 @@ julia> A = SymTridiagonal(fill([1 2; 3 4], 3), fill([1 2; 3 4], 2));
 
 julia> A[1,1]
 2×2 Symmetric{Int64,Array{Int64,2}}:
-1  2
-2  4
+ 1  2
+ 2  4
 
 julia> A[1,2]
 2×2 Array{Int64,2}:
-1  2
-3  4
+ 1  2
+ 3  4
 
 julia> A[2,1]
 2×2 Array{Int64,2}:
-1  3
-2  4
+ 1  3
+ 2  4
 ```
 """
 SymTridiagonal(dv::V, ev::V) where {T,V<:AbstractVector{T}} = SymTridiagonal{T}(dv, ev)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -398,6 +398,16 @@ end
     end
 end
 
+@testset "SymTridiagonal block matrix" begin
+    M = [1 2; 2 4]
+    A = SymTridiagonal(fill(M, 3), fill(M, 2))
+    @test @inferred A[1,1] == Symmetric(M)
+    @test @inferred A[1,2] == M
+    @test @inferred A[2,1] == transpose(M)
+    @test @inferred diag(A, 1) == fill(M, 2)
+    @test @inferred diag(A, 0) == fill(Symmetric(M), 3)
+    @test @inferred diag(A, -1) == fill(transpose(M), 2)
+end
 
 @testset "Issue 12068" begin
     @test SymTridiagonal([1, 2], [0])^3 == [1 0; 0 8]


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#613.

Previously, there was no distinction between whether the second argument in the `SymTridiagonal` constructor was the super- or subdiagional, and whether the matrices on the diagonal are `:U` or `:L` symmetric. With this PR, this is hardcoded to `:U` symmetry and superdiagonal, so that the subdiagonal gets transposed. Also, the code comment in line 8 should be changed then to "superdiagonal" as a correct reminder for developers.

We could introduce an `uplo::Char` field, to switch between the two cases, with `:U` being the default? But I'm not sure if this would be breaking...