### PR TITLE
Print macro definitions Exprs as readable julia code

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1273,8 +1273,8 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_block(io, head, Expr(:calldecl, args[1].args...), args[2], indent)
         print(io, "end")
 
-    elseif head === :function && nargs == 1
-        print(io, "function ", args[1], " end")
+    elseif (head === :function || head === :macro) && nargs == 1
+        print(io, head, ' ', args[1], " end")
 
     elseif head === :do && nargs == 2
         show_unquoted(io, args[1], indent, -1)
@@ -1288,7 +1288,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, "end")
 
     # block with argument
-    elseif head in (:for,:while,:function,:if,:elseif,:let) && nargs==2
+    elseif head in (:for,:while,:function,:macro,:if,:elseif,:let) && nargs==2
         show_block(io, head, args[1], args[2], indent)
         print(io, "end")
 

--- a/test/show.jl
+++ b/test/show.jl
@@ -741,6 +741,23 @@ test_mt(show_f5, "show_f5(A::AbstractArray{T,N}, indices::Vararg{$Int,N})")
 @test sprint(show, :(function f end)) == ":(function f end)"
 @test_repr "function g end"
 
+# Printing of macro definitions
+@test sprint(show, :(macro m end)) == ":(macro m end)"
+@test_repr "macro m end"
+@test sprint(show, Expr(:macro, Expr(:call, :m, :ex), Expr(:block, :m))) ==
+      ":(macro m(ex)\n      m\n  end)"
+@test_repr """macro identity(ex)
+    # line meta
+    esc(ex)
+end"""
+@test_repr """macro m(a,b)
+    # line meta
+    quote
+        # line meta
+        \$a + \$b
+    end
+end"""
+
 # Issue #15765 printing of continue and break
 @test sprint(show, :(continue)) == ":(continue)"
 @test sprint(show, :(break)) == ":(break)"


### PR DESCRIPTION
Rather than printing in bare "Expr(:macro, ...)" form, this prints them
as blocks, following the way that printing of function expressions
works.

This fixes the following uglyness:

```
julia> :(macro identity(ex)
           esc(ex)
         end)
:($(Expr(:macro, :(identity(ex)), quote
    #= REPL[3]:2 =#
    esc(ex)
end)))
```