### PR TITLE
fix mkl build for 1.2.0-rc1: (USE_BINARYBUILDER issue)

### DIFF
--- a/Make.inc
+++ b/Make.inc
@@ -960,18 +960,7 @@ endif
 endef
 $(foreach proj,$(BB_PROJECTS),$(eval $(call SET_BB_DEFAULT,$(proj))))
 
-# Some special restrictions on BB usage:
-ifeq ($(USE_SYSTEM_BLAS),1)
-# Since the names don't line up (`BLAS` vs. `OPENBLAS`), manually gate:
-USE_BINARYBUILDER_OPENBLAS ?= 0
-# Disable BB SuiteSparse if we're using system BLAS
-USE_BINARYBUILDER_SUITESPARSE ?= 0
-endif
 
-ifeq ($(USE_SYSTEM_LIBM),1)
-# If we're using system libm, disable BB OpenLibm
-USE_BINARYBUILDER_OPENLIBM ?= 0
-endif
 
 # Use the Assertions build
 BINARYBUILDER_LLVM_ASSERTS := 0
@@ -1206,6 +1195,20 @@ CXXFLAGS += -cxxlib-nostd -static-intel
 CLDFLAGS += -static-intel
 LDFLAGS += -cxxlib-nostd -static-intel
 endif
+endif
+
+
+# Some special restrictions on BB usage:
+ifeq ($(USE_SYSTEM_BLAS),1)
+# Since the names don't line up (`BLAS` vs. `OPENBLAS`), manually gate:
+USE_BINARYBUILDER_OPENBLAS := 0
+# Disable BB SuiteSparse if we're using system BLAS
+USE_BINARYBUILDER_SUITESPARSE := 0
+endif
+
+ifeq ($(USE_SYSTEM_LIBM),1)
+# If we're using system libm, disable BB OpenLibm
+USE_BINARYBUILDER_OPENLIBM := 0
 endif
 
 # Make tricks


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/julia/issues/32196

1.2.0-rc1 fails to build with mkl. This PR fixes the ordering of USE_BINARYBUILDER_{OPENBLAS, SUITESPARSE, OPENLIBM}: they need to happen after the intel libraries variables have been set. intel libraries set `USE_SYSTEM_BLAS:=1`, which `USE_BINARYBUILDER_` is supposed to check; this check needs to happen after `USE_SYSTEM_BLAS:=1` is set by `USE_INTEL_MKL`