### PR TITLE
add assert when trying to set a const global twice

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -503,6 +503,8 @@ JL_DLLEXPORT void jl_set_global(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *va
     if (!bp->constp) {
         bp->value = val;
         jl_gc_wb(m, val);
+    } else {
+        assert(0);
     }
 }
 
@@ -513,6 +515,8 @@ JL_DLLEXPORT void jl_set_const(jl_module_t *m JL_ROOTING_ARGUMENT, jl_sym_t *var
         bp->value = val;
         bp->constp = 1;
         jl_gc_wb(m, val);
+    } else {
+        assert(0);
     }
 }
 


### PR DESCRIPTION
Currently `jl_set_const` and `jl_set_global` silently ignores
attempts to set a constant global multiple times, but both functions
also promise to root the provided value. If the binding already
exists and is const we will **not** root the value, leading us
to miss a root.

Arguably this maybe should be a proper error, but there also probably
was a reason why we don't throw an error here.