### PR TITLE
Fix some vararg-related subtyping issues

### DIFF
--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -92,10 +92,13 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
         return t # easy case
     elseif isa(t, DataType) && isempty(t.parameters)
         return t # fast path: unparameterized are always simple
-    elseif isa(unwrap_unionall(t), DataType) && isa(c, Type) && c !== Union{} && c <: t
-        return t # t is already wider than the comparison in the type lattice
-    elseif is_derived_type_from_any(unwrap_unionall(t), sources, depth)
-        return t # t isn't something new
+    else
+        ut = unwrap_unionall(t)
+        if isa(ut, DataType) && ut.name !== unwrap_unionall(Vararg).name && isa(c, Type) && c !== Union{} && c <: t
+            return t # t is already wider than the comparison in the type lattice
+        elseif is_derived_type_from_any(ut, sources, depth)
+            return t # t isn't something new
+        end
     end
     # peel off (and ignore) wrappers - they contribute no useful information, so we don't need to consider their size
     # first attempt to turn `c` into a type that contributes meaningful information

--- a/base/compiler/typelimits.jl
+++ b/base/compiler/typelimits.jl
@@ -94,7 +94,7 @@ function _limit_type_size(@nospecialize(t), @nospecialize(c), sources::SimpleVec
         return t # fast path: unparameterized are always simple
     else
         ut = unwrap_unionall(t)
-        if isa(ut, DataType) && ut.name !== unwrap_unionall(Vararg).name && isa(c, Type) && c !== Union{} && c <: t
+        if isa(ut, DataType) && ut.name !== _va_typename && isa(c, Type) && c !== Union{} && c <: t
             return t # t is already wider than the comparison in the type lattice
         elseif is_derived_type_from_any(ut, sources, depth)
             return t # t isn't something new

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1138,6 +1138,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
         }
         int did_normalize = 0;
         jl_value_t *last2 = normalize_vararg(last);
+        assert(!jl_is_unionall(last2) || !jl_is_unionall(((jl_unionall_t*)last2)->body));
         if (last2 != last) {
             last = last2;
             did_normalize = 1;

--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1082,10 +1082,19 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
                 continue;
             if (jl_is_datatype(pi))
                 continue;
+            if (jl_is_vararg_type(pi)) {
+                pi = jl_unwrap_vararg(pi);
+                if (jl_has_free_typevars(pi))
+                    continue;
+            }
             // normalize types equal to wrappers (prepare for wrapper_id)
             jl_value_t *tw = extract_wrapper(pi);
             if (tw && tw != pi && (tn != jl_type_typename || jl_typeof(pi) == jl_typeof(tw)) &&
                     jl_types_equal(pi, tw)) {
+                if (jl_is_vararg_type(iparams[i])) {
+                    tw = jl_wrap_vararg(tw, jl_tparam1(jl_unwrap_unionall(iparams[i])));
+                    tw = jl_rewrap_unionall(tw, iparams[i]);
+                }
                 iparams[i] = tw;
                 if (p) jl_gc_wb(p, tw);
             }

--- a/src/julia.h
+++ b/src/julia.h
@@ -1278,6 +1278,14 @@ STATIC_INLINE jl_value_t *jl_unwrap_vararg(jl_value_t *v) JL_NOTSAFEPOINT
     return jl_tparam0(jl_unwrap_unionall(v));
 }
 
