### PR TITLE
Support valid paths for the editor

### DIFF
--- a/stdlib/InteractiveUtils/src/editless.jl
+++ b/stdlib/InteractiveUtils/src/editless.jl
@@ -21,9 +21,14 @@ function editor()
         default_editor = "emacs"
     end
     # Note: the editor path can include spaces (if escaped) and flags.
-    args = shell_split(get(ENV,"JULIA_EDITOR", get(ENV,"VISUAL", get(ENV,"EDITOR", default_editor))))
-    isempty(args) && error("editor is empty")
-    return args
+    default_editor = get(ENV,"JULIA_EDITOR", get(ENV,"VISUAL", get(ENV,"EDITOR", default_editor)))
+    isempty(default_editor) && error("editor is empty")
+    if Sys.iswindows()
+        # Allow users to pass a string path for the editor
+        return ispath(default_editor) ? [default_editor] : shell_split(default_editor)
+    else
+        return shell_split(default_editor)
+    end
 end
 
 """


### PR DESCRIPTION
Having spaces in environment variables is valid and is used throughout on Windows.

 For example the following currently fails, but should not. 
`ENV["JULIA_EDITOR"] = "C:\\Program Files\\Microsoft VS Code\\Code.exe"`

This is because currently `shell_split` is called on the string  and this ends up splitting the spaces, which leads to the bug, e.g.:
```julia
julia> Base.shell_split( "C:\\Program Files\\Microsoft VS Code\\Code.exe")
4-element Array{String,1}:
 "C:Program"
 "FilesMicrosoft"
 "VS"
 "CodeCode.exe"
```
Thus the subsequent calls to `editor()` in the `edit(..)` function fail. 
 