### PR TITLE
Use LLVM_DEBUG instead of DEBUG in final GC lowering pass

### DIFF
--- a/src/llvm-final-gc-lowering.cpp
+++ b/src/llvm-final-gc-lowering.cpp
@@ -16,6 +16,9 @@
 #include "llvm-pass-helpers.h"
 
 #define DEBUG_TYPE "final_gc_lowering"
+#if JL_LLVM_VERSION < 70000
+#define LLVM_DEBUG DEBUG
+#endif
 
 using namespace llvm;
 
@@ -281,7 +284,7 @@ static void replaceInstruction(
 
 bool FinalLowerGC::runOnFunction(Function &F)
 {
-    DEBUG(dbgs() << "FINAL GC LOWERING: Processing function " << F.getName() << "\n");
+    LLVM_DEBUG(dbgs() << "FINAL GC LOWERING: Processing function " << F.getName() << "\n");
     // Check availability of functions again since they might have been deleted.
     initFunctions(*F.getParent());
     if (!ptls_getter)


### PR DESCRIPTION
Hi! After reviewing @chriselrod's comment on #31135, I discovered a small flaw in said PR. The changes I'm proposing here fix that flaw.

Specifically, I discovered that @banex19 had prepared Julia's LLVM IR optimization passes for LLVM 7.0.1 by replacing calls to the `DEBUG` macro with calls to the new `LLVM_DEBUG` macro in 4e8bae366d0ad11b1814bf9df378539fe9d8c21a. These changes appear to have been made after I first posted #31135 but before it got merged in. I must've overlooked them when I rebased and hence didn't update `llvm-final-gc-lowering.cpp` to also use `LLVM_DEBUG` rather than `DEBUG`. Sorry about that!