### PR TITLE
Make Refs compare equal when their contents are equal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ New language features
 Language changes
 ----------------
 
+* `Ref`s now compare equal under `==`, `isequal`, and `isapprox` when their wrapped values
+  compare equal ([#31813]).
 
 Multi-threading changes
 -----------------------

--- a/base/refvalue.jl
+++ b/base/refvalue.jl
@@ -31,3 +31,7 @@ unsafe_convert(::Type{Ptr{Cvoid}}, b::RefValue{T}) where {T} = convert(Ptr{Cvoid
 
 getindex(b::RefValue) = b.x
 setindex!(b::RefValue, x) = (b.x = x; b)
+
+(==)(a::RefValue, b::RefValue) = a.x == b.x
+isequal(a::RefValue, b::RefValue) = isequal(a.x, b.x)
+isapprox(a::RefValue, b::RefValue; kwargs...) = isapprox(a.x, b.x; kwargs...)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -733,3 +733,11 @@ end
 
 # Pointer 0-arg constructor
 @test Ptr{Cvoid}() == C_NULL
+
+@testset "Ref equality" begin
+    a = Ref(1)
+    b = Ref(1.0)
+    @test a == b
+    @test isequal(a, b)
+    @test a ≈ b
+end


### PR DESCRIPTION
Currently `Ref(a) == Ref(b)` is always `false`, even when `a == b`. This changes the behavior such that `Ref(a) == Ref(b)` if `a == b`, and likewise for `isequal` and `isapprox`.

Fixes #31813.