### PR TITLE
base/stat.jl: Mask `UV_EINVAL` error codes for `jl_stat`

### DIFF
--- a/base/stat.jl
+++ b/base/stat.jl
@@ -65,7 +65,9 @@ macro stat_call(sym, arg1type, arg)
     return quote
         stat_buf = zeros(UInt8, ccall(:jl_sizeof_stat, Int32, ()))
         r = ccall($(Expr(:quote, sym)), Int32, ($(esc(arg1type)), Ptr{UInt8}), $(esc(arg)), stat_buf)
-        r == 0 || r == Base.UV_ENOENT || r == Base.UV_ENOTDIR || throw(_UVError("stat", r))
+        if !(r in (0, Base.UV_ENOENT, Base.UV_ENOTDIR, Base.UV_EINVAL))
+            throw(_UVError("stat", r))
+        end
         st = StatStruct(stat_buf)
         if ispath(st) != (r == 0)
             error("stat returned zero type for a valid path")

--- a/test/file.jl
+++ b/test/file.jl
@@ -68,6 +68,9 @@ chmod(file, filemode(file) | 0o222)
 @test filemode(file) & 0o111 == 0
 @test filesize(file) == 0
 
+# issue #26685
+@test !isfile("http://google.com")
+
 if Sys.iswindows()
     permissions = 0o444
     @test filemode(dir) & 0o777 != permissions


### PR DESCRIPTION
This fixes https://github.com/JuliaLang/julia/issues/26685, where libuv decided to throw `UV_EINVAL` on windows for invalid-filepaths such as `foo??` or `http://google.com`, instead of returning `UV_ENOENT` as they were previously [0].  This causes windows to throw errors on calls such as `isfile("http://google.com")`, whereas other platforms simply return `false`.  This change simply ignores `UV_EINVAL` alongside the other "allowed failure" error codes.

[0] https://github.com/libuv/libuv/pull/1088