### PR TITLE
add function for checking if a matrix is positive semi-definite with a given rank

### DIFF
--- a/stdlib/LinearAlgebra/src/LinearAlgebra.jl
+++ b/stdlib/LinearAlgebra/src/LinearAlgebra.jl
@@ -90,6 +90,7 @@ export
     ishermitian,
     isposdef,
     isposdef!,
+    ispossemdef,
     issuccess,
     issymmetric,
     istril,

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -110,6 +110,7 @@ true
 
 julia> ispossemdef(A, 2)
 false
+```
 """
 function ispossemdef(X::AbstractMatrix, k::Int;
                      atol::Real = 0.0,

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -114,7 +114,7 @@ false
 """
 function ispossemdef(X::AbstractMatrix, k::Int;
                      atol::Real=0.0,
-                     rtol::Real = (minimum(size(X))*eps(real(float(one(eltype(X))))))*iszero(atol))
+                     rtol::Real=(minimum(size(X))*eps(real(float(one(eltype(X))))))*iszero(atol))
     _check_rank_range(k, minimum(size(X)))
     return ishermitian(X) && _k_positive_eigenvalues(X, k, atol, rtol)
 end

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -125,7 +125,7 @@ function ispossemdef(X::Number, k::Int)
 end
 
 function _check_rank_range(k::Int, n::Int)
-    !(0 <= k <= n) && error("rank must be between 0 and $(n) (inclusive)")
+    0 <= k <= n || throw(ArgumentError("rank must be between 0 and $(n) (inclusive)"))
     nothing
 end
 

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -115,13 +115,13 @@ function ispossemdef(X::AbstractMatrix, k::Int;
                      atol::Real = 0.0,
                      rtol::Real = (size(X, 1)*eps(real(float(one(eltype(X))))))*iszero(atol))
     !ishermitian(X) && return false
-    !(0 <= k <= size(X, 1)) && error("rank must be in [0, n]")
+    !(0 <= k <= size(X, 1)) && error("rank must be between 0 and $(size(X, 1)) (inclusive)")
     eigs = eigvals(X)    #  eigenvalues of X in ascending order
     tol = max(atol, rtol * eigs[end])
     return _k_positive_eigenvalues(eigs, k, tol)
 end
 function ispossemdef(X::Number, k::Int)
-    !(0 <= k <= 1) && error("rank must be in [0, n]")
+    !(0 <= k <= 1) && error("rank must be 0 or 1")
     if k == 0
         return !isposdef(X)
     elseif k == 1

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -93,7 +93,7 @@ isposdef(A::AbstractMatrix) =
 isposdef(x::Number) = imag(x)==0 && real(x) > 0
 
 """
-ispossemdef(A, k) -> Bool
+    ispossemdef(A, k) -> Bool
 
 Test whether a matrix is positive semi-definite with specified rank `k` by
 checking that `k` of its eigenvalues are positive and the rest are zero.

--- a/stdlib/LinearAlgebra/src/dense.jl
+++ b/stdlib/LinearAlgebra/src/dense.jl
@@ -112,7 +112,7 @@ julia> ispossemdef(A, 2)
 false
 """
 function ispossemdef(X::AbstractMatrix, k::Int;
-                     atol::Real = 0.0,
+                     atol::Real=0.0,
                      rtol::Real = (minimum(size(X))*eps(real(float(one(eltype(X))))))*iszero(atol))
     _check_rank_range(k, minimum(size(X)))
     return ishermitian(X) && _k_positive_eigenvalues(X, k, atol, rtol)

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -119,7 +119,7 @@ issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(isposdef, D.diag)
 function ispossemdef(D::Diagonal, k::Int)
     !ishermitian(D) && return false
-    !(0 <= k <= length(D.diag)) && error("rank must be in [0, n]")
+    !(0 <= k <= length(D.diag)) && error("rank must be between 0 and $(length(D.diag)) (inclusive)")
     return _k_positive_eigenvalues(sort(real.(D.diag)), k, 0.0)
 end
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -118,9 +118,8 @@ issymmetric(D::Diagonal{<:Number}) = true
 issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(isposdef, D.diag)
 function ispossemdef(D::Diagonal, k::Int)
-    !ishermitian(D) && return false
-    !(0 <= k <= length(D.diag)) && error("rank must be between 0 and $(length(D.diag)) (inclusive)")
-    return _k_positive_eigenvalues(sort(real.(D.diag)), k, 0.0)
+    _check_rank_range(k, length(D.diag))
+    return ishermitian(D) && _k_positive_eigenvalues(sort(real.(D.diag)), k, 0.0)
 end
 
 factorize(D::Diagonal) = D

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -117,6 +117,7 @@ ishermitian(D::Diagonal) = all(ishermitian, D.diag)
 issymmetric(D::Diagonal{<:Number}) = true
 issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(isposdef, D.diag)
+ispossemdef(D::Diagonal, k::Int) = !(0 <= k <= length(D.diag)) ? error("rank must be in [0, n]") : isreal(D.diag) && sum(real.(D.diag) .> 0) == k
 
 factorize(D::Diagonal) = D
 

--- a/stdlib/LinearAlgebra/src/diagonal.jl
+++ b/stdlib/LinearAlgebra/src/diagonal.jl
@@ -117,7 +117,11 @@ ishermitian(D::Diagonal) = all(ishermitian, D.diag)
 issymmetric(D::Diagonal{<:Number}) = true
 issymmetric(D::Diagonal) = all(issymmetric, D.diag)
 isposdef(D::Diagonal) = all(isposdef, D.diag)
-ispossemdef(D::Diagonal, k::Int) = !(0 <= k <= length(D.diag)) ? error("rank must be in [0, n]") : isreal(D.diag) && sum(real.(D.diag) .> 0) == k
+function ispossemdef(D::Diagonal, k::Int)
+    !ishermitian(D) && return false
+    !(0 <= k <= length(D.diag)) && error("rank must be in [0, n]")
+    return _k_positive_eigenvalues(sort(real.(D.diag)), k, 0.0)
+end
 
 factorize(D::Diagonal) = D
 

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -127,7 +127,7 @@ isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0,
 function ispossemdef(A::Union{Eigen,GeneralizedEigen}, k::Int;
                      atol::Real = 0.0,
                      rtol::Real = (length(A.values)*eps(real(float(one(eltype(A.values))))))*iszero(atol))
-    !(0 <= k <= length(A.values)) && error("rank must be in [0, n]")
+    !(0 <= k <= length(A.values)) && error("rank must be between 0 and $(length(A.values)) (inclusive)")
     return isreal(A.values) && _k_positive_eigenvalues(A.values, k, max(atol, rtol * A.values[end]))
 end
 

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -127,8 +127,8 @@ isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0,
 function ispossemdef(A::Union{Eigen,GeneralizedEigen}, k::Int;
                      atol::Real = 0.0,
                      rtol::Real = (length(A.values)*eps(real(float(one(eltype(A.values))))))*iszero(atol))
-    !(0 <= k <= length(A.values)) && error("rank must be between 0 and $(length(A.values)) (inclusive)")
-    return isreal(A.values) && _k_positive_eigenvalues(A.values, k, max(atol, rtol * A.values[end]))
+    _check_rank_range(k, length(A.values))
+    return isreal(A.values) && _k_positive_eigenvalues(real.(A.values), k, atol, rtol)
 end
 
 # pick a canonical ordering to avoid returning eigenvalues in "random" order

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -124,6 +124,13 @@ Base.iterate(S::Union{Eigen,GeneralizedEigen}, ::Val{:done}) = nothing
 
 isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0, A.values)
 
+function ispossemdef(A::Union{Eigen,GeneralizedEigen}, k::Int;
+                     atol::Real = 0.0,
+                     rtol::Real = (length(A.values)*eps(real(float(one(eltype(A.values))))))*iszero(atol))
+    !(0 <= k <= length(A.values)) && error("rank must be in [0, n]")
+    return isreal(A.values) && _k_positive_eigenvalues(A.values, k, max(atol, rtol * A.values[end]))
+end
+
 # pick a canonical ordering to avoid returning eigenvalues in "random" order
 # as is the LAPACK default (for complex λ — LAPACK sorts by λ for the Hermitian/Symmetric case)
 eigsortby(λ::Real) = λ

--- a/stdlib/LinearAlgebra/src/eigen.jl
+++ b/stdlib/LinearAlgebra/src/eigen.jl
@@ -125,8 +125,8 @@ Base.iterate(S::Union{Eigen,GeneralizedEigen}, ::Val{:done}) = nothing
 isposdef(A::Union{Eigen,GeneralizedEigen}) = isreal(A.values) && all(x -> x > 0, A.values)
 
 function ispossemdef(A::Union{Eigen,GeneralizedEigen}, k::Int;
-                     atol::Real = 0.0,
-                     rtol::Real = (length(A.values)*eps(real(float(one(eltype(A.values))))))*iszero(atol))
+                     atol::Real=0.0,
+                     rtol::Real=(length(A.values)*eps(real(float(one(eltype(A.values))))))*iszero(atol))
     _check_rank_range(k, length(A.values))
     return isreal(A.values) && _k_positive_eigenvalues(real.(A.values), k, atol, rtol)
 end

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -55,12 +55,8 @@ bimg  = randn(n,2)/2
 
     @testset "Positive semi-definiteness" begin
 
-        #  not hermitian should return false regardless what k is
         notsymmetric = ainit
         notsquare    = [ainit ainit]
-
-        @test !ispossemdef(notsymmetric, -1)
-        @test !ispossemdef(notsquare, -1)
 
         for truerank in 0:n
 
@@ -74,6 +70,10 @@ bimg  = randn(n,2)/2
                     @test !ispossemdef(A, testrank)
                 end
             end
+            #  not hermitian should return false regardless what k is
+            @test !ispossemdef(notsymmetric, truerank)
+            @test !ispossemdef(notsquare, truerank)
+
             @test_throws ErrorException ispossemdef(A, -1)
             @test_throws ErrorException ispossemdef(A, n + 1)
         end
@@ -902,6 +902,8 @@ end
     @test isposdef(one(elty))
     @test ispossemdef(one(elty), 1)
     @test !ispossemdef(one(elty), 0)
+    @test !ispossemdef(zero(elty), 1)
+    @test ispossemdef(zero(elty), 0)
     @test lyap(one(elty),a) == -a/2
 end
 

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -74,8 +74,8 @@ bimg  = randn(n,2)/2
             @test !ispossemdef(notsymmetric, truerank)
             @test !ispossemdef(notsquare, truerank)
 
-            @test_throws ErrorException ispossemdef(A, -1)
-            @test_throws ErrorException ispossemdef(A, n + 1)
+            @test_throws ArgumentError ispossemdef(A, -1)
+            @test_throws ArgumentError ispossemdef(A, n + 1)
         end
     end
 

--- a/stdlib/LinearAlgebra/test/dense.jl
+++ b/stdlib/LinearAlgebra/test/dense.jl
@@ -52,6 +52,33 @@ bimg  = randn(n,2)/2
             @test isposdef!(copy(apd))
         end
     end
+
+    @testset "Positive semi-definiteness" begin
+
+        #  not hermitian should return false regardless what k is
+        notsymmetric = ainit
+        notsquare    = [ainit ainit]
+
+        @test !ispossemdef(notsymmetric, -1)
+        @test !ispossemdef(notsquare, -1)
+
+        for truerank in 0:n
+
+            X = ainit[:, 1:truerank]
+            A = truerank == 0 ? zeros(eltya, n, n) : X * X'
+
+            for testrank in 0:n
+                if testrank == truerank
+                    @test ispossemdef(A, testrank)
+                else
+                    @test !ispossemdef(A, testrank)
+                end
+            end
+            @test_throws ErrorException ispossemdef(A, -1)
+            @test_throws ErrorException ispossemdef(A, n + 1)
+        end
+    end
+
     @testset "For b containing $eltyb" for eltyb in (Float32, Float64, ComplexF32, ComplexF64, Int)
         binit = eltyb == Int ? rand(1:5, n, 2) : convert(Matrix{eltyb}, eltyb <: Complex ? complex.(breal, bimg) : breal)
         εb = eps(abs(float(one(eltyb))))
@@ -873,6 +900,8 @@ end
 @testset "test ops on Numbers for $elty" for elty in [Float32,Float64,ComplexF32,ComplexF64]
     a = rand(elty)
     @test isposdef(one(elty))
+    @test ispossemdef(one(elty), 1)
+    @test !ispossemdef(one(elty), 0)
     @test lyap(one(elty),a) == -a/2
 end
 

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -359,6 +359,14 @@ end
             @test_throws ErrorException ispossemdef(D, n + 1)
         end
     end
+    D = Diagonal(-areal)
+    for testrank in 0:n
+        @test !ispossemdef(D, testrank)
+    end
+    D = Diagonal(areal + areal*im)
+    for testrank in 0:n
+        @test !ispossemdef(D, testrank)
+    end
 end
 
 @testset "getindex" begin

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -338,6 +338,29 @@ end
     @test !isposdef(Diagonal([[1 0; 0 1], [1 0; 1 1]]))
 end
 
+@testset "ispossemdef" begin
+    areal  = rand(n)/2
+    aimg   = zeros(n)
+    for eltya in (Float32, Float64, ComplexF32, ComplexF64, Int)
+        ainit = eltya == Int ? rand(1:7, n) : convert(Vector{eltya}, eltya <: Complex ? complex.(areal, aimg) : areal)
+
+        for truerank in 0:n
+            d = vcat(ainit[1:truerank], zeros(n - truerank))
+            D = Diagonal( shuffle( d ) )
+
+            for testrank in 0:n
+                if testrank == truerank
+                    @test ispossemdef(D, testrank)
+                else
+                    @test !ispossemdef(D, testrank)
+                end
+            end
+            @test_throws ErrorException ispossemdef(D, -1)
+            @test_throws ErrorException ispossemdef(D, n + 1)
+        end
+    end
+end
+
 @testset "getindex" begin
     d = randn(n)
     D = Diagonal(d)

--- a/stdlib/LinearAlgebra/test/diagonal.jl
+++ b/stdlib/LinearAlgebra/test/diagonal.jl
@@ -355,8 +355,8 @@ end
                     @test !ispossemdef(D, testrank)
                 end
             end
-            @test_throws ErrorException ispossemdef(D, -1)
-            @test_throws ErrorException ispossemdef(D, n + 1)
+            @test_throws ArgumentError ispossemdef(D, -1)
+            @test_throws ArgumentError ispossemdef(D, n + 1)
         end
     end
     D = Diagonal(-areal)

--- a/stdlib/LinearAlgebra/test/eigen.jl
+++ b/stdlib/LinearAlgebra/test/eigen.jl
@@ -41,6 +41,9 @@ aimg  = randn(n,n)/2
             @test det(a) ≈ det(f)
             @test inv(a) ≈ inv(f)
             @test isposdef(a) == isposdef(f)
+            for testrank in 0:n
+                @test ispossemdef(a, testrank) == ispossemdef(f, testrank)
+            end
             @test eigvals(f) === f.values
             @test eigvecs(f) === f.vectors
             @test Array(f) ≈ a


### PR DESCRIPTION
Adds `ispossemdef(A, k)` to check if `A` is positive semi-definite with rank `k`. Does this by checking that exactly `k` of `A`'s eigenvalues are positive, and the rest are zero. 

The procedure for determining if the `k` largest eigenvalues are "meaningfully" positive and the rest are "practically" zero is taken straight from the [`rank`](https://github.com/JuliaLang/julia/blob/9bd5c185dbbcca739225980c8432210efed9fb87/stdlib/LinearAlgebra/src/generic.jl#L837) function. 