### PR TITLE
improve deserialize error message

### DIFF
--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -745,8 +745,8 @@ function gettable(s::AbstractSerializer, id::Int)
             Attempt to access internal table with key $id failed.
 
             This might occur if the Serializer contexts when serializing and deserializing are inconsistent.
-            In particular, if the stream was written with multiple calls to serialize(s::AbstractSerializer, x),
-            then it should be read with multiple calls to deserialize(s::AbstractSerializer).
+            In particular, if multiple serialize calls use the same Serializer object then
+            the corresponding deserialize calls should also use the same Serializer object.
         """
         error(errmsg)
     end

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -737,6 +737,21 @@ function resolve_ref_immediately(s::AbstractSerializer, @nospecialize(x))
     nothing
 end
 
+function gettable(s::AbstractSerializer, id::Int)
+    if haskey(s.table, id)
+        return s.table[id]
+    else
+        errmsg = """Inconsistent Serializer state when deserializing.
+            Attempt to access internal table with key $id failed.
+
+            This might occur if the Serializer contexts when serializing and deserializing are inconsistent.
+            In particular, if the stream was written with multiple calls to serialize(s::AbstractSerializer, x),
+            then it should be read with multiple calls to deserialize(s::AbstractSerializer).
+        """
+        error(errmsg)
+    end
+end
+
 # deserialize_ is an internal function to dispatch on the tag
 # describing the serialized representation. the number of
 # representations is fixed, so deserialize_ does not get extended.
@@ -750,10 +765,10 @@ function handle_deserialize(s::AbstractSerializer, b::Int32)
         return deserialize_tuple(s, Int(read(s.io, UInt8)::UInt8))
     elseif b == SHORTBACKREF_TAG
         id = read(s.io, UInt16)::UInt16
-        return s.table[Int(id)]
+        return gettable(s, Int(id))
     elseif b == BACKREF_TAG
         id = read(s.io, Int32)::Int32
-        return s.table[Int(id)]
+        return gettable(s, Int(id))
     elseif b == ARRAY_TAG
         return deserialize_array(s)
     elseif b == DATATYPE_TAG
@@ -800,7 +815,7 @@ function handle_deserialize(s::AbstractSerializer, b::Int32)
         return deserialize_expr(s, Int(read(s.io, Int32)::Int32))
     elseif b == LONGBACKREF_TAG
         id = read(s.io, Int64)::Int64
-        return s.table[Int(id)]
+        return gettable(s, Int(id))
     elseif b == LONGSYMBOL_TAG
         return deserialize_symbol(s, Int(read(s.io, Int32)::Int32))
     elseif b == HEADER_TAG

--- a/stdlib/Serialization/src/Serialization.jl
+++ b/stdlib/Serialization/src/Serialization.jl
@@ -738,9 +738,7 @@ function resolve_ref_immediately(s::AbstractSerializer, @nospecialize(x))
 end
 
 function gettable(s::AbstractSerializer, id::Int)
-    if haskey(s.table, id)
-        return s.table[id]
-    else
+    get(s.table, id) do
         errmsg = """Inconsistent Serializer state when deserializing.
             Attempt to access internal table with key $id failed.
 


### PR DESCRIPTION
Ref: https://github.com/JuliaLang/julia/issues/31337#issuecomment-472864234

> The values were written with the same Serializer context, so there can be shared references within the stream. They need to be deserialized using the same context object as well.

If this is not the case, then an error can be triggered with the somewhat cryptic message:
```
ERROR: KeyError: key 0 not found
```
This is an attempt to improve that error message.
Maybe the new message is too verbose or imprecise? 
Or maybe there are other conditions which trigger the error?
In any case I submit this for your consideration.
