### PR TITLE
Matrix operations involving different element types

### DIFF
--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -152,6 +152,50 @@ julia> sB\x
 ```
 The `\` operation here performs the linear solution. The left-division operator is pretty powerful and it's easy to write compact, readable code that is flexible enough to solve all sorts of systems of linear equations.
 
+## Matrix multiplications involving matrices of different element types
+
+When computing matrix operations with different element types there are tradeoffs a user has to decide.
+The following example shows 3 different choices when multiplying two matrices `A` and `B` of `Float64` and `Float32` values.
+
+```
+julia> n = 1000
+julia> A = rand(Float64,n,n);
+julia> B = rand(Float32,n,n);
+
+julia> @time C = A*B;                                # 1)                
+  1.048376 seconds (12 allocations: 7.630 MiB)
+julia> typeof(C)
+Array{Float64,2}
+
+julia> @time C = map(Float32,A)*B;                   # 2)
+  0.028782 seconds (9 allocations: 7.630 MiB)
+julia> typeof(C)
+Array{Float32,2}
+
+julia> @time C = A* map(Float64,B);                  # 3)
+  0.069675 seconds (9 allocations: 15.259 MiB)
+julia> typeof(C)
+Array{Float64,2}
+```
+
+Notice that in in 
+
+1) Allocates `7.630 MiB` for a single matrix `C` of Float64 values
+2) Allocates `7.630 MiB` for two matrices: `map(Float32,A)` and `C` both of which contain Float32 values
+3) Allocates `15.259 MiB` for two matrices: `map(Float64,B)` and `C` both of which contain Float64 values
+
+Notice that 
+
+- The best solution is 1) if you need a matrix of `Float64` values and you need to use the least amount of memory.
+
+- The best solution is 2) if a matrix of `Float32` values is enough and you need to miminize execution time.
+
+- The best solution is 3) when you need a matrix of `Float64` values but you don't need to minimize memory usage 
+
+
+
+
+
 ## Special matrices
 
 [Matrices with special symmetries and structures](http://www2.imm.dtu.dk/pubdb/views/publication_details.php?id=3274)

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -158,43 +158,42 @@ When computing matrix operations with different element types there are tradeoff
 The following example shows 3 different choices when multiplying two matrices `A` and `B` of `Float64` and `Float32` values.
 
 ```
-julia> n = 1000
+julia> n = 1000;
+
 julia> A = rand(Float64,n,n);
+
 julia> B = rand(Float32,n,n);
 
 julia> @time C = A*B;                                # 1)                
   1.048376 seconds (12 allocations: 7.630 MiB)
+
 julia> typeof(C)
 Array{Float64,2}
 
 julia> @time C = map(Float32,A)*B;                   # 2)
   0.028782 seconds (9 allocations: 7.630 MiB)
+
 julia> typeof(C)
 Array{Float32,2}
 
 julia> @time C = A* map(Float64,B);                  # 3)
   0.069675 seconds (9 allocations: 15.259 MiB)
+
 julia> typeof(C)
 Array{Float64,2}
 ```
 
-Notice that in in 
+Notice that
 
-1) Allocates `7.630 MiB` for a single matrix `C` of Float64 values
-2) Allocates `7.630 MiB` for two matrices: `map(Float32,A)` and `C` both of which contain Float32 values
-3) Allocates `15.259 MiB` for two matrices: `map(Float64,B)` and `C` both of which contain Float64 values
+- 1) allocates `7.630 MiB` for a single matrix `C` of `Float64` values
+- 2) allocates `7.630 MiB` for two matrices: `map(Float32,A)` and `C` both of which contain `Float32` values
+- 3) allocates `15.259 MiB` for two matrices: `map(Float64,B)` and `C` both of which contain `Float64` values
 
-Notice that 
+This means that
 
 - The best solution is 1) if you need a matrix of `Float64` values and you need to use the least amount of memory.
-
 - The best solution is 2) if a matrix of `Float32` values is enough and you need to miminize execution time.
-
-- The best solution is 3) when you need a matrix of `Float64` values but you don't need to minimize memory usage 
-
-
-
-
+- The best solution is 3) when you need a matrix of `Float64` values but you don't need to minimize memory usage.
 
 ## Special matrices
 

--- a/stdlib/LinearAlgebra/docs/src/index.md
+++ b/stdlib/LinearAlgebra/docs/src/index.md
@@ -164,19 +164,19 @@ julia> A = rand(Float64,n,n);
 
 julia> B = rand(Float32,n,n);
 
-julia> @time C = A*B;                                # 1)                
+julia> @time C = A*B;                                # (1)                
   1.048376 seconds (12 allocations: 7.630 MiB)
 
 julia> typeof(C)
 Array{Float64,2}
 
-julia> @time C = map(Float32,A)*B;                   # 2)
+julia> @time C = map(Float32,A)*B;                   # (2)
   0.028782 seconds (9 allocations: 7.630 MiB)
 
 julia> typeof(C)
 Array{Float32,2}
 
-julia> @time C = A* map(Float64,B);                  # 3)
+julia> @time C = A* map(Float64,B);                  # (3)
   0.069675 seconds (9 allocations: 15.259 MiB)
 
 julia> typeof(C)
@@ -185,15 +185,17 @@ Array{Float64,2}
 
 Notice that
 
-- 1) allocates `7.630 MiB` for a single matrix `C` of `Float64` values
-- 2) allocates `7.630 MiB` for two matrices: `map(Float32,A)` and `C` both of which contain `Float32` values
-- 3) allocates `15.259 MiB` for two matrices: `map(Float64,B)` and `C` both of which contain `Float64` values
+- (1) allocates `7.630 MiB` for a single matrix `C` of `Float64` values;
+- (2) allocates `7.630 MiB` for two matrices: `map(Float32,A)` and `C` both of which contain `Float32` values;
+- (3) allocates `15.259 MiB` for two matrices: `map(Float64,B)` and `C` both of which contain `Float64` values.
 
-This means that
+This means
 
-- The best solution is 1) if you need a matrix of `Float64` values and you need to use the least amount of memory.
-- The best solution is 2) if a matrix of `Float32` values is enough and you need to miminize execution time.
-- The best solution is 3) when you need a matrix of `Float64` values but you don't need to minimize memory usage.
+- The best solution is (1) if you need a matrix of `Float64` values and you need to use the least amount of memory;
+- The best solution is (2) if a matrix of `Float32` values is enough and you need to miminize execution time;
+- The best solution is (3) when you need a matrix of `Float64` values but you don't need to minimize memory usage.
+
+Rather than trying to guess which implementation is best for your use case, Julia lets you choose between the three.
 
 ## Special matrices
 


### PR DESCRIPTION
Making operations with different element types can impact a lot execution time. It would be nice to have in the documentation an example showing the tradeoffs a user has to decide. I am not sure where.

I am writting this request as a remainder, feel free to change the examples. I think many users (using LinearAlgebra) will face this problem and it would be nice to have a tiny part of the documentation exposing readers with the behaviour of the different approaches.