### PR TITLE
Patch LLVM AMDGPU addrspace no-ops, change Julia's addrspaces

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -459,7 +459,7 @@ $(eval $(call LLVM_PATCH,llvm-6.0-D63688-wasm-isLocal))
 $(eval $(call LLVM_PATCH,llvm-6.0-D64032-cmake-cross))
 $(eval $(call LLVM_PATCH,llvm-6.0-D64225-cmake-cross2))
 $(eval $(call LLVM_PATCH,llvm6-WASM-addrspaces)) # WebAssembly
-$(eval $(call LLVM_PATCH,llvm-AMDGPU-addrspaces)) # AMDGPU
+$(eval $(call LLVM_PATCH,llvm6-AMDGPU-addrspaces)) # AMDGPU
 endif # LLVM_VER 6.0
 
 ifeq ($(LLVM_VER_SHORT),7.0)
@@ -477,6 +477,7 @@ $(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
 $(eval $(call LLVM_PATCH,llvm-rL349068-llvm-config)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm7-WASM-addrspaces)) # WebAssembly
 $(eval $(call LLVM_PATCH,llvm7-revert-D44485))
+$(eval $(call LLVM_PATCH,llvm7-AMDGPU-addrspaces)) # AMDGPU
 endif # LLVM_VER 7.0
 
 ifeq ($(LLVM_VER_SHORT),8.0)
@@ -494,6 +495,7 @@ $(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-8.0-D66401-mingw-reloc)) # remove for 9.0
 $(eval $(call LLVM_PATCH,llvm7-revert-D44485))
+$(eval $(call LLVM_PATCH,llvm8-AMDGPU-addrspaces)) # AMDGPU
 endif # LLVM_VER 8.0
 
 ifeq ($(LLVM_VER_SHORT),9.0)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -459,6 +459,7 @@ $(eval $(call LLVM_PATCH,llvm-6.0-D63688-wasm-isLocal))
 $(eval $(call LLVM_PATCH,llvm-6.0-D64032-cmake-cross))
 $(eval $(call LLVM_PATCH,llvm-6.0-D64225-cmake-cross2))
 $(eval $(call LLVM_PATCH,llvm6-WASM-addrspaces)) # WebAssembly
+$(eval $(call LLVM_PATCH,llvm-AMDGPU-addrspaces)) # AMDGPU
 endif # LLVM_VER 6.0
 
 ifeq ($(LLVM_VER_SHORT),7.0)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -510,6 +510,7 @@ $(eval $(call LLVM_PATCH,llvm8-WASM-addrspaces)) # WebAssembly
 $(eval $(call LLVM_PATCH,llvm-exegesis-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm-test-plugin-mingw)) # mingw build
 $(eval $(call LLVM_PATCH,llvm7-revert-D44485))
+$(eval $(call LLVM_PATCH,llvm8-AMDGPU-addrspaces)) # AMDGPU
 endif # LLVM_VER 9.0
 
 

--- a/deps/patches/llvm-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm-AMDGPU-addrspaces.patch
@@ -4,14 +4,14 @@ Date: Mon, 18 Mar 2019 16:18:40 -0400
 Subject: [PATCH] AMDGPU ignore custom AS
 
 ---
- llvm/lib/Target/AMDGPU/AMDGPU.h           | 1 +
- llvm/lib/Target/AMDGPU/SIISelLowering.cpp | 4 ++--
+ lib/Target/AMDGPU/AMDGPU.h           | 1 +
+ lib/Target/AMDGPU/SIISelLowering.cpp | 4 ++--
  2 files changed, 3 insertions(+), 2 deletions(-)
 
-diff --git a/llvm/lib/Target/AMDGPU/AMDGPU.h b/llvm/lib/Target/AMDGPU/AMDGPU.h
+diff --git a/lib/Target/AMDGPU/AMDGPU.h b/lib/Target/AMDGPU/AMDGPU.h
 index 0ddc43ad503..6065abf6732 100644
---- a/llvm/lib/Target/AMDGPU/AMDGPU.h
-+++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
+--- a/lib/Target/AMDGPU/AMDGPU.h
++++ b/lib/Target/AMDGPU/AMDGPU.h
 @@ -251,6 +251,7 @@ struct AMDGPUAS {
      CONSTANT_BUFFER_13 = 21,
      CONSTANT_BUFFER_14 = 22,
@@ -20,10 +20,10 @@ index 0ddc43ad503..6065abf6732 100644
  
      // Some places use this if the address space can't be determined.
      UNKNOWN_ADDRESS_SPACE = ~0u,
-diff --git a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
 index 41ca7fe8bfa..90108c8be98 100644
---- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
-+++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+--- a/lib/Target/AMDGPU/SIISelLowering.cpp
++++ b/lib/Target/AMDGPU/SIISelLowering.cpp
 @@ -1063,8 +1063,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
  
  bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,

--- a/deps/patches/llvm-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm-AMDGPU-addrspaces.patch
@@ -1,0 +1,40 @@
+From de496d3cdf5d77967c04a7d6c599f8f7e53e9c9f Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Mon, 18 Mar 2019 16:18:40 -0400
+Subject: [PATCH] AMDGPU ignore custom AS
+
+---
+ llvm/lib/Target/AMDGPU/AMDGPU.h           | 1 +
+ llvm/lib/Target/AMDGPU/SIISelLowering.cpp | 4 ++--
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/llvm/lib/Target/AMDGPU/AMDGPU.h b/llvm/lib/Target/AMDGPU/AMDGPU.h
+index 0ddc43ad503..6065abf6732 100644
+--- a/llvm/lib/Target/AMDGPU/AMDGPU.h
++++ b/llvm/lib/Target/AMDGPU/AMDGPU.h
+@@ -251,6 +251,7 @@ struct AMDGPUAS {
+     CONSTANT_BUFFER_13 = 21,
+     CONSTANT_BUFFER_14 = 22,
+     CONSTANT_BUFFER_15 = 23,
++    LAST = CONSTANT_BUFFER_15,
+ 
+     // Some places use this if the address space can't be determined.
+     UNKNOWN_ADDRESS_SPACE = ~0u,
+diff --git a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+index 41ca7fe8bfa..90108c8be98 100644
+--- a/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
++++ b/llvm/lib/Target/AMDGPU/SIISelLowering.cpp
+@@ -1063,8 +1063,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
+ 
+ bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
+                                            unsigned DestAS) const {
+-  return isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) &&
+-         isFlatGlobalAddrSpace(DestAS, AMDGPUASI);
++  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
++         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
+ }
+ 
+ bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
+-- 
+2.21.0
+

--- a/deps/patches/llvm6-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm6-AMDGPU-addrspaces.patch
@@ -17,15 +17,26 @@ index 0ddc43ad503..6065abf6732 100644
      CONSTANT_BUFFER_14 = 22,
      CONSTANT_BUFFER_15 = 23,
 +    LAST = CONSTANT_BUFFER_15,
- 
+
      // Some places use this if the address space can't be determined.
      UNKNOWN_ADDRESS_SPACE = ~0u,
 diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
 index 41ca7fe8bfa..90108c8be98 100644
 --- a/lib/Target/AMDGPU/SIISelLowering.cpp
 +++ b/lib/Target/AMDGPU/SIISelLowering.cpp
+@@ -1009,6 +1009,8 @@ bool SITargetLowering::isLegalAddressingMode(const DataLayout &DL,
+     // addressing modes, so treat them as having no offset like flat
+     // instructions.
+     return isLegalFlatAddressingMode(AM);
++  } else if (AS > AMDGPUASI.LAST) {
++    return true;
+   } else {
+     llvm_unreachable("unhandled address space");
+   }
+--- a/lib/Target/AMDGPU/SIISelLowering.cpp
++++ b/lib/Target/AMDGPU/SIISelLowering.cpp
 @@ -1063,8 +1063,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
- 
+
  bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
                                             unsigned DestAS) const {
 -  return isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) &&
@@ -33,8 +44,8 @@ index 41ca7fe8bfa..90108c8be98 100644
 +  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
 +         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
  }
- 
+
  bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
--- 
+--
 2.18.1
 

--- a/deps/patches/llvm6-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm6-AMDGPU-addrspaces.patch
@@ -1,0 +1,40 @@
+From 16fdc6cee678a195fee4f31d308b9adb1e4e2c19 Mon Sep 17 00:00:00 2001
+From: Julian P Samaroo <jpsamaroo@jpsamaroo.me>
+Date: Sun, 12 May 2019 00:00:00 -0500
+Subject: [PATCH] AMDGPU ignore custom AS
+
+---
+ lib/Target/AMDGPU/AMDGPU.h           | 1 +
+ lib/Target/AMDGPU/SIISelLowering.cpp | 4 ++--
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Target/AMDGPU/AMDGPU.h b/lib/Target/AMDGPU/AMDGPU.h
+index 0ddc43ad503..6065abf6732 100644
+--- a/lib/Target/AMDGPU/AMDGPU.h
++++ b/lib/Target/AMDGPU/AMDGPU.h
+@@ -251,6 +251,7 @@ struct AMDGPUAS {
+     CONSTANT_BUFFER_13 = 21,
+     CONSTANT_BUFFER_14 = 22,
+     CONSTANT_BUFFER_15 = 23,
++    LAST = CONSTANT_BUFFER_15,
+ 
+     // Some places use this if the address space can't be determined.
+     UNKNOWN_ADDRESS_SPACE = ~0u,
+diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
+index 41ca7fe8bfa..90108c8be98 100644
+--- a/lib/Target/AMDGPU/SIISelLowering.cpp
++++ b/lib/Target/AMDGPU/SIISelLowering.cpp
+@@ -1063,8 +1063,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
+ 
+ bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
+                                            unsigned DestAS) const {
+-  return isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) &&
+-         isFlatGlobalAddrSpace(DestAS, AMDGPUASI);
++  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
++         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
+ }
+ 
+ bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
+-- 
+2.18.1
+

--- a/deps/patches/llvm7-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm7-AMDGPU-addrspaces.patch
@@ -1,0 +1,56 @@
+From 86d8f85b0157aa8ce17840adc1121dbc7ae35262 Mon Sep 17 00:00:00 2001
+From: Valentin Churavy <v.churavy@gmail.com>
+Date: Mon, 18 Mar 2019 16:18:40 -0400
+Subject: [PATCH] AMDGPU ignore custom AS
+
+---
+ lib/Target/AMDGPU/AMDGPU.h           | 5 +++++
+ lib/Target/AMDGPU/SIISelLowering.cpp | 9 +++++++--
+ 2 files changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/lib/Target/AMDGPU/AMDGPU.h b/lib/Target/AMDGPU/AMDGPU.h
+index 2b49c2ea88e..6992ae5e51d 100644
+--- a/lib/Target/AMDGPU/AMDGPU.h
++++ b/lib/Target/AMDGPU/AMDGPU.h
+@@ -264,6 +264,11 @@ struct AMDGPUAS {
+     CONSTANT_BUFFER_13 = 21,
+     CONSTANT_BUFFER_14 = 22,
+     CONSTANT_BUFFER_15 = 23,
++    JULIA_TRACKED = 100,
++    JULIA_DERIVED = 101,
++    JULIA_CALLEE_ROOTED = 102,
++    JULIA_LOADED = 103,
++    LAST = JULIA_LOADED,
+ 
+     // Some places use this if the address space can't be determined.
+     UNKNOWN_ADDRESS_SPACE = ~0u,
+diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
+index 25007861fd1..c59016453a2 100644
+--- a/lib/Target/AMDGPU/SIISelLowering.cpp
++++ b/lib/Target/AMDGPU/SIISelLowering.cpp
+@@ -1009,6 +1009,11 @@ bool SITargetLowering::isLegalAddressingMode(const DataLayout &DL,
+     // addressing modes, so treat them as having no offset like flat
+     // instructions.
+     return isLegalFlatAddressingMode(AM);
++  } else if (AS == AMDGPUASI.JULIA_TRACKED ||
++             AS == AMDGPUASI.JULIA_DERIVED ||
++             AS == AMDGPUASI.JULIA_CALLEE_ROOTED ||
++             AS == AMDGPUASI.JULIA_LOADED) {
++    return true;
+   } else {
+     llvm_unreachable("unhandled address space");
+   }
+@@ -1118,8 +1123,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
+ 
+ bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
+                                            unsigned DestAS) const {
+-  return isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) &&
+-         isFlatGlobalAddrSpace(DestAS, AMDGPUASI);
++  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
++         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
+ }
+ 
+ bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
+-- 
+2.21.0
+

--- a/deps/patches/llvm7-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm7-AMDGPU-addrspaces.patch
@@ -4,44 +4,37 @@ Date: Mon, 18 Mar 2019 16:18:40 -0400
 Subject: [PATCH] AMDGPU ignore custom AS
 
 ---
- lib/Target/AMDGPU/AMDGPU.h           | 5 +++++
+ lib/Target/AMDGPU/AMDGPU.h           | 1 +
  lib/Target/AMDGPU/SIISelLowering.cpp | 9 +++++++--
- 2 files changed, 12 insertions(+), 2 deletions(-)
+ 2 files changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/lib/Target/AMDGPU/AMDGPU.h b/lib/Target/AMDGPU/AMDGPU.h
 index 2b49c2ea88e..6992ae5e51d 100644
 --- a/lib/Target/AMDGPU/AMDGPU.h
 +++ b/lib/Target/AMDGPU/AMDGPU.h
-@@ -264,6 +264,11 @@ struct AMDGPUAS {
+@@ -264,6 +264,7 @@ struct AMDGPUAS {
      CONSTANT_BUFFER_13 = 21,
      CONSTANT_BUFFER_14 = 22,
      CONSTANT_BUFFER_15 = 23,
-+    JULIA_TRACKED = 100,
-+    JULIA_DERIVED = 101,
-+    JULIA_CALLEE_ROOTED = 102,
-+    JULIA_LOADED = 103,
-+    LAST = JULIA_LOADED,
- 
++    LAST = CONSTANT_BUFFER_15,
+
      // Some places use this if the address space can't be determined.
      UNKNOWN_ADDRESS_SPACE = ~0u,
 diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
 index 25007861fd1..c59016453a2 100644
 --- a/lib/Target/AMDGPU/SIISelLowering.cpp
 +++ b/lib/Target/AMDGPU/SIISelLowering.cpp
-@@ -1009,6 +1009,11 @@ bool SITargetLowering::isLegalAddressingMode(const DataLayout &DL,
+@@ -1009,6 +1009,8 @@ bool SITargetLowering::isLegalAddressingMode(const DataLayout &DL,
      // addressing modes, so treat them as having no offset like flat
      // instructions.
      return isLegalFlatAddressingMode(AM);
-+  } else if (AS == AMDGPUASI.JULIA_TRACKED ||
-+             AS == AMDGPUASI.JULIA_DERIVED ||
-+             AS == AMDGPUASI.JULIA_CALLEE_ROOTED ||
-+             AS == AMDGPUASI.JULIA_LOADED) {
++  } else if (AS > AMDGPUASI.LAST) {
 +    return true;
    } else {
      llvm_unreachable("unhandled address space");
    }
 @@ -1118,8 +1123,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
- 
+
  bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
                                             unsigned DestAS) const {
 -  return isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) &&
@@ -49,8 +42,8 @@ index 25007861fd1..c59016453a2 100644
 +  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
 +         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
  }
- 
+
  bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
--- 
+--
 2.21.0
 

--- a/deps/patches/llvm8-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm8-AMDGPU-addrspaces.patch
@@ -17,23 +17,34 @@ index 55668867cc8..0b6de567051 100644
      CONSTANT_BUFFER_14 = 22,
      CONSTANT_BUFFER_15 = 23,
 +    LAST = CONSTANT_BUFFER_15,
- 
+
      // Some places use this if the address space can't be determined.
      UNKNOWN_ADDRESS_SPACE = ~0u,
 diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
 index 12113fcc1fc..7e4cd209788 100644
 --- a/lib/Target/AMDGPU/SIISelLowering.cpp
 +++ b/lib/Target/AMDGPU/SIISelLowering.cpp
+@@ -1009,6 +1009,8 @@ bool SITargetLowering::isLegalAddressingMode(const DataLayout &DL,
+     // addressing modes, so treat them as having no offset like flat
+     // instructions.
+     return isLegalFlatAddressingMode(AM);
++  } else if (AS > AMDGPUASI.LAST) {
++    return true;
+   } else {
+     llvm_unreachable("unhandled address space");
+   }
+--- a/lib/Target/AMDGPU/SIISelLowering.cpp
++++ b/lib/Target/AMDGPU/SIISelLowering.cpp
 @@ -1210,7 +1210,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS) {
- 
+
  bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
                                             unsigned DestAS) const {
 -  return isFlatGlobalAddrSpace(SrcAS) && isFlatGlobalAddrSpace(DestAS);
 +  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
 +         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
  }
