### PR TITLE
Documentation, dependency install command (macOS, Homebrew)

### DIFF
--- a/doc/build/macos.md
+++ b/doc/build/macos.md
@@ -1,12 +1,10 @@
 ## macOS
 
-You need to have the current Xcode command line utilities installed: run `xcode-select --install` in the terminal.
+You need to have the current Xcode command line utilities installed: run `xcode-select --install` in the terminal. You will need to rerun this terminal command after each macOS update, otherwise you may run into errors involving missing libraries or headers.
 
-You will need to rerun this terminal command after each macOS update, otherwise you may run into errors involving missing libraries or headers.
-
-You will also need a 64-bit gfortran to compile Julia dependencies. The gfortran-4.7 (and newer) compilers in Homebrew work for building Julia.
+The dependent libraries are now built with [BinaryBuilder](https://binarybuilder.org) and will be automatically downloaded. This is the preferred way to build Julia source. In case you want to build them all on your own, you will need a 64-bit gfortran to compile Julia dependencies.
 ```bash
-brew cask install gfortran
+brew install gcc
 ```
 
 If you have set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` in your `.bashrc` or equivalent, Julia may be unable to find various libraries that come bundled with it. These environment variables need to be unset for Julia to work.

--- a/doc/build/macos.md
+++ b/doc/build/macos.md
@@ -5,7 +5,7 @@ You need to have the current Xcode command line utilities installed: run `xcode-
 You will need to rerun this terminal command after each macOS update, otherwise you may run into errors involving missing libraries or headers.
 
 You will also need a 64-bit gfortran to compile Julia dependencies. The gfortran-4.7 (and newer) compilers in Homebrew work for building Julia.
-```bash 
+```bash
 brew cask install gfortran
 ```
 

--- a/doc/build/macos.md
+++ b/doc/build/macos.md
@@ -1,8 +1,12 @@
 ## macOS
 
 You need to have the current Xcode command line utilities installed: run `xcode-select --install` in the terminal.
+
 You will need to rerun this terminal command after each macOS update, otherwise you may run into errors involving missing libraries or headers.
+
 You will also need a 64-bit gfortran to compile Julia dependencies. The gfortran-4.7 (and newer) compilers in Homebrew work for building Julia.
-`brew cask install gfortran`
+```bash 
+brew cask install gfortran
+```
 
 If you have set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` in your `.bashrc` or equivalent, Julia may be unable to find various libraries that come bundled with it. These environment variables need to be unset for Julia to work.

--- a/doc/build/macos.md
+++ b/doc/build/macos.md
@@ -3,5 +3,6 @@
 You need to have the current Xcode command line utilities installed: run `xcode-select --install` in the terminal.
 You will need to rerun this terminal command after each macOS update, otherwise you may run into errors involving missing libraries or headers.
 You will also need a 64-bit gfortran to compile Julia dependencies. The gfortran-4.7 (and newer) compilers in Homebrew work for building Julia.
+`brew cask install gfortran`
 
 If you have set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` in your `.bashrc` or equivalent, Julia may be unable to find various libraries that come bundled with it. These environment variables need to be unset for Julia to work.


### PR DESCRIPTION
Including the command to install dependency gfortran for macOS via Homebrew. Hopefully this will be helpful for a first-timer.