### PR TITLE
[doc] dlopen docstring

### DIFF
--- a/stdlib/Libdl/src/Libdl.jl
+++ b/stdlib/Libdl/src/Libdl.jl
@@ -117,7 +117,7 @@ end
     dlopen_e(libfile::AbstractString [, flags::Integer])
 
 Similar to [`dlopen`](@ref), except returns `C_NULL` instead of raising errors.
-This method is now deprecated in favor of `dlsym(handle, sym; throw_error=false)`.
+This method is now deprecated in favor of `dlopen(libfile::AbstractString [, flags::Integer]; throw_error=false)`.
 """
 dlopen_e(args...) = something(dlopen(args...; throw_error=false), C_NULL)
 


### PR DESCRIPTION
Documentation for `dlopen_e`: looks like copy-paste error from https://github.com/JuliaLang/julia/commit/d9d2b9cf808aab8c3a90e95e03ffc32761ce5316#diff-4f669dd4cc416a82508956a377e6a7c9

Correct:
`dlopen_e` deprecated in favor of `dlopen(...throw_error=false)`;
`dlsym_e` deprecated in favor of `dlsym(...throw_error=false)`;

Current documentation lists `dlopen_e` deprecated in favor of `dlsym`.