### PR TITLE
Fix show_vector for long offset arrays with :limit=true

### DIFF
--- a/base/arrayshow.jl
+++ b/base/arrayshow.jl
@@ -434,10 +434,11 @@ function show_vector(io::IO, v, opn='[', cls=']')
     io = IOContext(io, :typeinfo => eltype(v))
     limited = get(io, :limit, false)
     if limited && length(v) > 20
-        inds = axes1(v)
-        show_delim_array(io, v, opn, ",", "", false, inds[1], inds[1]+9)
+        axs1 = axes1(v)
+        f, l = first(axs1), last(axs1)
+        show_delim_array(io, v, opn, ",", "", false, f, f+9)
         print(io, "  …  ")
-        show_delim_array(io, v, "", ",", cls, false, inds[end-9], inds[end])
+        show_delim_array(io, v, "", ",", cls, false, l-9, l)
     else
         show_delim_array(io, v, opn, ",", cls, false)
     end

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -203,6 +203,8 @@ cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,5), (10,-9)))    # column
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(5,10^3), (10,-9)))    # rows fit
 cmp_showf(Base.print_matrix, io, OffsetArray(rand(10^3,10^3), (10,-9))) # neither fits
 cmp_showf(Base.print_matrix, io, OffsetArray(reshape(range(-0.212121212121, stop=2/11, length=3*29), 3, 29), (-2, -15)); options=(:displaysize=>(53,210),))
+cmp_showf(show, io, OffsetArray(collect(1:100), (100,)))   # issue #31641
+
 targets1 = ["0-dimensional $OAs_name.OffsetArray{Float64,0,Array{Float64,0}}:\n1.0",
             "1-element $OAs_name.OffsetArray{Float64,1,Array{Float64,1}} with indices 2:2:\n 1.0",
             "1×1 $OAs_name.OffsetArray{Float64,2,Array{Float64,2}} with indices 2:2×3:3:\n 1.0",


### PR DESCRIPTION
Fixes #31641