### PR TITLE
Revert "Check if Ti is sufficient for size of SparseMatrixCSC  (#31118)"

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -22,8 +22,10 @@ struct SparseMatrixCSC{Tv,Ti<:Integer} <: AbstractSparseMatrix{Tv,Ti}
 
     function SparseMatrixCSC{Tv,Ti}(m::Integer, n::Integer, colptr::Vector{Ti}, rowval::Vector{Ti},
                                     nzval::Vector{Tv}) where {Tv,Ti<:Integer}
-
-        sparse_check_Ti(m, n, Ti)
+        @noinline throwsz(str, lbl, k) =
+            throw(ArgumentError("number of $str ($lbl) must be ≥ 0, got $k"))
+        m < 0 && throwsz("rows", 'm', m)
+        n < 0 && throwsz("columns", 'n', n)
         new(Int(m), Int(n), colptr, rowval, nzval)
     end
 end
@@ -33,17 +35,6 @@ function SparseMatrixCSC(m::Integer, n::Integer, colptr::Vector, rowval::Vector,
     SparseMatrixCSC{Tv,Ti}(m, n, colptr, rowval, nzval)
 end
 
-function sparse_check_Ti(m::Integer, n::Integer, Ti::Type)
-        @noinline throwsz(str, lbl, k) =
-            throw(ArgumentError("number of $str ($lbl) must be ≥ 0, got $k"))
-        @noinline throwTi(str, lbl, k) =
-            throw(ArgumentError("$str ($lbl = $k) does not fit in Ti = $(Ti)"))
-        m < 0 && throwsz("rows", 'm', m)
-        n < 0 && throwsz("columns", 'n', n)
-        !isbitstype(Ti) || m ≤ typemax(Ti) || throwTi("number of rows", "m", m)
-        !isbitstype(Ti) || n ≤ typemax(Ti) || throwTi("number of columns", "n", n)
-        !isbitstype(Ti) || n*m+1 ≤ typemax(Ti) || throwTi("maximal nnz+1", "m*n+1", n*m+1)
-end
 size(S::SparseMatrixCSC) = (S.m, S.n)
 
 # Define an alias for views of a SparseMatrixCSC which include all rows and a unit range of the columns.
@@ -594,7 +585,6 @@ function sparse!(I::AbstractVector{Ti}, J::AbstractVector{Ti},
         csccolptr::Vector{Ti}, cscrowval::Vector{Ti}, cscnzval::Vector{Tv}) where {Tv,Ti<:Integer}
 
     require_one_based_indexing(I, J, V)
-    sparse_check_Ti(m, n, Ti)
     # Compute the CSR form's row counts and store them shifted forward by one in csrrowptr
     fill!(csrrowptr, Ti(0))
     coolen = length(I)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -2546,14 +2546,6 @@ end
     @test sparse(Adjoint(UpperTriangular(A'))) == Adjoint(UpperTriangular(B'))
 end
 
-@testset "Ti cannot store all potential values #31024" begin
-    @test_throws ArgumentError SparseMatrixCSC(128, 1, [Int8(1), Int8(1)], Int8[], Int[])
-    @test_throws ArgumentError SparseMatrixCSC(12, 12, [Int8(1), Int8(1)], Int8[], Int[])
-    I1 = [Int8(i) for i in 1:20 for _ in 1:20]
-    J1 = [Int8(i) for _ in 1:20 for i in 1:20]
-    @test_throws ArgumentError sparse(I1, J1, zero(length(I1)zero(length(I1))))
-end
-
 @testset "unary operations on matrices where length(nzval)>nnz" begin
     # this should create a sparse matrix with length(nzval)>nnz
     A = SparseMatrixCSC(Complex{BigInt}[1+im 2+2im]')'[1:1, 2:2]


### PR DESCRIPTION
This reverts commit 4236774ccd0cd9c02f1a2a42a40b588345bcb842.

This was an non-discussed breaking change and the PR to change it https://github.com/JuliaLang/julia/pull/31661 is starting to get too much discussion considering we want to tag 1.2.0 now.

I suggest just reverting wholesale and then we can discuss how to add the feature back, with more consideration to its breakiness.