- 
+
  bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
--- 
+--
 2.18.1
 

--- a/deps/patches/llvm8-AMDGPU-addrspaces.patch
+++ b/deps/patches/llvm8-AMDGPU-addrspaces.patch
@@ -1,18 +1,18 @@
-From de496d3cdf5d77967c04a7d6c599f8f7e53e9c9f Mon Sep 17 00:00:00 2001
-From: Valentin Churavy <v.churavy@gmail.com>
-Date: Mon, 18 Mar 2019 16:18:40 -0400
+From 9d25d80ebd46b7651f22ea59d904c8833c83cf3c Mon Sep 17 00:00:00 2001
+From: Julian P Samaroo <jpsamaroo@jpsamaroo.me>
+Date: Sun, 12 May 2019 00:00:00 -0500
 Subject: [PATCH] AMDGPU ignore custom AS
 
 ---
  lib/Target/AMDGPU/AMDGPU.h           | 1 +
- lib/Target/AMDGPU/SIISelLowering.cpp | 4 ++--
- 2 files changed, 3 insertions(+), 2 deletions(-)
+ lib/Target/AMDGPU/SIISelLowering.cpp | 3 ++-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/lib/Target/AMDGPU/AMDGPU.h b/lib/Target/AMDGPU/AMDGPU.h
-index 0ddc43ad503..6065abf6732 100644
+index 55668867cc8..0b6de567051 100644
 --- a/lib/Target/AMDGPU/AMDGPU.h
 +++ b/lib/Target/AMDGPU/AMDGPU.h
-@@ -251,6 +251,7 @@ struct AMDGPUAS {
+@@ -289,6 +289,7 @@ namespace AMDGPUAS {
      CONSTANT_BUFFER_13 = 21,
      CONSTANT_BUFFER_14 = 22,
      CONSTANT_BUFFER_15 = 23,
@@ -21,20 +21,19 @@ index 0ddc43ad503..6065abf6732 100644
      // Some places use this if the address space can't be determined.
      UNKNOWN_ADDRESS_SPACE = ~0u,
 diff --git a/lib/Target/AMDGPU/SIISelLowering.cpp b/lib/Target/AMDGPU/SIISelLowering.cpp
-index 41ca7fe8bfa..90108c8be98 100644
+index 12113fcc1fc..7e4cd209788 100644
 --- a/lib/Target/AMDGPU/SIISelLowering.cpp
 +++ b/lib/Target/AMDGPU/SIISelLowering.cpp
-@@ -1063,8 +1063,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS, AMDGPUAS AMDGPUASI) {
+@@ -1210,7 +1210,8 @@ static bool isFlatGlobalAddrSpace(unsigned AS) {
  
  bool SITargetLowering::isNoopAddrSpaceCast(unsigned SrcAS,
                                             unsigned DestAS) const {
--  return isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) &&
--         isFlatGlobalAddrSpace(DestAS, AMDGPUASI);
+-  return isFlatGlobalAddrSpace(SrcAS) && isFlatGlobalAddrSpace(DestAS);
 +  return (isFlatGlobalAddrSpace(SrcAS, AMDGPUASI) || SrcAS > AMDGPUASI.LAST) &&
 +         (isFlatGlobalAddrSpace(DestAS, AMDGPUASI) || DestAS > AMDGPUASI.LAST);
  }
  
  bool SITargetLowering::isMemOpHasNoClobberedMemOperand(const SDNode *N) const {
 -- 
-2.21.0
+2.18.1
 

--- a/doc/src/devdocs/llvm.md
+++ b/doc/src/devdocs/llvm.md
@@ -285,7 +285,7 @@ duration of this [`ccall`](@ref). We then take this information and represent
 it in an "operand bundle" at the IR level. An operand bundle is essentially a fake
 use that is attached to the call site. At the IR level, this looks like so:
 ```llvm
-call void inttoptr (i64 ... to void (double*)*)(double* %5) [ "jl_roots"(%jl_value_t addrspace(10)* %A) ]
+call void inttoptr (i64 ... to void (double*)*)(double* %5) [ "jl_roots"(%jl_value_t addrspace(100)* %A) ]
 ```
 The GC root placement pass will treat the `jl_roots` operand bundle as if it were
 a regular operand. However, as a final step, after the GC roots are inserted,
@@ -298,7 +298,7 @@ explicit control of GC rooting. By our above invariants, this function is illega
 because it performs an address space cast from 10 to 0. However, it can be useful,
 in certain situations, so we provide a special intrinsic:
 ```llvm
-declared %jl_value_t *julia.pointer_from_objref(%jl_value_t addrspace(10)*)
+declared %jl_value_t *julia.pointer_from_objref(%jl_value_t addrspace(100)*)
 ```
 which is lowered to the corresponding address space cast after GC root lowering.
 Do note however that by using this intrinsic, the caller assumes all responsibility

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -7737,7 +7737,7 @@ extern "C" void *jl_init_llvm(void)
 
     // Mark our address spaces as non-integral
     jl_data_layout = jl_ExecutionEngine->getDataLayout();
-    std::string DL = jl_data_layout.getStringRepresentation() + "-ni:10:11:12:13";
+    std::string DL = jl_data_layout.getStringRepresentation() + "-ni:100:101:102:103";
     jl_data_layout.reset(DL);
 
 // Register GDB event listener

--- a/src/codegen_shared.h
+++ b/src/codegen_shared.h
@@ -7,10 +7,10 @@
 
 enum AddressSpace {
     Generic = 0,
-    Tracked = 10,
-    Derived = 11,
-    CalleeRooted = 12,
-    Loaded = 13,
+    Tracked = 100,
+    Derived = 101,
+    CalleeRooted = 102,
+    Loaded = 103,
     FirstSpecial = Tracked,
     LastSpecial = Loaded,
 };

--- a/src/jitlayers.cpp
+++ b/src/jitlayers.cpp
@@ -1061,7 +1061,7 @@ void jl_dump_native(const char *bc_fname, const char *unopt_bc_fname, const char
     // Reset the target triple to make sure it matches the new target machine
     shadow_output->setTargetTriple(TM->getTargetTriple().str());
     DataLayout DL = TM->createDataLayout();
-    DL.reset(DL.getStringRepresentation() + "-ni:10:11:12:13");
+    DL.reset(DL.getStringRepresentation() + "-ni:100:101:102:103");
     shadow_output->setDataLayout(DL);
 
     // add metadata information

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -183,11 +183,11 @@ using namespace llvm;
       in:
 
       A:
-        %Abase = load addrspace(10) *...
-        %Aderived = addrspacecast %Abase to addrspace(11)
+        %Abase = load addrspace(100) *...
+        %Aderived = addrspacecast %Abase to addrspace(101)
       B:
-        %Bbase = load addrspace(10) *...
-        %Bderived = addrspacecast %Bbase to addrspace(11)
+        %Bbase = load addrspace(100) *...
+        %Bderived = addrspacecast %Bbase to addrspace(101)
       C:
         %phi = phi [%Aderived, %A
                     %Bderived, %B]

--- a/test/llvmpasses/alloc-opt.jl
+++ b/test/llvmpasses/alloc-opt.jl
@@ -6,19 +6,19 @@ isz = sizeof(UInt) == 8 ? "i64" : "i32"
 
 println("""
 %jl_value_t = type opaque
-@tag = external addrspace(10) global %jl_value_t
+@tag = external addrspace(100) global %jl_value_t
 """)
 
 # CHECK-LABEL: @return_obj
 # CHECK-NOT: @julia.gc_alloc_obj
-# CHECK: %v = call noalias nonnull %jl_value_t addrspace(10)* @jl_gc_pool_alloc
-# CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* {{.*}}, !tbaa !0
+# CHECK: %v = call noalias nonnull %jl_value_t addrspace(100)* @jl_gc_pool_alloc
+# CHECK: store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* {{.*}}, !tbaa !0
 println("""
-define %jl_value_t addrspace(10)* @return_obj() {
+define %jl_value_t addrspace(100)* @return_obj() {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  ret %jl_value_t addrspace(10)* %v
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  ret %jl_value_t addrspace(100)* %v
 }
 """)
 # CHECK-LABEL: }
@@ -34,12 +34,12 @@ println("""
 define i64 @return_load(i64 %i) {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %v64 = bitcast %jl_value_t addrspace(10)* %v to i64 addrspace(10)*
-  %v64a11 = addrspacecast i64 addrspace(10)* %v64 to i64 addrspace(11)*
-  store i64 %i, i64 addrspace(11)* %v64a11, align 16, !tbaa !4
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %v64 = bitcast %jl_value_t addrspace(100)* %v to i64 addrspace(100)*
+  %v64a11 = addrspacecast i64 addrspace(100)* %v64 to i64 addrspace(101)*
+  store i64 %i, i64 addrspace(101)* %v64a11, align 16, !tbaa !4
   call void @external_function()
-  %l = load i64, i64 addrspace(11)* %v64a11, align 16, !tbaa !4
+  %l = load i64, i64 addrspace(101)* %v64a11, align 16, !tbaa !4
   ret i64 %l
 }
 """)
@@ -49,14 +49,14 @@ define i64 @return_load(i64 %i) {
 # CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @jl_gc_pool_alloc
-# CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* {{.*}}, !tbaa !0
+# CHECK: store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* {{.*}}, !tbaa !0
 println("""
 define void @ccall_obj(i8* %fptr) {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %f = bitcast i8* %fptr to void (%jl_value_t addrspace(10)*)*
-  call void %f(%jl_value_t addrspace(10)* %v)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %f = bitcast i8* %fptr to void (%jl_value_t addrspace(100)*)*
+  call void %f(%jl_value_t addrspace(100)* %v)
   ret void
 }
 """)
@@ -76,12 +76,12 @@ println("""
 define void @ccall_ptr(i8* %fptr) {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
-  %ptrj = call %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(11)* %va)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %va = addrspacecast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(101)*
+  %ptrj = call %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(101)* %va)
   %ptr = bitcast %jl_value_t* %ptrj to i8*
   %f = bitcast i8* %fptr to void (i8*)*
-  call void %f(i8* %ptr) [ "jl_roots"(%jl_value_t addrspace(10)* %v), "unknown_bundle"(i8* %ptr) ]
+  call void %f(i8* %ptr) [ "jl_roots"(%jl_value_t addrspace(100)* %v), "unknown_bundle"(i8* %ptr) ]
   ret void
 }
 """)
@@ -91,17 +91,17 @@ define void @ccall_ptr(i8* %fptr) {
 # CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK: @jl_gc_pool_alloc
-# CHECK: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* {{.*}}, !tbaa !0
+# CHECK: store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* {{.*}}, !tbaa !0
 println("""
 define void @ccall_unknown_bundle(i8* %fptr) {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
-  %ptrj = call %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(11)* %va)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %va = addrspacecast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(101)*
+  %ptrj = call %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(101)* %va)
   %ptr = bitcast %jl_value_t* %ptrj to i8*
   %f = bitcast i8* %fptr to void (i8*)*
-  call void %f(i8* %ptr) [ "jl_not_jl_roots"(%jl_value_t addrspace(10)* %v) ]
+  call void %f(i8* %ptr) [ "jl_not_jl_roots"(%jl_value_t addrspace(100)* %v) ]
   ret void
 }
 """)
@@ -130,12 +130,12 @@ define void @lifetime_branches(i8* %fptr, i1 %b, i1 %b2) {
   br i1 %b, label %L1, label %L3
 
 L1:
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
-  %ptrj = call %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(11)* %va)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %va = addrspacecast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(101)*
+  %ptrj = call %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(101)* %va)
   %ptr = bitcast %jl_value_t* %ptrj to i8*
   %f = bitcast i8* %fptr to void (i8*)*
-  call void %f(i8* %ptr) [ "jl_roots"(%jl_value_t addrspace(10)* %v) ]
+  call void %f(i8* %ptr) [ "jl_roots"(%jl_value_t addrspace(100)* %v) ]
   br i1 %b2, label %L2, label %L3
 
 L2:
@@ -153,15 +153,15 @@ L3:
 # CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK-NOT: @julia.gc_alloc_obj
 # CHECK-NOT: @jl_gc_pool_alloc
-# CHECK-NOT: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* {{.*}}, !tbaa !0
+# CHECK-NOT: store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* {{.*}}, !tbaa !0
 println("""
-define void @object_field(%jl_value_t addrspace(10)* %field) {
+define void @object_field(%jl_value_t addrspace(100)* %field) {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %va = addrspacecast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(11)*
-  %vab = bitcast %jl_value_t addrspace(11)* %va to %jl_value_t addrspace(10)* addrspace(11)*
-  store %jl_value_t addrspace(10)* %field, %jl_value_t addrspace(10)* addrspace(11)* %vab
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %va = addrspacecast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(101)*
+  %vab = bitcast %jl_value_t addrspace(101)* %va to %jl_value_t addrspace(100)* addrspace(101)*
+  store %jl_value_t addrspace(100)* %field, %jl_value_t addrspace(100)* addrspace(101)* %vab
   ret void
 }
 """)
@@ -178,10 +178,10 @@ define void @memcpy_opt(i8* %v22) {
 top:
   %v6 = call %jl_value_t*** @julia.ptls_states()
   %v18 = bitcast %jl_value_t*** %v6 to i8*
-  %v19 = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %v18, $isz 16, %jl_value_t addrspace(10)* @tag)
-  %v20 = bitcast %jl_value_t addrspace(10)* %v19 to i8 addrspace(10)*
-  %v21 = addrspacecast i8 addrspace(10)* %v20 to i8 addrspace(11)*
-  call void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* %v21, i8* %v22, i64 16, i32 8, i1 false)
+  %v19 = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %v18, $isz 16, %jl_value_t addrspace(100)* @tag)
+  %v20 = bitcast %jl_value_t addrspace(100)* %v19 to i8 addrspace(100)*
+  %v21 = addrspacecast i8 addrspace(100)* %v20 to i8 addrspace(101)*
+  call void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(101)* %v21, i8* %v22, i64 16, i32 8, i1 false)
   ret void
 }
 """)
@@ -198,10 +198,10 @@ define void @preserve_opt(i8* %v22) {
 top:
   %v6 = call %jl_value_t*** @julia.ptls_states()
   %v18 = bitcast %jl_value_t*** %v6 to i8*
-  %v19 = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %v18, $isz 16, %jl_value_t addrspace(10)* @tag)
-  %v20 = bitcast %jl_value_t addrspace(10)* %v19 to i8 addrspace(10)*
-  %v21 = addrspacecast i8 addrspace(10)* %v20 to i8 addrspace(11)*
-  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(10)* %v19)
+  %v19 = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %v18, $isz 16, %jl_value_t addrspace(100)* @tag)
+  %v20 = bitcast %jl_value_t addrspace(100)* %v19 to i8 addrspace(100)*
+  %v21 = addrspacecast i8 addrspace(100)* %v20 to i8 addrspace(101)*
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(100)* %v19)
   call void @external_function()
   call void @llvm.julia.gc_preserve_end(token %tok)
   call void @external_function()
@@ -228,8 +228,8 @@ define void @preserve_branches(i8* %fptr, i1 %b, i1 %b2) {
   br i1 %b, label %L1, label %L3
 
 L1:
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(10)* %v)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(100)* %v)
   call void @external_function()
   br i1 %b2, label %L2, label %L3
 
@@ -243,14 +243,14 @@ L3:
 """)
 # CHECK-LABEL: }
 
