### PR TITLE
fix #32095, printing user-defined Function types

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -1114,12 +1114,23 @@ function which(m::Module, s::Symbol)
 end
 
 # function reflection
+
 """
     nameof(f::Function) -> Symbol
 
-Get the name of a generic `Function` as a symbol, or `:anonymous`.
+Get the name of a generic `Function` as a symbol. For anonymous functions,
+this is a compiler-generated name. For explicitly-declared subtypes of
+`Function`, it is the name of the function's type.
 """
-nameof(f::Function) = (typeof(f).name.mt::Core.MethodTable).name
+function nameof(f::Function)
+    t = typeof(f)
+    mt = t.name.mt::Core.MethodTable
+    if mt === Symbol.name.mt
+        # uses shared method table, so name is not unique to this function type
+        return nameof(t)
+    end
+    return mt.name
+end
 
 functionloc(m::Core.MethodInstance) = functionloc(m.def)
 

--- a/base/show.jl
+++ b/base/show.jl
@@ -378,12 +378,12 @@ function is_exported_from_stdlib(name::Symbol, mod::Module)
     return isexported(mod, name) && isdefined(mod, name) && !isdeprecated(mod, name) && getfield(mod, name) === orig
 end
 
-function show(io::IO, f::Function)
+function show_function(io::IO, f::Function, compact::Bool)
     ft = typeof(f)
     mt = ft.name.mt
     if isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
         getfield(mt.module, mt.name) === f
-        if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main || get(io, :compact, false)
+        if compact || is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
             print(io, mt.name)
         else
             print(io, mt.module, ".", mt.name)
@@ -393,7 +393,8 @@ function show(io::IO, f::Function)
     end
 end
 
-print(io::IO, f::Function) = print(io, nameof(f))
+show(io::IO, f::Function) = show_function(io, f, get(io, :compact, false))
+print(io::IO, f::Function) = show_function(io, f, true)
 
 function show(io::IO, x::Core.IntrinsicFunction)
     name = ccall(:jl_intrinsic_name, Cstring, (Core.IntrinsicFunction,), x)

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -882,3 +882,6 @@ _test_at_locals2(1,1)
                    #=dump_module=#true, #=syntax=#:att, #=optimize=#false, :none,
                    params)
 end
+
+@test nameof(Any) === :Any
+@test nameof(:) === :Colon

--- a/test/show.jl
+++ b/test/show.jl
@@ -1295,11 +1295,30 @@ end
     end
 end
 
+function _methodsstr(f)
+    buf = IOBuffer()
+    show(buf, methods(f))
+    String(take!(buf))
+end
+
+@testset "show function methods" begin
+    @test occursin("methods for generic function \"sin\":", _methodsstr(sin))
+end
+@testset "show macro methods" begin
+    @test startswith(_methodsstr(getfield(Base,Symbol("@show"))), "# 1 method for macro \"@show\":")
+end
+@testset "show constructor methods" begin
+    @test occursin("methods for type constructor:\n", _methodsstr(Vector))
+end
+@testset "show builtin methods" begin
+    @test startswith(_methodsstr(typeof), "# built-in function; no methods")
+end
+@testset "show callable object methods" begin
+    @test occursin("methods:", _methodsstr(:))
+end
 @testset "#20111 show for function" begin
     K20111(x) = y -> x
-    buf = IOBuffer()
-    show(buf, methods(K20111(1)))
-    @test occursin(" 1 method for generic function", String(take!(buf)))
+    @test startswith(_methodsstr(K20111(1)), "# 1 method for anonymous function")
 end
 
 @generated f22798(x::Integer, y) = :x
@@ -1474,6 +1493,7 @@ replstrcolor(x) = sprint((io, x) -> show(IOContext(io, :limit => true, :color =>
 @test repr(Symbol("a\$")) == "Symbol(\"a\\\$\")"
 
 @test string(sin) == "sin"
+@test string(:) == "Colon()"
 @test string(Iterators.flatten) == "flatten"
 @test Symbol(Iterators.flatten) === :flatten
 


### PR DESCRIPTION
This improves a few cases of printing function-like objects that don't have obvious names.

- Don't show a name in the method list header if there isn't a useful one. Before:
```
julia> methods(Vector)
# 5 methods for generic function "(::Type)":

julia> methods(x->x)
# 1 method for generic function "#5":
```
After:
```
julia> methods(Vector)
# 5 methods:

julia> methods(x->x)
# 1 method for anonymous function "#5":
```

- Fix the docstring of `nameof(::Function)`, and have it return the name of a function's type if it's not a named generic function. This makes `nameof(:)` return `:Colon` again instead of `:Any`.

- `show(::Function)` is unchanged, but `print(::Function)` now falls back to `show` if the argument doesn't have a clear name like `sin` or `+`.