### PR TITLE
slightly better sparse matrix output?

### DIFF
--- a/stdlib/SparseArrays/docs/src/index.md
+++ b/stdlib/SparseArrays/docs/src/index.md
@@ -104,10 +104,10 @@ julia> I = [1, 4, 3, 5]; J = [4, 7, 18, 9]; V = [1, 2, -5, 3];
 
 julia> S = sparse(I,J,V)
 5×18 SparseMatrixCSC{Int64,Int64} with 4 stored entries:
-  [1 ,  4]  =  1
-  [4 ,  7]  =  2
-  [5 ,  9]  =  3
-  [3 , 18]  =  -5
+  [1,  4]  =  1
+  [4,  7]  =  2
+  [5,  9]  =  3
+  [3, 18]  =  -5
 
 julia> R = sparsevec(I,V)
 5-element SparseVector{Int64,Int64} with 4 stored entries:

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -172,23 +172,11 @@ end
 
 Base.show(io::IO, S::SparseMatrixCSC) = Base.show(convert(IOContext, io), S::SparseMatrixCSC)
 function Base.show(io::IOContext, S::SparseMatrixCSC)
-    if nnz(S) == 0
-        return show(io, MIME("text/plain"), S)
-    end
-    limit::Bool = get(io, :limit, false)
-    rows = displaysize(io)[1] - 4 # -4 from [Prompt, header, newline after elements, new prompt]
-    will_fit = !limit || rows >= nnz(S) # Will the whole matrix fit when printed?
-
-    if rows <= 2 && !will_fit
-        print(io, "\n  \u22ee")
-        return
-    end
+    nnz(S) == 0 && return show(io, MIME("text/plain"), S)
 
     ioc = IOContext(io, :compact => true)
-    pad = ndigits.(size(S))
-
-    function _format_line(r, col)
-        print(ioc, "\n  [", rpad(S.rowval[r], pad[1]), ", ", lpad(col, pad[2]), "]  =  ")
+    function _format_line(r, col, padr, padc)
+        print(ioc, "\n  [", rpad(S.rowval[r], padr), ", ", lpad(col, padc), "]  =  ")
         if isassigned(S.nzval, Int(r))
             show(ioc, S.nzval[r])
         else
@@ -196,31 +184,38 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
         end
     end
 
-    if will_fit
-        print_count = nnz(S)
+    function _get_cols(from, to)
+        idx = eltype(S.colptr)[]
+        c = searchsortedlast(S.colptr, from)
+        for i = from:to
+            while i == S.colptr[c+1]
+                c +=1
+            end
+            push!(idx, c)
+        end
+        idx
+    end
+
+    rows = displaysize(io)[1] - 4 # -4 from [Prompt, header, newline after elements, new prompt]
+    if !get(io, :limit, false) || rows >= nnz(S) # Will the whole matrix fit when printed?
+        cols = _get_cols(1, nnz(S))
+        padr, padc = ndigits.((maximum(S.rowval[1:nnz(S)]), cols[end]))
+        _format_line.(1:nnz(S), cols, padr, padc)
     else
-        print_count = div(rows-1, 2)
-    end
-
-    count = 0
-    for col = 1:S.n, r = nzrange(S, col)
-        count += 1
-        _format_line(r, col)
-        count == print_count && break
-    end
-
-    if !will_fit
+        if rows <= 2
+            print(io, "\n  \u22ee")
+            return
+        end
+        s1, e1 = 1, div(rows - 1, 2) # -1 accounts for \vdots
+        s2, e2 = nnz(S) - (rows - 1 - e1) + 1, nnz(S)
+        cols1, cols2 = _get_cols(s1, e1), _get_cols(s2, e2)
+        padr = ndigits(max(maximum(S.rowval[s1:e1]), maximum(S.rowval[s2:e2])))
+        padc = ndigits(cols2[end])
+        _format_line.(s1:e1, cols1, padr, padc)
         print(io, "\n  \u22ee")
