### PR TITLE
faster xor and != for Bool

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -72,7 +72,8 @@ julia> [true; true; false] .⊻ [true; false; false]
  0
 ```
 """
-xor(x::Bool, y::Bool) = (x != y)
+xor(x::Bool, y::Bool) = xor_int(x, y)
+!=(x::Bool, y::Bool) = xor(x, y)
 
 >>(x::Bool, c::UInt) = Int(x) >> c
 <<(x::Bool, c::UInt) = Int(x) << c


### PR DESCRIPTION
See [discourse](https://discourse.julialang.org/t/treat-uint8-as-a-bool-in-certain-contexts/22366/4?u=stevengj).  Before this change:
```jl
julia> b = rand(Bool, 150); i = UInt8.(b);

julia> f(a) = reduce(xor, a); g(a) = reduce(!=, a);

julia> @btime f($b); @btime g($b);
  84.023 ns (0 allocations: 0 bytes)
  92.179 ns (0 allocations: 0 bytes)

julia> @btime f($i); @btime g($i);
  14.540 ns (0 allocations: 0 bytes)
  97.243 ns (0 allocations: 0 bytes)
```
After this change:
```jl
julia> @btime f($b); @btime g($b);
  14.557 ns (0 allocations: 0 bytes)
  14.647 ns (0 allocations: 0 bytes)
```