### PR TITLE
Improve performance of opnorm for (m x 1) and (1 x n) sparse matrices

### DIFF
--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1030,14 +1030,14 @@ function opnorm(A::SparseMatrixCSC, p::Real=2)
         return float(real(zero(eltype(A))))
     elseif m == 1
         if p == 1
-            return norm(A.nzval, Inf)
+            return norm(nzvalview(A), Inf)
         elseif p == 2
-            return norm(A.nzval, 2)
+            return norm(nzvalview(A), 2)
         elseif p == Inf
-            return norm(A.nzval, 1)
+            return norm(nzvalview(A), 1)
         end
     elseif n == 1 && p in (1, 2, Inf)
-        return norm(A.nzval, p)
+        return norm(nzvalview(A), p)
     else
         Tnorm = typeof(float(real(zero(eltype(A)))))
         Tsum = promote_type(Float64,Tnorm)

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1036,7 +1036,7 @@ function opnorm(A::SparseMatrixCSC, p::Real=2)
         elseif p == Inf
             return norm(A.nzval, 1)
         end
-    elseif n == 1
+    elseif n == 1 && p in (1, 2, Inf)
         return norm(A.nzval, p)
     else
         Tnorm = typeof(float(real(zero(eltype(A)))))

--- a/stdlib/SparseArrays/src/linalg.jl
+++ b/stdlib/SparseArrays/src/linalg.jl
@@ -1028,9 +1028,16 @@ function opnorm(A::SparseMatrixCSC, p::Real=2)
     m, n = size(A)
     if m == 0 || n == 0 || isempty(A)
         return float(real(zero(eltype(A))))
-    elseif m == 1 || n == 1
-        # TODO: compute more efficiently using A.nzval directly
-        return opnorm(Array(A), p)
+    elseif m == 1
+        if p == 1
+            return norm(A.nzval, Inf)
+        elseif p == 2
+            return norm(A.nzval, 2)
+        elseif p == Inf
+            return norm(A.nzval, 1)
+        end
+    elseif n == 1
+        return norm(A.nzval, p)
     else
         Tnorm = typeof(float(real(zero(eltype(A)))))
         Tsum = promote_type(Float64,Tnorm)

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1803,6 +1803,18 @@ end
     resize!(foo.nzval, 5)
     setindex!(foo.nzval, NaN, 5)
     @test norm(foo) == 2.0
+
+    # Test (m x 1) sparse matrix
+    colM = sprandn(10, 1, 0.6)
+    @test opnorm(colM, 1) ≈ opnorm(Array(colM), 1)
+    @test opnorm(colM) ≈ opnorm(Array(colM))
+    @test opnorm(colM, Inf) ≈ opnorm(Array(colM), Inf)
+
+    # Test (1 x n) sparse matrix
+    rowM = sprandn(1, 10, 0.6)
+    @test opnorm(rowM, 1) ≈ opnorm(Array(rowM), 1)
+    @test opnorm(rowM) ≈ opnorm(Array(rowM))
+    @test opnorm(rowM, Inf) ≈ opnorm(Array(rowM), Inf)
 end
 
 @testset "sparse matrix cond" begin

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1809,12 +1809,14 @@ end
     @test opnorm(colM, 1) ≈ opnorm(Array(colM), 1)
     @test opnorm(colM) ≈ opnorm(Array(colM))
     @test opnorm(colM, Inf) ≈ opnorm(Array(colM), Inf)
+    @test_throws ArgumentError opnorm(colM, 3)
 
     # Test (1 x n) sparse matrix
     rowM = sprandn(1, 10, 0.6)
     @test opnorm(rowM, 1) ≈ opnorm(Array(rowM), 1)
     @test opnorm(rowM) ≈ opnorm(Array(rowM))
     @test opnorm(rowM, Inf) ≈ opnorm(Array(rowM), Inf)
+    @test_throws ArgumentError opnorm(rowM, 3)
 end
 
 @testset "sparse matrix cond" begin


### PR DESCRIPTION
This PR improves the performance of `opnorm` for `m x 1` and `1 x n` sparse matrices by using `nzval` directly instead of allocating a dense array first.

To test the performance improvement, I have created two sparse matrices `A` and `B` with `A = sprandn(100_000, 1, 0.6)`, `B = sprandn(1, 100_000, 0.6)` and benchmarked `opnorm` using `BenchmarkTools.jl`. Here are the results:

| command        | Time (master) | Time (PR)   | Allocations (master)  | Allocations (PR)
| ------------- |-------------:| -----:|------:|-------:|
| `opnorm(A, 1)`  | 239.191 μs | 9.361 μs | 781.34 KiB | 16 bytes  |
| `opnorm(A)`  | 188.754 μs | 15.220 μs | 781.34 KiB | 16 bytes  |
| `opnorm(A, Inf)`  | 350.948 μs | 83.312 μs | 781.34 KiB | 16 bytes  |
| `opnorm(B, 1)`  |834.196 μs | 83.252 μs | 781.34 KiB | 16 bytes  |
| `opnorm(B)`  | 675.194 μs | 15.216 μs | 781.34 KiB  | 16 bytes |
| `opnorm(B, Inf)`  | 723.402 μs |9.448 μs | 781.34 KiB | 16 bytes  |

There could be one issue: Resizing `A.nzval` and changing a value of `A.nzval` outside of the array's size does affect the result of `opnorm(A, p)`. If that should not happen, this PR needs some rework. In that case, I would be thankful for some tips. 