### PR TITLE
Fix a missing widenconst in SROA

### DIFF
--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -292,7 +292,7 @@ function lift_leaves(compact::IncrementalCompact, @nospecialize(stmt),
                 lifted_leaves[leaf_key] = RefValue{Any}(lifted)
                 continue
             elseif isexpr(def, :new)
-                typ = types(compact)[leaf]
+                typ = widenconst(types(compact)[leaf])
                 if isa(typ, UnionAll)
                     typ = unwrap_unionall(typ)
                 end

--- a/test/compiler/irpasses.jl
+++ b/test/compiler/irpasses.jl
@@ -1,6 +1,7 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 using Test
+using Base.Meta
 
 # Tests for domsort
 
@@ -97,4 +98,15 @@ let nt = (a=1, b=2)
     @test isa(code_typed(blah31139, Tuple{typeof(nt)}), Array)
     # Should throw
     @test_throws ArgumentError blah31139(nt)
+end
+
+# Expr(:new) annoted as PartialStruct
+struct FooPartial
+    x
+    y
+    global f_partial
+    f_partial(x) = new(x, 2).x
+end
+let ci = code_typed(f_partial, Tuple{Float64})[1].first
+    @test length(ci.code) == 1 && isexpr(ci.code[1], :return)
 end


### PR DESCRIPTION
We can now infer Expr(:new) as returning a `PartialStruct` if
one of the arguments is constant. However, SROA was missing a
corresponding widenconst and thus refusing to process such Expr(:new).
This didn't show up very much in julia code, because inlining generally
dropped the PartialStruct annotation on the Expr(:new), but it does
show up with more aggressive inlining schemes that I'm playing with.
Fix it and add a test.