### PR TITLE
optimize (a little bit) faster

### DIFF
--- a/base/compiler/optimize.jl
+++ b/base/compiler/optimize.jl
@@ -272,7 +272,7 @@ intrinsic_effect_free_if_nothrow(f) = f === Intrinsics.pointerref || is_pure_int
 plus_saturate(x::Int, y::Int) = max(x, y, x+y)
 
 # known return type
-isknowntype(@nospecialize T) = (T == Union{}) || isconcretetype(T)
+isknowntype(@nospecialize T) = (T === Union{}) || isconcretetype(T)
 
 function statement_cost(ex::Expr, line::Int, src::CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any}, params::Params)
     head = ex.head

--- a/base/compiler/ssair/inlining.jl
+++ b/base/compiler/ssair/inlining.jl
@@ -923,12 +923,13 @@ end
 # functions.
 function process_simple!(ir::IRCode, idx::Int, params::Params)
     stmt = ir.stmts[idx]
-    if isexpr(stmt, :splatnew)
+    stmt isa Expr || return nothing
+    if stmt.head === :splatnew
         inline_splatnew!(ir, idx)
         return nothing
     end
 
-    isexpr(stmt, :call) || return nothing
+    stmt.head === :call || return nothing
 
     sig = call_sig(ir, stmt)
     sig === nothing && return nothing

--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -11,7 +11,7 @@ function inflate_ir(ci::CodeInfo, linfo::MethodInstance)
 end
 
 function inflate_ir(ci::CodeInfo, sptypes::Vector{Any}, argtypes::Vector{Any})
-    code = copy_exprargs(ci.code)
+    code = copy_exprargs(ci.code) # TODO: this is a huge hot-spot
     for i = 1:length(code)
         if isa(code[i], Expr)
             code[i] = normalize_expr(code[i])

