### PR TITLE
Add a juliadocs ref to the "trailing one" rule

### DIFF
--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -818,8 +818,8 @@ some ideas that might help to understand Julia's definition.
   the product of the size. The size of a zero-dimensional array is `()`, and
   therefore its length is `1`.
 * Zero-dimensional arrays don't natively have any dimensions into which you
-  index -- they’re just `A[]`. We can apply the same "trailing one" rule for them as for all other array dimensionalities, 
-  so you can indeed index them as `A[1]`, `A[1,1]`, etc; see 
+  index -- they’re just `A[]`. We can apply the same "trailing one" rule for them 
+  as for all other array dimensionalities, so you can indeed index them as `A[1]`, `A[1,1]`, etc; see 
   [Omitted and extra indices](https://docs.julialang.org/en/v1/manual/arrays/#Omitted-and-extra-indices-1).
 
 It is also important to understand the differences to ordinary scalars. Scalars

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -819,7 +819,7 @@ some ideas that might help to understand Julia's definition.
   therefore its length is `1`.
 * Zero-dimensional arrays don't natively have any dimensions into which you
   index -- they’re just `A[]`. We can apply the same "trailing one" rule for them 
-  as for all other array dimensionalities, so you can indeed index them as `A[1]`, `A[1,1]`, etc; see 
+  as for all other array dimensionalities, so you can indeed index them as `A[1]`, `A[1,1]`, etc; see
   [Omitted and extra indices](@ref).
 
 It is also important to understand the differences to ordinary scalars. Scalars

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -818,9 +818,9 @@ some ideas that might help to understand Julia's definition.
   the product of the size. The size of a zero-dimensional array is `()`, and
   therefore its length is `1`.
 * Zero-dimensional arrays don't natively have any dimensions into which you
-  index -- they’re just `A[]`. We can apply the same "trailing one" rule for them
-  as for all other array dimensionalities, so you can indeed index them as
-  `A[1]`, `A[1,1]`, etc.
+  index -- they’re just `A[]`. We can apply the same "trailing one" rule for them as for all other array dimensionalities, 
+  so you can indeed index them as `A[1]`, `A[1,1]`, etc; see 
+  [Omitted and extra indices](https://docs.julialang.org/en/v1/manual/arrays/#Omitted-and-extra-indices-1).
 
 It is also important to understand the differences to ordinary scalars. Scalars
 are not mutable containers (even though they are iterable and define things

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -820,7 +820,7 @@ some ideas that might help to understand Julia's definition.
 * Zero-dimensional arrays don't natively have any dimensions into which you
   index -- they’re just `A[]`. We can apply the same "trailing one" rule for them 
   as for all other array dimensionalities, so you can indeed index them as `A[1]`, `A[1,1]`, etc; see 
-  [Omitted and extra indices](https://docs.julialang.org/en/v1/manual/arrays/#Omitted-and-extra-indices-1).
+  [Omitted and extra indices](@ref).
 
 It is also important to understand the differences to ordinary scalars. Scalars
 are not mutable containers (even though they are iterable and define things

--- a/doc/src/manual/faq.md
+++ b/doc/src/manual/faq.md
@@ -818,7 +818,7 @@ some ideas that might help to understand Julia's definition.
   the product of the size. The size of a zero-dimensional array is `()`, and
   therefore its length is `1`.
 * Zero-dimensional arrays don't natively have any dimensions into which you
-  index -- they’re just `A[]`. We can apply the same "trailing one" rule for them 
+  index -- they’re just `A[]`. We can apply the same "trailing one" rule for them
   as for all other array dimensionalities, so you can indeed index them as `A[1]`, `A[1,1]`, etc; see
   [Omitted and extra indices](@ref).
 


### PR DESCRIPTION
I was surprised (perhaps shouldn't have been ...) that if A[1] is a valid index into A, so is A[1,1], and struggled to find the explanation in the docs