### PR TITLE
Allow ccall(..., llvmcall, ...) to external functions.

### DIFF
--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -1949,8 +1949,14 @@ jl_cgval_t function_sig_t::emit_a_ccall(
         }
         else {
             assert(symarg.f_name != NULL);
-            llvmf = jl_Module->getOrInsertFunction(symarg.f_name, functype);
-            if (!isa<Function>(llvmf) || cast<Function>(llvmf)->getIntrinsicID() == Intrinsic::not_intrinsic)
+            const char* f_name = symarg.f_name;
+            bool f_extern = (strncmp(f_name, "extern ", 7) == 0);
+            if (f_extern)
+                f_name += 7;
+            llvmf = jl_Module->getOrInsertFunction(f_name, functype);
+            if (!f_extern &&
+                (!isa<Function>(llvmf) ||
+                 cast<Function>(llvmf)->getIntrinsicID() == Intrinsic::not_intrinsic))
                 jl_error("llvmcall only supports intrinsic calls");
         }
     }

--- a/test/llvmcall.jl
+++ b/test/llvmcall.jl
@@ -229,3 +229,11 @@ module LLVMCallFunctionTest
         @test really_complicated_identity(x) === x
     end
 end
+
+# support for calling external functions
+let
+    f() = ccall("time", llvmcall, Cvoid, (Ptr{Cvoid},), C_NULL)
+    @test_throws ErrorException f()
+    f() = ccall("extern time", llvmcall, Cvoid, (Ptr{Cvoid},), C_NULL)
+    f()
+end


### PR DESCRIPTION
This is useful for calling into libraries that are linked by CUDAnative, both libraries with PTX bitcode (`libdevice`, like [here](https://github.com/JuliaGPU/CUDAnative.jl/blob/9dc167dfc44d518448998c6dac6b3616c2b0cdea/src/device/libdevice.jl)) and libraries with PTX assembly (`libcudadevrt`). We currently do this with [a nasty macro](https://github.com/JuliaGPU/CUDAnative.jl/blob/9dc167dfc44d518448998c6dac6b3616c2b0cdea/src/device/tools.jl#L3-L100) that generates `llvmcall` expressions that declare the function, but that duplicates functionality from the `ccall` implementation in Julia.


