### PR TITLE
Wrap module init in try/catch for error reporting

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -824,7 +824,17 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         int i, l = jl_array_len(init_order);
         for (i = 0; i < l; i++) {
             jl_value_t *mod = jl_array_ptr_ref(init_order, i);
-            jl_module_run_initializer((jl_module_t*)mod);
+            JL_TRY {
+                jl_module_run_initializer((jl_module_t*)mod);
+            }
+            JL_CATCH {
+                jl_printf(JL_STDERR, "error during sysimg module initializer:\n");
+                jl_static_show(JL_STDERR, jl_current_exception());
+                jl_printf(JL_STDERR, "\nWhen initializing module: ");
+                jl_static_show(JL_STDERR, mod);
+                jl_printf(JL_STDERR, "\n");
+                jl_exit(1);
+            }
         }
         JL_GC_POP();
     }


### PR DESCRIPTION
If julia segfaults while initializing modules when loading its sysimg
(such as, e.g., when running a statically compiled julia program), it
just segfaults without any error reporting. This makes it _very_
difficult to determine the cause of the crash.

This PR adds error reporting for module initialization by wrapping the module initializers in `JL_TRY` / `JL_CATCH`.


NOTE: The user cannot put a `JL_TRY` / `JL_CATCH` around `julia_init(...)`, because julia hasn't been initialized yet so the `JL_TRY` will segfault when attempting to initialize the exceptions array. So to get useful error reporting from exceptions thrown inside a module's `__init__()` method, we really need the try/catch to be a part of the definition of `julia_init()`.