### PR TITLE
Fix for 31456 -- `replace` with optional matching group fails when there is no match

### DIFF
--- a/base/pcre.jl
+++ b/base/pcre.jl
@@ -155,7 +155,11 @@ function substring_length_bynumber(match_data, number)
     s = RefValue{Csize_t}()
     rc = ccall((:pcre2_substring_length_bynumber_8, PCRE_LIB), Cint,
           (Ptr{Cvoid}, UInt32, Ref{Csize_t}), match_data, number, s)
-    rc < 0 && error("PCRE error: $(err_message(rc))")
+    if rc < 0
+        # PCRE2_ERROR_UNSET see https://code.woboq.org/qt5/qtbase/src/3rdparty/pcre2/src/pcre2_substring.c.html
+        rc == -55 && return 0
+        error("PCRE error: $(err_message(rc))")
+    end
     convert(Int, s[])
 end
 

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -363,6 +363,9 @@ macro s_str(string) SubstitutionString(string) end
 replace_err(repl) = error("Bad replacement string: $repl")
 
 function _write_capture(io, re, group)
+    # in the case of an optional group that doesn't match, don't write anything
+    # e.g. replace("The fox.", r"fox(es)?" => s"bus\1") 
+    isa(re.match_data, Ptr{Nothing}) && return
     len = PCRE.substring_length_bynumber(re.match_data, group)
     ensureroom(io, len+1)
     PCRE.substring_copy_bynumber(re.match_data, group,

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -364,7 +364,7 @@ replace_err(repl) = error("Bad replacement string: $repl")
 
 function _write_capture(io, re, group)
     # in the case of an optional group that doesn't match, don't write anything
-    # e.g. replace("The fox.", r"fox(es)?" => s"bus\1") 
+    # e.g. replace("The fox.", r"fox(es)?" => s"bus\1")
     isa(re.match_data, Ptr{Nothing}) && return
     len = PCRE.substring_length_bynumber(re.match_data, group)
     ensureroom(io, len+1)

--- a/base/regex.jl
+++ b/base/regex.jl
@@ -363,10 +363,10 @@ macro s_str(string) SubstitutionString(string) end
 replace_err(repl) = error("Bad replacement string: $repl")
 
 function _write_capture(io, re, group)
-    # in the case of an optional group that doesn't match, don't write anything
-    # e.g. replace("The fox.", r"fox(es)?" => s"bus\1")
-    isa(re.match_data, Ptr{Nothing}) && return
     len = PCRE.substring_length_bynumber(re.match_data, group)
+    # in the case of an optional group that doesn't match, len == 0
+    # e.g. replace("The fox.", r"fox(es)?" => s"bus\1")
+    len == 0 && return
     ensureroom(io, len+1)
     PCRE.substring_copy_bynumber(re.match_data, group,
         pointer(io.data, io.ptr), len+1)

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -272,6 +272,10 @@ end
     # Issue 13332
     @test replace("abc", 'b' => 2.1) == "a2.1c"
 
+    # Issue 31456
+    @test replace("The fox.", r"fox(es)?" => s"bus\1") == "The bus."
+    @test replace("The foxes.", r"fox(es)?" => s"bus\1") == "The buses."
+    
     # test replace with a count for String and GenericString
     # check that replace is a no-op if count==0
     for s in ["aaa", Test.GenericString("aaa")]
@@ -283,7 +287,7 @@ end
         @test replace(s, 'a' => 'z', count=typemax(Int)) == "zzz"
         @test replace(s, 'a' => 'z')    == "zzz"
     end
-
+    
     # Issue 25741
     @test replace("abc", ['a', 'd'] => 'A') == "Abc"
 

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -275,7 +275,8 @@ end
     # Issue 31456
     @test replace("The fox.", r"fox(es)?" => s"bus\1") == "The bus."
     @test replace("The foxes.", r"fox(es)?" => s"bus\1") == "The buses."
-    
+    @test replace("The quick fox quickly.", r"(quick)?\sfox(es)?\s(run)?" => s"\1 bus\2 \3") == "The quick bus quickly."
+
     # test replace with a count for String and GenericString
     # check that replace is a no-op if count==0
     for s in ["aaa", Test.GenericString("aaa")]

--- a/test/strings/util.jl
+++ b/test/strings/util.jl
@@ -287,7 +287,7 @@ end
         @test replace(s, 'a' => 'z', count=typemax(Int)) == "zzz"
         @test replace(s, 'a' => 'z')    == "zzz"
     end
-    
+
     # Issue 25741
     @test replace("abc", ['a', 'd'] => 'A') == "Abc"
 


### PR DESCRIPTION
This PR suggests a fix for #31456 . 

I don't know enough about Julia's regex system to know if that one line could have negative side-effects so I apologise in advance if it's a dumb idea.

**Edit**: added tests for the respective cases.
