### PR TITLE
Official Coveralls Badge to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,11 @@ Build status:
 [![appveyor][appveyor-img]](https://ci.appveyor.com/project/JuliaLang/julia/branch/master)
 
 Code coverage:
-[![coveralls][coveralls-img]](https://coveralls.io/r/JuliaLang/julia?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/JuliaLang/julia/badge.svg?branch=master)](https://coveralls.io/github/JuliaLang/julia?branch=master)
 [![codecov][codecov-img]](https://codecov.io/github/JuliaLang/julia?branch=master)
 
 [travis-img]: https://img.shields.io/travis/JuliaLang/julia/master.svg?label=Linux+/+macOS
 [appveyor-img]: https://img.shields.io/appveyor/ci/JuliaLang/julia/master.svg?label=Windows
-[coveralls-img]: https://img.shields.io/coveralls/github/JuliaLang/julia/master.svg?label=coveralls
 [codecov-img]: https://img.shields.io/codecov/c/github/JuliaLang/julia/master.svg?label=codecov
 
 ## The Julia Language


### PR DESCRIPTION
Including an official Coveralls badge in the README. Official instead of badge hosted on `ioshields.io`. This also removes the message in Coveralls to add a badge to the repo.