### PR TITLE
codegen: fix bug with String egal test

### DIFF
--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -102,7 +102,7 @@ end
 function ==(a::String, b::String)
     pointer_from_objref(a) == pointer_from_objref(b) && return true
     al = sizeof(a)
-    return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al)
+    return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al % UInt)
 end
 
 typemin(::Type{String}) = ""

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2388,7 +2388,13 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
     int ptr_comparable = 0; // whether this type is unique'd by pointer
     if (rt1 == (jl_value_t*)jl_sym_type || rt2 == (jl_value_t*)jl_sym_type)
         ptr_comparable = 1;
-    if (jl_is_mutable_datatype(rt1) || jl_is_mutable_datatype(rt2)) // excludes abstract types
+    if (jl_is_mutable_datatype(rt1) && // excludes abstract types
+        rt1 != (jl_value_t*)jl_string_type && // technically mutable, but compared by contents
+        rt1 != (jl_value_t*)jl_simplevector_type)
+        ptr_comparable = 1;
+    if (jl_is_mutable_datatype(rt2) && // excludes abstract types
+        rt2 != (jl_value_t*)jl_string_type && // technically mutable, but compared by contents
+        rt2 != (jl_value_t*)jl_simplevector_type)
         ptr_comparable = 1;
     if (jl_subtype(rt1, (jl_value_t*)jl_type_type) ||
         jl_subtype(rt2, (jl_value_t*)jl_type_type)) {
@@ -2400,9 +2406,6 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
             ptr_comparable = 1;
         }
     }
-    if ((rt1 == (jl_value_t*)jl_string_type && rt2 == (jl_value_t*)jl_string_type) ||
-        (rt1 == (jl_value_t*)jl_simplevector_type && rt2 == (jl_value_t*)jl_simplevector_type))
-        ptr_comparable = 0; // technically mutable, but compared by contents
     if (ptr_comparable) {
         Value *varg1 = arg1.constant ? literal_pointer_val(ctx, arg1.constant) : arg1.V;
         Value *varg2 = arg2.constant ? literal_pointer_val(ctx, arg2.constant) : arg2.V;

--- a/test/core.jl
+++ b/test/core.jl
@@ -5828,6 +5828,13 @@ for U in boxedunions
     end
 end
 
+# issue 31583
+a31583 = "a"
+f31583() = a31583 === "a"
+@test f31583()
+a31583 = "b"
+@test !f31583()
+
 # unsafe_wrap
 let
     A4 = [1, 2, 3]


### PR DESCRIPTION
Note that String is pretty much the only case we have where `==` is actually faster than `===`. We could perhaps consider importing the code for `==` into codegen, if we consider that to be an important consideration.