### PR TITLE
fix an assertion failure from `jl_obvious_subtype`

### DIFF
--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1307,11 +1307,13 @@ JL_DLLEXPORT int jl_obvious_subtype(jl_value_t *x, jl_value_t *y, int *subtype)
                 vy = npy > 0 && jl_is_vararg_type(jl_tparam(y, npy - 1));
             }
             if (npx != npy || vx || vy) {
-                if (!vy) {
+                if (!vy && (!vx || jl_vararg_kind(jl_tparam(x, npx - 1)) == JL_VARARG_UNBOUND)) {
                     *subtype = 0;
                     return 1;
                 }
                 if (npx - vx < npy - vy) {
+                    if (vx)
+                        return 0;
                     *subtype = 0;
                     return 1; // number of fixed parameters in x could be fewer than in y
                 }

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1509,3 +1509,9 @@ end
 
 # issue #26083
 @testintersect(Base.RefValue{<:Tuple}, Ref{Tuple{M}} where M, Base.RefValue{Tuple{M}} where M)
+
+let A = Tuple{T, Vararg{T, 1}} where T<:Int64,
+    B = Tuple{Int, Int}
+    @test A <: B
+    @test B <: A
+end


### PR DESCRIPTION
I encountered this while looking at #31899. The query was `(Tuple{T, Vararg{T, 1}} where T<:Int64) <: Tuple{Int64, Int64}`. Nothing about vararg subtyping is obvious! :smile: 