### PR TITLE
Stop exporting dot from LinearAlgebra.BLAS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@ Standard library changes
 
 #### LinearAlgebra
 
+* The BLAS submodule no longer exports `dot`, which conflicts with that in LinearAlgebra ([#31838]).
 * `diagm` and `spdiagm` now accept optional `m,n` initial arguments to specify a size ([#31654]).
 
 #### SparseArrays

--- a/stdlib/LinearAlgebra/src/blas.jl
+++ b/stdlib/LinearAlgebra/src/blas.jl
@@ -15,7 +15,6 @@ export
     axpy!,
     axpby!,
     blascopy!,
-    dot,
     dotc,
     dotu,
     scal!,


### PR DESCRIPTION
LinearAlgebra exports the familiar `dot` function. The BLAS submodule has its own `dot` function, which it also exports, leading to problems if a user tries to access `dot` after `using` both LinearAlgebra and BLAS.

Because this conflict currently exists, this change should be non-breaking, as it's difficult to resolve `dot` unqualified from BLAS before it's resolved from LinearAlgebra, so pretty much any consumer must already calling `BLAS.dot` as such.

Fixes JuliaLang/LinearAlgebra.jl#626.