### PR TITLE
Improve how some kind of Expr are displayed by the show method

### DIFF
--- a/base/show.jl
+++ b/base/show.jl
@@ -1520,22 +1520,9 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::In
     elseif head === :quote && nargs == 1 && isa(args[1], Symbol)
         show_unquoted_quote_expr(io, args[1]::Symbol, indent, 0, quote_level+1)
     elseif head === :quote && nargs == 1 && Meta.isexpr(args[1], :block)
-        if length(args[1].args) == 1
-            # one argument: Expr(:quote, Expr(:block, a_single_arg))
-            if isa(args[1].args[1], Symbol)
-                show_unquoted_quote_expr(io, args[1].args[1]::Symbol, indent,
-                                         0, quote_level+1)
-            else
-                print(io, ":(")
-                show_unquoted(io, args[1].args[1], indent+2, 0, quote_level+1)
-                print(io, ")")
-            end
-        else
-            # multiple arguments: Expr(:quote, Expr(:block, many_args...))
-            show_block(io, "quote", Expr(:quote, args[1].args...), indent,
-                       quote_level+1)
-            print(io, "end")
-        end
+        show_block(io, "quote", Expr(:quote, args[1].args...), indent,
+                   quote_level+1)
+        print(io, "end")
     elseif head === :quote && nargs == 1
         print(io, ":(")
         show_unquoted(io, args[1], indent+2, 0, quote_level+1)

--- a/base/show.jl
+++ b/base/show.jl
@@ -766,7 +766,7 @@ end
 show(io::IO, t::Tuple) = show_delim_array(io, t, '(', ',', ')', true)
 show(io::IO, v::SimpleVector) = show_delim_array(io, v, "svec(", ',', ')', false)
 
-show(io::IO, s::Symbol) = show_unquoted_quote_expr(io, s, 0, 0)
+show(io::IO, s::Symbol) = show_unquoted_quote_expr(io, s, 0, 0, 0)
 
 ## Abstract Syntax Tree (AST) printing ##
 
@@ -799,10 +799,11 @@ const ExprNode = Union{Expr, QuoteNode, Slot, LineNumberNode, SSAValue,
 # precedence level of 0 (the fourth argument). The top-level print and show
 # methods use a precedence of -1 to specially allow space-separated macro syntax
 print(        io::IO, ex::ExprNode)    = (show_unquoted(io, ex, 0, -1); nothing)
-show(         io::IO, ex::ExprNode)    = show_unquoted_quote_expr(io, ex, 0, -1)
+show(         io::IO, ex::ExprNode)    = show_unquoted_quote_expr(io, ex, 0, -1, 0)
 show_unquoted(io::IO, ex)              = show_unquoted(io, ex, 0, 0)
 show_unquoted(io::IO, ex, indent::Int) = show_unquoted(io, ex, indent, 0)
 show_unquoted(io::IO, ex, ::Int,::Int) = show(io, ex)
+show_unquoted(io::IO, ex, indent::Int, prec::Int, ::Int) = show_unquoted(io, ex, indent, prec)
 
 ## AST printing constants ##
 
@@ -813,7 +814,7 @@ const uni_ops = Set{Symbol}([:(+), :(-), :(!), :(¬), :(~), :(<:), :(>:), :(√)
 const expr_infix_wide = Set{Symbol}([
     :(=), :(+=), :(-=), :(*=), :(/=), :(\=), :(^=), :(&=), :(|=), :(÷=), :(%=), :(>>>=), :(>>=), :(<<=),
     :(.=), :(.+=), :(.-=), :(.*=), :(./=), :(.\=), :(.^=), :(.&=), :(.|=), :(.÷=), :(.%=), :(.>>>=), :(.>>=), :(.<<=),
-    :(&&), :(||), :(<:), :($=), :(⊻=)])
+    :(&&), :(||), :(<:), :($=), :(⊻=), :(>:)])
 const expr_infix = Set{Symbol}([:(:), :(->), Symbol("::")])
 const expr_infix_any = union(expr_infix, expr_infix_wide)
 const expr_calls  = Dict(:call => ('(',')'), :calldecl => ('(',')'),
@@ -955,36 +956,36 @@ show_linenumber(io::IO, line, file) = print(io, "#= ", file, ":", line, " =#")
 show_linenumber(io::IO, line, file::Nothing) = show_linenumber(io, line)
 
 # show a block, e g if/for/etc
-function show_block(io::IO, head, args::Vector, body, indent::Int)
+function show_block(io::IO, head, args::Vector, body, indent::Int, quote_level::Int)
     print(io, head)
     if !isempty(args)
         print(io, ' ')
         if head === :elseif
-            show_list(io, args, " ", indent)
+            show_list(io, args, " ", indent, 0, quote_level)
         else
-            show_list(io, args, ", ", indent)
+            show_list(io, args, ", ", indent, 0, quote_level)
         end
     end
 
     ind = head === :module || head === :baremodule ? indent : indent + indent_width
-    exs = is_expr(body, :block) ? body.args : Any[body]
+    exs = (is_expr(body, :block) || is_expr(body, :quote)) ? body.args : Any[body]
     for ex in exs
         print(io, '\n', " "^ind)
-        show_unquoted(io, ex, ind, -1)
+        show_unquoted(io, ex, ind, -1, quote_level)
     end
     print(io, '\n', " "^indent)
 end
-show_block(io::IO,head,    block,i::Int) = show_block(io,head, [], block,i)
-function show_block(io::IO, head, arg, block, i::Int)
-    if is_expr(arg, :block)
-        show_block(io, head, arg.args, block, i)
+show_block(io::IO,head,    block,i::Int, quote_level::Int) = show_block(io,head, [], block,i, quote_level)
+function show_block(io::IO, head, arg, block, i::Int, quote_level::Int)
+    if is_expr(arg, :block) || is_expr(arg, :quote)
+        show_block(io, head, arg.args, block, i, quote_level)
     else
-        show_block(io, head, Any[arg], block, i)
+        show_block(io, head, Any[arg], block, i, quote_level)
     end
 end
 
 # show an indented list
-function show_list(io::IO, items, sep, indent::Int, prec::Int=0, enclose_operators::Bool=false)
+function show_list(io::IO, items, sep, indent::Int, prec::Int=0, quote_level::Int=0, enclose_operators::Bool=false)
     n = length(items)
     n == 0 && return
     indent += indent_width
@@ -997,28 +998,28 @@ function show_list(io::IO, items, sep, indent::Int, prec::Int=0, enclose_operato
               (item isa Real && item < 0))) ||
               (enclose_operators && item isa Symbol && isoperator(item))
         parens && print(io, '(')
-        show_unquoted(io, item, indent, parens ? 0 : prec)
+        show_unquoted(io, item, indent, parens ? 0 : prec, quote_level)
         parens && print(io, ')')
         first = false
     end
 end
 # show an indented list inside the parens (op, cl)
-function show_enclosed_list(io::IO, op, items, sep, cl, indent, prec=0, encl_ops=false)
+function show_enclosed_list(io::IO, op, items, sep, cl, indent, prec=0, quote_level=0, encl_ops=false)
     print(io, op)
-    show_list(io, items, sep, indent, prec, encl_ops)
+    show_list(io, items, sep, indent, prec, quote_level, encl_ops)
     print(io, cl)
 end
 
 # show a normal (non-operator) function call, e.g. f(x, y) or A[z]
-function show_call(io::IO, head, func, func_args, indent)
+function show_call(io::IO, head, func, func_args, indent, quote_level)
     op, cl = expr_calls[head]
     if (isa(func, Symbol) && func !== :(:) && !(head === :. && isoperator(func))) ||
             (isa(func, Expr) && (func.head === :. || func.head === :curly || func.head === :macroname)) ||
             isa(func, GlobalRef)
-        show_unquoted(io, func, indent)
+        show_unquoted(io, func, indent, 0, quote_level)
     else
         print(io, '(')
-        show_unquoted(io, func, indent)
+        show_unquoted(io, func, indent, 0, quote_level)
         print(io, ')')
     end
     if head === :(.)
@@ -1026,12 +1027,12 @@ function show_call(io::IO, head, func, func_args, indent)
     end
     if !isempty(func_args) && isa(func_args[1], Expr) && func_args[1].head === :parameters
         print(io, op)
-        show_list(io, func_args[2:end], ", ", indent)
+        show_list(io, func_args[2:end], ", ", indent, 0, quote_level)
         print(io, "; ")
-        show_list(io, func_args[1].args, ", ", indent)
+        show_list(io, func_args[1].args, ", ", indent, 0, quote_level)
         print(io, cl)
     else
-        show_enclosed_list(io, op, func_args, ", ", cl, indent)
+        show_enclosed_list(io, op, func_args, ", ", cl, indent, 0, quote_level)
     end
 end
 
@@ -1052,7 +1053,7 @@ end
 ## AST printing ##
 
 show_unquoted(io::IO, val::SSAValue, ::Int, ::Int)      = print(io, "%", val.id)
-show_unquoted(io::IO, sym::Symbol, ::Int, ::Int)        = show_sym(io, sym)
+show_unquoted(io::IO, sym::Symbol, ::Int, ::Int)        = show_sym(io, sym, allow_macroname=false)
 show_unquoted(io::IO, ex::LineNumberNode, ::Int, ::Int) = show_linenumber(io, ex.line, ex.file)
 show_unquoted(io::IO, ex::GotoNode, ::Int, ::Int)       = print(io, "goto %", ex.label)
 function show_unquoted(io::IO, ex::GlobalRef, ::Int, ::Int)
@@ -1084,15 +1085,18 @@ end
 
 function show_unquoted(io::IO, ex::QuoteNode, indent::Int, prec::Int)
     if isa(ex.value, Symbol)
-        show_unquoted_quote_expr(io, ex.value, indent, prec)
+        show_unquoted_quote_expr(io, ex.value, indent, prec, 0)
     else
         print(io, "\$(QuoteNode(")
+        # QuoteNode does not allows for interpolation, so if ex.value is an
+        # Expr it should be shown with quote_level equal to zero.
+        # Calling show(io, ex.value) like this implicitly enforce that.
         show(io, ex.value)
         print(io, "))")
     end
 end
 
-function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int)
+function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, prec::Int, quote_level::Int)
     if isa(value, Symbol) && !(value in quoted_syms)
         s = string(value)
         if isidentifier(s) || (isoperator(value) && value !== Symbol("'"))
