### PR TITLE
types: lazy initialize the field-types when first needed

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -338,7 +338,7 @@ function nfields_tfunc(@nospecialize(x))
     x = widenconst(x)
     if isa(x, DataType) && !x.abstract && !(x.name === Tuple.name && isvatuple(x))
         if !(x.name === _NAMEDTUPLE_NAME && !isconcretetype(x))
-            return Const(length(x.types))
+            return Const(isdefined(x, :types) ? length(x.types) : length(x.name.names))
         end
     end
     return Int
@@ -588,7 +588,7 @@ function fieldcount_noerror(@nospecialize t)
     if abstr
         return nothing
     end
-    return length(t.types)
+    return isdefined(t, :types) ? length(t.types) : length(t.name.names)
 end
 
 
@@ -744,7 +744,8 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
         # TODO: better approximate inference
         return Any
     end
-    if isempty(s.types)
+    ftypes = datatype_fieldtypes(s)
+    if isempty(ftypes)
         return Bottom
     end
     if isa(name, Conditional)
@@ -754,27 +755,27 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
         if !(Int <: name || Symbol <: name)
             return Bottom
         end
-        if length(s.types) == 1
-            return rewrap_unionall(unwrapva(s.types[1]), s00)
+        if length(ftypes) == 1
+            return rewrap_unionall(unwrapva(ftypes[1]), s00)
         end
         # union together types of all fields
         t = Bottom
-        for _ft in s.types
+        for _ft in ftypes
             t = tmerge(t, rewrap_unionall(unwrapva(_ft), s00))
             t === Any && break
         end
         return t
     end
     fld = name.val
-    if isa(fld,Symbol)
+    if isa(fld, Symbol)
         fld = fieldindex(s, fld, false)
     end
-    if !isa(fld,Int)
+    if !isa(fld, Int)
         return Bottom
     end
-    nf = length(s.types)
-    if s <: Tuple && fld >= nf && isvarargtype(s.types[nf])
-        return rewrap_unionall(unwrapva(s.types[nf]), s00)
+    nf = length(ftypes)
+    if s <: Tuple && fld >= nf && isvarargtype(ftypes[nf])
+        return rewrap_unionall(unwrapva(ftypes[nf]), s00)
     end
     if fld < 1 || fld > nf
         return Bottom
@@ -790,7 +791,7 @@ function getfield_tfunc(@nospecialize(s00), @nospecialize(name))
         t = const_datatype_getfield_tfunc(sp, fld)
         t !== nothing && return t
     end
-    R = s.types[fld]
+    R = ftypes[fld]
     if isempty(s.parameters)
         return R
     end
@@ -843,7 +844,7 @@ function _fieldtype_nothrow(@nospecialize(s), exact::Bool, name::Const)
         fld = fieldindex(u, fld, false)
     end
     isa(fld, Int) || return false
-    ftypes = u.types
+    ftypes = datatype_fieldtypes(u)
     nf = length(ftypes)
     (fld >= 1 && fld <= nf) || return false
     if u.name === Tuple.name && fld >= nf && isvarargtype(ftypes[nf])
@@ -893,7 +894,7 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
         # TODO: better approximate inference
         return Type
     end
-    ftypes = u.types
+    ftypes = datatype_fieldtypes(u)
     if isempty(ftypes)
         return Bottom
     end

--- a/base/show.jl
+++ b/base/show.jl
@@ -1729,7 +1729,7 @@ function dump(io::IOContext, x::DataType, n::Int, indent)
             end
         end
         fields = fieldnames(x)
-        fieldtypes = x.types
+        fieldtypes = datatype_fieldtypes(x)
         for idx in 1:length(fields)
             println(io)
             print(io, indent, "  ", fields[idx], "::")

