### PR TITLE
fix #32325, struct plus outer ctor inside `let`

### DIFF
--- a/src/julia-syntax.scm
+++ b/src/julia-syntax.scm
@@ -840,9 +840,9 @@
                      (error (string "field name \"" (deparse v) "\" is not a symbol"))))
                field-names)
      `(block
+       (global ,name) (const ,name)
        (scope-block
         (block
-         (global ,name) (const ,name)
          ,@(map (lambda (v) `(local ,v)) params)
          ,@(map (lambda (n v) (make-assignment n (bounds-to-TypeVar v #t))) params bounds)
          (struct_type ,name (call (core svec) ,@params)

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1854,3 +1854,10 @@ macro id28992(x) x end
 # issue #31596
 f31596(x; kw...) = x
 @test f31596((a=1,), b = 1.0) === (a=1,)
+
+# issue #32325
+let
+    struct a32325 end
+    a32325(x) = a32325()
+end
+@test a32325(0) === a32325()


### PR DESCRIPTION
Fixes #32325. It's a bit ambiguous whether the function definition is meant to be a local variable, but if you replace `struct` with `abstract type` or `primitive type` the function is taken to be a constructor, so this just makes `struct` work the same way. That is almost certainly the intended/more useful behavior.