### PR TITLE
Try to avoid undefined behavior in runtime intrinsics

### DIFF
--- a/src/runtime_intrinsics.c
+++ b/src/runtime_intrinsics.c
@@ -853,20 +853,18 @@ un_fintrinsic_withtype(fpext,fpext)
 
 // checked arithmetic
 /**
- * s_typemin =  ((typeof a)~0 << (runtime_nbits - 1))
- * s_typemax = ~((typeof a)1 << (runtime_nbits - 1))
+ * s_typemin = - s_typemax - 1
+ * s_typemax = ((typeof a)1 << (runtime_nbits - 1)) - 1
  * u_typemin = 0
  * u_typemax = ((typeof a)1 << runtime_nbits) - 1
  * where (a - a) == (typeof(a)0
  **/
-#define sTYPEMIN(a) \
-    (8 * sizeof(a) == runtime_nbits \
-     ? ((a - a + ~0) << (8 * sizeof(a) - 1)) \
-     : ((a - a + ~0) << (runtime_nbits - 1)))
-#define sTYPEMAX(a) \
-    (8 * sizeof(a) == runtime_nbits \
-     ? ~((a - a + ~0) << (8 * sizeof(a) - 1)) \
-     : ~((a - a + ~0) << (runtime_nbits - 1)))
+#define sTYPEMIN(a) -sTYPEMAX(a) - 1
+#define sTYPEMAX(a)                                                \
+    (8 * sizeof(a) == runtime_nbits                                \
+         ? (((((a - a + 1) << (8 * sizeof(a) - 2)) - 1) << 1) + 1) \
+         : (  ((a - a + 1) << (runtime_nbits - 1)) - 1))
+
 #define uTYPEMIN(a) (0)
 #define uTYPEMAX(a) \
     (8 * sizeof(~a) == runtime_nbits \


### PR DESCRIPTION
The analyzer complains
```
/home/keno/julia/src/runtime_intrinsics.c:886:38: note: The result of the left shift is undefined because the left operand is
      negative
checked_iintrinsic_fast(LLVMSub_sov, check_ssub_int, sub, checked_ssub_int,  )
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/runtime_intrinsics.c:510:25: note: expanded from macro 'checked_iintrinsic_fast'
checked_intrinsic_ctype(CHECK_OP, OP, name, 64, u##int##64_t) \
~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/keno/julia/src/runtime_intrinsics.c:251:12: note: expanded from macro '\
checked_intrinsic_ctype'
    return CHECK_OP(a, b); \
           ^~~~~~~~~~~~~~
/home/keno/julia/src/runtime_intrinsics.c:885:49: note: expanded from macro 'check_ssub_int'
        (b >= 0) ? (a < sTYPEMIN(a) + b) : (a > sTYPEMAX(a) + b)
                                                ^~~~~~~~~~~
/home/keno/julia/src/runtime_intrinsics.c:868:23: note: expanded from macro 'sTYPEMAX'
     ? ~((a - a + ~0) << (8 * sizeof(a) - 1)) \
         ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
16 warnings generated.
```

And indeed shifting a negative number to the left is undefined in `C`.
Try an alternative expression for these that hopefully steers clear of any UB.