### PR TITLE
RFC: Fast mul! with Q matrices from QR factorizations.

### DIFF
--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -738,19 +738,19 @@ function *(adjA::Adjoint{<:Any,<:StridedVecOrMat}, adjQ::Adjoint{<:Any,<:Abstrac
 end
 
 ### mul!
-function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::AbstractMatrix{T}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::AbstractVecOrMat{T}) where T<:BlasFloat
     lmul!(Q, copyto!(C, B))
 end
 
-function mul!(C::StridedVecOrMat{T}, A::AbstractMatrix{T}, Q::AbstractQ{T}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, Q::AbstractQ{T}) where T<:BlasFloat
     rmul!(copyto!(C, A), Q)
 end
 
-function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::AbstractMatrix{T}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::AbstractVecOrMat{T}) where T<:BlasFloat
     lmul!(adjQ, copyto!(C, B))
 end
 
-function mul!(C::StridedVecOrMat{T}, A::AbstractMatrix{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where T<:BlasFloat
     rmul!(copyto!(C, A), adjQ)
 end
 

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -738,38 +738,19 @@ function *(adjA::Adjoint{<:Any,<:StridedVecOrMat}, adjQ::Adjoint{<:Any,<:Abstrac
 end
 
 ### mul!
-function check_dimensions(C::StridedVecOrMat{T}, tA::AbstractChar, tB::AbstractChar,
-    A::Union{StridedVecOrMat{T}, AbstractQ{T}},
-    B::Union{AbstractQ{T}, StridedVecOrMat{T}}) where T<:BlasFloat
-    # Auxiliary function used in mul! with StridedVecOrMat and Q matrices from QR decompositions
-    mA, nA = lapack_size(tA, A)
-    mB, nB = lapack_size(tB, B)
-
-    if nA != mB
-        throw(DimensionMismatch("A has dimensions ($mA,$nA) but B has dimensions ($mB,$nB)"))
-    end
-    if lapack_size('N', C) != (mA, nB)
-        throw(DimensionMismatch("C has dimensions $(size(C)), should have ($mA,$nB)"))
-    end
-end
-
-function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::StridedVecOrMat{T}) where T<:BlasFloat
-    check_dimensions(C, 'N', 'N', Q, B)
+function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::AbstractMatrix{T}) where T<:BlasFloat
     lmul!(Q, copyto!(C, B))
 end
 
-function mul!(C::StridedVecOrMat{T}, A::StridedVecOrMat{T}, Q::AbstractQ{T}) where T<:BlasFloat
-    check_dimensions(C, 'N', 'N', A, Q)
+function mul!(C::StridedVecOrMat{T}, A::AbstractMatrix{T}, Q::AbstractQ{T}) where T<:BlasFloat
     rmul!(copyto!(C, A), Q)
 end
 
-function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::StridedVecOrMat{T}) where T<:BlasFloat
-    check_dimensions(C, 'T', 'N', adjQ.parent, B)
+function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::AbstractMatrix{T}) where T<:BlasFloat
     lmul!(adjQ, copyto!(C, B))
 end
 
-function mul!(C::StridedVecOrMat{T}, A::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where T<:BlasFloat
-    check_dimensions(C, 'N', 'T', A, adjQ.parent)
+function mul!(C::StridedVecOrMat{T}, A::AbstractMatrix{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where T<:BlasFloat
     rmul!(copyto!(C, A), adjQ)
 end
 

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -738,21 +738,10 @@ function *(adjA::Adjoint{<:Any,<:StridedVecOrMat}, adjQ::Adjoint{<:Any,<:Abstrac
 end
 
 ### mul!
-function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::AbstractVecOrMat{T}) where {T}
-    lmul!(Q, copyto!(C, B))
-end
-
-function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, Q::AbstractQ{T}) where {T}
-    rmul!(copyto!(C, A), Q)
-end
-
-function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::AbstractVecOrMat{T}) where {T}
-    lmul!(adjQ, copyto!(C, B))
-end
-
-function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where {T}
-    rmul!(copyto!(C, A), adjQ)
-end
+mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::StridedVecOrMat{T}) where {T} = lmul!(Q, copyto!(C, B))
+mul!(C::StridedVecOrMat{T}, A::StridedVecOrMat{T}, Q::AbstractQ{T}) where {T} = rmul!(copyto!(C, A), Q)
+mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::StridedVecOrMat{T}) where {T} = lmul!(adjQ, copyto!(C, B))
+mul!(C::StridedVecOrMat{T}, A::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where {T} = rmul!(copyto!(C, A), adjQ)
 
 ldiv!(A::QRCompactWY{T}, b::StridedVector{T}) where {T<:BlasFloat} =
     (ldiv!(UpperTriangular(A.R), view(lmul!(adjoint(A.Q), b), 1:size(A, 2))); b)

--- a/stdlib/LinearAlgebra/src/qr.jl
+++ b/stdlib/LinearAlgebra/src/qr.jl
@@ -738,19 +738,19 @@ function *(adjA::Adjoint{<:Any,<:StridedVecOrMat}, adjQ::Adjoint{<:Any,<:Abstrac
 end
 
 ### mul!
-function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::AbstractVecOrMat{T}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, Q::AbstractQ{T}, B::AbstractVecOrMat{T}) where {T}
     lmul!(Q, copyto!(C, B))
 end
 
-function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, Q::AbstractQ{T}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, Q::AbstractQ{T}) where {T}
     rmul!(copyto!(C, A), Q)
 end
 
-function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::AbstractVecOrMat{T}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}, B::AbstractVecOrMat{T}) where {T}
     lmul!(adjQ, copyto!(C, B))
 end
 
