### PR TITLE
getipaddrs: make loopback (Bool) a keyword argument

### DIFF
--- a/stdlib/Sockets/src/addrinfo.jl
+++ b/stdlib/Sockets/src/addrinfo.jl
@@ -243,13 +243,15 @@ getipaddr() = getipaddr(IPv4)
 
 
 """
-    getipaddrs(include_lo::Bool=false) -> Vector{IPAddr}
+    getipaddrs(; loopback::Bool=false) -> Vector{IPAddr}
 
 Get the IPv4 addresses of the local machine.
 
-    getipaddrs(addr_type::Type{T}, include_lo::Bool=false) where T<:IPAddr -> Vector{T}
+    getipaddrs(addr_type::Type{T}; loopback::Bool=false) where T<:IPAddr -> Vector{T}
 
 Get the IP addresses of the local machine of the specified type.
+
+The `loopback` keyword argument dictates whether loopback addresses are included.
 
 !!! compat "Julia 1.2"
     This function is available as of Julia 1.2.
@@ -267,7 +269,7 @@ julia> getipaddrs(IPv6)
  ip"fe80::445e:5fff:fe5d:5500"
 ```
 """
-function getipaddrs(addr_type::Type{T}, include_lo::Bool=false) where T<:IPAddr
+function getipaddrs(addr_type::Type{T}=IPAddr; loopback::Bool=false) where T<:IPAddr
     addresses = T[]
     addr_ref = Ref{Ptr{UInt8}}(C_NULL)
     count_ref = Ref{Int32}(1)
@@ -279,7 +281,7 @@ function getipaddrs(addr_type::Type{T}, include_lo::Bool=false) where T<:IPAddr
         current_addr = addr + i*_sizeof_uv_interface_address
         if 1 == ccall(:jl_uv_interface_address_is_internal, Int32, (Ptr{UInt8},), current_addr)
             lo_present = true
-            if !include_lo
+            if !loopback
                 continue
             end
         end
@@ -304,4 +306,3 @@ function getipaddrs(addr_type::Type{T}, include_lo::Bool=false) where T<:IPAddr
     end)
     return addresses
 end
-getipaddrs(include_lo::Bool=false) = getipaddrs(IPAddr, include_lo)

--- a/stdlib/Sockets/test/runtests.jl
+++ b/stdlib/Sockets/test/runtests.jl
@@ -441,9 +441,9 @@ end
         end
     end
 
-    @testset "include lo" begin
-        @test issubset(getipaddrs(), getipaddrs(true))
-        @test issubset(getipaddrs(IPv6), getipaddrs(IPv6, true))
+    @testset "including loopback addresses" begin
+        @test issubset(getipaddrs(), getipaddrs(loopback=true))
+        @test issubset(getipaddrs(IPv6), getipaddrs(IPv6, loopback=true))
     end
 end
 


### PR DESCRIPTION
I think this is a somewhat better API. Boolean arguments are often better as keywords since the value itself conveys so little contextual information. The loopback argument and the type argument are also orthogonal which this allows us to express slightly more easily (i.e. with a single method definition).