### PR TITLE
fix droptol! docstrings

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -1225,7 +1225,7 @@ triu!(A::SparseMatrixCSC, k::Integer = 0, trim::Bool = true) =
 """
     droptol!(A::SparseMatrixCSC, tol; trim::Bool = true)
 
-Removes stored values from `A` whose absolute value is (strictly) larger than `tol`,
+Removes stored values from `A` whose absolute value is less than or equal to `tol`,
 optionally trimming resulting excess space from `A.rowval` and `A.nzval` when `trim`
 is `true`.
 """

--- a/stdlib/SparseArrays/src/sparsevector.jl
+++ b/stdlib/SparseArrays/src/sparsevector.jl
@@ -1914,7 +1914,7 @@ end
 """
     droptol!(x::SparseVector, tol; trim::Bool = true)
 
-Removes stored values from `x` whose absolute value is (strictly) larger than `tol`,
+Removes stored values from `x` whose absolute value is less than or equal to `tol`,
 optionally trimming resulting excess space from `A.rowval` and `A.nzval` when `trim`
 is `true`.
 """


### PR DESCRIPTION
Fixes a typo introduced in #31286. If that one goes into v1.2, it would be good to have this fix also there, if possible.