### PR TITLE
Don't bother building `julia-debug` during `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,11 @@ endif
 
 
 install: $(build_depsbindir)/stringreplace $(BUILDROOT)/doc/_build/html/en/index.html
+ifeq ($(BUNDLE_DEBUG_LIBS),1)
 	@$(MAKE) $(QUIET_MAKE) all
+else
+	@$(MAKE) $(QUIET_MAKE) release
+endif
 	@for subdir in $(bindir) $(datarootdir)/julia/stdlib/$(VERSDIR) $(docdir) $(man1dir) $(includedir)/julia $(libdir) $(private_libdir) $(sysconfdir); do \
 		mkdir -p $(DESTDIR)$$subdir; \
 	done


### PR DESCRIPTION
Since we're not going to install `julia-debug` unless
`BUNDLE_DEBUG_LIBS=1`, might as well save the cycles and not even build
it in the first place unless the aforementioned makevar is set.

This should shave 5-10 minutes off of the CI build time.