### PR TITLE
Doc: Add cross reference for `@sprintf`

### DIFF
--- a/stdlib/Printf/src/Printf.jl
+++ b/stdlib/Printf/src/Printf.jl
@@ -22,6 +22,8 @@ string further away from zero is chosen.
 Optionally, an [`IOStream`](@ref)
 may be passed as the first argument to redirect output.
 
+See also: [`@sprintf`](@ref)
+
 # Examples
 ```jldoctest
 julia> @printf("%f %F %f %F\\n", Inf, Inf, NaN, NaN)


### PR DESCRIPTION
Adding this cross reference to easier explore the library via the Julia REPL.