### PR TITLE
codegen: propagate at-pure macro to llvm

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -30,11 +30,7 @@ julia> .![true false true]
  0  1  0
 ```
 """
-function !(x::Bool)
-    ## We need a better heuristic to detect this automatically
-    @_pure_meta
-    return not_int(x)
-end
+!(x::Bool) = not_int(x)
 
 (~)(x::Bool) = !x
 (&)(x::Bool, y::Bool) = and_int(x, y)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -204,7 +204,7 @@ tail(::Tuple{}) = throw(ArgumentError("Cannot call tail on an empty tuple."))
 tuple_type_head(T::Type) = (@_pure_meta; fieldtype(T::Type{<:Tuple}, 1))
 
 function tuple_type_tail(T::Type)
-    @_pure_meta
+    @_pure_meta # TODO: this method is wrong (and not @pure)
     if isa(T, UnionAll)
         return UnionAll(T.var, tuple_type_tail(T.body))
     elseif isa(T, Union)
@@ -698,7 +698,7 @@ julia> f(Val(true))
 struct Val{x}
 end
 
-Val(x) = (@_pure_meta; Val{x}())
+Val(x) = Val{x}()
 
 """
     invokelatest(f, args...; kwargs...)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -9,8 +9,8 @@
 Return the closest common ancestor of `T` and `S`, i.e. the narrowest type from which
 they both inherit.
 """
-typejoin() = (@_pure_meta; Bottom)
-typejoin(@nospecialize(t)) = (@_pure_meta; t)
+typejoin() = Bottom
+typejoin(@nospecialize(t)) = t
 typejoin(@nospecialize(t), ts...) = (@_pure_meta; typejoin(t, typejoin(ts...)))
 function typejoin(@nospecialize(a), @nospecialize(b))
     @_pure_meta

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -539,31 +539,6 @@ struct type with no fields.
 issingletontype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && isdefined(t, :instance))
 
 """
-    Base.parameter_upper_bound(t::UnionAll, idx)
-
-Determine the upper bound of a type parameter in the underlying datatype.
-This method should generally not be relied upon:
-code instead should usually use static parameters in dispatch to extract these values.
-
-# Examples
-```jldoctest
-julia> struct Foo{T<:AbstractFloat, N}
-           x::Tuple{T, N}
-       end
-
-julia> Base.parameter_upper_bound(Foo, 1)
-AbstractFloat
-
-julia> Base.parameter_upper_bound(Foo, 2)
-Any
-```
-"""
-function parameter_upper_bound(t::UnionAll, idx)
-    @_pure_meta
-    return rewrap_unionall((unwrap_unionall(t)::DataType).parameters[idx], t)
-end
-
-"""
     typeintersect(T, S)
 
 Compute a type that contains the intersection of `T` and `S`. Usually this will be the
@@ -727,13 +702,12 @@ julia> instances(Color)
 function instances end
 
 function to_tuple_type(@nospecialize(t))
-    @_pure_meta
-    if isa(t,Tuple) || isa(t,AbstractArray) || isa(t,SimpleVector)
+    if isa(t, Tuple) || isa(t, AbstractArray) || isa(t, SimpleVector)
         t = Tuple{t...}
     end
-    if isa(t,Type) && t<:Tuple
+    if isa(t, Type) && t <: Tuple
         for p in unwrap_unionall(t).parameters
-            if !(isa(p,Type) || isa(p,TypeVar))
+            if !(isa(p, Type) || isa(p, TypeVar))
                 error("argument tuple type must contain only types")
             end
         end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -94,6 +94,7 @@ function _compute_eltype(t::Type{<:Tuple})
     @_pure_meta
     t isa Union && return promote_typejoin(eltype(t.a), eltype(t.b))
     t´ = unwrap_unionall(t)
+    # TODO: handle Union/UnionAll correctly here
     r = Union{}
     for ti in t´.parameters
         r = promote_typejoin(r, rewrap_unionall(unwrapva(ti), t))

--- a/doc/src/devdocs/ast.md
+++ b/doc/src/devdocs/ast.md
@@ -621,7 +621,8 @@ A (usually temporary) container for holding lowered source code.
     * 0 = inbounds
     * 1,2 = <reserved> inlinehint,always-inline,noinline
     * 3 = <reserved> strict-ieee (strictfp)
-    * 4-6 = <unused>
+    * 4 = <reserved> inferred-pure
+    * 5-6 = <unused>
     * 7 = <reserved> has out-of-band info
 
   * `linetable`

--- a/src/julia.h
+++ b/src/julia.h
@@ -243,8 +243,9 @@ typedef struct _jl_code_info_t {
         // 0 = inbounds
         // 1,2 = <reserved> inlinehint,always-inline,noinline
         // 3 = <reserved> strict-ieee (strictfp)
-        // 4-6 = <unused>
-        // 7 = has out-of-band info
+        // 4 = <reserved> inferred-pure
+        // 5-6 = <unused>
+        // 7 = <reserved> has out-of-band info
     // miscellaneous data:
     jl_value_t *method_for_inference_limit_heuristics; // optional method used during inference
     jl_value_t *linetable; // Table of locations [TODO: make this volatile like slotnames]

--- a/src/llvm-late-gc-lowering.cpp
+++ b/src/llvm-late-gc-lowering.cpp
@@ -1160,16 +1160,20 @@ State LateLowerGCFrame::LocalScan(Function &F) {
                         callee == write_barrier_func || callee->getName() == "memcmp") {
                         continue;
                     }
-                    if (callee->hasFnAttribute(Attribute::ReadNone) ||
-                        callee->hasFnAttribute(Attribute::ReadOnly) ||
-                        callee->hasFnAttribute(Attribute::ArgMemOnly)) {
-                        continue;
+                    if (!callee->hasFnAttribute("thunk")) {
+                        if (callee->hasFnAttribute(Attribute::ReadNone) ||
+                            callee->hasFnAttribute(Attribute::ReadOnly) ||
+                            callee->hasFnAttribute(Attribute::ArgMemOnly)) {
+                            continue;
+                        }
                     }
                 }
-                if (isa<IntrinsicInst>(CI) || CI->hasFnAttr(Attribute::ArgMemOnly) ||
-                    CI->hasFnAttr(Attribute::ReadNone) || CI->hasFnAttr(Attribute::ReadOnly)) {
-                    // Intrinsics are never safepoints.
-                    continue;
+                if (!CI->hasFnAttr("thunk")) {
+                    if (isa<IntrinsicInst>(CI) || CI->hasFnAttr(Attribute::ArgMemOnly) ||
+                        CI->hasFnAttr(Attribute::ReadNone) || CI->hasFnAttr(Attribute::ReadOnly)) {
+                        // Intrinsics are never safepoints.
+                        continue;
+                    }
                 }
                 int SafepointNumber = NoteSafepoint(S, BBS, CI);
                 BBS.HasSafepoint = true;

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -568,10 +568,6 @@ end
 @test !isstructtype(Int)
 @test isstructtype(TLayout)
 
-@test Base.parameter_upper_bound(ReflectionExample, 1) === AbstractFloat
-@test Base.parameter_upper_bound(ReflectionExample, 2) === Any
-@test Base.parameter_upper_bound(ReflectionExample{T, N} where T where N <: Real, 2) === Real
-
 let
     wrapperT(T) = Base.typename(T).wrapper
     @test @inferred wrapperT(ReflectionExample{Float64, Int64}) == ReflectionExample


### PR DESCRIPTION
Adds ReadNone and NoUnwind (and thunk) to call sites marked `@pure` in the source code. This allows LLVM to perform LICM and hoisting on these functions, which can be highly profitable.