### PR TITLE
Drop a duplicate description about get() for dictionaries.

### DIFF
--- a/doc/src/base/collections.md
+++ b/doc/src/base/collections.md
@@ -200,7 +200,6 @@ Base.WeakKeyDict
 Base.ImmutableDict
 Base.haskey
 Base.get(::Any, ::Any, ::Any)
-Base.get
 Base.get!(::Any, ::Any, ::Any)
 Base.get!(::Function, ::Any, ::Any)
 Base.getkey


### PR DESCRIPTION
In the Julia documentation web page, I noticed duplicate descriptions about get() for dictionaries. Drop one of the descriptions.