### PR TITLE
make a subtyping fast path a bit less aggressive

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -976,15 +976,17 @@ static int subtype(jl_value_t *x, jl_value_t *y, jl_stenv_t *e, int param)
         return 1;
     jl_value_t *ux = jl_unwrap_unionall(x);
     jl_value_t *uy = jl_unwrap_unionall(y);
-    if ((x != ux || y != uy) && y != (jl_value_t*)jl_any_type && jl_is_datatype(ux) && jl_is_datatype(uy)) {
+    if ((x != ux || y != uy) && y != (jl_value_t*)jl_any_type && jl_is_datatype(ux) && jl_is_datatype(uy) &&
+        !jl_is_type_type(ux)) {
         assert(ux);
+        if (uy == (jl_value_t*)jl_any_type)
+            return 1;
         jl_datatype_t *xd = (jl_datatype_t*)ux, *yd = (jl_datatype_t*)uy;
         while (xd != NULL && xd != jl_any_type && xd->name != yd->name) {
             xd = xd->super;
         }
-        if (xd == jl_any_type && !jl_is_type_type(ux)) {
+        if (xd == jl_any_type)
             return 0;
-        }
     }
     // handle forall ("left") vars first
     if (jl_is_unionall(x)) {

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1011,6 +1011,15 @@ test_properties()
 test_intersection_properties()
 
 
+let S = ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), UnionAll, [TypeVar(:T), Any], 2),
+    VS = TypeVar(:T),
+    T = ccall(:jl_new_structv, Any, (Any, Ptr{Cvoid}, UInt32), UnionAll, [VS, VS], 2)
+    # check (T where T) == (Any where T)
+    # these types are not normally valid, but check them just to make sure subtyping is robust
+    @test T <: S
+    @test S <: T
+end
+
 # issue #20121
 @test NTuple{170,Matrix{Int}} <: (Tuple{Vararg{Union{Array{T,1},Array{T,2},Array{T,3}}}} where T)
 


### PR DESCRIPTION
This code was using the fact that types like `Any where T` are normalized. That's usually a valid assumption in practice but some extra robustness here doesn't cost much.