### PR TITLE
Fast implementation of digits with base a power of 2

### DIFF
--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -759,7 +759,8 @@ function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10) where T<:
     isempty(a) && return a
 
     if base > 0
-        if ispow2(base) && n >= 0 && n isa Base.BitInteger
+        if ispow2(base) && n >= 0 && n isa Base.BitInteger && base <= typemax(Int)
+            base = Int(base)
             k = trailing_zeros(base)
             c = base - 1
             for i in eachindex(a)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -460,6 +460,10 @@ function ndigits0zpb(x::Integer, b::Integer)
         b == 8  && return (sizeof(x)<<3 - leading_zeros(x) + 2) ÷ 3
         b == 16 && return sizeof(x)<<1 - leading_zeros(x)>>2
         b == 10 && return bit_ndigits0z(x)
+        if ispow2(b)
+            dv, rm = divrem(sizeof(x)<<3 - leading_zeros(x), trailing_zeros(b))
+            return iszero(rm) ? dv : dv + 1
+        end
     end
 
     d = 0
@@ -755,9 +759,11 @@ function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10) where T<:
     isempty(a) && return a
 
     if base > 0
-        if base == 2
+        if ispow2(base) && n >= 0 && n isa Base.BitInteger
+            k = trailing_zeros(base)
+            c = base - 1
             for i in eachindex(a)
-                a[i] = (n >> (i - firstindex(a))) & 1
+                a[i] = (n >> (k * (i - firstindex(a)))) & c
             end
         else
             for i in eachindex(a)

--- a/base/intfuncs.jl
+++ b/base/intfuncs.jl
@@ -755,9 +755,15 @@ function digits!(a::AbstractVector{T}, n::Integer; base::Integer = 10) where T<:
     isempty(a) && return a
 
     if base > 0
-        for i in eachindex(a)
-            n, d = divrem(n, base)
-            a[i] = d
+        if base == 2
+            for i in eachindex(a)
+                a[i] = (n >> (i - firstindex(a))) & 1
+            end
+        else
+            for i in eachindex(a)
+                n, d = divrem(n, base)
+                a[i] = d
+            end
         end
     else
         # manually peel one loop iteration for type stability

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -203,7 +203,7 @@ end
         @test digits(321, base = 8) == [1, 0, 5]
         @test digits(0x123456789abcdef, base = 16) == 15:-1:1
         @test digits(0x2b1a210a750, base = 64) == [16, 29, 10, 4, 34, 6, 43]
-        @test digits(0x02a01407, base = 1024) == [7, 5, 42]
+        @test digits(0x02a01407, base = Int128(1024)) == [7, 5, 42]
     end
 
     @testset "digits/base with negative bases" begin

--- a/test/intfuncs.jl
+++ b/test/intfuncs.jl
@@ -117,6 +117,14 @@ end
 
         @test ndigits(146, base=-3) == 5
     end
+    @testset "ndigits with base power of 2" begin
+        @test ndigits(17, base = 2) == 5
+        @test ndigits(123, base = 4) == 4
+        @test ndigits(64, base = 8) == 3
+        @test ndigits(8436, base = 16) == 4
+        @test ndigits(159753, base = 32) == 4
+        @test ndigits(3578951, base = 64) == 4
+    end
     let (n, b) = rand(Int, 2)
         -1 <= b <= 1 && (b = 2) # invalid bases
         @test ndigits(n) == ndigits(big(n)) == ndigits(n, base=10)
@@ -181,11 +189,22 @@ end
     @test bitstring(Int128(3)) == "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000011"
 end
 @testset "digits/base" begin
-    @test digits(4, base = 2) == [0, 0, 1]
     @test digits(5, base = 3) == [2, 1]
-    @test digits(5, base = Int32(2), pad=Int32(3)) == [1, 0, 1]
     @test digits(5, pad = 3) == [5, 0, 0]
     @test digits(5, pad = Int32(3)) == [5, 0, 0]
