### PR TITLE
Improve searchsorted{,first,last} examples in documentation

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -305,18 +305,20 @@ if `a` does not contain values equal to `x`.
 
 # Examples
 ```jldoctest
-julia> a = [4, 3, 2, 1]
-4-element Array{Int64,1}:
- 4
- 3
- 2
- 1
+julia> searchsorted([1, 2, 4, 5, 5, 7], 4) # single match
+3:3
 
-julia> searchsorted(a, 4)
-5:4
+julia> searchsorted([1, 2, 4, 5, 5, 7], 5) # multiple matches
+4:5
 
-julia> searchsorted(a, 4, rev=true)
-1:1
+julia> searchsorted([1, 2, 4, 5, 5, 7], 3) # no match, insert in the middle
+3:2
+
+julia> searchsorted([1, 2, 4, 5, 5, 7], 9) # no match, insert at end
+7:6
+
+julia> searchsorted([1, 2, 4, 5, 5, 7], 0) # no match, insert at start
+1:0
 ```
 """ searchsorted
 
@@ -329,14 +331,20 @@ specified order. Return `length(a) + 1` if `x` is greater than all values in `a`
 
 # Examples
 ```jldoctest
-julia> searchsortedfirst([1, 2, 4, 5, 14], 4)
+julia> searchsortedfirst([1, 2, 4, 5, 5, 7], 4) # single match
 3
 
-julia> searchsortedfirst([1, 2, 4, 5, 14], 4, rev=true)
-1
+julia> searchsortedfirst([1, 2, 4, 5, 5, 7], 5) # multiple matches
+4
 
-julia> searchsortedfirst([1, 2, 4, 5, 14], 15)
-6
+julia> searchsortedfirst([1, 2, 4, 5, 5, 7], 3) # no match, insert in the middle
+3
+
+julia> searchsortedfirst([1, 2, 4, 5, 5, 7], 9) # no match, insert at end
+7
+
+julia> searchsortedfirst([1, 2, 4, 5, 5, 7], 0) # no match, insert at start
+1
 ```
 """ searchsortedfirst
 
@@ -349,13 +357,19 @@ be sorted.
 
 # Examples
 ```jldoctest
-julia> searchsortedlast([1, 2, 4, 5, 14], 4)
+julia> searchsortedlast([1, 2, 4, 5, 5, 7], 4) # single match
 3
 
-julia> searchsortedlast([1, 2, 4, 5, 14], 4, rev=true)
+julia> searchsortedlast([1, 2, 4, 5, 5, 7], 5) # multiple matches
 5
 
-julia> searchsortedlast([1, 2, 4, 5, 14], -1)
+julia> searchsortedlast([1, 2, 4, 5, 5, 7], 3) # no match, insert in the middle
+2
+
+julia> searchsortedlast([1, 2, 4, 5, 5, 7], 9) # no match, insert at end
+6
+
+julia> searchsortedlast([1, 2, 4, 5, 5, 7], 0) # no match, insert at start
 0
 ```
 """ searchsortedlast


### PR DESCRIPTION
Use the same inputs for all three functions, and cover various cases, to help
the reader grasp how these functions work and relate to each other.

Also remove the examples using the `rev` option, which did not really make
sense, as the input was not reversed, so these really were examples on "what
happens if the input is not sorted", which does not really help much (if at
all, an explanation in the text would be better).