### PR TITLE
Implement `for f.(args...)` syntax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@ New language features
 
   * `inv(::Missing)` has now been added and returns `missing` ([#31408]).
 
+  * A new syntax `for f.(...)` is added to create a non-`materialize`d `Broadcasted` object
+    from a given "dot call" expression ([#19198]).
+
 Multi-threading changes
 -----------------------
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -1341,6 +1341,10 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, head, ' ')
         show_list(io, args, ", ", indent)
 
+    elseif nargs == 1 && head == :fordot
+        print(io, "for ")
+        show_list(io, args, ", ", indent)
+
     elseif head === :macrocall && nargs >= 2
         # first show the line number argument as a comment
         if isa(args[2], LineNumberNode) || is_expr(args[2], :line)

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -26,6 +26,8 @@ For example `(call f x)` corresponds to `Expr(:call, :f, :x)` in Julia.
 | `f(x, y=1, z=2)` | `(call f x (kw y 1) (kw z 2))`     |
 | `f(x; y=1)`      | `(call f (parameters (kw y 1)) x)` |
 | `f(x...)`        | `(call f (... x))`                 |
+| `f.(x)`          | `(. f (tuple x))`                  |
+| `for f.(x)`      | `(fordot (. f (tuple x)))`         |
 
 `do` syntax:
 
@@ -48,6 +50,7 @@ call. Finally, chains of comparisons have their own special expression structure
 | Input       | AST                       |
 |:----------- |:------------------------- |
 | `x+y`       | `(call + x y)`            |
+| `x.+y`      | `(call .+ x y)`           |
 | `a+b+c+d`   | `(call + a b c d)`        |
 | `2x`        | `(call * 2 x)`            |
 | `a&&b`      | `(&& a b)`                |
@@ -59,7 +62,6 @@ call. Finally, chains of comparisons have their own special expression structure
 | `a==b`      | `(call == a b)`           |
 | `1<i<=n`    | `(comparison 1 < i <= n)` |
 | `a.b`       | `(. a (quote b))`         |
-| `a.(b)`     | `(. a b)`                 |
 
 ### Bracketed forms
 

--- a/doc/src/manual/arrays.md
+++ b/doc/src/manual/arrays.md
@@ -889,6 +889,20 @@ julia> string.(1:3, ". ", ["First", "Second", "Third"])
  "3. Third"
 ```
 
+Normal dot calls are evaluated (or _materialized_) immediately.  To construct an
+intermediate representation without invoking the computation, prepend `for` to
+the a dot calls.
+
+```jldoctest
+julia> bc = for (1:3).^2;
+
+julia> bc isa Broadcast.Broadcasted  # it's not an `Array`
+true
+
+julia> sum(bc)  # summation without allocating any arrays
+14
+```
+
 ## Implementation
 
 The base array type in Julia is the abstract type [`AbstractArray{T,N}`](@ref). It is parameterized by

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -182,6 +182,14 @@ let x = [1, 3.2, 4.7],
     @test atan.(α, y') == broadcast(atan, α, y')
 end
 
+@testset "for f.(args...) syntax (#19198, #31088)" begin
+    let bc = for (1:3).^2
+        @test bc isa Broadcast.Broadcasted
+        @test sum(bc) == 14
+    end
+    @test sum(for (1:3).^2) == 14
+end
+
 # issue 14725
 let a = Number[2, 2.0, 4//2, 2+0im] / 2
     @test eltype(a) == Number


### PR DESCRIPTION
This PR implements `for f.(args...)` syntax as discussed in #19198 and planned in https://github.com/JuliaLang/julia/pull/31088#issuecomment-473030504.

close #19198
close #31088

### Implementation detail

* A new `Expr(:fordot, :(broadcasted.(expression)))` AST node is introduced to represent `for broadcasted.(expression)`.
* This is lowered to a chain of `broadcasted` calls by using the pre-existing code in `julia-syntax.scm` but skips the outer-most `materialize` call.
* `for non(dot(call))` is a syntax error at the moment.
* Lowering manually constructed `for non(dot(call))` is an error at the moment.
* There is no performance specialization in this PR.  It is done separately in #31020.

## Demo

```julia
julia> ex = :(for f.(x))
:(for f.(x))

julia> ex.head
:fordot

julia> ex.args
1-element Array{Any,1}:
 :(f.(x))

julia> Meta.lower(Main, ex)
:($(Expr(:thunk, CodeInfo(
    @ none within `top-level scope'
1 ─ %1 = Base.broadcasted(f, x)
└──      return %1
))))

julia> :(for f(x))
ERROR: syntax: invalid expression after `for`

julia> nondot = Expr(:fordot, :(f(x)))
:(for f(x))

julia> Meta.lower(Main, nondot)
:($(Expr(:error, "non-dot call after `for`")))
```
