### PR TITLE
Fix for optind in getopt on musl libc.

### DIFF
--- a/src/jloptions.c
+++ b/src/jloptions.c
@@ -620,8 +620,9 @@ restart_switch:
     }
     jl_options.code_coverage = codecov;
     jl_options.malloc_log = malloclog;
-    *argvp += optind;
-    *argcp -= optind;
+    int proc_args = *argcp < optind ? *argcp : optind;
+    *argvp += proc_args;
+    *argcp -= proc_args;
 }
 
 JL_DLLEXPORT void jl_set_ARGS(int argc, char **argv)


### PR DESCRIPTION
This fixes  https://github.com/JuliaLang/julia/blob/11ce4d1936c913449d074cf352bd79a2737e0392/test/cmdlineargs.jl#L258 and https://github.com/JuliaLang/julia/blob/11ce4d1936c913449d074cf352bd79a2737e0392/test/cmdlineargs.jl#L263
i.e. the bug only shows where there are a last option with a default value.

On exit `optind` points to the last non-opt argument of `argv`, but in the case where there are only options `optind` does not go beyond `argc`, except on musl libc, where it becomes `argc + 1`. This causes https://github.com/JuliaLang/julia/blob/11ce4d1936c913449d074cf352bd79a2737e0392/src/jloptions.c#L624 to be `-1` and then we try to resize `ARGS` to `-1` here: https://github.com/JuliaLang/julia/blob/11ce4d1936c913449d074cf352bd79a2737e0392/src/jloptions.c#L638 and crash.

I don't know if this is an acceptable fix, but feels like it should be safe on all systems.

edit: fixes #26761