### PR TITLE
Always use summary for BoundsError, even with non-AbstractArrays

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -33,11 +33,7 @@ function showerror(io::IO, ex::BoundsError)
     print(io, "BoundsError")
     if isdefined(ex, :a)
         print(io, ": attempt to access ")
-        if isa(ex.a, AbstractArray)
-            summary(io, ex.a)
-        else
-            show(io, MIME"text/plain"(), ex.a)
-        end
+        summary(io, ex.a)
         if isdefined(ex, :i)
             !isa(ex.a, AbstractArray) && print(io, "\n ")
             print(io, " at index [")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1848,6 +1848,7 @@ function summary(x)
     summary(io, x)
     String(take!(io))
 end
+summary(io::IO, t::Tuple) = print(io, t)
 
 ## `summary` for AbstractArrays
 # sizes such as 0-dimensional, 4-dimensional, 2x3

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -225,6 +225,11 @@ let
 end
 
 struct TypeWithIntParam{T <: Integer} end
+struct Bounded  # not an AbstractArray
+    bound::Int
+end
+Base.getindex(b::Bounded, i) = checkindex(Bool, 1:b.bound, i) || throw(BoundsError(b, i))
+Base.summary(io::IO, b::Bounded) = print(io, "$(b.bound)-size Bounded")
 let undefvar
     err_str = @except_strbt sqrt(-1) DomainError
     @test occursin("Try sqrt(Complex(x)).", err_str)
@@ -245,6 +250,9 @@ let undefvar
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [-2, 1]"
     err_str = @except_str [5, 4, 3][1:5] BoundsError
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [1:5]"
+
+    err_str = @except_str Bounded(2)[3] BoundsError
+    @test err_str == "BoundsError: attempt to access 2-size Bounded\n  at index [3]"
 
     err_str = @except_str 0::Bool TypeError
     @test err_str == "TypeError: non-boolean ($Int) used in boolean context"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1320,6 +1320,11 @@ end
     @test summary(Base.OneTo(BigInt(10))) == "10-element Base.OneTo{BigInt}"
 end
 
+@testset "Tuple summary" begin
+    @test summary((1,2,3)) == "(1, 2, 3)"
+    @test summary((:a, "b", 'c')) == "(:a, \"b\", 'c')"
+end
+
 # Tests for code_typed linetable annotations
 function compute_annotations(f, types)
     src = code_typed(f, types, debuginfo=:source)[1][1]


### PR DESCRIPTION
Previously, BoundsError used `show` when the container wasn't an AbstractArray. That could print a lot of stuff, and customizing it required changing the behaviour of `show`. Now it always uses `summary`, so users can define their own `summary` to customize the display here. 

Also `summary` of a tuple now displays the whole tuple instead of its type. That's usually shorter than printing the type, and it keeps the existing behaviour for BoundsError.