### PR TITLE
update `VecElement` conversions

### DIFF
--- a/base/baseext.jl
+++ b/base/baseext.jl
@@ -4,8 +4,12 @@
 
 # hook up VecElement constructor to Base.convert
 VecElement{T}(arg) where {T} = VecElement{T}(convert(T, arg))
-convert(::Type{T}, arg)  where {T<:VecElement} = T(arg)
-convert(::Type{T}, arg::T) where {T<:VecElement} = arg
+
+convert(::Type{VecElement}, arg) = VecElement(arg)
+convert(::Type{VecElement}, arg::VecElement) = arg
+
+convert(::Type{VecElement{T}}, arg) where {T} = VecElement{T}(arg)
+convert(::Type{VecElement{T}}, arg::VecElement) where {T} = VecElement{T}(arg.value)
 
 # ## dims-type-converting Array constructors for convenience
 # type and dimensionality specified, accepting dims as series of Integers

--- a/test/vecelement.jl
+++ b/test/vecelement.jl
@@ -119,3 +119,10 @@ for T in (Float64, Float32, Int64, Int32)
         @test b == result
     end
 end
+
+# conversions
+@test convert(VecElement, 2) === VecElement(2)
+@test convert(VecElement, VecElement(3.1)) === VecElement(3.1)
+@test convert(VecElement{Float32}, 2) === VecElement(2.0f0)
+@test convert(VecElement{Int}, VecElement(2)) === VecElement(2)
+@test convert(VecElement{Float32}, VecElement(2)) === VecElement(2.0f0)


### PR DESCRIPTION
- narrow their applicability

The first method matched `convert(Union{}, ::Any)`, which can cause some strange effects.

- add conversions between different types of `VecElement`

If we're going to allow `convert(VecElement, 2)` we might as well allow `convert(VecElement{T}, VecElement(x))`.