### PR TITLE
Amend matrix * vector specialization for strided arrays

### DIFF
--- a/stdlib/LinearAlgebra/src/matmul.jl
+++ b/stdlib/LinearAlgebra/src/matmul.jl
@@ -41,9 +41,10 @@ function *(transx::Transpose{<:Any,<:StridedVector{T}}, y::StridedVector{T}) whe
 end
 
 # Matrix-vector multiplication
-function (*)(A::StridedMatrix{T}, x::StridedVector{S}) where {T<:BlasFloat,S}
+function (*)(A::StridedMatrix{T}, x::StridedVector{S}) where {T<:BlasFloat,S<:Real}
     TS = promote_op(matprod, T, S)
-    mul!(similar(x, TS, size(A,1)), A, convert(AbstractVector{TS}, x))
+    y = isconcretetype(TS) ? convert(AbstractVector{TS}, x) : x
+    mul!(similar(x, TS, size(A,1)), A, y)
 end
 function (*)(A::AbstractMatrix{T}, x::AbstractVector{S}) where {T,S}
     TS = promote_op(matprod, T, S)


### PR DESCRIPTION
This method entirely duplicates the one below it with the exception that it also does a `convert` on one of the inputs with the result of `promote_op`, which doesn't make a whole lot of sense in some cases. By virtue of calling `mul!`, strided arrays that go through the abstract array method will still hit the same optimized methods that use BLAS.

Fixes JuliaLang/LinearAlgebra.jl#632.

It would be great if this change could be backported, since it fixes an issue in private code that occurs on every version >= 1.1.0. Help coming up with a minimal test case for this would be much appreciated as well.