### PR TITLE
fix incorrect error path in `schedule`

### DIFF
--- a/base/task.jl
+++ b/base/task.jl
@@ -457,12 +457,12 @@ true
 """
 function schedule(t::Task, @nospecialize(arg); error=false)
     # schedule a task to be (re)started with the given value or exception
-    t.state == :runnable || error("schedule: Task not runnable")
+    t.state == :runnable || Base.error("schedule: Task not runnable")
     if error
         t.queue === nothing || Base.list_deletefirst!(t.queue, t)
         t.exception = arg
     else
-        t.queue === nothing || error("schedule: Task not runnable")
+        t.queue === nothing || Base.error("schedule: Task not runnable")
         t.result = arg
     end
     enq_work(t)

--- a/test/channels.jl
+++ b/test/channels.jl
@@ -389,3 +389,9 @@ let a = Ref(0)
     GC.gc()
     @test a[] == 1
 end
+
+# trying to `schedule` a finished task
+let t = @async nothing
+    wait(t)
+    @test_throws ErrorException("schedule: Task not runnable") schedule(t, nothing)
+end


### PR DESCRIPTION
This was trying to call its boolean argument instead of throwing the intended error.