+    # The following have bases powers of 2, but don't enter the fast path
+    @test digits(-3, base = 2) == -[1, 1]
+    @test digits(-42, base = 4) == -[2, 2, 2]
+
+    @testset "digits/base with bases powers of 2" begin
+        @test digits(4, base = 2) == [0, 0, 1]
+        @test digits(5, base = Int32(2), pad=Int32(3)) == [1, 0, 1]
+        @test digits(42, base = 4) == [2, 2, 2]
+        @test digits(321, base = 8) == [1, 0, 5]
+        @test digits(0x123456789abcdef, base = 16) == 15:-1:1
+        @test digits(0x2b1a210a750, base = 64) == [16, 29, 10, 4, 34, 6, 43]
+        @test digits(0x02a01407, base = 1024) == [7, 5, 42]
+    end
 
     @testset "digits/base with negative bases" begin
         @testset "digits(n::$T, base = b)" for T in (Int, UInt, BigInt, Int32, UInt32)


### PR DESCRIPTION
This PR adds a fast specialised implementation of `digits(::Integer, base = 2)`.  @ararslan said that making `base = 2` a special case wouldn't be a bad idea.  Performance with other bases shouldn't be affected.

Before this PR:
```julia
julia> @benchmark digits(3, base = 2)
BenchmarkTools.Trial: 
  memory estimate:  96 bytes
  allocs estimate:  1
  --------------
  minimum time:     40.681 ns (0.00% GC)
  median time:      41.959 ns (0.00% GC)
  mean time:        52.063 ns (14.25% GC)
  maximum time:     43.487 μs (99.85% GC)
  --------------
  samples:          10000
  evals/sample:     991

julia> @benchmark digits(3, base = 10)
BenchmarkTools.Trial: 
  memory estimate:  96 bytes
  allocs estimate:  1
  --------------
  minimum time:     35.241 ns (0.00% GC)
  median time:      36.893 ns (0.00% GC)
  mean time:        47.171 ns (16.41% GC)
  maximum time:     43.818 μs (99.88% GC)
  --------------
  samples:          10000
  evals/sample:     992

julia> @benchmark digits(1234567890123456, base = 2)
BenchmarkTools.Trial: 
  memory estimate:  496 bytes
  allocs estimate:  1
  --------------
  minimum time:     658.308 ns (0.00% GC)
  median time:      667.686 ns (0.00% GC)
  mean time:        730.018 ns (5.45% GC)
  maximum time:     247.337 μs (99.70% GC)
  --------------
  samples:          10000
  evals/sample:     159

julia> @benchmark digits(1234567890123456, base = 10)
BenchmarkTools.Trial: 
  memory estimate:  208 bytes
  allocs estimate:  1
  --------------
  minimum time:     222.505 ns (0.00% GC)
  median time:      225.409 ns (0.00% GC)
  mean time:        247.892 ns (5.90% GC)
  maximum time:     87.951 μs (99.67% GC)
  --------------
  samples:          10000
  evals/sample:     487
```

After this PR:
```julia
julia> @benchmark digits(3, base = 2)
BenchmarkTools.Trial: 
  memory estimate:  96 bytes
  allocs estimate:  1
  --------------
  minimum time:     34.707 ns (0.00% GC)
  median time:      35.394 ns (0.00% GC)
  mean time:        43.532 ns (14.30% GC)
  maximum time:     37.210 μs (99.85% GC)
  --------------
  samples:          10000
  evals/sample:     993

julia> @benchmark digits(3, base = 10)
BenchmarkTools.Trial: 
  memory estimate:  96 bytes
  allocs estimate:  1
  --------------
  minimum time:     34.356 ns (0.00% GC)
  median time:      35.174 ns (0.00% GC)
  mean time:        43.805 ns (14.93% GC)
  maximum time:     38.129 μs (99.86% GC)
  --------------
  samples:          10000
  evals/sample:     993

julia> @benchmark digits(1234567890123456, base = 2)
BenchmarkTools.Trial: 
  memory estimate:  496 bytes
  allocs estimate:  1
  --------------
  minimum time:     75.659 ns (0.00% GC)
  median time:      77.740 ns (0.00% GC)
  mean time:        88.100 ns (8.38% GC)
  maximum time:     30.302 μs (99.61% GC)
  --------------
  samples:          10000
  evals/sample:     971

julia> @benchmark digits(1234567890123456, base = 10)
BenchmarkTools.Trial: 
  memory estimate:  208 bytes
  allocs estimate:  1
  --------------
  minimum time:     215.581 ns (0.00% GC)
  median time:      217.726 ns (0.00% GC)
  mean time:        236.653 ns (5.16% GC)
  maximum time:     73.486 μs (99.63% GC)
  --------------
  samples:          10000
  evals/sample:     525
```