### PR TITLE
Have jl_realloc_aligned /try/ realloc, then fallback to malloc if not aligned

### DIFF
--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -923,9 +923,12 @@ STATIC_INLINE void *jl_realloc_aligned(void *d, size_t sz, size_t oldsz,
     // Since there is no system realloc_aligned, we use the following strategy: Try realloc
     // and hope that it maintains alignment. If it doesn't, manually allocate again via the
     // (malloc, memcpy, and free) steps, below.
-    d = realloc(d, sz);
-    if (jl_is_aligned(d, align)) {
-        return d;
+    void *r = realloc(d, sz);
+    if (r != NULL && jl_is_aligned(r, align)) {
+        return r;
+    } else if (r != NULL) {
+        // (Don't overwrite d unless r is non-null; if realloc returns NULL, d is unchanged)
+        d = r;
     }
 
     void *b = jl_malloc_aligned(sz, align);


### PR DESCRIPTION
Since there isn't a system realloc_aligned on non-windows systems, we
will simply call realloc, and hope that it will either manage to grow
the existing allocation, or if it had to move it, hope that the new
allocation is correctly aligned. If not, we will manually redo the
allocation via (malloc_aligned, copy, free).

Note that this makes the growth event on large arrays drastically faster:

```
$ julia-master -e 'b = collect(1:2^30); @time push!(b, 1);'
  5.433267 seconds (121 allocations: 327.686 MiB, 0.02% gc time)
$ ./julia -e 'b = collect(1:2^30); @time push!(b, 1);'
  0.003441 seconds (128 allocations: 327.689 MiB, 31.64% gc time)
```

Down to 0.003441 seconds from the previous 5.433267 seconds to double an
array of 2^30 integers. :)
(Of course, if you're growing an array from empty, one element at a time, this cost
would be amortized over all those insertions, so for such a task, this should end
up being around a 2x improvement.)


This is the solution to problem (2.) of #28588. 