### PR TITLE
Prevent domtree construction from overflowing for large functions

### DIFF
--- a/base/compiler/ssair/domtree.jl
+++ b/base/compiler/ssair/domtree.jl
@@ -207,9 +207,8 @@ begin
                             v::DFSNumber, last_linked::DFSNumber)
         u = ancestors[v]
         @assert u < v
-        worklist = DFSNumber[]
         if u >= last_linked
-            snca_compress!(state, ancestors, u, last_linked),
+            snca_compress!(state, ancestors, u, last_linked)
             if state[u].label < state[v].label
                 state[v] = Node(state[v].semi, state[u].label)
             end

--- a/base/compiler/ssair/domtree.jl
+++ b/base/compiler/ssair/domtree.jl
@@ -28,9 +28,13 @@ end
 bb_unreachable(domtree::DomTree, bb::Int) = bb != 1 && domtree.nodes[bb].level == 1
 
 function update_level!(domtree::Vector{DomTreeNode}, node::Int, level::Int)
-    domtree[node] = DomTreeNode(level, domtree[node].children)
-    foreach(domtree[node].children) do child
-        update_level!(domtree, child, level+1)
+    worklist = Tuple{Int, Int}[(node, level)]
+    while !isempty(worklist)
+        (node, level) = pop!(worklist)
+        domtree[node] = DomTreeNode(level, domtree[node].children)
+        foreach(domtree[node].children) do child
+            push!(worklist, (child, level+1))
+        end
     end
 end
 
@@ -203,14 +207,38 @@ begin
                             v::DFSNumber, last_linked::DFSNumber)
         u = ancestors[v]
         @assert u < v
+        worklist = DFSNumber[]
         if u >= last_linked
-            snca_compress!(state, ancestors, u, last_linked)
+            snca_compress!(state, ancestors, u, last_linked),
             if state[u].label < state[v].label
                 state[v] = Node(state[v].semi, state[u].label)
             end
             ancestors[v] = ancestors[u]
         end
         nothing
+    end
+
+    function snca_compress_worklist!(
+            state::Vector{Node}, ancestors::Vector{DFSNumber},
+            v::DFSNumber, last_linked::DFSNumber)
+        # TODO: There is a smarter way to do this
+        u = ancestors[v]
+        worklist = Tuple{Int, Int}[(u,v)]
+        @assert u < v
+        while !isempty(worklist)
+            u, v = last(worklist)
+            if u >= last_linked
+                if ancestors[u] >= last_linked
+                    push!(worklist, (ancestors[u], u))
+                    continue
+                end
+                if state[u].label < state[v].label
+                    state[v] = Node(state[v].semi, state[u].label)
+                end
+                ancestors[v] = ancestors[u]
+            end
+            pop!(worklist)
+        end
     end
 
     """
@@ -255,7 +283,13 @@ begin
                 # `ancestor[v] != 0` check in the `eval` implementation in
                 # figure 2.6
                 if vdfs >= last_linked
-                    snca_compress!(state, ancestors, vdfs, last_linked)
+                    # For performance, if the number of ancestors is small
+                    # avoid the extra allocation of the worklist.
+                    if length(ancestors) <= 32
+                        snca_compress!(state, ancestors, vdfs, last_linked)
+                    else
+                        snca_compress_worklist!(state, ancestors, vdfs, last_linked)
+                    end
                 end
                 semi_w = min(semi_w, state[vdfs].label)
             end


### PR DESCRIPTION
Backend's that perform aggressive inlining (e.g TPU/GPU) can produce
larger functions than normal Julia, which sometimes can trigger a
stack-overflow in domtree construction.

As an example see https://github.com/vchuravy/GPUifyLoops.jl/issues/46#issue-426696489

This backports a commit from kf/tpu3 which switches from a recursive function
to a worklist. The assoicated test-case fails on master, but finishes with
these changes.