### PR TITLE
Support non-BB LLVM build for Emscripten

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -440,6 +440,7 @@ $(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
 $(eval $(call LLVM_PATCH,llvm-r355582-avxminmax)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm-rL349068-llvm-config)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm-6.0-D63688-wasm-isLocal))
+$(eval $(call LLVM_PATCH,llvm-6.0-D64032-cmake-cross))
 endif # LLVM_VER 6.0
 
 ifeq ($(LLVM_VER_SHORT),7.0)

--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -88,6 +88,9 @@ ifneq ($(BUILD_OS),WINNT)
 LLVM_CMAKE += -DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=$(SRCDIR)/NATIVE.cmake
 endif # BUILD_OS != WINNT
 endif # OS == WINNT
+ifeq ($(OS), emscripten)
+LLVM_CMAKE += -DCMAKE_TOOLCHAIN_FILE=$(EMSCRIPTEN)/cmake/Modules/Platform/Emscripten.cmake -DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=$(SRCDIR)/NATIVE.cmake -DLLVM_INCLUDE_TOOLS=OFF -DLLVM_BUILD_TOOLS=OFF -DLLVM_INCLUDE_TESTS=OFF -DLLVM_ENABLE_THREADS=OFF -DLLVM_BUILD_UTILS=OFF
+endif # OS == emscripten
 ifeq ($(USE_LLVM_SHLIB),1)
 # NOTE: we could also --disable-static here (on the condition we link tools
 #       against libLLVM) but there doesn't seem to be a CMake counterpart option
@@ -436,6 +439,7 @@ $(eval $(call LLVM_PATCH,llvm-D51842-win64-byval-cc))
 $(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
 $(eval $(call LLVM_PATCH,llvm-r355582-avxminmax)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm-rL349068-llvm-config)) # remove for 8.0
+$(eval $(call LLVM_PATCH,llvm-6.0-D63688-wasm-isLocal))
 endif # LLVM_VER 6.0
 
 ifeq ($(LLVM_VER_SHORT),7.0)

