### PR TITLE
Properly handle non-normalized vararg tuples in tuple_type_tail

### DIFF
--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -212,7 +212,9 @@ function tuple_type_tail(T::Type)
     else
         T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))
         if isvatuple(T) && length(T.parameters) == 1
-            return T
+            va = T.parameters[1]
+            (isa(va, DataType) && isa(va.parameters[2], Int)) || return T
+            return Tuple{Vararg{va.parameters[1], va.parameters[2]-1}}
         end
         return Tuple{argtail(T.parameters...)...}
     end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -448,3 +448,6 @@ end
     @test map(p->getproperty(ttest, p), propertynames(ttest)) == ttest
     @test_throws ErrorException setproperty!(ttest, 1, :d)
 end
+
+# tuple_type_tail on non-normalized vararg tuple
+@test Base.tuple_type_tail(Tuple{Vararg{T, 3}} where T<:Real) == Tuple{Vararg{T, 2}} where T<:Real


### PR DESCRIPTION
In preparation for #31681 in particular, but the problem exists on master
as well, we just tend to not encounter non-normalized tuple types that often.