### PR TITLE
Update BINARYBUILDER instructions and stable version of julia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,22 +96,18 @@ git config --global url."https://".insteadOf git://
 ```
 Be sure to also configure your system to use the appropriate proxy settings, e.g. by setting the `https_proxy` and `http_proxy` variables.)
 
-By default you will be building the latest unstable version of Julia. However, most users should use the most recent stable version of Julia, which is currently the `1.0` series of releases. You can get this version by changing to the Julia directory and running
+By default you will be building the latest unstable version of Julia. However, most users should use the most recent stable version of Julia, which is currently the `1.1` series of releases. You can get this version by changing to the Julia directory and running
 
-    git checkout v1.0.3
+    git checkout v1.1.0
 
 Now run `make` to build the `julia` executable. To perform a parallel build, use `make -j N` and supply the maximum number of concurrent processes. (See [Platform Specific Build Notes](https://github.com/JuliaLang/julia#platform-specific-build-notes) for details.) If the defaults in the build do not work for you, and you need to set specific make parameters, you can save them in `Make.user`, and place the file in the root of your Julia source. The build will automatically check for the existence of `Make.user` and use it if it exists.
 
-When compiled the first time, the build will automatically download and build its [external dependencies](#required-build-tools-and-external-libraries).
-This takes a while, but only has to be done once. Alternatively, pre-built external dependencies can be used by adding the following in `Make.user`
+When compiled the first time, the build will automatically download pre-built [external dependencies](#required-build-tools-and-external-libraries). If you prefer to build all the dependencies on your own, add the following in `Make.user`
 ```
-USE_BINARYBUILDER_LLVM=1
-USE_BINARYBUILDER_OPENBLAS=1
-USE_BINARYBUILDER_SUITESPARSE=1
+USE_BINARYBUILDER=0
 ```
-this avoids the long compilation times associated with building the external dependencies manually.
 
-Building Julia requires 5GiB of disk space and approximately 2GiB of virtual memory.
+Building Julia requires 2GiB of disk space (5GiB if building all dependencies) and approximately 4GiB of virtual memory.
 
 You can create out-of-tree builds of Julia by specifying `make O=<build-directory> configure` on the command line. This will create a directory mirror, with all of the necessary Makefiles to build Julia, in the specified directory. These builds will share the source files in Julia and `deps/srccache`. Each out-of-tree build directory can have its own `Make.user` file to override the global `Make.user` file in the top-level folder.
 


### PR DESCRIPTION
Also update the disk space and memory requirements. I have noticed that I can't build with 2GiB on a raspberry pi but can do so when I add 2GiB of swap, and thus increasing the minimum to 4GiB.