@@ -1103,17 +1107,17 @@ function show_unquoted_quote_expr(io::IO, @nospecialize(value), indent::Int, pre
         end
     else
         if isa(value,Expr) && value.head === :block
-            show_block(io, "quote", value, indent)
+            show_block(io, "quote", value, indent, quote_level)
             print(io, "end")
         else
             print(io, ":(")
-            show_unquoted(io, value, indent+2, -1)  # +2 for `:(`
+            show_unquoted(io, value, indent+2, -1, quote_level)  # +2 for `:(`
             print(io, ")")
         end
     end
 end
 
-function show_generator(io, ex, indent)
+function show_generator(io, ex, indent, quote_level)
     if ex.head === :flatten
         fg = ex
         ranges = Any[]
@@ -1122,15 +1126,15 @@ function show_generator(io, ex, indent)
             fg = fg.args[1].args[1]
         end
         push!(ranges, fg.args[2:end])
-        show_unquoted(io, fg.args[1], indent)
+        show_unquoted(io, fg.args[1], indent, 0, quote_level)
         for r in ranges
             print(io, " for ")
-            show_list(io, r, ", ", indent)
+            show_list(io, r, ", ", indent, 0, quote_level)
         end
     else
-        show_unquoted(io, ex.args[1], indent)
+        show_unquoted(io, ex.args[1], indent, 0, quote_level)
         print(io, " for ")
-        show_list(io, ex.args[2:end], ", ", indent)
+        show_list(io, ex.args[2:end], ", ", indent, 0, quote_level)
     end
 end
 
@@ -1138,17 +1142,17 @@ function valid_import_path(@nospecialize ex)
     return Meta.isexpr(ex, :(.)) && length((ex::Expr).args) > 0 && all(a->isa(a,Symbol), (ex::Expr).args)
 end
 
-function show_import_path(io::IO, ex)
+function show_import_path(io::IO, ex, quote_level)
     if !isa(ex, Expr)
         show_unquoted(io, ex)
     elseif ex.head === :(:)
-        show_import_path(io, ex.args[1])
+        show_import_path(io, ex.args[1], quote_level)
         print(io, ": ")
         for i = 2:length(ex.args)
             if i > 2
                 print(io, ", ")
             end
-            show_import_path(io, ex.args[i])
+            show_import_path(io, ex.args[i], quote_level)
         end
     elseif ex.head === :(.)
         for i = 1:length(ex.args)
@@ -1158,16 +1162,28 @@ function show_import_path(io::IO, ex)
             show_sym(io, ex.args[i], allow_macroname=(i==length(ex.args)))
         end
     else
-        show_unquoted(io, ex)
+        show_unquoted(io, ex, 0, 0, quote_level)
     end
 end
 
 # Wrap symbols for macro names to allow them to be printed literally
-allow_macroname(ex) = ex isa Symbol && first(string(ex)) == '@' ?
-                      Expr(:macroname, ex) : ex
+function allow_macroname(ex)
+    if (ex isa Symbol && first(string(ex)) == '@') ||
+       (is_expr(ex, :(.)) && length(ex.args) == 2 &&
+        (ex.args[1] isa Symbol || ex.args[1] isa Module) &&
+        (is_expr(ex.args[2], :quote) || ex.args[2] isa QuoteNode))
+       return Expr(:macroname, ex)
+    else
+        ex
+    end
+end
+
+function is_core_macro(arg, macro_name::AbstractString)
+    arg === GlobalRef(Core, Symbol(macro_name))
+end
 
 # TODO: implement interpolated strings
-function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
+function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int, quote_level::Int = 0)
     head, args, nargs = ex.head, ex.args, length(ex.args)
     unhandled = false
     # dot (i.e. "x.y"), but not compact broadcast exps
