### PR TITLE
RFC: add `open3` function for easy access to all process streams

### DIFF
--- a/base/process.jl
+++ b/base/process.jl
@@ -265,11 +265,16 @@ file. This is a more general version of the 2-argument `pipeline` function.
 `pipeline(from, to)` is equivalent to `pipeline(from, stdout=to)` when `from` is a command,
 and to `pipeline(to, stdin=from)` when `from` is another kind of data source.
 
+A [`Pipe`](@ref) can be passed to allow general I/O operations on the process streams.
+
 **Examples**:
 
 ```julia
 run(pipeline(`dothings`, stdout="out.txt", stderr="errs.txt"))
 run(pipeline(`update`, stdout="log.txt", append=true))
+
+in = Pipe(); out = Pipe(); err = Pipe()
+proc = pipeline(`cat`, stdin = in, stdout = out, stderr = err)
 ```
 """
 function pipeline(cmd::AbstractCmd; stdin=nothing, stdout=nothing, stderr=nothing, append::Bool=false)
@@ -672,6 +677,17 @@ function open(cmds::AbstractCmd, other::Redirectable=devnull; write::Bool=false,
         processes = _spawn(cmds, Any[devnull, devnull, stderr])
     end
     return processes
+end
+
+function open3(cmds::AbstractCmd)
+    in = PipeEndpoint()
+    out = PipeEndpoint()
+    err = PipeEndpoint()
+    processes = _spawn(cmds, Any[in, out, err])
+    processes.in = in
+    processes.out = out
+    processes.err = err
+    return (processes, err)
 end
 
 """


### PR DESCRIPTION
This is a very simple wrapper but I've still often wanted it: a function that runs a process (or chain) and simply returns all the streams as pipes. I don't know if this is the best implementation, and the interface is absolutely up for debate. Ideally we could better integrate it with existing functions instead of adding a new name. If we agree on something I'll add docs and tests.

In the spirit of #24810.