### PR TITLE
work around #32087 by polling for I/O on windows inside thread loops

### DIFF
--- a/src/partr.c
+++ b/src/partr.c
@@ -314,7 +314,11 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *getsticky)
                 }
                 uv_loop_t *loop = jl_global_event_loop();
                 loop->stop_flag = 0;
+#ifdef _OS_WINDOWS_
+                uv_run(loop, UV_RUN_NOWAIT);
+#else
                 uv_run(loop, UV_RUN_ONCE);
+#endif
                 JL_UV_UNLOCK();
             }
             else {


### PR DESCRIPTION
This is a workaround to hopefully make `@threads` loops work again. Existing uses of `@threads` only do compute, so polling here should not make any difference in those cases (it will only happen briefly on the way out of the `@threads` loop). Not very satisfying, but this is the best I've got so far.