### PR TITLE
Replace != 0 with !iszero in sparse matrix constructions

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2809,7 +2809,7 @@ function setindex!(A::SparseMatrixCSC, x::AbstractArray, I::AbstractMatrix{Bool}
         (xidx > n) && break
     end # for col in 1:A.n
 
-    if (!iszero(nadd))
+    if !iszero(nadd)
         n = length(nzvalB)
         if n > (bidx-1)
             deleteat!(nzvalB, bidx:n)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -2782,7 +2782,7 @@ function setindex!(A::SparseMatrixCSC, x::AbstractArray, I::AbstractMatrix{Bool}
             end # if I[row, col]
         end # for row in 1:A.m
 
-        if (!iszero(nadd))
+        if !iszero(nadd)
             l = r2-r1+1
             if l > 0
                 copyto!(rowvalB, bidx, rowvalA, r1, l)


### PR DESCRIPTION
!iszero works better in some generic contexts. Xref: https://github.com/JuliaDiffEq/ModelingToolkit.jl/issues/133