### PR TITLE
Don't delete the buildroot julia folder for binary-dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,6 @@ ifeq ($(OS), WINNT)
 else
 	cd $(BUILDROOT) && $(TAR) zcvf $(JULIA_BINARYDIST_FILENAME).tar.gz julia-$(JULIA_COMMIT)
 endif
-	rm -fr $(BUILDROOT)/julia-$(JULIA_COMMIT)
 
 app:
 	$(MAKE) -C contrib/mac/app


### PR DESCRIPTION
This is already taken care of under `distclean` : https://github.com/JuliaLang/julia/blob/master/Makefile#L423. 
It doesn't seem right to delete it during this stage, as opposed to during the `distclean` stage. 
Plus it's really annoying  when the makefile deletes this folder and you want to use it for tweaking around.
 