### PR TITLE
Add a fast overload for `fieldcount(Tuple{...})`

### DIFF
--- a/base/reflection.jl
+++ b/base/reflection.jl
@@ -686,6 +686,10 @@ function fieldcount(@nospecialize t)
     end
     return length(t.name.names)
 end
+# Add an overload for Tuples, where we can determine this much more cheaply than for other types.
+function fieldcount(@nospecialize t::Type{T}) where T<:Tuple{Vararg{Any,N}} where N
+    N
+end
 
 """
     fieldtypes(T::Type)


### PR DESCRIPTION
Add an overload for `Base.fieldcount` for Tuples, since we can determine it much more cheaply than for other types:
```julia
fieldcount(@nospecialize t::Type{T}) where T<:Tuple{Vararg{Any,N}} where N = N
```

Currently `fieldcount(Tuple{Int, Float32})`, for example, cannot const fold, and thus requires a runtime length check of the types array.

Before this change, on Julia 1.1 this took around 6ns, and on master, it's currently 13ns:
```julia
julia> @btime fieldcount(Tuple{Int,Int})
  13.043 ns (0 allocations: 0 bytes)
2
```
After this change, this is instantaneous:
```julia
julia> @btime fieldcount(Tuple{Int,Int})
  0.025 ns (0 allocations: 0 bytes)
2
```

Of course, the tradeoff is that the dispatch becomes more expensive if we have to do a dynamic dispatch:
```julia
julia> randtup() = tuple(1:rand(1:10)...)
randtup (generic function with 1 method)

julia> f() = fieldcount(typeof(randtup()))+1
f (generic function with 1 method)

julia> @btime f()
  680.552 ns (8 allocations: 438 bytes)
5

julia> Base.fieldcount(@nospecialize t::Type{T}) where T<:Tuple{Vararg{Any,N}} where N = N

julia> @btime f()
  703.386 ns (8 allocations: 428 bytes)
7
```


(@JeffBezanson as I was reviewing my notes from a meeting we had last year, it occurred to me that this overload might be useful. I remembered that you said `fieldcount` is still more expensive than it needs to be, and we came up with this `Vararg` workaround together. Seems like that might be useful to put in base?)