### PR TITLE
Add an early-out to subtype_unionall

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -736,6 +736,11 @@ static int subtype_unionall(jl_value_t *t, jl_unionall_t *u, jl_stenv_t *e, int8
 
     e->vars = vb.prev;
 
+    if (!ans) {
+        JL_GC_POP();
+        return 0;
+    }
+
     btemp = e->vars;
     if (vb.lb != vb.ub) {
         while (btemp != NULL) {


### PR DESCRIPTION
The comment in the loop indicates that it takes a significant amount of time.
However, if `ans` is already `0`, the loop has no effect other than to waste time.
Exit the function early in that case to save some time.