### PR TITLE
Fix llvm-assertion: don't instantiate 0-sized structs (ghost types)

### DIFF
--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -671,11 +671,9 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
         if (!type_is_ghost(ptrty)) {
             thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
             typed_store(ctx, thePtr, im1, x, ety, tbaa_data, nullptr, nullptr, align_nb);
-        } else {
-          return e;
         }
     }
-    return mark_julia_type(ctx, thePtr, false, aty);
+    return e;
 }
 
 static Value *emit_checked_srem_int(jl_codectx_t &ctx, Value *x, Value *den)

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -600,8 +600,13 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
         bool isboxed;
         Type *ptrty = julia_type_to_llvm(ety, &isboxed);
         assert(!isboxed);
-        Value *thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
-        return typed_load(ctx, thePtr, im1, ety, tbaa_data, nullptr, true, align_nb);
+        if (!type_is_ghost(ptrty)) {
+            Value *thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
+            return typed_load(ctx, thePtr, im1, ety, tbaa_data, nullptr, true, align_nb);
+        }
+        else {
+            return mark_julia_const(((jl_datatype_t*)ety)->instance);
+        }
     }
 }
 
@@ -663,8 +668,12 @@ static jl_cgval_t emit_pointerset(jl_codectx_t &ctx, jl_cgval_t *argv)
         bool isboxed;
         Type *ptrty = julia_type_to_llvm(ety, &isboxed);
         assert(!isboxed);
-        thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
-        typed_store(ctx, thePtr, im1, x, ety, tbaa_data, nullptr, nullptr, align_nb);
+        if (!type_is_ghost(ptrty)) {
+            thePtr = emit_unbox(ctx, ptrty->getPointerTo(), e, e.typ);
+            typed_store(ctx, thePtr, im1, x, ety, tbaa_data, nullptr, nullptr, align_nb);
+        } else {
+          return e;
+        }
     }
     return mark_julia_type(ctx, thePtr, false, aty);
 }

--- a/src/intrinsics.cpp
+++ b/src/intrinsics.cpp
@@ -605,7 +605,7 @@ static jl_cgval_t emit_pointerref(jl_codectx_t &ctx, jl_cgval_t *argv)
             return typed_load(ctx, thePtr, im1, ety, tbaa_data, nullptr, true, align_nb);
         }
         else {
-            return mark_julia_const(((jl_datatype_t*)ety)->instance);
+            return ghostValue(ety);
         }
     }
 }

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -100,3 +100,6 @@ let f = Core.Intrinsics.ashr_int
     @test f(Int32(-1), -10) == -1
     @test f(Int32(2), -1) == 0
 end
+
+# issue #29929
+@test unsafe_store!(Ptr{Nothing}(C_NULL), nothing) == Ptr{Nothing}(0)

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -102,4 +102,7 @@ let f = Core.Intrinsics.ashr_int
 end
 
 # issue #29929
-@test unsafe_store!(Ptr{Nothing}(C_NULL), nothing) == Ptr{Nothing}(0)
+@test unsafe_store!(Ptr{Nothing}(C_NULL), nothing) === Ptr{Nothing}(0)
+@test unsafe_load(Ptr{Nothing}(0)) === nothing
+struct GhostStruct end
+@test unsafe_load(Ptr{GhostStruct}(rand(Int))) === GhostStruct()


### PR DESCRIPTION

I created this commit from a patch that @JeffBezanson sent me. I'm not familiar with this code myself, so I don't know if this is sufficient, but I wanted to open this PR so that we didn't forget about this fix! :) Feel free to commit to it directly / take it over / replace it with a new PR or whatever.

In particular, we were a bit unsure about what should go in the second `else` block, where we currently put `return e;`.

------------------


As I understand it, LLVM doesn't support 0-sized structs (ghost types),
which julia makes significant use of. This fixes an incorrect behavior
in the julia compiler accidentally attempting to instantiate such
0-sized structs.

When using a debug build of LLVM, this fails with an assertion error,
but failed silently on standard LLVM.


-----------------------------------


This came up when debugging https://github.com/JuliaLang/julia/issues/31418.