### PR TITLE
fix printing symbols with names `true` and `false`

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -783,6 +783,7 @@ is_id_start_char(c::AbstractChar) = ccall(:jl_id_start_char, Cint, (UInt32,), c)
 is_id_char(c::AbstractChar) = ccall(:jl_id_char, Cint, (UInt32,), c) != 0
 function isidentifier(s::AbstractString)
     isempty(s) && return false
+    (s == "true" || s == "false") && return false
     c, rest = Iterators.peel(s)
     is_id_start_char(c) || return false
     return all(is_id_char, rest)
@@ -1049,7 +1050,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if (isidentifier(s) || isoperator(value)) && !(s == "true" || s == "false")
+        if (isidentifier(s) || isoperator(value))
             print(io, ":")
             print(io, value)
         else

--- a/base/show.jl
+++ b/base/show.jl
@@ -1049,7 +1049,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if isidentifier(s) || isoperator(value)
+        if (isidentifier(s) || isoperator(value)) && !(s == "true" || s == "false")
             print(io, ":")
             print(io, value)
         else

--- a/base/show.jl
+++ b/base/show.jl
@@ -1050,7 +1050,7 @@ end
 function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
-        if (isidentifier(s) || isoperator(value))
+        if isidentifier(s) || isoperator(value)
             print(io, ":")
             print(io, value)
         else

--- a/test/show.jl
+++ b/test/show.jl
@@ -1612,3 +1612,9 @@ end
     @test startswith(showstr(Array{Int32, 0}(undef)), "fill(")
     @test startswith(replstr(Array{Int32, 0}(undef)), "0-dimensional Array{Int32,0}:\n")
 end
+
+# issue #31402, Print Symbol("true") as Symbol("true") instead of :true
+@test sprint(show, Symbol(true)) == "Symbol(\"true\")"
+@test sprint(show, Symbol("true")) == "Symbol(\"true\")"
+@test sprint(show, Symbol(false)) == "Symbol(\"false\")"
+@test sprint(show, Symbol("false")) == "Symbol(\"false\")"


### PR DESCRIPTION
Found the underlying problem for issue #31402.  In base/show.jl, the ```isidentifier``` function called by ```show_unquoted_quote_expr``` returns ```true``` for "true" and "false".  Opted to add an additional check to ```show_unquoted_quote_expr```, as I don't think this is incorrect behavior on the part of ```isidentifier```.