### PR TITLE
Make append! and push! definitions more generic

### DIFF
--- a/base/array.jl
+++ b/base/array.jl
@@ -896,14 +896,14 @@ function append!(a::Vector, items::AbstractVector)
     return a
 end
 
-append!(a::Vector, iter) = _append!(a, IteratorSize(iter), iter)
-push!(a::Vector, iter...) = append!(a, iter)
+append!(a::AbstractVector, iter) = _append!(a, IteratorSize(iter), iter)
+push!(a::AbstractVector, iter...) = append!(a, iter)
 
 function _append!(a, ::Union{HasLength,HasShape}, iter)
-    require_one_based_indexing(a)
     n = length(a)
+    i = lastindex(a)
     resize!(a, n+length(iter))
-    @inbounds for (i,item) in zip(n+1:length(a), iter)
+    @inbounds for (i, item) in zip(i+1:lastindex(a), iter)
         a[i] = item
     end
     a

--- a/test/bitarray.jl
+++ b/test/bitarray.jl
@@ -553,8 +553,17 @@ timesofar("indexing")
         b2 = bitrand(m2)
         i1 = Array(b1)
         i2 = Array(b2)
+        # Append from array
         @test isequal(Array(append!(b1, b2)), append!(i1, i2))
         @test isequal(Array(append!(b1, i2)), append!(i1, b2))
+        @test bitcheck(b1)
+        # Append from HasLength iterator
+        @test isequal(Array(append!(b1, (v for v in b2))), append!(i1, i2))
+        @test isequal(Array(append!(b1, (v for v in i2))), append!(i1, b2))
+        @test bitcheck(b1)
+        # Append from SizeUnknown iterator
+        @test isequal(Array(append!(b1, (v for v in b2 if true))), append!(i1, i2))
+        @test isequal(Array(append!(b1, (v for v in i2 if true))), append!(i1, b2))
         @test bitcheck(b1)
     end
 

--- a/test/offsetarray.jl
+++ b/test/offsetarray.jl
@@ -338,6 +338,34 @@ a = OffsetArray(a0, (-1,2,3,4,5))
 @test_throws ArgumentError dropdims(a, dims=4)
 @test_throws ArgumentError dropdims(a, dims=6)
 
+# push!
+v = OffsetArray(rand(4), (-3,))
+v2 = copy(v)
+@test push!(v2, 1) === v2
+@test v2[axes(v, 1)] == v
+@test v2[end] == 1
+v2 = copy(v)
+@test push!(v2, 2, 1) === v2
+@test v2[axes(v, 1)] == v
+@test v2[end-1] == 2
+@test v2[end] == 1
+
+# append! from array
+v2 = copy(v)
+@test append!(v2, [2, 1]) === v2
+@test v2[axes(v, 1)] == v
+@test v2[lastindex(v)+1:end] == [2, 1]
+# append! from HasLength iterator
+v2 = copy(v)
+@test append!(v2, (v for v in [2, 1])) === v2
+@test v2[axes(v, 1)] == v
+@test v2[lastindex(v)+1:end] == [2, 1]
+# append! from SizeUnknown iterator
+v2 = copy(v)
+@test append!(v2, (v for v in [2, 1] if true)) === v2
+@test v2[axes(v, 1)] == v
+@test v2[lastindex(v)+1:end] == [2, 1]
+
 # other functions
 v = OffsetArray(v0, (-3,))
 @test lastindex(v) == 1

--- a/test/testhelpers/OffsetArrays.jl
+++ b/test/testhelpers/OffsetArrays.jl
@@ -121,6 +121,14 @@ end
     @inbounds deleteat!(parent(A), first_idx:last_idx)
 end
 
+function Base.push!(a::OffsetArray{T,1}, item) where T
+    # convert first so we don't grow the array if the assignment won't work
+    itemT = convert(T, item)
+    resize!(a, length(a)+1)
+    a[end] = itemT
+    return a
+end
+
 # Computing a shifted index (subtracting the offset)
 offset(offsets::NTuple{N,Int}, inds::NTuple{N,Int}) where {N} = _offset((), offsets, inds)
 _offset(out, ::Tuple{}, ::Tuple{}) = out


### PR DESCRIPTION
Some methods for `append!` and `push!` for `Array` actually work for any `AbstractArray` since they only use `resize!`, `setindex!` and `push!`. Broaden the signatures so that custom array types do not need to copy definitions from Base.

`BitArray` uses special methods, one of which was apparently not covered by tests.

Ideally, fallback `append!(::AbstractVector, ::AbstractVector)` and `push!(::AbstractVector, ::Any)` methods would also be provided. Unfortunately, the existing definitions for `Vector` call `_grow_end` instead of `resize!`, which means that simply broadening the signature to `AbstractVector` won't work. It would be easy to fix that (using `x isa Vector` or a helper function), but since the non-`Vector` code path would not be used in Base I'm not sure that's OK. Comments?