### PR TITLE
Micro-optimization: remove unnecessary allocation

### DIFF
--- a/base/number.jl
+++ b/base/number.jl
@@ -80,7 +80,7 @@ function getindex(x::Number, i::Integer)
 end
 function getindex(x::Number, I::Integer...)
     @_inline_meta
-    @boundscheck all([i == 1 for i in I]) || throw(BoundsError())
+    @boundscheck all(i == 1 for i in I) || throw(BoundsError())
     x
 end
 first(x::Number) = x

--- a/base/number.jl
+++ b/base/number.jl
@@ -80,7 +80,7 @@ function getindex(x::Number, i::Integer)
 end
 function getindex(x::Number, I::Integer...)
     @_inline_meta
-    @boundscheck all(i == 1 for i in I) || throw(BoundsError())
+    @boundscheck all(isone, I) || throw(BoundsError())
     x
 end
 first(x::Number) = x


### PR DESCRIPTION
A small drive-by fix: it's much faster not to allocate the array here. 

```julia
julia> f(I::Integer...) = all(i == 1 for i in I)
f (generic function with 1 method)

julia> g(I::Integer...) = all([i == 1 for i in I])
g (generic function with 1 method)

julia> using BenchmarkTools
[ Info: Precompiling BenchmarkTools [6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf]

julia> @btime g(1,2,1)
  23.972 ns (1 allocation: 96 bytes)
false

julia> @btime f(1,2,1)
  1.335 ns (0 allocations: 0 bytes)
false
```

FWIW, In actual performance sensitive code, one would probably use `@inbounds` so this is moot.