### PR TITLE
PosDefException is too specific

### DIFF
--- a/stdlib/LinearAlgebra/src/exceptions.jl
+++ b/stdlib/LinearAlgebra/src/exceptions.jl
@@ -37,7 +37,7 @@ function Base.showerror(io::IO, ex::PosDefException)
     else
         print(io, "positive definite")
     end
-    print(io, "; Cholesky factorization failed.")
+    print(io, "; factorization failed.")
 end
 
 struct RankDeficientException <: Exception


### PR DESCRIPTION
It refers to Cholesky. I think it gets raised also by other algorithms, in which case the printed message is misleading.