### PR TITLE
Prevent download on windows picking up rogue curl executable

### DIFF
--- a/base/download.jl
+++ b/base/download.jl
@@ -28,7 +28,7 @@ function find_curl()
         "/usr/bin/curl"
     elseif Sys.iswindows() && Sys.isexecutable(joinpath(get(ENV, "SYSTEMROOT", "C:\\Windows"), "System32\\curl.exe"))
         joinpath(get(ENV, "SYSTEMROOT", "C:\\Windows"), "System32\\curl.exe")
-    elseif Sys.which("curl") !== nothing
+    elseif !Sys.iswindows() && Sys.which("curl") !== nothing
         "curl"
     else
         nothing

--- a/base/download.jl
+++ b/base/download.jl
@@ -24,10 +24,6 @@ if Sys.iswindows()
 end
 
 function find_curl()
-    if Sys.iswindows()
-        @show Sys.which("curl")
-        Sys.which("curl") !== nothing && run(`$(Sys.which("curl")) -V`)
-    end
     if Sys.isapple() && Sys.isexecutable("/usr/bin/curl")
         "/usr/bin/curl"
     elseif Sys.iswindows() && Sys.isexecutable(joinpath(get(ENV, "SYSTEMROOT", "C:\\Windows"), "System32\\curl.exe"))

--- a/base/download.jl
+++ b/base/download.jl
@@ -24,6 +24,10 @@ if Sys.iswindows()
 end
 
 function find_curl()
+    if Sys.iswindows()
+        @show Sys.which("curl")
+        Sys.which("curl") !== nothing && run(`$(Sys.which("curl")) -V`)
+    end
     if Sys.isapple() && Sys.isexecutable("/usr/bin/curl")
         "/usr/bin/curl"
     elseif Sys.iswindows() && Sys.isexecutable(joinpath(get(ENV, "SYSTEMROOT", "C:\\Windows"), "System32\\curl.exe"))


### PR DESCRIPTION
Checking if this is the cause of recent failures on buildbots