### PR TITLE
Remove definitions for `reduce` over `&`/`|` for unknown eltype collections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@ New language features
 Language changes
 ----------------
 
+* `reduce`/`mapreduce` using `&` and `|` as an operator over empty collections of unknown element type will throw an error instead of returning `true`/`false` ([#31635], [#31837]).
 
 Multi-threading changes
 -----------------------

--- a/base/reduce.jl
+++ b/base/reduce.jl
@@ -255,14 +255,12 @@ mapreduce_empty(f, op, T) = _empty_reduce_error()
 mapreduce_empty(::typeof(identity), op, T) = reduce_empty(op, T)
 mapreduce_empty(::typeof(abs), op, T)      = abs(reduce_empty(op, T))
 mapreduce_empty(::typeof(abs2), op, T)     = abs2(reduce_empty(op, T))
-
-mapreduce_empty(f::typeof(abs),  ::typeof(max), T) = abs(zero(T))
-mapreduce_empty(f::typeof(abs2), ::typeof(max), T) = abs2(zero(T))
+mapreduce_empty(::typeof(abs),  ::typeof(max), T) = abs(zero(T))
+mapreduce_empty(::typeof(abs2), ::typeof(max), T) = abs2(zero(T))
 
 mapreduce_empty_iter(f, op, itr, ::HasEltype) = mapreduce_empty(f, op, eltype(itr))
-mapreduce_empty_iter(f, op::typeof(&), itr, ::EltypeUnknown) = true
-mapreduce_empty_iter(f, op::typeof(|), itr, ::EltypeUnknown) = false
-mapreduce_empty_iter(f, op, itr, ::EltypeUnknown) = _empty_reduce_error()
+mapreduce_empty_iter(f, op, itr, ::EltypeUnknown) = mapreduce_empty(f, op, Any)
+
 
 # handling of single-element iterators
 """

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -110,7 +110,7 @@ end
     @test mean(skipmissing(Int[])) isa Float64
     @test_throws MethodError mean([])
     @test_throws MethodError mean(skipmissing([]))
-    @test_throws ArgumentError mean((1 for i in 2:1))
+    @test_throws MethodError mean((1 for i in 2:1))
 
     # Check that small types are accumulated using wider type
     for T in (Int8, UInt8)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -366,6 +366,12 @@ A = circshift(reshape(1:24,2,3,4), (0,1,1))
 @test @inferred all(x->x>0, [4]) == true
 @test @inferred all(x->x>0, [-3, 4, 5]) == false
 
+# issues #31635/#31837
+@test_throws ArgumentError reduce(&,[])
+@test reduce(&,Bool[]) == true
+@test_throws ArgumentError reduce(|,[])
+@test reduce(|,Bool[]) == false
+
 @test reduce((a, b) -> a .| b, fill(trues(5), 24))  == trues(5)
 @test reduce((a, b) -> a .| b, fill(falses(5), 24)) == falses(5)
 @test reduce((a, b) -> a .& b, fill(trues(5), 24))  == trues(5)

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -489,7 +489,7 @@ end
 # issue #18695
 test18695(r) = sum( t^2 for t in r )
 @test @inferred(test18695([1.0,2.0,3.0,4.0])) == 30.0
-@test_throws ArgumentError test18695(Any[])
+@test_throws MethodError test18695(Any[])
 
 # issue #21107
 @test foldr(-,2:2) == 2

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -287,7 +287,7 @@ call2(f,x,y) = f(x,y)
 @test (call2(42,1) do x,y; x+y+1 end) == 44
 
 # definitions using comparison syntax
-let a⊂b = reduce(&, x ∈ b for x in a) && length(b)>length(a)
+let a⊂b = all(x ∈ b for x in a) && length(b)>length(a)
     @test [1,2] ⊂ [1,2,3,4]
     @test !([1,2] ⊂ [1,3,4])
     @test !([1,2] ⊂ [1,2])


### PR DESCRIPTION
Fixes #31635/#31837.