### PR TITLE
fix #32467, parsing macro on `for` inside `do` inside call

### DIFF
--- a/src/julia-parser.scm
+++ b/src/julia-parser.scm
@@ -216,10 +216,6 @@
   `(with-bindings ((whitespace-newline #t))
                   ,@body))
 
-(define-macro (without-whitespace-newline . body)
-  `(with-bindings ((whitespace-newline #f))
-                  ,@body))
-
 ;; --- lexer ---
 
 (define (newline? c) (eqv? c #\newline))
@@ -1546,7 +1542,7 @@
 (define (parse-do s)
   (with-bindings
    ((expect-end-current-line (input-port-line (ts:port s))))
-   (without-whitespace-newline
+   (with-normal-context
     (let ((doargs (if (memv (peek-token s) '(#\newline #\;))
                       '()
                       (parse-comma-separated s parse-range))))

--- a/test/syntax.jl
+++ b/test/syntax.jl
@@ -1867,3 +1867,14 @@ end
 
 @test Meta.lower(Main, :(struct A; A() = new{Int}(); end)) == Expr(:error, "too many type parameters specified in \"new{...}\"")
 @test Meta.lower(Main, :(struct A{T, S}; A() = new{Int}(); end)) == Expr(:error, "too few type parameters specified in \"new{...}\"")
+
+# issue #32467
+let f = identity(identity() do
+                 x = 0
+                 @inbounds for i = 1:2
+                     x += i
+                 end
+                 x
+                 end)
+    @test f() == 3
+end


### PR DESCRIPTION
fix #32467