### PR TITLE
fix #31352, make sure errors while printing errors don't kill the REPL

### DIFF
--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -166,8 +166,17 @@ function print_response(errio::IO, @nospecialize(response), show_value::Bool, ha
             break
         catch
             if iserr
+                println(errio) # an error during printing is likely to leave us mid-line
                 println(errio, "SYSTEM (REPL): showing an error caused an error")
-                println(errio, catch_stack())
+                try
+                    Base.invokelatest(Base.display_error, errio, catch_stack())
+                catch e
+                    # at this point, only print the name of the type as a Symbol to
+                    # minimize the possibility of further errors.
+                    println(errio)
+                    println(errio, "SYSTEM (REPL): caught exception of type ", typeof(e).name.name,
+                            " while trying to handle a nested exception; giving up")
+                end
                 break
             end
             val = catch_stack()

--- a/stdlib/REPL/test/repl.jl
+++ b/stdlib/REPL/test/repl.jl
@@ -994,3 +994,20 @@ fake_repl() do stdin_write, stdout_read, repl
     write(stdin_write, '\x04')
     Base.wait(repltask)
 end
+
+# issue #31352
+fake_repl() do stdin_write, stdout_read, repl
+    repltask = @async begin
+        REPL.run_repl(repl)
+    end
+    write(stdin_write, "struct Errs end\n")
+    readline(stdout_read)
+    readline(stdout_read)
+    write(stdin_write, "Base.show(io::IO, ::Errs) = throw(Errs())\n")
+    readline(stdout_read)
+    readline(stdout_read)
+    write(stdin_write, "Errs()\n")
+    write(stdin_write, '\x04')
+    wait(repltask)
+    @test istaskdone(repltask)
+end


### PR DESCRIPTION
The idea here is to make one further attempt to print an exception trace for the error thrown while showing, and if *that* fails fall back to very simple printing that's unlikely to fail. If you manage to break printing of strings and symbols, well, you win a prize.

fixes #31352