### PR TITLE
improve checking of `Vararg` parameters

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -3488,6 +3488,11 @@ end
 @test_throws ErrorException NTuple{-1, Int}
 @test_throws TypeError Union{Int, 1}
 
+@test_throws ErrorException Vararg{Any,-2}
+@test_throws ErrorException Vararg{Int, N} where N<:T where T
+@test_throws ErrorException Vararg{Int, N} where N<:Integer
+@test_throws ErrorException Vararg{Int, N} where N>:Integer
+
 mutable struct FooNTuple{N}
     z::Tuple{Integer, Vararg{Int, N}}
 end


### PR DESCRIPTION
- make sure length var has full bounds
- check for negative length earlier (inside Vararg, not just Tuple{Vararg{}})