### PR TITLE
Ensure Main.eval and Main.include exist in embedded julia

### DIFF
--- a/base/client.jl
+++ b/base/client.jl
@@ -427,6 +427,7 @@ function run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_fil
     nothing
 end
 
+# MainInclude exists to hide Main.include and eval from `names(Main)`.
 baremodule MainInclude
 include(fname::AbstractString) = Main.Base.include(Main, fname)
 eval(x) = Core.eval(Main, x)
@@ -459,7 +460,6 @@ MainInclude.include
 function _start()
     empty!(ARGS)
     append!(ARGS, Core.ARGS)
-    @eval Main import Base.MainInclude: eval, include
     try
         exec_options(JLOptions())
     catch

--- a/src/init.c
+++ b/src/init.c
@@ -823,6 +823,11 @@ void _julia_init(JL_IMAGE_SEARCH rel)
     // it does "using Base" if Base is available.
     if (jl_base_module != NULL) {
         jl_add_standard_imports(jl_main_module);
+        jl_value_t *maininclude = jl_get_global(jl_base_module, jl_symbol("MainInclude"));
+        if (maininclude && jl_is_module(maininclude)) {
+            jl_module_import(jl_main_module, (jl_module_t*)maininclude, jl_symbol("include"));
+            jl_module_import(jl_main_module, (jl_module_t*)maininclude, jl_symbol("eval"));
+        }
         // Do initialization needed before starting child threads
         jl_value_t *f = jl_get_global(jl_base_module, jl_symbol("__preinit_threads__"));
         if (f) {

--- a/test/embedding/embedding-test.jl
+++ b/test/embedding/embedding-test.jl
@@ -9,10 +9,14 @@ if Sys.iswindows()
 end
 
 @test length(ARGS) == 1
+
 @testset "embedding example" begin
     out = Pipe()
     err = Pipe()
-    p = run(pipeline(Cmd(ARGS), stdin=devnull, stdout=out, stderr=err), wait=false)
+    embedded_cmd_path = abspath(ARGS[1])
+    p = cd(@__DIR__) do
+        run(pipeline(Cmd([embedded_cmd_path]), stdin=devnull, stdout=out, stderr=err), wait=false)
+    end
     close(out.in)
     close(err.in)
     out_task = @async readlines(out)

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -169,6 +169,12 @@ int main()
         checked_eval_string("LocalModule.myapp()");
     }
 
+    {
+        // Main.include and Main.eval exist (#28825)
+        checked_eval_string("include(\"include_and_eval.jl\")");
+        checked_eval_string("f28825()");
+    }
+
     int ret = 0;
     jl_atexit_hook(ret);
     return ret;

--- a/test/embedding/include_and_eval.jl
+++ b/test/embedding/include_and_eval.jl
@@ -1,0 +1,3 @@
+function f28825()
+    eval(:(1+1))
+end


### PR DESCRIPTION
These two functions need to be added to Main as part of `jl_init()`, but only when Base is present to avoid bootstrap issues.

Fixes #28825

Obviously `__preinit_threads__` is a weirdly named function to be moving this to, but this part of the init stage seems to be appropriate (ie, right after `jl_add_standard_imports(jl_main_module)`). Renaming/cleanup suggestions welcome.