### PR TITLE
Improve `analyzegc` experience

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -1345,6 +1345,7 @@ JULCOLOR:="\033[34;1m"
 GOAL=$(subst ','\'',$(subst $(abspath $(JULIAHOME))/,,$(abspath $@)))
 
 PRINT_CC = printf '    %b %b\n' $(CCCOLOR)CC$(ENDCOLOR) $(SRCCOLOR)$(GOAL)$(ENDCOLOR); $(1)
+PRINT_ANALYZE = printf '    %b %b\n' $(CCCOLOR)ANALYZE$(ENDCOLOR) $(SRCCOLOR)$(GOAL)$(ENDCOLOR); $(1)
 PRINT_LINK = printf '    %b %b\n' $(LINKCOLOR)LINK$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
 PRINT_PERL = printf '    %b %b\n' $(PERLCOLOR)PERL$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
 PRINT_FLISP = printf '    %b %b\n' $(FLISPCOLOR)FLISP$(ENDCOLOR) $(BINCOLOR)$(GOAL)$(ENDCOLOR); $(1)
@@ -1353,6 +1354,7 @@ PRINT_JULIA = printf '    %b %b\n' $(JULIACOLOR)JULIA$(ENDCOLOR) $(BINCOLOR)$(GO
 else
 QUIET_MAKE =
 PRINT_CC = echo '$(subst ','\'',$(1))'; $(1)
+PRINT_ANALYZE = echo '$(subst ','\'',$(1))'; $(1)
 PRINT_LINK = echo '$(subst ','\'',$(1))'; $(1)
 PRINT_PERL = echo '$(subst ','\'',$(1))'; $(1)
 PRINT_FLISP = echo '$(subst ','\'',$(1))'; $(1)

--- a/src/Makefile
+++ b/src/Makefile
@@ -353,4 +353,4 @@ $(foreach S,$(RUNTIME_C_SRCS),$(eval $(call CLANG_ANALYZE,$(S))))
 #   make -c deps install-libuv install-utf8proc install-unwind
 analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc
 
-.PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony
+.PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony analyzegc

--- a/src/Makefile
+++ b/src/Makefile
@@ -323,12 +323,13 @@ clean-support:
 
 cleanall: clean clean-flisp clean-support
 
-analyzegc:
+analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc
 ifeq ($(USE_BINARYBUILDER_LLVM),0)
 ifneq ($(BUILD_LLVM_CLANG),1)
 	$(error Clang must be available to use the clang analyzer. Either build it (BUILD_LLVM_CLANG) or use BinaryBuilder)
 endif
 endif
+	$(MAKE) -C $(JULIAHOME)/deps install-llvm install-libuv
 	$(MAKE) -C clangsa
 	$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)  $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -Xclang -analyzer-checker=core,julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $(RUNTIME_C_SRCS:%=$(SRCDIR)/%.c)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -329,6 +329,7 @@ $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.c
 define CLANG_ANALYZE
 clang-sa-$(1): $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT)
 	@$$(call PRINT_ANALYZE, $$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT) $$(CPPFLAGS) $$(CFLAGS) $$(DEBUGFLAGS) -Xclang -analyzer-checker=core$$(COMMA)julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $$(SRCDIR)/$(1).c)
+.PHONY: clang-sa-$(1)
 endef
 
 # Build a Makefile target for each file we want to analyze

--- a/src/Makefile
+++ b/src/Makefile
@@ -323,22 +323,27 @@ clean-support:
 
 cleanall: clean clean-flisp clean-support
 