--- a/base/summarysize.jl
+++ b/base/summarysize.jl
@@ -89,7 +89,9 @@ function (ss::SummarySize)(obj::DataType)
     size::Int = 7 * Core.sizeof(Int) + 6 * Core.sizeof(Int32)
     size += 4 * nfields(obj) + ifelse(Sys.WORD_SIZE == 64, 4, 0)
     size += ss(obj.parameters)::Int
-    size += ss(obj.types)::Int
+    if isdefined(obj, :types)
+        size += ss(obj.types)::Int
+    end
     return size
 end
 

--- a/src/array.c
+++ b/src/array.c
@@ -171,9 +171,10 @@ static inline int is_ntuple_long(jl_value_t *v)
 {
     if (!jl_is_tuple(v))
         return 0;
-    size_t nfields = jl_nfields(v);
-    for (size_t i = 0; i < nfields; i++) {
-        if (jl_field_type(jl_typeof(v), i) != (jl_value_t*)jl_long_type) {
+    jl_value_t *tt = jl_typeof(v);
+    size_t i, nfields = jl_nparams(tt);
+    for (i = 0; i < nfields; i++) {
+        if (jl_tparam(tt, i) != (jl_value_t*)jl_long_type) {
             return 0;
         }
     }

--- a/src/builtins.c
+++ b/src/builtins.c
@@ -752,7 +752,8 @@ static jl_value_t *get_fieldtype(jl_value_t *t, jl_value_t *f, int dothrow)
                 return (jl_value_t*)jl_any_type;
             return get_fieldtype(tt, f, dothrow);
         }
-        int nf = jl_field_count(st);
+        jl_svec_t *types = jl_get_fieldtypes(st);
+        int nf = jl_svec_len(types);
         if (nf > 0 && field_index >= nf-1 && st->name == jl_tuple_typename) {
             jl_value_t *ft = jl_field_type(st, nf-1);
             if (jl_is_vararg_type(ft))
@@ -790,8 +791,8 @@ JL_CALLABLE(jl_f_fieldtype)
 JL_CALLABLE(jl_f_nfields)
 {
     JL_NARGS(nfields, 1, 1);
-    jl_value_t *x = args[0];
-    return jl_box_long(jl_field_count(jl_typeof(x)));
+    jl_datatype_t *xt = (jl_datatype_t*)jl_typeof(args[0]);
+    return jl_box_long(jl_datatype_nfields(xt));
 }
 
 JL_CALLABLE(jl_f_isdefined)

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -202,7 +202,7 @@ unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *t)
     if (mask)
         return 0;               // nfields has more than two 1s
     assert(jl_datatype_nfields(t)==1);
-    jl_value_t *ty = jl_field_type(t, 0);
+    jl_value_t *ty = jl_field_type((jl_datatype_t*)t, 0);
     if (!jl_is_primitivetype(ty))
         // LLVM requires that a vector element be a primitive type.
         // LLVM allows pointer types as vector elements, but until a
@@ -301,9 +301,9 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         // based on whether its definition is self-referential
         if (w->types != NULL) {
             st->isbitstype = st->isconcretetype && !st->mutabl;
-            size_t i, nf = jl_field_count(st);
+            size_t i, nf = jl_svec_len(st->types);
             for (i = 0; i < nf; i++) {
-                jl_value_t *fld = jl_field_type(st, i);
+                jl_value_t *fld = jl_svecref(st->types, i);
                 if (st->isbitstype)
                     st->isbitstype = jl_is_datatype(fld) && ((jl_datatype_t*)fld)->isbitstype;
                 if (!st->zeroinit)
@@ -311,9 +311,9 @@ void jl_compute_field_offsets(jl_datatype_t *st)
             }
             if (st->isbitstype) {
                 st->isinlinealloc = 1;
-                size_t i, nf = jl_field_count(w);
+                size_t i, nf = jl_svec_len(w->types);
                 for (i = 0; i < nf; i++) {
-                    jl_value_t *fld = jl_field_type(w, i);
+                    jl_value_t *fld = jl_svecref(w->types, i);
                     if (references_name(fld, w->name)) {
                         st->isinlinealloc = 0;
                         st->isbitstype = 0;

--- a/src/dump.c
+++ b/src/dump.c
@@ -1458,7 +1458,7 @@ static jl_value_t *jl_deserialize_datatype(jl_serializer_state *s, int pos, jl_v
     dt->super = (jl_datatype_t*)jl_deserialize_value(s, (jl_value_t**)&dt->super);
     jl_gc_wb(dt, dt->super);
     dt->types = (jl_svec_t*)jl_deserialize_value(s, (jl_value_t**)&dt->types);
-    jl_gc_wb(dt, dt->types);
+    if (dt->types) jl_gc_wb(dt, dt->types);
 
     return (jl_value_t*)dt;
 }

--- a/src/gf.c
+++ b/src/gf.c
@@ -421,13 +421,13 @@ static int very_general_type(jl_value_t *t)
 jl_value_t *jl_nth_slot_type(jl_value_t *sig, size_t i)
 {
     sig = jl_unwrap_unionall(sig);
-    size_t len = jl_field_count(sig);
+    size_t len = jl_nparams(sig);
     if (len == 0)
         return NULL;
     if (i < len-1)
         return jl_tparam(sig, i);
-    if (jl_is_vararg_type(jl_tparam(sig,len-1)))
-        return jl_unwrap_vararg(jl_tparam(sig,len-1));
+    if (jl_is_vararg_type(jl_tparam(sig, len-1)))
+        return jl_unwrap_vararg(jl_tparam(sig, len-1));
     if (i == len-1)
         return jl_tparam(sig, i);
     return NULL;
@@ -473,7 +473,7 @@ static void jl_compilation_sig(
     jl_value_t *decl = definition->sig;
     assert(jl_is_tuple_type(tt));
     size_t i, np = jl_nparams(tt);
-    size_t nargs = definition->nargs; // == jl_field_count(jl_unwrap_unionall(decl));
+    size_t nargs = definition->nargs; // == jl_nparams(jl_unwrap_unionall(decl));
     for (i = 0; i < np; i++) {
         jl_value_t *elt = jl_tparam(tt, i);
         jl_value_t *decl_i = jl_nth_slot_type(decl, i);
@@ -678,7 +678,7 @@ JL_DLLEXPORT int jl_isa_compileable_sig(
         return 0;
 
     size_t i, np = jl_nparams(type);
-    size_t nargs = definition->nargs; // == jl_field_count(jl_unwrap_unionall(decl));
+    size_t nargs = definition->nargs; // == jl_nparams(jl_unwrap_unionall(decl));
     if (np == 0)
         return nargs == 0;
 
@@ -2565,7 +2565,7 @@ int jl_has_concrete_subtype(jl_value_t *typ)
         return 1;
     if (((jl_datatype_t*)typ)->name == jl_namedtuple_typename)
         return jl_has_concrete_subtype(jl_tparam1(typ));
-    jl_svec_t *fields = ((jl_datatype_t*)typ)->types;
+    jl_svec_t *fields = jl_get_fieldtypes((jl_datatype_t*)typ);
     size_t i, l = jl_svec_len(fields);
     if (l != ((jl_datatype_t*)typ)->ninitialized)
         if (((jl_datatype_t*)typ)->name != jl_tuple_typename)

--- a/src/jlapi.c
+++ b/src/jlapi.c
@@ -394,6 +394,12 @@ JL_DLLEXPORT jl_value_t *(jl_typeof)(jl_value_t *v)
     return jl_typeof(v);
 }
 
+JL_DLLEXPORT jl_value_t *(jl_get_fieldtypes)(jl_value_t *v)
+{
+    return (jl_value_t*)jl_get_fieldtypes((jl_datatype_t*)v);
+}
+
+
 #ifndef __clang_analyzer__
 JL_DLLEXPORT int8_t (jl_gc_unsafe_enter)(void)
 {

--- a/src/julia.h
+++ b/src/julia.h
@@ -896,6 +896,8 @@ STATIC_INLINE void jl_array_uint8_set(void *a, size_t i, uint8_t x) JL_NOTSAFEPO
 #define jl_gf_name(f)   (jl_gf_mtable(f)->name)
 
 // struct type info
+JL_DLLEXPORT jl_svec_t *jl_compute_fieldtypes(jl_datatype_t *st);
+#define jl_get_fieldtypes(st) ((st)->types ? (st)->types : jl_compute_fieldtypes((st)))
 STATIC_INLINE jl_svec_t *jl_field_names(jl_datatype_t *st) JL_NOTSAFEPOINT
 {
     jl_svec_t *names = st->names;
@@ -907,8 +909,10 @@ STATIC_INLINE jl_sym_t *jl_field_name(jl_datatype_t *st, size_t i) JL_NOTSAFEPOI
 {
     return (jl_sym_t*)jl_svecref(jl_field_names(st), i);
 }
-#define jl_field_type(st,i)    jl_svecref(((jl_datatype_t*)st)->types, (i))
-#define jl_field_count(st)     jl_svec_len(((jl_datatype_t*)st)->types)
+STATIC_INLINE jl_value_t *jl_field_type(jl_datatype_t *st, size_t i)
+{
+    return jl_svecref(jl_get_fieldtypes(st), i);
+}
 #define jl_datatype_size(t)    (((jl_datatype_t*)t)->size)
 #define jl_datatype_align(t)   (((jl_datatype_t*)t)->layout->alignment)
 #define jl_datatype_nbits(t)   ((((jl_datatype_t*)t)->size)*8)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -2791,7 +2791,7 @@ static int num_occurs(jl_tvar_t *v, jl_typeenv_t *env);
 
 static jl_value_t *nth_tuple_elt(jl_datatype_t *t JL_PROPAGATES_ROOT, size_t i) JL_NOTSAFEPOINT
 {
-    size_t len = jl_field_count(t);
+    size_t len = jl_nparams(t);
     if (len == 0)
         return NULL;
     if (i < len-1)

--- a/test/core.jl
+++ b/test/core.jl
@@ -219,13 +219,16 @@ struct D21923{T,N}; v::D21923{T}; end
 
 # issue #22624, more circular definitions
 struct T22624{A,B,C}; v::Vector{T22624{Int64,A}}; end
-let elT = T22624.body.body.body.types[1].parameters[1]
+let ft = Base.datatype_fieldtypes
+    elT = T22624.body.body.body.types[1].parameters[1]
     @test elT == T22624{Int64, T22624.var, C} where C
-    elT2 = elT.body.types[1].parameters[1]
+    elT2 = ft(elT.body)[1].parameters[1]
     @test elT2 == T22624{Int64, Int64, C} where C
-    @test elT2.body.types[1].parameters[1] === elT2
-    @test Base.isconcretetype(elT2.body.types[1])
+    @test ft(elT2.body)[1].parameters[1] === elT2
+    @test Base.isconcretetype(ft(elT2.body)[1])
 end
+struct S22624{A,B,C} <: Ref{S22624{Int64,A}}; end
+@test @isdefined S22624
 
 # issue #3890
 mutable struct A3890{T1}
@@ -3459,15 +3462,22 @@ end
 mutable struct FooNTuple{N}
     z::Tuple{Integer, Vararg{Int, N}}
 end
-@test_throws ErrorException FooNTuple{-1}
-@test_throws ErrorException FooNTuple{typemin(Int)}
-@test_throws TypeError FooNTuple{0x01}
+for i in (-1, typemin(Int), 0x01)
+    T = FooNTuple{i}
+    @test T.parameters[1] == i
+    @test fieldtypes(T) == (Union{},)
+end
 @test fieldtype(FooNTuple{0}, 1) == Tuple{Integer}
 
 mutable struct FooTupleT{T}
     z::Tuple{Int, T, Int}
 end
-@test_throws TypeError FooTupleT{Vararg{Int, 2}}
+let R = Vararg{Int, 2}
+    @test_throws TypeError Val{R}
+    @test_throws TypeError Ref{R}
+    @test_throws TypeError FooTupleT{R}
+    @test_throws TypeError Union{R}
+end
 @test fieldtype(FooTupleT{Int}, 1) == NTuple{3, Int}
 
 @test Tuple{} === NTuple{0, Any}
@@ -4619,7 +4629,9 @@ mutable struct B12238{T,S}
 end
 @test B12238.body.body.types[1] === A12238{B12238{Int}.body}
 @test isa(A12238{B12238{Int}}.instance, A12238{B12238{Int}})
-@test !isdefined(B12238.body.body.types[1], :instance)  # has free type vars
+let ft = Base.datatype_fieldtypes
+    @test !isdefined(ft(B12238.body.body)[1], :instance)  # has free type vars
+end
 
 # issue #16315
 let a = Any[]
@@ -4732,8 +4744,10 @@ end
 mutable struct C16767{T}
     b::A16767{C16767{:a}}
 end
-@test B16767.body.types[1].types[1].parameters[1].types[1] === A16767{B16767.body}
-@test C16767.body.types[1].types[1].parameters[1].types[1] === A16767{C16767{:a}}
+let ft = Base.datatype_fieldtypes
+    @test ft(ft(B16767.body.types[1])[1].parameters[1])[1] === A16767{B16767.body}
+    @test ft(C16767.body.types[1].types[1].parameters[1])[1] === A16767{C16767{:a}}
+end
 
 # issue #16340
 function f16340(x::T) where T

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -293,13 +293,14 @@ try
                     some_method, Tuple{typeof(Base.include), String}, Core.svec(), typemax(UInt))
         @test Foo.some_linfo::Core.MethodInstance === some_linfo
 
-        PV = Foo.Value18343{Some}.body.types[1]
-        VR = PV.types[1].parameters[1]
-        @test PV.types[1] === Array{VR,1}
-        @test pointer_from_objref(PV.types[1]) ===
-              pointer_from_objref(PV.types[1].parameters[1].types[1].types[1])
-        @test PV === PV.types[1].parameters[1].types[1]
-        @test pointer_from_objref(PV) === pointer_from_objref(PV.types[1].parameters[1].types[1])
+        ft = Base.datatype_fieldtypes
+        PV = ft(Foo.Value18343{Some}.body)[1]
+        VR = ft(PV)[1].parameters[1]
+        @test ft(PV)[1] === Array{VR,1}
+        @test pointer_from_objref(ft(PV)[1]) ===
+              pointer_from_objref(ft(ft(ft(PV)[1].parameters[1])[1])[1])
+        @test PV === ft(ft(PV)[1].parameters[1])[1]
+        @test pointer_from_objref(PV) === pointer_from_objref(ft(ft(PV)[1].parameters[1])[1])
     end
 
     Baz_file = joinpath(dir, "Baz.jl")


### PR DESCRIPTION
For concrete datatypes, we still always initialize the fieldtypes
immediately (so that we can immediately also compute the layout and other
related properties).

Note that this implies that constructing the fieldtype is no longer part of
subtyping, (since construction no longer verifies these conditions), and so
impossible constraints now lead to a computed value of `Union{}` being given
for the type of that field, instead of throwing an error when trying to
allocate the type.

It might be possible to instead store this error, and rethrow it when someone
tries to construct a (partially initialized) copy of the type and/or when the
user (but not inference or introspection tools) tries to examine the fieldtype
of the object. But I think this extra complexity (and additional failure cases
to consider) isn't worthwhile to add.