### PR TITLE
Add `do`-block support for `dlopen()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,10 @@ Standard library changes
   (environment, flags, working directory, etc) if `x` is the first interpolant and errors
   otherwise ([#24353]).
 
+#### Libdl
+
+* `dlopen()` can now be invoked in `do`-block syntax, similar to `open()`.
+
 #### LinearAlgebra
 
 * The BLAS submodule no longer exports `dot`, which conflicts with that in LinearAlgebra ([#31838]).

--- a/stdlib/Libdl/test/runtests.jl
+++ b/stdlib/Libdl/test/runtests.jl
@@ -196,6 +196,18 @@ let dl = C_NULL
     end
 end
 
+# test do-block dlopen
+Libdl.dlopen(abspath(joinpath(private_libdir, "libccalltest"))) do dl
+    fptr = Libdl.dlsym(dl, :set_verbose)
+    @test fptr !== nothing
+    @test_throws ErrorException Libdl.dlsym(dl, :foo)
+
+    fptr = Libdl.dlsym_e(dl, :set_verbose)
+    @test fptr != C_NULL
+    fptr = Libdl.dlsym_e(dl, :foo)
+    @test fptr == C_NULL
+end
+
 # test dlclose
 # If dl is NULL, jl_dlclose should return -1 and dlclose should return false
 # dlclose should return true on success and false on failure


### PR DESCRIPTION
This is helpful for things like quickly opening a dynamic library, checking if a symbol exists, then closing it again.  Example:

```julia
vendor = dlopen("libblas") do lib
    if Libdl.dlsym(lib, :openblas_set_num_threads; throw_error=false) !== nothing
        return :openblas
    else
        return :other
    end
end
```