### PR TITLE
sysimg: reduce the number of special cases (essentially NFC)

### DIFF
--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -345,6 +345,7 @@ static std::map<jl_fptr_args_t, Function*> builtin_func_map;
 // --- code generation ---
 extern "C" {
     int globalUnique = 0;
+    jl_cgparams_t jl_default_cgparams = {1, 1, 1, 1, 0, NULL, NULL, NULL, NULL, NULL};
 }
 
 template<typename T>
@@ -2383,7 +2384,7 @@ static Value *emit_f_is(jl_codectx_t &ctx, const jl_cgval_t &arg1, const jl_cgva
     //   TODO: handle with emit_bitsunion_compare
 
     int ptr_comparable = 0; // whether this type is unique'd by pointer
-    if (rt1 == (jl_value_t*)jl_sym_type || rt2 == (jl_value_t*)jl_sym_type)
+    if (rt1 == (jl_value_t*)jl_symbol_type || rt2 == (jl_value_t*)jl_symbol_type)
         ptr_comparable = 1;
     if (jl_is_mutable_datatype(rt1) && // excludes abstract types
         rt1 != (jl_value_t*)jl_string_type && // technically mutable, but compared by contents
@@ -7637,6 +7638,11 @@ extern "C" void *jl_init_llvm(void)
 
     jl_page_size = jl_getpagesize();
     imaging_mode = jl_generating_output() && !jl_options.incremental;
+    jl_default_cgparams.module_setup = jl_nothing;
+    jl_default_cgparams.module_activation = jl_nothing;
+    jl_default_cgparams.raise_exception = jl_nothing;
+    jl_default_cgparams.emit_function = jl_nothing;
+    jl_default_cgparams.emitted_function = jl_nothing;
     jl_init_debuginfo();
 
 #ifdef USE_POLLY

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -223,7 +223,7 @@ unsigned jl_special_vector_alignment(size_t nfields, jl_value_t *t)
 
 STATIC_INLINE int jl_is_datatype_make_singleton(jl_datatype_t *d)
 {
-    return (!d->abstract && jl_datatype_size(d) == 0 && d != jl_sym_type && d->name != jl_array_typename &&
+    return (!d->abstract && jl_datatype_size(d) == 0 && d != jl_symbol_type && d->name != jl_array_typename &&
             d->uid != 0 && !d->mutabl);
 }
 
@@ -337,7 +337,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         return;
     uint32_t nfields = jl_svec_len(st->types);
     if (nfields == 0) {
-        if (st == jl_sym_type || st == jl_string_type) {
+        if (st == jl_symbol_type || st == jl_string_type) {
             // opaque layout - heap-allocated blob
             static const jl_datatype_layout_t opaque_byte_layout = {0, 1, 0, 1, 0};
             st->layout = &opaque_byte_layout;
@@ -371,7 +371,7 @@ void jl_compute_field_offsets(jl_datatype_t *st)
         desc = (jl_fielddesc32_t*)alloca(descsz);
     int haspadding = 0;
     assert(st->name == jl_tuple_typename ||
-           st == jl_sym_type ||
+           st == jl_symbol_type ||
            st == jl_simplevector_type ||
            nfields != 0);
 
@@ -623,8 +623,7 @@ void jl_assign_bits(void *dest, jl_value_t *bits)
 
 #define PERMBOXN_FUNC(nb,nw)                                            \
     jl_value_t *jl_permbox##nb(jl_datatype_t *t, int##nb##_t x)         \
-    {                                                                   \
-        assert(jl_isbits(t));                                           \
+    {   /* NOTE: t must be a concrete isbits datatype */                \
         assert(jl_datatype_size(t) == sizeof(x));                       \
         jl_value_t *v = jl_gc_permobj(nw * sizeof(void*), t);           \
         *(int##nb##_t*)jl_data_ptr(v) = x;                              \

--- a/src/dump.c
+++ b/src/dump.c
@@ -68,10 +68,6 @@ static jl_array_t *serializer_worklist JL_GLOBALLY_ROOTED;
 // (only used by the incremental serializer in MODE_MODULE)
 htable_t edges_map;
 
-// list of modules being deserialized with __init__ methods
-// (not used in MODE_IR)
-extern jl_array_t *jl_module_init_order;
-
 #define TAG_SYMBOL              2
 #define TAG_SSAVALUE            3
 #define TAG_DATATYPE            4

--- a/src/gc.c
+++ b/src/gc.c
@@ -2477,7 +2477,6 @@ mark: {
     }
 }
 
-extern jl_array_t *jl_module_init_order;
 extern jl_typemap_entry_t *call_cache[N_CALL_CACHE];
 extern jl_array_t *jl_all_methods;
 

--- a/src/gf.c
+++ b/src/gf.c
@@ -133,7 +133,7 @@ JL_DLLEXPORT jl_code_instance_t* jl_set_method_inferred(
         jl_value_t *inferred_const, jl_value_t *inferred,
         int32_t const_flags, size_t min_world, size_t max_world);
 
-void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED
+jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED
 {
     jl_sym_t *sname = jl_symbol(name);
     if (dt == NULL) {
@@ -164,6 +164,7 @@ void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr
     jl_typemap_insert(&mt->cache, (jl_value_t*)mt, jl_anytuple_type,
         NULL, jl_emptysvec, (jl_value_t*)mi, 0, &lambda_cache, 1, ~(size_t)0, NULL);
     JL_GC_POP();
+    return dt;
 }
 
 // run type inference on lambda "mi" for given argument types.
@@ -1695,7 +1696,7 @@ JL_DLLEXPORT jl_value_t *jl_matching_methods(jl_tupletype_t *types, int lim, int
         return jl_false; // indeterminate - ml_matches can't deal with this case
     jl_methtable_t *mt = dt->name->mt;
     if (mt == NULL)
-        return (jl_value_t*)jl_alloc_vec_any(0);
+        return (jl_value_t*)jl_an_empty_vec_any;
     return ml_matches(mt->defs, 0, types, lim, include_ambiguous, world, min_valid, max_valid);
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -552,7 +552,6 @@ extern JL_DLLEXPORT jl_unionall_t *jl_type_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_typetype_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_typename_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_type_typename JL_GLOBALLY_ROOTED;
-extern JL_DLLEXPORT jl_datatype_t *jl_sym_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_symbol_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_ssavalue_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_abstractslot_type JL_GLOBALLY_ROOTED;
@@ -567,7 +566,6 @@ extern JL_DLLEXPORT jl_datatype_t *jl_emptytuple_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_anytuple_type_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_vararg_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_vararg_typename JL_GLOBALLY_ROOTED;
-extern JL_DLLEXPORT jl_datatype_t *jl_task_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_function_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_datatype_t *jl_builtin_type JL_GLOBALLY_ROOTED;
 
@@ -625,6 +623,7 @@ extern JL_DLLEXPORT jl_unionall_t *jl_ref_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_pointer_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_typename_t *jl_namedtuple_typename JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_unionall_t *jl_namedtuple_type JL_GLOBALLY_ROOTED;
+extern JL_DLLEXPORT jl_datatype_t *jl_task_type JL_GLOBALLY_ROOTED;
 
 extern JL_DLLEXPORT jl_value_t *jl_array_uint8_type JL_GLOBALLY_ROOTED;
 extern JL_DLLEXPORT jl_value_t *jl_array_any_type JL_GLOBALLY_ROOTED;
@@ -997,7 +996,7 @@ static inline int jl_is_layout_opaque(const jl_datatype_layout_t *l) JL_NOTSAFEP
 #define jl_is_uint32(v)      jl_typeis(v,jl_uint32_type)
 #define jl_is_uint64(v)      jl_typeis(v,jl_uint64_type)
 #define jl_is_bool(v)        jl_typeis(v,jl_bool_type)
-#define jl_is_symbol(v)      jl_typeis(v,jl_sym_type)
+#define jl_is_symbol(v)      jl_typeis(v,jl_symbol_type)
 #define jl_is_ssavalue(v)    jl_typeis(v,jl_ssavalue_type)
 #define jl_is_slot(v)        (jl_typeis(v,jl_slotnumber_type) || jl_typeis(v,jl_typedslot_type))
 #define jl_is_expr(v)        jl_typeis(v,jl_expr_type)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -422,7 +422,7 @@ int jl_has_concrete_subtype(jl_value_t *typ) JL_NOTSAFEPOINT;
 jl_datatype_t *jl_inst_concrete_tupletype_v(jl_value_t **p, size_t np) JL_ALWAYS_LEAFTYPE;
 jl_datatype_t *jl_inst_concrete_tupletype(jl_svec_t *p) JL_ALWAYS_LEAFTYPE;
 JL_DLLEXPORT void jl_method_table_insert(jl_methtable_t *mt, jl_method_t *method, jl_tupletype_t *simpletype);
-void jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
+jl_datatype_t *jl_mk_builtin_func(jl_datatype_t *dt, const char *name, jl_fptr_args_t fptr) JL_GC_DISABLED;
 jl_value_t *jl_type_intersection_env_s(jl_value_t *a, jl_value_t *b, jl_svec_t **penv, int *issubty);
 jl_value_t *jl_type_intersection_env(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);
 int jl_subtype_matching(jl_value_t *a, jl_value_t *b, jl_svec_t **penv);

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -600,7 +600,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
     else if (v == (jl_value_t*)jl_typename_type) {
         n += jl_printf(out, "Core.TypeName");
     }
-    else if (v == (jl_value_t*)jl_sym_type) {
+    else if (v == (jl_value_t*)jl_symbol_type) {
         n += jl_printf(out, "Symbol");
     }
     else if (v == (jl_value_t*)jl_methtable_type) {
@@ -820,7 +820,7 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         }
         n += jl_printf(out, "%s", jl_symbol_name(m->name));
     }
-    else if (vt == jl_sym_type) {
+    else if (vt == jl_symbol_type) {
         char *sn = jl_symbol_name((jl_sym_t*)v);
         int quoted = !jl_is_identifier(sn) && jl_operator_precedence(sn) == 0;
         if (quoted)

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -31,11 +31,12 @@ static jl_sym_t *mk_symbol(const char *str, size_t len)
 {
     jl_sym_t *sym;
     size_t nb = symbol_nbytes(len);
+    assert(jl_symbol_type && "not initialized");
 
     jl_taggedvalue_t *tag = (jl_taggedvalue_t*)jl_gc_perm_alloc_nolock(nb, 0, sizeof(void*), 0);
     sym = (jl_sym_t*)jl_valueof(tag);
     // set to old marked so that we won't look at it in the GC or write barrier.
-    tag->header = ((uintptr_t)jl_sym_type) | GC_OLD_MARKED;
+    tag->header = ((uintptr_t)jl_symbol_type) | GC_OLD_MARKED;
     sym->left = sym->right = NULL;
     sym->hash = hash_symbol(str, len);
     memcpy(jl_symbol_name(sym), str, len);

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -119,7 +119,7 @@ jl_value_t *jl_eval_module_expr(jl_module_t *parent_module, jl_expr_t *ex)
     int std_imports = (jl_exprarg(ex, 0) == jl_true);
     jl_sym_t *name = (jl_sym_t*)jl_exprarg(ex, 1);
     if (!jl_is_symbol(name)) {
-        jl_type_error("module", (jl_value_t*)jl_sym_type, (jl_value_t*)name);
+        jl_type_error("module", (jl_value_t*)jl_symbol_type, (jl_value_t*)name);
     }
 
     jl_module_t *newm = jl_new_module(name);
@@ -418,7 +418,7 @@ static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from JL_PR
     jl_module_t *m = NULL;
     *name = NULL;
     if (!jl_is_symbol(var))
-        jl_type_error(keyword, (jl_value_t*)jl_sym_type, (jl_value_t*)var);
+        jl_type_error(keyword, (jl_value_t*)jl_symbol_type, (jl_value_t*)var);
 
     if (from != NULL) {
         m = from;
@@ -456,7 +456,7 @@ static jl_module_t *eval_import_path(jl_module_t *where, jl_module_t *from JL_PR
     while (1) {
         var = (jl_sym_t*)jl_array_ptr_ref(args, i);
         if (!jl_is_symbol(var))
-            jl_type_error(keyword, (jl_value_t*)jl_sym_type, (jl_value_t*)var);
+            jl_type_error(keyword, (jl_value_t*)jl_symbol_type, (jl_value_t*)var);
         if (var == dot_sym)
             jl_errorf("invalid %s path: \".\" in identifier path", keyword);
         if (i == jl_array_len(args)-1)


### PR DESCRIPTION
Put the entire image(*) into our pre-constructed data image,
instead of attempting to leave out a couple of items.
This saves us a couple lines of code, and should makes it
simpler to keep the list of builtin objects (gc.c "tags") up-to-date.

(*) The remaining special objects are ptls->root_task,
since I was unsure the best way to handle it as no other Task
object is allowed to be referenced, and the small integer caches.