### PR TITLE
make GC counters thread-local

### DIFF
--- a/src/atomics.h
+++ b/src/atomics.h
@@ -49,6 +49,8 @@
     __atomic_fetch_add(obj, arg, __ATOMIC_RELAXED)
 #  define jl_atomic_fetch_add(obj, arg)                 \
     __atomic_fetch_add(obj, arg, __ATOMIC_SEQ_CST)
+#  define jl_atomic_add_fetch(obj, arg)                 \
+    __atomic_add_fetch(obj, arg, __ATOMIC_SEQ_CST)
 #  define jl_atomic_fetch_and_relaxed(obj, arg)         \
     __atomic_fetch_and(obj, arg, __ATOMIC_RELAXED)
 #  define jl_atomic_fetch_and(obj, arg)                 \
@@ -91,6 +93,8 @@
     __atomic_load_n(obj, __ATOMIC_SEQ_CST)
 #  define jl_atomic_load_acquire(obj)           \
     __atomic_load_n(obj, __ATOMIC_ACQUIRE)
+#  define jl_atomic_load_relaxed(obj)           \
+    __atomic_load_n(obj, __ATOMIC_RELAXED)
 #elif defined(_COMPILER_MICROSOFT_)
 #  define jl_signal_fence() _ReadWriteBarrier()
 

--- a/src/init.c
+++ b/src/init.c
@@ -742,10 +742,11 @@ void _julia_init(JL_IMAGE_SEARCH rel)
         jl_error("cannot generate code-coverage or track allocation information while generating a .o or .bc output file");
     }
 
+    jl_gc_init();
+
     jl_init_threading();
     jl_init_intrinsic_properties();
 
-    jl_gc_init();
     jl_gc_enable(0);
 
     jl_resolve_sysimg_location(rel);

--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -66,6 +66,16 @@ typedef struct {
 } jl_gc_pool_t;
 
 typedef struct {
+    int64_t     allocd;
+    int64_t     freed;
+    uint64_t    malloc;
+    uint64_t    realloc;
+    uint64_t    poolalloc;
+    uint64_t    bigalloc;
+    uint64_t    freecall;
+} jl_thread_gc_num_t;
+
+typedef struct {
     // variable for tracking weak references
     arraylist_t weak_refs;
     // live tasks started on this thread
@@ -156,6 +166,7 @@ struct _jl_tls_states_t {
     volatile int8_t in_finalizer;
     int8_t disable_gc;
     jl_thread_heap_t heap;
+    jl_thread_gc_num_t gc_num;
     uv_mutex_t sleep_lock;
     uv_cond_t wake_signal;
     volatile sig_atomic_t defer_signal;


### PR DESCRIPTION
This should fix #31923. I see much less memory growth in alloc-heavy threaded loops.

Also #27173