### PR TITLE
SparseMatrixCSC constructors for structured matrices - Diagonal, Tridiagonal, etc.

### DIFF
--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -405,16 +405,16 @@ end
 SparseMatrixCSC(M::Matrix) = sparse(M)
 function SparseMatrixCSC(T::SymTridiagonal)
     m = length(T.dv)
-    return sparse([1:m;2:m;1:m-1],[1:m;1:m-1;2:m],[T.dv;T.ev;T.ev], Int(m), Int(m))
+    return sparse([1:m;2:m;1:m-1], [1:m;1:m-1;2:m], [T.dv;T.ev;T.ev], Int(m), Int(m))
 end
 function SparseMatrixCSC(T::Tridiagonal)
     m = length(T.d)
-    return sparse([1:m;2:m;1:m-1],[1:m;1:m-1;2:m],[T.d;T.dl;T.du], Int(m), Int(m))
+    return sparse([1:m;2:m;1:m-1], [1:m;1:m-1;2:m], [T.d;T.dl;T.du], Int(m), Int(m))
 end
 function SparseMatrixCSC(B::Bidiagonal)
     m = length(B.dv)
     B.uplo == 'U' || return sparse([1:m;2:m],[1:m;1:m-1],[B.dv;B.ev], Int(m), Int(m)) # lower bidiagonal
-    return sparse([1:m;1:m-1],[1:m;2:m],[B.dv;B.ev], Int(m), Int(m)) # upper bidiagonal
+    return sparse([1:m;1:m-1], [1:m;2:m], [B.dv; B.ev], Int(m), Int(m)) # upper bidiagonal
 end
 function SparseMatrixCSC(D::Diagonal{T}) where T
     m = length(D.diag)

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -403,6 +403,23 @@ function SparseMatrixCSC{Tv,Ti}(S::SparseMatrixCSC) where {Tv,Ti}
 end
 # converting from other matrix types to SparseMatrixCSC (also see sparse())
 SparseMatrixCSC(M::Matrix) = sparse(M)