-# CHECK: declare noalias nonnull %jl_value_t addrspace(10)* @jl_gc_pool_alloc(i8*,
-# CHECK: declare noalias nonnull %jl_value_t addrspace(10)* @jl_gc_big_alloc(i8*,
+# CHECK: declare noalias nonnull %jl_value_t addrspace(100)* @jl_gc_pool_alloc(i8*,
+# CHECK: declare noalias nonnull %jl_value_t addrspace(100)* @jl_gc_big_alloc(i8*,
 println("""
 declare void @external_function()
 declare %jl_value_t*** @julia.ptls_states()
-declare noalias nonnull %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, %jl_value_t addrspace(10)*)
-declare %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(11)*)
-declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)
+declare noalias nonnull %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8*, $isz, %jl_value_t addrspace(100)*)
+declare %jl_value_t* @julia.pointer_from_objref(%jl_value_t addrspace(101)*)
+declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(101)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)
 declare token @llvm.julia.gc_preserve_begin(...)
 declare void @llvm.julia.gc_preserve_end(token)
 

--- a/test/llvmpasses/alloc-opt2.jl
+++ b/test/llvmpasses/alloc-opt2.jl
@@ -6,7 +6,7 @@ isz = sizeof(UInt) == 8 ? "i64" : "i32"
 
 println("""
 %jl_value_t = type opaque
-@tag = external addrspace(10) global %jl_value_t
+@tag = external addrspace(100) global %jl_value_t
 """)
 
 # Test that the gc_preserve intrinsics are deleted directly.
@@ -30,8 +30,8 @@ define void @preserve_branches(i8* %fptr, i1 %b, i1 %b2) {
   br i1 %b, label %L1, label %L3
 
 L1:
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(10)* %v)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(100)* %v)
   call void @external_function()
   br i1 %b2, label %L2, label %L3
 
@@ -48,7 +48,7 @@ L3:
 # CHECK-LABEL: @preserve_branches2
 # CHECK: call %jl_value_t*** @julia.ptls_states()
 # CHECK: L1:
-# CHECK-NEXT: @llvm.julia.gc_preserve_begin{{.*}}%jl_value_t addrspace(10)* %v2
+# CHECK-NEXT: @llvm.julia.gc_preserve_begin{{.*}}%jl_value_t addrspace(100)* %v2
 # CHECK-NEXT: @external_function()
 # CHECK-NEXT: br i1 %b2, label %L2, label %L3
 
@@ -61,12 +61,12 @@ println("""
 define void @preserve_branches2(i8* %fptr, i1 %b, i1 %b2) {
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-  %v2 = call %jl_value_t addrspace(10)* @external_function2()
+  %v2 = call %jl_value_t addrspace(100)* @external_function2()
   br i1 %b, label %L1, label %L3
 
 L1:
-  %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(10)* @tag)
-  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(10)* %v, %jl_value_t addrspace(10)* %v2)
+  %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, $isz 8, %jl_value_t addrspace(100)* @tag)
+  %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(100)* %v, %jl_value_t addrspace(100)* %v2)
   call void @external_function()
   br i1 %b2, label %L2, label %L3
 
@@ -82,11 +82,11 @@ L3:
 
 println("""
 declare void @external_function()
-declare %jl_value_t addrspace(10)* @external_function2()
+declare %jl_value_t addrspace(100)* @external_function2()
 declare %jl_value_t*** @julia.ptls_states()
-declare noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8*, $isz, %jl_value_t addrspace(10)*)
-declare i64 @julia.pointer_from_objref(%jl_value_t addrspace(11)*)
-declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(11)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)
+declare noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8*, $isz, %jl_value_t addrspace(100)*)
+declare i64 @julia.pointer_from_objref(%jl_value_t addrspace(101)*)
+declare void @llvm.memcpy.p11i8.p0i8.i64(i8 addrspace(101)* nocapture writeonly, i8* nocapture readonly, i64, i32, i1)
 declare token @llvm.julia.gc_preserve_begin(...)
 declare void @llvm.julia.gc_preserve_end(token)
 """)

--- a/test/llvmpasses/final-lower-gc.ll
+++ b/test/llvmpasses/final-lower-gc.ll
@@ -1,71 +1,71 @@
 ; RUN: opt -load libjulia%shlibext -FinalLowerGC -S %s | FileCheck %s
 
 %jl_value_t = type opaque
-@tag = external addrspace(10) global %jl_value_t
+@tag = external addrspace(100) global %jl_value_t
 
-declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
-declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare void @boxed_simple(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)*)
+declare %jl_value_t addrspace(100)* @jl_box_int64(i64)
 declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
-declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
+declare %jl_value_t addrspace(100)* @jl_apply_generic(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)**, i32)
 
-declare noalias nonnull %jl_value_t addrspace(10)** @julia.new_gc_frame(i32)
-declare void @julia.push_gc_frame(%jl_value_t addrspace(10)**, i32)
-declare %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)**, i32)
-declare void @julia.pop_gc_frame(%jl_value_t addrspace(10)**)
-declare noalias nonnull %jl_value_t addrspace(10)* @julia.gc_alloc_bytes(i8*, i64) #0
+declare noalias nonnull %jl_value_t addrspace(100)** @julia.new_gc_frame(i32)
+declare void @julia.push_gc_frame(%jl_value_t addrspace(100)**, i32)
+declare %jl_value_t addrspace(100)** @julia.get_gc_frame_slot(%jl_value_t addrspace(100)**, i32)
+declare void @julia.pop_gc_frame(%jl_value_t addrspace(100)**)
+declare noalias nonnull %jl_value_t addrspace(100)* @julia.gc_alloc_bytes(i8*, i64) #0
 
 attributes #0 = { allocsize(1) }
 
 define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @gc_frame_lowering
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
-  %gcframe = call %jl_value_t addrspace(10)** @julia.new_gc_frame(i32 2)
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
+  %gcframe = call %jl_value_t addrspace(100)** @julia.new_gc_frame(i32 2)
 ; CHECK: %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls = call %jl_value_t*** @julia.ptls_states()
-; CHECK-DAG: [[GCFRAME_SIZE_PTR:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 0
-; CHECK-DAG: [[GCFRAME_SIZE_PTR2:%.*]] = bitcast %jl_value_t addrspace(10)** [[GCFRAME_SIZE_PTR]] to i64*
+; CHECK-DAG: [[GCFRAME_SIZE_PTR:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 0
+; CHECK-DAG: [[GCFRAME_SIZE_PTR2:%.*]] = bitcast %jl_value_t addrspace(100)** [[GCFRAME_SIZE_PTR]] to i64*
 ; CHECK-DAG: store i64 4, i64* [[GCFRAME_SIZE_PTR2]], !tbaa !0
 ; CHECK-DAG: [[GCFRAME_SLOT:%.*]] = getelementptr %jl_value_t**, %jl_value_t*** %ptls, i32 0
-; CHECK-DAG: [[PREV_GCFRAME_PTR:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
-; CHECK-DAG: [[PREV_GCFRAME_PTR2:%.*]] = bitcast %jl_value_t addrspace(10)** [[PREV_GCFRAME_PTR]] to %jl_value_t***
+; CHECK-DAG: [[PREV_GCFRAME_PTR:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 1
+; CHECK-DAG: [[PREV_GCFRAME_PTR2:%.*]] = bitcast %jl_value_t addrspace(100)** [[PREV_GCFRAME_PTR]] to %jl_value_t***
 ; CHECK-DAG: [[PREV_GCFRAME:%.*]] = load %jl_value_t**, %jl_value_t*** [[GCFRAME_SLOT]]
 ; CHECK-DAG: store %jl_value_t** [[PREV_GCFRAME]], %jl_value_t*** [[PREV_GCFRAME_PTR2]], !tbaa !0
-; CHECK-DAG: [[GCFRAME_SLOT2:%.*]] = bitcast %jl_value_t*** [[GCFRAME_SLOT]] to %jl_value_t addrspace(10)***
-; CHECK-NEXT: store %jl_value_t addrspace(10)** %gcframe, %jl_value_t addrspace(10)*** [[GCFRAME_SLOT2]]
-  call void @julia.push_gc_frame(%jl_value_t addrspace(10)** %gcframe, i32 2)
-  %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: %frame_slot_1 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 3
-  %frame_slot_1 = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 1)
-  store %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)** %frame_slot_1
-  %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
-; CHECK: %frame_slot_2 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 2
-  %frame_slot_2 = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 0)
-  store %jl_value_t addrspace(10)* %bboxed, %jl_value_t addrspace(10)** %frame_slot_2
-; CHECK: call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)* %bboxed)
-  call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)* %bboxed)
-; CHECK-NEXT: [[PREV_GCFRAME_PTR3:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 1
-; CHECK-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** [[PREV_GCFRAME_PTR3]], !tbaa !0
+; CHECK-DAG: [[GCFRAME_SLOT2:%.*]] = bitcast %jl_value_t*** [[GCFRAME_SLOT]] to %jl_value_t addrspace(100)***
+; CHECK-NEXT: store %jl_value_t addrspace(100)** %gcframe, %jl_value_t addrspace(100)*** [[GCFRAME_SLOT2]]
+  call void @julia.push_gc_frame(%jl_value_t addrspace(100)** %gcframe, i32 2)
+  %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: %frame_slot_1 = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 3
+  %frame_slot_1 = call %jl_value_t addrspace(100)** @julia.get_gc_frame_slot(%jl_value_t addrspace(100)** %gcframe, i32 1)
+  store %jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)** %frame_slot_1
+  %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
+; CHECK: %frame_slot_2 = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 2
+  %frame_slot_2 = call %jl_value_t addrspace(100)** @julia.get_gc_frame_slot(%jl_value_t addrspace(100)** %gcframe, i32 0)
+  store %jl_value_t addrspace(100)* %bboxed, %jl_value_t addrspace(100)** %frame_slot_2
+; CHECK: call void @boxed_simple(%jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)* %bboxed)
+  call void @boxed_simple(%jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)* %bboxed)
+; CHECK-NEXT: [[PREV_GCFRAME_PTR3:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 1
+; CHECK-NEXT: [[PREV_GCFRAME_PTR4:%.*]] = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** [[PREV_GCFRAME_PTR3]], !tbaa !0
 ; CHECK-NEXT: [[GCFRAME_SLOT3:%.*]] = getelementptr %jl_value_t**, %jl_value_t*** %ptls, i32 0
-; CHECK-NEXT: [[GCFRAME_SLOT4:%.*]] = bitcast %jl_value_t*** [[GCFRAME_SLOT3]] to %jl_value_t addrspace(10)**
-; CHECK-NEXT: store %jl_value_t addrspace(10)* [[PREV_GCFRAME_PTR4]], %jl_value_t addrspace(10)** [[GCFRAME_SLOT4]], !tbaa !0
-  call void @julia.pop_gc_frame(%jl_value_t addrspace(10)** %gcframe)
+; CHECK-NEXT: [[GCFRAME_SLOT4:%.*]] = bitcast %jl_value_t*** [[GCFRAME_SLOT3]] to %jl_value_t addrspace(100)**
+; CHECK-NEXT: store %jl_value_t addrspace(100)* [[PREV_GCFRAME_PTR4]], %jl_value_t addrspace(100)** [[GCFRAME_SLOT4]], !tbaa !0
+  call void @julia.pop_gc_frame(%jl_value_t addrspace(100)** %gcframe)
 ; CHECK-NEXT: ret void
   ret void
 }
 
-define %jl_value_t addrspace(10)* @gc_alloc_lowering() {
+define %jl_value_t addrspace(100)* @gc_alloc_lowering() {
 top:
 ; CHECK-LABEL: @gc_alloc_lowering
   %ptls = call %jl_value_t*** @julia.ptls_states()
   %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-; CHECK: %v = call noalias nonnull %jl_value_t addrspace(10)* @jl_gc_pool_alloc
-  %v = call %jl_value_t addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, i64 8)
-  %0 = bitcast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(10)* addrspace(10)*
-  %1 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %0, i64 -1
-  store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* %1, !tbaa !0
-  ret %jl_value_t addrspace(10)* %v
+; CHECK: %v = call noalias nonnull %jl_value_t addrspace(100)* @jl_gc_pool_alloc
+  %v = call %jl_value_t addrspace(100)* @julia.gc_alloc_bytes(i8* %ptls_i8, i64 8)
+  %0 = bitcast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(100)* addrspace(100)*
+  %1 = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %0, i64 -1
+  store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* %1, !tbaa !0
+  ret %jl_value_t addrspace(100)* %v
 }
 
 !0 = !{!1, !1, i64 0}

--- a/test/llvmpasses/gcroots.ll
+++ b/test/llvmpasses/gcroots.ll
@@ -2,131 +2,131 @@
 
 %jl_value_t = type opaque
 
-declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
-declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare void @boxed_simple(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)*)
+declare %jl_value_t addrspace(100)* @jl_box_int64(i64)
 declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
-declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
+declare %jl_value_t addrspace(100)* @jl_apply_generic(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)**, i32)
 
 define void @simple(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @simple
     %ptls = call %jl_value_t*** @julia.ptls_states()
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
-; CHECK: call %jl_value_t addrspace(10)* @jl_box_int64
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
-; CHECK-NEXT: store %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)** [[GEP0]]
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
+; CHECK: call %jl_value_t addrspace(100)* @jl_box_int64
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
+; CHECK-NEXT: store %jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)** [[GEP0]]
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
 ; CHECK-NEXT: %bboxed =
 ; Make sure the same gc slot isn't re-used
-; CHECK-NOT: getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0]]
-; CHECK: [[GEP1:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT1:[0-9]+]]
-; CHECK-NEXT: store %jl_value_t addrspace(10)* %bboxed, %jl_value_t addrspace(10)** [[GEP1]]
+; CHECK-NOT: getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0]]
+; CHECK: [[GEP1:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT1:[0-9]+]]
+; CHECK-NEXT: store %jl_value_t addrspace(100)* %bboxed, %jl_value_t addrspace(100)** [[GEP1]]
 ; CHECK-NEXT: call void @boxed_simple
-    call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed,
-                            %jl_value_t addrspace(10)* %bboxed)
+    call void @boxed_simple(%jl_value_t addrspace(100)* %aboxed,
+                            %jl_value_t addrspace(100)* %bboxed)
     ret void
 }
 
