### PR TITLE
Add Base64 to Serialization test deps

### DIFF
--- a/stdlib/Serialization/Project.toml
+++ b/stdlib/Serialization/Project.toml
@@ -4,6 +4,7 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "Base64"]


### PR DESCRIPTION
This dependency was added in 8f9ace09a3571e2aef0f5639ea55ec8fe830b0cf, but not reflected in the
Project.toml file.

Fixes `test Serialization` invocation.