### PR TITLE
Relax constrain on `lq` to allwo `AbstractMatrix`

### DIFF
--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -107,8 +107,10 @@ julia> l == S.L &&  q == S.Q
 true
 ```
 """
-lq(A::AbstractMatrix)  = lq!(copy(A))
-lq(x::Number) = lq(fill(x,1,1))
+lq(A::AbstractMatrix{T}) where {T}  = lq!(copy_oftype(A, lq_eltype(T)))
+lq(x::Number) = lq!(fill(convert(lq_eltype(typeof(x)), x), 1, 1))
+
+lq_eltype(::Type{T}) where {T} = typeof(zero(T) / sqrt(abs2(one(T))))
 
 copy(A::LQ) = LQ(copy(A.factors), copy(A.τ))
 

--- a/stdlib/LinearAlgebra/src/lq.jl
+++ b/stdlib/LinearAlgebra/src/lq.jl
@@ -107,7 +107,7 @@ julia> l == S.L &&  q == S.Q
 true
 ```
 """
-lq(A::StridedMatrix{<:BlasFloat})  = lq!(copy(A))
+lq(A::AbstractMatrix)  = lq!(copy(A))
 lq(x::Number) = lq(fill(x,1,1))
 
 copy(A::LQ) = LQ(copy(A.factors), copy(A.τ))


### PR DESCRIPTION
My own matrix type implements `lq!` and `copy`
I therefore assumed that `lq` would just work,
but it does not as it is types to only allow `StridedMatrix`, which is a (nonextensible) `Union`.

What do people think of this change?
It will still method error right now for most matrix types,
because the restriction is still in play for `lq!`