-define void @leftover_alloca(%jl_value_t addrspace(10)* %a) {
+define void @leftover_alloca(%jl_value_t addrspace(100)* %a) {
 ; If this pass encounters an alloca, it'll just sink it into the gcframe,
 ; relying on mem2reg to catch simple cases such as this earlier
 ; CHECK-LABEL: @leftover_alloca
-; CHECK: %var = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe
+; CHECK: %var = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %var = alloca %jl_value_t addrspace(10)*
-    store %jl_value_t addrspace(10)* %a, %jl_value_t addrspace(10)** %var
-    %b = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %var
-    call void @boxed_simple(%jl_value_t addrspace(10)* %a,
-                            %jl_value_t addrspace(10)* %b)
+    %var = alloca %jl_value_t addrspace(100)*
+    store %jl_value_t addrspace(100)* %a, %jl_value_t addrspace(100)** %var
+    %b = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %var
+    call void @boxed_simple(%jl_value_t addrspace(100)* %a,
+                            %jl_value_t addrspace(100)* %b)
     ret void
 }
 
-declare {%jl_value_t addrspace(10)*, i8} @union_ret()
-declare void @union_arg({%jl_value_t addrspace(10)*, i8})
+declare {%jl_value_t addrspace(100)*, i8} @union_ret()
+declare void @union_arg({%jl_value_t addrspace(100)*, i8})
 
 define void @simple_union() {
 ; CHECK-LABEL: @simple_union
     %ptls = call %jl_value_t*** @julia.ptls_states()
-; CHECK: %a = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
-    %a = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
-; CHECK: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
-; CHECK-NEXT: [[EXTRACT:%.*]] = extractvalue { %jl_value_t addrspace(10)*, i8 } %a, 0
-; CHECK-NEXT: store %jl_value_t addrspace(10)* [[EXTRACT]], %jl_value_t addrspace(10)** [[GEP0]]
-    call void @union_arg({%jl_value_t addrspace(10)*, i8} %a)
+; CHECK: %a = call { %jl_value_t addrspace(100)*, i8 } @union_ret()
+    %a = call { %jl_value_t addrspace(100)*, i8 } @union_ret()
+; CHECK: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
+; CHECK-NEXT: [[EXTRACT:%.*]] = extractvalue { %jl_value_t addrspace(100)*, i8 } %a, 0
+; CHECK-NEXT: store %jl_value_t addrspace(100)* [[EXTRACT]], %jl_value_t addrspace(100)** [[GEP0]]
+    call void @union_arg({%jl_value_t addrspace(100)*, i8} %a)
     ret void
 }
 
-declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
+declare void @one_arg_boxed(%jl_value_t addrspace(100)*)
 
 define void @select_simple(i64 %a, i64 %b) {
 ; CHECK-LABEL: @select_simple
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
     %cmp = icmp eq i64 %a, %b
-    %selectb = select i1 %cmp, %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)* %bboxed
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %selectb)
+    %selectb = select i1 %cmp, %jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)* %bboxed
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %selectb)
     ret void
 }
 
 define void @phi_simple(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @phi_simple
-; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK:   %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
     %cmp = icmp eq i64 %a, %b
     br i1 %cmp, label %alabel, label %blabel
 alabel:
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
     br label %common
 blabel:
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
     br label %common
 common:
-    %phi = phi %jl_value_t addrspace(10)* [ %aboxed, %alabel ], [ %bboxed, %blabel ]
-; CHECK:  [[GEP:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 2
-; CHECK:  store %jl_value_t addrspace(10)* %phi, %jl_value_t addrspace(10)** [[GEP]]
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %phi)
+    %phi = phi %jl_value_t addrspace(100)* [ %aboxed, %alabel ], [ %bboxed, %blabel ]
+; CHECK:  [[GEP:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 2
+; CHECK:  store %jl_value_t addrspace(100)* %phi, %jl_value_t addrspace(100)** [[GEP]]
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %phi)
     ret void
 }
 
-declare void @one_arg_decayed(i64 addrspace(12)*)
+declare void @one_arg_decayed(i64 addrspace(102)*)
 
 define void @select_lift(i64 %a, i64 %b) {
 ; CHECK-LABEL: @select_lift
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %adecayed = addrspacecast %jl_value_t addrspace(10)* %aboxed to i64 addrspace(12)*
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
-    %bdecayed = addrspacecast %jl_value_t addrspace(10)* %bboxed to i64 addrspace(12)*
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %adecayed = addrspacecast %jl_value_t addrspace(100)* %aboxed to i64 addrspace(102)*
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
+    %bdecayed = addrspacecast %jl_value_t addrspace(100)* %bboxed to i64 addrspace(102)*
     %cmp = icmp eq i64 %a, %b
-; CHECK: %gclift = select i1 %cmp, %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)* %bboxed
-    %selectb = select i1 %cmp, i64 addrspace(12)* %adecayed, i64 addrspace(12)* %bdecayed
-    call void @one_arg_decayed(i64 addrspace(12)* %selectb)
+; CHECK: %gclift = select i1 %cmp, %jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)* %bboxed
+    %selectb = select i1 %cmp, i64 addrspace(102)* %adecayed, i64 addrspace(102)* %bdecayed
+    call void @one_arg_decayed(i64 addrspace(102)* %selectb)
     ret void
 }
 
 define void @phi_lift(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @phi_lift
-; CHECK: %gclift = phi %jl_value_t addrspace(10)* [ %aboxed, %alabel ], [ %bboxed, %blabel ], [ %gclift, %common ]
+; CHECK: %gclift = phi %jl_value_t addrspace(100)* [ %aboxed, %alabel ], [ %bboxed, %blabel ], [ %gclift, %common ]
     %ptls = call %jl_value_t*** @julia.ptls_states()
     %cmp = icmp eq i64 %a, %b
     br i1 %cmp, label %alabel, label %blabel
 alabel:
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %adecayed = addrspacecast %jl_value_t addrspace(10)* %aboxed to i64 addrspace(12)*
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %adecayed = addrspacecast %jl_value_t addrspace(100)* %aboxed to i64 addrspace(102)*
     br label %common
 blabel:
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
-    %bdecayed = addrspacecast %jl_value_t addrspace(10)* %bboxed to i64 addrspace(12)*
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
+    %bdecayed = addrspacecast %jl_value_t addrspace(100)* %bboxed to i64 addrspace(102)*
     br label %common
 common:
-    %phi = phi i64 addrspace(12)* [ %adecayed, %alabel ], [ %bdecayed, %blabel ], [ %phi, %common ]
-    call void @one_arg_decayed(i64 addrspace(12)* %phi)
+    %phi = phi i64 addrspace(102)* [ %adecayed, %alabel ], [ %bdecayed, %blabel ], [ %phi, %common ]
+    call void @one_arg_decayed(i64 addrspace(102)* %phi)
     br label %common
 }
 
@@ -138,79 +138,79 @@ top:
     %cmp = icmp eq i64 %a, %b
     br i1 %cmp, label %alabel, label %blabel
 alabel:
-    %u = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
-; CHECK: %aboxed = extractvalue { %jl_value_t addrspace(10)*, i8 } %u, 0
-    %aboxed = extractvalue { %jl_value_t addrspace(10)*, i8 } %u, 0
-    %adecayed = addrspacecast %jl_value_t addrspace(10)* %aboxed to i64 addrspace(12)*
+    %u = call { %jl_value_t addrspace(100)*, i8 } @union_ret()
+; CHECK: %aboxed = extractvalue { %jl_value_t addrspace(100)*, i8 } %u, 0
+    %aboxed = extractvalue { %jl_value_t addrspace(100)*, i8 } %u, 0
+    %adecayed = addrspacecast %jl_value_t addrspace(100)* %aboxed to i64 addrspace(102)*
 ; CHECK: br label %common
     br label %common
 blabel:
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
-    %bdecayed = addrspacecast %jl_value_t addrspace(10)* %bboxed to i64 addrspace(12)*
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
+    %bdecayed = addrspacecast %jl_value_t addrspace(100)* %bboxed to i64 addrspace(102)*
     br label %common
 common:
-; CHECK: %gclift = phi %jl_value_t addrspace(10)* [ %aboxed, %alabel ], [ %bboxed, %blabel ]
-    %phi = phi i64 addrspace(12)* [ %adecayed, %alabel ], [ %bdecayed, %blabel ]
-    call void @one_arg_decayed(i64 addrspace(12)* %phi)
+; CHECK: %gclift = phi %jl_value_t addrspace(100)* [ %aboxed, %alabel ], [ %bboxed, %blabel ]
+    %phi = phi i64 addrspace(102)* [ %adecayed, %alabel ], [ %bdecayed, %blabel ]
+    call void @one_arg_decayed(i64 addrspace(102)* %phi)
     ret void
 }
 
 define void @live_if_live_out(i64 %a, i64 %b) {
 ; CHECK-LABEL: @live_if_live_out
 top:
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
     %ptls = call %jl_value_t*** @julia.ptls_states()
 ; The failure case is failing to realize that `aboxed` is live across the first
 ; one_arg_boxed safepoint and putting bboxed in the same root slot
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %bboxed)
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %bboxed)
     br label %succ
 succ:
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %aboxed)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %aboxed)
     ret void
 }
 
 ; A ret is a use - make sure the value is kept alive for any intervening
 ; safepoint
-define %jl_value_t addrspace(10)* @ret_use(i64 %a, i64 %b) {
+define %jl_value_t addrspace(100)* @ret_use(i64 %a, i64 %b) {
 ; CHECK-LABEL: @ret_use
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: store %jl_value_t addrspace(10)* %aboxed
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
-    ret %jl_value_t addrspace(10)* %aboxed
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: store %jl_value_t addrspace(100)* %aboxed
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
+    ret %jl_value_t addrspace(100)* %aboxed
 }
 
-define {%jl_value_t addrspace(10)*, i8} @ret_use_struct() {
+define {%jl_value_t addrspace(100)*, i8} @ret_use_struct() {
 ; CHECK-LABEL: @ret_use_struct
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
-; CHECK: %aunion = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
-    %aunion = call { %jl_value_t addrspace(10)*, i8 } @union_ret()
-; CHECK-DAG: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
-; CHECK-DAG: [[EXTRACT:%.*]] = extractvalue { %jl_value_t addrspace(10)*, i8 } %aunion, 0
-; CHECK-NEXT: store %jl_value_t addrspace(10)* [[EXTRACT]], %jl_value_t addrspace(10)** [[GEP0]]
+; CHECK: %aunion = call { %jl_value_t addrspace(100)*, i8 } @union_ret()
+    %aunion = call { %jl_value_t addrspace(100)*, i8 } @union_ret()
+; CHECK-DAG: [[GEP0:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
+; CHECK-DAG: [[EXTRACT:%.*]] = extractvalue { %jl_value_t addrspace(100)*, i8 } %aunion, 0
+; CHECK-NEXT: store %jl_value_t addrspace(100)* [[EXTRACT]], %jl_value_t addrspace(100)** [[GEP0]]
 ; CHECK-NEXT: call void @jl_safepoint()
     call void @jl_safepoint()
-    ret {%jl_value_t addrspace(10)*, i8} %aunion
+    ret {%jl_value_t addrspace(100)*, i8} %aunion
 }
 
 
-define i8 @nosafepoint(%jl_value_t addrspace(10)* dereferenceable(16)) {
+define i8 @nosafepoint(%jl_value_t addrspace(100)* dereferenceable(16)) {
 ; CHECK-LABEL: @nosafepoint
 ; CHECK-NOT: %gcframe
 top:
   %1 = call %jl_value_t*** @julia.ptls_states()
-  %2 = bitcast %jl_value_t*** %1 to %jl_value_t addrspace(10)**
-  %3 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %2, i64 3
-  %4 = bitcast %jl_value_t addrspace(10)** %3 to i64**
+  %2 = bitcast %jl_value_t*** %1 to %jl_value_t addrspace(100)**
+  %3 = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %2, i64 3
+  %4 = bitcast %jl_value_t addrspace(100)** %3 to i64**
   %5 = load i64*, i64** %4
-  %6 = bitcast %jl_value_t addrspace(10)* %0 to i8 addrspace(10)*
-  %7 = addrspacecast i8 addrspace(10)* %6 to i8 addrspace(11)*
-  %8 = getelementptr i8, i8 addrspace(11)* %7, i64 0
-  %9 = load i8, i8 addrspace(11)* %8
+  %6 = bitcast %jl_value_t addrspace(100)* %0 to i8 addrspace(100)*
+  %7 = addrspacecast i8 addrspace(100)* %6 to i8 addrspace(101)*
+  %8 = getelementptr i8, i8 addrspace(101)* %7, i64 0
+  %9 = load i8, i8 addrspace(101)* %8
   %10 = trunc i8 %9 to i1
   %11 = zext i1 %10 to i8
   %12 = xor i8 %11, 1
@@ -219,21 +219,21 @@ top:
 
 define void @global_ref() {
 ; CHECK-LABEL: @global_ref
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %loaded = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** getelementptr (%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** inttoptr (i64 140540744325952 to %jl_value_t addrspace(10)**), i64 1)
-; CHECK: store %jl_value_t addrspace(10)* %loaded, %jl_value_t addrspace(10)**
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %loaded)
+    %loaded = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** getelementptr (%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** inttoptr (i64 140540744325952 to %jl_value_t addrspace(100)**), i64 1)
+; CHECK: store %jl_value_t addrspace(100)* %loaded, %jl_value_t addrspace(100)**
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %loaded)
     ret void
 }
 
-define %jl_value_t addrspace(10)* @no_redundant_rerooting(i64 %a, i1 %cond) {
+define %jl_value_t addrspace(100)* @no_redundant_rerooting(i64 %a, i1 %cond) {
 ; CHECK-LABEL: @no_redundant_rerooting
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: store %jl_value_t addrspace(10)* %aboxed
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: store %jl_value_t addrspace(100)* %aboxed
 ; CHECK-NEXT: call void @jl_safepoint()
     call void @jl_safepoint()
     br i1 %cond, label %blocka, label %blockb
@@ -241,26 +241,26 @@ blocka:
 ; CHECK-NOT: call void @jl_safepoint()
 ; CHECK: call void @jl_safepoint()
     call void @jl_safepoint()
-    ret %jl_value_t addrspace(10)* %aboxed
+    ret %jl_value_t addrspace(100)* %aboxed
 blockb:
 ; CHECK-NOT: call void @jl_safepoint()
 ; CHECK: call void @jl_safepoint()
     call void @jl_safepoint()
-    ret %jl_value_t addrspace(10)* %aboxed
+    ret %jl_value_t addrspace(100)* %aboxed
 }
 
-declare void @llvm.memcpy.p064.p10i8.i64(i64*, i8 addrspace(10)*, i64, i32, i1)
+declare void @llvm.memcpy.p064.p10i8.i64(i64*, i8 addrspace(100)*, i64, i32, i1)
 
 define void @memcpy_use(i64 %a, i64 *%aptr) {
 ; CHECK-LABEL: @memcpy_use
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: store %jl_value_t addrspace(10)* %aboxed
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: store %jl_value_t addrspace(100)* %aboxed
     call void @jl_safepoint()
-    %acast = bitcast %jl_value_t addrspace(10)* %aboxed to i8 addrspace(10)*
-    call void @llvm.memcpy.p064.p10i8.i64(i64* %aptr, i8 addrspace(10)* %acast, i64 8, i32 1, i1 false)
+    %acast = bitcast %jl_value_t addrspace(100)* %aboxed to i8 addrspace(100)*
+    call void @llvm.memcpy.p064.p10i8.i64(i64* %aptr, i8 addrspace(100)* %acast, i64 8, i32 1, i1 false)
     ret void
 }
 
@@ -269,183 +269,183 @@ declare void @llvm.julia.gc_preserve_end(token)
 
 define void @gc_preserve(i64 %a) {
 ; CHECK-LABEL: @gc_preserve
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: store %jl_value_t addrspace(10)* %aboxed
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: store %jl_value_t addrspace(100)* %aboxed
     call void @jl_safepoint()
-    %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(10)* %aboxed)
-    %aboxed2 = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: store %jl_value_t addrspace(10)* %aboxed2
+    %tok = call token (...) @llvm.julia.gc_preserve_begin(%jl_value_t addrspace(100)* %aboxed)
+    %aboxed2 = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: store %jl_value_t addrspace(100)* %aboxed2
     call void @jl_safepoint()
     call void @llvm.julia.gc_preserve_end(token %tok)
-    %aboxed3 = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: store %jl_value_t addrspace(10)* %aboxed3
+    %aboxed3 = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: store %jl_value_t addrspace(100)* %aboxed3
     call void @jl_safepoint()
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %aboxed2)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %aboxed3)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %aboxed2)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %aboxed3)
     ret void
 }
 
 @gv1 = external global %jl_value_t*
-@gv2 = external global %jl_value_t addrspace(10)*
+@gv2 = external global %jl_value_t addrspace(100)*
 
-define %jl_value_t addrspace(10)* @gv_const() {
+define %jl_value_t addrspace(100)* @gv_const() {
 ; CHECK-LABEL: @gv_const
 ; CHECK-NOT: %gcframe
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
     %v10 = load %jl_value_t*, %jl_value_t** @gv1, !tbaa !2
-    %v1 = addrspacecast %jl_value_t* %v10 to %jl_value_t addrspace(10)*
-    %v2 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** @gv2, !tbaa !2
+    %v1 = addrspacecast %jl_value_t* %v10 to %jl_value_t addrspace(100)*
+    %v2 = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** @gv2, !tbaa !2
     call void @jl_safepoint()
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %v1)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %v2)
-    ret %jl_value_t addrspace(10)* %v1
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %v1)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %v2)
+    ret %jl_value_t addrspace(100)* %v1
 }
 
