### PR TITLE
Make it possible to avoid the warning when replacing docstrings

### DIFF
--- a/base/docs/Docs.jl
+++ b/base/docs/Docs.jl
@@ -213,14 +213,14 @@ end
 
 Adds a new docstring `str` to the docsystem of `__module__` for `binding` and signature `sig`.
 """
-function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize sig = Union{})
+function doc!(__module__::Module, b::Binding, str::DocStr, @nospecialize(sig) = Union{}, shouldwarn::Bool=true)
     initmeta(__module__)
     m = get!(meta(__module__), b, MultiDoc())
     if haskey(m.docs, sig)
         # We allow for docstrings to be updated, but print a warning since it is possible
         # that over-writing a docstring *may* have been accidental.  The warning
         # is suppressed for symbols in Main, for interactive use (#23011).
-        __module__ == Main || @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
+        __module__ == Main || !shouldwarn || @warn "Replacing docs for `$b :: $sig` in module `$(__module__)`"
     else
         # The ordering of docstrings for each Binding is defined by the order in which they
         # are initially added. Replacing a specific docstring does not change it's ordering.

--- a/test/docs.jl
+++ b/test/docs.jl
@@ -1159,3 +1159,21 @@ end
 end
 @test M27832.xs == ":(\$(Expr(:\$, :fn)))"
 Core.atdoc!(_last_atdoc)
+
+# Replacing docstrings
+module Revise309
+"""
+A docstring
+"""
+c = 0
+end
+let b = Binding(Revise309, :c)
+    dstr = meta(Revise309)[b].docs[Union{}]
+    logs = Test.collect_test_logs() do
+        Base.Docs.doc!(Revise309, b, dstr, Union{}, false)
+    end
+    @test isempty(logs[1])
+    @test_logs (:warn, r"^Replacing docs for .*Revise309\.c") begin
+        Base.Docs.doc!(Revise309, b, dstr)
+    end
+end


### PR DESCRIPTION
The fact that `doc!` always warns led Revise to [skip `doc!` calls](https://github.com/timholy/Revise.jl/blob/8db99533f099299315927a0ad647378d2aab7cae/src/lowered.jl#L151-L152) but that led to a bug, https://github.com/timholy/Revise.jl/issues/309. The fix in https://github.com/timholy/Revise.jl/pull/310 basically requires copy-pasting the definition of `doc!`, which seems like a bad idea. This just adds an extra optional argument that allows one to suppress generation of the warning. Non-breaking but probably not advisable to backport since it's a new feature.

EDIT: alternatively this could be a keyword argument.