### PR TITLE
Fix edit when command is set to Visual Studio code

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -54,7 +54,7 @@ function edit(path::AbstractString, line::Integer=0)
         cmd = line != 0 ? `$command $path -l $line` : `$command $path`
     elseif startswith(name, "subl") || startswith(name, "atom")
         cmd = line != 0 ? `$command $path:$line` : `$command $path`
-    elseif name == "code" || (Sys.iswindows() && uppercase(name) == "CODE.EXE")
+    elseif name == "code" || (Sys.iswindows() && (uppercase(name) == "CODE.EXE" || uppercase(name) == "CODE.CMD"))
         cmd = line != 0 ? `$command -g $path:$line` : `$command -g $path`
     elseif startswith(name, "notepad++")
         cmd = line != 0 ? `$command $path -n$line` : `$command $path`


### PR DESCRIPTION
~~By default VS Code adds `code.cmd` to path. Thus simply setting the `JULIA_EDITOR=code` (the obvious thing) will fail since julia, without knowing it is a cmd, assumes it is an exe. The logic here is thus special cased.~~   

I decided to refrain from making this change in this PR (see the last comment) 

This  fixes the incorrect fall through in the  scenario where the user sets `JULIA_EDITOR=code.cmd`, since ` name == "code" || (Sys.iswindows() && uppercase(name) == "CODE.EXE")`  does not capture this case, which prevents line information passing through.

 `JULIA_EDITOR=code.cmd`, should work since `code.cmd` is added to path by VS Code.

