### PR TITLE
Faster implementation of Float64(::BigInt), Float32(::BigInt) and Float16(::BigInt)

### DIFF
--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -396,6 +396,36 @@ function (::Type{T})(n::BigInt, ::RoundingMode{:Nearest}) where T<:CdoubleMax
     x
 end
 
+function Float64(x::BigInt, ::RoundingMode{:Nearest})
+    x == 0 && return 0.0
+    if Int == Int64
+        if abs(x.size) > 16
+            temp = Inf
+        elseif abs(x.size) == 1
+            temp = Float64(unsafe_load(x.d))
+        else
+            y1 = unsafe_load(x.d, x.size)
+            n = 64 - leading_zeros(y1)
+            if n > 53
+                y = (y1 >> (n-54))
+                y = (y + 1) >> 1
+                y &= ~UInt64(trailing_zeros(x) == (n-54 + (x.size-1)*64))
+            else
+                y = y1 << (54 - n) + unsafe_load(x.d, x.size-1) >> (10 + n)
+                y = (y + 1) >> 1
+                y &= ~UInt64(trailing_zeros(x) == (10+n + (x.size-2)*64))
+                d = (n+1021) << 52
+            end
+            d = (n+1021) << 52
+            temp = reinterpret(Float64, d+y)
+            temp = ldexp(temp, (x.size - 1)*64)
+        end
+        signbit(x.size) && return -temp
+        return temp
+    end
+    #TODO: implement for 32 bit machine
+end
+
 Float64(n::BigInt) = Float64(n, RoundNearest)
 Float32(n::BigInt) = Float32(n, RoundNearest)
 Float16(n::BigInt) = Float16(n, RoundNearest)

--- a/base/gmp.jl
+++ b/base/gmp.jl
@@ -398,32 +398,59 @@ end
 
 function Float64(x::BigInt, ::RoundingMode{:Nearest})
     x == 0 && return 0.0
-    if Int == Int64
-        if abs(x.size) > 16
+    xsize = abs(x.size)
+    if Limb == UInt64
+        if xsize > 16
             temp = Inf
-        elseif abs(x.size) == 1
+        elseif xsize == 1
             temp = Float64(unsafe_load(x.d))
         else
-            y1 = unsafe_load(x.d, x.size)
+            y1 = unsafe_load(x.d, xsize)
             n = 64 - leading_zeros(y1)
             if n > 53
                 y = (y1 >> (n-54))
                 y = (y + 1) >> 1
-                y &= ~UInt64(trailing_zeros(x) == (n-54 + (x.size-1)*64))
+                y &= ~UInt64(trailing_zeros(x) == (n-54 + (xsize-1)*64))
             else
-                y = y1 << (54 - n) + unsafe_load(x.d, x.size-1) >> (10 + n)
+                y = y1 << (54 - n) + unsafe_load(x.d, xsize-1) >> (10 + n)
                 y = (y + 1) >> 1
-                y &= ~UInt64(trailing_zeros(x) == (10+n + (x.size-2)*64))
-                d = (n+1021) << 52
+                y &= ~UInt64(trailing_zeros(x) == (10+n + (xsize-2)*64))
             end
             d = (n+1021) << 52
             temp = reinterpret(Float64, d+y)
-            temp = ldexp(temp, (x.size - 1)*64)
+            temp = ldexp(temp, (xsize - 1)*64)
+        end
+        signbit(x.size) && return -temp
+        return temp
+    else
+        if xsize > 32
+            temp = Inf
+        elseif xsize == 1
+            temp = Float64(unsafe_load(x.d))
+        elseif xsize == 2
+            temp = Float64((unsafe_load(x.d, 2) % UInt64) << 32 + unsafe_load(x.d))
+        else
+            y1 = unsafe_load(x.d, xsize)
+            n = 32 - leading_zeros(y1)
+            if n < 22
+                y = (y1 % UInt64) << (n-54)
+                y += (unsafe_load(x.d, xsize-1) % UInt64) << (22 - n)
+                y += unsafe_load(x.d, xsize-2) >> (10 + n)
+                y = (y + 1) >> 1
+                y &= ~UInt64(trailing_zeros(x) == (10+n + (xsize-3)*32))
+            else
+                y = (y1 % UInt64) << (n-54)
+                y += unsafe_load(x.d, xsize-1) >> (n - 22)
+                y += (y + 1) >> 1
+                y &= ~UInt64(trailing_zeros(x) == (n-22 + (xsize-2)*32))
+            end
+            d = (n+1021) << 52
+            temp = reinterpret(Float64, d+y)
+            temp = ldexp(temp, (xsize - 1)*32)
         end
         signbit(x.size) && return -temp
         return temp
     end
-    #TODO: implement for 32 bit machine
 end
 
 Float64(n::BigInt) = Float64(n, RoundNearest)

--- a/test/bigint.jl
+++ b/test/bigint.jl
@@ -440,3 +440,33 @@ end
     @test big(Int64(-9223372036854775808)) == big"-9223372036854775808"
     @test big(Int128(-170141183460469231731687303715884105728)) == big"-170141183460469231731687303715884105728"
 end
+
+@testset "conversion to Float" begin
+    x = big"2"^256 + big"2"^(256-53) + 1
+    @test Float64(x) == reinterpret(Float64, 0x4ff0000000000001)
+    @test Float64(-x) == -Float64(x)
+    x = (x >> 1) + 1
+    @test Float64(x) == reinterpret(Float64, 0x4fe0000000000001)
+    @test Float64(-x) == -Float64(x)
+
+    x = big"2"^64 + big"2"^(64-24) + 1
+    @test Float32(x) == reinterpret(Float32, 0x5f800001)
+    @test Float32(-x) == -Float32(x)
+    x = (x >> 1) + 1
+    @test Float32(x) == reinterpret(Float32, 0x5f000001)
+    @test Float32(-x) == -Float32(x)
+
+    x = big"2"^15 + big"2"^(15-11) + 1
+    @test Float16(x) == reinterpret(Float16, 0x7801)
+    @test Float16(-x) == -Float16(x)
+    x = (x >> 1) + 1
+    @test Float16(x) == reinterpret(Float16, 0x7401)
+    @test Float16(-x) == -Float16(x)
+
+    for T in (Float16, Float32, Float64)
+        n = exponent(floatmax(T))
+        @test T(big"2"^(n+1)) === T(Inf)
+        @test T(big"2"^(n+1) - big"2"^(n-precision(T))) === T(Inf)
+        @test T(big"2"^(n+1) - big"2"^(n-precision(T)) - 1) === floatmax(T)
+    end
+end


### PR DESCRIPTION
Closes #31293 
Implements a faster version of `Float64(::BigInt)`, `Float32(::BigInt)` and `Float16(::BigInt)`.
Rounding Behaviour: RoundNearest