### PR TITLE
move export of `Event` from Base back to Threads

### DIFF
--- a/base/condition.jl
+++ b/base/condition.jl
@@ -153,7 +153,7 @@ Create an edge-triggered event source that tasks can wait for. Tasks that call [
 `Condition` are suspended and queued. Tasks are woken up when [`notify`](@ref) is later called on
 the `Condition`. Edge triggering means that only tasks waiting at the time [`notify`](@ref) is
 called can be woken up. For level-triggered notifications, you must keep extra state to keep
-track of whether a notification has happened. The [`Channel`](@ref) and [`Event`](@ref) types do
+track of whether a notification has happened. The [`Channel`](@ref) and [`Threads.Event`](@ref) types do
 this, and can be used for level-triggered events.
 
 This object is NOT thread-safe. See [`Threads.Condition`](@ref) for a thread-safe version.

--- a/base/exports.jl
+++ b/base/exports.jl
@@ -642,7 +642,6 @@ export
 
 # tasks and conditions
     Condition,
-    Event,
     current_task,
     islocked,
     istaskdone,

--- a/base/lock.jl
+++ b/base/lock.jl
@@ -274,3 +274,8 @@ function notify(e::Event)
     end
     nothing
 end
+
+@eval Threads begin
+    import .Base: Event
+    export Event
+end

--- a/doc/src/base/parallel.md
+++ b/doc/src/base/parallel.md
@@ -30,7 +30,7 @@ Base.Threads.Condition
 Base.notify
 Base.schedule
 
-Base.Event
+Base.Threads.Event
 
 Base.Semaphore
 Base.acquire

--- a/stdlib/Distributed/src/Distributed.jl
+++ b/stdlib/Distributed/src/Distributed.jl
@@ -14,6 +14,7 @@ using Base: Process, Semaphore, JLOptions, AnyDict, buffer_writes, wait_connecte
             VERSION_STRING, binding_module, atexit, julia_exename,
             julia_cmd, AsyncGenerator, acquire, release, invokelatest,
             shell_escape_posixly, uv_error, something, notnothing, isbuffered
+using Base.Threads: Event
 
 using Serialization, Sockets
 import Serialization: serialize, deserialize


### PR DESCRIPTION
This caused a name conflict in MDDatasets.jl, and seems likely to cause name conflicts in other places too.