### PR TITLE
Remove JL_GC_POP without corresponding push

### DIFF
--- a/src/jltypes.c
+++ b/src/jltypes.c
@@ -1600,7 +1600,6 @@ JL_DLLEXPORT jl_svec_t *jl_compute_fieldtypes(jl_datatype_t *st)
     top.prev = NULL;
     st->types = inst_ftypes(wt->types, &env[n - 1], &top);
     jl_gc_wb(st, st->types);
-    JL_GC_POP();
     return st->types;
 }
 


### PR DESCRIPTION
I'm fairly sure this fixes #32059, though I didn't rr that all the way to the end, but instead
used the static analyzer once I saw that it was a GC frame mismatch. The analyzer reports:
```
/home/keno/julia-old/src/jltypes.c:1603:5: warning: JL_GC_POP without corresponding push
    JL_GC_POP();
    ^~~~~~~~~~~
```
Fix that.

I'll work towards enabling the static analyzer on CI. I wasted the day on this, when the analyzer would have just caught it right away :(.