### PR TITLE
Remove copy(::SubArray) definition from SparseArrays, fixes #32213.

### DIFF
--- a/stdlib/SparseArrays/src/sparseconvert.jl
+++ b/stdlib/SparseArrays/src/sparseconvert.jl
@@ -76,9 +76,6 @@ For other types return A itself.
 unwrap(A::Any) = A
 unwrap(A::AbstractMatrix) = iswrsparse(A) ? convert(SparseMatrixCSC, A) : convert(Array, A)
 
-import Base.copy
-copy(A::SubArray{T,2}) where T = getindex(unwrap(parent(A)), A.indices...)
-
 # For pure sparse matrices and vectors return A.
 # For wrapped sparse matrices or vectors convert to SparseMatrixCSC.
 # Handle nested wrappers properly.


### PR DESCRIPTION
xref https://github.com/JuliaLang/julia/pull/32249#issuecomment-500114564, alternative to #32249.

This method was introduced in #30552, but was unrelated to the rest of
the changes, and no-one reviewed or thought about the implications.