### PR TITLE
bugfix in Hermitian + complex*I

### DIFF
--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -144,8 +144,8 @@ end
 function (+)(A::Hermitian, J::UniformScaling{<:Complex})
     TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
     B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
-    for i = 1:size(A, 1)
-        B[i,i] = A[i,i] + J
+    for i in diagind(B)
+        B[i] = A[i] + J
     end
     return B
 end
@@ -153,11 +153,9 @@ end
 function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
     TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
     B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
-    @inbounds for i in eachindex(B)
-        B[i] = -B[i]
-    end
-    for i = 1:size(A, 1)
-        B[i,i] = J - A[i,i]
+    B .= .-B
+    for i in diagind(B)
+        B[i] = J - A[i]
     end
     return B
 end

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -153,7 +153,6 @@ function (+)(A::Hermitian, J::UniformScaling{<:Complex})
             B[i] = A[i] + J
         end
         return B
-        return B
     end
 end
 

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -142,67 +142,42 @@ end
 # However, to preserve type stability, we do not special-case a
 # UniformScaling{<:Complex} that happens to be real.
 function (+)(A::Hermitian, J::UniformScaling{<:Complex})
-    if isempty(A)
-        return similar(A, Base._return_type(+, Tuple{eltype(A), typeof(J)}))
-    else
-        B11 = A[first(diagind(A))] + J
-        B = copytri!(copy_oftype(parent(A), typeof(B11)), A.uplo, true)
-        ax = diagind(B)
-        B[first(ax)] = B11
-        for i in Iterators.drop(ax, 1)
-            B[i] = A[i] + J
-        end
-        return B
+    TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
+    B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
+    for i = 1:size(A, 1)
+        B[i,i] = A[i,i] + J
     end
+    return B
 end
 
 function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
-    if isempty(A)
-        return similar(A, Base._return_type(-, Tuple{typeof(J), eltype(A)}))
-    else
-        B11 = J - A[first(diagind(A))]
-        B = copytri!(copy_oftype(parent(A), typeof(B11)), A.uplo, true)
-        B .= .-B
-        ax = diagind(B)
-        B[first(ax)] = B11
-        for i in Iterators.drop(ax, 1)
-            B[i] = J - A[i]
-        end
-        return B
+    TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
+    B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
+    @inbounds for i in eachindex(B)
+        B[i] = -B[i]
     end
+    for i = 1:size(A, 1)
+        B[i,i] = J - A[i,i]
+    end
+    return B
 end
 
 function (+)(A::AbstractMatrix, J::UniformScaling)
     checksquare(A)
-    if isempty(A)
-        return similar(A, Base._return_type(+, Tuple{eltype(A), typeof(J)}))
-    else
-        B11 = A[first(diagind(A))] + J
-        B = copy_oftype(A, typeof(B11))
-        ax = diagind(B)
-        B[first(ax)] = B11
-        @inbounds for i in Iterators.drop(ax, 1)
-            B[i] += J
-        end
-        return B
+    B = copy_oftype(A, Base._return_type(+, Tuple{eltype(A), typeof(J)}))
+    @inbounds for i in axes(A, 1)
+        B[i,i] += J
     end
+    return B
 end
 
 function (-)(J::UniformScaling, A::AbstractMatrix)
     checksquare(A)
-    if isempty(A)
-        return similar(A, Base._return_type(-, Tuple{typeof(J), eltype(A)}))
-    else
-        B11 = J - A[first(diagind(A))]
-        B = copy_oftype(A, typeof(B11))
-        B .= .-B
-        ax = diagind(B)
-        B[first(ax)] = B11
-        @inbounds for i in Iterators.drop(ax, 1)
-            B[i] += J
-        end
-        return B
+    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, -A)
+    @inbounds for i in axes(A, 1)
+        B[i,i] += J
     end
+    return B
 end
 
 inv(J::UniformScaling) = UniformScaling(inv(J.λ))

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -141,18 +141,18 @@ end
 # matrix breaks the hermiticity, if the UniformScaling is non-real.
 # However, to preserve type stability, we do not special-case a
 # UniformScaling{<:Complex} that happens to be real.
-function (+)(A::Hermitian{T,S}, J::UniformScaling{<:Complex}) where {T,S}
-    A_ = copytri!(copy(parent(A)), A.uplo)
-    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, A_)
+function (+)(A::Hermitian, J::UniformScaling{<:Complex})
+    TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
+    B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
     @inbounds for i in diagind(B)
         B[i] += J
     end
     return B
 end
 
-function (-)(J::UniformScaling{<:Complex}, A::Hermitian{T,S}) where {T,S}
-    A_ = copytri!(copy(parent(A)), A.uplo)
-    B = convert(AbstractMatrix{Base._return_type(+, Tuple{eltype(A), typeof(J)})}, A_)
+function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
+    TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
+    B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
     @inbounds for i in eachindex(B)
         B[i] = -B[i]
     end

--- a/stdlib/LinearAlgebra/src/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/src/uniformscaling.jl
@@ -144,8 +144,8 @@ end
 function (+)(A::Hermitian, J::UniformScaling{<:Complex})
     TS = Base._return_type(+, Tuple{eltype(A), typeof(J)})
     B = copytri!(copy_oftype(parent(A), TS), A.uplo, true)
-    @inbounds for i in diagind(B)
-        B[i] += J
+    for i = 1:size(A, 1)
+        B[i,i] = A[i,i] + J
     end
     return B
 end
@@ -156,8 +156,8 @@ function (-)(J::UniformScaling{<:Complex}, A::Hermitian)
     @inbounds for i in eachindex(B)
         B[i] = -B[i]
     end
-    @inbounds for i in diagind(B)
-        B[i] += J
+    for i = 1:size(A, 1)
+        B[i,i] = J - A[i,i]
     end
     return B
 end

--- a/stdlib/LinearAlgebra/test/uniformscaling.jl
+++ b/stdlib/LinearAlgebra/test/uniformscaling.jl
@@ -180,15 +180,17 @@ let
                 @test @inferred(J - T) == J - Array(T)
                 @test @inferred(T\I) == inv(T)
 
-                if isa(A, Array)
-                    T = Hermitian(randn(3,3))
-                else
-                    T = Hermitian(view(randn(3,3), 1:3, 1:3))
+                for elty in (Float64, ComplexF64)
+                    if isa(A, Array)
+                        T = Hermitian(randn(elty, 3,3))
+                    else
+                        T = Hermitian(view(randn(elty, 3,3), 1:3, 1:3))
+                    end
+                    @test @inferred(T + J) == Array(T) + J
+                    @test @inferred(J + T) == J + Array(T)
+                    @test @inferred(T - J) == Array(T) - J
+                    @test @inferred(J - T) == J - Array(T)
                 end
-                @test @inferred(T + J) == Array(T) + J
-                @test @inferred(J + T) == J + Array(T)
-                @test @inferred(T - J) == Array(T) - J
-                @test @inferred(J - T) == J - Array(T)
 
                 @test @inferred(I\A) == A
                 @test @inferred(A\I) == inv(A)


### PR DESCRIPTION
Fixes the bug noted in https://github.com/JuliaLang/julia/commit/49023b50eb22ce1276c381bd0cf88cf2f269ed0e#r33494573 (#29500) where a complex `Hermitian` matrix plus `complex*I` would give an incorrect result (complex-symmetric rather than conjugating the lower triangle).

*Update*: ~~Also reduces the problematic reliance on `Base._return_type` for non-empty matrices in this code.~~ Nevermind, this is tricky and should be left for another PR.