### PR TITLE
Better type specification in rehash! for IdDicts

### DIFF
--- a/base/abstractdict.jl
+++ b/base/abstractdict.jl
@@ -563,7 +563,7 @@ end
 empty(d::IdDict, ::Type{K}, ::Type{V}) where {K, V} = IdDict{K,V}()
 
 function rehash!(d::IdDict, newsz = length(d.ht))
-    d.ht = ccall(:jl_idtable_rehash, Any, (Any, Csize_t), d.ht, newsz)
+    d.ht = ccall(:jl_idtable_rehash, Vector{Any}, (Any, Csize_t), d.ht, newsz)
     d
 end
 


### PR DESCRIPTION
Master:
```julia
julia> d = IdDict([1,2,3]=>nothing, [1,2]=>nothing)
IdDict{Array{Int64,1},Nothing} with 2 entries:
  [1, 2, 3] => nothing
  [1, 2]    => nothing

julia> using BenchmarkTools

julia> @btime Base.rehash!($d, 16);
  85.895 ns (1 allocation: 208 bytes)

julia> @code_warntype Base.rehash!(d, 16)
Variables
  #self#::Core.Compiler.Const(Base.rehash!, false)
  d::IdDict{Array{Int64,1},Nothing}
  newsz::Int64

Body::IdDict{Array{Int64,1},Nothing}
1 ─ %1 = Base.cconvert(Base.Csize_t, newsz)::UInt64
│   %2 = Base.getproperty(d, :ht)::Array{Any,1}
│   %3 = Base.unsafe_convert(Base.Csize_t, %1)::UInt64
│   %4 = $(Expr(:foreigncall, :(:jl_idtable_rehash), Any, svec(Any, UInt64), :(:ccall), 2, :(%2), :(%3), :(%1)))::Any
│        Base.setproperty!(d, :ht, %4)
└──      return d
```

Now switch to this version:
```julia
julia> using Revise

julia> Revise.track(Base)

julia> @code_warntype Base.rehash!(d, 16)
Variables
  #self#::Core.Compiler.Const(Base.rehash!, false)
  d::IdDict{Array{Int64,1},Nothing}
  newsz::Int64

Body::IdDict{Array{Int64,1},Nothing}
1 ─ %1 = Core.apply_type(Base.Vector, Base.Any)::Core.Compiler.Const(Array{Any,1}, false)
│   %2 = Base.getproperty(d, :ht)::Array{Any,1}
│   %3 = Base.cconvert(%1, %2)::Array{Any,1}
│   %4 = Base.cconvert(Base.Csize_t, newsz)::UInt64
│   %5 = Core.apply_type(Base.Vector, Base.Any)::Core.Compiler.Const(Array{Any,1}, false)
│   %6 = Base.unsafe_convert(%5, %3)::Array{Any,1}
│   %7 = Base.unsafe_convert(Base.Csize_t, %4)::UInt64
│   %8 = $(Expr(:foreigncall, :(:jl_idtable_rehash), Array{Any,1}, svec(Array{Any,1}, UInt64), :(:ccall), 2, :(%6), :(%7), :(%4), :(%3)))::Array{Any,1}
│        Base.setproperty!(d, :ht, %8)
└──      return d

julia> @btime Base.rehash!($d, 16);
  51.866 ns (1 allocation: 208 bytes)
```