@@ -1178,7 +1194,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             field = unquoted(args[2])
             parens = !is_quoted(item) && !(item isa Symbol && isidentifier(item)) && !Meta.isexpr(item, :(.))
             parens && print(io, '(')
-            show_unquoted(io, item, indent)
+            show_unquoted(io, item, indent, 0, quote_level)
             parens && print(io, ')')
             # .
             print(io, '.')
@@ -1187,7 +1203,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             quoted = parens || isoperator(field)
             quoted && print(io, ':')
             parens && print(io, '(')
-            show_unquoted(io, field, indent)
+            show_unquoted(io, field, indent, 0, quote_level)
             parens && print(io, ')')
         else
             unhandled = true
@@ -1198,13 +1214,25 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         func_prec = operator_precedence(head)
         head_ = head in expr_infix_wide ? " $head " : head
         if func_prec <= prec
-            show_enclosed_list(io, '(', args, head_, ')', indent, func_prec, true)
+            show_enclosed_list(io, '(', args, head_, ')', indent, func_prec, quote_level, true)
         else
-            show_list(io, args, head_, indent, func_prec, true)
+            show_list(io, args, head_, indent, func_prec, quote_level, true)
         end
 
     # list (i.e. "(1, 2, 3)" or "[1, 2, 3]")
-    elseif haskey(expr_parens, head)               # :tuple/:vcat
+    elseif haskey(expr_parens, head) ||                          # :tuple/:vcat
+        head === :typed_vcat || head === :typed_hcat
+        # print the type and defer to the untyped case
+        if head === :typed_vcat || head === :typed_hcat
+            show_unquoted(io, args[1], indent, prec, quote_level)
+            if head === :typed_vcat
+                head = :vcat
+            else
+                head = :hcat
+            end
+            args = args[2:end]
+            nargs = nargs - 1
+        end
         op, cl = expr_parens[head]
         if head === :vcat || head === :bracescat
             sep = "; "
@@ -1214,7 +1242,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
             sep = ", "
         end
         head !== :row && print(io, op)
-        show_list(io, args, sep, indent)
+        show_list(io, args, sep, indent, 0, quote_level)
         if nargs == 1
             if head === :tuple
                 print(io, ',')
@@ -1238,19 +1266,19 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         if (func === :* &&
             length(func_args)==2 && isa(func_args[1], Real) && isa(func_args[2], Symbol))
             if func_prec <= prec
-                show_enclosed_list(io, '(', func_args, "", ')', indent, func_prec)
+                show_enclosed_list(io, '(', func_args, "", ')', indent, func_prec, quote_level)
             else
-                show_list(io, func_args, "", indent, func_prec)
+                show_list(io, func_args, "", indent, func_prec, quote_level)
             end
 
         # unary operator (i.e. "!z")
         elseif isa(func,Symbol) && func in uni_ops && length(func_args) == 1
-            show_unquoted(io, func, indent)
+            show_unquoted(io, func, indent, 0, quote_level)
             arg1 = func_args[1]
             if isa(arg1, Expr) || (isa(arg1, Symbol) && isoperator(arg1))
                 show_enclosed_list(io, '(', func_args, ", ", ')', indent, func_prec)
             else
-                show_unquoted(io, arg1, indent, func_prec)
+                show_unquoted(io, arg1, indent, func_prec, quote_level)
             end
 
         # binary operator (i.e. "x + y")
@@ -1261,70 +1289,70 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
                 sep = func === :(:) ? "$func" : " $func "
 
                 if func_prec <= prec
-                    show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, true)
+                    show_enclosed_list(io, '(', func_args, sep, ')', indent, func_prec, quote_level, true)
                 else
-                    show_list(io, func_args, sep, indent, func_prec, true)
+                    show_list(io, func_args, sep, indent, func_prec, quote_level, true)
                 end
             elseif na == 1
                 # 1-argument call to normally-binary operator
                 op, cl = expr_calls[head]
                 print(io, "(")
-                show_unquoted(io, func, indent)
+                show_unquoted(io, func, indent, 0, quote_level)
                 print(io, ")")
-                show_enclosed_list(io, op, func_args, ", ", cl, indent)
+                show_enclosed_list(io, op, func_args, ", ", cl, indent, 0, quote_level)
             else
-                show_call(io, head, func, func_args, indent)
+                show_call(io, head, func, func_args, indent, quote_level)
             end
 
         # normal function (i.e. "f(x,y)")
         else
-            show_call(io, head, func, func_args, indent)
+            show_call(io, head, func, func_args, indent, quote_level)
         end
 
     # new expr
     elseif head === :new || head === :splatnew
-        show_enclosed_list(io, "%$head(", args, ", ", ")", indent)
+        show_enclosed_list(io, "%$head(", args, ", ", ")", indent, 0, quote_level)
 
     # other call-like expressions ("A[1,2]", "T{X,Y}", "f.(X,Y)")
     elseif haskey(expr_calls, head) && nargs >= 1  # :ref/:curly/:calldecl/:(.)
         funcargslike = head === :(.) ? args[2].args : args[2:end]
-        show_call(io, head, args[1], funcargslike, indent)
+        show_call(io, head, args[1], funcargslike, indent, quote_level)
 
     # comprehensions
     elseif head === :typed_comprehension && nargs == 2
-        show_unquoted(io, args[1], indent)
+        show_unquoted(io, args[1], indent, 0, quote_level)
         print(io, '[')
-        show_generator(io, args[2], indent)
+        show_generator(io, args[2], indent, quote_level)
         print(io, ']')
 
     elseif head === :comprehension && nargs == 1
         print(io, '[')
-        show_generator(io, args[1], indent)
+        show_generator(io, args[1], indent, quote_level)
         print(io, ']')
 
     elseif (head === :generator && nargs >= 2) || (head === :flatten && nargs == 1)
         print(io, '(')
-        show_generator(io, ex, indent)
+        show_generator(io, ex, indent, quote_level)
         print(io, ')')
 
     elseif head === :filter && nargs == 2
