### PR TITLE
more performant SparseMatricCSC constructors for structured matrices

### DIFF
--- a/stdlib/SparseArrays/test/sparse.jl
+++ b/stdlib/SparseArrays/test/sparse.jl
@@ -1463,28 +1463,28 @@ end
 @testset "issues #10837 & #32466, sparse constructors from special matrices" begin
     T = Tridiagonal(randn(4),randn(5),randn(4))
     S = sparse(T)
-    @test norm(Array(T) - Array(S)) == 0.0
     S2 = SparseMatrixCSC(T)
+    @test Array(T) == Array(S) == Array(S2)
     @test S == S2
     T = SymTridiagonal(randn(5),rand(4))
     S = sparse(T)
-    @test norm(Array(T) - Array(S)) == 0.0
     S2 = SparseMatrixCSC(T)
+    @test Array(T) == Array(S) == Array(S2)
     @test S == S2
     B = Bidiagonal(randn(5),randn(4),:U)
     S = sparse(B)
-    @test norm(Array(B) - Array(S)) == 0.0
     S2 = SparseMatrixCSC(B)
+    @test Array(B) == Array(S) == Array(S2)
     @test S == S2
     B = Bidiagonal(randn(5),randn(4),:L)
     S = sparse(B)
-    @test norm(Array(B) - Array(S)) == 0.0
     S2 = SparseMatrixCSC(B)
+    @test Array(B) == Array(S) == Array(S2)
     @test S == S2
     D = Diagonal(randn(5))
     S = sparse(D)
-    @test norm(Array(D) - Array(S)) == 0.0
     S2 = SparseMatrixCSC(D)
+    @test Array(D) == Array(S) == Array(S2)
     @test S == S2
 end
 


### PR DESCRIPTION
This is a follow-up on #32466, implementing what was suggested here https://github.com/JuliaLang/julia/pull/10843#issuecomment-93715724. I was experimenting with all kinds of high-level things, like `repeat`, and `collect` of ranges etc., but nothing was working as fast with as little allocations as simply filling `undef`ined vectors of appropriate type (especially `repeat` was really bad!). Some benchmarks are below. The call to `sparse` corresponds to the current master code (i.e., "before PR"), the calls to `SparseMatrixCSC` call functions of this PR ("with PR"). For larger sizes the gain can be a factor larger than 10.

```julia
julia> using SparseArrays, LinearAlgebra, BenchmarkTools

julia> m = 1000
1000

julia> T =  Tridiagonal(randn(m-1),randn(m),randn(m-1));

julia> @btime sparse($T);
  27.698 μs (25 allocations: 188.83 KiB)

julia> @btime SparseMatrixCSC($T);
  3.931 μs (7 allocations: 55.09 KiB)

julia> T = SymTridiagonal(randn(m),randn(m-1));

julia> @btime sparse($T);
  27.504 μs (25 allocations: 188.83 KiB)

julia> @btime SparseMatrixCSC($T);
  3.880 μs (7 allocations: 55.09 KiB)

julia> B = Bidiagonal(rand(m), rand(m-1), :U);

julia> @btime sparse($B);
  21.705 μs (20 allocations: 134.38 KiB)

julia> @btime SparseMatrixCSC($B);
  2.664 μs (5 allocations: 39.56 KiB)

julia> B = Bidiagonal(rand(m), rand(m-1), :L);

julia> @btime sparse($B);
  21.365 μs (20 allocations: 134.38 KiB)

julia> @btime SparseMatrixCSC($B);
  2.632 μs (5 allocations: 39.56 KiB)
```