### PR TITLE
Stop detaching process for precompiling modules.

### DIFF
--- a/base/loading.jl
+++ b/base/loading.jl
@@ -1158,11 +1158,11 @@ function create_expr_cache(input::String, output::String, concrete_deps::typeof(
             eval(Meta.parse(code))
         end
         """
-    io = open(pipeline(detach(`$(julia_cmd()) -O0
-                              --output-ji $output --output-incremental=yes
-                              --startup-file=no --history-file=no --warn-overwrite=yes
-                              --color=$(have_color ? "yes" : "no")
-                              --eval $code_object`), stderr=stderr),
+    io = open(pipeline(`$(julia_cmd()) -O0
+                       --output-ji $output --output-incremental=yes
+                       --startup-file=no --history-file=no --warn-overwrite=yes
+                       --color=$(have_color ? "yes" : "no")
+                       --eval $code_object`, stderr=stderr),
               "w", stdout)
     in = io.in
     try


### PR DESCRIPTION
This means that interrupting the precompilation (ctrl-c) or killing
Julia will kill the process that is doing the precompilation.

This is useful because currently, interrupting julia while it is
precompiling a module will leave that precompilation running in the
background. For large packages that take a long time to precompile, this
can be frustrating, especially because the user most likely interrupted
the precompilation because they _didn't_ want it to happen (e.g. maybe
they realized they forgot to change something in the code).

We've been seeing this at RelationalAI a lot because our module takes so long to build. :'(