-        show_unquoted(io, args[2], indent)
+        show_unquoted(io, args[2], indent, 0, quote_level)
         print(io, " if ")
-        show_unquoted(io, args[1], indent)
+        show_unquoted(io, args[1], indent, 0, quote_level)
 
     # comparison (i.e. "x < y < z")
     elseif head === :comparison && nargs >= 3 && (nargs&1==1)
         comp_prec = minimum(operator_precedence, args[2:2:end])
         if comp_prec <= prec
-            show_enclosed_list(io, '(', args, " ", ')', indent, comp_prec)
+            show_enclosed_list(io, '(', args, " ", ')', indent, comp_prec, quote_level)
         else
-            show_list(io, args, " ", indent, comp_prec)
+            show_list(io, args, " ", indent, comp_prec, quote_level)
         end
 
     # function calls need to transform the function from :call to :calldecl
     # so that operators are printed correctly
     elseif head === :function && nargs==2 && is_expr(args[1], :call)
-        show_block(io, head, Expr(:calldecl, args[1].args...), args[2], indent)
+        show_block(io, head, Expr(:calldecl, args[1].args...), args[2], indent, quote_level)
         print(io, "end")
 
     elseif (head === :function || head === :macro) && nargs == 1
@@ -1333,47 +1361,51 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, " end")
 
     elseif head === :do && nargs == 2
-        show_unquoted(io, args[1], indent, -1)
+        show_unquoted(io, args[1], indent, -1, quote_level)
         print(io, " do ")
-        show_list(io, args[2].args[1].args, ", ", 0)
+        show_list(io, args[2].args[1].args, ", ", 0, 0, quote_level)
         for stmt in args[2].args[2].args
             print(io, '\n', " "^(indent + indent_width))
-            show_unquoted(io, stmt, indent + indent_width, -1)
+            show_unquoted(io, stmt, indent + indent_width, -1, quote_level)
         end
         print(io, '\n', " "^indent)
         print(io, "end")
 
     # block with argument
     elseif head in (:for,:while,:function,:macro,:if,:elseif,:let) && nargs==2
-        show_block(io, head, args[1], args[2], indent)
+        if Meta.isexpr(args[2], :block)
+            show_block(io, head, args[1], args[2], indent, quote_level)
+        else
+            show_block(io, head, args[1], Expr(:block, args[2]), indent, quote_level)
+        end
         print(io, "end")
 
     elseif (head === :if || head === :elseif) && nargs == 3
-        show_block(io, head, args[1], args[2], indent)
+        show_block(io, head, args[1], args[2], indent, quote_level)
         if isa(args[3],Expr) && args[3].head === :elseif
-            show_unquoted(io, args[3], indent, prec)
+            show_unquoted(io, args[3], indent, prec, quote_level)
         else
-            show_block(io, "else", args[3], indent)
+            show_block(io, "else", args[3], indent, quote_level)
             print(io, "end")
         end
 
     elseif head === :module && nargs==3 && isa(args[1],Bool)
-        show_block(io, args[1] ? :module : :baremodule, args[2], args[3], indent)
+        show_block(io, args[1] ? :module : :baremodule, args[2], args[3], indent, quote_level)
         print(io, "end")
 
     # type declaration
     elseif head === :struct && nargs==3
-        show_block(io, args[1] ? Symbol("mutable struct") : Symbol("struct"), args[2], args[3], indent)
+        show_block(io, args[1] ? Symbol("mutable struct") : Symbol("struct"), args[2], args[3], indent, quote_level)
         print(io, "end")
 
     elseif head === :primitive && nargs == 2
         print(io, "primitive type ")
-        show_list(io, args, ' ', indent)
+        show_list(io, args, ' ', indent, 0, quote_level)
         print(io, " end")
 
     elseif head === :abstract && nargs == 1
         print(io, "abstract type ")
-        show_list(io, args, ' ', indent)
+        show_list(io, args, ' ', indent, 0, quote_level)
         print(io, " end")
 
     # empty return (i.e. "function f() return end")
@@ -1383,12 +1415,12 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     # type annotation (i.e. "::Int")
     elseif head in uni_syms && nargs == 1
         print(io, head)
-        show_unquoted(io, args[1], indent)
+        show_unquoted(io, args[1], indent, 0, quote_level)
 
     # var-arg declaration or expansion
     # (i.e. "function f(L...) end" or "f(B...)")
     elseif head === :(...) && nargs == 1
-        show_unquoted(io, args[1], indent)
+        show_unquoted(io, args[1], indent, 0, quote_level)
         print(io, "...")
 
     elseif (nargs == 0 && head in (:break, :continue))
@@ -1397,33 +1429,73 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     elseif (nargs == 1 && head in (:return, :const)) ||
                           head in (:local,  :global)
         print(io, head, ' ')
-        show_list(io, args, ", ", indent)
+        show_list(io, args, ", ", indent, 0, quote_level)
 
     elseif head === :export
         print(io, head, ' ')
         show_list(io, allow_macroname.(args), ", ", indent)
 
     elseif head === :macrocall && nargs >= 2
-        # first show the line number argument as a comment
-        if isa(args[2], LineNumberNode) || is_expr(args[2], :line)
-            print(io, args[2], ' ')
-        end
-        # Use the functional syntax unless specifically designated with prec=-1
-        # and hide the line number argument from the argument list
-        mname = allow_macroname(args[1])
-        if prec >= 0
-            show_call(io, :call, mname, args[3:end], indent)
+        # handle some special syntaxes
+        # `a b c`
+        if is_core_macro(args[1], "@cmd")
+            print(io, "`", args[3], "`")
+        # 11111111111111111111, 0xfffffffffffffffff, 1111...many digits...
+        elseif is_core_macro(args[1], "@int128_str") ||
+               is_core_macro(args[1], "@uint128_str") ||
+               is_core_macro(args[1], "@big_str")
+            print(io, args[3])
+        # x"y" and x"y"z
+        elseif isa(args[1], Symbol) &&
+               startswith(string(args[1]::Symbol), "@") &&
+               endswith(string(args[1]::Symbol), "_str")
+            s = string(args[1]::Symbol)
+            print(io, s[2:prevind(s,end,4)], "\"", args[3], "\"")
+            if nargs == 4
+                print(io, args[4])
+            end
+        # general case
         else
