### PR TITLE
fix `deepcopy` on 0-field mutable structs

### DIFF
--- a/base/deepcopy.jl
+++ b/base/deepcopy.jl
@@ -53,8 +53,7 @@ end
 
 function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
     T = typeof(x)::DataType
-    nf = nfields(x)
-    (isbitstype(T) || nf == 0) && return x
+    isbitstype(T) && return x
     if haskey(stackdict, x)
         return stackdict[x]
     end
@@ -62,7 +61,7 @@ function deepcopy_internal(@nospecialize(x), stackdict::IdDict)
     if T.mutable
         stackdict[x] = y
     end
-    for i in 1:nf
+    for i in 1:nfields(x)
         if isdefined(x,i)
             ccall(:jl_set_nth_field, Cvoid, (Any, Csize_t, Any), y, i-1,
                   deepcopy_internal(getfield(x,i), stackdict))

--- a/test/copy.jl
+++ b/test/copy.jl
@@ -176,3 +176,10 @@ end
         end
     end
 end
+
+# issue #17149
+mutable struct Bar17149
+end
+let x = Bar17149()
+    @test deepcopy(x) !== x
+end


### PR DESCRIPTION
It looks like we forgot to change this with the fix for #17149.