### PR TITLE
fix part of #30901, more consistent printing of `Day`

### DIFF
--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -530,11 +530,7 @@ end
 # show
 
 function Base.show(io::IO, p::P) where P <: Period
-    if get(io, :compact, false)
-        print(io, p)
-    else
-        print(io, P, '(', p.value, ')')
-    end
+    print(io, P, '(', p.value, ')')
 end
 
 function Base.show(io::IO, dt::DateTime)

--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -25,6 +25,7 @@ using Dates
     @test sprint(show, Dates.Day(12)) == "Dates.Day(12)"
     @test sprint(print,Dates.Day(12)) == "12 days"
     @test repr(Dates.Day(12)) == "Dates.Day(12)"
+    @test occursin("Day(1)", repr(MIME("text/plain"), [Day(1) Day(2)]))
 
     @test string(Dates.Hour(12)) == "12 hours"
     @test sprint(show, Dates.Hour(12)) == "Dates.Hour(12)"


### PR DESCRIPTION
This prints as e.g. `Day(1)` for all `show` and `repr` calls. `1 day` is used for `print` or mimetype text/plain.

For this issue in the 1.2 timeframe, I think we should either do this or nothing. The only way to get a more significant improvement is to add another IOContext flag so we can be smarter about when to print in julia syntax.

Fixes part of #30901.