### PR TITLE
Add editor line support and write-only support for rmate

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -52,6 +52,8 @@ function edit(path::AbstractString, line::Integer=0)
         cmd = line != 0 ? `$command +$line $path` : `$command $path`
     elseif name == "textmate" || name == "mate" || name == "kate"
         cmd = line != 0 ? `$command $path -l $line` : `$command $path`
+    elseif name == "rmate"
+        cmd = line != 0 ? `$command $path -l $line -f` : `$command $path -f`
     elseif startswith(name, "subl") || startswith(name, "atom")
         cmd = line != 0 ? `$command $path:$line` : `$command $path`
     elseif name == "code" || (Sys.iswindows() && (uppercase(name) == "CODE.EXE" || uppercase(name) == "CODE.CMD"))


### PR DESCRIPTION
I often use [rmate](https://github.com/aurora/rmate) to support working on remote systems -- this adds line number support as well as uses the `-f` flag to force it to open read-only files