### PR TITLE
[Statistics] fix type determination in corm

### DIFF
--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -645,9 +645,9 @@ function corm(x::AbstractVector, mx, y::AbstractVector, my)
 
     @inbounds begin
         # Initialize the accumulators
-        xx = zero(sqrt(abs2(one(eltype(x)))))
-        yy = zero(sqrt(abs2(one(eltype(y)))))
-        xy = zero(one(eltype(x)) * one(eltype(y))')
+        xx = zero(sqrt(abs2(one(x[1]))))
+        yy = zero(sqrt(abs2(one(y[1]))))
+        xy = zero(x[1] * y[1]')
 
         @simd for i in eachindex(x, y)
             xi = x[i] - mx

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -645,9 +645,9 @@ function corm(x::AbstractVector, mx, y::AbstractVector, my)
 
     @inbounds begin
         # Initialize the accumulators
-        xx = zero(typeof(sqrt(abs2(one(eltype(x))))))
-        yy = zero(typeof(sqrt(abs2(one(eltype(y))))))
-        xy = zero(typeof(one(eltype(x)) * one(eltype(y))'))
+        xx = zero(sqrt(abs2(one(eltype(x)))))
+        yy = zero(sqrt(abs2(one(eltype(y)))))
+        xy = zero(one(eltype(x)) * one(eltype(y))')
 
         @simd for i in eachindex(x, y)
             xi = x[i] - mx

--- a/stdlib/Statistics/src/Statistics.jl
+++ b/stdlib/Statistics/src/Statistics.jl
@@ -645,9 +645,9 @@ function corm(x::AbstractVector, mx, y::AbstractVector, my)
 
     @inbounds begin
         # Initialize the accumulators
-        xx = zero(sqrt(abs2(x[1])))
-        yy = zero(sqrt(abs2(y[1])))
-        xy = zero(x[1] * y[1]')
+        xx = zero(typeof(sqrt(abs2(one(eltype(x))))))
+        yy = zero(typeof(sqrt(abs2(one(eltype(y))))))
+        xy = zero(typeof(one(eltype(x)) * one(eltype(y))'))
 
         @simd for i in eachindex(x, y)
             xi = x[i] - mx

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -460,6 +460,8 @@ end
     @test cor(repeat(1:17, 1, 17))[2] <= 1.0
     @test cor(1:17, 1:17) <= 1.0
     @test cor(1:17, 18:34) <= 1.0
+    @test cor(Any[1, 2], Any[1, 2]) == 1.0
+    @test cor([0], Int8[81]) == cor([0], [81])
     let tmp = range(1, stop=85, length=100)
         tmp2 = Vector(tmp)
         @test cor(tmp, tmp) <= 1.0

--- a/stdlib/Statistics/test/runtests.jl
+++ b/stdlib/Statistics/test/runtests.jl
@@ -461,7 +461,7 @@ end
     @test cor(1:17, 1:17) <= 1.0
     @test cor(1:17, 18:34) <= 1.0
     @test cor(Any[1, 2], Any[1, 2]) == 1.0
-    @test cor([0], Int8[81]) == cor([0], [81])
+    @test isnan(cor([0], Int8[81]))
     let tmp = range(1, stop=85, length=100)
         tmp2 = Vector(tmp)
         @test cor(tmp, tmp) <= 1.0


### PR DESCRIPTION
Fixes #32264. This avoids overflow (and subsequently a method error "sqrt of negative number") for smaller integer types at the initialization step. I guess this is a bugfix...?