### PR TITLE
Make `getindex` for `Bidiagonal` O(1) in the worst-case

### DIFF
--- a/stdlib/LinearAlgebra/src/bidiag.jl
+++ b/stdlib/LinearAlgebra/src/bidiag.jl
@@ -112,8 +112,10 @@ function getindex(A::Bidiagonal{T}, i::Integer, j::Integer) where T
     end
     if i == j
         return A.dv[i]
-    elseif (istriu(A) && (i == j - 1)) || (istril(A) && (i == j + 1))
-        return A.ev[min(i,j)]
+    elseif A.uplo == 'U' && (i == j - 1)
+        return A.ev[i]
+    elseif A.uplo == 'L' && (i == j + 1)
+        return A.ev[j]
     else
         return zero(T)
     end


### PR DESCRIPTION
This is similar to https://github.com/JuliaLang/julia/pull/32328, but I separated them since that is a bug fix and this is just an edge case optimization.

In the worst case, `getindex` for `Bidiagonal` matrices is `O(n)`. This PR makes it `O(1)`.

The worst case is a `Bidiagonal` where the off diagonal is zero. In the worst case, `iszero` (which is `O(n)`) is called twice (once in `istriu` and once in `istril`).

This only really comes into play for large matrices, but this pr doesn't slow down `getindex` for small matrices, so it seems like a net win.


--------------------------------------------------------------------------------------

Here are some timings:

Master:
```julia
julia> B = Bidiagonal(rand(100000), zeros(99999), 'U')

julia> @time B[100000, 99999]
  0.000379 seconds (5 allocations: 176 bytes)
0.0

julia> @time B[99999, 100000]
  0.000008 seconds (5 allocations: 176 bytes)
0.0
```

This PR:
```julia
julia> B = Bidiagonal(rand(100000), zeros(99999), 'U')

julia> @time B[99999, 100000]
  0.000003 seconds (5 allocations: 176 bytes)
0.0

julia> @time B[100000, 99999]
  0.000007 seconds (5 allocations: 176 bytes)
0.0
```