+$(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.cpp
+	@$(call PRINT_CC, $(CXX) -g -shared -fno-rtti -fPIC -o $@ -std=c++11 -DCLANG_PLUGIN -I$(build_includedir)  -I$(LLVM_SRC_DIR)/include -L$(build_libdir) $< -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)
+
 define CLANG_ANALYZE
-clang-sa-$(1):
+clang-sa-$(1): $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT)
 	@$$(call PRINT_ANALYZE, $$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT) $$(CPPFLAGS) $$(CFLAGS) $$(DEBUGFLAGS) -Xclang -analyzer-checker=core$$(COMMA)julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $$(SRCDIR)/$(1).c)
 endef
 
 # Build a Makefile target for each file we want to analyze
 $(foreach S,$(RUNTIME_C_SRCS),$(eval $(call CLANG_ANALYZE,$(S))))
 
-analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc
+# Note that for a default install, you will need to have run the following
+# before attempting this static analysis, so that all necessary headers
+# and dependencies are properly installed:
+#   make -c deps install-libuv install-utf8proc install-unwind
+analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
 ifeq ($(USE_BINARYBUILDER_LLVM),0)
 ifneq ($(BUILD_LLVM_CLANG),1)
 	$(error Clang must be available to use the clang analyzer. Either build it (BUILD_LLVM_CLANG) or use BinaryBuilder)
 endif
 endif
-	$(MAKE) -C clangsa
 	$(MAKE) $(addprefix clang-sa-,$(RUNTIME_C_SRCS))
-	#$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)  $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -Xclang -analyzer-checker=core,julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $(RUNTIME_C_SRCS:%=$(SRCDIR)/%.c)
 
 .PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony

--- a/src/Makefile
+++ b/src/Makefile
@@ -323,14 +323,22 @@ clean-support:
 
 cleanall: clean clean-flisp clean-support
 
+define CLANG_ANALYZE
+clang-sa-$(1):
+	@$$(call PRINT_ANALYZE, $$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT) $$(CPPFLAGS) $$(CFLAGS) $$(DEBUGFLAGS) -Xclang -analyzer-checker=core$$(COMMA)julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $$(SRCDIR)/$(1).c)
+endef
+
+# Build a Makefile target for each file we want to analyze
+$(foreach S,$(RUNTIME_C_SRCS),$(eval $(call CLANG_ANALYZE,$(S))))
+
 analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc
 ifeq ($(USE_BINARYBUILDER_LLVM),0)
 ifneq ($(BUILD_LLVM_CLANG),1)
 	$(error Clang must be available to use the clang analyzer. Either build it (BUILD_LLVM_CLANG) or use BinaryBuilder)
 endif
 endif
-	$(MAKE) -C $(JULIAHOME)/deps install-llvm install-libuv
 	$(MAKE) -C clangsa
-	$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)  $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -Xclang -analyzer-checker=core,julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $(RUNTIME_C_SRCS:%=$(SRCDIR)/%.c)
+	$(MAKE) $(addprefix clang-sa-,$(RUNTIME_C_SRCS))
+	#$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)  $(CPPFLAGS) $(CFLAGS) $(DEBUGFLAGS) -Xclang -analyzer-checker=core,julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $(RUNTIME_C_SRCS:%=$(SRCDIR)/%.c)
 
 .PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony

--- a/src/Makefile
+++ b/src/Makefile
@@ -324,7 +324,7 @@ clean-support:
 cleanall: clean clean-flisp clean-support
 
 $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.cpp
-	@$(call PRINT_CC, $(CXX) -g -shared -fno-rtti -fPIC -o $@ -std=c++11 -DCLANG_PLUGIN -I$(build_includedir)  -I$(LLVM_SRC_DIR)/include -L$(build_libdir) $< -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)
+	@$(call PRINT_CC, $(CXX) -g -shared -o $@ -DCLANG_PLUGIN -I$(build_includedir) $(shell $(LLVM_CONFIG_HOST) --cxxflags) $(CPPFLAGS) $(CFLAGS) $< $(shell $(LLVM_CONFIG_HOST) --ldflags) $(LDFLAGS) -L$(build_libdir) -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)
 
 # Throw an error if a proper version of `clang` is not available.
 analyzegc-deps-check:

