### PR TITLE
Avoid segfault when ptls->safepoint is NULL (rebased #27020)

### DIFF
--- a/src/julia_threads.h
+++ b/src/julia_threads.h
@@ -240,7 +240,7 @@ JL_DLLEXPORT void (jl_cpu_wake)(void);
 
 // gc safepoint and gc states
 // This triggers a SegFault when we are in GC
-// Assign it to a variable to make sure the compiler emit the load
+// Assign it to a variable to make sure the compiler emits the load
 // and to avoid Clang warning for -Wunused-volatile-lvalue
 #define jl_gc_safepoint_(ptls) do {                     \
         jl_signal_fence();                              \

--- a/test/threads_exec.jl
+++ b/test/threads_exec.jl
@@ -652,6 +652,12 @@ function pfib(n::Int)
 end
 @test pfib(20) == 6765
 
+function test_27020_SIGSEGV()
+    x = BigInt()
+    # We only care that this call does not throw a SIGSEGV, so no need to check return value
+    @threadcall((:__gmpz_init, :libgmp), Cvoid, (Ptr{BigInt}, ), Ref(x))
+end
+test_27020_SIGSEGV()
 
 # scheduling wake/sleep test (#32511)
 let timeout = 300 # this test should take about 1-10 seconds


### PR DESCRIPTION
This is the same as #27020 but rebased onto the current master. There were positive reviews but some CI issues at the time, lets hope it is better this time.

We have hit this issue with an external library that creates openmp threads which trigger the gc via gmp allocations.