-define %jl_value_t addrspace(10)* @vec_jlcallarg(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32) {
+define %jl_value_t addrspace(100)* @vec_jlcallarg(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)**, i32) {
 ; CHECK-LABEL: @vec_jlcallarg
 ; CHECK-NOT: %gcframe
   %v4 = call %jl_value_t*** @julia.ptls_states()
-  %v5 = bitcast %jl_value_t addrspace(10)** %1 to <2 x %jl_value_t addrspace(10)*>*
-  %v6 = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*>* %v5, align 8
-  %v7 = extractelement <2 x %jl_value_t addrspace(10)*> %v6, i32 0
-  ret %jl_value_t addrspace(10)* %v7
+  %v5 = bitcast %jl_value_t addrspace(100)** %1 to <2 x %jl_value_t addrspace(100)*>*
+  %v6 = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*>* %v5, align 8
+  %v7 = extractelement <2 x %jl_value_t addrspace(100)*> %v6, i32 0
+  ret %jl_value_t addrspace(100)* %v7
 }
 
-declare %jl_value_t addrspace(10) *@alloc()
+declare %jl_value_t addrspace(100) *@alloc()
 
-define %jl_value_t addrspace(10)* @vec_loadobj() {
+define %jl_value_t addrspace(100)* @vec_loadobj() {
 ; CHECK-LABEL: @vec_loadobj
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
   %v4 = call %jl_value_t*** @julia.ptls_states()
-  %obj = call %jl_value_t addrspace(10) *@alloc()
-  %v1 = bitcast %jl_value_t addrspace(10) * %obj to %jl_value_t addrspace(10)* addrspace(10)*
-  %v5 = bitcast %jl_value_t addrspace(10)* addrspace(10)* %v1 to <2 x %jl_value_t addrspace(10)*> addrspace(10)*
-  %v6 = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*> addrspace(10)* %v5, align 8
-  %obj2 = call %jl_value_t addrspace(10) *@alloc()
-  %v7 = extractelement <2 x %jl_value_t addrspace(10)*> %v6, i32 0
-  ret %jl_value_t addrspace(10)* %v7
+  %obj = call %jl_value_t addrspace(100) *@alloc()
+  %v1 = bitcast %jl_value_t addrspace(100) * %obj to %jl_value_t addrspace(100)* addrspace(100)*
+  %v5 = bitcast %jl_value_t addrspace(100)* addrspace(100)* %v1 to <2 x %jl_value_t addrspace(100)*> addrspace(100)*
+  %v6 = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*> addrspace(100)* %v5, align 8
+  %obj2 = call %jl_value_t addrspace(100) *@alloc()
+  %v7 = extractelement <2 x %jl_value_t addrspace(100)*> %v6, i32 0
+  ret %jl_value_t addrspace(100)* %v7
 }
 
-define %jl_value_t addrspace(10)* @vec_gep() {
+define %jl_value_t addrspace(100)* @vec_gep() {
 ; CHECK-LABEL: @vec_gep
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
   %v4 = call %jl_value_t*** @julia.ptls_states()
-  %obj = call %jl_value_t addrspace(10) *@alloc()
-  %obj1 = bitcast %jl_value_t addrspace(10) * %obj to %jl_value_t addrspace(10)* addrspace(10)*
-  %v1 = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %obj1, <2 x i32> < i32 0, i32 0 >
+  %obj = call %jl_value_t addrspace(100) *@alloc()
+  %obj1 = bitcast %jl_value_t addrspace(100) * %obj to %jl_value_t addrspace(100)* addrspace(100)*
+  %v1 = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %obj1, <2 x i32> < i32 0, i32 0 >
   call void @jl_safepoint()
-  %obj2 = extractelement <2 x %jl_value_t addrspace(10)* addrspace(10)*> %v1, i32 0
-  %obj3 = bitcast %jl_value_t addrspace(10)* addrspace(10)* %obj2 to %jl_value_t addrspace(10)*
-  ret %jl_value_t addrspace(10)* %obj3
+  %obj2 = extractelement <2 x %jl_value_t addrspace(100)* addrspace(100)*> %v1, i32 0
+  %obj3 = bitcast %jl_value_t addrspace(100)* addrspace(100)* %obj2 to %jl_value_t addrspace(100)*
+  ret %jl_value_t addrspace(100)* %obj3
 }
 
-declare i1 @check_property(%jl_value_t addrspace(10)* %val)
-define void @loopyness(i1 %cond1, %jl_value_t addrspace(10) *%arg) {
+declare i1 @check_property(%jl_value_t addrspace(100)* %val)
+define void @loopyness(i1 %cond1, %jl_value_t addrspace(100) *%arg) {
 ; CHECK-LABEL: @loopyness
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
     br label %header
 
 header:
-    %phi = phi %jl_value_t addrspace(10)* [null, %top], [%obj, %latch]
+    %phi = phi %jl_value_t addrspace(100)* [null, %top], [%obj, %latch]
     br i1 %cond1, label %a, label %latch
 
 a:
 ; This needs a store
 ; CHECK-LABEL: a:
-; CHECK:  [[GEP1:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
-; CHECK:  store %jl_value_t addrspace(10)* %phi, %jl_value_t addrspace(10)** [[GEP1]]
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %phi)
+; CHECK:  [[GEP1:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0:[0-9]+]]
+; CHECK:  store %jl_value_t addrspace(100)* %phi, %jl_value_t addrspace(100)** [[GEP1]]
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %phi)
     br label %latch
 
 latch:
 ; This as well in case we went the other path
-; CHECK:  [[GEP2:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0]]
-; CHECK:  store %jl_value_t addrspace(10)* %phi, %jl_value_t addrspace(10)** [[GEP2]]
-    %obj = call %jl_value_t addrspace(10)* @alloc()
-    %cond = call i1 @check_property(%jl_value_t addrspace(10)* %phi)
+; CHECK:  [[GEP2:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0]]
+; CHECK:  store %jl_value_t addrspace(100)* %phi, %jl_value_t addrspace(100)** [[GEP2]]
+    %obj = call %jl_value_t addrspace(100)* @alloc()
+    %cond = call i1 @check_property(%jl_value_t addrspace(100)* %phi)
     br i1 %cond, label %exit, label %header
 
 exit:
     ret void
 }
 
-define %jl_value_t addrspace(10)* @phi_union(i1 %cond) {
+define %jl_value_t addrspace(100)* @phi_union(i1 %cond) {
 ; CHECK-LABEL: @phi_union
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
 top:
   %ptls = call %jl_value_t*** @julia.ptls_states()
   br i1 %cond, label %a, label %b
 
 a:
-  %obj = call %jl_value_t addrspace(10) *@alloc()
-  %aobj = insertvalue {%jl_value_t addrspace(10)*, i8} undef, %jl_value_t addrspace(10)* %obj, 0
-  %aunion = insertvalue {%jl_value_t addrspace(10)*, i8} undef, i8 -126, 1
+  %obj = call %jl_value_t addrspace(100) *@alloc()
+  %aobj = insertvalue {%jl_value_t addrspace(100)*, i8} undef, %jl_value_t addrspace(100)* %obj, 0
+  %aunion = insertvalue {%jl_value_t addrspace(100)*, i8} undef, i8 -126, 1
   br label %join
 
 b:
-  %bunion = call {%jl_value_t addrspace(10)*, i8} @union_ret()
+  %bunion = call {%jl_value_t addrspace(100)*, i8} @union_ret()
   br label %join
 
 join:
-  %phi = phi {%jl_value_t addrspace(10)*, i8} [%aunion, %a], [%bunion, %b]
+  %phi = phi {%jl_value_t addrspace(100)*, i8} [%aunion, %a], [%bunion, %b]
   call void @jl_safepoint()
-  %rval = extractvalue { %jl_value_t addrspace(10)*, i8 } %phi, 0
-  ret %jl_value_t addrspace(10)* %rval
+  %rval = extractvalue { %jl_value_t addrspace(100)*, i8 } %phi, 0
+  ret %jl_value_t addrspace(100)* %rval
 }
 
-define %jl_value_t addrspace(10)* @select_union(i1 %cond) {
+define %jl_value_t addrspace(100)* @select_union(i1 %cond) {
 ; CHECK-LABEL: @select_union
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
 top:
   %ptls = call %jl_value_t*** @julia.ptls_states()
-  %obj = call %jl_value_t addrspace(10) *@alloc()
-  %aobj = insertvalue {%jl_value_t addrspace(10)*, i8} undef, %jl_value_t addrspace(10)* %obj, 0
-  %aunion = insertvalue {%jl_value_t addrspace(10)*, i8} undef, i8 -126, 1
-  %bunion = call {%jl_value_t addrspace(10)*, i8} @union_ret()
-  %select = select i1 %cond, {%jl_value_t addrspace(10)*, i8} %aunion, {%jl_value_t addrspace(10)*, i8} %bunion
+  %obj = call %jl_value_t addrspace(100) *@alloc()
+  %aobj = insertvalue {%jl_value_t addrspace(100)*, i8} undef, %jl_value_t addrspace(100)* %obj, 0
+  %aunion = insertvalue {%jl_value_t addrspace(100)*, i8} undef, i8 -126, 1
+  %bunion = call {%jl_value_t addrspace(100)*, i8} @union_ret()
+  %select = select i1 %cond, {%jl_value_t addrspace(100)*, i8} %aunion, {%jl_value_t addrspace(100)*, i8} %bunion
   call void @jl_safepoint()
-  %rval = extractvalue { %jl_value_t addrspace(10)*, i8 } %select, 0
-  ret %jl_value_t addrspace(10)* %rval
+  %rval = extractvalue { %jl_value_t addrspace(100)*, i8 } %select, 0
+  ret %jl_value_t addrspace(100)* %rval
 }
 
 define i8 @simple_arrayptr() {
 ; CHECK-LABEL: @simple_arrayptr
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
    %ptls = call %jl_value_t*** @julia.ptls_states()
-   %obj1 = call %jl_value_t addrspace(10) *@alloc()
-   %obj2 = call %jl_value_t addrspace(10) *@alloc()
-   %decayed = addrspacecast %jl_value_t addrspace(10) *%obj1 to %jl_value_t addrspace(11) *
-   %arrayptrptr = bitcast %jl_value_t addrspace(11) *%decayed to i8 addrspace(13)* addrspace(11)*
-   %arrayptr = load i8 addrspace(13)*, i8 addrspace(13)* addrspace(11)* %arrayptrptr
+   %obj1 = call %jl_value_t addrspace(100) *@alloc()
+   %obj2 = call %jl_value_t addrspace(100) *@alloc()
+   %decayed = addrspacecast %jl_value_t addrspace(100) *%obj1 to %jl_value_t addrspace(101) *
+   %arrayptrptr = bitcast %jl_value_t addrspace(101) *%decayed to i8 addrspace(103)* addrspace(101)*
+   %arrayptr = load i8 addrspace(103)*, i8 addrspace(103)* addrspace(101)* %arrayptrptr
    call void @jl_safepoint()
-   call void @one_arg_boxed(%jl_value_t addrspace(10) *%obj2)
-   %val = load i8, i8 addrspace(13)* %arrayptr
+   call void @one_arg_boxed(%jl_value_t addrspace(100) *%obj2)
+   %val = load i8, i8 addrspace(103)* %arrayptr
    ret i8 %val
 }
 
-define %jl_value_t addrspace(10)* @vecstoreload(<2 x %jl_value_t addrspace(10)*> *%arg) {
+define %jl_value_t addrspace(100)* @vecstoreload(<2 x %jl_value_t addrspace(100)*> *%arg) {
 ; CHECK-LABEL: @vecstoreload
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %loaded = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*> *%arg
+    %loaded = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*> *%arg
     call void @jl_safepoint()
-    %obj = call %jl_value_t addrspace(10) *@alloc()
-    %casted = bitcast %jl_value_t addrspace(10)* %obj to <2 x %jl_value_t addrspace(10)*> addrspace(10)*
-    store <2 x %jl_value_t addrspace(10)*> %loaded, <2 x %jl_value_t addrspace(10)*> addrspace(10)* %casted
-    ret %jl_value_t addrspace(10)* %obj
+    %obj = call %jl_value_t addrspace(100) *@alloc()
+    %casted = bitcast %jl_value_t addrspace(100)* %obj to <2 x %jl_value_t addrspace(100)*> addrspace(100)*
+    store <2 x %jl_value_t addrspace(100)*> %loaded, <2 x %jl_value_t addrspace(100)*> addrspace(100)* %casted
+    ret %jl_value_t addrspace(100)* %obj
 }
 
-define void @vecphi(i1 %cond, <2 x %jl_value_t addrspace(10)*> *%arg) {
+define void @vecphi(i1 %cond, <2 x %jl_value_t addrspace(100)*> *%arg) {
 ; CHECK-LABEL: @vecphi
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
     br i1 %cond, label %A, label %B
@@ -454,38 +454,38 @@ A:
     br label %common
 
 B:
-    %loaded = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*> *%arg
+    %loaded = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*> *%arg
     call void @jl_safepoint()
     br label %common
 
 common:
-    %phi = phi <2 x %jl_value_t addrspace(10)*> [ zeroinitializer, %A ], [ %loaded, %B ]
+    %phi = phi <2 x %jl_value_t addrspace(100)*> [ zeroinitializer, %A ], [ %loaded, %B ]
     call void @jl_safepoint()
-    %el1 = extractelement <2 x %jl_value_t addrspace(10)*> %phi, i32 0
-    %el2 = extractelement <2 x %jl_value_t addrspace(10)*> %phi, i32 1
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %el1)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %el2)
+    %el1 = extractelement <2 x %jl_value_t addrspace(100)*> %phi, i32 0
+    %el2 = extractelement <2 x %jl_value_t addrspace(100)*> %phi, i32 1
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %el1)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %el2)
     unreachable
 }
 
 define i8 @phi_arrayptr(i1 %cond) {
 ; CHECK-LABEL: @phi_arrayptr
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
     br i1 %cond, label %A, label %B
 
 A:
-    %obj1 = call %jl_value_t addrspace(10) *@alloc()
-    %obj2 = call %jl_value_t addrspace(10) *@alloc()
-    %decayed1 = addrspacecast %jl_value_t addrspace(10) *%obj1 to %jl_value_t addrspace(11) *
-    %arrayptrptr1 = bitcast %jl_value_t addrspace(11) *%decayed1 to i8 addrspace(13)* addrspace(11)*
-    %arrayptr1 = load i8 addrspace(13)*, i8 addrspace(13)* addrspace(11)* %arrayptrptr1
-    %decayed2 = addrspacecast %jl_value_t addrspace(10) *%obj2 to %jl_value_t addrspace(11) *
-    %arrayptrptr2 = bitcast %jl_value_t addrspace(11) *%decayed2 to i8 addrspace(13)* addrspace(11)*
-    %arrayptr2 = load i8 addrspace(13)*, i8 addrspace(13)* addrspace(11)* %arrayptrptr2
-    %insert1 = insertelement <2 x i8 addrspace(13)*> undef, i8 addrspace(13)* %arrayptr1, i32 0
-    %insert2 = insertelement <2 x i8 addrspace(13)*> %insert1, i8 addrspace(13)* %arrayptr2, i32 1
+    %obj1 = call %jl_value_t addrspace(100) *@alloc()
+    %obj2 = call %jl_value_t addrspace(100) *@alloc()
+    %decayed1 = addrspacecast %jl_value_t addrspace(100) *%obj1 to %jl_value_t addrspace(101) *
+    %arrayptrptr1 = bitcast %jl_value_t addrspace(101) *%decayed1 to i8 addrspace(103)* addrspace(101)*
+    %arrayptr1 = load i8 addrspace(103)*, i8 addrspace(103)* addrspace(101)* %arrayptrptr1
+    %decayed2 = addrspacecast %jl_value_t addrspace(100) *%obj2 to %jl_value_t addrspace(101) *
+    %arrayptrptr2 = bitcast %jl_value_t addrspace(101) *%decayed2 to i8 addrspace(103)* addrspace(101)*
+    %arrayptr2 = load i8 addrspace(103)*, i8 addrspace(103)* addrspace(101)* %arrayptrptr2
+    %insert1 = insertelement <2 x i8 addrspace(103)*> undef, i8 addrspace(103)* %arrayptr1, i32 0
+    %insert2 = insertelement <2 x i8 addrspace(103)*> %insert1, i8 addrspace(103)* %arrayptr2, i32 1
     call void @jl_safepoint()
     br label %common
 
@@ -496,124 +496,124 @@ common:
 ; CHECK: %gclift
 ; CHECK: %gclift1
 ; CHECK-NOT: %gclift2
-    %phi = phi <2 x i8 addrspace(13)*> [ %insert2, %A ], [ zeroinitializer, %B ]
+    %phi = phi <2 x i8 addrspace(103)*> [ %insert2, %A ], [ zeroinitializer, %B ]
     call void @jl_safepoint()
-    %el1 = extractelement <2 x i8 addrspace(13)*> %phi, i32 0
-    %el2 = extractelement <2 x i8 addrspace(13)*> %phi, i32 1
-    %l1 = load i8, i8 addrspace(13)* %el1
-    %l2 = load i8, i8 addrspace(13)* %el2
+    %el1 = extractelement <2 x i8 addrspace(103)*> %phi, i32 0
+    %el2 = extractelement <2 x i8 addrspace(103)*> %phi, i32 1
+    %l1 = load i8, i8 addrspace(103)* %el1
+    %l2 = load i8, i8 addrspace(103)* %el2
     %add = add i8 %l1, %l2
     ret i8 %add
 }
 
-define void @vecselect(i1 %cond, <2 x %jl_value_t addrspace(10)*> *%arg) {
+define void @vecselect(i1 %cond, <2 x %jl_value_t addrspace(100)*> *%arg) {
 ; CHECK-LABEL: @vecselect
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %loaded = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*> *%arg
+    %loaded = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*> *%arg
     call void @jl_safepoint()
-    %select = select i1 %cond, <2 x %jl_value_t addrspace(10)*> zeroinitializer, <2 x %jl_value_t addrspace(10)*> %loaded
+    %select = select i1 %cond, <2 x %jl_value_t addrspace(100)*> zeroinitializer, <2 x %jl_value_t addrspace(100)*> %loaded
     call void @jl_safepoint()
-    %el1 = extractelement <2 x %jl_value_t addrspace(10)*> %select, i32 0
-    %el2 = extractelement <2 x %jl_value_t addrspace(10)*> %select, i32 1
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %el1)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %el2)
+    %el1 = extractelement <2 x %jl_value_t addrspace(100)*> %select, i32 0
+    %el2 = extractelement <2 x %jl_value_t addrspace(100)*> %select, i32 1
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %el1)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %el2)
     unreachable
 }
 
