### PR TITLE
Another upgrade to hypot (second attempt). This adds a correctly roun…

### DIFF
--- a/base/math.jl
+++ b/base/math.jl
@@ -537,30 +537,60 @@ Stacktrace:
 [...]
 ```
 """
-hypot(x::Number, y::Number) = hypot(promote(x, y)...)
-function hypot(x::T, y::T) where T<:Number
-    ax = abs(x)
-    ay = abs(y)
-    if ax < ay
-        ax, ay = ay, ax
-    end
-    if iszero(ax)
-        r = ay / oneunit(ax)
-    else
-        r = ay / ax
+#  Hypot(a,b)
+#  This code is an implementation of the algorithm described in:
+#  An Improved Algorithm for hypot(a,b)
+#  by Carlos F. Borges
+#  The article is available online at ArXiv at the link
+#  https://arxiv.org/abs/1904.09481#
+Hypot(x::Number, y::Number) = Hypot(promote(x, y)...)
+Hypot(x::Complex, y::Complex) = Hypot(promote(abs(x),abs(y))...)
+Hypot(x::Integer, y::Integer) = Hypot(promote(float(x), float(y))...)
+function Hypot(x::T,y::T) where T<:AbstractFloat
+    #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
+    if isinf(x) || isinf(y)
+        return convert(T,Inf)
     end
 
-    rr = ax * sqrt(1 + r * r)
-
-    # Use type of rr to make sure that return type is the same for
-    # all branches
-    if isnan(r)
-        isinf(ax) && return oftype(rr, Inf)
-        isinf(ay) && return oftype(rr, Inf)
-        return oftype(rr, r)
-    else
-        return rr
+    # Order the operands
+    ax,ay = abs(x), abs(y)
+    if ay > ax
+        ax,ay = ay,ax
     end
+
+    # Widely varying operands
+    if ay <= ax*sqrt(eps(T)/2)  #Note: This also gets ay == 0
+        return ax
+    end
+
+    # Operands do not vary widely
+    scale = eps(sqrt(floatmin(T)))  #Rescaling constant
+    if ax > sqrt(floatmax(T)/2)
+        ax = ax*scale
+        ay = ay*scale
+        scale = inv(scale)
+    elseif ay < sqrt(floatmin(T))
+        ax = ax/scale
+        ay = ay/scale
+    else
+        scale = one(scale)
+    end
+    h = sqrt(muladd(ax,ax,ay*ay))
+    if Base.Math.FMA_NATIVE
+        h = sqrt(fma(ax,ax,ay*ay))
+        h_sq = h*h
+        ax_sq = ax*ax
+        h -= (fma(-ay,ay,h_sq-ax_sq) + fma(h,h,-h_sq) - fma(ax,ax,-ax_sq))/(2*h)
+    else
+        if h <= 2*ay
+            delta = h-ay
+            h -= muladd(delta,delta-2*(ax-ay),ax*(2*delta - ax))/(2*h)
+        else
+            delta = h-ax
+            h -= muladd(delta,delta,muladd(ay,(4*delta-ay),2*delta*(ax-2*ay)))/(2*h)
+        end
+    end
+    h*scale
 end
 
 """

--- a/base/math.jl
+++ b/base/math.jl
@@ -577,7 +577,6 @@ function hypot(x::T,y::T) where T<:AbstractFloat
     end
     h = sqrt(muladd(ax,ax,ay*ay))
     if Base.Math.FMA_NATIVE
-        h = sqrt(fma(ax,ax,ay*ay))
         h_sq = h*h
         ax_sq = ax*ax
         h -= (fma(-ay,ay,h_sq-ax_sq) + fma(h,h,-h_sq) - fma(ax,ax,-ax_sq))/(2*h)

--- a/base/math.jl
+++ b/base/math.jl
@@ -537,16 +537,16 @@ Stacktrace:
 [...]
 ```
 """
-#  Hypot(a,b)
+#  hypot(a,b)
 #  This code is an implementation of the algorithm described in:
 #  An Improved Algorithm for hypot(a,b)
 #  by Carlos F. Borges
 #  The article is available online at ArXiv at the link
 #  https://arxiv.org/abs/1904.09481#
-Hypot(x::Number, y::Number) = Hypot(promote(x, y)...)
-Hypot(x::Complex, y::Complex) = Hypot(promote(abs(x),abs(y))...)
-Hypot(x::Integer, y::Integer) = Hypot(promote(float(x), float(y))...)
-function Hypot(x::T,y::T) where T<:AbstractFloat
+hypot(x::Number, y::Number) = hypot(promote(x, y)...)
+hypot(x::Complex, y::Complex) = hypot(promote(abs(x),abs(y))...)
+hypot(x::Integer, y::Integer) = hypot(promote(float(x), float(y))...)
+function hypot(x::T,y::T) where T<:AbstractFloat
     #Return Inf if either or both imputs is Inf (Compliance with IEEE754)
     if isinf(x) || isinf(y)
         return convert(T,Inf)


### PR DESCRIPTION
Another attempt at adding the correctly rounded fma version. If the fma is native then it always uses that version. I removed the optional keyword argument form and I think I was more careful about not crushing other stuff. Don't know how to delete the other pull request so they're both here.

This commit also removes the old version of hypot() which is no longer needed.