### PR TITLE
Allow a callback to update the displayed location of a method

### DIFF
--- a/base/methodshow.jl
+++ b/base/methodshow.jl
@@ -112,6 +112,12 @@ function show_method_params(io::IO, tv)
     end
 end
 
+# In case the line numbers in the source code have changed since the code was compiled,
+# allow packages to set a callback function that corrects them.
+# (Used by Revise and perhaps other packages.)
+default_methodloc(method::Method) = method.file, method.line
+const methodloc_callback = Ref{Function}(default_methodloc)
+
 function show(io::IO, m::Method; kwtype::Union{DataType, Nothing}=nothing)
     tv, decls, file, line = arg_decl_parts(m)
     sig = unwrap_unionall(m.sig)
@@ -150,6 +156,10 @@ function show(io::IO, m::Method; kwtype::Union{DataType, Nothing}=nothing)
     show_method_params(io, tv)
     print(io, " in ", m.module)
     if line > 0
+        try
+            file, line = invokelatest(methodloc_callback[], m)
+        catch
+        end
         print(io, " at ", file, ":", line)
     end
 end
@@ -173,12 +183,17 @@ function show_method_table(io::IO, ms::MethodList, max::Int=-1, header::Bool=tru
 
     resize!(LAST_SHOWN_LINE_INFOS, 0)
     for meth in ms
-       if max==-1 || n<max
+        if max==-1 || n<max
             n += 1
             println(io)
             print(io, "[$(n)] ")
             show(io, meth; kwtype=kwtype)
-            push!(LAST_SHOWN_LINE_INFOS, (string(meth.file), meth.line))
+            file, line = meth.file, meth.line
+            try
+                file, line = invokelatest(methodloc_callback[], meth)
+            catch
+            end
+            push!(LAST_SHOWN_LINE_INFOS, (string(file), line))
         else
             rest += 1
             last = meth
@@ -286,6 +301,10 @@ function show(io::IO, ::MIME"text/html", m::Method; kwtype::Union{DataType, Noth
     end
     print(io, " in ", m.module)
     if line > 0
+        try
+            file, line = invokelatest(methodloc_callback[], m)
+        catch
+        end
         u = url(m)
         if isempty(u)
             print(io, " at ", file, ":", line)
@@ -324,7 +343,12 @@ function show(io::IO, mime::MIME"text/plain", mt::AbstractVector{Method})
         first = false
         print(io, "[$(i)] ")
         show(io, m)
-        push!(LAST_SHOWN_LINE_INFOS, (string(m.file), m.line))
+        file, line = m.file, m.line
+        try
+            file, line = invokelatest(methodloc_callback[], m)
+        catch
+        end
+        push!(LAST_SHOWN_LINE_INFOS, (string(file), line))
     end
 end
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -617,6 +617,18 @@ else
     @test occursin("https://github.com/JuliaLang/julia/tree/$(Base.GIT_VERSION_INFO.commit)/base/special/trig.jl#L", Base.url(which(sin, (Float64,))))
 end
 
+# Method location correction (Revise integration)
+methloc = Base.methodloc_callback[]
+dummyloc(m::Method) = :nofile, 123456789
+Base.methodloc_callback[] = dummyloc
+let repr = sprint(show, "text/plain", methods(Base.inbase))
+    @test occursin("nofile:123456789", repr)
+end
+let repr = sprint(show, "text/html", methods(Base.inbase))
+    @test occursin("nofile:123456789", repr)
+end
+Base.methodloc_callback[] = methloc
+
 # print_matrix should be able to handle small and large objects easily, test by
 # calling show. This also indirectly tests print_matrix_row, which
 # is used repeatedly by print_matrix.


### PR DESCRIPTION
This is for better integration with Revise.jl. Revise tries to update location info in stacktraces; we might as well do the same for methods and method lists.

Note: Method is mutable, so why not just update the file & line fields? Location info gets compiled into code on a line-by-line basis; to compute the offset into the method body, you need to know the
method's location at the time the method was compiled. Consequently we leave those fields untouched so that the correct offsets can be computed.
