### PR TITLE
Use `inv` to define inverse of trigonometric functions

### DIFF
--- a/base/special/trig.jl
+++ b/base/special/trig.jl
@@ -966,17 +966,17 @@ for (finv, f, finvh, fh, finvd, fd, fn) in ((:sec, :cos, :sech, :cosh, :secd, :c
             $($name)(x)
 
         Compute the $($fn) of `x`, where `x` is in radians.
-        """ ($finv)(z::T) where {T<:Number} = one(T) / (($f)(z))
+        """ ($finv)(z::Number) = inv(($f)(z))
         @doc """
             $($hname)(x)
 
         Compute the hyperbolic $($fn) of `x`.
-        """ ($finvh)(z::T) where {T<:Number} = one(T) / (($fh)(z))
+        """ ($finvh)(z::Number) = inv(($fh)(z))
         @doc """
             $($dname)(x)
 
         Compute the $($fn) of `x`, where `x` is in degrees.
-        """ ($finvd)(z::T) where {T<:Number} = one(T) / (($fd)(z))
+        """ ($finvd)(z::Number) = inv(($fd)(z))
     end
 end
 
@@ -988,10 +988,10 @@ for (tfa, tfainv, hfa, hfainv, fn) in ((:asec, :acos, :asech, :acosh, "secant"),
     @eval begin
         @doc """
             $($tname)(x)
-        Compute the inverse $($fn) of `x`, where the output is in radians. """ ($tfa)(y::T) where {T<:Number} = ($tfainv)(one(T) / y)
+        Compute the inverse $($fn) of `x`, where the output is in radians. """ ($tfa)(y::Number) = ($tfainv)(inv(y))
         @doc """
             $($hname)(x)
-        Compute the inverse hyperbolic $($fn) of `x`. """ ($hfa)(y::T) where {T<:Number} = ($hfainv)(one(T) / y)
+        Compute the inverse hyperbolic $($fn) of `x`. """ ($hfa)(y::Number) = ($hfainv)(inv(y))
     end
 end
 

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -124,6 +124,10 @@ end
             @test sqrt(x) ≈ sqrt(big(x))
             @test tan(x) ≈ tan(big(x))
             @test tanh(x) ≈ tanh(big(x))
+            @test sec(x) ≈ sec(big(x))
+            @test csc(x) ≈ csc(big(x))
+            @test sech(x) ≈ sech(big(x))
+            @test csch(x) ≈ csch(big(x))
         end
         @testset "Inverses" begin
             @test acos(cos(x)) ≈ x
@@ -156,6 +160,10 @@ end
             @test sinh(x) ≈ (exp(x)-exp(-x))/2
             @test tan(x) ≈ sin(x)/cos(x)
             @test tanh(x) ≈ sinh(x)/cosh(x)
+            @test sec(x) ≈ inv(cos(x))
+            @test csc(x) ≈ inv(sin(x))
+            @test sech(x) ≈ inv(cosh(x))
+            @test csch(x) ≈ inv(sinh(x))
         end
     end
 end
@@ -1124,4 +1132,13 @@ end
     @test tanh(atanh(complex(1.0,-1.0))) == complex(1.0,-1.0)
     @test tanh(atanh(complex(-1.0,1.0))) == complex(-1.0,1.0)
     @test tanh(atanh(complex(-1.0,-1.0))) == complex(-1.0,-1.0)
+end
+
+@testset "issue #29840" begin
+    @testset "$T" for T in (ComplexF32, ComplexF64, Complex{BigFloat})
+        @test isequal(ComplexF64(sec(T(-10, 1000))), ComplexF64(-0.0, 0.0))
+        @test isequal(ComplexF64(csc(T(-10, 1000))), ComplexF64(0.0, 0.0))
+        @test isequal(ComplexF64(sech(T(1000, 10))), ComplexF64(-0.0, 0.0))
+        @test isequal(ComplexF64(csch(T(1000, 10))), ComplexF64(-0.0, 0.0))
+    end
 end

--- a/test/complex.jl
+++ b/test/complex.jl
@@ -126,6 +126,8 @@ end
             @test tanh(x) ≈ tanh(big(x))
             @test sec(x) ≈ sec(big(x))
             @test csc(x) ≈ csc(big(x))
+            @test secd(x) ≈ secd(big(x))
+            @test cscd(x) ≈ cscd(big(x))
             @test sech(x) ≈ sech(big(x))
             @test csch(x) ≈ csch(big(x))
         end
@@ -162,6 +164,8 @@ end
             @test tanh(x) ≈ sinh(x)/cosh(x)
             @test sec(x) ≈ inv(cos(x))
             @test csc(x) ≈ inv(sin(x))
+            @test secd(x) ≈ inv(cosd(x))
+            @test cscd(x) ≈ inv(sind(x))
             @test sech(x) ≈ inv(cosh(x))
             @test csch(x) ≈ inv(sinh(x))
         end
@@ -1140,5 +1144,7 @@ end
         @test isequal(ComplexF64(csc(T(-10, 1000))), ComplexF64(0.0, 0.0))
         @test isequal(ComplexF64(sech(T(1000, 10))), ComplexF64(-0.0, 0.0))
         @test isequal(ComplexF64(csch(T(1000, 10))), ComplexF64(-0.0, 0.0))
+        @test isequal(ComplexF64(secd(T(-1000, 100000))), ComplexF64(0.0, 0.0))
+        @test isequal(ComplexF64(cscd(T(-1000, 100000))), ComplexF64(0.0, -0.0))
     end
 end

--- a/test/math.jl
+++ b/test/math.jl
@@ -170,6 +170,10 @@ end
             @test sqrt(x) ≈ sqrt(big(x))
             @test tan(x) ≈ tan(big(x))
             @test tanh(x) ≈ tanh(big(x))
+            @test sec(x) ≈ sec(big(x))
+            @test csc(x) ≈ csc(big(x))
+            @test sech(x) ≈ sech(big(x))
+            @test csch(x) ≈ csch(big(x))
         end
         @testset "Special values" begin
             @test isequal(T(1//4)^T(1//2), T(1//2))
@@ -208,6 +212,10 @@ end
             @test isequal(sqrt(T(100000000)), T(10000))
             @test isequal(tan(T(0)), T(0))
             @test tan(T(pi)/4) ≈ T(1) atol=eps(T)
+            @test isequal(sec(T(pi)), -one(T))
+            @test isequal(csc(T(pi)/2), one(T))
+            @test isequal(sech(log(one(T))), one(T))
+            @test isequal(csch(zero(T)), T(Inf))
         end
         @testset "Inverses" begin
             @test acos(cos(x)) ≈ x
@@ -244,6 +252,10 @@ end
             @test sinh(x) ≈ (exp(x)-exp(-x))/2
             @test tan(x) ≈ sin(x)/cos(x)
             @test tanh(x) ≈ sinh(x)/cosh(x)
+            @test sec(x) ≈ inv(cos(x))
+            @test csc(x) ≈ inv(sin(x))
+            @test sech(x) ≈ inv(cosh(x))
+            @test csch(x) ≈ inv(sinh(x))
         end
         @testset "Edge cases" begin
             @test isinf(log(zero(T)))

--- a/test/math.jl
+++ b/test/math.jl
@@ -172,6 +172,8 @@ end
             @test tanh(x) ≈ tanh(big(x))
             @test sec(x) ≈ sec(big(x))
             @test csc(x) ≈ csc(big(x))
+            @test secd(x) ≈ secd(big(x))
+            @test cscd(x) ≈ cscd(big(x))
             @test sech(x) ≈ sech(big(x))
             @test csch(x) ≈ csch(big(x))
         end
@@ -214,6 +216,8 @@ end
             @test tan(T(pi)/4) ≈ T(1) atol=eps(T)
             @test isequal(sec(T(pi)), -one(T))
             @test isequal(csc(T(pi)/2), one(T))
+            @test isequal(secd(T(180)), -one(T))
+            @test isequal(cscd(T(90)), one(T))
             @test isequal(sech(log(one(T))), one(T))
             @test isequal(csch(zero(T)), T(Inf))
         end
@@ -254,6 +258,8 @@ end
             @test tanh(x) ≈ sinh(x)/cosh(x)
             @test sec(x) ≈ inv(cos(x))
             @test csc(x) ≈ inv(sin(x))
+            @test secd(x) ≈ inv(cosd(x))
+            @test cscd(x) ≈ inv(sind(x))
             @test sech(x) ≈ inv(cosh(x))
             @test csch(x) ≈ inv(sinh(x))
         end


### PR DESCRIPTION
Fix #29840.  I also added a bunch of tests, I think these functions weren't tested at all.

CC: @stevengj @simonbyrne