### PR TITLE
treat Pair as broadcast scalar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@ Standard library changes
   (environment, flags, working directory, etc) if `x` is the first interpolant and errors
   otherwise ([#24353]).
 * `IPAddr` subtypes now behave like scalars when used in broadcasting ([#32133]).
+* `Pair` is now treated as a scalar for broadcasting ([#32209]).
 * `clamp` can now handle missing values ([#31066]).
 
 #### Libdl

--- a/base/broadcast.jl
+++ b/base/broadcast.jl
@@ -652,7 +652,7 @@ julia> Broadcast.broadcastable("hello") # Strings break convention of matching i
 Base.RefValue{String}("hello")
 ```
 """
-broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex}) = Ref(x)
+broadcastable(x::Union{Symbol,AbstractString,Function,UndefInitializer,Nothing,RoundingMode,Missing,Val,Ptr,Regex,Pair}) = Ref(x)
 broadcastable(::Type{T}) where {T} = Ref{Type{T}}(T)
 broadcastable(x::Union{AbstractArray,Number,Ref,Tuple,Broadcasted}) = x
 # Default to collecting iterables — which will error for non-iterables

--- a/base/pair.jl
+++ b/base/pair.jl
@@ -21,7 +21,7 @@ const => = Pair
 
 Construct a `Pair` object with type `Pair{typeof(x), typeof(y)}`. The elements
 are stored in the fields `first` and `second`. They can also be accessed via
-iteration.
+iteration (but a `Pair` is treated as a single "scalar" for broadcasting operations).
 
 See also: [`Dict`](@ref)
 

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -822,3 +822,7 @@ let a = rand(5), b = rand(5), c = copy(a)
     x[[1,1]] .+= 1
     @test x == [2]
 end
+
+# treat Pair as scalar:
+@test replace.(split("The quick brown fox jumps over the lazy dog"), r"[aeiou]"i => "_") ==
+      ["Th_", "q__ck", "br_wn", "f_x", "j_mps", "_v_r", "th_", "l_zy", "d_g"]


### PR DESCRIPTION
As discussed [on discourse](https://discourse.julialang.org/t/replace-behaving-strange/20008), it seems much more useful to treat `Pair` as a scalar for broadcast.  (There are other iterable objects, e.g. `String`, that are also broadcast scalars.)

The example on the mailing list was `replace.(["string1", "string2", ...], pat=>rep)`, and one can come up with many others.  Conversely, I find it hard to imagine any case where iterating over the pair would be useful in a broadcast context, especially since the output is an array rather than another `Pair`:
```jl
julia> .-(3 => 4)
2-element Array{Int64,1}:
 -3
 -4
```
Hence I'm marking this as a "minor change" — technically breaking, but unlikely to affect real code.