### PR TITLE
Export additional LLVM passes

### DIFF
--- a/src/llvm-alloc-opt.cpp
+++ b/src/llvm-alloc-opt.cpp
@@ -4,11 +4,15 @@
 #undef DEBUG
 #include "llvm-version.h"
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/ADT/SmallSet.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/SetVector.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/CFG.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Dominators.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -1489,4 +1493,9 @@ static RegisterPass<AllocOpt> X("AllocOpt", "Promote heap allocation to stack",
 Pass *createAllocOptPass()
 {
     return new AllocOpt();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddAllocOptPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createAllocOptPass());
 }

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -215,9 +215,9 @@ extern "C" JL_DLLEXPORT LLVMContextRef LLVMExtraGetValueContext(LLVMValueRef V)
 }
 
 extern ModulePass *createNVVMReflectPass();
-extern "C" JL_DLLEXPORT void LLVMExtraAddMVVMReflectPass(LLVMPassManagerRef PM)
+extern "C" JL_DLLEXPORT void LLVMExtraAddNVVMReflectPass(LLVMPassManagerRef PM)
 {
-    createNVVMReflectPass();
+    unwrap(PM)->add(createNVVMReflectPass());
 }
 
 extern "C" JL_DLLEXPORT void

--- a/src/llvm-api.cpp
+++ b/src/llvm-api.cpp
@@ -86,6 +86,12 @@ extern "C" JL_DLLEXPORT LLVMBool LLVMExtraInitializeNativeDisassembler()
     return InitializeNativeTargetDisassembler();
 }
 
+// Exporting the Barrier LLVM pass
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddBarrierNoopPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createBarrierNoopPass());
+}
 
 // Infrastructure for writing LLVM passes in Julia
 

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -3,11 +3,15 @@
 // This LLVM pass verifies invariants required for correct GC root placement.
 // See the devdocs for a description of these invariants.
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/PostOrderIterator.h>
 #include <llvm/Analysis/CFG.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Constants.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Dominators.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
@@ -185,4 +189,9 @@ static RegisterPass<GCInvariantVerifier> X("GCInvariantVerifier", "GC Invariant 
 
 Pass *createGCInvariantVerifierPass(bool Strong) {
     return new GCInvariantVerifier(Strong);
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddGCInvariantVerifierPass(LLVMPassManagerRef PM, bool Strong)
+{
+    unwrap(PM)->add(createGCInvariantVerifierPass(Strong));
 }

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1,5 +1,8 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/ADT/BitVector.h>
 #include <llvm/ADT/PostOrderIterator.h>
 #include <llvm/ADT/SetVector.h>
@@ -12,6 +15,7 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/CallSite.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/MDBuilder.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/IRBuilder.h>
@@ -2179,4 +2183,9 @@ static RegisterPass<LateLowerGCFrame> X("LateLowerGCFrame", "Late Lower GCFrame 
 
 Pass *createLateLowerGCFramePass() {
     return new LateLowerGCFrame();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddLateLowerGCFramePass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createLateLowerGCFramePass());
 }

--- a/src/llvm-lower-handlers.cpp
+++ b/src/llvm-lower-handlers.cpp
@@ -1,9 +1,13 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/ADT/DepthFirstIterator.h>
 #include <llvm/Analysis/CFG.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/Constants.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -238,4 +242,9 @@ static RegisterPass<LowerExcHandlers> X("LowerExcHandlers", "Lower Julia Excepti
 Pass *createLowerExcHandlersPass()
 {
     return new LowerExcHandlers();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddLowerExcHandlersPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createLowerExcHandlersPass());
 }

--- a/src/llvm-muladd.cpp
+++ b/src/llvm-muladd.cpp
@@ -4,7 +4,11 @@
 #undef DEBUG
 #include "llvm-version.h"
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/IR/Value.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -94,4 +98,9 @@ static RegisterPass<CombineMulAdd> X("CombineMulAdd", "Combine mul and add to mu
 Pass *createCombineMulAddPass()
 {
     return new CombineMulAdd();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddCombineMulAddPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createCombineMulAddPass());
 }

--- a/src/llvm-multiversioning.cpp
+++ b/src/llvm-multiversioning.cpp
@@ -9,8 +9,12 @@
 #include "llvm-version.h"
 #include "support/dtypes.h"
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/Pass.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
@@ -1077,4 +1081,9 @@ static RegisterPass<MultiVersioning> X("JuliaMultiVersioning", "JuliaMultiVersio
 Pass *createMultiVersioningPass()
 {
     return new MultiVersioning();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddMultiVersioningPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createMultiVersioningPass());
 }

--- a/src/llvm-propagate-addrspaces.cpp
+++ b/src/llvm-propagate-addrspaces.cpp
@@ -1,11 +1,15 @@
 // This file is a part of Julia. License is MIT: https://julialang.org/license
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/Analysis/CFG.h>
 #include <llvm/IR/Value.h>
 #include <llvm/IR/ValueMap.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Dominators.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -290,4 +294,9 @@ static RegisterPass<PropagateJuliaAddrspaces> X("PropagateJuliaAddrspaces", "Pro
 
 Pass *createPropagateJuliaAddrspaces() {
     return new PropagateJuliaAddrspaces();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddPropagateJuliaAddrspaces(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createPropagateJuliaAddrspaces());
 }

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -9,8 +9,12 @@
 #include "support/dtypes.h"
 #include <sstream>
 
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/Pass.h>
 #include <llvm/IR/Module.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Constants.h>
@@ -292,4 +296,9 @@ static RegisterPass<LowerPTLS> X("LowerPTLS", "LowerPTLS Pass",
 Pass *createLowerPTLSPass(bool imaging_mode)
 {
     return new LowerPTLS(imaging_mode);
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddLowerPTLSPass(LLVMPassManagerRef PM, bool imaging_mode)
+{
+    unwrap(PM)->add(createLowerPTLSPass(imaging_mode));
 }

--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -15,7 +15,12 @@
 
 #include "llvm-version.h"
 #include "support/dtypes.h"
+
+#include <llvm-c/Core.h>
+#include <llvm-c/Types.h>
+
 #include <llvm/Analysis/LoopPass.h>
+#include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Metadata.h>
@@ -247,6 +252,11 @@ static RegisterPass<LowerSIMDLoop> X("LowerSIMDLoop", "LowerSIMDLoop Pass",
 JL_DLLEXPORT Pass *createLowerSimdLoopPass()
 {
     return new LowerSIMDLoop();
+}
+
+extern "C" JL_DLLEXPORT void LLVMExtraAddLowerSimdLoopPass(LLVMPassManagerRef PM)
+{
+    unwrap(PM)->add(createLowerSimdLoopPass());
 }
 
 } // namespace llvm


### PR DESCRIPTION
Addendum to https://github.com/JuliaLang/julia/pull/31101: the GC lowering pass performs critical clean-up (specifically, removing unsupported operand bundles), so we need to able to call them from within CUDAnative.jl without having to rerun the entire optimization pipeline. This would also be another use case for https://github.com/JuliaLang/julia/pull/31135.

cc @vchuravy, you wanted to add other passes here?