### PR TITLE
improved implementation of hypot(a,b)

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -565,7 +565,7 @@ function hypot(x::T,y::T) where T<:AbstractFloat
 
     # Operands do not vary widely
     scale = eps(sqrt(floatmin(T)))  #Rescaling constant
-    if ax > sqrt(floatmax(T)/2.0)
+    if ax > sqrt(floatmax(T)/2)
         ax = ax*scale
         ay = ay*scale
         scale = 1.0/scale

--- a/base/math.jl
+++ b/base/math.jl
@@ -552,29 +552,33 @@ function hypot(x::T,y::T) where T<:AbstractFloat
         return convert(T,Inf)
     end
 
+    # Order the operands
     ax,ay = abs(x), abs(y)
     if ay > ax
         ax,ay = ay,ax
     end
 
-    if ay <= ax*sqrt(eps(T)/2)  #Note: This also gets ay == 0
+    # Widely varying operands
+    if ay <= ax*sqrt(eps(T)/2.0)  #Note: This also gets ay == 0
         return ax
     end
 
-    if (ax > sqrt(floatmax(T)/2)) || (ay < sqrt(floatmin(T)))
-        rescale = eps(sqrt(floatmin(T)))
-        if ax > sqrt(floatmax(T)/2)
-            ax = ax*rescale
-            ay = ay*rescale
-            return sqrt(muladd(ax,ax,ay*ay))/rescale
-        else
-            ax = ax/rescale
-            ay = ay/rescale
-            return sqrt(muladd(ax,ax,ay*ay))*rescale
-        end
-    else
-        return sqrt(muladd(ax,ax,ay*ay))
+    # Operands do not vary widely
+    rescale = eps(sqrt(floatmin(T)))  #Rescaling constant
+
+    if ax > sqrt(floatmax(T)/2.0)
+        ax = ax*rescale
+        ay = ay*rescale
+        return sqrt(muladd(ax,ax,ay*ay))/rescale
     end
