### PR TITLE
Add margin when printing MD tables to the terminal

### DIFF
--- a/stdlib/Markdown/src/GitHub/table.jl
+++ b/stdlib/Markdown/src/GitHub/table.jl
@@ -138,12 +138,15 @@ function rst(io::IO, md::Table)
 end
 
 function term(io::IO, md::Table, columns)
+    margin_str = " "^margin
     cells = mapmap(x -> terminline_string(io, x), md.rows)
     padcells!(cells, md.align, len = ansi_length)
     for i = 1:length(cells)
+        print(io, margin_str)
         join(io, cells[i], " ")
         if i == 1
             println(io)
+            print(io, margin_str)
             join(io, ["–"^ansi_length(cells[i][j]) for j = 1:length(cells[1])], " ")
         end
         i < length(cells) && println(io)

--- a/stdlib/Markdown/src/Markdown.jl
+++ b/stdlib/Markdown/src/Markdown.jl
@@ -8,6 +8,9 @@ module Markdown
 import Base: show, ==, with_output_color
 using Base64: stringmime
 
+# Margin for printing in terminal.
+const margin = 2
+
 include("parse/config.jl")
 include("parse/util.jl")
 include("parse/parse.jl")

--- a/stdlib/Markdown/src/render/terminal/render.jl
+++ b/stdlib/Markdown/src/render/terminal/render.jl
@@ -2,7 +2,6 @@
 
 include("formatting.jl")
 
-const margin = 2
 cols(io) = displaysize(io)[2]
 
 function term(io::IO, content::Vector, cols)

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -244,6 +244,13 @@ let doc = Markdown.parse(
     @test !occursin("3. ", sprint(term, doc))
 end
 
+# Testing margin when printing Tables to the terminal.
+@test sprint(term, md"""
+| R |
+|---|
+| L |
+""") == "  R\n  –\n  L"
+
 # HTML output
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
 @test md"something ***" |> html == "<p>something ***</p>\n"
@@ -1085,7 +1092,7 @@ t = """
     a   |   b
     :-- | --:
     1   |   2"""
-@test sprint(Markdown.term, Markdown.parse(t), 0) == "a b\n– –\n1 2"
+@test sprint(Markdown.term, Markdown.parse(t), 0) == "  a b\n  – –\n  1 2"
 
 # test Base.copy
 let

--- a/stdlib/Markdown/test/runtests.jl
+++ b/stdlib/Markdown/test/runtests.jl
@@ -251,6 +251,14 @@ end
 | L |
 """) == "  R\n  –\n  L"
 
+@test sprint(term, md"""
+!!! note "Tables in admonitions"
+
+    | R |
+    |---|
+    | L |
+""") == "  │ Tables in admonitions\n  │\n  │  R\n  │  –\n  │  L"
+
 # HTML output
 @test md"foo *bar* baz" |> html == "<p>foo <em>bar</em> baz</p>\n"
 @test md"something ***" |> html == "<p>something ***</p>\n"


### PR DESCRIPTION
The margin setting was not being considered when a markdown table was printed to the terminal. Thus, for example, take a look how the table is rendered misaligned when printing the documentation of the function `rECItoECI` of SatelliteToolbox.jl:

![Captura de Tela 2019-05-27 às 13 43 41](https://user-images.githubusercontent.com/1068295/58432368-69c5f780-8088-11e9-8d31-9e7368818e2f.png)

With this PR, the margin is now used and everything is aligned:

![Captura de Tela 2019-05-27 às 13 46 08](https://user-images.githubusercontent.com/1068295/58432382-8104e500-8088-11e9-9993-cd3d26d3daad.png)
