### PR TITLE
reduce usage of _pure_meta

### DIFF
--- a/base/bool.jl
+++ b/base/bool.jl
@@ -30,11 +30,7 @@ julia> .![true false true]
  0  1  0
 ```
 """
-function !(x::Bool)
-    ## We need a better heuristic to detect this automatically
-    @_pure_meta
-    return not_int(x)
-end
+!(x::Bool) = not_int(x)
 
 (~)(x::Bool) = !x
 (&)(x::Bool, y::Bool) = and_int(x, y)

--- a/base/compiler/compiler.jl
+++ b/base/compiler/compiler.jl
@@ -78,6 +78,13 @@ using .Iterators: zip, enumerate
 using .Iterators: Flatten, Filter, product  # for generators
 include("namedtuple.jl")
 
+ntuple(f, ::Val{0}) = ()
+ntuple(f, ::Val{1}) = (@_inline_meta; (f(1),))
+ntuple(f, ::Val{2}) = (@_inline_meta; (f(1), f(2)))
+ntuple(f, ::Val{3}) = (@_inline_meta; (f(1), f(2), f(3)))
+ntuple(f, ::Val{n}) where {n} = ntuple(f, n::Int)
+ntuple(f, n) = (Any[f(i) for i = 1:n]...,)
+
 # core docsystem
 include("docs/core.jl")
 

--- a/base/compiler/tfuncs.jl
+++ b/base/compiler/tfuncs.jl
@@ -894,12 +894,16 @@ function _fieldtype_nothrow(@nospecialize(s), exact::Bool, name::Const)
     isa(fld, Int) || return false
     ftypes = datatype_fieldtypes(u)
     nf = length(ftypes)
-    if u.name === Tuple.name && fld >= nf && isvarargtype(ftypes[nf])
-        # If we don't know the exact type, the length of the tuple will be determined
-        # at runtime and we can't say anything.
-        return exact
+    fld >= 1 || return false
+    if u.name === Tuple.name && nf > 0 && isvarargtype(ftypes[nf])
+        if !exact && fld >= nf
+            # If we don't know the exact type, the length of the tuple will be determined
+            # at runtime and we can't say anything.
+            return false
+        end
+    elseif fld > nf
+        return false
     end
-    (fld >= 1 && fld <= nf) || return false
     return true
 end
 

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -257,7 +257,7 @@ end
 
 # replace TypeVars in all enclosing UnionAlls with fresh TypeVars
 function rename_unionall(@nospecialize(u))
-    if !isa(u,UnionAll)
+    if !isa(u, UnionAll)
         return u
     end
     body = rename_unionall(u.body)
@@ -701,7 +701,7 @@ julia> f(Val(true))
 struct Val{x}
 end
 
-Val(x) = (@_pure_meta; Val{x}())
+Val(x) = Val{x}()
 
 """
     invokelatest(f, args...; kwargs...)

--- a/base/essentials.jl
+++ b/base/essentials.jl
@@ -106,6 +106,40 @@ macro specialize(vars...)
     return Expr(:meta, :specialize, vars...)
 end
 
+"""
+    @isdefined s -> Bool
+
+Tests whether variable `s` is defined in the current scope.
+
+See also [`isdefined`](@ref).
+
+# Examples
+```jldoctest
+julia> @isdefined newvar
+false
+
+julia> newvar = 1
+1
+
+julia> @isdefined newvar
+true
+
+julia> function f()
+           println(@isdefined x)
+           x = 3
+           println(@isdefined x)
+       end
+f (generic function with 1 method)
+
+julia> f()
+false
+true
+```
+"""
+macro isdefined(s::Symbol)
+    return Expr(:escape, Expr(:isdefined, s))
+end
+
 macro _pure_meta()
     return Expr(:meta, :pure)
 end
@@ -207,31 +241,6 @@ ERROR: ArgumentError: Cannot call tail on an empty tuple.
 tail(x::Tuple) = argtail(x...)
 tail(::Tuple{}) = throw(ArgumentError("Cannot call tail on an empty tuple."))
 
-tuple_type_head(T::Type) = (@_pure_meta; fieldtype(T, 1))
-
-function tuple_type_tail(T::Type)
-    @_pure_meta
-    if isa(T, UnionAll)
-        return UnionAll(T.var, tuple_type_tail(T.body))
-    elseif isa(T, Union)
-        return Union{tuple_type_tail(T.a), tuple_type_tail(T.b)}
-    else
-        T.name === Tuple.name || throw(MethodError(tuple_type_tail, (T,)))
-        if isvatuple(T) && length(T.parameters) == 1
-            va = T.parameters[1]
-            (isa(va, DataType) && isa(va.parameters[2], Int)) || return T
-            return Tuple{Vararg{va.parameters[1], va.parameters[2]-1}}
-        end
-        return Tuple{argtail(T.parameters...)...}
-    end
-end
-
-tuple_type_cons(::Type, ::Type{Union{}}) = Union{}
-function tuple_type_cons(::Type{S}, ::Type{T}) where T<:Tuple where S
-    @_pure_meta
-    Tuple{S, T.parameters...}
-end
-
 function unwrap_unionall(@nospecialize(a))
     while isa(a,UnionAll)
         a = a.body
@@ -301,52 +310,49 @@ function typename(a::Union)
 end
 typename(union::UnionAll) = typename(union.body)
 
-const AtLeast1 = Tuple{Any, Vararg{Any}}
+_tuple_error(T::Type, x) = (@_noinline_meta; throw(MethodError(convert, (T, x))))
 
-# converting to empty tuple type
-convert(::Type{Tuple{}}, ::Tuple{}) = ()
-convert(::Type{Tuple{}}, x::AtLeast1) = throw(MethodError(convert, (Tuple{}, x)))
+convert(::Type{T}, x::T) where {T<:Tuple} = x
+function convert(::Type{T}, x::NTuple{N,Any}) where {N, T<:Tuple}
+    # First see if there could be any conversion of the input type that'd be a subtype of the output.
+    # If not, we'll throw an explicit MethodError (otherwise, it might throw a typeassert).
+    if typeintersect(NTuple{N,Any}, T) === Union{}
+        _tuple_error(T, x)
+    end
+    cvt1(n) = (@_inline_meta; convert(fieldtype(T, n), getfield(x, n, #=boundscheck=#false)))
+    return ntuple(cvt1, Val(N))::NTuple{N,Any}
+end
 
-# converting to tuple types with at least one element
-convert(::Type{T}, x::T) where {T<:AtLeast1} = x
-convert(::Type{T}, x::AtLeast1) where {T<:AtLeast1} =
-    (convert(tuple_type_head(T), x[1]), convert(tuple_type_tail(T), tail(x))...)
-
-# converting to Vararg tuple types
-convert(::Type{Tuple{Vararg{V}}}, x::Tuple{Vararg{V}}) where {V} = x
-convert(T::Type{Tuple{Vararg{V}}}, x::Tuple) where {V} =
-    (convert(tuple_type_head(T), x[1]), convert(T, tail(x))...)
-
-# TODO: the following definitions are equivalent (behaviorally) to the above method
-# I think they may be faster / more efficient for inference,
-# if we could enable them, but are they?
-# TODO: These currently can't be used (#21026, #23017) since with
-#     z(::Type{<:Tuple{Vararg{T}}}) where {T} = T
-#   calling
-#     z(Tuple{Val{T}} where T)
-#   fails, even though `Type{Tuple{Val}} == Type{Tuple{Val{S}} where S}`
-#   and so T should be `Val` (aka `Val{S} where S`)
-#convert(_::Type{Tuple{S}}, x::Tuple{S}) where {S} = x
-#convert(_::Type{Tuple{S}}, x::Tuple{Any}) where {S} = (convert(S, x[1]),)
-#convert(_::Type{T}, x::T) where {S, N, T<:Tuple{S, Vararg{S, N}}} = x
-#convert(_::Type{Tuple{S, Vararg{S, N}}},
-#        x::Tuple{Any, Vararg{Any, N}}) where
-#       {S, N} = cnvt_all(S, x...)
-#convert(_::Type{Tuple{Vararg{S, N}}},
-#        x::Tuple{Vararg{Any, N}}) where
-#       {S, N} = cnvt_all(S, x...)
-# TODO: These are similar to the methods we currently use but cnvt_all might work better:
-#convert(_::Type{Tuple{Vararg{S}}},
-#        x::Tuple{Any, Vararg{Any}}) where
-#       {S} = cnvt_all(S, x...)
-#convert(_::Type{Tuple{Vararg{S}}},
-#        x::Tuple{Vararg{Any}}) where
-#       {S} = cnvt_all(S, x...)
-#cnvt_all(T) = ()
-#cnvt_all(T, x, rest...) = (convert(T, x), cnvt_all(T, rest...)...)
-# TODO: These may be necessary if the above are enabled
+# optimizations?
+# converting to tuple types of fixed length
+#convert(::Type{T}, x::T) where {N, T<:NTuple{N,Any}} = x
+#convert(::Type{T}, x::NTuple{N,Any}) where {N, T<:NTuple{N,Any}} =
+#    ntuple(n -> convert(fieldtype(T, n), x[n]), Val(N))
+#convert(::Type{T}, x::Tuple{Vararg{Any}}) where {N, T<:NTuple{N,Any}} =
+#    throw(MethodError(convert, (T, x)))
+# converting to tuple types of indefinite length
+#convert(::Type{Tuple{Vararg{V}}}, x::Tuple{Vararg{V}}) where {V} = x
+#convert(::Type{NTuple{N, V}}, x::NTuple{N, V}) where {N, V} = x
+#function convert(T::Type{Tuple{Vararg{V}}}, x::Tuple) where {V}
+#    @isdefined(V) || (V = fieldtype(T, 1))
+#    return map(t -> convert(V, t), x)
+#end
+#function convert(T::Type{NTuple{N, V}}, x::NTuple{N, Any}) where {N, V}
+#    @isdefined(V) || (V = fieldtype(T, 1))
+#    return map(t -> convert(V, t), x)
+#end
+# short tuples
 #convert(::Type{Tuple{}}, ::Tuple{}) = ()
-#convert(::Type{Tuple{Vararg{S}}} where S, ::Tuple{}) = ()
+#convert(::Type{Tuple{S}}, x::Tuple{S}) where {S} = x
+#convert(::Type{Tuple{S, T}}, x::Tuple{S, T}) where {S, T} = x
+#convert(::Type{Tuple{S, T, U}}, x::Tuple{S, T, U}) where {S, T, U} = x
+#convert(::Type{Tuple{S}}, x::Tuple{Any}) where {S} = (convert(S, x[1]),)
+#convert(::Type{Tuple{S, T}}, x::Tuple{Any, Any}) where {S, T} = (convert(S, x[1]), convert(T, x[2]),)
+#convert(::Type{Tuple{S, T, U}}, x::Tuple{Any, Any, Any}) where {S, T, U} = (convert(S, x[1]), convert(T, x[2]), convert(U, x[3]))
+#convert(::Type{Tuple{}}, x::Tuple) = _tuple_error(Tuple{}, x)
+#convert(::Type{Tuple{S}}, x::Tuple) = _tuple_error(Tuple{S}, x)
+#convert(::Type{Tuple{S, T}}, x::Tuple{Any, Any}) where {S, T} =_tuple_error(Tuple{S, T}, x)
+#convert(::Type{Tuple{S, T, U}}, x::Tuple{Any, Any, Any}) where {S, T, U} = _tuple_error(Tuple{S, T, U}, x)
 
 """
     oftype(x, y)

--- a/base/promotion.jl
+++ b/base/promotion.jl
@@ -9,8 +9,8 @@
 Return the closest common ancestor of `T` and `S`, i.e. the narrowest type from which
 they both inherit.
 """
-typejoin() = (@_pure_meta; Bottom)
-typejoin(@nospecialize(t)) = (@_pure_meta; t)
+typejoin() = Bottom
+typejoin(@nospecialize(t)) = t
 typejoin(@nospecialize(t), ts...) = (@_pure_meta; typejoin(t, typejoin(ts...)))
 function typejoin(@nospecialize(a), @nospecialize(b))
     @_pure_meta

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -241,40 +241,6 @@ isconst(m::Module, s::Symbol) =
     ccall(:jl_is_const, Cint, (Any, Any), m, s) != 0
 
 """
-    @isdefined s -> Bool
-
-Tests whether variable `s` is defined in the current scope.
-
-See also [`isdefined`](@ref).
-
-# Examples
-```jldoctest
-julia> @isdefined newvar
-false
-
-julia> newvar = 1
-1
-
-julia> @isdefined newvar
-true
-
-julia> function f()
-           println(@isdefined x)
-           x = 3
-           println(@isdefined x)
-       end
-f (generic function with 1 method)
-
-julia> f()
-false
-true
-```
-"""
-macro isdefined(s::Symbol)
-    return Expr(:isdefined, esc(s))
-end
-
-"""
     @locals()
 
 Construct a dictionary of the names (as symbols) and values of all local

--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -535,31 +535,6 @@ struct type with no fields.
 issingletontype(@nospecialize(t)) = (@_pure_meta; isa(t, DataType) && isdefined(t, :instance))
 
 """
-    Base.parameter_upper_bound(t::UnionAll, idx)
-
-Determine the upper bound of a type parameter in the underlying datatype.
-This method should generally not be relied upon:
-code instead should usually use static parameters in dispatch to extract these values.
-
-# Examples
-```jldoctest
-julia> struct Foo{T<:AbstractFloat, N}
-           x::Tuple{T, N}
-       end
-
-julia> Base.parameter_upper_bound(Foo, 1)
-AbstractFloat
-
-julia> Base.parameter_upper_bound(Foo, 2)
-Any
-```
-"""
-function parameter_upper_bound(t::UnionAll, idx)
-    @_pure_meta
-    return rewrap_unionall((unwrap_unionall(t)::DataType).parameters[idx], t)
-end
-
-"""
     typeintersect(T, S)
 
 Compute a type that contains the intersection of `T` and `S`. Usually this will be the
@@ -725,13 +700,12 @@ julia> instances(Color)
 function instances end
 
 function to_tuple_type(@nospecialize(t))
-    @_pure_meta
-    if isa(t,Tuple) || isa(t,AbstractArray) || isa(t,SimpleVector)
+    if isa(t, Tuple) || isa(t, AbstractArray) || isa(t, SimpleVector)
         t = Tuple{t...}
     end
-    if isa(t,Type) && t<:Tuple
+    if isa(t, Type) && t <: Tuple
         for p in unwrap_unionall(t).parameters
-            if !(isa(p,Type) || isa(p,TypeVar))
+            if !(isa(p, Type) || isa(p, TypeVar))
                 error("argument tuple type must contain only types")
             end
         end

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -118,6 +118,7 @@ function _compute_eltype(t::Type{<:Tuple})
     @nospecialize t
     t isa Union && return promote_typejoin(eltype(t.a), eltype(t.b))
     t´ = unwrap_unionall(t)
+    # TODO: handle Union/UnionAll correctly here
     r = Union{}
     for ti in t´.parameters
         r = promote_typejoin(r, rewrap_unionall(unwrapva(ti), t))

--- a/base/tuple.jl
+++ b/base/tuple.jl
@@ -14,6 +14,11 @@ true
 """
 NTuple
 
+# convenience function for extracting N from a Tuple (if defined)
+# else return `nothing` for anything else given (such as Vararg or other non-sized Union)
+_counttuple(::Type{<:NTuple{N,Any}}) where {N} = N
+_counttuple(::Type) = nothing
+
 ## indexing ##
 
 length(@nospecialize t::Tuple) = nfields(t)

--- a/src/subtype.c
+++ b/src/subtype.c
@@ -1501,6 +1501,8 @@ static int concrete_min(jl_value_t *t)
 {
     if (jl_is_unionall(t))
         t = jl_unwrap_unionall(t);
+    if (t == (jl_value_t*)jl_bottom_type)
+        return 1;
     if (jl_is_datatype(t)) {
         if (jl_is_type_type(t))
             return 0; // Type{T} may have the concrete supertype `typeof(T)`, so don't try to handle them here

--- a/test/ambiguous.jl
+++ b/test/ambiguous.jl
@@ -288,8 +288,6 @@ end
         @test_broken need_to_handle_undef_sparam == Set()
         pop!(need_to_handle_undef_sparam, which(Core.Compiler._cat, Tuple{Any, AbstractArray}))
         pop!(need_to_handle_undef_sparam, first(methods(Core.Compiler.same_names)))
-        pop!(need_to_handle_undef_sparam, which(Core.Compiler.convert, Tuple{Type{Tuple{Vararg{Int}}}, Tuple{}}))
-        pop!(need_to_handle_undef_sparam, which(Core.Compiler.convert, Tuple{Type{Tuple{Vararg{Int}}}, Tuple{Int8}}))
         @test need_to_handle_undef_sparam == Set()
     end
     let need_to_handle_undef_sparam =
@@ -305,8 +303,6 @@ end
         pop!(need_to_handle_undef_sparam, which(Base.zero, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.one, Tuple{Type{Union{Missing, T}} where T}))
         pop!(need_to_handle_undef_sparam, which(Base.oneunit, Tuple{Type{Union{Missing, T}} where T}))
-        pop!(need_to_handle_undef_sparam, which(Base.convert, Tuple{Type{Tuple{Vararg{Int}}}, Tuple{}}))
-        pop!(need_to_handle_undef_sparam, which(Base.convert, Tuple{Type{Tuple{Vararg{Int}}}, Tuple{Int8}}))
         @test need_to_handle_undef_sparam == Set()
     end
 end

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -659,7 +659,10 @@ let fieldtype_tfunc = Core.Compiler.fieldtype_tfunc,
     @test fieldtype_nothrow(Union{Type{Base.RefValue{<:Real}}, Type{Base.RefValue{Any}}}, Const(:x))
     @test fieldtype_nothrow(Const(Union{Base.RefValue{<:Real}, Base.RefValue{Any}}), Const(:x))
     @test fieldtype_nothrow(Type{Union{Base.RefValue{T}, Base.RefValue{Any}}} where {T<:Real}, Const(:x))
+    @test !fieldtype_nothrow(Type{Tuple{}}, Const(1))
+    @test fieldtype_nothrow(Type{Tuple{Int}}, Const(1))
     @test fieldtype_nothrow(Type{Tuple{Vararg{Int}}}, Const(1))
+    @test fieldtype_nothrow(Type{Tuple{Vararg{Int}}}, Const(2))
     @test fieldtype_nothrow(Type{Tuple{Vararg{Int}}}, Const(42))
     @test !fieldtype_nothrow(Type{<:Tuple{Vararg{Int}}}, Const(1))
 end
@@ -753,7 +756,7 @@ end
 g11015(::Type{S}, ::S) where {S} = 1
 f11015(a::AT11015) = g11015(Base.fieldtype(typeof(a), :f), true)
 g11015(::Type{Bool}, ::Bool) = 2.0
-@test Int <: Base.return_types(f11015, (AT11015,))[1]
+@test Base.return_types(f11015, (AT11015,)) == Any[Int]
 @test f11015(AT11015(true)) === 1
 
 # better inference of apply (#20343)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -799,12 +799,6 @@ fUnionAll(::Type{T}) where {T} = Type{S} where S <: T
 @inferred fUnionAll(Real) == Type{T} where T <: Real
 @inferred fUnionAll(Rational{T} where T <: AbstractFloat) == Type{T} where T<:(Rational{S} where S <: AbstractFloat)
 
-fComplicatedUnionAll(::Type{T}) where {T} = Type{Tuple{S,rand() >= 0.5 ? Int : Float64}} where S <: T
-let pub = Base.parameter_upper_bound, x = fComplicatedUnionAll(Real)
-    @test pub(pub(x, 1), 1) == Real
-    @test pub(pub(x, 1), 2) == Int || pub(pub(x, 1), 2) == Float64
-end
-
 # issue #20733
 # run this test in a separate process to avoid interfering with `getindex`
 let def = "Base.getindex(t::NTuple{3,NTuple{2,Int}}, i::Int, j::Int, k::Int) = (t[1][i], t[2][j], t[3][k])"

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -559,10 +559,6 @@ end
 @test !isstructtype(Int)
 @test isstructtype(TLayout)
 
-@test Base.parameter_upper_bound(ReflectionExample, 1) === AbstractFloat
-@test Base.parameter_upper_bound(ReflectionExample, 2) === Any
-@test Base.parameter_upper_bound(ReflectionExample{T, N} where T where N <: Real, 2) === Real
-
 let
     wrapperT(T) = Base.typename(T).wrapper
     @test @inferred wrapperT(ReflectionExample{Float64, Int64}) == ReflectionExample

--- a/test/subtype.jl
+++ b/test/subtype.jl
@@ -1247,7 +1247,6 @@ let ints = (Int, Int32, UInt, UInt32)
     T = Type{Tuple{V, I}} where V <: Vecs where I <: Ints
     @testintersect(T, T, T)
     test(a::Type{Tuple{V, I}}) where {V <: Vecs, I <: Ints} = I
-    test(a::Type{Tuple{V, I}}) where {V <: Vecs, I <: Ints} = I
 end
 
 # issue #21191

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -35,6 +35,12 @@ end
     @test convert(NTuple{3, Int}, (1.0, 2, 0x3)) === (1, 2, 3)
     @test convert(Tuple{Int, Int, Float64}, (1.0, 2, 0x3)) === (1, 2, 3.0)
 
+    @test convert(Tuple{Vararg{AbstractFloat}}, (2,)) == (2.0,)
+    @test convert(Tuple{Int, Vararg{AbstractFloat}}, (-9.0+0im, 2,)) == (-9, 2.0,)
+    let x = @inferred(convert(Tuple{Integer, UInt8, UInt16, UInt32, Int, Vararg{Real}}, (2.0, 3, 5, 6.0, 42, 3.0+0im)))
+        @test x == (2, 0x03, 0x0005, 0x00000006, 42, 3.0)
+    end
+
     @test_throws MethodError convert(Tuple{Int}, ())
     @test_throws MethodError convert(Tuple{Any}, ())
     @test_throws MethodError convert(Tuple{Int, Vararg{Int}}, ())
@@ -53,18 +59,18 @@ end
     # issue #26589
     @test_throws MethodError convert(NTuple{4}, (1.0,2.0,3.0,4.0,5.0))
     # issue #31824
-    # there is no generic way to convert an arbitrary tuple to a homogeneous tuple
-    @test_throws MethodError(convert, (NTuple, (1, 1.0)), Base.get_world_counter()) convert(NTuple, (1, 1.0))
+    @test convert(NTuple, (1, 1.0)) === (1, 1.0)
     let T = Tuple{Vararg{T}} where T<:Integer, v = (1.0, 2, 0x3)
-        @test_throws MethodError(convert, (T, (1.0, 2, 0x3)), Base.get_world_counter()) convert(T, v)
+        @test convert(T, v) === (1, 2, 0x3)
     end
     let T = Tuple{T, Vararg{T}} where T<:Integer, v = (1.0, 2, 0x3)
-        @test_throws MethodError(convert, (Tuple{Vararg{T}} where T<:Integer, (2, 0x3)), Base.get_world_counter()) convert(T, v)
+        @test convert(T, v) === (1, 2, 0x3)
     end
     function f31824(input...)
         b::NTuple = input
+        return b
     end
-    @test f31824(1,2,3) === (1,2,3)
+    @test f31824(1, 2, 3) === (1, 2, 3)
 
     # PR #15516
     @test Tuple{Char,Char}("za") === ('z','a')


### PR DESCRIPTION
In preparation for increasing the optimizations that are enabled by this flag (#32368), let's try to reduce the number of places we are using it.

The new single convert method here even lets us do things like `convert(Tuple{Vararg{AbstractFloat}}, (2,))`, which we couldn't previously express through dispatch.