### PR TITLE
RFC: use `AbstractMatrix` as the eltype of `Symmetric` for array of arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/symmetric.jl
+++ b/stdlib/LinearAlgebra/src/symmetric.jl
@@ -74,6 +74,12 @@ implemented for a custom type, so should be `symmetric_type`, and vice versa.
 function symmetric_type(::Type{T}) where {S, T<:AbstractMatrix{S}}
     return Symmetric{Union{S, promote_op(transpose, S), symmetric_type(S)}, T}
 end
+function symmetric_type(::Type{T}) where {S<:Number, T<:AbstractMatrix{S}}
+    return Symmetric{S, T}
+end
+function symmetric_type(::Type{T}) where {S<:AbstractMatrix, T<:AbstractMatrix{S}}
+    return Symmetric{AbstractMatrix, T}
+end
 symmetric_type(::Type{T}) where {T<:Number} = T
 
 struct Hermitian{T,S<:AbstractMatrix{<:T}} <: AbstractMatrix{T}
@@ -147,8 +153,14 @@ The type of the object returned by `hermitian(::T, ::Symbol)`. For matrices, thi
 appropriately typed `Hermitian`, for `Number`s, it is the original type. If `hermitian` is
 implemented for a custom type, so should be `hermitian_type`, and vice versa.
 """
-function hermitian_type(::Type{T}) where {S,T<:AbstractMatrix{S}}
+function hermitian_type(::Type{T}) where {S, T<:AbstractMatrix{S}}
     return Hermitian{Union{S, promote_op(adjoint, S), hermitian_type(S)}, T}
+end
+function hermitian_type(::Type{T}) where {S<:Number, T<:AbstractMatrix{S}}
+    return Hermitian{S, T}
+end
+function hermitian_type(::Type{T}) where {S<:AbstractMatrix, T<:AbstractMatrix{S}}
+    return Hermitian{AbstractMatrix, T}
 end
 hermitian_type(::Type{T}) where {T<:Number} = T
 


### PR DESCRIPTION
This fixes a crash in the StaticArrays tests on 1.2 and master. It can be reduced to this:
```
julia> using LinearAlgebra

julia> a = Hermitian([[rand(Complex{Int}) for i = 1 : 2, j = 1 : 2] for row = 1 : 3, col = 1 : 3]);

julia> transpose(a);
```

The functions `symmetric_type` and `hermitian_type` are involved; they are both recursive and call `return_type` and it seems we just cannot handle it. The eltype of `a` is currently `Union{Array{Complex{Int64},2}, Adjoint{Complex{Int64},Array{Complex{Int64},2}}, Hermitian{Complex{Int64},Array{Complex{Int64},2}}}`, which does not seem too useful to me. Here I switch it to `AbstractMatrix` instead, which works around the problem.

An alternate possible fix is to reduce the complexity of Symmetric and Hermitian `getindex`. They currently return three different types for diagonal, upper, and lower. I can also fix the crash by reducing this to two. My proposal is to materialize the recursive Symmetric/Hermitian array, removing the third type from `Union{S, promote_op(transpose, S), symmetric_type(S)}`. That gives a bit more precise type info, but would be more breaking since it changes what `getindex` returns, while this PR only changes the element type of the Symmetric/Hermitian wrapper.

Any way we can avoid `promote_op` would be even better, and would also fix it. For example I'd use `typeof(transpose(a[1]))`, and `Union{}` for empty arrays. But that would break the `symmetric_type` API, which expects to be able to compute the eltype from just a type.