### PR TITLE
fix #31676: add complex(::Array, ::Array) method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,8 @@ Standard library changes
 * `inv(::Missing)` has now been added and returns `missing` ([#31451]).
 * `nextfloat(::BigFloat, n::Integer)` and `prevfloat(::BigFloat, n::Integer)` methods
   have been added ([#31310]).
+* `complex(::Array, ::Array)` method has been added to maintain consistency with
+  `complex(::Array)` ([#31676]).
 
 #### LinearAlgebra
 * Added keyword arguments `rtol`, `atol` to `pinv` and `nullspace` ([#29998]).

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -1016,22 +1016,4 @@ big(z::Complex{T}) where {T<:Real} = Complex{big(T)}(z)
 
 complex(A::AbstractArray) = map(complex, A)
 complex(A::AbstractArray{<:Complex}) = A
-<<<<<<< HEAD
 complex(R::AbstractArray{<:Any,N}, I::AbstractArray{<:Any,N}) where {N} = map(complex, R, I)
-=======
-
-function complex(A::AbstractArray{T}) where T
-    if !isconcretetype(T)
-        error("`complex` not defined on abstractly-typed arrays; please convert to a more specific type")
-    end
-    convert(AbstractArray{typeof(complex(zero(T)))}, A)
-end
-
-function complex(A::AbstractArray{T1}, B::AbstractArray{T2}) where {T1, T2}
-    if !isconcretetype(T1) || !isconcretetype(T2)
-        error("`complex` not defined on abstractly-typed arrays; please convert to a more specific type")
-    end
-    size(A) == size(B) || throw(DimensionMismatch("real and imaginary array dimensions do not match"))
-    Complex.(A, B)
-end
->>>>>>> 8bdee56391... fix #31676: add complex(::Array, ::Array) method

--- a/base/complex.jl
+++ b/base/complex.jl
@@ -148,11 +148,14 @@ Convert real numbers or arrays to complex. `i` defaults to zero.
 julia> complex(7)
 7 + 0im
 
-julia> complex([1, 2, 3])
+julia> complex([1, 2, 3], [4, 5, 6])
 3-element Array{Complex{Int64},1}:
- 1 + 0im
- 2 + 0im
- 3 + 0im
+ 1 + 4im
+ 2 + 5im
+ 3 + 6im
+
+ !!! compat "Julia 1.3"
+    The two-array method of `complex` requires at least Julia 1.3.
 ```
 """
 complex(z::Complex) = z
@@ -1011,7 +1014,11 @@ big(z::Complex{T}) where {T<:Real} = Complex{big(T)}(z)
 
 ## Array operations on complex numbers ##
 
+complex(A::AbstractArray) = map(complex, A)
 complex(A::AbstractArray{<:Complex}) = A
+<<<<<<< HEAD
+complex(R::AbstractArray{<:Any,N}, I::AbstractArray{<:Any,N}) where {N} = map(complex, R, I)
+=======
 
 function complex(A::AbstractArray{T}) where T
     if !isconcretetype(T)
@@ -1019,3 +1026,12 @@ function complex(A::AbstractArray{T}) where T
     end
     convert(AbstractArray{typeof(complex(zero(T)))}, A)
 end
+
+function complex(A::AbstractArray{T1}, B::AbstractArray{T2}) where {T1, T2}
+    if !isconcretetype(T1) || !isconcretetype(T2)
+        error("`complex` not defined on abstractly-typed arrays; please convert to a more specific type")
+    end
+    size(A) == size(B) || throw(DimensionMismatch("real and imaginary array dimensions do not match"))
+    Complex.(A, B)
+end
+>>>>>>> 8bdee56391... fix #31676: add complex(::Array, ::Array) method

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -800,6 +800,7 @@ end
 
 @test complex.(1.0, [1.0, 1.0]) == [complex(1.0, 1.0), complex(1.0, 1.0)]
 @test complex.([1.0, 1.0], 1.0) == [complex(1.0, 1.0), complex(1.0, 1.0)]
+@test_throws DimensionMismatch complex(zeros(Int, 2), zeros(Float64, 3))
 # robust division of Float64
 # hard complex divisions from Fig 6 of arxiv.1210.4539
 z7 = Complex{Float64}(3.898125604559113300e289, 8.174961907852353577e295)


### PR DESCRIPTION
Addresses a perceived inconsistency: `complex(::Array)` exists, but `complex(::Array, ::Array)` does not. Closes JuliaLang/LinearAlgebra.jl#624.