### PR TITLE
fix off-by-one error in show_delim_array

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -701,7 +701,7 @@ function show_delim_array(io::IO, itr, op, delim, cl, delim_one, i1=1, n=typemax
         y = iterate(itr)
         first = true
         i0 = i1-1
-        while i1 > 2 && y !== nothing
+        while i1 > 1 && y !== nothing
             y = iterate(itr, y[2])
             i1 -= 1
         end

--- a/test/show.jl
+++ b/test/show.jl
@@ -1519,3 +1519,13 @@ Z = Array{Float64}(undef,0,0)
 
 # issue #31065, do not print parentheses for nested dot expressions
 @test sprint(Base.show_unquoted, :(foo.x.x)) == "foo.x.x"
+
+@testset "show_delim_array" begin
+    sdastr(f, n) =  # sda: Show Delim Array
+        sprint((io, x) -> Base.show_delim_array(io, x, "[", ",", "]", false, f, n), Iterators.take(1:f+n, f+n))
+    @test sdastr(1, 0) == "[1]"
+    @test sdastr(1, 1) == "[1]"
+    @test sdastr(1, 2) == "[1, 2]"
+    @test sdastr(2, 2) == "[2, 3]"
+    @test sdastr(3, 3) == "[3, 4, 5]"
+end


### PR DESCRIPTION
```julia
julia> Set(1:100)
Set([2, 89, 11, 29, 74, 57, 31, 78, 70, 33  …  98, 19, 51, 22, 6, 24, 73, 53, 23, 27, 56])
```
More numbers are printed at the end, this is how I noticed what seems to be a bug.
cc @Keno who touched this code in 1a1d6b6d1c636a822cf2da371dc41a5752e8c848 (new iteration protocol).
