### PR TITLE
Improve stat error messages.

### DIFF
--- a/base/libuv.jl
+++ b/base/libuv.jl
@@ -83,6 +83,11 @@ function _UVError(pfx::AbstractString, code::Integer)
     IOError(string(pfx, ": ", struverror(code), " (", uverrorname(code), ")"), code)
 end
 
+function _UVError(pfx::AbstractString, code::Integer, sfx::AbstractString)
+    code = Int32(code)
+    IOError(string(pfx, ": ", struverror(code), " (", uverrorname(code), ")", " ", sfx), code)
+end
+
 struverror(err::Int32) = unsafe_string(ccall(:uv_strerror,Cstring,(Int32,),err))
 uverrorname(err::Int32) = unsafe_string(ccall(:uv_err_name,Cstring,(Int32,),err))
 

--- a/base/stat.jl
+++ b/base/stat.jl
@@ -65,7 +65,12 @@ macro stat_call(sym, arg1type, arg)
     return quote
         stat_buf = zeros(UInt8, ccall(:jl_sizeof_stat, Int32, ()))
         r = ccall($(Expr(:quote, sym)), Int32, ($(esc(arg1type)), Ptr{UInt8}), $(esc(arg)), stat_buf)
-        r == 0 || r == Base.UV_ENOENT || r == Base.UV_ENOTDIR || throw(_UVError("stat", r))
+        if !(r == 0 || r == Base.UV_ENOENT || r == Base.UV_ENOTDIR)
+            if isa($(esc(arg)), AbstractString)
+                throw(_UVError("stat", r, string("for path ", repr($(esc(arg))))))
+            end
+            throw(_UVError("stat", r))
+        end
         st = StatStruct(stat_buf)
         if ispath(st) != (r == 0)
             error("stat returned zero type for a valid path")


### PR DESCRIPTION
Fixes #32030.

Adds a new method for `_UVError` which can also take a suffix and modifies the `@stat_call` macro to include a suffix containing the path if the arg is a string (as opposed to an `OS_HANDLE`).

Not sure if this warrants any other kind of testing.

## Old Behavior
```
julia> stat("/root/.ssh")
ERROR: IOError: stat: permission denied (EACCES)
Stacktrace:
 [1] stat(::String) at ./stat.jl:68
 [2] top-level scope at none:0
```

## New Behavior
```
julia> stat("/root/.ssh")
ERROR: IOError: stat: permission denied (EACCES) for path "/root/.ssh"
Stacktrace:
 [1] stat(::String) at ./stat.jl:70
 [2] top-level scope at REPL[1]:1
```