### PR TITLE
Fix tab completion in Logging for functions from CoreLogging

### DIFF
--- a/stdlib/Logging/src/Logging.jl
+++ b/stdlib/Logging/src/Logging.jl
@@ -8,27 +8,26 @@ and available by default.
 """
 module Logging
 
-# For now, simply import most names from Base - we don't want to fully
-# stabilize this API for 1.0 so it should officially live here in a stdlib
-# package.
-#
-# See #24490
-
-import Base.CoreLogging:
-    LogLevel, BelowMinLevel, Debug, Info, Warn, Error, AboveMaxLevel,
-    AbstractLogger,
-    NullLogger,
-    handle_message, shouldlog, min_enabled_level, catch_exceptions,
-    @debug,
-    @info,
-    @warn,
-    @error,
-    @logmsg,
-    with_logger,
-    current_logger,
-    global_logger,
-    disable_logging,
-    SimpleLogger
+# Import the CoreLogging implementation into Logging as new const bindings.
+# Doing it this way (rather than with import) makes these symbols accessible to
+# tab completion.
+for sym in [
+    :LogLevel, :BelowMinLevel, :Debug, :Info, :Warn, :Error, :AboveMaxLevel,
+    :AbstractLogger,
+    :NullLogger,
+    :handle_message, :shouldlog, :min_enabled_level, :catch_exceptions,
+    Symbol("@debug"),
+    Symbol("@info"),
+    Symbol("@warn"),
+    Symbol("@error"),
+    Symbol("@logmsg"),
+    :with_logger,
+    :current_logger,
+    :global_logger,
+    :disable_logging,
+    :SimpleLogger]
+    @eval const $sym = Base.CoreLogging.$sym
+end
 
 export
     AbstractLogger,

--- a/stdlib/Logging/test/runtests.jl
+++ b/stdlib/Logging/test/runtests.jl
@@ -8,6 +8,13 @@ import Logging: min_enabled_level, shouldlog, handle_message
 
 @testset "Logging" begin
 
+@testset "Core" begin
+    # Symbols imported from CoreLogging should appear in tab completions
+    @test :AbstractLogger in names(Logging, all=true)  # exported public type
+    @test :Info in names(Logging, all=true)            # non-exported public constant
+    @test :handle_message in names(Logging, all=true)  # non-exported public function
+end
+
 @testset "ConsoleLogger" begin
     # First pass log limiting
     @test min_enabled_level(ConsoleLogger(devnull, Logging.Debug)) == Logging.Debug


### PR DESCRIPTION
CoreLogging is an implementation detail, but the fact that Logging
imports things from there breaks tab completion of `Logging.<tab>` even though these
symbols are exported again. Fix this by explicitly creating bindings for
each imported symbol.