### PR TITLE
minor event and I/O code reorg

### DIFF
--- a/base/Base.jl
+++ b/base/Base.jl
@@ -209,6 +209,7 @@ include("shell.jl")
 include("regex.jl")
 include("show.jl")
 include("arrayshow.jl")
+include("methodshow.jl")
 
 # multidimensional arrays
 include("cartesian.jl")
@@ -241,9 +242,8 @@ end
 include("env.jl")
 
 # Scheduling
-include("libuv.jl")
 include("linked_list.jl")
-include("event.jl")
+include("condition.jl")
 include("threads.jl")
 include("lock.jl")
 include("task.jl")
@@ -258,12 +258,13 @@ function rand end
 function randn end
 
 # I/O
+include("libuv.jl")
+include("asyncevent.jl")
 include("stream.jl")
 include("filesystem.jl")
 using .Filesystem
 include("process.jl")
 include("grisu/grisu.jl")
-include("methodshow.jl")
 include("secretbuffer.jl")
 
 # core math functions

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -1,160 +1,5 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-## thread/task locking abstraction
-
-"""
-    AbstractLock
-
-Abstract supertype describing types that
-implement the synchronization primitives:
-[`lock`](@ref), [`trylock`](@ref), [`unlock`](@ref), and [`islocked`](@ref).
-"""
-abstract type AbstractLock end
-function lock end
-function unlock end
-function trylock end
-function islocked end
-unlockall(l::AbstractLock) = unlock(l) # internal function for implementing `wait`
-relockall(l::AbstractLock, token::Nothing) = lock(l) # internal function for implementing `wait`
-assert_havelock(l::AbstractLock) = assert_havelock(l, Threads.threadid())
-assert_havelock(l::AbstractLock, tid::Integer) =
-    (islocked(l) && tid == Threads.threadid()) ? nothing : error("concurrency violation detected")
-assert_havelock(l::AbstractLock, tid::Task) =
-    (islocked(l) && tid === current_task()) ? nothing : error("concurrency violation detected")
-assert_havelock(l::AbstractLock, tid::Nothing) = error("concurrency violation detected")
-
-"""
-    AlwaysLockedST
-
-This struct does not implement a real lock, but instead
-pretends to be always locked on the original thread it was allocated on,
-and simply ignores all other interactions.
-It also does not synchronize tasks; for that use a real lock such as [`RecursiveLock`](@ref).
-This can be used in the place of a real lock to, instead, simply and cheaply assert
-that the operation is only occurring on a single cooperatively-scheduled thread.
-It is thus functionally equivalent to allocating a real, recursive, task-unaware lock
-immediately calling `lock` on it, and then never calling a matching `unlock`,
-except that calling `lock` from another thread will throw a concurrency violation exception.
-"""
-struct AlwaysLockedST <: AbstractLock
-    ownertid::Int16
-    AlwaysLockedST() = new(Threads.threadid())
-end
-assert_havelock(l::AlwaysLockedST) = assert_havelock(l, l.ownertid)
-lock(l::AlwaysLockedST) = assert_havelock(l)
-unlock(l::AlwaysLockedST) = assert_havelock(l)
-trylock(l::AlwaysLockedST) = l.ownertid == Threads.threadid()
-islocked(::AlwaysLockedST) = true
-
-
-## condition variables
-
-"""
-    GenericCondition
-
-Abstract implementation of a condition object
-for synchonizing tasks objects with a given lock.
-"""
-struct GenericCondition{L<:AbstractLock}
-    waitq::InvasiveLinkedList{Task}
-    lock::L
-
-    GenericCondition{L}() where {L<:AbstractLock} = new{L}(InvasiveLinkedList{Task}(), L())
-    GenericCondition{L}(l::L) where {L<:AbstractLock} = new{L}(InvasiveLinkedList{Task}(), l)
-    GenericCondition(l::AbstractLock) = new{typeof(l)}(InvasiveLinkedList{Task}(), l)
-end
-
-assert_havelock(c::GenericCondition) = assert_havelock(c.lock)
-lock(c::GenericCondition) = lock(c.lock)
-unlock(c::GenericCondition) = unlock(c.lock)
-trylock(c::GenericCondition) = trylock(c.lock)
-islocked(c::GenericCondition) = islocked(c.lock)
-
-"""
-    wait([x])
-
-Block the current task until some event occurs, depending on the type of the argument:
-
-* [`Channel`](@ref): Wait for a value to be appended to the channel.
-* [`Condition`](@ref): Wait for [`notify`](@ref) on a condition.
-* `Process`: Wait for a process or process chain to exit. The `exitcode` field of a process
-  can be used to determine success or failure.
-* [`Task`](@ref): Wait for a `Task` to finish. If the task fails with an exception, the
-  exception is propagated (re-thrown in the task that called `wait`).
-* [`RawFD`](@ref): Wait for changes on a file descriptor (see the `FileWatching` package).
-
-If no argument is passed, the task blocks for an undefined period. A task can only be
-restarted by an explicit call to [`schedule`](@ref) or [`yieldto`](@ref).
-
-Often `wait` is called within a `while` loop to ensure a waited-for condition is met before
-proceeding.
-"""
-function wait(c::GenericCondition)
-    ct = current_task()
-    assert_havelock(c)
-    push!(c.waitq, ct)
-    token = unlockall(c.lock)
-    try
-        return wait()
-    catch
-        list_deletefirst!(c.waitq, ct)
-        rethrow()
-    finally
-        relockall(c.lock, token)
-    end
-end
-
-"""
-    notify(condition, val=nothing; all=true, error=false)
-
-Wake up tasks waiting for a condition, passing them `val`. If `all` is `true` (the default),
-all waiting tasks are woken, otherwise only one is. If `error` is `true`, the passed value
-is raised as an exception in the woken tasks.
-
-Return the count of tasks woken up. Return 0 if no tasks are waiting on `condition`.
-"""
-notify(c::GenericCondition, @nospecialize(arg = nothing); all=true, error=false) = notify(c, arg, all, error)
-function notify(c::GenericCondition, @nospecialize(arg), all, error)
-    assert_havelock(c)
-    cnt = 0
-    while !isempty(c.waitq)
-        t = popfirst!(c.waitq)
-        schedule(t, arg, error=error)
-        cnt += 1
-        all || break
-    end
-    return cnt
-end
-
-notify_error(c::GenericCondition, err) = notify(c, err, true, true)
-
-n_waiters(c::GenericCondition) = length(c.waitq)
-
-"""
-    isempty(condition)
-
-Return `true` if no tasks are waiting on the condition, `false` otherwise.
-"""
-isempty(c::GenericCondition) = isempty(c.waitq)
-
-
-# default (Julia v1.0) is currently single-threaded
-# (although it uses MT-safe versions, when possible)
-"""
-    Condition()
-
-Create an edge-triggered event source that tasks can wait for. Tasks that call [`wait`](@ref) on a
-`Condition` are suspended and queued. Tasks are woken up when [`notify`](@ref) is later called on
-the `Condition`. Edge triggering means that only tasks waiting at the time [`notify`](@ref) is
-called can be woken up. For level-triggered notifications, you must keep extra state to keep
-track of whether a notification has happened. The [`Channel`](@ref) and [`Event`](@ref) types do
-this, and can be used for level-triggered events.
-
-This object is NOT thread-safe. See [`Threads.Condition`](@ref) for a thread-safe version.
-"""
-const Condition = GenericCondition{AlwaysLockedST}
-
-
 ## async event notifications
 
 """
@@ -365,4 +210,38 @@ function Timer(cb::Function, timeout::Real; interval::Real = 0.0)
     # we re-enter the event loop. this avoids a race condition. see issue #12719
     yield(waiter)
     return t
+end
+
+"""
+    timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
+
+Waits until `testcb` returns `true` or for `secs` seconds, whichever is earlier.
+`testcb` is polled every `pollint` seconds.
+"""
+function timedwait(testcb::Function, secs::Float64; pollint::Float64=0.1)
+    pollint > 0 || throw(ArgumentError("cannot set pollint to $pollint seconds"))
+    start = time()
+    done = Channel(1)
+    timercb(aw) = begin
+        try
+            if testcb()
+                put!(done, :ok)
+            elseif (time() - start) > secs
+                put!(done, :timed_out)
+            end
+        catch e
+            put!(done, :error)
+        finally
+            isready(done) && close(aw)
+        end
+    end
+
+    if !testcb()
+        t = Timer(timercb, pollint, interval = pollint)
+        ret = fetch(done)
+        close(t)
+    else
+        ret = :ok
+    end
+    ret
 end

--- a/base/condition.jl
+++ b/base/condition.jl
@@ -1,0 +1,155 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+## thread/task locking abstraction
+
+"""
+    AbstractLock
+
+Abstract supertype describing types that
+implement the synchronization primitives:
+[`lock`](@ref), [`trylock`](@ref), [`unlock`](@ref), and [`islocked`](@ref).
+"""
+abstract type AbstractLock end
+function lock end
+function unlock end
+function trylock end
+function islocked end
+unlockall(l::AbstractLock) = unlock(l) # internal function for implementing `wait`
+relockall(l::AbstractLock, token::Nothing) = lock(l) # internal function for implementing `wait`
+assert_havelock(l::AbstractLock) = assert_havelock(l, Threads.threadid())
+assert_havelock(l::AbstractLock, tid::Integer) =
+    (islocked(l) && tid == Threads.threadid()) ? nothing : error("concurrency violation detected")
+assert_havelock(l::AbstractLock, tid::Task) =
+    (islocked(l) && tid === current_task()) ? nothing : error("concurrency violation detected")
+assert_havelock(l::AbstractLock, tid::Nothing) = error("concurrency violation detected")
+
+"""
+    AlwaysLockedST
+
+This struct does not implement a real lock, but instead
+pretends to be always locked on the original thread it was allocated on,
+and simply ignores all other interactions.
+It also does not synchronize tasks; for that use a real lock such as [`RecursiveLock`](@ref).
+This can be used in the place of a real lock to, instead, simply and cheaply assert
+that the operation is only occurring on a single cooperatively-scheduled thread.
+It is thus functionally equivalent to allocating a real, recursive, task-unaware lock
+immediately calling `lock` on it, and then never calling a matching `unlock`,
+except that calling `lock` from another thread will throw a concurrency violation exception.
+"""
+struct AlwaysLockedST <: AbstractLock
+    ownertid::Int16
+    AlwaysLockedST() = new(Threads.threadid())
+end
+assert_havelock(l::AlwaysLockedST) = assert_havelock(l, l.ownertid)
+lock(l::AlwaysLockedST) = assert_havelock(l)
+unlock(l::AlwaysLockedST) = assert_havelock(l)
+trylock(l::AlwaysLockedST) = l.ownertid == Threads.threadid()
+islocked(::AlwaysLockedST) = true
+
+
+## condition variables
+
+"""
+    GenericCondition
+
+Abstract implementation of a condition object
+for synchonizing tasks objects with a given lock.
+"""
+struct GenericCondition{L<:AbstractLock}
+    waitq::InvasiveLinkedList{Task}
+    lock::L
+
+    GenericCondition{L}() where {L<:AbstractLock} = new{L}(InvasiveLinkedList{Task}(), L())
+    GenericCondition{L}(l::L) where {L<:AbstractLock} = new{L}(InvasiveLinkedList{Task}(), l)
+    GenericCondition(l::AbstractLock) = new{typeof(l)}(InvasiveLinkedList{Task}(), l)
+end
+
+assert_havelock(c::GenericCondition) = assert_havelock(c.lock)
+lock(c::GenericCondition) = lock(c.lock)
+unlock(c::GenericCondition) = unlock(c.lock)
+trylock(c::GenericCondition) = trylock(c.lock)
+islocked(c::GenericCondition) = islocked(c.lock)
+
+"""
+    wait([x])
+
+Block the current task until some event occurs, depending on the type of the argument:
+
+* [`Channel`](@ref): Wait for a value to be appended to the channel.
+* [`Condition`](@ref): Wait for [`notify`](@ref) on a condition.
+* `Process`: Wait for a process or process chain to exit. The `exitcode` field of a process
+  can be used to determine success or failure.
+* [`Task`](@ref): Wait for a `Task` to finish. If the task fails with an exception, the
+  exception is propagated (re-thrown in the task that called `wait`).
+* [`RawFD`](@ref): Wait for changes on a file descriptor (see the `FileWatching` package).
+
+If no argument is passed, the task blocks for an undefined period. A task can only be
+restarted by an explicit call to [`schedule`](@ref) or [`yieldto`](@ref).
+
+Often `wait` is called within a `while` loop to ensure a waited-for condition is met before
+proceeding.
+"""
+function wait(c::GenericCondition)
+    ct = current_task()
+    assert_havelock(c)
+    push!(c.waitq, ct)
+    token = unlockall(c.lock)
+    try
+        return wait()
+    catch
+        list_deletefirst!(c.waitq, ct)
+        rethrow()
+    finally
+        relockall(c.lock, token)
+    end
+end
+
+"""
+    notify(condition, val=nothing; all=true, error=false)
+
+Wake up tasks waiting for a condition, passing them `val`. If `all` is `true` (the default),
+all waiting tasks are woken, otherwise only one is. If `error` is `true`, the passed value
+is raised as an exception in the woken tasks.
+
+Return the count of tasks woken up. Return 0 if no tasks are waiting on `condition`.
+"""
+notify(c::GenericCondition, @nospecialize(arg = nothing); all=true, error=false) = notify(c, arg, all, error)
+function notify(c::GenericCondition, @nospecialize(arg), all, error)
+    assert_havelock(c)
+    cnt = 0
+    while !isempty(c.waitq)
+        t = popfirst!(c.waitq)
+        schedule(t, arg, error=error)
+        cnt += 1
+        all || break
+    end
+    return cnt
+end
+
+notify_error(c::GenericCondition, err) = notify(c, err, true, true)
+
+n_waiters(c::GenericCondition) = length(c.waitq)
+
+"""
+    isempty(condition)
+
+Return `true` if no tasks are waiting on the condition, `false` otherwise.
+"""
+isempty(c::GenericCondition) = isempty(c.waitq)
+
+
+# default (Julia v1.0) is currently single-threaded
+# (although it uses MT-safe versions, when possible)
+"""
+    Condition()
+
+Create an edge-triggered event source that tasks can wait for. Tasks that call [`wait`](@ref) on a
+`Condition` are suspended and queued. Tasks are woken up when [`notify`](@ref) is later called on
+the `Condition`. Edge triggering means that only tasks waiting at the time [`notify`](@ref) is
+called can be woken up. For level-triggered notifications, you must keep extra state to keep
+track of whether a notification has happened. The [`Channel`](@ref) and [`Event`](@ref) types do
+this, and can be used for level-triggered events.
+
+This object is NOT thread-safe. See [`Threads.Condition`](@ref) for a thread-safe version.
+"""
+const Condition = GenericCondition{AlwaysLockedST}

--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -89,16 +89,8 @@ uv_error(prefix::AbstractString, c::Integer) = c < 0 ? throw(_UVError(prefix,c))
 eventloop() = uv_eventloop::Ptr{Cvoid}
 #mkNewEventLoop() = ccall(:jl_new_event_loop,Ptr{Cvoid},()) # this would probably be fine, but is nowhere supported
 
-function run_event_loop()
-    ccall(:jl_run_event_loop,Cvoid,(Ptr{Cvoid},),eventloop())
-end
-function process_events(block::Bool)
-    loop = eventloop()
-    if block
-        return ccall(:jl_run_once,Int32,(Ptr{Cvoid},),loop)
-    else
-        return ccall(:jl_process_events,Int32,(Ptr{Cvoid},),loop)
-    end
+function process_events()
+    return ccall(:jl_process_events, Int32, (Ptr{Cvoid},), eventloop())
 end
 
 function uv_alloc_buf end

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -177,6 +177,8 @@ end
     wait(c::Condition)
 end
 
+const ThreadSynchronizer = GenericCondition{Threads.SpinLock}
+
 """
     Semaphore(sem_size)
 

