### PR TITLE
doc/build/windows: fix broken link & line breaks

### DIFF
--- a/doc/build/windows.md
+++ b/doc/build/windows.md
@@ -212,8 +212,8 @@ end
 ### Cross-building Julia without Vagrant
 
 If you don't care that the build is potentially incompatible with the WinRPM
-ecosystem (or happen to be on opensuse), use the following steps to cross-
-compile julia:
+ecosystem (or happen to be on opensuse), use the following steps to
+cross-compile julia:
 
 First, you will need to ensure your system has the required dependencies.  We
 need wine (>=1.7.5), a system compiler, and some downloaders.
@@ -244,9 +244,9 @@ in 32-bit mode).
 
 ## Debugging a cross-compiled build under wine
 
-The most effective way to debug a cross-compiled version of julia on the cross-
-compilation host is to install a windows version of gdb and run it under wine as
-usual. The pre-built packages available [as part of the MSYS2 project](
+The most effective way to debug a cross-compiled version of julia on the
+cross-compilation host is to install a windows version of gdb and run it under wine
+as usual. The pre-built packages available [as part of the MSYS2 project](
 https://sourceforge.net/projects/msys2/files/REPOS/MINGW/) are known to work.
 Apart from the GDB package you may also need the python and termcap packages.
 Finally, GDB's prompt may not work when launch from the command line. This can
@@ -256,7 +256,8 @@ be worked around by prepending `wineconsole` to the regular GDB invocation.
 ## Using a Windows VM
 
 [Vagrant](https://www.vagrantup.com/downloads.html) can also be used with a Windows
-guest VM via the `Vagrantfile` in [contrib/windows](contrib/windows/Vagrantfile),
+guest VM via the `Vagrantfile` in [contrib/windows](
+https://github.com/JuliaLang/julia/blob/master/contrib/windows/Vagrantfile),
 just run `vagrant up` from that folder.
 
 


### PR DESCRIPTION
The Vagrant file link pointed to the incorrect location [doc/build/contrib/windows/Vagrantfile](https://github.com/JuliaLang/julia/blob/master/doc/build/contrib/windows/Vagrantfile). Instead of a relative URL, an absolute one was used to point to the right place, [contrib/windows/Vagrantfile](https://github.com/JuliaLang/julia/blob/master/contrib/windows/Vagrantfile).

As for the line breaks: GitHub's markdown renderer wraps single line breaks into spaces, so some a couple instances of "cross-compilation" were incorrectly rendered as "cross- compilation". The line breaks after hyphens were removed to avoid this.