+STATIC_INLINE size_t jl_vararg_length(jl_value_t *v) JL_NOTSAFEPOINT
+{
+    assert(jl_is_vararg_type(v));
+    jl_value_t *len = jl_tparam1(jl_unwrap_unionall(v));
+    assert(jl_is_long(len));
+    return jl_unbox_long(len);
+}
+
 STATIC_INLINE jl_vararg_kind_t jl_vararg_kind(jl_value_t *v) JL_NOTSAFEPOINT
 {
     if (!jl_is_vararg_type(v))

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -778,7 +778,8 @@ struct subtype_unionall_env {
 static int subtype_unionall_callback(struct subtype_unionall_env *env, int8_t R, jl_stenv_t *s, int param) {
     if (R) {
         return subtype(env->t, env->ubody, s, param);
-    } else {
+    }
+    else {
         return subtype(env->ubody, env->t, s, param);
     }
 }
@@ -857,7 +858,8 @@ static int subtype_tuple_varargs(struct subtype_tuple_env *env, jl_stenv_t *e, i
         if (jl_is_long(yl)) {
             return 0;
         }
-    } else {
+    }
+    else {
         jl_value_t *xl = jl_tparam1(env->vtx);
         if (jl_is_typevar(xl)) {
             jl_varbinding_t *xlv = lookup(e, (jl_tvar_t*)xl);
@@ -879,7 +881,8 @@ static int subtype_tuple_varargs(struct subtype_tuple_env *env, jl_stenv_t *e, i
                     if (jl_is_long(yl)) {
                         return jl_unbox_long(yl) + 1 == env->vy;
                     }
-                } else {
+                }
+                else {
                     // We can skip the subtype check, but we still
                     // need to make sure to constrain the length of y
                     // to 0.
@@ -928,8 +931,7 @@ constrain_length:
 
 static int subtype_tuple_tail(struct subtype_tuple_env *env, int8_t R, jl_stenv_t *e, int param)
 {
-loop:
-    // while (i <= lx) {
+loop: // while (i <= lx) {
         if (env->i >= env->lx)
             goto done;
 
@@ -954,7 +956,8 @@ loop:
                 env->vtx = xi;
             }
             xi = env->vtx;
-        } else {
+        }
+        else {
             xi = jl_tparam(env->xd, env->i);
         }
 
@@ -973,7 +976,8 @@ loop:
                     env->vty = yi;
                 }
                 yi = env->vty;
-            } else {
+            }
+            else {
                 yi = jl_tparam(env->yd, env->j);
             }
         }
@@ -1020,7 +1024,7 @@ loop:
             env->j++;
 
         goto loop;
-    // }
+    // } (from loop:)
 
 done:
     // TODO: handle Vararg with explicit integer length parameter
@@ -1058,10 +1062,12 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
                 return 0;
             else if (env.lx < env.ly) // Unbounded includes N == 0
                 return 0;
-        } else if (env.vvy == JL_VARARG_NONE && !check_vararg_length(jl_tparam(env.xd, env.lx-1), env.ly+1-env.lx, e)) {
+        }
+        else if (env.vvy == JL_VARARG_NONE && !check_vararg_length(jl_tparam(env.xd, env.lx-1), env.ly+1-env.lx, e)) {
             return 0;
         }
