### PR TITLE
Allow both EAUTH and ERROR for bad URL test in LibGit2 tests.

### DIFF
--- a/stdlib/LibGit2/test/online.jl
+++ b/stdlib/LibGit2/test/online.jl
@@ -68,7 +68,8 @@ mktempdir() do dir
                 error("unexpected")
             catch ex
                 @test isa(ex, LibGit2.Error.GitError)
-                @test ex.code == LibGit2.Error.ERROR
+                # Return code seems to vary, see #32186, #32219
+                @test ex.code ∈ (LibGit2.Error.EAUTH, LibGit2.Error.ERROR)
             end
             Base.shred!(cred)
         end


### PR DESCRIPTION
See https://github.com/JuliaLang/julia/pull/32219#issuecomment-500075737