### PR TITLE
Revert #26418, remove noinline annotation from fill!

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -289,7 +289,6 @@ copyto!(dest::Array{T}, src::Array{T}) where {T} = copyto!(dest, 1, src, 1, leng
 # N.B: The generic definition in multidimensional.jl covers, this, this is just here
 # for bootstrapping purposes.
 function fill!(dest::Array{T}, x) where T
-    @_noinline_meta
     xT = convert(T, x)
     for i in eachindex(dest)
         @inbounds dest[i] = xT


### PR DESCRIPTION
This used to be necessary to avoid a strange edge case in the compiler, but it is no longer necessary -- and can now in fact cause other performance snags.

Using the test case from [the original discourse post that prompted #26418](https://discourse.julialang.org/t/performance-degradation-of-fill-in-latest-julia-0-7-dev/9648):

```julia
# BEFORE
julia> @btime fill(1.0,5,5);
  49.335 ns (1 allocation: 288 bytes)

julia> @btime fill(0.0,5,5);
  52.773 ns (1 allocation: 288 bytes)

# AFTER
julia> @btime fill(0.0,5,5);
  46.724 ns (1 allocation: 288 bytes)

julia> @btime fill(1.0,5,5);
  42.202 ns (1 allocation: 288 bytes)
```

Even more compelling is the case for a larger array where LLVM can exploit some sort of wider/simdier implementation for zeros when this gets inlined thanks to constant propagation:

```julia
# AFTER
julia> A = Array{Float64}(undef, 1000, 1000);

julia> @btime fill!($A,0.0);
  345.103 μs (0 allocations: 0 bytes)

julia> @btime fill!($A,1.0);
  458.976 μs (0 allocations: 0 bytes)
```

Ref https://discourse.julialang.org/t/performance-of-filling-an-array/22788