### PR TITLE
Show correct Dates.format documentation

### DIFF
--- a/stdlib/Dates/docs/src/index.md
+++ b/stdlib/Dates/docs/src/index.md
@@ -654,7 +654,7 @@ Dates.DateTime(::Dates.Period)
 Dates.DateTime(::Function, ::Any...)
 Dates.DateTime(::Dates.TimeType)
 Dates.DateTime(::AbstractString, ::AbstractString)
-Dates.format
+Dates.format(::Dates.TimeType, ::AbstractString)
 Dates.DateFormat
 Dates.@dateformat_str
 Dates.DateTime(::AbstractString, ::Dates.DateFormat)

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -34,7 +34,7 @@ All subtypes of `AbstractDateToken` must define this method in order
 to be able to print a Date / DateTime object according to a `DateFormat`
 containing that token.
 """
-function format end
+format(io::IO, tok::AbstractDateToken, dt::TimeType, locale)
 
 # fallback to tryparsenext/format methods that don't care about locale
 @inline function tryparsenext(d::AbstractDateToken, str, i, len, locale)


### PR DESCRIPTION
Shows the `Dates.format` table which was the behaviour in the Julia 0.6 documentation. Currently we [show a docstring](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.format) for an internal `Dates.format` method.