### PR TITLE
Add missing test dependency on Random to Statistics

### DIFF
--- a/stdlib/Statistics/Project.toml
+++ b/stdlib/Statistics/Project.toml
@@ -6,7 +6,8 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Random", "Test"]


### PR DESCRIPTION
Statistics uses Random in its tests but doesn't declare it as a test dependency in its Project.toml. Because of this, Statistics fails in the PkgEval 1.2.0-rc2 run. (But oddly enough not for 1.1.1.) Backporting this should fix that.

I'm also marking it for backport to 1.0, because the issue exists there, PkgEval just doesn't seem to complain about it for 1.0.