### PR TITLE
specialize matrix multiplication with Diagonals

### DIFF
--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -285,25 +285,25 @@ mul!(out::AbstractMatrix, A::Diagonal, in::StridedMatrix) = out .= A.diag .* in
 mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::StridedMatrix) = out .= adjoint.(A.parent.diag) .* in
 mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::StridedMatrix) = out .= transpose.(A.parent.diag) .* in
 
-mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
-mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
-mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:StridedMatrix}) = out .= A.diag .* in
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix}) = out .= adjoint.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix}) = out .= transpose.(A.parent.diag) .* in
 
-mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
-mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
-mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:StridedMatrix}) = out .= A.diag .* in
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix}) = out .= adjoint.(A.parent.diag) .* in
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix}) = out .= transpose.(A.parent.diag) .* in
 
 mul!(out::AbstractMatrix, in::StridedMatrix, A::Diagonal) = out .= in .* permutedims(A.diag)
 mul!(out::AbstractMatrix, in::StridedMatrix, A::Adjoint{<:Any,<:Diagonal}) = out .= in .* adjoint(A.parent.diag)
 mul!(out::AbstractMatrix, in::StridedMatrix, A::Transpose{<:Any,<:Diagonal}) = out .= in .* transpose(A.parent.diag)
 
-mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Diagonal) = (copyto!(out, in); rmul!(out, A))
-mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
-mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
+mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Diagonal) = out .= in .* permutedims(A.diag)
+mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal}) = out .= in .* adjoint(A.parent.diag)
+mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal}) = out .= in .* transpose(A.parent.diag)
 
-mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Diagonal) = (copyto!(out, in); rmul!(out, A))
-mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
-mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
+mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Diagonal) = out .= in .* permutedims(A.diag)
+mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal}) = out .= in .* adjoint(A.parent.diag)
+mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal}) = out .= in .* transpose(A.parent.diag)
 
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -285,6 +285,26 @@ mul!(out::AbstractMatrix, A::Diagonal, in::StridedMatrix) = out .= A.diag .* in
 mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::StridedMatrix) = out .= adjoint.(A.parent.diag) .* in
 mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::StridedMatrix) = out .= transpose.(A.parent.diag) .* in
 
