### PR TITLE
Include Test.{Result, Pass, Fail, Error, Broken} in documentation

### DIFF
--- a/stdlib/Test/docs/src/index.md
+++ b/stdlib/Test/docs/src/index.md
@@ -258,6 +258,16 @@ in the test set reporting. The test will not run but gives a `Broken` `Result`.
 Test.@test_skip
 ```
 
+## Test result types
+
+```@docs
+Test.Result
+Test.Pass
+Test.Fail
+Test.Error
+Test.Broken
+```
+
 ## Creating Custom `AbstractTestSet` Types
 
 Packages can create their own `AbstractTestSet` subtypes by implementing the `record` and `finish`

--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -70,7 +70,7 @@ end
 @nospecialize
 
 """
-    Result
+    Test.Result
 
 All tests produce a result object. This object may or may not be
 stored, depending on whether the test is part of a test set.
@@ -78,7 +78,7 @@ stored, depending on whether the test is part of a test set.
 abstract type Result end
 
 """
-    Pass
+    Test.Pass <: Test.Result
 
 The test condition was true, i.e. the expression evaluated to true or
 the correct exception was thrown.
@@ -108,7 +108,7 @@ function Base.show(io::IO, t::Pass)
 end
 
 """
-    Fail
+    Test.Fail <: Test.Result
 
 The test condition was false, i.e. the expression evaluated to false or
 the correct exception was not thrown.
@@ -168,7 +168,7 @@ function Base.show(io::IO, t::Fail)
 end
 
 """
-    Error
+    Test.Error <: Test.Result
 
 The test condition couldn't be evaluated due to an exception, or
 it evaluated to something other than a [`Bool`](@ref).
@@ -249,7 +249,7 @@ function Base.show(io::IO, t::Error)
 end
 
 """
-    Broken
+    Test.Broken <: Test.Result
 
 The test condition is the expected (failed) result of a broken test,
 or was explicitly skipped with `@test_skip`.


### PR DESCRIPTION
The docstrings of the public API are already referring to `Test.Result` and its subtypes.  Also, querying test results seems to be a popular demand [1].  So, I think it makes sense to signal that they are public API by including them in the documentation.

[1] For example, it would be nice if the exception thrown in `@test_throws` can be accessed.  It can be done by

```julia
result = @test_throws Exception f()
@test occursin("error message", sprint(showerror, result.value))
```

However, since `Pass` and its fields are not documented, I cannot use this API (see also https://discourse.julialang.org/t/19224).  Another example is to provide debug info upon test failure #31495.
