### PR TITLE
add svdvals method for SymTridiagonal

### DIFF
--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -272,6 +272,11 @@ julia> eigvecs(A, [1.])
 """
 eigvecs(A::SymTridiagonal{<:BlasFloat}, eigvals::Vector{<:Real}) = LAPACK.stein!(A.dv, A.ev, eigvals)
 
+function svdvals!(A::SymTridiagonal)
+    vals = eigvals!(A)
+    return sort!(map!(abs, vals, vals); rev=true)
+end
+
 #tril and triu
 
 istriu(M::SymTridiagonal) = iszero(M.ev)

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -437,4 +437,12 @@ end
     @test A90\b90 ≈ inv(A90)*b90
 end
 
+@testset "singular values of SymTridiag" begin
+    @test svdvals(SymTridiagonal([-4,2,3], [0,0])) ≈ [4,3,2]
+    @test svdvals(SymTridiagonal(collect(0.:10.), zeros(10))) ≈ reverse(0:10)
+    @test svdvals(SymTridiagonal([1,2,1], [1,1])) ≈ [3,1,0]
+    # test that dependent methods such as `cond` also work
+    @test cond(SymTridiagonal([1,2,3], [0,0])) ≈ 3
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
The method `svdvals(::SymTridiagonal)` was missing:

```julia
julia> svdvals(SymTridiagonal([1,2],[1]))
ERROR: MethodError: no method matching svdvals!(::SymTridiagonal{Float64,Array{Float64,1}})
```

This PR adds a suitable definition.