### PR TITLE
speed up filter of vector

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -2377,7 +2377,7 @@ function filter!(f, a::AbstractVector)
         resize!(a, j-1)
         sizehint!(a, j-1)
     else
-        deleteat!(a, j:Int(lastindex(a)))
+        Int(lastindex(a)) < j && deleteat!(a, j:Int(lastindex(a)))
     end
     a
 end

--- a/base/array.jl
+++ b/base/array.jl
@@ -2364,7 +2364,34 @@ function filter!(f, a::AbstractVector)
     return a
 end
 
-filter(f, a::Vector) = mapfilter(f, push!, a, empty(a))
+function filter!(f, a::Vector)
+    i = j = 1
+    L = length(a)
+    @inbounds while i <= L
+        p = f(a[i])
+        a[j] = a[i]
+        j = ifelse(p, j+1, j)
+        i += 1
+    end
+    deleteat!(a, j:L)
+    sizehint!(a, j-1)
+    a
+end
+
+function filter(f, a::Vector{T}) where T
+    i = j = 1
+    L = length(a)    
+    b = Vector{T}(undef, L)
+    @inbounds while i <= L
+        p = f(a[i])
+        b[j] = a[i]
+        j = ifelse(p, j+1, j)
+        i += 1
+    end
+    deleteat!(b, j:L)
+    sizehint!(b, j-1)
+    b
+end
 
 # set-like operators for vectors
 # These are moderately efficient, preserve order, and remove dupes.

--- a/base/array.jl
+++ b/base/array.jl
@@ -2341,11 +2341,10 @@ end
 
 function filter(f, a::AbstractVector)
     j=1
-    offset = Int(firstindex(a))-1
     idxs = Vector{Int}(undef, length(a))
-    for ai in a
-        @inbounds idxs[j] = j + offset
-        j = ifelse(f(ai), j+1, j)
+    for idx in eachindex(a)
+        @inbounds idxs[j] = idx
+        j = ifelse(f(@inbounds a[idx]), j+1, j)
     end
     resize!(idxs, j-1)
     return a[idxs]

--- a/base/array.jl
+++ b/base/array.jl
@@ -2339,7 +2339,7 @@ end
 
 function filter(f, a::AbstractArray)
     (IndexStyle(a) != IndexLinear()) && return a[map(f, a)::AbstractArray{Bool}]
