### PR TITLE
Add optimised methods for reducing(hcat/vcat on any iterators of vectors

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1372,10 +1372,10 @@ end
 
 typed_vcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_vcat(T, A)
 
-reduce(::typeof(vcat), A::AbstractVector{<:AbstractVecOrMat}, et, isize) =
+reduce(::typeof(vcat), A::AbstractVector{<:AbstractVecOrMat}) =
     _typed_vcat(mapreduce(eltype, promote_type, A), A)
 
-reduce(::typeof(hcat), A::AbstractVector{<:AbstractVecOrMat}, et, isize) =
+reduce(::typeof(hcat), A::AbstractVector{<:AbstractVecOrMat}) =
     _typed_hcat(mapreduce(eltype, promote_type, A), A)
 
 ## cat: general case

--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -1372,10 +1372,10 @@ end
 
 typed_vcat(::Type{T}, A::AbstractVecOrMat...) where {T} = _typed_vcat(T, A)
 
-reduce(::typeof(vcat), A::AbstractVector{<:AbstractVecOrMat}) =
+reduce(::typeof(vcat), A::AbstractVector{<:AbstractVecOrMat}, et, isize) =
     _typed_vcat(mapreduce(eltype, promote_type, A), A)
 
-reduce(::typeof(hcat), A::AbstractVector{<:AbstractVecOrMat}) =
+reduce(::typeof(hcat), A::AbstractVector{<:AbstractVecOrMat}, et, isize) =
     _typed_hcat(mapreduce(eltype, promote_type, A), A)
 
 ## cat: general case

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -380,15 +380,15 @@ function reduce(::typeof(vcat), xs, T::Type{<:AbstractVector}, isize)
     x_state = iterate(xs)
     x_state === nothing && return T() # New empty instance
     x1, state = x_state
-    
+
     ret = copy(x1)  # this is **Not** going to work for StaticArrays
-    
+
     if !(isize isa SizeUnknown)
         # Assume first element has representitive size, unless that would make this too large
         SIZEHINT_CAP = 10^6
         sizehint!(ret, min(SIZEHINT_CAP, length(xs)*length(x1)))
     end
-    
+
     x_state = iterate(xs, state)
     while(x_state !== nothing)
         x, state =  x_state
@@ -404,20 +404,20 @@ function reduce(::typeof(hcat), xs, T::Type{<:AbstractVector}, isize::SizeUnknow
     x_state = iterate(xs)
     x_state === nothing && return et() # New empty instance
     x1, state = x_state
-    
+
     dim1_size = length(x1)
     dim2_size = 1
     ret_vec = copy(x1)  # this is **Not** going to work for StaticArrays
-        
+
     x_state = iterate(xs, state)
-    
+
     while(x_state !== nothing)
         x, state =  x_state
         append!(ret_vec, x)
         dim2_size += 1
         x_state = iterate(xs, state)
     end
-    
+
     # Reshape will throw errors if anything was the wrong size
     return reshape(ret_vec, (dim1_size, dim2_size))
 end
@@ -427,13 +427,13 @@ function reduce(::typeof(hcat), xs, T::Type{<:AbstractVector}, isize)
     x_state = iterate(xs)
     x_state === nothing && return T() # New empty instance
     x1, state = x_state
-    
+
     dim1_size = size(x1,1)
     dim2_size = length(xs)
 
     ret = similar(x1, eltype(x1), (dim1_size, dim2_size))
     copyto!(ret, 1, x1, 1)
-    
+
     x_state = iterate(xs, state)
     offset =  length(x1)+1
     while(x_state !== nothing)

--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -349,7 +349,7 @@ julia> reduce(max, a, dims=1)
  4  8  12  16
 ```
 """
-reduce(op, A::AbstractArray; kw...) = mapreduce(identity, op, A; kw...)
+reduce(op, A::AbstractArray; kw...)
 
 ##### Specific reduction functions #####
 """

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -533,14 +533,14 @@ end
     v_v_diff = [rand(128), rand(Float32,128), rand(Int, 128)]
     v_v_diff_typed = Union{Vector{Float64},Vector{Float32},Vector{Int}}[rand(128), rand(Float32,128), rand(Int, 128)]
 
-    for v_v in (v_v_same, v_v_diff_typed, v_v_diff_typed)
+    for v_v in (v_v_same, v_v_diff, v_v_diff_typed)
         # Cover all combinations of iterator traits.
         g_v = (x for x in v_v)
         f_g_v = Iterators.filter(x->true, g_v)
         f_v_v = Iterators.filter(x->true, v_v);
         hcat_expected = hcat(v_v...)
         vcat_expected = vcat(v_v...)
-        @testset "$(typeof(data))" for data in (v_v, g_v, f_g_v, f_g_v)
+        @testset "$(typeof(data))" for data in (v_v, g_v, f_g_v, f_v_v)
             @test reduce(hcat, data) == hcat_expected
             @test reduce(vcat, data) == vcat_expected
         end


### PR DESCRIPTION
This covers the 2 vector cases of https://github.com/JuliaLang/julia/issues/31636
which I think are the most important.
Basically making all iterators comparably performant for this as Arrays

Looking at it, I do wonder if they (including the existing ones from https://github.com/JuliaLang/julia/issues/21672)
should be pushed down to be specialisations of `mapreduce(identity,  vcat/hcat,`.
Not sure though.


## Benchmarks:
#### Data
Covering each combination of iterator traits
```
v_v = [rand(128) for ii in 1:1000]
g_v = (x for x in v_v)
f_g_v = Iterators.filter(x->true, g_v)
f_v_v = Iterators.filter(x->true, v_v);
```

### Results:

```
Vector
--- hcat, on: Array{Array{Float64,1},1} ---
splatting: 
  148.638 μs (8 allocations: 1023.94 KiB)
reduce old: 
  60.284 μs (2 allocations: 1000.08 KiB)
reduce new: 
  57.536 μs (2 allocations: 1000.08 KiB)

--- hcat, on: Base.Generator{Array{Array{Float64,1},1},getfield(Main, Symbol("##159#160"))} ---
splatting: 
  188.010 μs (1505 allocations: 1.05 MiB)
reduce old: 
  259.465 ms (2985 allocations: 488.88 MiB)
reduce new: 
  58.025 μs (2 allocations: 1000.08 KiB)

--- hcat, on: Base.Iterators.Filter{getfield(Main, Symbol("##163#164")),Array{Array{Float64,1},1}} ---
splatting: 
  190.236 μs (1505 allocations: 1.05 MiB)
reduce old: 
  282.979 ms (2985 allocations: 488.88 MiB)
reduce new: 
  187.215 μs (13 allocations: 2.00 MiB)

--- hcat, on: Base.Iterators.Filter{getfield(Main, Symbol("##161#162")),Base.Generator{Array{Array{Float64,1},1},getfield(Main, Symbol("##159#160"))}} ---
splatting: 
  191.919 μs (1505 allocations: 1.05 MiB)
reduce old: 
  266.831 ms (2985 allocations: 488.88 MiB)
reduce new: 
  228.940 μs (13 allocations: 2.00 MiB)

=================
--- vcat, on: Array{Array{Float64,1},1} ---
splatting: 
  61.553 μs (3 allocations: 1008.02 KiB)
reduce old: 
  57.962 μs (2 allocations: 1000.08 KiB)
reduce new: 
  55.552 μs (2 allocations: 1001.20 KiB)

--- vcat, on: Base.Generator{Array{Array{Float64,1},1},getfield(Main, Symbol("##159#160"))} ---
splatting: 
  103.196 μs (1500 allocations: 1.03 MiB)
reduce old: 
  282.454 ms (1984 allocations: 488.85 MiB)
reduce new: 
  55.424 μs (2 allocations: 1001.20 KiB)

--- vcat, on: Base.Iterators.Filter{getfield(Main, Symbol("##163#164")),Array{Array{Float64,1},1}} ---
splatting: 
  105.145 μs (1500 allocations: 1.03 MiB)
reduce old: 
  281.383 ms (1984 allocations: 488.85 MiB)
reduce new: 
  157.521 μs (11 allocations: 2.00 MiB)

--- vcat, on: Base.Iterators.Filter{getfield(Main, Symbol("##161#162")),Base.Generator{Array{Array{Float64,1},1},getfield(Main, Symbol("##159#160"))}} ---
splatting: 
  107.264 μs (1500 allocations: 1.03 MiB)
reduce old: 
  281.396 ms (1984 allocations: 488.85 MiB)
reduce new: 
  177.695 μs (11 allocations: 2.00 MiB)
```


Note the `reduce new:` entry bypasses the existing method for `reduce(vcat|hcat, ::Array{<:AbstractVector})`, 
so that I could compare performance on just treating `Arrays`, as `Iterators`,
and thus to see if we could drop the extra specialised methods for them.
(once another PR to do matrixes is complete)

### Benchmark Takeways:
 - On iterators with known length, performance is equivelent to that we get on `Array`s
 - Up to a 4000x speedup (`vcat` on generators)