### PR TITLE
RFC: Add `exitcode` keyword argument to `Base.atexit`

### DIFF
--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -307,7 +307,7 @@ If all three of the following conditions are met:
 3. Julia was previously planning on exiting with exit code `0`
 Then Julia will instead exit with exit code `exitcode`.
 
-If multiple exit hooks (each with nonzero `change_exit_hook`) throw
+If multiple exit hooks (each with nonzero `exitcode`) throw
 exceptions, then Julia will use the `change_exit_hook` of the first called
 exit hook to throw an exception. (Because exit hooks are called in LIFO order,
 "first called" is equivalent to "last registered.")

--- a/base/initdefs.jl
+++ b/base/initdefs.jl
@@ -308,7 +308,7 @@ If all three of the following conditions are met:
 Then Julia will instead exit with exit code `exitcode`.
 
 If multiple exit hooks (each with nonzero `exitcode`) throw
-exceptions, then Julia will use the `change_exit_hook` of the first called
+exceptions, then Julia will use the `exitcode` of the first called
 exit hook to throw an exception. (Because exit hooks are called in LIFO order,
 "first called" is equivalent to "last registered.")
 """

--- a/doc/src/manual/embedding.md
+++ b/doc/src/manual/embedding.md
@@ -31,8 +31,8 @@ int main(int argc, char *argv[])
          Julia time to cleanup pending write requests
          and run all finalizers
     */
-    jl_atexit_hook(0);
-    return 0;
+    int exitcode = jl_atexit_hook(0);
+    return exitcode;
 }
 ```
 
@@ -94,8 +94,8 @@ int main(int argc, char *argv[])
 {
     jl_init();
     (void)jl_eval_string("println(sqrt(2.0))");
-    jl_atexit_hook(0);
-    return 0;
+    int exitcode = jl_atexit_hook(0);
+    return exitcode;
 }
 ```
 
@@ -167,8 +167,8 @@ int main(int argc, char *argv[])
          Julia time to cleanup pending write requests
          and run all finalizers
     */
-    jl_atexit_hook(0);
-    return 0;
+    int exitcode = jl_atexit_hook(0);
+    return exitcode;
 }
 ```
 

--- a/src/jl_uv.c
+++ b/src/jl_uv.c
@@ -626,7 +626,7 @@ JL_DLLEXPORT void jl_safe_printf(const char *fmt, ...) JL_NOTSAFEPOINT
 JL_DLLEXPORT void jl_exit(int exitcode)
 {
     uv_tty_reset_mode();
-    jl_atexit_hook(exitcode);
+    exitcode = jl_atexit_hook(exitcode);
     exit(exitcode);
 }
 

--- a/src/julia.h
+++ b/src/julia.h
@@ -1537,7 +1537,7 @@ JL_DLLEXPORT void jl_init_with_image(const char *julia_bindir,
                                      const char *image_relative_path);
 JL_DLLEXPORT const char *jl_get_default_sysimg_path(void);
 JL_DLLEXPORT int jl_is_initialized(void);
-JL_DLLEXPORT void jl_atexit_hook(int status);
+JL_DLLEXPORT int jl_atexit_hook(int status);
 JL_DLLEXPORT void JL_NORETURN jl_exit(int status);
 JL_DLLEXPORT const char *jl_pathname_for_handle(void *handle);
 

--- a/test/atexit.jl
+++ b/test/atexit.jl
@@ -1,0 +1,248 @@
+using Test
+
+@testset "atexit.jl" begin
+    function _atexit_tests_gen_cmd_eval(expr::String)
+        cmd_eval = ```
+        $(Base.julia_cmd()) --check-bounds=yes --code-coverage=all
+        --inline=no --compiled-modules=no --eval $(expr)
+        ```
+        return cmd_eval
+    end
+    function _atexit_tests_gen_cmd_script(temp_dir::String, expr::String)
+        script, io = mktemp(temp_dir)
+        println(io, expr)
+        close(io)
+        cmd_script = ```
+        $(Base.julia_cmd()) --check-bounds=yes --code-coverage=all
+        --inline=no --compiled-modules=no $(script)
+        ```
+        return cmd_script
+    end
+    atexit_temp_dir = mktempdir()
+    atexit(() -> rm(atexit_temp_dir; force = true, recursive = true))
+    @testset "these should exit with exit code 0" begin
+        julia_expr_list = Dict(
+            """
+            atexit(() -> println("No error"))
+            """ => 0,
+            """
+            atexit(() -> println("No error"); exitcode=0)
+            """ => 0,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."))
+            """ => 0,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            """ => 0,
+            """
+            atexit(() -> println("No error"); exitcode=1)
+            """ => 0,
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> println("No error"); exitcode=1)
+            """ => 0,
+            """
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> println("No error"); exitcode=1)
+            """ => 0,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> println("No error"); exitcode=1)
+            """ => 0,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> println("No error"); exitcode=1)
+            """ => 0,
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test success(cmd_eval)
+            @test success(cmd_script)
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "these should exit with exit code 1" begin
+        julia_expr_list = Dict(
+            """
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            """ => 1,
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            """ => 1,
+            """
+            atexit(() -> println("No error"); exitcode=false)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            """ => 1,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            """ => 1,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            """ => 1,
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test_throws ProcessFailedException run(cmd_eval)
+            @test_throws ProcessFailedException run(cmd_script)
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "test exit codes other than 0 or 1" begin
+        julia_expr_list = Dict(
+            """
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=13)
+            """ => 13,
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=5)
+            """ => 5,
+            """
+            atexit(() -> println("No error"); exitcode=false)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=2)
+            """ => 2,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=33)
+            """ => 33,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=21)
+            """ => 21,
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test_throws(ProcessFailedException, run(cmd_eval))
+            @test_throws(ProcessFailedException, run(cmd_script))
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "test what happens if multiple exit hooks throw exceptions" begin
+        julia_expr_list = Dict(
+            """
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=2)
+            """ => 2,
+            """
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=2)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=1)
+            """ => 1,
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=3)
+            atexit(() -> println("No error"))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=4)
+            """ => 4,
+            """
+            atexit(() -> println("No error"))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=4)
+            atexit(() -> println("No error"))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=2)
+            """ => 2,
+            """
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=11)
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=21)
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=22)
+            """ => 22,
+            """
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=22)
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=11)
+            atexit(() -> println("No error"); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=11)
+            """ => 11,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=3)
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=7)
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=4)
+            """ => 4,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=7)
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=4)
+            atexit(() -> error("I throw an error but it gets ignored."))
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=3)
+            """ => 3,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=9)
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=15)
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=2)
+            """ => 2,
+            """
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=2)
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=15)
+            atexit(() -> error("I throw an error but it gets ignored."); exitcode=0)
+            atexit(() -> error("I throw an error that changes the exit code."); exitcode=9)
+            """ => 9,
+            )
+        for julia_expr in keys(julia_expr_list)
+            cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+            cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+            expected_exit_code = julia_expr_list[julia_expr]
+            @test_throws(ProcessFailedException, run(cmd_eval))
+            @test_throws(ProcessFailedException, run(cmd_script))
+            p_eval = run(cmd_eval; wait = false)
+            p_script = run(cmd_script; wait = false)
+            wait(p_eval)
+            wait(p_script)
+            @test p_eval.exitcode == expected_exit_code
+            @test p_script.exitcode == expected_exit_code
+        end
+    end
+    @testset "make sure you can't supply a `exitcode` larger than a Cint" begin
+        if isdefined(Main, :Int64)
+            julia_expr_list = [
+                """
+                atexit(() -> println("I don't follow the rules."); exitcode=typemax(Int64))
+                """,
+                """
+                atexit(() -> println("I don't follow the rules."); exitcode=typemin(Int64))
+                """,
+                ]
+            for julia_expr in julia_expr_list
+                cmd_eval = _atexit_tests_gen_cmd_eval(julia_expr)
+                cmd_script = _atexit_tests_gen_cmd_script(atexit_temp_dir, julia_expr)
+                @test_throws ProcessFailedException run(cmd_eval)
+                @test_throws ProcessFailedException run(cmd_script)
+            end
+        end
+    end
+
+    rm(atexit_temp_dir; force = true, recursive = true)
+end

