### PR TITLE
Prevent the GC task callback from segfaulting.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -2344,7 +2344,8 @@ mark: {
             if (gc_cblist_task_scanner) {
                 export_gc_state(ptls, &sp);
                 gc_invoke_callbacks(jl_gc_cb_task_scanner_t,
-                    gc_cblist_task_scanner, (ta, ta == ptls2->root_task));
+                    gc_cblist_task_scanner,
+                    (ta, ptls2 != NULL && ta == ptls2->root_task));
                 import_gc_state(ptls, &sp);
             }
 #ifdef COPY_STACKS


### PR DESCRIPTION
It is possible when marking task objects in the GC for the associated
jl_ptls_t reference to be NULL. To determine whether a task is a root
task, we therefore also have to check if that reference is valid.

This is a fix for a bug in the old "GC Extensions" [changes added last year](https://github.com/JuliaLang/julia/pull/28368) that did not manifest until now, because it was triggered by a combination of unusual circumstances. It should be fairly straightforward, as it only adds a missing null pointer check.