### PR TITLE
RFC: allow precompile to associate a MethodInstance with a module

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -458,6 +458,7 @@ sizeof(x) = Core.sizeof(x)
     precompile(f, args::Tuple{Vararg{Any}})
 
 Compile the given function `f` for the argument tuple (of types) `args`, but do not execute it.
+Returns `false` if no such specialization could be found.
 """
 function precompile(@nospecialize(f), args::Tuple)
     ccall(:jl_compile_hint, Int32, (Any,), Tuple{Core.Typeof(f), args...}) != 0
@@ -465,6 +466,15 @@ end
 
 function precompile(argt::Type)
     ccall(:jl_compile_hint, Int32, (Any,), argt) != 0
+end
+
+"""
+    precompile(m::Module, f, args::Tuple{Vararg{Any}})
+
+Forcibly insert `f` into the precompiles for the specified module.
+"""
+function precompile(m::Module, @nospecialize(f), args::Tuple)
+    ccall(:jl_compile_hint_module, Int32, (Module, Any,), m, Tuple{Core.Typeof(f), args...}) != 0
 end
 
 """

--- a/src/dump.c
+++ b/src/dump.c
@@ -441,6 +441,10 @@ static void jl_serialize_module(jl_serializer_state *s, jl_module_t *m)
         for(i=0; i < m->usings.len; i++) {
             jl_serialize_value(s, (jl_value_t*)m->usings.items[i]);
         }
+        write_int32(s->s, m->precompiles.len);
+        for(i=0; i < m->precompiles.len; i++) {
+            jl_serialize_value(s, (jl_value_t*)m->precompiles.items[i]);
+        }
     }
     write_uint8(s->s, m->istopmod);
     write_uint64(s->s, m->uuid.hi);
@@ -1800,6 +1804,14 @@ static jl_value_t *jl_deserialize_value_module(jl_serializer_state *s) JL_GC_DIS
     ni += i;
     while (i < ni) {
         m->usings.items[i] = jl_deserialize_value(s, (jl_value_t**)&m->usings.items[i]);
+        i++;
+    }
+    i = m->precompiles.len;
+    ni = read_int32(s->s);
+    arraylist_grow(&m->precompiles, ni);
+    ni += i;
+    while (i < ni) {
+        m->precompiles.items[i] = jl_deserialize_value(s, (jl_value_t**)&m->precompiles.items[i]);
         i++;
     }
     m->istopmod = read_uint8(s->s);

--- a/src/julia.h
+++ b/src/julia.h
@@ -460,7 +460,8 @@ typedef struct _jl_module_t {
     struct _jl_module_t *parent;
     // hidden fields:
     htable_t bindings;
-    arraylist_t usings;  // modules with all bindings potentially imported
+    arraylist_t usings;       // modules with all bindings potentially imported
+    arraylist_t precompiles;  // list of MethodInstances with explicit `precompile` statements
     uint64_t build_id;
     jl_uuid_t uuid;
     size_t primary_world;

--- a/src/module.c
+++ b/src/module.c
@@ -38,6 +38,7 @@ JL_DLLEXPORT jl_module_t *jl_new_module(jl_sym_t *name)
     m->nospecialize = 0;
     htable_new(&m->bindings, 0);
     arraylist_new(&m->usings, 0);
+    arraylist_new(&m->precompiles, 0);
     if (jl_core_module) {
         jl_module_using(m, jl_core_module);
     }


### PR DESCRIPTION
Suppose we have a package that does this:
```julia
module MyPkg

struct T end

if ccall(:jl_generating_output, Cint, ()) == 1
    precompile(setindex!, (Dict{T,Int}, Int, T))
end

end
```

Unfortunately, the `precompile` does nothing useful. I dove into this in some detail. It appears that the reason is that no `setindex!` methods are defined in `MyPkg`, and consequently the corresponding binding `b` has `b->value == NULL`. As a consequence it doesn't get added to the `*.ji` cache file. 

This is unfortunate, because inferring `setindex!` for Dicts is quite expensive. This PR aims to fix that by allowing package authors to write

```julia
    precompile(MyPkg, setindex!, (Dict{T,Int}, Int, T))
```

Note the module argument in the first slot. This adds it to a list of MethodInstances that should be associated with `MyPkg`.

I've verified it doesn't break anything, but it doesn't yet work. I tried the instructions [here](https://docs.julialang.org/en/latest/devdocs/debuggingtips/#Debugging-precompilation-errors-1) but gdb complains

```sh
(gdb) attach -w -n julia-debug
Illegal process-id: -w -n julia-debug.
```

Perhaps someone who knows more about this than me can offer some helpful tips.

I am not sure this alone will suffice, but I suspect that perhaps in conjunction with just a few other tweaks (and good ways to measure time spent on inference, see #31444 and [this SnoopCompile branch](https://github.com/timholy/SnoopCompile.jl/tree/teh/inference_timing)) we could dramatically cut latencies for certain packages. CC @SimonDanisch, who I know is very interested in the topic.