### PR TITLE
small fixes to libuv locks

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -296,13 +296,13 @@ restart_switch:
             break;
         case 'v': // version
             jl_printf(JL_STDOUT, "julia version %s\n", JULIA_VERSION_STRING);
-            jl_exit(0);
+            exit(0);
         case 'h': // help
             jl_printf(JL_STDOUT, "%s%s", usage, opts);
-            jl_exit(0);
+            exit(0);
         case opt_help_hidden:
             jl_printf(JL_STDOUT, "%s%s", usage, opts_hidden);
-            jl_exit(0);
+            exit(0);
         case 'g': // debug info
             if (optarg != NULL) {
                 if (!strcmp(optarg,"0"))

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -115,8 +115,8 @@ static inline void jl_assume_(int cond)
 static uv_loop_t *const unused_uv_loop_arg = (uv_loop_t *)0xBAD10;
 
 extern jl_mutex_t jl_uv_mutex;
-#define JL_UV_LOCK() JL_LOCK_NOGC(&jl_uv_mutex)
-#define JL_UV_UNLOCK() JL_UNLOCK_NOGC(&jl_uv_mutex)
+#define JL_UV_LOCK() JL_LOCK(&jl_uv_mutex)
+#define JL_UV_UNLOCK() JL_UNLOCK(&jl_uv_mutex)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/locks.h
+++ b/src/locks.h
@@ -121,6 +121,18 @@ static inline int jl_mutex_trylock_nogc(jl_mutex_t *lock)
     return 0;
 }
 
+static inline int jl_mutex_trylock(jl_mutex_t *lock)
+{
+    int got = jl_mutex_trylock_nogc(lock);
+    if (got) {
+        jl_ptls_t ptls = jl_get_ptls_states();
+        JL_SIGATOMIC_BEGIN();
+        jl_lock_frame_push(lock);
+        jl_gc_enable_finalizers(ptls, 0);
+    }
+    return got;
+}
+
 /* Call this function for code that could be called from either a managed
    or an unmanaged thread */
 static inline void jl_mutex_lock_maybe_nogc(jl_mutex_t *lock)


### PR DESCRIPTION
- use normal locking instead of nogc
- remove locks before threads have started
- add a trylock function (previously we only had trylock_nogc)