### PR TITLE
WIP: Give NTuple{N, T} a layout

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -338,15 +338,6 @@ struct VaFieldLayout
     padding::UInt32
 end
 
-struct DataTypeLayout
-    nfields::UInt32
-    alignment::UInt32
-    # alignment  : 9
-    # haspadding : 1
-    # npointers : 20
-    # fielddesc_type : 2
-end
-
 struct DTLayout
     dt::DataType
 end
@@ -401,6 +392,16 @@ function Base.getindex(l::DTLayout, i::Int)
         unsafe_load(Ptr{T}(ptr), 2))
 end
 =#
+
+struct DataTypeLayout
+    nfields::UInt32
+    alignment::UInt32
+    # alignment  : 9
+    # haspadding : 1
+    # npointers : 20
+    # fielddesc_type : 2
+end
+
 
 """
     Base.datatype_alignment(dt::DataType) -> Int

--- a/src/array.c
+++ b/src/array.c
@@ -173,7 +173,7 @@ static inline int is_ntuple_long(jl_value_t *v)
         return 0;
     size_t nfields = jl_nfields(v);
     for (size_t i = 0; i < nfields; i++) {
-        if (jl_field_type(jl_typeof(v), i) != (jl_value_t*)jl_long_type) {
+        if (jl_field_type((jl_datatype_t*)jl_typeof(v), i) != (jl_value_t*)jl_long_type) {
             return 0;
         }
     }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -791,7 +791,7 @@ JL_CALLABLE(jl_f_nfields)
 {
     JL_NARGS(nfields, 1, 1);
     jl_value_t *x = args[0];
-    return jl_box_long(jl_datatype_count_fields(jl_typeof(x)));
+    return jl_box_long(jl_datatype_count_fields((jl_datatype_t*)jl_typeof(x)));
 }
 
 JL_CALLABLE(jl_f_isdefined)

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -659,7 +659,7 @@ JL_CALLABLE(jl_f_getfield)
     size_t idx;
     if (jl_is_long(args[1])) {
         idx = jl_unbox_long(args[1])-1;
-        if (idx >= jl_datatype_nfields(st))
+        if (idx >= jl_datatype_count_fields(st))
             jl_bounds_error(args[0], args[1]);
     }
     else {
@@ -791,7 +791,7 @@ JL_CALLABLE(jl_f_nfields)
 {
     JL_NARGS(nfields, 1, 1);
     jl_value_t *x = args[0];
-    return jl_box_long(jl_field_count(jl_typeof(x)));
+    return jl_box_long(jl_datatype_count_fields(jl_typeof(x)));
 }
 
 JL_CALLABLE(jl_f_isdefined)

--- a/src/ccall.cpp
+++ b/src/ccall.cpp
@@ -355,7 +355,7 @@ static bool is_native_simd_type(jl_datatype_t *dt) {
             // Not homogeneous
             return false;
     // Type is homogeneous.  Check if it maps to LLVM vector.
-    return jl_special_vector_alignment(n, ft0) != 0;
+    return jl_special_vector_alignment(n, (jl_datatype_t*)ft0) != 0;
 }
 
 #include "abi_llvm.cpp"

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2779,7 +2779,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             jl_datatype_t *utt = (jl_datatype_t*)jl_unwrap_unionall(obj.typ);
             if (jl_is_datatype(utt) && utt->layout) {
                 if ((jl_is_structtype(utt) || jl_is_tuple_type(utt)) && !jl_subtype((jl_value_t*)jl_module_type, obj.typ)) {
-                    size_t nfields = jl_datatype_nfields(utt);
+                    size_t nfields = jl_datatype_count_fields(utt);
                     // integer index
                     size_t idx;
                     if (fld.constant && (idx = jl_unbox_long(fld.constant) - 1) < nfields) {
@@ -2869,7 +2869,7 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
         if (jl_is_type_type(obj.typ)) {
             jl_value_t *tp0 = jl_tparam0(obj.typ);
             if (jl_is_concrete_type(tp0)) {
-                *ret = mark_julia_type(ctx, ConstantInt::get(T_size, jl_datatype_nfields(tp0)), false, jl_long_type);
+                *ret = mark_julia_type(ctx, ConstantInt::get(T_size, jl_datatype_count_fields((jl_datatype_t*)tp0)), false, jl_long_type);
                 return true;
             }
         }
@@ -2877,16 +2877,16 @@ static bool emit_builtin_call(jl_codectx_t &ctx, jl_cgval_t *ret, jl_value_t *f,
             Value *sz;
             if (obj.constant) {
                 if (jl_typeof(obj.constant) == (jl_value_t*)jl_datatype_type)
-                    sz = ConstantInt::get(T_size, jl_datatype_nfields(obj.constant));
+                    sz = ConstantInt::get(T_size, jl_datatype_count_fields((jl_datatype_t*)obj.constant));
                 else
-                    sz = ConstantInt::get(T_size, jl_datatype_nfields(obj.typ));
+                    sz = ConstantInt::get(T_size, jl_datatype_count_fields((jl_datatype_t*)obj.typ));
             }
             else if (obj.typ == (jl_value_t*)jl_datatype_type) {
                 sz = emit_datatype_nfields(ctx, boxed(ctx, obj));
             }
             else {
                 assert(jl_is_datatype(obj.typ));
-                sz = ConstantInt::get(T_size, jl_datatype_nfields(obj.typ));
+                sz = ConstantInt::get(T_size, jl_datatype_count_fields((jl_datatype_t*)obj.typ));
             }
             *ret = mark_julia_type(ctx, sz, false, jl_long_type);
             return true;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5202,7 +5202,7 @@ static Function *gen_invoke_wrapper(jl_method_instance_t *lam, jl_value_t *jlret
         idx++;
         break;
     }
-    for (size_t i = 0; i < jl_nparams(lam->specTypes) && idx < nfargs; ++i) {
+    for (size_t i = 0; i < jl_datatype_count_fields((jl_datatype_t*)lam->specTypes) && idx < nfargs; ++i) {
         jl_value_t *ty = jl_nth_slot_type(lam->specTypes, i);
         bool isboxed;
         Type *lty = julia_type_to_llvm(ty, &isboxed);
@@ -5341,8 +5341,8 @@ static jl_returninfo_t get_specsig_function(Module *M, const std::string &name, 
         attributes = attributes.addAttribute(jl_LLVMContext, 1, Attribute::NoAlias);
         attributes = attributes.addAttribute(jl_LLVMContext, 1, Attribute::NoCapture);
     }
-    for (size_t i = 0; i < jl_nparams(sig); i++) {
-        jl_value_t *jt = jl_tparam(sig, i);
+    for (size_t i = 0; i < jl_datatype_count_fields((jl_datatype_t*)sig); i++) {
+        jl_value_t *jt = jl_field_type((jl_datatype_t*)sig, i);
         bool isboxed;
         Type *ty = julia_type_to_llvm(jt, &isboxed);
         if (type_is_ghost(ty))

--- a/src/dump.c
+++ b/src/dump.c
@@ -366,6 +366,7 @@ static void jl_serialize_datatype(jl_serializer_state *s, jl_datatype_t *dt) JL_
         }
         write_uint8(s->s, layout);
         if (layout == 0) {
+            assert(!dt->layout->isva);
             uint32_t nf = dt->layout->nfields;
             write_int32(s->s, nf);
             uint32_t alignment = ((uint32_t*)dt->layout)[1];

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -981,10 +981,10 @@ void jl_precompute_memoized_dt(jl_datatype_t *dt)
     size_t i, l = jl_nparams(dt);
     for (i = 0; i < l; i++) {
         jl_value_t *p = jl_tparam(dt, i);
-        if (jl_is_vararg_type(p))
-            p = jl_unwrap_vararg(p);
         if (!dt->hasfreetypevars)
             dt->hasfreetypevars = jl_has_free_typevars(p);
+        if (jl_is_vararg_type(p))
+            p = jl_unwrap_vararg(p);
         if (istuple && dt->isconcretetype)
             dt->isconcretetype = (jl_is_datatype(p) && ((jl_datatype_t*)p)->isconcretetype) || p == jl_bottom_type;
         if (dt->isdispatchtuple)

--- a/src/julia.h
+++ b/src/julia.h
@@ -1274,6 +1274,14 @@ STATIC_INLINE jl_value_t *jl_unwrap_vararg(jl_value_t *v) JL_NOTSAFEPOINT
     return jl_tparam0(jl_unwrap_unionall(v));
 }
 
+STATIC_INLINE size_t jl_vararg_length(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    assert(jl_is_vararg_type(v));
+    jl_value_t *len = jl_tparam1(jl_unwrap_unionall(v));
+    assert(jl_is_long(len));
+    return jl_unbox_long(len);
+}
+
 STATIC_INLINE jl_vararg_kind_t jl_vararg_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
     if (!jl_is_vararg_type(v))

--- a/src/julia.h
+++ b/src/julia.h
@@ -879,7 +879,7 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x) JL_NOTSAFEPO
 
 #define jl_fieldref(s,i) jl_get_nth_field(((jl_value_t*)(s)),i)
 #define jl_fieldref_noalloc(s,i) jl_get_nth_field_noalloc(((jl_value_t*)(s)),i)
-#define jl_nfields(v)    jl_datatype_nfields(jl_typeof(v))
+#define jl_nfields(v)    jl_datatype_count_fields((jl_datatype_t*)jl_typeof(v))
 
 // Not using jl_fieldref to avoid allocations
 #define jl_linenode_line(x) (((intptr_t*)(x))[0])
@@ -1367,7 +1367,7 @@ STATIC_INLINE jl_sym_t *jl_field_name(jl_datatype_t *st, size_t i) JL_NOTSAFEPOI
 STATIC_INLINE jl_value_t *jl_field_type(jl_datatype_t *st, size_t i) JL_NOTSAFEPOINT
 {   
     size_t len = jl_svec_len(st->types);
-    if (i + 2 < len) {
+    if (i + 2 <= len) {
         return jl_tfield(st, i);
     } else {
         jl_value_t *vt = jl_tfield(st, len - 1);

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -984,7 +984,7 @@ struct typemap_intersection_env {
 };
 int jl_typemap_intersection_visitor(jl_typemap_t *a, int offs, struct typemap_intersection_env *closure);
 
-unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *field_type);
+unsigned jl_special_vector_alignment(size_t nfields, jl_datatype_t *field_type);
 
 void register_eh_frames(uint8_t *Addr, size_t Size);
 void deregister_eh_frames(uint8_t *Addr, size_t Size);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -948,7 +948,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     }
     else if (jl_datatype_type && jl_is_datatype(vt)) {
         int istuple = jl_is_tuple_type(vt), isnamedtuple = jl_is_namedtuple_type(vt);
-        size_t tlen = jl_datatype_nfields(vt);
+        size_t tlen = jl_datatype_count_fields(vt);
         if (isnamedtuple) {
             if (tlen == 0)
                 n += jl_printf(out, "NamedTuple");

--- a/src/typemap.c
+++ b/src/typemap.c
@@ -30,7 +30,7 @@ static int sig_match_by_type_leaf(jl_value_t **types, jl_tupletype_t *sig, size_
 {
     size_t i;
     for (i = 0; i < n; i++) {
-        jl_value_t *decl = jl_field_type(sig, i);
+        jl_value_t *decl = jl_tfield(sig, i);
         jl_value_t *a = types[i];
         if (jl_is_type_type(a)) // decl is not Type, because it wouldn't be leafsig
             a = jl_typeof(jl_tparam0(a));
@@ -45,7 +45,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
     size_t i;
     if (va) lensig -= 1;
     for (i = 0; i < lensig; i++) {
-        jl_value_t *decl = jl_field_type(sig, i);
+        jl_value_t *decl = jl_tfield(sig, i);
         jl_value_t *a = types[i];
         jl_value_t *unw = jl_is_unionall(decl) ? ((jl_unionall_t*)decl)->body : decl;
         if (jl_is_type_type(unw)) {
@@ -78,7 +78,7 @@ static int sig_match_by_type_simple(jl_value_t **types, size_t n, jl_tupletype_t
         }
     }
     if (va) {
-        jl_value_t *decl = jl_unwrap_unionall(jl_field_type(sig, i));
+        jl_value_t *decl = jl_unwrap_unionall(jl_tfield(sig, i));
         if (jl_vararg_kind(decl) == JL_VARARG_INT) {
             if (n - i != jl_unbox_long(jl_tparam1(decl)))
                 return 0;
@@ -258,7 +258,7 @@ jl_typemap_t *mtcache_hash_lookup(const struct jl_ordereddict_t *a JL_PROPAGATES
             t = ((jl_typemap_level_t*)ml)->key;
         }
         else {
-            t = jl_field_type(jl_unwrap_unionall(jl_typemap_entry_sig(ml)), offs);
+            t = jl_tfield(jl_unwrap_unionall(jl_typemap_entry_sig(ml)), offs);
             if (tparam)
                 t = jl_tparam0(t);
         }
@@ -281,7 +281,7 @@ static void mtcache_rehash(struct jl_ordereddict_t *pa, size_t newlen, jl_value_
             t = ((jl_typemap_level_t*)ml)->key;
         }
         else {
-            t = jl_field_type(jl_unwrap_unionall(jl_typemap_entry_sig(ml)), offs);
+            t = jl_tfield(jl_unwrap_unionall(jl_typemap_entry_sig(ml)), offs);
             if (tparam)
                 t = jl_tparam0(t);
         }
@@ -359,7 +359,7 @@ static jl_typemap_t **mtcache_hash_bp(struct jl_ordereddict_t *pa JL_PROPAGATES_
                 t = ((jl_typemap_level_t*)*pml)->key;
             }
             else {
-                t = jl_field_type(jl_unwrap_unionall(
+                t = jl_tfield(jl_unwrap_unionall(
                     jl_typemap_entry_sig(*pml)),
                     offs);
                 if (tparam)
@@ -437,7 +437,7 @@ static int jl_typemap_intersection_array_visitor(struct jl_ordereddict_t *a, jl_
             t = ((jl_typemap_level_t*)ml)->key;
         }
         else {
-            t = jl_field_type(jl_unwrap_unionall(jl_typemap_entry_sig(ml)), offs);
+            t = jl_tfield(jl_unwrap_unionall(jl_typemap_entry_sig(ml)), offs);
             if (tparam)
                 t = jl_tparam0(t);
         }
@@ -1048,7 +1048,7 @@ jl_typemap_entry_t *jl_typemap_insert(jl_typemap_t **cache, jl_value_t *parent,
     assert(jl_is_tuple_type(ttype));
     size_t i, l;
     for (i = 0, l = jl_field_count(ttype); i < l && newrec->issimplesig; i++) {
-        jl_value_t *decl = jl_field_type(ttype, i);
+        jl_value_t *decl = jl_tfield(ttype, i);
         if (jl_is_kind(decl))
             newrec->isleafsig = 0; // Type{} may have a higher priority than a kind
         else if (jl_is_type_type(decl))

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1473,4 +1473,11 @@ CovType{T} = Union{AbstractArray{T,2},
                Pair{T,S} where S<:AbstractArray{T,2} where T<:AbstractFloat)
 
 # Various nasty varargs
-@assert issub_strict(Tuple{Int, Tuple{T}, Vararg{T, 3}} where T<:Int, Tuple{Int, Any, Any, Any, Integer})
+let T1 = Tuple{Int, Tuple{T}, Vararg{T, 3}} where T <: Int,
+    T2 = Tuple{Int, Any, Any, Any, Integer},
+    T3 = Tuple{Int, Any, Any, Any, Integer, Vararg{Integer, N} where N}
+
+    @test issub_strict(T1, T2)
+    @test issub_strict(T2, T3)
+    @test issub_strict(T1, T3)
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1471,3 +1471,6 @@ CovType{T} = Union{AbstractArray{T,2},
 @testintersect(Pair{<:Any, <:AbstractMatrix},
                Pair{T,     <:CovType{T}} where T<:AbstractFloat,
                Pair{T,S} where S<:AbstractArray{T,2} where T<:AbstractFloat)
+
+# Various nasty varargs
+@assert issub_strict(Tuple{Int, Tuple{T}, Vararg{T, 3}} where T<:Int, Tuple{Int, Any, Any, Any, Integer})


### PR DESCRIPTION
In the type system, we generally support tuples of the patter Tuple{..., Vararg{T, N}}.
However, when it comes to actually allocating these, we expand them out to
`Tuple{..., T, T, T, T, T, ...}`. This makes tuples not particularly suitable
as the representation for various memory buffers, because the cost of doing various
operations on their datatypes is proportional to the number of elements. This attempts
to keep them in the Vararg{T, N} form throughout the system, and similarly adding
a form of the layout specification that works for repeated trailing arguments.

Current status: Various things work, printing a tuple of this sort crashes in interesting
places. Inverse normalization (repeated trailing elements to NTuple) not yet implemented. Putting up early for feedback on the overall direction, since this involves a lot of tedious changes that I'd rather only do once.