### PR TITLE
Fix `setindex!` on `Bidiagonal` with `ev` zero bug.

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -123,9 +123,9 @@ function setindex!(A::Bidiagonal, x, i::Integer, j::Integer)
     @boundscheck checkbounds(A, i, j)
     if i == j
         @inbounds A.dv[i] = x
-    elseif istriu(A) && (i == j - 1)
+    elseif A.uplo == 'U' && (i == j - 1)
         @inbounds A.ev[i] = x
-    elseif istril(A) && (i == j + 1)
+    elseif A.uplo == 'L' && (i == j + 1)
         @inbounds A.ev[j] = x
     elseif !iszero(x)
         throw(ArgumentError(string("cannot set entry ($i, $j) off the ",

--- a/stdlib/LinearAlgebra/test/bidiag.jl
+++ b/stdlib/LinearAlgebra/test/bidiag.jl
@@ -91,6 +91,12 @@ Random.seed!(1)
         @test similar(ubd, Int).uplo == ubd.uplo
         @test isa(similar(ubd, (3, 2)), SparseMatrixCSC)
         @test isa(similar(ubd, Int, (3, 2)), SparseMatrixCSC{Int})
+
+        # setindex! when off diagonal is zero bug
+        Bu = Bidiagonal(rand(elty, 10), zeros(elty, 9), 'U')
+        Bl = Bidiagonal(rand(elty, 10), zeros(elty, 9), 'L')
+        @test_throws ArgumentError Bu[5, 4] = 1
+        @test_throws ArgumentError Bl[4, 5] = 1
     end
 
     @testset "show" begin


### PR DESCRIPTION
Below is a MWE and explanation of the bug. The bug is that we can assign to structural zeros in `Bidiagonal` matrices when the `B.ev` vector is zero, but they show up in the off diagonal. For example:

```julia
julia> using LinearAlgebra

julia> B = Bidiagonal(rand(5), zeros(4), 'U')
5×5 Bidiagonal{Float64,Array{Float64,1}}:
 0.73714  0.0        ⋅         ⋅         ⋅      
  ⋅       0.800223  0.0        ⋅         ⋅      
  ⋅        ⋅        0.328117  0.0        ⋅      
  ⋅        ⋅         ⋅        0.519735  0.0     
  ⋅        ⋅         ⋅         ⋅        0.313492

julia> istril(B)
true

julia> istriu(B)
true

julia> B[2,1] = 3 # Note, this is in the lower off-diagonal but this is an upper Bidiagonal matrix
3

julia> B
5×5 Bidiagonal{Float64,Array{Float64,1}}:
 0.73714  3.0        ⋅         ⋅         ⋅      
  ⋅       0.800223  0.0        ⋅         ⋅      
  ⋅        ⋅        0.328117  0.0        ⋅      
  ⋅        ⋅         ⋅        0.519735  0.0     
  ⋅        ⋅         ⋅         ⋅        0.313492

julia> B[1,2] = 0
0

julia> B[4,5] = 10
10

julia> B
5×5 Bidiagonal{Float64,Array{Float64,1}}:
 0.73714  0.0        ⋅         ⋅          ⋅      
  ⋅       0.800223  0.0        ⋅          ⋅      
  ⋅        ⋅        0.328117  0.0         ⋅      
  ⋅        ⋅         ⋅        0.519735  10.0     
  ⋅        ⋅         ⋅         ⋅         0.313492
```

Why it happens: In `setindex!` are checking `istriu(B)` which is https://github.com/JuliaLang/julia/blob/802e71907481de60ca701c6c41ac8a9540a479c7/stdlib/LinearAlgebra/src/bidiag.jl#L249

So, when the Bidiagonal matrix has `uplo = 'U'` but `B.ev` is zero, `setindex!` allows us to set values on the lower off diagonal.

This fix has the added effect of improving access time in the (admittedly, artificial) pessimal case of the very last element in `B.ev` being the only non-zero one.
