### PR TITLE
Fix #31357 - Missing Upsilon node in nested try/catch

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -6865,3 +6865,21 @@ let x = SplatNew{Tuple{Int16}}((1,))
     @test x.y === (Int16(1),)
 end
 @test_throws ArgumentError SplatNew{Int8}()
+
+# Issue #31357 - Missed assignment in nested try/catch
+function foo31357(b::Bool)
+    x = nothing
+    try
+        try
+            x = 12345
+            if !b
+               throw("hi")
+            end
+        finally
+        end
+    catch
+    end
+    return x
+end
+@test foo31357(true) == 12345
+@test foo31357(false) == 12345


### PR DESCRIPTION
As the issue demonstrates, if we have nested try/catch blocks,
we need one upsilon node for every layer of nesting. This just
inserts another upsilon node for every layer of nesting. Alternative
implementations would be to
1. Re-use the same upsilon node for every phic (but this currently conflicts
   with our implementation of this feature in the interpreter) or
2. To place the additional upsilon nodes in the catch block. This would be slightly
    faster, but also a bit more complicated, so is left as a future optimization.