### PR TITLE
Partially revert "Remove specialized sort! method for PartialQuickSort{Int} (fixes #12833)"

### DIFF
--- a/base/sort.jl
+++ b/base/sort.jl
@@ -401,10 +401,6 @@ struct PartialQuickSort{T <: Union{Int,OrdinalRange}} <: Algorithm
     k::T
 end
 
-Base.first(a::PartialQuickSort{Int}) = 1
-Base.last(a::PartialQuickSort{Int}) = a.k
-Base.first(a::PartialQuickSort) = first(a.k)
-Base.last(a::PartialQuickSort) = last(a.k)
 
 """
     InsertionSort
@@ -587,42 +583,38 @@ function sort!(v::AbstractVector, lo::Int, hi::Int, a::MergeSortAlg, o::Ordering
     return v
 end
 
-## TODO: When PartialQuickSort is parameterized by an Int, this version of sort
-##       has one less comparison per loop than the version below, but enabling
-##       it causes return type inference to fail for sort/sort! (#12833)
-##
-# function sort!(v::AbstractVector, lo::Int, hi::Int, a::PartialQuickSort{Int},
-#                o::Ordering)
-#     @inbounds while lo < hi
-#         hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
-#         j = partition!(v, lo, hi, o)
-#         if j >= a.k
-#             # we don't need to sort anything bigger than j
-#             hi = j-1
-#         elseif j-lo < hi-j
-#             # recurse on the smaller chunk
-#             # this is necessary to preserve O(log(n))
-#             # stack space in the worst case (rather than O(n))
-#             lo < (j-1) && sort!(v, lo, j-1, a, o)
-#             lo = j+1
-#         else
-#             (j+1) < hi && sort!(v, j+1, hi, a, o)
-#             hi = j-1
-#         end
-#     end
-#     return v
-# end
-
-
-function sort!(v::AbstractVector, lo::Int, hi::Int, a::PartialQuickSort,
+function sort!(v::AbstractVector, lo::Int, hi::Int, a::PartialQuickSort{Int},
                o::Ordering)
     @inbounds while lo < hi
         hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
         j = partition!(v, lo, hi, o)
-
-        if j <= first(a)
+        if j >= a.k
+            # we don't need to sort anything bigger than j
+            hi = j-1
+        elseif j-lo < hi-j
+            # recurse on the smaller chunk
+            # this is necessary to preserve O(log(n))
+            # stack space in the worst case (rather than O(n))
+            lo < (j-1) && sort!(v, lo, j-1, a, o)
             lo = j+1
-        elseif j >= last(a)
+        else
+            (j+1) < hi && sort!(v, j+1, hi, a, o)
+            hi = j-1
+        end
+    end
+    return v
+end
+
+
+function sort!(v::AbstractVector, lo::Int, hi::Int, a::PartialQuickSort{T},
+               o::Ordering) where T<:OrdinalRange
+    @inbounds while lo < hi
+        hi-lo <= SMALL_THRESHOLD && return sort!(v, lo, hi, SMALL_ALGORITHM, o)
+        j = partition!(v, lo, hi, o)
+
+        if j <= first(a.k)
+            lo = j+1
+        elseif j >= last(a.k)
             hi = j-1
         else
             if j-lo < hi-j


### PR DESCRIPTION
This reverts commit 9e8fcd30e9d7d4e88e94cfebec59778a71387b97, except for the
test.  The underlying issue(s) causing #12833 seem to have been fixed with recent
changes in inference.