--- a/test/choosetests.jl
+++ b/test/choosetests.jl
@@ -54,7 +54,7 @@ function choosetests(choices = [])
         "checked", "bitset", "floatfuncs", "precompile",
         "boundscheck", "error", "ambiguous", "cartesian", "osutils",
         "channels", "iostream", "secretbuffer", "specificity",
-        "reinterpretarray", "syntax", "logging", "missing", "asyncmap"
+        "reinterpretarray", "syntax", "logging", "missing", "asyncmap", "atexit"
     ]
 
     tests = []

--- a/test/embedding/embedding.c
+++ b/test/embedding/embedding.c
@@ -23,8 +23,8 @@ jl_value_t *checked_eval_string(const char* code)
                  jl_stderr_obj(),
                  jl_exception_occurred());
         jl_printf(jl_stderr_stream(), "\n");
-        jl_atexit_hook(1);
-        exit(1);
+        int exitcode = jl_atexit_hook(1);
+        exit(exitcode);
     }
     assert(result && "Missing return value but no exception occurred!");
     return result;
@@ -176,6 +176,6 @@ int main()
     }
 
     int ret = 0;
-    jl_atexit_hook(ret);
+    ret = jl_atexit_hook(ret);
     return ret;
 }

--- a/test/gcext/gcext.c
+++ b/test/gcext/gcext.c
@@ -585,8 +585,8 @@ jl_value_t *checked_eval_string(const char *code)
                 jl_stderr_obj(),
                 jl_exception_occurred());
         jl_printf(jl_stderr_stream(), "\n");
-        jl_atexit_hook(1);
-        exit(1);
+        int exitcode = jl_atexit_hook(1);
+        exit(exitcode);
     }
     assert(result && "Missing return value but no exception occurred!");
     return result;

--- a/ui/repl.c
+++ b/ui/repl.c
@@ -215,7 +215,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
         return 0;
     }
     int ret = true_main(argc, (char**)argv);
-    jl_atexit_hook(ret);
+    ret = jl_atexit_hook(ret);
     return ret;
 }
 


### PR DESCRIPTION
Fixes #31743

There is an alternative implementation in #32502, but I personally prefer the approach in this pull request.

This pull request adds functionality for Julia users to add an exit hook that has the ability to change a zero exit code to a non-zero exit code.

Specifically, this pull request adds the `exitcode` keyword argument to `Base.atexit`. The default value of `exitcode` is `0`.
- Old method signature: `atexit(f::Function)`
- New method signature: `atexit(f::Function; exitcode = 0)`

If all three of the following conditions are met:
1. An exit hook f() throws an exception
2. The corresponding value for `exitcode` was nonzero
3. Julia was previously planning on exiting with exit code `0`

Then Julia will instead exit with exit code `exitcode`.

If multiple exit hooks (each with nonzero `exitcode`) throw exceptions, then Julia will use the `exitcode` of the first called exit hook to throw an exception. (Because exit hooks are called in LIFO order, "first called" is equivalent to "last registered.")

I have included some tests. They are located in the newly created`test/atexit.jl` file.

This change is backwards-compatible.