-function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where T<:BlasFloat
+function mul!(C::StridedVecOrMat{T}, A::AbstractVecOrMat{T}, adjQ::Adjoint{<:Any,<:AbstractQ{T}}) where {T}
     rmul!(copyto!(C, A), adjQ)
 end
 

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -149,6 +149,14 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                 @test_throws DimensionMismatch LinearAlgebra.lmul!(q,zeros(eltya,n1+1))
                 @test_throws DimensionMismatch LinearAlgebra.lmul!(adjoint(q), zeros(eltya,n1+1))
 
+                c = similar(a)
+                @test mul!(c, q, b) ≈ q*b
+                @test mul!(c, q', b) ≈ q'*b
+                @test mul!(c, a, q) ≈ a*q
+                @test mul!(c, b, a') ≈ b*a'
+                @test_throws DimensionMismatch mul!(Matrix(eltya, n+1, n), q, b)
+                @test_throws DimensionMismatch mul!(c, q, Matrix(eltya, n+1, n)))
+
                 qra = qr(a[:,1:n1], Val(false))
                 q, r = qra.Q, qra.R
                 @test rmul!(copy(squareQ(q)'), q) ≈ Matrix(I, n, n)
@@ -157,6 +165,14 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                 @test_throws DimensionMismatch rmul!(Matrix{eltya}(I, n+1, n+1),adjoint(q))
                 @test_throws ErrorException size(q,-1)
                 @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
+
+                c = similar(a)
+                @test mul!(c, q, b) ≈ q*b
+                @test mul!(c, q', b) ≈ q'*b
+                @test mul!(c, a, q) ≈ a*q
+                @test mul!(c, b, a') ≈ b*a'
+                @test_throws DimensionMismatch mul!(Matrix(eltya, n+1, n), q, b)
+                @test_throws DimensionMismatch mul!(c, q, Matrix(eltya, n+1, n)))
             end
         end
     end

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -156,7 +156,6 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                 @test mul!(c, b, q) ≈ b*q
                 @test mul!(c, b, q') ≈ b*q'
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n), q, b)
-                @test_throws DimensionMismatch mul!(c, q, Matrix{eltya}(I, n+1, n))
 
                 qra = qr(a[:,1:n1], Val(false))
                 q, r = qra.Q, qra.R
@@ -172,7 +171,6 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                 @test mul!(c, b, q) ≈ b*q
                 @test mul!(c, b, q') ≈ b*q'
                 @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n), q, b)
-                @test_throws DimensionMismatch mul!(c, q, Matrix{eltya}(I, n+1, n))
             end
         end
     end

--- a/stdlib/LinearAlgebra/test/qr.jl
+++ b/stdlib/LinearAlgebra/test/qr.jl
@@ -149,13 +149,14 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                 @test_throws DimensionMismatch LinearAlgebra.lmul!(q,zeros(eltya,n1+1))
                 @test_throws DimensionMismatch LinearAlgebra.lmul!(adjoint(q), zeros(eltya,n1+1))
 
+                b = similar(a); rand!(b)
                 c = similar(a)
                 @test mul!(c, q, b) ≈ q*b
                 @test mul!(c, q', b) ≈ q'*b
-                @test mul!(c, a, q) ≈ a*q
-                @test mul!(c, b, a') ≈ b*a'
-                @test_throws DimensionMismatch mul!(Matrix(eltya, n+1, n), q, b)
-                @test_throws DimensionMismatch mul!(c, q, Matrix(eltya, n+1, n)))
+                @test mul!(c, b, q) ≈ b*q
+                @test mul!(c, b, q') ≈ b*q'
+                @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n), q, b)
+                @test_throws DimensionMismatch mul!(c, q, Matrix{eltya}(I, n+1, n))
 
                 qra = qr(a[:,1:n1], Val(false))
                 q, r = qra.Q, qra.R
@@ -166,13 +167,12 @@ rectangularQ(Q::LinearAlgebra.AbstractQ) = convert(Array, Q)
                 @test_throws ErrorException size(q,-1)
                 @test_throws DimensionMismatch q * Matrix{Int8}(I, n+4, n+4)
 
-                c = similar(a)
                 @test mul!(c, q, b) ≈ q*b
                 @test mul!(c, q', b) ≈ q'*b
-                @test mul!(c, a, q) ≈ a*q
-                @test mul!(c, b, a') ≈ b*a'
-                @test_throws DimensionMismatch mul!(Matrix(eltya, n+1, n), q, b)
-                @test_throws DimensionMismatch mul!(c, q, Matrix(eltya, n+1, n)))
+                @test mul!(c, b, q) ≈ b*q
+                @test mul!(c, b, q') ≈ b*q'
+                @test_throws DimensionMismatch mul!(Matrix{eltya}(I, n+1, n), q, b)
+                @test_throws DimensionMismatch mul!(c, q, Matrix{eltya}(I, n+1, n))
             end
         end
     end


### PR DESCRIPTION
# Purpose

Uses `LAPACK`'s `gemqrt!` and `ormqr!` when performing `mul!` with `Q` matrices, of `QR` decompositions, or their transpose. Fixes JuliaLang/LinearAlgebra.jl#612. Acknowledged duplicate of JuliaLang/julia#31163.

# Tasks list

- [x] Add `mul!` methods
- [x] Add tests
- [x] Discuss issues with `lmul!/mul!` on non-strided arrays.

# Notes
No methods for `mul!` with a tranposed `AbstractMatrix`/`AbstractVector` input. This is because I could not find a way to perform this without extra memory allocation.
