### PR TITLE
fix bug in block renaming for dead code elimination

### DIFF
--- a/base/compiler/ssair/ir.jl
+++ b/base/compiler/ssair/ir.jl
@@ -499,24 +499,28 @@ mutable struct IncrementalCompact
             cur_bb = 1
             for i = 1:length(bb_rename)
                 if i != 1 && length(blocks[i].preds) == 0
-                    bb_rename[i] = 0
+                    bb_rename[i] = -1
                 else
                     bb_rename[i] = cur_bb
                     cur_bb += 1
                 end
             end
             for i = 1:length(bb_rename)
-                bb_rename[i] == 0 && continue
+                bb_rename[i] == -1 && continue
                 preds, succs = blocks[i].preds, blocks[i].succs
                 # Rename preds
-                for j = 1:length(preds); preds[j] = bb_rename[preds[j]]; end
+                for j = 1:length(preds)
+                    if preds[j] != 0
+                        preds[j] = bb_rename[preds[j]]
+                    end
+                end
                 # Dead blocks get removed from the predecessor list
-                filter!(x->x !== 0, preds)
+                filter!(x->x !== -1, preds)
                 # Rename succs
                 for j = 1:length(succs); succs[j] = bb_rename[succs[j]]; end
             end
             let blocks=blocks
-                result_bbs = BasicBlock[blocks[i] for i = 1:length(blocks) if bb_rename[i] != 0]
+                result_bbs = BasicBlock[blocks[i] for i = 1:length(blocks) if bb_rename[i] != -1]
             end
         else
             bb_rename = Vector{Int}()

--- a/test/compiler/ssair.jl
+++ b/test/compiler/ssair.jl
@@ -97,6 +97,22 @@ let
     end
 end
 
+# PR #32145
+# Make sure IncrementalCompact can handle blocks with predecessors of index 0
+# while removing blocks with no predecessors.
+let cfg = CFG(BasicBlock[
+    make_bb([]        , [2, 4]),
+    make_bb([1]       , [4, 5]),
+    make_bb([]        , [4]   ), # should be removed
+    make_bb([0, 1, 2] , [5]   ), # 0 predecessor should be preserved
+    make_bb([2, 3]    , []    ),
+], Int[])
+    code = Compiler.IRCode(
+        [], [], Int32[], UInt8[], cfg, LineInfoNode[], [], [], [])
+    compact = Compiler.IncrementalCompact(code, true)
+    @test length(compact.result_bbs) == 4 && 0 in compact.result_bbs[3].preds
+end
+
 # Issue #32579 - Optimizer bug involving type constraints
 function f32579(x::Int, b::Bool)
     if b


### PR DESCRIPTION
IncrementalCompact can't deal with predecessors referred to by index 0, but according to @Keno, these are virtual and should not be renamed. I've changed IncrementalCompact to leave these predecessors as they are. To do this, I've also made it so that blocks that are to be removed are renamed to -1 rather than 0, to avoid conflicting with 0s that should be kept.

This should address https://github.com/JuliaDebug/Cthulhu.jl/issues/28