### PR TITLE
Fix tryparse for invalid Chars

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -123,7 +123,8 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     _Z = UInt32('Z')
     _z = UInt32('z')
     while n <= m
-        _c = UInt32(c)
+        # Fast path from `UInt32(::Char)`; non-ascii will be >= 0x80
+        _c = reinterpret(UInt32, c) >> 24
         d::T = _0 <= _c <= _9 ? _c-_0             :
                _A <= _c <= _Z ? _c-_A+ UInt32(10) :
                _a <= _c <= _z ? _c-_a+a           : base
@@ -142,7 +143,8 @@ function tryparse_internal(::Type{T}, s::AbstractString, startpos::Int, endpos::
     end
     (T <: Signed) && (n *= sgn)
     while !isspace(c)
-        _c = UInt32(c)
+        # Fast path from `UInt32(::Char)`; non-ascii will be >= 0x80
+        _c = reinterpret(UInt32, c) >> 24
         d::T = _0 <= _c <= _9 ? _c-_0             :
                _A <= _c <= _Z ? _c-_A+ UInt32(10) :
                _a <= _c <= _z ? _c-_a+a           : base

--- a/test/strings/basic.jl
+++ b/test/strings/basic.jl
@@ -377,6 +377,12 @@ end
     @test tryparse(Float32, "32o") === nothing
 end
 
+@testset "tryparse invalid chars" begin
+    # #32314: tryparse shouldn't throw, even given strings with invalid Chars
+    @test tryparse(UInt8, "\xb5")    === nothing
+    @test tryparse(UInt8, "100\xb5") === nothing  # Code path for numeric overflow
+end
+
 import Unicode
 
 @testset "issue #10994: handle embedded NUL chars for string parsing" begin


### PR DESCRIPTION
This fix adapts the fast path from UInt32(::Char) to the case of digit parsing.

Fixes #32314