-define void @vecselect_lift(i1 %cond, <2 x %jl_value_t addrspace(10)*> *%arg) {
+define void @vecselect_lift(i1 %cond, <2 x %jl_value_t addrspace(100)*> *%arg) {
 ; CHECK-LABEL: @vecselect_lift
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %loaded = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*> *%arg
-    %decayed = addrspacecast <2 x %jl_value_t addrspace(10)*> %loaded to <2 x i64 addrspace(12)*>
+    %loaded = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*> *%arg
+    %decayed = addrspacecast <2 x %jl_value_t addrspace(100)*> %loaded to <2 x i64 addrspace(102)*>
     call void @jl_safepoint()
-; CHECK: %gclift = select i1 %cond, %jl_value_t addrspace(10)* null, %jl_value_t addrspace(10)* %{{[0-9]+}}
-    %select = select i1 %cond, <2 x i64 addrspace(12)*> zeroinitializer, <2 x i64 addrspace(12)*> %decayed
+; CHECK: %gclift = select i1 %cond, %jl_value_t addrspace(100)* null, %jl_value_t addrspace(100)* %{{[0-9]+}}
+    %select = select i1 %cond, <2 x i64 addrspace(102)*> zeroinitializer, <2 x i64 addrspace(102)*> %decayed
     call void @jl_safepoint()
-    %el1 = extractelement <2 x i64 addrspace(12)*> %select, i32 0
-    %el2 = extractelement <2 x i64 addrspace(12)*> %select, i32 1
-    call void @one_arg_decayed(i64 addrspace(12)* %el1)
-    call void @one_arg_decayed(i64 addrspace(12)* %el2)
+    %el1 = extractelement <2 x i64 addrspace(102)*> %select, i32 0
+    %el2 = extractelement <2 x i64 addrspace(102)*> %select, i32 1
+    call void @one_arg_decayed(i64 addrspace(102)* %el1)
+    call void @one_arg_decayed(i64 addrspace(102)* %el2)
     unreachable
 }
 
-define void @vecvecselect_lift(<2 x i1> %cond, <2 x %jl_value_t addrspace(10)*> *%arg) {
+define void @vecvecselect_lift(<2 x i1> %cond, <2 x %jl_value_t addrspace(100)*> *%arg) {
 ; CHECK-LABEL: @vecvecselect_lift
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %loaded = load <2 x %jl_value_t addrspace(10)*>, <2 x %jl_value_t addrspace(10)*> *%arg
-    %decayed = addrspacecast <2 x %jl_value_t addrspace(10)*> %loaded to <2 x i64 addrspace(12)*>
+    %loaded = load <2 x %jl_value_t addrspace(100)*>, <2 x %jl_value_t addrspace(100)*> *%arg
+    %decayed = addrspacecast <2 x %jl_value_t addrspace(100)*> %loaded to <2 x i64 addrspace(102)*>
     call void @jl_safepoint()
-; CHECK: %gclift = select i1 %{{[0-9]+}}, %jl_value_t addrspace(10)* null, %jl_value_t addrspace(10)* %{{[0-9]+}}
-    %select = select <2 x i1> %cond, <2 x i64 addrspace(12)*> zeroinitializer, <2 x i64 addrspace(12)*> %decayed
+; CHECK: %gclift = select i1 %{{[0-9]+}}, %jl_value_t addrspace(100)* null, %jl_value_t addrspace(100)* %{{[0-9]+}}
+    %select = select <2 x i1> %cond, <2 x i64 addrspace(102)*> zeroinitializer, <2 x i64 addrspace(102)*> %decayed
     call void @jl_safepoint()
-    %el1 = extractelement <2 x i64 addrspace(12)*> %select, i32 0
-    %el2 = extractelement <2 x i64 addrspace(12)*> %select, i32 1
-    call void @one_arg_decayed(i64 addrspace(12)* %el1)
-    call void @one_arg_decayed(i64 addrspace(12)* %el2)
+    %el1 = extractelement <2 x i64 addrspace(102)*> %select, i32 0
+    %el2 = extractelement <2 x i64 addrspace(102)*> %select, i32 1
+    call void @one_arg_decayed(i64 addrspace(102)* %el1)
+    call void @one_arg_decayed(i64 addrspace(102)* %el2)
     unreachable
 }
 
 define void @vecscalarselect_lift(<2 x i1> %cond, i64 %a) {
 ; CHECK-LABEL: @vecscalarselect_lift
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %adecayed = addrspacecast %jl_value_t addrspace(10)* %aboxed to i64 addrspace(12)*
-    %avec = getelementptr i64, i64 addrspace(12)*  %adecayed, <2 x i32> zeroinitializer
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %adecayed = addrspacecast %jl_value_t addrspace(100)* %aboxed to i64 addrspace(102)*
+    %avec = getelementptr i64, i64 addrspace(102)*  %adecayed, <2 x i32> zeroinitializer
     call void @jl_safepoint()
-; CHECK: %gclift = select i1 %{{[0-9]+}}, %jl_value_t addrspace(10)* null, %jl_value_t addrspace(10)* %aboxed
-    %select = select <2 x i1> %cond, <2 x i64 addrspace(12)*> zeroinitializer, <2 x i64 addrspace(12)*> %avec
+; CHECK: %gclift = select i1 %{{[0-9]+}}, %jl_value_t addrspace(100)* null, %jl_value_t addrspace(100)* %aboxed
+    %select = select <2 x i1> %cond, <2 x i64 addrspace(102)*> zeroinitializer, <2 x i64 addrspace(102)*> %avec
     call void @jl_safepoint()
-    %el1 = extractelement <2 x i64 addrspace(12)*> %select, i32 0
-    %el2 = extractelement <2 x i64 addrspace(12)*> %select, i32 1
-    call void @one_arg_decayed(i64 addrspace(12)* %el1)
-    call void @one_arg_decayed(i64 addrspace(12)* %el2)
+    %el1 = extractelement <2 x i64 addrspace(102)*> %select, i32 0
+    %el2 = extractelement <2 x i64 addrspace(102)*> %select, i32 1
+    call void @one_arg_decayed(i64 addrspace(102)* %el1)
+    call void @one_arg_decayed(i64 addrspace(102)* %el2)
     unreachable
 }
 
 define void @scalarvecselect_lift(i1 %cond, i64 %a) {
 ; CHECK-LABEL: @scalarvecselect_lift
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %adecayed = addrspacecast %jl_value_t addrspace(10)* %aboxed to i64 addrspace(12)*
-    %avec = getelementptr i64, i64 addrspace(12)*  %adecayed, <2 x i32> zeroinitializer
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %adecayed = addrspacecast %jl_value_t addrspace(100)* %aboxed to i64 addrspace(102)*
+    %avec = getelementptr i64, i64 addrspace(102)*  %adecayed, <2 x i32> zeroinitializer
     call void @jl_safepoint()
-; CHECK: %gclift = select i1 %cond, %jl_value_t addrspace(10)* null, %jl_value_t addrspace(10)* %aboxed
-    %select = select i1 %cond, <2 x i64 addrspace(12)*> zeroinitializer, <2 x i64 addrspace(12)*> %avec
+; CHECK: %gclift = select i1 %cond, %jl_value_t addrspace(100)* null, %jl_value_t addrspace(100)* %aboxed
+    %select = select i1 %cond, <2 x i64 addrspace(102)*> zeroinitializer, <2 x i64 addrspace(102)*> %avec
     call void @jl_safepoint()
-    %el1 = extractelement <2 x i64 addrspace(12)*> %select, i32 0
-    %el2 = extractelement <2 x i64 addrspace(12)*> %select, i32 1
-    call void @one_arg_decayed(i64 addrspace(12)* %el1)
-    call void @one_arg_decayed(i64 addrspace(12)* %el2)
+    %el1 = extractelement <2 x i64 addrspace(102)*> %select, i32 0
+    %el2 = extractelement <2 x i64 addrspace(102)*> %select, i32 1
+    call void @one_arg_decayed(i64 addrspace(102)* %el1)
+    call void @one_arg_decayed(i64 addrspace(102)* %el2)
     unreachable
 }
 
 define i8 @select_arrayptr(i1 %cond) {
 ; CHECK-LABEL: @select_arrayptr
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %obj1 = call %jl_value_t addrspace(10) *@alloc()
-    %obj2 = call %jl_value_t addrspace(10) *@alloc()
-    %decayed1 = addrspacecast %jl_value_t addrspace(10) *%obj1 to %jl_value_t addrspace(11) *
-    %arrayptrptr1 = bitcast %jl_value_t addrspace(11) *%decayed1 to i8 addrspace(13)* addrspace(11)*
-    %arrayptr1 = load i8 addrspace(13)*, i8 addrspace(13)* addrspace(11)* %arrayptrptr1
-    %decayed2 = addrspacecast %jl_value_t addrspace(10) *%obj2 to %jl_value_t addrspace(11) *
-    %arrayptrptr2 = bitcast %jl_value_t addrspace(11) *%decayed2 to i8 addrspace(13)* addrspace(11)*
-    %arrayptr2 = load i8 addrspace(13)*, i8 addrspace(13)* addrspace(11)* %arrayptrptr2
-    %insert1 = insertelement <2 x i8 addrspace(13)*> undef, i8 addrspace(13)* %arrayptr1, i32 0
-    %insert2 = insertelement <2 x i8 addrspace(13)*> %insert1, i8 addrspace(13)* %arrayptr2, i32 1
+    %obj1 = call %jl_value_t addrspace(100) *@alloc()
+    %obj2 = call %jl_value_t addrspace(100) *@alloc()
+    %decayed1 = addrspacecast %jl_value_t addrspace(100) *%obj1 to %jl_value_t addrspace(101) *
+    %arrayptrptr1 = bitcast %jl_value_t addrspace(101) *%decayed1 to i8 addrspace(103)* addrspace(101)*
+    %arrayptr1 = load i8 addrspace(103)*, i8 addrspace(103)* addrspace(101)* %arrayptrptr1
+    %decayed2 = addrspacecast %jl_value_t addrspace(100) *%obj2 to %jl_value_t addrspace(101) *
+    %arrayptrptr2 = bitcast %jl_value_t addrspace(101) *%decayed2 to i8 addrspace(103)* addrspace(101)*
+    %arrayptr2 = load i8 addrspace(103)*, i8 addrspace(103)* addrspace(101)* %arrayptrptr2
+    %insert1 = insertelement <2 x i8 addrspace(103)*> undef, i8 addrspace(103)* %arrayptr1, i32 0
+    %insert2 = insertelement <2 x i8 addrspace(103)*> %insert1, i8 addrspace(103)* %arrayptr2, i32 1
     call void @jl_safepoint()
-    %select = select i1 %cond, <2 x i8 addrspace(13)*> %insert2, <2 x i8 addrspace(13)*> zeroinitializer
+    %select = select i1 %cond, <2 x i8 addrspace(103)*> %insert2, <2 x i8 addrspace(103)*> zeroinitializer
     call void @jl_safepoint()
-    %el1 = extractelement <2 x i8 addrspace(13)*> %select, i32 0
-    %el2 = extractelement <2 x i8 addrspace(13)*> %select, i32 1
-    %l1 = load i8, i8 addrspace(13)* %el1
-    %l2 = load i8, i8 addrspace(13)* %el2
+    %el1 = extractelement <2 x i8 addrspace(103)*> %select, i32 0
+    %el2 = extractelement <2 x i8 addrspace(103)*> %select, i32 1
+    %l1 = load i8, i8 addrspace(103)* %el1
+    %l2 = load i8, i8 addrspace(103)* %el2
     %add = add i8 %l1, %l2
     ret i8 %add
 }

--- a/test/llvmpasses/late-lower-gc.ll
+++ b/test/llvmpasses/late-lower-gc.ll
@@ -1,51 +1,51 @@
 ; RUN: opt -load libjulia%shlibext -LateLowerGCFrame -S %s | FileCheck %s
 
 %jl_value_t = type opaque
-@tag = external addrspace(10) global %jl_value_t
+@tag = external addrspace(100) global %jl_value_t
 
-declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
-declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare void @boxed_simple(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)*)
+declare %jl_value_t addrspace(100)* @jl_box_int64(i64)
 declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
-declare %jl_value_t addrspace(10)* @jl_apply_generic(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)**, i32)
-declare noalias nonnull %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8*, i64, %jl_value_t addrspace(10)*)
+declare %jl_value_t addrspace(100)* @jl_apply_generic(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)**, i32)
+declare noalias nonnull %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8*, i64, %jl_value_t addrspace(100)*)
 
 define void @gc_frame_lowering(i64 %a, i64 %b) {
 top:
 ; CHECK-LABEL: @gc_frame_lowering
-; CHECK: %gcframe = call %jl_value_t addrspace(10)** @julia.new_gc_frame(i32 2)
+; CHECK: %gcframe = call %jl_value_t addrspace(100)** @julia.new_gc_frame(i32 2)
     %ptls = call %jl_value_t*** @julia.ptls_states()
 ; CHECK: %ptls = call %jl_value_t*** @julia.ptls_states()
-; CHECK-NEXT: call void @julia.push_gc_frame(%jl_value_t addrspace(10)** %gcframe, i32 2)
-; CHECK-NEXT: call %jl_value_t addrspace(10)* @jl_box_int64
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-; CHECK: [[GEP0:%.*]] = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0:[0-9]+]])
-; CHECK-NEXT: store %jl_value_t addrspace(10)* %aboxed, %jl_value_t addrspace(10)** [[GEP0]]
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %b)
+; CHECK-NEXT: call void @julia.push_gc_frame(%jl_value_t addrspace(100)** %gcframe, i32 2)
+; CHECK-NEXT: call %jl_value_t addrspace(100)* @jl_box_int64
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+; CHECK: [[GEP0:%.*]] = call %jl_value_t addrspace(100)** @julia.get_gc_frame_slot(%jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0:[0-9]+]])
+; CHECK-NEXT: store %jl_value_t addrspace(100)* %aboxed, %jl_value_t addrspace(100)** [[GEP0]]
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %b)
 ; CHECK-NEXT: %bboxed =
 ; Make sure the same gc slot isn't re-used
