### PR TITLE
readdlm(bytearray) shouldn't modify bytearray

### DIFF
--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -226,7 +226,7 @@ readdlm(input, dlm::AbstractChar, T::Type, eol::AbstractChar; opts...) =
     readdlm_auto(input, dlm, T, eol, false; opts...)
 
 readdlm_auto(input::Vector{UInt8}, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...) =
-    readdlm_string(String(copy(input)), dlm, T, eol, auto, val_opts(opts))
+    readdlm_string(String(copyto!(Base.StringVector(length(input)), input)), dlm, T, eol, auto, val_opts(opts))
 readdlm_auto(input::IO, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...) =
     readdlm_string(read(input, String), dlm, T, eol, auto, val_opts(opts))
 function readdlm_auto(input::AbstractString, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...)

--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -226,7 +226,7 @@ readdlm(input, dlm::AbstractChar, T::Type, eol::AbstractChar; opts...) =
     readdlm_auto(input, dlm, T, eol, false; opts...)
 
 readdlm_auto(input::Vector{UInt8}, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...) =
-    readdlm_string(String(input), dlm, T, eol, auto, val_opts(opts))
+    readdlm_string(String(copy(input)), dlm, T, eol, auto, val_opts(opts))
 readdlm_auto(input::IO, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...) =
     readdlm_string(read(input, String), dlm, T, eol, auto, val_opts(opts))
 function readdlm_auto(input::AbstractString, dlm::AbstractChar, T::Type, eol::AbstractChar, auto::Bool; opts...)

--- a/stdlib/DelimitedFiles/test/runtests.jl
+++ b/stdlib/DelimitedFiles/test/runtests.jl
@@ -288,6 +288,12 @@ let data = "\"1\",\"灣\"\"灣灣灣灣\",\"3\""
     @test readdlm(IOBuffer(data), ',') == Any[1 "灣\"灣灣灣灣" 3]
 end
 
+# reading from a byte array (#16731)
+let data = Vector{UInt8}("1,2,3\n4,5,6"), origdata = copy(data)
+    @test readdlm(data, ',') == [1 2 3; 4 5 6]
+    @test data == origdata
+end
+
 # issue #11484: useful error message for invalid readdlm filepath arguments
 @test_throws ArgumentError readdlm(tempdir())
 


### PR DESCRIPTION
Fixes bug reported in https://github.com/JuliaLang/julia/pull/16731#issuecomment-499491529 by @bkamins.

(Would be nice to do this without making a copy of the data, but I don't see any way to do this without adding a new C routine.)