### PR TITLE
WIP: Allow newlines before where in a function definition

### DIFF
--- a/doc/src/devdocs/eval.md
+++ b/doc/src/devdocs/eval.md
@@ -71,6 +71,14 @@ which handles tokenizing Julia code and turning it into an AST, and [`julia-synt
 which handles transforming complex AST representations into simpler, "lowered" AST representations
 which are more suitable for analysis and execution.
 
+If you want to test the parser without re-building Julia in its entirety, you can run the frontend
+on its own as follows:
+
+    $ cd src
+    $ flisp/flisp
+    > (load "jlfrontend.scm")
+    > (jl-parse-file "<filename>")
+
 ## [Macro Expansion](@id dev-macro-expansion)
 
 When [`eval()`](@ref) encounters a macro, it expands that AST node before attempting to evaluate

--- a/src/flisp/aliases.scm
+++ b/src/flisp/aliases.scm
@@ -35,6 +35,9 @@
 (define (read-char (s *input-stream*)) (io.getc s))
 (define (peek-char (s *input-stream*)) (io.peekc s))
 (define (write-char c (s *output-stream*)) (io.putc s c))
+(define (peek-number-of-where-tokens (s *input-stream*)) (io.peek-number-of-where-tokens s))
+(define (peek-char-after-where-tokens (s *input-stream*)) (io.peek-char-after-where-tokens s))
+(define (peek-space-after-where-tokens? (s *input-stream*)) (io.peek-space-after-where-tokens? s))
 
 (define (port-eof? p) (io.eof? p))
 (define (open-input-string str)

--- a/src/flisp/iostream.c
+++ b/src/flisp/iostream.c
@@ -281,6 +281,33 @@ value_t fl_ioread(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
     return cv;
 }
 
+value_t fl_peek_number_of_where_tokens(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
+{
+    argcount(fl_ctx, "io.peek-number-of-where-tokens", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.peek-number-of-where-tokens");
+    size_t res = ios_peek_number_of_where_tokens(s);
+    return size_wrap(fl_ctx, res);
+}
+
+value_t fl_peek_char_after_where_tokens(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
+{
+    argcount(fl_ctx, "io.peek-char-after-where-tokens", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.peek-char-after-where-tokens");
+    uint32_t wc;
+    if (ios_peek_utf8_after_where_tokens(s, &wc) == IOS_EOF)
+        return fl_ctx->FL_EOF;
+    return mk_wchar(fl_ctx, wc);
+}
+
+value_t fl_peek_space_after_where_tokens(fl_context_t *fl_ctx, value_t *args, uint32_t nargs)
+{
+    argcount(fl_ctx, "io.peek-space-after-where-tokens?", nargs, 1);
+    ios_t *s = toiostream(fl_ctx, args[0], "io.peek-space-after-where-tokens?");
+    if (ios_peek_space_after_where_tokens(s))
+        return fl_ctx->T;
+    return fl_ctx->F;
+}
+
 // args must contain data[, offset[, count]]
 static void get_start_count_args(fl_context_t *fl_ctx, value_t *args, uint32_t nargs, size_t sz,
                                  size_t *offs, size_t *nb, char *fname)
@@ -426,6 +453,9 @@ static const builtinspec_t iostreamfunc_info[] = {
     { "io.peekc" , fl_iopeekc },
     { "io.discardbuffer", fl_iopurge },
     { "io.read", fl_ioread },
+    { "io.peek-number-of-where-tokens", fl_peek_number_of_where_tokens },
+    { "io.peek-char-after-where-tokens", fl_peek_char_after_where_tokens },
+    { "io.peek-space-after-where-tokens?", fl_peek_space_after_where_tokens },
     { "io.write", fl_iowrite },
     { "io.copy", fl_iocopy },
     { "io.readuntil", fl_ioreaduntil },

--- a/src/support/ios.h
+++ b/src/support/ios.h
@@ -133,6 +133,11 @@ JL_DLLEXPORT int ios_getutf8(ios_t *s, uint32_t *pwc);
 JL_DLLEXPORT int ios_peekutf8(ios_t *s, uint32_t *pwc);
 JL_DLLEXPORT char *ios_readline(ios_t *s) JL_NOTSAFEPOINT;
 
+/* high-level stream functions - specific parser needs */
+JL_DLLEXPORT int ios_peek_number_of_where_tokens(ios_t *s);
+JL_DLLEXPORT int ios_peek_utf8_after_where_tokens(ios_t *s, uint32_t *pwc);
+JL_DLLEXPORT int ios_peek_space_after_where_tokens(ios_t *s);
+
 // discard data buffered for reading
 JL_DLLEXPORT void ios_purge(ios_t *s);
 

--- a/test/where-on-newline.jl
+++ b/test/where-on-newline.jl
@@ -1,0 +1,158 @@
+using Test
+
+function f(x::I) where I <: Integer
+    return x
+end
+
+@test f(3) == 3
+
+function g(x::I)
+         where I <: Integer
+    return x
+end
+
+@test g(3) == 3
+
+function h()
+    where where where # an expression equal to Any
+end
+
+@test h() === Any
+
+function j(x::I) where(Union{} <: I <: Any)
+    return x
+end
+
+@test j(3) == 3
+
+function k(x::I)
+        where (Union{} <: I <: Any)
+    return x
+end
+
+@test k(3) == 3
+
+function where(x)
+    return x
+end
+
+function l0(x::I) where(I)
+end
+
+@test l0(3) == nothing
+
+function l(x::Integer)
+    where(x)
+end
+
+@test l(3) == 3
+
+function m(x::I) where I
+    where(Union{} <: I <: Any) # a function call: where(true)
+end
+
+@test m(3) == true
+
+function n(x::I) where J
+    where (Union{} <: I <: Any) # a continuation of the where clause
+end
+
+@test n(3) === nothing
+
+function o(where::Integer)
+    where
+end
+
+@test o(3) == 3
+
+function o2(where::Integer)
+    where + 1
+end
+
+@test o2(3) == 4
+
+function o3(where::Integer)
+    where+1
+end
+
+@test o3(3) == 4
+
+function p(integer::where) where where
+    where
+end
+
+@test p(3) == Int
+
+function q(x::I) where I <:
+                       Integer
+   return x
+end
+
+@test q(3) == 3
+
+function r(x::I) where
+                 I <: Integer
+   return x
+end
+
+@test r(3) == 3
+
+function s0(integer::where)
+    where where    # where clause
+    where          # expression
+end
+
+@test s0(3) == Int
+
+function t0(integer::where) where where; where; end # where clause
+function t1(integer::Int);  where where  where; end # where where where expression
+
+@test t0(3) == Int
+@test t1(3) == Any
+
+function f(x::I, y::J)
+         # I represents the type of x
+         where I <: Integer
+         # J represents the type of y
+         where J <: Real
+    return x * y
+end
+
+@test f(3, 4) == 12
+
+function u0(integer::A)
+    where where where A       # where clause
+    where where where where A # expression
+    A
+end
+
+@test u0(3) == Int
+
+function v(integer::whereA)
+    where whereA                   # where clause
+    where where whereA where where # expression
+    whereA
+end
+
+@test v(3) == Int
+
+# -----------------------------------------
+#
+# if we ever want to enable where-on-next-line for expressions:
+#
+# -----------------------------------------
+
+#function s1(integer::where)
+#    where          # expression
+#    where where    # where clause for the expression on the previous line
+#end
+#
+#@test s1(3) == Any
+
+#function u1(integer::where)
+#    where where A  # expression
+#    where where    # where clause for the expression on the previous line
+#end
+#
+#@test u1(3) == Any
+


### PR DESCRIPTION
This allows nicely aligning the `where`s, for example

    julia> function f(x::I)
                    where I <: Integer
               return x
           end
    f (generic function with 1 method)

    julia> f(3)
    3

This first naive attempt is not backwards-compatible, as evidenced by the necessity to modify the name of a variable called `where` in `loading.jl`. We should fix that before merging this.

Related Discourse thread: https://discourse.julialang.org/t/some-nice-to-have-syntax/24331