### PR TITLE
separate the two different functions called `issingletontype`

### DIFF
--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -435,7 +435,7 @@ function typeof_tfunc(@nospecialize(t))
     t = widenconst(t)
     if isType(t)
         tp = t.parameters[1]
-        if issingletontype(tp)
+        if hasuniquerep(tp)
             return Const(typeof(tp))
         end
     elseif isa(t, DataType)
@@ -914,7 +914,7 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
             exactft1 = exact || (!has_free_typevars(ft1) && u.name !== Tuple.name)
             ft1 = rewrap_unionall(ft1, s)
             if exactft1
-                if issingletontype(ft1)
+                if hasuniquerep(ft1)
                     ft1 = Const(ft1) # ft unique via type cache
                 else
                     ft1 = Type{ft1}
@@ -947,7 +947,7 @@ function _fieldtype_tfunc(@nospecialize(s), exact::Bool, @nospecialize(name))
     exactft = exact || (!has_free_typevars(ft) && u.name !== Tuple.name)
     ft = rewrap_unionall(ft, s)
     if exactft
-        if issingletontype(ft)
+        if hasuniquerep(ft)
             return Const(ft) # ft unique via type cache
         end
         return Type{ft}
@@ -1041,7 +1041,7 @@ function apply_type_tfunc(@nospecialize(headtypetype), @nospecialize args...)
             ai = args[i]
             if isType(ai)
                 aty = ai.parameters[1]
-                allconst &= issingletontype(aty)
+                allconst &= hasuniquerep(aty)
             else
                 aty = (ai::Const).val
             end
@@ -1174,7 +1174,7 @@ function tuple_tfunc(atypes::Vector{Any})
             x = widenconst(x)
             if isType(x)
                 xparam = x.parameters[1]
-                if issingletontype(xparam) || xparam === Bottom
+                if hasuniquerep(xparam) || xparam === Bottom
                     params[i] = typeof(xparam)
                 else
                     params[i] = Type