+function SparseMatrixCSC(T::SymTridiagonal)
+    m = length(T.dv)
+    return sparse([1:m;2:m;1:m-1],[1:m;1:m-1;2:m],[T.dv;T.ev;T.ev], Int(m), Int(m))
+end
+function SparseMatrixCSC(T::Tridiagonal)
+    m = length(T.d)
+    return sparse([1:m;2:m;1:m-1],[1:m;1:m-1;2:m],[T.d;T.dl;T.du], Int(m), Int(m))
+end
+function SparseMatrixCSC(B::Bidiagonal)
+    m = length(B.dv)
+    B.uplo == 'U' || return sparse([1:m;2:m],[1:m;1:m-1],[B.dv;B.ev], Int(m), Int(m)) # lower bidiagonal
+    return sparse([1:m;1:m-1],[1:m;2:m],[B.dv;B.ev], Int(m), Int(m)) # upper bidiagonal
+end
+function SparseMatrixCSC(D::Diagonal{T}) where T
+    m = length(D.diag)
+    return SparseMatrixCSC(m, m, Vector(1:(m+1)), Vector(1:m), Vector{T}(D.diag))
+end
 SparseMatrixCSC(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 SparseMatrixCSC{Tv}(M::AbstractMatrix{Tv}) where {Tv} = SparseMatrixCSC{Tv,Int}(M)
 function SparseMatrixCSC{Tv,Ti}(M::AbstractMatrix) where {Tv,Ti}
@@ -756,26 +773,11 @@ sparse(I,J,V::AbstractVector{Bool},m,n) = sparse(I, J, V, Int(m), Int(n), |)
 
 sparse(I,J,v::Number,m,n,combine::Function) = sparse(I, J, fill(v,length(I)), Int(m), Int(n), combine)
 
-function sparse(T::SymTridiagonal)
-    m = length(T.dv)
-    return sparse([1:m;2:m;1:m-1],[1:m;1:m-1;2:m],[T.dv;T.ev;T.ev], Int(m), Int(m))
-end
-
-function sparse(T::Tridiagonal)
-    m = length(T.d)
-    return sparse([1:m;2:m;1:m-1],[1:m;1:m-1;2:m],[T.d;T.dl;T.du], Int(m), Int(m))
-end
-
-function sparse(B::Bidiagonal)
-    m = length(B.dv)
-    B.uplo == 'U' || return sparse([1:m;2:m],[1:m;1:m-1],[B.dv;B.ev], Int(m), Int(m)) # lower bidiagonal
-    return sparse([1:m;1:m-1],[1:m;2:m],[B.dv;B.ev], Int(m), Int(m)) # upper bidiagonal
-end
-
-function sparse(D::Diagonal{T}) where T
-    m = length(D.diag)
-    return SparseMatrixCSC(m, m, Vector(1:(m+1)), Vector(1:m), Vector{T}(D.diag))
-end
+# should be handled by sparse(::AbstractMatrix)
+# sparse(T::SymTridiagonal) = SparseMatrixCSC(T)
+# sparse(T::Tridiagonal) = SparseMatrixCSC(T)
+# sparse(B::Bidiagonal) = SparseMatrixCSC(B)
+# sparse(D::Diagonal) = SparseMatrixCSC(D)
 
 ## Transposition and permutation methods
 

--- a/stdlib/SparseArrays/src/sparsematrix.jl
+++ b/stdlib/SparseArrays/src/sparsematrix.jl
@@ -405,16 +405,16 @@ end
 SparseMatrixCSC(M::Matrix) = sparse(M)
 function SparseMatrixCSC(T::SymTridiagonal)
     m = length(T.dv)
-    return sparse([1:m;2:m;1:m-1], [1:m;1:m-1;2:m], [T.dv;T.ev;T.ev], Int(m), Int(m))
+    return sparse([1:m; 2:m; 1:m-1], [1:m; 1:m-1; 2:m], [T.dv; T.ev; T.ev], Int(m), Int(m))
 end
 function SparseMatrixCSC(T::Tridiagonal)
     m = length(T.d)
-    return sparse([1:m;2:m;1:m-1], [1:m;1:m-1;2:m], [T.d;T.dl;T.du], Int(m), Int(m))
+    return sparse([1:m; 2:m; 1:m-1], [1:m; 1:m-1; 2:m], [T.d; T.dl; T.du], Int(m), Int(m))
 end
 function SparseMatrixCSC(B::Bidiagonal)
     m = length(B.dv)
     B.uplo == 'U' || return sparse([1:m;2:m],[1:m;1:m-1],[B.dv;B.ev], Int(m), Int(m)) # lower bidiagonal
-    return sparse([1:m;1:m-1], [1:m;2:m], [B.dv; B.ev], Int(m), Int(m)) # upper bidiagonal
+    return sparse([1:m; 1:m-1], [1:m; 2:m], [B.dv; B.ev], Int(m), Int(m)) # upper bidiagonal
 end
 function SparseMatrixCSC(D::Diagonal{T}) where T
     m = length(D.diag)
@@ -513,6 +513,14 @@ julia> sparse(A)
 sparse(A::AbstractMatrix{Tv}) where {Tv} = convert(SparseMatrixCSC{Tv,Int}, A)
 
 sparse(S::SparseMatrixCSC) = copy(S)
+
+sparse(T::SymTridiagonal) = SparseMatrixCSC(T)
+
+sparse(T::Tridiagonal) = SparseMatrixCSC(T)
+
+sparse(B::Bidiagonal) = SparseMatrixCSC(B)
+
+sparse(D::Diagonal) = SparseMatrixCSC(D)
 
 """
     sparse(I, J, V,[ m, n, combine])
@@ -772,12 +780,6 @@ sparse(I,J,V::AbstractVector,m,n) = sparse(I, J, V, Int(m), Int(n), +)
 sparse(I,J,V::AbstractVector{Bool},m,n) = sparse(I, J, V, Int(m), Int(n), |)
 
 sparse(I,J,v::Number,m,n,combine::Function) = sparse(I, J, fill(v,length(I)), Int(m), Int(n), combine)
-
-# should be handled by sparse(::AbstractMatrix)
-# sparse(T::SymTridiagonal) = SparseMatrixCSC(T)
-# sparse(T::Tridiagonal) = SparseMatrixCSC(T)
-# sparse(B::Bidiagonal) = SparseMatrixCSC(B)
-# sparse(D::Diagonal) = SparseMatrixCSC(D)
 
 ## Transposition and permutation methods
 

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1460,7 +1460,7 @@ end
     end
 end
 
-@testset "issues #10837 6 #32466, sparse constructors from special matrices" begin
+@testset "issues #10837 & #32466, sparse constructors from special matrices" begin
     T = Tridiagonal(randn(4),randn(5),randn(4))
     S = sparse(T)
     @test norm(Array(T) - Array(S)) == 0.0

--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1460,22 +1460,32 @@ end
     end
 end
 
-@testset "issue #10837, sparse constructors from special matrices" begin
+@testset "issues #10837 6 #32466, sparse constructors from special matrices" begin
     T = Tridiagonal(randn(4),randn(5),randn(4))
     S = sparse(T)
     @test norm(Array(T) - Array(S)) == 0.0
+    S2 = SparseMatrixCSC(T)
+    @test S == S2
     T = SymTridiagonal(randn(5),rand(4))
     S = sparse(T)
     @test norm(Array(T) - Array(S)) == 0.0
+    S2 = SparseMatrixCSC(T)
+    @test S == S2
     B = Bidiagonal(randn(5),randn(4),:U)
     S = sparse(B)
     @test norm(Array(B) - Array(S)) == 0.0
+    S2 = SparseMatrixCSC(B)
+    @test S == S2
     B = Bidiagonal(randn(5),randn(4),:L)
     S = sparse(B)
     @test norm(Array(B) - Array(S)) == 0.0
+    S2 = SparseMatrixCSC(B)
+    @test S == S2
     D = Diagonal(randn(5))
     S = sparse(D)
     @test norm(Array(D) - Array(S)) == 0.0
+    S2 = SparseMatrixCSC(D)
+    @test S == S2
 end
 
 @testset "error conditions for reshape, and dropdims" begin


### PR DESCRIPTION
This keeps identical functionality, but makes the specialized constructors for structured matrices such as `Diagonal`, `Bidiagonal` etc. available to the broadcast machinery.

Fixes #31770.