### PR TITLE
Accept both Cvoid and Ptr{Void} return type in ccall(:memcpy)

### DIFF
--- a/test/ccall.jl
+++ b/test/ccall.jl
@@ -1477,3 +1477,16 @@ test27477() = ccall((:ctest, Pkg27477.libccalltest), Complex{Int}, (Complex{Int}
 end
 
 @test Test27477.test27477() == 2 + 0im
+
+# issue #31073
+let
+    a = ['0']
+    arr = Vector{Char}(undef, 2)
+    ptr = pointer(arr)
+    elsz = sizeof(Char)
+    na = length(a)
+    nba = na * elsz
+    ptr = eval(:(ccall(:memcpy, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, UInt), $(arr), $(a), $(nba))))
+    @test isa(ptr, Ptr{Cvoid})
+    @test arr[1] == '0'
+end


### PR DESCRIPTION
POSIX specifies that memcpy returns its first argument, which is
a bit of a useless feature (e.g. the llvm intrinsic just returns
`void`). Nevertheless, since we're intercepting the ccall here, we
should allow it. For convenience, still allow the Cvoid return though.

Fixes #31073