### PR TITLE
precompile: permit saving code (regression)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -14,6 +14,8 @@
 # Set to zero to turn off extra precompile (e.g. for the REPL)
 JULIA_PRECOMPILE ?= 1
 
+FORCE_ASSERTIONS ?= 0
+
 # OPENBLAS build options
 OPENBLAS_TARGET_ARCH:=
 OPENBLAS_SYMBOLSUFFIX:=


### PR DESCRIPTION
fix #31665. We were accidentally deleting all cached inference entries during precompile loading.