### PR TITLE
Fix `detect_unbound_args(Package; recursive=true)`

### DIFF
--- a/stdlib/Test/src/Test.jl
+++ b/stdlib/Test/src/Test.jl
@@ -1468,7 +1468,8 @@ function detect_unbound_args(mods...;
                 continue
             end
             f = Base.unwrap_unionall(getfield(mod, n))
-            if recursive && isa(f, Module) && parentmodule(f) === mod && nameof(f) === n
+            if recursive && isa(f, Module) && f !== mod &&
+                    parentmodule(f) === mod && nameof(f) === n
                 subambs = detect_unbound_args(f, imported=imported, recursive=recursive)
                 union!(ambs, subambs)
             elseif isa(f, DataType) && isdefined(f.name, :mt)

--- a/stdlib/Test/test/runtests.jl
+++ b/stdlib/Test/test/runtests.jl
@@ -915,3 +915,6 @@ end
     end
 end
 
+@testset "Smoke test detect_unbound_args(...; recursive=true)" begin
+    @test detect_unbound_args(Test; recursive=true) == []
+end


### PR DESCRIPTION
Without this patch, calling `detect_unbound_args` on "top-level" modules
with `recursive=true` (e.g., `detect_unbound_args(Test; recursive=true)`)
throws a `StackOverflowError`.