### PR TITLE
Short-circuit deepcopy for bits types

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -25,7 +25,10 @@ so far within the recursion. Within the definition, `deepcopy_internal` should b
 in place of `deepcopy`, and the `dict` variable should be
 updated as appropriate before returning.
 """
-deepcopy(x) = deepcopy_internal(x, IdDict())::typeof(x)
+function deepcopy(x)
+    isbitstype(typeof(x)) && return x
+    return deepcopy_internal(x, IdDict())::typeof(x)
+end
 
 deepcopy_internal(x::Union{Symbol,Core.MethodInstance,Method,GlobalRef,DataType,Union,UnionAll,Task,Regex},
                   stackdict::IdDict) = x

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -93,6 +93,16 @@ end
     @test isempty(rgx1.captures)
 end
 
+@testset "deepcopy for bits types" begin
+    struct Immutable; x::Int; end
+    mutable struct Mutable; x::Int; end
+
+    @test deepcopy(Immutable(2)) === Immutable(2)
+    @test deepcopy(Mutable(2))   !== Mutable(2)
+    @inferred deepcopy(Immutable(2))
+    @inferred deepcopy(Mutable(2))
+end
+
 # issue #30911
 @test deepcopy(Array{Int,N} where N) == Array{Int,N} where N
 


### PR DESCRIPTION
This allows the compiler to elide the entire deepcopy call in these cases.

Example:
```julia
    julia> struct Foo; i::Int; end

    julia> @code_warntype deepcopy(Foo(1))
    Variables
      #self#::Core.Compiler.Const(deepcopy, false)
      x::Foo

    Body::Foo
    1 ─ %1 = Base.IdDict()::IdDict{Any,Any}
    │   %2 = Base.deepcopy_internal(x, %1)::Foo
    │   %3 = Base.typeof(x)::Core.Compiler.Const(Foo, false)
    │   %4 = Core.typeassert(%2, %3)::Foo
    └──      return %4

    julia> function fastdeepcopy(a)
               isbitstype(typeof(a)) && return a
               return deepcopy(a)
           end
    fastdeepcopy (generic function with 1 method)

    julia> @code_warntype fastdeepcopy(Foo(1))
    Variables
      #self#::Core.Compiler.Const(fastdeepcopy, false)
      a::Foo

    Body::Foo
    1 ─ %1 = Main.typeof(a)::Core.Compiler.Const(Foo, false)
    │   %2 = Main.isbitstype(%1)::Core.Compiler.Const(true, true)
    │        %2
    └──      return a
    2 ─      Core.Compiler.Const(:(goto %7), false)
    │        Core.Compiler.Const(false, false)
    │        Core.Compiler.Const(:(Main.deepcopy(a)), false)
    └──      Core.Compiler.Const(:(return %7), false)

    julia> @code_native fastdeepcopy(Foo(1))
            .text
    ; ┌ @ REPL[12]:2 within `fastdeepcopy'
            movq	(%rdi), %rax
            retq
            nopw	%cs:(%rax,%rax)
    ; └
```