### PR TITLE
Different invalid SSAValue for unexpected initial_incoming_vals

### DIFF
--- a/base/compiler/ssair/slot2ssa.jl
+++ b/base/compiler/ssair/slot2ssa.jl
@@ -653,7 +653,7 @@ function construct_ssa!(ci::CodeInfo, code::Vector{Any}, ir::IRCode, domtree::Do
         elseif !defuse[x].any_newvar
             undef_token
         else
-            SSAValue(-1)
+            SSAValue(-2)
         end for x in 1:length(ci.slotflags)
     ]
     worklist = Tuple{Int, Int, Vector{Any}}[(1, 0, initial_incoming_vals)]


### PR DESCRIPTION
There are two conditions for which we use negative SSAValues,
to trigger errors later if those values get used.

I figure we might as well make those different values,
because that will make debugging anything that goes wrong easier.

I say this after thinking I was debugging one kind of error, but I was actually debugging another.