@@ -1429,7 +1429,7 @@ function return_type_tfunc(argtypes::Vector{Any}, vtypes::VarTable, sv::Inferenc
                     if isa(rt, Const)
                         # output was computed to be constant
                         return Const(typeof(rt.val))
-                    elseif issingletontype(rt) || rt === Bottom
+                    elseif hasuniquerep(rt) || rt === Bottom
                         # output type was known for certain
                         return Const(rt)
                     elseif (isa(tt, Const) || isconstType(tt)) &&

--- a/base/compiler/typeutils.jl
+++ b/base/compiler/typeutils.jl
@@ -15,10 +15,10 @@ isType(@nospecialize t) = isa(t, DataType) && t.name === _TYPE_NAME
 
 # true if Type{T} is inlineable as constant T
 # requires that T is a singleton, s.t. T == S implies T === S
-isconstType(@nospecialize t) = isType(t) && issingletontype(t.parameters[1])
+isconstType(@nospecialize t) = isType(t) && hasuniquerep(t.parameters[1])
 
-# test whether T is a singleton type, s.t. T == S implies T === S
-function issingletontype(@nospecialize t)
+# test whether type T has a unique representation, s.t. T == S implies T === S
+function hasuniquerep(@nospecialize t)
     # typeof(Bottom) is special since even though it is a leaftype,
     # at runtime, it might be Type{Union{}} instead, so don't attempt inference of it
     t === typeof(Union{}) && return false
@@ -27,21 +27,21 @@ function issingletontype(@nospecialize t)
     iskindtype(typeof(t)) || return true # non-types are always compared by egal in the type system
     isconcretetype(t) && return true # these are also interned and pointer comparable
     if isa(t, DataType) && t.name !== Tuple.name && !isvarargtype(t) # invariant DataTypes
-        return _all(issingletontype, t.parameters)
+        return _all(hasuniquerep, t.parameters)
     end
     return false
 end
 
 function has_nontrivial_const_info(@nospecialize t)
     isa(t, PartialStruct) && return true
-    return isa(t, Const) && !isdefined(typeof(t.val), :instance) && !(isa(t.val, Type) && issingletontype(t.val))
+    return isa(t, Const) && !isdefined(typeof(t.val), :instance) && !(isa(t.val, Type) && hasuniquerep(t.val))
 end
 
 # Subtyping currently intentionally answers certain queries incorrectly for kind types. For
 # some of these queries, this check can be used to somewhat protect against making incorrect
 # decisions based on incorrect subtyping. Note that this check, itself, is broken for
 # certain combinations of `a` and `b` where one/both isa/are `Union`/`UnionAll` type(s)s.
-isnotbrokensubtype(@nospecialize(a), @nospecialize(b)) = (!iskindtype(b) || !isType(a) || issingletontype(a.parameters[1]))
+isnotbrokensubtype(@nospecialize(a), @nospecialize(b)) = (!iskindtype(b) || !isType(a) || hasuniquerep(a.parameters[1]))
 
 argtypes_to_type(argtypes::Array{Any,1}) = Tuple{anymap(widenconst, argtypes)...}
 

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -371,7 +371,7 @@ Return the size in bytes of each field-description entry in the layout array,
 located at `(dt.layout + sizeof(DataTypeLayout))`.
 Can be called on any `isconcretetype`.
 
-See also [`Base.fieldoffset`](@ref).
+See also [`fieldoffset`](@ref).
 """
 function datatype_fielddesc_type(dt::DataType)
     @_pure_meta
@@ -399,7 +399,7 @@ false
 isimmutable(@nospecialize(x)) = (@_pure_meta; !typeof(x).mutable)
 
 """
-    Base.isstructtype(T) -> Bool
+    isstructtype(T) -> Bool
 
 Determine whether type `T` was declared as a struct type
 (i.e. using the `struct` or `mutable struct` keyword).
@@ -414,7 +414,7 @@ function isstructtype(@nospecialize(t::Type))
 end
 
 """
-    Base.isprimitivetype(T) -> Bool
+    isprimitivetype(T) -> Bool
 
 Determine whether type `T` was declared as a primitive type
 (i.e. using the `primitive` keyword).
@@ -509,17 +509,17 @@ false
 isconcretetype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && t.isconcretetype)
 
 """
-    Base.isabstracttype(T)
+    isabstracttype(T)
 
 Determine whether type `T` was declared as an abstract type
 (i.e. using the `abstract` keyword).
 
 # Examples
 ```jldoctest
-julia> Base.isabstracttype(AbstractArray)
+julia> isabstracttype(AbstractArray)
 true
 
-julia> Base.isabstracttype(Vector)
+julia> isabstracttype(Vector)
 false
 ```
 """
@@ -529,6 +529,14 @@ function isabstracttype(@nospecialize(t))
     # TODO: what to do for `Union`?
     return isa(t, DataType) && t.abstract
 end
+
+"""
+    Base.issingletontype(T)
+
+Determine whether type `T` has exactly one possible instance; for example, a
+struct type with no fields.
+"""
+issingletontype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && isdefined(t, :instance))
 
 """
     Base.parameter_upper_bound(t::UnionAll, idx)
@@ -612,7 +620,7 @@ String
 fieldtype
 
 """
-    fieldindex(T, name::Symbol, err:Bool=true)
+    Base.fieldindex(T, name::Symbol, err:Bool=true)
 
 Get the index of a named field, throwing an error if the field does not exist (when err==true)
 or returning 0 (when err==false).
@@ -1232,7 +1240,7 @@ function hasmethod(@nospecialize(f), @nospecialize(t), kwnames::Tuple{Vararg{Sym
 end
 
 """
-    isambiguous(m1, m2; ambiguous_bottom=false) -> Bool
+    Base.isambiguous(m1, m2; ambiguous_bottom=false) -> Bool
 
 Determine whether two methods `m1` and `m2` (typically of the same
 function) are ambiguous.  This test is performed in the context of

--- a/base/set.jl
+++ b/base/set.jl
@@ -533,8 +533,6 @@ promote_valuetype(x::Pair{K, V}, y::Pair...) where {K, V} =
     promote_type(V, promote_valuetype(y...))
 
 # Subtract singleton types which are going to be replaced
-@pure issingletontype(T::DataType) = isdefined(T, :instance)
-issingletontype(::Type) = false
 function subtract_singletontype(::Type{T}, x::Pair{K}) where {T, K}
     if issingletontype(K)
         Core.Compiler.typesubtract(T, K)

--- a/doc/src/base/base.md
+++ b/doc/src/base/base.md
@@ -161,6 +161,7 @@ Base.isdispatchtuple
 Base.isimmutable
 Base.isabstracttype
 Base.isprimitivetype
+Base.issingletontype
 Base.isstructtype
 Base.nameof(::DataType)
 Base.fieldnames


### PR DESCRIPTION
`Base` and `Core.Compiler` both had functions with this name, and they are quite different. I moved `Base.issingletontype` to a more sensible place and documented it, and I propose renaming the compiler one to `hasuniquerep`, since it's used to determine when (we think) a type has a single representation.