--- a/base/locks-mt.jl
+++ b/base/locks-mt.jl
@@ -1,8 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import .Base: _uv_hook_close, unsafe_convert,
-    lock, trylock, unlock, islocked, wait, notify,
-    AbstractLock
+import .Base: unsafe_convert, lock, trylock, unlock, islocked, wait, notify, AbstractLock
 
 # Important Note: these low-level primitives defined here
 #   are typically not for general usage
@@ -88,14 +86,14 @@ mutable struct Mutex <: AbstractLock
     function Mutex()
         m = new(zero(Int16), Libc.malloc(UV_MUTEX_SIZE))
         ccall(:uv_mutex_init, Cvoid, (Ptr{Cvoid},), m.handle)
-        finalizer(_uv_hook_close, m)
+        finalizer(mutex_destroy, m)
         return m
     end
 end
 
 unsafe_convert(::Type{Ptr{Cvoid}}, m::Mutex) = m.handle
 
-function _uv_hook_close(x::Mutex)
+function mutex_destroy(x::Mutex)
     h = x.handle
     if h != C_NULL
         x.handle = C_NULL

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -277,17 +277,6 @@ end
     @test fetch(errstream) == "\nWARNING: Workqueue inconsistency detected: popfirst!(Workqueue).state != :runnable\n"
 end
 
