### PR TITLE
Carry LLVM patch that limits llvm-config flags

### DIFF
--- a/deps/llvm.mk
+++ b/deps/llvm.mk
@@ -431,6 +431,7 @@ endif
 $(eval $(call LLVM_PATCH,llvm-D51842-win64-byval-cc))
 $(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
 $(eval $(call LLVM_PATCH,llvm-r355582-avxminmax)) # remove for 8.0
+$(eval $(call LLVM_PATCH,llvm-rL349068-llvm-config)) # remove for 8.0
 endif # LLVM_VER 6.0
 
 ifeq ($(LLVM_VER_SHORT),7.0)
@@ -445,6 +446,7 @@ $(eval $(call LLVM_PATCH,llvm-7.0-D50167-scev-umin))
 $(eval $(call LLVM_PATCH,llvm7-windows-race))
 $(eval $(call LLVM_PATCH,llvm7-D51842-win64-byval-cc)) # remove for 8.0
 $(eval $(call LLVM_PATCH,llvm-D57118-powerpc))
+$(eval $(call LLVM_PATCH,llvm-rL349068-llvm-config)) # remove for 8.0
 endif # LLVM_VER 7.0
 
 ifeq ($(LLVM_VER_SHORT),8.0)

--- a/deps/patches/llvm-rL349068-llvm-config.patch
+++ b/deps/patches/llvm-rL349068-llvm-config.patch
@@ -1,0 +1,86 @@
+commit befe7b1ade08aad7a048ac5ed2d03b92605977a7
+Author: Tom Stellard <tstellar@redhat.com>
+Date:   Thu Dec 13 18:21:23 2018 +0000
+
+    Don't add unnecessary compiler flags to llvm-config output
+    
+    Summary:
+    llvm-config --cxxflags --cflags, should only output the minimal flags
+    required to link against the llvm libraries.  They currently contain
+    all flags used to compile llvm including flags like -g, -pedantic,
+    -Wall, etc, which users may not always want.
+    
+    This changes the llvm-config output to only include flags that have been
+    explictly added to the COMPILE_FLAGS property of the llvm-config target
+    by the llvm build system.
+    
+    llvm.org/PR8220
+    
+    Output from llvm-config when running cmake with:
+    cmake -G Ninja .. -DCMAKE_CXX_FLAGS=-funroll-loops
+    
+    Before:
+    
+    --cppflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include
+                -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+    --cflags:   -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include
+                -fPIC -Werror=date-time -Wall -Wextra -Wno-unused-parameter -Wwrite-strings \
+                -Wno-missing-field-initializers -pedantic -Wno-long-long -Wimplicit-fallthrough \
+                -Wno-comment -fdiagnostics-color -g -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS \
+                -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+    --cxxflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include\
+                -funroll-loops -fPIC -fvisibility-inlines-hidden -Werror=date-time -std=c++11 -Wall \
+                -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wno-missing-field-initializers \
+                -pedantic -Wno-long-long -Wimplicit-fallthrough -Wno-maybe-uninitialized \
+                -Wno-class-memaccess -Wno-noexcept-type -Wdelete-non-virtual-dtor -Wno-comment \
+                -fdiagnostics-color -g  -fno-exceptions -fno-rtti -D_GNU_SOURCE -D_DEBUG \
+                -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS"
+    
+    After:
+    
+    --cppflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include \
+                -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+    --cflags:   -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include \
+                -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+    --cxxflags: -I$HEADERS_DIR/llvm/include -I$HEADERS_DIR/llvm/build/include \
+                 -std=c++11   -fno-exceptions -fno-rtti \
+                 -D_GNU_SOURCE -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
+    
+    Reviewers: sylvestre.ledru, infinity0, mgorny
+    
+    Reviewed By: sylvestre.ledru, mgorny
+    
+    Subscribers: mgorny, dmgreen, llvm-commits
+    
+    Differential Revision: https://reviews.llvm.org/D55391
+    
+    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@349068 91177308-0d34-0410-b5e6-96231b3b80d8
+
+diff --git a/tools/llvm-config/CMakeLists.txt b/tools/llvm-config/CMakeLists.txt
+index a0bd36c3731..a7db17386fb 100644
+--- a/tools/llvm-config/CMakeLists.txt
++++ b/tools/llvm-config/CMakeLists.txt
+@@ -29,12 +29,20 @@ string(REPLACE ";" " " SYSTEM_LIBS "${SYSTEM_LIBS}")
+ # Fetch target specific compile options, e.g. RTTI option
+ get_property(COMPILE_FLAGS TARGET llvm-config PROPERTY COMPILE_FLAGS)
+ 
++# The language standard potentially affects the ABI/API of LLVM, so we want
++# to make sure it is reported by llvm-config.
++# NOTE: We don't want to start extracting any random C/CXX flags that the
++# user may add that could affect the ABI.  We only want to extract flags
++# that have been added by the LLVM build system.
++string(REGEX MATCH "-std=[^ ]\+" LLVM_CXX_STD_FLAG ${CMAKE_CXX_FLAGS})
++string(REGEX MATCH "-std=[^ ]\+" LLVM_C_STD_FLAG ${CMAKE_C_FLAGS})
++
+ # Use configure_file to create BuildVariables.inc.
+ set(LLVM_SRC_ROOT ${LLVM_MAIN_SRC_DIR})
+ set(LLVM_OBJ_ROOT ${LLVM_BINARY_DIR})
+-set(LLVM_CPPFLAGS "${CMAKE_CPP_FLAGS} ${CMAKE_CPP_FLAGS_${uppercase_CMAKE_BUILD_TYPE}} ${LLVM_DEFINITIONS}")
+-set(LLVM_CFLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_${uppercase_CMAKE_BUILD_TYPE}} ${LLVM_DEFINITIONS}")
+-set(LLVM_CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_${uppercase_CMAKE_BUILD_TYPE}} ${COMPILE_FLAGS} ${LLVM_DEFINITIONS}")
++set(LLVM_CPPFLAGS "${LLVM_DEFINITIONS}")
++set(LLVM_CFLAGS "${LLVM_C_STD_FLAG} ${LLVM_DEFINITIONS}")
++set(LLVM_CXXFLAGS "${LLVM_CXX_STD_FLAG} ${COMPILE_FLAGS} ${LLVM_DEFINITIONS}")
+ set(LLVM_BUILD_SYSTEM cmake)
+ set(LLVM_HAS_RTTI ${LLVM_CONFIG_HAS_RTTI})
+ set(LLVM_DYLIB_VERSION "${LLVM_VERSION_MAJOR}${LLVM_VERSION_SUFFIX}")


### PR DESCRIPTION
This is an LLVM 6.0/7.0 backport of a patch that changes which flags
llvm-config passes. This shouldn't matter much for most uses cases,
but it's useful for two reasons:
1) It makes the behavior of llvm-config consistent between all the LLVM
   versions we support, making it easier for find any problems with our
   Makefile.
2) It prevents any flags meant for LLVM only from creeping into the build
   of our .cpp files (there isn't usually a need for this, but I needed
   to be able to do this when trying to target wasm)