### PR TITLE
Support `repr` on `Time`

### DIFF
--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -51,7 +51,26 @@ function Base.string(t::Time)
     return "$hh:$mii:$ss$ns"
 end
 
-Base.show(io::IO, x::Time) = print(io, string(x))
+Base.show(io::IO, ::MIME"text/plain", t::Time) = print(io, t)
+Base.print(io::IO, t::Time) = print(io, string(t))
+
+function Base.show(io::IO, t::Time)
+    if get(io, :compact, false)
+        print(io, t)
+    else
+        values = [
+            hour(t)
+            minute(t)
+            second(t)
+            millisecond(t)
+            microsecond(t)
+            nanosecond(t)
+        ]
+        index = something(findlast(!iszero, values), 1)
+        params = map(repr, values[1:index])
+        print(io, Time, "(", join(params, ", "), ")")
+    end
+end
 
 @inline function format(io, d::AbstractDateToken, dt, locale)
     format(io, d, dt)

--- a/stdlib/Dates/src/io.jl
+++ b/stdlib/Dates/src/io.jl
@@ -67,8 +67,13 @@ function Base.show(io::IO, t::Time)
             nanosecond(t)
         ]
         index = something(findlast(!iszero, values), 1)
-        params = map(repr, values[1:index])
-        print(io, Time, "(", join(params, ", "), ")")
+
+        print(io, Time, "(")
+        for i in 1:index
+            show(io, values[i])
+            i != index && print(io, ", ")
+        end
+        print(io, ")")
     end
 end
 

--- a/stdlib/Dates/test/io.jl
+++ b/stdlib/Dates/test/io.jl
@@ -73,16 +73,28 @@ end
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 500)) == "2000-01-01T00:00:00.5"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 998)) == "2000-01-01T00:00:00.998"
     @test string(Dates.DateTime(2000, 1, 1, 0, 0, 0, 999)) == "2000-01-01T00:00:00.999"
-    @test string(Dates.Time(0)) == "00:00:00"
-    @test string(Dates.Time(0, 1)) == "00:01:00"
-    @test string(Dates.Time(0, 1, 2)) == "00:01:02"
-    @test string(Dates.Time(0, 1, 2, 3)) == "00:01:02.003"
-    @test string(Dates.Time(0, 1, 2, 3, 4)) == "00:01:02.003004"
-    @test string(Dates.Time(0, 1, 2, 3, 4, 5)) == "00:01:02.003004005"
-    @test string(Dates.Time(0, 0, 0, 0, 1)) == "00:00:00.000001"
-    @test string(Dates.Time(0, 0, 0, 0, 0, 1)) == "00:00:00.000000001"
-    @test string(Dates.Time(0, 0, 0, 1)) == "00:00:00.001"
 end
+
+@testset "string/show representation of Time" begin
+    tests = [
+        Dates.Time(0) => ("00:00:00", "Dates.Time(0)"),
+        Dates.Time(0, 1) => ("00:01:00", "Dates.Time(0, 1)"),
+        Dates.Time(0, 1, 2) => ("00:01:02", "Dates.Time(0, 1, 2)"),
+        Dates.Time(0, 1, 2, 3) => ("00:01:02.003", "Dates.Time(0, 1, 2, 3)"),
+        Dates.Time(0, 1, 2, 3, 4) => ("00:01:02.003004", "Dates.Time(0, 1, 2, 3, 4)"),
+        Dates.Time(0, 1, 2, 3, 4, 5) => ("00:01:02.003004005", "Dates.Time(0, 1, 2, 3, 4, 5)"),
+        Dates.Time(0, 0, 0, 0, 0, 1) => ("00:00:00.000000001", "Dates.Time(0, 0, 0, 0, 0, 1)"),
+        Dates.Time(0, 0, 0, 1) => ("00:00:00.001", "Dates.Time(0, 0, 0, 1)"),
+    ]
+
+    for (t, (printed, shown)) in tests
+        @test sprint(print, t) == printed
+        @test string(t) == printed
+        @test sprint(show, t) == shown
+        @test repr(t) == shown
+    end
+end
+
 @testset "DateTime parsing" begin
     # Useful reference for different locales: http://library.princeton.edu/departments/tsd/katmandu/reference/months.html
 


### PR DESCRIPTION
Along the same lines as #30200 and #30817 but for `Time`. Does not attempt to address #30901 but just brings `Time` up to date with the previous changes.