### PR TITLE
Fix #31396

### DIFF
--- a/base/rational.jl
+++ b/base/rational.jl
@@ -369,6 +369,7 @@ trunc(::Type{T}, x::Rational) where {T} = convert(T,div(x.num,x.den))
 floor(::Type{T}, x::Rational) where {T} = convert(T,fld(x.num,x.den))
 ceil(::Type{T}, x::Rational) where {T} = convert(T,cld(x.num,x.den))
 round(::Type{T}, x::Rational, r::RoundingMode=RoundNearest) where {T} = _round_rational(T, x, r)
+round(x::Rational, r::RoundingMode) = round(Rational, x, r)
 
 function _round_rational(::Type{T}, x::Rational{Tr}, ::RoundingMode{:Nearest}) where {T,Tr}
     if denominator(x) == zero(Tr) && T <: Integer

--- a/test/rational.jl
+++ b/test/rational.jl
@@ -367,3 +367,6 @@ end
 
 # issue #16282
 @test_throws MethodError 3 // 4.5im
+
+# issue #31396
+@test round(1//2, RoundNearestTiesUp) === 1//1


### PR DESCRIPTION
Since the `s` variable  in `_round_rational` is an Integer, I can't see a better way of fixing  #31396 , unless `_round_rational` is re-written.