-; CHECK-NOT: call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT0]])
-; CHECK: [[GEP1:%.*]] = call %jl_value_t addrspace(10)** @julia.get_gc_frame_slot(%jl_value_t addrspace(10)** %gcframe, i32 [[GEPSLOT1:[0-9]+]])
-; CHECK-NEXT: store %jl_value_t addrspace(10)* %bboxed, %jl_value_t addrspace(10)** [[GEP1]]
+; CHECK-NOT: call %jl_value_t addrspace(100)** @julia.get_gc_frame_slot(%jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT0]])
+; CHECK: [[GEP1:%.*]] = call %jl_value_t addrspace(100)** @julia.get_gc_frame_slot(%jl_value_t addrspace(100)** %gcframe, i32 [[GEPSLOT1:[0-9]+]])
+; CHECK-NEXT: store %jl_value_t addrspace(100)* %bboxed, %jl_value_t addrspace(100)** [[GEP1]]
 ; CHECK-NEXT: call void @boxed_simple
-    call void @boxed_simple(%jl_value_t addrspace(10)* %aboxed,
-                            %jl_value_t addrspace(10)* %bboxed)
-; CHECK-NEXT: call void @julia.pop_gc_frame(%jl_value_t addrspace(10)** %gcframe)
+    call void @boxed_simple(%jl_value_t addrspace(100)* %aboxed,
+                            %jl_value_t addrspace(100)* %bboxed)
+; CHECK-NEXT: call void @julia.pop_gc_frame(%jl_value_t addrspace(100)** %gcframe)
     ret void
 }
 
-define %jl_value_t addrspace(10)* @gc_alloc_lowering() {
+define %jl_value_t addrspace(100)* @gc_alloc_lowering() {
 top:
 ; CHECK-LABEL: @gc_alloc_lowering
     %ptls = call %jl_value_t*** @julia.ptls_states()
     %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-; CHECK: %v = call %jl_value_t addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
-; CHECK-NEXT: [[V2:%.*]] = bitcast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(10)* addrspace(10)*
-; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* [[V2]], i64 -1
-; CHECK-NEXT: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* [[V_HEADROOM]], !tbaa !0
-    %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, %jl_value_t addrspace(10)* @tag)
-; CHECK-NEXT: ret %jl_value_t addrspace(10)* %v
-    ret %jl_value_t addrspace(10)* %v
+; CHECK: %v = call %jl_value_t addrspace(100)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
+; CHECK-NEXT: [[V2:%.*]] = bitcast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(100)* addrspace(100)*
+; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* [[V2]], i64 -1
+; CHECK-NEXT: store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* [[V_HEADROOM]], !tbaa !0
+    %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, %jl_value_t addrspace(100)* @tag)
+; CHECK-NEXT: ret %jl_value_t addrspace(100)* %v
+    ret %jl_value_t addrspace(100)* %v
 }
 
 ; Confirm that loadedval instruction does not contain invariant.load metadata
@@ -58,19 +58,19 @@ top:
 ; CHECK-LABEL: @gc_drop_aliasing
     %ptls = call %jl_value_t*** @julia.ptls_states()
     %ptls_i8 = bitcast %jl_value_t*** %ptls to i8*
-; CHECK: %v = call %jl_value_t addrspace(10)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
-; CHECK-NEXT: [[V2:%.*]] = bitcast %jl_value_t addrspace(10)* %v to %jl_value_t addrspace(10)* addrspace(10)*
-; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* [[V2]], i64 -1
-; CHECK-NEXT: store %jl_value_t addrspace(10)* @tag, %jl_value_t addrspace(10)* addrspace(10)* [[V_HEADROOM]], !tbaa !0
-    %v = call noalias %jl_value_t addrspace(10)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, %jl_value_t addrspace(10)* @tag)
-; CHECK-NEXT: %v64 = bitcast %jl_value_t addrspace(10)* %v to i64 addrspace(10)*
-    %v64 = bitcast %jl_value_t addrspace(10)* %v to i64 addrspace(10)*
-; CHECK-NEXT: %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !4
-    %loadedval = load i64, i64 addrspace(10)* %v64, align 8, !range !0, !invariant.load !1
-; CHECK-NEXT: store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !5
-    store i64 %loadedval, i64 addrspace(10)* %v64, align 8, !noalias !2
-; CHECK-NEXT: %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !tbaa !6, !range !4
-    %lv2 = load i64, i64 addrspace(10)* %v64, align 8, !range !0, !tbaa !4
+; CHECK: %v = call %jl_value_t addrspace(100)* @julia.gc_alloc_bytes(i8* %ptls_i8, [[SIZE_T:i.[0-9]+]] 8)
+; CHECK-NEXT: [[V2:%.*]] = bitcast %jl_value_t addrspace(100)* %v to %jl_value_t addrspace(100)* addrspace(100)*
+; CHECK-NEXT: [[V_HEADROOM:%.*]] = getelementptr %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* [[V2]], i64 -1
+; CHECK-NEXT: store %jl_value_t addrspace(100)* @tag, %jl_value_t addrspace(100)* addrspace(100)* [[V_HEADROOM]], !tbaa !0
+    %v = call noalias %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %ptls_i8, i64 8, %jl_value_t addrspace(100)* @tag)
+; CHECK-NEXT: %v64 = bitcast %jl_value_t addrspace(100)* %v to i64 addrspace(100)*
+    %v64 = bitcast %jl_value_t addrspace(100)* %v to i64 addrspace(100)*
+; CHECK-NEXT: %loadedval = load i64, i64 addrspace(100)* %v64, align 8, !range !4
+    %loadedval = load i64, i64 addrspace(100)* %v64, align 8, !range !0, !invariant.load !1
+; CHECK-NEXT: store i64 %loadedval, i64 addrspace(100)* %v64, align 8, !noalias !5
+    store i64 %loadedval, i64 addrspace(100)* %v64, align 8, !noalias !2
+; CHECK-NEXT: %lv2 = load i64, i64 addrspace(100)* %v64, align 8, !tbaa !6, !range !4
+    %lv2 = load i64, i64 addrspace(100)* %v64, align 8, !range !0, !tbaa !4
 ; CHECK-NEXT: ret void
     ret void
 }

--- a/test/llvmpasses/propagate-addrspace.ll
+++ b/test/llvmpasses/propagate-addrspace.ll
@@ -2,59 +2,59 @@
 
 define i64 @simple() {
 ; CHECK-LABEL: @simple
-; CHECK-NOT: addrspace(11)
+; CHECK-NOT: addrspace(101)
     %stack = alloca i64
-    %casted = addrspacecast i64 *%stack to i64 addrspace(11)*
-    %loaded = load i64, i64 addrspace(11)* %casted
+    %casted = addrspacecast i64 *%stack to i64 addrspace(101)*
+    %loaded = load i64, i64 addrspace(101)* %casted
     ret i64 %loaded
 }
 
 define i64 @twogeps() {
 ; CHECK-LABEL: @twogeps
-; CHECK-NOT: addrspace(11)
+; CHECK-NOT: addrspace(101)
     %stack = alloca i64
-    %casted = addrspacecast i64 *%stack to i64 addrspace(11)*
-    %gep1 = getelementptr i64, i64 addrspace(11)* %casted, i64 1
-    %gep2 = getelementptr i64, i64 addrspace(11)* %gep1, i64 1
-    %loaded = load i64, i64 addrspace(11)* %gep2
+    %casted = addrspacecast i64 *%stack to i64 addrspace(101)*
+    %gep1 = getelementptr i64, i64 addrspace(101)* %casted, i64 1
+    %gep2 = getelementptr i64, i64 addrspace(101)* %gep1, i64 1
+    %loaded = load i64, i64 addrspace(101)* %gep2
     ret i64 %loaded
 }
 
 define i64 @phi(i1 %cond) {
 ; CHECK-LABEL: @phi
-; CHECK-NOT: addrspace(11)
+; CHECK-NOT: addrspace(101)
 top:
     %stack1 = alloca i64
     %stack2 = alloca i64
-    %stack1_casted = addrspacecast i64 *%stack1 to i64 addrspace(11)*
-    %stack2_casted = addrspacecast i64 *%stack2 to i64 addrspace(11)*
+    %stack1_casted = addrspacecast i64 *%stack1 to i64 addrspace(101)*
+    %stack2_casted = addrspacecast i64 *%stack2 to i64 addrspace(101)*
     br i1 %cond, label %A, label %B
 A:
     br label %B
 B:
-    %phi = phi i64 addrspace(11)* [ %stack1_casted, %top ], [ %stack2_casted, %A ]
-    %load = load i64, i64 addrspace(11)* %phi
+    %phi = phi i64 addrspace(101)* [ %stack1_casted, %top ], [ %stack2_casted, %A ]
+    %load = load i64, i64 addrspace(101)* %phi
     ret i64 %load
 }
 
 
 define i64 @select(i1 %cond) {
 ; CHECK-LABEL: @select
-; CHECK-NOT: addrspace(11)
+; CHECK-NOT: addrspace(101)
 top:
     %stack1 = alloca i64
     %stack2 = alloca i64
-    %stack1_casted = addrspacecast i64 *%stack1 to i64 addrspace(11)*
-    %stack2_casted = addrspacecast i64 *%stack2 to i64 addrspace(11)*
-    %select = select i1 %cond, i64 addrspace(11)* %stack1_casted, i64 addrspace(11)* %stack2_casted
-    %load = load i64, i64 addrspace(11)* %select
+    %stack1_casted = addrspacecast i64 *%stack1 to i64 addrspace(101)*
+    %stack2_casted = addrspacecast i64 *%stack2 to i64 addrspace(101)*
+    %select = select i1 %cond, i64 addrspace(101)* %stack1_casted, i64 addrspace(101)* %stack2_casted
+    %load = load i64, i64 addrspace(101)* %select
     ret i64 %load
 }
 
 define i64 @nullptr() {
 ; CHECK-LABEL: @nullptr
-; CHECK-NOT: addrspace(11)
-    %casted = addrspacecast i64 *null to i64 addrspace(11)*
-    %load = load i64, i64 addrspace(11)* %casted
+; CHECK-NOT: addrspace(101)
+    %casted = addrspacecast i64 *null to i64 addrspace(101)*
+    %load = load i64, i64 addrspace(101)* %casted
     ret i64 %load
 }

--- a/test/llvmpasses/refinements.ll
+++ b/test/llvmpasses/refinements.ll
@@ -4,85 +4,85 @@
 
 declare %jl_value_t*** @julia.ptls_states()
 declare void @jl_safepoint()
-declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
-declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare void @one_arg_boxed(%jl_value_t addrspace(100)*)
+declare %jl_value_t addrspace(100)* @jl_box_int64(i64)
 
-define void @argument_refinement(%jl_value_t addrspace(10)* %a) {
+define void @argument_refinement(%jl_value_t addrspace(100)* %a) {
 ; CHECK-LABEL: @argument_refinement
 ; CHECK-NOT: %gcframe
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %casted1 = bitcast %jl_value_t addrspace(10)* %a to %jl_value_t addrspace(10)* addrspace(10)*
-    %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
+    %casted1 = bitcast %jl_value_t addrspace(100)* %a to %jl_value_t addrspace(100)* addrspace(100)*
+    %loaded1 = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %casted1, !tbaa !1
     call void @jl_safepoint()
-    %casted2 = bitcast %jl_value_t addrspace(10)* %loaded1 to i64 addrspace(10)*
-    %loaded2 = load i64, i64 addrspace(10)* %casted2
+    %casted2 = bitcast %jl_value_t addrspace(100)* %loaded1 to i64 addrspace(100)*
+    %loaded2 = load i64, i64 addrspace(100)* %casted2
     ret void
 }
 
 ; Check that we reuse the gc slot from the box
 define void @heap_refinement1(i64 %a) {
 ; CHECK-LABEL: @heap_refinement1
-; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK:   %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %casted1 = bitcast %jl_value_t addrspace(10)* %aboxed to %jl_value_t addrspace(10)* addrspace(10)*
-    %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
-; CHECK: store %jl_value_t addrspace(10)* %aboxed
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %casted1 = bitcast %jl_value_t addrspace(100)* %aboxed to %jl_value_t addrspace(100)* addrspace(100)*
+    %loaded1 = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %casted1, !tbaa !1
+; CHECK: store %jl_value_t addrspace(100)* %aboxed
     call void @jl_safepoint()
-    %casted2 = bitcast %jl_value_t addrspace(10)* %loaded1 to i64 addrspace(10)*
-    %loaded2 = load i64, i64 addrspace(10)* %casted2
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %aboxed)
+    %casted2 = bitcast %jl_value_t addrspace(100)* %loaded1 to i64 addrspace(100)*
+    %loaded2 = load i64, i64 addrspace(100)* %casted2
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %aboxed)
     ret void
 }
 
 ; Check that we don't root the allocated value here, just the derived value
 define void @heap_refinement2(i64 %a) {
 ; CHECK-LABEL: @heap_refinement2
-; CHECK:   %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK:   %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 signext %a)
-    %casted1 = bitcast %jl_value_t addrspace(10)* %aboxed to %jl_value_t addrspace(10)* addrspace(10)*
-    %loaded1 = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
-; CHECK: store %jl_value_t addrspace(10)* %loaded1
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 signext %a)
+    %casted1 = bitcast %jl_value_t addrspace(100)* %aboxed to %jl_value_t addrspace(100)* addrspace(100)*
+    %loaded1 = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %casted1, !tbaa !1
+; CHECK: store %jl_value_t addrspace(100)* %loaded1
     call void @jl_safepoint()
-    %casted2 = bitcast %jl_value_t addrspace(10)* %loaded1 to i64 addrspace(10)*
-    %loaded2 = load i64, i64 addrspace(10)* %casted2
+    %casted2 = bitcast %jl_value_t addrspace(100)* %loaded1 to i64 addrspace(100)*
+    %loaded2 = load i64, i64 addrspace(100)* %casted2
     ret void
 }
 
-declare %jl_value_t addrspace(10)* @allocate_some_value()
+declare %jl_value_t addrspace(100)* @allocate_some_value()
 
 ; Check that the way we compute rooting is compatible with refinements
 define void @issue22770() {
 ; CHECK-LABEL: @issue22770
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
     %ptls = call %jl_value_t*** @julia.ptls_states()
-    %y = call %jl_value_t addrspace(10)* @allocate_some_value()
-    %casted1 = bitcast %jl_value_t addrspace(10)* %y to %jl_value_t addrspace(10)* addrspace(10)*
-    %x = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %casted1, !tbaa !1
-; CHECK: store %jl_value_t addrspace(10)* %y,
-    %a = call %jl_value_t addrspace(10)* @allocate_some_value()
-; CHECK: store %jl_value_t addrspace(10)* %a
-; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(10)* %x)
-; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(10)* %a)
-; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(10)* %y)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %x)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %a)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %y)
-; CHECK: store %jl_value_t addrspace(10)* %x
-    %c = call %jl_value_t addrspace(10)* @allocate_some_value()
-; CHECK: store %jl_value_t addrspace(10)* %c
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %x)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %c)
+    %y = call %jl_value_t addrspace(100)* @allocate_some_value()
+    %casted1 = bitcast %jl_value_t addrspace(100)* %y to %jl_value_t addrspace(100)* addrspace(100)*
+    %x = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %casted1, !tbaa !1
+; CHECK: store %jl_value_t addrspace(100)* %y,
+    %a = call %jl_value_t addrspace(100)* @allocate_some_value()
+; CHECK: store %jl_value_t addrspace(100)* %a
+; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(100)* %x)
+; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(100)* %a)
+; CHECK: call void @one_arg_boxed(%jl_value_t addrspace(100)* %y)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %x)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %a)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %y)
+; CHECK: store %jl_value_t addrspace(100)* %x
+    %c = call %jl_value_t addrspace(100)* @allocate_some_value()
+; CHECK: store %jl_value_t addrspace(100)* %c
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %x)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %c)
     ret void
 }
 