--- a/deps/patches/llvm-6.0-D63688-wasm-isLocal.patch
+++ b/deps/patches/llvm-6.0-D63688-wasm-isLocal.patch
@@ -1,0 +1,36 @@
+commit e5f9df1ac59925e12588c6edf4a371175090d203
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Sat Jun 22 19:42:28 2019 -0400
+
+    [Support] Fix build under Emscripten
+    
+    Summary:
+    Emscripten's libc doesn't define MNT_LOCAL, thus causing a build
+    failure in the fallback path. However, to the best of my knowledge,
+    it also doesn't support remote file system mounts, so we may simply
+    return `true` here (as we do for e.g. Fuchsia). With this fix, the
+    core LLVM libraries build correctly under emscripten (though some
+    of the tools and utils do not).
+    
+    Reviewers: kripken
+    
+    Subscribers: kristina, llvm-commits
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D63688
+
+diff --git a/lib/Support/Unix/Path.inc b/lib/Support/Unix/Path.inc
+index 2ecb97316c8..ea4c8b9db47 100644
+--- a/lib/Support/Unix/Path.inc
++++ b/lib/Support/Unix/Path.inc
+@@ -380,6 +380,9 @@ static bool is_local_impl(struct STATVFS &Vfs) {
+ #elif defined(__CYGWIN__)
+   // Cygwin doesn't expose this information; would need to use Win32 API.
+   return false;
++#elif defined(__EMSCRIPTEN__)
++  // Emscripten doesn't currently support remote filesystem mounts.
++  return true;
+ #elif defined(__sun)
+   // statvfs::f_basetype contains a null-terminated FSType name of the mounted target
+   StringRef fstype(Vfs.f_basetype);

--- a/deps/patches/llvm-6.0-D64032-cmake-cross.patch
+++ b/deps/patches/llvm-6.0-D64032-cmake-cross.patch
@@ -1,0 +1,69 @@
+commit e83088cbec5e5798651f02e2ff6b11969994cc86
+Author: Keno Fischer <keno@juliacomputing.com>
+Date:   Mon Jul 1 16:43:53 2019 -0400
+
+    With utils disabled, don't build tblgen in cross mode
+    
+    Summary:
+    In cross mode, we build a separate NATIVE tblgen that runs on the
+    host and is used during the build. Separately, we have a flag that
+    disables building all executables in utils/. Of course generally,
+    this doesn't turn off tblgen, since we need that during the build.
+    In cross mode, however, that tblegen is useless since we never
+    actually use it. Furthermore, it can be actively problematic if the
+    cross toolchain doesn't like building executables for whatever reason.
+    And even if building executables works fine, we can at least save
+    compile time by omitting it from the target build. There's two changes
+    needed to make this happen:
+    - Stop creating a dependency from the native tool to the target tool.
+      No such dependency is required for a correct build, so I'm not entirely
+      sure why it was there in the first place.
+    - If utils were disabled on the CMake command line and we're in cross mode,
+      respect that by excluding it from the install target (using EXCLUDE_FROM_ALL).
+    
+    Reviewers: smeenai, compnerd, aganea, pzheng
+    
+    Subscribers: mgorny, llvm-commits
+    
+    Tags: #llvm
+    
+    Differential Revision: https://reviews.llvm.org/D64032
+
+diff --git a/cmake/modules/TableGen.cmake b/cmake/modules/TableGen.cmake
+index d1afcb42f9d..095b316d627 100644
+--- a/cmake/modules/TableGen.cmake
++++ b/cmake/modules/TableGen.cmake
+@@ -127,9 +127,6 @@ macro(add_tablegen target project)
+     set(LLVM_ENABLE_OBJLIB ON)
+   endif()
+ 
+-  add_llvm_executable(${target} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
+-  set(LLVM_LINK_COMPONENTS ${${target}_OLD_LLVM_LINK_COMPONENTS})
+-
+   set(${project}_TABLEGEN "${target}" CACHE
+       STRING "Native TableGen executable. Saves building one when cross-compiling.")
+ 
+@@ -160,15 +157,22 @@ macro(add_tablegen target project)
+                                     CONFIGURATION Release)
+       add_custom_command(OUTPUT ${${project}_TABLEGEN_EXE}
+         COMMAND ${tblgen_build_cmd}
+-        DEPENDS CONFIGURE_LLVM_NATIVE ${target}
++        DEPENDS CONFIGURE_LLVM_NATIVE
+         WORKING_DIRECTORY ${LLVM_NATIVE_BUILD}
+         COMMENT "Building native TableGen..."
+         USES_TERMINAL)
+       add_custom_target(${project}-tablegen-host DEPENDS ${${project}_TABLEGEN_EXE})
+       set(${project}_TABLEGEN_TARGET ${project}-tablegen-host PARENT_SCOPE)
++
++      if ( NOT LLVM_BUILD_UTILS )
++        set(EXCLUDE_FROM_ALL ON)
++      endif()
+     endif()
+   endif()
+ 
++  add_llvm_executable(${target} DISABLE_LLVM_LINK_LLVM_DYLIB ${ARGN})
++  set(LLVM_LINK_COMPONENTS ${${target}_OLD_LLVM_LINK_COMPONENTS})
++
+   if (${project} STREQUAL LLVM AND NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+     if(${target} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR
+         NOT LLVM_DISTRIBUTION_COMPONENTS)


### PR DESCRIPTION
When targeting Emscripten/wasm, we were in the odd position that
we had BinaryBuilder support, but not in-tree support for building
LLVM. Unfortunately, the BinaryBuilder version has recently stopped
working due to ABI changes in Emscripten. Use that as an opportunity
to backfill the requisite definitions to make an in-tree build of
LLVM work on Emscripten.