### PR TITLE
Set line endings on shell script to be lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # treat patches as files that should not be modified
 *.patch -text
+
+*.sh text eol=lf


### PR DESCRIPTION
Ref: https://techblog.dorogin.com/case-of-windows-line-ending-in-bash-script-7236f056abe, https://github.com/Microsoft/WSL/issues/2318

Without this, I get errors about line endings in our bash scripts on a fresh clone with WSL.