### PR TITLE
tty: allow EOF streams to still be explicitly closed

### DIFF
--- a/stdlib/LibGit2/test/libgit2.jl
+++ b/stdlib/LibGit2/test/libgit2.jl
@@ -75,6 +75,7 @@ function challenge_prompt(cmd::Cmd, challenges; timeout::Integer=60, debug::Bool
                 sleep(3)
                 process_running(p) && kill(p, Base.SIGKILL)
             end
+            wait(p)
         end
 
         for (challenge, response) in challenges


### PR DESCRIPTION
We treat EOF detected on a TTY the same as being in the closed state, leading us to treat explicit calls to `close` (both directly and from uvfinalize) as being no-ops, instead of actually destroying the stream.

Cause of https://travis-ci.org/JuliaLang/julia/jobs/533462150