### PR TITLE
Mark aarch64 as BINARY=64

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -747,7 +747,7 @@ endif
 ifneq (,$(findstring aarch64,$(ARCH)))
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
-BINARY=:64
+BINARY:=64
 endif
 
 # Set MARCH-specific flags

--- a/Make.inc
+++ b/Make.inc
@@ -747,6 +747,7 @@ endif
 ifneq (,$(findstring aarch64,$(ARCH)))
 OPENBLAS_DYNAMIC_ARCH:=0
 OPENBLAS_TARGET_ARCH:=ARMV8
+BINARY=:64
 endif
 
 # Set MARCH-specific flags


### PR DESCRIPTION
This opts us in to things like automatically building `openblas64_.so` on `aarch64` systems, which seems more consistent.  I think this makes sense, please someone correct me if it doesn't.