### PR TITLE
use Base._memcmp instead of ccall(:memcmp)

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -1387,7 +1387,7 @@ function empty!(a::Vector)
     return a
 end
 
-_memcmp(a, b, len) = ccall(:memcmp, Int32, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), a, b, len) % Int
+_memcmp(a, b, len) = ccall(:memcmp, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), a, b, len % Csize_t) % Int
 
 # use memcmp for cmp on byte arrays
 function cmp(a::Array{UInt8,1}, b::Array{UInt8,1})

--- a/base/parse.jl
+++ b/base/parse.jl
@@ -199,10 +199,8 @@ function tryparse_internal(::Type{Bool}, sbuff::Union{String,SubString{String}},
     len = endpos - startpos + 1
     p   = pointer(sbuff) + startpos - 1
     GC.@preserve sbuff begin
-        (len == 4) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-                                  p, "true", 4)) && (return true)
-        (len == 5) && (0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-                                  p, "false", 5)) && (return false)
+        (len == 4) && (0 == _memcmp(p, "true", 4)) && (return true)
+        (len == 5) && (0 == _memcmp(p, "false", 5)) && (return false)
     end
 
     if raise

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -92,17 +92,18 @@ end
 
 ## comparison ##
 
+_memcmp(a::Union{Ptr{UInt8},AbstractString}, b::Union{Ptr{UInt8},AbstractString}, len) = ccall(:memcmp, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), a, b, len % Csize_t) % Int
+
 function cmp(a::String, b::String)
     al, bl = sizeof(a), sizeof(b)
-    c = ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-              a, b, min(al,bl))
+    c = _memcmp(a, b, min(al,bl))
     return c < 0 ? -1 : c > 0 ? +1 : cmp(al,bl)
 end
 
 function ==(a::String, b::String)
     pointer_from_objref(a) == pointer_from_objref(b) && return true
     al = sizeof(a)
-    return al == sizeof(b) && 0 == ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt), a, b, al % UInt)
+    return al == sizeof(b) && 0 == _memcmp(a, b, al)
 end
 
 typemin(::Type{String}) = ""

--- a/base/strings/string.jl
+++ b/base/strings/string.jl
@@ -92,7 +92,8 @@ end
 
 ## comparison ##
 
-_memcmp(a::Union{Ptr{UInt8},AbstractString}, b::Union{Ptr{UInt8},AbstractString}, len) = ccall(:memcmp, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), a, b, len % Csize_t) % Int
+_memcmp(a::Union{Ptr{UInt8},AbstractString}, b::Union{Ptr{UInt8},AbstractString}, len) =
+    ccall(:memcmp, Cint, (Ptr{UInt8}, Ptr{UInt8}, Csize_t), a, b, len % Csize_t) % Int
 
 function cmp(a::String, b::String)
     al, bl = sizeof(a), sizeof(b)

--- a/base/strings/substring.jl
+++ b/base/strings/substring.jl
@@ -94,8 +94,7 @@ nextind(s::SubString{String}, i::Int) = _nextind_str(s, i)
 function cmp(a::SubString{String}, b::SubString{String})
     na = sizeof(a)
     nb = sizeof(b)
-    c = ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-              pointer(a), pointer(b), min(na, nb))
+    c = _memcmp(a, b, min(na, nb))
     return c < 0 ? -1 : c > 0 ? +1 : cmp(na, nb)
 end
 

--- a/base/strings/util.jl
+++ b/base/strings/util.jl
@@ -50,8 +50,7 @@ function startswith(a::Union{String, SubString{String}},
     cub = ncodeunits(b)
     if ncodeunits(a) < cub
         false
-    elseif ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-                 pointer(a), pointer(b), sizeof(b)) == 0
+    elseif _memcmp(a, b, sizeof(b)) == 0
         nextind(a, cub) == cub + 1
     else
         false
@@ -64,8 +63,7 @@ function endswith(a::Union{String, SubString{String}},
     astart = ncodeunits(a) - ncodeunits(b) + 1
     if astart < 1
         false
-    elseif ccall(:memcmp, Int32, (Ptr{UInt8}, Ptr{UInt8}, UInt),
-                 pointer(a, astart), pointer(b), sizeof(b)) == 0
+    elseif GC.@preserve(a, _memcmp(pointer(a, astart), b, sizeof(b))) == 0
         thisind(a, astart) == astart
     else
         false


### PR DESCRIPTION
This is mainly a minor code cleanup — we have a `Base._memcmp` internal wrapper around `ccall(:memcmp)` that we use in the array code, and it seemed cleaner to use a similar function in the string code.

It also seems like this catches a couple of potential rooting problems where we were doing `ccall(:memcmp)` on `pointer(somestring)` without calling `GC.@preserve`.