-    
+
     j = 1
     idxs = Vector{Int}(undef, length(a))
     for idx in eachindex(a)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2327,12 +2327,12 @@ julia> filter(isodd, a)
 """
 filter(f, As::AbstractArray) = As[map(f, As)::AbstractArray{Bool}]
 
-function filter(f, a::Vector{T, N}) where {T,N}
+function filter(f, a::Vector{T}) where {T}
     j = 1
     b = Vector{T}(undef, length(a))
     for ai in a
         @inbounds b[j] = ai
-        j += f(ai)::Bool
+        j = ifelse(f(ai), j+1, j)
     end
     resize!(b, j-1)
     sizehint!(b, length(b))
@@ -2345,7 +2345,7 @@ function filter(f, a::AbstractVector)
     for idx in eachindex(a)
         @inbounds idxs[j] = idx
         ai = @inbounds a[idx]
-        j += f(ai)::Bool
+        j = ifelse(f(ai), j+1, j)
     end
     resize!(idxs, j-1)
     return a[idxs]

--- a/base/array.jl
+++ b/base/array.jl
@@ -2380,7 +2380,7 @@ end
 
 function filter(f, a::Vector{T}) where T
     i = j = 1
-    L = length(a)    
+    L = length(a)
     b = Vector{T}(undef, L)
     @inbounds while i <= L
         p = f(a[i])

--- a/base/array.jl
+++ b/base/array.jl
@@ -2375,7 +2375,7 @@ function filter!(f, a::Vector)
     a
 end
 
-function filter(f, a::Vector{T}) where T
+function filter(f, a::AbstractVector{T}) where T
     j = 1
     b = Vector{T}(undef, length(a))
     for ai in a

--- a/base/array.jl
+++ b/base/array.jl
@@ -2334,16 +2334,17 @@ function filter(f, a::Vector{T}) where T
         @inbounds b[j] = ai
         j = ifelse(f(ai), j+1, j)
     end
-    deleteat!(b, j:length(b))
+    resize!(b, j-1)
     sizehint!(b, length(b))
     b
 end
 
 function filter(f, a::AbstractVector)
-    j = Int(firstindex(a))
+    j=1
+    offset = Int(firstindex(a))-1
     idxs = Vector{Int}(undef, length(a))
     for ai in a
-        @inbounds idxs[j] = j
+        @inbounds idxs[j] = j + offset
         j = ifelse(f(ai), j+1, j)
     end
     resize!(idxs, j-1)

--- a/base/array.jl
+++ b/base/array.jl
@@ -2365,31 +2365,25 @@ function filter!(f, a::AbstractVector)
 end
 
 function filter!(f, a::Vector)
-    i = j = 1
-    L = length(a)
-    @inbounds while i <= L
-        p = f(a[i])
-        a[j] = a[i]
-        j = ifelse(p, j+1, j)
-        i += 1
+    j = 1
+    for ai in a
+        @inbounds a[j] = ai
+        j = ifelse(f(ai), j+1, j)
     end
-    deleteat!(a, j:L)
-    sizehint!(a, j-1)
+    deleteat!(a, j:length(a))
+    sizehint!(a, length(a))
     a
 end
 
 function filter(f, a::Vector{T}) where T
-    i = j = 1
-    L = length(a)
-    b = Vector{T}(undef, L)
-    @inbounds while i <= L
-        p = f(a[i])
-        b[j] = a[i]
-        j = ifelse(p, j+1, j)
-        i += 1
+    j = 1
+    b = Vector{T}(undef, length(a))
+    for ai in a
+        @inbounds b[j] = ai
+        j = ifelse(f(ai), j+1, j)
     end
-    deleteat!(b, j:L)
-    sizehint!(b, j-1)
+    deleteat!(b, j:length(b))
+    sizehint!(b, length(b))
     b
 end
 


### PR DESCRIPTION
Use branchfree code for filtering vectors. Part of the saved time is then spent to resize the buffer of the result, such that memory consumption is reduced, if the result should happen to be long-lived. 

I observe a 4x speedup for inplace filtering and 7x for out-of-place filtering in the 50% case. If desired we can obtain an additional 30% speedup by skipping the `realloc` of the buffer, i.e. the `sizehint!`; this will, however, increase memory consumption. Since the result may long-lived, I tend to be conservative with eating user memory. 1 ms corresponds to about 2 cycles / element. 

Abstract assumptions (updated):

1. AbstractVector and AbstractArray with IndexLinear have indices that survive a round-trip to Int
2. AbstractVector and AbstractArray with IndexLinear support `getindex(a, idxs::Vector{Int})`
3. AbstractArray without IndexLinear support logical indexing (the old code made this assumption).

Old algorithms: Branchy inplace filtering of AbstractVector; out of place, logical indexing for AbstractArray and `push!`-based for Vector.

New algorithms: Branchless inplace filtering for AbstractVector; branchless out-of-place for Array, `Vector{Int}`-indexing for AbstractArray with LinearIndexing (using branchless construction of the indexing vector; this is an 8 times larger temporary than the old code using logical indexing, so we immediately free its buffer via `empty!(tmp); sizehint!(tmp, 0)` to relieve gc pressure). For AbstractArray without IndexLinear, we continue to use the old logical indexing algorithm.

Memory consumption: We have a larger temporary to store selected indices. In case of inplace filtering Vector, we now shrink the underlying buffer post filtering. In case of out-of-place filtering of Vector, we now allocate a potentially larger buffer and shrink it afterwards, instead of relying on the `push!`-resize logic. This can be either a gain or a loss with respect to peak memory consumption, and is almost always a win with respect to sustained memory consumption for long-lived results (because the old `push!` based code leads to up to 2x overallocation of the resulting object, and the old code did not truncate the resulting buffer). This should be a gain with respect to gc pressure.

Updated (2) Microbenchmark:
```
julia> using BenchmarkTools, Test
julia> struct isle{T} <:Function
       elem::T
       end
julia> (c::isle)(x) = x <= c.elem
julia> Base.deleteat!(a::Test.GenericArray, ran) = begin deleteat!(a.a, ran); a end

julia> begin
       N=10^6
       println("N=$N, copy")
       @btime copy(arr)  evals=1 setup = (arr = rand(N))
       for p in [0.5, 0.15, 0.85, 0.05, 0.95, 0.01, 0.99]
       println("\np=$p, N=$N")
       global arr
       println("filter!(pred, a::Vector)")
       @btime filter!($(isle(p)), arr) evals=1 setup = (arr = rand(N))
       println("filter!(pred, a::Test.GenericVector)")
       @btime filter!($(isle(p)), arr) evals=1 setup = (arr = Test.GenericArray(rand(N)))
       println("filter(pred, a::Vector)")
       @btime filter($(isle(p)), arr) evals=1 setup = (arr = rand(N))
       println("filter(pred, a::Matrix)")
       @btime filter($(isle(p)), arr) evals=1 setup = (arr = rand(N, 1))
       println("filter(pred, a::Test.GenericVector)")
       @btime filter($(isle(p)), arr) evals=1 setup = (arr = Test.GenericArray(rand(N)))
       println("filter(pred, a::AbstractMatrix) with linear indexing")
       @btime filter($(isle(p)), arr) evals=1 setup = (arr = view(rand(N), :, 1:1))
       println("filter(pred, a::AbstractMatrix) with cartesian indexing")
       @btime filter($(isle(p)), arr) evals=1 setup = (arr = view(rand(N), :, [1]))
       end
       end
```
Before:
```
N=1000000, copy
  888.068 μs (2 allocations: 7.63 MiB)

p=0.5, N=1000000
filter!(pred, a::Vector)
  6.872 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  6.962 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  12.613 ms (19 allocations: 5.00 MiB)
filter(pred, a::Matrix)
  7.305 ms (9 allocations: 4.76 MiB)
filter(pred, a::Test.GenericVector)
  7.755 ms (9 allocations: 4.76 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  8.056 ms (9 allocations: 4.76 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  13.467 ms (9 allocations: 4.76 MiB)

p=0.15, N=1000000
filter!(pred, a::Vector)
  3.296 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  3.225 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  5.020 ms (18 allocations: 3.00 MiB)
filter(pred, a::Matrix)
  4.042 ms (9 allocations: 2.09 MiB)
filter(pred, a::Test.GenericVector)
  4.304 ms (9 allocations: 2.09 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  4.701 ms (9 allocations: 2.09 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  9.767 ms (9 allocations: 2.09 MiB)

p=0.85, N=1000000
filter!(pred, a::Vector)
  3.207 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  3.513 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  10.723 ms (20 allocations: 9.00 MiB)
filter(pred, a::Matrix)
  4.515 ms (9 allocations: 7.43 MiB)
filter(pred, a::Test.GenericVector)
  4.810 ms (9 allocations: 7.43 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  5.156 ms (9 allocations: 7.43 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  9.533 ms (9 allocations: 7.43 MiB)

p=0.05, N=1000000
filter!(pred, a::Vector)
  1.704 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.703 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  2.553 ms (16 allocations: 1.00 MiB)
filter(pred, a::Matrix)
  3.044 ms (9 allocations: 1.33 MiB)
filter(pred, a::Test.GenericVector)
  3.533 ms (9 allocations: 1.33 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  3.743 ms (9 allocations: 1.33 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  9.399 ms (9 allocations: 1.33 MiB)

p=0.95, N=1000000
filter!(pred, a::Vector)
  1.804 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  2.177 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  9.752 ms (20 allocations: 9.00 MiB)
filter(pred, a::Matrix)
  3.576 ms (9 allocations: 8.20 MiB)
filter(pred, a::Test.GenericVector)
  3.869 ms (9 allocations: 8.20 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  4.252 ms (9 allocations: 8.20 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  8.296 ms (9 allocations: 8.20 MiB)

p=0.01, N=1000000
filter!(pred, a::Vector)
  1.086 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.149 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.638 ms (14 allocations: 256.64 KiB)
filter(pred, a::Matrix)
  2.390 ms (9 allocations: 1.03 MiB)
filter(pred, a::Test.GenericVector)
  2.905 ms (9 allocations: 1.03 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  3.060 ms (9 allocations: 1.03 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  8.558 ms (9 allocations: 1.03 MiB)

p=0.99, N=1000000
filter!(pred, a::Vector)
  1.276 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.612 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  9.319 ms (20 allocations: 9.00 MiB)
filter(pred, a::Matrix)
  3.206 ms (9 allocations: 8.50 MiB)
filter(pred, a::Test.GenericVector)
  3.485 ms (9 allocations: 8.50 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  3.856 ms (9 allocations: 8.50 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  7.823 ms (9 allocations: 8.51 MiB)
```
After:
```
N=1000000, copy
  871.499 μs (2 allocations: 7.63 MiB)

p=0.5, N=1000000
filter!(pred, a::Vector)
  1.721 ms (1 allocation: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.674 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.747 ms (3 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  1.743 ms (3 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  3.383 ms (6 allocations: 11.43 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  3.171 ms (6 allocations: 11.43 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  13.479 ms (7 allocations: 4.76 MiB)

p=0.15, N=1000000
filter!(pred, a::Vector)
  1.321 ms (1 allocation: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.636 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.348 ms (3 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  1.342 ms (3 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  2.483 ms (6 allocations: 8.76 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  2.312 ms (6 allocations: 8.76 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  9.728 ms (7 allocations: 2.09 MiB)

p=0.85, N=1000000
filter!(pred, a::Vector)
  2.065 ms (1 allocation: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.699 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  2.224 ms (3 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  2.223 ms (3 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  4.222 ms (6 allocations: 14.11 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  4.028 ms (6 allocations: 14.11 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  9.560 ms (7 allocations: 7.43 MiB)

p=0.05, N=1000000
filter!(pred, a::Vector)
  1.181 ms (1 allocation: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.618 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.191 ms (3 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  1.189 ms (3 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  1.991 ms (6 allocations: 8.01 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  1.822 ms (6 allocations: 8.01 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  9.343 ms (7 allocations: 1.33 MiB)

p=0.95, N=1000000
filter!(pred, a::Vector)
  1.264 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.687 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.506 ms (2 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  1.502 ms (2 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  5.005 ms (6 allocations: 14.87 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  4.846 ms (6 allocations: 14.87 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  8.307 ms (7 allocations: 8.20 MiB)

p=0.01, N=1000000
filter!(pred, a::Vector)
  1.121 ms (1 allocation: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.621 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.131 ms (3 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  1.125 ms (3 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  1.677 ms (6 allocations: 7.70 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  1.504 ms (6 allocations: 7.70 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  8.522 ms (7 allocations: 1.03 MiB)

p=0.99, N=1000000
filter!(pred, a::Vector)
  1.233 ms (0 allocations: 0 bytes)
filter!(pred, a::Test.GenericVector)
  1.685 ms (0 allocations: 0 bytes)
filter(pred, a::Vector)
  1.507 ms (2 allocations: 7.63 MiB)
filter(pred, a::Matrix)
  1.524 ms (2 allocations: 7.63 MiB)
filter(pred, a::Test.GenericVector)
  5.155 ms (6 allocations: 15.18 MiB)
filter(pred, a::AbstractMatrix) with linear indexing
  4.941 ms (6 allocations: 15.18 MiB)
filter(pred, a::AbstractMatrix) with cartesian indexing
  7.816 ms (7 allocations: 8.51 MiB)
```

Monkey-patch:
```
julia> @eval Base begin

       filter(f::F, a::Vector) where F = invoke(filter, Tuple{F, Array}, f, a)

       function filter(f, a::AbstractArray)
           (IndexStyle(a) != IndexLinear()) && return a[map(f, a)::AbstractArray{Bool}]
           
           j = 1
           idxs = Vector{Int}(undef, length(a))
           for idx in eachindex(a)
               @inbounds idxs[j] = idx
               ai = @inbounds a[idx]
               j = ifelse(f(ai), j+1, j)
           end
           resize!(idxs, j-1)
           res = a[idxs]
           empty!(idxs)
           sizehint!(idxs, 0)
           return res
       end

       function filter(f, a::Array{T, N}) where {T, N}
           j = 1
           b = Vector{T}(undef, length(a))
           for ai in a
               @inbounds b[j] = ai
               j = ifelse(f(ai), j+1, j)
           end
           resize!(b, j-1)
           sizehint!(b, length(b))
           b
       end

       function filter!(f, a::AbstractVector)
           j = firstindex(a)
           for ai in a
               @inbounds a[j] = ai
               j = ifelse(f(ai), nextind(a, j), j)
           end
           j > lastindex(a) && return a
           if a isa Vector
               resize!(a, j-1)
               sizehint!(a, j-1)
           else
               deleteat!(a, j:lastindex(a))
           end
           return a
       end

       end
```


