### PR TITLE
Allow nothing to be printed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@ Standard library changes
 * `empty` now accepts a `NamedTuple` ([#32534]).
 * `mod` now accepts a unit range as the second argument to easily perform offset modular arithmetic to ensure the result is inside the range ([#32628]).
 * `Sockets.recvfrom` now returns both host and port as an InetAddr ([#32729]).
+* `nothing` can now be `print`ed, and interplated into strings etc. as the string `"nothing"`. It is still not permitted to be interplated into Cmds (i.e. ``echo `$(nothing)` `` will still error without running anything.) ([#32148])
 
 #### Libdl
 

--- a/base/cmd.jl
+++ b/base/cmd.jl
@@ -314,6 +314,10 @@ pipeline(a, b, c, d...) = pipeline(pipeline(a, b), c, d...)
 
 ## implementation of `cmd` syntax ##
 
+cmd_interpolate(xs...) = cstr(string(map(cmd_interpolate1, xs)...))
+cmd_interpolate1(x) = x
+cmd_interpolate1(::Nothing) = throw(ArgumentError("`nothing` can not be interpolated into commands (`Cmd`)"))
+
 arg_gen() = String[]
 arg_gen(x::AbstractString) = String[cstr(x)]
 function arg_gen(cmd::Cmd)
@@ -327,11 +331,11 @@ function arg_gen(head)
     if isiterable(typeof(head))
         vals = String[]
         for x in head
-            push!(vals, cstr(string(x)))
+            push!(vals, cmd_interpolate(x))
         end
         return vals
     else
-        return String[cstr(string(head))]
+        return String[cmd_interpolate(head)]
     end
 end
 
@@ -340,7 +344,7 @@ function arg_gen(head, tail...)
     tail = arg_gen(tail...)
     vals = String[]
     for h = head, t = tail
-        push!(vals, cstr(string(h,t)))
+        push!(vals, cmd_interpolate(h,t))
     end
     return vals
 end

--- a/base/show.jl
+++ b/base/show.jl
@@ -590,7 +590,6 @@ function show(io::IO, tn::Core.TypeName)
 end
 
 show(io::IO, ::Nothing) = print(io, "nothing")
-print(io::IO, ::Nothing) = throw(ArgumentError("`nothing` should not be printed; use `show`, `repr`, or custom output instead."))
 show(io::IO, b::Bool) = print(io, get(io, :typeinfo, Any) === Bool ? (b ? "1" : "0") : (b ? "true" : "false"))
 show(io::IO, n::Signed) = (write(io, string(n)); nothing)
 show(io::IO, n::Unsigned) = print(io, "0x", string(n, pad = sizeof(n)<<1, base = 16))

--- a/test/show.jl
+++ b/test/show.jl
@@ -1467,15 +1467,19 @@ let src = code_typed(gcd, (Int, Int), debuginfo=:source)[1][1]
     @test pop!(lines) == "   ! ──       unreachable::#UNDEF"
 end
 
-# issue #27352
-@test_throws ArgumentError print(nothing)
-@test_throws ArgumentError print(stdout, nothing)
-@test_throws ArgumentError string(nothing)
-@test_throws ArgumentError string(1, "", nothing)
-@test_throws ArgumentError let x = nothing; "x = $x" end
-@test let x = nothing; "x = $(repr(x))" end == "x = nothing"
-@test_throws ArgumentError `/bin/foo $nothing`
-@test_throws ArgumentError `$nothing`
+@testset "printing and interpolating nothing" begin
+    @test sprint(print, nothing) == "nothing"
+    @test string(nothing) == "nothing"
+    @test repr(nothing) == "nothing"
+    @test string(1, "", nothing) == "1nothing"
+    @test let x = nothing; "x = $x" end == "x = nothing"
+    @test let x = nothing; "x = $(repr(x))" end == "x = nothing"
+
+    # issue #27352 : No interpolating nothing into commands
+    @test_throws ArgumentError `/bin/foo $nothing`
+    @test_throws ArgumentError `$nothing`
+    @test_throws ArgumentError let x = nothing; `/bin/foo $x` end
+end
 
 struct X28004
     value::Any


### PR DESCRIPTION
I don't have julia installed so I am just sketching this out.

What this should do:
 - allow `nothing` to  be `print`ed, and interpolated into strings
 - not allow `nothing` to be interpolated into commands.


This PR partially undoes https://github.com/JuliaLang/julia/issues/27352.
Turns out that not being able to print `nothing` is just really annoying.