### PR TITLE
Add a test for PR 32097

### DIFF
--- a/stdlib/LinearAlgebra/test/matmul.jl
+++ b/stdlib/LinearAlgebra/test/matmul.jl
@@ -508,4 +508,13 @@ end
     @test success(pipeline(cmd; stdout=stdout, stderr=stderr))
 end
 
+struct A32092
+    x::Float64
+end
+Base.:+(x::Float64, a::A32092) = x + a.x
+Base.:*(x::Float64, a::A32092) = x * a.x
+@testset "Issue #32092" begin
+    @test ones(2, 2) * [A32092(1.0), A32092(2.0)] == fill(3.0, (2,))
+end
+
 end # module TestMatmul


### PR DESCRIPTION
This example reproduces the issue observed in issue JuliaLang/LinearAlgebra.jl#632 on Julia 1.1 that was fixed by PR JuliaLang/julia#32097.

Marking for backport for all of the same versions as JuliaLang/julia#32097, as this adds tests for that PR that were not included in the PR itself.