### PR TITLE
Update `-h` flag documentation in getting-started

### DIFF
--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -94,7 +94,7 @@ julia [switches] -- [programfile] [args...]
 |Switch                                 |Description|
 |:---                                   |:---|
 |`-v`, `--version`                      |Display version information|
-|`-h`, `--help`                         |Print this message|
+|`-h`, `--help`                         |Print this message. Prints command-line flags.|
 |`--project[={<dir>\|@.}]`              |Set <dir> as the home project/environment. The default @. option will search through parent directories until a Project.toml or JuliaProject.toml file is found.|
 |`-J`, `--sysimage <file>`              |Start up with the given system image file|
 |`-H`, `--home <dir>`                   |Set location of `julia` executable|

--- a/doc/src/manual/getting-started.md
+++ b/doc/src/manual/getting-started.md
@@ -94,7 +94,7 @@ julia [switches] -- [programfile] [args...]
 |Switch                                 |Description|
 |:---                                   |:---|
 |`-v`, `--version`                      |Display version information|
-|`-h`, `--help`                         |Print this message. Prints command-line flags.|
+|`-h`, `--help`                         |Print command-line options (this message).|
 |`--project[={<dir>\|@.}]`              |Set <dir> as the home project/environment. The default @. option will search through parent directories until a Project.toml or JuliaProject.toml file is found.|
 |`-J`, `--sysimage <file>`              |Start up with the given system image file|
 |`-H`, `--home <dir>`                   |Set location of `julia` executable|


### PR DESCRIPTION
I was looking for the meaning of `julia -e` and `julia --project=` and could not find it through the documentation search. Maybe by adding `flag` in the description of `julia -h`, it becomes searchable?

See discussion in : https://discourse.julialang.org/t/julia-flags-for-startup-is-there-a-list/25932/4 