### PR TITLE
use Iterators.reverse for foldr etc.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,7 +39,7 @@ Standard library changes
 
 #### Miscellaneous
 
-
+* `foldr` and `mapfoldr` now work on any iterator that supports `Iterators.reverse`, not just arrays ([#31781]).
 
 External dependencies
 ---------------------

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -91,28 +91,19 @@ foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)
 
 ## foldr & mapfoldr
 
-function mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, itr, i::Integer)
-    init = nt.init
-    # Unroll the while loop once; if init is known, the call to op may
-    # be evaluated at compile time
-    if isempty(itr) || i == 0
-        return init
-    else
-        x = itr[i]
-        v  = op(f(x), init)
-        while i > 1
-            x = itr[i -= 1]
-            v = op(f(x), v)
-        end
-        return v
-    end
-end
+mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, ritr, i...) =
+    mapfoldl_impl(f, (x,y) -> op(y,x), nt, ritr, i...)
 
-function mapfoldr_impl(f, op, ::NamedTuple{()}, itr, i::Integer)
-    if isempty(itr)
-        return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
+# we can't just call mapfoldl_impl with (x,y) -> op(y,x), because
+# we need to use the type of op for mapreduce_empty_iter and mapreduce_first.
+function mapfoldr_impl(f, op, nt::NamedTuple{()}, ritr)
+    y = iterate(ritr)
+    if y === nothing
+        return Base.mapreduce_empty_iter(f, op, ritr, IteratorEltype(ritr))
     end
-    return mapfoldr_impl(f, op, (init=mapreduce_first(f, op, itr[i]),), itr, i-1)
+    (x, i) = y
+    init = mapreduce_first(f, op, x)
+    return mapfoldr_impl(f, op, (init=init,), ritr, i)
 end
 
 """
@@ -122,7 +113,7 @@ Like [`mapreduce`](@ref), but with guaranteed right associativity, as in [`foldr
 provided, the keyword argument `init` will be used exactly once. In general, it will be
 necessary to provide `init` to work with empty collections.
 """
-mapfoldr(f, op, itr; kw...) = mapfoldr_impl(f, op, kw.data, itr, lastindex(itr))
+mapfoldr(f, op, itr; kw...) = mapfoldr_impl(f, op, kw.data, Iterators.reverse(itr))
 
 
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -91,8 +91,8 @@ foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)
 
 ## foldr & mapfoldr
 
-mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, ritr, i...) =
-    mapfoldl_impl(f, (x,y) -> op(y,x), nt, ritr, i...)
+mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, itr, i...) =
+    mapfoldl_impl(f, (x,y) -> op(y,x), nt, Iterators.reverse(itr), i...)
 
 # we can't just call mapfoldl_impl with (x,y) -> op(y,x), because
 # we need to use the type of op for mapreduce_empty_iter and mapreduce_first.

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -91,8 +91,8 @@ foldl(op, itr; kw...) = mapfoldl(identity, op, itr; kw...)
 
 ## foldr & mapfoldr
 
-mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, itr, i...) =
-    mapfoldl_impl(f, (x,y) -> op(y,x), nt, Iterators.reverse(itr), i...)
+mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, itr) =
+    mapfoldl_impl(f, (x,y) -> op(y,x), nt, Iterators.reverse(itr))
 
 # we can't just call mapfoldl_impl with (x,y) -> op(y,x), because
 # we need to use the type of op for mapreduce_empty_iter and mapreduce_first.
@@ -104,7 +104,7 @@ function mapfoldr_impl(f, op, nt::NamedTuple{()}, itr)
     end
     (x, i) = y
     init = mapreduce_first(f, op, x)
