### PR TITLE
fix #31488, regression precompiling modules with non-interned empty strings

### DIFF
--- a/src/dump.c
+++ b/src/dump.c
@@ -545,6 +545,10 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
             return;
         }
     }
+    else if (jl_typeis(v, jl_string_type) && jl_string_len(v) == 0) {
+        jl_serialize_value(s, jl_an_empty_string);
+        return;
+    }
     else if (!jl_is_uint8(v)) {
         void **bp = ptrhash_bp(&backref_table, v);
         if (*bp != HT_NOTFOUND) {
@@ -877,14 +881,9 @@ static void jl_serialize_value_(jl_serializer_state *s, jl_value_t *v, int as_li
         jl_error("Task cannot be serialized");
     }
     else if (jl_typeis(v, jl_string_type)) {
-        if (jl_string_len(v) == 0) {
-            jl_serialize_value(s, jl_an_empty_string);
-        }
-        else {
-            write_uint8(s->s, TAG_STRING);
-            write_int32(s->s, jl_string_len(v));
-            ios_write(s->s, jl_string_data(v), jl_string_len(v));
-        }
+        write_uint8(s->s, TAG_STRING);
+        write_int32(s->s, jl_string_len(v));
+        ios_write(s->s, jl_string_data(v), jl_string_len(v));
     }
     else if (jl_typeis(v, jl_typemap_entry_type)) {
         write_uint8(s->s, TAG_TYPEMAP_ENTRY);

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -158,6 +158,11 @@ try
               const abigfloat_x = big"43.21"
               const abigint_f() = big"123"
               const abigint_x = big"124"
+
+              # issue #31488
+              _v31488 = Base.StringVector(2)
+              resize!(_v31488, 0)
+              const a31488 = fill(String(_v31488), 100)
           end
           """)
     @test_throws ErrorException Core.kwfunc(Base.nothing) # make sure `nothing` didn't have a kwfunc (which would invalidate the attempted test)
@@ -193,6 +198,8 @@ try
         @test Foo.d29936b === Dict{K,V} where {V,K}
 
         @test Foo.x28998[end] == 6
+
+        @test Foo.a31488 == fill("", 100)
     end
 
     cachedir = joinpath(dir, "compiled", "v$(VERSION.major).$(VERSION.minor)")


### PR DESCRIPTION
fixes #31488