--- a/src/Makefile
+++ b/src/Makefile
@@ -326,10 +326,22 @@ cleanall: clean clean-flisp clean-support
 $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/clangsa/GCChecker.cpp
 	@$(call PRINT_CC, $(CXX) -g -shared -fno-rtti -fPIC -o $@ -std=c++11 -DCLANG_PLUGIN -I$(build_includedir)  -I$(LLVM_SRC_DIR)/include -L$(build_libdir) $< -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)
 
+# Throw an error if a proper version of `clang` is not available.
+analyzegc-deps-check:
+ifeq ($(USE_BINARYBUILDER_LLVM),0)
+ifneq ($(BUILD_LLVM_CLANG),1)
+	$(error Clang must be available to use the clang analyzer. Either build it (BUILD_LLVM_CLANG) or use BinaryBuilder)
+endif
+endif
+
+
 define CLANG_ANALYZE
-clang-sa-$(1): $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT)
+clang-sa-$(1): $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT) | analyzegc-deps-check
 	@$$(call PRINT_ANALYZE, $$(build_depsbindir)/clang --analyze -Xanalyzer -analyzer-output=text -Xclang -load -Xclang $$(build_shlibdir)/libGCCheckerPlugin.$$(SHLIB_EXT) $$(CPPFLAGS) $$(CFLAGS) $$(DEBUGFLAGS) -Xclang -analyzer-checker=core$$(COMMA)julia.GCChecker --analyzer-no-default-checks -fcolor-diagnostics -Werror -x c $$(SRCDIR)/$(1).c)
 .PHONY: clang-sa-$(1)
+
+# Add this as a target of `analyzegc`
+analyzegc: clang-sa-$(1)
 endef
 
 # Build a Makefile target for each file we want to analyze
@@ -339,12 +351,6 @@ $(foreach S,$(RUNTIME_C_SRCS),$(eval $(call CLANG_ANALYZE,$(S))))
 # before attempting this static analysis, so that all necessary headers
 # and dependencies are properly installed:
 #   make -c deps install-libuv install-utf8proc install-unwind
-analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc $(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT)
-ifeq ($(USE_BINARYBUILDER_LLVM),0)
-ifneq ($(BUILD_LLVM_CLANG),1)
-	$(error Clang must be available to use the clang analyzer. Either build it (BUILD_LLVM_CLANG) or use BinaryBuilder)
-endif
-endif
-	$(MAKE) $(addprefix clang-sa-,$(RUNTIME_C_SRCS))
+analyzegc: $(BUILDDIR)/julia_version.h $(BUILDDIR)/julia_flisp.boot.inc
 
 .PHONY: default all debug release clean cleanall clean-* libccalltest libllvmcalltest julia_flisp.boot.inc.phony

--- a/src/clangsa/Makefile
+++ b/src/clangsa/Makefile
@@ -1,7 +1,0 @@
-SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
-JULIAHOME := $(abspath $(SRCDIR)/../..)
-BUILDDIR := .
-include $(JULIAHOME)/Make.inc
-
-$(build_shlibdir)/libGCCheckerPlugin.$(SHLIB_EXT): $(SRCDIR)/GCChecker.cpp
-		@$(call PRINT_CC, $(CXX) -g -shared -fno-rtti -fPIC -o $@ -std=c++11 -DCLANG_PLUGIN -I$(build_includedir)  -I$(LLVM_SRC_DIR)/include -L$(build_libdir) $< -lclangAnalysis -lclangStaticAnalyzerCore -lclangASTMatchers -lclangAST -lclangLex -lclangBasic)

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -46,6 +46,9 @@ release: $(BUILDDIR)/$(EXENAME)$(EXE)
 
 debug: $(BUILDDIR)/$(EXENAME)-debug$(EXE)
 
+flisp-deps:
+	$(MAKE) -C $(JULIAHOME)/deps install-utf8proc
+
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
 
