### PR TITLE
Fix IEEEFloat import

### DIFF
--- a/base/reducedim.jl
+++ b/base/reducedim.jl
@@ -162,7 +162,7 @@ reducedim_init(f, op::typeof(|), A::AbstractArray, region) = reducedim_initarray
 # specialize to make initialization more efficient for common cases
 
 let
-    BitIntFloat = Union{BitInteger, Math.IEEEFloat}
+    BitIntFloat = Union{BitInteger, IEEEFloat}
     T = Union{
         [AbstractArray{t} for t in uniontypes(BitIntFloat)]...,
         [AbstractArray{Complex{t}} for t in uniontypes(BitIntFloat)]...}


### PR DESCRIPTION
Fix IEEEFloat import. IEEEFloat is defined in `float.jl`, which is not in the math module. (The current line still works since Base.Math.IEEEFloat searches in Base since it doesn't find IEEEFloat in Math)