### PR TITLE
Fixed bounds error when printing method where one of the arguments is…

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -13,7 +13,7 @@ function argtype_decl(env, n, sig::DataType, i::Int, nargs, isva::Bool) # -> (ar
     s = string(n)
     i = findfirst(isequal('#'), s)
     if i !== nothing
-        s = s[1:i-1]
+        s = s[1:prevind(s, i)]
     end
     if t === Any && !isempty(s)
         return s, ""


### PR DESCRIPTION
… a gensymed unicode character.

https://github.com/JuliaLang/julia/issues/31494#issuecomment-477325507

New behavior:
```julia
julia> αsym = gensym(:α)
Symbol("##α#371")

julia> ℓsym = gensym(:ℓ)
Symbol("##ℓ#372")

julia> eval(:(foo($αsym) = $αsym))
foo (generic function with 1 method)

julia> eval(:(bar($ℓsym) = $ℓsym))
bar (generic function with 1 method)

julia> foo(2.3), bar(2.3)
(2.3, 2.3)

julia> methods(foo)
# 1 method for generic function "foo":
[1] foo(α) in Main at REPL[3]:1

julia> methods(bar)
# 1 method for generic function "bar":
[1] bar(ℓ) in Main at REPL[4]:1
```