### PR TITLE
efficient subset query for unit ranges

### DIFF
--- a/base/range.jl
+++ b/base/range.jl
@@ -849,7 +849,7 @@ end
 
 issubset(r::OneTo, s::OneTo) = r.stop <= s.stop
 
-issubset(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) = 
+issubset(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) =
     first(r) >= first(s) && last(r) <= last(s)
 
 ## linear operations on ranges ##

--- a/base/range.jl
+++ b/base/range.jl
@@ -847,6 +847,11 @@ function _findin(r::AbstractRange{<:Integer}, span::AbstractUnitRange{<:Integer}
     r isa AbstractUnitRange ? (ifirst:ilast) : (ifirst:1:ilast)
 end
 
+issubset(r::OneTo, s::OneTo) = r.stop <= s.stop
+
+issubset(r::AbstractUnitRange{<:Integer}, s::AbstractUnitRange{<:Integer}) = 
+    first(r) >= first(s) && last(r) <= last(s)
+
 ## linear operations on ranges ##
 
 -(r::OrdinalRange) = range(-first(r), step=-step(r), length=length(r))

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -362,6 +362,20 @@ end
         @test intersect(1:3, 2) === intersect(2, 1:3) === 2:2
         @test intersect(1.0:3.0, 2) == intersect(2, 1.0:3.0) == [2.0]
     end
+    @testset "issubset" begin
+        @test issubset(1:3, 1:typemax(Int)) #32461
+        @test issubset(1:3, 1:3)
+        @test issubset(1:3, 1:4)
+        @test issubset(1:3, 0:3)
+        @test issubset(1:3, 0:4)
+        @test !issubset(1:5, 2:5)
+        @test !issubset(1:5, 1:4)
+        @test !issubset(1:5, 2:4)
+        @test issubset(Base.OneTo(5), Base.OneTo(10))
+        @test !issubset(Base.OneTo(10), Base.OneTo(5))
+        @test issubset(1:3:10, 1:10)
+        @test !issubset(1:10, 1:3:10)        
+    end
     @testset "sort/sort!/partialsort" begin
         @test sort(UnitRange(1,2)) == UnitRange(1,2)
         @test sort!(UnitRange(1,2)) == UnitRange(1,2)

--- a/test/ranges.jl
+++ b/test/ranges.jl
@@ -374,7 +374,7 @@ end
         @test issubset(Base.OneTo(5), Base.OneTo(10))
         @test !issubset(Base.OneTo(10), Base.OneTo(5))
         @test issubset(1:3:10, 1:10)
-        @test !issubset(1:10, 1:3:10)        
+        @test !issubset(1:10, 1:3:10)
     end
     @testset "sort/sort!/partialsort" begin
         @test sort(UnitRange(1,2)) == UnitRange(1,2)


### PR DESCRIPTION
This should fix #32461 . 

See also #32003, which will make `issubset([1,2,3],  1:10^8)` not take 5 seconds. 

Should I add more methods for `StepRange`, or keep this simple?