### PR TITLE
REPL shell mode for Windows

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -31,8 +31,11 @@ stackframe_lineinfo_color() = repl_color("JULIA_STACKFRAME_LINEINFO_COLOR", :bol
 stackframe_function_color() = repl_color("JULIA_STACKFRAME_FUNCTION_COLOR", :bold)
 
 function repl_cmd(cmd, out)
-    shell = shell_split(get(ENV, "JULIA_SHELL", get(ENV, "SHELL", "/bin/sh")))
+    shell = shell_split(get(ENV, "JULIA_SHELL", Sys.iswindows() ? "cmd" : get(ENV, "SHELL", "/bin/sh")))
     shell_name = Base.basename(shell[1])
+    if Sys.iswindows()
+        shell_name = lowercase(splitext(shell_name)[1]) # canonicalize for comparisons below
+    end
 
     # Immediately expand all arguments, so that typing e.g. ~/bin/foo works.
     cmd.exec .= expanduser.(cmd.exec)
@@ -66,15 +69,28 @@ function repl_cmd(cmd, out)
         ENV["OLDPWD"] = new_oldpwd
         println(out, pwd())
     else
-        @static if !Sys.iswindows()
+        local command::Cmd
+        if Sys.iswindows()
+            if shell_name == ""
+                command = cmd
+            elseif shell_name == "cmd"
+                command = Cmd(`$shell /s /c $(string('"', cmd, '"'))`, windows_verbatim=true)
+            elseif shell_name == "powershell"
+                command = `$shell -Command $cmd`
+            elseif shell_name == "busybox"
+                command = `$shell sh -c $(shell_escape_posixly(cmd))`
+            else
+                command = `$shell $cmd`
+            end
+        else
             if shell_name == "fish"
                 shell_escape_cmd = "begin; $(shell_escape_posixly(cmd)); and true; end"
             else
                 shell_escape_cmd = "($(shell_escape_posixly(cmd))) && true"
             end
-            cmd = `$shell -c $shell_escape_cmd`
+            command = `$shell -c $shell_escape_cmd`
         end
-        run(ignorestatus(cmd))
+        run(ignorestatus(command))
     end
     nothing
 end

--- a/base/client.jl
+++ b/base/client.jl
@@ -75,7 +75,7 @@ function repl_cmd(cmd, out)
                 command = cmd
             elseif shell_name == "cmd"
                 command = Cmd(`$shell /s /c $(string('"', cmd, '"'))`, windows_verbatim=true)
-            elseif shell_name == "powershell"
+            elseif shell_name == "powershell" || shell_name == "pwsh"
                 command = `$shell -Command $cmd`
             elseif shell_name == "busybox"
                 command = `$shell sh -c $(shell_escape_posixly(cmd))`

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -168,10 +168,9 @@ The absolute path of the shell with which Julia should execute external commands
 (via `Base.repl_cmd()`). Defaults to the environment variable `$SHELL`, and
 falls back to `/bin/sh` if `$SHELL` is unset.
 
-!!! note
-
-    On Windows, this environment variable is ignored, and external commands are
-    executed directly.
+On Windows, `$JULIA_SHELL` can be set to `cmd`, `powershell`, `busybox` or `""`.
+If set to `""` external commands are executed directly. Defaults to `cmd` if
+`$JULIA_SHELL` is not set.
 
 ### `JULIA_EDITOR`
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -103,7 +103,7 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 shell> echo hello
 hello
 ```
-See [`JULIA_SHELL`](@ref) in the Environment Variables section of the manual.
+See `JULIA_SHELL` in the Environment Variables section of the Julia manual.
 
 ### Search modes
 

--- a/stdlib/REPL/docs/src/index.md
+++ b/stdlib/REPL/docs/src/index.md
@@ -103,6 +103,7 @@ julia> ; # upon typing ;, the prompt changes (in place) to: shell>
 shell> echo hello
 hello
 ```
+See [`JULIA_SHELL`](@ref) in the Environment Variables section of the manual.
 
 ### Search modes
 


### PR DESCRIPTION
Updated and simplified version of #23703 and #21294.

On Windows, the `JULIA_SHELL` environment variable can be `cmd`, `powershell`, `busybux`, or `""`, defaulting to `cmd`, and REPL shell-mode commands are now passed through this shell.

(Compared to the previous PR, I removed the changes to line parsing and the `cd` command.)

I haven't tested this myself yet — just wanted to bring it back to a testable state.   One thing I'm not sure of is the correct quoting of commands to pass to the shell — Windows escaping is a huge annoyance because of the lack of a proper `fork`.

cc @GregPlowman