### PR TITLE
Fix REPL test result uniqueness

### DIFF
--- a/stdlib/REPL/test/replcompletions.jl
+++ b/stdlib/REPL/test/replcompletions.jl
@@ -87,7 +87,7 @@ end
 
 function map_completion_text(completions)
     c, r, res = completions
-    return map(completion_text, c), r, res
+    return unique!(map(completion_text, c)), r, res
 end
 
 test_complete(s) = map_completion_text(completions(s,lastindex(s)))


### PR DESCRIPTION
Fixes #32377

Makes the behavior match whats in production code? Since `REPL` can come from Package and module.
https://github.com/JuliaLang/julia/blob/67cdc550a0c5d615c4071b7fae12caaf85d01e30/stdlib/REPL/src/REPL.jl#L363