-    return mapfoldr_impl(f, op, (init=init,), ritr, i)
+    return mapfoldl_impl(f, (x,y) -> op(y,x), (init=init,), ritr, i)
 end
 
 """

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -56,7 +56,7 @@ function mapfoldl_impl(f, op, nt::NamedTuple{()}, itr)
     if y === nothing
         return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
     end
-    (x, i) = y
+    x, i = y
     init = mapreduce_first(f, op, x)
     return mapfoldl_impl(f, op, (init=init,), itr, i)
 end
@@ -102,7 +102,7 @@ function mapfoldr_impl(f, op, nt::NamedTuple{()}, itr)
     if y === nothing
         return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
     end
-    (x, i) = y
+    x, i = y
     init = mapreduce_first(f, op, x)
     return mapfoldl_impl(f, (x,y) -> op(y,x), (init=init,), ritr, i)
 end

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -36,7 +36,7 @@ mul_prod(x::Real, y::Real)::Real = x * y
 
 ## foldl && mapfoldl
 
-@noinline function mapfoldl_impl(f, op, nt::NamedTuple{(:init,)}, itr, i...)
+function mapfoldl_impl(f, op, nt::NamedTuple{(:init,)}, itr, i...)
     init = nt.init
     # Unroll the while loop once; if init is known, the call to op may
     # be evaluated at compile time
@@ -96,10 +96,11 @@ mapfoldr_impl(f, op, nt::NamedTuple{(:init,)}, ritr, i...) =
 
 # we can't just call mapfoldl_impl with (x,y) -> op(y,x), because
 # we need to use the type of op for mapreduce_empty_iter and mapreduce_first.
-function mapfoldr_impl(f, op, nt::NamedTuple{()}, ritr)
+function mapfoldr_impl(f, op, nt::NamedTuple{()}, itr)
+    ritr = Iterators.reverse(itr)
     y = iterate(ritr)
     if y === nothing
-        return Base.mapreduce_empty_iter(f, op, ritr, IteratorEltype(ritr))
+        return Base.mapreduce_empty_iter(f, op, itr, IteratorEltype(itr))
     end
     (x, i) = y
     init = mapreduce_first(f, op, x)
@@ -113,7 +114,7 @@ Like [`mapreduce`](@ref), but with guaranteed right associativity, as in [`foldr
 provided, the keyword argument `init` will be used exactly once. In general, it will be
 necessary to provide `init` to work with empty collections.
 """
-mapfoldr(f, op, itr; kw...) = mapfoldr_impl(f, op, kw.data, Iterators.reverse(itr))
+mapfoldr(f, op, itr; kw...) = mapfoldr_impl(f, op, kw.data, itr)
 
 
 """

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -31,7 +31,7 @@ using .Main.OffsetArrays
 @test Base.mapfoldr(abs2, -, 2:5) == -14
 @test Base.mapfoldr(abs2, -, 2:5; init=10) == -4
 
-@test foldr((x, y) -> ('⟨' * x * '|' * y * '⟩'), "⟨λ|⟨ |⟨x|⟨.|y⟩⟩⟩⟩" # issue #31780
+@test foldr((x, y) -> ('⟨' * x * '|' * y * '⟩'), "λ 🐨.α") == "⟨λ|⟨ |⟨🐨|⟨.|α⟩⟩⟩⟩" # issue #31780
 
 # reduce
 @test reduce(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -32,6 +32,10 @@ using .Main.OffsetArrays
 @test Base.mapfoldr(abs2, -, 2:5; init=10) == -4
 
 @test foldr((x, y) -> ('⟨' * x * '|' * y * '⟩'), "λ 🐨.α") == "⟨λ|⟨ |⟨🐨|⟨.|α⟩⟩⟩⟩" # issue #31780
+let x = rand(10)
+    @test 0 == @allocated(sum(Iterators.reverse(x)))
+    @test 0 == @allocated(foldr(-, x))
+end
 
 # reduce
 @test reduce(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -31,6 +31,8 @@ using .Main.OffsetArrays
 @test Base.mapfoldr(abs2, -, 2:5) == -14
 @test Base.mapfoldr(abs2, -, 2:5; init=10) == -4
 
+@test foldr((x, y) -> (x * '|' * y), "λ x.x") == "λ| |x|.|x" # issue #31780
+
 # reduce
 @test reduce(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)
 @test reduce(+, Int16[]) === Int16(0) # In reference to issues #21536

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -31,7 +31,7 @@ using .Main.OffsetArrays
 @test Base.mapfoldr(abs2, -, 2:5) == -14
 @test Base.mapfoldr(abs2, -, 2:5; init=10) == -4
 
-@test foldr((x, y) -> (x * '|' * y), "λ x.x") == "λ| |x|.|x" # issue #31780
+@test foldr((x, y) -> ('⟨' * x * '|' * y * '⟩'), "⟨λ|⟨ |⟨x|⟨.|y⟩⟩⟩⟩" # issue #31780
 
 # reduce
 @test reduce(+, Int64[]) === Int64(0) # In reference to issue #20144 (PR #20160)


### PR DESCRIPTION
This is an alternate version of #25520 (and #24833) that avoids wrapping `op` in a `Switch` type.    Rationale: avoids potential complications of overloading `mapreduce_empty_iter` and `mapreduce_first` discussed in https://github.com/JuliaLang/julia/pull/25520/files#r277144296, at a slight cost in code size.

Fixes #31780.  Closes #25520.  Fixes #24823.

Performance-wise it seems roughly identical to `master` in a simple benchmarks as I mentioned in #25520, ~~though for some reason `@btime` is now reporting `(1 allocation: 16 bytes)` whereas there were zero allocations before~~ (*update*: now fixed, see below).