### PR TITLE
Make sleep(n) and Timer creation more MT-safe

### DIFF
--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -87,11 +87,14 @@ mutable struct Timer
         interval ≥ 0 || throw(ArgumentError("timer cannot have negative repeat interval of $interval seconds"))
 
         this = new(Libc.malloc(_sizeof_uv_timer), ThreadSynchronizer(), true)
-
-        err = ccall(:jl_uv_update_timer_start, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
-              eventloop(), this, uv_jl_timercb::Ptr{Cvoid},
+        err = ccall(:jl_uv_update_timer_start, Cint,
+              (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
+              eventloop(), this, this.handle, uv_jl_timercb::Ptr{Cvoid},
               UInt64(round(timeout * 1000)) + 1, UInt64(round(interval * 1000)))
         if err != 0
+            #TODO: this codepath is currently not tested
+            Libc.free(this.handle)
+            this.handle = C_NULL
             throw(_UVError("uv_timer_init", err))
         end
         finalizer(uvfinalize, this)

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -88,7 +88,7 @@ mutable struct Timer
 
         this = new(Libc.malloc(_sizeof_uv_timer), ThreadSynchronizer(), true)
         err = ccall(:jl_uv_update_timer_start, Cint,
-              (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
+              (Ptr{Cvoid}, Any, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
               eventloop(), this, this.handle, uv_jl_timercb::Ptr{Cvoid},
               UInt64(round(timeout * 1000)) + 1, UInt64(round(interval * 1000)))
         if err != 0

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -98,9 +98,8 @@ mutable struct Timer
         associate_julia_struct(this.handle, this)
         finalizer(uvfinalize, this)
 
-        ccall(:uv_update_time, Cvoid, (Ptr{Cvoid},), eventloop())
-        ccall(:uv_timer_start,  Cint,  (Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
-              this, uv_jl_timercb::Ptr{Cvoid},
+        ccall(:jl_uv_update_timer_start, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
+              eventloop(), this, uv_jl_timercb::Ptr{Cvoid},
               UInt64(round(timeout * 1000)) + 1, UInt64(round(interval * 1000)))
         return this
     end

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -87,16 +87,10 @@ mutable struct Timer
         interval ≥ 0 || throw(ArgumentError("timer cannot have negative repeat interval of $interval seconds"))
 
         this = new(Libc.malloc(_sizeof_uv_timer), ThreadSynchronizer(), true)
-        err = ccall(:jl_uv_update_timer_start, Cint,
+        ccall(:jl_uv_update_timer_start, Cvoid,
               (Ptr{Cvoid}, Any, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
               eventloop(), this, this.handle, uv_jl_timercb::Ptr{Cvoid},
               UInt64(round(timeout * 1000)) + 1, UInt64(round(interval * 1000)))
-        if err != 0
-            #TODO: this codepath is currently not tested
-            Libc.free(this.handle)
-            this.handle = C_NULL
-            throw(_UVError("uv_timer_init", err))
-        end
         finalizer(uvfinalize, this)
         return this
     end

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -87,8 +87,9 @@ mutable struct Timer
         interval ≥ 0 || throw(ArgumentError("timer cannot have negative repeat interval of $interval seconds"))
 
         this = new(Libc.malloc(_sizeof_uv_timer), ThreadSynchronizer(), true)
+        #=
         err = ccall(:uv_timer_init, Cint, (Ptr{Cvoid}, Ptr{Cvoid}), eventloop(), this)
-        if err != 0
+        # FIXME: if err != 0
             #TODO: this codepath is currently not tested
             Libc.free(this.handle)
             this.handle = C_NULL
@@ -96,11 +97,12 @@ mutable struct Timer
         end
 
         associate_julia_struct(this.handle, this)
-        finalizer(uvfinalize, this)
+        =#
 
         ccall(:jl_uv_update_timer_start, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
               eventloop(), this, uv_jl_timercb::Ptr{Cvoid},
               UInt64(round(timeout * 1000)) + 1, UInt64(round(interval * 1000)))
+        finalizer(uvfinalize, this)
         return this
     end
 end

--- a/base/asyncevent.jl
+++ b/base/asyncevent.jl
@@ -87,21 +87,13 @@ mutable struct Timer
         interval ≥ 0 || throw(ArgumentError("timer cannot have negative repeat interval of $interval seconds"))
 
         this = new(Libc.malloc(_sizeof_uv_timer), ThreadSynchronizer(), true)
-        #=
-        err = ccall(:uv_timer_init, Cint, (Ptr{Cvoid}, Ptr{Cvoid}), eventloop(), this)
-        # FIXME: if err != 0
-            #TODO: this codepath is currently not tested
-            Libc.free(this.handle)
-            this.handle = C_NULL
-            throw(_UVError("uv_timer_init", err))
-        end
 
-        associate_julia_struct(this.handle, this)
-        =#
-
-        ccall(:jl_uv_update_timer_start, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
+        err = ccall(:jl_uv_update_timer_start, Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, UInt64, UInt64),
               eventloop(), this, uv_jl_timercb::Ptr{Cvoid},
               UInt64(round(timeout * 1000)) + 1, UInt64(round(interval * 1000)))
+        if err != 0
+            throw(_UVError("uv_timer_init", err))
+        end
         finalizer(uvfinalize, this)
         return this
     end

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1091,6 +1091,12 @@ JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, uv_timer_t* handle,
 {
     JL_UV_LOCK();
     int err = uv_timer_init(loop, handle);
+    if (err) {
+        // TODO: this codepath is currently not tested
+        free(handle);
+        return NULL;
+    }
+
     jl_uv_associate_julia_struct(handle, handle);
     uv_update_time(loop);
     int r = uv_timer_start(handle, cb, timeout, repeat);

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1085,23 +1085,22 @@ JL_DLLEXPORT int jl_queue_work(work_cb_t work_func, void *work_args, void *work_
     return 0;
 }
 
-JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, uv_timer_t* handle,
-                                          uv_timer_cb cb, uint64_t timeout,
-                                          uint64_t repeat)
+JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, jl_value_t* jltimer,
+                                          uv_timer_t* uvtimer, uv_timer_cb cb,
+                                          uint64_t timeout, uint64_t repeat)
 {
     JL_UV_LOCK();
-    int err = uv_timer_init(loop, handle);
+    int err = uv_timer_init(loop, uvtimer);
     if (err) {
-        // TODO: this codepath is currently not tested
-        free(handle);
+        JL_UV_UNLOCK();
         return err;
     }
 
-    jl_uv_associate_julia_struct((uv_handle_t *)handle, (jl_value_t *)handle);
+    jl_uv_associate_julia_struct((uv_handle_t*)uvtimer, jltimer);
     uv_update_time(loop);
-    int r = uv_timer_start(handle, cb, timeout, repeat);
+    err = uv_timer_start(uvtimer, cb, timeout, repeat);
     JL_UV_UNLOCK();
-    return r;
+    return err;
 }
 
 JL_DLLEXPORT void jl_uv_stop(uv_loop_t* loop)

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1085,6 +1085,18 @@ JL_DLLEXPORT int jl_queue_work(work_cb_t work_func, void *work_args, void *work_
     return 0;
 }
 
+JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, uv_timer_t* handle,
+                                          uv_timer_cb cb, uint64_t timeout,
+                                          uint64_t repeat)
+{
+    JL_UV_LOCK();
+    uv_update_time(loop);
+
+    int r = uv_timer_start(handle, cb, timeout, repeat);
+    JL_UV_UNLOCK();
+    return r;
+}
+
 JL_DLLEXPORT void jl_uv_stop(uv_loop_t* loop)
 {
     JL_UV_LOCK();

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1085,22 +1085,21 @@ JL_DLLEXPORT int jl_queue_work(work_cb_t work_func, void *work_args, void *work_
     return 0;
 }
 
-JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, jl_value_t* jltimer,
+JL_DLLEXPORT void jl_uv_update_timer_start(uv_loop_t* loop, jl_value_t* jltimer,
                                           uv_timer_t* uvtimer, uv_timer_cb cb,
                                           uint64_t timeout, uint64_t repeat)
 {
     JL_UV_LOCK();
     int err = uv_timer_init(loop, uvtimer);
-    if (err) {
-        JL_UV_UNLOCK();
-        return err;
-    }
+    if (err)
+        abort();
 
     jl_uv_associate_julia_struct((uv_handle_t*)uvtimer, jltimer);
     uv_update_time(loop);
     err = uv_timer_start(uvtimer, cb, timeout, repeat);
+    if (err)
+        abort();
     JL_UV_UNLOCK();
-    return err;
 }
 
 JL_DLLEXPORT void jl_uv_stop(uv_loop_t* loop)

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1094,10 +1094,10 @@ JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, uv_timer_t* handle,
     if (err) {
         // TODO: this codepath is currently not tested
         free(handle);
-        return NULL;
+        return err;
     }
 
-    jl_uv_associate_julia_struct(handle, handle);
+    jl_uv_associate_julia_struct((uv_handle_t *)handle, (jl_value_t *)handle);
     uv_update_time(loop);
     int r = uv_timer_start(handle, cb, timeout, repeat);
     JL_UV_UNLOCK();

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -1090,8 +1090,9 @@ JL_DLLEXPORT int jl_uv_update_timer_start(uv_loop_t* loop, uv_timer_t* handle,
                                           uint64_t repeat)
 {
     JL_UV_LOCK();
+    int err = uv_timer_init(loop, handle);
+    jl_uv_associate_julia_struct(handle, handle);
     uv_update_time(loop);
-
     int r = uv_timer_start(handle, cb, timeout, repeat);
     JL_UV_UNLOCK();
     return r;


### PR DESCRIPTION
This returns some of the locking removed by https://github.com/JuliaLang/julia/pull/32029/commits/93e3d284a6205d9a9cca6d5bdb3856439e0b55ad (which @JeffBezanson said was removed because it was probably incorrect), but this time the calls to `uv_update_time` and `uv_timer_start` are done within a single lock/unlock of the global libuv lock (instead of two separate lock/unlock pairs).

This still hangs every so often on my system with `JULIA_NUM_THREADS=8` when running a slightly longer version of the test laid out in https://github.com/JuliaLang/julia/issues/32152, which I'd like to have this PR fix once I figure out the root cause. I also think this PR should have at least one test to ensure highly-contended calls to `sleep` or `Timer` don't cause segfaults or hangs; I'll add a simple test to this PR soon to get something on the table.

(Eventually) fixes https://github.com/JuliaLang/julia/issues/32152