### PR TITLE
Specify type on CodeInfo.slotnames

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -530,7 +530,7 @@ function typeinf_ext(mi::MethodInstance, params::Params)
                 tree = ccall(:jl_new_code_info_uninit, Ref{CodeInfo}, ())
                 tree.code = Any[ Expr(:return, quoted(code.rettype_const)) ]
                 nargs = Int(method.nargs)
-                tree.slotnames = ccall(:jl_uncompress_argnames, Any, (Any,), method.slot_syms)
+                tree.slotnames = ccall(:jl_uncompress_argnames, Vector{Symbol}, (Any,), method.slot_syms)
                 tree.slotflags = fill(0x00, nargs)
                 tree.ssavaluetypes = 1
                 tree.codelocs = Int32[1]

--- a/base/show.jl
+++ b/base/show.jl
@@ -629,7 +629,6 @@ end
 
 function sourceinfo_slotnames(src::CodeInfo)
     slotnames = src.slotnames
-    isa(slotnames, Array) || return String[]
     names = Dict{String,Int}()
     printnames = Vector{String}(undef, length(slotnames))
     for i in eachindex(slotnames)

--- a/src/dump.c
+++ b/src/dump.c
@@ -2695,7 +2695,7 @@ JL_DLLEXPORT jl_array_t *jl_uncompress_argnames(jl_value_t *syms)
         remaining -= namelen + 1;
     }
     namestr = jl_string_data(syms);
-    jl_array_t *names = jl_alloc_vec_any(len);
+    jl_array_t *names = jl_alloc_array_1d(jl_array_symbol_type, len);
     JL_GC_PUSH1(&names);
     for (i = 0; i < len; i++) {
         size_t namelen = strlen(namestr);

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -2053,7 +2053,7 @@ void jl_init_types(void) JL_GC_DISABLED
                             jl_array_uint8_type,
                             jl_any_type,
                             jl_any_type,
-                            jl_any_type,
+                            jl_array_symbol_type,
                             jl_array_uint8_type,
                             jl_any_type,
                             jl_any_type,

--- a/src/method.c
+++ b/src/method.c
@@ -250,7 +250,7 @@ static void jl_code_info_set_ast(jl_code_info_t *li, jl_expr_t *ast)
     jl_value_t *ssavalue_types = jl_array_ptr_ref(vinfo, 2);
     assert(jl_is_long(ssavalue_types));
     size_t nssavalue = jl_unbox_long(ssavalue_types);
-    li->slotnames = jl_alloc_vec_any(nslots);
+    li->slotnames = jl_alloc_array_1d(jl_array_symbol_type, nslots);
     jl_gc_wb(li, li->slotnames);
     li->slotflags = jl_alloc_array_1d(jl_array_uint8_type, nslots);
     jl_gc_wb(li, li->slotflags);


### PR DESCRIPTION
[julia.h](https://github.com/JuliaLang/julia/blob/91151ab871c7e7d6689d1cfa793c12062d37d6b6/src/julia.h#L251) is more specific on this point than the type declaration. Is there any reason not to make it a `Vector{Symbol}`?

This is a surprisingly hot spot for JuliaInterpreter, e.g., https://github.com/JuliaDebug/JuliaInterpreter.jl/blob/ceee9c06dae85c79d5e7e918e4ed8c68ef5b180f/src/construct.jl#L264 (frame data preparation is our biggest cost for many workloads).