### PR TITLE
Have `pointer(x)` return `Ptr{Ptr{T}}` for Arrays of non-isbits types

### DIFF
--- a/base/abstractarray.jl
+++ b/base/abstractarray.jl
@@ -934,7 +934,8 @@ end
 pointer(x::AbstractArray{T}) where {T} = unsafe_convert(Ptr{T}, x)
 function pointer(x::AbstractArray{T}, i::Integer) where T
     @_inline_meta
-    unsafe_convert(Ptr{T}, x) + (i - first(LinearIndices(x)))*elsize(x)
+    ptrtype = isbitstype(T) || isbitsunion(T) ? Ptr{T} : Ptr{Ptr{T}}
+    unsafe_convert(ptrtype, x) + (i - first(LinearIndices(x)))*elsize(x)
 end
 
 ## Approach:


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/12053

-----------

We recently noticed this behavior as well, and it caused a frustrating half a day of confusion.

I know that the consensus in https://github.com/JuliaLang/julia/issues/12053 is that `pointer` should be deprecated in favor of `Ref`, but in the meantime it is currently broken and the fix is simple. :)

Following is a summary of the problem and of this solution:

-----

Currently, values in an `Array` are stored directly in the array for isbits types, and stored as `Ptr`s to heap-allocated objects for non-isbits types.

This behavior is correctly accounted for in array.jl's `elsize` function:
https://github.com/JuliaLang/julia/blob/14b74bcbc4d180fb27885926fbdfeb244b5b1344/base/array.jl#L201

However, this is _not_ accounted for in `Base.pointer`, which seems like a bug, and causes a type-error, where `pointer` calls `unsafe_convert` into the _wrong type_ for non-isbits types `T`.

Here is an example:

```julia
julia> begin
           mutable struct A  # mutable struct (not isbits)
               x::Int64
           end

           x = Vector{Tuple{A,Int64}}()
           push!(x, (A(3), 4))
           push!(x, (A(3), 4))
           p = pointer(x, 1)   # This should be a Ptr{Ptr{T}}, since the value in the array is a Ptr{T}.
       end
Ptr{Tuple{A,Int64}} @0x0000000105f579a0

julia> typeof(pointer(x,1))  # This is wrong: it does _not_ point to a Tuple{A,Int64}.
Ptr{Tuple{A,Int64}}

julia> Int(pointer(x,2)-pointer(x,1))  # As you can see, it's actually pointing to a pointer (word size).
8

julia> Int(sizeof(Tuple{A,Int64}))
16

julia> unsafe_load(pointer(x,1),1)   # And indeed, if we attempt to load it, we get an error, since we're attempting to load a `Ptr` into a `Tuple{A,Int64}`.
(Error showing value of type Tuple{A,Int64}:
ERROR: fatal error in type inference (type bound)
```

To fix this, `pointer` just needs to return a `Ptr{Ptr{T}}` if `T` is not `isbitstype`.

As you can see, that _is_ the correct type:
```julia
julia> unsafe_load(unsafe_load(reinterpret(Ptr{Ptr{Tuple{A,Int64}}}, pointer(x,1))))
(A(3), 4)
```

-------------------

And indeed, with this change, you can correctly load values out of the array:
```julia
julia> @eval Base function pointer(x::AbstractArray{T}, i::Integer) where T
           @_inline_meta
           ptrtype = isbitstype(T) || isbitsunion(T) ? Ptr{T} : Ptr{Ptr{T}}
           unsafe_convert(ptrtype, x) + (i - first(LinearIndices(x)))*elsize(x)
       end
pointer (generic function with 18 methods)

julia> p=pointer(x,1)  # Now this has the true return type
Ptr{Ptr{Tuple{A,Int64}}} @0x0000000105f579a0

julia> unsafe_load(unsafe_load(p))
(A(3), 4)
```


-------------------

:) As long as this function is still in Base, i think it would be good to return the correct type.