### PR TITLE
change array realloc alignment to 16 bytes?

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3133,7 +3133,7 @@ static void *gc_managed_realloc_(jl_ptls_t ptls, void *d, size_t sz, size_t olds
         // In theory we want JL_CACHE_BYTE_ALIGNMENT. We cannot guarantee this for inlined
         // arrays. In order to avoid unnecessary memcopies, we stick with 16 byte here.
         // Revisit when this gets fixed.
-        b = jl_realloc_aligned(p, sz, oldsz, JL_SMALL_BYTE_ALIGNMENT);
+        b = jl_realloc_aligned(d, allocsz, oldsz, JL_SMALL_BYTE_ALIGNMENT);
     else
         b = realloc(d, allocsz);
     if (b == NULL)

--- a/src/gc.c
+++ b/src/gc.c
@@ -3130,7 +3130,10 @@ static void *gc_managed_realloc_(jl_ptls_t ptls, void *d, size_t sz, size_t olds
 
     void *b;
     if (isaligned)
-        b = realloc_cache_align(d, allocsz, oldsz);
+        // In theory we want JL_CACHE_BYTE_ALIGNMENT. We cannot guarantee this for inlined
+        // arrays. In order to avoid unnecessary memcopies, we stick with 16 byte here.
+        // Revisit when this gets fixed.
+        b = jl_realloc_aligned(p, sz, oldsz, JL_SMALL_BYTE_ALIGNMENT);
     else
         b = realloc(d, allocsz);
     if (b == NULL)

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -33,6 +33,12 @@
 #endif
 #endif
 
+#if defined(__has_include)
+#if __has_include(<features.h>)
+#include <features.h>
+#endif
+#endif
+
 // Remove when C11 is required for C code.
 #ifndef static_assert
 #  ifndef __cplusplus
@@ -914,7 +920,7 @@ STATIC_INLINE void *jl_malloc_aligned(size_t sz, size_t align)
 STATIC_INLINE void *jl_realloc_aligned(void *d, size_t sz, size_t oldsz,
                                        size_t align)
 {
-#if defined(_P64) || defined(__APPLE__)
+#if defined(_P64) || defined(__APPLE__) || defined(__GLIBC__)
     if (align <= 16)
         return realloc(d, sz);
 #endif


### PR DESCRIPTION
Inline allocated arrays are only16 byte aligned. This means that we can de-facto only guarantee 16 byte alignment. Hence, there is no need for stronger alignment guarantees on realloc.

We call the system realloc when we don't need stronger alignment than supplied by the libc. This is good: In practice, only large arrays are system-allocated (instead of pool-allocated), and these get `mmap`ed and subsequently `mremap`ed (or whatever the analogue syscall the system allocator uses on whatever target kernel). This gives O(1) array growth and shrink operations. 

That should in theory be a speedup on apple and P64. 

Glibc malloc always returns 16-byte aligned pointers. Using this fact, we should be able to get the fast behavior on glibc/linux as well.

There are various alternatives to the way I wrote this here. Ultimately, I fear that we will need a small jungle of `#ifdef` that peeks into the internals of the most popular systems (glibc+linux, windows, macos, bsd). A more complicated alternative would be to bypass the system allocator and talk to the kernel directly, in the special case that we know how to do this. 

Needs: 
1. clarification whether we are happy with only 16 byte alignment
2. Check again in glibc for behavior on 32 bit x86, 32 bit arm, 64 bit arm, and add cross-refs for that.
3. Some better "portable C" person to tell me whether the feature check is correct
4. Someone knowledgeable about the build scripts to make this really work
5. Explore alternative: Optimistically try to realloc and see whether alignment happens to fit.

In theory I am for option 5 in favor of this one (seems more robust). Still, this is an option, especially since there is precedent of the `#if defined(__apple__)` special case, so I'll just put this preliminary PR up as a place for discussion.

Thanks for your comments on slack @NHDaly, @vtjnash 

Cross-ref: [28588](https://github.com/JuliaLang/julia/issues/28588#issuecomment-492699026)