### PR TITLE
fix #31326, setting of system image data size when loading

### DIFF
--- a/src/staticdata.c
+++ b/src/staticdata.c
@@ -195,9 +195,9 @@ static void jl_load_sysimg_so(void)
     }
     const char *sysimg_data;
     jl_dlsym(jl_sysimg_handle, "jl_system_image_data", (void **)&sysimg_data, 1);
-    size_t len;
-    jl_dlsym(jl_sysimg_handle, "jl_system_image_size", (void **)&len, 1);
-    jl_restore_system_image_data(sysimg_data, len);
+    size_t *plen;
+    jl_dlsym(jl_sysimg_handle, "jl_system_image_size", (void **)&plen, 1);
+    jl_restore_system_image_data(sysimg_data, *plen);
 }
 
 


### PR DESCRIPTION
This doesn't make any observable difference, since using the pointer instead of the value is equivalent to using a way-too-big-size, which doesn't affect loading the data since the stream is structured and we know when it ends anyway. Might as well do it right though.