### PR TITLE
Simplify llvm.dbg.declare for pointer arguments

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -5950,10 +5950,13 @@ static std::unique_ptr<Module> emit_function(
                 vi.value = theArg;
                 if (specsig && theArg.V && ctx.debug_enabled && vi.dinfo) {
                     SmallVector<uint64_t, 8> addr;
-                    if ((Metadata*)vi.dinfo->getType() != jl_pvalue_dillvmt && theArg.ispointer())
-                        addr.push_back(llvm::dwarf::DW_OP_deref);
-                    AllocaInst *parg = dyn_cast<AllocaInst>(theArg.V);
-                    if (!parg) {
+                    Value *parg;
+                    if (theArg.ispointer()) {
+                        parg = theArg.V;
+                        if ((Metadata*)vi.dinfo->getType() != jl_pvalue_dillvmt)
+                            addr.push_back(llvm::dwarf::DW_OP_deref);
+                    }
+                    else {
                         parg = ctx.builder.CreateAlloca(theArg.V->getType(), NULL, jl_symbol_name(s));
                         ctx.builder.CreateStore(theArg.V, parg);
                     }

--- a/src/llvm-gc-invariant-verifier.cpp
+++ b/src/llvm-gc-invariant-verifier.cpp
@@ -85,12 +85,10 @@ void GCInvariantVerifier::visitStoreInst(StoreInst &SI) {
     if (VTy->isPointerTy()) {
         /* We currently don't obey this for arguments. That's ok - they're
            externally rooted. */
-        if (!isa<Argument>(SI.getValueOperand())) {
-            unsigned AS = cast<PointerType>(VTy)->getAddressSpace();
-            Check(AS != AddressSpace::CalleeRooted &&
-                  AS != AddressSpace::Derived,
-                  "Illegal store of decayed value", &SI);
-        }
+        unsigned AS = cast<PointerType>(VTy)->getAddressSpace();
+        Check(AS != AddressSpace::CalleeRooted &&
+              AS != AddressSpace::Derived,
+              "Illegal store of decayed value", &SI);
     }
     VTy = SI.getPointerOperand()->getType();
     if (VTy->isPointerTy()) {


### PR DESCRIPTION
Thanks to @vtjnash, again. Fixes https://github.com/JuliaGPU/CUDAnative.jl/issues/133

Before:
```llvm
define void @julia_kernel_2({ i64 } addrspace(11)* nocapture nonnull readonly dereferenceable(8)) !dbg !4 {
top:
  %1 = call %jl_value_t*** @julia.ptls_states()
  %2 = bitcast %jl_value_t*** %1 to %jl_value_t addrspace(10)**
  %3 = getelementptr inbounds %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %2, i64 2
  %4 = bitcast %jl_value_t addrspace(10)** %3 to i64**
  %5 = load i64*, i64** %4, !tbaa !14, !invariant.load !3
  %"#temp#" = alloca { i64 } addrspace(11)*
  store { i64 } addrspace(11)* %0, { i64 } addrspace(11)** %"#temp#"
  call void @llvm.dbg.declare(metadata { i64 } addrspace(11)** %"#temp#", metadata !13, metadata !DIExpression(DW_OP_deref)), !dbg !17
  ret void, !dbg !17
}
```

The store into a stack slot turned out problematic for the GC invariant verifier, but only in the case of CUDAnative kernels where we wrap functions and thus the following check failed to prevent that check:

https://github.com/JuliaLang/julia/blob/100108706c57795691721b849843d4a806210b1e/src/llvm-gc-invariant-verifier.cpp#L86-L88

This check can probably go now?

After:
```llvm
define void @julia_kernel_2({ i64 } addrspace(11)* nocapture nonnull readonly dereferenceable(8)) !dbg !4 {
top:
  %1 = call %jl_value_t*** @julia.ptls_states()
  %2 = bitcast %jl_value_t*** %1 to %jl_value_t addrspace(10)**
  %3 = getelementptr inbounds %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %2, i64 2
  %4 = bitcast %jl_value_t addrspace(10)** %3 to i64**
  %5 = load i64*, i64** %4, !tbaa !14, !invariant.load !3
  call void @llvm.dbg.declare(metadata { i64 } addrspace(11)* %0, metadata !13, metadata !DIExpression(DW_OP_deref)), !dbg !17
  ret void, !dbg !17
}
```