### PR TITLE
Loosen SparseMatrixCSC colptr and rowval integer type restriction

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -23,7 +23,7 @@ struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
     function SparseMatrixCSC{Tv,Ti}(m::Integer, n::Integer, colptr::Vector{Ti}, rowval::Vector{Ti},
                                     nzval::Vector{Tv}) where {Tv,Ti<:Integer}
 
-        sparse_check_Ti(m, n, Ti)
+        sparse_check_Ti(m, n, length(nzval), Ti)
         new(Int(m), Int(n), colptr, rowval, nzval)
     end
 end
@@ -33,7 +33,7 @@ function SparseMatrixCSC(m::Integer, n::Integer, colptr::Vector, rowval::Vector,
     SparseMatrixCSC{Tv,Ti}(m, n, colptr, rowval, nzval)
 end
 
-function sparse_check_Ti(m::Integer, n::Integer, Ti::Type)
+function sparse_check_Ti(m::Integer, n::Integer, nnzval::Integer, Ti::Type)
         @noinline throwsz(str, lbl, k) =
             throw(ArgumentError("number of $str ($lbl) must be ≥ 0, got $k"))
         @noinline throwTi(str, lbl, k) =
@@ -42,7 +42,7 @@ function sparse_check_Ti(m::Integer, n::Integer, Ti::Type)
         n < 0 && throwsz("columns", 'n', n)
         !isbitstype(Ti) || m ≤ typemax(Ti) || throwTi("number of rows", "m", m)
         !isbitstype(Ti) || n ≤ typemax(Ti) || throwTi("number of columns", "n", n)
-        !isbitstype(Ti) || n*m+1 ≤ typemax(Ti) || throwTi("maximal nnz+1", "m*n+1", n*m+1)
+        !isbitstype(Ti) || nnzval+1 ≤ typemax(Ti) || throwTi("Number of nonzeros", "nnz+1", nnzval+1)
 end
 size(S::SparseMatrixCSC) = (S.m, S.n)
 
@@ -594,7 +594,7 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
         csccolptr::Vector{Ti}, cscrowval::Vector{Ti}, cscnzval::Vector{Tv}) where {Tv,Ti<:Integer}
 
     require_one_based_indexing(I, J, V)
-    sparse_check_Ti(m, n, Ti)
+    sparse_check_Ti(m, n, length(V), Ti)
     # Compute the CSR form's row counts and store them shifted forward by one in csrrowptr
     fill!(csrrowptr, Ti(0))
     coolen = length(I)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2563,7 +2563,9 @@ end
 
 @testset "Ti cannot store all potential values #31024" begin
     @test_throws ArgumentError SparseMatrixCSC(128, 1, [Int8(1), Int8(1)], Int8[], Int[])
-    @test_throws ArgumentError SparseMatrixCSC(12, 12, [Int8(1), Int8(1)], Int8[], Int[])
+    A = SparseMatrixCSC(12, 12, fill(Int8(1),13), Int8[], Int[])
+    @test size(A) == (12,12)
+    @test nnz(A) == 0
     I1 = [Int8(i) for i in 1:20 for _ in 1:20]
     J1 = [Int8(i) for _ in 1:20 for i in 1:20]
     @test_throws ArgumentError sparse(I1, J1, zero(length(I1)zero(length(I1))))


### PR DESCRIPTION
This fixes #31435. Please see that issue for full explanation. @KlausC any objection to this change?