### PR TITLE
export LinearAlgebra.fillband!

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -82,6 +82,7 @@ export
     eigvals!,
     eigvecs,
     factorize,
+    fillband!,
     givens,
     hessenberg,
     hessenberg!,


### PR DESCRIPTION
Add `fillband!` to the export list of `LinearAlgebra` module.
Justification: FEM algorithms use a lot of big sparse matrices with few non-zero diagonals. This function provides easy and efficient way to build these matrices.