### PR TITLE
added update! for dict

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -408,6 +408,33 @@ function filter(f, d::AbstractDict)
     return df
 end
 
+"""
+    update!(combine, dict::AbstractDict, key, val)
+
+If `haskey(dict, key)`, then updates `dict[key] = combine(dict[key], val)`. Otherwise,
+sets `dict[key] = combine(val)`. The new value is returned. Many concrete implementations
+of `AbstractDict` can perform such updates in a single lookup.
+
+# Examples
+```jldoctest
+julia> d = Dict("a"=>1, "b"=>2, "c"=>3);
+
+julia> update!(+, d, "a", 1)
+2
+
+julia> update!(-, d, "e", 1)
+-1
+
+julia> d
+Dict{String,Int64} with 4 entries:
+  "c" => 3
+  "e" => -1
+  "b" => 2
+  "a" => 2
+```
+"""
+update!(combine, dict::AbstractDict, key, val) = haskey(dict, key) ? dict[key] = combine(dict[key], val) : dict[val]=combine(val)
+
 function eltype(::Type{<:AbstractDict{K,V}}) where {K,V}
     if @isdefined(K)
         if @isdefined(V)

--- a/base/dict.jl
+++ b/base/dict.jl
@@ -391,6 +391,21 @@ function setindex!(h::Dict{K,V}, v0, key::K) where V where K
     return h
 end
 
+function update!(combine, h::Dict{K,V}, key, val)  where {K,V}
+    idx = ht_keyindex2!(h, key)
+    if idx > 0
+        @inbounds h.keys[idx] = convert(K, key)
+        @inbounds vold = h.vals[idx]
+        vnew = combine(vold, val)
+        @inbounds h.vals[idx] = vnew
+        return vnew
+    else
+        vnew = combine(val)
+        @inbounds _setindex!(h, vnew, key, -idx)
+        return vnew
+    end
+end
+
 """
     get!(collection, key, default)
 

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -525,6 +525,7 @@ export
     union,
     unique!,
     unique,
+    update!,
     values,
     valtype,
     ∈,

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -59,7 +59,7 @@ end
         update!(+, h, j, 1)
     end
     for i=0:600
-        @test (get(h, i, 0) == ((iseven(i) + rem(i, 3))==0))
+        @test (get(h, i, 0) == (!iseven(i) + (rem(i, 3)==0)))
     end
     empty!(h)
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -52,6 +52,17 @@ end
         delete!(h, i)
     end
     @test isempty(h)
+    for i=1:2:600
+        update!(+, h, i, 1)
+    end
+    for j=0:3:600
+        update!(+, h, j, 1)
+    end
+    for i=0:600
+        @test (get(h, i, 0) == ((iseven(i) + rem(i, 3))==0))
+    end
+    empty!(h)
+
     h[77] = 100
     @test h[77] == 100
     for i=1:10000


### PR DESCRIPTION
As discussed in [31199](https://github.com/JuliaLang/julia/issues/31199), @JeffBezanson 's suggestion for an API that updates a dictionary inplace using only a single lookup, combining the old and new value with a combiner function.

What I am unhappy about: `do`-syntax is ugly for varargs (try using this with `do` syntax). If the main usecase is with `do`-syntax, then it would be better to call `combine(key, (vold, vnew))` resp `combine(key, (vnew,))` or `combine((vold, vnew))` resp `combine((vnew,))` and leave the unpacking to the user code (since you can't use dispatch on the anonymous function). 

Second thing I am unhappy about: `update(combine, dict, key, value)` feels natural, but is in conflict with `setindex!(collection, value, key)`.

Ideas or opinions?