### PR TITLE
[release-1.1] Add missing license header

### DIFF
--- a/contrib/refresh_bb_tarballs.sh
+++ b/contrib/refresh_bb_tarballs.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# This file is a part of Julia. License is MIT: https://julialang.org/license
 
 # Get this list via:
 #    using BinaryBuilder


### PR DESCRIPTION
This is the last outstanding housekeeping item for v1.1.1. I also ran the documentation link checks and doc tests and things are looking okay there, so once this is merged I'll put up a PR to set the version on the branch to 1.1.1 then we can tag.