### PR TITLE
Revert "Always use summary for BoundsError, even with non-AbstractArrays"

### DIFF
--- a/base/errorshow.jl
+++ b/base/errorshow.jl
@@ -33,7 +33,11 @@ function showerror(io::IO, ex::BoundsError)
     print(io, "BoundsError")
     if isdefined(ex, :a)
         print(io, ": attempt to access ")
-        summary(io, ex.a)
+        if isa(ex.a, AbstractArray)
+            summary(io, ex.a)
+        else
+            show(io, MIME"text/plain"(), ex.a)
+        end
         if isdefined(ex, :i)
             !isa(ex.a, AbstractArray) && print(io, "\n ")
             print(io, " at index [")

--- a/base/show.jl
+++ b/base/show.jl
@@ -1849,7 +1849,6 @@ function summary(x)
     summary(io, x)
     String(take!(io))
 end
-summary(io::IO, t::Tuple) = print(io, t)
 
 ## `summary` for AbstractArrays
 # sizes such as 0-dimensional, 4-dimensional, 2x3

--- a/test/errorshow.jl
+++ b/test/errorshow.jl
@@ -225,11 +225,6 @@ let
 end
 
 struct TypeWithIntParam{T <: Integer} end
-struct Bounded  # not an AbstractArray
-    bound::Int
-end
-Base.getindex(b::Bounded, i) = checkindex(Bool, 1:b.bound, i) || throw(BoundsError(b, i))
-Base.summary(io::IO, b::Bounded) = print(io, "$(b.bound)-size Bounded")
 let undefvar
     err_str = @except_strbt sqrt(-1) DomainError
     @test occursin("Try sqrt(Complex(x)).", err_str)
@@ -250,9 +245,6 @@ let undefvar
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [-2, 1]"
     err_str = @except_str [5, 4, 3][1:5] BoundsError
     @test err_str == "BoundsError: attempt to access 3-element Array{$Int,1} at index [1:5]"
-
-    err_str = @except_str Bounded(2)[3] BoundsError
-    @test err_str == "BoundsError: attempt to access 2-size Bounded\n  at index [3]"
 
     err_str = @except_str 0::Bool TypeError
     @test err_str == "TypeError: non-boolean ($Int) used in boolean context"

--- a/test/show.jl
+++ b/test/show.jl
@@ -1356,11 +1356,6 @@ end
     @test summary(Base.OneTo(BigInt(10))) == "10-element Base.OneTo{BigInt}"
 end
 
-@testset "Tuple summary" begin
-    @test summary((1,2,3)) == "(1, 2, 3)"
-    @test summary((:a, "b", 'c')) == "(:a, \"b\", 'c')"
-end
-
 # Tests for code_typed linetable annotations
 function compute_annotations(f, types)
     src = code_typed(f, types, debuginfo=:source)[1][1]


### PR DESCRIPTION
Reverts JuliaLang/julia#32058

See e.g. https://github.com/JuliaLang/julia/pull/32166/commits/2b0c2f35eee649b4690d629c369e3b2e00c64567 why this might not be a good idea, the only reason `summary` makes sense for abstract arrays is that they show the size, which is exactly what you want for a `BoundsError`, e.g.
```
julia> [1 2; 3 4][4, 5]
ERROR: BoundsError: attempt to access 2×2 Array{Int64,2} at index [4, 5]
```
but in other cases I think showing the value is better (unless the fallback `summary` shows the indexing size...).