### PR TITLE
Explicitly ask for `HFS+` filesystems when creating `.dmg` files on MacOS

### DIFF
--- a/contrib/mac/app/Makefile
+++ b/contrib/mac/app/Makefile
@@ -23,7 +23,7 @@ APP_COPYRIGHT:=© 2016 The Julia Project
 all: clean $(DMG_NAME)
 
 $(DMG_NAME): dmg/$(APP_NAME) dmg/.VolumeIcon.icns dmg/Applications
-	hdiutil create $@ -size 1t -ov -volname "$(VOL_NAME)" -imagekey zlib-level=9 -srcfolder dmg
+	hdiutil create $@ -size 1t -fs HFS+ -ov -volname "$(VOL_NAME)" -imagekey zlib-level=9 -srcfolder dmg
 
 dmg/.VolumeIcon.icns: julia.icns
 	-mkdir -p dmg


### PR DESCRIPTION
This is necessary for cross-compatibility, as if a user creates a `.dmg`
file on a newer version of MacOS, it may default to `APFS` which is
unreadable on MacOS 10.11 and lower.