### PR TITLE
Load startup.jl, if it exists, from DEPOT_PATH[1] instead of homedir/.julia

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -324,7 +324,7 @@ function load_julia_startup()
     else
         include_ifexists(Main, abspath(BINDIR, "..", "etc", "julia", "startup.jl"))
     end
-    include_ifexists(Main, abspath(homedir(), ".julia", "config", "startup.jl"))
+    include_ifexists(Main, abspath(DEPOT_PATH[1], "config", "startup.jl"))
     return nothing
 end
 

--- a/base/client.jl
+++ b/base/client.jl
@@ -324,7 +324,7 @@ function load_julia_startup()
     else
         include_ifexists(Main, abspath(BINDIR, "..", "etc", "julia", "startup.jl"))
     end
-    include_ifexists(Main, abspath(DEPOT_PATH[1], "config", "startup.jl"))
+    !isempty(DEPOT_PATH) && include_ifexists(Main, abspath(DEPOT_PATH[1], "config", "startup.jl"))
     return nothing
 end
 

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -143,7 +143,7 @@ The absolute path `REPL.find_hist_file()` of the REPL's history file. If
 `$JULIA_HISTORY` is not set, then `REPL.find_hist_file()` defaults to
 
 ```
-DEPOT_PATH[1]/logs/repl_history.jl
+$(DEPOT_PATH[1])/logs/repl_history.jl
 ```
 
 ### `JULIA_PKGRESOLVE_ACCURACY`

--- a/doc/src/manual/environment-variables.md
+++ b/doc/src/manual/environment-variables.md
@@ -116,8 +116,8 @@ environment variable or if it must have a value, set it to the string `:`.
 The `JULIA_DEPOT_PATH` environment variable is used to populate the global Julia
 [`DEPOT_PATH`](@ref) variable, which controls where the package manager, as well
 as Julia's code loading mechanisms, look for package registries, installed
-packages, named environments, repo clones, cached compiled package images, and
-configuration files.
+packages, named environments, repo clones, cached compiled package images,
+configuration files, and the default location of the REPL's history file.
 
 Unlike the shell `PATH` variable but similar to `JULIA_LOAD_PATH`, empty entries in
 `JULIA_DEPOT_PATH` are expanded to the default value of `DEPOT_PATH`. This allows
@@ -143,7 +143,7 @@ The absolute path `REPL.find_hist_file()` of the REPL's history file. If
 `$JULIA_HISTORY` is not set, then `REPL.find_hist_file()` defaults to
 
 ```
-$HOME/.julia/logs/repl_history.jl
+DEPOT_PATH[1]/logs/repl_history.jl
 ```
 
 ### `JULIA_PKGRESOLVE_ACCURACY`

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -691,7 +691,8 @@ function return_callback(s)
 end
 
 find_hist_file() = get(ENV, "JULIA_HISTORY",
-    !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") : nothing)
+                       !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") :
+                       error("DEPOT_PATH is empty and and ENV[\"JULIA_HISTORY\"] not set."))
 
 backend(r::AbstractREPL) = r.backendref
 
@@ -849,7 +850,6 @@ function setup_interface(
     if repl.history_file
         try
             hist_path = find_hist_file()
-            hist_path === nothing && throw("No valid history file")
             mkpath(dirname(hist_path))
             f = open(hist_path, read=true, write=true, create=true)
             finalizer(replc) do replc

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -691,7 +691,7 @@ function return_callback(s)
 end
 
 find_hist_file() = get(ENV, "JULIA_HISTORY",
-    joinpath(homedir(), ".julia", "logs", "repl_history.jl"))
+    !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") : "")
 
 backend(r::AbstractREPL) = r.backendref
 

--- a/stdlib/REPL/src/REPL.jl
+++ b/stdlib/REPL/src/REPL.jl
@@ -691,7 +691,7 @@ function return_callback(s)
 end
 
 find_hist_file() = get(ENV, "JULIA_HISTORY",
-    !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") : "")
+    !isempty(DEPOT_PATH) ? joinpath(DEPOT_PATH[1], "logs", "repl_history.jl") : nothing)
 
 backend(r::AbstractREPL) = r.backendref
 
@@ -849,6 +849,7 @@ function setup_interface(
     if repl.history_file
         try
             hist_path = find_hist_file()
+            hist_path === nothing && throw("No valid history file")
             mkpath(dirname(hist_path))
             f = open(hist_path, read=true, write=true, create=true)
             finalizer(replc) do replc


### PR DESCRIPTION
As the title says, load the startup.jl file from DEPOT_PATH[1]/config/startup.jl   Two other alternatives would be to sequentially search for a startup.jl file in all entries in DEPOT_PATH and load the first one or sequentially search and load all startup.jl files found in the entries of DEPOT_PATH. 