### PR TITLE
fix undefined variable error in uncompress_ast

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -903,7 +903,7 @@ uncompressed_ast(m::Method) = isdefined(m, :source) ? _uncompressed_ast(m, m.sou
                               error("Code for this Method is not available.")
 _uncompressed_ast(m::Method, s::CodeInfo) = copy(s)
 _uncompressed_ast(m::Method, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)::CodeInfo
-_uncompressed_ast(m::Core.CodeInstance, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), li.def.def::Method, li, s)::CodeInfo
+_uncompressed_ast(ci::Core.CodeInstance, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), ci.def.def::Method, ci, s)::CodeInfo
 
 function method_instances(@nospecialize(f), @nospecialize(t), world::UInt = typemax(UInt))
     tt = signature_type(f, t)

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -903,7 +903,7 @@ uncompressed_ast(m::Method) = isdefined(m, :source) ? _uncompressed_ast(m, m.sou
                               error("Code for this Method is not available.")
 _uncompressed_ast(m::Method, s::CodeInfo) = copy(s)
 _uncompressed_ast(m::Method, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), m, C_NULL, s)::CodeInfo
-_uncompressed_ast(ci::Core.CodeInstance, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Ptr{Cvoid}, Any), ci.def.def::Method, ci, s)::CodeInfo
+_uncompressed_ast(ci::Core.CodeInstance, s::Array{UInt8,1}) = ccall(:jl_uncompress_ast, Any, (Any, Any, Any), ci.def.def::Method, ci, s)::CodeInfo
 
 function method_instances(@nospecialize(f), @nospecialize(t), world::UInt = typemax(UInt))
     tt = signature_type(f, t)


### PR DESCRIPTION
Introduced by #31191

I managed to trigger this by executing:

```julia
Base.Threads.@threads for i in 1:Base.Threads.nthreads()
           if Base.Threads.threadid() == 1
             tasks = Task[]
             for i in 1:10
               t = Task(()->println("tid: ", Base.Threads.threadid()))
               t.sticky = false
               push!(tasks, t)
               schedule(t)
             end
             Base.sync_end(tasks)
           end
        end
```

Or by compiling the sysimage with `JULIA_NUM_THREADS=4` set.

@vtjnash what would be the expected codepath to trigger this method?