+mul!(out::AbstractMatrix, A::Diagonal, in::Adjoint{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Adjoint{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+
+mul!(out::AbstractMatrix, A::Diagonal, in::Transpose{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+mul!(out::AbstractMatrix, A::Adjoint{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+mul!(out::AbstractMatrix, A::Transpose{<:Any,<:Diagonal}, in::Transpose{<:Any,<:StridedMatrix}) = (copyto!(out, in); lmul!(A, out))
+
+mul!(out::AbstractMatrix, in::StridedMatrix, A::Diagonal) = out .= in .* permutedims(A.diag)
+mul!(out::AbstractMatrix, in::StridedMatrix, A::Adjoint{<:Any,<:Diagonal}) = out .= in .* adjoint(A.parent.diag)
+mul!(out::AbstractMatrix, in::StridedMatrix, A::Transpose{<:Any,<:Diagonal}) = out .= in .* transpose(A.parent.diag)
+
+mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Diagonal) = (copyto!(out, in); rmul!(out, A))
+mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
+mul!(out::AbstractMatrix, in::Adjoint{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
+
+mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Diagonal) = (copyto!(out, in); rmul!(out, A))
+mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Adjoint{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
+mul!(out::AbstractMatrix, in::Transpose{<:Any,<:StridedMatrix}, A::Transpose{<:Any,<:Diagonal}) = (copyto!(out, in); rmul!(out, A))
+
 # ambiguities with Symmetric/Hermitian
 # RealHermSymComplex[Sym]/[Herm] only include Number; invariant to [c]transpose
 *(A::Diagonal, transB::Transpose{<:Any,<:RealHermSymComplexSym}) = A * transB.parent

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -199,9 +199,12 @@ Random.seed!(1)
         @test (r = transpose(Matrix(D)) * vv ; mul!(vvv, transpose(D), vv) ≈ r ≈ vvv)
 
         UUU = similar(UU)
-        @test (r = Matrix(D) * UU   ; mul!(UUU, D, UU) ≈ r ≈ UUU)
-        @test (r = Matrix(D)' * UU  ; mul!(UUU, adjoint(D), UU) ≈ r ≈ UUU)
-        @test (r = transpose(Matrix(D)) * UU ; mul!(UUU, transpose(D), UU) ≈ r ≈ UUU)
+        for transformA in (identity, adjoint, transpose)
+            for transformD in (identity, Adjoint, Transpose, adjoint, transpose)
+                @test mul!(UUU, transformA(UU), transformD(D)) ≈  transformA(UU) * Matrix(transformD(D))
+                @test mul!(UUU, transformD(D), transformA(UU)) ≈  Matrix(transformD(D)) * transformA(UU)
+            end
+        end
 
         # make sure that mul!(A, {Adj|Trans}(B)) works with B as a Diagonal
         VV = Array(D)


### PR DESCRIPTION
Fixes JuliaLang/LinearAlgebra.jl#617. This is a continuation of JuliaLang/julia#31400, which got stalled. Closes JuliaLang/julia#31400.

The following benchmarks tell pretty much everything about which specialized methods were missing and hence falling back to generic matmuls.

```julia
# before the PR
julia> using LinearAlgebra, BenchmarkTools, Test

julia> A = rand(100, 100);

julia> B = similar(A);

julia> D = Diagonal(rand(100));

julia> for transformA in (identity, adjoint, transpose), transformD in (identity, Adjoint, Transpose)
           @btime mul!($(copy(B)), $(transformA(A)), $(transformD(D)))
           @btime mul!($(copy(B)), $(transformD(D)), $(transformA(A)))
       end
  791.282 μs (6 allocations: 336 bytes)
  2.169 μs (0 allocations: 0 bytes)
  809.140 μs (6 allocations: 336 bytes)
  2.300 μs (0 allocations: 0 bytes)
  809.392 μs (6 allocations: 336 bytes)
  2.166 μs (0 allocations: 0 bytes)
  906.218 μs (0 allocations: 0 bytes)
  810.070 μs (6 allocations: 336 bytes)
  796.803 μs (6 allocations: 336 bytes)
  790.676 μs (6 allocations: 336 bytes)
  796.903 μs (6 allocations: 336 bytes)
  791.014 μs (6 allocations: 336 bytes)
  905.247 μs (0 allocations: 0 bytes)
  810.338 μs (6 allocations: 336 bytes)
  796.873 μs (6 allocations: 336 bytes)
  790.946 μs (6 allocations: 336 bytes)
  796.773 μs (6 allocations: 336 bytes)
  790.640 μs (6 allocations: 336 bytes)

# with this PR
julia> for transformA in (identity, adjoint, transpose), transformD in (identity, Adjoint, Transpose)
           @btime mul!($(copy(B)), $(transformA(A)), $(transformD(D)))
           @btime mul!($(copy(B)), $(transformD(D)), $(transformA(A)))
       end
  1.982 μs (2 allocations: 96 bytes)
  2.238 μs (0 allocations: 0 bytes)
  1.954 μs (0 allocations: 0 bytes)
  2.145 μs (0 allocations: 0 bytes)
  1.971 μs (0 allocations: 0 bytes)
  2.133 μs (0 allocations: 0 bytes)
  21.606 μs (2 allocations: 96 bytes)
  22.907 μs (0 allocations: 0 bytes)
  21.615 μs (3 allocations: 112 bytes)
  22.823 μs (1 allocation: 16 bytes)
  21.529 μs (2 allocations: 96 bytes)
  22.920 μs (0 allocations: 0 bytes)
  21.543 μs (2 allocations: 96 bytes)
  22.940 μs (0 allocations: 0 bytes)
  21.546 μs (3 allocations: 112 bytes)
  23.016 μs (1 allocation: 16 bytes)
  21.588 μs (2 allocations: 96 bytes)
  22.967 μs (0 allocations: 0 bytes)
```
I know I keep asking the same question in (almost) all of my PRs: this is a pure performance improvement, all methods (as per the code above) have been working correctly before, so this might be worth backporting?