-        # find the column to start printing in for the last print_count elements
-        nextcol = searchsortedfirst(S.colptr, nnz(S) - print_count + 1)
-        for r = (nnz(S) - print_count + 1) : (S.colptr[nextcol] - 1)
-            _format_line(r, nextcol - 1)
-        end
-        # print all of the remaining columns
-        for col = nextcol:S.n, r = nzrange(S, col)
-            _format_line(r, col)
-        end
+        _format_line.(s2:e2, cols2, padr, padc)
     end
+    return
 end
 
 ## Reshape

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -185,10 +185,10 @@ function Base.show(io::IOContext, S::SparseMatrixCSC)
     end
 
     ioc = IOContext(io, :compact => true)
-    pad = ndigits(max(S.m, S.n))
+    pad = ndigits.(size(S))
 
     function _format_line(r, col)
-        print(ioc, "\n  [", rpad(S.rowval[r], pad), ", ", lpad(col, pad), "]  =  ")
+        print(ioc, "\n  [", rpad(S.rowval[r], pad[1]), ", ", lpad(col, pad[2]), "]  =  ")
         if isassigned(S.nzval, Int(r))
             show(ioc, S.nzval[r])
         else

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2088,11 +2088,11 @@ end
 
     show(ioc, MIME"text/plain"(), sparse(Int64[1,2,3,4,5], Int64[1,1,2,2,3], [1.0,2.0,3.0,4.0,5.0]))
     @test String(take!(io)) ==  string("5×3 SparseArrays.SparseMatrixCSC{Float64,Int64} with 5 stored entries:\n  [1, 1]",
-                                       "  =  1.0\n  ⋮\n  [5, 3]  =  5.0")
+                                       "  =  1.0\n  ⋮\n  [4, 2]  =  4.0\n  [5, 3]  =  5.0")
 
     show(ioc, MIME"text/plain"(), sparse(fill(1.,5,3)))
     @test String(take!(io)) ==  string("5×3 SparseArrays.SparseMatrixCSC{Float64,$Int} with 15 stored entries:\n  [1, 1]",
-                                       "  =  1.0\n  ⋮\n  [5, 3]  =  1.0")
+                                       "  =  1.0\n  ⋮\n  [4, 3]  =  1.0\n  [5, 3]  =  1.0")
 
     # odd number of rows
     ioc = IOContext(io, :displaysize => (9, 80), :limit => true)


### PR DESCRIPTION
This trivial change in my opinion slightly improves the output of sparse non-square matrices. The difference WRT to master is only whitespace:  it computes the right  size of each column of indices, instead of using the same size for both. It is not so much about saving horizontal space (of which there is plenty in this case) but being visually more clear about the range of possible row and column indices.

