### PR TITLE
A few missing tests for sparse broadcast styles and converters

### DIFF
--- a/stdlib/SparseArrays/test/higherorderfns.jl
+++ b/stdlib/SparseArrays/test/higherorderfns.jl
@@ -101,6 +101,8 @@ end
     fa, fA = Array(a), Array(A)
     @test broadcast(sin, a) == sparse(broadcast(sin, fa))
     @test broadcast(sin, A) == sparse(broadcast(sin, fA))
+    # also test the typed broadcast
+    @test broadcast(convert, Float32, A) == sparse(broadcast(convert, Float32, fA))
 end
 
 @testset "broadcast! implementation specialized for a single (input) sparse vector/matrix" begin
@@ -639,7 +641,7 @@ end
     @test_broken ((_, _, _, _, x) -> x).(Int, Int, Int, Int, spzeros(3)) == spzeros(3)
 end
 
-using SparseArrays.HigherOrderFns: SparseVecStyle
+using SparseArrays.HigherOrderFns: SparseVecStyle, SparseMatStyle
 
 @testset "Issue #30120: method ambiguity" begin
     # HigherOrderFns._copy(f) was ambiguous.  It may be impossible to
@@ -679,6 +681,17 @@ end
     f(x, y, z) = x == y == z == 0 ? 0.0 : NaN
     y .= f.(x1, x2, x3)
     @test all(isnan, y)
+end
+
+@testset "Vec/Mat Style" begin
+    @test SparseVecStyle(Val(0)) == SparseVecStyle()
+    @test SparseVecStyle(Val(1)) == SparseVecStyle()
+    @test SparseVecStyle(Val(2)) == SparseMatStyle()
+    @test SparseVecStyle(Val(3)) == Broadcast.DefaultArrayStyle{3}()
+    @test SparseMatStyle(Val(0)) == SparseMatStyle()
+    @test SparseMatStyle(Val(1)) == SparseMatStyle()
+    @test SparseMatStyle(Val(2)) == SparseMatStyle()
+    @test SparseMatStyle(Val(3)) == Broadcast.DefaultArrayStyle{3}()
 end
 
 end # module

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -39,6 +39,13 @@ end
     @test SparseArrays.indtype(sparse(Int8[1,1],Int8[1,1],[1,1])) == Int8
 end
 
+@testset "conversion to AbstractMatrix/SparseMatrix of same eltype" begin
+    a = sprand(5, 5, 0.2)
+    @test AbstractMatrix{eltype(a)}(a) == a
+    @test SparseMatrixCSC{eltype(a)}(a) == a
+    @test SparseMatrixCSC{eltype(a), Int}(a) == a
+end
+
 @testset "sparse matrix construction" begin
     @test (A = fill(1.0+im,5,5); isequal(Array(sparse(A)), A))
     @test_throws ArgumentError sparse([1,2,3], [1,2], [1,2,3], 3, 3)
@@ -2339,6 +2346,15 @@ end
     @test SparseMatrixCSC(A') isa SparseMatrixCSC
     @test transpose(A) == SparseMatrixCSC(transpose(A))
     @test SparseMatrixCSC(transpose(A)) isa SparseMatrixCSC
+    @test SparseMatrixCSC{eltype(A)}(transpose(A)) == transpose(A)
+    @test SparseMatrixCSC{eltype(A), Int}(transpose(A)) == transpose(A)
+    @test SparseMatrixCSC{Float16}(transpose(A)) == transpose(SparseMatrixCSC{Float16}(A))
+    @test SparseMatrixCSC{Float16, Int}(transpose(A)) == transpose(SparseMatrixCSC{Float16}(A))
+    B = sprand(ComplexF64, 10, 10, 0.75)
+    @test SparseMatrixCSC{eltype(B)}(adjoint(B)) == adjoint(B)
+    @test SparseMatrixCSC{eltype(B), Int}(adjoint(B)) == adjoint(B)
+    @test SparseMatrixCSC{ComplexF16}(adjoint(B)) == adjoint(SparseMatrixCSC{ComplexF16}(B))
+    @test SparseMatrixCSC{ComplexF16, Int8}(adjoint(B)) == adjoint(SparseMatrixCSC{ComplexF16, Int8}(B))
 end
 
 # PR 28242


### PR DESCRIPTION
These guys seem not to be covered according to the [latest coverage build](https://codecov.io/gh/JuliaLang/julia/tree/master/stdlib/SparseArrays).