### PR TITLE
Fix  #31325. Fast inplace multiplication by a diagonal matrix on the …

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -285,6 +285,9 @@ mul!(out::AbstractMatrix, A::Diagonal, in::StridedMatrix) = out .= A.diag .* in
 mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::StridedMatrix) = out .= adjoint.(A.parent.diag) .* in
 mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::StridedMatrix) = out .= transpose.(A.parent.diag) .* in
 
+# add methods for mul! when right multiplication by diagonal (no need for an AbstractVector case)
+mul!(out::AbstractMatrix, in::StridedMatrix, A::Diagonal) = out .= transpose(A.diag) .* in
+
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose
 *(A::Diagonal, transB::Transpose{<:Any,<:RealHermSymComplexSym}) = A * transB.parent

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -185,6 +185,9 @@ Random.seed!(1)
         @test (r = transpose(Matrix(D)) * vv ; mul!(vvv, transpose(D), vv) ≈ r ≈ vvv)
 
         UUU = similar(UU)
+        @test (r = UU * Matrix(D)   ; mul!(UUU, UU, D) ≈ r ≈ UUU)
+
+        UUU = similar(UU)
         @test (r = Matrix(D) * UU   ; mul!(UUU, D, UU) ≈ r ≈ UUU)
         @test (r = Matrix(D)' * UU  ; mul!(UUU, adjoint(D), UU) ≈ r ≈ UUU)
         @test (r = transpose(Matrix(D)) * UU ; mul!(UUU, transpose(D), UU) ≈ r ≈ UUU)


### PR DESCRIPTION
…right: mul!(out,matrix,diagonal)

For now I only implemented one new case. I'm not quite sure if the dispatch on the Adjoint/Transpose{<:Any,<:Diagonal} are useful as I do not seem able to create these type (when I transpose a Diagonal I still get a simple Diagonal...)

Also first pull request here! Don't hesitate to tell me if I did something wrong :)