### PR TITLE
WIP: statistical allocation profiling

### DIFF
--- a/base/util.jl
+++ b/base/util.jl
@@ -21,6 +21,11 @@ end
 
 gc_num() = ccall(:jl_gc_num, GC_Num, ())
 
+# TODO(tkluck): not sure if it's necessary to expose these; we can alternatively just use
+# ccall in the Profile module.
+gc_get_statprofile_sample() = ccall(:jl_gc_get_statprofile_sample, Cdouble, ())
+gc_set_statprofile_sample!(n) = ccall(:jl_gc_set_statprofile_sample, Cvoid, (Cdouble,), n)
+
 # This type is to represent differences in the counters, so fields may be negative
 struct GC_Diff
     allocd      ::Int64 # Bytes allocated

--- a/src/gc.h
+++ b/src/gc.h
@@ -655,6 +655,9 @@ static inline void gc_scrub(void)
 }
 #endif
 
+double jl_gc_get_statprofile_sample(void);
+void jl_gc_set_statprofile_sample(double);
+
 #ifdef OBJPROFILE
 void objprofile_count(void *ty, int old, int sz) JL_NOTSAFEPOINT;
 void objprofile_printall(void);

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -42,7 +42,7 @@ line of code; backtraces generally consist of a long list of instruction pointer
 settings can be obtained by calling this function with no arguments, and each can be set
 independently using keywords or in the order `(n, delay)`.
 """
-function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} = nothing)
+function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} = nothing, alloc_rate::Real=0)
     n_cur = ccall(:jl_profile_maxlen_data, Csize_t, ())
     delay_cur = ccall(:jl_profile_delay_nsec, UInt64, ())/10^9
     if n === nothing && delay === nothing
@@ -53,11 +53,12 @@ function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} 
     init(nnew, delaynew)
 end
 
-function init(n::Integer, delay::Real)
+function init(n::Integer, delay::Real, alloc_rate::Real=0)
     status = ccall(:jl_profile_init, Cint, (Csize_t, UInt64), n, round(UInt64,10^9*delay))
     if status == -1
         error("could not allocate space for ", n, " instruction pointers")
     end
+    Base.gc_set_statprofile_sample!(alloc_rate)
 end
 
 # init with default values

--- a/stdlib/Profile/src/Profile.jl
+++ b/stdlib/Profile/src/Profile.jl
@@ -50,7 +50,7 @@ function init(; n::Union{Nothing,Integer} = nothing, delay::Union{Nothing,Real} 
     end
     nnew = (n === nothing) ? n_cur : n
     delaynew = (delay === nothing) ? delay_cur : delay
-    init(nnew, delaynew)
+    init(nnew, delaynew, alloc_rate)
 end
 
 function init(n::Integer, delay::Real, alloc_rate::Real=0)


### PR DESCRIPTION
Julia has a mature statistical profiler. It sets a timer that captures a backtrace when it is triggered. By the law of large numbers, this gives insight into where an algorithm spends its time, without noticably slowing the program down.

By comparison, finding out where the allocations are happening is quite a bit more cumbersome. It needs starting Julia with a specific command line switch, code execution is _much_ slower, and after program exit, the results are scattered over the file system.

This pull request represents an attempt at bringing the ergonomics of statistical _runtime_ profiling to allocations: "statistical _allocation_ profiling". Similar to how, in the former case, `Profile.init` configures a delay between backtraces, this branch add an option to specify a fraction of allocations that capture a backtrace.

Example usage:

```julia
using Profile
Profile.init(alloc_rate = 0.01)

doublefibonacci(n) = if n <= 2
    return [1, 1]
else
    return doublefibonacci(n - 1) .+ doublefibonacci(n - 2)
end
@profile for i=1:1000; doublefibonacci(15); end

Profile.print() # but better to use e.g. ProfileView or StatProfilerHTML
```

State of this commit:

 - linux support only
 - not thread-safe
 - no attempt at a friendly human interface; as it is, the `Profile.init` API almost encourages a linear combination of runtime and allocation profiling. That makes no sense at all.

I'm sending this as a WIP early so I can get feedback before investing time in productionizing this. What do you think?