### PR TITLE
Specialized broadcasted on `in`

### DIFF
--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -1072,6 +1072,10 @@ function broadcasted(::typeof(-), j::CartesianIndex{N}, I::CartesianIndices{N}) 
     Iterators.reverse(CartesianIndices(map(diffrange, Tuple(j), I.indices)))
 end
 
+## Performance improvement. Specializes `broadcasted` on `in`, so that
+#  `in.(a, Ref(b))` will create a hash table for `b`.
+broadcasted(::typeof(in), lhs::AbstractArray, rhs::Base.RefValue{<:AbstractArray}) = broadcasted(in, lhs, Ref(Set(rhs[])))
+
 ## In specific instances, we can broadcast masked BitArrays whole chunks at a time
 # Very intentionally do not support much functionality here: scalar indexing would be O(n)
 struct BitMaskedBitArray{N,M}


### PR DESCRIPTION
Specializes `in.(a, Ref(b))` as discussed here: https://discourse.julialang.org/t/julias-in-seems-slow-compared-to-rs-in/23900/25 . The actual code is written by @foobar_lv2 (whose github tag I do not know), I'm just the messenger.

To summarize the discussion on discourse, the motivation for this is that as soon as `b` is larger than a few elements, `in.(a, Ref(Set(b))` is several orders of magnitude faster than `in.(a, Ref(b))`. However, this is by no means apparent to most users. This PR creates the Set automatically and views this as an implementation detail - the result is identical but usually much faster. From the thread (by @foobar_lv2):
```julia
julia> @btime in.(lhs, Ref(rhs));
  39.737 ms (6 allocations: 5.61 KiB)

#this PR
julia> Base.Broadcast.broadcasted(::typeof(in), lhs::AbstractArray, rhs::Base.RefValue{<:AbstractArray}) = Base.broadcasted(in, lhs, Ref(Set(rhs[])))

julia> @btime in.(lhs, Ref(rhs));
  497.682 μs (15 allocations: 150.30 KiB)
```
The most weighty argument against is that in some cases, e.g. when `b` is very few elements, it is slightly slower, and the user would not be able to opt out of it. Also from the thread (by @tkluck ):
```julia
julia> a = [1,2,3];

julia> b = rand(1:10, 1000);

julia> @btime in.($b, Ref($a));
  2.979 μs (3 allocations: 4.42 KiB)

julia> @btime in.($b, Ref(Set($a)));
  6.300 μs (8 allocations: 4.91 KiB)
```
There was also a philosophical discussion that having to learn about using `Set` here would improve user's understanding of the code.