### PR TITLE
RFC: Add `remove_atexit` keyword argument to `mktempdir(parent)`

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -518,15 +518,15 @@ is an open file object for this path.
 mktemp(parent)
 
 """
-    mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)), remove_on_exit=false)
+    mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)), remove_atexit=false)
 
 Create a temporary directory in the `parent` directory with a name
 constructed from the given prefix and a random suffix, and return its path.
 Additionally, any trailing `X` characters may be replaced with random characters.
-If `parent` does not exist, throw an error. If `remove_on_exit` is true, then
+If `parent` does not exist, throw an error. If `remove_atexit` is true, then
 the temporary directory will be removed when Julia exits.
 """
-function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_on_exit=false)
+function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_atexit=false)
     if isempty(parent) || occursin(path_separator_re, parent[end:end])
         # append a path_separator only if parent didn't already have one
         tpath = "$(parent)$(prefix)XXXXXX"
@@ -545,7 +545,7 @@ function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_on_exit=false)
         end
         path = unsafe_string(ccall(:jl_uv_fs_t_path, Cstring, (Ptr{Cvoid},), req))
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
-        if remove_on_exit
+        if remove_atexit
             atexit(() -> rm(path; force=true, recursive=true))
         end
         return path

--- a/base/file.jl
+++ b/base/file.jl
@@ -526,7 +526,7 @@ Additionally, any trailing `X` characters may be replaced with random characters
 If `parent` does not exist, throw an error. If `remove_on_exit` is true, then
 the temporary directory will be removed when Julia exits.
 """
-function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_on_exit = false)
+function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_on_exit=false)
     if isempty(parent) || occursin(path_separator_re, parent[end:end])
         # append a path_separator only if parent didn't already have one
         tpath = "$(parent)$(prefix)XXXXXX"
@@ -546,7 +546,7 @@ function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_on_exit = false)
         path = unsafe_string(ccall(:jl_uv_fs_t_path, Cstring, (Ptr{Cvoid},), req))
         ccall(:uv_fs_req_cleanup, Cvoid, (Ptr{Cvoid},), req)
         if remove_on_exit
-            atexit(() -> rm(path; force = true, recursive = true))
+            atexit(() -> rm(path; force=true, recursive=true))
         end
         return path
     finally

--- a/base/file.jl
+++ b/base/file.jl
@@ -523,8 +523,11 @@ mktemp(parent)
 Create a temporary directory in the `parent` directory with a name
 constructed from the given prefix and a random suffix, and return its path.
 Additionally, any trailing `X` characters may be replaced with random characters.
-If `parent` does not exist, throw an error. If `remove_atexit` is true, then
-the temporary directory will be removed when Julia exits.
+If `parent` does not exist, throw an error.
+
+!!! compat "Julia 1.3"
+    The `remove_atexit` keyword argument requires at least Julia 1.3.
+    If `remove_atexit` is true, then the temporary directory will be removed when Julia exits.
 """
 function mktempdir(parent=tempdir(); prefix=temp_prefix, remove_atexit=false)
     if isempty(parent) || occursin(path_separator_re, parent[end:end])

--- a/base/file.jl
+++ b/base/file.jl
@@ -518,7 +518,7 @@ is an open file object for this path.
 mktemp(parent)
 
 """
-    mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)), remove_on_exit = false)
+    mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)), remove_on_exit=false)
 
 Create a temporary directory in the `parent` directory with a name
 constructed from the given prefix and a random suffix, and return its path.

--- a/test/file.jl
+++ b/test/file.jl
@@ -6,7 +6,18 @@
 starttime = time()
 pwd_ = pwd()
 dir = mktempdir()
-dir_removed_on_exit = mktempdir(; remove_on_exit=true)
+code = """
+child_dir = mktempdir(; remove_on_exit=true)
+ispath(child_dir) || error("`child_dir` is not a path")
+isdir(child_dir) || error("`child_dir` is not a directory")
+println(child_dir)
+"""
+cmd = ```
+$(Base.julia_cmd()) --eval $code
+```
+child_dir = chomp(read(cmd, String))
+@test !isdir(child_dir)
+@test !ispath(child_dir)
 file = joinpath(dir, "afile.txt")
 # like touch, but lets the operating system update the timestamp
 # for greater precision on some platforms (windows)

--- a/test/file.jl
+++ b/test/file.jl
@@ -6,6 +6,7 @@
 starttime = time()
 pwd_ = pwd()
 dir = mktempdir()
+dir_removed_on_exit = mktempdir(; remove_on_exit = true)
 file = joinpath(dir, "afile.txt")
 # like touch, but lets the operating system update the timestamp
 # for greater precision on some platforms (windows)

--- a/test/file.jl
+++ b/test/file.jl
@@ -6,7 +6,7 @@
 starttime = time()
 pwd_ = pwd()
 dir = mktempdir()
-dir_removed_on_exit = mktempdir(; remove_on_exit = true)
+dir_removed_on_exit = mktempdir(; remove_on_exit=true)
 file = joinpath(dir, "afile.txt")
 # like touch, but lets the operating system update the timestamp
 # for greater precision on some platforms (windows)

--- a/test/file.jl
+++ b/test/file.jl
@@ -7,7 +7,7 @@ starttime = time()
 pwd_ = pwd()
 dir = mktempdir()
 code = """
-child_dir = mktempdir(; remove_on_exit=true)
+child_dir = mktempdir(; remove_atexit=true)
 ispath(child_dir) || error("`child_dir` is not a path")
 isdir(child_dir) || error("`child_dir` is not a directory")
 println(child_dir)


### PR DESCRIPTION
## Description

This pull request adds a `remove_atexit` keyword argument to the `mktempdir(parent)` method.

Old method signature: `mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)))`

New method signature: `mktempdir(parent=tempdir(); prefix=$(repr(temp_prefix)), remove_atexit=false)`

If `remove_atexit` is `true`, then we add an `atexit` exit hook that will remove the temporary directory when Julia exits.

If `remove_atexit` is `false` (default), then the current behavior is preserved. Therefore, this change is backwards compatible.

## Rationale

Currently, you can use the `mktempdir(fn::Function, parent=tempdir(); prefix=temp_prefix)` method to create a temporary directory, apply the function `fn`, and then remove the temporary directory. However, this requires that you have a function `fn` that contains all of the code that you want to run while the temporary directory is available. You may instead want to create a temporary directory, keep it available for the entire duration of the Julia program, and only delete it when Julia exits. Currently, if you want this functionality, you have to create the `atexit` exit hook yourself. This pull request makes this easier by creating the exit hook for you.