### PR TITLE
Move ack out to its own repo in JuliaEditorSupport.

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -31,7 +31,5 @@ If your favorite IDE, is not listed there, [open an issue in the JuliaEditorSupp
 
 | Name                           |  Description                                                |
 | ------------------------------ | ----------------------------------------------------------- |
-|[ ackrc ](https://github.com/JuliaLang/julia/blob/master/contrib/ackrc ) |  Config for Ack search tool |
 |[ debug_bootstrap.gdb ](https://github.com/JuliaLang/julia/blob/master/contrib/debug_bootstrap.gdb) | Bootstrap process using the debug build |
-|[ README.ackrc.txt ](https://github.com/JuliaLang/julia/blob/master/contrib/README.ackrc.txt) | README for ackrc  config file |
 |[ valgrind-julia.supp ](https://github.com/JuliaLang/julia/blob/master/contrib/valgrind-julia.supp) | Suppressions  for Valgrind debugging tool |

--- a/contrib/ack/README.md
+++ b/contrib/ack/README.md
@@ -1,2 +1,0 @@
-The 'ackrc' file is for Ack (http://beyondgrep.com/)
-Place its contents in your ~/.ackrc file.

--- a/contrib/ack/ackrc
+++ b/contrib/ack/ackrc
@@ -1,2 +1,0 @@
---type-set=julia=.jl
---type-add=julia:firstlinematch:/^#!.*\bjulia/


### PR DESCRIPTION
Last roadmap issue in moving things out of `contrib` to `JuliaEditorSupport` org. https://github.com/JuliaEditorSupport/roadmap/issues/6

