### PR TITLE
Auto-detect `ld v2.24` and disable `USE_BINARYBUILDER_LIBUV`.

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -940,6 +940,15 @@ $(foreach proj,$(BB_PROJECTS),$(eval USE_BINARYBUILDER_$(proj) = $(USE_BINARYBUI
 # Use the Assertions build
 BINARYBUILDER_LLVM_ASSERTS := 0
 
+# If we're running on Linux, and our `ld` is known to be bad (2.24),
+# disable USE_BINARYBUILDER_LIBUV by setting it to zero:
+ifeq ($(OS),Linux)
+LD_VERSION := $(lastword $(shell ld --version | head -1))
+ifneq ($(findstring .24,$(LD_VERSION)),)
+$(warning Linker version $(LD_VERSION) known to cause problems with libuv BB tarball, compiling from scratch by automatically setting USE_BINARYBUILDER_LIBUV=0)
+USE_BINARYBUILDER_LIBUV := 0
+endif
+endif
 
 
 # OS specific stuff

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -191,7 +191,7 @@ Pass *createGCInvariantVerifierPass(bool Strong) {
     return new GCInvariantVerifier(Strong);
 }
 
-extern "C" JL_DLLEXPORT void LLVMExtraAddGCInvariantVerifierPass(LLVMPassManagerRef PM, bool Strong)
+extern "C" JL_DLLEXPORT void LLVMExtraAddGCInvariantVerifierPass(LLVMPassManagerRef PM, LLVMBool Strong)
 {
     unwrap(PM)->add(createGCInvariantVerifierPass(Strong));
 }

--- a/src/llvm-ptls.cpp
+++ b/src/llvm-ptls.cpp
@@ -298,7 +298,7 @@ Pass *createLowerPTLSPass(bool imaging_mode)
     return new LowerPTLS(imaging_mode);
 }
 
-extern "C" JL_DLLEXPORT void LLVMExtraAddLowerPTLSPass(LLVMPassManagerRef PM, bool imaging_mode)
+extern "C" JL_DLLEXPORT void LLVMExtraAddLowerPTLSPass(LLVMPassManagerRef PM, LLVMBool imaging_mode)
 {
     unwrap(PM)->add(createLowerPTLSPass(imaging_mode));
 }


### PR DESCRIPTION
Potential solution to https://github.com/JuliaLang/julia/issues/31555#issuecomment-478356383.  I am trying to avoid having to fully parse the version number as that's complex in Make, and I don't even know what the proper bounds on invalid `ld` versions are (I just know that `2.24` doesn't work, and `2.26` does work)