### PR TITLE
Fix pop_exception lowering for try-break-finally (#31766)

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -3479,7 +3479,7 @@ f(x) = yt(x)
         (label-map (table))   ;; maps label names to generated addresses
         (label-nesting (table)) ;; exception handler and catch block nesting of each label
         (finally-handler #f)  ;; `(var label map level)` where `map` is a list of `(tag . action)`.
-                              ;; to exit the current finally block, set `var` to integer `tag`,
+                              ;; To exit the current finally block, set `var` to integer `tag`,
                               ;; jump to `label`, and put `(tag . action)` in the map, where `action`
                               ;; is `(return x)`, `(break x)`, or a call to rethrow.
         (handler-goto-fixups '())  ;; `goto`s that might need `leave` exprs added
@@ -3542,11 +3542,11 @@ f(x) = yt(x)
     (define (emit-break labl)
       (let ((lvl (caddr labl))
             (dest-tokens (cadddr labl)))
+        (let ((pexc (pop-exc-expr catch-token-stack dest-tokens)))
+          (if pexc (emit pexc)))
         (if (and finally-handler (> (cadddr finally-handler) lvl))
             (leave-finally-block `(break ,labl))
             (begin
-              (let ((pexc (pop-exc-expr catch-token-stack dest-tokens)))
-                (if pexc (emit pexc)))
               (if (> handler-level lvl)
                   (emit `(leave ,(- handler-level lvl))))
               (emit `(goto ,(cadr labl)))))))

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -83,6 +83,7 @@ end
         end
     end
     test_exc_stack_catch_return()
+
     for i=1:1
         try
             error("A")
@@ -91,6 +92,19 @@ end
             break
         end
     end
+    # Also test try-break-finally forms here. See #31766
+    for i=1:1
+        try
+            error("A")
+        catch
+            @test length(catch_stack()) == 1
+            break
+        finally
+            @test length(catch_stack()) == 0
+        end
+    end
+    @test length(catch_stack()) == 0
+
     for i=1:1
         try
             error("A")
@@ -99,6 +113,18 @@ end
             continue
         end
     end
+    for i=1:1
+        try
+            error("A")
+        catch
+            @test length(catch_stack()) == 1
+            continue
+        finally
+            @test length(catch_stack()) == 0
+        end
+    end
+    @test length(catch_stack()) == 0
+
     try
         error("A")
     catch
@@ -106,6 +132,15 @@ end
         @goto outofcatch
     end
     @label outofcatch
+    try
+        error("A")
+    catch
+        @test length(catch_stack()) == 1
+        @goto outofcatch2
+    finally
+        @test length(catch_stack()) == 0
+    end
+    @label outofcatch2
     @test length(catch_stack()) == 0
 
     # Exiting from a try block in various ways should not affect the exception


### PR DESCRIPTION
In the case where a finally handler was active, pop_exception was
incorrectly omitted when lowering `break` inside a catch block. This
leads to stale exceptions on the stack.

Fix #31766