--- a/base/compiler/ssair/passes.jl
+++ b/base/compiler/ssair/passes.jl
@@ -191,16 +191,16 @@ function walk_to_defs(compact::IncrementalCompact, @nospecialize(defssa), @nospe
         def = compact[defssa]
         if isa(def, PhiNode)
             push!(visited_phinodes, defssa)
-            possible_predecessors = let def=def, typeconstraint=typeconstraint
-                collect(Iterators.filter(1:length(def.edges)) do n
-                    isassigned(def.values, n) || return false
-                    val = def.values[n]
-                    if is_old(compact, defssa) && isa(val, SSAValue)
-                        val = OldSSAValue(val.id)
-                    end
-                    edge_typ = widenconst(compact_exprtype(compact, val))
-                    return typeintersect(edge_typ, typeconstraint) !== Union{}
-                end)
+            possible_predecessors = Int[]
+            for n in 1:length(def.edges)
+                isassigned(def.values, n) || continue
+                val = def.values[n]
+                if is_old(compact, defssa) && isa(val, SSAValue)
+                    val = OldSSAValue(val.id)
+                end
+                edge_typ = widenconst(compact_exprtype(compact, val))
+                typeintersect(edge_typ, typeconstraint) === Union{} && continue
+                push!(possible_predecessors, n)
             end
             for n in possible_predecessors
                 pred = def.edges[n]
@@ -829,15 +829,16 @@ function adce_erase!(phi_uses, extra_worklist, compact, idx)
     end
 end
 
-function count_uses(stmt, uses)
+function count_uses(@nospecialize(stmt), uses::Vector{Int})
     for ur in userefs(stmt)
-        if isa(ur[], SSAValue)
-            uses[ur[].id] += 1
+        use = ur[]
+        if isa(use, SSAValue)
+            uses[use.id] += 1
         end
     end
 end
 
-function mark_phi_cycles(compact, safe_phis, phi)
+function mark_phi_cycles(compact::IncrementalCompact, safe_phis::BitSet, phi::Int)
     worklist = Int[]
     push!(worklist, phi)
     while !isempty(worklist)
@@ -864,7 +865,7 @@ function adce_pass!(ir::IRCode)
     end
     non_dce_finish!(compact)
     for phi in all_phis
-        count_uses(compact.result[phi], phi_uses)
+        count_uses(compact.result[phi]::PhiNode, phi_uses)
     end
     # Perform simple DCE for unused values
     extra_worklist = Int[]
@@ -880,7 +881,7 @@ function adce_pass!(ir::IRCode)
     changed = true
     while changed
         changed = false
-        safe_phis = IdSet{Int}()
+        safe_phis = BitSet()
         for phi in all_phis
             # Save any phi cycles that have non-phi uses
             if compact.used_ssas[phi] - phi_uses[phi] != 0
@@ -898,7 +899,7 @@ function adce_pass!(ir::IRCode)
             end
         end
     end
-    complete(compact)
+    return complete(compact)
 end
 
 function type_lift_pass!(ir::IRCode)

--- a/base/compiler/ssair/queries.jl
+++ b/base/compiler/ssair/queries.jl
@@ -4,10 +4,13 @@
 Determine whether a statement is side-effect-free, i.e. may be removed if it has no uses.
 """
 function stmt_effect_free(@nospecialize(stmt), @nospecialize(rt), src, sptypes::Vector{Any})
-    isa(stmt, Union{PiNode, PhiNode}) && return true
-    isa(stmt, Union{ReturnNode, GotoNode, GotoIfNot}) && return false
-    isa(stmt, GlobalRef) && return isdefined(stmt.mod, stmt.name)
+    isa(stmt, PiNode) && return true
+    isa(stmt, PhiNode) && return true
+    isa(stmt, ReturnNode) && return false
+    isa(stmt, GotoNode) && return false
+    isa(stmt, GotoIfNot) && return false
     isa(stmt, Slot) && return false # Slots shouldn't occur in the IR at this point, but let's be defensive here
+    isa(stmt, GlobalRef) && return isdefined(stmt.mod, stmt.name)
     if isa(stmt, Expr)
         e = stmt::Expr
         head = e.head

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -410,7 +410,7 @@ add_tfunc(pointerref, 3, 3,
 add_tfunc(pointerset, 4, 4, (@nospecialize(a), @nospecialize(v), @nospecialize(i), @nospecialize(align)) -> a, 5)
 
 # more accurate typeof_tfunc for vararg tuples abstract only in length
-function typeof_concrete_vararg(@nospecialize(t))
+function typeof_concrete_vararg(t::DataType)
     np = length(t.parameters)
     for i = 1:np
         p = t.parameters[i]

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1179,6 +1179,183 @@ JL_DLLEXPORT int jl_subtype_env_size(jl_value_t *t)
     return sz;
 }
 
+// quickly compute if x seems like a possible subtype of y
+// especially optimized for x isa concrete type
+// returns true if it could be easily determined, with the result in subtype
+// the approximation widens typevar bounds under the assumption they are bound
+// in the immediate caller--the caller must be conservative in handling the result
+JL_DLLEXPORT int jl_obvious_subtype(jl_value_t *x, jl_value_t *y, int *subtype)
+{
+    if (x == y || y == (jl_value_t*)jl_any_type) {
+        *subtype = 1;
+        return 1;
+    }
+    if (jl_is_unionall(x))
+        x = jl_unwrap_unionall(x);
+    if (jl_is_unionall(y))
+        y = jl_unwrap_unionall(y);
+    if (x == y || y == (jl_value_t*)jl_any_type) {
+        *subtype = 1;
+        return 1;
+    }
+    if (jl_is_typevar(x)) {
+        if (((jl_tvar_t*)x)->lb != (jl_value_t*)jl_bottom_type)
+            return 0;
+        if (jl_obvious_subtype(((jl_tvar_t*)x)->ub, y, subtype) && *subtype)
+            return 1;
+        return 0;
+    }
+    if (jl_is_typevar(y)) {
+        if (((jl_tvar_t*)y)->lb != (jl_value_t*)jl_bottom_type)
+            return 0;
+        if (jl_obvious_subtype(x, ((jl_tvar_t*)y)->ub, subtype) && !*subtype)
+            return 1;
+        return 0;
+    }
+    if (x == (jl_value_t*)jl_bottom_type) {
+        *subtype = 1;
+        return 1;
+    }
+    if (y == (jl_value_t*)jl_bottom_type) {
+        *subtype = 0;
+        return 1;
+    }
+    if (!jl_is_type(x) || !jl_is_type(y)) {
+        *subtype = jl_egal(x, y);
+        return 1;
+    }
+    if (jl_is_uniontype(x)) {
+        // TODO: consider handling more LHS unions, being wary of covariance
+        if (jl_obvious_subtype(((jl_uniontype_t*)x)->a, y, subtype) && *subtype) {
+            if (jl_obvious_subtype(((jl_uniontype_t*)x)->b, y, subtype) && *subtype)
+                return 1;
+        }
+        //if (jl_obvious_subtype(((jl_uniontype_t*)x)->a, y, subtype)) {
+        //    if (!*subtype)
+        //        return 1;
+        //    if (jl_obvious_subtype(((jl_uniontype_t*)x)->b, y, subtype))
+        //        return 1;
+        //}
+        //else if (jl_obvious_subtype(((jl_uniontype_t*)x)->b, y, subtype)) {
+        //    if (!*subtype)
+        //        return 1;
+        //}
+        return 0;
+    }
+    if (jl_is_uniontype(y)) {
+        if (jl_obvious_subtype(x, ((jl_uniontype_t*)y)->a, subtype)) {
+            if (*subtype)
+                return 1;
+            if (jl_obvious_subtype(x, ((jl_uniontype_t*)y)->b, subtype))
+                return 1;
+        }
+        else if (jl_obvious_subtype(x, ((jl_uniontype_t*)y)->b, subtype)) {
+            if (*subtype)
+                return 1;
+        }
+        return 0;
+    }
+    if (x == (jl_value_t*)jl_any_type) {
+        *subtype = 0;
+        return 1;
+    }
+    if (jl_is_datatype(y)) {
+        int istuple = (((jl_datatype_t*)y)->name == jl_tuple_typename);
+        int iscov = istuple || (((jl_datatype_t*)y)->name == jl_vararg_typename);
+        // TODO: this would be a nice fast-path to have, unfortuanately,
+        //       datatype allocation fails to correctly cons them
+        //       and the subtyping tests include tests for this case
+        //if (!iscov && ((jl_datatype_t*)y)->isconcretetype && !jl_is_type_type(x)) {
+        //    *subtype = 0;
+        //    return 1;
+        //}
+        if (jl_is_datatype(x)) {
+            int uncertain = 0;
+            if (((jl_datatype_t*)x)->name != ((jl_datatype_t*)y)->name) {
+                if (jl_is_type_type(x) || jl_is_type_type(y))
+                    return 0;
+                jl_datatype_t *temp = (jl_datatype_t*)x;
+                while (temp->name != ((jl_datatype_t*)y)->name) {
+                    temp = temp->super;
+                    if (temp == NULL) // invalid state during type declaration
+                        return 0;
+                    if (temp == jl_any_type) {
+                        *subtype = 0;
+                        return 1;
+                    }
+                }
+                if (jl_obvious_subtype((jl_value_t*)temp, y, subtype) && *subtype)
+                    return 1;
+                return 0;
+            }
+            if (!iscov && !((jl_datatype_t*)x)->hasfreetypevars) {
+                // by transitivity, if `wrapper <: y`, then `x <: y` if x is a leaf type of its name
+                if (jl_obvious_subtype(((jl_datatype_t*)x)->name->wrapper, y, subtype) && *subtype)
+                    return 1;
+            }
+            int i, npx = jl_nparams(x), npy = jl_nparams(y);
+            int vx = 0, vy = 0;
+            if (istuple) {
+                vx = npx > 0 && jl_is_vararg_type(jl_tparam(x, npx - 1));
+                vy = npy > 0 && jl_is_vararg_type(jl_tparam(y, npy - 1));
+            }
+            if (npx != npy || vx || vy) {
+                if (!vy) {
+                    *subtype = 0;
+                    return 1;
+                }
+                if (npx - vx < npy - vy) {
+                    *subtype = 0;
+                    return 1; // number of fixed parameters in x could be fewer than in y
+                }
+                uncertain = 1;
+            }
+            for (i = 0; i < npy - vy; i++) {
+                jl_value_t *a = jl_tparam(x, i);
+                jl_value_t *b = jl_tparam(y, i);
+                if (iscov || jl_is_typevar(b)) {
+                    if (jl_obvious_subtype(a, b, subtype)) {
+                        if (!*subtype)
+                            return 1;
+                        if (jl_has_free_typevars(b)) // b is actually more constrained that this
+                            uncertain = 1;
+                    }
+                    else {
+                        uncertain = 1;
+                    }
+                }
+                else {
+                    if (!obviously_egal(a, b)) {
+                        if (jl_obvious_subtype(a, b, subtype)) {
+                            if (!*subtype)
+                                return 1;
+                            if (jl_has_free_typevars(b)) // b is actually more constrained that this
+                                uncertain = 1;
+                        }
+                        else {
+                            uncertain = 1;
+                        }
+                        if (!jl_has_free_typevars(b) && jl_obvious_subtype(b, a, subtype)) {
+                            if (!*subtype)
+                                return 1;
+                            if (jl_has_free_typevars(a)) // a is actually more constrained that this
+                                uncertain = 1;
+                        }
+                        else {
+                            uncertain = 1;
+                        }
+                    }
+                }
+            }
+            if (uncertain)
+                return 0;
+            *subtype = 1;
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // `env` is NULL if no typevar information is requested, or otherwise
 // points to a rooted array of length `jl_subtype_env_size(y)`.
 // This will be populated with the values of variables from unionall
@@ -1186,15 +1363,35 @@ JL_DLLEXPORT int jl_subtype_env_size(jl_value_t *t)
 JL_DLLEXPORT int jl_subtype_env(jl_value_t *x, jl_value_t *y, jl_value_t **env, int envsz)
 {
     jl_stenv_t e;
-    if (envsz == 0 && (y == (jl_value_t*)jl_any_type || x == jl_bottom_type || x == y))
-        return 1;
-    if (envsz == 0 && ((jl_is_unionall(x) && jl_is_unionall(y)) ||
-                       (jl_is_uniontype(x) && jl_is_uniontype(y))) &&
-        jl_egal(x, y)) {
-        return 1;
+    if (envsz == 0) {
+        if (y == (jl_value_t*)jl_any_type || x == jl_bottom_type || x == y)
+            return 1;
+        if (jl_typeof(x) == jl_typeof(y) &&
+            (jl_is_unionall(y) || jl_is_uniontype(y)) &&
+            jl_egal(x, y))
+            return 1;
+    }
+    int obvious_subtype = 2;
+    if (jl_obvious_subtype(x, y, &obvious_subtype)) {
+#ifdef NDEBUG
+        if (obvious_subtype == 0)
+            return obvious_subtype;
+        else if (jl_has_free_typevars(y))
+            obvious_subtype = 3;
+        else if (envsz == 0)
+            return obvious_subtype;
+#else
+        if (jl_has_free_typevars(y))
+            obvious_subtype = 3;
+#endif
+    }
+    else {
+        obvious_subtype = 3;
     }
     init_stenv(&e, env, envsz);
-    return forall_exists_subtype(x, y, &e, 0);
+    int subtype = forall_exists_subtype(x, y, &e, 0);
+    assert(obvious_subtype == 3 || obvious_subtype == subtype);
+    return subtype;
 }
 
 static int subtype_in_env(jl_value_t *x, jl_value_t *y, jl_stenv_t *e)


### PR DESCRIPTION
Simplifies some code patterns that the compiler can't optimize.

Adds a fast-path to subtype to attempt to handle common simple cases. We also still probably should duplicate parts of this fast path in the compiler (to handle the pattern `x isa AnySSAValue`), since it is now heavily used by the optimizer code in various hot-paths.

~~Also updates a few of the inlining costs to reflect that certain operations have non-zero expected cost in aggregate. This helps to put an eventual cap on the inlining of large functions that consist mostly of these operations.~~