-@testset "schedule_and_wait" begin
-    t = @async(nothing)
-    ct = current_task()
-    testobject = "testobject"
-    # note: there is a low probability this test could fail, due to receiving network traffic simultaneously
-    @test length(Base.Workqueue) == 1
-    @test Base.schedule_and_wait(ct, 8) == 8
-    @test isempty(Base.Workqueue)
-    @test Base.schedule_and_wait(ct, testobject) === testobject
-end
-
 @testset "throwto" begin
     t = @task(nothing)
     ct = current_task()
@@ -307,7 +296,7 @@ end
         tc[] += 1
     end
     @test isopen(t)
-    Base.process_events(false)
+    Base.process_events()
     @test !isopen(t)
     @test tc[] == 0
     yield()
@@ -329,9 +318,9 @@ end
     end
     @test isopen(async)
     ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
-    Base.process_events(false) # schedule event
+    Base.process_events() # schedule event
     ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
-    Sys.iswindows() && Base.process_events(false) # schedule event (windows?)
+    Sys.iswindows() && Base.process_events() # schedule event (windows?)
     @test tc[] == 0
     yield() # consume event
     @test tc[] == 1
@@ -342,8 +331,8 @@ end
     close(async)
     @test !isopen(async)
     @test tc[] == 1
-    Base.process_events(false) # schedule event & then close
-    Sys.iswindows() && Base.process_events(false) # schedule event (windows?)
+    Base.process_events() # schedule event & then close
+    Sys.iswindows() && Base.process_events() # schedule event (windows?)
     yield() # consume event & then close
     @test tc[] == 2
     sleep(0.1) # no further events
@@ -357,8 +346,8 @@ end
     ccall(:uv_async_send, Cvoid, (Ptr{Cvoid},), async)
     close(async)
     @test !isopen(async)
-    Base.process_events(false) # schedule event & then close
-    Sys.iswindows() && Base.process_events(false) # schedule event (windows)
+    Base.process_events() # schedule event & then close
+    Sys.iswindows() && Base.process_events() # schedule event (windows)
     @test tc[] == 0
     yield() # consume event & then close
     @test tc[] == 1


### PR DESCRIPTION
- remove unused argument to `process_events`
- a bit of file renaming and reorg; remove some dead code
- this allows code in libuv.jl to use locks and other things in Threads