### PR TITLE
Fix missing GC root in splatnew implementation

### DIFF
--- a/src/datatype.c
+++ b/src/datatype.c
@@ -853,21 +853,24 @@ JL_DLLEXPORT jl_value_t *jl_new_structt(jl_datatype_t *type, jl_value_t *tup)
     if (na > nf)
         jl_too_many_args("new", nf);
     if (type->instance != NULL) {
+        jl_datatype_t *tupt = (jl_datatype_t*)jl_typeof(tup);
         for (size_t i = 0; i < na; i++) {
             jl_value_t *ft = jl_field_type(type, i);
-            jl_value_t *fi = jl_get_nth_field(tup, i);
-            if (!jl_isa(fi, ft))
-                jl_type_error("new", ft, fi);
+            jl_value_t *et = jl_field_type(tupt, i);
+            assert(jl_is_concrete_type(ft) && jl_is_concrete_type(et));
+            if (et != ft)
+                jl_type_error("new", ft, jl_get_nth_field(tup, i));
         }
         return type->instance;
     }
     if (type->layout == NULL)
         jl_type_error("new", (jl_value_t*)jl_datatype_type, (jl_value_t*)type);
     jl_value_t *jv = jl_gc_alloc(ptls, jl_datatype_size(type), type);
-    JL_GC_PUSH1(&jv);
+    jl_value_t *fi = NULL;
+    JL_GC_PUSH2(&jv, &fi);
     for (size_t i = 0; i < na; i++) {
         jl_value_t *ft = jl_field_type(type, i);
-        jl_value_t *fi = jl_get_nth_field(tup, i);
+        fi = jl_get_nth_field(tup, i);
         if (!jl_isa(fi, ft))
             jl_type_error("new", ft, fi);
         jl_set_nth_field(jv, i, fi);


### PR DESCRIPTION
subtyping (and by extension jl_isa), can allocate, though that happening
is a bit of a rare occurrence. ClangSA thus correctly complains:
```
/home/keno/julia/src/datatype.c:872:14: note: Passing non-rooted value as argument to function that may GC
        if (!jl_isa(fi, ft))
             ^      ~~
```

There's two cases here: In the first, we were allocating a useless object, just
to check its type. Replace that by manually looking at the type. In the second
we were actually using the object. Add a root.