### PR TITLE
sum for diagonal (and related) matrices

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -724,3 +724,5 @@ function eigvecs(M::Bidiagonal{T}) where T
     Q #Actually Triangular
 end
 eigen(M::Bidiagonal) = Eigen(eigvals(M), eigvecs(M))
+
+Base._sum(A::Bidiagonal, ::Colon) = sum(A.dv) + sum(A.ev)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -575,3 +575,5 @@ end
 
 cholesky(A::Diagonal, ::Val{false} = Val(false); check::Bool = true) =
     cholesky!(cholcopy(A), Val(false); check = check)
+
+Base._sum(A::Diagonal, ::Colon) = sum(A.diag)

--- a/stdlib/LinearAlgebra/src/tridiag.jl
+++ b/stdlib/LinearAlgebra/src/tridiag.jl
@@ -646,3 +646,6 @@ function SymTridiagonal{T}(M::Tridiagonal) where T
         throw(ArgumentError("Tridiagonal is not symmetric, cannot convert to SymTridiagonal"))
     end
 end
+
+Base._sum(A::Tridiagonal, ::Colon) = sum(A.d) + sum(A.dl) + sum(A.du)
+Base._sum(A::SymTridiagonal, ::Colon) = sum(A.dv) + 2sum(A.ev)

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -409,4 +409,9 @@ end
     @test vcat((Aub\bb)...) ≈ UpperTriangular(A)\b
 end
 
+@testset "sum" begin
+    @test sum(Bidiagonal([1,2,3], [1,2], :U)) == 9
+    @test sum(Bidiagonal([1,2,3], [1,2], :L)) == 9
+end
+
 end # module TestBidiagonal

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -539,4 +539,8 @@ end
     @test E.vectors == [0 1 0; 1 0 0; 0 0 1]
 end
 
+@testset "sum" begin
+    @test sum(Diagonal([1,2,3])) == 6
+end
+
 end # module TestDiagonal

--- a/stdlib/LinearAlgebra/test/tridiag.jl
+++ b/stdlib/LinearAlgebra/test/tridiag.jl
@@ -445,4 +445,9 @@ end
     @test cond(SymTridiagonal([1,2,3], [0,0])) ≈ 3
 end
 
+@testset "sum" begin
+    @test sum(Tridiagonal([1,2], [1,2,3], [7,8])) == 24
+    @test sum(SymTridiagonal([1,2,3], [1,2])) == 12
+end
+
 end # module TestTridiagonal


### PR DESCRIPTION
Specializes `sum` for diagonal and related matrices.

Let:

```
julia> C = Diagonal(1:10000);
```

Before this PR:

```
julia> @time sum(C);
  0.173762 seconds (14 allocations: 528 bytes)
```

After this PR:

```
julia> @time sum(C);
  0.000008 seconds (14 allocations: 528 bytes)
```

Fixes #32178.