[Additionally, I would align also the left column by the least significant digit, but I admit that this is even more subjective so I'm not proposing that change.]

```julia
100000000×10 SparseMatrixCSC{Float64,Int64} with 9996998 stored entries:
  [195      ,         1]  =  0.865211
  [354      ,         1]  =  0.393485
  [355      ,         1]  =  0.126857
  [378      ,         1]  =  0.0752492
  [394      ,         1]  =  0.137049
  [499      ,         1]  =  0.0758633
  [546      ,         1]  =  0.0365848
  [561      ,         1]  =  0.268665
  [565      ,         1]  =  0.077
  [628      ,         1]  =  0.943001
  [723      ,         1]  =  0.123411
  [753      ,         1]  =  0.895078
  [780      ,         1]  =  0.786817
  [818      ,         1]  =  0.610368
  [908      ,         1]  =  0.715888
  [962      ,         1]  =  0.665009
  [1155     ,         1]  =  0.443157
  [1226     ,         1]  =  0.51486
  ⋮
  [99998671 ,        10]  =  0.631988
  [99998727 ,        10]  =  0.577736
  [99998730 ,        10]  =  0.0949251
  [99998814 ,        10]  =  0.999344
  [99998893 ,        10]  =  0.722478
  [99999057 ,        10]  =  0.191442
  [99999082 ,        10]  =  0.66009
  [99999113 ,        10]  =  0.132979
  [99999187 ,        10]  =  0.0882425
  [99999204 ,        10]  =  0.923285
  [99999224 ,        10]  =  0.789961
  [99999293 ,        10]  =  0.0230649
  [99999383 ,        10]  =  0.52332
  [99999467 ,        10]  =  0.486454
  [99999509 ,        10]  =  0.0963375
  [99999702 ,        10]  =  0.160637
  [99999902 ,        10]  =  0.705339
  [99999943 ,        10]  =  0.785736
```

PR
```julia
100000000×10 SparseMatrixCSC{Float64,Int64} with 9996998 stored entries:
  [195      ,  1]  =  0.865211
  [354      ,  1]  =  0.393485
  [355      ,  1]  =  0.126857
  [378      ,  1]  =  0.0752492
  [394      ,  1]  =  0.137049
  [499      ,  1]  =  0.0758633
  [546      ,  1]  =  0.0365848
  [561      ,  1]  =  0.268665
  [565      ,  1]  =  0.077
  [628      ,  1]  =  0.943001
  [723      ,  1]  =  0.123411
  [753      ,  1]  =  0.895078
  [780      ,  1]  =  0.786817
  [818      ,  1]  =  0.610368
  [908      ,  1]  =  0.715888
  [962      ,  1]  =  0.665009
  [1155     ,  1]  =  0.443157
  [1226     ,  1]  =  0.51486
  ⋮
  [99998671 , 10]  =  0.631988
  [99998727 , 10]  =  0.577736
  [99998730 , 10]  =  0.0949251
  [99998814 , 10]  =  0.999344
  [99998893 , 10]  =  0.722478
  [99999057 , 10]  =  0.191442
  [99999082 , 10]  =  0.66009
  [99999113 , 10]  =  0.132979
  [99999187 , 10]  =  0.0882425
  [99999204 , 10]  =  0.923285
  [99999224 , 10]  =  0.789961
  [99999293 , 10]  =  0.0230649
  [99999383 , 10]  =  0.52332
  [99999467 , 10]  =  0.486454
  [99999509 , 10]  =  0.0963375
  [99999702 , 10]  =  0.160637
  [99999902 , 10]  =  0.705339
  [99999943 , 10]  =  0.785736
```
EDIT: last version of the PR (sorry for the different matrix):

```julia
100000000×10 SparseMatrixCSC{Float64,Int64} with 9999732 stored entries:
  [242     ,  1]  =  0.551921
  [313     ,  1]  =  0.117638
  [424     ,  1]  =  0.254358
  [465     ,  1]  =  0.287937
  [533     ,  1]  =  0.82697
  [651     ,  1]  =  0.907275
  [751     ,  1]  =  0.0180757
  [776     ,  1]  =  0.861264
  [851     ,  1]  =  0.105642
  [934     ,  1]  =  0.0383061
  [1066    ,  1]  =  0.892889
  [1099    ,  1]  =  0.737068
  [1106    ,  1]  =  0.127759
  [1154    ,  1]  =  0.670391
  [1191    ,  1]  =  0.447258
  [1267    ,  1]  =  0.371928
  [1293    ,  1]  =  0.19494
  [1372    ,  1]  =  0.631801
  ⋮
  [99998621, 10]  =  0.0947452
  [99998650, 10]  =  0.356015
  [99998664, 10]  =  0.737927
  [99998860, 10]  =  0.376107
  [99998900, 10]  =  0.221452
  [99999035, 10]  =  0.161449
  [99999047, 10]  =  0.216959
  [99999256, 10]  =  0.462335
  [99999327, 10]  =  0.302406
  [99999538, 10]  =  0.735865
  [99999569, 10]  =  0.480121
  [99999577, 10]  =  0.907891
  [99999579, 10]  =  0.935664
  [99999654, 10]  =  0.610292
  [99999728, 10]  =  0.902237
  [99999879, 10]  =  0.429649
  [99999932, 10]  =  0.586774
  [99999971, 10]  =  0.534574
```