-define void @refine_select_phi(%jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y, i1 %b) {
+define void @refine_select_phi(%jl_value_t addrspace(100)* %x, %jl_value_t addrspace(100)* %y, i1 %b) {
 ; CHECK-LABEL: @refine_select_phi
 ; CHECK-NOT: %gcframe
 top:
   %ptls = call %jl_value_t*** @julia.ptls_states()
-  %s = select i1 %b, %jl_value_t addrspace(10)* %x, %jl_value_t addrspace(10)* %y
+  %s = select i1 %b, %jl_value_t addrspace(100)* %x, %jl_value_t addrspace(100)* %y
   br i1 %b, label %L1, label %L2
 
 L1:
@@ -92,25 +92,25 @@ L2:
   br label %L3
 
 L3:
-  %p = phi %jl_value_t addrspace(10)* [ %x, %L1 ], [ %y, %L2 ]
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %s)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  %p = phi %jl_value_t addrspace(100)* [ %x, %L1 ], [ %y, %L2 ]
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %s)
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %p)
   ret void
 }
 
-define void @dont_refine_loop(%jl_value_t addrspace(10)* %x) {
+define void @dont_refine_loop(%jl_value_t addrspace(100)* %x) {
 ; CHECK-LABEL: @dont_refine_loop
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
   %ptls = call %jl_value_t*** @julia.ptls_states()
   br label %L1
 
 L1:
   %continue = phi i1 [ true, %top ], [ false, %L1 ]
-  %p = phi %jl_value_t addrspace(10)* [ %x, %top ], [ %v, %L1 ]
-  %v = call %jl_value_t addrspace(10)* @allocate_some_value()
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  %p = phi %jl_value_t addrspace(100)* [ %x, %top ], [ %v, %L1 ]
+  %v = call %jl_value_t addrspace(100)* @allocate_some_value()
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %p)
   br i1 %continue, label %L1, label %L2
 
 L2:
@@ -119,7 +119,7 @@ L2:
 
 @gv1 = external global %jl_value_t*
 
-define void @refine_loop_const(%jl_value_t addrspace(10)* %x) {
+define void @refine_loop_const(%jl_value_t addrspace(100)* %x) {
 ; CHECK-LABEL: @refine_loop_const
 ; CHECK-NOT: %gcframe
 top:
@@ -128,23 +128,23 @@ top:
 
 L1:
   %continue = phi i1 [ true, %top ], [ false, %L1 ]
-  %p = phi %jl_value_t addrspace(10)* [ %x, %top ], [ %v, %L1 ]
+  %p = phi %jl_value_t addrspace(100)* [ %x, %top ], [ %v, %L1 ]
   %v0 = load %jl_value_t*, %jl_value_t** @gv1, !tbaa !4
-  %v = addrspacecast %jl_value_t* %v0 to %jl_value_t addrspace(10)*
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  %v = addrspacecast %jl_value_t* %v0 to %jl_value_t addrspace(100)*
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %p)
   br i1 %continue, label %L1, label %L2
 
 L2:
   ret void
 }
 
-define void @refine_loop_indirect(%jl_value_t addrspace(10)* %x) {
+define void @refine_loop_indirect(%jl_value_t addrspace(100)* %x) {
 ; CHECK-LABEL: @refine_loop_indirect
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
 top:
   %ptls = call %jl_value_t*** @julia.ptls_states()
-  %a = call %jl_value_t addrspace(10)* @allocate_some_value()
+  %a = call %jl_value_t addrspace(100)* @allocate_some_value()
   br label %L1
 
 L1:
@@ -152,62 +152,62 @@ L1:
 ; `%v` is not a valid refinement incoming value of the phi node `%p`,
 ; however, `%v` can be refined to `%a` and `%a` is a valid refinement
 ; of the phi node. Therefore, we need only one gc slot for `%a`.
-  %p = phi %jl_value_t addrspace(10)* [ %x, %top ], [ %v, %L1 ]
-  %ca = bitcast %jl_value_t addrspace(10)* %a to %jl_value_t addrspace(10)* addrspace(10)*
-  %v = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %ca, !tbaa !1
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  %p = phi %jl_value_t addrspace(100)* [ %x, %top ], [ %v, %L1 ]
+  %ca = bitcast %jl_value_t addrspace(100)* %a to %jl_value_t addrspace(100)* addrspace(100)*
+  %v = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %ca, !tbaa !1
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %p)
   br i1 %continue, label %L1, label %L2
 
 L2:
   ret void
 }
 
-define void @refine_loop_indirect2(%jl_value_t addrspace(10)* %x) {
+define void @refine_loop_indirect2(%jl_value_t addrspace(100)* %x) {
 ; CHECK-LABEL: @refine_loop_indirect2
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 3
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 3
 top:
   %ptls = call %jl_value_t*** @julia.ptls_states()
-  %a = call %jl_value_t addrspace(10)* @allocate_some_value()
+  %a = call %jl_value_t addrspace(100)* @allocate_some_value()
   br label %L1
 
 L1:
   %continue = phi i1 [ true, %top ], [ false, %L1 ]
 ; `%p` has circular dependency but it can only be derived from `%a` which dominate `%p`.
-  %p = phi %jl_value_t addrspace(10)* [ %a, %top ], [ %v, %L1 ]
-  %ca = bitcast %jl_value_t addrspace(10)* %p to %jl_value_t addrspace(10)* addrspace(10)*
-  %v = load %jl_value_t addrspace(10)*, %jl_value_t addrspace(10)* addrspace(10)* %ca, !tbaa !1
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %p)
+  %p = phi %jl_value_t addrspace(100)* [ %a, %top ], [ %v, %L1 ]
+  %ca = bitcast %jl_value_t addrspace(100)* %p to %jl_value_t addrspace(100)* addrspace(100)*
+  %v = load %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(100)* %ca, !tbaa !1
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %v)
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %p)
   br i1 %continue, label %L1, label %L2
 
 L2:
   ret void
 }
 
-declare %jl_value_t addrspace(10)* @julia.typeof(%jl_value_t addrspace(10)*) #0
+declare %jl_value_t addrspace(100)* @julia.typeof(%jl_value_t addrspace(100)*) #0
 
-define %jl_value_t addrspace(10)* @typeof(%jl_value_t addrspace(10)* %x) {
+define %jl_value_t addrspace(100)* @typeof(%jl_value_t addrspace(100)* %x) {
 ; CHECK-LABEL: @typeof(
 ; CHECK-NOT: %gcframe
   %ptls = call %jl_value_t*** @julia.ptls_states()
-  %v = call %jl_value_t addrspace(10)* @julia.typeof(%jl_value_t addrspace(10)* %x)
-  call void @one_arg_boxed(%jl_value_t addrspace(10)* %v)
-  ret %jl_value_t addrspace(10)* %v
+  %v = call %jl_value_t addrspace(100)* @julia.typeof(%jl_value_t addrspace(100)* %x)
+  call void @one_arg_boxed(%jl_value_t addrspace(100)* %v)
+  ret %jl_value_t addrspace(100)* %v
 }
 
-declare void @julia.write_barrier(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*) #1
+declare void @julia.write_barrier(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)*) #1
 
-define %jl_value_t addrspace(10)* @setfield(%jl_value_t addrspace(10)* %p) {
+define %jl_value_t addrspace(100)* @setfield(%jl_value_t addrspace(100)* %p) {
 ; CHECK-LABEL: @setfield(
 ; CHECK-NOT: %gcframe
 ; CHECK: call void @jl_gc_queue_root
   %ptls = call %jl_value_t*** @julia.ptls_states()
-  %c = call %jl_value_t addrspace(10)* @allocate_some_value()
-  %fp = bitcast %jl_value_t addrspace(10)* %p to %jl_value_t addrspace(10)* addrspace(10)*
-  store %jl_value_t addrspace(10)* %c, %jl_value_t addrspace(10)* addrspace(10)* %fp
-  call void @julia.write_barrier(%jl_value_t addrspace(10)* %p, %jl_value_t addrspace(10)* %c)
-  ret %jl_value_t addrspace(10)* %c
+  %c = call %jl_value_t addrspace(100)* @allocate_some_value()
+  %fp = bitcast %jl_value_t addrspace(100)* %p to %jl_value_t addrspace(100)* addrspace(100)*
+  store %jl_value_t addrspace(100)* %c, %jl_value_t addrspace(100)* addrspace(100)* %fp
+  call void @julia.write_barrier(%jl_value_t addrspace(100)* %p, %jl_value_t addrspace(100)* %c)
+  ret %jl_value_t addrspace(100)* %c
 }
 
 attributes #0 = { argmemonly norecurse nounwind readonly }

--- a/test/llvmpasses/returnstwicegc.ll
+++ b/test/llvmpasses/returnstwicegc.ll
@@ -2,29 +2,29 @@
 
 %jl_value_t = type opaque
 
-declare void @boxed_simple(%jl_value_t addrspace(10)*, %jl_value_t addrspace(10)*)
-declare %jl_value_t addrspace(10)* @jl_box_int64(i64)
+declare void @boxed_simple(%jl_value_t addrspace(100)*, %jl_value_t addrspace(100)*)
+declare %jl_value_t addrspace(100)* @jl_box_int64(i64)
 declare %jl_value_t*** @julia.ptls_states()
 declare i32 @sigsetjmp(i8*, i32) returns_twice
-declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
+declare void @one_arg_boxed(%jl_value_t addrspace(100)*)
 
 define void @try_catch(i64 %a, i64 %b)
 {
 ; Because of the returns_twice function, we need to keep aboxed live everywhere
-; CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 4
+; CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 4
 top:
     %sigframe = alloca [208 x i8], align 16
     %sigframe.sub = getelementptr inbounds [208 x i8], [208 x i8]* %sigframe, i64 0, i64 0
     call %jl_value_t*** @julia.ptls_states()
-    %aboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 %a)
+    %aboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 %a)
     %val = call i32 @sigsetjmp(i8 *%sigframe.sub, i32 0) returns_twice
     %cmp = icmp eq i32 %val, 0
     br i1 %cmp, label %zero, label %not
 zero:
-    %bboxed = call %jl_value_t addrspace(10)* @jl_box_int64(i64 %b)
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %bboxed)
+    %bboxed = call %jl_value_t addrspace(100)* @jl_box_int64(i64 %b)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %bboxed)
     unreachable
 not:
-    call void @one_arg_boxed(%jl_value_t addrspace(10)* %aboxed)
+    call void @one_arg_boxed(%jl_value_t addrspace(100)* %aboxed)
     ret void
 }

--- a/test/llvmpasses/safepoint_stress.jl
+++ b/test/llvmpasses/safepoint_stress.jl
@@ -4,21 +4,21 @@
 
 println("""
 %jl_value_t = type opaque
-declare %jl_value_t addrspace(10)* @alloc()
-declare void @one_arg_boxed(%jl_value_t addrspace(10)*)
+declare %jl_value_t addrspace(100)* @alloc()
+declare void @one_arg_boxed(%jl_value_t addrspace(100)*)
 declare %jl_value_t*** @julia.ptls_states()
 
 define void @stress(i64 %a, i64 %b) {
     %ptls = call %jl_value_t*** @julia.ptls_states()
 """)
 
-# CHECK: %gcframe = alloca %jl_value_t addrspace(10)*, i32 10002
+# CHECK: %gcframe = alloca %jl_value_t addrspace(100)*, i32 10002
 for i = 1:10000
-    println("\t%arg$i = call %jl_value_t addrspace(10)* @alloc()")
+    println("\t%arg$i = call %jl_value_t addrspace(100)* @alloc()")
 end
 
 for i = 1:10000
-    println("\tcall void @one_arg_boxed(%jl_value_t addrspace(10)* %arg$i)")
+    println("\tcall void @one_arg_boxed(%jl_value_t addrspace(100)* %arg$i)")
 end
 
 println("""

--- a/test/llvmpasses/throw-amdgpu.ll
+++ b/test/llvmpasses/throw-amdgpu.ll
@@ -1,0 +1,46 @@
+; This file is a part of Julia. License is MIT: https://julialang.org/license
+
+; RUN: opt -load libjulia%shlibext -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -AllocOpt -LateLowerGCFrame -S %s | FileCheck %s
+
+%jl_value_t = type opaque
+declare void @roc_report_exception(i64)
+declare %jl_value_t*** @julia.ptls_states()
+declare %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8*, i64, %jl_value_t addrspace(100)*)
+declare void @llvm.trap()
+@exception = external global [10 x i8]
+
+; CHECK-LABEL: @throw_func
+define void @throw_func(i8) {
+top:
+  %1 = call %jl_value_t*** @julia.ptls_states()
+  %2 = bitcast %jl_value_t*** %1 to %jl_value_t addrspace(100)**
+  %3 = getelementptr inbounds %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)** %2, i64 4
+  %4 = bitcast %jl_value_t addrspace(100)** %3 to i64**
+  %5 = load i64*, i64** %4
+  %6 = trunc i8 %0 to i1
+  %7 = xor i1 %6, true
+  br i1 %7, label %L5, label %L2
+
+L2:                                               ; preds = %top
+  %8 = bitcast %jl_value_t*** %1 to i8*
+  %9 = call noalias nonnull %jl_value_t addrspace(100)* @julia.gc_alloc_obj(i8* %8, i64 8, %jl_value_t addrspace(100)* addrspacecast (%jl_value_t* inttoptr (i64 140281676247392 to %jl_value_t*) to %jl_value_t addrspace(100)*)) #0
+  %10 = addrspacecast %jl_value_t addrspace(100)* %9 to %jl_value_t addrspace(101)*
+  %11 = bitcast %jl_value_t addrspace(101)* %10 to %jl_value_t addrspace(100)* addrspace(101)*
+  %12 = getelementptr inbounds %jl_value_t addrspace(100)*, %jl_value_t addrspace(100)* addrspace(101)* %11, i64 0
+  store %jl_value_t addrspace(100)* null, %jl_value_t addrspace(100)* addrspace(101)* %12
+  %13 = bitcast %jl_value_t addrspace(100)* %9 to %jl_value_t addrspace(100)* addrspace(100)*
+  store %jl_value_t addrspace(100)* addrspacecast (%jl_value_t* inttoptr (i64 140281609886928 to %jl_value_t*) to %jl_value_t addrspace(100)*), %jl_value_t addrspace(100)* addrspace(100)* %13
+  call void @roc_report_exception(i64 ptrtoint ([10 x i8]* @exception to i64))
+  call void @llvm.trap()
+  unreachable
+
+L5:                                               ; preds = %top
+  ret void
+
+after_throw:                                      ; No predecessors!
+  call void @llvm.trap()
+  unreachable
+
+after_noret:                                      ; No predecessors!
+  unreachable
+}


### PR DESCRIPTION
The LLVM AMDGPU target uses addrspace numbers greater than and including 10
for various "constant buffers", while Julia uses addrspace numbers 10-13 for
itself. Here, we change Julia's addrspace numbers to 100-103, and patch the
LLVM AMDGPU target to consider an `addrspacecast` between the Global/Flat
addrspace and any of Julia's addrspaces to be a no-op.

EDIT: Removed WebAssembly patches

TODO:
- [ ] Add a test for AMDGPU targets
- [x] ~Update all other patches' tests which hard-code Julia's original addrspace numbers~
- [x] Update everything else for new addrspace numbers
- [x] Ensure patches apply against LLVM 6.x, 7.x, 8.x

CC: @vchuravy @maleadt 