### PR TITLE
During bootstrap, print julia assertion failures using fallback printing

### DIFF
--- a/base/error.jl
+++ b/base/error.jl
@@ -183,7 +183,11 @@ macro assert(ex, msgs...)
         msg = Main.Base.string(msg)
     else
         # string() might not be defined during bootstrap
-        msg = :(Main.Base.string($(Expr(:quote,msg))))
+        msg = quote
+            msg = $(Expr(:quote,msg))
+            isdefined(Main, :Base) ? Main.Base.string(msg) :
+                (Core.println(msg); "Error during bootstrap. See stdout.")
+        end
     end
     return :($(esc(ex)) ? $(nothing) : throw(AssertionError($msg)))
 end


### PR DESCRIPTION
The `@assert` macro already had support for assertions being defined using
bootstrap. However, it would throw an uninformative `UndefVarError(:Base)`
if one of those assertions actually failed during bootstrap (when Base is
unavailable). Instead, for assertions generated during bootstrap add an
extra check to see if Base is available and if not, use the fallback printing
to print the assertion message.