### PR TITLE
Changed signature of writedlm in documentation, since it looked like …

### DIFF
--- a/stdlib/DelimitedFiles/src/DelimitedFiles.jl
+++ b/stdlib/DelimitedFiles/src/DelimitedFiles.jl
@@ -791,7 +791,7 @@ function writedlm(fname::AbstractString, a, dlm; opts...)
 end
 
 """
-    writedlm(f, A, delim='\\t'; opts)
+    writedlm(f, A, delim; opts)
 
 Write `A` (a vector, matrix, or an iterable collection of iterable rows) as text to `f`
 (either a filename string or an `IO` stream) using the given delimiter


### PR DESCRIPTION
…'delim' is a keyword argument, and it isn't.
(I couldn't get `make docs` to work, sorry about that.)