### PR TITLE
Allow more circular type definitions

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1068,6 +1068,7 @@ static jl_value_t *normalize_vararg(jl_value_t *va)
     return va;
 }
 
+int obviously_egal(jl_value_t *a, jl_value_t *b);
 static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value_t **iparams, size_t ntp,
                                        int cacheable, jl_typestack_t *stack, jl_typeenv_t *env)
 {
@@ -1088,7 +1089,7 @@ static jl_value_t *inst_datatype_inner(jl_datatype_t *dt, jl_svec_t *p, jl_value
             // normalize types equal to wrappers (prepare for wrapper_id)
             jl_value_t *tw = extract_wrapper(pi);
             if (tw && tw != pi && (tn != jl_type_typename || jl_typeof(pi) == jl_typeof(tw)) &&
-                    jl_types_equal(pi, tw)) {
+                    obviously_egal(pi, tw)) {
                 iparams[i] = tw;
                 if (p) jl_gc_wb(p, tw);
             }

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -186,7 +186,7 @@ static void restore_env(jl_stenv_t *e, jl_value_t *root, jl_savedenv_t *se) JL_N
 // type utilities
 
 // quickly test that two types are identical
-static int obviously_egal(jl_value_t *a, jl_value_t *b)
+int obviously_egal(jl_value_t *a, jl_value_t *b)
 {
     if (a == b) return 1;
     if (jl_typeof(a) != jl_typeof(b)) return 0;

--- a/test/core.jl
+++ b/test/core.jl
@@ -226,6 +226,14 @@ let elT = T22624.body.body.body.types[1].parameters[1]
     @test elT2.body.types[1].parameters[1] === elT2
     @test Base.isconcretetype(elT2.body.types[1])
 end
+struct T22624b{A,B,C}; v::Vector{T22624b{Integer,A}}; end
+let elT = T22624b.body.body.body.types[1].parameters[1]
+    @test elT == T22624b{Integer, T22624b.var, C} where C
+    elT2 = elT.body.types[1].parameters[1]
+    @test elT2 == T22624b{Integer, Integer, C} where C
+    @test elT2.body.types[1].parameters[1] === elT2
+    @test Base.isconcretetype(elT2.body.types[1])
+end
 
 # issue #3890
 mutable struct A3890{T1}


### PR DESCRIPTION
Checking `jl_types_equal` against a potential wrapper when trying to normalize type parameters can result in an infinite recursion for circular type definitions. E.g.:
```julia
julia> struct T22624{A,B,C}; v::Vector{T22624{Int64,A}}; end # ok and tested for

julia> struct T22624b{A,B,C}; v::Vector{T22624b{Integer,A}}; end
ERROR: StackOverflowError:
```
Notably, the former only works due to an invalid fast-path, making it also recurse infinitely in #25796 and #31807 (without appropriate countermeasures). The culprit is that `jl_types_equal` needs to `rename_unionall` here, which tries to re-instantiate the same type (with another typevar), which comes to same test again. The obvious counter-measure is to avoid `jl_types_equal` and instead use a heuristic that may miss opportunities for normalization, but will not lead to recursion. As a starter, I'm using `obviously_egal` here, which fixes above issue, but may be too restrictive, e.g.
```julia
julia> Ref{Array{T,N} where {N,T}}
Ref{Array} # master
Ref{Array{T,N} where T where N} # using obviously_egal
```
Tests still pass, but we probably miss some optimization opportunities this way. Though I have no idea how much impact this actually has, so it might even be ok like this.

Discussion of this started in #25796, but this issue is somewhat independent, so for the sake of more focused discussions, I'm opening this draft PR.
