### PR TITLE
Make --code-coverage testing more robust for filepath.

### DIFF
--- a/test/cmdlineargs.jl
+++ b/test/cmdlineargs.jl
@@ -212,7 +212,7 @@ let exename = `$(Base.julia_cmd()) --startup-file=no`
         helperdir = joinpath(@__DIR__, "testhelpers")
         inputfile = joinpath(helperdir, "coverage_file.jl")
         expected = replace(read(joinpath(helperdir, "coverage_file.info"), String),
-            "<FILENAME>" => inputfile)
+            "<FILENAME>" => realpath(inputfile))
         covfile = replace(joinpath(dir, "coverage.info"), "%" => "%%")
         @test !isfile(covfile)
         defaultcov = readchomp(`$exename -E "Bool(Base.JLOptions().code_coverage)" -L $inputfile`)


### PR DESCRIPTION
Without this there is a discrepancy between between the file paths, e.g. `repo/usr/share/julia/test/testhelpers/coverage_file.jl` returned by `@__DIR__` (on L212) and the file reported in the coverage output which is `repo/test/testhelpers/coverage_file.jl`. This shows up e.g. when you do `make && ./julia -e 'Base.runtests("cmdlineargs")'`.