-            show_args = Vector{Any}(undef, nargs - 1)
-            show_args[1] = mname
-            show_args[2:end] = args[3:end]
-            show_list(io, show_args, ' ', indent)
+            # first show the line number argument as a comment
+            if isa(args[2], LineNumberNode) || is_expr(args[2], :line)
+                print(io, args[2], ' ')
+            end
+            # Use the functional syntax unless specifically designated with
+            # prec=-1 and hide the line number argument from the argument list
+            mname = allow_macroname(args[1])
+            if prec >= 0
+                show_call(io, :call, mname, args[3:end], indent, quote_level)
+            else
+                show_args = Vector{Any}(undef, nargs - 1)
+                show_args[1] = mname
+                show_args[2:end] = args[3:end]
+                show_list(io, show_args, ' ', indent, 0, quote_level)
+            end
         end
 
     elseif head === :macroname && nargs == 1
         arg1 = args[1]
         if arg1 isa Symbol
             show_sym(io, arg1, allow_macroname=true)
+        elseif is_expr(arg1, :(.)) && length(arg1.args) == 2
+            if arg1.args[1] isa Module
+                print(io, '(')
+                print(io, arg1.args[1])
+                print(io, ").")
+            else
+                print(io, arg1.args[1])
+                print(io, '.')
+            end
+            if is_expr(arg1.args[2], :quote)
+                mname = arg1.args[2].args[1]
+            else
+                mname = arg1.args[2].value
+            end
+            if mname isa Symbol
+                show_sym(io, mname, allow_macroname=true)
+            else
+                show_unquoted(io, mname)
+            end
         else
             show_unquoted(io, arg1)
         end
@@ -1432,25 +1504,49 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show_linenumber(io, args...)
 
     elseif head === :try && 3 <= nargs <= 4
-        show_block(io, "try", args[1], indent)
+        show_block(io, "try", args[1], indent, quote_level)
         if is_expr(args[3], :block)
-            show_block(io, "catch", args[2] === false ? Any[] : args[2], args[3], indent)
+            show_block(io, "catch", args[2] === false ? Any[] : args[2], args[3], indent, quote_level)
         end
         if nargs >= 4 && is_expr(args[4], :block)
-            show_block(io, "finally", Any[], args[4], indent)
+            show_block(io, "finally", Any[], args[4], indent, quote_level)
         end
         print(io, "end")
 
     elseif head === :block
-        show_block(io, "begin", ex, indent)
+        show_block(io, "begin", ex, indent, quote_level)
         print(io, "end")
 
     elseif head === :quote && nargs == 1 && isa(args[1], Symbol)
-        show_unquoted_quote_expr(io, args[1]::Symbol, indent, 0)
+        show_unquoted_quote_expr(io, args[1]::Symbol, indent, 0, quote_level+1)
+    elseif head === :quote && nargs == 1 && Meta.isexpr(args[1], :block)
+        if length(args[1].args) == 1
+            # one argument: Expr(:quote, Expr(:block, a_single_arg))
+            if isa(args[1].args[1], Symbol)
+                show_unquoted_quote_expr(io, args[1].args[1]::Symbol, indent,
+                                         0, quote_level+1)
+            else
+                print(io, ":(")
+                show_unquoted(io, args[1].args[1], indent+2, 0, quote_level+1)
+                print(io, ")")
+            end
+        else
+            # multiple arguments: Expr(:quote, Expr(:block, many_args...))
+            show_block(io, "quote", Expr(:quote, args[1].args...), indent,
+                       quote_level+1)
+            print(io, "end")
+        end
+    elseif head === :quote && nargs == 1
+        print(io, ":(")
+        show_unquoted(io, args[1], indent+2, 0, quote_level+1)
+        print(io, ")")
+    elseif head === :quote
+        show_block(io, "quote", ex, indent, quote_level+1)
+        print(io, "end")
 
     elseif head === :gotoifnot && nargs == 2 && isa(args[2], Int)
         print(io, "unless ")
-        show_unquoted(io, args[1], indent, 0)
+        show_unquoted(io, args[1], indent, 0, quote_level)
         print(io, " goto %")
         print(io, args[2]::Int)
 
@@ -1461,16 +1557,20 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         print(io, "nothing")
 
     elseif head === :kw && nargs == 2
-        show_unquoted(io, args[1], indent+indent_width)
+        show_unquoted(io, args[1], indent+indent_width, 0, quote_level)
         print(io, '=')
-        show_unquoted(io, args[2], indent+indent_width)
+        show_unquoted(io, args[2], indent+indent_width, 0, quote_level)
 
     elseif head === :string
         print(io, '"')
         for x in args
             if !isa(x,AbstractString)
                 print(io, "\$(")
-                show_unquoted(io, x)
+                if isa(x,Symbol) && !(x in quoted_syms)
+                    show_sym(io, x)
+                else
+                    show_unquoted(io, x, 0, 0, quote_level)
+                end
                 print(io, ")")
             else
                 escape_string(io, x, "\"\$")
@@ -1478,21 +1578,29 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         end
         print(io, '"')
 
