### PR TITLE
Fix Int overrun potential in dict skip_deleted

### DIFF
--- a/base/dict.jl
+++ b/base/dict.jl
@@ -657,18 +657,22 @@ end
 
 function skip_deleted(h::Dict, i)
     L = length(h.slots)
-    @inbounds while i<=L && !isslotfilled(h,i)
-        i += 1
+    for i = i:L
+        @inbounds if isslotfilled(h,i)
+            return  i
+        end
     end
-    return i
+    return nothing
 end
 function skip_deleted_floor!(h::Dict)
     idx = skip_deleted(h, h.idxfloor)
-    h.idxfloor = idx
+    if idx !== nothing
+        h.idxfloor = idx
+    end
     idx
 end
 
-@propagate_inbounds _iterate(t::Dict{K,V}, i) where {K,V} = i > length(t.vals) ? nothing : (Pair{K,V}(t.keys[i],t.vals[i]), i+1)
+@propagate_inbounds _iterate(t::Dict{K,V}, i) where {K,V} = i === nothing  ? nothing : (Pair{K,V}(t.keys[i],t.vals[i]), i == typemax(Int) ? nothing : i+1)
 @propagate_inbounds function iterate(t::Dict)
     _iterate(t, skip_deleted_floor!(t))
 end
@@ -677,11 +681,12 @@ end
 isempty(t::Dict) = (t.count == 0)
 length(t::Dict) = t.count
 
-@propagate_inbounds function iterate(v::Union{KeySet{<:Any, <:Dict}, ValueIterator{<:Dict}},
-                                     i=v.dict.idxfloor)
+@propagate_inbounds function Base.iterate(v::T, i::Union{Int,Nothing}=v.dict.idxfloor) where T <: Union{KeySet{<:Any, <:Dict}, ValueIterator{<:Dict}}
+    i === nothing && return nothing # This is to catch nothing returned when i = typemax
     i = skip_deleted(v.dict, i)
-    i > length(v.dict.vals) && return nothing
-    (v isa KeySet ? v.dict.keys[i] : v.dict.vals[i], i+1)
+    i === nothing && return nothing # This is to catch nothing returned by skip_deleted
+    vals = T <: KeySet ? v.dict.keys : v.dict.vals
+    (@inbounds vals[i], i == typemax(Int) ? nothing : i+1)
 end
 
 filter!(f, d::Dict) = filter_in_one_pass!(f, d)


### PR DESCRIPTION
Previously there was the potential for an infinite loop in the `skip_deleted` function in `L=typemax(Int)`.   This fixes that and provides some performance benefits.

Baseline:
```julia
julia> using BenchmarkTools

julia> d=Dict(v=>v for v in 1:1000);

julia> @benchmark collect(values(d))
BenchmarkTools.Trial: 
  memory estimate:  7.95 KiB
  allocs estimate:  2
  --------------
  minimum time:     6.313 μs (0.00% GC)
  median time:      8.026 μs (0.00% GC)
  mean time:        11.180 μs (15.87% GC)
  maximum time:     12.011 ms (99.82% GC)
  --------------
  samples:          10000
  evals/sample:     5

julia> @benchmark sum(values(d))
BenchmarkTools.Trial: 
  memory estimate:  32 bytes
  allocs estimate:  2
  --------------
  minimum time:     5.716 μs (0.00% GC)
  median time:      6.483 μs (0.00% GC)
  mean time:        8.101 μs (0.00% GC)
  maximum time:     1.149 ms (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     6

julia> @benchmark sum(v->v.second,d)
BenchmarkTools.Trial: 
  memory estimate:  272 bytes
  allocs estimate:  7
  --------------
  minimum time:     8.236 μs (0.00% GC)
  median time:      10.181 μs (0.00% GC)
  mean time:        12.392 μs (0.00% GC)
  maximum time:     1.016 ms (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     3
```

After fix:
```julia
julia> using BenchmarkTools

julia> d=Dict(v=>v for v in 1:1000);

julia> @benchmark collect(values(d))
BenchmarkTools.Trial: 
  memory estimate:  7.95 KiB
  allocs estimate:  2
  --------------
  minimum time:     4.154 μs (0.00% GC)
  median time:      7.265 μs (0.00% GC)
  mean time:        14.121 μs (17.00% GC)
  maximum time:     12.819 ms (99.87% GC)
  --------------
  samples:          10000
  evals/sample:     7

julia> @benchmark sum(values(d))
BenchmarkTools.Trial: 
  memory estimate:  272 bytes
  allocs estimate:  8
  --------------
  minimum time:     5.441 μs (0.00% GC)
  median time:      5.808 μs (0.00% GC)
  mean time:        6.910 μs (0.00% GC)
  maximum time:     243.749 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     6

julia> @benchmark sum(v->v.second,d)
BenchmarkTools.Trial: 
  memory estimate:  272 bytes
  allocs estimate:  7
  --------------
  minimum time:     5.749 μs (0.00% GC)
  median time:      6.785 μs (0.00% GC)
  mean time:        10.137 μs (0.00% GC)
  maximum time:     2.498 ms (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     6
```