### PR TITLE
Don't modify existing MDNodes in SIMDloop pass.

### DIFF
--- a/src/llvm-simdloop.cpp
+++ b/src/llvm-simdloop.cpp
@@ -203,8 +203,9 @@ bool LowerSIMDLoop::markSIMDLoop(Module &M, Function *marker, bool ivdep)
         MDNode *n = L->getLoopID();
         if (!n) {
             // Loop does not have a LoopID yet, so give it one.
-            n = MDNode::get(Lh->getContext(), ArrayRef<Metadata *>(NULL));
-            n->replaceOperandWith(0, n);
+            auto temp_n = MDNode::getTemporary(Lh->getContext(), ArrayRef<Metadata *>(NULL));
+            temp_n->replaceOperandWith(0, temp_n.get());
+            n = MDNode::replaceWithPermanent(std::move(temp_n));
             L->setLoopID(n);
         }
 


### PR DESCRIPTION
This has been fixed on master, but might be interesting to backport to 1.1 or even 1.0 depending on our plans for those branches. Fixes debug code emission with CUDAnative.jl, but the underlying problem is significant.

Fixes https://github.com/JuliaGPU/CUDAnative.jl/issues/344