### PR TITLE
Revert "Don't use jl_rethrow_other for LoadError/InitError" (fix #31830)

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -85,11 +85,18 @@ function showerror(io::IO, ex, bt; backtrace=true)
 end
 
 function showerror(io::IO, ex::LoadError, bt; backtrace=true)
-    print(io, "Error while loading expression starting at ", ex.file, ":", ex.line)
+    print(io, "LoadError: ")
+    showerror(io, ex.error, bt, backtrace=backtrace)
+    print(io, "\nin expression starting at $(ex.file):$(ex.line)")
 end
 showerror(io::IO, ex::LoadError) = showerror(io, ex, [])
 
-showerror(io::IO, ex::InitError) = print(io, "InitError during initialization of module ", ex.mod)
+function showerror(io::IO, ex::InitError, bt; backtrace=true)
+    print(io, "InitError: ")
+    showerror(io, ex.error, bt, backtrace=backtrace)
+    print(io, "\nduring initialization of module ", ex.mod)
+end
+showerror(io::IO, ex::InitError) = showerror(io, ex, [])
 
 function showerror(io::IO, ex::DomainError)
     if isa(ex.val, AbstractArray)

--- a/src/ast.c
+++ b/src/ast.c
@@ -892,8 +892,8 @@ finally:
         if (jl_loaderror_type == NULL)
             jl_rethrow();
         else
-            jl_throw(jl_new_struct(jl_loaderror_type, form, result,
-                                   jl_current_exception()));
+            jl_rethrow_other(jl_new_struct(jl_loaderror_type, form, result,
+                                           jl_current_exception()));
     }
     JL_GC_POP();
     return result;
@@ -1050,8 +1050,8 @@ static jl_value_t *jl_invoke_julia_macro(jl_array_t *args, jl_module_t *inmodule
             else
                 margs[0] = jl_cstr_to_string("<macrocall>");
             margs[1] = jl_fieldref(lno, 0); // extract and allocate line number
-            jl_throw(jl_new_struct(jl_loaderror_type, margs[0], margs[1],
-                                   jl_current_exception()));
+            jl_rethrow_other(jl_new_struct(jl_loaderror_type, margs[0], margs[1],
+                                           jl_current_exception()));
         }
     }
     ptls->world_age = last_age;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -79,8 +79,8 @@ void jl_module_run_initializer(jl_module_t *m)
             jl_rethrow();
         }
         else {
-            jl_throw(jl_new_struct(jl_initerror_type, m->name,
-                                   jl_current_exception()));
+            jl_rethrow_other(jl_new_struct(jl_initerror_type, m->name,
+                                           jl_current_exception()));
         }
     }
 }

--- a/test/backtrace.jl
+++ b/test/backtrace.jl
@@ -199,7 +199,7 @@ let trace = try
 
             """, "a_filename")
     catch
-        stacktrace(Base.catch_stack()[end-1][2]) # Ignore LoadError
+        stacktrace(catch_backtrace())
     end
     @test trace[1].func == Symbol("top-level scope")
     @test trace[1].file == :a_filename
@@ -213,7 +213,7 @@ let trace = try
 
             """, "a_filename")
     catch
-        stacktrace(Base.catch_stack()[end-1][2]) # Ignore LoadError
+        stacktrace(catch_backtrace())
     end
     @test trace[1].func == Symbol("top-level scope")
     @test trace[1].file == :a_filename

--- a/test/precompile.jl
+++ b/test/precompile.jl
@@ -372,7 +372,7 @@ try
           error("break me")
           end
           """)
-    @test_warn r"ERROR: Error while loading expression starting at.*FooBar2.*caused by.*break me"s try
+    @test_warn "ERROR: LoadError: break me\nStacktrace:\n [1] error" try
         Base.require(Main, :FooBar2)
         error("\"LoadError: break me\" test failed")
     catch exc


### PR DESCRIPTION
Fix #31830 in the simplest way possible by reverting commit d3dbe86f49da6779c2f3af8354c6a3933f48fcad + fixup new tests in backtrace.jl

This fix is for expediency and stability in the julia-1.2 release (see https://github.com/JuliaLang/julia/pull/31882#issuecomment-488402382, https://github.com/JuliaLang/julia/pull/31882#issuecomment-489794979); I expect we will move forward with #31882 in julia-1.3 as a better way to clean up this code.