### PR TITLE
Fast-track `@threads` when `nthreads() == 1`

### DIFF
--- a/base/threadingconstructs.jl
+++ b/base/threadingconstructs.jl
@@ -66,8 +66,8 @@ function _threadsfor(iter,lbody)
         end
         end
         # Hack to make nested threaded loops kinda work
-        if threadid() != 1 || in_threaded_loop[]
-            # We are in a nested threaded loop
+        if nthreads() == 1 || threadid() != 1 || in_threaded_loop[]
+            # We are in a nested threaded loop, or running single-threaded
             Base.invokelatest(threadsfor_fun, true)
         else
             in_threaded_loop[] = true


### PR DESCRIPTION
This avoids overhead when threading is disabled, Example benchmark:

```julia
using BenchmarkTools, Base.Threads, Test

function func(val, N)
    sums = [0*(1 .^ val) for thread_idx in 1:nthreads()]
    for idx in 1:N
        sums[threadid()] += idx.^val
    end
    return sum(sums)
end

function func_threaded(val, N)
    sums = [0*(1 .^ val) for thread_idx in 1:nthreads()]
    @threads for idx in 1:N
        sums[threadid()] += idx.^val
    end
    return sum(sums)
end

# Ensure they all get the same answer
@test func(2.0, 1<<10) == func_threaded(2.0, 1<<10)

@show @benchmark func(2.0, 1<<10)
@show @benchmark func_threaded(2.0, 1<<10)
```

I run the benchmarks as:
```bash
for JULIA in julia-master ./julia; do
	for T in 1 2; do
		echo "$JULIA with $T threads:"
		JULIA_NUM_THREADS=$T $JULIA speedtest.jl
	done
done
```

Before this PR:
```
julia-master with 1 threads:
#= /Users/sabae/src/julia/speedtest.jl:22 =# @benchmark(func(2.0, 1 << 10)) = Trial(24.243 μs)
#= /Users/sabae/src/julia/speedtest.jl:23 =# @benchmark(func_threaded(2.0, 1 << 10)) = Trial(28.331 μs)
julia-master with 2 threads:
#= /Users/sabae/src/julia/speedtest.jl:22 =# @benchmark(func(2.0, 1 << 10)) = Trial(24.239 μs)
#= /Users/sabae/src/julia/speedtest.jl:23 =# @benchmark(func_threaded(2.0, 1 << 10)) = Trial(17.019 μs)

```

After this PR:
```
./julia with 1 threads:
#= /Users/sabae/src/julia/speedtest.jl:22 =# @benchmark(func(2.0, 1 << 10)) = Trial(24.254 μs)
#= /Users/sabae/src/julia/speedtest.jl:23 =# @benchmark(func_threaded(2.0, 1 << 10)) = Trial(24.257 μs)
./julia with 2 threads:
#= /Users/sabae/src/julia/speedtest.jl:22 =# @benchmark(func(2.0, 1 << 10)) = Trial(24.263 μs)
#= /Users/sabae/src/julia/speedtest.jl:23 =# @benchmark(func_threaded(2.0, 1 << 10)) = Trial(17.008 μs)
```