### PR TITLE
Fix broken link to "Getting Started" page

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ lists a series of running tests; if they complete without error, you
 should be in good shape to start using Julia.
 
 You can read about [getting
-started](https://docs.julialang.org/en/stable/manual/getting-started/)
+started](https://docs.julialang.org/en/v1/manual/getting-started/)
 in the manual.
 
 In case this default build path did not work, detailed build instructions


### PR DESCRIPTION
I have discovered that the link to the "Getting Started" page from the README is broken. This PR replaces that broken link with a working one.

Edit: fixes #32319