-    } else {
+    }
+    else {
         size_t nx = env.lx;
         if (env.vvx == JL_VARARG_INT)
             nx += jl_vararg_length(jl_tparam(env.xd, env.lx-1)) - 1;
@@ -1075,7 +1081,8 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
         if (env.vvy == JL_VARARG_NONE || env.vvy == JL_VARARG_INT) {
             if (nx != ny)
                 return 0;
-        } else {
+        }
+        else {
             if (ny > nx)
                 return 0;
         }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -807,11 +807,16 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     if (lx == 0 && ly == 0)
         return 1;
     size_t i=0, j=0;
-    int vx=0, vy=0, vvx = (lx > 0 && jl_is_vararg_type(jl_tparam(xd, lx-1)));
+    int vx=0, vy=0;
+    jl_vararg_kind_t vvx = JL_VARARG_NONE;
+    if (lx > 0)
+        vvx = jl_vararg_kind(jl_tparam(xd, lx-1));
     int vvy = (ly > 0 && jl_is_vararg_type(jl_tparam(yd, ly-1)));
-    if (vvx) {
-        if ((vvy && ly > lx) || (!vvy && ly < lx-1))
-            return 0;
+    if (vvx != JL_VARARG_NONE) {
+        if (vvx == JL_VARARG_UNBOUND) {
+            if (!vvy && ly < lx - 1)
+                return 0;
+        }
     }
     else if ((vvy && ly > lx+1) || (!vvy && lx != ly)) {
         return 0;
@@ -820,14 +825,16 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
     jl_value_t *lastx=NULL, *lasty=NULL;
     while (i < lx) {
         jl_value_t *xi = jl_tparam(xd, i);
-        if (i == lx-1 && vvx) vx = 1;
+        if (i == lx-1 && vvx) {
+            vx += 1;
+        }
         jl_value_t *yi = NULL;
         if (j < ly) {
             yi = jl_tparam(yd, j);
-            if (j == ly-1 && vvy) vy = 1;
+            if (j == ly-1 && vvy) vy += 1;
         }
         if (vx && !vy) {
-            if (!check_vararg_length(xi, ly+1-lx, e))
+            if (!check_vararg_length(xi, ly-lx+(vvy ? 0 : 1), e))
                 return 0;
             jl_tvar_t *p1=NULL, *p2=NULL;
             xi = unwrap_2_unionall(xi, &p1, &p2);
@@ -869,9 +876,11 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
                 jl_value_t *xl = jl_tparam1(xi);
                 if (jl_is_typevar(xl)) {
                     jl_varbinding_t *xlv = lookup(e, (jl_tvar_t*)xl);
-                    if (xlv && jl_is_long(xlv->lb) && jl_unbox_long(xlv->lb) == 0)
-                        break;
+                    if (xlv)
+                        xl = xlv->lb;
                 }
+                if (jl_is_long(xl) && jl_unbox_long(xl) + 1 == vx)
+                    return 1;
             }
             if (jl_is_datatype(yi)) {
                 jl_value_t *yl = jl_tparam1(yi);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -917,7 +917,7 @@ constrain_length:
 
     // Vararg{T,N} <: Vararg{T2,N2}; equate N and N2
     e->invdepth++;
-    JL_GC_PUSH2(xp1, yp1);
+    JL_GC_PUSH2(&xp1, &yp1);
     if (jl_is_long(xp1) && env->vx != 1)
         xp1 = jl_box_long(jl_unbox_long(xp1) - env->vx + 1);
     if (jl_is_long(yp1) && env->vy != 1)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1500,16 +1500,16 @@ JL_DLLEXPORT int jl_obvious_subtype(jl_value_t *x, jl_value_t *y, int *subtype)
             jl_vararg_kind_t vx = JL_VARARG_NONE;
             jl_value_t *vxt = NULL;
             int vy = 0;
-            int vnpx = npx;
+            int nparams_expanded_x = npx;
             if (istuple) {
                 if (npx > 0) {
                     jl_value_t *xva = jl_tparam(x, npx - 1);
                     vx = jl_vararg_kind(xva);
                     if (vx != JL_VARARG_NONE) {
                         vxt = jl_unwrap_vararg(xva);
-                        vnpx -= 1;
+                        nparams_expanded_x -= 1;
                         if (vx == JL_VARARG_INT)
-                            vnpx += jl_vararg_length(xva);
+                            nparams_expanded_x += jl_vararg_length(xva);
                     }
                 }
                 vy = npy > 0 && jl_is_vararg_type(jl_tparam(y, npy - 1));
@@ -1519,7 +1519,8 @@ JL_DLLEXPORT int jl_obvious_subtype(jl_value_t *x, jl_value_t *y, int *subtype)
                     *subtype = 0;
                     return 1;
                 }
-                if ((vx == JL_VARARG_NONE || vx == JL_VARARG_INT) && vnpx < npy - vy) {
+                if ((vx == JL_VARARG_NONE || vx == JL_VARARG_INT) && nparams_expanded_x < npy - vy)
+                {
                     *subtype = 0;
                     return 1; // number of fixed parameters in x could be fewer than in y
                 }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -834,7 +834,7 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
             if (j == ly-1 && vvy) vy += 1;
         }
         if (vx && !vy) {
-            if (!check_vararg_length(xi, ly-lx+(vvy ? 0 : 1), e))
+            if (!vvy && !check_vararg_length(xi, ly-lx+1, e))
                 return 0;
             jl_tvar_t *p1=NULL, *p2=NULL;
             xi = unwrap_2_unionall(xi, &p1, &p2);
@@ -912,13 +912,14 @@ static int subtype_tuple(jl_datatype_t *xd, jl_datatype_t *yd, jl_stenv_t *e, in
             j++;
     }
     // TODO: handle Vararg with explicit integer length parameter
-    vy = vy || (j < ly && jl_is_vararg_type(jl_tparam(yd,j)));
+    if (!vy && j < ly && jl_is_vararg_type(jl_tparam(yd,j)))
+        vy += 1;
     if (vy && !vx && lx+1 >= ly) {
         // in Tuple{...,tn} <: Tuple{...,Vararg{T,N}}, check (lx+1-ly) <: N
         if (!check_vararg_length(jl_tparam(yd,ly-1), lx+1-ly, e))
             return 0;
     }
-    return (lx==ly && vx==vy) || (vy && (lx >= (vx ? ly : (ly-1))));
+    return (lx + vx == ly + vy) || (vy && (lx >= (vx ? ly : (ly-1))));
 }
 
 static int forall_exists_equal(jl_value_t *x, jl_value_t *y, jl_stenv_t *e);

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1308,24 +1308,37 @@ JL_DLLEXPORT int jl_obvious_subtype(jl_value_t *x, jl_value_t *y, int *subtype)
                     return 1;
             }
             int i, npx = jl_nparams(x), npy = jl_nparams(y);
-            int vx = 0, vy = 0;
+            jl_vararg_kind_t vx = JL_VARARG_NONE;
+            jl_value_t *vxt = NULL;
+            int vy = 0;
+            int vnpx = npx;
             if (istuple) {
-                vx = npx > 0 && jl_is_vararg_type(jl_tparam(x, npx - 1));
+                if (npx > 0) {
+                    jl_value_t *xva = jl_tparam(x, npx - 1);
+                    vx = jl_vararg_kind(xva);
+                    if (vx != JL_VARARG_NONE) {
+                        vxt = jl_unwrap_vararg(xva);
+                        vnpx -= 1;
+                        if (vx == JL_VARARG_INT)
+                            vnpx += jl_vararg_length(xva);
+                    }
+                }
                 vy = npy > 0 && jl_is_vararg_type(jl_tparam(y, npy - 1));
             }
-            if (npx != npy || vx || vy) {
-                if (!vy) {
+            if (npx != npy || vx != JL_VARARG_NONE || vy) {
+                if ((vx == JL_VARARG_NONE || vx == JL_VARARG_UNBOUND) && !vy) {
                     *subtype = 0;
                     return 1;
                 }
-                if (npx - vx < npy - vy) {
+                if ((vx == JL_VARARG_NONE || vx == JL_VARARG_INT) && vnpx < npy - vy) {
                     *subtype = 0;
                     return 1; // number of fixed parameters in x could be fewer than in y
                 }
+                // TODO: Can do better here for the JL_VARARG_INT case.
                 uncertain = 1;
             }
             for (i = 0; i < npy - vy; i++) {
-                jl_value_t *a = jl_tparam(x, i);
+                jl_value_t *a = i >= (npx - (vx == JL_VARARG_NONE ? 0 : 1)) ? vxt : jl_tparam(x, i);
                 jl_value_t *b = jl_tparam(y, i);
                 if (iscov || jl_is_typevar(b)) {
                     if (jl_obvious_subtype(a, b, subtype)) {

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1584,3 +1584,7 @@ let T31805 = Tuple{Type{Tuple{}}, Tuple{Vararg{Int8, A}}} where A,
     S31805 = Tuple{Type{Tuple{Vararg{Int32, A}}}, Tuple{Vararg{Int16, A}}} where A
     @test !issub(T31805, S31805)
 end
+@testintersect(
+    Tuple{Array{Tuple{Vararg{Int64,N}},N},Tuple{Vararg{Array{Int64,1},N}}} where N,
+    Tuple{Array{Tuple{Int64},1}, Tuple},
+    Tuple{Array{Tuple{Int64},1},Tuple{Array{Int64,1}}})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1548,4 +1548,11 @@ let X = LinearAlgebra.Symmetric{T, S} where S<:(AbstractArray{U, 2} where U<:T) 
 end
 
 # Various nasty varargs
-@assert issub_strict(Tuple{Int, Tuple{T}, Vararg{T, 3}} where T<:Int, Tuple{Int, Any, Any, Any, Integer})
+let T1 = Tuple{Int, Tuple{T}, Vararg{T, 3}} where T <: Int,
+    T2 = Tuple{Int, Any, Any, Any, Integer},
+    T3 = Tuple{Int, Any, Any, Any, Integer, Vararg{Integer, N} where N}
+
+    @test issub_strict(T1, T2)
+    @test issub_strict(T2, T3)
+    @test issub_strict(T1, T3)
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1177,7 +1177,7 @@ end
 struct TT20103{X,Y} end
 f20103(::Type{TT20103{X,Y}},x::X,y::Y) where {X,Y} = 1
 f20103(::Type{TT20103{X,X}},x::X) where {X} = 100
-@test typeintersect(Type{NTuple{N,E}} where E where N, Type{NTuple{N,E} where N} where E) == Union{} # use @testintersect once fixed
+@testintersect(Type{NTuple{N,E}} where E where N, Type{NTuple{N,E} where N} where E, Union{})
 let ints = (Int, Int32, UInt, UInt32)
     Ints = Union{ints...}
     vecs = []

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1556,3 +1556,13 @@ let T1 = Tuple{Int, Tuple{T}, Vararg{T, 3}} where T <: Int,
     @test issub_strict(T2, T3)
     @test issub_strict(T1, T3)
 end
+let A = Tuple{Float64, Vararg{Int64, 2}},
+    B1 = Tuple{Float64, Vararg{T, 2}} where T <: Int64,
+    B2 = Tuple{Float64, T, T} where T <: Int64,
+    C = Tuple{Float64, Any, Vararg{Integer, N} where N}
+
+    @test A == B1 == B2
+    @test issub_strict(A, C)
+    @test issub_strict(B1, C)
+    @test issub_strict(B2, C)
+end

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1546,3 +1546,6 @@ let X = LinearAlgebra.Symmetric{T, S} where S<:(AbstractArray{U, 2} where U<:T) 
               LinearAlgebra.Symmetric{T, S} where S<:(AbstractArray{U, 2} where U<:T) where T}
     @test X <: Y
 end
+
+# Various nasty varargs
+@assert issub_strict(Tuple{Int, Tuple{T}, Vararg{T, 3}} where T<:Int, Tuple{Int, Any, Any, Any, Integer})

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1580,3 +1580,7 @@ end
 @test !issub(Tuple{Vararg{T, 3}} where T<:Real, Tuple{Any, Any, Any, Any, Vararg{Any, N} where N})
 @test !issub(Tuple{Vararg{T, 3}} where T<:Real, Tuple{Any, Any, Any, Any, Vararg{Any, N}} where N)
 @test issub_strict(Ref{Tuple{Int, Vararg{Int, N}}} where N, Ref{Tuple{Vararg{Int, N}}} where N)
+let T31805 = Tuple{Type{Tuple{}}, Tuple{Vararg{Int8, A}}} where A,
+    S31805 = Tuple{Type{Tuple{Vararg{Int32, A}}}, Tuple{Vararg{Int16, A}}} where A
+    @test !issub(T31805, S31805)
+end


### PR DESCRIPTION
This is a backport from (a local version of) #31681. Turns out the same subtyping issues I addressed there exist on master, but we just tend to not see those types a whole lot. 