### PR TITLE
add eps(::Missing) = missing

### DIFF
--- a/base/missing.jl
+++ b/base/missing.jl
@@ -75,7 +75,7 @@ for f in (:(!), :(~), :(+), :(-), :(zero), :(one), :(oneunit),
           :(isinteger), :(isreal), :(isnan),
           :(iszero), :(transpose), :(adjoint), :(float), :(conj),
           :(abs), :(abs2), :(iseven), :(ispow2),
-          :(real), :(imag), :(sign), :(inv))
+          :(real), :(imag), :(sign), :(inv), :(eps))
     @eval ($f)(::Missing) = missing
 end
 for f in (:(Base.zero), :(Base.one), :(Base.oneunit))

--- a/test/missing.jl
+++ b/test/missing.jl
@@ -157,7 +157,7 @@ Base.one(::Type{Unit}) = 1
                             identity, zero, one, oneunit,
                             iseven, isodd, ispow2,
                             isfinite, isinf, isnan, iszero,
-                            isinteger, isreal, transpose, adjoint, float, inv]
+                            isinteger, isreal, transpose, adjoint, float, inv, eps]
 
     # All elementary functions return missing when evaluating missing
     for f in elementary_functions


### PR DESCRIPTION
avoids ERROR: MethodError: no method matching eps(::Missing)
which can happen in generic code