### PR TITLE
re-fix function printing

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -381,9 +381,14 @@ end
 function show_function(io::IO, f::Function, compact::Bool)
     ft = typeof(f)
     mt = ft.name.mt
-    if isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
+    if mt === Symbol.name.mt
+        # uses shared method table
+        show_default(io, f)
+    elseif compact
+        print(io, mt.name)
+    elseif isdefined(mt, :module) && isdefined(mt.module, mt.name) &&
         getfield(mt.module, mt.name) === f
-        if compact || is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
+        if is_exported_from_stdlib(mt.name, mt.module) || mt.module === Main
             print(io, mt.name)
         else
             print(io, mt.module, ".", mt.name)

--- a/test/show.jl
+++ b/test/show.jl
@@ -1501,6 +1501,7 @@ replstrcolor(x) = sprint((io, x) -> show(IOContext(io, :limit => true, :color =>
 @test string(:) == "Colon()"
 @test string(Iterators.flatten) == "flatten"
 @test Symbol(Iterators.flatten) === :flatten
+@test startswith(string(x->x), "#")
 
 # printing of bools and bool arrays
 @testset "Bool" begin


### PR DESCRIPTION
This fixes a bad interaction between #32098 and #30565 that caused `print` on anonymous functions to regress.