### PR TITLE
Remove reference to "if unsure if a bug" in issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,5 @@
-If you have a question or are unsure if the behavior you're experiencing is a bug,
-please search or post to our Discourse site: https://discourse.julialang.org. We use
-the GitHub issue tracker for bug reports and feature requests only.
+If you have a question please search or post to our Discourse site: https://discourse.julialang.org.
+We use the GitHub issue tracker for bug reports and feature requests only.
 
 If you're submitting a bug report, be sure to include as much relevant information as
 possible, including a minimal reproducible example and the output of `versioninfo()`.


### PR DESCRIPTION
After the following exchange in the[ Stack Overflow comments:](https://stackoverflow.com/a/55602639/179081)

>  - The iteration thing is intentional, the lastindex thing I do not think is. idx[end] makes sense as a thing to do. Would you care to raise an issue? – Lyndon White Apr 10 at 8:03  
>  - @LyndonWhite I asked about this on Discourse but didn't get a response from anyone (and it has been over a week now)... – Colin T Bowers 15 hours ago
>  - Issues belong on github, not on discourse. Even potential issues that get rapidly closed as being features, or stemming from user error still belong on GitHub – Lyndon White 12 hours ago  
> - @LyndonWhite I actually did start at the GitHub issues page, but was put off by the default banner: If you have a question or are unsure if the behavior you're experiencing is a bug, please search or post to our Discourse site. I've opened an issue now #31815 – Colin T Bowers 10 hours ago


I stand by my comment:
Bug reports (even "incorrect" ones), are much better handled here than on Discourse.
 - People who watch the issues here are a different (overlapping) group to those who read discourse.
 - In particular they are more likey to know if something was implemented with a particular behavour.
 - People looking to see if something is a bug look in issues. And the closed issues act as a sign-post to tell them it isn't.

I think that exchange quoted above, shows this language is indeed directing people with legit issues away to discourse where they get silence for over a week. Vs raising an issue which got a response in <5 hours. By someone who is rarely on Discourse.