@@ -59,9 +62,9 @@ $(BUILDDIR)/flisp.dbg.obj:  flisp.c cvalues.c types.c flisp.h print.c read.c equ
 $(BUILDDIR)/flmain.o:  flmain.c flisp.h
 $(BUILDDIR)/flmain.dbg.obj: flmain.c flisp.h
 
-$(LLT_release): $(LLTDIR)/*.h $(LLTDIR)/*.c
+$(LLT_release): $(LLTDIR)/*.h $(LLTDIR)/*.c flisp-deps
 	$(MAKE) -C $(LLTDIR) BUILDDIR='$(abspath $(BUILDDIR)/$(LLTDIR))'
-$(LLT_debug): $(LLTDIR)/*.h $(LLTDIR)/*.c
+$(LLT_debug): $(LLTDIR)/*.h $(LLTDIR)/*.c flisp-deps
 	$(MAKE) debug -C $(LLTDIR) BUILDDIR='$(abspath $(BUILDDIR)/$(LLTDIR))'
 
 $(BUILDDIR)/$(LIBTARGET)-debug.a: $(DOBJS) | $(BUILDDIR)
@@ -100,3 +103,5 @@ clean:
 	rm -f $(BUILDDIR)/*.a
 	rm -f $(BUILDDIR)/$(EXENAME)$(EXE)
 	rm -f $(BUILDDIR)/$(EXENAME)-debug$(EXE)
+
+.PHONY: flisp-deps

--- a/src/flisp/Makefile
+++ b/src/flisp/Makefile
@@ -46,9 +46,6 @@ release: $(BUILDDIR)/$(EXENAME)$(EXE)
 
 debug: $(BUILDDIR)/$(EXENAME)-debug$(EXE)
 
-flisp-deps:
-	$(MAKE) -C $(JULIAHOME)/deps install-utf8proc
-
 $(BUILDDIR):
 	mkdir -p $(BUILDDIR)
 
@@ -62,9 +59,9 @@ $(BUILDDIR)/flisp.dbg.obj:  flisp.c cvalues.c types.c flisp.h print.c read.c equ
 $(BUILDDIR)/flmain.o:  flmain.c flisp.h
 $(BUILDDIR)/flmain.dbg.obj: flmain.c flisp.h
 
-$(LLT_release): $(LLTDIR)/*.h $(LLTDIR)/*.c flisp-deps
+$(LLT_release): $(LLTDIR)/*.h $(LLTDIR)/*.c
 	$(MAKE) -C $(LLTDIR) BUILDDIR='$(abspath $(BUILDDIR)/$(LLTDIR))'
-$(LLT_debug): $(LLTDIR)/*.h $(LLTDIR)/*.c flisp-deps
+$(LLT_debug): $(LLTDIR)/*.h $(LLTDIR)/*.c
 	$(MAKE) debug -C $(LLTDIR) BUILDDIR='$(abspath $(BUILDDIR)/$(LLTDIR))'
 
 $(BUILDDIR)/$(LIBTARGET)-debug.a: $(DOBJS) | $(BUILDDIR)

--- a/src/support/Makefile
+++ b/src/support/Makefile
@@ -61,11 +61,11 @@ endif
 release: $(BUILDDIR)/libsupport.a
 debug: $(BUILDDIR)/libsupport-debug.a
 
-$(BUILDDIR)/libsupport.a: $(OBJS)
+$(BUILDDIR)/libsupport.a: $(OBJS) | $(BUILDIR)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $^)
 
-$(BUILDDIR)/libsupport-debug.a: $(DOBJS)
+$(BUILDDIR)/libsupport-debug.a: $(DOBJS) | $(BUILDDIR)
 	rm -rf $@
 	@$(call PRINT_LINK, $(AR) -rcs $@ $^)
 


### PR DESCRIPTION
This makes the `analyzegc` experience faster, more beautiful, and a lot easier to run from a clean clone, as we expect to do regularly on CI.  In particular, the `clang` analysis pass is now invoked in serial, which reduces runtime from 6.5 minutes to 2.5 minutes on a 4-core box; which isn't a bad speedup.