### PR TITLE
Disable startup files in misc. tests that spawn julia_cmd

### DIFF
--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -446,7 +446,7 @@ end
             srv = listen(addr)
             s = connect(addr)
 
-            @test success(pipeline(`$(Base.julia_cmd()) -e "exit()" -i`, stdin=s))
+            @test success(pipeline(`$(Base.julia_cmd()) --startup-file=no -e "exit()" -i`, stdin=s))
 
             close(s)
             close(srv)

--- a/test/loading.jl
+++ b/test/loading.jl
@@ -568,9 +568,9 @@ end
         cd("foo")
         @test Base.active_project() == old
         """
-        @test success(`$(Base.julia_cmd()) --project=foo -e $(script)`)
+        @test success(`$(Base.julia_cmd()) --startup-file=no --project=foo -e $(script)`)
         withenv("JULIA_PROJECT" => "foo") do
-            @test success(`$(Base.julia_cmd()) -e $(script)`)
+            @test success(`$(Base.julia_cmd()) --startup-file=no -e $(script)`)
         end
     end; end
 end
@@ -586,7 +586,7 @@ mktempdir() do dir
     mkpath(vpath)
     withenv("JULIA_DEPOT_PATH" => dir) do
         script = "@assert startswith(Base.active_project(), $(repr(vpath)))"
-        @test success(`$(Base.julia_cmd()) -e $(script)`)
+        @test success(`$(Base.julia_cmd()) --startup-file=no -e $(script)`)
     end
 end
 
@@ -603,7 +603,7 @@ end
     for (env, result) in pairs(cases)
         withenv("JULIA_LOAD_PATH" => env) do
             script = "LOAD_PATH == $(repr(result)) || error()"
-            @test success(`$(Base.julia_cmd()) -e $script`)
+            @test success(`$(Base.julia_cmd()) --startup-file=no -e $script`)
         end
     end
 end
@@ -622,7 +622,7 @@ end
     for (env, result) in pairs(cases)
         withenv("JULIA_DEPOT_PATH" => env) do
             script = "DEPOT_PATH == $(repr(result)) || error()"
-            @test success(`$(Base.julia_cmd()) -e $script`)
+            @test success(`$(Base.julia_cmd()) --startup-file=no -e $script`)
         end
     end
 end

--- a/test/spawn.jl
+++ b/test/spawn.jl
@@ -519,7 +519,7 @@ end
 
 # Logging macros should not output to finalized streams (#26687)
 let
-    cmd = `$(Base.julia_cmd()) -e 'finalizer(x->@info(x), "Hello")'`
+    cmd = `$exename --startup-file=no -e 'finalizer(x->@info(x), "Hello")'`
     output = readchomp(pipeline(cmd, stderr=catcmd))
     @test occursin("Info: Hello", output)
 end
@@ -614,7 +614,7 @@ end
 
 let text = "input-test-text"
     b = PipeBuffer()
-    proc = open(Base.CmdRedirect(Base.CmdRedirect(```$(Base.julia_cmd()) -E '
+    proc = open(Base.CmdRedirect(Base.CmdRedirect(```$exename --startup-file=no -E '
                     in14 = Base.open(RawFD(14))
                     out15 = Base.open(RawFD(15))
                     write(out15, in14)'```,


### PR DESCRIPTION
Some of these tests were failing for me when running locally since I have a custom startup file.