-    elseif (head === :&#= || head === :$=#) && nargs == 1
-        print(io, head)
-        a1 = args[1]
-        parens = (isa(a1,Expr) && a1.head !== :tuple) || (isa(a1,Symbol) && isoperator(a1))
-        parens && print(io, "(")
-        show_unquoted(io, a1)
-        parens && print(io, ")")
+    elseif (head === :& || head === :$) && nargs == 1
+        if head === :$
+            quote_level -= 1
+        end
+        if head === :$ && quote_level < 0
+            unhandled = true
+        else
+            print(io, head)
+            a1 = args[1]
+            parens = (isa(a1,Expr) && (a1.head !== :tuple && a1.head !== :$)) ||
+                     (isa(a1,Symbol) && isoperator(a1))
+            parens && print(io, "(")
+            show_unquoted(io, a1, 0, 0, quote_level)
+            parens && print(io, ")")
+        end
 
     # transpose
     elseif head === Symbol('\'') && nargs == 1
         if isa(args[1], Symbol)
-            show_unquoted(io, args[1])
+            show_unquoted(io, args[1], 0, 0, quote_level)
         else
             print(io, "(")
-            show_unquoted(io, args[1])
+            show_unquoted(io, args[1], 0, 0, quote_level)
             print(io, ")")
         end
         print(io, head)
@@ -1501,20 +1609,23 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
     elseif head === :where && nargs > 1
         parens = 1 <= prec
         parens && print(io, "(")
-        show_unquoted(io, args[1], indent, operator_precedence(:(::)))
+        show_unquoted(io, args[1], indent, operator_precedence(:(::)), quote_level)
         print(io, " where ")
         if nargs == 2
-            show_unquoted(io, args[2], indent, 1)
+            show_unquoted(io, args[2], indent, 1, quote_level)
         else
             print(io, "{")
-            show_list(io, args[2:end], ", ", indent)
+            show_list(io, args[2:end], ", ", indent, 0, quote_level)
             print(io, "}")
         end
         parens && print(io, ")")
 
-    elseif (head === :import || head === :using) && nargs == 1 &&
-            (valid_import_path(args[1]) ||
-             (Meta.isexpr(args[1], :(:)) && length((args[1]::Expr).args) > 1 && all(valid_import_path, (args[1]::Expr).args)))
+    elseif (head === :import || head === :using) &&
+           ((nargs == 1 && (valid_import_path(args[1]) ||
+                           (Meta.isexpr(args[1], :(:)) &&
+                            length((args[1]::Expr).args) > 1 &&
+                            all(valid_import_path, (args[1]::Expr).args)))) ||
+             all(valid_import_path, args))
         print(io, head)
         print(io, ' ')
         first = true
@@ -1523,7 +1634,7 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
                 print(io, ", ")
             end
             first = false
-            show_import_path(io, a)
+            show_import_path(io, a, quote_level)
         end
     elseif head === :meta && nargs >= 2 && args[1] === :push_loc
         print(io, "# meta: location ", join(args[2:end], " "))
@@ -1540,7 +1651,13 @@ function show_unquoted(io::IO, ex::Expr, indent::Int, prec::Int)
         show(io, ex.head)
         for arg in args
             print(io, ", ")
-            show(io, arg)
+            if isa(arg, Expr)
+                print(io, ":(")
+                show_unquoted(io, arg, indent, 0, quote_level+1)
+                print(io, ")")
+            else
+                show(io, arg)
+            end
         end
         print(io, "))")
     end

--- a/doc/src/manual/metaprogramming.md
+++ b/doc/src/manual/metaprogramming.md
@@ -261,14 +261,14 @@ julia> x = :(1 + 2);
 julia> e = quote quote $x end end
 quote
     #= none:1 =#
-    $(Expr(:quote, quote
-    #= none:1 =#
-    $(Expr(:$, :x))
-end))
+    quote
+        #= none:1 =#
+        $x
+    end
 end
 ```
 
-Notice that the result contains `Expr(:$, :x)`, which means that `x` has not been
+Notice that the result contains `$x`, which means that `x` has not been
 evaluated yet.
 In other words, the `$` expression "belongs to" the inner quote expression, and
 so its argument is only evaluated when the inner quote expression is:
@@ -289,14 +289,14 @@ This is done with multiple `$`s:
 julia> e = quote quote $$x end end
 quote
     #= none:1 =#
-    $(Expr(:quote, quote
-    #= none:1 =#
-    $(Expr(:$, :(1 + 2)))
-end))
+    quote
+        #= none:1 =#
+        $(1 + 2)
+    end
 end
 ```
 
-Notice that `:(1 + 2)` now appears in the result instead of the symbol `:x`.
+Notice that `(1 + 2)` now appears in the result instead of the symbol `x`.
 Evaluating this expression yields an interpolated `3`:
 
 ```jldoctest interp1
@@ -553,7 +553,7 @@ julia> macro twostep(arg)
 @twostep (macro with 1 method)
 
 julia> ex = macroexpand(Main, :(@twostep :(1, 2, 3)) );
-I execute at parse time. The argument is: $(Expr(:quote, :((1, 2, 3))))
+I execute at parse time. The argument is: :((1, 2, 3))
 ```
 
 The first call to [`println`](@ref) is executed when [`macroexpand`](@ref) is called. The

--- a/test/show.jl
+++ b/test/show.jl
@@ -58,10 +58,12 @@ function test_repr(x::String)
     # strings get converted to string Exprs by the first show().
     # This could produce a few false positives, but until string
     # interpolation works we don't really have a choice.
+    #
+    # Rectification: comparing x1 and x2 seems to be working
     x1 = Meta.parse(x)
     x2 = eval(Meta.parse(repr(x1)))
     x3 = eval(Meta.parse(repr(x2)))
-    if x3 != x1
+    if ! (x1 == x2 == x3)
         error(string(
             "repr test failed:",
             "\noriginal: ", x,
@@ -69,6 +71,7 @@ function test_repr(x::String)
             "\n\nreparsed: ", x3, "\n", sprint(dump, x3)
             ))
     end
+    @test x1 == x2 == x3
 end
 
 # primitive types
@@ -143,9 +146,29 @@ end
 @test_repr "import A: a, x, y.z"
 @test_repr "import A.B.C: a, x, y.z"
 @test_repr "import ..A: a, x, y.z"
+@test_repr "import A.B, C.D"
 
 @test repr(Expr(:using, :Foo)) == ":(\$(Expr(:using, :Foo)))"
 @test repr(Expr(:using, Expr(:(.), ))) == ":(\$(Expr(:using, :(\$(Expr(:.))))))"
+@test repr(Expr(:import, :Foo)) == ":(\$(Expr(:import, :Foo)))"
+@test repr(Expr(:import, Expr(:(.), ))) == ":(\$(Expr(:import, :(\$(Expr(:.))))))"
+
+@test repr(Expr(:using, Expr(:(.), :A))) == ":(using A)"
+@test repr(Expr(:using, Expr(:(.), :A),
+                        Expr(:(.), :B))) == ":(using A, B)"
+@test repr(Expr(:using, Expr(:(.), :A),
+                        Expr(:(.), :B, :C),
+                        Expr(:(.), :D))) == ":(using A, B.C, D)"
+@test repr(Expr(:using, Expr(:(.), :A, :B),
+                        Expr(:(.), :C, :D))) == ":(using A.B, C.D)"
+@test repr(Expr(:import, Expr(:(.), :A))) == ":(import A)"
+@test repr(Expr(:import, Expr(:(.), :A),
+                         Expr(:(.), :B))) == ":(import A, B)"
+@test repr(Expr(:import, Expr(:(.), :A),
+                         Expr(:(.), :B, :(C)),
+                         Expr(:(.), :D))) == ":(import A, B.C, D)"
+@test repr(Expr(:import, Expr(:(.), :A, :B),
+                         Expr(:(.), :C, :D))) == ":(import A.B, C.D)"
 
 # range syntax
 @test_repr "1:2"
@@ -769,6 +792,21 @@ test_mt(show_f5, "show_f5(A::AbstractArray{T,N}, indices::Vararg{$Int,N})")
 @test_repr "{a b c}"
 @test_repr "{a b; c d}"
 
+# typed vcat and hcat
+@test_repr "T[a]"
+@test_repr "T[a,b]"
+@test_repr "T[a;b;c]"
+@test_repr "T[a b]"
+@test_repr "T[a b;]"
+@test_repr "T[a b c]"
+@test_repr "T[a b; c d]"
+@test_repr repr(Expr(:quote, Expr(:typed_vcat, Expr(:$, :a), 1)))
+@test_repr repr(Expr(:quote, Expr(:typed_hcat, Expr(:$, :a), 1)))
+@test_repr "Expr(:quote, Expr(:typed_vcat, Expr(:\$, :a), 1))"
+@test_repr "Expr(:quote, Expr(:typed_hcat, Expr(:\$, :a), 1))"
+@test repr(Expr(:quote, Expr(:typed_vcat, Expr(:$, :a), 1))) == ":(:(\$a[1;]))"
+@test repr(Expr(:quote, Expr(:typed_hcat, Expr(:$, :a), 1))) == ":(:(\$a[1]))"
+
 # Printing of :(function f end)
 @test sprint(show, :(function f end)) == ":(function f end)"
 @test_repr "function g end"
@@ -789,6 +827,220 @@ end"""
         \$a + \$b
     end
 end"""
+@test repr(Meta.parse(
+"""macro m(a, b)
+    quote
+        \$a + \$b
+    end
+end""")) ==
+"""
+:(macro m(a, b)
+      #= none:2 =#
+      quote
+          #= none:3 =#
+          \$a + \$b
+      end
+  end)"""
+@test repr(Base.remove_linenums!(Meta.parse(
+"""macro m(a, b)
+    quote
+        \$a + \$b
+    end
+end"""))) ==
+"""
+:(macro m(a, b)
+      :(\$a + \$b)
+  end)"""
+@test repr(Meta.parse(
+"""macro m(a, b)
+    :(\$a + \$b)
+end""")) ==
+":(macro m(a, b)\n      #= none:2 =#\n      :(\$a + \$b)\n  end)"
+@test repr(Expr(:macro, Expr(:call, :m, :x), Expr(:quote, Expr(:call, :+, Expr(:($), :x), 1)))) ==
+":(macro m(x)\n      :(\$x + 1)\n  end)"
+
+# nested quotes and interpolations
+@test repr(Meta.parse(
+"""quote
+    quote
+        \$\$x
+    end
+end""")) ==
+"""
+:(quote
+      #= none:2 =#
+      quote
+          #= none:3 =#
+          \$\$x
+      end
+  end)"""
+@test_repr """
+quote
+    #= none:2 =#
+    quote
+        #= none:3 =#
+        \$\$x
+    end
+end"""
+
+# fallback printing + nested quotes and unquotes
+@test_repr repr(Expr(:block, LineNumberNode(0, :none),
+                     Expr(:exotic_head, Expr(:$, :x))))
+@test_repr repr(Expr(:exotic_head, Expr(:call, :+, 1, Expr(:quote, Expr(:$, Expr(:$, :y))))))
+@test_repr repr(Expr(:quote, Expr(:$, Expr(:exotic_head, Expr(:call, :+, 1, Expr(:$, :y))))))
+@test_repr repr(Expr(:$, Expr(:exotic_head, Expr(:call, :+, 1, Expr(:$, :y)))))
+@test_repr "Expr(:block, LineNumberNode(0, :none), Expr(:exotic_head, Expr(:\$, :x)))"
+@test_repr "Expr(:exotic_head, Expr(:call, :+, 1, \$y))"
+@test_repr "Expr(:exotic_head, Expr(:call, :+, 1, \$\$y))"
+@test_repr ":(Expr(:exotic_head, Expr(:call, :+, 1, \$y)))"
+@test_repr ":(:(Expr(:exotic_head, Expr(:call, :+, 1, \$\$y))))"
+@test repr(Expr(:block, LineNumberNode(0, :none),
+                Expr(:exotic_head, Expr(:$, :x)))) ==
+"""
+quote
+    #= none:0 =#
+    \$(Expr(:exotic_head, :(\$x)))
+end"""
+@test repr(Expr(:exotic_head, Expr(:call, :+, 1, :(Expr(:$, :y))))) ==
+    ":(\$(Expr(:exotic_head, :(1 + Expr(:\$, :y)))))"
+@test repr(Expr(:exotic_head, Expr(:call, :+, 1, Expr(:quote, Expr(:$, :y))))) ==
+    ":(\$(Expr(:exotic_head, :(1 + :(\$y)))))"
+@test repr(Expr(:quote, Expr(:exotic_head, Expr(:call, :+, 1, Expr(:$, :y))))) ==
+    ":(:(\$(Expr(:exotic_head, :(1 + \$y)))))"
+@test repr(Expr(:block, Expr(:(=), :y, 2),
+                        Expr(:quote, Expr(:exotic_head,
+                                          Expr(:call, :+, 1, Expr(:$, :y)))))) ==
+"""
+quote
+    y = 2
+    :(\$(Expr(:exotic_head, :(1 + \$y))))
+end"""
+@test repr(eval(Expr(:block, Expr(:(=), :y, 2),
+                        Expr(:quote, Expr(:exotic_head,
+                                          Expr(:call, :+, 1, Expr(:$, :y))))))) ==
+    ":(\$(Expr(:exotic_head, :(1 + 2))))"
+
+# nested quotes and blocks
+@test_repr "Expr(:quote, Expr(:block, :a, :b))"
+# @test_repr repr(Expr(:quote, Expr(:block, :a, :b)))
+@test_repr repr(Expr(:quote, Expr(:block, LineNumberNode(0, :none), :a, LineNumberNode(0, :none), :b)))
+@test repr(Expr(:quote, Expr(:block, :a, :b))) ==
+":(quote
+      a
+      b
+  end)"
+@test_repr "Expr(:quote, Expr(:block, :a))"
+@test_repr repr(Expr(:quote, Expr(:block, :a)))
+@test repr(Expr(:quote, Expr(:block, :a))) == ":(:a)"
+@test_repr "Expr(:quote, Expr(:block, :(a + b)))"
+@test_repr repr(Expr(:quote, Expr(:block, :(a + b))))
+@test repr(Expr(:quote, Expr(:block, :(a + b)))) == ":(:(a + b))"
+
+# QuoteNode + quotes and unquotes
+@test_repr "QuoteNode(\$x)"
+@test_repr "QuoteNode(\$\$x)"
+@test_repr ":(QuoteNode(\$x))"
+@test_repr ":(:(QuoteNode(\$\$x))"
+@test repr(QuoteNode(Expr(:$, :x))) == ":(\$(QuoteNode(:(\$(Expr(:\$, :x))))))"
+@test repr(QuoteNode(Expr(:quote, Expr(:$, :x)))) == ":(\$(QuoteNode(:(:(\$x)))))"
+@test repr(Expr(:quote, QuoteNode(Expr(:$, :x)))) == ":(:(\$(QuoteNode(:(\$(Expr(:\$, :x)))))))"
+
+# unquoting
+@test_repr "\$y"
+@test_repr "\$\$y"
+@test_repr """
+begin
+    # line meta
+    \$y
+end"""
+@test_repr """
+begin
+    # line meta
+    \$\$y
+end"""
+@test_repr ":(\$\$y)"
+@test_repr repr(Expr(:$, :y))
+
+# with reference to https://github.com/JuliaLang/julia/commit/9ef17207d5f99c7a0019cbbe0e58f77e7c4c1d21
+y856739 = 2
+x856739 = :y856739
+z856739 = [:a, :b]
+@test_repr repr(:(:(f($$x856739))))
+@test repr(:(:(f($$x856739)))) == ":(:(f(\$y856739)))"
+@test repr(eval(:(:(f($$x856739))))) == ":(f(2))"
+@test_repr repr(:(:(f($x856739))))
+@test repr(:(:(f($x856739)))) == ":(:(f(\$x856739)))"
+@test repr(eval(:(:(f($x856739))))) == ":(f(y856739))"
+@test_repr repr(:(:(f($(($z856739)...)))))
+@test repr(:(:(f($(($z856739)...))))) == ":(:(f(\$([:a, :b]...))))"
+@test repr(eval(:(:(f($(($z856739)...)))))) == ":(f(a, b))"
+
+# string interpolation, if this is what the comment in test_rep function
+# definition talk about
+@test repr(Expr(:string, "foo", :x, "bar")) == ":(\"foo\$(x)bar\")"
+@test Meta.parse(string(Expr(:string, "foo", :x, "bar"))) == Expr(:string, "foo", :x, "bar")
+@test repr(Meta.parse("\"foo\$(x)bar\"")) == ":(\"foo\$(x)bar\")"
+@test_repr "\"foo\$(x)bar\""
+
+# Printing of macrocall expressions with qualified macroname argument
+@test sprint(show, Expr(:macrocall,
+                   GlobalRef(Base, Symbol("@m")),
+                   LineNumberNode(0, :none), :a, :b)) ==
+    ":(#= none:0 =# Base.@m a b)"
+@test sprint(show, Expr(:macrocall,
+                   Expr(:(.), :Base, Expr(:quote, Symbol("@m"))),
+                   LineNumberNode(0, :none), :a, :b)) ==
+    ":(#= none:0 =# Base.@m a b)"
+@test sprint(show, Expr(:macrocall,
+                   Expr(:(.), Base, Expr(:quote, Symbol("@m"))),
+                   LineNumberNode(0, :none), :a, :b)) ==
+    ":(#= none:0 =# (Base).@m a b)"
+@test sprint(show, Expr(:macrocall,
+                   Expr(:(.), :Base, QuoteNode(Symbol("@m"))),
+                   LineNumberNode(0, :none), :a, :b)) ==
+    ":(#= none:0 =# Base.@m a b)"
+@test sprint(show, Expr(:macrocall,
+                   Expr(:(.), Base, QuoteNode(Symbol("@m"))),
+                   LineNumberNode(0, :none), :a, :b)) ==
+    ":(#= none:0 =# (Base).@m a b)"
+
+# Printing of special macro syntaxes
+# `a b c`
+@test sprint(show, Expr(:macrocall,
+                   GlobalRef(Core, Symbol("@cmd")),
+                   LineNumberNode(0, :none), "a b c")) == ":(`a b c`)"
+@test sprint(show, Expr(:macrocall,
+                        Expr(:(.), :Core, Expr(:quote, Symbol("@cmd"))),
+                        LineNumberNode(0, :none), "a b c")) == ":(#= none:0 =# Core.@cmd \"a b c\")"
+@test sprint(show, Expr(:macrocall,
+                        Expr(:(.), Core, Expr(:quote, Symbol("@cmd"))),
+                        LineNumberNode(0, :none), "a b c")) == ":(#= none:0 =# (Core).@cmd \"a b c\")"
+@test sprint(show, Expr(:macrocall,
+                        Expr(:(.), :Core, QuoteNode(Symbol("@cmd"))),
+                        LineNumberNode(0, :none), "a b c")) == ":(#= none:0 =# Core.@cmd \"a b c\")"
+@test sprint(show, Expr(:macrocall,
+                        Expr(:(.), Core, QuoteNode(Symbol("@cmd"))),
+                        LineNumberNode(0, :none), "a b c")) == ":(#= none:0 =# (Core).@cmd \"a b c\")"
+@test_repr "`a b c`"
+@test sprint(show, Meta.parse("`a b c`")) == ":(`a b c`)"
+# a"b" and a"b"c
+@test_repr "a\"b\""
+@test_repr "a\"b\"c"
+@test_repr "aa\"b\""
+@test_repr "a\"b\"cc"
+@test sprint(show, Meta.parse("a\"b\"")) == ":(a\"b\")"
+@test sprint(show, Meta.parse("a\"b\"c")) == ":(a\"b\"c)"
+@test sprint(show, Meta.parse("aa\"b\"")) == ":(aa\"b\")"
+@test sprint(show, Meta.parse("a\"b\"cc")) == ":(a\"b\"cc)"
+# 11111111111111111111, 0xfffffffffffffffff, 1111...many digits...
+@test sprint(show, Meta.parse("11111111111111111111")) == ":(11111111111111111111)"
+# @test_repr "Base.@int128_str \"11111111111111111111\""
+@test sprint(show, Meta.parse("Base.@int128_str \"11111111111111111111\"")) ==
+    ":(#= none:1 =# Base.@int128_str \"11111111111111111111\")"
+@test sprint(show, Meta.parse("11111111111111111111")) == ":(11111111111111111111)"
+@test sprint(show, Meta.parse("0xfffffffffffffffff")) == ":(0xfffffffffffffffff)"
+@test sprint(show, Meta.parse("11111111111111111111111111111111111111111111111111111111111111")) ==
+":(11111111111111111111111111111111111111111111111111111111111111)"
 
 # Issue #15765 printing of continue and break
 @test sprint(show, :(continue)) == ":(continue)"


### PR DESCRIPTION
The improvements concerns the following Expr:
- typed bracket expressions as
`T[a b]
T[a b; c d]`
- quote blocks + unquoting
`quote    
    $a+$b    
end`
-"special macros"
`` `a b c`    
r"foo"    
foo"bar"zot``
-"long" numeric literals, which are implemented as macros
`11111111111111111111    
0xfffffffffffffffff    
11111111111111111111111111111111111111111111111111111111111111`


Also, now the function test_repr in test/show.jl can (and indeed does) directly and successfully compare
`Meta.parse(x)`
with
`eval(Meta.parse(repr(Meta.parse(x))))`
Notice that I'm not to be credited with the latter achievement, since master branch also could have
(but did not) directly and successfully use the same comparison. I suppose the person to be credited
with solving the issue preventing this way of testing to succeed failed to actually update the test routine.
