### PR TITLE
faster rand(::Tuple)

### DIFF
--- a/stdlib/Random/src/RNGs.jl
+++ b/stdlib/Random/src/RNGs.jl
@@ -601,7 +601,7 @@ end
 #### from a range
 
 for T in BitInteger_types, R=(1, Inf) # eval because of ambiguity otherwise
-    @eval Sampler(::Type{MersenneTwister}, r::UnitRange{$T}, ::Val{$R}) =
+    @eval Sampler(::Type{MersenneTwister}, r::AbstractUnitRange{$T}, ::Val{$R}) =
         SamplerRangeFast(r)
 end
 


### PR DESCRIPTION
The idea is quite simple:
- for powers of 2 lengths `L`, we do like for length 4, i.e. use a mask: `rand(UInt32) & (L-1)`
- for others lengths, we fix an oversight which made `rand(Base.OneTo(n))` (used in `rand(::Tuple)`) slower than `rand(1:n)` for `MersenneTwister`. 

This breaks the reproducibility of generated streams, but we now have a precedent for that.