### PR TITLE
Two fixes to win32 cross compilation

### DIFF
--- a/contrib/normalize_triplet.py
+++ b/contrib/normalize_triplet.py
@@ -117,7 +117,7 @@ if gcc_version == "blank_gcc":
             "7": "gcc7",
             "8": "gcc8",
             "9": "gcc8",
-        }[list(filter(lambda x: re.match("\d+\.\d+\.\d+", x), sys.argv[2].split()))[-1][0]]
+        }[list(filter(lambda x: re.match("\d+\.\d+(\.\d+)?", x), sys.argv[2].split()))[-1][0]]
 
 if cxx_abi == "blank_cxx_abi":
     if len(sys.argv) == 4:

--- a/deps/tools/bb-install.mk
+++ b/deps/tools/bb-install.mk
@@ -1,6 +1,6 @@
 # Auto-detect triplet once, create different versions that we use as defaults below for each BB install target
 # This is much more efficient than launching `gcc` and `python` once for each BB install target.
-BB_TRIPLET_GCCABI_CXXABI := $(shell python $(call cygpath_w,$(JULIAHOME)/contrib/normalize_triplet.py) $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' )")
+BB_TRIPLET_GCCABI_CXXABI := $(shell python $(JULIAHOME)/contrib/normalize_triplet.py $(or $(XC_HOST),$(XC_HOST),$(BUILD_MACHINE)) "$(shell $(FC) --version | head -1)" "$(shell echo '\#include <string>' | $(CXX) $(CXXFLAGS) -x c++ -dM -E - | grep _GLIBCXX_USE_CXX11_ABI | awk '{ print $$3 }' )")
 BB_TRIPLET_GCCABI := $(subst $(SPACE),-,$(filter-out cxx%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI))))
 BB_TRIPLET_CXXABI := $(subst $(SPACE),-,$(filter-out gcc%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI))))
 BB_TRIPLET := $(subst $(SPACE),-,$(filter-out cxx%,$(filter-out gcc%,$(subst -,$(SPACE),$(BB_TRIPLET_GCCABI_CXXABI)))))


### PR DESCRIPTION
- The default mingw32 gfortran on ubuntu prints the version as `GNU Fortran (GCC) 7.3-win32 20180312`,
  rather than `7.3.0` most other gfortrans do, so be robust to that in normalize_triplet
- When shelling out to python use the host path rather than the windows-equivalent path, since python
  is a host tool.