### PR TITLE
Recover meta nodes in replace_code_newstyle

### DIFF
--- a/base/compiler/ssair/legacy.jl
+++ b/base/compiler/ssair/legacy.jl
@@ -57,6 +57,12 @@ function replace_code_newstyle!(ci::CodeInfo, ir::IRCode, nargs::Int)
     ci.linetable = ir.linetable
     ci.ssavaluetypes = ir.types
     ci.ssaflags = ir.flags
+    for metanode in ir.meta
+        push!(ci.code, metanode)
+        push!(ci.codelocs, 1)
+        push!(ci.ssavaluetypes, Any)
+        push!(ci.ssaflags, 0x00)
+    end
     # Translate BB Edges to statement edges
     # (and undo normalization for now)
     for i = 1:length(ci.code)

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -87,3 +87,12 @@ for compile in ("min", "yes")
         error("Interpreter test failed, cmd : $cmd")
     end
 end
+
+# Issue #27104
+# Test whether meta nodes are still present after code optimization.
+let
+    @noinline f(x, y) = x + y
+    @test any(code_typed(f)[1][1].code) do ex
+        Meta.isexpr(ex, :meta)
+    end
+end

--- a/test/llvmpasses/noinline.jl
+++ b/test/llvmpasses/noinline.jl
@@ -1,0 +1,21 @@
+# This file is a part of Julia. License is MIT: https://julialang.org/license
+
+# RUN: julia --startup-file=no %s %t && llvm-link -S %t/* -o %t/module.ll
+# RUN: cat %t/module.ll | FileCheck %s
+
+## Notes:
+# This script uses the `emit` function (defined llvmpasses.jl) to emit either
+# optimized or unoptimized LLVM IR. Each function is emitted individually and
+# `llvm-link` is used to create a single module that can be passed to opt.
+# The order in which files are emitted and linked is important since `lit` will
+# process the test cases in order.
+
+include(joinpath("..", "testhelpers", "llvmpasses.jl"))
+
+# CHECK-LABEL: @julia_simple_noinline
+@noinline function simple_noinline(A, B)
+    return A + B
+end
+
+# CHECK: attributes #{{[0-9]+}} = {{{([a-z]+ )*}} noinline {{([a-z]+ )*}}}
+emit(simple_noinline, Float64, Float64)


### PR DESCRIPTION
Fix for issue #27104. Meta nodes in `ir.meta` are appended to `ci.code`.