### PR TITLE
fix LibGit2 test: unknown repo now returns error instead of EAUTH

### DIFF
--- a/stdlib/LibGit2/test/online.jl
+++ b/stdlib/LibGit2/test/online.jl
@@ -68,7 +68,7 @@ mktempdir() do dir
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)
-                @test ex.code == LibGit2.Error.EAUTH
+                @test ex.code == LibGit2.Error.ERROR
             end
             Base.shred!(cred)
         end


### PR DESCRIPTION
This test literally has my name on it so I figure this is my job :)

This may not be an ideal fix, depending on the intent of this test. If it's just checking what happens with an unknown URL, it's ok, but if we need to test incorrect credentials we need to do something else.

Fixes #32186