+
+    if ay < sqrt(floatmin(T))
+        ax = ax/rescale
+        ay = ay/rescale
+        return sqrt(muladd(ax,ax,ay*ay))*rescale
+    end
+
+    sqrt(muladd(ax,ax,ay*ay))
 end
 function hypot(x::T, y::T) where T<:Number
     ax = abs(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -568,7 +568,7 @@ function hypot(x::T,y::T) where T<:AbstractFloat
     if ax > sqrt(floatmax(T)/2)
         ax = ax*scale
         ay = ay*scale
-        scale = 1.0/scale
+        scale = inv(scale)
     elseif ay < sqrt(floatmin(T))
         ax = ax/scale
         ay = ay/scale

--- a/base/math.jl
+++ b/base/math.jl
@@ -576,8 +576,14 @@ function hypot(x::T,y::T) where T<:AbstractFloat
         scale = one(scale)
     end
     h = sqrt(muladd(ax,ax,ay*ay))
-    delta = h-ax
-    (h - muladd(ax,delta,(delta+ay)*(delta-ay)/2)/h)*scale
+    if h <= 2*ay
+        delta = h-ay
+        h -= muladd(delta,delta-2*(ax-ay),ax*(2*delta - ax))/(2*h)
+    else
+        delta = h-ax
+        h -= muladd(delta,delta,muladd(ay,(4*delta-ay),2*delta*(ax-2*ay)))/(2*h)
+    end
+    h*scale
 end
 function hypot(x::T, y::T) where T<:Number
     ax = abs(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -559,7 +559,7 @@ function hypot(x::T,y::T) where T<:AbstractFloat
     end
 
     # Widely varying operands
-    if ay <= ax*sqrt(eps(T)/2.0)  #Note: This also gets ay == 0
+    if ay <= ax*sqrt(eps(T)/2)  #Note: This also gets ay == 0
         return ax
     end
 

--- a/base/math.jl
+++ b/base/math.jl
@@ -573,7 +573,7 @@ function hypot(x::T,y::T) where T<:AbstractFloat
         ax = ax/scale
         ay = ay/scale
     else
-        scale = 1.0
+        scale = one(scale)
     end
     sqrt(muladd(ax,ax,ay*ay))*scale
 end

--- a/base/math.jl
+++ b/base/math.jl
@@ -564,21 +564,18 @@ function hypot(x::T,y::T) where T<:AbstractFloat
     end
 
     # Operands do not vary widely
-    rescale = eps(sqrt(floatmin(T)))  #Rescaling constant
-
+    scale = eps(sqrt(floatmin(T)))  #Rescaling constant
     if ax > sqrt(floatmax(T)/2.0)
-        ax = ax*rescale
-        ay = ay*rescale
-        return sqrt(muladd(ax,ax,ay*ay))/rescale
+        ax = ax*scale
+        ay = ay*scale
+        scale = 1.0/scale
+    elseif ay < sqrt(floatmin(T))
+        ax = ax/scale
+        ay = ay/scale
+    else
+        scale = 1.0
     end
-
-    if ay < sqrt(floatmin(T))
-        ax = ax/rescale
-        ay = ay/rescale
-        return sqrt(muladd(ax,ax,ay*ay))*rescale
-    end
-
-    sqrt(muladd(ax,ax,ay*ay))
+    sqrt(muladd(ax,ax,ay*ay))*scale
 end
 function hypot(x::T, y::T) where T<:Number
     ax = abs(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -575,7 +575,9 @@ function hypot(x::T,y::T) where T<:AbstractFloat
     else
         scale = one(scale)
     end
-    sqrt(muladd(ax,ax,ay*ay))*scale
+    h = sqrt(muladd(ax,ax,ay*ay))
+    delta = h-ax
+    (h - muladd(ax,delta,(delta+ay)*(delta-ay)/2)/h)*scale
 end
 function hypot(x::T, y::T) where T<:Number
     ax = abs(x)

--- a/base/math.jl
+++ b/base/math.jl
@@ -544,6 +544,7 @@ Stacktrace:
 ```
 """
 hypot(x::Number, y::Number) = hypot(promote(x, y)...)
+hypot(x::Complex, y::Complex) = hypot(promote(abs(x),abs(y))...)
 hypot(x::Integer, y::Integer) = hypot(promote(float(x), float(y))...)
 function hypot(x::T,y::T) where T<:AbstractFloat
     #Return Inf if either or both imputs is Inf (Compliance with IEEE754)

--- a/test/math.jl
+++ b/test/math.jl
@@ -193,6 +193,7 @@ end
             @test isequal(hypot(T(3),T(4)), T(5))
             @test isequal(hypot(floatmax(T),T(1)),floatmax(T))
             @test isequal(hypot(floatmin(T)*sqrt(eps(T)),T(0)),floatmin(T)*sqrt(eps(T)))
+            @test isequal(floatmin(T)*hypot(1.368423059742933,1.3510496552495361),hypot(floatmin(T)*1.368423059742933,floatmin(T)*1.3510496552495361))
             @test isequal(log(T(1)), T(0))
             @test isequal(log(ℯ,T(1)), T(0))
             @test log(T(ℯ)) ≈ T(1) atol=eps(T)

--- a/test/math.jl
+++ b/test/math.jl
@@ -191,6 +191,8 @@ end
             @test isequal(expm1(T(0)), T(0))
             @test expm1(T(1)) ≈ T(ℯ)-1 atol=10*eps(T)
             @test isequal(hypot(T(3),T(4)), T(5))
+            @test isequal(hypot(floatmax(T),T(1)),floatmax(T))
+            @test isequal(hypot(floatmin(T)*sqrt(eps(T)),T(0)),floatmin(T)*sqrt(eps(T)))
             @test isequal(log(T(1)), T(0))
             @test isequal(log(ℯ,T(1)), T(0))
             @test log(T(ℯ)) ≈ T(1) atol=eps(T)


### PR DESCRIPTION
Provides a fast and accurate implementation of hypot() that leverages
the fused multiply add where available. The approach is explained
and tested in detail in the paper:
 An Improved Algorithm for hypot(a,b) by Carlos F. Borges
The article is available online at ArXiv at the link
https://arxiv.org/abs/1904.09481

cc: @simonbyrne 