### PR TITLE
Force "uUeE" dateformats to return Int64 values

### DIFF
--- a/stdlib/Dates/src/query.jl
+++ b/stdlib/Dates/src/query.jl
@@ -7,10 +7,10 @@ struct DateLocale
     months_abbr::Vector{String}
     days_of_week::Vector{String}
     days_of_week_abbr::Vector{String}
-    month_value::Dict{String, Int}
-    month_abbr_value::Dict{String, Int}
-    day_of_week_value::Dict{String, Int}
-    day_of_week_abbr_value::Dict{String, Int}
+    month_value::Dict{String, Int64}
+    month_abbr_value::Dict{String, Int64}
+    day_of_week_value::Dict{String, Int64}
+    day_of_week_abbr_value::Dict{String, Int64}
 end
 
 function locale_dict(names::Vector{<:AbstractString})


### PR DESCRIPTION
Attempt at addressing #31363 